### PR TITLE
docs(readme): add CLI to platforms table with access references

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,13 @@ Stages: `stable` production-ready · `beta` feature-complete, edge cases remain 
 
 **Platforms**
 
-| Platform              | Stage   |
-| --------------------- | ------- |
-| macOS (menu bar app)  | beta    |
-| Web dashboard         | alpha   |
-| Linux                 | planned |
-| Windows               | planned |
+| Platform              | Stage   | Access                    |
+| --------------------- | ------- | ------------------------- |
+| macOS (menu bar app)  | beta    | Menu bar                  |
+| Web dashboard         | alpha   | `http://127.0.0.1:7837`   |
+| CLI                   | alpha   | `irrlicht-ls` (`-w` for watch) |
+| Linux                 | planned | —                         |
+| Windows               | planned | —                         |
 
 → [Adapters reference](https://ingo-eichhorst.github.io/Irrlicht/docs/adapters.html#maturity-stages) for stage criteria, watch paths, model detection, and roadmap.
 


### PR DESCRIPTION
## Summary
- Adds **CLI** (`irrlicht-ls`, alpha) to the platforms table
- Adds an **Access** column showing how to reach each surface: `Menu bar` for macOS, `http://127.0.0.1:7837` for web, `irrlicht-ls` for CLI

## Test plan
- [x] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)