### PR TITLE
refactor(agents): add Watcher port + Identity() on existing watchers (#159 Phase A.4)

### DIFF
--- a/core/adapters/inbound/agents/fswatcher/identity_test.go
+++ b/core/adapters/inbound/agents/fswatcher/identity_test.go
@@ -1,0 +1,33 @@
+package fswatcher
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/ports/inbound"
+)
+
+// Compile-time assertion that Watcher satisfies both the legacy and the
+// new inbound port interfaces. PR5 deletes AgentWatcher; until then the
+// concrete type satisfies both, which is checked here at compile time.
+var (
+	_ inbound.AgentWatcher = (*Watcher)(nil)
+	_ inbound.Watcher      = (*Watcher)(nil)
+)
+
+func TestWithIdentityRoundTrip(t *testing.T) {
+	w := New("", "claude-code", 0)
+	if got := w.Identity(); got != (agent.Identity{}) {
+		t.Fatalf("Identity before WithIdentity: got %+v, want zero", got)
+	}
+	id := agent.Identity{
+		Name:         "claude-code",
+		DisplayName:  "Claude Code",
+		IconSVGLight: "<svg>light</svg>",
+		IconSVGDark:  "<svg>dark</svg>",
+	}
+	w.WithIdentity(id)
+	if got := w.Identity(); got != id {
+		t.Errorf("Identity after WithIdentity: got %+v, want %+v", got, id)
+	}
+}

--- a/core/adapters/inbound/agents/fswatcher/watcher.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher.go
@@ -17,14 +17,31 @@ import (
 )
 
 // Watcher watches a directory tree for .jsonl transcript file events.
-// It implements inbound.AgentWatcher.
+// It implements inbound.AgentWatcher and (when WithIdentity has been
+// called) inbound.Watcher.
 type Watcher struct {
-	root    string        // resolved absolute path to the watched directory
-	adapter string        // adapter name set on emitted events
-	maxAge  time.Duration // ignore files older than this (0 = no limit)
+	root     string         // resolved absolute path to the watched directory
+	adapter  string         // adapter name set on emitted events
+	identity agent.Identity // populated via WithIdentity (#159 Phase A.4)
+	maxAge   time.Duration  // ignore files older than this (0 = no limit)
 
 	subMu sync.Mutex
 	subs  []chan agent.Event
+}
+
+// WithIdentity sets the full agent.Identity for this watcher so it
+// satisfies inbound.Watcher. Returns the watcher for chaining. Callers
+// in cmd/irrlichd/wiring.go invoke this immediately after New(); test
+// callers (e2e) may omit it because they don't consume the new port.
+func (w *Watcher) WithIdentity(id agent.Identity) *Watcher {
+	w.identity = id
+	return w
+}
+
+// Identity returns the agent.Identity supplied via WithIdentity, or the
+// zero value if WithIdentity was never called.
+func (w *Watcher) Identity() agent.Identity {
+	return w.identity
 }
 
 // New creates a Watcher for the given directory relative to $HOME.

--- a/core/adapters/inbound/agents/opencode/identity_test.go
+++ b/core/adapters/inbound/agents/opencode/identity_test.go
@@ -1,0 +1,27 @@
+package opencode
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/ports/inbound"
+)
+
+// Compile-time assertion that Watcher satisfies both inbound port interfaces.
+var (
+	_ inbound.AgentWatcher = (*Watcher)(nil)
+	_ inbound.Watcher      = (*Watcher)(nil)
+)
+
+func TestOpenCodeWithIdentityRoundTrip(t *testing.T) {
+	w := New(time.Hour)
+	if got := w.Identity(); got != (agent.Identity{}) {
+		t.Fatalf("Identity before WithIdentity: got %+v, want zero", got)
+	}
+	id := Agent().Identity
+	w.WithIdentity(id)
+	if got := w.Identity(); got != id {
+		t.Errorf("Identity after WithIdentity: got %+v, want %+v", got, id)
+	}
+}

--- a/core/adapters/inbound/agents/opencode/watcher.go
+++ b/core/adapters/inbound/agents/opencode/watcher.go
@@ -43,9 +43,10 @@ const defaultMinScanGap = 500 * time.Millisecond
 // write — rather than the main DB file which is only updated on checkpoint.
 // The session ID is the OpenCode session UUID (ses_...).
 type Watcher struct {
-	dbPath  string        // absolute path to opencode.db
-	adapter string        // always "opencode"
-	maxAge  time.Duration // ignore sessions older than this (0 = no limit)
+	dbPath   string         // absolute path to opencode.db
+	adapter  string         // always "opencode"
+	identity agent.Identity // populated via WithIdentity (#159 Phase A.4)
+	maxAge   time.Duration  // ignore sessions older than this (0 = no limit)
 
 	subMu sync.Mutex
 	subs  []chan agent.Event
@@ -139,6 +140,19 @@ func (w *Watcher) Root() string { return w.dbPath }
 
 // Adapter returns the adapter name.
 func (w *Watcher) Adapter() string { return w.adapter }
+
+// WithIdentity sets the full agent.Identity for this watcher so it
+// satisfies inbound.Watcher. Returns the watcher for chaining.
+func (w *Watcher) WithIdentity(id agent.Identity) *Watcher {
+	w.identity = id
+	return w
+}
+
+// Identity returns the agent.Identity supplied via WithIdentity, or the
+// zero value if WithIdentity was never called.
+func (w *Watcher) Identity() agent.Identity {
+	return w.identity
+}
 
 // Watch begins monitoring the OpenCode database. It blocks until ctx is
 // cancelled.

--- a/core/adapters/inbound/agents/processlifecycle/identity_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/identity_test.go
@@ -1,0 +1,31 @@
+package processlifecycle
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/ports/inbound"
+)
+
+// Compile-time assertion that Scanner satisfies both inbound port interfaces.
+var (
+	_ inbound.AgentWatcher = (*Scanner)(nil)
+	_ inbound.Watcher      = (*Scanner)(nil)
+)
+
+func TestScannerWithIdentityRoundTrip(t *testing.T) {
+	s := NewScanner("aider", "aider", 0)
+	if got := s.Identity(); got != (agent.Identity{}) {
+		t.Fatalf("Identity before WithIdentity: got %+v, want zero", got)
+	}
+	id := agent.Identity{
+		Name:         "aider",
+		DisplayName:  "Aider",
+		IconSVGLight: "<svg>aider-light</svg>",
+		IconSVGDark:  "<svg>aider-dark</svg>",
+	}
+	s.WithIdentity(id)
+	if got := s.Identity(); got != id {
+		t.Errorf("Identity after WithIdentity: got %+v, want %+v", got, id)
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/scanner.go
+++ b/core/adapters/inbound/agents/processlifecycle/scanner.go
@@ -34,12 +34,14 @@ type trackedProc struct {
 
 // Scanner polls for agent processes and emits synthetic EventNewSession /
 // EventRemoved events so the session can be shown before the first message.
-// It implements inbound.AgentWatcher.
+// It implements inbound.AgentWatcher and (when WithIdentity has been
+// called) inbound.Watcher.
 type Scanner struct {
-	processName        string // exact process name matched by pgrep -x
-	commandLineMatch   string // if non-empty, used with pgrep -f instead of -x ProcessName
-	transcriptFilename string // if non-empty, scanner checks <CWD>/<filename> for the real transcript
-	adapter            string // adapter label placed on emitted events
+	processName        string         // exact process name matched by pgrep -x
+	commandLineMatch   string         // if non-empty, used with pgrep -f instead of -x ProcessName
+	transcriptFilename string         // if non-empty, scanner checks <CWD>/<filename> for the real transcript
+	adapter            string         // adapter label placed on emitted events
+	identity           agent.Identity // populated via WithIdentity (#159 Phase A.4)
 	interval           time.Duration
 
 	// sessionChecker is an optional function that reports whether a real
@@ -82,6 +84,19 @@ func NewScanner(processName, adapter string, interval time.Duration) *Scanner {
 func (s *Scanner) WithCommandLineMatch(pattern string) *Scanner {
 	s.commandLineMatch = pattern
 	return s
+}
+
+// WithIdentity sets the full agent.Identity for this scanner so it
+// satisfies inbound.Watcher. Returns the scanner for chaining.
+func (s *Scanner) WithIdentity(id agent.Identity) *Scanner {
+	s.identity = id
+	return s
+}
+
+// Identity returns the agent.Identity supplied via WithIdentity, or the
+// zero value if WithIdentity was never called.
+func (s *Scanner) Identity() agent.Identity {
+	return s.identity
 }
 
 // WithTranscriptFilename tells the scanner to additionally probe each

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -351,7 +351,7 @@ func main() {
 
 		// OpenCode uses a SQLite database instead of JSONL files, so it needs
 		// its own dedicated watcher in addition to the process scanner above.
-		ocw := opencode.New(cfg.MaxSessionAge)
+		ocw := opencode.New(cfg.MaxSessionAge).WithIdentity(opencode.Agent().Identity)
 		watchers = append(watchers, ocw)
 		watcherRoots = append(watcherRoots, fmt.Sprintf("%s-db (%s)", opencode.AdapterName, ocw.Root()))
 	}

--- a/core/cmd/irrlichd/wiring.go
+++ b/core/cmd/irrlichd/wiring.go
@@ -41,12 +41,12 @@ func buildAgentWatchers(
 	)
 
 	if s, ok := a.Source.(agent.FilesUnderRoot); ok {
-		w := fswatcher.New(s.Dir, a.Identity.Name, maxSessionAge)
+		w := fswatcher.New(s.Dir, a.Identity.Name, maxSessionAge).WithIdentity(a.Identity)
 		watchers = append(watchers, w)
 		labels = append(labels, fmt.Sprintf("%s (%s)", a.Identity.Name, w.Root()))
 	}
 
-	scanner := processlifecycle.NewScanner(processNameFor(a), a.Identity.Name, 0)
+	scanner := processlifecycle.NewScanner(processNameFor(a), a.Identity.Name, 0).WithIdentity(a.Identity)
 	if m, ok := a.Process.Match.(agent.CommandPattern); ok {
 		scanner.WithCommandLineMatch(m.Regex.String())
 	}

--- a/core/ports/inbound/watcher.go
+++ b/core/ports/inbound/watcher.go
@@ -1,0 +1,35 @@
+package inbound
+
+import (
+	"context"
+
+	"irrlicht/core/domain/agent"
+)
+
+// Watcher is the new inbound port introduced in #159 Phase A.4. It mirrors
+// AgentWatcher's shape (lifecycle + event stream) and adds Identity() so
+// the daemon can tag events with their watcher's identity without
+// bouncing through the redundant agent.Event.Adapter field. In PR5 the
+// daemon switches to consuming this port exclusively, AgentWatcher is
+// deleted, and agent.Event.Adapter is dropped.
+//
+// PR4 (this PR) leaves AgentWatcher intact and has every existing
+// watcher implementation satisfy both interfaces by gaining an
+// Identity() method.
+type Watcher interface {
+	// Identity returns the metadata for the agent this watcher serves
+	// (Name, DisplayName, IconSVGLight, IconSVGDark). Stored on the
+	// watcher at construction time via the new WithIdentity() builder
+	// method.
+	Identity() agent.Identity
+
+	// Watch begins watching for transcript changes. Blocks until ctx is
+	// cancelled or an unrecoverable error occurs.
+	Watch(ctx context.Context) error
+
+	// Subscribe returns a channel that receives agent events.
+	Subscribe() <-chan agent.Event
+
+	// Unsubscribe removes a previously subscribed channel and closes it.
+	Unsubscribe(ch <-chan agent.Event)
+}


### PR DESCRIPTION
## Summary

Phase A.4 of the agent-adapter refactor. **Pure additions.** Introduces the new internal `inbound.Watcher` port and gives every existing watcher type a `WithIdentity()` builder + `Identity()` method so it satisfies both interfaces.

Builds on #311 / #313 / #314. Followed by PR5 (drop `AgentWatcher` + `Event.Adapter`).

### What's new

**`core/ports/inbound/watcher.go`** — `Watcher` interface:

```go
type Watcher interface {
    Identity() agent.Identity
    Watch(ctx context.Context) error
    Subscribe() <-chan agent.Event
    Unsubscribe(ch <-chan agent.Event)
}
```

Same shape as `AgentWatcher` plus `Identity()`. PR5 deletes `AgentWatcher` and `agent.Event.Adapter`; `Watcher` is what the daemon will consume from then on.

**`WithIdentity()` builder + `Identity()` method** on each of the three existing watcher types:

- `fswatcher.Watcher`
- `processlifecycle.Scanner`
- `opencode.Watcher`

The builder pattern (rather than threading identity as a new constructor argument) leaves the 9 existing e2e test call sites for `fswatcher.New` / `processlifecycle.NewScanner` / `fswatcher.NewWithRoot` untouched — test callers that don't consume `Identity()` don't need updating.

**Three new identity_test.go files** under each watcher package: compile-time assertions that each concrete type satisfies both `inbound.AgentWatcher` and `inbound.Watcher`, plus a unit test asserting `WithIdentity → Identity` round-trips.

### Wiring updates

- `wiring.go:buildAgentWatchers` chains `.WithIdentity(a.Identity)` after each `fswatcher.New` and `processlifecycle.NewScanner`.
- `main.go` chains `.WithIdentity(opencode.Agent().Identity)` after `opencode.New`.

## Acceptance

- [x] `core/ports/inbound/watcher.go` exists with the `Watcher` interface
- [x] Each watcher type satisfies both `AgentWatcher` and `Watcher` (compile-time assertions in `identity_test.go`)
- [x] `Identity()` returns the value supplied by `WithIdentity()` (unit test per watcher)
- [x] `core/ports/inbound/ports.go` still defines `AgentWatcher`
- [x] `wiring.go` / `main.go` pass `a.Identity` to every watcher
- [x] M0 contract goldens byte-identity with PR1's versions
- [x] `tools/replay-fixtures.sh` green
- [x] `grep "func.*Identity() agent\.Identity" core/` returns exactly 3 hits (one per watcher)
- [x] `go test ./core/... -race -count=1` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)