### PR TITLE
fix(ui): show "…" overflow indicator beyond 5 menu-bar groups

### DIFF
--- a/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
@@ -18,14 +18,40 @@ struct MenuBarStatusRenderer {
     private static let groupGap: CGFloat = 6
     private static let height: CGFloat = 18
     private static let fontSize: CGFloat = 10
+    private static let maxVisibleGroups = 5
+    private static let overflowFillHex = "8E8E93"
     private static let segmentOrder: [SessionState.State] = [.waiting, .working, .ready]
 
     static func buildStatusImage(
         sessions: [SessionState],
         projectGroupOrder: [String]
     ) -> NSImage? {
+        guard let (svg, totalWidth) = buildStatusSVG(
+            sessions: sessions,
+            projectGroupOrder: projectGroupOrder
+        ) else {
+            return nil
+        }
+
+        guard let data = svg.data(using: .utf8),
+              let image = NSImage(data: data) else {
+            return nil
+        }
+
+        image.isTemplate = false
+        image.size = NSSize(width: totalWidth, height: height)
+        return image
+    }
+
+    static func buildStatusSVG(
+        sessions: [SessionState],
+        projectGroupOrder: [String]
+    ) -> (svg: String, width: CGFloat)? {
         let groups = orderedProjectGroups(from: sessions, projectGroupOrder: projectGroupOrder)
-        let renders = groups.prefix(8).map { renderGroup($0.1) }
+        var renders = groups.prefix(maxVisibleGroups).map { renderGroup($0.1) }
+        if groups.count > maxVisibleGroups {
+            renders.append(renderOverflow())
+        }
         let totalWidth = totalRenderWidth(renders)
 
         guard totalWidth > 0 else { return nil }
@@ -44,14 +70,7 @@ struct MenuBarStatusRenderer {
         }
         svg += "</svg>"
 
-        guard let data = svg.data(using: .utf8),
-              let image = NSImage(data: data) else {
-            return nil
-        }
-
-        image.isTemplate = false
-        image.size = NSSize(width: totalWidth, height: height)
-        return image
+        return (svg, totalWidth)
     }
 
     static func stateSegments(for sessions: [SessionState]) -> [StateSegment] {
@@ -118,6 +137,14 @@ struct MenuBarStatusRenderer {
         let elements = aggregatedGroupSVG(for: sessions)
         let width = radius * 2 + 2 + countWidth
         return GroupRender(elements: elements, width: width)
+    }
+
+    private static func renderOverflow() -> GroupRender {
+        let textY = (height / 2) + fontSize * 0.35
+        let elements = """
+        <text x="0" y="\(svgNumber(textY))" font-family="Menlo,monospace" font-size="\(Int(fontSize))" font-weight="bold" fill="#\(overflowFillHex)">…</text>
+        """
+        return GroupRender(elements: elements, width: 10)
     }
 
     private static func renderCompactGroup(_ sessions: [SessionState]) -> GroupRender {

--- a/platforms/macos/Tests/MenuBarStatusRendererTests.swift
+++ b/platforms/macos/Tests/MenuBarStatusRendererTests.swift
@@ -62,13 +62,50 @@ final class MenuBarStatusRendererTests: XCTestCase {
         XCTAssertNotNil(image)
     }
 
-    private func makeSession(id: String, state: SessionState.State) -> SessionState {
+    func testBuildStatusSVGOmitsOverflowGlyphAtOrBelowFiveGroups() {
+        let sessions = (1...5).map { makeSession(id: "\($0)", state: .working, project: "proj\($0)") }
+
+        let result = MenuBarStatusRenderer.buildStatusSVG(
+            sessions: sessions,
+            projectGroupOrder: []
+        )
+
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result?.svg.contains(">…</text>") ?? true)
+    }
+
+    func testBuildStatusSVGAppendsOverflowGlyphBeyondFiveGroups() {
+        let sessions = (1...6).map { makeSession(id: "\($0)", state: .working, project: "proj\($0)") }
+
+        let result = MenuBarStatusRenderer.buildStatusSVG(
+            sessions: sessions,
+            projectGroupOrder: []
+        )
+
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result?.svg.contains(">…</text>") ?? false)
+    }
+
+    func testBuildStatusSVGReturnsNilForNoSessions() {
+        let result = MenuBarStatusRenderer.buildStatusSVG(
+            sessions: [],
+            projectGroupOrder: []
+        )
+
+        XCTAssertNil(result)
+    }
+
+    private func makeSession(
+        id: String,
+        state: SessionState.State,
+        project: String = "test"
+    ) -> SessionState {
         SessionState(
             id: "sess_\(id)",
             state: state,
             model: "claude-3.7-sonnet",
-            cwd: "/Users/test/projects/test",
-            projectName: "test",
+            cwd: "/Users/test/projects/\(project)",
+            projectName: project,
             firstSeen: Date(),
             updatedAt: Date()
         )


### PR DESCRIPTION
## Summary
- Fixes #190 — menu bar silently swallowed the 9th+ group (`.prefix(8)` with no indicator).
- Caps visible groups at 5 and appends a muted `…` glyph whenever `groups.count > 5`, making hidden content discoverable.
- Splits SVG assembly into a new internal `buildStatusSVG` helper so the overflow behavior is unit-testable (the public `buildStatusImage` API is unchanged).

## Test plan
- [x] `swift test --filter MenuBarStatusRendererTests` — 7/7 green (4 existing + 3 new)
  - 5 groups → no `…`
  - 6 groups → `…` appended
  - 0 sessions → returns `nil`
- [x] Manual smoke test via `/ir:test-mac` with ≥6 active sessions across distinct project groups to confirm the ellipsis renders correctly and menu bar width stays within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)