### PR TITLE
feat(tools): coverage-viewer dev webview (#222)

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,3 +1,6 @@
 go 1.25.0
 
-use ./core
+use (
+	./core
+	./tools/coverage-viewer
+)

--- a/replaydata/agents/aider/capabilities.json
+++ b/replaydata/agents/aider/capabilities.json
@@ -5,6 +5,7 @@
   "source": "discovery_subagent",
   "features": {
     "headless_mode": true,
+    "tui": true,
     "tool_calls": true,
     "permission_hooks": false,
     "subagents": false,

--- a/replaydata/agents/claudecode/capabilities.json
+++ b/replaydata/agents/claudecode/capabilities.json
@@ -5,6 +5,7 @@
   "source": "manual_bootstrap",
   "features": {
     "headless_mode": true,
+    "tui": true,
     "tool_calls": true,
     "permission_hooks": true,
     "subagents": true,

--- a/replaydata/agents/codex/capabilities.json
+++ b/replaydata/agents/codex/capabilities.json
@@ -5,6 +5,7 @@
   "source": "manual_bootstrap",
   "features": {
     "headless_mode": true,
+    "tui": true,
     "tool_calls": true,
     "permission_hooks": false,
     "subagents": false,

--- a/replaydata/agents/features.json
+++ b/replaydata/agents/features.json
@@ -1,16 +1,33 @@
 {
-  "version": 1,
+  "version": 2,
+  "categories": [
+    {"id": "runtime", "title": "Runtime / launch surface"},
+    {"id": "interaction", "title": "Tool & permission interaction"},
+    {"id": "session", "title": "Session & transcript shape"},
+    {"id": "workflow", "title": "Coding workflow"},
+    {"id": "input", "title": "Input modality"}
+  ],
   "features": [
     {
       "id": "headless_mode",
       "title": "Headless / non-interactive mode",
+      "category": "runtime",
       "description": "Agent can be invoked with a single prompt and exit cleanly without a TTY. Required for any scenario that drives the agent from a script. Test: run agent with one prompt argument; expect clean exit code 0 and no terminal control sequences.",
       "added_in": "2026-04-25",
       "notes": "Replaces the legacy CapHeadlessMode enum value."
     },
     {
+      "id": "tui",
+      "title": "Interactive TUI mode",
+      "category": "runtime",
+      "description": "Agent provides an interactive terminal UI (REPL with line editing, key bindings, scrollback) when launched without a one-shot prompt. Distinct from headless_mode — TUI is for humans typing into a session. Test: launch with no prompt argument; expect an interactive prompt and key-binding behavior (e.g. arrow keys, ctrl+c to cancel a turn).",
+      "added_in": "2026-04-26",
+      "notes": "All four currently-onboarded CLIs (claudecode, codex, pi, aider) ship a TUI; first canonical scenario for it would test that the TUI launches and accepts input without crashing."
+    },
+    {
       "id": "tool_calls",
       "title": "Tool / function calling",
+      "category": "interaction",
       "description": "Agent can invoke tools (file read/write, shell, web fetch, custom integrations) during a turn and surface the results back into the conversation. Test: run a scenario that requires file editing; expect a tool-use event in the transcript.",
       "added_in": "2026-04-25",
       "notes": "Does not include MCP specifically — see mcp_servers. Replaces the legacy CapToolCalls enum value."
@@ -18,6 +35,7 @@
     {
       "id": "permission_hooks",
       "title": "Permission / approval interception",
+      "category": "interaction",
       "description": "Agent supports an external interceptor that can allow, deny, or modify a tool invocation before it runs (hook events, callbacks, policy files, etc.). Test: configure a deny rule for a specific tool; expect the agent to surface the denial without executing.",
       "added_in": "2026-04-25",
       "notes": "Widened 2026-04-25 from claudecode-specific PreToolUse/PostToolUse hooks to any external-interception mechanism. Replaces the legacy CapPermissionHooks enum value."
@@ -25,6 +43,7 @@
     {
       "id": "subagents",
       "title": "Subagent / child-session spawning",
+      "category": "session",
       "description": "Agent can spawn child sessions (often called subagents, task agents, or background agents) that run with their own session ID and report back to the parent. Test: run a scenario that triggers a child agent; expect a parent-child link event in the recording.",
       "added_in": "2026-04-25",
       "notes": "Replaces the legacy CapSubagents enum value. Child sessions surface in irrlicht via ParentSessionID linking."
@@ -32,6 +51,7 @@
     {
       "id": "session_id_assignment",
       "title": "Caller-assigned session ID",
+      "category": "session",
       "description": "Caller can pin the session UUID at launch (e.g. via a --session-id flag) instead of having the agent generate one. Lets a driver correlate the eventual transcript without out-of-band guessing. Test: launch with a known UUID; expect the transcript file to use that UUID.",
       "added_in": "2026-04-25",
       "notes": "claudecode supports this directly; codex and pi require parsing the UUID from output."
@@ -39,6 +59,7 @@
     {
       "id": "settings_file_support",
       "title": "Per-invocation settings file",
+      "category": "interaction",
       "description": "Agent accepts a config file at launch (JSON, TOML, YAML, etc.) that scopes configuration (model choice, policy, integrations) to that single invocation without mutating user-level config. Test: pass a settings file with a non-default model; expect that model to be used for that run only.",
       "added_in": "2026-04-25",
       "notes": "claudecode --settings supports this; aider --config likewise. codex and pi do not honor a per-invocation settings file."
@@ -46,12 +67,14 @@
     {
       "id": "session_resume",
       "title": "Session resume / continuation",
+      "category": "session",
       "description": "Agent can resume a previous session and continue the same conversation, preserving session ID and history (e.g. claude --continue / --resume, codex resume). Test: end a session, then re-launch with the resume flag and the prior session ID; expect the new transcript to extend the prior one.",
       "added_in": "2026-04-25"
     },
     {
       "id": "mcp_servers",
       "title": "MCP server hosting",
+      "category": "interaction",
       "description": "Agent can connect to and call tools from Model Context Protocol servers configured at launch. Test: configure an MCP server with a known tool; trigger the agent to call it; expect the tool name to appear in the tool-use event.",
       "added_in": "2026-04-25",
       "notes": "Distinct from tool_calls — this specifically tests the MCP protocol path."
@@ -59,12 +82,14 @@
     {
       "id": "streaming_output",
       "title": "Streaming output",
+      "category": "session",
       "description": "Agent emits partial response tokens / events while a turn is in progress, before the turn finishes. Affects how the recorder needs to handle in-flight events. Test: tail the transcript during a long turn; expect intermediate writes before the final event.",
       "added_in": "2026-04-25"
     },
     {
       "id": "structured_output_jsonl",
       "title": "Structured JSONL transcript output",
+      "category": "session",
       "description": "Agent emits a machine-readable transcript as JSON Lines (one event per line), either to stdout or a sidecar file. The preferred surface for replay capture. Test: invoke with the JSONL flag; expect each line to parse as valid JSON.",
       "added_in": "2026-04-25",
       "notes": "codex --json exposes this. claudecode writes to ~/.claude/projects/. pi writes to ~/.pi/agent/sessions/. Aider does not — it uses a chat-history file in markdown-ish format."
@@ -72,6 +97,7 @@
     {
       "id": "slash_commands",
       "title": "Slash-command interface",
+      "category": "interaction",
       "description": "Agent provides a slash-command interface (`/foo`) for user actions during a session — built-in commands, user-defined commands, or both. Test: type a known command; expect the agent to recognize it as a command (not as a prompt).",
       "added_in": "2026-04-25",
       "notes": "Widened 2026-04-25 from 'user-defined slash commands' to 'any slash interface'. Aider has built-in /add, /drop, /run; claudecode has built-in /login plus user-defined ~/.claude/commands/*.md."
@@ -79,6 +105,7 @@
     {
       "id": "plan_mode",
       "title": "Read-only / advisory mode",
+      "category": "workflow",
       "description": "Agent supports a constrained mode where it can analyze, propose, or answer questions but not mutate the workspace (no file writes, no shell side effects). Includes plan-then-execute flows, ask-only/Q&A modes, and dry-run modes. Test: launch in the read-only mode and ask for a change; expect a proposal but no file mutations.",
       "added_in": "2026-04-25",
       "notes": "Widened 2026-04-25 from 'plan mode' to 'any read-only/advisory mode'. claudecode has plan mode; aider has /ask mode."
@@ -86,6 +113,7 @@
     {
       "id": "git_integration",
       "title": "Version-control automation",
+      "category": "workflow",
       "description": "Agent automates version-control operations during a session — built-in auto-commit with descriptive messages, tracked edits, undo/rollback support, OR a tool-driven git workflow (git invoked via the agent's shell tool with the agent reasoning about commits). Test: run a scenario that edits a file in a git repo; expect a commit (or a record that the agent considered/proposed one).",
       "added_in": "2026-04-25",
       "notes": "Added 2026-04-25 from aider discovery. Aider has built-in auto-commit; claudecode does this via Bash + git; codex/pi behavior unclear."
@@ -93,6 +121,7 @@
     {
       "id": "multi_model_orchestration",
       "title": "Multi-model orchestration",
+      "category": "workflow",
       "description": "Agent can invoke different LLMs for different sub-tasks within a single session — e.g. a planner model paired with an editor model, a fast model for routine work plus a strong model for hard tasks, or per-tool model routing. Test: configure two models; trigger a flow that should route to one then the other; expect both providers in the transcript.",
       "added_in": "2026-04-25",
       "notes": "Added 2026-04-25 from aider discovery (architect/editor mode). Likely cross-agent: claudecode has Haiku-for-some-tasks; codex may grow similar."
@@ -100,6 +129,7 @@
     {
       "id": "repo_map",
       "title": "Automatic repository map",
+      "category": "workflow",
       "description": "Agent maintains an automatic structural summary of the repository (tree-sitter, AST, or similar) so it can reason about distant code without loading every file into the prompt. Distinct from a project memory file (CLAUDE.md / AGENTS.md), which is human-curated. Test: run the agent in a large repo; expect references to symbols/files the agent did not explicitly read.",
       "added_in": "2026-04-25",
       "notes": "Added 2026-04-25 from aider discovery. Aider's repo-map is the canonical example. Configurable token budget."
@@ -107,6 +137,7 @@
     {
       "id": "voice_input",
       "title": "Voice input",
+      "category": "input",
       "description": "Agent accepts spoken input (microphone capture, transcribed via STT) as an alternative to typed prompts. Test: invoke the voice command; speak a prompt; expect the transcribed text to enter the conversation.",
       "added_in": "2026-04-25",
       "notes": "Added 2026-04-25 from aider discovery. Aider-distinctive today; widely applicable feature."
@@ -114,6 +145,7 @@
     {
       "id": "multimodal_input",
       "title": "Multimodal input",
+      "category": "input",
       "description": "Agent accepts non-text inputs as part of a turn — images, screenshots, web page snapshots, PDFs, etc. Test: include an image in the prompt; expect the agent to refer to its content in the response.",
       "added_in": "2026-04-25",
       "notes": "Added 2026-04-25 from aider discovery. Likely cross-agent: aider supports images; claudecode is vision-capable; codex behavior unclear."
@@ -121,6 +153,7 @@
     {
       "id": "gui_mode",
       "title": "GUI / browser mode",
+      "category": "runtime",
       "description": "Agent ships a graphical interface (browser-based or native window) as an alternative to the terminal — for visual file editing, prompt composition, or session inspection. Test: launch with the GUI flag; expect a window/page to open and the agent to remain functional from it.",
       "added_in": "2026-04-25",
       "notes": "Aider --browser mode; potential common ground with future agents that ship a desktop app or web UI."
@@ -128,6 +161,7 @@
     {
       "id": "watch_mode",
       "title": "File-watch / IDE-driven mode",
+      "category": "runtime",
       "description": "Agent runs as a long-lived daemon watching files for marker comments (e.g. `# AI: do X`) or change events, responding without an explicit prompt invocation. Enables IDE integrations and ambient coding flows. Test: place an inline marker comment in a watched file; expect the agent to act on it.",
       "added_in": "2026-04-25",
       "notes": "Aider --watch-files; widely applicable to any agent designed to integrate inside an editor."
@@ -135,6 +169,7 @@
     {
       "id": "linting_test_automation",
       "title": "Auto-run linters / tests",
+      "category": "workflow",
       "description": "Agent automatically runs linters and/or test suites after edits and feeds failures back into its own loop to fix them. Test: edit a file with a deliberate lint or test failure; expect the agent to run the tools, surface the failure, and propose or apply a fix.",
       "added_in": "2026-04-25",
       "notes": "Common pattern across agents (claudecode does this on demand; aider does it automatically). Worth canonicalizing."
@@ -142,6 +177,7 @@
     {
       "id": "edit_strategy_selection",
       "title": "Selectable edit strategy",
+      "category": "workflow",
       "description": "Agent supports multiple file-editing formats (whole-file rewrite, unified diff, search/replace block, function-level patch, etc.) that the user can select per session or per model. Test: swap edit strategies between two runs against the same prompt; expect different patch shapes in the transcript.",
       "added_in": "2026-04-25",
       "notes": "Aider exposes 15+ Coder strategies. claudecode picks one internally; codex similar. Only canonical when the user can choose."
@@ -149,6 +185,7 @@
     {
       "id": "context_curation",
       "title": "Explicit context curation",
+      "category": "workflow",
       "description": "Agent exposes user commands to add/drop files from the active context, mark files as read-only references, or otherwise prune the prompt window mid-session. Test: add a file then drop it; expect the file's contents to leave the next prompt sent to the LLM.",
       "added_in": "2026-04-25",
       "notes": "Aider /add /drop /read-only. claudecode has /clear; the granularity differs but the capability is shared."

--- a/replaydata/agents/pi/capabilities.json
+++ b/replaydata/agents/pi/capabilities.json
@@ -5,6 +5,7 @@
   "source": "manual_bootstrap",
   "features": {
     "headless_mode": true,
+    "tui": true,
     "tool_calls": true,
     "permission_hooks": false,
     "subagents": false,

--- a/tools/coverage-viewer/.gitignore
+++ b/tools/coverage-viewer/.gitignore
@@ -1,0 +1,1 @@
+/coverage-viewer

--- a/tools/coverage-viewer/README.md
+++ b/tools/coverage-viewer/README.md
@@ -1,0 +1,25 @@
+# coverage-viewer
+
+A small dev-only HTTP server that renders the agent × scenario coverage matrix, a per-cell pipeline drilldown, and a per-session swim-lane timeline. Reads canonical files (`replaydata/agents/*`, `.claude/skills/ir:onboard-agent/scenarios.json`) in place — no cache, no DB.
+
+## Run
+
+```sh
+cd tools/coverage-viewer
+go run .
+open http://127.0.0.1:7838/
+```
+
+The server walks up from CWD looking for `go.work` (or `.git`) to find the repo root. Override with `--root /path/to/repo` and `--addr 127.0.0.1:9999` if needed.
+
+## What it shows
+
+- **Matrix** — every (adapter × scenario) cell, color-coded as `covered` / `staged-only` / `missing-prompt` / `n/a`. Click a cell to open the drilldown.
+- **Drilldown** — the 6-step `run-cell` pipeline (precheck → daemon → driver → curate → replay → verify) with GitHub permalinks pinned to the current `git rev-parse HEAD`, plus the live `by_adapter` prompt/settings and `verify` block from `scenarios.json`.
+- **Timeline** — for any scenario with a committed fixture, a swim-lane view (driver / agent / tool result / hook / daemon state / subagent) merged from `events.jsonl` + `transcript.jsonl` (normalized via the per-adapter parser in `core/adapters/inbound/agents/<adapter>/parser.go`). Click any block for the raw payload.
+
+## Known limits
+
+- **Driver lane** only shows what's visible in committed fixtures (the dispatched prompt). Literal driver script keystrokes/tmux send-keys aren't captured in committed fixtures, only in fresh local `.build/refresh/` runs.
+- **Aider transcripts are markdown**, not JSONL. Aider timelines show daemon-side events only with a "transcript not parsed" note.
+- **Replay-report mismatch markers** are not yet rendered — `replaydata/agents/_reports/` is empty today. Will land once a report producer exists.

--- a/tools/coverage-viewer/go.mod
+++ b/tools/coverage-viewer/go.mod
@@ -1,0 +1,9 @@
+module irrlicht/tools/coverage-viewer
+
+go 1.25.0
+
+require irrlicht/core v0.0.0
+
+require golang.org/x/sys v0.42.0 // indirect
+
+replace irrlicht/core => ../../core

--- a/tools/coverage-viewer/go.sum
+++ b/tools/coverage-viewer/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/tools/coverage-viewer/main.go
+++ b/tools/coverage-viewer/main.go
@@ -1,0 +1,656 @@
+// Coverage-viewer is a small dev-only HTTP server that renders the agent ×
+// scenario coverage matrix, a per-cell pipeline drilldown, and a per-session
+// swim-lane timeline. It reads canonical files in place — no cache, no DB.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"irrlicht/core/adapters/inbound/agents/aider"
+	"irrlicht/core/adapters/inbound/agents/claudecode"
+	"irrlicht/core/adapters/inbound/agents/codex"
+	"irrlicht/core/adapters/inbound/agents/pi"
+	"irrlicht/core/pkg/tailer"
+)
+
+const (
+	githubRepoURL  = "https://github.com/ingo-eichhorst/Irrlicht"
+	scenariosJSON  = ".claude/skills/ir:onboard-agent/scenarios.json"
+	featuresJSON   = "replaydata/agents/features.json"
+	replayAgentDir = "replaydata/agents"
+)
+
+var (
+	addr    = flag.String("addr", "127.0.0.1:7838", "HTTP listen address")
+	rootDir = flag.String("root", "", "repo root (auto-detected if empty)")
+)
+
+func main() {
+	flag.Parse()
+	if *rootDir == "" {
+		root, err := findRepoRoot()
+		if err != nil {
+			log.Fatalf("find repo root: %v", err)
+		}
+		*rootDir = root
+	}
+	log.Printf("repo root: %s", *rootDir)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/matrix", handleMatrix)
+	mux.HandleFunc("/api/scenario/", handleScenario)
+	mux.HandleFunc("/api/timeline/", handleTimeline)
+	mux.Handle("/", http.FileServer(http.Dir(filepath.Join(execDir(), "ui"))))
+
+	log.Printf("coverage-viewer listening on http://%s", *addr)
+	if err := http.ListenAndServe(*addr, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// findRepoRoot walks up from CWD looking for go.work or .git.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+			return dir, nil
+		}
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.work or .git found above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// execDir returns the directory containing this binary's source/ui assets.
+// When run via `go run .` it's the source dir; for a built binary, fall back
+// to <rootDir>/tools/coverage-viewer for serving ui/.
+func execDir() string {
+	if wd, err := os.Getwd(); err == nil {
+		// `go run .` in tools/coverage-viewer → cwd contains ui/
+		if _, err := os.Stat(filepath.Join(wd, "ui", "index.html")); err == nil {
+			return wd
+		}
+	}
+	return filepath.Join(*rootDir, "tools", "coverage-viewer")
+}
+
+// ---------- /api/matrix ----------
+
+type cell struct {
+	State  string `json:"state"`            // "covered" | "staged-only" | "missing-prompt" | "n/a"
+	Reason string `json:"reason,omitempty"` // human-readable detail
+}
+
+type scenarioMeta struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Requires    []string `json:"requires"`
+}
+
+type featureMeta struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+type matrixResp struct {
+	Adapters     []string                      `json:"adapters"`
+	Scenarios    []scenarioMeta                `json:"scenarios"`
+	Cells        map[string]map[string]cell    `json:"cells"`        // adapter → scenario → cell
+	Features     []featureMeta                 `json:"features"`
+	Capabilities map[string]map[string]any     `json:"capabilities"` // adapter → feature → true|false|"unknown"
+}
+
+func handleMatrix(w http.ResponseWriter, r *http.Request) {
+	resp, err := buildMatrix()
+	if err != nil {
+		httpError(w, err)
+		return
+	}
+	writeJSON(w, resp)
+}
+
+func buildMatrix() (*matrixResp, error) {
+	features, err := loadFeatures()
+	if err != nil {
+		return nil, fmt.Errorf("features: %w", err)
+	}
+	scenarios, _, err := loadScenarios()
+	if err != nil {
+		return nil, fmt.Errorf("scenarios: %w", err)
+	}
+	adapters, err := discoverAdapters()
+	if err != nil {
+		return nil, fmt.Errorf("adapters: %w", err)
+	}
+
+	caps := make(map[string]map[string]any)
+	for _, a := range adapters {
+		c, err := loadCapabilities(a)
+		if err != nil {
+			return nil, fmt.Errorf("caps %s: %w", a, err)
+		}
+		caps[a] = c
+	}
+
+	cells := make(map[string]map[string]cell, len(adapters))
+	for _, a := range adapters {
+		cells[a] = make(map[string]cell, len(scenarios))
+		for _, s := range scenarios {
+			cells[a][s.Name] = deriveCell(a, s, caps[a])
+		}
+	}
+
+	metas := make([]scenarioMeta, len(scenarios))
+	for i, s := range scenarios {
+		metas[i] = scenarioMeta{Name: s.Name, Description: s.Description, Requires: s.Requires}
+	}
+	return &matrixResp{
+		Adapters:     adapters,
+		Scenarios:    metas,
+		Cells:        cells,
+		Features:     features,
+		Capabilities: caps,
+	}, nil
+}
+
+// deriveCell mirrors .claude/skills/ir:onboard-agent/skill.md step 2.
+func deriveCell(adapter string, s scenario, caps map[string]any) cell {
+	for _, req := range s.Requires {
+		v, ok := caps[req]
+		if !ok || v != true { // both false and "unknown" block
+			return cell{State: "n/a", Reason: "missing capability: " + req}
+		}
+	}
+	if _, ok := s.ByAdapter[adapter]; !ok {
+		return cell{State: "missing-prompt", Reason: "no by_adapter." + adapter + " entry in scenarios.json"}
+	}
+	fixture := filepath.Join(*rootDir, replayAgentDir, adapter, "scenarios", s.Name, "transcript.jsonl")
+	if _, err := os.Stat(fixture); err == nil {
+		return cell{State: "covered"}
+	}
+	return cell{State: "staged-only", Reason: "by_adapter present but no committed fixture"}
+}
+
+// ---------- /api/scenario/{adapter}/{scenario} ----------
+
+type drilldownStep struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Link        string `json:"link"`
+}
+
+type drilldownResp struct {
+	Adapter        string          `json:"adapter"`
+	Scenario       string          `json:"scenario"`
+	Description    string          `json:"description"`
+	Requires       []string        `json:"requires"`
+	State          string          `json:"state"`
+	Reason         string          `json:"reason,omitempty"`
+	Prompt         string          `json:"prompt,omitempty"`
+	Settings       any             `json:"settings,omitempty"`
+	TimeoutSeconds int             `json:"timeout_seconds,omitempty"`
+	Verify         map[string]any  `json:"verify,omitempty"`
+	Steps          []drilldownStep `json:"steps"`
+	HasFixture     bool            `json:"has_fixture"`
+}
+
+func handleScenario(w http.ResponseWriter, r *http.Request) {
+	adapter, scenarioName, ok := splitAdapterScenario(r.URL.Path, "/api/scenario/")
+	if !ok {
+		http.Error(w, "bad path", http.StatusBadRequest)
+		return
+	}
+	scenarios, _, err := loadScenarios()
+	if err != nil {
+		httpError(w, err)
+		return
+	}
+	var s *scenario
+	for i := range scenarios {
+		if scenarios[i].Name == scenarioName {
+			s = &scenarios[i]
+			break
+		}
+	}
+	if s == nil {
+		http.Error(w, "scenario not found", http.StatusNotFound)
+		return
+	}
+	caps, err := loadCapabilities(adapter)
+	if err != nil {
+		httpError(w, err)
+		return
+	}
+	c := deriveCell(adapter, *s, caps)
+
+	resp := drilldownResp{
+		Adapter:     adapter,
+		Scenario:    scenarioName,
+		Description: s.Description,
+		Requires:    s.Requires,
+		State:       c.State,
+		Reason:      c.Reason,
+		Verify:      s.Verify,
+		HasFixture:  c.State == "covered",
+	}
+	if ba, ok := s.ByAdapter[adapter]; ok {
+		resp.Prompt = ba.Prompt
+		resp.Settings = ba.Settings
+		resp.TimeoutSeconds = ba.TimeoutSeconds
+	}
+
+	sha := headSHA()
+	pl := func(rel string) string {
+		return fmt.Sprintf("%s/blob/%s/%s", githubRepoURL, sha, rel)
+	}
+	driverScript := fmt.Sprintf(".claude/skills/ir:onboard-agent/scripts/drive-%s.sh", adapter)
+	resp.Steps = []drilldownStep{
+		{Title: "Precheck", Description: "Validate adapter, port 7837 free, daemon binary present, working tree clean.", Link: pl(".claude/skills/ir:onboard-agent/scripts/precheck.sh")},
+		{Title: "Daemon spawn", Description: "irrlichd --record on 127.0.0.1:7837 with isolated IRRLICHT_RECORDINGS_DIR. SIGINT → 6s grace → SIGTERM → SIGKILL teardown.", Link: pl(".claude/skills/ir:onboard-agent/scripts/run-cell.sh")},
+		{Title: "Driver", Description: "Drives the " + adapter + " CLI with the prompt + settings shown above.", Link: pl(driverScript)},
+		{Title: "Curate fixture", Description: "Bundle the recording + per-session transcripts (and any subagents) into replaydata/agents/" + adapter + "/scenarios/" + scenarioName + "/.", Link: pl("scripts/curate-lifecycle-fixture.sh")},
+		{Title: "Replay", Description: "replay --quiet --out <report> runs the simulator against the staged + committed transcripts and emits per-state-transition diffs.", Link: pl("scripts/replay-fixtures.sh")},
+		{Title: "Verify", Description: "Assert the verify block (above) holds: transitions topology, tool-call presence, hook firings, final state, etc.", Link: pl(scenariosJSON)},
+	}
+	writeJSON(w, resp)
+}
+
+// ---------- /api/timeline/{adapter}/{scenario} ----------
+
+type timelineEntry struct {
+	TS        time.Time      `json:"ts"`
+	Lane      string         `json:"lane"`              // driver | agent | tool_result | hook | daemon | subagent
+	Kind      string         `json:"kind"`              // narrower (state_transition, tool_call, …)
+	SessionID string         `json:"session_id,omitempty"`
+	ParentID  string         `json:"parent_id,omitempty"`
+	Title     string         `json:"title"`
+	Payload   map[string]any `json:"payload"`
+}
+
+type timelineResp struct {
+	Adapter   string          `json:"adapter"`
+	Scenario  string          `json:"scenario"`
+	Note      string          `json:"note,omitempty"`
+	Entries   []timelineEntry `json:"entries"`
+}
+
+func handleTimeline(w http.ResponseWriter, r *http.Request) {
+	adapter, scenarioName, ok := splitAdapterScenario(r.URL.Path, "/api/timeline/")
+	if !ok {
+		http.Error(w, "bad path", http.StatusBadRequest)
+		return
+	}
+	scenarioDir := filepath.Join(*rootDir, replayAgentDir, adapter, "scenarios", scenarioName)
+	if _, err := os.Stat(scenarioDir); err != nil {
+		http.Error(w, "no fixture", http.StatusNotFound)
+		return
+	}
+
+	resp := timelineResp{Adapter: adapter, Scenario: scenarioName}
+
+	eventsPath := filepath.Join(scenarioDir, "events.jsonl")
+	eventEntries, parents, err := loadEvents(eventsPath)
+	if err != nil && !os.IsNotExist(err) {
+		httpError(w, err)
+		return
+	}
+	resp.Entries = append(resp.Entries, eventEntries...)
+
+	transcriptPath := filepath.Join(scenarioDir, "transcript.jsonl")
+	parser := newParserFor(adapter)
+	if parser == nil {
+		resp.Note = "transcript not parsed for adapter: " + adapter + " (e.g. aider markdown)"
+	} else if _, err := os.Stat(transcriptPath); err == nil {
+		txEntries, err := loadTranscript(transcriptPath, parser, "agent", primarySessionID(eventEntries))
+		if err != nil {
+			httpError(w, err)
+			return
+		}
+		resp.Entries = append(resp.Entries, txEntries...)
+	}
+
+	subDir := filepath.Join(scenarioDir, "subagents")
+	if entries, _ := os.ReadDir(subDir); len(entries) > 0 && parser != nil {
+		for _, ent := range entries {
+			if ent.IsDir() || !strings.HasSuffix(ent.Name(), ".jsonl") {
+				continue
+			}
+			childID := strings.TrimSuffix(ent.Name(), ".jsonl")
+			parent := parents[childID]
+			subParser := newParserFor(adapter)
+			subEntries, err := loadTranscript(filepath.Join(subDir, ent.Name()), subParser, "subagent", childID)
+			if err != nil {
+				continue
+			}
+			for i := range subEntries {
+				if parent != "" {
+					subEntries[i].ParentID = parent
+				}
+			}
+			resp.Entries = append(resp.Entries, subEntries...)
+		}
+	}
+
+	sort.SliceStable(resp.Entries, func(i, j int) bool {
+		return resp.Entries[i].TS.Before(resp.Entries[j].TS)
+	})
+	writeJSON(w, resp)
+}
+
+func loadEvents(path string) ([]timelineEntry, map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+	parents := map[string]string{} // child_session_id → parent_session_id
+	var out []timelineEntry
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var raw map[string]any
+		if err := dec.Decode(&raw); err != nil {
+			break
+		}
+		kind, _ := raw["kind"].(string)
+		ts := parseTime(raw["ts"])
+		sid, _ := raw["session_id"].(string)
+		entry := timelineEntry{TS: ts, Kind: kind, SessionID: sid, Payload: raw}
+		switch kind {
+		case "state_transition":
+			entry.Lane = "daemon"
+			prev, _ := raw["prev_state"].(string)
+			ns, _ := raw["new_state"].(string)
+			if prev == "" {
+				entry.Title = "→ " + ns
+			} else {
+				entry.Title = prev + " → " + ns
+			}
+		case "hook_received":
+			entry.Lane = "hook"
+			name, _ := raw["hook_name"].(string)
+			entry.Title = "hook: " + name
+		case "parent_linked":
+			entry.Lane = "subagent"
+			parent, _ := raw["parent_session_id"].(string)
+			entry.ParentID = parent
+			entry.Title = "subagent linked"
+			if sid != "" && parent != "" {
+				parents[sid] = parent
+			}
+		case "transcript_new", "transcript_removed", "presession_created", "presession_removed", "pid_discovered", "process_exited":
+			entry.Lane = "daemon"
+			entry.Title = kind
+		default:
+			entry.Lane = "daemon"
+			entry.Title = kind
+		}
+		out = append(out, entry)
+	}
+	return out, parents, nil
+}
+
+func loadTranscript(path string, parser tailer.TranscriptParser, lane, sessionID string) ([]timelineEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var out []timelineEntry
+	dec := json.NewDecoder(f)
+	for dec.More() {
+		var raw map[string]any
+		if err := dec.Decode(&raw); err != nil {
+			break
+		}
+		ev := parser.ParseLine(raw)
+		if ev == nil || ev.Skip {
+			// Surface queue-operation enqueue as a Driver-lane prompt event.
+			if t, _ := raw["type"].(string); t == "queue-operation" && raw["operation"] == "enqueue" {
+				out = append(out, timelineEntry{
+					TS:        parseTime(raw["timestamp"]),
+					Lane:      "driver",
+					Kind:      "prompt_send",
+					SessionID: sessionID,
+					Title:     truncate(stringField(raw, "content"), 80),
+					Payload:   raw,
+				})
+			}
+			continue
+		}
+		entry := timelineEntry{
+			TS:        ev.Timestamp,
+			Lane:      lane,
+			Kind:      ev.EventType,
+			SessionID: sessionID,
+			Payload:   raw,
+		}
+		switch {
+		case len(ev.ToolUses) > 0:
+			names := make([]string, len(ev.ToolUses))
+			for i, t := range ev.ToolUses {
+				names[i] = t.Name
+			}
+			entry.Lane = lane
+			entry.Kind = "tool_call"
+			entry.Title = "tool: " + strings.Join(names, ", ")
+		case len(ev.ToolResultIDs) > 0:
+			entry.Lane = "tool_result"
+			entry.Kind = "tool_result"
+			if ev.IsError {
+				entry.Title = "tool result (error)"
+			} else {
+				entry.Title = "tool result"
+			}
+		case ev.EventType == "user_message":
+			entry.Lane = "driver"
+			entry.Title = "user message"
+		case ev.EventType == "assistant_message", ev.EventType == "assistant", ev.EventType == "turn_done":
+			entry.Title = describeAssistant(raw, ev)
+		default:
+			entry.Title = ev.EventType
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+func describeAssistant(raw map[string]any, ev *tailer.ParsedEvent) string {
+	text := tailer.ExtractAssistantText(raw)
+	if text != "" {
+		return truncate(text, 80)
+	}
+	if ev.EventType != "" {
+		return ev.EventType
+	}
+	return "assistant"
+}
+
+func primarySessionID(entries []timelineEntry) string {
+	for _, e := range entries {
+		if e.Kind == "transcript_new" && e.SessionID != "" && !strings.HasPrefix(e.SessionID, "proc-") {
+			return e.SessionID
+		}
+	}
+	return ""
+}
+
+// ---------- adapters / parsers ----------
+
+func newParserFor(adapter string) tailer.TranscriptParser {
+	switch adapter {
+	case "claudecode":
+		return &claudecode.Parser{}
+	case "codex":
+		return &codex.Parser{}
+	case "pi":
+		return &pi.Parser{}
+	case "aider":
+		return &aider.NoOpParser{}
+	default:
+		return nil
+	}
+}
+
+func discoverAdapters() ([]string, error) {
+	dir := filepath.Join(*rootDir, replayAgentDir)
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, e := range ents {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), "_") {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(dir, e.Name(), "capabilities.json")); err != nil {
+			continue
+		}
+		out = append(out, e.Name())
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// ---------- file loaders ----------
+
+func loadFeatures() ([]featureMeta, error) {
+	b, err := os.ReadFile(filepath.Join(*rootDir, featuresJSON))
+	if err != nil {
+		return nil, err
+	}
+	var doc struct {
+		Features []featureMeta `json:"features"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return nil, err
+	}
+	return doc.Features, nil
+}
+
+type byAdapterEntry struct {
+	Prompt         string `json:"prompt"`
+	Settings       any    `json:"settings"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+}
+
+type scenario struct {
+	Name        string                    `json:"name"`
+	Description string                    `json:"description"`
+	Requires    []string                  `json:"requires"`
+	Verify      map[string]any            `json:"verify"`
+	ByAdapter   map[string]byAdapterEntry `json:"by_adapter"`
+}
+
+func loadScenarios() ([]scenario, []scenario, error) {
+	b, err := os.ReadFile(filepath.Join(*rootDir, scenariosJSON))
+	if err != nil {
+		return nil, nil, err
+	}
+	var doc struct {
+		Scenarios             []scenario `json:"scenarios"`
+		OrchestratorScenarios []scenario `json:"orchestrator_scenarios"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return nil, nil, err
+	}
+	return doc.Scenarios, doc.OrchestratorScenarios, nil
+}
+
+func loadCapabilities(adapter string) (map[string]any, error) {
+	path := filepath.Join(*rootDir, replayAgentDir, adapter, "capabilities.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var doc struct {
+		Features map[string]any `json:"features"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return nil, err
+	}
+	return doc.Features, nil
+}
+
+// ---------- helpers ----------
+
+func headSHA() string {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = *rootDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "main"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func splitAdapterScenario(urlPath, prefix string) (string, string, bool) {
+	rest := strings.TrimPrefix(urlPath, prefix)
+	parts := strings.SplitN(rest, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func parseTime(v any) time.Time {
+	s, _ := v.(string)
+	if s == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05Z07:00"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		log.Printf("encode: %v", err)
+	}
+}
+
+func httpError(w http.ResponseWriter, err error) {
+	log.Printf("error: %v", err)
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}
+
+func truncate(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
+
+func stringField(raw map[string]any, key string) string {
+	v, _ := raw[key].(string)
+	return v
+}
+
+// Keep io referenced for future streaming use.
+var _ = io.Discard

--- a/tools/coverage-viewer/main.go
+++ b/tools/coverage-viewer/main.go
@@ -7,12 +7,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -23,6 +23,11 @@ import (
 	"irrlicht/core/adapters/inbound/agents/pi"
 	"irrlicht/core/pkg/tailer"
 )
+
+// safeSegment matches the only shapes adapter and scenario names take in this
+// repo: lowercase ascii words with dashes, optionally suffixed with a short hex
+// hash. Anything else (slashes, dots, ..) is rejected to prevent path escape.
+var safeSegment = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{0,127}$`)
 
 const (
 	githubRepoURL  = "https://github.com/ingo-eichhorst/Irrlicht"
@@ -108,7 +113,6 @@ type scenarioMeta struct {
 
 type featureMeta struct {
 	ID          string `json:"id"`
-	Title       string `json:"title"`
 	Description string `json:"description"`
 }
 
@@ -134,7 +138,7 @@ func buildMatrix() (*matrixResp, error) {
 	if err != nil {
 		return nil, fmt.Errorf("features: %w", err)
 	}
-	scenarios, _, err := loadScenarios()
+	scenarios, err := loadScenarios()
 	if err != nil {
 		return nil, fmt.Errorf("scenarios: %w", err)
 	}
@@ -220,7 +224,7 @@ func handleScenario(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bad path", http.StatusBadRequest)
 		return
 	}
-	scenarios, _, err := loadScenarios()
+	scenarios, err := loadScenarios()
 	if err != nil {
 		httpError(w, err)
 		return
@@ -561,19 +565,18 @@ type scenario struct {
 	ByAdapter   map[string]byAdapterEntry `json:"by_adapter"`
 }
 
-func loadScenarios() ([]scenario, []scenario, error) {
+func loadScenarios() ([]scenario, error) {
 	b, err := os.ReadFile(filepath.Join(*rootDir, scenariosJSON))
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	var doc struct {
-		Scenarios             []scenario `json:"scenarios"`
-		OrchestratorScenarios []scenario `json:"orchestrator_scenarios"`
+		Scenarios []scenario `json:"scenarios"`
 	}
 	if err := json.Unmarshal(b, &doc); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return doc.Scenarios, doc.OrchestratorScenarios, nil
+	return doc.Scenarios, nil
 }
 
 func loadCapabilities(adapter string) (map[string]any, error) {
@@ -603,10 +606,16 @@ func headSHA() string {
 	return strings.TrimSpace(string(out))
 }
 
+// splitAdapterScenario parses /<prefix>/<adapter>/<scenario> and rejects any
+// segment that isn't a plain lowercase identifier — guards against path
+// escape (../, absolute paths, encoded slashes, etc.).
 func splitAdapterScenario(urlPath, prefix string) (string, string, bool) {
 	rest := strings.TrimPrefix(urlPath, prefix)
 	parts := strings.SplitN(rest, "/", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	if !safeSegment.MatchString(parts[0]) || !safeSegment.MatchString(parts[1]) {
 		return "", "", false
 	}
 	return parts[0], parts[1], true
@@ -652,5 +661,3 @@ func stringField(raw map[string]any, key string) string {
 	return v
 }
 
-// Keep io referenced for future streaming use.
-var _ = io.Discard

--- a/tools/coverage-viewer/main.go
+++ b/tools/coverage-viewer/main.go
@@ -126,15 +126,23 @@ type scenarioMeta struct {
 
 type featureMeta struct {
 	ID          string `json:"id"`
+	Title       string `json:"title,omitempty"`
+	Category    string `json:"category,omitempty"`
 	Description string `json:"description"`
 }
 
+type categoryMeta struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
 type matrixResp struct {
-	Adapters     []string                      `json:"adapters"`
-	Scenarios    []scenarioMeta                `json:"scenarios"`
-	Cells        map[string]map[string]cell    `json:"cells"`        // adapter → scenario → cell
-	Features     []featureMeta                 `json:"features"`
-	Capabilities map[string]map[string]any     `json:"capabilities"` // adapter → feature → true|false|"unknown"
+	Adapters     []string                   `json:"adapters"`
+	Scenarios    []scenarioMeta             `json:"scenarios"`
+	Cells        map[string]map[string]cell `json:"cells"` // adapter → scenario → cell
+	Features     []featureMeta              `json:"features"`
+	Categories   []categoryMeta             `json:"categories,omitempty"`
+	Capabilities map[string]map[string]any  `json:"capabilities"` // adapter → feature → true|false|"unknown"
 }
 
 func handleMatrix(w http.ResponseWriter, r *http.Request) {
@@ -147,7 +155,7 @@ func handleMatrix(w http.ResponseWriter, r *http.Request) {
 }
 
 func buildMatrix() (*matrixResp, error) {
-	features, err := loadFeatures()
+	features, categories, err := loadFeatures()
 	if err != nil {
 		return nil, fmt.Errorf("features: %w", err)
 	}
@@ -186,6 +194,7 @@ func buildMatrix() (*matrixResp, error) {
 		Scenarios:    metas,
 		Cells:        cells,
 		Features:     features,
+		Categories:   categories,
 		Capabilities: caps,
 	}, nil
 }
@@ -546,18 +555,19 @@ func discoverAdapters() ([]string, error) {
 
 // ---------- file loaders ----------
 
-func loadFeatures() ([]featureMeta, error) {
+func loadFeatures() ([]featureMeta, []categoryMeta, error) {
 	b, err := os.ReadFile(filepath.Join(*rootDir, featuresJSON))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var doc struct {
-		Features []featureMeta `json:"features"`
+		Features   []featureMeta  `json:"features"`
+		Categories []categoryMeta `json:"categories"`
 	}
 	if err := json.Unmarshal(b, &doc); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return doc.Features, nil
+	return doc.Features, doc.Categories, nil
 }
 
 type byAdapterEntry struct {

--- a/tools/coverage-viewer/main.go
+++ b/tools/coverage-viewer/main.go
@@ -15,13 +15,26 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"irrlicht/core/adapters/inbound/agents/aider"
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/adapters/inbound/agents/codex"
 	"irrlicht/core/adapters/inbound/agents/pi"
+	"irrlicht/core/domain/lifecycle"
 	"irrlicht/core/pkg/tailer"
+)
+
+// Lane labels used in the timeline swim-lanes — kept as constants so the Go
+// emitter and the JS consumer share a single source of truth.
+const (
+	laneDriver     = "driver"
+	laneAgent      = "agent"
+	laneToolResult = "tool_result"
+	laneHook       = "hook"
+	laneDaemon     = "daemon"
+	laneSubagent   = "subagent"
 )
 
 // safeSegment matches the only shapes adapter and scenario names take in this
@@ -282,13 +295,13 @@ func handleScenario(w http.ResponseWriter, r *http.Request) {
 // ---------- /api/timeline/{adapter}/{scenario} ----------
 
 type timelineEntry struct {
-	TS        time.Time      `json:"ts"`
-	Lane      string         `json:"lane"`              // driver | agent | tool_result | hook | daemon | subagent
-	Kind      string         `json:"kind"`              // narrower (state_transition, tool_call, …)
-	SessionID string         `json:"session_id,omitempty"`
-	ParentID  string         `json:"parent_id,omitempty"`
-	Title     string         `json:"title"`
-	Payload   map[string]any `json:"payload"`
+	TS        time.Time `json:"ts"`
+	Lane      string    `json:"lane"`              // driver | agent | tool_result | hook | daemon | subagent
+	Kind      string    `json:"kind"`              // narrower (state_transition, tool_call, …)
+	SessionID string    `json:"session_id,omitempty"`
+	ParentID  string    `json:"parent_id,omitempty"`
+	Title     string    `json:"title"`
+	Payload   any       `json:"payload"` // lifecycle.Event for daemon events, raw map[string]any for transcripts
 }
 
 type timelineResp struct {
@@ -305,32 +318,32 @@ func handleTimeline(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	scenarioDir := filepath.Join(*rootDir, replayAgentDir, adapter, "scenarios", scenarioName)
-	if _, err := os.Stat(scenarioDir); err != nil {
-		http.Error(w, "no fixture", http.StatusNotFound)
-		return
-	}
-
 	resp := timelineResp{Adapter: adapter, Scenario: scenarioName}
 
-	eventsPath := filepath.Join(scenarioDir, "events.jsonl")
-	eventEntries, parents, err := loadEvents(eventsPath)
+	eventEntries, parents, err := loadEvents(filepath.Join(scenarioDir, "events.jsonl"))
 	if err != nil && !os.IsNotExist(err) {
 		httpError(w, err)
 		return
 	}
 	resp.Entries = append(resp.Entries, eventEntries...)
 
-	transcriptPath := filepath.Join(scenarioDir, "transcript.jsonl")
 	parser := newParserFor(adapter)
 	if parser == nil {
 		resp.Note = "transcript not parsed for adapter: " + adapter + " (e.g. aider markdown)"
-	} else if _, err := os.Stat(transcriptPath); err == nil {
-		txEntries, err := loadTranscript(transcriptPath, parser, "agent", primarySessionID(eventEntries))
-		if err != nil {
+	} else {
+		txEntries, err := loadTranscript(filepath.Join(scenarioDir, "transcript.jsonl"), parser, laneAgent, primarySessionID(eventEntries))
+		if err != nil && !os.IsNotExist(err) {
 			httpError(w, err)
 			return
 		}
 		resp.Entries = append(resp.Entries, txEntries...)
+	}
+
+	// If neither events.jsonl nor transcript.jsonl produced anything, the
+	// (adapter, scenario) directory likely doesn't exist — surface that.
+	if len(resp.Entries) == 0 {
+		http.Error(w, "no fixture", http.StatusNotFound)
+		return
 	}
 
 	subDir := filepath.Join(scenarioDir, "subagents")
@@ -341,13 +354,14 @@ func handleTimeline(w http.ResponseWriter, r *http.Request) {
 			}
 			childID := strings.TrimSuffix(ent.Name(), ".jsonl")
 			parent := parents[childID]
-			subParser := newParserFor(adapter)
-			subEntries, err := loadTranscript(filepath.Join(subDir, ent.Name()), subParser, "subagent", childID)
+			// Fresh parser per subagent file — claudecode.Parser is stateful
+			// (lastRequestID / pendingContrib) and would carry state across files otherwise.
+			subEntries, err := loadTranscript(filepath.Join(subDir, ent.Name()), newParserFor(adapter), laneSubagent, childID)
 			if err != nil {
 				continue
 			}
-			for i := range subEntries {
-				if parent != "" {
+			if parent != "" {
+				for i := range subEntries {
 					subEntries[i].ParentID = parent
 				}
 			}
@@ -371,42 +385,35 @@ func loadEvents(path string) ([]timelineEntry, map[string]string, error) {
 	var out []timelineEntry
 	dec := json.NewDecoder(f)
 	for dec.More() {
-		var raw map[string]any
-		if err := dec.Decode(&raw); err != nil {
+		var ev lifecycle.Event
+		if err := dec.Decode(&ev); err != nil {
 			break
 		}
-		kind, _ := raw["kind"].(string)
-		ts := parseTime(raw["ts"])
-		sid, _ := raw["session_id"].(string)
-		entry := timelineEntry{TS: ts, Kind: kind, SessionID: sid, Payload: raw}
-		switch kind {
-		case "state_transition":
-			entry.Lane = "daemon"
-			prev, _ := raw["prev_state"].(string)
-			ns, _ := raw["new_state"].(string)
-			if prev == "" {
-				entry.Title = "→ " + ns
+		entry := timelineEntry{
+			TS:        ev.Timestamp,
+			Kind:      string(ev.Kind),
+			SessionID: ev.SessionID,
+			Lane:      laneDaemon,
+			Title:     string(ev.Kind),
+			Payload:   ev,
+		}
+		switch ev.Kind {
+		case lifecycle.KindStateTransition:
+			if ev.PrevState == "" {
+				entry.Title = "→ " + ev.NewState
 			} else {
-				entry.Title = prev + " → " + ns
+				entry.Title = ev.PrevState + " → " + ev.NewState
 			}
-		case "hook_received":
-			entry.Lane = "hook"
-			name, _ := raw["hook_name"].(string)
-			entry.Title = "hook: " + name
-		case "parent_linked":
-			entry.Lane = "subagent"
-			parent, _ := raw["parent_session_id"].(string)
-			entry.ParentID = parent
+		case lifecycle.KindHookReceived:
+			entry.Lane = laneHook
+			entry.Title = "hook: " + ev.HookName
+		case lifecycle.KindParentLinked:
+			entry.Lane = laneSubagent
+			entry.ParentID = ev.ParentSessionID
 			entry.Title = "subagent linked"
-			if sid != "" && parent != "" {
-				parents[sid] = parent
+			if ev.SessionID != "" && ev.ParentSessionID != "" {
+				parents[ev.SessionID] = ev.ParentSessionID
 			}
-		case "transcript_new", "transcript_removed", "presession_created", "presession_removed", "pid_discovered", "process_exited":
-			entry.Lane = "daemon"
-			entry.Title = kind
-		default:
-			entry.Lane = "daemon"
-			entry.Title = kind
 		}
 		out = append(out, entry)
 	}
@@ -432,7 +439,7 @@ func loadTranscript(path string, parser tailer.TranscriptParser, lane, sessionID
 			if t, _ := raw["type"].(string); t == "queue-operation" && raw["operation"] == "enqueue" {
 				out = append(out, timelineEntry{
 					TS:        parseTime(raw["timestamp"]),
-					Lane:      "driver",
+					Lane:      laneDriver,
 					Kind:      "prompt_send",
 					SessionID: sessionID,
 					Title:     truncate(stringField(raw, "content"), 80),
@@ -454,11 +461,10 @@ func loadTranscript(path string, parser tailer.TranscriptParser, lane, sessionID
 			for i, t := range ev.ToolUses {
 				names[i] = t.Name
 			}
-			entry.Lane = lane
 			entry.Kind = "tool_call"
 			entry.Title = "tool: " + strings.Join(names, ", ")
 		case len(ev.ToolResultIDs) > 0:
-			entry.Lane = "tool_result"
+			entry.Lane = laneToolResult
 			entry.Kind = "tool_result"
 			if ev.IsError {
 				entry.Title = "tool result (error)"
@@ -466,7 +472,7 @@ func loadTranscript(path string, parser tailer.TranscriptParser, lane, sessionID
 				entry.Title = "tool result"
 			}
 		case ev.EventType == "user_message":
-			entry.Lane = "driver"
+			entry.Lane = laneDriver
 			entry.Title = "user message"
 		case ev.EventType == "assistant_message", ev.EventType == "assistant", ev.EventType == "turn_done":
 			entry.Title = describeAssistant(raw, ev)
@@ -489,9 +495,12 @@ func describeAssistant(raw map[string]any, ev *tailer.ParsedEvent) string {
 	return "assistant"
 }
 
+// primarySessionID picks the agent session ID from the lifecycle stream — the
+// first transcript_new whose session_id isn't a "proc-<pid>" pre-session
+// sentinel emitted by the daemon's process scanner.
 func primarySessionID(entries []timelineEntry) string {
 	for _, e := range entries {
-		if e.Kind == "transcript_new" && e.SessionID != "" && !strings.HasPrefix(e.SessionID, "proc-") {
+		if e.Kind == string(lifecycle.KindTranscriptNew) && e.SessionID != "" && !strings.HasPrefix(e.SessionID, "proc-") {
 			return e.SessionID
 		}
 	}
@@ -596,14 +605,26 @@ func loadCapabilities(adapter string) (map[string]any, error) {
 
 // ---------- helpers ----------
 
+var (
+	headSHAOnce  sync.Once
+	cachedHeadSHA string
+)
+
+// headSHA returns the repo HEAD SHA, cached once at first call. The viewer
+// doesn't watch for new commits, so per-request `git rev-parse` would just
+// fork a process to return the same answer.
 func headSHA() string {
-	cmd := exec.Command("git", "rev-parse", "HEAD")
-	cmd.Dir = *rootDir
-	out, err := cmd.Output()
-	if err != nil {
-		return "main"
-	}
-	return strings.TrimSpace(string(out))
+	headSHAOnce.Do(func() {
+		cmd := exec.Command("git", "rev-parse", "HEAD")
+		cmd.Dir = *rootDir
+		out, err := cmd.Output()
+		if err != nil {
+			cachedHeadSHA = "main"
+			return
+		}
+		cachedHeadSHA = strings.TrimSpace(string(out))
+	})
+	return cachedHeadSHA
 }
 
 // splitAdapterScenario parses /<prefix>/<adapter>/<scenario> and rejects any

--- a/tools/coverage-viewer/ui/app.js
+++ b/tools/coverage-viewer/ui/app.js
@@ -1,0 +1,394 @@
+// Coverage-viewer SPA: matrix → modals (drilldown / timeline / feature coverage).
+// Vanilla JS, no framework.
+
+const $ = (id) => document.getElementById(id);
+
+let matrixData = null;
+let featureIndex = {};
+
+init();
+
+async function init() {
+  bindUI();
+  try {
+    matrixData = await fetchJSON("/api/matrix");
+    featureIndex = Object.fromEntries(matrixData.features.map((f) => [f.id, f]));
+    renderMatrix(matrixData);
+    $("matrix-loading").hidden = true;
+    $("matrix-wrap").hidden = false;
+  } catch (err) {
+    $("matrix-loading").innerHTML = `<div class="error">Failed to load matrix: ${escapeHtml(err.message)}</div>`;
+  }
+}
+
+function bindUI() {
+  // Close modal: button click, backdrop click, ESC.
+  document.body.addEventListener("click", (e) => {
+    const target = e.target.closest("[data-close]");
+    if (target) {
+      closeModal(target.dataset.close);
+      return;
+    }
+    if (e.target.classList.contains("modal-backdrop")) {
+      closeModal(e.target.id.replace(/-modal$/, ""));
+    }
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      // Close topmost open modal first (detail > features/timeline > drilldown).
+      if (!$("timeline-detail").hidden) return closeModal("detail");
+      for (const id of ["features", "timeline", "drilldown"]) {
+        if (!$(`${id}-modal`).hidden) return closeModal(id);
+      }
+    }
+  });
+}
+
+function openModal(name) {
+  $(`${name}-modal`).hidden = false;
+  document.body.style.overflow = "hidden";
+}
+
+function closeModal(name) {
+  if (name === "detail") {
+    $("timeline-detail").hidden = true;
+    return;
+  }
+  $(`${name}-modal`).hidden = true;
+  if (allModalsClosed()) document.body.style.overflow = "";
+}
+
+function allModalsClosed() {
+  return ["drilldown", "timeline", "features"].every((n) => $(`${n}-modal`).hidden);
+}
+
+// ---------- matrix ----------
+
+function renderMatrix(m) {
+  const groups = groupByRequires(m.scenarios);
+  const tbl = $("matrix");
+  tbl.innerHTML = "";
+
+  const head = tbl.appendChild(document.createElement("thead"));
+  const headRow = head.appendChild(document.createElement("tr"));
+  headRow.appendChild(th("Scenario"));
+  for (const a of m.adapters) {
+    const c = th(`${a}\n`);
+    c.className = "adapter";
+    c.innerHTML = `${escapeHtml(a)}<span class="hint">click for features</span>`;
+    c.addEventListener("click", () => openFeatures(a));
+    headRow.appendChild(c);
+  }
+
+  const body = tbl.appendChild(document.createElement("tbody"));
+  for (const [reqKey, scenarios] of groups) {
+    const groupRow = body.appendChild(document.createElement("tr"));
+    groupRow.className = "group-head";
+    const td = document.createElement("td");
+    td.colSpan = m.adapters.length + 1;
+    td.innerHTML =
+      `<span>requires: ${escapeHtml(reqKey || "(none)")}</span>` +
+      `<span class="req">${scenarios.length} scenario${scenarios.length === 1 ? "" : "s"}</span>`;
+    groupRow.appendChild(td);
+
+    for (const s of scenarios) {
+      const row = body.appendChild(document.createElement("tr"));
+      const sc = document.createElement("td");
+      sc.className = "scenario";
+      sc.innerHTML = `<div>${escapeHtml(s.name)}</div><div class="desc">${escapeHtml(s.description || "")}</div>`;
+      row.appendChild(sc);
+      for (const a of m.adapters) {
+        const cellData = m.cells[a]?.[s.name] || { state: "n/a", reason: "" };
+        const td = document.createElement("td");
+        td.className = "cell";
+        td.title = cellData.reason || "";
+        td.innerHTML = `<span class="chip ${chipClass(cellData.state)}">${escapeHtml(cellData.state)}</span>`;
+        td.addEventListener("click", () => openDrilldown(a, s.name));
+        row.appendChild(td);
+      }
+    }
+  }
+}
+
+function groupByRequires(scenarios) {
+  const map = new Map();
+  for (const s of scenarios) {
+    const key = (s.requires || []).join(", ");
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(s);
+  }
+  return map;
+}
+
+// ---------- feature coverage modal ----------
+
+function openFeatures(adapter) {
+  const body = $("features-body");
+  const caps = matrixData.capabilities[adapter] || {};
+  const cells = matrixData.cells[adapter] || {};
+  const scenariosByName = Object.fromEntries(matrixData.scenarios.map((s) => [s.name, s]));
+
+  // For each feature, find scenarios that require it AND their cell state for this adapter.
+  const rows = matrixData.features.map((f) => {
+    const cap = caps[f.id];
+    const scenariosRequiring = matrixData.scenarios.filter((s) =>
+      (s.requires || []).includes(f.id),
+    );
+    const coveringScenarios = scenariosRequiring.filter(
+      (s) => (cells[s.name] || {}).state === "covered",
+    );
+    return {
+      feature: f,
+      cap,
+      scenariosRequiring,
+      coveringScenarios,
+      coverageCount: coveringScenarios.length,
+    };
+  });
+
+  const stats = {
+    capTrue: rows.filter((r) => r.cap === true).length,
+    capFalse: rows.filter((r) => r.cap === false).length,
+    capUnknown: rows.filter((r) => r.cap === "unknown").length,
+    capMissing: rows.filter((r) => r.cap === undefined).length,
+    coveredAtLeastOnce: rows.filter((r) => r.coverageCount > 0).length,
+    coveredMultiple: rows.filter((r) => r.coverageCount > 1).length,
+    declaredButUntested: rows.filter((r) => r.cap === true && r.coverageCount === 0).length,
+  };
+
+  body.innerHTML = `
+    <h2>${escapeHtml(adapter)} <span style="color:var(--text-dim);font-weight:400">— feature coverage</span></h2>
+    <p class="crumb">Which features <strong>${escapeHtml(adapter)}</strong> declares, and which scenarios actually exercise them.</p>
+    <div class="summary">
+      <span class="stat"><strong>${stats.coveredAtLeastOnce}</strong>/${matrixData.features.length} features covered ≥ 1×</span>
+      <span class="stat"><strong>${stats.coveredMultiple}</strong> covered multiple times</span>
+      <span class="stat"><strong>${stats.declaredButUntested}</strong> declared but untested</span>
+      <span class="stat"><strong>${stats.capTrue}</strong> capable · <strong>${stats.capUnknown + stats.capMissing}</strong> unknown · <strong>${stats.capFalse}</strong> not capable</span>
+    </div>
+    <table class="features">
+      <thead><tr>
+        <th>Feature</th>
+        <th>Declared</th>
+        <th>Scenarios testing it</th>
+        <th>Times covered</th>
+      </tr></thead>
+      <tbody>
+        ${rows.map((r) => renderFeatureRow(adapter, r, scenariosByName)).join("")}
+      </tbody>
+    </table>
+  `;
+  // Wire scenario links → drilldown modal (replaces features modal).
+  body.querySelectorAll("[data-scenario]").forEach((el) => {
+    el.addEventListener("click", () => {
+      closeModal("features");
+      openDrilldown(adapter, el.dataset.scenario);
+    });
+  });
+  openModal("features");
+}
+
+function renderFeatureRow(adapter, r, scenariosByName) {
+  const capChip = renderCapChip(r.cap);
+  const scnLinks = r.scenariosRequiring.length === 0
+    ? `<span style="color:var(--text-dim)">— no scenario requires this feature —</span>`
+    : r.scenariosRequiring.map((s) => {
+        const state = (matrixData.cells[adapter]?.[s.name] || {}).state || "n/a";
+        return `<span class="scn-link ${chipClass(state)}" data-scenario="${escapeHtml(s.name)}" title="${escapeHtml(state)}">${escapeHtml(s.name)}</span>`;
+      }).join("");
+  const countCls = r.coverageCount === 0 ? "zero" : "covered";
+  return `
+    <tr class="${r.coverageCount === 0 ? "uncovered" : ""}">
+      <td class="feature-id">
+        ${escapeHtml(r.feature.id)}
+        ${r.feature.description ? `<span class="desc">${escapeHtml(r.feature.description)}</span>` : ""}
+      </td>
+      <td class="cap">${capChip}</td>
+      <td class="scenarios">${scnLinks}</td>
+      <td class="count ${countCls}">${r.coverageCount}</td>
+    </tr>
+  `;
+}
+
+function renderCapChip(cap) {
+  if (cap === true) return `<span class="chip cap-true">true</span>`;
+  if (cap === false) return `<span class="chip cap-false">false</span>`;
+  if (cap === "unknown") return `<span class="chip cap-unknown">unknown</span>`;
+  return `<span class="chip cap-unknown">—</span>`;
+}
+
+// ---------- drilldown ----------
+
+async function openDrilldown(adapter, scenario) {
+  const dd = $("drilldown");
+  dd.innerHTML = `<p class="crumb">Loading ${escapeHtml(adapter)} / ${escapeHtml(scenario)}…</p>`;
+  openModal("drilldown");
+  try {
+    const d = await fetchJSON(`/api/scenario/${adapter}/${scenario}`);
+    renderDrilldown(d);
+  } catch (err) {
+    dd.innerHTML = `<div class="error">${escapeHtml(err.message)}</div>`;
+  }
+}
+
+function renderDrilldown(d) {
+  const dd = $("drilldown");
+  const verifyHtml = renderVerify(d.verify);
+  const meta = [];
+  if (d.prompt) meta.push(`<dt>Prompt</dt><dd><pre>${escapeHtml(d.prompt)}</pre></dd>`);
+  if (d.timeout_seconds) meta.push(`<dt>Timeout</dt><dd>${d.timeout_seconds}s</dd>`);
+  if (d.requires?.length) meta.push(`<dt>Requires</dt><dd>${d.requires.map((r) => `<code>${escapeHtml(r)}</code>`).join(" ")}</dd>`);
+  if (d.settings && Object.keys(d.settings).length > 0) {
+    meta.push(`<dt>Settings</dt><dd><pre>${escapeHtml(JSON.stringify(d.settings, null, 2))}</pre></dd>`);
+  }
+  if (d.reason) meta.push(`<dt>Reason</dt><dd>${escapeHtml(d.reason)}</dd>`);
+
+  dd.innerHTML = `
+    <h2>${escapeHtml(d.adapter)} <span style="color:var(--text-dim)">/</span> ${escapeHtml(d.scenario)} <span class="chip ${chipClass(d.state)}">${escapeHtml(d.state)}</span></h2>
+    <p class="crumb">${escapeHtml(d.description || "")}</p>
+    <dl class="meta">${meta.join("")}</dl>
+    <div class="steps">
+      ${d.steps.map((s, i) => `
+        <div class="step">
+          <h4><span class="num">${i + 1}</span> ${escapeHtml(s.title)}</h4>
+          <p>${escapeHtml(s.description)}</p>
+          <a href="${escapeHtml(s.link)}" target="_blank" rel="noopener">${escapeHtml(s.link.replace(/^https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/[^/]+\//, ""))}</a>
+        </div>
+      `).join("")}
+    </div>
+    ${verifyHtml}
+    <button class="timeline-btn" id="show-timeline" ${d.has_fixture ? "" : "disabled"}>${d.has_fixture ? "View timeline →" : "No committed fixture"}</button>
+  `;
+  if (d.has_fixture) {
+    $("show-timeline").addEventListener("click", () => openTimeline(d.adapter, d.scenario));
+  }
+}
+
+function renderVerify(verify) {
+  if (!verify || Object.keys(verify).length === 0) return "";
+  const items = Object.entries(verify).map(([k, v]) => {
+    return `<li><code>${escapeHtml(k)}</code> = ${escapeHtml(JSON.stringify(v))}</li>`;
+  });
+  return `<div class="verify"><h4>Verify block</h4><ul>${items.join("")}</ul></div>`;
+}
+
+// ---------- timeline ----------
+
+const LANES = [
+  ["driver", "Driver"],
+  ["agent", "Agent"],
+  ["tool_result", "Tool result"],
+  ["hook", "Hook"],
+  ["daemon", "Daemon state"],
+  ["subagent", "Subagent"],
+];
+
+async function openTimeline(adapter, scenario) {
+  $("timeline-meta").innerHTML = `Loading timeline for <strong>${escapeHtml(adapter)} / ${escapeHtml(scenario)}</strong>…`;
+  $("timeline").innerHTML = "";
+  openModal("timeline");
+  try {
+    const t = await fetchJSON(`/api/timeline/${adapter}/${scenario}`);
+    renderTimeline(t);
+  } catch (err) {
+    $("timeline").innerHTML = `<div class="error">${escapeHtml(err.message)}</div>`;
+  }
+}
+
+function renderTimeline(t) {
+  const meta = [`<strong>${escapeHtml(t.adapter)} / ${escapeHtml(t.scenario)}</strong> · ${t.entries.length} events`];
+  if (t.note) meta.push(`<span class="note">${escapeHtml(t.note)}</span>`);
+  $("timeline-meta").innerHTML = meta.join(" ");
+
+  const tl = $("timeline");
+  tl.innerHTML = "";
+
+  const byLane = Object.fromEntries(LANES.map(([k]) => [k, []]));
+  for (const e of t.entries) {
+    if (!byLane[e.lane]) byLane[e.lane] = [];
+    byLane[e.lane].push(e);
+  }
+
+  const subsByParent = {};
+  for (const e of byLane.subagent || []) {
+    const key = e.parent_id || "_root";
+    if (!subsByParent[key]) subsByParent[key] = [];
+    subsByParent[key].push(e);
+  }
+
+  for (const [laneKey, laneLabel] of LANES) {
+    if (laneKey === "subagent") continue;
+    const label = document.createElement("div");
+    label.className = "lane-label";
+    label.textContent = laneLabel;
+    tl.appendChild(label);
+
+    const row = document.createElement("div");
+    row.className = "lane-row lane-" + laneKey;
+    for (const e of byLane[laneKey] || []) row.appendChild(blockEl(e));
+    tl.appendChild(row);
+  }
+
+  for (const [parentSid, children] of Object.entries(subsByParent)) {
+    const label = document.createElement("div");
+    label.className = "lane-label";
+    label.textContent = parentSid === "_root" ? "Subagent" : "↳ subagent";
+    label.title = parentSid;
+    tl.appendChild(label);
+
+    const row = document.createElement("div");
+    row.className = "lane-row lane-subagent";
+    for (const e of children) row.appendChild(blockEl(e));
+    tl.appendChild(row);
+  }
+}
+
+function blockEl(e) {
+  const b = document.createElement("div");
+  b.className = `tl-block kind-${cssToken(e.kind)}`;
+  b.innerHTML = `<div class="ts">${formatTime(e.ts)}</div><div class="title">${escapeHtml(e.title || e.kind)}</div>`;
+  b.addEventListener("click", () => showDetail(e));
+  return b;
+}
+
+function showDetail(e) {
+  $("timeline-detail-body").textContent = JSON.stringify(e, null, 2);
+  $("timeline-detail").hidden = false;
+}
+
+// ---------- helpers ----------
+
+async function fetchJSON(url) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`${url} → ${r.status} ${await r.text()}`);
+  return r.json();
+}
+
+function chipClass(state) {
+  if (state === "n/a") return "n-a";
+  return state.replace(/[^a-z0-9]+/g, "-");
+}
+
+function cssToken(s) {
+  return (s || "").replace(/[^a-z0-9_]+/g, "_");
+}
+
+function escapeHtml(s) {
+  return String(s ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function formatTime(ts) {
+  if (!ts) return "—";
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return "—";
+  return d.toISOString().slice(11, 23);
+}
+
+function th(text) {
+  const el = document.createElement("th");
+  el.textContent = text;
+  return el;
+}

--- a/tools/coverage-viewer/ui/app.js
+++ b/tools/coverage-viewer/ui/app.js
@@ -126,31 +126,51 @@ function openFeatures(adapter) {
   const cells = matrixData.cells[adapter] || {};
 
   const rows = matrixData.features.map((f) => {
-    const cap = caps[f.id];
     const scenariosRequiring = matrixData.scenarios.filter((s) =>
       (s.requires || []).includes(f.id),
     );
-    const coveringScenarios = scenariosRequiring.filter(
-      (s) => (cells[s.name] || {}).state === "covered",
-    );
     return {
       feature: f,
-      cap,
+      cap: caps[f.id],
       scenariosRequiring,
-      coveringScenarios,
-      coverageCount: coveringScenarios.length,
+      coverageCount: scenariosRequiring.filter(
+        (s) => (cells[s.name] || {}).state === "covered",
+      ).length,
     };
   });
 
   const stats = {
-    capTrue: rows.filter((r) => r.cap === true).length,
-    capFalse: rows.filter((r) => r.cap === false).length,
-    capUnknown: rows.filter((r) => r.cap === "unknown").length,
-    capMissing: rows.filter((r) => r.cap === undefined).length,
-    coveredAtLeastOnce: rows.filter((r) => r.coverageCount > 0).length,
-    coveredMultiple: rows.filter((r) => r.coverageCount > 1).length,
-    declaredButUntested: rows.filter((r) => r.cap === true && r.coverageCount === 0).length,
+    capTrue: 0, capFalse: 0, capUnknownOrMissing: 0,
+    coveredAtLeastOnce: 0, coveredMultiple: 0, declaredButUntested: 0,
   };
+  for (const r of rows) {
+    if (r.cap === true) stats.capTrue++;
+    else if (r.cap === false) stats.capFalse++;
+    else stats.capUnknownOrMissing++;
+    if (r.coverageCount >= 1) stats.coveredAtLeastOnce++;
+    if (r.coverageCount >= 2) stats.coveredMultiple++;
+    if (r.cap === true && r.coverageCount === 0) stats.declaredButUntested++;
+  }
+
+  // Group rows by category, in declared category order; "Uncategorised" last.
+  const categoryOrder = (matrixData.categories || []).map((c) => c.id);
+  const categoryTitle = Object.fromEntries((matrixData.categories || []).map((c) => [c.id, c.title]));
+  const groups = new Map();
+  for (const id of categoryOrder) groups.set(id, []);
+  for (const r of rows) {
+    const key = r.feature.category || "_uncategorised";
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(r);
+  }
+
+  const groupHTML = [...groups.entries()]
+    .filter(([, list]) => list.length > 0)
+    .map(([id, list]) => `
+      <tbody>
+        <tr class="cat-head"><td colspan="4">${escapeHtml(categoryTitle[id] || "Uncategorised")} <span class="cat-count">${list.length} feature${list.length === 1 ? "" : "s"}</span></td></tr>
+        ${list.map((r) => renderFeatureRow(adapter, r)).join("")}
+      </tbody>
+    `).join("");
 
   body.innerHTML = `
     <h2>${escapeHtml(adapter)} <span style="color:var(--text-dim);font-weight:400">— feature coverage</span></h2>
@@ -159,7 +179,7 @@ function openFeatures(adapter) {
       <span class="stat"><strong>${stats.coveredAtLeastOnce}</strong>/${matrixData.features.length} features covered ≥ 1×</span>
       <span class="stat"><strong>${stats.coveredMultiple}</strong> covered multiple times</span>
       <span class="stat"><strong>${stats.declaredButUntested}</strong> declared but untested</span>
-      <span class="stat"><strong>${stats.capTrue}</strong> capable · <strong>${stats.capUnknown + stats.capMissing}</strong> unknown · <strong>${stats.capFalse}</strong> not capable</span>
+      <span class="stat"><strong>${stats.capTrue}</strong> capable · <strong>${stats.capUnknownOrMissing}</strong> unknown · <strong>${stats.capFalse}</strong> not capable</span>
     </div>
     <table class="features">
       <thead><tr>
@@ -168,12 +188,9 @@ function openFeatures(adapter) {
         <th>Scenarios testing it</th>
         <th>Times covered</th>
       </tr></thead>
-      <tbody>
-        ${rows.map((r) => renderFeatureRow(adapter, r)).join("")}
-      </tbody>
+      ${groupHTML}
     </table>
   `;
-  // Wire scenario links → drilldown modal (replaces features modal).
   body.querySelectorAll("[data-scenario]").forEach((el) => {
     el.addEventListener("click", () => {
       closeModal("features");

--- a/tools/coverage-viewer/ui/app.js
+++ b/tools/coverage-viewer/ui/app.js
@@ -125,7 +125,6 @@ function openFeatures(adapter) {
   const caps = matrixData.capabilities[adapter] || {};
   const cells = matrixData.cells[adapter] || {};
 
-  // For each feature, find scenarios that require it AND their cell state for this adapter.
   const rows = matrixData.features.map((f) => {
     const cap = caps[f.id];
     const scenariosRequiring = matrixData.scenarios.filter((s) =>
@@ -215,16 +214,23 @@ function renderCapChip(cap) {
 
 // ---------- drilldown ----------
 
-async function openDrilldown(adapter, scenario) {
-  const dd = $("drilldown");
-  dd.innerHTML = `<p class="crumb">Loading ${escapeHtml(adapter)} / ${escapeHtml(scenario)}…</p>`;
-  openModal("drilldown");
+async function loadAndRender({ modal, placeholderEl, url, render }) {
+  placeholderEl.innerHTML = `<p class="crumb">Loading…</p>`;
+  openModal(modal);
   try {
-    const d = await fetchJSON(`/api/scenario/${adapter}/${scenario}`);
-    renderDrilldown(d);
+    render(await fetchJSON(url));
   } catch (err) {
-    dd.innerHTML = `<div class="error">${escapeHtml(err.message)}</div>`;
+    placeholderEl.innerHTML = `<div class="error">${escapeHtml(err.message)}</div>`;
   }
+}
+
+function openDrilldown(adapter, scenario) {
+  return loadAndRender({
+    modal: "drilldown",
+    placeholderEl: $("drilldown"),
+    url: `/api/scenario/${adapter}/${scenario}`,
+    render: renderDrilldown,
+  });
 }
 
 function renderDrilldown(d) {
@@ -279,16 +285,13 @@ const LANES = [
   ["subagent", "Subagent"],
 ];
 
-async function openTimeline(adapter, scenario) {
-  $("timeline-meta").innerHTML = `Loading timeline for <strong>${escapeHtml(adapter)} / ${escapeHtml(scenario)}</strong>…`;
-  $("timeline").innerHTML = "";
-  openModal("timeline");
-  try {
-    const t = await fetchJSON(`/api/timeline/${adapter}/${scenario}`);
-    renderTimeline(t);
-  } catch (err) {
-    $("timeline").innerHTML = `<div class="error">${escapeHtml(err.message)}</div>`;
-  }
+function openTimeline(adapter, scenario) {
+  return loadAndRender({
+    modal: "timeline",
+    placeholderEl: $("timeline"),
+    url: `/api/timeline/${adapter}/${scenario}`,
+    render: renderTimeline,
+  });
 }
 
 function renderTimeline(t) {
@@ -305,38 +308,35 @@ function renderTimeline(t) {
     byLane[e.lane].push(e);
   }
 
+  for (const [laneKey, laneLabel] of LANES) {
+    if (laneKey === "subagent") continue;
+    appendLaneRow(tl, laneLabel, byLane[laneKey] || [], laneKey);
+  }
+
+  // Subagents render as nested rows under their parent session, not as one
+  // sibling lane — preserves causality when multiple parents spawn children.
   const subsByParent = {};
   for (const e of byLane.subagent || []) {
     const key = e.parent_id || "_root";
-    if (!subsByParent[key]) subsByParent[key] = [];
-    subsByParent[key].push(e);
+    (subsByParent[key] ||= []).push(e);
   }
-
-  for (const [laneKey, laneLabel] of LANES) {
-    if (laneKey === "subagent") continue;
-    const label = document.createElement("div");
-    label.className = "lane-label";
-    label.textContent = laneLabel;
-    tl.appendChild(label);
-
-    const row = document.createElement("div");
-    row.className = "lane-row lane-" + laneKey;
-    for (const e of byLane[laneKey] || []) row.appendChild(blockEl(e));
-    tl.appendChild(row);
-  }
-
   for (const [parentSid, children] of Object.entries(subsByParent)) {
-    const label = document.createElement("div");
-    label.className = "lane-label";
-    label.textContent = parentSid === "_root" ? "Subagent" : "↳ subagent";
-    label.title = parentSid;
-    tl.appendChild(label);
-
-    const row = document.createElement("div");
-    row.className = "lane-row lane-subagent";
-    for (const e of children) row.appendChild(blockEl(e));
-    tl.appendChild(row);
+    const label = parentSid === "_root" ? "Subagent" : "↳ subagent";
+    appendLaneRow(tl, label, children, "subagent", parentSid);
   }
+}
+
+function appendLaneRow(tl, labelText, entries, laneClass, labelTitle = "") {
+  const label = document.createElement("div");
+  label.className = "lane-label";
+  label.textContent = labelText;
+  if (labelTitle) label.title = labelTitle;
+  tl.appendChild(label);
+
+  const row = document.createElement("div");
+  row.className = "lane-row lane-" + laneClass;
+  for (const e of entries) row.appendChild(blockEl(e));
+  tl.appendChild(row);
 }
 
 function blockEl(e) {
@@ -361,7 +361,6 @@ async function fetchJSON(url) {
 }
 
 function chipClass(state) {
-  if (state === "n/a") return "n-a";
   return state.replace(/[^a-z0-9]+/g, "-");
 }
 

--- a/tools/coverage-viewer/ui/app.js
+++ b/tools/coverage-viewer/ui/app.js
@@ -4,7 +4,6 @@
 const $ = (id) => document.getElementById(id);
 
 let matrixData = null;
-let featureIndex = {};
 
 init();
 
@@ -12,7 +11,6 @@ async function init() {
   bindUI();
   try {
     matrixData = await fetchJSON("/api/matrix");
-    featureIndex = Object.fromEntries(matrixData.features.map((f) => [f.id, f]));
     renderMatrix(matrixData);
     $("matrix-loading").hidden = true;
     $("matrix-wrap").hidden = false;
@@ -126,7 +124,6 @@ function openFeatures(adapter) {
   const body = $("features-body");
   const caps = matrixData.capabilities[adapter] || {};
   const cells = matrixData.cells[adapter] || {};
-  const scenariosByName = Object.fromEntries(matrixData.scenarios.map((s) => [s.name, s]));
 
   // For each feature, find scenarios that require it AND their cell state for this adapter.
   const rows = matrixData.features.map((f) => {
@@ -173,7 +170,7 @@ function openFeatures(adapter) {
         <th>Times covered</th>
       </tr></thead>
       <tbody>
-        ${rows.map((r) => renderFeatureRow(adapter, r, scenariosByName)).join("")}
+        ${rows.map((r) => renderFeatureRow(adapter, r)).join("")}
       </tbody>
     </table>
   `;
@@ -187,7 +184,7 @@ function openFeatures(adapter) {
   openModal("features");
 }
 
-function renderFeatureRow(adapter, r, scenariosByName) {
+function renderFeatureRow(adapter, r) {
   const capChip = renderCapChip(r.cap);
   const scnLinks = r.scenariosRequiring.length === 0
     ? `<span style="color:var(--text-dim)">— no scenario requires this feature —</span>`

--- a/tools/coverage-viewer/ui/index.html
+++ b/tools/coverage-viewer/ui/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Irrlicht — Coverage Viewer</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+  <h1>Coverage Viewer</h1>
+  <p class="sub">Agent × scenario coverage matrix · live from <code>replaydata/</code></p>
+</header>
+
+<main>
+  <section id="matrix-section">
+    <div id="matrix-loading">Loading matrix…</div>
+    <div id="matrix-wrap" hidden>
+      <table id="matrix"></table>
+      <aside id="legend">
+        <h3>Cell states</h3>
+        <ul>
+          <li><span class="chip covered">covered</span> committed fixture exists</li>
+          <li><span class="chip staged-only">staged-only</span> by_adapter present, no fixture yet</li>
+          <li><span class="chip missing-prompt">missing-prompt</span> capability satisfied, scenarios.json missing entry</li>
+          <li><span class="chip n-a">N/A</span> adapter lacks a required capability</li>
+        </ul>
+        <h3>Tips</h3>
+        <ul class="tips">
+          <li>Click a <strong>cell</strong> to open the scenario drilldown.</li>
+          <li>Click an <strong>adapter name</strong> in the column header to see which features that adapter covers.</li>
+        </ul>
+      </aside>
+    </div>
+  </section>
+</main>
+
+<!-- Modal: scenario drilldown -->
+<div class="modal-backdrop" id="drilldown-modal" hidden>
+  <div class="modal-card">
+    <button class="modal-close" data-close="drilldown" aria-label="Close">×</button>
+    <div class="modal-body" id="drilldown"></div>
+  </div>
+</div>
+
+<!-- Modal: timeline (full-width) -->
+<div class="modal-backdrop" id="timeline-modal" hidden>
+  <div class="modal-card wide">
+    <button class="modal-close" data-close="timeline" aria-label="Close">×</button>
+    <div class="modal-body">
+      <div id="timeline-meta"></div>
+      <div id="timeline"></div>
+    </div>
+  </div>
+</div>
+
+<!-- Side panel: timeline event detail (sits on top of timeline modal) -->
+<div class="side-panel" id="timeline-detail" hidden>
+  <button class="modal-close" data-close="detail" aria-label="Close">×</button>
+  <pre id="timeline-detail-body"></pre>
+</div>
+
+<!-- Modal: per-adapter feature coverage -->
+<div class="modal-backdrop" id="features-modal" hidden>
+  <div class="modal-card wide">
+    <button class="modal-close" data-close="features" aria-label="Close">×</button>
+    <div class="modal-body" id="features-body"></div>
+  </div>
+</div>
+
+<script src="app.js" type="module"></script>
+</body>
+</html>

--- a/tools/coverage-viewer/ui/style.css
+++ b/tools/coverage-viewer/ui/style.css
@@ -164,6 +164,8 @@ table.features td.count { text-align: center; color: var(--text-dim); font-famil
 table.features td.count.covered { color: var(--ready); font-weight: 500; }
 table.features td.count.zero { color: var(--text-dim); }
 table.features tr.uncovered td.feature-id { color: var(--text-dim); }
+table.features tr.cat-head td { background: var(--bg); color: var(--text-bright); font-weight: 500; padding: 0.6rem 0.6rem 0.4rem; border-top: 1px solid var(--border); text-transform: none; letter-spacing: 0; font-size: 0.8rem; }
+table.features tr.cat-head .cat-count { color: var(--text-dim); font-size: 0.72rem; font-weight: 400; margin-left: 0.5rem; }
 
 #matrix-loading { color: var(--text-dim); font-size: 0.9rem; padding: 2rem 0; }
 .error { color: var(--danger); padding: 0.75rem; background: rgba(239, 68, 68, 0.08); border: 1px solid var(--danger); border-radius: 4px; }

--- a/tools/coverage-viewer/ui/style.css
+++ b/tools/coverage-viewer/ui/style.css
@@ -1,0 +1,169 @@
+:root {
+  --bg: #050a14;
+  --bg-card: #0c1224;
+  --bg-elev: #131a2e;
+  --border: rgba(138, 92, 246, 0.18);
+  --border-soft: rgba(200, 205, 216, 0.08);
+  --text: #c8cdd8;
+  --text-dim: #6a7388;
+  --text-bright: #e8ecf4;
+  --accent: #8B5CF6;
+  --working: #8B5CF6;
+  --waiting: #FF9500;
+  --ready: #34C759;
+  --neutral: #5a6378;
+  --danger: #ef4444;
+  --warn: #f59e0b;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { background: var(--bg); color: var(--text); font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; }
+
+header { padding: 1.25rem 2rem; border-bottom: 1px solid var(--border); }
+header h1 { font-weight: 500; font-size: 1.1rem; color: var(--text-bright); letter-spacing: 0.05em; }
+header .sub { color: var(--text-dim); font-size: 0.85rem; margin-top: 0.25rem; }
+header code { background: var(--bg-card); padding: 0.1rem 0.4rem; border-radius: 3px; }
+
+main { padding: 1.5rem 2rem 4rem; max-width: 1400px; }
+
+section { margin-bottom: 2rem; }
+
+/* ---- matrix ---- */
+#matrix-wrap { display: grid; grid-template-columns: 1fr 280px; gap: 2rem; align-items: start; }
+
+table#matrix { border-collapse: collapse; width: 100%; }
+table#matrix th, table#matrix td { padding: 0.4rem 0.6rem; text-align: left; border-bottom: 1px solid var(--border-soft); font-size: 0.85rem; }
+table#matrix th { color: var(--text-dim); font-weight: 500; text-transform: uppercase; letter-spacing: 0.06em; font-size: 0.7rem; position: sticky; top: 0; background: var(--bg); }
+table#matrix th.adapter { text-align: center; cursor: pointer; transition: color 0.15s; }
+table#matrix th.adapter:hover { color: var(--accent); }
+table#matrix th.adapter .hint { display: block; color: var(--text-dim); font-size: 0.6rem; font-weight: 400; opacity: 0.6; margin-top: 0.1rem; }
+table#matrix tr.group-head td { background: var(--bg-card); color: var(--text-bright); font-weight: 500; padding-top: 0.8rem; padding-bottom: 0.4rem; border-top: 2px solid var(--border); }
+table#matrix tr.group-head .req { color: var(--text-dim); font-size: 0.75rem; margin-left: 0.5rem; font-weight: 400; }
+table#matrix td.scenario { color: var(--text-bright); }
+table#matrix td.scenario .desc { color: var(--text-dim); font-size: 0.75rem; margin-top: 0.15rem; }
+table#matrix td.cell { text-align: center; cursor: pointer; }
+table#matrix td.cell:hover { background: rgba(138, 92, 246, 0.06); }
+
+.chip { display: inline-block; padding: 0.15rem 0.55rem; border-radius: 99px; font-size: 0.72rem; font-weight: 500; letter-spacing: 0.04em; text-transform: lowercase; }
+.chip.covered { background: rgba(52, 199, 89, 0.15); color: var(--ready); }
+.chip.staged-only { background: rgba(255, 149, 0, 0.15); color: var(--waiting); }
+.chip.missing-prompt { background: rgba(139, 92, 246, 0.15); color: var(--working); }
+.chip.n-a { background: rgba(90, 99, 120, 0.18); color: var(--neutral); }
+.chip.cap-true { background: rgba(52, 199, 89, 0.15); color: var(--ready); }
+.chip.cap-false { background: rgba(239, 68, 68, 0.15); color: var(--danger); }
+.chip.cap-unknown { background: rgba(90, 99, 120, 0.18); color: var(--neutral); }
+
+#legend { background: var(--bg-card); border: 1px solid var(--border); border-radius: 6px; padding: 1rem; font-size: 0.8rem; }
+#legend h3 { color: var(--text-bright); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 0.5rem; margin-top: 0.75rem; font-weight: 500; }
+#legend h3:first-child { margin-top: 0; }
+#legend ul { list-style: none; }
+#legend li { padding: 0.25rem 0; color: var(--text-dim); }
+#legend ul.tips li { color: var(--text); }
+#legend ul.tips strong { color: var(--text-bright); font-weight: 500; }
+
+/* ---- modal scaffolding ---- */
+.modal-backdrop {
+  position: fixed; inset: 0; background: rgba(5, 10, 20, 0.75);
+  backdrop-filter: blur(4px);
+  display: flex; align-items: flex-start; justify-content: center;
+  padding: 4vh 2rem; z-index: 100; overflow-y: auto;
+}
+.modal-backdrop[hidden] { display: none; }
+.modal-card {
+  position: relative; background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px;
+  padding: 2rem 2rem 2.5rem; width: 100%; max-width: 800px;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6);
+}
+.modal-card.wide { max-width: 1200px; }
+.modal-close {
+  position: absolute; top: 0.75rem; right: 0.75rem;
+  background: none; border: 1px solid var(--border); color: var(--text-dim);
+  width: 28px; height: 28px; border-radius: 4px; cursor: pointer; font-size: 1.1rem; line-height: 1;
+}
+.modal-close:hover { color: var(--text-bright); border-color: var(--accent); background: rgba(139, 92, 246, 0.1); }
+
+/* ---- drilldown ---- */
+#drilldown h2 { color: var(--text-bright); font-size: 1.1rem; font-weight: 500; margin-bottom: 0.25rem; }
+#drilldown .crumb { color: var(--text-dim); font-size: 0.85rem; margin-bottom: 1rem; }
+#drilldown .meta { display: grid; grid-template-columns: 120px 1fr; gap: 0.4rem 1rem; margin-bottom: 1.5rem; font-size: 0.85rem; }
+#drilldown .meta dt { color: var(--text-dim); }
+#drilldown .meta dd { color: var(--text); }
+#drilldown .meta dd code, #drilldown .meta dd pre { background: var(--bg); padding: 0.4rem 0.6rem; border-radius: 3px; font-size: 0.78rem; display: block; white-space: pre-wrap; word-break: break-word; }
+
+#drilldown .steps { display: flex; flex-direction: column; gap: 0.6rem; }
+.step { background: var(--bg); border: 1px solid var(--border-soft); border-radius: 4px; padding: 0.75rem 1rem; }
+.step h4 { color: var(--text-bright); font-size: 0.9rem; font-weight: 500; margin-bottom: 0.3rem; display: flex; gap: 0.6rem; align-items: baseline; }
+.step h4 .num { color: var(--accent); font-family: ui-monospace, monospace; font-size: 0.75rem; }
+.step p { color: var(--text); font-size: 0.85rem; margin-bottom: 0.4rem; }
+.step a { color: var(--accent); font-size: 0.78rem; text-decoration: none; font-family: ui-monospace, monospace; }
+.step a:hover { text-decoration: underline; }
+
+#drilldown .verify { margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--border-soft); }
+#drilldown .verify h4 { color: var(--text-bright); font-size: 0.85rem; margin-bottom: 0.4rem; font-weight: 500; }
+#drilldown .verify ul { list-style: none; font-size: 0.82rem; }
+#drilldown .verify li { padding: 0.15rem 0; color: var(--text); }
+#drilldown .verify code { color: var(--accent); font-size: 0.78rem; }
+
+button.timeline-btn { margin-top: 1rem; background: rgba(139, 92, 246, 0.15); color: var(--accent); border: 1px solid var(--accent); padding: 0.5rem 1rem; border-radius: 4px; cursor: pointer; font-size: 0.85rem; }
+button.timeline-btn:hover { background: rgba(139, 92, 246, 0.25); }
+button.timeline-btn:disabled { opacity: 0.4; cursor: not-allowed; border-color: var(--border-soft); color: var(--text-dim); background: transparent; }
+
+/* ---- timeline ---- */
+#timeline-meta { color: var(--text-dim); font-size: 0.85rem; margin-bottom: 1rem; }
+#timeline-meta strong { color: var(--text-bright); }
+#timeline-meta .note { display: block; color: var(--waiting); margin-top: 0.4rem; font-style: italic; }
+
+#timeline { display: grid; grid-template-columns: 130px 1fr; gap: 4px; align-items: stretch; max-height: 70vh; overflow-y: auto; padding-right: 0.5rem; }
+.lane-label { color: var(--text-dim); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em; padding: 0.5rem 0.75rem; align-self: start; border-right: 1px solid var(--border-soft); position: sticky; left: 0; background: var(--bg-card); }
+.lane-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 0.4rem 0.5rem; min-height: 2rem; align-content: flex-start; }
+.lane-row.lane-driver { background: rgba(139, 92, 246, 0.04); }
+.lane-row.lane-agent { background: rgba(52, 199, 89, 0.04); }
+.lane-row.lane-tool_result { background: rgba(255, 149, 0, 0.04); }
+.lane-row.lane-hook { background: rgba(239, 68, 68, 0.04); }
+.lane-row.lane-daemon { background: rgba(255, 255, 255, 0.02); }
+.lane-row.lane-subagent { background: rgba(139, 92, 246, 0.08); border-left: 2px solid var(--accent); }
+
+.tl-block { background: var(--bg); border: 1px solid var(--border-soft); border-radius: 3px; padding: 0.3rem 0.55rem; font-size: 0.78rem; cursor: pointer; max-width: 100%; transition: border-color 0.15s; }
+.tl-block:hover { border-color: var(--accent); }
+.tl-block .ts { color: var(--text-dim); font-size: 0.68rem; font-family: ui-monospace, monospace; }
+.tl-block .title { color: var(--text); margin-top: 0.1rem; word-break: break-word; }
+.tl-block.kind-state_transition .title { color: var(--working); font-weight: 500; }
+.tl-block.kind-tool_call .title { color: var(--waiting); }
+.tl-block.kind-tool_result .title { color: var(--ready); }
+
+/* ---- timeline detail side panel ---- */
+.side-panel {
+  position: fixed; right: 1rem; top: 1rem; bottom: 1rem; width: 360px;
+  background: var(--bg-elev); border: 1px solid var(--border); border-radius: 8px;
+  padding: 2.5rem 1rem 1rem; overflow: auto; z-index: 110;
+  box-shadow: -8px 0 32px rgba(0, 0, 0, 0.5);
+}
+.side-panel[hidden] { display: none; }
+.side-panel pre { font-family: ui-monospace, monospace; font-size: 0.72rem; color: var(--text); white-space: pre-wrap; word-break: break-word; }
+
+/* ---- features (per-adapter coverage) ---- */
+#features-body h2 { color: var(--text-bright); font-size: 1.1rem; font-weight: 500; margin-bottom: 0.25rem; }
+#features-body .crumb { color: var(--text-dim); font-size: 0.85rem; margin-bottom: 1rem; }
+#features-body .summary { display: flex; gap: 1.5rem; padding: 0.75rem 1rem; background: var(--bg); border: 1px solid var(--border-soft); border-radius: 4px; margin-bottom: 1rem; font-size: 0.85rem; flex-wrap: wrap; }
+#features-body .summary .stat { color: var(--text-dim); }
+#features-body .summary .stat strong { color: var(--text-bright); margin-right: 0.3rem; font-weight: 500; }
+table.features { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+table.features th { text-align: left; color: var(--text-dim); font-weight: 500; text-transform: uppercase; letter-spacing: 0.06em; font-size: 0.68rem; padding: 0.5rem 0.6rem; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: var(--bg-card); }
+table.features td { padding: 0.5rem 0.6rem; border-bottom: 1px solid var(--border-soft); vertical-align: top; }
+table.features td.feature-id { color: var(--text-bright); font-family: ui-monospace, monospace; font-size: 0.78rem; white-space: nowrap; }
+table.features td.feature-id .desc { display: block; color: var(--text-dim); font-family: -apple-system, system-ui, sans-serif; font-size: 0.75rem; font-weight: 400; margin-top: 0.15rem; max-width: 24rem; }
+table.features td.cap { white-space: nowrap; }
+table.features td.scenarios { color: var(--text); }
+table.features td.scenarios .scn-link { display: inline-block; margin: 0.1rem 0.3rem 0.1rem 0; padding: 0.1rem 0.5rem; border: 1px solid var(--border-soft); border-radius: 3px; cursor: pointer; font-size: 0.78rem; color: var(--text); }
+table.features td.scenarios .scn-link:hover { border-color: var(--accent); color: var(--accent); }
+table.features td.scenarios .scn-link.covered { border-color: rgba(52, 199, 89, 0.4); }
+table.features td.scenarios .scn-link.missing-prompt { border-color: rgba(139, 92, 246, 0.4); opacity: 0.7; }
+table.features td.scenarios .scn-link.staged-only { border-color: rgba(255, 149, 0, 0.4); opacity: 0.7; }
+table.features td.scenarios .scn-link.n-a { border-color: var(--border-soft); opacity: 0.4; }
+table.features td.count { text-align: center; color: var(--text-dim); font-family: ui-monospace, monospace; }
+table.features td.count.covered { color: var(--ready); font-weight: 500; }
+table.features td.count.zero { color: var(--text-dim); }
+table.features tr.uncovered td.feature-id { color: var(--text-dim); }
+
+#matrix-loading { color: var(--text-dim); font-size: 0.9rem; padding: 2rem 0; }
+.error { color: var(--danger); padding: 0.75rem; background: rgba(239, 68, 68, 0.08); border: 1px solid var(--danger); border-radius: 4px; }


### PR DESCRIPTION
Closes #222.

## Summary

- New `tools/coverage-viewer/` Go binary that serves an internal dev webview for the agent × scenario coverage matrix.
- **Matrix view** — every (adapter × scenario) cell color-coded as `covered` / `staged-only` / `missing-prompt` / `n/a`, derived live from `replaydata/agents/*` and `.claude/skills/ir:onboard-agent/scenarios.json`. No precompute, no cache.
- **Drilldown modal** — click a cell → 6-step pipeline (precheck / daemon / driver / curate / replay / verify) with GitHub permalinks pinned to the current `git rev-parse HEAD`, plus the live `by_adapter` prompt+settings and `verify` block.
- **Timeline modal** — for any committed fixture, a swim-lane view (driver / agent / tool result / hook / daemon state / subagent) merged from `events.jsonl` + `transcript.jsonl` (normalized via the per-adapter parser in `core/adapters/inbound/agents/<adapter>/parser.go`) + nested `subagents/*.jsonl`. Click a block for the raw payload.
- **Feature-coverage modal** — click an adapter name in the column header → per-adapter table showing each feature's declared capability, which scenarios test it, and how many times it's covered.

Lives in `tools/` (new top-level dir) to keep dev-only tooling out of `core/`. Wired into `go.work` as a separate Go module that depends on `irrlicht/core` for the parser library.

## Run

```sh
cd tools/coverage-viewer && go run .
open http://127.0.0.1:7838/
```

The binary auto-detects the repo root by walking up for `go.work` or `.git`.

## Known limits (deferred to follow-ups)

- **Driver lane** only shows the dispatched prompt — committed fixtures don't include literal driver `tmux send-keys`.
- **Aider transcripts** are markdown, not JSONL; aider timelines show daemon-side events only with a "transcript not parsed" note.
- **Replay-report mismatch markers** are stubbed out — `replaydata/agents/_reports/` is empty today.

## Test plan

- [ ] `cd tools/coverage-viewer && go run .` starts the server on `127.0.0.1:7838`.
- [ ] Matrix renders 4 adapters (aider, claudecode, codex, pi) × 4 canonical scenarios; spot-check `claudecode/baseline-hello` = covered, `codex/permission-hook-denial` = n/a (no `permission_hooks` cap).
- [ ] Click a covered cell → drilldown modal opens with 6 steps and resolvable GitHub links.
- [ ] Click "View timeline →" on `claudecode/baseline-hello` → swim-lane timeline renders.
- [ ] Click an adapter name in the column header → feature-coverage modal renders with declared cap, scenarios-testing-it chips, and a count column.
- [ ] Click a scenario chip inside the feature modal → drilldown opens.
- [ ] ESC closes the topmost modal; backdrop click closes too.
- [ ] Append a fake scenario to `scenarios.json` (no `by_adapter`) → matrix shows it as `missing-prompt` across all adapters with no code change. Revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)