### PR TITLE
fix(pi): emit turn_done on stopReason:stop (#119)

### DIFF
--- a/core/adapters/inbound/agents/pi/parser.go
+++ b/core/adapters/inbound/agents/pi/parser.go
@@ -77,7 +77,7 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 	case "assistant":
 		stopReason, _ := piMsg["stopReason"].(string)
 		if stopReason == "stop" {
-			ev.EventType = "assistant_message" // end-of-turn
+			ev.EventType = "turn_done" // end-of-turn (primary path for IsAgentDone)
 		} else {
 			ev.EventType = "assistant" // mid-turn (toolUse, etc.)
 		}

--- a/core/adapters/inbound/agents/pi/parser_test.go
+++ b/core/adapters/inbound/agents/pi/parser_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 )
 
@@ -126,8 +127,8 @@ func TestParser_AssistantEndOfTurn(t *testing.T) {
 	if ev == nil {
 		t.Fatal("expected non-nil event")
 	}
-	if ev.EventType != "assistant_message" {
-		t.Errorf("EventType = %q, want assistant_message (end-of-turn)", ev.EventType)
+	if ev.EventType != "turn_done" {
+		t.Errorf("EventType = %q, want turn_done (end-of-turn)", ev.EventType)
 	}
 	if ev.AssistantText != "Done!" {
 		t.Errorf("AssistantText = %q, want Done!", ev.AssistantText)
@@ -260,14 +261,62 @@ func TestParser_FullTranscript_EndDetection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if m.LastEventType != "assistant_message" {
-		t.Errorf("LastEventType = %q, want assistant_message", m.LastEventType)
+	if m.LastEventType != "turn_done" {
+		t.Errorf("LastEventType = %q, want turn_done", m.LastEventType)
 	}
 	if m.HasOpenToolCall {
 		t.Error("expected HasOpenToolCall=false after all tool calls resolved")
 	}
 	if m.OpenToolCallCount != 0 {
 		t.Errorf("OpenToolCallCount = %d, want 0", m.OpenToolCallCount)
+	}
+}
+
+func TestParser_TextOnlyTurn_TriggersIsAgentDone(t *testing.T) {
+	// Regression for #119: a text-only pi turn (stopReason:stop) must
+	// drive IsAgentDone() to true so the classifier transitions to ready.
+	// Previously, the parser emitted "assistant_message" which IsAgentDone()
+	// deliberately excludes (to avoid codex preliminary-message flicker), so
+	// pi sessions stayed pinned at working after every text-only reply.
+	path := writeLines(t, []map[string]interface{}{
+		{"type": "session", "version": float64(3), "cwd": "/tmp"},
+		{"type": "message", "timestamp": ts(0),
+			"message": map[string]interface{}{
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "hi"},
+				}}},
+		{"type": "message", "timestamp": ts(1),
+			"message": map[string]interface{}{
+				"role":       "assistant",
+				"stopReason": "stop",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text",
+						"text": "Hi! What would you like to work on?"},
+				}}},
+	})
+
+	tl := tailer.NewTranscriptTailer(path, &Parser{}, "pi")
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.LastEventType != "turn_done" {
+		t.Errorf("LastEventType = %q, want turn_done", m.LastEventType)
+	}
+	if m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=false for text-only turn")
+	}
+	// Cross-check that the domain's IsAgentDone() — which is what the
+	// classifier ultimately consults — accepts the parser output. The
+	// tailer and domain each have their own SessionMetrics struct; the
+	// classifier pipes LastEventType/HasOpenToolCall from one to the other.
+	dm := &session.SessionMetrics{
+		LastEventType:   m.LastEventType,
+		HasOpenToolCall: m.HasOpenToolCall,
+	}
+	if !dm.IsAgentDone() {
+		t.Error("session.IsAgentDone() = false, want true (session should be ready after text-only turn)")
 	}
 }
 
@@ -309,7 +358,7 @@ func TestParser_BashExecutionSkipped_PreservesLastEvent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if m.LastEventType != "assistant_message" {
-		t.Errorf("LastEventType = %q, want assistant_message (bashExecution should be skipped)", m.LastEventType)
+	if m.LastEventType != "turn_done" {
+		t.Errorf("LastEventType = %q, want turn_done (bashExecution should be skipped)", m.LastEventType)
 	}
 }


### PR DESCRIPTION
## Summary

- Pi sessions were pinned at `working` after any text-only turn because the parser mapped `stopReason:"stop"` to `assistant_message`, which `session.IsAgentDone()` deliberately excludes (to prevent codex preliminary-message flicker). Pi has no other terminal signal, so the primary `turn_done` path never fired.
- Map `stopReason:"stop"` to `turn_done` instead, slotting pi into the same primary `IsAgentDone()` path as claudecode (`system/turn_duration`) and codex (`task_complete`).
- Safe because pi doesn't emit preliminary assistant messages before tool calls — it uses `stopReason:"toolUse"` mid-turn, already mapped to `"assistant"`.
- Adds a regression test that calls `session.IsAgentDone()` directly so the parser→domain hand-off is covered end-to-end — the gap that let the original bug slip through `TestParser_FullTranscript_EndDetection` (which only checked `LastEventType`).

Fixes #119.

## Test plan

- [x] `go test ./core/adapters/inbound/agents/pi/...` — passes
- [x] `go test ./core/domain/session/... ./core/pkg/tailer/... ./core/application/services/... ./core/adapters/inbound/agents/...` — no regressions
- [x] Replay captured live bug transcript (`~/.pi/agent/sessions/--Users-ingo-projects-irrlicht--/2026-04-09T21-45-54-074Z_bae19f34-...jsonl`) via `core/cmd/replay-session`: terminal state is now `ready` with `last_event_type=turn_done` (pre-fix: stuck at `working` with `last_event_type=assistant_message`)
- [x] Replay existing fixture `testdata/replay/pi/01-example-session.jsonl`: 11 "flickers" reported are all legitimate rapid turn boundaries (`ready→working→ready` within 10s on short user/agent exchanges) — not regressions. Pre-fix only had 0/15 transitions because the session was stuck at `working` most of the time.
- [x] Live smoke test: built worktree via `ir:test-mac` skill, pi session sending "hi" transitions to `ready` within one tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)