### PR TITLE
chore: retire deprecated env vars, document the real ones

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,11 +72,16 @@ and the daemon-spawning logic in the macOS app.
 - `IRRLICHT_BIND_ADDR` overrides the default loopback bind (e.g.
   `0.0.0.0:7837` to expose on the LAN). Use with care — state files and
   session metadata become reachable to anyone who can reach that address.
+  See [the configuration docs](https://irrlicht.io/docs/configuration.html#when-to-use)
+  for the LAN-exposure recipe and tradeoffs.
 - `IRRLICHT_MDNS=1` enables mDNS/Bonjour advertisement of `_irrlicht._tcp`
-  on the local network. Off by default.
+  on the local network. Off by default. Paired with `IRRLICHT_BIND_ADDR` in
+  the [configuration docs example](https://irrlicht.io/docs/configuration.html#when-to-use).
 - The WebSocket endpoint (`/api/v1/sessions/stream`) rejects cross-site
   handshakes: only requests from loopback origins (or with no `Origin`
   header, as native clients send) are accepted. This holds even when the
   daemon is bound to a non-loopback address.
+- Planned: both knobs will be retired in favor of an explicit hub mode.
+  See the [Relay Server design](https://github.com/ingo-eichhorst/Irrlicht/wiki/Relay-Server).
 
 Thanks for helping keep Irrlicht users safe.

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -52,6 +52,9 @@ class SessionManager: ObservableObject {
     private var projectCostsTimer: Timer?
     private let projectCostsRefreshInterval: TimeInterval = 30.0
 
+    /// Daemon-owned directory. `irrlichd` creates it and writes session JSON
+    /// files; the app only mutates individual files for explicit user actions
+    /// (`resetSessionState`, `deleteSession`). Reads go through the WebSocket.
     private let instancesPath: URL
     private let orderFilePath: URL
     private var sessionOrder: [String] = []

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -64,14 +64,6 @@ class SessionManager: ObservableObject {
     // for each session ID. Prevents re-firing on every state update.
     private var notifiedThresholds: [String: Set<Int>] = [:]
 
-    // MARK: - File polling (legacy, active when IRRLICHT_USE_FILES=1)
-
-    private var fileSystemWatcher: DispatchSourceFileSystemObject?
-    private var debounceTimer: Timer?
-    private var periodicUpdateTimer: Timer?
-    private let debounceInterval: TimeInterval = 0.2 // 200ms debounce
-    private let updateInterval: TimeInterval = 1.0 // 1 second periodic updates
-
     // MARK: - WebSocket state
 
     private var webSocketTask: URLSessionWebSocketTask?
@@ -95,12 +87,6 @@ class SessionManager: ObservableObject {
     /// Held strongly so UNUserNotificationCenter's weak delegate reference
     /// stays alive.
     private var notificationForwarder: NotificationClickForwarder?
-
-    // MARK: - Mode selection
-
-    private var useFilePolling: Bool {
-        ProcessInfo.processInfo.environment["IRRLICHT_USE_FILES"] == "1"
-    }
 
     init() {
         let homeURL = FileManager.default.homeDirectoryForCurrentUser
@@ -127,12 +113,7 @@ class SessionManager: ObservableObject {
             loadSessionOrder()
             loadProjectGroupOrder()
             requestNotificationPermission()
-            if self.useFilePolling {
-                self.startWatching()
-                self.loadExistingSessions()
-            } else {
-                self.startWebSocket()
-            }
+            self.startWebSocket()
             self.startProjectCostsPolling()
         }
     }
@@ -142,12 +123,6 @@ class SessionManager: ObservableObject {
         connectTask = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
         webSocketTask = nil
-        fileSystemWatcher?.cancel()
-        fileSystemWatcher = nil
-        debounceTimer?.invalidate()
-        debounceTimer = nil
-        periodicUpdateTimer?.invalidate()
-        periodicUpdateTimer = nil
         projectCostsTimer?.invalidate()
         projectCostsTimer = nil
     }
@@ -680,151 +655,6 @@ class SessionManager: ObservableObject {
         allSessions = all // includes children for badge counting
         checkContextPressureAlerts(sessions: topLevel)
         writeDebugState()
-    }
-
-    // MARK: - File System Watching (legacy)
-
-    func startWatching() {
-        guard connectionState == .disconnected else { return }
-
-        // Create directory if it doesn't exist
-        createInstancesDirectoryIfNeeded()
-
-        // Set up file system watcher
-        let fileDescriptor = open(instancesPath.path, O_EVTONLY)
-        guard fileDescriptor >= 0 else {
-            lastError = "Failed to open instances directory for watching"
-            return
-        }
-
-        fileSystemWatcher = DispatchSource.makeFileSystemObjectSource(
-            fileDescriptor: fileDescriptor,
-            eventMask: [.write, .delete, .rename],
-            queue: DispatchQueue.main
-        )
-
-        fileSystemWatcher?.setEventHandler { [weak self] in
-            self?.debouncedReload()
-        }
-
-        fileSystemWatcher?.setCancelHandler {
-            close(fileDescriptor)
-        }
-
-        fileSystemWatcher?.resume()
-
-        // Start periodic update timer
-        periodicUpdateTimer = Timer.scheduledTimer(withTimeInterval: updateInterval, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.loadExistingSessions()
-            }
-        }
-
-        connectionState = .connected
-    }
-
-    func stopWatching() {
-        fileSystemWatcher?.cancel()
-        fileSystemWatcher = nil
-        debounceTimer?.invalidate()
-        debounceTimer = nil
-        periodicUpdateTimer?.invalidate()
-        periodicUpdateTimer = nil
-        connectionState = .disconnected
-    }
-
-    private func debouncedReload() {
-        debounceTimer?.invalidate()
-        debounceTimer = Timer.scheduledTimer(withTimeInterval: debounceInterval, repeats: false) { [weak self] _ in
-            Task {
-                await self?.loadExistingSessions()
-            }
-        }
-    }
-
-    // MARK: - Session Loading (file polling mode)
-
-    func loadExistingSessions() {
-        print("📂 Loading sessions from: \(instancesPath.path)")
-        do {
-            let fileURLs = try FileManager.default.contentsOfDirectory(
-                at: instancesPath,
-                includingPropertiesForKeys: [.contentModificationDateKey],
-                options: [.skipsHiddenFiles]
-            ).filter { $0.pathExtension == "json" }
-
-            print("📄 Found \(fileURLs.count) session files")
-
-            var newSessions: [SessionState] = []
-
-            for fileURL in fileURLs {
-                do {
-                    let data = try Data(contentsOf: fileURL)
-                    let session = try JSONDecoder().decode(SessionState.self, from: data)
-
-                    newSessions.append(session)
-                } catch {
-                    print("Failed to decode session file \(fileURL.lastPathComponent): \(error)")
-                    // Continue processing other files
-                }
-            }
-
-            // Auto-cleanup orphaned sessions whose Claude Code process has exited.
-            // This catches the common case where Claude Code is force-quit or crashes
-            // without firing SessionEnd.
-            var orphanedIds: [String] = []
-            let staleTTL: TimeInterval = 3600 // 1 hour — for legacy sessions without PID
-            for session in newSessions {
-                let isOrphaned: Bool
-                if let pid = session.pid, pid > 0 {
-                    // PID-based check: probe with signal 0 (no signal sent, just liveness check)
-                    isOrphaned = kill(pid_t(pid), 0) != 0
-                } else {
-                    // Legacy session: no PID stored; only reap active states after TTL
-                    let isActive = session.state == .working || session.state == .waiting
-                    isOrphaned = isActive && session.updatedAt < Date().addingTimeInterval(-staleTTL)
-                }
-                if isOrphaned {
-                    let filePath = instancesPath.appendingPathComponent("\(session.id).json")
-                    try? FileManager.default.removeItem(at: filePath)
-                    orphanedIds.append(session.id)
-                    let pidDesc = session.pid.map { "pid=\($0)" } ?? "no-pid"
-                    print("🧹 Auto-deleted orphaned session \(session.shortId) (\(pidDesc))")
-                }
-            }
-            if !orphanedIds.isEmpty {
-                newSessions.removeAll { orphanedIds.contains($0.id) }
-            }
-
-            // Sort sessions according to saved order, with new sessions at the end
-            newSessions = sortSessionsByOrder(newSessions)
-
-            // Update session order to include any new sessions and remove deleted ones
-            updateSessionOrder(with: newSessions)
-
-            // Assign duplicate indexes for sessions with same project/branch
-            assignDuplicateIndexes(&newSessions)
-
-            sessions = newSessions
-            checkContextPressureAlerts(sessions: newSessions)
-            writeDebugState()
-
-        } catch {
-            lastError = "Failed to load sessions: \(error.localizedDescription)"
-            print("Session loading error: \(error)")
-        }
-    }
-
-    private func createInstancesDirectoryIfNeeded() {
-        do {
-            try FileManager.default.createDirectory(
-                at: instancesPath,
-                withIntermediateDirectories: true,
-                attributes: nil
-            )
-        } catch {
-            lastError = "Failed to create instances directory: \(error.localizedDescription)"
-        }
     }
 
     // MARK: - Computed Properties for UI

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -246,7 +246,6 @@
         <li><strong>Idempotent operations</strong> &mdash; safe to restart at any time</li>
         <li><strong>Non-destructive</strong> &mdash; never corrupts existing configs or data</li>
         <li><strong>Atomic writes</strong> &mdash; temp file + rename pattern prevents partial writes</li>
-        <li><strong>Kill switch</strong> &mdash; set <code>IRRLICHT_DISABLED=1</code> to disable entirely</li>
       </ul>
 
       <!-- ── Bottom nav ── -->

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -163,15 +163,16 @@ launchctl setenv IRRLICHT_MDNS 1
 
       <h3>The dashboard returned "Dashboard UI not found"</h3>
 
-      <p>The daemon serves the dashboard from disk and looks in three places, in order:</p>
+      <p>The daemon resolves the dashboard's location in this order (first hit wins):</p>
 
       <ol>
+        <li><code>$IRRLICHT_UI_DIR</code> &mdash; escape hatch (what this recipe sets)</li>
         <li><code>&lt;exe&gt;/../Resources/web/</code> &mdash; production <code>.app</code> bundle layout</li>
         <li><code>~/.local/share/irrlicht/web/</code> &mdash; daemon-only curl install</li>
         <li>Walking up from the executable for <code>platforms/web/index.html</code> &mdash; dev checkout</li>
       </ol>
 
-      <p>If all three miss (custom install layout, fork with a moved UI, broken symlink), point the daemon at the right directory:</p>
+      <p>If the three auto-detect paths (2&ndash;4) all miss &mdash; custom install layout, fork with a moved UI, broken symlink &mdash; set the env var so it takes precedence:</p>
 
       <pre><code>IRRLICHT_UI_DIR=/path/to/dir/containing/index.html irrlichd</code></pre>
 

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -145,11 +145,17 @@
 
       <h3>I want to peek at sessions from my phone on the same WiFi</h3>
 
-      <p>Run the daemon with both LAN binding and Bonjour discovery enabled:</p>
+      <p>If you run <code>irrlichd</code> yourself from a terminal, set both vars inline:</p>
 
       <pre><code>IRRLICHT_BIND_ADDR=0.0.0.0:7837 IRRLICHT_MDNS=1 irrlichd</code></pre>
 
-      <p>Then open <code>http://&lt;hostname&gt;.local:7837</code> in any browser on the same network. mDNS lets the phone find the host without you typing an IP.</p>
+      <p>If the macOS app auto-spawns the daemon for you (the default for DMG / Homebrew installs), shell env vars never reach it. Set them in the per-user launchd context first, then relaunch the app:</p>
+
+      <pre><code>launchctl setenv IRRLICHT_BIND_ADDR 0.0.0.0:7837
+launchctl setenv IRRLICHT_MDNS 1
+# quit Irrlicht.app from the menu bar, then reopen it</code></pre>
+
+      <p>Either way, then open <code>http://&lt;hostname&gt;.local:7837</code> in any browser on the same network. mDNS lets the phone find the host without you typing an IP.</p>
 
       <p><strong>Security note:</strong> the daemon has no authentication today. Anyone on the network you bind to can read all your transcripts. Only do this on networks you trust (your home LAN, your tailnet) &mdash; never on a coffee-shop WiFi. See <a href="https://github.com/ingo-eichhorst/Irrlicht/blob/main/SECURITY.md">SECURITY.md</a> for the full posture.</p>
 
@@ -171,9 +177,17 @@
 
       <h3>The macOS app is misbehaving and I want to see its session state</h3>
 
-      <p>Launch the app with debug state dumps enabled:</p>
+      <p>Env vars set in your shell do <em>not</em> reach a GUI app launched via <code>open -a</code> &mdash; LaunchServices spawns the app without inheriting them. Use one of these instead:</p>
 
-      <pre><code>IRRLICHT_DEBUG=1 open -a Irrlicht</code></pre>
+      <pre><code># Most reliable: invoke the binary directly
+IRRLICHT_DEBUG=1 /Applications/Irrlicht.app/Contents/MacOS/Irrlicht
+
+# Or, on macOS 13+: forward via open's --env flag
+open -a Irrlicht --env IRRLICHT_DEBUG=1
+
+# Or, persist for the launchd session and relaunch normally
+launchctl setenv IRRLICHT_DEBUG 1
+# quit Irrlicht.app, then reopen it</code></pre>
 
       <p>The current session list, connection state, and history buckets are written to <code>~/.irrlicht/debug-state.json</code> on every update. Useful when filing a bug report.</p>
 

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -112,19 +112,70 @@
             <td>Override path to Gas Town <code>gt</code> CLI binary</td>
           </tr>
           <tr>
-            <td><code>IRRLICHT_USE_FILES</code></td>
-            <td>Boolean (1/0)</td>
-            <td>unset</td>
-            <td>Enable file polling mode in macOS app (legacy, not recommended)</td>
+            <td><code>IRRLICHT_UI_DIR</code></td>
+            <td>Path</td>
+            <td>auto-detect</td>
+            <td>Directory containing the dashboard's <code>index.html</code>; escape hatch when auto-detection fails (see <a href="#when-to-use">When to use these</a>)</td>
           </tr>
           <tr>
-            <td><code>IRRLICHT_DISABLED</code></td>
+            <td><code>IRRLICHT_BIND_ADDR</code></td>
+            <td>host:port</td>
+            <td><code>127.0.0.1:7837</code></td>
+            <td>Override the daemon's TCP bind &mdash; use <code>0.0.0.0:7837</code> to expose on the LAN</td>
+          </tr>
+          <tr>
+            <td><code>IRRLICHT_MDNS</code></td>
             <td>Boolean (1/0)</td>
             <td>unset</td>
-            <td>Disable the daemon entirely (kill switch)</td>
+            <td>Advertise <code>_irrlicht._tcp</code> via Bonjour so other devices on the LAN can discover the daemon</td>
+          </tr>
+          <tr>
+            <td><code>IRRLICHT_DEBUG</code></td>
+            <td>Boolean (1/0)</td>
+            <td>unset</td>
+            <td>macOS app dumps session state to <code>~/.irrlicht/debug-state.json</code> on every update</td>
           </tr>
         </tbody>
       </table>
+
+      <!-- ── When to use these ── -->
+      <h2 id="when-to-use">When to use these</h2>
+
+      <p>The defaults work for solo, single-machine use. Reach for these overrides when one of the following describes you:</p>
+
+      <h3>I want to peek at sessions from my phone on the same WiFi</h3>
+
+      <p>Run the daemon with both LAN binding and Bonjour discovery enabled:</p>
+
+      <pre><code>IRRLICHT_BIND_ADDR=0.0.0.0:7837 IRRLICHT_MDNS=1 irrlichd</code></pre>
+
+      <p>Then open <code>http://&lt;hostname&gt;.local:7837</code> in any browser on the same network. mDNS lets the phone find the host without you typing an IP.</p>
+
+      <p><strong>Security note:</strong> the daemon has no authentication today. Anyone on the network you bind to can read all your transcripts. Only do this on networks you trust (your home LAN, your tailnet) &mdash; never on a coffee-shop WiFi. See <a href="https://github.com/ingo-eichhorst/Irrlicht/blob/main/SECURITY.md">SECURITY.md</a> for the full posture.</p>
+
+      <p><strong>Future:</strong> these two knobs will be replaced by a single explicit <em>hub mode</em>. See the <a href="https://github.com/ingo-eichhorst/Irrlicht/wiki/Relay-Server">Relay Server design</a> for the planned consolidation.</p>
+
+      <h3>The dashboard returned "Dashboard UI not found"</h3>
+
+      <p>The daemon serves the dashboard from disk and looks in three places, in order:</p>
+
+      <ol>
+        <li><code>&lt;exe&gt;/../Resources/web/</code> &mdash; production <code>.app</code> bundle layout</li>
+        <li><code>~/.local/share/irrlicht/web/</code> &mdash; daemon-only curl install</li>
+        <li>Walking up from the executable for <code>platforms/web/index.html</code> &mdash; dev checkout</li>
+      </ol>
+
+      <p>If all three miss (custom install layout, fork with a moved UI, broken symlink), point the daemon at the right directory:</p>
+
+      <pre><code>IRRLICHT_UI_DIR=/path/to/dir/containing/index.html irrlichd</code></pre>
+
+      <h3>The macOS app is misbehaving and I want to see its session state</h3>
+
+      <p>Launch the app with debug state dumps enabled:</p>
+
+      <pre><code>IRRLICHT_DEBUG=1 open -a Irrlicht</code></pre>
+
+      <p>The current session list, connection state, and history buckets are written to <code>~/.irrlicht/debug-state.json</code> on every update. Useful when filing a bug report.</p>
 
       <!-- ── Filesystem Paths ── -->
       <h2>Filesystem Paths</h2>


### PR DESCRIPTION
## Summary

- Delete two env vars that no longer earn their keep:
  - `IRRLICHT_DISABLED` — vaporware, zero code references anywhere.
  - `IRRLICHT_USE_FILES` — gated a legacy file-polling fallback in the macOS app (~165 lines) that the WebSocket path has fully replaced.
- Document four env vars that exist in code but were missing from user docs: `IRRLICHT_UI_DIR`, `IRRLICHT_BIND_ADDR`, `IRRLICHT_MDNS`, `IRRLICHT_DEBUG`.
- Add a **When to use these** section to `site/docs/configuration.html` with three concrete recipes: LAN phone access, UI-not-found recovery, debug state dump.
- Cross-link `SECURITY.md`'s network-exposure paragraphs to the new configuration docs and to the planned hub-mode design (Relay Server wiki, Phase 0).

Dev-only vars (`IRRLICHT_RECORD`, `IRRLICHT_RECORDINGS_DIR`, `IRRLICHT_DEMO_MODE`) intentionally stay out of user docs — they're already documented in `AGENTS.md` / `CHANGELOG.md` and would create noise for the 99% of readers who never run the fixture pipeline.

## Test plan

- [x] `grep IRRLICHT_USE_FILES\|IRRLICHT_DISABLED` outside `CHANGELOG.md`: zero hits.
- [x] `swift build --arch arm64` on `platforms/macos/`: clean, no warnings about unused symbols (~165 lines removed across 5 ranges in `SessionManager.swift`).
- [x] `go test ./core/... -race -count=1`: passes. (One fswatcher e2e test flaked on the full run; passed on isolated re-run. No Go code was touched.)
- [ ] Functional smoke test: launch the macOS app fresh, confirm sessions appear via the WebSocket path (today's default), and that state stays in sync as Claude Code sessions start/stop.
- [ ] Visual check of `site/docs/configuration.html`: env-var table has exactly 6 rows (`MAX_SESSION_AGE`, `GT_BIN`, `UI_DIR`, `BIND_ADDR`, `MDNS`, `DEBUG`) and the "When to use these" subsection renders cleanly.
- [ ] Visual check of `site/docs/architecture.html`: no `IRRLICHT_DISABLED` mention.

## Notes

A separate change to `.build/wiki/Relay-Server.md` adds **Phase 0 — Topology decision: one binary, hub-mode in irrlichd** as the new first step of the relay roadmap. That edit lives in the wiki repo (separate publish) and is the rationale behind the "planned: both knobs will be retired" cross-link added in `SECURITY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)