### PR TITLE
fix(tailer): preserve user-blocking tools across turn_done sweep

### DIFF
--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -310,21 +310,20 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 			t.openToolCalls = make(map[string]string)
 		}
 		// turn_done is Claude Code's authoritative end-of-turn signal. By
-		// definition every non-Agent tool_use opened during the turn has
-		// already received its tool_result, so anything still in
+		// definition most tool_use events opened during the turn have
+		// already received their tool_result, so anything still in
 		// openToolCalls is a stale leak. Sweeping here lets the classifier
 		// see HasOpenToolCall=false and transition working → ready.
 		//
-		// Agent tool calls are preserved: a sub-agent spawned via the Agent
-		// tool can still be running when the parent's turn_done fires
-		// (session.go:IsAgentDone treats open tool calls as authoritative
-		// over turn_done for exactly this reason), and the claudecode
-		// adapter's CountOpenSubagents relies on Agent entries in
-		// LastOpenToolNames to count in-process sub-agents. Only non-Agent
-		// leaks are swept.
+		// Some tools survive the sweep (see surviveTurnDone): Agent
+		// (sub-agent still running), AskUserQuestion, and ExitPlanMode
+		// (user-blocking tools whose result arrives only after the user
+		// responds). Preserving them ensures NeedsUserAttention() returns
+		// true so the classifier transitions to "waiting" instead of
+		// "ready".
 		if parsed.EventType == "turn_done" && len(t.openToolCalls) > 0 {
 			for id, name := range t.openToolCalls {
-				if name != "Agent" {
+				if !surviveTurnDone(name) {
 					delete(t.openToolCalls, id)
 				}
 			}
@@ -658,6 +657,21 @@ func (t *TranscriptTailer) computeContextUtilization() {
 	t.metrics.ContextWindow = effectiveContextWindow
 	t.metrics.ContextUtilization = utilizationPercentage
 	t.metrics.PressureLevel = pressureLevel
+}
+
+// surviveTurnDone returns true for tools whose tool_result arrives after the
+// turn_done event. These must not be swept from openToolCalls:
+//
+//   - Agent: sub-agents can still be running when the parent's turn ends.
+//   - AskUserQuestion, ExitPlanMode: user-blocking tools whose result only
+//     arrives after the user responds. Also listed in session.isUserBlockingTool;
+//     the overlap is intentional — the two predicates serve different purposes.
+func surviveTurnDone(name string) bool {
+	switch name {
+	case "Agent", "AskUserQuestion", "ExitPlanMode":
+		return true
+	}
+	return false
 }
 
 // --- Model config fallback ---

--- a/core/pkg/tailer/tool_call_test.go
+++ b/core/pkg/tailer/tool_call_test.go
@@ -830,3 +830,127 @@ func TestIDTracking_AgentSurvivesTurnDone(t *testing.T) {
 		t.Errorf("expected [Agent], got %v", m.LastOpenToolNames)
 	}
 }
+
+func TestSurviveTurnDone(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"Agent", true},
+		{"AskUserQuestion", true},
+		{"ExitPlanMode", true},
+		{"Bash", false},
+		{"Read", false},
+		{"Write", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := surviveTurnDone(tt.name); got != tt.want {
+				t.Errorf("surviveTurnDone(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasOpenToolCall_TurnDonePreservesAskUserQuestion(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "user", "timestamp": ts(0)},
+		{"type": "tool_use", "id": "tu_ask", "name": "AskUserQuestion", "timestamp": ts(1)},
+		{"type": "system", "subtype": "stop_hook_summary", "timestamp": ts(2)},
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=true with AskUserQuestion still open after turn_done")
+	}
+	if m.OpenToolCallCount != 1 {
+		t.Errorf("expected OpenToolCallCount=1, got %d", m.OpenToolCallCount)
+	}
+	if len(m.LastOpenToolNames) != 1 || m.LastOpenToolNames[0] != "AskUserQuestion" {
+		t.Errorf("expected [AskUserQuestion], got %v", m.LastOpenToolNames)
+	}
+}
+
+func TestHasOpenToolCall_TurnDonePreservesExitPlanMode(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "user", "timestamp": ts(0)},
+		{"type": "tool_use", "id": "tu_plan", "name": "ExitPlanMode", "timestamp": ts(1)},
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(2)},
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=true with ExitPlanMode still open after turn_done")
+	}
+	if m.OpenToolCallCount != 1 {
+		t.Errorf("expected OpenToolCallCount=1, got %d", m.OpenToolCallCount)
+	}
+	if len(m.LastOpenToolNames) != 1 || m.LastOpenToolNames[0] != "ExitPlanMode" {
+		t.Errorf("expected [ExitPlanMode], got %v", m.LastOpenToolNames)
+	}
+}
+
+func TestIDTracking_UserBlockingToolsSurviveTurnDone(t *testing.T) {
+	// AskUserQuestion survives turn_done while Bash is swept.
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "tool_use", "id": "tu_ask", "name": "AskUserQuestion", "timestamp": ts(0)},
+		{"type": "tool_use", "id": "tu_bash", "name": "Bash", "timestamp": ts(1)}, // leaked
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(2)},
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=true with AskUserQuestion still open")
+	}
+	if m.OpenToolCallCount != 1 {
+		t.Errorf("expected OpenToolCallCount=1 (AskUserQuestion only), got %d", m.OpenToolCallCount)
+	}
+	if len(m.LastOpenToolNames) != 1 || m.LastOpenToolNames[0] != "AskUserQuestion" {
+		t.Errorf("expected [AskUserQuestion], got %v", m.LastOpenToolNames)
+	}
+}
+
+func TestHasOpenToolCall_TurnDonePreservesMultipleSurvivors(t *testing.T) {
+	// Agent + AskUserQuestion both survive, Read is swept.
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "tool_use", "id": "tu_agent", "name": "Agent", "timestamp": ts(0)},
+		{"type": "tool_use", "id": "tu_ask", "name": "AskUserQuestion", "timestamp": ts(1)},
+		{"type": "tool_use", "id": "tu_read", "name": "Read", "timestamp": ts(2)}, // leaked
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(3)},
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=true with Agent and AskUserQuestion still open")
+	}
+	if m.OpenToolCallCount != 2 {
+		t.Errorf("expected OpenToolCallCount=2, got %d", m.OpenToolCallCount)
+	}
+	nameSet := map[string]bool{}
+	for _, n := range m.LastOpenToolNames {
+		nameSet[n] = true
+	}
+	if !nameSet["Agent"] || !nameSet["AskUserQuestion"] {
+		t.Errorf("expected Agent and AskUserQuestion in LastOpenToolNames, got %v", m.LastOpenToolNames)
+	}
+	if nameSet["Read"] {
+		t.Error("Read should have been swept by turn_done")
+	}
+}


### PR DESCRIPTION
## Summary

- The `turn_done` sweep in `TailAndProcess` deleted all non-Agent entries from `openToolCalls`, including AskUserQuestion and ExitPlanMode — user-blocking tools whose `tool_result` only arrives after the user responds
- Introduces `surviveTurnDone()` predicate covering Agent, AskUserQuestion, and ExitPlanMode, replacing the hardcoded `name != "Agent"` check
- Adds 5 new test cases covering AskUserQuestion/ExitPlanMode preservation, mixed survivors, and unit tests for the helper

## Test plan

- [x] `TestSurviveTurnDone` — table-driven unit test for the helper
- [x] `TestHasOpenToolCall_TurnDonePreservesAskUserQuestion` — AskUserQuestion survives turn_done
- [x] `TestHasOpenToolCall_TurnDonePreservesExitPlanMode` — ExitPlanMode survives turn_done
- [x] `TestIDTracking_UserBlockingToolsSurviveTurnDone` — Bash swept while AskUserQuestion preserved
- [x] `TestHasOpenToolCall_TurnDonePreservesMultipleSurvivors` — Agent + AskUserQuestion survive, Read swept
- [x] Existing `TestHasOpenToolCall_TurnDonePreservesAgent` and `TestIDTracking_AgentSurvivesTurnDone` still pass
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)