### PR TITLE
test(replay): zero source_transcript so goldens are worktree-portable (#238)

### DIFF
--- a/core/cmd/replay/fixtures_test.go
+++ b/core/cmd/replay/fixtures_test.go
@@ -86,8 +86,9 @@ func discoverReplayFixtures(t *testing.T, root string) []string {
 }
 
 // runFixtureReplay dispatches through the same runReplay() path as main(),
-// zeroes GeneratedAt on the returned report so the golden is stable, and
-// returns the indented JSON.
+// zeroes per-run fields (GeneratedAt, SourceTranscript) on the returned
+// report so goldens are stable across worktrees and clones, and returns
+// the indented JSON.
 func runFixtureReplay(t *testing.T, transcriptPath string) []byte {
 	t.Helper()
 	adapter, err := detectAdapter(transcriptPath)
@@ -105,8 +106,6 @@ func runFixtureReplay(t *testing.T, transcriptPath string) []byte {
 		t.Fatalf("runReplay %s: %v", transcriptPath, err)
 	}
 	report.GeneratedAt = time.Time{}
-	// Zero the source path so goldens are portable across worktrees and clones —
-	// the field is informational and the golden already lives next to its fixture.
 	report.SourceTranscript = ""
 
 	var buf bytes.Buffer

--- a/core/cmd/replay/fixtures_test.go
+++ b/core/cmd/replay/fixtures_test.go
@@ -105,6 +105,9 @@ func runFixtureReplay(t *testing.T, transcriptPath string) []byte {
 		t.Fatalf("runReplay %s: %v", transcriptPath, err)
 	}
 	report.GeneratedAt = time.Time{}
+	// Zero the source path so goldens are portable across worktrees and clones —
+	// the field is informational and the golden already lives next to its fixture.
+	report.SourceTranscript = ""
 
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)

--- a/replaydata/agents/claudecode/scenarios/04-current-session-issue-102/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/04-current-session-issue-102/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/04-current-session-issue-102/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/05-bug-c-orphan-toolresult/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/05-bug-c-orphan-toolresult/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/05-bug-c-orphan-toolresult/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/06-cost-calculation-07f5cca9/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/06-cost-calculation-07f5cca9/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/06-cost-calculation-07f5cca9/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/07-tool-denial-and-esc-db57d2ab/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/07-tool-denial-and-esc-db57d2ab/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/07-tool-denial-and-esc-db57d2ab/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/08-issue-114-stuck-working-a/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/08-issue-114-stuck-working-a/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/08-issue-114-stuck-working-a/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/09-issue-114-stuck-working-b/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/09-issue-114-stuck-working-b/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/09-issue-114-stuck-working-b/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/10-full-lifecycle-839f0678/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/10-full-lifecycle-839f0678/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/10-full-lifecycle-839f0678/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a0ecfa598b8d3e4cb.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a0ecfa598b8d3e4cb.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a0ecfa598b8d3e4cb.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a3788f20434910dfb.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a3788f20434910dfb.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a3788f20434910dfb.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a8c6b99a5471d404c.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a8c6b99a5471d404c.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a8c6b99a5471d404c.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a9df09b50d5f3ad98.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a9df09b50d5f3ad98.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-a9df09b50d5f3ad98.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-aa893b95554e698f9.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-aa893b95554e698f9.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-aa893b95554e698f9.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-aaf3eed3bb8d10332.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-aaf3eed3bb8d10332.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-aaf3eed3bb8d10332.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-ab5d816197e4bbfec.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-ab5d816197e4bbfec.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-ab5d816197e4bbfec.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-abb993514b4da5e14.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-abb993514b4da5e14.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-abb993514b4da5e14.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-ad5ac77d703f22b9f.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-ad5ac77d703f22b9f.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-ad5ac77d703f22b9f.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-adafcd67f82b65a1f.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-adafcd67f82b65a1f.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-adafcd67f82b65a1f.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-ae04f393030f3393b.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-ae04f393030f3393b.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-ae04f393030f3393b.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-af7bf8be5a1b511e4.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-af7bf8be5a1b511e4.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/subagents/agent-af7bf8be5a1b511e4.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/13-full-lifecycle-continue-8a525d27/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/14-user-esc-interrupt-06f604ec/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/14-user-esc-interrupt-06f604ec/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/14-user-esc-interrupt-06f604ec/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/15-permission-hooks-a845d6c4/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/15-permission-hooks-a845d6c4/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/15-permission-hooks-a845d6c4/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/16-ask-user-question-issue-150/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/16-ask-user-question-issue-150/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/16-ask-user-question-issue-150/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/agent-question-pending/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/agent-question-pending/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/agent-question-pending/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/baseline-hello/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/baseline-hello/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/baseline-hello/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/full-lifecycle-toolcall/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/full-lifecycle-toolcall/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/full-lifecycle-toolcall/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/permission-hook-denial/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/permission-hook-denial/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/permission-hook-denial/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/subagent-spawn/subagents/agent-a31559a022d9a2cb6.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/subagent-spawn/subagents/agent-a31559a022d9a2cb6.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/subagent-spawn/subagents/agent-a31559a022d9a2cb6.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/subagent-spawn/subagents/agent-a5435e8f32c1127d1.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/subagent-spawn/subagents/agent-a5435e8f32c1127d1.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/subagent-spawn/subagents/agent-a5435e8f32c1127d1.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/subagent-spawn/subagents/agent-a8662875f7da1388c.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/subagent-spawn/subagents/agent-a8662875f7da1388c.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/subagent-spawn/subagents/agent-a8662875f7da1388c.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/claudecode/scenarios/subagent-spawn/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/subagent-spawn/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/claudecode/scenarios/subagent-spawn/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "claude-code",

--- a/replaydata/agents/codex/scenarios/01-example-session/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/01-example-session/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/codex/scenarios/01-example-session/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "codex",

--- a/replaydata/agents/codex/scenarios/02-flicker-start-session/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/02-flicker-start-session/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/codex/scenarios/02-flicker-start-session/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "codex",

--- a/replaydata/agents/codex/scenarios/agent-question-pending/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/agent-question-pending/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/codex/scenarios/agent-question-pending/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "codex",

--- a/replaydata/agents/codex/scenarios/baseline-hello/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/baseline-hello/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/codex/scenarios/baseline-hello/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "codex",

--- a/replaydata/agents/codex/scenarios/full-lifecycle-toolcall/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/full-lifecycle-toolcall/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/codex/scenarios/full-lifecycle-toolcall/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "codex",

--- a/replaydata/agents/pi/scenarios/01-example-session/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/scenarios/01-example-session/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/pi/scenarios/01-example-session/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "pi",

--- a/replaydata/agents/pi/scenarios/agent-question-pending/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/scenarios/agent-question-pending/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/pi/scenarios/agent-question-pending/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "pi",

--- a/replaydata/agents/pi/scenarios/baseline-hello/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/scenarios/baseline-hello/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/pi/scenarios/baseline-hello/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "pi",

--- a/replaydata/agents/pi/scenarios/full-lifecycle-toolcall/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/scenarios/full-lifecycle-toolcall/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/pi/scenarios/full-lifecycle-toolcall/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "pi",

--- a/replaydata/agents/pi/scenarios/interrupted-turn/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/scenarios/interrupted-turn/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/pi/scenarios/interrupted-turn/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "pi",

--- a/replaydata/agents/pi/scenarios/multi-turn-conversation/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/scenarios/multi-turn-conversation/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "/Users/ingo/projects/irrlicht/replaydata/agents/pi/scenarios/multi-turn-conversation/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "pi",


### PR DESCRIPTION
## Summary
- Fixes #238 — `TestFixtureReplayByteIdentity` failed from any worktree/alternate clone because committed goldens stored the absolute input path.
- Zero `report.SourceTranscript` in `runFixtureReplay` (mirrors the existing `GeneratedAt` zeroing pattern), then refresh all 42 `.replay.json.golden` files to `"source_transcript": ""`.
- Production CLI behavior unchanged — only the test compare path is normalized. The golden file already sits next to its fixture, so the embedded path was redundant.
- Removes the need for the `sed`-rewrite recipe introduced by PR #232 after `UPDATE_REPLAY_GOLDENS=1`.

## Test plan
- [x] `go test ./core/cmd/replay/... -race -count=1` passes from this worktree (no `UPDATE_REPLAY_GOLDENS`).
- [x] `go test ./core/... -race -count=1` (full unit + e2e suite) passes.
- [x] `tools/replay-fixtures.sh` runs to completion.
- [x] `git diff` of regenerated goldens is exactly one line per file flipping the absolute path to `""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)