### PR TITLE
feat(macos): toggleable cost display (default off)

### DIFF
--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -383,6 +383,7 @@ struct SessionRowView: View {
     let agentNumber: Int
     var activeSubagentCount: Int = 0
     @AppStorage("debugMode") private var debugMode: Bool = false
+    @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
     @State private var isHovered = false
 
     var body: some View {
@@ -434,7 +435,7 @@ struct SessionRowView: View {
                 }
 
                 // Estimated cost
-                if let cost = session.metrics?.formattedCost {
+                if showCostDisplay, let cost = session.metrics?.formattedCost {
                     Text(cost)
                         .font(.system(size: 9, weight: .medium, design: .monospaced))
                         .foregroundColor(.secondary)
@@ -1000,6 +1001,7 @@ struct ProjectGroupSectionView: View {
     let totalProjectGroups: Int
     @EnvironmentObject var sessionManager: SessionManager
     @AppStorage("debugMode") private var debugMode: Bool = false
+    @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
     @State private var isExpanded = true
 
     /// Combined cost of all sessions in the group
@@ -1052,7 +1054,7 @@ struct ProjectGroupSectionView: View {
                             .fontWeight(.semibold)
                             .foregroundColor(projectNameColor)
 
-                        if let cost = formattedTotalCost {
+                        if showCostDisplay, let cost = formattedTotalCost {
                             Text(cost)
                                 .font(.system(size: 9, weight: .medium, design: .monospaced))
                                 .foregroundColor(.secondary)

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsView: View {
     @Binding var isPresented: Bool
     @AppStorage("debugMode") private var debugMode: Bool = false
+    @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -19,6 +20,14 @@ struct SettingsView: View {
                     .foregroundColor(.secondary)
             }
 
+            VStack(alignment: .leading, spacing: 8) {
+                Toggle("Show Estimated Cost", isOn: $showCostDisplay)
+
+                Text("Display estimated USD cost per session and per project group. Cost estimates are approximate.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
             Spacer()
 
             HStack {
@@ -28,6 +37,6 @@ struct SettingsView: View {
             }
         }
         .padding(20)
-        .frame(width: 320, height: 200)
+        .frame(width: 320, height: 260)
     }
 }


### PR DESCRIPTION
## Summary
- Cost estimation is still approximate, so hide the per-session and per-project-group cost labels by default.
- Adds a **Show Estimated Cost** toggle in Settings (gated by `@AppStorage("showCostDisplay")`, default `false`).
- Caption under the toggle notes that estimates are approximate.

## Test plan
- [x] `swift build` passes
- [x] Dev stack launched via `/ir:test-mac`
- [ ] Confirm cost labels are hidden on fresh launch
- [ ] Toggle **Show Estimated Cost** in Settings and confirm cost reappears on both session rows and project group headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)