### PR TITLE
Stream session history over WebSocket; bit-pack 60-bucket rings

### DIFF
--- a/core/adapters/outbound/websocket/hub.go
+++ b/core/adapters/outbound/websocket/hub.go
@@ -46,16 +46,21 @@ func loopbackCheckOrigin(r *http.Request) bool {
 
 // hub manages WebSocket connections and fans out session state updates.
 type hub struct {
-	push     outbound.PushBroadcaster
-	upgrader websocket.Upgrader
+	push           outbound.PushBroadcaster
+	encodeHistory  func() map[string]map[string]string
+	upgrader       websocket.Upgrader
 }
 
 // NewHub creates a hub backed by the provided PushBroadcaster. The upgrader
-// enforces a loopback-only origin policy.
-func NewHub(push outbound.PushBroadcaster) *hub {
+// enforces a loopback-only origin policy. encodeHistory, when non-nil, is
+// called on each new connection to ship one history_snapshot per session
+// before the live event stream takes over (so freshly-attached clients see
+// the full 60-bucket history without polling).
+func NewHub(push outbound.PushBroadcaster, encodeHistory func() map[string]map[string]string) *hub {
 	return &hub{
-		push:     push,
-		upgrader: websocket.Upgrader{CheckOrigin: loopbackCheckOrigin},
+		push:          push,
+		encodeHistory: encodeHistory,
+		upgrader:      websocket.Upgrader{CheckOrigin: loopbackCheckOrigin},
 	}
 }
 
@@ -71,6 +76,27 @@ func (h *hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 
 	ch := h.push.Subscribe()
 	defer h.push.Unsubscribe(ch)
+
+	// Hydrate the new client with one history_snapshot per known session
+	// before the live stream starts. Subscribe-then-snapshot order ensures
+	// no tick or upgrade emitted between these two operations is lost.
+	if h.encodeHistory != nil {
+		for sid, hist := range h.encodeHistory() {
+			snap := outbound.PushMessage{
+				Type:      outbound.PushTypeHistorySnapshot,
+				SessionID: sid,
+				History:   hist,
+			}
+			data, err := json.Marshal(snap)
+			if err != nil {
+				continue
+			}
+			conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+			if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+				return
+			}
+		}
+	}
 
 	// Set initial read deadline; reset on each pong.
 	conn.SetReadDeadline(time.Now().Add(pongTimeout))

--- a/core/adapters/outbound/websocket/hub.go
+++ b/core/adapters/outbound/websocket/hub.go
@@ -44,23 +44,27 @@ func loopbackCheckOrigin(r *http.Request) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+// ConnectSnapshots returns the messages to deliver to a freshly-attached
+// WebSocket client before the live stream takes over. Typically this is one
+// history_snapshot per known session.
+type ConnectSnapshots func() []outbound.PushMessage
+
 // hub manages WebSocket connections and fans out session state updates.
 type hub struct {
-	push           outbound.PushBroadcaster
-	encodeHistory  func() map[string]map[string]string
-	upgrader       websocket.Upgrader
+	push             outbound.PushBroadcaster
+	connectSnapshots ConnectSnapshots
+	upgrader         websocket.Upgrader
 }
 
 // NewHub creates a hub backed by the provided PushBroadcaster. The upgrader
-// enforces a loopback-only origin policy. encodeHistory, when non-nil, is
-// called on each new connection to ship one history_snapshot per session
-// before the live event stream takes over (so freshly-attached clients see
-// the full 60-bucket history without polling).
-func NewHub(push outbound.PushBroadcaster, encodeHistory func() map[string]map[string]string) *hub {
+// enforces a loopback-only origin policy. connectSnapshots, when non-nil, is
+// invoked on each new connection to ship the per-session history snapshots
+// (so freshly-attached clients see the full 60-bucket history without polling).
+func NewHub(push outbound.PushBroadcaster, connectSnapshots ConnectSnapshots) *hub {
 	return &hub{
-		push:          push,
-		encodeHistory: encodeHistory,
-		upgrader:      websocket.Upgrader{CheckOrigin: loopbackCheckOrigin},
+		push:             push,
+		connectSnapshots: connectSnapshots,
+		upgrader:         websocket.Upgrader{CheckOrigin: loopbackCheckOrigin},
 	}
 }
 
@@ -79,14 +83,11 @@ func (h *hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 
 	// Hydrate the new client with one history_snapshot per known session
 	// before the live stream starts. Subscribe-then-snapshot order ensures
-	// no tick or upgrade emitted between these two operations is lost.
-	if h.encodeHistory != nil {
-		for sid, hist := range h.encodeHistory() {
-			snap := outbound.PushMessage{
-				Type:      outbound.PushTypeHistorySnapshot,
-				SessionID: sid,
-				History:   hist,
-			}
+	// no tick or upgrade emitted between these two operations is lost; per-
+	// session tick generations on snapshot/tick messages let the client
+	// dedupe a tick that's already reflected in its snapshot.
+	if h.connectSnapshots != nil {
+		for _, snap := range h.connectSnapshots() {
 			data, err := json.Marshal(snap)
 			if err != nil {
 				continue

--- a/core/adapters/outbound/websocket/hub_test.go
+++ b/core/adapters/outbound/websocket/hub_test.go
@@ -49,7 +49,7 @@ func TestLoopbackCheckOrigin(t *testing.T) {
 // TestServeWS_OriginHandshake exercises the full HTTP upgrade with a custom
 // Origin header to confirm the upgrader rejects cross-site handshakes.
 func TestServeWS_OriginHandshake(t *testing.T) {
-	hub := NewHub(services.NewPushService())
+	hub := NewHub(services.NewPushService(), nil)
 	srv := httptest.NewServer(http.HandlerFunc(hub.ServeWS))
 	defer srv.Close()
 

--- a/core/application/services/history_tracker.go
+++ b/core/application/services/history_tracker.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -20,6 +21,9 @@ const (
 	statePriorityReady   = 0
 	statePriorityWorking = 1
 	statePriorityWaiting = 2
+	// statePriorityNoData encodes empty/unfilled buckets on the wire. Stored
+	// in-memory as int8(-1); only surfaces when bit-packing for transport.
+	statePriorityNoData = 3
 )
 
 var validGranularities = []int{1, 10, 60}
@@ -84,10 +88,13 @@ func (rb *ringBuffer) upgrade(newState string) {
 	rb.lastState = newState
 }
 
-func (rb *ringBuffer) tick() {
+// tick advances the ring by one granularity-second when its accumulator
+// reaches the threshold. Returns (rolled, priority) so callers can build
+// per-granularity Tick events without re-reading the ring.
+func (rb *ringBuffer) tick() (bool, int8) {
 	rb.tickAcc++
 	if rb.tickAcc < rb.tickMod {
-		return
+		return false, 0
 	}
 	rb.tickAcc = 0
 
@@ -97,6 +104,7 @@ func (rb *ringBuffer) tick() {
 	if rb.size < HistoryBucketCount {
 		rb.size++
 	}
+	return true, p
 }
 
 func (rb *ringBuffer) snapshot() []string {
@@ -107,6 +115,31 @@ func (rb *ringBuffer) snapshot() []string {
 	start := (rb.head - rb.size + HistoryBucketCount) % HistoryBucketCount
 	for i := 0; i < rb.size; i++ {
 		out[i] = priorityToState(rb.buckets[(start+i)%HistoryBucketCount])
+	}
+	return out
+}
+
+// encodePriorities returns the buffer's 60 buckets oldest→newest as a slice of
+// 2-bit priority codes (0/1/2 = ready/working/waiting, 3 = no-data). Unfilled
+// slots in a partially-filled ring pad the front so the newest bucket is always
+// at index 59.
+func (rb *ringBuffer) encodePriorities() [HistoryBucketCount]uint8 {
+	var out [HistoryBucketCount]uint8
+	for i := range out {
+		out[i] = statePriorityNoData
+	}
+	if rb.size == 0 {
+		return out
+	}
+	start := (rb.head - rb.size + HistoryBucketCount) % HistoryBucketCount
+	dst := HistoryBucketCount - rb.size
+	for i := 0; i < rb.size; i++ {
+		p := rb.buckets[(start+i)%HistoryBucketCount]
+		if p < 0 {
+			out[dst+i] = statePriorityNoData
+		} else {
+			out[dst+i] = uint8(p)
+		}
 	}
 	return out
 }
@@ -168,6 +201,36 @@ func granularityIndex(sec int) int {
 	}
 }
 
+// HistoryEventKind identifies the wire-message type a HistoryEvent maps to.
+type HistoryEventKind int
+
+const (
+	// HistoryEventSnapshot carries the bit-packed history for one session.
+	// Emitted on demand when a session is created or a client connects.
+	HistoryEventSnapshot HistoryEventKind = iota
+	// HistoryEventTick is a bulk per-granularity message: one map entry per
+	// session with the priority of the bucket that just rolled. Emitted
+	// once per granularity-second by the internal ticker.
+	HistoryEventTick
+	// HistoryEventUpgrade is a single-session transition that mutates the
+	// current bucket of all three rings (the client merges with `max`).
+	HistoryEventUpgrade
+)
+
+// HistoryEvent is the tagged event delivered to a HistoryTracker.EmitFunc.
+// Only the fields matching Kind are populated.
+type HistoryEvent struct {
+	Kind HistoryEventKind
+	// Snapshot
+	SessionID string
+	History   map[string]string
+	// Tick
+	GranularitySec int
+	Buckets        map[string]int8
+	// Upgrade
+	Priority int8
+}
+
 // HistoryTracker maintains per-session rolling state buffers in memory.
 // Three granularities (1 s / 10 s / 60 s) are kept in parallel; within each
 // bucket priority aggregation (waiting > working > ready) determines the state.
@@ -177,6 +240,7 @@ type HistoryTracker struct {
 	mu       sync.Mutex
 	sessions map[string]*sessionBuffers
 	saveDir  string
+	emit     func(HistoryEvent)
 }
 
 // NewHistoryTracker creates a HistoryTracker without persistence.
@@ -193,6 +257,38 @@ func NewHistoryTrackerWithDir(saveDir string) *HistoryTracker {
 	}
 }
 
+// SetEmitFunc installs a callback that receives history events (snapshots,
+// ticks, upgrades) for fan-out over the WebSocket hub. Set to nil to disable
+// emission. Must be called before Run() or any OnTransition() to avoid
+// missing the early events of a session.
+func (h *HistoryTracker) SetEmitFunc(fn func(HistoryEvent)) {
+	h.mu.Lock()
+	h.emit = fn
+	h.mu.Unlock()
+}
+
+// EmitSnapshot ships the current bit-packed history for one session through
+// the emit callback. Lazy-creates an empty session entry on first call so a
+// brand-new session yields an all-no-data snapshot instead of being silently
+// skipped — call alongside session_created broadcasts so newly-attached
+// clients see a placeholder history bar before the first tick.
+func (h *HistoryTracker) EmitSnapshot(sessionID string) {
+	h.mu.Lock()
+	if _, ok := h.sessions[sessionID]; !ok {
+		h.sessions[sessionID] = newSessionBuffers()
+	}
+	emit := h.emit
+	h.mu.Unlock()
+	if emit == nil {
+		return
+	}
+	enc, ok := h.Encode(sessionID)
+	if !ok {
+		return
+	}
+	emit(HistoryEvent{Kind: HistoryEventSnapshot, SessionID: sessionID, History: enc})
+}
+
 func (h *HistoryTracker) OnTransition(sessionID, newState string, _ time.Time) {
 	h.mu.Lock()
 	sb, ok := h.sessions[sessionID]
@@ -200,13 +296,77 @@ func (h *HistoryTracker) OnTransition(sessionID, newState string, _ time.Time) {
 		sb = newSessionBuffers()
 		h.sessions[sessionID] = sb
 	}
+	emit := h.emit
 	h.mu.Unlock()
 
 	sb.mu.Lock()
-	defer sb.mu.Unlock()
 	for _, rb := range sb.bufs {
 		rb.upgrade(newState)
 	}
+	sb.mu.Unlock()
+
+	if emit != nil {
+		emit(HistoryEvent{
+			Kind:      HistoryEventUpgrade,
+			SessionID: sessionID,
+			Priority:  int8(statePriority(newState)),
+		})
+	}
+}
+
+// historyEncodedBytes is the byte length of one bit-packed granularity:
+// 60 buckets × 2 bits = 120 bits = 15 bytes. Base64-std encodes this to 20
+// chars (no padding since 15 % 3 == 0).
+const historyEncodedBytes = (HistoryBucketCount*2 + 7) / 8
+
+// packPriorities bit-packs 60 2-bit priority codes into 15 bytes, MSB-first
+// within each byte (oldest bucket in the high-order bits of byte 0).
+func packPriorities(priorities [HistoryBucketCount]uint8) [historyEncodedBytes]byte {
+	var out [historyEncodedBytes]byte
+	for i, p := range priorities {
+		byteIdx := i / 4
+		shift := uint((3 - i%4) * 2)
+		out[byteIdx] |= (p & 0x3) << shift
+	}
+	return out
+}
+
+// Encode bit-packs the session's three rolling buffers into a per-granularity
+// map of base64-std strings (20 chars each, 60 buckets × 2 bits). Returns
+// false if the session is unknown.
+func (h *HistoryTracker) Encode(sessionID string) (map[string]string, bool) {
+	h.mu.Lock()
+	sb, ok := h.sessions[sessionID]
+	h.mu.Unlock()
+	if !ok {
+		return nil, false
+	}
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	out := make(map[string]string, 3)
+	for _, g := range validGranularities {
+		bytes := packPriorities(sb.bufs[granularityIndex(g)].encodePriorities())
+		out[strconv.Itoa(g)] = base64.StdEncoding.EncodeToString(bytes[:])
+	}
+	return out, true
+}
+
+// EncodeAll returns the bit-packed history for every known session, keyed by
+// session ID. Inner map shape matches Encode().
+func (h *HistoryTracker) EncodeAll() map[string]map[string]string {
+	h.mu.Lock()
+	sids := make([]string, 0, len(h.sessions))
+	for sid := range h.sessions {
+		sids = append(sids, sid)
+	}
+	h.mu.Unlock()
+	out := make(map[string]map[string]string, len(sids))
+	for _, sid := range sids {
+		if enc, ok := h.Encode(sid); ok {
+			out[sid] = enc
+		}
+	}
+	return out
 }
 
 func (h *HistoryTracker) Snapshot(sessionID string, granularitySec int) ([]string, bool) {
@@ -252,18 +412,47 @@ func (h *HistoryTracker) Run(ctx context.Context) {
 
 func (h *HistoryTracker) tick() {
 	h.mu.Lock()
-	sbs := make([]*sessionBuffers, 0, len(h.sessions))
-	for _, sb := range h.sessions {
-		sbs = append(sbs, sb)
+	type entry struct {
+		sid string
+		sb  *sessionBuffers
 	}
+	entries := make([]entry, 0, len(h.sessions))
+	for sid, sb := range h.sessions {
+		entries = append(entries, entry{sid, sb})
+	}
+	emit := h.emit
 	h.mu.Unlock()
 
-	for _, sb := range sbs {
-		sb.mu.Lock()
-		for _, rb := range sb.bufs {
-			rb.tick()
+	// Per-granularity buckets that rolled this tick. Index matches
+	// granularityIndex (0=1s, 1=10s, 2=60s).
+	var rolled [3]map[string]int8
+	for _, e := range entries {
+		e.sb.mu.Lock()
+		for gi, rb := range e.sb.bufs {
+			ok, p := rb.tick()
+			if !ok {
+				continue
+			}
+			if rolled[gi] == nil {
+				rolled[gi] = make(map[string]int8)
+			}
+			rolled[gi][e.sid] = p
 		}
-		sb.mu.Unlock()
+		e.sb.mu.Unlock()
+	}
+
+	if emit == nil {
+		return
+	}
+	for gi, m := range rolled {
+		if len(m) == 0 {
+			continue
+		}
+		emit(HistoryEvent{
+			Kind:           HistoryEventTick,
+			GranularitySec: validGranularities[gi],
+			Buckets:        m,
+		})
 	}
 }
 

--- a/core/application/services/history_tracker.go
+++ b/core/application/services/history_tracker.go
@@ -178,6 +178,12 @@ func priorityToState(p int8) string {
 type sessionBuffers struct {
 	mu   sync.Mutex
 	bufs [3]*ringBuffer // index 0=1s, 1=10s, 2=60s
+	// tickGen[i] increments by 1 each time bufs[i] rolls a bucket. Captured
+	// alongside bucket state under mu so snapshots and tick events can be
+	// reconciled by the client (see EncodeWithGens / tick(): if a snapshot
+	// already reflects a tick, the matching tick message arrives with a gen
+	// equal to the snapshot's, and the client skips it).
+	tickGen [3]uint64
 }
 
 func newSessionBuffers() *sessionBuffers {
@@ -222,11 +228,13 @@ const (
 type HistoryEvent struct {
 	Kind HistoryEventKind
 	// Snapshot
-	SessionID string
-	History   map[string]string
+	SessionID   string
+	History     map[string]string // granularity → base64
+	Generations map[string]uint64 // granularity → tick generation that produced History
 	// Tick
-	GranularitySec int
-	Buckets        map[string]int8
+	GranularitySec    int
+	Buckets           map[string]int8   // sessionID → priority of the bucket that just rolled
+	BucketGenerations map[string]uint64 // sessionID → tick generation after this roll
 	// Upgrade
 	Priority int8
 }
@@ -286,7 +294,12 @@ func (h *HistoryTracker) EmitSnapshot(sessionID string) {
 	if !ok {
 		return
 	}
-	emit(HistoryEvent{Kind: HistoryEventSnapshot, SessionID: sessionID, History: enc})
+	emit(HistoryEvent{
+		Kind:        HistoryEventSnapshot,
+		SessionID:   sessionID,
+		History:     enc.History,
+		Generations: enc.Generations,
+	})
 }
 
 func (h *HistoryTracker) OnTransition(sessionID, newState string, _ time.Time) {
@@ -331,36 +344,51 @@ func packPriorities(priorities [HistoryBucketCount]uint8) [historyEncodedBytes]b
 	return out
 }
 
-// Encode bit-packs the session's three rolling buffers into a per-granularity
-// map of base64-std strings (20 chars each, 60 buckets × 2 bits). Returns
-// false if the session is unknown.
-func (h *HistoryTracker) Encode(sessionID string) (map[string]string, bool) {
+// EncodedHistory is one session's bit-packed history together with the
+// per-granularity tick generations that produced it. Both are read under the
+// session's lock so a client receiving a snapshot+tick pair can dedupe by
+// generation: see SessionManager.swift / index.html for the apply-or-skip
+// logic.
+type EncodedHistory struct {
+	History     map[string]string // granularity ("1"/"10"/"60") → 20-char base64
+	Generations map[string]uint64 // same keys as History
+}
+
+// Encode bit-packs the session's three rolling buffers and captures the
+// matching tick generations atomically under the session lock. Returns false
+// if the session is unknown.
+func (h *HistoryTracker) Encode(sessionID string) (EncodedHistory, bool) {
 	h.mu.Lock()
 	sb, ok := h.sessions[sessionID]
 	h.mu.Unlock()
 	if !ok {
-		return nil, false
+		return EncodedHistory{}, false
 	}
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
-	out := make(map[string]string, 3)
+	out := EncodedHistory{
+		History:     make(map[string]string, 3),
+		Generations: make(map[string]uint64, 3),
+	}
 	for _, g := range validGranularities {
-		bytes := packPriorities(sb.bufs[granularityIndex(g)].encodePriorities())
-		out[strconv.Itoa(g)] = base64.StdEncoding.EncodeToString(bytes[:])
+		gi := granularityIndex(g)
+		bytes := packPriorities(sb.bufs[gi].encodePriorities())
+		key := strconv.Itoa(g)
+		out.History[key] = base64.StdEncoding.EncodeToString(bytes[:])
+		out.Generations[key] = sb.tickGen[gi]
 	}
 	return out, true
 }
 
-// EncodeAll returns the bit-packed history for every known session, keyed by
-// session ID. Inner map shape matches Encode().
-func (h *HistoryTracker) EncodeAll() map[string]map[string]string {
+// EncodeAll returns the bit-packed history for every known session.
+func (h *HistoryTracker) EncodeAll() map[string]EncodedHistory {
 	h.mu.Lock()
 	sids := make([]string, 0, len(h.sessions))
 	for sid := range h.sessions {
 		sids = append(sids, sid)
 	}
 	h.mu.Unlock()
-	out := make(map[string]map[string]string, len(sids))
+	out := make(map[string]EncodedHistory, len(sids))
 	for _, sid := range sids {
 		if enc, ok := h.Encode(sid); ok {
 			out[sid] = enc
@@ -423,9 +451,14 @@ func (h *HistoryTracker) tick() {
 	emit := h.emit
 	h.mu.Unlock()
 
-	// Per-granularity buckets that rolled this tick. Index matches
-	// granularityIndex (0=1s, 1=10s, 2=60s).
+	// Per-granularity buckets that rolled this tick (and the tick generation
+	// at which each session's bucket rolled). Index matches granularityIndex
+	// (0=1s, 1=10s, 2=60s). The generation is captured under sb.mu in the
+	// same critical section that mutates the ring, so a concurrent Encode
+	// either observes pre-tick (gen=N-1, pre-mutated buckets) or post-tick
+	// (gen=N, post-mutated buckets) — never a mismatched pair.
 	var rolled [3]map[string]int8
+	var rolledGens [3]map[string]uint64
 	for _, e := range entries {
 		e.sb.mu.Lock()
 		for gi, rb := range e.sb.bufs {
@@ -433,10 +466,13 @@ func (h *HistoryTracker) tick() {
 			if !ok {
 				continue
 			}
+			e.sb.tickGen[gi]++
 			if rolled[gi] == nil {
 				rolled[gi] = make(map[string]int8)
+				rolledGens[gi] = make(map[string]uint64)
 			}
 			rolled[gi][e.sid] = p
+			rolledGens[gi][e.sid] = e.sb.tickGen[gi]
 		}
 		e.sb.mu.Unlock()
 	}
@@ -449,9 +485,10 @@ func (h *HistoryTracker) tick() {
 			continue
 		}
 		emit(HistoryEvent{
-			Kind:           HistoryEventTick,
-			GranularitySec: validGranularities[gi],
-			Buckets:        m,
+			Kind:              HistoryEventTick,
+			GranularitySec:    validGranularities[gi],
+			Buckets:           m,
+			BucketGenerations: rolledGens[gi],
 		})
 	}
 }

--- a/core/application/services/history_tracker_test.go
+++ b/core/application/services/history_tracker_test.go
@@ -254,7 +254,7 @@ func TestHistoryTracker_EncodeEmptyBuffer(t *testing.T) {
 		t.Fatal("Encode missing for known empty session")
 	}
 	for _, g := range []string{"1", "10", "60"} {
-		s, ok := enc[g]
+		s, ok := enc.History[g]
 		if !ok {
 			t.Fatalf("missing granularity %s", g)
 		}
@@ -284,7 +284,7 @@ func TestHistoryTracker_EncodePartialFillPadsFront(t *testing.T) {
 	if !ok {
 		t.Fatal("Encode failed")
 	}
-	buckets := decodeHistoryString(t, enc["1"])
+	buckets := decodeHistoryString(t, enc.History["1"])
 
 	// Last 4 buckets: ready, working, waiting, waiting (carry-forward open
 	// bucket inherits "waiting"). Front 56 are padding (no-data).
@@ -314,7 +314,7 @@ func TestHistoryTracker_EncodeFullRing(t *testing.T) {
 	if !ok {
 		t.Fatal("Encode failed")
 	}
-	buckets := decodeHistoryString(t, enc["1"])
+	buckets := decodeHistoryString(t, enc.History["1"])
 	for i, p := range buckets {
 		if p != statePriorityWorking {
 			t.Errorf("buckets[%d] = %d, want %d", i, p, statePriorityWorking)
@@ -332,11 +332,11 @@ func TestHistoryTracker_EncodeAll(t *testing.T) {
 		t.Fatalf("len(EncodeAll) = %d, want 2", len(all))
 	}
 	for sid, enc := range all {
-		if len(enc) != 3 {
-			t.Errorf("session %q: granularity count = %d, want 3", sid, len(enc))
+		if len(enc.History) != 3 {
+			t.Errorf("session %q: granularity count = %d, want 3", sid, len(enc.History))
 		}
 		for _, g := range []string{"1", "10", "60"} {
-			if _, ok := enc[g]; !ok {
+			if _, ok := enc.History[g]; !ok {
 				t.Errorf("session %q: missing granularity %s", sid, g)
 			}
 		}
@@ -365,7 +365,7 @@ func TestHistoryTracker_EncodeBitOrder(t *testing.T) {
 	if !ok {
 		t.Fatal("Encode failed")
 	}
-	raw, _ := base64.StdEncoding.DecodeString(enc["1"])
+	raw, _ := base64.StdEncoding.DecodeString(enc.History["1"])
 	// encodePriorities front-pads, so these 4 buckets land at output indices
 	// 56..59 = byte 14. MSB-first: (0<<6)|(1<<4)|(2<<2)|(3) = 0b00_01_10_11 = 0x1B.
 	const want = byte(0x1B)
@@ -414,6 +414,70 @@ func TestHistoryTracker_EmitOnTransitionAndTick(t *testing.T) {
 	}
 	if events[0].Buckets["a"] != statePriorityWorking || events[0].Buckets["b"] != statePriorityWaiting {
 		t.Errorf("Buckets = %+v", events[0].Buckets)
+	}
+}
+
+// TestHistoryTracker_GenerationsMatchBuckets locks down the dedup contract
+// the clients rely on: a snapshot's per-granularity Generations equals the
+// number of ticks already folded into its History buckets, and the next
+// tick after that snapshot carries Generations+1. If this invariant breaks
+// (e.g. tick increments outside the sb.mu critical section), clients double-
+// apply ticks on connect and history bars drift one bucket per reconnect.
+func TestHistoryTracker_GenerationsMatchBuckets(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "gens"
+	ht.OnTransition(sid, "working", epoch)
+
+	enc, ok := ht.Encode(sid)
+	if !ok {
+		t.Fatal("Encode failed")
+	}
+	if enc.Generations["1"] != 0 || enc.Generations["10"] != 0 || enc.Generations["60"] != 0 {
+		t.Errorf("pre-tick generations = %+v, want all 0", enc.Generations)
+	}
+
+	var ticks []HistoryEvent
+	ht.SetEmitFunc(func(ev HistoryEvent) {
+		if ev.Kind == HistoryEventTick {
+			ticks = append(ticks, ev)
+		}
+	})
+
+	// One tick: 1s ring rolls; 10s/60s do not.
+	ht.tick()
+	if len(ticks) != 1 {
+		t.Fatalf("tick count = %d, want 1", len(ticks))
+	}
+	if got := ticks[0].BucketGenerations[sid]; got != 1 {
+		t.Errorf("first tick gen = %d, want 1", got)
+	}
+
+	// Snapshot after tick: 1s gen = 1, 10s/60s gen still 0.
+	enc, _ = ht.Encode(sid)
+	if enc.Generations["1"] != 1 || enc.Generations["10"] != 0 || enc.Generations["60"] != 0 {
+		t.Errorf("post-tick generations = %+v, want {1:1, 10:0, 60:0}", enc.Generations)
+	}
+
+	// Ten more ticks: 1s rolls 10×, 10s rolls 1×, 60s still 0.
+	ticks = nil
+	for i := 0; i < 10; i++ {
+		ht.tick()
+	}
+	enc, _ = ht.Encode(sid)
+	if enc.Generations["1"] != 11 || enc.Generations["10"] != 1 || enc.Generations["60"] != 0 {
+		t.Errorf("after 10 ticks generations = %+v, want {1:11, 10:1, 60:0}", enc.Generations)
+	}
+
+	// The most recent 1s tick event must carry the current 1s generation,
+	// so client logic of `gen <= last → skip` deduplicates exactly once.
+	var lastOneSec uint64
+	for _, ev := range ticks {
+		if ev.GranularitySec == 1 {
+			lastOneSec = ev.BucketGenerations[sid]
+		}
+	}
+	if lastOneSec != enc.Generations["1"] {
+		t.Errorf("last 1s tick gen = %d, snapshot gen = %d — must match", lastOneSec, enc.Generations["1"])
 	}
 }
 

--- a/core/application/services/history_tracker_test.go
+++ b/core/application/services/history_tracker_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
@@ -214,6 +215,261 @@ func TestHistoryTracker_NoSaveWithoutDir(t *testing.T) {
 	ht := NewHistoryTracker()
 	ht.OnTransition("s", "working", epoch)
 	ht.save() // must not panic, must not create any file
+}
+
+// decodeHistoryString unpacks a 20-char base64 string back into 60 priority
+// codes. Mirrors the on-the-wire format the Swift client decodes.
+func decodeHistoryString(t *testing.T, s string) [HistoryBucketCount]uint8 {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	if len(raw) != historyEncodedBytes {
+		t.Fatalf("decoded length = %d, want %d", len(raw), historyEncodedBytes)
+	}
+	var out [HistoryBucketCount]uint8
+	for i := 0; i < HistoryBucketCount; i++ {
+		shift := uint((3 - i%4) * 2)
+		out[i] = (raw[i/4] >> shift) & 0x3
+	}
+	return out
+}
+
+func TestHistoryTracker_EncodeUnknownSession(t *testing.T) {
+	ht := NewHistoryTracker()
+	if _, ok := ht.Encode("nope"); ok {
+		t.Error("Encode for unknown session should return ok=false")
+	}
+}
+
+func TestHistoryTracker_EncodeEmptyBuffer(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "empty"
+	// Session exists with all-no-data buffers (no transitions, no ticks yet).
+	ht.sessions[sid] = newSessionBuffers()
+
+	enc, ok := ht.Encode(sid)
+	if !ok {
+		t.Fatal("Encode missing for known empty session")
+	}
+	for _, g := range []string{"1", "10", "60"} {
+		s, ok := enc[g]
+		if !ok {
+			t.Fatalf("missing granularity %s", g)
+		}
+		if len(s) != 20 {
+			t.Errorf("granularity %s: encoded length = %d, want 20", g, len(s))
+		}
+		buckets := decodeHistoryString(t, s)
+		for i, p := range buckets {
+			if p != statePriorityNoData {
+				t.Errorf("granularity %s: bucket[%d] = %d, want %d (no-data)", g, i, p, statePriorityNoData)
+			}
+		}
+	}
+}
+
+func TestHistoryTracker_EncodePartialFillPadsFront(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "partial"
+	// Three sealed buckets: ready, working, waiting (matches
+	// TestHistoryTracker_SnapshotOldestNewest setup).
+	for _, s := range []string{"ready", "working", "waiting"} {
+		ht.OnTransition(sid, s, epoch)
+		ht.tick()
+	}
+
+	enc, ok := ht.Encode(sid)
+	if !ok {
+		t.Fatal("Encode failed")
+	}
+	buckets := decodeHistoryString(t, enc["1"])
+
+	// Last 4 buckets: ready, working, waiting, waiting (carry-forward open
+	// bucket inherits "waiting"). Front 56 are padding (no-data).
+	for i := 0; i < HistoryBucketCount-4; i++ {
+		if buckets[i] != statePriorityNoData {
+			t.Errorf("front padding[%d] = %d, want no-data", i, buckets[i])
+		}
+	}
+	want := []uint8{statePriorityReady, statePriorityWorking, statePriorityWaiting, statePriorityWaiting}
+	for i, w := range want {
+		if got := buckets[HistoryBucketCount-4+i]; got != w {
+			t.Errorf("buckets[%d] = %d, want %d", HistoryBucketCount-4+i, got, w)
+		}
+	}
+}
+
+func TestHistoryTracker_EncodeFullRing(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "full"
+	// Fill all 60 buckets with "working".
+	ht.OnTransition(sid, "working", epoch)
+	for i := 0; i < HistoryBucketCount; i++ {
+		ht.tick()
+	}
+
+	enc, ok := ht.Encode(sid)
+	if !ok {
+		t.Fatal("Encode failed")
+	}
+	buckets := decodeHistoryString(t, enc["1"])
+	for i, p := range buckets {
+		if p != statePriorityWorking {
+			t.Errorf("buckets[%d] = %d, want %d", i, p, statePriorityWorking)
+		}
+	}
+}
+
+func TestHistoryTracker_EncodeAll(t *testing.T) {
+	ht := NewHistoryTracker()
+	ht.OnTransition("a", "working", epoch)
+	ht.OnTransition("b", "waiting", epoch)
+
+	all := ht.EncodeAll()
+	if len(all) != 2 {
+		t.Fatalf("len(EncodeAll) = %d, want 2", len(all))
+	}
+	for sid, enc := range all {
+		if len(enc) != 3 {
+			t.Errorf("session %q: granularity count = %d, want 3", sid, len(enc))
+		}
+		for _, g := range []string{"1", "10", "60"} {
+			if _, ok := enc[g]; !ok {
+				t.Errorf("session %q: missing granularity %s", sid, g)
+			}
+		}
+	}
+}
+
+func TestHistoryTracker_EncodeBitOrder(t *testing.T) {
+	// Hand-craft a buffer with 4 sealed buckets {ready, working, waiting, no-data}
+	// so we can assert MSB-first byte layout of the trailing byte that holds them.
+	ht := NewHistoryTracker()
+	sid := "bitorder"
+	ht.sessions[sid] = newSessionBuffers()
+	rb := ht.sessions[sid].bufs[0]
+	for i := range rb.buckets {
+		rb.buckets[i] = -1
+	}
+	rb.buckets[0] = 0 // ready
+	rb.buckets[1] = 1 // working
+	rb.buckets[2] = 2 // waiting
+	rb.buckets[3] = -1
+	rb.head = 4
+	rb.size = 4
+	rb.lastState = "waiting"
+
+	enc, ok := ht.Encode(sid)
+	if !ok {
+		t.Fatal("Encode failed")
+	}
+	raw, _ := base64.StdEncoding.DecodeString(enc["1"])
+	// encodePriorities front-pads, so these 4 buckets land at output indices
+	// 56..59 = byte 14. MSB-first: (0<<6)|(1<<4)|(2<<2)|(3) = 0b00_01_10_11 = 0x1B.
+	const want = byte(0x1B)
+	if raw[14] != want {
+		t.Errorf("trailing byte = %#x, want %#x", raw[14], want)
+	}
+	// Front padding bytes must be all-no-data: 4 × 0b11 = 0xFF.
+	for i := 0; i < 14; i++ {
+		if raw[i] != 0xFF {
+			t.Errorf("padding byte[%d] = %#x, want 0xFF", i, raw[i])
+		}
+	}
+}
+
+func TestHistoryTracker_EmitOnTransitionAndTick(t *testing.T) {
+	ht := NewHistoryTracker()
+	var events []HistoryEvent
+	ht.SetEmitFunc(func(ev HistoryEvent) { events = append(events, ev) })
+
+	ht.OnTransition("a", "working", epoch)
+	ht.OnTransition("b", "waiting", epoch)
+
+	// Two upgrades emitted, in order.
+	if len(events) != 2 {
+		t.Fatalf("len(events) after transitions = %d, want 2", len(events))
+	}
+	for i, ev := range events {
+		if ev.Kind != HistoryEventUpgrade {
+			t.Errorf("events[%d].Kind = %d, want Upgrade", i, ev.Kind)
+		}
+	}
+	if events[0].SessionID != "a" || events[0].Priority != statePriorityWorking {
+		t.Errorf("events[0] = %+v", events[0])
+	}
+	if events[1].SessionID != "b" || events[1].Priority != statePriorityWaiting {
+		t.Errorf("events[1] = %+v", events[1])
+	}
+
+	events = nil
+	ht.tick() // 1s ring rolls; 10s/60s do not.
+	if len(events) != 1 {
+		t.Fatalf("len(events) after tick = %d, want 1", len(events))
+	}
+	if events[0].Kind != HistoryEventTick || events[0].GranularitySec != 1 {
+		t.Errorf("events[0] = %+v, want Tick @ 1s", events[0])
+	}
+	if events[0].Buckets["a"] != statePriorityWorking || events[0].Buckets["b"] != statePriorityWaiting {
+		t.Errorf("Buckets = %+v", events[0].Buckets)
+	}
+}
+
+func TestHistoryTracker_TickEmitsAllGranularitiesAt60s(t *testing.T) {
+	ht := NewHistoryTracker()
+	var events []HistoryEvent
+	ht.SetEmitFunc(func(ev HistoryEvent) { events = append(events, ev) })
+	ht.OnTransition("s", "working", epoch)
+	events = nil
+
+	// 60 ticks → 1s rolls 60×, 10s rolls 6×, 60s rolls 1×.
+	for i := 0; i < 60; i++ {
+		ht.tick()
+	}
+	var per [3]int
+	for _, ev := range events {
+		if ev.Kind != HistoryEventTick {
+			continue
+		}
+		per[granularityIndex(ev.GranularitySec)]++
+	}
+	if per[0] != 60 || per[1] != 6 || per[2] != 1 {
+		t.Errorf("tick counts (1s,10s,60s) = %v, want (60,6,1)", per)
+	}
+}
+
+func TestHistoryTracker_EmitSnapshot(t *testing.T) {
+	ht := NewHistoryTracker()
+	var events []HistoryEvent
+	ht.SetEmitFunc(func(ev HistoryEvent) { events = append(events, ev) })
+	ht.OnTransition("s", "working", epoch)
+	events = nil
+
+	ht.EmitSnapshot("s")
+	if len(events) != 1 || events[0].Kind != HistoryEventSnapshot {
+		t.Fatalf("expected one Snapshot event, got %+v", events)
+	}
+	if events[0].SessionID != "s" || len(events[0].History) != 3 {
+		t.Errorf("snapshot event = %+v", events[0])
+	}
+
+	// EmitSnapshot for an unknown session lazy-creates an empty entry and
+	// emits an all-no-data snapshot. That's intentional: session_created
+	// fires before the first state transition, but clients still need a
+	// hydration message so the row's history bar renders.
+	events = nil
+	ht.EmitSnapshot("fresh")
+	if len(events) != 1 || events[0].SessionID != "fresh" || len(events[0].History) != 3 {
+		t.Errorf("unknown-session snapshot = %+v", events)
+	}
+	buckets := decodeHistoryString(t, events[0].History["1"])
+	for i, p := range buckets {
+		if p != statePriorityNoData {
+			t.Errorf("fresh snapshot bucket[%d] = %d, want no-data", i, p)
+		}
+	}
 }
 
 func TestValidGranularity(t *testing.T) {

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -34,6 +34,13 @@ func (d *SessionDetector) broadcast(msgType string, state *session.SessionState)
 	d.refreshSubagentSummary(state)
 	d.broadcaster.Broadcast(outbound.PushMessage{Type: msgType, Session: state})
 
+	// Newly-created sessions get an immediate history_snapshot so any
+	// connected client can hydrate the row's history bars before the first
+	// tick or transition rolls in.
+	if msgType == outbound.PushTypeCreated && d.historyTracker != nil {
+		d.historyTracker.EmitSnapshot(state.SessionID)
+	}
+
 	if state.ParentSessionID == "" {
 		return
 	}

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"net/http"
-	"strconv"
 	"sync"
 	"time"
 
@@ -49,51 +48,6 @@ func handleGetSessions(repo outbound.SessionRepository, orchMonitor *services.Or
 		resp := session.BuildDashboard(sessions, orchMonitor.State("gastown"))
 		if tracker != nil {
 			attachGroupCosts(resp, tracker, cache)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	}
-}
-
-// handleGetSessionsHistory serves pre-aggregated per-session state history at
-// a chosen granularity. Clients poll this endpoint at their own cadence to
-// populate history bars without bloating the WebSocket envelope.
-//
-// GET /api/v1/sessions/history?granularity=1|10|60
-func handleGetSessionsHistory(repo outbound.SessionRepository, ht outbound.HistoryTracker) http.HandlerFunc {
-	type historyResponse struct {
-		GranularitySec int                 `json:"granularity_sec"`
-		BucketCount    int                 `json:"bucket_count"`
-		Sessions       map[string][]string `json:"sessions"`
-	}
-	return func(w http.ResponseWriter, r *http.Request) {
-		granularity := 1
-		if g := r.URL.Query().Get("granularity"); g != "" {
-			n, err := strconv.Atoi(g)
-			if err != nil || (n != 1 && n != 10 && n != 60) {
-				http.Error(w, "granularity must be 1, 10, or 60", http.StatusBadRequest)
-				return
-			}
-			granularity = n
-		}
-
-		sessions, err := repo.ListAll()
-		if err != nil {
-			http.Error(w, "internal error", http.StatusInternalServerError)
-			return
-		}
-
-		out := make(map[string][]string, len(sessions))
-		for _, s := range sessions {
-			if snap, ok := ht.Snapshot(s.SessionID, granularity); ok {
-				out[s.SessionID] = snap
-			}
-		}
-
-		resp := historyResponse{
-			GranularitySec: granularity,
-			BucketCount:    services.HistoryBucketCount,
-			Sessions:       out,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -140,6 +140,10 @@ func main() {
 	// Push broadcaster for WebSocket fan-out.
 	push := services.NewPushService()
 
+	// Stream history events (snapshots, ticks, upgrades) over the same
+	// WebSocket envelope as session-state messages.
+	historyTracker.SetEmitFunc(historyEventBroadcaster(push))
+
 	// Unified registration for every inbound agent adapter. Wiring below
 	// (fswatchers, process scanners, metrics parser map, PID discovery map)
 	// derives from this single slice — the only place new agents need to be
@@ -198,7 +202,7 @@ func main() {
 	// Sessions endpoint registered after orchMonitor is available (see below).
 	mux.HandleFunc("GET /state", handleGetState(cachedRepo))
 
-	hub := wshub.NewHub(push)
+	hub := wshub.NewHub(push, historyTracker.EncodeAll)
 	mux.HandleFunc("GET /api/v1/sessions/stream", hub.ServeWS)
 
 	// pprof debug endpoints for runtime profiling (localhost only).
@@ -296,7 +300,6 @@ func main() {
 
 	// Register API endpoints (after orchMonitor is available).
 	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(cachedRepo, orchMonitor, costTracker))
-	mux.HandleFunc("GET /api/v1/sessions/history", handleGetSessionsHistory(cachedRepo, historyTracker))
 
 	focusService := services.NewFocusService(cachedRepo, push, logger)
 	mux.HandleFunc("POST /api/v1/sessions/{id}/focus", sessionshandler.NewFocusHandler(focusService, logger))
@@ -612,6 +615,35 @@ func initCostTracker(logger outbound.Logger, fsRepo *filesystem.SessionRepositor
 		}
 	}
 	return costTracker
+}
+
+// historyEventBroadcaster maps HistoryEvent (the in-memory tagged union the
+// tracker emits) onto PushMessage envelopes the WebSocket hub already knows
+// how to serialize.
+func historyEventBroadcaster(push outbound.PushBroadcaster) func(services.HistoryEvent) {
+	return func(ev services.HistoryEvent) {
+		switch ev.Kind {
+		case services.HistoryEventSnapshot:
+			push.Broadcast(outbound.PushMessage{
+				Type:      outbound.PushTypeHistorySnapshot,
+				SessionID: ev.SessionID,
+				History:   ev.History,
+			})
+		case services.HistoryEventTick:
+			push.Broadcast(outbound.PushMessage{
+				Type:           outbound.PushTypeHistoryTick,
+				GranularitySec: ev.GranularitySec,
+				Buckets:        ev.Buckets,
+			})
+		case services.HistoryEventUpgrade:
+			p := ev.Priority
+			push.Broadcast(outbound.PushMessage{
+				Type:      outbound.PushTypeHistoryUpgrade,
+				SessionID: ev.SessionID,
+				Priority:  &p,
+			})
+		}
+	}
 }
 
 // startHistoryTracker brings up the per-session rolling ring buffers used by

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -202,7 +202,7 @@ func main() {
 	// Sessions endpoint registered after orchMonitor is available (see below).
 	mux.HandleFunc("GET /state", handleGetState(cachedRepo))
 
-	hub := wshub.NewHub(push, historyTracker.EncodeAll)
+	hub := wshub.NewHub(push, historySnapshotProvider(historyTracker))
 	mux.HandleFunc("GET /api/v1/sessions/stream", hub.ServeWS)
 
 	// pprof debug endpoints for runtime profiling (localhost only).
@@ -625,15 +625,17 @@ func historyEventBroadcaster(push outbound.PushBroadcaster) func(services.Histor
 		switch ev.Kind {
 		case services.HistoryEventSnapshot:
 			push.Broadcast(outbound.PushMessage{
-				Type:      outbound.PushTypeHistorySnapshot,
-				SessionID: ev.SessionID,
-				History:   ev.History,
+				Type:        outbound.PushTypeHistorySnapshot,
+				SessionID:   ev.SessionID,
+				History:     ev.History,
+				Generations: ev.Generations,
 			})
 		case services.HistoryEventTick:
 			push.Broadcast(outbound.PushMessage{
-				Type:           outbound.PushTypeHistoryTick,
-				GranularitySec: ev.GranularitySec,
-				Buckets:        ev.Buckets,
+				Type:              outbound.PushTypeHistoryTick,
+				GranularitySec:    ev.GranularitySec,
+				Buckets:           ev.Buckets,
+				BucketGenerations: ev.BucketGenerations,
 			})
 		case services.HistoryEventUpgrade:
 			p := ev.Priority
@@ -643,6 +645,26 @@ func historyEventBroadcaster(push outbound.PushBroadcaster) func(services.Histor
 				Priority:  &p,
 			})
 		}
+	}
+}
+
+// historySnapshotProvider builds a connect-time hydration list for the
+// WebSocket hub. Each PushMessage carries the snapshot's per-granularity
+// tick generations alongside the bit-packed history so a client can dedupe
+// any tick that fires between subscribe and the first message dispatch.
+func historySnapshotProvider(ht *services.HistoryTracker) wshub.ConnectSnapshots {
+	return func() []outbound.PushMessage {
+		all := ht.EncodeAll()
+		out := make([]outbound.PushMessage, 0, len(all))
+		for sid, enc := range all {
+			out = append(out, outbound.PushMessage{
+				Type:        outbound.PushTypeHistorySnapshot,
+				SessionID:   sid,
+				History:     enc.History,
+				Generations: enc.Generations,
+			})
+		}
+		return out
 	}
 }
 

--- a/core/cmd/irrlichd/main_test.go
+++ b/core/cmd/irrlichd/main_test.go
@@ -34,7 +34,7 @@ func newTestStack(t *testing.T) (*httptest.Server, *filesystem.SessionRepository
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(repo, orchMonitor, nil))
 	mux.HandleFunc("GET /state", handleGetState(repo))
-	hub := wshub.NewHub(push)
+	hub := wshub.NewHub(push, nil)
 	mux.HandleFunc("GET /api/v1/sessions/stream", hub.ServeWS)
 
 	uiSub, _ := fs.Sub(uiFS, "ui")
@@ -53,85 +53,6 @@ func seedSession(t *testing.T, repo *filesystem.SessionRepository, id, state str
 	}
 	if err := repo.Save(s); err != nil {
 		t.Fatalf("seed session %s: %v", id, err)
-	}
-}
-
-// newHistoryTestStack is a variant of newTestStack that also wires the
-// /api/v1/sessions/history handler against a provided HistoryTracker.
-func newHistoryTestStack(t *testing.T, ht *services.HistoryTracker) (*httptest.Server, *filesystem.SessionRepository) {
-	t.Helper()
-
-	repo := filesystem.NewWithDir(t.TempDir())
-	push := services.NewPushService()
-	orchMonitor := services.NewOrchestratorMonitor(nil, push, nil)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(repo, orchMonitor, nil))
-	mux.HandleFunc("GET /api/v1/sessions/history", handleGetSessionsHistory(repo, ht))
-	return httptest.NewServer(mux), repo
-}
-
-// TestGate_GetSessionsHistory_SeedsPerSession verifies the web UI's seed
-// endpoint returns per-session state slices and response-shape fields.
-func TestGate_GetSessionsHistory_SeedsPerSession(t *testing.T) {
-	ht := services.NewHistoryTracker()
-	srv, repo := newHistoryTestStack(t, ht)
-	defer srv.Close()
-
-	seedSession(t, repo, "hist-1", session.StateWorking)
-	seedSession(t, repo, "hist-2", session.StateReady)
-
-	now := time.Now()
-	ht.OnTransition("hist-1", session.StateWorking, now)
-	ht.OnTransition("hist-2", session.StateReady, now)
-
-	resp, err := http.Get(srv.URL + "/api/v1/sessions/history?granularity=1")
-	if err != nil {
-		t.Fatalf("GET: %v", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200", resp.StatusCode)
-	}
-
-	var body struct {
-		GranularitySec int                 `json:"granularity_sec"`
-		BucketCount    int                 `json:"bucket_count"`
-		Sessions       map[string][]string `json:"sessions"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if body.GranularitySec != 1 {
-		t.Errorf("granularity_sec = %d, want 1", body.GranularitySec)
-	}
-	if body.BucketCount != services.HistoryBucketCount {
-		t.Errorf("bucket_count = %d, want %d", body.BucketCount, services.HistoryBucketCount)
-	}
-	s1, ok := body.Sessions["hist-1"]
-	if !ok {
-		t.Fatalf("sessions missing hist-1: %v", body.Sessions)
-	}
-	if len(s1) == 0 || s1[len(s1)-1] != session.StateWorking {
-		t.Errorf("hist-1 last = %v, want working", s1)
-	}
-	if _, ok := body.Sessions["hist-2"]; !ok {
-		t.Errorf("sessions missing hist-2: %v", body.Sessions)
-	}
-}
-
-func TestGate_GetSessionsHistory_BadGranularity(t *testing.T) {
-	ht := services.NewHistoryTracker()
-	srv, _ := newHistoryTestStack(t, ht)
-	defer srv.Close()
-
-	resp, err := http.Get(srv.URL + "/api/v1/sessions/history?granularity=7")
-	if err != nil {
-		t.Fatalf("GET: %v", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Errorf("status = %d, want 400", resp.StatusCode)
 	}
 }
 

--- a/core/cmd/irrlichd/ui/index.html
+++ b/core/cmd/irrlichd/ui/index.html
@@ -865,6 +865,9 @@
     // historyByGranularity[g][sessionID] is a 60-element oldest→newest array of state names
     // (or "" for no-data buckets). Mirrored from the daemon's bit-packed wire format.
     const historyByGranularity = {1: {}, 10: {}, 60: {}};
+    // lastTickGen[sessionID][granularity] = highest applied tick generation. Lets us drop
+    // a tick that's already reflected in our snapshot (closing the connect-time race).
+    const lastTickGen = {};
 
     const HISTORY_PRIORITY_TO_STATE = ['ready', 'working', 'waiting', ''];
     function historyPriorityForState(s) {
@@ -910,7 +913,7 @@
       timelineHistory = newMap;
     }
 
-    function applyHistorySnapshot(sessionID, history) {
+    function applyHistorySnapshot(sessionID, history, generations) {
       for (const granKey of Object.keys(history)) {
         const gran = parseInt(granKey, 10);
         if (![1, 10, 60].includes(gran)) continue;
@@ -918,21 +921,41 @@
         if (!buckets) continue;
         historyByGranularity[gran][sessionID] = buckets;
       }
+      // Seed the dedup high-water-mark from the snapshot so any tick already
+      // folded into this snapshot gets skipped on arrival.
+      if (generations) {
+        const perGran = lastTickGen[sessionID] || {};
+        for (const granKey of Object.keys(generations)) {
+          const gran = parseInt(granKey, 10);
+          if ([1, 10, 60].includes(gran)) perGran[gran] = generations[granKey];
+        }
+        lastTickGen[sessionID] = perGran;
+      }
       rebuildTimelineHistory();
     }
 
-    function applyHistoryTick(granularitySec, buckets) {
+    function applyHistoryTick(granularitySec, buckets, bucketGenerations) {
       if (![1, 10, 60].includes(granularitySec)) return;
       const dict = historyByGranularity[granularitySec];
+      let changed = false;
       for (const sid of Object.keys(buckets)) {
+        // Skip if this tick has already been folded into our snapshot.
+        if (bucketGenerations && bucketGenerations[sid] !== undefined) {
+          const gen = bucketGenerations[sid];
+          const last = (lastTickGen[sid] && lastTickGen[sid][granularitySec]) || 0;
+          if (gen <= last) continue;
+          if (!lastTickGen[sid]) lastTickGen[sid] = {};
+          lastTickGen[sid][granularitySec] = gen;
+        }
         let arr = dict[sid];
         if (!arr) arr = new Array(60).fill('');
         arr.shift();
         arr.push(HISTORY_PRIORITY_TO_STATE[buckets[sid] & 0x3]);
         while (arr.length < 60) arr.unshift('');
         dict[sid] = arr;
+        changed = true;
       }
-      if (granularitySec === currentGranularity) rebuildTimelineHistory();
+      if (changed && granularitySec === currentGranularity) rebuildTimelineHistory();
     }
 
     function applyHistoryUpgrade(sessionID, priority) {
@@ -1092,6 +1115,10 @@
 
     function applySessionDelete(sessionId) {
       var entry = sessionIndex.get(sessionId);
+      delete lastTickGen[sessionId];
+      delete historyByGranularity[1][sessionId];
+      delete historyByGranularity[10][sessionId];
+      delete historyByGranularity[60][sessionId];
       if (!entry) return;
       sessionIndex.delete(sessionId);
       if (entry.parent) {
@@ -1743,12 +1770,12 @@
           return;
         }
         if (msg.type === 'history_snapshot' && msg.session_id && msg.history) {
-          applyHistorySnapshot(msg.session_id, msg.history);
+          applyHistorySnapshot(msg.session_id, msg.history, msg.generations);
           repaintHistory();
           return;
         }
         if (msg.type === 'history_tick' && typeof msg.granularity_sec === 'number' && msg.buckets) {
-          applyHistoryTick(msg.granularity_sec, msg.buckets);
+          applyHistoryTick(msg.granularity_sec, msg.buckets, msg.bucket_generations);
           if (msg.granularity_sec === currentGranularity) repaintHistory();
           return;
         }

--- a/core/cmd/irrlichd/ui/index.html
+++ b/core/cmd/irrlichd/ui/index.html
@@ -219,6 +219,63 @@
       width: 100%;
     }
 
+    .timeline-controls {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      margin-bottom: 6px;
+    }
+
+    .timeline-gran-label {
+      font-size: 9px;
+      color: var(--muted);
+      font-family: var(--font-mono);
+      margin-right: 2px;
+    }
+
+    .timeline-gran-btn {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      color: var(--muted);
+      font-size: 9px;
+      font-family: var(--font-mono);
+      padding: 1px 5px;
+      cursor: pointer;
+    }
+
+    .timeline-gran-btn:hover { border-color: var(--working); color: var(--text); }
+    .timeline-gran-btn.active { border-color: var(--working); color: var(--working); }
+
+    /* Per-row history bar (wide viewports only) */
+    .row-history {
+      width: 120px;
+      height: 6px;
+      flex-shrink: 0;
+      display: block;
+    }
+
+    /* View-mode toggle (narrow viewports) */
+    .view-mode-bar {
+      display: none;
+      gap: 4px;
+      margin-bottom: 8px;
+    }
+
+    .view-mode-btn {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      color: var(--muted);
+      font-size: 9px;
+      font-family: var(--font-mono);
+      padding: 2px 8px;
+      cursor: pointer;
+    }
+
+    .view-mode-btn:hover { border-color: var(--working); color: var(--text); }
+    .view-mode-btn.active { border-color: var(--working); color: var(--working); }
+
     /* --- Session list --- */
     .session-list {
       display: flex;
@@ -286,6 +343,7 @@
     .session-row {
       display: flex;
       align-items: center;
+      flex-wrap: wrap;
       gap: 6px;
       padding: 3px 10px;
       font-family: var(--font-mono);
@@ -427,6 +485,30 @@
       white-space: nowrap;
       max-width: 300px;
       padding: 0 4px;
+    }
+
+    /* Task progress dots */
+    .row-tasks {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 3px;
+    }
+    .task-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      flex-shrink: 0;
+      cursor: default;
+    }
+    .task-dot.task-pending    { background: transparent; border: 1.5px solid var(--working); }
+    .task-dot.task-in_progress { background: transparent; border: 1.5px solid var(--working); }
+    .task-dot.task-completed  { background: var(--ready); border: 1.5px solid var(--ready); }
+    .row-task-count {
+      font-size: 9px;
+      color: var(--muted);
+      margin-left: 2px;
+      font-family: var(--font-mono);
     }
 
     /* Pressure alert row */
@@ -674,6 +756,9 @@
       .row-branch { max-width: 80px; }
       .row-ctx-bar { width: 50px; }
       .row-model { max-width: 80px; }
+      /* History bar is hidden on narrow; toggle controls visibility via JS */
+      .row-history { display: none; }
+      .view-mode-bar { display: flex; }
     }
 
     @media (max-width: 480px) {
@@ -682,6 +767,13 @@
       .row-ctx-bar { display: none; }
       .row-ctx-pct { display: none; }
     }
+
+    /* History view mode: hide meta columns, show history bar */
+    body.view-history .row-ctx-bar { display: none !important; }
+    body.view-history .row-ctx-pct { display: none !important; }
+    body.view-history .row-cost    { display: none !important; }
+    body.view-history .row-model   { display: none !important; }
+    body.view-history .row-history { display: block !important; }
   </style>
 </head>
 <body>
@@ -717,7 +809,19 @@
 
     <div id="dashboard-panel" class="tab-panel active">
       <div id="gt-container" style="display:none" aria-label="Gas Town"></div>
-      <div id="timeline-wrap"><canvas id="timeline"></canvas></div>
+      <div class="view-mode-bar">
+        <button class="view-mode-btn active" data-mode="meta">Context/Cost/Model</button>
+        <button class="view-mode-btn" data-mode="history">History</button>
+      </div>
+      <div id="timeline-wrap">
+        <div class="timeline-controls">
+          <span class="timeline-gran-label">Interval:</span>
+          <button class="timeline-gran-btn active" data-gran="1">1s</button>
+          <button class="timeline-gran-btn" data-gran="10">10s</button>
+          <button class="timeline-gran-btn" data-gran="60">60s</button>
+        </div>
+        <canvas id="timeline"></canvas>
+      </div>
       <div id="empty-state">
         <div class="empty-dot"></div>
         <p>awaiting sessions</p>
@@ -753,10 +857,99 @@
     let currentTimeframe = localStorage.getItem('irrlicht_costTimeframe') || 'day';
     if (!COST_TIMEFRAMES.find(t => t.key === currentTimeframe)) currentTimeframe = 'day';
 
-    // --- Timeline history ---
-    const TIMELINE_MAX_TICKS = 150;
-    const TIMELINE_TICK_MS = 2000;
-    const timelineHistory = new Map(); // session_id -> {label, states: string[]}
+    // --- Timeline / history state (WebSocket-streamed, see history_snapshot/tick/upgrade) ---
+    let timelineHistory = new Map(); // session_id -> {label, states: string[]} for the active granularity
+    let currentGranularity = parseInt(localStorage.getItem('irrlicht_granularity') || '1', 10);
+    if (![1, 10, 60].includes(currentGranularity)) currentGranularity = 1;
+    let currentBucketCount = 60;
+    // historyByGranularity[g][sessionID] is a 60-element oldest→newest array of state names
+    // (or "" for no-data buckets). Mirrored from the daemon's bit-packed wire format.
+    const historyByGranularity = {1: {}, 10: {}, 60: {}};
+
+    const HISTORY_PRIORITY_TO_STATE = ['ready', 'working', 'waiting', ''];
+    function historyPriorityForState(s) {
+      switch (s) {
+        case 'waiting': return 2;
+        case 'working': return 1;
+        case 'ready':   return 0;
+        default:        return -1;
+      }
+    }
+    function decodeHistoryBuckets(b64) {
+      // Daemon ships 60 buckets × 2 bits MSB-first = 15 bytes = 20 base64 chars.
+      let raw;
+      try { raw = atob(b64); } catch (e) { return null; }
+      if (raw.length !== 15) return null;
+      const out = new Array(60);
+      for (let i = 0; i < 15; i++) {
+        const byte = raw.charCodeAt(i);
+        out[i * 4 + 0] = HISTORY_PRIORITY_TO_STATE[(byte >> 6) & 0x3];
+        out[i * 4 + 1] = HISTORY_PRIORITY_TO_STATE[(byte >> 4) & 0x3];
+        out[i * 4 + 2] = HISTORY_PRIORITY_TO_STATE[(byte >> 2) & 0x3];
+        out[i * 4 + 3] = HISTORY_PRIORITY_TO_STATE[byte & 0x3];
+      }
+      return out;
+    }
+
+    // Rebuild `timelineHistory` from the chosen granularity dict. The renderer
+    // expects `states` to omit leading no-data slots so the bar right-anchors.
+    function rebuildTimelineHistory() {
+      const dict = historyByGranularity[currentGranularity] || {};
+      const newMap = new Map();
+      for (const sid of Object.keys(dict)) {
+        const buckets = dict[sid];
+        let i = 0;
+        while (i < buckets.length && buckets[i] === '') i++;
+        const states = buckets.slice(i);
+        const entry = sessionIndex.get(sid);
+        const label = entry
+          ? (entry.agent.project_name || '').slice(0, 10) + ' ' + shortID(sid)
+          : shortID(sid);
+        newMap.set(sid, {label, states});
+      }
+      timelineHistory = newMap;
+    }
+
+    function applyHistorySnapshot(sessionID, history) {
+      for (const granKey of Object.keys(history)) {
+        const gran = parseInt(granKey, 10);
+        if (![1, 10, 60].includes(gran)) continue;
+        const buckets = decodeHistoryBuckets(history[granKey]);
+        if (!buckets) continue;
+        historyByGranularity[gran][sessionID] = buckets;
+      }
+      rebuildTimelineHistory();
+    }
+
+    function applyHistoryTick(granularitySec, buckets) {
+      if (![1, 10, 60].includes(granularitySec)) return;
+      const dict = historyByGranularity[granularitySec];
+      for (const sid of Object.keys(buckets)) {
+        let arr = dict[sid];
+        if (!arr) arr = new Array(60).fill('');
+        arr.shift();
+        arr.push(HISTORY_PRIORITY_TO_STATE[buckets[sid] & 0x3]);
+        while (arr.length < 60) arr.unshift('');
+        dict[sid] = arr;
+      }
+      if (granularitySec === currentGranularity) rebuildTimelineHistory();
+    }
+
+    function applyHistoryUpgrade(sessionID, priority) {
+      const newState = HISTORY_PRIORITY_TO_STATE[priority & 0x3];
+      const newPrio = historyPriorityForState(newState);
+      let changedActive = false;
+      for (const gran of [1, 10, 60]) {
+        const arr = historyByGranularity[gran][sessionID];
+        if (!arr || arr.length === 0) continue;
+        const lastPrio = historyPriorityForState(arr[arr.length - 1]);
+        if (newPrio > lastPrio) {
+          arr[arr.length - 1] = newState;
+          if (gran === currentGranularity) changedActive = true;
+        }
+      }
+      if (changedActive) rebuildTimelineHistory();
+    }
 
     // --- SVG Icons (compact 12px) ---
     const svgIcons = {
@@ -1116,6 +1309,7 @@
     function createSessionRow(agent, isChild) {
       const el = document.createElement('div');
       el.className = 'session-row' + (isChild ? ' child' : '');
+      el.dataset.sessionId = agent.session_id;
       // Build inner structure
       el.innerHTML =
         '<span class="row-state-icon"></span>' +
@@ -1124,11 +1318,13 @@
         '<span class="row-sub-badge" style="display:none"></span>' +
         '<span class="row-branch"></span>' +
         '<span class="row-question" style="display:none"></span>' +
+        '<div class="row-tasks" style="display:none"></div>' +
         '<span class="row-ctx-bar"><span class="row-ctx-fill"></span></span>' +
         '<span class="row-ctx-pct"></span>' +
         '<span class="row-cost"></span>' +
         '<span class="row-tool" style="display:none"></span>' +
         '<span class="row-spacer"></span>' +
+        '<canvas class="row-history"></canvas>' +
         '<span class="row-model"></span>' +
         '<span class="row-elapsed"></span>' +
         '<span class="row-id"></span>';
@@ -1182,6 +1378,23 @@
         }
       } else {
         questionEl.style.display = 'none';
+      }
+
+      // Task progress dots (Claude Code TaskCreate / TaskUpdate)
+      const tasksEl = el.querySelector('.row-tasks');
+      const tasks = metrics.tasks;
+      const allDone = tasks && tasks.length > 0 && tasks.every(t => t.status === 'completed');
+      if (tasks && tasks.length > 0 && !allDone) {
+        tasksEl.style.display = '';
+        const done = tasks.filter(t => t.status === 'completed').length;
+        const taskLabel = (t) => (t.status === 'in_progress' && t.active_form) ? t.active_form : t.subject;
+        const newHtml = tasks.map(t => {
+          const tip = taskLabel(t).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
+          return '<span class="task-dot task-' + (t.status || 'pending') + '" title="' + tip + '"></span>';
+        }).join('') + '<span class="row-task-count">' + done + ' / ' + tasks.length + '</span>';
+        if (tasksEl.innerHTML !== newHtml) tasksEl.innerHTML = newHtml;
+      } else {
+        tasksEl.style.display = 'none';
       }
 
       // Context bar
@@ -1242,6 +1455,10 @@
       } else {
         toolEl.style.display = 'none';
       }
+
+      // Per-row history bar
+      const histCanvas = el.querySelector('.row-history');
+      paintRowHistory(histCanvas, agent.session_id);
     }
 
     // --- Render ---
@@ -1385,33 +1602,37 @@
       ready: '#34C759',
     };
 
-    function timelineTick() {
-      // Record current state of all sessions
-      const seen = new Set();
-      for (const [sid, entry] of sessionIndex) {
-        seen.add(sid);
-        let rec = timelineHistory.get(sid);
-        if (!rec) {
-          const label = (entry.agent.project_name || '').slice(0, 10) + ' ' + shortID(sid);
-          rec = {label, states: []};
-          timelineHistory.set(sid, rec);
-        }
-        rec.states.push(entry.agent.state || 'ready');
-        if (rec.states.length > TIMELINE_MAX_TICKS) rec.states.shift();
+    // paintRowHistory draws the per-row history mini-bar for a single session.
+    function paintRowHistory(canvas, sessionID) {
+      if (!canvas) return;
+      const rec = timelineHistory.get(sessionID);
+      const dpr = window.devicePixelRatio || 1;
+      const w = canvas.offsetWidth || 120;
+      const h = canvas.offsetHeight || 6;
+      canvas.width = w * dpr;
+      canvas.height = h * dpr;
+      const ctx = canvas.getContext('2d');
+      ctx.scale(dpr, dpr);
+      ctx.clearRect(0, 0, w, h);
+      if (!rec || !rec.states.length) return;
+      const states = rec.states;
+      const colW = w / currentBucketCount;
+      for (let i = 0; i < states.length; i++) {
+        ctx.fillStyle = stateColors[states[i]] || '#1a2340';
+        ctx.fillRect(i * colW, 0, Math.max(colW, 0.5), h);
       }
-      // Mark unseen sessions with null
-      for (const [sid, rec] of timelineHistory) {
-        if (!seen.has(sid)) {
-          rec.states.push(null);
-          if (rec.states.length > TIMELINE_MAX_TICKS) rec.states.shift();
-        }
-      }
-      // Prune fully-null rows
-      for (const [sid, rec] of timelineHistory) {
-        if (rec.states.every(s => s === null)) timelineHistory.delete(sid);
-      }
+    }
 
+    // repaintHistory repaints all history-bearing surfaces from `timelineHistory`.
+    // Called after rebuildTimelineHistory() on snapshot/tick/upgrade or when the
+    // user toggles granularity. No network I/O — history rides the WebSocket.
+    function repaintHistory() {
       renderTimeline();
+      for (const el of document.querySelectorAll('.session-row')) {
+        const canvas = el.querySelector('.row-history');
+        const sid = el.dataset.sessionId;
+        if (canvas && sid) paintRowHistory(canvas, sid);
+      }
     }
 
     function renderTimeline() {
@@ -1426,9 +1647,8 @@
 
       const dpr = window.devicePixelRatio || 1;
       const rows = Array.from(timelineHistory.values());
-      // Fixed-width canvas — empty slots stay on the LEFT so new ticks always
-      // land at the rightmost column and older buckets shift leftward.
-      const canvasW = TIMELINE_LABEL_W + TIMELINE_MAX_TICKS * TIMELINE_COL_W;
+      const maxTicks = rows.reduce((m, r) => Math.max(m, r.states.length), 0);
+      const canvasW = TIMELINE_LABEL_W + maxTicks * TIMELINE_COL_W;
       const canvasH = rows.length * (TIMELINE_ROW_H + TIMELINE_GAP);
 
       canvas.width = canvasW * dpr;
@@ -1458,9 +1678,8 @@
         ctx.textBaseline = 'middle';
         ctx.fillText(rec.label, 2, y + TIMELINE_ROW_H / 2);
 
-        // State columns — right-aligned within the fixed TIMELINE_MAX_TICKS
-        // window so every row's newest tick sits at the same right edge.
-        const startCol = TIMELINE_MAX_TICKS - rec.states.length;
+        // State columns — right-aligned so newest is at right
+        const startCol = maxTicks - rec.states.length;
         for (let t = 0; t < rec.states.length; t++) {
           const state = rec.states[t];
           if (!state) continue;
@@ -1471,29 +1690,13 @@
       }
     }
 
-    setInterval(timelineTick, TIMELINE_TICK_MS);
-
     // --- Initial load ---
     fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
       if (!resp) return;
       dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
       rebuildIndex();
       render();
-      // Seed timeline from persisted daemon history before first live tick
-      fetch('/api/v1/sessions/history?granularity=1')
-        .then(r => r.json()).catch(() => null)
-        .then(hist => {
-          if (hist && hist.sessions) {
-            for (const [sid, states] of Object.entries(hist.sessions)) {
-              const entry = sessionIndex.get(sid);
-              const label = entry
-                ? (entry.agent.project_name || '').slice(0, 10) + ' ' + shortID(sid)
-                : shortID(sid);
-              timelineHistory.set(sid, { label, states: states.slice(-TIMELINE_MAX_TICKS) });
-            }
-          }
-          timelineTick(); // First live tick immediately after seeding
-        });
+      repaintHistory();
     });
     // Periodic re-hydration so trailing-window costs (carried on each group
     // under `costs`) don't go stale between WebSocket deltas, which only
@@ -1537,6 +1740,21 @@
           orchestrator = orch.running ? orch : null;
           orchFull = orch.running ? orch : null;
           render();
+          return;
+        }
+        if (msg.type === 'history_snapshot' && msg.session_id && msg.history) {
+          applyHistorySnapshot(msg.session_id, msg.history);
+          repaintHistory();
+          return;
+        }
+        if (msg.type === 'history_tick' && typeof msg.granularity_sec === 'number' && msg.buckets) {
+          applyHistoryTick(msg.granularity_sec, msg.buckets);
+          if (msg.granularity_sec === currentGranularity) repaintHistory();
+          return;
+        }
+        if (msg.type === 'history_upgrade' && msg.session_id && typeof msg.priority === 'number') {
+          applyHistoryUpgrade(msg.session_id, msg.priority);
+          repaintHistory();
           return;
         }
         if (!msg.session) return;
@@ -1587,6 +1805,38 @@
     }
 
     document.getElementById('raw-refresh').addEventListener('click', fetchRaw);
+
+    // --- Granularity toggle ---
+    function applyGranularity(g) {
+      currentGranularity = g;
+      localStorage.setItem('irrlicht_granularity', g);
+      document.querySelectorAll('.timeline-gran-btn').forEach(b => {
+        b.classList.toggle('active', parseInt(b.dataset.gran, 10) === g);
+      });
+      rebuildTimelineHistory();
+      repaintHistory();
+    }
+
+    for (const btn of document.querySelectorAll('.timeline-gran-btn')) {
+      btn.addEventListener('click', function() {
+        applyGranularity(parseInt(this.dataset.gran, 10));
+      });
+    }
+
+    // Restore saved granularity on load
+    applyGranularity(currentGranularity);
+
+    // --- View-mode toggle (narrow viewports) ---
+    for (const btn of document.querySelectorAll('.view-mode-btn')) {
+      btn.addEventListener('click', function() {
+        const mode = this.dataset.mode;
+        document.querySelectorAll('.view-mode-btn').forEach(b => b.classList.toggle('active', b === this));
+        document.body.classList.toggle('view-history', mode === 'history');
+        // Repaint row bars immediately so there's no flash of empty canvases
+        // when switching to history mode (offsetWidth is now non-zero).
+        if (mode === 'history') repaintHistory();
+      });
+    }
 
     function fetchRaw() {
       const out = document.getElementById('raw-output');

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -24,6 +24,15 @@ type PushMessage struct {
 	GranularitySec int               `json:"granularity_sec,omitempty"`
 	Buckets        map[string]int8   `json:"buckets,omitempty"`
 	Priority       *int8             `json:"priority,omitempty"`
+
+	// Tick generations let the client dedupe a tick that's already
+	// reflected in its snapshot. Captured under the session lock together
+	// with the bucket state, so a snapshot's Generations always match the
+	// History it ships, and a tick's BucketGenerations always match the
+	// post-roll state. Keys: granularity for snapshots ("1"/"10"/"60"),
+	// session_id for ticks (parallel to Buckets).
+	Generations       map[string]uint64 `json:"generations,omitempty"`
+	BucketGenerations map[string]uint64 `json:"bucket_generations,omitempty"`
 }
 
 // Valid PushMessage type constants.

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -9,9 +9,21 @@ import (
 )
 
 // PushMessage is a typed WebSocket envelope for session state fan-out.
+// Session-state messages populate Session; history messages use SessionID +
+// the History/Granularity/Buckets/Priority fields (see PushTypeHistory*).
 type PushMessage struct {
 	Type    string                `json:"type"`
 	Session *session.SessionState `json:"session,omitempty"`
+
+	// History-message fields. SessionID identifies the target row for
+	// snapshot/upgrade messages; tick messages use the per-session entries
+	// in Buckets instead. History maps granularity ("1"/"10"/"60") → 20-char
+	// base64 of 60 bit-packed buckets.
+	SessionID      string            `json:"session_id,omitempty"`
+	History        map[string]string `json:"history,omitempty"`
+	GranularitySec int               `json:"granularity_sec,omitempty"`
+	Buckets        map[string]int8   `json:"buckets,omitempty"`
+	Priority       *int8             `json:"priority,omitempty"`
 }
 
 // Valid PushMessage type constants.
@@ -20,6 +32,19 @@ const (
 	PushTypeUpdated        = "session_updated"
 	PushTypeDeleted        = "session_deleted"
 	PushTypeFocusRequested = "focus_requested"
+
+	// PushTypeHistorySnapshot delivers the bit-packed 60-bucket history
+	// for one session across all three granularities. Sent on WebSocket
+	// connect, on session creation, and after a client reconnects.
+	PushTypeHistorySnapshot = "history_snapshot"
+	// PushTypeHistoryTick is a bulk per-granularity delta: one entry per
+	// session with the priority of the bucket that just rolled. Emitted
+	// once per granularity-second by the daemon.
+	PushTypeHistoryTick = "history_tick"
+	// PushTypeHistoryUpgrade fires on a state transition mid-bucket. The
+	// client merges the priority into the current bucket of all three
+	// rings using max-priority aggregation.
+	PushTypeHistoryUpgrade = "history_upgrade"
 )
 
 // SessionRepository loads, saves, and deletes session state files.
@@ -112,11 +137,12 @@ type HistoryTracker interface {
 	// OnTransition records a state transition for a session, upgrading the
 	// current bucket's priority if the new state outranks the stored one.
 	OnTransition(sessionID, newState string, ts time.Time)
-	// Snapshot returns the ring-buffer contents for a session at the given
-	// granularity (1, 10, or 60), oldest→newest. Returns nil, false if unknown.
-	Snapshot(sessionID string, granularitySec int) ([]string, bool)
 	// Remove drops all buffers for a session.
 	Remove(sessionID string)
+	// EmitSnapshot ships the current bit-packed history for one session
+	// through the configured emit callback. Used to hydrate newly-created
+	// sessions on the WebSocket without waiting for the next tick.
+	EmitSnapshot(sessionID string)
 }
 
 // ProcessWatcher monitors process PIDs via kqueue EVFILT_PROC NOTE_EXIT and

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -27,8 +27,14 @@ class SessionManager: ObservableObject {
     @Published var connectionState: ConnectionState = .disconnected
     @Published var lastError: String?
     @Published var apiGroups: [AgentGroup] = []  // recursive group structure from API
-    @Published var stateHistory: [String: [String]] = [:]  // session_id → oldest→newest state strings
-    @Published var historyBucketCount: Int = 150
+    @Published var stateHistory: [String: [String]] = [:]  // session_id → oldest→newest state strings (active granularity)
+    @Published var historyBucketCount: Int = 60          // matches HistoryBucketCount on the daemon
+
+    /// All three granularities held in parallel so toggling 1s/10s/60s is
+    /// instant — the WebSocket streams every granularity continuously, the
+    /// view just picks which dict to mirror into `stateHistory`.
+    private var historyByGranularity: [Int: [String: [String]]] = [1: [:], 10: [:], 60: [:]]
+    private var currentHistoryGranularitySec: Int = 1
 
     /// Group names the user has collapsed. Lifted out of GroupView's local
     /// state so (a) SessionListView's size estimator can skip collapsed
@@ -40,8 +46,6 @@ class SessionManager: ObservableObject {
     /// WebSocket deltas only carry individual session updates.
     private var projectCostsTimer: Timer?
     private let projectCostsRefreshInterval: TimeInterval = 30.0
-
-    private var historyTimer: Timer?
 
     private let instancesPath: URL
     private let orderFilePath: URL
@@ -260,39 +264,108 @@ class SessionManager: ObservableObject {
         }
     }
 
-    /// Starts periodic history polling at the specified granularity (1, 10, or 60 s).
-    func startHistoryPolling(granularitySec: Int) {
-        historyTimer?.invalidate()
-        let interval = TimeInterval(max(1, granularitySec))
-        Task { @MainActor [weak self] in await self?.fetchHistory(granularitySec: granularitySec) }
-        historyTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                await self?.fetchHistory(granularitySec: granularitySec)
-            }
+    /// Selects which granularity the history bar renders (1, 10, or 60 s).
+    /// All three streams arrive continuously over the WebSocket, so this is a
+    /// constant-time mirror — no polling kick-off, no cancellation needed.
+    func setHistoryGranularity(_ granularitySec: Int) {
+        guard [1, 10, 60].contains(granularitySec) else { return }
+        currentHistoryGranularitySec = granularitySec
+        refreshActiveStateHistory()
+    }
+
+    private func refreshActiveStateHistory() {
+        let active = historyByGranularity[currentHistoryGranularitySec] ?? [:]
+        // Strip leading no-data buckets so HistoryBarView's right-anchored
+        // rendering leaves the front of the bar empty (matches pre-WS shape).
+        stateHistory = active.mapValues { trimLeadingNoData($0) }
+    }
+
+    private func trimLeadingNoData(_ buckets: [String]) -> [String] {
+        var i = 0
+        while i < buckets.count && buckets[i].isEmpty { i += 1 }
+        return Array(buckets[i...])
+    }
+
+    /// Maps the wire 2-bit priority code back to its state name.
+    /// `""` represents no-data; HistoryBarView treats it as a blank slot.
+    private func historyPriorityToState(_ p: Int8) -> String {
+        switch p {
+        case 0: return "ready"
+        case 1: return "working"
+        case 2: return "waiting"
+        default: return ""
         }
     }
 
-    func stopHistoryPolling() {
-        historyTimer?.invalidate()
-        historyTimer = nil
+    private func historyPriorityForState(_ s: String) -> Int {
+        switch s {
+        case "waiting": return 2
+        case "working": return 1
+        case "ready":   return 0
+        default:        return -1 // no-data — strictly less than any real priority
+        }
     }
 
-    private func fetchHistory(granularitySec: Int) async {
-        guard let url = URL(string: "http://localhost:7837/api/v1/sessions/history?granularity=\(granularitySec)") else { return }
-        do {
-            let (data, response) = try await URLSession.shared.data(from: url)
-            guard (response as? HTTPURLResponse)?.statusCode == 200 else { return }
-            struct HistoryResponse: Decodable {
-                let sessions: [String: [String]]
-                let bucketCount: Int
+    /// Decodes a 20-char base64 (15 bytes, MSB-first 2-bit codes) into a
+    /// 60-element oldest→newest state-name array. Returns nil on malformed
+    /// input so the caller can drop the message rather than corrupt the ring.
+    private func decodeHistoryBuckets(_ encoded: String) -> [String]? {
+        guard let raw = Data(base64Encoded: encoded), raw.count == 15 else { return nil }
+        var out: [String] = []
+        out.reserveCapacity(60)
+        for byte in raw {
+            for shift in stride(from: 6, through: 0, by: -2) {
+                let code = Int8((byte >> UInt8(shift)) & 0x3)
+                out.append(historyPriorityToState(code))
             }
-            let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
-            let decoded = try decoder.decode(HistoryResponse.self, from: data)
-            stateHistory = decoded.sessions
-            historyBucketCount = decoded.bucketCount
-        } catch {
-            // Non-fatal: history is optional.
+        }
+        return out
+    }
+
+    private func applyHistorySnapshot(sessionID: String, history: [String: String]) {
+        for (granKey, b64) in history {
+            guard let gran = Int(granKey),
+                  [1, 10, 60].contains(gran),
+                  let buckets = decodeHistoryBuckets(b64) else { continue }
+            historyByGranularity[gran, default: [:]][sessionID] = buckets
+        }
+        refreshActiveStateHistory()
+    }
+
+    private func applyHistoryTick(granularitySec: Int, buckets: [String: Int8]) {
+        guard [1, 10, 60].contains(granularitySec) else { return }
+        var dict = historyByGranularity[granularitySec] ?? [:]
+        for (sid, prio) in buckets {
+            var arr = dict[sid] ?? Array(repeating: "", count: 60)
+            if arr.count == 60 { arr.removeFirst() }
+            arr.append(historyPriorityToState(prio))
+            // Pad to 60 if a previously-unknown session ticks before its snapshot.
+            while arr.count < 60 { arr.insert("", at: 0) }
+            dict[sid] = arr
+        }
+        historyByGranularity[granularitySec] = dict
+        if granularitySec == currentHistoryGranularitySec {
+            refreshActiveStateHistory()
+        }
+    }
+
+    private func applyHistoryUpgrade(sessionID: String, priority: Int8) {
+        let newState = historyPriorityToState(priority)
+        let newPrio = historyPriorityForState(newState)
+        var changedActive = false
+        for gran in [1, 10, 60] {
+            var dict = historyByGranularity[gran] ?? [:]
+            guard var arr = dict[sessionID], !arr.isEmpty else { continue }
+            let lastPrio = historyPriorityForState(arr[arr.count - 1])
+            if newPrio > lastPrio {
+                arr[arr.count - 1] = newState
+                dict[sessionID] = arr
+                historyByGranularity[gran] = dict
+                if gran == currentHistoryGranularitySec { changedActive = true }
+            }
+        }
+        if changedActive {
+            refreshActiveStateHistory()
         }
     }
 
@@ -333,6 +406,23 @@ class SessionManager: ObservableObject {
     private struct WsEnvelope: Decodable {
         let type: String
         let session: SessionState?
+
+        // History-message fields (snapshot/tick/upgrade).
+        let sessionID: String?
+        let history: [String: String]?
+        let granularitySec: Int?
+        let buckets: [String: Int8]?
+        let priority: Int8?
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case session
+            case sessionID      = "session_id"
+            case history
+            case granularitySec = "granularity_sec"
+            case buckets
+            case priority
+        }
     }
 
     private func handleWsMessage(_ text: String) {
@@ -383,6 +473,18 @@ class SessionManager: ObservableObject {
                     DispatchQueue.main.async {
                         SessionLauncher.jump(session)
                     }
+                }
+            case "history_snapshot":
+                if let sid = envelope.sessionID, let hist = envelope.history {
+                    applyHistorySnapshot(sessionID: sid, history: hist)
+                }
+            case "history_tick":
+                if let gran = envelope.granularitySec, let bks = envelope.buckets {
+                    applyHistoryTick(granularitySec: gran, buckets: bks)
+                }
+            case "history_upgrade":
+                if let sid = envelope.sessionID, let prio = envelope.priority {
+                    applyHistoryUpgrade(sessionID: sid, priority: prio)
                 }
             default:
                 break

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -34,6 +34,11 @@ class SessionManager: ObservableObject {
     /// instant — the WebSocket streams every granularity continuously, the
     /// view just picks which dict to mirror into `stateHistory`.
     private var historyByGranularity: [Int: [String: [String]]] = [1: [:], 10: [:], 60: [:]]
+    /// Per-session per-granularity high-water-mark of applied tick generations.
+    /// Lets us drop a tick that's already reflected in our snapshot — closing
+    /// the connect-time race where the daemon emits a tick between snapshot
+    /// generation and the WebSocket flushing the snapshot to us.
+    private var lastTickGen: [String: [Int: UInt64]] = [:]
     private var currentHistoryGranularitySec: Int = 1
 
     /// Group names the user has collapsed. Lifted out of GroupView's local
@@ -322,29 +327,50 @@ class SessionManager: ObservableObject {
         return out
     }
 
-    private func applyHistorySnapshot(sessionID: String, history: [String: String]) {
+    private func applyHistorySnapshot(sessionID: String, history: [String: String], generations: [String: UInt64]?) {
         for (granKey, b64) in history {
             guard let gran = Int(granKey),
                   [1, 10, 60].contains(gran),
                   let buckets = decodeHistoryBuckets(b64) else { continue }
             historyByGranularity[gran, default: [:]][sessionID] = buckets
         }
+        // Seed the dedup high-water-mark from the snapshot's generations so
+        // any tick already reflected in this snapshot gets skipped on arrival.
+        if let gens = generations {
+            var perGran = lastTickGen[sessionID] ?? [:]
+            for (granKey, gen) in gens {
+                if let gran = Int(granKey), [1, 10, 60].contains(gran) {
+                    perGran[gran] = gen
+                }
+            }
+            lastTickGen[sessionID] = perGran
+        }
         refreshActiveStateHistory()
     }
 
-    private func applyHistoryTick(granularitySec: Int, buckets: [String: Int8]) {
+    private func applyHistoryTick(granularitySec: Int, buckets: [String: Int8], bucketGenerations: [String: UInt64]?) {
         guard [1, 10, 60].contains(granularitySec) else { return }
         var dict = historyByGranularity[granularitySec] ?? [:]
+        var changedActive = false
         for (sid, prio) in buckets {
+            // Skip if this tick has already been folded into our snapshot.
+            if let gen = bucketGenerations?[sid] {
+                let last = lastTickGen[sid]?[granularitySec] ?? 0
+                if gen <= last { continue }
+                var perGran = lastTickGen[sid] ?? [:]
+                perGran[granularitySec] = gen
+                lastTickGen[sid] = perGran
+            }
             var arr = dict[sid] ?? Array(repeating: "", count: 60)
             if arr.count == 60 { arr.removeFirst() }
             arr.append(historyPriorityToState(prio))
             // Pad to 60 if a previously-unknown session ticks before its snapshot.
             while arr.count < 60 { arr.insert("", at: 0) }
             dict[sid] = arr
+            changedActive = true
         }
         historyByGranularity[granularitySec] = dict
-        if granularitySec == currentHistoryGranularitySec {
+        if changedActive && granularitySec == currentHistoryGranularitySec {
             refreshActiveStateHistory()
         }
     }
@@ -413,15 +439,22 @@ class SessionManager: ObservableObject {
         let granularitySec: Int?
         let buckets: [String: Int8]?
         let priority: Int8?
+        // Tick generations: keyed by granularity for snapshots, by session_id
+        // for ticks (parallel to `buckets`). Optional so older daemons still
+        // decode.
+        let generations: [String: UInt64]?
+        let bucketGenerations: [String: UInt64]?
 
         enum CodingKeys: String, CodingKey {
             case type
             case session
-            case sessionID      = "session_id"
+            case sessionID         = "session_id"
             case history
-            case granularitySec = "granularity_sec"
+            case granularitySec    = "granularity_sec"
             case buckets
             case priority
+            case generations
+            case bucketGenerations = "bucket_generations"
         }
     }
 
@@ -460,6 +493,10 @@ class SessionManager: ObservableObject {
                 if let session = envelope.session {
                     sessionMap.removeValue(forKey: session.id)
                     sessionOrder.removeAll { $0 == session.id }
+                    lastTickGen.removeValue(forKey: session.id)
+                    for gran in [1, 10, 60] {
+                        historyByGranularity[gran]?.removeValue(forKey: session.id)
+                    }
                     rebuildSessionsFromMap()
                     removeFromApiGroups(sessionId: session.id)
                     scheduleRehydration()
@@ -476,11 +513,11 @@ class SessionManager: ObservableObject {
                 }
             case "history_snapshot":
                 if let sid = envelope.sessionID, let hist = envelope.history {
-                    applyHistorySnapshot(sessionID: sid, history: hist)
+                    applyHistorySnapshot(sessionID: sid, history: hist, generations: envelope.generations)
                 }
             case "history_tick":
                 if let gran = envelope.granularitySec, let bks = envelope.buckets {
-                    applyHistoryTick(granularitySec: gran, buckets: bks)
+                    applyHistoryTick(granularitySec: gran, buckets: bks, bucketGenerations: envelope.bucketGenerations)
                 }
             case "history_upgrade":
                 if let sid = envelope.sessionID, let prio = envelope.priority {

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -317,9 +317,7 @@ struct SessionListView: View {
                 let next = displayMode.next()
                 displayModeRaw = next.rawValue
                 if next.isHistory {
-                    sessionManager.startHistoryPolling(granularitySec: next.granularitySec)
-                } else {
-                    sessionManager.stopHistoryPolling()
+                    sessionManager.setHistoryGranularity(next.granularitySec)
                 }
             } label: {
                 Text(displayMode.rawValue)
@@ -342,11 +340,8 @@ struct SessionListView: View {
         .padding(.vertical, 8)
         .onAppear {
             if displayMode.isHistory {
-                sessionManager.startHistoryPolling(granularitySec: displayMode.granularitySec)
+                sessionManager.setHistoryGranularity(displayMode.granularitySec)
             }
-        }
-        .onDisappear {
-            sessionManager.stopHistoryPolling()
         }
     }
     

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -865,6 +865,9 @@
     // historyByGranularity[g][sessionID] is a 60-element oldest→newest array of state names
     // (or "" for no-data buckets). Mirrored from the daemon's bit-packed wire format.
     const historyByGranularity = {1: {}, 10: {}, 60: {}};
+    // lastTickGen[sessionID][granularity] = highest applied tick generation. Lets us drop
+    // a tick that's already reflected in our snapshot (closing the connect-time race).
+    const lastTickGen = {};
 
     const HISTORY_PRIORITY_TO_STATE = ['ready', 'working', 'waiting', ''];
     function historyPriorityForState(s) {
@@ -910,7 +913,7 @@
       timelineHistory = newMap;
     }
 
-    function applyHistorySnapshot(sessionID, history) {
+    function applyHistorySnapshot(sessionID, history, generations) {
       for (const granKey of Object.keys(history)) {
         const gran = parseInt(granKey, 10);
         if (![1, 10, 60].includes(gran)) continue;
@@ -918,21 +921,41 @@
         if (!buckets) continue;
         historyByGranularity[gran][sessionID] = buckets;
       }
+      // Seed the dedup high-water-mark from the snapshot so any tick already
+      // folded into this snapshot gets skipped on arrival.
+      if (generations) {
+        const perGran = lastTickGen[sessionID] || {};
+        for (const granKey of Object.keys(generations)) {
+          const gran = parseInt(granKey, 10);
+          if ([1, 10, 60].includes(gran)) perGran[gran] = generations[granKey];
+        }
+        lastTickGen[sessionID] = perGran;
+      }
       rebuildTimelineHistory();
     }
 
-    function applyHistoryTick(granularitySec, buckets) {
+    function applyHistoryTick(granularitySec, buckets, bucketGenerations) {
       if (![1, 10, 60].includes(granularitySec)) return;
       const dict = historyByGranularity[granularitySec];
+      let changed = false;
       for (const sid of Object.keys(buckets)) {
+        // Skip if this tick has already been folded into our snapshot.
+        if (bucketGenerations && bucketGenerations[sid] !== undefined) {
+          const gen = bucketGenerations[sid];
+          const last = (lastTickGen[sid] && lastTickGen[sid][granularitySec]) || 0;
+          if (gen <= last) continue;
+          if (!lastTickGen[sid]) lastTickGen[sid] = {};
+          lastTickGen[sid][granularitySec] = gen;
+        }
         let arr = dict[sid];
         if (!arr) arr = new Array(60).fill('');
         arr.shift();
         arr.push(HISTORY_PRIORITY_TO_STATE[buckets[sid] & 0x3]);
         while (arr.length < 60) arr.unshift('');
         dict[sid] = arr;
+        changed = true;
       }
-      if (granularitySec === currentGranularity) rebuildTimelineHistory();
+      if (changed && granularitySec === currentGranularity) rebuildTimelineHistory();
     }
 
     function applyHistoryUpgrade(sessionID, priority) {
@@ -1092,6 +1115,10 @@
 
     function applySessionDelete(sessionId) {
       var entry = sessionIndex.get(sessionId);
+      delete lastTickGen[sessionId];
+      delete historyByGranularity[1][sessionId];
+      delete historyByGranularity[10][sessionId];
+      delete historyByGranularity[60][sessionId];
       if (!entry) return;
       sessionIndex.delete(sessionId);
       if (entry.parent) {
@@ -1743,12 +1770,12 @@
           return;
         }
         if (msg.type === 'history_snapshot' && msg.session_id && msg.history) {
-          applyHistorySnapshot(msg.session_id, msg.history);
+          applyHistorySnapshot(msg.session_id, msg.history, msg.generations);
           repaintHistory();
           return;
         }
         if (msg.type === 'history_tick' && typeof msg.granularity_sec === 'number' && msg.buckets) {
-          applyHistoryTick(msg.granularity_sec, msg.buckets);
+          applyHistoryTick(msg.granularity_sec, msg.buckets, msg.bucket_generations);
           if (msg.granularity_sec === currentGranularity) repaintHistory();
           return;
         }

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -857,11 +857,99 @@
     let currentTimeframe = localStorage.getItem('irrlicht_costTimeframe') || 'day';
     if (!COST_TIMEFRAMES.find(t => t.key === currentTimeframe)) currentTimeframe = 'day';
 
-    // --- Timeline / history state (server-backed) ---
-    let timelineHistory = new Map(); // session_id -> {label, states: string[]}
+    // --- Timeline / history state (WebSocket-streamed, see history_snapshot/tick/upgrade) ---
+    let timelineHistory = new Map(); // session_id -> {label, states: string[]} for the active granularity
     let currentGranularity = parseInt(localStorage.getItem('irrlicht_granularity') || '1', 10);
     if (![1, 10, 60].includes(currentGranularity)) currentGranularity = 1;
-    let currentBucketCount = 150;
+    let currentBucketCount = 60;
+    // historyByGranularity[g][sessionID] is a 60-element oldest→newest array of state names
+    // (or "" for no-data buckets). Mirrored from the daemon's bit-packed wire format.
+    const historyByGranularity = {1: {}, 10: {}, 60: {}};
+
+    const HISTORY_PRIORITY_TO_STATE = ['ready', 'working', 'waiting', ''];
+    function historyPriorityForState(s) {
+      switch (s) {
+        case 'waiting': return 2;
+        case 'working': return 1;
+        case 'ready':   return 0;
+        default:        return -1;
+      }
+    }
+    function decodeHistoryBuckets(b64) {
+      // Daemon ships 60 buckets × 2 bits MSB-first = 15 bytes = 20 base64 chars.
+      let raw;
+      try { raw = atob(b64); } catch (e) { return null; }
+      if (raw.length !== 15) return null;
+      const out = new Array(60);
+      for (let i = 0; i < 15; i++) {
+        const byte = raw.charCodeAt(i);
+        out[i * 4 + 0] = HISTORY_PRIORITY_TO_STATE[(byte >> 6) & 0x3];
+        out[i * 4 + 1] = HISTORY_PRIORITY_TO_STATE[(byte >> 4) & 0x3];
+        out[i * 4 + 2] = HISTORY_PRIORITY_TO_STATE[(byte >> 2) & 0x3];
+        out[i * 4 + 3] = HISTORY_PRIORITY_TO_STATE[byte & 0x3];
+      }
+      return out;
+    }
+
+    // Rebuild `timelineHistory` from the chosen granularity dict. The renderer
+    // expects `states` to omit leading no-data slots so the bar right-anchors.
+    function rebuildTimelineHistory() {
+      const dict = historyByGranularity[currentGranularity] || {};
+      const newMap = new Map();
+      for (const sid of Object.keys(dict)) {
+        const buckets = dict[sid];
+        let i = 0;
+        while (i < buckets.length && buckets[i] === '') i++;
+        const states = buckets.slice(i);
+        const entry = sessionIndex.get(sid);
+        const label = entry
+          ? (entry.agent.project_name || '').slice(0, 10) + ' ' + shortID(sid)
+          : shortID(sid);
+        newMap.set(sid, {label, states});
+      }
+      timelineHistory = newMap;
+    }
+
+    function applyHistorySnapshot(sessionID, history) {
+      for (const granKey of Object.keys(history)) {
+        const gran = parseInt(granKey, 10);
+        if (![1, 10, 60].includes(gran)) continue;
+        const buckets = decodeHistoryBuckets(history[granKey]);
+        if (!buckets) continue;
+        historyByGranularity[gran][sessionID] = buckets;
+      }
+      rebuildTimelineHistory();
+    }
+
+    function applyHistoryTick(granularitySec, buckets) {
+      if (![1, 10, 60].includes(granularitySec)) return;
+      const dict = historyByGranularity[granularitySec];
+      for (const sid of Object.keys(buckets)) {
+        let arr = dict[sid];
+        if (!arr) arr = new Array(60).fill('');
+        arr.shift();
+        arr.push(HISTORY_PRIORITY_TO_STATE[buckets[sid] & 0x3]);
+        while (arr.length < 60) arr.unshift('');
+        dict[sid] = arr;
+      }
+      if (granularitySec === currentGranularity) rebuildTimelineHistory();
+    }
+
+    function applyHistoryUpgrade(sessionID, priority) {
+      const newState = HISTORY_PRIORITY_TO_STATE[priority & 0x3];
+      const newPrio = historyPriorityForState(newState);
+      let changedActive = false;
+      for (const gran of [1, 10, 60]) {
+        const arr = historyByGranularity[gran][sessionID];
+        if (!arr || arr.length === 0) continue;
+        const lastPrio = historyPriorityForState(arr[arr.length - 1]);
+        if (newPrio > lastPrio) {
+          arr[arr.length - 1] = newState;
+          if (gran === currentGranularity) changedActive = true;
+        }
+      }
+      if (changedActive) rebuildTimelineHistory();
+    }
 
     // --- SVG Icons (compact 12px) ---
     const svgIcons = {
@@ -1535,30 +1623,16 @@
       }
     }
 
-    // pollHistory fetches server-aggregated history and rebuilds timelineHistory.
-    function pollHistory() {
-      fetch('/api/v1/sessions/history?granularity=' + currentGranularity)
-        .then(r => r.json()).catch(() => null)
-        .then(resp => {
-          if (!resp) return;
-          if (resp.bucket_count) currentBucketCount = resp.bucket_count;
-          const newMap = new Map();
-          for (const [sid, states] of Object.entries(resp.sessions || {})) {
-            const entry = sessionIndex.get(sid);
-            const label = entry
-              ? (entry.agent.project_name || '').slice(0, 10) + ' ' + shortID(sid)
-              : shortID(sid);
-            newMap.set(sid, {label, states});
-          }
-          timelineHistory = newMap;
-          renderTimeline();
-          // Repaint per-row bars
-          for (const el of document.querySelectorAll('.session-row')) {
-            const canvas = el.querySelector('.row-history');
-            const sid = el.dataset.sessionId;
-            if (canvas && sid) paintRowHistory(canvas, sid);
-          }
-        });
+    // repaintHistory repaints all history-bearing surfaces from `timelineHistory`.
+    // Called after rebuildTimelineHistory() on snapshot/tick/upgrade or when the
+    // user toggles granularity. No network I/O — history rides the WebSocket.
+    function repaintHistory() {
+      renderTimeline();
+      for (const el of document.querySelectorAll('.session-row')) {
+        const canvas = el.querySelector('.row-history');
+        const sid = el.dataset.sessionId;
+        if (canvas && sid) paintRowHistory(canvas, sid);
+      }
     }
 
     function renderTimeline() {
@@ -1616,22 +1690,13 @@
       }
     }
 
-    // Kick off server history polling — poll at granularity * 1000ms.
-    // Started by applyGranularity() below after DOM buttons are wired up.
-    let historyPollTimer = null;
-    function startHistoryPoll() {
-      if (historyPollTimer) clearInterval(historyPollTimer);
-      pollHistory();
-      historyPollTimer = setInterval(pollHistory, currentGranularity * 1000);
-    }
-
     // --- Initial load ---
     fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
       if (!resp) return;
       dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
       rebuildIndex();
       render();
-      pollHistory();
+      repaintHistory();
     });
     // Periodic re-hydration so trailing-window costs (carried on each group
     // under `costs`) don't go stale between WebSocket deltas, which only
@@ -1675,6 +1740,21 @@
           orchestrator = orch.running ? orch : null;
           orchFull = orch.running ? orch : null;
           render();
+          return;
+        }
+        if (msg.type === 'history_snapshot' && msg.session_id && msg.history) {
+          applyHistorySnapshot(msg.session_id, msg.history);
+          repaintHistory();
+          return;
+        }
+        if (msg.type === 'history_tick' && typeof msg.granularity_sec === 'number' && msg.buckets) {
+          applyHistoryTick(msg.granularity_sec, msg.buckets);
+          if (msg.granularity_sec === currentGranularity) repaintHistory();
+          return;
+        }
+        if (msg.type === 'history_upgrade' && msg.session_id && typeof msg.priority === 'number') {
+          applyHistoryUpgrade(msg.session_id, msg.priority);
+          repaintHistory();
           return;
         }
         if (!msg.session) return;
@@ -1733,7 +1813,8 @@
       document.querySelectorAll('.timeline-gran-btn').forEach(b => {
         b.classList.toggle('active', parseInt(b.dataset.gran, 10) === g);
       });
-      startHistoryPoll();
+      rebuildTimelineHistory();
+      repaintHistory();
     }
 
     for (const btn of document.querySelectorAll('.timeline-gran-btn')) {
@@ -1753,7 +1834,7 @@
         document.body.classList.toggle('view-history', mode === 'history');
         // Repaint row bars immediately so there's no flash of empty canvases
         // when switching to history mode (offsetWidth is now non-zero).
-        if (mode === 'history') pollHistory();
+        if (mode === 'history') repaintHistory();
       });
     }
 


### PR DESCRIPTION
## Summary
- Drops `/api/v1/sessions/history` polling. Three new WebSocket messages take over: `history_snapshot` (sent on connect + on `session_created`), `history_tick` (one bulk delta per granularity-second), `history_upgrade` (mid-bucket transitions).
- Bit-packs the 60-bucket ring buffers (2 bits/bucket → 15 bytes → 20-char base64 per granularity, ~30× smaller than the polled `[]string` payload).
- Migrates both clients (macOS `SessionManager.swift` and `platforms/web/index.html`) to decode the packed format and dispatch the new messages; both now keep all three granularities resident so toggling 1s/10s/60s is a constant-time mirror.

Closes #241.

## Test plan
- [x] `go test ./core/... -race -count=1` — all green except the pre-existing `TestFixtureReplayByteIdentity` (worktree-hostile golden paths, #238).
- [x] `tools/replay-fixtures.sh` runs to completion.
- [x] `swift build` (macOS package) clean.
- [x] `/ir:test-mac` dev stack: daemon + app launch, `GET /api/v1/sessions/history` returns 404, `/api/v1/sessions` hydrates, app log shows clean processing.
- [ ] Visual verification of history bars in the menu-bar overlay across 1s/10s/60s.

## Out of scope
- No `?legacy=1` shim — outright deletion (irrlicht is pre-1.0, in-tree clients only).
- Demo-seeder history field deferred (issue called it a bonus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)