### PR TITLE
fix(security): lock down irrlichd network exposure (#94)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,10 +61,22 @@ Out of scope:
 ## Threat model, briefly
 
 Irrlicht is local-first. The daemon reads transcript files the user already
-has on disk and exposes state on `127.0.0.1:7837`. It does not open any
-external network ports and does not transmit transcript contents off the
-machine. Security-relevant areas include: any path traversal or TOCTOU around
-transcript watching, the loopback HTTP/WS surface, file-permission handling
-on the state directory, and the daemon-spawning logic in the macOS app.
+has on disk and exposes state on `127.0.0.1:7837` by default. It does not
+transmit transcript contents off the machine. Security-relevant areas
+include: any path traversal or TOCTOU around transcript watching, the
+loopback HTTP/WS surface, file-permission handling on the state directory,
+and the daemon-spawning logic in the macOS app.
+
+### Network exposure (opt-in)
+
+- `IRRLICHT_BIND_ADDR` overrides the default loopback bind (e.g.
+  `0.0.0.0:7837` to expose on the LAN). Use with care — state files and
+  session metadata become reachable to anyone who can reach that address.
+- `IRRLICHT_MDNS=1` enables mDNS/Bonjour advertisement of `_irrlicht._tcp`
+  on the local network. Off by default.
+- The WebSocket endpoint (`/api/v1/sessions/stream`) rejects cross-site
+  handshakes: only requests from loopback origins (or with no `Origin`
+  header, as native clients send) are accepted. This holds even when the
+  daemon is bound to a non-loopback address.
 
 Thanks for helping keep Irrlicht users safe.

--- a/core/adapters/outbound/filesystem/repository.go
+++ b/core/adapters/outbound/filesystem/repository.go
@@ -54,7 +54,7 @@ func (r *SessionRepository) Load(sessionID string) (*session.SessionState, error
 
 // Save atomically writes a session state to disk.
 func (r *SessionRepository) Save(state *session.SessionState) error {
-	if err := os.MkdirAll(r.instancesDir, 0755); err != nil {
+	if err := os.MkdirAll(r.instancesDir, 0700); err != nil {
 		return fmt.Errorf("failed to create instances directory: %w", err)
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
@@ -63,7 +63,7 @@ func (r *SessionRepository) Save(state *session.SessionState) error {
 	}
 	path := r.statePath(state.SessionID)
 	tmpPath := fmt.Sprintf("%s.tmp.%d.%d", path, os.Getpid(), time.Now().UnixNano())
-	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
 		return fmt.Errorf("failed to write temp file: %w", err)
 	}
 	if err := os.Rename(tmpPath, path); err != nil {

--- a/core/adapters/outbound/filesystem/repository_test.go
+++ b/core/adapters/outbound/filesystem/repository_test.go
@@ -165,6 +165,29 @@ func TestRepository_ListAll_SkipsNonJSON(t *testing.T) {
 	}
 }
 
+func TestRepository_FilePermissions(t *testing.T) {
+	dir := t.TempDir() + "/instances"
+	repo := filesystem.NewWithDir(dir)
+	s := &session.SessionState{SessionID: "perm", State: session.StateReady, UpdatedAt: time.Now().Unix()}
+	if err := repo.Save(s); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0700 {
+		t.Errorf("dir perm: got %o, want 0700", got)
+	}
+	fileInfo, err := os.Stat(dir + "/perm.json")
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0600 {
+		t.Errorf("file perm: got %o, want 0600", got)
+	}
+}
+
 func TestRepository_AtomicWrite(t *testing.T) {
 	// Save twice to the same session — should overwrite without leaving tmp files.
 	repo := filesystem.NewWithDir(t.TempDir())

--- a/core/adapters/outbound/filesystem/repository_test.go
+++ b/core/adapters/outbound/filesystem/repository_test.go
@@ -2,6 +2,7 @@ package filesystem_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -166,7 +167,7 @@ func TestRepository_ListAll_SkipsNonJSON(t *testing.T) {
 }
 
 func TestRepository_FilePermissions(t *testing.T) {
-	dir := t.TempDir() + "/instances"
+	dir := filepath.Join(t.TempDir(), "instances")
 	repo := filesystem.NewWithDir(dir)
 	s := &session.SessionState{SessionID: "perm", State: session.StateReady, UpdatedAt: time.Now().Unix()}
 	if err := repo.Save(s); err != nil {
@@ -179,7 +180,7 @@ func TestRepository_FilePermissions(t *testing.T) {
 	if got := dirInfo.Mode().Perm(); got != 0700 {
 		t.Errorf("dir perm: got %o, want 0700", got)
 	}
-	fileInfo, err := os.Stat(dir + "/perm.json")
+	fileInfo, err := os.Stat(filepath.Join(dir, "perm.json"))
 	if err != nil {
 		t.Fatalf("stat file: %v", err)
 	}

--- a/core/adapters/outbound/httputil/loopback.go
+++ b/core/adapters/outbound/httputil/loopback.go
@@ -1,0 +1,19 @@
+// Package httputil provides small HTTP-related helpers shared between adapters.
+package httputil
+
+import (
+	"net"
+	"net/http"
+)
+
+// IsLoopbackRequest reports whether the request came from the loopback
+// interface or a Unix-domain socket. Unix-socket connections have an empty or
+// non-host:port RemoteAddr, which we treat as trusted local IPC.
+func IsLoopbackRequest(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/core/adapters/outbound/logging/logger.go
+++ b/core/adapters/outbound/logging/logger.go
@@ -44,7 +44,7 @@ func New() (*StructuredLogger, error) {
 		return nil, fmt.Errorf("failed to get home directory: %w", err)
 	}
 	logsDir := filepath.Join(homeDir, appSupportDir, "logs")
-	if err := os.MkdirAll(logsDir, 0755); err != nil {
+	if err := os.MkdirAll(logsDir, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create logs directory: %w", err)
 	}
 	return newWithPath(filepath.Join(logsDir, "events.log"))
@@ -56,7 +56,7 @@ func NewWithPath(path string) (*StructuredLogger, error) {
 }
 
 func newWithPath(logPath string) (*StructuredLogger, error) {
-	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
@@ -169,7 +169,7 @@ func (sl *StructuredLogger) rotate() error {
 	if _, err := os.Stat(sl.logPath); err == nil {
 		os.Rename(sl.logPath, sl.logPath+".1")
 	}
-	file, err := os.OpenFile(sl.logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(sl.logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create new log file: %w", err)
 	}

--- a/core/adapters/outbound/logging/logger_test.go
+++ b/core/adapters/outbound/logging/logger_test.go
@@ -1,0 +1,29 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLogger_FilePermissions(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "logs")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	logPath := filepath.Join(dir, "events.log")
+	logger, err := NewWithPath(logPath)
+	if err != nil {
+		t.Fatalf("NewWithPath: %v", err)
+	}
+	defer logger.Close()
+	logger.LogInfo("test", "", "hello")
+
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("stat log: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Errorf("log perm: got %o, want 0600", got)
+	}
+}

--- a/core/adapters/outbound/websocket/hub.go
+++ b/core/adapters/outbound/websocket/hub.go
@@ -2,11 +2,14 @@ package websocket
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/gorilla/websocket"
 
+	"irrlicht/core/adapters/outbound/httputil"
 	"irrlicht/core/ports/outbound"
 )
 
@@ -16,25 +19,51 @@ const (
 	writeTimeout = 10 * time.Second
 )
 
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
+// LoopbackCheckOrigin accepts WebSocket handshakes only from loopback origins
+// (or requests with no Origin header, which native clients like URLSession do
+// not send). It blocks cross-site WebSocket connections from arbitrary web
+// pages. The RemoteAddr check is a second line of defence in case the daemon
+// is bound to a non-loopback interface.
+func LoopbackCheckOrigin(r *http.Request) bool {
+	if !httputil.IsLoopbackRequest(r) {
+		return false
+	}
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	host := u.Hostname()
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // Hub manages WebSocket connections and fans out session state updates.
 type Hub struct {
-	push outbound.PushBroadcaster
+	push     outbound.PushBroadcaster
+	upgrader websocket.Upgrader
 }
 
-// NewHub creates a Hub backed by the provided PushBroadcaster.
+// NewHub creates a Hub backed by the provided PushBroadcaster. The upgrader
+// enforces a loopback-only origin policy.
 func NewHub(push outbound.PushBroadcaster) *Hub {
-	return &Hub{push: push}
+	return &Hub{
+		push:     push,
+		upgrader: websocket.Upgrader{CheckOrigin: LoopbackCheckOrigin},
+	}
 }
 
 // ServeWS upgrades the HTTP connection to WebSocket and streams typed session
 // state update messages until the client disconnects.
 // Register on GET /api/v1/sessions/stream.
 func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
-	conn, err := upgrader.Upgrade(w, r, nil)
+	conn, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return
 	}

--- a/core/adapters/outbound/websocket/hub_test.go
+++ b/core/adapters/outbound/websocket/hub_test.go
@@ -1,0 +1,80 @@
+package websocket
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+
+	"irrlicht/core/application/services"
+)
+
+func TestLoopbackCheckOrigin(t *testing.T) {
+	tests := []struct {
+		name       string
+		origin     string
+		remoteAddr string
+		want       bool
+	}{
+		{"no origin from loopback", "", "127.0.0.1:54321", true},
+		{"localhost origin", "http://localhost:5173", "127.0.0.1:54321", true},
+		{"127.0.0.1 origin", "http://127.0.0.1:5173", "127.0.0.1:54321", true},
+		{"127.0.0.2 origin", "http://127.0.0.2", "127.0.0.1:54321", true},
+		{"ipv6 loopback origin", "http://[::1]:5173", "127.0.0.1:54321", true},
+		{"foreign origin", "https://evil.example.com", "127.0.0.1:54321", false},
+		{"foreign origin bare host", "http://example.com", "127.0.0.1:54321", false},
+		{"malformed origin", "://bad", "127.0.0.1:54321", false},
+		{"origin with no host", "http://", "127.0.0.1:54321", false},
+		{"non-loopback remote addr", "http://localhost", "10.0.0.5:54321", false},
+		{"unix socket remote addr", "", "@", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			r.RemoteAddr = tt.remoteAddr
+			if tt.origin != "" {
+				r.Header.Set("Origin", tt.origin)
+			}
+			if got := LoopbackCheckOrigin(r); got != tt.want {
+				t.Errorf("LoopbackCheckOrigin(origin=%q remote=%q) = %v, want %v",
+					tt.origin, tt.remoteAddr, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestServeWS_OriginHandshake exercises the full HTTP upgrade with a custom
+// Origin header to confirm the upgrader rejects cross-site handshakes.
+func TestServeWS_OriginHandshake(t *testing.T) {
+	hub := NewHub(services.NewPushService())
+	srv := httptest.NewServer(http.HandlerFunc(hub.ServeWS))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	// Accepted: loopback Origin.
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{
+		"Origin": []string{"http://localhost:5173"},
+	})
+	if err != nil {
+		t.Fatalf("loopback origin: dial failed: %v", err)
+	}
+	conn.Close()
+
+	// Rejected: foreign Origin.
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL, http.Header{
+		"Origin": []string{"https://evil.example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected dial to fail for foreign origin")
+	}
+	if resp == nil {
+		t.Fatalf("expected HTTP response on handshake rejection, got nil (err=%v)", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("foreign origin: got status %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -269,7 +269,6 @@ func main() {
 		logger.LogError("startup", "", fmt.Sprintf("failed to listen on TCP %s: %v", bindAddr, err))
 		os.Exit(1)
 	}
-	logger.LogInfo("startup", "", fmt.Sprintf("listening on %s", bindAddr))
 
 	go func() { _ = srv.Serve(unixL) }()
 	go func() { _ = srv.Serve(tcpL) }()

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -26,6 +26,7 @@ import (
 	"irrlicht/core/adapters/outbound/filesystem"
 	"irrlicht/core/adapters/outbound/git"
 	"irrlicht/core/adapters/outbound/gtbin"
+	"irrlicht/core/adapters/outbound/httputil"
 	"irrlicht/core/adapters/outbound/logging"
 	"irrlicht/core/adapters/outbound/mdns"
 	"irrlicht/core/adapters/outbound/metrics"
@@ -47,9 +48,22 @@ var uiFS embed.FS
 var Version = "dev"
 
 const (
-	tcpAddr = ":7837"
-	tcpPort = 7837
+	defaultBindAddr = "127.0.0.1:7837"
+	tcpPort         = 7837
 )
+
+// resolveBindAddr returns the TCP bind address for the daemon. Default is
+// loopback-only; set IRRLICHT_BIND_ADDR to override (e.g. "0.0.0.0:7837" to
+// expose the daemon on the LAN).
+func resolveBindAddr(envValue string) string {
+	if envValue == "" {
+		return defaultBindAddr
+	}
+	if _, _, err := net.SplitHostPort(envValue); err != nil {
+		return defaultBindAddr
+	}
+	return envValue
+}
 
 func hasFlag(name string) bool {
 	for _, arg := range os.Args[1:] {
@@ -225,11 +239,19 @@ func main() {
 	}
 	mux.Handle("/", http.FileServer(http.FS(uiSub)))
 
-	srv := &http.Server{Handler: mux}
+	// WriteTimeout is intentionally 0: WebSocket streams and long-polling
+	// responses need unbounded writes, and gorilla/websocket sets its own
+	// per-message deadlines.
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
 
 	// Unix socket.
 	sockPath := socketPath()
-	if err := os.MkdirAll(filepath.Dir(sockPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0700); err != nil {
 		logger.LogError("startup", "", fmt.Sprintf("failed to create socket dir: %v", err))
 		os.Exit(1)
 	}
@@ -240,22 +262,30 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TCP listener.
-	tcpL, err := net.Listen("tcp", tcpAddr)
+	// TCP listener — default loopback; override with IRRLICHT_BIND_ADDR.
+	bindAddr := resolveBindAddr(os.Getenv("IRRLICHT_BIND_ADDR"))
+	tcpL, err := net.Listen("tcp", bindAddr)
 	if err != nil {
-		logger.LogError("startup", "", fmt.Sprintf("failed to listen on TCP %s: %v", tcpAddr, err))
+		logger.LogError("startup", "", fmt.Sprintf("failed to listen on TCP %s: %v", bindAddr, err))
 		os.Exit(1)
 	}
+	logger.LogInfo("startup", "", fmt.Sprintf("listening on %s", bindAddr))
 
 	go func() { _ = srv.Serve(unixL) }()
 	go func() { _ = srv.Serve(tcpL) }()
 
-	// mDNS/Bonjour advertisement — non-fatal if unavailable.
-	mdnsAdv, err := mdns.New(tcpPort)
-	if err != nil {
-		logger.LogError("startup", "", fmt.Sprintf("mDNS advertisement failed (non-fatal): %v", err))
+	// mDNS/Bonjour advertisement — opt-in via IRRLICHT_MDNS=1 to avoid
+	// broadcasting the daemon on networks the user did not intend to share on.
+	var mdnsAdv *mdns.Advertiser
+	if os.Getenv("IRRLICHT_MDNS") == "1" {
+		mdnsAdv, err = mdns.New(tcpPort)
+		if err != nil {
+			logger.LogError("startup", "", fmt.Sprintf("mDNS advertisement failed (non-fatal): %v", err))
+		} else {
+			logger.LogInfo("startup", "", "mDNS: advertising _irrlicht._tcp on the local network")
+		}
 	} else {
-		logger.LogInfo("startup", "", "mDNS: advertising _irrlicht._tcp on the local network")
+		logger.LogInfo("startup", "", "mDNS: disabled (set IRRLICHT_MDNS=1 to advertise)")
 	}
 
 	// Orchestrator adapters: detect and watch multi-agent orchestration systems.
@@ -387,7 +417,7 @@ func main() {
 		}()
 	}
 
-	logger.LogInfo("startup", "", fmt.Sprintf("irrlichd %s listening on unix:%s and tcp:%s", Version, sockPath, tcpAddr))
+	logger.LogInfo("startup", "", fmt.Sprintf("irrlichd %s listening on unix:%s and tcp:%s", Version, sockPath, bindAddr))
 
 	// Wait for SIGTERM or SIGINT.
 	sig := make(chan os.Signal, 1)
@@ -507,17 +537,10 @@ func handleGetState(repo outbound.SessionRepository) http.HandlerFunc {
 // localhost or Unix sockets. Used to protect sensitive endpoints like pprof.
 func localhostOnly(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		host, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			// Unix socket connections have no host:port — allow them.
-			h(w, r)
+		if !httputil.IsLoopbackRequest(r) {
+			http.Error(w, "forbidden", http.StatusForbidden)
 			return
 		}
-		ip := net.ParseIP(host)
-		if ip != nil && ip.IsLoopback() {
-			h(w, r)
-			return
-		}
-		http.Error(w, "forbidden", http.StatusForbidden)
+		h(w, r)
 	}
 }

--- a/core/cmd/irrlichd/main_test.go
+++ b/core/cmd/irrlichd/main_test.go
@@ -99,6 +99,44 @@ func TestGate_WebSocketConnect(t *testing.T) {
 	defer conn.Close()
 }
 
+// TestGate_WebSocketRejectsForeignOrigin verifies that the stream endpoint
+// refuses cross-site WebSocket handshakes.
+func TestGate_WebSocketRejectsForeignOrigin(t *testing.T) {
+	srv, _ := newTestStack(t)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/api/v1/sessions/stream"
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL, http.Header{
+		"Origin": []string{"https://evil.example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected handshake to fail for foreign origin")
+	}
+	if resp == nil {
+		t.Fatalf("expected HTTP response on rejection, got nil (err=%v)", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestResolveBindAddr(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", defaultBindAddr},
+		{"garbage", defaultBindAddr},
+		{"127.0.0.1:7837", "127.0.0.1:7837"},
+		{"0.0.0.0:7837", "0.0.0.0:7837"},
+		{":7837", ":7837"},
+	}
+	for _, tt := range tests {
+		if got := resolveBindAddr(tt.in); got != tt.want {
+			t.Errorf("resolveBindAddr(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
 // TestGate_GetState verifies that GET /state returns the compact debug-state format.
 func TestGate_GetState(t *testing.T) {
 	srv, repo := newTestStack(t)


### PR DESCRIPTION
## Summary
- Default TCP bind to `127.0.0.1:7837`; opt-in LAN exposure via `IRRLICHT_BIND_ADDR`.
- WebSocket `CheckOrigin` rejects non-loopback origins; defence-in-depth `RemoteAddr` check for when the daemon is bound to a non-loopback address.
- mDNS/Bonjour advertisement now opt-in via `IRRLICHT_MDNS=1` (was unconditional).
- HTTP server gains `ReadHeaderTimeout` / `ReadTimeout` / `IdleTimeout` (WriteTimeout left 0 for WebSocket / streaming, which manage their own deadlines).
- Session/log files now created with `0600` / `0700` perms; socket dir `0700`.
- `SECURITY.md` realigned with new defaults and documents the two new env vars.

Closes #94.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all green (new tests: `LoopbackCheckOrigin` table + handshake 403, `resolveBindAddr`, file-perm assertions for repo and logger)
- [x] `go vet ./...` clean
- [x] Manual: dev daemon starts bound to `127.0.0.1:7837`; LAN IP `curl` refused (connect-refused); startup log shows `mDNS: disabled`
- [x] Manual: WebSocket handshake with `Origin: https://evil.example.com` → `403 Forbidden`; loopback origin → `101 Switching Protocols`
- [x] Manual: new session files created under `~/Library/Application Support/Irrlicht/instances/` with mode `-rw-------`
- [x] Manual: Swift app connects and hydrates sessions against the loopback-only daemon (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)