### PR TITLE
fix(macos): only notify on transitions from working

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -268,7 +268,7 @@ class SessionManager: ObservableObject {
                     rebuildSessionsFromMap()
                     patchApiGroups(session: session)
                     if let old = oldState, old != session.state {
-                        checkStateTransitionNotification(session: session)
+                        checkStateTransitionNotification(session: session, previousState: old)
                     }
                 }
             case "session_deleted":
@@ -628,7 +628,7 @@ class SessionManager: ObservableObject {
 
     // MARK: - State Transition Notifications
 
-    private func checkStateTransitionNotification(session: SessionState) {
+    private func checkStateTransitionNotification(session: SessionState, previousState: SessionState.State) {
         // Skip subagent sessions to avoid notification noise
         if session.parentSessionId != nil { return }
 
@@ -637,9 +637,9 @@ class SessionManager: ObservableObject {
 
         let title: String
         switch session.state {
-        case .ready where notifyReady:
+        case .ready where notifyReady && previousState == .working:
             title = "Agent ready"
-        case .waiting where notifyWaiting:
+        case .waiting where notifyWaiting && previousState == .working:
             title = "Agent waiting for input"
         default:
             return


### PR DESCRIPTION
## Summary
- Ready/waiting notifications now require the previous state to be `working`
- Prevents a duplicate ready notification when a session went `waiting → ready`

## Test plan
- [x] `swift build -c debug --arch arm64` succeeds
- [x] Manual: working→waiting still fires waiting notification
- [x] Manual: working→ready still fires ready notification
- [x] Manual: waiting→ready no longer fires ready notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)