### PR TITLE
fix(claudecode): silence hook errors when daemon is down (#221)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -20,7 +20,10 @@ const hookSentinel = "localhost:7837/api/v1/hooks/claudecode"
 //   - -f: fail silently on HTTP errors (non-blocking)
 //   - -sS: silent but show errors
 //   - --max-time 1: abort after 1 second (fast no-op when daemon is down)
-const installedHookCommand = "curl -fsS --max-time 1 -X POST --data-binary @- http://localhost:7837/api/v1/hooks/claudecode"
+//
+// `|| true` keeps exit status 0 when the daemon is down so Claude Code
+// doesn't surface "connection refused" as a PostToolUse hook error.
+const installedHookCommand = "curl -fsS --max-time 1 -X POST --data-binary @- http://localhost:7837/api/v1/hooks/claudecode || true"
 
 // hookMatcher filters which tools trigger the hooks. PermissionRequest only
 // fires for tools that need permission, but PostToolUse/PostToolUseFailure
@@ -48,6 +51,9 @@ func EnsureHooksInstalled() (bool, error) {
 
 	modified := false
 	for _, event := range installedHookEvents {
+		if upgradeStaleHookCommands(hooksMap, event) {
+			modified = true
+		}
 		if !hasOurHook(hooksMap, event) {
 			addOurHook(hooksMap, event)
 			modified = true
@@ -187,6 +193,51 @@ func hasOurHook(hooksMap map[string]interface{}, event string) bool {
 		}
 	}
 	return false
+}
+
+// upgradeStaleHookCommands rewrites any hook command that contains hookSentinel
+// but isn't the canonical installedHookCommand. Returns true if any entry was
+// rewritten. This migrates users whose settings.json still has an older form
+// of our command (e.g., missing the trailing `|| true`).
+func upgradeStaleHookCommands(hooksMap map[string]interface{}, event string) bool {
+	arr, ok := hooksMap[event]
+	if !ok {
+		return false
+	}
+	groups, ok := arr.([]interface{})
+	if !ok {
+		return false
+	}
+	upgraded := false
+	for _, g := range groups {
+		group, ok := g.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		innerArr, ok := group["hooks"]
+		if !ok {
+			continue
+		}
+		innerHooks, ok := innerArr.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, h := range innerHooks {
+			hook, ok := h.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			cmd, ok := hook["command"].(string)
+			if !ok {
+				continue
+			}
+			if strings.Contains(cmd, hookSentinel) && cmd != installedHookCommand {
+				hook["command"] = installedHookCommand
+				upgraded = true
+			}
+		}
+	}
+	return upgraded
 }
 
 // addOurHook appends a matcher group with our hook command to the event's array.

--- a/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
@@ -119,6 +119,74 @@ func TestEnsureHooksInstalled_PreservesExistingHooks(t *testing.T) {
 	}
 }
 
+func TestEnsureHooksInstalled_UpgradesStaleCommand(t *testing.T) {
+	home := withTempHome(t)
+	path := filepath.Join(home, ".claude", "settings.json")
+
+	// Stale command: same sentinel, but missing the trailing `|| true`.
+	const staleCommand = "curl -fsS --max-time 1 -X POST --data-binary @- http://localhost:7837/api/v1/hooks/claudecode"
+	if staleCommand == installedHookCommand {
+		t.Fatal("stale command must differ from canonical command for this test to be meaningful")
+	}
+
+	staleGroup := map[string]interface{}{
+		"matcher": hookMatcher,
+		"hooks": []interface{}{
+			map[string]interface{}{
+				"type":    "command",
+				"command": staleCommand,
+			},
+		},
+	}
+	existing := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			HookPostToolUse: []interface{}{staleGroup},
+		},
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(existing)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true when upgrading stale command")
+	}
+
+	settings := readJSON(t, path)
+	hooksMap := settings["hooks"].(map[string]interface{})
+
+	postArr, ok := hooksMap[HookPostToolUse].([]interface{})
+	if !ok {
+		t.Fatalf("missing %s array after upgrade", HookPostToolUse)
+	}
+	if len(postArr) != 1 {
+		t.Fatalf("expected 1 %s matcher group (in-place upgrade, no append), got %d", HookPostToolUse, len(postArr))
+	}
+
+	group := postArr[0].(map[string]interface{})
+	innerHooks := group["hooks"].([]interface{})
+	cmd := innerHooks[0].(map[string]interface{})["command"].(string)
+	if cmd != installedHookCommand {
+		t.Fatalf("expected upgraded command, got %q", cmd)
+	}
+
+	// Second call must be idempotent.
+	modified, err = EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modified {
+		t.Fatal("expected modified=false on second install after upgrade (idempotent)")
+	}
+}
+
 func TestUninstallHooks_RemovesOurHooks(t *testing.T) {
 	home := withTempHome(t)
 


### PR DESCRIPTION
## Summary
- Append `|| true` to the installed Claude Code hook curl so a refused connection no longer surfaces as a red `PostToolUse:Bash hook error` banner.
- `EnsureHooksInstalled` now upgrades legacy entries in place: any hook command containing our sentinel but not equal to the canonical command is rewritten on next daemon start, so existing users pick up the fix automatically.

Fixes #221.

## Test plan
- [x] `go test ./adapters/inbound/agents/claudecode/...` — passes (new `TestEnsureHooksInstalled_UpgradesStaleCommand` covers fresh-upgrade + idempotent second call).
- [x] `go build ./...` and `go vet ./adapters/inbound/agents/claudecode/...` clean.
- [ ] Manual: stop daemon, hand-edit `~/.claude/settings.json` to the old (no `|| true`) curl form, restart daemon → file is rewritten with `|| true`. Stop daemon again, run a Bash tool in Claude Code → no red hook-error banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)