### PR TITLE
docs: post-v0.4.0 sweep gaps + harden release skill

### DIFF
--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -77,8 +77,9 @@ typically owns the surface:
 
 | Diff touches… | Likely-affected docs |
 |---|---|
-| `core/adapters/inbound/agents/**` | `site/docs/adapters.html`, README compatibility grid |
-| `core/ports/**`, `core/domain/**` | `site/docs/architecture.html`, `site/docs/adapters.html` |
+| `core/adapters/inbound/agents/**` | `site/docs/adapters.html`, README compatibility grid, `AGENTS.md` "Adding a new agent adapter" section |
+| `core/ports/**`, `core/domain/**` | `site/docs/architecture.html`, `site/docs/adapters.html`, `AGENTS.md` if the adapter contract shape changes |
+| `core/cmd/irrlichd/main.go` slice/wiring rename (e.g. `agentCfgs` → `allAgents`) | `site/docs/api-reference.html` (the `GET /api/v1/agents` blurb references the slice name), `site/docs/contributing.html` adapter-PR checklist, `AGENTS.md` |
 | `core/cmd/irrlichd/handlers.go` (HTTP routes / payloads) | `site/docs/api-reference.html` |
 | `core/cmd/irrlicht-ls`, `core/cmd/irrlicht-focus` | `site/docs/cli-tools.html` |
 | `core/application/services/**`, `core/domain/session/**` | `site/docs/state-machine.html`, `site/docs/session-detection.html` |
@@ -209,9 +210,15 @@ ditto -c -k --sequesterRsrc --keepParent /tmp/Irrlicht.app /tmp/Irrlicht-$NEW_VE
 ```
 
 ### Checksums
+
+Include the daemon-only tarball alongside the zip — `site/install.sh`
+verifies it on the curl `--daemon-only` path. Omitting it ships a
+release where the standalone daemon installer fails the integrity check.
+
 ```bash
 cd /tmp && shasum -a 256 \
   irrlichd-darwin-universal \
+  irrlichd-darwin-universal.tar.gz \
   Irrlicht-$NEW_VERSION.dmg \
   Irrlicht-$NEW_VERSION-mac-installer.pkg \
   Irrlicht-$NEW_VERSION.zip \
@@ -281,8 +288,13 @@ gh pr create --title "chore: release v$NEW_VERSION" \
 gh pr view --json mergeable,mergeStateStatus \
   --jq '"mergeable=\(.mergeable) state=\(.mergeStateStatus)"'
 
-gh pr merge --squash --delete-branch
+gh pr merge --squash
 ```
+
+Do **not** pass `--delete-branch`. The release branch is intentionally
+kept after merge so the pre-squash commit and its CI history remain
+addressable (e.g. for forensic comparison against the squashed commit
+if a regression surfaces).
 
 ### 7c. Realign local `main` and tag the merged commit
 

--- a/site/docs/api-reference.html
+++ b/site/docs/api-reference.html
@@ -180,7 +180,7 @@
 
       <h3>GET /api/v1/agents</h3>
 
-      <p>Returns the registered adapter branding so frontends can look up an adapter's display name and icon by <code>name</code> instead of hardcoding their own switches. Order mirrors <code>agentCfgs</code> in <code>core/cmd/irrlichd/main.go</code>; frontends should treat ordering as informational only and key by <code>name</code>.</p>
+      <p>Returns the registered adapter branding so frontends can look up an adapter's display name and icon by <code>name</code> instead of hardcoding their own switches. Order mirrors <code>allAgents</code> in <code>core/cmd/irrlichd/main.go</code>; frontends should treat ordering as informational only and key by <code>name</code>.</p>
 
       <pre><code>[
   {

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -314,8 +314,8 @@ test: add table-driven tests for state machine</code></pre>
 
       <ul class="checklist">
         <li>Adapter package at <code>core/adapters/inbound/agents/&lt;name&gt;/</code></li>
-        <li>Implements the <code>AgentWatcher</code> interface</li>
-        <li>Registered in <code>core/cmd/irrlichd/main.go</code></li>
+        <li>Exports an <code>agent.Agent</code> from <code>Agent()</code> with the right <code>Source</code> variant (<code>FilesUnderRoot</code> / <code>FilesUnderCWD</code> / <code>ProcessOwnedStore</code>)</li>
+        <li>Registered in the <code>allAgents</code> slice in <code>core/cmd/irrlichd/main.go</code></li>
         <li>Emits all three lifecycle states (<code>working</code>, <code>waiting</code>, <code>ready</code>)</li>
         <li><code>replaydata/agents/&lt;name&gt;/capabilities.json</code> populated against <code>replaydata/agents/features.json</code></li>
         <li><code>baseline-hello</code> and <code>full-lifecycle-toolcall</code> fixtures committed under <code>replaydata/agents/&lt;name&gt;/scenarios/</code></li>


### PR DESCRIPTION
## Summary

- Fix two stale doc spots the v0.4.0 release skill missed: `agentCfgs` → `allAgents` in `api-reference.html`, and the adapter-PR checklist in `contributing.html` (still referenced the deleted `AgentWatcher` interface).
- Harden `/ir:release` so the same misses can't happen again:
  - Step 6 checksum recipe now includes `irrlichd-darwin-universal.tar.gz` (the curl `--daemon-only` installer verifies it).
  - Step 7b drops `--delete-branch` from the squash-merge with a brief rationale.
  - Step 4b trigger table gets two new rows: adapter-package / ports-domain edits flag `AGENTS.md`; `main.go` slice/wiring renames flag `api-reference.html` + `contributing.html`.

## Test plan

- [x] `grep -n "agentCfgs\|AgentWatcher" site/docs/*.html` returns 0 hits outside the historical changelog
- [x] Skill file diff reads cleanly