### PR TITLE
refactor(agents): apply review fixes for PRs #313-#316 (#159)

### DIFF
--- a/core/adapters/inbound/agents/fswatcher/watcher.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher.go
@@ -21,7 +21,7 @@ import (
 type Watcher struct {
 	root     string         // resolved absolute path to the watched directory
 	adapter  string         // adapter name set on emitted events
-	identity agent.Identity // populated via WithIdentity (#159 Phase A.4)
+	identity agent.Identity // populated via WithIdentity
 	maxAge   time.Duration  // ignore files older than this (0 = no limit)
 
 	subMu sync.Mutex

--- a/core/adapters/inbound/agents/maps.go
+++ b/core/adapters/inbound/agents/maps.go
@@ -66,13 +66,11 @@ func PIDDiscoverers(agents []agent.Agent) map[string]agent.PIDDiscoverFunc {
 }
 
 // ProcessNames produces the adapter-name → OS-process-name map used by
-// the startup zombie sweep. For ExactName matchers, the OS process name
-// IS the matcher name. For CommandPattern matchers (aider), no reliable
-// OS process name exists (aider runs under python), so we fall back to
-// Identity.Name — same value the historical agents.Config.ProcessName
-// carried for that adapter. The zombie sweep does pgrep -x against this
-// and finds nothing for CommandPattern adapters, which is correct
-// behavior.
+// the startup zombie sweep. For ExactName matchers the OS process name
+// IS the matcher name. For CommandPattern matchers no reliable OS
+// process name exists (e.g. aider runs under python), so we fall back
+// to Identity.Name; the zombie sweep does pgrep -x against this and
+// finds nothing, which is correct behavior.
 func ProcessNames(agents []agent.Agent) map[string]string {
 	m := make(map[string]string, len(agents))
 	for _, a := range agents {
@@ -80,7 +78,7 @@ func ProcessNames(agents []agent.Agent) map[string]string {
 			m[a.Identity.Name] = e.Name
 			continue
 		}
-		// CommandPattern: preserve historical Config.ProcessName=Identity.Name.
+		// CommandPattern: fall back to the adapter's Identity.Name.
 		m[a.Identity.Name] = a.Identity.Name
 	}
 	return m

--- a/core/adapters/inbound/agents/opencode/watcher.go
+++ b/core/adapters/inbound/agents/opencode/watcher.go
@@ -45,7 +45,7 @@ const defaultMinScanGap = 500 * time.Millisecond
 type Watcher struct {
 	dbPath   string         // absolute path to opencode.db
 	adapter  string         // always "opencode"
-	identity agent.Identity // populated via WithIdentity (#159 Phase A.4)
+	identity agent.Identity // populated via WithIdentity
 	maxAge   time.Duration  // ignore sessions older than this (0 = no limit)
 
 	subMu sync.Mutex

--- a/core/adapters/inbound/agents/processlifecycle/scanner.go
+++ b/core/adapters/inbound/agents/processlifecycle/scanner.go
@@ -40,7 +40,7 @@ type Scanner struct {
 	commandLineMatch   string         // if non-empty, used with pgrep -f instead of -x ProcessName
 	transcriptFilename string         // if non-empty, scanner checks <CWD>/<filename> for the real transcript
 	adapter            string         // adapter label placed on emitted events
-	identity           agent.Identity // populated via WithIdentity (#159 Phase A.4)
+	identity           agent.Identity // populated via WithIdentity
 	interval           time.Duration
 
 	// sessionChecker is an optional function that reports whether a real

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -33,21 +33,27 @@ type Adapter struct {
 	fallback         agents.ParserFactory // used for unknown adapter names
 }
 
-// New returns a new metrics Adapter configured from the given per-adapter
-// registries. The fallback parser is used for unknown adapter names to
-// preserve the historical "default to Claude Code" behavior; callers
-// should pass the Claude Code factory.
-//
-// Signature simplified in #159 Phase A.2: previously took []agents.Config
-// and derived the three maps internally. Callers now produce the maps via
-// agents.Parsers / SubagentCounters / MetricsProviders.
-func New(parsers map[string]agents.ParserFactory, subagents map[string]agents.SubagentCounter, providers map[string]agents.MetricsProvider, fallback agents.ParserFactory) *Adapter {
+// Registry holds the per-adapter behaviour the metrics adapter dispatches
+// on. Callers populate it from an []agent.Agent slice via the helpers in
+// core/adapters/inbound/agents (Parsers, SubagentCounters,
+// MetricsProviders).
+type Registry struct {
+	Parsers          map[string]agents.ParserFactory
+	SubagentCounters map[string]agents.SubagentCounter
+	MetricsProviders map[string]agents.MetricsProvider
+	// FallbackParser is used for unknown adapter names — preserves the
+	// historical "default to Claude Code" behaviour.
+	FallbackParser agents.ParserFactory
+}
+
+// New returns a metrics Adapter configured from the given Registry.
+func New(r Registry) *Adapter {
 	return &Adapter{
 		tailers:          make(map[string]*lockedTailer),
-		parsers:          parsers,
-		subagents:        subagents,
-		metricsProviders: providers,
-		fallback:         fallback,
+		parsers:          r.Parsers,
+		subagents:        r.SubagentCounters,
+		metricsProviders: r.MetricsProviders,
+		fallback:         r.FallbackParser,
 	}
 }
 

--- a/core/adapters/outbound/metrics/adapter_test.go
+++ b/core/adapters/outbound/metrics/adapter_test.go
@@ -31,7 +31,7 @@ func TestPruneEntry_RemovesLedgerAndCacheEntry(t *testing.T) {
 		t.Fatalf("write ledger: %v", err)
 	}
 
-	a := New(nil, nil, nil, nil)
+	a := New(Registry{})
 	a.tailers[transcript] = &lockedTailer{}
 
 	a.PruneEntry(transcript)
@@ -48,12 +48,12 @@ func TestPruneEntry_IdempotentOnMissingFile(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	a := New(nil, nil, nil, nil)
+	a := New(Registry{})
 	// No file written, no map entry — should not panic or error.
 	a.PruneEntry(filepath.Join(tmpHome, "never-existed.jsonl"))
 }
 
 func TestPruneEntry_EmptyPathNoop(t *testing.T) {
-	a := New(nil, nil, nil, nil)
+	a := New(Registry{})
 	a.PruneEntry("") // must not panic
 }

--- a/core/application/services/identity_guard_test.go
+++ b/core/application/services/identity_guard_test.go
@@ -1,0 +1,41 @@
+package services_test
+
+import (
+	"strings"
+	"testing"
+
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/ports/inbound"
+)
+
+// TestNewSessionDetector_PanicsOnZeroIdentity verifies the safety check
+// that fails fast when a watcher with an unset Identity is wired into
+// the detector. Without this guard, every session bootstrapped from
+// that watcher's events would have an empty Adapter field — silent
+// observability failure.
+func TestNewSessionDetector_PanicsOnZeroIdentity(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when watcher has zero Identity, got none")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("panic payload not a string: %T %v", r, r)
+		}
+		if !strings.Contains(msg, "Identity") || !strings.Contains(msg, "WithIdentity") {
+			t.Errorf("panic message should name Identity and WithIdentity; got %q", msg)
+		}
+	}()
+
+	tw := newMockAgentWatcher()
+	tw.identity = agent.Identity{} // clear the default
+
+	services.NewSessionDetector(
+		[]inbound.Watcher{tw},
+		newMockProcessWatcher(), newMockRepo(),
+		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
+		"test", 0, nil, nil, nil,
+	)
+}

--- a/core/application/services/metadata_enricher.go
+++ b/core/application/services/metadata_enricher.go
@@ -53,8 +53,7 @@ func (e *metadataEnricher) EnrichNewSession(state *session.SessionState, ev agen
 
 	// Compute initial metrics (no-op for pre-sessions with no transcript).
 	// state.Adapter is already populated by the caller in onNewSession
-	// before this enricher runs; metadata_enricher uses it the same way
-	// RefreshOnActivity does (#159 Phase A.5, post-Event.Adapter removal).
+	// before this enricher runs.
 	if m, _ := e.metrics.ComputeMetrics(ev.TranscriptPath, state.Adapter); m != nil {
 		state.Metrics = m
 	}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -10,6 +10,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -124,8 +125,14 @@ type SessionDetector struct {
 	permissionPending map[string]bool // sessionID → true
 }
 
-// NewSessionDetector creates a SessionDetector with all required dependencies.
-// pw and broadcaster may be nil (optional).
+// NewSessionDetector creates a SessionDetector with all required
+// dependencies. pw and broadcaster may be nil (optional).
+//
+// Panics if any supplied watcher has a zero-value Identity. Every
+// downstream session created from that watcher's events would otherwise
+// have an empty Adapter field — a silent partial-failure mode (the
+// adapter-aware code paths fall back gracefully, but logs and the
+// /api/v1/agents endpoint surface "" instead of the real name).
 func NewSessionDetector(
 	watchers []inbound.Watcher,
 	pw outbound.ProcessWatcher,
@@ -140,6 +147,11 @@ func NewSessionDetector(
 	processNames map[string]string,
 	liveCWDs LiveCWDsFunc,
 ) *SessionDetector {
+	for _, w := range watchers {
+		if w.Identity() == (agent.Identity{}) {
+			panic(fmt.Sprintf("session_detector: watcher %T has no Identity — call .WithIdentity() before passing it to NewSessionDetector", w))
+		}
+	}
 	det := &SessionDetector{
 		watchers:          watchers,
 		repo:              repo,
@@ -247,8 +259,7 @@ func (d *SessionDetector) record(ev lifecycle.Event) {
 // Each per-watcher drain goroutine captures the watcher's Identity once
 // and tags every event with it as the event flows into the merged
 // channel; this is how the adapter name reaches handleTranscriptEvent
-// for lifecycle recording and SessionState bootstrap (it no longer
-// lives on agent.Event itself — see #159 Phase A.5).
+// for lifecycle recording and SessionState bootstrap.
 func (d *SessionDetector) Run(ctx context.Context) error {
 	merged := make(chan identifiedEvent, 16)
 	var wg sync.WaitGroup
@@ -315,10 +326,7 @@ func (d *SessionDetector) Run(ctx context.Context) error {
 		case ev := <-d.debouncedEvents:
 			// Coalesced events from debounce timers — process in the event
 			// loop goroutine so processActivity never runs concurrently.
-			// Identity isn't carried through the debounce path; processActivity
-			// uses state.Adapter for live sessions and drops the (rare) event
-			// where state is nil and we'd need an identity to bootstrap.
-			d.processActivity(agent.Identity{}, ev)
+			d.processActivityWithoutIdentity(ev)
 		case <-refreshTicker.C:
 			d.refreshStaleSessions()
 		}

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -214,17 +214,26 @@ func (d *SessionDetector) onActivity(id agent.Identity, ev agent.Event) {
 	d.record(lifecycle.Event{Kind: lifecycle.KindDebounceCoalesced, SessionID: ev.SessionID})
 }
 
-// processActivity handles a (possibly debounced) transcript activity event.
-// It uses content-based detection to determine whether the agent is working
-// or waiting for user input.
+// processActivityWithoutIdentity is the entry point for paths where the
+// originating watcher's Identity is not available — coalesced events
+// from the debounce timers and synthetic refresh events injected by
+// refreshStaleSessions. The session is expected to already exist with
+// a populated state.Adapter; for live sessions processActivity uses
+// state.Adapter, and the rare onNewSession fallback runs with empty
+// identity (state.Adapter ends up empty, then is back-filled by the
+// next watcher-driven event for the same session).
+func (d *SessionDetector) processActivityWithoutIdentity(ev agent.Event) {
+	d.processActivity(agent.Identity{}, ev)
+}
+
+// processActivity handles a (possibly debounced) transcript activity
+// event. It uses content-based detection to determine whether the agent
+// is working or waiting for user input.
 //
-// id is the watcher's Identity only when this method is invoked directly
-// from handleTranscriptEvent / onActivity (the first event in a debounce
-// window). Coalesced events from the debouncedEvents channel and synthetic
-// refresh events both arrive with an empty Identity — they rely on a
-// pre-existing state record's Adapter field instead. The rare fallback
-// path (state == nil, --continue cooldown expired) drops the event when
-// id is empty rather than bootstrap a session without an adapter name.
+// id is the watcher's Identity only when invoked directly from
+// handleTranscriptEvent / onActivity (the first event in a debounce
+// window). For the no-identity entry points, call
+// processActivityWithoutIdentity instead.
 func (d *SessionDetector) processActivity(id agent.Identity, ev agent.Event) {
 	// Load session state.
 	state, err := d.repo.Load(ev.SessionID)
@@ -438,7 +447,7 @@ func (d *SessionDetector) refreshStaleSessions() {
 		if now.Sub(time.Unix(state.UpdatedAt, 0)) < staleWorkingRefreshInterval {
 			continue
 		}
-		d.processActivity(agent.Identity{}, agent.Event{
+		d.processActivityWithoutIdentity(agent.Event{
 			Type:           agent.EventActivity,
 			SessionID:      state.SessionID,
 			TranscriptPath: state.TranscriptPath,

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -164,12 +164,15 @@ func main() {
 
 	// Shared adapters for SessionDetector.
 	gitResolver := git.New()
-	metricsCollector := metrics.New(
-		parserFactories,
-		agents.SubagentCounters(allAgents),
-		agents.MetricsProviders(allAgents),
-		parserFactories[allAgents[0].Identity.Name],
-	)
+	// Claude Code's parser is the documented fallback for unknown adapter
+	// names. Pinning by name rather than allAgents[0] decouples the
+	// fallback from slice ordering.
+	metricsCollector := metrics.New(metrics.Registry{
+		Parsers:          parserFactories,
+		SubagentCounters: agents.SubagentCounters(allAgents),
+		MetricsProviders: agents.MetricsProviders(allAgents),
+		FallbackParser:   parserFactories[claudecode.AdapterName],
+	})
 
 	// --- File-based SessionDetector (primary detection path) ---
 	// Forward-reference: detector is assigned before any callbacks can fire,

--- a/core/cmd/irrlichd/wiring.go
+++ b/core/cmd/irrlichd/wiring.go
@@ -10,26 +10,18 @@ import (
 	"irrlicht/core/ports/inbound"
 )
 
-// buildAgentWatchers dispatches on the Agent's Source variant and constructs
-// the appropriate transcript watchers + process scanners for that adapter.
+// buildAgentWatchers dispatches on the Agent's Source variant and
+// constructs the appropriate transcript watchers + process scanners.
 //
-// FilesUnderRoot adapters (claudecode, codex, pi) get both:
-//   - an fswatcher rooted at the variant's Dir
-//   - a process scanner keyed on ProcessName/CommandPattern
+// FilesUnderRoot adapters get both an fswatcher rooted at the variant's
+// Dir and a process scanner keyed on the matcher. FilesUnderCWD adapters
+// get only a scanner, configured with the variant's Filename so it emits
+// transcript_new events on first appearance of the per-process file
+// inside CWD. ProcessOwnedStore adapters get only a scanner; their
+// dedicated DB-aware watcher is constructed separately by main.go.
 //
-// FilesUnderCWD adapters (aider) get only a process scanner, configured with
-// the variant's Filename so the scanner emits transcript_new events on first
-// appearance of the per-process file inside CWD.
-//
-// ProcessOwnedStore adapters (opencode) get only a process scanner. Their
-// dedicated DB-aware watcher is constructed separately by main.go (e.g.
-// opencode.New). The fswatcher that pre-A.2 code mistakenly created for these
-// adapters (rooted at the DB directory) emitted no useful transcript events
-// and is no longer constructed — drop is behavior-preserving in effect.
-//
-// Returns the list of watchers and a human-readable label for the startup
-// log line (matches the pre-A.2 "<adapter> (<root>)" / "<adapter>-db (<root>)"
-// format).
+// Returns the list of watchers and a human-readable label for the
+// startup log line ("<adapter> (<root>)").
 func buildAgentWatchers(
 	a agent.Agent,
 	maxSessionAge time.Duration,
@@ -60,13 +52,11 @@ func buildAgentWatchers(
 }
 
 // processNameFor returns the OS process name suitable for pgrep -x. For
-// ExactName matchers, that's the matcher's Name. For CommandPattern
-// matchers (aider), no reliable name exists — aider runs under python —
-// so we fall back to the Identity.Name, mirroring the historical value
-// the legacy agents.Config.ProcessName carried for that adapter. The
-// scanner's WithCommandLineMatch path bypasses pgrep -x and matches the
-// full command line instead, so the fallback name is never actually
-// matched against running processes.
+// ExactName matchers it's the matcher's Name. For CommandPattern
+// matchers (e.g. aider runs under python) no reliable name exists, so
+// we fall back to Identity.Name. The scanner's WithCommandLineMatch
+// path bypasses pgrep -x in that case, so the fallback name is never
+// actually matched against running processes.
 func processNameFor(a agent.Agent) string {
 	if e, ok := a.Process.Match.(agent.ExactName); ok {
 		return e.Name

--- a/core/e2e/concurrent_test.go
+++ b/core/e2e/concurrent_test.go
@@ -8,6 +8,7 @@ import (
 
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/ports/inbound"
 )
 
@@ -23,7 +24,7 @@ func TestScanner_TracksTwoConcurrentProcessesWithSameAgentName(t *testing.T) {
 	cmd1, cwd1 := startFakeClaudeProcessNamed(t, name)
 	cmd2, cwd2 := startFakeClaudeProcessNamed(t, name)
 
-	scanner := processlifecycle.NewScanner(name, "test", 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(name, "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
 	repo := newMemRepo()
 
 	detector := services.NewSessionDetector(

--- a/core/e2e/crash_test.go
+++ b/core/e2e/crash_test.go
@@ -9,6 +9,7 @@ import (
 
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/inbound"
 )
@@ -24,7 +25,7 @@ import (
 func TestSession_NoCancelledState_OnSIGKILL(t *testing.T) {
 	cmd, _ := startFakeClaudeProcess(t)
 
-	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
 	repo := newMemRepo()
 
 	detector := services.NewSessionDetector(

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -44,7 +44,7 @@ func TestPreSession_DetectedBeforeTranscript(t *testing.T) {
 	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
 
 	// Wire up: Scanner → SessionDetector (with in-memory stubs).
-	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
 	repo := newMemRepo()
 
 	detector := services.NewSessionDetector(
@@ -117,11 +117,14 @@ func TestPreSession_ReplacedByRealSession(t *testing.T) {
 	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
 
 	projectsRoot := realTempDir(t)
-	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
 	repo := newMemRepo()
 
 	// Also wire a mock transcript watcher so we can inject a real session event.
-	transcriptWatcher := &mockWatcher{ch: make(chan agent.Event, 4)}
+	transcriptWatcher := &mockWatcher{
+		ch:       make(chan agent.Event, 4),
+		identity: agent.Identity{Name: "test"},
+	}
 
 	detector := services.NewSessionDetector(
 		[]inbound.Watcher{scanner, transcriptWatcher},
@@ -204,7 +207,7 @@ func TestPreSession_CreatedDespiteHistoricalSession(t *testing.T) {
 		TranscriptPath: filepath.Join(projectsRoot, projectDir, "old.jsonl"),
 	})
 
-	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
 	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
 	detector := services.NewSessionDetector(
@@ -255,7 +258,7 @@ func TestPreSession_SurvivesNeighbourSessionActivity(t *testing.T) {
 	_ = os.Chtimes(neighbourJSONL, now, now)
 
 	repo := newMemRepo()
-	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
 	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
 	detector := services.NewSessionDetector(
@@ -305,7 +308,7 @@ func TestPreSession_RemovedOnProcessExit(t *testing.T) {
 		t.Fatalf("start: %v", err)
 	}
 
-	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond)
+	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
 	repo := newMemRepo()
 
 	detector := services.NewSessionDetector(

--- a/core/ports/inbound/ports.go
+++ b/core/ports/inbound/ports.go
@@ -1,11 +1,9 @@
-// Package inbound defines inbound port interfaces — contracts that inbound
-// adapters (file watchers, HTTP handlers, etc.) satisfy to drive the
-// application core.
+// Package inbound defines inbound port interfaces — contracts that
+// inbound adapters (file watchers, HTTP handlers, etc.) satisfy to
+// drive the application core.
 //
-// The new agent-side port is Watcher (see watcher.go). The historical
-// AgentWatcher was removed in #159 Phase A.5; the daemon now consumes
-// Watcher exclusively and uses Watcher.Identity() to tag events with
-// their adapter name (replacing the agent.Event.Adapter field).
+// The agent-side port is Watcher (see watcher.go); the orchestrator
+// side is OrchestratorWatcher (below).
 package inbound
 
 import (

--- a/core/ports/inbound/watcher.go
+++ b/core/ports/inbound/watcher.go
@@ -6,21 +6,14 @@ import (
 	"irrlicht/core/domain/agent"
 )
 
-// Watcher is the new inbound port introduced in #159 Phase A.4. It mirrors
-// AgentWatcher's shape (lifecycle + event stream) and adds Identity() so
-// the daemon can tag events with their watcher's identity without
-// bouncing through the redundant agent.Event.Adapter field. In PR5 the
-// daemon switches to consuming this port exclusively, AgentWatcher is
-// deleted, and agent.Event.Adapter is dropped.
-//
-// PR4 (this PR) leaves AgentWatcher intact and has every existing
-// watcher implementation satisfy both interfaces by gaining an
-// Identity() method.
+// Watcher is the inbound port the daemon consumes for transcript-file
+// events. Identity() lets the daemon tag each event with its watcher's
+// adapter identity instead of stamping the name on every event payload.
 type Watcher interface {
 	// Identity returns the metadata for the agent this watcher serves
-	// (Name, DisplayName, IconSVGLight, IconSVGDark). Stored on the
-	// watcher at construction time via the new WithIdentity() builder
-	// method.
+	// (Name, DisplayName, IconSVGLight, IconSVGDark). Implementations
+	// must return a non-zero Identity before being registered with the
+	// SessionDetector (which panics on zero values).
 	Identity() agent.Identity
 
 	// Watch begins watching for transcript changes. Blocks until ctx is


### PR DESCRIPTION
## Summary

Five fixes from the post-merge code review of #313–#316. None change runtime behavior; all tests + replay green; M0 contract goldens byte-identical.

### 1. Pin metrics fallback parser by name

\`core/cmd/irrlichd/main.go:171\` used \`parserFactories[allAgents[0].Identity.Name]\` — relying on slice ordering for the "default to Claude Code" convention. Now pinned explicitly: \`parserFactories[claudecode.AdapterName]\`.

### 2. \`metrics.New\` takes a \`Registry\` struct

Replaces the 4-arg signature (\`parsers, subagents, providers, fallback\`) with:

\`\`\`go
metrics.New(metrics.Registry{
    Parsers:          ...,
    SubagentCounters: ...,
    MetricsProviders: ...,
    FallbackParser:   ...,
})
\`\`\`

Scales without further parameter sprawl; field names are self-documenting at the call site.

### 3. Zero-Identity panic guard at \`NewSessionDetector\`

The most substantive change. \`NewSessionDetector\` now panics if any supplied \`inbound.Watcher\` has a zero-value Identity. Previously, a watcher constructed without \`.WithIdentity()\` would silently emit events tagged with empty identity → sessions get \`state.Adapter=""\` → empty in logs and API responses, papered over only by the defensive backfill in \`onNewSession\`'s else-branch.

Fallout fixed:
- 6 e2e test sites that constructed real \`Scanner\` instances without identity now chain \`.WithIdentity(agent.Identity{Name: \"test\"})\`.
- One \`mockWatcher\` in \`presession_test.go\` gains an explicit test identity.
- New test \`TestNewSessionDetector_PanicsOnZeroIdentity\` locks the invariant.

### 4. Named entry point for the no-identity path

The \`processActivity(agent.Identity{}, ev)\` magic-value pattern at two call sites (debouncedEvents consumer + \`refreshStaleSessions\`) is now wrapped by \`processActivityWithoutIdentity(ev)\`. Documents the convention in one place rather than at every reader of an empty struct literal.

### 5. Phase-narration sweep #2

Strips \"#159 Phase A.4/A.5\", \"PR3/PR5 of #159\", and \"pre-A.2 code\" references from:

- \`core/ports/inbound/{watcher,ports}.go\`
- \`core/cmd/irrlichd/wiring.go\`
- \`core/adapters/inbound/agents/maps.go\`
- \`core/application/services/{session_detector,metadata_enricher}.go\`
- The \`identity\` field comments in the three watcher implementations

Keeps the genuine WHY where it's load-bearing (e.g. \"aider runs under python\").

## Test plan

- [x] \`go build ./core/...\` clean
- [x] \`go test ./core/... -race -count=1\` green
- [x] \`tools/replay-fixtures.sh\` green
- [x] M0 contract goldens byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)