### PR TITLE
feat: jump to launching terminal or IDE on session click (#170)

### DIFF
--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -58,7 +58,7 @@ Build the irrlicht daemon and Swift app, then replace all running instances with
        <key>LSUIElement</key>
        <true/>
        <key>NSAppleEventsUsageDescription</key>
-       <string>Irrlicht uses AppleScript to bring the correct iTerm2 window and tab to the front when you click a session row.</string>
+       <string>Irrlicht uses AppleScript to bring the correct iTerm2 or Terminal.app window and tab to the front when you click a session row.</string>
    </dict>
    </plist>
    PLIST

--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -57,10 +57,19 @@ Build the irrlicht daemon and Swift app, then replace all running instances with
        <string>dev</string>
        <key>LSUIElement</key>
        <true/>
+       <key>NSAppleEventsUsageDescription</key>
+       <string>Irrlicht uses AppleScript to bring the correct iTerm2 window and tab to the front when you click a session row.</string>
    </dict>
    </plist>
    PLIST
-   codesign --force --deep --sign - "$DEV_APP" 2>&1
+   # Sign with the persistent "Irrlicht Dev" identity if it exists; otherwise
+   # fall back to ad-hoc (TCC permissions will need to be re-granted each
+   # rebuild). Run scripts/dev-sign-setup.sh once to install the identity.
+   if security find-identity -v -p codesigning 2>/dev/null | grep -q "Irrlicht Dev"; then
+       codesign --force --deep --sign "Irrlicht Dev" "$DEV_APP" 2>&1
+   else
+       codesign --force --deep --sign - "$DEV_APP" 2>&1
+   fi
    ```
 
 3. **Kill all running irrlicht processes** (production app, production daemon, debug app, debug daemon)
@@ -101,3 +110,4 @@ Build the irrlicht daemon and Swift app, then replace all running instances with
 - The production Irrlicht.app (from DMG) bundles its own daemon. It MUST be killed before starting the dev daemon, otherwise port 7837 will be occupied.
 - Daemon logs: `/tmp/irrlichd-dev.log`
 - Swift app logs: `/tmp/irrlicht-app-dev.log`
+- **TCC stability**: run `scripts/dev-sign-setup.sh` once to install the `"Irrlicht Dev"` self-signed code signing identity. The skill automatically signs with it when present, giving the app a stable designated requirement so Accessibility/Automation grants persist across rebuilds. Without it, every rebuild invalidates TCC and requires re-granting in System Settings.

--- a/core/adapters/inbound/agents/processlifecycle/hosts_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/hosts_darwin.go
@@ -1,0 +1,46 @@
+//go:build darwin
+
+package processlifecycle
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// termProgramByAppName maps the `.app` bundle name from a process's
+// executable path to the canonical $TERM_PROGRAM string the Swift
+// launcher dispatcher expects. Keys match the directory segment that
+// precedes `.app/Contents/MacOS/` on macOS.
+//
+// The value side is what Swift uses for registry lookup — every entry
+// here must have a matching activator in
+// `platforms/macos/Irrlicht/Managers/SessionLauncher.swift:activators`.
+// Adding a new host means adding one line here (so the hardened-runtime
+// ancestry fallback can identify it when env is stripped) AND one line
+// on the Swift side.
+var termProgramByAppName = map[string]string{
+	"iTerm":              "iTerm.app",
+	"Terminal":           "Apple_Terminal",
+	"Visual Studio Code": "vscode",
+	"Cursor":             "cursor",
+	"Windsurf":           "windsurf",
+	"Ghostty":            "ghostty",
+	"WezTerm":            "WezTerm",
+	"Hyper":              "Hyper",
+	"Warp":               "Warp",
+}
+
+// termProgramForAppPath extracts the host app's canonical TERM_PROGRAM
+// value from an executable path of the form
+// `/Applications/<App>.app/Contents/MacOS/<binary>`. Returns "" for paths
+// without an `.app` segment or when the app isn't one of the hosts we
+// know how to activate.
+func termProgramForAppPath(cmdPath string) string {
+	idx := strings.Index(cmdPath, ".app/")
+	if idx < 0 {
+		return ""
+	}
+	head := cmdPath[:idx]
+	appName := filepath.Base(head)
+	return termProgramByAppName[appName]
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -154,10 +154,39 @@ func ReadLauncherEnv(pid int) *session.Launcher {
 	if l.TermProgram == "" {
 		l.TermProgram = resolveTermProgramFromAncestry(pid)
 	}
+	// Capture the controlling TTY so Terminal.app (and potentially others)
+	// can target the exact tab — Terminal.app's AppleScript dictionary
+	// matches tabs by `tty` but has no session-UUID analog.
+	l.TTY = processTTY(pid)
 	if l.IsEmpty() {
 		return nil
 	}
 	return l
+}
+
+// processTTY returns the controlling TTY of pid in the form "/dev/ttysNNN",
+// or "" if the process has no controlling terminal (hardened-runtime
+// children often don't) or the ps lookup fails. The result is normalized
+// to match Terminal.app's AppleScript `tty` property format — `ps -o tty=`
+// on macOS omits the "/dev/" prefix that AppleScript returns.
+func processTTY(pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ps", "-o", "tty=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return ""
+	}
+	tty := strings.TrimSpace(string(out))
+	if tty == "" || tty == "?" || tty == "??" || tty == "-" {
+		return ""
+	}
+	if !strings.HasPrefix(tty, "/dev/") {
+		tty = "/dev/" + tty
+	}
+	return tty
 }
 
 // readProcessEnv is implemented per-platform (osutil_darwin.go,

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -6,11 +6,14 @@ package processlifecycle
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"os/exec"
 	"strconv"
 	"strings"
 	"time"
+
+	"irrlicht/core/domain/session"
 )
 
 // FindProcesses returns PIDs of processes whose name exactly matches name
@@ -91,3 +94,122 @@ func CWDToProjectDir(cwd string) string {
 	s := strings.ReplaceAll(cwd, "/", "-")
 	return strings.ReplaceAll(s, ".", "-")
 }
+
+// launcherEnvKeys are the env vars whitelisted for launcher identity capture.
+// Everything else is ignored — we never read the full env, only these keys.
+var launcherEnvKeys = map[string]struct{}{
+	"TERM_PROGRAM":     {},
+	"ITERM_SESSION_ID": {},
+	"TERM_SESSION_ID":  {},
+	"TMUX":             {},
+	"TMUX_PANE":        {},
+	"VSCODE_PID":       {},
+}
+
+// ReadLauncherEnv returns the launcher identity captured from the process env
+// of pid. Returns nil if env cannot be read or no interesting vars are present.
+//
+// Never blocks longer than 2 seconds. Never prompts the user — on macOS we use
+// `sysctl(kern.procargs2)` (no TCC prompt; `ps e` stopped exposing env on
+// modern macOS). On Linux we read /proc/<pid>/environ. Other platforms return
+// nil.
+func ReadLauncherEnv(pid int) *session.Launcher {
+	if pid <= 0 {
+		return nil
+	}
+	env, err := readProcessEnv(pid)
+	if err != nil || len(env) == 0 {
+		return nil
+	}
+	l := &session.Launcher{
+		TermProgram:    env["TERM_PROGRAM"],
+		ITermSessionID: env["ITERM_SESSION_ID"],
+		TermSessionID:  env["TERM_SESSION_ID"],
+		TmuxPane:       env["TMUX_PANE"],
+	}
+	if tmux := env["TMUX"]; tmux != "" {
+		// $TMUX is "/path/to/socket,pid,session" — first field is the socket.
+		if i := strings.Index(tmux, ","); i > 0 {
+			l.TmuxSocket = tmux[:i]
+		} else {
+			l.TmuxSocket = tmux
+		}
+	}
+	if v := env["VSCODE_PID"]; v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			l.VSCodePID = n
+		}
+	}
+	// Treat VSCODE_PID as an implicit TERM_PROGRAM hint when the env only
+	// exposes VS Code / Cursor / Windsurf indirectly (their integrated
+	// terminal sets VSCODE_PID but not always TERM_PROGRAM=vscode).
+	if l.TermProgram == "" && l.VSCodePID > 0 {
+		l.TermProgram = "vscode"
+	}
+	if l.IsEmpty() {
+		return nil
+	}
+	return l
+}
+
+// readProcessEnv is implemented per-platform (osutil_darwin.go,
+// osutil_linux.go, osutil_other.go) and returns the whitelisted env vars
+// for pid. Returns nil, nil on unsupported platforms.
+
+// parseProcargs2 extracts the env portion of a KERN_PROCARGS2 sysctl buffer
+// and returns the whitelisted entries. The buffer layout is:
+//
+//	int32 argc
+//	NUL-terminated exec path (possibly followed by alignment padding of \0)
+//	argv[0] NUL ... argv[argc-1] NUL
+//	envp[0] NUL ... envp[n] NUL
+//
+// Modern macOS disables `ps e` envvar output, so sysctl is the only
+// non-cgo / non-TCC path to read another process's env.
+func parseProcargs2(buf []byte) map[string]string {
+	out := map[string]string{}
+	if len(buf) < 4 {
+		return out
+	}
+	argc := int(binary.LittleEndian.Uint32(buf[:4]))
+	p := 4
+	// Skip exec path (NUL-terminated) and any alignment NULs before argv[0].
+	for p < len(buf) && buf[p] != 0 {
+		p++
+	}
+	for p < len(buf) && buf[p] == 0 {
+		p++
+	}
+	// Skip argv entries.
+	for i := 0; i < argc && p < len(buf); i++ {
+		for p < len(buf) && buf[p] != 0 {
+			p++
+		}
+		if p < len(buf) {
+			p++ // skip NUL
+		}
+	}
+	// Remaining NUL-terminated strings are env entries until we hit an empty
+	// string or the end of the buffer.
+	for p < len(buf) {
+		start := p
+		for p < len(buf) && buf[p] != 0 {
+			p++
+		}
+		if p == start {
+			break
+		}
+		entry := string(buf[start:p])
+		if eq := strings.IndexByte(entry, '='); eq > 0 {
+			key := entry[:eq]
+			if _, ok := launcherEnvKeys[key]; ok {
+				out[key] = entry[eq+1:]
+			}
+		}
+		if p < len(buf) {
+			p++
+		}
+	}
+	return out
+}
+

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -117,10 +117,11 @@ func ReadLauncherEnv(pid int) *session.Launcher {
 	if pid <= 0 {
 		return nil
 	}
-	env, err := readProcessEnv(pid)
-	if err != nil || len(env) == 0 {
-		return nil
-	}
+	// Env may be empty — hardened-runtime processes hide it from sysctl.
+	// Don't bail here: the ancestry fallback below is the only signal we
+	// have in that case.
+	env, _ := readProcessEnv(pid)
+
 	l := &session.Launcher{
 		TermProgram:    env["TERM_PROGRAM"],
 		ITermSessionID: env["ITERM_SESSION_ID"],
@@ -145,6 +146,13 @@ func ReadLauncherEnv(pid int) *session.Launcher {
 	// terminal sets VSCODE_PID but not always TERM_PROGRAM=vscode).
 	if l.TermProgram == "" && l.VSCodePID > 0 {
 		l.TermProgram = "vscode"
+	}
+	// Hardened-runtime processes (e.g. Anthropic's signed `claude` binary)
+	// hide env from sysctl. Fall back to process-ancestry walking so the UI
+	// can at least bring the host app to the front. Darwin-only; other
+	// platforms return "" and this is a no-op.
+	if l.TermProgram == "" {
+		l.TermProgram = resolveTermProgramFromAncestry(pid)
 	}
 	if l.IsEmpty() {
 		return nil

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -1,0 +1,20 @@
+//go:build darwin
+
+package processlifecycle
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// readProcessEnv reads the exec-time env of pid via KERN_PROCARGS2 sysctl
+// and returns the whitelisted entries. Modern macOS disables env visibility
+// in `ps e`, so this is the only non-cgo, non-TCC path.
+func readProcessEnv(pid int) (map[string]string, error) {
+	buf, err := unix.SysctlRaw("kern.procargs2", pid)
+	if err != nil {
+		return nil, fmt.Errorf("sysctl kern.procargs2 pid %d: %w", pid, err)
+	}
+	return parseProcargs2(buf), nil
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -34,39 +33,6 @@ func readProcessEnv(pid int) (map[string]string, error) {
 // inside VS Code's integrated terminal (claude → zsh → Code Helper → Code);
 // ten gives generous headroom for tmux / SSH nesting.
 const maxAncestry = 10
-
-// termProgramByAppName maps the `.app` bundle name from a process's
-// executable path to the canonical $TERM_PROGRAM string the Swift
-// launcher dispatcher expects. Keys match the directory segment that
-// precedes `.app/Contents/MacOS/` on macOS.
-var termProgramByAppName = map[string]string{
-	"iTerm":              "iTerm.app",
-	"Terminal":           "Apple_Terminal",
-	"Visual Studio Code": "vscode",
-	"Cursor":             "cursor",
-	"Windsurf":           "windsurf",
-	"Ghostty":            "ghostty",
-	"WezTerm":            "WezTerm",
-	"Hyper":              "Hyper",
-	"Warp":               "Warp",
-}
-
-// termProgramForAppPath extracts the host app's canonical TERM_PROGRAM
-// value from an executable path of the form
-// `/Applications/<App>.app/Contents/MacOS/<binary>`. Returns "" for paths
-// without an `.app` segment or when the app isn't one of the hosts we
-// know how to activate.
-func termProgramForAppPath(cmdPath string) string {
-	// Split on ".app/" to find the bundle boundary. The element before the
-	// split contains the app's display name as its final path segment.
-	idx := strings.Index(cmdPath, ".app/")
-	if idx < 0 {
-		return ""
-	}
-	head := cmdPath[:idx]
-	appName := filepath.Base(head)
-	return termProgramByAppName[appName]
-}
 
 // resolveTermProgramFromAncestry walks the parent-process chain of pid and
 // returns the first recognized host app's TERM_PROGRAM string. Returns ""

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -3,7 +3,13 @@
 package processlifecycle
 
 import (
+	"context"
 	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -11,10 +17,109 @@ import (
 // readProcessEnv reads the exec-time env of pid via KERN_PROCARGS2 sysctl
 // and returns the whitelisted entries. Modern macOS disables env visibility
 // in `ps e`, so this is the only non-cgo, non-TCC path.
+//
+// On hardened-runtime processes (e.g. Anthropic's signed `claude` binary)
+// the kernel strips argv and env from the response; the returned map is
+// empty and callers fall back to resolveTermProgramFromAncestry.
 func readProcessEnv(pid int) (map[string]string, error) {
 	buf, err := unix.SysctlRaw("kern.procargs2", pid)
 	if err != nil {
 		return nil, fmt.Errorf("sysctl kern.procargs2 pid %d: %w", pid, err)
 	}
 	return parseProcargs2(buf), nil
+}
+
+// maxAncestry caps how far up the parent-process chain we walk when
+// env capture failed. Four is the typical depth for a Claude Code session
+// inside VS Code's integrated terminal (claude → zsh → Code Helper → Code);
+// ten gives generous headroom for tmux / SSH nesting.
+const maxAncestry = 10
+
+// termProgramByAppName maps the `.app` bundle name from a process's
+// executable path to the canonical $TERM_PROGRAM string the Swift
+// launcher dispatcher expects. Keys match the directory segment that
+// precedes `.app/Contents/MacOS/` on macOS.
+var termProgramByAppName = map[string]string{
+	"iTerm":              "iTerm.app",
+	"Terminal":           "Apple_Terminal",
+	"Visual Studio Code": "vscode",
+	"Cursor":             "cursor",
+	"Windsurf":           "windsurf",
+	"Ghostty":            "ghostty",
+	"WezTerm":            "WezTerm",
+	"Hyper":              "Hyper",
+	"Warp":               "Warp",
+}
+
+// termProgramForAppPath extracts the host app's canonical TERM_PROGRAM
+// value from an executable path of the form
+// `/Applications/<App>.app/Contents/MacOS/<binary>`. Returns "" for paths
+// without an `.app` segment or when the app isn't one of the hosts we
+// know how to activate.
+func termProgramForAppPath(cmdPath string) string {
+	// Split on ".app/" to find the bundle boundary. The element before the
+	// split contains the app's display name as its final path segment.
+	idx := strings.Index(cmdPath, ".app/")
+	if idx < 0 {
+		return ""
+	}
+	head := cmdPath[:idx]
+	appName := filepath.Base(head)
+	return termProgramByAppName[appName]
+}
+
+// resolveTermProgramFromAncestry walks the parent-process chain of pid and
+// returns the first recognized host app's TERM_PROGRAM string. Returns ""
+// when no supported host appears within maxAncestry levels.
+//
+// Intentionally ignores tmux: tmux's env vars (TMUX, TMUX_PANE) come from
+// the regular env-capture path when readable, and a tmux-only ancestor
+// (without a known host terminal above it) can't be brought to the front
+// by NSWorkspace.
+func resolveTermProgramFromAncestry(pid int) string {
+	cur := pid
+	for i := 0; i < maxAncestry && cur > 1; i++ {
+		ppid, cmd, err := readProcInfo(cur)
+		if err != nil {
+			return ""
+		}
+		if term := termProgramForAppPath(cmd); term != "" {
+			return term
+		}
+		if ppid == cur || ppid <= 1 {
+			return ""
+		}
+		cur = ppid
+	}
+	return ""
+}
+
+// readProcInfo returns the parent PID and executable path of pid using a
+// bounded `ps` shell-out. Same 2-second timeout pattern as the sibling
+// helpers. We shell out rather than parse `kinfo_proc` from sysctl because
+// ps already handles the comm-vs-argv-path distinction we need, and the
+// existing package is built around these bounded exec calls.
+func readProcInfo(pid int) (ppid int, cmd string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ps", "-o", "ppid=,comm=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0, "", fmt.Errorf("ps pid %d: %w", pid, err)
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return 0, "", fmt.Errorf("no process info for pid %d", pid)
+	}
+	// ppid is the first whitespace-separated token; everything after is the
+	// command path (which may itself contain spaces, e.g. "Visual Studio Code").
+	space := strings.IndexAny(line, " \t")
+	if space < 0 {
+		return 0, "", fmt.Errorf("unexpected ps output for pid %d: %q", pid, line)
+	}
+	ppid, err = strconv.Atoi(strings.TrimSpace(line[:space]))
+	if err != nil {
+		return 0, "", fmt.Errorf("parse ppid %q: %w", line[:space], err)
+	}
+	cmd = strings.TrimSpace(line[space:])
+	return ppid, cmd, nil
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -29,3 +29,8 @@ func readProcessEnv(pid int) (map[string]string, error) {
 	}
 	return out, nil
 }
+
+// resolveTermProgramFromAncestry is a darwin-only fallback for hardened-
+// runtime processes that hide env from sysctl. Linux reads /proc/<pid>/environ
+// directly, so this stub is unused on linux.
+func resolveTermProgramFromAncestry(pid int) string { return "" }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package processlifecycle
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// readProcessEnv reads /proc/<pid>/environ and returns the whitelisted
+// entries. The file contains NUL-delimited KEY=VALUE entries.
+func readProcessEnv(pid int) (map[string]string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err != nil {
+		return nil, fmt.Errorf("read /proc/%d/environ: %w", pid, err)
+	}
+	out := map[string]string{}
+	for _, entry := range strings.Split(string(data), "\x00") {
+		eq := strings.IndexByte(entry, '=')
+		if eq <= 0 {
+			continue
+		}
+		key := entry[:eq]
+		if _, ok := launcherEnvKeys[key]; !ok {
+			continue
+		}
+		out[key] = entry[eq+1:]
+	}
+	return out, nil
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -7,3 +7,7 @@ package processlifecycle
 func readProcessEnv(pid int) (map[string]string, error) {
 	return nil, nil
 }
+
+// resolveTermProgramFromAncestry is a darwin-only fallback; other platforms
+// return "" and keep whatever the env-based path produced.
+func resolveTermProgramFromAncestry(pid int) string { return "" }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package processlifecycle
+
+// readProcessEnv is not implemented on this platform — launcher capture
+// is disabled and the menu-bar app falls back to Finder-reveal of cwd.
+func readProcessEnv(pid int) (map[string]string, error) {
+	return nil, nil
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -1,0 +1,216 @@
+package processlifecycle
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestHelperProcess is a sleeper used by the subprocess env-capture tests.
+// It runs only when GO_WANT_LAUNCHER_HELPER=1 is set, and exits after a
+// short sleep. We self-exec the test binary (which is unsigned on darwin,
+// unlike /bin/sleep) so `sysctl kern.procargs2` can read its env — macOS
+// strips env from sysctl responses for Apple-signed binaries.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_LAUNCHER_HELPER") != "1" {
+		return
+	}
+	time.Sleep(3 * time.Second)
+	os.Exit(0)
+}
+
+func TestParseProcargs2(t *testing.T) {
+	// Build a synthetic KERN_PROCARGS2 buffer:
+	//   argc (int32 LE) | exec_path\0 | argv[0]\0 argv[1]\0 | envp[0]\0 envp[1]\0 envp[2]\0
+	makeBuf := func(argc int32, execPath string, argv []string, envp []string) []byte {
+		var b []byte
+		b = append(b, byte(argc), byte(argc>>8), byte(argc>>16), byte(argc>>24))
+		b = append(b, []byte(execPath)...)
+		b = append(b, 0)
+		// real kernel adds alignment \0 padding after exec path — we omit it; the parser handles either.
+		for _, a := range argv {
+			b = append(b, []byte(a)...)
+			b = append(b, 0)
+		}
+		for _, e := range envp {
+			b = append(b, []byte(e)...)
+			b = append(b, 0)
+		}
+		return b
+	}
+
+	tests := []struct {
+		name string
+		buf  []byte
+		want map[string]string
+	}{
+		{
+			name: "empty buffer",
+			buf:  nil,
+			want: map[string]string{},
+		},
+		{
+			name: "whitelisted only, everything else dropped",
+			buf: makeBuf(2, "/usr/local/bin/claude",
+				[]string{"/usr/local/bin/claude", "--mode"},
+				[]string{
+					"HOME=/Users/alice",
+					"PATH=/usr/bin",
+					"TERM_PROGRAM=iTerm.app",
+					"ITERM_SESSION_ID=w0t0p0",
+					"SHELL=/bin/zsh",
+				}),
+			want: map[string]string{
+				"TERM_PROGRAM":     "iTerm.app",
+				"ITERM_SESSION_ID": "w0t0p0",
+			},
+		},
+		{
+			name: "tmux pair",
+			buf: makeBuf(1, "/bin/claude",
+				[]string{"/bin/claude"},
+				[]string{
+					"TMUX=/private/tmp/tmux-501/default,1234,0",
+					"TMUX_PANE=%17",
+				}),
+			want: map[string]string{
+				"TMUX":      "/private/tmp/tmux-501/default,1234,0",
+				"TMUX_PANE": "%17",
+			},
+		},
+		{
+			name: "vscode fields",
+			buf: makeBuf(1, "/bin/claude",
+				[]string{"/bin/claude"},
+				[]string{
+					"TERM_PROGRAM=vscode",
+					"VSCODE_PID=9876",
+					"VSCODE_INJECTION=1",
+				}),
+			want: map[string]string{
+				"TERM_PROGRAM": "vscode",
+				"VSCODE_PID":   "9876",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseProcargs2(tc.buf)
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseProcargs2: want %v, got %v", tc.want, got)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("key %q: want %q, got %q", k, v, got[k])
+				}
+			}
+		})
+	}
+}
+
+func TestReadLauncherEnv_InvalidPID(t *testing.T) {
+	if l := ReadLauncherEnv(0); l != nil {
+		t.Errorf("pid 0: want nil, got %+v", l)
+	}
+	if l := ReadLauncherEnv(-1); l != nil {
+		t.Errorf("pid -1: want nil, got %+v", l)
+	}
+}
+
+// spawnSleeperWithEnv starts a short-lived test-binary subprocess (via
+// TestHelperProcess) with the given env and returns its PID. We self-exec
+// the test binary rather than running /bin/sleep because on macOS sysctl
+// kern.procargs2 strips env from Apple-signed binaries; the Go-built test
+// binary is unsigned so env is readable.
+func spawnSleeperWithEnv(t *testing.T, env []string) int {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestHelperProcess$", "-test.count=1")
+	cmd.Env = append([]string{"GO_WANT_LAUNCHER_HELPER=1"}, env...)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn helper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+	// Give the kernel a beat to publish the exec'd env to sysctl / /proc.
+	time.Sleep(50 * time.Millisecond)
+	return cmd.Process.Pid
+}
+
+// TestReadLauncherEnv_Subprocess exercises the real ps / /proc path against
+// a child process with a known controlled env.
+func TestReadLauncherEnv_Subprocess(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skipf("no env reader for %s", runtime.GOOS)
+	}
+	pid := spawnSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"TERM_PROGRAM=iTerm.app",
+		"ITERM_SESSION_ID=w0t0p0-test",
+	})
+	l := ReadLauncherEnv(pid)
+	if l == nil {
+		t.Fatal("expected non-nil launcher")
+	}
+	if l.TermProgram != "iTerm.app" {
+		t.Errorf("TermProgram: want iTerm.app, got %q", l.TermProgram)
+	}
+	if l.ITermSessionID != "w0t0p0-test" {
+		t.Errorf("ITermSessionID: want w0t0p0-test, got %q", l.ITermSessionID)
+	}
+}
+
+func TestReadLauncherEnv_Subprocess_VSCodePIDImpliesTermProgram(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip()
+	}
+	pid := spawnSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"VSCODE_PID=4242",
+	})
+	l := ReadLauncherEnv(pid)
+	if l == nil {
+		t.Fatal("expected non-nil launcher when VSCODE_PID present")
+	}
+	if l.VSCodePID != 4242 {
+		t.Errorf("VSCodePID: want 4242, got %d", l.VSCodePID)
+	}
+	if l.TermProgram != "vscode" {
+		t.Errorf("TermProgram: expected implicit 'vscode', got %q", l.TermProgram)
+	}
+}
+
+func TestReadLauncherEnv_Subprocess_NoRelevantEnv(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip()
+	}
+	pid := spawnSleeperWithEnv(t, []string{"PATH=/usr/bin:/bin"})
+	if l := ReadLauncherEnv(pid); l != nil {
+		t.Errorf("expected nil launcher, got %+v", l)
+	}
+}
+
+func TestReadLauncherEnv_Subprocess_Tmux(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip()
+	}
+	pid := spawnSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"TERM_PROGRAM=tmux",
+		"TMUX=/private/tmp/tmux-501/default,1234,0",
+		"TMUX_PANE=%17",
+	})
+	l := ReadLauncherEnv(pid)
+	if l == nil {
+		t.Fatal("expected non-nil launcher")
+	}
+	if l.TmuxSocket != "/private/tmp/tmux-501/default" {
+		t.Errorf("TmuxSocket: got %q", l.TmuxSocket)
+	}
+	if l.TmuxPane != "%17" {
+		t.Errorf("TmuxPane: got %q", l.TmuxPane)
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -188,8 +188,16 @@ func TestReadLauncherEnv_Subprocess_NoRelevantEnv(t *testing.T) {
 		t.Skip()
 	}
 	pid := spawnSleeperWithEnv(t, []string{"PATH=/usr/bin:/bin"})
-	if l := ReadLauncherEnv(pid); l != nil {
-		t.Errorf("expected nil launcher, got %+v", l)
+	// With the ancestry fallback, an empty relevant env no longer guarantees
+	// nil — if the test process's host terminal/IDE is on the recognized
+	// list, we'll populate TermProgram from ppid walk. The invariant that
+	// still holds: env-derived fields must be empty (we only set PATH).
+	l := ReadLauncherEnv(pid)
+	if l == nil {
+		return // legitimate on unknown hosts
+	}
+	if l.ITermSessionID != "" || l.TermSessionID != "" || l.TmuxPane != "" || l.VSCodePID != 0 {
+		t.Errorf("expected only ancestry-derived TermProgram, got %+v", l)
 	}
 }
 
@@ -213,4 +221,61 @@ func TestReadLauncherEnv_Subprocess_Tmux(t *testing.T) {
 	if l.TmuxPane != "%17" {
 		t.Errorf("TmuxPane: got %q", l.TmuxPane)
 	}
+}
+
+func TestTermProgramForAppPath(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only helper")
+	}
+	tests := []struct {
+		in, want string
+	}{
+		{"/Applications/Visual Studio Code.app/Contents/MacOS/Code", "vscode"},
+		{"/Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper", "vscode"},
+		{"/Applications/iTerm.app/Contents/MacOS/iTerm2", "iTerm.app"},
+		{"/System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal", "Apple_Terminal"},
+		{"/Applications/Cursor.app/Contents/MacOS/Cursor", "cursor"},
+		{"/Applications/Ghostty.app/Contents/MacOS/ghostty", "ghostty"},
+		{"/Applications/Warp.app/Contents/MacOS/stable", "Warp"},
+		{"/Applications/WezTerm.app/Contents/MacOS/wezterm-gui", "WezTerm"},
+		{"/Applications/Hyper.app/Contents/MacOS/Hyper", "Hyper"},
+		{"/Applications/Windsurf.app/Contents/MacOS/Windsurf", "windsurf"},
+		// No .app segment: not a host we know.
+		{"/bin/zsh", ""},
+		{"/Users/ingo/.local/share/claude/versions/2.1.114", ""},
+		{"/usr/bin/tmux", ""},
+		// .app appears in a path fragment but not as a bundle boundary.
+		{"/tmp/not.appended/bin/thing", ""},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := termProgramForAppPath(tc.in); got != tc.want {
+			t.Errorf("termProgramForAppPath(%q): got %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestResolveTermProgramFromAncestry_Self walks the ancestry of the running
+// test binary. We don't know what terminal launched the developer's `go test`
+// invocation, so we only assert that the helper either finds a supported host
+// (non-empty) or returns "" cleanly — never errors or panics.
+func TestResolveTermProgramFromAncestry_Self(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only helper")
+	}
+	got := resolveTermProgramFromAncestry(os.Getpid())
+	if got != "" {
+		if _, known := termProgramByAppName[reverseLookup(got)]; !known {
+			t.Errorf("resolveTermProgramFromAncestry returned unknown TermProgram %q", got)
+		}
+	}
+}
+
+func reverseLookup(termProgram string) string {
+	for k, v := range termProgramByAppName {
+		if v == termProgram {
+			return k
+		}
+	}
+	return ""
 }

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -505,6 +505,19 @@ func (pm *PIDManager) SeedPIDs(states []*session.SessionState) {
 						fmt.Sprintf("failed to watch existing pid %d: %v", state.PID, err))
 				}
 			}
+			// Best-effort backfill: pre-existing sessions from a previous
+			// daemon build may have Launcher=nil. Re-attempt capture so
+			// row/notification clicks work without requiring the user to
+			// start a new session. Guard on state.Launcher != nil prevents
+			// re-reads when the field is already populated; we persist the
+			// result so the new field is visible via the API immediately.
+			if state.Launcher == nil {
+				pm.captureLauncher(state, state.PID)
+				if state.Launcher != nil {
+					state.UpdatedAt = time.Now().Unix()
+					_ = pm.repo.Save(state)
+				}
+			}
 
 			// Track newest non-subagent session per PID for dedup below.
 			if state.ParentSessionID == "" && !strings.HasPrefix(state.SessionID, "proc-") {

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -506,14 +506,23 @@ func (pm *PIDManager) SeedPIDs(states []*session.SessionState) {
 				}
 			}
 			// Best-effort backfill: pre-existing sessions from a previous
-			// daemon build may have Launcher=nil. Re-attempt capture so
+			// daemon build may have Launcher=nil, or a Launcher struct from
+			// before newer fields (e.g. TTY) existed. Re-attempt capture so
 			// row/notification clicks work without requiring the user to
-			// start a new session. Guard on state.Launcher != nil prevents
-			// re-reads when the field is already populated; we persist the
-			// result so the new field is visible via the API immediately.
+			// start a new session.
 			if state.Launcher == nil {
 				pm.captureLauncher(state, state.PID)
 				if state.Launcher != nil {
+					state.UpdatedAt = time.Now().Unix()
+					_ = pm.repo.Save(state)
+				}
+			} else if state.Launcher.TTY == "" && pm.launcherEnv != nil {
+				// Targeted TTY backfill. Keep the stable env-based identity
+				// (iterm_session_id, vscode_pid, ...) and only fill in what's
+				// missing — avoids clobbering known-good data in the rare
+				// case where a PID got recycled.
+				if fresh := pm.launcherEnv(state.PID); fresh != nil && fresh.TTY != "" {
+					state.Launcher.TTY = fresh.TTY
 					state.UpdatedAt = time.Now().Unix()
 					_ = pm.repo.Save(state)
 				}

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -24,6 +24,13 @@ import (
 // candidates match.
 type PIDDiscoverFunc func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error)
 
+// LauncherEnvReader captures the terminal/IDE identity from the process env
+// of pid. Returns nil when env cannot be read or no launcher is identifiable.
+// Implementations must never block longer than a couple of seconds and must
+// never prompt the user (no TCC). The real implementation lives in the
+// processlifecycle adapter and is injected to preserve the hexagonal layering.
+type LauncherEnvReader func(pid int) *session.Launcher
+
 // PIDManager manages the process lifecycle for sessions. It discovers PIDs,
 // registers them with ProcessWatcher, handles exits, and sweeps dead processes.
 type PIDManager struct {
@@ -36,6 +43,9 @@ type PIDManager struct {
 	// pidDiscovers maps adapter name → PID discovery function.
 	// Nil or missing entry means no PID discovery for that adapter.
 	pidDiscovers map[string]PIDDiscoverFunc
+
+	// launcherEnv reads launcher env from a PID. Optional — nil skips capture.
+	launcherEnv LauncherEnvReader
 
 	// onSessionDeleted is called when a session is deleted so the caller can
 	// clean up its own tracking structures (e.g. projectSessions map).
@@ -98,6 +108,25 @@ func (pm *PIDManager) SetRecorder(r outbound.EventRecorder, seq *int64) {
 // `working` solely because of that child.
 func (pm *PIDManager) SetChildDeletedHandler(fn func(parentID string)) {
 	pm.onChildDeleted = fn
+}
+
+// SetLauncherEnvReader installs a reader that captures launcher identity
+// (terminal/IDE env vars) from a session's PID. Called once at startup.
+// Nil disables launcher capture.
+func (pm *PIDManager) SetLauncherEnvReader(fn LauncherEnvReader) {
+	pm.launcherEnv = fn
+}
+
+// captureLauncher invokes the launcher-env reader if one is installed and
+// the session does not yet have a launcher recorded. Safe to call multiple
+// times; only populates on the first successful read.
+func (pm *PIDManager) captureLauncher(state *session.SessionState, pid int) {
+	if pm.launcherEnv == nil || state == nil || state.Launcher != nil || pid <= 0 {
+		return
+	}
+	if l := pm.launcherEnv(pid); l != nil {
+		state.Launcher = l
+	}
 }
 
 // record emits a lifecycle event if recording is enabled.
@@ -192,6 +221,7 @@ func (pm *PIDManager) HandlePIDAssigned(pid int, sessionID string) {
 	}
 
 	state.PID = pid
+	pm.captureLauncher(state, pid)
 	state.UpdatedAt = time.Now().Unix()
 	_ = pm.repo.Save(state)
 

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -87,3 +87,49 @@ func TestCheckPIDLiveness_StaleTranscript_Deleted(t *testing.T) {
 		t.Fatal("session should be deleted (stale transcript + ready + pid=0 + >30s)")
 	}
 }
+
+// TestHandlePIDAssigned_LauncherCaptureIsIdempotent verifies the reader runs
+// exactly once when a session first gets a launcher, and is never invoked
+// again even if a different PID later arrives.
+func TestHandlePIDAssigned_LauncherCaptureIsIdempotent(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = &session.SessionState{
+		SessionID: "s",
+		State:     session.StateWorking,
+		UpdatedAt: time.Now().Unix(),
+	}
+
+	pm := newPIDManagerForTest(repo)
+	var calls int
+	pm.SetLauncherEnvReader(func(pid int) *session.Launcher {
+		calls++
+		return &session.Launcher{TermProgram: "iTerm.app"}
+	})
+
+	pm.HandlePIDAssigned(42, "s")
+	if calls != 1 {
+		t.Fatalf("first assign: reader calls = %d, want 1", calls)
+	}
+	if repo.states["s"].Launcher == nil {
+		t.Fatal("first assign: launcher not captured")
+	}
+
+	// Same PID, same session: HandlePIDAssigned early-returns at the
+	// `state.PID == pid` guard before reaching captureLauncher.
+	pm.HandlePIDAssigned(42, "s")
+	if calls != 1 {
+		t.Errorf("repeat same PID: reader re-invoked (%d calls)", calls)
+	}
+
+	// Different PID on a session that already has a launcher: state.PID
+	// changes, but captureLauncher's `state.Launcher != nil` guard prevents
+	// a re-read — preserving the original launcher identity even across
+	// process restarts / /clear scenarios.
+	pm.HandlePIDAssigned(99, "s")
+	if calls != 1 {
+		t.Errorf("new PID with existing launcher: reader re-invoked (%d calls)", calls)
+	}
+	if repo.states["s"].Launcher == nil || repo.states["s"].Launcher.TermProgram != "iTerm.app" {
+		t.Errorf("launcher clobbered by later PID assignment: %+v", repo.states["s"].Launcher)
+	}
+}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -179,6 +179,12 @@ func (d *SessionDetector) SetCostTracker(c outbound.CostTracker) {
 	d.costTracker = c
 }
 
+// SetLauncherEnvReader installs a reader that captures terminal/IDE identity
+// from a session's PID when the PID is first assigned.
+func (d *SessionDetector) SetLauncherEnvReader(fn LauncherEnvReader) {
+	d.pidMgr.SetLauncherEnvReader(fn)
+}
+
 // recordCost is a helper that calls the optional CostTracker and logs but
 // does not propagate errors — cost tracking must never block the detector.
 func (d *SessionDetector) recordCost(state *session.SessionState) {
@@ -500,6 +506,10 @@ func (d *SessionDetector) processActivity(ev agent.Event) {
 			d.log.LogInfo("session-detector", ev.SessionID,
 				fmt.Sprintf("applied deferred pid %d", pid))
 		}
+		// Capture launcher identity idempotently — HandlePIDAssigned
+		// normally populates it, but this path runs first in startup
+		// races where the pending PID is applied before the direct save.
+		d.pidMgr.captureLauncher(state, pid)
 	}
 
 	// Retry PID discovery if not yet known.

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -1142,6 +1142,52 @@ func TestSessionDetector_PIDAssigned_CleansUpOldSession(t *testing.T) {
 	}
 }
 
+func TestSessionDetector_PIDAssigned_CapturesLauncher(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	now := time.Now().Unix()
+	repo.states["s"] = &session.SessionState{
+		SessionID: "s",
+		State:     session.StateWorking,
+		FirstSeen: now,
+		UpdatedAt: now,
+	}
+
+	det := newDetector(tw, pw, repo)
+	var calledPID int
+	det.SetLauncherEnvReader(func(pid int) *session.Launcher {
+		calledPID = pid
+		return &session.Launcher{
+			TermProgram:    "iTerm.app",
+			ITermSessionID: "w0t0p0",
+		}
+	})
+
+	det.HandlePIDAssigned(4242, "s")
+
+	if calledPID != 4242 {
+		t.Errorf("LauncherEnvReader pid: got %d, want 4242", calledPID)
+	}
+	state, _ := repo.Load("s")
+	if state == nil || state.Launcher == nil {
+		t.Fatal("expected Launcher to be set after HandlePIDAssigned")
+	}
+	if state.Launcher.TermProgram != "iTerm.app" {
+		t.Errorf("Launcher.TermProgram: got %q, want iTerm.app", state.Launcher.TermProgram)
+	}
+
+	// Subsequent PID assignment with the same PID must not clobber — the
+	// guard `state.PID == pid` bails before we re-read env, so the reader
+	// should not even be invoked again.
+	calledPID = 0
+	det.HandlePIDAssigned(4242, "s")
+	if calledPID != 0 {
+		t.Errorf("LauncherEnvReader invoked again for same PID: got %d", calledPID)
+	}
+}
+
 func TestSessionDetector_PIDAssigned_SkipsSubagents(t *testing.T) {
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -403,6 +403,9 @@ func main() {
 	if costTracker != nil {
 		detector.SetCostTracker(costTracker)
 	}
+	// Capture terminal/IDE identity at first PID assignment so the menu-bar
+	// app can jump back to the launching terminal on row/notification click.
+	detector.SetLauncherEnvReader(processlifecycle.ReadLauncherEnv)
 
 	// Hook receiver: Claude Code PermissionRequest/PostToolUse events.
 	// The detector satisfies claudecode.HookTarget via HandlePermissionHook.

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -203,6 +203,7 @@ type Launcher struct {
 	TmuxPane       string `json:"tmux_pane,omitempty"`        // $TMUX_PANE
 	TmuxSocket     string `json:"tmux_socket,omitempty"`      // first `,`-field of $TMUX
 	VSCodePID      int    `json:"vscode_pid,omitempty"`       // $VSCODE_PID (vscode/cursor/windsurf)
+	TTY            string `json:"tty,omitempty"`              // controlling TTY of the agent process, e.g. "/dev/ttys021" — Terminal.app AppleScript matches tabs by this
 }
 
 // IsEmpty reports whether the launcher carries no identifying information
@@ -211,7 +212,7 @@ type Launcher struct {
 func (l *Launcher) IsEmpty() bool {
 	return l == nil || (l.TermProgram == "" && l.ITermSessionID == "" &&
 		l.TermSessionID == "" && l.TmuxPane == "" &&
-		l.TmuxSocket == "" && l.VSCodePID == 0)
+		l.TmuxSocket == "" && l.VSCodePID == 0 && l.TTY == "")
 }
 
 // SessionState represents the current state of a Claude Code or Copilot session.

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -187,6 +187,33 @@ type SubagentSummary struct {
 	Ready   int `json:"ready"`
 }
 
+// Launcher identifies the terminal emulator or IDE that spawned the session's
+// agent process. Captured once from the process env when the PID is first
+// known (see processlifecycle.ReadLauncherEnv). Fields are best-effort —
+// clients must treat every field as optional and fall back to the session
+// CWD when nothing identifies the host.
+//
+// TermProgram is the primary identifier; clients map it to a platform-native
+// activator (e.g. the macOS menu-bar app derives an app bundle ID from it).
+// Keeping that derivation client-side avoids persisting redundant state.
+type Launcher struct {
+	TermProgram    string `json:"term_program,omitempty"`     // $TERM_PROGRAM (e.g. iTerm.app, Apple_Terminal, vscode, cursor, ghostty, WezTerm, Hyper)
+	ITermSessionID string `json:"iterm_session_id,omitempty"` // $ITERM_SESSION_ID
+	TermSessionID  string `json:"term_session_id,omitempty"`  // $TERM_SESSION_ID (Terminal.app)
+	TmuxPane       string `json:"tmux_pane,omitempty"`        // $TMUX_PANE
+	TmuxSocket     string `json:"tmux_socket,omitempty"`      // first `,`-field of $TMUX
+	VSCodePID      int    `json:"vscode_pid,omitempty"`       // $VSCODE_PID (vscode/cursor/windsurf)
+}
+
+// IsEmpty reports whether the launcher carries no identifying information
+// — i.e. every field is zero. Capture helpers use this to decide whether to
+// return nil rather than attach a meaningless struct to the session.
+func (l *Launcher) IsEmpty() bool {
+	return l == nil || (l.TermProgram == "" && l.ITermSessionID == "" &&
+		l.TermSessionID == "" && l.TmuxPane == "" &&
+		l.TmuxSocket == "" && l.VSCodePID == 0)
+}
+
 // SessionState represents the current state of a Claude Code or Copilot session.
 type SessionState struct {
 	Version         int             `json:"version"`
@@ -211,6 +238,11 @@ type SessionState struct {
 
 	// PID of the Claude Code process that owns this session (set on SessionStart).
 	PID int `json:"pid,omitempty"`
+
+	// Launcher identifies the terminal/IDE that spawned the agent process.
+	// Captured once when PID is first assigned; nil if env capture failed
+	// or no recognized env vars were present.
+	Launcher *Launcher `json:"launcher,omitempty"`
 
 	// ParentSessionID links a subagent session to its spawning parent session.
 	// Derived from file path or heuristic matching in SessionDetector.

--- a/core/domain/session/session_test.go
+++ b/core/domain/session/session_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -28,5 +29,42 @@ func TestIsStale(t *testing.T) {
 				t.Errorf("IsStale(%v) = %v, want %v", tt.maxAge, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSessionState_LauncherJSONRoundTrip(t *testing.T) {
+	// With Launcher present.
+	in := &SessionState{
+		SessionID: "abc",
+		State:     StateWorking,
+		PID:       1234,
+		Launcher: &Launcher{
+			TermProgram:    "iTerm.app",
+			ITermSessionID: "w0t0p0",
+		},
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out SessionState
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Launcher == nil {
+		t.Fatal("Launcher lost in round-trip")
+	}
+	if out.Launcher.TermProgram != "iTerm.app" || out.Launcher.ITermSessionID != "w0t0p0" {
+		t.Errorf("launcher round-trip mismatch: %+v", out.Launcher)
+	}
+
+	// Without Launcher — backwards compat with pre-170 session JSON files.
+	legacy := []byte(`{"session_id":"xyz","state":"ready","pid":99}`)
+	var legacyOut SessionState
+	if err := json.Unmarshal(legacy, &legacyOut); err != nil {
+		t.Fatalf("unmarshal legacy: %v", err)
+	}
+	if legacyOut.Launcher != nil {
+		t.Errorf("legacy session should have nil Launcher, got %+v", legacyOut.Launcher)
 	}
 }

--- a/core/go.mod
+++ b/core/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/grandcat/zeroconf v1.0.0
+	golang.org/x/sys v0.42.0
 )
 
 require (
@@ -15,6 +16,5 @@ require (
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/tools v0.40.0 // indirect
 )

--- a/platforms/build-release.sh
+++ b/platforms/build-release.sh
@@ -114,6 +114,8 @@ cat > "$APP_CONTENTS/Info.plist" <<PLIST
     <string>13.0</string>
     <key>LSUIElement</key>
     <true/>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Irrlicht uses AppleScript to bring the correct iTerm2 window and tab to the front when you click a session row.</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright 2024 Anthropic. All rights reserved.</string>
     <key>NSPrincipalClass</key>

--- a/platforms/build-release.sh
+++ b/platforms/build-release.sh
@@ -115,7 +115,7 @@ cat > "$APP_CONTENTS/Info.plist" <<PLIST
     <key>LSUIElement</key>
     <true/>
     <key>NSAppleEventsUsageDescription</key>
-    <string>Irrlicht uses AppleScript to bring the correct iTerm2 window and tab to the front when you click a session row.</string>
+    <string>Irrlicht uses AppleScript to bring the correct iTerm2 or Terminal.app window and tab to the front when you click a session row.</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright 2024 Anthropic. All rights reserved.</string>
     <key>NSPrincipalClass</key>

--- a/platforms/macos/Irrlicht/Managers/Launcher/AccessibilityPermission.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/AccessibilityPermission.swift
@@ -1,0 +1,16 @@
+import ApplicationServices
+import Foundation
+
+/// macOS Accessibility permission check shared by AX-based activators.
+/// First call with a non-trusted process triggers the system prompt;
+/// subsequent calls short-circuit.
+enum AccessibilityPermission {
+    /// Returns true when the current process has been granted
+    /// Accessibility access. When the user hasn't yet decided, shows the
+    /// system prompt (controlled by `kAXTrustedCheckOptionPrompt`).
+    static func ensureTrusted() -> Bool {
+        let key = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+        let opts = [key: true] as CFDictionary
+        return AXIsProcessTrustedWithOptions(opts)
+    }
+}

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/AXTitleMatchActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/AXTitleMatchActivator.swift
@@ -1,0 +1,124 @@
+import AppKit
+import ApplicationServices
+import Foundation
+import OSLog
+
+/// Generic activator for hosts that don't expose a scripting-dictionary
+/// session ID: activates the app via LaunchServices, then uses the
+/// Accessibility API to raise the window whose title best matches the
+/// session's cwd (deepest common ancestor segment wins).
+///
+/// Covers VS Code / Cursor / Windsurf (whose window titles show the
+/// workspace folder name like `"README.md — irrlicht"`) and every other
+/// terminal without a stable per-tab selector. Parameterised, so a new
+/// host is just one line in the registry.
+struct AXTitleMatchActivator: HostActivator {
+    private static let logger = Logger(subsystem: "io.irrlicht.app", category: "AXTitleMatchActivator")
+
+    let termProgram: String
+    let bundleID: String
+
+    func activate(_ session: SessionState) -> Bool {
+        let cwd = session.cwd
+        guard !cwd.isEmpty else {
+            Self.logger.info("no cwd for session \(session.id, privacy: .public)")
+            return false
+        }
+        let bid = bundleID
+        let ok = AppActivator.activate(bundleID: bid) { activated in
+            guard activated else { return }
+            Self.raiseMatchingWindow(bundleID: bid, cwd: cwd)
+        }
+        return ok
+    }
+
+    // MARK: - AX window selection
+
+    private static func raiseMatchingWindow(bundleID: String, cwd: String) {
+        guard AccessibilityPermission.ensureTrusted() else {
+            logger.info("AX permission not granted — staying on app-level activation")
+            return
+        }
+        let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+        guard let app = runningApps.first else { return }
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+
+        var windowsRef: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef)
+        guard status == .success, let windows = windowsRef as? [AXUIElement] else { return }
+
+        let titles = windows.map { windowTitle($0) }
+        guard let idx = bestMatchIndex(titles: titles, cwd: cwd) else {
+            logger.info("no window title matched cwd \(cwd, privacy: .public); candidates=\(titles, privacy: .public)")
+            return
+        }
+        let target = windows[idx]
+        AXUIElementPerformAction(target, kAXRaiseAction as CFString)
+        AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
+    }
+
+    private static func windowTitle(_ window: AXUIElement) -> String {
+        var titleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef)
+        return (titleRef as? String) ?? ""
+    }
+
+    // MARK: - Title match (pure, testable)
+
+    /// Generic root-level path segments that must never serve as a match
+    /// signal — they appear in virtually every home-directory path string.
+    private static let genericTopSegments: Set<String> = [
+        "Users", "home", "tmp", "var", "private", "opt", "mnt", "root"
+    ]
+
+    /// Scores a window title against a cwd. Higher score = better match.
+    /// Returns 0 when the title shares no meaningful path segment with cwd.
+    ///
+    /// - Tier A (score 1000): title contains the full absolute cwd — common
+    ///   for terminal tab titles, and the only signal that should beat an
+    ///   ancestor match regardless of depth.
+    /// - Tier B (score = depth index + 1): deepest path segment of cwd that
+    ///   appears in the title wins. This handles VS Code, whose window title
+    ///   shows only the *workspace folder* name (e.g. `"2.1.114 — irrlicht"`)
+    ///   even when the Claude Code session's cwd is a subdirectory several
+    ///   levels below (`.../irrlicht/.claude/worktrees/170`). The deeper the
+    ///   matching ancestor, the more specific the signal.
+    ///
+    /// Generic top segments (`Users`, user home basename, `tmp`, etc.) are
+    /// skipped because they occur in nearly every string and would cause
+    /// false matches.
+    static func titleMatchScore(title: String, cwd: String) -> Int {
+        if title.isEmpty || cwd.isEmpty { return 0 }
+        if title.contains(cwd) { return 1_000 }
+
+        let trimmed = cwd.hasSuffix("/") ? String(cwd.dropLast()) : cwd
+        let parts = trimmed.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+
+        let homeBasename = (ProcessInfo.processInfo.environment["HOME"] ?? "")
+            .split(separator: "/").last.map(String.init) ?? ""
+
+        for i in (0..<parts.count).reversed() {
+            let p = parts[i]
+            if p.isEmpty { continue }
+            if genericTopSegments.contains(p) { continue }
+            if !homeBasename.isEmpty && p == homeBasename { continue }
+            if title.contains(p) { return i + 1 }
+        }
+        return 0
+    }
+
+    /// Index of the highest-scoring title, or nil when all scores are 0.
+    /// Ties break by first occurrence (AX returns windows in z-order; the
+    /// topmost matching window wins).
+    static func bestMatchIndex(titles: [String], cwd: String) -> Int? {
+        var best: (idx: Int, score: Int)?
+        for (i, t) in titles.enumerated() {
+            let s = titleMatchScore(title: t, cwd: cwd)
+            if s == 0 { continue }
+            if best == nil || s > best!.score {
+                best = (i, s)
+            }
+        }
+        return best?.idx
+    }
+}

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/ITermActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/ITermActivator.swift
@@ -1,0 +1,67 @@
+import Foundation
+import OSLog
+
+/// iTerm2 activator: selects the exact session (window/tab/pane) by its
+/// AppleScript `unique id`, which we captured from `$ITERM_SESSION_ID`
+/// at session birth.
+///
+/// Why AppleScript and not AX: iTerm2's window titles are just the
+/// program name (`"zsh"`) — no path signal for the AX matcher. But its
+/// scripting dictionary exposes `unique id` on sessions and a `select`
+/// action on windows/tabs/sessions that works across spaces and screens.
+/// `select` is pure focus — no `do script`, nothing typed into shells.
+struct ITermActivator: HostActivator {
+    private static let logger = Logger(subsystem: "io.irrlicht.app", category: "ITermActivator")
+
+    let termProgram = "iTerm.app"
+    let bundleID = "com.googlecode.iterm2"
+
+    func activate(_ session: SessionState) -> Bool {
+        guard let uuid = Self.iTermUUID(from: session.launcher?.itermSessionID) else {
+            Self.logger.info("no iterm_session_id for session \(session.id, privacy: .public)")
+            return false
+        }
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = Self.selectSession(uuid: uuid)
+        }
+        return true
+    }
+
+    /// Extracts the UUID portion from an `$ITERM_SESSION_ID` value. Accepts
+    /// both legacy `w0t0p0:UUID` and current `w0:t0:p0:UUID` formats by
+    /// taking the substring after the *last* colon.
+    static func iTermUUID(from sessionID: String?) -> String? {
+        guard let sid = sessionID, !sid.isEmpty else { return nil }
+        guard let r = sid.range(of: ":", options: .backwards) else { return sid }
+        let tail = String(sid[r.upperBound...])
+        return tail.isEmpty ? nil : tail
+    }
+
+    private static func selectSession(uuid: String) -> Bool {
+        let safe = AppleScriptRunner.escape(uuid)
+        let source = """
+        tell application "iTerm"
+            activate
+            repeat with w in windows
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        if (unique id of s) is "\(safe)" then
+                            select w
+                            tell t to select
+                            tell s to select
+                            return "1"
+                        end if
+                    end repeat
+                end repeat
+            end repeat
+            return "0"
+        end tell
+        """
+        let result = AppleScriptRunner.run(source, tag: "iTerm")
+        let matched = result == "1"
+        if !matched {
+            logger.info("iTerm: no session matched uuid \(uuid, privacy: .public)")
+        }
+        return matched
+    }
+}

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/TerminalAppActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/TerminalAppActivator.swift
@@ -1,0 +1,60 @@
+import Foundation
+import OSLog
+
+/// Terminal.app activator: selects the tab whose `tty` matches the
+/// session's captured controlling TTY.
+///
+/// Terminal.app has no session-UUID analog on tabs, but its scripting
+/// dictionary exposes `tty` on tabs. Every process in a tab shares the
+/// same controlling TTY, so it's a stable selector for as long as the
+/// tab lives.
+///
+/// Uses `select` + `set index` only — no `do script`, which would type
+/// into the user's live shells.
+struct TerminalAppActivator: HostActivator {
+    private static let logger = Logger(subsystem: "io.irrlicht.app", category: "TerminalAppActivator")
+
+    let termProgram = "Apple_Terminal"
+    let bundleID = "com.apple.Terminal"
+
+    func activate(_ session: SessionState) -> Bool {
+        guard let tty = session.launcher?.tty, !tty.isEmpty else {
+            Self.logger.info("no tty for session \(session.id, privacy: .public)")
+            return false
+        }
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = Self.selectTab(tty: tty)
+        }
+        return true
+    }
+
+    private static func selectTab(tty: String) -> Bool {
+        let safe = AppleScriptRunner.escape(tty)
+        // `activate` LAST, after the window is already at index 1 and the
+        // tab is selected — if we activate first, Terminal races to the
+        // foreground while we're still reordering, and the previously
+        // frontmost window shows through until the next click.
+        let source = """
+        tell application "Terminal"
+            repeat with w in windows
+                repeat with t in tabs of w
+                    if tty of t is "\(safe)" then
+                        set selected tab of w to t
+                        set index of w to 1
+                        activate
+                        return "1"
+                    end if
+                end repeat
+            end repeat
+            activate
+            return "0"
+        end tell
+        """
+        let result = AppleScriptRunner.run(source, tag: "Terminal")
+        let matched = result == "1"
+        if !matched {
+            logger.info("Terminal: no tab matched tty \(tty, privacy: .public)")
+        }
+        return matched
+    }
+}

--- a/platforms/macos/Irrlicht/Managers/Launcher/AppActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/AppActivator.swift
@@ -1,0 +1,41 @@
+import AppKit
+import Foundation
+import OSLog
+
+/// Wraps `NSWorkspace.openApplication` for the generic activation path.
+/// Used by AX-based activators that need to bring an app forward before
+/// raising a specific window via the Accessibility API.
+///
+/// iTerm2 and Terminal.app deliberately do NOT use this — their
+/// AppleScript's own `activate` races with LaunchServices activation and
+/// the wrong window can show through on the first click. Their activators
+/// let AppleScript own activation end-to-end.
+enum AppActivator {
+    private static let logger = Logger(subsystem: "io.irrlicht.app", category: "AppActivator")
+
+    /// Activates the app for `bundleID` and invokes `then` on the
+    /// completion queue when LaunchServices confirms. Returns false
+    /// synchronously if the bundle isn't installed; otherwise the async
+    /// callback carries success/failure.
+    ///
+    /// `then` fires on an arbitrary queue — callers that touch UI state
+    /// must dispatch to main themselves.
+    @discardableResult
+    static func activate(bundleID: String, then: @escaping (Bool) -> Void) -> Bool {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
+            logger.info("no installed app for bundle id \(bundleID, privacy: .public)")
+            return false
+        }
+        let config = NSWorkspace.OpenConfiguration()
+        config.activates = true
+        NSWorkspace.shared.openApplication(at: url, configuration: config) { _, error in
+            if let error {
+                logger.error("openApplication failed: \(error.localizedDescription, privacy: .public)")
+                then(false)
+                return
+            }
+            then(true)
+        }
+        return true
+    }
+}

--- a/platforms/macos/Irrlicht/Managers/Launcher/AppleScriptRunner.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/AppleScriptRunner.swift
@@ -1,0 +1,38 @@
+import Foundation
+import OSLog
+
+/// Thin wrapper around `NSAppleScript` that centralises escaping, error
+/// logging, and the return-value-as-string contract every activator uses.
+enum AppleScriptRunner {
+    private static let logger = Logger(subsystem: "io.irrlicht.app", category: "AppleScriptRunner")
+
+    /// Escapes a string for safe interpolation into an AppleScript
+    /// double-quoted literal. Backslashes must be escaped before quotes
+    /// — otherwise the quote's own escape gets re-escaped and the literal
+    /// breaks.
+    static func escape(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    /// Runs `source` and returns the descriptor's string value, or nil on
+    /// AppleScript error (permission denied, syntax error, target app
+    /// missing). Logs under the activator's `tag` for diagnostics.
+    ///
+    /// Callers typically check `result == "1"` vs `"0"` — scripts should
+    /// return those literals to signal match/no-match so permission
+    /// failures don't silently look like successes.
+    static func run(_ source: String, tag: String) -> String? {
+        var err: NSDictionary?
+        guard let script = NSAppleScript(source: source) else {
+            logger.error("\(tag, privacy: .public): NSAppleScript init failed")
+            return nil
+        }
+        let descriptor = script.executeAndReturnError(&err)
+        if let err {
+            logger.error("\(tag, privacy: .public) AppleScript failed: \(err, privacy: .public)")
+            return nil
+        }
+        return descriptor.stringValue
+    }
+}

--- a/platforms/macos/Irrlicht/Managers/Launcher/HostActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/HostActivator.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Brings a specific window or tab of a given terminal/IDE to the
+/// foreground. One conforming type per supported `$TERM_PROGRAM`.
+///
+/// Activators are consulted by `SessionLauncher.jump(_:)` via the registry
+/// — see `SessionLauncher.swift`. Register a new host by adding an instance
+/// to that registry; no other dispatch code needs to change.
+///
+/// The contract is "works or it doesn't, no fallback": if `activate` can
+/// precisely target the session's window, it does; otherwise it returns
+/// false and the caller logs but does not cascade to another activator.
+/// This avoids misleading partial-behaviour (e.g. landing in Finder when
+/// the user asked for a worktree's editor window).
+protocol HostActivator {
+    /// The `$TERM_PROGRAM` value this activator handles (e.g. `"iTerm.app"`,
+    /// `"Apple_Terminal"`, `"vscode"`). Used as the registry dispatch key.
+    var termProgram: String { get }
+
+    /// macOS bundle identifier of the target app. Exposed so callers that
+    /// want a pure app-level activation can reach it without knowing the
+    /// concrete activator type.
+    var bundleID: String { get }
+
+    /// Perform window/tab activation for `session`. Returns true when the
+    /// activator attempted a real target (regardless of whether macOS then
+    /// animated the focus); false when the activator lacks the signals
+    /// needed for precise targeting or a required permission was denied.
+    func activate(_ session: SessionState) -> Bool
+}

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -1,14 +1,20 @@
 import AppKit
+import ApplicationServices
 import Foundation
 import OSLog
 
-/// Brings the originating terminal or IDE for a session to the foreground.
-/// Used by the session-row tap gesture and the notification click handler.
+/// Brings the originating terminal or IDE window for a session to the
+/// foreground. Used by the session-row tap gesture and the notification
+/// click handler.
 ///
-/// It works, or it doesn't. No fallback — a folder-open in Finder or a
-/// new editor window is worse than no-op (a new VS Code window on the
-/// same workspace kills the existing one, which kills any sessions
-/// running in it, e.g. worktrees).
+/// Two-step dispatch:
+///   1. `NSWorkspace.openApplication` — activate the host app (no permission).
+///   2. Accessibility API — raise the specific window whose title matches
+///      the session's cwd. Silently no-ops if AX permission isn't granted.
+///
+/// It works (right window) or it degrades to app activation (right app, last
+/// used window). No Finder-reveal, no URL schemes that would open a new
+/// editor window and clobber the worktree's existing window.
 enum SessionLauncher {
     private static let logger = Logger(subsystem: "io.irrlicht.app", category: "SessionLauncher")
 
@@ -38,12 +44,94 @@ enum SessionLauncher {
             logger.info("no installed app for bundle id \(bundleID, privacy: .public)")
             return
         }
+        let cwd = session.cwd
         let config = NSWorkspace.OpenConfiguration()
         config.activates = true
         NSWorkspace.shared.openApplication(at: url, configuration: config) { _, error in
             if let error {
                 logger.error("openApplication failed: \(error.localizedDescription, privacy: .public)")
+                return
+            }
+            if !cwd.isEmpty {
+                raiseMatchingWindow(bundleID: bundleID, cwd: cwd)
             }
         }
+    }
+
+    // MARK: - AX window selection
+
+    private static func raiseMatchingWindow(bundleID: String, cwd: String) {
+        guard ensureAXTrust() else {
+            logger.info("AX permission not granted — staying on app-level activation")
+            return
+        }
+        let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
+        guard let app = runningApps.first else { return }
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+
+        var windowsRef: CFTypeRef?
+        let status = AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef)
+        guard status == .success, let windows = windowsRef as? [AXUIElement] else { return }
+
+        let titles = windows.map { windowTitle($0) }
+        guard let idx = bestMatchIndex(titles: titles, cwd: cwd) else {
+            logger.info("no window title matched cwd \(cwd, privacy: .public)")
+            return
+        }
+        let target = windows[idx]
+        AXUIElementPerformAction(target, kAXRaiseAction as CFString)
+        AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
+    }
+
+    private static func windowTitle(_ window: AXUIElement) -> String {
+        var titleRef: CFTypeRef?
+        AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef)
+        return (titleRef as? String) ?? ""
+    }
+
+    private static func ensureAXTrust() -> Bool {
+        let key = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+        let opts = [key: true] as CFDictionary
+        return AXIsProcessTrustedWithOptions(opts)
+    }
+
+    // MARK: - Title match (pure, testable)
+
+    /// Scores a window title against a cwd. Higher score = better match.
+    /// 0 means no match — caller should skip this window.
+    ///
+    ///   3 — title contains the full absolute cwd (iTerm2/Terminal tab titles often do)
+    ///   2 — title contains the last two cwd components joined by "/"
+    ///       (disambiguates common basenames like "src" or "170")
+    ///   1 — title contains just the cwd basename
+    ///   0 — no match
+    static func titleMatchScore(title: String, cwd: String) -> Int {
+        if title.isEmpty || cwd.isEmpty { return 0 }
+        if title.contains(cwd) { return 3 }
+        let trimmed = cwd.hasSuffix("/") ? String(cwd.dropLast()) : cwd
+        let parts = trimmed.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        if parts.count >= 2 {
+            let lastTwo = parts.suffix(2).joined(separator: "/")
+            if title.contains(lastTwo) { return 2 }
+        }
+        if let base = parts.last, !base.isEmpty, title.contains(base) {
+            return 1
+        }
+        return 0
+    }
+
+    /// Index of the highest-scoring title, or nil when all scores are 0.
+    /// Ties break by first occurrence (AX returns windows in z-order; the
+    /// topmost matching window wins).
+    static func bestMatchIndex(titles: [String], cwd: String) -> Int? {
+        var best: (idx: Int, score: Int)?
+        for (i, t) in titles.enumerated() {
+            let s = titleMatchScore(title: t, cwd: cwd)
+            if s == 0 { continue }
+            if best == nil || s > best!.score {
+                best = (i, s)
+            }
+        }
+        return best?.idx
     }
 }

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -2,26 +2,16 @@ import AppKit
 import Foundation
 import OSLog
 
-/// SessionLauncher brings the originating terminal or IDE for a session back
-/// to the foreground. Used by the session-row tap gesture and the notification
-/// click handler.
+/// Brings the originating terminal or IDE for a session to the foreground.
+/// Used by the session-row tap gesture and the notification click handler.
 ///
-/// Dispatch order, most-specific first:
-///   1. iTerm2 session by $ITERM_SESSION_ID (AppleScript, with match detection)
-///   2. VS Code / Cursor / Windsurf → their file URL scheme against cwd
-///   3. tmux switch-client by socket + pane, then fall through to host terminal
-///   4. NSWorkspace activate by bundle ID derived from termProgram (covers Terminal.app,
-///      Ghostty, Warp, WezTerm, Hyper, and iTerm2 when tier 1 found no match)
-///   5. Finder-reveal of session.cwd (final fallback)
-///
-/// Each tier logs and falls through on failure — permission denials from
-/// AppleScript must never crash the UI.
+/// It works, or it doesn't. No fallback — a folder-open in Finder or a
+/// new editor window is worse than no-op (a new VS Code window on the
+/// same workspace kills the existing one, which kills any sessions
+/// running in it, e.g. worktrees).
 enum SessionLauncher {
     private static let logger = Logger(subsystem: "io.irrlicht.app", category: "SessionLauncher")
 
-    /// Maps $TERM_PROGRAM values to macOS bundle identifiers for the fallback
-    /// NSWorkspace activation tier. tmux is intentionally absent — a tmux
-    /// passthrough has no host terminal we can activate by itself.
     private static let bundleIDByTermProgram: [String: String] = [
         "iTerm.app":      "com.googlecode.iterm2",
         "Apple_Terminal": "com.apple.Terminal",
@@ -34,190 +24,25 @@ enum SessionLauncher {
         "Warp":           "dev.warp.Warp-Stable",
     ]
 
-    /// Derives the macOS bundle ID for a $TERM_PROGRAM value, or nil when we
-    /// don't know one. Kept client-side so the daemon's domain model stays
-    /// platform-neutral.
     static func bundleID(for termProgram: String?) -> String? {
         guard let termProgram else { return nil }
         return bundleIDByTermProgram[termProgram]
     }
 
-    /// Brings the session's originating terminal/IDE to the foreground.
-    /// Safe to call on the main thread; AppleScript work is dispatched to a
-    /// background queue internally.
     static func jump(_ session: SessionState) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            dispatch(session)
-        }
-    }
-
-    private static func dispatch(_ session: SessionState) {
-        let launcher = session.launcher
-
-        // 1. iTerm2 — precise per-session targeting.
-        if launcher?.termProgram == "iTerm.app",
-           let sid = launcher?.itermSessionID, !sid.isEmpty {
-            if runAppleScriptMatching(iterm2SelectScript(sessionID: sid)) {
-                return
-            }
-            // No matching session (window closed, session rotated): fall
-            // through to tier 4 and just bring iTerm2 frontmost.
-        }
-
-        // 2. VS Code / Cursor / Windsurf — open the folder in the editor.
-        if let scheme = editorURLScheme(for: launcher?.termProgram),
-           !session.cwd.isEmpty,
-           let url = editorFolderURL(scheme: scheme, cwd: session.cwd),
-           openURL(url) {
+        guard let bundleID = bundleID(for: session.launcher?.termProgram) else {
+            logger.info("no launcher for session \(session.id, privacy: .public)")
             return
         }
-
-        // 3. tmux — switch-client then fall through to the host terminal.
-        if let pane = launcher?.tmuxPane, !pane.isEmpty {
-            runTmuxSwitch(socket: launcher?.tmuxSocket, pane: pane)
-            // Intentional fall-through: bring the host terminal frontmost.
-        }
-
-        // 4. NSWorkspace activate by bundle ID. Covers Terminal.app (we don't
-        //    target individual tabs — Terminal.app AppleScript has no way to
-        //    read a tab's env, and `do script` would type commands into real
-        //    tabs), Ghostty, Warp, WezTerm, Hyper, and iTerm2 fallback.
-        if let bundleID = bundleID(for: launcher?.termProgram) {
-            activateApp(bundleID: bundleID)
-            return
-        }
-
-        // 5. Final fallback: Finder-reveal the working directory.
-        if !session.cwd.isEmpty {
-            let url = URL(fileURLWithPath: session.cwd, isDirectory: true)
-            NSWorkspace.shared.activateFileViewerSelecting([url])
-            return
-        }
-
-        logger.info("SessionLauncher: no target for session \(session.id, privacy: .public)")
-    }
-
-    // MARK: - Pure helpers (testable)
-
-    /// Returns the editor URL scheme for a $TERM_PROGRAM value that Irrlicht
-    /// supports directly, or nil when the program isn't a folder-opening editor.
-    static func editorURLScheme(for termProgram: String?) -> String? {
-        switch termProgram {
-        case "vscode":   return "vscode"
-        case "cursor":   return "cursor"
-        case "windsurf": return "windsurf"
-        default:         return nil
-        }
-    }
-
-    /// Builds `<scheme>://file<cwd>` using URLComponents so the path segment is
-    /// correctly percent-encoded. Returns nil when the components don't form a
-    /// valid URL (e.g. non-absolute cwd).
-    static func editorFolderURL(scheme: String, cwd: String) -> URL? {
-        var comps = URLComponents()
-        comps.scheme = scheme
-        comps.host = "file"
-        comps.path = cwd
-        return comps.url
-    }
-
-    /// Escapes a string for safe interpolation into an AppleScript double-
-    /// quoted literal. Backslashes must be escaped before quotes, otherwise
-    /// the quote's own escape gets re-escaped and the literal breaks.
-    static func appleScriptEscape(_ s: String) -> String {
-        return s
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-    }
-
-    // MARK: - Scripts
-
-    static func iterm2SelectScript(sessionID: String) -> String {
-        // Returns "1" if a session with the given unique id was found and
-        // selected, "0" otherwise — so the Swift caller can fall through to
-        // a bundle-ID activate when the originating session is gone.
-        let safe = appleScriptEscape(sessionID)
-        return """
-        tell application "iTerm"
-            activate
-            repeat with w in windows
-                repeat with t in tabs of w
-                    repeat with s in sessions of t
-                        if (unique id of s) is "\(safe)" then
-                            select w
-                            tell t to select
-                            tell s to select
-                            return "1"
-                        end if
-                    end repeat
-                end repeat
-            end repeat
-            return "0"
-        end tell
-        """
-    }
-
-    // MARK: - AppleScript execution
-
-    /// Runs an AppleScript expected to return `"1"` on match / `"0"` on
-    /// no-match. Returns true only when the script executed successfully AND
-    /// returned "1". A raised AppleScript error (e.g. automation permission
-    /// denied) returns false so callers can fall through to other tiers.
-    private static func runAppleScriptMatching(_ source: String) -> Bool {
-        var error: NSDictionary?
-        guard let script = NSAppleScript(source: source) else { return false }
-        let descriptor = script.executeAndReturnError(&error)
-        if let error {
-            logger.error("SessionLauncher AppleScript failed: \(error, privacy: .public)")
-            return false
-        }
-        return descriptor.stringValue == "1"
-    }
-
-    // MARK: - tmux
-
-    private static func runTmuxSwitch(socket: String?, pane: String) {
-        let task = Process()
-        task.launchPath = "/usr/bin/env"
-        var args = ["tmux"]
-        if let s = socket, !s.isEmpty {
-            args += ["-S", s]
-        }
-        args += ["switch-client", "-t", pane]
-        task.arguments = args
-        do {
-            try task.run()
-            task.waitUntilExit()
-        } catch {
-            logger.error("SessionLauncher: tmux switch-client failed: \(error.localizedDescription, privacy: .public)")
-        }
-    }
-
-    // MARK: - URL + bundle activation
-
-    private static func openURL(_ url: URL) -> Bool {
-        let opened = NSWorkspace.shared.open(url)
-        if !opened {
-            logger.error("SessionLauncher: NSWorkspace.open failed for \(url.absoluteString, privacy: .public)")
-        }
-        return opened
-    }
-
-    /// Brings the app identified by bundleID to the front. Async under the
-    /// hood; we never block waiting for the open. Errors are logged, never
-    /// propagated — the caller has already committed to this as the chosen
-    /// tier and there is no useful fallback for a missing-app case beyond
-    /// the UI's own error surfacing (which we don't have).
-    private static func activateApp(bundleID: String) {
         guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
-            logger.info("SessionLauncher: no installed app for bundle id \(bundleID, privacy: .public)")
+            logger.info("no installed app for bundle id \(bundleID, privacy: .public)")
             return
         }
         let config = NSWorkspace.OpenConfiguration()
         config.activates = true
         NSWorkspace.shared.openApplication(at: url, configuration: config) { _, error in
             if let error {
-                logger.error("SessionLauncher: openApplication failed: \(error.localizedDescription, privacy: .public)")
+                logger.error("openApplication failed: \(error.localizedDescription, privacy: .public)")
             }
         }
     }

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -75,7 +75,7 @@ enum SessionLauncher {
 
         let titles = windows.map { windowTitle($0) }
         guard let idx = bestMatchIndex(titles: titles, cwd: cwd) else {
-            logger.info("no window title matched cwd \(cwd, privacy: .public)")
+            logger.info("no window title matched cwd \(cwd, privacy: .public); candidates=\(titles, privacy: .public)")
             return
         }
         let target = windows[idx]
@@ -97,25 +97,44 @@ enum SessionLauncher {
 
     // MARK: - Title match (pure, testable)
 
+    /// Generic root-level path segments that must never serve as a match
+    /// signal — they appear in virtually every home-directory path string.
+    private static let genericTopSegments: Set<String> = [
+        "Users", "home", "tmp", "var", "private", "opt", "mnt", "root"
+    ]
+
     /// Scores a window title against a cwd. Higher score = better match.
-    /// 0 means no match — caller should skip this window.
+    /// Returns 0 when the title shares no meaningful path segment with cwd.
     ///
-    ///   3 — title contains the full absolute cwd (iTerm2/Terminal tab titles often do)
-    ///   2 — title contains the last two cwd components joined by "/"
-    ///       (disambiguates common basenames like "src" or "170")
-    ///   1 — title contains just the cwd basename
-    ///   0 — no match
+    /// - Tier A (score 1000): title contains the full absolute cwd — common
+    ///   for terminal tab titles, and the only signal that should beat an
+    ///   ancestor match regardless of depth.
+    /// - Tier B (score = depth index + 1): deepest path segment of cwd that
+    ///   appears in the title wins. This handles VS Code, whose window title
+    ///   shows only the *workspace folder* name (e.g. `"2.1.114 — irrlicht"`)
+    ///   even when the Claude Code session's cwd is a subdirectory several
+    ///   levels below (`.../irrlicht/.claude/worktrees/170`). The deeper the
+    ///   matching ancestor, the more specific the signal.
+    ///
+    /// Generic top segments (`Users`, user home basename, `tmp`, etc.) are
+    /// skipped because they occur in nearly every string and would cause
+    /// false matches.
     static func titleMatchScore(title: String, cwd: String) -> Int {
         if title.isEmpty || cwd.isEmpty { return 0 }
-        if title.contains(cwd) { return 3 }
+        if title.contains(cwd) { return 1_000 }
+
         let trimmed = cwd.hasSuffix("/") ? String(cwd.dropLast()) : cwd
         let parts = trimmed.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
-        if parts.count >= 2 {
-            let lastTwo = parts.suffix(2).joined(separator: "/")
-            if title.contains(lastTwo) { return 2 }
-        }
-        if let base = parts.last, !base.isEmpty, title.contains(base) {
-            return 1
+
+        let homeBasename = (ProcessInfo.processInfo.environment["HOME"] ?? "")
+            .split(separator: "/").last.map(String.init) ?? ""
+
+        for i in (0..<parts.count).reversed() {
+            let p = parts[i]
+            if p.isEmpty { continue }
+            if genericTopSegments.contains(p) { continue }
+            if !homeBasename.isEmpty && p == homeBasename { continue }
+            if title.contains(p) { return i + 1 }
         }
         return 0
     }

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -9,14 +9,15 @@ import OSLog
 ///
 /// Dispatch:
 ///   1. `NSWorkspace.openApplication` — activate the host app.
-///   2. iTerm2 only: AppleScript `select` by session UUID — works across
-///      screens/spaces and uses a stable ID, not title guesswork.
-///   3. Everything else: Accessibility API, raise the window whose title's
+///   2. iTerm2: AppleScript `select` by session UUID.
+///   3. Terminal.app: AppleScript select the tab whose `tty` matches
+///      the captured controlling TTY of the agent process.
+///   4. Everything else: Accessibility API, raise the window whose title's
 ///      deepest matching ancestor segment of cwd wins. Silently no-ops if
 ///      AX permission isn't granted.
 ///
-/// It works (right window) or it degrades to app activation (right app, last
-/// used window). No Finder-reveal, no URL schemes that would clobber a
+/// It works (right window/tab) or it degrades to app activation (right app,
+/// last used window). No Finder-reveal, no URL schemes that would clobber a
 /// worktree's existing editor window.
 enum SessionLauncher {
     private static let logger = Logger(subsystem: "io.irrlicht.app", category: "SessionLauncher")
@@ -61,6 +62,12 @@ enum SessionLauncher {
             if launcher?.termProgram == "iTerm.app",
                let uuid = iTermUUID(from: launcher?.itermSessionID),
                selectITermSession(uuid: uuid) {
+                return
+            }
+            // Terminal.app: select the tab whose tty matches the session's.
+            if launcher?.termProgram == "Apple_Terminal",
+               let tty = launcher?.tty, !tty.isEmpty,
+               selectTerminalTab(tty: tty) {
                 return
             }
             // Everything else: AX + cwd-ancestor title match.
@@ -117,6 +124,50 @@ enum SessionLauncher {
         let matched = descriptor.stringValue == "1"
         if !matched {
             logger.info("iTerm AppleScript: no session matched uuid \(uuid, privacy: .public)")
+        }
+        return matched
+    }
+
+    // MARK: - Terminal.app AppleScript
+
+    /// Selects the Terminal.app tab whose `tty` property matches the given
+    /// device path (e.g. `/dev/ttys021`). Returns true on a match, false on
+    /// AppleScript error (permission denied) or no-match (tab closed).
+    ///
+    /// Terminal.app's dictionary has no session UUID on tabs, but it does
+    /// expose `tty` — and every process in a tab shares the same controlling
+    /// TTY, so this is a stable selector for as long as the tab lives.
+    /// Deliberately uses `select` and `set index` only — no `do script`,
+    /// which would type into the user's live shell.
+    private static func selectTerminalTab(tty: String) -> Bool {
+        let safe = tty
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let source = """
+        tell application "Terminal"
+            activate
+            repeat with w in windows
+                repeat with t in tabs of w
+                    if tty of t is "\(safe)" then
+                        set selected of t to true
+                        set index of w to 1
+                        return "1"
+                    end if
+                end repeat
+            end repeat
+            return "0"
+        end tell
+        """
+        var err: NSDictionary?
+        guard let script = NSAppleScript(source: source) else { return false }
+        let descriptor = script.executeAndReturnError(&err)
+        if let err {
+            logger.error("Terminal AppleScript failed: \(err, privacy: .public)")
+            return false
+        }
+        let matched = descriptor.stringValue == "1"
+        if !matched {
+            logger.info("Terminal AppleScript: no tab matched tty \(tty, privacy: .public)")
         }
         return matched
     }

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -1,0 +1,224 @@
+import AppKit
+import Foundation
+import OSLog
+
+/// SessionLauncher brings the originating terminal or IDE for a session back
+/// to the foreground. Used by the session-row tap gesture and the notification
+/// click handler.
+///
+/// Dispatch order, most-specific first:
+///   1. iTerm2 session by $ITERM_SESSION_ID (AppleScript, with match detection)
+///   2. VS Code / Cursor / Windsurf → their file URL scheme against cwd
+///   3. tmux switch-client by socket + pane, then fall through to host terminal
+///   4. NSWorkspace activate by bundle ID derived from termProgram (covers Terminal.app,
+///      Ghostty, Warp, WezTerm, Hyper, and iTerm2 when tier 1 found no match)
+///   5. Finder-reveal of session.cwd (final fallback)
+///
+/// Each tier logs and falls through on failure — permission denials from
+/// AppleScript must never crash the UI.
+enum SessionLauncher {
+    private static let logger = Logger(subsystem: "io.irrlicht.app", category: "SessionLauncher")
+
+    /// Maps $TERM_PROGRAM values to macOS bundle identifiers for the fallback
+    /// NSWorkspace activation tier. tmux is intentionally absent — a tmux
+    /// passthrough has no host terminal we can activate by itself.
+    private static let bundleIDByTermProgram: [String: String] = [
+        "iTerm.app":      "com.googlecode.iterm2",
+        "Apple_Terminal": "com.apple.Terminal",
+        "vscode":         "com.microsoft.VSCode",
+        "cursor":         "com.todesktop.230313mzl4w4u92",
+        "windsurf":       "com.exafunction.windsurf",
+        "ghostty":        "com.mitchellh.ghostty",
+        "WezTerm":        "com.github.wez.wezterm",
+        "Hyper":          "co.zeit.hyper",
+        "Warp":           "dev.warp.Warp-Stable",
+    ]
+
+    /// Derives the macOS bundle ID for a $TERM_PROGRAM value, or nil when we
+    /// don't know one. Kept client-side so the daemon's domain model stays
+    /// platform-neutral.
+    static func bundleID(for termProgram: String?) -> String? {
+        guard let termProgram else { return nil }
+        return bundleIDByTermProgram[termProgram]
+    }
+
+    /// Brings the session's originating terminal/IDE to the foreground.
+    /// Safe to call on the main thread; AppleScript work is dispatched to a
+    /// background queue internally.
+    static func jump(_ session: SessionState) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            dispatch(session)
+        }
+    }
+
+    private static func dispatch(_ session: SessionState) {
+        let launcher = session.launcher
+
+        // 1. iTerm2 — precise per-session targeting.
+        if launcher?.termProgram == "iTerm.app",
+           let sid = launcher?.itermSessionID, !sid.isEmpty {
+            if runAppleScriptMatching(iterm2SelectScript(sessionID: sid)) {
+                return
+            }
+            // No matching session (window closed, session rotated): fall
+            // through to tier 4 and just bring iTerm2 frontmost.
+        }
+
+        // 2. VS Code / Cursor / Windsurf — open the folder in the editor.
+        if let scheme = editorURLScheme(for: launcher?.termProgram),
+           !session.cwd.isEmpty,
+           let url = editorFolderURL(scheme: scheme, cwd: session.cwd),
+           openURL(url) {
+            return
+        }
+
+        // 3. tmux — switch-client then fall through to the host terminal.
+        if let pane = launcher?.tmuxPane, !pane.isEmpty {
+            runTmuxSwitch(socket: launcher?.tmuxSocket, pane: pane)
+            // Intentional fall-through: bring the host terminal frontmost.
+        }
+
+        // 4. NSWorkspace activate by bundle ID. Covers Terminal.app (we don't
+        //    target individual tabs — Terminal.app AppleScript has no way to
+        //    read a tab's env, and `do script` would type commands into real
+        //    tabs), Ghostty, Warp, WezTerm, Hyper, and iTerm2 fallback.
+        if let bundleID = bundleID(for: launcher?.termProgram) {
+            activateApp(bundleID: bundleID)
+            return
+        }
+
+        // 5. Final fallback: Finder-reveal the working directory.
+        if !session.cwd.isEmpty {
+            let url = URL(fileURLWithPath: session.cwd, isDirectory: true)
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+            return
+        }
+
+        logger.info("SessionLauncher: no target for session \(session.id, privacy: .public)")
+    }
+
+    // MARK: - Pure helpers (testable)
+
+    /// Returns the editor URL scheme for a $TERM_PROGRAM value that Irrlicht
+    /// supports directly, or nil when the program isn't a folder-opening editor.
+    static func editorURLScheme(for termProgram: String?) -> String? {
+        switch termProgram {
+        case "vscode":   return "vscode"
+        case "cursor":   return "cursor"
+        case "windsurf": return "windsurf"
+        default:         return nil
+        }
+    }
+
+    /// Builds `<scheme>://file<cwd>` using URLComponents so the path segment is
+    /// correctly percent-encoded. Returns nil when the components don't form a
+    /// valid URL (e.g. non-absolute cwd).
+    static func editorFolderURL(scheme: String, cwd: String) -> URL? {
+        var comps = URLComponents()
+        comps.scheme = scheme
+        comps.host = "file"
+        comps.path = cwd
+        return comps.url
+    }
+
+    /// Escapes a string for safe interpolation into an AppleScript double-
+    /// quoted literal. Backslashes must be escaped before quotes, otherwise
+    /// the quote's own escape gets re-escaped and the literal breaks.
+    static func appleScriptEscape(_ s: String) -> String {
+        return s
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    // MARK: - Scripts
+
+    static func iterm2SelectScript(sessionID: String) -> String {
+        // Returns "1" if a session with the given unique id was found and
+        // selected, "0" otherwise — so the Swift caller can fall through to
+        // a bundle-ID activate when the originating session is gone.
+        let safe = appleScriptEscape(sessionID)
+        return """
+        tell application "iTerm"
+            activate
+            repeat with w in windows
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        if (unique id of s) is "\(safe)" then
+                            select w
+                            tell t to select
+                            tell s to select
+                            return "1"
+                        end if
+                    end repeat
+                end repeat
+            end repeat
+            return "0"
+        end tell
+        """
+    }
+
+    // MARK: - AppleScript execution
+
+    /// Runs an AppleScript expected to return `"1"` on match / `"0"` on
+    /// no-match. Returns true only when the script executed successfully AND
+    /// returned "1". A raised AppleScript error (e.g. automation permission
+    /// denied) returns false so callers can fall through to other tiers.
+    private static func runAppleScriptMatching(_ source: String) -> Bool {
+        var error: NSDictionary?
+        guard let script = NSAppleScript(source: source) else { return false }
+        let descriptor = script.executeAndReturnError(&error)
+        if let error {
+            logger.error("SessionLauncher AppleScript failed: \(error, privacy: .public)")
+            return false
+        }
+        return descriptor.stringValue == "1"
+    }
+
+    // MARK: - tmux
+
+    private static func runTmuxSwitch(socket: String?, pane: String) {
+        let task = Process()
+        task.launchPath = "/usr/bin/env"
+        var args = ["tmux"]
+        if let s = socket, !s.isEmpty {
+            args += ["-S", s]
+        }
+        args += ["switch-client", "-t", pane]
+        task.arguments = args
+        do {
+            try task.run()
+            task.waitUntilExit()
+        } catch {
+            logger.error("SessionLauncher: tmux switch-client failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - URL + bundle activation
+
+    private static func openURL(_ url: URL) -> Bool {
+        let opened = NSWorkspace.shared.open(url)
+        if !opened {
+            logger.error("SessionLauncher: NSWorkspace.open failed for \(url.absoluteString, privacy: .public)")
+        }
+        return opened
+    }
+
+    /// Brings the app identified by bundleID to the front. Async under the
+    /// hood; we never block waiting for the open. Errors are logged, never
+    /// propagated — the caller has already committed to this as the chosen
+    /// tier and there is no useful fallback for a missing-app case beyond
+    /// the UI's own error surfacing (which we don't have).
+    private static func activateApp(bundleID: String) {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
+            logger.info("SessionLauncher: no installed app for bundle id \(bundleID, privacy: .public)")
+            return
+        }
+        let config = NSWorkspace.OpenConfiguration()
+        config.activates = true
+        NSWorkspace.shared.openApplication(at: url, configuration: config) { _, error in
+            if let error {
+                logger.error("SessionLauncher: openApplication failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+}

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -44,12 +44,39 @@ enum SessionLauncher {
             logger.info("no launcher for session \(session.id, privacy: .public)")
             return
         }
+        let launcher = session.launcher
+        let cwd = session.cwd
+
+        // iTerm2 / Terminal.app: AppleScript handles activation AND window
+        // selection in a single event. Running NSWorkspace.openApplication
+        // *and* AppleScript's `activate` creates a race — on a cold click
+        // the openApplication activation is still in flight when the script
+        // reorders windows, so the wrong window comes forward and the user
+        // has to click again. Let the AppleScript own it.
+        //
+        // Dispatch off the main thread so NSAppleScript doesn't block the
+        // UI; the script itself is synchronous and takes tens of ms.
+        if launcher?.termProgram == "iTerm.app",
+           let uuid = iTermUUID(from: launcher?.itermSessionID) {
+            DispatchQueue.global(qos: .userInitiated).async {
+                _ = selectITermSession(uuid: uuid)
+            }
+            return
+        }
+        if launcher?.termProgram == "Apple_Terminal",
+           let tty = launcher?.tty, !tty.isEmpty {
+            DispatchQueue.global(qos: .userInitiated).async {
+                _ = selectTerminalTab(tty: tty)
+            }
+            return
+        }
+
+        // Everything else: activate app via LaunchServices, then raise the
+        // matching window via AX.
         guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
             logger.info("no installed app for bundle id \(bundleID, privacy: .public)")
             return
         }
-        let launcher = session.launcher
-        let cwd = session.cwd
         let config = NSWorkspace.OpenConfiguration()
         config.activates = true
         NSWorkspace.shared.openApplication(at: url, configuration: config) { _, error in
@@ -57,20 +84,6 @@ enum SessionLauncher {
                 logger.error("openApplication failed: \(error.localizedDescription, privacy: .public)")
                 return
             }
-            // iTerm2 fast path: select the exact session by UUID — only
-            // reliable cross-space/screen target we have for iTerm.
-            if launcher?.termProgram == "iTerm.app",
-               let uuid = iTermUUID(from: launcher?.itermSessionID),
-               selectITermSession(uuid: uuid) {
-                return
-            }
-            // Terminal.app: select the tab whose tty matches the session's.
-            if launcher?.termProgram == "Apple_Terminal",
-               let tty = launcher?.tty, !tty.isEmpty,
-               selectTerminalTab(tty: tty) {
-                return
-            }
-            // Everything else: AX + cwd-ancestor title match.
             if !cwd.isEmpty {
                 raiseMatchingWindow(bundleID: bundleID, cwd: cwd)
             }
@@ -143,18 +156,23 @@ enum SessionLauncher {
         let safe = tty
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
+        // `activate` LAST, after the window is already at index 1 and the
+        // tab is selected — if we activate first, Terminal races to the
+        // foreground while we're still reordering, and the previously
+        // frontmost window shows through until the next click.
         let source = """
         tell application "Terminal"
-            activate
             repeat with w in windows
                 repeat with t in tabs of w
                     if tty of t is "\(safe)" then
-                        set selected of t to true
+                        set selected tab of w to t
                         set index of w to 1
+                        activate
                         return "1"
                     end if
                 end repeat
             end repeat
+            activate
             return "0"
         end tell
         """

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -1,288 +1,55 @@
-import AppKit
-import ApplicationServices
 import Foundation
 import OSLog
 
 /// Brings the originating terminal or IDE window for a session to the
-/// foreground. Used by the session-row tap gesture and the notification
-/// click handler.
+/// foreground. Entry point for the session-row tap gesture
+/// (`SessionListView`) and the notification click handler
+/// (`SessionManager`).
 ///
-/// Dispatch:
-///   1. `NSWorkspace.openApplication` — activate the host app.
-///   2. iTerm2: AppleScript `select` by session UUID.
-///   3. Terminal.app: AppleScript select the tab whose `tty` matches
-///      the captured controlling TTY of the agent process.
-///   4. Everything else: Accessibility API, raise the window whose title's
-///      deepest matching ancestor segment of cwd wins. Silently no-ops if
-///      AX permission isn't granted.
+/// Dispatch is a simple registry lookup: pick the `HostActivator` whose
+/// `termProgram` matches `session.launcher?.termProgram` and hand off.
+/// Adding a new host = one line in `activators` (plus a new activator
+/// file if it needs a strategy beyond `AXTitleMatchActivator`).
 ///
-/// It works (right window/tab) or it degrades to app activation (right app,
-/// last used window). No Finder-reveal, no URL schemes that would clobber a
-/// worktree's existing editor window.
+/// The activators themselves implement the actual AppleScript / AX
+/// targeting logic — see `Managers/Launcher/Activators/`.
 enum SessionLauncher {
     private static let logger = Logger(subsystem: "io.irrlicht.app", category: "SessionLauncher")
 
-    private static let bundleIDByTermProgram: [String: String] = [
-        "iTerm.app":      "com.googlecode.iterm2",
-        "Apple_Terminal": "com.apple.Terminal",
-        "vscode":         "com.microsoft.VSCode",
-        "cursor":         "com.todesktop.230313mzl4w4u92",
-        "windsurf":       "com.exafunction.windsurf",
-        "ghostty":        "com.mitchellh.ghostty",
-        "WezTerm":        "com.github.wez.wezterm",
-        "Hyper":          "co.zeit.hyper",
-        "Warp":           "dev.warp.Warp-Stable",
+    /// Registry of supported hosts. Order is irrelevant — lookup is by
+    /// `termProgram` equality, not first-match iteration.
+    private static let activators: [HostActivator] = [
+        ITermActivator(),
+        TerminalAppActivator(),
+        AXTitleMatchActivator(termProgram: "vscode",   bundleID: "com.microsoft.VSCode"),
+        AXTitleMatchActivator(termProgram: "cursor",   bundleID: "com.todesktop.230313mzl4w4u92"),
+        AXTitleMatchActivator(termProgram: "windsurf", bundleID: "com.exafunction.windsurf"),
+        AXTitleMatchActivator(termProgram: "ghostty",  bundleID: "com.mitchellh.ghostty"),
+        AXTitleMatchActivator(termProgram: "WezTerm",  bundleID: "com.github.wez.wezterm"),
+        AXTitleMatchActivator(termProgram: "Hyper",    bundleID: "co.zeit.hyper"),
+        AXTitleMatchActivator(termProgram: "Warp",     bundleID: "dev.warp.Warp-Stable"),
     ]
 
-    static func bundleID(for termProgram: String?) -> String? {
-        guard let termProgram else { return nil }
-        return bundleIDByTermProgram[termProgram]
-    }
-
+    /// Brings the session's originating terminal/IDE window to the front.
+    /// Safe to call on the main thread — activators dispatch any blocking
+    /// work themselves.
     static func jump(_ session: SessionState) {
-        guard let bundleID = bundleID(for: session.launcher?.termProgram) else {
+        guard let tp = session.launcher?.termProgram else {
             logger.info("no launcher for session \(session.id, privacy: .public)")
             return
         }
-        let launcher = session.launcher
-        let cwd = session.cwd
-
-        // iTerm2 / Terminal.app: AppleScript handles activation AND window
-        // selection in a single event. Running NSWorkspace.openApplication
-        // *and* AppleScript's `activate` creates a race — on a cold click
-        // the openApplication activation is still in flight when the script
-        // reorders windows, so the wrong window comes forward and the user
-        // has to click again. Let the AppleScript own it.
-        //
-        // Dispatch off the main thread so NSAppleScript doesn't block the
-        // UI; the script itself is synchronous and takes tens of ms.
-        if launcher?.termProgram == "iTerm.app",
-           let uuid = iTermUUID(from: launcher?.itermSessionID) {
-            DispatchQueue.global(qos: .userInitiated).async {
-                _ = selectITermSession(uuid: uuid)
-            }
+        guard let activator = activators.first(where: { $0.termProgram == tp }) else {
+            logger.info("no activator for term program \(tp, privacy: .public)")
             return
         }
-        if launcher?.termProgram == "Apple_Terminal",
-           let tty = launcher?.tty, !tty.isEmpty {
-            DispatchQueue.global(qos: .userInitiated).async {
-                _ = selectTerminalTab(tty: tty)
-            }
-            return
-        }
-
-        // Everything else: activate app via LaunchServices, then raise the
-        // matching window via AX.
-        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleID) else {
-            logger.info("no installed app for bundle id \(bundleID, privacy: .public)")
-            return
-        }
-        let config = NSWorkspace.OpenConfiguration()
-        config.activates = true
-        NSWorkspace.shared.openApplication(at: url, configuration: config) { _, error in
-            if let error {
-                logger.error("openApplication failed: \(error.localizedDescription, privacy: .public)")
-                return
-            }
-            if !cwd.isEmpty {
-                raiseMatchingWindow(bundleID: bundleID, cwd: cwd)
-            }
-        }
+        _ = activator.activate(session)
     }
 
-    // MARK: - iTerm2 AppleScript
-
-    /// Extracts the UUID portion from an `$ITERM_SESSION_ID` value. Accepts
-    /// both legacy `w0t0p0:UUID` and current `w0:t0:p0:UUID` formats by
-    /// taking the substring after the *last* colon.
-    static func iTermUUID(from sessionID: String?) -> String? {
-        guard let sid = sessionID, !sid.isEmpty else { return nil }
-        guard let r = sid.range(of: ":", options: .backwards) else { return sid }
-        let tail = String(sid[r.upperBound...])
-        return tail.isEmpty ? nil : tail
-    }
-
-    /// Runs iTerm2 AppleScript to `select` the session with the given
-    /// `unique id`. Returns true on a real match, false on AppleScript
-    /// error (permission denied) or no-match (window/session closed).
-    private static func selectITermSession(uuid: String) -> Bool {
-        let safe = uuid
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-        let source = """
-        tell application "iTerm"
-            activate
-            repeat with w in windows
-                repeat with t in tabs of w
-                    repeat with s in sessions of t
-                        if (unique id of s) is "\(safe)" then
-                            select w
-                            tell t to select
-                            tell s to select
-                            return "1"
-                        end if
-                    end repeat
-                end repeat
-            end repeat
-            return "0"
-        end tell
-        """
-        var err: NSDictionary?
-        guard let script = NSAppleScript(source: source) else { return false }
-        let descriptor = script.executeAndReturnError(&err)
-        if let err {
-            logger.error("iTerm AppleScript failed: \(err, privacy: .public)")
-            return false
-        }
-        let matched = descriptor.stringValue == "1"
-        if !matched {
-            logger.info("iTerm AppleScript: no session matched uuid \(uuid, privacy: .public)")
-        }
-        return matched
-    }
-
-    // MARK: - Terminal.app AppleScript
-
-    /// Selects the Terminal.app tab whose `tty` property matches the given
-    /// device path (e.g. `/dev/ttys021`). Returns true on a match, false on
-    /// AppleScript error (permission denied) or no-match (tab closed).
-    ///
-    /// Terminal.app's dictionary has no session UUID on tabs, but it does
-    /// expose `tty` — and every process in a tab shares the same controlling
-    /// TTY, so this is a stable selector for as long as the tab lives.
-    /// Deliberately uses `select` and `set index` only — no `do script`,
-    /// which would type into the user's live shell.
-    private static func selectTerminalTab(tty: String) -> Bool {
-        let safe = tty
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-        // `activate` LAST, after the window is already at index 1 and the
-        // tab is selected — if we activate first, Terminal races to the
-        // foreground while we're still reordering, and the previously
-        // frontmost window shows through until the next click.
-        let source = """
-        tell application "Terminal"
-            repeat with w in windows
-                repeat with t in tabs of w
-                    if tty of t is "\(safe)" then
-                        set selected tab of w to t
-                        set index of w to 1
-                        activate
-                        return "1"
-                    end if
-                end repeat
-            end repeat
-            activate
-            return "0"
-        end tell
-        """
-        var err: NSDictionary?
-        guard let script = NSAppleScript(source: source) else { return false }
-        let descriptor = script.executeAndReturnError(&err)
-        if let err {
-            logger.error("Terminal AppleScript failed: \(err, privacy: .public)")
-            return false
-        }
-        let matched = descriptor.stringValue == "1"
-        if !matched {
-            logger.info("Terminal AppleScript: no tab matched tty \(tty, privacy: .public)")
-        }
-        return matched
-    }
-
-    // MARK: - AX window selection
-
-    private static func raiseMatchingWindow(bundleID: String, cwd: String) {
-        guard ensureAXTrust() else {
-            logger.info("AX permission not granted — staying on app-level activation")
-            return
-        }
-        let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
-        guard let app = runningApps.first else { return }
-        let axApp = AXUIElementCreateApplication(app.processIdentifier)
-
-        var windowsRef: CFTypeRef?
-        let status = AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef)
-        guard status == .success, let windows = windowsRef as? [AXUIElement] else { return }
-
-        let titles = windows.map { windowTitle($0) }
-        guard let idx = bestMatchIndex(titles: titles, cwd: cwd) else {
-            logger.info("no window title matched cwd \(cwd, privacy: .public); candidates=\(titles, privacy: .public)")
-            return
-        }
-        let target = windows[idx]
-        AXUIElementPerformAction(target, kAXRaiseAction as CFString)
-        AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
-    }
-
-    private static func windowTitle(_ window: AXUIElement) -> String {
-        var titleRef: CFTypeRef?
-        AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef)
-        return (titleRef as? String) ?? ""
-    }
-
-    private static func ensureAXTrust() -> Bool {
-        let key = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
-        let opts = [key: true] as CFDictionary
-        return AXIsProcessTrustedWithOptions(opts)
-    }
-
-    // MARK: - Title match (pure, testable)
-
-    /// Generic root-level path segments that must never serve as a match
-    /// signal — they appear in virtually every home-directory path string.
-    private static let genericTopSegments: Set<String> = [
-        "Users", "home", "tmp", "var", "private", "opt", "mnt", "root"
-    ]
-
-    /// Scores a window title against a cwd. Higher score = better match.
-    /// Returns 0 when the title shares no meaningful path segment with cwd.
-    ///
-    /// - Tier A (score 1000): title contains the full absolute cwd — common
-    ///   for terminal tab titles, and the only signal that should beat an
-    ///   ancestor match regardless of depth.
-    /// - Tier B (score = depth index + 1): deepest path segment of cwd that
-    ///   appears in the title wins. This handles VS Code, whose window title
-    ///   shows only the *workspace folder* name (e.g. `"2.1.114 — irrlicht"`)
-    ///   even when the Claude Code session's cwd is a subdirectory several
-    ///   levels below (`.../irrlicht/.claude/worktrees/170`). The deeper the
-    ///   matching ancestor, the more specific the signal.
-    ///
-    /// Generic top segments (`Users`, user home basename, `tmp`, etc.) are
-    /// skipped because they occur in nearly every string and would cause
-    /// false matches.
-    static func titleMatchScore(title: String, cwd: String) -> Int {
-        if title.isEmpty || cwd.isEmpty { return 0 }
-        if title.contains(cwd) { return 1_000 }
-
-        let trimmed = cwd.hasSuffix("/") ? String(cwd.dropLast()) : cwd
-        let parts = trimmed.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
-
-        let homeBasename = (ProcessInfo.processInfo.environment["HOME"] ?? "")
-            .split(separator: "/").last.map(String.init) ?? ""
-
-        for i in (0..<parts.count).reversed() {
-            let p = parts[i]
-            if p.isEmpty { continue }
-            if genericTopSegments.contains(p) { continue }
-            if !homeBasename.isEmpty && p == homeBasename { continue }
-            if title.contains(p) { return i + 1 }
-        }
-        return 0
-    }
-
-    /// Index of the highest-scoring title, or nil when all scores are 0.
-    /// Ties break by first occurrence (AX returns windows in z-order; the
-    /// topmost matching window wins).
-    static func bestMatchIndex(titles: [String], cwd: String) -> Int? {
-        var best: (idx: Int, score: Int)?
-        for (i, t) in titles.enumerated() {
-            let s = titleMatchScore(title: t, cwd: cwd)
-            if s == 0 { continue }
-            if best == nil || s > best!.score {
-                best = (i, s)
-            }
-        }
-        return best?.idx
+    /// Returns the macOS bundle ID for a `$TERM_PROGRAM` value, or nil
+    /// when none is registered. Thin wrapper over the activator registry
+    /// — primarily kept for tests that verify the host map.
+    static func bundleID(for termProgram: String?) -> String? {
+        guard let tp = termProgram else { return nil }
+        return activators.first { $0.termProgram == tp }?.bundleID
     }
 }

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -7,14 +7,17 @@ import OSLog
 /// foreground. Used by the session-row tap gesture and the notification
 /// click handler.
 ///
-/// Two-step dispatch:
-///   1. `NSWorkspace.openApplication` — activate the host app (no permission).
-///   2. Accessibility API — raise the specific window whose title matches
-///      the session's cwd. Silently no-ops if AX permission isn't granted.
+/// Dispatch:
+///   1. `NSWorkspace.openApplication` — activate the host app.
+///   2. iTerm2 only: AppleScript `select` by session UUID — works across
+///      screens/spaces and uses a stable ID, not title guesswork.
+///   3. Everything else: Accessibility API, raise the window whose title's
+///      deepest matching ancestor segment of cwd wins. Silently no-ops if
+///      AX permission isn't granted.
 ///
 /// It works (right window) or it degrades to app activation (right app, last
-/// used window). No Finder-reveal, no URL schemes that would open a new
-/// editor window and clobber the worktree's existing window.
+/// used window). No Finder-reveal, no URL schemes that would clobber a
+/// worktree's existing editor window.
 enum SessionLauncher {
     private static let logger = Logger(subsystem: "io.irrlicht.app", category: "SessionLauncher")
 
@@ -44,6 +47,7 @@ enum SessionLauncher {
             logger.info("no installed app for bundle id \(bundleID, privacy: .public)")
             return
         }
+        let launcher = session.launcher
         let cwd = session.cwd
         let config = NSWorkspace.OpenConfiguration()
         config.activates = true
@@ -52,10 +56,69 @@ enum SessionLauncher {
                 logger.error("openApplication failed: \(error.localizedDescription, privacy: .public)")
                 return
             }
+            // iTerm2 fast path: select the exact session by UUID — only
+            // reliable cross-space/screen target we have for iTerm.
+            if launcher?.termProgram == "iTerm.app",
+               let uuid = iTermUUID(from: launcher?.itermSessionID),
+               selectITermSession(uuid: uuid) {
+                return
+            }
+            // Everything else: AX + cwd-ancestor title match.
             if !cwd.isEmpty {
                 raiseMatchingWindow(bundleID: bundleID, cwd: cwd)
             }
         }
+    }
+
+    // MARK: - iTerm2 AppleScript
+
+    /// Extracts the UUID portion from an `$ITERM_SESSION_ID` value. Accepts
+    /// both legacy `w0t0p0:UUID` and current `w0:t0:p0:UUID` formats by
+    /// taking the substring after the *last* colon.
+    static func iTermUUID(from sessionID: String?) -> String? {
+        guard let sid = sessionID, !sid.isEmpty else { return nil }
+        guard let r = sid.range(of: ":", options: .backwards) else { return sid }
+        let tail = String(sid[r.upperBound...])
+        return tail.isEmpty ? nil : tail
+    }
+
+    /// Runs iTerm2 AppleScript to `select` the session with the given
+    /// `unique id`. Returns true on a real match, false on AppleScript
+    /// error (permission denied) or no-match (window/session closed).
+    private static func selectITermSession(uuid: String) -> Bool {
+        let safe = uuid
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let source = """
+        tell application "iTerm"
+            activate
+            repeat with w in windows
+                repeat with t in tabs of w
+                    repeat with s in sessions of t
+                        if (unique id of s) is "\(safe)" then
+                            select w
+                            tell t to select
+                            tell s to select
+                            return "1"
+                        end if
+                    end repeat
+                end repeat
+            end repeat
+            return "0"
+        end tell
+        """
+        var err: NSDictionary?
+        guard let script = NSAppleScript(source: source) else { return false }
+        let descriptor = script.executeAndReturnError(&err)
+        if let err {
+            logger.error("iTerm AppleScript failed: \(err, privacy: .public)")
+            return false
+        }
+        let matched = descriptor.stringValue == "1"
+        if !matched {
+            logger.info("iTerm AppleScript: no session matched uuid \(uuid, privacy: .public)")
+        }
+        return matched
     }
 
     // MARK: - AX window selection

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -63,6 +63,12 @@ class SessionManager: ObservableObject {
     /// Tracks whether any group has type == "gastown" from the last hydration.
     private var hasGasTownGroups = false
 
+    /// Forwards notification-tap events back to the manager so clicked
+    /// notifications can bring the originating terminal/IDE to the front.
+    /// Held strongly so UNUserNotificationCenter's weak delegate reference
+    /// stays alive.
+    private var notificationForwarder: NotificationClickForwarder?
+
     // MARK: - Mode selection
 
     private var useFilePolling: Bool {
@@ -567,6 +573,16 @@ class SessionManager: ObservableObject {
             return
         }
         let center = UNUserNotificationCenter.current()
+
+        // Register the click-forwarder delegate before the first notification
+        // is scheduled, otherwise macOS drops notification taps silently.
+        if notificationForwarder == nil {
+            let forwarder = NotificationClickForwarder { [weak self] sessionID in
+                self?.handleNotificationTap(sessionID: sessionID)
+            }
+            notificationForwarder = forwarder
+            center.delegate = forwarder
+        }
         center.getNotificationSettings { settings in
             switch settings.authorizationStatus {
             case .notDetermined:
@@ -649,7 +665,8 @@ class SessionManager: ObservableObject {
         sendNotification(
             identifier: "irrlicht-context-\(session.id)-\(threshold)",
             title: "Context pressure: \(threshold)% threshold reached",
-            body: "\(label) is at \(String(format: "%.1f%%", utilization)) context. Consider switching to a fresh session."
+            body: "\(label) is at \(String(format: "%.1f%%", utilization)) context. Consider switching to a fresh session.",
+            sessionID: session.id
         )
     }
 
@@ -678,16 +695,20 @@ class SessionManager: ObservableObject {
         sendNotification(
             identifier: "irrlicht-state-\(session.id)",
             title: title,
-            body: "\(label)\(branch)"
+            body: "\(label)\(branch)",
+            sessionID: session.id
         )
     }
 
-    private func sendNotification(identifier: String, title: String, body: String) {
+    private func sendNotification(identifier: String, title: String, body: String, sessionID: String) {
         guard canUseUserNotifications else { return }
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
         content.sound = .default
+        // Round-trip the session ID so the click-forwarder can look up
+        // the session and jump back to its launching terminal/IDE.
+        content.userInfo = [NotificationUserInfoKey.sessionID: sessionID]
 
         let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(request) { error in
@@ -695,6 +716,14 @@ class SessionManager: ObservableObject {
                 print("⚠️ Failed to send notification: \(error.localizedDescription)")
             }
         }
+    }
+
+    /// Invoked by `NotificationClickForwarder` on the main actor when the user
+    /// taps a notification. Silently no-ops for unknown IDs (e.g. a stale
+    /// notification for a session that's since been deleted).
+    fileprivate func handleNotificationTap(sessionID: String) {
+        guard let session = sessionMap[sessionID] else { return }
+        SessionLauncher.jump(session)
     }
 
     // MARK: - Session Order Management
@@ -1019,4 +1048,45 @@ private struct DebugState: Codable {
 private struct SessionOrderData: Codable {
     let version: Int
     let order: [String]
+}
+
+/// Keys used in UNNotificationContent.userInfo so notification click-handlers
+/// can identify the originating session.
+enum NotificationUserInfoKey {
+    static let sessionID = "sessionID"
+}
+
+/// NSObject-based forwarder that receives `UNUserNotificationCenterDelegate`
+/// callbacks and hands them off to a closure on the main actor. Used instead
+/// of making `SessionManager` itself inherit from NSObject.
+final class NotificationClickForwarder: NSObject, UNUserNotificationCenterDelegate {
+    private let onTap: @MainActor (String) -> Void
+
+    init(onTap: @escaping @MainActor (String) -> Void) {
+        self.onTap = onTap
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let sessionID = response.notification.request.content.userInfo[NotificationUserInfoKey.sessionID] as? String
+        if let sessionID {
+            Task { @MainActor in
+                onTap(sessionID)
+            }
+        }
+        completionHandler()
+    }
+
+    // Show banners for notifications delivered while the app is foregrounded
+    // — without this, in-app notifications are silently suppressed on macOS.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
 }

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -146,6 +146,27 @@ struct SubagentSummary: Codable {
     let ready: Int
 }
 
+/// Launcher identifies the terminal or IDE that spawned the session's agent.
+/// Captured by the daemon when the PID is first assigned. All fields optional —
+/// clients must fall back to the session CWD when nothing identifies the host.
+struct Launcher: Codable, Hashable {
+    let termProgram: String?
+    let itermSessionID: String?
+    let termSessionID: String?
+    let tmuxPane: String?
+    let tmuxSocket: String?
+    let vscodePID: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case termProgram    = "term_program"
+        case itermSessionID = "iterm_session_id"
+        case termSessionID  = "term_session_id"
+        case tmuxPane       = "tmux_pane"
+        case tmuxSocket     = "tmux_socket"
+        case vscodePID      = "vscode_pid"
+    }
+}
+
 struct SessionState: Identifiable, Codable {
     let id: String              // session_id
     let state: State            // working, waiting, ready
@@ -170,6 +191,7 @@ struct SessionState: Identifiable, Codable {
     var workerName: String?     // orchestrator worker name
     var workerID: String?       // orchestrator worker/bead ID
     let children: [SessionState]? // nested child sessions from API (optional)
+    let launcher: Launcher?     // terminal/IDE that spawned this session (optional)
 
     // For duplicate handling (not stored in JSON, computed by SessionManager)
     var duplicateIndex: Int? = nil
@@ -198,6 +220,7 @@ struct SessionState: Identifiable, Codable {
         case workerName = "worker_name"
         case workerID = "worker_id"
         case children
+        case launcher
     }
     
     // Custom decoder to handle multiple date formats and missing fields
@@ -231,6 +254,7 @@ struct SessionState: Identifiable, Codable {
         workerName = try container.decodeIfPresent(String.self, forKey: .workerName)
         workerID = try container.decodeIfPresent(String.self, forKey: .workerID)
         children = try container.decodeIfPresent([SessionState].self, forKey: .children)
+        launcher = try container.decodeIfPresent(Launcher.self, forKey: .launcher)
 
         // Handle firstSeen date (unix timestamp format)
         if let timestamp = try? container.decode(Double.self, forKey: .firstSeen) {
@@ -278,7 +302,7 @@ struct SessionState: Identifiable, Codable {
     }
     
     // Regular initializer for testing/preview purposes
-    init(id: String, state: State, model: String, cwd: String, transcriptPath: String? = nil, gitBranch: String? = nil, projectName: String? = nil, firstSeen: Date, updatedAt: Date, eventCount: Int? = nil, lastEvent: String? = nil, metrics: SessionMetrics? = nil, pid: Int? = nil, parentSessionId: String? = nil, subagents: SubagentSummary? = nil, adapter: String? = nil, daemonVersion: String? = nil, role: String? = nil, roleIcon: String? = nil, roleDescription: String? = nil, workerName: String? = nil, workerID: String? = nil, children: [SessionState]? = nil) {
+    init(id: String, state: State, model: String, cwd: String, transcriptPath: String? = nil, gitBranch: String? = nil, projectName: String? = nil, firstSeen: Date, updatedAt: Date, eventCount: Int? = nil, lastEvent: String? = nil, metrics: SessionMetrics? = nil, pid: Int? = nil, parentSessionId: String? = nil, subagents: SubagentSummary? = nil, adapter: String? = nil, daemonVersion: String? = nil, role: String? = nil, roleIcon: String? = nil, roleDescription: String? = nil, workerName: String? = nil, workerID: String? = nil, children: [SessionState]? = nil, launcher: Launcher? = nil) {
         self.id = id
         self.state = state
         self.model = model
@@ -302,6 +326,7 @@ struct SessionState: Identifiable, Codable {
         self.workerName = workerName
         self.workerID = workerID
         self.children = children
+        self.launcher = launcher
     }
     
     enum State: String, CaseIterable, Codable {

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -155,7 +155,6 @@ struct Launcher: Codable, Hashable {
     let termSessionID: String?
     let tmuxPane: String?
     let tmuxSocket: String?
-    let vscodePID: Int?
     let tty: String?
 
     enum CodingKeys: String, CodingKey {
@@ -164,7 +163,6 @@ struct Launcher: Codable, Hashable {
         case termSessionID  = "term_session_id"
         case tmuxPane       = "tmux_pane"
         case tmuxSocket     = "tmux_socket"
-        case vscodePID      = "vscode_pid"
         case tty            = "tty"
     }
 }

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -156,6 +156,7 @@ struct Launcher: Codable, Hashable {
     let tmuxPane: String?
     let tmuxSocket: String?
     let vscodePID: Int?
+    let tty: String?
 
     enum CodingKeys: String, CodingKey {
         case termProgram    = "term_program"
@@ -164,6 +165,7 @@ struct Launcher: Codable, Hashable {
         case tmuxPane       = "tmux_pane"
         case tmuxSocket     = "tmux_socket"
         case vscodePID      = "vscode_pid"
+        case tty            = "tty"
     }
 }
 

--- a/platforms/macos/Irrlicht/Resources/Info.plist
+++ b/platforms/macos/Irrlicht/Resources/Info.plist
@@ -26,6 +26,8 @@
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>LSUIElement</key>
     <true/>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Irrlicht brings your terminal or editor to the front when you click a session or notification.</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2024 Anthropic. All rights reserved.</string>
     <key>NSPrincipalClass</key>

--- a/platforms/macos/Irrlicht/Resources/Info.plist
+++ b/platforms/macos/Irrlicht/Resources/Info.plist
@@ -27,7 +27,7 @@
     <key>LSUIElement</key>
     <true/>
     <key>NSAppleEventsUsageDescription</key>
-    <string>Irrlicht uses AppleScript to bring the correct iTerm2 window and tab to the front when you click a session row.</string>
+    <string>Irrlicht uses AppleScript to bring the correct iTerm2 or Terminal.app window and tab to the front when you click a session row.</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2024 Anthropic. All rights reserved.</string>
     <key>NSPrincipalClass</key>

--- a/platforms/macos/Irrlicht/Resources/Info.plist
+++ b/platforms/macos/Irrlicht/Resources/Info.plist
@@ -26,8 +26,6 @@
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>LSUIElement</key>
     <true/>
-    <key>NSAppleEventsUsageDescription</key>
-    <string>Irrlicht brings your terminal or editor to the front when you click a session or notification.</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2024 Anthropic. All rights reserved.</string>
     <key>NSPrincipalClass</key>

--- a/platforms/macos/Irrlicht/Resources/Info.plist
+++ b/platforms/macos/Irrlicht/Resources/Info.plist
@@ -26,6 +26,8 @@
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>LSUIElement</key>
     <true/>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Irrlicht uses AppleScript to bring the correct iTerm2 window and tab to the front when you click a session row.</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2024 Anthropic. All rights reserved.</string>
     <key>NSPrincipalClass</key>

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -366,13 +366,19 @@ struct SessionRowView: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 4)
         .background(isHovered ? Color.accentColor.opacity(0.1) : Color.clear)
+        .contentShape(Rectangle())
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.15)) {
                 isHovered = hovering
             }
         }
+        .onTapGesture {
+            SessionLauncher.jump(session)
+        }
         .accessibilityIdentifier("session-card-\(session.id)")
         .accessibilityLabel("\(session.projectName ?? "unknown") \(session.state.rawValue) \(session.shortModelName)")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint("Brings the session's terminal or editor to the foreground")
     }
 
     private func elapsedString(from date: Date, now: Date) -> String {

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -243,4 +243,110 @@ final class SessionManagerTests: XCTestCase {
         let data = try JSONEncoder().encode(session)
         try data.write(to: url)
     }
+
+    // MARK: - Launcher
+
+    func testLauncherDecodes() throws {
+        let jsonData = """
+        {
+            "session_id": "sess_l",
+            "state": "working",
+            "model": "claude-opus-4-7",
+            "cwd": "/Users/test/projects/app",
+            "updated_at": 1700000000,
+            "launcher": {
+                "term_program": "iTerm.app",
+                "iterm_session_id": "w0t0p0-ABC"
+            }
+        }
+        """.data(using: .utf8)!
+
+        let session = try JSONDecoder().decode(SessionState.self, from: jsonData)
+        XCTAssertNotNil(session.launcher)
+        XCTAssertEqual(session.launcher?.termProgram, "iTerm.app")
+        XCTAssertEqual(session.launcher?.itermSessionID, "w0t0p0-ABC")
+        XCTAssertNil(session.launcher?.tmuxPane)
+    }
+
+    func testLauncherMissingIsNil() throws {
+        // Session JSON without a launcher key must still decode cleanly for
+        // backwards compatibility with older daemon builds.
+        let jsonData = """
+        {
+            "session_id": "sess_legacy",
+            "state": "ready",
+            "model": "claude-opus-4-7",
+            "cwd": "/tmp",
+            "updated_at": 1700000000
+        }
+        """.data(using: .utf8)!
+        let session = try JSONDecoder().decode(SessionState.self, from: jsonData)
+        XCTAssertNil(session.launcher)
+    }
+
+    // MARK: - SessionLauncher helpers
+
+    func testSessionLauncherBundleIDDerivation() {
+        // The map lives client-side so the daemon's domain model stays
+        // platform-neutral. Unknown / unsupported programs return nil so
+        // dispatch can fall through to Finder-reveal.
+        XCTAssertEqual(SessionLauncher.bundleID(for: "iTerm.app"), "com.googlecode.iterm2")
+        XCTAssertEqual(SessionLauncher.bundleID(for: "Apple_Terminal"), "com.apple.Terminal")
+        XCTAssertEqual(SessionLauncher.bundleID(for: "vscode"), "com.microsoft.VSCode")
+        XCTAssertEqual(SessionLauncher.bundleID(for: "ghostty"), "com.mitchellh.ghostty")
+        XCTAssertNil(SessionLauncher.bundleID(for: "tmux"))
+        XCTAssertNil(SessionLauncher.bundleID(for: nil))
+        XCTAssertNil(SessionLauncher.bundleID(for: "unknown-terminal"))
+    }
+
+    func testSessionLauncherEditorURLScheme() {
+        XCTAssertEqual(SessionLauncher.editorURLScheme(for: "vscode"), "vscode")
+        XCTAssertEqual(SessionLauncher.editorURLScheme(for: "cursor"), "cursor")
+        XCTAssertEqual(SessionLauncher.editorURLScheme(for: "windsurf"), "windsurf")
+        XCTAssertNil(SessionLauncher.editorURLScheme(for: "iTerm.app"))
+        XCTAssertNil(SessionLauncher.editorURLScheme(for: nil))
+        XCTAssertNil(SessionLauncher.editorURLScheme(for: ""))
+    }
+
+    func testSessionLauncherEditorFolderURL() {
+        let simple = SessionLauncher.editorFolderURL(scheme: "vscode", cwd: "/Users/alice/projects/app")
+        XCTAssertEqual(simple?.absoluteString, "vscode://file/Users/alice/projects/app")
+
+        let spaced = SessionLauncher.editorFolderURL(scheme: "cursor", cwd: "/Users/alice/my projects/app")
+        XCTAssertEqual(spaced?.absoluteString, "cursor://file/Users/alice/my%20projects/app")
+
+        // Non-absolute cwd yields no host-relative URL we want to hand to the OS.
+        let relative = SessionLauncher.editorFolderURL(scheme: "vscode", cwd: "relative/path")
+        // URLComponents builds *something*, but it must not crash; only assert it's not our expected absolute form.
+        XCTAssertNotEqual(relative?.absoluteString, "vscode://file/relative/path")
+    }
+
+    func testSessionLauncherAppleScriptEscape() {
+        XCTAssertEqual(SessionLauncher.appleScriptEscape("w0t0p0"), "w0t0p0")
+        XCTAssertEqual(SessionLauncher.appleScriptEscape("a\"b"), "a\\\"b")
+        // Backslash escapes before quotes — otherwise the quote's escape gets re-escaped.
+        XCTAssertEqual(SessionLauncher.appleScriptEscape("a\\b"), "a\\\\b")
+        XCTAssertEqual(SessionLauncher.appleScriptEscape("a\\\"b"), "a\\\\\\\"b")
+    }
+
+    func testSessionLauncherITerm2ScriptReturnsBoolean() {
+        // The iTerm2 script must include both "return \"1\"" (match) and
+        // "return \"0\"" (no-match) so runAppleScriptMatching can detect
+        // when to fall through to the bundle-ID activator.
+        let script = SessionLauncher.iterm2SelectScript(sessionID: "w0t0p0-ABC")
+        XCTAssertTrue(script.contains("return \"1\""),
+                      "script must signal match with \"1\": \(script)")
+        XCTAssertTrue(script.contains("return \"0\""),
+                      "script must signal no-match with \"0\": \(script)")
+        XCTAssertTrue(script.contains("\"w0t0p0-ABC\""),
+                      "script must embed the escaped session id: \(script)")
+    }
+
+    func testSessionLauncherITerm2ScriptEscapesQuotes() {
+        // Defensive: if a future env source ever produces a quoted ID, the
+        // script literal must still parse.
+        let script = SessionLauncher.iterm2SelectScript(sessionID: "a\"b")
+        XCTAssertTrue(script.contains("\"a\\\"b\""),
+                      "quote must be backslash-escaped: \(script)")
+    }
 }

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -287,9 +287,6 @@ final class SessionManagerTests: XCTestCase {
     // MARK: - SessionLauncher helpers
 
     func testSessionLauncherBundleIDDerivation() {
-        // The map lives client-side so the daemon's domain model stays
-        // platform-neutral. Unknown / unsupported programs return nil so
-        // dispatch can fall through to Finder-reveal.
         XCTAssertEqual(SessionLauncher.bundleID(for: "iTerm.app"), "com.googlecode.iterm2")
         XCTAssertEqual(SessionLauncher.bundleID(for: "Apple_Terminal"), "com.apple.Terminal")
         XCTAssertEqual(SessionLauncher.bundleID(for: "vscode"), "com.microsoft.VSCode")
@@ -297,56 +294,5 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertNil(SessionLauncher.bundleID(for: "tmux"))
         XCTAssertNil(SessionLauncher.bundleID(for: nil))
         XCTAssertNil(SessionLauncher.bundleID(for: "unknown-terminal"))
-    }
-
-    func testSessionLauncherEditorURLScheme() {
-        XCTAssertEqual(SessionLauncher.editorURLScheme(for: "vscode"), "vscode")
-        XCTAssertEqual(SessionLauncher.editorURLScheme(for: "cursor"), "cursor")
-        XCTAssertEqual(SessionLauncher.editorURLScheme(for: "windsurf"), "windsurf")
-        XCTAssertNil(SessionLauncher.editorURLScheme(for: "iTerm.app"))
-        XCTAssertNil(SessionLauncher.editorURLScheme(for: nil))
-        XCTAssertNil(SessionLauncher.editorURLScheme(for: ""))
-    }
-
-    func testSessionLauncherEditorFolderURL() {
-        let simple = SessionLauncher.editorFolderURL(scheme: "vscode", cwd: "/Users/alice/projects/app")
-        XCTAssertEqual(simple?.absoluteString, "vscode://file/Users/alice/projects/app")
-
-        let spaced = SessionLauncher.editorFolderURL(scheme: "cursor", cwd: "/Users/alice/my projects/app")
-        XCTAssertEqual(spaced?.absoluteString, "cursor://file/Users/alice/my%20projects/app")
-
-        // Non-absolute cwd yields no host-relative URL we want to hand to the OS.
-        let relative = SessionLauncher.editorFolderURL(scheme: "vscode", cwd: "relative/path")
-        // URLComponents builds *something*, but it must not crash; only assert it's not our expected absolute form.
-        XCTAssertNotEqual(relative?.absoluteString, "vscode://file/relative/path")
-    }
-
-    func testSessionLauncherAppleScriptEscape() {
-        XCTAssertEqual(SessionLauncher.appleScriptEscape("w0t0p0"), "w0t0p0")
-        XCTAssertEqual(SessionLauncher.appleScriptEscape("a\"b"), "a\\\"b")
-        // Backslash escapes before quotes — otherwise the quote's escape gets re-escaped.
-        XCTAssertEqual(SessionLauncher.appleScriptEscape("a\\b"), "a\\\\b")
-        XCTAssertEqual(SessionLauncher.appleScriptEscape("a\\\"b"), "a\\\\\\\"b")
-    }
-
-    func testSessionLauncherITerm2ScriptReturnsBoolean() {
-        // The iTerm2 script must include both "return \"1\"" (match) and
-        // "return \"0\"" (no-match) so runAppleScriptMatching can detect
-        // when to fall through to the bundle-ID activator.
-        let script = SessionLauncher.iterm2SelectScript(sessionID: "w0t0p0-ABC")
-        XCTAssertTrue(script.contains("return \"1\""),
-                      "script must signal match with \"1\": \(script)")
-        XCTAssertTrue(script.contains("return \"0\""),
-                      "script must signal no-match with \"0\": \(script)")
-        XCTAssertTrue(script.contains("\"w0t0p0-ABC\""),
-                      "script must embed the escaped session id: \(script)")
-    }
-
-    func testSessionLauncherITerm2ScriptEscapesQuotes() {
-        // Defensive: if a future env source ever produces a quoted ID, the
-        // script literal must still parse.
-        let script = SessionLauncher.iterm2SelectScript(sessionID: "a\"b")
-        XCTAssertTrue(script.contains("\"a\\\"b\""),
-                      "quote must be backslash-escaped: \(script)")
     }
 }

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -379,4 +379,33 @@ final class SessionManagerTests: XCTestCase {
         let titles = ["README.md — some-other-project", "", "main.swift — another"]
         XCTAssertNil(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd))
     }
+
+    // MARK: - iTerm UUID extraction
+
+    func testITermUUIDExtractsFromLegacyFormat() {
+        // Older iTerm2 ITERM_SESSION_ID: "w0t0p0:UUID"
+        XCTAssertEqual(
+            SessionLauncher.iTermUUID(from: "w4t0p0:1FFEA6B4-1EA4-4A3C-86B6-B80027B5690F"),
+            "1FFEA6B4-1EA4-4A3C-86B6-B80027B5690F")
+    }
+
+    func testITermUUIDExtractsFromCurrentFormat() {
+        // Newer format: "w0:t0:p0:UUID"
+        XCTAssertEqual(
+            SessionLauncher.iTermUUID(from: "w0:t0:p0:ABCD-1234"),
+            "ABCD-1234")
+    }
+
+    func testITermUUIDWithoutColonReturnsInput() {
+        // If the env value has no colon at all, treat the whole thing as a
+        // UUID — best-effort, still lets the AppleScript try a match.
+        XCTAssertEqual(SessionLauncher.iTermUUID(from: "BARE-UUID"), "BARE-UUID")
+    }
+
+    func testITermUUIDEmptyOrNil() {
+        XCTAssertNil(SessionLauncher.iTermUUID(from: nil))
+        XCTAssertNil(SessionLauncher.iTermUUID(from: ""))
+        // Trailing colon → empty tail → nil (no usable UUID to target).
+        XCTAssertNil(SessionLauncher.iTermUUID(from: "w0t0p0:"))
+    }
 }

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -301,7 +301,7 @@ final class SessionManagerTests: XCTestCase {
         // ancestor match.
         let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
         XCTAssertEqual(
-            SessionLauncher.titleMatchScore(
+            AXTitleMatchActivator.titleMatchScore(
                 title: "ingo@mac: /Users/ingo/projects/irrlicht/.claude/worktrees/170 — zsh",
                 cwd: cwd),
             1_000)
@@ -316,17 +316,17 @@ final class SessionManagerTests: XCTestCase {
         // parts index: Users(0) ingo(1) projects(2) irrlicht(3) .claude(4) worktrees(5) 170(6)
         //   Basename "170" — score 7.
         XCTAssertEqual(
-            SessionLauncher.titleMatchScore(title: "SessionLauncher.swift — 170", cwd: cwd),
+            AXTitleMatchActivator.titleMatchScore(title: "SessionLauncher.swift — 170", cwd: cwd),
             7)
 
         //   "worktrees" at depth 5 → score 6 (basename "170" missing).
         XCTAssertEqual(
-            SessionLauncher.titleMatchScore(title: "Edit.swift — worktrees", cwd: cwd),
+            AXTitleMatchActivator.titleMatchScore(title: "Edit.swift — worktrees", cwd: cwd),
             6)
 
         //   VS Code workspace is the repo root: "irrlicht" at depth 3 → score 4.
         XCTAssertEqual(
-            SessionLauncher.titleMatchScore(title: "2.1.114 — irrlicht", cwd: cwd),
+            AXTitleMatchActivator.titleMatchScore(title: "2.1.114 — irrlicht", cwd: cwd),
             4)
     }
 
@@ -336,18 +336,18 @@ final class SessionManagerTests: XCTestCase {
         let cwd = "/Users/ingo/projects/irrlicht"
         // Title matches "ingo" only — must score 0 (skipped).
         XCTAssertEqual(
-            SessionLauncher.titleMatchScore(title: "ingo@mac: ~ — zsh", cwd: cwd),
+            AXTitleMatchActivator.titleMatchScore(title: "ingo@mac: ~ — zsh", cwd: cwd),
             0)
         // Title matches "Users" only — must score 0.
         XCTAssertEqual(
-            SessionLauncher.titleMatchScore(title: "Users directory", cwd: cwd),
+            AXTitleMatchActivator.titleMatchScore(title: "Users directory", cwd: cwd),
             0)
     }
 
     func testTitleMatchScoreEmptyInputs() {
         let cwd = "/Users/ingo/projects/irrlicht"
-        XCTAssertEqual(SessionLauncher.titleMatchScore(title: "", cwd: cwd), 0)
-        XCTAssertEqual(SessionLauncher.titleMatchScore(title: "anything", cwd: ""), 0)
+        XCTAssertEqual(AXTitleMatchActivator.titleMatchScore(title: "", cwd: cwd), 0)
+        XCTAssertEqual(AXTitleMatchActivator.titleMatchScore(title: "anything", cwd: ""), 0)
     }
 
     func testBestMatchIndexPicksDeepestAncestor() {
@@ -360,7 +360,7 @@ final class SessionManagerTests: XCTestCase {
             "index.html — opencode-test",        // 1: unrelated
             "benchmark.md — agent-readyness",    // 2: unrelated
         ]
-        XCTAssertEqual(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd), 0)
+        XCTAssertEqual(AXTitleMatchActivator.bestMatchIndex(titles: titles, cwd: cwd), 0)
     }
 
     func testBestMatchIndexPrefersDeeperMatchWhenBothPresent() {
@@ -371,13 +371,13 @@ final class SessionManagerTests: XCTestCase {
             "README.md — irrlicht",     // ancestor at depth 3 → score 4
             "main.go — core",           // basename at depth 4 → score 5 (wins)
         ]
-        XCTAssertEqual(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd), 1)
+        XCTAssertEqual(AXTitleMatchActivator.bestMatchIndex(titles: titles, cwd: cwd), 1)
     }
 
     func testBestMatchIndexReturnsNilWhenNoMatch() {
         let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
         let titles = ["README.md — some-other-project", "", "main.swift — another"]
-        XCTAssertNil(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd))
+        XCTAssertNil(AXTitleMatchActivator.bestMatchIndex(titles: titles, cwd: cwd))
     }
 
     // MARK: - iTerm UUID extraction
@@ -385,27 +385,27 @@ final class SessionManagerTests: XCTestCase {
     func testITermUUIDExtractsFromLegacyFormat() {
         // Older iTerm2 ITERM_SESSION_ID: "w0t0p0:UUID"
         XCTAssertEqual(
-            SessionLauncher.iTermUUID(from: "w4t0p0:1FFEA6B4-1EA4-4A3C-86B6-B80027B5690F"),
+            ITermActivator.iTermUUID(from: "w4t0p0:1FFEA6B4-1EA4-4A3C-86B6-B80027B5690F"),
             "1FFEA6B4-1EA4-4A3C-86B6-B80027B5690F")
     }
 
     func testITermUUIDExtractsFromCurrentFormat() {
         // Newer format: "w0:t0:p0:UUID"
         XCTAssertEqual(
-            SessionLauncher.iTermUUID(from: "w0:t0:p0:ABCD-1234"),
+            ITermActivator.iTermUUID(from: "w0:t0:p0:ABCD-1234"),
             "ABCD-1234")
     }
 
     func testITermUUIDWithoutColonReturnsInput() {
         // If the env value has no colon at all, treat the whole thing as a
         // UUID — best-effort, still lets the AppleScript try a match.
-        XCTAssertEqual(SessionLauncher.iTermUUID(from: "BARE-UUID"), "BARE-UUID")
+        XCTAssertEqual(ITermActivator.iTermUUID(from: "BARE-UUID"), "BARE-UUID")
     }
 
     func testITermUUIDEmptyOrNil() {
-        XCTAssertNil(SessionLauncher.iTermUUID(from: nil))
-        XCTAssertNil(SessionLauncher.iTermUUID(from: ""))
+        XCTAssertNil(ITermActivator.iTermUUID(from: nil))
+        XCTAssertNil(ITermActivator.iTermUUID(from: ""))
         // Trailing colon → empty tail → nil (no usable UUID to target).
-        XCTAssertNil(SessionLauncher.iTermUUID(from: "w0t0p0:"))
+        XCTAssertNil(ITermActivator.iTermUUID(from: "w0t0p0:"))
     }
 }

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -295,4 +295,77 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertNil(SessionLauncher.bundleID(for: nil))
         XCTAssertNil(SessionLauncher.bundleID(for: "unknown-terminal"))
     }
+
+    func testTitleMatchScore() {
+        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
+
+        // 3: full absolute cwd in title (iTerm2/Terminal tab title style).
+        XCTAssertEqual(
+            SessionLauncher.titleMatchScore(
+                title: "ingo@mac: /Users/ingo/projects/irrlicht/.claude/worktrees/170 — zsh",
+                cwd: cwd),
+            3)
+
+        // 2: last two components match (VS Code shows "file — worktrees/170" rarely
+        //    but terminals do: "~/…/worktrees/170").
+        XCTAssertEqual(
+            SessionLauncher.titleMatchScore(
+                title: "Edit.swift — worktrees/170",
+                cwd: cwd),
+            2)
+
+        // 1: basename only — weakest, still wins when unique.
+        XCTAssertEqual(
+            SessionLauncher.titleMatchScore(
+                title: "SessionLauncher.swift — 170",
+                cwd: cwd),
+            1)
+
+        // 0: unrelated title.
+        XCTAssertEqual(
+            SessionLauncher.titleMatchScore(
+                title: "main.swift — irrlicht",
+                cwd: cwd),
+            0)
+
+        // Empty inputs are safe.
+        XCTAssertEqual(SessionLauncher.titleMatchScore(title: "", cwd: cwd), 0)
+        XCTAssertEqual(SessionLauncher.titleMatchScore(title: "anything", cwd: ""), 0)
+    }
+
+    func testBestMatchIndexPicksHighestScoring() {
+        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
+        let titles = [
+            "main.swift — irrlicht",             // 0: main repo window
+            "SessionLauncher.swift — 170",       // 1: basename-only match
+            "Edit.swift — worktrees/170",        // 2: last-two match, should win
+        ]
+        XCTAssertEqual(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd), 2)
+    }
+
+    func testBestMatchIndexDisambiguatesWorktreeVsMainRepo() {
+        // Realistic collision: both windows have "irrlicht" in the title. The
+        // worktree session's cwd has its own basename ("170"), so only the
+        // worktree window should match.
+        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
+        let titles = [
+            "README.md — irrlicht",                     // main repo (basename=irrlicht)
+            "SessionLauncher.swift — 170",              // worktree (basename=170)
+        ]
+        XCTAssertEqual(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd), 1)
+    }
+
+    func testBestMatchIndexReturnsNilWhenNoMatch() {
+        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
+        let titles = ["README.md — some-other-project", "", "main.swift — another"]
+        XCTAssertNil(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd))
+    }
+
+    func testBestMatchIndexTiesBreakByFirstOccurrence() {
+        // AX returns windows in z-order (frontmost first). On equal scores we
+        // prefer the frontmost, which is the first element.
+        let cwd = "/tmp/foo"
+        let titles = ["edit foo — bar", "view foo — baz"]
+        XCTAssertEqual(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd), 0)
+    }
 }

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -296,61 +296,80 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertNil(SessionLauncher.bundleID(for: "unknown-terminal"))
     }
 
-    func testTitleMatchScore() {
+    func testTitleMatchScoreFullCwdDominates() {
+        // Full cwd in title (iTerm2/Terminal tab title style) dominates any
+        // ancestor match.
         let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
-
-        // 3: full absolute cwd in title (iTerm2/Terminal tab title style).
         XCTAssertEqual(
             SessionLauncher.titleMatchScore(
                 title: "ingo@mac: /Users/ingo/projects/irrlicht/.claude/worktrees/170 — zsh",
                 cwd: cwd),
-            3)
+            1_000)
+    }
 
-        // 2: last two components match (VS Code shows "file — worktrees/170" rarely
-        //    but terminals do: "~/…/worktrees/170").
-        XCTAssertEqual(
-            SessionLauncher.titleMatchScore(
-                title: "Edit.swift — worktrees/170",
-                cwd: cwd),
-            2)
+    func testTitleMatchScoreDeepestAncestorWins() {
+        // cwd is several levels below the VS Code workspace root.
+        // VS Code's window title shows only the workspace folder name
+        // ("irrlicht"). The matcher must still find that as an ancestor.
+        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
 
-        // 1: basename only — weakest, still wins when unique.
+        // parts index: Users(0) ingo(1) projects(2) irrlicht(3) .claude(4) worktrees(5) 170(6)
+        //   Basename "170" — score 7.
         XCTAssertEqual(
-            SessionLauncher.titleMatchScore(
-                title: "SessionLauncher.swift — 170",
-                cwd: cwd),
-            1)
+            SessionLauncher.titleMatchScore(title: "SessionLauncher.swift — 170", cwd: cwd),
+            7)
 
-        // 0: unrelated title.
+        //   "worktrees" at depth 5 → score 6 (basename "170" missing).
         XCTAssertEqual(
-            SessionLauncher.titleMatchScore(
-                title: "main.swift — irrlicht",
-                cwd: cwd),
+            SessionLauncher.titleMatchScore(title: "Edit.swift — worktrees", cwd: cwd),
+            6)
+
+        //   VS Code workspace is the repo root: "irrlicht" at depth 3 → score 4.
+        XCTAssertEqual(
+            SessionLauncher.titleMatchScore(title: "2.1.114 — irrlicht", cwd: cwd),
+            4)
+    }
+
+    func testTitleMatchScoreSkipsGenericTopsAndHomeBasename() {
+        // "Users" and the user's home basename must never match alone —
+        // otherwise every title string containing "ingo" would win.
+        let cwd = "/Users/ingo/projects/irrlicht"
+        // Title matches "ingo" only — must score 0 (skipped).
+        XCTAssertEqual(
+            SessionLauncher.titleMatchScore(title: "ingo@mac: ~ — zsh", cwd: cwd),
             0)
+        // Title matches "Users" only — must score 0.
+        XCTAssertEqual(
+            SessionLauncher.titleMatchScore(title: "Users directory", cwd: cwd),
+            0)
+    }
 
-        // Empty inputs are safe.
+    func testTitleMatchScoreEmptyInputs() {
+        let cwd = "/Users/ingo/projects/irrlicht"
         XCTAssertEqual(SessionLauncher.titleMatchScore(title: "", cwd: cwd), 0)
         XCTAssertEqual(SessionLauncher.titleMatchScore(title: "anything", cwd: ""), 0)
     }
 
-    func testBestMatchIndexPicksHighestScoring() {
+    func testBestMatchIndexPicksDeepestAncestor() {
+        // Worktree session, three VS Code windows open. Only one window
+        // (the main repo) is an ancestor of the cwd — that one wins, even
+        // though the cwd basename itself doesn't appear anywhere.
         let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
         let titles = [
-            "main.swift — irrlicht",             // 0: main repo window
-            "SessionLauncher.swift — 170",       // 1: basename-only match
-            "Edit.swift — worktrees/170",        // 2: last-two match, should win
+            "2.1.114 — irrlicht",                // 0: main repo, ancestor depth 3 → score 4
+            "index.html — opencode-test",        // 1: unrelated
+            "benchmark.md — agent-readyness",    // 2: unrelated
         ]
-        XCTAssertEqual(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd), 2)
+        XCTAssertEqual(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd), 0)
     }
 
-    func testBestMatchIndexDisambiguatesWorktreeVsMainRepo() {
-        // Realistic collision: both windows have "irrlicht" in the title. The
-        // worktree session's cwd has its own basename ("170"), so only the
-        // worktree window should match.
-        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
+    func testBestMatchIndexPrefersDeeperMatchWhenBothPresent() {
+        // If both a deeper subfolder window ("core") and the repo root ("irrlicht")
+        // are open, a cwd inside core should pick the core window.
+        let cwd = "/Users/ingo/projects/irrlicht/core"
         let titles = [
-            "README.md — irrlicht",                     // main repo (basename=irrlicht)
-            "SessionLauncher.swift — 170",              // worktree (basename=170)
+            "README.md — irrlicht",     // ancestor at depth 3 → score 4
+            "main.go — core",           // basename at depth 4 → score 5 (wins)
         ]
         XCTAssertEqual(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd), 1)
     }
@@ -359,13 +378,5 @@ final class SessionManagerTests: XCTestCase {
         let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
         let titles = ["README.md — some-other-project", "", "main.swift — another"]
         XCTAssertNil(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd))
-    }
-
-    func testBestMatchIndexTiesBreakByFirstOccurrence() {
-        // AX returns windows in z-order (frontmost first). On equal scores we
-        // prefer the frontmost, which is the first element.
-        let cwd = "/tmp/foo"
-        let titles = ["edit foo — bar", "view foo — baz"]
-        XCTAssertEqual(SessionLauncher.bestMatchIndex(titles: titles, cwd: cwd), 0)
     }
 }

--- a/scripts/dev-sign-setup.sh
+++ b/scripts/dev-sign-setup.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Generate a self-signed code signing certificate ("Irrlicht Dev") in the
+# login keychain so dev builds keep a stable code identity across rebuilds.
+#
+# Why: macOS TCC permissions (Accessibility, Automation) key on the app's
+# designated requirement, which is derived from the code signature. Ad-hoc
+# signing (`codesign --sign -`) produces a fresh hash-based identity every
+# time, so every rebuild invalidates granted TCC permissions. A persistent
+# self-signed cert keeps the identity stable.
+#
+# Idempotent: re-running after the identity already exists is a no-op.
+# Reversible: `security delete-certificate -c "Irrlicht Dev"` to undo.
+
+set -euo pipefail
+
+IDENTITY="Irrlicht Dev"
+KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
+
+if security find-identity -v -p codesigning "$KEYCHAIN" 2>/dev/null | grep -q "$IDENTITY"; then
+    echo "Identity \"$IDENTITY\" already present in login keychain — nothing to do."
+    exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Minimal OpenSSL config with a Code Signing EKU — `codesign` requires this
+# extension on the signing cert.
+cat > "$TMP/cert.cnf" <<'EOF'
+[req]
+distinguished_name = dn
+prompt = no
+[dn]
+CN = Irrlicht Dev
+[v3]
+basicConstraints = critical, CA:FALSE
+keyUsage = critical, digitalSignature
+extendedKeyUsage = codeSigning
+EOF
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+    -keyout "$TMP/key.pem" \
+    -out "$TMP/cert.pem" \
+    -config "$TMP/cert.cnf" \
+    -extensions v3
+
+# macOS's `security import` only accepts the older PKCS12 MAC/cipher combo.
+# OpenSSL 3 changed defaults; force the legacy provider *and* the SHA1 MAC
+# with 3DES encryption that the Keychain APIs know how to read. Without
+# this import fails with "MAC verification failed".
+# A non-empty password is required — empty passwords also trip import.
+P12_PASS="irrlicht-dev"
+openssl pkcs12 -export -legacy \
+    -keypbe PBE-SHA1-3DES \
+    -certpbe PBE-SHA1-3DES \
+    -macalg SHA1 \
+    -inkey "$TMP/key.pem" \
+    -in "$TMP/cert.pem" \
+    -name "$IDENTITY" \
+    -out "$TMP/bundle.p12" \
+    -passout pass:"$P12_PASS"
+
+security import "$TMP/bundle.p12" \
+    -k "$KEYCHAIN" \
+    -P "$P12_PASS" \
+    -T /usr/bin/codesign \
+    -A
+
+# Trust the cert for code signing in this user's trust settings. macOS 12+
+# requires this for codesign to accept the identity even though the private
+# key is in the same keychain.
+security add-trusted-cert \
+    -d -r trustRoot -p codeSign \
+    -k "$KEYCHAIN" \
+    "$TMP/cert.pem" 2>/dev/null || \
+    echo "note: user-level trust setting failed (may prompt for keychain password); \
+signing will still work but codesign may warn about unknown trust."
+
+echo "Installed code signing identity \"$IDENTITY\"."
+echo ""
+echo "Next steps:"
+echo "  1. Re-sign installed app:  codesign --force --sign \"$IDENTITY\" --deep /Applications/Irrlicht.app"
+echo "  2. Re-grant Accessibility once in System Settings → Privacy & Security."
+echo "  3. Future rebuilds using this identity keep the grant intact."


### PR DESCRIPTION
## Summary

Clicking a session row in the menu-bar app — or a delivered notification — brings the originating terminal or IDE *window* to the foreground. Closes #170.

### Architecture

**Daemon** (`core/adapters/inbound/agents/processlifecycle/`):
- Captures `$TERM_PROGRAM`, `$ITERM_SESSION_ID`, `$TERM_SESSION_ID`, `$TMUX`/`$TMUX_PANE`, `$VSCODE_PID`, and the controlling `tty` at first PID assignment. Exposed as `launcher` on each session JSON.
- `sysctl(kern.procargs2)` on darwin, `/proc/<pid>/environ` on linux — no TCC prompt.
- **Hardened-runtime fallback**: Anthropic's signed `claude` binary hides env from sysctl. Walks the ppid chain and identifies the host app by `.app/Contents/MacOS/` segment in the exec path (`hosts_darwin.go:termProgramByAppName`). Without this, VS Code sessions would always fall through to app-level.
- **TTY backfill**: `pid_manager.SeedPIDs` re-reads just the TTY for pre-existing sessions whose Launcher was captured before this field existed, without clobbering stable env-based identity.

**Menu-bar app** (`platforms/macos/Irrlicht/Managers/Launcher/`):
- `HostActivator` protocol; one activator per strategy; static registry in `SessionLauncher.swift`.
- **iTerm2**: AppleScript `select` by session `unique id` (UUID from `$ITERM_SESSION_ID`). Cross-space/screen safe.
- **Terminal.app**: AppleScript `select tab` by `tty`. `select` + `set index` only — no `do script` (would type into live shells).
- **VS Code / Cursor / Windsurf / Ghostty / WezTerm / Hyper / Warp**: `AXTitleMatchActivator` — activates app, then AX-raises the window whose title matches the deepest ancestor segment of cwd. VS Code shows only the workspace folder name (`"file — irrlicht"`) in its title, so the matcher walks `/Users/ingo/projects/irrlicht/.claude/worktrees/170` → `170` → `worktrees` → `.claude` → `irrlicht` and takes the first hit. Skips generic roots (`Users`, `$HOME` basename, `tmp`) to avoid collision false-positives.
- "Works or it doesn't" — no Finder-reveal fallback, no `vscode://file/` URL scheme (would open a new window and kill worktree sessions).

**Dev ergonomics** (`scripts/dev-sign-setup.sh`):
- Self-signed `"Irrlicht Dev"` code-signing identity in login keychain. Stable designated requirement across rebuilds → Accessibility/Automation TCC grants persist. Otherwise every `codesign --force --sign -` invalidates prior grants.
- `/ir:test-mac` skill auto-detects and uses the identity when present.

### Refactor landing state

`SessionLauncher.swift` shrank from a 200-line monolith (env map + if-ladder + per-host AppleScript/AX helpers intermixed) to ~55 lines: registry + `jump(_:)` + `bundleID(for:)`. New host onboarding:
1. Add one line to the Swift registry (+ one Go `termProgramByAppName` entry if the host doesn't set `$TERM_PROGRAM`).
2. Only write a new activator if the strategy isn't AX+title.

### Permissions

- **Accessibility** (AX path) — prompted on first click of a VS Code / Cursor / etc. session. One-time per signing identity.
- **Automation** (AppleScript paths) — prompted per target app (iTerm, Terminal). Unaffected by Irrlicht re-signing.

## Test plan

- [x] `GOWORK=off go test ./...` — all packages green.
- [x] `swift test` — 35 tests green, including `ITermActivator.iTermUUID` format extraction, `AXTitleMatchActivator.titleMatchScore` / `.bestMatchIndex` (worktree vs main-repo disambiguation, generic-root skipping, deepest-ancestor tie-break), `Launcher` Codable round-trip with/without new fields.
- [x] Live: iTerm2 (two windows on two spaces) → correct window/tab.
- [x] Live: Terminal.app (two tabs) → correct tab.
- [x] Live: VS Code with main repo + worktree directories — clicks raise the correct window whose title contains the deepest matching ancestor of cwd.
- [x] Live: hardened-runtime Claude Code sessions populate `term_program` via ancestry walk (verified via `/api/v1/sessions`).
- [x] Notification click uses the same `SessionLauncher.jump(_:)` path.
- [x] Regression: unknown host (no activator registered) logs and no-ops cleanly — no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)