### PR TITLE
docs(site): fix installation git clone URL and add SEO audit

### DIFF
--- a/site/ACTION-PLAN.md
+++ b/site/ACTION-PLAN.md
@@ -1,0 +1,385 @@
+# Irrlicht SEO Action Plan
+**Date:** 2026-04-10
+**Overall Score:** 61 / 100
+
+---
+
+## Critical (Fix Immediately)
+
+### AC1 — Convert hero PNG to WebP/AVIF and add preload hint
+**File:** `site/index.html`, `site/assets/`
+**Impact:** LCP — moves from Poor to Good on most devices
+
+`bg_no_lights.png` is 1.7 MB. Convert to AVIF (expected ~150-300 KB) and add a preload hint before the Google Fonts links:
+
+```html
+<!-- Add to <head>, before Google Fonts links -->
+<link rel="preload" as="image" href="assets/bg_no_lights.avif" type="image/avif">
+```
+
+Update the CSS background line (~L264):
+```css
+/* Use image-set for AVIF with PNG fallback */
+background: url('assets/bg_no_lights.png') center center / cover no-repeat;
+```
+To:
+```css
+background: image-set(
+  url('assets/bg_no_lights.avif') type("image/avif"),
+  url('assets/bg_no_lights.png') type("image/png")
+) center center / cover no-repeat;
+```
+
+Also remove/convert `bg_lights.png`, `bg_lights_2.png` (1.7 MB each, unreferenced) and `dmg-background.tiff` (1.0 MB, build artifact) from the deployment.
+
+---
+
+### AC2 — Fix BreadcrumbList on homepage (inverted hierarchy)
+**File:** `site/index.html` (JSON-LD Block 4)
+**Impact:** Schema — eliminates Google Search Console rich result error
+
+Replace the 2-item `Home > Documentation` breadcrumb with a single-item list (or remove it entirely):
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://irrlicht.io/"
+    }
+  ]
+}
+```
+
+---
+
+### AC3 — Add /landscape/ to sitemap.xml
+**File:** `site/sitemap.xml`
+**Impact:** Crawlability — ensures Googlebot discovers and indexes the landscape page
+
+Add before `</urlset>`:
+```xml
+<url>
+  <loc>https://irrlicht.io/landscape/</loc>
+  <lastmod>2026-04-10</lastmod>
+  <priority>0.7</priority>
+</url>
+```
+
+Also add `/landscape/` to `site/llms.txt` under the Documentation section.
+
+---
+
+## High Priority (Fix Within One Week)
+
+### AH1 — Make Google Fonts non-render-blocking
+**File:** All 16 HTML pages
+**Impact:** LCP — eliminates font stylesheet as a render-blocking resource
+
+Replace (on every page):
+```html
+<link href="https://fonts.googleapis.com/css2?..." rel="stylesheet">
+```
+With:
+```html
+<link href="https://fonts.googleapis.com/css2?..." rel="stylesheet" media="print" onload="this.media='all'">
+<noscript><link href="https://fonts.googleapis.com/css2?..." rel="stylesheet"></noscript>
+```
+
+---
+
+### AH2 — Add og:image and upgrade Twitter card
+**File:** All pages
+**Impact:** Social sharing — enables image previews on all social platforms
+
+Create a 1200×630px `og-image.png` in `site/assets/`. Add to `<head>` on every page:
+```html
+<meta property="og:image" content="https://irrlicht.io/assets/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://irrlicht.io/assets/og-image.png">
+```
+
+---
+
+### AH3 — Fix H1 to include topic descriptor
+**File:** `site/index.html` (line ~1045)
+**Impact:** On-Page SEO, E-E-A-T — H1 currently says only "Irrlicht"
+
+Change the H1 text or add a subtitle H2 directly below it. The gradient styling can remain on the brand name. Example approach — change the hero subtitle-top `<p>` to an `<h2>`:
+
+```html
+<h1><span>Irrlicht</span></h1>
+<h2 class="hero-subtitle-top">Menu-Bar Telemetry for AI Coding Agents</h2>
+```
+
+(Update the CSS class `.hero-subtitle-top` to target both `p` and `h2` if needed.)
+
+---
+
+### AH4 — Add analytics to landscape page
+**File:** `site/landscape/index.html`
+**Impact:** Measurement — traffic to this page is currently invisible
+
+Copy the counter.dev script tag from index.html and add it before `</body>` in landscape/index.html. The `data-id` should match.
+
+---
+
+### AH5 — Make counter.dev script async on all pages
+**File:** All pages with the script
+**Impact:** Performance — eliminates synchronous script block at end of `<body>`
+
+Change:
+```html
+<script src="https://cdn.counter.dev/script.js" data-id="..." data-utcoffset="1"></script>
+```
+To:
+```html
+<script async src="https://cdn.counter.dev/script.js" data-id="..." data-utcoffset="1"></script>
+```
+
+Also add `<link rel="preconnect" href="https://cdn.counter.dev">` to `<head>` on all pages.
+
+---
+
+### AH6 — Fix URL inconsistency in schema (trailing slash)
+**File:** `site/index.html` (JSON-LD Blocks 1, 2, 3)
+**Impact:** Schema — resolves entity mismatch with canonical URL
+
+In all three blocks, change `"https://irrlicht.io"` → `"https://irrlicht.io/"` (add trailing slash) to match the canonical tag. Affects `url`, `@id`, and `publisher.url` fields.
+
+---
+
+### AH7 — Add @id to all schema entities and link them
+**File:** `site/index.html` (all 4 JSON-LD blocks)
+**Impact:** Schema — enables entity graph linking across blocks
+
+Add `"@id"` to each block:
+- Organization: `"@id": "https://irrlicht.io/#organization"`
+- WebSite: `"@id": "https://irrlicht.io/#website"`
+- SoftwareApplication: `"@id": "https://irrlicht.io/#software"`
+- Person (author/founder): `"@id": "https://github.com/ingo-eichhorst"`
+
+Then replace the inline `publisher` object in the WebSite block with: `"publisher": {"@id": "https://irrlicht.io/#organization"}`
+
+---
+
+### AH8 — Add visible author attribution
+**File:** `site/index.html` footer (line ~1363)
+**Impact:** E-E-A-T Trustworthiness — author currently invisible to human readers
+
+Change the footer left text from:
+```
+MIT License · Irrlicht v0.3.2 · Follow the right light.
+```
+To:
+```
+MIT License · Irrlicht v0.3.2 · Built by <a href="https://github.com/ingo-eichhorst">Ingo Eichhorst</a>
+```
+
+---
+
+## Medium Priority (Fix Within One Month)
+
+### AM1 — Add structured data to all docs pages
+**File:** `site/docs/*.html` (13 pages)
+**Impact:** Rich results, AI citation readiness
+
+Each docs page needs two JSON-LD blocks: a `TechArticle` and a `BreadcrumbList`. Template per page:
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "[Page Title] — Irrlicht Docs",
+  "description": "[Meta description text]",
+  "url": "https://irrlicht.io/docs/[page].html",
+  "datePublished": "2026-04-04",
+  "dateModified": "2026-04-04",
+  "author": {"@type": "Person", "@id": "https://github.com/ingo-eichhorst", "name": "Ingo Eichhorst"},
+  "publisher": {"@id": "https://irrlicht.io/#organization"},
+  "isPartOf": {"@id": "https://irrlicht.io/#website"},
+  "about": {"@id": "https://irrlicht.io/#software"},
+  "proficiencyLevel": "Beginner"
+}
+```
+
+BreadcrumbList for each: `Home > Documentation > [Page Name]`
+
+---
+
+### AM2 — Add FAQ block to homepage
+**File:** `site/index.html`
+**Impact:** AI citability, Google AI Overviews, long-tail query coverage
+
+Add before the footer, a FAQ section with `FAQPage` JSON-LD and H3 question headings:
+
+Suggested questions:
+- "What is Irrlicht?" (explicitly disambiguate from Irrlicht 3D engine)
+- "Which AI coding agents does Irrlicht support?"
+- "How does Irrlicht detect agent state?"
+- "Does Irrlicht send data to the cloud?"
+- "What does each light color mean?"
+- "Is Irrlicht free?"
+
+---
+
+### AM3 — Rewrite homepage H2 headings to include keywords
+**File:** `site/index.html`
+**Impact:** On-page SEO, keyword signals in heading outline
+
+Current → Proposed:
+- "Three states. No ambiguity." → "Three Agent States, Zero Ambiguity"
+- "Everything you need, nothing you don't" → "Real-Time AI Agent Monitoring Features"
+- "What Irrlicht works with" → "Supported AI Agents and Platforms"
+- "Up and running in sixty seconds" → "Install Irrlicht in Sixty Seconds"
+
+(Keep marketing phrasing in the `<p class="section-desc">` copy below each heading.)
+
+---
+
+### AM4 — Create llms-full.txt
+**File:** `site/llms-full.txt` (new file)
+**Impact:** AI citability — enables LLMs to answer detailed questions without 9+ fetches
+
+Compile the full prose content from each documentation page into a single Markdown file. Reference it from `llms.txt` with a comment line. Add it to `sitemap.xml`.
+
+---
+
+### AM5 — Disambiguate Irrlicht from the 3D engine
+**File:** `site/llms.txt`, `site/index.html` (FAQ), `site/index.html` (meta description update)
+**Impact:** AI search — critical for ChatGPT/Perplexity where the 3D engine dominates training data
+
+Add to `llms.txt` (after the blockquote):
+```
+Note: Irrlicht (this macOS menu bar app) is unrelated to the Irrlicht 3D rendering engine (irrlicht3d.org). This tool monitors AI coding agent sessions; the name refers to the will-o'-the-wisp (Irrlicht) from Goethe's Faust.
+```
+
+Include the same disambiguation in the FAQ answer for "What is Irrlicht?".
+
+---
+
+### AM6 — Add `twitter:description` to landscape page
+**File:** `site/landscape/index.html`
+**Impact:** Social — Twitter card renders incomplete without it
+
+```html
+<meta name="twitter:description" content="[same as og:description on that page]">
+```
+
+---
+
+### AM7 — Add og:site_name to landscape page
+**File:** `site/landscape/index.html`
+**Impact:** Consistency — all other pages have this tag
+
+```html
+<meta property="og:site_name" content="Irrlicht">
+```
+
+---
+
+### AM8 — Add missing SoftwareApplication schema properties
+**File:** `site/index.html` (JSON-LD Block 1)
+**Impact:** Schema — fills recommended Google rich result fields
+
+Add to the SoftwareApplication block:
+```json
+"screenshot": "https://irrlicht.io/assets/og-image.png",
+"datePublished": "2026-04-07",
+"dateModified": "2026-04-07",
+"applicationSubCategory": "Developer Tools",
+"softwareRequirements": "macOS 13 Ventura or later"
+```
+
+---
+
+### AM9 — Expand quickstart.html with troubleshooting
+**File:** `site/docs/quickstart.html`
+**Impact:** Content depth, E-E-A-T, user satisfaction
+
+Add at minimum:
+- H2: "Troubleshooting" — Gatekeeper approval, daemon not starting, no sessions appearing
+- H2: "Understanding Context Pressure" — explain what the percentage means
+- Cross-reference to installation.html for Gatekeeper step
+
+---
+
+### AM10 — Populate changelog.html
+**File:** `site/docs/changelog.html`
+**Impact:** Freshness signal, trustworthiness, version history
+
+Add at minimum v0.3.2 and v0.3.1 release notes. A visible changelog is a strong trustworthiness signal for developer tools.
+
+---
+
+## Low Priority (Backlog)
+
+### AL1 — Add IndexNow to deploy pipeline
+Generate an IndexNow key, place `<key>.txt` at site root, and fire a POST to `https://api.indexnow.org/indexnow` on each GitHub Pages deploy. Near-instant indexing on Bing.
+
+### AL2 — Add custom 404.html
+Create `site/404.html` with site navigation and links back to homepage and docs hub.
+
+### AL3 — Add explicit AI crawler rules to robots.txt
+Add named `User-agent: GPTBot`, `ClaudeBot`, `PerplexityBot` blocks before the catch-all to signal deliberate AI-readiness.
+
+### AL4 — Add `<link rel="alternate">` for llms.txt
+In `<head>` of index.html:
+```html
+<link rel="alternate" type="text/plain" title="LLMs.txt" href="/llms.txt">
+```
+
+### AL5 — Add `rel="me"` author link
+In `<head>` of index.html:
+```html
+<link rel="me" href="https://github.com/ingo-eichhorst">
+```
+
+### AL6 — Add `<changefreq>` to sitemap
+Add `<changefreq>weekly</changefreq>` to homepage and landscape, `<changefreq>monthly</changefreq>` to stable docs.
+
+### AL7 — Pause canvas animation on tab hidden
+In the wisp canvas IIFE, add:
+```js
+let rafId;
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) cancelAnimationFrame(rafId);
+  else rafId = requestAnimationFrame(animate);
+});
+// Replace requestAnimationFrame(animate) calls with: rafId = requestAnimationFrame(animate)
+```
+
+### AL8 — Create a YouTube demo video
+A 2-3 min screen recording titled "Irrlicht — macOS Menu Bar Monitor for Claude Code and AI Agents". YouTube mentions correlate ~0.737 with AI citation frequency (strongest known GEO signal).
+
+### AL9 — Expand sameAs in Organization schema
+Once any of these exist, add to `sameAs`: Product Hunt listing, AlternativeTo page, Homebrew Cask entry, Hacker News launch post.
+
+---
+
+## Bugs Fixed in This Audit
+
+| File | Line | Issue | Fix Applied |
+|---|---|---|---|
+| `site/docs/installation.html` | 139 | `git clone` URL used `anthropics/irrlicht` (wrong org) | Changed to `ingo-eichhorst/Irrlicht` |
+
+---
+
+## Score Projection After Fixes
+
+| Category | Current | After Critical+High | After All |
+|---|---|---|---|
+| Technical SEO | 72 | 88 | 93 |
+| Content Quality | 62 | 74 | 82 |
+| On-Page SEO | 58 | 74 | 81 |
+| Schema | 58 | 76 | 85 |
+| Performance | 48 | 72 | 78 |
+| Images | 45 | 80 | 84 |
+| AI Search | 62 | 72 | 82 |
+| **Overall** | **61** | **79** | **85** |

--- a/site/FULL-AUDIT-REPORT.md
+++ b/site/FULL-AUDIT-REPORT.md
@@ -1,0 +1,263 @@
+# Irrlicht SEO Full Audit Report
+**Date:** 2026-04-10
+**Scope:** irrlicht.io — all pages in site/
+
+---
+
+## SEO Health Score: 61 / 100
+
+| Category | Weight | Score | Weighted |
+|---|---|---|---|
+| Technical SEO | 25% | 72 | 18.0 |
+| Content Quality / E-E-A-T | 25% | 62 | 15.5 |
+| On-Page SEO | 20% | 58 | 11.6 |
+| Schema / Structured Data | 10% | 58 | 5.8 |
+| Performance (Core Web Vitals) | 10% | 48 | 4.8 |
+| Images | 5% | 45 | 2.3 |
+| AI Search Readiness (GEO) | 5% | 62 | 3.1 |
+| **Total** | | | **61 / 100** |
+
+---
+
+## Business Context
+
+- **Site type:** Open-source macOS developer tool (SoftwareApplication)
+- **Target audience:** Developers running Claude Code, OpenAI Codex, Pi, or other AI coding agents
+- **Deployment:** Static HTML, GitHub Pages
+- **Pages crawled:** 16 (index.html, docs/index.html, 13 doc pages, landscape/index.html)
+- **Canonical domain:** https://irrlicht.io/
+
+---
+
+## Top 5 Critical Issues
+
+1. **1.7 MB unoptimized PNG hero image** — primary LCP killer. No WebP/AVIF, no preload hint, CSS background discovery is late. Estimated LCP on mobile: Poor.
+2. **H1 contains only the brand name "Irrlicht"** — no topic descriptor. Crawler and quality rater cannot identify page topic from the heading hierarchy.
+3. **/landscape/ page missing from sitemap.xml** — an indexed, linked page completely absent from the sitemap.
+4. **Wrong GitHub URL in installation.html (already fixed)** — `anthropics/irrlicht` was the source, now corrected to `ingo-eichhorst/Irrlicht`.
+5. **BreadcrumbList on homepage shows Home > Documentation** — semantically inverted; homepage cannot be its own child.
+
+---
+
+## Top 5 Quick Wins
+
+1. Add `<link rel="preload" as="image" href="assets/bg_no_lights.png">` to `<head>` — 1 line, immediate LCP improvement.
+2. Add `/landscape/` entry to `sitemap.xml` — 5-minute edit, immediate crawl coverage.
+3. Add `async` to the counter.dev script tag — 6 characters, eliminates synchronous parsing block.
+4. Fix BreadcrumbList — change to single-item `[Home]` or remove it from homepage.
+5. Add `og:image` meta tag — unlocks social sharing previews across all platforms.
+
+---
+
+## Technical SEO — 72 / 100
+
+### Critical
+| # | Issue | File |
+|---|---|---|
+| T1 | `/landscape/index.html` not in sitemap.xml | site/sitemap.xml |
+
+### High
+| # | Issue | File |
+|---|---|---|
+| T2 | Hero `bg_no_lights.png` (1.7 MB) loaded via CSS with no preload hint | site/index.html |
+| T3 | Google Fonts stylesheet is render-blocking on all 16 pages | All pages |
+| T4 | No `og:image` or `twitter:image` on any page | All pages |
+| T5 | Landscape page (`landscape/index.html`) has no analytics script | site/landscape/index.html |
+
+### Medium
+| # | Issue | File |
+|---|---|---|
+| T6 | `twitter:description` missing from landscape page | site/landscape/index.html |
+| T7 | No structured data on docs pages or landscape page | site/docs/*.html, landscape/ |
+| T8 | Sitemap has no `<changefreq>` elements; useful for Bing/Yandex | site/sitemap.xml |
+| T9 | No IndexNow key or submission mechanism | Deploy pipeline |
+| T10 | No custom `404.html` — GitHub Pages shows generic error | site/ |
+| T11 | `dmg-background.tiff` (1.0 MB) is served from web root but not referenced in HTML | site/assets/ |
+
+### Low
+| # | Issue | File |
+|---|---|---|
+| T12 | Doc pages use `.html` extension; no clean-URL fallback testing confirmed | site/docs/ |
+| T13 | `og:site_name` missing from landscape page | site/landscape/index.html |
+| T14 | Per-page BreadcrumbList absent from all doc pages and landscape | All pages |
+| T15 | `llms.txt` exists but does not include landscape URL (mirrors sitemap gap) | site/llms.txt |
+
+---
+
+## Content Quality / E-E-A-T — 62 / 100
+
+### E-E-A-T Dimension Scores
+| Dimension | Score |
+|---|---|
+| Experience | 12 / 20 |
+| Expertise | 18 / 25 |
+| Authoritativeness | 15 / 25 |
+| Trustworthiness | 25 / 30 |
+
+### Critical
+| # | Issue | File | Line |
+|---|---|---|---|
+| C1 | H1 contains only brand name — no topic descriptor | site/index.html | 1045 |
+| C2 | No visible author attribution on any page | All pages | — |
+| C3 | Wrong GitHub org in clone command: `anthropics/irrlicht` **[FIXED]** | site/docs/installation.html | 139 |
+
+### High
+| # | Issue | File |
+|---|---|---|
+| C4 | Homepage body word count ~490-520 words — at the floor, no narrative depth | site/index.html |
+| C5 | Zero social proof (no star count, no user count, no testimonials) | site/index.html |
+| C6 | Quickstart page is ~220 words, no troubleshooting section | site/docs/quickstart.html |
+| C7 | H2 headings contain no primary keywords ("Three states. No ambiguity." etc.) | site/index.html |
+
+### Medium
+| # | Issue | File |
+|---|---|---|
+| C8 | No TechArticle schema on doc pages despite `og:type: article` in OG meta | site/docs/*.html |
+| C9 | changelog.html is linked in footer/nav but appears to be empty/stub | site/docs/changelog.html |
+| C10 | Feature cards lack "how" mechanism explanations (e.g., Cost Estimation: "Know what you're spending" — no mechanism) | site/index.html |
+| C11 | No FAQ / Q&A content block anywhere on the homepage | site/index.html |
+
+### Low
+| # | Issue | File |
+|---|---|---|
+| C12 | No `og:image` — social sharing renders with no preview image | All pages |
+| C13 | Twitter card type `summary` instead of `summary_large_image` | All pages |
+| C14 | `counter.dev` analytics `data-id` is publicly visible in source | All pages |
+| C15 | No `rel="me"` author link in homepage `<head>` | site/index.html |
+
+---
+
+## Schema / Structured Data — 58 / 100
+
+The homepage has 4 JSON-LD blocks (SoftwareApplication, Organization, WebSite, BreadcrumbList). Foundation is good; execution has gaps.
+
+### Critical
+| # | Issue | Details |
+|---|---|---|
+| S1 | BreadcrumbList on homepage is inverted — shows `Home > Documentation` on the homepage itself | Block 4 |
+| S2 | URL inconsistency: `https://irrlicht.io` (no trailing slash) vs `https://irrlicht.io/` across Blocks 1, 2, 3 | Blocks 1–3 |
+
+### High
+| # | Issue |
+|---|---|
+| S3 | Zero structured data on all 13 doc pages (no TechArticle, no BreadcrumbList) |
+| S4 | No `@id` on Organization, WebSite, or Person — entity linking impossible |
+
+### Medium
+| # | Issue |
+|---|---|
+| S5 | `screenshot` property missing from SoftwareApplication |
+| S6 | `datePublished` / `dateModified` absent from SoftwareApplication |
+| S7 | `logo` is a bare URL string rather than an `ImageObject` with dimensions |
+| S8 | WebSite `publisher` is inline object, not `@id` reference to Organization block |
+
+### Low
+| # | Issue |
+|---|---|
+| S9 | `applicationSubCategory` and `softwareRequirements` missing |
+| S10 | `author` Person described twice (SoftwareApplication + Organization) without shared `@id` |
+
+---
+
+## Performance (Core Web Vitals) — 48 / 100
+
+| Metric | Predicted Status | Primary Cause |
+|---|---|---|
+| LCP | Poor / Needs Improvement | 1.7 MB unpreloaded PNG + render-blocking Fonts |
+| CLS | Needs Improvement | Cormorant Garamond FOUT with no `size-adjust` |
+| INP | Good | Minimal interactive JS |
+
+### Asset sizes (measured)
+| Asset | Size | Used? |
+|---|---|---|
+| bg_no_lights.png | 1.7 MB | Yes (hero CSS background) |
+| bg_lights.png | 1.7 MB | No (unreferenced in index.html) |
+| bg_lights_2.png | 1.7 MB | No (unreferenced in index.html) |
+| dmg-background.tiff | 1.0 MB | No |
+| apple-touch-icon.png | 3.6 KB | Yes |
+
+### Critical
+| # | Issue |
+|---|---|
+| P1 | `bg_no_lights.png` is 1.7 MB PNG, loaded via CSS background with no `<link rel="preload">`. Converting to AVIF expected to yield ~150-300 KB (85-90% reduction). |
+| P2 | Google Fonts stylesheet is render-blocking — delays H1 text paint (primary LCP candidate). |
+
+### High
+| # | Issue |
+|---|---|
+| P3 | `counter.dev` script has no `async` or `defer` — synchronous block at end of `<body>`. |
+| P4 | CLS from Google Fonts FOUT: Cormorant Garamond is a display serif with unusual metrics; no `size-adjust` or `font-display: optional` compensation. |
+
+### Medium
+| # | Issue |
+|---|---|
+| P5 | Canvas animation loop runs indefinitely with no `visibilitychange` pause. |
+| P6 | `bg_lights.png` and `bg_lights_2.png` (1.7 MB each) are in the deployment but unreferenced — remove or convert. |
+| P7 | `dmg-background.tiff` (1.0 MB) is a build artifact served from web root. |
+| P8 | No `<link rel="preconnect" href="https://cdn.counter.dev">` in `<head>`. |
+
+---
+
+## AI Search Readiness (GEO) — 62 / 100
+
+| Platform | Score |
+|---|---|
+| Google AI Overviews | 55/100 |
+| ChatGPT | 48/100 |
+| Perplexity | 65/100 |
+| Bing Copilot | 58/100 |
+
+### Critical Signal: Brand Name Conflict
+"Irrlicht" is also a well-established C++ 3D rendering engine (irrlicht3d.org) with a Wikipedia article and 20+ years of web presence. AI systems trained on historical data will associate "Irrlicht" primarily with the 3D engine. **Any query containing only "Irrlicht" will likely return the 3D engine, not this tool.**
+
+### llms.txt Assessment
+- Present and well-structured: ✓
+- Has a citable 95-word summary: ✓
+- Links to 9 documentation pages: ✓
+- Missing: `llms-full.txt` companion file with full prose content
+- Missing: daemon name (`irrlichd`), CLI (`irrlicht-ls`), API shapes, version, macOS requirement
+- Missing: landscape page URL (mirrors sitemap gap)
+- Missing: `<link rel="alternate" type="text/plain" title="LLMs.txt" href="/llms.txt">` in HTML head
+
+### Citability Gaps
+- Hero text is marketing copy, not citable ("In Faust, an Irrlicht guides...")
+- No question-format headings anywhere on the site
+- No FAQ block
+- Feature cards too short for self-contained citation
+- Strongest citable line: `Transcript Files → FSEvents/kqueue → SessionDetector → State Machine → WebSocket → Menu Bar` (pipeline-code div)
+
+### robots.txt
+- All AI crawlers permitted (wildcard `Allow: /`) ✓
+- No explicit named rules for major AI crawlers (GPTBot, ClaudeBot, PerplexityBot)
+- No training-opt-out for CCBot/anthropic-ai/cohere-ai if needed
+
+---
+
+## Sitemap Analysis
+
+15 URLs present. Issues:
+- `/landscape/` is **missing** (indexed, linked from nav + footer)
+- `/llms.txt` not listed (optional but beneficial)
+- All `lastmod` dates are `2026-04-04` (consistent, recent)
+- No `<changefreq>` on any URL
+
+---
+
+## robots.txt Analysis
+
+```
+User-agent: *
+Allow: /
+Sitemap: https://irrlicht.io/sitemap.xml
+```
+
+- No AI crawlers blocked ✓
+- No directories blocked ✓  
+- Sitemap reference present ✓
+- No explicit named AI crawler rules (informational gap, not a problem)
+
+---
+
+## llms.txt Analysis
+
+Present at `https://irrlicht.io/llms.txt`. Well-formed baseline, notable gaps documented above.

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -136,8 +136,8 @@
 
       <h3>One-command build</h3>
 
-      <pre><code>git clone https://github.com/anthropics/irrlicht.git
-cd irrlicht
+      <pre><code>git clone https://github.com/ingo-eichhorst/Irrlicht.git
+cd Irrlicht
 ./platforms/build-release.sh</code></pre>
 
       <p>The script produces a <code>.dmg</code> (and optionally a <code>.pkg</code>) in the build directory.</p>


### PR DESCRIPTION
## Summary

- **Bug fix**: `site/docs/installation.html` — the build-from-source `git clone` command pointed to `anthropics/irrlicht` (wrong org). Fixed to `ingo-eichhorst/Irrlicht` (also fixes the subsequent `cd irrlicht` → `cd Irrlicht`).
- **SEO audit**: Full site audit across 5 specialist agents (technical, content/E-E-A-T, schema, performance, GEO). Overall score: **61/100**.
  - `site/FULL-AUDIT-REPORT.md` — detailed findings by category
  - `site/ACTION-PLAN.md` — prioritised action items (Critical → Low), with projected score 79/100 after Critical+High fixes

Closes #98

## Test plan

- [ ] Verify `git clone` command on installation.html now uses the correct org/repo
- [ ] Review `FULL-AUDIT-REPORT.md` for accuracy
- [ ] Pick Critical/High items from `ACTION-PLAN.md` for follow-up issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)