### PR TITLE
chore: refresh agent landscape + release tracking (2026-05-15)

### DIFF
--- a/.claude/skills/ir:agent-landscape/references/agent-data.json
+++ b/.claude/skills/ir:agent-landscape/references/agent-data.json
@@ -1,21 +1,25 @@
 {
-  "last_updated": "2026-04-24",
+  "last_updated": "2026-05-15",
   "agents": [
     {
       "name": "Claw Code",
       "github_repo": "ultraworkers/claw-code",
       "category": "agent",
       "website": "https://github.com/ultraworkers/claw-code",
-      "description": "Rust CLI agent harness that wraps Claude via the Anthropic API; star count inflated by viral self-promotion in the README.",
-      "stars": 188050,
+      "description": "Rust CLI agent harness that wraps Claude via the Anthropic API; star count inflated by viral self-promotion in the README (\"fastest repo to 100K stars\").",
+      "stars": 191505,
       "language": "Rust",
-      "license": null,
+      "license": "MIT",
       "interface": "CLI",
       "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 191505
+        },
         {
           "date": "2026-04-24",
           "stars": 188050
@@ -31,16 +35,20 @@
       "github_repo": "anomalyco/opencode",
       "category": "agent",
       "website": "https://opencode.ai",
-      "description": "Open-source coding agent (TypeScript CLI).",
-      "stars": 148747,
+      "description": "The open source coding agent.",
+      "stars": 160573,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "CLI",
       "pricing": "Free (open source)",
-      "irrlicht_support": "planned",
+      "irrlicht_support": "live",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 160573
+        },
         {
           "date": "2026-04-24",
           "stars": 148747
@@ -56,8 +64,8 @@
       "github_repo": "anthropics/claude-code",
       "category": "agent",
       "website": "https://www.anthropic.com/claude-code",
-      "description": "Anthropic's terminal-based coding agent.",
-      "stars": 117553,
+      "description": "Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands.",
+      "stars": 123761,
       "language": "Shell",
       "license": null,
       "interface": "CLI",
@@ -66,6 +74,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 123761
+        },
         {
           "date": "2026-04-24",
           "stars": 117553
@@ -81,8 +93,8 @@
       "github_repo": "google-gemini/gemini-cli",
       "category": "agent",
       "website": "https://github.com/google-gemini/gemini-cli",
-      "description": "Google's open-source terminal coding agent for Gemini models.",
-      "stars": 102304,
+      "description": "An open-source AI agent that brings the power of Gemini directly into your terminal.",
+      "stars": 104022,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -91,6 +103,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 104022
+        },
         {
           "date": "2026-04-24",
           "stars": 102304
@@ -106,8 +122,8 @@
       "github_repo": "openai/codex",
       "category": "agent",
       "website": "https://github.com/openai/codex",
-      "description": "OpenAI's lightweight terminal coding agent.",
-      "stars": 77568,
+      "description": "Lightweight coding agent that runs in your terminal",
+      "stars": 82811,
       "language": "Rust",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -116,6 +132,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 82811
+        },
         {
           "date": "2026-04-24",
           "stars": 77568
@@ -131,16 +151,20 @@
       "github_repo": "OpenHands/OpenHands",
       "category": "agent",
       "website": "https://github.com/OpenHands/OpenHands",
-      "description": "AI-driven development platform for autonomous software agents.",
-      "stars": 71985,
+      "description": "🙌 OpenHands: AI-Driven Development",
+      "stars": 73613,
       "language": "Python",
-      "license": "MIT",
+      "license": "NOASSERTION",
       "interface": "CLI / Web",
       "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 73613
+        },
         {
           "date": "2026-04-24",
           "stars": 71985
@@ -156,8 +180,8 @@
       "github_repo": "cline/cline",
       "category": "agent",
       "website": "https://cline.bot",
-      "description": "Autonomous coding agent embedded in VS Code.",
-      "stars": 60949,
+      "description": "Autonomous coding agent as an SDK, IDE extension, or CLI assistant.",
+      "stars": 61809,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "IDE extension (VS Code)",
@@ -166,6 +190,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 61809
+        },
         {
           "date": "2026-04-24",
           "stars": 60949
@@ -177,62 +205,41 @@
       ]
     },
     {
-      "name": "Aider",
-      "github_repo": "Aider-AI/aider",
+      "name": "Warp",
+      "github_repo": "warpdotdev/warp",
       "category": "agent",
-      "website": "https://aider.chat",
-      "description": "AI pair-programming tool in your terminal.",
-      "stars": 43874,
-      "language": "Python",
-      "license": "Apache-2.0",
-      "interface": "CLI",
-      "pricing": "Free (open source)",
-      "irrlicht_support": "planned",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {
-          "date": "2026-04-24",
-          "stars": 43874
-        },
-        {
-          "date": "2026-04-12",
-          "stars": 43202
-        }
-      ]
-    },
-    {
-      "name": "Goose",
-      "github_repo": "aaif-goose/goose",
-      "category": "agent",
-      "website": "https://block.github.io/goose/",
-      "description": "Extensible open-source agent that can install, execute, edit, and test with any LLM (originated at Block).",
-      "stars": 43139,
+      "website": "https://www.warp.dev",
+      "description": "Warp is an agentic development environment, born out of the terminal.",
+      "stars": 58530,
       "language": "Rust",
-      "license": "Apache-2.0",
-      "interface": "CLI / Desktop app",
-      "pricing": "Free (open source)",
-      "irrlicht_support": "planned",
+      "license": "AGPL-3.0",
+      "interface": "Desktop app (Terminal)",
+      "pricing": "Freemium",
+      "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
         {
+          "date": "2026-05-15",
+          "stars": 58530
+        },
+        {
           "date": "2026-04-24",
-          "stars": 43139
+          "stars": 26501
         },
         {
           "date": "2026-04-12",
-          "stars": 41312
+          "stars": 26372
         }
       ]
     },
     {
       "name": "Pi",
-      "github_repo": "badlogic/pi-mono",
+      "github_repo": "earendil-works/pi",
       "category": "agent",
       "website": "https://github.com/badlogic/pi-mono",
-      "description": "Mario Zechner's AI agent toolkit: coding agent CLI, unified LLM API, TUI/web libraries, Slack bot, vLLM pods.",
-      "stars": 39373,
+      "description": "Mario Zechner's AI agent toolkit (CLI coding agent, unified LLM API, TUI/web libraries, Slack bot, vLLM pods); repo and `@earendil-works/*` packages moved to `earendil-works/pi` in v0.74.",
+      "stars": 49664,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "CLI",
@@ -241,6 +248,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 49664
+        },
         {
           "date": "2026-04-24",
           "stars": 39373
@@ -252,12 +263,70 @@
       ]
     },
     {
+      "name": "Goose",
+      "github_repo": "aaif-goose/goose",
+      "category": "agent",
+      "website": "https://block.github.io/goose/",
+      "description": "Extensible open-source agent (install/execute/edit/test with any LLM); originated at Block before transfer to the `aaif-goose` org.",
+      "stars": 45230,
+      "language": "Rust",
+      "license": "Apache-2.0",
+      "interface": "CLI / Desktop app",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "planned",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 45230
+        },
+        {
+          "date": "2026-04-24",
+          "stars": 43139
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 41312
+        }
+      ]
+    },
+    {
+      "name": "Aider",
+      "github_repo": "Aider-AI/aider",
+      "category": "agent",
+      "website": "https://aider.chat",
+      "description": "aider is AI pair programming in your terminal",
+      "stars": 44842,
+      "language": "Python",
+      "license": "Apache-2.0",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "live",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 44842
+        },
+        {
+          "date": "2026-04-24",
+          "stars": 43874
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 43202
+        }
+      ]
+    },
+    {
       "name": "Continue",
       "github_repo": "continuedev/continue",
       "category": "agent",
       "website": "https://continue.dev",
-      "description": "Source-controlled AI coding assistant and CI checks; VS Code / JetBrains / CLI.",
-      "stars": 32770,
+      "description": "⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI",
+      "stars": 33196,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "IDE extension / CLI",
@@ -266,6 +335,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 33196
+        },
         {
           "date": "2026-04-24",
           "stars": 32770
@@ -282,7 +355,7 @@
       "category": "agent",
       "website": "https://cursor.com",
       "description": "Proprietary AI-first code editor (the GitHub repo hosts issues only; editor source is closed).",
-      "stars": 32693,
+      "stars": 32875,
       "language": null,
       "license": null,
       "interface": "Desktop app (IDE)",
@@ -291,6 +364,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 32875
+        },
         {
           "date": "2026-04-24",
           "stars": 32693
@@ -307,7 +384,7 @@
       "category": "agent",
       "website": "https://voideditor.com",
       "description": "Open-source AI code editor (VS Code fork).",
-      "stars": 28644,
+      "stars": 28752,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "Desktop app (IDE)",
@@ -316,6 +393,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 28752
+        },
         {
           "date": "2026-04-24",
           "stars": 28644
@@ -327,37 +408,12 @@
       ]
     },
     {
-      "name": "Warp",
-      "github_repo": "warpdotdev/Warp",
-      "category": "agent",
-      "website": "https://www.warp.dev",
-      "description": "Agentic development environment built on a modern terminal.",
-      "stars": 26501,
-      "language": null,
-      "license": null,
-      "interface": "Desktop app (Terminal)",
-      "pricing": "Freemium",
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {
-          "date": "2026-04-24",
-          "stars": 26501
-        },
-        {
-          "date": "2026-04-12",
-          "stars": 26372
-        }
-      ]
-    },
-    {
       "name": "Qwen Code",
       "github_repo": "QwenLM/qwen-code",
       "category": "agent",
       "website": "https://qwen.ai/qwencode",
-      "description": "Alibaba's open-source terminal coding agent tuned for the Qwen3-Coder model family.",
-      "stars": 23813,
+      "description": "An open-source AI agent that lives in your terminal.",
+      "stars": 24401,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -366,6 +422,10 @@
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 24401
+        },
         {
           "date": "2026-04-24",
           "stars": 23813
@@ -381,16 +441,20 @@
       "github_repo": "charmbracelet/crush",
       "category": "agent",
       "website": "https://charm.land/crush",
-      "description": "Charmbracelet's multi-model terminal coding agent written in Go.",
-      "stars": 23418,
+      "description": "Glamourous agentic coding for all 💘",
+      "stars": 24298,
       "language": "Go",
-      "license": "MIT",
+      "license": "NOASSERTION",
       "interface": "CLI",
       "pricing": "Free (open source)",
       "irrlicht_support": "planned",
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 24298
+        },
         {
           "date": "2026-04-24",
           "stars": 23418
@@ -406,8 +470,8 @@
       "github_repo": "RooCodeInc/Roo-Code",
       "category": "agent",
       "website": "https://roocode.com",
-      "description": "VS Code coding agent with multi-mode team-of-agents support.",
-      "stars": 23345,
+      "description": "Roo Code gives you a whole dev team of AI agents in your code editor.",
+      "stars": 24073,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "IDE extension (VS Code)",
@@ -416,6 +480,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 24073
+        },
         {
           "date": "2026-04-24",
           "stars": 23345
@@ -427,37 +495,12 @@
       ]
     },
     {
-      "name": "SWE-agent",
-      "github_repo": "SWE-agent/SWE-agent",
-      "category": "agent",
-      "website": "https://swe-agent.com",
-      "description": "Princeton NLP's autonomous agent for resolving GitHub issues (NeurIPS 2024).",
-      "stars": 19050,
-      "language": "Python",
-      "license": "MIT",
-      "interface": "CLI",
-      "pricing": "Free (open source)",
-      "irrlicht_support": "planned",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {
-          "date": "2026-04-24",
-          "stars": 19050
-        },
-        {
-          "date": "2026-04-12",
-          "stars": 18968
-        }
-      ]
-    },
-    {
       "name": "Kilo Code",
       "github_repo": "Kilo-Org/kilocode",
       "category": "agent",
       "website": "https://kilo.ai",
-      "description": "All-in-one agentic coding platform for VS Code, JetBrains, and CLI.",
-      "stars": 18505,
+      "description": "Kilo is the all-in-one agentic engineering platform. Build, ship, and iterate faster with the most popular open source coding agent.",
+      "stars": 19304,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "IDE extension / CLI",
@@ -466,6 +509,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 19304
+        },
         {
           "date": "2026-04-24",
           "stars": 18505
@@ -477,12 +524,41 @@
       ]
     },
     {
+      "name": "SWE-agent",
+      "github_repo": "SWE-agent/SWE-agent",
+      "category": "agent",
+      "website": "https://swe-agent.com",
+      "description": "SWE-agent takes a GitHub issue and tries to automatically fix it, using your LM of choice. It can also be employed for offensive cybersecurity or competitive coding challenges. [NeurIPS 2024]",
+      "stars": 19225,
+      "language": "Python",
+      "license": "MIT",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "planned",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 19225
+        },
+        {
+          "date": "2026-04-24",
+          "stars": 19050
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 18968
+        }
+      ]
+    },
+    {
       "name": "Plandex",
       "github_repo": "plandex-ai/plandex",
       "category": "agent",
       "website": "https://plandex.ai",
-      "description": "Open-source terminal agent for large, multi-step coding tasks spanning many files.",
-      "stars": 15289,
+      "description": "Open source AI coding agent. Designed for large projects and real world tasks.",
+      "stars": 15365,
       "language": "Go",
       "license": "MIT",
       "interface": "CLI",
@@ -491,6 +567,10 @@
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 15365
+        },
         {
           "date": "2026-04-24",
           "stars": 15289
@@ -506,8 +586,8 @@
       "github_repo": "langchain-ai/open-swe",
       "category": "agent",
       "website": "https://github.com/langchain-ai/open-swe",
-      "description": "LangChain's open-source asynchronous cloud coding agent.",
-      "stars": 9642,
+      "description": "An Open-Source Asynchronous Coding Agent",
+      "stars": 9802,
       "language": "Python",
       "license": "MIT",
       "interface": "Web",
@@ -516,6 +596,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 9802
+        },
         {
           "date": "2026-04-24",
           "stars": 9642
@@ -531,16 +615,20 @@
       "github_repo": "sweepai/sweep",
       "category": "agent",
       "website": "https://sweep.dev",
-      "description": "AI coding assistant for JetBrains (pivoted from earlier GitHub-issue automation).",
-      "stars": 7705,
+      "description": "Sweep: AI coding assistant for JetBrains",
+      "stars": 7713,
       "language": "Jupyter Notebook",
-      "license": null,
+      "license": "NOASSERTION",
       "interface": "IDE extension (JetBrains)",
       "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 7713
+        },
         {
           "date": "2026-04-24",
           "stars": 7705
@@ -556,8 +644,8 @@
       "github_repo": "tailcallhq/forgecode",
       "category": "agent",
       "website": "https://forgecode.dev",
-      "description": "Rust-based open-source terminal AI pair programmer supporting 300+ models.",
-      "stars": 6925,
+      "description": "AI enabled pair programmer for Claude, GPT, O Series, Grok, Deepseek, Gemini and 300+ models",
+      "stars": 7295,
       "language": "Rust",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -566,6 +654,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 7295
+        },
         {
           "date": "2026-04-24",
           "stars": 6925
@@ -581,8 +673,8 @@
       "github_repo": "ai-christianson/RA.Aid",
       "category": "agent",
       "website": "https://www.ra-aid.ai",
-      "description": "LangGraph-based autonomous coding agent with research \u2192 plan \u2192 implement loop.",
-      "stars": 2223,
+      "description": "Develop software autonomously.",
+      "stars": 2224,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -591,6 +683,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 2224
+        },
         {
           "date": "2026-04-24",
           "stars": 2223
@@ -606,8 +702,8 @@
       "github_repo": "Factory-AI/factory",
       "category": "agent",
       "website": "https://www.factory.ai",
-      "description": "Agent-native software development platform with Droid agents.",
-      "stars": 794,
+      "description": "Factory - Agent-Native Software Development",
+      "stars": 876,
       "language": null,
       "license": null,
       "interface": "Web / CLI",
@@ -616,6 +712,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 876
+        },
         {
           "date": "2026-04-24",
           "stars": 794
@@ -631,8 +731,8 @@
       "github_repo": "trypear/pearai-app",
       "category": "agent",
       "website": "https://trypear.ai",
-      "description": "Open-source AI code editor (VS Code fork with Continue submodule).",
-      "stars": 676,
+      "description": "PearAI: Open Source AI Code Editor (Fork of VSCode). The PearAI Submodule (https://github.com/trypear/pearai-submodule) is a fork of Continue.",
+      "stars": 689,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "Desktop app (IDE)",
@@ -641,6 +741,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 689
+        },
         {
           "date": "2026-04-24",
           "stars": 676
@@ -656,7 +760,7 @@
       "github_repo": "codegen-sh/codegen",
       "category": "agent",
       "website": "https://codegen.com",
-      "description": "Python wrapper for the Codegen API \u2014 run code agents at scale against a hosted service.",
+      "description": "Python wrapper for the Codegen API - run code agents at scale",
       "stars": 521,
       "language": "Python",
       "license": "Apache-2.0",
@@ -666,6 +770,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 521
+        },
         {
           "date": "2026-04-24",
           "stars": 521
@@ -735,15 +843,15 @@
       "stars_history": []
     },
     {
-      "name": "Codebuff",
+      "name": "CodeGPT",
       "github_repo": null,
       "category": "agent",
-      "website": "https://codebuff.com",
-      "description": "AI coding agent for the terminal.",
+      "website": "https://www.codegpt.co",
+      "description": "Full-stack AI agent platform with a codebase knowledge graph.",
       "stars": null,
       "language": null,
       "license": null,
-      "interface": "CLI",
+      "interface": "IDE extension / Web",
       "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
@@ -754,15 +862,15 @@
       "stars_history": []
     },
     {
-      "name": "CodeGPT",
+      "name": "Codebuff",
       "github_repo": null,
       "category": "agent",
-      "website": "https://www.codegpt.co",
-      "description": "Full-stack AI agent platform with a codebase knowledge graph.",
+      "website": "https://codebuff.com",
+      "description": "AI coding agent for the terminal.",
       "stars": null,
       "language": null,
       "license": null,
-      "interface": "IDE extension / Web",
+      "interface": "CLI",
       "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
@@ -976,8 +1084,8 @@
       "github_repo": "paperclipai/paperclip",
       "category": "orchestrator",
       "website": "https://paperclip.ing",
-      "description": "Orchestration platform for \"zero-human companies\" \u2014 agents assigned to CEO/manager/worker roles with budgets and approvals.",
-      "stars": 58383,
+      "description": "The open-source app everyone uses to manage agents at work",
+      "stars": 65560,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "Web",
@@ -986,6 +1094,10 @@
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 65560
+        },
         {
           "date": "2026-04-24",
           "stars": 58383
@@ -997,37 +1109,12 @@
       ]
     },
     {
-      "name": "Agno",
-      "github_repo": "agno-agi/agno",
-      "category": "orchestrator",
-      "website": "https://www.agno.com",
-      "description": "Python agent runtime for teams and workflows (formerly Phidata).",
-      "stars": 39648,
-      "language": "Python",
-      "license": "Apache-2.0",
-      "interface": "SDK / Web",
-      "pricing": "Freemium",
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {
-          "date": "2026-04-24",
-          "stars": 39648
-        },
-        {
-          "date": "2026-04-12",
-          "stars": 39367
-        }
-      ]
-    },
-    {
       "name": "Ruflo",
       "github_repo": "ruvnet/ruflo",
       "category": "orchestrator",
       "website": "https://github.com/ruvnet/ruflo",
-      "description": "Agent orchestration platform for Claude: multi-agent swarms, RAG integration, Claude Code/Codex integration.",
-      "stars": 33079,
+      "description": "Agent orchestration platform for Claude: multi-agent swarms, RAG integration, Claude Code / Codex integration.",
+      "stars": 51261,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "CLI / SDK",
@@ -1036,6 +1123,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 51261
+        },
         {
           "date": "2026-04-24",
           "stars": 33079
@@ -1047,12 +1138,41 @@
       ]
     },
     {
+      "name": "Agno",
+      "github_repo": "agno-agi/agno",
+      "category": "orchestrator",
+      "website": "https://www.agno.com",
+      "description": "Build, run, and manage agent platforms.",
+      "stars": 40134,
+      "language": "Python",
+      "license": "Apache-2.0",
+      "interface": "SDK / Web",
+      "pricing": "Freemium",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 40134
+        },
+        {
+          "date": "2026-04-24",
+          "stars": 39648
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 39367
+        }
+      ]
+    },
+    {
       "name": "ChatDev",
       "github_repo": "OpenBMB/ChatDev",
       "category": "orchestrator",
       "website": "https://github.com/OpenBMB/ChatDev",
-      "description": "Virtual software company powered by multi-agent LLM collaboration (ChatDev 2.0).",
-      "stars": 32847,
+      "description": "ChatDev 2.0: Dev All through LLM-powered Multi-Agent Collaboration",
+      "stars": 33093,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "CLI / Web",
@@ -1061,6 +1181,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 33093
+        },
         {
           "date": "2026-04-24",
           "stars": 32847
@@ -1077,7 +1201,7 @@
       "category": "orchestrator",
       "website": "https://github.com/stitionai/devika",
       "description": "Open-source agentic software engineer (originally an open alternative to Devin).",
-      "stars": 19502,
+      "stars": 19507,
       "language": "Python",
       "license": "MIT",
       "interface": "Web",
@@ -1086,6 +1210,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 19507
+        },
         {
           "date": "2026-04-24",
           "stars": 19502
@@ -1101,8 +1229,8 @@
       "github_repo": "gastownhall/gastown",
       "category": "orchestrator",
       "website": "https://github.com/gastownhall/gastown",
-      "description": "Multi-agent workspace manager: Mayor (coordinator) routes work through Rigs and Polecats with a Beads work-state ledger.",
-      "stars": 14580,
+      "description": "Gas Town - multi-agent workspace manager",
+      "stars": 15195,
       "language": "Go",
       "license": "MIT",
       "interface": "CLI",
@@ -1111,6 +1239,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 15195
+        },
         {
           "date": "2026-04-24",
           "stars": 14580
@@ -1126,8 +1258,8 @@
       "github_repo": "smtg-ai/claude-squad",
       "category": "orchestrator",
       "website": "https://github.com/smtg-ai/claude-squad",
-      "description": "Manage multiple AI terminal agents (Claude Code, Codex, OpenCode, Amp) in tmux.",
-      "stars": 7145,
+      "description": "Manage multiple AI terminal agents like Claude Code, Codex, OpenCode, and Amp.",
+      "stars": 7475,
       "language": "Go",
       "license": "AGPL-3.0",
       "interface": "CLI (tmux)",
@@ -1136,6 +1268,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 7475
+        },
         {
           "date": "2026-04-24",
           "stars": 7145
@@ -1151,8 +1287,8 @@
       "github_repo": "ComposioHQ/agent-orchestrator",
       "category": "orchestrator",
       "website": "https://composio.dev",
-      "description": "Agent-agnostic orchestrator for parallel coding agents with autonomous CI auto-fix.",
-      "stars": 6474,
+      "description": "Agentic orchestrator for parallel coding agents — plans tasks, spawns agents, and autonomously handles CI fixes, merge conflicts, and code reviews.",
+      "stars": 7047,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "CLI / Web",
@@ -1161,6 +1297,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 7047
+        },
         {
           "date": "2026-04-24",
           "stars": 6474
@@ -1177,7 +1317,7 @@
       "category": "orchestrator",
       "website": "https://github.com/dlorenc/multiclaude",
       "description": "Parallel Claude Code instances in tmux with a Brownian-ratchet CI model.",
-      "stars": 539,
+      "stars": 548,
       "language": "Go",
       "license": null,
       "interface": "CLI (tmux)",
@@ -1186,6 +1326,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 548
+        },
         {
           "date": "2026-04-24",
           "stars": 539
@@ -1201,8 +1345,8 @@
       "github_repo": "stoneforge-ai/stoneforge",
       "category": "orchestrator",
       "website": "https://stoneforge.ai",
-      "description": "Web dashboard orchestrating AI coding agent teams with worktree isolation.",
-      "stars": 130,
+      "description": "A web dashboard and runtime for orchestrating AI coding agents",
+      "stars": 143,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "Web",
@@ -1211,6 +1355,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 143
+        },
         {
           "date": "2026-04-24",
           "stars": 130
@@ -1227,15 +1375,19 @@
       "category": "orchestrator",
       "website": "https://forge.nxtg.ai",
       "description": "Rust-based multi-AI task orchestrator with file locking and drift detection.",
-      "stars": 109,
+      "stars": 116,
       "language": "Rust",
-      "license": null,
+      "license": "NOASSERTION",
       "interface": "CLI",
       "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 116
+        },
         {
           "date": "2026-04-24",
           "stars": 109

--- a/.claude/skills/ir:agent-landscape/skill.md
+++ b/.claude/skills/ir:agent-landscape/skill.md
@@ -91,8 +91,8 @@ An agent is "NEW" only if both:
 
 The canonical source of truth is `core/adapters/inbound/agents/` + `core/adapters/inbound/orchestrators/`. As of this writing:
 
-- `live`: Claude Code (`anthropics/claude-code`), OpenAI Codex (`openai/codex`), Pi (`badlogic/pi-mono`), Gas Town (`gastownhall/gastown`).
-- `planned`: Gemini CLI, Cursor, Amp, Claude Squad, OpenCode, Qwen Code, Crush, Continue, Goose, Aider, Kilo Code, Paperclip, Ruflo, Multiclaude, SWE-agent.
+- `live`: Claude Code (`anthropics/claude-code`), OpenAI Codex (`openai/codex`), Pi (`earendil-works/pi`, renamed from `badlogic/pi-mono` in v0.74), Gas Town (`gastownhall/gastown`), Aider (`Aider-AI/aider`), OpenCode (`anomalyco/opencode`).
+- `planned`: Gemini CLI, Cursor, Amp, Claude Squad, Qwen Code, Crush, Continue, Goose, Kilo Code, Paperclip, Ruflo, Multiclaude, SWE-agent.
 - Everything else: `none`.
 
 Before each run, `ls core/adapters/inbound/agents/` and `ls core/adapters/inbound/orchestrators/` to confirm the list is still correct. If the set of live adapters has changed, update this section and apply the change to `agent-data.json`.

--- a/.claude/skills/ir:agent-releases/references/tracked-releases.md
+++ b/.claude/skills/ir:agent-releases/references/tracked-releases.md
@@ -7,6 +7,20 @@ This file tracks releases already analyzed. Update after each run to avoid re-re
 Each entry: `- <version> (<date>) — <one-line summary of impact or "no impact">`
 
 ## Claude Code
+- v2.1.142 (2026-05-15) — MEDIUM/UNCERTAIN: new `claude agents` flags (--add-dir, --settings, --mcp-config, --plugin-dir, --permission-mode, --model, --effort, --dangerously-skip-permissions) for dispatched background sessions; verify whether dispatched sessions still write transcripts to `~/.claude/projects/<project>/<uuid>.jsonl` flat or to a new nested path
+- v2.1.141 (2026-05-14) — no impact (`claude agents --cwd` scoping, `terminalSequence` hook output, /feedback last-24h/7d, plugin menu nav, Bedrock/MCP fixes)
+- v2.1.140 (2026-05-13) — no impact (Agent tool case-insensitive subagent_type matching, /goal hook gating, settings hot-reload fix)
+- v2.1.139 (2026-05-12) — HIGH/UNCERTAIN: `claude agents` view (Research Preview) GA's a unified list of every Claude Code session including background-dispatched; `/goal` command added; subagent API requests now carry `x-claude-code-agent-id`/`parent-agent-id` headers and OTEL attrs. Verify (a) whether dispatched/background sessions land in the same `~/.claude/projects/<project>/<uuid>.jsonl` watcher path, (b) whether subagent counting via open `Agent` tool still works or now relies on `agent_id` headers
+- v2.1.138 (2026-05) — no impact (internal fixes)
+- v2.1.137 (2026-05) — no impact (VSCode Windows activation fix)
+- v2.1.136 (2026-05) — no impact (settings.autoMode.hard_deny, MCP /clear fix, plan-mode Edit rule fix)
+- v2.1.129 (2026-05) — no impact (`--plugin-url`, force-sync-output, package-manager auto-update, plugin manifest experimental key, gateway model discovery opt-in, Ctrl+R history default, skillOverrides settings honoring, /context grid bugfix)
+- v2.1.128 (2026-05) — no impact (`--plugin-dir` zip, `--channels` with API key, /mcp tool counts, MCP reserved name `workspace`, EnterWorktree uses local HEAD, parallel shell sibling cancellation fix)
+- v2.1.126 (2026-04) — no impact (`claude project purge`, /model picker gateway discovery, Win PowerShell detection, Bedrock/Vertex/managed-domain fixes)
+- v2.1.123 (2026-04) — no impact (single OAuth fix)
+- v2.1.122 (2026-04) — no impact (Bedrock service tier, PR URL paste resume, OTel attrs, image resize bug)
+- v2.1.121 (2026-04) — MEDIUM/UNCERTAIN: `CLAUDE_CODE_FORK_SUBAGENT=1` now works in non-interactive (`claude -p`/SDK) sessions, expanding the forked-subagent transcript-path question (re v2.1.117 — still needs verification of nested `~/.claude/projects/<project>/<session>/subagents/` dir)
+- v2.1.120 (2026-04) — no impact (`claude ultrareview` non-interactive subcommand prints findings to stdout, no session; AI_AGENT env var for subprocesses; PgUp/PgDn hint; /rewind keyboard fix; `find` FD exhaustion fix)
 - v2.1.119 (2026-04-23) — no impact (/config persistence, prUrlTemplate, misc fixes)
 - v2.1.118 (2026-04-23) — no impact (vim visual mode, /usage merge, themes, hook MCP tools)
 - v2.1.117 (2026-04-22) — MEDIUM/UNCERTAIN: CLAUDE_CODE_FORK_SUBAGENT=1 enables forked subagents; verify if transcripts land in nested ~/.claude/projects/<project>/<session>/subagents/ dir (watcher scans flat jsonl only)
@@ -55,6 +69,10 @@ Each entry: `- <version> (<date>) — <one-line summary of impact or "no impact"
 - v0.2.125–v0.2.21 (2025-10 to 2025-05) — no impact (tool renames, MCP, settings, compaction, etc.)
 
 ## OpenAI Codex
+- v0.130.0 (2026-05-08) — no impact (plugin details/share metadata, `codex remote-control` headless app-server entrypoint, paginated thread item views, Bedrock console-login auth, view_image multi-env resolution; no session-storage changes)
+- v0.129.0 (2026-05-07) — no impact (TUI Vim mode, resume/fork picker redesign, raw scrollback, /ide context injection, workspace-aware /diff, plugin workspace sharing, hooks before/after compaction + PreToolUse context, experimental goals; rollout JSONL schema unchanged)
+- v0.128.0 (2026-04-30) — no impact (persisted /goal model-tool + TUI, `codex update`, permission profiles with built-in defaults, marketplace plugin install + remote bundle caching, external agent session **import** (ingest direction; doesn't change Codex's own session storage), MultiAgentV2 thread-cap config)
+- v0.125.0 (2026-04-25) — no impact (Unix socket transport, pagination-friendly resume/fork, sticky environments, remote thread store, model provider discovery, `codex exec --json` reasoning tokens, rollout tracing of tool/code-mode/session/multi-agent relationships)
 - v0.125.0-alpha.3 (2026-04-24) — no impact (pre-release)
 - v0.125.0-alpha.2 (2026-04-24) — no impact (pre-release)
 - v0.124.0 (2026-04-23) — no impact (TUI reasoning controls, multi-env app-server sessions, Bedrock SigV4, stable hooks, ChatGPT Fast tier)
@@ -66,6 +84,14 @@ Each entry: `- <version> (<date>) — <one-line summary of impact or "no impact"
 - Pre-v0.117.0 (2025-05 to 2026-03) — no impact (session format stable, rollout-*.jsonl matches *.jsonl glob, YYYY/MM/DD nesting handled by recursive WalkDir)
 
 ## Pi Coding Agent
+- v0.74.0 (2026-05-07) — LOW: repository moved from `badlogic/pi-mono` to `earendil-works/pi-mono`; `@earendil-works/*` package scopes. Filesystem-monitoring path unchanged (`~/.pi/agent/sessions/...`); only affects landscape repo references
+- v0.73.1 (2026-05-07) — no impact (patch)
+- v0.73.0 (2026-05-04) — MEDIUM/UNCERTAIN: **incremental bash output streaming** — Bash tool output now appears while commands run. Verify whether this changes `tool_result` event emission (multiple partial events vs single terminal event) for irrlicht's open-tool-call tracking. Also: Xiaomi MiMo API billing + regional Token Plan providers (no monitoring impact), compact read rendering (UI only)
+- v0.72.1 (2026-05-02) — no impact (patch)
+- v0.72.0 (2026-05-01) — no impact (Xiaomi MiMo Token Plan provider, `thinkingLevelMap` replaces `reasoningEffortMap` (custom-provider API), `shouldStopAfterTurn` agent loop callback, custom provider `baseUrl` overrides)
+- v0.71.1 (2026-05-01) — no impact (patch)
+- v0.71.0 (2026-04-30) — MEDIUM: **`PI_CODING_AGENT_SESSION_DIR` env var added** — overrides the default `~/.pi/agent/sessions/...` location. Pi adapter's `FilesUnderRoot{Dir, ...}` watches the fixed home-relative path; sessions in a custom dir are invisible. Consider honoring this env var (or documenting that custom locations aren't discovered). Also: Cloudflare/Moonshot providers, Mistral Medium 3.5 (no monitoring impact); built-in Gemini CLI / Antigravity providers removed
+- v0.70.6/.5/.4/.3/.2/.1 (2026-04-24 to 2026-04-28) — no impact (patch series)
 - v0.70.0 (2026-04) — no impact (--no-builtin-tools preserves extension tools)
 - v0.69.0 (2026-04) — no impact (TypeBox 1.x validation, internal)
 - v0.68.0 (2026-04) — no impact (Tool[]→string[] tool selection is extension-author API; PI_CODING_AGENT env — irrlicht doesn't process-monitor Pi; reason/targetSessionFile on session_shutdown — parser already skips)
@@ -81,6 +107,8 @@ Each entry: `- <version> (<date>) — <one-line summary of impact or "no impact"
 - v0.61.x–v0.60.0 (2026-03) — details unavailable (changelog truncated)
 
 ## Gas Town
+- v1.1.0 (2026-05-07) — no impact (convoy completion + cross-rig dep resolution notifications; BEADS_DIR routing to avoid pthread deadlock with bd 1.0+; ResolveProcessNames Args plumbing; no `gt list --json` schema changes)
+- v1.0.1 (2026-04-25) — no impact (Bitbucket Cloud merge-queue integration, custom-groq-opus cost tier, per-role effort, stuck-agent-dog auto-restart, deacon model-escalation.json, formula --set/interactive support, dolt commit freshness, reaper close_reason logging; orchestration internals only)
 - (2026-04-24 check) — no public releases after v1.0.0 found; Libraries.io pseudo-version v1.0.1-0.20260420010148-db74d7567d58 is a Go-module commit ref, not a release
 - v1.0.0 (2026-04-02) — MEDIUM: new Boot/Dog role not in irrlicht's roleMeta; verify role derivation
 - v0.13.0 (2026-03-29) — no impact (new CLI commands not monitored, session-hygiene plugin removed)

--- a/site/landscape/compare/index.html
+++ b/site/landscape/compare/index.html
@@ -15,10 +15,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="../../assets/apple-touch-icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://cdn.counter.dev">
-<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400&family=DM+Mono:wght@300;400&family=Outfit:wght@200;300;400;500;600&display=swap">
-<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400&family=DM+Mono:wght@300;400&family=Outfit:wght@200;300;400;500;600&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
-<noscript><link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400&family=DM+Mono:wght@300;400&family=Outfit:wght@200;300;400;500;600&display=swap" rel="stylesheet"></noscript>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400&family=DM+Mono:wght@300;400&family=Outfit:wght@200;300;400;500;600&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 :root {
@@ -125,7 +122,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <a href="../" class="back-link">&larr; Back to Landscape</a>
   <div class="page-header">
     <h1>Agent Comparison</h1>
-    <div class="updated">Last updated: 2026-04-24</div>
+    <div class="updated">Last updated: 2026-05-15</div>
     <p class="intro">In-depth comparison of all tracked AI coding agents and orchestrators. Click any column header to sort. Growth figures are measured relative to today using snapshots taken at: today, ~1 month ago, and ~3 months ago.</p>
   </div>
 
@@ -149,10 +146,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="claw code"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="188050">188,050</td>
-  <td class="growth-3m"><span class="growth-up">+5,939 <span class="growth-pct">(+3.3%)</span></span></td>
+  <td class="mono" data-sort="191505">191,505</td>
+  <td class="growth-3m"><span class="growth-up">+3,455 <span class="growth-pct">(+1.8%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>—</td>
+  <td>MIT</td>
   <td>Rust</td>
   <td>CLI</td>
   <td>Free (open source)</td>
@@ -161,20 +158,20 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="opencode"><a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="148747">148,747</td>
-  <td class="growth-3m"><span class="growth-up">+6,859 <span class="growth-pct">(+4.8%)</span></span></td>
+  <td class="mono" data-sort="160573">160,573</td>
+  <td class="growth-3m"><span class="growth-up">+11,826 <span class="growth-pct">(+8.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
   <td>CLI</td>
   <td>Free (open source)</td>
-  <td><span class="badge badge-planned">planned</span></td>
+  <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
   <td class="name" data-sort="claude code"><a href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener">Claude Code</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="117553">117,553</td>
-  <td class="growth-3m"><span class="growth-up">+4,708 <span class="growth-pct">(+4.2%)</span></span></td>
+  <td class="mono" data-sort="123761">123,761</td>
+  <td class="growth-3m"><span class="growth-up">+6,208 <span class="growth-pct">(+5.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>—</td>
   <td>Shell</td>
@@ -185,8 +182,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="gemini cli"><a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener">Gemini CLI</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="102304">102,304</td>
-  <td class="growth-3m"><span class="growth-up">+1,310 <span class="growth-pct">(+1.3%)</span></span></td>
+  <td class="mono" data-sort="104022">104,022</td>
+  <td class="growth-3m"><span class="growth-up">+1,718 <span class="growth-pct">(+1.7%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -197,8 +194,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="openai codex"><a href="https://github.com/openai/codex" target="_blank" rel="noopener">OpenAI Codex</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="77568">77,568</td>
-  <td class="growth-3m"><span class="growth-up">+2,810 <span class="growth-pct">(+3.8%)</span></span></td>
+  <td class="mono" data-sort="82811">82,811</td>
+  <td class="growth-3m"><span class="growth-up">+5,243 <span class="growth-pct">(+6.8%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Rust</td>
@@ -209,32 +206,20 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="openhands"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">OpenHands</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="71985">71,985</td>
-  <td class="growth-3m"><span class="growth-up">+925 <span class="growth-pct">(+1.3%)</span></span></td>
+  <td class="mono" data-sort="73613">73,613</td>
+  <td class="growth-3m"><span class="growth-up">+1,628 <span class="growth-pct">(+2.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
+  <td>NOASSERTION</td>
   <td>Python</td>
   <td>CLI / Web</td>
   <td>Free (open source)</td>
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="cline"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="60949">60,949</td>
-  <td class="growth-3m"><span class="growth-up">+771 <span class="growth-pct">(+1.3%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>TypeScript</td>
-  <td>IDE extension (VS Code)</td>
-  <td>Freemium</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="paperclip"><a href="https://paperclip.ing" target="_blank" rel="noopener">Paperclip</a><sup class="badge badge-new">NEW</sup></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="58383">58,383</td>
-  <td class="growth-3m"><span class="growth-up">+6,341 <span class="growth-pct">(+12.2%)</span></span></td>
+  <td class="mono" data-sort="65560">65,560</td>
+  <td class="growth-3m"><span class="growth-up">+7,177 <span class="growth-pct">(+12.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -243,58 +228,34 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="aider"><a href="https://aider.chat" target="_blank" rel="noopener">Aider</a></td>
+  <td class="name" data-sort="cline"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="43874">43,874</td>
-  <td class="growth-3m"><span class="growth-up">+672 <span class="growth-pct">(+1.6%)</span></span></td>
+  <td class="mono" data-sort="61809">61,809</td>
+  <td class="growth-3m"><span class="growth-up">+860 <span class="growth-pct">(+1.4%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
-  <td>Python</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-planned">planned</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="goose"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="43139">43,139</td>
-  <td class="growth-3m"><span class="growth-up">+1,827 <span class="growth-pct">(+4.4%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>Rust</td>
-  <td>CLI / Desktop app</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-planned">planned</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="agno"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
-  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="39648">39,648</td>
-  <td class="growth-3m"><span class="growth-up">+281 <span class="growth-pct">(+0.7%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>Python</td>
-  <td>SDK / Web</td>
+  <td>TypeScript</td>
+  <td>IDE extension (VS Code)</td>
   <td>Freemium</td>
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="pi"><a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener">Pi</a></td>
+  <td class="name" data-sort="warp"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="39373">39,373</td>
-  <td class="growth-3m"><span class="growth-up">+4,684 <span class="growth-pct">(+13.5%)</span></span></td>
+  <td class="mono" data-sort="58530">58,530</td>
+  <td class="growth-3m"><span class="growth-up">+32,029 <span class="growth-pct">(+120.9%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>TypeScript</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-live">live</span></td>
+  <td>AGPL-3.0</td>
+  <td>Rust</td>
+  <td>Desktop app (Terminal)</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
   <td class="name" data-sort="ruflo"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="33079">33,079</td>
-  <td class="growth-3m"><span class="growth-up">+1,713 <span class="growth-pct">(+5.5%)</span></span></td>
+  <td class="mono" data-sort="51261">51,261</td>
+  <td class="growth-3m"><span class="growth-up">+18,182 <span class="growth-pct">(+55.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -303,22 +264,58 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="chatdev"><a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener">ChatDev</a></td>
-  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="32847">32,847</td>
-  <td class="growth-3m"><span class="growth-up">+162 <span class="growth-pct">(+0.5%)</span></span></td>
+  <td class="name" data-sort="pi"><a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener">Pi</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="49664">49,664</td>
+  <td class="growth-3m"><span class="growth-up">+10,291 <span class="growth-pct">(+26.1%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-live">live</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="goose"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="45230">45,230</td>
+  <td class="growth-3m"><span class="growth-up">+2,091 <span class="growth-pct">(+4.8%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Rust</td>
+  <td>CLI / Desktop app</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="aider"><a href="https://aider.chat" target="_blank" rel="noopener">Aider</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="44842">44,842</td>
+  <td class="growth-3m"><span class="growth-up">+968 <span class="growth-pct">(+2.2%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Python</td>
-  <td>CLI / Web</td>
+  <td>CLI</td>
   <td>Free (open source)</td>
+  <td><span class="badge badge-live">live</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="agno"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="40134">40,134</td>
+  <td class="growth-3m"><span class="growth-up">+486 <span class="growth-pct">(+1.2%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Python</td>
+  <td>SDK / Web</td>
+  <td>Freemium</td>
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
   <td class="name" data-sort="continue"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="32770">32,770</td>
-  <td class="growth-3m"><span class="growth-up">+271 <span class="growth-pct">(+0.8%)</span></span></td>
+  <td class="mono" data-sort="33196">33,196</td>
+  <td class="growth-3m"><span class="growth-up">+426 <span class="growth-pct">(+1.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -327,10 +324,22 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="chatdev"><a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener">ChatDev</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="33093">33,093</td>
+  <td class="growth-3m"><span class="growth-up">+246 <span class="growth-pct">(+0.7%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Python</td>
+  <td>CLI / Web</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="cursor"><a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="32693">32,693</td>
-  <td class="growth-3m"><span class="growth-up">+69 <span class="growth-pct">(+0.2%)</span></span></td>
+  <td class="mono" data-sort="32875">32,875</td>
+  <td class="growth-3m"><span class="growth-up">+182 <span class="growth-pct">(+0.6%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>—</td>
   <td>—</td>
@@ -341,8 +350,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="void"><a href="https://voideditor.com" target="_blank" rel="noopener">Void</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="28644">28,644</td>
-  <td class="growth-3m"><span class="growth-up">+91 <span class="growth-pct">(+0.3%)</span></span></td>
+  <td class="mono" data-sort="28752">28,752</td>
+  <td class="growth-3m"><span class="growth-up">+108 <span class="growth-pct">(+0.4%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -351,22 +360,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="warp"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="26501">26,501</td>
-  <td class="growth-3m"><span class="growth-up">+129 <span class="growth-pct">(+0.5%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>—</td>
-  <td>—</td>
-  <td>Desktop app (Terminal)</td>
-  <td>Freemium</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="qwen code"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a><sup class="badge badge-new">NEW</sup></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="23813">23,813</td>
-  <td class="growth-3m"><span class="growth-up">+990 <span class="growth-pct">(+4.3%)</span></span></td>
+  <td class="mono" data-sort="24401">24,401</td>
+  <td class="growth-3m"><span class="growth-up">+588 <span class="growth-pct">(+2.5%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -377,10 +374,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="crush"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a><sup class="badge badge-new">NEW</sup></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="23418">23,418</td>
-  <td class="growth-3m"><span class="growth-up">+529 <span class="growth-pct">(+2.3%)</span></span></td>
+  <td class="mono" data-sort="24298">24,298</td>
+  <td class="growth-3m"><span class="growth-up">+880 <span class="growth-pct">(+3.8%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
+  <td>NOASSERTION</td>
   <td>Go</td>
   <td>CLI</td>
   <td>Free (open source)</td>
@@ -389,8 +386,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="roo code"><a href="https://roocode.com" target="_blank" rel="noopener">Roo Code</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="23345">23,345</td>
-  <td class="growth-3m"><span class="growth-up">+257 <span class="growth-pct">(+1.1%)</span></span></td>
+  <td class="mono" data-sort="24073">24,073</td>
+  <td class="growth-3m"><span class="growth-up">+728 <span class="growth-pct">(+3.1%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -401,7 +398,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="devika"><a href="https://github.com/stitionai/devika" target="_blank" rel="noopener">Devika</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="19502">19,502</td>
+  <td class="mono" data-sort="19507">19,507</td>
   <td class="growth-3m"><span class="growth-up">+5 <span class="growth-pct">(+0.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
@@ -411,22 +408,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="swe-agent"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="19050">19,050</td>
-  <td class="growth-3m"><span class="growth-up">+82 <span class="growth-pct">(+0.4%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>Python</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-planned">planned</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="kilo code"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="18505">18,505</td>
-  <td class="growth-3m"><span class="growth-up">+517 <span class="growth-pct">(+2.9%)</span></span></td>
+  <td class="mono" data-sort="19304">19,304</td>
+  <td class="growth-3m"><span class="growth-up">+799 <span class="growth-pct">(+4.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -435,10 +420,22 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="swe-agent"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="19225">19,225</td>
+  <td class="growth-3m"><span class="growth-up">+175 <span class="growth-pct">(+0.9%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Python</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="plandex"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a><sup class="badge badge-new">NEW</sup></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="15289">15,289</td>
-  <td class="growth-3m"><span class="growth-up">+58 <span class="growth-pct">(+0.4%)</span></span></td>
+  <td class="mono" data-sort="15365">15,365</td>
+  <td class="growth-3m"><span class="growth-up">+76 <span class="growth-pct">(+0.5%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>Go</td>
@@ -449,8 +446,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="gas town"><a href="https://github.com/gastownhall/gastown" target="_blank" rel="noopener">Gas Town</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="14580">14,580</td>
-  <td class="growth-3m"><span class="growth-up">+682 <span class="growth-pct">(+4.9%)</span></span></td>
+  <td class="mono" data-sort="15195">15,195</td>
+  <td class="growth-3m"><span class="growth-up">+615 <span class="growth-pct">(+4.2%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>Go</td>
@@ -461,8 +458,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="open swe"><a href="https://github.com/langchain-ai/open-swe" target="_blank" rel="noopener">Open SWE</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="9642">9,642</td>
-  <td class="growth-3m"><span class="growth-up">+158 <span class="growth-pct">(+1.7%)</span></span></td>
+  <td class="mono" data-sort="9802">9,802</td>
+  <td class="growth-3m"><span class="growth-up">+160 <span class="growth-pct">(+1.7%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>Python</td>
@@ -473,10 +470,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="sweep"><a href="https://sweep.dev" target="_blank" rel="noopener">Sweep</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="7705">7,705</td>
-  <td class="growth-3m"><span class="growth-down">-4 <span class="growth-pct">(-0.1%)</span></span></td>
+  <td class="mono" data-sort="7713">7,713</td>
+  <td class="growth-3m"><span class="growth-up">+8 <span class="growth-pct">(+0.1%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>—</td>
+  <td>NOASSERTION</td>
   <td>Jupyter Notebook</td>
   <td>IDE extension (JetBrains)</td>
   <td>Freemium</td>
@@ -485,8 +482,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="claude squad"><a href="https://github.com/smtg-ai/claude-squad" target="_blank" rel="noopener">Claude Squad</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="7145">7,145</td>
-  <td class="growth-3m"><span class="growth-up">+184 <span class="growth-pct">(+2.6%)</span></span></td>
+  <td class="mono" data-sort="7475">7,475</td>
+  <td class="growth-3m"><span class="growth-up">+330 <span class="growth-pct">(+4.6%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>AGPL-3.0</td>
   <td>Go</td>
@@ -497,8 +494,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="forge code"><a href="https://forgecode.dev" target="_blank" rel="noopener">Forge Code</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="6925">6,925</td>
-  <td class="growth-3m"><span class="growth-up">+459 <span class="growth-pct">(+7.1%)</span></span></td>
+  <td class="mono" data-sort="7295">7,295</td>
+  <td class="growth-3m"><span class="growth-up">+370 <span class="growth-pct">(+5.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Rust</td>
@@ -509,8 +506,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="composio"><a href="https://composio.dev" target="_blank" rel="noopener">Composio</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="6474">6,474</td>
-  <td class="growth-3m"><span class="growth-up">+292 <span class="growth-pct">(+4.7%)</span></span></td>
+  <td class="mono" data-sort="7047">7,047</td>
+  <td class="growth-3m"><span class="growth-up">+573 <span class="growth-pct">(+8.9%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -521,8 +518,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="ra.aid"><a href="https://www.ra-aid.ai" target="_blank" rel="noopener">RA.Aid</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="2223">2,223</td>
-  <td class="growth-3m"><span class="growth-up">+5 <span class="growth-pct">(+0.2%)</span></span></td>
+  <td class="mono" data-sort="2224">2,224</td>
+  <td class="growth-3m"><span class="growth-up">+1 <span class="growth-pct">(+0.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Python</td>
@@ -533,8 +530,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="factory"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="794">794</td>
-  <td class="growth-3m"><span class="growth-up">+38 <span class="growth-pct">(+5.0%)</span></span></td>
+  <td class="mono" data-sort="876">876</td>
+  <td class="growth-3m"><span class="growth-up">+82 <span class="growth-pct">(+10.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>—</td>
   <td>—</td>
@@ -545,8 +542,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="pear ai"><a href="https://trypear.ai" target="_blank" rel="noopener">Pear AI</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="676">676</td>
-  <td class="growth-3m"><span class="growth-up">+2 <span class="growth-pct">(+0.3%)</span></span></td>
+  <td class="mono" data-sort="689">689</td>
+  <td class="growth-3m"><span class="growth-up">+13 <span class="growth-pct">(+1.9%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -557,8 +554,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="multiclaude"><a href="https://github.com/dlorenc/multiclaude" target="_blank" rel="noopener">Multiclaude</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="539">539</td>
-  <td class="growth-3m"><span class="growth-up">+10 <span class="growth-pct">(+1.9%)</span></span></td>
+  <td class="mono" data-sort="548">548</td>
+  <td class="growth-3m"><span class="growth-up">+9 <span class="growth-pct">(+1.7%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>—</td>
   <td>Go</td>
@@ -581,8 +578,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="stoneforge"><a href="https://stoneforge.ai" target="_blank" rel="noopener">Stoneforge</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="130">130</td>
-  <td class="growth-3m"><span class="growth-up">+17 <span class="growth-pct">(+15.0%)</span></span></td>
+  <td class="mono" data-sort="143">143</td>
+  <td class="growth-3m"><span class="growth-up">+13 <span class="growth-pct">(+10.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -593,10 +590,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="forge orchestrator"><a href="https://forge.nxtg.ai" target="_blank" rel="noopener">Forge Orchestrator</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="109">109</td>
-  <td class="growth-3m"><span class="growth-up">+1 <span class="growth-pct">(+0.9%)</span></span></td>
+  <td class="mono" data-sort="116">116</td>
+  <td class="growth-3m"><span class="growth-up">+7 <span class="growth-pct">(+6.4%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>—</td>
+  <td>NOASSERTION</td>
   <td>Rust</td>
   <td>CLI</td>
   <td>Free (open source)</td>

--- a/site/landscape/index.html
+++ b/site/landscape/index.html
@@ -15,10 +15,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="../assets/apple-touch-icon.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://cdn.counter.dev">
-<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400&family=DM+Mono:wght@300;400&family=Outfit:wght@200;300;400;500;600&display=swap">
-<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400&family=DM+Mono:wght@300;400&family=Outfit:wght@200;300;400;500;600&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
-<noscript><link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400&family=DM+Mono:wght@300;400&family=Outfit:wght@200;300;400;500;600&display=swap" rel="stylesheet"></noscript>
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400&family=DM+Mono:wght@300;400&family=Outfit:wght@200;300;400;500;600&display=swap" rel="stylesheet">
 <style>
 *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
 :root {
@@ -123,13 +120,13 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <div class="container">
   <div class="page-header">
     <h1>AI Coding Agent Landscape</h1>
-    <div class="updated">Last updated: 2026-04-24</div>
+    <div class="updated">Last updated: 2026-05-15</div>
     <p class="intro">A living ranking of AI coding agents and agent orchestrators, sorted by a blend of GitHub popularity and growth momentum. Agents that Irrlicht already monitors are marked <span class="badge badge-live">live</span>, upcoming integrations are <span class="badge badge-planned">planned</span>. Agents first tracked less than 3 months ago are marked <span class="badge badge-new">NEW</span>.</p>
     <a href="compare/" class="compare-link">See detailed comparison with all metrics &rarr;</a>
   </div>
 
   <h2 class="section-title">Coding Agents</h2>
-  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-04-24.</p>
+  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-05-15.</p>
   <table class="landscape-table">
 <thead><tr>
   <th class="rank">#</th><th>Name</th><th>Stars</th><th class="growth-3m">Recent growth</th><th>Irrlicht</th><th>Description</th>
@@ -139,210 +136,210 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <tr>
     <td class="rank">#1</td>
     <td class="name"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
-    <td class="stars">188,050</td>
-    <td class="growth growth-3m"><span class="growth-up">+5,939 <span class="growth-pct">(+3.3%)</span></span></td>
+    <td class="stars">191,505</td>
+    <td class="growth growth-3m"><span class="growth-up">+3,455 <span class="growth-pct">(+1.8%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Rust CLI agent harness that wraps Claude via the Anthropic API; star count inflated by viral self-promotion in the README.</td>
+    <td class="desc">Rust CLI agent harness that wraps Claude via the Anthropic API; star count inflated by viral self-promotion in the README (&quot;fastest repo to 100K stars&quot;).</td>
   </tr>
   <tr>
     <td class="rank">#2</td>
     <td class="name"><a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a></td>
-    <td class="stars">148,747</td>
-    <td class="growth growth-3m"><span class="growth-up">+6,859 <span class="growth-pct">(+4.8%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Open-source coding agent (TypeScript CLI).</td>
+    <td class="stars">160,573</td>
+    <td class="growth growth-3m"><span class="growth-up">+11,826 <span class="growth-pct">(+8.0%)</span></span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">The open source coding agent.</td>
   </tr>
   <tr>
     <td class="rank">#3</td>
     <td class="name"><a href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener">Claude Code</a></td>
-    <td class="stars">117,553</td>
-    <td class="growth growth-3m"><span class="growth-up">+4,708 <span class="growth-pct">(+4.2%)</span></span></td>
+    <td class="stars">123,761</td>
+    <td class="growth growth-3m"><span class="growth-up">+6,208 <span class="growth-pct">(+5.3%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
-    <td class="desc">Anthropic&#x27;s terminal-based coding agent.</td>
+    <td class="desc">Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands.</td>
   </tr>
   <tr>
     <td class="rank">#4</td>
     <td class="name"><a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener">Gemini CLI</a></td>
-    <td class="stars">102,304</td>
-    <td class="growth growth-3m"><span class="growth-up">+1,310 <span class="growth-pct">(+1.3%)</span></span></td>
+    <td class="stars">104,022</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,718 <span class="growth-pct">(+1.7%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Google&#x27;s open-source terminal coding agent for Gemini models.</td>
+    <td class="desc">An open-source AI agent that brings the power of Gemini directly into your terminal.</td>
   </tr>
   <tr>
     <td class="rank">#5</td>
     <td class="name"><a href="https://github.com/openai/codex" target="_blank" rel="noopener">OpenAI Codex</a></td>
-    <td class="stars">77,568</td>
-    <td class="growth growth-3m"><span class="growth-up">+2,810 <span class="growth-pct">(+3.8%)</span></span></td>
+    <td class="stars">82,811</td>
+    <td class="growth growth-3m"><span class="growth-up">+5,243 <span class="growth-pct">(+6.8%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
-    <td class="desc">OpenAI&#x27;s lightweight terminal coding agent.</td>
+    <td class="desc">Lightweight coding agent that runs in your terminal</td>
   </tr>
   <tr>
     <td class="rank">#6</td>
     <td class="name"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">OpenHands</a></td>
-    <td class="stars">71,985</td>
-    <td class="growth growth-3m"><span class="growth-up">+925 <span class="growth-pct">(+1.3%)</span></span></td>
+    <td class="stars">73,613</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,628 <span class="growth-pct">(+2.3%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">AI-driven development platform for autonomous software agents.</td>
+    <td class="desc">🙌 OpenHands: AI-Driven Development</td>
   </tr>
   <tr>
     <td class="rank">#7</td>
     <td class="name"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
-    <td class="stars">60,949</td>
-    <td class="growth growth-3m"><span class="growth-up">+771 <span class="growth-pct">(+1.3%)</span></span></td>
+    <td class="stars">61,809</td>
+    <td class="growth growth-3m"><span class="growth-up">+860 <span class="growth-pct">(+1.4%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Autonomous coding agent embedded in VS Code.</td>
+    <td class="desc">Autonomous coding agent as an SDK, IDE extension, or CLI assistant.</td>
   </tr>
   <tr>
     <td class="rank">#8</td>
-    <td class="name"><a href="https://aider.chat" target="_blank" rel="noopener">Aider</a></td>
-    <td class="stars">43,874</td>
-    <td class="growth growth-3m"><span class="growth-up">+672 <span class="growth-pct">(+1.6%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">AI pair-programming tool in your terminal.</td>
+    <td class="name"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
+    <td class="stars">58,530</td>
+    <td class="growth growth-3m"><span class="growth-up">+32,029 <span class="growth-pct">(+120.9%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Warp is an agentic development environment, born out of the terminal.</td>
   </tr>
   <tr>
     <td class="rank">#9</td>
-    <td class="name"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
-    <td class="stars">43,139</td>
-    <td class="growth growth-3m"><span class="growth-up">+1,827 <span class="growth-pct">(+4.4%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Extensible open-source agent that can install, execute, edit, and test with any LLM (originated at Block).</td>
+    <td class="name"><a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener">Pi</a></td>
+    <td class="stars">49,664</td>
+    <td class="growth growth-3m"><span class="growth-up">+10,291 <span class="growth-pct">(+26.1%)</span></span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">Mario Zechner&#x27;s AI agent toolkit (CLI coding agent, unified LLM API, TUI/web libraries, Slack bot, vLLM pods); repo and `@earendil-works/*` packages moved to `earendil-works/pi` in v0.74.</td>
   </tr>
   <tr>
     <td class="rank">#10</td>
-    <td class="name"><a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener">Pi</a></td>
-    <td class="stars">39,373</td>
-    <td class="growth growth-3m"><span class="growth-up">+4,684 <span class="growth-pct">(+13.5%)</span></span></td>
-    <td><span class="badge badge-live">live</span></td>
-    <td class="desc">Mario Zechner&#x27;s AI agent toolkit: coding agent CLI, unified LLM API, TUI/web libraries, Slack bot, vLLM pods.</td>
+    <td class="name"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
+    <td class="stars">45,230</td>
+    <td class="growth growth-3m"><span class="growth-up">+2,091 <span class="growth-pct">(+4.8%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Extensible open-source agent (install/execute/edit/test with any LLM); originated at Block before transfer to the `aaif-goose` org.</td>
   </tr>
   <tr>
     <td class="rank">#11</td>
-    <td class="name"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
-    <td class="stars">32,770</td>
-    <td class="growth growth-3m"><span class="growth-up">+271 <span class="growth-pct">(+0.8%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Source-controlled AI coding assistant and CI checks; VS Code / JetBrains / CLI.</td>
+    <td class="name"><a href="https://aider.chat" target="_blank" rel="noopener">Aider</a></td>
+    <td class="stars">44,842</td>
+    <td class="growth growth-3m"><span class="growth-up">+968 <span class="growth-pct">(+2.2%)</span></span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">aider is AI pair programming in your terminal</td>
   </tr>
   <tr>
     <td class="rank">#12</td>
+    <td class="name"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
+    <td class="stars">33,196</td>
+    <td class="growth growth-3m"><span class="growth-up">+426 <span class="growth-pct">(+1.3%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI</td>
+  </tr>
+  <tr>
+    <td class="rank">#13</td>
     <td class="name"><a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a></td>
-    <td class="stars">32,693</td>
-    <td class="growth growth-3m"><span class="growth-up">+69 <span class="growth-pct">(+0.2%)</span></span></td>
+    <td class="stars">32,875</td>
+    <td class="growth growth-3m"><span class="growth-up">+182 <span class="growth-pct">(+0.6%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">Proprietary AI-first code editor (the GitHub repo hosts issues only; editor source is closed).</td>
   </tr>
   <tr>
-    <td class="rank">#13</td>
+    <td class="rank">#14</td>
     <td class="name"><a href="https://voideditor.com" target="_blank" rel="noopener">Void</a></td>
-    <td class="stars">28,644</td>
-    <td class="growth growth-3m"><span class="growth-up">+91 <span class="growth-pct">(+0.3%)</span></span></td>
+    <td class="stars">28,752</td>
+    <td class="growth growth-3m"><span class="growth-up">+108 <span class="growth-pct">(+0.4%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Open-source AI code editor (VS Code fork).</td>
   </tr>
   <tr>
-    <td class="rank">#14</td>
-    <td class="name"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
-    <td class="stars">26,501</td>
-    <td class="growth growth-3m"><span class="growth-up">+129 <span class="growth-pct">(+0.5%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Agentic development environment built on a modern terminal.</td>
-  </tr>
-  <tr>
     <td class="rank">#15</td>
     <td class="name"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">23,813</td>
-    <td class="growth growth-3m"><span class="growth-up">+990 <span class="growth-pct">(+4.3%)</span></span></td>
+    <td class="stars">24,401</td>
+    <td class="growth growth-3m"><span class="growth-up">+588 <span class="growth-pct">(+2.5%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Alibaba&#x27;s open-source terminal coding agent tuned for the Qwen3-Coder model family.</td>
+    <td class="desc">An open-source AI agent that lives in your terminal.</td>
   </tr>
   <tr>
     <td class="rank">#16</td>
     <td class="name"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">23,418</td>
-    <td class="growth growth-3m"><span class="growth-up">+529 <span class="growth-pct">(+2.3%)</span></span></td>
+    <td class="stars">24,298</td>
+    <td class="growth growth-3m"><span class="growth-up">+880 <span class="growth-pct">(+3.8%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Charmbracelet&#x27;s multi-model terminal coding agent written in Go.</td>
+    <td class="desc">Glamourous agentic coding for all 💘</td>
   </tr>
   <tr>
     <td class="rank">#17</td>
     <td class="name"><a href="https://roocode.com" target="_blank" rel="noopener">Roo Code</a></td>
-    <td class="stars">23,345</td>
-    <td class="growth growth-3m"><span class="growth-up">+257 <span class="growth-pct">(+1.1%)</span></span></td>
+    <td class="stars">24,073</td>
+    <td class="growth growth-3m"><span class="growth-up">+728 <span class="growth-pct">(+3.1%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">VS Code coding agent with multi-mode team-of-agents support.</td>
+    <td class="desc">Roo Code gives you a whole dev team of AI agents in your code editor.</td>
   </tr>
   <tr>
     <td class="rank">#18</td>
-    <td class="name"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
-    <td class="stars">19,050</td>
-    <td class="growth growth-3m"><span class="growth-up">+82 <span class="growth-pct">(+0.4%)</span></span></td>
+    <td class="name"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
+    <td class="stars">19,304</td>
+    <td class="growth growth-3m"><span class="growth-up">+799 <span class="growth-pct">(+4.3%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Princeton NLP&#x27;s autonomous agent for resolving GitHub issues (NeurIPS 2024).</td>
+    <td class="desc">Kilo is the all-in-one agentic engineering platform. Build, ship, and iterate faster with the most popular open source coding agent.</td>
   </tr>
   <tr>
     <td class="rank">#19</td>
-    <td class="name"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
-    <td class="stars">18,505</td>
-    <td class="growth growth-3m"><span class="growth-up">+517 <span class="growth-pct">(+2.9%)</span></span></td>
+    <td class="name"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
+    <td class="stars">19,225</td>
+    <td class="growth growth-3m"><span class="growth-up">+175 <span class="growth-pct">(+0.9%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">All-in-one agentic coding platform for VS Code, JetBrains, and CLI.</td>
+    <td class="desc">SWE-agent takes a GitHub issue and tries to automatically fix it, using your LM of choice. It can also be employed for offensive cybersecurity or competitive coding challenges. [NeurIPS 2024]</td>
   </tr>
   <tr>
     <td class="rank">#20</td>
     <td class="name"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">15,289</td>
-    <td class="growth growth-3m"><span class="growth-up">+58 <span class="growth-pct">(+0.4%)</span></span></td>
+    <td class="stars">15,365</td>
+    <td class="growth growth-3m"><span class="growth-up">+76 <span class="growth-pct">(+0.5%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Open-source terminal agent for large, multi-step coding tasks spanning many files.</td>
+    <td class="desc">Open source AI coding agent. Designed for large projects and real world tasks.</td>
   </tr>
   <tr>
     <td class="rank">#21</td>
     <td class="name"><a href="https://github.com/langchain-ai/open-swe" target="_blank" rel="noopener">Open SWE</a></td>
-    <td class="stars">9,642</td>
-    <td class="growth growth-3m"><span class="growth-up">+158 <span class="growth-pct">(+1.7%)</span></span></td>
+    <td class="stars">9,802</td>
+    <td class="growth growth-3m"><span class="growth-up">+160 <span class="growth-pct">(+1.7%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">LangChain&#x27;s open-source asynchronous cloud coding agent.</td>
+    <td class="desc">An Open-Source Asynchronous Coding Agent</td>
   </tr>
   <tr>
     <td class="rank">#22</td>
     <td class="name"><a href="https://sweep.dev" target="_blank" rel="noopener">Sweep</a></td>
-    <td class="stars">7,705</td>
-    <td class="growth growth-3m"><span class="growth-down">-4 <span class="growth-pct">(-0.1%)</span></span></td>
+    <td class="stars">7,713</td>
+    <td class="growth growth-3m"><span class="growth-up">+8 <span class="growth-pct">(+0.1%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">AI coding assistant for JetBrains (pivoted from earlier GitHub-issue automation).</td>
+    <td class="desc">Sweep: AI coding assistant for JetBrains</td>
   </tr>
   <tr>
     <td class="rank">#23</td>
     <td class="name"><a href="https://forgecode.dev" target="_blank" rel="noopener">Forge Code</a></td>
-    <td class="stars">6,925</td>
-    <td class="growth growth-3m"><span class="growth-up">+459 <span class="growth-pct">(+7.1%)</span></span></td>
+    <td class="stars">7,295</td>
+    <td class="growth growth-3m"><span class="growth-up">+370 <span class="growth-pct">(+5.3%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Rust-based open-source terminal AI pair programmer supporting 300+ models.</td>
+    <td class="desc">AI enabled pair programmer for Claude, GPT, O Series, Grok, Deepseek, Gemini and 300+ models</td>
   </tr>
   <tr>
     <td class="rank">#24</td>
     <td class="name"><a href="https://www.ra-aid.ai" target="_blank" rel="noopener">RA.Aid</a></td>
-    <td class="stars">2,223</td>
-    <td class="growth growth-3m"><span class="growth-up">+5 <span class="growth-pct">(+0.2%)</span></span></td>
+    <td class="stars">2,224</td>
+    <td class="growth growth-3m"><span class="growth-up">+1 <span class="growth-pct">(+0.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">LangGraph-based autonomous coding agent with research → plan → implement loop.</td>
+    <td class="desc">Develop software autonomously.</td>
   </tr>
   <tr>
     <td class="rank">#25</td>
     <td class="name"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
-    <td class="stars">794</td>
-    <td class="growth growth-3m"><span class="growth-up">+38 <span class="growth-pct">(+5.0%)</span></span></td>
+    <td class="stars">876</td>
+    <td class="growth growth-3m"><span class="growth-up">+82 <span class="growth-pct">(+10.3%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Agent-native software development platform with Droid agents.</td>
+    <td class="desc">Factory - Agent-Native Software Development</td>
   </tr>
   <tr>
     <td class="rank">#26</td>
     <td class="name"><a href="https://trypear.ai" target="_blank" rel="noopener">Pear AI</a></td>
-    <td class="stars">676</td>
-    <td class="growth growth-3m"><span class="growth-up">+2 <span class="growth-pct">(+0.3%)</span></span></td>
+    <td class="stars">689</td>
+    <td class="growth growth-3m"><span class="growth-up">+13 <span class="growth-pct">(+1.9%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Open-source AI code editor (VS Code fork with Continue submodule).</td>
+    <td class="desc">PearAI: Open Source AI Code Editor (Fork of VSCode). The PearAI Submodule (https://github.com/trypear/pearai-submodule) is a fork of Continue.</td>
   </tr>
   <tr>
     <td class="rank">#27</td>
@@ -350,7 +347,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
     <td class="stars">521</td>
     <td class="growth growth-3m"><span class="growth-flat">0 <span class="growth-pct">(0.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Python wrapper for the Codegen API — run code agents at scale against a hosted service.</td>
+    <td class="desc">Python wrapper for the Codegen API - run code agents at scale</td>
   </tr>
   <tr><td colspan="6" style="padding-top:1.2rem; color: var(--text-dim); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; border-bottom: none;">No public repo — popularity via funding / users</td></tr>
   <tr>
@@ -476,7 +473,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 </tbody></table>
 
   <h2 class="section-title">Agent Orchestrators</h2>
-  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-04-24.</p>
+  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-05-15.</p>
   <table class="landscape-table">
 <thead><tr>
   <th class="rank">#</th><th>Name</th><th>Stars</th><th class="growth-3m">Recent growth</th><th>Irrlicht</th><th>Description</th>
@@ -486,39 +483,39 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <tr>
     <td class="rank">#1</td>
     <td class="name"><a href="https://paperclip.ing" target="_blank" rel="noopener">Paperclip</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">58,383</td>
-    <td class="growth growth-3m"><span class="growth-up">+6,341 <span class="growth-pct">(+12.2%)</span></span></td>
+    <td class="stars">65,560</td>
+    <td class="growth growth-3m"><span class="growth-up">+7,177 <span class="growth-pct">(+12.3%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Orchestration platform for &quot;zero-human companies&quot; — agents assigned to CEO/manager/worker roles with budgets and approvals.</td>
+    <td class="desc">The open-source app everyone uses to manage agents at work</td>
   </tr>
   <tr>
     <td class="rank">#2</td>
-    <td class="name"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
-    <td class="stars">39,648</td>
-    <td class="growth growth-3m"><span class="growth-up">+281 <span class="growth-pct">(+0.7%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Python agent runtime for teams and workflows (formerly Phidata).</td>
+    <td class="name"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
+    <td class="stars">51,261</td>
+    <td class="growth growth-3m"><span class="growth-up">+18,182 <span class="growth-pct">(+55.0%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Agent orchestration platform for Claude: multi-agent swarms, RAG integration, Claude Code / Codex integration.</td>
   </tr>
   <tr>
     <td class="rank">#3</td>
-    <td class="name"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
-    <td class="stars">33,079</td>
-    <td class="growth growth-3m"><span class="growth-up">+1,713 <span class="growth-pct">(+5.5%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Agent orchestration platform for Claude: multi-agent swarms, RAG integration, Claude Code/Codex integration.</td>
+    <td class="name"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
+    <td class="stars">40,134</td>
+    <td class="growth growth-3m"><span class="growth-up">+486 <span class="growth-pct">(+1.2%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Build, run, and manage agent platforms.</td>
   </tr>
   <tr>
     <td class="rank">#4</td>
     <td class="name"><a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener">ChatDev</a></td>
-    <td class="stars">32,847</td>
-    <td class="growth growth-3m"><span class="growth-up">+162 <span class="growth-pct">(+0.5%)</span></span></td>
+    <td class="stars">33,093</td>
+    <td class="growth growth-3m"><span class="growth-up">+246 <span class="growth-pct">(+0.7%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Virtual software company powered by multi-agent LLM collaboration (ChatDev 2.0).</td>
+    <td class="desc">ChatDev 2.0: Dev All through LLM-powered Multi-Agent Collaboration</td>
   </tr>
   <tr>
     <td class="rank">#5</td>
     <td class="name"><a href="https://github.com/stitionai/devika" target="_blank" rel="noopener">Devika</a></td>
-    <td class="stars">19,502</td>
+    <td class="stars">19,507</td>
     <td class="growth growth-3m"><span class="growth-up">+5 <span class="growth-pct">(+0.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Open-source agentic software engineer (originally an open alternative to Devin).</td>
@@ -526,48 +523,48 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <tr>
     <td class="rank">#6</td>
     <td class="name"><a href="https://github.com/gastownhall/gastown" target="_blank" rel="noopener">Gas Town</a></td>
-    <td class="stars">14,580</td>
-    <td class="growth growth-3m"><span class="growth-up">+682 <span class="growth-pct">(+4.9%)</span></span></td>
+    <td class="stars">15,195</td>
+    <td class="growth growth-3m"><span class="growth-up">+615 <span class="growth-pct">(+4.2%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
-    <td class="desc">Multi-agent workspace manager: Mayor (coordinator) routes work through Rigs and Polecats with a Beads work-state ledger.</td>
+    <td class="desc">Gas Town - multi-agent workspace manager</td>
   </tr>
   <tr>
     <td class="rank">#7</td>
     <td class="name"><a href="https://github.com/smtg-ai/claude-squad" target="_blank" rel="noopener">Claude Squad</a></td>
-    <td class="stars">7,145</td>
-    <td class="growth growth-3m"><span class="growth-up">+184 <span class="growth-pct">(+2.6%)</span></span></td>
+    <td class="stars">7,475</td>
+    <td class="growth growth-3m"><span class="growth-up">+330 <span class="growth-pct">(+4.6%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Manage multiple AI terminal agents (Claude Code, Codex, OpenCode, Amp) in tmux.</td>
+    <td class="desc">Manage multiple AI terminal agents like Claude Code, Codex, OpenCode, and Amp.</td>
   </tr>
   <tr>
     <td class="rank">#8</td>
     <td class="name"><a href="https://composio.dev" target="_blank" rel="noopener">Composio</a></td>
-    <td class="stars">6,474</td>
-    <td class="growth growth-3m"><span class="growth-up">+292 <span class="growth-pct">(+4.7%)</span></span></td>
+    <td class="stars">7,047</td>
+    <td class="growth growth-3m"><span class="growth-up">+573 <span class="growth-pct">(+8.9%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Agent-agnostic orchestrator for parallel coding agents with autonomous CI auto-fix.</td>
+    <td class="desc">Agentic orchestrator for parallel coding agents — plans tasks, spawns agents, and autonomously handles CI fixes, merge conflicts, and code reviews.</td>
   </tr>
   <tr>
     <td class="rank">#9</td>
     <td class="name"><a href="https://github.com/dlorenc/multiclaude" target="_blank" rel="noopener">Multiclaude</a></td>
-    <td class="stars">539</td>
-    <td class="growth growth-3m"><span class="growth-up">+10 <span class="growth-pct">(+1.9%)</span></span></td>
+    <td class="stars">548</td>
+    <td class="growth growth-3m"><span class="growth-up">+9 <span class="growth-pct">(+1.7%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">Parallel Claude Code instances in tmux with a Brownian-ratchet CI model.</td>
   </tr>
   <tr>
     <td class="rank">#10</td>
     <td class="name"><a href="https://stoneforge.ai" target="_blank" rel="noopener">Stoneforge</a></td>
-    <td class="stars">130</td>
-    <td class="growth growth-3m"><span class="growth-up">+17 <span class="growth-pct">(+15.0%)</span></span></td>
+    <td class="stars">143</td>
+    <td class="growth growth-3m"><span class="growth-up">+13 <span class="growth-pct">(+10.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Web dashboard orchestrating AI coding agent teams with worktree isolation.</td>
+    <td class="desc">A web dashboard and runtime for orchestrating AI coding agents</td>
   </tr>
   <tr>
     <td class="rank">#11</td>
     <td class="name"><a href="https://forge.nxtg.ai" target="_blank" rel="noopener">Forge Orchestrator</a></td>
-    <td class="stars">109</td>
-    <td class="growth growth-3m"><span class="growth-up">+1 <span class="growth-pct">(+0.9%)</span></span></td>
+    <td class="stars">116</td>
+    <td class="growth growth-3m"><span class="growth-up">+7 <span class="growth-pct">(+6.4%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Rust-based multi-AI task orchestrator with file locking and drift detection.</td>
   </tr>


### PR DESCRIPTION
## Summary

- Refresh the landscape page (38 agents) with fresh `gh api` data; today's snapshot appended.
- Promote **Aider** and **OpenCode** from `planned` → `live` to match the adapters now living under `core/adapters/inbound/agents/`.
- Pick up two upstream repo renames: Pi (`badlogic/pi-mono` → `earendil-works/pi`, v0.74) and Warp (`warpdotdev/Warp` → `warpdotdev/warp`).
- Bring agent-release tracking current (22 new versions across Claude Code, Codex, Pi, Gas Town) and flag five items that may quietly affect irrlicht's session monitoring.

## What might affect monitoring

These are flagged in `tracked-releases.md` for follow-up verification:

| Release | Severity | Concern |
|---|---|---|
| Claude Code v2.1.139 | HIGH/UNCERTAIN | `claude agents` view GA's a unified list of all sessions including background-dispatched. Verify dispatched sessions still land in flat `~/.claude/projects/<project>/<uuid>.jsonl` and that subagent counting via the `Agent` tool isn't superseded by the new `x-claude-code-agent-id` headers. |
| Claude Code v2.1.142 | MEDIUM/UNCERTAIN | New `claude agents --add-dir/--settings/--mcp-config/--plugin-dir/--permission-mode/--model/--effort/--dangerously-skip-permissions` flags imply dispatched sessions are configured separately; verify transcript path. |
| Claude Code v2.1.121 | MEDIUM/UNCERTAIN | `CLAUDE_CODE_FORK_SUBAGENT=1` now works in non-interactive mode, widening the v2.1.117 nested forked-subagent path question. |
| Pi v0.71.0 | MEDIUM | New `PI_CODING_AGENT_SESSION_DIR` env var lets users move session storage off `~/.pi/agent/sessions/...`. The Pi adapter watches the fixed home-relative root, so custom dirs are invisible. |
| Pi v0.73.0 | MEDIUM/UNCERTAIN | Incremental Bash output streaming may emit multiple partial `tool_result` events instead of one terminal event — affects open-tool tracking. |

## Plausibility check (rule #6 of the landscape skill)

Two repos cleared the >30%-in-<30-days threshold and are kept with documented reasons:

- **Warp** 26,501 → 58,530 (+121%). Description and language flipped from `null` to `"Warp is an agentic development environment, born out of the terminal."` / Rust / AGPL-3.0 — consistent with Warp open-sourcing its codebase.
- **Ruflo** 33,079 → 51,261 (+55%). No structural metadata change; viral-promotion growth (heavy 🌊 marketing prose in the README/description).

## Test plan

- [ ] Open `site/landscape/index.html` locally and confirm Aider + OpenCode show the `live` badge.
- [ ] Confirm Pi's row links to `earendil-works/pi` and Warp's to `warpdotdev/warp`.
- [ ] Spot-check 2–3 ranks against the current GitHub star counts.
- [ ] (Follow-up issues, not part of this PR) verify the five monitoring concerns above against the live adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)