### PR TITLE
fix(claudecode): reconcile phantom in_progress from task_reminder snapshots

### DIFF
--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -93,8 +93,56 @@ func handleEarlyReturn(eventType string, raw map[string]interface{}, ev *tailer.
 		}
 		ev.Skip = true
 		return true
+	case "attachment":
+		handleAttachmentEvent(raw, ev)
+		return true
 	}
 	return false
+}
+
+// handleAttachmentEvent extracts task_reminder snapshots into ev.TaskSnapshot
+// and skips the event from the message-content pipeline. Other attachment
+// kinds are ignored. The reminder is Claude Code's authoritative view of which
+// task IDs it's currently tracking; the tailer uses it to reconcile drift
+// from stale TaskUpdate deltas that never get a `completed` follow-up
+// (issue #282).
+func handleAttachmentEvent(raw map[string]interface{}, ev *tailer.ParsedEvent) {
+	ev.Skip = true
+	att, ok := raw["attachment"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	if kind, _ := att["type"].(string); kind != "task_reminder" {
+		return
+	}
+	contentArr, ok := att["content"].([]interface{})
+	if !ok {
+		// Defensive: an absent content field is not a snapshot. An explicit
+		// `content: []` decodes to a non-nil empty slice and DOES count
+		// (Claude is telling us nothing is active).
+		return
+	}
+	snap := make([]tailer.TaskSnapshotEntry, 0, len(contentArr))
+	for _, item := range contentArr {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, _ := entry["id"].(string)
+		if id == "" {
+			continue
+		}
+		subject, _ := entry["subject"].(string)
+		activeForm, _ := entry["activeForm"].(string)
+		status, _ := entry["status"].(string)
+		snap = append(snap, tailer.TaskSnapshotEntry{
+			ID:         id,
+			Subject:    subject,
+			ActiveForm: activeForm,
+			Status:     status,
+		})
+	}
+	ev.TaskSnapshot = &snap
 }
 
 // handleSystemEvent maps turn_duration / stop_hook_summary subtypes to

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -1545,22 +1545,7 @@ func TestTailer_TaskReminder_DemotesPhantomInProgress(t *testing.T) {
 		}),
 	}
 
-	dir := t.TempDir()
-	path := dir + "/reminder.jsonl"
-	f, err := os.Create(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	enc := json.NewEncoder(f)
-	for _, e := range events {
-		if err := enc.Encode(e); err != nil {
-			t.Fatal(err)
-		}
-	}
-	f.Close()
-
-	tr := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
-	m, err := tr.TailAndProcess()
+	m, err := newCCTailer(writeTranscript(t, events)).TailAndProcess()
 	if err != nil {
 		t.Fatalf("TailAndProcess: %v", err)
 	}
@@ -1604,22 +1589,7 @@ func TestTailer_TaskReminder_EmptySnapshotDemotesAll(t *testing.T) {
 		makeReminderEvent([]map[string]interface{}{}),
 	}
 
-	dir := t.TempDir()
-	path := dir + "/empty.jsonl"
-	f, err := os.Create(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	enc := json.NewEncoder(f)
-	for _, e := range events {
-		if err := enc.Encode(e); err != nil {
-			t.Fatal(err)
-		}
-	}
-	f.Close()
-
-	tr := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
-	m, err := tr.TailAndProcess()
+	m, err := newCCTailer(writeTranscript(t, events)).TailAndProcess()
 	if err != nil {
 		t.Fatalf("TailAndProcess: %v", err)
 	}
@@ -1647,22 +1617,7 @@ func TestTailer_TaskReminder_SyncsDivergingStatus(t *testing.T) {
 		}),
 	}
 
-	dir := t.TempDir()
-	path := dir + "/diverge.jsonl"
-	f, err := os.Create(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	enc := json.NewEncoder(f)
-	for _, e := range events {
-		if err := enc.Encode(e); err != nil {
-			t.Fatal(err)
-		}
-	}
-	f.Close()
-
-	tr := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
-	m, err := tr.TailAndProcess()
+	m, err := newCCTailer(writeTranscript(t, events)).TailAndProcess()
 	if err != nil {
 		t.Fatalf("TailAndProcess: %v", err)
 	}

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -1421,3 +1421,252 @@ func TestTailer_TaskAccumulation(t *testing.T) {
 		t.Errorf("task 2 = %+v", m.Tasks[2])
 	}
 }
+
+// --- task_reminder reconcile tests (issue #282) ---
+
+// makeReminderEvent builds a top-level Claude Code attachment event whose
+// attachment.type is "task_reminder". Pass nil to model the absent-content
+// (defensive) case; pass an empty slice to model the legitimate "nothing
+// active" reminder.
+func makeReminderEvent(content []map[string]interface{}) map[string]interface{} {
+	att := map[string]interface{}{"type": "task_reminder"}
+	if content != nil {
+		arr := make([]interface{}, 0, len(content))
+		for _, c := range content {
+			arr = append(arr, c)
+		}
+		att["content"] = arr
+	}
+	return map[string]interface{}{
+		"type":       "attachment",
+		"timestamp":  "2026-04-05T22:00:00Z",
+		"attachment": att,
+	}
+}
+
+func TestParser_TaskReminder_PopulatesSnapshot(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(makeReminderEvent([]map[string]interface{}{
+		{"id": "1", "subject": "First", "activeForm": "Firsting", "status": "in_progress"},
+		{"id": "2", "subject": "Second", "status": "pending"},
+	}))
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if !ev.Skip {
+		t.Errorf("attachment events must skip the message-content pipeline")
+	}
+	if ev.TaskSnapshot == nil {
+		t.Fatal("TaskSnapshot is nil")
+	}
+	snap := *ev.TaskSnapshot
+	if len(snap) != 2 {
+		t.Fatalf("snapshot len = %d, want 2", len(snap))
+	}
+	if snap[0].ID != "1" || snap[0].Subject != "First" || snap[0].Status != "in_progress" || snap[0].ActiveForm != "Firsting" {
+		t.Errorf("snap[0] = %+v", snap[0])
+	}
+	if snap[1].ID != "2" || snap[1].Status != "pending" {
+		t.Errorf("snap[1] = %+v", snap[1])
+	}
+}
+
+func TestParser_TaskReminder_EmptyContentIsAuthoritative(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(makeReminderEvent([]map[string]interface{}{}))
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if ev.TaskSnapshot == nil {
+		t.Fatal("empty content[] must produce a non-nil empty snapshot, not absent")
+	}
+	if len(*ev.TaskSnapshot) != 0 {
+		t.Errorf("empty snapshot len = %d, want 0", len(*ev.TaskSnapshot))
+	}
+}
+
+func TestParser_TaskReminder_AbsentContentLeavesSnapshotNil(t *testing.T) {
+	// A task_reminder attachment without a content key is malformed/defensive.
+	// Treat it as no snapshot rather than empty — we don't want to demote
+	// every in_progress on a malformed event.
+	p := &Parser{}
+	ev := p.ParseLine(makeReminderEvent(nil))
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if ev.TaskSnapshot != nil {
+		t.Errorf("absent content must leave TaskSnapshot nil, got %+v", *ev.TaskSnapshot)
+	}
+}
+
+func TestParser_TaskReminder_NonTaskReminderIgnored(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type":      "attachment",
+		"timestamp": "2026-04-05T22:00:00Z",
+		"attachment": map[string]interface{}{
+			"type":    "something_else",
+			"content": []interface{}{},
+		},
+	})
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if !ev.Skip {
+		t.Errorf("non-task_reminder attachments still skip the pipeline")
+	}
+	if ev.TaskSnapshot != nil {
+		t.Errorf("non-task_reminder attachments must not populate TaskSnapshot")
+	}
+}
+
+// TestTailer_TaskReminder_DemotesPhantomInProgress models the real-session
+// failure mode from issue #282: TaskUpdate marks task 1 in_progress, then a
+// later task_reminder snapshot that omits task 1 arrives; the tailer must
+// demote the stuck in_progress to completed so allDone goes true in the UI.
+func TestTailer_TaskReminder_DemotesPhantomInProgress(t *testing.T) {
+	events := []map[string]interface{}{
+		makeToolUseEvent("tu_1", "TaskCreate", map[string]interface{}{
+			"subject": "Stale task", "activeForm": "Stale-tasking",
+		}),
+		makeToolUseEvent("tu_2", "TaskCreate", map[string]interface{}{
+			"subject": "New task", "activeForm": "New-tasking",
+		}),
+		// Bogus TaskUpdate against a stale ID — never followed by completed.
+		makeToolUseEvent("tu_3", "TaskUpdate", map[string]interface{}{
+			"taskId": "1", "status": "in_progress",
+		}),
+		makeToolUseEvent("tu_4", "TaskUpdate", map[string]interface{}{
+			"taskId": "2", "status": "completed",
+		}),
+		// Snapshot omits task 1 entirely — Claude's view doesn't track it.
+		makeReminderEvent([]map[string]interface{}{
+			{"id": "2", "subject": "New task", "status": "completed"},
+		}),
+	}
+
+	dir := t.TempDir()
+	path := dir + "/reminder.jsonl"
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := json.NewEncoder(f)
+	for _, e := range events {
+		if err := enc.Encode(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f.Close()
+
+	tr := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+	m, err := tr.TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+	if len(m.Tasks) != 2 {
+		t.Fatalf("Tasks len = %d, want 2", len(m.Tasks))
+	}
+	if m.Tasks[0].ID != "1" || m.Tasks[0].Status != tailer.TaskStatusCompleted {
+		t.Errorf("phantom task 1 not reconciled: %+v", m.Tasks[0])
+	}
+	if m.Tasks[1].ID != "2" || m.Tasks[1].Status != tailer.TaskStatusCompleted {
+		t.Errorf("task 2 = %+v", m.Tasks[1])
+	}
+	allDone := true
+	for _, task := range m.Tasks {
+		if task.Status != tailer.TaskStatusCompleted {
+			allDone = false
+		}
+	}
+	if !allDone {
+		t.Errorf("expected allDone=true after reconciliation; tasks=%+v", m.Tasks)
+	}
+}
+
+// TestTailer_TaskReminder_EmptySnapshotDemotesAll covers the legitimate
+// "nothing active" reminder — a `content:[]` snapshot must demote every
+// in_progress task to completed.
+func TestTailer_TaskReminder_EmptySnapshotDemotesAll(t *testing.T) {
+	events := []map[string]interface{}{
+		makeToolUseEvent("tu_1", "TaskCreate", map[string]interface{}{
+			"subject": "A", "activeForm": "Aing",
+		}),
+		makeToolUseEvent("tu_2", "TaskCreate", map[string]interface{}{
+			"subject": "B", "activeForm": "Bing",
+		}),
+		makeToolUseEvent("tu_3", "TaskUpdate", map[string]interface{}{
+			"taskId": "1", "status": "in_progress",
+		}),
+		makeToolUseEvent("tu_4", "TaskUpdate", map[string]interface{}{
+			"taskId": "2", "status": "in_progress",
+		}),
+		makeReminderEvent([]map[string]interface{}{}),
+	}
+
+	dir := t.TempDir()
+	path := dir + "/empty.jsonl"
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := json.NewEncoder(f)
+	for _, e := range events {
+		if err := enc.Encode(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f.Close()
+
+	tr := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+	m, err := tr.TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+	for i, task := range m.Tasks {
+		if task.Status != tailer.TaskStatusCompleted {
+			t.Errorf("task[%d] %+v should be completed after empty reminder", i, task)
+		}
+	}
+}
+
+// TestTailer_TaskReminder_SyncsDivergingStatus covers the symmetric case:
+// snapshot says completed but local state still has in_progress (never got
+// the TaskUpdate). Reconcile must trust the snapshot.
+func TestTailer_TaskReminder_SyncsDivergingStatus(t *testing.T) {
+	events := []map[string]interface{}{
+		makeToolUseEvent("tu_1", "TaskCreate", map[string]interface{}{
+			"subject": "A", "activeForm": "Aing",
+		}),
+		makeToolUseEvent("tu_2", "TaskUpdate", map[string]interface{}{
+			"taskId": "1", "status": "in_progress",
+		}),
+		// Snapshot disagrees: task 1 is actually completed.
+		makeReminderEvent([]map[string]interface{}{
+			{"id": "1", "subject": "A", "status": "completed"},
+		}),
+	}
+
+	dir := t.TempDir()
+	path := dir + "/diverge.jsonl"
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := json.NewEncoder(f)
+	for _, e := range events {
+		if err := enc.Encode(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f.Close()
+
+	tr := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+	m, err := tr.TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+	if len(m.Tasks) != 1 || m.Tasks[0].Status != tailer.TaskStatusCompleted {
+		t.Errorf("expected task 1 reconciled to completed, got %+v", m.Tasks)
+	}
+}

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -57,6 +57,17 @@ type TaskDelta struct {
 	Status      string // TaskUpdate only; "pending" on create is applied by tailer
 }
 
+// TaskSnapshotEntry is one row in a Claude Code task_reminder attachment, an
+// authoritative snapshot of which tasks Claude is still actively tracking and
+// their current status. Used by the tailer to reconcile drift after a stale
+// or bogus TaskUpdate that never gets a follow-up `completed`. See issue #282.
+type TaskSnapshotEntry struct {
+	ID         string
+	Subject    string
+	ActiveForm string
+	Status     string // "pending" | "in_progress" | "completed"
+}
+
 // ParsedEvent is the normalized output from a format-specific transcript parser.
 // Each parser maps its native event structure into these fields.
 type ParsedEvent struct {
@@ -96,6 +107,14 @@ type ParsedEvent struct {
 	// TaskDeltas are TaskCreate / TaskUpdate events from the Claude Code
 	// transcript. The tailer folds them into a running tasks slice.
 	TaskDeltas []TaskDelta
+
+	// TaskSnapshot, when non-nil, is the authoritative list of tasks Claude
+	// Code is currently tracking, parsed from a task_reminder attachment.
+	// Pointer-to-slice so an empty list (legitimate "nothing active" signal)
+	// is distinguishable from "no snapshot in this event". The tailer applies
+	// it after TaskDeltas as a defensive reconciliation pass against drift
+	// from stale/bogus TaskUpdate deltas. See issue #282.
+	TaskSnapshot *[]TaskSnapshotEntry
 
 	// Metadata extracted by the parser.
 	ModelName     string

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -417,12 +417,15 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 			// SubagentCompletions — task-notification lines are deliberately
 			// marked Skip=true so they don't pollute message-event tracking,
 			// but the completion signal must still surface to the detector
-			// (issue #134).
+			// (issue #134). Likewise, task_reminder attachments are Skip=true
+			// but carry an authoritative TaskSnapshot the tailer must apply
+			// (issue #282).
 			if parsed != nil {
 				t.applyMetadata(parsed)
 				if len(parsed.SubagentCompletions) > 0 {
 					t.metrics.SubagentCompletions = append(t.metrics.SubagentCompletions, parsed.SubagentCompletions...)
 				}
+				t.reconcileTaskSnapshot(parsed)
 			}
 			continue
 		}
@@ -559,6 +562,37 @@ func (t *TranscriptTailer) FlushIdle() (*SessionMetrics, bool) {
 	return t.metrics, true
 }
 
+// reconcileTaskSnapshot applies a Claude Code task_reminder snapshot from
+// parsed (when present) to the running tasks slice. Reminders are
+// authoritative: a local in_progress task whose ID is missing from the
+// snapshot is demoted to completed (Claude has dropped it from active
+// tracking), and an ID present in the snapshot with a divergent status
+// takes the snapshot's value. Defensive safety net for stale/bogus
+// TaskUpdate deltas that never get a `completed` follow-up. See issue #282.
+func (t *TranscriptTailer) reconcileTaskSnapshot(parsed *ParsedEvent) {
+	if parsed == nil || parsed.TaskSnapshot == nil {
+		return
+	}
+	snapByID := make(map[string]TaskSnapshotEntry, len(*parsed.TaskSnapshot))
+	for _, entry := range *parsed.TaskSnapshot {
+		snapByID[entry.ID] = entry
+	}
+	for i := range t.tasks {
+		entry, present := snapByID[t.tasks[i].ID]
+		if !present {
+			if t.tasks[i].Status == TaskStatusInProgress {
+				log.Printf("irrlicht/tailer: reconciling phantom in_progress task id=%s subject=%q → completed (not in task_reminder snapshot) in %s", t.tasks[i].ID, t.tasks[i].Subject, t.path)
+				t.tasks[i].Status = TaskStatusCompleted
+			}
+			continue
+		}
+		if entry.Status != "" && entry.Status != t.tasks[i].Status {
+			log.Printf("irrlicht/tailer: reconciling task id=%s status %s → %s from task_reminder in %s", t.tasks[i].ID, t.tasks[i].Status, entry.Status, t.path)
+			t.tasks[i].Status = entry.Status
+		}
+	}
+}
+
 // processParsedEvent applies a single non-skipped ParsedEvent to the tailer's
 // running state: tool tracking, task deltas, turn_done sweep, interrupt/denial
 // flags, metadata, assistant-text bookkeeping, content-char accumulation, and
@@ -613,6 +647,7 @@ func (t *TranscriptTailer) processParsedEvent(parsed *ParsedEvent, sawUserBlocki
 			}
 		}
 	}
+	t.reconcileTaskSnapshot(parsed)
 
 	// turn_done is the authoritative end-of-turn signal. By definition most
 	// tool_use events opened during the turn have already received their

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -579,7 +579,7 @@ func (t *TranscriptTailer) FlushIdle() (*SessionMetrics, bool) {
 // Snapshots that mention IDs we never saw a TaskCreate for are ignored;
 // the reconcile only updates pre-existing tasks. See issue #282.
 func (t *TranscriptTailer) reconcileTaskSnapshot(parsed *ParsedEvent) {
-	if parsed == nil || parsed.TaskSnapshot == nil {
+	if parsed == nil || parsed.TaskSnapshot == nil || len(t.tasks) == 0 {
 		return
 	}
 	snapByID := make(map[string]TaskSnapshotEntry, len(*parsed.TaskSnapshot))

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -564,11 +564,20 @@ func (t *TranscriptTailer) FlushIdle() (*SessionMetrics, bool) {
 
 // reconcileTaskSnapshot applies a Claude Code task_reminder snapshot from
 // parsed (when present) to the running tasks slice. Reminders are
-// authoritative: a local in_progress task whose ID is missing from the
-// snapshot is demoted to completed (Claude has dropped it from active
-// tracking), and an ID present in the snapshot with a divergent status
-// takes the snapshot's value. Defensive safety net for stale/bogus
-// TaskUpdate deltas that never get a `completed` follow-up. See issue #282.
+// authoritative over local state in two ways:
+//
+//  1. Phantom demotion: a local in_progress task whose ID is missing from
+//     the snapshot is set to completed (Claude has dropped it from active
+//     tracking) — this is the primary fix for the stale TaskUpdate bug.
+//  2. Present divergence: for any ID present in the snapshot whose status
+//     differs from local state, the snapshot's status wins. Strictly more
+//     than a "phantom only" rule — Claude's view is authoritative whenever
+//     it speaks. Safe under transcript ordering because reminders appear
+//     on user turns, after the assistant tool_use that emitted any deltas
+//     for that turn.
+//
+// Snapshots that mention IDs we never saw a TaskCreate for are ignored;
+// the reconcile only updates pre-existing tasks. See issue #282.
 func (t *TranscriptTailer) reconcileTaskSnapshot(parsed *ParsedEvent) {
 	if parsed == nil || parsed.TaskSnapshot == nil {
 		return


### PR DESCRIPTION
## Summary
- Phantom `in_progress` tasks no longer get stuck in irrlicht's session metrics when Claude Code emits a stale `TaskUpdate(taskId)` that never receives a follow-up `completed`.
- Parses Claude Code's `task_reminder` attachment as an authoritative state snapshot; after the existing TaskDelta loop, the tailer demotes any local `in_progress` whose ID is missing from the snapshot to `completed` and trusts snapshot status when it diverges.
- Existing `TaskCreate` / `TaskUpdate` paths are untouched — the snapshot is purely a defensive safety net. No web UI changes needed: the existing `allDone` check works once the underlying state is consistent.

Closes #282

## Test plan
- [x] `go test ./core/adapters/inbound/agents/claudecode/... -race -count=1` — all pass, including 7 new tests covering snapshot population, empty/absent content, non-task_reminder attachments, phantom demotion timeline, empty-snapshot demote-all, and status divergence sync.
- [x] `go test ./core/... -race -count=1` — full suite green (one pre-existing `core/cmd/replay` byte-identity drift on opencode `baseline-hello` is unrelated; reproduces on `main` without these changes).
- [x] `tools/replay-fixtures.sh` — clean, no regressions in committed fixture goldens.
- [x] End-to-end replay of the real issue transcript (`~/.claude/projects/-Users-ingo-references/01ace73d-aac6-4d32-b77e-5eaf2740a637.jsonl`) yields `tasks=19 allDone=true`; reconcile log fires exactly once for phantom `taskId=1`.

## Commits
1. `fix(claudecode)` — core fix: parse `task_reminder`, surface as `TaskSnapshot`, reconcile in tailer.
2. `docs(tailer)` — clarify in `reconcileTaskSnapshot` doc that snapshots also win on present-with-divergent-status, not only phantom in_progress; note that snapshot-only IDs are ignored.
3. `refactor` — cleanup pass: reuse existing `writeTranscript` / `newCCTailer` test helpers (-45 lines of duplication); add `len(t.tasks) == 0` early-exit to `reconcileTaskSnapshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)