### PR TITLE
fix(session): detect mid-paragraph questions and trim snippet (#236)

### DIFF
--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -148,6 +148,12 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 	if result.PressureLevel == "" {
 		result.PressureLevel = "unknown"
 	}
+	// Trim the rendered snippet to just the question sentence when one is
+	// present, so the macOS overlay shows "What would you like?" instead of
+	// the full surrounding paragraph (issue #236).
+	if snippet := session.ExtractQuestionSnippet(result.LastAssistantText); snippet != "" {
+		result.LastAssistantText = snippet
+	}
 	return result, nil
 }
 

--- a/core/cmd/replay/metrics.go
+++ b/core/cmd/replay/metrics.go
@@ -92,6 +92,9 @@ func tailerToDomain(m *tailer.SessionMetrics) *session.SessionMetrics {
 			}
 		}
 	}
+	if snippet := session.ExtractQuestionSnippet(result.LastAssistantText); snippet != "" {
+		result.LastAssistantText = snippet
+	}
 	return result
 }
 

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -172,23 +172,89 @@ func isUserBlockingTool(name string) bool {
 // trailing whitespace.
 const trailingMarkdownNoise = "*_~`\"')] \t\n\r"
 
-// IsWaitingForUserInput returns true when the agent finished its turn but the
-// last assistant message ends with a question mark — indicating the agent is
+// markdownWrapper is the subset of trailingMarkdownNoise excluding whitespace —
+// characters that wrap a sentence terminator like `?**` or `?]` without
+// breaking the sentence.
+const markdownWrapper = "*_~`\"')]"
+
+// IsWaitingForUserInput returns true when the agent finished its turn and the
+// last assistant message contains a question — indicating the agent is
 // waiting for user input even though no user-blocking tool is open.
 //
-// Models routinely wrap questions in markdown for emphasis, e.g.
-// `**Should I do X?**`, leaving the literal final byte as `*` rather
-// than `?`. We strip trailing markdown delimiters and whitespace before
-// the check so the heuristic survives any reasonable formatting.
+// Detects questions anywhere in the text, not just at the trailing position,
+// so phrases like "What would you like? In the meantime I'll move on." are
+// recognized as waiting prompts.
 func (m *SessionMetrics) IsWaitingForUserInput() bool {
-	if m == nil || m.LastAssistantText == "" {
+	if m == nil {
 		return false
 	}
-	trimmed := strings.TrimRight(m.LastAssistantText, trailingMarkdownNoise)
-	if trimmed == "" {
-		return false
+	return ExtractQuestionSnippet(m.LastAssistantText) != ""
+}
+
+// ExtractQuestionSnippet returns the first question sentence found in text,
+// or an empty string when no sentence-terminating `?` is present. It preserves
+// any trailing markdown wrappers (e.g. `**Question?**`) so the rendered
+// snippet still reads naturally. URL fragments and other non-sentence `?`
+// occurrences are skipped because the question mark must be followed by
+// whitespace, end-of-string, or markdown wrappers leading to either.
+//
+// First-question-wins is preferred over last-question because agents typically
+// lead with the actual question and follow with examples or status notes; a
+// bullet list of options ending in `?` would otherwise hijack the snippet.
+func ExtractQuestionSnippet(text string) string {
+	if text == "" {
+		return ""
 	}
-	return trimmed[len(trimmed)-1] == '?'
+	for _, s := range splitSentences(text) {
+		trimmed := strings.TrimSpace(s)
+		if trimmed == "" {
+			continue
+		}
+		stripped := strings.TrimRight(trimmed, trailingMarkdownNoise)
+		if stripped == "" {
+			continue
+		}
+		if stripped[len(stripped)-1] == '?' {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// splitSentences splits text on sentence terminators (`.`, `!`, `?`) and
+// newlines. A terminator only ends a sentence when followed by whitespace,
+// end-of-string, or markdown wrappers leading to either — so URL `?` and
+// abbreviations like `e.g.` don't split. Each returned sentence retains its
+// terminator and any wrapper characters.
+func splitSentences(text string) []string {
+	var sentences []string
+	start := 0
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+		switch c {
+		case '.', '!', '?':
+			j := i + 1
+			for j < len(text) && strings.IndexByte(markdownWrapper, text[j]) >= 0 {
+				j++
+			}
+			if j == len(text) || isSentenceBreak(text[j]) {
+				sentences = append(sentences, text[start:j])
+				start = j
+				i = j - 1
+			}
+		case '\n':
+			sentences = append(sentences, text[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(text) {
+		sentences = append(sentences, text[start:])
+	}
+	return sentences
+}
+
+func isSentenceBreak(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
 // IsAgentDone returns true when the agent finished its turn. The primary

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -191,21 +191,28 @@ func (m *SessionMetrics) IsWaitingForUserInput() bool {
 	return ExtractQuestionSnippet(m.LastAssistantText) != ""
 }
 
-// ExtractQuestionSnippet returns the first question sentence found in text,
-// or an empty string when no sentence-terminating `?` is present. It preserves
-// any trailing markdown wrappers (e.g. `**Question?**`) so the rendered
-// snippet still reads naturally. URL fragments and other non-sentence `?`
-// occurrences are skipped because the question mark must be followed by
-// whitespace, end-of-string, or markdown wrappers leading to either.
+// ExtractQuestionSnippet returns the first non-rhetorical question sentence
+// found in text, or an empty string when none is present. It preserves any
+// trailing markdown wrappers (e.g. `**Question?**`) so the rendered snippet
+// still reads naturally. URL fragments and other non-sentence `?` occurrences
+// are skipped because the question mark must be followed by whitespace,
+// end-of-string, or markdown wrappers leading to either.
 //
 // First-question-wins is preferred over last-question because agents typically
 // lead with the actual question and follow with examples or status notes; a
 // bullet list of options ending in `?` would otherwise hijack the snippet.
+//
+// Rhetorical questions — Q&A pairs like "Why do programmers prefer dark mode?
+// Because light attracts bugs." — are skipped: the agent isn't actually
+// waiting on the user. Detection is heuristic (the next sentence starts with
+// an answer marker like "Because"); false negatives are preferred over
+// false positives in mid-paragraph waiting detection.
 func ExtractQuestionSnippet(text string) string {
 	if text == "" {
 		return ""
 	}
-	for _, s := range splitSentences(text) {
+	sentences := splitSentences(text)
+	for i, s := range sentences {
 		trimmed := strings.TrimSpace(s)
 		if trimmed == "" {
 			continue
@@ -214,11 +221,54 @@ func ExtractQuestionSnippet(text string) string {
 		if stripped == "" {
 			continue
 		}
-		if stripped[len(stripped)-1] == '?' {
-			return trimmed
+		if stripped[len(stripped)-1] != '?' {
+			continue
 		}
+		if isRhetorical(sentences, i) {
+			continue
+		}
+		return trimmed
 	}
 	return ""
+}
+
+// answerPrefixes flag a sentence as starting with an explanatory answer to a
+// preceding question. Conservative on purpose — connectives that strongly
+// imply "this sentence answers the previous question" rather than continuing
+// the agent's status report. False negatives (rhetorical Qs we miss) are
+// preferable to false positives that would re-break #236's mid-paragraph
+// detection.
+var answerPrefixes = []string{
+	"because ", "because,", "because:",
+	"since ", "since,",
+}
+
+// isRhetorical reports whether the question at sentences[qIdx] is answered
+// by a subsequent sentence in the same paragraph — i.e. a Q&A pair like
+// "Why do programmers prefer dark mode? Because light attracts bugs."
+func isRhetorical(sentences []string, qIdx int) bool {
+	for k := qIdx + 1; k < len(sentences); k++ {
+		next := strings.TrimSpace(sentences[k])
+		if next == "" {
+			continue
+		}
+		return looksLikeAnswer(next)
+	}
+	return false
+}
+
+func looksLikeAnswer(s string) bool {
+	s = strings.TrimLeft(s, markdownWrapper)
+	if s == "" {
+		return false
+	}
+	lower := strings.ToLower(s)
+	for _, p := range answerPrefixes {
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // splitSentences splits text on sentence terminators (`.`, `!`, `?`) and

--- a/core/domain/session/session_test.go
+++ b/core/domain/session/session_test.go
@@ -32,12 +32,47 @@ func TestIsWaitingForUserInput_TrailingMarkdown(t *testing.T) {
 		{"declarative ending in *", "**Done**", false},
 		{"empty", "", false},
 		{"only delimiters", "***", false},
+		// Mid-paragraph questions — issue #236.
+		{"mid-paragraph question with trailing status", "What would you like? In the meantime I'll move step 7 to blocked.", true},
+		{"question on first line, status after newline", "Do you want me to refactor?\nLet me know.", true},
+		{"two questions, both detected", "What's first? Or what's second?", true},
+		{"URL with ? not a question", "See https://example.com/?foo=bar for details.", false},
+		{"abbreviation e.g. is not a question", "Use a fixture, e.g. small.json. The tests pass.", false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			m := &SessionMetrics{LastAssistantText: c.text}
 			if got := m.IsWaitingForUserInput(); got != c.want {
 				t.Errorf("text=%q: got %v, want %v", c.text, got, c.want)
+			}
+		})
+	}
+}
+
+func TestExtractQuestionSnippet(t *testing.T) {
+	// Issue #236: when a question is detected, the rendered snippet should be
+	// the question sentence — not the full surrounding paragraph.
+	cases := []struct {
+		name string
+		text string
+		want string
+	}{
+		{"plain", "What now?", "What now?"},
+		{"mid-paragraph trims trailing status", "What would you like? In the meantime I'll move step 7 to blocked and not touch your daemon.", "What would you like?"},
+		{"multi-question keeps first (top-level question over bullet options)", "What's first? Or what's second?", "What's first?"},
+		{"bullet options after lead question keep lead", "what would you like me to test? For example:\n- run tests?\n- something else?", "what would you like me to test?"},
+		{"newline-separated", "Looking at the code.\nDo you want me to refactor?\nLet me know.", "Do you want me to refactor?"},
+		{"bold-wrapped preserved", "**What now?**", "**What now?**"},
+		{"trailing whitespace stripped", "What now?   \n", "What now?"},
+		{"leading ellipsis from truncation", "…end of context. Hello, what's next?", "Hello, what's next?"},
+		{"no question returns empty", "Done. The tests pass.", ""},
+		{"empty input", "", ""},
+		{"only punctuation", "***", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ExtractQuestionSnippet(c.text); got != c.want {
+				t.Errorf("text=%q: got %q, want %q", c.text, got, c.want)
 			}
 		})
 	}

--- a/core/domain/session/session_test.go
+++ b/core/domain/session/session_test.go
@@ -38,6 +38,11 @@ func TestIsWaitingForUserInput_TrailingMarkdown(t *testing.T) {
 		{"two questions, both detected", "What's first? Or what's second?", true},
 		{"URL with ? not a question", "See https://example.com/?foo=bar for details.", false},
 		{"abbreviation e.g. is not a question", "Use a fixture, e.g. small.json. The tests pass.", false},
+		// Rhetorical Q&A — agent answers itself, not waiting on user.
+		{"joke with Because answer", "Why do programmers prefer dark mode? Because light attracts bugs.", false},
+		{"joke with Because answer across newline", "Why do programmers prefer dark mode?\nBecause light attracts bugs.", false},
+		{"Since-prefixed answer is rhetorical", "Why bother? Since the cache already has it, we skip.", false},
+		{"rhetorical Q followed by real Q", "Why? Because reasons. Should I proceed?", true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -68,6 +73,11 @@ func TestExtractQuestionSnippet(t *testing.T) {
 		{"no question returns empty", "Done. The tests pass.", ""},
 		{"empty input", "", ""},
 		{"only punctuation", "***", ""},
+		// Rhetorical Q&A is skipped — the agent isn't waiting on the user.
+		{"joke with Because answer returns empty", "Why do programmers prefer dark mode? Because light attracts bugs.", ""},
+		{"joke with Because across newline returns empty", "Why do programmers prefer dark mode?\nBecause light attracts bugs.", ""},
+		{"rhetorical Q followed by real Q returns the real one", "Why? Because reasons. Should I proceed?", "Should I proceed?"},
+		{"non-answer continuation is not rhetorical", "What would you like? In the meantime I'll move on.", "What would you like?"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/replaydata/agents/claudecode/scenarios/06-cost-calculation-07f5cca9/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/06-cost-calculation-07f5cca9/transcript.jsonl.replay.json.golden
@@ -15,8 +15,8 @@
     "last_event_time": "2026-04-07T23:15:42.607Z",
     "wall_clock_session_duration": 11901617000000,
     "state_durations": {
-      "ready": 3353586000000,
-      "waiting": 998415000000,
+      "ready": 3231325000000,
+      "waiting": 1120676000000,
       "working": 7549616000000
     },
     "flicker_count": 2,
@@ -191,7 +191,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "… as-is,\n- (b) commit only 02/03/04 and drop the 60 MB one,\n- (c) run a secret…"
+      "last_assistant_text_head": "- (d) build a small redactor that strips paths + suspicious strings before commi…"
     },
     {
       "index": 11,
@@ -220,7 +220,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "… to land for the regression numbers to drop.\n\nWant me to start with the Bug B…"
+      "last_assistant_text_head": "Want me to start with the Bug B fix (small, self-contained, immediately visible …"
     },
     {
       "index": 13,
@@ -242,23 +242,23 @@
       "virtual_time": "2026-04-07T20:58:37.445Z",
       "cause": "debounce_coalesce",
       "prev_state": "working",
-      "new_state": "ready",
-      "reason": "agent finished turn → ready",
+      "new_state": "waiting",
+      "reason": "turn ended with question → waiting",
       "last_event_type": "turn_done",
       "has_open_tool": false,
       "is_agent_done": true,
       "needs_user_attention": false,
-      "waiting_for_user_input": false,
-      "last_assistant_text_head": "… | 4               | 2           | **0**           |\n\nWant me to ship both fi…"
+      "waiting_for_user_input": true,
+      "last_assistant_text_head": "Want me to ship both fixes as two separate commits?"
     },
     {
       "index": 15,
       "event_index": 187,
       "virtual_time": "2026-04-07T21:00:39.706Z",
       "cause": "event",
-      "prev_state": "ready",
+      "prev_state": "waiting",
       "new_state": "working",
-      "reason": "force ready→working on first activity",
+      "reason": "transcript activity (waiting → working)",
       "last_event_type": "user",
       "has_open_tool": false,
       "is_agent_done": false,
@@ -307,7 +307,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "…e scoreboard, then move through the fixes one by one? Or would you prefer I d…"
+      "last_assistant_text_head": "…e scoreboard, then move through the fixes one by one?"
     },
     {
       "index": 19,

--- a/replaydata/agents/claudecode/scenarios/08-issue-114-stuck-working-a/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/08-issue-114-stuck-working-a/transcript.jsonl.replay.json.golden
@@ -462,7 +462,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "…menu bar may be collapsed — `proc-21130` should appear under the `irrlicht`…"
+      "last_assistant_text_head": "Want me to restart the Swift app, or should I look at the app log to see what it…"
     },
     {
       "index": 30,
@@ -477,7 +477,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "…menu bar may be collapsed — `proc-21130` should appear under the `irrlicht`…"
+      "last_assistant_text_head": "Want me to restart the Swift app, or should I look at the app log to see what it…"
     },
     {
       "index": 31,

--- a/replaydata/agents/claudecode/scenarios/10-full-lifecycle-839f0678/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/10-full-lifecycle-839f0678/transcript.jsonl.replay.json.golden
@@ -140,7 +140,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "Got it — just chatting. What's on your mind?"
+      "last_assistant_text_head": "What's on your mind?"
     },
     {
       "index": 7,

--- a/replaydata/agents/claudecode/scenarios/16-ask-user-question-issue-150/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/16-ask-user-question-issue-150/transcript.jsonl.replay.json.golden
@@ -15,21 +15,21 @@
     "last_event_time": "2026-04-12T22:29:31.472Z",
     "wall_clock_session_duration": 13030969000000,
     "state_durations": {
-      "ready": 11898016000000,
-      "waiting": 1034872000000,
+      "ready": 11797731000000,
+      "waiting": 1135157000000,
       "working": 98081000000
     },
     "flicker_count": 12,
     "flickers_by_category": {
       "ready_between_working": 2,
       "waiting_between_working": 1,
-      "working_between_ready": 3,
-      "working_between_waiting": 6
+      "working_between_ready": 2,
+      "working_between_waiting": 7
     },
     "flickers_by_reason": {
       "agent finished turn → ready": 2,
-      "force ready→working on first activity": 3,
-      "transcript activity (waiting → working)": 6,
+      "force ready→working on first activity": 2,
+      "transcript activity (waiting → working)": 7,
       "user-blocking tool open → waiting": 1
     },
     "estimated_cost_usd": 1.3103285,
@@ -292,7 +292,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "Hi! What can I help you with?"
+      "last_assistant_text_head": "What can I help you with?"
     },
     {
       "index": 17,
@@ -307,7 +307,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "Hi! What can I help you with?"
+      "last_assistant_text_head": "What can I help you with?"
     },
     {
       "index": 18,
@@ -336,7 +336,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "Hey! What would you like to work on?"
+      "last_assistant_text_head": "What would you like to work on?"
     },
     {
       "index": 20,
@@ -440,7 +440,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "…at would you like me to test? For example:\n\n- Run the Go test suite (`go test…"
+      "last_assistant_text_head": "…at would you like me to test?"
     },
     {
       "index": 27,
@@ -462,23 +462,23 @@
       "virtual_time": "2026-04-12T21:20:39.367Z",
       "cause": "debounce_coalesce",
       "prev_state": "working",
-      "new_state": "ready",
-      "reason": "agent finished turn → ready",
+      "new_state": "waiting",
+      "reason": "turn ended with question → waiting",
       "last_event_type": "assistant",
       "has_open_tool": false,
       "is_agent_done": true,
       "needs_user_attention": false,
-      "waiting_for_user_input": false,
-      "last_assistant_text_head": "What are you looking to test? Give me a bit more context and I'll jump in."
+      "waiting_for_user_input": true,
+      "last_assistant_text_head": "What are you looking to test?"
     },
     {
       "index": 29,
       "event_index": 78,
       "virtual_time": "2026-04-12T21:22:19.652Z",
       "cause": "event",
-      "prev_state": "ready",
+      "prev_state": "waiting",
       "new_state": "working",
-      "reason": "force ready→working on first activity",
+      "reason": "transcript activity (waiting → working)",
       "last_event_type": "user",
       "has_open_tool": false,
       "is_agent_done": false,

--- a/replaydata/agents/pi/scenarios/01-example-session/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/scenarios/01-example-session/transcript.jsonl.replay.json.golden
@@ -15,20 +15,20 @@
     "last_event_time": "2026-04-06T20:39:45.037Z",
     "wall_clock_session_duration": 15454196000000,
     "state_durations": {
-      "ready": 11440582000000,
-      "waiting": 1023852000000,
+      "ready": 11811544000000,
+      "waiting": 652890000000,
       "working": 2989762000000
     },
     "flicker_count": 11,
     "flickers_by_category": {
       "ready_between_working": 2,
-      "working_between_ready": 7,
-      "working_between_waiting": 2
+      "working_between_ready": 8,
+      "working_between_waiting": 1
     },
     "flickers_by_reason": {
       "agent finished turn → ready": 2,
-      "force ready→working on first activity": 7,
-      "transcript activity (waiting → working)": 2
+      "force ready→working on first activity": 8,
+      "transcript activity (waiting → working)": 1
     },
     "cum_input_tokens": 910869,
     "cum_output_tokens": 82483,
@@ -1144,23 +1144,23 @@
       "virtual_time": "2026-04-06T20:13:12.359Z",
       "cause": "event",
       "prev_state": "working",
-      "new_state": "waiting",
-      "reason": "turn ended with question → waiting",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
       "last_event_type": "turn_done",
       "has_open_tool": false,
       "is_agent_done": true,
       "needs_user_attention": false,
-      "waiting_for_user_input": true,
-      "last_assistant_text_head": "Why do programmers prefer dark mode?"
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "Why do programmers prefer dark mode?  \nBecause light attracts bugs. 🐛"
     },
     {
       "index": 77,
       "event_index": 538,
       "virtual_time": "2026-04-06T20:19:23.321Z",
       "cause": "event",
-      "prev_state": "waiting",
+      "prev_state": "ready",
       "new_state": "working",
-      "reason": "transcript activity (waiting → working)",
+      "reason": "force ready→working on first activity",
       "last_event_type": "user_message",
       "has_open_tool": false,
       "is_agent_done": false,

--- a/replaydata/agents/pi/scenarios/01-example-session/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/scenarios/01-example-session/transcript.jsonl.replay.json.golden
@@ -15,18 +15,20 @@
     "last_event_time": "2026-04-06T20:39:45.037Z",
     "wall_clock_session_duration": 15454196000000,
     "state_durations": {
-      "ready": 12431135000000,
-      "waiting": 33299000000,
+      "ready": 11440582000000,
+      "waiting": 1023852000000,
       "working": 2989762000000
     },
     "flicker_count": 11,
     "flickers_by_category": {
       "ready_between_working": 2,
-      "working_between_ready": 9
+      "working_between_ready": 7,
+      "working_between_waiting": 2
     },
     "flickers_by_reason": {
       "agent finished turn → ready": 2,
-      "force ready→working on first activity": 9
+      "force ready→working on first activity": 7,
+      "transcript activity (waiting → working)": 2
     },
     "cum_input_tokens": 910869,
     "cum_output_tokens": 82483,
@@ -1084,23 +1086,23 @@
       "virtual_time": "2026-04-06T20:02:07.141Z",
       "cause": "event",
       "prev_state": "working",
-      "new_state": "ready",
-      "reason": "agent finished turn → ready",
+      "new_state": "waiting",
+      "reason": "turn ended with question → waiting",
       "last_event_type": "turn_done",
       "has_open_tool": false,
       "is_agent_done": true,
       "needs_user_attention": false,
-      "waiting_for_user_input": false,
-      "last_assistant_text_head": "Yep — what do you want to do with **pi**?\n\nI can help with setup, config, skil…"
+      "waiting_for_user_input": true,
+      "last_assistant_text_head": "Yep — what do you want to do with **pi**?"
     },
     {
       "index": 73,
       "event_index": 534,
       "virtual_time": "2026-04-06T20:12:26.732Z",
       "cause": "event",
-      "prev_state": "ready",
+      "prev_state": "waiting",
       "new_state": "working",
-      "reason": "force ready→working on first activity",
+      "reason": "transcript activity (waiting → working)",
       "last_event_type": "user_message",
       "has_open_tool": false,
       "is_agent_done": false,
@@ -1142,23 +1144,23 @@
       "virtual_time": "2026-04-06T20:13:12.359Z",
       "cause": "event",
       "prev_state": "working",
-      "new_state": "ready",
-      "reason": "agent finished turn → ready",
+      "new_state": "waiting",
+      "reason": "turn ended with question → waiting",
       "last_event_type": "turn_done",
       "has_open_tool": false,
       "is_agent_done": true,
       "needs_user_attention": false,
-      "waiting_for_user_input": false,
-      "last_assistant_text_head": "Why do programmers prefer dark mode?  \nBecause light attracts bugs. 🐛"
+      "waiting_for_user_input": true,
+      "last_assistant_text_head": "Why do programmers prefer dark mode?"
     },
     {
       "index": 77,
       "event_index": 538,
       "virtual_time": "2026-04-06T20:19:23.321Z",
       "cause": "event",
-      "prev_state": "ready",
+      "prev_state": "waiting",
       "new_state": "working",
-      "reason": "force ready→working on first activity",
+      "reason": "transcript activity (waiting → working)",
       "last_event_type": "user_message",
       "has_open_tool": false,
       "is_agent_done": false,


### PR DESCRIPTION
## Summary
- `IsWaitingForUserInput` now detects `?` anywhere in `LastAssistantText`, not just as the trailing character — so mid-paragraph prompts like *"What would you like? In the meantime I'll move step 7 to blocked."* are correctly classified as waiting.
- New `ExtractQuestionSnippet()` in the session domain returns the first `?`-terminated sentence (markdown-aware — URL `?` and abbreviations don't split). The metrics adapter and replay tool trim `LastAssistantText` to that snippet, so the macOS overlay shows just the question.
- First-question-wins (vs. last) keeps the top-level question even when agents follow with bullet options like `- Something else?`.

Closes #236.

## Test plan
- [x] `go test ./core/domain/session/... -race -count=1` — passes (new `TestExtractQuestionSnippet` + extended `TestIsWaitingForUserInput_TrailingMarkdown`).
- [x] `go test ./core/... -race -count=1` — only pre-existing worktree-vs-main-repo `source_transcript` path mismatch in `TestFixtureReplayByteIdentity` (offset 79 in every golden); content matches.
- [x] `tools/replay-fixtures.sh` — clean run.
- [x] Replay goldens refreshed for 5 scenarios; diffs reflect intended behavior (preambles like *"Hi!"*, *"Hey!"* trimmed; new `working → waiting` transitions where mid-paragraph questions were previously missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)