### PR TITLE
fix(macos): drop cents on cost display at >=$100

### DIFF
--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -142,6 +142,7 @@ struct SessionMetrics: Codable {
     var formattedCost: String? {
         guard let cost = estimatedCostUSD, cost > 0 else { return nil }
         if cost < 0.01 { return "<$0.01" }
+        if cost >= 100 { return String(format: "$%.0f", cost) }
         return String(format: "$%.2f", cost)
     }
     

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -770,6 +770,7 @@ struct GroupView: View {
         guard v > 0 else { return "$0" + costTimeframe.suffix }
         let formatted: String
         if v < 0.01 { formatted = "<$0.01" }
+        else if v >= 100 { formatted = String(format: "$%.0f", v) }
         else { formatted = String(format: "$%.2f", v) }
         return formatted + costTimeframe.suffix
     }

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -186,12 +186,16 @@ final class SessionManagerTests: XCTestCase {
         )
     }
 
-    func testFormattedCost_AlwaysTwoDecimalsAboveOneDollar() {
-        // Regression: old code switched to "$%.0f" for cost >= $10, hiding the
-        // cents. Now every non-trivial cost uses two decimals.
-        XCTAssertEqual(makeMetrics(cost: 12.5).formattedCost, "$12.50")
-        XCTAssertEqual(makeMetrics(cost: 105.0).formattedCost, "$105.00")
+    func testFormattedCost_DropsCentsAt100AndAbove() {
+        // Below $100: keep two decimals. The prior bug hid cents at $10+.
         XCTAssertEqual(makeMetrics(cost: 9.99).formattedCost, "$9.99")
+        XCTAssertEqual(makeMetrics(cost: 12.5).formattedCost, "$12.50")
+        XCTAssertEqual(makeMetrics(cost: 99.99).formattedCost, "$99.99")
+        // $100+: drop cents so the value fits the 36pt cost column behind the
+        // context bar (issue #214).
+        XCTAssertEqual(makeMetrics(cost: 100.0).formattedCost, "$100")
+        XCTAssertEqual(makeMetrics(cost: 105.0).formattedCost, "$105")
+        XCTAssertEqual(makeMetrics(cost: 106.99).formattedCost, "$107")
     }
 
     func testFormattedCost_SmallAndZero() {


### PR DESCRIPTION
## Summary
- Render `$%.0f` instead of `$%.2f` once cost ≥ \$100 in `SessionMetrics.formattedCost` and the parallel `GroupView.formattedCost`. The 36pt monospaced cost column behind the context-usage bar can't fit three-digit dollars + cents, so the trailing cent wraps onto a second line. At that magnitude two cents of precision isn't meaningful.
- Below \$100 the existing `$XX.XX` format is unchanged.
- Renamed/extended the existing test with boundary coverage at \$99.99 / \$100 / \$105 / \$106.99.

Closes #214

## Test plan
- [x] `swift test --filter SessionManagerTests/testFormattedCost` — passes
- [x] Visual check via `/ir:test-mac` with a session at \$106.99 and a group whose weekly/daily cost > \$100 — no wrap on any timeframe
- [ ] Reviewer: cents still shown for sessions < \$100

🤖 Generated with [Claude Code](https://claude.com/claude-code)