### PR TITLE
fix(opencode): suppress ghost sessions when no opencode process is live

### DIFF
--- a/core/adapters/inbound/agents/config.go
+++ b/core/adapters/inbound/agents/config.go
@@ -120,6 +120,20 @@ func PIDDiscoverMap(cfgs []Config) map[string]agent.PIDDiscoverFunc {
 	return m
 }
 
+// ProcessNameMap collapses a slice of Configs into an adapter → OS process
+// name map. Used by the startup zombie sweep to detect orphaned sessions of
+// DB-backed adapters (OpenCode), where transcript-mtime staleness can't tell
+// a live session from a historical row.
+func ProcessNameMap(cfgs []Config) map[string]string {
+	m := make(map[string]string, len(cfgs))
+	for _, c := range cfgs {
+		if c.ProcessName != "" {
+			m[c.Name] = c.ProcessName
+		}
+	}
+	return m
+}
+
 // MetricsProviderMap collapses a slice of Configs into an adapter → provider
 // map. Only adapters with a non-nil ComputeMetrics are included.
 func MetricsProviderMap(cfgs []Config) map[string]MetricsProvider {

--- a/core/adapters/inbound/agents/opencode/watcher.go
+++ b/core/adapters/inbound/agents/opencode/watcher.go
@@ -67,9 +67,7 @@ type Watcher struct {
 	lastArchivedCheck time.Time
 
 	// liveCWDs returns the set of directories currently owned by a live
-	// opencode process. Used to gate EventNewSession so the watcher doesn't
-	// surface historical DB rows as live sessions when no opencode CLI is
-	// actually running. Defaults to processlifecycle.LiveCWDs(ProcessName);
+	// opencode process. Defaults to processlifecycle.LiveCWDs(ProcessName);
 	// overridable from tests.
 	liveCWDs func() map[string]struct{}
 }
@@ -81,16 +79,14 @@ type sessionCursor struct {
 	seenIDs map[string]struct{} // part IDs already processed at lastTS
 
 	// emitted is true once EventNewSession has been broadcast for this
-	// session. Sessions that exist in the DB but have no live opencode
-	// process owning their CWD are tracked (so we don't back-fill activity
-	// if the process later starts) but not emitted.
+	// session. Sessions tracked but not emitted are awaiting a live
+	// opencode process to own their CWD.
 	emitted bool
 
 	// lastObserved is the wall-clock time of the most recent scan that saw
-	// this session in the SQL result set. Used by gcExpiredCursors to drop
-	// entries that have aged out of the maxAge window — independent of
-	// lastTS, which only advances when new parts arrive (a session whose
-	// time_updated bumps without new parts would otherwise look stale).
+	// this session. Drives gcExpiredCursors independently of lastTS, which
+	// only advances on new parts (a session bumped without new parts would
+	// otherwise look stale).
 	lastObserved time.Time
 }
 
@@ -293,11 +289,9 @@ func (w *Watcher) scanSessions() {
 	}
 	rows.Close()
 
-	// Snapshot the set of CWDs currently owned by a live opencode process.
-	// Used to gate EventNewSession: a row in the session table is just
-	// history unless some opencode CLI is actually running for it. Without
-	// this gate the watcher floods the UI with stale rows on every startup
-	// (every non-archived session within maxAge gets re-emitted as new).
+	// Gate EventNewSession on a live opencode process owning the session's
+	// CWD — otherwise every non-archived row in the DB would be re-emitted
+	// as live on each daemon start.
 	live := w.liveCWDs()
 
 	w.mu.Lock()
@@ -307,34 +301,26 @@ func (w *Watcher) scanSessions() {
 	for _, s := range sessions {
 		cur, known := w.cursors[s.id]
 		if !known {
-			// First sighting — track the cursor at the current timestamp so
-			// that if the session later becomes live we don't back-fill its
-			// historical parts as fresh activity.
+			// Seed lastTS so a later live-transition's scanParts doesn't
+			// back-fill historical parts as fresh activity.
 			cur = &sessionCursor{
 				lastTS:  s.timeUpdated,
 				seenIDs: make(map[string]struct{}),
 			}
 			w.cursors[s.id] = cur
 		}
-		// Mark the cursor as observed in this scan so gcExpiredCursors
-		// keeps it alive even if no new parts arrived (lastTS only moves
-		// when scanParts sees a fresher part timestamp).
 		cur.lastObserved = scanWallClock
 
 		if !cur.emitted {
 			if _, alive := live[s.directory]; !alive {
-				// No opencode process owns this CWD — keep the cursor
-				// advanced so we skip historical activity if it ever
-				// becomes live.
 				cur.lastTS = s.timeUpdated
 				continue
 			}
-			// A live process owns this CWD — surface the session.
-			// Encode the session ID into TranscriptPath so that the
-			// MetricsProvider (opencode/metrics.go ComputeMetrics) can
-			// extract it via parseTranscriptPath. The WAL suffix is
-			// preserved so isStaleTranscript() checks the WAL (updated on
-			// every OpenCode write) rather than the main DB (checkpoint-only).
+			// TranscriptPath encodes the session ID so MetricsProvider
+			// (opencode/metrics.go ComputeMetrics) can extract it via
+			// parseTranscriptPath. The WAL suffix routes isStaleTranscript()
+			// at the WAL (updated on every write), not the checkpoint-only
+			// main DB.
 			walPath := w.dbPath + "-wal" + "?session=" + s.id
 			w.broadcast(agent.Event{
 				Type:            agent.EventNewSession,
@@ -348,27 +334,17 @@ func (w *Watcher) scanSessions() {
 			cur.emitted = true
 		}
 
-		// Scan for new parts since cursor (only for surfaced sessions).
 		w.scanParts(db, s.id, s.directory, cur)
 	}
 
-	// Emit EventRemoved for sessions that were archived since the last scan.
 	w.emitRemovedForArchivedSessions(db)
-
-	// GC cursors that have aged out of the maxAge window. The session SQL
-	// query above filters on `time_updated >= now - maxAge`, so any cursor
-	// whose lastTS is older than that cutoff will never appear in a future
-	// scan and is safe to drop. Without this, the map would grow without
-	// bound for users who accumulate many OpenCode sessions over time
-	// (especially when no opencode process is running, since untouched
-	// cursors stay at their initial lastTS forever).
 	w.gcExpiredCursors()
 }
 
 // gcExpiredCursors drops cursor entries whose most recent observation
-// (lastObserved) predates the maxAge window — those sessions cannot
-// reappear in the SQL query, so retaining their cursors only wastes
-// memory. No-op when maxAge == 0 (no upper bound configured).
+// predates the maxAge window — those sessions cannot reappear in the
+// SQL query, so retaining the cursor is pure waste. Bounds map growth
+// for users who accumulate many OpenCode sessions over time.
 func (w *Watcher) gcExpiredCursors() {
 	if w.maxAge <= 0 {
 		return

--- a/core/adapters/inbound/agents/opencode/watcher.go
+++ b/core/adapters/inbound/agents/opencode/watcher.go
@@ -17,15 +17,7 @@ import (
 	"irrlicht/core/domain/agent"
 )
 
-const (
-	defaultMinScanGap = 500 * time.Millisecond
-
-	// initialArchiveCleanupWindow is how far back the first archive-cleanup
-	// scan looks. Anything archived in this window before the daemon started
-	// gets an EventRemoved on the first scan; older archives are ignored
-	// (they were never surfaced as live in this daemon process anyway).
-	initialArchiveCleanupWindow = 5 * time.Minute
-)
+const defaultMinScanGap = 500 * time.Millisecond
 
 // Watcher monitors the OpenCode SQLite database for new and updated sessions.
 // It implements inbound.AgentWatcher.
@@ -93,6 +85,13 @@ type sessionCursor struct {
 	// process owning their CWD are tracked (so we don't back-fill activity
 	// if the process later starts) but not emitted.
 	emitted bool
+
+	// lastObserved is the wall-clock time of the most recent scan that saw
+	// this session in the SQL result set. Used by gcExpiredCursors to drop
+	// entries that have aged out of the maxAge window — independent of
+	// lastTS, which only advances when new parts arrive (a session whose
+	// time_updated bumps without new parts would otherwise look stale).
+	lastObserved time.Time
 }
 
 // New creates a Watcher for the OpenCode database relative to $HOME.
@@ -102,12 +101,13 @@ func New(maxAge time.Duration) *Watcher {
 		log.Printf("opencode: $HOME not set, using relative path: %v", err)
 	}
 	return &Watcher{
-		dbPath:     filepath.Join(home, dbRelPath),
-		adapter:    AdapterName,
-		maxAge:     maxAge,
-		cursors:    make(map[string]*sessionCursor),
-		minScanGap: defaultMinScanGap,
-		liveCWDs:   defaultLiveCWDs,
+		dbPath:            filepath.Join(home, dbRelPath),
+		adapter:           AdapterName,
+		maxAge:            maxAge,
+		cursors:           make(map[string]*sessionCursor),
+		minScanGap:        defaultMinScanGap,
+		lastArchivedCheck: time.Now(),
+		liveCWDs:          defaultLiveCWDs,
 	}
 }
 
@@ -115,12 +115,13 @@ func New(maxAge time.Duration) *Watcher {
 // Intended for tests.
 func NewWithDBPath(dbPath string, maxAge time.Duration) *Watcher {
 	return &Watcher{
-		dbPath:     dbPath,
-		adapter:    AdapterName,
-		maxAge:     maxAge,
-		cursors:    make(map[string]*sessionCursor),
-		minScanGap: defaultMinScanGap,
-		liveCWDs:   defaultLiveCWDs,
+		dbPath:            dbPath,
+		adapter:           AdapterName,
+		maxAge:            maxAge,
+		cursors:           make(map[string]*sessionCursor),
+		minScanGap:        defaultMinScanGap,
+		lastArchivedCheck: time.Now(),
+		liveCWDs:          defaultLiveCWDs,
 	}
 }
 
@@ -302,6 +303,7 @@ func (w *Watcher) scanSessions() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	scanWallClock := time.Now()
 	for _, s := range sessions {
 		cur, known := w.cursors[s.id]
 		if !known {
@@ -314,6 +316,10 @@ func (w *Watcher) scanSessions() {
 			}
 			w.cursors[s.id] = cur
 		}
+		// Mark the cursor as observed in this scan so gcExpiredCursors
+		// keeps it alive even if no new parts arrived (lastTS only moves
+		// when scanParts sees a fresher part timestamp).
+		cur.lastObserved = scanWallClock
 
 		if !cur.emitted {
 			if _, alive := live[s.directory]; !alive {
@@ -348,23 +354,50 @@ func (w *Watcher) scanSessions() {
 
 	// Emit EventRemoved for sessions that were archived since the last scan.
 	w.emitRemovedForArchivedSessions(db)
+
+	// GC cursors that have aged out of the maxAge window. The session SQL
+	// query above filters on `time_updated >= now - maxAge`, so any cursor
+	// whose lastTS is older than that cutoff will never appear in a future
+	// scan and is safe to drop. Without this, the map would grow without
+	// bound for users who accumulate many OpenCode sessions over time
+	// (especially when no opencode process is running, since untouched
+	// cursors stay at their initial lastTS forever).
+	w.gcExpiredCursors()
+}
+
+// gcExpiredCursors drops cursor entries whose most recent observation
+// (lastObserved) predates the maxAge window — those sessions cannot
+// reappear in the SQL query, so retaining their cursors only wastes
+// memory. No-op when maxAge == 0 (no upper bound configured).
+func (w *Watcher) gcExpiredCursors() {
+	if w.maxAge <= 0 {
+		return
+	}
+	cutoff := time.Now().Add(-w.maxAge)
+	for id, cur := range w.cursors {
+		if !cur.lastObserved.IsZero() && cur.lastObserved.Before(cutoff) {
+			delete(w.cursors, id)
+		}
+	}
 }
 
 // emitRemovedForArchivedSessions queries for sessions whose time_archived
 // column was set since the last check and emits EventRemoved for those
 // that are tracked in our cursors map.
 //
-// On the first call after daemon start, the cutoff is set to a short window
-// (initialArchiveCleanupWindow) before now so that sessions archived just
-// before startup still get cleaned up — without scanning OpenCode's entire
-// archive history.
+// On the first call after daemon start, the cutoff is seeded to "now" and we
+// return early — pre-startup archives are intentionally ignored here because
+// the cursors map is empty at that point (every emit gates on `if !known`).
+// Carryover archives from a previous daemon run are handled separately by
+// the DB-backed-orphan branch in PIDManager.CleanupZombies, which operates
+// on persisted state files rather than this in-memory cursor set.
 func (w *Watcher) emitRemovedForArchivedSessions(db *sql.DB) {
-	now := time.Now()
 	if w.lastArchivedCheck.IsZero() {
-		w.lastArchivedCheck = now.Add(-initialArchiveCleanupWindow)
+		w.lastArchivedCheck = time.Now()
+		return
 	}
 	cutoff := w.lastArchivedCheck.UnixMilli()
-	w.lastArchivedCheck = now
+	w.lastArchivedCheck = time.Now()
 
 	rows, err := db.Query(`
 		SELECT id FROM session

--- a/core/adapters/inbound/agents/opencode/watcher.go
+++ b/core/adapters/inbound/agents/opencode/watcher.go
@@ -13,10 +13,19 @@ import (
 	"github.com/fsnotify/fsnotify"
 	_ "modernc.org/sqlite" // pure-Go SQLite driver; no CGo required
 
+	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	"irrlicht/core/domain/agent"
 )
 
-const defaultMinScanGap = 500 * time.Millisecond
+const (
+	defaultMinScanGap = 500 * time.Millisecond
+
+	// initialArchiveCleanupWindow is how far back the first archive-cleanup
+	// scan looks. Anything archived in this window before the daemon started
+	// gets an EventRemoved on the first scan; older archives are ignored
+	// (they were never surfaced as live in this daemon process anyway).
+	initialArchiveCleanupWindow = 5 * time.Minute
+)
 
 // Watcher monitors the OpenCode SQLite database for new and updated sessions.
 // It implements inbound.AgentWatcher.
@@ -64,6 +73,13 @@ type Watcher struct {
 
 	// lastArchivedCheck is the cut-off for querying newly archived sessions.
 	lastArchivedCheck time.Time
+
+	// liveCWDs returns the set of directories currently owned by a live
+	// opencode process. Used to gate EventNewSession so the watcher doesn't
+	// surface historical DB rows as live sessions when no opencode CLI is
+	// actually running. Defaults to processlifecycle.LiveCWDs(ProcessName);
+	// overridable from tests.
+	liveCWDs func() map[string]struct{}
 }
 
 // sessionCursor tracks the last-seen part timestamp and deduplicates parts
@@ -71,6 +87,12 @@ type Watcher struct {
 type sessionCursor struct {
 	lastTS  int64
 	seenIDs map[string]struct{} // part IDs already processed at lastTS
+
+	// emitted is true once EventNewSession has been broadcast for this
+	// session. Sessions that exist in the DB but have no live opencode
+	// process owning their CWD are tracked (so we don't back-fill activity
+	// if the process later starts) but not emitted.
+	emitted bool
 }
 
 // New creates a Watcher for the OpenCode database relative to $HOME.
@@ -80,12 +102,12 @@ func New(maxAge time.Duration) *Watcher {
 		log.Printf("opencode: $HOME not set, using relative path: %v", err)
 	}
 	return &Watcher{
-		dbPath:            filepath.Join(home, dbRelPath),
-		adapter:           AdapterName,
-		maxAge:            maxAge,
-		cursors:           make(map[string]*sessionCursor),
-		minScanGap:        defaultMinScanGap,
-		lastArchivedCheck: time.Now(),
+		dbPath:     filepath.Join(home, dbRelPath),
+		adapter:    AdapterName,
+		maxAge:     maxAge,
+		cursors:    make(map[string]*sessionCursor),
+		minScanGap: defaultMinScanGap,
+		liveCWDs:   defaultLiveCWDs,
 	}
 }
 
@@ -93,13 +115,25 @@ func New(maxAge time.Duration) *Watcher {
 // Intended for tests.
 func NewWithDBPath(dbPath string, maxAge time.Duration) *Watcher {
 	return &Watcher{
-		dbPath:            dbPath,
-		adapter:           AdapterName,
-		maxAge:            maxAge,
-		cursors:           make(map[string]*sessionCursor),
-		minScanGap:        defaultMinScanGap,
-		lastArchivedCheck: time.Now(),
+		dbPath:     dbPath,
+		adapter:    AdapterName,
+		maxAge:     maxAge,
+		cursors:    make(map[string]*sessionCursor),
+		minScanGap: defaultMinScanGap,
+		liveCWDs:   defaultLiveCWDs,
 	}
+}
+
+// defaultLiveCWDs returns the set of CWDs currently held by live opencode
+// processes. Failures are logged and treated as "no live processes" — the
+// scan continues but won't surface ghost sessions.
+func defaultLiveCWDs() map[string]struct{} {
+	set, err := processlifecycle.LiveCWDs(ProcessName)
+	if err != nil {
+		log.Printf("opencode: LiveCWDs: %v", err)
+		return nil
+	}
+	return set
 }
 
 // Root returns the watched database path (satisfies the interface used in
@@ -258,21 +292,44 @@ func (w *Watcher) scanSessions() {
 	}
 	rows.Close()
 
+	// Snapshot the set of CWDs currently owned by a live opencode process.
+	// Used to gate EventNewSession: a row in the session table is just
+	// history unless some opencode CLI is actually running for it. Without
+	// this gate the watcher floods the UI with stale rows on every startup
+	// (every non-archived session within maxAge gets re-emitted as new).
+	live := w.liveCWDs()
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
 	for _, s := range sessions {
 		cur, known := w.cursors[s.id]
 		if !known {
-			// New session — emit EventNewSession.
+			// First sighting — track the cursor at the current timestamp so
+			// that if the session later becomes live we don't back-fill its
+			// historical parts as fresh activity.
+			cur = &sessionCursor{
+				lastTS:  s.timeUpdated,
+				seenIDs: make(map[string]struct{}),
+			}
+			w.cursors[s.id] = cur
+		}
+
+		if !cur.emitted {
+			if _, alive := live[s.directory]; !alive {
+				// No opencode process owns this CWD — keep the cursor
+				// advanced so we skip historical activity if it ever
+				// becomes live.
+				cur.lastTS = s.timeUpdated
+				continue
+			}
+			// A live process owns this CWD — surface the session.
 			// Encode the session ID into TranscriptPath so that the
 			// MetricsProvider (opencode/metrics.go ComputeMetrics) can
 			// extract it via parseTranscriptPath. The WAL suffix is
 			// preserved so isStaleTranscript() checks the WAL (updated on
 			// every OpenCode write) rather than the main DB (checkpoint-only).
 			walPath := w.dbPath + "-wal" + "?session=" + s.id
-			cur = &sessionCursor{seenIDs: make(map[string]struct{})}
-			w.cursors[s.id] = cur
 			w.broadcast(agent.Event{
 				Type:            agent.EventNewSession,
 				Adapter:         w.adapter,
@@ -282,9 +339,10 @@ func (w *Watcher) scanSessions() {
 				CWD:             s.directory,
 				ParentSessionID: s.parentID,
 			})
+			cur.emitted = true
 		}
 
-		// Scan for new parts since cursor.
+		// Scan for new parts since cursor (only for surfaced sessions).
 		w.scanParts(db, s.id, s.directory, cur)
 	}
 
@@ -295,13 +353,18 @@ func (w *Watcher) scanSessions() {
 // emitRemovedForArchivedSessions queries for sessions whose time_archived
 // column was set since the last check and emits EventRemoved for those
 // that are tracked in our cursors map.
+//
+// On the first call after daemon start, the cutoff is set to a short window
+// (initialArchiveCleanupWindow) before now so that sessions archived just
+// before startup still get cleaned up — without scanning OpenCode's entire
+// archive history.
 func (w *Watcher) emitRemovedForArchivedSessions(db *sql.DB) {
+	now := time.Now()
 	if w.lastArchivedCheck.IsZero() {
-		w.lastArchivedCheck = time.Now()
-		return
+		w.lastArchivedCheck = now.Add(-initialArchiveCleanupWindow)
 	}
 	cutoff := w.lastArchivedCheck.UnixMilli()
-	w.lastArchivedCheck = time.Now()
+	w.lastArchivedCheck = now
 
 	rows, err := db.Query(`
 		SELECT id FROM session

--- a/core/adapters/inbound/agents/opencode/watcher_test.go
+++ b/core/adapters/inbound/agents/opencode/watcher_test.go
@@ -61,6 +61,23 @@ func setupTestDB(t *testing.T) (*Watcher, *sql.DB) {
 
 	w := NewWithDBPath(dbPath, 1*time.Hour)
 	w.minScanGap = 0 // disable debounce for direct scanSessions() calls in tests
+	// Default test stub: every CWD currently in the DB is "live". Tests that
+	// want to exercise the no-live-process gate override this.
+	w.liveCWDs = func() map[string]struct{} {
+		rows, err := db.Query(`SELECT DISTINCT directory FROM session`)
+		if err != nil {
+			return nil
+		}
+		defer rows.Close()
+		set := make(map[string]struct{})
+		for rows.Next() {
+			var d string
+			if err := rows.Scan(&d); err == nil {
+				set[d] = struct{}{}
+			}
+		}
+		return set
+	}
 	return w, db
 }
 
@@ -201,11 +218,11 @@ func TestScanSessions_Removed(t *testing.T) {
 	now := time.Now().UnixMilli()
 	insertSession(t, db, "ses_rm", "/tmp", now, "")
 
-	// First scan to discover and set lastArchivedCheck.
+	// First scan: surface the session and seed lastArchivedCheck.
 	w.scanSessions()
 	drainEvents(ch)
 
-	// Wait so time_archived is distinctly after lastArchivedCheck.
+	// Wait so time_archived lands strictly after lastArchivedCheck.
 	time.Sleep(10 * time.Millisecond)
 
 	// Archive the session.
@@ -345,27 +362,104 @@ func TestScanSessions_NoArchivedBeforeCheck(t *testing.T) {
 	defer w.Unsubscribe(ch)
 
 	// Create an already-archived session (before watcher knows about it).
+	// Even though the first emitRemovedForArchivedSessions call now does scan
+	// the recent-archive window (initialArchiveCleanupWindow), this session
+	// was never in cursors → no EventRemoved should fire for it.
 	now := time.Now().UnixMilli()
-	insertSessionWithArchive := func() {
-		insertSession(t, db, "ses_already_archived", "/tmp", now, "")
-		_, err := db.Exec(`UPDATE session SET time_archived = ? WHERE id = ?`, now, "ses_already_archived")
-		if err != nil {
-			t.Fatalf("archive session: %v", err)
-		}
+	insertSession(t, db, "ses_already_archived", "/tmp", now, "")
+	if _, err := db.Exec(`UPDATE session SET time_archived = ? WHERE id = ?`, now, "ses_already_archived"); err != nil {
+		t.Fatalf("archive session: %v", err)
 	}
-	insertSessionWithArchive()
-
-	// firstArchivedCheck is zero → emitRemovedForArchivedSessions returns early.
-	// Even if it did run, the session was never in cursors → no event.
 
 	w.scanSessions()
 	events := collectEvents(ch, 500*time.Millisecond)
 
-	// Should not emit EventRemoved for an unknown archived session.
 	for _, ev := range events {
 		if ev.Type == agent.EventRemoved {
 			t.Errorf("unexpected EventRemoved for session not in cursors: %v", ev)
 		}
+	}
+}
+
+// TestScanSessions_NoLiveProcessSuppressesGhosts is the regression for the
+// v0.3.12 ghost-sessions bug: when no opencode CLI is running, historical DB
+// rows must NOT be surfaced as live sessions.
+func TestScanSessions_NoLiveProcessSuppressesGhosts(t *testing.T) {
+	w, db := setupTestDB(t)
+	ch := w.Subscribe()
+	defer w.Unsubscribe(ch)
+
+	// No opencode processes are alive.
+	w.liveCWDs = func() map[string]struct{} { return nil }
+
+	now := time.Now().UnixMilli()
+	insertSession(t, db, "ses_ghost1", "/tmp", now, "")
+	insertSession(t, db, "ses_ghost2", "/home/user/projects/foo", now, "")
+	insertSession(t, db, "ses_ghost3", "/home/user/projects/bar", now, "")
+
+	w.scanSessions()
+
+	events := collectEvents(ch, 500*time.Millisecond)
+	for _, ev := range events {
+		if ev.Type == agent.EventNewSession {
+			t.Errorf("expected zero EventNewSession with no live opencode process, got %+v", ev)
+		}
+	}
+}
+
+// TestScanSessions_EmitsWhenProcessBecomesLive verifies that a session
+// initially gated out by the no-live-process check still emits EventNewSession
+// once the user starts opencode in its CWD.
+func TestScanSessions_EmitsWhenProcessBecomesLive(t *testing.T) {
+	w, db := setupTestDB(t)
+	ch := w.Subscribe()
+	defer w.Unsubscribe(ch)
+
+	var liveSet map[string]struct{}
+	w.liveCWDs = func() map[string]struct{} { return liveSet }
+
+	now := time.Now().UnixMilli()
+	insertSession(t, db, "ses_dormant", "/tmp/work", now, "")
+	insertMessage(t, db, "msg_d", "ses_dormant", "user", "gpt-4", now)
+	insertPart(t, db, "part_d1", "ses_dormant", "msg_d", "text", `{"text":"hello"}`, now)
+
+	// First scan: process not live → no emit.
+	w.scanSessions()
+	drainEvents(ch)
+
+	// User starts opencode in /tmp/work.
+	liveSet = map[string]struct{}{"/tmp/work": {}}
+
+	// New activity arrives.
+	later := now + 1000
+	insertPart(t, db, "part_d2", "ses_dormant", "msg_d", "text", `{"text":"more"}`, later)
+	if _, err := db.Exec(`UPDATE session SET time_updated = ? WHERE id = ?`, later, "ses_dormant"); err != nil {
+		t.Fatalf("bump time_updated: %v", err)
+	}
+
+	w.scanSessions()
+	events := collectEvents(ch, 500*time.Millisecond)
+
+	var newSessions, activities int
+	for _, ev := range events {
+		switch ev.Type {
+		case agent.EventNewSession:
+			if ev.SessionID == "ses_dormant" {
+				newSessions++
+			}
+		case agent.EventActivity:
+			if ev.SessionID == "ses_dormant" {
+				activities++
+			}
+		}
+	}
+	if newSessions != 1 {
+		t.Errorf("expected 1 EventNewSession after process becomes live, got %d (events=%v)", newSessions, events)
+	}
+	// Activity for the new part should also fire — but not for the historical
+	// part_d1 that landed before the session was surfaced.
+	if activities != 1 {
+		t.Errorf("expected 1 EventActivity (for the post-emit part), got %d (events=%v)", activities, events)
 	}
 }
 

--- a/core/adapters/inbound/agents/opencode/watcher_test.go
+++ b/core/adapters/inbound/agents/opencode/watcher_test.go
@@ -362,9 +362,10 @@ func TestScanSessions_NoArchivedBeforeCheck(t *testing.T) {
 	defer w.Unsubscribe(ch)
 
 	// Create an already-archived session (before watcher knows about it).
-	// Even though the first emitRemovedForArchivedSessions call now does scan
-	// the recent-archive window (initialArchiveCleanupWindow), this session
-	// was never in cursors → no EventRemoved should fire for it.
+	// The session was never in cursors → emitRemovedForArchivedSessions's
+	// `if !known` gate skips it, so no EventRemoved should fire. Carryover
+	// archives from a previous daemon run are handled by
+	// PIDManager.CleanupZombies's DB-backed-orphan branch instead.
 	now := time.Now().UnixMilli()
 	insertSession(t, db, "ses_already_archived", "/tmp", now, "")
 	if _, err := db.Exec(`UPDATE session SET time_archived = ? WHERE id = ?`, now, "ses_already_archived"); err != nil {
@@ -405,6 +406,62 @@ func TestScanSessions_NoLiveProcessSuppressesGhosts(t *testing.T) {
 			t.Errorf("expected zero EventNewSession with no live opencode process, got %+v", ev)
 		}
 	}
+}
+
+// TestScanSessions_GCsExpiredCursors verifies that cursors for sessions
+// whose lastTS has aged out of the maxAge window are dropped from memory.
+// Without this GC, the cursors map grows without bound for users who
+// accumulate many OpenCode sessions but rarely run the CLI (every session
+// the watcher ever saw would stick around as a not-emitted cursor).
+func TestScanSessions_GCsExpiredCursors(t *testing.T) {
+	w, db := setupTestDB(t)
+	ch := w.Subscribe()
+	defer w.Unsubscribe(ch)
+
+	// Tight maxAge so we don't have to backdate by days.
+	w.maxAge = 100 * time.Millisecond
+
+	// Two sessions with distinct CWDs, both fresh enough to appear in scan.
+	now := time.Now().UnixMilli()
+	insertSession(t, db, "ses_recent", "/tmp/recent", now, "")
+	insertSession(t, db, "ses_will_age", "/tmp/age-out", now, "")
+
+	w.scanSessions()
+	drainEvents(ch)
+
+	w.mu.Lock()
+	if len(w.cursors) != 2 {
+		t.Fatalf("after first scan: cursors=%d, want 2", len(w.cursors))
+	}
+	w.mu.Unlock()
+
+	// Bump only ses_recent's time_updated past the maxAge boundary; leave
+	// ses_will_age frozen at its original timestamp so it ages out.
+	time.Sleep(150 * time.Millisecond)
+	fresh := time.Now().UnixMilli()
+	if _, err := db.Exec(`UPDATE session SET time_updated = ? WHERE id = ?`, fresh, "ses_recent"); err != nil {
+		t.Fatalf("bump time_updated: %v", err)
+	}
+
+	w.scanSessions()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, ok := w.cursors["ses_recent"]; !ok {
+		t.Error("ses_recent cursor was GC'd but it's within maxAge")
+	}
+	if _, ok := w.cursors["ses_will_age"]; ok {
+		t.Errorf("ses_will_age cursor should have been GC'd (lastTS older than maxAge), cursors=%v", keysOf(w.cursors))
+	}
+}
+
+// keysOf returns the keys of m as a slice, for test diagnostic output.
+func keysOf(m map[string]*sessionCursor) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 // TestScanSessions_EmitsWhenProcessBecomesLive verifies that a session

--- a/core/adapters/inbound/agents/processlifecycle/discovery.go
+++ b/core/adapters/inbound/agents/processlifecycle/discovery.go
@@ -40,6 +40,38 @@ func DiscoverPIDByCWDAndCmdLine(cmdLinePattern, cwd string, disambiguate func([]
 	return narrowByCWD(pids, cwd, disambiguate), nil
 }
 
+// LiveCWDs returns the set of working directories currently held by live
+// processes whose binary name matches processName (via `pgrep -x`). Excludes
+// the daemon's own PID. PIDs whose CWD cannot be read (race against process
+// exit, restricted permissions) are skipped silently — this is a best-effort
+// snapshot, not a guarantee.
+//
+// Used by the OpenCode adapter to gate EventNewSession on a live process: a
+// session row in the DB is only surfaced if some opencode process currently
+// owns its CWD.
+func LiveCWDs(processName string) (map[string]struct{}, error) {
+	if processName == "" {
+		return nil, nil
+	}
+	pids, err := findProcesses(processName)
+	if err != nil {
+		return nil, fmt.Errorf("find %s processes: %w", processName, err)
+	}
+	myPID := os.Getpid()
+	set := make(map[string]struct{}, len(pids))
+	for _, pid := range pids {
+		if pid == myPID {
+			continue
+		}
+		dir, err := processCWD(pid)
+		if err != nil {
+			continue
+		}
+		set[dir] = struct{}{}
+	}
+	return set, nil
+}
+
 // narrowByCWD filters pids to those whose CWD equals the given path, then
 // resolves to a single PID via disambiguate (falling back to highest PID).
 // Excludes the daemon's own PID. Returns 0 when no match.

--- a/core/application/services/helpers.go
+++ b/core/application/services/helpers.go
@@ -9,20 +9,25 @@ import (
 	"time"
 )
 
+// dbBackedPathSentinel marks a TranscriptPath that encodes a DB-backed
+// session (e.g. OpenCode's "…/opencode.db-wal?session=ses_xxx"). The query
+// string carries the session ID since the WAL itself is shared across all
+// sessions in the DB. Used by isDBBackedTranscriptPath.
+const dbBackedPathSentinel = '?'
+
+// isDBBackedTranscriptPath reports whether path encodes a DB-backed adapter
+// session. Such paths can't be stat'd for mtime-based staleness (the WAL is
+// shared), so callers route them through adapter-specific liveness checks
+// instead.
+func isDBBackedTranscriptPath(path string) bool {
+	return strings.IndexByte(path, dbBackedPathSentinel) >= 0
+}
+
 // isStaleTranscript reports whether the transcript file at path has not been
-// modified within orphanTranscriptAge. Returns false for empty paths or
-// stat errors (file missing → not stale, will be caught elsewhere).
-// Any query-string suffix (e.g. "?session=ses_xxx") signals a DB-backed
-// adapter (e.g. OpenCode) whose staleness is managed by the adapter itself —
-// these paths are never considered stale by this function.
+// modified within orphanTranscriptAge. Returns false for empty paths, stat
+// errors, or DB-backed paths (whose staleness is managed by the adapter).
 func isStaleTranscript(path string) bool {
-	if path == "" {
-		return false
-	}
-	// DB-backed adapters embed session ID as a query string. Staleness for
-	// these sessions is handled by the adapter's own maxAge filter, not by
-	// transcript mtime — the WAL is shared across all sessions in the DB.
-	if strings.IndexByte(path, '?') >= 0 {
+	if path == "" || isDBBackedTranscriptPath(path) {
 		return false
 	}
 	info, err := os.Stat(path)

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -19,6 +19,14 @@ import (
 	"irrlicht/core/ports/outbound"
 )
 
+// LiveCWDsFunc returns the set of working directories currently held by live
+// processes whose binary name matches processName. Implementations live in
+// the processlifecycle adapter; the function is injected to preserve the
+// hexagonal layering. A nil result with a nil error means "no live processes
+// matched"; a non-nil error means the lookup failed and callers should treat
+// the answer as unknown (do NOT delete sessions on this signal).
+type LiveCWDsFunc func(processName string) (map[string]struct{}, error)
+
 // LauncherEnvReader captures the terminal/IDE identity from the process env
 // of pid. Returns nil when env cannot be read or no launcher is identifiable.
 // Implementations must never block longer than a couple of seconds and must
@@ -38,6 +46,19 @@ type PIDManager struct {
 	// pidDiscovers maps adapter name → PID discovery function.
 	// Nil or missing entry means no PID discovery for that adapter.
 	pidDiscovers map[string]agent.PIDDiscoverFunc
+
+	// processNames maps adapter name → OS process name (the binary `pgrep -x`
+	// would match). Used by the startup zombie sweep to detect orphaned
+	// sessions of DB-backed adapters (OpenCode), where transcript-mtime
+	// staleness can't tell a live session from a historical row.
+	// Nil or missing entry disables the DB-backed-orphan check for that
+	// adapter — those sessions are kept until their PID is discovered.
+	processNames map[string]string
+
+	// liveCWDs is the live-process lookup used by the DB-backed-orphan
+	// branch of the startup zombie sweep. Injected from main.go (typically
+	// processlifecycle.LiveCWDs). Nil disables the branch.
+	liveCWDs LiveCWDsFunc
 
 	// launcherEnv reads launcher env from a PID. Optional — nil skips capture.
 	launcherEnv LauncherEnvReader
@@ -67,7 +88,9 @@ type PIDManager struct {
 }
 
 // NewPIDManager creates a PIDManager with the given dependencies.
-// pw and broadcaster may be nil (optional).
+// pw and broadcaster may be nil (optional). processNames + liveCWDs may
+// both be nil — that disables the DB-backed-orphan branch of the startup
+// zombie sweep.
 func NewPIDManager(
 	pw outbound.ProcessWatcher,
 	repo outbound.SessionRepository,
@@ -75,6 +98,8 @@ func NewPIDManager(
 	broadcaster outbound.PushBroadcaster,
 	readyTTL time.Duration,
 	pidDiscovers map[string]agent.PIDDiscoverFunc,
+	processNames map[string]string,
+	liveCWDs LiveCWDsFunc,
 	onSessionDeleted func(sessionID string),
 ) *PIDManager {
 	return &PIDManager{
@@ -84,6 +109,8 @@ func NewPIDManager(
 		broadcaster:      broadcaster,
 		readyTTL:         readyTTL,
 		pidDiscovers:     pidDiscovers,
+		processNames:     processNames,
+		liveCWDs:         liveCWDs,
 		onSessionDeleted: onSessionDeleted,
 		pendingPIDs:      make(map[string]int),
 	}
@@ -166,13 +193,19 @@ func (pm *PIDManager) HandleProcessExit(pid int, sessionID string) {
 // HTTP server is already serving — so without this synchronous pre-pass the
 // API briefly returns zombies inherited from the previous daemon run.
 //
-// Two predicates, both narrower than CheckPIDLiveness so we never delete an
+// Three predicates, all narrower than CheckPIDLiveness so we never delete an
 // in-flight session (at startup nothing is in-flight, but the predicates
 // stay conservative anyway in case CleanupZombies is ever called later):
 //  1. Known PID and syscall.Kill returns ESRCH        → process exited.
 //  2. PID == 0, not a subagent, transcript file has
 //     not been modified within orphanTranscriptAge    → orphan that
 //     never bound.
+//  3. PID == 0, not a subagent, DB-backed transcript
+//     (path contains "?session="), no live process of
+//     the adapter's binary owns the session's CWD     → DB-backed orphan
+//     (the carryover-state case for OpenCode where
+//     isStaleTranscript can't help — the WAL is shared
+//     across all sessions in the DB).
 //
 // Note: a "live PID, old record" case is intentionally NOT included. A
 // long-idle but still-running agent (user away from keyboard for >2 min)
@@ -188,7 +221,7 @@ func (pm *PIDManager) CleanupZombies() int {
 	}
 	deleted := 0
 	for _, state := range states {
-		if !isStartupZombie(state) {
+		if !pm.isStartupZombie(state) {
 			continue
 		}
 		pm.log.LogInfo("startup-cleanup", state.SessionID,
@@ -201,7 +234,7 @@ func (pm *PIDManager) CleanupZombies() int {
 
 // isStartupZombie returns true for sessions whose process is provably gone.
 // Mirrors the predicate documented on CleanupZombies.
-func isStartupZombie(state *session.SessionState) bool {
+func (pm *PIDManager) isStartupZombie(state *session.SessionState) bool {
 	if state == nil {
 		return false
 	}
@@ -213,7 +246,35 @@ func isStartupZombie(state *session.SessionState) bool {
 	if state.ParentSessionID != "" {
 		return false
 	}
+	// PID == 0 and a DB-backed transcript path: isStaleTranscript can't tell
+	// us anything (the WAL is shared across all sessions in the DB), so use
+	// the adapter's process name as the liveness signal — if no live process
+	// owns the session's CWD, the session is an orphan from a previous
+	// daemon run.
+	if isDBBackedTranscriptPath(state.TranscriptPath) && state.CWD != "" && pm.liveCWDs != nil {
+		if name, ok := pm.processNames[state.Adapter]; ok && name != "" {
+			live, err := pm.liveCWDs(name)
+			// Only mark zombie when the lookup succeeded and returned a
+			// definitive answer (non-nil set). On error, keep the session
+			// — better to leave a stale row than to wipe legitimate state.
+			if err == nil && live != nil {
+				if _, alive := live[state.CWD]; !alive {
+					return true
+				}
+			}
+		}
+		// No process-name registered for this adapter, or the lookup was
+		// inconclusive: don't delete. The standard isStaleTranscript path
+		// below will short-circuit to false for DB-backed paths anyway.
+	}
 	return isStaleTranscript(state.TranscriptPath)
+}
+
+// isDBBackedTranscriptPath reports whether a transcript path encodes a
+// DB-backed adapter session (e.g. OpenCode's
+// "…/opencode.db-wal?session=ses_xxx").
+func isDBBackedTranscriptPath(path string) bool {
+	return strings.IndexByte(path, '?') >= 0
 }
 
 // deleteWithChildren removes a session and all its child sessions (subagents).

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -219,9 +219,14 @@ func (pm *PIDManager) CleanupZombies() int {
 	if err != nil {
 		return 0
 	}
+	// Memoize live-CWD lookups per adapter for the duration of this sweep —
+	// when M ghost candidates share an adapter, the lookup is identical and
+	// each call shells out to pgrep. At startup with heavy carryover state,
+	// M can easily reach 10+.
+	liveLookup := pm.newLiveLookupCache()
 	deleted := 0
 	for _, state := range states {
-		if !pm.isStartupZombie(state) {
+		if !pm.isStartupZombie(state, liveLookup) {
 			continue
 		}
 		pm.log.LogInfo("startup-cleanup", state.SessionID,
@@ -232,49 +237,62 @@ func (pm *PIDManager) CleanupZombies() int {
 	return deleted
 }
 
+// newLiveLookupCache returns a memoizing adapter→live-CWDs lookup backed by
+// pm.liveCWDs / pm.processNames. Returns nil when liveCWDs is unset (the
+// DB-backed-orphan branch is disabled). The returned closure caches both
+// successful results and the "no process name registered" / "lookup failed"
+// states so that repeat calls within a single sweep don't re-fork pgrep.
+func (pm *PIDManager) newLiveLookupCache() func(adapter string) map[string]struct{} {
+	if pm.liveCWDs == nil {
+		return nil
+	}
+	cache := make(map[string]map[string]struct{})
+	cached := make(map[string]bool)
+	return func(adapter string) map[string]struct{} {
+		if cached[adapter] {
+			return cache[adapter]
+		}
+		cached[adapter] = true
+		name, ok := pm.processNames[adapter]
+		if !ok || name == "" {
+			return nil
+		}
+		live, err := pm.liveCWDs(name)
+		if err != nil {
+			return nil
+		}
+		cache[adapter] = live
+		return live
+	}
+}
+
 // isStartupZombie returns true for sessions whose process is provably gone.
-// Mirrors the predicate documented on CleanupZombies.
-func (pm *PIDManager) isStartupZombie(state *session.SessionState) bool {
+// Mirrors the predicate documented on CleanupZombies. liveLookup may be nil
+// (disables the DB-backed-orphan branch); callers that need the branch must
+// supply one — typically pm.newLiveLookupCache().
+func (pm *PIDManager) isStartupZombie(state *session.SessionState, liveLookup func(adapter string) map[string]struct{}) bool {
 	if state == nil {
 		return false
 	}
 	if state.PID > 0 {
 		return syscall.Kill(state.PID, 0) == syscall.ESRCH
 	}
-	// PID == 0: subagents share their parent's PID and are cleaned up via
-	// child-specific paths in CheckPIDLiveness, so exempt them here.
+	// Subagents share their parent's PID and are cleaned up via child-
+	// specific paths in CheckPIDLiveness.
 	if state.ParentSessionID != "" {
 		return false
 	}
-	// PID == 0 and a DB-backed transcript path: isStaleTranscript can't tell
-	// us anything (the WAL is shared across all sessions in the DB), so use
-	// the adapter's process name as the liveness signal — if no live process
-	// owns the session's CWD, the session is an orphan from a previous
-	// daemon run.
-	if isDBBackedTranscriptPath(state.TranscriptPath) && state.CWD != "" && pm.liveCWDs != nil {
-		if name, ok := pm.processNames[state.Adapter]; ok && name != "" {
-			live, err := pm.liveCWDs(name)
-			// Only mark zombie when the lookup succeeded and returned a
-			// definitive answer (non-nil set). On error, keep the session
-			// — better to leave a stale row than to wipe legitimate state.
-			if err == nil && live != nil {
-				if _, alive := live[state.CWD]; !alive {
-					return true
-				}
+	// DB-backed adapters: WAL is shared across sessions, so transcript-mtime
+	// staleness is meaningless. Fall back to "is any process of this adapter
+	// owning the session's CWD?" — no owner ⇒ orphan.
+	if isDBBackedTranscriptPath(state.TranscriptPath) && state.CWD != "" && liveLookup != nil {
+		if live := liveLookup(state.Adapter); live != nil {
+			if _, alive := live[state.CWD]; !alive {
+				return true
 			}
 		}
-		// No process-name registered for this adapter, or the lookup was
-		// inconclusive: don't delete. The standard isStaleTranscript path
-		// below will short-circuit to false for DB-backed paths anyway.
 	}
 	return isStaleTranscript(state.TranscriptPath)
-}
-
-// isDBBackedTranscriptPath reports whether a transcript path encodes a
-// DB-backed adapter session (e.g. OpenCode's
-// "…/opencode.db-wal?session=ses_xxx").
-func isDBBackedTranscriptPath(path string) bool {
-	return strings.IndexByte(path, '?') >= 0
 }
 
 // deleteWithChildren removes a session and all its child sessions (subagents).

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -280,7 +280,9 @@ func TestCleanupZombies_DBBackedOrphan(t *testing.T) {
 		"opencode":       "opencode",
 		"opencode-flaky": "opencode-flaky", // mapped, but lookup will fail
 	}
+	calls := make(map[string]int)
 	liveCWDs := func(name string) (map[string]struct{}, error) {
+		calls[name]++
 		switch name {
 		case "opencode":
 			return map[string]struct{}{
@@ -303,6 +305,16 @@ func TestCleanupZombies_DBBackedOrphan(t *testing.T) {
 		if repo.states[id] == nil {
 			t.Errorf("session %q should have been kept", id)
 		}
+	}
+
+	// Cache assertion: each registered adapter is looked up at most once,
+	// even though "opencode" has two ghost candidates and "opencode-flaky"
+	// errors out. Without the per-sweep cache this would be 3 calls.
+	if calls["opencode"] != 1 {
+		t.Errorf("liveCWDs(opencode) call count = %d, want 1 (cached)", calls["opencode"])
+	}
+	if calls["opencode-flaky"] != 1 {
+		t.Errorf("liveCWDs(opencode-flaky) call count = %d, want 1 (cached error)", calls["opencode-flaky"])
 	}
 }
 

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -277,8 +277,8 @@ func TestCleanupZombies_DBBackedOrphan(t *testing.T) {
 	}
 
 	processNames := map[string]string{
-		"opencode":        "opencode",
-		"opencode-flaky":  "opencode-flaky", // mapped, but lookup will fail
+		"opencode":       "opencode",
+		"opencode-flaky": "opencode-flaky", // mapped, but lookup will fail
 	}
 	liveCWDs := func(name string) (map[string]struct{}, error) {
 		switch name {

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,6 +35,25 @@ func newPIDManagerForTest(repo *mockRepo) *services.PIDManager {
 		nil, // no broadcaster
 		10*time.Minute,
 		nil, // no pid discovers
+		nil, // no process names
+		nil, // no live-CWDs lookup
+		func(string) {},
+	)
+}
+
+// newPIDManagerForTestWithLiveCWDs builds a PIDManager whose startup zombie
+// sweep can use the DB-backed-orphan branch — the sweep needs both an
+// adapter→process-name map and a live-CWDs lookup.
+func newPIDManagerForTestWithLiveCWDs(repo *mockRepo, processNames map[string]string, liveCWDs services.LiveCWDsFunc) *services.PIDManager {
+	return services.NewPIDManager(
+		nil,
+		repo,
+		&mockLogger{},
+		nil,
+		10*time.Minute,
+		nil,
+		processNames,
+		liveCWDs,
 		func(string) {},
 	)
 }
@@ -198,6 +218,90 @@ func TestCleanupZombies(t *testing.T) {
 	for _, id := range wantKept {
 		if repo.states[id] == nil {
 			t.Errorf("session %q should have been kept but is gone", id)
+		}
+	}
+}
+
+// TestCleanupZombies_DBBackedOrphan covers the carryover-state path for
+// DB-backed adapters (OpenCode): a PID=0 session whose TranscriptPath
+// contains "?session=" is deleted iff the adapter's process name has no
+// live process owning the session's CWD. This is the cleanup half of the
+// v0.3.12 ghost-sessions fix — the watcher gates new emissions, but
+// existing on-disk state from the buggy daemon needs this branch to clear
+// without a manual wipe.
+func TestCleanupZombies_DBBackedOrphan(t *testing.T) {
+	wal := "/Users/test/.local/share/opencode/opencode.db-wal"
+	repo := newMockRepo()
+
+	// 1. DB-backed session whose CWD is NOT held by any live process → deleted.
+	repo.states["opencode-orphan"] = &session.SessionState{
+		SessionID:      "opencode-orphan",
+		Adapter:        "opencode",
+		State:          session.StateWorking,
+		PID:            0,
+		CWD:            "/home/user/orphan-project",
+		TranscriptPath: wal + "?session=ses_orphan",
+		UpdatedAt:      time.Now().Unix(),
+	}
+	// 2. DB-backed session whose CWD IS held by a live process → kept.
+	repo.states["opencode-live"] = &session.SessionState{
+		SessionID:      "opencode-live",
+		Adapter:        "opencode",
+		State:          session.StateWorking,
+		PID:            0,
+		CWD:            "/home/user/active-project",
+		TranscriptPath: wal + "?session=ses_live",
+		UpdatedAt:      time.Now().Unix(),
+	}
+	// 3. DB-backed session whose adapter has no registered process name →
+	//    kept (lookup is inconclusive; safer not to delete).
+	repo.states["unknown-adapter"] = &session.SessionState{
+		SessionID:      "unknown-adapter",
+		Adapter:        "future-db-adapter",
+		State:          session.StateWorking,
+		PID:            0,
+		CWD:            "/home/user/somewhere",
+		TranscriptPath: wal + "?session=ses_unknown",
+		UpdatedAt:      time.Now().Unix(),
+	}
+	// 4. DB-backed session whose lookup fails (lookup returns error) →
+	//    kept (we don't delete on uncertain liveness signals).
+	repo.states["opencode-lookup-error"] = &session.SessionState{
+		SessionID:      "opencode-lookup-error",
+		Adapter:        "opencode-flaky",
+		State:          session.StateWorking,
+		PID:            0,
+		CWD:            "/home/user/whatever",
+		TranscriptPath: wal + "?session=ses_err",
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	processNames := map[string]string{
+		"opencode":        "opencode",
+		"opencode-flaky":  "opencode-flaky", // mapped, but lookup will fail
+	}
+	liveCWDs := func(name string) (map[string]struct{}, error) {
+		switch name {
+		case "opencode":
+			return map[string]struct{}{
+				"/home/user/active-project": {},
+			}, nil
+		case "opencode-flaky":
+			return nil, errors.New("pgrep failed")
+		}
+		return nil, nil
+	}
+
+	deleted := newPIDManagerForTestWithLiveCWDs(repo, processNames, liveCWDs).CleanupZombies()
+	if deleted != 1 {
+		t.Errorf("CleanupZombies returned %d, want 1 (only opencode-orphan)", deleted)
+	}
+	if repo.states["opencode-orphan"] != nil {
+		t.Error("opencode-orphan should have been deleted (no live process for its CWD)")
+	}
+	for _, id := range []string{"opencode-live", "unknown-adapter", "opencode-lookup-error"} {
+		if repo.states[id] == nil {
+			t.Errorf("session %q should have been kept", id)
 		}
 	}
 }

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -127,6 +127,8 @@ func NewSessionDetector(
 	version string,
 	readyTTL time.Duration,
 	pidDiscovers map[string]agent.PIDDiscoverFunc,
+	processNames map[string]string,
+	liveCWDs LiveCWDsFunc,
 ) *SessionDetector {
 	det := &SessionDetector{
 		watchers:          watchers,
@@ -144,7 +146,7 @@ func NewSessionDetector(
 	}
 	det.pidMgr = NewPIDManager(
 		pw, repo, log, broadcaster, readyTTL,
-		pidDiscovers, det.removeFromProjectSessions,
+		pidDiscovers, processNames, liveCWDs, det.removeFromProjectSessions,
 	)
 	det.pidMgr.SetChildDeletedHandler(det.reevaluateParent)
 	return det

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -633,7 +633,7 @@ func TestSessionDetector_Removed_PrunesMetricsLedger(t *testing.T) {
 	det := services.NewSessionDetector(
 		[]inbound.AgentWatcher{tw}, pw, repo,
 		&mockLogger{}, &mockGit{}, mm, nil,
-		"test", 0, nil,
+		"test", 0, nil, nil, nil,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1449,7 +1449,7 @@ func TestSessionDetector_ClearWithStaleMetadata_DeletesOldSessionImmediately(t *
 	det := services.NewSessionDetector(
 		[]inbound.AgentWatcher{tw}, pw, repo,
 		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 0, discovers,
+		"test", 0, discovers, nil, nil,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -2029,7 +2029,7 @@ func TestSessionDetector_ParentReleasedToReady_WhenChildSweptByLiveness(t *testi
 	det := services.NewSessionDetector(
 		[]inbound.AgentWatcher{tw}, pw, repo,
 		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 1*time.Second, nil,
+		"test", 1*time.Second, nil, nil, nil,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -204,7 +204,7 @@ func newDetector(
 	return services.NewSessionDetector(
 		[]inbound.AgentWatcher{tw}, pw, repo,
 		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 0, nil,
+		"test", 0, nil, nil, nil,
 	)
 }
 
@@ -219,7 +219,7 @@ func newDetectorWithMetrics(
 	return services.NewSessionDetector(
 		[]inbound.AgentWatcher{tw}, pw, repo,
 		&mockLogger{}, &mockGit{}, metrics, nil,
-		"test", 0, nil,
+		"test", 0, nil, nil, nil,
 	)
 }
 
@@ -239,6 +239,6 @@ func newDetectorWithCWDDiscovery(
 	return services.NewSessionDetector(
 		[]inbound.AgentWatcher{tw}, pw, repo,
 		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 0, discovers,
+		"test", 0, discovers, nil, nil,
 	)
 }

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -352,13 +352,14 @@ func main() {
 	}
 
 	pidDiscovers := agents.PIDDiscoverMap(agentCfgs)
+	processNames := agents.ProcessNameMap(agentCfgs)
 
 	// SessionDetector: orchestrates AgentWatchers + ProcessWatcher.
 	detector = services.NewSessionDetector(
 		watchers, pwPort,
 		cachedRepo, logger, gitResolver, metricsCollector, push,
 		Version, cfg.ReadySessionTTL,
-		pidDiscovers,
+		pidDiscovers, processNames, processlifecycle.LiveCWDs,
 	)
 	if costTracker != nil {
 		detector.SetCostTracker(costTracker)

--- a/core/e2e/concurrent_test.go
+++ b/core/e2e/concurrent_test.go
@@ -29,7 +29,7 @@ func TestScanner_TracksTwoConcurrentProcessesWithSameAgentName(t *testing.T) {
 	detector := services.NewSessionDetector(
 		[]inbound.AgentWatcher{scanner},
 		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil,
+		"test", 0, nil, nil, nil,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/core/e2e/crash_test.go
+++ b/core/e2e/crash_test.go
@@ -30,7 +30,7 @@ func TestSession_NoCancelledState_OnSIGKILL(t *testing.T) {
 	detector := services.NewSessionDetector(
 		[]inbound.AgentWatcher{scanner},
 		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil,
+		"test", 0, nil, nil, nil,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -55,7 +55,7 @@ func TestPreSession_DetectedBeforeTranscript(t *testing.T) {
 		&stubGit{},
 		&stubMetrics{},
 		nil, // no broadcaster
-		"test", 0, nil,
+		"test", 0, nil, nil, nil,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -126,7 +126,7 @@ func TestPreSession_ReplacedByRealSession(t *testing.T) {
 	detector := services.NewSessionDetector(
 		[]inbound.AgentWatcher{scanner, transcriptWatcher},
 		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil,
+		"test", 0, nil, nil, nil,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -211,7 +211,7 @@ func TestPreSession_CreatedDespiteHistoricalSession(t *testing.T) {
 	detector := services.NewSessionDetector(
 		[]inbound.AgentWatcher{scanner},
 		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil,
+		"test", 0, nil, nil, nil,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -262,7 +262,7 @@ func TestPreSession_SurvivesNeighbourSessionActivity(t *testing.T) {
 	detector := services.NewSessionDetector(
 		[]inbound.AgentWatcher{scanner},
 		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil,
+		"test", 0, nil, nil, nil,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -312,7 +312,7 @@ func TestPreSession_RemovedOnProcessExit(t *testing.T) {
 	detector := services.NewSessionDetector(
 		[]inbound.AgentWatcher{scanner},
 		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil,
+		"test", 0, nil, nil, nil,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/core/e2e/startup_cleanup_test.go
+++ b/core/e2e/startup_cleanup_test.go
@@ -71,7 +71,7 @@ func TestStartupCleanup_DeletesZombieFromPriorDaemonRun(t *testing.T) {
 	detector := services.NewSessionDetector(
 		[]inbound.AgentWatcher{},
 		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil,
+		"test", 0, nil, nil, nil,
 	)
 
 	deleted := detector.CleanupZombies()


### PR DESCRIPTION
## Problem

After upgrading to v0.3.12 the OpenCode adapter populates the menu bar with ghost session rows even when no `opencode` CLI is running. Reported with 5 stale rows across two project groups, two of them showing `working` / `waiting` state with old snippets ("Hi again!", a CO₂ paragraph) surfaced from historical transcript content.

## Root cause

Two layers:

1. **Watcher emits ghosts on every startup.** `scanSessions` in `core/adapters/inbound/agents/opencode/watcher.go` emits `EventNewSession` for every non-archived row in OpenCode's DB whose `time_updated` is within `maxAge` (default 5 days). It never checks whether `opencode` is actually running — a row in the DB is just history, but the watcher treats every row as live.

2. **Carryover state from the buggy v0.3.12 daemon never gets cleaned.** Once a ghost is written to disk under `~/Library/Application Support/Irrlicht/instances/`, neither branch of `CleanupZombies` removes it: `syscall.Kill` is gated on `PID > 0` and OpenCode sessions where PID discovery failed have `PID == 0`; `isStaleTranscript` short-circuits to `false` for any path containing `?` (the `?session=` suffix matches every OpenCode session).

## Fix

### Watcher: gate `EventNewSession` on a live process

Same liveness signal the JSONL adapters already use. New helper `processlifecycle.LiveCWDs(processName)` returns the set of CWDs currently held by live processes matching the name. The watcher gains a swappable `liveCWDs func() map[string]struct{}` hook (defaults to `processlifecycle.LiveCWDs("opencode")`).

In `scanSessions`, snapshot live CWDs once per scan. For each unknown session, only emit `EventNewSession` if its CWD is in the live set. Sessions whose process isn't live are still tracked — `cursor.lastTS` is seeded to `s.timeUpdated` so a later process start won't back-fill historical activity. A new `emitted` flag on `sessionCursor` lets a dormant session emit `EventNewSession` later when its process becomes live.

### Cleanup: extend `CleanupZombies` for DB-backed orphans

A new third predicate in `isStartupZombie`: PID=0 sessions whose `TranscriptPath` is DB-backed (contains `?`) and whose adapter has a registered process name are deleted iff no live process of that name owns the session's CWD. `LiveCWDsFunc` is injected as `services.LiveCWDsFunc` to preserve hexagonal layering (the services package can't import adapter packages).

`CleanupZombies` builds a per-sweep memoizing closure (`pm.newLiveLookupCache`) so M ghost candidates of the same adapter cost exactly 1 `pgrep` call, not M.

Plumbing: `processNames map[string]string` and `liveCWDs LiveCWDsFunc` threaded through `NewPIDManager` and `NewSessionDetector`. Built in `main.go` from `agents.ProcessNameMap(agentCfgs)` (new helper, mirrors `PIDDiscoverMap`). Tests pass `nil` to keep the branch disabled by default.

**Safety**: the new branch only deletes when `liveCWDs` returns a non-nil result with no error. On lookup failure or unregistered adapter, the session is kept — better to leave a stale row than wipe legitimate state on an inconclusive signal.

### Cursor GC

Tracked-but-not-emitted cursors used to stay in the watcher's `cursors` map forever — for users who accumulate many OpenCode sessions but rarely run the CLI, the map would grow without bound. New `gcExpiredCursors` runs at the end of every `scanSessions` and drops entries whose `lastObserved` (new wall-clock field on `sessionCursor`) predates the `maxAge` window. Tracked separately from `cur.lastTS` because `lastTS` only advances when `scanParts` sees a fresher part timestamp — a session whose `time_updated` bumps without new parts would otherwise look stale to the GC.

### DRY: shared DB-backed path predicate

`isDBBackedTranscriptPath` was duplicated inline in `helpers.go:isStaleTranscript` and as a separate helper in `pid_manager.go`. Promoted to `helpers.go` with a named `dbBackedPathSentinel = '?'` constant; the staleness check now reuses it. Single source of truth.

## Tests

- `TestScanSessions_NoLiveProcessSuppressesGhosts` — regression for the user's report; zero `EventNewSession` when `liveCWDs` returns empty.
- `TestScanSessions_EmitsWhenProcessBecomesLive` — dormant-then-live transition; session is gated out initially, then emitted (exactly once) when `opencode` starts in its CWD; only post-emit parts trigger `EventActivity` (no historical back-fill).
- `TestScanSessions_GCsExpiredCursors` — pins the cursor GC: bumped session survives, stale session is dropped.
- `TestCleanupZombies_DBBackedOrphan` — five assertions for the new cleanup branch (no-live → deleted; live-CWD-match → kept; unregistered adapter → kept; lookup error → kept) plus a call-count assertion that pins the per-sweep cache (each adapter looked up at most once even with multiple ghost candidates).
- `setupTestDB` installs a default `liveCWDs` stub that auto-discovers CWDs from the test DB so existing tests behave as before.

## Test plan

- [x] `go test ./core/... -race -count=1` — all green
- [x] `tools/replay-fixtures.sh` — no goldens drifted
- [x] End-to-end on the reporter's box: 5 → 0 OpenCode ghosts after the watcher fix lands
- [x] End-to-end carryover-cleanup: seeded a synthetic ghost JSON whose CWD has no live opencode → deleted by `CleanupZombies` on next daemon start; 0 rows surface in `/api/v1/sessions`

## Out of scope

- `helpers.go:isStaleTranscript`'s `?session=` short-circuit stays. With ghosts no longer entering the repo and the cleanup branch handling carryover state, the orphan-cleanup gate isn't load-bearing for this symptom.
- Subagents in distinct CWDs from their parent: would be hidden by this gate. Not seen in current OpenCode behavior; future problem if it changes.
- `pgrep` / `lsof` caching in the watcher hot path: 0.2-1% overhead at the 500ms scan debounce, premature.

## Commits

1. `fix(opencode): suppress ghost sessions when no opencode process is live` — watcher gate
2. `fix(opencode): clean up carryover ghost state on startup` — `CleanupZombies` DB-backed-orphan branch
3. `review(opencode): GC stale cursors, drop dead initialArchiveCleanupWindow` — review follow-ups (cursor GC, dropped a no-op archive-window tweak)
4. `simplify(opencode): consolidate DB-backed predicate, cache liveCWDs lookup` — DRY pass + per-sweep cache for `liveCWDs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)