### PR TITLE
fix(claudecode): catch AskUserQuestion via PreToolUse hook (#307)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -25,35 +25,32 @@ const hookSentinel = "localhost:7837/api/v1/hooks/claudecode"
 // doesn't surface "connection refused" as a PostToolUse hook error.
 const installedHookCommand = "curl -fsS --max-time 1 -X POST --data-binary @- http://localhost:7837/api/v1/hooks/claudecode || true"
 
-// hookMatcherDefault filters which tools trigger the permission-style hooks.
-// PermissionRequest only fires for tools that need permission, but
-// PostToolUse/PostToolUseFailure fire for all completions — the matcher
-// reduces noise for the latter.
-const hookMatcherDefault = "Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*"
+// hookMatcher is the matcher used by PermissionRequest, PostToolUse, and
+// PostToolUseFailure. AskUserQuestion / ExitPlanMode are included so the
+// PostToolUse clearing edge fires for user-input overlays too (issue #307).
+// PermissionRequest only fires for tools that actually need permission, so
+// the extra alternatives are no-ops there.
+const hookMatcher = "Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*|AskUserQuestion|ExitPlanMode"
 
-// hookMatcherUserInput is the matcher for user-blocking tools that suspend the
-// agent waiting for user input. PreToolUse fires synchronously when the model
-// emits the tool_use (before the transcript is flushed), so the daemon flips
-// to waiting immediately; the paired PostToolUse group clears the flag once
-// the user answers. (Issue #307.)
-const hookMatcherUserInput = "AskUserQuestion|ExitPlanMode"
+// hookMatcherPreToolUse is the narrow matcher for the PreToolUse event. We
+// only want to flip working→waiting on the user-input tools — matching every
+// Bash/Write/… would set permissionPending on every tool call. (Issue #307.)
+const hookMatcherPreToolUse = "AskUserQuestion|ExitPlanMode"
 
-// hookSpec is a single (event, matcher) entry we manage in settings.json.
-// We may install multiple groups under the same event (e.g. PostToolUse has
-// both the default matcher and the user-input matcher).
-type hookSpec struct {
-	event   string
-	matcher string
+// installedHookEvents are the Claude Code hook events we install handlers for.
+var installedHookEvents = []string{
+	HookPermissionRequest,
+	HookPreToolUse,
+	HookPostToolUse,
+	HookPostToolUseFailure,
 }
 
-// installedHooks is the set of hook groups irrlicht manages. Each entry maps
-// to one matcher group under the named event in ~/.claude/settings.json.
-var installedHooks = []hookSpec{
-	{HookPermissionRequest, hookMatcherDefault},
-	{HookPostToolUse, hookMatcherDefault},
-	{HookPostToolUseFailure, hookMatcherDefault},
-	{HookPreToolUse, hookMatcherUserInput},
-	{HookPostToolUse, hookMatcherUserInput},
+// matcherForEvent returns the tool matcher we install for the given event.
+func matcherForEvent(event string) string {
+	if event == HookPreToolUse {
+		return hookMatcherPreToolUse
+	}
+	return hookMatcher
 }
 
 // EnsureHooksInstalled adds irrlicht hook entries to ~/.claude/settings.json
@@ -73,16 +70,16 @@ func EnsureHooksInstalled() (bool, error) {
 	hooksMap := ensureHooksMap(settings)
 
 	modified := false
-	// Upgrade stale sentinel commands once per event (matcher-agnostic).
-	for _, event := range uniqueHookEvents() {
+	for _, event := range installedHookEvents {
+		expected := matcherForEvent(event)
 		if upgradeStaleHookCommands(hooksMap, event) {
 			modified = true
 		}
-	}
-	// Install any missing (event, matcher) group.
-	for _, spec := range installedHooks {
-		if !hasOurHook(hooksMap, spec.event, spec.matcher) {
-			addOurHook(hooksMap, spec.event, spec.matcher)
+		if upgradeStaleHookMatchers(hooksMap, event, expected) {
+			modified = true
+		}
+		if !hasOurHook(hooksMap, event) {
+			addOurHook(hooksMap, event, expected)
 			modified = true
 		}
 	}
@@ -117,7 +114,7 @@ func UninstallHooks() (bool, error) {
 	}
 
 	modified := false
-	for _, event := range uniqueHookEvents() {
+	for _, event := range installedHookEvents {
 		if removeOurHook(hooksMap, event) {
 			modified = true
 		}
@@ -185,62 +182,20 @@ func ensureHooksMap(settings map[string]interface{}) map[string]interface{} {
 	return m
 }
 
-// hasOurHook checks if a matcher group with the given matcher AND our sentinel
-// command already exists in the event's hook array. Both (event, matcher)
-// dimensions are required so we can install multiple groups per event
-// (e.g. PostToolUse has both the default matcher and the user-input matcher).
-func hasOurHook(hooksMap map[string]interface{}, event, matcher string) bool {
-	arr, ok := hooksMap[event]
+// hasOurHook checks if any matcher group containing our sentinel command
+// already exists in the event's hook array. Matcher-agnostic: a group with
+// our sentinel is "ours" regardless of which matcher string it carries.
+func hasOurHook(hooksMap map[string]interface{}, event string) bool {
+	arr, ok := hooksMap[event].([]interface{})
 	if !ok {
 		return false
 	}
-	groups, ok := arr.([]interface{})
-	if !ok {
-		return false
-	}
-	for _, g := range groups {
-		group, ok := g.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if m, _ := group["matcher"].(string); m != matcher {
-			continue
-		}
-		innerArr, ok := group["hooks"]
-		if !ok {
-			continue
-		}
-		innerHooks, ok := innerArr.([]interface{})
-		if !ok {
-			continue
-		}
-		for _, h := range innerHooks {
-			hook, ok := h.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if cmd, ok := hook["command"].(string); ok && strings.Contains(cmd, hookSentinel) {
-				return true
-			}
+	for _, g := range arr {
+		if containsHookSentinel(g) {
+			return true
 		}
 	}
 	return false
-}
-
-// uniqueHookEvents returns the distinct event names across installedHooks,
-// preserving order of first appearance. Used for per-event operations
-// (stale-command upgrade, uninstall) that don't depend on the matcher.
-func uniqueHookEvents() []string {
-	seen := make(map[string]bool, len(installedHooks))
-	events := make([]string, 0, len(installedHooks))
-	for _, spec := range installedHooks {
-		if seen[spec.event] {
-			continue
-		}
-		seen[spec.event] = true
-		events = append(events, spec.event)
-	}
-	return events
 }
 
 // upgradeStaleHookCommands rewrites any hook command that contains hookSentinel
@@ -248,25 +203,17 @@ func uniqueHookEvents() []string {
 // rewritten. This migrates users whose settings.json still has an older form
 // of our command (e.g., missing the trailing `|| true`).
 func upgradeStaleHookCommands(hooksMap map[string]interface{}, event string) bool {
-	arr, ok := hooksMap[event]
-	if !ok {
-		return false
-	}
-	groups, ok := arr.([]interface{})
+	arr, ok := hooksMap[event].([]interface{})
 	if !ok {
 		return false
 	}
 	upgraded := false
-	for _, g := range groups {
+	for _, g := range arr {
 		group, ok := g.(map[string]interface{})
 		if !ok {
 			continue
 		}
-		innerArr, ok := group["hooks"]
-		if !ok {
-			continue
-		}
-		innerHooks, ok := innerArr.([]interface{})
+		innerHooks, ok := group["hooks"].([]interface{})
 		if !ok {
 			continue
 		}
@@ -283,6 +230,33 @@ func upgradeStaleHookCommands(hooksMap map[string]interface{}, event string) boo
 				hook["command"] = installedHookCommand
 				upgraded = true
 			}
+		}
+	}
+	return upgraded
+}
+
+// upgradeStaleHookMatchers rewrites the matcher of any group containing our
+// sentinel whose matcher differs from the expected value. Used to migrate
+// existing installs when we widen (or change) the matcher for an event — for
+// example, the #307 expansion that adds AskUserQuestion|ExitPlanMode to the
+// PostToolUse matcher.
+func upgradeStaleHookMatchers(hooksMap map[string]interface{}, event, expected string) bool {
+	arr, ok := hooksMap[event].([]interface{})
+	if !ok {
+		return false
+	}
+	upgraded := false
+	for _, g := range arr {
+		group, ok := g.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if !containsHookSentinel(g) {
+			continue
+		}
+		if m, _ := group["matcher"].(string); m != expected {
+			group["matcher"] = expected
+			upgraded = true
 		}
 	}
 	return upgraded
@@ -313,18 +287,14 @@ func addOurHook(hooksMap map[string]interface{}, event, matcher string) {
 // removeOurHook removes matcher groups containing our sentinel from the event's
 // array. Returns true if any were removed.
 func removeOurHook(hooksMap map[string]interface{}, event string) bool {
-	arr, ok := hooksMap[event]
-	if !ok {
-		return false
-	}
-	groups, ok := arr.([]interface{})
+	arr, ok := hooksMap[event].([]interface{})
 	if !ok {
 		return false
 	}
 
 	var kept []interface{}
 	removed := false
-	for _, g := range groups {
+	for _, g := range arr {
 		if containsHookSentinel(g) {
 			removed = true
 			continue
@@ -349,11 +319,7 @@ func containsHookSentinel(g interface{}) bool {
 	if !ok {
 		return false
 	}
-	innerArr, ok := group["hooks"]
-	if !ok {
-		return false
-	}
-	innerHooks, ok := innerArr.([]interface{})
+	innerHooks, ok := group["hooks"].([]interface{})
 	if !ok {
 		return false
 	}

--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -1,7 +1,7 @@
 // hookinstaller.go manages Claude Code hook entries in ~/.claude/settings.json
-// for the irrlicht daemon. It installs PermissionRequest, PostToolUse, and
-// PostToolUseFailure hooks that POST to the daemon's HTTP endpoint, and can
-// remove them cleanly. (Issue #108.)
+// for the irrlicht daemon. It installs PermissionRequest, PreToolUse,
+// PostToolUse, and PostToolUseFailure hooks that POST to the daemon's HTTP
+// endpoint, and can remove them cleanly. (Issues #108, #307.)
 package claudecode
 
 import (
@@ -25,13 +25,36 @@ const hookSentinel = "localhost:7837/api/v1/hooks/claudecode"
 // doesn't surface "connection refused" as a PostToolUse hook error.
 const installedHookCommand = "curl -fsS --max-time 1 -X POST --data-binary @- http://localhost:7837/api/v1/hooks/claudecode || true"
 
-// hookMatcher filters which tools trigger the hooks. PermissionRequest only
-// fires for tools that need permission, but PostToolUse/PostToolUseFailure
-// fire for all completions — the matcher reduces noise for the latter.
-const hookMatcher = "Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*"
+// hookMatcherDefault filters which tools trigger the permission-style hooks.
+// PermissionRequest only fires for tools that need permission, but
+// PostToolUse/PostToolUseFailure fire for all completions — the matcher
+// reduces noise for the latter.
+const hookMatcherDefault = "Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*"
 
-// installedHookEvents are the Claude Code hook events we install handlers for.
-var installedHookEvents = []string{HookPermissionRequest, HookPostToolUse, HookPostToolUseFailure}
+// hookMatcherUserInput is the matcher for user-blocking tools that suspend the
+// agent waiting for user input. PreToolUse fires synchronously when the model
+// emits the tool_use (before the transcript is flushed), so the daemon flips
+// to waiting immediately; the paired PostToolUse group clears the flag once
+// the user answers. (Issue #307.)
+const hookMatcherUserInput = "AskUserQuestion|ExitPlanMode"
+
+// hookSpec is a single (event, matcher) entry we manage in settings.json.
+// We may install multiple groups under the same event (e.g. PostToolUse has
+// both the default matcher and the user-input matcher).
+type hookSpec struct {
+	event   string
+	matcher string
+}
+
+// installedHooks is the set of hook groups irrlicht manages. Each entry maps
+// to one matcher group under the named event in ~/.claude/settings.json.
+var installedHooks = []hookSpec{
+	{HookPermissionRequest, hookMatcherDefault},
+	{HookPostToolUse, hookMatcherDefault},
+	{HookPostToolUseFailure, hookMatcherDefault},
+	{HookPreToolUse, hookMatcherUserInput},
+	{HookPostToolUse, hookMatcherUserInput},
+}
 
 // EnsureHooksInstalled adds irrlicht hook entries to ~/.claude/settings.json
 // if they are not already present. Creates the file if it doesn't exist.
@@ -50,12 +73,16 @@ func EnsureHooksInstalled() (bool, error) {
 	hooksMap := ensureHooksMap(settings)
 
 	modified := false
-	for _, event := range installedHookEvents {
+	// Upgrade stale sentinel commands once per event (matcher-agnostic).
+	for _, event := range uniqueHookEvents() {
 		if upgradeStaleHookCommands(hooksMap, event) {
 			modified = true
 		}
-		if !hasOurHook(hooksMap, event) {
-			addOurHook(hooksMap, event)
+	}
+	// Install any missing (event, matcher) group.
+	for _, spec := range installedHooks {
+		if !hasOurHook(hooksMap, spec.event, spec.matcher) {
+			addOurHook(hooksMap, spec.event, spec.matcher)
 			modified = true
 		}
 	}
@@ -90,7 +117,7 @@ func UninstallHooks() (bool, error) {
 	}
 
 	modified := false
-	for _, event := range installedHookEvents {
+	for _, event := range uniqueHookEvents() {
 		if removeOurHook(hooksMap, event) {
 			modified = true
 		}
@@ -158,9 +185,11 @@ func ensureHooksMap(settings map[string]interface{}) map[string]interface{} {
 	return m
 }
 
-// hasOurHook checks if a matcher group with our sentinel command already exists
-// in the given event's hook array.
-func hasOurHook(hooksMap map[string]interface{}, event string) bool {
+// hasOurHook checks if a matcher group with the given matcher AND our sentinel
+// command already exists in the event's hook array. Both (event, matcher)
+// dimensions are required so we can install multiple groups per event
+// (e.g. PostToolUse has both the default matcher and the user-input matcher).
+func hasOurHook(hooksMap map[string]interface{}, event, matcher string) bool {
 	arr, ok := hooksMap[event]
 	if !ok {
 		return false
@@ -172,6 +201,9 @@ func hasOurHook(hooksMap map[string]interface{}, event string) bool {
 	for _, g := range groups {
 		group, ok := g.(map[string]interface{})
 		if !ok {
+			continue
+		}
+		if m, _ := group["matcher"].(string); m != matcher {
 			continue
 		}
 		innerArr, ok := group["hooks"]
@@ -193,6 +225,22 @@ func hasOurHook(hooksMap map[string]interface{}, event string) bool {
 		}
 	}
 	return false
+}
+
+// uniqueHookEvents returns the distinct event names across installedHooks,
+// preserving order of first appearance. Used for per-event operations
+// (stale-command upgrade, uninstall) that don't depend on the matcher.
+func uniqueHookEvents() []string {
+	seen := make(map[string]bool, len(installedHooks))
+	events := make([]string, 0, len(installedHooks))
+	for _, spec := range installedHooks {
+		if seen[spec.event] {
+			continue
+		}
+		seen[spec.event] = true
+		events = append(events, spec.event)
+	}
+	return events
 }
 
 // upgradeStaleHookCommands rewrites any hook command that contains hookSentinel
@@ -241,9 +289,9 @@ func upgradeStaleHookCommands(hooksMap map[string]interface{}, event string) boo
 }
 
 // addOurHook appends a matcher group with our hook command to the event's array.
-func addOurHook(hooksMap map[string]interface{}, event string) {
+func addOurHook(hooksMap map[string]interface{}, event, matcher string) {
 	entry := map[string]interface{}{
-		"matcher": hookMatcher,
+		"matcher": matcher,
 		"hooks": []interface{}{
 			map[string]interface{}{
 				"type":    "command",

--- a/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
@@ -47,7 +47,7 @@ func TestEnsureHooksInstalled_CreatesFileIfAbsent(t *testing.T) {
 		t.Fatal("missing hooks map")
 	}
 
-	for _, event := range installedHookEvents {
+	for _, event := range uniqueHookEvents() {
 		arr, ok := hooksMap[event].([]interface{})
 		if !ok || len(arr) == 0 {
 			t.Errorf("missing hook array for %s", event)
@@ -106,7 +106,7 @@ func TestEnsureHooksInstalled_PreservesExistingHooks(t *testing.T) {
 	hooksMap := settings["hooks"].(map[string]interface{})
 
 	// Our hooks should be added.
-	for _, event := range installedHookEvents {
+	for _, event := range uniqueHookEvents() {
 		if _, ok := hooksMap[event]; !ok {
 			t.Errorf("missing hook for %s", event)
 		}
@@ -130,7 +130,7 @@ func TestEnsureHooksInstalled_UpgradesStaleCommand(t *testing.T) {
 	}
 
 	staleGroup := map[string]interface{}{
-		"matcher": hookMatcher,
+		"matcher": hookMatcherDefault,
 		"hooks": []interface{}{
 			map[string]interface{}{
 				"type":    "command",
@@ -166,12 +166,27 @@ func TestEnsureHooksInstalled_UpgradesStaleCommand(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing %s array after upgrade", HookPostToolUse)
 	}
-	if len(postArr) != 1 {
-		t.Fatalf("expected 1 %s matcher group (in-place upgrade, no append), got %d", HookPostToolUse, len(postArr))
+	// Two groups expected: the upgraded default-matcher group (in place,
+	// no append) plus the narrow user-input matcher group added on first
+	// install. (#307)
+	if len(postArr) != 2 {
+		t.Fatalf("expected 2 %s matcher groups (default upgrade + user-input add), got %d", HookPostToolUse, len(postArr))
 	}
 
-	group := postArr[0].(map[string]interface{})
-	innerHooks := group["hooks"].([]interface{})
+	// Find the default-matcher group — that's the one that should have been
+	// upgraded in place from the stale command.
+	var defaultGroup map[string]interface{}
+	for _, g := range postArr {
+		group := g.(map[string]interface{})
+		if m, _ := group["matcher"].(string); m == hookMatcherDefault {
+			defaultGroup = group
+			break
+		}
+	}
+	if defaultGroup == nil {
+		t.Fatalf("missing default-matcher %s group after upgrade", HookPostToolUse)
+	}
+	innerHooks := defaultGroup["hooks"].([]interface{})
 	cmd := innerHooks[0].(map[string]interface{})["command"].(string)
 	if cmd != installedHookCommand {
 		t.Fatalf("expected upgraded command, got %q", cmd)
@@ -210,7 +225,7 @@ func TestUninstallHooks_RemovesOurHooks(t *testing.T) {
 		return
 	}
 
-	for _, event := range installedHookEvents {
+	for _, event := range uniqueHookEvents() {
 		if _, ok := hooksMap[event]; ok {
 			t.Errorf("hook for %s should have been removed", event)
 		}
@@ -257,6 +272,141 @@ func TestUninstallHooks_PreservesOtherHooks(t *testing.T) {
 	permArr, ok := hooksMap["PermissionRequest"].([]interface{})
 	if !ok || len(permArr) != 1 {
 		t.Fatalf("expected 1 remaining PermissionRequest group, got %d", len(permArr))
+	}
+}
+
+// TestEnsureHooksInstalled_InstallsUserInputGroups verifies that a fresh
+// install writes both the PreToolUse and a second PostToolUse matcher group
+// scoped to AskUserQuestion|ExitPlanMode. (Issue #307.)
+func TestEnsureHooksInstalled_InstallsUserInputGroups(t *testing.T) {
+	home := withTempHome(t)
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := readJSON(t, filepath.Join(home, ".claude", "settings.json"))
+	hooksMap := settings["hooks"].(map[string]interface{})
+
+	// PreToolUse should have exactly one group with the user-input matcher.
+	pre, ok := hooksMap[HookPreToolUse].([]interface{})
+	if !ok || len(pre) != 1 {
+		t.Fatalf("expected 1 PreToolUse group, got %d", len(pre))
+	}
+	preGroup := pre[0].(map[string]interface{})
+	if m, _ := preGroup["matcher"].(string); m != hookMatcherUserInput {
+		t.Errorf("PreToolUse matcher = %q, want %q", m, hookMatcherUserInput)
+	}
+
+	// PostToolUse should have both the default-matcher group and the
+	// user-input matcher group.
+	post, ok := hooksMap[HookPostToolUse].([]interface{})
+	if !ok || len(post) != 2 {
+		t.Fatalf("expected 2 PostToolUse groups, got %d", len(post))
+	}
+	var sawDefault, sawUserInput bool
+	for _, g := range post {
+		group := g.(map[string]interface{})
+		switch m, _ := group["matcher"].(string); m {
+		case hookMatcherDefault:
+			sawDefault = true
+		case hookMatcherUserInput:
+			sawUserInput = true
+		}
+	}
+	if !sawDefault || !sawUserInput {
+		t.Errorf("PostToolUse groups missing matcher: default=%v userInput=%v", sawDefault, sawUserInput)
+	}
+}
+
+// TestEnsureHooksInstalled_AppendsUserInputToLegacyInstall simulates an
+// existing irrlicht install from before issue #307: settings.json has the
+// default-matcher PostToolUse group but no narrow group. EnsureHooksInstalled
+// should leave the existing group alone and append the new narrow one.
+func TestEnsureHooksInstalled_AppendsUserInputToLegacyInstall(t *testing.T) {
+	home := withTempHome(t)
+	path := filepath.Join(home, ".claude", "settings.json")
+
+	// Legacy install: PermissionRequest, PostToolUse, PostToolUseFailure
+	// each with one default-matcher group containing our sentinel.
+	makeGroup := func() map[string]interface{} {
+		return map[string]interface{}{
+			"matcher": hookMatcherDefault,
+			"hooks": []interface{}{
+				map[string]interface{}{
+					"type":    "command",
+					"command": installedHookCommand,
+				},
+			},
+		}
+	}
+	existing := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			HookPermissionRequest:  []interface{}{makeGroup()},
+			HookPostToolUse:        []interface{}{makeGroup()},
+			HookPostToolUseFailure: []interface{}{makeGroup()},
+		},
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(existing)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true to add the new user-input groups")
+	}
+
+	settings := readJSON(t, path)
+	hooksMap := settings["hooks"].(map[string]interface{})
+
+	// PreToolUse should be brand new.
+	if _, ok := hooksMap[HookPreToolUse].([]interface{}); !ok {
+		t.Errorf("PreToolUse group not installed")
+	}
+
+	// PostToolUse should now have 2 groups: the original (untouched) and the new one.
+	post := hooksMap[HookPostToolUse].([]interface{})
+	if len(post) != 2 {
+		t.Fatalf("expected 2 PostToolUse groups after legacy upgrade, got %d", len(post))
+	}
+
+	// Second install is a no-op (idempotent).
+	modified, err = EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modified {
+		t.Fatal("expected modified=false on second install (idempotent)")
+	}
+}
+
+// TestUninstallHooks_RemovesNarrowGroups verifies uninstall sweeps both the
+// default-matcher and user-input matcher groups.
+func TestUninstallHooks_RemovesNarrowGroups(t *testing.T) {
+	home := withTempHome(t)
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := UninstallHooks(); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := readJSON(t, filepath.Join(home, ".claude", "settings.json"))
+	hooksMap, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		return // hooks key removed — acceptable
+	}
+	if _, ok := hooksMap[HookPreToolUse]; ok {
+		t.Error("PreToolUse should have been removed")
+	}
+	if _, ok := hooksMap[HookPostToolUse]; ok {
+		t.Error("PostToolUse should have been removed")
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
@@ -29,6 +29,11 @@ func readJSON(t *testing.T, path string) map[string]interface{} {
 	return m
 }
 
+// legacyMatcher is the pre-#307 PostToolUse matcher, used to seed test
+// fixtures that simulate an existing irrlicht install from before the
+// AskUserQuestion / ExitPlanMode expansion.
+const legacyMatcher = "Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*"
+
 func TestEnsureHooksInstalled_CreatesFileIfAbsent(t *testing.T) {
 	home := withTempHome(t)
 	modified, err := EnsureHooksInstalled()
@@ -47,7 +52,7 @@ func TestEnsureHooksInstalled_CreatesFileIfAbsent(t *testing.T) {
 		t.Fatal("missing hooks map")
 	}
 
-	for _, event := range uniqueHookEvents() {
+	for _, event := range installedHookEvents {
 		arr, ok := hooksMap[event].([]interface{})
 		if !ok || len(arr) == 0 {
 			t.Errorf("missing hook array for %s", event)
@@ -74,7 +79,7 @@ func TestEnsureHooksInstalled_PreservesExistingHooks(t *testing.T) {
 	home := withTempHome(t)
 	path := filepath.Join(home, ".claude", "settings.json")
 
-	// Pre-populate with an existing hook.
+	// Pre-populate with an existing foreign hook on PreToolUse.
 	existing := map[string]interface{}{
 		"hooks": map[string]interface{}{
 			"PreToolUse": []interface{}{
@@ -105,17 +110,17 @@ func TestEnsureHooksInstalled_PreservesExistingHooks(t *testing.T) {
 	settings := readJSON(t, path)
 	hooksMap := settings["hooks"].(map[string]interface{})
 
-	// Our hooks should be added.
-	for _, event := range uniqueHookEvents() {
+	// Our hooks should be added for all managed events.
+	for _, event := range installedHookEvents {
 		if _, ok := hooksMap[event]; !ok {
 			t.Errorf("missing hook for %s", event)
 		}
 	}
 
-	// Existing hook should be preserved.
+	// Foreign PreToolUse group should be preserved (alongside our new one).
 	preToolUse, ok := hooksMap["PreToolUse"].([]interface{})
-	if !ok || len(preToolUse) == 0 {
-		t.Error("existing PreToolUse hook was removed")
+	if !ok || len(preToolUse) < 2 {
+		t.Errorf("expected at least 2 PreToolUse groups (foreign + ours), got %d", len(preToolUse))
 	}
 }
 
@@ -129,8 +134,11 @@ func TestEnsureHooksInstalled_UpgradesStaleCommand(t *testing.T) {
 		t.Fatal("stale command must differ from canonical command for this test to be meaningful")
 	}
 
+	// Legacy install: a single PostToolUse group with the pre-#307 narrow
+	// matcher and the stale command. EnsureHooksInstalled should upgrade
+	// both the command and the matcher in place — no group append.
 	staleGroup := map[string]interface{}{
-		"matcher": hookMatcherDefault,
+		"matcher": legacyMatcher,
 		"hooks": []interface{}{
 			map[string]interface{}{
 				"type":    "command",
@@ -166,27 +174,15 @@ func TestEnsureHooksInstalled_UpgradesStaleCommand(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing %s array after upgrade", HookPostToolUse)
 	}
-	// Two groups expected: the upgraded default-matcher group (in place,
-	// no append) plus the narrow user-input matcher group added on first
-	// install. (#307)
-	if len(postArr) != 2 {
-		t.Fatalf("expected 2 %s matcher groups (default upgrade + user-input add), got %d", HookPostToolUse, len(postArr))
+	if len(postArr) != 1 {
+		t.Fatalf("expected 1 %s matcher group (in-place upgrade, no append), got %d", HookPostToolUse, len(postArr))
 	}
 
-	// Find the default-matcher group — that's the one that should have been
-	// upgraded in place from the stale command.
-	var defaultGroup map[string]interface{}
-	for _, g := range postArr {
-		group := g.(map[string]interface{})
-		if m, _ := group["matcher"].(string); m == hookMatcherDefault {
-			defaultGroup = group
-			break
-		}
+	group := postArr[0].(map[string]interface{})
+	if m, _ := group["matcher"].(string); m != hookMatcher {
+		t.Errorf("expected matcher upgraded to %q, got %q", hookMatcher, m)
 	}
-	if defaultGroup == nil {
-		t.Fatalf("missing default-matcher %s group after upgrade", HookPostToolUse)
-	}
-	innerHooks := defaultGroup["hooks"].([]interface{})
+	innerHooks := group["hooks"].([]interface{})
 	cmd := innerHooks[0].(map[string]interface{})["command"].(string)
 	if cmd != installedHookCommand {
 		t.Fatalf("expected upgraded command, got %q", cmd)
@@ -225,7 +221,7 @@ func TestUninstallHooks_RemovesOurHooks(t *testing.T) {
 		return
 	}
 
-	for _, event := range uniqueHookEvents() {
+	for _, event := range installedHookEvents {
 		if _, ok := hooksMap[event]; ok {
 			t.Errorf("hook for %s should have been removed", event)
 		}
@@ -275,10 +271,11 @@ func TestUninstallHooks_PreservesOtherHooks(t *testing.T) {
 	}
 }
 
-// TestEnsureHooksInstalled_InstallsUserInputGroups verifies that a fresh
-// install writes both the PreToolUse and a second PostToolUse matcher group
-// scoped to AskUserQuestion|ExitPlanMode. (Issue #307.)
-func TestEnsureHooksInstalled_InstallsUserInputGroups(t *testing.T) {
+// TestEnsureHooksInstalled_InstallsPreToolUseAndExpandedMatcher verifies that
+// a fresh install writes the narrow PreToolUse group and uses the expanded
+// matcher (including AskUserQuestion|ExitPlanMode) for the clearing events.
+// (Issue #307.)
+func TestEnsureHooksInstalled_InstallsPreToolUseAndExpandedMatcher(t *testing.T) {
 	home := withTempHome(t)
 	if _, err := EnsureHooksInstalled(); err != nil {
 		t.Fatal(err)
@@ -287,50 +284,39 @@ func TestEnsureHooksInstalled_InstallsUserInputGroups(t *testing.T) {
 	settings := readJSON(t, filepath.Join(home, ".claude", "settings.json"))
 	hooksMap := settings["hooks"].(map[string]interface{})
 
-	// PreToolUse should have exactly one group with the user-input matcher.
+	// PreToolUse: one group with the narrow matcher.
 	pre, ok := hooksMap[HookPreToolUse].([]interface{})
 	if !ok || len(pre) != 1 {
 		t.Fatalf("expected 1 PreToolUse group, got %d", len(pre))
 	}
 	preGroup := pre[0].(map[string]interface{})
-	if m, _ := preGroup["matcher"].(string); m != hookMatcherUserInput {
-		t.Errorf("PreToolUse matcher = %q, want %q", m, hookMatcherUserInput)
+	if m, _ := preGroup["matcher"].(string); m != hookMatcherPreToolUse {
+		t.Errorf("PreToolUse matcher = %q, want %q", m, hookMatcherPreToolUse)
 	}
 
-	// PostToolUse should have both the default-matcher group and the
-	// user-input matcher group.
+	// PostToolUse: one group, matcher includes AskUserQuestion|ExitPlanMode.
 	post, ok := hooksMap[HookPostToolUse].([]interface{})
-	if !ok || len(post) != 2 {
-		t.Fatalf("expected 2 PostToolUse groups, got %d", len(post))
+	if !ok || len(post) != 1 {
+		t.Fatalf("expected 1 PostToolUse group, got %d", len(post))
 	}
-	var sawDefault, sawUserInput bool
-	for _, g := range post {
-		group := g.(map[string]interface{})
-		switch m, _ := group["matcher"].(string); m {
-		case hookMatcherDefault:
-			sawDefault = true
-		case hookMatcherUserInput:
-			sawUserInput = true
-		}
-	}
-	if !sawDefault || !sawUserInput {
-		t.Errorf("PostToolUse groups missing matcher: default=%v userInput=%v", sawDefault, sawUserInput)
+	postGroup := post[0].(map[string]interface{})
+	if m, _ := postGroup["matcher"].(string); m != hookMatcher {
+		t.Errorf("PostToolUse matcher = %q, want %q", m, hookMatcher)
 	}
 }
 
-// TestEnsureHooksInstalled_AppendsUserInputToLegacyInstall simulates an
-// existing irrlicht install from before issue #307: settings.json has the
-// default-matcher PostToolUse group but no narrow group. EnsureHooksInstalled
-// should leave the existing group alone and append the new narrow one.
-func TestEnsureHooksInstalled_AppendsUserInputToLegacyInstall(t *testing.T) {
+// TestEnsureHooksInstalled_MigratesLegacyMatchers simulates a pre-#307
+// install where PermissionRequest/PostToolUse/PostToolUseFailure each have
+// a single managed group with the legacy narrow matcher. EnsureHooksInstalled
+// must rewrite those matchers to the expanded form in place (no group
+// append) and add the new PreToolUse group.
+func TestEnsureHooksInstalled_MigratesLegacyMatchers(t *testing.T) {
 	home := withTempHome(t)
 	path := filepath.Join(home, ".claude", "settings.json")
 
-	// Legacy install: PermissionRequest, PostToolUse, PostToolUseFailure
-	// each with one default-matcher group containing our sentinel.
 	makeGroup := func() map[string]interface{} {
 		return map[string]interface{}{
-			"matcher": hookMatcherDefault,
+			"matcher": legacyMatcher,
 			"hooks": []interface{}{
 				map[string]interface{}{
 					"type":    "command",
@@ -359,24 +345,31 @@ func TestEnsureHooksInstalled_AppendsUserInputToLegacyInstall(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !modified {
-		t.Fatal("expected modified=true to add the new user-input groups")
+		t.Fatal("expected modified=true to migrate matchers and add PreToolUse")
 	}
 
 	settings := readJSON(t, path)
 	hooksMap := settings["hooks"].(map[string]interface{})
 
-	// PreToolUse should be brand new.
-	if _, ok := hooksMap[HookPreToolUse].([]interface{}); !ok {
-		t.Errorf("PreToolUse group not installed")
+	// Legacy groups upgraded in place; still exactly one group per event.
+	for _, event := range []string{HookPermissionRequest, HookPostToolUse, HookPostToolUseFailure} {
+		arr := hooksMap[event].([]interface{})
+		if len(arr) != 1 {
+			t.Errorf("%s: expected 1 group after migration (in-place rewrite), got %d", event, len(arr))
+			continue
+		}
+		group := arr[0].(map[string]interface{})
+		if m, _ := group["matcher"].(string); m != hookMatcher {
+			t.Errorf("%s: matcher = %q, want %q (legacy not migrated)", event, m, hookMatcher)
+		}
 	}
 
-	// PostToolUse should now have 2 groups: the original (untouched) and the new one.
-	post := hooksMap[HookPostToolUse].([]interface{})
-	if len(post) != 2 {
-		t.Fatalf("expected 2 PostToolUse groups after legacy upgrade, got %d", len(post))
+	// PreToolUse is brand new.
+	if pre, ok := hooksMap[HookPreToolUse].([]interface{}); !ok || len(pre) != 1 {
+		t.Errorf("PreToolUse group not installed (groups=%d)", len(pre))
 	}
 
-	// Second install is a no-op (idempotent).
+	// Second install is idempotent.
 	modified, err = EnsureHooksInstalled()
 	if err != nil {
 		t.Fatal(err)
@@ -386,9 +379,9 @@ func TestEnsureHooksInstalled_AppendsUserInputToLegacyInstall(t *testing.T) {
 	}
 }
 
-// TestUninstallHooks_RemovesNarrowGroups verifies uninstall sweeps both the
-// default-matcher and user-input matcher groups.
-func TestUninstallHooks_RemovesNarrowGroups(t *testing.T) {
+// TestUninstallHooks_RemovesPreToolUseGroup ensures uninstall sweeps both
+// the new PreToolUse group and the existing clearing-event groups.
+func TestUninstallHooks_RemovesPreToolUseGroup(t *testing.T) {
 	home := withTempHome(t)
 	if _, err := EnsureHooksInstalled(); err != nil {
 		t.Fatal(err)

--- a/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
@@ -34,6 +34,20 @@ func readJSON(t *testing.T, path string) map[string]interface{} {
 // AskUserQuestion / ExitPlanMode expansion.
 const legacyMatcher = "Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*"
 
+// makeHookGroup builds a settings.json hook matcher group with the given
+// matcher and command. Used by tests to seed fixtures.
+func makeHookGroup(matcher, command string) map[string]interface{} {
+	return map[string]interface{}{
+		"matcher": matcher,
+		"hooks": []interface{}{
+			map[string]interface{}{
+				"type":    "command",
+				"command": command,
+			},
+		},
+	}
+}
+
 func TestEnsureHooksInstalled_CreatesFileIfAbsent(t *testing.T) {
 	home := withTempHome(t)
 	modified, err := EnsureHooksInstalled()
@@ -82,17 +96,7 @@ func TestEnsureHooksInstalled_PreservesExistingHooks(t *testing.T) {
 	// Pre-populate with an existing foreign hook on PreToolUse.
 	existing := map[string]interface{}{
 		"hooks": map[string]interface{}{
-			"PreToolUse": []interface{}{
-				map[string]interface{}{
-					"matcher": "Bash",
-					"hooks": []interface{}{
-						map[string]interface{}{
-							"type":    "command",
-							"command": "echo custom-hook",
-						},
-					},
-				},
-			},
+			"PreToolUse": []interface{}{makeHookGroup("Bash", "echo custom-hook")},
 		},
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -137,18 +141,9 @@ func TestEnsureHooksInstalled_UpgradesStaleCommand(t *testing.T) {
 	// Legacy install: a single PostToolUse group with the pre-#307 narrow
 	// matcher and the stale command. EnsureHooksInstalled should upgrade
 	// both the command and the matcher in place — no group append.
-	staleGroup := map[string]interface{}{
-		"matcher": legacyMatcher,
-		"hooks": []interface{}{
-			map[string]interface{}{
-				"type":    "command",
-				"command": staleCommand,
-			},
-		},
-	}
 	existing := map[string]interface{}{
 		"hooks": map[string]interface{}{
-			HookPostToolUse: []interface{}{staleGroup},
+			HookPostToolUse: []interface{}{makeHookGroup(legacyMatcher, staleCommand)},
 		},
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -241,17 +236,8 @@ func TestUninstallHooks_PreservesOtherHooks(t *testing.T) {
 	hooksMap := settings["hooks"].(map[string]interface{})
 
 	// Add a foreign matcher group to PermissionRequest.
-	foreignGroup := map[string]interface{}{
-		"matcher": "Bash",
-		"hooks": []interface{}{
-			map[string]interface{}{
-				"type":    "command",
-				"command": "echo foreign",
-			},
-		},
-	}
 	arr := hooksMap["PermissionRequest"].([]interface{})
-	hooksMap["PermissionRequest"] = append(arr, foreignGroup)
+	hooksMap["PermissionRequest"] = append(arr, makeHookGroup("Bash", "echo foreign"))
 	data, _ := json.MarshalIndent(settings, "", "  ")
 	if err := os.WriteFile(path, data, 0o644); err != nil {
 		t.Fatal(err)
@@ -314,22 +300,14 @@ func TestEnsureHooksInstalled_MigratesLegacyMatchers(t *testing.T) {
 	home := withTempHome(t)
 	path := filepath.Join(home, ".claude", "settings.json")
 
-	makeGroup := func() map[string]interface{} {
-		return map[string]interface{}{
-			"matcher": legacyMatcher,
-			"hooks": []interface{}{
-				map[string]interface{}{
-					"type":    "command",
-					"command": installedHookCommand,
-				},
-			},
-		}
+	legacy := func() []interface{} {
+		return []interface{}{makeHookGroup(legacyMatcher, installedHookCommand)}
 	}
 	existing := map[string]interface{}{
 		"hooks": map[string]interface{}{
-			HookPermissionRequest:  []interface{}{makeGroup()},
-			HookPostToolUse:        []interface{}{makeGroup()},
-			HookPostToolUseFailure: []interface{}{makeGroup()},
+			HookPermissionRequest:  legacy(),
+			HookPostToolUse:        legacy(),
+			HookPostToolUseFailure: legacy(),
 		},
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -1,7 +1,9 @@
 // hooks.go provides the HTTP handler for receiving Claude Code hook events.
-// Claude Code fires hooks on PermissionRequest, PostToolUse, and
-// PostToolUseFailure — the daemon uses these to surface permission-pending
-// state in the classifier (issue #108).
+// Claude Code fires hooks on PermissionRequest, PreToolUse, PostToolUse, and
+// PostToolUseFailure — the daemon uses these to surface user-blocking state
+// in the classifier. PermissionRequest covers permission gates (issue #108);
+// PreToolUse on AskUserQuestion / ExitPlanMode covers user-input overlays
+// that block the agent before the transcript is flushed (issue #307).
 package claudecode
 
 import (
@@ -15,9 +17,10 @@ import (
 )
 
 // Hook event names. Claude Code fires these; the daemon recognizes only
-// these three and ignores everything else.
+// these four and ignores everything else.
 const (
 	HookPermissionRequest  = "PermissionRequest"
+	HookPreToolUse         = "PreToolUse"
 	HookPostToolUse        = "PostToolUse"
 	HookPostToolUseFailure = "PostToolUseFailure"
 )
@@ -79,7 +82,7 @@ func NewHookHandler(target HookTarget, log outbound.Logger) http.HandlerFunc {
 		}
 
 		switch payload.HookEventName {
-		case HookPermissionRequest, HookPostToolUse, HookPostToolUseFailure:
+		case HookPermissionRequest, HookPreToolUse, HookPostToolUse, HookPostToolUseFailure:
 			log.LogInfo("hook-receiver", sessionID,
 				fmt.Sprintf("received %s (tool=%s)", payload.HookEventName, payload.ToolName))
 			target.HandlePermissionHook(sessionID, payload.TranscriptPath, payload.HookEventName)

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -25,6 +25,15 @@ const (
 	HookPostToolUseFailure = "PostToolUseFailure"
 )
 
+// Tool names that suspend the agent waiting for user input. PreToolUse hooks
+// must match one of these — anything else is rejected by the handler, even
+// if the matcher in settings.json was edited to be broader. Defense-in-depth
+// against the matcher being the sole filter.
+const (
+	toolAskUserQuestion = "AskUserQuestion"
+	toolExitPlanMode    = "ExitPlanMode"
+)
+
 // hookPayload is the JSON body sent by Claude Code hook events.
 // Only the fields used by the handler are decoded; the rest is ignored.
 type hookPayload struct {
@@ -81,11 +90,24 @@ func NewHookHandler(target HookTarget, log outbound.Logger) http.HandlerFunc {
 			return
 		}
 
-		switch payload.HookEventName {
-		case HookPermissionRequest, HookPreToolUse, HookPostToolUse, HookPostToolUseFailure:
+		dispatch := func() {
 			log.LogInfo("hook-receiver", sessionID,
 				fmt.Sprintf("received %s (tool=%s)", payload.HookEventName, payload.ToolName))
 			target.HandlePermissionHook(sessionID, payload.TranscriptPath, payload.HookEventName)
+		}
+
+		switch payload.HookEventName {
+		case HookPermissionRequest, HookPostToolUse, HookPostToolUseFailure:
+			dispatch()
+		case HookPreToolUse:
+			// Only dispatch for user-input tools; reject anything else even
+			// if the settings.json matcher was misconfigured to be broader.
+			if payload.ToolName == toolAskUserQuestion || payload.ToolName == toolExitPlanMode {
+				dispatch()
+			} else {
+				log.LogInfo("hook-receiver", sessionID,
+					fmt.Sprintf("ignored PreToolUse for unexpected tool %q", payload.ToolName))
+			}
 		default:
 			// Unrecognized hook event — accept but ignore.
 			log.LogInfo("hook-receiver", sessionID,

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -113,6 +113,37 @@ func TestHookHandler_PostToolUse(t *testing.T) {
 	}
 }
 
+func TestHookHandler_PreToolUse(t *testing.T) {
+	target := &mockTarget{}
+	handler := NewHookHandler(target, mockLogger{})
+
+	payload := hookPayload{
+		TranscriptPath: "/Users/u/.claude/projects/p/sess-pre.jsonl",
+		HookEventName:  "PreToolUse",
+		ToolName:       "AskUserQuestion",
+		ToolUseID:      "toolu_pre",
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	calls := target.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("got %d calls, want 1", len(calls))
+	}
+	if calls[0].sessionID != "sess-pre" {
+		t.Errorf("sessionID = %q, want %q", calls[0].sessionID, "sess-pre")
+	}
+	if calls[0].hookEventName != "PreToolUse" {
+		t.Errorf("hookEventName = %q, want %q", calls[0].hookEventName, "PreToolUse")
+	}
+}
+
 func TestHookHandler_PostToolUseFailure(t *testing.T) {
 	target := &mockTarget{}
 	handler := NewHookHandler(target, mockLogger{})

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -144,6 +144,34 @@ func TestHookHandler_PreToolUse(t *testing.T) {
 	}
 }
 
+// TestHookHandler_PreToolUse_RejectsUnexpectedTool verifies the defensive
+// guard: even if settings.json was edited so PreToolUse fires for, say, Bash,
+// the handler refuses to set the permission-pending flag. The matcher is not
+// the sole filter.
+func TestHookHandler_PreToolUse_RejectsUnexpectedTool(t *testing.T) {
+	target := &mockTarget{}
+	handler := NewHookHandler(target, mockLogger{})
+
+	payload := hookPayload{
+		TranscriptPath: "/Users/u/.claude/projects/p/sess-x.jsonl",
+		HookEventName:  "PreToolUse",
+		ToolName:       "Bash",
+		ToolUseID:      "toolu_bash",
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (handler should accept but ignore)", rec.Code, http.StatusOK)
+	}
+	if len(target.getCalls()) != 0 {
+		t.Errorf("PreToolUse for Bash should not dispatch; got %d calls", len(target.getCalls()))
+	}
+}
+
 func TestHookHandler_PostToolUseFailure(t *testing.T) {
 	target := &mockTarget{}
 	handler := NewHookHandler(target, mockLogger{})

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -79,15 +79,21 @@ func (d *SessionDetector) HandlePIDAssigned(pid int, sessionID string) {
 	d.pidMgr.HandlePIDAssigned(pid, sessionID)
 }
 
-// HandlePermissionHook processes a Claude Code PermissionRequest, PostToolUse,
-// or PostToolUseFailure hook event. It updates the in-memory permission-pending
-// flag and injects a synthetic activity event to trigger re-classification.
+// HandlePermissionHook processes a Claude Code PermissionRequest, PreToolUse,
+// PostToolUse, or PostToolUseFailure hook event. It updates the in-memory
+// permission-pending flag and injects a synthetic activity event to trigger
+// re-classification.
+//
+// PreToolUse fires synchronously when the model emits a tool_use block, before
+// the assistant message is persisted to JSONL. For AskUserQuestion and
+// ExitPlanMode (matched by the installer), this lets the daemon flip
+// working → waiting without depending on transcript flush latency (issue #307).
 //
 // Safe to call from any goroutine (e.g. HTTP handler).
 func (d *SessionDetector) HandlePermissionHook(sessionID, transcriptPath, hookEventName string) {
 	d.permMu.Lock()
 	switch hookEventName {
-	case "PermissionRequest":
+	case "PermissionRequest", "PreToolUse":
 		d.permissionPending[sessionID] = true
 	case "PostToolUse", "PostToolUseFailure":
 		delete(d.permissionPending, sessionID)

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -26,6 +26,13 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	delete(d.projectSessions, ev.SessionID)
 	d.mu.Unlock()
 
+	// Drop any leftover permission-pending flag — otherwise a hook that
+	// fired without a clearing partner (e.g. agent crash mid-overlay) would
+	// keep the entry forever, and a recycled session ID would inherit it.
+	d.permMu.Lock()
+	delete(d.permissionPending, ev.SessionID)
+	d.permMu.Unlock()
+
 	state, err := d.repo.Load(ev.SessionID)
 	if err != nil || state == nil {
 		return

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -1101,6 +1101,59 @@ func TestSessionDetector_SeedFromDisk_DeletesDeadPIDs(t *testing.T) {
 	}
 }
 
+// TestSessionDetector_HandlePermissionHook_PreToolUseTransitionsToWaiting is
+// the regression test for issue #307. The Claude Code transcript may not yet
+// contain the AskUserQuestion tool_use (assistant message persistence can
+// lag the overlay by minutes), so metrics show no open tool call. A
+// PreToolUse hook fires synchronously when the model emits the tool_use —
+// the detector must transition working → waiting on that signal alone,
+// without depending on the JSONL flush.
+func TestSessionDetector_HandlePermissionHook_PreToolUseTransitionsToWaiting(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	const sessID = "pre-307"
+	const transcript = "/home/.claude/projects/-Users-test/" + sessID + ".jsonl"
+
+	now := time.Now().Unix()
+	repo.states[sessID] = &session.SessionState{
+		SessionID:      sessID,
+		State:          session.StateWorking,
+		TranscriptPath: transcript,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     2,
+		Metrics: &session.SessionMetrics{
+			// Mimics the bug scenario: prior user turn flushed, but the
+			// AskUserQuestion tool_use is still in Claude Code's write
+			// buffer. No open tool call is visible to the classifier.
+			LastEventType:   "user",
+			HasOpenToolCall: false,
+		},
+	}
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	// Let Run() start so the event loop is reading debouncedEvents.
+	time.Sleep(20 * time.Millisecond)
+
+	det.HandlePermissionHook(sessID, transcript, claudecode.HookPreToolUse)
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	state, _ := repo.Load(sessID)
+	if state.State != session.StateWaiting {
+		t.Errorf("state: got %q, want waiting (PreToolUse should flip working→waiting via permissionPending overlay)", state.State)
+	}
+}
+
 func TestNeedsUserAttention(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

- Add a `PreToolUse` hook scoped to `AskUserQuestion|ExitPlanMode` so the daemon flips `working → waiting` the moment Claude Code emits the tool_use — independent of when (or whether) the assistant message reaches JSONL.
- Widen the existing `PostToolUse` / `PostToolUseFailure` matcher to include `AskUserQuestion|ExitPlanMode` so the clearing edge fires when the user answers. Legacy installs get the matcher migrated in place by a new `upgradeStaleHookMatchers` helper (symmetric to `upgradeStaleHookCommands`).
- Defense-in-depth: handler rejects `PreToolUse` for any `tool_name` outside `{AskUserQuestion, ExitPlanMode}`, so a misconfigured `~/.claude/settings.json` matcher can't flip the session on every Bash call.
- Reuses the existing `permissionPending` session-keyed flag; no `tool_use_id` correlation since the overlays are exclusive per session.

Closes #307.

## Why

Empirically Claude Code can leave an AskUserQuestion overlay visible for 5+ minutes before flushing the `tool_use` block to disk. With only transcript-driven detection, `session-detector` never sees the open tool call and the session sits in `working` while the user is actively blocked. This is distinct from #150 (fswatcher missing a brief on-disk window) — here there is *nothing on disk to read*.

## Commits

1. **`fix: catch AskUserQuestion via PreToolUse hook`** — the core change: register `PreToolUse`, route it through `HandlePermissionHook`, install the new matcher group.
2. **`fix: reject PreToolUse for unexpected tools`** — defensive `tool_name` guard in the handler.
3. **`refactor: simplify hook installer to one matcher per event`** — drops the `hookSpec` tuple model. PostToolUse stays one group; the matcher widens. Legacy matcher migration handled by `upgradeStaleHookMatchers`.

## Out of scope

The seed-on-discovery scan suggested at the bottom of issue #307 (scan back for unmatched `AskUserQuestion` tool_use IDs on startup) is intentionally not in this PR.

## Test plan

- [x] `go test ./core/... -race -count=1` — all packages green.
- [x] `tools/replay-fixtures.sh` — no failures.
- [x] `TestSessionDetector_HandlePermissionHook_PreToolUseTransitionsToWaiting` — regression: session with `HasOpenToolCall: false` flips to waiting on `PreToolUse` alone.
- [x] `TestHookHandler_PreToolUse` — happy path.
- [x] `TestHookHandler_PreToolUse_RejectsUnexpectedTool` — `tool_name` guard rejects Bash even if the matcher would let it through.
- [x] `TestEnsureHooksInstalled_InstallsPreToolUseAndExpandedMatcher` — fresh install writes narrow PreToolUse + expanded matcher on clearing events.
- [x] `TestEnsureHooksInstalled_MigratesLegacyMatchers` — pre-#307 install gets matchers rewritten in place (no group append) + new PreToolUse group added.
- [x] `TestEnsureHooksInstalled_UpgradesStaleCommand` — stale command + matcher both upgraded in one pass, single group preserved.
- [ ] Manual: rebuild daemon, run `irrlichd --uninstall-hooks && irrlichd`, confirm `~/.claude/settings.json` shows the new `PreToolUse` block and the widened `PostToolUse` matcher, then trigger an `AskUserQuestion` in a real Claude Code session and confirm `events.log` shows `received PreToolUse (tool=AskUserQuestion)` before the JSONL flushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)