### PR TITLE
Detect Pi compaction as working activity

### DIFF
--- a/core/adapters/inbound/agents/claudecode/policy.go
+++ b/core/adapters/inbound/agents/claudecode/policy.go
@@ -1,0 +1,8 @@
+package claudecode
+
+import "irrlicht/core/domain/agent"
+
+// StatePolicy returns Claude Code-specific state behavior.
+func StatePolicy() agent.StatePolicy {
+	return agent.StatePolicy{EnableStaleToolTimer: true}
+}

--- a/core/adapters/inbound/agents/claudecode/policy_test.go
+++ b/core/adapters/inbound/agents/claudecode/policy_test.go
@@ -1,0 +1,10 @@
+package claudecode
+
+import "testing"
+
+func TestStatePolicy_EnableStaleToolTimer(t *testing.T) {
+	p := StatePolicy()
+	if !p.EnableStaleToolTimer {
+		t.Fatal("expected EnableStaleToolTimer=true for Claude Code")
+	}
+}

--- a/core/adapters/inbound/agents/codex/policy.go
+++ b/core/adapters/inbound/agents/codex/policy.go
@@ -1,0 +1,8 @@
+package codex
+
+import "irrlicht/core/domain/agent"
+
+// StatePolicy returns Codex-specific state behavior.
+func StatePolicy() agent.StatePolicy {
+	return agent.StatePolicy{EnableStaleToolTimer: true}
+}

--- a/core/adapters/inbound/agents/codex/policy_test.go
+++ b/core/adapters/inbound/agents/codex/policy_test.go
@@ -1,0 +1,10 @@
+package codex
+
+import "testing"
+
+func TestStatePolicy_EnableStaleToolTimer(t *testing.T) {
+	p := StatePolicy()
+	if !p.EnableStaleToolTimer {
+		t.Fatal("expected EnableStaleToolTimer=true for Codex")
+	}
+}

--- a/core/adapters/inbound/agents/pi/parser.go
+++ b/core/adapters/inbound/agents/pi/parser.go
@@ -47,8 +47,15 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 
 	// Non-message metadata types — skip.
 	switch eventType {
-	case "thinking_level_change", "compaction", "branch_summary", "custom":
+	case "thinking_level_change", "branch_summary", "custom":
 		ev.Skip = true
+		return ev
+	}
+
+	// Compaction is active model work and should promote ready→working.
+	// Pi emits this as a top-level event instead of a message block.
+	if eventType == "compaction" {
+		ev.EventType = "assistant"
 		return ev
 	}
 

--- a/core/adapters/inbound/agents/pi/parser_test.go
+++ b/core/adapters/inbound/agents/pi/parser_test.go
@@ -78,6 +78,24 @@ func TestParser_ThinkingLevelChange_Skip(t *testing.T) {
 	}
 }
 
+func TestParser_Compaction_IsActivityEvent(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type":      "compaction",
+		"timestamp": ts(0),
+		"summary":   "checkpoint",
+	})
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if ev.Skip {
+		t.Fatal("expected compaction not to be skipped")
+	}
+	if ev.EventType != "assistant" {
+		t.Errorf("EventType = %q, want assistant", ev.EventType)
+	}
+}
+
 func TestParser_BashExecution_Skip(t *testing.T) {
 	p := &Parser{}
 	ev := p.ParseLine(map[string]interface{}{
@@ -250,6 +268,22 @@ func TestParser_FullTranscript_EndDetection(t *testing.T) {
 	}
 	if m.OpenToolCallCount != 0 {
 		t.Errorf("OpenToolCallCount = %d, want 0", m.OpenToolCallCount)
+	}
+}
+
+func TestParser_Compaction_SetsLastEventToAssistant(t *testing.T) {
+	path := writeLines(t, []map[string]interface{}{
+		{"type": "session", "version": float64(3), "cwd": "/tmp"},
+		{"type": "compaction", "timestamp": ts(0), "summary": "checkpoint"},
+	})
+
+	tl := tailer.NewTranscriptTailer(path, &Parser{}, "pi")
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.LastEventType != "assistant" {
+		t.Errorf("LastEventType = %q, want assistant (compaction should count as activity)", m.LastEventType)
 	}
 }
 

--- a/core/adapters/inbound/agents/pi/policy.go
+++ b/core/adapters/inbound/agents/pi/policy.go
@@ -1,0 +1,12 @@
+package pi
+
+import "irrlicht/core/domain/agent"
+
+// StatePolicy returns Pi-specific state behavior.
+//
+// Pi transcripts currently don't expose a permission-pending signal,
+// and normal tool calls can run for >5s. Disable stale-tool waiting to
+// avoid false waiting transitions.
+func StatePolicy() agent.StatePolicy {
+	return agent.StatePolicy{EnableStaleToolTimer: false}
+}

--- a/core/adapters/inbound/agents/pi/policy_test.go
+++ b/core/adapters/inbound/agents/pi/policy_test.go
@@ -1,0 +1,10 @@
+package pi
+
+import "testing"
+
+func TestStatePolicy_DisableStaleToolTimer(t *testing.T) {
+	p := StatePolicy()
+	if p.EnableStaleToolTimer {
+		t.Fatal("expected EnableStaleToolTimer=false for Pi")
+	}
+}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -91,6 +91,10 @@ type SessionDetector struct {
 	// can be re-created from transcript activity (e.g. --continue). Prevents
 	// ghost sessions from late-arriving writes of a dying process.
 	deletedCooldown time.Duration
+
+	// adapterPolicies customizes adapter-specific state heuristics.
+	// Keys are adapter names (claude-code, codex, pi).
+	adapterPolicies map[string]agent.StatePolicy
 }
 
 // NewSessionDetector creates a SessionDetector with all required dependencies.
@@ -120,7 +124,8 @@ func NewSessionDetector(
 		debouncedEvents:  make(chan agent.Event, 64),
 		staleToolTimeout: defaultStaleToolTimeout,
 		staleToolTimers:  make(map[string]*time.Timer),
-		deletedCooldown: 10 * time.Second,
+		deletedCooldown:  10 * time.Second,
+		adapterPolicies:  make(map[string]agent.StatePolicy),
 	}
 	det.pidMgr = NewPIDManager(
 		pw, repo, log, broadcaster, readyTTL,
@@ -141,19 +146,70 @@ func (d *SessionDetector) SetDeletedCooldown(dur time.Duration) {
 	d.deletedCooldown = dur
 }
 
+// SetAdapterPolicies installs adapter-specific state policies.
+// Should be called during startup before Run.
+func (d *SessionDetector) SetAdapterPolicies(policies map[string]agent.StatePolicy) {
+	if len(policies) == 0 {
+		d.adapterPolicies = make(map[string]agent.StatePolicy)
+		return
+	}
+	copied := make(map[string]agent.StatePolicy, len(policies))
+	for k, v := range policies {
+		copied[k] = v
+	}
+	d.adapterPolicies = copied
+}
+
+func (d *SessionDetector) adapterPolicy(adapter string) agent.StatePolicy {
+	if p, ok := d.adapterPolicies[adapter]; ok {
+		return p
+	}
+	return agent.DefaultStatePolicy()
+}
+
+func (d *SessionDetector) staleToolTimeoutFor(adapter string) time.Duration {
+	p := d.adapterPolicy(adapter)
+	if p.StaleToolTimeout > 0 {
+		return p.StaleToolTimeout
+	}
+	return d.staleToolTimeout
+}
+
+func (d *SessionDetector) shouldStartStaleToolTimer(state *session.SessionState) bool {
+	if state == nil || state.State != session.StateWorking || state.Metrics == nil {
+		return false
+	}
+	if !d.adapterPolicy(state.Adapter).EnableStaleToolTimer {
+		return false
+	}
+	if !state.Metrics.HasOpenToolCall || state.Metrics.NeedsUserAttention() {
+		return false
+	}
+	if hasOnlyAgentTools(state.Metrics.LastOpenToolNames) {
+		return false
+	}
+	if state.Metrics.PermissionMode == "bypassPermissions" {
+		return false
+	}
+	return true
+}
+
 // startStaleToolTimer starts a timer that will transition a session to "waiting"
 // if no new transcript activity arrives within staleToolTimeout. Called when
 // processActivity leaves the session in "working" with open non-blocking tool
 // calls in a permission mode that requires user approval.
-func (d *SessionDetector) startStaleToolTimer(sessionID string, expectedUpdatedAt int64) {
+func (d *SessionDetector) startStaleToolTimer(sessionID, adapter string, expectedUpdatedAt int64) {
 	d.staleToolMu.Lock()
 	defer d.staleToolMu.Unlock()
 
 	if t, ok := d.staleToolTimers[sessionID]; ok {
 		t.Stop()
 	}
-
-	d.staleToolTimers[sessionID] = time.AfterFunc(d.staleToolTimeout, func() {
+	timeout := d.staleToolTimeoutFor(adapter)
+	if timeout <= 0 {
+		timeout = defaultStaleToolTimeout
+	}
+	d.staleToolTimers[sessionID] = time.AfterFunc(timeout, func() {
 		d.onStaleToolTimeout(sessionID, expectedUpdatedAt)
 	})
 }
@@ -184,10 +240,10 @@ func (d *SessionDetector) onStaleToolTimeout(sessionID string, expectedUpdatedAt
 	// Guard: only transition if the session is still in the exact state we
 	// expect. If UpdatedAt changed, new activity arrived and processActivity
 	// already re-evaluated.
-	if state.State != session.StateWorking || state.UpdatedAt != expectedUpdatedAt {
+	if state.UpdatedAt != expectedUpdatedAt {
 		return
 	}
-	if state.Metrics == nil || !state.Metrics.HasOpenToolCall || state.Metrics.NeedsUserAttention() {
+	if !d.shouldStartStaleToolTimer(state) {
 		return
 	}
 
@@ -560,13 +616,8 @@ func (d *SessionDetector) processActivity(ev agent.Event) {
 	// If the session is still "working" with open non-blocking tool calls
 	// in a permission mode that requires approval, start a timer to detect
 	// permission-pending state.
-	if state.State == session.StateWorking &&
-		state.Metrics != nil &&
-		state.Metrics.HasOpenToolCall &&
-		!state.Metrics.NeedsUserAttention() &&
-		!hasOnlyAgentTools(state.Metrics.LastOpenToolNames) &&
-		state.Metrics.PermissionMode != "bypassPermissions" {
-		d.startStaleToolTimer(ev.SessionID, state.UpdatedAt)
+	if d.shouldStartStaleToolTimer(state) {
+		d.startStaleToolTimer(ev.SessionID, state.Adapter, state.UpdatedAt)
 	}
 
 	// When a parent session finishes, clean up all its child sessions.
@@ -688,13 +739,8 @@ func (d *SessionDetector) seedFromDisk() {
 		// Start stale-tool timer for sessions that are working with open
 		// non-blocking tool calls — they may be permission-pending from a
 		// previous daemon run.
-		if state.State == session.StateWorking &&
-			state.Metrics != nil &&
-			state.Metrics.HasOpenToolCall &&
-			!state.Metrics.NeedsUserAttention() &&
-			!hasOnlyAgentTools(state.Metrics.LastOpenToolNames) &&
-			state.Metrics.PermissionMode != "bypassPermissions" {
-			d.startStaleToolTimer(state.SessionID, state.UpdatedAt)
+		if d.shouldStartStaleToolTimer(state) {
+			d.startStaleToolTimer(state.SessionID, state.Adapter, state.UpdatedAt)
 		}
 	}
 

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -1330,6 +1330,59 @@ func TestSessionDetector_StaleToolCall_SkipsBypassPermissions(t *testing.T) {
 	<-done
 }
 
+func TestSessionDetector_StaleToolCall_DisabledByAdapterPolicy(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetectorWithStaleTimeout(tw, pw, repo, 100*time.Millisecond)
+	det.SetAdapterPolicies(map[string]agent.StatePolicy{
+		"pi": {EnableStaleToolTimer: false},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	repo.Save(&session.SessionState{
+		SessionID:      "pi1",
+		Adapter:        "pi",
+		State:          session.StateWorking,
+		TranscriptPath: "/home/.pi/agent/sessions/--Users-test--/pi1.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     5,
+		Metrics: &session.SessionMetrics{
+			HasOpenToolCall:   true,
+			OpenToolCallCount: 1,
+			LastOpenToolNames: []string{"Bash"},
+			LastEventType:     "assistant",
+			PermissionMode:    "default",
+		},
+	})
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "pi1",
+		ProjectDir:     "--Users-test--",
+		TranscriptPath: "/home/.pi/agent/sessions/--Users-test--/pi1.jsonl",
+	}
+
+	// Wait past timeout: adapter policy disables the stale timer.
+	time.Sleep(250 * time.Millisecond)
+
+	state, _ := repo.Load("pi1")
+	if state.State != session.StateWorking {
+		t.Errorf("state: got %q, want working (pi policy disables stale timer)", state.State)
+	}
+
+	cancel()
+	<-done
+}
+
 func TestSessionDetector_StaleToolCall_GuardChecksState(t *testing.T) {
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -32,6 +32,7 @@ import (
 	"irrlicht/core/adapters/outbound/metrics"
 	wshub "irrlicht/core/adapters/outbound/websocket"
 	"irrlicht/core/application/services"
+	domainagent "irrlicht/core/domain/agent"
 	"irrlicht/core/domain/config"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/inbound"
@@ -293,6 +294,11 @@ func main() {
 		Version, cfg.ReadySessionTTL,
 		pidDiscovers,
 	)
+	detector.SetAdapterPolicies(map[string]domainagent.StatePolicy{
+		claudecode.AdapterName: claudecode.StatePolicy(),
+		codex.AdapterName:      codex.StatePolicy(),
+		pi.AdapterName:         pi.StatePolicy(),
+	})
 	{
 		detectorCtx, detectorCancel := context.WithCancel(context.Background())
 		defer detectorCancel()

--- a/core/domain/agent/state_policy.go
+++ b/core/domain/agent/state_policy.go
@@ -1,0 +1,23 @@
+package agent
+
+import "time"
+
+// StatePolicy controls adapter-specific session state behavior.
+//
+// SessionDetector owns the shared state machine, while each adapter can
+// provide policy overrides for heuristics that differ by transcript format.
+// Today this is used for stale-tool-call waiting detection.
+type StatePolicy struct {
+	// EnableStaleToolTimer enables the stale open-tool heuristic that
+	// transitions working → waiting after a timeout with no activity.
+	EnableStaleToolTimer bool
+
+	// StaleToolTimeout overrides the detector default timeout when > 0.
+	StaleToolTimeout time.Duration
+}
+
+// DefaultStatePolicy returns the fallback behavior when an adapter doesn't
+// provide an explicit policy.
+func DefaultStatePolicy() StatePolicy {
+	return StatePolicy{EnableStaleToolTimer: true}
+}

--- a/core/pkg/capacity/model-capacity.json
+++ b/core/pkg/capacity/model-capacity.json
@@ -1,6 +1,6 @@
 {
   "version": "2.1.0",
-  "last_updated": "2026-04-03",
+  "last_updated": "2026-04-06",
   "models": {
     "claude-3.5-sonnet": {
       "context_window": 200000,
@@ -196,6 +196,20 @@
         "cache_creation_per_mtok": 3.75
       }
     },
+    "gpt-5.3-codex": {
+      "context_window": 256000,
+      "max_output": 32768,
+      "char_to_token_ratio": 3.5,
+      "family": "gpt-5",
+      "display_name": "GPT-5.3 Codex",
+      "notes": "OpenAI Codex model with 256K context window",
+      "pricing": {
+        "input_per_mtok": 2.0,
+        "output_per_mtok": 8.0,
+        "cache_read_per_mtok": 0,
+        "cache_creation_per_mtok": 0
+      }
+    },
     "gpt-5.4": {
       "context_window": 258400,
       "max_output": 32768,
@@ -254,6 +268,17 @@
         "output_per_mtok": 15.0,
         "cache_read_per_mtok": 0.30,
         "cache_creation_per_mtok": 3.75
+      }
+    },
+    "gpt-5": {
+      "context_window": 256000,
+      "max_output": 32768,
+      "char_to_token_ratio": 3.5,
+      "pricing": {
+        "input_per_mtok": 2.0,
+        "output_per_mtok": 8.0,
+        "cache_read_per_mtok": 0,
+        "cache_creation_per_mtok": 0
       }
     }
   },

--- a/core/pkg/tailer/context_utilization_test.go
+++ b/core/pkg/tailer/context_utilization_test.go
@@ -94,6 +94,67 @@ func TestContextUtilization_UnknownModel_Fallback200K(t *testing.T) {
 	assertPressure(t, m, "safe", 50.0)
 }
 
+func TestContextUtilization_Codex53_Uses256KContextWindow(t *testing.T) {
+	// gpt-5.3-codex should use 256K context window.
+	// 35,650 / 256,000 = 13.93% → "safe"
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{
+			"type":      "assistant",
+			"timestamp": ts(0),
+			"message": map[string]interface{}{
+				"model": "gpt-5.3-codex",
+				"usage": map[string]interface{}{
+					"input":      float64(1093),
+					"output":     float64(509),
+					"cacheRead":  float64(34048),
+					"cacheWrite": float64(0),
+					"totalTokens": float64(35650),
+				},
+			},
+		},
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m.ContextWindow != 256000 {
+		t.Fatalf("ContextWindow = %d, want 256000", m.ContextWindow)
+	}
+	assertPressure(t, m, "safe", 13.93)
+}
+
+func TestContextUtilization_GPT5FamilyDefault_Uses256KContextWindow(t *testing.T) {
+	// Unknown gpt-5 variant should resolve through family_defaults.gpt-5.
+	// 102,400 / 256,000 = 40% → "safe"
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{
+			"type":      "assistant",
+			"timestamp": ts(0),
+			"message": map[string]interface{}{
+				"model": "gpt-5.9-codex-preview",
+				"usage": map[string]interface{}{
+					"input_tokens":  float64(102400),
+					"output_tokens": float64(0),
+				},
+			},
+		},
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m.ContextWindow != 256000 {
+		t.Fatalf("ContextWindow = %d, want 256000", m.ContextWindow)
+	}
+	assertPressure(t, m, "safe", 40.0)
+}
+
 func TestContextUtilization_ExtendedContext1M(t *testing.T) {
 	// Model with [1m] suffix → 1M window
 	// 180K tokens / 1M = 18% → "safe"

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -22,21 +22,21 @@ type MessageEvent struct {
 
 // SessionMetrics holds computed performance metrics
 type SessionMetrics struct {
-	MessagesPerMinute float64        `json:"messages_per_minute"`
-	ElapsedSeconds    int64          `json:"elapsed_seconds"`
-	LastMessageAt     time.Time      `json:"last_message_at"`
-	MessageHistory    []MessageEvent `json:"-"` // Sliding window, not serialized
-	SessionStartAt    time.Time      `json:"session_start_at"`
-	TotalTokens       int64          `json:"total_tokens,omitempty"`
-	InputTokens       int64          `json:"input_tokens,omitempty"`
-	OutputTokens      int64          `json:"output_tokens,omitempty"`
-	CacheReadTokens   int64          `json:"cache_read_tokens,omitempty"`
-	CacheCreationTokens int64        `json:"cache_creation_tokens,omitempty"`
-	EstimatedCostUSD  float64        `json:"estimated_cost_usd,omitempty"`
-	ModelName         string         `json:"model_name,omitempty"`
-	ContextWindow     int64          `json:"context_window,omitempty"`
-	ContextUtilization float64       `json:"context_utilization_percentage,omitempty"`
-	PressureLevel     string         `json:"pressure_level,omitempty"` // "safe", "caution", "warning", "critical"
+	MessagesPerMinute   float64        `json:"messages_per_minute"`
+	ElapsedSeconds      int64          `json:"elapsed_seconds"`
+	LastMessageAt       time.Time      `json:"last_message_at"`
+	MessageHistory      []MessageEvent `json:"-"` // Sliding window, not serialized
+	SessionStartAt      time.Time      `json:"session_start_at"`
+	TotalTokens         int64          `json:"total_tokens,omitempty"`
+	InputTokens         int64          `json:"input_tokens,omitempty"`
+	OutputTokens        int64          `json:"output_tokens,omitempty"`
+	CacheReadTokens     int64          `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens int64          `json:"cache_creation_tokens,omitempty"`
+	EstimatedCostUSD    float64        `json:"estimated_cost_usd,omitempty"`
+	ModelName           string         `json:"model_name,omitempty"`
+	ContextWindow       int64          `json:"context_window,omitempty"`
+	ContextUtilization  float64        `json:"context_utilization_percentage,omitempty"`
+	PressureLevel       string         `json:"pressure_level,omitempty"` // "safe", "caution", "warning", "critical"
 
 	// Raw event data for real-time client-side calculations
 	TotalEventCount        int64     `json:"total_event_count,omitempty"`
@@ -161,11 +161,16 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 
 	const maxTailSize = 64 * 1024
 	startPos := int64(0)
-	if fileSize > maxTailSize {
-		startPos = fileSize - maxTailSize
-	}
-	if t.lastOffset > startPos {
+	switch {
+	case fileSize < t.lastOffset:
+		// File rotated/truncated.
+		startPos = 0
+	case t.lastOffset > 0:
+		// Normal incremental path: never skip ahead of the last processed byte.
 		startPos = t.lastOffset
+	case fileSize > maxTailSize:
+		// Initial read for large files: only tail the latest window.
+		startPos = fileSize - maxTailSize
 	}
 
 	_, err = file.Seek(startPos, io.SeekStart)
@@ -173,8 +178,29 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 		return nil, fmt.Errorf("failed to seek transcript: %w", err)
 	}
 
-	scanner := bufio.NewScanner(file)
 	currentOffset := startPos
+	var reader io.Reader = file
+
+	// On the initial truncated read of a large file, we may start in the
+	// middle of a JSON line. If so, discard the partial line to align scanner
+	// to a full JSONL entry boundary.
+	if t.lastOffset == 0 && startPos > 0 {
+		prev := []byte{0}
+		if _, err := file.ReadAt(prev, startPos-1); err == nil && prev[0] != '\n' {
+			br := bufio.NewReader(file)
+			if discarded, err := br.ReadString('\n'); err == nil {
+				currentOffset += int64(len(discarded))
+			} else {
+				return nil, fmt.Errorf("failed to align transcript boundary: %w", err)
+			}
+			reader = br
+		}
+	}
+
+	scanner := bufio.NewScanner(reader)
+	// Large tool results (especially from Pi/Codex read/bash output) can exceed
+	// bufio.Scanner's 64KB default token size.
+	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/core/pkg/tailer/tool_call_test.go
+++ b/core/pkg/tailer/tool_call_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -161,6 +162,18 @@ func writeTranscriptLines(t *testing.T, lines []map[string]interface{}) string {
 	return path
 }
 
+func appendTranscriptLine(t *testing.T, path string, line map[string]interface{}) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(line); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func ts(offset int) string {
 	return time.Now().Add(time.Duration(offset) * time.Second).Format(time.RFC3339)
 }
@@ -222,6 +235,38 @@ func TestHasOpenToolCall_OneOpenToolCall(t *testing.T) {
 	}
 	if m.OpenToolCallCount != 1 {
 		t.Errorf("expected OpenToolCallCount=1, got %d", m.OpenToolCallCount)
+	}
+}
+
+func TestTailAndProcess_LargeAppendedToolResult_NotSkipped(t *testing.T) {
+	// Regression: if >64KB is appended between polls, we must continue from
+	// lastOffset and parse the full new JSON line instead of skipping into it.
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "user", "timestamp": ts(0)},
+		{"type": "tool_use", "timestamp": ts(1), "name": "Read"},
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.HasOpenToolCall || m.OpenToolCallCount != 1 {
+		t.Fatalf("setup failed: expected one open call, got open=%v count=%d", m.HasOpenToolCall, m.OpenToolCallCount)
+	}
+
+	appendTranscriptLine(t, path, map[string]interface{}{
+		"type":      "tool_result",
+		"timestamp": ts(2),
+		"output":    strings.Repeat("x", 120*1024),
+	})
+
+	m, err = tailer.TailAndProcess()
+	if err != nil {
+		t.Fatalf("unexpected tail error on large appended line: %v", err)
+	}
+	if m.HasOpenToolCall || m.OpenToolCallCount != 0 {
+		t.Fatalf("expected large tool_result to close call, got open=%v count=%d", m.HasOpenToolCall, m.OpenToolCallCount)
 	}
 }
 


### PR DESCRIPTION
## Summary
- treat Pi `type: "compaction"` transcript entries as activity events instead of skipping them
- map compaction to `assistant` activity so ready sessions transition to `working`
- pull stale-tool waiting behavior behind adapter policies
  - add `agent.StatePolicy`
  - add `StatePolicy()` in Claude Code, Codex, and Pi adapters
  - wire policies into `SessionDetector` via `SetAdapterPolicies(...)`
  - disable stale-tool timeout waiting for Pi to avoid false `waiting` while long-running tools are still processing
- fix tailer ingestion for large JSONL appends (>64KB)
  - continue from `lastOffset` once established (no jumping into mid-line)
  - increase scanner token buffer to handle large tool results
  - align initial truncated reads to newline boundary
- add regression test: large appended tool_result line is parsed and closes open calls

## Verification
- `cd core && go test ./pkg/tailer -count=1`
- `cd core && go test ./... -count=1`
