### PR TITLE
chore(cask): bump v0.4.4 DMG sha256 after re-spin

### DIFF
--- a/tools/homebrew-tap/Casks/irrlicht.rb
+++ b/tools/homebrew-tap/Casks/irrlicht.rb
@@ -1,6 +1,6 @@
 cask "irrlicht" do
   version "0.4.4"
-  sha256 "d09cd1b248cbd3b1e8ba075239fc41de1242d73c93827928e784ed678cefe363"
+  sha256 "6ea43f76186abe848d1fe884a3763bc1aac3c0ff1c98acda4bd567af24a2a2a4"
 
   url "https://github.com/ingo-eichhorst/Irrlicht/releases/download/v#{version}/Irrlicht-#{version}.dmg",
       verified: "github.com/ingo-eichhorst/Irrlicht/"


### PR DESCRIPTION
## Summary

- Re-spun v0.4.4 DMG to include \`Contents/Resources/web/index.html\` (missing in original assets — every install hit the 503 \"Dashboard UI not found\" fallback at \`http://127.0.0.1:7837/\`).
- GitHub release assets replaced via \`gh release upload --clobber\`.
- External tap \`ingo-eichhorst/homebrew-irrlicht\` already pushed by \`update-cask.sh --push\`; this PR brings the in-repo template in sync.

Old DMG sha256: \`d09cd1b248cbd3b1e8ba075239fc41de1242d73c93827928e784ed678cefe363\`
New DMG sha256: \`6ea43f76186abe848d1fe884a3763bc1aac3c0ff1c98acda4bd567af24a2a2a4\`

Skill fix that prevents recurrence: PR #367.

## Test plan

- [x] DMG rebuilt with web/index.html present (verified by mounting + \`ls\`).
- [x] All 5 release assets re-uploaded; checksums.sha256 regenerated.
- [x] External tap pushed (\`e73d038 irrlicht 0.4.4\`).
- [ ] Validate post-install: \`brew install --cask irrlicht\` → \`curl -fsS http://127.0.0.1:7837/ | grep -q '<title>'\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)