### PR TITLE
fix(macos): use brand off-flame for idle/empty state (#246)

### DIFF
--- a/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
@@ -9,7 +9,7 @@ enum MenuBarImageBuilder {
         if let combined = combinedImage(sessionManager: sessionManager, gasTownProvider: gasTownProvider) {
             return combined
         }
-        return idleFlameImage()
+        return OffFlameImage.menuBar
     }
 
     private static func combinedImage(
@@ -59,7 +59,4 @@ enum MenuBarImageBuilder {
         return combined
     }
 
-    private static func idleFlameImage() -> NSImage {
-        OffFlameImage.image(pointSize: 18, variant: .menuBar)
-    }
 }

--- a/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
@@ -9,7 +9,7 @@ enum MenuBarImageBuilder {
         if let combined = combinedImage(sessionManager: sessionManager, gasTownProvider: gasTownProvider) {
             return combined
         }
-        return sparkleImage()
+        return idleFlameImage()
     }
 
     private static func combinedImage(
@@ -59,12 +59,7 @@ enum MenuBarImageBuilder {
         return combined
     }
 
-    private static func sparkleImage() -> NSImage {
-        let config = NSImage.SymbolConfiguration(pointSize: 14, weight: .regular)
-        let base = NSImage(systemSymbolName: "sparkle", accessibilityDescription: "Irrlicht")
-            ?? NSImage()
-        let configured = base.withSymbolConfiguration(config) ?? base
-        configured.isTemplate = true
-        return configured
+    private static func idleFlameImage() -> NSImage {
+        OffFlameImage.image(pointSize: 18, variant: .menuBar)
     }
 }

--- a/platforms/macos/Irrlicht/App/OffFlameImage.swift
+++ b/platforms/macos/Irrlicht/App/OffFlameImage.swift
@@ -1,0 +1,81 @@
+import AppKit
+
+// Brand-mark "no sessions" flame, mirroring tools/irrlicht-design-system/assets/favicon-off.svg.
+// Inline SVG → NSImage to match the pattern used in MenuBarStatusRenderer.
+@MainActor
+enum OffFlameImage {
+    enum Variant {
+        // Menu-bar idle: brighter, near-white gradient so the glyph reads
+        // clearly at small sizes against any menu-bar background.
+        case menuBar
+        // Overlay empty state: dimmed grey gradient + diagonal slash, the
+        // "no light" treatment paired with "No coding agent sessions detected".
+        case overlaySlashed
+    }
+
+    static func image(pointSize: CGFloat, variant: Variant) -> NSImage {
+        let size = Int(pointSize.rounded())
+        let body: String
+        let core: String
+        let slash: String
+
+        switch variant {
+        case .menuBar:
+            body = """
+            <linearGradient id="wisp-off-body" x1="50%" y1="0%" x2="50%" y2="100%">
+            <stop offset="0%" stop-color="#f3f4f6" stop-opacity="0.95"/>
+            <stop offset="100%" stop-color="#9ca3af" stop-opacity="0.95"/>
+            </linearGradient>
+            """
+            core = """
+            <linearGradient id="wisp-off-core" x1="50%" y1="20%" x2="50%" y2="100%">
+            <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95"/>
+            <stop offset="100%" stop-color="#e5e7eb" stop-opacity="0.7"/>
+            </linearGradient>
+            """
+            slash = ""
+        case .overlaySlashed:
+            body = """
+            <linearGradient id="wisp-off-body" x1="50%" y1="0%" x2="50%" y2="100%">
+            <stop offset="0%" stop-color="#6b7280" stop-opacity="0.6"/>
+            <stop offset="100%" stop-color="#3f4551" stop-opacity="0.9"/>
+            </linearGradient>
+            """
+            core = """
+            <linearGradient id="wisp-off-core" x1="50%" y1="20%" x2="50%" y2="100%">
+            <stop offset="0%" stop-color="#9ca3af" stop-opacity="0.55"/>
+            <stop offset="100%" stop-color="#6b7280" stop-opacity="0.3"/>
+            </linearGradient>
+            """
+            // Diagonal slash, top-left to bottom-right, matching SF Symbol's
+            // *.slash treatment. Drawn as a thicker dark stroke "shadow" plus
+            // a lighter foreground stroke so it reads on both the flame and
+            // the panel background.
+            slash = """
+            <line x1="5" y1="4" x2="27" y2="29" stroke="#0a0f1a" stroke-width="3.5" stroke-linecap="round" opacity="0.9"/>
+            <line x1="5" y1="4" x2="27" y2="29" stroke="#9ca3af" stroke-width="1.6" stroke-linecap="round"/>
+            """
+        }
+
+        let svg = """
+        <svg xmlns="http://www.w3.org/2000/svg" width="\(size)" height="\(size)" viewBox="0 0 32 32">
+        <defs>
+        \(body)
+        \(core)
+        </defs>
+        <path d="M 16.5 3 C 14.5 6, 12 8.5, 10.5 12 C 9 15.5, 9 19, 9.8 22 C 10.5 25, 12.5 27.5, 15 28.5 C 15.5 28.7, 16 28.8, 16.5 28.7 C 17.5 28.5, 19 28, 20.5 27 C 22.5 25.5, 23 22.5, 23 19.5 C 23 16, 22 13, 20.5 10.5 C 19 8, 17.5 5.5, 16.5 3 Z" fill="url(#wisp-off-body)"/>
+        <path d="M 16 10 C 14.5 12, 13.5 14.5, 13.5 17.5 C 13.5 20.5, 14.5 23, 16 23.5 C 17.5 23, 18.5 20.5, 18.5 17.5 C 18.5 14.5, 17.5 12, 16 10 Z" fill="url(#wisp-off-core)"/>
+        \(slash)
+        </svg>
+        """
+
+        guard let data = svg.data(using: .utf8),
+              let image = NSImage(data: data) else {
+            return NSImage()
+        }
+        image.isTemplate = false
+        image.size = NSSize(width: pointSize, height: pointSize)
+        image.accessibilityDescription = "Irrlicht — no active sessions"
+        return image
+    }
+}

--- a/platforms/macos/Irrlicht/App/OffFlameImage.swift
+++ b/platforms/macos/Irrlicht/App/OffFlameImage.swift
@@ -1,81 +1,73 @@
 import AppKit
 
-// Brand-mark "no sessions" flame, mirroring tools/irrlicht-design-system/assets/favicon-off.svg.
-// Inline SVG → NSImage to match the pattern used in MenuBarStatusRenderer.
 @MainActor
 enum OffFlameImage {
-    enum Variant {
-        // Menu-bar idle: brighter, near-white gradient so the glyph reads
-        // clearly at small sizes against any menu-bar background.
-        case menuBar
-        // Overlay empty state: dimmed grey gradient + diagonal slash, the
-        // "no light" treatment paired with "No coding agent sessions detected".
-        case overlaySlashed
-    }
+    static let menuBar = build(pointSize: 18, config: .menuBar)
+    static let overlaySlashed = build(pointSize: 24, config: .overlaySlashed)
 
-    static func image(pointSize: CGFloat, variant: Variant) -> NSImage {
-        let size = Int(pointSize.rounded())
-        let body: String
-        let core: String
+    private struct Config {
+        let bodyStops: String
+        let coreStops: String
         let slash: String
+        let accessibilityDescription: String?
 
-        switch variant {
-        case .menuBar:
-            body = """
-            <linearGradient id="wisp-off-body" x1="50%" y1="0%" x2="50%" y2="100%">
+        static let menuBar = Config(
+            bodyStops: """
             <stop offset="0%" stop-color="#f3f4f6" stop-opacity="0.95"/>
             <stop offset="100%" stop-color="#9ca3af" stop-opacity="0.95"/>
-            </linearGradient>
-            """
-            core = """
-            <linearGradient id="wisp-off-core" x1="50%" y1="20%" x2="50%" y2="100%">
+            """,
+            coreStops: """
             <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95"/>
             <stop offset="100%" stop-color="#e5e7eb" stop-opacity="0.7"/>
-            </linearGradient>
-            """
-            slash = ""
-        case .overlaySlashed:
-            body = """
-            <linearGradient id="wisp-off-body" x1="50%" y1="0%" x2="50%" y2="100%">
+            """,
+            slash: "",
+            accessibilityDescription: "Irrlicht — no active sessions"
+        )
+
+        static let overlaySlashed = Config(
+            bodyStops: """
             <stop offset="0%" stop-color="#6b7280" stop-opacity="0.6"/>
             <stop offset="100%" stop-color="#3f4551" stop-opacity="0.9"/>
-            </linearGradient>
-            """
-            core = """
-            <linearGradient id="wisp-off-core" x1="50%" y1="20%" x2="50%" y2="100%">
+            """,
+            coreStops: """
             <stop offset="0%" stop-color="#9ca3af" stop-opacity="0.55"/>
             <stop offset="100%" stop-color="#6b7280" stop-opacity="0.3"/>
-            </linearGradient>
-            """
-            // Diagonal slash, top-left to bottom-right, matching SF Symbol's
-            // *.slash treatment. Drawn as a thicker dark stroke "shadow" plus
-            // a lighter foreground stroke so it reads on both the flame and
-            // the panel background.
-            slash = """
+            """,
+            // Dark stroke under a lighter foreground stroke so the slash reads
+            // against both the flame and the panel background.
+            slash: """
             <line x1="5" y1="4" x2="27" y2="29" stroke="#0a0f1a" stroke-width="3.5" stroke-linecap="round" opacity="0.9"/>
             <line x1="5" y1="4" x2="27" y2="29" stroke="#9ca3af" stroke-width="1.6" stroke-linecap="round"/>
-            """
-        }
+            """,
+            // Surrounding Text already announces the empty state.
+            accessibilityDescription: nil
+        )
+    }
 
+    private static func build(pointSize: CGFloat, config: Config) -> NSImage {
+        let size = Int(pointSize.rounded())
         let svg = """
         <svg xmlns="http://www.w3.org/2000/svg" width="\(size)" height="\(size)" viewBox="0 0 32 32">
         <defs>
-        \(body)
-        \(core)
+        <linearGradient id="wisp-off-body" x1="50%" y1="0%" x2="50%" y2="100%">
+        \(config.bodyStops)
+        </linearGradient>
+        <linearGradient id="wisp-off-core" x1="50%" y1="20%" x2="50%" y2="100%">
+        \(config.coreStops)
+        </linearGradient>
         </defs>
         <path d="M 16.5 3 C 14.5 6, 12 8.5, 10.5 12 C 9 15.5, 9 19, 9.8 22 C 10.5 25, 12.5 27.5, 15 28.5 C 15.5 28.7, 16 28.8, 16.5 28.7 C 17.5 28.5, 19 28, 20.5 27 C 22.5 25.5, 23 22.5, 23 19.5 C 23 16, 22 13, 20.5 10.5 C 19 8, 17.5 5.5, 16.5 3 Z" fill="url(#wisp-off-body)"/>
         <path d="M 16 10 C 14.5 12, 13.5 14.5, 13.5 17.5 C 13.5 20.5, 14.5 23, 16 23.5 C 17.5 23, 18.5 20.5, 18.5 17.5 C 18.5 14.5, 17.5 12, 16 10 Z" fill="url(#wisp-off-core)"/>
-        \(slash)
+        \(config.slash)
         </svg>
         """
-
         guard let data = svg.data(using: .utf8),
               let image = NSImage(data: data) else {
             return NSImage()
         }
         image.isTemplate = false
         image.size = NSSize(width: pointSize, height: pointSize)
-        image.accessibilityDescription = "Irrlicht — no active sessions"
+        image.accessibilityDescription = config.accessibilityDescription
         return image
     }
 }

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -279,7 +279,7 @@ struct SessionListView: View {
 
     private var emptyStateView: some View {
         VStack(spacing: 8) {
-            Image(nsImage: OffFlameImage.image(pointSize: 24, variant: .overlaySlashed))
+            Image(nsImage: OffFlameImage.overlaySlashed)
 
             Text("No coding agent sessions detected")
                 .font(.headline)

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -279,9 +279,7 @@ struct SessionListView: View {
 
     private var emptyStateView: some View {
         VStack(spacing: 8) {
-            Image(systemName: "lightbulb.slash")
-                .font(.system(size: 24))
-                .foregroundColor(.secondary)
+            Image(nsImage: OffFlameImage.image(pointSize: 24, variant: .overlaySlashed))
 
             Text("No coding agent sessions detected")
                 .font(.headline)

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -156,7 +156,7 @@ curl -fsSL https://irrlicht.io/install.sh | sh -s -- --version 0.3.4</code></pre
         </li>
         <li>
           <strong>Launch the app</strong>
-          <p>Open <strong>Irrlicht</strong> from Applications. A sparkle icon appears in the menu bar, and the daemon starts automatically in the background.</p>
+          <p>Open <strong>Irrlicht</strong> from Applications. A dimmed grey flame appears in the menu bar, and the daemon starts automatically in the background.</p>
         </li>
       </ol>
 

--- a/site/docs/light-system.html
+++ b/site/docs/light-system.html
@@ -258,7 +258,7 @@
         <tbody>
           <tr>
             <td>0</td>
-            <td>A single white sparkle &mdash; clean slate, no active sessions</td>
+            <td>A single dimmed grey flame &mdash; clean slate, no active sessions</td>
           </tr>
           <tr>
             <td>1 &ndash; 5</td>

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -91,8 +91,8 @@
           <p>The embedded daemon starts automatically &mdash; no separate services to manage.</p>
         </li>
         <li>
-          <strong>Look for the sparkle icon</strong><br>
-          A small sparkle icon appears in your macOS menu bar, confirming Irrlicht is running.
+          <strong>Look for the flame icon</strong><br>
+          A small flame appears in your macOS menu bar &mdash; dimmed grey when no sessions are active &mdash; confirming Irrlicht is running.
         </li>
         <li>
           <strong>Start an AI coding session</strong><br>

--- a/tools/irrlicht-design-system/README.md
+++ b/tools/irrlicht-design-system/README.md
@@ -7,7 +7,7 @@
 - 🟣 **working** — the agent is thinking, building, streaming
 - 🟠 **waiting** — it needs you; the story pauses for your judgment
 - 🟢 **ready** — the path ahead is clear, ready for new work
-- ✦ **no sessions** — clean slate
+- **no sessions** — clean slate, dimmed grey flame
 
 The brand is built entirely around that **three-light vocabulary**. Purple, orange, green — everywhere, always in that semantic role.
 
@@ -239,7 +239,7 @@ Irrlicht is **deliberately icon-light**. Most of what looks like iconography is 
 
 ### 1. The Light System (primary visual vocabulary)
 
-- 🟣 🟠 🟢 ✦ — colored dots (SVG or `<span>` with border-radius:50%) in the three light colors, plus a four-pointed sparkle ✦ for "no sessions."
+- 🟣 🟠 🟢 — colored dots (SVG or `<span>` with border-radius:50%) in the three light colors, plus a dimmed grey flame for "no sessions" (see `assets/favicon-off.svg`).
 - These are the brand. They appear in the menu bar, web dashboard header, session rows, marketing hero, and the favicon.
 - In the macOS menu bar, groups of ≤3 sessions overlap as dots; ≥4 become a pie chart with a number label — see `MenuBarStatusRenderer.swift`.
 


### PR DESCRIPTION
## Summary
- Replace SF `sparkle` (menu-bar idle) and SF `lightbulb.slash` (overlay empty state) with a brand off-flame helper. New `OffFlameImage` builds inline SVG → `NSImage`, matching the SVG-string pattern already used in `MenuBarStatusRenderer.swift`.
- Menu bar gets a bright near-white flame at 18pt; overlay gets a dimmed grey flame at 24pt with a diagonal slash for the "no light" treatment per the issue.
- Both rendered images are cached as `static let` since the call sites pass compile-time constants — no re-rasterization on menu-bar ticks or SwiftUI body re-evaluation.
- Per-variant gradient stops and slash markup live in a private `Config` struct, so the build function has one code path.
- Docs synced: `site/docs/{quickstart,installation,light-system}.html` and `tools/irrlicht-design-system/README.md` no longer describe the idle indicator as a "sparkle".

Closes #246.

## Test plan
- [x] `swift build` from `platforms/macos/` succeeds.
- [x] Built and launched dev stack via `/ir:test-mac`; menu-bar flame and overlay slashed flame confirmed visually.
- [x] Pre-existing `GroupViewSnapshotTests` chevron drift and Go replay path-prefix mismatches are unrelated (both fail on a clean stash of the worktree).
- [x] No snapshot test references the prior sparkle menu-bar image, so no goldens to refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)