### PR TITLE
fix(detector): unstick subagents via parent task-notification (#134)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -63,6 +63,28 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 			ev.Skip = true
 			return ev
 		}
+		// Task-notification events are Claude Code's authoritative "subagent
+		// done" signal on the parent transcript (origin.kind="task-notification"
+		// with an XML payload as message.content string). The subagent's own
+		// JSONL is structurally ambiguous when --continue kills the parent
+		// mid-stream, so this parent-side event is the only reliable signal
+		// without timing heuristics. Skip=true so the line does not feed
+		// LastEventType / interrupt flags. See issue #134.
+		if origin, ok := raw["origin"].(map[string]interface{}); ok {
+			if kind, _ := origin["kind"].(string); kind == "task-notification" {
+				if msg, ok := raw["message"].(map[string]interface{}); ok {
+					if content, ok := msg["content"].(string); ok {
+						ev.SubagentCompletions = append(ev.SubagentCompletions, tailer.SubagentCompletion{
+							AgentID:   extractXMLField(content, "task-id"),
+							ToolUseID: extractXMLField(content, "tool-use-id"),
+							Status:    extractXMLField(content, "status"),
+						})
+					}
+				}
+				ev.Skip = true
+				return ev
+			}
+		}
 		if msg, ok := raw["message"].(map[string]interface{}); ok {
 			if content, ok := msg["content"].(string); ok {
 				if strings.HasPrefix(content, "<local-command") ||
@@ -299,6 +321,24 @@ func extractClaudeCodeTokens(raw map[string]interface{}) *tailer.TokenSnapshot {
 // subagents that don't create transcripts, we only need to change this file.
 func CountOpenSubagents(m *tailer.SessionMetrics) int {
 	return 0
+}
+
+// extractXMLField pulls the inner text of <tag>...</tag> from a flat XML blob.
+// Used to read task-id, tool-use-id, and status from task-notification events.
+// Returns "" if the tag is missing or malformed.
+func extractXMLField(xml, tag string) string {
+	open := "<" + tag + ">"
+	close := "</" + tag + ">"
+	start := strings.Index(xml, open)
+	if start < 0 {
+		return ""
+	}
+	start += len(open)
+	end := strings.Index(xml[start:], close)
+	if end < 0 {
+		return ""
+	}
+	return xml[start : start+end]
 }
 
 // isClaudeCodeMessageEvent returns true for event types that count as messages.

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -1009,3 +1009,74 @@ func TestTranscript_ExitPlanMode_SplitMessage_DetectedAsWaiting(t *testing.T) {
 		t.Errorf("LastEventType = %q, want assistant", m.LastEventType)
 	}
 }
+
+// TestParser_TaskNotification_EmitsSubagentCompletion is the issue #134
+// regression: parent user line with origin.kind="task-notification" must
+// emit a single SubagentCompletion (parsed task-id, tool-use-id, status),
+// be marked Skip=true so it doesn't pollute LastEventType, and must NOT
+// set IsUserInterrupt or IsToolDenial.
+func TestParser_TaskNotification_EmitsSubagentCompletion(t *testing.T) {
+	p := &Parser{}
+	xmlPayload := "<task-notification>\n" +
+		"<task-id>af7bf8be5a1b511e4</task-id>\n" +
+		"<tool-use-id>toolu_01WfKzuNdE9j8zVUsTE7twbF</tool-use-id>\n" +
+		"<status>completed</status>\n" +
+		"<summary>Agent \"Find TODO comments\" completed</summary>\n" +
+		"</task-notification>"
+
+	ev := p.ParseLine(map[string]interface{}{
+		"type":      "user",
+		"timestamp": "2026-04-11T18:53:50.828Z",
+		"origin":    map[string]interface{}{"kind": "task-notification"},
+		"message":   map[string]interface{}{"role": "user", "content": xmlPayload},
+	})
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if !ev.Skip {
+		t.Error("task-notification line must be Skip=true so it doesn't feed LastEventType")
+	}
+	if ev.IsUserInterrupt {
+		t.Error("task-notification must not be classified as a user interrupt")
+	}
+	if ev.IsToolDenial {
+		t.Error("task-notification must not be classified as a tool denial")
+	}
+	if len(ev.SubagentCompletions) != 1 {
+		t.Fatalf("expected 1 SubagentCompletion, got %d", len(ev.SubagentCompletions))
+	}
+	got := ev.SubagentCompletions[0]
+	want := tailer.SubagentCompletion{
+		AgentID:   "af7bf8be5a1b511e4",
+		ToolUseID: "toolu_01WfKzuNdE9j8zVUsTE7twbF",
+		Status:    "completed",
+	}
+	if got != want {
+		t.Errorf("SubagentCompletion = %+v, want %+v", got, want)
+	}
+}
+
+// TestTailer_TaskNotification_SurfacedThroughMetrics is the per-pass surfacing
+// test: the fixture from issue #134 must produce a SubagentCompletion in
+// SessionMetrics.SubagentCompletions after a single TailAndProcess pass.
+func TestTailer_TaskNotification_SurfacedThroughMetrics(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "..", "..", "testdata", "replay", "claudecode",
+		"13-full-lifecycle-continue-8a525d27.jsonl")
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("fixture not present at %s: %v", path, err)
+	}
+	m, err := newCCTailer(path).TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+	found := false
+	for _, c := range m.SubagentCompletions {
+		if c.AgentID == "af7bf8be5a1b511e4" && c.Status == "completed" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected SubagentCompletion for af7bf8be5a1b511e4 in metrics; got %+v", m.SubagentCompletions)
+	}
+}

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -103,6 +103,16 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 		LastAssistantText:      m.LastAssistantText,
 		PermissionMode:         m.PermissionMode,
 	}
+	if len(m.SubagentCompletions) > 0 {
+		result.SubagentCompletions = make([]session.SubagentCompletion, len(m.SubagentCompletions))
+		for i, c := range m.SubagentCompletions {
+			result.SubagentCompletions[i] = session.SubagentCompletion{
+				AgentID:   c.AgentID,
+				ToolUseID: c.ToolUseID,
+				Status:    c.Status,
+			}
+		}
+	}
 	if result.ModelName == "" {
 		result.ModelName = "unknown"
 	}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -490,6 +490,16 @@ func (d *SessionDetector) processActivity(ev agent.Event) {
 	// Refresh CWD/branch/project and metrics from transcript.
 	d.enricher.RefreshOnActivity(state, ev.TranscriptPath)
 
+	// Drain authoritative subagent-completion signals harvested from this
+	// parent's transcript (origin.kind="task-notification" lines parsed by
+	// the Claude Code adapter). This is the event-based path to ready for
+	// child subagents whose own JSONL ends with stop_reason=null — see
+	// issue #134. The defensive finishOrphanedChildren below still runs as
+	// a fallback for adapters/versions that don't emit notifications.
+	if state.ParentSessionID == "" && state.Metrics != nil && len(state.Metrics.SubagentCompletions) > 0 {
+		d.applySubagentCompletions(state.SessionID, state.Metrics.SubagentCompletions)
+	}
+
 	// Force ready→working when metrics show activity so ClassifyState can
 	// properly detect the working→ready transition. Without this, sessions
 	// that start as ready (initial state) and whose first activity event
@@ -912,6 +922,60 @@ func (d *SessionDetector) finishOrphanedChildren(parentID string) {
 		d.log.LogInfo("session-detector", s.SessionID,
 			fmt.Sprintf("finished orphaned subagent (%s → ready) — parent %s turn done", prev, parentID))
 		d.broadcast(outbound.PushTypeUpdated, s)
+	}
+}
+
+// applySubagentCompletions resolves each completion to a child session and
+// transitions it to ready. Match is by ParentSessionID + transcript filename
+// suffix (agent-<AgentID>.jsonl) — the latter mirrors the subagent transcript
+// layout Claude Code uses on disk. If no child is indexed yet, the no-op is
+// safe: finishOrphanedChildren still acts as a defensive fallback later.
+// See issue #134.
+func (d *SessionDetector) applySubagentCompletions(parentID string, completions []session.SubagentCompletion) {
+	if len(completions) == 0 {
+		return
+	}
+	states, err := d.repo.ListAll()
+	if err != nil {
+		return
+	}
+	now := time.Now().Unix()
+	for _, c := range completions {
+		if c.AgentID == "" {
+			continue
+		}
+		suffix := "agent-" + c.AgentID + ".jsonl"
+		for _, s := range states {
+			if s.ParentSessionID != parentID {
+				continue
+			}
+			if !strings.HasSuffix(s.TranscriptPath, suffix) {
+				continue
+			}
+			if s.State != session.StateWorking && s.State != session.StateWaiting {
+				continue
+			}
+			prev := s.State
+			s.State = session.StateReady
+			s.UpdatedAt = now
+			s.WaitingStartTime = nil
+			d.record(lifecycle.Event{
+				Kind:      lifecycle.KindStateTransition,
+				SessionID: s.SessionID,
+				PrevState: prev,
+				NewState:  session.StateReady,
+				Reason:    "subagent completed (parent task-notification)",
+			})
+			if err := d.repo.Save(s); err != nil {
+				d.log.LogError("session-detector", s.SessionID,
+					fmt.Sprintf("failed to apply subagent completion: %v", err))
+				continue
+			}
+			d.log.LogInfo("session-detector", s.SessionID,
+				fmt.Sprintf("subagent completed via parent task-notification (%s → ready, parent %s)", prev, parentID))
+			d.broadcast(outbound.PushTypeUpdated, s)
+			break
+		}
 	}
 }
 

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -1781,3 +1781,76 @@ func TestSessionDetector_ParentNotAffected_WhenNoChildren(t *testing.T) {
 	cancel()
 	<-done
 }
+
+// TestSessionDetector_Activity_SubagentCompletion_TransitionsChildToReady is
+// the issue #134 regression: a parent activity event whose metrics carry a
+// SubagentCompletion (parsed from origin.kind="task-notification") must
+// transition the matching child session to ready immediately, without
+// depending on the time-gated finishOrphanedChildren fallback.
+func TestSessionDetector_Activity_SubagentCompletion_TransitionsChildToReady(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	const parentID = "8a525d27-37a4-4a12-8523-a3ea345290cf"
+	const childID = "child-af7bf8be"
+	const agentID = "af7bf8be5a1b511e4"
+	parentTranscript := "/home/.claude/projects/-Users-test/" + parentID + ".jsonl"
+	childTranscript := "/home/.claude/projects/-Users-test/" + parentID + "/subagents/agent-" + agentID + ".jsonl"
+
+	// Parent: turn still in flight (working). Pre-populate the completion
+	// signal on metrics — the mock metrics collector returns nil from
+	// ComputeMetrics, so MergeMetrics(nil, oldM) keeps these values.
+	repo.states[parentID] = &session.SessionState{
+		SessionID:      parentID,
+		State:          session.StateWorking,
+		TranscriptPath: parentTranscript,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+		EventCount:     5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:   "assistant_streaming",
+			HasOpenToolCall: false,
+			SubagentCompletions: []session.SubagentCompletion{
+				{AgentID: agentID, ToolUseID: "toolu_01Wf", Status: "completed"},
+			},
+		},
+	}
+
+	// Child: stuck in working with stop_reason=null (the bug condition).
+	repo.states[childID] = &session.SessionState{
+		SessionID:       childID,
+		ParentSessionID: parentID,
+		State:           session.StateWorking,
+		TranscriptPath:  childTranscript,
+		FirstSeen:       time.Now().Unix(),
+		UpdatedAt:       time.Now().Unix(),
+		EventCount:      8,
+		Metrics: &session.SessionMetrics{
+			LastEventType:   "assistant_streaming",
+			HasOpenToolCall: false,
+		},
+	}
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      parentID,
+		ProjectDir:     "-Users-test",
+		TranscriptPath: parentTranscript,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	child, _ := repo.Load(childID)
+	if child.State != session.StateReady {
+		t.Errorf("child state: got %q, want ready (parent task-notification should transition child)", child.State)
+	}
+}

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -84,6 +84,21 @@ type SessionMetrics struct {
 	// corresponding PostToolUse/PostToolUseFailure has cleared it. Transient —
 	// set by the hook receiver in processActivity, not derived from transcript.
 	PermissionPending bool `json:"-"`
+
+	// SubagentCompletions surfaces parent-side "subagent done" signals
+	// from the most recent transcript scan (origin.kind="task-notification"
+	// lines parsed by the Claude Code adapter). Per-pass and transient —
+	// drained by the detector each activity event. See issue #134.
+	SubagentCompletions []SubagentCompletion `json:"-"`
+}
+
+// SubagentCompletion is the domain mirror of tailer.SubagentCompletion. The
+// detector uses these to transition child sessions to ready as soon as their
+// parent transcript records the authoritative task-notification event.
+type SubagentCompletion struct {
+	AgentID   string
+	ToolUseID string
+	Status    string
 }
 
 // NeedsUserAttention returns true when a user-blocking tool is open — one
@@ -249,6 +264,7 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 		EstimatedCostUSD:     newM.EstimatedCostUSD,
 		LastAssistantText:    newM.LastAssistantText,
 		PermissionMode:       newM.PermissionMode,
+		SubagentCompletions:  newM.SubagentCompletions,
 	}
 	if merged.ContextWindow == 0 && oldM.ContextWindow > 0 {
 		merged.ContextWindow = oldM.ContextWindow

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -15,6 +15,17 @@ type ToolUse struct {
 	Name string // tool name (e.g. "Bash", "Read", "shell")
 }
 
+// SubagentCompletion is an authoritative "subagent done" signal that lives on
+// the parent transcript (Claude Code writes it as a user-origin event with
+// origin.kind="task-notification"). The subagent's own JSONL is structurally
+// ambiguous when stop_reason is null; this parent-side event resolves it
+// without timing-based heuristics. See issue #134.
+type SubagentCompletion struct {
+	AgentID   string // <task-id> — matches the agent-<id>.jsonl filename
+	ToolUseID string // <tool-use-id> — the parent's Agent tool_use call
+	Status    string // <status> — "completed", etc.
+}
+
 // ParsedEvent is the normalized output from a format-specific transcript parser.
 // Each parser maps its native event structure into these fields.
 type ParsedEvent struct {
@@ -44,6 +55,12 @@ type ParsedEvent struct {
 	// working→ready→working flicker that happened when the parser lumped
 	// both markers under IsUserInterrupt.
 	IsToolDenial bool
+
+	// SubagentCompletions are parent-side signals that a child subagent has
+	// finished (parsed from origin.kind="task-notification" lines). The
+	// detector drains these on the parent path to transition children to
+	// ready without depending on the subagent's own ambiguous final line.
+	SubagentCompletions []SubagentCompletion
 
 	// Metadata extracted by the parser.
 	ModelName        string

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -57,6 +57,12 @@ type SessionMetrics struct {
 	// LastOpenToolNames or whatever adapter-specific signal they use.
 	OpenSubagents int `json:"open_subagents,omitempty"`
 
+	// SubagentCompletions surfaces parent-side "subagent done" signals
+	// discovered during the most recent TailAndProcess() pass. Cleared at
+	// the start of every pass so the detector drains fresh events only.
+	// See issue #134.
+	SubagentCompletions []SubagentCompletion `json:"-"`
+
 	// LastEventType is the event type of the most recent message event in
 	// the transcript (e.g. "assistant", "user", "tool_use", "tool_result").
 	// Used for content-based working/waiting detection.
@@ -213,6 +219,10 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 	}
 	fileSize := stat.Size()
 
+	// Per-pass signals must be cleared so the detector only drains events
+	// discovered in this scan (see issue #134).
+	t.metrics.SubagentCompletions = nil
+
 	const maxTailSize = 64 * 1024
 	startPos := int64(0)
 	switch {
@@ -285,11 +295,21 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 		parsed := t.parser.ParseLine(raw)
 		if parsed == nil || parsed.Skip {
 			// Even for skipped events, apply metadata that the parser extracted
-			// (e.g. model from model_change, CWD from session header).
+			// (e.g. model from model_change, CWD from session header) and drain
+			// SubagentCompletions — task-notification lines are deliberately
+			// marked Skip=true so they don't pollute message-event tracking,
+			// but the completion signal must still surface to the detector
+			// (issue #134).
 			if parsed != nil {
 				t.applyMetadata(parsed)
+				if len(parsed.SubagentCompletions) > 0 {
+					t.metrics.SubagentCompletions = append(t.metrics.SubagentCompletions, parsed.SubagentCompletions...)
+				}
 			}
 			continue
+		}
+		if len(parsed.SubagentCompletions) > 0 {
+			t.metrics.SubagentCompletions = append(t.metrics.SubagentCompletions, parsed.SubagentCompletions...)
 		}
 
 		// Apply tool tracking deltas from the parser. openToolCalls is an


### PR DESCRIPTION
## Summary

- Closes #134. Subagents could get stuck in `working` indefinitely when their transcript's final assistant line has `stop_reason: null` and no `end_turn` follows (e.g. parent killed by `--continue` mid-stream).
- New event-based fix: parse the parent's `origin.kind="task-notification"` user line, surface a `SubagentCompletion` per pass, and transition the matching child to `ready` with reason `"subagent completed (parent task-notification)"`.
- The classifier still (correctly) treats `stop_reason: null` as streaming — flipping that would re-introduce the Bug D / first-chunk-flicker regression. `finishOrphanedChildren` remains as defensive fallback. Supersedes #133.

## Layers touched

- `core/adapters/inbound/agents/claudecode/parser.go` — recognise `task-notification`, parse `<task-id>/<tool-use-id>/<status>`, mark `Skip=true`.
- `core/pkg/tailer/{parser,tailer}.go` — new `SubagentCompletion` type, per-pass field on `SessionMetrics`, drained even on `Skip=true` lines.
- `core/domain/session/session.go` + `core/adapters/outbound/metrics/adapter.go` — domain mirror + tailer→domain mapping.
- `core/application/services/session_detector.go` — `applySubagentCompletions` resolves child by `ParentSessionID` + `agent-<AgentID>.jsonl` suffix and transitions to `ready`.

## Test plan

- [x] `TestParser_TaskNotification_EmitsSubagentCompletion` — parser unit test
- [x] `TestTailer_TaskNotification_SurfacedThroughMetrics` — tail of fixture `13-full-lifecycle-continue-8a525d27.jsonl` surfaces the completion
- [x] `TestSessionDetector_Activity_SubagentCompletion_TransitionsChildToReady` — child transitions to `ready` when parent metrics carry the completion
- [x] Guardrails: `TestTranscript_FirstChunkNewMessage_NoFlicker` and `TestParser_MaxTokensStopReason_ClassifiedAsStreaming` still pass
- [x] `go test ./...` green across full core/ tree (incl. e2e and replay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)