### PR TITLE
fix: clean up orphan sessions after /clear (#64)

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/discovery.go
+++ b/core/adapters/inbound/agents/processlifecycle/discovery.go
@@ -1,13 +1,8 @@
 package processlifecycle
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"strconv"
-	"strings"
-	"time"
 )
 
 // DiscoverPIDByCWD finds a "claude" process whose CWD matches the given
@@ -57,36 +52,3 @@ func DiscoverPIDByCWD(cwd string, disambiguate func([]int) int) (int, error) {
 	}
 }
 
-// DiscoverPID uses lsof to find the PID that has filePath open.
-// Returns 0, nil when no process has the file open.
-func DiscoverPID(filePath string) (int, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	out, err := exec.CommandContext(ctx, "lsof", "-t", filePath).Output()
-	if err != nil {
-		// Exit status 1 means no matches — not an error.
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-			return 0, nil
-		}
-		return 0, fmt.Errorf("lsof %s: %w", filePath, err)
-	}
-
-	// Skip our own PID — the daemon reads transcript files for metrics,
-	// so lsof often returns the daemon itself. We want the external
-	// process (e.g. Claude Code CLI) that owns the session.
-	myPID := os.Getpid()
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if line == "" {
-			continue
-		}
-		pid, err := strconv.Atoi(strings.TrimSpace(line))
-		if err != nil {
-			continue
-		}
-		if pid != myPID {
-			return pid, nil
-		}
-	}
-	return 0, nil
-}

--- a/core/adapters/inbound/agents/processlifecycle/monitor_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/monitor_test.go
@@ -1,7 +1,6 @@
 package processlifecycle
 
 import (
-	"os"
 	"os/exec"
 	"sync"
 	"testing"
@@ -166,41 +165,3 @@ func TestUnwatch(t *testing.T) {
 	}
 }
 
-func TestDiscoverPID_FiltersSelf(t *testing.T) {
-	// Create a temp file and keep it open — only our own process has it open.
-	// DiscoverPID should filter out the caller's own PID (the daemon in prod)
-	// and return 0 since no external process has the file open.
-	f, err := os.CreateTemp("", "processlifecycle-test-*")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
-	defer os.Remove(f.Name())
-	defer f.Close()
-
-	pid, err := DiscoverPID(f.Name())
-	if err != nil {
-		t.Fatalf("DiscoverPID: %v", err)
-	}
-	if pid != 0 {
-		t.Errorf("DiscoverPID got pid %d, want 0 (self-PID should be filtered)", pid)
-	}
-}
-
-func TestDiscoverPID_NoMatch(t *testing.T) {
-	// File that no one has open.
-	f, err := os.CreateTemp("", "processlifecycle-noop-*")
-	if err != nil {
-		t.Fatalf("CreateTemp: %v", err)
-	}
-	name := f.Name()
-	f.Close() // Close it so no one has it open.
-	defer os.Remove(name)
-
-	pid, err := DiscoverPID(name)
-	if err != nil {
-		t.Fatalf("DiscoverPID: %v", err)
-	}
-	if pid != 0 {
-		t.Errorf("DiscoverPID got pid %d, want 0 (no match)", pid)
-	}
-}

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1,7 +1,7 @@
-// PIDManager handles process lifecycle for sessions: PID discovery (lsof +
-// CWD fallback), ProcessWatcher registration, exit handling, and periodic
-// liveness sweeps. It was extracted from SessionDetector to separate process
-// management (~250 lines) from session detection.
+// PIDManager handles process lifecycle for sessions: CWD-based PID discovery,
+// ProcessWatcher registration, exit handling, and periodic liveness sweeps.
+// It was extracted from SessionDetector to separate process management from
+// session detection.
 package services
 
 import (
@@ -24,8 +24,7 @@ type PIDManager struct {
 	broadcaster outbound.PushBroadcaster // optional
 	readyTTL    time.Duration            // max idle time for ready sessions
 
-	discoverPID      func(string) (int, error)                    // lsof-based discovery
-	discoverPIDByCWD func(string, func([]int) int) (int, error) // optional CWD fallback
+	discoverPIDByCWD func(string, func([]int) int) (int, error) // CWD-based discovery
 
 	// onSessionDeleted is called when a session is deleted so the caller can
 	// clean up its own tracking structures (e.g. projectSessions map).
@@ -40,7 +39,7 @@ func NewPIDManager(
 	log outbound.Logger,
 	broadcaster outbound.PushBroadcaster,
 	readyTTL time.Duration,
-	discoverPID func(string) (int, error),
+	discoverPIDByCWD func(string, func([]int) int) (int, error),
 	onSessionDeleted func(sessionID string),
 ) *PIDManager {
 	return &PIDManager{
@@ -49,16 +48,9 @@ func NewPIDManager(
 		log:              log,
 		broadcaster:      broadcaster,
 		readyTTL:         readyTTL,
-		discoverPID:      discoverPID,
+		discoverPIDByCWD: discoverPIDByCWD,
 		onSessionDeleted: onSessionDeleted,
 	}
-}
-
-// SetCWDDiscovery sets an optional fallback PID discovery function that finds
-// a process by matching its working directory. Called when lsof on the
-// transcript file fails to find a PID.
-func (pm *PIDManager) SetCWDDiscovery(fn func(string, func([]int) int) (int, error)) {
-	pm.discoverPIDByCWD = fn
 }
 
 // HandleProcessExit deletes a session when its process exits.
@@ -113,14 +105,6 @@ func (pm *PIDManager) cleanupChildren(parentID string) {
 // This handles the /clear scenario: the CLI process stays alive (same PID) but
 // starts a new transcript, making the old session obsolete.
 func (pm *PIDManager) HandlePIDAssigned(pid int, sessionID string) {
-	pm.handlePIDAssignedInternal(pid, sessionID, true)
-}
-
-// handlePIDAssignedInternal is the core of HandlePIDAssigned. When authoritative
-// is true (lsof-based discovery), old sessions sharing the same PID are cleaned
-// up (/clear scenario). When false (CWD-based fallback), cleanup is skipped
-// because CWD discovery is ambiguous for multiple instances in the same repo.
-func (pm *PIDManager) handlePIDAssignedInternal(pid int, sessionID string, authoritative bool) {
 	if pid <= 0 {
 		return
 	}
@@ -142,20 +126,15 @@ func (pm *PIDManager) handlePIDAssignedInternal(pid int, sessionID string, autho
 		}
 	}
 
-	// Clean up old sessions that had the same PID (e.g. /clear).
-	// Only do this for authoritative (lsof) discoveries — CWD-based
-	// fallback is unreliable when multiple instances share a directory
-	// and could incorrectly delete a still-active session.
-	if !authoritative {
-		return
-	}
-
 	// Subagent sessions share the parent's PID, so skip cleanup when
 	// either side is a subagent.
 	if state.ParentSessionID != "" {
 		return
 	}
 
+	// Clean up old sessions that had the same PID (e.g. /clear).
+	// A non-subagent PID can only belong to one session at a time —
+	// if a new session claims a PID, the old one is stale.
 	states, err := pm.repo.ListAll()
 	if err != nil {
 		return
@@ -182,8 +161,7 @@ func (pm *PIDManager) handlePIDAssignedInternal(pid int, sessionID string, autho
 }
 
 // claimedPIDs returns the set of PIDs already assigned to sessions other than
-// excludeSessionID. Used to prevent CWD-based discovery from assigning a PID
-// that is already tracked by another session.
+// excludeSessionID.
 func (pm *PIDManager) claimedPIDs(excludeSessionID string) map[int]bool {
 	states, err := pm.repo.ListAll()
 	if err != nil {
@@ -198,10 +176,12 @@ func (pm *PIDManager) claimedPIDs(excludeSessionID string) map[int]bool {
 	return claimed
 }
 
-// TryDiscoverPID attempts lsof-on-transcript (primary), then CWD-based
-// discovery (fallback). Returns true if a PID was found and assigned.
-func (pm *PIDManager) TryDiscoverPID(sessionID, transcriptPath, cwd string) bool {
-	if pm.pw == nil {
+// TryDiscoverPID finds the PID for a session by matching Claude processes
+// by working directory. Prefers unclaimed PIDs but falls back to already-
+// claimed PIDs when no unclaimed candidate exists (the /clear scenario where
+// the same process starts a new transcript). Returns true if a PID was found.
+func (pm *PIDManager) TryDiscoverPID(sessionID, cwd string) bool {
+	if pm.pw == nil || pm.discoverPIDByCWD == nil || cwd == "" {
 		return false
 	}
 	// Check if session already has a PID.
@@ -210,48 +190,39 @@ func (pm *PIDManager) TryDiscoverPID(sessionID, transcriptPath, cwd string) bool
 		return true
 	}
 
-	// Primary: lsof on transcript file (authoritative).
-	if transcriptPath != "" {
-		if pid, err := pm.discoverPID(transcriptPath); err == nil && pid > 0 {
-			pm.log.LogInfo("session-detector", sessionID,
-				fmt.Sprintf("lsof discovered pid %d", pid))
-			pm.handlePIDAssignedInternal(pid, sessionID, true)
-			return true
+	// Prefer unclaimed PIDs (multiple instances in same dir), but allow
+	// claimed PIDs when all candidates are claimed (/clear scenario).
+	claimed := pm.claimedPIDs(sessionID)
+	disambiguate := func(pids []int) int {
+		bestUnclaimed, bestAny := 0, 0
+		for _, p := range pids {
+			if p > bestAny {
+				bestAny = p
+			}
+			if !claimed[p] && p > bestUnclaimed {
+				bestUnclaimed = p
+			}
 		}
+		if bestUnclaimed > 0 {
+			return bestUnclaimed
+		}
+		return bestAny
 	}
 
-	// Fallback: CWD-based discovery (not authoritative).
-	// Filter out PIDs already claimed by other sessions to prevent
-	// assigning the same PID to multiple sessions in the same directory.
-	if pm.discoverPIDByCWD != nil && cwd != "" {
-		claimed := pm.claimedPIDs(sessionID)
-		disambiguate := func(pids []int) int {
-			best := 0
-			for _, p := range pids {
-				if claimed[p] {
-					continue
-				}
-				if p > best {
-					best = p
-				}
-			}
-			return best
-		}
-		if pid, err := pm.discoverPIDByCWD(cwd, disambiguate); err == nil && pid > 0 {
-			pm.log.LogInfo("session-detector", sessionID,
-				fmt.Sprintf("cwd fallback discovered pid %d", pid))
-			pm.handlePIDAssignedInternal(pid, sessionID, false)
-			return true
-		}
+	if pid, err := pm.discoverPIDByCWD(cwd, disambiguate); err == nil && pid > 0 {
+		pm.log.LogInfo("session-detector", sessionID,
+			fmt.Sprintf("discovered pid %d via cwd %s", pid, cwd))
+		pm.HandlePIDAssigned(pid, sessionID)
+		return true
 	}
 	return false
 }
 
 // DiscoverPIDWithRetry tries to discover a PID immediately, then retries at
-// 500ms, 1s, 2s intervals. This covers the common timing issue where the CLI
-// hasn't opened the transcript file yet at session creation time.
-func (pm *PIDManager) DiscoverPIDWithRetry(sessionID, transcriptPath, cwd string) {
-	if pm.TryDiscoverPID(sessionID, transcriptPath, cwd) {
+// 500ms, 1s, 2s intervals. This covers the timing where the Claude process
+// hasn't started yet or CWD isn't resolved at session creation time.
+func (pm *PIDManager) DiscoverPIDWithRetry(sessionID, cwd string) {
+	if pm.TryDiscoverPID(sessionID, cwd) {
 		return
 	}
 	for _, delay := range []time.Duration{500 * time.Millisecond, 1 * time.Second, 2 * time.Second} {
@@ -260,7 +231,7 @@ func (pm *PIDManager) DiscoverPIDWithRetry(sessionID, transcriptPath, cwd string
 		if state == nil || state.PID > 0 {
 			return
 		}
-		if pm.TryDiscoverPID(sessionID, transcriptPath, cwd) {
+		if pm.TryDiscoverPID(sessionID, cwd) {
 			return
 		}
 	}
@@ -342,6 +313,20 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 				}
 				continue
 			}
+			// Claude Code sessions with PID=0 that are ready: the process
+			// likely exited before CWD discovery succeeded. Clean up quickly
+			// (30s) rather than waiting the full readyTTL. Non-Claude
+			// adapters (Pi, Codex) legitimately have PID=0 — they don't
+			// use PID-based lifecycle.
+			if state.PID == 0 && state.State == session.StateReady &&
+				state.Adapter == "claude-code" &&
+				time.Since(time.Unix(state.UpdatedAt, 0)) > 30*time.Second {
+				pm.log.LogInfo("session-detector", state.SessionID,
+					"ready session with no PID for >30s, deleting")
+				pm.deleteWithChildren(state)
+				continue
+			}
+
 			if !state.IsStale(pm.readyTTL) {
 				continue
 			}
@@ -365,6 +350,9 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 // SeedPIDs cleans up dead sessions and registers alive PIDs with ProcessWatcher
 // during startup. Called from SessionDetector.seedFromDisk.
 func (pm *PIDManager) SeedPIDs(states []*session.SessionState) {
+	// Track the newest session per PID for deduplication.
+	newestByPID := make(map[int]*session.SessionState)
+
 	for _, state := range states {
 		switch {
 		case state.PID > 0:
@@ -381,14 +369,46 @@ func (pm *PIDManager) SeedPIDs(states []*session.SessionState) {
 				}
 			}
 
-		case state.PID == 0 && state.ParentSessionID == "" && isStaleTranscript(state.TranscriptPath):
-			// Orphan from exited Claude Code process (never assigned a PID
-			// because Claude Code doesn't keep transcript files open).
-			// Child sessions (ParentSessionID set) are exempt — they run
-			// inside the parent process and never get their own PID.
+			// Track newest non-subagent session per PID for dedup below.
+			if state.ParentSessionID == "" && !strings.HasPrefix(state.SessionID, "proc-") {
+				if prev, ok := newestByPID[state.PID]; !ok || state.FirstSeen > prev.FirstSeen {
+					newestByPID[state.PID] = state
+				}
+			}
+
+		case state.PID == 0 && state.ParentSessionID == "" && state.Adapter == "claude-code" && isStaleTranscript(state.TranscriptPath):
+			// Orphan from exited Claude Code process (PID discovery never
+			// succeeded). Child sessions (ParentSessionID set) are exempt —
+			// they run inside the parent process and never get their own PID.
+			// Non-Claude adapters (Pi, Codex) legitimately have PID=0.
 			pm.log.LogInfo("session-detector-seed", state.SessionID,
 				"deleting orphan session")
 			pm.deleteWithChildren(state)
+		}
+	}
+
+	// Deduplicate: when multiple non-subagent sessions share a PID (e.g.
+	// orphans left by /clear), keep only the newest one.
+	for pid, newest := range newestByPID {
+		for _, state := range states {
+			if state.PID != pid || state.SessionID == newest.SessionID {
+				continue
+			}
+			if state.ParentSessionID != "" || strings.HasPrefix(state.SessionID, "proc-") {
+				continue
+			}
+			// Verify session still exists (may have been deleted above).
+			if s, _ := pm.repo.Load(state.SessionID); s == nil {
+				continue
+			}
+			pm.log.LogInfo("session-detector-seed", state.SessionID,
+				fmt.Sprintf("duplicate pid %d (keeping %s) — deleting", pid, newest.SessionID))
+
+			if pm.onSessionDeleted != nil {
+				pm.onSessionDeleted(state.SessionID)
+			}
+			_ = pm.repo.Delete(state.SessionID)
+			pm.broadcast(outbound.PushTypeDeleted, state)
 		}
 	}
 }

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/inbound"
@@ -57,6 +56,11 @@ type SessionDetector struct {
 	mu              sync.Mutex
 	projectSessions map[string]string // sessionID → projectDir
 
+	// deletedSessions tracks session IDs that were explicitly deleted (process
+	// exit, /clear cleanup). Prevents late-arriving transcript activity from
+	// re-creating a session that was intentionally removed.
+	deletedSessions map[string]bool
+
 	// debounce coalesces rapid transcript activity events per session.
 	debounceMu sync.Mutex
 	debounce   map[string]*debounceEntry
@@ -74,6 +78,7 @@ func NewSessionDetector(
 	broadcaster outbound.PushBroadcaster,
 	version string,
 	readyTTL time.Duration,
+	discoverPIDByCWD func(string, func([]int) int) (int, error),
 ) *SessionDetector {
 	det := &SessionDetector{
 		watchers:        watchers,
@@ -83,20 +88,14 @@ func NewSessionDetector(
 		version:         version,
 		enricher:        NewMetadataEnricher(git, metrics),
 		projectSessions: make(map[string]string),
+		deletedSessions: make(map[string]bool),
 		debounce:        make(map[string]*debounceEntry),
 	}
 	det.pidMgr = NewPIDManager(
 		pw, repo, log, broadcaster, readyTTL,
-		processlifecycle.DiscoverPID, det.removeFromProjectSessions,
+		discoverPIDByCWD, det.removeFromProjectSessions,
 	)
 	return det
-}
-
-// WithCWDDiscovery sets an optional fallback PID discovery function that finds
-// a process by matching its working directory. Called when lsof on the
-// transcript file fails to find a PID.
-func (d *SessionDetector) WithCWDDiscovery(fn func(string, func([]int) int) (int, error)) {
-	d.pidMgr.SetCWDDiscovery(fn)
 }
 
 // Run subscribes to all AgentWatcher event streams, fans them into a single
@@ -188,6 +187,18 @@ func (d *SessionDetector) onNewSession(ev agent.Event) {
 	now := time.Now().Unix()
 
 	if isNew {
+		// Skip transcripts whose session was recently deleted (process exit
+		// or /clear cleanup). This prevents late-arriving file events from
+		// re-creating a session that was intentionally removed.
+		d.mu.Lock()
+		deleted := d.deletedSessions[ev.SessionID]
+		d.mu.Unlock()
+		if deleted {
+			d.log.LogInfo("session-detector", ev.SessionID,
+				"skipping recently deleted session")
+			return
+		}
+
 		// Skip orphan transcripts left by exited Claude Code processes.
 		if isStaleTranscript(ev.TranscriptPath) {
 			d.log.LogInfo("session-detector", ev.SessionID,
@@ -241,12 +252,20 @@ func (d *SessionDetector) onNewSession(ev agent.Event) {
 		}
 	}
 
-	// PID discovery with retry and CWD fallback (async).
-	cwd := ev.CWD
+	// PID discovery (async). Only for claude-code sessions — the CWD-based
+	// discovery searches for "claude" processes and would assign the wrong
+	// PID to Codex/Pi sessions that share the same directory.
+	adapter := ev.Adapter
 	if !isNew {
-		cwd = existing.CWD
+		adapter = existing.Adapter
 	}
-	go d.pidMgr.DiscoverPIDWithRetry(ev.SessionID, ev.TranscriptPath, cwd)
+	if adapter == "claude-code" {
+		cwd := ev.CWD
+		if !isNew {
+			cwd = existing.CWD
+		}
+		go d.pidMgr.DiscoverPIDWithRetry(ev.SessionID, cwd)
+	}
 }
 
 // onActivity debounces transcript activity events per session. The first event
@@ -293,16 +312,24 @@ func (d *SessionDetector) processActivity(ev agent.Event) {
 	// Load session state.
 	state, err := d.repo.Load(ev.SessionID)
 	if err != nil || state == nil {
-		// Session not tracked yet — treat as new.
+		// If the session was explicitly deleted (process exit, /clear cleanup),
+		// don't re-create it from a late-arriving transcript write.
+		d.mu.Lock()
+		deleted := d.deletedSessions[ev.SessionID]
+		d.mu.Unlock()
+		if deleted {
+			return
+		}
+		// Session not tracked yet — treat as new (startup race where activity
+		// arrives before the initial scan).
 		d.onNewSession(ev)
 		return
 	}
 
-	// Retry PID discovery if not yet known (async to avoid blocking the
-	// event loop on lsof I/O). Includes CWD fallback.
-	if state.PID == 0 && ev.TranscriptPath != "" {
-		sid, tp, cwd := ev.SessionID, ev.TranscriptPath, state.CWD
-		go d.pidMgr.TryDiscoverPID(sid, tp, cwd)
+	// Retry PID discovery if not yet known (claude-code only).
+	if state.PID == 0 && state.CWD != "" && state.Adapter == "claude-code" {
+		sid, cwd := ev.SessionID, state.CWD
+		go d.pidMgr.TryDiscoverPID(sid, cwd)
 	}
 
 	// Refresh CWD/branch/project and metrics from transcript.
@@ -468,11 +495,12 @@ func (d *SessionDetector) seedFromDisk() {
 	d.pidMgr.SeedPIDs(states)
 }
 
-// removeFromProjectSessions removes a session from the projectSessions map.
-// Used as a callback by PIDManager when sessions are deleted.
+// removeFromProjectSessions removes a session from the projectSessions map and
+// marks it as deleted. Used as a callback by PIDManager when sessions are deleted.
 func (d *SessionDetector) removeFromProjectSessions(sessionID string) {
 	d.mu.Lock()
 	delete(d.projectSessions, sessionID)
+	d.deletedSessions[sessionID] = true
 	d.mu.Unlock()
 }
 

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -751,6 +751,7 @@ func TestSessionDetector_CWDFallback_DoesNotAssignDuplicatePID(t *testing.T) {
 	// Send two new sessions in the same project (same CWD).
 	tw.ch <- agent.Event{
 		Type:           agent.EventNewSession,
+		Adapter:        "claude-code",
 		SessionID:      "sess-a",
 		ProjectDir:     "-Users-test-project",
 		TranscriptPath: "/home/.claude/projects/-Users-test-project/sess-a.jsonl",
@@ -762,6 +763,7 @@ func TestSessionDetector_CWDFallback_DoesNotAssignDuplicatePID(t *testing.T) {
 
 	tw.ch <- agent.Event{
 		Type:           agent.EventNewSession,
+		Adapter:        "claude-code",
 		SessionID:      "sess-b",
 		ProjectDir:     "-Users-test-project",
 		TranscriptPath: "/home/.claude/projects/-Users-test-project/sess-b.jsonl",
@@ -795,7 +797,7 @@ func TestSessionDetector_CWDFallback_DoesNotAssignDuplicatePID(t *testing.T) {
 	}
 }
 
-func TestSessionDetector_CWDFallback_SkipsAlreadyClaimedPID(t *testing.T) {
+func TestSessionDetector_CWDFallback_CleansUpOldSessionOnClear(t *testing.T) {
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()
 	repo := newMockRepo()
@@ -803,9 +805,9 @@ func TestSessionDetector_CWDFallback_SkipsAlreadyClaimedPID(t *testing.T) {
 	// Use our own PID so seedFromDisk doesn't delete sess-a as a dead process.
 	myPID := os.Getpid()
 
-	// Mock CWD discovery returns only our PID — the only candidate is
-	// already claimed by sess-a, so the disambiguator should filter it out
-	// and sess-b should NOT get a PID assigned at all.
+	// Mock CWD discovery returns only our PID — simulates the /clear scenario
+	// where the same process starts a new transcript. The new session should
+	// claim the PID and clean up the old session.
 	cwdFn := func(cwd string, disambiguate func([]int) int) (int, error) {
 		return disambiguate([]int{myPID}), nil
 	}
@@ -824,17 +826,19 @@ func TestSessionDetector_CWDFallback_SkipsAlreadyClaimedPID(t *testing.T) {
 	// Session A already has a PID assigned (discovered earlier).
 	repo.Save(&session.SessionState{
 		SessionID:      "sess-a",
+		Adapter:        "claude-code",
 		State:          session.StateWorking,
 		PID:            myPID,
 		TranscriptPath: "/home/.claude/projects/-Users-test/sess-a.jsonl",
 		CWD:            "/Users/test/project",
 		FirstSeen:      now,
-		UpdatedAt:       now,
+		UpdatedAt:      now,
 	})
 
-	// Session B has no PID yet.
+	// Session B has no PID yet (new transcript after /clear).
 	repo.Save(&session.SessionState{
 		SessionID:      "sess-b",
+		Adapter:        "claude-code",
 		State:          session.StateReady,
 		TranscriptPath: "/home/.claude/projects/-Users-test/sess-b.jsonl",
 		CWD:            "/Users/test/project",
@@ -842,7 +846,7 @@ func TestSessionDetector_CWDFallback_SkipsAlreadyClaimedPID(t *testing.T) {
 		UpdatedAt:      now,
 	})
 
-	// Trigger activity on sess-b to initiate PID discovery (CWD fallback).
+	// Trigger activity on sess-b to initiate PID discovery.
 	tw.ch <- agent.Event{
 		Type:           agent.EventActivity,
 		SessionID:      "sess-b",
@@ -854,25 +858,25 @@ func TestSessionDetector_CWDFallback_SkipsAlreadyClaimedPID(t *testing.T) {
 	cancel()
 	<-done
 
-	// sess-a must NOT be deleted.
+	// sess-a should be deleted — replaced by sess-b (same PID, /clear).
 	stateA, _ := repo.Load("sess-a")
-	if stateA == nil {
-		t.Error("sess-a must not be deleted")
+	if stateA != nil {
+		t.Error("sess-a should be deleted (replaced by sess-b with same PID)")
 	}
 
-	// sess-b should still exist but with PID=0 (no unclaimed PID available).
+	// sess-b should have the PID.
 	stateB, _ := repo.Load("sess-b")
 	if stateB == nil {
 		t.Fatal("sess-b should exist")
 	}
-	if stateB.PID != 0 {
-		t.Errorf("sess-b PID: got %d, want 0 (all candidates were claimed)", stateB.PID)
+	if stateB.PID != myPID {
+		t.Errorf("sess-b PID: got %d, want %d", stateB.PID, myPID)
 	}
 }
 
-func TestSessionDetector_LsofPath_StillCleansUpOldSession(t *testing.T) {
-	// Verify that the /clear cleanup still works when using the authoritative
-	// path (HandlePIDAssigned, which delegates with authoritative=true).
+func TestSessionDetector_HandlePIDAssigned_CleansUpOldSession(t *testing.T) {
+	// Verify that HandlePIDAssigned cleans up old sessions with the same PID
+	// (the /clear scenario).
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()
 	repo := newMockRepo()
@@ -900,11 +904,11 @@ func TestSessionDetector_LsofPath_StillCleansUpOldSession(t *testing.T) {
 
 	det := newDetector(tw, pw, repo)
 
-	// Authoritative PID assignment (lsof path) should clean up old session.
+	// PID assignment should clean up old session.
 	det.HandlePIDAssigned(42, "new")
 
 	if state, _ := repo.Load("old"); state != nil {
-		t.Error("old session should be deleted by authoritative /clear cleanup")
+		t.Error("old session should be deleted by /clear cleanup")
 	}
 	newState, _ := repo.Load("new")
 	if newState == nil {

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -160,23 +160,21 @@ func newDetector(
 	return services.NewSessionDetector(
 		[]inbound.AgentWatcher{tw}, pw, repo,
 		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 0,
+		"test", 0, nil,
 	)
 }
 
 // newDetectorWithCWDDiscovery builds a SessionDetector with a mock CWD-based
-// PID discovery function wired up via WithCWDDiscovery.
+// PID discovery function.
 func newDetectorWithCWDDiscovery(
 	tw *mockAgentWatcher,
 	pw *mockProcessWatcher,
 	repo *mockRepo,
 	cwdFn func(string, func([]int) int) (int, error),
 ) *services.SessionDetector {
-	det := services.NewSessionDetector(
+	return services.NewSessionDetector(
 		[]inbound.AgentWatcher{tw}, pw, repo,
 		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 0,
+		"test", 0, cwdFn,
 	)
-	det.WithCWDDiscovery(cwdFn)
-	return det
 }

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -283,8 +283,8 @@ func main() {
 		watchers, pwPort,
 		cachedRepo, logger, gitResolver, metricsCollector, push,
 		Version, cfg.ReadySessionTTL,
+		processlifecycle.DiscoverPIDByCWD,
 	)
-	detector.WithCWDDiscovery(processlifecycle.DiscoverPIDByCWD)
 	{
 		detectorCtx, detectorCancel := context.WithCancel(context.Background())
 		defer detectorCancel()

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -60,7 +60,7 @@ func TestPreSession_DetectedBeforeTranscript(t *testing.T) {
 		&stubGit{},
 		&stubMetrics{},
 		nil, // no broadcaster
-		"test", 0,
+		"test", 0, nil,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -131,7 +131,7 @@ func TestPreSession_ReplacedByRealSession(t *testing.T) {
 	detector := services.NewSessionDetector(
 		[]inbound.AgentWatcher{scanner, transcriptWatcher},
 		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0,
+		"test", 0, nil,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -211,7 +211,7 @@ func TestPreSession_RemovedOnProcessExit(t *testing.T) {
 	detector := services.NewSessionDetector(
 		[]inbound.AgentWatcher{scanner},
 		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0,
+		"test", 0, nil,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
## Summary

- Replace lsof-based PID discovery (never worked) with CWD-only discovery
- Remove authoritative guard so same-PID cleanup always fires after `/clear`
- Dedup sessions sharing a PID on daemon startup
- Prevent zombie re-creation from late transcript writes after process exit
- Restrict CWD discovery to claude-code adapter (Pi/Codex have no PID lifecycle)

Closes #64

## Test plan

- [x] `go test ./... -count=1` — all pass
- [x] Manual: `/clear` in Claude Code → old session replaced by new one
- [x] Manual: 3 adapters (Claude, Codex, Pi) in same dir → no cross-contamination
- [x] Manual: Ctrl+C a session → no zombie re-creation
- [x] Manual: daemon restart → stale sessions deduped on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)