### PR TITLE
refactor: centralize per-adapter transcript extension (#239)

### DIFF
--- a/.claude/skills/ir:onboard-agent/README.md
+++ b/.claude/skills/ir:onboard-agent/README.md
@@ -81,7 +81,10 @@ replaydata/
   agents/
     features.json                     — canonical feature catalog (WS01)
     <adapter>/
-      capabilities.json               — per-adapter feature support (WS03)
+      capabilities.json               — per-adapter feature support (WS03);
+                                        optional top-level `transcript_extension`
+                                        (default "jsonl") names the curated
+                                        fixture's extension (e.g. "md" for aider)
       scenarios/<scenario>/
         transcript.jsonl              — agent transcript (raw)
         events.jsonl                  — lifecycle events

--- a/.claude/skills/ir:onboard-agent/scripts/run-cell.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/run-cell.sh
@@ -279,7 +279,7 @@ fi
   "$RECORDING" "$ACTUAL_UUID" "$TRANSCRIPT" "$ADAPTER" "$SCENARIO"
 
 # Adapter declares its curated transcript extension in capabilities.json
-# (default "jsonl"). curate-lifecycle-fixture.sh reads the same field.
+# (default "jsonl").
 TRANSCRIPT_EXT="$(jq -r '.transcript_extension // "jsonl"' \
   "$REPO_ROOT/replaydata/agents/$ADAPTER/capabilities.json")"
 STAGED_TRANSCRIPT="$STAGING/replaydata/agents/$ADAPTER/scenarios/$SCENARIO/transcript.$TRANSCRIPT_EXT"

--- a/.claude/skills/ir:onboard-agent/scripts/run-cell.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/run-cell.sh
@@ -278,13 +278,10 @@ fi
   -d "$STAGING/replaydata/agents" \
   "$RECORDING" "$ACTUAL_UUID" "$TRANSCRIPT" "$ADAPTER" "$SCENARIO"
 
-# Aider's curated fixture is markdown (curate-lifecycle-fixture.sh keeps
-# the native extension); other adapters are JSONL.
-if [[ "$ADAPTER" == "aider" ]]; then
-  TRANSCRIPT_EXT="md"
-else
-  TRANSCRIPT_EXT="jsonl"
-fi
+# Adapter declares its curated transcript extension in capabilities.json
+# (default "jsonl"). curate-lifecycle-fixture.sh reads the same field.
+TRANSCRIPT_EXT="$(jq -r '.transcript_extension // "jsonl"' \
+  "$REPO_ROOT/replaydata/agents/$ADAPTER/capabilities.json")"
 STAGED_TRANSCRIPT="$STAGING/replaydata/agents/$ADAPTER/scenarios/$SCENARIO/transcript.$TRANSCRIPT_EXT"
 
 # --- Build replay reports -----------------------------------------------

--- a/replaydata/agents/aider/capabilities.json
+++ b/replaydata/agents/aider/capabilities.json
@@ -3,6 +3,7 @@
   "agent": "aider",
   "discovered_at": "2026-04-25",
   "source": "discovery_subagent",
+  "transcript_extension": "md",
   "features": {
     "headless_mode": true,
     "tui": true,

--- a/tools/coverage-viewer/main.go
+++ b/tools/coverage-viewer/main.go
@@ -169,19 +169,21 @@ func buildMatrix() (*matrixResp, error) {
 	}
 
 	caps := make(map[string]map[string]any)
+	exts := make(map[string]string)
 	for _, a := range adapters {
-		c, err := loadCapabilities(a)
+		c, ext, err := loadCapabilities(a)
 		if err != nil {
 			return nil, fmt.Errorf("caps %s: %w", a, err)
 		}
 		caps[a] = c
+		exts[a] = ext
 	}
 
 	cells := make(map[string]map[string]cell, len(adapters))
 	for _, a := range adapters {
 		cells[a] = make(map[string]cell, len(scenarios))
 		for _, s := range scenarios {
-			cells[a][s.Name] = deriveCell(a, s, caps[a])
+			cells[a][s.Name] = deriveCell(a, s, caps[a], exts[a])
 		}
 	}
 
@@ -200,7 +202,9 @@ func buildMatrix() (*matrixResp, error) {
 }
 
 // deriveCell mirrors .claude/skills/ir:onboard-agent/skill.md step 2.
-func deriveCell(adapter string, s scenario, caps map[string]any) cell {
+// transcriptExt is the adapter's curated-fixture extension from
+// capabilities.json (e.g. "jsonl", "md").
+func deriveCell(adapter string, s scenario, caps map[string]any, transcriptExt string) cell {
 	for _, req := range s.Requires {
 		v, ok := caps[req]
 		if !ok || v != true { // both false and "unknown" block
@@ -210,13 +214,7 @@ func deriveCell(adapter string, s scenario, caps map[string]any) cell {
 	if _, ok := s.ByAdapter[adapter]; !ok {
 		return cell{State: "missing-prompt", Reason: "no by_adapter." + adapter + " entry in scenarios.json"}
 	}
-	// aider's curated transcript is markdown; all other adapters are jsonl.
-	// Mirrors the convention in .claude/skills/ir:onboard-agent/scripts/run-cell.sh.
-	ext := "jsonl"
-	if adapter == "aider" {
-		ext = "md"
-	}
-	fixture := filepath.Join(*rootDir, replayAgentDir, adapter, "scenarios", s.Name, "transcript."+ext)
+	fixture := filepath.Join(*rootDir, replayAgentDir, adapter, "scenarios", s.Name, "transcript."+transcriptExt)
 	if _, err := os.Stat(fixture); err == nil {
 		return cell{State: "covered"}
 	}
@@ -268,12 +266,12 @@ func handleScenario(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "scenario not found", http.StatusNotFound)
 		return
 	}
-	caps, err := loadCapabilities(adapter)
+	caps, transcriptExt, err := loadCapabilities(adapter)
 	if err != nil {
 		httpError(w, err)
 		return
 	}
-	c := deriveCell(adapter, *s, caps)
+	c := deriveCell(adapter, *s, caps, transcriptExt)
 
 	resp := drilldownResp{
 		Adapter:     adapter,
@@ -604,19 +602,26 @@ func loadScenarios() ([]scenario, error) {
 	return doc.Scenarios, nil
 }
 
-func loadCapabilities(adapter string) (map[string]any, error) {
+// loadCapabilities returns the adapter's feature map and its curated
+// transcript extension (defaulting to "jsonl" when the field is absent).
+func loadCapabilities(adapter string) (map[string]any, string, error) {
 	path := filepath.Join(*rootDir, replayAgentDir, adapter, "capabilities.json")
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	var doc struct {
-		Features map[string]any `json:"features"`
+		Features            map[string]any `json:"features"`
+		TranscriptExtension string         `json:"transcript_extension"`
 	}
 	if err := json.Unmarshal(b, &doc); err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return doc.Features, nil
+	ext := doc.TranscriptExtension
+	if ext == "" {
+		ext = "jsonl"
+	}
+	return doc.Features, ext, nil
 }
 
 // ---------- helpers ----------

--- a/tools/coverage-viewer/main.go
+++ b/tools/coverage-viewer/main.go
@@ -202,8 +202,6 @@ func buildMatrix() (*matrixResp, error) {
 }
 
 // deriveCell mirrors .claude/skills/ir:onboard-agent/skill.md step 2.
-// transcriptExt is the adapter's curated-fixture extension from
-// capabilities.json (e.g. "jsonl", "md").
 func deriveCell(adapter string, s scenario, caps map[string]any, transcriptExt string) cell {
 	for _, req := range s.Requires {
 		v, ok := caps[req]

--- a/tools/coverage-viewer/main_test.go
+++ b/tools/coverage-viewer/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadCapabilitiesTranscriptExtension locks in the contract that
+// loadCapabilities returns the adapter's transcript_extension when present
+// and falls back to "jsonl" when absent. Three call sites (run-cell.sh,
+// curate-lifecycle-fixture.sh, deriveCell) depend on this default.
+func TestLoadCapabilitiesTranscriptExtension(t *testing.T) {
+	cases := []struct {
+		name    string
+		json    string
+		wantExt string
+	}{
+		{
+			name:    "explicit md",
+			json:    `{"schema_version":1,"agent":"aider","transcript_extension":"md","features":{}}`,
+			wantExt: "md",
+		},
+		{
+			name:    "missing field defaults to jsonl",
+			json:    `{"schema_version":1,"agent":"claudecode","features":{}}`,
+			wantExt: "jsonl",
+		},
+		{
+			name:    "empty string defaults to jsonl",
+			json:    `{"schema_version":1,"agent":"x","transcript_extension":"","features":{}}`,
+			wantExt: "jsonl",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			adapter := "testadapter"
+			adir := filepath.Join(tmp, replayAgentDir, adapter)
+			if err := os.MkdirAll(adir, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(adir, "capabilities.json"), []byte(tc.json), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+
+			orig := *rootDir
+			*rootDir = tmp
+			t.Cleanup(func() { *rootDir = orig })
+
+			_, ext, err := loadCapabilities(adapter)
+			if err != nil {
+				t.Fatalf("loadCapabilities: %v", err)
+			}
+			if ext != tc.wantExt {
+				t.Fatalf("ext = %q, want %q", ext, tc.wantExt)
+			}
+		})
+	}
+}

--- a/tools/curate-lifecycle-fixture.sh
+++ b/tools/curate-lifecycle-fixture.sh
@@ -92,14 +92,12 @@ fi
 OUT_EVENTS="$SCENARIO_DIR/events.jsonl"
 OUT_SUBAGENTS_DIR="$SCENARIO_DIR/subagents"
 
-# Aider's source transcript is markdown (.aider.chat.history.md), not
-# JSONL — preserve the native extension so the parser can ingest the file
+# Adapter declares its native transcript extension in capabilities.json
+# (default "jsonl"); preserve it so the parser can ingest the file
 # verbatim during replay.
-if [[ "$ADAPTER" == "aider" ]]; then
-  OUT_TRANSCRIPT="$SCENARIO_DIR/transcript.md"
-else
-  OUT_TRANSCRIPT="$SCENARIO_DIR/transcript.jsonl"
-fi
+CAPS_JSON="$REPO_ROOT/replaydata/agents/$ADAPTER/capabilities.json"
+TRANSCRIPT_EXT="$(jq -r '.transcript_extension // "jsonl"' "$CAPS_JSON")"
+OUT_TRANSCRIPT="$SCENARIO_DIR/transcript.$TRANSCRIPT_EXT"
 
 # Discover child session IDs by scanning parent_linked events in the
 # recording. Each such event carries (session_id=child, parent_session_id=parent).


### PR DESCRIPTION
## Summary
- Move the "aider→`md`, others→`jsonl`" curated-fixture rule into a top-level `transcript_extension` field on `replaydata/agents/<adapter>/capabilities.json` (default `"jsonl"` when absent).
- Replace three hardcodes that all encoded the same fact: the write-side in `tools/curate-lifecycle-fixture.sh`, the staged-fixture path in `.claude/skills/ir:onboard-agent/scripts/run-cell.sh`, and the covered/staged-only check in `tools/coverage-viewer/main.go` (`deriveCell`).
- Adding a new adapter with a non-jsonl transcript is now a one-line edit to its `capabilities.json`.

Closes #239.

## Test plan
- [x] `go build ./tools/coverage-viewer/...` — clean
- [x] `go test ./core/... -race -count=1` — passes (the `core/cmd/replay` golden-byte-identity failures reproduce on unmodified `worktree-239`; goldens contain absolute paths baked for the main repo, not this worktree path — pre-existing, unrelated)
- [x] `tools/replay-fixtures.sh` — all committed fixtures (including aider `.md`) replay end-to-end via the new `transcript_extension` lookup
- [x] `jq -r '.transcript_extension // "jsonl"'` returns `md` for aider, `jsonl` for adapters without the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)