### PR TITLE
fix(daemon): reject zombie sessions with missing cwd (#321)

### DIFF
--- a/core/application/services/helpers.go
+++ b/core/application/services/helpers.go
@@ -37,13 +37,9 @@ func isStaleTranscript(path string) bool {
 	return time.Since(info.ModTime()) > orphanTranscriptAge
 }
 
-// cwdMissing reports whether cwd refers to a directory that no longer exists.
-// Returns false for empty or relative paths to avoid second-guessing callers
-// when the cwd metadata is incomplete.
-//
-// Used to short-circuit admission of zombie sessions whose worktree was
-// deleted but whose transcript was touched recently (e.g. by `claude --resume`
-// from elsewhere) — see issue #321.
+// cwdMissing reports whether cwd refers to a directory that no longer
+// exists. Returns false for empty or relative paths to avoid second-guessing
+// callers when the cwd metadata is incomplete.
 func cwdMissing(cwd string) bool {
 	if cwd == "" || !filepath.IsAbs(cwd) {
 		return false

--- a/core/application/services/helpers.go
+++ b/core/application/services/helpers.go
@@ -37,6 +37,21 @@ func isStaleTranscript(path string) bool {
 	return time.Since(info.ModTime()) > orphanTranscriptAge
 }
 
+// cwdMissing reports whether cwd refers to a directory that no longer exists.
+// Returns false for empty or relative paths to avoid second-guessing callers
+// when the cwd metadata is incomplete.
+//
+// Used to short-circuit admission of zombie sessions whose worktree was
+// deleted but whose transcript was touched recently (e.g. by `claude --resume`
+// from elsewhere) — see issue #321.
+func cwdMissing(cwd string) bool {
+	if cwd == "" || !filepath.IsAbs(cwd) {
+		return false
+	}
+	_, err := os.Stat(cwd)
+	return os.IsNotExist(err)
+}
+
 // deriveParentSession tries all known methods to extract a parent session ID.
 // 1. Claude Code path pattern: .../<parent-session-id>/subagents/<agent-id>.jsonl
 // 2. Pi transcript header: {"type": "session", "parentSession": "..."}

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -642,10 +642,15 @@ func (pm *PIDManager) seedAlivePIDs(states []*session.SessionState) map[int]*ses
 					}
 				}
 			}
-		case state.PID == 0 && state.ParentSessionID == "" && isStaleTranscript(state.TranscriptPath):
+		case state.PID == 0 && state.ParentSessionID == "" && (isStaleTranscript(state.TranscriptPath) || cwdMissing(state.CWD)):
 			// Orphan from exited process (PID discovery never succeeded).
 			// Child sessions (ParentSessionID set) are exempt — they run
-			// inside the parent process and never get their own PID.
+			// inside the parent process and never get their own PID; they
+			// will be removed by deleteWithChildren via the parent.
+			//
+			// A missing cwd is an unambiguous orphan signal even when the
+			// transcript mtime is fresh — covers zombie sessions re-touched
+			// by `claude --resume` after the worktree was deleted (#321).
 			pm.log.LogInfo("session-detector-seed", state.SessionID, "deleting orphan session")
 			pm.deleteWithChildren(state)
 		}

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -645,12 +645,9 @@ func (pm *PIDManager) seedAlivePIDs(states []*session.SessionState) map[int]*ses
 		case state.PID == 0 && state.ParentSessionID == "" && (isStaleTranscript(state.TranscriptPath) || cwdMissing(state.CWD)):
 			// Orphan from exited process (PID discovery never succeeded).
 			// Child sessions (ParentSessionID set) are exempt — they run
-			// inside the parent process and never get their own PID; they
-			// will be removed by deleteWithChildren via the parent.
-			//
-			// A missing cwd is an unambiguous orphan signal even when the
-			// transcript mtime is fresh — covers zombie sessions re-touched
-			// by `claude --resume` after the worktree was deleted (#321).
+			// inside the parent process and never get their own PID.
+			// cwdMissing also catches zombies re-touched by `claude --resume`
+			// after the worktree was deleted (#321).
 			pm.log.LogInfo("session-detector-seed", state.SessionID, "deleting orphan session")
 			pm.deleteWithChildren(state)
 		}

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -127,6 +127,54 @@ func deadPIDForTest(t *testing.T) int {
 	return pid
 }
 
+// TestSeedAlivePIDs_DeletesWhenCWDMissing is the seed-time half of issue
+// #321. On daemon startup, a previously-tracked session whose worktree has
+// been deleted must be cleaned up even when its transcript was touched
+// within the staleness window (e.g. by `claude --resume` from elsewhere).
+// A missing cwd directory is the unambiguous orphan signal.
+func TestSeedAlivePIDs_DeletesWhenCWDMissing(t *testing.T) {
+	tmp := t.TempDir()
+	freshTranscript := filepath.Join(tmp, "zombie.jsonl")
+	writeTranscript(t, freshTranscript, time.Now())
+
+	// CWD that does not exist (worktree was deleted).
+	missingCWD := filepath.Join(tmp, "deleted-worktree")
+
+	repo := newMockRepo()
+	repo.states["zombie"] = &session.SessionState{
+		SessionID:      "zombie",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		PID:            0,
+		CWD:            missingCWD,
+		TranscriptPath: freshTranscript,
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	// Child session with the same missing cwd — should be cleaned up too,
+	// via deleteWithChildren, when the parent is removed.
+	repo.states["zombie-child"] = &session.SessionState{
+		SessionID:       "zombie-child",
+		ParentSessionID: "zombie",
+		Adapter:         "claude-code",
+		State:           session.StateReady,
+		PID:             0,
+		CWD:             missingCWD,
+		TranscriptPath:  freshTranscript,
+		UpdatedAt:       time.Now().Unix(),
+	}
+
+	states := []*session.SessionState{repo.states["zombie"], repo.states["zombie-child"]}
+	newPIDManagerForTest(repo).SeedPIDs(states)
+
+	if repo.states["zombie"] != nil {
+		t.Error("zombie session with missing cwd should have been deleted at seed time")
+	}
+	if repo.states["zombie-child"] != nil {
+		t.Error("child of zombie session should have been deleted via deleteWithChildren")
+	}
+}
+
 // TestCleanupZombies covers the two predicates plus the happy-path
 // exemptions: dead PID is deleted; live PID is kept (regardless of how old
 // the record is — see the comment on isStartupZombie about the deliberate

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -71,6 +71,18 @@ func (d *SessionDetector) onNewSession(id agent.Identity, ev agent.Event) {
 			return
 		}
 
+		// Skip zombie sessions whose worktree has been deleted from disk.
+		// A long-dead session can be re-touched via `claude --resume` from
+		// another worktree, which refreshes the transcript mtime and would
+		// otherwise sneak past the staleness check during a daemon restart
+		// (issue #321). The cwd directory missing on disk is an unambiguous
+		// orphan signal — no live process can be running in a gone cwd.
+		if cwdMissing(ev.CWD) {
+			d.log.LogInfo("session-detector", ev.SessionID,
+				"skipping session with missing cwd")
+			return
+		}
+
 		// All new sessions start as ready. Content-based detection on
 		// subsequent activity events will transition to working/waiting.
 		parentID := ev.ParentSessionID

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -1364,9 +1364,7 @@ func TestSessionDetector_CWDFallback_DoesNotAssignDuplicatePID(t *testing.T) {
 	pw := newMockProcessWatcher()
 	repo := newMockRepo()
 
-	// CWD must exist on disk — the daemon rejects sessions whose worktree
-	// directory has been deleted (see #321).
-	cwd := t.TempDir()
+	cwd := t.TempDir() // see #321 — daemon rejects sessions with missing cwd
 
 	// Mock CWD discovery: always returns the same two candidate PIDs.
 	cwdFn := func(cwd string, disambiguate func([]int) int) (int, error) {
@@ -1434,9 +1432,7 @@ func TestSessionDetector_CWDFallback_CleansUpOldSessionOnClear(t *testing.T) {
 	// Use our own PID so seedFromDisk doesn't delete sess-a as a dead process.
 	myPID := os.Getpid()
 
-	// CWD must exist on disk — the daemon rejects sessions whose worktree
-	// directory has been deleted (see #321).
-	cwd := t.TempDir()
+	cwd := t.TempDir() // see #321 — daemon rejects sessions with missing cwd
 
 	// Mock CWD discovery returns only our PID — simulates the /clear scenario
 	// where the same process starts a new transcript. The new session should
@@ -1564,9 +1560,7 @@ func TestSessionDetector_ClearWithStaleMetadata_DeletesOldSessionImmediately(t *
 
 	now := time.Now().Unix()
 
-	// CWD must exist on disk — the daemon rejects sessions whose worktree
-	// directory has been deleted (see #321).
-	cwd := t.TempDir()
+	cwd := t.TempDir() // see #321 — daemon rejects sessions with missing cwd
 
 	// Old session from before /clear — holds the live PID.
 	repo.Save(&session.SessionState{

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -94,6 +94,50 @@ func TestSessionDetector_NewSession_SkipsOrphanTranscript(t *testing.T) {
 	}
 }
 
+// TestSessionDetector_NewSession_SkipsWhenCWDDeleted is the regression test
+// for issue #321. A long-dead session can have its transcript mtime
+// refreshed by `claude --resume` from elsewhere; on a daemon restart within
+// the 2-minute staleness window the transcript-mtime check admits a ghost.
+// A missing cwd directory is unambiguous: no live process can run there.
+func TestSessionDetector_NewSession_SkipsWhenCWDDeleted(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+
+	// Fresh transcript — would normally be admitted.
+	tmpDir := t.TempDir()
+	transcriptPath := filepath.Join(tmpDir, "zombie.jsonl")
+	if err := os.WriteFile(transcriptPath, []byte(`{"type":"user"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// CWD points at a directory that no longer exists.
+	missingCWD := filepath.Join(tmpDir, "deleted-worktree")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "zombie1",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: transcriptPath,
+		CWD:            missingCWD,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	state, _ := repo.Load("zombie1")
+	if state != nil {
+		t.Errorf("zombie session with missing cwd should not be created, got state %q", state.State)
+	}
+}
+
 func TestSessionDetector_Activity_TransitionsToWaiting_WhenToolUseOpen(t *testing.T) {
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()
@@ -1320,6 +1364,10 @@ func TestSessionDetector_CWDFallback_DoesNotAssignDuplicatePID(t *testing.T) {
 	pw := newMockProcessWatcher()
 	repo := newMockRepo()
 
+	// CWD must exist on disk — the daemon rejects sessions whose worktree
+	// directory has been deleted (see #321).
+	cwd := t.TempDir()
+
 	// Mock CWD discovery: always returns the same two candidate PIDs.
 	cwdFn := func(cwd string, disambiguate func([]int) int) (int, error) {
 		return disambiguate([]int{1000, 1001}), nil
@@ -1337,7 +1385,7 @@ func TestSessionDetector_CWDFallback_DoesNotAssignDuplicatePID(t *testing.T) {
 		SessionID:      "sess-a",
 		ProjectDir:     "-Users-test-project",
 		TranscriptPath: "/home/.claude/projects/-Users-test-project/sess-a.jsonl",
-		CWD:            "/Users/test/project",
+		CWD:            cwd,
 	}
 
 	// Wait for first session's PID discovery retry goroutine to complete.
@@ -1348,7 +1396,7 @@ func TestSessionDetector_CWDFallback_DoesNotAssignDuplicatePID(t *testing.T) {
 		SessionID:      "sess-b",
 		ProjectDir:     "-Users-test-project",
 		TranscriptPath: "/home/.claude/projects/-Users-test-project/sess-b.jsonl",
-		CWD:            "/Users/test/project",
+		CWD:            cwd,
 	}
 
 	// Wait for second session's PID discovery.
@@ -1386,6 +1434,10 @@ func TestSessionDetector_CWDFallback_CleansUpOldSessionOnClear(t *testing.T) {
 	// Use our own PID so seedFromDisk doesn't delete sess-a as a dead process.
 	myPID := os.Getpid()
 
+	// CWD must exist on disk — the daemon rejects sessions whose worktree
+	// directory has been deleted (see #321).
+	cwd := t.TempDir()
+
 	// Mock CWD discovery returns only our PID — simulates the /clear scenario
 	// where the same process starts a new transcript. The new session should
 	// claim the PID and clean up the old session.
@@ -1411,7 +1463,7 @@ func TestSessionDetector_CWDFallback_CleansUpOldSessionOnClear(t *testing.T) {
 		State:          session.StateWorking,
 		PID:            myPID,
 		TranscriptPath: "/home/.claude/projects/-Users-test/sess-a.jsonl",
-		CWD:            "/Users/test/project",
+		CWD:            cwd,
 		FirstSeen:      now,
 		UpdatedAt:      now,
 	})
@@ -1422,7 +1474,7 @@ func TestSessionDetector_CWDFallback_CleansUpOldSessionOnClear(t *testing.T) {
 		Adapter:        "claude-code",
 		State:          session.StateReady,
 		TranscriptPath: "/home/.claude/projects/-Users-test/sess-b.jsonl",
-		CWD:            "/Users/test/project",
+		CWD:            cwd,
 		FirstSeen:      now,
 		UpdatedAt:      now,
 	})
@@ -1512,6 +1564,10 @@ func TestSessionDetector_ClearWithStaleMetadata_DeletesOldSessionImmediately(t *
 
 	now := time.Now().Unix()
 
+	// CWD must exist on disk — the daemon rejects sessions whose worktree
+	// directory has been deleted (see #321).
+	cwd := t.TempDir()
+
 	// Old session from before /clear — holds the live PID.
 	repo.Save(&session.SessionState{
 		SessionID:      "sess-old",
@@ -1519,7 +1575,7 @@ func TestSessionDetector_ClearWithStaleMetadata_DeletesOldSessionImmediately(t *
 		State:          session.StateWorking,
 		PID:            myPID,
 		TranscriptPath: "/home/.claude/projects/-Users-test/sess-old.jsonl",
-		CWD:            "/Users/test/project",
+		CWD:            cwd,
 		FirstSeen:      now,
 		UpdatedAt:      now,
 	})
@@ -1530,7 +1586,7 @@ func TestSessionDetector_ClearWithStaleMetadata_DeletesOldSessionImmediately(t *
 		Adapter:        "claude-code",
 		State:          session.StateReady,
 		TranscriptPath: newTranscript,
-		CWD:            "/Users/test/project",
+		CWD:            cwd,
 		FirstSeen:      now,
 		UpdatedAt:      now,
 	})


### PR DESCRIPTION
## Summary
- Fix #321: daemon restart within 2 min of a `claude --resume` against a deleted-worktree session re-admits it as a ghost; UI shows it for ~75s before the steady-state sweep removes it.
- Add `cwdMissing(cwd)` helper and gate both admission paths on it (`session_detector_activity.go:onNewSession`, `pid_manager.go:seedAlivePIDs`). A missing cwd directory is unambiguous — no live process runs in a gone cwd.
- Existing stale-transcript guard kept; the cwd check fires before the 2-minute mtime window can be tricked by a refreshed transcript.

## Test plan
- [x] `go test ./core/... -race -count=1` — full suite green.
- [x] `tools/replay-fixtures.sh` — replay fixtures unchanged.
- [x] New unit tests: `TestSessionDetector_NewSession_SkipsWhenCWDDeleted`, `TestSeedAlivePIDs_DeletesWhenCWDMissing`.
- [x] End-to-end tmux validation: built daemon w/ isolated `\$HOME`, seeded synthetic zombie state (fresh transcript, PID=0, missing cwd) → fixed daemon logs `session-detector-seed deleting orphan session` at startup and API returns no sessions; baseline daemon (pre-fix) admits the same fixture as a ghost.
- [x] Three existing CWD-fallback tests updated to use `t.TempDir()` for CWD (the new check correctly rejects synthetic non-existent paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)