### PR TITLE
fix(pre-session): add process lifecycle scanners for codex and pi

### DIFF
--- a/core/adapters/inbound/agents/codex/adapter.go
+++ b/core/adapters/inbound/agents/codex/adapter.go
@@ -11,6 +11,10 @@ import (
 // AdapterName identifies sessions originating from OpenAI Codex.
 const AdapterName = "codex"
 
+// ProcessName is the OS-level executable name for Codex CLI, used by
+// the process lifecycle scanner to detect running instances via pgrep -x.
+const ProcessName = "codex"
+
 // rootDir is the path relative to $HOME where Codex stores session transcripts.
 // Sessions live under sessions/YYYY/MM/DD/*.jsonl (deep nesting).
 const rootDir = ".codex/sessions"

--- a/core/adapters/inbound/agents/pi/adapter.go
+++ b/core/adapters/inbound/agents/pi/adapter.go
@@ -11,6 +11,10 @@ import (
 // AdapterName identifies sessions originating from Pi coding agent.
 const AdapterName = "pi"
 
+// ProcessName is the OS-level executable name for Pi CLI, used by
+// the process lifecycle scanner to detect running instances via pgrep -x.
+const ProcessName = "pi"
+
 // rootDir is the path relative to $HOME where Pi stores session transcripts.
 // Sessions live under --<cwd-with-dashes>--/<timestamp>_<uuid>.jsonl.
 const rootDir = ".pi/agent/sessions"

--- a/core/adapters/inbound/agents/pi/pid.go
+++ b/core/adapters/inbound/agents/pi/pid.go
@@ -8,5 +8,5 @@ import (
 // whose CWD equals the session's working directory. Pi's binary resolves to
 // process name "pi" (despite being a Node.js script), so pgrep -x "pi" works.
 func DiscoverPID(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
-	return processlifecycle.DiscoverPIDByCWD("pi", cwd, disambiguate)
+	return processlifecycle.DiscoverPIDByCWD(ProcessName, cwd, disambiguate)
 }

--- a/core/adapters/inbound/agents/processlifecycle/scanner.go
+++ b/core/adapters/inbound/agents/processlifecycle/scanner.go
@@ -79,11 +79,12 @@ func (s *Scanner) WithSessionChecker(fn func(projectDir string, pid int) bool) *
 
 // HasRealSessionForPID reports whether sessions contains a real
 // (transcript-backed, non-proc) session that belongs to the given PID and
-// whose transcript lives under the given encoded projectDir (e.g.
-// "-Users-ingo-projects-foo"). It is the canonical predicate the Scanner's
-// sessionChecker should delegate to — encoding the "is a proc- pre-session
-// redundant?" policy in one place so production callers and tests cannot
-// drift apart.
+// project directory. It matches by transcript path (Claude Code layout:
+// ~/.claude/projects/<projectDir>/) or by CWD (codex/pi layouts where the
+// transcript path doesn't encode the project directory). It is the canonical
+// predicate the Scanner's sessionChecker should delegate to — encoding the
+// "is a proc- pre-session redundant?" policy in one place so production
+// callers and tests cannot drift apart.
 func HasRealSessionForPID(sessions []*session.SessionState, projectDir string, pid int) bool {
 	for _, s := range sessions {
 		if strings.HasPrefix(s.SessionID, "proc-") {
@@ -92,8 +93,13 @@ func HasRealSessionForPID(sessions []*session.SessionState, projectDir string, p
 		if s.PID != pid {
 			continue
 		}
-		if s.TranscriptPath != "" &&
-			filepath.Base(filepath.Dir(s.TranscriptPath)) == projectDir {
+		if s.TranscriptPath == "" {
+			continue
+		}
+		if filepath.Base(filepath.Dir(s.TranscriptPath)) == projectDir {
+			return true
+		}
+		if s.CWD != "" && CWDToProjectDir(s.CWD) == projectDir {
 			return true
 		}
 	}
@@ -186,7 +192,7 @@ func (s *Scanner) poll() {
 		s.mu.Unlock()
 
 		cwd, err := ProcessCWD(pid)
-		if err != nil || cwd == "" {
+		if err != nil || cwd == "" || cwd == "/" {
 			continue
 		}
 		projectDir := CWDToProjectDir(cwd)

--- a/core/adapters/inbound/agents/processlifecycle/scanner_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/scanner_test.go
@@ -1,0 +1,67 @@
+package processlifecycle
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+func TestHasRealSessionForPID_TranscriptPathMatch(t *testing.T) {
+	sessions := []*session.SessionState{{
+		SessionID:      "abc-123",
+		PID:            42,
+		TranscriptPath: "/home/user/.claude/projects/-Users-user-myproject/abc-123.jsonl",
+	}}
+	if !HasRealSessionForPID(sessions, "-Users-user-myproject", 42) {
+		t.Error("expected match via transcript path projectDir")
+	}
+}
+
+func TestHasRealSessionForPID_CWDFallback(t *testing.T) {
+	// Codex transcript path uses date-based layout — filepath.Base(filepath.Dir(...))
+	// returns "10" (the day), not the project directory. The CWD fallback should match.
+	sessions := []*session.SessionState{{
+		SessionID:      "rollout-2026-04-10",
+		PID:            42,
+		TranscriptPath: "/home/user/.codex/sessions/2026/04/10/rollout-2026-04-10.jsonl",
+		CWD:            "/Users/user/myproject",
+	}}
+	projectDir := CWDToProjectDir("/Users/user/myproject") // "-Users-user-myproject"
+	if !HasRealSessionForPID(sessions, projectDir, 42) {
+		t.Error("expected match via CWD fallback for codex-style transcript path")
+	}
+}
+
+func TestHasRealSessionForPID_SkipsProcSessions(t *testing.T) {
+	sessions := []*session.SessionState{{
+		SessionID:      "proc-42",
+		PID:            42,
+		TranscriptPath: "/some/path/proj/session.jsonl",
+	}}
+	if HasRealSessionForPID(sessions, "proj", 42) {
+		t.Error("proc- sessions should be skipped")
+	}
+}
+
+func TestHasRealSessionForPID_RequiresPIDMatch(t *testing.T) {
+	sessions := []*session.SessionState{{
+		SessionID:      "abc-123",
+		PID:            99,
+		TranscriptPath: "/home/user/.claude/projects/-Users-user-myproject/abc-123.jsonl",
+		CWD:            "/Users/user/myproject",
+	}}
+	if HasRealSessionForPID(sessions, "-Users-user-myproject", 42) {
+		t.Error("should not match when PID differs")
+	}
+}
+
+func TestHasRealSessionForPID_RequiresTranscript(t *testing.T) {
+	sessions := []*session.SessionState{{
+		SessionID: "abc-123",
+		PID:       42,
+		CWD:       "/Users/user/myproject",
+	}}
+	if HasRealSessionForPID(sessions, "-Users-user-myproject", 42) {
+		t.Error("should not match when TranscriptPath is empty")
+	}
+}

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -173,7 +173,7 @@ func (pm *PIDManager) HandlePIDAssigned(pid int, sessionID string) {
 		if old.SessionID == sessionID || old.PID != pid {
 			continue
 		}
-		if old.ParentSessionID != "" || strings.HasPrefix(old.SessionID, "proc-") {
+		if old.ParentSessionID != "" {
 			continue
 		}
 
@@ -458,6 +458,37 @@ func (pm *PIDManager) SeedPIDs(states []*session.SessionState) {
 			}
 			_ = pm.repo.Delete(state.SessionID)
 			pm.broadcast(outbound.PushTypeDeleted, state)
+		}
+	}
+
+	// Clean up stale pre-sessions (proc-*) that have a corresponding real
+	// session. Match by PID (preferred) or by adapter + CWD (for adapters
+	// like Codex whose PID discovery may not have completed yet).
+	for _, proc := range states {
+		if !strings.HasPrefix(proc.SessionID, "proc-") {
+			continue
+		}
+		if s, _ := pm.repo.Load(proc.SessionID); s == nil {
+			continue // already deleted above
+		}
+		for _, candidate := range states {
+			if strings.HasPrefix(candidate.SessionID, "proc-") || candidate.TranscriptPath == "" {
+				continue
+			}
+			matched := proc.PID > 0 && proc.PID == candidate.PID
+			if !matched && proc.CWD != "" && proc.Adapter == candidate.Adapter && proc.CWD == candidate.CWD {
+				matched = true
+			}
+			if matched {
+				pm.log.LogInfo("session-detector-seed", proc.SessionID,
+					fmt.Sprintf("pre-session superseded by %s — deleting", candidate.SessionID))
+				if pm.onSessionDeleted != nil {
+					pm.onSessionDeleted(proc.SessionID)
+				}
+				_ = pm.repo.Delete(proc.SessionID)
+				pm.broadcast(outbound.PushTypeDeleted, proc)
+				break
+			}
 		}
 	}
 }

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -268,9 +268,10 @@ func (d *SessionDetector) onNewSession(ev agent.Event) {
 		d.broadcast(outbound.PushTypeCreated, state)
 
 		// When a real transcript session arrives, remove any pre-sessions for
-		// the same project directory (they are now superseded).
+		// the same project. Match by projectDir first (Claude Code layout),
+		// then fall back to CWD (Codex/Pi have different transcript layouts).
 		if ev.TranscriptPath != "" {
-			d.cleanupPreSessionsForProject(ev.ProjectDir)
+			d.cleanupPreSessionsForProject(ev.ProjectDir, state.CWD, ev.Adapter)
 		}
 	} else {
 		// Session already exists. Update transcript path if missing.
@@ -687,18 +688,41 @@ func (d *SessionDetector) reevaluateParent(parentID string) {
 }
 
 // cleanupPreSessionsForProject removes all synthetic pre-sessions (proc-*)
-// in the given project directory. Called when a real transcript session arrives
-// so the pre-session doesn't linger alongside the real one.
-func (d *SessionDetector) cleanupPreSessionsForProject(projectDir string) {
+// in the given project. It matches by projectDir first (Claude Code layout
+// where the transcript path encodes the project directory), then falls back
+// to CWD comparison for adapters whose transcript paths use different layouts
+// (Codex stores by date, Pi uses double-dash encoding).
+func (d *SessionDetector) cleanupPreSessionsForProject(projectDir, realCWD, adapter string) {
+	// Collect candidates under the lock; defer I/O (repo.Load) to outside.
 	d.mu.Lock()
 	var ids []string
+	var cwdCandidates []string
 	for sid, pdir := range d.projectSessions {
-		if pdir == projectDir && strings.HasPrefix(sid, "proc-") {
+		if !strings.HasPrefix(sid, "proc-") {
+			continue
+		}
+		if pdir == projectDir {
 			ids = append(ids, sid)
 			delete(d.projectSessions, sid)
+			continue
+		}
+		if realCWD != "" {
+			cwdCandidates = append(cwdCandidates, sid)
 		}
 	}
 	d.mu.Unlock()
+
+	// CWD fallback: match pre-sessions whose CWD equals the real session's
+	// CWD. Needed for adapters whose transcript paths don't encode the
+	// project directory (Codex stores by date, Pi uses double-dash encoding).
+	for _, sid := range cwdCandidates {
+		if state, _ := d.repo.Load(sid); state != nil && state.Adapter == adapter && state.CWD == realCWD {
+			d.mu.Lock()
+			delete(d.projectSessions, sid)
+			d.mu.Unlock()
+			ids = append(ids, sid)
+		}
+	}
 
 	for _, sid := range ids {
 		state, _ := d.repo.Load(sid)

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -265,27 +265,45 @@ func main() {
 	codexWatcher := codex.New(cfg.MaxSessionAge)
 	piWatcher := pi.New(cfg.MaxSessionAge)
 
-	// Process scanner: detects Claude Code processes before they create a
-	// transcript, so the session appears as ready from the moment the app opens.
-	procScanner := processlifecycle.NewScanner(
-		"claude",
-		claudecode.AdapterName,
-		0, // use default interval
-	)
-	// Suppress ghost proc pre-sessions for live Claude Code processes whose
-	// real session is already persisted. The PID discriminator in
-	// HasRealSessionForPID is what prevents historical sessions on disk
-	// (GH #113, within MaxSessionAge) from blocking new processes in the
-	// same project.
-	procScanner.WithSessionChecker(func(projectDir string, pid int) bool {
+	// Suppress ghost proc pre-sessions for live processes whose real session
+	// is already persisted. The PID discriminator in HasRealSessionForPID
+	// prevents historical sessions on disk (GH #113, within MaxSessionAge)
+	// from blocking new processes in the same project.
+	realSessionCheck := func(projectDir string, pid int) bool {
 		sessions, err := cachedRepo.ListAll()
 		if err != nil {
 			return false
 		}
 		return processlifecycle.HasRealSessionForPID(sessions, projectDir, pid)
-	})
+	}
 
-	watchers := []inbound.AgentWatcher{claudeCodeWatcher, codexWatcher, piWatcher, procScanner}
+	// Process scanners: detect agent processes before they create a
+	// transcript, so the session appears as ready from the moment the app opens.
+	procScanner := processlifecycle.NewScanner(
+		claudecode.ProcessName,
+		claudecode.AdapterName,
+		0, // use default interval
+	)
+	procScanner.WithSessionChecker(realSessionCheck)
+
+	codexProcScanner := processlifecycle.NewScanner(
+		codex.ProcessName,
+		codex.AdapterName,
+		0,
+	)
+	codexProcScanner.WithSessionChecker(realSessionCheck)
+
+	piProcScanner := processlifecycle.NewScanner(
+		pi.ProcessName,
+		pi.AdapterName,
+		0,
+	)
+	piProcScanner.WithSessionChecker(realSessionCheck)
+
+	watchers := []inbound.AgentWatcher{
+		claudeCodeWatcher, codexWatcher, piWatcher,
+		procScanner, codexProcScanner, piProcScanner,
+	}
 
 	// Per-adapter PID discovery: Claude Code uses CWD-based matching,
 	// Codex/Pi use transcript file writer detection.


### PR DESCRIPTION
## Summary

Closes #120.

- **Pre-session detection**: Add process lifecycle scanners for codex and pi so sessions appear in `irrlicht-ls` the moment the agent opens, before any transcript is written
- **Ghost suppression**: Filter `cwd=="/"` to prevent codex worker processes from creating phantom pre-sessions
- **Pre-session cleanup**: Fix 4 cleanup paths that failed for codex/pi because their transcript layouts don't encode the project directory like Claude Code does — now matches by CWD as fallback

## Test plan

- [x] All 26 test packages pass (`go test ./...`)
- [x] All 5 e2e presession tests pass
- [x] Live verified: codex and pi pre-sessions appear immediately, no ghost `cwd=/` sessions
- [x] Live verified: pre-sessions are replaced when real transcript appears (0 stale proc- sessions after activity)
- [x] Live verified: daemon restart correctly cleans up stale pre-sessions from disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)