### PR TITLE
fix(ui): restore tooltips lost in NSPanel migration (#218)

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -9,6 +9,15 @@ enum ConnectionState {
     case connecting     // initial connection attempt
     case connected      // WebSocket active and receiving
     case reconnecting   // transient disconnect, auto-recovering
+
+    var tooltip: String {
+        switch self {
+        case .connected:    return "Daemon connected — watching for sessions"
+        case .connecting:   return "Connecting to daemon\u{2026}"
+        case .reconnecting: return "Reconnecting to daemon\u{2026}"
+        case .disconnected: return "Daemon disconnected"
+        }
+    }
 }
 
 @MainActor

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -263,16 +263,7 @@ struct SessionListView: View {
                 .font(.caption2)
                 .foregroundColor(.secondary)
         }
-        .tooltip(statusTooltip)
-    }
-
-    private var statusTooltip: String {
-        switch sessionManager.connectionState {
-        case .connected: return "Daemon connected — watching for sessions"
-        case .connecting: return "Connecting to daemon\u{2026}"
-        case .reconnecting: return "Reconnecting to daemon\u{2026}"
-        case .disconnected: return "Daemon disconnected"
-        }
+        .tooltip(sessionManager.connectionState.tooltip)
     }
 
     private var statusColor: Color {
@@ -417,7 +408,6 @@ struct SessionRowView: View {
                                 .font(.system(size: 9, design: .monospaced))
                                 .foregroundColor(Color(hex: metrics.contextPressureColor))
                                 .frame(width: 32, alignment: .leading)
-                                .tooltip("Context window usage")
                         }
                     } else if debugMode, let metrics = session.metrics, metrics.totalTokens > 0 {
                         Color.clear.frame(width: 100, height: 13)
@@ -479,7 +469,8 @@ struct SessionRowView: View {
                     .background(Color.orange.opacity(0.12))
                     .cornerRadius(4)
                     .padding(.top, 2)
-                    .tooltip("Agent is waiting for input")
+                    // Surface the full prompt — head-truncation hides the start.
+                    .tooltip(text)
             }
 
             // Context pressure alert (80%+, active sessions only)
@@ -777,6 +768,14 @@ struct GroupView: View {
 
     private var isTopLevel: Bool { depth == 0 }
 
+    private var groupExpandTooltip: String {
+        let action = isExpanded ? "Collapse" : "Expand"
+        if isTopLevel && group.isGasTown {
+            return "\(action) Gas Town group (external API calls)"
+        }
+        return "\(action) group"
+    }
+
     /// Formatted cost for this group in the currently-selected time frame.
     /// Returns nil only when there is no cost data at all (hides the toggle).
     /// Returns "$0 / <frame>" when data exists for other frames but not this one,
@@ -814,7 +813,6 @@ struct GroupView: View {
                         if isTopLevel && group.isGasTown {
                             Text("\u{26FD}")
                                 .font(.system(size: 10))
-                                .tooltip("Gas Town session (external API calls)")
                         }
 
                         Text(group.name)
@@ -825,7 +823,7 @@ struct GroupView: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .tooltip(isExpanded ? "Collapse group" : "Expand group")
+                .tooltip(groupExpandTooltip)
 
                 if let cost = formattedCost {
                     Button(action: cycleCostTimeframe) {

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -14,7 +14,7 @@ import SwiftUI
 // nonactivating panel, positioned in screen coordinates above the cursor.
 
 @MainActor
-final class TooltipWindowController {
+private final class TooltipWindowController {
     static let shared = TooltipWindowController()
 
     private let panel: NSPanel
@@ -82,7 +82,10 @@ final class TooltipWindowController {
         // Native macOS tooltips appear diagonally below-right of the cursor.
         // Screen Y grows upward, so "below cursor" = lower Y.
         var origin = NSPoint(x: cursor.x + 14, y: cursor.y - size.height - 18)
-        if let visible = NSScreen.main?.visibleFrame {
+        // Clamp to the screen the cursor is actually on, not NSScreen.main —
+        // otherwise the tooltip jumps to the focused display on multi-monitor.
+        let cursorScreen = NSScreen.screens.first { $0.frame.contains(cursor) } ?? NSScreen.main
+        if let visible = cursorScreen?.visibleFrame {
             origin.x = max(visible.minX + 4, min(origin.x, visible.maxX - size.width - 4))
             if origin.y < visible.minY + 4 {
                 origin.y = cursor.y + 18  // flip above when no room below

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -107,6 +107,7 @@ struct SessionListView: View {
                             }
                     }
                     .buttonStyle(.plain)
+                    .tooltip("Open settings panel")
 
                     Divider().frame(height: 20)
 
@@ -122,6 +123,7 @@ struct SessionListView: View {
                             }
                     }
                     .buttonStyle(.plain)
+                    .tooltip("Quit Irrlicht")
                 }
             }
             .frame(width: Self.panelWidth)
@@ -261,6 +263,16 @@ struct SessionListView: View {
                 .font(.caption2)
                 .foregroundColor(.secondary)
         }
+        .tooltip(statusTooltip)
+    }
+
+    private var statusTooltip: String {
+        switch sessionManager.connectionState {
+        case .connected: return "Daemon connected — watching for sessions"
+        case .connecting: return "Connecting to daemon\u{2026}"
+        case .reconnecting: return "Reconnecting to daemon\u{2026}"
+        case .disconnected: return "Daemon disconnected"
+        }
     }
 
     private var statusColor: Color {
@@ -371,6 +383,7 @@ struct SessionRowView: View {
                         .frame(width: 14, height: 14)
                         .background(Color.purple)
                         .clipShape(Circle())
+                        .tooltip("\(activeSubagentCount) active subagent\(activeSubagentCount == 1 ? "" : "s")")
                 }
 
                 // Branch name — column shrinks when a subagent badge is present so
@@ -392,16 +405,19 @@ struct SessionRowView: View {
                                    pressureColor: metrics.contextPressureColor,
                                    label: metrics.formattedTokenCount)
                             .frame(width: 100, height: 13)
+                            .tooltip("Context window usage")
                         if showCostDisplay {
                             Text(metrics.formattedCost ?? "")
                                 .font(.system(size: 9, weight: .medium, design: .monospaced))
                                 .foregroundColor(.secondary)
                                 .frame(width: 36, alignment: .leading)
+                                .tooltip("Estimated session cost")
                         } else {
                             Text(metrics.formattedContextUtilization)
                                 .font(.system(size: 9, design: .monospaced))
                                 .foregroundColor(Color(hex: metrics.contextPressureColor))
                                 .frame(width: 32, alignment: .leading)
+                                .tooltip("Context window usage")
                         }
                     } else if debugMode, let metrics = session.metrics, metrics.totalTokens > 0 {
                         Color.clear.frame(width: 100, height: 13)
@@ -463,6 +479,7 @@ struct SessionRowView: View {
                     .background(Color.orange.opacity(0.12))
                     .cornerRadius(4)
                     .padding(.top, 2)
+                    .tooltip("Agent is waiting for input")
             }
 
             // Context pressure alert (80%+, active sessions only)
@@ -484,6 +501,7 @@ struct SessionRowView: View {
                 .background((isCritical ? Color.red : Color.orange).opacity(0.08))
                 .cornerRadius(4)
                 .padding(.top, 2)
+                .tooltip(isCritical ? "Context window critically full" : "Context window nearing limit")
             }
 
             // Task list (Claude Code TaskCreate / TaskUpdate)
@@ -500,7 +518,7 @@ struct SessionRowView: View {
                                 NSPasteboard.general.clearContents()
                                 NSPasteboard.general.setString(session.id, forType: .string)
                             }
-                            .help("Click to copy full ID")
+                            .tooltip("Click to copy full ID")
                         Text("updated: \(elapsedString(from: session.updatedAt, now: context.date))")
                         Text("created: \(elapsedString(from: session.firstSeen, now: context.date))")
                         if let metrics = session.metrics, metrics.totalTokens > 0 {
@@ -644,7 +662,7 @@ struct SessionActionButtons: View {
                     .foregroundColor(.secondary)
             }
             .buttonStyle(.plain)
-            .help("Reset to ready state")
+            .tooltip("Reset to ready state")
 
             Button(action: {
                 sessionManager.deleteSession(sessionId: session.id)
@@ -654,7 +672,7 @@ struct SessionActionButtons: View {
                     .foregroundColor(.secondary)
             }
             .buttonStyle(.plain)
-            .help("Delete session")
+            .tooltip("Delete session")
         }
         .opacity(0.6)
     }
@@ -796,6 +814,7 @@ struct GroupView: View {
                         if isTopLevel && group.isGasTown {
                             Text("\u{26FD}")
                                 .font(.system(size: 10))
+                                .tooltip("Gas Town session (external API calls)")
                         }
 
                         Text(group.name)
@@ -806,6 +825,7 @@ struct GroupView: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .tooltip(isExpanded ? "Collapse group" : "Expand group")
 
                 if let cost = formattedCost {
                     Button(action: cycleCostTimeframe) {
@@ -815,7 +835,7 @@ struct GroupView: View {
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                    .help("Click to cycle time frame (day → week → month → year)")
+                    .tooltip("Click to cycle time frame (day → week → month → year)")
                 }
 
                 Spacer()
@@ -828,10 +848,10 @@ struct GroupView: View {
                 if isTopLevel, sessionManager.apiGroups.count > 1,
                    let idx = sessionManager.apiGroups.firstIndex(where: { $0.name == group.name }) {
                     HStack(spacing: 0) {
-                        reorderButton(icon: "chevron.up", disabled: idx == 0) {
+                        reorderButton(icon: "chevron.up", tooltip: "Move group up", disabled: idx == 0) {
                             sessionManager.moveProjectGroupUp(name: group.name)
                         }
-                        reorderButton(icon: "chevron.down", disabled: idx == sessionManager.apiGroups.count - 1) {
+                        reorderButton(icon: "chevron.down", tooltip: "Move group down", disabled: idx == sessionManager.apiGroups.count - 1) {
                             sessionManager.moveProjectGroupDown(name: group.name)
                         }
                     }
@@ -857,7 +877,7 @@ struct GroupView: View {
         }
     }
 
-    private func reorderButton(icon: String, disabled: Bool, action: @escaping () -> Void) -> some View {
+    private func reorderButton(icon: String, tooltip: String, disabled: Bool, action: @escaping () -> Void) -> some View {
         Button {
             withAnimation(.easeInOut(duration: 0.22)) { action() }
         } label: {
@@ -870,6 +890,7 @@ struct GroupView: View {
         .buttonStyle(.plain)
         .disabled(disabled)
         .opacity(disabled ? 0.3 : 1.0)
+        .tooltip(tooltip)
     }
 }
 

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1,31 +1,144 @@
 import AppKit
 import SwiftUI
 
-// MARK: - Tooltip support for MenuBarExtra
+// MARK: - Tooltip
+//
+// SwiftUI overlays are children of the host window's content layer, which the
+// MenuBarController clips to a rounded rectangle (`masksToBounds = true`). Any
+// SwiftUI-rendered tooltip that's wider than the hovered element gets cropped
+// at the panel edge. NSView.toolTip likewise doesn't fire here because
+// NSToolTipManager hit-tests the cursor's view, and the bridge's
+// click-through hitTest=nil makes it invisible to that lookup.
+//
+// The fix is what AppKit itself does: render the tooltip in its own borderless
+// nonactivating panel, positioned in screen coordinates above the cursor.
 
-/// Forces a native NSView tooltip on any SwiftUI view.
-/// `.help()` doesn't work inside MenuBarExtra panels, so we bridge to AppKit.
-/// `hitTest` returns nil so the overlay doesn't swallow clicks meant for
-/// interactive views (buttons) underneath.
-private final class PassThroughTooltipView: NSView {
-    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+@MainActor
+final class TooltipWindowController {
+    static let shared = TooltipWindowController()
+
+    private let panel: NSPanel
+    private let label: NSTextField
+
+    private init() {
+        panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 30),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        // Z-order vs the host panel is enforced via addChildWindow(_:ordered:.above)
+        // in show(...) — that guarantees the tooltip renders above the host
+        // regardless of level. Level only matters when there is no host.
+        panel.level = NSWindow.Level(rawValue: 200)
+        panel.ignoresMouseEvents = true
+        panel.becomesKeyOnlyIfNeeded = true
+        panel.hidesOnDeactivate = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        panel.animationBehavior = .none
+
+        label = NSTextField(labelWithString: "")
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = .labelColor
+        label.backgroundColor = .clear
+        label.isBezeled = false
+        label.isEditable = false
+        label.isSelectable = false
+        label.lineBreakMode = .byWordWrapping
+        label.maximumNumberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        let bg = NSVisualEffectView()
+        bg.material = .toolTip
+        bg.blendingMode = .behindWindow
+        bg.state = .active
+        bg.wantsLayer = true
+        bg.layer?.cornerRadius = 4
+        bg.layer?.borderWidth = 0.5
+        bg.layer?.borderColor = NSColor.separatorColor.cgColor
+        bg.layer?.masksToBounds = true
+
+        bg.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: bg.leadingAnchor, constant: 6),
+            label.trailingAnchor.constraint(equalTo: bg.trailingAnchor, constant: -6),
+            label.topAnchor.constraint(equalTo: bg.topAnchor, constant: 3),
+            label.bottomAnchor.constraint(equalTo: bg.bottomAnchor, constant: -3),
+        ])
+
+        panel.contentView = bg
+    }
+
+    func show(text: String, near cursor: NSPoint) {
+        label.stringValue = text
+        let maxWidth: CGFloat = 280
+        label.preferredMaxLayoutWidth = maxWidth
+        let labelSize = label.sizeThatFits(NSSize(width: maxWidth, height: .greatestFiniteMagnitude))
+        let size = NSSize(width: ceil(labelSize.width) + 12, height: ceil(labelSize.height) + 6)
+
+        // Native macOS tooltips appear diagonally below-right of the cursor.
+        // Screen Y grows upward, so "below cursor" = lower Y.
+        var origin = NSPoint(x: cursor.x + 14, y: cursor.y - size.height - 18)
+        if let visible = NSScreen.main?.visibleFrame {
+            origin.x = max(visible.minX + 4, min(origin.x, visible.maxX - size.width - 4))
+            if origin.y < visible.minY + 4 {
+                origin.y = cursor.y + 18  // flip above when no room below
+            }
+            origin.y = min(origin.y, visible.maxY - size.height - 4)
+        }
+        panel.setFrame(NSRect(origin: origin, size: size), display: true)
+        // Parent the tooltip to whichever window is on top (main panel, or a
+        // sheet presented on top of it). AppKit guarantees children render
+        // above their parent in z-order — this is the only mechanism that
+        // works reliably for two nonactivating panels in the same process.
+        if let host = findHostWindow(), panel.parent !== host {
+            panel.parent?.removeChildWindow(panel)
+            host.addChildWindow(panel, ordered: .above)
+        }
+        panel.orderFrontRegardless()
+    }
+
+    func hide() {
+        panel.orderOut(nil)
+    }
+
+    private func findHostWindow() -> NSWindow? {
+        // orderedWindows is front-to-back; first non-tooltip visible window
+        // is whichever the user is currently interacting with.
+        NSApp.orderedWindows.first { $0 !== panel && $0.isVisible }
+    }
 }
 
-private struct TooltipView: NSViewRepresentable {
+private struct TooltipModifier: ViewModifier {
     let text: String
-    func makeNSView(context: Context) -> NSView {
-        let view = PassThroughTooltipView()
-        view.toolTip = text
-        return view
-    }
-    func updateNSView(_ nsView: NSView, context: Context) {
-        nsView.toolTip = text
+    @State private var hoverTask: Task<Void, Never>?
+
+    func body(content: Content) -> some View {
+        content.onHover { hovering in
+            hoverTask?.cancel()
+            if hovering, !text.isEmpty {
+                hoverTask = Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 700_000_000)
+                    if !Task.isCancelled {
+                        TooltipWindowController.shared.show(
+                            text: text,
+                            near: NSEvent.mouseLocation
+                        )
+                    }
+                }
+            } else {
+                TooltipWindowController.shared.hide()
+            }
+        }
     }
 }
 
 extension View {
     func tooltip(_ text: String) -> some View {
-        overlay(TooltipView(text: text))
+        modifier(TooltipModifier(text: text))
     }
 }
 

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -52,6 +52,7 @@ struct SettingsView: View {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundColor(.orange)
                             .font(.caption)
+                            .tooltip("Notifications blocked in System Settings")
                         Text("Notifications are blocked.")
                             .font(.caption)
                             .foregroundColor(.orange)
@@ -62,6 +63,7 @@ struct SettingsView: View {
                         }
                         .font(.caption)
                         .buttonStyle(.link)
+                        .tooltip("Open System Settings → Notifications")
                     }
                 }
             }

--- a/platforms/macos/Tests/ViewTooltipsLintTests.swift
+++ b/platforms/macos/Tests/ViewTooltipsLintTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+final class ViewTooltipsLintTests: XCTestCase {
+
+    // Regression guard for #218: SwiftUI's `.help(...)` modifier silently stops
+    // rendering inside the app's NSPanel, so the codebase uses a custom
+    // `.tooltip(...)` AppKit bridge (defined in SessionListView.swift). Any new
+    // `.help(...)` call would silently break tooltips again — the kind of
+    // regression that snapshot tests can't catch because tooltips don't render
+    // until hover. This test fails the build on any non-comment `.help(`
+    // occurrence under Irrlicht/.
+    func testNoHelpModifierInSwiftUIViews() throws {
+        let appURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()        // Tests/
+            .deletingLastPathComponent()        // platforms/macos/
+            .appendingPathComponent("Irrlicht")
+
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(at: appURL, includingPropertiesForKeys: nil) else {
+            XCTFail("Could not enumerate \(appURL.path)")
+            return
+        }
+
+        var offenders: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let source = try String(contentsOf: url, encoding: .utf8)
+            let lines = source.split(separator: "\n", omittingEmptySubsequences: false)
+            for (idx, rawLine) in lines.enumerated() {
+                let line = String(rawLine)
+                // Strip line/doc comments — any "//" outside a string literal kills
+                // the rest. The codebase has no `.help(` inside string literals, so
+                // this naive prefix scan is sufficient.
+                let codePart: Substring
+                if let commentRange = line.range(of: "//") {
+                    codePart = line[..<commentRange.lowerBound]
+                } else {
+                    codePart = line[...]
+                }
+                if codePart.contains(".help(") {
+                    let rel = url.path.replacingOccurrences(of: appURL.path + "/", with: "")
+                    offenders.append("\(rel):\(idx + 1): \(line.trimmingCharacters(in: .whitespaces))")
+                }
+            }
+        }
+
+        XCTAssertTrue(
+            offenders.isEmpty,
+            """
+            Found `.help(...)` modifier — use `.tooltip(...)` instead. \
+            `.help()` does not render inside the app's NSPanel (regression of #218).
+
+            \(offenders.joined(separator: "\n"))
+            """
+        )
+    }
+}


### PR DESCRIPTION
## Summary

**Fixes #218** — restores tooltips that were broken since the MenuBarExtra → NSStatusItem+NSPanel migration (#196). What we found and fixed during implementation:

### Root cause (deeper than the original audit suggested)

The original `.tooltip(_:)` AppKit bridge was *also* broken in the new NSPanel host, not just the four `.help(...)` sites. `NSToolTipManager` hit-tests at the cursor and reads `toolTip` only from the resolved view, but the bridge's `PassThroughTooltipView` returned nil from `hitTest` (to preserve click-through), making it invisible to that lookup. Every `.tooltip(...)` and `.help(...)` call in the panel was silently dead.

### Fix

- **New `TooltipWindowController`** (singleton) that owns its own borderless nonactivating NSPanel, positioned in screen coordinates so it escapes the host panel's `masksToBounds` rounded-corner clip.
- **Z-order via `addChildWindow(_:ordered:.above)`** on every show. Raw window-level comparison (`.screenSaver` vs `.popUpMenu`) was being overridden by AppKit's internal ordering rules for two nonactivating panels in the same process. The child-window relationship is the only mechanism that reliably puts a tooltip above another nonactivating panel — same approach `NSPopover` uses internally.
- **`findHostWindow()`** uses `NSApp.orderedWindows.first` so the tooltip auto-attaches to the topmost visible window — main panel OR Settings sheet — without coupling to MenuBarController.
- **SwiftUI `.tooltip(_:)`** now drives the controller via `.onHover` with a 700 ms delay matching macOS native feel.

### Tooltip coverage (the original task)

- Migrated 4 stale `.help(...)` → `.tooltip(...)` sites.
- Added `.tooltip(...)` to icon-only / unlabeled controls: connection-state indicator, subagent-count badge, ContextBar, cost readout, waiting-question block (surfaces full prompt text), context-pressure alert, group expand/collapse (with Gas Town variant), reorder chevrons, footer Settings/Quit, SettingsView notification-blocked warning + "Open Settings" link.
- `ConnectionState.tooltip` computed property added to the enum, mirroring the existing `DisplayMode.tooltip` precedent.

### Lint regression guard

`ViewTooltipsLintTests` walks `Irrlicht/`, strips comments, and fails the build on any `.help(` occurrence. Snapshot tests can't catch tooltip regressions because tooltips don't render until hover — that's how #218 slipped through originally.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter ViewTooltipsLintTests` passes (15 ms)
- [x] Lint negative case: temporarily injected `.help("...")` → lint failed with file:line; reverted
- [x] **Visual confirmation**: long tooltips render fully above the main panel; tooltips work above the Settings sheet too

🤖 Generated with [Claude Code](https://claude.com/claude-code)