### PR TITLE
Homebrew cask via own tap (#187)

### DIFF
--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -166,10 +166,26 @@ cd /tmp && shasum -a 256 \
   > checksums.sha256
 ```
 
+## Step 6.5: Update Homebrew Cask
+
+Bump the cask in `tools/homebrew-tap/Casks/irrlicht.rb` to `$NEW_VERSION`
+with the sha256 of the freshly built DMG. The same script also syncs to the
+external tap repo (`ingo-eichhorst/homebrew-irrlicht`) when
+`IRRLICHT_TAP_DIR` is set — but skip the `--push` flag here so the local
+in-repo template gets committed alongside the release in Step 7 first;
+external publish happens in Step 8.5 after the GitHub release exists.
+
+```bash
+tools/homebrew-tap/update-cask.sh --version "$NEW_VERSION"
+```
+
+Without `IRRLICHT_TAP_DIR` set, this only updates the in-repo template —
+fine for first releases before the tap repo exists.
+
 ## Step 7: Commit, Tag, Push
 
 ```bash
-git add version.json CHANGELOG.md site/ platforms/macos/Irrlicht/Resources/Info.plist
+git add version.json CHANGELOG.md site/ platforms/macos/Irrlicht/Resources/Info.plist tools/homebrew-tap/Casks/irrlicht.rb
 git commit -m "chore: release v$NEW_VERSION"
 git tag v$NEW_VERSION
 git push origin main --tags
@@ -187,6 +203,24 @@ gh release create v$NEW_VERSION \
   --title "v$NEW_VERSION" \
   --notes "<drafted release notes from Step 2>"
 ```
+
+## Step 8.5: Publish Cask to External Tap
+
+Push the bumped cask to `ingo-eichhorst/homebrew-irrlicht` so
+`brew install --cask irrlicht` resolves to the new version. Requires
+`IRRLICHT_TAP_DIR` to point at a clone of the tap repo.
+
+```bash
+tools/homebrew-tap/update-cask.sh --version "$NEW_VERSION" --push
+```
+
+**Failure handling:** if the push fails (tap repo offline, auth issue,
+etc.), log a warning but **do not roll back the GitHub release**. The cask
+can be republished later by re-running the script — version + sha256 are
+already pinned in the in-repo template from Step 6.5.
+
+If the tap repo doesn't exist yet, this step is a no-op (the script exits 0
+when `IRRLICHT_TAP_DIR` isn't set).
 
 ## Step 9: Verify
 

--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -210,14 +210,17 @@ Push the bumped cask to `ingo-eichhorst/homebrew-irrlicht` so
 `brew install --cask irrlicht` resolves to the new version. Requires
 `IRRLICHT_TAP_DIR` to point at a clone of the tap repo.
 
-```bash
-tools/homebrew-tap/update-cask.sh --version "$NEW_VERSION" --push
-```
+The `||` fallback below is load-bearing: the script uses `set -e` and exits
+non-zero on tap failures (offline, auth, rebase conflict). The release
+itself is already on GitHub at this point, so we explicitly **do not**
+propagate that failure — log a warning and move on. The cask can be
+republished later by re-running the script; version + sha256 are already
+pinned in the in-repo template from Step 6.5.
 
-**Failure handling:** if the push fails (tap repo offline, auth issue,
-etc.), log a warning but **do not roll back the GitHub release**. The cask
-can be republished later by re-running the script — version + sha256 are
-already pinned in the in-repo template from Step 6.5.
+```bash
+tools/homebrew-tap/update-cask.sh --version "$NEW_VERSION" --push \
+  || echo "WARNING: cask publish failed — re-run later. GitHub release is unaffected."
+```
 
 If the tap repo doesn't exist yet, this step is a no-op (the script exits 0
 when `IRRLICHT_TAP_DIR` isn't set).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,14 @@ Irrlicht claims a narrower, more opinionated slot in that third camp:
 
 ## Install
 
-**DMG (recommended):**
+**Homebrew (recommended):**
+
+```sh
+brew tap ingo-eichhorst/irrlicht
+brew install --cask irrlicht
+```
+
+**DMG:**
 
 1. Download `Irrlicht-<version>.dmg` from [Releases](https://github.com/ingo-eichhorst/Irrlicht/releases)
 2. Open the DMG and drag **Irrlicht.app** to **Applications**

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -97,8 +97,20 @@
         <li><strong>Xcode Command Line Tools</strong> &mdash; install with <code>xcode-select --install</code></li>
       </ul>
 
+      <!-- ── Homebrew Install ── -->
+      <h2>Install via Homebrew (Recommended)</h2>
+
+      <p>For Mac users with <a href="https://brew.sh">Homebrew</a>, this is the simplest path. The cask points at the same signed DMG as the GitHub release, strips the quarantine attribute on first install, and lets <code>brew upgrade</code> handle future versions.</p>
+
+      <pre><code>brew tap ingo-eichhorst/irrlicht
+brew install --cask irrlicht</code></pre>
+
+      <p>To upgrade later:</p>
+
+      <pre><code>brew upgrade --cask irrlicht</code></pre>
+
       <!-- ── Curl Install ── -->
-      <h2>Install via curl (Recommended)</h2>
+      <h2>Install via curl</h2>
 
       <p>One command. No Gatekeeper prompts. The script downloads the signed app, verifies the SHA-256 checksum, strips the quarantine attribute, and launches it.</p>
 

--- a/tools/homebrew-tap/Casks/irrlicht.rb
+++ b/tools/homebrew-tap/Casks/irrlicht.rb
@@ -26,12 +26,13 @@ cask "irrlicht" do
                    sudo: false
   end
 
-  uninstall launchctl: "io.irrlicht.app.daemon",
-            quit:      "io.irrlicht.app"
+  # The cask install path doesn't register a LaunchAgent — the menu-bar app
+  # spawns the embedded daemon itself. Power users who installed the
+  # optional plist by hand can rm it themselves.
+  uninstall quit: "io.irrlicht.app"
 
   zap trash: [
     "~/Library/Application Support/Irrlicht",
-    "~/Library/LaunchAgents/io.irrlicht.app.daemon.plist",
     "~/Library/Preferences/io.irrlicht.app.plist",
   ]
 end

--- a/tools/homebrew-tap/Casks/irrlicht.rb
+++ b/tools/homebrew-tap/Casks/irrlicht.rb
@@ -1,0 +1,37 @@
+cask "irrlicht" do
+  version "0.3.8"
+  sha256 "ca21dcf9b1e425ffd20e72a0e6e92b19b1764ad573d8db2a13d90f2b072c7276"
+
+  url "https://github.com/ingo-eichhorst/Irrlicht/releases/download/v#{version}/Irrlicht-#{version}.dmg",
+      verified: "github.com/ingo-eichhorst/Irrlicht/"
+  name "Irrlicht"
+  desc "Menu-bar telemetry for AI coding agents"
+  homepage "https://irrlicht.io/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: ">= :ventura"
+
+  app "Irrlicht.app"
+
+  # The DMG is ad-hoc signed but not Apple-notarized. Strip the quarantine
+  # attribute so Gatekeeper won't block first launch. Remove this once the
+  # release flow notarizes (issue #187 follow-up).
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Irrlicht.app"],
+                   sudo: false
+  end
+
+  uninstall launchctl: "io.irrlicht.app.daemon",
+            quit:      "io.irrlicht.app"
+
+  zap trash: [
+    "~/Library/Application Support/Irrlicht",
+    "~/Library/LaunchAgents/io.irrlicht.app.daemon.plist",
+    "~/Library/Preferences/io.irrlicht.app.plist",
+  ]
+end

--- a/tools/homebrew-tap/update-cask.sh
+++ b/tools/homebrew-tap/update-cask.sh
@@ -91,15 +91,24 @@ mkdir -p "$IRRLICHT_TAP_DIR/Casks"
 cp "$CASK_FILE" "$IRRLICHT_TAP_DIR/Casks/irrlicht.rb"
 
 cd "$IRRLICHT_TAP_DIR"
-if git diff --quiet Casks/irrlicht.rb; then
+
+# Stage first, then check the index — `git diff --quiet` reports no diff for
+# untracked files, which would silently no-op a fresh tap clone.
+git add Casks/irrlicht.rb
+if git diff --cached --quiet -- Casks/irrlicht.rb; then
     echo "tap repo already at $VERSION — nothing to commit."
     exit 0
 fi
 
-git add Casks/irrlicht.rb
 git commit -m "irrlicht $VERSION"
 
 if [ "$PUSH" -eq 1 ]; then
+    # Rebase on top of remote first to avoid non-fast-forward push failures
+    # when another machine has already advanced the tap.
+    git pull --rebase --autostash || {
+        echo "ERROR: rebase failed — resolve manually in $IRRLICHT_TAP_DIR" >&2
+        exit 1
+    }
     git push origin HEAD
     echo "pushed to $(git remote get-url origin)"
 else

--- a/tools/homebrew-tap/update-cask.sh
+++ b/tools/homebrew-tap/update-cask.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# update-cask.sh — bump the Homebrew cask to a new version + DMG sha256.
+#
+# Updates tools/homebrew-tap/Casks/irrlicht.rb in this repo (the canonical
+# template). If IRRLICHT_TAP_DIR points at a clone of the external tap repo
+# (ingo-eichhorst/homebrew-irrlicht), the file is also copied there and
+# committed; pass --push to push to origin.
+#
+# Usage:
+#   tools/homebrew-tap/update-cask.sh [--version X.Y.Z] [--dmg path] [--push]
+#
+# Defaults:
+#   --version  read from version.json
+#   --dmg      .build/Irrlicht-<version>.dmg, fallback /tmp/Irrlicht-<version>.dmg
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CASK_FILE="$SCRIPT_DIR/Casks/irrlicht.rb"
+
+VERSION=""
+DMG_PATH=""
+PUSH=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --version) VERSION="$2"; shift 2 ;;
+        --dmg)     DMG_PATH="$2"; shift 2 ;;
+        --push)    PUSH=1; shift ;;
+        -h|--help) sed -n '2,15p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    VERSION=$(python3 -c "import json; print(json.load(open('$ROOT_DIR/version.json'))['version'])")
+fi
+
+if [ -z "$DMG_PATH" ]; then
+    if [ -f "$ROOT_DIR/.build/Irrlicht-$VERSION.dmg" ]; then
+        DMG_PATH="$ROOT_DIR/.build/Irrlicht-$VERSION.dmg"
+    elif [ -f "/tmp/Irrlicht-$VERSION.dmg" ]; then
+        DMG_PATH="/tmp/Irrlicht-$VERSION.dmg"
+    else
+        echo "DMG not found at .build/ or /tmp/ for version $VERSION" >&2
+        echo "pass --dmg <path>" >&2
+        exit 1
+    fi
+fi
+
+if [ ! -f "$DMG_PATH" ]; then
+    echo "DMG does not exist: $DMG_PATH" >&2
+    exit 1
+fi
+
+if [ ! -f "$CASK_FILE" ]; then
+    echo "cask template missing: $CASK_FILE" >&2
+    exit 1
+fi
+
+SHA=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
+
+echo "version: $VERSION"
+echo "dmg:     $DMG_PATH"
+echo "sha256:  $SHA"
+
+python3 - "$CASK_FILE" "$VERSION" "$SHA" <<'PY'
+import re, sys
+path, version, sha = sys.argv[1], sys.argv[2], sys.argv[3]
+src = open(path).read()
+src = re.sub(r'(version\s+)"[^"]+"', f'\\1"{version}"', src, count=1)
+src = re.sub(r'(sha256\s+)"[0-9a-fA-F]{64}"', f'\\1"{sha}"', src, count=1)
+open(path, "w").write(src)
+PY
+
+echo "updated $CASK_FILE"
+
+if [ -z "${IRRLICHT_TAP_DIR:-}" ]; then
+    echo "IRRLICHT_TAP_DIR not set — skipping external tap sync."
+    echo "set IRRLICHT_TAP_DIR=<path to homebrew-irrlicht clone> to publish."
+    exit 0
+fi
+
+if [ ! -d "$IRRLICHT_TAP_DIR/.git" ]; then
+    echo "IRRLICHT_TAP_DIR is not a git repo: $IRRLICHT_TAP_DIR" >&2
+    exit 1
+fi
+
+mkdir -p "$IRRLICHT_TAP_DIR/Casks"
+cp "$CASK_FILE" "$IRRLICHT_TAP_DIR/Casks/irrlicht.rb"
+
+cd "$IRRLICHT_TAP_DIR"
+if git diff --quiet Casks/irrlicht.rb; then
+    echo "tap repo already at $VERSION — nothing to commit."
+    exit 0
+fi
+
+git add Casks/irrlicht.rb
+git commit -m "irrlicht $VERSION"
+
+if [ "$PUSH" -eq 1 ]; then
+    git push origin HEAD
+    echo "pushed to $(git remote get-url origin)"
+else
+    echo "committed locally in $IRRLICHT_TAP_DIR — pass --push to publish."
+fi

--- a/tools/homebrew-tap/update-cask.sh
+++ b/tools/homebrew-tap/update-cask.sh
@@ -5,13 +5,6 @@
 # template). If IRRLICHT_TAP_DIR points at a clone of the external tap repo
 # (ingo-eichhorst/homebrew-irrlicht), the file is also copied there and
 # committed; pass --push to push to origin.
-#
-# Usage:
-#   tools/homebrew-tap/update-cask.sh [--version X.Y.Z] [--dmg path] [--push]
-#
-# Defaults:
-#   --version  read from version.json
-#   --dmg      .build/Irrlicht-<version>.dmg, fallback /tmp/Irrlicht-<version>.dmg
 
 set -euo pipefail
 
@@ -23,13 +16,23 @@ VERSION=""
 DMG_PATH=""
 PUSH=0
 
+usage() {
+    cat <<'HELP'
+Usage: update-cask.sh [--version X.Y.Z] [--dmg path] [--push]
+
+  --version  bump to this version (default: read from version.json)
+  --dmg      DMG path to hash (default: probe .build/ then /tmp/)
+  --push     git push the bumped cask in $IRRLICHT_TAP_DIR
+HELP
+}
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --version) VERSION="$2"; shift 2 ;;
         --dmg)     DMG_PATH="$2"; shift 2 ;;
         --push)    PUSH=1; shift ;;
-        -h|--help) sed -n '2,15p' "$0"; exit 0 ;;
-        *) echo "unknown arg: $1" >&2; exit 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; usage >&2; exit 2 ;;
     esac
 done
 
@@ -37,25 +40,18 @@ if [ -z "$VERSION" ]; then
     VERSION=$(python3 -c "import json; print(json.load(open('$ROOT_DIR/version.json'))['version'])")
 fi
 
+DMG_CANDIDATES=(
+    "$ROOT_DIR/.build/Irrlicht-$VERSION.dmg"
+    "/tmp/Irrlicht-$VERSION.dmg"
+)
 if [ -z "$DMG_PATH" ]; then
-    if [ -f "$ROOT_DIR/.build/Irrlicht-$VERSION.dmg" ]; then
-        DMG_PATH="$ROOT_DIR/.build/Irrlicht-$VERSION.dmg"
-    elif [ -f "/tmp/Irrlicht-$VERSION.dmg" ]; then
-        DMG_PATH="/tmp/Irrlicht-$VERSION.dmg"
-    else
-        echo "DMG not found at .build/ or /tmp/ for version $VERSION" >&2
-        echo "pass --dmg <path>" >&2
-        exit 1
-    fi
+    for candidate in "${DMG_CANDIDATES[@]}"; do
+        [ -f "$candidate" ] && { DMG_PATH="$candidate"; break; }
+    done
 fi
 
-if [ ! -f "$DMG_PATH" ]; then
-    echo "DMG does not exist: $DMG_PATH" >&2
-    exit 1
-fi
-
-if [ ! -f "$CASK_FILE" ]; then
-    echo "cask template missing: $CASK_FILE" >&2
+if [ -z "$DMG_PATH" ] || [ ! -f "$DMG_PATH" ]; then
+    echo "DMG not found for version $VERSION (probed: ${DMG_CANDIDATES[*]}) — pass --dmg <path>" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Closes #187. Follow-up: #233 (notarize DMG, drop quarantine workaround).

## Summary

- Adds `brew tap ingo-eichhorst/irrlicht && brew install --cask irrlicht` as the recommended install path.
- Tap repo seeded at https://github.com/ingo-eichhorst/homebrew-irrlicht (v0.3.8, `brew style` + `brew audit --cask` clean).
- `tools/homebrew-tap/update-cask.sh` automates the per-release bump (version + DMG sha256) and pushes to the tap clone via `IRRLICHT_TAP_DIR`.
- `/ir:release` skill grows two steps: 6.5 (update in-repo cask before release commit) and 8.5 (publish to external tap after `gh release create`). Both are no-ops when `IRRLICHT_TAP_DIR` is unset, so unrelated releases won't break.
- The cask `postflight` strips `com.apple.quarantine` because the DMG is only ad-hoc signed. Removing this depends on Apple notarization → tracked separately in #233 (milestone v0.5, gated on the 75-star homebrew-cask notability bar).

## Test plan

- [x] `brew style ingo-eichhorst/irrlicht/irrlicht` — clean
- [x] `brew audit --cask --tap ingo-eichhorst/irrlicht ingo-eichhorst/irrlicht/irrlicht` — exit 0
- [x] `brew tap ingo-eichhorst/irrlicht && brew info --cask irrlicht` resolves to v0.3.8 from GitHub
- [x] `update-cask.sh` smoke test (fake DMG → version + sha256 patched correctly)
- [ ] End-to-end on next `/ir:release`: set `IRRLICHT_TAP_DIR=~/projects/homebrew-irrlicht`, run release, verify `brew upgrade --cask irrlicht` picks up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)