### PR TITLE
fix(ir:release): drop --entitlements from ad-hoc codesign (AMFI kills v0.4.3)

### DIFF
--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -249,16 +249,28 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
    </plist>
    ```
 
-6. Ad-hoc code sign. App entitlements come from
-   `platforms/macos/Irrlicht/Resources/Irrlicht.entitlements` (currently
-   `get-task-allow` + `com.apple.developer.focus-status`). `--entitlements` is
-   required at sign time; Apple-gated entitlements carry no privileges in the
-   produced bundle without it.
+6. Ad-hoc code sign. **Do not pass `--entitlements`.** AMFI (Apple Mobile
+   File Integrity) rejects ad-hoc-signed binaries that claim Apple-restricted
+   entitlements; `com.apple.developer.focus-status` (in
+   `platforms/macos/Irrlicht/Resources/Irrlicht.entitlements`) is one such
+   entitlement. Applying the entitlements file at sign time bakes that claim
+   into the binary, which `amfid` then refuses to launch — surfacing as
+   `launchd POSIX 153` / `Launchd job spawn failed` on first launch. This
+   shipped a broken v0.4.3 that the curl installer couldn't open on any end
+   user's machine; the assets were re-cut without entitlements applied.
+   The `Irrlicht.entitlements` file is preserved in the repo for the future
+   Developer-ID-signed + notarized path (separate work, tracked under #233);
+   until that lands, it must not be applied. `INFocusStatusCenter` works at
+   runtime on macOS without the entitlement — only `NSFocusStatusUsageDescription`
+   in `Info.plist` (already written in step 5 above) is required for TCC.
    ```bash
-   ENTITLEMENTS="/Users/ingo/projects/irrlicht/platforms/macos/Irrlicht/Resources/Irrlicht.entitlements"
    codesign --force --deep --sign - "$APP_STAGING/Contents/MacOS/irrlichd"
-   codesign --force --deep --sign - --entitlements "$ENTITLEMENTS" "$APP_STAGING"
+   codesign --force --deep --sign - "$APP_STAGING"
    codesign --verify --deep --strict "$APP_STAGING"
+   # Sanity check — must be empty (matches v0.4.2 working behavior).
+   codesign -d --entitlements - "$APP_STAGING" 2>&1 | grep -q '\[Key\]' \
+     && { echo "FAIL: entitlements baked into ad-hoc binary"; exit 1; } \
+     || echo "OK no entitlements (AMFI won't reject)"
    ```
 7. **Smoke test before packaging** — launch the built app, wait ~2s, confirm
    the process is still alive and has spawned `irrlichd`. Missing resources


### PR DESCRIPTION
## Summary

The ir:release skill's Step 6 step 6 instructed `codesign --force --deep --sign - --entitlements "$ENTITLEMENTS" "$APP_STAGING"`, which baked `com.apple.developer.focus-status` (an Apple-restricted entitlement) into the ad-hoc-signed `.app` bundle for the first time in v0.4.3. AMFI (Apple Mobile File Integrity) rejects ad-hoc-signed binaries that claim restricted entitlements — surfacing as launchd POSIX 153 / "Launchd job spawn failed" on every end user's first launch attempt.

Confirmed live on the shipped v0.4.3 install:

```
$ codesign -d --entitlements - /Applications/Irrlicht.app
  [Key] com.apple.developer.focus-status   [Value] [Bool] true
  [Key] com.apple.security.get-task-allow  [Value] [Bool] true
```

Production v0.4.2 had no entitlements applied (verified during the release run before being overwritten) and launches cleanly.

## Changes

- **Drop `--entitlements "$ENTITLEMENTS"` from the `.app` codesign line.** The daemon-binary sign was already entitlement-less; leave it.
- **Add a post-sign sanity check** that fails the release run if any `[Key]` line appears in `codesign -d --entitlements -` output. Prevents silent recurrence.
- **Expand the prose** to explain *why* not to apply entitlements (AMFI, restricted entitlements, the v0.4.3 incident as the historical reference) so future contributors don't put the flag back without intent.

## Not in scope

- The v0.4.3 asset re-cut itself — separate workstream, in progress concurrently.
- Notarization / Developer ID — tracked at #233. Once that lands, `--entitlements` becomes appropriate again, but for ad-hoc only the daemon's `com.apple.security.get-task-allow` would still be safe; the focus-status entitlement requires the provisioning profile.

## Test plan

- [ ] Next release run uses the no-`--entitlements` form and the sanity-check guard fires zero hits.
- [ ] `codesign -d --entitlements -` on the resulting `.app` returns empty (matches v0.4.2 working behavior).
- [ ] Curl installer launches the new build without POSIX 153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)