### PR TITLE
refactor(agents): switch main+replay to []agent.Agent via shim (#159 Phase A.2)

### DIFF
--- a/core/adapters/inbound/agents/legacy.go
+++ b/core/adapters/inbound/agents/legacy.go
@@ -1,0 +1,123 @@
+package agents
+
+import (
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/pkg/tailer"
+)
+
+// TEMPORARY: removed in PR3 (#159 M4).
+//
+// LegacyParsers / LegacyPIDDiscoverers / LegacyProcessNames /
+// LegacySubagentCounters / LegacyMetricsProviders bridge []agent.Agent
+// (the new declaration shape) to the legacy adapter-name → function map
+// shapes that pre-Agent consumers (metrics.New, NewSessionDetector, the
+// replay CLI) still expect.
+//
+// Each helper is a leaf: no cross-helper dependencies, no global state.
+// Once the consumers switch to consuming []agent.Agent directly (PR3+),
+// this file and the agents.Config struct above it both delete.
+
+// LegacyParsers produces the adapter-name → parser-factory map used by
+// metrics.New() and the replay CLI's parserFor().
+//
+// JSONLineParser-shape adapters (claudecode, codex, pi) are produced
+// uniformly. FilesUnderCWD (aider) and ProcessOwnedStore (opencode)
+// adapters are intentionally omitted — main.go and the replay CLI
+// register those entries explicitly via adapter-package imports, since
+// the new RawLineParser/ProcessOwnedStore variants don't carry a parser
+// factory that's compatible with the legacy ParserFactory type.
+func LegacyParsers(agents []agent.Agent) map[string]ParserFactory {
+	m := make(map[string]ParserFactory, len(agents))
+	for _, a := range agents {
+		if jp, ok := jsonLineParserOf(a); ok {
+			np := jp.NewParser
+			m[a.Identity.Name] = func() tailer.TranscriptParser {
+				return np().(tailer.TranscriptParser)
+			}
+		}
+	}
+	return m
+}
+
+// LegacyPIDDiscoverers produces the adapter-name → PIDDiscoverFunc map
+// consumed by NewSessionDetector / NewPIDManager.
+func LegacyPIDDiscoverers(agents []agent.Agent) map[string]agent.PIDDiscoverFunc {
+	m := make(map[string]agent.PIDDiscoverFunc, len(agents))
+	for _, a := range agents {
+		m[a.Identity.Name] = a.Process.PIDForSession
+	}
+	return m
+}
+
+// LegacyProcessNames produces the adapter-name → OS-process-name map
+// used by the startup zombie sweep. For ExactName matchers, the OS
+// process name IS the matcher name. For CommandPattern matchers (aider),
+// no reliable OS process name exists (aider runs under python), so we
+// fall back to Identity.Name — same value the legacy agents.Config used
+// historically. The zombie sweep does pgrep -x against this and finds
+// nothing for CommandPattern adapters, which is correct behavior.
+func LegacyProcessNames(agents []agent.Agent) map[string]string {
+	m := make(map[string]string, len(agents))
+	for _, a := range agents {
+		if e, ok := a.Process.Match.(agent.ExactName); ok {
+			m[a.Identity.Name] = e.Name
+			continue
+		}
+		// CommandPattern: preserve historical Config.ProcessName=Identity.Name.
+		m[a.Identity.Name] = a.Identity.Name
+	}
+	return m
+}
+
+// LegacySubagentCounters produces the adapter-name → SubagentCounter map
+// consumed by metrics.New. Only adapters whose LineParser implements
+// agent.SubagentCounter (currently: claudecode) appear in the map.
+func LegacySubagentCounters(agents []agent.Agent) map[string]SubagentCounter {
+	m := make(map[string]SubagentCounter)
+	for _, a := range agents {
+		jp, ok := jsonLineParserOf(a)
+		if !ok {
+			continue
+		}
+		p := jp.NewParser()
+		sc, ok := p.(agent.SubagentCounter)
+		if !ok {
+			continue
+		}
+		m[a.Identity.Name] = func(metrics *tailer.SessionMetrics) int {
+			return sc.OpenSubagents(metrics)
+		}
+	}
+	return m
+}
+
+// LegacyMetricsProviders produces the adapter-name → MetricsProvider map
+// consumed by metrics.New. Only ProcessOwnedStore adapters with a
+// non-nil Reader appear in the map.
+func LegacyMetricsProviders(agents []agent.Agent) map[string]MetricsProvider {
+	m := make(map[string]MetricsProvider)
+	for _, a := range agents {
+		s, ok := a.Source.(agent.ProcessOwnedStore)
+		if !ok || s.Reader == nil {
+			continue
+		}
+		r := s.Reader
+		m[a.Identity.Name] = func(transcriptPath, sessionID string) (*session.SessionMetrics, error) {
+			return r.ComputeMetrics(transcriptPath, sessionID)
+		}
+	}
+	return m
+}
+
+// jsonLineParserOf returns the JSONLineParser carried inside an Agent's
+// FilesUnderRoot source (if any). Returns the parser and ok=true when
+// the Agent declares a FilesUnderRoot source with a JSONLineParser.
+func jsonLineParserOf(a agent.Agent) (agent.JSONLineParser, bool) {
+	s, ok := a.Source.(agent.FilesUnderRoot)
+	if !ok {
+		return agent.JSONLineParser{}, false
+	}
+	jp, ok := s.Parser.(agent.JSONLineParser)
+	return jp, ok
+}

--- a/core/adapters/inbound/agents/legacy_test.go
+++ b/core/adapters/inbound/agents/legacy_test.go
@@ -1,0 +1,98 @@
+package agents_test
+
+import (
+	"reflect"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents"
+	"irrlicht/core/adapters/inbound/agents/aider"
+	"irrlicht/core/adapters/inbound/agents/claudecode"
+	"irrlicht/core/adapters/inbound/agents/codex"
+	"irrlicht/core/adapters/inbound/agents/opencode"
+	"irrlicht/core/adapters/inbound/agents/pi"
+	"irrlicht/core/domain/agent"
+)
+
+// testAgents mirrors the production agentCfgs/agents slice used by main.go
+// and replay.
+func testAgents() []agent.Agent {
+	return []agent.Agent{
+		claudecode.Agent(),
+		codex.Agent(),
+		pi.Agent(),
+		aider.Agent(),
+		opencode.Agent(),
+	}
+}
+
+func TestLegacyParsers_includesJSONLineParserAdapters(t *testing.T) {
+	m := agents.LegacyParsers(testAgents())
+	for _, name := range []string{claudecode.AdapterName, codex.AdapterName, pi.AdapterName} {
+		if _, ok := m[name]; !ok {
+			t.Errorf("LegacyParsers missing %q", name)
+		}
+	}
+}
+
+func TestLegacyParsers_omitsRawAndStoreAdapters(t *testing.T) {
+	m := agents.LegacyParsers(testAgents())
+	// aider (FilesUnderCWD/RawLineParser) and opencode (ProcessOwnedStore)
+	// are intentionally absent — main.go and replay register them
+	// explicitly via adapter-package imports.
+	if _, ok := m[aider.AdapterName]; ok {
+		t.Error("LegacyParsers should not include aider (FilesUnderCWD)")
+	}
+	if _, ok := m[opencode.AdapterName]; ok {
+		t.Error("LegacyParsers should not include opencode (ProcessOwnedStore)")
+	}
+}
+
+func TestLegacyPIDDiscoverers_coversAllAdapters(t *testing.T) {
+	m := agents.LegacyPIDDiscoverers(testAgents())
+	for _, name := range []string{
+		claudecode.AdapterName, codex.AdapterName, pi.AdapterName,
+		aider.AdapterName, opencode.AdapterName,
+	} {
+		if _, ok := m[name]; !ok {
+			t.Errorf("LegacyPIDDiscoverers missing %q", name)
+		}
+	}
+}
+
+func TestLegacyProcessNames_matchesConfigShape(t *testing.T) {
+	got := agents.LegacyProcessNames(testAgents())
+	want := map[string]string{
+		claudecode.AdapterName: "claude",
+		codex.AdapterName:      "codex",
+		pi.AdapterName:         "pi",
+		aider.AdapterName:      "aider",    // CommandPattern fallback to Identity.Name
+		opencode.AdapterName:   "opencode",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LegacyProcessNames: got %v, want %v", got, want)
+	}
+}
+
+func TestLegacySubagentCounters_onlyClaudecode(t *testing.T) {
+	m := agents.LegacySubagentCounters(testAgents())
+	if _, ok := m[claudecode.AdapterName]; !ok {
+		t.Errorf("LegacySubagentCounters missing %q", claudecode.AdapterName)
+	}
+	for _, name := range []string{codex.AdapterName, pi.AdapterName, aider.AdapterName, opencode.AdapterName} {
+		if _, ok := m[name]; ok {
+			t.Errorf("LegacySubagentCounters should not include %q", name)
+		}
+	}
+}
+
+func TestLegacyMetricsProviders_onlyOpencode(t *testing.T) {
+	m := agents.LegacyMetricsProviders(testAgents())
+	if _, ok := m[opencode.AdapterName]; !ok {
+		t.Errorf("LegacyMetricsProviders missing %q", opencode.AdapterName)
+	}
+	for _, name := range []string{claudecode.AdapterName, codex.AdapterName, pi.AdapterName, aider.AdapterName} {
+		if _, ok := m[name]; ok {
+			t.Errorf("LegacyMetricsProviders should not include %q", name)
+		}
+	}
+}

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -33,31 +33,20 @@ type Adapter struct {
 	fallback         agents.ParserFactory // used for unknown adapter names
 }
 
-// New returns a new metrics Adapter configured from the given agent
-// registrations. The adapter uses cfgs[0].NewParser as the fallback parser for
-// unknown adapter names to preserve the historical "default to Claude Code"
-// behavior; callers should pass the Claude Code config first.
-func New(cfgs []agents.Config) *Adapter {
-	parsers := make(map[string]agents.ParserFactory, len(cfgs))
-	subs := make(map[string]agents.SubagentCounter, len(cfgs))
-	providers := make(map[string]agents.MetricsProvider)
-	var fallback agents.ParserFactory
-	for i, c := range cfgs {
-		parsers[c.Name] = c.NewParser
-		if c.CountOpenSubagents != nil {
-			subs[c.Name] = c.CountOpenSubagents
-		}
-		if c.ComputeMetrics != nil {
-			providers[c.Name] = c.ComputeMetrics
-		}
-		if i == 0 {
-			fallback = c.NewParser
-		}
-	}
+// New returns a new metrics Adapter configured from the given per-adapter
+// registries. The fallback parser is used for unknown adapter names to
+// preserve the historical "default to Claude Code" behavior; callers
+// should pass the Claude Code factory.
+//
+// Signature simplified in #159 Phase A.2: previously took []agents.Config
+// and derived the three maps internally. Callers now produce the maps via
+// agents.LegacyParsers / LegacySubagentCounters / LegacyMetricsProviders
+// (themselves removed in Phase A.3 when agents.Config is deleted).
+func New(parsers map[string]agents.ParserFactory, subagents map[string]agents.SubagentCounter, providers map[string]agents.MetricsProvider, fallback agents.ParserFactory) *Adapter {
 	return &Adapter{
 		tailers:          make(map[string]*lockedTailer),
 		parsers:          parsers,
-		subagents:        subs,
+		subagents:        subagents,
 		metricsProviders: providers,
 		fallback:         fallback,
 	}

--- a/core/adapters/outbound/metrics/adapter_test.go
+++ b/core/adapters/outbound/metrics/adapter_test.go
@@ -31,7 +31,7 @@ func TestPruneEntry_RemovesLedgerAndCacheEntry(t *testing.T) {
 		t.Fatalf("write ledger: %v", err)
 	}
 
-	a := New(nil)
+	a := New(nil, nil, nil, nil)
 	a.tailers[transcript] = &lockedTailer{}
 
 	a.PruneEntry(transcript)
@@ -48,12 +48,12 @@ func TestPruneEntry_IdempotentOnMissingFile(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	a := New(nil)
+	a := New(nil, nil, nil, nil)
 	// No file written, no map entry — should not panic or error.
 	a.PruneEntry(filepath.Join(tmpHome, "never-existed.jsonl"))
 }
 
 func TestPruneEntry_EmptyPathNoop(t *testing.T) {
-	a := New(nil)
+	a := New(nil, nil, nil, nil)
 	a.PruneEntry("") // must not panic
 }

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"irrlicht/core/adapters/inbound/agents"
 	"irrlicht/core/adapters/outbound/httputil"
 	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/outbound"
 )
@@ -89,22 +89,22 @@ func attachGroupCosts(groups []*session.AgentGroup, tracker outbound.CostTracker
 
 // handleGetAgents serves the registered adapter branding so frontends can look
 // up an adapter's display name and icon by `name` instead of hardcoding their
-// own switches. The slice mirrors the order configured in main.go's agentCfgs;
+// own switches. The slice mirrors the order configured in main.go's agents;
 // frontends should treat ordering as informational only and key by `name`.
-func handleGetAgents(cfgs []agents.Config) http.HandlerFunc {
+func handleGetAgents(allAgents []agent.Agent) http.HandlerFunc {
 	type agentEntry struct {
 		Name         string `json:"name"`
 		DisplayName  string `json:"display_name"`
 		IconSVGLight string `json:"icon_svg_light"`
 		IconSVGDark  string `json:"icon_svg_dark"`
 	}
-	entries := make([]agentEntry, 0, len(cfgs))
-	for _, c := range cfgs {
+	entries := make([]agentEntry, 0, len(allAgents))
+	for _, a := range allAgents {
 		entries = append(entries, agentEntry{
-			Name:         c.Name,
-			DisplayName:  c.DisplayName,
-			IconSVGLight: c.IconSVGLight,
-			IconSVGDark:  c.IconSVGDark,
+			Name:         a.Identity.Name,
+			DisplayName:  a.Identity.DisplayName,
+			IconSVGLight: a.Identity.IconSVGLight,
+			IconSVGDark:  a.Identity.IconSVGDark,
 		})
 	}
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -19,7 +19,6 @@ import (
 	"irrlicht/core/adapters/inbound/agents/aider"
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/adapters/inbound/agents/codex"
-	"irrlicht/core/adapters/inbound/agents/fswatcher"
 	"irrlicht/core/adapters/inbound/agents/opencode"
 	"irrlicht/core/adapters/inbound/agents/pi"
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
@@ -34,8 +33,10 @@ import (
 	"irrlicht/core/adapters/outbound/recorder"
 	wshub "irrlicht/core/adapters/outbound/websocket"
 	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/config"
 	"irrlicht/core/pkg/capacity"
+	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/ports/inbound"
 	"irrlicht/core/ports/outbound"
 )
@@ -144,17 +145,29 @@ func main() {
 	// derives from this single slice — the only place new agents need to be
 	// listed. Order matters: the metrics collector uses the first entry's
 	// parser as the fallback for unknown adapter names.
-	agentCfgs := []agents.Config{
-		claudecode.Config(),
-		codex.Config(),
-		pi.Config(),
-		aider.Config(),
-		opencode.Config(),
+	allAgents := []agent.Agent{
+		claudecode.Agent(),
+		codex.Agent(),
+		pi.Agent(),
+		aider.Agent(),
+		opencode.Agent(),
 	}
+
+	// Build the legacy parser map and patch in the FilesUnderCWD (aider)
+	// and ProcessOwnedStore (opencode) entries that LegacyParsers omits.
+	// Both will go away in PR3 (#159 M4) when agents.Config is deleted.
+	legacyParsers := agents.LegacyParsers(allAgents)
+	legacyParsers[aider.AdapterName] = func() tailer.TranscriptParser { return &aider.Parser{} }
+	legacyParsers[opencode.AdapterName] = func() tailer.TranscriptParser { return &opencode.Parser{} }
 
 	// Shared adapters for SessionDetector.
 	gitResolver := git.New()
-	metricsCollector := metrics.New(agentCfgs)
+	metricsCollector := metrics.New(
+		legacyParsers,
+		agents.LegacySubagentCounters(allAgents),
+		agents.LegacyMetricsProviders(allAgents),
+		legacyParsers[allAgents[0].Identity.Name],
+	)
 
 	// --- File-based SessionDetector (primary detection path) ---
 	// Forward-reference: detector is assigned before any callbacks can fire,
@@ -200,7 +213,7 @@ func main() {
 
 	hub := wshub.NewHub(push, historySnapshotProvider(historyTracker))
 	mux.HandleFunc("GET /api/v1/sessions/stream", hub.ServeWS)
-	mux.HandleFunc("GET /api/v1/agents", handleGetAgents(agentCfgs))
+	mux.HandleFunc("GET /api/v1/agents", handleGetAgents(allAgents))
 
 	// pprof debug endpoints for runtime profiling (localhost only).
 	mux.HandleFunc("GET /debug/pprof/", localhostOnly(pprof.Index))
@@ -320,28 +333,18 @@ func main() {
 		return processlifecycle.HasRealSessionForPID(sessions, projectDir, pid)
 	}
 
-	// Per-adapter inbound wiring: one transcript watcher + one process scanner
-	// per AgentConfig. Scanners detect agent processes before they create a
-	// transcript so the session appears as ready from the moment the app opens.
-	// Skipped entirely under IRRLICHT_DEMO_MODE=1 — daemon serves only what's
-	// already on disk in instances/.
+	// Per-adapter inbound wiring: dispatch on each Agent's Source variant via
+	// buildAgentWatchers (see wiring.go). FilesUnderRoot adapters get both an
+	// fswatcher and a process scanner; FilesUnderCWD and ProcessOwnedStore
+	// adapters get only a scanner. Skipped entirely under IRRLICHT_DEMO_MODE=1
+	// — daemon serves only what's already on disk in instances/.
 	var watchers []inbound.AgentWatcher
-	watcherRoots := make([]string, 0, len(agentCfgs))
+	watcherRoots := make([]string, 0, len(allAgents))
 	if !demoMode {
-		for _, c := range agentCfgs {
-			w := fswatcher.New(c.RootDir, c.Name, cfg.MaxSessionAge)
-			watchers = append(watchers, w)
-			watcherRoots = append(watcherRoots, fmt.Sprintf("%s (%s)", c.Name, w.Root()))
-
-			scanner := processlifecycle.NewScanner(c.ProcessName, c.Name, 0)
-			if c.CommandLineMatch != "" {
-				scanner.WithCommandLineMatch(c.CommandLineMatch)
-			}
-			if c.TranscriptFilename != "" {
-				scanner.WithTranscriptFilename(c.TranscriptFilename)
-			}
-			scanner.WithSessionChecker(realSessionCheck)
-			watchers = append(watchers, scanner)
+		for _, a := range allAgents {
+			aws, labels := buildAgentWatchers(a, cfg.MaxSessionAge, realSessionCheck)
+			watchers = append(watchers, aws...)
+			watcherRoots = append(watcherRoots, labels...)
 		}
 
 		// OpenCode uses a SQLite database instead of JSONL files, so it needs
@@ -351,8 +354,8 @@ func main() {
 		watcherRoots = append(watcherRoots, fmt.Sprintf("%s-db (%s)", opencode.AdapterName, ocw.Root()))
 	}
 
-	pidDiscovers := agents.PIDDiscoverMap(agentCfgs)
-	processNames := agents.ProcessNameMap(agentCfgs)
+	pidDiscovers := agents.LegacyPIDDiscoverers(allAgents)
+	processNames := agents.LegacyProcessNames(allAgents)
 
 	// SessionDetector: orchestrates AgentWatchers + ProcessWatcher.
 	detector = services.NewSessionDetector(

--- a/core/cmd/irrlichd/main_test.go
+++ b/core/cmd/irrlichd/main_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"irrlicht/core/adapters/inbound/agents"
 	"irrlicht/core/adapters/inbound/agents/aider"
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/adapters/inbound/agents/codex"
@@ -25,20 +24,21 @@ import (
 	"irrlicht/core/adapters/outbound/filesystem"
 	wshub "irrlicht/core/adapters/outbound/websocket"
 	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/capacity"
 )
 
-// testAgentCfgs mirrors main.go's agentCfgs slice. Tests register the real
-// production Configs so the gate test catches any future adapter that ships
-// without branding fields filled in.
-func testAgentCfgs() []agents.Config {
-	return []agents.Config{
-		claudecode.Config(),
-		codex.Config(),
-		pi.Config(),
-		aider.Config(),
-		opencode.Config(),
+// testAgents mirrors main.go's agents slice. Tests register the real
+// production Agent declarations so the gate test catches any future
+// adapter that ships without branding fields filled in.
+func testAgents() []agent.Agent {
+	return []agent.Agent{
+		claudecode.Agent(),
+		codex.Agent(),
+		pi.Agent(),
+		aider.Agent(),
+		opencode.Agent(),
 	}
 }
 
@@ -51,7 +51,7 @@ func newTestStack(t *testing.T) (*httptest.Server, *filesystem.SessionRepository
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(repo, orchMonitor, nil))
-	mux.HandleFunc("GET /api/v1/agents", handleGetAgents(testAgentCfgs()))
+	mux.HandleFunc("GET /api/v1/agents", handleGetAgents(testAgents()))
 	mux.HandleFunc("GET /state", handleGetState(repo))
 	hub := wshub.NewHub(push, nil)
 	mux.HandleFunc("GET /api/v1/sessions/stream", hub.ServeWS)

--- a/core/cmd/irrlichd/wiring.go
+++ b/core/cmd/irrlichd/wiring.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"irrlicht/core/adapters/inbound/agents/fswatcher"
+	"irrlicht/core/adapters/inbound/agents/processlifecycle"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/ports/inbound"
+)
+
+// buildAgentWatchers dispatches on the Agent's Source variant and constructs
+// the appropriate transcript watchers + process scanners for that adapter.
+//
+// FilesUnderRoot adapters (claudecode, codex, pi) get both:
+//   - an fswatcher rooted at the variant's Dir
+//   - a process scanner keyed on ProcessName/CommandPattern
+//
+// FilesUnderCWD adapters (aider) get only a process scanner, configured with
+// the variant's Filename so the scanner emits transcript_new events on first
+// appearance of the per-process file inside CWD.
+//
+// ProcessOwnedStore adapters (opencode) get only a process scanner. Their
+// dedicated DB-aware watcher is constructed separately by main.go (e.g.
+// opencode.New). The fswatcher that pre-A.2 code mistakenly created for these
+// adapters (rooted at the DB directory) emitted no useful transcript events
+// and is no longer constructed — drop is behavior-preserving in effect.
+//
+// Returns the list of watchers and a human-readable label for the startup
+// log line (matches the pre-A.2 "<adapter> (<root>)" / "<adapter>-db (<root>)"
+// format).
+func buildAgentWatchers(
+	a agent.Agent,
+	maxSessionAge time.Duration,
+	sessionChecker func(projectDir string, pid int) bool,
+) ([]inbound.AgentWatcher, []string) {
+	var (
+		watchers []inbound.AgentWatcher
+		labels   []string
+	)
+
+	if s, ok := a.Source.(agent.FilesUnderRoot); ok {
+		w := fswatcher.New(s.Dir, a.Identity.Name, maxSessionAge)
+		watchers = append(watchers, w)
+		labels = append(labels, fmt.Sprintf("%s (%s)", a.Identity.Name, w.Root()))
+	}
+
+	scanner := processlifecycle.NewScanner(processNameFor(a), a.Identity.Name, 0)
+	if m, ok := a.Process.Match.(agent.CommandPattern); ok {
+		scanner.WithCommandLineMatch(m.Regex.String())
+	}
+	if s, ok := a.Source.(agent.FilesUnderCWD); ok {
+		scanner.WithTranscriptFilename(s.Filename)
+	}
+	scanner.WithSessionChecker(sessionChecker)
+	watchers = append(watchers, scanner)
+
+	return watchers, labels
+}
+
+// processNameFor returns the OS process name suitable for pgrep -x. For
+// ExactName matchers, that's the matcher's Name. For CommandPattern
+// matchers (aider), no reliable name exists — aider runs under python —
+// so we fall back to the Identity.Name, mirroring the historical value
+// the legacy agents.Config.ProcessName carried for that adapter. The
+// scanner's WithCommandLineMatch path bypasses pgrep -x and matches the
+// full command line instead, so the fallback name is never actually
+// matched against running processes.
+func processNameFor(a agent.Agent) string {
+	if e, ok := a.Process.Match.(agent.ExactName); ok {
+		return e.Name
+	}
+	return a.Identity.Name
+}

--- a/core/cmd/replay/main.go
+++ b/core/cmd/replay/main.go
@@ -48,21 +48,33 @@ import (
 	"irrlicht/core/adapters/inbound/agents/codex"
 	"irrlicht/core/adapters/inbound/agents/opencode"
 	"irrlicht/core/adapters/inbound/agents/pi"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/pkg/tailer"
 )
 
-// agentConfigs lists every inbound agent adapter the replay CLI knows about.
+// allAgents lists every inbound agent adapter the replay CLI knows about.
 // Kept local to main so this package isn't re-importing a shared registry —
 // the daemon's production wiring lives in cmd/irrlichd/main.go.
-var agentConfigs = []agents.Config{
-	claudecode.Config(),
-	codex.Config(),
-	pi.Config(),
-	aider.Config(),
-	opencode.Config(),
+var allAgents = []agent.Agent{
+	claudecode.Agent(),
+	codex.Agent(),
+	pi.Agent(),
+	aider.Agent(),
+	opencode.Agent(),
 }
 
-var parserFactories = agents.ParserMap(agentConfigs)
+// parserFactories is the legacy parser map consumed by parserFor() below.
+// Built once at package init via the temporary agents.LegacyParsers shim
+// plus explicit entries for FilesUnderCWD (aider) and ProcessOwnedStore
+// (opencode) adapters — those variants don't carry a parser factory in the
+// new shape compatible with agents.ParserFactory. The shim + the inline
+// entries here both go away in PR3 (#159 M4) when agents.Config is deleted.
+var parserFactories = func() map[string]agents.ParserFactory {
+	m := agents.LegacyParsers(allAgents)
+	m[aider.AdapterName] = func() tailer.TranscriptParser { return &aider.Parser{} }
+	m[opencode.AdapterName] = func() tailer.TranscriptParser { return &opencode.Parser{} }
+	return m
+}()
 
 // parserFor returns a fresh TranscriptParser for the given adapter name,
 // falling back to Claude Code for unknown names (preserves prior behavior).


### PR DESCRIPTION
## Summary

Phase A.2 of the agent-adapter refactor proposed on #159. Switches `cmd/irrlichd/main.go` and `cmd/replay/main.go` from `[]agents.Config` to `[]agent.Agent` (the new declaration shape introduced in #311). Wire format and persistence shapes unchanged — M0 contract goldens are byte-identity.

Builds on #311 (Phase A.1). Followed by PR3 (delete `agents.Config`), PR4 (new `Watcher` port), PR5 (drop `AgentWatcher`).

### What's in this PR

**New temporary shim** at `core/adapters/inbound/agents/legacy.go`:

- `LegacyParsers([]Agent) → map[name]ParserFactory` (JSONLineParser adapters only)
- `LegacyPIDDiscoverers([]Agent) → map[name]PIDDiscoverFunc`
- `LegacyProcessNames([]Agent) → map[name]string`
- `LegacySubagentCounters([]Agent) → map[name]SubagentCounter` (via type assertion on the LineParser)
- `LegacyMetricsProviders([]Agent) → map[name]MetricsProvider`

All five helpers and the file containing them are deleted in PR3 (#159 M4) when `agents.Config` goes.

**New variant-dispatch wiring** at `core/cmd/irrlichd/wiring.go`:

`buildAgentWatchers(agent, maxAge, sessionChecker) → []AgentWatcher` dispatches on `Agent.Source`:

| Source variant | fswatcher | scanner |
|---|---|---|
| FilesUnderRoot | ✓ (rooted at `Dir`) | ✓ (ExactName) |
| FilesUnderCWD | — | ✓ (CommandPattern + Filename) |
| ProcessOwnedStore | — | ✓ (ExactName) |

This replaces the pre-A.2 loop at `main.go:328-345` which constructed an fswatcher for every adapter regardless of variant.

**Daemon and replay** now consume `[]agent.Agent`:

- `core/cmd/irrlichd/main.go` — builds the slice via each adapter's `Agent()` constructor.
- `core/cmd/replay/main.go` — same. Aider and opencode parsers registered explicitly because their variants (RawLineParser, ProcessOwnedStore) don't carry an `agents.ParserFactory`-compatible factory in the new shape.

**Signature changes**:

- `metrics.New([]agents.Config)` → `metrics.New(parsers, subagents, providers, fallback)` (4 maps + 1 fallback).
- `handleGetAgents([]agents.Config)` → `handleGetAgents([]agent.Agent)`.

## Behavior change worth flagging

The pre-A.2 wiring constructed an `fswatcher` for every adapter, including:

- aider: rooted at `~/.aider`, which aider never writes transcripts to.
- opencode: rooted at the SQLite DB directory, whose binary writes weren't emitted as JSONL events.

The new variant-dispatched wiring omits both. Effect on production behavior: **zero**. The two fswatchers emitted nothing useful; they were dead goroutines.

## Test plan

- [x] `go build ./core/...` clean
- [x] `go test ./core/... -race -count=1` green (full suite, including new legacy.go tests in `agents_test` external package)
- [x] `tools/replay-fixtures.sh` green (5 adapters, 23 fixtures)
- [x] M0 contract goldens byte-identical with PR1's committed versions — `SessionState` on-disk JSON, 7 `PushMessage` variants, `GET /api/v1/agents`
- [x] M2 parity tests still pass (per-adapter)
- [x] `grep "agents\.Config" core/cmd/irrlichd/main.go core/cmd/replay/main.go` returns only comments (no production references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)