### PR TITLE
feat(macos): reorderable project groups in popup and menu bar

### DIFF
--- a/platforms/macos/Irrlicht/IrrlichtApp.swift
+++ b/platforms/macos/Irrlicht/IrrlichtApp.swift
@@ -17,6 +17,7 @@ let appVersion: String = {
 
 struct StatusIndicatorLabel: View {
     let sessions: [SessionState]
+    let projectGroupOrder: [String]
 
     var body: some View {
         if sessions.isEmpty {
@@ -33,16 +34,22 @@ struct StatusIndicatorLabel: View {
 
     private func buildStatusImage() -> NSImage? {
         // Group sessions by project (top-level only)
-        var groups: [(String, [SessionState])] = []
-        var seen: [String: Int] = [:]
+        var groupMap: [String: [SessionState]] = [:]
         for s in sessions where s.parentSessionId == nil {
             let key = s.projectName ?? s.cwd
-            if let idx = seen[key] {
-                groups[idx].1.append(s)
-            } else {
-                seen[key] = groups.count
-                groups.append((key, [s]))
+            groupMap[key, default: []].append(s)
+        }
+
+        // Order groups according to saved project group order
+        var groups: [(String, [SessionState])] = []
+        var remaining = groupMap
+        for key in projectGroupOrder {
+            if let sessions = remaining.removeValue(forKey: key) {
+                groups.append((key, sessions))
             }
+        }
+        for (key, sessions) in remaining.sorted(by: { $0.key < $1.key }) {
+            groups.append((key, sessions))
         }
 
         let r: CGFloat = 5
@@ -144,7 +151,7 @@ struct IrrlichtApp: App {
                     sessionManager.gasTownProvider = gasTownProvider
                 }
         } label: {
-            StatusIndicatorLabel(sessions: sessionManager.sessions)
+            StatusIndicatorLabel(sessions: sessionManager.sessions, projectGroupOrder: sessionManager.projectGroupOrder)
                 .task {
                     // Start daemon on app launch (label renders immediately, unlike popover content).
                     appDelegate.daemonManager = daemonManager

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -21,6 +21,10 @@ class SessionManager: ObservableObject {
     private let orderFilePath: URL
     private var sessionOrder: [String] = []
 
+    // Project group ordering (persisted in UserDefaults)
+    @Published var projectGroupOrder: [String] = []
+    private let projectGroupOrderKey = "projectGroupOrder"
+
     // Tracks which pressure thresholds (80, 95) have already fired a notification
     // for each session ID. Prevents re-firing on every state update.
     private var notifiedThresholds: [String: Set<Int>] = [:]
@@ -62,6 +66,7 @@ class SessionManager: ObservableObject {
 
         Task {
             loadSessionOrder()
+            loadProjectGroupOrder()
             requestNotificationPermission()
             if self.useFilePolling {
                 self.startWatching()
@@ -674,6 +679,71 @@ class SessionManager: ObservableObject {
         saveSessionOrder()
 
         print("🔄 Reordered session \(session.shortId) from \(sourceIndex) to \(adjustedDestination)")
+    }
+
+    // MARK: - Project Group Order Management
+
+    private func loadProjectGroupOrder() {
+        projectGroupOrder = UserDefaults.standard.stringArray(forKey: projectGroupOrderKey) ?? []
+        print("📋 Loaded project group order with \(projectGroupOrder.count) groups")
+    }
+
+    private func saveProjectGroupOrder() {
+        UserDefaults.standard.set(projectGroupOrder, forKey: projectGroupOrderKey)
+        print("💾 Saved project group order with \(projectGroupOrder.count) groups")
+    }
+
+    func orderedProjectGroups(from groups: [ProjectGroup]) -> [ProjectGroup] {
+        let groupMap = Dictionary(uniqueKeysWithValues: groups.map { ($0.projectDirectory, $0) })
+        var ordered: [ProjectGroup] = []
+
+        // Groups in saved order first
+        for key in projectGroupOrder {
+            if let group = groupMap[key] {
+                ordered.append(group)
+            }
+        }
+
+        // New groups not in saved order, sorted alphabetically
+        let orderedKeys = Set(projectGroupOrder)
+        let newGroups = groups.filter { !orderedKeys.contains($0.projectDirectory) }
+            .sorted { $0.displayName < $1.displayName }
+        ordered.append(contentsOf: newGroups)
+
+        // Prune stale entries and persist if changed
+        let newOrder = ordered.map { $0.projectDirectory }
+        if newOrder != projectGroupOrder {
+            projectGroupOrder = newOrder
+            saveProjectGroupOrder()
+        }
+
+        return ordered
+    }
+
+    func reorderProjectGroup(projectDirectory: String, to destinationIndex: Int) {
+        guard let sourceIndex = projectGroupOrder.firstIndex(of: projectDirectory) else { return }
+        guard destinationIndex >= 0, destinationIndex <= projectGroupOrder.count else { return }
+        guard sourceIndex != destinationIndex else { return }
+
+        projectGroupOrder.remove(at: sourceIndex)
+        let adjusted = destinationIndex > sourceIndex ? destinationIndex - 1 : destinationIndex
+        projectGroupOrder.insert(projectDirectory, at: adjusted)
+        saveProjectGroupOrder()
+
+        print("🔄 Reordered project group \(projectDirectory) from \(sourceIndex) to \(adjusted)")
+    }
+
+    func moveProjectGroupUp(projectDirectory: String) {
+        guard let index = projectGroupOrder.firstIndex(of: projectDirectory), index > 0 else { return }
+        projectGroupOrder.swapAt(index, index - 1)
+        saveProjectGroupOrder()
+    }
+
+    func moveProjectGroupDown(projectDirectory: String) {
+        guard let index = projectGroupOrder.firstIndex(of: projectDirectory),
+              index < projectGroupOrder.count - 1 else { return }
+        projectGroupOrder.swapAt(index, index + 1)
+        saveProjectGroupOrder()
     }
 
     // MARK: - Duplicate Session Handling

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -319,9 +319,6 @@ struct SessionListView: View {
                         projectGroupIndex: pgIndex,
                         totalProjectGroups: projectGroupCount
                     )
-                    .onDrag {
-                        NSItemProvider(object: projectGroup.projectDirectory as NSString)
-                    }
                     .onDrop(of: [.text], delegate: ProjectGroupDropDelegate(
                         sessionManager: sessionManager,
                         targetProjectGroupIndex: pgIndex,
@@ -1025,69 +1022,78 @@ struct ProjectGroupSectionView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Collapsible project header
-            Button(action: {
-                withAnimation(.easeInOut(duration: 0.15)) {
-                    isExpanded.toggle()
-                }
-            }) {
-                HStack(spacing: 6) {
-                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                        .font(.system(size: 8))
-                        .foregroundColor(.secondary)
-                        .frame(width: 10)
-
-                    Text(projectGroup.displayName)
-                        .font(.system(.caption, design: .monospaced))
-                        .fontWeight(.semibold)
-                        .foregroundColor(projectNameColor)
-
-                    if let cost = formattedTotalCost {
-                        Text(cost)
-                            .font(.system(size: 9, weight: .medium, design: .monospaced))
+            // Collapsible project header with reorder arrows
+            HStack(spacing: 0) {
+                Button(action: {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        isExpanded.toggle()
+                    }
+                }) {
+                    HStack(spacing: 6) {
+                        Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 8))
                             .foregroundColor(.secondary)
-                    }
+                            .frame(width: 10)
 
-                    SessionStateDots(projectGroup: projectGroup, isCompact: isCompact)
+                        Text(projectGroup.displayName)
+                            .font(.system(.caption, design: .monospaced))
+                            .fontWeight(.semibold)
+                            .foregroundColor(projectNameColor)
 
-                    Spacer()
-
-                    if totalProjectGroups > 1 {
-                        HStack(spacing: 2) {
-                            Button(action: {
-                                sessionManager.moveProjectGroupUp(projectDirectory: projectGroup.projectDirectory)
-                            }) {
-                                Image(systemName: "chevron.up")
-                                    .font(.system(size: 8))
-                                    .foregroundColor(.secondary)
-                            }
-                            .buttonStyle(.plain)
-                            .disabled(projectGroupIndex == 0)
-                            .opacity(projectGroupIndex == 0 ? 0.3 : 1.0)
-
-                            Button(action: {
-                                sessionManager.moveProjectGroupDown(projectDirectory: projectGroup.projectDirectory)
-                            }) {
-                                Image(systemName: "chevron.down")
-                                    .font(.system(size: 8))
-                                    .foregroundColor(.secondary)
-                            }
-                            .buttonStyle(.plain)
-                            .disabled(projectGroupIndex == totalProjectGroups - 1)
-                            .opacity(projectGroupIndex == totalProjectGroups - 1 ? 0.3 : 1.0)
+                        if let cost = formattedTotalCost {
+                            Text(cost)
+                                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                                .foregroundColor(.secondary)
                         }
-                    }
 
-                    let count = projectGroup.sessionGroups.count
-                    Text("\(count) \(count == 1 ? "session" : "sessions")")
-                        .font(.caption2)
-                        .foregroundColor(.secondary.opacity(0.7))
+                        SessionStateDots(projectGroup: projectGroup, isCompact: isCompact)
+
+                        Spacer()
+
+                        let count = projectGroup.sessionGroups.count
+                        Text("\(count) \(count == 1 ? "session" : "sessions")")
+                            .font(.caption2)
+                            .foregroundColor(.secondary.opacity(0.7))
+                    }
+                    .contentShape(Rectangle())
                 }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 4)
-                .contentShape(Rectangle())
+                .buttonStyle(.plain)
+
+                if totalProjectGroups > 1 {
+                    HStack(spacing: 0) {
+                        Button(action: {
+                            sessionManager.moveProjectGroupUp(projectDirectory: projectGroup.projectDirectory)
+                        }) {
+                            Image(systemName: "chevron.up")
+                                .font(.system(size: 10))
+                                .foregroundColor(.secondary)
+                                .frame(width: 14, height: 20)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(projectGroupIndex == 0)
+                        .opacity(projectGroupIndex == 0 ? 0.3 : 1.0)
+
+                        Button(action: {
+                            sessionManager.moveProjectGroupDown(projectDirectory: projectGroup.projectDirectory)
+                        }) {
+                            Image(systemName: "chevron.down")
+                                .font(.system(size: 10))
+                                .foregroundColor(.secondary)
+                                .frame(width: 14, height: 20)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(projectGroupIndex == totalProjectGroups - 1)
+                        .opacity(projectGroupIndex == totalProjectGroups - 1 ? 0.3 : 1.0)
+                    }
+                }
             }
-            .buttonStyle(.plain)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
+            .onDrag {
+                NSItemProvider(object: projectGroup.projectDirectory as NSString)
+            }
 
             // Session rows (indented under the project header)
             if isExpanded {

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -286,12 +286,13 @@ struct SessionListView: View {
             grouped[key, default: []].append(group)
         }
 
-        // Convert to ProjectGroup array, sorted by display name
-        return grouped.map { key, value in
+        // Convert to ProjectGroup array, ordered by user preference
+        let unsorted = grouped.map { key, value in
             let display = value.first?.parent.projectName
                 ?? URL(fileURLWithPath: key).lastPathComponent
             return ProjectGroup(projectDirectory: key, displayName: display, sessionGroups: value)
-        }.sorted { $0.displayName < $1.displayName }
+        }
+        return sessionManager.orderedProjectGroups(from: unsorted)
     }
 
     private var sessionListContent: some View {
@@ -306,17 +307,29 @@ struct SessionListView: View {
         }
         let totalGroups = runningIndex
 
+        let projectGroupCount = allProjectGroups.count
+
         return ScrollView {
             LazyVStack(alignment: .leading, spacing: 1) {
-                ForEach(allProjectGroups) { projectGroup in
+                ForEach(Array(allProjectGroups.enumerated()), id: \.element.id) { pgIndex, projectGroup in
                     ProjectGroupSectionView(
                         projectGroup: projectGroup,
                         startingGroupIndex: startIndices[projectGroup.id] ?? 0,
-                        isCompact: isCompactMode
+                        isCompact: isCompactMode,
+                        projectGroupIndex: pgIndex,
+                        totalProjectGroups: projectGroupCount
                     )
+                    .onDrag {
+                        NSItemProvider(object: projectGroup.projectDirectory as NSString)
+                    }
+                    .onDrop(of: [.text], delegate: ProjectGroupDropDelegate(
+                        sessionManager: sessionManager,
+                        targetProjectGroupIndex: pgIndex,
+                        allProjectDirectories: Set(allProjectGroups.map(\.projectDirectory))
+                    ))
                 }
 
-                // Drop zone at the end of the list
+                // Drop zone at the end of the list (for sessions)
                 Rectangle()
                     .fill(Color.clear)
                     .frame(height: 20)
@@ -974,6 +987,8 @@ struct ProjectGroupSectionView: View {
     let projectGroup: ProjectGroup
     let startingGroupIndex: Int
     let isCompact: Bool
+    let projectGroupIndex: Int
+    let totalProjectGroups: Int
     @EnvironmentObject var sessionManager: SessionManager
     @AppStorage("debugMode") private var debugMode: Bool = false
     @State private var isExpanded = true
@@ -1036,6 +1051,32 @@ struct ProjectGroupSectionView: View {
                     SessionStateDots(projectGroup: projectGroup, isCompact: isCompact)
 
                     Spacer()
+
+                    if totalProjectGroups > 1 {
+                        HStack(spacing: 2) {
+                            Button(action: {
+                                sessionManager.moveProjectGroupUp(projectDirectory: projectGroup.projectDirectory)
+                            }) {
+                                Image(systemName: "chevron.up")
+                                    .font(.system(size: 8))
+                                    .foregroundColor(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(projectGroupIndex == 0)
+                            .opacity(projectGroupIndex == 0 ? 0.3 : 1.0)
+
+                            Button(action: {
+                                sessionManager.moveProjectGroupDown(projectDirectory: projectGroup.projectDirectory)
+                            }) {
+                                Image(systemName: "chevron.down")
+                                    .font(.system(size: 8))
+                                    .foregroundColor(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(projectGroupIndex == totalProjectGroups - 1)
+                            .opacity(projectGroupIndex == totalProjectGroups - 1 ? 0.3 : 1.0)
+                        }
+                    }
 
                     let count = projectGroup.sessionGroups.count
                     Text("\(count) \(count == 1 ? "session" : "sessions")")
@@ -1131,6 +1172,41 @@ struct SessionGroupDropDelegate: DropDelegate {
             guard let parentId = item as? String else { return }
             DispatchQueue.main.async {
                 sessionManager.reorderGroup(parentId: parentId, to: targetGroupIndex)
+            }
+        }
+
+        return true
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        return DropProposal(operation: .move)
+    }
+}
+
+// MARK: - Project Group Drag and Drop
+
+struct ProjectGroupDropDelegate: DropDelegate {
+    let sessionManager: SessionManager
+    let targetProjectGroupIndex: Int
+    let allProjectDirectories: Set<String>
+
+    func validateDrop(info: DropInfo) -> Bool {
+        return info.hasItemsConforming(to: [.text])
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        guard let itemProvider = info.itemProviders(for: [.text]).first else {
+            return false
+        }
+
+        itemProvider.loadObject(ofClass: NSString.self) { item, error in
+            guard let projectDirectory = item as? String,
+                  allProjectDirectories.contains(projectDirectory) else { return }
+            DispatchQueue.main.async {
+                sessionManager.reorderProjectGroup(
+                    projectDirectory: projectDirectory,
+                    to: targetProjectGroupIndex
+                )
             }
         }
 


### PR DESCRIPTION
## Summary

- Add up/down arrow buttons on project group headers for reordering (hidden when only 1 group)
- Add drag-and-drop at the project group level (alongside existing session-level drag-and-drop)
- Persist project group order in UserDefaults (UI-only preference)
- Sync menu bar indicator order to match popup order (leftmost = first group)

## Test plan

- [ ] With multiple project groups, verify arrow buttons move groups up/down in the popup
- [ ] Verify arrow buttons are disabled at boundaries (up on first, down on last)
- [ ] Verify arrow buttons are hidden when only one project group exists
- [ ] Verify drag-and-drop reorders project groups
- [ ] Verify menu bar dot order matches popup group order after reordering
- [ ] Verify order persists after app restart

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)