### PR TITLE
feat(tailer): replace FIFO tool tracking with id-keyed map

### DIFF
--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -191,11 +191,15 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 				if block, ok := item.(map[string]interface{}); ok {
 					switch block["type"] {
 					case "tool_use":
-						if name, ok := block["name"].(string); ok {
-							ev.ToolUseNames = append(ev.ToolUseNames, name)
+						id, _ := block["id"].(string)
+						name, _ := block["name"].(string)
+						if name != "" {
+							ev.ToolUses = append(ev.ToolUses, tailer.ToolUse{ID: id, Name: name})
 						}
 					case "tool_result":
-						ev.ToolResultCount++
+						if toolUseID, ok := block["tool_use_id"].(string); ok && toolUseID != "" {
+							ev.ToolResultIDs = append(ev.ToolResultIDs, toolUseID)
+						}
 						if isErr, ok := block["is_error"].(bool); ok && isErr {
 							ev.IsError = true
 						}

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -98,8 +98,8 @@ func TestParser_ToolUseInContent(t *testing.T) {
 	if ev == nil {
 		t.Fatal("expected non-nil event")
 	}
-	if len(ev.ToolUseNames) != 1 || ev.ToolUseNames[0] != "Bash" {
-		t.Errorf("ToolUseNames = %v, want [Bash]", ev.ToolUseNames)
+	if len(ev.ToolUses) != 1 || ev.ToolUses[0].Name != "Bash" || ev.ToolUses[0].ID != "tu_1" {
+		t.Errorf("ToolUses = %v, want [{tu_1 Bash}]", ev.ToolUses)
 	}
 }
 
@@ -118,8 +118,8 @@ func TestParser_ToolResultInContent(t *testing.T) {
 	if ev == nil {
 		t.Fatal("expected non-nil event")
 	}
-	if ev.ToolResultCount != 1 {
-		t.Errorf("ToolResultCount = %d, want 1", ev.ToolResultCount)
+	if len(ev.ToolResultIDs) != 1 || ev.ToolResultIDs[0] != "tu_1" {
+		t.Errorf("ToolResultIDs = %v, want [tu_1]", ev.ToolResultIDs)
 	}
 }
 
@@ -268,8 +268,8 @@ func TestParser_AssistantFinal_ToolUse(t *testing.T) {
 	if ev.EventType != "assistant" {
 		t.Errorf("EventType = %q, want assistant (stop_reason=tool_use)", ev.EventType)
 	}
-	if len(ev.ToolUseNames) != 1 || ev.ToolUseNames[0] != "Read" {
-		t.Errorf("ToolUseNames = %v, want [Read]", ev.ToolUseNames)
+	if len(ev.ToolUses) != 1 || ev.ToolUses[0].Name != "Read" || ev.ToolUses[0].ID != "tu_1" {
+		t.Errorf("ToolUses = %v, want [{tu_1 Read}]", ev.ToolUses)
 	}
 }
 

--- a/core/adapters/inbound/agents/codex/parser.go
+++ b/core/adapters/inbound/agents/codex/parser.go
@@ -73,7 +73,7 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 		}
 
 	case "function_call_output":
-		parseCodexFunctionCallOutput(ev)
+		parseCodexFunctionCallOutput(raw, ev)
 
 	case "event_msg":
 		// Most event_msg payloads are metadata (token_count, task_started,
@@ -129,12 +129,14 @@ func parseCodexResponseItem(payload map[string]interface{}, ev *tailer.ParsedEve
 	case "function_call", "custom_tool_call":
 		return parseCodexFunctionCall(payload, ev)
 	case "function_call_output", "custom_tool_call_output":
-		parseCodexFunctionCallOutput(ev)
+		parseCodexFunctionCallOutput(payload, ev)
 		return true
 	case "web_search_call":
+		// Self-closing tool: both opens and closes in the same event.
 		ev.EventType = "function_call_output"
-		ev.ToolUseNames = []string{"web_search"}
-		ev.ToolResultCount = 1
+		id, _ := payload["id"].(string)
+		ev.ToolUses = []tailer.ToolUse{{ID: id, Name: "web_search"}}
+		ev.ToolResultIDs = []string{id}
 		return true
 	default:
 		return false
@@ -143,16 +145,19 @@ func parseCodexResponseItem(payload map[string]interface{}, ev *tailer.ParsedEve
 
 func parseCodexFunctionCall(raw map[string]interface{}, ev *tailer.ParsedEvent) bool {
 	name, _ := raw["name"].(string)
+	callID, _ := raw["call_id"].(string)
 	ev.EventType = "function_call"
-	if name != "" {
-		ev.ToolUseNames = []string{name}
+	if name != "" || callID != "" {
+		ev.ToolUses = []tailer.ToolUse{{ID: callID, Name: name}}
 	}
 	return true
 }
 
-func parseCodexFunctionCallOutput(ev *tailer.ParsedEvent) {
+func parseCodexFunctionCallOutput(raw map[string]interface{}, ev *tailer.ParsedEvent) {
 	ev.EventType = "function_call_output"
-	ev.ToolResultCount = 1
+	if callID, ok := raw["call_id"].(string); ok && callID != "" {
+		ev.ToolResultIDs = []string{callID}
+	}
 }
 
 func extractCodexContentChars(raw map[string]interface{}) int64 {

--- a/core/adapters/inbound/agents/codex/parser_test.go
+++ b/core/adapters/inbound/agents/codex/parser_test.go
@@ -110,6 +110,7 @@ func TestParser_FunctionCall(t *testing.T) {
 	ev := p.ParseLine(map[string]interface{}{
 		"type":      "function_call",
 		"name":      "shell",
+		"call_id":   "call_abc",
 		"arguments": `{"command":["zsh","-lc","ls"]}`,
 		"timestamp": ts(2),
 	})
@@ -119,8 +120,8 @@ func TestParser_FunctionCall(t *testing.T) {
 	if ev.EventType != "function_call" {
 		t.Errorf("EventType = %q, want function_call", ev.EventType)
 	}
-	if len(ev.ToolUseNames) != 1 || ev.ToolUseNames[0] != "shell" {
-		t.Errorf("ToolUseNames = %v, want [shell]", ev.ToolUseNames)
+	if len(ev.ToolUses) != 1 || ev.ToolUses[0].Name != "shell" || ev.ToolUses[0].ID != "call_abc" {
+		t.Errorf("ToolUses = %v, want [{call_abc shell}]", ev.ToolUses)
 	}
 }
 
@@ -137,8 +138,8 @@ func TestParser_FunctionCall_WithoutNameStillCountsAsActivity(t *testing.T) {
 	if ev.EventType != "function_call" {
 		t.Errorf("EventType = %q, want function_call", ev.EventType)
 	}
-	if len(ev.ToolUseNames) != 0 {
-		t.Errorf("ToolUseNames = %v, want empty", ev.ToolUseNames)
+	if len(ev.ToolUses) != 0 {
+		t.Errorf("ToolUses = %v, want empty", ev.ToolUses)
 	}
 }
 
@@ -156,8 +157,8 @@ func TestParser_FunctionCallOutput(t *testing.T) {
 	if ev.EventType != "function_call_output" {
 		t.Errorf("EventType = %q, want function_call_output", ev.EventType)
 	}
-	if ev.ToolResultCount != 1 {
-		t.Errorf("ToolResultCount = %d, want 1", ev.ToolResultCount)
+	if len(ev.ToolResultIDs) != 1 || ev.ToolResultIDs[0] != "call_abc" {
+		t.Errorf("ToolResultIDs = %v, want [call_abc]", ev.ToolResultIDs)
 	}
 }
 
@@ -275,8 +276,8 @@ func TestParser_WrappedCustomAndWebSearchTools(t *testing.T) {
 	if custom.EventType != "function_call" {
 		t.Errorf("custom EventType = %q, want function_call", custom.EventType)
 	}
-	if len(custom.ToolUseNames) != 1 || custom.ToolUseNames[0] != "apply_patch" {
-		t.Errorf("custom ToolUseNames = %v, want [apply_patch]", custom.ToolUseNames)
+	if len(custom.ToolUses) != 1 || custom.ToolUses[0].Name != "apply_patch" || custom.ToolUses[0].ID != "call_patch" {
+		t.Errorf("custom ToolUses = %v, want [{call_patch apply_patch}]", custom.ToolUses)
 	}
 
 	web := p.ParseLine(map[string]interface{}{
@@ -284,6 +285,7 @@ func TestParser_WrappedCustomAndWebSearchTools(t *testing.T) {
 		"timestamp": ts(1),
 		"payload": map[string]interface{}{
 			"type":   "web_search_call",
+			"id":     "ws_1",
 			"status": "completed",
 			"action": map[string]interface{}{"type": "search", "query": "irrlicht issue 90"},
 		},
@@ -294,11 +296,11 @@ func TestParser_WrappedCustomAndWebSearchTools(t *testing.T) {
 	if web.EventType != "function_call_output" {
 		t.Errorf("web EventType = %q, want function_call_output", web.EventType)
 	}
-	if len(web.ToolUseNames) != 1 || web.ToolUseNames[0] != "web_search" {
-		t.Errorf("web ToolUseNames = %v, want [web_search]", web.ToolUseNames)
+	if len(web.ToolUses) != 1 || web.ToolUses[0].Name != "web_search" {
+		t.Errorf("web ToolUses = %v, want [{ws_1 web_search}]", web.ToolUses)
 	}
-	if web.ToolResultCount != 1 {
-		t.Errorf("web ToolResultCount = %d, want 1", web.ToolResultCount)
+	if len(web.ToolResultIDs) != 1 || web.ToolResultIDs[0] != "ws_1" {
+		t.Errorf("web ToolResultIDs = %v, want [ws_1]", web.ToolResultIDs)
 	}
 }
 

--- a/core/adapters/inbound/agents/pi/parser.go
+++ b/core/adapters/inbound/agents/pi/parser.go
@@ -87,8 +87,10 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 			for _, item := range contentArr {
 				if block, ok := item.(map[string]interface{}); ok {
 					if block["type"] == "toolCall" {
-						if name, ok := block["name"].(string); ok {
-							ev.ToolUseNames = append(ev.ToolUseNames, name)
+						id, _ := block["id"].(string)
+						name, _ := block["name"].(string)
+						if name != "" {
+							ev.ToolUses = append(ev.ToolUses, tailer.ToolUse{ID: id, Name: name})
 						}
 					}
 				}
@@ -112,7 +114,9 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 
 	case "toolResult":
 		ev.EventType = "tool_result"
-		ev.ToolResultCount = 1 // Single canonical count — NOT also counted in addMessageEvent.
+		if toolCallID, ok := piMsg["toolCallId"].(string); ok && toolCallID != "" {
+			ev.ToolResultIDs = []string{toolCallID}
+		}
 		if isErr, ok := piMsg["isError"].(bool); ok && isErr {
 			ev.IsError = true
 		}

--- a/core/adapters/inbound/agents/pi/parser_test.go
+++ b/core/adapters/inbound/agents/pi/parser_test.go
@@ -155,14 +155,14 @@ func TestParser_AssistantMidTurn(t *testing.T) {
 	if ev.EventType != "assistant" {
 		t.Errorf("EventType = %q, want assistant (mid-turn)", ev.EventType)
 	}
-	if len(ev.ToolUseNames) != 1 || ev.ToolUseNames[0] != "bash" {
-		t.Errorf("ToolUseNames = %v, want [bash]", ev.ToolUseNames)
+	if len(ev.ToolUses) != 1 || ev.ToolUses[0].Name != "bash" || ev.ToolUses[0].ID != "call_1" {
+		t.Errorf("ToolUses = %v, want [{call_1 bash}]", ev.ToolUses)
 	}
 }
 
 func TestParser_ToolResult_SingleCount(t *testing.T) {
-	// This is the Bug 1 regression test: toolResult should be counted
-	// exactly once (in the parser), not also in addMessageEvent.
+	// This is the Bug 1 regression test: toolResult should produce exactly
+	// one ToolResultID (in the parser), not also in addMessageEvent.
 	p := &Parser{}
 	ev := p.ParseLine(map[string]interface{}{
 		"type":      "message",
@@ -183,8 +183,8 @@ func TestParser_ToolResult_SingleCount(t *testing.T) {
 	if ev.EventType != "tool_result" {
 		t.Errorf("EventType = %q, want tool_result", ev.EventType)
 	}
-	if ev.ToolResultCount != 1 {
-		t.Errorf("ToolResultCount = %d, want exactly 1 (no double-counting)", ev.ToolResultCount)
+	if len(ev.ToolResultIDs) != 1 || ev.ToolResultIDs[0] != "call_1" {
+		t.Errorf("ToolResultIDs = %v, want [call_1]", ev.ToolResultIDs)
 	}
 }
 

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -9,6 +9,12 @@ import (
 	"time"
 )
 
+// ToolUse represents a single tool invocation with its unique ID.
+type ToolUse struct {
+	ID   string // unique tool call ID (e.g. "toolu_01FUU...", "call_TkY0...", "call_63hf...")
+	Name string // tool name (e.g. "Bash", "Read", "shell")
+}
+
 // ParsedEvent is the normalized output from a format-specific transcript parser.
 // Each parser maps its native event structure into these fields.
 type ParsedEvent struct {
@@ -17,10 +23,10 @@ type ParsedEvent struct {
 	Skip      bool      // true → ignore this line entirely
 
 	// Tool tracking — parser reports deltas, tailer accumulates.
-	ToolUseNames    []string // tool names from tool_use/toolCall blocks in this event
-	ToolResultCount int      // number of tool_result blocks in this event
-	IsError         bool     // true if the tool result had is_error=true
-	ClearToolNames  bool     // true → reset lastOpenToolNames (on user messages)
+	ToolUses      []ToolUse // tool invocations from this event (id + name)
+	ToolResultIDs []string  // IDs of completed tool results in this event
+	IsError       bool      // true if the tool result had is_error=true
+	ClearToolNames bool     // true → reset open tool state (on user messages)
 
 	// IsUserInterrupt is true only for real user ESC cancellations — the
 	// exact "[Request interrupted by user]" text marker on a user event,

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -110,18 +110,20 @@ type TranscriptTailer struct {
 	// Context window override from transcript or extended context model suffix.
 	contextWindowOverride int64
 
-	// lastOpenToolNames is the single source of truth for currently-open tool
-	// calls. Tool uses append, tool results shift from the front. HasOpenToolCall
-	// and OpenToolCallCount are derived from `len(lastOpenToolNames)`.
+	// openToolCalls is the single source of truth for currently-open tool
+	// calls. Keyed by tool call ID; value is the tool name. Tool uses
+	// insert by ID (idempotent — duplicate IDs overwrite), tool results
+	// delete by ID (orphan IDs are harmless no-ops). HasOpenToolCall and
+	// OpenToolCallCount are derived from len(openToolCalls).
 	//
-	// Historical note: this used to be paired with integer counters
-	// `toolUseCount` / `toolResultCount`, with HasOpenToolCall computed from
-	// (use > result). That allowed the two bookkeeping paths to desync on
-	// orphan tool_result events (--continue resume, compact replay, retries)
-	// leaving metrics in an impossible state (has_open=false, names=["Bash"]).
-	// The classifier then treated the session as done mid-turn, producing
-	// thousands of spurious working→ready flickers. See issue #102.
-	lastOpenToolNames []string
+	// Historical note: this was originally paired integer counters
+	// (toolUseCount/toolResultCount, see #102), then a []string FIFO
+	// (lastOpenToolNames, see #114). Both had the same structural weakness:
+	// no correlation between a tool_result and the tool_use it pertains to.
+	// The id-keyed map eliminates phantom entries from orphan results,
+	// duplicate tool_use events (multi-line splits), and out-of-order
+	// parallel tool closures. See issue #117.
+	openToolCalls map[string]string
 
 	// contentChars accumulates character count from message content for
 	// token estimation when explicit token counts aren't available.
@@ -171,11 +173,12 @@ type TranscriptTailer struct {
 // config fallback.
 func NewTranscriptTailer(path string, parser TranscriptParser, adapter string) *TranscriptTailer {
 	return &TranscriptTailer{
-		path:        path,
-		lastOffset:  0,
-		capacityMgr: capacity.DefaultCapacityManager(),
-		parser:      parser,
-		adapter:     adapter,
+		path:          path,
+		lastOffset:    0,
+		capacityMgr:   capacity.DefaultCapacityManager(),
+		parser:        parser,
+		adapter:       adapter,
+		openToolCalls: make(map[string]string),
 		metrics: &SessionMetrics{
 			MessageHistory: make([]MessageEvent, 0),
 			SessionStartAt: time.Time{},
@@ -284,28 +287,28 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 			continue
 		}
 
-		// Apply tool tracking deltas from the parser. lastOpenToolNames is
-		// the single source of truth — tool_use blocks append, tool_result
-		// blocks shift from the front. Orphan tool_result events (more
-		// results than we've seen uses for — common on --continue resume or
-		// compaction replay) shift a no-op instead of corrupting a counter.
-		t.lastOpenToolNames = append(t.lastOpenToolNames, parsed.ToolUseNames...)
-		for i := 0; i < parsed.ToolResultCount; i++ {
-			if len(t.lastOpenToolNames) > 0 {
-				t.lastOpenToolNames = t.lastOpenToolNames[1:]
+		// Apply tool tracking deltas from the parser. openToolCalls is an
+		// id-keyed map — tool_use events insert by ID (idempotent: duplicate
+		// IDs from multi-line splits overwrite), tool_result events delete by
+		// ID (orphan IDs with no matching entry are harmless no-ops). This
+		// eliminates the FIFO's structural weakness where out-of-order or
+		// orphan results could pop unrelated entries. See issue #117.
+		for _, tu := range parsed.ToolUses {
+			if tu.ID != "" {
+				t.openToolCalls[tu.ID] = tu.Name
 			}
 		}
-		if parsed.ClearToolNames && parsed.ToolResultCount == 0 {
-			t.lastOpenToolNames = nil
+		for _, id := range parsed.ToolResultIDs {
+			delete(t.openToolCalls, id)
+		}
+		if parsed.ClearToolNames && len(parsed.ToolResultIDs) == 0 {
+			t.openToolCalls = make(map[string]string)
 		}
 		// turn_done is Claude Code's authoritative end-of-turn signal. By
 		// definition every non-Agent tool_use opened during the turn has
 		// already received its tool_result, so anything still in
-		// lastOpenToolNames is a stale leak (orphan tool_result from
-		// --continue/compact, multi-line assistant message splits, parallel
-		// tool_use bookkeeping drift — see #114). Reconciling here lets the
-		// classifier see HasOpenToolCall=false and transition
-		// working → ready the way turn_done is supposed to drive.
+		// openToolCalls is a stale leak. Sweeping here lets the classifier
+		// see HasOpenToolCall=false and transition working → ready.
 		//
 		// Agent tool calls are preserved: a sub-agent spawned via the Agent
 		// tool can still be running when the parent's turn_done fires
@@ -313,14 +316,12 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 		// over turn_done for exactly this reason), and InferSubagents relies
 		// on Agent entries in LastOpenToolNames to count in-process
 		// sub-agents. Only non-Agent leaks are swept.
-		if parsed.EventType == "turn_done" && len(t.lastOpenToolNames) > 0 {
-			kept := t.lastOpenToolNames[:0]
-			for _, name := range t.lastOpenToolNames {
-				if name == "Agent" {
-					kept = append(kept, name)
+		if parsed.EventType == "turn_done" && len(t.openToolCalls) > 0 {
+			for id, name := range t.openToolCalls {
+				if name != "Agent" {
+					delete(t.openToolCalls, id)
 				}
 			}
-			t.lastOpenToolNames = kept
 		}
 		// IsUserInterrupt and IsToolDenial each set their own sticky flag;
 		// any subsequent user event that isn't itself the same kind clears
@@ -513,13 +514,17 @@ func (t *TranscriptTailer) computeMetrics() {
 	}
 	t.metrics.RecentEventCount = recentEventCount
 
-	// Open tool calls are derived directly from the name slice — the only
-	// source of truth. See the lastOpenToolNames field comment for why the
-	// previous counter-based approach was removed (issue #102).
-	openCalls := len(t.lastOpenToolNames)
+	// Open tool calls are derived directly from the id-keyed map — the only
+	// source of truth. See the openToolCalls field comment for history (#102,
+	// #114, #117).
+	openCalls := len(t.openToolCalls)
 	t.metrics.OpenToolCallCount = openCalls
 	t.metrics.HasOpenToolCall = openCalls > 0
-	t.metrics.LastOpenToolNames = t.lastOpenToolNames
+	names := make([]string, 0, openCalls)
+	for _, name := range t.openToolCalls {
+		names = append(names, name)
+	}
+	t.metrics.LastOpenToolNames = names
 	t.metrics.LastWasUserInterrupt = t.lastWasUserInterrupt
 	t.metrics.LastWasToolDenial = t.lastWasToolDenial
 	t.metrics.LastCWD = t.lastCWD

--- a/core/pkg/tailer/tool_call_test.go
+++ b/core/pkg/tailer/tool_call_test.go
@@ -105,11 +105,15 @@ func (p *testParser) ParseLine(raw map[string]interface{}) *ParsedEvent {
 				if block, ok := item.(map[string]interface{}); ok {
 					switch block["type"] {
 					case "tool_use":
-						if name, ok := block["name"].(string); ok {
-							ev.ToolUseNames = append(ev.ToolUseNames, name)
+						id, _ := block["id"].(string)
+						name, _ := block["name"].(string)
+						if name != "" {
+							ev.ToolUses = append(ev.ToolUses, ToolUse{ID: id, Name: name})
 						}
 					case "tool_result":
-						ev.ToolResultCount++
+						if toolUseID, ok := block["tool_use_id"].(string); ok && toolUseID != "" {
+							ev.ToolResultIDs = append(ev.ToolResultIDs, toolUseID)
+						}
 						if isErr, ok := block["is_error"].(bool); ok && isErr {
 							ev.IsError = true
 						}
@@ -122,17 +126,21 @@ func (p *testParser) ParseLine(raw map[string]interface{}) *ParsedEvent {
 	// Top-level tool events (not embedded in message.content[]).
 	switch eventType {
 	case "tool_use":
+		id, _ := raw["id"].(string)
 		name, _ := raw["name"].(string)
-		ev.ToolUseNames = append(ev.ToolUseNames, name)
+		ev.ToolUses = append(ev.ToolUses, ToolUse{ID: id, Name: name})
 	case "tool_call":
 		// Legacy format: {"tool_call": {"name": "Bash"}}
 		name := ""
+		id := ""
 		if tc, ok := raw["tool_call"].(map[string]interface{}); ok {
 			name, _ = tc["name"].(string)
+			id, _ = tc["id"].(string)
 		}
-		ev.ToolUseNames = append(ev.ToolUseNames, name)
+		ev.ToolUses = append(ev.ToolUses, ToolUse{ID: id, Name: name})
 	case "tool_result":
-		ev.ToolResultCount++
+		id, _ := raw["tool_use_id"].(string)
+		ev.ToolResultIDs = append(ev.ToolResultIDs, id)
 	}
 
 	// Assistant text.
@@ -208,8 +216,8 @@ func TestHasOpenToolCall_NoToolEvents(t *testing.T) {
 func TestHasOpenToolCall_SinglePairedToolCall(t *testing.T) {
 	path := writeTranscriptLines(t, []map[string]interface{}{
 		{"type": "user", "timestamp": ts(0)},
-		{"type": "tool_use", "timestamp": ts(1)},
-		{"type": "tool_result", "timestamp": ts(2)},
+		{"type": "tool_use", "id": "tu_1", "name": "Bash", "timestamp": ts(1)},
+		{"type": "tool_result", "tool_use_id": "tu_1", "timestamp": ts(2)},
 		{"type": "assistant", "timestamp": ts(3)},
 	})
 
@@ -229,7 +237,7 @@ func TestHasOpenToolCall_SinglePairedToolCall(t *testing.T) {
 func TestHasOpenToolCall_OneOpenToolCall(t *testing.T) {
 	path := writeTranscriptLines(t, []map[string]interface{}{
 		{"type": "user", "timestamp": ts(0)},
-		{"type": "tool_use", "timestamp": ts(1)},
+		{"type": "tool_use", "id": "tu_1", "name": "Bash", "timestamp": ts(1)},
 		// No matching tool_result
 	})
 
@@ -251,7 +259,7 @@ func TestTailAndProcess_LargeAppendedToolResult_NotSkipped(t *testing.T) {
 	// lastOffset and parse the full new JSON line instead of skipping into it.
 	path := writeTranscriptLines(t, []map[string]interface{}{
 		{"type": "user", "timestamp": ts(0)},
-		{"type": "tool_use", "timestamp": ts(1), "name": "Read"},
+		{"type": "tool_use", "id": "tu_read", "name": "Read", "timestamp": ts(1)},
 	})
 
 	tailer := newTestTailer(path)
@@ -264,9 +272,10 @@ func TestTailAndProcess_LargeAppendedToolResult_NotSkipped(t *testing.T) {
 	}
 
 	appendTranscriptLine(t, path, map[string]interface{}{
-		"type":      "tool_result",
-		"timestamp": ts(2),
-		"output":    strings.Repeat("x", 120*1024),
+		"type":        "tool_result",
+		"tool_use_id": "tu_read",
+		"timestamp":   ts(2),
+		"output":      strings.Repeat("x", 120*1024),
 	})
 
 	m, err = tailer.TailAndProcess()
@@ -281,10 +290,10 @@ func TestTailAndProcess_LargeAppendedToolResult_NotSkipped(t *testing.T) {
 func TestHasOpenToolCall_ParallelToolCalls(t *testing.T) {
 	// Simulate 3 parallel tool_use events, only 1 tool_result so far
 	path := writeTranscriptLines(t, []map[string]interface{}{
-		{"type": "tool_use", "timestamp": ts(0)},
-		{"type": "tool_use", "timestamp": ts(1)},
-		{"type": "tool_use", "timestamp": ts(2)},
-		{"type": "tool_result", "timestamp": ts(3)},
+		{"type": "tool_use", "id": "tu_1", "name": "Bash", "timestamp": ts(0)},
+		{"type": "tool_use", "id": "tu_2", "name": "Read", "timestamp": ts(1)},
+		{"type": "tool_use", "id": "tu_3", "name": "Grep", "timestamp": ts(2)},
+		{"type": "tool_result", "tool_use_id": "tu_1", "timestamp": ts(3)},
 	})
 
 	tailer := newTestTailer(path)
@@ -306,8 +315,8 @@ func TestHasOpenToolCall_TurnDoneReconciles(t *testing.T) {
 	// reconcile them so the classifier can transition working → ready.
 	path := writeTranscriptLines(t, []map[string]interface{}{
 		{"type": "user", "timestamp": ts(0)},
-		{"type": "tool_use", "timestamp": ts(1), "name": "Bash"},
-		{"type": "tool_use", "timestamp": ts(2), "name": "Bash"},
+		{"type": "tool_use", "id": "tu_1", "name": "Bash", "timestamp": ts(1)},
+		{"type": "tool_use", "id": "tu_2", "name": "Bash", "timestamp": ts(2)},
 		// No matching tool_results — simulates the phantom-leak state.
 		{"type": "system", "subtype": "turn_duration", "timestamp": ts(3)},
 	})
@@ -339,9 +348,9 @@ func TestHasOpenToolCall_TurnDonePreservesAgent(t *testing.T) {
 	// sub-agents. Only non-Agent leaks get swept.
 	path := writeTranscriptLines(t, []map[string]interface{}{
 		{"type": "user", "timestamp": ts(0)},
-		{"type": "tool_use", "timestamp": ts(1), "name": "Bash"},  // leak
-		{"type": "tool_use", "timestamp": ts(2), "name": "Agent"}, // legit subagent
-		{"type": "tool_use", "timestamp": ts(3), "name": "Read"},  // leak
+		{"type": "tool_use", "id": "tu_1", "name": "Bash", "timestamp": ts(1)},  // leak
+		{"type": "tool_use", "id": "tu_2", "name": "Agent", "timestamp": ts(2)}, // legit subagent
+		{"type": "tool_use", "id": "tu_3", "name": "Read", "timestamp": ts(3)},  // leak
 		{"type": "system", "subtype": "turn_duration", "timestamp": ts(4)},
 	})
 
@@ -365,7 +374,7 @@ func TestHasOpenToolCall_ToolCallEventType(t *testing.T) {
 	// The "tool_call" event type (legacy format) should also be counted
 	path := writeTranscriptLines(t, []map[string]interface{}{
 		{"type": "user", "timestamp": ts(0)},
-		{"tool_call": map[string]interface{}{"name": "Bash"}, "timestamp": ts(1)},
+		{"tool_call": map[string]interface{}{"name": "Bash", "id": "tu_1"}, "timestamp": ts(1)},
 		// No matching tool_result
 	})
 
@@ -384,10 +393,10 @@ func TestHasOpenToolCall_ToolCallEventType(t *testing.T) {
 
 func TestHasOpenToolCall_ExtraResultsClamped(t *testing.T) {
 	// If we start reading mid-stream, we might see more tool_results than
-	// tool_use events. The count should be clamped to 0.
+	// tool_use events. Orphan result IDs are harmless no-ops on the map.
 	path := writeTranscriptLines(t, []map[string]interface{}{
-		{"type": "tool_result", "timestamp": ts(0)},
-		{"type": "tool_result", "timestamp": ts(1)},
+		{"type": "tool_result", "tool_use_id": "tu_orphan1", "timestamp": ts(0)},
+		{"type": "tool_result", "tool_use_id": "tu_orphan2", "timestamp": ts(1)},
 		{"type": "assistant", "timestamp": ts(2)},
 	})
 
@@ -407,12 +416,12 @@ func TestHasOpenToolCall_ExtraResultsClamped(t *testing.T) {
 func TestHasOpenToolCall_MultipleRoundsAllClosed(t *testing.T) {
 	// Multiple tool use/result rounds, all closed
 	path := writeTranscriptLines(t, []map[string]interface{}{
-		{"type": "tool_use", "timestamp": ts(0)},
-		{"type": "tool_result", "timestamp": ts(1)},
-		{"type": "tool_use", "timestamp": ts(2)},
-		{"type": "tool_result", "timestamp": ts(3)},
-		{"type": "tool_use", "timestamp": ts(4)},
-		{"type": "tool_result", "timestamp": ts(5)},
+		{"type": "tool_use", "id": "tu_1", "name": "Bash", "timestamp": ts(0)},
+		{"type": "tool_result", "tool_use_id": "tu_1", "timestamp": ts(1)},
+		{"type": "tool_use", "id": "tu_2", "name": "Read", "timestamp": ts(2)},
+		{"type": "tool_result", "tool_use_id": "tu_2", "timestamp": ts(3)},
+		{"type": "tool_use", "id": "tu_3", "name": "Grep", "timestamp": ts(4)},
+		{"type": "tool_result", "tool_use_id": "tu_3", "timestamp": ts(5)},
 	})
 
 	tailer := newTestTailer(path)
@@ -561,26 +570,26 @@ func TestLastOpenToolNames_AgentToolsPreservedAfterPartialResults(t *testing.T) 
 		{"type": "assistant", "timestamp": ts(0), "message": map[string]interface{}{
 			"role": "assistant", "stop_reason": nil,
 			"content": []interface{}{
-				map[string]interface{}{"type": "tool_use", "name": "Agent"},
+				map[string]interface{}{"type": "tool_use", "id": "tu_agent1", "name": "Agent"},
 			},
 		}},
 		{"type": "assistant", "timestamp": ts(1), "message": map[string]interface{}{
 			"role": "assistant", "stop_reason": nil,
 			"content": []interface{}{
-				map[string]interface{}{"type": "tool_use", "name": "Agent"},
+				map[string]interface{}{"type": "tool_use", "id": "tu_agent2", "name": "Agent"},
 			},
 		}},
 		{"type": "assistant", "timestamp": ts(2), "message": map[string]interface{}{
 			"role": "assistant", "stop_reason": "tool_use",
 			"content": []interface{}{
-				map[string]interface{}{"type": "tool_use", "name": "Agent"},
+				map[string]interface{}{"type": "tool_use", "id": "tu_agent3", "name": "Agent"},
 			},
 		}},
 		// First tool_result arrives (user event with embedded tool_result)
 		{"type": "user", "timestamp": ts(3), "message": map[string]interface{}{
 			"role": "user",
 			"content": []interface{}{
-				map[string]interface{}{"type": "tool_result", "content": "done"},
+				map[string]interface{}{"type": "tool_result", "tool_use_id": "tu_agent1", "content": "done"},
 			},
 		}},
 	})
@@ -619,38 +628,38 @@ func TestLastOpenToolNames_AllAgentResultsCleared(t *testing.T) {
 		{"type": "assistant", "timestamp": ts(0), "message": map[string]interface{}{
 			"role": "assistant", "stop_reason": nil,
 			"content": []interface{}{
-				map[string]interface{}{"type": "tool_use", "name": "Agent"},
+				map[string]interface{}{"type": "tool_use", "id": "tu_agent1", "name": "Agent"},
 			},
 		}},
 		{"type": "assistant", "timestamp": ts(1), "message": map[string]interface{}{
 			"role": "assistant", "stop_reason": nil,
 			"content": []interface{}{
-				map[string]interface{}{"type": "tool_use", "name": "Agent"},
+				map[string]interface{}{"type": "tool_use", "id": "tu_agent2", "name": "Agent"},
 			},
 		}},
 		{"type": "assistant", "timestamp": ts(2), "message": map[string]interface{}{
 			"role": "assistant", "stop_reason": "tool_use",
 			"content": []interface{}{
-				map[string]interface{}{"type": "tool_use", "name": "Agent"},
+				map[string]interface{}{"type": "tool_use", "id": "tu_agent3", "name": "Agent"},
 			},
 		}},
 		// All 3 results
 		{"type": "user", "timestamp": ts(3), "message": map[string]interface{}{
 			"role": "user",
 			"content": []interface{}{
-				map[string]interface{}{"type": "tool_result", "content": "done"},
+				map[string]interface{}{"type": "tool_result", "tool_use_id": "tu_agent1", "content": "done"},
 			},
 		}},
 		{"type": "user", "timestamp": ts(4), "message": map[string]interface{}{
 			"role": "user",
 			"content": []interface{}{
-				map[string]interface{}{"type": "tool_result", "content": "done"},
+				map[string]interface{}{"type": "tool_result", "tool_use_id": "tu_agent2", "content": "done"},
 			},
 		}},
 		{"type": "user", "timestamp": ts(5), "message": map[string]interface{}{
 			"role": "user",
 			"content": []interface{}{
-				map[string]interface{}{"type": "tool_result", "content": "done"},
+				map[string]interface{}{"type": "tool_result", "tool_use_id": "tu_agent3", "content": "done"},
 			},
 		}},
 	})
@@ -669,5 +678,150 @@ func TestLastOpenToolNames_AllAgentResultsCleared(t *testing.T) {
 	}
 	if len(m.LastOpenToolNames) != 0 {
 		t.Errorf("expected empty LastOpenToolNames, got %v", m.LastOpenToolNames)
+	}
+}
+
+// --- Issue #117: id-based tool tracking tests ---
+
+func TestIDTracking_DuplicateToolUseID(t *testing.T) {
+	// Duplicate tool_use with same ID (e.g. multi-line streaming split) should
+	// be idempotent — one delete removes it.
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "tool_use", "id": "tu_1", "name": "Bash", "timestamp": ts(0)},
+		{"type": "tool_use", "id": "tu_1", "name": "Bash", "timestamp": ts(1)}, // duplicate
+		{"type": "tool_result", "tool_use_id": "tu_1", "timestamp": ts(2)},
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=false: duplicate ID should be idempotent")
+	}
+	if m.OpenToolCallCount != 0 {
+		t.Errorf("expected OpenToolCallCount=0, got %d", m.OpenToolCallCount)
+	}
+}
+
+func TestIDTracking_OrphanToolResultID(t *testing.T) {
+	// Orphan tool_result with unknown ID (from --continue/compact replay) should
+	// be a no-op — the real entry must survive.
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "tool_use", "id": "tu_1", "name": "Bash", "timestamp": ts(0)},
+		{"type": "tool_result", "tool_use_id": "tu_unknown", "timestamp": ts(1)}, // orphan
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=true: orphan result should not remove the real entry")
+	}
+	if m.OpenToolCallCount != 1 {
+		t.Errorf("expected OpenToolCallCount=1, got %d", m.OpenToolCallCount)
+	}
+
+	// Now close the real one.
+	appendTranscriptLine(t, path, map[string]interface{}{
+		"type": "tool_result", "tool_use_id": "tu_1", "timestamp": ts(2),
+	})
+	m, err = tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=false after real result arrives")
+	}
+}
+
+func TestIDTracking_ParallelOutOfOrder(t *testing.T) {
+	// 3 parallel tool_use events, results arrive in reverse order.
+	// With the old FIFO this would corrupt state; with id-keyed map each
+	// delete targets the correct entry.
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "tool_use", "id": "tu_1", "name": "Bash", "timestamp": ts(0)},
+		{"type": "tool_use", "id": "tu_2", "name": "Read", "timestamp": ts(1)},
+		{"type": "tool_use", "id": "tu_3", "name": "Grep", "timestamp": ts(2)},
+		{"type": "tool_result", "tool_use_id": "tu_3", "timestamp": ts(3)}, // last finishes first
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.OpenToolCallCount != 2 {
+		t.Errorf("expected 2 open after tu_3 result, got %d", m.OpenToolCallCount)
+	}
+
+	appendTranscriptLine(t, path, map[string]interface{}{
+		"type": "tool_result", "tool_use_id": "tu_1", "timestamp": ts(4),
+	})
+	m, err = tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.OpenToolCallCount != 1 {
+		t.Errorf("expected 1 open after tu_1 result, got %d", m.OpenToolCallCount)
+	}
+	if len(m.LastOpenToolNames) != 1 || m.LastOpenToolNames[0] != "Read" {
+		t.Errorf("expected [Read] remaining, got %v", m.LastOpenToolNames)
+	}
+
+	appendTranscriptLine(t, path, map[string]interface{}{
+		"type": "tool_result", "tool_use_id": "tu_2", "timestamp": ts(5),
+	})
+	m, err = tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=false after all results")
+	}
+}
+
+func TestIDTracking_EmptyID(t *testing.T) {
+	// Empty-ID tool_use degrades to a single-slot fallback via the empty-string
+	// map key. Functional but not ideal — tests graceful degradation.
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "tool_use", "id": "", "name": "Bash", "timestamp": ts(0)},
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Empty IDs are skipped by the insert logic (tu.ID != "")
+	if m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=false: empty ID should be skipped")
+	}
+}
+
+func TestIDTracking_AgentSurvivesTurnDone(t *testing.T) {
+	// Agent + non-Agent open, turn_done sweeps only non-Agent.
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "tool_use", "id": "tu_agent", "name": "Agent", "timestamp": ts(0)},
+		{"type": "tool_use", "id": "tu_bash", "name": "Bash", "timestamp": ts(1)}, // leaked
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(2)},
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=true with Agent still open")
+	}
+	if m.OpenToolCallCount != 1 {
+		t.Errorf("expected OpenToolCallCount=1 (Agent only), got %d", m.OpenToolCallCount)
+	}
+	if len(m.LastOpenToolNames) != 1 || m.LastOpenToolNames[0] != "Agent" {
+		t.Errorf("expected [Agent], got %v", m.LastOpenToolNames)
 	}
 }

--- a/core/pkg/tailer/tool_call_test.go
+++ b/core/pkg/tailer/tool_call_test.go
@@ -128,7 +128,9 @@ func (p *testParser) ParseLine(raw map[string]interface{}) *ParsedEvent {
 	case "tool_use":
 		id, _ := raw["id"].(string)
 		name, _ := raw["name"].(string)
-		ev.ToolUses = append(ev.ToolUses, ToolUse{ID: id, Name: name})
+		if name != "" {
+			ev.ToolUses = append(ev.ToolUses, ToolUse{ID: id, Name: name})
+		}
 	case "tool_call":
 		// Legacy format: {"tool_call": {"name": "Bash"}}
 		name := ""
@@ -137,10 +139,13 @@ func (p *testParser) ParseLine(raw map[string]interface{}) *ParsedEvent {
 			name, _ = tc["name"].(string)
 			id, _ = tc["id"].(string)
 		}
-		ev.ToolUses = append(ev.ToolUses, ToolUse{ID: id, Name: name})
+		if name != "" {
+			ev.ToolUses = append(ev.ToolUses, ToolUse{ID: id, Name: name})
+		}
 	case "tool_result":
-		id, _ := raw["tool_use_id"].(string)
-		ev.ToolResultIDs = append(ev.ToolResultIDs, id)
+		if id, ok := raw["tool_use_id"].(string); ok && id != "" {
+			ev.ToolResultIDs = append(ev.ToolResultIDs, id)
+		}
 	}
 
 	// Assistant text.
@@ -785,8 +790,9 @@ func TestIDTracking_ParallelOutOfOrder(t *testing.T) {
 }
 
 func TestIDTracking_EmptyID(t *testing.T) {
-	// Empty-ID tool_use degrades to a single-slot fallback via the empty-string
-	// map key. Functional but not ideal — tests graceful degradation.
+	// Empty-ID tool_use is skipped by the tailer's insert guard (tu.ID != "").
+	// Not tracked, but harmless — tests graceful degradation when a parser
+	// fails to extract an ID from a transcript format.
 	path := writeTranscriptLines(t, []map[string]interface{}{
 		{"type": "tool_use", "id": "", "name": "Bash", "timestamp": ts(0)},
 	})
@@ -796,7 +802,6 @@ func TestIDTracking_EmptyID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Empty IDs are skipped by the insert logic (tu.ID != "")
 	if m.HasOpenToolCall {
 		t.Error("expected HasOpenToolCall=false: empty ID should be skipped")
 	}


### PR DESCRIPTION
## Summary
- Replaces `lastOpenToolNames []string` FIFO with `openToolCalls map[string]string` keyed by tool call ID, eliminating phantom entries from orphan tool_results, duplicate tool_use events (multi-line splits), and out-of-order parallel tool closures
- Adds `ToolUse{ID, Name}` struct and `ToolResultIDs []string` to `ParsedEvent`, replacing `ToolUseNames`/`ToolResultCount`
- All three adapter parsers (Claude Code, Codex, Pi) now extract tool IDs from their raw event data — IDs were already present but previously ignored

Closes #117

## Test plan
- [x] All 24 unit tests pass (19 existing updated with IDs + 5 new tests for leak patterns)
- [x] New tests cover: duplicate tool_use ID (idempotent), orphan tool_result ID (no-op), parallel out-of-order closing, empty ID graceful degradation, Agent survives turn_done sweep
- [x] All adapter test suites pass (claudecode, codex, pi)
- [x] Full replay harness across 11 fixtures produces identical state transitions vs baseline (zero regressions)
- [x] #114 stuck-working fixtures still reach ready at every turn_done

🤖 Generated with [Claude Code](https://claude.com/claude-code)