### PR TITLE
fix(codex): attribute split-event token_count to session model (#361)

### DIFF
--- a/core/pkg/tailer/cost_test.go
+++ b/core/pkg/tailer/cost_test.go
@@ -563,6 +563,99 @@ func TestCost_LedgerState_RestartPreservesCumulative(t *testing.T) {
 	}
 }
 
+// TestCost_ApplyContribution_FallbackToMetricsModelName covers the codex
+// split-event case from issue #361: a turn_context event sets the model, then
+// a later token_count event emits a PerTurnContribution with Model="". The
+// fallback in applyContribution must route that contribution under the
+// session's known ModelName so it gets priced.
+func TestCost_ApplyContribution_FallbackToMetricsModelName(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		// Mimics codex turn_context: model only, no usage.
+		{
+			"type": "assistant", "timestamp": ts(0),
+			"message": map[string]interface{}{"model": "gpt-5.4"},
+		},
+		// Mimics codex token_count: usage only, no model. testParser emits
+		// Contribution{Model: ""} for this event.
+		{
+			"type": "assistant", "timestamp": ts(1),
+			"cumulative_usage": map[string]interface{}{
+				"input_tokens": float64(1000), "output_tokens": float64(200),
+			},
+		},
+	})
+
+	tl := newTestTailer(path)
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m.ModelName != "gpt-5.4" {
+		t.Fatalf("ModelName = %q, want gpt-5.4", m.ModelName)
+	}
+	if m.CumInputTokens != 1000 {
+		t.Errorf("CumInputTokens = %d, want 1000", m.CumInputTokens)
+	}
+	if m.CumOutputTokens != 200 {
+		t.Errorf("CumOutputTokens = %d, want 200", m.CumOutputTokens)
+	}
+	// gpt-5.4 pricing in the fixture: $2/Mtok input, $8/Mtok output.
+	// 1000 * 2/1e6 + 200 * 8/1e6 = 0.002 + 0.0016 = 0.0036
+	if m.EstimatedCostUSD <= 0 {
+		t.Errorf("EstimatedCostUSD = %f, want > 0 (model fallback should price the contribution; see #361)", m.EstimatedCostUSD)
+	}
+}
+
+// TestCost_LedgerState_RestartPreservesModelName covers the restart half of
+// issue #361. After a daemon restart mid-session, the next event in the file
+// may be a token_count (usage only, no model) before the next turn_context.
+// The ledger must round-trip ModelName so the applyContribution fallback in
+// the rehydrated tailer still routes the contribution to a priced bucket.
+func TestCost_LedgerState_RestartPreservesModelName(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{
+			"type": "assistant", "timestamp": ts(0),
+			"message": map[string]interface{}{"model": "gpt-5.4"},
+		},
+	})
+
+	tl1 := newTestTailer(path)
+	_, err := tl1.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledger := tl1.GetLedgerState()
+	if ledger.ModelName != "gpt-5.4" {
+		t.Fatalf("ledger ModelName = %q, want gpt-5.4", ledger.ModelName)
+	}
+
+	// Append a token_count-style event after the restart boundary.
+	appendTranscriptLine(t, path, map[string]interface{}{
+		"type": "assistant", "timestamp": ts(1),
+		"cumulative_usage": map[string]interface{}{
+			"input_tokens": float64(500), "output_tokens": float64(100),
+		},
+	})
+
+	tl2 := newTestTailer(path)
+	tl2.SetLedgerState(ledger)
+	m2, err := tl2.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m2.ModelName != "gpt-5.4" {
+		t.Errorf("after restart: ModelName = %q, want gpt-5.4 (must be restored from ledger)", m2.ModelName)
+	}
+	if m2.CumInputTokens != 500 {
+		t.Errorf("after restart: CumInputTokens = %d, want 500", m2.CumInputTokens)
+	}
+	if m2.EstimatedCostUSD <= 0 {
+		t.Errorf("after restart: EstimatedCostUSD = %f, want > 0 (ledger-restored model should price the contribution)", m2.EstimatedCostUSD)
+	}
+}
+
 // TestCost_LedgerState_NoDoubleCountOnRehydrate verifies that SetLedgerState
 // with a non-zero LastOffset causes the tailer to resume from that offset rather
 // than re-reading from byte 0, so already-accumulated turns are not re-priced.

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -240,6 +240,11 @@ type LedgerState struct {
 	CumProviderCostUSD float64                    `json:"cum_provider_cost_usd,omitempty"`
 	ParserState        *ParserLedger              `json:"parser_state,omitempty"`
 	Tasks              []Task                     `json:"tasks,omitempty"`
+	// ModelName is the last observed model for the session. Persisted so that
+	// applyContribution's fallback (used when a contribution event carries no
+	// model — codex token_count) still routes to the right pricing bucket
+	// after a daemon restart, before the next model-bearing event arrives.
+	ModelName string `json:"model_name,omitempty"`
 }
 
 // --- Shared helpers used by multiple parsers ---

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -267,6 +267,7 @@ func (t *TranscriptTailer) GetLedgerState() LedgerState {
 		SchemaVersion:      2,
 		LastOffset:         t.lastOffset,
 		CumProviderCostUSD: t.cumProviderCostUSD,
+		ModelName:          t.metrics.ModelName,
 	}
 	if len(t.cumByModel) > 0 {
 		// Direct assignment is safe: the caller JSON-marshals immediately
@@ -303,6 +304,9 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 		}
 	}
 	t.cumProviderCostUSD = s.CumProviderCostUSD
+	if s.ModelName != "" {
+		t.metrics.ModelName = s.ModelName
+	}
 	if s.ParserState != nil {
 		if pp, ok := t.parser.(ParserStateProvider); ok {
 			pp.SetParserLedger(*s.ParserState)

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -70,18 +70,27 @@ func (t *TranscriptTailer) accumulateTokens(parsed *ParsedEvent) {
 // applyContribution handles the new Phase-2+ path where the adapter already
 // deduped and handed us a finalized per-turn contribution. Provider-reported
 // USD cost wins; otherwise we accumulate tokens into the per-model breakdown.
+//
+// When the contribution carries no Model (codex token_count events split the
+// model name onto a separate turn_context event), fall back to the session's
+// current ModelName from applyModelMetadata so the delta still lands under
+// a priced bucket instead of cumByModel[""].
 func (t *TranscriptTailer) applyContribution(c *PerTurnContribution) {
 	if c.ProviderCostUSD != nil {
 		t.cumProviderCostUSD += *c.ProviderCostUSD
 		return
 	}
-	if c.Model == "" && c.Usage.Input == 0 && c.Usage.Output == 0 {
+	model := c.Model
+	if model == "" {
+		model = t.metrics.ModelName
+	}
+	if model == "" && c.Usage.Input == 0 && c.Usage.Output == 0 {
 		return
 	}
-	bd := t.cumByModel[c.Model]
+	bd := t.cumByModel[model]
 	if bd == nil {
 		bd = &UsageBreakdown{}
-		t.cumByModel[c.Model] = bd
+		t.cumByModel[model] = bd
 	}
 	bd.Input += c.Usage.Input
 	bd.Output += c.Usage.Output

--- a/replaydata/agents/codex/scenarios/02-flicker-start-session/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/02-flicker-start-session/transcript.jsonl.replay.json.golden
@@ -25,6 +25,7 @@
     "flickers_by_reason": {
       "force ready→working on first activity": 2
     },
+    "estimated_cost_usd": 2.8542325,
     "cum_input_tokens": 1094023,
     "cum_output_tokens": 7945,
     "model_name": "gpt-5.4"

--- a/replaydata/agents/codex/scenarios/agent-question-pending/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/agent-question-pending/transcript.jsonl.replay.json.golden
@@ -20,6 +20,7 @@
     "flicker_count": 0,
     "flickers_by_category": {},
     "flickers_by_reason": {},
+    "estimated_cost_usd": 0.0600875,
     "cum_input_tokens": 23729,
     "cum_output_tokens": 51,
     "model_name": "gpt-5.4"

--- a/replaydata/agents/codex/scenarios/baseline-hello/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/baseline-hello/transcript.jsonl.replay.json.golden
@@ -20,6 +20,7 @@
     "flicker_count": 0,
     "flickers_by_category": {},
     "flickers_by_reason": {},
+    "estimated_cost_usd": 0.0596825,
     "cum_input_tokens": 23717,
     "cum_output_tokens": 26,
     "model_name": "gpt-5.4"

--- a/replaydata/agents/codex/scenarios/full-lifecycle-toolcall/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/full-lifecycle-toolcall/transcript.jsonl.replay.json.golden
@@ -25,6 +25,7 @@
     "flickers_by_reason": {
       "force ready→working on first activity": 1
     },
+    "estimated_cost_usd": 0.121735,
     "cum_input_tokens": 47662,
     "cum_output_tokens": 172,
     "model_name": "gpt-5.4"

--- a/replaydata/agents/codex/scenarios/interrupted-turn/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/interrupted-turn/transcript.jsonl.replay.json.golden
@@ -21,6 +21,7 @@
     "flicker_count": 0,
     "flickers_by_category": {},
     "flickers_by_reason": {},
+    "estimated_cost_usd": 0.061735,
     "cum_input_tokens": 24568,
     "cum_output_tokens": 21,
     "model_name": "gpt-5.4"

--- a/replaydata/agents/codex/scenarios/multi-turn-conversation/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/multi-turn-conversation/transcript.jsonl.replay.json.golden
@@ -21,6 +21,7 @@
     "flicker_count": 0,
     "flickers_by_category": {},
     "flickers_by_reason": {},
+    "estimated_cost_usd": 0.18477,
     "cum_input_tokens": 73554,
     "cum_output_tokens": 59,
     "model_name": "gpt-5.4"


### PR DESCRIPTION
## Summary
- Codex sessions reported `$0` cost because the parser emitted `PerTurnContribution{Model: ""}` on every `token_count` event — codex splits the model name onto `turn_context` and the usage cursor onto `token_count`. The tailer then bucketed deltas under `cumByModel[""]`, which has no pricing.
- In `applyContribution`, fall back to `t.metrics.ModelName` (already maintained by `applyModelMetadata` from `turn_context`) when the contribution carries no model. Single source of truth — pricing and the UI's model display now read the same field by construction.
- `LedgerState` persists `ModelName` so the fallback still works on the first `token_count` after a daemon restart (when the next `turn_context` might not arrive until the following turn boundary).

Fixes #361.

## Test plan
- [x] Two new unit tests in `core/pkg/tailer/cost_test.go`:
  - `TestCost_ApplyContribution_FallbackToMetricsModelName` — split-event ordering, asserts the contribution lands in a priced bucket.
  - `TestCost_LedgerState_RestartPreservesModelName` — `LedgerState` round-trip; rehydrated tailer prices the post-restart `token_count`.
- [x] `go test ./core/... -race -count=1` — all packages green.
- [x] `tools/replay-fixtures.sh` — green.
- [x] Six codex replay goldens regenerated with `UPDATE_REPLAY_GOLDENS=1`:
  - `02-flicker-start-session $2.85`, `agent-question-pending $0.06`, `baseline-hello $0.06`, `full-lifecycle-toolcall $0.12`, `interrupted-turn $0.06`, `multi-turn-conversation $0.18`.
  - `proposed-plan-pending` stays uncosted because its model (`gpt-5.2-codex`) isn't in the LiteLLM cache — the explicit out-of-scope case in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)