### PR TITLE
fix(install): preserve provenance and register with LaunchServices

### DIFF
--- a/site/install.sh
+++ b/site/install.sh
@@ -73,17 +73,17 @@ EOF
 uninstall_previous() {
     removed_something=0
 
-    # Stop running processes
-    if pgrep -f "$APP_PATH/Contents/MacOS/Irrlicht" >/dev/null 2>&1; then
-        pkill -f "$APP_PATH/Contents/MacOS/Irrlicht" 2>/dev/null || true
+    # Stop running processes — match any Irrlicht*.app bundle regardless of
+    # parent path, so dev builds (/private/tmp/IrrlichtDev.app) and App
+    # Translocation ghost paths are cleaned up alongside /Applications/Irrlicht.app.
+    if pgrep -f 'Irrlicht[^/]*\.app/Contents/MacOS/Irrlicht' >/dev/null 2>&1; then
+        pkill -f 'Irrlicht[^/]*\.app/Contents/MacOS/Irrlicht' 2>/dev/null || true
         removed_something=1
     fi
     if pgrep -x irrlichd >/dev/null 2>&1; then
         pkill -x irrlichd 2>/dev/null || true
         removed_something=1
     fi
-    # App Translocation ghost processes (macOS runs unsigned apps from random paths)
-    pkill -f 'AppTranslocation.*Irrlicht' 2>/dev/null || true
 
     # Unload + remove LaunchAgent (daemon-only installs may have registered one)
     if [ -f "$LAUNCHAGENT_PATH" ]; then
@@ -229,7 +229,12 @@ ditto -xk "$TMPDIR/$ASSET" /Applications/ || fail "Extract failed"
 ok
 
 step "Stripping quarantine attribute"
-xattr -cr /Applications/Irrlicht.app 2>/dev/null || true
+xattr -dr com.apple.quarantine /Applications/Irrlicht.app 2>/dev/null || true
+ok
+
+step "Registering with LaunchServices"
+"/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister" \
+    -f /Applications/Irrlicht.app 2>/dev/null || true
 ok
 
 step "Launching Irrlicht"


### PR DESCRIPTION
## Summary

- Replace blanket `xattr -cr` with targeted `xattr -dr com.apple.quarantine` so `com.apple.provenance` is preserved — LaunchServices relies on it for ad-hoc signed bundles, and stripping it put the curl-install path into a silently-denied state for notifications.
- Add an explicit `lsregister -f` step after extract so LaunchServices registers the bundle synchronously before `open` — closes the race with `requestAuthorization` for LSUIElement apps that flip activation policy.
- Broaden `uninstall_previous` `pkill -f` pattern to match any `Irrlicht*.app/Contents/MacOS/Irrlicht` regardless of parent path, covering dev builds (`/private/tmp/IrrlichtDev.app`) and App Translocation ghosts in a single rule.

Closes #157.

## Test plan

- [x] `sh -n site/install.sh` — syntax clean
- [x] Run `install.sh` locally: "Registering with LaunchServices" step visible in output; daemon reachable on `:7837` within 15s.
- [x] `xattr -l /Applications/Irrlicht.app` after install → `com.apple.provenance` present, `com.apple.quarantine` absent.
- [x] `codesign -dvvv /Applications/Irrlicht.app` → `Identifier=io.irrlicht.app`, `Signature=adhoc` intact.
- [x] UN framework log confirms `[io.irrlicht.app] Requested authorization [ didGrant: 1 hasError: 0 ]` on first launch after clean reset.
- [ ] Full end-to-end verification on a second never-had-Irrlicht Mac (out of scope for this PR — reported working on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)