### PR TITLE
docs(readme): link macOS access cell to releases page

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Stages: `stable` production-ready · `beta` feature-complete, edge cases remain 
 
 | Platform              | Stage   | Access                    |
 | --------------------- | ------- | ------------------------- |
-| macOS (menu bar app)  | beta    | Menu bar                  |
+| macOS (menu bar app)  | beta    | [Releases](https://github.com/ingo-eichhorst/Irrlicht/releases/latest) |
 | Web dashboard         | alpha   | `http://127.0.0.1:7837`   |
 | CLI                   | alpha   | `irrlicht-ls` (`-w` for watch) |
 | Linux                 | planned | —                         |


### PR DESCRIPTION
## Summary
- Replaces the macOS access cell ("Menu bar") with a link to the GitHub Releases download page

## Test plan
- [x] README renders correctly on GitHub
- [x] Link resolves to latest release

🤖 Generated with [Claude Code](https://claude.com/claude-code)