### PR TITLE
fix(aider): emit turn_done on LLM-layer error so session unsticks (#262)

### DIFF
--- a/core/adapters/inbound/agents/aider/parser.go
+++ b/core/adapters/inbound/agents/aider/parser.go
@@ -40,6 +40,11 @@ var (
 	appliedEditRE = regexp.MustCompile(`^>\s*Applied edit to\s+`)
 	// `> Running <cmd>` or `> Running shell command:` — shell tool call
 	runningRE = regexp.MustCompile(`^>\s*Running\s+`)
+	// `> litellm.BadRequestError: …`, `> openai.RateLimitError: …`,
+	// `> OpenAIException - …` — LLM-layer failures that abort a turn
+	// without ever printing `> Tokens: …`. Matched only inside an open
+	// turn so we don't fabricate a turn for startup-banner noise.
+	errorRE = regexp.MustCompile(`^>\s*\S*(?:Error|Exception)[: ]`)
 )
 
 // ParseLine satisfies tailer.TranscriptParser but is unused: aider transcripts
@@ -86,6 +91,10 @@ func (p *Parser) ParseLineRaw(line string) *tailer.ParsedEvent {
 	}
 	if runningRE.MatchString(line) {
 		return p.toolCall("Bash")
+	}
+
+	if p.turnOpen && errorRE.MatchString(line) {
+		return p.flushErrorTurn(line)
 	}
 
 	if strings.HasPrefix(line, ">") {
@@ -142,6 +151,24 @@ func (p *Parser) flushAssistantTurn(m []string) *tailer.ParsedEvent {
 			Output: received,
 			Total:  sent + received,
 		},
+	}
+}
+
+// flushErrorTurn closes the current turn after aider prints an LLM-layer
+// error blockquote. Aider does not emit a `> Tokens: …` line in this case,
+// so without this synthetic turn_done the session would stay stuck in
+// `working`. The error text is surfaced as AssistantText so the dashboard
+// shows what happened. Tokens/Contribution are intentionally nil because
+// no usage was reported.
+func (p *Parser) flushErrorTurn(line string) *tailer.ParsedEvent {
+	errText := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), ">"))
+	p.assistantBuffer.Reset()
+	p.turnOpen = false
+	return &tailer.ParsedEvent{
+		EventType:     "turn_done",
+		ModelName:     p.model,
+		AssistantText: truncate(errText),
+		ContentChars:  int64(len(errText)),
 	}
 }
 

--- a/core/adapters/inbound/agents/aider/parser.go
+++ b/core/adapters/inbound/agents/aider/parser.go
@@ -15,9 +15,12 @@ import (
 // no-op kept only to satisfy the TranscriptParser interface.
 //
 // State machine: a turn begins on a `#### …` line (user prompt). Plain
-// prose lines accumulate as assistant text until the next `> Tokens: …`
-// line, which closes the turn and triggers a turn_done event carrying
-// the buffered text and a PerTurnContribution.
+// prose lines accumulate as assistant text until either:
+//   - a `> Tokens: …` line closes the turn cleanly with usage, or
+//   - an LLM-layer error blockquote (e.g. `> litellm.BadRequestError: …`)
+//     aborts the turn before tokens are reported.
+// Both paths emit a turn_done event so the state classifier returns the
+// session to ready; only the clean path carries a PerTurnContribution.
 type Parser struct {
 	model           string
 	assistantBuffer strings.Builder
@@ -41,10 +44,12 @@ var (
 	// `> Running <cmd>` or `> Running shell command:` — shell tool call
 	runningRE = regexp.MustCompile(`^>\s*Running\s+`)
 	// `> litellm.BadRequestError: …`, `> openai.RateLimitError: …`,
-	// `> OpenAIException - …` — LLM-layer failures that abort a turn
-	// without ever printing `> Tokens: …`. Matched only inside an open
-	// turn so we don't fabricate a turn for startup-banner noise.
-	errorRE = regexp.MustCompile(`^>\s*\S*(?:Error|Exception)[: ]`)
+	// `> OpenAIException - …`, `> LookupError` — LLM-layer failures that
+	// abort a turn without ever printing `> Tokens: …`. The trailing
+	// alternation `(?:[: ]|$)` covers both delimited forms and bare
+	// error tokens at end-of-line. Matched only inside an open turn so
+	// we don't fabricate a turn for startup-banner noise.
+	errorRE = regexp.MustCompile(`^>\s*\S*(?:Error|Exception)(?:[: ]|$)`)
 )
 
 // ParseLine satisfies tailer.TranscriptParser but is unused: aider transcripts

--- a/core/adapters/inbound/agents/aider/parser.go
+++ b/core/adapters/inbound/agents/aider/parser.go
@@ -43,12 +43,10 @@ var (
 	appliedEditRE = regexp.MustCompile(`^>\s*Applied edit to\s+`)
 	// `> Running <cmd>` or `> Running shell command:` — shell tool call
 	runningRE = regexp.MustCompile(`^>\s*Running\s+`)
-	// `> litellm.BadRequestError: …`, `> openai.RateLimitError: …`,
-	// `> OpenAIException - …`, `> LookupError` — LLM-layer failures that
-	// abort a turn without ever printing `> Tokens: …`. The trailing
-	// alternation `(?:[: ]|$)` covers both delimited forms and bare
-	// error tokens at end-of-line. Matched only inside an open turn so
-	// we don't fabricate a turn for startup-banner noise.
+	// `> litellm.BadRequestError: …` / `> OpenAIException - …` / bare
+	// `> LookupError` — LLM failures that abort a turn before any
+	// `> Tokens: …` line. Gated on turnOpen at the call site so startup
+	// banners can't fabricate a phantom turn.
 	errorRE = regexp.MustCompile(`^>\s*\S*(?:Error|Exception)(?:[: ]|$)`)
 )
 
@@ -98,11 +96,10 @@ func (p *Parser) ParseLineRaw(line string) *tailer.ParsedEvent {
 		return p.toolCall("Bash")
 	}
 
-	if p.turnOpen && errorRE.MatchString(line) {
-		return p.flushErrorTurn(line)
-	}
-
 	if strings.HasPrefix(line, ">") {
+		if p.turnOpen && errorRE.MatchString(line) {
+			return p.flushErrorTurn(line)
+		}
 		// Other blockquote lines are aider status output (warnings,
 		// confirmation prompts, invocation echo). Ignore.
 		return nil
@@ -166,7 +163,7 @@ func (p *Parser) flushAssistantTurn(m []string) *tailer.ParsedEvent {
 // shows what happened. Tokens/Contribution are intentionally nil because
 // no usage was reported.
 func (p *Parser) flushErrorTurn(line string) *tailer.ParsedEvent {
-	errText := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), ">"))
+	errText := strings.TrimSpace(strings.TrimPrefix(line, ">"))
 	p.assistantBuffer.Reset()
 	p.turnOpen = false
 	return &tailer.ParsedEvent{

--- a/core/adapters/inbound/agents/aider/parser_test.go
+++ b/core/adapters/inbound/agents/aider/parser_test.go
@@ -1,6 +1,7 @@
 package aider
 
 import (
+	"strings"
 	"testing"
 
 	"irrlicht/core/pkg/tailer"
@@ -263,6 +264,54 @@ func TestParser_TrailingQuestionMark_PreservedForWaitingClassification(t *testin
 				t.Errorf("AssistantText must end in '?', got %q (full=%q)", last, done.AssistantText)
 			}
 		})
+	}
+}
+
+// TestParser_LLMError_EndsTurn pins issue #262: when aider's LLM call fails
+// (e.g. `> litellm.BadRequestError: …`) the turn closes via a synthetic
+// turn_done event rather than hanging because no `> Tokens: …` line was
+// printed. Without this, sessions stay stuck in `working` forever.
+func TestParser_LLMError_EndsTurn(t *testing.T) {
+	lines := []string{
+		"> Model: openai/google/gemma-4-26b-a4b with whole edit format",
+		"#### search the codebase for security vulnerabilities",
+		`> litellm.BadRequestError: OpenAIException - Failed to load model "google/gemma-4-26b-a4b". Error: Model loading was stopped due to insufficient system resources.`,
+	}
+	events := drive(&Parser{}, lines)
+
+	var done *tailer.ParsedEvent
+	doneCount := 0
+	for _, e := range events {
+		if e.EventType == "turn_done" {
+			done = e
+			doneCount++
+		}
+	}
+	if doneCount != 1 {
+		t.Fatalf("expected exactly 1 turn_done, got %d", doneCount)
+	}
+	if !strings.Contains(done.AssistantText, "BadRequestError") {
+		t.Errorf("expected error text in AssistantText, got %q", done.AssistantText)
+	}
+	if done.ContentChars == 0 {
+		t.Errorf("expected non-zero ContentChars for error turn")
+	}
+}
+
+// TestParser_ErrorBeforeTurn_NoPhantomEvent guards against false positives:
+// error-shaped blockquotes printed before any `####` (e.g. startup banners)
+// must not fabricate a turn_done. The matcher is gated on turnOpen.
+func TestParser_ErrorBeforeTurn_NoPhantomEvent(t *testing.T) {
+	p := &Parser{}
+	for _, line := range []string{
+		"> Model: openai/gpt-5 with diff edit format",
+		"> SomeStartupError: not a real turn",
+		"> litellm.ConfigError: pre-prompt failure",
+	} {
+		ev := p.ParseLineRaw(line)
+		if ev != nil && ev.EventType == "turn_done" {
+			t.Errorf("expected no turn_done before turn opened, got %+v for %q", ev, line)
+		}
 	}
 }
 

--- a/core/adapters/inbound/agents/aider/parser_test.go
+++ b/core/adapters/inbound/agents/aider/parser_test.go
@@ -298,6 +298,65 @@ func TestParser_LLMError_EndsTurn(t *testing.T) {
 	}
 }
 
+// TestParser_ErrorTurn_RecoversOnNextPrompt pins the recovery path: after an
+// error closes a turn, a subsequent `####` prompt must reopen a fresh turn
+// and the next `> Tokens: …` must produce a clean turn_done with usage.
+// Without this, a single error would silently break the rest of the session.
+func TestParser_ErrorTurn_RecoversOnNextPrompt(t *testing.T) {
+	p := &Parser{}
+	events := drive(p, []string{
+		"> Model: openai/gpt-5 with diff edit format",
+		"#### first attempt",
+		"> litellm.BadRequestError: transient failure",
+		"#### retry",
+		"this time it works",
+		"> Tokens: 100 sent, 20 received.",
+	})
+
+	var dones []*tailer.ParsedEvent
+	for _, e := range events {
+		if e.EventType == "turn_done" {
+			dones = append(dones, e)
+		}
+	}
+	if len(dones) != 2 {
+		t.Fatalf("expected 2 turn_done events (error + clean), got %d", len(dones))
+	}
+	if !strings.Contains(dones[0].AssistantText, "BadRequestError") {
+		t.Errorf("first turn_done should carry error text, got %q", dones[0].AssistantText)
+	}
+	if dones[0].Contribution != nil {
+		t.Errorf("error turn should have no Contribution, got %+v", dones[0].Contribution)
+	}
+	if dones[1].AssistantText != "this time it works" {
+		t.Errorf("second turn should carry the recovered prose, got %q", dones[1].AssistantText)
+	}
+	if dones[1].Contribution == nil || dones[1].Contribution.Usage.Input != 100 {
+		t.Fatalf("second turn should carry token contribution, got %+v", dones[1].Contribution)
+	}
+}
+
+// TestParser_ErrorWithoutDelimiter_EndsTurn covers the trailing-`$` branch
+// of errorRE: aider/litellm sometimes prints a bare error token with no
+// trailing `:` or argument (e.g. `> LookupError`). Without `|$` in the
+// regex these would fall through to the catch-all and hang the session.
+func TestParser_ErrorWithoutDelimiter_EndsTurn(t *testing.T) {
+	p := &Parser{}
+	events := drive(p, []string{
+		"#### do the thing",
+		"> LookupError",
+	})
+	doneCount := 0
+	for _, e := range events {
+		if e.EventType == "turn_done" {
+			doneCount++
+		}
+	}
+	if doneCount != 1 {
+		t.Fatalf("expected 1 turn_done for bare error token, got %d", doneCount)
+	}
+}
+
 // TestParser_ErrorBeforeTurn_NoPhantomEvent guards against false positives:
 // error-shaped blockquotes printed before any `####` (e.g. startup banners)
 // must not fabricate a turn_done. The matcher is gated on turnOpen.

--- a/replaydata/agents/aider/scenarios/llm-error/transcript.md
+++ b/replaydata/agents/aider/scenarios/llm-error/transcript.md
@@ -1,0 +1,15 @@
+
+# aider chat started at 2026-04-29 20:29:24
+
+> /Users/ingo/.local/bin/aider --model openai/google/gemma-4-26b-a4b --no-auto-commits --yes-always  
+> Warning for openai/google/gemma-4-26b-a4b: Unknown context window size and costs, using sane defaults.  
+> You can skip this check with --no-show-model-warnings  
+> https://aider.chat/docs/llms/warnings.html  
+> Open documentation url for more info? (Y)es/(N)o/(D)on't ask again [Yes]: y  
+> Aider v0.86.2  
+> Model: openai/google/gemma-4-26b-a4b with whole edit format  
+> Git repo: .git with 548 files  
+> Repo-map: using 1024 tokens, auto refresh  
+
+#### search the codebase for security vulnerabilities  
+> litellm.BadRequestError: OpenAIException - Failed to load model "google/gemma-4-26b-a4b". Error: Model loading was stopped due to insufficient system resources. Under the current settings, this model requires approximately 17.93 GB of memory, and continuing to load it would likely overload your system and cause it to freeze. If you think this is incorrect, you can adjust the model loading guardrails in settings.  


### PR DESCRIPTION
## Summary

- Aider parser now detects LLM-layer error blockquotes (e.g. `> litellm.BadRequestError: …`, `> openai.RateLimitError: …`, `> OpenAIException - …`) inside an open turn and emits a synthetic `turn_done` event so the session returns from `working` to `ready`.
- Error text is surfaced as the turn's `AssistantText` so the dashboard shows what happened. Tokens/Contribution stay `nil` since none were consumed.
- Match is gated on `turnOpen == true` — startup-banner errors before any `####` prompt cannot fabricate phantom turns.

Fixes #262.

## Test plan

- [x] `go test ./core/adapters/inbound/agents/aider/... -race -count=1` — all 11 tests pass, including new `TestParser_LLMError_EndsTurn` (drives the issue's exact transcript) and `TestParser_ErrorBeforeTurn_NoPhantomEvent` (false-positive guard).
- [x] `tools/replay-fixtures.sh` against new fixture `replaydata/agents/aider/scenarios/llm-error/` — replay shows `working → ready` transition with reason "agent finished turn → ready".
- [x] Existing `TestParser_BlockquoteNoise_Skipped` still passes (genuine noise without `Error:`/`Exception:` is unaffected).

Pre-existing `TestFixtureReplayByteIdentity` failures in `core/cmd/replay/...` for claudecode goldens are unrelated to this change (verified via `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)