### PR TITLE
fix(claudecode): gate PID negative filter on metadata mtime (#169)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/pid.go
+++ b/core/adapters/inbound/agents/claudecode/pid.go
@@ -53,13 +53,8 @@ type claudeSessionMeta struct {
 func DiscoverPID(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
 	wantSessionID := sessionIDFromTranscript(transcriptPath)
 
-	// Transcript mtime is used to detect stale metadata (issue #169): after a
-	// /clear, ~/.claude/sessions/<pid>.json can still point at the previous
-	// sessionId for up to ~2 min, which would wrongly exclude the live PID
-	// from the fallback. A new transcript written after /clear will have a
-	// fresher mtime than the stale metadata, so we can safely ignore such
-	// entries as negative filters. Zero on error → gate inert (current
-	// behavior preserved).
+	// Transcript mtime anchors the mtime gate below. Zero on error keeps
+	// the gate inert so behavior falls back to strict negative filtering.
 	var wantMTime time.Time
 	if transcriptPath != "" {
 		if info, err := os.Stat(transcriptPath); err == nil {
@@ -151,9 +146,9 @@ func sessionIDFromTranscript(path string) string {
 }
 
 // metaFileMTime returns the modification time of a metadata directory entry,
-// or zero on any error. Prefers os.DirEntry.Info() (uses the already-cached
-// stat from ReadDir on most platforms, avoiding a syscall) and falls back to
-// zero on failure — callers must treat zero as "unknown".
+// or zero on any error. Callers must treat zero as "unknown". Note: on
+// Linux/Darwin, os.DirEntry.Info() issues a fresh Lstat — acceptable here
+// because ~/.claude/sessions/ typically holds a handful of entries.
 func metaFileMTime(e os.DirEntry) time.Time {
 	info, err := e.Info()
 	if err != nil {

--- a/core/adapters/inbound/agents/claudecode/pid.go
+++ b/core/adapters/inbound/agents/claudecode/pid.go
@@ -6,9 +6,17 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 )
+
+// staleMetaSlack is the margin by which a ~/.claude/sessions/<pid>.json mtime
+// must trail the caller's transcript mtime before we treat the metadata as
+// stale and stop using it as a negative filter (issue #169). Must be larger
+// than filesystem-time jitter (APFS: ns, HFS+: 1s) and small compared to the
+// ~2 min window during which Claude may leave stale metadata after /clear.
+const staleMetaSlack = 2 * time.Second
 
 // sessionsDir is the directory Claude Code writes per-process metadata files to.
 // Each live Claude process owns ~/.claude/sessions/<pid>.json containing
@@ -45,10 +53,26 @@ type claudeSessionMeta struct {
 func DiscoverPID(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
 	wantSessionID := sessionIDFromTranscript(transcriptPath)
 
+	// Transcript mtime is used to detect stale metadata (issue #169): after a
+	// /clear, ~/.claude/sessions/<pid>.json can still point at the previous
+	// sessionId for up to ~2 min, which would wrongly exclude the live PID
+	// from the fallback. A new transcript written after /clear will have a
+	// fresher mtime than the stale metadata, so we can safely ignore such
+	// entries as negative filters. Zero on error → gate inert (current
+	// behavior preserved).
+	var wantMTime time.Time
+	if transcriptPath != "" {
+		if info, err := os.Stat(transcriptPath); err == nil {
+			wantMTime = info.ModTime()
+		}
+	}
+
 	// Layer 1: authoritative metadata lookup.
 	// Scan ~/.claude/sessions/*.json once, collecting PIDs that some metadata
 	// file owns (for negative-filtering the fallback) and looking for an
-	// exact sessionId match.
+	// exact sessionId match. Entries whose mtime is older than the caller's
+	// transcript by more than staleMetaSlack are treated as positive-only
+	// signals (their PID is NOT added to claimedByOthers) — see issue #169.
 	claimedByOthers := make(map[int]bool)
 	if wantSessionID != "" && sessionsDir != "" {
 		entries, err := os.ReadDir(sessionsDir)
@@ -67,9 +91,15 @@ func DiscoverPID(cwd, transcriptPath string, disambiguate func([]int) int) (int,
 				if meta.SessionID == wantSessionID {
 					return meta.PID, nil
 				}
-				// A live Claude process owns this PID for a different sessionId;
-				// exclude it from the cwd fallback below.
-				claimedByOthers[meta.PID] = true
+				// A live Claude process owns this PID for a different sessionId.
+				// Exclude it from the cwd fallback — unless the metadata is
+				// demonstrably older than the caller's transcript, which
+				// indicates a stale post-/clear entry that would otherwise
+				// strand the new session at PID=0 (issue #169).
+				metaMTime := metaFileMTime(e)
+				if wantMTime.IsZero() || metaMTime.IsZero() || !metaMTime.Before(wantMTime.Add(-staleMetaSlack)) {
+					claimedByOthers[meta.PID] = true
+				}
 			}
 		}
 	}
@@ -118,6 +148,18 @@ func sessionIDFromTranscript(path string) string {
 		return ""
 	}
 	return strings.TrimSuffix(base, ".jsonl")
+}
+
+// metaFileMTime returns the modification time of a metadata directory entry,
+// or zero on any error. Prefers os.DirEntry.Info() (uses the already-cached
+// stat from ReadDir on most platforms, avoiding a syscall) and falls back to
+// zero on failure — callers must treat zero as "unknown".
+func metaFileMTime(e os.DirEntry) time.Time {
+	info, err := e.Info()
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime()
 }
 
 // readSessionMeta reads and parses a single ~/.claude/sessions/<pid>.json file.

--- a/core/adapters/inbound/agents/claudecode/pid_test.go
+++ b/core/adapters/inbound/agents/claudecode/pid_test.go
@@ -67,10 +67,8 @@ func transcriptFor(sessionID string) string {
 // entries left behind after a /clear.
 func writeMetaAt(t *testing.T, dir string, pid int, sessionID string, mtime time.Time) {
 	t.Helper()
-	writeMeta(t, dir, pid, sessionID)
-	path := filepath.Join(dir, strconv.Itoa(pid)+".json")
-	if err := os.Chtimes(path, mtime, mtime); err != nil {
-		t.Fatalf("chtimes: %v", err)
+	if err := WriteSessionMetaForTest(dir, pid, sessionID, mtime); err != nil {
+		t.Fatalf("write meta at: %v", err)
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/pid_test.go
+++ b/core/adapters/inbound/agents/claudecode/pid_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 )
 
 // withTestDeps swaps sessionsDir, pidAlive, and discoverByCWD for the duration
@@ -59,6 +60,29 @@ func writeMeta(t *testing.T, dir string, pid int, sessionID string) {
 
 func transcriptFor(sessionID string) string {
 	return "/Users/x/.claude/projects/foo/" + sessionID + ".jsonl"
+}
+
+// writeMetaAt writes a metadata file and then sets its mtime to the given time.
+// Used by #169 regression tests to simulate stale ~/.claude/sessions/<pid>.json
+// entries left behind after a /clear.
+func writeMetaAt(t *testing.T, dir string, pid int, sessionID string, mtime time.Time) {
+	t.Helper()
+	writeMeta(t, dir, pid, sessionID)
+	path := filepath.Join(dir, strconv.Itoa(pid)+".json")
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+}
+
+// transcriptForWithFile creates a real transcript file in t.TempDir so that
+// os.Stat returns a meaningful mtime. Returns the absolute path.
+func transcriptForWithFile(t *testing.T, sessionID string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
 }
 
 func TestDiscoverPID_StrongMatchByMetadata(t *testing.T) {
@@ -184,6 +208,64 @@ func TestDiscoverPID_EmptyTranscriptFallsBackToCWD(t *testing.T) {
 	}
 	if pid != 42 {
 		t.Fatalf("got pid=%d, want 42", pid)
+	}
+}
+
+func TestDiscoverPID_StaleMetadataDoesNotBlockCWDFallback(t *testing.T) {
+	// Regression for #169. After /clear, Claude keeps the same PID (62896)
+	// but ~/.claude/sessions/62896.json still points at the OLD sessionId.
+	// The new session's transcript was written after /clear, so it is newer
+	// than the stale metadata; DiscoverPID must NOT treat the stale entry
+	// as a hard negative filter, and must return 62896 via the CWD fallback.
+	dir := withTestDeps(t, map[int]bool{62896: true}, []int{62896})
+	writeMetaAt(t, dir, 62896, "old-session", time.Now().Add(-30*time.Second))
+	transcript := transcriptForWithFile(t, "new-session")
+
+	pid, err := DiscoverPID("/repo", transcript, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 62896 {
+		t.Fatalf("got pid=%d, want 62896 (stale metadata must not block fallback)", pid)
+	}
+}
+
+func TestDiscoverPID_FreshMetadataStillBlocksConcurrentSession(t *testing.T) {
+	// #109 protection regression guard: two concurrent Claude processes in
+	// the same CWD, both with fresh metadata. The one whose metadata points
+	// at a different sessionId must still be filtered out.
+	dir := withTestDeps(t,
+		map[int]bool{100: true, 200: true},
+		[]int{100, 200},
+	)
+	writeMetaAt(t, dir, 200, "other-session", time.Now())
+	transcript := transcriptForWithFile(t, "new-sid")
+
+	pid, err := DiscoverPID("/repo", transcript, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 100 {
+		t.Fatalf("got pid=%d, want 100 (fresh metadata must still exclude 200)", pid)
+	}
+}
+
+func TestDiscoverPID_NoTranscriptFileFallsBackSafely(t *testing.T) {
+	// When the transcript file doesn't exist on disk (os.Stat fails),
+	// wantMTime is zero and the mtime gate must be inert — current
+	// negative-filtering behavior must be preserved.
+	dir := withTestDeps(t,
+		map[int]bool{100: true, 200: true},
+		[]int{100, 200},
+	)
+	writeMeta(t, dir, 200, "other-session")
+
+	pid, err := DiscoverPID("/repo", transcriptFor("new-sid"), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pid != 100 {
+		t.Fatalf("got pid=%d, want 100 (gate must be inert without transcript mtime)", pid)
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/testsupport.go
+++ b/core/adapters/inbound/agents/claudecode/testsupport.go
@@ -1,0 +1,32 @@
+package claudecode
+
+// ReplaceTestDeps swaps DiscoverPID's filesystem dependencies (sessionsDir,
+// pidAlive, discoverByCWD) with caller-provided stubs and returns a closure
+// that restores the originals. Intended only for tests in other packages
+// (e.g. services) that need to drive the real DiscoverPID against controlled
+// filesystem state. Not for production callers.
+//
+// Any of cwd / alive may be nil to keep the current implementation.
+func ReplaceTestDeps(
+	dir string,
+	alive func(int) bool,
+	cwd func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error),
+) (restore func()) {
+	origDir := sessionsDir
+	origAlive := pidAlive
+	origCWD := discoverByCWD
+
+	sessionsDir = dir
+	if alive != nil {
+		pidAlive = alive
+	}
+	if cwd != nil {
+		discoverByCWD = cwd
+	}
+
+	return func() {
+		sessionsDir = origDir
+		pidAlive = origAlive
+		discoverByCWD = origCWD
+	}
+}

--- a/core/adapters/inbound/agents/claudecode/testsupport.go
+++ b/core/adapters/inbound/agents/claudecode/testsupport.go
@@ -1,5 +1,29 @@
 package claudecode
 
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// WriteSessionMetaForTest writes a ~/.claude/sessions/<pid>.json file in dir
+// and sets its mtime. Exported so tests in other packages (e.g. services
+// E2E) can construct the same metadata fixtures as the package's own unit
+// tests. Not for production callers.
+func WriteSessionMetaForTest(dir string, pid int, sessionID string, mtime time.Time) error {
+	data, err := json.Marshal(claudeSessionMeta{PID: pid, SessionID: sessionID})
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, strconv.Itoa(pid)+".json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return err
+	}
+	return os.Chtimes(path, mtime, mtime)
+}
+
 // ReplaceTestDeps swaps DiscoverPID's filesystem dependencies (sessionsDir,
 // pidAlive, discoverByCWD) with caller-provided stubs and returns a closure
 // that restores the originals. Intended only for tests in other packages

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -2,10 +2,8 @@ package services_test
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -1341,15 +1339,8 @@ func TestSessionDetector_ClearWithStaleMetadata_DeletesOldSessionImmediately(t *
 	// the OLD sessionId — simulating Claude's post-/clear behaviour where
 	// <pid>.json lingers on the previous session for up to ~2 min.
 	sessionsDir := t.TempDir()
-	staleMeta := map[string]any{"pid": myPID, "sessionId": "sess-old"}
-	data, _ := json.Marshal(staleMeta)
-	metaPath := filepath.Join(sessionsDir, strconv.Itoa(myPID)+".json")
-	if err := os.WriteFile(metaPath, data, 0o644); err != nil {
+	if err := claudecode.WriteSessionMetaForTest(sessionsDir, myPID, "sess-old", time.Now().Add(-30*time.Second)); err != nil {
 		t.Fatalf("write stale meta: %v", err)
-	}
-	past := time.Now().Add(-30 * time.Second)
-	if err := os.Chtimes(metaPath, past, past); err != nil {
-		t.Fatalf("chtimes: %v", err)
 	}
 
 	// Real transcript file so DiscoverPID can stat its mtime (fresh, > stale
@@ -1421,7 +1412,9 @@ func TestSessionDetector_ClearWithStaleMetadata_DeletesOldSessionImmediately(t *
 		TranscriptPath: newTranscript,
 	}
 
-	// Allow retries (500ms + 1s + 2s = 3.5s window).
+	// 300ms covers the immediate synchronous discovery attempt; retries at
+	// 500ms/1s/2s aren't needed — DiscoverPID must succeed on the first try
+	// once the mtime gate lets it past the stale metadata.
 	time.Sleep(300 * time.Millisecond)
 	cancel()
 	<-done

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -2,11 +2,14 @@ package services_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
+	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/application/services"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/lifecycle"
@@ -1318,6 +1321,120 @@ func TestSessionDetector_CWDFallback_CleansUpOldSessionOnClear(t *testing.T) {
 	}
 	if stateB.PID != myPID {
 		t.Errorf("sess-b PID: got %d, want %d", stateB.PID, myPID)
+	}
+}
+
+// TestSessionDetector_ClearWithStaleMetadata_DeletesOldSessionImmediately is the
+// end-to-end regression for #169. It drives the real claudecode.DiscoverPID
+// with a stale ~/.claude/sessions/<pid>.json pointing at the old session and
+// asserts the full pipeline — DiscoverPIDWithRetry → HandlePIDAssigned →
+// same-PID cleanup — deletes the old session within the retry window.
+func TestSessionDetector_ClearWithStaleMetadata_DeletesOldSessionImmediately(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	// Use our own PID so seedFromDisk doesn't delete sess-old as a dead process.
+	myPID := os.Getpid()
+
+	// Install a fake sessionsDir with a stale metadata file that points at
+	// the OLD sessionId — simulating Claude's post-/clear behaviour where
+	// <pid>.json lingers on the previous session for up to ~2 min.
+	sessionsDir := t.TempDir()
+	staleMeta := map[string]any{"pid": myPID, "sessionId": "sess-old"}
+	data, _ := json.Marshal(staleMeta)
+	metaPath := filepath.Join(sessionsDir, strconv.Itoa(myPID)+".json")
+	if err := os.WriteFile(metaPath, data, 0o644); err != nil {
+		t.Fatalf("write stale meta: %v", err)
+	}
+	past := time.Now().Add(-30 * time.Second)
+	if err := os.Chtimes(metaPath, past, past); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	// Real transcript file so DiscoverPID can stat its mtime (fresh, > stale
+	// metadata + staleMetaSlack). Without a real file, the mtime gate would
+	// be inert and current negative-filter behaviour would keep applying.
+	transcriptDir := t.TempDir()
+	newTranscript := filepath.Join(transcriptDir, "sess-new.jsonl")
+	if err := os.WriteFile(newTranscript, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	restore := claudecode.ReplaceTestDeps(
+		sessionsDir,
+		func(pid int) bool { return pid == myPID },
+		func(_ string, _ string, disambiguate func([]int) int) (int, error) {
+			return disambiguate([]int{myPID}), nil
+		},
+	)
+	defer restore()
+
+	discovers := map[string]services.PIDDiscoverFunc{
+		"claude-code": claudecode.DiscoverPID,
+	}
+	det := services.NewSessionDetector(
+		[]inbound.AgentWatcher{tw}, pw, repo,
+		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
+		"test", 0, discovers,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	// Wait for seedFromDisk before injecting state.
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+
+	// Old session from before /clear — holds the live PID.
+	repo.Save(&session.SessionState{
+		SessionID:      "sess-old",
+		Adapter:        "claude-code",
+		State:          session.StateWorking,
+		PID:            myPID,
+		TranscriptPath: "/home/.claude/projects/-Users-test/sess-old.jsonl",
+		CWD:            "/Users/test/project",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	})
+
+	// New session from after /clear — PID not yet discovered, fresh transcript.
+	repo.Save(&session.SessionState{
+		SessionID:      "sess-new",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		TranscriptPath: newTranscript,
+		CWD:            "/Users/test/project",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	})
+
+	// Activity on sess-new triggers PID discovery. The real DiscoverPID must
+	// see the stale metadata, skip the negative filter (mtime gate), return
+	// myPID via the CWD stub, and fire HandlePIDAssigned's same-PID cleanup.
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "sess-new",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: newTranscript,
+	}
+
+	// Allow retries (500ms + 1s + 2s = 3.5s window).
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	<-done
+
+	if stateOld, _ := repo.Load("sess-old"); stateOld != nil {
+		t.Error("sess-old should be deleted (stale metadata must not block /clear cleanup)")
+	}
+	stateNew, _ := repo.Load("sess-new")
+	if stateNew == nil {
+		t.Fatal("sess-new should exist")
+	}
+	if stateNew.PID != myPID {
+		t.Errorf("sess-new PID: got %d, want %d", stateNew.PID, myPID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes #169: after `/clear` in Claude Code, the old session lingered ~2 min in Irrlicht's UI before being replaced.
- `DiscoverPID` now gates the `claimedByOthers` negative filter on metadata mtime: a `~/.claude/sessions/<pid>.json` whose mtime trails the caller's transcript mtime by more than 2s is treated as positive-only, not as a hard exclude for CWD fallback.
- Existing #109 protection against PID stealing between concurrent same-CWD sessions is preserved — fresh metadata still excludes the PID.

## Root cause

Claude keeps the same OS process on `/clear` but starts a new transcript sessionId. Its own `<pid>.json` can still point at the old sessionId for ~2 min. Irrlicht's negative filter treated that stale entry as authoritative, so the CWD fallback refused to bind the live PID to the new session. `HandlePIDAssigned`'s same-PID cleanup never ran. The old session only disappeared when its transcript aged past `orphanTranscriptAge = 2m`.

With the gate, the new session claims the PID within the existing 3.5s retry window, same-PID cleanup fires, and the old session disappears in seconds.

## Test plan

- [x] `go test ./core/adapters/inbound/agents/claudecode/...` — 3 new tests + 10 existing all green
  - `TestDiscoverPID_StaleMetadataDoesNotBlockCWDFallback` — direct #169 regression
  - `TestDiscoverPID_FreshMetadataStillBlocksConcurrentSession` — #109 guard
  - `TestDiscoverPID_NoTranscriptFileFallsBackSafely` — gate-inert path
- [x] `go test ./core/...` — full suite green (including `session_detector_test.go` /clear and CWD-fallback tests at lines 1101–1367)
- [ ] Manual: build+restart on macOS, open Claude Code, `/clear`, confirm old session disappears within seconds (was ~2 min). Verify log shows `"replaced by new session … (same pid …) — deleting"` firing promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)