### PR TITLE
refactor(agents): simplify per /simplify of #319 (#159)

### DIFF
--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -30,7 +30,7 @@ type Adapter struct {
 	parsers          map[string]agents.ParserFactory
 	subagents        map[string]agents.SubagentCounter
 	metricsProviders map[string]agents.MetricsProvider
-	fallback         agents.ParserFactory // used for unknown adapter names
+	fallbackName     string // adapter name to use when the requested name is unknown
 }
 
 // Registry holds the per-adapter behaviour the metrics adapter dispatches
@@ -41,9 +41,12 @@ type Registry struct {
 	Parsers          map[string]agents.ParserFactory
 	SubagentCounters map[string]agents.SubagentCounter
 	MetricsProviders map[string]agents.MetricsProvider
-	// FallbackParser is used for unknown adapter names — preserves the
-	// historical "default to Claude Code" behaviour.
-	FallbackParser agents.ParserFactory
+	// FallbackName is the adapter name whose parser handles unknown
+	// adapters (preserves the "default to Claude Code" behaviour). Looked
+	// up in Parsers at parse time — single source of truth for the
+	// fallback factory, and zero ambiguity if Parsers["claude-code"] is
+	// ever swapped.
+	FallbackName string
 }
 
 // New returns a metrics Adapter configured from the given Registry.
@@ -53,18 +56,19 @@ func New(r Registry) *Adapter {
 		parsers:          r.Parsers,
 		subagents:        r.SubagentCounters,
 		metricsProviders: r.MetricsProviders,
-		fallback:         r.FallbackParser,
+		fallbackName:     r.FallbackName,
 	}
 }
 
 // parserFor returns a fresh TranscriptParser for the given adapter name,
-// falling back to the first registered adapter's parser for unknown names.
+// falling back to the parser registered under fallbackName for unknown
+// names. Returns nil when neither lookup yields a factory.
 func (a *Adapter) parserFor(name string) tailer.TranscriptParser {
 	if f, ok := a.parsers[name]; ok {
 		return f()
 	}
-	if a.fallback != nil {
-		return a.fallback()
+	if f, ok := a.parsers[a.fallbackName]; ok {
+		return f()
 	}
 	return nil
 }

--- a/core/application/services/identity_guard_test.go
+++ b/core/application/services/identity_guard_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -20,10 +21,9 @@ func TestNewSessionDetector_PanicsOnZeroIdentity(t *testing.T) {
 		if r == nil {
 			t.Fatal("expected panic when watcher has zero Identity, got none")
 		}
-		msg, ok := r.(string)
-		if !ok {
-			t.Fatalf("panic payload not a string: %T %v", r, r)
-		}
+		// fmt.Sprint handles both string and error payloads, so this test
+		// survives a future refactor that wraps the panic in an error.
+		msg := fmt.Sprint(r)
 		if !strings.Contains(msg, "Identity") || !strings.Contains(msg, "WithIdentity") {
 			t.Errorf("panic message should name Identity and WithIdentity; got %q", msg)
 		}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -147,9 +147,9 @@ func NewSessionDetector(
 	processNames map[string]string,
 	liveCWDs LiveCWDsFunc,
 ) *SessionDetector {
-	for _, w := range watchers {
+	for i, w := range watchers {
 		if w.Identity() == (agent.Identity{}) {
-			panic(fmt.Sprintf("session_detector: watcher %T has no Identity — call .WithIdentity() before passing it to NewSessionDetector", w))
+			panic(fmt.Sprintf("session_detector: watchers[%d] (%T) has no Identity — call .WithIdentity() before passing it to NewSessionDetector", i, w))
 		}
 	}
 	det := &SessionDetector{

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -214,14 +214,9 @@ func (d *SessionDetector) onActivity(id agent.Identity, ev agent.Event) {
 	d.record(lifecycle.Event{Kind: lifecycle.KindDebounceCoalesced, SessionID: ev.SessionID})
 }
 
-// processActivityWithoutIdentity is the entry point for paths where the
-// originating watcher's Identity is not available — coalesced events
-// from the debounce timers and synthetic refresh events injected by
-// refreshStaleSessions. The session is expected to already exist with
-// a populated state.Adapter; for live sessions processActivity uses
-// state.Adapter, and the rare onNewSession fallback runs with empty
-// identity (state.Adapter ends up empty, then is back-filled by the
-// next watcher-driven event for the same session).
+// processActivityWithoutIdentity is the entry point for paths where no
+// watcher identity is available — debounce-coalesced events and synthetic
+// refresh events. See processActivity for what "no identity" implies.
 func (d *SessionDetector) processActivityWithoutIdentity(ev agent.Event) {
 	d.processActivity(agent.Identity{}, ev)
 }

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -165,13 +165,12 @@ func main() {
 	// Shared adapters for SessionDetector.
 	gitResolver := git.New()
 	// Claude Code's parser is the documented fallback for unknown adapter
-	// names. Pinning by name rather than allAgents[0] decouples the
-	// fallback from slice ordering.
+	// names.
 	metricsCollector := metrics.New(metrics.Registry{
 		Parsers:          parserFactories,
 		SubagentCounters: agents.SubagentCounters(allAgents),
 		MetricsProviders: agents.MetricsProviders(allAgents),
-		FallbackParser:   parserFactories[claudecode.AdapterName],
+		FallbackName:     claudecode.AdapterName,
 	})
 
 	// --- File-based SessionDetector (primary detection path) ---

--- a/core/e2e/concurrent_test.go
+++ b/core/e2e/concurrent_test.go
@@ -8,7 +8,6 @@ import (
 
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	"irrlicht/core/application/services"
-	"irrlicht/core/domain/agent"
 	"irrlicht/core/ports/inbound"
 )
 
@@ -24,7 +23,7 @@ func TestScanner_TracksTwoConcurrentProcessesWithSameAgentName(t *testing.T) {
 	cmd1, cwd1 := startFakeClaudeProcessNamed(t, name)
 	cmd2, cwd2 := startFakeClaudeProcessNamed(t, name)
 
-	scanner := processlifecycle.NewScanner(name, "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
+	scanner := processlifecycle.NewScanner(name, "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
 	detector := services.NewSessionDetector(

--- a/core/e2e/crash_test.go
+++ b/core/e2e/crash_test.go
@@ -9,7 +9,6 @@ import (
 
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	"irrlicht/core/application/services"
-	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/inbound"
 )
@@ -25,7 +24,7 @@ import (
 func TestSession_NoCancelledState_OnSIGKILL(t *testing.T) {
 	cmd, _ := startFakeClaudeProcess(t)
 
-	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
+	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
 	detector := services.NewSessionDetector(

--- a/core/e2e/e2e_helpers_test.go
+++ b/core/e2e/e2e_helpers_test.go
@@ -172,9 +172,25 @@ func (m *stubMetrics) ComputeMetrics(_, _ string) (*session.SessionMetrics, erro
 
 func (m *stubMetrics) PruneEntry(_ string) {}
 
+// testIdentity is the shared Identity value e2e tests stamp on every
+// watcher they hand to NewSessionDetector. NewSessionDetector's panic
+// guard requires a non-zero Identity; the actual Name doesn't matter to
+// these tests beyond clearing the guard.
+var testIdentity = agent.Identity{Name: "test"}
+
+// mockWatcher's identity defaults to testIdentity so callers that don't
+// care about the adapter name (the common case) don't have to set it.
+// Callers that need a different identity override the field directly.
 type mockWatcher struct {
 	ch       chan agent.Event
 	identity agent.Identity
+}
+
+func newMockWatcher(buf int) *mockWatcher {
+	return &mockWatcher{
+		ch:       make(chan agent.Event, buf),
+		identity: testIdentity,
+	}
 }
 
 func (w *mockWatcher) Watch(ctx context.Context) error  { <-ctx.Done(); return ctx.Err() }

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -44,7 +44,7 @@ func TestPreSession_DetectedBeforeTranscript(t *testing.T) {
 	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
 
 	// Wire up: Scanner → SessionDetector (with in-memory stubs).
-	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
+	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
 	detector := services.NewSessionDetector(
@@ -117,13 +117,13 @@ func TestPreSession_ReplacedByRealSession(t *testing.T) {
 	t.Cleanup(func() { cmd.Process.Kill(); cmd.Wait() })
 
 	projectsRoot := realTempDir(t)
-	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
+	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
 	// Also wire a mock transcript watcher so we can inject a real session event.
 	transcriptWatcher := &mockWatcher{
 		ch:       make(chan agent.Event, 4),
-		identity: agent.Identity{Name: "test"},
+		identity: testIdentity,
 	}
 
 	detector := services.NewSessionDetector(
@@ -207,7 +207,7 @@ func TestPreSession_CreatedDespiteHistoricalSession(t *testing.T) {
 		TranscriptPath: filepath.Join(projectsRoot, projectDir, "old.jsonl"),
 	})
 
-	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
+	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
 	detector := services.NewSessionDetector(
@@ -258,7 +258,7 @@ func TestPreSession_SurvivesNeighbourSessionActivity(t *testing.T) {
 	_ = os.Chtimes(neighbourJSONL, now, now)
 
 	repo := newMemRepo()
-	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
+	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
 	detector := services.NewSessionDetector(
@@ -308,7 +308,7 @@ func TestPreSession_RemovedOnProcessExit(t *testing.T) {
 		t.Fatalf("start: %v", err)
 	}
 
-	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(agent.Identity{Name: "test"})
+	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
 	detector := services.NewSessionDetector(


### PR DESCRIPTION
## Summary

Six small follow-ups from a `/simplify` review of #319. None change runtime behaviour; all tests + replay green; M0 contract goldens byte-identical.

1. **`testIdentity` helper in e2e** — extract `agent.Identity{Name: \"test\"}` into a package var at `core/e2e/e2e_helpers_test.go`. Substitutes 7 verbatim sites across `concurrent_test.go`, `crash_test.go`, `presession_test.go`, and the `mockWatcher` default.

2. **`mockWatcher` gains a default identity** via a new `newMockWatcher(buf)` constructor — symmetric with the `mockAgentWatcher` default in services tests. Callers that don't care about adapter name no longer have to set it.

3. **`identity_guard_test.go` brittleness fix** — `r.(string)` replaced with `fmt.Sprint(r)` so the test survives a future change from `panic(string)` to `panic(error)`.

4. **`processActivityWithoutIdentity` doc trim** — 8 lines → 2; the wrapper now just points at `processActivity`'s contract for the detail.

5. **Panic includes slice index** — `NewSessionDetector` panic message now names `watchers[%d] (%T)` so wiring failures with a slice of multiple watchers point at the bad entry.

6. **`metrics.Registry.FallbackName`** replaces `FallbackParser`. Single source of truth: `parserFor` looks up by name in `Parsers`, eliminating the drift risk if `Parsers[\"claude-code\"]` is ever swapped without updating `FallbackParser` in lockstep.

## Skipped findings (noted, deliberate)

- **Embed `Registry` in `Adapter`** to drop the 4 copy fields. Would change `Adapter` from private fields (`a.parsers` etc.) to either public embedding or private `*Registry` indirection — net cosmetic at best, costs the idiomatic short-name accessors used by the existing methods.
- **`maps.go` `ProcessNames` collapsed branch**. Explicit form reads more clearly; not worth changing.

## Test plan

- [x] `go build ./core/...` clean
- [x] `go test ./core/... -race -count=1` green
- [x] `tools/replay-fixtures.sh` green
- [x] M0 contract goldens byte-identical

Net diff: 9 files, +47 / −35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)