### PR TITLE
ci(coverage): make badge update non-blocking, surface HTTP errors

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,15 +57,24 @@ jobs:
           echo "COLOR=$COLOR" >> $GITHUB_ENV
 
       - name: Update Gist with coverage
+        continue-on-error: true
         env:
           GIST_SECRET: ${{ secrets.GIST_SECRET }}
           COVERAGE_GIST_ID: ${{ secrets.COVERAGE_GIST_ID }}
         run: |
           BADGE_JSON="{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"${COLOR}\"}"
           jq -n --arg content "$BADGE_JSON" '{"files":{"coverage.json":{"content":$content}}}' > /tmp/gist-payload.json
-          curl -sf -X PATCH \
+          status=$(curl -s -o /tmp/gist-response.json -w "%{http_code}" -X PATCH \
             -H "Authorization: token $GIST_SECRET" \
             -H "Content-Type: application/json" \
             -d @/tmp/gist-payload.json \
-            "https://api.github.com/gists/$COVERAGE_GIST_ID" > /dev/null
+            "https://api.github.com/gists/$COVERAGE_GIST_ID")
+          echo "Gist API HTTP status: $status"
+          if [ "$status" -ge 400 ]; then
+            echo "Response body:"
+            cat /tmp/gist-response.json
+            echo ""
+            echo "::warning::Coverage badge gist update failed (HTTP $status). Likely GIST_SECRET expired — rotate the token in repo secrets."
+            exit 1
+          fi
 


### PR DESCRIPTION
## Summary
- Coverage badge update failed post-merge of #255 with `curl` exit 22 (HTTP ≥400) — see [run 25460501651](https://github.com/ingo-eichhorst/Irrlicht/actions/runs/25460501651/job/74701154054). Most likely the `GIST_SECRET` PAT expired (last successful run was 2026-05-02).
- Badge updates are non-critical; shouldn't show a red ✗ on main.
- Adds `continue-on-error: true`, logs HTTP status + response body, and emits a workflow warning naming the likely root cause.

## Follow-up
Rotate `GIST_SECRET` in repo secrets (PAT with `gist` scope) to restore the badge. The workflow itself will now succeed regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)