### PR TITLE
refactor(agents): address PR #311 review nits (#159)

### DIFF
--- a/core/adapters/inbound/agents/aider/agent.go
+++ b/core/adapters/inbound/agents/aider/agent.go
@@ -26,14 +26,16 @@ const iconSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" 
 </svg>`
 
 // Agent returns the new declaration shape introduced in #159 Phase A.
-// Mirrors Config() for legacy callers and will replace Config() once the
-// daemon switches over (PR2/PR3). Parity tests assert equivalence.
 //
 // Aider is the only currently-supported adapter using FilesUnderCWD —
 // its transcript lives in each project's working directory rather than
 // under a fixed root, and the format is markdown rather than JSONL.
+//
+// RawLineParser carries a NewParser factory rather than bound method
+// values so each running aider process gets its own Parser instance.
+// Aider's Parser tracks idle-flush state, which must not collide across
+// concurrent processes targeting different project CWDs.
 func Agent() agent.Agent {
-	p := &Parser{}
 	return agent.Agent{
 		Identity: agent.Identity{
 			Name:         AdapterName,
@@ -48,8 +50,7 @@ func Agent() agent.Agent {
 		Source: agent.FilesUnderCWD{
 			Filename: transcriptFilename,
 			Parser: agent.RawLineParser{
-				ParseLineRaw: p.ParseLineRaw,
-				IdleFlush:    p.IdleFlush,
+				NewParser: func() agent.RawParser { return &Parser{} },
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/opencode/agent.go
+++ b/core/adapters/inbound/agents/opencode/agent.go
@@ -21,14 +21,15 @@ const iconSVGDark = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="
 </svg>`
 
 // Agent returns the new declaration shape introduced in #159 Phase A.
-// Mirrors Config() for legacy callers and will replace Config() once the
-// daemon switches over (PR2/PR3). Parity tests assert equivalence.
 //
 // OpenCode is the only currently-supported adapter using ProcessOwnedStore
 // — session state lives in a SQLite database rather than JSONL files.
-// PathForPID is a placeholder until PR5 wires the runtime dispatch; the
-// legacy shim in PR2 still drives metric computation through the Reader
-// directly using the adapter-supplied path string.
+// The daemon's wiring today drives metric computation through Reader
+// using the agent.Event.TranscriptPath supplied by the dedicated opencode
+// watcher (constructed inline in cmd/irrlichd/main.go); PathForPID is
+// not yet called. Phase C will introduce a runtime variant-dispatcher
+// that resolves the DB path from PID and installs a real implementation
+// here.
 func Agent() agent.Agent {
 	return agent.Agent{
 		Identity: agent.Identity{
@@ -42,12 +43,15 @@ func Agent() agent.Agent {
 			PIDForSession: DiscoverPID,
 		},
 		Source: agent.ProcessOwnedStore{
-			// Placeholder — runtime dispatch (PR5) will replace with the
-			// real PID→DB-path resolver. The legacy shim in PR2 does not
-			// call PathForPID; it uses the agent.Event.TranscriptPath
-			// supplied by the existing opencode watcher.
-			PathForPID: func(int) string { return "" },
-			Reader:     metricsReader{},
+			// Fail loudly if anything ever calls this before the Phase C
+			// runtime dispatcher installs a real resolver. Returning an
+			// empty string here would have caused silent downstream
+			// failures (ComputeMetrics opening "" → no rows → empty
+			// metrics) instead of an obvious crash.
+			PathForPID: func(int) string {
+				panic("opencode.Agent().Source.PathForPID: not wired — Phase C runtime dispatch installs the real resolver")
+			},
+			Reader: metricsReader{},
 		},
 	}
 }

--- a/core/adapters/outbound/filesystem/repository_contract_test.go
+++ b/core/adapters/outbound/filesystem/repository_contract_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"irrlicht/core/adapters/outbound/filesystem"
-	"irrlicht/core/domain/session"
+	"irrlicht/core/internal/contracttesting"
 )
 
 const updateContractGoldensEnv = "UPDATE_CONTRACT_GOLDENS"
@@ -25,7 +25,7 @@ const updateContractGoldensEnv = "UPDATE_CONTRACT_GOLDENS"
 // intentionally left nil — covering it would require an exported constructor
 // in domain/session, which is out of scope for this safety-net test.
 func TestContract_SessionStateOnDisk(t *testing.T) {
-	state := buildContractSessionState()
+	state := contracttesting.BuildFullSessionState()
 	repo := filesystem.NewWithDir(t.TempDir())
 	if err := repo.Save(state); err != nil {
 		t.Fatalf("save: %v", err)
@@ -37,65 +37,6 @@ func TestContract_SessionStateOnDisk(t *testing.T) {
 
 	goldenPath := filepath.Join("testdata", "session_state.golden.json")
 	compareContractGolden(t, got, goldenPath)
-}
-
-// buildContractSessionState produces a deterministic SessionState fixture that
-// exercises every JSON-persisted field. Hardcoded UUIDs and timestamps make
-// the golden stable across machines and runs.
-func buildContractSessionState() *session.SessionState {
-	waitingStart := int64(1700000050)
-	return &session.SessionState{
-		Version:         1,
-		SessionID:       "00000000-0000-0000-0000-000000000001",
-		State:           session.StateWorking,
-		Adapter:         "claude-code",
-		CompactionState: session.CompactionStateNotCompacting,
-		Model:           "claude-sonnet-4-6",
-		CWD:             "/tmp/test-cwd",
-		TranscriptPath:  "/tmp/test-transcript.jsonl",
-		GitBranch:       "main",
-		ProjectName:     "test-project",
-		FirstSeen:       1700000000,
-		UpdatedAt:       1700000100,
-		Confidence:      "high",
-		EventCount:      42,
-		LastEvent:       "assistant",
-		LastMatcher:     "claude-stop-hook",
-		Metrics: &session.SessionMetrics{
-			ElapsedSeconds:         300,
-			TotalTokens:            10000,
-			ModelName:              "claude-sonnet-4-6",
-			ContextWindow:          200000,
-			ContextUtilization:     5.0,
-			PressureLevel:          "low",
-			HasOpenToolCall:        true,
-			OpenToolCallCount:      1,
-			OpenSubagents:          2,
-			LastEventType:          "tool_use",
-			LastOpenToolNames:      []string{"Bash"},
-			EstimatedCostUSD:       0.0123,
-			CumInputTokens:         8000,
-			CumOutputTokens:        2000,
-			CumCacheReadTokens:     1500,
-			CumCacheCreationTokens: 500,
-			LastAssistantText:      "Working on it.",
-			PermissionMode:         "default",
-			Tasks: []session.Task{
-				{ID: "task-1", Subject: "first task", ActiveForm: "Doing first task", Status: "in_progress"},
-				{ID: "task-2", Subject: "second task", Status: "pending"},
-			},
-		},
-		PID: 12345,
-		Launcher: &session.Launcher{
-			TermProgram:    "iTerm.app",
-			ITermSessionID: "w0t0p0:ABCDEF",
-			TTY:            "/dev/ttys001",
-		},
-		ParentSessionID:    "00000000-0000-0000-0000-000000000002",
-		DaemonVersion:      "0.3.13",
-		LastTranscriptSize: 1024,
-		WaitingStartTime:   &waitingStart,
-	}
 }
 
 // compareContractGolden is the byte-identity comparator shared by every

--- a/core/cmd/irrlichd/contract_helpers_test.go
+++ b/core/cmd/irrlichd/contract_helpers_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"irrlicht/core/domain/session"
 )
 
 // Contract-test shared helpers. Files in this package whose names contain
@@ -38,65 +36,5 @@ func compareContractGolden(t *testing.T, got []byte, goldenPath string) {
 	if !bytes.Equal(got, want) {
 		t.Fatalf("contract drift in %s; run %s=1 go test ./... to refresh\n--- want (%d bytes) ---\n%s\n--- got (%d bytes) ---\n%s",
 			goldenPath, updateContractGoldensEnv, len(want), want, len(got), got)
-	}
-}
-
-// buildContractSessionState mirrors the fixture in
-// core/adapters/outbound/filesystem/repository_contract_test.go. Kept in
-// sync by hand — if the SessionState shape changes, both fixtures and both
-// goldens are regenerated together via the UPDATE env var.
-func buildContractSessionState() *session.SessionState {
-	waitingStart := int64(1700000050)
-	return &session.SessionState{
-		Version:         1,
-		SessionID:       "00000000-0000-0000-0000-000000000001",
-		State:           session.StateWorking,
-		Adapter:         "claude-code",
-		CompactionState: session.CompactionStateNotCompacting,
-		Model:           "claude-sonnet-4-6",
-		CWD:             "/tmp/test-cwd",
-		TranscriptPath:  "/tmp/test-transcript.jsonl",
-		GitBranch:       "main",
-		ProjectName:     "test-project",
-		FirstSeen:       1700000000,
-		UpdatedAt:       1700000100,
-		Confidence:      "high",
-		EventCount:      42,
-		LastEvent:       "assistant",
-		LastMatcher:     "claude-stop-hook",
-		Metrics: &session.SessionMetrics{
-			ElapsedSeconds:         300,
-			TotalTokens:            10000,
-			ModelName:              "claude-sonnet-4-6",
-			ContextWindow:          200000,
-			ContextUtilization:     5.0,
-			PressureLevel:          "low",
-			HasOpenToolCall:        true,
-			OpenToolCallCount:      1,
-			OpenSubagents:          2,
-			LastEventType:          "tool_use",
-			LastOpenToolNames:      []string{"Bash"},
-			EstimatedCostUSD:       0.0123,
-			CumInputTokens:         8000,
-			CumOutputTokens:        2000,
-			CumCacheReadTokens:     1500,
-			CumCacheCreationTokens: 500,
-			LastAssistantText:      "Working on it.",
-			PermissionMode:         "default",
-			Tasks: []session.Task{
-				{ID: "task-1", Subject: "first task", ActiveForm: "Doing first task", Status: "in_progress"},
-				{ID: "task-2", Subject: "second task", Status: "pending"},
-			},
-		},
-		PID: 12345,
-		Launcher: &session.Launcher{
-			TermProgram:    "iTerm.app",
-			ITermSessionID: "w0t0p0:ABCDEF",
-			TTY:            "/dev/ttys001",
-		},
-		ParentSessionID:    "00000000-0000-0000-0000-000000000002",
-		DaemonVersion:      "0.3.13",
-		LastTranscriptSize: 1024,
-		WaitingStartTime:   &waitingStart,
 	}
 }

--- a/core/cmd/irrlichd/push_contract_test.go
+++ b/core/cmd/irrlichd/push_contract_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"irrlicht/core/internal/contracttesting"
 	"irrlicht/core/ports/outbound"
 )
 
@@ -23,7 +24,7 @@ import (
 // bytes the WebSocket writes" — so json.MarshalIndent is used for golden
 // readability.
 func TestContract_PushMessages(t *testing.T) {
-	state := buildContractSessionState()
+	state := contracttesting.BuildFullSessionState()
 	priority := int8(2)
 
 	cases := []struct {

--- a/core/domain/agent/file_parser.go
+++ b/core/domain/agent/file_parser.go
@@ -27,16 +27,21 @@ type JSONLineParser struct {
 func (JSONLineParser) isFileParser() {}
 
 // RawLineParser is used by adapters whose source format is not JSONL
-// (aider's .aider.chat.history.md is markdown). ParseLineRaw is called for
-// each raw line; IdleFlush synthesizes a turn_done event after the
-// transcript has been quiet for `idleFor` because raw formats typically
-// don't write an explicit end-of-turn marker.
+// (aider's .aider.chat.history.md is markdown). NewParser returns a
+// fresh stateful RawParser instance per transcript file — same factory
+// pattern as JSONLineParser. ParseLineRaw is called for each raw line;
+// IdleFlush synthesizes a turn_done event after the transcript has been
+// quiet for `idleFor` because raw formats typically don't write an
+// explicit end-of-turn marker.
 //
-// FilesUnderCWD always pairs with this type. FilesUnderRoot could in
-// principle carry one, though no currently-supported adapter does so.
+// FilesUnderCWD always pairs with this type, and each running agent
+// process gets its own RawParser instance (idle tracking and similar
+// state must not collide across concurrent processes).
+//
+// FilesUnderRoot could in principle carry one, though no currently-
+// supported adapter does so.
 type RawLineParser struct {
-	ParseLineRaw func(line string) *tailer.ParsedEvent
-	IdleFlush    func(idleFor time.Duration) *tailer.ParsedEvent
+	NewParser func() RawParser
 }
 
 func (RawLineParser) isFileParser() {}
@@ -47,6 +52,17 @@ func (RawLineParser) isFileParser() {}
 // lines that should be silently ignored.
 type LineParser interface {
 	ParseLine(raw map[string]interface{}) *tailer.ParsedEvent
+}
+
+// RawParser extends LineParser with the raw-text methods used by
+// FilesUnderCWD adapters. ParseLine on a RawParser is expected to be a
+// no-op returning nil — the runtime calls ParseLineRaw instead. IdleFlush
+// synthesizes a turn_done event when the transcript has been quiet for
+// `idleFor`; raw formats typically have no end-of-turn marker.
+type RawParser interface {
+	LineParser
+	ParseLineRaw(line string) *tailer.ParsedEvent
+	IdleFlush(idleFor time.Duration) *tailer.ParsedEvent
 }
 
 // PendingContributor is an optional refinement on LineParser. Stateful

--- a/core/internal/contracttesting/fixtures.go
+++ b/core/internal/contracttesting/fixtures.go
@@ -1,0 +1,83 @@
+// Package contracttesting holds shared test fixtures consumed by the M0
+// contract tests in multiple packages.
+//
+// The same SessionState fixture is exercised by:
+//   - core/adapters/outbound/filesystem/repository_contract_test.go
+//     (snapshots the on-disk JSON written by SessionRepository.Save)
+//   - core/cmd/irrlichd/push_contract_test.go
+//     (snapshots the WebSocket envelope shape for each PushMessage type
+//     that carries a SessionState)
+//
+// Keeping it in one place prevents the goldens in those two packages
+// from drifting silently when the SessionState shape evolves: a change
+// here regenerates both via UPDATE_CONTRACT_GOLDENS=1.
+//
+// The package lives under core/internal/ so production code cannot
+// import it.
+package contracttesting
+
+import "irrlicht/core/domain/session"
+
+// BuildFullSessionState produces a deterministic SessionState fixture
+// that exercises every JSON-persisted field. Hardcoded UUIDs and
+// timestamps make the resulting golden stable across machines and runs.
+//
+// The Subagents field uses an unexported type from the session package
+// and is intentionally left nil — covering it would require an exported
+// constructor in domain/session, which is out of scope for this
+// safety-net test.
+func BuildFullSessionState() *session.SessionState {
+	waitingStart := int64(1700000050)
+	return &session.SessionState{
+		Version:         1,
+		SessionID:       "00000000-0000-0000-0000-000000000001",
+		State:           session.StateWorking,
+		Adapter:         "claude-code",
+		CompactionState: session.CompactionStateNotCompacting,
+		Model:           "claude-sonnet-4-6",
+		CWD:             "/tmp/test-cwd",
+		TranscriptPath:  "/tmp/test-transcript.jsonl",
+		GitBranch:       "main",
+		ProjectName:     "test-project",
+		FirstSeen:       1700000000,
+		UpdatedAt:       1700000100,
+		Confidence:      "high",
+		EventCount:      42,
+		LastEvent:       "assistant",
+		LastMatcher:     "claude-stop-hook",
+		Metrics: &session.SessionMetrics{
+			ElapsedSeconds:         300,
+			TotalTokens:            10000,
+			ModelName:              "claude-sonnet-4-6",
+			ContextWindow:          200000,
+			ContextUtilization:     5.0,
+			PressureLevel:          "low",
+			HasOpenToolCall:        true,
+			OpenToolCallCount:      1,
+			OpenSubagents:          2,
+			LastEventType:          "tool_use",
+			LastOpenToolNames:      []string{"Bash"},
+			EstimatedCostUSD:       0.0123,
+			CumInputTokens:         8000,
+			CumOutputTokens:        2000,
+			CumCacheReadTokens:     1500,
+			CumCacheCreationTokens: 500,
+			LastAssistantText:      "Working on it.",
+			PermissionMode:         "default",
+			Tasks: []session.Task{
+				{ID: "task-1", Subject: "first task", ActiveForm: "Doing first task", Status: "in_progress"},
+				{ID: "task-2", Subject: "second task", Status: "pending"},
+			},
+		},
+		PID: 12345,
+		Launcher: &session.Launcher{
+			TermProgram:    "iTerm.app",
+			ITermSessionID: "w0t0p0:ABCDEF",
+			TTY:            "/dev/ttys001",
+		},
+		ParentSessionID:    "00000000-0000-0000-0000-000000000002",
+		DaemonVersion:      "0.3.13",
+		LastTranscriptSize: 1024,
+		WaitingStartTime:   &waitingStart,
+	}
+}


### PR DESCRIPTION
## Summary

Three small follow-ups to #311 surfaced by the post-merge review. None change runtime behavior; M0 contract goldens are byte-identity.

### 1. Factor SessionState fixture into `core/internal/contracttesting`

`BuildFullSessionState` was duplicated in `core/adapters/outbound/filesystem/repository_contract_test.go` and `core/cmd/irrlichd/contract_helpers_test.go` and explicitly documented as \"kept in sync by hand\" — a silent-drift risk between the two goldens. Moved to a single source.

\`core/internal/\` placement prevents production code from importing the fixture by accident.

### 2. `RawLineParser` carries a `NewParser` factory + new `RawParser` interface

The PR1 shape bound bound method values to a **single shared** `aider.Parser` instance:

\`\`\`go
p := &Parser{}
agent.RawLineParser{
    ParseLineRaw: p.ParseLineRaw,  // ← bound to *this* instance
    IdleFlush:    p.IdleFlush,
}
\`\`\`

`FilesUnderCWD` is per-process by design — each running aider's transcript lives in its own working directory. With the bound shape, parser state (idle tracking, etc.) would collide once a real runtime starts driving the parser per agent process. New shape mirrors `JSONLineParser.NewParser` so each process gets its own `RawParser`.

### 3. `opencode.PathForPID` panics instead of returning `\"\"`

The PR1 placeholder returned `\"\"` silently. If anything calls it before Phase C wires the real resolver, `ComputeMetrics` opens `\"\"` → empty metrics → no error → silent partial failure. Now panics with a message naming the missing wiring.

## Test plan

- [x] `go build ./core/...` clean
- [x] `go test ./core/... -race -count=1` green
- [x] `tools/replay-fixtures.sh` green
- [x] M0 contract goldens **byte-identical** with versions committed in #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)