### PR TITLE
feat(macos): selectable notification sounds per event (#253)

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -112,6 +112,17 @@ class SessionManager: ObservableObject {
         self.instancesPath = supportPath.appendingPathComponent("instances")
         self.orderFilePath = supportPath.appendingPathComponent("session-order.json")
 
+        // Out-of-the-box notification defaults: all three events enabled, each
+        // with a distinguishable sound (Ready=Funk, Waiting=Ping, Context=Sosumi).
+        // register(defaults:) only seeds unset keys, so it never overrides a
+        // user who has explicitly picked something else.
+        var notificationDefaults: [String: Any] = [:]
+        for event in NotificationEvent.allCases {
+            notificationDefaults[event.enabledKey] = true
+            notificationDefaults[event.soundKey] = event.defaultSound.rawValue
+        }
+        UserDefaults.standard.register(defaults: notificationDefaults)
+
         Task {
             loadSessionOrder()
             loadProjectGroupOrder()
@@ -952,12 +963,14 @@ class SessionManager: ObservableObject {
     }
 
     private func sendContextPressureNotification(session: SessionState, threshold: Int, utilization: Double) {
+        guard UserDefaults.standard.bool(forKey: NotificationEvent.contextPressure.enabledKey) else { return }
         let label = session.projectName ?? session.shortId
         sendNotification(
             identifier: "irrlicht-context-\(session.id)-\(threshold)",
             title: "Context pressure: \(threshold)% threshold reached",
             body: "\(label) is at \(String(format: "%.1f%%", utilization)) context. Consider switching to a fresh session.",
-            sessionID: session.id
+            sessionID: session.id,
+            event: .contextPressure
         )
     }
 
@@ -971,11 +984,14 @@ class SessionManager: ObservableObject {
         let notifyWaiting = UserDefaults.standard.bool(forKey: "notifyOnWaiting")
 
         let title: String
+        let event: NotificationEvent
         switch session.state {
         case .ready where notifyReady && previousState == .working:
             title = "Agent ready"
+            event = .ready
         case .waiting where notifyWaiting && previousState == .working:
             title = "Agent waiting for input"
+            event = .waiting
         default:
             return
         }
@@ -987,16 +1003,23 @@ class SessionManager: ObservableObject {
             identifier: "irrlicht-state-\(session.id)",
             title: title,
             body: "\(label)\(branch)",
-            sessionID: session.id
+            sessionID: session.id,
+            event: event
         )
     }
 
-    private func sendNotification(identifier: String, title: String, body: String, sessionID: String) {
+    private func sendNotification(
+        identifier: String,
+        title: String,
+        body: String,
+        sessionID: String,
+        event: NotificationEvent
+    ) {
         guard canUseUserNotifications else { return }
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
-        content.sound = .default
+        content.sound = Self.resolveNotificationSound(for: event)
         // Round-trip the session ID so the click-forwarder can look up
         // the session and jump back to its launching terminal/IDE.
         content.userInfo = [NotificationUserInfoKey.sessionID: sessionID]
@@ -1007,6 +1030,39 @@ class SessionManager: ObservableObject {
                 print("⚠️ Failed to send notification: \(error.localizedDescription)")
             }
         }
+
+        if Self.choice(for: event) == .speak {
+            SoundPlayer.speak("\(title). \(body)")
+        }
+    }
+
+    /// Reads the user's per-event sound choice, then turns it into a
+    /// `UNNotificationSound`. `.none` and `.speak` return `nil` (no audible
+    /// alert from the notification center). A `.custom` choice whose
+    /// installed file went missing falls back to the default Ping.
+    nonisolated static func resolveNotificationSound(for event: NotificationEvent) -> UNNotificationSound? {
+        let choice = choice(for: event)
+        switch choice {
+        case .none, .speak:
+            return nil
+        case .custom(let installedFilename, _):
+            let library = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
+            let path = library?
+                .appendingPathComponent("Sounds")
+                .appendingPathComponent(installedFilename).path
+            if let path, FileManager.default.fileExists(atPath: path) {
+                return UNNotificationSound(named: UNNotificationSoundName(installedFilename))
+            }
+            return UNNotificationSound(named: UNNotificationSoundName("Ping.aiff"))
+        default:
+            guard let name = choice.notificationSoundName else { return .default }
+            return UNNotificationSound(named: UNNotificationSoundName(name))
+        }
+    }
+
+    nonisolated static func choice(for event: NotificationEvent) -> SoundChoice {
+        let raw = UserDefaults.standard.string(forKey: event.soundKey) ?? SoundChoice.default.rawValue
+        return SoundChoice(rawValue: raw) ?? .default
     }
 
     /// Invoked by `NotificationClickForwarder` on the main actor when the user

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -1016,17 +1016,12 @@ class SessionManager: ObservableObject {
         event: NotificationEvent
     ) {
         guard canUseUserNotifications else { return }
+        let choice = Self.choice(for: event)
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
-        content.sound = Self.resolveNotificationSound(for: event)
-        // Round-trip the session ID so the click-forwarder can look up
-        // the session and jump back to its launching terminal/IDE.
-        var userInfo: [AnyHashable: Any] = [NotificationUserInfoKey.sessionID: sessionID]
-        if Self.choice(for: event) == .speak {
-            userInfo[NotificationUserInfoKey.speakText] = "\(title). \(body)"
-        }
-        content.userInfo = userInfo
+        content.sound = Self.notificationSound(for: choice)
+        content.userInfo = [NotificationUserInfoKey.sessionID: sessionID]
 
         let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(request) { error in
@@ -1034,14 +1029,21 @@ class SessionManager: ObservableObject {
                 print("⚠️ Failed to send notification: \(error.localizedDescription)")
             }
         }
+
+        // willPresent is unreliable for LSUIElement menubar-only apps — macOS
+        // skips it when it considers the app not-in-foreground, and Irrlicht
+        // sits in that grey zone. Drive speech from here (on @MainActor) so
+        // it actually fires for real state transitions. The per-event toggle
+        // is the off switch; users who pick a Speak aloud variant have opted in.
+        if case .speak(let voice) = choice {
+            SoundPlayer.speak(title: title, body: body, voice: voice)
+        }
     }
 
-    /// Reads the user's per-event sound choice, then turns it into a
-    /// `UNNotificationSound`. `.none` and `.speak` return `nil` (no audible
-    /// alert from the notification center). A `.custom` choice whose
-    /// installed file went missing falls back to the default Ping.
-    nonisolated static func resolveNotificationSound(for event: NotificationEvent) -> UNNotificationSound? {
-        let choice = choice(for: event)
+    /// Pure: turn a SoundChoice into a UNNotificationSound. `.none` / `.speak`
+    /// → nil (no audible alert from the notification center). A `.custom`
+    /// choice whose installed file went missing falls back to Ping.
+    nonisolated static func notificationSound(for choice: SoundChoice) -> UNNotificationSound? {
         switch choice {
         case .none, .speak:
             return nil
@@ -1058,6 +1060,13 @@ class SessionManager: ObservableObject {
             guard let name = choice.notificationSoundName else { return .default }
             return UNNotificationSound(named: UNNotificationSoundName(name))
         }
+    }
+
+    /// Convenience for tests + callers that want the event → sound lookup in
+    /// a single hop. Production path uses `choice(for:)` + `notificationSound(for:)`
+    /// directly to avoid double-reading UserDefaults.
+    nonisolated static func resolveNotificationSound(for event: NotificationEvent) -> UNNotificationSound? {
+        notificationSound(for: choice(for: event))
     }
 
     nonisolated static func choice(for event: NotificationEvent) -> SoundChoice {
@@ -1414,11 +1423,6 @@ private struct SessionOrderData: Codable {
 /// can identify the originating session.
 enum NotificationUserInfoKey {
     static let sessionID = "sessionID"
-    /// Present when the user picked "Speak aloud" for this event. The
-    /// willPresent delegate reads it and hands the text to
-    /// `SoundPlayer.speak` — keeps speech tied to actual banner presentation
-    /// rather than to enqueue, so a suppressed notification doesn't speak.
-    static let speakText = "speakText"
 }
 
 /// NSObject-based forwarder that receives `UNUserNotificationCenterDelegate`
@@ -1452,12 +1456,6 @@ final class NotificationClickForwarder: NSObject, UNUserNotificationCenterDelega
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
-        // Only speak when the banner is actually about to be shown. Tying
-        // speech to enqueue would speak even when macOS suppresses the
-        // notification (DND, dedupe, focus mode).
-        if let speakText = notification.request.content.userInfo[NotificationUserInfoKey.speakText] as? String {
-            SoundPlayer.speak(speakText)
-        }
         completionHandler([.banner, .sound])
     }
 }

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -1022,17 +1022,17 @@ class SessionManager: ObservableObject {
         content.sound = Self.resolveNotificationSound(for: event)
         // Round-trip the session ID so the click-forwarder can look up
         // the session and jump back to its launching terminal/IDE.
-        content.userInfo = [NotificationUserInfoKey.sessionID: sessionID]
+        var userInfo: [AnyHashable: Any] = [NotificationUserInfoKey.sessionID: sessionID]
+        if Self.choice(for: event) == .speak {
+            userInfo[NotificationUserInfoKey.speakText] = "\(title). \(body)"
+        }
+        content.userInfo = userInfo
 
         let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(request) { error in
             if let error = error {
                 print("⚠️ Failed to send notification: \(error.localizedDescription)")
             }
-        }
-
-        if Self.choice(for: event) == .speak {
-            SoundPlayer.speak("\(title). \(body)")
         }
     }
 
@@ -1414,6 +1414,11 @@ private struct SessionOrderData: Codable {
 /// can identify the originating session.
 enum NotificationUserInfoKey {
     static let sessionID = "sessionID"
+    /// Present when the user picked "Speak aloud" for this event. The
+    /// willPresent delegate reads it and hands the text to
+    /// `SoundPlayer.speak` — keeps speech tied to actual banner presentation
+    /// rather than to enqueue, so a suppressed notification doesn't speak.
+    static let speakText = "speakText"
 }
 
 /// NSObject-based forwarder that receives `UNUserNotificationCenterDelegate`
@@ -1447,6 +1452,12 @@ final class NotificationClickForwarder: NSObject, UNUserNotificationCenterDelega
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
+        // Only speak when the banner is actually about to be shown. Tying
+        // speech to enqueue would speak even when macOS suppresses the
+        // notification (DND, dedupe, focus mode).
+        if let speakText = notification.request.content.userInfo[NotificationUserInfoKey.speakText] as? String {
+            SoundPlayer.speak(speakText)
+        }
         completionHandler([.banner, .sound])
     }
 }

--- a/platforms/macos/Irrlicht/Managers/SoundPlayer.swift
+++ b/platforms/macos/Irrlicht/Managers/SoundPlayer.swift
@@ -34,24 +34,53 @@ enum SoundPlayer {
         switch choice {
         case .none:
             return
-        case .speak:
-            speak(sampleText)
+        case .speak(let voice):
+            speak(sampleText, voice: voice)
         default:
             guard let url = choice.previewURL else { return }
             NSSound(contentsOf: url, byReference: true)?.play()
         }
     }
 
-    /// Synthesizes speech. Holds onto a long-lived synthesizer so utterances
-    /// aren't cut off when the local goes out of scope.
-    static func speak(_ text: String) {
+    /// Synthesizes a single utterance with the given voice. Long-lived
+    /// synthesizer keeps utterances from being cut short when the local
+    /// reference goes out of scope.
+    static func speak(_ text: String, voice spoken: SpokenVoice = .default) {
         let utterance = AVSpeechUtterance(string: text)
-        // Notification titles/bodies are produced in English elsewhere in
-        // the app, so pin the voice to en-US regardless of the system speech
-        // locale. If the voice catalogue lacks en-US, AVSpeechSynthesisVoice
-        // returns nil and the synthesizer falls back to its default voice.
-        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        utterance.voice = voice(for: spoken)
         synthesizer.speak(utterance)
+    }
+
+    /// Speaks `title`, then `body`, with a short pause between. The pause
+    /// gives the listener a beat to register what's about to be detailed —
+    /// "Agent ready" then "<project> (<branch>)" lands better than running
+    /// them together as one sentence.
+    static func speak(title: String, body: String, voice spoken: SpokenVoice = .default) {
+        let v = voice(for: spoken)
+        let titleUtterance = AVSpeechUtterance(string: title)
+        titleUtterance.voice = v
+        let bodyUtterance = AVSpeechUtterance(string: body)
+        bodyUtterance.voice = v
+        bodyUtterance.preUtteranceDelay = 0.4
+        synthesizer.speak(titleUtterance)
+        synthesizer.speak(bodyUtterance)
+    }
+
+    /// Resolves a SpokenVoice to a concrete AVSpeechSynthesisVoice. Picks
+    /// the highest-installed quality (premium > enhanced > default) for the
+    /// canonical name, so once the user downloads Ava-Premium / Tom-Premium
+    /// in System Settings the upgrade is automatic. Falls back to the
+    /// system en-US voice when no name match exists at all.
+    static func voice(for spoken: SpokenVoice) -> AVSpeechSynthesisVoice? {
+        guard let name = spoken.canonicalName else {
+            return AVSpeechSynthesisVoice(language: "en-US")
+        }
+        if let best = AVSpeechSynthesisVoice.speechVoices()
+            .filter({ $0.name == name })
+            .max(by: { $0.quality.rawValue < $1.quality.rawValue }) {
+            return best
+        }
+        return AVSpeechSynthesisVoice(language: "en-US")
     }
 
     /// Copies (or transcodes) `srcURL` into `~/Library/Sounds/` under the
@@ -96,9 +125,7 @@ enum SoundPlayer {
             let destURL = destDir.appendingPathComponent(destName)
             do {
                 try removeStaleVariants(for: event, in: destDir, keeping: destName)
-                if FileManager.default.fileExists(atPath: destURL.path) {
-                    try FileManager.default.removeItem(at: destURL)
-                }
+                try? FileManager.default.removeItem(at: destURL)
                 try FileManager.default.copyItem(at: srcURL, to: destURL)
                 main(.success(destName))
             } catch {
@@ -110,13 +137,11 @@ enum SoundPlayer {
         // mp3 / m4a → transcode to LPCM-in-CAF. UNNotificationSound only plays
         // PCM/MA4/µLaw/aLaw packaged in aiff/wav/caf — it will refuse AAC, so
         // we must decode to PCM rather than passthrough the source codec.
-        let destName = event.customFilename // "IrrlichtCustom-<event>.caf"
+        let destName = transcodeFilename(for: event)
         let destURL = destDir.appendingPathComponent(destName)
         do {
             try removeStaleVariants(for: event, in: destDir, keeping: destName)
-            if FileManager.default.fileExists(atPath: destURL.path) {
-                try FileManager.default.removeItem(at: destURL)
-            }
+            try? FileManager.default.removeItem(at: destURL)
         } catch {
             main(.failure(InstallError.writeFailed(error.localizedDescription)))
             return
@@ -133,27 +158,27 @@ enum SoundPlayer {
     }
 
     /// Decodes `src` (any AVFoundation-readable audio format — mp3, m4a, etc.)
-    /// and writes 16-bit LPCM into a `.caf` container at `dest`, which is the
-    /// format UNNotificationSound supports. Streams in 4096-frame chunks so a
-    /// 10 MB mp3 doesn't allocate its full PCM expansion in memory.
+    /// and writes LPCM into a `.caf` container at `dest`. CAF + LPCM is
+    /// the combination UNNotificationSound plays reliably.
+    ///
+    /// The output mirrors the source's *processing format* (typically
+    /// 32-bit float PCM) rather than forcing a fixed Int16/interleaved
+    /// layout — forcing one combination produced
+    /// `com.apple.coreaudio.avfaudio -50` (paramErr) for mp3s whose
+    /// decoded frame layout didn't match. Float32 PCM is still LPCM and
+    /// UNNotificationSound accepts it.
+    ///
+    /// Streams in 4096-frame chunks so a 10 MB mp3 doesn't allocate its
+    /// full PCM expansion in memory.
     private static func transcodeToLPCMCAF(src: URL, dest: URL) throws {
         let sourceFile = try AVAudioFile(forReading: src)
         let processingFormat = sourceFile.processingFormat
 
-        let outputSettings: [String: Any] = [
-            AVFormatIDKey: kAudioFormatLinearPCM,
-            AVSampleRateKey: processingFormat.sampleRate,
-            AVNumberOfChannelsKey: processingFormat.channelCount,
-            AVLinearPCMBitDepthKey: 16,
-            AVLinearPCMIsFloatKey: false,
-            AVLinearPCMIsBigEndianKey: false,
-            AVLinearPCMIsNonInterleaved: false,
-        ]
         let outputFile = try AVAudioFile(
             forWriting: dest,
-            settings: outputSettings,
-            commonFormat: .pcmFormatInt16,
-            interleaved: true
+            settings: processingFormat.settings,
+            commonFormat: processingFormat.commonFormat,
+            interleaved: processingFormat.isInterleaved
         )
 
         let chunkFrames: AVAudioFrameCount = 4096
@@ -166,6 +191,13 @@ enum SoundPlayer {
             if buffer.frameLength == 0 { break }
             try outputFile.write(from: buffer)
         }
+    }
+
+    /// Output filename for the transcode branch: always `.caf` because we
+    /// always emit LPCM-in-CAF. Kept inside SoundPlayer because callers
+    /// outside the transcode flow shouldn't need to know the extension.
+    private static func transcodeFilename(for event: NotificationEvent) -> String {
+        "IrrlichtCustom-\(event.rawValue).caf"
     }
 
     /// Resolves `~/Library/Sounds/`, creating it if necessary.

--- a/platforms/macos/Irrlicht/Managers/SoundPlayer.swift
+++ b/platforms/macos/Irrlicht/Managers/SoundPlayer.swift
@@ -107,7 +107,9 @@ enum SoundPlayer {
             return
         }
 
-        // mp3 / m4a → transcode to .caf via AVAssetExportSession.
+        // mp3 / m4a → transcode to LPCM-in-CAF. UNNotificationSound only plays
+        // PCM/MA4/µLaw/aLaw packaged in aiff/wav/caf — it will refuse AAC, so
+        // we must decode to PCM rather than passthrough the source codec.
         let destName = event.customFilename // "IrrlichtCustom-<event>.caf"
         let destURL = destDir.appendingPathComponent(destName)
         do {
@@ -120,23 +122,49 @@ enum SoundPlayer {
             return
         }
 
-        let asset = AVURLAsset(url: srcURL)
-        guard let session = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A) else {
-            main(.failure(InstallError.exportFailed("no exporter")))
-            return
-        }
-        // `.caf` accepts AAC payload; UNNotificationSound plays CAF reliably.
-        session.outputFileType = .caf
-        session.outputURL = destURL
-        session.exportAsynchronously {
-            switch session.status {
-            case .completed:
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try transcodeToLPCMCAF(src: srcURL, dest: destURL)
                 main(.success(destName))
-            case .failed, .cancelled:
-                main(.failure(InstallError.exportFailed(session.error?.localizedDescription ?? "unknown")))
-            default:
-                main(.failure(InstallError.exportFailed("unexpected status \(session.status.rawValue)")))
+            } catch {
+                main(.failure(InstallError.exportFailed(error.localizedDescription)))
             }
+        }
+    }
+
+    /// Decodes `src` (any AVFoundation-readable audio format — mp3, m4a, etc.)
+    /// and writes 16-bit LPCM into a `.caf` container at `dest`, which is the
+    /// format UNNotificationSound supports. Streams in 4096-frame chunks so a
+    /// 10 MB mp3 doesn't allocate its full PCM expansion in memory.
+    private static func transcodeToLPCMCAF(src: URL, dest: URL) throws {
+        let sourceFile = try AVAudioFile(forReading: src)
+        let processingFormat = sourceFile.processingFormat
+
+        let outputSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: processingFormat.sampleRate,
+            AVNumberOfChannelsKey: processingFormat.channelCount,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+        let outputFile = try AVAudioFile(
+            forWriting: dest,
+            settings: outputSettings,
+            commonFormat: .pcmFormatInt16,
+            interleaved: true
+        )
+
+        let chunkFrames: AVAudioFrameCount = 4096
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: processingFormat, frameCapacity: chunkFrames) else {
+            throw InstallError.exportFailed("could not allocate PCM buffer")
+        }
+
+        while sourceFile.framePosition < sourceFile.length {
+            try sourceFile.read(into: buffer)
+            if buffer.frameLength == 0 { break }
+            try outputFile.write(from: buffer)
         }
     }
 

--- a/platforms/macos/Irrlicht/Managers/SoundPlayer.swift
+++ b/platforms/macos/Irrlicht/Managers/SoundPlayer.swift
@@ -1,0 +1,170 @@
+import AVFoundation
+import AppKit
+import Foundation
+
+/// Plays preview sounds, installs custom audio files into `~/Library/Sounds/`
+/// (transcoding mp3/m4a to CAF so `UNNotificationSound` can resolve them),
+/// and drives text-to-speech for the "Speak aloud" choice.
+enum SoundPlayer {
+    enum InstallError: Error, LocalizedError {
+        case unreadable
+        case unsupportedFormat
+        case tooLarge
+        case exportFailed(String)
+        case writeFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .unreadable: return "Selected file could not be read."
+            case .unsupportedFormat: return "Unsupported audio format."
+            case .tooLarge: return "File is larger than 10 MB."
+            case .exportFailed(let msg): return "Transcode failed: \(msg)"
+            case .writeFailed(let msg): return "Could not install sound: \(msg)"
+            }
+        }
+    }
+
+    static let supportedExtensions: Set<String> = ["aiff", "aif", "wav", "caf", "mp3", "m4a"]
+    private static let passthroughExtensions: Set<String> = ["aiff", "aif", "wav", "caf"]
+    private static let maxBytes: Int64 = 10 * 1024 * 1024
+
+    /// Plays the preview audio (or speaks a sample phrase) for the given
+    /// choice. Returns immediately; playback runs on the system audio thread.
+    static func preview(_ choice: SoundChoice, sampleText: String = "Agent ready") {
+        switch choice {
+        case .none:
+            return
+        case .speak:
+            speak(sampleText)
+        default:
+            guard let url = choice.previewURL else { return }
+            NSSound(contentsOf: url, byReference: true)?.play()
+        }
+    }
+
+    /// Synthesizes speech. Holds onto a long-lived synthesizer so utterances
+    /// aren't cut off when the local goes out of scope.
+    static func speak(_ text: String) {
+        let utterance = AVSpeechUtterance(string: text)
+        // Notification titles/bodies are produced in English elsewhere in
+        // the app, so pin the voice to en-US regardless of the system speech
+        // locale. If the voice catalogue lacks en-US, AVSpeechSynthesisVoice
+        // returns nil and the synthesizer falls back to its default voice.
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        synthesizer.speak(utterance)
+    }
+
+    /// Copies (or transcodes) `srcURL` into `~/Library/Sounds/` under the
+    /// canonical filename for `event`, returning the installed basename.
+    ///
+    /// The completion fires on the main thread.
+    static func installCustom(
+        srcURL: URL,
+        event: NotificationEvent,
+        completion: @escaping (Result<String, Error>) -> Void
+    ) {
+        let main: (Result<String, Error>) -> Void = { result in
+            DispatchQueue.main.async { completion(result) }
+        }
+
+        let ext = srcURL.pathExtension.lowercased()
+        guard supportedExtensions.contains(ext) else {
+            main(.failure(InstallError.unsupportedFormat))
+            return
+        }
+
+        let attrs = try? FileManager.default.attributesOfItem(atPath: srcURL.path)
+        if let size = attrs?[.size] as? NSNumber, size.int64Value > maxBytes {
+            main(.failure(InstallError.tooLarge))
+            return
+        }
+        guard FileManager.default.isReadableFile(atPath: srcURL.path) else {
+            main(.failure(InstallError.unreadable))
+            return
+        }
+
+        let destDir: URL
+        do {
+            destDir = try soundsDirectory()
+        } catch {
+            main(.failure(error))
+            return
+        }
+
+        if passthroughExtensions.contains(ext) {
+            let destName = "IrrlichtCustom-\(event.rawValue).\(ext)"
+            let destURL = destDir.appendingPathComponent(destName)
+            do {
+                try removeStaleVariants(for: event, in: destDir, keeping: destName)
+                if FileManager.default.fileExists(atPath: destURL.path) {
+                    try FileManager.default.removeItem(at: destURL)
+                }
+                try FileManager.default.copyItem(at: srcURL, to: destURL)
+                main(.success(destName))
+            } catch {
+                main(.failure(InstallError.writeFailed(error.localizedDescription)))
+            }
+            return
+        }
+
+        // mp3 / m4a → transcode to .caf via AVAssetExportSession.
+        let destName = event.customFilename // "IrrlichtCustom-<event>.caf"
+        let destURL = destDir.appendingPathComponent(destName)
+        do {
+            try removeStaleVariants(for: event, in: destDir, keeping: destName)
+            if FileManager.default.fileExists(atPath: destURL.path) {
+                try FileManager.default.removeItem(at: destURL)
+            }
+        } catch {
+            main(.failure(InstallError.writeFailed(error.localizedDescription)))
+            return
+        }
+
+        let asset = AVURLAsset(url: srcURL)
+        guard let session = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A) else {
+            main(.failure(InstallError.exportFailed("no exporter")))
+            return
+        }
+        // `.caf` accepts AAC payload; UNNotificationSound plays CAF reliably.
+        session.outputFileType = .caf
+        session.outputURL = destURL
+        session.exportAsynchronously {
+            switch session.status {
+            case .completed:
+                main(.success(destName))
+            case .failed, .cancelled:
+                main(.failure(InstallError.exportFailed(session.error?.localizedDescription ?? "unknown")))
+            default:
+                main(.failure(InstallError.exportFailed("unexpected status \(session.status.rawValue)")))
+            }
+        }
+    }
+
+    /// Resolves `~/Library/Sounds/`, creating it if necessary.
+    static func soundsDirectory() throws -> URL {
+        let library = try FileManager.default.url(
+            for: .libraryDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+        let sounds = library.appendingPathComponent("Sounds", isDirectory: true)
+        if !FileManager.default.fileExists(atPath: sounds.path) {
+            try FileManager.default.createDirectory(at: sounds, withIntermediateDirectories: true)
+        }
+        return sounds
+    }
+
+    /// Wipes any previously-installed custom file for `event` whose extension
+    /// differs from the one we're about to write, so a user re-picking
+    /// `.mp3` after `.wav` doesn't leave a stale `.wav` behind.
+    private static func removeStaleVariants(for event: NotificationEvent, in dir: URL, keeping name: String) throws {
+        let prefix = "IrrlichtCustom-\(event.rawValue)."
+        let contents = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
+        for entry in contents where entry.hasPrefix(prefix) && entry != name {
+            try FileManager.default.removeItem(at: dir.appendingPathComponent(entry))
+        }
+    }
+
+    private static let synthesizer = AVSpeechSynthesizer()
+}

--- a/platforms/macos/Irrlicht/Models/NotificationEvent.swift
+++ b/platforms/macos/Irrlicht/Models/NotificationEvent.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Categories of desktop notifications the app can fire. Each event has its
+/// own enable toggle and its own sound choice stored in `UserDefaults`.
+enum NotificationEvent: String, CaseIterable {
+    case ready
+    case waiting
+    case contextPressure
+
+    var displayName: String {
+        switch self {
+        case .ready: return "Agent ready"
+        case .waiting: return "Agent waiting for input"
+        case .contextPressure: return "Context pressure alert"
+        }
+    }
+
+    var enabledKey: String {
+        switch self {
+        case .ready: return "notifyOnReady"
+        case .waiting: return "notifyOnWaiting"
+        case .contextPressure: return "notifyOnContextPressure"
+        }
+    }
+
+    var soundKey: String {
+        switch self {
+        case .ready: return "soundOnReady"
+        case .waiting: return "soundOnWaiting"
+        case .contextPressure: return "soundOnContextPressure"
+        }
+    }
+
+    /// Filename used when a custom audio file is installed into
+    /// `~/Library/Sounds/` — UNNotificationSound resolves by basename there.
+    var customFilename: String {
+        "IrrlichtCustom-\(rawValue).caf"
+    }
+
+    /// Out-of-the-box sound for each event. New installs pick these up via
+    /// `UserDefaults.register(defaults:)`; existing users keep whatever they
+    /// already chose.
+    var defaultSound: SoundChoice {
+        switch self {
+        case .ready: return .funk
+        case .waiting: return .ping
+        case .contextPressure: return .sosumi
+        }
+    }
+}

--- a/platforms/macos/Irrlicht/Models/NotificationEvent.swift
+++ b/platforms/macos/Irrlicht/Models/NotificationEvent.swift
@@ -31,12 +31,6 @@ enum NotificationEvent: String, CaseIterable {
         }
     }
 
-    /// Filename used when a custom audio file is installed into
-    /// `~/Library/Sounds/` — UNNotificationSound resolves by basename there.
-    var customFilename: String {
-        "IrrlichtCustom-\(rawValue).caf"
-    }
-
     /// Out-of-the-box sound for each event. New installs pick these up via
     /// `UserDefaults.register(defaults:)`; existing users keep whatever they
     /// already chose.

--- a/platforms/macos/Irrlicht/Models/SoundChoice.swift
+++ b/platforms/macos/Irrlicht/Models/SoundChoice.swift
@@ -5,7 +5,10 @@ import Foundation
 ///
 /// Raw-value grammar:
 ///   - built-in / mode tokens: `"ping"`, `"chime"`, `"funk"`, `"whoosh"`,
-///     `"sosumi"`, `"none"`, `"speak"`
+///     `"sosumi"`, `"none"`
+///   - speak: `"speak:default" | "speak:female" | "speak:male"`. Bare
+///     `"speak"` is accepted for backwards compatibility with the earlier
+///     single-voice design and decodes to `.speak(.default)`.
 ///   - custom file: `"custom:<installedFilename>|<displayPath>"`
 ///     `installedFilename` is the basename inside `~/Library/Sounds/`;
 ///     `displayPath` is the user-facing source path shown in the UI.
@@ -16,7 +19,7 @@ enum SoundChoice: Hashable {
     case whoosh
     case sosumi
     case none
-    case speak
+    case speak(SpokenVoice)
     case custom(installedFilename: String, displayPath: String)
 
     static let `default`: SoundChoice = .ping
@@ -31,7 +34,8 @@ enum SoundChoice: Hashable {
         case .whoosh: return "Whoosh"
         case .sosumi: return "Sosumi"
         case .none: return "None"
-        case .speak: return "Speak aloud"
+        case .speak(let voice):
+            return "Speak aloud (\(voice.displayName))"
         case .custom(_, let displayPath):
             return "Custom: \((displayPath as NSString).lastPathComponent)"
         }
@@ -64,6 +68,11 @@ enum SoundChoice: Hashable {
         }
     }
 
+    /// Convenience: speak-aloud variants ignore the embedded voice for picker
+    /// presentation purposes — listing them out by hand reads cleaner than
+    /// open-coding `[.speak(.default), .speak(.female), .speak(.male)]`.
+    static let speakChoices: [SoundChoice] = [.speak(.default), .speak(.female), .speak(.male)]
+
     /// File URL used for in-app preview playback via `NSSound(contentsOf:)`.
     var previewURL: URL? {
         switch self {
@@ -88,7 +97,13 @@ extension SoundChoice: RawRepresentable {
         case "whoosh": self = .whoosh
         case "sosumi": self = .sosumi
         case "none": self = .none
-        case "speak": self = .speak
+        // Bare "speak" was the previous (single-voice) encoding — keep it
+        // decoding so users with the old preference don't lose speech.
+        case "speak": self = .speak(.default)
+        case let s where s.hasPrefix("speak:"):
+            let voiceRaw = String(s.dropFirst("speak:".count))
+            guard let voice = SpokenVoice(rawValue: voiceRaw) else { return nil }
+            self = .speak(voice)
         default:
             guard rawValue.hasPrefix("custom:") else { return nil }
             let payload = String(rawValue.dropFirst("custom:".count))
@@ -109,7 +124,7 @@ extension SoundChoice: RawRepresentable {
         case .whoosh: return "whoosh"
         case .sosumi: return "sosumi"
         case .none: return "none"
-        case .speak: return "speak"
+        case .speak(let voice): return "speak:\(voice.rawValue)"
         case .custom(let installed, let display):
             return "custom:\(installed)|\(display)"
         }

--- a/platforms/macos/Irrlicht/Models/SoundChoice.swift
+++ b/platforms/macos/Irrlicht/Models/SoundChoice.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// What a user hears when a notification event fires. Encoded as a single
+/// `String` so it can ride on `@AppStorage` directly.
+///
+/// Raw-value grammar:
+///   - built-in / mode tokens: `"ping"`, `"chime"`, `"funk"`, `"whoosh"`,
+///     `"sosumi"`, `"none"`, `"speak"`
+///   - custom file: `"custom:<installedFilename>|<displayPath>"`
+///     `installedFilename` is the basename inside `~/Library/Sounds/`;
+///     `displayPath` is the user-facing source path shown in the UI.
+enum SoundChoice: Hashable {
+    case ping
+    case chime
+    case funk
+    case whoosh
+    case sosumi
+    case none
+    case speak
+    case custom(installedFilename: String, displayPath: String)
+
+    static let `default`: SoundChoice = .ping
+
+    static let builtIns: [SoundChoice] = [.ping, .chime, .funk, .whoosh, .sosumi]
+
+    var displayName: String {
+        switch self {
+        case .ping: return "Ping"
+        case .chime: return "Chime"
+        case .funk: return "Funk"
+        case .whoosh: return "Whoosh"
+        case .sosumi: return "Sosumi"
+        case .none: return "None"
+        case .speak: return "Speak aloud"
+        case .custom(_, let displayPath):
+            return "Custom: \((displayPath as NSString).lastPathComponent)"
+        }
+    }
+
+    /// macOS system-sound filename (in `/System/Library/Sounds`) that backs
+    /// each built-in choice. `nil` for non-audio choices.
+    var systemSoundFilename: String? {
+        switch self {
+        case .ping: return "Ping.aiff"
+        case .chime: return "Glass.aiff"
+        case .funk: return "Funk.aiff"
+        case .whoosh: return "Blow.aiff"
+        case .sosumi: return "Sosumi.aiff"
+        default: return nil
+        }
+    }
+
+    /// Basename `UNNotificationSound(named:)` should resolve.
+    /// `nil` means "no audible alert" (.none / .speak — speak is handled
+    /// separately via AVSpeechSynthesizer).
+    var notificationSoundName: String? {
+        switch self {
+        case .none, .speak:
+            return nil
+        case .custom(let installedFilename, _):
+            return installedFilename
+        default:
+            return systemSoundFilename
+        }
+    }
+
+    /// File URL used for in-app preview playback via `NSSound(contentsOf:)`.
+    var previewURL: URL? {
+        switch self {
+        case .ping, .chime, .funk, .whoosh, .sosumi:
+            guard let name = systemSoundFilename else { return nil }
+            return URL(fileURLWithPath: "/System/Library/Sounds/\(name)")
+        case .custom(let installedFilename, _):
+            let library = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
+            return library?.appendingPathComponent("Sounds").appendingPathComponent(installedFilename)
+        case .none, .speak:
+            return nil
+        }
+    }
+}
+
+extension SoundChoice: RawRepresentable {
+    init?(rawValue: String) {
+        switch rawValue {
+        case "ping": self = .ping
+        case "chime": self = .chime
+        case "funk": self = .funk
+        case "whoosh": self = .whoosh
+        case "sosumi": self = .sosumi
+        case "none": self = .none
+        case "speak": self = .speak
+        default:
+            guard rawValue.hasPrefix("custom:") else { return nil }
+            let payload = String(rawValue.dropFirst("custom:".count))
+            let parts = payload.split(separator: "|", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { return nil }
+            let installed = String(parts[0])
+            let display = String(parts[1])
+            guard !installed.isEmpty else { return nil }
+            self = .custom(installedFilename: installed, displayPath: display)
+        }
+    }
+
+    var rawValue: String {
+        switch self {
+        case .ping: return "ping"
+        case .chime: return "chime"
+        case .funk: return "funk"
+        case .whoosh: return "whoosh"
+        case .sosumi: return "sosumi"
+        case .none: return "none"
+        case .speak: return "speak"
+        case .custom(let installed, let display):
+            return "custom:\(installed)|\(display)"
+        }
+    }
+}

--- a/platforms/macos/Irrlicht/Models/SpokenVoice.swift
+++ b/platforms/macos/Irrlicht/Models/SpokenVoice.swift
@@ -1,0 +1,48 @@
+import AVFoundation
+import Foundation
+
+/// Which voice the "Speak aloud" notification choice uses.
+///
+/// - `.default` uses whatever `AVSpeechSynthesisVoice(language: "en-US")`
+///   returns on the host system.
+/// - `.female` targets **Zoe**, a premium female macOS voice. Compact
+///   quality on a stock install; premium when the user downloads it via
+///   System Settings → Accessibility → Spoken Content → System Voice →
+///   Manage Voices.
+/// - `.male` targets **Jamie**, a premium male macOS voice.
+///
+/// `SoundPlayer.voice(for:)` walks the installed voices and picks the
+/// highest-quality match for the canonical name, so installing the
+/// premium variant later upgrades speech with no app change.
+enum SpokenVoice: String, CaseIterable {
+    case `default`
+    case female
+    case male
+
+    var displayName: String {
+        switch self {
+        case .default: return "Default"
+        case .female:  return "Zoe, Premium"
+        case .male:    return "Jamie, Premium"
+        }
+    }
+
+    /// The Apple voice name to look up. `nil` for `.default` (which means
+    /// "use whatever `AVSpeechSynthesisVoice(language: "en-US")` returns").
+    var canonicalName: String? {
+        switch self {
+        case .default: return nil
+        case .female:  return "Zoe"
+        case .male:    return "Jamie"
+        }
+    }
+
+    /// Whether a voice matching `canonicalName` is installed at any
+    /// quality. Drives the "Install voice…" affordance in Settings.
+    /// `.default` always reports `true` because the system-language voice
+    /// is always available.
+    var isInstalled: Bool {
+        guard let name = canonicalName else { return true }
+        return AVSpeechSynthesisVoice.speechVoices().contains { $0.name == name }
+    }
+}

--- a/platforms/macos/Irrlicht/Views/HistoryBarView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryBarView.swift
@@ -1,10 +1,18 @@
 import SwiftUI
 
 // Colors match the web frontend palette and SessionState.State.color.
+// Exposed via `AppPalette` so other views (e.g. the Settings toggle style)
+// can reuse the same brand greens/oranges/purples without re-stating hex.
+enum AppPalette {
+    static let working = Color(hex: "#8B5CF6")
+    static let waiting = Color(hex: "#FF9500")
+    static let ready   = Color(hex: "#34C759")
+}
+
 private let stateColors: [String: Color] = [
-    "working": Color(hex: "#8B5CF6"),
-    "waiting": Color(hex: "#FF9500"),
-    "ready":   Color(hex: "#34C759"),
+    "working": AppPalette.working,
+    "waiting": AppPalette.waiting,
+    "ready":   AppPalette.ready,
 ]
 
 /// A compact horizontal bar that visualises per-session state history.

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -6,9 +6,9 @@ struct SettingsView: View {
     @Binding var isPresented: Bool
     @AppStorage("debugMode") private var debugMode: Bool = false
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
-    @AppStorage("notifyOnReady") private var notifyOnReady: Bool = true
-    @AppStorage("notifyOnWaiting") private var notifyOnWaiting: Bool = true
-    @AppStorage("notifyOnContextPressure") private var notifyOnContextPressure: Bool = true
+    @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = true
+    @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = true
+    @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = true
     @State private var notificationsDenied = false
     @State private var customImportError: String?
 
@@ -108,7 +108,7 @@ struct SettingsView: View {
             }
         }
         .padding(20)
-        .frame(width: 360, height: 480)
+        .frame(width: 360, height: 520)
         .background(Color(NSColor.windowBackgroundColor))
         .toggleStyle(IrrlichtSwitchToggleStyle())
     }
@@ -123,10 +123,10 @@ struct SettingsView: View {
             }
             // If user just toggled a notification setting and we've never asked,
             // show the "blocked" banner so the user knows to enable in System Settings.
-            if settings.authorizationStatus == .notDetermined,
-               (UserDefaults.standard.bool(forKey: "notifyOnReady") ||
-                UserDefaults.standard.bool(forKey: "notifyOnWaiting") ||
-                UserDefaults.standard.bool(forKey: "notifyOnContextPressure")) {
+            let anyEnabled = NotificationEvent.allCases.contains {
+                UserDefaults.standard.bool(forKey: $0.enabledKey)
+            }
+            if settings.authorizationStatus == .notDetermined, anyEnabled {
                 DispatchQueue.main.async {
                     center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
                         DispatchQueue.main.async {
@@ -159,7 +159,9 @@ private struct NotificationEventRow: View {
                     }
                     Divider()
                     Text("None").tag(SoundChoice.none)
-                    Text("Speak aloud").tag(SoundChoice.speak)
+                    ForEach(SoundChoice.speakChoices, id: \.self) { choice in
+                        Text(choice.displayName).tag(choice)
+                    }
                     if case .custom = selection {
                         Text(selection.displayName).tag(selection)
                     }
@@ -183,8 +185,38 @@ private struct NotificationEventRow: View {
                 .disabled(!enabled || selection == .none)
                 .tooltip("Preview")
             }
+
+            if case .speak(let voice) = selection,
+               voice != .default,
+               !voice.isInstalled {
+                Button {
+                    Self.openSpokenContentSettings()
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.down.circle")
+                        Text("Install \(voice.displayName) in System Settings")
+                    }
+                    .font(.caption)
+                }
+                .buttonStyle(.link)
+                .foregroundColor(.orange)
+                .tooltip("Open System Settings → Accessibility → Spoken Content")
+            }
         }
         .onAppear { loadFromDefaults() }
+    }
+
+    private static func openSpokenContentSettings() {
+        // macOS 14/15 expose Spoken Content as an anchor inside the
+        // Accessibility settings extension. Older macOS opens the general
+        // Accessibility pane (no Spoken Content anchor, but close enough).
+        let candidates = [
+            "x-apple.systempreferences:com.apple.Accessibility-Settings.extension?SpokenContent",
+            "x-apple.systempreferences:com.apple.preference.universalaccess",
+        ]
+        for raw in candidates {
+            if let url = URL(string: raw), NSWorkspace.shared.open(url) { return }
+        }
     }
 
     private func loadFromDefaults() {
@@ -245,14 +277,11 @@ private struct LeadingToggle: View {
 /// switch ignores `.tint(_:)` — its on color is locked to the system accent.
 /// Drawing the pill ourselves makes the color independent of System Settings.
 private struct IrrlichtSwitchToggleStyle: ToggleStyle {
-    /// Same green that HistoryBarView uses for the "ready" state.
-    private static let onColor = Color(hex: "#34C759")
-
     func makeBody(configuration: Configuration) -> some View {
         HStack(spacing: 8) {
             ZStack(alignment: configuration.isOn ? .trailing : .leading) {
                 Capsule()
-                    .fill(configuration.isOn ? Self.onColor : Color.secondary.opacity(0.35))
+                    .fill(configuration.isOn ? AppPalette.ready : Color.secondary.opacity(0.35))
                 Circle()
                     .fill(Color.white)
                     .shadow(color: Color.black.opacity(0.18), radius: 1, x: 0, y: 0.5)

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -1,13 +1,16 @@
 import SwiftUI
+import UniformTypeIdentifiers
 import UserNotifications
 
 struct SettingsView: View {
     @Binding var isPresented: Bool
     @AppStorage("debugMode") private var debugMode: Bool = false
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
-    @AppStorage("notifyOnReady") private var notifyOnReady: Bool = false
-    @AppStorage("notifyOnWaiting") private var notifyOnWaiting: Bool = false
+    @AppStorage("notifyOnReady") private var notifyOnReady: Bool = true
+    @AppStorage("notifyOnWaiting") private var notifyOnWaiting: Bool = true
+    @AppStorage("notifyOnContextPressure") private var notifyOnContextPressure: Bool = true
     @State private var notificationsDenied = false
+    @State private var customImportError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -34,20 +37,41 @@ struct SettingsView: View {
 
             Divider()
 
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 10) {
                 Text("Notifications")
                     .font(.subheadline)
                     .fontWeight(.medium)
 
-                Toggle("Notify when agent is ready", isOn: $notifyOnReady)
+                NotificationEventRow(
+                    event: .ready,
+                    enabled: $notifyOnReady,
+                    sampleText: "Agent ready",
+                    onImportError: { customImportError = $0 }
+                )
+                NotificationEventRow(
+                    event: .waiting,
+                    enabled: $notifyOnWaiting,
+                    sampleText: "Agent waiting for input",
+                    onImportError: { customImportError = $0 }
+                )
+                NotificationEventRow(
+                    event: .contextPressure,
+                    enabled: $notifyOnContextPressure,
+                    sampleText: "Context pressure: 80% threshold reached",
+                    onImportError: { customImportError = $0 }
+                )
 
-                Toggle("Notify when agent is waiting", isOn: $notifyOnWaiting)
-
-                Text("Send a desktop notification when an agent finishes work or needs your input.")
+                Text("Pick a sound per event, choose your own audio file, or have the message read aloud.")
                     .font(.caption)
                     .foregroundColor(.secondary)
 
-                if notificationsDenied && (notifyOnReady || notifyOnWaiting) {
+                if let error = customImportError {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+
+                if notificationsDenied && (notifyOnReady || notifyOnWaiting || notifyOnContextPressure) {
                     HStack(spacing: 4) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundColor(.orange)
@@ -70,6 +94,7 @@ struct SettingsView: View {
             .onAppear { checkNotificationAuth() }
             .onChange(of: notifyOnReady) { _ in checkNotificationAuth() }
             .onChange(of: notifyOnWaiting) { _ in checkNotificationAuth() }
+            .onChange(of: notifyOnContextPressure) { _ in checkNotificationAuth() }
 
             Spacer()
 
@@ -80,7 +105,7 @@ struct SettingsView: View {
             }
         }
         .padding(20)
-        .frame(width: 320, height: 380)
+        .frame(width: 360, height: 480)
         .background(Color(NSColor.windowBackgroundColor))
     }
 
@@ -96,10 +121,9 @@ struct SettingsView: View {
             // show the "blocked" banner so the user knows to enable in System Settings.
             if settings.authorizationStatus == .notDetermined,
                (UserDefaults.standard.bool(forKey: "notifyOnReady") ||
-                UserDefaults.standard.bool(forKey: "notifyOnWaiting")) {
+                UserDefaults.standard.bool(forKey: "notifyOnWaiting") ||
+                UserDefaults.standard.bool(forKey: "notifyOnContextPressure")) {
                 DispatchQueue.main.async {
-                    // Request authorization — the SessionManager startup flow handles
-                    // the LSUIElement workaround, but if it hasn't run yet we try here too.
                     center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
                         DispatchQueue.main.async {
                             notificationsDenied = !granted
@@ -109,4 +133,100 @@ struct SettingsView: View {
             }
         }
     }
+}
+
+/// One row in the Settings notifications section: enable toggle, sound
+/// picker, and a ▶ preview button.
+private struct NotificationEventRow: View {
+    let event: NotificationEvent
+    @Binding var enabled: Bool
+    let sampleText: String
+    let onImportError: (String) -> Void
+
+    @State private var selection: SoundChoice = .default
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Toggle(event.displayName, isOn: $enabled)
+            HStack(spacing: 8) {
+                Picker("", selection: $selection) {
+                    ForEach(SoundChoice.builtIns, id: \.self) { choice in
+                        Text(choice.displayName).tag(choice)
+                    }
+                    Divider()
+                    Text("None").tag(SoundChoice.none)
+                    Text("Speak aloud").tag(SoundChoice.speak)
+                    if case .custom = selection {
+                        Text(selection.displayName).tag(selection)
+                    }
+                    Divider()
+                    Text("Custom audio file…").tag(SoundChoice.customPickerSentinel)
+                }
+                .labelsHidden()
+                .disabled(!enabled)
+                .frame(maxWidth: .infinity)
+                .onChange(of: selection) { newValue in
+                    handle(newValue)
+                }
+
+                Button {
+                    SoundPlayer.preview(selection, sampleText: sampleText)
+                } label: {
+                    Image(systemName: "play.fill")
+                        .frame(width: 14, height: 14)
+                }
+                .buttonStyle(.bordered)
+                .disabled(!enabled || selection == .none)
+                .tooltip("Preview")
+            }
+        }
+        .onAppear { loadFromDefaults() }
+    }
+
+    private func loadFromDefaults() {
+        let raw = UserDefaults.standard.string(forKey: event.soundKey) ?? event.defaultSound.rawValue
+        selection = SoundChoice(rawValue: raw) ?? event.defaultSound
+    }
+
+    private func handle(_ newValue: SoundChoice) {
+        if newValue == .customPickerSentinel {
+            // Restore previous selection until the open panel resolves.
+            let previous = SoundChoice(rawValue: UserDefaults.standard.string(forKey: event.soundKey) ?? "") ?? .default
+            selection = previous
+            pickCustomFile()
+            return
+        }
+        UserDefaults.standard.set(newValue.rawValue, forKey: event.soundKey)
+    }
+
+    private func pickCustomFile() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowedContentTypes = [UTType.audio]
+        panel.message = "Choose an audio file (aiff, wav, mp3, m4a, caf)"
+        let response = panel.runModal()
+        guard response == .OK, let url = panel.url else { return }
+
+        SoundPlayer.installCustom(srcURL: url, event: event) { result in
+            switch result {
+            case .success(let installed):
+                let choice = SoundChoice.custom(installedFilename: installed, displayPath: url.path)
+                UserDefaults.standard.set(choice.rawValue, forKey: event.soundKey)
+                selection = choice
+                onImportError("")
+            case .failure(let error):
+                onImportError("Could not import audio file: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+private extension SoundChoice {
+    /// Stand-in tag for the "Custom audio file…" picker item. We can't use
+    /// `.custom(...)` directly because the menu row pre-exists the user's
+    /// selection — picking it presents `NSOpenPanel` and only then promotes
+    /// into a real `.custom` value.
+    static let customPickerSentinel: SoundChoice = .custom(installedFilename: "__picker_sentinel__", displayPath: "")
 }

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -20,7 +20,7 @@ struct SettingsView: View {
             Divider()
 
             VStack(alignment: .leading, spacing: 8) {
-                Toggle("Debug Mode", isOn: $debugMode)
+                LeadingToggle(isOn: $debugMode, label: "Debug Mode")
 
                 Text("Show session IDs, creation time, and time since last update.")
                     .font(.caption)
@@ -28,11 +28,12 @@ struct SettingsView: View {
             }
 
             VStack(alignment: .leading, spacing: 8) {
-                Toggle("Show Estimated Cost", isOn: $showCostDisplay)
+                LeadingToggle(isOn: $showCostDisplay, label: "Show Estimated Cost")
 
                 Text("Display estimated USD cost per session and per project group. Cost estimates are approximate.")
                     .font(.caption)
                     .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Divider()
@@ -109,7 +110,7 @@ struct SettingsView: View {
         .padding(20)
         .frame(width: 360, height: 480)
         .background(Color(NSColor.windowBackgroundColor))
-        .toggleStyle(.switch)
+        .toggleStyle(IrrlichtSwitchToggleStyle())
     }
 
     private func checkNotificationAuth() {
@@ -150,7 +151,7 @@ private struct NotificationEventRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Toggle(event.displayName, isOn: $enabled)
+            LeadingToggle(isOn: $enabled, label: event.displayName)
             HStack(spacing: 8) {
                 Picker("", selection: $selection) {
                     ForEach(SoundChoice.builtIns, id: \.self) { choice in
@@ -222,6 +223,48 @@ private struct NotificationEventRow: View {
             case .failure(let error):
                 onImportError("Could not import audio file: \(error.localizedDescription)")
             }
+        }
+    }
+}
+
+/// Left-aligned switch + label, rendered by `IrrlichtSwitchToggleStyle`.
+private struct LeadingToggle: View {
+    @Binding var isOn: Bool
+    let label: String
+
+    var body: some View {
+        HStack {
+            Toggle(isOn: $isOn) { Text(label) }
+            Spacer()
+        }
+    }
+}
+
+/// Custom switch style: a green-on / neutral-off capsule with a sliding
+/// white knob. Replaces `ToggleStyle.switch` because macOS's NSSwitch-backed
+/// switch ignores `.tint(_:)` — its on color is locked to the system accent.
+/// Drawing the pill ourselves makes the color independent of System Settings.
+private struct IrrlichtSwitchToggleStyle: ToggleStyle {
+    /// Same green that HistoryBarView uses for the "ready" state.
+    private static let onColor = Color(hex: "#34C759")
+
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(spacing: 8) {
+            ZStack(alignment: configuration.isOn ? .trailing : .leading) {
+                Capsule()
+                    .fill(configuration.isOn ? Self.onColor : Color.secondary.opacity(0.35))
+                Circle()
+                    .fill(Color.white)
+                    .shadow(color: Color.black.opacity(0.18), radius: 1, x: 0, y: 0.5)
+                    .padding(2)
+            }
+            .frame(width: 30, height: 18)
+            .animation(.easeInOut(duration: 0.15), value: configuration.isOn)
+            .onTapGesture { configuration.isOn.toggle() }
+            .accessibilityAddTraits(.isButton)
+            .accessibilityValue(configuration.isOn ? "on" : "off")
+
+            configuration.label
         }
     }
 }

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -64,11 +64,13 @@ struct SettingsView: View {
                 Text("Pick a sound per event, choose your own audio file, or have the message read aloud.")
                     .font(.caption)
                     .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 if let error = customImportError {
                     Text(error)
                         .font(.caption)
                         .foregroundColor(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 if notificationsDenied && (notifyOnReady || notifyOnWaiting || notifyOnContextPressure) {
@@ -107,6 +109,7 @@ struct SettingsView: View {
         .padding(20)
         .frame(width: 360, height: 480)
         .background(Color(NSColor.windowBackgroundColor))
+        .toggleStyle(.switch)
     }
 
     private func checkNotificationAuth() {

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -260,12 +260,16 @@ private struct IrrlichtSwitchToggleStyle: ToggleStyle {
             }
             .frame(width: 30, height: 18)
             .animation(.easeInOut(duration: 0.15), value: configuration.isOn)
-            .onTapGesture { configuration.isOn.toggle() }
-            .accessibilityAddTraits(.isButton)
-            .accessibilityValue(configuration.isOn ? "on" : "off")
 
             configuration.label
         }
+        // contentShape extends the hit area across the entire row (pill + gap
+        // + label), so tapping anywhere along the row flips the switch — not
+        // just the small pill itself.
+        .contentShape(Rectangle())
+        .onTapGesture { configuration.isOn.toggle() }
+        .accessibilityAddTraits(.isButton)
+        .accessibilityValue(configuration.isOn ? "on" : "off")
     }
 }
 

--- a/platforms/macos/Tests/SettingsViewTests.swift
+++ b/platforms/macos/Tests/SettingsViewTests.swift
@@ -21,8 +21,8 @@ final class SettingsViewTests: XCTestCase {
         // deterministically — the test verifies opacity, not hue, but
         // appearance-pinning keeps the render stable across themes.
         hosting.appearance = NSAppearance(named: .darkAqua)
-        // SettingsView hard-codes its own 360×480 frame.
-        hosting.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
+        // SettingsView hard-codes its own 360×520 frame.
+        hosting.frame = CGRect(x: 0, y: 0, width: 360, height: 520)
         hosting.layoutSubtreeIfNeeded()
 
         guard let bitmap = hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds) else {

--- a/platforms/macos/Tests/SettingsViewTests.swift
+++ b/platforms/macos/Tests/SettingsViewTests.swift
@@ -21,8 +21,8 @@ final class SettingsViewTests: XCTestCase {
         // deterministically — the test verifies opacity, not hue, but
         // appearance-pinning keeps the render stable across themes.
         hosting.appearance = NSAppearance(named: .darkAqua)
-        // SettingsView hard-codes its own 320×380 frame.
-        hosting.frame = CGRect(x: 0, y: 0, width: 320, height: 380)
+        // SettingsView hard-codes its own 360×480 frame.
+        hosting.frame = CGRect(x: 0, y: 0, width: 360, height: 480)
         hosting.layoutSubtreeIfNeeded()
 
         guard let bitmap = hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds) else {

--- a/platforms/macos/Tests/SoundChoiceTests.swift
+++ b/platforms/macos/Tests/SoundChoiceTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import Irrlicht
+
+final class SoundChoiceTests: XCTestCase {
+
+    func testBuiltInRoundTrip() {
+        for choice in SoundChoice.builtIns + [.none, .speak] {
+            let raw = choice.rawValue
+            let decoded = SoundChoice(rawValue: raw)
+            XCTAssertEqual(decoded, choice, "round-trip failed for \(choice)")
+        }
+    }
+
+    func testCustomRoundTrip() {
+        let original = SoundChoice.custom(installedFilename: "IrrlichtCustom-ready.caf", displayPath: "/Users/x/Music/alert.mp3")
+        let decoded = SoundChoice(rawValue: original.rawValue)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testCustomWithPipeInPathRoundTrips() {
+        // The grammar splits on the first `|`, so a display path that itself
+        // contains `|` after the separator must survive intact.
+        let original = SoundChoice.custom(installedFilename: "IrrlichtCustom-waiting.caf", displayPath: "/tmp/weird|name.wav")
+        let decoded = SoundChoice(rawValue: original.rawValue)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testRejectsUnknownRawValues() {
+        XCTAssertNil(SoundChoice(rawValue: "bogus"))
+        XCTAssertNil(SoundChoice(rawValue: "custom:"))
+        XCTAssertNil(SoundChoice(rawValue: "custom:noseparator"))
+    }
+
+    func testBuiltInsResolveToSystemSounds() {
+        XCTAssertEqual(SoundChoice.ping.systemSoundFilename, "Ping.aiff")
+        XCTAssertEqual(SoundChoice.chime.systemSoundFilename, "Glass.aiff")
+        XCTAssertEqual(SoundChoice.funk.systemSoundFilename, "Funk.aiff")
+        XCTAssertEqual(SoundChoice.whoosh.systemSoundFilename, "Blow.aiff")
+        XCTAssertEqual(SoundChoice.sosumi.systemSoundFilename, "Sosumi.aiff")
+    }
+
+    func testSpeakAndNoneHaveNoNotificationSoundName() {
+        XCTAssertNil(SoundChoice.none.notificationSoundName)
+        XCTAssertNil(SoundChoice.speak.notificationSoundName)
+    }
+
+    func testCustomNotificationSoundUsesInstalledFilename() {
+        let choice = SoundChoice.custom(installedFilename: "IrrlichtCustom-ready.caf", displayPath: "/x.mp3")
+        XCTAssertEqual(choice.notificationSoundName, "IrrlichtCustom-ready.caf")
+    }
+}

--- a/platforms/macos/Tests/SoundChoiceTests.swift
+++ b/platforms/macos/Tests/SoundChoiceTests.swift
@@ -4,11 +4,17 @@ import XCTest
 final class SoundChoiceTests: XCTestCase {
 
     func testBuiltInRoundTrip() {
-        for choice in SoundChoice.builtIns + [.none, .speak] {
+        for choice in SoundChoice.builtIns + [.none] + SoundChoice.speakChoices {
             let raw = choice.rawValue
             let decoded = SoundChoice(rawValue: raw)
             XCTAssertEqual(decoded, choice, "round-trip failed for \(choice)")
         }
+    }
+
+    func testBareSpeakDecodesToDefaultVoice() {
+        // Backwards-compat: the earlier single-voice encoding stored "speak".
+        // Existing users must keep working without losing their selection.
+        XCTAssertEqual(SoundChoice(rawValue: "speak"), .speak(.default))
     }
 
     func testCustomRoundTrip() {
@@ -41,7 +47,9 @@ final class SoundChoiceTests: XCTestCase {
 
     func testSpeakAndNoneHaveNoNotificationSoundName() {
         XCTAssertNil(SoundChoice.none.notificationSoundName)
-        XCTAssertNil(SoundChoice.speak.notificationSoundName)
+        for choice in SoundChoice.speakChoices {
+            XCTAssertNil(choice.notificationSoundName, "speak variant \(choice) must have no notification sound")
+        }
     }
 
     func testCustomNotificationSoundUsesInstalledFilename() {

--- a/platforms/macos/Tests/SoundPlayerTests.swift
+++ b/platforms/macos/Tests/SoundPlayerTests.swift
@@ -1,0 +1,125 @@
+import AVFoundation
+import UserNotifications
+import XCTest
+@testable import Irrlicht
+
+final class SoundPlayerTests: XCTestCase {
+
+    // MARK: - resolveNotificationSound
+
+    func testResolveBuiltInProducesNamedSound() throws {
+        let defaults = UserDefaults.standard
+        let event = NotificationEvent.ready
+        defaults.set(SoundChoice.chime.rawValue, forKey: event.soundKey)
+        defer { defaults.removeObject(forKey: event.soundKey) }
+
+        let sound = SessionManager.resolveNotificationSound(for: event)
+        XCTAssertNotNil(sound, "built-in choice should produce a UNNotificationSound")
+    }
+
+    func testResolveNoneAndSpeakReturnNil() {
+        let defaults = UserDefaults.standard
+        let event = NotificationEvent.waiting
+        defer { defaults.removeObject(forKey: event.soundKey) }
+
+        defaults.set(SoundChoice.none.rawValue, forKey: event.soundKey)
+        XCTAssertNil(SessionManager.resolveNotificationSound(for: event))
+
+        defaults.set(SoundChoice.speak.rawValue, forKey: event.soundKey)
+        XCTAssertNil(SessionManager.resolveNotificationSound(for: event))
+    }
+
+    func testResolveMissingCustomFallsBackToPing() {
+        let defaults = UserDefaults.standard
+        let event = NotificationEvent.contextPressure
+        let missing = SoundChoice.custom(installedFilename: "IrrlichtCustom-doesnotexist.caf", displayPath: "/tmp/x.mp3")
+        defaults.set(missing.rawValue, forKey: event.soundKey)
+        defer { defaults.removeObject(forKey: event.soundKey) }
+
+        // We can't introspect UNNotificationSound's name, so the assertion is
+        // limited to "produces a non-nil fallback rather than crashing or
+        // returning nil." Combined with the explicit Ping branch in
+        // resolveNotificationSound, this guards against the regression.
+        let sound = SessionManager.resolveNotificationSound(for: event)
+        XCTAssertNotNil(sound, "missing custom should fall back to Ping, not nil")
+    }
+
+    // MARK: - installCustom
+
+    func testInstallCustomPassthroughCopiesAiff() throws {
+        let src = URL(fileURLWithPath: "/System/Library/Sounds/Glass.aiff")
+        try XCTSkipUnless(FileManager.default.fileExists(atPath: src.path), "system Glass.aiff missing")
+
+        let installed = try waitInstall(src: src, event: .ready)
+        defer { try? FileManager.default.removeItem(at: try SoundPlayer.soundsDirectory().appendingPathComponent(installed)) }
+
+        XCTAssertEqual(installed, "IrrlichtCustom-ready.aiff")
+        let dest = try SoundPlayer.soundsDirectory().appendingPathComponent(installed)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: dest.path))
+    }
+
+    func testInstallCustomRejectsUnsupportedExtension() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("not-audio-\(UUID().uuidString).txt")
+        try "junk".write(to: tmp, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let result = waitInstallResult(src: tmp, event: .ready)
+        switch result {
+        case .success(let name):
+            XCTFail("expected failure, got success(\(name))")
+        case .failure(let error):
+            guard let installError = error as? SoundPlayer.InstallError else {
+                XCTFail("wrong error type: \(error)")
+                return
+            }
+            if case .unsupportedFormat = installError { return }
+            XCTFail("expected .unsupportedFormat, got \(installError)")
+        }
+    }
+
+    func testInstallCustomReplacesStaleVariant() throws {
+        // First install a .aiff, then install a .wav for the same event and
+        // confirm the .aiff is gone.
+        let aiffSrc = URL(fileURLWithPath: "/System/Library/Sounds/Pop.aiff")
+        try XCTSkipUnless(FileManager.default.fileExists(atPath: aiffSrc.path), "system Pop.aiff missing")
+
+        let installedA = try waitInstall(src: aiffSrc, event: .waiting)
+        let dir = try SoundPlayer.soundsDirectory()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: dir.appendingPathComponent(installedA).path))
+
+        // Fabricate a tiny .wav by writing a header-less placeholder; installCustom
+        // doesn't validate format internals, so a renamed copy is enough.
+        let wavSrc = FileManager.default.temporaryDirectory.appendingPathComponent("fake-\(UUID().uuidString).wav")
+        try Data(repeating: 0, count: 256).write(to: wavSrc)
+        defer { try? FileManager.default.removeItem(at: wavSrc) }
+
+        let installedB = try waitInstall(src: wavSrc, event: .waiting)
+        defer { try? FileManager.default.removeItem(at: dir.appendingPathComponent(installedB)) }
+
+        XCTAssertEqual(installedB, "IrrlichtCustom-waiting.wav")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dir.appendingPathComponent(installedA).path),
+            "stale .aiff should have been removed when the .wav was installed"
+        )
+    }
+
+    // MARK: - helpers
+
+    private func waitInstall(src: URL, event: NotificationEvent, timeout: TimeInterval = 5) throws -> String {
+        switch waitInstallResult(src: src, event: event, timeout: timeout) {
+        case .success(let name): return name
+        case .failure(let error): throw error
+        }
+    }
+
+    private func waitInstallResult(src: URL, event: NotificationEvent, timeout: TimeInterval = 5) -> Result<String, Error> {
+        let expectation = XCTestExpectation(description: "installCustom completes")
+        var captured: Result<String, Error>!
+        SoundPlayer.installCustom(srcURL: src, event: event) { result in
+            captured = result
+            expectation.fulfill()
+        }
+        _ = XCTWaiter.wait(for: [expectation], timeout: timeout)
+        return captured
+    }
+}

--- a/platforms/macos/Tests/SoundPlayerTests.swift
+++ b/platforms/macos/Tests/SoundPlayerTests.swift
@@ -25,8 +25,31 @@ final class SoundPlayerTests: XCTestCase {
         defaults.set(SoundChoice.none.rawValue, forKey: event.soundKey)
         XCTAssertNil(SessionManager.resolveNotificationSound(for: event))
 
-        defaults.set(SoundChoice.speak.rawValue, forKey: event.soundKey)
+        defaults.set(SoundChoice.speak(.default).rawValue, forKey: event.soundKey)
         XCTAssertNil(SessionManager.resolveNotificationSound(for: event))
+    }
+
+    // MARK: - SpokenVoice / voice(for:)
+
+    func testSpokenVoiceRawValueRoundTrip() {
+        for v in SpokenVoice.allCases {
+            XCTAssertEqual(SpokenVoice(rawValue: v.rawValue), v)
+        }
+    }
+
+    func testVoiceForEachSpokenVoiceIsNonNil() {
+        // Every variant must resolve to a usable voice: when the canonical
+        // name (Ava / Tom) is installed we get the best-quality variant of
+        // it; when it isn't, we fall back to AVSpeechSynthesisVoice(
+        // language: "en-US") which is always present.
+        for v in SpokenVoice.allCases {
+            XCTAssertNotNil(SoundPlayer.voice(for: v), "voice missing for \(v)")
+        }
+    }
+
+    func testSpokenVoiceIsInstalledForDefaultAlwaysTrue() {
+        XCTAssertTrue(SpokenVoice.default.isInstalled,
+            ".default has no canonical name and must always report installed")
     }
 
     func testResolveMissingCustomFallsBackToPing() {

--- a/platforms/macos/Tests/SoundPlayerTests.swift
+++ b/platforms/macos/Tests/SoundPlayerTests.swift
@@ -77,6 +77,61 @@ final class SoundPlayerTests: XCTestCase {
         }
     }
 
+    func testInstallCustomTranscodesM4AToLPCMCAF() throws {
+        // Synthesize a short m4a (AAC) at runtime so the test is self-contained.
+        // The transcode path must decode AAC and re-encode as 16-bit LPCM in a
+        // CAF container — anything else (passthrough, AAC-in-CAF) won't play
+        // through UNNotificationSound.
+        let m4aSrc = try makeSilentM4A(durationSec: 0.25)
+        defer { try? FileManager.default.removeItem(at: m4aSrc) }
+
+        let installed = try waitInstall(src: m4aSrc, event: .ready, timeout: 10)
+        let dir = try SoundPlayer.soundsDirectory()
+        let destURL = dir.appendingPathComponent(installed)
+        defer { try? FileManager.default.removeItem(at: destURL) }
+
+        XCTAssertEqual(installed, "IrrlichtCustom-ready.caf")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: destURL.path))
+
+        // Verify the output is actually LPCM (UNNotificationSound's requirement),
+        // not AAC-in-CAF or something else.
+        let producedFile = try AVAudioFile(forReading: destURL)
+        let asbd = producedFile.fileFormat.streamDescription.pointee
+        XCTAssertEqual(asbd.mFormatID, kAudioFormatLinearPCM, "transcoded file must be LPCM, got format \(asbd.mFormatID)")
+        XCTAssertGreaterThan(producedFile.length, 0, "transcoded file should have audio frames")
+    }
+
+    /// Writes a short AAC-encoded m4a file to `tmp` and returns its URL. Used
+    /// only to feed `installCustom`'s transcode branch a real non-passthrough
+    /// source.
+    private func makeSilentM4A(durationSec: Double) throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("silent-\(UUID().uuidString).m4a")
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: 44100.0,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderBitRateKey: 32_000,
+        ]
+        let outputFile = try AVAudioFile(forWriting: url, settings: settings)
+
+        guard let pcmFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 44100,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "could not build PCM format"])
+        }
+        let frames = AVAudioFrameCount(44100 * durationSec)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: pcmFormat, frameCapacity: frames) else {
+            throw NSError(domain: "Test", code: 0, userInfo: [NSLocalizedDescriptionKey: "could not build PCM buffer"])
+        }
+        buffer.frameLength = frames
+        // buffer is zero-filled by default → silence.
+        try outputFile.write(from: buffer)
+        return url
+    }
+
     func testInstallCustomReplacesStaleVariant() throws {
         // First install a .aiff, then install a .wav for the same event and
         // confirm the .aiff is gone.


### PR DESCRIPTION
## Summary

- Adds a Notifications section in Preferences with a per-event row for **Agent ready**, **Agent waiting for input**, and **Context pressure alert**. Each row has an enable toggle, a sound picker, and a ▶ preview button.
- Sound picker options: **Ping · Chime · Funk · Whoosh · Sosumi** (macOS system sounds), **None** (silent banner — banner still shown), **Speak aloud** (uses `AVSpeechSynthesizer`, pinned to `en-US`), and **Custom audio file…** which accepts `.aiff/.wav/.mp3/.m4a/.caf`. mp3/m4a are transcoded to CAF on import so `UNNotificationSound` can play them.
- Custom files are installed into `~/Library/Sounds/` under a canonical name per event; if the file is later missing/unreadable, playback falls back to `Ping.aiff`.
- Defaults: all three events enabled, Ready=Funk, Waiting=Ping, Context=Sosumi. Seeded via `UserDefaults.register(defaults:)` so existing users' preferences aren't overridden.
- Bug fix: `sendContextPressureNotification` now respects the `notifyOnContextPressure` toggle (previously fired unconditionally).
- UI polish: Settings overlay sized to fit (360×480), description caption wraps to multiple lines, all toggles use `ToggleStyle.switch`.

Closes #253.

## Test plan

- [x] `swift test` from `platforms/macos/` — 7 new `SoundChoiceTests` + 6 new `SoundPlayerTests` pass. Only the 5 pre-existing `GroupViewSnapshotTests` snapshot failures remain (unrelated to this change).
- [x] `go test ./core/... -race -count=1` — passes cleanly (no Go changes, smoke-tested anyway).
- [x] Manual: open Settings → Notifications, switch each event among Ping/Chime/Funk/Whoosh/Sosumi/None/Speak/Custom, click ▶ to preview each.
- [x] Manual: "Speak aloud" reads in English even though the system speech locale is German.
- [x] Manual: Toggle "Context pressure alert" off — alert no longer fires at the next 80%/95% crossing.
- [x] Manual: Import a `.mp3` via Custom — transcodes to `~/Library/Sounds/IrrlichtCustom-<event>.caf` and previews correctly.
- [ ] Reviewer: try a missing/deleted custom file — confirm the notification falls back to Ping (visible in `/tmp/irrlicht-app-dev.log`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)