### PR TITLE
feat(onboarding): codex + pi drivers for ir:onboard-agent (#200)

### DIFF
--- a/.claude/skills/ir:onboard-agent/scenarios.json
+++ b/.claude/skills/ir:onboard-agent/scenarios.json
@@ -4,7 +4,7 @@
   "min_versions": {
     "claudecode": "2.0.0",
     "codex": "0.50.0",
-    "pi": "1.0.0"
+    "pi": "0.70.0"
   },
 
   "scenarios": [
@@ -22,6 +22,16 @@
           "prompt": "Reply with exactly the word: ok",
           "settings": {},
           "timeout_seconds": 60
+        },
+        "codex": {
+          "prompt": "Output exactly the two characters: ok",
+          "settings": {},
+          "timeout_seconds": 120
+        },
+        "pi": {
+          "prompt": "Reply with exactly the word: ok",
+          "settings": {},
+          "timeout_seconds": 90
         }
       }
     },
@@ -39,6 +49,16 @@
           "prompt": "Run bash 'echo hello' using the Bash tool, then reply 'done'.",
           "settings": {},
           "timeout_seconds": 180
+        },
+        "codex": {
+          "prompt": "Run the shell command 'echo hello', then reply 'done'.",
+          "settings": {},
+          "timeout_seconds": 240
+        },
+        "pi": {
+          "prompt": "Use the bash tool to run 'echo hello', then reply 'done'.",
+          "settings": {},
+          "timeout_seconds": 240
         }
       }
     },

--- a/.claude/skills/ir:onboard-agent/scripts/drive-claudecode.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/drive-claudecode.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 # drive-claudecode.sh — run one scenario against the claude CLI headlessly.
 #
-# Writes driver.log (stdout+stderr) and exit-code/session-uuid into the
-# staging dir. The caller (run-cell.sh) handles daemon lifecycle, curation,
-# and report generation.
+# Writes driver.log (stdout+stderr), driver.exit-reason, transcript.path,
+# and session.uuid into the staging dir. The caller (run-cell.sh) handles
+# daemon lifecycle, curation, and report generation.
+#
+# Contract files written to <staging-dir>:
+#   driver.log[.stdout|.stderr]  — captured CLI output
+#   driver.exit-reason           — ok|timeout|killed|nonzero(N)
+#   transcript.path              — absolute path to the resolved transcript
+#   session.uuid                 — actual session UUID (== arg $2 for claude)
 #
 # Usage:
 #   drive-claudecode.sh <staging-dir> <session-uuid> \
@@ -64,6 +70,27 @@ case "$EXIT_CODE" in
 esac
 
 echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
-echo "drive-claudecode: $EXIT_REASON (uuid=$UUID, log=$DRIVER_LOG)"
+
+# Resolve the transcript path. Claude Code writes transcripts to
+# ~/.claude/projects/<slug>/<UUID>.jsonl. Stat the expected path under
+# each slug dir (O(#projects)) rather than walking the whole tree with
+# `find`. Poll up to 30s — claude may still be flushing after exit.
+TRANSCRIPT=""
+for _ in $(seq 1 60); do
+  for slug_dir in "$HOME"/.claude/projects/*/; do
+    candidate="$slug_dir$UUID.jsonl"
+    if [[ -f "$candidate" ]]; then
+      TRANSCRIPT="$candidate"
+      break 2
+    fi
+  done
+  sleep 0.5
+done
+
+# Always write session.uuid; transcript.path is empty if resolution failed.
+echo "$UUID" > "$STAGING/session.uuid"
+echo "${TRANSCRIPT:-}" > "$STAGING/transcript.path"
+
+echo "drive-claudecode: $EXIT_REASON (uuid=$UUID, transcript=${TRANSCRIPT:-<unresolved>}, log=$DRIVER_LOG)"
 
 exit "$EXIT_CODE"

--- a/.claude/skills/ir:onboard-agent/scripts/drive-codex.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/drive-codex.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# drive-codex.sh — run one scenario against the codex CLI headlessly.
+#
+# codex exec has no --session-id flag; the UUID is assigned by codex and
+# revealed on stdout's first event when --json is used:
+#   {"type":"thread.started","thread_id":"<UUID>"}
+# We capture that UUID, then locate the rollout file at
+# ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<UUID>.jsonl.
+#
+# Contract files written to <staging-dir>:
+#   driver.log[.stdout|.stderr]  — captured CLI output
+#   driver.exit-reason           — ok|timeout|killed|nonzero(N)
+#   transcript.path              — absolute path to the resolved transcript
+#   session.uuid                 — actual session UUID assigned by codex
+#
+# Usage:
+#   drive-codex.sh <staging-dir> <preferred-uuid-ignored> \
+#                  <timeout-seconds> <settings-path-ignored> <prompt>
+
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "usage: drive-codex.sh <staging> <preferred-uuid> <timeout-s> <settings-path> <prompt>" >&2
+  exit 2
+fi
+
+STAGING="$1"
+PREFERRED_UUID="$2"   # codex assigns its own; we keep this arg for ABI parity
+TIMEOUT_S="$3"
+SETTINGS_PATH="$4"    # codex has no --settings flag; arg accepted, no-op
+PROMPT="$5"
+
+# Reference unused args once each so `set -u` and shellcheck don't flag them.
+: "${PREFERRED_UUID:-}"
+: "${SETTINGS_PATH:-}"
+
+mkdir -p "$STAGING"
+DRIVER_LOG="$STAGING/driver.log"
+
+# --json prints lifecycle events as JSONL; --skip-git-repo-check lets the
+# CLI run inside worktrees and other unusual checkouts. Auth is the user's
+# responsibility (`codex` config); failures surface via stderr.
+set +e
+timeout --signal=SIGINT --kill-after=10 "$TIMEOUT_S" \
+  codex exec --json --skip-git-repo-check "$PROMPT" \
+  >"$DRIVER_LOG.stdout" 2>"$DRIVER_LOG.stderr"
+EXIT_CODE=$?
+set -e
+
+{
+  echo "=== stdout ==="
+  cat "$DRIVER_LOG.stdout"
+  echo
+  echo "=== stderr ==="
+  cat "$DRIVER_LOG.stderr"
+  echo
+  echo "=== exit code: $EXIT_CODE ==="
+} >"$DRIVER_LOG"
+
+case "$EXIT_CODE" in
+  0)   EXIT_REASON="ok" ;;
+  124) EXIT_REASON="timeout" ;;
+  137) EXIT_REASON="killed" ;;
+  *)   EXIT_REASON="nonzero($EXIT_CODE)" ;;
+esac
+echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+
+# Extract the assigned UUID. Don't strictly require the FIRST line — a
+# future codex release could prepend a banner — but scan the first 50
+# events for `thread.started`.
+UUID="$(jq -r 'select(.type == "thread.started") | .thread_id' \
+        < <(head -n 50 "$DRIVER_LOG.stdout") 2>/dev/null | head -n1)"
+
+# Resolve the rollout file. Codex stores transcripts under date-stamped
+# subdirs; the filename always contains the UUID, so a name-glob is
+# sufficient. Poll up to 30s in case the file is still being created.
+TRANSCRIPT=""
+if [[ -n "$UUID" ]]; then
+  for _ in $(seq 1 60); do
+    candidate="$(find "$HOME/.codex/sessions" -maxdepth 4 \
+                  -name "rollout-*-${UUID}.jsonl" -type f 2>/dev/null \
+                | head -n1)"
+    if [[ -n "$candidate" ]]; then
+      TRANSCRIPT="$candidate"
+      break
+    fi
+    sleep 0.5
+  done
+fi
+
+echo "${UUID:-}" > "$STAGING/session.uuid"
+echo "${TRANSCRIPT:-}" > "$STAGING/transcript.path"
+
+echo "drive-codex: $EXIT_REASON (uuid=${UUID:-<unknown>}, transcript=${TRANSCRIPT:-<unresolved>}, log=$DRIVER_LOG)"
+
+exit "$EXIT_CODE"

--- a/.claude/skills/ir:onboard-agent/scripts/drive-codex.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/drive-codex.sh
@@ -25,14 +25,11 @@ if [[ $# -ne 5 ]]; then
 fi
 
 STAGING="$1"
-PREFERRED_UUID="$2"   # codex assigns its own; we keep this arg for ABI parity
+# $2 (preferred-uuid) and $4 (settings-path) are accepted for ABI parity
+# with drive-claudecode.sh; codex assigns its own UUID and has no
+# --settings flag, so both are unused here.
 TIMEOUT_S="$3"
-SETTINGS_PATH="$4"    # codex has no --settings flag; arg accepted, no-op
 PROMPT="$5"
-
-# Reference unused args once each so `set -u` and shellcheck don't flag them.
-: "${PREFERRED_UUID:-}"
-: "${SETTINGS_PATH:-}"
 
 mkdir -p "$STAGING"
 DRIVER_LOG="$STAGING/driver.log"

--- a/.claude/skills/ir:onboard-agent/scripts/drive-pi.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/drive-pi.sh
@@ -32,28 +32,23 @@ if [[ $# -ne 5 ]]; then
 fi
 
 STAGING="$1"
-PREFERRED_UUID="$2"   # pi assigns its own; we keep this arg for ABI parity
+# $2 (preferred-uuid) and $4 (settings-path) are accepted for ABI parity
+# with drive-claudecode.sh; pi assigns its own UUID and has no
+# --settings flag, so both are unused here.
 TIMEOUT_S="$3"
-SETTINGS_PATH="$4"    # pi has no --settings flag; arg accepted, no-op
 PROMPT="$5"
-
-: "${PREFERRED_UUID:-}"
-: "${SETTINGS_PATH:-}"
 
 mkdir -p "$STAGING"
 DRIVER_LOG="$STAGING/driver.log"
 PI_SESSIONS_DIR="$HOME/.pi/agent/sessions"
 
-# Marker file lets `find -newer` reliably pick up only the file pi
-# creates during this run. mkdir guarantees the parent exists even if
-# the user has never run pi before.
+# Marker scopes the post-run `find -newer` to this invocation.
+# mkdir handles the case where the user has never run pi.
 mkdir -p "$PI_SESSIONS_DIR"
 MARKER="$STAGING/.pi-start-marker"
 touch "$MARKER"
-sleep 1   # ensure mtime resolution distinguishes new files (HFS+ = 1s)
 
-# `pi --print -p` is the documented non-interactive mode. Auth is the
-# user's responsibility (`pi --api-key` or provider env vars).
+# Auth is the user's responsibility (`pi --api-key` or provider env vars).
 set +e
 timeout --signal=SIGINT --kill-after=10 "$TIMEOUT_S" \
   pi --print -p "$PROMPT" \

--- a/.claude/skills/ir:onboard-agent/scripts/drive-pi.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/drive-pi.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# drive-pi.sh — run one scenario against the pi CLI headlessly.
+#
+# Pi's `--session <UUID>` resumes an existing session; we cannot
+# pre-assign a UUID for a fresh session. We also can't redirect with
+# `--session-dir` because the daemon's fswatcher only watches the
+# default $HOME/.pi/agent/sessions tree.
+#
+# Strategy:
+#   1. touch a marker file before launching pi
+#   2. run `pi --print -p <PROMPT>` under timeout
+#   3. find the new .jsonl under ~/.pi/agent/sessions newer than the
+#      marker (there should be exactly one)
+#   4. read its first line — pi writes the session header
+#      `{"type":"session","id":"<UUID>",...}` — to extract the UUID.
+#
+# Contract files written to <staging-dir>:
+#   driver.log[.stdout|.stderr]  — captured CLI output
+#   driver.exit-reason           — ok|timeout|killed|nonzero(N)
+#   transcript.path              — absolute path to the resolved transcript
+#   session.uuid                 — actual session UUID assigned by pi
+#
+# Usage:
+#   drive-pi.sh <staging-dir> <preferred-uuid-ignored> \
+#               <timeout-seconds> <settings-path-ignored> <prompt>
+
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "usage: drive-pi.sh <staging> <preferred-uuid> <timeout-s> <settings-path> <prompt>" >&2
+  exit 2
+fi
+
+STAGING="$1"
+PREFERRED_UUID="$2"   # pi assigns its own; we keep this arg for ABI parity
+TIMEOUT_S="$3"
+SETTINGS_PATH="$4"    # pi has no --settings flag; arg accepted, no-op
+PROMPT="$5"
+
+: "${PREFERRED_UUID:-}"
+: "${SETTINGS_PATH:-}"
+
+mkdir -p "$STAGING"
+DRIVER_LOG="$STAGING/driver.log"
+PI_SESSIONS_DIR="$HOME/.pi/agent/sessions"
+
+# Marker file lets `find -newer` reliably pick up only the file pi
+# creates during this run. mkdir guarantees the parent exists even if
+# the user has never run pi before.
+mkdir -p "$PI_SESSIONS_DIR"
+MARKER="$STAGING/.pi-start-marker"
+touch "$MARKER"
+sleep 1   # ensure mtime resolution distinguishes new files (HFS+ = 1s)
+
+# `pi --print -p` is the documented non-interactive mode. Auth is the
+# user's responsibility (`pi --api-key` or provider env vars).
+set +e
+timeout --signal=SIGINT --kill-after=10 "$TIMEOUT_S" \
+  pi --print -p "$PROMPT" \
+  >"$DRIVER_LOG.stdout" 2>"$DRIVER_LOG.stderr"
+EXIT_CODE=$?
+set -e
+
+{
+  echo "=== stdout ==="
+  cat "$DRIVER_LOG.stdout"
+  echo
+  echo "=== stderr ==="
+  cat "$DRIVER_LOG.stderr"
+  echo
+  echo "=== exit code: $EXIT_CODE ==="
+} >"$DRIVER_LOG"
+
+case "$EXIT_CODE" in
+  0)   EXIT_REASON="ok" ;;
+  124) EXIT_REASON="timeout" ;;
+  137) EXIT_REASON="killed" ;;
+  *)   EXIT_REASON="nonzero($EXIT_CODE)" ;;
+esac
+echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+
+# Resolve the transcript: newest .jsonl under PI_SESSIONS_DIR newer than
+# the marker. Poll up to 30s for pi to flush. If multiple files appear
+# (e.g. another pi run interleaved), pick the lexicographically last —
+# pi prefixes filenames with an ISO8601 timestamp so newest sorts last.
+TRANSCRIPT=""
+for _ in $(seq 1 60); do
+  candidate="$(find "$PI_SESSIONS_DIR" -type f -name '*.jsonl' \
+                -newer "$MARKER" 2>/dev/null | sort | tail -n1)"
+  if [[ -n "$candidate" && -s "$candidate" ]]; then
+    TRANSCRIPT="$candidate"
+    break
+  fi
+  sleep 0.5
+done
+
+# Extract UUID from the session header on line 1.
+UUID=""
+if [[ -n "$TRANSCRIPT" ]]; then
+  UUID="$(head -n1 "$TRANSCRIPT" | jq -r '.id // empty' 2>/dev/null || true)"
+fi
+
+echo "${UUID:-}" > "$STAGING/session.uuid"
+echo "${TRANSCRIPT:-}" > "$STAGING/transcript.path"
+
+echo "drive-pi: $EXIT_REASON (uuid=${UUID:-<unknown>}, transcript=${TRANSCRIPT:-<unresolved>}, log=$DRIVER_LOG)"
+
+exit "$EXIT_CODE"

--- a/.claude/skills/ir:onboard-agent/scripts/drive-pi.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/drive-pi.sh
@@ -100,6 +100,15 @@ if [[ -n "$TRANSCRIPT" ]]; then
   UUID="$(head -n1 "$TRANSCRIPT" | jq -r '.id // empty' 2>/dev/null || true)"
 fi
 
+# Maintain the invariant: transcript.path is non-empty ⇒ session.uuid is
+# valid. If we can't extract a UUID, the transcript is unusable for
+# curation (the daemon's recording session_id won't correlate). Clear
+# transcript.path and let run-cell.sh report ERROR.
+if [[ -n "$TRANSCRIPT" && -z "$UUID" ]]; then
+  echo "drive-pi: WARN — found transcript $TRANSCRIPT but could not extract session UUID from line 1" >&2
+  TRANSCRIPT=""
+fi
+
 echo "${UUID:-}" > "$STAGING/session.uuid"
 echo "${TRANSCRIPT:-}" > "$STAGING/transcript.path"
 

--- a/.claude/skills/ir:onboard-agent/scripts/precheck.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/precheck.sh
@@ -63,38 +63,22 @@ if [[ ! -f "$SCENARIOS_JSON" ]]; then
 fi
 MIN_VERSION="$(jq -r --arg a "$ADAPTER" '.min_versions[$a] // empty' "$SCENARIOS_JSON")"
 
-CLI_VER=""
+# Version-string layout per adapter: <bin>:<awk-field-of-version-token>.
+# claude --version → "X.Y.Z (...)"; codex --version → "codex-cli X.Y.Z";
+# pi --version → "X.Y.Z".
 case "$ADAPTER" in
-  claudecode)
-    if ! command -v claude >/dev/null 2>&1; then
-      fail "claude CLI not on PATH"
-    fi
-    CLI_VER="$(claude --version 2>/dev/null | awk '{print $1}' | head -n1)"
-    [[ -n "$CLI_VER" ]] || fail "could not parse 'claude --version' output"
-    ;;
-  codex)
-    if ! command -v codex >/dev/null 2>&1; then
-      fail "codex CLI not on PATH"
-    fi
-    # `codex --version` prints "codex-cli X.Y.Z"; take field 2.
-    CLI_VER="$(codex --version 2>/dev/null | awk '{print $2}' | head -n1)"
-    [[ -n "$CLI_VER" ]] || fail "could not parse 'codex --version' output"
-    ;;
-  pi)
-    if ! command -v pi >/dev/null 2>&1; then
-      fail "pi CLI not on PATH"
-    fi
-    # `pi --version` prints just "X.Y.Z".
-    CLI_VER="$(pi --version 2>/dev/null | awk '{print $1}' | head -n1)"
-    [[ -n "$CLI_VER" ]] || fail "could not parse 'pi --version' output"
-    ;;
+  claudecode) CLI_BIN="claude"; VER_FIELD=1 ;;
+  codex)      CLI_BIN="codex";  VER_FIELD=2 ;;
+  pi)         CLI_BIN="pi";     VER_FIELD=1 ;;
 esac
 
-if [[ -n "$MIN_VERSION" && -n "$CLI_VER" ]]; then
+command -v "$CLI_BIN" >/dev/null 2>&1 || fail "$CLI_BIN CLI not on PATH"
+CLI_VER="$("$CLI_BIN" --version 2>/dev/null | awk -v f="$VER_FIELD" '{print $f}' | head -n1)"
+[[ -n "$CLI_VER" ]] || fail "could not parse '$CLI_BIN --version' output"
+
+if [[ -n "$MIN_VERSION" ]]; then
   LOWEST="$(printf '%s\n%s\n' "$MIN_VERSION" "$CLI_VER" | sort -V | head -n1)"
-  if [[ "$LOWEST" != "$MIN_VERSION" ]]; then
-    fail "$ADAPTER $CLI_VER is below pinned minimum $MIN_VERSION"
-  fi
+  [[ "$LOWEST" == "$MIN_VERSION" ]] || fail "$ADAPTER $CLI_VER is below pinned minimum $MIN_VERSION"
 fi
 
 # 5. Build irrlichd + replay from the current worktree so recordings

--- a/.claude/skills/ir:onboard-agent/scripts/precheck.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/precheck.sh
@@ -30,10 +30,7 @@ fail() {
 
 # 1. Adapter is supported by a driver.
 case "$ADAPTER" in
-  claudecode) ;;
-  codex|pi)
-    fail "adapter '$ADAPTER' has no driver script yet (see README: 'Adding an adapter column')"
-    ;;
+  claudecode|codex|pi) ;;
   *)
     fail "unknown adapter: $ADAPTER"
     ;;
@@ -66,23 +63,39 @@ if [[ ! -f "$SCENARIOS_JSON" ]]; then
 fi
 MIN_VERSION="$(jq -r --arg a "$ADAPTER" '.min_versions[$a] // empty' "$SCENARIOS_JSON")"
 
+CLI_VER=""
 case "$ADAPTER" in
   claudecode)
     if ! command -v claude >/dev/null 2>&1; then
       fail "claude CLI not on PATH"
     fi
-    CLAUDE_VER="$(claude --version 2>/dev/null | awk '{print $1}' | head -n1)"
-    if [[ -z "$CLAUDE_VER" ]]; then
-      fail "could not parse 'claude --version' output"
+    CLI_VER="$(claude --version 2>/dev/null | awk '{print $1}' | head -n1)"
+    [[ -n "$CLI_VER" ]] || fail "could not parse 'claude --version' output"
+    ;;
+  codex)
+    if ! command -v codex >/dev/null 2>&1; then
+      fail "codex CLI not on PATH"
     fi
-    if [[ -n "$MIN_VERSION" ]]; then
-      LOWEST="$(printf '%s\n%s\n' "$MIN_VERSION" "$CLAUDE_VER" | sort -V | head -n1)"
-      if [[ "$LOWEST" != "$MIN_VERSION" ]]; then
-        fail "claude $CLAUDE_VER is below pinned minimum $MIN_VERSION"
-      fi
+    # `codex --version` prints "codex-cli X.Y.Z"; take field 2.
+    CLI_VER="$(codex --version 2>/dev/null | awk '{print $2}' | head -n1)"
+    [[ -n "$CLI_VER" ]] || fail "could not parse 'codex --version' output"
+    ;;
+  pi)
+    if ! command -v pi >/dev/null 2>&1; then
+      fail "pi CLI not on PATH"
     fi
+    # `pi --version` prints just "X.Y.Z".
+    CLI_VER="$(pi --version 2>/dev/null | awk '{print $1}' | head -n1)"
+    [[ -n "$CLI_VER" ]] || fail "could not parse 'pi --version' output"
     ;;
 esac
+
+if [[ -n "$MIN_VERSION" && -n "$CLI_VER" ]]; then
+  LOWEST="$(printf '%s\n%s\n' "$MIN_VERSION" "$CLI_VER" | sort -V | head -n1)"
+  if [[ "$LOWEST" != "$MIN_VERSION" ]]; then
+    fail "$ADAPTER $CLI_VER is below pinned minimum $MIN_VERSION"
+  fi
+fi
 
 # 5. Build irrlichd + replay from the current worktree so recordings
 #    reflect code under review, and so run-cell.sh can invoke replay
@@ -95,4 +108,4 @@ for bin in irrlichd replay; do
   fi
 done
 
-echo "precheck: OK (adapter=$ADAPTER, claude=${CLAUDE_VER:-n/a}, bin=$BIN_DIR)"
+echo "precheck: OK (adapter=$ADAPTER, $ADAPTER=${CLI_VER:-n/a}, bin=$BIN_DIR)"

--- a/.claude/skills/ir:onboard-agent/scripts/run-cell.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/run-cell.sh
@@ -150,9 +150,6 @@ trap - EXIT
 # --- Read driver-resolved transcript + actual UUID ----------------------
 TRANSCRIPT="$(cat "$STAGING/transcript.path" 2>/dev/null || true)"
 ACTUAL_UUID="$(cat "$STAGING/session.uuid" 2>/dev/null || true)"
-# Fall back to the pre-generated UUID if the driver didn't write one
-# (e.g., a stale driver from before the contract change).
-[[ -n "$ACTUAL_UUID" ]] || ACTUAL_UUID="$UUID"
 
 # --- Locate the recording file ------------------------------------------
 RECORDING="$(find "$STAGING/recordings" -maxdepth 1 -name '*.jsonl' -type f 2>/dev/null | head -n1)"

--- a/.claude/skills/ir:onboard-agent/scripts/run-cell.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/run-cell.sh
@@ -132,6 +132,10 @@ done
 [[ -S "$SOCK" ]] || { echo "daemon socket never appeared: $SOCK" >&2; exit 1; }
 
 # --- Drive the agent ----------------------------------------------------
+# Drivers are responsible for resolving the transcript path and writing
+# session.uuid + transcript.path back to staging. UUID arg $2 is a
+# "preferred" UUID — drive-claudecode.sh honors it via --session-id;
+# codex/pi drivers ignore it and surface the agent-assigned UUID.
 DRIVER="$SCRIPT_DIR/drive-$ADAPTER.sh"
 [[ -x "$DRIVER" ]] || { echo "driver missing: $DRIVER" >&2; exit 1; }
 set +e
@@ -143,21 +147,12 @@ DRIVER_REASON="$(cat "$STAGING/driver.exit-reason" 2>/dev/null || echo "unknown"
 cleanup
 trap - EXIT
 
-# --- Resolve the transcript path ----------------------------------------
-# Claude Code writes transcripts to ~/.claude/projects/<slug>/<UUID>.jsonl.
-# Stat the expected path under each slug dir (O(#projects)) rather than
-# walking the whole tree with `find`. Poll up to 30s.
-TRANSCRIPT=""
-for _ in $(seq 1 60); do
-  for slug_dir in "$HOME"/.claude/projects/*/; do
-    candidate="$slug_dir$UUID.jsonl"
-    if [[ -f "$candidate" ]]; then
-      TRANSCRIPT="$candidate"
-      break 2
-    fi
-  done
-  sleep 0.5
-done
+# --- Read driver-resolved transcript + actual UUID ----------------------
+TRANSCRIPT="$(cat "$STAGING/transcript.path" 2>/dev/null || true)"
+ACTUAL_UUID="$(cat "$STAGING/session.uuid" 2>/dev/null || true)"
+# Fall back to the pre-generated UUID if the driver didn't write one
+# (e.g., a stale driver from before the contract change).
+[[ -n "$ACTUAL_UUID" ]] || ACTUAL_UUID="$UUID"
 
 # --- Locate the recording file ------------------------------------------
 RECORDING="$(find "$STAGING/recordings" -maxdepth 1 -name '*.jsonl' -type f 2>/dev/null | head -n1)"
@@ -169,7 +164,7 @@ if [[ -z "$TRANSCRIPT" || -z "$RECORDING" ]]; then
   jq -n \
     --arg adapter "$ADAPTER" \
     --arg scenario "$SCENARIO" \
-    --arg session_uuid "$UUID" \
+    --arg session_uuid "$ACTUAL_UUID" \
     --argjson transcript_found "$([[ -n "$TRANSCRIPT" ]] && echo true || echo false)" \
     --argjson recording_found "$([[ -n "$RECORDING" ]] && echo true || echo false)" \
     --arg driver_exit_reason "$DRIVER_REASON" \
@@ -195,7 +190,7 @@ fi
 #   <staging>/testdata/replay/<adapter>/<scenario>.{jsonl,events.jsonl}
 "$REPO_ROOT/scripts/curate-lifecycle-fixture.sh" \
   -d "$STAGING/testdata/replay" \
-  "$RECORDING" "$UUID" "$TRANSCRIPT" "$ADAPTER" "$SCENARIO"
+  "$RECORDING" "$ACTUAL_UUID" "$TRANSCRIPT" "$ADAPTER" "$SCENARIO"
 
 STAGED_TRANSCRIPT="$STAGING/testdata/replay/$ADAPTER/$SCENARIO.jsonl"
 
@@ -226,7 +221,7 @@ fi
 jq -n \
   --arg adapter "$ADAPTER" \
   --arg scenario "$SCENARIO" \
-  --arg session_uuid "$UUID" \
+  --arg session_uuid "$ACTUAL_UUID" \
   --arg staging "$STAGING" \
   --arg raw_recording "$RECORDING" \
   --arg source_transcript "$TRANSCRIPT" \

--- a/.claude/skills/ir:onboard-agent/scripts/run-cell.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/run-cell.sh
@@ -160,13 +160,14 @@ RECORDING="$(find "$STAGING/recordings" -maxdepth 1 -name '*.jsonl' -type f 2>/d
 MANIFEST="$STAGING/run-manifest.json"
 DAEMON_SHUTDOWN="$(cat "$STAGING/daemon.shutdown" 2>/dev/null || echo "unknown")"
 
-if [[ -z "$TRANSCRIPT" || -z "$RECORDING" ]]; then
+if [[ -z "$TRANSCRIPT" || -z "$RECORDING" || -z "$ACTUAL_UUID" ]]; then
   jq -n \
     --arg adapter "$ADAPTER" \
     --arg scenario "$SCENARIO" \
     --arg session_uuid "$ACTUAL_UUID" \
     --argjson transcript_found "$([[ -n "$TRANSCRIPT" ]] && echo true || echo false)" \
     --argjson recording_found "$([[ -n "$RECORDING" ]] && echo true || echo false)" \
+    --argjson uuid_resolved "$([[ -n "$ACTUAL_UUID" ]] && echo true || echo false)" \
     --arg driver_exit_reason "$DRIVER_REASON" \
     --arg daemon_shutdown "$DAEMON_SHUTDOWN" \
     --arg staging "$STAGING" \
@@ -174,14 +175,15 @@ if [[ -z "$TRANSCRIPT" || -z "$RECORDING" ]]; then
       scenario: $scenario,
       session_uuid: $session_uuid,
       verdict: "ERROR",
-      error: "transcript_or_recording_missing",
+      error: "transcript_recording_or_uuid_missing",
       transcript_found: $transcript_found,
       recording_found: $recording_found,
+      uuid_resolved: $uuid_resolved,
       driver_exit_reason: $driver_exit_reason,
       daemon_shutdown: $daemon_shutdown,
       staging: $staging}' \
     > "$MANIFEST"
-  echo "ERROR: transcript=${TRANSCRIPT:-missing} recording=${RECORDING:-missing}" >&2
+  echo "ERROR: transcript=${TRANSCRIPT:-missing} recording=${RECORDING:-missing} uuid=${ACTUAL_UUID:-missing}" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Closes #200.

## Summary
- New `drive-codex.sh` and `drive-pi.sh` driver scripts. Codex's UUID is parsed from the first `thread.started` event of `codex exec --json` stdout; pi's UUID is read from the new session file header located via a `find -newer` marker.
- `scenarios.json` gains `by_adapter.codex` and `by_adapter.pi` entries for `baseline-hello` and `full-lifecycle-toolcall`. `min_versions.pi` lowered to `0.70.0` to match the installed CLI. `permission-hook-denial` stays claudecode-only — codex/pi lack `CapPermissionHooks`, so those cells are correctly N/A.
- Driver-vs-orchestrator contract grows two staging files (`transcript.path`, `session.uuid`). Each driver owns its adapter-specific transcript-resolution. The slug-scan that previously lived in `run-cell.sh` moves into `drive-claudecode.sh`. `precheck.sh` drops the codex/pi stub refusal and gains version checks for both CLIs (table-driven dispatch).

## Commits
- `ef5776c` — initial implementation (drivers, contract, scenarios, precheck).
- `a511ad1` — review fix: ERROR manifest now gates on `uuid_resolved`, and `drive-pi.sh` clears `transcript.path` if the session header `id` field can't be parsed (preserving the `transcript ⇒ valid UUID` invariant).
- `8bbf182` — simplification: collapse three near-duplicate version-parse blocks in `precheck.sh` into a table; drop the `sleep 1` HFS+ workaround in `drive-pi.sh` (APFS/modern Linux have sub-second mtime, saves ~1s per pi cell); drop dead UUID fall-back in `run-cell.sh` and dead shellcheck silencers in the new drivers. Net −27 LOC.

## Test plan
- [x] `bash -n` passes on all five scripts.
- [x] `jq '.' scenarios.json` validates.
- [ ] Re-run `/ir:onboard-agent` (no args) — confirm matrix shows `never-recorded` (not `missing-prompt`) for the four codex/pi cells with prompts and `N/A (no permission_hooks)` for codex/pi `permission-hook-denial`.
- [ ] Re-run `/ir:onboard-agent claudecode baseline-hello` — verdict should be `OK: no material change` (regression check on the contract refactor).
- [ ] Run `/ir:onboard-agent codex baseline-hello`, `codex full-lifecycle-toolcall`, `pi baseline-hello`, `pi full-lifecycle-toolcall`. Each should produce a `FIRST-RECORD (new fixture)` verdict whose staged report satisfies the scenario's `verify` block.
- [ ] Maintainer reviews and copies the four staged fixture pairs into `testdata/replay/{codex,pi}/`; `go test ./core/cmd/replay/... -run TestReplayWithSidecar` passes.

Note: `permission-hook-denial` is intentionally not added for codex/pi — they don't declare `CapPermissionHooks`. The Pi `full-lifecycle-toolcall` prompt may need one tuning pass if it doesn't reliably fire a Bash tool call (per the issue's note on per-adapter prompt wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)