### PR TITLE
fix(ui): render sessions on initial load; drop dead gastown endpoint (#167)

### DIFF
--- a/core/cmd/irrlichd/ui/index.html
+++ b/core/cmd/irrlichd/ui/index.html
@@ -1475,7 +1475,7 @@
     fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
       if (!resp) return;
       dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
-      orchestrator = (!Array.isArray(resp) && resp.orchestrator) || null;
+      orchestrator = resp.orchestrator || null;
       rebuildIndex();
       render();
       timelineTick(); // First tick immediately

--- a/core/cmd/irrlichd/ui/index.html
+++ b/core/cmd/irrlichd/ui/index.html
@@ -1475,7 +1475,6 @@
     fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
       if (!resp) return;
       dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
-      orchestrator = resp.orchestrator || null;
       rebuildIndex();
       render();
       timelineTick(); // First tick immediately

--- a/core/cmd/irrlichd/ui/index.html
+++ b/core/cmd/irrlichd/ui/index.html
@@ -729,7 +729,6 @@
       <div class="raw-toolbar">
         <span class="raw-label">Endpoint:</span>
         <button class="active" data-raw-src="sessions">/api/v1/sessions</button>
-        <button data-raw-src="gastown">/api/v1/orchestrators/gastown</button>
         <button id="raw-refresh" title="Refresh">refresh</button>
       </div>
       <pre id="raw-output">Loading…</pre>
@@ -1473,9 +1472,10 @@
     setInterval(timelineTick, TIMELINE_TICK_MS);
 
     // --- Initial load ---
-    fetch('/api/v1/sessions').then(r => r.json()).catch(() => ({})).then(resp => {
-      dashboardGroups = resp.groups || [];
-      orchestrator = resp.orchestrator || null;
+    fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
+      if (!resp) return;
+      dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
+      orchestrator = (!Array.isArray(resp) && resp.orchestrator) || null;
       rebuildIndex();
       render();
       timelineTick(); // First tick immediately
@@ -1491,12 +1491,6 @@
         render();
       });
     }, 30000);
-    // Secondary fetch for full orchestrator hierarchy (global_agents, codebases).
-    // The initial /api/v1/sessions response only carries an OrchestratorSummary;
-    // the full state is needed to render the Gas Town hierarchy view.
-    fetch('/api/v1/orchestrators/gastown').then(r => r.json()).catch(() => ({})).then(data => {
-      if (data && data.running) { orchFull = data; render(); }
-    });
 
     // --- WebSocket ---
     let ws = null;
@@ -1567,7 +1561,6 @@
     // --- Raw panel ---
     const rawEndpoints = {
       sessions: '/api/v1/sessions',
-      gastown: '/api/v1/orchestrators/gastown',
     };
 
     for (const btn of document.querySelectorAll('[data-raw-src]')) {

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -1475,7 +1475,7 @@
     fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
       if (!resp) return;
       dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
-      orchestrator = (!Array.isArray(resp) && resp.orchestrator) || null;
+      orchestrator = resp.orchestrator || null;
       rebuildIndex();
       render();
       timelineTick(); // First tick immediately

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -1475,7 +1475,6 @@
     fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
       if (!resp) return;
       dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
-      orchestrator = resp.orchestrator || null;
       rebuildIndex();
       render();
       timelineTick(); // First tick immediately

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -729,7 +729,6 @@
       <div class="raw-toolbar">
         <span class="raw-label">Endpoint:</span>
         <button class="active" data-raw-src="sessions">/api/v1/sessions</button>
-        <button data-raw-src="gastown">/api/v1/orchestrators/gastown</button>
         <button id="raw-refresh" title="Refresh">refresh</button>
       </div>
       <pre id="raw-output">Loading…</pre>
@@ -1473,9 +1472,10 @@
     setInterval(timelineTick, TIMELINE_TICK_MS);
 
     // --- Initial load ---
-    fetch('/api/v1/sessions').then(r => r.json()).catch(() => ({})).then(resp => {
-      dashboardGroups = resp.groups || [];
-      orchestrator = resp.orchestrator || null;
+    fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
+      if (!resp) return;
+      dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
+      orchestrator = (!Array.isArray(resp) && resp.orchestrator) || null;
       rebuildIndex();
       render();
       timelineTick(); // First tick immediately
@@ -1491,12 +1491,6 @@
         render();
       });
     }, 30000);
-    // Secondary fetch for full orchestrator hierarchy (global_agents, codebases).
-    // The initial /api/v1/sessions response only carries an OrchestratorSummary;
-    // the full state is needed to render the Gas Town hierarchy view.
-    fetch('/api/v1/orchestrators/gastown').then(r => r.json()).catch(() => ({})).then(data => {
-      if (data && data.running) { orchFull = data; render(); }
-    });
 
     // --- WebSocket ---
     let ws = null;
@@ -1567,7 +1561,6 @@
     // --- Raw panel ---
     const rawEndpoints = {
       sessions: '/api/v1/sessions',
-      gastown: '/api/v1/orchestrators/gastown',
     };
 
     for (const btn of document.querySelectorAll('[data-raw-src]')) {


### PR DESCRIPTION
Fixes #167.

## Summary
- Initial-load handler now handles the bare-array response from `GET /api/v1/sessions` (was reading `resp.groups`/`resp.orchestrator`, which left `dashboardGroups = []` until the 30s rehydrator or a WS delta arrived).
- Remove three stale references to the removed `/api/v1/orchestrators/gastown` endpoint: Raw-tab button, secondary fetch on load, and the `rawEndpoints` map entry. `orchFull` is already populated by the `orchestrator_state` WS frame.
- Applied to `platforms/web/index.html` (source of truth) and the `//go:embed` copy at `core/cmd/irrlichd/ui/index.html`.

## Test plan
- [x] `go vet ./...` clean in `core/`
- [x] Rebuilt daemon + Swift app, confirmed dev stack running on port 7837
- [ ] Hard-reload `http://127.0.0.1:7837/` — session groups render immediately (not after 30s)
- [ ] Raw tab only shows `/api/v1/sessions` button
- [ ] Devtools Network has no 404 on `orchestrators/gastown`
- [ ] WS-driven updates (session add/remove, orchestrator state) still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)