### PR TITLE
Support newer wrapped Codex transcript schema

### DIFF
--- a/core/adapters/inbound/agents/codex/parser.go
+++ b/core/adapters/inbound/agents/codex/parser.go
@@ -1,10 +1,8 @@
 package codex
 
 import (
-	"encoding/json"
-	"strings"
-
 	"irrlicht/core/pkg/tailer"
+	"irrlicht/core/pkg/transcript"
 )
 
 // Parser implements tailer.TranscriptParser for OpenAI Codex transcripts.
@@ -41,8 +39,7 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 		return ev
 	}
 
-	// CWD extraction from <cwd> XML tags and function_call workdir.
-	ev.CWD = extractCodexCWD(raw)
+	ev.CWD = transcript.ExtractCWDFromLine(raw)
 
 	// Model/token extraction from payload-wrapped events.
 	ev.ModelName, ev.ContextWindow, ev.Tokens = extractCodexMetadata(raw)
@@ -53,33 +50,14 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 	// Map event types to normalized forms.
 	switch eventType {
 	case "message":
-		role, _ := raw["role"].(string)
-		switch role {
-		case "assistant":
-			ev.EventType = "assistant_message"
-			ev.AssistantText = tailer.ExtractAssistantText(raw)
-		case "user", "developer":
-			ev.EventType = "user_message"
-			ev.ClearToolNames = true
-		default:
+		if !parseCodexMessage(raw, ev) {
 			ev.Skip = true
 			return ev
 		}
 
 	case "response_item":
 		if payload, ok := raw["payload"].(map[string]interface{}); ok {
-			if role, ok := payload["role"].(string); ok {
-				switch role {
-				case "assistant":
-					ev.EventType = "assistant_message"
-				case "user", "developer":
-					ev.EventType = "user_message"
-					ev.ClearToolNames = true
-				default:
-					ev.Skip = true
-					return ev
-				}
-			} else {
+			if !parseCodexResponseItem(payload, ev) {
 				ev.Skip = true
 				return ev
 			}
@@ -89,17 +67,15 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 		}
 
 	case "function_call":
-		ev.EventType = "function_call"
-		if name, ok := raw["name"].(string); ok {
-			ev.ToolUseNames = []string{name}
+		if !parseCodexFunctionCall(raw, ev) {
+			ev.Skip = true
+			return ev
 		}
 
 	case "function_call_output":
-		ev.EventType = "function_call_output"
-		ev.ToolResultCount = 1
+		parseCodexFunctionCallOutput(ev)
 
 	case "session_meta", "event_msg", "turn_context":
-		// Metadata events — extract model/token info (already done above) and skip.
 		ev.Skip = true
 		return ev
 
@@ -111,36 +87,54 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 	return ev
 }
 
-// extractCodexCWD extracts the working directory from a Codex event.
-// Checks <cwd> XML tags in content blocks and workdir in function_call arguments.
-func extractCodexCWD(raw map[string]interface{}) string {
-	// <cwd> XML tag in content blocks.
-	if content, ok := raw["content"].([]interface{}); ok {
-		for _, item := range content {
-			if block, ok := item.(map[string]interface{}); ok {
-				if text, ok := block["text"].(string); ok {
-					if idx := strings.Index(text, "<cwd>"); idx >= 0 {
-						end := strings.Index(text[idx:], "</cwd>")
-						if end > 5 {
-							return strings.TrimSpace(text[idx+5 : idx+end])
-						}
-					}
-				}
-			}
-		}
+func parseCodexMessage(raw map[string]interface{}, ev *tailer.ParsedEvent) bool {
+	role, _ := raw["role"].(string)
+	switch role {
+	case "assistant":
+		ev.EventType = "assistant_message"
+		ev.AssistantText = tailer.ExtractAssistantText(raw)
+	case "user", "developer":
+		ev.EventType = "user_message"
+		ev.ClearToolNames = true
+	default:
+		return false
 	}
-	// workdir in function_call arguments.
-	if raw["type"] == "function_call" {
-		if args, ok := raw["arguments"].(string); ok {
-			var parsed map[string]interface{}
-			if json.Unmarshal([]byte(args), &parsed) == nil {
-				if wd, ok := parsed["workdir"].(string); ok && wd != "" {
-					return wd
-				}
-			}
-		}
+	return true
+}
+
+func parseCodexResponseItem(payload map[string]interface{}, ev *tailer.ParsedEvent) bool {
+	payloadType, _ := payload["type"].(string)
+	switch payloadType {
+	case "message":
+		return parseCodexMessage(payload, ev)
+	case "function_call", "custom_tool_call":
+		return parseCodexFunctionCall(payload, ev)
+	case "function_call_output", "custom_tool_call_output":
+		parseCodexFunctionCallOutput(ev)
+		return true
+	case "web_search_call":
+		ev.EventType = "function_call_output"
+		ev.ToolUseNames = []string{"web_search"}
+		ev.ToolResultCount = 1
+		return true
+	default:
+		return false
 	}
-	return ""
+}
+
+func parseCodexFunctionCall(raw map[string]interface{}, ev *tailer.ParsedEvent) bool {
+	name, _ := raw["name"].(string)
+	if name == "" {
+		return false
+	}
+	ev.EventType = "function_call"
+	ev.ToolUseNames = []string{name}
+	return true
+}
+
+func parseCodexFunctionCallOutput(ev *tailer.ParsedEvent) {
+	ev.EventType = "function_call_output"
+	ev.ToolResultCount = 1
 }
 
 // extractCodexMetadata extracts model, context window, and token info from Codex events.

--- a/core/adapters/inbound/agents/codex/parser.go
+++ b/core/adapters/inbound/agents/codex/parser.go
@@ -45,7 +45,7 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 	ev.ModelName, ev.ContextWindow, ev.Tokens = extractCodexMetadata(raw)
 
 	// Content character count.
-	ev.ContentChars = tailer.ExtractContentChars(raw)
+	ev.ContentChars = extractCodexContentChars(raw)
 
 	// Map event types to normalized forms.
 	switch eventType {
@@ -124,17 +124,27 @@ func parseCodexResponseItem(payload map[string]interface{}, ev *tailer.ParsedEve
 
 func parseCodexFunctionCall(raw map[string]interface{}, ev *tailer.ParsedEvent) bool {
 	name, _ := raw["name"].(string)
-	if name == "" {
-		return false
-	}
 	ev.EventType = "function_call"
-	ev.ToolUseNames = []string{name}
+	if name != "" {
+		ev.ToolUseNames = []string{name}
+	}
 	return true
 }
 
 func parseCodexFunctionCallOutput(ev *tailer.ParsedEvent) {
 	ev.EventType = "function_call_output"
 	ev.ToolResultCount = 1
+}
+
+func extractCodexContentChars(raw map[string]interface{}) int64 {
+	if payload, ok := raw["payload"].(map[string]interface{}); ok {
+		return extractCodexContentChars(payload)
+	}
+	chars := tailer.ExtractContentChars(raw)
+	if message, ok := raw["message"].(string); ok {
+		chars += int64(len(message))
+	}
+	return chars
 }
 
 // extractCodexMetadata extracts model, context window, and token info from Codex events.

--- a/core/adapters/inbound/agents/codex/parser_test.go
+++ b/core/adapters/inbound/agents/codex/parser_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"irrlicht/core/application/services"
-	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 )
 
@@ -123,6 +121,24 @@ func TestParser_FunctionCall(t *testing.T) {
 	}
 	if len(ev.ToolUseNames) != 1 || ev.ToolUseNames[0] != "shell" {
 		t.Errorf("ToolUseNames = %v, want [shell]", ev.ToolUseNames)
+	}
+}
+
+func TestParser_FunctionCall_WithoutNameStillCountsAsActivity(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type":      "function_call",
+		"arguments": `{"command":["zsh","-lc","ls"]}`,
+		"timestamp": ts(2),
+	})
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if ev.EventType != "function_call" {
+		t.Errorf("EventType = %q, want function_call", ev.EventType)
+	}
+	if len(ev.ToolUseNames) != 0 {
+		t.Errorf("ToolUseNames = %v, want empty", ev.ToolUseNames)
 	}
 }
 
@@ -421,13 +437,4 @@ func TestParser_FullWrappedTranscript_MetadataAndWaitingState(t *testing.T) {
 		t.Error("expected HasOpenToolCall=false after wrapped tool calls resolved")
 	}
 
-	state, _ := services.ClassifyState(session.StateWorking, &session.SessionMetrics{
-		HasOpenToolCall:   m.HasOpenToolCall,
-		LastEventType:     m.LastEventType,
-		LastAssistantText: m.LastAssistantText,
-		LastOpenToolNames: m.LastOpenToolNames,
-	})
-	if state != session.StateWaiting {
-		t.Errorf("state = %q, want waiting", state)
-	}
 }

--- a/core/adapters/inbound/agents/codex/parser_test.go
+++ b/core/adapters/inbound/agents/codex/parser_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 )
 
@@ -211,5 +213,221 @@ func TestParser_CWDExtraction(t *testing.T) {
 	})
 	if ev.CWD != "/Users/test/project" {
 		t.Errorf("CWD = %q, want /Users/test/project", ev.CWD)
+	}
+}
+
+func TestParser_WrappedAssistantMessage(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type":      "response_item",
+		"timestamp": ts(0),
+		"payload": map[string]interface{}{
+			"type": "message",
+			"role": "assistant",
+			"content": []interface{}{
+				map[string]interface{}{"type": "output_text", "text": "Should I run the tests?"},
+			},
+		},
+	})
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if ev.EventType != "assistant_message" {
+		t.Errorf("EventType = %q, want assistant_message", ev.EventType)
+	}
+	if ev.AssistantText != "Should I run the tests?" {
+		t.Errorf("AssistantText = %q, want wrapped assistant text", ev.AssistantText)
+	}
+}
+
+func TestParser_WrappedCustomAndWebSearchTools(t *testing.T) {
+	p := &Parser{}
+
+	custom := p.ParseLine(map[string]interface{}{
+		"type":      "response_item",
+		"timestamp": ts(0),
+		"payload": map[string]interface{}{
+			"type":    "custom_tool_call",
+			"name":    "apply_patch",
+			"call_id": "call_patch",
+			"status":  "completed",
+		},
+	})
+	if custom == nil {
+		t.Fatal("expected non-nil custom tool event")
+	}
+	if custom.EventType != "function_call" {
+		t.Errorf("custom EventType = %q, want function_call", custom.EventType)
+	}
+	if len(custom.ToolUseNames) != 1 || custom.ToolUseNames[0] != "apply_patch" {
+		t.Errorf("custom ToolUseNames = %v, want [apply_patch]", custom.ToolUseNames)
+	}
+
+	web := p.ParseLine(map[string]interface{}{
+		"type":      "response_item",
+		"timestamp": ts(1),
+		"payload": map[string]interface{}{
+			"type":   "web_search_call",
+			"status": "completed",
+			"action": map[string]interface{}{"type": "search", "query": "irrlicht issue 90"},
+		},
+	})
+	if web == nil {
+		t.Fatal("expected non-nil web search event")
+	}
+	if web.EventType != "function_call_output" {
+		t.Errorf("web EventType = %q, want function_call_output", web.EventType)
+	}
+	if len(web.ToolUseNames) != 1 || web.ToolUseNames[0] != "web_search" {
+		t.Errorf("web ToolUseNames = %v, want [web_search]", web.ToolUseNames)
+	}
+	if web.ToolResultCount != 1 {
+		t.Errorf("web ToolResultCount = %d, want 1", web.ToolResultCount)
+	}
+}
+
+func TestParser_FullWrappedTranscript_MetadataAndWaitingState(t *testing.T) {
+	path := writeLines(t, []map[string]interface{}{
+		{
+			"timestamp": ts(0),
+			"type":      "session_meta",
+			"payload": map[string]interface{}{
+				"id":         "sess_wrapped",
+				"cwd":        "/Users/test/project",
+				"source":     "vscode",
+				"originator": "codex_vscode",
+			},
+		},
+		{
+			"timestamp": ts(1),
+			"type":      "turn_context",
+			"payload": map[string]interface{}{
+				"cwd":             "/Users/test/project",
+				"model":           "gpt-5.2-codex",
+				"approval_policy": "never",
+				"sandbox_policy":  "danger-full-access",
+			},
+		},
+		{
+			"timestamp": ts(2),
+			"type":      "event_msg",
+			"payload": map[string]interface{}{
+				"type": "token_count",
+				"info": map[string]interface{}{
+					"total_token_usage": map[string]interface{}{
+						"input_tokens":  12,
+						"output_tokens": 3,
+						"total_tokens":  15,
+					},
+					"model_context_window": 258400,
+				},
+			},
+		},
+		{
+			"timestamp": ts(3),
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "input_text", "text": "Please inspect the repo."},
+				},
+			},
+		},
+		{
+			"timestamp": ts(4),
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type":      "function_call",
+				"name":      "shell_command",
+				"call_id":   "call_shell",
+				"arguments": `{"command":["pwd"],"workdir":"/Users/test/project"}`,
+			},
+		},
+		{
+			"timestamp": ts(5),
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type":    "function_call_output",
+				"call_id": "call_shell",
+				"output":  "/Users/test/project\n",
+			},
+		},
+		{
+			"timestamp": ts(6),
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type":    "custom_tool_call",
+				"name":    "apply_patch",
+				"call_id": "call_patch",
+				"status":  "completed",
+			},
+		},
+		{
+			"timestamp": ts(7),
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type":    "custom_tool_call_output",
+				"call_id": "call_patch",
+				"output":  "Success. Updated the following files:\nM foo.go",
+			},
+		},
+		{
+			"timestamp": ts(8),
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type":   "web_search_call",
+				"status": "completed",
+				"action": map[string]interface{}{"type": "search", "query": "irrlicht wrapped codex schema"},
+			},
+		},
+		{
+			"timestamp": ts(9),
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type": "message",
+				"role": "assistant",
+				"content": []interface{}{
+					map[string]interface{}{"type": "output_text", "text": "Should I run the tests?"},
+				},
+			},
+		},
+	})
+
+	tl := tailer.NewTranscriptTailer(path, &Parser{}, "codex")
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.LastCWD != "/Users/test/project" {
+		t.Errorf("LastCWD = %q, want /Users/test/project", m.LastCWD)
+	}
+	if m.ModelName != "gpt-5.2-codex" {
+		t.Errorf("ModelName = %q, want gpt-5.2-codex", m.ModelName)
+	}
+	if m.ContextWindow != 258400 {
+		t.Errorf("ContextWindow = %d, want 258400", m.ContextWindow)
+	}
+	if m.TotalTokens != 15 {
+		t.Errorf("TotalTokens = %d, want 15", m.TotalTokens)
+	}
+	if m.LastEventType != "assistant_message" {
+		t.Errorf("LastEventType = %q, want assistant_message", m.LastEventType)
+	}
+	if m.LastAssistantText != "Should I run the tests?" {
+		t.Errorf("LastAssistantText = %q, want wrapped assistant text", m.LastAssistantText)
+	}
+	if m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=false after wrapped tool calls resolved")
+	}
+
+	state, _ := services.ClassifyState(session.StateWorking, &session.SessionMetrics{
+		HasOpenToolCall:   m.HasOpenToolCall,
+		LastEventType:     m.LastEventType,
+		LastAssistantText: m.LastAssistantText,
+		LastOpenToolNames: m.LastOpenToolNames,
+	})
+	if state != session.StateWaiting {
+		t.Errorf("state = %q, want waiting", state)
 	}
 }

--- a/core/adapters/outbound/git/adapter_test.go
+++ b/core/adapters/outbound/git/adapter_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -93,5 +94,49 @@ func TestGetProjectName_DeletedWorktree(t *testing.T) {
 	got := a.GetProjectName(deleted)
 	if got != "myproject" {
 		t.Errorf("got %q, want %q", got, "myproject")
+	}
+}
+
+func TestGetCWDFromTranscript_WrappedCodex(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "wrapped-codex.jsonl")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create transcript: %v", err)
+	}
+	defer f.Close()
+
+	enc := json.NewEncoder(f)
+	lines := []map[string]interface{}{
+		{
+			"type": "session_meta",
+			"payload": map[string]interface{}{
+				"cwd": "/Users/test/original",
+			},
+		},
+		{
+			"type": "turn_context",
+			"payload": map[string]interface{}{
+				"cwd": "/Users/test/worktree",
+			},
+		},
+		{
+			"type": "response_item",
+			"payload": map[string]interface{}{
+				"type":      "function_call",
+				"name":      "shell_command",
+				"arguments": `{"command":["pwd"],"workdir":"/Users/test/override"}`,
+			},
+		},
+	}
+	for _, line := range lines {
+		if err := enc.Encode(line); err != nil {
+			t.Fatalf("encode transcript line: %v", err)
+		}
+	}
+
+	a := New()
+	got := a.GetCWDFromTranscript(path)
+	if got != "/Users/test/override" {
+		t.Errorf("got %q, want %q", got, "/Users/test/override")
 	}
 }

--- a/core/application/services/state_classifier_test.go
+++ b/core/application/services/state_classifier_test.go
@@ -16,15 +16,15 @@ func TestClassifyState(t *testing.T) {
 	}{
 		// Nil metrics — no transition.
 		{
-			name:    "nil metrics, working stays working",
-			current: session.StateWorking,
-			metrics: nil,
+			name:      "nil metrics, working stays working",
+			current:   session.StateWorking,
+			metrics:   nil,
 			wantState: session.StateWorking,
 		},
 		{
-			name:    "nil metrics, ready stays ready",
-			current: session.StateReady,
-			metrics: nil,
+			name:      "nil metrics, ready stays ready",
+			current:   session.StateReady,
+			metrics:   nil,
 			wantState: session.StateReady,
 		},
 
@@ -145,6 +145,17 @@ func TestClassifyState(t *testing.T) {
 			wantReason: true,
 		},
 		{
+			name:    "working → waiting (assistant_message Codex fallback + question)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				LastEventType:     "assistant_message",
+				HasOpenToolCall:   false,
+				LastAssistantText: "Should I run the tests?",
+			},
+			wantState:  session.StateWaiting,
+			wantReason: true,
+		},
+		{
 			name:    "working → ready (assistant with stop_reason)",
 			current: session.StateWorking,
 			metrics: &session.SessionMetrics{
@@ -213,8 +224,8 @@ func TestClassifyState(t *testing.T) {
 			name:    "working stays working (no transition needed)",
 			current: session.StateWorking,
 			metrics: &session.SessionMetrics{
-				LastEventType:   "assistant",
-				HasOpenToolCall: true,
+				LastEventType:     "assistant",
+				HasOpenToolCall:   true,
 				LastOpenToolNames: []string{"Bash"},
 			},
 			wantState: session.StateWorking,

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -127,6 +127,12 @@ func ExtractAssistantText(raw map[string]interface{}) string {
 	if arr, ok := raw["content"].([]interface{}); ok {
 		collectText(arr)
 	}
+	// Wrapped Codex: payload.content[]
+	if payload, ok := raw["payload"].(map[string]interface{}); ok {
+		if arr, ok := payload["content"].([]interface{}); ok {
+			collectText(arr)
+		}
+	}
 
 	var text string
 	switch len(parts) {
@@ -149,8 +155,7 @@ func ExtractAssistantText(raw map[string]interface{}) string {
 // a transcript event, checking common content locations across formats.
 func ExtractContentChars(raw map[string]interface{}) int64 {
 	var chars int64
-	// Top-level content array (Codex newer format)
-	if arr, ok := raw["content"].([]interface{}); ok {
+	addContentChars := func(arr []interface{}) {
 		for _, item := range arr {
 			if block, ok := item.(map[string]interface{}); ok {
 				if text, ok := block["text"].(string); ok {
@@ -159,16 +164,29 @@ func ExtractContentChars(raw map[string]interface{}) int64 {
 			}
 		}
 	}
+	// Top-level content array (Codex newer format)
+	if arr, ok := raw["content"].([]interface{}); ok {
+		addContentChars(arr)
+	}
 	// Nested message.content array (Claude Code format)
 	if msg, ok := raw["message"].(map[string]interface{}); ok {
 		if arr, ok := msg["content"].([]interface{}); ok {
-			for _, item := range arr {
-				if block, ok := item.(map[string]interface{}); ok {
-					if text, ok := block["text"].(string); ok {
-						chars += int64(len(text))
-					}
-				}
-			}
+			addContentChars(arr)
+		}
+	}
+	// Wrapped Codex payload content.
+	if payload, ok := raw["payload"].(map[string]interface{}); ok {
+		if arr, ok := payload["content"].([]interface{}); ok {
+			addContentChars(arr)
+		}
+		if args, ok := payload["arguments"].(string); ok {
+			chars += int64(len(args))
+		}
+		if output, ok := payload["output"].(string); ok {
+			chars += int64(len(output))
+		}
+		if message, ok := payload["message"].(string); ok {
+			chars += int64(len(message))
 		}
 	}
 	// Codex function_call arguments

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -127,12 +127,6 @@ func ExtractAssistantText(raw map[string]interface{}) string {
 	if arr, ok := raw["content"].([]interface{}); ok {
 		collectText(arr)
 	}
-	// Wrapped Codex: payload.content[]
-	if payload, ok := raw["payload"].(map[string]interface{}); ok {
-		if arr, ok := payload["content"].([]interface{}); ok {
-			collectText(arr)
-		}
-	}
 
 	var text string
 	switch len(parts) {
@@ -172,21 +166,6 @@ func ExtractContentChars(raw map[string]interface{}) int64 {
 	if msg, ok := raw["message"].(map[string]interface{}); ok {
 		if arr, ok := msg["content"].([]interface{}); ok {
 			addContentChars(arr)
-		}
-	}
-	// Wrapped Codex payload content.
-	if payload, ok := raw["payload"].(map[string]interface{}); ok {
-		if arr, ok := payload["content"].([]interface{}); ok {
-			addContentChars(arr)
-		}
-		if args, ok := payload["arguments"].(string); ok {
-			chars += int64(len(args))
-		}
-		if output, ok := payload["output"].(string); ok {
-			chars += int64(len(output))
-		}
-		if message, ok := payload["message"].(string); ok {
-			chars += int64(len(message))
 		}
 	}
 	// Codex function_call arguments

--- a/core/pkg/transcript/cwd.go
+++ b/core/pkg/transcript/cwd.go
@@ -50,6 +50,10 @@ func ExtractCWDFromLine(raw map[string]interface{}) string {
 }
 
 func extractCWDFromArguments(raw map[string]interface{}) string {
+	typeName, _ := raw["type"].(string)
+	if typeName != "function_call" && typeName != "custom_tool_call" {
+		return ""
+	}
 	if args, ok := raw["arguments"].(string); ok {
 		var parsed map[string]interface{}
 		if json.Unmarshal([]byte(args), &parsed) == nil {

--- a/core/pkg/transcript/cwd.go
+++ b/core/pkg/transcript/cwd.go
@@ -22,18 +22,39 @@ func ExtractCWDFromLine(raw map[string]interface{}) string {
 	if cwd, ok := raw["cwd"].(string); ok && cwd != "" {
 		return cwd
 	}
+	// Wrapped Codex metadata: payload.cwd.
+	if payload, ok := raw["payload"].(map[string]interface{}); ok {
+		if cwd, ok := payload["cwd"].(string); ok && cwd != "" {
+			return cwd
+		}
+	}
 	// Codex: <cwd> XML tag inside environment_context content blocks.
 	if cwd := extractCWDFromContentBlocks(raw); cwd != "" {
 		return cwd
 	}
+	if payload, ok := raw["payload"].(map[string]interface{}); ok {
+		if cwd := extractCWDFromContentBlocks(payload); cwd != "" {
+			return cwd
+		}
+	}
 	// Codex: workdir inside function_call arguments.
-	if raw["type"] == "function_call" {
-		if args, ok := raw["arguments"].(string); ok {
-			var parsed map[string]interface{}
-			if json.Unmarshal([]byte(args), &parsed) == nil {
-				if wd, ok := parsed["workdir"].(string); ok && wd != "" {
-					return wd
-				}
+	if cwd := extractCWDFromArguments(raw); cwd != "" {
+		return cwd
+	}
+	if payload, ok := raw["payload"].(map[string]interface{}); ok {
+		if cwd := extractCWDFromArguments(payload); cwd != "" {
+			return cwd
+		}
+	}
+	return ""
+}
+
+func extractCWDFromArguments(raw map[string]interface{}) string {
+	if args, ok := raw["arguments"].(string); ok {
+		var parsed map[string]interface{}
+		if json.Unmarshal([]byte(args), &parsed) == nil {
+			if wd, ok := parsed["workdir"].(string); ok && wd != "" {
+				return wd
 			}
 		}
 	}

--- a/core/pkg/transcript/cwd_test.go
+++ b/core/pkg/transcript/cwd_test.go
@@ -1,0 +1,67 @@
+package transcript
+
+import "testing"
+
+func TestExtractCWDFromLine(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  map[string]interface{}
+		want string
+	}{
+		{
+			name: "claude top-level cwd",
+			raw: map[string]interface{}{
+				"cwd": "/Users/test/claude",
+			},
+			want: "/Users/test/claude",
+		},
+		{
+			name: "classic codex environment context",
+			raw: map[string]interface{}{
+				"type": "message",
+				"content": []interface{}{
+					map[string]interface{}{"type": "input_text", "text": "<environment_context><cwd>/Users/test/classic</cwd></environment_context>"},
+				},
+			},
+			want: "/Users/test/classic",
+		},
+		{
+			name: "wrapped session metadata cwd",
+			raw: map[string]interface{}{
+				"type": "session_meta",
+				"payload": map[string]interface{}{
+					"cwd": "/Users/test/wrapped-meta",
+				},
+			},
+			want: "/Users/test/wrapped-meta",
+		},
+		{
+			name: "wrapped tool call workdir",
+			raw: map[string]interface{}{
+				"type": "response_item",
+				"payload": map[string]interface{}{
+					"type":      "function_call",
+					"name":      "shell_command",
+					"arguments": `{"command":["pwd"],"workdir":"/Users/test/wrapped-tool"}`,
+				},
+			},
+			want: "/Users/test/wrapped-tool",
+		},
+		{
+			name: "non tool arguments ignored",
+			raw: map[string]interface{}{
+				"type":      "event_msg",
+				"arguments": `{"workdir":"/Users/test/ignored"}`,
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractCWDFromLine(tt.raw); got != tt.want {
+				t.Errorf("ExtractCWDFromLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- support wrapped Codex `response_item` payloads for messages, tool calls, tool outputs, custom tools, and web search activity
- recover CWD from wrapped `session_meta`, `turn_context`, and wrapped tool-call arguments in the shared transcript helper
- extend shared tailer text/char extraction so wrapped assistant text and payload content are normalized like classic Codex events
- add regression coverage for wrapped parser behavior, waiting-state heuristics, and transcript CWD recovery

## Testing
- `cd core && go test ./adapters/inbound/agents/codex ./adapters/outbound/git ./pkg/transcript ./pkg/tailer ./application/services`
- `cd core && go test ./...` *(currently fails in `cmd/irrlichd` because `cmd/irrlichd/main.go` embeds `ui` but no matching files are present in this worktree)*

Fixes #90
