### PR TITLE
feat(capacity): dynamic model data from LiteLLM, no fallback assumption

### DIFF
--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"irrlicht/core/adapters/inbound/agents/claudecode"
+	"irrlicht/core/pkg/capacity"
 	"irrlicht/core/adapters/inbound/agents/codex"
 	"irrlicht/core/adapters/inbound/agents/pi"
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
@@ -75,6 +76,25 @@ func main() {
 		}
 	}
 	logger.LogInfo("startup", "", fmt.Sprintf("max session age: %s", cfg.MaxSessionAge))
+
+	// Background model capacity refresh from LiteLLM.
+	go func() {
+		if n, err := capacity.RefreshRemoteDataIfStale(); err != nil {
+			logger.LogError("capacity", "", fmt.Sprintf("remote refresh failed: %v", err))
+		} else if n > 0 {
+			logger.LogInfo("capacity", "", fmt.Sprintf("cached %d remote models from LiteLLM", n))
+		}
+
+		ticker := time.NewTicker(24 * time.Hour)
+		defer ticker.Stop()
+		for range ticker.C {
+			if n, err := capacity.RefreshRemoteDataIfStale(); err != nil {
+				logger.LogError("capacity", "", fmt.Sprintf("remote refresh failed: %v", err))
+			} else if n > 0 {
+				logger.LogInfo("capacity", "", fmt.Sprintf("cached %d remote models from LiteLLM", n))
+			}
+		}
+	}()
 
 	// Resolve the gt binary path (GT_BIN env → common paths → which gt).
 	gtResolver := gtbin.New()

--- a/core/pkg/capacity/capacity.go
+++ b/core/pkg/capacity/capacity.go
@@ -176,6 +176,23 @@ func (cm *CapacityManager) GetModelCapacity(modelName string) ModelCapacity {
 	return fallback
 }
 
+// MergeRemoteModels adds models from remote data that don't already exist
+// in the current config. Existing (hand-tuned) entries are preserved.
+func (cm *CapacityManager) MergeRemoteModels(remote *CapacityConfig) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	if remote == nil || cm.config == nil {
+		return
+	}
+
+	for name, remoteCap := range remote.Models {
+		if _, exists := cm.config.Models[name]; !exists {
+			cm.config.Models[name] = remoteCap
+		}
+	}
+}
+
 // EstimateTokensFromContent estimates token count from text content
 func (cm *CapacityManager) EstimateTokensFromContent(content string, modelName string) TokenEstimation {
 	capacity := cm.GetModelCapacity(modelName)
@@ -202,11 +219,23 @@ func (cm *CapacityManager) EstimateTokensFromContent(content string, modelName s
 
 // CalculateContextUtilization computes context utilization metrics
 func (cm *CapacityManager) CalculateContextUtilization(tokensUsed int64, modelName string, isEstimated bool) ContextUtilization {
-	capacity := cm.GetModelCapacity(modelName)
-	
-	utilizationPercentage := (float64(tokensUsed) / float64(capacity.ContextWindow)) * 100
-	remainingTokens := capacity.ContextWindow - tokensUsed
-	
+	cap := cm.GetModelCapacity(modelName)
+
+	// Unknown model: no context window — report raw tokens only.
+	if cap.ContextWindow <= 0 {
+		return ContextUtilization{
+			TokensUsed:    tokensUsed,
+			IsEstimated:   isEstimated,
+			ModelName:     modelName,
+			ModelFamily:   cap.Family,
+			LastTokenCount: tokensUsed,
+			PressureLevel: "unknown",
+		}
+	}
+
+	utilizationPercentage := (float64(tokensUsed) / float64(cap.ContextWindow)) * 100
+	remainingTokens := cap.ContextWindow - tokensUsed
+
 	// Determine pressure level
 	pressureLevel := "safe"
 	if utilizationPercentage >= 96 {
@@ -216,17 +245,17 @@ func (cm *CapacityManager) CalculateContextUtilization(tokensUsed int64, modelNa
 	} else if utilizationPercentage >= 51 {
 		pressureLevel = "caution"
 	}
-	
+
 	return ContextUtilization{
-		TokensUsed:              tokensUsed,
-		ContextCapacity:         capacity.ContextWindow,
-		UtilizationPercentage:   utilizationPercentage,
+		TokensUsed:               tokensUsed,
+		ContextCapacity:          cap.ContextWindow,
+		UtilizationPercentage:    utilizationPercentage,
 		EstimatedTokensRemaining: remainingTokens,
-		IsEstimated:             isEstimated,
-		ModelName:               modelName,
-		ModelFamily:             capacity.Family,
-		LastTokenCount:          tokensUsed,
-		PressureLevel:           pressureLevel,
+		IsEstimated:              isEstimated,
+		ModelName:                modelName,
+		ModelFamily:              cap.Family,
+		LastTokenCount:           tokensUsed,
+		PressureLevel:            pressureLevel,
 	}
 }
 

--- a/core/pkg/capacity/default.go
+++ b/core/pkg/capacity/default.go
@@ -23,11 +23,18 @@ func NewCapacityManagerFromData(data []byte) (*CapacityManager, error) {
 }
 
 // DefaultCapacityManager returns a CapacityManager initialized with the
-// embedded model-capacity.json. Returns nil if parsing fails.
+// embedded model-capacity.json, merged with any cached remote data.
+// Returns nil if parsing fails.
 func DefaultCapacityManager() *CapacityManager {
 	cm, err := NewCapacityManagerFromData(defaultConfigData)
 	if err != nil {
 		return nil
 	}
+
+	// Merge cached remote data (fills in models not in embedded JSON).
+	if remote := LoadCachedRemoteData(); remote != nil {
+		cm.MergeRemoteModels(remote)
+	}
+
 	return cm
 }

--- a/core/pkg/capacity/model-capacity.json
+++ b/core/pkg/capacity/model-capacity.json
@@ -283,16 +283,10 @@
     }
   },
   "fallback": {
-    "context_window": 200000,
-    "max_output": 4096,
+    "context_window": 0,
+    "max_output": 0,
     "char_to_token_ratio": 4.0,
-    "display_name": "Unknown Model",
-    "pricing": {
-      "input_per_mtok": 3.0,
-      "output_per_mtok": 15.0,
-      "cache_read_per_mtok": 0.30,
-      "cache_creation_per_mtok": 3.75
-    }
+    "display_name": "Unknown Model"
   },
   "estimation_notes": {
     "char_to_token_ratio": "Average characters per token, varies by language and content type",

--- a/core/pkg/capacity/remote.go
+++ b/core/pkg/capacity/remote.go
@@ -1,0 +1,240 @@
+package capacity
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	liteLLMURL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+	cacheTTL   = 24 * time.Hour
+	cacheFile  = "model-capacity-cache.json"
+)
+
+// liteLLMEntry represents a single model entry from LiteLLM's JSON.
+type liteLLMEntry struct {
+	MaxInputTokens              int64   `json:"max_input_tokens"`
+	MaxOutputTokens             int64   `json:"max_output_tokens"`
+	InputCostPerToken           float64 `json:"input_cost_per_token"`
+	OutputCostPerToken          float64 `json:"output_cost_per_token"`
+	CacheReadInputTokenCost     float64 `json:"cache_read_input_token_cost"`
+	CacheCreationInputTokenCost float64 `json:"cache_creation_input_token_cost"`
+	LiteLLMProvider             string  `json:"litellm_provider"`
+	Mode                        string  `json:"mode"`
+}
+
+// cachedCapacity wraps CapacityConfig with cache metadata.
+type cachedCapacity struct {
+	FetchedAt time.Time      `json:"fetched_at"`
+	Config    CapacityConfig `json:"config"`
+}
+
+// CachePath returns the path for the cached remote capacity data.
+func CachePath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(homeDir, ".local", "share", "irrlicht")
+	return filepath.Join(dir, cacheFile), nil
+}
+
+// FetchAndCacheLiteLLMData fetches model data from LiteLLM and caches it locally.
+// Non-fatal: callers should fall back to embedded data on error.
+func FetchAndCacheLiteLLMData() (*CapacityConfig, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(liteLLMURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch LiteLLM data: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("LiteLLM returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read LiteLLM response: %w", err)
+	}
+
+	config, err := parseLiteLLMData(body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache to disk (non-fatal if this fails).
+	_ = saveCachedData(config)
+
+	return config, nil
+}
+
+// parseLiteLLMData converts LiteLLM's JSON format to our CapacityConfig.
+func parseLiteLLMData(data []byte) (*CapacityConfig, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse LiteLLM JSON: %w", err)
+	}
+
+	config := &CapacityConfig{
+		Version:     "remote",
+		LastUpdated: time.Now().Format("2006-01-02"),
+		Models:      make(map[string]ModelCapacity),
+	}
+
+	for key, rawEntry := range raw {
+		// Skip provider-prefixed entries (e.g. "bedrock/anthropic.claude...")
+		// and the sample_spec entry. Only keep canonical model IDs.
+		if strings.Contains(key, "/") || key == "sample_spec" {
+			continue
+		}
+
+		var entry liteLLMEntry
+		if err := json.Unmarshal(rawEntry, &entry); err != nil {
+			continue
+		}
+
+		if entry.MaxInputTokens <= 0 {
+			continue
+		}
+
+		// Skip non-chat models.
+		if entry.Mode != "" && entry.Mode != "chat" {
+			continue
+		}
+
+		mc := ModelCapacity{
+			ContextWindow:    entry.MaxInputTokens,
+			MaxOutput:        entry.MaxOutputTokens,
+			CharToTokenRatio: 3.5,
+			DisplayName:      key,
+			Family:           deriveFamilyFromLiteLLM(key, entry.LiteLLMProvider),
+		}
+
+		// Convert per-token pricing to per-million-token pricing.
+		if entry.InputCostPerToken > 0 || entry.OutputCostPerToken > 0 {
+			mc.Pricing = &ModelPricing{
+				InputPerMTok:         entry.InputCostPerToken * 1_000_000,
+				OutputPerMTok:        entry.OutputCostPerToken * 1_000_000,
+				CacheReadPerMTok:     entry.CacheReadInputTokenCost * 1_000_000,
+				CacheCreationPerMTok: entry.CacheCreationInputTokenCost * 1_000_000,
+			}
+		}
+
+		config.Models[key] = mc
+	}
+
+	return config, nil
+}
+
+// deriveFamilyFromLiteLLM infers a model family string.
+func deriveFamilyFromLiteLLM(modelID, provider string) string {
+	lower := strings.ToLower(modelID)
+	switch {
+	case strings.Contains(lower, "claude-4") ||
+		strings.Contains(lower, "claude-opus-4") ||
+		strings.Contains(lower, "claude-sonnet-4") ||
+		strings.Contains(lower, "claude-haiku-4"):
+		return "claude-4"
+	case strings.Contains(lower, "claude-3.7"):
+		return "claude-3.7"
+	case strings.Contains(lower, "claude-3.5"):
+		return "claude-3.5"
+	case strings.Contains(lower, "claude-3"):
+		return "claude-3"
+	case strings.Contains(lower, "gpt-5"):
+		return "gpt-5"
+	case strings.Contains(lower, "gpt-4"):
+		return "gpt-4"
+	default:
+		return provider
+	}
+}
+
+// LoadCachedRemoteData reads previously cached remote capacity data.
+// Returns nil if cache doesn't exist or is expired.
+func LoadCachedRemoteData() *CapacityConfig {
+	path, err := CachePath()
+	if err != nil {
+		return nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	var cached cachedCapacity
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil
+	}
+
+	if time.Since(cached.FetchedAt) > cacheTTL {
+		return nil
+	}
+
+	return &cached.Config
+}
+
+// saveCachedData writes capacity config to the cache file.
+func saveCachedData(config *CapacityConfig) error {
+	path, err := CachePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
+	cached := cachedCapacity{
+		FetchedAt: time.Now(),
+		Config:    *config,
+	}
+
+	data, err := json.Marshal(cached)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0644)
+}
+
+// IsCacheStale returns true if the cache doesn't exist or has expired.
+func IsCacheStale() bool {
+	path, err := CachePath()
+	if err != nil {
+		return true
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return true
+	}
+
+	var cached cachedCapacity
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return true
+	}
+
+	return time.Since(cached.FetchedAt) > cacheTTL
+}
+
+// RefreshRemoteDataIfStale checks if the cache is stale and fetches fresh data.
+// Returns the number of models fetched, or an error.
+func RefreshRemoteDataIfStale() (int, error) {
+	if !IsCacheStale() {
+		return 0, nil
+	}
+	config, err := FetchAndCacheLiteLLMData()
+	if err != nil {
+		return 0, err
+	}
+	return len(config.Models), nil
+}

--- a/core/pkg/capacity/remote_test.go
+++ b/core/pkg/capacity/remote_test.go
@@ -1,0 +1,195 @@
+package capacity
+
+import (
+	"testing"
+)
+
+func TestParseLiteLLMData_BasicMapping(t *testing.T) {
+	data := []byte(`{
+		"claude-sonnet-4-6": {
+			"max_input_tokens": 200000,
+			"max_output_tokens": 64000,
+			"input_cost_per_token": 0.000003,
+			"output_cost_per_token": 0.000015,
+			"cache_read_input_token_cost": 0.0000003,
+			"cache_creation_input_token_cost": 0.00000375,
+			"litellm_provider": "anthropic",
+			"mode": "chat"
+		}
+	}`)
+
+	config, err := parseLiteLLMData(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(config.Models) != 1 {
+		t.Fatalf("got %d models, want 1", len(config.Models))
+	}
+
+	mc, ok := config.Models["claude-sonnet-4-6"]
+	if !ok {
+		t.Fatal("missing claude-sonnet-4-6")
+	}
+
+	if mc.ContextWindow != 200000 {
+		t.Errorf("ContextWindow = %d, want 200000", mc.ContextWindow)
+	}
+	if mc.MaxOutput != 64000 {
+		t.Errorf("MaxOutput = %d, want 64000", mc.MaxOutput)
+	}
+	if mc.Family != "claude-4" {
+		t.Errorf("Family = %q, want %q", mc.Family, "claude-4")
+	}
+	if mc.Pricing == nil {
+		t.Fatal("Pricing is nil")
+	}
+	if mc.Pricing.InputPerMTok != 3.0 {
+		t.Errorf("InputPerMTok = %f, want 3.0", mc.Pricing.InputPerMTok)
+	}
+	if mc.Pricing.OutputPerMTok != 15.0 {
+		t.Errorf("OutputPerMTok = %f, want 15.0", mc.Pricing.OutputPerMTok)
+	}
+}
+
+func TestParseLiteLLMData_SkipsProviderPrefixed(t *testing.T) {
+	data := []byte(`{
+		"claude-sonnet-4-6": {
+			"max_input_tokens": 200000,
+			"max_output_tokens": 64000,
+			"litellm_provider": "anthropic",
+			"mode": "chat"
+		},
+		"bedrock/anthropic.claude-sonnet-4-6": {
+			"max_input_tokens": 200000,
+			"max_output_tokens": 64000,
+			"litellm_provider": "bedrock",
+			"mode": "chat"
+		},
+		"sample_spec": {
+			"max_input_tokens": 100000,
+			"litellm_provider": "sample"
+		}
+	}`)
+
+	config, err := parseLiteLLMData(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(config.Models) != 1 {
+		t.Fatalf("got %d models, want 1 (should skip prefixed and sample_spec)", len(config.Models))
+	}
+	if _, ok := config.Models["claude-sonnet-4-6"]; !ok {
+		t.Error("missing canonical claude-sonnet-4-6")
+	}
+}
+
+func TestParseLiteLLMData_SkipsNoContextWindow(t *testing.T) {
+	data := []byte(`{
+		"model-with-tokens": {
+			"max_input_tokens": 100000,
+			"litellm_provider": "test",
+			"mode": "chat"
+		},
+		"model-without-tokens": {
+			"max_input_tokens": 0,
+			"litellm_provider": "test",
+			"mode": "chat"
+		}
+	}`)
+
+	config, err := parseLiteLLMData(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(config.Models) != 1 {
+		t.Fatalf("got %d models, want 1", len(config.Models))
+	}
+}
+
+func TestDeriveFamilyFromLiteLLM(t *testing.T) {
+	tests := []struct {
+		modelID  string
+		provider string
+		want     string
+	}{
+		{"claude-sonnet-4-6", "anthropic", "claude-4"},
+		{"claude-opus-4-1", "anthropic", "claude-4"},
+		{"claude-haiku-4-5", "anthropic", "claude-4"},
+		{"claude-3.5-sonnet", "anthropic", "claude-3.5"},
+		{"claude-3.7-sonnet", "anthropic", "claude-3.7"},
+		{"claude-3-haiku", "anthropic", "claude-3"},
+		{"gpt-5.3-codex", "openai", "gpt-5"},
+		{"gpt-4o", "openai", "gpt-4"},
+		{"gemini-pro", "google", "google"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.modelID, func(t *testing.T) {
+			got := deriveFamilyFromLiteLLM(tt.modelID, tt.provider)
+			if got != tt.want {
+				t.Errorf("deriveFamilyFromLiteLLM(%q, %q) = %q, want %q", tt.modelID, tt.provider, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeRemoteModels_PreservesExisting(t *testing.T) {
+	cm := DefaultCapacityManager()
+	if cm == nil {
+		t.Fatal("DefaultCapacityManager returned nil")
+	}
+
+	// Get the existing context window for a known model.
+	existing := cm.GetModelCapacity("claude-opus-4-6")
+	if existing.ContextWindow != 200000 {
+		t.Fatalf("pre-merge ContextWindow = %d, want 200000", existing.ContextWindow)
+	}
+
+	// Merge remote data that includes both a conflicting and a new model.
+	remote := &CapacityConfig{
+		Models: map[string]ModelCapacity{
+			"claude-opus-4-6": {
+				ContextWindow: 999999, // should NOT override existing
+			},
+			"brand-new-model": {
+				ContextWindow:    500000,
+				MaxOutput:        16000,
+				CharToTokenRatio: 3.5,
+				Family:           "new",
+				DisplayName:      "Brand New Model",
+			},
+		},
+	}
+
+	cm.MergeRemoteModels(remote)
+
+	// Existing model should be unchanged.
+	after := cm.GetModelCapacity("claude-opus-4-6")
+	if after.ContextWindow != 200000 {
+		t.Errorf("post-merge ContextWindow = %d, want 200000 (should preserve existing)", after.ContextWindow)
+	}
+
+	// New model should be available.
+	newModel := cm.GetModelCapacity("brand-new-model")
+	if newModel.ContextWindow != 500000 {
+		t.Errorf("brand-new-model ContextWindow = %d, want 500000", newModel.ContextWindow)
+	}
+}
+
+func TestFallback_NoContextWindow(t *testing.T) {
+	cm := DefaultCapacityManager()
+	if cm == nil {
+		t.Fatal("DefaultCapacityManager returned nil")
+	}
+
+	mc := cm.GetModelCapacity("totally-unknown-model-xyz")
+	if mc.ContextWindow != 0 {
+		t.Errorf("fallback ContextWindow = %d, want 0", mc.ContextWindow)
+	}
+	if mc.Family != "unknown" {
+		t.Errorf("fallback Family = %q, want %q", mc.Family, "unknown")
+	}
+}

--- a/core/pkg/tailer/context_utilization_test.go
+++ b/core/pkg/tailer/context_utilization_test.go
@@ -68,9 +68,9 @@ func TestContextUtilization_KnownModel_Opus46(t *testing.T) {
 	assertPressure(t, m, "critical", 90.0)
 }
 
-func TestContextUtilization_UnknownModel_Fallback200K(t *testing.T) {
-	// Unknown model falls back to 200K
-	// 100K tokens / 200K = 50% → "safe"
+func TestContextUtilization_UnknownModel_ShowsTokensOnly(t *testing.T) {
+	// Unknown model: no context window assumption, pressure is "unknown",
+	// raw token count is still available.
 	path := writeTranscriptLines(t, []map[string]interface{}{
 		{
 			"type":      "assistant",
@@ -91,7 +91,18 @@ func TestContextUtilization_UnknownModel_Fallback200K(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertPressure(t, m, "safe", 50.0)
+	if m.PressureLevel != "unknown" {
+		t.Errorf("PressureLevel = %q, want %q", m.PressureLevel, "unknown")
+	}
+	if m.ContextWindow != 0 {
+		t.Errorf("ContextWindow = %d, want 0 (unknown)", m.ContextWindow)
+	}
+	if m.ContextUtilization != 0 {
+		t.Errorf("ContextUtilization = %.1f, want 0", m.ContextUtilization)
+	}
+	if m.TotalTokens != 100000 {
+		t.Errorf("TotalTokens = %d, want 100000", m.TotalTokens)
+	}
 }
 
 func TestContextUtilization_Codex53_Uses256KContextWindow(t *testing.T) {

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -475,8 +475,12 @@ func (t *TranscriptTailer) computeContextUtilization() {
 		}
 	}
 
+	// Unknown model: no context window data available — report raw tokens only.
 	if effectiveContextWindow <= 0 {
-		effectiveContextWindow = int64(200000)
+		t.metrics.ContextWindow = 0
+		t.metrics.ContextUtilization = 0
+		t.metrics.PressureLevel = "unknown"
+		return
 	}
 
 	utilizationPercentage := (float64(t.metrics.TotalTokens) / float64(effectiveContextWindow)) * 100

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -355,24 +355,6 @@ class SessionManager: ObservableObject {
                 }
             }
 
-            // TTL-based auto-cleanup for ready sessions
-            let storedTTL = UserDefaults.standard.object(forKey: "sessionTTLMinutes") as? Int ?? 30
-            if storedTTL > 0 {
-                let ttlCutoff = Date().addingTimeInterval(-TimeInterval(storedTTL * 60))
-                var expiredIds: [String] = []
-                for session in newSessions where session.state == .ready {
-                    if session.updatedAt < ttlCutoff {
-                        let filePath = instancesPath.appendingPathComponent("\(session.id).json")
-                        try? FileManager.default.removeItem(at: filePath)
-                        expiredIds.append(session.id)
-                        print("🧹 TTL-expired ready session \(session.shortId) (ttl=\(storedTTL)m)")
-                    }
-                }
-                if !expiredIds.isEmpty {
-                    newSessions.removeAll { expiredIds.contains($0.id) }
-                }
-            }
-
             // Auto-cleanup orphaned sessions whose Claude Code process has exited.
             // This catches the common case where Claude Code is force-quit or crashes
             // without firing SessionEnd.
@@ -398,28 +380,6 @@ class SessionManager: ObservableObject {
             }
             if !orphanedIds.isEmpty {
                 newSessions.removeAll { orphanedIds.contains($0.id) }
-            }
-
-            // TTL-based expiry for ready sessions.
-            // sessionTTLMinutes: 0 = never expire, >0 = expire after N minutes.
-            // Default is 30 when the key hasn't been set yet.
-            let effectiveTTL: Int = UserDefaults.standard.object(forKey: "sessionTTLMinutes") == nil
-                ? 30
-                : UserDefaults.standard.integer(forKey: "sessionTTLMinutes")
-            if effectiveTTL > 0 {
-                let ttlCutoff = Date().addingTimeInterval(-Double(effectiveTTL) * 60)
-                var expiredIds: [String] = []
-                for session in newSessions where session.state == .ready {
-                    if session.updatedAt < ttlCutoff {
-                        let filePath = instancesPath.appendingPathComponent("\(session.id).json")
-                        try? FileManager.default.removeItem(at: filePath)
-                        expiredIds.append(session.id)
-                        print("⏰ TTL-expired ready session \(session.shortId) (idle > \(effectiveTTL)m)")
-                    }
-                }
-                if !expiredIds.isEmpty {
-                    newSessions.removeAll { expiredIds.contains($0.id) }
-                }
             }
 
             // Sort sessions according to saved order, with new sessions at the end

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -7,6 +7,7 @@ struct SessionMetrics: Codable {
     let elapsedSeconds: Int64       // elapsed time when metrics were computed (for ready sessions)
     let totalTokens: Int64          // total token count from transcript (0 if not available)
     let modelName: String           // model name extracted from transcript ("" if not available) 
+    let contextWindow: Int64?       // model context window size (nil/0 if unknown)
     let contextUtilization: Double  // context utilization percentage (0-100) (0 if not available)
     let pressureLevel: String       // pressure level: "safe", "caution", "warning", "critical" ("unknown" if not available)
     let estimatedCostUSD: Double?   // estimated session cost in USD (nil if not available)
@@ -16,6 +17,7 @@ struct SessionMetrics: Codable {
         case elapsedSeconds = "elapsed_seconds"
         case totalTokens = "total_tokens"
         case modelName = "model_name"
+        case contextWindow = "context_window"
         case contextUtilization = "context_utilization_percentage"
         case pressureLevel = "pressure_level"
         case estimatedCostUSD = "estimated_cost_usd"
@@ -50,6 +52,23 @@ struct SessionMetrics: Codable {
         }
     }
     
+    var formattedTokenUsage: String {
+        if totalTokens == 0 { return "—" }
+        let used = formattedTokenCount
+        if let cw = contextWindow, cw > 0 {
+            let window: String
+            if cw < 1000 {
+                window = "\(cw)"
+            } else if cw < 1000000 {
+                window = String(format: "%.0fK", Double(cw) / 1000)
+            } else {
+                window = String(format: "%.0fM", Double(cw) / 1000000)
+            }
+            return "\(used) / \(window)"
+        }
+        return "\(used) / ?"
+    }
+
     var formattedContextUtilization: String {
         if contextUtilization == 0 && pressureLevel == "unknown" { return "—" }
         return String(format: "%.1f%%", contextUtilization)

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -414,9 +414,13 @@ struct SessionRowView: View {
                     ContextBar(utilization: metrics.contextUtilization,
                                pressureColor: metrics.contextPressureColor)
                         .frame(maxWidth: 80, maxHeight: 8)
-                    Text(metrics.formattedContextUtilization)
+                    Text(debugMode ? metrics.formattedTokenUsage : metrics.formattedContextUtilization)
                         .font(.system(size: 9, design: .monospaced))
                         .foregroundColor(Color(hex: metrics.contextPressureColor))
+                } else if debugMode, let metrics = session.metrics, metrics.totalTokens > 0 {
+                    Text(metrics.formattedTokenUsage)
+                        .font(.system(size: 9, design: .monospaced))
+                        .foregroundColor(Color(hex: "#8E8E93"))
                 }
 
                 // Estimated cost
@@ -480,6 +484,9 @@ struct SessionRowView: View {
                             .help("Click to copy full ID")
                         Text("updated: \(elapsedString(from: session.updatedAt, now: context.date))")
                         Text("created: \(elapsedString(from: session.firstSeen, now: context.date))")
+                        if let metrics = session.metrics, metrics.totalTokens > 0 {
+                            Text("ctx: \(metrics.formattedTokenUsage)")
+                        }
                         Spacer()
                     }
                     .font(.system(size: 9, design: .monospaced))
@@ -550,6 +557,7 @@ struct SessionActionButtons: View {
 
 struct SubagentRowView: View {
     let session: SessionState
+    @AppStorage("debugMode") private var debugMode: Bool = false
     @State private var isHovered = false
 
     var body: some View {
@@ -566,9 +574,13 @@ struct SubagentRowView: View {
 
             // Context utilization
             if let metrics = session.metrics, metrics.hasContextData {
-                Text(metrics.formattedContextUtilization)
+                Text(debugMode ? metrics.formattedTokenUsage : metrics.formattedContextUtilization)
                     .font(.caption2)
                     .foregroundColor(Color(hex: metrics.contextPressureColor))
+            } else if debugMode, let metrics = session.metrics, metrics.totalTokens > 0 {
+                Text(metrics.formattedTokenUsage)
+                    .font(.caption2)
+                    .foregroundColor(.secondary.opacity(0.6))
             } else {
                 Text("—")
                     .font(.caption2)
@@ -1166,6 +1178,7 @@ struct SessionListView_Previews: PreviewProvider {
                             elapsedSeconds: 180,
                             totalTokens: 15000,
                             modelName: "claude-sonnet-4-6",
+                            contextWindow: 200000,
                             contextUtilization: 7.5,
                             pressureLevel: "safe",
                             estimatedCostUSD: nil,

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -414,7 +414,7 @@ struct SessionRowView: View {
                     ContextBar(utilization: metrics.contextUtilization,
                                pressureColor: metrics.contextPressureColor)
                         .frame(maxWidth: 80, maxHeight: 8)
-                    Text(debugMode ? metrics.formattedTokenUsage : metrics.formattedContextUtilization)
+                    Text(metrics.formattedContextUtilization)
                         .font(.system(size: 9, design: .monospaced))
                         .foregroundColor(Color(hex: metrics.contextPressureColor))
                 } else if debugMode, let metrics = session.metrics, metrics.totalTokens > 0 {
@@ -574,7 +574,7 @@ struct SubagentRowView: View {
 
             // Context utilization
             if let metrics = session.metrics, metrics.hasContextData {
-                Text(debugMode ? metrics.formattedTokenUsage : metrics.formattedContextUtilization)
+                Text(metrics.formattedContextUtilization)
                     .font(.caption2)
                     .foregroundColor(Color(hex: metrics.contextPressureColor))
             } else if debugMode, let metrics = session.metrics, metrics.totalTokens > 0 {

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -2,41 +2,12 @@ import SwiftUI
 
 struct SettingsView: View {
     @Binding var isPresented: Bool
-    @AppStorage("sessionTTLMinutes") private var sessionTTLMinutes: Int = 30
     @AppStorage("debugMode") private var debugMode: Bool = false
-
-    private let ttlOptions: [(label: String, value: Int)] = [
-        ("Never", 0),
-        ("15 minutes", 15),
-        ("30 minutes", 30),
-        ("1 hour", 60),
-        ("4 hours", 240),
-    ]
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Settings")
                 .font(.headline)
-
-            Divider()
-
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Session Expiry")
-                    .font(.subheadline)
-                    .foregroundColor(.primary)
-
-                Text("Auto-delete finished sessions after this idle time.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                Picker("Expire after", selection: $sessionTTLMinutes) {
-                    ForEach(ttlOptions, id: \.value) { option in
-                        Text(option.label).tag(option.value)
-                    }
-                }
-                .pickerStyle(.menu)
-                .frame(maxWidth: 200)
-            }
 
             Divider()
 
@@ -57,6 +28,6 @@ struct SettingsView: View {
             }
         }
         .padding(20)
-        .frame(width: 320, height: 260)
+        .frame(width: 320, height: 200)
     }
 }

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -702,6 +702,12 @@
       return 'var(--pressure-low)';
     }
 
+    function formatTokens(n) {
+      if (n < 1000) return n + '';
+      if (n < 1000000) return (n / 1000).toFixed(1) + 'K';
+      return (n / 1000000).toFixed(1) + 'M';
+    }
+
     function esc(s) {
       if (s == null) return '';
       return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -1057,9 +1063,12 @@
 
       // Context %
       const pctEl = el.querySelector('.row-ctx-pct');
-      const pctText = ctxPct > 0 ? ctxPct.toFixed(0) + '%' : '';
+      const totalTok = metrics.total_tokens || 0;
+      const pctText = ctxPct > 0 ? ctxPct.toFixed(0) + '%'
+        : (pressure === 'unknown' && totalTok > 0) ? formatTokens(totalTok) + ' / ?' : '';
       if (pctEl.textContent !== pctText) pctEl.textContent = pctText;
-      pctEl.style.color = ctxPct > 0 ? pressureColor(pressure) : '';
+      pctEl.style.color = ctxPct > 0 ? pressureColor(pressure)
+        : (pressure === 'unknown' && totalTok > 0) ? '#8E8E93' : '';
 
       // Cost
       const costEl = el.querySelector('.row-cost');


### PR DESCRIPTION
## Summary
- Remove hardcoded 200K context window fallback for unknown models — unknown models now report `PressureLevel="unknown"` with raw token counts instead of fabricated utilization percentages
- Add periodic fetch of [LiteLLM's model dataset](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) (2600+ models across 107 providers, no auth required, updated every 1-2 days) — cached locally with 24h TTL
- Merge remote model data into the capacity manager on startup, preserving hand-tuned entries from the embedded JSON
- Show "used / total" token counts (e.g. "94.3K / 1M") in debug mode; unknown models show "100K / ?" in gray
- Remove redundant client-side session expiry setting from macOS app — daemon already owns session lifecycle via ReadySessionTTL

## How it works
1. **On daemon startup**: background goroutine fetches LiteLLM data if cache is stale (>24h)
2. **Each `DefaultCapacityManager()` call**: loads embedded JSON + merges cached remote data
3. **Lookup chain**: direct match → fuzzy → family → remote models → fallback (ContextWindow=0)
4. **Unknown models**: `ContextWindow=0`, `PressureLevel="unknown"`, raw `TotalTokens` still available
5. Both frontends (macOS Swift, web) handle `"unknown"` pressure level gracefully

## Files changed
- **New**: `core/pkg/capacity/remote.go` — LiteLLM fetch, parse, cache, merge
- **New**: `core/pkg/capacity/remote_test.go` — 6 test functions
- **Modified**: `core/pkg/capacity/capacity.go` — `MergeRemoteModels()`, unknown-model handling
- **Modified**: `core/pkg/capacity/default.go` — merge cached remote data on init
- **Modified**: `core/pkg/capacity/model-capacity.json` — fallback `context_window: 0`
- **Modified**: `core/pkg/tailer/tailer.go` — remove hardcoded 200K, return `"unknown"` pressure
- **Modified**: `core/cmd/irrlichd/main.go` — background refresh goroutine
- **Modified**: `core/pkg/tailer/context_utilization_test.go` — updated for new behavior
- **Modified**: `platforms/macos/Irrlicht/Models/SessionState.swift` — decode `context_window`, add `formattedTokenUsage`
- **Modified**: `platforms/macos/Irrlicht/Views/SessionListView.swift` — debug mode token display
- **Modified**: `platforms/macos/Irrlicht/Views/SettingsView.swift` — remove session expiry setting
- **Modified**: `platforms/macos/Irrlicht/Managers/SessionManager.swift` — remove client-side TTL cleanup
- **Modified**: `platforms/web/index.html` — show token count for unknown models

## Test plan
- [x] All existing tests pass (full suite: 15 packages)
- [x] Unknown model returns `PressureLevel="unknown"`, `ContextWindow=0`, raw tokens preserved
- [x] LiteLLM JSON parsing maps fields correctly, provider-prefixed entries filtered
- [x] Merge preserves hand-tuned entries, adds new remote models
- [x] Debug mode shows "ctx: 94.3K / 1M" in debug line, percentage stays next to bar
- [x] Session expiry setting removed, daemon handles lifecycle

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)