### PR TITLE
docs(readme): add supported platforms table

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ Stages: `stable` production-ready · `beta` feature-complete, edge cases remain 
 | Claude Squad          | planned |
 | Custom (plugin API)   | planned |
 
+**Platforms**
+
+| Platform              | Stage   |
+| --------------------- | ------- |
+| macOS (menu bar app)  | beta    |
+| Web dashboard         | alpha   |
+| Linux                 | planned |
+| Windows               | planned |
+
 → [Adapters reference](https://ingo-eichhorst.github.io/Irrlicht/docs/adapters.html#maturity-stages) for stage criteria, watch paths, model detection, and roadmap.
 
 ## Posture


### PR DESCRIPTION
## Summary
- Adds a **Platforms** table to the README, just below the Agents and Orchestrators tables
- Mirrors the stages already shown on the landing page: macOS (beta), Web dashboard (alpha), Linux (planned), Windows (planned)

## Test plan
- [x] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)