### PR TITLE
fix(macos): sync apiGroups on local session delete + reset (#287)

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -1239,10 +1239,13 @@ class SessionManager: ObservableObject {
         }
         sessionOrder.removeAll { $0 == sessionId }
         saveSessionOrder()
-        if !useFilePolling {
-            sessionMap.removeValue(forKey: sessionId)
-            rebuildSessionsFromMap()
+        sessionMap.removeValue(forKey: sessionId)
+        lastTickGen.removeValue(forKey: sessionId)
+        for gran in [1, 10, 60] {
+            historyByGranularity[gran]?.removeValue(forKey: sessionId)
         }
+        rebuildSessionsFromMap()
+        removeFromApiGroups(sessionId: sessionId)
     }
 
     // MARK: - Debug State Dump (IRRLICHT_DEBUG=1)

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -511,14 +511,7 @@ class SessionManager: ObservableObject {
                 }
             case "session_deleted":
                 if let session = envelope.session {
-                    sessionMap.removeValue(forKey: session.id)
-                    sessionOrder.removeAll { $0 == session.id }
-                    lastTickGen.removeValue(forKey: session.id)
-                    for gran in [1, 10, 60] {
-                        historyByGranularity[gran]?.removeValue(forKey: session.id)
-                    }
-                    rebuildSessionsFromMap()
-                    removeFromApiGroups(sessionId: session.id)
+                    purgeSessionState(sessionId: session.id)
                     scheduleRehydration()
                 }
             case "focus_requested":
@@ -1226,8 +1219,10 @@ class SessionManager: ObservableObject {
         }
     }
 
+    /// `scheduleRehydration` is intentionally not called — we're authoritative
+    /// for the local delete, and a rehydrate could re-add the row before the
+    /// daemon's file watcher catches up.
     func deleteSession(sessionId: String) {
-        notifiedThresholds.removeValue(forKey: sessionId)
         let sessionFilePath = instancesPath.appendingPathComponent("\(sessionId).json")
         if FileManager.default.fileExists(atPath: sessionFilePath.path) {
             do {
@@ -1237,9 +1232,14 @@ class SessionManager: ObservableObject {
                 return
             }
         }
-        sessionOrder.removeAll { $0 == sessionId }
+        notifiedThresholds.removeValue(forKey: sessionId)
+        purgeSessionState(sessionId: sessionId)
         saveSessionOrder()
+    }
+
+    private func purgeSessionState(sessionId: String) {
         sessionMap.removeValue(forKey: sessionId)
+        sessionOrder.removeAll { $0 == sessionId }
         lastTickGen.removeValue(forKey: sessionId)
         for gran in [1, 10, 60] {
             historyByGranularity[gran]?.removeValue(forKey: sessionId)

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -1202,7 +1202,7 @@ class SessionManager: ObservableObject {
             updatedJson["updated_at"] = Int64(Date().timeIntervalSince1970)
             let updatedData = try JSONSerialization.data(withJSONObject: updatedJson, options: [])
             try updatedData.write(to: sessionFilePath)
-            if !useFilePolling, var s = sessionMap[sessionId] {
+            if var s = sessionMap[sessionId] {
                 s = SessionState(
                     id: s.id, state: .ready, model: s.model, cwd: s.cwd,
                     transcriptPath: s.transcriptPath, gitBranch: s.gitBranch,
@@ -1213,6 +1213,7 @@ class SessionManager: ObservableObject {
                 )
                 sessionMap[sessionId] = s
                 rebuildSessionsFromMap()
+                patchApiGroups(session: s)
             }
         } catch {
             lastError = "Failed to reset session: \(error.localizedDescription)"

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -78,7 +78,7 @@ class SessionManager: ObservableObject {
     private var connectTask: Task<Void, Never>?
     private var reconnectDelay: TimeInterval = 1.0
     private let maxReconnectDelay: TimeInterval = 30.0
-    private var sessionMap: [String: SessionState] = [:]
+    var sessionMap: [String: SessionState] = [:]
 
     /// GasTownProvider reference for forwarding Gas Town availability.
     weak var gasTownProvider: GasTownProvider? {
@@ -1202,15 +1202,7 @@ class SessionManager: ObservableObject {
             updatedJson["updated_at"] = Int64(Date().timeIntervalSince1970)
             let updatedData = try JSONSerialization.data(withJSONObject: updatedJson, options: [])
             try updatedData.write(to: sessionFilePath)
-            if var s = sessionMap[sessionId] {
-                s = SessionState(
-                    id: s.id, state: .ready, model: s.model, cwd: s.cwd,
-                    transcriptPath: s.transcriptPath, gitBranch: s.gitBranch,
-                    projectName: s.projectName, firstSeen: s.firstSeen,
-                    updatedAt: Date(), eventCount: s.eventCount,
-                    lastEvent: s.lastEvent, metrics: s.metrics,
-                    pid: s.pid, parentSessionId: s.parentSessionId
-                )
+            if let s = sessionMap[sessionId]?.withState(.ready) {
                 sessionMap[sessionId] = s
                 rebuildSessionsFromMap()
                 patchApiGroups(session: s)
@@ -1238,6 +1230,9 @@ class SessionManager: ObservableObject {
         saveSessionOrder()
     }
 
+    /// Caller persists `sessionOrder` if it's authoritative for the deletion;
+    /// the WS handler skips the save because the daemon is the source of truth
+    /// in that path and will re-emit on reconnect.
     private func purgeSessionState(sessionId: String) {
         sessionMap.removeValue(forKey: sessionId)
         sessionOrder.removeAll { $0 == sessionId }

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -486,6 +486,25 @@ struct SessionState: Identifiable, Codable {
         return copy
     }
 
+    /// Return a copy with `state` replaced and `updatedAt` set to now. All
+    /// other fields are preserved — including children, subagents, role, and
+    /// adapter — which a field-by-field reconstruction would silently drop.
+    func withState(_ newState: State) -> SessionState {
+        var copy = SessionState(
+            id: id, state: newState, model: model, cwd: cwd,
+            transcriptPath: transcriptPath, gitBranch: gitBranch,
+            projectName: projectName, firstSeen: firstSeen, updatedAt: Date(),
+            eventCount: eventCount, lastEvent: lastEvent, metrics: metrics,
+            pid: pid, parentSessionId: parentSessionId, subagents: subagents,
+            adapter: adapter, daemonVersion: daemonVersion,
+            role: role, roleIcon: roleIcon, roleDescription: roleDescription,
+            workerName: workerName, workerID: workerID,
+            children: children, launcher: launcher
+        )
+        copy.duplicateIndex = duplicateIndex
+        return copy
+    }
+
     var activeSubagentCount: Int {
         (subagents?.working ?? 0) + (subagents?.waiting ?? 0)
     }

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -262,22 +262,18 @@ final class SessionManagerApiGroupsTests: XCTestCase {
 
     // MARK: - deleteSession (regression for #287)
 
-    func testDeleteSession_clearsApiGroupsAndGroupedSessionIds() {
-        // Regression: deleteSession used to update only `sessions` (menu bar),
-        // leaving `apiGroups` (list view) stale until a daemon WS event or a
-        // rehydration arrived. The fix wires removeFromApiGroups into the
-        // local-delete path so both surfaces clear together.
-        let id = "regression-287-\(UUID().uuidString)"
+    func testDeleteSession_clearsBothMenuBarAndListViewSurfaces() {
+        let id = UUID().uuidString
         let session = makeSession(id: id, cost: 1.00)
+        sut.sessions = [session]
         sut.apiGroups = [AgentGroup(name: "proj", agents: [session])]
         sut.groupedSessionIds = [id]
 
         sut.deleteSession(sessionId: id)
 
-        XCTAssertTrue(sut.apiGroups.isEmpty,
-                      "apiGroups must be pruned by deleteSession, not just sessions")
-        XCTAssertFalse(sut.groupedSessionIds.contains(id),
-                       "groupedSessionIds must drop the deleted id")
+        XCTAssertTrue(sut.sessions.isEmpty)
+        XCTAssertTrue(sut.apiGroups.isEmpty)
+        XCTAssertFalse(sut.groupedSessionIds.contains(id))
     }
 
     // MARK: - SessionState.withChildren

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -276,6 +276,45 @@ final class SessionManagerApiGroupsTests: XCTestCase {
         XCTAssertFalse(sut.groupedSessionIds.contains(id))
     }
 
+    // MARK: - resetSessionState (regression for #287)
+
+    func testResetSessionState_flipsBothSurfacesAndPreservesFields() throws {
+        let id = UUID().uuidString
+        let child = makeSession(id: "\(id)-child")
+        let working = SessionState(
+            id: id, state: .working, model: "test-model", cwd: "/tmp",
+            firstSeen: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            role: "test-role", children: [child]
+        )
+        let dir = instancesURL()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let fixturePath = dir.appendingPathComponent("\(id).json")
+        try Data("{\"state\":\"working\",\"updated_at\":0}".utf8).write(to: fixturePath)
+        defer { try? FileManager.default.removeItem(at: fixturePath) }
+
+        sut.sessionMap[id] = working
+        sut.sessions = [working]
+        sut.apiGroups = [AgentGroup(name: "proj", agents: [working])]
+        sut.groupedSessionIds = [id]
+
+        sut.resetSessionState(sessionId: id)
+
+        XCTAssertEqual(sut.sessions.first?.state, .ready,
+                       "menu-bar surface must flip to ready")
+        XCTAssertEqual(sut.apiGroups.first?.agents?.first?.state, .ready,
+                       "list-view surface must flip to ready")
+        XCTAssertEqual(sut.sessions.first?.role, "test-role",
+                       "withState must preserve role across reset")
+        XCTAssertEqual(sut.sessions.first?.children?.map(\.id), ["\(id)-child"],
+                       "withState must preserve children across reset")
+    }
+
+    private func instancesURL() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Irrlicht/instances")
+    }
+
     // MARK: - SessionState.withChildren
 
     func testWithChildren_preservesIdentityAndMetrics() {

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -260,6 +260,26 @@ final class SessionManagerApiGroupsTests: XCTestCase {
         XCTAssertEqual(sut.groupedSessionIds, ["alive"])
     }
 
+    // MARK: - deleteSession (regression for #287)
+
+    func testDeleteSession_clearsApiGroupsAndGroupedSessionIds() {
+        // Regression: deleteSession used to update only `sessions` (menu bar),
+        // leaving `apiGroups` (list view) stale until a daemon WS event or a
+        // rehydration arrived. The fix wires removeFromApiGroups into the
+        // local-delete path so both surfaces clear together.
+        let id = "regression-287-\(UUID().uuidString)"
+        let session = makeSession(id: id, cost: 1.00)
+        sut.apiGroups = [AgentGroup(name: "proj", agents: [session])]
+        sut.groupedSessionIds = [id]
+
+        sut.deleteSession(sessionId: id)
+
+        XCTAssertTrue(sut.apiGroups.isEmpty,
+                      "apiGroups must be pruned by deleteSession, not just sessions")
+        XCTAssertFalse(sut.groupedSessionIds.contains(id),
+                       "groupedSessionIds must drop the deleted id")
+    }
+
     // MARK: - SessionState.withChildren
 
     func testWithChildren_preservesIdentityAndMetrics() {


### PR DESCRIPTION
## Summary

- Local `SessionManager.deleteSession()` and `resetSessionState()` only updated the menu bar's `sessions` array, leaving the list view's `apiGroups` tree stale until a daemon WS event or rehydration arrived. Mirror the `session_deleted` / `session_updated` WS handlers so both surfaces clear/flip together.
- Drops the `!useFilePolling` gate from both functions; `sessionMap`, `lastTickGen`, `historyByGranularity`, and `apiGroups` are all updated in both modes.
- Extracts the in-memory cleanup for delete into `purgeSessionState(sessionId:)` so the WS handler and the local-delete path share one implementation.
- Adds `SessionState.withState(_:)` so the reset path stops silently dropping 10 optional fields (children, role, subagents, adapter, launcher, etc.) that a field-by-field reconstruction would lose. Mirrors the existing `withChildren` shape.
- Adds regression tests for both delete and reset, including a check that `role` and `children` survive a reset.

Fixes #287

## Test plan

- [x] `swift test --filter SessionManagerApiGroupsTests` — 19/19 pass (both regression tests included)
- [x] `go test ./core/... -race -count=1` — passes (pre-existing #285 replay-byte-identity failure unrelated)
- [x] `tools/replay-fixtures.sh` — passes, no fixture drift
- [ ] Manual: with `IRRLICHT_DEBUG=1` and the debug action buttons visible, deleting a session removes the row from both menu-bar dropdown and list-view window simultaneously; resetting a working/waiting session flips both surfaces to ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)