### PR TITLE
docs(community): add GitHub-recognized community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/adapter_request.yml
+++ b/.github/ISSUE_TEMPLATE/adapter_request.yml
@@ -1,0 +1,79 @@
+name: Adapter request
+description: Request support for a new coding agent or orchestrator.
+title: "[adapter]: support for "
+labels: ["adapter-request", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Irrlicht currently supports Claude Code, OpenAI Codex, Pi, and Gas
+        Town. New adapters are welcome — the more detail you can provide
+        here, the easier it is to prioritize and implement.
+
+        The architecture uses hexagonal inbound adapters under
+        `core/adapters/inbound/<agent>/`. See existing adapters and
+        [docs/adapters.html](https://irrlicht.io/docs/adapters.html) for the
+        integration contract.
+
+  - type: input
+    id: agent-name
+    attributes:
+      label: Agent name
+      placeholder: "e.g. Gemini CLI, OpenCode, Cursor Agent"
+    validations:
+      required: true
+
+  - type: input
+    id: agent-url
+    attributes:
+      label: Project URL
+      placeholder: "https://github.com/..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: usage
+    attributes:
+      label: How do you use it?
+      description: What does a typical session look like? Single-shot? Long-running? Parallel?
+    validations:
+      required: true
+
+  - type: textarea
+    id: transcript
+    attributes:
+      label: Transcript / state location
+      description: |
+        Where does the agent store session data on disk? File format
+        (JSONL, SQLite, plaintext)? How are new sessions discovered?
+      placeholder: "e.g. ~/.gemini/sessions/**/*.jsonl, one file per turn"
+
+  - type: textarea
+    id: state-signals
+    attributes:
+      label: State signals
+      description: |
+        How can Irrlicht tell the agent is **working**, **waiting** (needs
+        you), or **ready** (turn complete) from the transcript or process?
+        Think: prompt markers, process lifecycle, explicit events.
+
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Which platforms does this agent run on?
+      multiple: true
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Cross-platform CLI
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Contribution
+      options:
+        - label: I'm willing to help build and test this adapter.
+        - label: I can provide sample transcripts for fixtures.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,104 @@
+name: Bug report
+description: Something broken or surprising in Irrlicht? Report it here.
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please include logs and
+        version info — it makes the difference between a fix and a guess.
+
+        Daemon logs live at `~/Library/Application Support/Irrlicht/logs/`.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I'm on the latest release from [Releases](https://github.com/ingo-eichhorst/Irrlicht/releases/latest).
+          required: true
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Irrlicht version
+      description: Output of `irrlichd --version`, or the version shown in the app's About panel.
+      placeholder: "e.g. 0.7.3"
+    validations:
+      required: true
+
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      placeholder: "e.g. 14.4 (Sonoma) on Apple Silicon"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Which agent(s) were involved?
+      multiple: true
+      options:
+        - Claude Code
+        - OpenAI Codex
+        - Pi
+        - Gas Town
+        - Not agent-specific / app or daemon itself
+        - Other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and its impact.
+      placeholder: "The menu bar showed 'working' after the agent had already printed end_turn..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start a Claude Code session in project X
+        2. Ask a question that triggers plan mode
+        3. Observe menu bar still showing 'working' instead of 'waiting'
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log excerpts
+      description: |
+        From `~/Library/Application Support/Irrlicht/logs/irrlicht.log`. Redact
+        anything sensitive. Logs are structured JSON — a few lines around the
+        transition you're reporting is usually enough.
+      render: shell
+
+  - type: textarea
+    id: state
+    attributes:
+      label: Session state file (optional)
+      description: Contents of the relevant file under `~/Library/Application Support/Irrlicht/instances/<session_id>.json` if you can share it.
+      render: json
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Screenshots, screen recordings, related issues, hypotheses.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and ideas
+    url: https://github.com/ingo-eichhorst/Irrlicht/discussions
+    about: Use GitHub Discussions for questions, ideas, and "show your setup" posts.
+  - name: Documentation
+    url: https://irrlicht.io/docs/
+    about: Installation, quick start, state machine, adapters, and architecture docs.
+  - name: Security vulnerabilities
+    url: https://github.com/ingo-eichhorst/Irrlicht/security/advisories/new
+    about: Please report security issues privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Propose a new capability or UX improvement for Irrlicht.
+title: "[feat]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing a feature request, consider starting a
+        [Discussion](https://github.com/ingo-eichhorst/Irrlicht/discussions)
+        to gauge interest and collect use cases. Features that fit the
+        project philosophy — zero-config, deterministic, honest signals —
+        have the best shot at landing.
+
+        For new agent adapters (Gemini CLI, OpenCode, Cursor Agent, etc.)
+        please use the **Adapter request** template instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the situation and why current behavior falls short. Please avoid jumping straight to a solution.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How you'd like it to work. UI mockups, API sketches, or CLI examples are welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why they weren't better.
+
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Who benefits from this?
+      multiple: true
+      options:
+        - Single-agent users
+        - Multi-agent users (3+ concurrent sessions)
+        - Orchestrator users (Gas Town, Claude Squad, etc.)
+        - Adapter authors / integrators
+        - Everyone
+    validations:
+      required: true
+
+  - type: textarea
+    id: fit
+    attributes:
+      label: How does this fit the philosophy?
+      description: Zero-config? Deterministic? Does it add signal without noise? If it introduces configuration, why is that worth it?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--
+Thanks for the PR! A few notes before you submit:
+
+  - Run ./validate.sh locally. A change is only done at exit 0.
+  - Keep PRs focused — one concern per PR merges fastest.
+  - For UI changes, include a screenshot or short screen recording.
+  - Reference related issues with "Fixes #123" or "Refs #123".
+-->
+
+## Summary
+
+<!-- What does this PR do, and *why*? One short paragraph is enough. -->
+
+## Changes
+
+<!-- Bullet list of the main things touched. Keep it terse. -->
+
+-
+-
+
+## Test plan
+
+<!-- How you verified the change. Be concrete. -->
+
+- [ ] `./validate.sh` passes locally
+- [ ] Added or updated tests covering the change
+- [ ] Manually exercised the relevant flow (describe below)
+
+<!-- If UI: attach screenshots or a short screen recording. -->
+
+## Related issues
+
+<!-- Fixes #123, Refs #456 -->
+
+## Checklist
+
+- [ ] Follows the conventions in [AGENTS.md](../AGENTS.md) and [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] Commit messages use [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] No new abstractions added ahead of need
+- [ ] Documentation updated if behavior changed (README, `site/docs/`, or `events.md`)
+- [ ] No `cancelled` session state introduced — three states only: `working`, `waiting`, `ready`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,86 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the
+Irrlicht community a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Sexualized language or imagery, and unwelcome sexual attention or advances
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Maintainers are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (GitHub issues,
+pull requests, discussions, and any other Irrlicht venue), and also when an
+individual is officially representing the community in public spaces.
+
+## Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers at **git@ingo-eichhorst.de**. All reports will
+be reviewed and investigated promptly and fairly. Maintainers are obligated
+to respect the privacy and security of the reporter.
+
+## Enforcement Guidelines
+
+### 1. Correction
+
+**Impact:** minor or unintentional inappropriate behavior.
+**Consequence:** private written warning with clarity around the nature of
+the violation. A public apology may be requested.
+
+### 2. Warning
+
+**Impact:** violation through a single incident or series of actions.
+**Consequence:** warning with consequences for continued behavior. No
+interaction with the people involved for a specified period. Violating these
+terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Impact:** serious violation.
+**Consequence:** temporary ban from any sort of interaction or public
+communication with the community for a specified period.
+
+### 4. Permanent Ban
+
+**Impact:** pattern of violation, sustained harassment, or aggression.
+**Consequence:** permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,118 @@
+# Contributing to Irrlicht
+
+Thanks for considering a contribution. Irrlicht is MIT-licensed and welcomes
+bug reports, feature ideas, documentation fixes, and code.
+
+The full contributor guide lives at
+[irrlicht.io/docs/contributing.html](https://irrlicht.io/docs/contributing.html).
+This file is the short version that GitHub surfaces directly on the repo.
+
+## Ways to contribute
+
+- **Report bugs** — [open an issue](https://github.com/ingo-eichhorst/Irrlicht/issues/new/choose)
+- **Request an adapter** — use the *Adapter request* issue template
+- **Discuss ideas** — [GitHub Discussions](https://github.com/ingo-eichhorst/Irrlicht/discussions)
+- **Send a PR** — small, focused changes get merged fastest
+- **Improve docs** — fixes to the site under `site/docs/` and to this repo's markdown are always welcome
+
+First time? Look for issues labeled
+[`good first issue`](https://github.com/ingo-eichhorst/Irrlicht/labels/good%20first%20issue).
+
+## Development setup
+
+Prerequisites: macOS 13+, Go 1.21+, Swift 5.9+, Xcode Command Line Tools.
+
+```bash
+git clone https://github.com/ingo-eichhorst/Irrlicht.git
+cd Irrlicht
+./platforms/build-release.sh   # build daemon + macOS app
+./validate.sh                  # run the full validation pipeline
+```
+
+`./validate.sh` runs Go build → Swift build → Go tests → Swift tests →
+integration tests. **A change is only done when `./validate.sh` exits 0.**
+No exceptions.
+
+Project layout:
+
+```
+core/        Go daemon (hexagonal: domain → ports → adapters → services)
+platforms/   Swift macOS app, web frontend, build scripts
+site/        Landing page and docs (GitHub Pages)
+fixtures/    Sample transcripts and recorded sessions
+```
+
+See [AGENTS.md](AGENTS.md) for the architectural conventions every change is
+expected to follow.
+
+## Pull request workflow
+
+1. Fork and branch from `main` using a prefix: `feat/`, `fix/`, `docs/`, `refactor/`, `test/`.
+2. Keep the change focused — one concern per PR.
+3. Add tests for new behavior; prefer table-driven tests in Go.
+4. Run `./validate.sh` locally.
+5. Push and open a PR. Fill in the PR template (summary, test plan, screenshots for UI work).
+6. Expect review feedback. Small PRs merge faster.
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat(core): add WebSocket reconnection with backoff
+fix(macos): correct state transition on ESC cancellation
+docs(adapters): clarify Gas Town polling cadence
+```
+
+Keep the first line under 72 characters, explain *why*, and reference issues
+when relevant (`Fixes #42`).
+
+## Code guidelines
+
+**Go (daemon).** Follow `gofmt`/`go vet`. Errors are logged via the `Logger`
+interface, not propagated with `fmt.Errorf` for observability-only failures.
+Adapter packages own their format-specific parsers — don't move parsing into
+shared code. Three session states only: `working`, `waiting`, `ready` (no
+`cancelled`).
+
+**Swift (app).** Follow the
+[Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
+Keep SwiftUI views small and composable; use previews for visual tests.
+
+**General.** Don't add abstractions ahead of need. Delete unused code rather
+than commenting it out. Comments explain *why*, not *what*. Prefer editing
+existing files over creating new ones.
+
+## Reporting bugs
+
+Before filing, check existing issues and confirm you're on the latest release.
+Daemon logs live at `~/Library/Application Support/Irrlicht/logs/` — including
+a relevant excerpt in your report helps a lot.
+
+Please use the **Bug report** issue template. It asks for macOS version,
+Irrlicht version (`irrlichd --version`), repro steps, expected vs. actual
+behavior, and logs.
+
+## Feature requests
+
+Open a [Discussion](https://github.com/ingo-eichhorst/Irrlicht/discussions)
+first to gauge interest. Describe the *problem* you're solving, not just the
+solution, and consider how it fits the project philosophy: zero-config,
+deterministic, honest signals.
+
+## AI agent contributors
+
+If you're an AI coding agent working on this repo:
+
+- Run `./validate.sh` after every change. A task is only complete at exit 0.
+- Never mark a task done based on compilation alone.
+- If validation fails, find the root cause. Don't skip, comment out, or weaken assertions.
+- Record session semantics in adapter parsers, not in shared tailer code.
+
+## Security
+
+Please don't file security issues in public. See [SECURITY.md](SECURITY.md)
+for the private reporting process.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the
+[MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+## Supported versions
+
+Irrlicht is a single-artifact macOS app and ships as rolling releases. Only
+the **latest release** published on
+[GitHub Releases](https://github.com/ingo-eichhorst/Irrlicht/releases/latest)
+receives security fixes. If you're on an older version, please update before
+reporting.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately through one of these channels:
+
+1. **GitHub private vulnerability reporting** (preferred) —
+   [Report a vulnerability](https://github.com/ingo-eichhorst/Irrlicht/security/advisories/new)
+2. **Email** — git@ingo-eichhorst.de with the subject line
+   `[Irrlicht security]`
+
+Include as much of the following as you can:
+
+- A description of the issue and its impact
+- The Irrlicht version (`irrlichd --version`) and macOS version
+- Reproduction steps or a proof-of-concept
+- Any relevant log excerpts from `~/Library/Application Support/Irrlicht/logs/`
+- Whether the issue is already public
+
+## What to expect
+
+- **Acknowledgement** within 3 business days.
+- **Triage and severity assessment** within 7 days.
+- **Fix timeline** communicated once the issue is understood. Critical issues
+  get an out-of-band release; lower-severity issues roll into the next planned
+  release.
+- **Credit** in the release notes if you'd like it — let us know how you want
+  to be named.
+
+Please give us a reasonable window to ship a fix before any public disclosure.
+We'll coordinate timing with you.
+
+## Scope
+
+In scope:
+
+- The Go daemon (`irrlichd`) and its HTTP/WebSocket API on port 7837
+- The Swift macOS app and its IPC with the daemon
+- Local state files under `~/Library/Application Support/Irrlicht/`
+- Transcript parsing in the agent adapters (Claude Code, Codex, Pi, Gas Town)
+- Build and release scripts in `platforms/`
+
+Out of scope:
+
+- Vulnerabilities in upstream coding agents (Claude Code, Codex, Pi, Gas Town)
+  themselves — please report those to their respective projects
+- Issues that require an attacker already running code as your user on your Mac
+- Social-engineering or physical-access scenarios
+- Findings from automated scanners without a demonstrated impact
+
+## Threat model, briefly
+
+Irrlicht is local-first. The daemon reads transcript files the user already
+has on disk and exposes state on `127.0.0.1:7837`. It does not open any
+external network ports and does not transmit transcript contents off the
+machine. Security-relevant areas include: any path traversal or TOCTOU around
+transcript watching, the loopback HTTP/WS surface, file-permission handling
+on the state directory, and the daemon-spawning logic in the macOS app.
+
+Thanks for helping keep Irrlicht users safe.


### PR DESCRIPTION
## Summary

- Add root `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SECURITY.md` so GitHub recognizes the community standards (previously only present as HTML pages under `site/docs/`).
- Add `.github/ISSUE_TEMPLATE/` forms for bug reports, feature requests, and **adapter requests** (new category for "support for <agent X>" asks), plus a `config.yml` that links Discussions, docs, and the private security advisory form.
- Add `.github/PULL_REQUEST_TEMPLATE.md` with summary / test plan / checklist, including the "three states only" guardrail.

Content mirrors the existing site docs so there is a single source of truth. No code changes.

## Why

GitHub's community-health detection doesn't see the HTML versions under `site/docs/`, so the repo currently shows as missing these files. Adding the recognized filenames unlocks:

- the **Community Standards** checklist going green
- an actual **Contribute** tab driven by labels like `good first issue`
- structured issue intake (adapter requests in particular have been coming in as free-form)
- a clear private channel for security reports

Pairs with three other changes that already landed in the repo (not in this PR): the `adapter-request`, `Priority-High`, and `Priority-Medium` labels, label application across 17 open issues, and three seeded Discussions (#135–#137).

## Test plan

- [ ] Visit repo Insights → Community Standards after merge and confirm all five recognized files are detected.
- [ ] Open a new issue and confirm the template chooser shows Bug / Feature / Adapter and links Discussions + Security advisory.
- [ ] Open a draft PR and confirm the PR template renders.
- [ ] Check that email `git@ingo-eichhorst.de` in `CODE_OF_CONDUCT.md` / `SECURITY.md` is the right reporting address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)