### PR TITLE
docs: note v0.4.3 asset re-spin + bump cask sha256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ attached to each [GitHub release](https://github.com/ingo-eichhorst/Irrlicht/rel
 
 ## [0.4.3] — 2026-05-15
 
+> **Note:** Assets re-cut later the same day. The original v0.4.3 binary statically linked `Intents.framework` (via `FocusMonitor.swift`'s direct `INFocusStatusCenter` calls), which made macOS TCC preflight `kTCCServiceListenEvent` at process startup and AMFI/TCC SIGABRT the ad-hoc-signed binary with `launchd POSIX 153` on every end-user install. The re-cut moves `FocusMonitor` to dynamic dispatch (`NSClassFromString` + `SecCodeCopySigningInformation` gate) so Intents.framework is never loaded on ad-hoc builds. DND-aware notification silencing is paused until Developer-ID signing lands (#233); restoration tracked in #357. Release-skill regression fix that prevents recurrence: #356.
+
 ### Added
 - **macOS: autostart Irrlicht.app at login, on by default** (#343) — On first launch the app registers itself as a login item via `SMAppService.mainApp` so the menu-bar overlay is up before you open your first terminal. A new toggle in Preferences flips the setting, and the choice is persisted to `UserDefaults`; a one-time gate (`didApplyDefaultLoginItem`) ensures the default never re-enables itself after you turn it off. The XPC call to launchd runs on a detached `userInitiated` task so the toggle animation stays smooth on slower Macs. The unsigned-then-signed-build dev edge case is called out inline in `applyDefaultIfNeeded` so future maintainers know why the gate exists.
 

--- a/site/docs/changelog.html
+++ b/site/docs/changelog.html
@@ -83,6 +83,8 @@
 
       <h2>v0.4.3 <small>(2026-05-15)</small></h2>
 
+      <blockquote><strong>Note:</strong> Assets re-cut later the same day. The original v0.4.3 binary statically linked <code>Intents.framework</code> via <code>FocusMonitor.swift</code>'s direct <code>INFocusStatusCenter</code> calls, which made macOS TCC preflight <code>kTCCServiceListenEvent</code> at process startup and AMFI/TCC SIGABRT the ad-hoc-signed binary with <code>launchd POSIX 153</code> on every end-user install. The re-cut moves <code>FocusMonitor</code> to dynamic dispatch (<code>NSClassFromString</code> + <code>SecCodeCopySigningInformation</code> gate) so Intents.framework is never loaded on ad-hoc builds. DND-aware notification silencing is paused until Developer-ID signing lands (#233); restoration tracked in #357. Release-skill regression fix that prevents recurrence: #356.</blockquote>
+
       <h3>Added</h3>
 
       <ul>

--- a/tools/homebrew-tap/Casks/irrlicht.rb
+++ b/tools/homebrew-tap/Casks/irrlicht.rb
@@ -1,6 +1,6 @@
 cask "irrlicht" do
   version "0.4.3"
-  sha256 "658ad1935bc79f0518820b83385f7779a7b68fd84d500e04f9e22df1b35f5637"
+  sha256 "1c9a57ea58cb6a3169aae16b99a1741a73ba344dc092455d3da1f57e52c8405a"
 
   url "https://github.com/ingo-eichhorst/Irrlicht/releases/download/v#{version}/Irrlicht-#{version}.dmg",
       verified: "github.com/ingo-eichhorst/Irrlicht/"


### PR DESCRIPTION
Tiny PR. Adds a footnote to the v0.4.3 CHANGELOG entries (both <code>CHANGELOG.md</code> and <code>site/docs/changelog.html</code>) explaining the asset re-spin earlier today and pointing at the follow-up trackers (#357 DevID restoration, #356 skill regression fix). Bumps the in-repo cask sha256 to match the re-cut DMG. No version bump — the v0.4.3 tag and filenames stay as-is.