### PR TITLE
fix(metrics): GC stale session ledger files (#185)

### DIFF
--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -154,6 +154,11 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 // in-memory tailer cache entry and removes the on-disk ledger file. Idempotent
 // on a missing transcript path or already-removed ledger file. Silent on I/O
 // errors — the ledger is best-effort cache, not authoritative state.
+//
+// We don't take the per-tailer lock — caller invariant is that PruneEntry runs
+// in response to EventRemoved (transcript file gone), so any concurrent
+// TailAndProcess returns nil metrics without saving. If a save did race in,
+// the daemon-startup orphan sweep would clean it up on next restart.
 func (a *Adapter) PruneEntry(transcriptPath string) {
 	if transcriptPath == "" {
 		return

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"os"
 	"sync"
 
 	"irrlicht/core/adapters/inbound/agents"
@@ -147,6 +148,22 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 		result.PressureLevel = "unknown"
 	}
 	return result, nil
+}
+
+// PruneEntry releases per-session state when a session ends: drops the
+// in-memory tailer cache entry and removes the on-disk ledger file. Idempotent
+// on a missing transcript path or already-removed ledger file. Silent on I/O
+// errors — the ledger is best-effort cache, not authoritative state.
+func (a *Adapter) PruneEntry(transcriptPath string) {
+	if transcriptPath == "" {
+		return
+	}
+	a.mu.Lock()
+	delete(a.tailers, transcriptPath)
+	a.mu.Unlock()
+	if lp := ledgerPath(transcriptPath); lp != "" {
+		_ = os.Remove(lp)
+	}
 }
 
 // tailerTasksToDomain converts a tailer task slice to the domain mirror type.

--- a/core/adapters/outbound/metrics/adapter_test.go
+++ b/core/adapters/outbound/metrics/adapter_test.go
@@ -1,0 +1,59 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLedgerFilenameDeterministic(t *testing.T) {
+	a := LedgerFilename("/path/to/transcript.jsonl")
+	b := LedgerFilename("/path/to/transcript.jsonl")
+	if a != b {
+		t.Fatalf("LedgerFilename not deterministic: %q vs %q", a, b)
+	}
+	if LedgerFilename("/path/to/other.jsonl") == a {
+		t.Fatalf("LedgerFilename collided across distinct paths")
+	}
+}
+
+func TestPruneEntry_RemovesLedgerAndCacheEntry(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	dir := filepath.Join(tmpHome, ".local", "share", "irrlicht", "sessions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	transcript := filepath.Join(tmpHome, "transcript.jsonl")
+	lp := ledgerPath(transcript)
+	if err := os.WriteFile(lp, []byte(`{"schemaVersion":2}`), 0o644); err != nil {
+		t.Fatalf("write ledger: %v", err)
+	}
+
+	a := New(nil)
+	a.tailers[transcript] = &lockedTailer{}
+
+	a.PruneEntry(transcript)
+
+	if _, ok := a.tailers[transcript]; ok {
+		t.Errorf("tailers map still contains %q after PruneEntry", transcript)
+	}
+	if _, err := os.Stat(lp); !os.IsNotExist(err) {
+		t.Errorf("ledger file still present after PruneEntry: err=%v", err)
+	}
+}
+
+func TestPruneEntry_IdempotentOnMissingFile(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	a := New(nil)
+	// No file written, no map entry — should not panic or error.
+	a.PruneEntry(filepath.Join(tmpHome, "never-existed.jsonl"))
+}
+
+func TestPruneEntry_EmptyPathNoop(t *testing.T) {
+	a := New(nil)
+	a.PruneEntry("") // must not panic
+}

--- a/core/adapters/outbound/metrics/ledger.go
+++ b/core/adapters/outbound/metrics/ledger.go
@@ -45,9 +45,20 @@ func ledgerPath(transcriptPath string) string {
 	if err != nil {
 		return ""
 	}
-	h := sha256.Sum256([]byte(transcriptPath))
-	return filepath.Join(dir, fmt.Sprintf("%x.ledger.json", h[:8]))
+	return filepath.Join(dir, LedgerFilename(transcriptPath))
 }
+
+// LedgerFilename returns the basename of the ledger file for a transcript path.
+// Exposed so the daemon-startup orphan sweep can compute the expected filenames
+// for live sessions without re-implementing the SHA-256 scheme.
+func LedgerFilename(transcriptPath string) string {
+	h := sha256.Sum256([]byte(transcriptPath))
+	return fmt.Sprintf("%x.ledger.json", h[:8])
+}
+
+// LedgerDir returns the directory holding per-session ledger files.
+// Exposed for the daemon-startup orphan sweep.
+func LedgerDir() (string, error) { return ledgerDir() }
 
 // loadLedger reads the ledger at path, returning nil on error or version mismatch.
 // Silent on all errors so a missing or corrupt ledger just falls back to a fresh scan.

--- a/core/adapters/outbound/metrics/ledger.go
+++ b/core/adapters/outbound/metrics/ledger.go
@@ -13,6 +13,11 @@ import (
 
 const ledgerSchemaVersion = 2 // bumped to force re-scan for task support
 
+// LedgerSuffix is the filename suffix used for per-session ledger files.
+// Exposed so the daemon-startup orphan sweep can filter directory entries
+// without re-encoding the convention.
+const LedgerSuffix = ".ledger.json"
+
 var ledgerDirOnce sync.Once
 
 // ensureLedgerDir creates the ledger directory on the first call; subsequent
@@ -53,7 +58,7 @@ func ledgerPath(transcriptPath string) string {
 // for live sessions without re-implementing the SHA-256 scheme.
 func LedgerFilename(transcriptPath string) string {
 	h := sha256.Sum256([]byte(transcriptPath))
-	return fmt.Sprintf("%x.ledger.json", h[:8])
+	return fmt.Sprintf("%x%s", h[:8], LedgerSuffix)
 }
 
 // LedgerDir returns the directory holding per-session ledger files.

--- a/core/application/services/metadata_enricher.go
+++ b/core/application/services/metadata_enricher.go
@@ -24,6 +24,14 @@ func newMetadataEnricher(git outbound.GitResolver, metrics outbound.MetricsColle
 	return &metadataEnricher{git: git, metrics: metrics}
 }
 
+// PruneMetrics releases per-session metrics state when a session ends.
+func (e *metadataEnricher) PruneMetrics(transcriptPath string) {
+	if e.metrics == nil || transcriptPath == "" {
+		return
+	}
+	e.metrics.PruneEntry(transcriptPath)
+}
+
 // EnrichNewSession resolves git metadata and computes initial metrics for a
 // newly created session. It prefers CWD from the event (set by process
 // scanner), falling back to transcript inspection for file-based sessions.

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -63,6 +63,10 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	if d.historyTracker != nil {
 		d.historyTracker.Remove(ev.SessionID)
 	}
+
+	// Drop the in-memory tailer cache and the on-disk ledger file —
+	// the transcript is gone, so this state will never change again.
+	d.enricher.PruneMetrics(state.TranscriptPath)
 }
 
 // HandleProcessExit deletes a session when its process exits.

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -615,6 +615,42 @@ func TestSessionDetector_Removed_TransitionsToReady(t *testing.T) {
 	}
 }
 
+func TestSessionDetector_Removed_PrunesMetricsLedger(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	mm := &mockMetrics{}
+
+	transcriptPath := "/home/.claude/projects/-Users-test/rm-prune.jsonl"
+	repo.states["rm-prune"] = &session.SessionState{
+		SessionID:      "rm-prune",
+		State:          session.StateWorking,
+		TranscriptPath: transcriptPath,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	det := services.NewSessionDetector(
+		[]inbound.AgentWatcher{tw}, pw, repo,
+		&mockLogger{}, &mockGit{}, mm, nil,
+		"test", 0, nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{Type: agent.EventRemoved, SessionID: "rm-prune"}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if len(mm.pruned) != 1 || mm.pruned[0] != transcriptPath {
+		t.Errorf("PruneEntry calls: got %v, want [%q]", mm.pruned, transcriptPath)
+	}
+}
+
 func TestSessionDetector_Removed_SkipsTerminalState(t *testing.T) {
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -114,11 +114,15 @@ func (g *mockGit) GetGitRoot(dir string) string                { return "" }
 func (g *mockGit) GetBranchFromTranscript(path string) string  { return "" }
 func (g *mockGit) GetCWDFromTranscript(path string) string     { return "" }
 
-type mockMetrics struct{}
+type mockMetrics struct {
+	pruned []string
+}
 
 func (m *mockMetrics) ComputeMetrics(path, adapter string) (*session.SessionMetrics, error) {
 	return nil, nil
 }
+
+func (m *mockMetrics) PruneEntry(path string) { m.pruned = append(m.pruned, path) }
 
 // funcMetrics is a metrics collector whose ComputeMetrics behaviour can be
 // configured per test. Used to simulate a tailer that returns refreshed
@@ -133,6 +137,8 @@ func (m *funcMetrics) ComputeMetrics(path, adapter string) (*session.SessionMetr
 	}
 	return m.fn(path, adapter)
 }
+
+func (m *funcMetrics) PruneEntry(path string) {}
 
 // --- AgentWatcher mock -------------------------------------------------------
 

--- a/core/cmd/irrlichd/ledger_gc_test.go
+++ b/core/cmd/irrlichd/ledger_gc_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/adapters/outbound/filesystem"
+	"irrlicht/core/adapters/outbound/metrics"
+	"irrlicht/core/domain/session"
+)
+
+// TestPruneOrphanLedgers_KeepsExpectedRemovesOrphans seeds a temp HOME with a
+// sessions dir containing one ledger file matching a live session and one
+// orphan, plus a non-ledger file that must be left alone. The sweep should
+// remove only the orphan.
+func TestPruneOrphanLedgers_KeepsExpectedRemovesOrphans(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	dir := filepath.Join(tmpHome, ".local", "share", "irrlicht", "sessions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	livePath := "/some/transcripts/live.jsonl"
+	liveLedger := filepath.Join(dir, metrics.LedgerFilename(livePath))
+	orphanLedger := filepath.Join(dir, "deadbeefcafef00d.ledger.json")
+	bystander := filepath.Join(dir, "README.txt")
+	for _, p := range []string{liveLedger, orphanLedger, bystander} {
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("seed file %s: %v", p, err)
+		}
+	}
+
+	repo := filesystem.NewWithDir(t.TempDir())
+	if err := repo.Save(&session.SessionState{
+		SessionID:      "live1",
+		State:          session.StateWorking,
+		TranscriptPath: livePath,
+		UpdatedAt:      time.Now().Unix(),
+	}); err != nil {
+		t.Fatalf("repo.Save: %v", err)
+	}
+
+	logger := &capturingLogger{}
+	pruneOrphanLedgers(repo, logger)
+
+	if _, err := os.Stat(liveLedger); err != nil {
+		t.Errorf("live ledger removed unexpectedly: %v", err)
+	}
+	if _, err := os.Stat(orphanLedger); !os.IsNotExist(err) {
+		t.Errorf("orphan ledger still present: err=%v", err)
+	}
+	if _, err := os.Stat(bystander); err != nil {
+		t.Errorf("non-ledger file removed: %v", err)
+	}
+
+	foundLog := false
+	for _, msg := range logger.infos {
+		if msg == "pruned 1 orphan ledger files" {
+			foundLog = true
+		}
+	}
+	if !foundLog {
+		t.Errorf("missing prune log; infos=%v", logger.infos)
+	}
+}
+
+// TestPruneOrphanLedgers_NoLedgerDir is a no-op when the ledger directory
+// does not yet exist (fresh install before any session has run).
+func TestPruneOrphanLedgers_NoLedgerDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	repo := filesystem.NewWithDir(t.TempDir())
+	logger := &capturingLogger{}
+	pruneOrphanLedgers(repo, logger) // must not panic
+	if len(logger.errors) != 0 {
+		t.Errorf("expected no errors on missing dir, got %v", logger.errors)
+	}
+}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -528,7 +528,7 @@ func pruneOrphanLedgers(fsRepo *filesystem.SessionRepository, logger outbound.Lo
 			continue
 		}
 		name := e.Name()
-		if !strings.HasSuffix(name, ".ledger.json") {
+		if !strings.HasSuffix(name, metrics.LedgerSuffix) {
 			continue
 		}
 		if _, ok := expected[name]; ok {

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -487,9 +487,60 @@ func initSessionStorage(logger outbound.Logger, cfg config.Config) (*filesystem.
 		logger.LogInfo("startup", "", fmt.Sprintf("pruned %d stale session files", pruned))
 	}
 	pruneDeadProcSessions(fsRepo, logger)
+	pruneOrphanLedgers(fsRepo, logger)
 
 	cachedRepo := filesystem.NewCachedSessionRepository(fsRepo, 3*time.Second)
 	return fsRepo, cachedRepo
+}
+
+// pruneOrphanLedgers removes per-session ledger files in
+// ~/.local/share/irrlicht/sessions/ that no longer correspond to any session
+// known to the repo. Handles transcripts deleted while the daemon was off —
+// the live-daemon case is covered by SessionDetector.onRemoved calling
+// MetricsCollector.PruneEntry.
+func pruneOrphanLedgers(fsRepo *filesystem.SessionRepository, logger outbound.Logger) {
+	dir, err := metrics.LedgerDir()
+	if err != nil {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		logger.LogError("startup", "", fmt.Sprintf("ledger dir read failed: %v", err))
+		return
+	}
+	allSessions, err := fsRepo.ListAll()
+	if err != nil {
+		return
+	}
+	expected := make(map[string]struct{}, len(allSessions))
+	for _, s := range allSessions {
+		if s.TranscriptPath == "" {
+			continue
+		}
+		expected[metrics.LedgerFilename(s.TranscriptPath)] = struct{}{}
+	}
+	removed := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".ledger.json") {
+			continue
+		}
+		if _, ok := expected[name]; ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, name)); err == nil {
+			removed++
+		}
+	}
+	if removed > 0 {
+		logger.LogInfo("startup", "", fmt.Sprintf("pruned %d orphan ledger files", removed))
+	}
 }
 
 // pruneDeadProcSessions removes proc-<pid> session files whose backing

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -479,6 +479,8 @@ func (m *stubMetrics) ComputeMetrics(_, _ string) (*session.SessionMetrics, erro
 	return nil, nil
 }
 
+func (m *stubMetrics) PruneEntry(_ string) {}
+
 type mockWatcher struct {
 	ch chan agent.Event
 }

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -56,6 +56,10 @@ type GitResolver interface {
 // "codex", "pi") so the correct parser is used.
 type MetricsCollector interface {
 	ComputeMetrics(transcriptPath, adapter string) (*session.SessionMetrics, error)
+	// PruneEntry releases per-session state — both the in-memory tailer
+	// cache and the on-disk ledger file — when a session ends. Idempotent
+	// on a missing or already-removed entry.
+	PruneEntry(transcriptPath string)
 }
 
 // PushBroadcaster fans out session state changes to subscribers (e.g. WebSocket clients).


### PR DESCRIPTION
Closes #185.

## Summary

- Per-session ledger files at `~/.local/share/irrlicht/sessions/<hash>.ledger.json` accumulated indefinitely (172 files on my machine when I picked this up).
- Live-daemon cleanup: `SessionDetector.onRemoved` now calls `MetricsCollector.PruneEntry` after the ready transition, dropping both the in-memory tailer cache entry and the on-disk ledger file.
- Daemon-startup cleanup: `pruneOrphanLedgers` in `initSessionStorage` diffs the ledger directory against repo sessions and removes orphans, covering transcripts deleted while the daemon was off.

## Notes

- Issue body suggested hooking `SessionState.IsExpired()`, which doesn't exist. The actual lifecycle hook is `onRemoved` (fires on `EventRemoved`); a startup sweep handles the daemon-off gap.
- `MetricsCollector` port grew a new `PruneEntry(transcriptPath string)` method; test stubs in `services/` and `e2e/` updated accordingly.
- `LedgerFilename` and `LedgerDir` exposed from the metrics package so the startup sweep can compute expected filenames without re-implementing the SHA-256 scheme.

## Test plan

- [x] `go test ./core/adapters/outbound/metrics/...` — `PruneEntry` removes file + map entry, idempotent on missing file/empty path.
- [x] `go test ./core/application/services/ -run TestSessionDetector_Removed` — `EventRemoved` for an active session calls `PruneEntry` with the right transcript path.
- [x] `go test ./core/cmd/irrlichd/ -run TestPruneOrphanLedgers` — orphan sweep keeps live-session ledger, removes orphan, leaves non-`.ledger.json` files alone, no-ops on missing dir.
- [x] `go test ./core/...` passes everywhere except the pre-existing `core/cmd/replay` golden-path mismatch (worktree path vs `replaydata/...`), confirmed independent by re-running the same tests with these changes stashed.
- [ ] Manual: drop a junk `00000000deadbeef.ledger.json` into `~/.local/share/irrlicht/sessions/`, start daemon, confirm "pruned N orphan ledger files" log line and the file is gone.
- [ ] Manual live-flow: start a Claude Code session, observe its ledger appears, `rm` the transcript JSONL, watch the corresponding ledger file disappear within one tail interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)