### PR TITLE
fix: resolve git root for deleted worktree directories

### DIFF
--- a/core/adapters/outbound/git/adapter.go
+++ b/core/adapters/outbound/git/adapter.go
@@ -42,7 +42,13 @@ func (a *Adapter) GetBranch(dir string) string {
 // GetGitRoot returns the absolute path of the git repo root for the given
 // directory, or "" if the directory is not inside a git repository.
 // For worktrees it returns the main repo root (not the worktree path).
+// If dir has been deleted (e.g. a cleaned-up worktree), it walks up to the
+// nearest existing ancestor so the repo can still be resolved.
 func (a *Adapter) GetGitRoot(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	dir = nearestExistingDir(dir)
 	if dir == "" {
 		return ""
 	}
@@ -62,6 +68,21 @@ func (a *Adapter) GetGitRoot(dir string) string {
 		return ""
 	}
 	return root
+}
+
+// nearestExistingDir returns dir if it exists, otherwise walks up to the
+// nearest existing ancestor directory. Returns "" if no ancestor exists.
+func nearestExistingDir(dir string) string {
+	for {
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 // GetProjectName returns the project name for the given directory.

--- a/core/adapters/outbound/git/adapter_test.go
+++ b/core/adapters/outbound/git/adapter_test.go
@@ -1,0 +1,97 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestNearestExistingDir(t *testing.T) {
+	t.Run("existing dir returns itself", func(t *testing.T) {
+		dir := t.TempDir()
+		got := nearestExistingDir(dir)
+		if got != dir {
+			t.Errorf("got %q, want %q", got, dir)
+		}
+	})
+
+	t.Run("deleted child resolves to parent", func(t *testing.T) {
+		dir := t.TempDir()
+		child := filepath.Join(dir, "deleted-child")
+		got := nearestExistingDir(child)
+		if got != dir {
+			t.Errorf("got %q, want %q", got, dir)
+		}
+	})
+
+	t.Run("deeply nested non-existent resolves to ancestor", func(t *testing.T) {
+		dir := t.TempDir()
+		deep := filepath.Join(dir, "a", "b", "c", "d")
+		got := nearestExistingDir(deep)
+		if got != dir {
+			t.Errorf("got %q, want %q", got, dir)
+		}
+	})
+}
+
+func TestGetGitRoot_DeletedSubdir(t *testing.T) {
+	dir := realPath(t, t.TempDir())
+	if err := exec.Command("git", "init", dir).Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	a := New()
+
+	// Existing dir works as before.
+	got := a.GetGitRoot(dir)
+	if got != dir {
+		t.Errorf("existing dir: got %q, want %q", got, dir)
+	}
+
+	// Deleted subdir resolves to the same repo root.
+	deleted := filepath.Join(dir, "nonexistent", "child")
+	got = a.GetGitRoot(deleted)
+	if got != dir {
+		t.Errorf("deleted subdir: got %q, want %q", got, dir)
+	}
+}
+
+func TestGetGitRoot_NotARepo(t *testing.T) {
+	dir := t.TempDir()
+	a := New()
+	got := a.GetGitRoot(dir)
+	if got != "" {
+		t.Errorf("non-repo dir: got %q, want empty", got)
+	}
+}
+
+// realPath resolves symlinks (e.g. macOS /var → /private/var) so test
+// comparisons match the absolute paths returned by git.
+func realPath(t *testing.T, dir string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", dir, err)
+	}
+	return resolved
+}
+
+func TestGetProjectName_DeletedWorktree(t *testing.T) {
+	// Create a temp dir structure that mimics a repo with a deleted worktree.
+	parent := t.TempDir()
+	repoDir := filepath.Join(parent, "myproject")
+	if err := os.Mkdir(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := exec.Command("git", "init", repoDir).Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	a := New()
+	deleted := filepath.Join(repoDir, ".claude", "worktrees", "62")
+	got := a.GetProjectName(deleted)
+	if got != "myproject" {
+		t.Errorf("got %q, want %q", got, "myproject")
+	}
+}


### PR DESCRIPTION
## Summary
- When a worktree is cleaned up before irrlicht resolves its project name, `GetGitRoot()` fails because `git rev-parse` can't chdir to the non-existent directory, causing worktree sessions to appear as separate groups (e.g. "62" instead of "irrlicht")
- Added `nearestExistingDir()` helper that walks up to the nearest existing ancestor directory, so `GetGitRoot()` can still resolve the repo root from a deleted worktree path
- Added tests for the new helper, deleted-subdir git root resolution, and deleted-worktree project name resolution

## Test plan
- [x] `go test ./adapters/outbound/git/ -count=1 -v` — all new tests pass
- [x] `go test ./... -count=1` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)