### PR TITLE
ci(coverage): surface badge update failures

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,11 +61,25 @@ jobs:
           GIST_SECRET: ${{ secrets.GIST_SECRET }}
           COVERAGE_GIST_ID: ${{ secrets.COVERAGE_GIST_ID }}
         run: |
+          if [ -z "$GIST_SECRET" ]; then
+            echo "::error::GIST_SECRET is not set in repository secrets"
+            exit 1
+          fi
+          if [ -z "$COVERAGE_GIST_ID" ]; then
+            echo "::error::COVERAGE_GIST_ID is not set in repository secrets"
+            exit 1
+          fi
           BADGE_JSON="{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"${COLOR}\"}"
           jq -n --arg content "$BADGE_JSON" '{"files":{"coverage.json":{"content":$content}}}' > /tmp/gist-payload.json
-          curl -sf -X PATCH \
+          http_code=$(curl -sS -o /tmp/gist-response.json -w '%{http_code}' -X PATCH \
             -H "Authorization: token $GIST_SECRET" \
             -H "Content-Type: application/json" \
             -d @/tmp/gist-payload.json \
-            "https://api.github.com/gists/$COVERAGE_GIST_ID" > /dev/null
+            "https://api.github.com/gists/$COVERAGE_GIST_ID")
+          echo "HTTP $http_code"
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::error::Gist update failed (HTTP $http_code)"
+            cat /tmp/gist-response.json
+            exit 1
+          fi
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -75,11 +75,17 @@ jobs:
             -H "Authorization: token $GIST_SECRET" \
             -H "Content-Type: application/json" \
             -d @/tmp/gist-payload.json \
-            "https://api.github.com/gists/$COVERAGE_GIST_ID")
+            "https://api.github.com/gists/$COVERAGE_GIST_ID") || true
+          # curl emits "000" when no HTTP response was received (DNS/TLS/connect failure).
+          http_code="${http_code:-000}"
           echo "HTTP $http_code"
           if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
             echo "::error::Gist update failed (HTTP $http_code)"
-            cat /tmp/gist-response.json
+            if [ -s /tmp/gist-response.json ]; then
+              cat /tmp/gist-response.json
+            else
+              echo "(no response body — likely transport failure)"
+            fi
             exit 1
           fi
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -71,13 +71,15 @@ jobs:
           fi
           BADGE_JSON="{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"${COLOR}\"}"
           jq -n --arg content "$BADGE_JSON" '{"files":{"coverage.json":{"content":$content}}}' > /tmp/gist-payload.json
-          http_code=$(curl -sS -o /tmp/gist-response.json -w '%{http_code}' -X PATCH \
+          # curl writes "000" to %{http_code} when no response was received (DNS/TLS/connect failure).
+          http_code=$(curl -sS -o /tmp/gist-response.json -w '%{http_code}' \
+            --connect-timeout 10 --max-time 30 \
+            --retry 3 --retry-delay 2 --retry-all-errors \
+            -X PATCH \
             -H "Authorization: token $GIST_SECRET" \
             -H "Content-Type: application/json" \
             -d @/tmp/gist-payload.json \
-            "https://api.github.com/gists/$COVERAGE_GIST_ID") || true
-          # curl emits "000" when no HTTP response was received (DNS/TLS/connect failure).
-          http_code="${http_code:-000}"
+            "https://api.github.com/gists/$COVERAGE_GIST_ID")
           echo "HTTP $http_code"
           if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
             echo "::error::Gist update failed (HTTP $http_code)"


### PR DESCRIPTION
## Summary
- Fail fast with `::error::` annotations when `GIST_SECRET` or `COVERAGE_GIST_ID` repo secrets are unset
- Capture the gist PATCH HTTP status + response body and fail the job on non-2xx, instead of letting `curl -sf … > /dev/null` die silently

## Test plan
- [x] Trigger the coverage workflow and confirm a successful run still updates the badge
- [x] (Optional) Temporarily unset one of the secrets in a fork to confirm the new error annotation surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)