### PR TITLE
fix(adapters): honor agent-CLI env vars for relocated session dirs (#349)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/adapter.go
+++ b/core/adapters/inbound/agents/claudecode/adapter.go
@@ -3,6 +3,7 @@
 package claudecode
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 )
@@ -19,16 +20,26 @@ const ProcessName = "claude"
 const defaultProjectsDir = ".claude/projects"
 
 // configDirEnvVar is the upstream Claude Code env var that relocates the
-// agent's home directory (default: $HOME/.claude). When set, projects and
-// PID metadata both move under it.
+// agent's config root. Officially undocumented as of this writing; third-
+// party tooling (ccusage) treats projects/ as relocating under it, which
+// matches the common config-root convention. The PID-metadata directory
+// (~/.claude/sessions/) is NOT moved here — its behavior under the env var
+// is unverified, so pid.go intentionally keeps the hardcoded path.
 const configDirEnvVar = "CLAUDE_CONFIG_DIR"
 
 // transcriptsDir returns the directory the Claude Code adapter should watch.
-// When CLAUDE_CONFIG_DIR is set, transcripts live under $CLAUDE_CONFIG_DIR/projects;
-// otherwise the default $HOME-relative path is returned.
+// When CLAUDE_CONFIG_DIR is set to an absolute path, transcripts live under
+// $CLAUDE_CONFIG_DIR/projects; non-absolute values (relative paths,
+// unexpanded ~) are logged and ignored to surface misconfiguration. The env
+// var is read once at Agent() construction; a daemon restart is required
+// after changing it.
 func transcriptsDir() string {
 	if v := os.Getenv(configDirEnvVar); v != "" {
-		return filepath.Join(v, "projects")
+		cleaned := filepath.Clean(v)
+		if filepath.IsAbs(cleaned) {
+			return filepath.Join(cleaned, "projects")
+		}
+		log.Printf("claudecode: ignoring %s=%q — must be an absolute path (no shell expansion)", configDirEnvVar, v)
 	}
 	return defaultProjectsDir
 }

--- a/core/adapters/inbound/agents/claudecode/adapter.go
+++ b/core/adapters/inbound/agents/claudecode/adapter.go
@@ -2,6 +2,11 @@
 // transcript files under ~/.claude/projects/*/*.jsonl.
 package claudecode
 
+import (
+	"os"
+	"path/filepath"
+)
+
 // AdapterName identifies sessions originating from Claude Code.
 const AdapterName = "claude-code"
 
@@ -9,5 +14,21 @@ const AdapterName = "claude-code"
 // PID-discovery lookups (pgrep, etc.). Distinct from AdapterName.
 const ProcessName = "claude"
 
-// projectsDir is the path relative to $HOME where Claude Code stores transcripts.
-const projectsDir = ".claude/projects"
+// defaultProjectsDir is the path relative to $HOME where Claude Code stores
+// transcripts by default.
+const defaultProjectsDir = ".claude/projects"
+
+// configDirEnvVar is the upstream Claude Code env var that relocates the
+// agent's home directory (default: $HOME/.claude). When set, projects and
+// PID metadata both move under it.
+const configDirEnvVar = "CLAUDE_CONFIG_DIR"
+
+// transcriptsDir returns the directory the Claude Code adapter should watch.
+// When CLAUDE_CONFIG_DIR is set, transcripts live under $CLAUDE_CONFIG_DIR/projects;
+// otherwise the default $HOME-relative path is returned.
+func transcriptsDir() string {
+	if v := os.Getenv(configDirEnvVar); v != "" {
+		return filepath.Join(v, "projects")
+	}
+	return defaultProjectsDir
+}

--- a/core/adapters/inbound/agents/claudecode/adapter.go
+++ b/core/adapters/inbound/agents/claudecode/adapter.go
@@ -28,11 +28,8 @@ const defaultProjectsDir = ".claude/projects"
 const configDirEnvVar = "CLAUDE_CONFIG_DIR"
 
 // transcriptsDir returns the directory the Claude Code adapter should watch.
-// When CLAUDE_CONFIG_DIR is set to an absolute path, transcripts live under
-// $CLAUDE_CONFIG_DIR/projects; non-absolute values (relative paths,
-// unexpanded ~) are logged and ignored to surface misconfiguration. The env
-// var is read once at Agent() construction; a daemon restart is required
-// after changing it.
+// Non-absolute env values are rejected so a misconfigured path surfaces in
+// logs instead of silently watching the wrong place.
 func transcriptsDir() string {
 	if v := os.Getenv(configDirEnvVar); v != "" {
 		cleaned := filepath.Clean(v)

--- a/core/adapters/inbound/agents/claudecode/adapter_test.go
+++ b/core/adapters/inbound/agents/claudecode/adapter_test.go
@@ -1,10 +1,6 @@
 package claudecode
 
-import (
-	"os"
-	"path/filepath"
-	"testing"
-)
+import "testing"
 
 func TestTranscriptsDir(t *testing.T) {
 	tests := []struct {
@@ -13,7 +9,10 @@ func TestTranscriptsDir(t *testing.T) {
 		want string
 	}{
 		{"empty falls back to default", "", defaultProjectsDir},
-		{"override produces $CLAUDE_CONFIG_DIR/projects", "/tmp/claude-home", "/tmp/claude-home/projects"},
+		{"absolute override produces $CLAUDE_CONFIG_DIR/projects", "/tmp/claude-home", "/tmp/claude-home/projects"},
+		{"trailing slash is cleaned", "/tmp/claude-home/", "/tmp/claude-home/projects"},
+		{"relative override is rejected (falls back to default)", "relative/home", defaultProjectsDir},
+		{"tilde-prefixed override is rejected (no shell expansion)", "~/custom", defaultProjectsDir},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -22,25 +21,5 @@ func TestTranscriptsDir(t *testing.T) {
 				t.Errorf("transcriptsDir() = %q, want %q", got, tc.want)
 			}
 		})
-	}
-}
-
-func TestDefaultSessionsDirRespectsConfigDir(t *testing.T) {
-	t.Setenv(configDirEnvVar, "/tmp/claude-home")
-	want := "/tmp/claude-home/sessions"
-	if got := defaultSessionsDir(); got != want {
-		t.Errorf("defaultSessionsDir() = %q, want %q", got, want)
-	}
-}
-
-func TestDefaultSessionsDirFallsBackToHome(t *testing.T) {
-	t.Setenv(configDirEnvVar, "")
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skip("no home dir")
-	}
-	want := filepath.Join(home, ".claude", "sessions")
-	if got := defaultSessionsDir(); got != want {
-		t.Errorf("defaultSessionsDir() = %q, want %q", got, want)
 	}
 }

--- a/core/adapters/inbound/agents/claudecode/adapter_test.go
+++ b/core/adapters/inbound/agents/claudecode/adapter_test.go
@@ -1,0 +1,46 @@
+package claudecode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTranscriptsDir(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"empty falls back to default", "", defaultProjectsDir},
+		{"override produces $CLAUDE_CONFIG_DIR/projects", "/tmp/claude-home", "/tmp/claude-home/projects"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(configDirEnvVar, tc.env)
+			if got := transcriptsDir(); got != tc.want {
+				t.Errorf("transcriptsDir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultSessionsDirRespectsConfigDir(t *testing.T) {
+	t.Setenv(configDirEnvVar, "/tmp/claude-home")
+	want := "/tmp/claude-home/sessions"
+	if got := defaultSessionsDir(); got != want {
+		t.Errorf("defaultSessionsDir() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultSessionsDirFallsBackToHome(t *testing.T) {
+	t.Setenv(configDirEnvVar, "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	want := filepath.Join(home, ".claude", "sessions")
+	if got := defaultSessionsDir(); got != want {
+		t.Errorf("defaultSessionsDir() = %q, want %q", got, want)
+	}
+}

--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -34,7 +34,7 @@ func Agent() agent.Agent {
 			PIDForSession: DiscoverPID,
 		},
 		Source: agent.FilesUnderRoot{
-			Dir: projectsDir,
+			Dir: transcriptsDir(),
 			Parser: agent.JSONLineParser{
 				NewParser: func() agent.LineParser { return &Parser{} },
 			},

--- a/core/adapters/inbound/agents/claudecode/pid.go
+++ b/core/adapters/inbound/agents/claudecode/pid.go
@@ -25,9 +25,6 @@ const staleMetaSlack = 2 * time.Second
 var sessionsDir = defaultSessionsDir()
 
 func defaultSessionsDir() string {
-	if v := os.Getenv(configDirEnvVar); v != "" {
-		return filepath.Join(v, "sessions")
-	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""

--- a/core/adapters/inbound/agents/claudecode/pid.go
+++ b/core/adapters/inbound/agents/claudecode/pid.go
@@ -25,6 +25,9 @@ const staleMetaSlack = 2 * time.Second
 var sessionsDir = defaultSessionsDir()
 
 func defaultSessionsDir() string {
+	if v := os.Getenv(configDirEnvVar); v != "" {
+		return filepath.Join(v, "sessions")
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""

--- a/core/adapters/inbound/agents/codex/adapter.go
+++ b/core/adapters/inbound/agents/codex/adapter.go
@@ -25,12 +25,9 @@ const defaultRootDir = ".codex/sessions"
 // $CODEX_HOME/sessions.
 const codexHomeEnvVar = "CODEX_HOME"
 
-// sessionsDir returns the directory the Codex adapter should watch. When
-// CODEX_HOME is set to an absolute path, sessions live under
-// $CODEX_HOME/sessions; non-absolute values (relative paths, unexpanded ~)
-// are logged and ignored to surface misconfiguration. The env var is read
-// once at Agent() construction; a daemon restart is required after changing
-// it.
+// sessionsDir returns the directory the Codex adapter should watch. Non-
+// absolute env values are rejected so a misconfigured path surfaces in
+// logs instead of silently watching the wrong place.
 func sessionsDir() string {
 	if v := os.Getenv(codexHomeEnvVar); v != "" {
 		cleaned := filepath.Clean(v)

--- a/core/adapters/inbound/agents/codex/adapter.go
+++ b/core/adapters/inbound/agents/codex/adapter.go
@@ -3,6 +3,7 @@
 package codex
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 )
@@ -25,11 +26,18 @@ const defaultRootDir = ".codex/sessions"
 const codexHomeEnvVar = "CODEX_HOME"
 
 // sessionsDir returns the directory the Codex adapter should watch. When
-// CODEX_HOME is set, sessions live under $CODEX_HOME/sessions; otherwise
-// the default $HOME-relative path is returned.
+// CODEX_HOME is set to an absolute path, sessions live under
+// $CODEX_HOME/sessions; non-absolute values (relative paths, unexpanded ~)
+// are logged and ignored to surface misconfiguration. The env var is read
+// once at Agent() construction; a daemon restart is required after changing
+// it.
 func sessionsDir() string {
 	if v := os.Getenv(codexHomeEnvVar); v != "" {
-		return filepath.Join(v, "sessions")
+		cleaned := filepath.Clean(v)
+		if filepath.IsAbs(cleaned) {
+			return filepath.Join(cleaned, "sessions")
+		}
+		log.Printf("codex: ignoring %s=%q — must be an absolute path (no shell expansion)", codexHomeEnvVar, v)
 	}
 	return defaultRootDir
 }

--- a/core/adapters/inbound/agents/codex/adapter.go
+++ b/core/adapters/inbound/agents/codex/adapter.go
@@ -2,6 +2,11 @@
 // transcript files under ~/.codex/*/*.jsonl.
 package codex
 
+import (
+	"os"
+	"path/filepath"
+)
+
 // AdapterName identifies sessions originating from OpenAI Codex.
 const AdapterName = "codex"
 
@@ -9,6 +14,22 @@ const AdapterName = "codex"
 // the process lifecycle scanner to detect running instances via pgrep -x.
 const ProcessName = "codex"
 
-// rootDir is the path relative to $HOME where Codex stores session transcripts.
-// Sessions live under sessions/YYYY/MM/DD/*.jsonl (deep nesting).
-const rootDir = ".codex/sessions"
+// defaultRootDir is the path relative to $HOME where Codex stores session
+// transcripts by default. Sessions live under sessions/YYYY/MM/DD/*.jsonl
+// (deep nesting).
+const defaultRootDir = ".codex/sessions"
+
+// codexHomeEnvVar is the upstream Codex env var that relocates the agent's
+// home directory (default: $HOME/.codex). When set, sessions move to
+// $CODEX_HOME/sessions.
+const codexHomeEnvVar = "CODEX_HOME"
+
+// sessionsDir returns the directory the Codex adapter should watch. When
+// CODEX_HOME is set, sessions live under $CODEX_HOME/sessions; otherwise
+// the default $HOME-relative path is returned.
+func sessionsDir() string {
+	if v := os.Getenv(codexHomeEnvVar); v != "" {
+		return filepath.Join(v, "sessions")
+	}
+	return defaultRootDir
+}

--- a/core/adapters/inbound/agents/codex/adapter_test.go
+++ b/core/adapters/inbound/agents/codex/adapter_test.go
@@ -9,7 +9,10 @@ func TestSessionsDir(t *testing.T) {
 		want string
 	}{
 		{"empty falls back to default", "", defaultRootDir},
-		{"override produces $CODEX_HOME/sessions", "/tmp/codex-home", "/tmp/codex-home/sessions"},
+		{"absolute override produces $CODEX_HOME/sessions", "/tmp/codex-home", "/tmp/codex-home/sessions"},
+		{"trailing slash is cleaned", "/tmp/codex-home/", "/tmp/codex-home/sessions"},
+		{"relative override is rejected (falls back to default)", "relative/home", defaultRootDir},
+		{"tilde-prefixed override is rejected (no shell expansion)", "~/custom", defaultRootDir},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/core/adapters/inbound/agents/codex/adapter_test.go
+++ b/core/adapters/inbound/agents/codex/adapter_test.go
@@ -1,0 +1,22 @@
+package codex
+
+import "testing"
+
+func TestSessionsDir(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"empty falls back to default", "", defaultRootDir},
+		{"override produces $CODEX_HOME/sessions", "/tmp/codex-home", "/tmp/codex-home/sessions"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(codexHomeEnvVar, tc.env)
+			if got := sessionsDir(); got != tc.want {
+				t.Errorf("sessionsDir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/core/adapters/inbound/agents/codex/agent.go
+++ b/core/adapters/inbound/agents/codex/agent.go
@@ -30,7 +30,7 @@ func Agent() agent.Agent {
 			PIDForSession: DiscoverPID,
 		},
 		Source: agent.FilesUnderRoot{
-			Dir: rootDir,
+			Dir: sessionsDir(),
 			Parser: agent.JSONLineParser{
 				NewParser: func() agent.LineParser { return &Parser{} },
 			},

--- a/core/adapters/inbound/agents/fswatcher/watcher.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher.go
@@ -43,17 +43,25 @@ func (w *Watcher) Identity() agent.Identity {
 	return w.identity
 }
 
-// New creates a Watcher for the given directory relative to $HOME.
+// New creates a Watcher for the given directory. If dir is absolute, it is
+// used as-is; otherwise it is resolved relative to $HOME. Absolute paths let
+// adapters honor upstream env-var overrides (e.g. PI_CODING_AGENT_SESSION_DIR,
+// CLAUDE_CONFIG_DIR, CODEX_HOME) without coupling fswatcher to any specific
+// agent's environment conventions.
+//
 // adapter is the name set on all emitted TranscriptEvents (e.g. "claude-code").
 // maxAge controls the maximum file age — transcript files not modified within
 // this window are silently ignored. A zero value disables the filter.
-func New(relDir, adapter string, maxAge time.Duration) *Watcher {
+func New(dir, adapter string, maxAge time.Duration) *Watcher {
+	if filepath.IsAbs(dir) {
+		return &Watcher{root: dir, adapter: adapter, maxAge: maxAge}
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return &Watcher{adapter: adapter, maxAge: maxAge}
 	}
 	return &Watcher{
-		root:    filepath.Join(home, relDir),
+		root:    filepath.Join(home, dir),
 		adapter: adapter,
 		maxAge:  maxAge,
 	}

--- a/core/adapters/inbound/agents/fswatcher/watcher.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher.go
@@ -54,7 +54,7 @@ func (w *Watcher) Identity() agent.Identity {
 // this window are silently ignored. A zero value disables the filter.
 func New(dir, adapter string, maxAge time.Duration) *Watcher {
 	if filepath.IsAbs(dir) {
-		return &Watcher{root: dir, adapter: adapter, maxAge: maxAge}
+		return &Watcher{root: filepath.Clean(dir), adapter: adapter, maxAge: maxAge}
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/core/adapters/inbound/agents/fswatcher/watcher_test.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher_test.go
@@ -40,6 +40,28 @@ func TestNewWithRoot(t *testing.T) {
 	}
 }
 
+// New treats an absolute dir as-is so adapters can pass an env-var override
+// (e.g. PI_CODING_AGENT_SESSION_DIR=/tmp/pi-sessions) without it being
+// silently rejoined under $HOME.
+func TestNew_AbsoluteDir_UsedAsIs(t *testing.T) {
+	w := New("/tmp/pi-sessions", testAdapter, 0)
+	if w.Root() != "/tmp/pi-sessions" {
+		t.Errorf("Root() = %q, want /tmp/pi-sessions", w.Root())
+	}
+}
+
+func TestNew_RelativeDir_JoinedWithHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	w := New(".pi/agent/sessions", testAdapter, 0)
+	want := filepath.Join(home, ".pi/agent/sessions")
+	if w.Root() != want {
+		t.Errorf("Root() = %q, want %q", w.Root(), want)
+	}
+}
+
 func TestExtractSessionID(t *testing.T) {
 	tests := []struct {
 		path string

--- a/core/adapters/inbound/agents/pi/adapter.go
+++ b/core/adapters/inbound/agents/pi/adapter.go
@@ -2,7 +2,11 @@
 // transcript files under ~/.pi/agent/sessions/--<cwd>--/*.jsonl.
 package pi
 
-import "os"
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
 
 // AdapterName identifies sessions originating from Pi coding agent.
 const AdapterName = "pi"
@@ -17,17 +21,23 @@ const ProcessName = "pi"
 const defaultRootDir = ".pi/agent/sessions"
 
 // sessionDirEnvVar is the upstream Pi env var (introduced in Pi v0.71.0,
-// 2026-04-30) that relocates the session-transcript root. When set, it is
-// the absolute path of the session directory itself (not a parent).
+// 2026-04-30) that relocates the session-transcript root. When set, it must
+// be the absolute path of the session directory itself (not a parent).
 const sessionDirEnvVar = "PI_CODING_AGENT_SESSION_DIR"
 
 // sessionsDir returns the directory the Pi adapter should watch. It honors
-// PI_CODING_AGENT_SESSION_DIR (absolute path) when set; otherwise it returns
-// the default $HOME-relative path. Daemon restart is required to pick up
-// changes — the env var is read once at Agent() construction time.
+// PI_CODING_AGENT_SESSION_DIR when set to an absolute path; non-absolute
+// values (relative paths, unexpanded ~) are logged and ignored to surface
+// the misconfiguration instead of silently watching the wrong place. The
+// env var is read once at Agent() construction time, so a daemon restart
+// is required after changing it.
 func sessionsDir() string {
 	if v := os.Getenv(sessionDirEnvVar); v != "" {
-		return v
+		cleaned := filepath.Clean(v)
+		if filepath.IsAbs(cleaned) {
+			return cleaned
+		}
+		log.Printf("pi: ignoring %s=%q — must be an absolute path (no shell expansion)", sessionDirEnvVar, v)
 	}
 	return defaultRootDir
 }

--- a/core/adapters/inbound/agents/pi/adapter.go
+++ b/core/adapters/inbound/agents/pi/adapter.go
@@ -20,17 +20,14 @@ const ProcessName = "pi"
 // --<cwd-with-dashes>--/<timestamp>_<uuid>.jsonl.
 const defaultRootDir = ".pi/agent/sessions"
 
-// sessionDirEnvVar is the upstream Pi env var (introduced in Pi v0.71.0,
-// 2026-04-30) that relocates the session-transcript root. When set, it must
-// be the absolute path of the session directory itself (not a parent).
+// sessionDirEnvVar is the upstream Pi env var that relocates the session-
+// transcript root. When set, it must be the absolute path of the session
+// directory itself (not a parent).
 const sessionDirEnvVar = "PI_CODING_AGENT_SESSION_DIR"
 
-// sessionsDir returns the directory the Pi adapter should watch. It honors
-// PI_CODING_AGENT_SESSION_DIR when set to an absolute path; non-absolute
-// values (relative paths, unexpanded ~) are logged and ignored to surface
-// the misconfiguration instead of silently watching the wrong place. The
-// env var is read once at Agent() construction time, so a daemon restart
-// is required after changing it.
+// sessionsDir returns the directory the Pi adapter should watch. Non-
+// absolute env values are rejected so a misconfigured path surfaces in
+// logs instead of silently watching the wrong place.
 func sessionsDir() string {
 	if v := os.Getenv(sessionDirEnvVar); v != "" {
 		cleaned := filepath.Clean(v)

--- a/core/adapters/inbound/agents/pi/adapter.go
+++ b/core/adapters/inbound/agents/pi/adapter.go
@@ -2,6 +2,8 @@
 // transcript files under ~/.pi/agent/sessions/--<cwd>--/*.jsonl.
 package pi
 
+import "os"
+
 // AdapterName identifies sessions originating from Pi coding agent.
 const AdapterName = "pi"
 
@@ -9,6 +11,23 @@ const AdapterName = "pi"
 // the process lifecycle scanner to detect running instances via pgrep -x.
 const ProcessName = "pi"
 
-// rootDir is the path relative to $HOME where Pi stores session transcripts.
-// Sessions live under --<cwd-with-dashes>--/<timestamp>_<uuid>.jsonl.
-const rootDir = ".pi/agent/sessions"
+// defaultRootDir is the path relative to $HOME where Pi stores session
+// transcripts by default. Sessions live under
+// --<cwd-with-dashes>--/<timestamp>_<uuid>.jsonl.
+const defaultRootDir = ".pi/agent/sessions"
+
+// sessionDirEnvVar is the upstream Pi env var (introduced in Pi v0.71.0,
+// 2026-04-30) that relocates the session-transcript root. When set, it is
+// the absolute path of the session directory itself (not a parent).
+const sessionDirEnvVar = "PI_CODING_AGENT_SESSION_DIR"
+
+// sessionsDir returns the directory the Pi adapter should watch. It honors
+// PI_CODING_AGENT_SESSION_DIR (absolute path) when set; otherwise it returns
+// the default $HOME-relative path. Daemon restart is required to pick up
+// changes — the env var is read once at Agent() construction time.
+func sessionsDir() string {
+	if v := os.Getenv(sessionDirEnvVar); v != "" {
+		return v
+	}
+	return defaultRootDir
+}

--- a/core/adapters/inbound/agents/pi/adapter_test.go
+++ b/core/adapters/inbound/agents/pi/adapter_test.go
@@ -1,0 +1,22 @@
+package pi
+
+import "testing"
+
+func TestSessionsDir(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"empty falls back to default", "", defaultRootDir},
+		{"absolute override is used as-is", "/tmp/pi-sessions", "/tmp/pi-sessions"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(sessionDirEnvVar, tc.env)
+			if got := sessionsDir(); got != tc.want {
+				t.Errorf("sessionsDir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/core/adapters/inbound/agents/pi/adapter_test.go
+++ b/core/adapters/inbound/agents/pi/adapter_test.go
@@ -10,6 +10,9 @@ func TestSessionsDir(t *testing.T) {
 	}{
 		{"empty falls back to default", "", defaultRootDir},
 		{"absolute override is used as-is", "/tmp/pi-sessions", "/tmp/pi-sessions"},
+		{"trailing slash is cleaned", "/tmp/pi-sessions/", "/tmp/pi-sessions"},
+		{"relative override is rejected (falls back to default)", "relative/sessions", defaultRootDir},
+		{"tilde-prefixed override is rejected (no shell expansion)", "~/custom", defaultRootDir},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/core/adapters/inbound/agents/pi/agent.go
+++ b/core/adapters/inbound/agents/pi/agent.go
@@ -32,7 +32,7 @@ func Agent() agent.Agent {
 			PIDForSession: DiscoverPID,
 		},
 		Source: agent.FilesUnderRoot{
-			Dir: rootDir,
+			Dir: sessionsDir(),
 			Parser: agent.JSONLineParser{
 				NewParser: func() agent.LineParser { return &Parser{} },
 			},


### PR DESCRIPTION
## Summary

- Three coding-agent adapters now respect their upstream env-var convention for relocating session transcripts:
  - **Pi** → `PI_CODING_AGENT_SESSION_DIR` (the absolute session dir itself)
  - **Claude Code** → `CLAUDE_CONFIG_DIR` (`/projects` appended; transcripts only — see notes)
  - **Codex** → `CODEX_HOME` (`/sessions` appended)
- `fswatcher.New` treats an absolute `dir` as-is and falls back to `$HOME`-relative for relative paths. One small seam, no caller signature change.
- Non-absolute env values (relative paths, unexpanded `~`, trailing slashes) are `filepath.Clean`-ed and rejected with a `log.Printf` warning so a misconfigured path surfaces in logs instead of silently watching the wrong place.
- Default-install behavior is unchanged.

Fixes #349.

## Test plan

- [x] `go test ./core/... -race -count=1` — all packages green
- [x] `tools/replay-fixtures.sh` — clean
- [x] Per-adapter unit tests cover: empty/default fallback, absolute override, trailing-slash cleaning, relative reject, tilde reject
- [x] `fswatcher` tests cover absolute-vs-relative path resolution
- [ ] Manual: `export PI_CODING_AGENT_SESSION_DIR=/tmp/pi-sessions && mkdir -p /tmp/pi-sessions`, restart daemon, start a Pi session, confirm it appears in the dashboard

## Notes

- **Env vars read once at `Agent()` construction (daemon startup).** A daemon restart is required after changing them.
- **`CLAUDE_CONFIG_DIR` scope** — officially undocumented. Third-party tooling (ccusage) treats `projects/` as relocating under it, so transcript discovery follows that. The PID-metadata directory (`~/.claude/sessions/`) is **not** moved here — behavior is unverified, so `pid.go` intentionally keeps the hardcoded path. This is documented in the `configDirEnvVar` doc-comment.
- **Codex `CODEX_HOME` semantics** assumed to follow the convention `$CODEX_HOME/sessions` (matching today's `~/.codex/sessions`). If upstream Codex ever points the env var at the session dir directly, that's a one-line follow-up.
- **Aider / OpenCode** intentionally untouched: aider is per-CWD (no root to override); opencode uses XDG via SQLite and isn't on the same hardcoded-path pattern.

## Commits

1. `fix(adapters): honor agent-CLI env vars for relocated session dirs (#349)` — initial change
2. `review fixups: validate env values, revert unverified CLAUDE_CONFIG_DIR/sessions` — `filepath.Clean` + non-absolute rejection; reverted unverified PID-metadata hunk
3. `simplify: trim WHAT-narrating bits from env-helper doc comments`

🤖 Generated with [Claude Code](https://claude.com/claude-code)