### PR TITLE
feat: session state dots in menu bar and popover headers

### DIFF
--- a/platforms/macos/Irrlicht/IrrlichtApp.swift
+++ b/platforms/macos/Irrlicht/IrrlichtApp.swift
@@ -32,11 +32,10 @@ struct StatusIndicatorLabel: View {
     }
 
     private func buildStatusImage() -> NSImage? {
-        // Group sessions by project
+        // Group sessions by project (top-level only)
         var groups: [(String, [SessionState])] = []
         var seen: [String: Int] = [:]
-        let capped = Array(sessions.filter { $0.parentSessionId == nil }.prefix(8))
-        for s in capped {
+        for s in sessions where s.parentSessionId == nil {
             let key = s.projectName ?? s.cwd
             if let idx = seen[key] {
                 groups[idx].1.append(s)
@@ -46,36 +45,68 @@ struct StatusIndicatorLabel: View {
             }
         }
 
-        let r: CGFloat = 5          // circle radius
-        let overlap: CGFloat = 4    // overlap within group
-        let groupGap: CGFloat = 6   // gap between groups
+        let r: CGFloat = 5
+        let overlap: CGFloat = 4
+        let groupGap: CGFloat = 6
         let height: CGFloat = 18
         let cy = height / 2
 
-        // Calculate total width
-        var totalWidth: CGFloat = 0
-        for (i, (_, group)) in groups.enumerated() {
-            if i > 0 { totalWidth += groupGap }
-            totalWidth += CGFloat(group.count) * (r * 2 - overlap) + overlap
+        // Pre-compute SVG elements for each group
+        struct GroupRender {
+            var elements: String
+            var width: CGFloat
         }
 
-        // Build SVG
-        var svg = """
-        <svg xmlns="http://www.w3.org/2000/svg" width="\(Int(totalWidth))" height="\(Int(height))">
-        """
-
-        var x: CGFloat = r
-        for (i, (_, group)) in groups.enumerated() {
-            if i > 0 { x += groupGap }
-            for s in group {
-                let hex = s.state.color.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
-                svg += """
-                <circle cx="\(Int(x))" cy="\(Int(cy))" r="\(Int(r))" fill="#\(hex)" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>
+        var renders: [GroupRender] = []
+        for (_, groupSessions) in groups {
+            if groupSessions.count <= 3 {
+                // ≤3: individual overlapping filled circles
+                var el = ""
+                var lx: CGFloat = r
+                for s in groupSessions {
+                    let hex = s.state.color.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+                    el += """
+                    <circle cx="\(Int(lx))" cy="\(Int(cy))" r="\(Int(r))" fill="#\(hex)" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>
+                    """
+                    lx += r * 2 - overlap
+                }
+                let w = CGFloat(groupSessions.count) * (r * 2 - overlap) + overlap
+                renders.append(GroupRender(elements: el, width: w))
+            } else {
+                // >3: single filled circle (dominant state) + total count
+                let hex = dominantColor(groupSessions).trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+                let count = groupSessions.count
+                let fontSize: CGFloat = 10
+                let textX = Int(r * 2 + 2)
+                let textY = Int(cy + fontSize * 0.35)
+                let countStr = "\(count)"
+                let textWidth: CGFloat = CGFloat(countStr.count) * 6.5
+                let el = """
+                <circle cx="\(Int(r))" cy="\(Int(cy))" r="\(Int(r))" fill="#\(hex)" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>
+                <text x="\(textX)" y="\(textY)" font-family="Menlo,monospace" font-size="\(Int(fontSize))" font-weight="bold" fill="#\(hex)">\(countStr)</text>
                 """
-                x += r * 2 - overlap
+                renders.append(GroupRender(elements: el, width: r * 2 + 2 + textWidth))
             }
         }
 
+        // Calculate total width
+        var totalWidth: CGFloat = 0
+        for (i, render) in renders.enumerated() {
+            if i > 0 { totalWidth += groupGap }
+            totalWidth += render.width
+        }
+        guard totalWidth > 0 else { return nil }
+
+        // Assemble SVG
+        var svg = """
+        <svg xmlns="http://www.w3.org/2000/svg" width="\(Int(totalWidth))" height="\(Int(height))">
+        """
+        var offsetX: CGFloat = 0
+        for (i, render) in renders.enumerated() {
+            if i > 0 { offsetX += groupGap }
+            svg += "<g transform=\"translate(\(Int(offsetX)),0)\">\(render.elements)</g>"
+            offsetX += render.width
+        }
         svg += "</svg>"
 
         guard let data = svg.data(using: .utf8),
@@ -84,6 +115,17 @@ struct StatusIndicatorLabel: View {
         nsImage.isTemplate = false
         nsImage.size = NSSize(width: totalWidth, height: height)
         return nsImage
+    }
+
+    /// Returns the hex color of the highest-priority state (waiting > working > ready).
+    private func dominantColor(_ sessions: [SessionState]) -> String {
+        if sessions.contains(where: { $0.state == .waiting }) {
+            return SessionState.State.waiting.color
+        }
+        if sessions.contains(where: { $0.state == .working }) {
+            return SessionState.State.working.color
+        }
+        return SessionState.State.ready.color
     }
 }
 

--- a/platforms/macos/Irrlicht/IrrlichtApp.swift
+++ b/platforms/macos/Irrlicht/IrrlichtApp.swift
@@ -58,7 +58,7 @@ struct StatusIndicatorLabel: View {
         }
 
         var renders: [GroupRender] = []
-        for (_, groupSessions) in groups {
+        for (_, groupSessions) in groups.prefix(8) {
             if groupSessions.count <= 3 {
                 // ≤3: individual overlapping filled circles
                 var el = ""

--- a/platforms/macos/Irrlicht/IrrlichtApp.swift
+++ b/platforms/macos/Irrlicht/IrrlichtApp.swift
@@ -64,7 +64,7 @@ struct StatusIndicatorLabel: View {
                 var el = ""
                 var lx: CGFloat = r
                 for s in groupSessions {
-                    let hex = s.state.color.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+                    let hex = s.state.hexColor
                     el += """
                     <circle cx="\(Int(lx))" cy="\(Int(cy))" r="\(Int(r))" fill="#\(hex)" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>
                     """
@@ -74,7 +74,7 @@ struct StatusIndicatorLabel: View {
                 renders.append(GroupRender(elements: el, width: w))
             } else {
                 // >3: single filled circle (dominant state) + total count
-                let hex = dominantColor(groupSessions).trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+                let hex = SessionState.State.dominant(in: groupSessions.map(\.state)).hexColor
                 let count = groupSessions.count
                 let fontSize: CGFloat = 10
                 let textX = Int(r * 2 + 2)
@@ -115,17 +115,6 @@ struct StatusIndicatorLabel: View {
         nsImage.isTemplate = false
         nsImage.size = NSSize(width: totalWidth, height: height)
         return nsImage
-    }
-
-    /// Returns the hex color of the highest-priority state (waiting > working > ready).
-    private func dominantColor(_ sessions: [SessionState]) -> String {
-        if sessions.contains(where: { $0.state == .waiting }) {
-            return SessionState.State.waiting.color
-        }
-        if sessions.contains(where: { $0.state == .working }) {
-            return SessionState.State.working.color
-        }
-        return SessionState.State.ready.color
     }
 }
 

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -294,6 +294,18 @@ struct SessionState: Identifiable, Codable {
             }
         }
 
+        /// Hex color without leading `#`, for SVG markup.
+        var hexColor: String {
+            String(color.dropFirst())
+        }
+
+        /// Highest-priority state in a collection (waiting > working > ready).
+        static func dominant<C: Collection>(in states: C) -> State where C.Element == State {
+            if states.contains(.waiting) { return .waiting }
+            if states.contains(.working) { return .working }
+            return .ready
+        }
+
         var emoji: String {
             switch self {
             case .working: return "🟣"   // purple circle

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -282,7 +282,8 @@ struct SessionListView: View {
         // Sessions in different worktrees of the same repo share the same project name.
         var grouped: [String: [SessionGroup]] = [:]
         for group in groups {
-            let project = group.parent.projectName ?? "unknown"
+            let project = group.parent.projectName
+                ?? URL(fileURLWithPath: group.parent.cwd).lastPathComponent
             grouped[project, default: []].append(group)
         }
 
@@ -294,6 +295,7 @@ struct SessionListView: View {
 
     private var sessionListContent: some View {
         let allProjectGroups = projectGroups
+        let isCompactMode = allProjectGroups.count > 5
         // Pre-compute starting flat index for each project group (for drag/drop continuity)
         var startIndices: [String: Int] = [:]
         var runningIndex = 0
@@ -308,7 +310,8 @@ struct SessionListView: View {
                 ForEach(allProjectGroups) { projectGroup in
                     ProjectGroupSectionView(
                         projectGroup: projectGroup,
-                        startingGroupIndex: startIndices[projectGroup.id] ?? 0
+                        startingGroupIndex: startIndices[projectGroup.id] ?? 0,
+                        isCompact: isCompactMode
                     )
                 }
 
@@ -860,6 +863,126 @@ struct ProjectGroup: Identifiable {
     let sessionGroups: [SessionGroup]
 
     var id: String { projectDirectory }
+
+    /// States in display order (maps left-to-right dots to top-to-bottom sessions).
+    var sessionStates: [SessionState.State] {
+        sessionGroups.map { $0.parent.state }
+    }
+
+    /// Highest-priority state across all sessions (waiting > working > ready).
+    var dominantState: SessionState.State {
+        if sessionStates.contains(.waiting) { return .waiting }
+        if sessionStates.contains(.working) { return .working }
+        return .ready
+    }
+}
+
+// MARK: - Session State Dots
+
+struct SessionStateDots: View {
+    let projectGroup: ProjectGroup
+    let isCompact: Bool
+
+    var body: some View {
+        if isCompact {
+            compactDot
+        } else if projectGroup.sessionStates.count > 4 {
+            overflowCounts
+        } else {
+            normalDots
+        }
+    }
+
+    // MARK: Normal mode (≤4 sessions): individual dots
+
+    private var normalDots: some View {
+        HStack(spacing: 3) {
+            ForEach(Array(projectGroup.sessionStates.enumerated()), id: \.offset) { _, state in
+                dotForState(state)
+            }
+        }
+        .tooltip(stateBreakdownTooltip)
+    }
+
+    @ViewBuilder
+    private func dotForState(_ state: SessionState.State) -> some View {
+        let color = Color(hex: state.color)
+        switch state {
+        case .working:
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+        case .waiting:
+            Circle()
+                .fill(color)
+                .frame(width: 6, height: 6)
+                .overlay(
+                    Circle()
+                        .stroke(color, lineWidth: 1)
+                        .frame(width: 9, height: 9)
+                )
+        case .ready:
+            Circle()
+                .stroke(color.opacity(0.6), lineWidth: 1)
+                .frame(width: 6, height: 6)
+        }
+    }
+
+    // MARK: Overflow mode (>4 sessions): state counts
+
+    private var overflowCounts: some View {
+        let states = projectGroup.sessionStates
+        let waitingCount = states.filter { $0 == .waiting }.count
+        let workingCount = states.filter { $0 == .working }.count
+        let readyCount = states.filter { $0 == .ready }.count
+
+        return HStack(spacing: 4) {
+            if waitingCount > 0 {
+                stateCountLabel("◉", count: waitingCount, color: Color(hex: SessionState.State.waiting.color))
+            }
+            if workingCount > 0 {
+                stateCountLabel("●", count: workingCount, color: Color(hex: SessionState.State.working.color))
+            }
+            if readyCount > 0 {
+                stateCountLabel("○", count: readyCount, color: Color(hex: SessionState.State.ready.color))
+            }
+        }
+        .tooltip(stateBreakdownTooltip)
+    }
+
+    private func stateCountLabel(_ symbol: String, count: Int, color: Color) -> some View {
+        HStack(spacing: 1) {
+            Text(symbol)
+                .font(.system(size: 8))
+                .foregroundColor(color)
+            Text("\(count)")
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .foregroundColor(color)
+        }
+    }
+
+    // MARK: Compact mode (many groups): single dominant dot
+
+    private var compactDot: some View {
+        Circle()
+            .fill(Color(hex: projectGroup.dominantState.color))
+            .frame(width: 6, height: 6)
+            .tooltip(stateBreakdownTooltip)
+    }
+
+    // MARK: Tooltip
+
+    private var stateBreakdownTooltip: String {
+        let states = projectGroup.sessionStates
+        let w = states.filter { $0 == .waiting }.count
+        let k = states.filter { $0 == .working }.count
+        let r = states.filter { $0 == .ready }.count
+        var parts: [String] = []
+        if w > 0 { parts.append("\(w) waiting") }
+        if k > 0 { parts.append("\(k) working") }
+        if r > 0 { parts.append("\(r) ready") }
+        return parts.joined(separator: ", ")
+    }
 }
 
 // MARK: - Project Group Section View
@@ -867,6 +990,7 @@ struct ProjectGroup: Identifiable {
 struct ProjectGroupSectionView: View {
     let projectGroup: ProjectGroup
     let startingGroupIndex: Int
+    let isCompact: Bool
     @EnvironmentObject var sessionManager: SessionManager
     @State private var isExpanded = true
 
@@ -924,6 +1048,8 @@ struct ProjectGroupSectionView: View {
                             .font(.system(size: 9, weight: .medium, design: .monospaced))
                             .foregroundColor(.secondary)
                     }
+
+                    SessionStateDots(projectGroup: projectGroup, isCompact: isCompact)
 
                     Spacer()
 

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -278,19 +278,20 @@ struct SessionListView: View {
     var projectGroups: [ProjectGroup] {
         let groups = sessionGroups
 
-        // Group session groups by project name (from git repo root).
+        // Group session groups by project name (from git repo root) or full cwd path.
         // Sessions in different worktrees of the same repo share the same project name.
         var grouped: [String: [SessionGroup]] = [:]
         for group in groups {
-            let project = group.parent.projectName
-                ?? URL(fileURLWithPath: group.parent.cwd).lastPathComponent
-            grouped[project, default: []].append(group)
+            let key = group.parent.projectName ?? group.parent.cwd
+            grouped[key, default: []].append(group)
         }
 
-        // Convert to ProjectGroup array, sorted by project name
+        // Convert to ProjectGroup array, sorted by display name
         return grouped.map { key, value in
-            ProjectGroup(projectDirectory: key, sessionGroups: value)
-        }.sorted { $0.projectDirectory < $1.projectDirectory }
+            let display = value.first?.parent.projectName
+                ?? URL(fileURLWithPath: key).lastPathComponent
+            return ProjectGroup(projectDirectory: key, displayName: display, sessionGroups: value)
+        }.sorted { $0.displayName < $1.displayName }
     }
 
     private var sessionListContent: some View {
@@ -859,7 +860,8 @@ struct SessionGroup: Identifiable {
 }
 
 struct ProjectGroup: Identifiable {
-    let projectDirectory: String
+    let projectDirectory: String   // full path or project name (grouping key)
+    let displayName: String        // short name shown in UI
     let sessionGroups: [SessionGroup]
 
     var id: String { projectDirectory }
@@ -1038,7 +1040,7 @@ struct ProjectGroupSectionView: View {
                         .foregroundColor(.secondary)
                         .frame(width: 10)
 
-                    Text(projectGroup.projectDirectory)
+                    Text(projectGroup.displayName)
                         .font(.system(.caption, design: .monospaced))
                         .fontWeight(.semibold)
                         .foregroundColor(projectNameColor)

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -275,7 +275,7 @@ struct SessionListView: View {
         }
     }
 
-    var projectGroups: [ProjectGroup] {
+    private var projectGroups: [ProjectGroup] {
         let groups = sessionGroups
 
         // Group session groups by project name (from git repo root) or full cwd path.
@@ -873,17 +873,25 @@ struct ProjectGroup: Identifiable {
 
     /// Highest-priority state across all sessions (waiting > working > ready).
     var dominantState: SessionState.State {
-        if sessionStates.contains(.waiting) { return .waiting }
-        if sessionStates.contains(.working) { return .working }
-        return .ready
+        .dominant(in: sessionStates)
     }
 }
-
-// MARK: - Session State Dots
 
 struct SessionStateDots: View {
     let projectGroup: ProjectGroup
     let isCompact: Bool
+
+    private var stateCounts: (waiting: Int, working: Int, ready: Int) {
+        var w = 0, k = 0, r = 0
+        for s in projectGroup.sessionStates {
+            switch s {
+            case .waiting: w += 1
+            case .working: k += 1
+            case .ready:   r += 1
+            }
+        }
+        return (w, k, r)
+    }
 
     var body: some View {
         if isCompact {
@@ -903,7 +911,7 @@ struct SessionStateDots: View {
                 dotForState(state)
             }
         }
-        .tooltip(stateBreakdownTooltip)
+        .tooltip(tooltipText)
     }
 
     @ViewBuilder
@@ -933,23 +941,19 @@ struct SessionStateDots: View {
     // MARK: Overflow mode (>4 sessions): state counts
 
     private var overflowCounts: some View {
-        let states = projectGroup.sessionStates
-        let waitingCount = states.filter { $0 == .waiting }.count
-        let workingCount = states.filter { $0 == .working }.count
-        let readyCount = states.filter { $0 == .ready }.count
-
+        let c = stateCounts
         return HStack(spacing: 4) {
-            if waitingCount > 0 {
-                stateCountLabel("◉", count: waitingCount, color: Color(hex: SessionState.State.waiting.color))
+            if c.waiting > 0 {
+                stateCountLabel("◉", count: c.waiting, color: Color(hex: SessionState.State.waiting.color))
             }
-            if workingCount > 0 {
-                stateCountLabel("●", count: workingCount, color: Color(hex: SessionState.State.working.color))
+            if c.working > 0 {
+                stateCountLabel("●", count: c.working, color: Color(hex: SessionState.State.working.color))
             }
-            if readyCount > 0 {
-                stateCountLabel("○", count: readyCount, color: Color(hex: SessionState.State.ready.color))
+            if c.ready > 0 {
+                stateCountLabel("○", count: c.ready, color: Color(hex: SessionState.State.ready.color))
             }
         }
-        .tooltip(stateBreakdownTooltip)
+        .tooltip(tooltipText)
     }
 
     private func stateCountLabel(_ symbol: String, count: Int, color: Color) -> some View {
@@ -969,20 +973,15 @@ struct SessionStateDots: View {
         Circle()
             .fill(Color(hex: projectGroup.dominantState.color))
             .frame(width: 6, height: 6)
-            .tooltip(stateBreakdownTooltip)
+            .tooltip(tooltipText)
     }
 
-    // MARK: Tooltip
-
-    private var stateBreakdownTooltip: String {
-        let states = projectGroup.sessionStates
-        let w = states.filter { $0 == .waiting }.count
-        let k = states.filter { $0 == .working }.count
-        let r = states.filter { $0 == .ready }.count
+    private var tooltipText: String {
+        let c = stateCounts
         var parts: [String] = []
-        if w > 0 { parts.append("\(w) waiting") }
-        if k > 0 { parts.append("\(k) working") }
-        if r > 0 { parts.append("\(r) ready") }
+        if c.waiting > 0 { parts.append("\(c.waiting) waiting") }
+        if c.working > 0 { parts.append("\(c.working) working") }
+        if c.ready > 0 { parts.append("\(c.ready) ready") }
         return parts.joined(separator: ", ")
     }
 }


### PR DESCRIPTION
## Summary
- **Menu bar icon**: ≤3 sessions per group show individual filled circles; >3 show a single dominant-state circle + total count (capped at 8 groups)
- **Popover project headers**: State dots added — individual dots (≤4), state counts with symbols (>4), compact single dot (>5 groups)
- **Grouping fix**: Sessions without `projectName` group by full cwd path (avoids folder-name collisions), display folder name in UI
- **Refactor**: Dominant-state priority logic centralized in `SessionState.State.dominant(in:)`, `hexColor` property for SVG, single-pass state counting

## Test plan
- [x] 1-3 sessions in a group: individual colored dots in menu bar
- [x] 4+ sessions in a group: single circle + count in menu bar
- [x] Popover shows state dots in project group headers
- [x] Waiting state always surfaces as dominant color
- [x] Sessions without project name show folder name (not "unknown")
- [x] Different paths with same folder name stay as separate groups

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)