### PR TITLE
fix(capacity): retry LiteLLM fetch with backoff when offline at startup

### DIFF
--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -121,24 +121,7 @@ func main() {
 	}
 	logger.LogInfo("startup", "", fmt.Sprintf("max session age: %s", cfg.MaxSessionAge))
 
-	// Background model capacity refresh from LiteLLM.
-	go func() {
-		if n, err := capacity.RefreshRemoteDataIfStale(); err != nil {
-			logger.LogError("capacity", "", fmt.Sprintf("remote refresh failed: %v", err))
-		} else if n > 0 {
-			logger.LogInfo("capacity", "", fmt.Sprintf("cached %d remote models from LiteLLM", n))
-		}
-
-		ticker := time.NewTicker(24 * time.Hour)
-		defer ticker.Stop()
-		for range ticker.C {
-			if n, err := capacity.RefreshRemoteDataIfStale(); err != nil {
-				logger.LogError("capacity", "", fmt.Sprintf("remote refresh failed: %v", err))
-			} else if n > 0 {
-				logger.LogInfo("capacity", "", fmt.Sprintf("cached %d remote models from LiteLLM", n))
-			}
-		}
-	}()
+	go runCapacityRefreshLoop(context.Background(), logger, 30*time.Second, 256*time.Minute, 24*time.Hour)
 
 	// Resolve the gt binary path (GT_BIN env → common paths → which gt).
 	gtResolver := gtbin.New()
@@ -461,6 +444,47 @@ func main() {
 
 	if err := srv.Shutdown(ctx); err != nil {
 		logger.LogError("shutdown", "", fmt.Sprintf("graceful shutdown error: %v", err))
+	}
+}
+
+// runCapacityRefreshLoop keeps the LiteLLM model-capacity cache current,
+// retrying failed fetches with exponential backoff so a daemon started
+// offline recovers as soon as connectivity returns (rather than waiting
+// the full successInterval for the next attempt).
+func runCapacityRefreshLoop(ctx context.Context, logger outbound.Logger, initialBackoff, maxBackoff, successInterval time.Duration) {
+	backoff := initialBackoff
+	for {
+		if !capacity.IsCacheStale() {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(successInterval):
+			}
+			continue
+		}
+
+		config, err := capacity.FetchAndCacheLiteLLMData()
+		if err != nil {
+			logger.LogError("capacity", "", fmt.Sprintf("remote refresh failed (retry in %s): %v", backoff, err))
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
+		}
+
+		logger.LogInfo("capacity", "", fmt.Sprintf("cached %d remote models from LiteLLM", len(config.Models)))
+		backoff = initialBackoff
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(successInterval):
+		}
 	}
 }
 

--- a/core/cmd/irrlichd/main_test.go
+++ b/core/cmd/irrlichd/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -9,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -18,6 +21,7 @@ import (
 	wshub "irrlicht/core/adapters/outbound/websocket"
 	"irrlicht/core/application/services"
 	"irrlicht/core/domain/session"
+	"irrlicht/core/pkg/capacity"
 )
 
 func newTestStack(t *testing.T) (*httptest.Server, *filesystem.SessionRepository) {
@@ -309,6 +313,95 @@ func writeCostRow(t *testing.T, costDir, project string, ts int64, sessionID str
 	if _, err := f.WriteString(line); err != nil {
 		t.Fatalf("write: %v", err)
 	}
+}
+
+// TestRunCapacityRefreshLoop_RetriesUntilSuccess verifies that a server
+// failing the first few requests is retried with backoff until it recovers,
+// after which the cache file is written.
+func TestRunCapacityRefreshLoop_RetriesUntilSuccess(t *testing.T) {
+	var hits atomic.Int32
+	const failUntil = 3
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		if n <= failUntil {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"claude-sonnet-4-6": {
+				"max_input_tokens": 200000,
+				"max_output_tokens": 64000,
+				"input_cost_per_token": 0.000003,
+				"output_cost_per_token": 0.000015,
+				"litellm_provider": "anthropic",
+				"mode": "chat"
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	capacity.SetLiteLLMURLForTest(t, srv.URL)
+	t.Setenv("HOME", t.TempDir())
+
+	logger := &capturingLogger{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		runCapacityRefreshLoop(ctx, logger, 5*time.Millisecond, 50*time.Millisecond, time.Hour)
+		close(done)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && !logger.hasInfo() {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !logger.hasInfo() {
+		t.Fatalf("expected success log within 5s; errors=%d", logger.errorCount())
+	}
+	if got := logger.errorCount(); got < failUntil {
+		t.Errorf("expected at least %d error logs before success, got %d", failUntil, got)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not exit after context cancel")
+	}
+}
+
+type capturingLogger struct {
+	mu     sync.Mutex
+	infos  []string
+	errors []string
+}
+
+func (l *capturingLogger) LogInfo(eventType, sessionID, message string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.infos = append(l.infos, message)
+}
+func (l *capturingLogger) LogError(eventType, sessionID, errorMsg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.errors = append(l.errors, errorMsg)
+}
+func (l *capturingLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (l *capturingLogger) Close() error                                         { return nil }
+
+func (l *capturingLogger) hasInfo() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.infos) > 0
+}
+func (l *capturingLogger) errorCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.errors)
 }
 
 // TestGate_UIServed verifies that GET / returns 200 with HTML content.

--- a/core/pkg/capacity/remote.go
+++ b/core/pkg/capacity/remote.go
@@ -12,10 +12,22 @@ import (
 )
 
 const (
-	liteLLMURL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
-	cacheTTL   = 24 * time.Hour
-	cacheFile  = "model-capacity-cache.json"
+	cacheTTL  = 24 * time.Hour
+	cacheFile = "model-capacity-cache.json"
 )
+
+// liteLLMURL is a var (not const) so tests can redirect fetches to an
+// httptest.Server. Production callers must not mutate it.
+var liteLLMURL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+
+// SetLiteLLMURLForTest redirects the LiteLLM fetch URL for the duration of
+// the test, restoring it on cleanup. Exists because cross-package tests
+// (e.g. the irrlichd refresh loop) need to stub the endpoint.
+func SetLiteLLMURLForTest(t interface{ Cleanup(func()) }, url string) {
+	orig := liteLLMURL
+	liteLLMURL = url
+	t.Cleanup(func() { liteLLMURL = orig })
+}
 
 // liteLLMEntry represents a single model entry from LiteLLM's JSON.
 type liteLLMEntry struct {

--- a/core/pkg/capacity/remote_test.go
+++ b/core/pkg/capacity/remote_test.go
@@ -2,6 +2,8 @@ package capacity
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -252,6 +254,82 @@ func getViaPath(t *testing.T, cm *CapacityManager) *CapacityManager {
 	cm.lastModified = info.ModTime()
 	cm.mu.Unlock()
 	return cm
+}
+
+// TestFetchAndCacheLiteLLMData_WritesCache verifies the end-to-end fetch +
+// cache-to-disk path against a stubbed LiteLLM endpoint. This is the success
+// leg of the retry loop.
+func TestFetchAndCacheLiteLLMData_WritesCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"claude-sonnet-4-6": {
+				"max_input_tokens": 200000,
+				"max_output_tokens": 64000,
+				"input_cost_per_token": 0.000003,
+				"output_cost_per_token": 0.000015,
+				"litellm_provider": "anthropic",
+				"mode": "chat"
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	SetLiteLLMURLForTest(t, srv.URL)
+	withTempHome(t)
+
+	config, err := FetchAndCacheLiteLLMData()
+	if err != nil {
+		t.Fatalf("FetchAndCacheLiteLLMData: %v", err)
+	}
+	if _, ok := config.Models["claude-sonnet-4-6"]; !ok {
+		t.Fatalf("expected claude-sonnet-4-6 in returned config")
+	}
+
+	path, _ := CachePath()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("cache file not written: %v", err)
+	}
+}
+
+// TestLoadCachedRemoteData_OfflineFallback verifies that a previously
+// written cache file is returned by LoadCachedRemoteData — the path the
+// daemon relies on when starting without network connectivity.
+func TestLoadCachedRemoteData_OfflineFallback(t *testing.T) {
+	withTempHome(t)
+
+	path, _ := CachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cached := cachedCapacity{
+		FetchedAt: time.Now(),
+		Config: CapacityConfig{
+			Models: map[string]ModelCapacity{
+				"claude-sonnet-4-6": {ContextWindow: 200000},
+			},
+		},
+	}
+	data, _ := json.Marshal(cached)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	got := LoadCachedRemoteData()
+	if got == nil {
+		t.Fatal("LoadCachedRemoteData returned nil despite a fresh cache file")
+	}
+	if got.Models["claude-sonnet-4-6"].ContextWindow != 200000 {
+		t.Errorf("cached ContextWindow = %d, want 200000", got.Models["claude-sonnet-4-6"].ContextWindow)
+	}
+}
+
+// withTempHome points os.UserHomeDir() at a tempdir so CachePath() writes
+// are isolated per test.
+func withTempHome(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
 }
 
 func TestConcurrentGet_NoPanicUnderConcurrentReload(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replaces the flat 24h ticker in `irrlichd` with an exponential-backoff retry loop (30s → 60s → 2m → 4m → 8m → 16m → 32m → 64m → 128m → 256m cap) so a daemon that starts offline recovers as soon as connectivity returns.
- Guards the loop with `IsCacheStale()` so daemon restarts within 24h still skip the network call and reuse the on-disk cache.
- Adds cross-package test support by promoting `liteLLMURL` from `const` → `var` and exposing `SetLiteLLMURLForTest`.

Fixes #177.

## Test plan
- [x] `go test -race ./pkg/capacity/ ./cmd/irrlichd/` — passes
- [x] New unit test drives the real retry loop against an `httptest.Server` that fails three times before succeeding; asserts ≥3 error logs and a success log
- [x] New regression test confirms `LoadCachedRemoteData` returns a previously written cache file (offline-fallback path)
- [ ] Manual: disconnect network → launch daemon → observe retry logs with backoff → reconnect → confirm `cached N remote models from LiteLLM` log

🤖 Generated with [Claude Code](https://claude.com/claude-code)