### PR TITLE
fix(claudecode): use ~/.claude/sessions metadata for PID discovery (#109)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/adapter.go
+++ b/core/adapters/inbound/agents/claudecode/adapter.go
@@ -11,6 +11,10 @@ import (
 // AdapterName identifies sessions originating from Claude Code.
 const AdapterName = "claude-code"
 
+// ProcessName is the OS-level executable name for Claude Code, used by
+// PID-discovery lookups (pgrep, etc.). Distinct from AdapterName.
+const ProcessName = "claude"
+
 // projectsDir is the path relative to $HOME where Claude Code stores transcripts.
 const projectsDir = ".claude/projects"
 

--- a/core/adapters/inbound/agents/claudecode/pid.go
+++ b/core/adapters/inbound/agents/claudecode/pid.go
@@ -25,11 +25,10 @@ func defaultSessionsDir() string {
 }
 
 // claudeSessionMeta mirrors the on-disk schema of ~/.claude/sessions/<pid>.json.
-// Only the fields we need are declared.
+// Only the fields we consume are declared; json.Unmarshal ignores the rest.
 type claudeSessionMeta struct {
 	PID       int    `json:"pid"`
 	SessionID string `json:"sessionId"`
-	CWD       string `json:"cwd"`
 }
 
 // DiscoverPID finds the Claude Code process owning a session. It prefers an
@@ -104,7 +103,7 @@ func DiscoverPID(cwd, transcriptPath string, disambiguate func([]int) int) (int,
 			return 0
 		}
 	}
-	return discoverByCWD("claude", cwd, wrapped)
+	return discoverByCWD(ProcessName, cwd, wrapped)
 }
 
 // sessionIDFromTranscript extracts Claude's canonical session UUID from a

--- a/core/adapters/inbound/agents/claudecode/pid.go
+++ b/core/adapters/inbound/agents/claudecode/pid.go
@@ -1,11 +1,153 @@
 package claudecode
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 )
 
-// DiscoverPID finds the Claude Code process owning a session by matching
-// "claude" processes whose CWD matches the session's working directory.
-func DiscoverPID(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
-	return processlifecycle.DiscoverPIDByCWD("claude", cwd, disambiguate)
+// sessionsDir is the directory Claude Code writes per-process metadata files to.
+// Each live Claude process owns ~/.claude/sessions/<pid>.json containing
+// {"pid":N,"sessionId":"<uuid>","cwd":"...","startedAt":...}.
+// Overridable in tests via the test helper in pid_test.go.
+var sessionsDir = defaultSessionsDir()
+
+func defaultSessionsDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude", "sessions")
 }
+
+// claudeSessionMeta mirrors the on-disk schema of ~/.claude/sessions/<pid>.json.
+// Only the fields we need are declared.
+type claudeSessionMeta struct {
+	PID       int    `json:"pid"`
+	SessionID string `json:"sessionId"`
+	CWD       string `json:"cwd"`
+}
+
+// DiscoverPID finds the Claude Code process owning a session. It prefers an
+// authoritative lookup in ~/.claude/sessions/<pid>.json (where Claude writes a
+// direct PID↔sessionId mapping for every live process) and falls back to
+// CWD-based matching only when that metadata is missing.
+//
+// The CWD fallback is restricted: if more than one live Claude process matches
+// the CWD after excluding PIDs that belong to other sessions (per metadata),
+// DiscoverPID returns 0 (unknown — retry later) rather than guessing. This
+// prevents the flap loop in issue #109 where cwd-only matching would bind a
+// new transcript to a PID already legitimately owned by another session,
+// triggering destructive duplicate-PID cleanup.
+func DiscoverPID(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
+	wantSessionID := sessionIDFromTranscript(transcriptPath)
+
+	// Layer 1: authoritative metadata lookup.
+	// Scan ~/.claude/sessions/*.json once, collecting PIDs that some metadata
+	// file owns (for negative-filtering the fallback) and looking for an
+	// exact sessionId match.
+	claimedByOthers := make(map[int]bool)
+	if wantSessionID != "" && sessionsDir != "" {
+		entries, err := os.ReadDir(sessionsDir)
+		if err == nil {
+			for _, e := range entries {
+				if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+					continue
+				}
+				meta, ok := readSessionMeta(filepath.Join(sessionsDir, e.Name()))
+				if !ok {
+					continue
+				}
+				if !pidAlive(meta.PID) {
+					continue
+				}
+				if meta.SessionID == wantSessionID {
+					return meta.PID, nil
+				}
+				// A live Claude process owns this PID for a different sessionId;
+				// exclude it from the cwd fallback below.
+				claimedByOthers[meta.PID] = true
+			}
+		}
+	}
+
+	// Layer 2: restricted CWD fallback.
+	// Used when the metadata file for this session hasn't appeared yet (brief
+	// startup window) or when transcriptPath is empty. Never guesses between
+	// competing candidates — DiscoverPIDWithRetry will retry shortly.
+	wrapped := func(pids []int) int {
+		filtered := pids[:0:0]
+		for _, p := range pids {
+			if claimedByOthers[p] {
+				continue
+			}
+			filtered = append(filtered, p)
+		}
+		switch len(filtered) {
+		case 0:
+			return 0
+		case 1:
+			return filtered[0]
+		default:
+			// Ambiguous: multiple live claude processes share this cwd and
+			// none are disambiguated by metadata. Returning 0 causes the
+			// caller to retry, giving Claude time to write its metadata file.
+			return 0
+		}
+	}
+	// The disambiguate arg from the caller (PIDManager.TryDiscoverPID) is
+	// deliberately ignored: its "prefer unclaimed, else highest PID" strategy
+	// is the exact behavior that lets a new session steal a rival's PID.
+	// The wrapped callback above enforces the stricter unambiguous rule.
+	_ = disambiguate
+	return discoverByCWD("claude", cwd, wrapped)
+}
+
+// sessionIDFromTranscript extracts Claude's canonical session UUID from a
+// transcript path of the form .../<sessionID>.jsonl. Returns "" when the path
+// is empty or doesn't look like a Claude transcript.
+func sessionIDFromTranscript(path string) string {
+	if path == "" {
+		return ""
+	}
+	base := filepath.Base(path)
+	if !strings.HasSuffix(base, ".jsonl") {
+		return ""
+	}
+	return strings.TrimSuffix(base, ".jsonl")
+}
+
+// readSessionMeta reads and parses a single ~/.claude/sessions/<pid>.json file.
+// Returns ok=false on any I/O or decode error — stale/garbage files are simply
+// skipped.
+func readSessionMeta(path string) (claudeSessionMeta, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return claudeSessionMeta{}, false
+	}
+	var meta claudeSessionMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return claudeSessionMeta{}, false
+	}
+	if meta.PID <= 0 || meta.SessionID == "" {
+		return claudeSessionMeta{}, false
+	}
+	return meta, true
+}
+
+// pidAlive returns true if signal 0 can be delivered to pid (i.e. the process
+// exists and the caller has permission). Overridable in tests.
+var pidAlive = func(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
+
+// discoverByCWD is the fallback CWD-matching implementation. It's a package
+// variable so tests can inject a stub in place of the real pgrep+lsof call.
+var discoverByCWD = processlifecycle.DiscoverPIDByCWD

--- a/core/adapters/inbound/agents/claudecode/pid.go
+++ b/core/adapters/inbound/agents/claudecode/pid.go
@@ -79,8 +79,13 @@ func DiscoverPID(cwd, transcriptPath string, disambiguate func([]int) int) (int,
 	// Used when the metadata file for this session hasn't appeared yet (brief
 	// startup window) or when transcriptPath is empty. Never guesses between
 	// competing candidates — DiscoverPIDWithRetry will retry shortly.
+	//
+	// The disambiguate arg from the caller (PIDManager.TryDiscoverPID) is
+	// deliberately ignored: its "prefer unclaimed, else highest PID" strategy
+	// is the exact behavior that lets a new session steal a rival's PID.
+	// The wrapped callback below enforces the stricter unambiguous rule.
 	wrapped := func(pids []int) int {
-		filtered := pids[:0:0]
+		filtered := make([]int, 0, len(pids))
 		for _, p := range pids {
 			if claimedByOthers[p] {
 				continue
@@ -99,11 +104,6 @@ func DiscoverPID(cwd, transcriptPath string, disambiguate func([]int) int) (int,
 			return 0
 		}
 	}
-	// The disambiguate arg from the caller (PIDManager.TryDiscoverPID) is
-	// deliberately ignored: its "prefer unclaimed, else highest PID" strategy
-	// is the exact behavior that lets a new session steal a rival's PID.
-	// The wrapped callback above enforces the stricter unambiguous rule.
-	_ = disambiguate
 	return discoverByCWD("claude", cwd, wrapped)
 }
 

--- a/core/adapters/inbound/agents/claudecode/pid_test.go
+++ b/core/adapters/inbound/agents/claudecode/pid_test.go
@@ -40,10 +40,13 @@ func withTestDeps(t *testing.T, alive map[int]bool, fallbackPids []int) string {
 	return dir
 }
 
-func writeMeta(t *testing.T, dir string, pid int, sessionID, cwd string) {
+func writeMeta(t *testing.T, dir string, pid int, sessionID string) {
 	t.Helper()
-	// Mirror Claude's naming: ~/.claude/sessions/<pid>.json
-	meta := claudeSessionMeta{PID: pid, SessionID: sessionID, CWD: cwd}
+	// Mirror Claude's on-disk schema at ~/.claude/sessions/<pid>.json.
+	// We intentionally write only the fields DiscoverPID consumes; real
+	// files include cwd/startedAt/kind/entrypoint which json.Unmarshal
+	// silently drops.
+	meta := claudeSessionMeta{PID: pid, SessionID: sessionID}
 	data, err := json.Marshal(meta)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -61,7 +64,7 @@ func transcriptFor(sessionID string) string {
 func TestDiscoverPID_StrongMatchByMetadata(t *testing.T) {
 	const sid = "aaaa-1111"
 	dir := withTestDeps(t, map[int]bool{42: true}, nil)
-	writeMeta(t, dir, 42, sid, "/repo")
+	writeMeta(t, dir, 42, sid)
 
 	pid, err := DiscoverPID("/repo", transcriptFor(sid), nil)
 	if err != nil {
@@ -75,9 +78,9 @@ func TestDiscoverPID_StrongMatchByMetadata(t *testing.T) {
 func TestDiscoverPID_StrongMatchAmongMultipleMetadataFiles(t *testing.T) {
 	const wantSID = "bbbb-2222"
 	dir := withTestDeps(t, map[int]bool{100: true, 200: true, 300: true}, nil)
-	writeMeta(t, dir, 100, "other-1", "/repo")
-	writeMeta(t, dir, 200, wantSID, "/repo")
-	writeMeta(t, dir, 300, "other-3", "/repo")
+	writeMeta(t, dir, 100, "other-1")
+	writeMeta(t, dir, 200, wantSID)
+	writeMeta(t, dir, 300, "other-3")
 
 	pid, err := DiscoverPID("/repo", transcriptFor(wantSID), nil)
 	if err != nil {
@@ -93,7 +96,7 @@ func TestDiscoverPID_DeadPIDMetadataIsSkipped(t *testing.T) {
 	// Metadata says pid=42 owns the session, but 42 is dead.
 	// No live fallback candidates → returns 0.
 	dir := withTestDeps(t, map[int]bool{}, nil)
-	writeMeta(t, dir, 42, sid, "/repo")
+	writeMeta(t, dir, 42, sid)
 
 	pid, err := DiscoverPID("/repo", transcriptFor(sid), nil)
 	if err != nil {
@@ -112,7 +115,7 @@ func TestDiscoverPID_CorruptMetadataIsIgnored(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "99999.json"), []byte("not json"), 0o644); err != nil {
 		t.Fatalf("write garbage: %v", err)
 	}
-	writeMeta(t, dir, 50, sid, "/repo")
+	writeMeta(t, dir, 50, sid)
 
 	pid, err := DiscoverPID("/repo", transcriptFor(sid), nil)
 	if err != nil {
@@ -159,7 +162,7 @@ func TestDiscoverPID_FallbackExcludesPIDsClaimedByOthers(t *testing.T) {
 		map[int]bool{100: true, 200: true},
 		[]int{100, 200},
 	)
-	writeMeta(t, dir, 200, "other-session", "/repo")
+	writeMeta(t, dir, 200, "other-session")
 
 	pid, err := DiscoverPID("/repo", transcriptFor("new-sid"), nil)
 	if err != nil {

--- a/core/adapters/inbound/agents/claudecode/pid_test.go
+++ b/core/adapters/inbound/agents/claudecode/pid_test.go
@@ -1,0 +1,201 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// withTestDeps swaps sessionsDir, pidAlive, and discoverByCWD for the duration
+// of a test and restores them afterward. alive is the set of PIDs considered
+// live. fallbackPids is what the stubbed discoverByCWD should return as
+// candidates before the wrapped disambiguator runs.
+func withTestDeps(t *testing.T, alive map[int]bool, fallbackPids []int) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	origSessionsDir := sessionsDir
+	origPidAlive := pidAlive
+	origDiscoverByCWD := discoverByCWD
+
+	sessionsDir = dir
+	pidAlive = func(pid int) bool { return alive[pid] }
+	discoverByCWD = func(_ string, _ string, disambiguate func([]int) int) (int, error) {
+		if len(fallbackPids) == 0 {
+			return 0, nil
+		}
+		if disambiguate != nil {
+			return disambiguate(fallbackPids), nil
+		}
+		return fallbackPids[0], nil
+	}
+
+	t.Cleanup(func() {
+		sessionsDir = origSessionsDir
+		pidAlive = origPidAlive
+		discoverByCWD = origDiscoverByCWD
+	})
+	return dir
+}
+
+func writeMeta(t *testing.T, dir string, pid int, sessionID, cwd string) {
+	t.Helper()
+	// Mirror Claude's naming: ~/.claude/sessions/<pid>.json
+	meta := claudeSessionMeta{PID: pid, SessionID: sessionID, CWD: cwd}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := filepath.Join(dir, strconv.Itoa(pid)+".json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+}
+
+func transcriptFor(sessionID string) string {
+	return "/Users/x/.claude/projects/foo/" + sessionID + ".jsonl"
+}
+
+func TestDiscoverPID_StrongMatchByMetadata(t *testing.T) {
+	const sid = "aaaa-1111"
+	dir := withTestDeps(t, map[int]bool{42: true}, nil)
+	writeMeta(t, dir, 42, sid, "/repo")
+
+	pid, err := DiscoverPID("/repo", transcriptFor(sid), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 42 {
+		t.Fatalf("got pid=%d, want 42", pid)
+	}
+}
+
+func TestDiscoverPID_StrongMatchAmongMultipleMetadataFiles(t *testing.T) {
+	const wantSID = "bbbb-2222"
+	dir := withTestDeps(t, map[int]bool{100: true, 200: true, 300: true}, nil)
+	writeMeta(t, dir, 100, "other-1", "/repo")
+	writeMeta(t, dir, 200, wantSID, "/repo")
+	writeMeta(t, dir, 300, "other-3", "/repo")
+
+	pid, err := DiscoverPID("/repo", transcriptFor(wantSID), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 200 {
+		t.Fatalf("got pid=%d, want 200", pid)
+	}
+}
+
+func TestDiscoverPID_DeadPIDMetadataIsSkipped(t *testing.T) {
+	const sid = "cccc-3333"
+	// Metadata says pid=42 owns the session, but 42 is dead.
+	// No live fallback candidates → returns 0.
+	dir := withTestDeps(t, map[int]bool{}, nil)
+	writeMeta(t, dir, 42, sid, "/repo")
+
+	pid, err := DiscoverPID("/repo", transcriptFor(sid), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 0 {
+		t.Fatalf("got pid=%d, want 0 (dead metadata should be ignored)", pid)
+	}
+}
+
+func TestDiscoverPID_CorruptMetadataIsIgnored(t *testing.T) {
+	const sid = "dddd-4444"
+	dir := withTestDeps(t, map[int]bool{50: true}, nil)
+
+	// Write a garbage file alongside a valid one.
+	if err := os.WriteFile(filepath.Join(dir, "99999.json"), []byte("not json"), 0o644); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+	writeMeta(t, dir, 50, sid, "/repo")
+
+	pid, err := DiscoverPID("/repo", transcriptFor(sid), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 50 {
+		t.Fatalf("got pid=%d, want 50", pid)
+	}
+}
+
+func TestDiscoverPID_FallbackAmbiguousReturnsZero(t *testing.T) {
+	// No metadata match → fallback runs → cwd has two live claude processes.
+	// The fix: ambiguous fallback returns 0, not a guess.
+	withTestDeps(t, map[int]bool{100: true, 200: true}, []int{100, 200})
+
+	pid, err := DiscoverPID("/repo", transcriptFor("unknown-sid"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 0 {
+		t.Fatalf("got pid=%d, want 0 (ambiguous fallback must not guess)", pid)
+	}
+}
+
+func TestDiscoverPID_FallbackSingleCandidate(t *testing.T) {
+	// No metadata match, cwd has exactly one claude process → return it.
+	withTestDeps(t, map[int]bool{777: true}, []int{777})
+
+	pid, err := DiscoverPID("/repo", transcriptFor("unknown-sid"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 777 {
+		t.Fatalf("got pid=%d, want 777", pid)
+	}
+}
+
+func TestDiscoverPID_FallbackExcludesPIDsClaimedByOthers(t *testing.T) {
+	// Two claude processes live in /repo. Metadata says pid=200 owns a
+	// different sessionId, leaving only pid=100 as a fallback candidate.
+	// Even though the target sessionId has no metadata file yet, the
+	// fallback must return 100 (not 0 and not 200).
+	dir := withTestDeps(t,
+		map[int]bool{100: true, 200: true},
+		[]int{100, 200},
+	)
+	writeMeta(t, dir, 200, "other-session", "/repo")
+
+	pid, err := DiscoverPID("/repo", transcriptFor("new-sid"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 100 {
+		t.Fatalf("got pid=%d, want 100 (metadata should exclude 200 from fallback)", pid)
+	}
+}
+
+func TestDiscoverPID_EmptyTranscriptFallsBackToCWD(t *testing.T) {
+	// No transcriptPath → can't derive sessionId → skip strong match, go
+	// straight to fallback.
+	withTestDeps(t, map[int]bool{42: true}, []int{42})
+
+	pid, err := DiscoverPID("/repo", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 42 {
+		t.Fatalf("got pid=%d, want 42", pid)
+	}
+}
+
+func TestSessionIDFromTranscript(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/a/b/c/deadbeef-1234.jsonl", "deadbeef-1234"},
+		{"", ""},
+		{"/a/b/not-a-transcript.txt", ""},
+		{"foo.jsonl", "foo"},
+	}
+	for _, tc := range cases {
+		if got := sessionIDFromTranscript(tc.in); got != tc.want {
+			t.Errorf("sessionIDFromTranscript(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -361,11 +361,18 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 			}
 			// Sessions with PID=0 that are ready: the process likely exited
 			// before PID discovery succeeded. Clean up quickly (30s) rather
-			// than waiting the full readyTTL.
+			// than waiting the full readyTTL — BUT only if the transcript
+			// itself is stale. A freshly-written transcript with no PID
+			// yet means PID discovery is still catching up (e.g. Claude
+			// hasn't written ~/.claude/sessions/<pid>.json yet, or multiple
+			// claude processes share a cwd and the metadata lookup is
+			// retrying). Deleting under those conditions causes the flap
+			// loop in issue #109.
 			if state.PID == 0 && state.State == session.StateReady &&
-				time.Since(time.Unix(state.UpdatedAt, 0)) > 30*time.Second {
+				time.Since(time.Unix(state.UpdatedAt, 0)) > 30*time.Second &&
+				isStaleTranscript(state.TranscriptPath) {
 				pm.log.LogInfo("session-detector", state.SessionID,
-					"ready session with no PID for >30s, deleting")
+					"ready session with no PID and stale transcript for >30s, deleting")
 				pm.deleteWithChildren(state)
 				continue
 			}

--- a/core/application/services/pid_manager_internal_test.go
+++ b/core/application/services/pid_manager_internal_test.go
@@ -1,0 +1,139 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// --- tiny in-package test doubles --------------------------------------------
+
+type stubRepo struct {
+	states map[string]*session.SessionState
+}
+
+func newStubRepo() *stubRepo { return &stubRepo{states: make(map[string]*session.SessionState)} }
+
+func (r *stubRepo) Load(sessionID string) (*session.SessionState, error) {
+	s, ok := r.states[sessionID]
+	if !ok {
+		return nil, nil
+	}
+	return s, nil
+}
+func (r *stubRepo) Save(s *session.SessionState) error {
+	r.states[s.SessionID] = s
+	return nil
+}
+func (r *stubRepo) Delete(sessionID string) error {
+	delete(r.states, sessionID)
+	return nil
+}
+func (r *stubRepo) ListAll() ([]*session.SessionState, error) {
+	out := make([]*session.SessionState, 0, len(r.states))
+	for _, s := range r.states {
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+type stubLogger struct{}
+
+func (stubLogger) LogInfo(_, _, _ string)                          {}
+func (stubLogger) LogError(_, _, _ string)                         {}
+func (stubLogger) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
+func (stubLogger) Close() error                                    { return nil }
+
+// writeTranscript creates a transcript file at path with the given mtime.
+func writeTranscript(t *testing.T, path string, mtime time.Time) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+}
+
+// TestCheckPIDLiveness_FreshTranscript_NotDeleted verifies the Layer 2 fix for
+// issue #109: a ready session with PID=0 and a freshly-written transcript must
+// NOT be fast-deleted after 30s. PID discovery may still be catching up (e.g.
+// Claude hasn't written ~/.claude/sessions/<pid>.json yet).
+func TestCheckPIDLiveness_FreshTranscript_NotDeleted(t *testing.T) {
+	tmp := t.TempDir()
+	transcript := filepath.Join(tmp, "fresh.jsonl")
+	writeTranscript(t, transcript, time.Now()) // fresh mtime
+
+	repo := newStubRepo()
+	// Updated 60s ago → past the 30s threshold, but transcript is fresh.
+	repo.states["fresh"] = &session.SessionState{
+		SessionID:      "fresh",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		PID:            0,
+		TranscriptPath: transcript,
+		UpdatedAt:      time.Now().Add(-60 * time.Second).Unix(),
+	}
+
+	pm := NewPIDManager(
+		nil, // no ProcessWatcher
+		repo,
+		stubLogger{},
+		nil,                   // no broadcaster
+		10*time.Minute,        // readyTTL (large, so normal idle cleanup doesn't fire)
+		nil,                   // no pid discovers
+		func(string) {},       // noop onSessionDeleted
+	)
+
+	pm.CheckPIDLiveness()
+
+	if _, err := repo.Load("fresh"); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if repo.states["fresh"] == nil {
+		t.Fatal("session was deleted but transcript is fresh — fast-delete guard failed")
+	}
+}
+
+// TestCheckPIDLiveness_StaleTranscript_Deleted verifies the existing behavior
+// still works: a ready session with PID=0 AND a stale transcript (>2m) is
+// still fast-deleted after 30s.
+func TestCheckPIDLiveness_StaleTranscript_Deleted(t *testing.T) {
+	tmp := t.TempDir()
+	transcript := filepath.Join(tmp, "stale.jsonl")
+	writeTranscript(t, transcript, time.Now().Add(-10*time.Minute)) // stale mtime
+
+	repo := newStubRepo()
+	repo.states["stale"] = &session.SessionState{
+		SessionID:      "stale",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		PID:            0,
+		TranscriptPath: transcript,
+		UpdatedAt:      time.Now().Add(-60 * time.Second).Unix(),
+	}
+
+	pm := NewPIDManager(
+		nil,
+		repo,
+		stubLogger{},
+		nil,
+		10*time.Minute,
+		nil,
+		func(string) {},
+	)
+
+	pm.CheckPIDLiveness()
+
+	if repo.states["stale"] != nil {
+		t.Fatal("session should be deleted (stale transcript + ready + pid=0 + >30s)")
+	}
+}
+
+// Ensure stubRepo satisfies the outbound.SessionRepository interface.
+var _ outbound.SessionRepository = (*stubRepo)(nil)
+var _ outbound.Logger = stubLogger{}

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -1,4 +1,4 @@
-package services
+package services_test
 
 import (
 	"os"
@@ -6,47 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"irrlicht/core/application/services"
 	"irrlicht/core/domain/session"
-	"irrlicht/core/ports/outbound"
 )
-
-// --- tiny in-package test doubles --------------------------------------------
-
-type stubRepo struct {
-	states map[string]*session.SessionState
-}
-
-func newStubRepo() *stubRepo { return &stubRepo{states: make(map[string]*session.SessionState)} }
-
-func (r *stubRepo) Load(sessionID string) (*session.SessionState, error) {
-	s, ok := r.states[sessionID]
-	if !ok {
-		return nil, nil
-	}
-	return s, nil
-}
-func (r *stubRepo) Save(s *session.SessionState) error {
-	r.states[s.SessionID] = s
-	return nil
-}
-func (r *stubRepo) Delete(sessionID string) error {
-	delete(r.states, sessionID)
-	return nil
-}
-func (r *stubRepo) ListAll() ([]*session.SessionState, error) {
-	out := make([]*session.SessionState, 0, len(r.states))
-	for _, s := range r.states {
-		out = append(out, s)
-	}
-	return out, nil
-}
-
-type stubLogger struct{}
-
-func (stubLogger) LogInfo(_, _, _ string)                          {}
-func (stubLogger) LogError(_, _, _ string)                         {}
-func (stubLogger) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
-func (stubLogger) Close() error                                    { return nil }
 
 // writeTranscript creates a transcript file at path with the given mtime.
 func writeTranscript(t *testing.T, path string, mtime time.Time) {
@@ -59,6 +21,21 @@ func writeTranscript(t *testing.T, path string, mtime time.Time) {
 	}
 }
 
+// newPIDManagerForTest builds a PIDManager wired to the shared mockRepo and
+// mockLogger from testhelpers_test.go. readyTTL is set large so the normal
+// idle sweep doesn't interfere with the fast-delete path under test.
+func newPIDManagerForTest(repo *mockRepo) *services.PIDManager {
+	return services.NewPIDManager(
+		nil, // no ProcessWatcher
+		repo,
+		&mockLogger{},
+		nil, // no broadcaster
+		10*time.Minute,
+		nil, // no pid discovers
+		func(string) {},
+	)
+}
+
 // TestCheckPIDLiveness_FreshTranscript_NotDeleted verifies the Layer 2 fix for
 // issue #109: a ready session with PID=0 and a freshly-written transcript must
 // NOT be fast-deleted after 30s. PID discovery may still be catching up (e.g.
@@ -66,9 +43,9 @@ func writeTranscript(t *testing.T, path string, mtime time.Time) {
 func TestCheckPIDLiveness_FreshTranscript_NotDeleted(t *testing.T) {
 	tmp := t.TempDir()
 	transcript := filepath.Join(tmp, "fresh.jsonl")
-	writeTranscript(t, transcript, time.Now()) // fresh mtime
+	writeTranscript(t, transcript, time.Now())
 
-	repo := newStubRepo()
+	repo := newMockRepo()
 	// Updated 60s ago → past the 30s threshold, but transcript is fresh.
 	repo.states["fresh"] = &session.SessionState{
 		SessionID:      "fresh",
@@ -79,21 +56,8 @@ func TestCheckPIDLiveness_FreshTranscript_NotDeleted(t *testing.T) {
 		UpdatedAt:      time.Now().Add(-60 * time.Second).Unix(),
 	}
 
-	pm := NewPIDManager(
-		nil, // no ProcessWatcher
-		repo,
-		stubLogger{},
-		nil,                   // no broadcaster
-		10*time.Minute,        // readyTTL (large, so normal idle cleanup doesn't fire)
-		nil,                   // no pid discovers
-		func(string) {},       // noop onSessionDeleted
-	)
+	newPIDManagerForTest(repo).CheckPIDLiveness()
 
-	pm.CheckPIDLiveness()
-
-	if _, err := repo.Load("fresh"); err != nil {
-		t.Fatalf("load: %v", err)
-	}
 	if repo.states["fresh"] == nil {
 		t.Fatal("session was deleted but transcript is fresh — fast-delete guard failed")
 	}
@@ -105,9 +69,9 @@ func TestCheckPIDLiveness_FreshTranscript_NotDeleted(t *testing.T) {
 func TestCheckPIDLiveness_StaleTranscript_Deleted(t *testing.T) {
 	tmp := t.TempDir()
 	transcript := filepath.Join(tmp, "stale.jsonl")
-	writeTranscript(t, transcript, time.Now().Add(-10*time.Minute)) // stale mtime
+	writeTranscript(t, transcript, time.Now().Add(-10*time.Minute))
 
-	repo := newStubRepo()
+	repo := newMockRepo()
 	repo.states["stale"] = &session.SessionState{
 		SessionID:      "stale",
 		Adapter:        "claude-code",
@@ -117,23 +81,9 @@ func TestCheckPIDLiveness_StaleTranscript_Deleted(t *testing.T) {
 		UpdatedAt:      time.Now().Add(-60 * time.Second).Unix(),
 	}
 
-	pm := NewPIDManager(
-		nil,
-		repo,
-		stubLogger{},
-		nil,
-		10*time.Minute,
-		nil,
-		func(string) {},
-	)
-
-	pm.CheckPIDLiveness()
+	newPIDManagerForTest(repo).CheckPIDLiveness()
 
 	if repo.states["stale"] != nil {
 		t.Fatal("session should be deleted (stale transcript + ready + pid=0 + >30s)")
 	}
 }
-
-// Ensure stubRepo satisfies the outbound.SessionRepository interface.
-var _ outbound.SessionRepository = (*stubRepo)(nil)
-var _ outbound.Logger = stubLogger{}


### PR DESCRIPTION
## Summary

Fixes #109 — Claude sessions flapping in and out of the dashboard when multiple live `claude` processes share the same cwd.

- **Root cause:** `claudecode.DiscoverPID` matched `claude` processes by cwd only. When several ran in the same repo, a new transcript could bind to a PID already owned by another session, and `PIDManager.HandlePIDAssigned`'s duplicate-PID cleanup then deleted the rival — re-activating the orphaned transcript in a loop.
- **Layer 1 fix:** `DiscoverPID` now reads `~/.claude/sessions/<pid>.json`, Claude's authoritative `{pid, sessionId, cwd, ...}` per-process record, and matches the target sessionId (derived from the transcript filename) against metadata first. The cwd fallback is restricted to unambiguous, non-metadata-claimed candidates and returns `0` rather than guessing when multiple candidates remain. `DiscoverPIDWithRetry` retries 500ms / 1s / 2s, which absorbs metadata-write latency on startup.
- **Layer 2 fix:** `CheckPIDLiveness` no longer fast-deletes a `ready/pid=0` session after 30s if its transcript is still fresh (`!isStaleTranscript`). A fresh transcript with no PID means discovery is catching up, not a zombie. Truly abandoned sessions still get collected by the `readyTTL` sweep.
- **No signature change to `PIDDiscoverFunc`.** Codex and Pi adapters are untouched. `/clear` cleanup still works because Claude overwrites `<pid>.json` in place when it rotates sessionIds.

## Why not "strong vs weak" confidence flag on `HandlePIDAssigned`?

Considered. Rejected because it forces signature churn on Codex/Pi for no benefit — their transcript-writer discovery is already strong. The restricted fallback above already guarantees `HandlePIDAssigned` never sees a weak, ambiguous Claude match.

## Commits

1. `fa6180c` — initial fix (Layers 1 + 2 + tests)
2. `135251a` — review fixups: clarify fallback slice (`pids[:0:0]` → `make([]int, 0, len(pids))`), drop dead `_ = disambiguate` assignment
3. `52b2ed1` — simplify cleanup: drop unused `claudeSessionMeta.CWD` field, extract `claudecode.ProcessName` constant, consolidate test doubles by moving `CheckPIDLiveness` tests into `services_test` package reusing `mockRepo`/`mockLogger`

## Test plan

- [x] `go clean -testcache && go test ./...` — full core module green across all 17 packages (`e2e`, `cmd/irrlichd`, `pkg/tailer`, `pkg/transcript`, `pkg/capacity`, etc.)
- [x] `go vet ./...` — clean
- [x] `core/adapters/inbound/agents/claudecode/pid_test.go` (9 cases): strong match, multi-file match, dead PID rejected, corrupt JSON ignored, ambiguous fallback returns 0, single-candidate fallback, fallback excludes PIDs claimed by others, empty transcript, `sessionIDFromTranscript` parser
- [x] `core/application/services/pid_manager_test.go` (2 cases): fresh transcript NOT fast-deleted, stale transcript still fast-deleted
- [x] Live verification — worktree daemon running against three real Claude sessions (worktrees 109, 113, 114), each bound to its authoritative metadata PID; zero `replaced by new session` or `ready session with no PID` log lines after ~30 min
- [ ] Manual two-session repro: open two terminals in the same repo, run `claude` in both, watch the dashboard and `/tmp/irrlichd-dev.log` for 5 minutes — expect both sessions visible continuously, no flap log lines
- [ ] `/clear` regression: inside a running `claude`, type `/clear`; expect the old session to be cleaned up and the new session to take over the same PID

🤖 Generated with [Claude Code](https://claude.com/claude-code)