### PR TITLE
fix: prevent incorrect session assignment with multiple instances in same repo

### DIFF
--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -91,6 +91,14 @@ func (pm *PIDManager) HandleProcessExit(pid int, sessionID string) {
 // This handles the /clear scenario: the CLI process stays alive (same PID) but
 // starts a new transcript, making the old session obsolete.
 func (pm *PIDManager) HandlePIDAssigned(pid int, sessionID string) {
+	pm.handlePIDAssignedInternal(pid, sessionID, true)
+}
+
+// handlePIDAssignedInternal is the core of HandlePIDAssigned. When authoritative
+// is true (lsof-based discovery), old sessions sharing the same PID are cleaned
+// up (/clear scenario). When false (CWD-based fallback), cleanup is skipped
+// because CWD discovery is ambiguous for multiple instances in the same repo.
+func (pm *PIDManager) handlePIDAssignedInternal(pid int, sessionID string, authoritative bool) {
 	if pid <= 0 {
 		return
 	}
@@ -113,6 +121,13 @@ func (pm *PIDManager) HandlePIDAssigned(pid int, sessionID string) {
 	}
 
 	// Clean up old sessions that had the same PID (e.g. /clear).
+	// Only do this for authoritative (lsof) discoveries — CWD-based
+	// fallback is unreliable when multiple instances share a directory
+	// and could incorrectly delete a still-active session.
+	if !authoritative {
+		return
+	}
+
 	// Subagent sessions share the parent's PID, so skip cleanup when
 	// either side is a subagent.
 	if state.ParentSessionID != "" {
@@ -144,6 +159,23 @@ func (pm *PIDManager) HandlePIDAssigned(pid int, sessionID string) {
 	}
 }
 
+// claimedPIDs returns the set of PIDs already assigned to sessions other than
+// excludeSessionID. Used to prevent CWD-based discovery from assigning a PID
+// that is already tracked by another session.
+func (pm *PIDManager) claimedPIDs(excludeSessionID string) map[int]bool {
+	states, err := pm.repo.ListAll()
+	if err != nil {
+		return nil
+	}
+	claimed := make(map[int]bool)
+	for _, s := range states {
+		if s.PID > 0 && s.SessionID != excludeSessionID {
+			claimed[s.PID] = true
+		}
+	}
+	return claimed
+}
+
 // TryDiscoverPID attempts lsof-on-transcript (primary), then CWD-based
 // discovery (fallback). Returns true if a PID was found and assigned.
 func (pm *PIDManager) TryDiscoverPID(sessionID, transcriptPath, cwd string) bool {
@@ -156,21 +188,27 @@ func (pm *PIDManager) TryDiscoverPID(sessionID, transcriptPath, cwd string) bool
 		return true
 	}
 
-	// Primary: lsof on transcript file.
+	// Primary: lsof on transcript file (authoritative).
 	if transcriptPath != "" {
 		if pid, err := pm.discoverPID(transcriptPath); err == nil && pid > 0 {
 			pm.log.LogInfo("session-detector", sessionID,
 				fmt.Sprintf("lsof discovered pid %d", pid))
-			pm.HandlePIDAssigned(pid, sessionID)
+			pm.handlePIDAssignedInternal(pid, sessionID, true)
 			return true
 		}
 	}
 
-	// Fallback: CWD-based discovery.
+	// Fallback: CWD-based discovery (not authoritative).
+	// Filter out PIDs already claimed by other sessions to prevent
+	// assigning the same PID to multiple sessions in the same directory.
 	if pm.discoverPIDByCWD != nil && cwd != "" {
+		claimed := pm.claimedPIDs(sessionID)
 		disambiguate := func(pids []int) int {
 			best := 0
 			for _, p := range pids {
+				if claimed[p] {
+					continue
+				}
 				if p > best {
 					best = p
 				}
@@ -180,7 +218,7 @@ func (pm *PIDManager) TryDiscoverPID(sessionID, transcriptPath, cwd string) bool
 		if pid, err := pm.discoverPIDByCWD(cwd, disambiguate); err == nil && pid > 0 {
 			pm.log.LogInfo("session-detector", sessionID,
 				fmt.Sprintf("cwd fallback discovered pid %d", pid))
-			pm.HandlePIDAssigned(pid, sessionID)
+			pm.handlePIDAssignedInternal(pid, sessionID, false)
 			return true
 		}
 	}

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -732,6 +732,189 @@ func TestSessionDetector_PIDAssigned_SkipsSubagents(t *testing.T) {
 	}
 }
 
+func TestSessionDetector_CWDFallback_DoesNotAssignDuplicatePID(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	// Mock CWD discovery: always returns the same two candidate PIDs.
+	cwdFn := func(cwd string, disambiguate func([]int) int) (int, error) {
+		return disambiguate([]int{1000, 1001}), nil
+	}
+
+	det := newDetectorWithCWDDiscovery(tw, pw, repo, cwdFn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	// Send two new sessions in the same project (same CWD).
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "sess-a",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: "/home/.claude/projects/-Users-test-project/sess-a.jsonl",
+		CWD:            "/Users/test/project",
+	}
+
+	// Wait for first session's PID discovery retry goroutine to complete.
+	time.Sleep(200 * time.Millisecond)
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "sess-b",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: "/home/.claude/projects/-Users-test-project/sess-b.jsonl",
+		CWD:            "/Users/test/project",
+	}
+
+	// Wait for second session's PID discovery.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	stateA, _ := repo.Load("sess-a")
+	stateB, _ := repo.Load("sess-b")
+
+	if stateA == nil {
+		t.Fatal("sess-a should still exist (must not be deleted by sess-b's PID assignment)")
+	}
+	if stateB == nil {
+		t.Fatal("sess-b should exist")
+	}
+
+	// Both sessions should exist and have different PIDs.
+	if stateA.PID == stateB.PID {
+		t.Errorf("sessions should have different PIDs, both got %d", stateA.PID)
+	}
+	if stateA.PID != 1001 {
+		t.Errorf("sess-a PID: got %d, want 1001 (highest unclaimed)", stateA.PID)
+	}
+	if stateB.PID != 1000 {
+		t.Errorf("sess-b PID: got %d, want 1000 (1001 already claimed)", stateB.PID)
+	}
+}
+
+func TestSessionDetector_CWDFallback_SkipsAlreadyClaimedPID(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	// Use our own PID so seedFromDisk doesn't delete sess-a as a dead process.
+	myPID := os.Getpid()
+
+	// Mock CWD discovery returns only our PID — the only candidate is
+	// already claimed by sess-a, so the disambiguator should filter it out
+	// and sess-b should NOT get a PID assigned at all.
+	cwdFn := func(cwd string, disambiguate func([]int) int) (int, error) {
+		return disambiguate([]int{myPID}), nil
+	}
+
+	det := newDetectorWithCWDDiscovery(tw, pw, repo, cwdFn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	// Wait for seedFromDisk, then inject sessions.
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+
+	// Session A already has a PID assigned (discovered earlier).
+	repo.Save(&session.SessionState{
+		SessionID:      "sess-a",
+		State:          session.StateWorking,
+		PID:            myPID,
+		TranscriptPath: "/home/.claude/projects/-Users-test/sess-a.jsonl",
+		CWD:            "/Users/test/project",
+		FirstSeen:      now,
+		UpdatedAt:       now,
+	})
+
+	// Session B has no PID yet.
+	repo.Save(&session.SessionState{
+		SessionID:      "sess-b",
+		State:          session.StateReady,
+		TranscriptPath: "/home/.claude/projects/-Users-test/sess-b.jsonl",
+		CWD:            "/Users/test/project",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	})
+
+	// Trigger activity on sess-b to initiate PID discovery (CWD fallback).
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "sess-b",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: "/home/.claude/projects/-Users-test/sess-b.jsonl",
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	// sess-a must NOT be deleted.
+	stateA, _ := repo.Load("sess-a")
+	if stateA == nil {
+		t.Error("sess-a must not be deleted")
+	}
+
+	// sess-b should still exist but with PID=0 (no unclaimed PID available).
+	stateB, _ := repo.Load("sess-b")
+	if stateB == nil {
+		t.Fatal("sess-b should exist")
+	}
+	if stateB.PID != 0 {
+		t.Errorf("sess-b PID: got %d, want 0 (all candidates were claimed)", stateB.PID)
+	}
+}
+
+func TestSessionDetector_LsofPath_StillCleansUpOldSession(t *testing.T) {
+	// Verify that the /clear cleanup still works when using the authoritative
+	// path (HandlePIDAssigned, which delegates with authoritative=true).
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	now := time.Now().Unix()
+
+	// Old session with PID 42 (from before /clear).
+	repo.states["old"] = &session.SessionState{
+		SessionID:      "old",
+		State:          session.StateReady,
+		PID:            42,
+		TranscriptPath: "/home/.claude/projects/-Users-test/old.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	}
+
+	// New session after /clear, PID not yet discovered.
+	repo.states["new"] = &session.SessionState{
+		SessionID:      "new",
+		State:          session.StateReady,
+		TranscriptPath: "/home/.claude/projects/-Users-test/new.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	}
+
+	det := newDetector(tw, pw, repo)
+
+	// Authoritative PID assignment (lsof path) should clean up old session.
+	det.HandlePIDAssigned(42, "new")
+
+	if state, _ := repo.Load("old"); state != nil {
+		t.Error("old session should be deleted by authoritative /clear cleanup")
+	}
+	newState, _ := repo.Load("new")
+	if newState == nil {
+		t.Fatal("new session should exist")
+	}
+	if newState.PID != 42 {
+		t.Errorf("new session PID: got %d, want 42", newState.PID)
+	}
+}
+
 func TestIsAgentDone(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -163,3 +163,20 @@ func newDetector(
 		"test", 0,
 	)
 }
+
+// newDetectorWithCWDDiscovery builds a SessionDetector with a mock CWD-based
+// PID discovery function wired up via WithCWDDiscovery.
+func newDetectorWithCWDDiscovery(
+	tw *mockAgentWatcher,
+	pw *mockProcessWatcher,
+	repo *mockRepo,
+	cwdFn func(string, func([]int) int) (int, error),
+) *services.SessionDetector {
+	det := services.NewSessionDetector(
+		[]inbound.AgentWatcher{tw}, pw, repo,
+		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
+		"test", 0,
+	)
+	det.WithCWDDiscovery(cwdFn)
+	return det
+}


### PR DESCRIPTION
## Summary

- Filters already-claimed PIDs from CWD-based disambiguator so each Claude Code instance in the same repo gets a unique PID
- Skips `/clear` cleanup on CWD-derived (non-authoritative) PID assignments as defense-in-depth against race conditions
- Adds `claimedPIDs()` helper and `handlePIDAssignedInternal()` with authoritative flag, keeping `HandlePIDAssigned` API unchanged

## Test plan

- [x] New test: CWD fallback assigns different PIDs to two sessions in same directory
- [x] New test: CWD fallback skips assignment when all candidates are claimed
- [x] New test: lsof (authoritative) path still cleans up old sessions for /clear
- [x] All existing session detector tests pass unchanged
- [ ] Manual: run two Claude Code instances in same repo, exit one, confirm only the correct session is removed

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)