### PR TITLE
fix: expand click target for Settings and Quit buttons

### DIFF
--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -65,33 +65,33 @@ struct SessionListView: View {
                 // Settings and Quit buttons at bottom
                 Divider()
                 HStack(spacing: 0) {
-                    Button("Settings…") {
-                        showSettings = true
+                    Button(action: { showSettings = true }) {
+                        Text("Settings…")
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                            .background(isSettingsButtonHovered ? Color.accentColor.opacity(0.1) : Color.clear)
+                            .contentShape(Rectangle())
+                            .onHover { hovering in
+                                isSettingsButtonHovered = hovering
+                            }
                     }
                     .buttonStyle(.plain)
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(isSettingsButtonHovered ? Color.accentColor.opacity(0.1) : Color.clear)
-                    .onHover { hovering in
-                        isSettingsButtonHovered = hovering
-                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
 
                     Divider().frame(height: 20)
 
-                    Button("Quit") {
-                        NSApplication.shared.terminate(nil)
+                    Button(action: { NSApplication.shared.terminate(nil) }) {
+                        Text("Quit")
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                            .background(isQuitButtonHovered ? Color.accentColor.opacity(0.1) : Color.clear)
+                            .contentShape(Rectangle())
+                            .onHover { hovering in
+                                isQuitButtonHovered = hovering
+                            }
                     }
                     .buttonStyle(.plain)
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(isQuitButtonHovered ? Color.accentColor.opacity(0.1) : Color.clear)
-                    .onHover { hovering in
-                        isQuitButtonHovered = hovering
-                        if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-                    }
                 }
             }
             .frame(width: 350)
@@ -1174,7 +1174,8 @@ struct SessionListView_Previews: PreviewProvider {
                             modelName: "claude-sonnet-4-6",
                             contextUtilization: 7.5,
                             pressureLevel: "safe",
-                            estimatedCostUSD: nil
+                            estimatedCostUSD: nil,
+                            lastAssistantText: nil
                         )
                     )
                 ]


### PR DESCRIPTION
## Summary
- Move frame, padding, `contentShape(Rectangle())`, and hover handling into button label closures so the entire button area is clickable — not just the text label
- Remove non-functional `NSCursor` pointer changes
- Fix missing `lastAssistantText` parameter in preview mock

Closes #67

## Test plan
- [x] Open menu bar popover, click anywhere in the Settings button area (not just text) — triggers settings
- [x] Click anywhere in the Quit button area — triggers quit
- [x] Hover highlight still appears across full button area

🤖 Generated with [Claude Code](https://claude.com/claude-code)