### PR TITLE
fix(capacity): serve stale LiteLLM cache instead of zeroing all costs

### DIFF
--- a/core/pkg/capacity/remote.go
+++ b/core/pkg/capacity/remote.go
@@ -179,7 +179,12 @@ func deriveFamilyFromLiteLLM(modelID, provider string) string {
 }
 
 // loadCachedRemoteData reads previously cached remote capacity data.
-// Returns nil if cache doesn't exist or is expired.
+// Returns nil only when the cache file is missing or unreadable. Stale
+// caches (older than cacheTTL) are still returned: pricing rarely shifts
+// fast enough to make day-old data dangerous, and serving zero cost
+// silently is worse than serving slightly stale numbers. The daemon's
+// background refresh loop uses IsCacheStale separately to decide when
+// to refetch.
 func loadCachedRemoteData() *capacityConfig {
 	path, err := cachePath()
 	if err != nil {
@@ -193,10 +198,6 @@ func loadCachedRemoteData() *capacityConfig {
 
 	var cached cachedCapacity
 	if err := json.Unmarshal(data, &cached); err != nil {
-		return nil
-	}
-
-	if time.Since(cached.FetchedAt) > cacheTTL {
 		return nil
 	}
 

--- a/core/pkg/capacity/remote_test.go
+++ b/core/pkg/capacity/remote_test.go
@@ -401,6 +401,52 @@ func TestLoadCachedRemoteData_OfflineFallback(t *testing.T) {
 	}
 }
 
+// TestLoadCachedRemoteData_ServesStaleCache pins the rule that pricing
+// data older than cacheTTL is still returned. Returning nil for stale
+// caches silently zeroed every cost downstream — a far worse outcome
+// than serving day-old prices. Refresh decisions stay with IsCacheStale.
+func TestLoadCachedRemoteData_ServesStaleCache(t *testing.T) {
+	withTempHome(t)
+
+	path, _ := cachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	stale := cachedCapacity{
+		FetchedAt: time.Now().Add(-2 * cacheTTL),
+		Config: capacityConfig{
+			Models: map[string]ModelCapacity{
+				"claude-opus-4-6": {
+					ContextWindow: 1000000,
+					Pricing:       &ModelPricing{InputPerMTok: 15, OutputPerMTok: 75},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(stale)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	got := loadCachedRemoteData()
+	if got == nil {
+		t.Fatal("loadCachedRemoteData returned nil for stale cache; stale pricing must still be served")
+	}
+	cap, ok := got.Models["claude-opus-4-6"]
+	if !ok {
+		t.Fatal("stale cache missing claude-opus-4-6")
+	}
+	if cap.Pricing == nil || cap.Pricing.InputPerMTok != 15 {
+		t.Errorf("stale pricing not preserved: %+v", cap.Pricing)
+	}
+
+	// IsCacheStale must still flag the cache so the daemon's refresh loop
+	// re-fetches; the two checks have different jobs.
+	if !IsCacheStale() {
+		t.Error("IsCacheStale should still report true for past-TTL cache")
+	}
+}
+
 // withTempHome points os.UserHomeDir() at a tempdir so cachePath() writes
 // are isolated per test.
 func withTempHome(t *testing.T) {

--- a/core/pkg/capacity/remote_test.go
+++ b/core/pkg/capacity/remote_test.go
@@ -291,9 +291,15 @@ func TestMaybeReload_PicksUpNewCache(t *testing.T) {
 	}
 }
 
-// writeCacheAt writes a cache file with the given models and sets its mtime.
+// writeCacheAt writes a cache file with the given models, creating parent
+// directories as needed and stamping both FetchedAt (in JSON) and the
+// file's mtime to `when`. Tests that target the real cachePath() rely on
+// the MkdirAll; tests that pass a t.TempDir() get it as a no-op.
 func writeCacheAt(t *testing.T, path string, models map[string]ModelCapacity, when time.Time) {
 	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
 	cached := cachedCapacity{
 		FetchedAt: when,
 		Config:    capacityConfig{Models: models},
@@ -401,36 +407,27 @@ func TestLoadCachedRemoteData_OfflineFallback(t *testing.T) {
 	}
 }
 
-// TestLoadCachedRemoteData_ServesStaleCache pins the rule that pricing
-// data older than cacheTTL is still returned. Returning nil for stale
-// caches silently zeroed every cost downstream — a far worse outcome
-// than serving day-old prices. Refresh decisions stay with IsCacheStale.
+// staleCacheModels is the fixture both stale-cache tests load. Pricing
+// values are arbitrary but non-zero so a missing-pricing failure is
+// distinguishable from a zero-pricing one.
+var staleCacheModels = map[string]ModelCapacity{
+	"claude-opus-4-6": {
+		ContextWindow: 1000000,
+		Pricing:       &ModelPricing{InputPerMTok: 15, OutputPerMTok: 75},
+	},
+}
+
+// TestLoadCachedRemoteData_ServesStaleCache asserts cached pricing past
+// cacheTTL is still returned, and that IsCacheStale keeps its separate
+// refresh-signal job.
 func TestLoadCachedRemoteData_ServesStaleCache(t *testing.T) {
 	withTempHome(t)
-
 	path, _ := cachePath()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	stale := cachedCapacity{
-		FetchedAt: time.Now().Add(-2 * cacheTTL),
-		Config: capacityConfig{
-			Models: map[string]ModelCapacity{
-				"claude-opus-4-6": {
-					ContextWindow: 1000000,
-					Pricing:       &ModelPricing{InputPerMTok: 15, OutputPerMTok: 75},
-				},
-			},
-		},
-	}
-	data, _ := json.Marshal(stale)
-	if err := os.WriteFile(path, data, 0644); err != nil {
-		t.Fatalf("write cache: %v", err)
-	}
+	writeCacheAt(t, path, staleCacheModels, time.Now().Add(-2*cacheTTL))
 
 	got := loadCachedRemoteData()
 	if got == nil {
-		t.Fatal("loadCachedRemoteData returned nil for stale cache; stale pricing must still be served")
+		t.Fatal("loadCachedRemoteData returned nil for stale cache")
 	}
 	mc, ok := got.Models["claude-opus-4-6"]
 	if !ok {
@@ -439,50 +436,27 @@ func TestLoadCachedRemoteData_ServesStaleCache(t *testing.T) {
 	if mc.Pricing == nil || mc.Pricing.InputPerMTok != 15 {
 		t.Errorf("stale pricing not preserved: %+v", mc.Pricing)
 	}
-
-	// IsCacheStale must still flag the cache so the daemon's refresh loop
-	// re-fetches; the two checks have different jobs.
 	if !IsCacheStale() {
 		t.Error("IsCacheStale should still report true for past-TTL cache")
 	}
 }
 
-// TestCapacityManager_GetModelCapacity_ServesStaleCache pins the bug fix
-// at the public-API layer: a manager whose only cache file is past TTL
-// must still surface that file's pricing through GetModelCapacity. This
-// is what the replay tool, CLI, and any non-daemon caller actually go
-// through; without it, EstimatedCostUSD silently zeroes.
-func TestCapacityManager_GetModelCapacity_ServesStaleCache(t *testing.T) {
+// TestGetModelCapacity_ServesStaleCache asserts the public API surfaces
+// stale pricing — the path the replay tool and CLI actually traverse.
+// A regression in maybeReload that re-introduced a stale gate would
+// slip past the loadCachedRemoteData-only test above.
+func TestGetModelCapacity_ServesStaleCache(t *testing.T) {
 	withTempHome(t)
-
 	path, _ := cachePath()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	stale := cachedCapacity{
-		FetchedAt: time.Now().Add(-2 * cacheTTL),
-		Config: capacityConfig{
-			Models: map[string]ModelCapacity{
-				"claude-opus-4-6": {
-					ContextWindow: 1000000,
-					Pricing:       &ModelPricing{InputPerMTok: 15, OutputPerMTok: 75},
-				},
-			},
-		},
-	}
-	data, _ := json.Marshal(stale)
-	if err := os.WriteFile(path, data, 0644); err != nil {
-		t.Fatalf("write cache: %v", err)
-	}
+	writeCacheAt(t, path, staleCacheModels, time.Now().Add(-2*cacheTTL))
 
-	// Build a fresh manager bound to the same on-disk path the load helper
-	// reads (cachePath() resolves via the temp HOME). DefaultCapacityManager
-	// is a sync.Once singleton, so it can't be safely used here.
+	// DefaultCapacityManager is a sync.Once singleton, so build a fresh
+	// manager bound to the same path withTempHome redirected cachePath() to.
 	cm := &CapacityManager{cachePath: path}
 
 	mc := cm.GetModelCapacity("claude-opus-4-6")
 	if mc.Pricing == nil {
-		t.Fatal("GetModelCapacity returned no pricing for stale cache; cost would silently be zero")
+		t.Fatal("GetModelCapacity returned no pricing for stale cache")
 	}
 	if mc.Pricing.InputPerMTok != 15 || mc.Pricing.OutputPerMTok != 75 {
 		t.Errorf("stale pricing not surfaced via GetModelCapacity: %+v", mc.Pricing)

--- a/core/pkg/capacity/remote_test.go
+++ b/core/pkg/capacity/remote_test.go
@@ -432,18 +432,60 @@ func TestLoadCachedRemoteData_ServesStaleCache(t *testing.T) {
 	if got == nil {
 		t.Fatal("loadCachedRemoteData returned nil for stale cache; stale pricing must still be served")
 	}
-	cap, ok := got.Models["claude-opus-4-6"]
+	mc, ok := got.Models["claude-opus-4-6"]
 	if !ok {
 		t.Fatal("stale cache missing claude-opus-4-6")
 	}
-	if cap.Pricing == nil || cap.Pricing.InputPerMTok != 15 {
-		t.Errorf("stale pricing not preserved: %+v", cap.Pricing)
+	if mc.Pricing == nil || mc.Pricing.InputPerMTok != 15 {
+		t.Errorf("stale pricing not preserved: %+v", mc.Pricing)
 	}
 
 	// IsCacheStale must still flag the cache so the daemon's refresh loop
 	// re-fetches; the two checks have different jobs.
 	if !IsCacheStale() {
 		t.Error("IsCacheStale should still report true for past-TTL cache")
+	}
+}
+
+// TestCapacityManager_GetModelCapacity_ServesStaleCache pins the bug fix
+// at the public-API layer: a manager whose only cache file is past TTL
+// must still surface that file's pricing through GetModelCapacity. This
+// is what the replay tool, CLI, and any non-daemon caller actually go
+// through; without it, EstimatedCostUSD silently zeroes.
+func TestCapacityManager_GetModelCapacity_ServesStaleCache(t *testing.T) {
+	withTempHome(t)
+
+	path, _ := cachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	stale := cachedCapacity{
+		FetchedAt: time.Now().Add(-2 * cacheTTL),
+		Config: capacityConfig{
+			Models: map[string]ModelCapacity{
+				"claude-opus-4-6": {
+					ContextWindow: 1000000,
+					Pricing:       &ModelPricing{InputPerMTok: 15, OutputPerMTok: 75},
+				},
+			},
+		},
+	}
+	data, _ := json.Marshal(stale)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+
+	// Build a fresh manager bound to the same on-disk path the load helper
+	// reads (cachePath() resolves via the temp HOME). DefaultCapacityManager
+	// is a sync.Once singleton, so it can't be safely used here.
+	cm := &CapacityManager{cachePath: path}
+
+	mc := cm.GetModelCapacity("claude-opus-4-6")
+	if mc.Pricing == nil {
+		t.Fatal("GetModelCapacity returned no pricing for stale cache; cost would silently be zero")
+	}
+	if mc.Pricing.InputPerMTok != 15 || mc.Pricing.OutputPerMTok != 75 {
+		t.Errorf("stale pricing not surfaced via GetModelCapacity: %+v", mc.Pricing)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `loadCachedRemoteData` returned `nil` whenever the cache file was older than 24h, so any caller without the daemon's background refresh loop (replay tool, CLI, `go test`) ended up with an empty pricing table.
- That zeroed `EstimatedCostUSD` everywhere; the `omitempty` JSON tag then silently dropped `estimated_cost_usd` from output.
- Symptom: `TestFixtureReplayByteIdentity` failed for any contributor whose `~/.local/share/irrlicht/model-capacity-cache.json` had gone a day without a daemon-driven refresh — every claudecode golden's `estimated_cost_usd` line went missing.

## Fix

- `loadCachedRemoteData` now always returns the cached config (only nil on missing/unreadable/corrupt). Stale pricing > zero pricing.
- The TTL check stays where it belongs: `IsCacheStale`, which the daemon's background refresh loop uses to decide when to refetch.
- New regression test `TestLoadCachedRemoteData_ServesStaleCache` pins the rule and verifies `IsCacheStale` still flags the same file.

## Test plan

- [x] \`go test ./core/pkg/capacity/... -count=1\` — passes including new test
- [x] \`go test ./core/... -race -count=1\` — full suite green (including the previously failing \`TestFixtureReplayByteIdentity\`)
- [x] \`tools/replay-fixtures.sh\` — runs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)