### PR TITLE
feat(history): agent history bar with server-side interval aggregation

### DIFF
--- a/core/application/services/history_tracker.go
+++ b/core/application/services/history_tracker.go
@@ -9,7 +9,9 @@ import (
 )
 
 const (
-	historyBucketCount = 150
+	// HistoryBucketCount is the number of buckets retained per granularity per
+	// session. At 1s granularity this is 2.5 min; at 60s it is 2.5 h.
+	HistoryBucketCount = 150
 
 	// statePriority maps state names to an integer so we can apply
 	// waiting > working > ready aggregation within a bucket.
@@ -19,6 +21,16 @@ const (
 )
 
 var validGranularities = []int{1, 10, 60}
+
+// validGranularity reports whether sec is an accepted granularity value (1, 10, or 60).
+func validGranularity(sec int) bool {
+	for _, g := range validGranularities {
+		if g == sec {
+			return true
+		}
+	}
+	return false
+}
 
 func statePriority(s string) int {
 	switch s {
@@ -33,7 +45,7 @@ func statePriority(s string) int {
 
 // ringBuffer is a fixed-size circular buffer of state strings.
 type ringBuffer struct {
-	buckets  [historyBucketCount]int8 // encoded priority; -1 = empty
+	buckets  [HistoryBucketCount]int8 // encoded priority; -1 = empty
 	head     int                      // next-write index
 	size     int                      // number of valid entries
 	tickMod  int                      // advance every tickMod global 1-s ticks
@@ -54,7 +66,7 @@ func (rb *ringBuffer) current() int {
 	if rb.size == 0 {
 		return -1
 	}
-	return (rb.head - 1 + historyBucketCount) % historyBucketCount
+	return (rb.head - 1 + HistoryBucketCount) % HistoryBucketCount
 }
 
 // upgrade writes the highest-priority state into the current open bucket.
@@ -63,7 +75,7 @@ func (rb *ringBuffer) upgrade(newState string) {
 	if rb.size == 0 {
 		// Initialise first bucket.
 		rb.buckets[rb.head] = p
-		rb.head = (rb.head + 1) % historyBucketCount
+		rb.head = (rb.head + 1) % HistoryBucketCount
 		rb.size = 1
 	} else {
 		cur := rb.current()
@@ -85,8 +97,8 @@ func (rb *ringBuffer) tick() {
 	// Carry forward the last known state into the new bucket.
 	p := int8(statePriority(rb.lastState))
 	rb.buckets[rb.head] = p
-	rb.head = (rb.head + 1) % historyBucketCount
-	if rb.size < historyBucketCount {
+	rb.head = (rb.head + 1) % HistoryBucketCount
+	if rb.size < HistoryBucketCount {
 		rb.size++
 	}
 }
@@ -97,9 +109,9 @@ func (rb *ringBuffer) snapshot() []string {
 		return nil
 	}
 	out := make([]string, rb.size)
-	start := (rb.head - rb.size + historyBucketCount) % historyBucketCount
+	start := (rb.head - rb.size + HistoryBucketCount) % HistoryBucketCount
 	for i := 0; i < rb.size; i++ {
-		out[i] = priorityToState(rb.buckets[(start+i)%historyBucketCount])
+		out[i] = priorityToState(rb.buckets[(start+i)%HistoryBucketCount])
 	}
 	return out
 }
@@ -233,12 +245,3 @@ func (h *HistoryTracker) tick() {
 	}
 }
 
-// ValidGranularity reports whether sec is an accepted granularity value.
-func ValidGranularity(sec int) bool {
-	for _, g := range validGranularities {
-		if g == sec {
-			return true
-		}
-	}
-	return false
-}

--- a/core/application/services/history_tracker.go
+++ b/core/application/services/history_tracker.go
@@ -1,0 +1,244 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+const (
+	historyBucketCount = 150
+
+	// statePriority maps state names to an integer so we can apply
+	// waiting > working > ready aggregation within a bucket.
+	statePriorityReady   = 0
+	statePriorityWorking = 1
+	statePriorityWaiting = 2
+)
+
+var validGranularities = []int{1, 10, 60}
+
+func statePriority(s string) int {
+	switch s {
+	case session.StateWaiting:
+		return statePriorityWaiting
+	case session.StateWorking:
+		return statePriorityWorking
+	default:
+		return statePriorityReady
+	}
+}
+
+// ringBuffer is a fixed-size circular buffer of state strings.
+type ringBuffer struct {
+	buckets  [historyBucketCount]int8 // encoded priority; -1 = empty
+	head     int                      // next-write index
+	size     int                      // number of valid entries
+	tickMod  int                      // advance every tickMod global 1-s ticks
+	tickAcc  int                      // accumulator towards tickMod
+	lastState string                  // carry-forward: last state before current open bucket
+}
+
+func newRingBuffer(granularitySec int) *ringBuffer {
+	rb := &ringBuffer{tickMod: granularitySec}
+	for i := range rb.buckets {
+		rb.buckets[i] = -1
+	}
+	return rb
+}
+
+// current returns the index of the currently open (not yet finalised) bucket.
+func (rb *ringBuffer) current() int {
+	if rb.size == 0 {
+		return -1
+	}
+	return (rb.head - 1 + historyBucketCount) % historyBucketCount
+}
+
+// upgrade writes the highest-priority state into the current open bucket.
+func (rb *ringBuffer) upgrade(newState string) {
+	p := int8(statePriority(newState))
+	if rb.size == 0 {
+		// Initialise first bucket.
+		rb.buckets[rb.head] = p
+		rb.head = (rb.head + 1) % historyBucketCount
+		rb.size = 1
+	} else {
+		cur := rb.current()
+		if p > rb.buckets[cur] {
+			rb.buckets[cur] = p
+		}
+	}
+	rb.lastState = newState
+}
+
+// tick advances the buffer by one global 1-second tick.
+func (rb *ringBuffer) tick() {
+	rb.tickAcc++
+	if rb.tickAcc < rb.tickMod {
+		return
+	}
+	rb.tickAcc = 0
+
+	// Carry forward the last known state into the new bucket.
+	p := int8(statePriority(rb.lastState))
+	rb.buckets[rb.head] = p
+	rb.head = (rb.head + 1) % historyBucketCount
+	if rb.size < historyBucketCount {
+		rb.size++
+	}
+}
+
+// snapshot returns all valid entries oldest→newest as state strings.
+func (rb *ringBuffer) snapshot() []string {
+	if rb.size == 0 {
+		return nil
+	}
+	out := make([]string, rb.size)
+	start := (rb.head - rb.size + historyBucketCount) % historyBucketCount
+	for i := 0; i < rb.size; i++ {
+		out[i] = priorityToState(rb.buckets[(start+i)%historyBucketCount])
+	}
+	return out
+}
+
+func priorityToState(p int8) string {
+	switch p {
+	case statePriorityWaiting:
+		return session.StateWaiting
+	case statePriorityWorking:
+		return session.StateWorking
+	default:
+		return session.StateReady
+	}
+}
+
+// sessionBuffers holds one ring buffer per supported granularity.
+type sessionBuffers struct {
+	mu  sync.Mutex
+	bufs [3]*ringBuffer // index 0=1s, 1=10s, 2=60s
+}
+
+func newSessionBuffers() *sessionBuffers {
+	return &sessionBuffers{
+		bufs: [3]*ringBuffer{
+			newRingBuffer(1),
+			newRingBuffer(10),
+			newRingBuffer(60),
+		},
+	}
+}
+
+func granularityIndex(sec int) int {
+	switch sec {
+	case 10:
+		return 1
+	case 60:
+		return 2
+	default:
+		return 0
+	}
+}
+
+// HistoryTracker maintains per-session rolling state buffers in memory for as
+// long as the daemon runs. Three granularities (1 s / 10 s / 60 s) are kept in
+// parallel; within each bucket, priority aggregation (waiting > working > ready)
+// determines the displayed state.
+type HistoryTracker struct {
+	mu       sync.Mutex
+	sessions map[string]*sessionBuffers
+}
+
+// NewHistoryTracker creates a HistoryTracker ready for use. Call Run(ctx) to
+// start the internal 1-second ticker.
+func NewHistoryTracker() *HistoryTracker {
+	return &HistoryTracker{
+		sessions: make(map[string]*sessionBuffers),
+	}
+}
+
+// OnTransition records a state transition, upgrading all three buffers' current
+// open buckets if the new state has higher priority.
+func (h *HistoryTracker) OnTransition(sessionID, newState string, _ time.Time) {
+	h.mu.Lock()
+	sb, ok := h.sessions[sessionID]
+	if !ok {
+		sb = newSessionBuffers()
+		h.sessions[sessionID] = sb
+	}
+	h.mu.Unlock()
+
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	for _, rb := range sb.bufs {
+		rb.upgrade(newState)
+	}
+}
+
+// Snapshot returns the ring-buffer contents for a session at the given
+// granularity (1, 10, or 60 seconds), oldest→newest. Returns nil, false when
+// the session is unknown.
+func (h *HistoryTracker) Snapshot(sessionID string, granularitySec int) ([]string, bool) {
+	h.mu.Lock()
+	sb, ok := h.sessions[sessionID]
+	h.mu.Unlock()
+	if !ok {
+		return nil, false
+	}
+
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	idx := granularityIndex(granularitySec)
+	return sb.bufs[idx].snapshot(), true
+}
+
+// Remove drops all buffers for a session when it is deleted.
+func (h *HistoryTracker) Remove(sessionID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.sessions, sessionID)
+}
+
+// Run starts the internal 1-second ticker that advances all ring buffers.
+// Blocks until ctx is cancelled.
+func (h *HistoryTracker) Run(ctx context.Context) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.tick()
+		}
+	}
+}
+
+func (h *HistoryTracker) tick() {
+	h.mu.Lock()
+	sbs := make([]*sessionBuffers, 0, len(h.sessions))
+	for _, sb := range h.sessions {
+		sbs = append(sbs, sb)
+	}
+	h.mu.Unlock()
+
+	for _, sb := range sbs {
+		sb.mu.Lock()
+		for _, rb := range sb.bufs {
+			rb.tick()
+		}
+		sb.mu.Unlock()
+	}
+}
+
+// ValidGranularity reports whether sec is an accepted granularity value.
+func ValidGranularity(sec int) bool {
+	for _, g := range validGranularities {
+		if g == sec {
+			return true
+		}
+	}
+	return false
+}

--- a/core/application/services/history_tracker_test.go
+++ b/core/application/services/history_tracker_test.go
@@ -1,0 +1,132 @@
+package services
+
+import (
+	"testing"
+	"time"
+)
+
+var epoch = time.Unix(0, 0)
+
+func TestHistoryTracker_PriorityAggregation(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "test-session"
+
+	// Within a single bucket: waiting overrides working overrides ready.
+	ht.OnTransition(sid, "ready", epoch)
+	ht.OnTransition(sid, "working", epoch)
+	ht.OnTransition(sid, "waiting", epoch)
+	ht.OnTransition(sid, "working", epoch)
+
+	snap, ok := ht.Snapshot(sid, 1)
+	if !ok {
+		t.Fatal("snapshot not found")
+	}
+	if len(snap) < 1 {
+		t.Fatal("snapshot empty")
+	}
+	last := snap[len(snap)-1]
+	if last != "waiting" {
+		t.Errorf("expected waiting, got %q", last)
+	}
+}
+
+func TestHistoryTracker_BucketRollover(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "rollover"
+
+	ht.OnTransition(sid, "working", epoch)
+
+	// Advance past one 1-second bucket.
+	ht.tick()
+
+	// Now a fresh bucket is open, seeded with carry-forward ("working").
+	// Another transition should affect only the new bucket.
+	ht.OnTransition(sid, "ready", epoch)
+
+	snap, ok := ht.Snapshot(sid, 1)
+	if !ok {
+		t.Fatal("snapshot not found")
+	}
+	if len(snap) < 2 {
+		t.Fatalf("expected ≥2 buckets, got %d", len(snap))
+	}
+	// First bucket: working
+	if snap[0] != "working" {
+		t.Errorf("bucket[0] = %q, want working", snap[0])
+	}
+	// Second bucket started as carry-forward "working" but then received "ready"
+	// which has lower priority — so it stays "working".
+	if snap[1] != "working" {
+		t.Errorf("bucket[1] = %q, want working (carry-forward wins)", snap[1])
+	}
+}
+
+func TestHistoryTracker_SnapshotOldestNewest(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "order"
+
+	states := []string{"ready", "working", "waiting"}
+	for _, s := range states {
+		ht.OnTransition(sid, s, epoch)
+		ht.tick()
+	}
+
+	snap, ok := ht.Snapshot(sid, 1)
+	if !ok {
+		t.Fatal("snapshot not found")
+	}
+	// The sequence must be oldest→newest. Because carry-forward within each
+	// bucket wins and we transitioned: ready → working → waiting, the last
+	// finalised bucket should be the highest across those ticks.
+	if len(snap) < 3 {
+		t.Fatalf("expected ≥3 entries, got %d", len(snap))
+	}
+}
+
+func TestHistoryTracker_Remove(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "to-remove"
+
+	ht.OnTransition(sid, "working", epoch)
+	ht.Remove(sid)
+
+	_, ok := ht.Snapshot(sid, 1)
+	if ok {
+		t.Error("expected snapshot to be gone after Remove")
+	}
+}
+
+func TestHistoryTracker_GranularityVariants(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "gran"
+
+	ht.OnTransition(sid, "waiting", epoch)
+
+	for _, g := range []int{1, 10, 60} {
+		snap, ok := ht.Snapshot(sid, g)
+		if !ok {
+			t.Errorf("granularity %d: snapshot not found", g)
+			continue
+		}
+		if len(snap) == 0 {
+			t.Errorf("granularity %d: empty snapshot", g)
+			continue
+		}
+		if snap[len(snap)-1] != "waiting" {
+			t.Errorf("granularity %d: got %q, want waiting", g, snap[len(snap)-1])
+		}
+	}
+}
+
+func TestValidGranularity(t *testing.T) {
+	for _, g := range []int{1, 10, 60} {
+		if !ValidGranularity(g) {
+			t.Errorf("expected %d to be valid", g)
+		}
+	}
+	for _, g := range []int{0, 2, 5, 30, 100} {
+		if ValidGranularity(g) {
+			t.Errorf("expected %d to be invalid", g)
+		}
+	}
+}

--- a/core/application/services/history_tracker_test.go
+++ b/core/application/services/history_tracker_test.go
@@ -65,8 +65,11 @@ func TestHistoryTracker_SnapshotOldestNewest(t *testing.T) {
 	ht := NewHistoryTracker()
 	sid := "order"
 
-	states := []string{"ready", "working", "waiting"}
-	for _, s := range states {
+	// Transition, then tick to seal each bucket before the next transition.
+	// Bucket 0: "ready" (only transition), sealed by tick.
+	// Bucket 1: starts with carry-forward "ready", then "working" upgrades it → "working", sealed.
+	// Bucket 2: starts with carry-forward "working", then "waiting" upgrades it → "waiting", open.
+	for _, s := range []string{"ready", "working", "waiting"} {
 		ht.OnTransition(sid, s, epoch)
 		ht.tick()
 	}
@@ -75,11 +78,16 @@ func TestHistoryTracker_SnapshotOldestNewest(t *testing.T) {
 	if !ok {
 		t.Fatal("snapshot not found")
 	}
-	// The sequence must be oldest→newest. Because carry-forward within each
-	// bucket wins and we transitioned: ready → working → waiting, the last
-	// finalised bucket should be the highest across those ticks.
 	if len(snap) < 3 {
 		t.Fatalf("expected ≥3 entries, got %d", len(snap))
+	}
+
+	// oldest → newest: ready, working, waiting
+	want := []string{"ready", "working", "waiting"}
+	for i, w := range want {
+		if snap[i] != w {
+			t.Errorf("snap[%d] = %q, want %q", i, snap[i], w)
+		}
 	}
 }
 
@@ -120,12 +128,12 @@ func TestHistoryTracker_GranularityVariants(t *testing.T) {
 
 func TestValidGranularity(t *testing.T) {
 	for _, g := range []int{1, 10, 60} {
-		if !ValidGranularity(g) {
+		if !validGranularity(g) {
 			t.Errorf("expected %d to be valid", g)
 		}
 	}
 	for _, g := range []int{0, 2, 5, 30, 100} {
-		if ValidGranularity(g) {
+		if validGranularity(g) {
 			t.Errorf("expected %d to be invalid", g)
 		}
 	}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -205,7 +205,6 @@ func (d *SessionDetector) recordCost(state *session.SessionState) {
 
 // record emits a lifecycle event if recording is enabled. It assigns a
 // monotonic sequence number and fills in the timestamp if missing.
-// As a side-effect, state transitions are fed to the optional HistoryTracker.
 func (d *SessionDetector) record(ev lifecycle.Event) {
 	if ev.Kind == lifecycle.KindStateTransition && ev.NewState != "" && d.historyTracker != nil {
 		ts := ev.Timestamp

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -890,6 +890,9 @@ func (d *SessionDetector) removeFromProjectSessions(sessionID string) {
 	delete(d.projectSessions, sessionID)
 	d.deletedSessions[sessionID] = time.Now().Unix()
 	d.mu.Unlock()
+	if d.historyTracker != nil {
+		d.historyTracker.Remove(sessionID)
+	}
 }
 
 // broadcast sends a push notification if a broadcaster is configured. For

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -75,7 +75,8 @@ type SessionDetector struct {
 
 	enricher    *MetadataEnricher
 	pidMgr      *PIDManager
-	costTracker outbound.CostTracker // optional; nil = disabled
+	costTracker    outbound.CostTracker    // optional; nil = disabled
+	historyTracker outbound.HistoryTracker // optional; nil = disabled
 
 	// projectSessions tracks sessionID → projectDir for pre-session cleanup.
 	mu              sync.Mutex
@@ -179,6 +180,12 @@ func (d *SessionDetector) SetCostTracker(c outbound.CostTracker) {
 	d.costTracker = c
 }
 
+// SetHistoryTracker wires an optional HistoryTracker that records per-session
+// state-transition timelines in memory. Pass nil to disable.
+func (d *SessionDetector) SetHistoryTracker(h outbound.HistoryTracker) {
+	d.historyTracker = h
+}
+
 // SetLauncherEnvReader installs a reader that captures terminal/IDE identity
 // from a session's PID when the PID is first assigned.
 func (d *SessionDetector) SetLauncherEnvReader(fn LauncherEnvReader) {
@@ -198,7 +205,15 @@ func (d *SessionDetector) recordCost(state *session.SessionState) {
 
 // record emits a lifecycle event if recording is enabled. It assigns a
 // monotonic sequence number and fills in the timestamp if missing.
+// As a side-effect, state transitions are fed to the optional HistoryTracker.
 func (d *SessionDetector) record(ev lifecycle.Event) {
+	if ev.Kind == lifecycle.KindStateTransition && ev.NewState != "" && d.historyTracker != nil {
+		ts := ev.Timestamp
+		if ts.IsZero() {
+			ts = time.Now()
+		}
+		d.historyTracker.OnTransition(ev.SessionID, ev.NewState, ts)
+	}
 	if d.recorder == nil {
 		return
 	}
@@ -735,6 +750,10 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	}
 
 	d.broadcast(outbound.PushTypeUpdated, state)
+
+	if d.historyTracker != nil {
+		d.historyTracker.Remove(ev.SessionID)
+	}
 }
 
 // HandleProcessExit deletes a session when its process exits.

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -189,11 +189,9 @@ func main() {
 	// History tracker: per-session rolling ring buffers for 1s/10s/60s
 	// granularity, kept in memory while the daemon runs.
 	historyTracker := services.NewHistoryTracker()
-	{
-		histCtx, histCancel := context.WithCancel(context.Background())
-		defer histCancel()
-		go historyTracker.Run(histCtx)
-	}
+	histCtx, histCancel := context.WithCancel(context.Background())
+	defer histCancel()
+	go historyTracker.Run(histCtx)
 
 	// Push broadcaster for WebSocket fan-out.
 	push := services.NewPushService()
@@ -608,7 +606,7 @@ func handleGetSessionsHistory(repo outbound.SessionRepository, ht outbound.Histo
 
 		resp := historyResponse{
 			GranularitySec: granularity,
-			BucketCount:    150,
+			BucketCount:    services.HistoryBucketCount,
 			Sessions:       out,
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -186,6 +186,15 @@ func main() {
 		}
 	}
 
+	// History tracker: per-session rolling ring buffers for 1s/10s/60s
+	// granularity, kept in memory while the daemon runs.
+	historyTracker := services.NewHistoryTracker()
+	{
+		histCtx, histCancel := context.WithCancel(context.Background())
+		defer histCancel()
+		go historyTracker.Run(histCtx)
+	}
+
 	// Push broadcaster for WebSocket fan-out.
 	push := services.NewPushService()
 
@@ -322,6 +331,7 @@ func main() {
 
 	// Register API endpoints (after orchMonitor is available).
 	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(cachedRepo, orchMonitor, costTracker))
+	mux.HandleFunc("GET /api/v1/sessions/history", handleGetSessionsHistory(cachedRepo, historyTracker))
 
 	// Inbound adapters: watch agent transcript directories for session files.
 	claudeCodeWatcher := claudecode.New(cfg.MaxSessionAge)
@@ -386,6 +396,7 @@ func main() {
 	if costTracker != nil {
 		detector.SetCostTracker(costTracker)
 	}
+	detector.SetHistoryTracker(historyTracker)
 	// Capture terminal/IDE identity at first PID assignment so the menu-bar
 	// app can jump back to the launching terminal on row/notification click.
 	detector.SetLauncherEnvReader(processlifecycle.ReadLauncherEnv)
@@ -549,6 +560,56 @@ func handleGetSessions(repo outbound.SessionRepository, orchMonitor *services.Or
 		resp := session.BuildDashboard(sessions, orchMonitor.State("gastown"))
 		if tracker != nil {
 			attachGroupCosts(resp, tracker, cache)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// handleGetSessionsHistory serves pre-aggregated per-session state history at
+// a chosen granularity. Clients poll this endpoint at their own cadence to
+// populate history bars without bloating the WebSocket envelope.
+//
+// GET /api/v1/sessions/history?granularity=1|10|60
+func handleGetSessionsHistory(repo outbound.SessionRepository, ht outbound.HistoryTracker) http.HandlerFunc {
+	type historyResponse struct {
+		GranularitySec int                 `json:"granularity_sec"`
+		BucketCount    int                 `json:"bucket_count"`
+		Sessions       map[string][]string `json:"sessions"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		granularity := 1
+		if g := r.URL.Query().Get("granularity"); g != "" {
+			switch g {
+			case "10":
+				granularity = 10
+			case "60":
+				granularity = 60
+			case "1":
+				// default
+			default:
+				http.Error(w, "granularity must be 1, 10, or 60", http.StatusBadRequest)
+				return
+			}
+		}
+
+		sessions, err := repo.ListAll()
+		if err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+
+		out := make(map[string][]string, len(sessions))
+		for _, s := range sessions {
+			if snap, ok := ht.Snapshot(s.SessionID, granularity); ok {
+				out[s.SessionID] = snap
+			}
+		}
+
+		resp := historyResponse{
+			GranularitySec: granularity,
+			BucketCount:    150,
+			Sessions:       out,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -578,17 +579,12 @@ func handleGetSessionsHistory(repo outbound.SessionRepository, ht outbound.Histo
 	return func(w http.ResponseWriter, r *http.Request) {
 		granularity := 1
 		if g := r.URL.Query().Get("granularity"); g != "" {
-			switch g {
-			case "10":
-				granularity = 10
-			case "60":
-				granularity = 60
-			case "1":
-				// default
-			default:
+			n, err := strconv.Atoi(g)
+			if err != nil || (n != 1 && n != 10 && n != 60) {
 				http.Error(w, "granularity must be 1, 10, or 60", http.StatusBadRequest)
 				return
 			}
+			granularity = n
 		}
 
 		sessions, err := repo.ListAll()

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -2,6 +2,7 @@ package outbound
 
 import (
 	"context"
+	"time"
 
 	"irrlicht/core/domain/lifecycle"
 	"irrlicht/core/domain/session"
@@ -97,6 +98,20 @@ type CostTracker interface {
 	// Prune drops snapshot rows older than the given number of days.
 	// Safe to call periodically (e.g. daemon startup).
 	Prune(olderThanDays int) error
+}
+
+// HistoryTracker maintains per-session rolling state buffers for three
+// granularities (1s, 10s, 60s), using priority aggregation waiting>working>ready.
+// Implementations must be safe for concurrent use.
+type HistoryTracker interface {
+	// OnTransition records a state transition for a session, upgrading the
+	// current bucket's priority if the new state outranks the stored one.
+	OnTransition(sessionID, newState string, ts time.Time)
+	// Snapshot returns the ring-buffer contents for a session at the given
+	// granularity (1, 10, or 60), oldest→newest. Returns nil, false if unknown.
+	Snapshot(sessionID string, granularitySec int) ([]string, bool)
+	// Remove drops all buffers for a session.
+	Remove(sessionID string)
 }
 
 // ProcessWatcher monitors process PIDs via kqueue EVFILT_PROC NOTE_EXIT and

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -18,12 +18,15 @@ class SessionManager: ObservableObject {
     @Published var connectionState: ConnectionState = .disconnected
     @Published var lastError: String?
     @Published var apiGroups: [AgentGroup] = []  // recursive group structure from API
+    @Published var stateHistory: [String: [String]] = [:]  // session_id → oldest→newest state strings
 
     /// Timer that periodically re-hydrates sessions so group-level cost
     /// values (which only ride the /api/v1/sessions response) stay fresh —
     /// WebSocket deltas only carry individual session updates.
     private var projectCostsTimer: Timer?
     private let projectCostsRefreshInterval: TimeInterval = 30.0
+
+    private var historyTimer: Timer?
 
     private let instancesPath: URL
     private let orderFilePath: URL
@@ -238,6 +241,38 @@ class SessionManager: ObservableObject {
             Task { @MainActor [weak self] in
                 await self?.hydrateSessions()
             }
+        }
+    }
+
+    /// Starts periodic history polling at the specified granularity (1, 10, or 60 s).
+    func startHistoryPolling(granularitySec: Int) {
+        historyTimer?.invalidate()
+        let interval = TimeInterval(max(1, granularitySec))
+        Task { @MainActor [weak self] in await self?.fetchHistory(granularitySec: granularitySec) }
+        historyTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                await self?.fetchHistory(granularitySec: granularitySec)
+            }
+        }
+    }
+
+    func stopHistoryPolling() {
+        historyTimer?.invalidate()
+        historyTimer = nil
+    }
+
+    private func fetchHistory(granularitySec: Int) async {
+        guard let url = URL(string: "http://localhost:7837/api/v1/sessions/history?granularity=\(granularitySec)") else { return }
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else { return }
+            struct HistoryResponse: Decodable {
+                let sessions: [String: [String]]
+            }
+            let decoded = try JSONDecoder().decode(HistoryResponse.self, from: data)
+            stateHistory = decoded.sessions
+        } catch {
+            // Non-fatal: history is optional.
         }
     }
 

--- a/platforms/macos/Irrlicht/Views/HistoryBarView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryBarView.swift
@@ -13,27 +13,22 @@ struct HistoryBarView: View {
     let states: [String]  // oldest → newest
 
     var body: some View {
-        GeometryReader { geo in
-            if states.isEmpty {
-                RoundedRectangle(cornerRadius: 2)
-                    .fill(Color.secondary.opacity(0.12))
-            } else {
-                Canvas { context, size in
-                    let count = states.count
-                    let colW = size.width / CGFloat(count)
-                    for (i, state) in states.enumerated() {
-                        let color = stateColors[state] ?? stateColors["ready"]!
-                        let rect = CGRect(
-                            x: CGFloat(i) * colW,
-                            y: 0,
-                            width: max(colW - 0.5, 0.5),
-                            height: size.height
-                        )
-                        context.fill(Path(rect), with: .color(color))
-                    }
-                }
-                .clipShape(RoundedRectangle(cornerRadius: 2))
+        Canvas { context, size in
+            guard !states.isEmpty else { return }
+            let count = states.count
+            let colW = size.width / CGFloat(count)
+            for (i, state) in states.enumerated() {
+                let color = stateColors[state] ?? stateColors["ready"]!
+                let rect = CGRect(
+                    x: CGFloat(i) * colW,
+                    y: 0,
+                    width: max(colW - 0.5, 0.5),
+                    height: size.height
+                )
+                context.fill(Path(rect), with: .color(color))
             }
         }
+        .background(states.isEmpty ? Color.secondary.opacity(0.12) : .clear)
+        .clipShape(RoundedRectangle(cornerRadius: 2))
     }
 }

--- a/platforms/macos/Irrlicht/Views/HistoryBarView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryBarView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+// Colors match the web frontend palette and SessionState.State.color.
+private let stateColors: [String: Color] = [
+    "working": Color(hex: "#8B5CF6"),
+    "waiting": Color(hex: "#FF9500"),
+    "ready":   Color(hex: "#34C759"),
+]
+
+/// A compact horizontal bar that visualises per-session state history.
+/// Each bucket is a single coloured rectangle: purple=working, orange=waiting, green=ready.
+struct HistoryBarView: View {
+    let states: [String]  // oldest → newest
+
+    var body: some View {
+        GeometryReader { geo in
+            if states.isEmpty {
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color.secondary.opacity(0.12))
+            } else {
+                Canvas { context, size in
+                    let count = states.count
+                    let colW = size.width / CGFloat(count)
+                    for (i, state) in states.enumerated() {
+                        let color = stateColors[state] ?? stateColors["ready"]!
+                        let rect = CGRect(
+                            x: CGFloat(i) * colW,
+                            y: 0,
+                            width: max(colW - 0.5, 0.5),
+                            height: size.height
+                        )
+                        context.fill(Path(rect), with: .color(color))
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 2))
+            }
+        }
+    }
+}

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -210,6 +210,9 @@ struct SessionListView: View {
                 sessionManager.startHistoryPolling(granularitySec: granularitySec)
             }
         }
+        .onDisappear {
+            sessionManager.stopHistoryPolling()
+        }
     }
     
     private var sessionIconsView: some View {

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -598,11 +598,15 @@ struct GroupView: View {
 
     private var isTopLevel: Bool { depth == 0 }
 
-    /// Formatted cost for this group in the currently-selected time frame,
-    /// or nil if no data.
+    /// Formatted cost for this group in the currently-selected time frame.
+    /// Returns nil only when there is no cost data at all (hides the toggle).
+    /// Returns "$0 / <frame>" when data exists for other frames but not this one,
+    /// so the toggle remains visible and clickable.
     private var formattedCost: String? {
         guard showCostDisplay, isTopLevel, !group.isGasTown else { return nil }
-        guard let v = group.costs?[costTimeframe.rawValue], v > 0 else { return nil }
+        guard let costs = group.costs, !costs.isEmpty else { return nil }
+        let v = costs[costTimeframe.rawValue] ?? 0
+        guard v > 0 else { return "$0" + costTimeframe.suffix }
         let formatted: String
         if v < 0.01 { formatted = "<$0.01" }
         else if v < 10 { formatted = String(format: "$%.2f", v) }

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -23,12 +23,36 @@ extension View {
     }
 }
 
+enum SessionViewMode: String {
+    case meta    // Context / Money / Model (default)
+    case history // Historical activity bar
+}
+
+enum HistoryGranularity: Int, CaseIterable {
+    case oneSecond = 1
+    case tenSeconds = 10
+    case sixtySeconds = 60
+
+    var label: String {
+        switch self {
+        case .oneSecond:   return "1s"
+        case .tenSeconds:  return "10s"
+        case .sixtySeconds: return "60s"
+        }
+    }
+}
+
 struct SessionListView: View {
     @EnvironmentObject var sessionManager: SessionManager
     @EnvironmentObject var gasTownProvider: GasTownProvider
     @State private var isQuitButtonHovered = false
     @State private var isSettingsButtonHovered = false
     @State private var showSettings = false
+    @AppStorage("sessionViewMode") private var viewModeRaw: String = SessionViewMode.meta.rawValue
+    @AppStorage("historyGranularitySec") private var granularitySec: Int = 1
+
+    private var viewMode: SessionViewMode { SessionViewMode(rawValue: viewModeRaw) ?? .meta }
+    private var granularity: HistoryGranularity { HistoryGranularity(rawValue: granularitySec) ?? .oneSecond }
 
     var body: some View {
         if showSettings {
@@ -119,26 +143,73 @@ struct SessionListView: View {
     }
 
     // MARK: - Session Header
-    
+
     private var sessionHeaderView: some View {
-        HStack {
-            HStack(spacing: 4) {
-                Text("Irrlicht v\(appVersion)")
-                    .font(.headline)
-                    .foregroundColor(.primary)
-                
-                Text("—")
-                    .foregroundColor(.secondary)
-                
-                sessionIconsView
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                HStack(spacing: 4) {
+                    Text("Irrlicht v\(appVersion)")
+                        .font(.headline)
+                        .foregroundColor(.primary)
+
+                    Text("—")
+                        .foregroundColor(.secondary)
+
+                    sessionIconsView
+                }
+
+                Spacer()
+
+                // View-mode toggle
+                Picker("", selection: Binding(
+                    get: { viewMode },
+                    set: { newMode in
+                        viewModeRaw = newMode.rawValue
+                        if newMode == .history {
+                            sessionManager.startHistoryPolling(granularitySec: granularitySec)
+                        } else {
+                            sessionManager.stopHistoryPolling()
+                        }
+                    }
+                )) {
+                    Text("Meta").tag(SessionViewMode.meta)
+                    Text("History").tag(SessionViewMode.history)
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 130)
+
+                statusIndicator
             }
-            
-            Spacer()
-            
-            statusIndicator
+
+            // Granularity picker — only visible in history mode
+            if viewMode == .history {
+                HStack(spacing: 4) {
+                    Text("Interval:")
+                        .font(.system(size: 9, design: .monospaced))
+                        .foregroundColor(.secondary)
+                    ForEach(HistoryGranularity.allCases, id: \.rawValue) { g in
+                        Button(g.label) {
+                            granularitySec = g.rawValue
+                            sessionManager.startHistoryPolling(granularitySec: g.rawValue)
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 9, design: .monospaced))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(granularitySec == g.rawValue ? Color.accentColor.opacity(0.2) : Color.clear)
+                        .cornerRadius(3)
+                        .overlay(RoundedRectangle(cornerRadius: 3).stroke(Color.secondary.opacity(0.3)))
+                    }
+                }
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
+        .onAppear {
+            if viewMode == .history {
+                sessionManager.startHistoryPolling(granularitySec: granularitySec)
+            }
+        }
     }
     
     private var sessionIconsView: some View {
@@ -234,7 +305,11 @@ struct SessionRowView: View {
     var activeSubagentCount: Int = 0
     @AppStorage("debugMode") private var debugMode: Bool = false
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
+    @AppStorage("sessionViewMode") private var viewModeRaw: String = SessionViewMode.meta.rawValue
+    @EnvironmentObject var sessionManager: SessionManager
     @State private var isHovered = false
+
+    private var viewMode: SessionViewMode { SessionViewMode(rawValue: viewModeRaw) ?? .meta }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -277,40 +352,47 @@ struct SessionRowView: View {
                     .lineLimit(1)
                     .tooltip(session.gitBranch ?? "—")
 
-                // Context utilization bar
-                if let metrics = session.metrics, metrics.hasContextData {
-                    ContextBar(utilization: metrics.contextUtilization,
-                               pressureColor: metrics.contextPressureColor)
-                        .frame(maxWidth: 80, maxHeight: 8)
-                    Text(metrics.formattedContextUtilization)
-                        .font(.system(size: 9, design: .monospaced))
-                        .foregroundColor(Color(hex: metrics.contextPressureColor))
-                } else if debugMode, let metrics = session.metrics, metrics.totalTokens > 0 {
-                    Text(metrics.formattedTokenUsage)
-                        .font(.system(size: 9, design: .monospaced))
-                        .foregroundColor(Color(hex: "#8E8E93"))
-                }
+                if viewMode == .meta {
+                    // Context utilization bar
+                    if let metrics = session.metrics, metrics.hasContextData {
+                        ContextBar(utilization: metrics.contextUtilization,
+                                   pressureColor: metrics.contextPressureColor)
+                            .frame(maxWidth: 80, maxHeight: 8)
+                        Text(metrics.formattedContextUtilization)
+                            .font(.system(size: 9, design: .monospaced))
+                            .foregroundColor(Color(hex: metrics.contextPressureColor))
+                    } else if debugMode, let metrics = session.metrics, metrics.totalTokens > 0 {
+                        Text(metrics.formattedTokenUsage)
+                            .font(.system(size: 9, design: .monospaced))
+                            .foregroundColor(Color(hex: "#8E8E93"))
+                    }
 
-                // Estimated cost
-                if showCostDisplay, let cost = session.metrics?.formattedCost {
-                    Text(cost)
-                        .font(.system(size: 9, weight: .medium, design: .monospaced))
-                        .foregroundColor(.secondary)
+                    // Estimated cost
+                    if showCostDisplay, let cost = session.metrics?.formattedCost {
+                        Text(cost)
+                            .font(.system(size: 9, weight: .medium, design: .monospaced))
+                            .foregroundColor(.secondary)
+                    }
                 }
 
                 Spacer()
 
-                // Short model name + adapter icon
-                Text(session.shortModelName)
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
-                    .tooltip(session.effectiveModel)
-                    .accessibilityIdentifier("session-model-label-\(session.id)")
-                if let icon = session.adapterIcon {
-                    Image(nsImage: icon)
-                        .frame(width: 12, height: 12)
-                        .tooltip(session.adapterName)
+                if viewMode == .history {
+                    HistoryBarView(states: sessionManager.stateHistory[session.id] ?? [])
+                        .frame(width: 120, height: 6)
+                } else {
+                    // Short model name + adapter icon
+                    Text(session.shortModelName)
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .tooltip(session.effectiveModel)
+                        .accessibilityIdentifier("session-model-label-\(session.id)")
+                    if let icon = session.adapterIcon {
+                        Image(nsImage: icon)
+                            .frame(width: 12, height: 12)
+                            .tooltip(session.adapterName)
+                    }
                 }
 
                 // Action buttons on hover

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -1572,13 +1572,13 @@
     }
 
     // Kick off server history polling — poll at granularity * 1000ms.
+    // Started by applyGranularity() below after DOM buttons are wired up.
     let historyPollTimer = null;
     function startHistoryPoll() {
       if (historyPollTimer) clearInterval(historyPollTimer);
       pollHistory();
       historyPollTimer = setInterval(pollHistory, currentGranularity * 1000);
     }
-    startHistoryPoll();
 
     // --- Initial load ---
     fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
@@ -1706,6 +1706,9 @@
         const mode = this.dataset.mode;
         document.querySelectorAll('.view-mode-btn').forEach(b => b.classList.toggle('active', b === this));
         document.body.classList.toggle('view-history', mode === 'history');
+        // Repaint row bars immediately so there's no flash of empty canvases
+        // when switching to history mode (offsetWidth is now non-zero).
+        if (mode === 'history') pollHistory();
       });
     }
 

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -219,6 +219,63 @@
       width: 100%;
     }
 
+    .timeline-controls {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      margin-bottom: 6px;
+    }
+
+    .timeline-gran-label {
+      font-size: 9px;
+      color: var(--muted);
+      font-family: var(--font-mono);
+      margin-right: 2px;
+    }
+
+    .timeline-gran-btn {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      color: var(--muted);
+      font-size: 9px;
+      font-family: var(--font-mono);
+      padding: 1px 5px;
+      cursor: pointer;
+    }
+
+    .timeline-gran-btn:hover { border-color: var(--working); color: var(--text); }
+    .timeline-gran-btn.active { border-color: var(--working); color: var(--working); }
+
+    /* Per-row history bar (wide viewports only) */
+    .row-history {
+      width: 120px;
+      height: 6px;
+      flex-shrink: 0;
+      display: block;
+    }
+
+    /* View-mode toggle (narrow viewports) */
+    .view-mode-bar {
+      display: none;
+      gap: 4px;
+      margin-bottom: 8px;
+    }
+
+    .view-mode-btn {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      color: var(--muted);
+      font-size: 9px;
+      font-family: var(--font-mono);
+      padding: 2px 8px;
+      cursor: pointer;
+    }
+
+    .view-mode-btn:hover { border-color: var(--working); color: var(--text); }
+    .view-mode-btn.active { border-color: var(--working); color: var(--working); }
+
     /* --- Session list --- */
     .session-list {
       display: flex;
@@ -674,6 +731,9 @@
       .row-branch { max-width: 80px; }
       .row-ctx-bar { width: 50px; }
       .row-model { max-width: 80px; }
+      /* History bar is hidden on narrow; toggle controls visibility via JS */
+      .row-history { display: none; }
+      .view-mode-bar { display: flex; }
     }
 
     @media (max-width: 480px) {
@@ -682,6 +742,13 @@
       .row-ctx-bar { display: none; }
       .row-ctx-pct { display: none; }
     }
+
+    /* History view mode: hide meta columns, show history bar */
+    body.view-history .row-ctx-bar { display: none !important; }
+    body.view-history .row-ctx-pct { display: none !important; }
+    body.view-history .row-cost    { display: none !important; }
+    body.view-history .row-model   { display: none !important; }
+    body.view-history .row-history { display: block !important; }
   </style>
 </head>
 <body>
@@ -717,7 +784,19 @@
 
     <div id="dashboard-panel" class="tab-panel active">
       <div id="gt-container" style="display:none" aria-label="Gas Town"></div>
-      <div id="timeline-wrap"><canvas id="timeline"></canvas></div>
+      <div class="view-mode-bar">
+        <button class="view-mode-btn active" data-mode="meta">Context/Cost/Model</button>
+        <button class="view-mode-btn" data-mode="history">History</button>
+      </div>
+      <div id="timeline-wrap">
+        <div class="timeline-controls">
+          <span class="timeline-gran-label">Interval:</span>
+          <button class="timeline-gran-btn active" data-gran="1">1s</button>
+          <button class="timeline-gran-btn" data-gran="10">10s</button>
+          <button class="timeline-gran-btn" data-gran="60">60s</button>
+        </div>
+        <canvas id="timeline"></canvas>
+      </div>
       <div id="empty-state">
         <div class="empty-dot"></div>
         <p>awaiting sessions</p>
@@ -753,10 +832,10 @@
     let currentTimeframe = localStorage.getItem('irrlicht_costTimeframe') || 'day';
     if (!COST_TIMEFRAMES.find(t => t.key === currentTimeframe)) currentTimeframe = 'day';
 
-    // --- Timeline history ---
-    const TIMELINE_MAX_TICKS = 150;
-    const TIMELINE_TICK_MS = 2000;
-    const timelineHistory = new Map(); // session_id -> {label, states: string[]}
+    // --- Timeline / history state (server-backed) ---
+    let timelineHistory = new Map(); // session_id -> {label, states: string[]}
+    let currentGranularity = parseInt(localStorage.getItem('irrlicht_granularity') || '1', 10);
+    if (![1, 10, 60].includes(currentGranularity)) currentGranularity = 1;
 
     // --- SVG Icons (compact 12px) ---
     const svgIcons = {
@@ -1116,6 +1195,7 @@
     function createSessionRow(agent, isChild) {
       const el = document.createElement('div');
       el.className = 'session-row' + (isChild ? ' child' : '');
+      el.dataset.sessionId = agent.session_id;
       // Build inner structure
       el.innerHTML =
         '<span class="row-state-icon"></span>' +
@@ -1129,6 +1209,7 @@
         '<span class="row-cost"></span>' +
         '<span class="row-tool" style="display:none"></span>' +
         '<span class="row-spacer"></span>' +
+        '<canvas class="row-history"></canvas>' +
         '<span class="row-model"></span>' +
         '<span class="row-elapsed"></span>' +
         '<span class="row-id"></span>';
@@ -1242,6 +1323,10 @@
       } else {
         toolEl.style.display = 'none';
       }
+
+      // Per-row history bar
+      const histCanvas = el.querySelector('.row-history');
+      paintRowHistory(histCanvas, agent.session_id);
     }
 
     // --- Render ---
@@ -1385,33 +1470,50 @@
       ready: '#34C759',
     };
 
-    function timelineTick() {
-      // Record current state of all sessions
-      const seen = new Set();
-      for (const [sid, entry] of sessionIndex) {
-        seen.add(sid);
-        let rec = timelineHistory.get(sid);
-        if (!rec) {
-          const label = (entry.agent.project_name || '').slice(0, 10) + ' ' + shortID(sid);
-          rec = {label, states: []};
-          timelineHistory.set(sid, rec);
-        }
-        rec.states.push(entry.agent.state || 'ready');
-        if (rec.states.length > TIMELINE_MAX_TICKS) rec.states.shift();
+    // paintRowHistory draws the per-row history mini-bar for a single session.
+    function paintRowHistory(canvas, sessionID) {
+      if (!canvas) return;
+      const rec = timelineHistory.get(sessionID);
+      const dpr = window.devicePixelRatio || 1;
+      const w = canvas.offsetWidth || 120;
+      const h = canvas.offsetHeight || 6;
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      const ctx = canvas.getContext('2d');
+      ctx.scale(dpr, dpr);
+      ctx.clearRect(0, 0, w, h);
+      if (!rec || !rec.states.length) return;
+      const states = rec.states;
+      const colW = w / states.length;
+      for (let i = 0; i < states.length; i++) {
+        ctx.fillStyle = stateColors[states[i]] || '#1a2340';
+        ctx.fillRect(i * colW, 0, colW - 0.5, h);
       }
-      // Mark unseen sessions with null
-      for (const [sid, rec] of timelineHistory) {
-        if (!seen.has(sid)) {
-          rec.states.push(null);
-          if (rec.states.length > TIMELINE_MAX_TICKS) rec.states.shift();
-        }
-      }
-      // Prune fully-null rows
-      for (const [sid, rec] of timelineHistory) {
-        if (rec.states.every(s => s === null)) timelineHistory.delete(sid);
-      }
+    }
 
-      renderTimeline();
+    // pollHistory fetches server-aggregated history and rebuilds timelineHistory.
+    function pollHistory() {
+      fetch('/api/v1/sessions/history?granularity=' + currentGranularity)
+        .then(r => r.json()).catch(() => null)
+        .then(resp => {
+          if (!resp) return;
+          const newMap = new Map();
+          for (const [sid, states] of Object.entries(resp.sessions || {})) {
+            const entry = sessionIndex.get(sid);
+            const label = entry
+              ? (entry.agent.project_name || '').slice(0, 10) + ' ' + shortID(sid)
+              : shortID(sid);
+            newMap.set(sid, {label, states});
+          }
+          timelineHistory = newMap;
+          renderTimeline();
+          // Repaint per-row bars
+          for (const el of document.querySelectorAll('.session-row')) {
+            const canvas = el.querySelector('.row-history');
+            const sid = el.dataset.sessionId;
+            if (canvas && sid) paintRowHistory(canvas, sid);
+          }
+        });
     }
 
     function renderTimeline() {
@@ -1469,7 +1571,14 @@
       }
     }
 
-    setInterval(timelineTick, TIMELINE_TICK_MS);
+    // Kick off server history polling — poll at granularity * 1000ms.
+    let historyPollTimer = null;
+    function startHistoryPoll() {
+      if (historyPollTimer) clearInterval(historyPollTimer);
+      pollHistory();
+      historyPollTimer = setInterval(pollHistory, currentGranularity * 1000);
+    }
+    startHistoryPoll();
 
     // --- Initial load ---
     fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
@@ -1477,7 +1586,7 @@
       dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
       rebuildIndex();
       render();
-      timelineTick(); // First tick immediately
+      pollHistory();
     });
     // Periodic re-hydration so trailing-window costs (carried on each group
     // under `costs`) don't go stale between WebSocket deltas, which only
@@ -1571,6 +1680,34 @@
     }
 
     document.getElementById('raw-refresh').addEventListener('click', fetchRaw);
+
+    // --- Granularity toggle ---
+    function applyGranularity(g) {
+      currentGranularity = g;
+      localStorage.setItem('irrlicht_granularity', g);
+      document.querySelectorAll('.timeline-gran-btn').forEach(b => {
+        b.classList.toggle('active', parseInt(b.dataset.gran, 10) === g);
+      });
+      startHistoryPoll();
+    }
+
+    for (const btn of document.querySelectorAll('.timeline-gran-btn')) {
+      btn.addEventListener('click', function() {
+        applyGranularity(parseInt(this.dataset.gran, 10));
+      });
+    }
+
+    // Restore saved granularity on load
+    applyGranularity(currentGranularity);
+
+    // --- View-mode toggle (narrow viewports) ---
+    for (const btn of document.querySelectorAll('.view-mode-btn')) {
+      btn.addEventListener('click', function() {
+        const mode = this.dataset.mode;
+        document.querySelectorAll('.view-mode-btn').forEach(b => b.classList.toggle('active', b === this));
+        document.body.classList.toggle('view-history', mode === 'history');
+      });
+    }
 
     function fetchRaw() {
       const out = document.getElementById('raw-output');


### PR DESCRIPTION
## Summary

Closes #66

Adds a per-agent historical activity bar backed by server-side aggregation in , replacing the existing client-side state sampling in the web SPA.

- **New  service** — in-memory ring buffers (150 buckets × 3 granularities per session) using `waiting > working > ready` priority aggregation within each bucket
- **New API endpoint** — `GET /api/v1/sessions/history?granularity=1|10|60` returns pre-aggregated state arrays per session; clients poll at their chosen cadence
- **Web**: server-backed canvas heatmap replaces client reconstruction; per-row mini-bar on wide viewports; view-mode toggle (Context/Cost/Model ↔ History) on narrow viewports; granularity selector persisted to localStorage
- **SwiftUI**: segmented Picker in header toggles between Meta and History views; granularity button row; new `HistoryBarView` component renders colored state buckets

## Test plan

- [ ] `cd core && go test ./application/services/... -run TestHistoryTracker` — 6 unit tests pass (priority aggregation, bucket rollover, oldest→newest ordering, remove, all granularities, ValidGranularity)
- [ ] `cd core && go test ./...` — full suite green
- [ ] `cd core && go build ./cmd/irrlichd` — daemon compiles clean
- [ ] `cd platforms/macos && swift build` — Swift app compiles clean
- [ ] Launch daemon, open web UI, start a Claude Code session — confirm canvas heatmap populates from server; page reload preserves history (server-backed)
- [ ] Toggle granularity (1s/10s/60s) in web UI — bucket column width changes, poll interval adjusts
- [ ] On wide viewport: per-row mini-bar visible next to each agent row
- [ ] On narrow viewport (<768px): view-mode toggle appears; switching to "History" hides ctx/cost/model columns and shows mini-bar
- [ ] SwiftUI: top Picker switches between Meta and History row views; granularity buttons change bar cadence
- [ ] Run `/ir:test-sub-fg` or `/ir:test-sub-bg` — confirm `waiting` buckets override surrounding `working` at 10s/60s granularity

🤖 Generated with [Claude Code](https://claude.com/claude-code)