### PR TITLE
fix(macos): suppress notification sound under Focus / DND (#338)

### DIFF
--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -178,11 +178,11 @@ NEWEST_SRC=$(find /Users/ingo/projects/irrlicht/platforms/macos/Irrlicht -name '
          /tmp/Irrlicht.app/Contents/Resources/Irrlicht_Irrlicht.bundle
    ```
 6. Write a **resolved** `Info.plist` to `Contents/Info.plist` (no Xcode variables — use actual values: `CFBundleExecutable=Irrlicht`, `CFBundleIdentifier=io.irrlicht.app`, `CFBundlePackageType=APPL`, version from `$NEW_VERSION`).
-7. Ad-hoc code sign. The app entitlements come from
+7. Ad-hoc code sign. App entitlements come from
    `platforms/macos/Irrlicht/Resources/Irrlicht.entitlements` (currently
-   `get-task-allow` + `com.apple.developer.focus-status` for #338's TTS-under-
-   Focus suppression). `--entitlements` is required at sign time; INFocusStatusCenter
-   silently reports "unauthorized" without it regardless of what the user grants.
+   `get-task-allow` + `com.apple.developer.focus-status`). `--entitlements` is
+   required at sign time; Apple-gated entitlements carry no privileges in the
+   produced bundle without it.
    ```bash
    ENTITLEMENTS="/Users/ingo/projects/irrlicht/platforms/macos/Irrlicht/Resources/Irrlicht.entitlements"
    codesign --force --deep --sign - /tmp/Irrlicht.app/Contents/MacOS/irrlichd

--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -178,10 +178,15 @@ NEWEST_SRC=$(find /Users/ingo/projects/irrlicht/platforms/macos/Irrlicht -name '
          /tmp/Irrlicht.app/Contents/Resources/Irrlicht_Irrlicht.bundle
    ```
 6. Write a **resolved** `Info.plist` to `Contents/Info.plist` (no Xcode variables — use actual values: `CFBundleExecutable=Irrlicht`, `CFBundleIdentifier=io.irrlicht.app`, `CFBundlePackageType=APPL`, version from `$NEW_VERSION`).
-7. Ad-hoc code sign:
+7. Ad-hoc code sign. The app entitlements come from
+   `platforms/macos/Irrlicht/Resources/Irrlicht.entitlements` (currently
+   `get-task-allow` + `com.apple.developer.focus-status` for #338's TTS-under-
+   Focus suppression). `--entitlements` is required at sign time; INFocusStatusCenter
+   silently reports "unauthorized" without it regardless of what the user grants.
    ```bash
+   ENTITLEMENTS="/Users/ingo/projects/irrlicht/platforms/macos/Irrlicht/Resources/Irrlicht.entitlements"
    codesign --force --deep --sign - /tmp/Irrlicht.app/Contents/MacOS/irrlichd
-   codesign --force --deep --sign - /tmp/Irrlicht.app
+   codesign --force --deep --sign - --entitlements "$ENTITLEMENTS" /tmp/Irrlicht.app
    codesign --verify --deep --strict /tmp/Irrlicht.app
    ```
 8. **Smoke test before packaging** — launch the built app, wait ~2s, confirm

--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -59,16 +59,27 @@ Build the irrlicht daemon and Swift app, then replace all running instances with
        <true/>
        <key>NSAppleEventsUsageDescription</key>
        <string>Irrlicht uses AppleScript to bring the correct iTerm2 or Terminal.app window and tab to the front when you click a session row.</string>
+       <key>NSFocusStatusUsageDescription</key>
+       <string>Irrlicht uses macOS Focus status to silence notification sounds and spoken alerts while you're in Do Not Disturb, Sleep, or any other Focus mode.</string>
    </dict>
    </plist>
    PLIST
+   # Use the dev-only entitlements file (no com.apple.developer.* entries —
+   # Apple gates those to its own certificates and launchd will refuse to spawn
+   # a self-signed/ad-hoc binary that claims them). The full release entitlements
+   # at Irrlicht.entitlements include com.apple.developer.focus-status for the
+   # production Developer-ID build; in dev, INFocusStatusCenter therefore reports
+   # "unauthorized" and FocusMonitor returns false. That's expected — verify the
+   # gating logic via unit tests; the live Focus suppression is only testable in
+   # the signed release build.
+   ENTITLEMENTS="$REPO_ROOT/platforms/macos/Irrlicht/Resources/Irrlicht-dev.entitlements"
    # Sign with the persistent "Irrlicht Dev" identity if it exists; otherwise
    # fall back to ad-hoc (TCC permissions will need to be re-granted each
    # rebuild). Run tools/dev-sign-setup.sh once to install the identity.
    if security find-identity -v -p codesigning 2>/dev/null | grep -q "Irrlicht Dev"; then
-       codesign --force --deep --sign "Irrlicht Dev" "$DEV_APP" 2>&1
+       codesign --force --deep --sign "Irrlicht Dev" --entitlements "$ENTITLEMENTS" "$DEV_APP" 2>&1
    else
-       codesign --force --deep --sign - "$DEV_APP" 2>&1
+       codesign --force --deep --sign - --entitlements "$ENTITLEMENTS" "$DEV_APP" 2>&1
    fi
    ```
 

--- a/platforms/macos/Irrlicht/Managers/FocusMonitor.swift
+++ b/platforms/macos/Irrlicht/Managers/FocusMonitor.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Intents
+
+/// Provides the current macOS Focus / Do Not Disturb state so notification
+/// emitters can suppress sound (and TTS) alongside the system-suppressed
+/// banner. Conforms to `Sendable` because the `UNUserNotificationCenter`
+/// delegate's `willPresent` runs nonisolated.
+protocol FocusStateProviding: AnyObject, Sendable {
+    var isFocusActive: Bool { get }
+}
+
+/// Reads Focus state via `INFocusStatusCenter` (Intents framework, macOS 12+).
+///
+/// **Authorization model.** Requires the `com.apple.developer.focus-status`
+/// entitlement (set in `Irrlicht.entitlements`) plus `NSFocusStatusUsageDescription`
+/// in Info.plist. On first launch with `.notDetermined`, we request authorization
+/// — the system shows a permission dialog. After approval, `focusStatus.isFocused`
+/// returns the live Focus state. Without authorization the property returns nil,
+/// and we fall back to `false` (= pre-fix behavior: TTS plays under Focus).
+///
+/// **Dev signing caveat.** Per the same constraint that applies to notification
+/// permission (see `SessionManager.requestWithTemporaryWindow`), ad-hoc-signed
+/// dev builds may not get the prompt at all and silently end up `.denied`. The
+/// dev workflow uses a persistent self-signed identity ("Irrlicht Dev", set up
+/// by `tools/dev-sign-setup.sh`) which is stronger than ad-hoc. Released
+/// Developer-ID-signed builds present the dialog correctly.
+///
+/// **Why not the older approach.** Revision 1 of this monitor read
+/// `~/Library/Preferences/com.apple.ncprefs.plist` for `userPref.enabled` and
+/// `data[].storeAssertionRecords`. Field testing on macOS Sequoia 15.7.4
+/// showed *neither* schema is present — current Focus state has migrated to
+/// `~/Library/DoNotDisturb/DB/Assertions.json`, which is TCC-protected and
+/// requires Full Disk Access. INFocusStatusCenter is the only supported API.
+final class FocusMonitor: FocusStateProviding, @unchecked Sendable {
+    /// True only when running inside the real Irrlicht.app bundle. Test
+    /// binaries (xctest) have a different bundle identifier and crash if we
+    /// poke the Intents framework from them.
+    private static let isAppContext: Bool = Bundle.main.bundleIdentifier == "io.irrlicht.app"
+
+    init() {
+        guard Self.isAppContext else {
+            print("🌙 FocusMonitor: non-app context, isFocusActive will return false")
+            return
+        }
+
+        let status = INFocusStatusCenter.default.authorizationStatus
+        let focused = INFocusStatusCenter.default.focusStatus.isFocused ?? false
+        print("🌙 FocusMonitor init: auth=\(status.rawValue) focused=\(focused)")
+
+        switch status {
+        case .notDetermined:
+            INFocusStatusCenter.default.requestAuthorization { granted in
+                print("🌙 FocusMonitor authorization → \(granted.rawValue)")
+            }
+        case .denied, .restricted:
+            print("ℹ️ Focus permission unavailable — sound/TTS won't be suppressed under Focus. " +
+                  "Grant in System Settings → Privacy & Security → Focus → Irrlicht.")
+        case .authorized:
+            break
+        @unknown default:
+            break
+        }
+    }
+
+    /// Synchronous live read. `INFocusStatusCenter.default.focusStatus` is
+    /// process-safe and cheap; no caching needed for the rate at which we
+    /// emit notifications. Returns `false` in non-app contexts (xctest) so
+    /// tests don't inadvertently exercise the Intents framework.
+    var isFocusActive: Bool {
+        guard Self.isAppContext else { return false }
+        return INFocusStatusCenter.default.focusStatus.isFocused ?? false
+    }
+}

--- a/platforms/macos/Irrlicht/Managers/FocusMonitor.swift
+++ b/platforms/macos/Irrlicht/Managers/FocusMonitor.swift
@@ -13,17 +13,22 @@ protocol FocusStateProviding: AnyObject, Sendable {
 ///
 /// **Authorization model.** Requires the `com.apple.developer.focus-status`
 /// entitlement (set in `Irrlicht.entitlements`) plus `NSFocusStatusUsageDescription`
-/// in Info.plist. On first launch with `.notDetermined`, we request authorization
-/// — the system shows a permission dialog. After approval, `focusStatus.isFocused`
-/// returns the live Focus state. Without authorization the property returns nil,
-/// and we fall back to `false` (= pre-fix behavior: TTS plays under Focus).
+/// in Info.plist. On first launch with `.notDetermined`, we call
+/// `requestAuthorization`. In a properly Developer-ID-signed build that surfaces
+/// a system prompt; the user grants → `focusStatus.isFocused` returns the live
+/// Focus state.
 ///
-/// **Dev signing caveat.** Per the same constraint that applies to notification
-/// permission (see `SessionManager.requestWithTemporaryWindow`), ad-hoc-signed
-/// dev builds may not get the prompt at all and silently end up `.denied`. The
-/// dev workflow uses a persistent self-signed identity ("Irrlicht Dev", set up
-/// by `tools/dev-sign-setup.sh`) which is stronger than ad-hoc. Released
-/// Developer-ID-signed builds present the dialog correctly.
+/// **Dev signing caveat (observed on macOS Sequoia 15.7.4).** Self-signed and
+/// ad-hoc builds claiming `com.apple.developer.focus-status` won't launch at
+/// all (launchd refuses the entitlement). Self-signed builds *without* the
+/// entitlement still load the Intents framework: `requestAuthorization` reports
+/// `.authorized` (raw 3) with no prompt — but `focusStatus.isFocused` then
+/// *always returns `Optional(false)`* regardless of the actual system Focus
+/// state. The `auth=.authorized` reading is a misleading no-op; Apple gates the
+/// real read on Developer-ID-signed binaries. Practical consequence: live Focus
+/// suppression is only verifiable in the released DMG, not via `/ir:test-mac`.
+/// The `?? false` fallback in `isFocusActive` therefore covers both the truly-
+/// unauthorized case and the silently-faked-authorized case.
 ///
 /// **Why not the older approach.** Revision 1 of this monitor read
 /// `~/Library/Preferences/com.apple.ncprefs.plist` for `userPref.enabled` and
@@ -32,10 +37,12 @@ protocol FocusStateProviding: AnyObject, Sendable {
 /// `~/Library/DoNotDisturb/DB/Assertions.json`, which is TCC-protected and
 /// requires Full Disk Access. INFocusStatusCenter is the only supported API.
 final class FocusMonitor: FocusStateProviding, @unchecked Sendable {
-    /// True only when running inside the real Irrlicht.app bundle. Test
-    /// binaries (xctest) have a different bundle identifier and crash if we
-    /// poke the Intents framework from them.
-    private static let isAppContext: Bool = Bundle.main.bundleIdentifier == "io.irrlicht.app"
+    /// True when running as a real .app (production or dev bundle); false in
+    /// xctest. The xctest host has no `.app` suffix on its bundle path, so we
+    /// use that to skip Intents-framework calls — those crashed the test
+    /// runner with signal 6 during SessionManager setUp when `FocusMonitor()`
+    /// was constructed back-to-back across tests.
+    private static let isAppContext: Bool = Bundle.main.bundlePath.hasSuffix(".app")
 
     init() {
         guard Self.isAppContext else {

--- a/platforms/macos/Irrlicht/Managers/FocusMonitor.swift
+++ b/platforms/macos/Irrlicht/Managers/FocusMonitor.swift
@@ -51,8 +51,7 @@ final class FocusMonitor: FocusStateProviding, @unchecked Sendable {
         }
 
         let status = INFocusStatusCenter.default.authorizationStatus
-        let focused = INFocusStatusCenter.default.focusStatus.isFocused ?? false
-        print("🌙 FocusMonitor init: auth=\(status.rawValue) focused=\(focused)")
+        print("🌙 FocusMonitor init: auth=\(status.rawValue) focused=\(INFocusStatusCenter.default.focusStatus.isFocused ?? false)")
 
         switch status {
         case .notDetermined:

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -96,13 +96,20 @@ class SessionManager: ObservableObject {
     /// stays alive.
     private var notificationForwarder: NotificationClickForwarder?
 
+    /// Source of truth for "is macOS Focus / DND active right now". Consulted
+    /// when emitting notifications so we suppress sound + TTS alongside the
+    /// system-suppressed banner. Injectable for tests.
+    private let focusMonitor: FocusStateProviding
+
     // MARK: - Mode selection
 
     private var useFilePolling: Bool {
         ProcessInfo.processInfo.environment["IRRLICHT_USE_FILES"] == "1"
     }
 
-    init() {
+    init(focusMonitor: FocusStateProviding = FocusMonitor()) {
+        self.focusMonitor = focusMonitor
+
         let homeURL = FileManager.default.homeDirectoryForCurrentUser
         let supportPath = homeURL
             .appendingPathComponent("Library")
@@ -879,9 +886,12 @@ class SessionManager: ObservableObject {
         // Register the click-forwarder delegate before the first notification
         // is scheduled, otherwise macOS drops notification taps silently.
         if notificationForwarder == nil {
-            let forwarder = NotificationClickForwarder { [weak self] sessionID in
-                self?.handleNotificationTap(sessionID: sessionID)
-            }
+            let forwarder = NotificationClickForwarder(
+                onTap: { [weak self] sessionID in
+                    self?.handleNotificationTap(sessionID: sessionID)
+                },
+                focusMonitor: focusMonitor
+            )
             notificationForwarder = forwarder
             center.delegate = forwarder
         }
@@ -1035,9 +1045,20 @@ class SessionManager: ObservableObject {
         // sits in that grey zone. Drive speech from here (on @MainActor) so
         // it actually fires for real state transitions. The per-event toggle
         // is the off switch; users who pick a Speak aloud variant have opted in.
-        if case .speak(let voice) = choice {
+        // TTS bypasses UNNotificationContent entirely, so we must also gate on
+        // Focus here — otherwise the loudest sound option leaks through DND.
+        if let voice = Self.voiceForSpeak(choice: choice, focusActive: focusMonitor.isFocusActive) {
             SoundPlayer.speak(title: title, body: body, voice: voice)
         }
+    }
+
+    /// Pure decision helper: returns the voice to speak with when the chosen
+    /// SoundChoice is `.speak(_)` AND Focus is not active. Anything else → nil.
+    /// Extracted so the Focus-gating branch in `sendNotification` has direct
+    /// unit-test coverage without needing to stub `SoundPlayer`.
+    nonisolated static func voiceForSpeak(choice: SoundChoice, focusActive: Bool) -> SpokenVoice? {
+        if case .speak(let voice) = choice, !focusActive { return voice }
+        return nil
     }
 
     /// Pure: turn a SoundChoice into a UNNotificationSound. `.none` / `.speak`
@@ -1430,9 +1451,11 @@ enum NotificationUserInfoKey {
 /// of making `SessionManager` itself inherit from NSObject.
 final class NotificationClickForwarder: NSObject, UNUserNotificationCenterDelegate {
     private let onTap: @MainActor (String) -> Void
+    private let focusMonitor: FocusStateProviding
 
-    init(onTap: @escaping @MainActor (String) -> Void) {
+    init(onTap: @escaping @MainActor (String) -> Void, focusMonitor: FocusStateProviding) {
         self.onTap = onTap
+        self.focusMonitor = focusMonitor
     }
 
     nonisolated func userNotificationCenter(
@@ -1451,11 +1474,21 @@ final class NotificationClickForwarder: NSObject, UNUserNotificationCenterDelega
 
     // Show banners for notifications delivered while the app is foregrounded
     // — without this, in-app notifications are silently suppressed on macOS.
+    // Under Focus / DND, suppress both banner and sound: the user has asked
+    // macOS for quiet, and forcing `.sound` here is what lets the sound leak
+    // through even when the OS is suppressing the banner.
     nonisolated func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
-        completionHandler([.banner, .sound])
+        completionHandler(Self.presentationOptions(focusActive: focusMonitor.isFocusActive))
+    }
+
+    /// Pure decision helper for `willPresent`. Extracted so tests can verify
+    /// the Focus-gating branch without needing a real UNUserNotificationCenter
+    /// instance (which can't be constructed outside an app bundle).
+    nonisolated static func presentationOptions(focusActive: Bool) -> UNNotificationPresentationOptions {
+        focusActive ? [] : [.banner, .sound]
     }
 }

--- a/platforms/macos/Irrlicht/Resources/Info.plist
+++ b/platforms/macos/Irrlicht/Resources/Info.plist
@@ -28,6 +28,8 @@
     <true/>
     <key>NSAppleEventsUsageDescription</key>
     <string>Irrlicht uses AppleScript to bring the correct iTerm2 or Terminal.app window and tab to the front when you click a session row.</string>
+    <key>NSFocusStatusUsageDescription</key>
+    <string>Irrlicht uses macOS Focus status to silence notification sounds and spoken alerts while you're in Do Not Disturb, Sleep, or any other Focus mode.</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2024 Anthropic. All rights reserved.</string>
     <key>NSPrincipalClass</key>

--- a/platforms/macos/Irrlicht/Resources/Irrlicht-dev.entitlements
+++ b/platforms/macos/Irrlicht/Resources/Irrlicht-dev.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+</dict>
+</plist>

--- a/platforms/macos/Irrlicht/Resources/Irrlicht.entitlements
+++ b/platforms/macos/Irrlicht/Resources/Irrlicht.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+    <key>com.apple.developer.focus-status</key>
+    <true/>
+</dict>
+</plist>

--- a/platforms/macos/Tests/SessionManagerFocusTests.swift
+++ b/platforms/macos/Tests/SessionManagerFocusTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+import UserNotifications
+@testable import Irrlicht
+
+/// Regression coverage for #338: when macOS Focus / DND is active, notification
+/// sound must be suppressed alongside the (system-suppressed) banner — for
+/// both built-in/custom sounds (gated in `willPresent` via
+/// `presentationOptions`) and TTS (gated in `sendNotification` via
+/// `voiceForSpeak`).
+final class SessionManagerFocusTests: XCTestCase {
+
+    // MARK: - presentationOptions (willPresent gating)
+
+    func testPresentationOptionsUnderFocusSuppressesEverything() {
+        XCTAssertEqual(NotificationClickForwarder.presentationOptions(focusActive: true), [])
+    }
+
+    func testPresentationOptionsWithoutFocusShowsBannerAndSound() {
+        XCTAssertEqual(NotificationClickForwarder.presentationOptions(focusActive: false), [.banner, .sound])
+    }
+
+    // MARK: - voiceForSpeak (TTS gating)
+
+    func testVoiceForSpeakReturnsVoiceWhenFocusOff() {
+        let result = SessionManager.voiceForSpeak(choice: .speak(.female), focusActive: false)
+        XCTAssertEqual(result, .female)
+    }
+
+    func testVoiceForSpeakReturnsNilWhenFocusOn() {
+        XCTAssertNil(SessionManager.voiceForSpeak(choice: .speak(.female), focusActive: true))
+    }
+
+    func testVoiceForSpeakReturnsNilForNonSpeakChoices() {
+        XCTAssertNil(SessionManager.voiceForSpeak(choice: .chime, focusActive: false))
+        XCTAssertNil(SessionManager.voiceForSpeak(choice: .none, focusActive: false))
+        XCTAssertNil(SessionManager.voiceForSpeak(choice: .ping, focusActive: true))
+    }
+}

--- a/platforms/macos/Tests/SessionManagerFocusTests.swift
+++ b/platforms/macos/Tests/SessionManagerFocusTests.swift
@@ -35,4 +35,18 @@ final class SessionManagerFocusTests: XCTestCase {
         XCTAssertNil(SessionManager.voiceForSpeak(choice: .none, focusActive: false))
         XCTAssertNil(SessionManager.voiceForSpeak(choice: .ping, focusActive: true))
     }
+
+    // MARK: - FocusMonitor xctest-safety guard
+
+    /// Lock-in for the `isAppContext` guard in `FocusMonitor`. Without it,
+    /// constructing FocusMonitor inside xctest pokes INFocusStatusCenter,
+    /// which aborts the runner with signal 6 when it fires repeatedly across
+    /// tests (each SessionManager test re-creates one). Always-false in test
+    /// context is the contract that lets SessionManagerTests stay green.
+    func testFocusMonitorInTestContextIsAlwaysFalseAndSafe() {
+        let m1 = FocusMonitor()
+        let m2 = FocusMonitor()
+        XCTAssertFalse(m1.isFocusActive)
+        XCTAssertFalse(m2.isFocusActive)
+    }
 }

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -102,10 +102,9 @@ echo "  Embedded daemon and irrlicht-focus in app bundle"
 
 # Generate Info.plist with resolved variables.
 # NOTE: this script does NOT codesign the bundle — signing (and applying
-# Irrlicht.entitlements, which carries com.apple.developer.focus-status used
-# by #338's Focus-suppression fix) happens in the `/ir:release` skill flow.
-# Without that sign step, INFocusStatusCenter won't actually read Focus state
-# in the produced bundle.
+# Irrlicht.entitlements) happens in the `/ir:release` skill flow. Without
+# that sign step, entitlements like com.apple.developer.focus-status carry
+# no privileges in the produced bundle.
 cat > "$APP_CONTENTS/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -100,7 +100,12 @@ cp "$BUILD_DIR/irrlicht-focus-darwin-universal" "$APP_CONTENTS/MacOS/irrlicht-fo
 chmod 755 "$APP_CONTENTS/MacOS/irrlicht-focus"
 echo "  Embedded daemon and irrlicht-focus in app bundle"
 
-# Generate Info.plist with resolved variables
+# Generate Info.plist with resolved variables.
+# NOTE: this script does NOT codesign the bundle — signing (and applying
+# Irrlicht.entitlements, which carries com.apple.developer.focus-status used
+# by #338's Focus-suppression fix) happens in the `/ir:release` skill flow.
+# Without that sign step, INFocusStatusCenter won't actually read Focus state
+# in the produced bundle.
 cat > "$APP_CONTENTS/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -132,6 +132,8 @@ cat > "$APP_CONTENTS/Info.plist" <<PLIST
     <true/>
     <key>NSAppleEventsUsageDescription</key>
     <string>Irrlicht uses AppleScript to bring the correct iTerm2 or Terminal.app window and tab to the front when you click a session row.</string>
+    <key>NSFocusStatusUsageDescription</key>
+    <string>Irrlicht uses macOS Focus status to silence notification sounds and spoken alerts while you're in Do Not Disturb, Sleep, or any other Focus mode.</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright 2024 Anthropic. All rights reserved.</string>
     <key>NSPrincipalClass</key>


### PR DESCRIPTION
Closes #338.

## Summary

- macOS Focus / DND suppresses the banner, but Irrlicht's notification **sound — especially the Speak-aloud TTS variant — kept playing**. Root cause: `SoundPlayer.speak()` runs an `AVSpeechSynthesizer` inline (bypassing the system Focus filter) and `willPresent` unconditionally returned `[.banner, .sound]`.
- Adds `FocusMonitor` (Intents framework / `INFocusStatusCenter`, macOS 12+) consulted at both emit points: `willPresent` returns `[]` under Focus, and the TTS fallback in `sendNotification` is gated on the same signal. Pure decision helpers (`presentationOptions(focusActive:)`, `voiceForSpeak(choice:focusActive:)`) are extracted as `nonisolated static` for direct unit-test coverage.
- Ships `com.apple.developer.focus-status` + `NSFocusStatusUsageDescription` in the **release** sign path. Dev builds use a separate `Irrlicht-dev.entitlements` (no `com.apple.developer.*` claims) so self-signed launches still spawn — Apple gates the real Focus read on Developer-ID-signed binaries, so the fix only takes effect in the released DMG.

## Why the v1 approach didn't ship

An earlier revision read `~/Library/Preferences/com.apple.ncprefs.plist` for `userPref.enabled` / `data[].storeAssertionRecords` to avoid the entitlement. Field testing on macOS Sequoia 15.7.4 showed *neither* schema is present — Focus state has migrated to `~/Library/DoNotDisturb/DB/Assertions.json` which is TCC-protected. `INFocusStatusCenter` turned out to be the only viable API; the entitlement requirement was unavoidable.

## Commits

1. `fix(macos): suppress notification sound under Focus / DND` — core implementation.
2. `fix(macos): address review feedback` — corrected misleading doc comments on `INFocusStatusCenter` behavior (self-signed reports `.authorized` but reads silently fake `false`); replaced hardcoded bundle-id gate with `bundlePath.hasSuffix(".app")`; added a lock-in test asserting `FocusMonitor` is safe to construct in xctest.
3. `refactor: drop one-shot local + scrub task references` — `/simplify` pass: inlined a transient local, stripped issue/PR mentions from build comments.

## Verification status

- ✅ 40 SessionManager + Focus tests pass; full suite green except 5 pre-existing `GroupViewSnapshotTests` failures unrelated to this change.
- ✅ Dev build launches with new entitlements; `FocusMonitor init: auth=3` (system grants without prompt for self-signed).
- ⚠️ **Live Focus suppression cannot be verified in dev** — Apple silently returns `focused=false` for self-signed apps even with `auth=.authorized`. The release Developer-ID-signed build is the only path that exercises real Focus reads.

## Test plan

- [ ] Merge + `/ir:release` to produce a Developer-ID-signed DMG.
- [ ] Install the released build.
- [ ] On first launch, accept the new Focus permission prompt.
- [ ] Enable Do Not Disturb in Control Center → Focus.
- [ ] Trigger a `working → waiting` transition (Claude session pause); confirm **no TTS, no sound, no banner**.
- [ ] Disable DND; repeat; confirm TTS speaks and banner appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)