### PR TITLE
fix(macos): correct dev fallback path for irrlichd binary

### DIFF
--- a/platforms/macos/Irrlicht/Managers/DaemonManager.swift
+++ b/platforms/macos/Irrlicht/Managers/DaemonManager.swift
@@ -89,7 +89,7 @@ final class DaemonManager: ObservableObject {
             .deletingLastPathComponent() // macos/
             .deletingLastPathComponent() // platforms/
             .deletingLastPathComponent() // repo root
-            .appendingPathComponent("bin/irrlichd")
+            .appendingPathComponent("core/bin/irrlichd")
         return FileManager.default.fileExists(atPath: devURL.path) ? devURL : nil
     }
 


### PR DESCRIPTION
## Summary
- The dev-mode fallback path in `DaemonManager.swift` resolved to `<repo>/bin/irrlichd` instead of `<repo>/core/bin/irrlichd`
- This caused the Mac app to fail silently when spawning the daemon, leaving it permanently in "reconnecting" state

## Test plan
- [x] Build and launch the Swift app in dev mode
- [x] Verify the daemon starts and the app connects (green status dot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)