### PR TITLE
feat(macos): autostart Irrlicht.app at login (on by default) (#342)

### DIFF
--- a/platforms/macos/Irrlicht/IrrlichtApp.swift
+++ b/platforms/macos/Irrlicht/IrrlichtApp.swift
@@ -43,6 +43,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Wire gasTownProvider before daemon starts (hydration needs it).
         sessionManager.gasTownProvider = gasTownProvider
         daemonManager.start()
+        LoginItemManager.applyDefaultIfNeeded()
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/platforms/macos/Irrlicht/Managers/LoginItemManager.swift
+++ b/platforms/macos/Irrlicht/Managers/LoginItemManager.swift
@@ -35,21 +35,23 @@ enum LoginItemManager {
         }
     }
 
-    /// Bound to the Preferences toggle. Writes the user's intent to disk
-    /// (the `@AppStorage` binding already does this) and pushes through to
-    /// `SMAppService`. Logs failures — typically unsigned debug builds —
-    /// without surfacing them in the UI.
+    /// Bound to the Preferences toggle. The `SMAppService` call talks to
+    /// launchd over XPC, so run it off the main actor — keeps the switch
+    /// animation smooth on slower Macs. Errors (typically unsigned debug
+    /// builds) are logged, never surfaced in the UI.
     static func setEnabled(_ enabled: Bool) {
-        do {
-            if enabled {
-                try SMAppService.mainApp.register()
-                logger.info("Registered as login item")
-            } else {
-                try SMAppService.mainApp.unregister()
-                logger.info("Unregistered as login item")
+        Task.detached(priority: .userInitiated) {
+            do {
+                if enabled {
+                    try SMAppService.mainApp.register()
+                    logger.info("Registered as login item")
+                } else {
+                    try SMAppService.mainApp.unregister()
+                    logger.info("Unregistered as login item")
+                }
+            } catch {
+                logger.error("setEnabled(\(enabled)) failed: \(error.localizedDescription, privacy: .public)")
             }
-        } catch {
-            logger.error("setEnabled(\(enabled)) failed: \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/platforms/macos/Irrlicht/Managers/LoginItemManager.swift
+++ b/platforms/macos/Irrlicht/Managers/LoginItemManager.swift
@@ -11,15 +11,14 @@ enum LoginItemManager {
     private static let launchAtLoginKey = "launchAtLogin"
     private static let didApplyDefaultKey = "didApplyDefaultLoginItem"
 
-    static var isEnabled: Bool {
-        SMAppService.mainApp.status == .enabled
-    }
-
     /// Called once during `applicationDidFinishLaunching`. On first ever
     /// launch (when the gate flag is still false), opt the user in by
     /// registering the app as a login item. The gate flips to true whether
     /// or not registration succeeds, so a transient signing error doesn't
-    /// turn into an every-launch retry.
+    /// turn into an every-launch retry — note this also means a dev who
+    /// runs an unsigned build first never gets auto-opted-in by a later
+    /// signed install under the same bundle ID; not a concern for end
+    /// users, who only see the signed release.
     static func applyDefaultIfNeeded() {
         let defaults = UserDefaults.standard
         guard !defaults.bool(forKey: didApplyDefaultKey) else { return }

--- a/platforms/macos/Irrlicht/Managers/LoginItemManager.swift
+++ b/platforms/macos/Irrlicht/Managers/LoginItemManager.swift
@@ -1,0 +1,56 @@
+import Foundation
+import ServiceManagement
+import os
+
+/// Thin wrapper around `SMAppService.mainApp` for registering Irrlicht as a
+/// login item. The app opts the user in on first launch (gated by the
+/// `didApplyDefaultLoginItem` UserDefault) and respects later opt-outs.
+enum LoginItemManager {
+    private static let logger = Logger(subsystem: "io.irrlicht.app", category: "LoginItemManager")
+
+    private static let launchAtLoginKey = "launchAtLogin"
+    private static let didApplyDefaultKey = "didApplyDefaultLoginItem"
+
+    static var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    /// Called once during `applicationDidFinishLaunching`. On first ever
+    /// launch (when the gate flag is still false), opt the user in by
+    /// registering the app as a login item. The gate flips to true whether
+    /// or not registration succeeds, so a transient signing error doesn't
+    /// turn into an every-launch retry.
+    static func applyDefaultIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: didApplyDefaultKey) else { return }
+        defaults.set(true, forKey: didApplyDefaultKey)
+
+        guard defaults.bool(forKey: launchAtLoginKey) else { return }
+        guard SMAppService.mainApp.status == .notRegistered else { return }
+
+        do {
+            try SMAppService.mainApp.register()
+            logger.info("Registered as login item (first-launch default)")
+        } catch {
+            logger.error("First-launch register() failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Bound to the Preferences toggle. Writes the user's intent to disk
+    /// (the `@AppStorage` binding already does this) and pushes through to
+    /// `SMAppService`. Logs failures — typically unsigned debug builds —
+    /// without surfacing them in the UI.
+    static func setEnabled(_ enabled: Bool) {
+        do {
+            if enabled {
+                try SMAppService.mainApp.register()
+                logger.info("Registered as login item")
+            } else {
+                try SMAppService.mainApp.unregister()
+                logger.info("Unregistered as login item")
+            }
+        } catch {
+            logger.error("setEnabled(\(enabled)) failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -112,7 +112,10 @@ class SessionManager: ObservableObject {
         // with a distinguishable sound (Ready=Funk, Waiting=Ping, Context=Sosumi).
         // register(defaults:) only seeds unset keys, so it never overrides a
         // user who has explicitly picked something else.
-        var notificationDefaults: [String: Any] = [:]
+        var notificationDefaults: [String: Any] = [
+            "launchAtLogin": true,
+            "didApplyDefaultLoginItem": false,
+        ]
         for event in NotificationEvent.allCases {
             notificationDefaults[event.enabledKey] = true
             notificationDefaults[event.soundKey] = event.defaultSound.rawValue

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -108,19 +108,21 @@ class SessionManager: ObservableObject {
         self.instancesPath = supportPath.appendingPathComponent("instances")
         self.orderFilePath = supportPath.appendingPathComponent("session-order.json")
 
-        // Out-of-the-box notification defaults: all three events enabled, each
-        // with a distinguishable sound (Ready=Funk, Waiting=Ping, Context=Sosumi).
+        // Out-of-the-box defaults. Notifications: all three events enabled,
+        // each with a distinguishable sound (Ready=Funk, Waiting=Ping,
+        // Context=Sosumi). Login item: opt the user in on first launch, with
+        // the gate flag tracking that we've applied the default once.
         // register(defaults:) only seeds unset keys, so it never overrides a
         // user who has explicitly picked something else.
-        var notificationDefaults: [String: Any] = [
+        var defaultsSeed: [String: Any] = [
             "launchAtLogin": true,
             "didApplyDefaultLoginItem": false,
         ]
         for event in NotificationEvent.allCases {
-            notificationDefaults[event.enabledKey] = true
-            notificationDefaults[event.soundKey] = event.defaultSound.rawValue
+            defaultsSeed[event.enabledKey] = true
+            defaultsSeed[event.soundKey] = event.defaultSound.rawValue
         }
-        UserDefaults.standard.register(defaults: notificationDefaults)
+        UserDefaults.standard.register(defaults: defaultsSeed)
 
         Task {
             loadSessionOrder()

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @Binding var isPresented: Bool
     @AppStorage("debugMode") private var debugMode: Bool = false
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
+    @AppStorage("launchAtLogin") private var launchAtLogin: Bool = true
     @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = true
     @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = true
     @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = true
@@ -35,6 +36,16 @@ struct SettingsView: View {
                     .foregroundColor(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
+
+            VStack(alignment: .leading, spacing: 8) {
+                LeadingToggle(isOn: $launchAtLogin, label: "Open at Login")
+
+                Text("Start Irrlicht automatically when you log in to your Mac.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .onChange(of: launchAtLogin) { newValue in LoginItemManager.setEnabled(newValue) }
 
             Divider()
 


### PR DESCRIPTION
Closes #342.

## Summary

- Registers Irrlicht.app as a macOS login item on first launch via `SMAppService.mainApp` (no LaunchAgent, no privileged helper — `LSMinimumSystemVersion` is 13.0, which is when the API shipped).
- Adds a Preferences toggle ("Open at Login", default on) wired to register/unregister live. The XPC call to launchd runs in a detached `userInitiated` task so the switch animation stays smooth.
- Persists user intent in `UserDefaults` (`launchAtLogin`) plus a one-time gate (`didApplyDefaultLoginItem`) so we never re-enable after the user opts out.
- No daemon-side change: the app already spawns `irrlichd` on launch via `DaemonManager`, so login-item-enabling the app covers both processes.

## Files

- `platforms/macos/Irrlicht/Managers/LoginItemManager.swift` *(new)* — `applyDefaultIfNeeded()` and `setEnabled(_:)` wrapping `SMAppService.mainApp`. `setEnabled` offloads the launchd round-trip to a detached task; errors (unsigned debug builds, etc.) are logged via `os.Logger`, never surfaced in UI or fatal.
- `platforms/macos/Irrlicht/IrrlichtApp.swift` — call `LoginItemManager.applyDefaultIfNeeded()` after `daemonManager.start()` in `applicationDidFinishLaunching`.
- `platforms/macos/Irrlicht/Managers/SessionManager.swift` — seed `launchAtLogin = true` and `didApplyDefaultLoginItem = false` in the existing `register(defaults:)` call.
- `platforms/macos/Irrlicht/Views/SettingsView.swift` — new toggle row between "Show Estimated Cost" and the Notifications section, bound to `@AppStorage("launchAtLogin")` with `.onChange` calling `LoginItemManager.setEnabled`.

## Visual verification (dev build)

Built and launched via `ir:test-mac`; the Settings panel renders the new toggle in the expected slot (between "Show Estimated Cost" and the Notifications divider), styled identically to the existing switches. Toggling it in the unsigned dev build logs a `SMAppService` signing failure to Console.app as expected — the UI wiring and `UserDefaults` plumbing are exercised; the actual login-item registration is only valid in a signed release.

## Test plan

**Quick UI check (debug build, unsigned — SMAppService calls will fail but UI wiring is verified):**

- [x] `cd platforms/macos && swift build -c debug` — clean compile
- [x] Open Preferences via the menu bar — confirmed "Open at Login" appears between "Show Estimated Cost" and the Notifications section, with the same switch styling as other toggles
- [ ] `defaults read io.irrlicht.app launchAtLogin` returns `1`; `defaults read io.irrlicht.app didApplyDefaultLoginItem` returns `1`
- [ ] Toggle the switch off and on — confirm Console.app shows `LoginItemManager` log lines (signing errors expected in debug, but the call is exercised)

**Full end-to-end (signed release — not yet executed, requires signing key):**

- [ ] Build a signed `Irrlicht.app` via `/ir:release` (or `tools/build-release.sh` + signing) and install to `/Applications/`
- [ ] Reset state: `defaults delete io.irrlicht.app`; System Settings → General → Login Items → remove any existing Irrlicht entry
- [ ] Quit any running instance (`pkill -x Irrlicht`) and launch from `/Applications`
- [ ] Verify Irrlicht now appears under System Settings → General → Login Items, enabled
- [ ] Reboot — menu bar dot reappears without manual launch
- [ ] Open Preferences → toggle "Open at Login" off → verify removed from Login Items, `defaults read io.irrlicht.app launchAtLogin` is `0`
- [ ] Quit + relaunch with `launchAtLogin = 0`, `didApplyDefaultLoginItem = 1` → app does **not** re-register itself (regression guard for the one-time gate)
- [ ] Toggle back on → verify re-registered

**Regression suite (Go side untouched, but per CLAUDE.md):**

- [x] \`go test ./core/... -race -count=1\` — green
- [x] \`tools/replay-fixtures.sh\` — green

## Review / cleanup pass

- Dropped unused \`isEnabled\` accessor (\`eeddac9\`).
- Renamed \`SessionManager\`'s defaults dict from \`notificationDefaults\` to \`defaultsSeed\` so the new login-item keys aren't filed under "notification defaults" (\`eeddac9\`).
- Offloaded \`setEnabled\` to a detached \`userInitiated\` task so toggling the switch doesn't block the main actor on a launchd XPC round-trip (\`ab3c320\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)