### PR TITLE
fix: prevent false 'waiting' state during tool execution

### DIFF
--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -103,8 +103,9 @@ func TestSessionDetector_Activity_TransitionsToWaiting_WhenToolUseOpen(t *testin
 		UpdatedAt:      time.Now().Unix(),
 		EventCount:     1,
 		Metrics: &session.SessionMetrics{
-			LastEventType:   "tool_use",
-			HasOpenToolCall: true,
+			LastEventType:     "tool_use",
+			HasOpenToolCall:   true,
+			LastOpenToolNames: []string{"AskUserQuestion"},
 		},
 	}
 
@@ -184,8 +185,9 @@ func TestSessionDetector_Activity_TransitionsToWaiting_WhenAssistantButOpenTools
 		FirstSeen:      time.Now().Unix(),
 		UpdatedAt:      time.Now().Unix(),
 		Metrics: &session.SessionMetrics{
-			LastEventType:   "assistant",
-			HasOpenToolCall: true,
+			LastEventType:     "assistant",
+			HasOpenToolCall:   true,
+			LastOpenToolNames: []string{"ExitPlanMode"},
 		},
 	}
 
@@ -623,10 +625,14 @@ func TestNeedsUserAttention(t *testing.T) {
 	}{
 		{"nil metrics", nil, false},
 		{"no open tools", &session.SessionMetrics{LastEventType: "assistant", HasOpenToolCall: false}, false},
-		{"open tool call (Bash)", &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Bash"}}, true},
-		{"open tool call (Write)", &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Write"}}, true},
+		{"open tool call (Bash)", &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Bash"}}, false},
+		{"open tool call (Write)", &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Write"}}, false},
+		{"open tool call (Agent)", &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Agent"}}, false},
+		{"open tool call (mcp__tool)", &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"mcp__claude-in-chrome__navigate"}}, false},
 		{"open tool call (AskUserQuestion)", &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"AskUserQuestion"}}, true},
-		{"open tool call, no names", &session.SessionMetrics{HasOpenToolCall: true}, true},
+		{"open tool call (ExitPlanMode)", &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"ExitPlanMode"}}, true},
+		{"mixed tools with AskUserQuestion", &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Bash", "AskUserQuestion"}}, true},
+		{"open tool call, no names", &session.SessionMetrics{HasOpenToolCall: true}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"strings"
 	"time"
 )
 
@@ -48,33 +47,27 @@ type SessionMetrics struct {
 	EstimatedCostUSD float64 `json:"estimated_cost_usd,omitempty"`
 }
 
-// NeedsUserAttention returns true when a tool call is open and the agent
-// may be waiting for user input (permission prompt, question, plan approval).
-// Tools that auto-execute (Agent, MCP tools) don't need user attention.
+// NeedsUserAttention returns true when a user-blocking tool is open — one
+// that always requires user input regardless of permission settings.
+// Most tools auto-execute (Bash, Read, Write, Agent, MCP, etc.) and should
+// NOT trigger a waiting state; only explicit user-interaction tools do.
 func (m *SessionMetrics) NeedsUserAttention() bool {
 	if m == nil || !m.HasOpenToolCall {
 		return false
 	}
-	// If all open tools are auto-executing, the session is working, not waiting.
-	if len(m.LastOpenToolNames) > 0 {
-		allAuto := true
-		for _, name := range m.LastOpenToolNames {
-			if !isAutoExecutingTool(name) {
-				allAuto = false
-				break
-			}
-		}
-		if allAuto {
-			return false
+	for _, name := range m.LastOpenToolNames {
+		if isUserBlockingTool(name) {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
-// isAutoExecutingTool returns true for tools that execute without user interaction.
-// Agent tools run sub-agents in-process; MCP tools (mcp__*) are server-side.
-func isAutoExecutingTool(name string) bool {
-	return name == "Agent" || strings.HasPrefix(name, "mcp__")
+// isUserBlockingTool returns true for tools that always block for user input,
+// regardless of permission settings. These are the only tools that should
+// trigger the "waiting" state.
+func isUserBlockingTool(name string) bool {
+	return name == "AskUserQuestion" || name == "ExitPlanMode"
 }
 
 // IsAgentDone returns true when the agent finished its turn. The primary


### PR DESCRIPTION
## Summary
- Flips `isAutoExecutingTool()` allowlist → `isUserBlockingTool()` blocklist in session state detection
- Only `AskUserQuestion` and `ExitPlanMode` trigger the "waiting" state — all other tools (Bash, Read, Write, Agent, MCP, etc.) keep the session "working"
- Eliminates false orange flashes in the menu bar during continuous tool execution

Closes #53

## Test plan
- [x] Unit tests updated and passing (10 cases in `TestNeedsUserAttention`)
- [x] Integration tests updated (`TransitionsToWaiting` tests now use user-blocking tool names)
- [x] Manual test: built and installed on macOS, session stays purple (working) during tool execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)