### PR TITLE
fix(pre-session): discriminate by PID so neighbours don't suppress new sessions (#113)

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/backoff_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/backoff_test.go
@@ -16,7 +16,7 @@ func TestBackoffConstants(t *testing.T) {
 }
 
 func TestScanner_BackoffFields(t *testing.T) {
-	s := NewScanner("nonexistent-process", "test-adapter", t.TempDir(), 10*time.Millisecond)
+	s := NewScanner("nonexistent-process", "test-adapter", 10*time.Millisecond)
 
 	// Verify initial state.
 	if s.stablePolls != 0 {
@@ -46,19 +46,19 @@ func TestScanner_BackoffFields(t *testing.T) {
 
 func TestNewScanner_DefaultInterval(t *testing.T) {
 	// Passing 0 should use DefaultInterval.
-	s := NewScanner("test", "adapter", "/tmp", 0)
+	s := NewScanner("test", "adapter", 0)
 	if s.interval != DefaultInterval {
 		t.Errorf("interval = %v, want DefaultInterval (%v)", s.interval, DefaultInterval)
 	}
 
 	// Passing a negative value should also use DefaultInterval.
-	s = NewScanner("test", "adapter", "/tmp", -1*time.Second)
+	s = NewScanner("test", "adapter", -1*time.Second)
 	if s.interval != DefaultInterval {
 		t.Errorf("interval = %v, want DefaultInterval (%v) for negative input", s.interval, DefaultInterval)
 	}
 
 	// Passing a positive value should use that value.
-	s = NewScanner("test", "adapter", "/tmp", 2*time.Second)
+	s = NewScanner("test", "adapter", 2*time.Second)
 	if s.interval != 2*time.Second {
 		t.Errorf("interval = %v, want 2s", s.interval)
 	}

--- a/core/adapters/inbound/agents/processlifecycle/scanner.go
+++ b/core/adapters/inbound/agents/processlifecycle/scanner.go
@@ -3,10 +3,13 @@ package processlifecycle
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
 )
 
 // DefaultInterval is the polling interval used when none is specified.
@@ -33,13 +36,9 @@ type Scanner struct {
 	adapter     string // adapter label placed on emitted events
 	interval    time.Duration
 
-	// sessionChecker is an optional function that reports whether a
-	// non-proc session already exists for the given encoded projectDir and
-	// belongs to the given live PID. It is the sole signal consulted by
-	// hasActiveSession; discriminating by PID ensures historical sessions
-	// from prior daemon runs (GH #113) and freshly-written transcripts
-	// belonging to *other* live sessions in the same project don't block
-	// or prematurely supersede this pre-session.
+	// sessionChecker is an optional function that reports whether a real
+	// (non-proc) session for the given projectDir and PID already exists.
+	// Callers typically delegate to HasRealSessionForPID.
 	sessionChecker func(projectDir string, pid int) bool
 
 	mu      sync.Mutex
@@ -67,16 +66,38 @@ func NewScanner(processName, adapter string, interval time.Duration) *Scanner {
 	}
 }
 
-// WithSessionChecker sets a function that reports whether a non-proc session
-// exists for the given encoded projectDir (e.g. "-Users-ingo-projects-foo")
-// AND belongs to the given PID. The checker is the sole signal used by
-// hasActiveSession: it prevents ghost proc sessions for live processes whose
-// real transcript-backed session is already persisted, without suppressing
-// pre-sessions for new processes in projects that merely have historical
-// or concurrently-active neighbour sessions on disk.
+// WithSessionChecker sets a function that reports whether a real
+// (non-proc) session exists for the given projectDir and PID. It is the
+// sole signal used by hasActiveSession to decide whether a pre-session is
+// redundant — discriminating by PID is what prevents historical sessions
+// (GH #113) and concurrently-active neighbour sessions from suppressing
+// new pre-sessions for freshly-opened processes.
 func (s *Scanner) WithSessionChecker(fn func(projectDir string, pid int) bool) *Scanner {
 	s.sessionChecker = fn
 	return s
+}
+
+// HasRealSessionForPID reports whether sessions contains a real
+// (transcript-backed, non-proc) session that belongs to the given PID and
+// whose transcript lives under the given encoded projectDir (e.g.
+// "-Users-ingo-projects-foo"). It is the canonical predicate the Scanner's
+// sessionChecker should delegate to — encoding the "is a proc- pre-session
+// redundant?" policy in one place so production callers and tests cannot
+// drift apart.
+func HasRealSessionForPID(sessions []*session.SessionState, projectDir string, pid int) bool {
+	for _, s := range sessions {
+		if strings.HasPrefix(s.SessionID, "proc-") {
+			continue
+		}
+		if s.PID != pid {
+			continue
+		}
+		if s.TranscriptPath != "" &&
+			filepath.Base(filepath.Dir(s.TranscriptPath)) == projectDir {
+			return true
+		}
+	}
+	return false
 }
 
 // Watch begins polling. It runs an immediate scan then continues on the
@@ -251,19 +272,10 @@ func (s *Scanner) poll() {
 	}
 }
 
-// hasActiveSession returns true if the project directory has an active session
-// belonging to the given PID, as reported by the injected sessionChecker. The
-// checker discriminates by PID so historical sessions from prior daemon runs
-// don't block pre-session creation (GH #113) and so unrelated activity from
-// *other* live sessions in the same project doesn't prematurely supersede this
-// pre-session.
-//
-// A previous version of this function fell back to a project-wide .jsonl mtime
-// check when sessionChecker returned false. That fallback was fundamentally
-// wrong for the supersession path: it picked up writes from any session in the
-// project, not just the transcript owned by this pid, and silently deleted
-// freshly-created pre-sessions whenever a neighbour session was actively being
-// written to. The sessionChecker is now trusted as the sole signal.
+// hasActiveSession returns true iff the injected sessionChecker reports a
+// real session already exists for this projectDir and PID. The per-PID
+// discrimination is what prevents GH #113 (historical sessions on disk) and
+// the neighbour-session supersession bug.
 func (s *Scanner) hasActiveSession(projectDir string, pid int) bool {
 	if projectDir == "" {
 		return false

--- a/core/adapters/inbound/agents/processlifecycle/scanner.go
+++ b/core/adapters/inbound/agents/processlifecycle/scanner.go
@@ -3,9 +3,6 @@ package processlifecycle
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -37,12 +34,15 @@ type Scanner struct {
 	projectsRoot string        // absolute path to ~/.claude/projects (or equivalent)
 	interval     time.Duration
 
-	// sessionChecker is an optional function that reports whether any
-	// non-proc session already exists for the given encoded projectDir.
-	// When set, it is consulted before the file-modification-time fallback
-	// in hasActiveSession so that idle (but alive) sessions suppress ghost
-	// proc creation.
-	sessionChecker func(projectDir string) bool
+	// sessionChecker is an optional function that reports whether a
+	// non-proc session already exists for the given encoded projectDir and
+	// belongs to the given live PID. When set, it is consulted before the
+	// file-modification-time fallback in hasActiveSession so that idle (but
+	// alive) sessions suppress ghost proc creation for the same process.
+	// Discriminating by PID ensures historical sessions from prior daemon
+	// runs do not block pre-session creation for new processes in the same
+	// project (GH #113).
+	sessionChecker func(projectDir string, pid int) bool
 
 	mu      sync.Mutex
 	tracked map[int]trackedProc // pid → pre-session
@@ -71,11 +71,13 @@ func NewScanner(processName, adapter, projectsRoot string, interval time.Duratio
 	}
 }
 
-// WithSessionChecker sets a function that reports whether any non-proc session
-// exists for the given encoded projectDir (e.g. "-Users-ingo-projects-foo").
-// When set, hasActiveSession consults it before the file-modification fallback,
-// preventing ghost proc sessions for directories with idle real sessions.
-func (s *Scanner) WithSessionChecker(fn func(projectDir string) bool) *Scanner {
+// WithSessionChecker sets a function that reports whether a non-proc session
+// exists for the given encoded projectDir (e.g. "-Users-ingo-projects-foo")
+// AND belongs to the given PID. When set, hasActiveSession consults it before
+// the file-modification fallback, preventing ghost proc sessions for the same
+// live process without also suppressing pre-sessions for new processes in
+// projects that merely have historical sessions on disk.
+func (s *Scanner) WithSessionChecker(fn func(projectDir string, pid int) bool) *Scanner {
 	s.sessionChecker = fn
 	return s
 }
@@ -182,7 +184,7 @@ func (s *Scanner) poll() {
 			}
 
 			// Check whether a real transcript has appeared since we last looked.
-			if s.hasActiveSession(projectDir) {
+			if s.hasActiveSession(projectDir, pid) {
 				// Mark as superseded and emit removal. Keep in tracked map
 				// so we don't recreate the pre-session on the next poll.
 				s.mu.Lock()
@@ -202,7 +204,7 @@ func (s *Scanner) poll() {
 		// Skip if an active transcript was recently modified in this project
 		// dir (the file watcher handles those). Old transcripts from previous
 		// sessions are ignored so new processes are still detected.
-		if s.hasActiveSession(projectDir) {
+		if s.hasActiveSession(projectDir, pid) {
 			continue
 		}
 
@@ -252,39 +254,27 @@ func (s *Scanner) poll() {
 	}
 }
 
-// hasActiveSession returns true if the project directory has an active session.
-// It first consults the injected sessionChecker (if set) to catch idle sessions
-// whose transcripts haven't been written recently, then falls back to checking
-// for a recently-modified .jsonl file (within 60 seconds).
-func (s *Scanner) hasActiveSession(projectDir string) bool {
+// hasActiveSession returns true if the project directory has an active session
+// belonging to the given PID, as reported by the injected sessionChecker. The
+// checker discriminates by PID so historical sessions from prior daemon runs
+// don't block pre-session creation (GH #113) and so unrelated activity from
+// *other* live sessions in the same project doesn't prematurely supersede this
+// pre-session.
+//
+// A previous version of this function fell back to a project-wide .jsonl mtime
+// check when sessionChecker returned false. That fallback was fundamentally
+// wrong for the supersession path: it picked up writes from any session in the
+// project, not just the transcript owned by this pid, and silently deleted
+// freshly-created pre-sessions whenever a neighbour session was actively being
+// written to. The sessionChecker is now trusted as the sole signal.
+func (s *Scanner) hasActiveSession(projectDir string, pid int) bool {
 	if projectDir == "" {
 		return false
 	}
-	if s.sessionChecker != nil && s.sessionChecker(projectDir) {
-		return true
-	}
-	if s.projectsRoot == "" {
+	if s.sessionChecker == nil {
 		return false
 	}
-	dir := filepath.Join(s.projectsRoot, projectDir)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	cutoff := time.Now().Add(-60 * time.Second)
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
-			continue
-		}
-		info, err := e.Info()
-		if err != nil {
-			continue
-		}
-		if info.ModTime().After(cutoff) {
-			return true
-		}
-	}
-	return false
+	return s.sessionChecker(projectDir, pid)
 }
 
 // broadcast sends an event to all subscribers non-blocking (drops if full).

--- a/core/adapters/inbound/agents/processlifecycle/scanner.go
+++ b/core/adapters/inbound/agents/processlifecycle/scanner.go
@@ -29,19 +29,17 @@ type trackedProc struct {
 // EventRemoved events so the session can be shown before the first message.
 // It implements inbound.AgentWatcher.
 type Scanner struct {
-	processName  string        // exact process name matched by pgrep -x
-	adapter      string        // adapter label placed on emitted events
-	projectsRoot string        // absolute path to ~/.claude/projects (or equivalent)
-	interval     time.Duration
+	processName string // exact process name matched by pgrep -x
+	adapter     string // adapter label placed on emitted events
+	interval    time.Duration
 
 	// sessionChecker is an optional function that reports whether a
 	// non-proc session already exists for the given encoded projectDir and
-	// belongs to the given live PID. When set, it is consulted before the
-	// file-modification-time fallback in hasActiveSession so that idle (but
-	// alive) sessions suppress ghost proc creation for the same process.
-	// Discriminating by PID ensures historical sessions from prior daemon
-	// runs do not block pre-session creation for new processes in the same
-	// project (GH #113).
+	// belongs to the given live PID. It is the sole signal consulted by
+	// hasActiveSession; discriminating by PID ensures historical sessions
+	// from prior daemon runs (GH #113) and freshly-written transcripts
+	// belonging to *other* live sessions in the same project don't block
+	// or prematurely supersede this pre-session.
 	sessionChecker func(projectDir string, pid int) bool
 
 	mu      sync.Mutex
@@ -56,27 +54,26 @@ type Scanner struct {
 // NewScanner creates a Scanner for the given agent process.
 //   - processName: exact binary name, e.g. "claude"
 //   - adapter:     adapter label, e.g. "claude-code"
-//   - projectsRoot: absolute path to the projects directory, e.g. ~/.claude/projects
 //   - interval:    how often to poll; pass 0 to use DefaultInterval
-func NewScanner(processName, adapter, projectsRoot string, interval time.Duration) *Scanner {
+func NewScanner(processName, adapter string, interval time.Duration) *Scanner {
 	if interval <= 0 {
 		interval = DefaultInterval
 	}
 	return &Scanner{
-		processName:  processName,
-		adapter:      adapter,
-		projectsRoot: projectsRoot,
-		interval:     interval,
-		tracked:      make(map[int]trackedProc),
+		processName: processName,
+		adapter:     adapter,
+		interval:    interval,
+		tracked:     make(map[int]trackedProc),
 	}
 }
 
 // WithSessionChecker sets a function that reports whether a non-proc session
 // exists for the given encoded projectDir (e.g. "-Users-ingo-projects-foo")
-// AND belongs to the given PID. When set, hasActiveSession consults it before
-// the file-modification fallback, preventing ghost proc sessions for the same
-// live process without also suppressing pre-sessions for new processes in
-// projects that merely have historical sessions on disk.
+// AND belongs to the given PID. The checker is the sole signal used by
+// hasActiveSession: it prevents ghost proc sessions for live processes whose
+// real transcript-backed session is already persisted, without suppressing
+// pre-sessions for new processes in projects that merely have historical
+// or concurrently-active neighbour sessions on disk.
 func (s *Scanner) WithSessionChecker(fn func(projectDir string, pid int) bool) *Scanner {
 	s.sessionChecker = fn
 	return s

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -272,7 +272,6 @@ func main() {
 	procScanner := processlifecycle.NewScanner(
 		"claude",
 		claudecode.AdapterName,
-		claudeCodeWatcher.Root(),
 		0, // use default interval
 	)
 	// Suppress ghost proc sessions for live Claude Code processes whose real

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -17,8 +17,6 @@ import (
 	"syscall"
 	"time"
 
-	"strings"
-
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/pkg/capacity"
 	"irrlicht/core/adapters/inbound/agents/codex"
@@ -274,30 +272,17 @@ func main() {
 		claudecode.AdapterName,
 		0, // use default interval
 	)
-	// Suppress ghost proc sessions for live Claude Code processes whose real
-	// (transcript-backed) session is already persisted, even if the transcript
-	// hasn't been written recently. Discrimination by PID is essential: matching
-	// on projectDir alone blocked pre-session creation in any project that ever
-	// had a prior session on disk (GH #113), because historical sessions remain
-	// in the repo for up to MaxSessionAge (default 5 days).
+	// Suppress ghost proc pre-sessions for live Claude Code processes whose
+	// real session is already persisted. The PID discriminator in
+	// HasRealSessionForPID is what prevents historical sessions on disk
+	// (GH #113, within MaxSessionAge) from blocking new processes in the
+	// same project.
 	procScanner.WithSessionChecker(func(projectDir string, pid int) bool {
 		sessions, err := cachedRepo.ListAll()
 		if err != nil {
 			return false
 		}
-		for _, s := range sessions {
-			if strings.HasPrefix(s.SessionID, "proc-") {
-				continue
-			}
-			if s.PID != pid {
-				continue
-			}
-			if s.TranscriptPath != "" &&
-				filepath.Base(filepath.Dir(s.TranscriptPath)) == projectDir {
-				return true
-			}
-		}
-		return false
+		return processlifecycle.HasRealSessionForPID(sessions, projectDir, pid)
 	})
 
 	watchers := []inbound.AgentWatcher{claudeCodeWatcher, codexWatcher, piWatcher, procScanner}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -275,17 +275,22 @@ func main() {
 		claudeCodeWatcher.Root(),
 		0, // use default interval
 	)
-	// Suppress ghost proc sessions for directories that already have a real
-	// (transcript-backed) session, even if the transcript hasn't been written
-	// recently. Without this, idle sessions allow short-lived helper processes
-	// to create spurious proc-<pid> entries in the UI.
-	procScanner.WithSessionChecker(func(projectDir string) bool {
+	// Suppress ghost proc sessions for live Claude Code processes whose real
+	// (transcript-backed) session is already persisted, even if the transcript
+	// hasn't been written recently. Discrimination by PID is essential: matching
+	// on projectDir alone blocked pre-session creation in any project that ever
+	// had a prior session on disk (GH #113), because historical sessions remain
+	// in the repo for up to MaxSessionAge (default 5 days).
+	procScanner.WithSessionChecker(func(projectDir string, pid int) bool {
 		sessions, err := cachedRepo.ListAll()
 		if err != nil {
 			return false
 		}
 		for _, s := range sessions {
 			if strings.HasPrefix(s.SessionID, "proc-") {
+				continue
+			}
+			if s.PID != pid {
 				continue
 			}
 			if s.TranscriptPath != "" &&

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -45,11 +45,8 @@ func TestPreSession_DetectedBeforeTranscript(t *testing.T) {
 	}
 	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
 
-	// Empty projects root — no transcripts exist yet.
-	projectsRoot := realTempDir(t)
-
 	// Wire up: Scanner → SessionDetector (with in-memory stubs).
-	scanner := processlifecycle.NewScanner(processName, "test", projectsRoot, 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond)
 	repo := &memRepo{states: make(map[string]*session.SessionState)}
 
 	detector := services.NewSessionDetector(
@@ -122,7 +119,7 @@ func TestPreSession_ReplacedByRealSession(t *testing.T) {
 	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
 
 	projectsRoot := realTempDir(t)
-	scanner := processlifecycle.NewScanner(processName, "test", projectsRoot, 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond)
 	repo := &memRepo{states: make(map[string]*session.SessionState)}
 
 	// Also wire a mock transcript watcher so we can inject a real session event.
@@ -231,7 +228,7 @@ func TestPreSession_CreatedDespiteHistoricalSession(t *testing.T) {
 		TranscriptPath: filepath.Join(projectsRoot, projectDir, "old.jsonl"),
 	})
 
-	scanner := processlifecycle.NewScanner(processName, "test", projectsRoot, 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond)
 	// Mirror the production sessionChecker in core/cmd/irrlichd/main.go:
 	// match on both projectDir and PID so historical sessions don't suppress
 	// new pre-sessions for freshly-opened processes.
@@ -331,7 +328,7 @@ func TestPreSession_SurvivesNeighbourSessionActivity(t *testing.T) {
 
 	repo := &memRepo{states: make(map[string]*session.SessionState)}
 
-	scanner := processlifecycle.NewScanner(processName, "test", projectsRoot, 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond)
 	// Production-equivalent sessionChecker: PID-aware. No non-proc session
 	// in the repo has our target PID, so this returns false for every call.
 	scanner.WithSessionChecker(func(pd string, pid int) bool {
@@ -404,8 +401,7 @@ func TestPreSession_RemovedOnProcessExit(t *testing.T) {
 		t.Fatalf("start: %v", err)
 	}
 
-	projectsRoot := realTempDir(t)
-	scanner := processlifecycle.NewScanner(processName, "test", projectsRoot, 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond)
 	repo := &memRepo{states: make(map[string]*session.SessionState)}
 
 	detector := services.NewSessionDetector(

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -186,6 +186,206 @@ func TestPreSession_ReplacedByRealSession(t *testing.T) {
 	}
 }
 
+// TestPreSession_CreatedDespiteHistoricalSession is the regression test for
+// GH #113: opening Claude Code in a project that already has a prior session
+// on disk (with a different PID) must still produce a pre-session for the new
+// process. Before the fix, the projectDir-only sessionChecker returned true
+// for the historical session and scanner.poll() silently skipped pre-session
+// creation.
+func TestPreSession_CreatedDespiteHistoricalSession(t *testing.T) {
+	processName := fmt.Sprintf("irrlicht-e2e-%d", os.Getpid())
+
+	binDir := realTempDir(t)
+	binPath := filepath.Join(binDir, processName)
+	if err := os.Symlink("/bin/sleep", binPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	fakeCWD := realTempDir(t)
+	cmd := exec.Command(binPath, "60")
+	cmd.Dir = fakeCWD
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
+
+	// Pre-seed memRepo with a historical session for the SAME project dir
+	// but a DIFFERENT PID — simulating a session from a prior daemon run
+	// that's still within MaxSessionAge. Use os.Getpid() (the test process
+	// itself) as the historical PID: it's guaranteed alive, so pidMgr.SeedPIDs
+	// leaves it in the repo, and it's guaranteed different from the fake
+	// claude process PID so the new sessionChecker correctly returns false
+	// for the live process. The transcript file does not need to exist on
+	// disk; the callback only reads the persisted state.
+	projectsRoot := realTempDir(t)
+	projectDir := processlifecycle.CWDToProjectDir(fakeCWD)
+	histPID := os.Getpid()
+	if histPID == cmd.Process.Pid {
+		t.Fatalf("test PID unexpectedly matches fake process PID")
+	}
+	repo := &memRepo{states: make(map[string]*session.SessionState)}
+	repo.Save(&session.SessionState{
+		SessionID:      "historical-aaaa-bbbb-cccc-dddd",
+		State:          session.StateReady,
+		PID:            histPID,
+		TranscriptPath: filepath.Join(projectsRoot, projectDir, "old.jsonl"),
+	})
+
+	scanner := processlifecycle.NewScanner(processName, "test", projectsRoot, 200*time.Millisecond)
+	// Mirror the production sessionChecker in core/cmd/irrlichd/main.go:
+	// match on both projectDir and PID so historical sessions don't suppress
+	// new pre-sessions for freshly-opened processes.
+	scanner.WithSessionChecker(func(pd string, pid int) bool {
+		sessions, err := repo.ListAll()
+		if err != nil {
+			return false
+		}
+		for _, s := range sessions {
+			if len(s.SessionID) >= 5 && s.SessionID[:5] == "proc-" {
+				continue
+			}
+			if s.PID != pid {
+				continue
+			}
+			if s.TranscriptPath != "" &&
+				filepath.Base(filepath.Dir(s.TranscriptPath)) == pd {
+				return true
+			}
+		}
+		return false
+	})
+
+	detector := services.NewSessionDetector(
+		[]inbound.AgentWatcher{scanner},
+		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
+		"test", 0, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	go scanner.Watch(ctx)
+	go detector.Run(ctx)
+
+	// The new pre-session for the live PID must appear even though a
+	// historical session exists for the same project.
+	expectedID := fmt.Sprintf("proc-%d", cmd.Process.Pid)
+	if !waitForSession(repo, expectedID, 5*time.Second) {
+		t.Fatalf("regression: pre-session %s never appeared while historical session for project %s (PID=%d) was present", expectedID, projectDir, histPID)
+	}
+
+	// The historical session must still be present — the scanner should not
+	// touch sessions that don't belong to any live PID it observed.
+	if s, _ := repo.Load("historical-aaaa-bbbb-cccc-dddd"); s == nil {
+		t.Errorf("historical session should still be in repo, but was removed")
+	}
+}
+
+// TestPreSession_SurvivesNeighbourSessionActivity is the regression test for
+// the mtime-fallback bug observed live on GH #113: after the PID-aware
+// sessionChecker landed, pre-sessions were still being wrongly superseded
+// whenever *another* session in the same project dir had a freshly-written
+// transcript. scanner.hasActiveSession used to fall back to a project-wide
+// jsonl mtime check, which couldn't discriminate which jsonl belonged to
+// which PID. The scanner would mark the pre-session superseded and
+// SessionDetector.onRemoved would delete it entirely, leaving the user's new
+// Claude Code session invisible until they sent their first message.
+//
+// This test creates a fake claude process, seeds a neighbour .jsonl file
+// with a fresh mtime (simulating another active session in the same project
+// dir), and verifies the pre-session (a) appears AND (b) is still alive
+// after several scanner polls.
+func TestPreSession_SurvivesNeighbourSessionActivity(t *testing.T) {
+	processName := fmt.Sprintf("irrlicht-e2e-%d", os.Getpid())
+
+	binDir := realTempDir(t)
+	binPath := filepath.Join(binDir, processName)
+	if err := os.Symlink("/bin/sleep", binPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	fakeCWD := realTempDir(t)
+	cmd := exec.Command(binPath, "60")
+	cmd.Dir = fakeCWD
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
+
+	// Create a neighbour .jsonl file with a fresh mtime inside the project
+	// dir — this simulates another live Claude Code session writing to its
+	// own transcript while our target process has none yet.
+	projectsRoot := realTempDir(t)
+	projectDir := processlifecycle.CWDToProjectDir(fakeCWD)
+	projPath := filepath.Join(projectsRoot, projectDir)
+	if err := os.MkdirAll(projPath, 0755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+	neighbourJSONL := filepath.Join(projPath, "neighbour-aaaa-bbbb-cccc-dddd.jsonl")
+	if err := os.WriteFile(neighbourJSONL, []byte(`{"type":"user"}`+"\n"), 0644); err != nil {
+		t.Fatalf("write neighbour jsonl: %v", err)
+	}
+	// Ensure mtime is "now" so it falls inside the old 60s mtime window.
+	now := time.Now()
+	_ = os.Chtimes(neighbourJSONL, now, now)
+
+	repo := &memRepo{states: make(map[string]*session.SessionState)}
+
+	scanner := processlifecycle.NewScanner(processName, "test", projectsRoot, 200*time.Millisecond)
+	// Production-equivalent sessionChecker: PID-aware. No non-proc session
+	// in the repo has our target PID, so this returns false for every call.
+	scanner.WithSessionChecker(func(pd string, pid int) bool {
+		sessions, err := repo.ListAll()
+		if err != nil {
+			return false
+		}
+		for _, s := range sessions {
+			if len(s.SessionID) >= 5 && s.SessionID[:5] == "proc-" {
+				continue
+			}
+			if s.PID != pid {
+				continue
+			}
+			if s.TranscriptPath != "" &&
+				filepath.Base(filepath.Dir(s.TranscriptPath)) == pd {
+				return true
+			}
+		}
+		return false
+	})
+
+	detector := services.NewSessionDetector(
+		[]inbound.AgentWatcher{scanner},
+		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
+		"test", 0, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	go scanner.Watch(ctx)
+	go detector.Run(ctx)
+
+	// Pre-session should appear…
+	expectedID := fmt.Sprintf("proc-%d", cmd.Process.Pid)
+	if !waitForSession(repo, expectedID, 5*time.Second) {
+		t.Fatalf("timeout: pre-session %s never appeared (initial detection suppressed?)", expectedID)
+	}
+
+	// …and survive several scanner polls despite the neighbour jsonl
+	// having a fresh mtime. Poll interval is 200ms, so wait 1.5s → ~7 polls.
+	// Continuously refresh the neighbour jsonl's mtime to ensure the old
+	// bug's 60s window would always trip.
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		_ = os.Chtimes(neighbourJSONL, time.Now(), time.Now())
+		time.Sleep(150 * time.Millisecond)
+		if state, _ := repo.Load(expectedID); state == nil {
+			t.Fatalf("regression: pre-session %s was removed while neighbour jsonl had fresh mtime — scanner's hasActiveSession mtime fallback reintroduced", expectedID)
+		}
+	}
+}
+
 // TestPreSession_RemovedOnProcessExit verifies that if the process exits
 // without ever creating a transcript, the pre-session is deleted from the repo.
 func TestPreSession_RemovedOnProcessExit(t *testing.T) {

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -184,36 +184,15 @@ func TestPreSession_ReplacedByRealSession(t *testing.T) {
 }
 
 // TestPreSession_CreatedDespiteHistoricalSession is the regression test for
-// GH #113: opening Claude Code in a project that already has a prior session
-// on disk (with a different PID) must still produce a pre-session for the new
-// process. Before the fix, the projectDir-only sessionChecker returned true
-// for the historical session and scanner.poll() silently skipped pre-session
-// creation.
+// GH #113: a prior session on disk with a different PID must not block
+// pre-session creation for a freshly-opened process in the same project.
 func TestPreSession_CreatedDespiteHistoricalSession(t *testing.T) {
-	processName := fmt.Sprintf("irrlicht-e2e-%d", os.Getpid())
+	cmd, fakeCWD := startFakeClaudeProcess(t)
 
-	binDir := realTempDir(t)
-	binPath := filepath.Join(binDir, processName)
-	if err := os.Symlink("/bin/sleep", binPath); err != nil {
-		t.Fatalf("symlink: %v", err)
-	}
-
-	fakeCWD := realTempDir(t)
-	cmd := exec.Command(binPath, "60")
-	cmd.Dir = fakeCWD
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start: %v", err)
-	}
-	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
-
-	// Pre-seed memRepo with a historical session for the SAME project dir
-	// but a DIFFERENT PID — simulating a session from a prior daemon run
-	// that's still within MaxSessionAge. Use os.Getpid() (the test process
-	// itself) as the historical PID: it's guaranteed alive, so pidMgr.SeedPIDs
-	// leaves it in the repo, and it's guaranteed different from the fake
-	// claude process PID so the new sessionChecker correctly returns false
-	// for the live process. The transcript file does not need to exist on
-	// disk; the callback only reads the persisted state.
+	// Seed memRepo with a historical session using os.Getpid() as its PID
+	// so it's guaranteed alive (pidMgr.SeedPIDs keeps it) AND guaranteed
+	// different from the fake claude PID (the new sessionChecker correctly
+	// returns false for the live process).
 	projectsRoot := realTempDir(t)
 	projectDir := processlifecycle.CWDToProjectDir(fakeCWD)
 	histPID := os.Getpid()
@@ -228,29 +207,8 @@ func TestPreSession_CreatedDespiteHistoricalSession(t *testing.T) {
 		TranscriptPath: filepath.Join(projectsRoot, projectDir, "old.jsonl"),
 	})
 
-	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond)
-	// Mirror the production sessionChecker in core/cmd/irrlichd/main.go:
-	// match on both projectDir and PID so historical sessions don't suppress
-	// new pre-sessions for freshly-opened processes.
-	scanner.WithSessionChecker(func(pd string, pid int) bool {
-		sessions, err := repo.ListAll()
-		if err != nil {
-			return false
-		}
-		for _, s := range sessions {
-			if len(s.SessionID) >= 5 && s.SessionID[:5] == "proc-" {
-				continue
-			}
-			if s.PID != pid {
-				continue
-			}
-			if s.TranscriptPath != "" &&
-				filepath.Base(filepath.Dir(s.TranscriptPath)) == pd {
-				return true
-			}
-		}
-		return false
-	})
+	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond)
+	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
 	detector := services.NewSessionDetector(
 		[]inbound.AgentWatcher{scanner},
@@ -264,54 +222,28 @@ func TestPreSession_CreatedDespiteHistoricalSession(t *testing.T) {
 	go scanner.Watch(ctx)
 	go detector.Run(ctx)
 
-	// The new pre-session for the live PID must appear even though a
-	// historical session exists for the same project.
 	expectedID := fmt.Sprintf("proc-%d", cmd.Process.Pid)
 	if !waitForSession(repo, expectedID, 5*time.Second) {
 		t.Fatalf("regression: pre-session %s never appeared while historical session for project %s (PID=%d) was present", expectedID, projectDir, histPID)
 	}
 
-	// The historical session must still be present — the scanner should not
-	// touch sessions that don't belong to any live PID it observed.
 	if s, _ := repo.Load("historical-aaaa-bbbb-cccc-dddd"); s == nil {
 		t.Errorf("historical session should still be in repo, but was removed")
 	}
 }
 
 // TestPreSession_SurvivesNeighbourSessionActivity is the regression test for
-// the mtime-fallback bug observed live on GH #113: after the PID-aware
-// sessionChecker landed, pre-sessions were still being wrongly superseded
-// whenever *another* session in the same project dir had a freshly-written
-// transcript. scanner.hasActiveSession used to fall back to a project-wide
-// jsonl mtime check, which couldn't discriminate which jsonl belonged to
-// which PID. The scanner would mark the pre-session superseded and
-// SessionDetector.onRemoved would delete it entirely, leaving the user's new
-// Claude Code session invisible until they sent their first message.
-//
-// This test creates a fake claude process, seeds a neighbour .jsonl file
-// with a fresh mtime (simulating another active session in the same project
-// dir), and verifies the pre-session (a) appears AND (b) is still alive
-// after several scanner polls.
+// the mtime-fallback bug: scanner.hasActiveSession used to fall back to a
+// project-wide jsonl mtime check that couldn't discriminate which transcript
+// belonged to which PID, so a freshly-written neighbour transcript would
+// wrongly mark our pre-session as superseded and SessionDetector.onRemoved
+// would delete it.
 func TestPreSession_SurvivesNeighbourSessionActivity(t *testing.T) {
-	processName := fmt.Sprintf("irrlicht-e2e-%d", os.Getpid())
+	cmd, fakeCWD := startFakeClaudeProcess(t)
 
-	binDir := realTempDir(t)
-	binPath := filepath.Join(binDir, processName)
-	if err := os.Symlink("/bin/sleep", binPath); err != nil {
-		t.Fatalf("symlink: %v", err)
-	}
-
-	fakeCWD := realTempDir(t)
-	cmd := exec.Command(binPath, "60")
-	cmd.Dir = fakeCWD
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start: %v", err)
-	}
-	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
-
-	// Create a neighbour .jsonl file with a fresh mtime inside the project
-	// dir — this simulates another live Claude Code session writing to its
-	// own transcript while our target process has none yet.
+	// Simulate another active session in the same project by touching a
+	// neighbour .jsonl with a fresh mtime — this is exactly what the old
+	// 60s mtime window would pick up and wrongly attribute to our PID.
 	projectsRoot := realTempDir(t)
 	projectDir := processlifecycle.CWDToProjectDir(fakeCWD)
 	projPath := filepath.Join(projectsRoot, projectDir)
@@ -322,34 +254,12 @@ func TestPreSession_SurvivesNeighbourSessionActivity(t *testing.T) {
 	if err := os.WriteFile(neighbourJSONL, []byte(`{"type":"user"}`+"\n"), 0644); err != nil {
 		t.Fatalf("write neighbour jsonl: %v", err)
 	}
-	// Ensure mtime is "now" so it falls inside the old 60s mtime window.
 	now := time.Now()
 	_ = os.Chtimes(neighbourJSONL, now, now)
 
 	repo := &memRepo{states: make(map[string]*session.SessionState)}
-
-	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond)
-	// Production-equivalent sessionChecker: PID-aware. No non-proc session
-	// in the repo has our target PID, so this returns false for every call.
-	scanner.WithSessionChecker(func(pd string, pid int) bool {
-		sessions, err := repo.ListAll()
-		if err != nil {
-			return false
-		}
-		for _, s := range sessions {
-			if len(s.SessionID) >= 5 && s.SessionID[:5] == "proc-" {
-				continue
-			}
-			if s.PID != pid {
-				continue
-			}
-			if s.TranscriptPath != "" &&
-				filepath.Base(filepath.Dir(s.TranscriptPath)) == pd {
-				return true
-			}
-		}
-		return false
-	})
+	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond)
+	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
 	detector := services.NewSessionDetector(
 		[]inbound.AgentWatcher{scanner},
@@ -363,22 +273,19 @@ func TestPreSession_SurvivesNeighbourSessionActivity(t *testing.T) {
 	go scanner.Watch(ctx)
 	go detector.Run(ctx)
 
-	// Pre-session should appear…
 	expectedID := fmt.Sprintf("proc-%d", cmd.Process.Pid)
 	if !waitForSession(repo, expectedID, 5*time.Second) {
 		t.Fatalf("timeout: pre-session %s never appeared (initial detection suppressed?)", expectedID)
 	}
 
-	// …and survive several scanner polls despite the neighbour jsonl
-	// having a fresh mtime. Poll interval is 200ms, so wait 1.5s → ~7 polls.
-	// Continuously refresh the neighbour jsonl's mtime to ensure the old
-	// bug's 60s window would always trip.
+	// Continuously refresh the neighbour mtime across several scanner polls
+	// (200ms interval) to ensure the old 60s window would always be tripped.
 	deadline := time.Now().Add(1500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		_ = os.Chtimes(neighbourJSONL, time.Now(), time.Now())
 		time.Sleep(150 * time.Millisecond)
 		if state, _ := repo.Load(expectedID); state == nil {
-			t.Fatalf("regression: pre-session %s was removed while neighbour jsonl had fresh mtime — scanner's hasActiveSession mtime fallback reintroduced", expectedID)
+			t.Fatalf("regression: pre-session %s was removed while neighbour jsonl had fresh mtime — mtime fallback reintroduced", expectedID)
 		}
 	}
 }
@@ -469,6 +376,46 @@ func waitForSession(repo *memRepo, id string, timeout time.Duration) bool {
 	}
 }
 
+// fakeProcessName returns a deterministic per-run process name that won't
+// collide with a real "claude" binary pgrep picks up.
+func fakeProcessName() string {
+	return fmt.Sprintf("irrlicht-e2e-%d", os.Getpid())
+}
+
+// startFakeClaudeProcess symlinks /bin/sleep under a unique name so pgrep -x
+// sees our test-controlled "claude" stand-in, starts it with a controlled
+// CWD, and registers a t.Cleanup to kill and reap it. Returns the running
+// command and its CWD.
+func startFakeClaudeProcess(t *testing.T) (*exec.Cmd, string) {
+	t.Helper()
+	name := fakeProcessName()
+	binDir := realTempDir(t)
+	binPath := filepath.Join(binDir, name)
+	if err := os.Symlink("/bin/sleep", binPath); err != nil {
+		t.Fatalf("symlink /bin/sleep → %s: %v", binPath, err)
+	}
+	fakeCWD := realTempDir(t)
+	cmd := exec.Command(binPath, "60")
+	cmd.Dir = fakeCWD
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start fake process: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _ = cmd.Wait() })
+	return cmd, fakeCWD
+}
+
+// realSessionCheckerFor returns a production-equivalent sessionChecker
+// backed by the given memRepo — the same predicate
+// processlifecycle.HasRealSessionForPID used by the daemon.
+func realSessionCheckerFor(repo *memRepo) func(string, int) bool {
+	return func(projectDir string, pid int) bool {
+		sessions, err := repo.ListAll()
+		if err != nil {
+			return false
+		}
+		return processlifecycle.HasRealSessionForPID(sessions, projectDir, pid)
+	}
+}
 
 // --- stubs -------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes ingo-eichhorst/Irrlicht#113 plus a second-order bug discovered during live verification. Together these kept `proc-<pid>` pre-sessions from appearing whenever a new Claude Code process opened in a project that already had a session on disk or a neighbour with recent transcript activity — hiding every new session from the menu bar until the user sent their first message.

## Commits

| SHA | Scope |
| --- | --- |
| `24a22e7` | **fix**: thread PID through `sessionChecker`, remove mtime fallback, add 2 regression tests |
| `ffac93c` | **refactor**: remove dead `projectsRoot` field + constructor parameter, refresh stale doc comments |
| `707b226` | **refactor**: extract `HasRealSessionForPID` + test helpers, shorten verbose docs |

## Bug 1 — projectDir-only match (reported in #113)

`sessionChecker` in `core/cmd/irrlichd/main.go` matched sessions by `projectDir` alone, so any historical session on disk (within the default 5-day `MaxSessionAge`) blocked pre-session creation for every new claude process in that project.

**Fix**: thread the polling PID through `scanner.hasActiveSession` → `sessionChecker` and require `s.PID == pid` in the match condition.

## Bug 2 — project-wide mtime fallback (discovered during verification)

After fixing bug 1, a live test showed `proc-21130` appearing correctly at `23:16:07` and then being silently removed 30s later. Root cause: `scanner.hasActiveSession` also fell back to a project-wide `.jsonl` mtime check that returned `true` whenever ANY transcript in the dir had been modified within 60s — including transcripts owned by other live sessions. This both suppressed initial pre-session creation when a neighbour was active AND marked freshly-created pre-sessions as superseded on the next poll, so `onRemoved` deleted them entirely (`session_detector.go:489` — pre-sessions have no `TranscriptPath`, so removal = delete).

**Fix**: remove the mtime fallback entirely. The PID-aware `sessionChecker` already covers every scenario it was trying to catch (idle real sessions, daemon-restart seeding).

## Architecture

`processlifecycle.HasRealSessionForPID(sessions, projectDir, pid)` now encodes the "is a proc- pre-session redundant?" predicate in one place. Both production (`cmd/irrlichd/main.go`) and the e2e tests delegate to it, so they cannot drift apart. This also killed a cross-file inconsistency where production used `strings.HasPrefix` and tests had been open-coding `s.SessionID[:5] == "proc-"`.

## Files changed

```
core/adapters/inbound/agents/processlifecycle/scanner.go        |  80 +++----
core/adapters/inbound/agents/processlifecycle/backoff_test.go   |   8 +-
core/cmd/irrlichd/main.go                                       |  19 +-
core/e2e/presession_test.go                                     | 210 ++++++++++++++++-
```

Net across the three commits: `+185 / −110`, most of which is the two new regression tests.

## Regression tests

Both live in `core/e2e/presession_test.go` and both were test-the-test verified to fail when their respective bug is reintroduced:

- **`TestPreSession_CreatedDespiteHistoricalSession`** — pre-seeds memRepo with a historical session using a different (live) PID and asserts the new `proc-<pid>` still appears. Uses `os.Getpid()` as the historical PID so `pidMgr.SeedPIDs` doesn't clean it up.
- **`TestPreSession_SurvivesNeighbourSessionActivity`** — creates a neighbour `.jsonl` with a continuously-refreshed fresh mtime and asserts the pre-session both appears AND survives several scanner polls.

## Verification

```
cd core && go build ./...                      # clean
cd core && go vet ./...                        # clean
cd core && go test ./...                       # all 18 packages green
cd core && go test ./e2e/ -run TestPreSession  # 5/5 pass
```

**Live**: dev daemon rebuilt and restarted. New Claude Code process opened in `/Users/ingo/projects/irrlicht` while another active session was writing to its transcript produces a stable `proc-<pid>` immediately in both `irrlicht-ls` and the `/api/v1/sessions` endpoint.

Log comparison before/after fix 2:

```
# Before (bug 2):
23:16:07.513  proc-21130  new session detected
23:16:07.800  proc-21130  discovered pid 21130
23:16:38.396  proc-21130  session removed          ← mtime fallback superseded it

# After:
23:32:23.364  proc-21130  new session detected
23:32:23.654  proc-21130  discovered pid 21130
                          (no removal — stable)
```

## Out of scope (follow-up candidates)

- `cleanupPreSessionsForProject` (`session_detector.go:692`) deletes **all** `proc-*` sessions in the project dir when any real transcript arrives. If two new Claude Code processes open in the same project at roughly the same time, the one whose transcript lands first wrongly deletes the other's pre-session. PID discrimination would fix this too, but it's a separate bug with its own review surface.
- `filesystem.CachedSessionRepository.ListAll` deep-copies every session via JSON round-trip on every call. The new `HasRealSessionForPID` only reads 3 fields and never mutates, so a read-only `ListAllView()` method would be cheaper. Agent estimated the savings at ~50-100µs/sec — not critical at current scale, not worth the interface churn now.

## Test plan

- [x] Unit + integration + e2e tests pass (18/18 packages green, 5/5 pre-session tests green)
- [x] Full build + vet clean
- [x] Live manual reproduction of #113 (prior session on disk scenario)
- [x] Live verification of bug 2 (neighbour session activity scenario)
- [x] Daemon-restart regression (original 0243172 scenario — no duplicate pre-session)
- [x] Dev daemon rebuilt from refactored code and serving sessions correctly

Closes #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)