### PR TITLE
fix(macos): focus VS Code windows on other Spaces (#344)

### DIFF
--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/AXTitleMatchActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/AXTitleMatchActivator.swift
@@ -40,27 +40,98 @@ struct AXTitleMatchActivator: HostActivator {
             return
         }
         let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
-        guard let app = runningApps.first else { return }
-        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        guard !runningApps.isEmpty else { return }
 
-        var windowsRef: CFTypeRef?
-        let status = AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef)
-        guard status == .success, let windows = windowsRef as? [AXUIElement] else { return }
-
-        let titles = windows.map { windowTitle($0) }
+        // Enumerate window candidates via the app's **Window menu** rather
+        // than kAXWindowsAttribute. The latter omits windows that are
+        // fullscreen on another Space for many Electron apps (VS Code,
+        // Cursor, Windsurf), so the only candidate we ever see is whatever
+        // happens to be on the current Space — making click-to-focus a
+        // silent no-op when the target lives on a different fullscreen
+        // Space (issue #344). The Window menu always lists every open
+        // window of the app, and AX-pressing a menu item is the same as
+        // the user picking it from the menu bar: macOS handles the Space
+        // switch and raise atomically.
+        var candidates: [(menuItem: AXUIElement, title: String)] = []
+        for app in runningApps {
+            let axApp = AXUIElementCreateApplication(app.processIdentifier)
+            candidates.append(contentsOf: windowMenuItems(axApp: axApp))
+        }
+        let titles = candidates.map { $0.title }
         guard let idx = bestMatchIndex(titles: titles, cwd: cwd) else {
-            logger.info("no window title matched cwd \(cwd, privacy: .public); candidates=\(titles, privacy: .public)")
+            logger.info("no window menu item matched cwd \(cwd, privacy: .public); candidates=\(titles, privacy: .public)")
             return
         }
-        let target = windows[idx]
-        // Set main first so the subsequent activate() knows which Space to switch to.
-        AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
-        AXUIElementPerformAction(target, kAXRaiseAction as CFString)
-        // Re-activate the app after designating the target window as main. This
-        // triggers a macOS Space switch when the target is a fullscreen window on
-        // another Space — kAXRaiseAction alone does not cross Space boundaries.
-        NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
-            .first?.activate(options: [])
+        let target = candidates[idx]
+        logger.info("AX dispatch: cwd=\(cwd, privacy: .public) picked=[\(idx)] \(titles[idx], privacy: .public) of candidates=\(titles, privacy: .public)")
+        AXUIElementPerformAction(target.menuItem, kAXPressAction as CFString)
+    }
+
+    /// Returns (menuItem, title) pairs for every entry in the app's Window
+    /// menu. The Window menu is identified by title — locale-resilient
+    /// enough for English-default users; we additionally accept a few
+    /// common localizations. Items with empty titles or that match common
+    /// command names (Minimize, Zoom, Close, Bring All to Front) are
+    /// filtered so they never compete with real window entries.
+    private static let windowMenuTitles: Set<String> = [
+        "Window", "Fenster", "Fenêtre", "Ventana", "ウィンドウ", "窗口", "창",
+    ]
+    private static let windowMenuCommandTitles: Set<String> = [
+        "Minimize", "Zoom", "Close", "Bring All to Front",
+        "Minimieren", "Zoomen", "Schließen", "Alle nach vorne bringen",
+    ]
+
+    private static func windowMenuItems(axApp: AXUIElement) -> [(menuItem: AXUIElement, title: String)] {
+        var menuBarRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(axApp, kAXMenuBarAttribute as CFString, &menuBarRef) == .success,
+              CFGetTypeID(menuBarRef) == AXUIElementGetTypeID()
+        else { return [] }
+        let menuBar = menuBarRef as! AXUIElement
+
+        var menusRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(menuBar, kAXChildrenAttribute as CFString, &menusRef) == .success,
+              let menus = menusRef as? [AXUIElement]
+        else { return [] }
+
+        // Find the Window menu by title (locale-tolerant). Fallback: the
+        // second-to-last top-level menu (Cocoa convention: …Window, Help).
+        var windowMenu: AXUIElement?
+        for menu in menus {
+            var t: CFTypeRef?
+            if AXUIElementCopyAttributeValue(menu, kAXTitleAttribute as CFString, &t) == .success,
+               let title = t as? String, windowMenuTitles.contains(title) {
+                windowMenu = menu
+                break
+            }
+        }
+        if windowMenu == nil, menus.count >= 2 {
+            windowMenu = menus[menus.count - 2]
+        }
+        guard let windowMenu else { return [] }
+
+        // The menu's children contain a single AXMenu (the popup); its
+        // children are the menu items.
+        var popupChildrenRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(windowMenu, kAXChildrenAttribute as CFString, &popupChildrenRef) == .success,
+              let popupChildren = popupChildrenRef as? [AXUIElement],
+              let popup = popupChildren.first
+        else { return [] }
+
+        var itemsRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(popup, kAXChildrenAttribute as CFString, &itemsRef) == .success,
+              let items = itemsRef as? [AXUIElement]
+        else { return [] }
+
+        var out: [(menuItem: AXUIElement, title: String)] = []
+        for item in items {
+            var t: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(item, kAXTitleAttribute as CFString, &t) == .success,
+                  let title = t as? String, !title.isEmpty,
+                  !windowMenuCommandTitles.contains(title)
+            else { continue }
+            out.append((item, title))
+        }
+        return out
     }
 
     private static func windowTitle(_ window: AXUIElement) -> String {

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/AXTitleMatchActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/AXTitleMatchActivator.swift
@@ -42,16 +42,12 @@ struct AXTitleMatchActivator: HostActivator {
         let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID)
         guard !runningApps.isEmpty else { return }
 
-        // Enumerate window candidates via the app's **Window menu** rather
-        // than kAXWindowsAttribute. The latter omits windows that are
-        // fullscreen on another Space for many Electron apps (VS Code,
-        // Cursor, Windsurf), so the only candidate we ever see is whatever
-        // happens to be on the current Space — making click-to-focus a
-        // silent no-op when the target lives on a different fullscreen
-        // Space (issue #344). The Window menu always lists every open
-        // window of the app, and AX-pressing a menu item is the same as
-        // the user picking it from the menu bar: macOS handles the Space
-        // switch and raise atomically.
+        // kAXWindowsAttribute omits windows that are fullscreen on
+        // another Space for Electron hosts (VS Code, Cursor, Windsurf), so
+        // we enumerate via the app's Window menu instead — it lists every
+        // open window across Spaces, and AX-pressing an item is what the
+        // user would do manually, so macOS handles the Space switch and
+        // raise atomically.
         var candidates: [(menuItem: AXUIElement, title: String)] = []
         for app in runningApps {
             let axApp = AXUIElementCreateApplication(app.processIdentifier)
@@ -99,44 +95,26 @@ struct AXTitleMatchActivator: HostActivator {
 
     private static func windowMenuItems(axApp: AXUIElement) -> [(menuItem: AXUIElement, title: String)] {
         var menuBarRef: CFTypeRef?
-        // Unwrap to a non-optional before CFGetTypeID — Swift's CF bridging
-        // does not allow `as? AXUIElement` (always-succeed); the runtime
-        // check has to go through CFGetTypeID, and that crashes on NULL.
+        // CFGetTypeID crashes on NULL and Swift CF bridging doesn't allow
+        // `as? AXUIElement`, so we unwrap then runtime-check the type.
         guard AXUIElementCopyAttributeValue(axApp, kAXMenuBarAttribute as CFString, &menuBarRef) == .success,
               let menuBarRef,
               CFGetTypeID(menuBarRef) == AXUIElementGetTypeID()
         else { return [] }
         let menuBar = menuBarRef as! AXUIElement
 
-        let menus = axChildren(menuBar)
+        guard let windowMenu = axChildren(menuBar).first(where: { menu in
+            axTitle(menu).map(windowMenuTitles.contains) ?? false
+        }) else { return [] }
 
-        // Find the Window menu by localized title. No positional fallback —
-        // pressing the first item of an unknown menu in a non-Cocoa-standard
-        // app could trigger a destructive action.
-        var windowMenu: AXUIElement?
-        for menu in menus {
-            var t: CFTypeRef?
-            if AXUIElementCopyAttributeValue(menu, kAXTitleAttribute as CFString, &t) == .success,
-               let title = t as? String, windowMenuTitles.contains(title) {
-                windowMenu = menu
-                break
-            }
-        }
-        guard let windowMenu else { return [] }
-
-        // Each top-level menu has a single AXMenu child (the popup); its
-        // children are the menu items.
+        // A top-level menu has a single AXMenu popup child; its children
+        // are the menu items.
         guard let popup = axChildren(windowMenu).first else { return [] }
 
-        var out: [(menuItem: AXUIElement, title: String)] = []
-        for item in axChildren(popup) {
-            var t: CFTypeRef?
-            guard AXUIElementCopyAttributeValue(item, kAXTitleAttribute as CFString, &t) == .success,
-                  let title = t as? String, !title.isEmpty
-            else { continue }
-            out.append((item, title))
+        return axChildren(popup).compactMap { item in
+            guard let title = axTitle(item), !title.isEmpty else { return nil }
+            return (item, title)
         }
-        return out
     }
 
     private static func axChildren(_ element: AXUIElement) -> [AXUIElement] {
@@ -147,10 +125,11 @@ struct AXTitleMatchActivator: HostActivator {
         return children
     }
 
-    private static func windowTitle(_ window: AXUIElement) -> String {
-        var titleRef: CFTypeRef?
-        AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef)
-        return (titleRef as? String) ?? ""
+    private static func axTitle(_ element: AXUIElement) -> String? {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXTitleAttribute as CFString, &ref) == .success
+        else { return nil }
+        return ref as? String
     }
 
     // MARK: - Title match (pure, testable)

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/AXTitleMatchActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/AXTitleMatchActivator.swift
@@ -68,33 +68,51 @@ struct AXTitleMatchActivator: HostActivator {
     }
 
     /// Returns (menuItem, title) pairs for every entry in the app's Window
-    /// menu. The Window menu is identified by title — locale-resilient
-    /// enough for English-default users; we additionally accept a few
-    /// common localizations. Items with empty titles or that match common
-    /// command names (Minimize, Zoom, Close, Bring All to Front) are
-    /// filtered so they never compete with real window entries.
+    /// menu. The Window menu is identified by its localized title; if
+    /// the app's locale isn't in our list we fail gracefully (returns
+    /// `[]`) rather than guessing at a positional fallback that might
+    /// land on a non-Window menu and press a destructive item.
+    ///
+    /// Non-window entries in the menu (Minimize, Zoom, …) are not
+    /// filtered explicitly — `bestMatchIndex` scores them 0 against any
+    /// real cwd, so they never win regardless of locale.
     private static let windowMenuTitles: Set<String> = [
-        "Window", "Fenster", "Fenêtre", "Ventana", "ウィンドウ", "窗口", "창",
-    ]
-    private static let windowMenuCommandTitles: Set<String> = [
-        "Minimize", "Zoom", "Close", "Bring All to Front",
-        "Minimieren", "Zoomen", "Schließen", "Alle nach vorne bringen",
+        "Window",       // en
+        "Fenster",      // de
+        "Fenêtre",      // fr
+        "Ventana",      // es
+        "Finestra",     // it
+        "Janela",       // pt (BR & PT)
+        "Venster",      // nl
+        "Fönster",      // sv
+        "Vindue",       // da
+        "Vindu",        // no/nb
+        "Ikkuna",       // fi
+        "Okno",         // pl/cs
+        "Окно",         // ru
+        "Pencere",      // tr
+        "ウィンドウ",      // ja
+        "窗口",          // zh-Hans
+        "視窗",          // zh-Hant
+        "창",           // ko
     ]
 
     private static func windowMenuItems(axApp: AXUIElement) -> [(menuItem: AXUIElement, title: String)] {
         var menuBarRef: CFTypeRef?
+        // Unwrap to a non-optional before CFGetTypeID — Swift's CF bridging
+        // does not allow `as? AXUIElement` (always-succeed); the runtime
+        // check has to go through CFGetTypeID, and that crashes on NULL.
         guard AXUIElementCopyAttributeValue(axApp, kAXMenuBarAttribute as CFString, &menuBarRef) == .success,
+              let menuBarRef,
               CFGetTypeID(menuBarRef) == AXUIElementGetTypeID()
         else { return [] }
         let menuBar = menuBarRef as! AXUIElement
 
-        var menusRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(menuBar, kAXChildrenAttribute as CFString, &menusRef) == .success,
-              let menus = menusRef as? [AXUIElement]
-        else { return [] }
+        let menus = axChildren(menuBar)
 
-        // Find the Window menu by title (locale-tolerant). Fallback: the
-        // second-to-last top-level menu (Cocoa convention: …Window, Help).
+        // Find the Window menu by localized title. No positional fallback —
+        // pressing the first item of an unknown menu in a non-Cocoa-standard
+        // app could trigger a destructive action.
         var windowMenu: AXUIElement?
         for menu in menus {
             var t: CFTypeRef?
@@ -104,34 +122,29 @@ struct AXTitleMatchActivator: HostActivator {
                 break
             }
         }
-        if windowMenu == nil, menus.count >= 2 {
-            windowMenu = menus[menus.count - 2]
-        }
         guard let windowMenu else { return [] }
 
-        // The menu's children contain a single AXMenu (the popup); its
+        // Each top-level menu has a single AXMenu child (the popup); its
         // children are the menu items.
-        var popupChildrenRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(windowMenu, kAXChildrenAttribute as CFString, &popupChildrenRef) == .success,
-              let popupChildren = popupChildrenRef as? [AXUIElement],
-              let popup = popupChildren.first
-        else { return [] }
-
-        var itemsRef: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(popup, kAXChildrenAttribute as CFString, &itemsRef) == .success,
-              let items = itemsRef as? [AXUIElement]
-        else { return [] }
+        guard let popup = axChildren(windowMenu).first else { return [] }
 
         var out: [(menuItem: AXUIElement, title: String)] = []
-        for item in items {
+        for item in axChildren(popup) {
             var t: CFTypeRef?
             guard AXUIElementCopyAttributeValue(item, kAXTitleAttribute as CFString, &t) == .success,
-                  let title = t as? String, !title.isEmpty,
-                  !windowMenuCommandTitles.contains(title)
+                  let title = t as? String, !title.isEmpty
             else { continue }
             out.append((item, title))
         }
         return out
+    }
+
+    private static func axChildren(_ element: AXUIElement) -> [AXUIElement] {
+        var ref: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &ref) == .success,
+              let children = ref as? [AXUIElement]
+        else { return [] }
+        return children
     }
 
     private static func windowTitle(_ window: AXUIElement) -> String {


### PR DESCRIPTION
## Summary

- Fixes #344: clicking a session row in the macOS overlay was a silent no-op when the host VS Code window was fullscreen on its own Space.
- Root cause: `AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute, ...)` omits windows that are fullscreen on another Space for Electron hosts (VS Code, Cursor, Windsurf). With multiple VS Code windows open, the title-matched window simply wasn't in the candidate list, so the AX raise / Space switch never happened.
- Fix: enumerate candidates via the app's **Window menu** instead. The Window menu always lists every open window across all Spaces, and AX-pressing a menu item is exactly what the user would do manually — macOS handles the Space switch and raise atomically.
- Same fix applies to all AX-title-match hosts (Cursor, Windsurf, JetBrains, Zed, Rio, Tabby, Waveterm, Alacritty, Nova, Cmux) since they share `raiseMatchingWindow`.

## Test plan

- [x] Confirmed on the repro: 4 VS Code windows, target one is fullscreen on its own Space → click row → Space switches and the right window comes forward. Verified via the new `AX dispatch: cwd=… picked=[N] … of candidates=[…]` log line that all Window-menu entries are now visible to the matcher.
- [x] `go test ./core/... -race -count=1` and `tools/replay-fixtures.sh` green.
- [x] Swift build clean (`swift build`).
- [ ] Non-fullscreen / single-instance VS Code → still works (unchanged path).
- [ ] Cold launch (no VS Code running) → still works (openApplication path unchanged).
- [ ] Cursor / Windsurf / JetBrains in fullscreen on own Space → expected to inherit the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)