### PR TITLE
test(replay): refresh stale opencode baseline-hello golden

### DIFF
--- a/replaydata/agents/opencode/scenarios/baseline-hello/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/opencode/scenarios/baseline-hello/transcript.jsonl.replay.json.golden
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "source_transcript": "replaydata/agents/opencode/scenarios/baseline-hello/transcript.jsonl",
+  "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
     "adapter": "opencode",


### PR DESCRIPTION
## Summary
- Fixes #285 — `TestFixtureReplayByteIdentity/transcript.jsonl#25` was failing on `main` for the opencode `baseline-hello` fixture.
- The golden was committed in #255 with a populated `source_transcript`, but the test deliberately zeros that field (and `generated_at`) before JSON encoding so goldens stay worktree-portable (`core/cmd/replay/fixtures_test.go:108-109`). All 4 other adapters' goldens already had `""`; opencode was the lone outlier.
- Regenerated via `UPDATE_REPLAY_GOLDENS=1 go test ./core/cmd/replay/... -count=1`. Diff is one line.

## Test plan
- [x] `go test ./core/cmd/replay/... -race -count=1` passes
- [x] `go test ./core/... -race -count=1` passes
- [x] `tools/replay-fixtures.sh` clean
- [x] `git diff` confirms only `source_transcript` flipped to `""`; no other field/event drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)