### PR TITLE
fix(daemon): bypass CWD PID discovery for proc-<pid> pre-sessions

### DIFF
--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -432,7 +432,6 @@ func (pm *PIDManager) claimedPIDs(excludeSessionID string) map[int]bool {
 // claimed PIDs when no unclaimed candidate exists (the /clear scenario where
 // the same process starts a new transcript). Returns true if a PID was found.
 func (pm *PIDManager) TryDiscoverPID(sessionID, cwd, transcriptPath, adapter string) bool {
-	// Check if session already has a PID.
 	state, _ := pm.repo.Load(sessionID)
 	if state != nil && state.PID > 0 {
 		return true

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -445,6 +445,22 @@ func (pm *PIDManager) TryDiscoverPID(sessionID, cwd, transcriptPath, adapter str
 		return true
 	}
 
+	// Pre-sessions encode their PID in the session ID by construction
+	// (processlifecycle/scanner.go mints `proc-<pid>`). Skip adapter-level
+	// CWD discovery — it can misattribute the PID to a sibling process
+	// sharing the same CWD during the new agent's brief pre-`cd` window
+	// (issue #345).
+	if strings.HasPrefix(sessionID, "proc-") {
+		var pid int
+		if _, err := fmt.Sscanf(sessionID, "proc-%d", &pid); err == nil && pid > 0 {
+			pm.log.LogInfo("session-detector", sessionID,
+				fmt.Sprintf("encoded pid %d for %s pre-session", pid, adapter))
+			pm.HandlePIDAssigned(pid, sessionID)
+			return true
+		}
+		return false
+	}
+
 	// Prefer unclaimed PIDs (multiple instances in same dir), but allow
 	// claimed PIDs when all candidates are claimed (/clear scenario).
 	claimed := pm.claimedPIDs(sessionID)

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -432,13 +432,6 @@ func (pm *PIDManager) claimedPIDs(excludeSessionID string) map[int]bool {
 // claimed PIDs when no unclaimed candidate exists (the /clear scenario where
 // the same process starts a new transcript). Returns true if a PID was found.
 func (pm *PIDManager) TryDiscoverPID(sessionID, cwd, transcriptPath, adapter string) bool {
-	if pm.pw == nil {
-		return false
-	}
-	discoverFn := pm.pidDiscovers[adapter]
-	if discoverFn == nil {
-		return false
-	}
 	// Check if session already has a PID.
 	state, _ := pm.repo.Load(sessionID)
 	if state != nil && state.PID > 0 {
@@ -449,7 +442,10 @@ func (pm *PIDManager) TryDiscoverPID(sessionID, cwd, transcriptPath, adapter str
 	// (processlifecycle/scanner.go mints `proc-<pid>`). Skip adapter-level
 	// CWD discovery — it can misattribute the PID to a sibling process
 	// sharing the same CWD during the new agent's brief pre-`cd` window
-	// (issue #345).
+	// (issue #345). This bypass intentionally runs before the pw / discoverFn
+	// guards below: it only needs to parse the ID and call HandlePIDAssigned,
+	// which is safe regardless of whether the adapter has a PIDForSession
+	// registered or whether the daemon has a live ProcessWatcher.
 	if strings.HasPrefix(sessionID, "proc-") {
 		var pid int
 		if _, err := fmt.Sscanf(sessionID, "proc-%d", &pid); err == nil && pid > 0 {
@@ -458,6 +454,14 @@ func (pm *PIDManager) TryDiscoverPID(sessionID, cwd, transcriptPath, adapter str
 			pm.HandlePIDAssigned(pid, sessionID)
 			return true
 		}
+		return false
+	}
+
+	if pm.pw == nil {
+		return false
+	}
+	discoverFn := pm.pidDiscovers[adapter]
+	if discoverFn == nil {
 		return false
 	}
 

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 )
 
@@ -548,5 +549,77 @@ func TestBackfillLauncher_NonKittyUnaffected(t *testing.T) {
 	}
 	if repo.states["s"].Launcher.KittyPID != 0 {
 		t.Errorf("KittyPID leaked into non-kitty launcher: %d", repo.states["s"].Launcher.KittyPID)
+	}
+}
+
+// TestTryDiscoverPID_ProcSession_BypassesDiscoverFn is the regression guard for
+// issue #345. Pre-sessions (proc-<pid>) encode their PID in the session ID, so
+// TryDiscoverPID must not invoke the adapter's CWD-based discoverFn for them —
+// doing so misattributes the PID to a sibling agent process in the same CWD
+// and triggers the same-PID cleanup that evicts the legitimate neighbor.
+func TestTryDiscoverPID_ProcSession_BypassesDiscoverFn(t *testing.T) {
+	repo := newMockRepo()
+
+	// Neighbor session that shares the encoded PID space: it has a *different*
+	// PID, so the same-PID cleanup must NOT touch it after we assign 12345.
+	repo.states["neighbor-uuid"] = &session.SessionState{
+		SessionID:      "neighbor-uuid",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		PID:            99999,
+		TranscriptPath: filepath.Join(t.TempDir(), "neighbor.jsonl"),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	// Pre-session as the scanner emits it: PID=0, ID encodes the PID.
+	repo.states["proc-12345"] = &session.SessionState{
+		SessionID: "proc-12345",
+		Adapter:   "claude-code",
+		State:     session.StateReady,
+		PID:       0,
+		CWD:       "/tmp/shared-cwd",
+		UpdatedAt: time.Now().Unix(),
+	}
+
+	// Stub discoverFn that fails the test if it is ever called.
+	discoverCalls := 0
+	discovers := map[string]agent.PIDDiscoverFunc{
+		"claude-code": func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
+			discoverCalls++
+			// Return a wrong PID to make sure the test fails loudly if the
+			// short-circuit regresses — this is exactly the bug scenario:
+			// CWD-based discovery returning the neighbor's PID.
+			return 99999, nil
+		},
+	}
+
+	pm := services.NewPIDManager(
+		newMockProcessWatcher(),
+		repo,
+		&mockLogger{},
+		nil,
+		10*time.Minute,
+		discovers,
+		nil,
+		nil,
+		func(string) {},
+	)
+
+	if !pm.TryDiscoverPID("proc-12345", "/tmp/shared-cwd", "", "claude-code") {
+		t.Fatal("TryDiscoverPID returned false for proc-12345")
+	}
+
+	if discoverCalls != 0 {
+		t.Errorf("adapter discoverFn was called %d times for a proc-<pid> session; want 0", discoverCalls)
+	}
+
+	if got := repo.states["proc-12345"]; got == nil {
+		t.Fatal("proc-12345 was deleted")
+	} else if got.PID != 12345 {
+		t.Errorf("proc-12345 PID = %d, want 12345", got.PID)
+	}
+
+	if repo.states["neighbor-uuid"] == nil {
+		t.Fatal("neighbor-uuid was evicted by same-PID cleanup — issue #345 regression")
 	}
 }

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -385,10 +386,10 @@ func TestPreSession_DoesNotEvictNeighborSessionWithSharedCWD(t *testing.T) {
 	// where CWD-based discovery misattributes the new proc-<pid> pre-session
 	// to a sibling process in the same CWD. With the fix, this function MUST
 	// NOT be called for proc-<pid> sessions.
-	var discoverCalls int32
+	var discoverCalls atomic.Int32
 	discovers := map[string]agent.PIDDiscoverFunc{
 		"test": func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
-			discoverCalls++
+			discoverCalls.Add(1)
 			return neighborPID, nil
 		},
 	}
@@ -398,7 +399,7 @@ func TestPreSession_DoesNotEvictNeighborSessionWithSharedCWD(t *testing.T) {
 
 	detector := services.NewSessionDetector(
 		[]inbound.Watcher{scanner},
-		&nopProcessWatcher{}, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
+		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
 		"test", 0, discovers, nil, nil,
 	)
 
@@ -417,8 +418,8 @@ func TestPreSession_DoesNotEvictNeighborSessionWithSharedCWD(t *testing.T) {
 	// 1s) so any erroneous discoverFn invocation has a chance to fire.
 	time.Sleep(2 * time.Second)
 
-	if discoverCalls != 0 {
-		t.Errorf("adapter discoverFn was called %d times for proc-<pid> session — issue #345 regression", discoverCalls)
+	if n := discoverCalls.Load(); n != 0 {
+		t.Errorf("adapter discoverFn was called %d times for proc-<pid> session — issue #345 regression", n)
 	}
 
 	pre, _ := repo.Load(preID)
@@ -433,13 +434,3 @@ func TestPreSession_DoesNotEvictNeighborSessionWithSharedCWD(t *testing.T) {
 		t.Fatal("neighbor session was evicted by same-PID cleanup — issue #345 regression")
 	}
 }
-
-// nopProcessWatcher is a no-op outbound.ProcessWatcher for tests that need
-// to clear PIDManager's `pw == nil` guard in TryDiscoverPID without spinning
-// up the real kqueue watcher.
-type nopProcessWatcher struct{}
-
-func (nopProcessWatcher) Watch(int, string) error      { return nil }
-func (nopProcessWatcher) Unwatch(int)                  {}
-func (nopProcessWatcher) Run(ctx context.Context) error { <-ctx.Done(); return ctx.Err() }
-func (nopProcessWatcher) Close() error                  { return nil }

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -347,3 +347,99 @@ func TestPreSession_RemovedOnProcessExit(t *testing.T) {
 		}
 	}
 }
+
+// TestPreSession_DoesNotEvictNeighborSessionWithSharedCWD is the regression
+// test for issue #345. When a second claude process starts in VS Code while
+// another is already running, the scanner can catch it during the brief
+// pre-`cd` window where its CWD still reads as the parent (the repo root).
+// Pre-fix, PIDManager called the adapter's CWD-based discovery for the new
+// `proc-<NEW>` pre-session, which could return the *neighbor's* PID — then
+// HandlePIDAssigned's same-PID cleanup evicted the legitimate neighbor.
+//
+// The fix short-circuits TryDiscoverPID for `proc-<pid>` sessions: the PID
+// is encoded in the ID, so adapter-level discovery is skipped entirely.
+// This test fails pre-fix because the registered discoverFn returns the
+// neighbor's PID.
+func TestPreSession_DoesNotEvictNeighborSessionWithSharedCWD(t *testing.T) {
+	cmd, _ := startFakeClaudeProcess(t)
+
+	// Pre-seed a neighbor session whose PID is alive (use os.Getpid() — the
+	// test binary itself — so PID liveness checks pass) and is NOT the fake
+	// process's PID.
+	neighborPID := os.Getpid()
+	if neighborPID == cmd.Process.Pid {
+		t.Fatalf("test PID unexpectedly matches fake process PID")
+	}
+
+	repo := newMemRepo()
+	repo.Save(&session.SessionState{
+		SessionID:      "neighbor-aaaa-bbbb-cccc-dddd",
+		State:          session.StateReady,
+		Adapter:        "test",
+		PID:            neighborPID,
+		TranscriptPath: filepath.Join(realTempDir(t), "neighbor.jsonl"),
+		UpdatedAt:      time.Now().Unix(),
+	})
+
+	// Adversarial discoverFn: returns the neighbor's PID, simulating the bug
+	// where CWD-based discovery misattributes the new proc-<pid> pre-session
+	// to a sibling process in the same CWD. With the fix, this function MUST
+	// NOT be called for proc-<pid> sessions.
+	var discoverCalls int32
+	discovers := map[string]agent.PIDDiscoverFunc{
+		"test": func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
+			discoverCalls++
+			return neighborPID, nil
+		},
+	}
+
+	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
+	scanner.WithSessionChecker(realSessionCheckerFor(repo))
+
+	detector := services.NewSessionDetector(
+		[]inbound.Watcher{scanner},
+		&nopProcessWatcher{}, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
+		"test", 0, discovers, nil, nil,
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	go scanner.Watch(ctx)
+	go detector.Run(ctx)
+
+	preID := fmt.Sprintf("proc-%d", cmd.Process.Pid)
+	if !waitForSession(repo, preID, 5*time.Second) {
+		t.Fatalf("timeout: pre-session %s never appeared", preID)
+	}
+
+	// Wait past the first DiscoverPIDWithRetry tick (immediate + 500ms +
+	// 1s) so any erroneous discoverFn invocation has a chance to fire.
+	time.Sleep(2 * time.Second)
+
+	if discoverCalls != 0 {
+		t.Errorf("adapter discoverFn was called %d times for proc-<pid> session — issue #345 regression", discoverCalls)
+	}
+
+	pre, _ := repo.Load(preID)
+	if pre == nil {
+		t.Fatalf("pre-session %s was deleted", preID)
+	}
+	if pre.PID != cmd.Process.Pid {
+		t.Errorf("pre-session PID = %d, want %d (encoded from session ID)", pre.PID, cmd.Process.Pid)
+	}
+
+	if s, _ := repo.Load("neighbor-aaaa-bbbb-cccc-dddd"); s == nil {
+		t.Fatal("neighbor session was evicted by same-PID cleanup — issue #345 regression")
+	}
+}
+
+// nopProcessWatcher is a no-op outbound.ProcessWatcher for tests that need
+// to clear PIDManager's `pw == nil` guard in TryDiscoverPID without spinning
+// up the real kqueue watcher.
+type nopProcessWatcher struct{}
+
+func (nopProcessWatcher) Watch(int, string) error      { return nil }
+func (nopProcessWatcher) Unwatch(int)                  {}
+func (nopProcessWatcher) Run(ctx context.Context) error { <-ctx.Done(); return ctx.Err() }
+func (nopProcessWatcher) Close() error                  { return nil }


### PR DESCRIPTION
## Summary

- Opening a second Claude Code session in VS Code briefly leaves the new process in the parent CWD before it `cd`s into its worktree. The scanner mints a `proc-<NEW>` pre-session for that CWD; PIDManager then called the claudecode adapter's CWD-based `DiscoverPID` which — with no transcript path yet, so the metadata-based filter collapses — returned the **neighbor's** PID. `HandlePIDAssigned`'s same-PID cleanup then evicted the legitimate session row.
- Pre-session IDs already encode the PID by construction (`fmt.Sprintf("proc-%d", pid)` in `processlifecycle/scanner.go`). The fix short-circuits `TryDiscoverPID` for `proc-<pid>` IDs: parse the PID out of the session ID and call `HandlePIDAssigned` directly, bypassing adapter discovery entirely. Real sessions (UUID IDs with a transcript path) continue through `discoverFn` unchanged.

Fixes #345

## Implementation notes

- The `proc-<pid>` bypass sits **before** the `pw == nil` / `discoverFn == nil` early returns. It only needs to parse the session ID and call `HandlePIDAssigned`, so it's correct regardless of whether the adapter registered a `PIDForSession` or whether the daemon has a live `ProcessWatcher`. Future adapters with a process matcher but no PID-discovery function inherit the fix for free.
- Adapter discovery for real (UUID) sessions is unchanged; the existing layered defenses in `claudecode/pid.go` (metadata-based `claimedByOthers` + ambiguity retry) still apply where they were designed to.

## Test plan

- [x] New unit test `TestTryDiscoverPID_ProcSession_BypassesDiscoverFn` — registers an adversarial discoverFn that would return a neighbor's PID and asserts it's never called for `proc-*` IDs; verifies the encoded PID is assigned and the neighbor isn't evicted.
- [x] New e2e regression test `TestPreSession_DoesNotEvictNeighborSessionWithSharedCWD` — full Scanner → SessionDetector → PIDManager pipeline with a real fake claude process and an adversarial CWD discoverFn. Counter is `atomic.Int32` so a regression would fail under `-race` as well as on the count assertion.
- [x] `go test ./core/... -race -count=1` — all packages green.
- [x] `tools/replay-fixtures.sh` — clean.
- [ ] Manual repro (post-merge, on a dev build): start a Claude session in VS Code at the repo root, open a second `claude --worktree N`, watch `events.log | grep -E 'same pid|encoded pid'` — expect an `encoded pid <NEW> for claudecode pre-session` line and **no** `same pid` cleanup against the legitimate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)