### PR TITLE
fix(tailer): drop bufio.Scanner cap so JSONL lines >2 MB don't wedge sessions (#270)

### DIFF
--- a/core/pkg/tailer/large_line_test.go
+++ b/core/pkg/tailer/large_line_test.go
@@ -1,0 +1,186 @@
+package tailer
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTailAndProcess_LargeToolResultLine exercises the wedge fix from issue
+// #270: a JSONL line above bufio.Scanner's old 2 MB cap must not block
+// downstream events from being parsed.
+func TestTailAndProcess_LargeToolResultLine(t *testing.T) {
+	bigContent := strings.Repeat("x", 3*1024*1024) // 3 MB
+
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := json.NewEncoder(f)
+	must := func(v map[string]interface{}) {
+		if err := enc.Encode(v); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(map[string]interface{}{"type": "user", "timestamp": ts(0)})
+	// Oversized tool_result, written as a "user" event with a content array
+	// (the shape that triggered the live wedge in issue #270).
+	must(map[string]interface{}{
+		"type": "user", "timestamp": ts(1),
+		"message": map[string]interface{}{
+			"content": []interface{}{
+				map[string]interface{}{
+					"type":        "tool_result",
+					"tool_use_id": "tu1",
+					"content":     bigContent,
+				},
+			},
+		},
+	})
+	must(map[string]interface{}{
+		"type": "assistant", "timestamp": ts(2),
+		"message": map[string]interface{}{
+			"role": "assistant", "stop_reason": "end_turn",
+		},
+	})
+	must(map[string]interface{}{
+		"type": "system", "subtype": "turn_duration", "timestamp": ts(3),
+	})
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tailer := newTestTailer(path)
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+	if m.LastEventType != "turn_done" {
+		t.Errorf("LastEventType = %q, want %q", m.LastEventType, "turn_done")
+	}
+}
+
+// TestTailAndProcess_PartialTrailingLine verifies that a transcript ending
+// mid-line does not advance the offset past the partial bytes — they must be
+// re-read once the writer flushes the rest of the line.
+func TestTailAndProcess_PartialTrailingLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// One complete user line, then partial bytes of a later event with no '\n'.
+	if err := json.NewEncoder(f).Encode(map[string]interface{}{
+		"type": "user", "timestamp": ts(0),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	endOfFirstLine, err := f.Seek(0, io.SeekCurrent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	partial := []byte(`{"type":"assistant","timestamp":"` + ts(1) + `","message":{"role":"assistant","stop_reason":"end`)
+	if _, err := f.Write(partial); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tailer := newTestTailer(path)
+	if _, err := tailer.TailAndProcess(); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	if got := tailer.GetLedgerState().LastOffset; got != endOfFirstLine {
+		t.Errorf("after partial-line pass: lastOffset = %d, want %d (start of partial bytes)", got, endOfFirstLine)
+	}
+
+	// Append the rest of the assistant line plus a turn_duration line.
+	f, err = os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("_turn\"}}\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.NewEncoder(f).Encode(map[string]interface{}{
+		"type": "system", "subtype": "turn_duration", "timestamp": ts(2),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := tailer.TailAndProcess()
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if m.LastEventType != "turn_done" {
+		t.Errorf("after second pass: LastEventType = %q, want %q", m.LastEventType, "turn_done")
+	}
+}
+
+// TestReadLineCapped_OversizedLineSkipped exercises the skip path directly
+// with a small ceiling so we don't have to round-trip 64 MB through the disk.
+func TestReadLineCapped_OversizedLineSkipped(t *testing.T) {
+	const max = 1024
+	oversized := bytes.Repeat([]byte("a"), max*4) // 4 KB > 1 KB cap
+	follow := []byte(`{"type":"user"}`)
+	var input bytes.Buffer
+	input.Write(oversized)
+	input.WriteByte('\n')
+	input.Write(follow)
+	input.WriteByte('\n')
+
+	r := bufio.NewReaderSize(&input, 256) // small buffer so ReadSlice returns ErrBufferFull
+	line, consumed, err := readLineCapped(r, max)
+	if !errors.Is(err, errLineTooLong) {
+		t.Fatalf("first call: err = %v, want errLineTooLong", err)
+	}
+	if line != nil {
+		t.Errorf("first call: line = %q, want nil", line)
+	}
+	if want := int64(len(oversized) + 1); consumed != want {
+		t.Errorf("first call: consumed = %d, want %d", consumed, want)
+	}
+
+	line, consumed, err = readLineCapped(r, max)
+	if err != nil {
+		t.Fatalf("second call: err = %v, want nil", err)
+	}
+	if string(line) != string(follow) {
+		t.Errorf("second call: line = %q, want %q", line, follow)
+	}
+	if want := int64(len(follow) + 1); consumed != want {
+		t.Errorf("second call: consumed = %d, want %d", consumed, want)
+	}
+
+	if _, _, err := readLineCapped(r, max); !errors.Is(err, io.EOF) {
+		t.Errorf("third call: err = %v, want io.EOF", err)
+	}
+}
+
+// TestReadLineCapped_PartialAtEOF asserts that bytes without a trailing '\n'
+// are surfaced as errPartialAtEOF with consumed == 0 so the caller does not
+// advance past them.
+func TestReadLineCapped_PartialAtEOF(t *testing.T) {
+	r := bufio.NewReaderSize(bytes.NewReader([]byte(`{"partial":true`)), 256)
+	line, consumed, err := readLineCapped(r, 1<<20)
+	if !errors.Is(err, errPartialAtEOF) {
+		t.Errorf("err = %v, want errPartialAtEOF", err)
+	}
+	if line != nil {
+		t.Errorf("line = %q, want nil", line)
+	}
+	if consumed != 0 {
+		t.Errorf("consumed = %d, want 0", consumed)
+	}
+}

--- a/core/pkg/tailer/large_line_test.go
+++ b/core/pkg/tailer/large_line_test.go
@@ -184,3 +184,42 @@ func TestReadLineCapped_PartialAtEOF(t *testing.T) {
 		t.Errorf("consumed = %d, want 0", consumed)
 	}
 }
+
+// TestReadLineCapped_PartialOversizedAtEOF locks in the in-progress
+// oversized-line case: bytes already exceed max but the writer hasn't
+// flushed '\n' yet. Must surface as errPartialAtEOF (not errLineTooLong)
+// with consumed == 0 so the caller waits for the writer to finish the line.
+// Otherwise the tail beyond max would be silently swallowed by the
+// JSON-validity check on the next tick.
+func TestReadLineCapped_PartialOversizedAtEOF(t *testing.T) {
+	const max = 1024
+	// 4 KB of bytes, no trailing '\n' — exceeds the cap and is in-progress.
+	input := bytes.Repeat([]byte("a"), max*4)
+	r := bufio.NewReaderSize(bytes.NewReader(input), 256)
+	line, consumed, err := readLineCapped(r, max)
+	if !errors.Is(err, errPartialAtEOF) {
+		t.Fatalf("err = %v, want errPartialAtEOF", err)
+	}
+	if line != nil {
+		t.Errorf("line = %q, want nil", line)
+	}
+	if consumed != 0 {
+		t.Errorf("consumed = %d, want 0 (caller must not advance)", consumed)
+	}
+
+	// Simulate the writer flushing the rest of the line plus '\n'. The next
+	// pass (fresh reader from same underlying bytes) must report a single
+	// errLineTooLong with the full consumed count.
+	complete := append(append([]byte{}, input...), '\n')
+	r2 := bufio.NewReaderSize(bytes.NewReader(complete), 256)
+	line, consumed, err = readLineCapped(r2, max)
+	if !errors.Is(err, errLineTooLong) {
+		t.Fatalf("after completion: err = %v, want errLineTooLong", err)
+	}
+	if line != nil {
+		t.Errorf("after completion: line = %q, want nil", line)
+	}
+	if want := int64(len(complete)); consumed != want {
+		t.Errorf("after completion: consumed = %d, want %d", consumed, want)
+	}
+}

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -545,12 +545,15 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 //
 // Outcomes:
 //   - (line, consumed, nil): full line read.
-//   - (nil, consumed, errLineTooLong): line exceeded max; bytes were
-//     discarded and consumed reflects the skip distance.
+//   - (nil, consumed, errLineTooLong): line exceeded max and ended with '\n';
+//     bytes were discarded and consumed reflects the skip distance.
 //   - (nil, 0, io.EOF): clean EOF, no bytes read.
-//   - (nil, 0, errPartialAtEOF): EOF reached before '\n' with bytes pending;
-//     caller stops without advancing so the partial line is re-read on the
-//     next pass once more data is appended.
+//   - (nil, 0, errPartialAtEOF): EOF reached before '\n' with bytes pending —
+//     either an in-progress line below the cap or one that has already grown
+//     past the cap but the writer hasn't flushed '\n' yet. Caller stops
+//     without advancing so the bytes are re-read once more data is appended;
+//     when the line eventually completes it is reported as either a success
+//     or errLineTooLong with a single accurate consumed count.
 //   - (nil, 0, err): other I/O error.
 func readLineCapped(r *bufio.Reader, max int64) ([]byte, int64, error) {
 	var (
@@ -562,8 +565,8 @@ func readLineCapped(r *bufio.Reader, max int64) ([]byte, int64, error) {
 		chunk, err := r.ReadSlice('\n')
 		consumed += int64(len(chunk))
 
-		switch {
-		case err == nil:
+		switch err {
+		case nil:
 			if skipping {
 				return nil, consumed, errLineTooLong
 			}
@@ -578,7 +581,7 @@ func readLineCapped(r *bufio.Reader, max int64) ([]byte, int64, error) {
 			}
 			buf = append(buf, line...)
 			return buf, consumed, nil
-		case errors.Is(err, bufio.ErrBufferFull):
+		case bufio.ErrBufferFull:
 			if skipping {
 				continue
 			}
@@ -588,17 +591,17 @@ func readLineCapped(r *bufio.Reader, max int64) ([]byte, int64, error) {
 				continue
 			}
 			buf = append(buf, chunk...)
-		case errors.Is(err, io.EOF):
+		case io.EOF:
 			if consumed == 0 {
 				return nil, 0, io.EOF
 			}
-			if skipping {
-				// Mid-skip EOF: treat as a fully-discarded oversized line so
-				// the caller advances past it — otherwise we'd re-read the
-				// same oversized prefix forever.
-				return nil, consumed, errLineTooLong
-			}
-			// Partial line at EOF — leave bytes for the next tail pass.
+			// Partial line at EOF — leave bytes for the next tail pass. This
+			// covers both small in-progress lines and oversized lines whose
+			// '\n' hasn't been flushed yet; in the latter case we'll re-read
+			// the same prefix on subsequent ticks until the line completes,
+			// at which point it surfaces as a single errLineTooLong with the
+			// real total size. Without this, the tail beyond `consumed` would
+			// be silently consumed at the JSON-validity check next tick.
 			return nil, 0, errPartialAtEOF
 		default:
 			return nil, 0, err

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -3,14 +3,26 @@ package tailer
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"irrlicht/core/pkg/capacity"
+)
+
+// maxTranscriptLineSize caps a single JSONL line at 64 MB. Lines beyond this
+// are skipped so a malformed or pathological transcript can never wedge the
+// tailer (issue #270).
+const maxTranscriptLineSize = 64 * 1024 * 1024
+
+var (
+	errLineTooLong  = errors.New("transcript line exceeds size cap")
+	errPartialAtEOF = errors.New("transcript ends mid-line")
 )
 
 // MessageEvent represents a single message event from transcript
@@ -337,16 +349,34 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 
 	currentOffset := startPos
 
-	scanner := bufio.NewScanner(file)
-	// Large tool results (especially from Pi/Codex read/bash output) can exceed
-	// bufio.Scanner's 64KB default token size.
-	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
+	// bufio.Reader (not Scanner) so a single oversized JSONL line can't wedge
+	// the tailer. Lines above maxTranscriptLineSize are skipped: the offset is
+	// advanced past them and processing continues. See issue #270.
+	reader := bufio.NewReaderSize(file, 64*1024)
 
 	rawLineParser, isRawLine := t.parser.(RawLineParser)
 
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		currentOffset += int64(len(scanner.Bytes()) + 1)
+	var loopErr error
+	for {
+		raw, consumed, lineErr := readLineCapped(reader, maxTranscriptLineSize)
+		if errors.Is(lineErr, io.EOF) || errors.Is(lineErr, errPartialAtEOF) {
+			// EOF (clean) or partial trailing line — stop without advancing
+			// past the partial bytes; they'll be re-read next tick once more
+			// data is appended.
+			break
+		}
+		if errors.Is(lineErr, errLineTooLong) {
+			log.Printf("irrlicht/tailer: skipping oversized line at offset %d (%d bytes) in %s", currentOffset, consumed, t.path)
+			currentOffset += consumed
+			continue
+		}
+		if lineErr != nil {
+			loopErr = lineErr
+			break
+		}
+
+		currentOffset += consumed
+		line := strings.TrimSpace(string(raw))
 
 		if line == "" {
 			continue
@@ -504,5 +534,74 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 
 	t.computeContextUtilization()
 
-	return t.metrics, scanner.Err()
+	return t.metrics, loopErr
+}
+
+// readLineCapped reads a single '\n'-terminated line from r. The returned
+// slice does not include the trailing '\n' (or '\r' before it); consumed is
+// the total bytes drawn from r — the caller advances the file offset by that
+// amount whenever the result represents a fully-handled line (success or
+// errLineTooLong).
+//
+// Outcomes:
+//   - (line, consumed, nil): full line read.
+//   - (nil, consumed, errLineTooLong): line exceeded max; bytes were
+//     discarded and consumed reflects the skip distance.
+//   - (nil, 0, io.EOF): clean EOF, no bytes read.
+//   - (nil, 0, errPartialAtEOF): EOF reached before '\n' with bytes pending;
+//     caller stops without advancing so the partial line is re-read on the
+//     next pass once more data is appended.
+//   - (nil, 0, err): other I/O error.
+func readLineCapped(r *bufio.Reader, max int64) ([]byte, int64, error) {
+	var (
+		buf      []byte
+		consumed int64
+		skipping bool
+	)
+	for {
+		chunk, err := r.ReadSlice('\n')
+		consumed += int64(len(chunk))
+
+		switch {
+		case err == nil:
+			if skipping {
+				return nil, consumed, errLineTooLong
+			}
+			line := chunk[:len(chunk)-1] // drop '\n'
+			if len(line) > 0 && line[len(line)-1] == '\r' {
+				line = line[:len(line)-1]
+			}
+			if buf == nil {
+				out := make([]byte, len(line))
+				copy(out, line)
+				return out, consumed, nil
+			}
+			buf = append(buf, line...)
+			return buf, consumed, nil
+		case errors.Is(err, bufio.ErrBufferFull):
+			if skipping {
+				continue
+			}
+			if consumed > max {
+				buf = nil // release accumulated bytes for GC
+				skipping = true
+				continue
+			}
+			buf = append(buf, chunk...)
+		case errors.Is(err, io.EOF):
+			if consumed == 0 {
+				return nil, 0, io.EOF
+			}
+			if skipping {
+				// Mid-skip EOF: treat as a fully-discarded oversized line so
+				// the caller advances past it — otherwise we'd re-read the
+				// same oversized prefix forever.
+				return nil, consumed, errLineTooLong
+			}
+			// Partial line at EOF — leave bytes for the next tail pass.
+			return nil, 0, errPartialAtEOF
+		default:
+			return nil, 0, err
+		}
+	}
 }

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -595,13 +595,6 @@ func readLineCapped(r *bufio.Reader, max int64) ([]byte, int64, error) {
 			if consumed == 0 {
 				return nil, 0, io.EOF
 			}
-			// Partial line at EOF — leave bytes for the next tail pass. This
-			// covers both small in-progress lines and oversized lines whose
-			// '\n' hasn't been flushed yet; in the latter case we'll re-read
-			// the same prefix on subsequent ticks until the line completes,
-			// at which point it surfaces as a single errLineTooLong with the
-			// real total size. Without this, the tail beyond `consumed` would
-			// be silently consumed at the JSON-validity check next tick.
 			return nil, 0, errPartialAtEOF
 		default:
 			return nil, 0, err


### PR DESCRIPTION
## Summary
- A claude-code session would freeze in `working` forever once its transcript accumulated any single JSONL line above ~2 MB. `bufio.Scanner` with a 2 MB `Buffer` cap returned `bufio.ErrTooLong`, the tailer loop never advanced `currentOffset`, and the metrics adapter discarded the (nil, err) pair — every subsequent fswatcher tick re-failed at the same offset.
- Replace the `bufio.Scanner` in `TailAndProcess` with a `bufio.Reader` + `readLineCapped` helper that has no fixed cap but skips lines above a 64 MB sanity ceiling (offset advanced, `log.Printf` warning, processing continues). Partial-trailing-line bytes are correctly preserved for the next tick instead of being silently consumed.
- Verified end-to-end on the live wedge session `15c6a867…`: after restarting the daemon the ledger drained from offset 1,374,147 → 13,709,801 and the session went `working` → `ready` within one fswatcher tick.

Closes #270.

## Test plan
- [x] `go test ./core/pkg/tailer/ -race -count=1 -v` — 4 new tests pass (3 MB tool_result, partial trailing line, oversized-line skip path, partial-at-EOF helper)
- [x] `go test ./core/... -race -count=1` — full core suite green
- [x] `tools/replay-fixtures.sh` — no fixture drift
- [x] `go vet ./core/...` — clean
- [x] Manual regression: rebuilt daemon + Swift app via `/ir:test-mac`, restarted; live wedge session `15c6a867…` (cwd `/Users/ingo/references`) transitioned to `ready`, `last_event_type=turn_done`, ledger advanced to full transcript size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)