### PR TITLE
Add Gas Town educational UI: role hierarchy, active tool display

### DIFF
--- a/core/adapters/inbound/orchestrators/gastown/poller.go
+++ b/core/adapters/inbound/orchestrators/gastown/poller.go
@@ -132,28 +132,38 @@ func (p *Poller) mapToOrchestratorState(
 
 	// Global agents (mayor, deacon).
 	globalAgents := []orchestrator.GlobalAgent{}
+	mayorMeta := roleMeta[RoleMayor]
 	if mayorSID, mayorState := matchSession(filepath.Join(gtRoot, "mayor")); mayorSID != "" {
 		globalAgents = append(globalAgents, orchestrator.GlobalAgent{
-			Role:      RoleMayor,
-			SessionID: mayorSID,
-			State:     mayorState,
+			Role:        RoleMayor,
+			Icon:        mayorMeta.Icon,
+			Description: mayorMeta.Desc,
+			SessionID:   mayorSID,
+			State:       mayorState,
 		})
 	} else {
 		globalAgents = append(globalAgents, orchestrator.GlobalAgent{
-			Role:  RoleMayor,
-			State: "idle",
+			Role:        RoleMayor,
+			Icon:        mayorMeta.Icon,
+			Description: mayorMeta.Desc,
+			State:       "idle",
 		})
 	}
+	deaconMeta := roleMeta[RoleDeacon]
 	if deaconSID, deaconState := matchSession(filepath.Join(gtRoot, "deacon")); deaconSID != "" {
 		globalAgents = append(globalAgents, orchestrator.GlobalAgent{
-			Role:      RoleDeacon,
-			SessionID: deaconSID,
-			State:     deaconState,
+			Role:        RoleDeacon,
+			Icon:        deaconMeta.Icon,
+			Description: deaconMeta.Desc,
+			SessionID:   deaconSID,
+			State:       deaconState,
 		})
 	} else {
 		globalAgents = append(globalAgents, orchestrator.GlobalAgent{
-			Role:  RoleDeacon,
-			State: "idle",
+			Role:        RoleDeacon,
+			Icon:        deaconMeta.Icon,
+			Description: deaconMeta.Desc,
+			State:       "idle",
 		})
 	}
 	state.GlobalAgents = globalAgents
@@ -181,9 +191,12 @@ func (p *Poller) mapToOrchestratorState(
 		mainWorkers := []orchestrator.Worker{}
 
 		// Witness worker.
+		witnessMeta := roleMeta[RoleWitness]
 		witnessWorker := orchestrator.Worker{
-			Role:  RoleWitness,
-			State: rig.Witness,
+			Role:        RoleWitness,
+			Icon:        witnessMeta.Icon,
+			Description: witnessMeta.Desc,
+			State:       rig.Witness,
 		}
 		if sid, sState := matchSession(filepath.Join(gtRoot, rig.Name, "witness")); sid != "" {
 			witnessWorker.SessionID = sid
@@ -192,9 +205,12 @@ func (p *Poller) mapToOrchestratorState(
 		mainWorkers = append(mainWorkers, witnessWorker)
 
 		// Refinery worker.
+		refineryMeta := roleMeta[RoleRefinery]
 		refineryWorker := orchestrator.Worker{
-			Role:  RoleRefinery,
-			State: rig.Refinery,
+			Role:        RoleRefinery,
+			Icon:        refineryMeta.Icon,
+			Description: refineryMeta.Desc,
+			State:       rig.Refinery,
 		}
 		if sid, sState := matchSession(filepath.Join(gtRoot, rig.Name, "refinery")); sid != "" {
 			refineryWorker.SessionID = sid
@@ -203,6 +219,7 @@ func (p *Poller) mapToOrchestratorState(
 		mainWorkers = append(mainWorkers, refineryWorker)
 
 		// Crew workers.
+		crewMeta := roleMeta[RoleCrew]
 		for _, s := range sessions {
 			if s.CWD == "" {
 				continue
@@ -212,10 +229,12 @@ func (p *Poller) mapToOrchestratorState(
 				continue
 			}
 			mainWorkers = append(mainWorkers, orchestrator.Worker{
-				Role:      RoleCrew,
-				Name:      ri.Name,
-				SessionID: s.SessionID,
-				State:     s.State,
+				Role:        RoleCrew,
+				Icon:        crewMeta.Icon,
+				Description: crewMeta.Desc,
+				Name:        ri.Name,
+				SessionID:   s.SessionID,
+				State:       s.State,
 			})
 		}
 
@@ -230,11 +249,14 @@ func (p *Poller) mapToOrchestratorState(
 				IsMain: false,
 			}
 
+			polecatMeta := roleMeta[RolePolecat]
 			pcWorker := orchestrator.Worker{
-				Role:  RolePolecat,
-				Name:  pc.Name,
-				ID:    pc.Issue,
-				State: pc.State,
+				Role:        RolePolecat,
+				Icon:        polecatMeta.Icon,
+				Description: polecatMeta.Desc,
+				Name:        pc.Name,
+				ID:          pc.Issue,
+				State:       pc.State,
 			}
 
 			if sid, sState := matchSession(filepath.Join(gtRoot, rig.Name, "polecats", pc.Name)); sid != "" {

--- a/core/adapters/inbound/orchestrators/gastown/types.go
+++ b/core/adapters/inbound/orchestrators/gastown/types.go
@@ -12,6 +12,18 @@ const (
 	RoleCrew     = "crew"
 )
 
+// roleMeta provides display metadata for each Gas Town role.
+// Keeping this in the adapter (not the domain model) ensures the domain
+// stays orchestrator-agnostic; any future orchestrator defines its own metadata.
+var roleMeta = map[string]struct{ Icon, Desc string }{
+	RoleMayor:    {"\U0001F3A9", "Coordinates all rigs and global state"},
+	RoleDeacon:   {"\U0001F4CB", "Assigns tasks to polecats, manages the queue"},
+	RoleWitness:  {"\U0001F989", "Reviews polecat work before merging"},
+	RoleRefinery: {"\U0001F3ED", "Merges accepted work into the main branch"},
+	RolePolecat:  {"\U0001F477", "Executes a single task in an isolated worktree"},
+	RoleCrew:     {"\U0001F9D1\u200D\U0001F4BB", "Supports a polecat with research or sub-tasks"},
+}
+
 // WorkUnit type discriminators.
 const (
 	WorkUnitConvoy   = "convoy"

--- a/core/domain/orchestrator/state.go
+++ b/core/domain/orchestrator/state.go
@@ -25,9 +25,11 @@ type State struct {
 
 // GlobalAgent represents an orchestrator-level agent not scoped to a codebase.
 type GlobalAgent struct {
-	Role      string `json:"role"`
-	SessionID string `json:"session_id,omitempty"`
-	State     string `json:"state"`
+	Role        string `json:"role"`
+	Icon        string `json:"icon,omitempty"`        // Display icon (e.g. "🎩"), set by each adapter.
+	Description string `json:"description,omitempty"` // Human-readable role description, set by each adapter.
+	SessionID   string `json:"session_id,omitempty"`
+	State       string `json:"state"`
 }
 
 // Codebase represents a repository managed by the orchestrator.
@@ -48,11 +50,13 @@ type Worktree struct {
 
 // Worker represents a coding agent operating within a worktree.
 type Worker struct {
-	Role      string `json:"role"`
-	Name      string `json:"name,omitempty"`
-	ID        string `json:"id,omitempty"` // bead ID, task ID, etc.
-	SessionID string `json:"session_id,omitempty"`
-	State     string `json:"state"`
+	Role        string `json:"role"`
+	Icon        string `json:"icon,omitempty"`        // Display icon, set by each adapter.
+	Description string `json:"description,omitempty"` // Human-readable role description, set by each adapter.
+	Name        string `json:"name,omitempty"`
+	ID          string `json:"id,omitempty"` // bead ID, task ID, etc.
+	SessionID   string `json:"session_id,omitempty"`
+	State       string `json:"state"`
 }
 
 // WorkUnit represents a trackable unit of work with progress.

--- a/core/domain/session/grouped.go
+++ b/core/domain/session/grouped.go
@@ -37,18 +37,22 @@ type AgentGroup struct {
 // Agent is a session with optional orchestrator role and nested children.
 type Agent struct {
 	*SessionState
-	Role       string   `json:"role,omitempty"`
-	WorkerName string   `json:"worker_name,omitempty"`
-	WorkerID   string   `json:"worker_id,omitempty"`
-	Children   []*Agent `json:"children,omitempty"`
+	Role        string   `json:"role,omitempty"`
+	Icon        string   `json:"icon,omitempty"`
+	Description string   `json:"description,omitempty"`
+	WorkerName  string   `json:"worker_name,omitempty"`
+	WorkerID    string   `json:"worker_id,omitempty"`
+	Children    []*Agent `json:"children,omitempty"`
 }
 
 // workerInfo holds orchestrator metadata for a matched session.
 type workerInfo struct {
-	Role string
-	Rig  string
-	Name string
-	ID   string
+	Role        string
+	Icon        string
+	Description string
+	Rig         string
+	Name        string
+	ID          string
 }
 
 // BuildDashboard creates a hierarchical DashboardResponse from a flat list
@@ -135,6 +139,8 @@ func buildAgent(s *SessionState, workerMap map[string]*workerInfo, parentChildre
 	// Annotate with orchestrator role.
 	if wi, ok := workerMap[s.SessionID]; ok {
 		agent.Role = wi.Role
+		agent.Icon = wi.Icon
+		agent.Description = wi.Description
 		agent.WorkerName = wi.Name
 		agent.WorkerID = wi.ID
 	}
@@ -211,7 +217,11 @@ func buildWorkerMap(orch *orchestrator.State) map[string]*workerInfo {
 
 	for _, ga := range orch.GlobalAgents {
 		if ga.SessionID != "" {
-			m[ga.SessionID] = &workerInfo{Role: ga.Role}
+			m[ga.SessionID] = &workerInfo{
+				Role:        ga.Role,
+				Icon:        ga.Icon,
+				Description: ga.Description,
+			}
 		}
 	}
 
@@ -220,10 +230,12 @@ func buildWorkerMap(orch *orchestrator.State) map[string]*workerInfo {
 			for _, w := range wt.Workers {
 				if w.SessionID != "" {
 					m[w.SessionID] = &workerInfo{
-						Role: w.Role,
-						Rig:  cb.Name,
-						Name: w.Name,
-						ID:   w.ID,
+						Role:        w.Role,
+						Icon:        w.Icon,
+						Description: w.Description,
+						Rig:         cb.Name,
+						Name:        w.Name,
+						ID:          w.ID,
 					}
 				}
 			}

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -537,6 +537,41 @@
       flex-shrink: 0;
     }
 
+    /* Role badge on session rows */
+    .row-role-badge {
+      font-size: 10px; padding: 0 5px; height: 14px; border-radius: 3px;
+      background: rgba(139, 92, 246, 0.12); color: var(--working);
+      font-family: var(--font-mono); font-weight: 600;
+      display: flex; align-items: center; white-space: nowrap; flex-shrink: 0;
+    }
+    /* Active tool indicator on session rows */
+    .row-tool {
+      font-family: var(--font-mono); font-size: 9px; color: var(--muted);
+      flex-shrink: 0; white-space: nowrap; max-width: 80px;
+      overflow: hidden; text-overflow: ellipsis;
+    }
+    .row-tool.tool-user { color: var(--waiting); }
+    /* Gas Town hierarchy */
+    .gt-agents-row {
+      display: flex; align-items: center; gap: 8px;
+      padding: 5px 12px; border-bottom: 1px solid var(--border-subtle); flex-wrap: wrap;
+    }
+    .gt-agent-chip {
+      display: flex; align-items: center; gap: 5px;
+      font-family: var(--font-mono); font-size: 10px; color: var(--text);
+      padding: 2px 7px; border-radius: 3px;
+      background: var(--surface-hover); border: 1px solid var(--border-subtle); cursor: default;
+    }
+    .gt-chip-dot { width: 5px; height: 5px; border-radius: 50%; flex-shrink: 0; }
+    .gt-chip-id { font-size: 9px; color: var(--muted); }
+    .gt-rig-block { padding: 5px 12px; border-bottom: 1px solid var(--border-subtle); }
+    .gt-rig-block:last-of-type { border-bottom: none; }
+    .gt-rig-name {
+      font-family: var(--font-mono); font-size: 9px; font-weight: 700;
+      color: var(--muted); letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 4px;
+    }
+    .gt-workers { display: flex; flex-wrap: wrap; gap: 4px; }
+
     /* Responsive */
     @media (max-width: 768px) {
       header { padding: 10px 14px; }
@@ -592,7 +627,8 @@
   <script>
     // --- State ---
     let dashboardGroups = [];
-    let orchestrator = null;
+    let orchestrator = null;   // OrchestratorSummary from initial load
+    let orchFull = null;       // Full orchestrator.State (global_agents, codebases) from WS / secondary fetch
     let sessionIndex = new Map();
     let collapsedGroups = new Set();
 
@@ -752,7 +788,20 @@
     }
 
     // --- Orchestrator rendering (innerHTML is fine — updates rarely) ---
-    const roleEmoji = { mayor: '\u{1F3A9}', deacon: '\u{1F4CB}', witness: '\u{1F989}', refinery: '\u{1F3ED}', polecat: '\u{1F477}', crew: '\u{1F9D1}\u200D\u{1F4BB}' };
+    // toolLabel maps raw tool names to short display strings for session rows.
+    const toolLabel = {
+      Bash: 'Bash', Read: 'Read', Write: 'Write', Edit: 'Edit',
+      Glob: 'Glob', Grep: 'Grep', Agent: 'Agent',
+      AskUserQuestion: 'Ask User', ExitPlanMode: 'Plan Mode',
+      WebSearch: 'Search', WebFetch: 'Fetch', TodoWrite: 'Todo',
+    };
+
+    function stateColor(s) {
+      if (s === 'working') return 'var(--working)';
+      if (s === 'waiting') return 'var(--waiting)';
+      if (s === 'ready') return 'var(--ready)';
+      return 'var(--muted)';
+    }
 
     function dotBar(total, done) {
       const maxDots = 7;
@@ -764,13 +813,10 @@
 
     function renderOrchestrator() {
       const container = document.getElementById('gt-container');
-      if (!orchestrator || !orchestrator.running) {
-        container.style.display = 'none';
-        return;
-      }
+      const hasOrch = orchestrator && orchestrator.running;
+      const hasFull = orchFull && orchFull.running;
+      if (!hasOrch && !hasFull) { container.style.display = 'none'; return; }
       container.style.display = 'block';
-      const workUnits = orchestrator.work_units || [];
-      const convoys = workUnits.filter(w => w.type === 'convoy');
 
       let html = '<div class="gt-section">';
       html += '<div class="gt-header">';
@@ -778,6 +824,44 @@
       html += '<div class="gt-status-label"><div class="gt-status-dot" style="background:var(--ready)"></div>running</div>';
       html += '</div>';
 
+      // Global agents — icon/description come from the API, no hardcoding here.
+      if (hasFull && orchFull.global_agents && orchFull.global_agents.length) {
+        html += '<div class="gt-agents-row">';
+        for (const ga of orchFull.global_agents) {
+          const sid = ga.session_id ? shortID(ga.session_id) : 'idle';
+          html += '<div class="gt-agent-chip" title="' + esc(ga.description || ga.role) + '">';
+          html += '<span>' + (ga.icon ? esc(ga.icon) + ' ' : '') + esc(ga.role) + '</span>';
+          html += '<span class="gt-chip-dot" style="background:' + stateColor(ga.state) + '"></span>';
+          html += '<span class="gt-chip-id">' + esc(sid) + '</span>';
+          html += '</div>';
+        }
+        html += '</div>';
+      }
+
+      // Rig/codebase blocks — flatten worktrees for readability.
+      if (hasFull && orchFull.codebases && orchFull.codebases.length) {
+        for (const cb of orchFull.codebases) {
+          const workers = (cb.worktrees || []).flatMap(wt => wt.workers || []);
+          if (!workers.length) continue;
+          html += '<div class="gt-rig-block">';
+          html += '<div class="gt-rig-name">rig: ' + esc(cb.name) + '</div>';
+          html += '<div class="gt-workers">';
+          for (const w of workers) {
+            html += '<div class="gt-agent-chip" title="' + esc(w.description || w.role) + '">';
+            html += '<span>' + (w.icon ? esc(w.icon) + ' ' : '') + esc(w.role);
+            if (w.name) html += ' <span style="color:var(--text)">' + esc(w.name) + '</span>';
+            html += '</span>';
+            html += '<span class="gt-chip-dot" style="background:' + stateColor(w.state) + '"></span>';
+            if (w.id) html += '<span class="gt-chip-id">' + esc(w.id.slice(0, 8)) + '</span>';
+            html += '</div>';
+          }
+          html += '</div></div>';
+        }
+      }
+
+      // Convoys — use work_units from whichever source is available.
+      const workUnits = ((orchFull || orchestrator) || {}).work_units || [];
+      const convoys = workUnits.filter(w => w.type === 'convoy');
       if (convoys.length > 0) {
         html += '<div class="gt-body">';
         html += '<div class="gt-convoy-header">\u{1F69A} Convoys</div>';
@@ -889,12 +973,14 @@
       // Build inner structure
       el.innerHTML =
         '<span class="row-state-icon"></span>' +
+        '<span class="row-role-badge" style="display:none"></span>' +
         '<span class="row-num"></span>' +
         '<span class="row-sub-badge" style="display:none"></span>' +
         '<span class="row-branch"></span>' +
         '<span class="row-ctx-bar"><span class="row-ctx-fill"></span></span>' +
         '<span class="row-ctx-pct"></span>' +
         '<span class="row-cost"></span>' +
+        '<span class="row-tool" style="display:none"></span>' +
         '<span class="row-spacer"></span>' +
         '<span class="row-model"></span>' +
         '<span class="row-elapsed"></span>' +
@@ -968,6 +1054,30 @@
       const idEl = el.querySelector('.row-id');
       const sid = shortID(agent.session_id);
       if (idEl.textContent !== sid) idEl.textContent = sid;
+
+      // Role badge — icon and description come from the API (agent.icon, agent.description).
+      const roleBadge = el.querySelector('.row-role-badge');
+      const role = agent.role || '';
+      if (role) {
+        roleBadge.style.display = '';
+        roleBadge.textContent = (agent.icon ? agent.icon + ' ' : '') + role;
+        roleBadge.title = agent.description || role;
+      } else {
+        roleBadge.style.display = 'none';
+      }
+
+      // Active tool label — shown only when agent is working and inside a tool call.
+      const toolEl = el.querySelector('.row-tool');
+      const tools = metrics.last_open_tool_names || [];
+      if (metrics.has_open_tool_call && tools[0] && state === 'working') {
+        const raw = tools[0];
+        const isUser = raw === 'AskUserQuestion' || raw === 'ExitPlanMode';
+        toolEl.style.display = '';
+        toolEl.textContent = toolLabel[raw] || raw.slice(0, 12);
+        toolEl.className = 'row-tool' + (isUser ? ' tool-user' : '');
+      } else {
+        toolEl.style.display = 'none';
+      }
     }
 
     // --- Render ---
@@ -1205,6 +1315,12 @@
       render();
       timelineTick(); // First tick immediately
     });
+    // Secondary fetch for full orchestrator hierarchy (global_agents, codebases).
+    // The initial /api/v1/sessions response only carries an OrchestratorSummary;
+    // the full state is needed to render the Gas Town hierarchy view.
+    fetch('/api/v1/orchestrators/gastown').then(r => r.json()).catch(() => ({})).then(data => {
+      if (data && data.running) { orchFull = data; render(); }
+    });
 
     // --- WebSocket ---
     let ws = null;
@@ -1232,7 +1348,9 @@
         try { msg = JSON.parse(evt.data); } catch(e) { return; }
         if (!msg) return;
         if (msg.type === 'orchestrator_state' && msg.orchestrator) {
-          orchestrator = msg.orchestrator.running ? msg.orchestrator : null;
+          const orch = msg.orchestrator;
+          orchestrator = orch.running ? orch : null;
+          orchFull = orch.running ? orch : null;
           render();
           return;
         }


### PR DESCRIPTION
- Extend orchestrator.State domain model with Icon and Description fields
  on GlobalAgent and Worker; these are set by each adapter, keeping the
  domain orchestrator-agnostic for future orchestrators (Gas City etc.)
- Gas Town poller populates Icon/Description from a roleMeta map in
  types.go (icon/description constants stay in the adapter, not the domain)
- session.Agent and workerInfo carry Icon/Description through BuildDashboard
  so session rows can render role badges without any hardcoded frontend maps
- Web UI: replace hardcoded roleEmoji map with generic rendering using
  agent.icon and agent.description from the API
- Web UI: add orchFull state variable populated from WS orchestrator_state
  messages and a secondary fetch of /api/v1/orchestrators/gastown; used to
  render Gas Town hierarchy (global agents row + rig blocks with workers)
- Web UI: add role badge on each session row showing icon + role name with
  description tooltip when a session is linked to a Gas Town worker
- Web UI: add active tool label on working session rows showing the current
  tool name (Bash, Agent, Ask User etc.) from metrics.last_open_tool_names

https://claude.ai/code/session_01WfSCm8oSZVE69eAjzhZRKb