### PR TITLE
feat(site): drop Terminals & IDEs column from the landing page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -764,7 +764,7 @@ section {
 
 .supported-columns {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 1.5rem;
   margin-top: 4rem;
 }
@@ -1370,60 +1370,6 @@ footer {
           <div class="si-dot"></div>
           <span class="si-name">Custom orchestrators</span>
           <span class="si-tag tag-planned">plugin api</span>
-        </div>
-      </div>
-
-      <div class="supported-col col-blue">
-        <h3>Terminals &amp; IDEs</h3>
-        <div class="supported-item">
-          <div class="si-dot"></div>
-          <span class="si-name">iTerm2</span>
-          <span class="si-tag tag-live">exact tab</span>
-        </div>
-        <div class="supported-item">
-          <div class="si-dot"></div>
-          <span class="si-name">Apple Terminal</span>
-          <span class="si-tag tag-live">exact tab</span>
-        </div>
-        <div class="supported-item">
-          <div class="si-dot"></div>
-          <span class="si-name">VS Code / Cursor / Windsurf</span>
-          <span class="si-tag tag-live">best window</span>
-        </div>
-        <div class="supported-item">
-          <div class="si-dot"></div>
-          <span class="si-name">Ghostty / WezTerm / Warp / Hyper</span>
-          <span class="si-tag tag-live">best window</span>
-        </div>
-        <div class="supported-item">
-          <div class="si-dot"></div>
-          <span class="si-name">JetBrains IDEs (GoLand, IntelliJ…)</span>
-          <span class="si-tag tag-live">best window</span>
-        </div>
-        <div class="supported-item">
-          <div class="si-dot"></div>
-          <span class="si-name">Zed</span>
-          <span class="si-tag tag-live">best window</span>
-        </div>
-        <div class="supported-item">
-          <div class="si-dot"></div>
-          <span class="si-name">kitty</span>
-          <span class="si-tag tag-live">exact window</span>
-        </div>
-        <div class="supported-item">
-          <div class="si-dot"></div>
-          <span class="si-name">Rio / Tabby / Wave / Alacritty</span>
-          <span class="si-tag tag-live">best window</span>
-        </div>
-        <div class="supported-item">
-          <div class="si-dot"></div>
-          <span class="si-name">Nova / cmux</span>
-          <span class="si-tag tag-live">best window</span>
-        </div>
-        <div class="supported-item">
-          <div class="si-dot"></div>
-          <span class="si-name">tmux (inside any host)</span>
-          <span class="si-tag tag-live">exact pane</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Removes the Terminals & IDEs column from the supported-surfaces grid on the landing page.
- Narrows the grid from 4 columns to 3 so it reads as Agents · Orchestrators · Platforms.

The surface-support data was noise on the "what we integrate with" message — the launcher figures out tab/window targeting automatically, so enumerating every terminal/IDE was duplicate signal without adding trust.

## Test plan
- [ ] Open `site/index.html` locally — grid shows three columns (purple / orange / green), no blue "Terminals & IDEs" column.
- [ ] Responsive: narrow the viewport below 900px — columns still stack to 1 column.
- [ ] Nothing else on the page references the dropped column (styles, anchors, copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)