### PR TITLE
fix(capacity): add claude-opus-4-7 with 1M context beta

### DIFF
--- a/core/pkg/capacity/model-capacity.json
+++ b/core/pkg/capacity/model-capacity.json
@@ -182,6 +182,23 @@
         "cache_creation_per_mtok": 18.75
       }
     },
+    "claude-opus-4-7": {
+      "context_window": 200000,
+      "max_output": 64000,
+      "char_to_token_ratio": 3.2,
+      "family": "claude-4",
+      "display_name": "Claude Opus 4.7",
+      "notes": "Latest high-capability model, 1M context available",
+      "beta_features": {
+        "context_1m": 1000000
+      },
+      "pricing": {
+        "input_per_mtok": 15.0,
+        "output_per_mtok": 75.0,
+        "cache_read_per_mtok": 1.875,
+        "cache_creation_per_mtok": 18.75
+      }
+    },
     "claude-sonnet-4-6": {
       "context_window": 200000,
       "max_output": 64000,


### PR DESCRIPTION
## Summary
- claude-opus-4-7 sessions were displaying 200K or 1M inconsistently
- Root cause: no entry for claude-opus-4-7 in model-capacity.json
- With the `[1m]` transcript marker: parser forces 1M (correct)
- Without the marker: fuzzy fallback hits claude-4.1-opus (200K, no 1m beta)
- Fix mirrors the claude-opus-4-6 entry so the `context_1m` beta is always picked up

## Test plan
- [x] `go test ./pkg/capacity/... ./pkg/tailer/...` passes
- [x] JSON validates
- [ ] Restart daemon; confirm existing opus-4-7 sessions now show 1M

🤖 Generated with [Claude Code](https://claude.com/claude-code)