### PR TITLE
feat(tasks): display Claude Code task list progress in session view

### DIFF
--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -242,7 +242,7 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 								desc, _ := input["description"].(string)
 								activeForm, _ := input["activeForm"].(string)
 								ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
-									Op:          "create",
+									Op:          tailer.TaskOpCreate,
 									Subject:     subject,
 									Description: desc,
 									ActiveForm:  activeForm,
@@ -253,7 +253,7 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 								taskID, _ := input["taskId"].(string)
 								status, _ := input["status"].(string)
 								ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
-									Op:     "update",
+									Op:     tailer.TaskOpUpdate,
 									ID:     taskID,
 									Status: status,
 								})

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -235,27 +235,28 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 						if name != "" {
 							ev.ToolUses = append(ev.ToolUses, tailer.ToolUse{ID: id, Name: name})
 						}
-						if name == "TaskCreate" || name == "TaskUpdate" {
+						switch name {
+						case "TaskCreate":
 							if input, ok := block["input"].(map[string]interface{}); ok {
-								if name == "TaskCreate" {
-									subject, _ := input["subject"].(string)
-									desc, _ := input["description"].(string)
-									activeForm, _ := input["activeForm"].(string)
-									ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
-										Op:          "create",
-										Subject:     subject,
-										Description: desc,
-										ActiveForm:  activeForm,
-									})
-								} else {
-									taskID, _ := input["taskId"].(string)
-									status, _ := input["status"].(string)
-									ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
-										Op:     "update",
-										ID:     taskID,
-										Status: status,
-									})
-								}
+								subject, _ := input["subject"].(string)
+								desc, _ := input["description"].(string)
+								activeForm, _ := input["activeForm"].(string)
+								ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
+									Op:          "create",
+									Subject:     subject,
+									Description: desc,
+									ActiveForm:  activeForm,
+								})
+							}
+						case "TaskUpdate":
+							if input, ok := block["input"].(map[string]interface{}); ok {
+								taskID, _ := input["taskId"].(string)
+								status, _ := input["status"].(string)
+								ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
+									Op:     "update",
+									ID:     taskID,
+									Status: status,
+								})
 							}
 						}
 					case "tool_result":

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -235,6 +235,29 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 						if name != "" {
 							ev.ToolUses = append(ev.ToolUses, tailer.ToolUse{ID: id, Name: name})
 						}
+						if name == "TaskCreate" || name == "TaskUpdate" {
+							if input, ok := block["input"].(map[string]interface{}); ok {
+								if name == "TaskCreate" {
+									subject, _ := input["subject"].(string)
+									desc, _ := input["description"].(string)
+									activeForm, _ := input["activeForm"].(string)
+									ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
+										Op:          "create",
+										Subject:     subject,
+										Description: desc,
+										ActiveForm:  activeForm,
+									})
+								} else {
+									taskID, _ := input["taskId"].(string)
+									status, _ := input["status"].(string)
+									ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
+										Op:     "update",
+										ID:     taskID,
+										Status: status,
+									})
+								}
+							}
+						}
 					case "tool_result":
 						if toolUseID, ok := block["tool_use_id"].(string); ok && toolUseID != "" {
 							ev.ToolResultIDs = append(ev.ToolResultIDs, toolUseID)

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -1202,3 +1202,145 @@ func TestTailer_TaskNotification_SurfacedThroughMetrics(t *testing.T) {
 		t.Fatalf("expected SubagentCompletion for af7bf8be5a1b511e4 in metrics; got %+v", m.SubagentCompletions)
 	}
 }
+
+// --- Task list tests ---
+
+func makeToolUseEvent(id, name string, input map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type":      "assistant",
+		"timestamp": "2026-04-05T22:00:00Z",
+		"message": map[string]interface{}{
+			"role":        "assistant",
+			"stop_reason": "tool_use",
+			"content": []interface{}{
+				map[string]interface{}{
+					"type":  "tool_use",
+					"id":    id,
+					"name":  name,
+					"input": input,
+				},
+			},
+		},
+	}
+}
+
+func TestParser_TaskCreate_EmitsTaskDelta(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(makeToolUseEvent("tu_1", "TaskCreate", map[string]interface{}{
+		"subject":     "Write tests",
+		"description": "Add unit tests for the parser",
+		"activeForm":  "Writing tests",
+	}))
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if len(ev.TaskDeltas) != 1 {
+		t.Fatalf("TaskDeltas len = %d, want 1", len(ev.TaskDeltas))
+	}
+	d := ev.TaskDeltas[0]
+	if d.Op != "create" {
+		t.Errorf("Op = %q, want create", d.Op)
+	}
+	if d.Subject != "Write tests" {
+		t.Errorf("Subject = %q, want Write tests", d.Subject)
+	}
+	if d.Description != "Add unit tests for the parser" {
+		t.Errorf("Description = %q", d.Description)
+	}
+	if d.ActiveForm != "Writing tests" {
+		t.Errorf("ActiveForm = %q", d.ActiveForm)
+	}
+	// ID is empty on create — the tailer assigns it sequentially.
+	if d.ID != "" {
+		t.Errorf("ID should be empty on create, got %q", d.ID)
+	}
+}
+
+func TestParser_TaskUpdate_EmitsTaskDelta(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(makeToolUseEvent("tu_2", "TaskUpdate", map[string]interface{}{
+		"taskId": "1",
+		"status": "in_progress",
+	}))
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if len(ev.TaskDeltas) != 1 {
+		t.Fatalf("TaskDeltas len = %d, want 1", len(ev.TaskDeltas))
+	}
+	d := ev.TaskDeltas[0]
+	if d.Op != "update" {
+		t.Errorf("Op = %q, want update", d.Op)
+	}
+	if d.ID != "1" {
+		t.Errorf("ID = %q, want 1", d.ID)
+	}
+	if d.Status != "in_progress" {
+		t.Errorf("Status = %q, want in_progress", d.Status)
+	}
+}
+
+func TestParser_TaskList_NoTaskDelta(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(makeToolUseEvent("tu_3", "TaskList", map[string]interface{}{}))
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if len(ev.TaskDeltas) != 0 {
+		t.Errorf("TaskDeltas len = %d, want 0 for TaskList", len(ev.TaskDeltas))
+	}
+}
+
+func TestTailer_TaskAccumulation(t *testing.T) {
+	// Build a tiny transcript with TaskCreate × 3 then TaskUpdate × 2.
+	events := []map[string]interface{}{
+		makeToolUseEvent("tu_1", "TaskCreate", map[string]interface{}{
+			"subject": "Step one", "activeForm": "Doing step one",
+		}),
+		makeToolUseEvent("tu_2", "TaskCreate", map[string]interface{}{
+			"subject": "Step two", "activeForm": "Doing step two",
+		}),
+		makeToolUseEvent("tu_3", "TaskCreate", map[string]interface{}{
+			"subject": "Step three", "activeForm": "Doing step three",
+		}),
+		makeToolUseEvent("tu_4", "TaskUpdate", map[string]interface{}{
+			"taskId": "1", "status": "completed",
+		}),
+		makeToolUseEvent("tu_5", "TaskUpdate", map[string]interface{}{
+			"taskId": "2", "status": "in_progress",
+		}),
+	}
+
+	// Write to a temp file.
+	dir := t.TempDir()
+	path := dir + "/tasks.jsonl"
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := json.NewEncoder(f)
+	for _, e := range events {
+		if err := enc.Encode(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f.Close()
+
+	tr := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+	m, err := tr.TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+	if len(m.Tasks) != 3 {
+		t.Fatalf("Tasks len = %d, want 3", len(m.Tasks))
+	}
+	if m.Tasks[0].ID != "1" || m.Tasks[0].Subject != "Step one" || m.Tasks[0].Status != "completed" {
+		t.Errorf("task 0 = %+v", m.Tasks[0])
+	}
+	if m.Tasks[1].ID != "2" || m.Tasks[1].Status != "in_progress" {
+		t.Errorf("task 1 = %+v", m.Tasks[1])
+	}
+	if m.Tasks[2].ID != "3" || m.Tasks[2].Status != "pending" {
+		t.Errorf("task 2 = %+v", m.Tasks[2])
+	}
+}

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -123,18 +123,7 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 			}
 		}
 	}
-	if len(m.Tasks) > 0 {
-		result.Tasks = make([]session.Task, len(m.Tasks))
-		for i, t := range m.Tasks {
-			result.Tasks[i] = session.Task{
-				ID:          t.ID,
-				Subject:     t.Subject,
-				Description: t.Description,
-				ActiveForm:  t.ActiveForm,
-				Status:      t.Status,
-			}
-		}
-	}
+	result.Tasks = tailerTasksToDomain(m.Tasks)
 	if result.ModelName == "" {
 		result.ModelName = "unknown"
 	}
@@ -142,4 +131,22 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 		result.PressureLevel = "unknown"
 	}
 	return result, nil
+}
+
+// tailerTasksToDomain converts a tailer task slice to the domain mirror type.
+func tailerTasksToDomain(src []tailer.Task) []session.Task {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]session.Task, len(src))
+	for i, t := range src {
+		dst[i] = session.Task{
+			ID:          t.ID,
+			Subject:     t.Subject,
+			Description: t.Description,
+			ActiveForm:  t.ActiveForm,
+			Status:      t.Status,
+		}
+	}
+	return dst
 }

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -123,6 +123,18 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 			}
 		}
 	}
+	if len(m.Tasks) > 0 {
+		result.Tasks = make([]session.Task, len(m.Tasks))
+		for i, t := range m.Tasks {
+			result.Tasks[i] = session.Task{
+				ID:          t.ID,
+				Subject:     t.Subject,
+				Description: t.Description,
+				ActiveForm:  t.ActiveForm,
+				Status:      t.Status,
+			}
+		}
+	}
 	if result.ModelName == "" {
 		result.ModelName = "unknown"
 	}

--- a/core/adapters/outbound/metrics/ledger.go
+++ b/core/adapters/outbound/metrics/ledger.go
@@ -11,7 +11,7 @@ import (
 	"irrlicht/core/pkg/tailer"
 )
 
-const ledgerSchemaVersion = 1
+const ledgerSchemaVersion = 2 // bumped to force re-scan for task support
 
 var ledgerDirOnce sync.Once
 

--- a/core/cmd/replay/main.go
+++ b/core/cmd/replay/main.go
@@ -1081,7 +1081,7 @@ func tailerToDomain(m *tailer.SessionMetrics) *session.SessionMetrics {
 	if m == nil {
 		return nil
 	}
-	return &session.SessionMetrics{
+	result := &session.SessionMetrics{
 		ElapsedSeconds:         m.ElapsedSeconds,
 		TotalTokens:            m.TotalTokens,
 		ModelName:              m.ModelName,
@@ -1103,6 +1103,19 @@ func tailerToDomain(m *tailer.SessionMetrics) *session.SessionMetrics {
 		PermissionMode:         m.PermissionMode,
 		SawUserBlockingToolClosedThisPass: m.SawUserBlockingToolClosedThisPass,
 	}
+	if len(m.Tasks) > 0 {
+		result.Tasks = make([]session.Task, len(m.Tasks))
+		for i, t := range m.Tasks {
+			result.Tasks[i] = session.Task{
+				ID:          t.ID,
+				Subject:     t.Subject,
+				Description: t.Description,
+				ActiveForm:  t.ActiveForm,
+				Status:      t.Status,
+			}
+		}
+	}
+	return result
 }
 
 // computeFlickers counts short-lived X→Y→X sandwich patterns.

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -363,8 +363,7 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 	if merged.CumCacheCreationTokens == 0 && oldM.CumCacheCreationTokens > 0 {
 		merged.CumCacheCreationTokens = oldM.CumCacheCreationTokens
 	}
-	// Preserve tasks from old metrics when new metrics carry none. A non-nil
-	// empty slice from the tailer is a real "no tasks" state and must overwrite.
+	// nil Tasks = "no data yet"; non-nil empty slice = "no tasks" — overwrite only for the latter.
 	if merged.Tasks == nil && oldM.Tasks != nil {
 		merged.Tasks = oldM.Tasks
 	}

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -97,6 +97,12 @@ type SessionMetrics struct {
 	// lines parsed by the Claude Code adapter). Per-pass and transient —
 	// drained by the detector each activity event. See issue #134.
 	SubagentCompletions []SubagentCompletion `json:"-"`
+
+	// Tasks is the current task list for this session, populated from
+	// TaskCreate / TaskUpdate tool calls in the Claude Code transcript.
+	// Nil for sessions that have not used TaskCreate (including non-Claude-Code
+	// adapters).
+	Tasks []Task `json:"tasks,omitempty"`
 }
 
 // SubagentCompletion is the domain mirror of tailer.SubagentCompletion. The
@@ -106,6 +112,16 @@ type SubagentCompletion struct {
 	AgentID   string
 	ToolUseID string
 	Status    string
+}
+
+// Task is the domain mirror of tailer.Task. It represents one item in the
+// Claude Code task list, accumulated from TaskCreate / TaskUpdate tool calls.
+type Task struct {
+	ID          string `json:"id"`
+	Subject     string `json:"subject"`
+	Description string `json:"description,omitempty"`
+	ActiveForm  string `json:"active_form,omitempty"`
+	Status      string `json:"status"` // "pending" | "in_progress" | "completed"
 }
 
 // NeedsUserAttention returns true when a user-blocking tool is open — one
@@ -309,6 +325,7 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 		CumOutputTokens:        newM.CumOutputTokens,
 		CumCacheReadTokens:     newM.CumCacheReadTokens,
 		CumCacheCreationTokens: newM.CumCacheCreationTokens,
+		Tasks:                  newM.Tasks,
 	}
 	if merged.ContextWindow == 0 && oldM.ContextWindow > 0 {
 		merged.ContextWindow = oldM.ContextWindow
@@ -345,6 +362,11 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 	}
 	if merged.CumCacheCreationTokens == 0 && oldM.CumCacheCreationTokens > 0 {
 		merged.CumCacheCreationTokens = oldM.CumCacheCreationTokens
+	}
+	// Preserve tasks from old metrics when new metrics carry none. A non-nil
+	// empty slice from the tailer is a real "no tasks" state and must overwrite.
+	if merged.Tasks == nil && oldM.Tasks != nil {
+		merged.Tasks = oldM.Tasks
 	}
 	return merged
 }

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -26,6 +26,13 @@ type SubagentCompletion struct {
 	Status    string // <status> — "completed", etc.
 }
 
+// Task status values used in TaskCreate / TaskUpdate tool_use events.
+const (
+	TaskStatusPending    = "pending"
+	TaskStatusInProgress = "in_progress"
+	TaskStatusCompleted  = "completed"
+)
+
 // Task represents a single item in the session's Claude Code task list,
 // accumulated from TaskCreate / TaskUpdate tool_use events in the transcript.
 type Task struct {
@@ -33,7 +40,7 @@ type Task struct {
 	Subject     string `json:"subject"`
 	Description string `json:"description,omitempty"`
 	ActiveForm  string `json:"active_form,omitempty"`
-	Status      string `json:"status"` // "pending" | "in_progress" | "completed"
+	Status      string `json:"status"` // TaskStatusPending | TaskStatusInProgress | TaskStatusCompleted
 }
 
 // TaskDelta is emitted by the Claude Code parser for each TaskCreate or

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -26,6 +26,27 @@ type SubagentCompletion struct {
 	Status    string // <status> — "completed", etc.
 }
 
+// Task represents a single item in the session's Claude Code task list,
+// accumulated from TaskCreate / TaskUpdate tool_use events in the transcript.
+type Task struct {
+	ID          string `json:"id"`
+	Subject     string `json:"subject"`
+	Description string `json:"description,omitempty"`
+	ActiveForm  string `json:"active_form,omitempty"`
+	Status      string `json:"status"` // "pending" | "in_progress" | "completed"
+}
+
+// TaskDelta is emitted by the Claude Code parser for each TaskCreate or
+// TaskUpdate tool_use block. The tailer folds deltas into its tasks slice.
+type TaskDelta struct {
+	Op          string // "create" | "update"
+	ID          string // set on update (matches taskId input); empty on create
+	Subject     string // TaskCreate only
+	Description string // TaskCreate only
+	ActiveForm  string // TaskCreate only
+	Status      string // TaskUpdate only; "pending" on create is applied by tailer
+}
+
 // ParsedEvent is the normalized output from a format-specific transcript parser.
 // Each parser maps its native event structure into these fields.
 type ParsedEvent struct {
@@ -61,6 +82,10 @@ type ParsedEvent struct {
 	// detector drains these on the parent path to transition children to
 	// ready without depending on the subagent's own ambiguous final line.
 	SubagentCompletions []SubagentCompletion
+
+	// TaskDeltas are TaskCreate / TaskUpdate events from the Claude Code
+	// transcript. The tailer folds them into a running tasks slice.
+	TaskDeltas []TaskDelta
 
 	// Metadata extracted by the parser.
 	ModelName     string
@@ -157,6 +182,7 @@ type LedgerState struct {
 	CumByModel         map[string]*UsageBreakdown `json:"cum_by_model,omitempty"`
 	CumProviderCostUSD float64                    `json:"cum_provider_cost_usd,omitempty"`
 	ParserState        *ParserLedger              `json:"parser_state,omitempty"`
+	Tasks              []Task                     `json:"tasks,omitempty"`
 }
 
 // --- Shared helpers used by multiple parsers ---

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -26,11 +26,14 @@ type SubagentCompletion struct {
 	Status    string // <status> — "completed", etc.
 }
 
-// Task status values used in TaskCreate / TaskUpdate tool_use events.
+// Task status and operation constants for TaskCreate / TaskUpdate tool_use events.
 const (
 	TaskStatusPending    = "pending"
 	TaskStatusInProgress = "in_progress"
 	TaskStatusCompleted  = "completed"
+
+	TaskOpCreate = "create"
+	TaskOpUpdate = "update"
 )
 
 // Task represents a single item in the session's Claude Code task list,

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -227,7 +227,7 @@ func NewTranscriptTailer(path string, parser TranscriptParser, adapter string) *
 // can be persisted to disk and rehydrated after a daemon restart.
 func (t *TranscriptTailer) GetLedgerState() LedgerState {
 	s := LedgerState{
-		SchemaVersion:      1,
+		SchemaVersion:      2,
 		LastOffset:         t.lastOffset,
 		CumProviderCostUSD: t.cumProviderCostUSD,
 	}

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -400,8 +400,6 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 		if parsed.ClearToolNames && len(parsed.ToolResultIDs) == 0 {
 			t.openToolCalls = make(map[string]string)
 		}
-		// Fold task deltas from the parser (Claude Code only — other adapters
-		// emit no TaskDeltas so this loop is a no-op for them).
 		for _, d := range parsed.TaskDeltas {
 			switch d.Op {
 			case "create":
@@ -411,7 +409,7 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 					Subject:     d.Subject,
 					Description: d.Description,
 					ActiveForm:  d.ActiveForm,
-					Status:      "pending",
+					Status:      TaskStatusPending,
 				})
 			case "update":
 				for i := range t.tasks {

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -109,6 +110,11 @@ type SessionMetrics struct {
 	// episode. Per-pass transient; daemon uses it to synthesise the
 	// missing working→waiting step (issue #150).
 	SawUserBlockingToolClosedThisPass bool `json:"-"`
+
+	// Tasks is the current task list for this session, accumulated from
+	// TaskCreate / TaskUpdate tool_use events in the Claude Code transcript.
+	// Nil for sessions that have not called TaskCreate.
+	Tasks []Task `json:"tasks,omitempty"`
 }
 
 // TranscriptTailer monitors transcript files and computes metrics.
@@ -190,6 +196,11 @@ type TranscriptTailer struct {
 	// lastAssistantText holds the text content of the most recent assistant
 	// message, truncated to ~200 characters.
 	lastAssistantText string
+
+	// tasks accumulates the session's task list from TaskCreate / TaskUpdate
+	// tool_use events parsed by the Claude Code adapter.
+	tasks   []Task
+	taskSeq int // counter: next id to assign on TaskCreate
 }
 
 // NewTranscriptTailer creates a new tailer for the given transcript path.
@@ -230,6 +241,9 @@ func (t *TranscriptTailer) GetLedgerState() LedgerState {
 		pl := pp.GetParserLedger()
 		s.ParserState = &pl
 	}
+	if len(t.tasks) > 0 {
+		s.Tasks = append([]Task(nil), t.tasks...)
+	}
 	return s
 }
 
@@ -256,6 +270,10 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 		if pp, ok := t.parser.(ParserStateProvider); ok {
 			pp.SetParserLedger(*s.ParserState)
 		}
+	}
+	if len(s.Tasks) > 0 {
+		t.tasks = append([]Task(nil), s.Tasks...)
+		t.taskSeq = len(t.tasks)
 	}
 }
 
@@ -380,6 +398,31 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 		if parsed.ClearToolNames && len(parsed.ToolResultIDs) == 0 {
 			t.openToolCalls = make(map[string]string)
 		}
+		// Fold task deltas from the parser (Claude Code only — other adapters
+		// emit no TaskDeltas so this loop is a no-op for them).
+		for _, d := range parsed.TaskDeltas {
+			switch d.Op {
+			case "create":
+				t.taskSeq++
+				t.tasks = append(t.tasks, Task{
+					ID:          strconv.Itoa(t.taskSeq),
+					Subject:     d.Subject,
+					Description: d.Description,
+					ActiveForm:  d.ActiveForm,
+					Status:      "pending",
+				})
+			case "update":
+				for i := range t.tasks {
+					if t.tasks[i].ID == d.ID {
+						if d.Status != "" {
+							t.tasks[i].Status = d.Status
+						}
+						break
+					}
+				}
+			}
+		}
+
 		// turn_done is Claude Code's authoritative end-of-turn signal. By
 		// definition most tool_use events opened during the turn have
 		// already received their tool_result, so anything still in
@@ -676,6 +719,11 @@ func (t *TranscriptTailer) computeMetrics() {
 	t.metrics.LastWasToolDenial = t.lastWasToolDenial
 	t.metrics.LastCWD = t.lastCWD
 	t.metrics.LastAssistantText = t.lastAssistantText
+	if len(t.tasks) > 0 {
+		t.metrics.Tasks = append([]Task(nil), t.tasks...)
+	} else {
+		t.metrics.Tasks = nil
+	}
 
 	// Token snapshot (latest turn — for context utilization display).
 	t.metrics.InputTokens = t.inputTokens

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -322,6 +322,8 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 		t.pendingSnapshot = nil
 		t.cumByModel = make(map[string]*UsageBreakdown)
 		t.cumProviderCostUSD = 0
+		t.tasks = nil
+		t.taskSeq = 0
 	case t.lastOffset > 0:
 		// Normal incremental path: never skip ahead of the last processed byte.
 		startPos = t.lastOffset

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -200,7 +200,9 @@ type TranscriptTailer struct {
 	// tasks accumulates the session's task list from TaskCreate / TaskUpdate
 	// tool_use events parsed by the Claude Code adapter.
 	tasks   []Task
-	taskSeq int // counter: next id to assign on TaskCreate
+	// taskSeq is the next sequential ID to assign on TaskCreate.
+	// Invariant: taskSeq == len(tasks) always (tasks are never removed).
+	taskSeq int
 }
 
 // NewTranscriptTailer creates a new tailer for the given transcript path.
@@ -402,7 +404,7 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 		}
 		for _, d := range parsed.TaskDeltas {
 			switch d.Op {
-			case "create":
+			case TaskOpCreate:
 				t.taskSeq++
 				t.tasks = append(t.tasks, Task{
 					ID:          strconv.Itoa(t.taskSeq),
@@ -411,7 +413,7 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 					ActiveForm:  d.ActiveForm,
 					Status:      TaskStatusPending,
 				})
-			case "update":
+			case TaskOpUpdate:
 				for i := range t.tasks {
 					if t.tasks[i].ID == d.ID {
 						if d.Status != "" {

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -3,7 +3,7 @@ import Foundation
 import os
 
 /// A single item in the Claude Code task list, derived from TaskCreate / TaskUpdate tool calls.
-struct Task: Codable, Hashable {
+struct SessionTask: Codable, Hashable {
     let id: String
     let subject: String
     let description: String?
@@ -36,7 +36,7 @@ struct SessionMetrics: Codable {
     let pressureLevel: String       // pressure level: "safe", "caution", "warning", "critical" ("unknown" if not available)
     let estimatedCostUSD: Double?   // estimated session cost in USD (nil if not available)
     let lastAssistantText: String?  // last assistant message text, truncated (~200 chars)
-    let tasks: [Task]?              // Claude Code task list (nil when TaskCreate never called)
+    let tasks: [SessionTask]?              // Claude Code task list (nil when TaskCreate never called)
 
     enum CodingKeys: String, CodingKey {
         case elapsedSeconds = "elapsed_seconds"

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -2,16 +2,41 @@ import AppKit
 import Foundation
 import os
 
+/// A single item in the Claude Code task list, derived from TaskCreate / TaskUpdate tool calls.
+struct Task: Codable, Hashable {
+    let id: String
+    let subject: String
+    let description: String?
+    let activeForm: String?
+    let status: String  // "pending" | "in_progress" | "completed"
+
+    enum CodingKeys: String, CodingKey {
+        case id, subject, description, status
+        case activeForm = "active_form"
+    }
+
+    var isCompleted: Bool { status == "completed" }
+    var isInProgress: Bool { status == "in_progress" }
+
+    var displayLabel: String {
+        if isInProgress, let form = activeForm, !form.isEmpty {
+            return form
+        }
+        return subject
+    }
+}
+
 // Performance metrics from transcript analysis
 struct SessionMetrics: Codable {
     let elapsedSeconds: Int64       // elapsed time when metrics were computed (for ready sessions)
     let totalTokens: Int64          // total token count from transcript (0 if not available)
-    let modelName: String           // model name extracted from transcript ("" if not available) 
+    let modelName: String           // model name extracted from transcript ("" if not available)
     let contextWindow: Int64?       // model context window size (nil/0 if unknown)
     let contextUtilization: Double  // context utilization percentage (0-100) (0 if not available)
     let pressureLevel: String       // pressure level: "safe", "caution", "warning", "critical" ("unknown" if not available)
     let estimatedCostUSD: Double?   // estimated session cost in USD (nil if not available)
     let lastAssistantText: String?  // last assistant message text, truncated (~200 chars)
+    let tasks: [Task]?              // Claude Code task list (nil when TaskCreate never called)
 
     enum CodingKeys: String, CodingKey {
         case elapsedSeconds = "elapsed_seconds"
@@ -22,6 +47,7 @@ struct SessionMetrics: Codable {
         case pressureLevel = "pressure_level"
         case estimatedCostUSD = "estimated_cost_usd"
         case lastAssistantText = "last_assistant_text"
+        case tasks
     }
     
     // Computed properties for UI display

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -488,9 +488,9 @@ struct SessionRowView: View {
 
 /// Compact task list rendered inside a session row when tasks are present.
 struct TaskListView: View {
-    let tasks: [Task]
+    let tasks: [SessionTask]
 
-    private func icon(for task: Task) -> (String, Color) {
+    private func icon(for task: SessionTask) -> (String, Color) {
         switch task.status {
         case "completed":  return ("checkmark", Color.secondary.opacity(0.5))
         case "in_progress": return ("square.fill", Color.accentColor)
@@ -838,7 +838,8 @@ struct SessionListView_Previews: PreviewProvider {
                             contextUtilization: 7.5,
                             pressureLevel: "safe",
                             estimatedCostUSD: nil,
-                            lastAssistantText: nil
+                            lastAssistantText: nil,
+                            tasks: nil
                         )
                     )
                 ]

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -481,7 +481,7 @@ struct TaskListView: View {
                     }
                 }
                 .frame(width: 7, height: 7)
-                .help(task.displayLabel)
+                .tooltip(task.displayLabel)
             }
             Text("\(done) / \(tasks.count)")
                 .font(.system(size: 9))

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -465,13 +465,55 @@ struct SessionRowView: View {
 
 // MARK: - Task Progress
 
-/// Compact dot-progress row: one circle per task (filled = done/active, empty = pending) + "4 / 6" count.
+/// Wraps children left-to-right, starting a new row when the available width is exhausted.
+private struct FlowLayout: Layout {
+    var hSpacing: CGFloat = 4
+    var vSpacing: CGFloat = 3
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        for sub in subviews {
+            let size = sub.sizeThatFits(.unspecified)
+            if x + size.width > maxWidth && x > 0 {
+                y += rowHeight + vSpacing
+                x = 0
+                rowHeight = 0
+            }
+            x += size.width + hSpacing
+            rowHeight = max(rowHeight, size.height)
+        }
+        return CGSize(width: maxWidth, height: y + rowHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+        for sub in subviews {
+            let size = sub.sizeThatFits(.unspecified)
+            if x + size.width > bounds.maxX && x > bounds.minX {
+                y += rowHeight + vSpacing
+                x = bounds.minX
+                rowHeight = 0
+            }
+            sub.place(at: CGPoint(x: x, y: y), proposal: .unspecified)
+            x += size.width + hSpacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
+
+/// Compact dot-progress row: one circle per task (filled = done, empty = pending) + "4 / 6" count.
+/// Dots wrap to the next line when the row is full.
 struct TaskListView: View {
     let tasks: [SessionTask]
 
     var body: some View {
         let done = tasks.filter(\.isCompleted).count
-        HStack(spacing: 4) {
+        FlowLayout(hSpacing: 4, vSpacing: 3) {
             ForEach(tasks, id: \.id) { task in
                 Group {
                     if task.isCompleted {

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -426,9 +426,8 @@ struct SessionRowView: View {
             }
 
             // Task list (Claude Code TaskCreate / TaskUpdate)
-            if let tasks = session.metrics?.tasks, !tasks.isEmpty {
+            if let tasks = session.metrics?.tasks, !tasks.isEmpty, !tasks.allSatisfy(\.isCompleted) {
                 TaskListView(tasks: tasks)
-                    .padding(.top, 2)
             }
 
             // Debug info
@@ -484,41 +483,34 @@ struct SessionRowView: View {
     }
 }
 
-// MARK: - Task List
+// MARK: - Task Progress
 
-/// Compact task list rendered inside a session row when tasks are present.
+/// Compact dot-progress row: one circle per task (filled = done/active, empty = pending) + "4 / 6" count.
 struct TaskListView: View {
     let tasks: [SessionTask]
 
-    private func icon(for task: SessionTask) -> (String, Color) {
+    private func dotColor(for task: SessionTask) -> Color {
         switch task.status {
-        case "completed":  return ("checkmark", Color.secondary.opacity(0.5))
-        case "in_progress": return ("square.fill", Color.accentColor)
-        default:           return ("square", Color.secondary.opacity(0.4))
+        case "completed":   return Color.accentColor.opacity(0.5)
+        case "in_progress": return Color.accentColor
+        default:            return Color.secondary.opacity(0.3)
         }
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 1) {
+        let done = tasks.filter { $0.isCompleted || $0.isInProgress }.count
+        HStack(spacing: 4) {
             ForEach(tasks, id: \.id) { task in
-                HStack(spacing: 4) {
-                    let (glyph, color) = icon(for: task)
-                    Image(systemName: glyph)
-                        .font(.system(size: 8, weight: .medium))
-                        .foregroundColor(color)
-                        .frame(width: 10)
-                    Text(task.displayLabel)
-                        .font(.system(size: 9))
-                        .foregroundColor(task.isInProgress ? .primary : .secondary)
-                        .strikethrough(task.isCompleted, color: .secondary.opacity(0.5))
-                        .lineLimit(1)
-                }
+                Circle()
+                    .fill(dotColor(for: task))
+                    .frame(width: 7, height: 7)
+                    .help(task.displayLabel)
             }
+            Text("\(done) / \(tasks.count)")
+                .font(.system(size: 9))
+                .foregroundColor(.secondary)
+                .padding(.leading, 2)
         }
-        .padding(.horizontal, 4)
-        .padding(.vertical, 3)
-        .background(Color.secondary.opacity(0.05))
-        .cornerRadius(4)
     }
 }
 

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -508,7 +508,7 @@ private struct FlowLayout: Layout {
 
 /// Compact dot-progress row: one circle per task (filled = done, empty = pending) + "4 / 6" count.
 /// Dots wrap to the next line when the row is full.
-struct TaskListView: View {
+private struct TaskListView: View {
     let tasks: [SessionTask]
 
     var body: some View {

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -425,6 +425,12 @@ struct SessionRowView: View {
                 .padding(.top, 2)
             }
 
+            // Task list (Claude Code TaskCreate / TaskUpdate)
+            if let tasks = session.metrics?.tasks, !tasks.isEmpty {
+                TaskListView(tasks: tasks)
+                    .padding(.top, 2)
+            }
+
             // Debug info
             if debugMode {
                 TimelineView(.periodic(from: .now, by: 1)) { context in
@@ -475,6 +481,44 @@ struct SessionRowView: View {
             return String(format: "%d:%02d:%02d", h, m, s)
         }
         return String(format: "%d:%02d", m, s)
+    }
+}
+
+// MARK: - Task List
+
+/// Compact task list rendered inside a session row when tasks are present.
+struct TaskListView: View {
+    let tasks: [Task]
+
+    private func icon(for task: Task) -> (String, Color) {
+        switch task.status {
+        case "completed":  return ("checkmark", Color.secondary.opacity(0.5))
+        case "in_progress": return ("square.fill", Color.accentColor)
+        default:           return ("square", Color.secondary.opacity(0.4))
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            ForEach(tasks, id: \.id) { task in
+                HStack(spacing: 4) {
+                    let (glyph, color) = icon(for: task)
+                    Image(systemName: glyph)
+                        .font(.system(size: 8, weight: .medium))
+                        .foregroundColor(color)
+                        .frame(width: 10)
+                    Text(task.displayLabel)
+                        .font(.system(size: 9))
+                        .foregroundColor(task.isInProgress ? .primary : .secondary)
+                        .strikethrough(task.isCompleted, color: .secondary.opacity(0.5))
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 3)
+        .background(Color.secondary.opacity(0.05))
+        .cornerRadius(4)
     }
 }
 

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -489,22 +489,19 @@ struct SessionRowView: View {
 struct TaskListView: View {
     let tasks: [SessionTask]
 
-    private func dotColor(for task: SessionTask) -> Color {
-        switch task.status {
-        case "completed":   return Color.accentColor.opacity(0.5)
-        case "in_progress": return Color.accentColor
-        default:            return Color.secondary.opacity(0.3)
-        }
-    }
-
     var body: some View {
-        let done = tasks.filter { $0.isCompleted || $0.isInProgress }.count
+        let done = tasks.filter(\.isCompleted).count
         HStack(spacing: 4) {
             ForEach(tasks, id: \.id) { task in
-                Circle()
-                    .fill(dotColor(for: task))
-                    .frame(width: 7, height: 7)
-                    .help(task.displayLabel)
+                Group {
+                    if task.isCompleted {
+                        Circle().fill(Color.green.opacity(0.85))
+                    } else {
+                        Circle().strokeBorder(Color.accentColor, lineWidth: 1.5)
+                    }
+                }
+                .frame(width: 7, height: 7)
+                .help(task.displayLabel)
             }
             Text("\(done) / \(tasks.count)")
                 .font(.system(size: 9))

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -477,7 +477,7 @@ struct TaskListView: View {
                     if task.isCompleted {
                         Circle().fill(Color.green.opacity(0.85))
                     } else {
-                        Circle().strokeBorder(Color.accentColor, lineWidth: 1.5)
+                        Circle().strokeBorder(Color(hex: "#8B5CF6"), lineWidth: 1.5)
                     }
                 }
                 .frame(width: 7, height: 7)

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -506,7 +506,7 @@
     .task-dot.task-completed  { background: var(--ready); border: 1.5px solid var(--ready); }
     .row-task-count {
       font-size: 9px;
-      color: var(--text-secondary);
+      color: var(--muted);
       margin-left: 2px;
       font-family: var(--font-mono);
     }
@@ -1298,7 +1298,7 @@
       const allDone = tasks && tasks.length > 0 && tasks.every(t => t.status === 'completed');
       if (tasks && tasks.length > 0 && !allDone) {
         tasksEl.style.display = '';
-        const done = tasks.filter(t => t.status === 'completed' || t.status === 'in_progress').length;
+        const done = tasks.filter(t => t.status === 'completed').length;
         const taskLabel = (t) => (t.status === 'in_progress' && t.active_form) ? t.active_form : t.subject;
         const newHtml = tasks.map(t => {
           const tip = taskLabel(t).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -487,33 +487,27 @@
       padding: 0 4px;
     }
 
-    /* Task list */
+    /* Task progress dots */
     .row-tasks {
-      flex: 1 1 100%;
-      order: 10;
       display: flex;
-      flex-direction: column;
-      gap: 1px;
-      padding: 3px 4px;
-      background: rgba(128,128,128,0.05);
-      border-radius: 3px;
+      align-items: center;
+      gap: 3px;
+    }
+    .task-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      flex-shrink: 0;
+      cursor: default;
+    }
+    .task-dot.task-pending    { background: rgba(128,128,128,0.3); }
+    .task-dot.task-in_progress { background: var(--working); }
+    .task-dot.task-completed  { background: rgba(139,92,246,0.45); }
+    .row-task-count {
       font-size: 9px;
-      font-family: var(--font-mono);
-      margin-top: -2px; /* compensate for row gap so it sits flush */
-    }
-    .task-item {
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
       color: var(--text-secondary);
-    }
-    .task-item.task-in_progress {
-      color: var(--text-primary);
-      font-weight: 500;
-    }
-    .task-item.task-completed {
-      opacity: 0.45;
-      text-decoration: line-through;
+      margin-left: 2px;
+      font-family: var(--font-mono);
     }
 
     /* Pressure alert row */
@@ -1296,19 +1290,18 @@
         questionEl.style.display = 'none';
       }
 
-      // Task list (Claude Code TaskCreate / TaskUpdate)
+      // Task progress dots (Claude Code TaskCreate / TaskUpdate)
       const tasksEl = el.querySelector('.row-tasks');
       const tasks = metrics.tasks;
-      if (tasks && tasks.length > 0) {
+      const allDone = tasks && tasks.length > 0 && tasks.every(t => t.status === 'completed');
+      if (tasks && tasks.length > 0 && !allDone) {
         tasksEl.style.display = '';
-        const icons = { completed: '✓', in_progress: '■', pending: '□' };
+        const done = tasks.filter(t => t.status === 'completed' || t.status === 'in_progress').length;
+        const taskLabel = (t) => (t.status === 'in_progress' && t.active_form) ? t.active_form : t.subject;
         const newHtml = tasks.map(t => {
-          const icon = icons[t.status] || '□';
-          const label = (t.status === 'in_progress' && t.active_form) ? t.active_form : t.subject;
-          const cls = 'task-item task-' + (t.status || 'pending');
-          const escaped = label.replace(/&/g,'&amp;').replace(/</g,'&lt;');
-          return '<span class="' + cls + '">' + icon + ' ' + escaped + '</span>';
-        }).join('');
+          const tip = taskLabel(t).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
+          return '<span class="task-dot task-' + (t.status || 'pending') + '" title="' + tip + '"></span>';
+        }).join('') + '<span class="row-task-count">' + done + ' / ' + tasks.length + '</span>';
         if (tasksEl.innerHTML !== newHtml) tasksEl.innerHTML = newHtml;
       } else {
         tasksEl.style.display = 'none';

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -490,6 +490,7 @@
     /* Task progress dots */
     .row-tasks {
       display: flex;
+      flex-wrap: wrap;
       align-items: center;
       gap: 3px;
     }

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -486,6 +486,34 @@
       padding: 0 4px;
     }
 
+    /* Task list */
+    .row-tasks {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+      padding: 3px 4px;
+      background: rgba(128,128,128,0.05);
+      border-radius: 3px;
+      font-size: 9px;
+      font-family: var(--font-mono);
+      margin-top: 2px;
+    }
+    .task-item {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: var(--text-secondary);
+    }
+    .task-item.task-in_progress {
+      color: var(--text-primary);
+      font-weight: 500;
+    }
+    .task-item.task-completed {
+      opacity: 0.45;
+      text-decoration: line-through;
+    }
+
     /* Pressure alert row */
     .pressure-alert-row {
       padding: 2px 10px 2px 30px;
@@ -1204,6 +1232,7 @@
         '<span class="row-sub-badge" style="display:none"></span>' +
         '<span class="row-branch"></span>' +
         '<span class="row-question" style="display:none"></span>' +
+        '<div class="row-tasks" style="display:none"></div>' +
         '<span class="row-ctx-bar"><span class="row-ctx-fill"></span></span>' +
         '<span class="row-ctx-pct"></span>' +
         '<span class="row-cost"></span>' +
@@ -1263,6 +1292,24 @@
         }
       } else {
         questionEl.style.display = 'none';
+      }
+
+      // Task list (Claude Code TaskCreate / TaskUpdate)
+      const tasksEl = el.querySelector('.row-tasks');
+      const tasks = metrics.tasks;
+      if (tasks && tasks.length > 0) {
+        tasksEl.style.display = '';
+        const icons = { completed: '✓', in_progress: '■', pending: '□' };
+        const newHtml = tasks.map(t => {
+          const icon = icons[t.status] || '□';
+          const label = (t.status === 'in_progress' && t.active_form) ? t.active_form : t.subject;
+          const cls = 'task-item task-' + (t.status || 'pending');
+          const escaped = label.replace(/&/g,'&amp;').replace(/</g,'&lt;');
+          return '<span class="' + cls + '">' + icon + ' ' + escaped + '</span>';
+        }).join('');
+        if (tasksEl.innerHTML !== newHtml) tasksEl.innerHTML = newHtml;
+      } else {
+        tasksEl.style.display = 'none';
       }
 
       // Context bar

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -343,6 +343,7 @@
     .session-row {
       display: flex;
       align-items: center;
+      flex-wrap: wrap;
       gap: 6px;
       padding: 3px 10px;
       font-family: var(--font-mono);
@@ -488,7 +489,8 @@
 
     /* Task list */
     .row-tasks {
-      width: 100%;
+      flex: 1 1 100%;
+      order: 10;
       display: flex;
       flex-direction: column;
       gap: 1px;
@@ -497,7 +499,7 @@
       border-radius: 3px;
       font-size: 9px;
       font-family: var(--font-mono);
-      margin-top: 2px;
+      margin-top: -2px; /* compensate for row gap so it sits flush */
     }
     .task-item {
       white-space: nowrap;

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -500,9 +500,9 @@
       flex-shrink: 0;
       cursor: default;
     }
-    .task-dot.task-pending    { background: rgba(128,128,128,0.3); }
-    .task-dot.task-in_progress { background: var(--working); }
-    .task-dot.task-completed  { background: rgba(139,92,246,0.45); }
+    .task-dot.task-pending    { background: transparent; border: 1.5px solid var(--working); }
+    .task-dot.task-in_progress { background: transparent; border: 1.5px solid var(--working); }
+    .task-dot.task-completed  { background: var(--ready); border: 1.5px solid var(--ready); }
     .row-task-count {
       font-size: 9px;
       color: var(--text-secondary);


### PR DESCRIPTION
## Summary

Surfaces the Claude Code task list (TaskCreate / TaskUpdate tool calls) as compact progress dots in both the macOS menu bar app and web dashboard. Sessions that have never called TaskCreate show no task UI at all.

- **Go daemon**: parse TaskCreate/TaskUpdate tool_use blocks → accumulate into `[]Task` per session → persist in ledger (schema v2) → expose on `SessionMetrics.tasks`
- **macOS**: wrapping dot row per session row — purple outline = pending/in_progress, green filled = completed; hidden when all done; tooltip on each dot shows task subject
- **Web**: same dot + count pattern with CSS flex-wrap
- **Ledger schema v2**: invalidates pre-task ledgers so existing sessions are re-scanned and pick up their task history on next daemon start

## Behavior

- Dots wrap to next line when the row is full (FlowLayout in Swift, flex-wrap in CSS)
- Count shown as `completed / total` (e.g. `4 / 6`)
- Entire row hidden once all tasks reach `completed`
- Hover/tooltip shows task subject (or activeForm when in_progress)
- Non-Claude-Code sessions (Codex, Pi) are unaffected — tasks field stays nil

## Test plan

- [ ] Start a Claude Code session and use TaskCreate / TaskUpdate — dots appear and update live
- [ ] All tasks complete → dot row disappears
- [ ] Restart daemon mid-session → tasks rehydrate from ledger (schema v2 re-scan)
- [ ] Session with many tasks (>1 row) → dots wrap cleanly
- [ ] Codex / Pi session → no task UI rendered
- [ ] Hover dot → tooltip shows task name

🤖 Generated with [Claude Code](https://claude.com/claude-code)