### PR TITLE
fix(web): migrate sessions when project_name lands after first push

### DIFF
--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -1548,6 +1548,31 @@
         if (wn && !a.worker_name) a.worker_name = wn;
         if (wid && !a.worker_id) a.worker_id = wid;
         a.children = ch;
+        // Migrate the agent if its project_name now points at a different
+        // group than where it currently lives. Without this, sessions whose
+        // first WS push arrived before metadata enrichment landed (empty
+        // project_name → "unknown" bucket) stay stranded there forever even
+        // after later updates carry the correct name. Children inherit their
+        // parent's group, so only migrate top-level entries.
+        if (!entry.parent) {
+          var desired = a.project_name || 'unknown';
+          if (entry.group.name !== desired) {
+            var oldGroup = entry.group;
+            var ai = oldGroup.agents.findIndex(x => x.session_id === s.session_id);
+            if (ai >= 0) oldGroup.agents.splice(ai, 1);
+            var target = dashboardGroups.find(g => g.name === desired);
+            if (!target) {
+              target = {name: desired, agents: []};
+              dashboardGroups.push(target);
+            }
+            target.agents.push(a);
+            entry.group = target;
+            if (oldGroup.agents.length === 0) {
+              var gi = dashboardGroups.indexOf(oldGroup);
+              if (gi >= 0) dashboardGroups.splice(gi, 1);
+            }
+          }
+        }
         maybeNotifyOnUpdate(prevSnap, a);
         return;
       }

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -1567,6 +1567,11 @@
             }
             target.agents.push(a);
             entry.group = target;
+            // Children's sessionIndex entries still point at the old group;
+            // refresh them so any future site that reads child.entry.group
+            // (e.g. a parent-deletion cleanup that drills into children)
+            // doesn't follow a reference to a group we just spliced out.
+            indexChildren(target, a);
             if (oldGroup.agents.length === 0) {
               var gi = dashboardGroups.indexOf(oldGroup);
               if (gi >= 0) dashboardGroups.splice(gi, 1);


### PR DESCRIPTION
## Summary

- Web dashboard sessions whose first `session_created` WS push arrived with an empty `project_name` (because git metadata enrichment hadn't run yet) were placed in the `unknown` bucket and stayed there forever — later `session_updated` pushes carried the correct name but `applySessionUpdate` only field-merged via `Object.assign`, never reconciling group membership.
- The macOS menu bar avoided this because `patchApiGroups` schedules a full re-hydration on a missed id, which rebuilds the group tree from the daemon's authoritative `BuildDashboard` output. The web had no equivalent path.
- Fix: in `applySessionUpdate`, after merging the update onto an existing top-level entry, detect when its current group no longer matches the latest `project_name`, splice it out, find-or-create the target group, and prune the source group if it goes empty (mirroring `applySessionDelete`).

## Test plan

- [x] `go test ./core/... -race -count=1` passes (the one observed failure was a pre-existing timestamp-sensitive flake — re-ran in isolation, green).
- [x] `tools/replay-fixtures.sh` green.
- [x] Inline `<script>` block in `platforms/web/index.html` parses (`new Function(body)` check).
- [ ] Manual: open the dashboard while a session is starting (process-scanner pre-session → transcript-new) and confirm it lands directly in the project group rather than `unknown`. Existing stranded "unknown" rows clear on next `session_updated` after this PR ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)