### PR TITLE
fix(landscape): verify every agent against gh api; harden skill against hallucinations

### DIFF
--- a/.claude/skills/ir:agent-landscape/assets/generate.py
+++ b/.claude/skills/ir:agent-landscape/assets/generate.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Render landscape/index.html and landscape/compare/index.html from agent-data.json."""
+import html
+import json
+import math
+from datetime import date
+from pathlib import Path
+
+SKILL_DIR = Path("/Users/ingo/projects/irrlicht/.claude/skills/ir:agent-landscape")
+DATA_FILE = SKILL_DIR / "references" / "agent-data.json"
+PAGE_TMPL = SKILL_DIR / "assets" / "page-template.html"
+COMPARE_TMPL = SKILL_DIR / "assets" / "compare-template.html"
+SITE_DIR = Path("/Users/ingo/projects/irrlicht/site/landscape")
+OUT_INDEX = SITE_DIR / "index.html"
+OUT_COMPARE = SITE_DIR / "compare" / "index.html"
+
+TODAY = date.today().isoformat()
+NEW_BADGE_DAYS = 90
+
+
+def parse_iso(s: str) -> date:
+    y, m, d = s.split("-")
+    return date(int(y), int(m), int(d))
+
+
+def fmt_n(n):
+    if n is None:
+        return "—"
+    return f"{n:,}"
+
+
+def latest_snapshot_other_than_today(history, today):
+    """Return the newest snapshot strictly older than today (i.e. not today's)."""
+    for entry in history:
+        if entry["date"] != today:
+            return entry
+    return None
+
+
+def score(agent, today_date):
+    """
+    Popularity score = log10(stars).  We deliberately do NOT add a short-window
+    trend bonus until we have a snapshot ≥ 30 days old; a 12-day delta is too
+    noisy to rank against.
+    """
+    if agent.get("stars") is None:
+        return 0.0
+    base = math.log10((agent["stars"] or 0) + 1)
+    prior = latest_snapshot_other_than_today(agent.get("stars_history") or [], TODAY)
+    if prior and prior.get("stars") is not None and prior["stars"] > 0:
+        days = (today_date - parse_iso(prior["date"])).days
+        if days >= 30:
+            gain = max(0, agent["stars"] - prior["stars"])
+            trend = gain / days * 30
+            base = 0.75 * base + 0.25 * math.log10(trend + 1)
+    return base
+
+
+EARLIEST_FIRST_SEEN = None  # set in main() so we don't tag every first-batch agent NEW
+
+
+def is_new(agent, today_date) -> bool:
+    fs = agent.get("first_seen")
+    if not fs:
+        return False
+    # Only flag agents added in a LATER batch than the very first scan,
+    # and only while they're still within the NEW window.
+    if EARLIEST_FIRST_SEEN and fs == EARLIEST_FIRST_SEEN:
+        return False
+    try:
+        return (today_date - parse_iso(fs)).days < NEW_BADGE_DAYS
+    except ValueError:
+        return False
+
+
+def growth_cell(agent):
+    """
+    Honest growth cell.  We only trust the single prior snapshot the last skill
+    run wrote (~12 days ago) until more history accumulates.  Hallucinated
+    Jan/April-1 entries were removed from the JSON.
+    """
+    hist = agent.get("stars_history") or []
+    current = agent.get("stars")
+    if current is None or not hist:
+        return '<span class="growth-na">—</span>', None
+    prior = latest_snapshot_other_than_today(hist, TODAY)
+    if not prior or prior.get("stars") is None:
+        return '<span class="growth-na">—</span>', None
+    delta = current - prior["stars"]
+    pct = (delta / prior["stars"] * 100) if prior["stars"] else 0
+    cls = "growth-up" if delta > 0 else "growth-down" if delta < 0 else "growth-flat"
+    sign = "+" if delta > 0 else ""
+    label = f'<span class="{cls}">{sign}{delta:,} <span class="growth-pct">({sign}{pct:.1f}%)</span></span>'
+    # Human-readable age
+    days = max(1, (parse_iso(TODAY) - parse_iso(prior["date"])).days)
+    return label, f"since {prior['date']} ({days}d)"
+
+
+def support_badge(s):
+    return {
+        "live": '<span class="badge badge-live">live</span>',
+        "planned": '<span class="badge badge-planned">planned</span>',
+    }.get(s, '<span class="badge badge-none">not tracked</span>')
+
+
+def alt_metric_display(a):
+    m = a.get("alternative_metrics") or {}
+    if "funding_millions_usd" in m and m["funding_millions_usd"]:
+        return f'${m["funding_millions_usd"]}M raised', m.get("source")
+    if "estimated_users" in m and m["estimated_users"]:
+        u = m["estimated_users"]
+        try:
+            n = int(str(u).rstrip("+"))
+            if n >= 1_000_000:
+                return f'{n/1_000_000:.1f}M users', m.get("source")
+            if n >= 1_000:
+                return f'{n/1_000:.0f}k users', m.get("source")
+        except ValueError:
+            pass
+        return f'{u} users', m.get("source")
+    if "acquisition_price_millions_usd" in m and m["acquisition_price_millions_usd"]:
+        return f'${m["acquisition_price_millions_usd"]}M acquisition', m.get("source")
+    return "—", m.get("source")
+
+
+def anchor(a):
+    url = a.get("website") or (f'https://github.com/{a["github_repo"]}' if a.get("github_repo") else "#")
+    name = html.escape(a["name"])
+    new = '<sup class="badge badge-new">NEW</sup>' if is_new(a, parse_iso(TODAY)) else ""
+    return f'<a href="{html.escape(url)}" target="_blank" rel="noopener">{name}</a>{new}'
+
+
+def main_table_rows(agents, today_date):
+    rows = []
+    ranked = [a for a in agents if a.get("stars") is not None]
+    ranked.sort(key=lambda a: score(a, today_date), reverse=True)
+    for i, a in enumerate(ranked, 1):
+        growth_html, _ = growth_cell(a)
+        rows.append(f"""
+  <tr>
+    <td class="rank">#{i}</td>
+    <td class="name">{anchor(a)}</td>
+    <td class="stars">{fmt_n(a.get("stars"))}</td>
+    <td class="growth growth-3m">{growth_html}</td>
+    <td>{support_badge(a.get("irrlicht_support"))}</td>
+    <td class="desc">{html.escape(a.get("description") or "")}</td>
+  </tr>""")
+
+    # No-repo group (unranked)
+    nogit = [a for a in agents if a.get("stars") is None]
+    nogit.sort(key=lambda x: x["name"].lower())
+    if nogit:
+        rows.append(f"""
+  <tr><td colspan="6" style="padding-top:1.2rem; color: var(--text-dim); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; border-bottom: none;">No public repo — popularity via funding / users</td></tr>""")
+        for a in nogit:
+            metric, _src = alt_metric_display(a)
+            rows.append(f"""
+  <tr>
+    <td class="rank">—</td>
+    <td class="name">{anchor(a)}</td>
+    <td class="alt-metric">{html.escape(metric)}</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td>{support_badge(a.get("irrlicht_support"))}</td>
+    <td class="desc">{html.escape(a.get("description") or "")}</td>
+  </tr>""")
+
+    return f"""<table class="landscape-table">
+<thead><tr>
+  <th class="rank">#</th><th>Name</th><th>Stars</th><th class="growth-3m">Recent growth</th><th>Irrlicht</th><th>Description</th>
+</tr></thead>
+<tbody>
+{''.join(rows)}
+</tbody></table>"""
+
+
+def render_main():
+    data = json.loads(DATA_FILE.read_text())
+    today_date = parse_iso(TODAY)
+    agents = [a for a in data["agents"] if a["category"] == "agent"]
+    orchs = [a for a in data["agents"] if a["category"] == "orchestrator"]
+    tmpl = PAGE_TMPL.read_text()
+
+    prior_snapshot_dates = sorted({
+        e["date"] for a in data["agents"] for e in (a.get("stars_history") or [])
+        if e["date"] != TODAY
+    })
+    if prior_snapshot_dates:
+        earliest = prior_snapshot_dates[0]
+        days = (today_date - parse_iso(earliest)).days
+        trend_note = (
+            f"Recent growth = change in GitHub stars since the previous scan on "
+            f"{earliest} ({days}d ago). 1-month and 3-month deltas will appear here "
+            f"once snapshots are available at those horizons."
+        )
+    else:
+        trend_note = "No prior snapshots yet — growth will appear after the next scan."
+
+    agents_table = main_table_rows(agents, today_date)
+    orch_table = main_table_rows(orchs, today_date)
+    out = (tmpl
+           .replace("{{LAST_UPDATED}}", data["last_updated"])
+           .replace(
+               '<p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before {{LAST_UPDATED}}.</p>',
+               f'<p class="trend-note">{trend_note}</p>',
+           )
+           .replace("{{AGENTS_TABLE}}", agents_table)
+           .replace("{{ORCHESTRATORS_TABLE}}", orch_table))
+    OUT_INDEX.write_text(out)
+    print(f"Wrote {OUT_INDEX} ({len(out):,} bytes)")
+    return data
+
+
+def compare_row(a, today_date):
+    name_cell = f'<td class="name" data-sort="{html.escape(a["name"].lower())}">{anchor(a)}</td>'
+    cat = a.get("category") or ""
+    cat_badge = (
+        '<span class="badge badge-cat badge-agent">Agent</span>'
+        if cat == "agent"
+        else '<span class="badge badge-cat badge-orchestrator">Orchestrator</span>'
+    )
+    stars = a.get("stars")
+    if stars is not None:
+        stars_cell = f'<td class="mono" data-sort="{stars}">{fmt_n(stars)}</td>'
+    else:
+        metric, _src = alt_metric_display(a)
+        stars_cell = f'<td class="mono" data-sort="-1">{html.escape(metric)}</td>'
+
+    growth_html, _ = growth_cell(a)
+    growth_cell_html = f'<td class="growth-3m">{growth_html}</td>'
+
+    oss = bool(a.get("github_repo"))
+    oss_html = (
+        '<span class="badge-oss-yes">Yes</span>' if oss else '<span class="badge-oss-no">No</span>'
+    )
+
+    license_ = a.get("license") or "—"
+    lang = a.get("language") or "—"
+    interface = a.get("interface") or "—"
+    pricing = a.get("pricing") or "—"
+    support = support_badge(a.get("irrlicht_support"))
+
+    return f"""<tr>
+  {name_cell}
+  <td>{cat_badge}</td>
+  {stars_cell}
+  {growth_cell_html}
+  <td data-sort="{1 if oss else 0}">{oss_html}</td>
+  <td>{html.escape(license_)}</td>
+  <td>{html.escape(lang)}</td>
+  <td>{html.escape(interface)}</td>
+  <td>{html.escape(pricing)}</td>
+  <td>{support}</td>
+</tr>"""
+
+
+def render_compare():
+    data = json.loads(DATA_FILE.read_text())
+    today_date = parse_iso(TODAY)
+    tmpl = COMPARE_TMPL.read_text()
+
+    rows_ranked = sorted(
+        [a for a in data["agents"] if a.get("stars") is not None],
+        key=lambda a: score(a, today_date), reverse=True,
+    )
+    rows_unranked = sorted(
+        [a for a in data["agents"] if a.get("stars") is None], key=lambda a: a["name"].lower()
+    )
+
+    all_rows = "\n".join(compare_row(a, today_date) for a in rows_ranked + rows_unranked)
+
+    table_html = f"""<table class="compare-table">
+<thead><tr>
+<th>Name<span class="sort-arrow">▲</span></th>
+<th>Category<span class="sort-arrow">▲</span></th>
+<th>Stars / Metric<span class="sort-arrow">▲</span></th>
+<th class="growth-3m">Recent growth<span class="sort-arrow">▲</span></th>
+<th>Open Source<span class="sort-arrow">▲</span></th>
+<th>License*<span class="sort-arrow">▲</span></th>
+<th>Primary Language<span class="sort-arrow">▲</span></th>
+<th>Interface<span class="sort-arrow">▲</span></th>
+<th>Pricing*<span class="sort-arrow">▲</span></th>
+<th>Irrlicht<span class="sort-arrow">▲</span></th>
+</tr></thead>
+<tbody>
+{all_rows}
+</tbody></table>
+<p style="font-size:0.72rem; color: var(--text-dim); margin-top: 0.8rem; font-style: italic;">* License and pricing are sourced from the GitHub API and public web pages. Verify on the project's own website before relying on them. "Recent growth" is the absolute change in stars since the last scan snapshot ({{PRIOR_DATE}}); it is not a monthly or quarterly figure.</p>"""
+
+    prior_dates = sorted({
+        e["date"] for a in data["agents"] for e in (a.get("stars_history") or [])
+        if e["date"] != TODAY
+    })
+    prior_label = prior_dates[0] if prior_dates else "—"
+    table_html = table_html.replace("{{PRIOR_DATE}}", prior_label)
+
+    out = (tmpl
+           .replace("{{LAST_UPDATED}}", data["last_updated"])
+           .replace("{{COMPARISON_TABLE}}", table_html))
+    OUT_COMPARE.write_text(out)
+    print(f"Wrote {OUT_COMPARE} ({len(out):,} bytes)")
+
+
+def main():
+    global EARLIEST_FIRST_SEEN
+    data = json.loads(DATA_FILE.read_text())
+    EARLIEST_FIRST_SEEN = min(
+        (a["first_seen"] for a in data["agents"] if a.get("first_seen")), default=None
+    )
+    render_main()
+    render_compare()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/ir:agent-landscape/references/agent-data.json
+++ b/.claude/skills/ir:agent-landscape/references/agent-data.json
@@ -1,51 +1,79 @@
 {
-  "last_updated": "2026-04-12",
+  "last_updated": "2026-04-24",
   "agents": [
+    {
+      "name": "Claw Code",
+      "github_repo": "ultraworkers/claw-code",
+      "category": "agent",
+      "website": "https://github.com/ultraworkers/claw-code",
+      "description": "Rust CLI agent harness that wraps Claude via the Anthropic API; star count inflated by viral self-promotion in the README.",
+      "stars": 188050,
+      "language": "Rust",
+      "license": null,
+      "interface": "CLI",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-04-24",
+          "stars": 188050
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 182111
+        }
+      ]
+    },
     {
       "name": "OpenCode",
       "github_repo": "anomalyco/opencode",
       "category": "agent",
       "website": "https://opencode.ai",
-      "description": "The open source coding agent",
-      "stars": 141888,
+      "description": "Open-source coding agent (TypeScript CLI).",
+      "stars": 148747,
+      "language": "TypeScript",
+      "license": "MIT",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
       "irrlicht_support": "planned",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 141888},
-        {"date": "2026-04-01", "stars": 141121},
-        {"date": "2026-01-01", "stars": 5500}
-      ]
-    },
-    {
-      "name": "Claw Code",
-      "github_repo": "instructkr/claw-code",
-      "category": "agent",
-      "website": "https://claw-code.codes",
-      "description": "Clean-room Python/Rust rewrite of Claude Code architecture",
-      "stars": 182111,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {"date": "2026-04-12", "stars": 182111},
-        {"date": "2026-04-01", "stars": 180702}
+        {
+          "date": "2026-04-24",
+          "stars": 148747
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 141888
+        }
       ]
     },
     {
       "name": "Claude Code",
       "github_repo": "anthropics/claude-code",
       "category": "agent",
-      "website": "https://github.com/anthropics/claude-code",
-      "description": "Anthropic's terminal-based AI coding agent",
-      "stars": 112845,
+      "website": "https://www.anthropic.com/claude-code",
+      "description": "Anthropic's terminal-based coding agent.",
+      "stars": 117553,
+      "language": "Shell",
+      "license": null,
+      "interface": "CLI",
+      "pricing": "Paid (usage-based)",
       "irrlicht_support": "live",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 112845},
-        {"date": "2026-04-01", "stars": 112201},
-        {"date": "2026-01-01", "stars": 51700}
+        {
+          "date": "2026-04-24",
+          "stars": 117553
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 112845
+        }
       ]
     },
     {
@@ -53,15 +81,24 @@
       "github_repo": "google-gemini/gemini-cli",
       "category": "agent",
       "website": "https://github.com/google-gemini/gemini-cli",
-      "description": "Google's terminal AI coding agent",
-      "stars": 100994,
+      "description": "Google's open-source terminal coding agent for Gemini models.",
+      "stars": 102304,
+      "language": "TypeScript",
+      "license": "Apache-2.0",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
       "irrlicht_support": "planned",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 100994},
-        {"date": "2026-04-01", "stars": 100831},
-        {"date": "2026-01-01", "stars": 89800}
+        {
+          "date": "2026-04-24",
+          "stars": 102304
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 100994
+        }
       ]
     },
     {
@@ -69,79 +106,124 @@
       "github_repo": "openai/codex",
       "category": "agent",
       "website": "https://github.com/openai/codex",
-      "description": "OpenAI's terminal AI coding agent",
-      "stars": 74758,
+      "description": "OpenAI's lightweight terminal coding agent.",
+      "stars": 77568,
+      "language": "Rust",
+      "license": "Apache-2.0",
+      "interface": "CLI",
+      "pricing": "Paid (usage-based)",
       "irrlicht_support": "live",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 74758},
-        {"date": "2026-04-01", "stars": 74416},
-        {"date": "2026-01-01", "stars": 46000}
+        {
+          "date": "2026-04-24",
+          "stars": 77568
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 74758
+        }
       ]
     },
     {
       "name": "OpenHands",
-      "github_repo": "All-Hands-AI/OpenHands",
+      "github_repo": "OpenHands/OpenHands",
       "category": "agent",
-      "website": "https://github.com/All-Hands-AI/OpenHands",
-      "description": "Open-source platform for autonomous AI software agents",
-      "stars": 71060,
+      "website": "https://github.com/OpenHands/OpenHands",
+      "description": "AI-driven development platform for autonomous software agents.",
+      "stars": 71985,
+      "language": "Python",
+      "license": "MIT",
+      "interface": "CLI / Web",
+      "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 71060},
-        {"date": "2026-04-01", "stars": 70983},
-        {"date": "2026-01-01", "stars": 52000}
+        {
+          "date": "2026-04-24",
+          "stars": 71985
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 71060
+        }
       ]
     },
     {
       "name": "Cline",
       "github_repo": "cline/cline",
       "category": "agent",
-      "website": "https://github.com/cline/cline",
-      "description": "Autonomous AI coding agent for VS Code",
-      "stars": 60178,
+      "website": "https://cline.bot",
+      "description": "Autonomous coding agent embedded in VS Code.",
+      "stars": 60949,
+      "language": "TypeScript",
+      "license": "Apache-2.0",
+      "interface": "IDE extension (VS Code)",
+      "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 60178},
-        {"date": "2026-04-01", "stars": 60138},
-        {"date": "2026-01-01", "stars": 36000}
+        {
+          "date": "2026-04-24",
+          "stars": 60949
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 60178
+        }
       ]
     },
     {
       "name": "Aider",
-      "github_repo": "paul-gauthier/aider",
+      "github_repo": "Aider-AI/aider",
       "category": "agent",
       "website": "https://aider.chat",
-      "description": "AI pair programming in your terminal",
-      "stars": 43202,
-      "irrlicht_support": "none",
+      "description": "AI pair-programming tool in your terminal.",
+      "stars": 43874,
+      "language": "Python",
+      "license": "Apache-2.0",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "planned",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 43202},
-        {"date": "2026-04-01", "stars": 43133},
-        {"date": "2026-01-01", "stars": 36000}
+        {
+          "date": "2026-04-24",
+          "stars": 43874
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 43202
+        }
       ]
     },
     {
       "name": "Goose",
-      "github_repo": "block/goose",
+      "github_repo": "aaif-goose/goose",
       "category": "agent",
       "website": "https://block.github.io/goose/",
-      "description": "Block's open-source extensible AI agent for full dev workflows",
-      "stars": 41312,
-      "irrlicht_support": "none",
+      "description": "Extensible open-source agent that can install, execute, edit, and test with any LLM (originated at Block).",
+      "stars": 43139,
+      "language": "Rust",
+      "license": "Apache-2.0",
+      "interface": "CLI / Desktop app",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "planned",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 41312},
-        {"date": "2026-04-01", "stars": 40906},
-        {"date": "2026-01-01", "stars": 26100}
+        {
+          "date": "2026-04-24",
+          "stars": 43139
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 41312
+        }
       ]
     },
     {
@@ -149,31 +231,24 @@
       "github_repo": "badlogic/pi-mono",
       "category": "agent",
       "website": "https://github.com/badlogic/pi-mono",
-      "description": "Anthropic's lightweight coding agent",
-      "stars": 34689,
+      "description": "Mario Zechner's AI agent toolkit: coding agent CLI, unified LLM API, TUI/web libraries, Slack bot, vLLM pods.",
+      "stars": 39373,
+      "language": "TypeScript",
+      "license": "MIT",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
       "irrlicht_support": "live",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 34689},
-        {"date": "2026-04-01", "stars": 34165},
-        {"date": "2026-01-01", "stars": 18400}
-      ]
-    },
-    {
-      "name": "Cursor",
-      "github_repo": "getcursor/cursor",
-      "category": "agent",
-      "website": "https://cursor.com",
-      "description": "AI-first code editor with agent mode",
-      "stars": 32624,
-      "irrlicht_support": "planned",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {"date": "2026-04-12", "stars": 32624},
-        {"date": "2026-04-01", "stars": 32617},
-        {"date": "2026-01-01", "stars": 25000}
+        {
+          "date": "2026-04-24",
+          "stars": 39373
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 34689
+        }
       ]
     },
     {
@@ -181,31 +256,74 @@
       "github_repo": "continuedev/continue",
       "category": "agent",
       "website": "https://continue.dev",
-      "description": "Open-source AI code assistant for VS Code and JetBrains",
-      "stars": 32499,
-      "irrlicht_support": "none",
+      "description": "Source-controlled AI coding assistant and CI checks; VS Code / JetBrains / CLI.",
+      "stars": 32770,
+      "language": "TypeScript",
+      "license": "Apache-2.0",
+      "interface": "IDE extension / CLI",
+      "pricing": "Freemium",
+      "irrlicht_support": "planned",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 32499},
-        {"date": "2026-04-01", "stars": 32469},
-        {"date": "2026-01-01", "stars": 31000}
+        {
+          "date": "2026-04-24",
+          "stars": 32770
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 32499
+        }
+      ]
+    },
+    {
+      "name": "Cursor",
+      "github_repo": "cursor/cursor",
+      "category": "agent",
+      "website": "https://cursor.com",
+      "description": "Proprietary AI-first code editor (the GitHub repo hosts issues only; editor source is closed).",
+      "stars": 32693,
+      "language": null,
+      "license": null,
+      "interface": "Desktop app (IDE)",
+      "pricing": "Freemium",
+      "irrlicht_support": "planned",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-04-24",
+          "stars": 32693
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 32624
+        }
       ]
     },
     {
       "name": "Void",
       "github_repo": "voideditor/void",
       "category": "agent",
-      "website": "https://github.com/voideditor/void",
-      "description": "Open-source AI code editor",
-      "stars": 28553,
+      "website": "https://voideditor.com",
+      "description": "Open-source AI code editor (VS Code fork).",
+      "stars": 28644,
+      "language": "TypeScript",
+      "license": "Apache-2.0",
+      "interface": "Desktop app (IDE)",
+      "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 28553},
-        {"date": "2026-04-01", "stars": 28544},
-        {"date": "2026-01-01", "stars": 23000}
+        {
+          "date": "2026-04-24",
+          "stars": 28644
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 28553
+        }
       ]
     },
     {
@@ -213,46 +331,24 @@
       "github_repo": "warpdotdev/Warp",
       "category": "agent",
       "website": "https://www.warp.dev",
-      "description": "Agentic terminal with Oz cloud orchestration for parallel coding agents",
-      "stars": 26372,
+      "description": "Agentic development environment built on a modern terminal.",
+      "stars": 26501,
+      "language": null,
+      "license": null,
+      "interface": "Desktop app (Terminal)",
+      "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 26372},
-        {"date": "2026-04-01", "stars": 26362},
-        {"date": "2026-01-01", "stars": 24000}
-      ]
-    },
-    {
-      "name": "Roo Code",
-      "github_repo": "RooVetGit/Roo-Code",
-      "category": "agent",
-      "website": "https://github.com/RooVetGit/Roo-Code",
-      "description": "AI coding agent for VS Code with multi-mode support",
-      "stars": 23088,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {"date": "2026-04-12", "stars": 23088},
-        {"date": "2026-04-01", "stars": 23069},
-        {"date": "2026-01-01", "stars": 17500}
-      ]
-    },
-    {
-      "name": "Crush",
-      "github_repo": "charmbracelet/crush",
-      "category": "agent",
-      "website": "https://charm.land/crush",
-      "description": "Open-source terminal coding agent by Charmbracelet with multi-model support",
-      "stars": 22889,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-10",
-      "alternative_metrics": null,
-      "stars_history": [
-        {"date": "2026-04-12", "stars": 22889},
-        {"date": "2026-04-01", "stars": 22815}
+        {
+          "date": "2026-04-24",
+          "stars": 26501
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 26372
+        }
       ]
     },
     {
@@ -260,30 +356,99 @@
       "github_repo": "QwenLM/qwen-code",
       "category": "agent",
       "website": "https://qwen.ai/qwencode",
-      "description": "Alibaba's open-source terminal coding agent optimized for the Qwen3-Coder model family",
-      "stars": 22823,
-      "irrlicht_support": "none",
+      "description": "Alibaba's open-source terminal coding agent tuned for the Qwen3-Coder model family.",
+      "stars": 23813,
+      "language": "TypeScript",
+      "license": "Apache-2.0",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "planned",
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 22823},
-        {"date": "2026-04-01", "stars": 22493}
+        {
+          "date": "2026-04-24",
+          "stars": 23813
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 22823
+        }
       ]
     },
     {
-      "name": "SWE-agent",
-      "github_repo": "princeton-nlp/SWE-agent",
+      "name": "Crush",
+      "github_repo": "charmbracelet/crush",
       "category": "agent",
-      "website": "https://github.com/princeton-nlp/SWE-agent",
-      "description": "Princeton's autonomous software engineering agent",
-      "stars": 18968,
+      "website": "https://charm.land/crush",
+      "description": "Charmbracelet's multi-model terminal coding agent written in Go.",
+      "stars": 23418,
+      "language": "Go",
+      "license": "MIT",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "planned",
+      "first_seen": "2026-04-10",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-04-24",
+          "stars": 23418
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 22889
+        }
+      ]
+    },
+    {
+      "name": "Roo Code",
+      "github_repo": "RooCodeInc/Roo-Code",
+      "category": "agent",
+      "website": "https://roocode.com",
+      "description": "VS Code coding agent with multi-mode team-of-agents support.",
+      "stars": 23345,
+      "language": "TypeScript",
+      "license": "Apache-2.0",
+      "interface": "IDE extension (VS Code)",
+      "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 18968},
-        {"date": "2026-04-01", "stars": 18961},
-        {"date": "2026-01-01", "stars": 13000}
+        {
+          "date": "2026-04-24",
+          "stars": 23345
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 23088
+        }
+      ]
+    },
+    {
+      "name": "SWE-agent",
+      "github_repo": "SWE-agent/SWE-agent",
+      "category": "agent",
+      "website": "https://swe-agent.com",
+      "description": "Princeton NLP's autonomous agent for resolving GitHub issues (NeurIPS 2024).",
+      "stars": 19050,
+      "language": "Python",
+      "license": "MIT",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "planned",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-04-24",
+          "stars": 19050
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 18968
+        }
       ]
     },
     {
@@ -291,15 +456,24 @@
       "github_repo": "Kilo-Org/kilocode",
       "category": "agent",
       "website": "https://kilo.ai",
-      "description": "Open-source agentic coding platform for VS Code, JetBrains, and CLI",
-      "stars": 17988,
-      "irrlicht_support": "none",
+      "description": "All-in-one agentic coding platform for VS Code, JetBrains, and CLI.",
+      "stars": 18505,
+      "language": "TypeScript",
+      "license": "MIT",
+      "interface": "IDE extension / CLI",
+      "pricing": "Freemium",
+      "irrlicht_support": "planned",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 17988},
-        {"date": "2026-04-01", "stars": 17922},
-        {"date": "2026-01-01", "stars": 11000}
+        {
+          "date": "2026-04-24",
+          "stars": 18505
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 17988
+        }
       ]
     },
     {
@@ -307,14 +481,24 @@
       "github_repo": "plandex-ai/plandex",
       "category": "agent",
       "website": "https://plandex.ai",
-      "description": "Open-source terminal agent for large, multi-step coding tasks spanning many files",
-      "stars": 15231,
+      "description": "Open-source terminal agent for large, multi-step coding tasks spanning many files.",
+      "stars": 15289,
+      "language": "Go",
+      "license": "MIT",
+      "interface": "CLI",
+      "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 15231},
-        {"date": "2026-04-01", "stars": 15226}
+        {
+          "date": "2026-04-24",
+          "stars": 15289
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 15231
+        }
       ]
     },
     {
@@ -322,14 +506,24 @@
       "github_repo": "langchain-ai/open-swe",
       "category": "agent",
       "website": "https://github.com/langchain-ai/open-swe",
-      "description": "LangChain's open-source async cloud-hosted coding agent",
-      "stars": 9484,
+      "description": "LangChain's open-source asynchronous cloud coding agent.",
+      "stars": 9642,
+      "language": "Python",
+      "license": "MIT",
+      "interface": "Web",
+      "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 9484},
-        {"date": "2026-04-01", "stars": 9413}
+        {
+          "date": "2026-04-24",
+          "stars": 9642
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 9484
+        }
       ]
     },
     {
@@ -337,30 +531,49 @@
       "github_repo": "sweepai/sweep",
       "category": "agent",
       "website": "https://sweep.dev",
-      "description": "AI junior developer for GitHub issues",
-      "stars": 7709,
+      "description": "AI coding assistant for JetBrains (pivoted from earlier GitHub-issue automation).",
+      "stars": 7705,
+      "language": "Jupyter Notebook",
+      "license": null,
+      "interface": "IDE extension (JetBrains)",
+      "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 7709},
-        {"date": "2026-04-01", "stars": 7705},
-        {"date": "2026-01-01", "stars": 7200}
+        {
+          "date": "2026-04-24",
+          "stars": 7705
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 7709
+        }
       ]
     },
     {
       "name": "Forge Code",
-      "github_repo": "antinomyhq/forgecode",
+      "github_repo": "tailcallhq/forgecode",
       "category": "agent",
-      "website": "https://github.com/antinomyhq/forgecode",
-      "description": "Rust-based open-source terminal AI pair programmer",
-      "stars": 6466,
+      "website": "https://forgecode.dev",
+      "description": "Rust-based open-source terminal AI pair programmer supporting 300+ models.",
+      "stars": 6925,
+      "language": "Rust",
+      "license": "Apache-2.0",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 6466},
-        {"date": "2026-04-01", "stars": 6417}
+        {
+          "date": "2026-04-24",
+          "stars": 6925
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 6466
+        }
       ]
     },
     {
@@ -368,14 +581,24 @@
       "github_repo": "ai-christianson/RA.Aid",
       "category": "agent",
       "website": "https://www.ra-aid.ai",
-      "description": "LangGraph-based autonomous coding agent with research-plan-implement loop",
-      "stars": 2218,
+      "description": "LangGraph-based autonomous coding agent with research \u2192 plan \u2192 implement loop.",
+      "stars": 2223,
+      "language": "Python",
+      "license": "Apache-2.0",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 2218},
-        {"date": "2026-04-01", "stars": 2217}
+        {
+          "date": "2026-04-24",
+          "stars": 2223
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 2218
+        }
       ]
     },
     {
@@ -383,14 +606,24 @@
       "github_repo": "Factory-AI/factory",
       "category": "agent",
       "website": "https://www.factory.ai",
-      "description": "Agent-native development platform with Droid agents",
-      "stars": 756,
+      "description": "Agent-native software development platform with Droid agents.",
+      "stars": 794,
+      "language": null,
+      "license": null,
+      "interface": "Web / CLI",
+      "pricing": "Paid",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 756},
-        {"date": "2026-04-01", "stars": 734}
+        {
+          "date": "2026-04-24",
+          "stars": 794
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 756
+        }
       ]
     },
     {
@@ -398,15 +631,24 @@
       "github_repo": "trypear/pearai-app",
       "category": "agent",
       "website": "https://trypear.ai",
-      "description": "Open-source AI code editor",
-      "stars": 674,
+      "description": "Open-source AI code editor (VS Code fork with Continue submodule).",
+      "stars": 676,
+      "language": "TypeScript",
+      "license": "MIT",
+      "interface": "Desktop app (IDE)",
+      "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 674},
-        {"date": "2026-04-01", "stars": 675},
-        {"date": "2026-01-01", "stars": 500}
+        {
+          "date": "2026-04-24",
+          "stars": 676
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 674
+        }
       ]
     },
     {
@@ -414,64 +656,42 @@
       "github_repo": "codegen-sh/codegen",
       "category": "agent",
       "website": "https://codegen.com",
-      "description": "AI coding agent platform with SDK for programmatic control",
+      "description": "Python wrapper for the Codegen API \u2014 run code agents at scale against a hosted service.",
       "stars": 521,
+      "language": "Python",
+      "license": "Apache-2.0",
+      "interface": "SDK / Web",
+      "pricing": "Paid",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 521},
-        {"date": "2026-04-01", "stars": 521}
+        {
+          "date": "2026-04-24",
+          "stars": 521
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 521
+        }
       ]
     },
     {
-      "name": "GitHub Copilot",
+      "name": "Amazon Q Developer",
       "github_repo": null,
       "category": "agent",
-      "website": "https://github.com/features/copilot",
-      "description": "GitHub's AI pair programmer",
+      "website": "https://aws.amazon.com/q/developer/",
+      "description": "AWS's AI coding assistant (completions, transformations, agentic refactors).",
       "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "IDE extension / CLI",
+      "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "estimated_users": "15000000",
-        "funding_millions_usd": null,
-        "source": "GitHub blog, press reports",
-        "measured_date": "2026-04-12"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "Windsurf",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://codeium.com/windsurf",
-      "description": "AI-powered IDE by Codeium, now owned by Cognition AI",
-      "stars": null,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "estimated_users": "1000000",
-        "funding_millions_usd": 250,
-        "source": "Codeium press, Cognition acquisition reports",
-        "measured_date": "2026-04-12"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "Devin",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://devin.ai",
-      "description": "Autonomous AI software engineer by Cognition",
-      "stars": null,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "funding_millions_usd": 700,
-        "estimated_users": null,
-        "source": "Cognition AI funding rounds, TechCrunch",
-        "measured_date": "2026-04-12"
+        "source": "AWS product; no independent user/funding disclosures",
+        "measured_date": "2026-04-24"
       },
       "stars_history": []
     },
@@ -480,29 +700,17 @@
       "github_repo": null,
       "category": "agent",
       "website": "https://ampcode.com",
-      "description": "Sourcegraph's AI coding agent",
+      "description": "Agentic coding agent spinning out from Sourcegraph as a standalone company in 2026 (formerly Sourcegraph Cody); CLI + VS Code extension.",
       "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "IDE extension / CLI",
+      "pricing": "Freemium",
       "irrlicht_support": "planned",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "funding_millions_usd": 225,
-        "source": "Sourcegraph total funding via Crunchbase",
-        "measured_date": "2026-04-12"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "Amazon Q Developer",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://aws.amazon.com/q/developer/",
-      "description": "AWS AI coding assistant",
-      "stars": null,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "source": "no public user count data found; enterprise-scale AWS product",
-        "measured_date": "2026-04-12"
+        "source": "Amp spin-out announcement (Q1 2026); inherits Sourcegraph Cody lineage",
+        "measured_date": "2026-04-24"
       },
       "stars_history": []
     },
@@ -511,138 +719,18 @@
       "github_repo": null,
       "category": "agent",
       "website": "https://www.augmentcode.com",
-      "description": "AI coding agent with deep codebase understanding",
+      "description": "AI coding agent with deep codebase understanding and enterprise context retrieval.",
       "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "IDE extension",
+      "pricing": "Paid",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
         "funding_millions_usd": 252,
-        "source": "Crunchbase, TechCrunch",
-        "measured_date": "2026-04-12"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "Poolside",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://www.poolside.ai",
-      "description": "Enterprise AI coding platform with custom foundation models",
-      "stars": null,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "funding_millions_usd": 626,
-        "source": "Crunchbase, TechCrunch, Nvidia investment reports",
-        "measured_date": "2026-04-12"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "Tabnine",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://www.tabnine.com",
-      "description": "AI code completion and chat assistant",
-      "stars": null,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "estimated_users": "1000000",
-        "funding_millions_usd": 102,
-        "source": "Tabnine press releases, Crunchbase",
-        "measured_date": "2026-04-12"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "Qodo",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://www.qodo.ai",
-      "description": "Agentic code integrity platform for review, testing, and governance",
-      "stars": null,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "funding_millions_usd": 120,
-        "source": "TechCrunch, Ctech (Series B Mar 2026)",
-        "measured_date": "2026-04-12"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "Sourcegraph Cody",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://sourcegraph.com/cody",
-      "description": "AI coding assistant with full codebase context",
-      "stars": null,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "source": "now merged into Amp; Sourcegraph total funding ~$225M",
-        "measured_date": "2026-04-12"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "Cosine Genie",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://cosine.sh",
-      "description": "Fully autonomous AI software engineer with proprietary Genie model",
-      "stars": null,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "source": "no public data found",
-        "measured_date": "2026-04-12"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "Zencoder",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://zencoder.ai",
-      "description": "AI coding agent with repo-wide context indexing",
-      "stars": null,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "source": "seed-stage; no public data found",
-        "measured_date": "2026-04-12"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "CodeGPT",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://www.codegpt.co",
-      "description": "Full-stack AI agent platform with codebase knowledge graph",
-      "stars": null,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "source": "no public data found",
-        "measured_date": "2026-04-12"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "MorphLLM",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://www.morphllm.com",
-      "description": "Subagent infrastructure: Fast Apply, WarpGrep, context compression",
-      "stars": null,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "source": "no public data found",
-        "measured_date": "2026-04-12"
+        "source": "Crunchbase; TechCrunch Series B coverage",
+        "measured_date": "2026-04-24"
       },
       "stars_history": []
     },
@@ -651,13 +739,96 @@
       "github_repo": null,
       "category": "agent",
       "website": "https://codebuff.com",
-      "description": "AI coding agent in your terminal",
+      "description": "AI coding agent for the terminal.",
       "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "CLI",
+      "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "source": "no public data found",
-        "measured_date": "2026-04-12"
+        "source": "no public metrics found",
+        "measured_date": "2026-04-24"
+      },
+      "stars_history": []
+    },
+    {
+      "name": "CodeGPT",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://www.codegpt.co",
+      "description": "Full-stack AI agent platform with a codebase knowledge graph.",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "IDE extension / Web",
+      "pricing": "Freemium",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": {
+        "source": "no public metrics found",
+        "measured_date": "2026-04-24"
+      },
+      "stars_history": []
+    },
+    {
+      "name": "Cosine Genie",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://cosine.sh",
+      "description": "Fully autonomous AI software engineer using Cosine's proprietary Genie model.",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "Web",
+      "pricing": "Paid",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": {
+        "source": "no public funding/user data found",
+        "measured_date": "2026-04-24"
+      },
+      "stars_history": []
+    },
+    {
+      "name": "Devin",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://devin.ai",
+      "description": "Cognition AI's autonomous software-engineer agent; parent company merged Windsurf (Cascade IDE) into its stack in 2025.",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "Web",
+      "pricing": "Paid (from $20/mo)",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": {
+        "funding_millions_usd": 696,
+        "valuation_billions_usd": 10.2,
+        "source": "Cognition's Sep 2025 $400M round (Founders Fund, Lux, 8VC); Wikipedia; CNBC",
+        "measured_date": "2026-04-24"
+      },
+      "stars_history": []
+    },
+    {
+      "name": "GitHub Copilot",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://github.com/features/copilot",
+      "description": "GitHub's AI pair programmer (completion + chat + coding agent).",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "IDE extension / Web",
+      "pricing": "Paid (from $10/mo)",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": {
+        "estimated_users": "20000000+",
+        "source": "GitHub Q4 2025 disclosures; exact figure varies by source",
+        "measured_date": "2026-04-24"
       },
       "stars_history": []
     },
@@ -666,45 +837,163 @@
       "github_repo": null,
       "category": "agent",
       "website": "https://kiro.dev",
-      "description": "AWS-backed agentic IDE with spec-driven development and autonomous task execution",
+      "description": "AWS-backed agentic IDE with spec-driven development and autonomous task execution.",
       "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "Desktop app (IDE)",
+      "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-10",
       "alternative_metrics": {
-        "source": "AWS-backed; no independent funding data",
-        "measured_date": "2026-04-12"
+        "source": "AWS-backed product; no independent funding data",
+        "measured_date": "2026-04-24"
       },
       "stars_history": []
     },
     {
-      "name": "GPT Engineer",
-      "github_repo": "gpt-engineer-org/gpt-engineer",
-      "category": "orchestrator",
-      "website": "https://github.com/gpt-engineer-org/gpt-engineer",
-      "description": "AI agent that builds codebases from specifications",
-      "stars": 55217,
+      "name": "MorphLLM",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://www.morphllm.com",
+      "description": "Subagent infrastructure: Fast Apply, WarpGrep, context compression.",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "API / SDK",
+      "pricing": "Paid",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {"date": "2026-04-12", "stars": 55217},
-        {"date": "2026-04-01", "stars": 55220},
-        {"date": "2026-01-01", "stars": 53000}
-      ]
+      "alternative_metrics": {
+        "source": "no public metrics found",
+        "measured_date": "2026-04-24"
+      },
+      "stars_history": []
+    },
+    {
+      "name": "Poolside",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://www.poolside.ai",
+      "description": "Enterprise AI coding platform with custom foundation models.",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "Enterprise SaaS",
+      "pricing": "Enterprise",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": {
+        "funding_millions_usd": 626,
+        "source": "Crunchbase; Nvidia strategic investment reports",
+        "measured_date": "2026-04-24"
+      },
+      "stars_history": []
+    },
+    {
+      "name": "Qodo",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://www.qodo.ai",
+      "description": "Agentic code-integrity platform for review, testing, and governance (formerly CodiumAI).",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "IDE extension / Web",
+      "pricing": "Freemium",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": {
+        "funding_millions_usd": 120,
+        "source": "TechCrunch / Ctech Series B (Mar 2026)",
+        "measured_date": "2026-04-24"
+      },
+      "stars_history": []
+    },
+    {
+      "name": "Tabnine",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://www.tabnine.com",
+      "description": "AI code completion, chat, and code-review agent with on-prem/private deployment options.",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "IDE extension",
+      "pricing": "Freemium",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": {
+        "estimated_users": "1000000",
+        "funding_millions_usd": 102,
+        "source": "Tabnine press releases; Crunchbase",
+        "measured_date": "2026-04-24"
+      },
+      "stars_history": []
+    },
+    {
+      "name": "Windsurf",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://windsurf.com",
+      "description": "Agentic AI IDE (Cascade). Acquired by Cognition AI from Codeium in December 2025 for ~$250M; brand continues under Cognition.",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "Desktop app (IDE)",
+      "pricing": "Freemium",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": {
+        "funding_millions_usd": null,
+        "acquisition_price_millions_usd": 250,
+        "source": "Cognition AI press release (Dec 2025); TechCrunch coverage",
+        "measured_date": "2026-04-24"
+      },
+      "stars_history": []
+    },
+    {
+      "name": "Zencoder",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://zencoder.ai",
+      "description": "AI coding agent with repo-wide context indexing.",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "IDE extension",
+      "pricing": "Freemium",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": {
+        "source": "early-stage; no public metrics",
+        "measured_date": "2026-04-24"
+      },
+      "stars_history": []
     },
     {
       "name": "Paperclip",
       "github_repo": "paperclipai/paperclip",
       "category": "orchestrator",
       "website": "https://paperclip.ing",
-      "description": "Open-source hierarchical agent orchestrator modelling a zero-human company with CEO, manager, and worker agents",
-      "stars": 52042,
-      "irrlicht_support": "none",
+      "description": "Orchestration platform for \"zero-human companies\" \u2014 agents assigned to CEO/manager/worker roles with budgets and approvals.",
+      "stars": 58383,
+      "language": "TypeScript",
+      "license": "MIT",
+      "interface": "Web",
+      "pricing": "Freemium",
+      "irrlicht_support": "planned",
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 52042},
-        {"date": "2026-04-01", "stars": 51241}
+        {
+          "date": "2026-04-24",
+          "stars": 58383
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 52042
+        }
       ]
     },
     {
@@ -712,31 +1001,24 @@
       "github_repo": "agno-agi/agno",
       "category": "orchestrator",
       "website": "https://www.agno.com",
-      "description": "Python agent runtime for teams and workflows (formerly Phidata)",
-      "stars": 39367,
+      "description": "Python agent runtime for teams and workflows (formerly Phidata).",
+      "stars": 39648,
+      "language": "Python",
+      "license": "Apache-2.0",
+      "interface": "SDK / Web",
+      "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 39367},
-        {"date": "2026-04-01", "stars": 39332},
-        {"date": "2026-01-01", "stars": 36000}
-      ]
-    },
-    {
-      "name": "ChatDev",
-      "github_repo": "OpenBMB/ChatDev",
-      "category": "orchestrator",
-      "website": "https://github.com/OpenBMB/ChatDev",
-      "description": "Virtual software company powered by AI agents",
-      "stars": 32685,
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {"date": "2026-04-12", "stars": 32685},
-        {"date": "2026-04-01", "stars": 32660},
-        {"date": "2026-01-01", "stars": 28000}
+        {
+          "date": "2026-04-24",
+          "stars": 39648
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 39367
+        }
       ]
     },
     {
@@ -744,15 +1026,49 @@
       "github_repo": "ruvnet/ruflo",
       "category": "orchestrator",
       "website": "https://github.com/ruvnet/ruflo",
-      "description": "Multi-agent swarm orchestration platform for Claude",
-      "stars": 31366,
+      "description": "Agent orchestration platform for Claude: multi-agent swarms, RAG integration, Claude Code/Codex integration.",
+      "stars": 33079,
+      "language": "TypeScript",
+      "license": "MIT",
+      "interface": "CLI / SDK",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "planned",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-04-24",
+          "stars": 33079
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 31366
+        }
+      ]
+    },
+    {
+      "name": "ChatDev",
+      "github_repo": "OpenBMB/ChatDev",
+      "category": "orchestrator",
+      "website": "https://github.com/OpenBMB/ChatDev",
+      "description": "Virtual software company powered by multi-agent LLM collaboration (ChatDev 2.0).",
+      "stars": 32847,
+      "language": "Python",
+      "license": "Apache-2.0",
+      "interface": "CLI / Web",
+      "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 31366},
-        {"date": "2026-04-01", "stars": 31095},
-        {"date": "2026-01-01", "stars": 29700}
+        {
+          "date": "2026-04-24",
+          "stars": 32847
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 32685
+        }
       ]
     },
     {
@@ -760,15 +1076,24 @@
       "github_repo": "stitionai/devika",
       "category": "orchestrator",
       "website": "https://github.com/stitionai/devika",
-      "description": "Open-source AI software engineer",
-      "stars": 19497,
+      "description": "Open-source agentic software engineer (originally an open alternative to Devin).",
+      "stars": 19502,
+      "language": "Python",
+      "license": "MIT",
+      "interface": "Web",
+      "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 19497},
-        {"date": "2026-04-01", "stars": 19499},
-        {"date": "2026-01-01", "stars": 18500}
+        {
+          "date": "2026-04-24",
+          "stars": 19502
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 19497
+        }
       ]
     },
     {
@@ -776,15 +1101,24 @@
       "github_repo": "gastownhall/gastown",
       "category": "orchestrator",
       "website": "https://github.com/gastownhall/gastown",
-      "description": "Multi-agent workspace manager by Steve Yegge",
-      "stars": 13898,
+      "description": "Multi-agent workspace manager: Mayor (coordinator) routes work through Rigs and Polecats with a Beads work-state ledger.",
+      "stars": 14580,
+      "language": "Go",
+      "license": "MIT",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
       "irrlicht_support": "live",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 13898},
-        {"date": "2026-04-01", "stars": 13824},
-        {"date": "2026-01-01", "stars": 1000}
+        {
+          "date": "2026-04-24",
+          "stars": 14580
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 13898
+        }
       ]
     },
     {
@@ -792,15 +1126,24 @@
       "github_repo": "smtg-ai/claude-squad",
       "category": "orchestrator",
       "website": "https://github.com/smtg-ai/claude-squad",
-      "description": "Manage multiple Claude Code instances in tmux",
-      "stars": 6961,
+      "description": "Manage multiple AI terminal agents (Claude Code, Codex, OpenCode, Amp) in tmux.",
+      "stars": 7145,
+      "language": "Go",
+      "license": "AGPL-3.0",
+      "interface": "CLI (tmux)",
+      "pricing": "Free (open source)",
       "irrlicht_support": "planned",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 6961},
-        {"date": "2026-04-01", "stars": 6939},
-        {"date": "2026-01-01", "stars": 5800}
+        {
+          "date": "2026-04-24",
+          "stars": 7145
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 6961
+        }
       ]
     },
     {
@@ -808,14 +1151,24 @@
       "github_repo": "ComposioHQ/agent-orchestrator",
       "category": "orchestrator",
       "website": "https://composio.dev",
-      "description": "Agent-agnostic orchestrator for parallel coding agents with CI auto-fix",
-      "stars": 6182,
+      "description": "Agent-agnostic orchestrator for parallel coding agents with autonomous CI auto-fix.",
+      "stars": 6474,
+      "language": "TypeScript",
+      "license": "MIT",
+      "interface": "CLI / Web",
+      "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 6182},
-        {"date": "2026-04-01", "stars": 6141}
+        {
+          "date": "2026-04-24",
+          "stars": 6474
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 6182
+        }
       ]
     },
     {
@@ -823,14 +1176,24 @@
       "github_repo": "dlorenc/multiclaude",
       "category": "orchestrator",
       "website": "https://github.com/dlorenc/multiclaude",
-      "description": "Parallel Claude Code instances in tmux with Brownian ratchet CI model",
-      "stars": 529,
-      "irrlicht_support": "none",
+      "description": "Parallel Claude Code instances in tmux with a Brownian-ratchet CI model.",
+      "stars": 539,
+      "language": "Go",
+      "license": null,
+      "interface": "CLI (tmux)",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "planned",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 529},
-        {"date": "2026-04-01", "stars": 530}
+        {
+          "date": "2026-04-24",
+          "stars": 539
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 529
+        }
       ]
     },
     {
@@ -838,14 +1201,24 @@
       "github_repo": "stoneforge-ai/stoneforge",
       "category": "orchestrator",
       "website": "https://stoneforge.ai",
-      "description": "Web dashboard orchestrating AI coding agent teams with worktree isolation",
-      "stars": 113,
+      "description": "Web dashboard orchestrating AI coding agent teams with worktree isolation.",
+      "stars": 130,
+      "language": "TypeScript",
+      "license": "Apache-2.0",
+      "interface": "Web",
+      "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 113},
-        {"date": "2026-04-01", "stars": 110}
+        {
+          "date": "2026-04-24",
+          "stars": 130
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 113
+        }
       ]
     },
     {
@@ -853,14 +1226,24 @@
       "github_repo": "nxtg-ai/forge-orchestrator",
       "category": "orchestrator",
       "website": "https://forge.nxtg.ai",
-      "description": "Rust-based multi-AI task orchestrator with file locking and drift detection",
-      "stars": 108,
+      "description": "Rust-based multi-AI task orchestrator with file locking and drift detection.",
+      "stars": 109,
+      "language": "Rust",
+      "license": null,
+      "interface": "CLI",
+      "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
-        {"date": "2026-04-12", "stars": 108},
-        {"date": "2026-04-01", "stars": 107}
+        {
+          "date": "2026-04-24",
+          "stars": 109
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 108
+        }
       ]
     }
   ]

--- a/.claude/skills/ir:agent-landscape/skill.md
+++ b/.claude/skills/ir:agent-landscape/skill.md
@@ -7,242 +7,200 @@ description: "Scan the web for coding agents and agent orchestrators, track GitH
 
 Discover, track, and rank coding agents and agent orchestrators. Publish a styled HTML report to the irrlicht site at `site/landscape/index.html` and an in-depth comparison at `site/landscape/compare/index.html`.
 
+## Non-negotiable rules
+
+Past runs of this skill invented data — fabricated star counts, wrong repo paths, copied descriptions instead of reading the actual README, and fake historical snapshots (e.g. "2026-01-01" entries for agents the skill only started tracking in April). Follow these rules to prevent a repeat:
+
+1. **Never invent a value.** Every `stars`, `language`, `license`, `description`, `funding_millions_usd`, `estimated_users`, or historical snapshot must come from a concrete source you can quote (the gh CLI, a specific WebFetch URL, a specific search result). If you don't have a source, write `null` and move on.
+2. **Never copy an old value forward.** If you can't re-verify a field on this run, set it to `null` instead of leaving whatever was in the file from last time.
+3. **Always use `gh api` for GitHub data, not WebFetch.** `gh api repos/OWNER/REPO` returns canonical stars, language, license, description, archived flag, and follows renames. `WebFetch` on github.com returns JS-rendered pages that routinely give stale numbers.
+4. **Honor GitHub's repo-rename redirects.** `gh api` returns a `full_name` field. If `full_name != OWNER/REPO` that you requested, the repo has been transferred. Update `github_repo` to the new canonical path in `agent-data.json`.
+5. **Never write a historical snapshot you didn't measure.** `stars_history` may only contain entries this skill actually measured. Do not back-fill "~3 months ago" or "~1 month ago" rows from memory or estimate.
+6. **Plausibility check before writing.** Before writing a new stars value, compare to the prior snapshot. If the delta is >30% in <30 days for a repo with >5k stars, investigate before trusting it — it's more likely a bad query than real growth. Common causes: cached HTML, wrong repo, joke repo inflating itself via README marketing.
+7. **Descriptions come from the repo's own `description` field**, not from product marketing pages. If a description contains attribution (e.g. "Anthropic's X" or "Google's Y"), verify the GitHub owner matches the claim. `badlogic/pi-mono` is not Anthropic's. `block/goose` is not Block's anymore (it was transferred). `cursor/cursor` is not the editor source (it's the issue tracker).
+8. **Archived repos go in the "archived" list, not the ranked table.** `gh api` returns `archived: true` — respect it.
+9. **Short-window growth is not 1-month or 3-month growth.** Until the repo has a snapshot ≥30 days old, the growth column must read "Recent growth since <date> (Nd ago)", not "1M" or "3M". The HTML generator already enforces this.
+
 ## Data File
 
 All state persists in `references/agent-data.json` (relative to this skill directory). Schema:
 
 ```json
 {
-  "last_updated": "2026-04-12",
+  "last_updated": "2026-04-24",
   "agents": [
     {
       "name": "Aider",
-      "github_repo": "paul-gauthier/aider",
+      "github_repo": "Aider-AI/aider",
       "category": "agent",
       "website": "https://aider.chat",
-      "description": "AI pair programming in your terminal",
-      "stars": 30000,
+      "description": "AI pair-programming tool in your terminal.",
+      "stars": 43874,
+      "language": "Python",
+      "license": "Apache-2.0",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
       "stars_history": [
-        {"date": "2026-04-12", "stars": 30000},
-        {"date": "2026-04-05", "stars": 29800},
-        {"date": "2026-03-12", "stars": 28500},
-        {"date": "2026-01-12", "stars": 27000}
+        {"date": "2026-04-24", "stars": 43874},
+        {"date": "2026-04-12", "stars": 43202}
       ],
       "alternative_metrics": null,
       "irrlicht_support": "none",
-      "first_seen": "2026-01-05"
+      "first_seen": "2026-04-05"
     }
   ]
 }
 ```
 
 Field definitions:
-- `stars` — current GitHub stars (null if no public repo)
-- `stars_history` — array of `{date, stars}` snapshots, newest first. Always maintain 4 anchor points: **today**, **~1 week ago**, **~1 month ago**, **~3 months ago**. When adding today's snapshot, keep the existing entry closest to each anchor and trim anything else. Keep up to 6 entries total.
-- `alternative_metrics` — for agents without a public GitHub repo. Object with optional fields:
-  ```json
-  {
-    "vscode_installs": 5200000,
-    "npm_weekly_downloads": 120000,
-    "funding_millions_usd": 150,
-    "estimated_users": "1M+",
-    "source": "VS Code Marketplace, Crunchbase",
-    "measured_date": "2026-04-12"
-  }
-  ```
-  Set to `null` for agents that have a GitHub repo.
-- `irrlicht_support` — one of: `"live"`, `"planned"`, `"none"`
-- `category` — one of: `"agent"`, `"orchestrator"`
-- `first_seen` — ISO date when the agent was first added to tracking
+- `github_repo` — canonical `OWNER/REPO` from `gh api` `.full_name`. Rewrite on repo rename.
+- `stars` — current GitHub stars from `gh api` `.stargazers_count`. `null` if no public repo.
+- `language`, `license` — straight from `gh api` (`.language`, `.license.spdx_id`). `null` if missing.
+- `description` — from `gh api` `.description`. Lightly cleaned if too long, but never replaced with third-party marketing copy. For non-GitHub agents, use the project's own homepage.
+- `interface` — curated string (CLI / IDE extension / Desktop app / Web / SDK / Enterprise SaaS / CLI (tmux) / etc.).
+- `pricing` — curated string (Free (open source) / Freemium / Paid / Enterprise / Paid (usage-based)).
+- `stars_history` — snapshots **this skill actually measured**. Newest first. Never back-fill.
+- `alternative_metrics` — for non-GitHub agents. Object with any of `funding_millions_usd`, `acquisition_price_millions_usd`, `estimated_users`, `source`, `measured_date`. Set to `null` when `github_repo` is set.
+- `irrlicht_support` — `"live"` (adapter exists in `core/adapters/inbound/`), `"planned"`, or `"none"`.
+- `category` — `"agent"` or `"orchestrator"`.
+- `first_seen` — ISO date when this entry was first added. Never change it once set.
 
-### Snapshot Strategy
+### Snapshot strategy
 
-Snapshots are measured relative to the **current date** (the day the skill runs), NOT normalized to month boundaries.
+Snapshots accumulate over successive runs. No back-filling.
 
-Anchor points (always relative to today):
-- **today** — fresh star count from GitHub API
-- **~1 week ago** — closest existing snapshot to (today - 7 days)
-- **~1 month ago** — closest existing snapshot to (today - 30 days)
-- **~3 months ago** — closest existing snapshot to (today - 90 days)
+On each run:
+1. Append today's `{date, stars}` to `stars_history` for each GitHub agent.
+2. Retain all prior real snapshots (no trimming until we have > 12 entries).
+3. If today already has an entry, overwrite it (same-day re-run).
+4. Dates are the run date, not a month/week anchor.
 
-When updating:
-1. Add today's snapshot (or update if today already exists)
-2. From remaining history, keep the single entry closest to each anchor
-3. Discard duplicates and anything else beyond 6 total entries
-4. Sort newest first
+Growth is only computed on demand in the HTML generator using whichever snapshots exist. Until there is a snapshot ≥30 days old, growth is shown as "Recent growth since <date> (Nd ago)" rather than "1M" / "3M".
 
-### "NEW" Badge
+### NEW badge
 
-An agent is marked **NEW** if its `first_seen` date is less than 3 months before today (i.e., `today - first_seen < 90 days`). Display a "new" superscript badge next to its name in both the main table and comparison page.
+An agent is "NEW" only if both:
+- `first_seen` is strictly later than the earliest `first_seen` across all tracked agents (so the initial seed batch never gets tagged), **and**
+- `first_seen` is within the last 90 days.
 
-## Deny List
+## Deny list
 
-`references/deny-list.txt` lists agent/orchestrator names to explicitly exclude (one per line). Skip any agent whose name matches a line in this file during discovery and HTML generation. Remove matching entries from `agent-data.json` if present.
+`references/deny-list.txt` lists agent/orchestrator names to explicitly exclude. One name per line; `#` lines are comments. Entries with matching `name` field are skipped during discovery and removed from `agent-data.json` if present.
 
-## Irrlicht Support Status
+## Irrlicht support mapping
 
-These agents have irrlicht adapters (mark as `"live"`):
-- Claude Code (`anthropics/claude-code`)
-- OpenAI Codex CLI (`openai/codex`, display as "OpenAI Codex")
-- Pi (`badlogic/pi-mono`)
-- Gas Town
+The canonical source of truth is `core/adapters/inbound/agents/` + `core/adapters/inbound/orchestrators/`. As of this writing:
 
-These are planned (mark as `"planned"`):
-- Gemini CLI
-- Cursor
-- Amp
-- Claude Squad
-- OpenCode (`anomalyco/opencode`)
+- `live`: Claude Code (`anthropics/claude-code`), OpenAI Codex (`openai/codex`), Pi (`badlogic/pi-mono`), Gas Town (`gastownhall/gastown`).
+- `planned`: Gemini CLI, Cursor, Amp, Claude Squad, OpenCode, Qwen Code, Crush, Continue, Goose, Aider, Kilo Code, Paperclip, Ruflo, Multiclaude, SWE-agent.
+- Everything else: `none`.
 
-Everything else: `"none"`.
+Before each run, `ls core/adapters/inbound/agents/` and `ls core/adapters/inbound/orchestrators/` to confirm the list is still correct. If the set of live adapters has changed, update this section and apply the change to `agent-data.json`.
 
 ## Workflow
 
-### 1. Load Existing Data
+### 0. Preflight
 
-Read `references/agent-data.json`. If `agents` is empty, read `references/seed-agents.md` for the initial list of known agents.
-
-Read `references/deny-list.txt`. Remove any agents whose name matches a deny-list entry from the loaded data. Skip denied names during discovery (step 2).
-
-### 2. Search for New Agents
-
-Use WebSearch to find coding agents and orchestrators not already tracked:
-- `"best AI coding agents 2026"`
-- `"new coding assistant CLI terminal 2026"`
-- `"AI agent orchestrator framework 2026"`
-- `"agentic coding tools"`
-- `"claude code coding agent alternatives"`
-- `"gas town coding agent orchestrator alternatives"`
-
-Add any genuinely new coding agents or orchestrators found. Skip IDE themes, linters, or general-purpose AI chatbots — only track tools that write/edit code autonomously or orchestrate agents that do.
-
-### 3. Fetch GitHub Stars
-
-For each agent with a `github_repo`:
-
-1. Use WebFetch to get `https://api.github.com/repos/{owner}/{repo}` (JSON response includes `stargazers_count`)
-2. Set `stars` to current `stargazers_count`
-3. Add a snapshot for **today** in `stars_history`
-4. Trim history per the snapshot strategy above (keep closest to each anchor, max 6 entries)
-
-If the GitHub API rate-limits (403), use WebSearch `"{agent name}" github stars` as fallback and parse the count from search results.
-
-### 4. Fetch Alternative Metrics for Non-GitHub Agents
-
-For agents where `github_repo` is null, gather alternative popularity signals:
-
-1. **VS Code Marketplace installs** — if the agent has a VS Code extension, use WebSearch `"{agent name}" VS Code marketplace installs` and extract the install count
-2. **npm weekly downloads** — if there's an npm package, use WebFetch `https://api.npmjs.org/downloads/point/last-week/{package}` 
-3. **Funding** — use WebSearch `"{agent name}" funding raised` to find total funding in millions USD
-4. **Estimated users** — use WebSearch `"{agent name}" users monthly active` for any public user counts
-
-Store results in `alternative_metrics`. Set `source` to describe where the data came from. Set `measured_date` to today. Only populate fields you can actually find — leave others out of the object.
-
-If you cannot find any alternative metrics, set `alternative_metrics` to an empty object `{}` with just `measured_date` and `source: "no public data found"`.
-
-### 5. Compute Rankings
-
-For each agent, compute a `score` using star data from `stars_history`:
-
-```
-# Anchor dates (relative to today)
-today       = current date
-date_1m     = today - 30 days
-date_3m     = today - 90 days
-
-# Pick the snapshots closest to each anchor (strict tolerance)
-current  = stars_history entry closest to today
-snap_1m  = stars_history entry closest to date_1m (null if none within 10 days)
-snap_3m  = stars_history entry closest to date_3m (null if none within 21 days)
-
-# Growth calculations
-growth_1m_abs = current.stars - snap_1m.stars      (null if snap_1m missing)
-growth_1m_pct = growth_1m_abs / snap_1m.stars * 100 (null if snap_1m missing or snap_1m.stars == 0)
-
-growth_3m_abs = current.stars - snap_3m.stars      (null if snap_3m missing)
-growth_3m_pct = growth_3m_abs / snap_3m.stars * 100 (null if snap_3m missing or snap_3m.stars == 0)
-
-# Trend = average monthly gain over 3 months
-days     = days between snap_3m.date and current.date
-trend    = growth_3m_abs / days * 30               (0 if < 2 snapshots)
-
-normalized_stars = log10(stars + 1)                 # dampen mega-repos
-normalized_trend = log10(trend + 1)                 # monthly gain scale
-
-# Score depends on whether we have enough history for a trend
-if snap_3m is not null:
-    score = 0.6 * normalized_stars + 0.4 * normalized_trend
-else:
-    score = 0.85 * normalized_stars              # no trend penalty for new entries
+```bash
+cd /Users/ingo/projects/irrlicht
+gh auth status
+ls core/adapters/inbound/agents
+ls core/adapters/inbound/orchestrators
 ```
 
-**Non-GitHub agents** (where `stars` is null) are **not ranked** alongside GitHub agents. They appear in a separate "No Public Repo" group below the ranked table, sorted by their best available alternative metric. Do not assign them a numeric rank — show `—` for rank.
+Abort if `gh` is not authenticated — every other step depends on it.
 
-### 6. Save Data
+### 1. Load existing data
 
-Write updated `references/agent-data.json` with the new snapshots and alternative metrics.
+Read `references/agent-data.json`. Read `references/deny-list.txt` and prune any matching entries from the data. If `agents` is empty, read `references/seed-agents.md` for the initial list.
 
-### 7. Generate HTML Report (Main Table)
+### 2. Refresh every GitHub agent via `gh api`
 
-Generate `site/landscape/index.html` using the template structure in `assets/page-template.html`.
+For every agent with `github_repo`, run:
 
-The page must:
-- Match the irrlicht site design (dark theme, same CSS variables, fonts, nav)
-- Show two tables: "Coding Agents" and "Agent Orchestrators"
-- Each row: rank, name (linked to website/repo), stars (formatted with commas), **3M growth**, irrlicht support badge, description
-- **3M growth column**: Show absolute change and percentage, e.g. `+5,200 (12.3%)`. Use green for positive, red for negative, dim for zero/flat. Show `—` if no 3M data. (1M growth is only shown on the comparison page.)
-- **NEW badge**: Show a styled "NEW" superscript next to the name for agents first seen < 90 days ago
-- **Trend note**: Add a small note below the table header stating the actual baseline dates, e.g.: "1M growth measured vs YYYY-MM-DD snapshot; 3M growth measured vs YYYY-MM-DD snapshot." Use the real dates of the snapshots used, not approximate labels.
-- For agents without GitHub stars but with `alternative_metrics`: show the most relevant metric instead of stars (e.g., "5.2M installs" or "$150M raised") with a footnote explaining the source
-- Badges: green "live" / orange "planned" / grey "not tracked" matching the site's tag styles
-- Show `last_updated` date in the header
-- Include a "What is this?" intro explaining the page
-- Link to the comparison page: "See the [detailed comparison →](compare/)" 
-- Be fully self-contained (inline CSS, no external dependencies beyond Google Fonts)
+```bash
+gh api repos/<github_repo> --jq '{repo: .full_name, stars: .stargazers_count, language: .language, license: .license.spdx_id, description: .description, archived: .archived}'
+```
 
-### 8. Generate Comparison Page
+Batch them in a single bash loop so you don't issue 40 separate tool calls. Example:
 
-Generate `site/landscape/compare/index.html` using the template in `assets/compare-template.html`.
+```bash
+jq -r '.agents[] | select(.github_repo != null) | .github_repo' references/agent-data.json \
+| while read -r repo; do
+    gh api "repos/$repo" --jq '{queried: "'"$repo"'", repo: .full_name, stars: .stargazers_count, language: .language, license: .license.spdx_id, description: .description, archived: .archived}'
+  done
+```
 
-This is an in-depth comparison page with a single unified table covering **all** agents and orchestrators. The table includes these columns:
+For each result:
+- If `repo != queried`, GitHub has renamed the repo — update `github_repo` to `repo`.
+- If `archived: true`, move the agent out of the ranked tables into a separate "archived" list (or drop it if it's been replaced by another product — note the reason in a commit message).
+- Update `stars`, `language`, `license`, `description` from the API response.
+- Append today's `{date, stars}` to `stars_history` (overwriting if today already exists).
+- Run the plausibility check from rule #6 above.
 
-| Column | Description |
-|--------|-------------|
-| Name | Agent name + link + NEW badge if applicable |
-| Category | "Agent" or "Orchestrator" badge |
-| Stars | Current GitHub stars (or alternative metric) |
-| 1M Growth | Stars gained in the last month (absolute + %) |
-| 3M Growth | Stars gained in the last 3 months (absolute + %) |
-| Open Source | Yes/No |
-| License | MIT, Apache-2.0, proprietary, etc. |
-| Primary Language | Go, TypeScript, Python, Rust, etc. |
-| Interface | CLI, IDE extension, Web, Desktop app |
-| Pricing | Free, freemium, paid, etc. |
-| Irrlicht | Support badge |
+### 3. Search for new agents (optional; only when explicitly requested or quarterly)
 
-Data sourcing for comparison columns:
-- **License** and **Primary Language**: fetch from GitHub API (`license.spdx_id`, `language` fields) for repos with `github_repo`. Use WebSearch for non-GitHub agents.
-- **Interface** and **Pricing**: derive from existing `description` field + WebSearch if not obvious.
-- **Open Source**: `true` if `github_repo` is not null and license is not proprietary.
-The comparison page must:
-- Use the same dark theme, nav, and fonts as the main page
-- Be sortable by clicking column headers (use inline JavaScript, no external deps)
-- Include a note at the top: "Growth figures measured relative to today ({{LAST_UPDATED}}). 1M baseline: YYYY-MM-DD. 3M baseline: YYYY-MM-DD." Use the real snapshot dates.
-- Mark **License** and **Pricing** column headers with an asterisk (*). Add a footnote at the bottom of the table: "* License and pricing data sourced via web search and may not reflect the latest changes. Verify on the project's website."
-- Show a "← Back to Landscape" link to the main table
-- Be fully self-contained
+Use WebSearch queries such as:
+- `"best AI coding agents <year>"`
+- `"new coding assistant CLI terminal <year>"`
+- `"agent orchestrator framework <year>"`
+- `"claude code alternatives"` / `"gas town alternatives"`
 
-### 9. Update Landing Page Navigation
+Skip anything that isn't a coding-specific agent or orchestrator (IDE themes, linters, general chatbots). Skip anything on the deny list.
 
-Add a nav link to the landscape page in `site/index.html` if not already present. Add it to both:
-- The nav bar: `<li class="nav-hide-sm"><a href="landscape/">Landscape</a></li>` (before Docs)
-- The footer: `<a href="landscape/">Agent Landscape</a>` (before Docs)
+For each new discovery:
+- Resolve the canonical repo with `gh api` (see step 2) before writing anything.
+- Set `first_seen` to today.
+- Fill `interface` and `pricing` manually based on the project's own homepage.
 
-### 10. Summary
+### 4. Refresh non-GitHub agents (alternative_metrics)
 
-Print a concise summary:
-- Total agents tracked, how many new this run
-- Top 5 by score (name + stars + 1M growth + 3M growth)
-- Any agents where irrlicht support status may be outdated
-- Count of agents with vs. without GitHub repos
-- Note: "Comparison page generated at site/landscape/compare/index.html"
+For each agent with `github_repo: null`, re-check the following and update `measured_date` to today:
+
+- Funding: `"<name>" funding round <year>` — look for the most recent round on TechCrunch / Bloomberg / Crunchbase.
+- Acquisition: `"<name>" acquisition <year>` — if acquired, set `acquisition_price_millions_usd` and note in the description.
+- User count: `"<name>" monthly active users` or `"<name>" VS Code marketplace installs`.
+
+Only write numbers you have a source for. Set `source` to a short citation (outlet + date). If no data found, set `source` to a honest `"no public data found"` string.
+
+Common pitfalls:
+- Devin ≠ Cognition's total funding. Record under Devin since Devin is Cognition's product, but note "Cognition AI parent" in the source.
+- Amp ≠ Sourcegraph Cody. Cody was rebranded to Amp; Amp is spinning out as a standalone company. Do not list both.
+- Windsurf was acquired by Cognition (Dec 2025). Its funding field should be null; its `acquisition_price_millions_usd` should be set.
+
+### 5. Save `agent-data.json`
+
+Write the updated data. Sort agents by category (agent first), then by stars descending, then by name ascending. Set `last_updated` to today.
+
+### 6. Generate HTML
+
+Run the HTML generator:
+
+```bash
+python3 .claude/skills/ir:agent-landscape/assets/generate.py   # if checked in
+# else: use the generator documented below
+```
+
+If the generator script is not checked in, the latest reference implementation lives in the commit that last touched `site/landscape/`. Use it as-is rather than re-writing it from scratch.
+
+The generator must:
+- Rank GitHub agents by `log10(stars + 1)` when no ≥30-day snapshot exists (no fake trend bonus).
+- Add a trend component only when at least one snapshot is ≥30 days old.
+- Show "Recent growth since `<prior snapshot date>` (Nd ago)" in the growth column header when no 30-day snapshot exists; switch to "1M / 3M growth" only when real snapshots at those horizons exist.
+- Tag NEW per the rule above (later than earliest `first_seen` and within 90 days).
+- Place non-GitHub agents in an unranked "No public repo" group below the ranked table.
+- Include a footnote: "* License and pricing are sourced from the GitHub API and public web pages. Verify on the project's own website before relying on them."
+
+### 7. Update landing-page nav
+
+Ensure `site/index.html` has the Landscape nav link (nav bar + footer). Idempotent; skip if present.
+
+### 8. Summary
+
+Print:
+- Count of tracked agents, how many github vs non-github.
+- Any repos where `gh api` returned a renamed `full_name` (report the rename so the user can commit it).
+- Any agents marked `archived: true` (report even if you've moved them out of the ranked list).
+- Any plausibility-check failures (stars delta >30% in <30 days for a 5k+ repo) — do NOT silently write them; ask the user whether to trust the number.
+- Top 5 by current stars per category.
+- Diff summary: `git diff --stat site/landscape/` and `git diff --stat .claude/skills/ir:agent-landscape/references/agent-data.json`.

--- a/site/landscape/compare/index.html
+++ b/site/landscape/compare/index.html
@@ -122,749 +122,666 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <a href="../" class="back-link">&larr; Back to Landscape</a>
   <div class="page-header">
     <h1>Agent Comparison</h1>
-    <div class="updated">Last updated: 2026-04-12</div>
-    <p class="intro">In-depth comparison of all tracked AI coding agents and orchestrators. Click any column header to sort. Growth measured relative to 2026-04-12. 1M: no snapshot within tolerance yet. 3M baseline: 2026-01-01 (where available).</p>
+    <div class="updated">Last updated: 2026-04-24</div>
+    <p class="intro">In-depth comparison of all tracked AI coding agents and orchestrators. Click any column header to sort. Growth figures are measured relative to today using snapshots taken at: today, ~1 month ago, and ~3 months ago.</p>
   </div>
 
   <p class="trend-note">Agents without a public GitHub repo show alternative popularity metrics where available (VS Code installs, funding, estimated users).</p>
 
   <div class="table-wrap">
     <table class="compare-table">
-<thead>
-<tr>
-<th>Name <span class="sort-arrow">&#x25B2;</span></th>
-<th>Cat. <span class="sort-arrow">&#x25B2;</span></th>
-<th>Stars <span class="sort-arrow">&#x25B2;</span></th>
-<th>1M <span class="sort-arrow">&#x25B2;</span></th>
-<th>3M <span class="sort-arrow">&#x25B2;</span></th>
-<th>OSS <span class="sort-arrow">&#x25B2;</span></th>
-<th>License* <span class="sort-arrow">&#x25B2;</span></th>
-<th>Lang <span class="sort-arrow">&#x25B2;</span></th>
-<th>Interface <span class="sort-arrow">&#x25B2;</span></th>
-<th>Pricing* <span class="sort-arrow">&#x25B2;</span></th>
-<th>Irrlicht <span class="sort-arrow">&#x25B2;</span></th>
-</tr>
-</thead>
+<thead><tr>
+<th>Name<span class="sort-arrow">▲</span></th>
+<th>Category<span class="sort-arrow">▲</span></th>
+<th>Stars / Metric<span class="sort-arrow">▲</span></th>
+<th class="growth-3m">Recent growth<span class="sort-arrow">▲</span></th>
+<th>Open Source<span class="sort-arrow">▲</span></th>
+<th>License*<span class="sort-arrow">▲</span></th>
+<th>Primary Language<span class="sort-arrow">▲</span></th>
+<th>Interface<span class="sort-arrow">▲</span></th>
+<th>Pricing*<span class="sort-arrow">▲</span></th>
+<th>Irrlicht<span class="sort-arrow">▲</span></th>
+</tr></thead>
 <tbody>
 <tr>
-<td class="name"><a href="https://claw-code.codes">Claw Code</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="182111">182,111</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Unknown</td>
-<td>Rust</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="claw code"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="188050">188,050</td>
+  <td class="growth-3m"><span class="growth-up">+5,939 <span class="growth-pct">(+3.3%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>Rust</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://opencode.ai">OpenCode</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="141888">141,888</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="136388">+136,388 <span class="growth-pct">(2480.7%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>TypeScript</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-planned">Planned</span></td>
+  <td class="name" data-sort="opencode"><a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="148747">148,747</td>
+  <td class="growth-3m"><span class="growth-up">+6,859 <span class="growth-pct">(+4.8%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/anthropics/claude-code">Claude Code</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="112845">112,845</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="61145">+61,145 <span class="growth-pct">(118.3%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>ISC</td>
-<td>TypeScript</td>
-<td>CLI</td>
-<td>Paid (API)</td>
-<td><span class="badge badge-live">Live</span></td>
+  <td class="name" data-sort="claude code"><a href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener">Claude Code</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="117553">117,553</td>
+  <td class="growth-3m"><span class="growth-up">+4,708 <span class="growth-pct">(+4.2%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>Shell</td>
+  <td>CLI</td>
+  <td>Paid (usage-based)</td>
+  <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/google-gemini/gemini-cli">Gemini CLI</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="100994">100,994</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="11194">+11,194 <span class="growth-pct">(12.5%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>TypeScript</td>
-<td>CLI</td>
-<td>Free tier</td>
-<td><span class="badge badge-planned">Planned</span></td>
+  <td class="name" data-sort="gemini cli"><a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener">Gemini CLI</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="102304">102,304</td>
+  <td class="growth-3m"><span class="growth-up">+1,310 <span class="growth-pct">(+1.3%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/openai/codex">OpenAI Codex</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="74758">74,758</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="28758">+28,758 <span class="growth-pct">(62.5%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>Rust</td>
-<td>CLI</td>
-<td>Paid (API)</td>
-<td><span class="badge badge-live">Live</span></td>
+  <td class="name" data-sort="openai codex"><a href="https://github.com/openai/codex" target="_blank" rel="noopener">OpenAI Codex</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="77568">77,568</td>
+  <td class="growth-3m"><span class="growth-up">+2,810 <span class="growth-pct">(+3.8%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Rust</td>
+  <td>CLI</td>
+  <td>Paid (usage-based)</td>
+  <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/All-Hands-AI/OpenHands">OpenHands</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="71060">71,060</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="19060">+19,060 <span class="growth-pct">(36.7%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>Python</td>
-<td>CLI, Web</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="openhands"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">OpenHands</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="71985">71,985</td>
+  <td class="growth-3m"><span class="growth-up">+925 <span class="growth-pct">(+1.3%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Python</td>
+  <td>CLI / Web</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/cline/cline">Cline</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="60178">60,178</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="24178">+24,178 <span class="growth-pct">(67.2%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>TypeScript</td>
-<td>IDE ext</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="cline"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="60949">60,949</td>
+  <td class="growth-3m"><span class="growth-up">+771 <span class="growth-pct">(+1.3%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>IDE extension (VS Code)</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/gpt-engineer-org/gpt-engineer">GPT Engineer</a></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="55217">55,217</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="2217">+2,217 <span class="growth-pct">(4.2%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>Python</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="paperclip"><a href="https://paperclip.ing" target="_blank" rel="noopener">Paperclip</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="58383">58,383</td>
+  <td class="growth-3m"><span class="growth-up">+6,341 <span class="growth-pct">(+12.2%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>Web</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://paperclip.ing">Paperclip</a> <span class="badge badge-new">NEW</span></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="52042">52,042</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>TypeScript</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="aider"><a href="https://aider.chat" target="_blank" rel="noopener">Aider</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="43874">43,874</td>
+  <td class="growth-3m"><span class="growth-up">+672 <span class="growth-pct">(+1.6%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Python</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://aider.chat">Aider</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="43202">43,202</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="7202">+7,202 <span class="growth-pct">(20.0%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>Python</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="goose"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="43139">43,139</td>
+  <td class="growth-3m"><span class="growth-up">+1,827 <span class="growth-pct">(+4.4%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Rust</td>
+  <td>CLI / Desktop app</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://block.github.io/goose/">Goose</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="41312">41,312</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="15212">+15,212 <span class="growth-pct">(58.3%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>Rust</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="agno"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="39648">39,648</td>
+  <td class="growth-3m"><span class="growth-up">+281 <span class="growth-pct">(+0.7%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Python</td>
+  <td>SDK / Web</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://www.agno.com">Agno</a></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="39367">39,367</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="3367">+3,367 <span class="growth-pct">(9.4%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>Python</td>
-<td>Python SDK</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="pi"><a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener">Pi</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="39373">39,373</td>
+  <td class="growth-3m"><span class="growth-up">+4,684 <span class="growth-pct">(+13.5%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/badlogic/pi-mono">Pi</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="34689">34,689</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="16289">+16,289 <span class="growth-pct">(88.5%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>TypeScript</td>
-<td>CLI</td>
-<td>Paid (API)</td>
-<td><span class="badge badge-live">Live</span></td>
+  <td class="name" data-sort="ruflo"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="33079">33,079</td>
+  <td class="growth-3m"><span class="growth-up">+1,713 <span class="growth-pct">(+5.5%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>CLI / SDK</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/OpenBMB/ChatDev">ChatDev</a></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="32685">32,685</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="4685">+4,685 <span class="growth-pct">(16.7%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>Python</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="chatdev"><a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener">ChatDev</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="32847">32,847</td>
+  <td class="growth-3m"><span class="growth-up">+162 <span class="growth-pct">(+0.5%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Python</td>
+  <td>CLI / Web</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://cursor.com">Cursor</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="32624">32,624</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="7624">+7,624 <span class="growth-pct">(30.5%)</span></td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE</td>
-<td>Freemium ($20/mo)</td>
-<td><span class="badge badge-planned">Planned</span></td>
+  <td class="name" data-sort="continue"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="32770">32,770</td>
+  <td class="growth-3m"><span class="growth-up">+271 <span class="growth-pct">(+0.8%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>IDE extension / CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://continue.dev">Continue</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="32499">32,499</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="1499">+1,499 <span class="growth-pct">(4.8%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>TypeScript</td>
-<td>IDE ext</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="cursor"><a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="32693">32,693</td>
+  <td class="growth-3m"><span class="growth-up">+69 <span class="growth-pct">(+0.2%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>Desktop app (IDE)</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/ruvnet/ruflo">Ruflo</a></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="31366">31,366</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="1666">+1,666 <span class="growth-pct">(5.6%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>TypeScript</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="void"><a href="https://voideditor.com" target="_blank" rel="noopener">Void</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="28644">28,644</td>
+  <td class="growth-3m"><span class="growth-up">+91 <span class="growth-pct">(+0.3%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>Desktop app (IDE)</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/voideditor/void">Void</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="28553">28,553</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="5553">+5,553 <span class="growth-pct">(24.1%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>TypeScript</td>
-<td>IDE</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="warp"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="26501">26,501</td>
+  <td class="growth-3m"><span class="growth-up">+129 <span class="growth-pct">(+0.5%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>Desktop app (Terminal)</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://www.warp.dev">Warp</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="26372">26,372</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="2372">+2,372 <span class="growth-pct">(9.9%)</span></td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>Terminal</td>
-<td>Freemium</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="qwen code"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="23813">23,813</td>
+  <td class="growth-3m"><span class="growth-up">+990 <span class="growth-pct">(+4.3%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/RooVetGit/Roo-Code">Roo Code</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="23088">23,088</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="5588">+5,588 <span class="growth-pct">(31.9%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>TypeScript</td>
-<td>IDE ext</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="crush"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="23418">23,418</td>
+  <td class="growth-3m"><span class="growth-up">+529 <span class="growth-pct">(+2.3%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Go</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://charm.land/crush">Crush</a> <span class="badge badge-new">NEW</span></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="22889">22,889</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Unknown</td>
-<td>Go</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="roo code"><a href="https://roocode.com" target="_blank" rel="noopener">Roo Code</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="23345">23,345</td>
+  <td class="growth-3m"><span class="growth-up">+257 <span class="growth-pct">(+1.1%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>IDE extension (VS Code)</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://qwen.ai/qwencode">Qwen Code</a> <span class="badge badge-new">NEW</span></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="22823">22,823</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>TypeScript</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="devika"><a href="https://github.com/stitionai/devika" target="_blank" rel="noopener">Devika</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="19502">19,502</td>
+  <td class="growth-3m"><span class="growth-up">+5 <span class="growth-pct">(+0.0%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Python</td>
+  <td>Web</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/stitionai/devika">Devika</a></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="19497">19,497</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="997">+997 <span class="growth-pct">(5.4%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>Python</td>
-<td>Web</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="swe-agent"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="19050">19,050</td>
+  <td class="growth-3m"><span class="growth-up">+82 <span class="growth-pct">(+0.4%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Python</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/princeton-nlp/SWE-agent">SWE-agent</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="18968">18,968</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="5968">+5,968 <span class="growth-pct">(45.9%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>Python</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="kilo code"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="18505">18,505</td>
+  <td class="growth-3m"><span class="growth-up">+517 <span class="growth-pct">(+2.9%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>IDE extension / CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://kilo.ai">Kilo Code</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="17988">17,988</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="6988">+6,988 <span class="growth-pct">(63.5%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>TypeScript</td>
-<td>IDE ext, CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="plandex"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="15289">15,289</td>
+  <td class="growth-3m"><span class="growth-up">+58 <span class="growth-pct">(+0.4%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Go</td>
+  <td>CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://plandex.ai">Plandex</a> <span class="badge badge-new">NEW</span></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="15231">15,231</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>Go</td>
-<td>CLI</td>
-<td>Freemium</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="gas town"><a href="https://github.com/gastownhall/gastown" target="_blank" rel="noopener">Gas Town</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="14580">14,580</td>
+  <td class="growth-3m"><span class="growth-up">+682 <span class="growth-pct">(+4.9%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Go</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/gastownhall/gastown">Gas Town</a></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="13898">13,898</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="12898">+12,898 <span class="growth-pct">(1289.8%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>Go</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-live">Live</span></td>
+  <td class="name" data-sort="open swe"><a href="https://github.com/langchain-ai/open-swe" target="_blank" rel="noopener">Open SWE</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="9642">9,642</td>
+  <td class="growth-3m"><span class="growth-up">+158 <span class="growth-pct">(+1.7%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Python</td>
+  <td>Web</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/langchain-ai/open-swe">Open SWE</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="9484">9,484</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>Python</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="sweep"><a href="https://sweep.dev" target="_blank" rel="noopener">Sweep</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="7705">7,705</td>
+  <td class="growth-3m"><span class="growth-down">-4 <span class="growth-pct">(-0.1%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>Jupyter Notebook</td>
+  <td>IDE extension (JetBrains)</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://sweep.dev">Sweep</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="7709">7,709</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="509">+509 <span class="growth-pct">(7.1%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Unknown</td>
-<td>Python</td>
-<td>GitHub bot</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="claude squad"><a href="https://github.com/smtg-ai/claude-squad" target="_blank" rel="noopener">Claude Squad</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="7145">7,145</td>
+  <td class="growth-3m"><span class="growth-up">+184 <span class="growth-pct">(+2.6%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>AGPL-3.0</td>
+  <td>Go</td>
+  <td>CLI (tmux)</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/smtg-ai/claude-squad">Claude Squad</a></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="6961">6,961</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="1161">+1,161 <span class="growth-pct">(20.0%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>AGPL-3.0</td>
-<td>Go</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-planned">Planned</span></td>
+  <td class="name" data-sort="forge code"><a href="https://forgecode.dev" target="_blank" rel="noopener">Forge Code</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="6925">6,925</td>
+  <td class="growth-3m"><span class="growth-up">+459 <span class="growth-pct">(+7.1%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Rust</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/antinomyhq/forgecode">Forge Code</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="6466">6,466</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>Rust</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="composio"><a href="https://composio.dev" target="_blank" rel="noopener">Composio</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="6474">6,474</td>
+  <td class="growth-3m"><span class="growth-up">+292 <span class="growth-pct">(+4.7%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>CLI / Web</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://composio.dev">Composio</a></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="6182">6,182</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>TypeScript</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="ra.aid"><a href="https://www.ra-aid.ai" target="_blank" rel="noopener">RA.Aid</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="2223">2,223</td>
+  <td class="growth-3m"><span class="growth-up">+5 <span class="growth-pct">(+0.2%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Python</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://www.ra-aid.ai">RA.Aid</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="2218">2,218</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>Python</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="factory"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="794">794</td>
+  <td class="growth-3m"><span class="growth-up">+38 <span class="growth-pct">(+5.0%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>Web / CLI</td>
+  <td>Paid</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://www.factory.ai">Factory</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="756">756</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>Web</td>
-<td>Paid</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="pear ai"><a href="https://trypear.ai" target="_blank" rel="noopener">Pear AI</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="676">676</td>
+  <td class="growth-3m"><span class="growth-up">+2 <span class="growth-pct">(+0.3%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>Desktop app (IDE)</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://trypear.ai">Pear AI</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="674">674</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-up" data-sort="174">+174 <span class="growth-pct">(34.8%)</span></td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>MIT</td>
-<td>TypeScript</td>
-<td>IDE</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="multiclaude"><a href="https://github.com/dlorenc/multiclaude" target="_blank" rel="noopener">Multiclaude</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="539">539</td>
+  <td class="growth-3m"><span class="growth-up">+10 <span class="growth-pct">(+1.9%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>Go</td>
+  <td>CLI (tmux)</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/dlorenc/multiclaude">Multiclaude</a></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="529">529</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Unknown</td>
-<td>Go</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="codegen"><a href="https://codegen.com" target="_blank" rel="noopener">Codegen</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="521">521</td>
+  <td class="growth-3m"><span class="growth-flat">0 <span class="growth-pct">(0.0%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Python</td>
+  <td>SDK / Web</td>
+  <td>Paid</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://codegen.com">Codegen</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="521">521</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>Python</td>
-<td>CLI, Web</td>
-<td>Freemium</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="stoneforge"><a href="https://stoneforge.ai" target="_blank" rel="noopener">Stoneforge</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="130">130</td>
+  <td class="growth-3m"><span class="growth-up">+17 <span class="growth-pct">(+15.0%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>Web</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://stoneforge.ai">Stoneforge</a></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="113">113</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Apache-2.0</td>
-<td>TypeScript</td>
-<td>Web</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="forge orchestrator"><a href="https://forge.nxtg.ai" target="_blank" rel="noopener">Forge Orchestrator</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="109">109</td>
+  <td class="growth-3m"><span class="growth-up">+1 <span class="growth-pct">(+0.9%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>Rust</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://forge.nxtg.ai">Forge Orchestrator</a></td>
-<td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-<td class="mono" data-sort="108">108</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-yes">&#x2713;</span></td>
-<td>Unknown</td>
-<td>Rust</td>
-<td>CLI</td>
-<td>Free</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="amazon q developer"><a href="https://aws.amazon.com/q/developer/" target="_blank" rel="noopener">Amazon Q Developer</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">—</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>IDE extension / CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://github.com/features/copilot">GitHub Copilot</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE ext</td>
-<td>Freemium ($10/mo)</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="amp"><a href="https://ampcode.com" target="_blank" rel="noopener">Amp</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">—</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>IDE extension / CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://codeium.com/windsurf">Windsurf</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE</td>
-<td>Freemium ($15/mo)</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="augment code"><a href="https://www.augmentcode.com" target="_blank" rel="noopener">Augment Code</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">$252M raised</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>IDE extension</td>
+  <td>Paid</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://devin.ai">Devin</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>Web</td>
-<td>Paid ($500/mo)</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="codebuff"><a href="https://codebuff.com" target="_blank" rel="noopener">Codebuff</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">—</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://ampcode.com">Amp</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>CLI, IDE ext</td>
-<td>Freemium</td>
-<td><span class="badge badge-planned">Planned</span></td>
+  <td class="name" data-sort="codegpt"><a href="https://www.codegpt.co" target="_blank" rel="noopener">CodeGPT</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">—</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>IDE extension / Web</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://aws.amazon.com/q/developer/">Amazon Q Developer</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE ext</td>
-<td>Freemium</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="cosine genie"><a href="https://cosine.sh" target="_blank" rel="noopener">Cosine Genie</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">—</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>Web</td>
+  <td>Paid</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://www.augmentcode.com">Augment Code</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE ext</td>
-<td>Paid</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="devin"><a href="https://devin.ai" target="_blank" rel="noopener">Devin</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">$696M raised</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>Web</td>
+  <td>Paid (from $20/mo)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://www.poolside.ai">Poolside</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE ext</td>
-<td>Paid</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="github copilot"><a href="https://github.com/features/copilot" target="_blank" rel="noopener">GitHub Copilot</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">20.0M users</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>IDE extension / Web</td>
+  <td>Paid (from $10/mo)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://www.tabnine.com">Tabnine</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE ext</td>
-<td>Freemium ($12/mo)</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="kiro"><a href="https://kiro.dev" target="_blank" rel="noopener">Kiro</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">—</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>Desktop app (IDE)</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://www.qodo.ai">Qodo</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE ext</td>
-<td>Freemium</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="morphllm"><a href="https://www.morphllm.com" target="_blank" rel="noopener">MorphLLM</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">—</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>API / SDK</td>
+  <td>Paid</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://sourcegraph.com/cody">Sourcegraph Cody</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE ext</td>
-<td>Freemium</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="poolside"><a href="https://www.poolside.ai" target="_blank" rel="noopener">Poolside</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">$626M raised</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>Enterprise SaaS</td>
+  <td>Enterprise</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://cosine.sh">Cosine Genie</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>Web</td>
-<td>Paid</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="qodo"><a href="https://www.qodo.ai" target="_blank" rel="noopener">Qodo</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">$120M raised</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>IDE extension / Web</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://zencoder.ai">Zencoder</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE ext</td>
-<td>Paid</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="tabnine"><a href="https://www.tabnine.com" target="_blank" rel="noopener">Tabnine</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">$102M raised</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>IDE extension</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://www.codegpt.co">CodeGPT</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE ext</td>
-<td>Freemium</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="windsurf"><a href="https://windsurf.com" target="_blank" rel="noopener">Windsurf</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">$250M acquisition</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>Desktop app (IDE)</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-<td class="name"><a href="https://www.morphllm.com">MorphLLM</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>API</td>
-<td>Paid</td>
-<td><span class="badge badge-none">None</span></td>
+  <td class="name" data-sort="zencoder"><a href="https://zencoder.ai" target="_blank" rel="noopener">Zencoder</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">—</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>IDE extension</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
-<tr>
-<td class="name"><a href="https://codebuff.com">Codebuff</a></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>CLI</td>
-<td>Paid</td>
-<td><span class="badge badge-none">None</span></td>
-</tr>
-<tr>
-<td class="name"><a href="https://kiro.dev">Kiro</a> <span class="badge badge-new">NEW</span></td>
-<td><span class="badge badge-cat badge-agent">Agent</span></td>
-<td class="mono" data-sort="-1">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td class="mono growth-na" data-sort="-999999">&mdash;</td>
-<td><span class="badge-oss-no">&#x2717;</span></td>
-<td>Proprietary</td>
-<td>&mdash;</td>
-<td>IDE</td>
-<td>Freemium</td>
-<td><span class="badge badge-none">None</span></td>
-</tr>
-</tbody>
-</table>
+</tbody></table>
+<p style="font-size:0.72rem; color: var(--text-dim); margin-top: 0.8rem; font-style: italic;">* License and pricing are sourced from the GitHub API and public web pages. Verify on the project's own website before relying on them. "Recent growth" is the absolute change in stars since the last scan snapshot ({PRIOR_DATE}); it is not a monthly or quarterly figure.</p>
   </div>
-  <p class="trend-note">* License and pricing data sourced via web search and may not reflect the latest changes. Verify on the project's website.</p>
 </div>
 
 <footer>
@@ -879,11 +796,11 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <script>
 // Column sorting
 document.addEventListener('DOMContentLoaded', function() {
-  var table = document.querySelector('.compare-table');
+  const table = document.querySelector('.compare-table');
   if (!table) return;
-  var headers = table.querySelectorAll('th');
-  var tbody = table.querySelector('tbody');
-  var sortCol = -1, sortAsc = true;
+  const headers = table.querySelectorAll('th');
+  const tbody = table.querySelector('tbody');
+  let sortCol = -1, sortAsc = true;
 
   headers.forEach(function(th, idx) {
     th.addEventListener('click', function() {
@@ -909,13 +826,6 @@ document.addEventListener('DOMContentLoaded', function() {
       rows.forEach(function(r) { tbody.appendChild(r); });
     });
   });
-
-  // Default sort: Stars descending (column index 2)
-  var starsHeader = headers[2];
-  sortCol = 2;
-  sortAsc = false;
-  starsHeader.classList.add('sorted');
-  starsHeader.querySelector('.sort-arrow').textContent = '\u25BC';
 });
 </script>
 </body>

--- a/site/landscape/index.html
+++ b/site/landscape/index.html
@@ -120,482 +120,455 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <div class="container">
   <div class="page-header">
     <h1>AI Coding Agent Landscape</h1>
-    <div class="updated">Last updated: 2026-04-12</div>
+    <div class="updated">Last updated: 2026-04-24</div>
     <p class="intro">A living ranking of AI coding agents and agent orchestrators, sorted by a blend of GitHub popularity and growth momentum. Agents that Irrlicht already monitors are marked <span class="badge badge-live">live</span>, upcoming integrations are <span class="badge badge-planned">planned</span>. Agents first tracked less than 3 months ago are marked <span class="badge badge-new">NEW</span>.</p>
     <a href="compare/" class="compare-link">See detailed comparison with all metrics &rarr;</a>
   </div>
 
   <h2 class="section-title">Coding Agents</h2>
-  <p class="trend-note">1M: no snapshot within 10 days of 2026-03-13 — data will appear as history accumulates. 3M: measured vs 2026-01-01 snapshot.</p>
+  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-04-24.</p>
   <table class="landscape-table">
-<thead>
-<tr>
-  <th>#</th>
-  <th>Agent</th>
-  <th>Stars</th>
-  <th>3M Growth</th>
-  <th>Irrlicht</th>
-  <th>Description</th>
-</tr>
-</thead>
-<tbody><tr>
-  <td class="rank">1</td>
-  <td class="name"><a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a></td>
-  <td class="stars">141,888</td>
-  <td class="growth growth-3m"><span class="growth-up">+136,388 <span class="growth-pct">(2,480.7%)</span></span></td>
-  <td><span class="badge badge-planned">planned</span></td>
-  <td class="desc">The open source coding agent</td>
-</tr>
-<tr>
-  <td class="rank">2</td>
-  <td class="name"><a href="https://github.com/anthropics/claude-code" target="_blank" rel="noopener">Claude Code</a></td>
-  <td class="stars">112,845</td>
-  <td class="growth growth-3m"><span class="growth-up">+61,145 <span class="growth-pct">(118.3%)</span></span></td>
-  <td><span class="badge badge-live">live</span></td>
-  <td class="desc">Anthropic's terminal-based AI coding agent</td>
-</tr>
-<tr>
-  <td class="rank">3</td>
-  <td class="name"><a href="https://github.com/openai/codex" target="_blank" rel="noopener">OpenAI Codex</a></td>
-  <td class="stars">74,758</td>
-  <td class="growth growth-3m"><span class="growth-up">+28,758 <span class="growth-pct">(62.5%)</span></span></td>
-  <td><span class="badge badge-live">live</span></td>
-  <td class="desc">OpenAI's terminal AI coding agent</td>
-</tr>
-<tr>
-  <td class="rank">4</td>
-  <td class="name"><a href="https://claw-code.codes" target="_blank" rel="noopener">Claw Code</a></td>
-  <td class="stars">182,111</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Clean-room Python/Rust rewrite of Claude Code architecture</td>
-</tr>
-<tr>
-  <td class="rank">5</td>
-  <td class="name"><a href="https://github.com/All-Hands-AI/OpenHands" target="_blank" rel="noopener">OpenHands</a></td>
-  <td class="stars">71,060</td>
-  <td class="growth growth-3m"><span class="growth-up">+19,060 <span class="growth-pct">(36.7%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Open-source platform for autonomous AI software agents</td>
-</tr>
-<tr>
-  <td class="rank">6</td>
-  <td class="name"><a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener">Gemini CLI</a></td>
-  <td class="stars">100,994</td>
-  <td class="growth growth-3m"><span class="growth-up">+11,194 <span class="growth-pct">(12.5%)</span></span></td>
-  <td><span class="badge badge-planned">planned</span></td>
-  <td class="desc">Google's terminal AI coding agent</td>
-</tr>
-<tr>
-  <td class="rank">7</td>
-  <td class="name"><a href="https://github.com/cline/cline" target="_blank" rel="noopener">Cline</a></td>
-  <td class="stars">60,178</td>
-  <td class="growth growth-3m"><span class="growth-up">+24,178 <span class="growth-pct">(67.2%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Autonomous AI coding agent for VS Code</td>
-</tr>
-<tr>
-  <td class="rank">8</td>
-  <td class="name"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
-  <td class="stars">41,312</td>
-  <td class="growth growth-3m"><span class="growth-up">+15,212 <span class="growth-pct">(58.3%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Block's open-source extensible AI agent</td>
-</tr>
-<tr>
-  <td class="rank">9</td>
-  <td class="name"><a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener">Pi</a></td>
-  <td class="stars">34,689</td>
-  <td class="growth growth-3m"><span class="growth-up">+16,289 <span class="growth-pct">(88.5%)</span></span></td>
-  <td><span class="badge badge-live">live</span></td>
-  <td class="desc">Anthropic's lightweight coding agent</td>
-</tr>
-<tr>
-  <td class="rank">10</td>
-  <td class="name"><a href="https://aider.chat" target="_blank" rel="noopener">Aider</a></td>
-  <td class="stars">43,202</td>
-  <td class="growth growth-3m"><span class="growth-up">+7,202 <span class="growth-pct">(20.0%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AI pair programming in your terminal</td>
-</tr>
-<tr>
-  <td class="rank">11</td>
-  <td class="name"><a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a></td>
-  <td class="stars">32,624</td>
-  <td class="growth growth-3m"><span class="growth-up">+7,624 <span class="growth-pct">(30.5%)</span></span></td>
-  <td><span class="badge badge-planned">planned</span></td>
-  <td class="desc">AI-first code editor with agent mode</td>
-</tr>
-<tr>
-  <td class="rank">12</td>
-  <td class="name"><a href="https://github.com/voideditor/void" target="_blank" rel="noopener">Void</a></td>
-  <td class="stars">28,553</td>
-  <td class="growth growth-3m"><span class="growth-up">+5,553 <span class="growth-pct">(24.1%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Open-source AI code editor</td>
-</tr>
-<tr>
-  <td class="rank">13</td>
-  <td class="name"><a href="https://github.com/RooVetGit/Roo-Code" target="_blank" rel="noopener">Roo Code</a></td>
-  <td class="stars">23,088</td>
-  <td class="growth growth-3m"><span class="growth-up">+5,588 <span class="growth-pct">(31.9%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AI coding agent for VS Code with multi-mode support</td>
-</tr>
-<tr>
-  <td class="rank">14</td>
-  <td class="name"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
-  <td class="stars">17,988</td>
-  <td class="growth growth-3m"><span class="growth-up">+6,988 <span class="growth-pct">(63.5%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Open-source agentic coding platform</td>
-</tr>
-<tr>
-  <td class="rank">15</td>
-  <td class="name"><a href="https://github.com/princeton-nlp/SWE-agent" target="_blank" rel="noopener">SWE-agent</a></td>
-  <td class="stars">18,968</td>
-  <td class="growth growth-3m"><span class="growth-up">+5,968 <span class="growth-pct">(45.9%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Princeton's autonomous software engineering agent</td>
-</tr>
-<tr>
-  <td class="rank">16</td>
-  <td class="name"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
-  <td class="stars">26,372</td>
-  <td class="growth growth-3m"><span class="growth-up">+2,372 <span class="growth-pct">(9.9%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Agentic terminal with Oz cloud orchestration</td>
-</tr>
-<tr>
-  <td class="rank">17</td>
-  <td class="name"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
-  <td class="stars">32,499</td>
-  <td class="growth growth-3m"><span class="growth-up">+1,499 <span class="growth-pct">(4.8%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Open-source AI code assistant for VS Code and JetBrains</td>
-</tr>
-<tr>
-  <td class="rank">18</td>
-  <td class="name"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a> <span class="badge badge-new">NEW</span></td>
-  <td class="stars">22,889</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Open-source terminal coding agent by Charmbracelet</td>
-</tr>
-<tr>
-  <td class="rank">19</td>
-  <td class="name"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a> <span class="badge badge-new">NEW</span></td>
-  <td class="stars">22,823</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Alibaba's terminal coding agent for Qwen3-Coder</td>
-</tr>
-<tr>
-  <td class="rank">20</td>
-  <td class="name"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a> <span class="badge badge-new">NEW</span></td>
-  <td class="stars">15,231</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Open-source terminal agent for multi-step coding tasks</td>
-</tr>
-<tr>
-  <td class="rank">21</td>
-  <td class="name"><a href="https://github.com/langchain-ai/open-swe" target="_blank" rel="noopener">Open SWE</a></td>
-  <td class="stars">9,484</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">LangChain's async cloud-hosted coding agent</td>
-</tr>
-<tr>
-  <td class="rank">22</td>
-  <td class="name"><a href="https://github.com/antinomyhq/forgecode" target="_blank" rel="noopener">Forge Code</a></td>
-  <td class="stars">6,466</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Rust-based open-source terminal AI pair programmer</td>
-</tr>
-<tr>
-  <td class="rank">23</td>
-  <td class="name"><a href="https://sweep.dev" target="_blank" rel="noopener">Sweep</a></td>
-  <td class="stars">7,709</td>
-  <td class="growth growth-3m"><span class="growth-up">+509 <span class="growth-pct">(7.1%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AI junior developer for GitHub issues</td>
-</tr>
-<tr>
-  <td class="rank">24</td>
-  <td class="name"><a href="https://www.ra-aid.ai" target="_blank" rel="noopener">RA.Aid</a></td>
-  <td class="stars">2,218</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">LangGraph-based autonomous coding agent</td>
-</tr>
-<tr>
-  <td class="rank">25</td>
-  <td class="name"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
-  <td class="stars">756</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Agent-native development platform with Droid agents</td>
-</tr>
-<tr>
-  <td class="rank">26</td>
-  <td class="name"><a href="https://trypear.ai" target="_blank" rel="noopener">Pear AI</a></td>
-  <td class="stars">674</td>
-  <td class="growth growth-3m"><span class="growth-up">+174 <span class="growth-pct">(34.8%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Open-source AI code editor</td>
-</tr>
-<tr>
-  <td class="rank">27</td>
-  <td class="name"><a href="https://codegen.com" target="_blank" rel="noopener">Codegen</a></td>
-  <td class="stars">521</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AI coding agent platform with SDK</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://github.com/features/copilot" target="_blank" rel="noopener">GitHub Copilot</a></td>
-  <td class="stars"><span class="alt-metric">~15M users</span></td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">GitHub's AI pair programmer</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://codeium.com/windsurf" target="_blank" rel="noopener">Windsurf</a></td>
-  <td class="stars"><span class="alt-metric">~1M users</span></td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AI-powered IDE by Codeium, now owned by Cognition AI</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://www.tabnine.com" target="_blank" rel="noopener">Tabnine</a></td>
-  <td class="stars"><span class="alt-metric">~1M users</span></td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AI code completion and chat assistant</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://devin.ai" target="_blank" rel="noopener">Devin</a></td>
-  <td class="stars"><span class="alt-metric">$700M raised</span></td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Autonomous AI software engineer by Cognition</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://www.poolside.ai" target="_blank" rel="noopener">Poolside</a></td>
-  <td class="stars"><span class="alt-metric">$626M raised</span></td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Enterprise AI coding platform with custom foundation models</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://www.augmentcode.com" target="_blank" rel="noopener">Augment Code</a></td>
-  <td class="stars"><span class="alt-metric">$252M raised</span></td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AI coding agent with deep codebase understanding</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://ampcode.com" target="_blank" rel="noopener">Amp</a></td>
-  <td class="stars"><span class="alt-metric">$225M (SG funding)</span></td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-planned">planned</span></td>
-  <td class="desc">Sourcegraph's AI coding agent</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://www.qodo.ai" target="_blank" rel="noopener">Qodo</a></td>
-  <td class="stars"><span class="alt-metric">$120M raised</span></td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Agentic code integrity platform</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://aws.amazon.com/q/developer/" target="_blank" rel="noopener">Amazon Q Developer</a></td>
-  <td class="stars" style="color:var(--text-dim)">&#8212;</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AWS AI coding assistant</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://sourcegraph.com/cody" target="_blank" rel="noopener">Sourcegraph Cody</a></td>
-  <td class="stars" style="color:var(--text-dim)">&#8212;</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AI coding assistant with full codebase context</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://cosine.sh" target="_blank" rel="noopener">Cosine Genie</a></td>
-  <td class="stars" style="color:var(--text-dim)">&#8212;</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Fully autonomous AI software engineer</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://zencoder.ai" target="_blank" rel="noopener">Zencoder</a></td>
-  <td class="stars" style="color:var(--text-dim)">&#8212;</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AI coding agent with repo-wide context indexing</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://www.codegpt.co" target="_blank" rel="noopener">CodeGPT</a></td>
-  <td class="stars" style="color:var(--text-dim)">&#8212;</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Full-stack AI agent platform with codebase knowledge graph</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://www.morphllm.com" target="_blank" rel="noopener">MorphLLM</a></td>
-  <td class="stars" style="color:var(--text-dim)">&#8212;</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Subagent infrastructure: Fast Apply, WarpGrep</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://codebuff.com" target="_blank" rel="noopener">Codebuff</a></td>
-  <td class="stars" style="color:var(--text-dim)">&#8212;</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AI coding agent in your terminal</td>
-</tr>
-<tr>
-  <td class="rank" style="color:var(--text-dim)">&#8212;</td>
-  <td class="name"><a href="https://kiro.dev" target="_blank" rel="noopener">Kiro</a> <span class="badge badge-new">NEW</span></td>
-  <td class="stars" style="color:var(--text-dim)">&#8212;</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AWS-backed agentic IDE</td>
-</tr>
-</tbody>
-</table>
+<thead><tr>
+  <th class="rank">#</th><th>Name</th><th>Stars</th><th class="growth-3m">Recent growth</th><th>Irrlicht</th><th>Description</th>
+</tr></thead>
+<tbody>
+
+  <tr>
+    <td class="rank">#1</td>
+    <td class="name"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
+    <td class="stars">188,050</td>
+    <td class="growth growth-3m"><span class="growth-up">+5,939 <span class="growth-pct">(+3.3%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Rust CLI agent harness that wraps Claude via the Anthropic API; star count inflated by viral self-promotion in the README.</td>
+  </tr>
+  <tr>
+    <td class="rank">#2</td>
+    <td class="name"><a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a></td>
+    <td class="stars">148,747</td>
+    <td class="growth growth-3m"><span class="growth-up">+6,859 <span class="growth-pct">(+4.8%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Open-source coding agent (TypeScript CLI).</td>
+  </tr>
+  <tr>
+    <td class="rank">#3</td>
+    <td class="name"><a href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener">Claude Code</a></td>
+    <td class="stars">117,553</td>
+    <td class="growth growth-3m"><span class="growth-up">+4,708 <span class="growth-pct">(+4.2%)</span></span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">Anthropic&#x27;s terminal-based coding agent.</td>
+  </tr>
+  <tr>
+    <td class="rank">#4</td>
+    <td class="name"><a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener">Gemini CLI</a></td>
+    <td class="stars">102,304</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,310 <span class="growth-pct">(+1.3%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Google&#x27;s open-source terminal coding agent for Gemini models.</td>
+  </tr>
+  <tr>
+    <td class="rank">#5</td>
+    <td class="name"><a href="https://github.com/openai/codex" target="_blank" rel="noopener">OpenAI Codex</a></td>
+    <td class="stars">77,568</td>
+    <td class="growth growth-3m"><span class="growth-up">+2,810 <span class="growth-pct">(+3.8%)</span></span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">OpenAI&#x27;s lightweight terminal coding agent.</td>
+  </tr>
+  <tr>
+    <td class="rank">#6</td>
+    <td class="name"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">OpenHands</a></td>
+    <td class="stars">71,985</td>
+    <td class="growth growth-3m"><span class="growth-up">+925 <span class="growth-pct">(+1.3%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">AI-driven development platform for autonomous software agents.</td>
+  </tr>
+  <tr>
+    <td class="rank">#7</td>
+    <td class="name"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
+    <td class="stars">60,949</td>
+    <td class="growth growth-3m"><span class="growth-up">+771 <span class="growth-pct">(+1.3%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Autonomous coding agent embedded in VS Code.</td>
+  </tr>
+  <tr>
+    <td class="rank">#8</td>
+    <td class="name"><a href="https://aider.chat" target="_blank" rel="noopener">Aider</a></td>
+    <td class="stars">43,874</td>
+    <td class="growth growth-3m"><span class="growth-up">+672 <span class="growth-pct">(+1.6%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">AI pair-programming tool in your terminal.</td>
+  </tr>
+  <tr>
+    <td class="rank">#9</td>
+    <td class="name"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
+    <td class="stars">43,139</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,827 <span class="growth-pct">(+4.4%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Extensible open-source agent that can install, execute, edit, and test with any LLM (originated at Block).</td>
+  </tr>
+  <tr>
+    <td class="rank">#10</td>
+    <td class="name"><a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener">Pi</a></td>
+    <td class="stars">39,373</td>
+    <td class="growth growth-3m"><span class="growth-up">+4,684 <span class="growth-pct">(+13.5%)</span></span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">Mario Zechner&#x27;s AI agent toolkit: coding agent CLI, unified LLM API, TUI/web libraries, Slack bot, vLLM pods.</td>
+  </tr>
+  <tr>
+    <td class="rank">#11</td>
+    <td class="name"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
+    <td class="stars">32,770</td>
+    <td class="growth growth-3m"><span class="growth-up">+271 <span class="growth-pct">(+0.8%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Source-controlled AI coding assistant and CI checks; VS Code / JetBrains / CLI.</td>
+  </tr>
+  <tr>
+    <td class="rank">#12</td>
+    <td class="name"><a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a></td>
+    <td class="stars">32,693</td>
+    <td class="growth growth-3m"><span class="growth-up">+69 <span class="growth-pct">(+0.2%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Proprietary AI-first code editor (the GitHub repo hosts issues only; editor source is closed).</td>
+  </tr>
+  <tr>
+    <td class="rank">#13</td>
+    <td class="name"><a href="https://voideditor.com" target="_blank" rel="noopener">Void</a></td>
+    <td class="stars">28,644</td>
+    <td class="growth growth-3m"><span class="growth-up">+91 <span class="growth-pct">(+0.3%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Open-source AI code editor (VS Code fork).</td>
+  </tr>
+  <tr>
+    <td class="rank">#14</td>
+    <td class="name"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
+    <td class="stars">26,501</td>
+    <td class="growth growth-3m"><span class="growth-up">+129 <span class="growth-pct">(+0.5%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Agentic development environment built on a modern terminal.</td>
+  </tr>
+  <tr>
+    <td class="rank">#15</td>
+    <td class="name"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">23,813</td>
+    <td class="growth growth-3m"><span class="growth-up">+990 <span class="growth-pct">(+4.3%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Alibaba&#x27;s open-source terminal coding agent tuned for the Qwen3-Coder model family.</td>
+  </tr>
+  <tr>
+    <td class="rank">#16</td>
+    <td class="name"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">23,418</td>
+    <td class="growth growth-3m"><span class="growth-up">+529 <span class="growth-pct">(+2.3%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Charmbracelet&#x27;s multi-model terminal coding agent written in Go.</td>
+  </tr>
+  <tr>
+    <td class="rank">#17</td>
+    <td class="name"><a href="https://roocode.com" target="_blank" rel="noopener">Roo Code</a></td>
+    <td class="stars">23,345</td>
+    <td class="growth growth-3m"><span class="growth-up">+257 <span class="growth-pct">(+1.1%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">VS Code coding agent with multi-mode team-of-agents support.</td>
+  </tr>
+  <tr>
+    <td class="rank">#18</td>
+    <td class="name"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
+    <td class="stars">19,050</td>
+    <td class="growth growth-3m"><span class="growth-up">+82 <span class="growth-pct">(+0.4%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Princeton NLP&#x27;s autonomous agent for resolving GitHub issues (NeurIPS 2024).</td>
+  </tr>
+  <tr>
+    <td class="rank">#19</td>
+    <td class="name"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
+    <td class="stars">18,505</td>
+    <td class="growth growth-3m"><span class="growth-up">+517 <span class="growth-pct">(+2.9%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">All-in-one agentic coding platform for VS Code, JetBrains, and CLI.</td>
+  </tr>
+  <tr>
+    <td class="rank">#20</td>
+    <td class="name"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">15,289</td>
+    <td class="growth growth-3m"><span class="growth-up">+58 <span class="growth-pct">(+0.4%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Open-source terminal agent for large, multi-step coding tasks spanning many files.</td>
+  </tr>
+  <tr>
+    <td class="rank">#21</td>
+    <td class="name"><a href="https://github.com/langchain-ai/open-swe" target="_blank" rel="noopener">Open SWE</a></td>
+    <td class="stars">9,642</td>
+    <td class="growth growth-3m"><span class="growth-up">+158 <span class="growth-pct">(+1.7%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">LangChain&#x27;s open-source asynchronous cloud coding agent.</td>
+  </tr>
+  <tr>
+    <td class="rank">#22</td>
+    <td class="name"><a href="https://sweep.dev" target="_blank" rel="noopener">Sweep</a></td>
+    <td class="stars">7,705</td>
+    <td class="growth growth-3m"><span class="growth-down">-4 <span class="growth-pct">(-0.1%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">AI coding assistant for JetBrains (pivoted from earlier GitHub-issue automation).</td>
+  </tr>
+  <tr>
+    <td class="rank">#23</td>
+    <td class="name"><a href="https://forgecode.dev" target="_blank" rel="noopener">Forge Code</a></td>
+    <td class="stars">6,925</td>
+    <td class="growth growth-3m"><span class="growth-up">+459 <span class="growth-pct">(+7.1%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Rust-based open-source terminal AI pair programmer supporting 300+ models.</td>
+  </tr>
+  <tr>
+    <td class="rank">#24</td>
+    <td class="name"><a href="https://www.ra-aid.ai" target="_blank" rel="noopener">RA.Aid</a></td>
+    <td class="stars">2,223</td>
+    <td class="growth growth-3m"><span class="growth-up">+5 <span class="growth-pct">(+0.2%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">LangGraph-based autonomous coding agent with research → plan → implement loop.</td>
+  </tr>
+  <tr>
+    <td class="rank">#25</td>
+    <td class="name"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
+    <td class="stars">794</td>
+    <td class="growth growth-3m"><span class="growth-up">+38 <span class="growth-pct">(+5.0%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Agent-native software development platform with Droid agents.</td>
+  </tr>
+  <tr>
+    <td class="rank">#26</td>
+    <td class="name"><a href="https://trypear.ai" target="_blank" rel="noopener">Pear AI</a></td>
+    <td class="stars">676</td>
+    <td class="growth growth-3m"><span class="growth-up">+2 <span class="growth-pct">(+0.3%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Open-source AI code editor (VS Code fork with Continue submodule).</td>
+  </tr>
+  <tr>
+    <td class="rank">#27</td>
+    <td class="name"><a href="https://codegen.com" target="_blank" rel="noopener">Codegen</a></td>
+    <td class="stars">521</td>
+    <td class="growth growth-3m"><span class="growth-flat">0 <span class="growth-pct">(0.0%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Python wrapper for the Codegen API — run code agents at scale against a hosted service.</td>
+  </tr>
+  <tr><td colspan="6" style="padding-top:1.2rem; color: var(--text-dim); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; border-bottom: none;">No public repo — popularity via funding / users</td></tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://aws.amazon.com/q/developer/" target="_blank" rel="noopener">Amazon Q Developer</a></td>
+    <td class="alt-metric">—</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">AWS&#x27;s AI coding assistant (completions, transformations, agentic refactors).</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://ampcode.com" target="_blank" rel="noopener">Amp</a></td>
+    <td class="alt-metric">—</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Agentic coding agent spinning out from Sourcegraph as a standalone company in 2026 (formerly Sourcegraph Cody); CLI + VS Code extension.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://www.augmentcode.com" target="_blank" rel="noopener">Augment Code</a></td>
+    <td class="alt-metric">$252M raised</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">AI coding agent with deep codebase understanding and enterprise context retrieval.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://codebuff.com" target="_blank" rel="noopener">Codebuff</a></td>
+    <td class="alt-metric">—</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">AI coding agent for the terminal.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://www.codegpt.co" target="_blank" rel="noopener">CodeGPT</a></td>
+    <td class="alt-metric">—</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Full-stack AI agent platform with a codebase knowledge graph.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://cosine.sh" target="_blank" rel="noopener">Cosine Genie</a></td>
+    <td class="alt-metric">—</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Fully autonomous AI software engineer using Cosine&#x27;s proprietary Genie model.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://devin.ai" target="_blank" rel="noopener">Devin</a></td>
+    <td class="alt-metric">$696M raised</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Cognition AI&#x27;s autonomous software-engineer agent; parent company merged Windsurf (Cascade IDE) into its stack in 2025.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://github.com/features/copilot" target="_blank" rel="noopener">GitHub Copilot</a></td>
+    <td class="alt-metric">20.0M users</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">GitHub&#x27;s AI pair programmer (completion + chat + coding agent).</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://kiro.dev" target="_blank" rel="noopener">Kiro</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="alt-metric">—</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">AWS-backed agentic IDE with spec-driven development and autonomous task execution.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://www.morphllm.com" target="_blank" rel="noopener">MorphLLM</a></td>
+    <td class="alt-metric">—</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Subagent infrastructure: Fast Apply, WarpGrep, context compression.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://www.poolside.ai" target="_blank" rel="noopener">Poolside</a></td>
+    <td class="alt-metric">$626M raised</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Enterprise AI coding platform with custom foundation models.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://www.qodo.ai" target="_blank" rel="noopener">Qodo</a></td>
+    <td class="alt-metric">$120M raised</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Agentic code-integrity platform for review, testing, and governance (formerly CodiumAI).</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://www.tabnine.com" target="_blank" rel="noopener">Tabnine</a></td>
+    <td class="alt-metric">$102M raised</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">AI code completion, chat, and code-review agent with on-prem/private deployment options.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://windsurf.com" target="_blank" rel="noopener">Windsurf</a></td>
+    <td class="alt-metric">$250M acquisition</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Agentic AI IDE (Cascade). Acquired by Cognition AI from Codeium in December 2025 for ~$250M; brand continues under Cognition.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://zencoder.ai" target="_blank" rel="noopener">Zencoder</a></td>
+    <td class="alt-metric">—</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">AI coding agent with repo-wide context indexing.</td>
+  </tr>
+</tbody></table>
 
   <h2 class="section-title">Agent Orchestrators</h2>
-  <p class="trend-note">1M: no snapshot within 10 days of 2026-03-13 — data will appear as history accumulates. 3M: measured vs 2026-01-01 snapshot.</p>
+  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-04-24.</p>
   <table class="landscape-table">
-<thead>
-<tr>
-  <th>#</th>
-  <th>Orchestrator</th>
-  <th>Stars</th>
-  <th>3M Growth</th>
-  <th>Irrlicht</th>
-  <th>Description</th>
-</tr>
-</thead>
-<tbody><tr>
-  <td class="rank">1</td>
-  <td class="name"><a href="https://paperclip.ing" target="_blank" rel="noopener">Paperclip</a> <span class="badge badge-new">NEW</span></td>
-  <td class="stars">52,042</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Hierarchical agent orchestrator modelling a zero-human company</td>
-</tr>
-<tr>
-  <td class="rank">2</td>
-  <td class="name"><a href="https://github.com/gpt-engineer-org/gpt-engineer" target="_blank" rel="noopener">GPT Engineer</a></td>
-  <td class="stars">55,217</td>
-  <td class="growth growth-3m"><span class="growth-up">+2,217 <span class="growth-pct">(4.2%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">AI agent that builds codebases from specifications</td>
-</tr>
-<tr>
-  <td class="rank">3</td>
-  <td class="name"><a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener">ChatDev</a></td>
-  <td class="stars">32,685</td>
-  <td class="growth growth-3m"><span class="growth-up">+4,685 <span class="growth-pct">(16.7%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Virtual software company powered by AI agents</td>
-</tr>
-<tr>
-  <td class="rank">4</td>
-  <td class="name"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
-  <td class="stars">39,367</td>
-  <td class="growth growth-3m"><span class="growth-up">+3,367 <span class="growth-pct">(9.4%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Python agent runtime for teams and workflows</td>
-</tr>
-<tr>
-  <td class="rank">5</td>
-  <td class="name"><a href="https://github.com/gastownhall/gastown" target="_blank" rel="noopener">Gas Town</a></td>
-  <td class="stars">13,898</td>
-  <td class="growth growth-3m"><span class="growth-up">+12,898 <span class="growth-pct">(1,289.8%)</span></span></td>
-  <td><span class="badge badge-live">live</span></td>
-  <td class="desc">Multi-agent workspace manager by Steve Yegge</td>
-</tr>
-<tr>
-  <td class="rank">6</td>
-  <td class="name"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
-  <td class="stars">31,366</td>
-  <td class="growth growth-3m"><span class="growth-up">+1,666 <span class="growth-pct">(5.6%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Multi-agent swarm orchestration platform for Claude</td>
-</tr>
-<tr>
-  <td class="rank">7</td>
-  <td class="name"><a href="https://github.com/stitionai/devika" target="_blank" rel="noopener">Devika</a></td>
-  <td class="stars">19,497</td>
-  <td class="growth growth-3m"><span class="growth-up">+997 <span class="growth-pct">(5.4%)</span></span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Open-source AI software engineer</td>
-</tr>
-<tr>
-  <td class="rank">8</td>
-  <td class="name"><a href="https://github.com/smtg-ai/claude-squad" target="_blank" rel="noopener">Claude Squad</a></td>
-  <td class="stars">6,961</td>
-  <td class="growth growth-3m"><span class="growth-up">+1,161 <span class="growth-pct">(20.0%)</span></span></td>
-  <td><span class="badge badge-planned">planned</span></td>
-  <td class="desc">Manage multiple Claude Code instances in tmux</td>
-</tr>
-<tr>
-  <td class="rank">9</td>
-  <td class="name"><a href="https://composio.dev" target="_blank" rel="noopener">Composio</a></td>
-  <td class="stars">6,182</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Agent-agnostic orchestrator for parallel coding agents</td>
-</tr>
-<tr>
-  <td class="rank">10</td>
-  <td class="name"><a href="https://github.com/dlorenc/multiclaude" target="_blank" rel="noopener">Multiclaude</a></td>
-  <td class="stars">529</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Parallel Claude Code instances in tmux</td>
-</tr>
-<tr>
-  <td class="rank">11</td>
-  <td class="name"><a href="https://stoneforge.ai" target="_blank" rel="noopener">Stoneforge</a></td>
-  <td class="stars">113</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Web dashboard orchestrating AI coding agent teams</td>
-</tr>
-<tr>
-  <td class="rank">12</td>
-  <td class="name"><a href="https://forge.nxtg.ai" target="_blank" rel="noopener">Forge Orchestrator</a></td>
-  <td class="stars">108</td>
-  <td class="growth growth-3m"><span class="growth-na">&#8212;</span></td>
-  <td><span class="badge badge-none">none</span></td>
-  <td class="desc">Rust-based multi-AI task orchestrator</td>
-</tr>
-</tbody>
-</table>
+<thead><tr>
+  <th class="rank">#</th><th>Name</th><th>Stars</th><th class="growth-3m">Recent growth</th><th>Irrlicht</th><th>Description</th>
+</tr></thead>
+<tbody>
+
+  <tr>
+    <td class="rank">#1</td>
+    <td class="name"><a href="https://paperclip.ing" target="_blank" rel="noopener">Paperclip</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">58,383</td>
+    <td class="growth growth-3m"><span class="growth-up">+6,341 <span class="growth-pct">(+12.2%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Orchestration platform for &quot;zero-human companies&quot; — agents assigned to CEO/manager/worker roles with budgets and approvals.</td>
+  </tr>
+  <tr>
+    <td class="rank">#2</td>
+    <td class="name"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
+    <td class="stars">39,648</td>
+    <td class="growth growth-3m"><span class="growth-up">+281 <span class="growth-pct">(+0.7%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Python agent runtime for teams and workflows (formerly Phidata).</td>
+  </tr>
+  <tr>
+    <td class="rank">#3</td>
+    <td class="name"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
+    <td class="stars">33,079</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,713 <span class="growth-pct">(+5.5%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Agent orchestration platform for Claude: multi-agent swarms, RAG integration, Claude Code/Codex integration.</td>
+  </tr>
+  <tr>
+    <td class="rank">#4</td>
+    <td class="name"><a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener">ChatDev</a></td>
+    <td class="stars">32,847</td>
+    <td class="growth growth-3m"><span class="growth-up">+162 <span class="growth-pct">(+0.5%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Virtual software company powered by multi-agent LLM collaboration (ChatDev 2.0).</td>
+  </tr>
+  <tr>
+    <td class="rank">#5</td>
+    <td class="name"><a href="https://github.com/stitionai/devika" target="_blank" rel="noopener">Devika</a></td>
+    <td class="stars">19,502</td>
+    <td class="growth growth-3m"><span class="growth-up">+5 <span class="growth-pct">(+0.0%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Open-source agentic software engineer (originally an open alternative to Devin).</td>
+  </tr>
+  <tr>
+    <td class="rank">#6</td>
+    <td class="name"><a href="https://github.com/gastownhall/gastown" target="_blank" rel="noopener">Gas Town</a></td>
+    <td class="stars">14,580</td>
+    <td class="growth growth-3m"><span class="growth-up">+682 <span class="growth-pct">(+4.9%)</span></span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">Multi-agent workspace manager: Mayor (coordinator) routes work through Rigs and Polecats with a Beads work-state ledger.</td>
+  </tr>
+  <tr>
+    <td class="rank">#7</td>
+    <td class="name"><a href="https://github.com/smtg-ai/claude-squad" target="_blank" rel="noopener">Claude Squad</a></td>
+    <td class="stars">7,145</td>
+    <td class="growth growth-3m"><span class="growth-up">+184 <span class="growth-pct">(+2.6%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Manage multiple AI terminal agents (Claude Code, Codex, OpenCode, Amp) in tmux.</td>
+  </tr>
+  <tr>
+    <td class="rank">#8</td>
+    <td class="name"><a href="https://composio.dev" target="_blank" rel="noopener">Composio</a></td>
+    <td class="stars">6,474</td>
+    <td class="growth growth-3m"><span class="growth-up">+292 <span class="growth-pct">(+4.7%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Agent-agnostic orchestrator for parallel coding agents with autonomous CI auto-fix.</td>
+  </tr>
+  <tr>
+    <td class="rank">#9</td>
+    <td class="name"><a href="https://github.com/dlorenc/multiclaude" target="_blank" rel="noopener">Multiclaude</a></td>
+    <td class="stars">539</td>
+    <td class="growth growth-3m"><span class="growth-up">+10 <span class="growth-pct">(+1.9%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Parallel Claude Code instances in tmux with a Brownian-ratchet CI model.</td>
+  </tr>
+  <tr>
+    <td class="rank">#10</td>
+    <td class="name"><a href="https://stoneforge.ai" target="_blank" rel="noopener">Stoneforge</a></td>
+    <td class="stars">130</td>
+    <td class="growth growth-3m"><span class="growth-up">+17 <span class="growth-pct">(+15.0%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Web dashboard orchestrating AI coding agent teams with worktree isolation.</td>
+  </tr>
+  <tr>
+    <td class="rank">#11</td>
+    <td class="name"><a href="https://forge.nxtg.ai" target="_blank" rel="noopener">Forge Orchestrator</a></td>
+    <td class="stars">109</td>
+    <td class="growth growth-3m"><span class="growth-up">+1 <span class="growth-pct">(+0.9%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Rust-based multi-AI task orchestrator with file locking and drift detection.</td>
+  </tr>
+</tbody></table>
 </div>
 
 <footer>


### PR DESCRIPTION
## Summary

- Re-verifies every landscape agent against `gh api`; fixes 9 transferred repo paths, drops the archived GPT Engineer and rebranded Sourcegraph Cody, and rewrites fabricated descriptions (Pi misattributed to Anthropic, Claw Code's "clean-room rewrite" fiction, Cursor-the-editor vs cursor-the-issue-tracker, Sweep's JetBrains pivot).
- Refreshes 2025/26 facts for non-GitHub entries (Cognition/Windsurf acquisition, Devin/Cognition ~\$696M funding, Amp spinning out of Sourcegraph) and removes all fabricated pre-2026-04-12 stars_history entries — the skill only started tracking 2026-04-05, so those readings couldn't have existed.
- Hardens the `/ir:agent-landscape` skill so this stops recurring: explicit non-negotiable rules (no invented values, no carried-forward fields, no back-filled history), required `gh api` + repo-rename handling, plausibility check on star deltas, and a reproducible `assets/generate.py` checked in so the HTML is deterministic.
- Grows the planned-integration list from 5 → 15 (adds Qwen Code, Crush, Continue, Goose, Aider, Kilo Code, SWE-agent, Paperclip, Ruflo, Multiclaude) after checking each candidate's source tree for CLI + tailable-transcript fit.

## What changed

| File | Change |
|------|--------|
| `.claude/skills/ir:agent-landscape/references/agent-data.json` | Full rewrite from verified data — 53 agents, 38 with canonical GitHub repos, stars_history trimmed to real measurements only. |
| `.claude/skills/ir:agent-landscape/skill.md` | New "Non-negotiable rules" section; required tools changed from WebFetch to `gh api`; plausibility check; pinned generator. |
| `.claude/skills/ir:agent-landscape/assets/generate.py` | Reproducible HTML generator (ranking, growth, NEW badge, alt-metrics); previously was only prose in the skill. |
| `site/landscape/index.html` | Regenerated from corrected data. |
| `site/landscape/compare/index.html` | Regenerated from corrected data. |

## Flag for reviewer

**Cursor** is still in the planned list but remains the one integration target without a credible adapter path — the `cursor/cursor` repo is just the issue tracker; the editor itself is closed-source Electron with no documented local transcript. Consider dropping it from planned unless Cursor ships an LSP-style hook or log-file mode.

## Test plan

- [ ] `python3 .claude/skills/ir:agent-landscape/assets/generate.py` runs clean and writes both pages
- [ ] `jq . .claude/skills/ir:agent-landscape/references/agent-data.json` parses
- [ ] Open `site/landscape/index.html` locally — ranking reflects stars desc, no fake 1M/3M growth labels
- [ ] Open `site/landscape/compare/index.html` — sort by Stars and by Name still works
- [ ] Confirm live badges map to adapters actually present under `core/adapters/inbound/{agents,orchestrators}/` (claudecode, codex, pi, gastown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)