### PR TITLE
fix: survive SendMessage tool across turn_done (#81)

### DIFF
--- a/core/pkg/tailer/tailer_config.go
+++ b/core/pkg/tailer/tailer_config.go
@@ -11,12 +11,15 @@ import (
 // turn_done event. These must not be swept from openToolCalls:
 //
 //   - Agent: sub-agents can still be running when the parent's turn ends.
+//   - SendMessage: continues a previously spawned sub-agent (Claude Code 2.1.77
+//     replaced Agent({resume}) with SendMessage({to}) for resumption). Same
+//     rationale as Agent — the sub-agent runs in the background.
 //   - AskUserQuestion, ExitPlanMode: user-blocking tools whose result only
 //     arrives after the user responds. Also listed in session.isUserBlockingTool;
 //     the overlap is intentional — the two predicates serve different purposes.
 func surviveTurnDone(name string) bool {
 	switch name {
-	case "Agent", "AskUserQuestion", "ExitPlanMode":
+	case "Agent", "SendMessage", "AskUserQuestion", "ExitPlanMode":
 		return true
 	}
 	return false

--- a/core/pkg/tailer/tool_call_test.go
+++ b/core/pkg/tailer/tool_call_test.go
@@ -1044,12 +1044,39 @@ func TestIDTracking_AgentSurvivesTurnDone(t *testing.T) {
 	}
 }
 
+func TestIDTracking_SendMessageSurvivesTurnDone(t *testing.T) {
+	// Claude Code 2.1.77 replaced Agent({resume}) with SendMessage({to}) for
+	// resuming background sub-agents. SendMessage's tool_result arrives after
+	// turn_done just like Agent's, so it must survive the sweep.
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "tool_use", "id": "tu_send", "name": "SendMessage", "timestamp": ts(0)},
+		{"type": "tool_use", "id": "tu_bash", "name": "Bash", "timestamp": ts(1)}, // leaked
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(2)},
+	})
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m.HasOpenToolCall {
+		t.Error("expected HasOpenToolCall=true with SendMessage still open")
+	}
+	if m.OpenToolCallCount != 1 {
+		t.Errorf("expected OpenToolCallCount=1 (SendMessage only), got %d", m.OpenToolCallCount)
+	}
+	if len(m.LastOpenToolNames) != 1 || m.LastOpenToolNames[0] != "SendMessage" {
+		t.Errorf("expected [SendMessage], got %v", m.LastOpenToolNames)
+	}
+}
+
 func TestSurviveTurnDone(t *testing.T) {
 	tests := []struct {
 		name string
 		want bool
 	}{
 		{"Agent", true},
+		{"SendMessage", true},
 		{"AskUserQuestion", true},
 		{"ExitPlanMode", true},
 		{"Bash", false},


### PR DESCRIPTION
## Summary

Investigation pass for #81 (upstream agent changes affecting monitoring). Verified all 7 items against locally-installed agent versions and made the one code change that was actually needed.

**Code change:** added `SendMessage` to `surviveTurnDone()` in `core/pkg/tailer/tailer_config.go` so the tool_use entry for resuming a background sub-agent (Claude Code 2.1.77+ replaced `Agent({resume})` with `SendMessage({to})`) isn't swept from `openToolCalls` at `turn_done`. Same rationale as `Agent`. Two unit tests added (table case + transcript-driven survival test).

## Verification of issue items

Versions installed: Pi 0.70.0, Gas Town v1.0.0, Claude Code 2.1.119, Codex 0.125.0.

| # | Item | Outcome |
|---|---|---|
| HIGH | Pi v0.62 session dir | `~/.pi/agent/sessions/--<cwd>--/<ts>_<uuid>.jsonl` still in use today on Pi 0.70 → no change |
| MED | Gas Town Boot/Dog role | `RoleBoot`/`RoleDog`/`roleMeta` already present; `DeriveGasTownRole` already parses `deacon/dogs/...`; verified `gt boot status --json` and `gt dog list --json` shapes match `bootStatus` / `dogState` → no change |
| MED | SendMessage replacing Agent({resume}) | **Code change in this PR** |
| MED | EnterWorktree / ExitWorktree | Verified against real 2.1.91/2.1.104 transcripts: both auto-execute (`input:{}` / `{action:"remove"}`), no user prompt → not user-blocking, no change |
| LOW | Beads Classic JSON shape | `gt rig list --json` matches `rigState`; `gt polecat list --all --json` returns `[]` (shape unverifiable from runtime, struct fields match upstream contract). Note: the issue mentions a `ConvoyState` type — there is no convoy parsing in irrlicht, so nothing to break |
| LOW | Codex legacy tool removal | `core/adapters/inbound/agents/codex/parser.go:171-186` accepts any tool name without validation → safe |
| LOW | AskUserQuestion disabled in channels mode | Documented gap, deferred to follow-up. Channels mode would silently never trigger primary waiting detection in `state_classifier.go:39-45` (`isUserBlockingTool`); secondary heuristic (trailing `?` in last assistant message) still fires |

## Notes

- Two of the issue's line/symbol references were stale and have been corrected here:
  - `hasOnlyAgentTools()` / `InferSubagents()` → actual hook is `surviveTurnDone()` in `core/pkg/tailer/tailer_config.go:17-23`.
  - Gas Town Boot/Dog item was already implemented in code; only verification remained.

## Test plan

- [x] `go test ./core/pkg/tailer/...` — all pass (new SendMessage tests included)
- [x] `go test ./core/...` — all pass except pre-existing replay golden path mismatches (`replaydata/agents/...` baked into goldens vs worktree path), confirmed unrelated by stashing the diff and re-running
- [ ] Soak in real session monitoring against Claude Code 2.1.119 to confirm SendMessage tool_use entries close cleanly when the sub-agent finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)