### PR TITLE
fix(macos): keep menu-bar button highlighted while panel is open (#224)

### DIFF
--- a/platforms/macos/Irrlicht/App/MenuBarController.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarController.swift
@@ -148,11 +148,17 @@ final class MenuBarController: NSObject {
         anchorPanelToStatusItem()
         panel.orderFrontRegardless()
         installDismissMonitors()
+        // Defer highlight past AppKit's mouseUp, which would otherwise clear it.
+        DispatchQueue.main.async { [weak self] in
+            guard self?.panel.isVisible == true else { return }
+            self?.statusItem.button?.highlight(true)
+        }
     }
 
     private func hidePanel() {
         panel.orderOut(nil)
         removeDismissMonitors()
+        statusItem.button?.highlight(false)
     }
 
     /// Place the panel with its top edge just below the status item and


### PR DESCRIPTION
## Summary
- Defer `highlight(true)` in `showPanel()` to the next runloop turn so it lands after AppKit's mouseUp, which was clearing it
- Add explicit `highlight(false)` in `hidePanel()` so all four dismiss paths (toggle re-click, outside-click, Escape, app resign) clear the highlight
- `panel.isVisible` guard in the deferred closure handles rapid re-toggle

Fixes #224.

## Test plan
- [x] `/ir:test-mac` rebuild + relaunch
- [ ] Click icon → panel opens, button stays grey-highlighted after click release
- [ ] Click icon again → panel closes, highlight clears
- [ ] Open panel, click outside → dismisses, highlight clears
- [ ] Open panel, press Escape → dismisses, highlight clears
- [ ] Open panel, Cmd-Tab away → dismisses, highlight clears
- [ ] Visual parity with Wi-Fi / Battery menu-bar items

🤖 Generated with [Claude Code](https://claude.com/claude-code)