### PR TITLE
fix: skip session creation for orphan transcript files

### DIFF
--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -12,6 +12,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -24,6 +25,11 @@ import (
 	"irrlicht/core/ports/inbound"
 	"irrlicht/core/ports/outbound"
 )
+
+// orphanTranscriptAge is the maximum age of a transcript file for it to be
+// considered active. Files older than this during initial scan are treated as
+// orphans left by exited processes and skipped.
+const orphanTranscriptAge = 2 * time.Minute
 
 // SessionDetector watches transcript files to detect sessions and orchestrate
 // ProcessWatcher for lifecycle management. Working/waiting state is determined
@@ -38,6 +44,8 @@ type SessionDetector struct {
 	broadcaster outbound.PushBroadcaster // optional
 	version     string                   // daemon version stamped on new sessions
 	readyTTL    time.Duration            // max idle time for ready sessions before deletion
+
+	discoverPID func(string) (int, error) // defaults to processadapter.DiscoverPID
 
 	// projectSessions tracks sessionID → projectDir for pre-session cleanup.
 	mu              sync.Mutex
@@ -67,6 +75,7 @@ func NewSessionDetector(
 		broadcaster:     broadcaster,
 		version:         version,
 		readyTTL:        readyTTL,
+		discoverPID:     processadapter.DiscoverPID,
 		projectSessions: make(map[string]string),
 	}
 }
@@ -158,6 +167,13 @@ func (d *SessionDetector) onNewSession(ev agent.Event) {
 	now := time.Now().Unix()
 
 	if isNew {
+		// Skip orphan transcripts left by exited Claude Code processes.
+		if isStaleTranscript(ev.TranscriptPath) {
+			d.log.LogInfo("session-detector", ev.SessionID,
+				"skipping orphan transcript")
+			return
+		}
+
 		// All new sessions start as ready. Content-based detection on
 		// subsequent activity events will transition to working/waiting.
 		initialState := session.StateReady
@@ -460,7 +476,7 @@ func (d *SessionDetector) discoverAndRegisterPID(sessionID, transcriptPath strin
 		return
 	}
 
-	pid, err := processadapter.DiscoverPID(transcriptPath)
+	pid, err := d.discoverPID(transcriptPath)
 	if err != nil || pid <= 0 {
 		return
 	}
@@ -624,26 +640,47 @@ func (d *SessionDetector) seedFromDisk() {
 		}
 	}
 
-	// Check PID liveness and register alive PIDs with ProcessWatcher.
-	// Dead processes are cleaned up synchronously (no async ESRCH race).
+	// Clean up dead sessions and register alive PIDs with ProcessWatcher.
 	for _, state := range states {
-		if state.PID <= 0 {
-			continue
-		}
-		if err := syscall.Kill(state.PID, 0); err == syscall.ESRCH {
+		switch {
+		case state.PID > 0:
+			if err := syscall.Kill(state.PID, 0); err == syscall.ESRCH {
+				d.log.LogInfo("session-detector-seed", state.SessionID,
+					fmt.Sprintf("pid %d dead, deleting session", state.PID))
+				_ = d.repo.Delete(state.SessionID)
+				d.broadcast(outbound.PushTypeDeleted, state)
+				continue
+			}
+			if d.pw != nil {
+				if err := d.pw.Watch(state.PID, state.SessionID); err != nil {
+					d.log.LogError("session-detector-seed", state.SessionID,
+						fmt.Sprintf("failed to watch existing pid %d: %v", state.PID, err))
+				}
+			}
+
+		case state.PID == 0 && isStaleTranscript(state.TranscriptPath):
+			// Orphan from exited Claude Code process (never assigned a PID
+			// because Claude Code doesn't keep transcript files open).
 			d.log.LogInfo("session-detector-seed", state.SessionID,
-				fmt.Sprintf("pid %d dead, deleting session", state.PID))
+				"deleting orphan session")
 			_ = d.repo.Delete(state.SessionID)
 			d.broadcast(outbound.PushTypeDeleted, state)
-			continue
-		}
-		if d.pw != nil {
-			if err := d.pw.Watch(state.PID, state.SessionID); err != nil {
-				d.log.LogError("session-detector-seed", state.SessionID,
-					fmt.Sprintf("failed to watch existing pid %d: %v", state.PID, err))
-			}
 		}
 	}
+}
+
+// isStaleTranscript reports whether the transcript file at path has not been
+// modified within orphanTranscriptAge. Returns false for empty paths or
+// stat errors (file missing → not stale, will be caught elsewhere).
+func isStaleTranscript(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return time.Since(info.ModTime()) > orphanTranscriptAge
 }
 
 // broadcast sends a push notification if a broadcaster is configured.

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -2,6 +2,8 @@ package services_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -45,6 +47,46 @@ func TestSessionDetector_NewSession_CreatesState(t *testing.T) {
 	}
 	if state.Confidence != "medium" {
 		t.Errorf("confidence: got %q, want medium", state.Confidence)
+	}
+}
+
+func TestSessionDetector_NewSession_SkipsOrphanTranscript(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+
+	// Create a transcript file with an old mtime (orphan).
+	tmpDir := t.TempDir()
+	transcriptPath := filepath.Join(tmpDir, "orphan1.jsonl")
+	if err := os.WriteFile(transcriptPath, []byte(`{"type":"user"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Set mtime to 10 minutes ago to exceed orphanTranscriptAge.
+	old := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(transcriptPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "orphan1",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: transcriptPath,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	state, _ := repo.Load("orphan1")
+	if state != nil {
+		t.Errorf("orphan session should not be created, but found state %q", state.State)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Skip session creation for stale transcript files (not modified in >2min) during startup scan
- Delete persisted PID=0 sessions with stale transcripts during `seedFromDisk`
- Use file modification time instead of lsof (Claude Code doesn't keep transcript files open, making PID discovery unreliable)

## Details
- New `isStaleTranscript()` helper shared by `onNewSession` and `seedFromDisk`
- `discoverPID` made injectable on `SessionDetector` for testability
- Merged PID=0 cleanup and PID liveness check into a single loop in `seedFromDisk`

## Test plan
- [x] New unit test `TestSessionDetector_NewSession_SkipsOrphanTranscript` — creates a file with backdated mtime, verifies session is not created
- [x] Existing tests pass (including e2e `TestPreSession_ReplacedByRealSession`)
- [x] Manual: deployed to local machine, verified stale sessions cleaned up on startup, active sessions preserved

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)