### PR TITLE
docs(landing): mark OpenCode alpha; teach release skill the landing-page grid

### DIFF
--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -61,8 +61,10 @@ rely on a hardcoded list — enumerate the targets dynamically so new pages
 can't be silently missed:
 
 ```bash
-# Files in scope for the sweep
-ls site/docs/*.html
+# Files in scope for the sweep — top-level site/*.html (the landing page
+# carries its own compatibility grid, separate from site/docs/), the docs
+# pages, and every top-level README.
+ls site/*.html site/docs/*.html
 echo README.md AGENTS.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md
 
 # What changed in this release — drives which pages are likely affected
@@ -82,8 +84,9 @@ typically owns the surface:
 | `core/application/services/**`, `core/domain/session/**` | `site/docs/state-machine.html`, `site/docs/session-detection.html` |
 | `site/install.sh`, `tools/homebrew-tap/**`, install flow | `site/docs/installation.html`, `site/docs/quickstart.html`, `README.md` install section |
 | Config schema / settings files | `site/docs/configuration.html` |
-| New agent adapter shipped | README compatibility grid + `site/docs/adapters.html` per-adapter row |
-| New platform shipped | README + `site/docs/index.html` overview |
+| New agent adapter shipped | README compatibility grid + `site/index.html` "Supported Agents & Platforms" grid (search for `tag-planned` / `tag-alpha`) + `site/docs/adapters.html` per-adapter row |
+| Adapter maturity-stage change | Same three places as "new adapter shipped" — README, landing page grid, adapters doc |
+| New platform shipped | README + `site/index.html` "Supported Agents & Platforms" grid (Platforms column) + `site/docs/index.html` overview |
 
 Update only where content is actually outdated — do **not** paraphrase
 correct content for the sake of touching the file. If a doc is fine, leave

--- a/site/index.html
+++ b/site/index.html
@@ -1587,7 +1587,7 @@ footer {
         <div class="supported-item">
           <div class="si-dot"></div>
           <span class="si-name">OpenCode</span>
-          <span class="si-tag tag-planned">planned</span>
+          <span class="si-tag tag-alpha">alpha</span>
         </div>
         <div class="supported-item">
           <div class="si-dot"></div>


### PR DESCRIPTION
Fixes #297.

## Problem

Landing page (\`site/index.html\`) still tagged OpenCode as \`planned\` even though the adapter shipped in v0.3.12 (#255). The README compatibility grid and \`site/docs/adapters.html\` were bumped to \`alpha\` during the v0.3.12 release sweep, but the parallel grid on the landing page wasn't.

## Why it slipped through

\`.claude/skills/ir:release/skill.md\` Step 4b ("Doc + README sweep"):
- The dynamic enumeration only scanned \`site/docs/*.html\`. Top-level \`site/*.html\` was invisible, so \`site/index.html\` was only touched by Step 3 (version-string substitution).
- The trigger-table row for "New agent adapter shipped" named only the README and \`site/docs/adapters.html\`.

## Fix

- \`site/index.html\`: OpenCode \`planned\` → \`alpha\` (matches the README + adapters doc).
- \`.claude/skills/ir:release/skill.md\`:
  - Step 4b enumeration now scans \`site/*.html\` in addition to \`site/docs/*.html\`.
  - Trigger-table row for "New agent adapter shipped" names \`site/index.html\`'s "Supported Agents & Platforms" grid alongside README + adapters doc.
  - New "Adapter maturity-stage change" row so future alpha→beta promotions don't slip through.
  - "New platform shipped" row updated to mention the landing-page grid too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)