### PR TITLE
feat(macos): desktop notifications on state transitions

### DIFF
--- a/platforms/macos/Irrlicht/IrrlichtApp.swift
+++ b/platforms/macos/Irrlicht/IrrlichtApp.swift
@@ -43,6 +43,15 @@ struct StatusIndicatorLabel: View {
 class AppDelegate: NSObject, NSApplicationDelegate {
     var daemonManager: DaemonManager?
 
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Try Bundle.module (SwiftPM resource bundle) first, then Bundle.main (.app bundle)
+        let iconURL = Bundle.module.url(forResource: "AppIcon", withExtension: "icns", subdirectory: "Resources")
+            ?? Bundle.main.url(forResource: "AppIcon", withExtension: "icns")
+        if let iconURL, let icon = NSImage(contentsOf: iconURL) {
+            NSApp.applicationIconImage = icon
+        }
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         daemonManager?.stop()
     }

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -231,8 +231,12 @@ class SessionManager: ObservableObject {
             switch envelope.type {
             case "session_created", "session_updated":
                 if let session = envelope.session {
+                    let oldState = sessionMap[session.id]?.state
                     sessionMap[session.id] = session
                     rebuildSessionsFromMap()
+                    if let old = oldState, old != session.state {
+                        checkStateTransitionNotification(session: session, from: old)
+                    }
                 }
             case "session_deleted":
                 if let session = envelope.session {
@@ -515,6 +519,50 @@ class SessionManager: ObservableObject {
                 print("⚠️ Failed to send context pressure notification: \(error.localizedDescription)")
             } else {
                 print("🔔 Context pressure alert (\(threshold)%) fired for session \(session.shortId)")
+            }
+        }
+    }
+
+    // MARK: - State Transition Notifications
+
+    private func checkStateTransitionNotification(session: SessionState, from oldState: SessionState.State) {
+        // Skip subagent sessions to avoid notification noise
+        if session.parentSessionId != nil { return }
+
+        guard canUseUserNotifications else { return }
+
+        let notifyReady = UserDefaults.standard.bool(forKey: "notifyOnReady")
+        let notifyWaiting = UserDefaults.standard.bool(forKey: "notifyOnWaiting")
+
+        let title: String
+        switch session.state {
+        case .ready where notifyReady:
+            title = "Agent ready"
+        case .waiting where notifyWaiting:
+            title = "Agent waiting for input"
+        default:
+            return
+        }
+
+        let label = session.projectName ?? session.shortId
+        let branch = session.gitBranch.map { " (\($0))" } ?? ""
+
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = "\(label)\(branch)"
+        content.sound = .default
+
+        let timestamp = Int(Date().timeIntervalSince1970 * 1000)
+        let request = UNNotificationRequest(
+            identifier: "irrlicht-state-\(session.id)-\(timestamp)",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error = error {
+                print("⚠️ Failed to send state transition notification: \(error.localizedDescription)")
+            } else {
+                print("🔔 State transition alert (\(session.state.rawValue)) fired for session \(session.shortId)")
             }
         }
     }

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -235,7 +235,7 @@ class SessionManager: ObservableObject {
                     sessionMap[session.id] = session
                     rebuildSessionsFromMap()
                     if let old = oldState, old != session.state {
-                        checkStateTransitionNotification(session: session, from: old)
+                        checkStateTransitionNotification(session: session)
                     }
                 }
             case "session_deleted":
@@ -502,34 +502,19 @@ class SessionManager: ObservableObject {
     }
 
     private func sendContextPressureNotification(session: SessionState, threshold: Int, utilization: Double) {
-        guard canUseUserNotifications else { return }
-        let content = UNMutableNotificationContent()
-        content.title = "Context pressure: \(threshold)% threshold reached"
         let label = session.projectName ?? session.shortId
-        content.body = "\(label) is at \(String(format: "%.1f%%", utilization)) context. Consider switching to a fresh session."
-        content.sound = .default
-
-        let request = UNNotificationRequest(
+        sendNotification(
             identifier: "irrlicht-context-\(session.id)-\(threshold)",
-            content: content,
-            trigger: nil
+            title: "Context pressure: \(threshold)% threshold reached",
+            body: "\(label) is at \(String(format: "%.1f%%", utilization)) context. Consider switching to a fresh session."
         )
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error = error {
-                print("⚠️ Failed to send context pressure notification: \(error.localizedDescription)")
-            } else {
-                print("🔔 Context pressure alert (\(threshold)%) fired for session \(session.shortId)")
-            }
-        }
     }
 
     // MARK: - State Transition Notifications
 
-    private func checkStateTransitionNotification(session: SessionState, from oldState: SessionState.State) {
+    private func checkStateTransitionNotification(session: SessionState) {
         // Skip subagent sessions to avoid notification noise
         if session.parentSessionId != nil { return }
-
-        guard canUseUserNotifications else { return }
 
         let notifyReady = UserDefaults.standard.bool(forKey: "notifyOnReady")
         let notifyWaiting = UserDefaults.standard.bool(forKey: "notifyOnWaiting")
@@ -547,22 +532,24 @@ class SessionManager: ObservableObject {
         let label = session.projectName ?? session.shortId
         let branch = session.gitBranch.map { " (\($0))" } ?? ""
 
+        sendNotification(
+            identifier: "irrlicht-state-\(session.id)",
+            title: title,
+            body: "\(label)\(branch)"
+        )
+    }
+
+    private func sendNotification(identifier: String, title: String, body: String) {
+        guard canUseUserNotifications else { return }
         let content = UNMutableNotificationContent()
         content.title = title
-        content.body = "\(label)\(branch)"
+        content.body = body
         content.sound = .default
 
-        let timestamp = Int(Date().timeIntervalSince1970 * 1000)
-        let request = UNNotificationRequest(
-            identifier: "irrlicht-state-\(session.id)-\(timestamp)",
-            content: content,
-            trigger: nil
-        )
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(request) { error in
             if let error = error {
-                print("⚠️ Failed to send state transition notification: \(error.localizedDescription)")
-            } else {
-                print("🔔 State transition alert (\(session.state.rawValue)) fired for session \(session.shortId)")
+                print("⚠️ Failed to send notification: \(error.localizedDescription)")
             }
         }
     }

--- a/platforms/macos/Irrlicht/Resources/Info.plist
+++ b/platforms/macos/Irrlicht/Resources/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleIconFile</key>
-    <string></string>
+    <string>AppIcon</string>
     <key>CFBundleIdentifier</key>
     <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
     <key>CFBundleInfoDictionaryVersion</key>

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UserNotifications
 
 struct SettingsView: View {
     @Binding var isPresented: Bool
@@ -6,6 +7,7 @@ struct SettingsView: View {
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
     @AppStorage("notifyOnReady") private var notifyOnReady: Bool = false
     @AppStorage("notifyOnWaiting") private var notifyOnWaiting: Bool = false
+    @State private var notificationsDenied = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -44,7 +46,28 @@ struct SettingsView: View {
                 Text("Send a desktop notification when an agent finishes work or needs your input.")
                     .font(.caption)
                     .foregroundColor(.secondary)
+
+                if notificationsDenied && (notifyOnReady || notifyOnWaiting) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(.orange)
+                            .font(.caption)
+                        Text("Notifications are blocked.")
+                            .font(.caption)
+                            .foregroundColor(.orange)
+                        Button("Open Settings") {
+                            if let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings") {
+                                NSWorkspace.shared.open(url)
+                            }
+                        }
+                        .font(.caption)
+                        .buttonStyle(.link)
+                    }
+                }
             }
+            .onAppear { checkNotificationAuth() }
+            .onChange(of: notifyOnReady) { _ in checkNotificationAuth() }
+            .onChange(of: notifyOnWaiting) { _ in checkNotificationAuth() }
 
             Spacer()
 
@@ -55,6 +78,16 @@ struct SettingsView: View {
             }
         }
         .padding(20)
-        .frame(width: 320, height: 360)
+        .frame(width: 320, height: 380)
+    }
+
+    private func checkNotificationAuth() {
+        guard Bundle.main.bundleIdentifier != nil,
+              Bundle.main.bundleURL.pathExtension == "app" else { return }
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                notificationsDenied = settings.authorizationStatus == .denied
+            }
+        }
     }
 }

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -4,6 +4,8 @@ struct SettingsView: View {
     @Binding var isPresented: Bool
     @AppStorage("debugMode") private var debugMode: Bool = false
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
+    @AppStorage("notifyOnReady") private var notifyOnReady: Bool = false
+    @AppStorage("notifyOnWaiting") private var notifyOnWaiting: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -28,6 +30,22 @@ struct SettingsView: View {
                     .foregroundColor(.secondary)
             }
 
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Notifications")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Toggle("Notify when agent is ready", isOn: $notifyOnReady)
+
+                Toggle("Notify when agent is waiting", isOn: $notifyOnWaiting)
+
+                Text("Send a desktop notification when an agent finishes work or needs your input.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
             Spacer()
 
             HStack {
@@ -37,6 +55,6 @@ struct SettingsView: View {
             }
         }
         .padding(20)
-        .frame(width: 320, height: 260)
+        .frame(width: 320, height: 360)
     }
 }

--- a/platforms/macos/Package.swift
+++ b/platforms/macos/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         .executableTarget(
             name: "Irrlicht",
             dependencies: [],
-            path: "Irrlicht"
+            path: "Irrlicht",
+            resources: [.copy("Resources")]
         ),
         .testTarget(
             name: "IrrlichtTests",


### PR DESCRIPTION
## Summary

- Adds two independent toggles in Settings: **Notify on ready** and **Notify on waiting** (#103)
- Fires macOS desktop notifications when a top-level session transitions to `ready` or `waiting`
- Subagent sessions are excluded to avoid notification noise
- Reuses existing `UNUserNotificationCenter` infrastructure from context pressure alerts

## Test plan

- [ ] Open Settings — verify two new toggles appear under "Notifications" section
- [ ] Enable "Notify when agent is ready" — start a Claude Code session, confirm notification fires when session reaches ready
- [ ] Enable "Notify when agent is waiting" — confirm notification fires when agent needs input
- [ ] Disable one toggle — confirm only the enabled state triggers notifications
- [ ] Verify subagent transitions do not fire notifications

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)