### PR TITLE
feat: show last question in waiting state (#49)

### DIFF
--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -64,6 +64,7 @@ func (a *Adapter) ComputeMetrics(transcriptPath string) (*session.SessionMetrics
 		LastToolResultWasError: m.LastToolResultWasError,
 		EstimatedCostUSD:       m.EstimatedCostUSD,
 		LastCWD:                m.LastCWD,
+		LastAssistantText:      m.LastAssistantText,
 	}
 	if result.ModelName == "" {
 		result.ModelName = "unknown"

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -426,11 +426,12 @@ func (d *SessionDetector) seedFromDisk() {
 	}
 	d.mu.Unlock()
 
-	// Re-evaluate state for all non-ready sessions: recompute metrics from
-	// transcript and apply the current detection logic. This ensures sessions
-	// persisted with stale states are corrected on startup.
+	// Re-evaluate state for sessions with transcripts: recompute metrics
+	// and apply the current detection logic. This ensures sessions persisted
+	// with stale states are corrected on startup (e.g. ready sessions whose
+	// last assistant message ends with a question should be waiting).
 	for _, state := range states {
-		if state.State == session.StateReady || state.TranscriptPath == "" {
+		if state.TranscriptPath == "" {
 			continue
 		}
 		d.enricher.RefreshMetrics(state)

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -32,8 +32,16 @@ func ClassifyState(currentState string, metrics *session.SessionMetrics) (string
 		return currentState, ""
 	}
 
-	// 2. Agent finished turn → ready.
+	// 2. Agent finished turn — check if waiting for user input first.
 	if metrics.IsAgentDone() {
+		// 2a. Turn ended with a question → waiting (agent needs user input).
+		if metrics.IsWaitingForUserInput() {
+			if currentState != session.StateWaiting {
+				return session.StateWaiting, "turn ended with question → waiting"
+			}
+			return currentState, ""
+		}
+		// 2b. Normal turn completion → ready.
 		if currentState == session.StateWorking || currentState == session.StateWaiting {
 			return session.StateReady, "agent finished turn → ready"
 		}

--- a/core/application/services/state_classifier_test.go
+++ b/core/application/services/state_classifier_test.go
@@ -59,9 +59,54 @@ func TestClassifyState(t *testing.T) {
 			wantState: session.StateWaiting,
 		},
 
-		// Rule 2: IsAgentDone → ready.
+		// Rule 2a: Turn ended with question → waiting.
 		{
-			name:    "working → ready (turn_done)",
+			name:    "working → waiting (turn_done + question)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				LastEventType:     "turn_done",
+				HasOpenToolCall:   false,
+				LastAssistantText: "Should I proceed with the migration?",
+			},
+			wantState:  session.StateWaiting,
+			wantReason: true,
+		},
+		{
+			name:    "ready → waiting (turn_done + question)",
+			current: session.StateReady,
+			metrics: &session.SessionMetrics{
+				LastEventType:     "turn_done",
+				HasOpenToolCall:   false,
+				LastAssistantText: "Do you want me to fix this?",
+			},
+			wantState:  session.StateWaiting,
+			wantReason: true,
+		},
+		{
+			name:    "waiting stays waiting (turn_done + question, already waiting)",
+			current: session.StateWaiting,
+			metrics: &session.SessionMetrics{
+				LastEventType:     "turn_done",
+				HasOpenToolCall:   false,
+				LastAssistantText: "Which approach do you prefer?",
+			},
+			wantState: session.StateWaiting,
+		},
+
+		// Rule 2b: IsAgentDone without question → ready.
+		{
+			name:    "working → ready (turn_done, no question)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				LastEventType:     "turn_done",
+				HasOpenToolCall:   false,
+				LastAssistantText: "Done. The tests pass.",
+			},
+			wantState:  session.StateReady,
+			wantReason: true,
+		},
+		{
+			name:    "working → ready (turn_done, empty text)",
 			current: session.StateWorking,
 			metrics: &session.SessionMetrics{
 				LastEventType:   "turn_done",

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -49,6 +49,11 @@ type SessionMetrics struct {
 	// LastCWD is the most recent working directory extracted from the
 	// transcript during metrics parsing. Used to avoid a separate file read.
 	LastCWD string `json:"-"` // transient — not persisted in session JSON
+
+	// LastAssistantText is the text content of the most recent assistant
+	// message, truncated to ~200 characters. Used to surface the question
+	// or request when the session is in the waiting state.
+	LastAssistantText string `json:"last_assistant_text,omitempty"`
 }
 
 // NeedsUserAttention returns true when a user-blocking tool is open — one
@@ -72,6 +77,17 @@ func (m *SessionMetrics) NeedsUserAttention() bool {
 // trigger the "waiting" state.
 func isUserBlockingTool(name string) bool {
 	return name == "AskUserQuestion" || name == "ExitPlanMode"
+}
+
+// IsWaitingForUserInput returns true when the agent finished its turn but the
+// last assistant message ends with a question mark — indicating the agent is
+// waiting for user input even though no user-blocking tool is open.
+func (m *SessionMetrics) IsWaitingForUserInput() bool {
+	if m == nil || m.LastAssistantText == "" {
+		return false
+	}
+	// LastAssistantText is already trimmed by the tailer.
+	return m.LastAssistantText[len(m.LastAssistantText)-1] == '?'
 }
 
 // IsAgentDone returns true when the agent finished its turn. The primary
@@ -191,6 +207,7 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 		LastOpenToolNames:      newM.LastOpenToolNames,
 		LastToolResultWasError: newM.LastToolResultWasError,
 		EstimatedCostUSD:       newM.EstimatedCostUSD,
+		LastAssistantText:      newM.LastAssistantText,
 	}
 	if merged.ContextWindow == 0 && oldM.ContextWindow > 0 {
 		merged.ContextWindow = oldM.ContextWindow

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -208,6 +208,10 @@ type SessionMetrics struct {
 	// LastCWD is the most recent working directory seen in the transcript.
 	// Extracted during parsing so callers don't need a separate file read.
 	LastCWD string `json:"last_cwd,omitempty"`
+
+	// LastAssistantText is the text content of the most recent assistant
+	// message, truncated to ~200 characters.
+	LastAssistantText string `json:"last_assistant_text,omitempty"`
 }
 
 // TranscriptTailer monitors transcript files and computes metrics
@@ -251,6 +255,10 @@ type TranscriptTailer struct {
 
 	// lastCWD tracks the most recent working directory seen in transcript lines.
 	lastCWD string
+
+	// lastAssistantText holds the text content of the most recent assistant
+	// message, truncated to ~200 characters. Updated on each assistant event.
+	lastAssistantText string
 }
 
 // NewTranscriptTailer creates a new tailer for the given transcript path
@@ -668,6 +676,17 @@ func (t *TranscriptTailer) parseTranscriptLine(line string) (*MessageEvent, erro
 		}
 	}
 
+	// Track assistant text for waiting-state display.
+	// Clear on user messages so stale text from a previous turn doesn't linger.
+	switch eventType {
+	case "assistant", "assistant_message", "assistant_output":
+		if text := extractAssistantText(raw); text != "" {
+			t.lastAssistantText = text
+		}
+	case "user", "user_message", "user_input":
+		t.lastAssistantText = ""
+	}
+
 	// Accumulate content character count for token estimation.
 	// Works across formats: Claude Code (message.content[].text),
 	// Codex (content[].text), Pi (content[].text), and function_call (arguments).
@@ -678,6 +697,54 @@ func (t *TranscriptTailer) parseTranscriptLine(line string) (*MessageEvent, erro
 		EventType: eventType,
 		Content:   line,
 	}, nil
+}
+
+// extractAssistantText extracts and concatenates text blocks from an assistant
+// message, returning at most 200 characters. Checks both Claude Code
+// (message.content[].text) and Codex (content[].text) formats.
+func extractAssistantText(raw map[string]interface{}) string {
+	var parts []string
+
+	collectText := func(arr []interface{}) {
+		for _, item := range arr {
+			if block, ok := item.(map[string]interface{}); ok {
+				if block["type"] == "text" {
+					if text, ok := block["text"].(string); ok && text != "" {
+						parts = append(parts, text)
+					}
+				}
+			}
+		}
+	}
+
+	// Claude Code: message.content[]
+	if msg, ok := raw["message"].(map[string]interface{}); ok {
+		if arr, ok := msg["content"].([]interface{}); ok {
+			collectText(arr)
+		}
+	}
+	// Codex: top-level content[]
+	if arr, ok := raw["content"].([]interface{}); ok {
+		collectText(arr)
+	}
+
+	// Fast path: single text block (common case) avoids Join allocation.
+	var text string
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		text = strings.TrimSpace(parts[0])
+	default:
+		text = strings.TrimSpace(strings.Join(parts, " "))
+	}
+
+	// Single rune decode for both length check and truncation.
+	runes := []rune(text)
+	if len(runes) > 200 {
+		return string(runes[:200])
+	}
+	return text
 }
 
 // extractContentChars returns the total character count of text content in
@@ -818,6 +885,7 @@ func (t *TranscriptTailer) computeMetrics() {
 	t.metrics.LastOpenToolNames = t.lastOpenToolNames
 	t.metrics.LastToolResultWasError = t.lastToolResultWasError
 	t.metrics.LastCWD = t.lastCWD
+	t.metrics.LastAssistantText = t.lastAssistantText
 
 	// Token breakdown + estimated cost
 	t.metrics.InputTokens = t.inputTokens

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -708,7 +708,9 @@ func extractAssistantText(raw map[string]interface{}) string {
 	collectText := func(arr []interface{}) {
 		for _, item := range arr {
 			if block, ok := item.(map[string]interface{}); ok {
-				if block["type"] == "text" {
+				bt := block["type"]
+				// Claude Code uses "text", Codex uses "output_text".
+				if bt == "text" || bt == "output_text" {
 					if text, ok := block["text"].(string); ok && text != "" {
 						parts = append(parts, text)
 					}

--- a/core/pkg/tailer/tool_call_test.go
+++ b/core/pkg/tailer/tool_call_test.go
@@ -179,3 +179,77 @@ func TestHasOpenToolCall_MultipleRoundsAllClosed(t *testing.T) {
 		t.Errorf("expected OpenToolCallCount=0, got %d", m.OpenToolCallCount)
 	}
 }
+
+// --- LastAssistantText extraction tests ---
+
+func TestLastAssistantText_ClaudeCode(t *testing.T) {
+	// Claude Code format: type="assistant", message.content[].type="text"
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "user", "timestamp": ts(0)},
+		{"type": "assistant", "timestamp": ts(1), "message": map[string]interface{}{
+			"role": "assistant",
+			"content": []interface{}{
+				map[string]interface{}{"type": "text", "text": "Should I proceed with the migration?"},
+			},
+		}},
+		{"type": "system", "subtype": "stop_hook_summary", "timestamp": ts(2)},
+	})
+	m, err := NewTranscriptTailer(path).TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.LastAssistantText != "Should I proceed with the migration?" {
+		t.Errorf("LastAssistantText = %q, want question text", m.LastAssistantText)
+	}
+	if m.LastEventType != "turn_done" {
+		t.Errorf("LastEventType = %q, want turn_done", m.LastEventType)
+	}
+}
+
+func TestLastAssistantText_Codex(t *testing.T) {
+	// Codex format: type="message" role="assistant", content[].type="output_text"
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "message", "role": "user", "timestamp": ts(0),
+			"content": []interface{}{
+				map[string]interface{}{"type": "input_text", "text": "hello"},
+			}},
+		{"type": "message", "role": "assistant", "timestamp": ts(1),
+			"content": []interface{}{
+				map[string]interface{}{"type": "output_text", "text": "What would you like to do with these files?"},
+			}},
+	})
+	m, err := NewTranscriptTailer(path).TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.LastAssistantText != "What would you like to do with these files?" {
+		t.Errorf("LastAssistantText = %q, want question text", m.LastAssistantText)
+	}
+}
+
+func TestLastAssistantText_ClearedOnUserMessage(t *testing.T) {
+	// Assistant text should be cleared when a new user message arrives.
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "assistant", "timestamp": ts(0), "message": map[string]interface{}{
+			"role": "assistant",
+			"content": []interface{}{
+				map[string]interface{}{"type": "text", "text": "Should I continue?"},
+			},
+		}},
+		{"type": "user", "timestamp": ts(1)},
+		{"type": "assistant", "timestamp": ts(2), "message": map[string]interface{}{
+			"role": "assistant",
+			"content": []interface{}{
+				map[string]interface{}{"type": "text", "text": "Done."},
+			},
+		}},
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(3)},
+	})
+	m, err := NewTranscriptTailer(path).TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.LastAssistantText != "Done." {
+		t.Errorf("LastAssistantText = %q, want 'Done.' (previous question should be cleared)", m.LastAssistantText)
+	}
+}

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -10,6 +10,7 @@ struct SessionMetrics: Codable {
     let contextUtilization: Double  // context utilization percentage (0-100) (0 if not available)
     let pressureLevel: String       // pressure level: "safe", "caution", "warning", "critical" ("unknown" if not available)
     let estimatedCostUSD: Double?   // estimated session cost in USD (nil if not available)
+    let lastAssistantText: String?  // last assistant message text, truncated (~200 chars)
 
     enum CodingKeys: String, CodingKey {
         case elapsedSeconds = "elapsed_seconds"
@@ -18,6 +19,7 @@ struct SessionMetrics: Codable {
         case contextUtilization = "context_utilization_percentage"
         case pressureLevel = "pressure_level"
         case estimatedCostUSD = "estimated_cost_usd"
+        case lastAssistantText = "last_assistant_text"
     }
     
     // Computed properties for UI display

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -412,6 +412,17 @@
       flex-shrink: 0;
     }
 
+    .row-question {
+      font-size: 9px;
+      color: var(--waiting);
+      opacity: 0.85;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: 300px;
+      padding: 0 4px;
+    }
+
     /* Pressure alert row */
     .pressure-alert-row {
       padding: 2px 10px 2px 30px;
@@ -977,6 +988,7 @@
         '<span class="row-num"></span>' +
         '<span class="row-sub-badge" style="display:none"></span>' +
         '<span class="row-branch"></span>' +
+        '<span class="row-question" style="display:none"></span>' +
         '<span class="row-ctx-bar"><span class="row-ctx-fill"></span></span>' +
         '<span class="row-ctx-pct"></span>' +
         '<span class="row-cost"></span>' +
@@ -1022,6 +1034,20 @@
       // Branch
       const branchEl = el.querySelector('.row-branch');
       if (branchEl.textContent !== branch) branchEl.textContent = branch || '\u2014';
+
+      // Waiting question — show last assistant text when waiting
+      const questionEl = el.querySelector('.row-question');
+      const questionText = (state === 'waiting' && metrics.last_assistant_text) ?
+        (metrics.last_assistant_text.length > 100 ? metrics.last_assistant_text.slice(0, 100) + '\u2026' : metrics.last_assistant_text) : '';
+      if (questionText) {
+        questionEl.style.display = '';
+        if (questionEl.textContent !== questionText) {
+          questionEl.textContent = questionText;
+          questionEl.title = metrics.last_assistant_text;
+        }
+      } else {
+        questionEl.style.display = 'none';
+      }
 
       // Context bar
       const fill = el.querySelector('.row-ctx-fill');


### PR DESCRIPTION
## Summary
- **Detect question-based waiting**: When a turn ends with `?` in the last assistant message, classify the session as `waiting` instead of `ready` — the agent needs user input even without an explicit `AskUserQuestion` tool call
- **Surface waiting reason**: Extract and display the last assistant message text (truncated to 100 chars) in the web dashboard when a session is waiting, with full text on hover
- **Full-stack**: Domain model, tailer, state classifier, metrics adapter, web UI, and Swift model all updated

## Implementation
- `SessionMetrics.LastAssistantText` — new field carrying the last assistant message text (~200 chars max), extracted from transcript by the tailer
- `SessionMetrics.IsWaitingForUserInput()` — returns true when `LastAssistantText` ends with `?`
- `ClassifyState` rule 2a: `IsAgentDone() && IsWaitingForUserInput()` → waiting (before falling through to ready)
- Web dashboard shows orange question text in the session row when waiting
- Swift `SessionMetrics` updated with `lastAssistantText` CodingKey

## Test plan
- [x] All 18 state classifier tests pass (5 new: question→waiting, no-question→ready, empty-text→ready, already-waiting stays, ready→waiting)
- [x] Domain, tailer, and e2e tests pass
- [x] Manual: verify waiting state shows question text in web dashboard
- [x] Manual: verify macOS app decodes the new field without crash

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)