### PR TITLE
feat: add Pi coding agent adapter

### DIFF
--- a/core/adapters/inbound/agents/pi/adapter.go
+++ b/core/adapters/inbound/agents/pi/adapter.go
@@ -1,0 +1,22 @@
+// Package pi provides an inbound adapter that watches Pi coding agent
+// transcript files under ~/.pi/agent/sessions/--<cwd>--/*.jsonl.
+package pi
+
+import (
+	"time"
+
+	"irrlicht/core/adapters/inbound/agents/fswatcher"
+)
+
+// AdapterName identifies sessions originating from Pi coding agent.
+const AdapterName = "pi"
+
+// rootDir is the path relative to $HOME where Pi stores session transcripts.
+// Sessions live under --<cwd-with-dashes>--/<timestamp>_<uuid>.jsonl.
+const rootDir = ".pi/agent/sessions"
+
+// New creates a file-system watcher for Pi coding agent transcripts.
+// maxAge controls the maximum transcript file age; older files are ignored.
+func New(maxAge time.Duration) *fswatcher.Watcher {
+	return fswatcher.New(rootDir, AdapterName, maxAge)
+}

--- a/core/application/services/helpers.go
+++ b/core/application/services/helpers.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"bufio"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"time"
@@ -20,6 +22,16 @@ func isStaleTranscript(path string) bool {
 	return time.Since(info.ModTime()) > orphanTranscriptAge
 }
 
+// deriveParentSession tries all known methods to extract a parent session ID.
+// 1. Claude Code path pattern: .../<parent-session-id>/subagents/<agent-id>.jsonl
+// 2. Pi transcript header: {"type": "session", "parentSession": "..."}
+func deriveParentSession(transcriptPath string) string {
+	if id := deriveParentSessionID(transcriptPath); id != "" {
+		return id
+	}
+	return deriveParentSessionFromTranscript(transcriptPath)
+}
+
 // deriveParentSessionID extracts a parent session ID from a subagent transcript path.
 // Claude Code subagent transcripts live at .../<parent-session-id>/subagents/<agent-id>.jsonl.
 // Returns "" if the path doesn't match the subagent pattern.
@@ -29,6 +41,36 @@ func deriveParentSessionID(transcriptPath string) string {
 		return ""
 	}
 	return filepath.Base(filepath.Dir(dir)) // parent session ID
+}
+
+// deriveParentSessionFromTranscript reads the first line of a Pi transcript
+// and extracts the parentSession field from the session header.
+// Returns "" if the transcript is not Pi format or has no parent session.
+func deriveParentSessionFromTranscript(transcriptPath string) string {
+	if transcriptPath == "" {
+		return ""
+	}
+	f, err := os.Open(transcriptPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	if !scanner.Scan() {
+		return ""
+	}
+	var header map[string]interface{}
+	if err := json.Unmarshal(scanner.Bytes(), &header); err != nil {
+		return ""
+	}
+	if header["type"] != "session" {
+		return ""
+	}
+	if parent, ok := header["parentSession"].(string); ok && parent != "" {
+		return parent
+	}
+	return ""
 }
 
 // extractProjectDir extracts the project directory name from a transcript path.

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -186,7 +186,7 @@ func (d *SessionDetector) onNewSession(ev agent.Event) {
 			TranscriptPath:  ev.TranscriptPath,
 			CWD:             ev.CWD,
 			DaemonVersion:   d.version,
-			ParentSessionID: deriveParentSessionID(ev.TranscriptPath),
+			ParentSessionID: deriveParentSession(ev.TranscriptPath),
 			FirstSeen:       now,
 			UpdatedAt:       now,
 			Confidence:      "medium",

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -20,6 +20,7 @@ import (
 
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/adapters/inbound/agents/codex"
+	"irrlicht/core/adapters/inbound/agents/pi"
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	gastownadapter "irrlicht/core/adapters/inbound/orchestrators/gastown"
 	"irrlicht/core/adapters/outbound/filesystem"
@@ -232,6 +233,7 @@ func main() {
 	// Inbound adapters: watch agent transcript directories for session files.
 	claudeCodeWatcher := claudecode.New(cfg.MaxSessionAge)
 	codexWatcher := codex.New(cfg.MaxSessionAge)
+	piWatcher := pi.New(cfg.MaxSessionAge)
 
 	// Process scanner: detects Claude Code processes before they create a
 	// transcript, so the session appears as ready from the moment the app opens.
@@ -262,7 +264,7 @@ func main() {
 		return false
 	})
 
-	watchers := []inbound.AgentWatcher{claudeCodeWatcher, codexWatcher, procScanner}
+	watchers := []inbound.AgentWatcher{claudeCodeWatcher, codexWatcher, piWatcher, procScanner}
 
 	// SessionDetector: orchestrates AgentWatchers + ProcessWatcher.
 	detector = services.NewSessionDetector(
@@ -274,8 +276,8 @@ func main() {
 	{
 		detectorCtx, detectorCancel := context.WithCancel(context.Background())
 		defer detectorCancel()
-		logger.LogInfo("startup", "", fmt.Sprintf("watching Claude Code (%s), Codex (%s)",
-			claudeCodeWatcher.Root(), codexWatcher.Root()))
+		logger.LogInfo("startup", "", fmt.Sprintf("watching Claude Code (%s), Codex (%s), Pi (%s)",
+			claudeCodeWatcher.Root(), codexWatcher.Root(), piWatcher.Root()))
 		for _, w := range watchers {
 			go func() {
 				if err := w.Watch(detectorCtx); err != nil && err != context.Canceled {

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -446,14 +446,19 @@ func (t *TranscriptTailer) parseTranscriptLine(line string) (*MessageEvent, erro
 		return nil, nil
 	}
 
-	// Pi uses "message" type with role. Must be checked before the Codex
-	// fallback below since both formats use type: "message".
-	if eventType == "message" && t.isPi {
-		if role, ok := raw["role"].(string); ok {
+	// Pi nests role, stopReason, content, and usage inside a "message" object:
+	//   {"type": "message", "message": {"role": "assistant", "stopReason": "stop", ...}}
+	// Extract the inner message for Pi-specific field access.
+	piMsg, hasPiMsg := raw["message"].(map[string]interface{})
+
+	// Pi uses "message" type with message.role. Must be checked before the
+	// Codex fallback below since both formats use type: "message".
+	if eventType == "message" && t.isPi && hasPiMsg {
+		if role, ok := piMsg["role"].(string); ok {
 			switch role {
 			case "assistant":
 				// Distinguish mid-turn (toolUse) from end-of-turn (stop).
-				stopReason, _ := raw["stopReason"].(string)
+				stopReason, _ := piMsg["stopReason"].(string)
 				if stopReason == "stop" {
 					eventType = "assistant_message"
 				} else {
@@ -474,27 +479,24 @@ func (t *TranscriptTailer) parseTranscriptLine(line string) (*MessageEvent, erro
 
 	// Pi secondary detection: role values unique to Pi (for 64KB-tail scenarios
 	// where the session header was not included in the read window).
-	if eventType == "message" && !t.isPi {
-		if role, ok := raw["role"].(string); ok {
+	if eventType == "message" && !t.isPi && hasPiMsg {
+		if role, ok := piMsg["role"].(string); ok {
 			if role == "toolResult" || role == "bashExecution" {
 				t.isPi = true
-				switch role {
-				case "toolResult", "bashExecution":
-					eventType = "tool_result"
-					t.toolResultCount++
-					if len(t.lastOpenToolNames) > 0 {
-						t.lastOpenToolNames = t.lastOpenToolNames[1:]
-					}
+				eventType = "tool_result"
+				t.toolResultCount++
+				if len(t.lastOpenToolNames) > 0 {
+					t.lastOpenToolNames = t.lastOpenToolNames[1:]
 				}
 			}
 		}
-		// Also detect from stopReason field presence (Pi-specific).
-		if _, ok := raw["stopReason"].(string); ok && !t.isCodex {
+		// Also detect from message.stopReason field presence (Pi-specific).
+		if _, ok := piMsg["stopReason"].(string); ok && !t.isCodex {
 			t.isPi = true
-			if role, ok := raw["role"].(string); ok {
+			if role, ok := piMsg["role"].(string); ok {
 				switch role {
 				case "assistant":
-					stopReason, _ := raw["stopReason"].(string)
+					stopReason, _ := piMsg["stopReason"].(string)
 					if stopReason == "stop" {
 						eventType = "assistant_message"
 					} else {
@@ -635,15 +637,17 @@ func (t *TranscriptTailer) parseTranscriptLine(line string) (*MessageEvent, erro
 		}
 	}
 
-	// Pi embeds toolCall in top-level content[] array (not under message.content).
+	// Pi embeds toolCall in message.content[] array.
 	if t.isPi {
-		if contentArr, ok := raw["content"].([]interface{}); ok {
-			for _, item := range contentArr {
-				if block, ok := item.(map[string]interface{}); ok {
-					if block["type"] == "toolCall" {
-						t.toolUseCount++
-						if name, ok := block["name"].(string); ok {
-							t.lastOpenToolNames = append(t.lastOpenToolNames, name)
+		if piMsg, ok := raw["message"].(map[string]interface{}); ok {
+			if contentArr, ok := piMsg["content"].([]interface{}); ok {
+				for _, item := range contentArr {
+					if block, ok := item.(map[string]interface{}); ok {
+						if block["type"] == "toolCall" {
+							t.toolUseCount++
+							if name, ok := block["name"].(string); ok {
+								t.lastOpenToolNames = append(t.lastOpenToolNames, name)
+							}
 						}
 					}
 				}

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -88,12 +88,15 @@ func normalizeModelName(rawModel string) string {
 
 // getDefaultModelFromConfig reads the default model from the appropriate config
 // based on detected transcript format.
-func getDefaultModelFromConfig(isCodex bool) string {
+func getDefaultModelFromConfig(isCodex, isPi bool) string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return ""
 	}
 
+	if isPi {
+		return getPiModel(homeDir)
+	}
 	if isCodex {
 		return getCodexModel(homeDir)
 	}
@@ -133,6 +136,22 @@ func getCodexModel(homeDir string) string {
 				}
 			}
 		}
+	}
+	return ""
+}
+
+// getPiModel reads the default model from ~/.pi/agent/settings.json.
+func getPiModel(homeDir string) string {
+	data, err := os.ReadFile(filepath.Join(homeDir, ".pi", "agent", "settings.json"))
+	if err != nil {
+		return ""
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return ""
+	}
+	if model, ok := settings["defaultModel"].(string); ok {
+		return normalizeModelName(model)
 	}
 	return ""
 }
@@ -208,6 +227,9 @@ type TranscriptTailer struct {
 
 	// isCodex is set when Codex-specific event types are found in the transcript.
 	isCodex bool
+
+	// isPi is set when Pi coding agent event types are found in the transcript.
+	isPi bool
 
 	// contentChars accumulates character count from message content for
 	// token estimation when explicit token counts aren't available.
@@ -309,7 +331,7 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 	// Use settings fallback if no model was found in transcript.
 	// Pick the right config based on detected transcript format.
 	if t.metrics.ModelName == "" {
-		if defaultModel := getDefaultModelFromConfig(t.isCodex); defaultModel != "" {
+		if defaultModel := getDefaultModelFromConfig(t.isCodex, t.isPi); defaultModel != "" {
 			t.metrics.ModelName = defaultModel
 		}
 	}
@@ -380,6 +402,9 @@ func (t *TranscriptTailer) parseTranscriptLine(line string) (*MessageEvent, erro
 			} else if parsed, err := time.Parse("2006-01-02T15:04:05.000Z", tsStr); err == nil {
 				timestamp = parsed
 			}
+		} else if tsNum, ok := ts.(float64); ok && tsNum > 0 {
+			// Pi uses numeric Unix timestamps (seconds since epoch).
+			timestamp = time.Unix(int64(tsNum), 0)
 		}
 	}
 	
@@ -401,9 +426,91 @@ func (t *TranscriptTailer) parseTranscriptLine(line string) (*MessageEvent, erro
 		eventType = "tool_call"
 	}
 
+	// Pi v3 session header: {"type": "session", "version": 3, "cwd": "...", ...}
+	// Definitive Pi detection signal. Not a message event — return nil.
+	if eventType == "session" {
+		if v, ok := raw["version"].(float64); ok && v >= 3 {
+			t.isPi = true
+		}
+		return nil, nil
+	}
+
+	// Pi-specific non-message entry types. Set isPi flag and skip.
+	if eventType == "model_change" {
+		t.isPi = true
+		t.extractModelInfo(raw)
+		return nil, nil
+	}
+	if eventType == "thinking_level_change" || eventType == "compaction" || eventType == "branch_summary" || eventType == "custom" {
+		t.isPi = true
+		return nil, nil
+	}
+
+	// Pi uses "message" type with role. Must be checked before the Codex
+	// fallback below since both formats use type: "message".
+	if eventType == "message" && t.isPi {
+		if role, ok := raw["role"].(string); ok {
+			switch role {
+			case "assistant":
+				// Distinguish mid-turn (toolUse) from end-of-turn (stop).
+				stopReason, _ := raw["stopReason"].(string)
+				if stopReason == "stop" {
+					eventType = "assistant_message"
+				} else {
+					eventType = "assistant"
+				}
+			case "user":
+				eventType = "user_message"
+				t.lastOpenToolNames = nil
+			case "toolResult", "bashExecution":
+				eventType = "tool_result"
+				t.toolResultCount++
+				if len(t.lastOpenToolNames) > 0 {
+					t.lastOpenToolNames = t.lastOpenToolNames[1:]
+				}
+			}
+		}
+	}
+
+	// Pi secondary detection: role values unique to Pi (for 64KB-tail scenarios
+	// where the session header was not included in the read window).
+	if eventType == "message" && !t.isPi {
+		if role, ok := raw["role"].(string); ok {
+			if role == "toolResult" || role == "bashExecution" {
+				t.isPi = true
+				switch role {
+				case "toolResult", "bashExecution":
+					eventType = "tool_result"
+					t.toolResultCount++
+					if len(t.lastOpenToolNames) > 0 {
+						t.lastOpenToolNames = t.lastOpenToolNames[1:]
+					}
+				}
+			}
+		}
+		// Also detect from stopReason field presence (Pi-specific).
+		if _, ok := raw["stopReason"].(string); ok && !t.isCodex {
+			t.isPi = true
+			if role, ok := raw["role"].(string); ok {
+				switch role {
+				case "assistant":
+					stopReason, _ := raw["stopReason"].(string)
+					if stopReason == "stop" {
+						eventType = "assistant_message"
+					} else {
+						eventType = "assistant"
+					}
+				case "user":
+					eventType = "user_message"
+					t.lastOpenToolNames = nil
+				}
+			}
+		}
+	}
+
 	// Codex uses generic "message" type with role to distinguish user/assistant.
 	// Map to specific types so IsAgentDone recognizes assistant end-of-turn.
-	if eventType == "message" {
+	if eventType == "message" && !t.isPi {
 		if role, ok := raw["role"].(string); ok {
 			switch role {
 			case "assistant":
@@ -528,9 +635,25 @@ func (t *TranscriptTailer) parseTranscriptLine(line string) (*MessageEvent, erro
 		}
 	}
 
+	// Pi embeds toolCall in top-level content[] array (not under message.content).
+	if t.isPi {
+		if contentArr, ok := raw["content"].([]interface{}); ok {
+			for _, item := range contentArr {
+				if block, ok := item.(map[string]interface{}); ok {
+					if block["type"] == "toolCall" {
+						t.toolUseCount++
+						if name, ok := block["name"].(string); ok {
+							t.lastOpenToolNames = append(t.lastOpenToolNames, name)
+						}
+					}
+				}
+			}
+		}
+	}
+
 	// Accumulate content character count for token estimation.
 	// Works across formats: Claude Code (message.content[].text),
-	// Codex (content[].text), and function_call (arguments).
+	// Codex (content[].text), Pi (content[].text), and function_call (arguments).
 	t.contentChars += extractContentChars(raw)
 
 	return &MessageEvent{
@@ -797,6 +920,7 @@ func (t *TranscriptTailer) extractTokenInfo(raw map[string]interface{}) {
 	hasBreakdown := false
 
 	// extractUsage pulls breakdown fields from a usage map.
+	// Handles both standard (Claude/Codex) and Pi field naming conventions.
 	extractUsage := func(usage map[string]interface{}) {
 		if v, ok := usage["input_tokens"].(float64); ok {
 			inTok = int64(v)
@@ -806,15 +930,38 @@ func (t *TranscriptTailer) extractTokenInfo(raw map[string]interface{}) {
 			outTok = int64(v)
 			hasBreakdown = true
 		}
+		// Pi uses shorter field names as fallback.
+		if !hasBreakdown {
+			if v, ok := usage["input"].(float64); ok {
+				inTok = int64(v)
+				hasBreakdown = true
+			}
+			if v, ok := usage["output"].(float64); ok {
+				outTok = int64(v)
+				hasBreakdown = true
+			}
+		}
+		// Standard cache field names.
 		if v, ok := usage["cache_read_input_tokens"].(float64); ok {
 			cacheRead = int64(v)
 		}
 		if v, ok := usage["cache_creation_input_tokens"].(float64); ok {
 			cacheCreate = int64(v)
 		}
+		// Pi cache field names.
+		if v, ok := usage["cacheRead"].(float64); ok {
+			cacheRead = int64(v)
+		}
+		if v, ok := usage["cacheWrite"].(float64); ok {
+			cacheCreate = int64(v)
+		}
 		totalTokens = inTok + outTok + cacheRead + cacheCreate
 		// total_tokens override (replaces computed sum, breakdown stays)
 		if total, ok := usage["total_tokens"].(float64); ok {
+			totalTokens = int64(total)
+		}
+		// Pi totalTokens field.
+		if total, ok := usage["totalTokens"].(float64); ok {
 			totalTokens = int64(total)
 		}
 	}

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -363,6 +363,7 @@ struct SessionState: Identifiable, Codable {
     var adapterName: String {
         switch adapter ?? "claude-code" {
         case "codex": return "Codex"
+        case "pi": return "Pi"
         default: return "Claude Code"
         }
     }
@@ -376,6 +377,8 @@ struct SessionState: Identifiable, Codable {
             svg = SessionState.claudeCodeSVG
         case "codex":
             svg = SessionState.codexSVG(dark: isDark)
+        case "pi":
+            svg = SessionState.piSVG(dark: isDark)
         default:
             svg = SessionState.claudeCodeSVG
         }
@@ -409,6 +412,19 @@ struct SessionState: Identifiable, Codable {
           <circle cx="50" cy="50" r="44" fill="none" stroke="\(c)" stroke-width="8"/>
           <path d="M28 38 L42 50 L28 62" fill="none" stroke="\(c)" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
           <line x1="48" y1="62" x2="68" y2="62" stroke="\(c)" stroke-width="7" stroke-linecap="round"/>
+        </svg>
+        """
+    }
+
+    // Pi coding agent — Greek letter pi in a circle. Color adapts to appearance.
+    private static func piSVG(dark: Bool) -> String {
+        let c = dark ? "#E0E0E0" : "#1A1A1A"
+        return """
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="44" fill="none" stroke="\(c)" stroke-width="8"/>
+          <line x1="28" y1="30" x2="72" y2="30" stroke="\(c)" stroke-width="8" stroke-linecap="round"/>
+          <line x1="40" y1="30" x2="40" y2="74" stroke="\(c)" stroke-width="8" stroke-linecap="round"/>
+          <line x1="60" y1="30" x2="64" y2="74" stroke="\(c)" stroke-width="8" stroke-linecap="round"/>
         </svg>
         """
     }

--- a/site/docs/adapters.html
+++ b/site/docs/adapters.html
@@ -101,6 +101,17 @@
         <li>Model detection from <code>~/.codex/config.toml</code></li>
       </ul>
 
+      <h3>Pi Adapter</h3>
+
+      <ul>
+        <li><strong>Package:</strong> <code>core/adapters/inbound/agents/pi/</code></li>
+        <li><strong>Watches:</strong> <code>~/.pi/agent/sessions/</code> (nested: <code>--&lt;cwd-dashed&gt;--/*.jsonl</code>)</li>
+        <li>Uses the shared fswatcher with recursive directory watching</li>
+        <li><strong>Adapter name:</strong> <code>"pi"</code></li>
+        <li>Model detection from <code>~/.pi/agent/settings.json</code></li>
+        <li>JSONL v3 format with session header, tree-structured entries, and multi-provider support</li>
+      </ul>
+
       <h3>Process Scanner</h3>
 
       <ul>

--- a/site/docs/changelog.html
+++ b/site/docs/changelog.html
@@ -78,6 +78,15 @@
       <h1>Changelog</h1>
       <p class="page-subtitle">All notable changes to Irrlicht, following Keep a Changelog conventions.</p>
 
+      <h2>v0.2.5 <small>(2026-04-05)</small></h2>
+
+      <h3>Added</h3>
+
+      <ul>
+        <li><strong>Pi coding agent adapter</strong> &mdash; Monitor <a href="https://github.com/badlogic/pi-mono">Pi</a> sessions alongside Claude Code and Codex. Watches <code>~/.pi/agent/sessions/</code>, parses JSONL v3 transcripts, detects state from <code>stopReason</code>, extracts tokens/cost/model, and supports Pi subagent linking via <code>parentSession</code></li>
+        <li><strong>Pi icon in macOS menu bar</strong> &mdash; Greek letter pi (&pi;) icon distinguishes Pi sessions from other agents</li>
+      </ul>
+
       <h2>v0.2.4 <small>(2026-04-05)</small></h2>
 
       <h3>Added</h3>

--- a/site/docs/session-detection.html
+++ b/site/docs/session-detection.html
@@ -127,6 +127,18 @@
         <li>Model detection from <code>~/.codex/config.toml</code></li>
       </ul>
 
+      <h3>Pi Coding Agent</h3>
+
+      <ul>
+        <li><strong>Transcript location:</strong> <code>~/.pi/agent/sessions/--&lt;cwd-dashed&gt;--/&lt;timestamp&gt;_&lt;uuid&gt;.jsonl</code></li>
+        <li>JSONL v3 format &mdash; session header on first line with <code>cwd</code>, <code>parentSession</code>, and <code>version</code> fields</li>
+        <li>Messages use <code>role</code> field: <code>user</code>, <code>assistant</code>, <code>toolResult</code>, <code>bashExecution</code></li>
+        <li>Turn completion detected from <code>stopReason: "stop"</code> on assistant messages</li>
+        <li><strong>Adapter name:</strong> <code>pi</code></li>
+        <li>Model detection from <code>~/.pi/agent/settings.json</code> (<code>defaultModel</code> field)</li>
+        <li>Supports multiple LLM providers (Anthropic, OpenAI, Google, xAI, Groq)</li>
+      </ul>
+
       <h2>PID Discovery</h2>
 
       <table>


### PR DESCRIPTION
## Summary

- Add Pi coding agent adapter to monitor [Pi](https://github.com/badlogic/pi-mono) sessions alongside Claude Code and Codex
- Parse JSONL v3 transcripts with auto-detection from session headers and Pi-specific role values (`toolResult`, `bashExecution`)
- Extract tokens/cost using Pi's field naming convention (`input`/`output`/`cacheRead`/`cacheWrite`/`totalTokens`)
- Detect turn completion from `stopReason: "stop"` on assistant messages
- Support Pi subagent linking via `parentSession` in session header
- Add Pi icon (π in circle) to macOS menu bar UI

## Test plan

- [x] All existing tailer tests pass (`go test ./pkg/tailer/... -count=1`)
- [x] Go daemon compiles (`go build -o /tmp/irrlichd ./cmd/irrlichd`)
- [x] Swift macOS app compiles (`swift build`)
- [ ] Manual: create mock Pi transcript, verify session appears in dashboard with correct state/model/icon

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)