### PR TITLE
feat(quota): surface Pro/Max burn-rate forecast in macOS overlay (#309)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/statusline.go
+++ b/core/adapters/inbound/agents/claudecode/statusline.go
@@ -1,0 +1,136 @@
+// statusline.go provides the HTTP handler for receiving Claude Code's
+// statusline JSON. Claude Code is configured (via settings.json's
+// statusLine.command) to pipe the statusline payload to a curl that POSTs
+// here. The handler extracts rate_limits (subscription quota data only
+// available to Claude.ai Pro/Max users) and pushes the snapshot through
+// to the tailer for the matching session.
+//
+// Statusline JSON shape (Pro/Max account):
+//
+//	{
+//	  "session_id":     "...",
+//	  "transcript_path":"/path/to/session.jsonl",
+//	  "rate_limits": {
+//	    "five_hour": { "used_percentage": 16,    "resets_at": 1778761800 },
+//	    "seven_day": { "used_percentage": 14.0,  "resets_at": 1779188400 }
+//	  }
+//	}
+//
+// API-key users, Bedrock, and Vertex don't get the rate_limits block — the
+// handler simply records nothing in that case.
+package claudecode
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// statuslineNow is a package-level clock the handler uses to stamp incoming
+// snapshots. Indirected so tests can pin time deterministically.
+var statuslineNow = time.Now
+
+// statuslinePayload models the fields the handler reads from Claude Code's
+// statusline JSON. Anything outside `rate_limits` is currently ignored.
+type statuslinePayload struct {
+	SessionID      string                  `json:"session_id"`
+	TranscriptPath string                  `json:"transcript_path"`
+	RateLimits     *statuslineRateLimits   `json:"rate_limits,omitempty"`
+}
+
+// statuslineRateLimits mirrors the on-the-wire shape Claude Code sends —
+// flat `five_hour` / `seven_day` keys (subset of the Codex schema). The
+// 7-day percentage often carries floating-point noise (14.000000000000002);
+// we keep it as-is and let the UI round.
+type statuslineRateLimits struct {
+	FiveHour *statuslineWindow `json:"five_hour,omitempty"`
+	SevenDay *statuslineWindow `json:"seven_day,omitempty"`
+}
+
+type statuslineWindow struct {
+	UsedPercentage float64 `json:"used_percentage"`
+	ResetsAt       int64   `json:"resets_at"`
+}
+
+// RateLimitTarget is the narrow interface the statusline handler depends on.
+// Satisfied by outbound.MetricsCollector — broken out so tests can supply a
+// fake without depending on the broader port surface.
+type RateLimitTarget interface {
+	IngestRateLimit(transcriptPath string, snap *session.RateLimitSnapshot)
+}
+
+// NewStatuslineHandler returns the HTTP handler for
+// POST /api/v1/hooks/claudecode/statusline. The handler returns 200 with an
+// empty body on success; on bad input or missing transcript_path it returns
+// the appropriate 4xx. It never blocks: target.IngestRateLimit is a no-op
+// when the session hasn't been seen yet, so the handler returns immediately.
+func NewStatuslineHandler(target RateLimitTarget, log outbound.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var payload statuslinePayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
+			return
+		}
+
+		if payload.TranscriptPath == "" {
+			http.Error(w, "bad request: missing transcript_path", http.StatusBadRequest)
+			return
+		}
+
+		sessionID := sessionIDFromTranscriptPath(payload.TranscriptPath)
+		snap := statuslineToSnapshot(payload.RateLimits)
+		if snap == nil {
+			// API-key / Bedrock / Vertex users — nothing to record. Ack and move on.
+			log.LogInfo("statusline-receiver", sessionID, "received statusline tick with no rate_limits block")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		target.IngestRateLimit(payload.TranscriptPath, snap)
+		log.LogInfo("statusline-receiver", sessionID, "ingested rate-limit snapshot")
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// statuslineToSnapshot converts Claude Code's two-window statusline payload
+// into the domain RateLimitSnapshot shape. Returns nil when both windows
+// are absent — the API-key / no-subscription case.
+//
+// Mapping:
+//   - five_hour → WindowMinutes=300
+//   - seven_day → WindowMinutes=10080
+//
+// SampledAt is derived from statuslineNow() rather than any payload
+// timestamp: Claude Code's statusline JSON doesn't carry one, and the
+// request landed within the last few hundred milliseconds.
+func statuslineToSnapshot(rl *statuslineRateLimits) *session.RateLimitSnapshot {
+	if rl == nil || (rl.FiveHour == nil && rl.SevenDay == nil) {
+		return nil
+	}
+	snap := &session.RateLimitSnapshot{
+		SampledAt: statuslineNow().Unix(),
+	}
+	if rl.FiveHour != nil {
+		snap.Windows = append(snap.Windows, session.RateLimitWindow{
+			UsedPercent:   rl.FiveHour.UsedPercentage,
+			WindowMinutes: 300,
+			ResetsAt:      rl.FiveHour.ResetsAt,
+		})
+	}
+	if rl.SevenDay != nil {
+		snap.Windows = append(snap.Windows, session.RateLimitWindow{
+			UsedPercent:   rl.SevenDay.UsedPercentage,
+			WindowMinutes: 10080,
+			ResetsAt:      rl.SevenDay.ResetsAt,
+		})
+	}
+	return snap
+}

--- a/core/adapters/inbound/agents/claudecode/statusline_installer.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_installer.go
@@ -1,0 +1,167 @@
+// statusline_installer.go manages the Claude Code statusLine.command entry in
+// ~/.claude/settings.json. Claude Code pipes statusline JSON to stdin of the
+// configured command on every assistant message / mode toggle / /compact —
+// the data carries rate_limits for Pro/Max users, which the daemon ingests
+// via POST /api/v1/hooks/claudecode/statusline (issue #309).
+package claudecode
+
+import (
+	"strings"
+)
+
+// statuslineSentinel is the substring that identifies an irrlicht-managed
+// statusline command. Used for idempotency checks and chained-command
+// upgrades.
+const statuslineSentinel = "localhost:7837/api/v1/hooks/claudecode/statusline"
+
+// installedStatuslineCommand is the canonical statusLine.command we install.
+// Reads the statusline JSON from stdin, POSTs it to the daemon, then echoes
+// nothing (so the menu-bar / terminal-prompt statusline area stays empty —
+// the user already sees per-session data in the irrlicht overlay).
+//
+// `tee` duplicates stdin so a user-configured chained command can still run
+// downstream when we wrap an existing entry (see chainStatuslineCommand).
+// Flags mirror the hook command:
+//   - -fsS  : fail silently on HTTP errors, but show curl errors on stderr
+//   - --max-time 1 : abort if the daemon is unreachable, keeps statusline snappy
+//   - || true: don't surface non-zero exit (e.g. daemon down) to Claude Code
+const installedStatuslineCommand = "curl -fsS --max-time 1 -X POST --data-binary @- " +
+	"http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true"
+
+// EnsureStatuslineInstalled adds (or upgrades) the statusLine.command entry
+// in ~/.claude/settings.json. Returns true when the file was modified.
+//
+// Idempotency rules:
+//   - If statusLine is absent, install it with our canonical command.
+//   - If statusLine.command equals our canonical command verbatim, no-op.
+//   - If statusLine.command contains our sentinel but differs from the
+//     canonical form, rewrite in place (migration path).
+//   - If statusLine.command is set to a third-party command (no sentinel),
+//     wrap it: pipe stdin through `tee` to both the user's command and ours.
+//     The user's statusline output is preserved.
+func EnsureStatuslineInstalled() (bool, error) {
+	path, err := claudeSettingsPath()
+	if err != nil {
+		return false, err
+	}
+
+	settings, err := readClaudeSettings(path)
+	if err != nil {
+		return false, err
+	}
+
+	current := readStatuslineCommand(settings)
+	desired := chainStatuslineCommand(current)
+
+	if current == desired {
+		return false, nil
+	}
+	writeStatuslineCommand(settings, desired)
+	return true, writeClaudeSettings(path, settings)
+}
+
+// UninstallStatusline removes the irrlicht statusline entry. When the entry
+// was a chained wrap, the user's original command is restored; when it was
+// our standalone install, statusLine is removed entirely.
+func UninstallStatusline() (bool, error) {
+	path, err := claudeSettingsPath()
+	if err != nil {
+		return false, err
+	}
+
+	settings, err := readClaudeSettings(path)
+	if err != nil {
+		return false, err
+	}
+
+	current := readStatuslineCommand(settings)
+	if current == "" || !strings.Contains(current, statuslineSentinel) {
+		return false, nil
+	}
+
+	user := unchainStatuslineCommand(current)
+	if user == "" {
+		// Standalone install — drop the whole statusLine block.
+		delete(settings, "statusLine")
+	} else {
+		writeStatuslineCommand(settings, user)
+	}
+	return true, writeClaudeSettings(path, settings)
+}
+
+// readStatuslineCommand returns settings.statusLine.command when present,
+// otherwise empty. Tolerates the entry being either a plain string (legacy
+// older Claude Code versions) or the canonical { "type": "command",
+// "command": "…" } object form.
+func readStatuslineCommand(settings map[string]interface{}) string {
+	sl, ok := settings["statusLine"]
+	if !ok {
+		return ""
+	}
+	switch v := sl.(type) {
+	case string:
+		return v
+	case map[string]interface{}:
+		if cmd, ok := v["command"].(string); ok {
+			return cmd
+		}
+	}
+	return ""
+}
+
+// writeStatuslineCommand sets settings.statusLine to the canonical object
+// form ({"type":"command","command":cmd}), replacing whatever was there.
+func writeStatuslineCommand(settings map[string]interface{}, cmd string) {
+	settings["statusLine"] = map[string]interface{}{
+		"type":    "command",
+		"command": cmd,
+	}
+}
+
+// chainStatuslineCommand returns the command to install given the current
+// configured command.
+//
+//   - "" (nothing configured) → install our standalone command.
+//   - already-our-canonical → return as-is (caller treats as no-op).
+//   - contains our sentinel but isn't canonical → return canonical (rewrite).
+//   - some other command → wrap with tee so both ours and theirs receive stdin.
+//
+// The wrap form is:
+//
+//	tee >(<user command>) | curl -fsS … >/dev/null 2>&1 || true
+//
+// `tee >(…)` duplicates stdin to the user's process; the second branch flows
+// through the pipeline to curl. Bash process substitution is bash-only, but
+// Claude Code already invokes statusLine.command via bash on macOS/Linux.
+func chainStatuslineCommand(current string) string {
+	if current == "" || current == installedStatuslineCommand {
+		return installedStatuslineCommand
+	}
+	if strings.Contains(current, statuslineSentinel) {
+		// Already managed by us; force back to canonical form (and drop any
+		// stale wrap of a removed user command).
+		return installedStatuslineCommand
+	}
+	// Wrap: user's command runs alongside ours via process substitution.
+	return "tee >(" + current + ") | curl -fsS --max-time 1 -X POST --data-binary @- " +
+		"http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true"
+}
+
+// unchainStatuslineCommand returns the user's original command when current
+// was a chained wrap, or "" when current is our standalone install. Used by
+// uninstall to restore the prior state.
+func unchainStatuslineCommand(current string) string {
+	const prefix = "tee >("
+	if !strings.HasPrefix(current, prefix) {
+		return ""
+	}
+	rest := current[len(prefix):]
+	// Find the matching close paren of `tee >(...)`. The user's command
+	// shouldn't contain an unbalanced ")"; if it does, we conservatively
+	// give up on round-tripping and return empty.
+	end := strings.Index(rest, ") | curl ")
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}

--- a/core/adapters/inbound/agents/claudecode/statusline_installer.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_installer.go
@@ -124,44 +124,73 @@ func writeStatuslineCommand(settings map[string]interface{}, cmd string) {
 //   - "" (nothing configured) → install our standalone command.
 //   - already-our-canonical → return as-is (caller treats as no-op).
 //   - contains our sentinel but isn't canonical → return canonical (rewrite).
-//   - some other command → wrap with tee so both ours and theirs receive stdin.
+//   - some other command → wrap so both ours and theirs receive stdin.
 //
-// The wrap form is:
+// The wrap form uses `bash -c` explicitly because Claude Code invokes
+// statusLine.command via POSIX `sh` on Unix, and the process substitution
+// (`tee >(…)`) we rely on to duplicate stdin is bash-only. Without the
+// `bash -c` envelope, `sh` errors at parse time and the entire pipeline
+// (including our curl) never runs.
+//
+// Internal shape, inside `bash -c "…"`:
 //
 //	tee >(<user command>) | curl -fsS … >/dev/null 2>&1 || true
 //
-// `tee >(…)` duplicates stdin to the user's process; the second branch flows
-// through the pipeline to curl. Bash process substitution is bash-only, but
-// Claude Code already invokes statusLine.command via bash on macOS/Linux.
+// The user's command sees a copy of stdin via `tee`; the trailing curl
+// branch carries stdin onward to our endpoint. The `|| true` keeps the
+// overall command status zero so Claude Code doesn't surface a failure.
 func chainStatuslineCommand(current string) string {
 	if current == "" || current == installedStatuslineCommand {
 		return installedStatuslineCommand
 	}
+	// If current is already a managed wrap (old or new format), unchain to
+	// recover the user's original command, then re-chain in the canonical
+	// new format. This is the migration path from the v1 wrap (no `bash -c`
+	// envelope, which silently failed under POSIX sh) to the v2 wrap that
+	// works regardless of which shell Claude Code invokes us through.
+	if user := unchainStatuslineCommand(current); user != "" {
+		return wrapStatuslineCommand(user)
+	}
 	if strings.Contains(current, statuslineSentinel) {
-		// Already managed by us; force back to canonical form (and drop any
-		// stale wrap of a removed user command).
+		// Managed standalone — no user command to preserve. Force canonical.
 		return installedStatuslineCommand
 	}
-	// Wrap: user's command runs alongside ours via process substitution.
-	return "tee >(" + current + ") | curl -fsS --max-time 1 -X POST --data-binary @- " +
-		"http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true"
+	// Pure user command — wrap it.
+	return wrapStatuslineCommand(current)
+}
+
+// wrapStatuslineCommand builds the canonical chained form for the given
+// user command. Single-quotes inside the user's command are escaped so the
+// command can be embedded in `bash -c '…'` without breaking quoting.
+func wrapStatuslineCommand(user string) string {
+	escaped := strings.ReplaceAll(user, "'", `'\''`)
+	return `bash -c 'tee >(` + escaped + `) | curl -fsS --max-time 1 -X POST --data-binary @- ` +
+		`http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true'`
 }
 
 // unchainStatuslineCommand returns the user's original command when current
-// was a chained wrap, or "" when current is our standalone install. Used by
-// uninstall to restore the prior state.
+// was a chained wrap, or "" otherwise (standalone install, unknown shape).
+//
+// Recognises both wrap formats:
+//   - v1 (broken under sh): `tee >(<user>) | curl … sentinel … || true`
+//   - v2 (canonical):       `bash -c 'tee >(<user>) | curl … sentinel … || true'`
+//
+// The v1 form is still recognised for migration; new installs always emit v2.
 func unchainStatuslineCommand(current string) string {
-	const prefix = "tee >("
-	if !strings.HasPrefix(current, prefix) {
-		return ""
+	for _, prefix := range []string{`bash -c 'tee >(`, `tee >(`} {
+		if !strings.HasPrefix(current, prefix) {
+			continue
+		}
+		rest := current[len(prefix):]
+		end := strings.Index(rest, `) | curl `)
+		if end < 0 {
+			continue
+		}
+		inner := rest[:end]
+		// Reverse the single-quote escaping for v2 wraps; v1 wraps were
+		// never escaped, but the replace is a safe no-op when no escapes
+		// are present.
+		return strings.ReplaceAll(inner, `'\''`, "'")
 	}
-	rest := current[len(prefix):]
-	// Find the matching close paren of `tee >(...)`. The user's command
-	// shouldn't contain an unbalanced ")"; if it does, we conservatively
-	// give up on round-tripping and return empty.
-	end := strings.Index(rest, ") | curl ")
-	if end < 0 {
-		return ""
-	}
-	return rest[:end]
+	return ""
 }

--- a/core/adapters/inbound/agents/claudecode/statusline_installer.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_installer.go
@@ -6,8 +6,15 @@
 package claudecode
 
 import (
+	"regexp"
 	"strings"
 )
+
+// unchainBoundary matches the boundary between the user's tee-fed
+// command and our trailing curl pipeline. Whitespace-tolerant so a
+// hand-edited wrap with extra spaces still round-trips through
+// unchainStatuslineCommand.
+var unchainBoundary = regexp.MustCompile(`\)\s*\|\s*curl\s`)
 
 // statuslineSentinel is the substring that identifies an irrlicht-managed
 // statusline command. Used for idempotency checks and chained-command
@@ -182,11 +189,16 @@ func unchainStatuslineCommand(current string) string {
 			continue
 		}
 		rest := current[len(prefix):]
-		end := strings.Index(rest, `) | curl `)
-		if end < 0 {
+		// Whitespace-tolerant match for `) | curl ` so a hand-edited
+		// wrap (e.g. with extra spaces around the pipe) still unwinds
+		// cleanly. The first match wins — user commands containing a
+		// literal ") | curl " inside their own command would still
+		// round-trip wrong, but that's a pathological case.
+		loc := unchainBoundary.FindStringIndex(rest)
+		if loc == nil {
 			continue
 		}
-		inner := rest[:end]
+		inner := rest[:loc[0]]
 		// Reverse the single-quote escaping for v2 wraps; v1 wraps were
 		// never escaped, but the replace is a safe no-op when no escapes
 		// are present.

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -1,0 +1,179 @@
+package claudecode
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+type fakeRateLimitTarget struct {
+	calls []rateLimitCall
+}
+
+type rateLimitCall struct {
+	path string
+	snap *session.RateLimitSnapshot
+}
+
+func (f *fakeRateLimitTarget) IngestRateLimit(path string, snap *session.RateLimitSnapshot) {
+	f.calls = append(f.calls, rateLimitCall{path: path, snap: snap})
+}
+
+type silentLogger struct{}
+
+func (silentLogger) LogInfo(string, string, string)                     {}
+func (silentLogger) LogError(string, string, string)                    {}
+func (silentLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (silentLogger) Close() error                                       { return nil }
+
+func TestStatuslineHandler_IngestsRateLimits(t *testing.T) {
+	target := &fakeRateLimitTarget{}
+	h := NewStatuslineHandler(target, silentLogger{})
+
+	body := `{
+		"session_id": "abc",
+		"transcript_path": "/tmp/sessions/abc.jsonl",
+		"rate_limits": {
+			"five_hour": {"used_percentage": 47, "resets_at": 1778761800},
+			"seven_day": {"used_percentage": 14.0, "resets_at": 1779188400}
+		}
+	}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/hooks/claudecode/statusline", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", rr.Code, rr.Body.String())
+	}
+	if len(target.calls) != 1 {
+		t.Fatalf("expected one IngestRateLimit call, got %d", len(target.calls))
+	}
+	call := target.calls[0]
+	if call.path != "/tmp/sessions/abc.jsonl" {
+		t.Errorf("wrong path: %s", call.path)
+	}
+	if len(call.snap.Windows) != 2 {
+		t.Fatalf("expected 2 windows, got %d", len(call.snap.Windows))
+	}
+	if call.snap.Windows[0].WindowMinutes != 300 || call.snap.Windows[0].UsedPercent != 47 {
+		t.Errorf("five_hour mapping wrong: %+v", call.snap.Windows[0])
+	}
+	if call.snap.Windows[1].WindowMinutes != 10080 {
+		t.Errorf("seven_day mapping wrong: %+v", call.snap.Windows[1])
+	}
+}
+
+func TestStatuslineHandler_NoRateLimitsBlockIsOk(t *testing.T) {
+	target := &fakeRateLimitTarget{}
+	h := NewStatuslineHandler(target, silentLogger{})
+
+	body := `{"session_id":"abc","transcript_path":"/tmp/abc.jsonl"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for API-key path (no rate_limits), got %d", rr.Code)
+	}
+	if len(target.calls) != 0 {
+		t.Fatalf("expected no IngestRateLimit calls for absent block, got %d", len(target.calls))
+	}
+}
+
+func TestStatuslineHandler_RejectsMissingTranscriptPath(t *testing.T) {
+	h := NewStatuslineHandler(&fakeRateLimitTarget{}, silentLogger{})
+	body := `{"session_id":"abc"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestStatuslineHandler_RejectsNonPost(t *testing.T) {
+	h := NewStatuslineHandler(&fakeRateLimitTarget{}, silentLogger{})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", nil)
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestStatuslineHandler_SampledAtUsesClock(t *testing.T) {
+	pinned := time.Unix(1700000000, 0).UTC()
+	prev := statuslineNow
+	statuslineNow = func() time.Time { return pinned }
+	t.Cleanup(func() { statuslineNow = prev })
+
+	target := &fakeRateLimitTarget{}
+	h := NewStatuslineHandler(target, silentLogger{})
+	body := `{"transcript_path":"/tmp/x.jsonl","rate_limits":{"five_hour":{"used_percentage":1,"resets_at":2}}}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", bytes.NewBufferString(body))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatal(rr.Body.String())
+	}
+	if target.calls[0].snap.SampledAt != pinned.Unix() {
+		t.Errorf("SampledAt = %d, want %d", target.calls[0].snap.SampledAt, pinned.Unix())
+	}
+}
+
+func TestChainStatuslineCommand_BareInstall(t *testing.T) {
+	got := chainStatuslineCommand("")
+	if got != installedStatuslineCommand {
+		t.Errorf("expected canonical command on empty input, got %q", got)
+	}
+}
+
+func TestChainStatuslineCommand_IdempotentOnCanonical(t *testing.T) {
+	got := chainStatuslineCommand(installedStatuslineCommand)
+	if got != installedStatuslineCommand {
+		t.Errorf("expected idempotency, got %q", got)
+	}
+}
+
+func TestChainStatuslineCommand_WrapsThirdPartyCommand(t *testing.T) {
+	user := "/usr/local/bin/my-statusline --foo"
+	got := chainStatuslineCommand(user)
+	if !strings.Contains(got, user) {
+		t.Errorf("expected wrap to preserve user command, got %q", got)
+	}
+	if !strings.Contains(got, statuslineSentinel) {
+		t.Errorf("expected wrap to include our sentinel, got %q", got)
+	}
+	if !strings.HasPrefix(got, "tee >(") {
+		t.Errorf("expected wrap to start with `tee >(`, got %q", got)
+	}
+}
+
+func TestChainStatuslineCommand_RewritesStaleManagedForm(t *testing.T) {
+	stale := "curl --silent " + statuslineSentinel + " /old"
+	got := chainStatuslineCommand(stale)
+	if got != installedStatuslineCommand {
+		t.Errorf("expected stale managed command to be rewritten to canonical, got %q", got)
+	}
+}
+
+func TestUnchainStatuslineCommand_RoundTripsUserCommand(t *testing.T) {
+	user := "/usr/local/bin/my-statusline --foo"
+	wrapped := chainStatuslineCommand(user)
+	if got := unchainStatuslineCommand(wrapped); got != user {
+		t.Errorf("round-trip mismatch: got %q want %q", got, user)
+	}
+}
+
+func TestUnchainStatuslineCommand_StandaloneReturnsEmpty(t *testing.T) {
+	if got := unchainStatuslineCommand(installedStatuslineCommand); got != "" {
+		t.Errorf("expected empty for standalone install, got %q", got)
+	}
+}

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -194,6 +194,46 @@ func TestChainStatuslineCommand_WrapUsesBashEnvelope(t *testing.T) {
 // On the next daemon start, we must unwrap their command and re-chain it in
 // the bash-envelope form — not overwrite it with the standalone install,
 // which would drop their original statusline script.
+// TestChainStatuslineCommand_RoundTripsSingleQuotedCommand pins the
+// escape contract. The wrap embeds the user command inside
+// `bash -c '…'`, so any single quote in the user command has to be
+// escaped (POSIX `'\''` idiom) for the wrapped form to parse, AND
+// reversed when we unchain it back. Easy to break either side.
+func TestChainStatuslineCommand_RoundTripsSingleQuotedCommand(t *testing.T) {
+	originals := []string{
+		`echo 'hello'`,
+		`bash -c 'set -e; echo ok'`,
+		`/usr/local/bin/x --flag 'a b' --other "ok"`,
+		`echo "no single quotes here"`,
+		`printf '%s\n' '<hi>'`,
+	}
+	for _, original := range originals {
+		t.Run(original, func(t *testing.T) {
+			wrapped := chainStatuslineCommand(original)
+			if !strings.HasPrefix(wrapped, `bash -c 'tee >(`) {
+				t.Fatalf("expected v2 wrap, got %q", wrapped)
+			}
+			unwrapped := unchainStatuslineCommand(wrapped)
+			if unwrapped != original {
+				t.Errorf("round-trip mismatch:\n  in:  %q\n  out: %q\n  via: %q",
+					original, unwrapped, wrapped)
+			}
+		})
+	}
+}
+
+// TestUnchainStatuslineCommand_ToleratesExtraWhitespace covers the
+// regex-based boundary detection in the unchain path. A hand-edited
+// wrap with extra spaces around the pipe should still round-trip
+// through unchain → chain.
+func TestUnchainStatuslineCommand_ToleratesExtraWhitespace(t *testing.T) {
+	hand := `bash -c 'tee >(/usr/local/bin/x)   |  curl -fsS --max-time 1 -X POST --data-binary @- ` +
+		`http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true'`
+	if got := unchainStatuslineCommand(hand); got != `/usr/local/bin/x` {
+		t.Errorf("expected user command despite extra whitespace, got %q", got)
+	}
+}
+
 func TestChainStatuslineCommand_MigratesV1WrapToV2(t *testing.T) {
 	userCmd := "bash ~/.claude/interplay-statusline.sh"
 	v1 := "tee >(" + userCmd + ") | curl -fsS --max-time 1 -X POST --data-binary @- " +

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -151,8 +151,8 @@ func TestChainStatuslineCommand_WrapsThirdPartyCommand(t *testing.T) {
 	if !strings.Contains(got, statuslineSentinel) {
 		t.Errorf("expected wrap to include our sentinel, got %q", got)
 	}
-	if !strings.HasPrefix(got, "tee >(") {
-		t.Errorf("expected wrap to start with `tee >(`, got %q", got)
+	if !strings.HasPrefix(got, `bash -c 'tee >(`) {
+		t.Errorf("expected wrap to start with `bash -c 'tee >(`, got %q", got)
 	}
 }
 
@@ -175,5 +175,34 @@ func TestUnchainStatuslineCommand_RoundTripsUserCommand(t *testing.T) {
 func TestUnchainStatuslineCommand_StandaloneReturnsEmpty(t *testing.T) {
 	if got := unchainStatuslineCommand(installedStatuslineCommand); got != "" {
 		t.Errorf("expected empty for standalone install, got %q", got)
+	}
+}
+
+func TestChainStatuslineCommand_WrapUsesBashEnvelope(t *testing.T) {
+	got := chainStatuslineCommand("/usr/local/bin/my-statusline")
+	if !strings.HasPrefix(got, `bash -c 'tee >(`) {
+		t.Errorf("expected bash -c envelope, got %q", got)
+	}
+	if !strings.HasSuffix(got, `|| true'`) {
+		t.Errorf("expected trailing `|| true'`, got %q", got)
+	}
+}
+
+// TestChainStatuslineCommand_MigratesV1WrapToV2 covers the existing-install
+// path: users who picked up the first (broken) statusline wrap end up with a
+// `tee >(…) | curl …` command in settings.json that fails under POSIX sh.
+// On the next daemon start, we must unwrap their command and re-chain it in
+// the bash-envelope form — not overwrite it with the standalone install,
+// which would drop their original statusline script.
+func TestChainStatuslineCommand_MigratesV1WrapToV2(t *testing.T) {
+	userCmd := "bash ~/.claude/interplay-statusline.sh"
+	v1 := "tee >(" + userCmd + ") | curl -fsS --max-time 1 -X POST --data-binary @- " +
+		"http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true"
+	got := chainStatuslineCommand(v1)
+	if !strings.HasPrefix(got, `bash -c 'tee >(`) {
+		t.Fatalf("expected v2 (bash -c) form after migration, got %q", got)
+	}
+	if !strings.Contains(got, userCmd) {
+		t.Errorf("expected user command to survive migration, got %q", got)
 	}
 }

--- a/core/adapters/inbound/agents/codex/parser.go
+++ b/core/adapters/inbound/agents/codex/parser.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"strings"
+	"time"
 
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/pkg/transcript"
@@ -90,6 +91,18 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 	// Model/token extraction from payload-wrapped events.
 	var cumBreakdown *tailer.UsageBreakdown
 	ev.ModelName, ev.ContextWindow, ev.Tokens, cumBreakdown = extractCodexMetadata(raw)
+
+	// Rate-limit extraction from token_count events. Lives on
+	// event_msg.payload.rate_limits and is emitted on every API turn (clean
+	// cadence — no zero-delta noise like Claude Code's statusline). Other
+	// event types either don't carry the block or carry stale duplicates.
+	if eventType == "event_msg" {
+		if payload, ok := raw["payload"].(map[string]interface{}); ok {
+			if pt, _ := payload["type"].(string); pt == "token_count" {
+				ev.RateLimit = extractCodexRateLimits(payload, ev.Timestamp)
+			}
+		}
+	}
 
 	// Emit a Contribution when cumulative usage advances (monotonic delta).
 	if cumBreakdown != nil {
@@ -317,6 +330,86 @@ func (p *Parser) SetParserLedger(l tailer.ParserLedger) {
 	if l.CumCursor != nil {
 		p.cursor = *l.CumCursor
 	}
+}
+
+// extractCodexRateLimits parses payload.rate_limits from a Codex token_count
+// event into a tailer.RateLimitSnapshot. Returns nil when no rate_limits
+// block is present (older transcripts, or pre-first-response events).
+//
+// Handles three observed schema versions:
+//
+//   - v1 (Oct 2025): primary/secondary with window_minutes + resets_in_seconds
+//     (relative). 82 samples carry off-by-one minutes (299, 10079); we keep
+//     them verbatim — the matching logic downstream tolerates ±1.
+//   - v2 (Nov–Dec 2025): adds plan_type + credits, uses resets_at (absolute).
+//   - v3 (Jan 2026+): adds limit_id, limit_name, rate_limit_reached_type.
+//
+// sampledAt is the event's wall-clock time; used as the snapshot timestamp
+// and as the anchor when converting v1's relative resets_in_seconds to
+// absolute epoch seconds.
+func extractCodexRateLimits(payload map[string]interface{}, sampledAt time.Time) *tailer.RateLimitSnapshot {
+	rl, ok := payload["rate_limits"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	snap := &tailer.RateLimitSnapshot{SampledAt: sampledAt.Unix()}
+
+	if v, ok := rl["plan_type"].(string); ok {
+		snap.PlanType = v
+	}
+	if v, ok := rl["rate_limit_reached_type"].(string); ok {
+		snap.ReachedType = v
+	}
+	if c, ok := rl["credits"].(map[string]interface{}); ok {
+		creds := &tailer.CreditsSnapshot{}
+		if v, ok := c["has_credits"].(bool); ok {
+			creds.HasCredits = v
+		}
+		if v, ok := c["unlimited"].(bool); ok {
+			creds.Unlimited = v
+		}
+		if v, ok := c["balance"].(float64); ok {
+			creds.Balance = v
+		}
+		snap.Credits = creds
+	}
+
+	// Windows: read primary/secondary in that order so the slice is stable.
+	if w := extractCodexRateLimitWindow(rl["primary"], sampledAt); w != nil {
+		snap.Windows = append(snap.Windows, *w)
+	}
+	if w := extractCodexRateLimitWindow(rl["secondary"], sampledAt); w != nil {
+		snap.Windows = append(snap.Windows, *w)
+	}
+	if len(snap.Windows) == 0 && snap.PlanType == "" && snap.Credits == nil {
+		// Nothing useful to surface — block was empty.
+		return nil
+	}
+	return snap
+}
+
+// extractCodexRateLimitWindow parses one window (primary or secondary) from
+// the rate_limits block. Returns nil when the value is missing or not a map.
+func extractCodexRateLimitWindow(raw interface{}, sampledAt time.Time) *tailer.RateLimitWindow {
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	w := &tailer.RateLimitWindow{}
+	if v, ok := m["used_percent"].(float64); ok {
+		w.UsedPercent = v
+	}
+	if v, ok := m["window_minutes"].(float64); ok {
+		w.WindowMinutes = int(v)
+	}
+	if v, ok := m["resets_at"].(float64); ok && v > 0 {
+		w.ResetsAt = int64(v)
+	} else if v, ok := m["resets_in_seconds"].(float64); ok && v > 0 {
+		// v1 schema: relative seconds. Anchor to the event timestamp so
+		// downstream consumers see a consistent absolute epoch.
+		w.ResetsAt = sampledAt.Add(time.Duration(v) * time.Second).Unix()
+	}
+	return w
 }
 
 // extractOpenAIUsageBreakdown parses an OpenAI-style usage map into a UsageBreakdown,

--- a/core/adapters/inbound/agents/codex/parser_test.go
+++ b/core/adapters/inbound/agents/codex/parser_test.go
@@ -920,3 +920,178 @@ func TestParser_EventMsgNonTaskCompleteSkipped(t *testing.T) {
 		}
 	}
 }
+
+// TestParser_RateLimits_V3Schema asserts the parser extracts a complete v3
+// rate_limits block (limit_id + plan_type + reached_type, no credits) from
+// a token_count event into the snapshot.
+func TestParser_RateLimits_V3Schema(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type": "event_msg",
+		"payload": map[string]interface{}{
+			"type":        "token_count",
+			"limit_id":    "codex",
+			"limit_name":  nil,
+			"rate_limits": map[string]interface{}{
+				"limit_id":   "codex",
+				"limit_name": nil,
+				"primary": map[string]interface{}{
+					"used_percent":   1.0,
+					"window_minutes": 300.0,
+					"resets_at":      1778625131.0,
+				},
+				"secondary": map[string]interface{}{
+					"used_percent":   0.0,
+					"window_minutes": 10080.0,
+					"resets_at":      1778949174.0,
+				},
+				"credits":                  nil,
+				"plan_type":                "plus",
+				"rate_limit_reached_type":  nil,
+			},
+		},
+	})
+	if ev == nil || !ev.Skip {
+		t.Fatal("expected token_count to be skipped (post-rate-limit extraction)")
+	}
+	if ev.RateLimit == nil {
+		t.Fatal("expected RateLimit snapshot on token_count event")
+	}
+	if ev.RateLimit.PlanType != "plus" {
+		t.Errorf("plan_type = %q, want plus", ev.RateLimit.PlanType)
+	}
+	if len(ev.RateLimit.Windows) != 2 {
+		t.Fatalf("expected 2 windows, got %d", len(ev.RateLimit.Windows))
+	}
+	primary := ev.RateLimit.Windows[0]
+	if primary.WindowMinutes != 300 || primary.UsedPercent != 1.0 || primary.ResetsAt != 1778625131 {
+		t.Errorf("primary = %+v", primary)
+	}
+	secondary := ev.RateLimit.Windows[1]
+	if secondary.WindowMinutes != 10080 || secondary.ResetsAt != 1778949174 {
+		t.Errorf("secondary = %+v", secondary)
+	}
+	if ev.RateLimit.Credits != nil {
+		t.Errorf("expected nil Credits on subscription path, got %+v", ev.RateLimit.Credits)
+	}
+}
+
+// TestParser_RateLimits_V2WithCredits exercises the API-key / usage-path
+// shape where plan_type is null and credits carries a balance.
+func TestParser_RateLimits_V2WithCredits(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type": "event_msg",
+		"payload": map[string]interface{}{
+			"type": "token_count",
+			"rate_limits": map[string]interface{}{
+				"primary": map[string]interface{}{
+					"used_percent":   12.5,
+					"window_minutes": 300.0,
+					"resets_at":      1778625131.0,
+				},
+				"secondary": map[string]interface{}{
+					"used_percent":   2.0,
+					"window_minutes": 10080.0,
+					"resets_at":      1778949174.0,
+				},
+				"credits": map[string]interface{}{
+					"has_credits": true,
+					"unlimited":   false,
+					"balance":     42.5,
+				},
+				"plan_type": nil,
+			},
+		},
+	})
+	if ev.RateLimit == nil {
+		t.Fatal("expected RateLimit snapshot")
+	}
+	if ev.RateLimit.PlanType != "" {
+		t.Errorf("expected empty plan_type, got %q", ev.RateLimit.PlanType)
+	}
+	if ev.RateLimit.Credits == nil {
+		t.Fatal("expected non-nil Credits on API-key path")
+	}
+	if !ev.RateLimit.Credits.HasCredits || ev.RateLimit.Credits.Balance != 42.5 {
+		t.Errorf("credits = %+v", ev.RateLimit.Credits)
+	}
+}
+
+// TestParser_RateLimits_V1RelativeResets converts v1's resets_in_seconds
+// (relative) to absolute epoch using the event timestamp, and preserves
+// the off-by-one (299, 10079) window-minute values verbatim.
+func TestParser_RateLimits_V1RelativeResets(t *testing.T) {
+	p := &Parser{}
+	tsStr := "2025-10-15T12:00:00Z"
+	parsed, _ := time.Parse(time.RFC3339, tsStr)
+	ev := p.ParseLine(map[string]interface{}{
+		"type":      "event_msg",
+		"timestamp": tsStr,
+		"payload": map[string]interface{}{
+			"type": "token_count",
+			"rate_limits": map[string]interface{}{
+				"primary": map[string]interface{}{
+					"used_percent":      5.0,
+					"window_minutes":    299.0,
+					"resets_in_seconds": 1800.0,
+				},
+				"secondary": map[string]interface{}{
+					"used_percent":      1.0,
+					"window_minutes":    10079.0,
+					"resets_in_seconds": 86400.0,
+				},
+			},
+		},
+	})
+	if ev.RateLimit == nil {
+		t.Fatal("expected RateLimit snapshot")
+	}
+	if ev.RateLimit.Windows[0].WindowMinutes != 299 {
+		t.Errorf("expected v1 quirk window_minutes=299 preserved, got %d", ev.RateLimit.Windows[0].WindowMinutes)
+	}
+	wantPrimaryResets := parsed.Add(1800 * time.Second).Unix()
+	if ev.RateLimit.Windows[0].ResetsAt != wantPrimaryResets {
+		t.Errorf("primary resets_at = %d, want %d (relative→absolute)", ev.RateLimit.Windows[0].ResetsAt, wantPrimaryResets)
+	}
+}
+
+// TestParser_RateLimits_AbsentReturnsNil keeps the snapshot nil when the
+// payload has no rate_limits block (older Codex transcripts, pre-first-API
+// response events). Must not produce a phantom empty snapshot.
+func TestParser_RateLimits_AbsentReturnsNil(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type": "event_msg",
+		"payload": map[string]interface{}{
+			"type": "token_count",
+			"info": map[string]interface{}{},
+		},
+	})
+	if ev.RateLimit != nil {
+		t.Errorf("expected nil RateLimit on payload without rate_limits, got %+v", ev.RateLimit)
+	}
+}
+
+// TestParser_RateLimits_OnlyOnTokenCount ensures we don't extract from
+// other event_msg payload types (task_started, exec_command_*, etc.) even
+// if a malformed transcript carries a rate_limits block on them.
+func TestParser_RateLimits_OnlyOnTokenCount(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type": "event_msg",
+		"payload": map[string]interface{}{
+			"type": "task_started",
+			"rate_limits": map[string]interface{}{
+				"primary": map[string]interface{}{
+					"used_percent":   99.0,
+					"window_minutes": 300.0,
+					"resets_at":      1778625131.0,
+				},
+			},
+		},
+	})
+	if ev.RateLimit != nil {
+		t.Errorf("expected nil RateLimit on non-token_count event_msg, got %+v", ev.RateLimit)
+	}
+}

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"os"
 	"sync"
+	"time"
 
 	"irrlicht/core/adapters/inbound/agents"
 	"irrlicht/core/domain/session"
@@ -161,6 +162,14 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 		}
 	}
 	result.Tasks = tailerTasksToDomain(m.Tasks)
+	if m.RateLimit != nil {
+		result.RateLimit = tailerRateLimitToDomain(m.RateLimit)
+		history := tailerRateLimitHistoryToDomain(m.RateLimitHistory)
+		if eta := session.ForecastCap(history, time.Now()); eta != nil {
+			etaUnix := eta.Unix()
+			result.RateLimitForecastEta = &etaUnix
+		}
+	}
 	if result.ModelName == "" {
 		result.ModelName = "unknown"
 	}
@@ -174,6 +183,59 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 		result.LastAssistantText = snippet
 	}
 	return result, nil
+}
+
+// IngestRateLimit pushes a rate-limit snapshot into the tailer for
+// transcriptPath. Used by the Claude Code statusline hook receiver. No-op
+// when no tailer exists for the path (snapshot arrived before the session
+// was detected) — the snapshot is simply dropped; the next statusline tick
+// will populate it once the tailer exists.
+func (a *Adapter) IngestRateLimit(transcriptPath string, snap *session.RateLimitSnapshot) {
+	if transcriptPath == "" || snap == nil {
+		return
+	}
+	a.mu.Lock()
+	lt, ok := a.tailers[transcriptPath]
+	a.mu.Unlock()
+	if !ok {
+		return
+	}
+	tailerSnap := domainRateLimitToTailer(snap)
+	lt.mu.Lock()
+	lt.t.IngestRateLimit(tailerSnap)
+	lt.mu.Unlock()
+}
+
+// domainRateLimitToTailer is the inbound counterpart to tailerRateLimitToDomain
+// — used by IngestRateLimit when the HTTP layer hands us a domain-typed
+// snapshot that has to land inside the tailer's mirror type.
+func domainRateLimitToTailer(src *session.RateLimitSnapshot) *tailer.RateLimitSnapshot {
+	if src == nil {
+		return nil
+	}
+	dst := &tailer.RateLimitSnapshot{
+		PlanType:    src.PlanType,
+		ReachedType: src.ReachedType,
+		SampledAt:   src.SampledAt,
+	}
+	if len(src.Windows) > 0 {
+		dst.Windows = make([]tailer.RateLimitWindow, len(src.Windows))
+		for i, w := range src.Windows {
+			dst.Windows[i] = tailer.RateLimitWindow{
+				UsedPercent:   w.UsedPercent,
+				WindowMinutes: w.WindowMinutes,
+				ResetsAt:      w.ResetsAt,
+			}
+		}
+	}
+	if src.Credits != nil {
+		dst.Credits = &tailer.CreditsSnapshot{
+			HasCredits: src.Credits.HasCredits,
+			Unlimited:  src.Credits.Unlimited,
+			Balance:    src.Credits.Balance,
+		}
+	}
+	return dst
 }
 
 // PruneEntry releases per-session state when a session ends: drops the
@@ -195,6 +257,50 @@ func (a *Adapter) PruneEntry(transcriptPath string) {
 	if lp := ledgerPath(transcriptPath); lp != "" {
 		_ = os.Remove(lp)
 	}
+}
+
+// tailerRateLimitToDomain converts a tailer-side snapshot to its domain mirror.
+func tailerRateLimitToDomain(src *tailer.RateLimitSnapshot) *session.RateLimitSnapshot {
+	if src == nil {
+		return nil
+	}
+	dst := &session.RateLimitSnapshot{
+		PlanType:    src.PlanType,
+		ReachedType: src.ReachedType,
+		SampledAt:   src.SampledAt,
+	}
+	if len(src.Windows) > 0 {
+		dst.Windows = make([]session.RateLimitWindow, len(src.Windows))
+		for i, w := range src.Windows {
+			dst.Windows[i] = session.RateLimitWindow{
+				UsedPercent:   w.UsedPercent,
+				WindowMinutes: w.WindowMinutes,
+				ResetsAt:      w.ResetsAt,
+			}
+		}
+	}
+	if src.Credits != nil {
+		dst.Credits = &session.CreditsSnapshot{
+			HasCredits: src.Credits.HasCredits,
+			Unlimited:  src.Credits.Unlimited,
+			Balance:    src.Credits.Balance,
+		}
+	}
+	return dst
+}
+
+// tailerRateLimitHistoryToDomain copies the rolling history into the
+// domain-typed slice the forecast helper consumes.
+func tailerRateLimitHistoryToDomain(src []tailer.RateLimitSnapshot) []session.RateLimitSnapshot {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]session.RateLimitSnapshot, len(src))
+	for i := range src {
+		converted := tailerRateLimitToDomain(&src[i])
+		dst[i] = *converted
+	}
+	return dst
 }
 
 // tailerTasksToDomain converts a tailer task slice to the domain mirror type.

--- a/core/application/services/quotainherit.go
+++ b/core/application/services/quotainherit.go
@@ -25,9 +25,75 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
+	"time"
 
 	"irrlicht/core/domain/session"
 )
+
+// authFileCache memoizes parsed auth-file lookups by path so the
+// inheritance pass doesn't reread three small JSON files on every
+// `/api/v1/sessions` hit. Validated by mtime: a stale entry is dropped
+// when the file's modification time changes. Concurrent readers are
+// fine — the cache is keyed by path and writes are coordinated by mu.
+//
+// Entries are kept indefinitely; the working set is at most three
+// files (~/.codex, ~/.pi/agent, ~/.local/share/opencode), so there's
+// no eviction need.
+var authFileCache struct {
+	mu      sync.Mutex
+	entries map[string]authCacheEntry
+}
+
+type authCacheEntry struct {
+	mtime time.Time
+	// One of the parsed-doc fields below is populated, depending on
+	// which reader filled the entry. Distinguishing by path keeps the
+	// readers type-safe without a generic any-typed payload.
+	codexAccountID string
+	piDoc          map[string]piAuthEntry
+	openCodeDoc    map[string]openCodeAuthEntry
+}
+
+type piAuthEntry struct {
+	Type      string `json:"type"`
+	AccountID string `json:"accountId"`
+}
+
+type openCodeAuthEntry struct {
+	Type string `json:"type"`
+}
+
+// readAuthCache returns the parsed entry for path, populating the
+// cache via parse if the file is new or has been modified since the
+// last read. Returns (zero, false) on any read/parse error.
+func readAuthCache(path string, parse func([]byte) (authCacheEntry, bool)) (authCacheEntry, bool) {
+	authFileCache.mu.Lock()
+	defer authFileCache.mu.Unlock()
+	if authFileCache.entries == nil {
+		authFileCache.entries = map[string]authCacheEntry{}
+	}
+	stat, err := os.Stat(path)
+	if err != nil {
+		// Drop any stale entry — the file was removed.
+		delete(authFileCache.entries, path)
+		return authCacheEntry{}, false
+	}
+	if entry, ok := authFileCache.entries[path]; ok && entry.mtime.Equal(stat.ModTime()) {
+		return entry, true
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return authCacheEntry{}, false
+	}
+	entry, ok := parse(data)
+	if !ok {
+		return authCacheEntry{}, false
+	}
+	entry.mtime = stat.ModTime()
+	authFileCache.entries[path] = entry
+	return entry, true
+}
 
 // AccountKey identifies a subscription bucket: the provider name plus
 // an account anchor (empty for the Anthropic singleton case).
@@ -146,10 +212,14 @@ func recipientKey(s *session.SessionState, home string) (AccountKey, bool) {
 // failure — the caller treats absence as "no donor available", which
 // is the safe default.
 func readCodexAccountID(home string) string {
-	data, err := os.ReadFile(filepath.Join(home, ".codex", "auth.json"))
-	if err != nil {
+	entry, ok := readAuthCache(filepath.Join(home, ".codex", "auth.json"), parseCodexAuth)
+	if !ok {
 		return ""
 	}
+	return entry.codexAccountID
+}
+
+func parseCodexAuth(data []byte) (authCacheEntry, bool) {
 	var doc struct {
 		AuthMode string `json:"auth_mode"`
 		Tokens   struct {
@@ -157,12 +227,14 @@ func readCodexAccountID(home string) string {
 		} `json:"tokens"`
 	}
 	if err := json.Unmarshal(data, &doc); err != nil {
-		return ""
+		return authCacheEntry{}, false
 	}
 	if doc.AuthMode != "chatgpt" {
-		return ""
+		// Valid file, not a subscription user — cache the empty
+		// account_id to avoid re-parsing on every request.
+		return authCacheEntry{codexAccountID: ""}, true
 	}
-	return doc.Tokens.AccountID
+	return authCacheEntry{codexAccountID: doc.Tokens.AccountID}, true
 }
 
 // readPiInheritKey parses ~/.pi/agent/auth.json. Pi keys each provider
@@ -171,27 +243,27 @@ func readCodexAccountID(home string) string {
 // prefer OpenAI over Anthropic when both are configured; either choice
 // is defensible for a single-provider Pi user.
 func readPiInheritKey(home string) (AccountKey, bool) {
-	data, err := os.ReadFile(filepath.Join(home, ".pi", "agent", "auth.json"))
-	if err != nil {
+	entry, ok := readAuthCache(filepath.Join(home, ".pi", "agent", "auth.json"), parsePiAuth)
+	if !ok {
 		return AccountKey{}, false
 	}
-	var doc map[string]struct {
-		Type      string `json:"type"`
-		AccountID string `json:"accountId"`
+	if v, ok := entry.piDoc["openai-codex"]; ok && v.Type == "oauth" && v.AccountID != "" {
+		return AccountKey{Provider: "openai", AccountID: v.AccountID}, true
 	}
-	if err := json.Unmarshal(data, &doc); err != nil {
-		return AccountKey{}, false
-	}
-	if entry, ok := doc["openai-codex"]; ok && entry.Type == "oauth" && entry.AccountID != "" {
-		return AccountKey{Provider: "openai", AccountID: entry.AccountID}, true
-	}
-	if entry, ok := doc["anthropic"]; ok && entry.Type == "oauth" {
+	if v, ok := entry.piDoc["anthropic"]; ok && v.Type == "oauth" {
 		// Anthropic singleton — AccountID intentionally empty so the
 		// key matches Claude Code's donor entry.
-		_ = entry
 		return AccountKey{Provider: "anthropic"}, true
 	}
 	return AccountKey{}, false
+}
+
+func parsePiAuth(data []byte) (authCacheEntry, bool) {
+	var doc map[string]piAuthEntry
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return authCacheEntry{}, false
+	}
+	return authCacheEntry{piDoc: doc}, true
 }
 
 // readOpenCodeInheritKey parses ~/.local/share/opencode/auth.json.
@@ -203,27 +275,28 @@ func readPiInheritKey(home string) (AccountKey, bool) {
 // the chatgpt account_id; out of scope for v1, so OpenCode→OpenAI
 // just doesn't inherit until that lands).
 func readOpenCodeInheritKey(home string) (AccountKey, bool) {
-	data, err := os.ReadFile(filepath.Join(home, ".local", "share", "opencode", "auth.json"))
-	if err != nil {
+	entry, ok := readAuthCache(filepath.Join(home, ".local", "share", "opencode", "auth.json"), parseOpenCodeAuth)
+	if !ok {
 		return AccountKey{}, false
 	}
-	var doc map[string]struct {
-		Type string `json:"type"`
-	}
-	if err := json.Unmarshal(data, &doc); err != nil {
-		return AccountKey{}, false
-	}
-	if entry, ok := doc["openai-oauth"]; ok && entry.Type == "oauth" {
-		_ = entry
+	if v, ok := entry.openCodeDoc["openai-oauth"]; ok && v.Type == "oauth" {
 		// AccountID unavailable in the OpenCode auth file shape
 		// observed so far — would need to decode the JWT access token
 		// to recover it. Leave inheritance disabled for this branch
 		// until we have data to verify the JWT extraction against.
+		// See issue #384.
 		return AccountKey{}, false
 	}
-	if entry, ok := doc["anthropic-oauth"]; ok && entry.Type == "oauth" {
-		_ = entry
+	if v, ok := entry.openCodeDoc["anthropic-oauth"]; ok && v.Type == "oauth" {
 		return AccountKey{Provider: "anthropic"}, true
 	}
 	return AccountKey{}, false
+}
+
+func parseOpenCodeAuth(data []byte) (authCacheEntry, bool) {
+	var doc map[string]openCodeAuthEntry
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return authCacheEntry{}, false
+	}
+	return authCacheEntry{openCodeDoc: doc}, true
 }

--- a/core/application/services/quotainherit.go
+++ b/core/application/services/quotainherit.go
@@ -106,6 +106,13 @@ func readAuthCache(path string, parse func([]byte) (authCacheEntry, bool)) (auth
 	return entry, true
 }
 
+// Canonical provider keys. Centralised so a typo at any inheritance
+// site fails the build instead of silently creating a phantom bucket.
+const (
+	ProviderAnthropic = "anthropic"
+	ProviderOpenAI    = "openai"
+)
+
 // AccountKey identifies a subscription bucket: the provider name plus
 // an account anchor. An empty `AccountID` is a sentinel meaning
 // "singleton donor for this provider, no account-level disambiguation"
@@ -120,7 +127,7 @@ func readAuthCache(path string, parse func([]byte) (authCacheEntry, bool)) (auth
 // account anchor, or document the singleton intent explicitly (and
 // gate it via IsSingleton below). See issue #309.
 type AccountKey struct {
-	Provider  string // "anthropic" | "openai"
+	Provider  string // one of the Provider* constants above
 	AccountID string // empty only for the documented singleton case (currently Anthropic)
 }
 
@@ -205,10 +212,10 @@ func donorKey(s *session.SessionState, home string) (AccountKey, bool) {
 		// Code (lives in keychain), so we deliberately leave AccountID
 		// empty. Wrappers' recipientKey returns the matching singleton
 		// shape, so the lookup still hits.
-		return AccountKey{Provider: "anthropic"}, true
+		return AccountKey{Provider: ProviderAnthropic}, true
 	case "codex":
 		if id := readCodexAccountID(home); id != "" {
-			return AccountKey{Provider: "openai", AccountID: id}, true
+			return AccountKey{Provider: ProviderOpenAI, AccountID: id}, true
 		}
 	}
 	return AccountKey{}, false
@@ -277,12 +284,12 @@ func readPiInheritKey(home string) (AccountKey, bool) {
 		return AccountKey{}, false
 	}
 	if v, ok := entry.piDoc["openai-codex"]; ok && v.Type == "oauth" && v.AccountID != "" {
-		return AccountKey{Provider: "openai", AccountID: v.AccountID}, true
+		return AccountKey{Provider: ProviderOpenAI, AccountID: v.AccountID}, true
 	}
 	if v, ok := entry.piDoc["anthropic"]; ok && v.Type == "oauth" {
 		// Anthropic singleton — AccountID intentionally empty so the
 		// key matches Claude Code's donor entry.
-		return AccountKey{Provider: "anthropic"}, true
+		return AccountKey{Provider: ProviderAnthropic}, true
 	}
 	return AccountKey{}, false
 }
@@ -317,7 +324,7 @@ func readOpenCodeInheritKey(home string) (AccountKey, bool) {
 		return AccountKey{}, false
 	}
 	if v, ok := entry.openCodeDoc["anthropic-oauth"]; ok && v.Type == "oauth" {
-		return AccountKey{Provider: "anthropic"}, true
+		return AccountKey{Provider: ProviderAnthropic}, true
 	}
 	return AccountKey{}, false
 }

--- a/core/application/services/quotainherit.go
+++ b/core/application/services/quotainherit.go
@@ -1,0 +1,229 @@
+// Package services — quotainherit.go implements cross-account rate-limit
+// inheritance. Subscriptions are OAuth-account-scoped, not CLI-scoped:
+// once any first-party CLI surfaces a quota snapshot for an account, every
+// wrapper session (Pi, OpenCode) backed by the same account can read it.
+//
+// See issue #309 for the design context and supported matrix:
+//
+//   - Anthropic (Claude.ai Pro/Max): Claude Code's statusline hook is the
+//     only source. Account anchor lives in macOS keychain — irrlicht treats
+//     the snapshot as a global singleton, donating from any Claude Code
+//     session with rate_limit data to any Pi(anthropic) or
+//     OpenCode(anthropic-oauth) wrapper session that doesn't have one.
+//   - OpenAI (ChatGPT Plus/Pro): Codex CLI emits rate_limits directly in
+//     its transcripts. Both Codex's ~/.codex/auth.json (snake_case
+//     `account_id`) and Pi's ~/.pi/agent/auth.json (camelCase `accountId`
+//     under the `openai-codex` provider) expose the same identifier in
+//     plaintext, letting us key the donor map exactly.
+//
+// Wrappers without a matching first-party donor session keep their
+// existing (usually empty) rate_limit. The inheritance pass is a one-way
+// copy: it never overwrites a session that already has its own snapshot.
+package services
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"irrlicht/core/domain/session"
+)
+
+// AccountKey identifies a subscription bucket: the provider name plus
+// an account anchor (empty for the Anthropic singleton case).
+type AccountKey struct {
+	Provider  string // "anthropic" | "openai"
+	AccountID string // empty when the provider's anchor isn't reachable in plaintext
+}
+
+// InheritRateLimits walks the given sessions, builds a donor map of
+// rate_limit snapshots from sessions that have one, then copies the
+// matching donor snapshot into wrapper sessions that don't. Mutates
+// each recipient's Metrics in place; non-matching sessions are
+// untouched.
+//
+// `userHome` lets tests pin a synthetic HOME directory without
+// monkeypatching os.UserHomeDir; production callers pass "" to use the
+// real home.
+func InheritRateLimits(sessions []*session.SessionState, userHome string) {
+	home := userHome
+	if home == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return
+		}
+		home = h
+	}
+
+	// Build donor map. Prefer the freshest snapshot per key when more
+	// than one session can donate (multiple Claude Code sessions all
+	// share the anthropic singleton, for example).
+	donors := map[AccountKey]*session.RateLimitSnapshot{}
+	for _, s := range sessions {
+		if s == nil || s.Metrics == nil || s.Metrics.RateLimit == nil {
+			continue
+		}
+		key, ok := donorKey(s, home)
+		if !ok {
+			continue
+		}
+		current, exists := donors[key]
+		if !exists || s.Metrics.RateLimit.SampledAt > current.SampledAt {
+			donors[key] = s.Metrics.RateLimit
+		}
+	}
+	if len(donors) == 0 {
+		return
+	}
+
+	// Apply to recipients. Skip any session that already has a snapshot
+	// — its own data is more authoritative than inherited data.
+	for _, s := range sessions {
+		if s == nil {
+			continue
+		}
+		if s.Metrics != nil && s.Metrics.RateLimit != nil {
+			continue
+		}
+		key, ok := recipientKey(s, home)
+		if !ok {
+			continue
+		}
+		donor, found := donors[key]
+		if !found {
+			continue
+		}
+		if s.Metrics == nil {
+			s.Metrics = &session.SessionMetrics{}
+		}
+		s.Metrics.RateLimit = donor
+	}
+}
+
+// donorKey returns the AccountKey under which this session's snapshot
+// can be donated to wrappers. Returns (_, false) when the adapter has
+// no usable donor mapping (e.g. aider, bedrock, vertex paths).
+func donorKey(s *session.SessionState, home string) (AccountKey, bool) {
+	switch s.Adapter {
+	case "claude-code":
+		// Anthropic singleton: account anchor isn't on disk for Claude
+		// Code (lives in keychain), so we deliberately leave AccountID
+		// empty. Wrappers' recipientKey returns the matching singleton
+		// shape, so the lookup still hits.
+		return AccountKey{Provider: "anthropic"}, true
+	case "codex":
+		if id := readCodexAccountID(home); id != "" {
+			return AccountKey{Provider: "openai", AccountID: id}, true
+		}
+	}
+	return AccountKey{}, false
+}
+
+// recipientKey returns the AccountKey this session needs a snapshot
+// for, by reading the wrapper's own auth.json to determine which
+// subscription it's authenticated to. Returns (_, false) when no
+// inheritable provider is configured.
+//
+// Pi and OpenCode both let a user configure several providers at once.
+// We pick OpenAI over Anthropic when both are present — empirically,
+// users who run both first-party CLIs tend to use the wrappers for
+// OpenAI overflow rather than Anthropic. Either choice is defensible
+// for a v1; the user-visible behaviour is identical for the common
+// single-provider case.
+func recipientKey(s *session.SessionState, home string) (AccountKey, bool) {
+	switch s.Adapter {
+	case "pi":
+		return readPiInheritKey(home)
+	case "opencode":
+		return readOpenCodeInheritKey(home)
+	}
+	return AccountKey{}, false
+}
+
+// readCodexAccountID parses ~/.codex/auth.json and returns
+// tokens.account_id when the auth_mode is "chatgpt" (the OAuth/
+// subscription path). Returns "" for API-key users or any read/parse
+// failure — the caller treats absence as "no donor available", which
+// is the safe default.
+func readCodexAccountID(home string) string {
+	data, err := os.ReadFile(filepath.Join(home, ".codex", "auth.json"))
+	if err != nil {
+		return ""
+	}
+	var doc struct {
+		AuthMode string `json:"auth_mode"`
+		Tokens   struct {
+			AccountID string `json:"account_id"`
+		} `json:"tokens"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return ""
+	}
+	if doc.AuthMode != "chatgpt" {
+		return ""
+	}
+	return doc.Tokens.AccountID
+}
+
+// readPiInheritKey parses ~/.pi/agent/auth.json. Pi keys each provider
+// block by name (e.g. "openai-codex", "anthropic") and tags OAuth
+// entries with `type: "oauth"` plus an `accountId` (camelCase). We
+// prefer OpenAI over Anthropic when both are configured; either choice
+// is defensible for a single-provider Pi user.
+func readPiInheritKey(home string) (AccountKey, bool) {
+	data, err := os.ReadFile(filepath.Join(home, ".pi", "agent", "auth.json"))
+	if err != nil {
+		return AccountKey{}, false
+	}
+	var doc map[string]struct {
+		Type      string `json:"type"`
+		AccountID string `json:"accountId"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return AccountKey{}, false
+	}
+	if entry, ok := doc["openai-codex"]; ok && entry.Type == "oauth" && entry.AccountID != "" {
+		return AccountKey{Provider: "openai", AccountID: entry.AccountID}, true
+	}
+	if entry, ok := doc["anthropic"]; ok && entry.Type == "oauth" {
+		// Anthropic singleton — AccountID intentionally empty so the
+		// key matches Claude Code's donor entry.
+		_ = entry
+		return AccountKey{Provider: "anthropic"}, true
+	}
+	return AccountKey{}, false
+}
+
+// readOpenCodeInheritKey parses ~/.local/share/opencode/auth.json.
+// OpenCode names OAuth providers `anthropic-oauth` and `openai-oauth`
+// per its upstream docs; we map them onto irrlicht's canonical
+// "anthropic" / "openai" provider keys. Account anchor isn't surfaced
+// in the file we've seen — Anthropic always lands on the singleton
+// key, OpenAI is best-effort (would need to read the JWT to recover
+// the chatgpt account_id; out of scope for v1, so OpenCode→OpenAI
+// just doesn't inherit until that lands).
+func readOpenCodeInheritKey(home string) (AccountKey, bool) {
+	data, err := os.ReadFile(filepath.Join(home, ".local", "share", "opencode", "auth.json"))
+	if err != nil {
+		return AccountKey{}, false
+	}
+	var doc map[string]struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return AccountKey{}, false
+	}
+	if entry, ok := doc["openai-oauth"]; ok && entry.Type == "oauth" {
+		_ = entry
+		// AccountID unavailable in the OpenCode auth file shape
+		// observed so far — would need to decode the JWT access token
+		// to recover it. Leave inheritance disabled for this branch
+		// until we have data to verify the JWT extraction against.
+		return AccountKey{}, false
+	}
+	if entry, ok := doc["anthropic-oauth"]; ok && entry.Type == "oauth" {
+		_ = entry
+		return AccountKey{Provider: "anthropic"}, true
+	}
+	return AccountKey{}, false
+}

--- a/core/application/services/quotainherit.go
+++ b/core/application/services/quotainherit.go
@@ -46,7 +46,13 @@ var authFileCache struct {
 }
 
 type authCacheEntry struct {
-	mtime time.Time
+	// missing is true when the file isn't present (negative cache);
+	// mtime and the parsed-doc fields below are then meaningless.
+	// Negative caching keeps `/api/v1/sessions` from re-stat'ing
+	// non-existent paths on every hit for users who don't have all
+	// three wrapper CLIs installed (the common case).
+	missing bool
+	mtime   time.Time
 	// One of the parsed-doc fields below is populated, depending on
 	// which reader filled the entry. Distinguishing by path keeps the
 	// readers type-safe without a generic any-typed payload.
@@ -66,7 +72,10 @@ type openCodeAuthEntry struct {
 
 // readAuthCache returns the parsed entry for path, populating the
 // cache via parse if the file is new or has been modified since the
-// last read. Returns (zero, false) on any read/parse error.
+// last read. Returns (zero, false) when the file is missing or parses
+// fail. Negative results (missing file) are cached so subsequent
+// calls don't restat — a user without all three wrappers installed
+// hits this path on every `/api/v1/sessions`.
 func readAuthCache(path string, parse func([]byte) (authCacheEntry, bool)) (authCacheEntry, bool) {
 	authFileCache.mu.Lock()
 	defer authFileCache.mu.Unlock()
@@ -75,11 +84,13 @@ func readAuthCache(path string, parse func([]byte) (authCacheEntry, bool)) (auth
 	}
 	stat, err := os.Stat(path)
 	if err != nil {
-		// Drop any stale entry — the file was removed.
-		delete(authFileCache.entries, path)
+		// Negative cache: remember the absence. If the file appears
+		// later, the next Stat will succeed and the cached `missing`
+		// entry gets overwritten below.
+		authFileCache.entries[path] = authCacheEntry{missing: true}
 		return authCacheEntry{}, false
 	}
-	if entry, ok := authFileCache.entries[path]; ok && entry.mtime.Equal(stat.ModTime()) {
+	if entry, ok := authFileCache.entries[path]; ok && !entry.missing && entry.mtime.Equal(stat.ModTime()) {
 		return entry, true
 	}
 	data, err := os.ReadFile(path)
@@ -96,10 +107,28 @@ func readAuthCache(path string, parse func([]byte) (authCacheEntry, bool)) (auth
 }
 
 // AccountKey identifies a subscription bucket: the provider name plus
-// an account anchor (empty for the Anthropic singleton case).
+// an account anchor. An empty `AccountID` is a sentinel meaning
+// "singleton donor for this provider, no account-level disambiguation"
+// — currently only Anthropic uses this because Claude Code stores its
+// OAuth tokens in the macOS keychain rather than in a plaintext file
+// we can read.
+//
+// Footgun warning: a future provider whose anchor isn't reachable in
+// plaintext would, if added with `AccountID == ""`, silently start
+// inheriting from / donating to every other empty-AccountID provider
+// of the same name. Always either populate `AccountID` from the
+// account anchor, or document the singleton intent explicitly (and
+// gate it via IsSingleton below). See issue #309.
 type AccountKey struct {
 	Provider  string // "anthropic" | "openai"
-	AccountID string // empty when the provider's anchor isn't reachable in plaintext
+	AccountID string // empty only for the documented singleton case (currently Anthropic)
+}
+
+// IsSingleton reports whether this key is the no-account-anchor
+// sentinel — used by the donor map to match any wrapper recipient of
+// the same provider regardless of the wrapper's own account hint.
+func (k AccountKey) IsSingleton() bool {
+	return k.AccountID == ""
 }
 
 // InheritRateLimits walks the given sessions, builds a donor map of

--- a/core/application/services/quotainherit_test.go
+++ b/core/application/services/quotainherit_test.go
@@ -217,6 +217,80 @@ func TestInheritRateLimits_NoDonorIsNoOp(t *testing.T) {
 	}
 }
 
+// writeCodexAuth stages a synthetic ~/.codex/auth.json under home.
+// Raw bytes (`raw`) trump structured body when both are set, so we
+// can exercise malformed-JSON cases.
+func writeCodexAuth(t *testing.T, home string, body any, raw string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(home, ".codex", "auth.json")
+	var data []byte
+	if raw != "" {
+		data = []byte(raw)
+	} else {
+		var err error
+		data, err = json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReadCodexAccountID_ErrorPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		body any
+		raw  string
+		want string
+	}{
+		{
+			name: "valid chatgpt mode",
+			body: map[string]any{"auth_mode": "chatgpt", "tokens": map[string]any{"account_id": "acct-x"}},
+			want: "acct-x",
+		},
+		{
+			name: "api-key mode returns empty",
+			body: map[string]any{"auth_mode": "apikey", "tokens": map[string]any{"account_id": "ignored"}},
+			want: "",
+		},
+		{
+			name: "missing auth_mode returns empty",
+			body: map[string]any{"tokens": map[string]any{"account_id": "ignored"}},
+			want: "",
+		},
+		{
+			name: "missing tokens field returns empty",
+			body: map[string]any{"auth_mode": "chatgpt"},
+			want: "",
+		},
+		{
+			name: "malformed JSON returns empty",
+			raw:  "{not json",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			writeCodexAuth(t, home, tc.body, tc.raw)
+			if got := readCodexAccountID(home); got != tc.want {
+				t.Errorf("readCodexAccountID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadCodexAccountID_MissingFileReturnsEmpty(t *testing.T) {
+	if got := readCodexAccountID(t.TempDir()); got != "" {
+		t.Errorf("expected empty for missing file, got %q", got)
+	}
+}
+
 func TestInheritRateLimits_CodexAPIKeyDoesNotDonate(t *testing.T) {
 	// Codex on API-key auth (auth_mode != "chatgpt") shouldn't be
 	// treated as a subscription donor — its rate_limit reflects the

--- a/core/application/services/quotainherit_test.go
+++ b/core/application/services/quotainherit_test.go
@@ -1,0 +1,241 @@
+package services
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// stageAuth writes a fake home with the given auth files. Returns the
+// home path; the caller's t.TempDir cleanup removes everything.
+func stageAuth(t *testing.T, files map[string]any) string {
+	t.Helper()
+	home := t.TempDir()
+	for rel, body := range files {
+		path := filepath.Join(home, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return home
+}
+
+func donorClaudeCode(sampledAt int64, percent float64) *session.SessionState {
+	return &session.SessionState{
+		SessionID: "claudecode-donor",
+		Adapter:   "claude-code",
+		Metrics: &session.SessionMetrics{
+			RateLimit: &session.RateLimitSnapshot{
+				SampledAt: sampledAt,
+				PlanType:  "max",
+				Windows: []session.RateLimitWindow{
+					{UsedPercent: percent, WindowMinutes: 300, ResetsAt: 99999999},
+				},
+			},
+		},
+	}
+}
+
+func donorCodex(sampledAt int64, percent float64) *session.SessionState {
+	return &session.SessionState{
+		SessionID: "codex-donor",
+		Adapter:   "codex",
+		Metrics: &session.SessionMetrics{
+			RateLimit: &session.RateLimitSnapshot{
+				SampledAt: sampledAt,
+				PlanType:  "plus",
+				Windows: []session.RateLimitWindow{
+					{UsedPercent: percent, WindowMinutes: 300, ResetsAt: 99999999},
+				},
+			},
+		},
+	}
+}
+
+func emptyWrapper(adapter, id string) *session.SessionState {
+	return &session.SessionState{
+		SessionID: id,
+		Adapter:   adapter,
+		Metrics:   &session.SessionMetrics{},
+	}
+}
+
+func TestInheritRateLimits_PiOpenAIInheritsFromCodex(t *testing.T) {
+	home := stageAuth(t, map[string]any{
+		".codex/auth.json": map[string]any{
+			"auth_mode": "chatgpt",
+			"tokens":    map[string]any{"account_id": "acct-shared"},
+		},
+		".pi/agent/auth.json": map[string]any{
+			"openai-codex": map[string]any{
+				"type":      "oauth",
+				"accountId": "acct-shared",
+			},
+		},
+	})
+
+	codex := donorCodex(1000, 22)
+	pi := emptyWrapper("pi", "pi-1")
+	InheritRateLimits([]*session.SessionState{codex, pi}, home)
+
+	if pi.Metrics.RateLimit == nil {
+		t.Fatal("expected pi session to inherit codex snapshot")
+	}
+	if pi.Metrics.RateLimit.SampledAt != 1000 {
+		t.Errorf("inherited snapshot timestamp mismatch: got %d", pi.Metrics.RateLimit.SampledAt)
+	}
+}
+
+func TestInheritRateLimits_PiNotInheritsOnAccountMismatch(t *testing.T) {
+	home := stageAuth(t, map[string]any{
+		".codex/auth.json": map[string]any{
+			"auth_mode": "chatgpt",
+			"tokens":    map[string]any{"account_id": "acct-codex"},
+		},
+		".pi/agent/auth.json": map[string]any{
+			"openai-codex": map[string]any{
+				"type":      "oauth",
+				"accountId": "acct-different",
+			},
+		},
+	})
+
+	codex := donorCodex(1000, 22)
+	pi := emptyWrapper("pi", "pi-1")
+	InheritRateLimits([]*session.SessionState{codex, pi}, home)
+
+	if pi.Metrics.RateLimit != nil {
+		t.Fatal("expected no inheritance when account ids don't match")
+	}
+}
+
+func TestInheritRateLimits_PiAnthropicInheritsFromClaudeCode(t *testing.T) {
+	home := stageAuth(t, map[string]any{
+		".pi/agent/auth.json": map[string]any{
+			"anthropic": map[string]any{"type": "oauth"},
+		},
+	})
+
+	cc := donorClaudeCode(2000, 47)
+	pi := emptyWrapper("pi", "pi-1")
+	InheritRateLimits([]*session.SessionState{cc, pi}, home)
+
+	if pi.Metrics.RateLimit == nil {
+		t.Fatal("expected pi(anthropic) to inherit from claude code")
+	}
+	if pi.Metrics.RateLimit.SampledAt != 2000 {
+		t.Errorf("expected donor snapshot, got SampledAt=%d", pi.Metrics.RateLimit.SampledAt)
+	}
+}
+
+func TestInheritRateLimits_PiPrefersOpenAIOverAnthropic(t *testing.T) {
+	home := stageAuth(t, map[string]any{
+		".codex/auth.json": map[string]any{
+			"auth_mode": "chatgpt",
+			"tokens":    map[string]any{"account_id": "acct-x"},
+		},
+		".pi/agent/auth.json": map[string]any{
+			"openai-codex": map[string]any{"type": "oauth", "accountId": "acct-x"},
+			"anthropic":    map[string]any{"type": "oauth"},
+		},
+	})
+
+	codex := donorCodex(1000, 22)
+	cc := donorClaudeCode(2000, 47)
+	pi := emptyWrapper("pi", "pi-1")
+	InheritRateLimits([]*session.SessionState{codex, cc, pi}, home)
+
+	if pi.Metrics.RateLimit == nil {
+		t.Fatal("expected inheritance")
+	}
+	if pi.Metrics.RateLimit.SampledAt != 1000 {
+		t.Errorf("expected codex (openai) donor wins; got SampledAt=%d", pi.Metrics.RateLimit.SampledAt)
+	}
+}
+
+func TestInheritRateLimits_FreshestDonorWinsOnTies(t *testing.T) {
+	home := stageAuth(t, map[string]any{
+		".pi/agent/auth.json": map[string]any{
+			"anthropic": map[string]any{"type": "oauth"},
+		},
+	})
+
+	stale := donorClaudeCode(1000, 80)
+	fresh := donorClaudeCode(5000, 20)
+	pi := emptyWrapper("pi", "pi-1")
+	InheritRateLimits([]*session.SessionState{stale, fresh, pi}, home)
+
+	if pi.Metrics.RateLimit.SampledAt != 5000 {
+		t.Errorf("expected fresh donor (5000), got %d", pi.Metrics.RateLimit.SampledAt)
+	}
+}
+
+func TestInheritRateLimits_DoesNotOverwriteOwnSnapshot(t *testing.T) {
+	home := stageAuth(t, map[string]any{
+		".pi/agent/auth.json": map[string]any{
+			"anthropic": map[string]any{"type": "oauth"},
+		},
+	})
+
+	cc := donorClaudeCode(2000, 47)
+	pi := &session.SessionState{
+		SessionID: "pi-own",
+		Adapter:   "pi",
+		Metrics: &session.SessionMetrics{
+			RateLimit: &session.RateLimitSnapshot{SampledAt: 9999, PlanType: "self"},
+		},
+	}
+	InheritRateLimits([]*session.SessionState{cc, pi}, home)
+
+	if pi.Metrics.RateLimit.SampledAt != 9999 || pi.Metrics.RateLimit.PlanType != "self" {
+		t.Errorf("inheritance overwrote a session's own snapshot: %+v", pi.Metrics.RateLimit)
+	}
+}
+
+func TestInheritRateLimits_NoDonorIsNoOp(t *testing.T) {
+	home := stageAuth(t, map[string]any{
+		".pi/agent/auth.json": map[string]any{
+			"anthropic": map[string]any{"type": "oauth"},
+		},
+	})
+
+	pi := emptyWrapper("pi", "pi-1")
+	InheritRateLimits([]*session.SessionState{pi}, home)
+
+	if pi.Metrics.RateLimit != nil {
+		t.Fatal("expected no inheritance when no donor exists")
+	}
+}
+
+func TestInheritRateLimits_CodexAPIKeyDoesNotDonate(t *testing.T) {
+	// Codex on API-key auth (auth_mode != "chatgpt") shouldn't be
+	// treated as a subscription donor — its rate_limit reflects the
+	// API-key bucket, not the user's ChatGPT subscription.
+	home := stageAuth(t, map[string]any{
+		".codex/auth.json": map[string]any{
+			"auth_mode": "apikey",
+			"tokens":    map[string]any{"account_id": "ignored"},
+		},
+		".pi/agent/auth.json": map[string]any{
+			"openai-codex": map[string]any{"type": "oauth", "accountId": "acct-x"},
+		},
+	})
+
+	codex := donorCodex(1000, 22)
+	pi := emptyWrapper("pi", "pi-1")
+	InheritRateLimits([]*session.SessionState{codex, pi}, home)
+
+	if pi.Metrics.RateLimit != nil {
+		t.Fatal("api-key codex should not donate to pi")
+	}
+}

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -124,6 +124,8 @@ func (m *mockMetrics) ComputeMetrics(path, adapter string) (*session.SessionMetr
 
 func (m *mockMetrics) PruneEntry(path string) { m.pruned = append(m.pruned, path) }
 
+func (m *mockMetrics) IngestRateLimit(path string, snap *session.RateLimitSnapshot) {}
+
 // funcMetrics is a metrics collector whose ComputeMetrics behaviour can be
 // configured per test. Used to simulate a tailer that returns refreshed
 // metrics for already-persisted sessions during seedFromDisk.
@@ -139,6 +141,8 @@ func (m *funcMetrics) ComputeMetrics(path, adapter string) (*session.SessionMetr
 }
 
 func (m *funcMetrics) PruneEntry(path string) {}
+
+func (m *funcMetrics) IngestRateLimit(path string, snap *session.RateLimitSnapshot) {}
 
 // --- AgentWatcher mock -------------------------------------------------------
 

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -46,6 +46,13 @@ func handleGetSessions(repo outbound.SessionRepository, orchMonitor *services.Or
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
+		// Cross-account rate-limit inheritance (issue #309): wrapper
+		// sessions (Pi, OpenCode) inherit the subscription quota
+		// snapshot from a first-party CLI authenticated to the same
+		// OAuth account. Mutates `sessions` in place — the dashboard
+		// builder then sees the inherited snapshots and the chip
+		// renders for the wrapper just like it does for the donor.
+		services.InheritRateLimits(sessions, "")
 		resp := session.BuildDashboard(sessions, orchMonitor.State("gastown"))
 		if tracker != nil {
 			attachGroupCosts(resp, tracker, cache)

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -107,6 +107,15 @@ func main() {
 		logger.LogInfo("startup", "", "installed Claude Code hooks for permission tracking")
 	}
 
+	// Auto-install Claude Code statusLine.command for rate-limit ingestion
+	// (issue #309). Chains any user-configured statusline so we don't clobber
+	// it.
+	if modified, err := claudecode.EnsureStatuslineInstalled(); err != nil {
+		logger.LogError("startup", "", fmt.Sprintf("failed to install statusline: %v", err))
+	} else if modified {
+		logger.LogInfo("startup", "", "installed Claude Code statusline hook for rate-limit ingestion")
+	}
+
 	// Configuration.
 	cfg := config.Default()
 	if v := os.Getenv("IRRLICHT_MAX_SESSION_AGE"); v != "" {
@@ -381,6 +390,12 @@ func main() {
 	// The detector satisfies claudecode.HookTarget via HandlePermissionHook.
 	mux.HandleFunc("POST /api/v1/hooks/claudecode",
 		claudecode.NewHookHandler(detector, logger))
+
+	// Statusline receiver: Claude Code's per-tick statusline JSON, carrying
+	// rate_limits for Pro/Max subscribers (issue #309). Routes to the
+	// metrics adapter so the snapshot lands in the right session's tailer.
+	mux.HandleFunc("POST /api/v1/hooks/claudecode/statusline",
+		claudecode.NewStatuslineHandler(metricsCollector, logger))
 
 	// Lifecycle recording: opt-in via --record flag or IRRLICHT_RECORD=1.
 	// IRRLICHT_RECORDINGS_DIR overrides the default directory so test

--- a/core/domain/session/rate_limit.go
+++ b/core/domain/session/rate_limit.go
@@ -1,0 +1,158 @@
+package session
+
+import (
+	"time"
+)
+
+// RateLimitSnapshot is one provider-emitted reading of subscription quota.
+// Codex's schema is the superset; Claude Code's statusline JSON is a strict
+// subset that maps to a two-window snapshot (five_hour, seven_day) with no
+// credits and no reached-type.
+//
+// Snapshots are per-account: a Claude Pro/Max user running multiple sessions
+// on the same OAuth account sees identical Windows in every snapshot — the
+// bucket is account-scoped, not per-session.
+type RateLimitSnapshot struct {
+	// Windows holds one entry per rate-limit window (typically two: a 5-hour
+	// primary and a 7-day secondary). Order is provider-defined; callers
+	// pick the most-imminent for display.
+	Windows []RateLimitWindow `json:"windows"`
+
+	// PlanType identifies the subscription tier when the provider supplies
+	// one ("plus", "pro", "max", "team", "enterprise"). Empty for the
+	// API-key / usage path where Credits is populated instead.
+	PlanType string `json:"plan_type,omitempty"`
+
+	// Credits, when non-nil, indicates the user is on a prepaid / API-key
+	// path and the bucket is balance-based rather than time-window-based.
+	// Claude Code never populates this; Codex does on API-key auth.
+	Credits *CreditsSnapshot `json:"credits,omitempty"`
+
+	// ReachedType, when non-empty, signals that one of the windows has
+	// hit its cap. UI uses this to switch the display into a warning state.
+	ReachedType string `json:"reached_type,omitempty"`
+
+	// SampledAt is the wall-clock time at which the snapshot was observed,
+	// stored as Unix seconds. Used as the x-axis when computing burn rate.
+	SampledAt int64 `json:"sampled_at"`
+}
+
+// RateLimitWindow is a single time-windowed bucket reading.
+type RateLimitWindow struct {
+	// UsedPercent is the provider-reported utilization for this window
+	// expressed as a percentage in [0, 100]. Floats are preserved as-is —
+	// providers occasionally return values with floating-point noise (e.g.
+	// 14.000000000000002) which the UI should round, not the parser.
+	UsedPercent float64 `json:"used_percent"`
+
+	// WindowMinutes is the nominal window length. Codex emits this
+	// explicitly (300, 10080); Claude Code's flat five_hour / seven_day
+	// fields map to 300 and 10080 respectively. Some Codex v1 samples
+	// emit 299 / 10079 due to a server-side rounding quirk — the parser
+	// must tolerate both.
+	WindowMinutes int `json:"window_minutes"`
+
+	// ResetsAt is the wall-clock time (Unix seconds) at which the window
+	// rolls over and UsedPercent returns to zero.
+	ResetsAt int64 `json:"resets_at"`
+}
+
+// CreditsSnapshot describes a prepaid balance, populated only on the
+// API-key / usage path. Subscription users see Credits=nil.
+type CreditsSnapshot struct {
+	HasCredits bool    `json:"has_credits"`
+	Unlimited  bool    `json:"unlimited,omitempty"`
+	Balance    float64 `json:"balance,omitempty"`
+}
+
+// ImminentWindow returns the window with the soonest projected cap given the
+// current snapshot — defined as the one with the highest UsedPercent. Returns
+// nil when the snapshot has no windows or every window is at zero (rendering
+// has no signal to display).
+func (s *RateLimitSnapshot) ImminentWindow() *RateLimitWindow {
+	if s == nil || len(s.Windows) == 0 {
+		return nil
+	}
+	var best *RateLimitWindow
+	for i := range s.Windows {
+		w := &s.Windows[i]
+		if best == nil || w.UsedPercent > best.UsedPercent {
+			best = w
+		}
+	}
+	if best == nil || best.UsedPercent <= 0 {
+		return nil
+	}
+	return best
+}
+
+// ForecastCap projects when UsedPercent for the most-imminent window will hit
+// 100% given a history of snapshots. The projection is a simple linear fit
+// over the recent samples: rate = (latest.UsedPercent - earliest.UsedPercent)
+// / (latest.SampledAt - earliest.SampledAt). The history is expected to be
+// "sample on change" — callers should drop duplicate-percent samples before
+// passing them in so zero-delta noise from statusline ticks doesn't flatten
+// the slope (see issue #309 cadence-gotcha findings).
+//
+// Returns nil when:
+//   - history is shorter than 2 samples (no slope possible),
+//   - the slope is non-positive (usage is flat or decreasing),
+//   - the projected ETA is after the window's ResetsAt (the user won't hit
+//     the cap in the current window).
+//
+// The returned time is rounded to the nearest second.
+func ForecastCap(history []RateLimitSnapshot, now time.Time) *time.Time {
+	if len(history) < 2 {
+		return nil
+	}
+	latest := history[len(history)-1]
+	earliest := history[0]
+	imminent := latest.ImminentWindow()
+	if imminent == nil {
+		return nil
+	}
+	// Find the same window in the earliest snapshot — match on WindowMinutes
+	// rather than slice index, since providers may reorder. Tolerate ±1
+	// minute (Codex v1 quirk: 299/10079).
+	var prev *RateLimitWindow
+	for i := range earliest.Windows {
+		w := &earliest.Windows[i]
+		if abs(w.WindowMinutes-imminent.WindowMinutes) <= 1 {
+			prev = w
+			break
+		}
+	}
+	if prev == nil {
+		return nil
+	}
+	dtSeconds := latest.SampledAt - earliest.SampledAt
+	if dtSeconds <= 0 {
+		return nil
+	}
+	dPct := imminent.UsedPercent - prev.UsedPercent
+	if dPct <= 0 {
+		return nil
+	}
+	ratePerSecond := dPct / float64(dtSeconds)
+	remaining := 100.0 - imminent.UsedPercent
+	if remaining <= 0 {
+		// Already at or past the cap — surface the current time.
+		t := now.Round(time.Second)
+		return &t
+	}
+	secondsToCap := remaining / ratePerSecond
+	eta := time.Unix(latest.SampledAt, 0).Add(time.Duration(secondsToCap) * time.Second)
+	if imminent.ResetsAt > 0 && eta.After(time.Unix(imminent.ResetsAt, 0)) {
+		// Won't hit cap before the window rolls over.
+		return nil
+	}
+	eta = eta.Round(time.Second)
+	return &eta
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/core/domain/session/rate_limit.go
+++ b/core/domain/session/rate_limit.go
@@ -141,7 +141,12 @@ func ForecastCap(history []RateLimitSnapshot, now time.Time) *time.Time {
 		return &t
 	}
 	secondsToCap := remaining / ratePerSecond
-	eta := time.Unix(latest.SampledAt, 0).Add(time.Duration(secondsToCap) * time.Second)
+	// Convert the float seconds-until-cap to a Duration without first
+	// truncating the float: `Duration(secondsToCap) * Second` would
+	// cast 12.7 → 12 before multiplying, losing sub-second precision.
+	// Multiplying then casting preserves it (rounded by Duration's
+	// integer nanosecond representation).
+	eta := time.Unix(latest.SampledAt, 0).Add(time.Duration(secondsToCap * float64(time.Second)))
 	if imminent.ResetsAt > 0 && eta.After(time.Unix(imminent.ResetsAt, 0)) {
 		// Won't hit cap before the window rolls over.
 		return nil

--- a/core/domain/session/rate_limit_serialize_test.go
+++ b/core/domain/session/rate_limit_serialize_test.go
@@ -1,0 +1,58 @@
+package session
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSessionMetricsJSON_RateLimitFields confirms the new rate-limit fields
+// appear in serialized SessionMetrics with the expected JSON keys, and that
+// nil values are omitted (so API-key sessions don't carry empty keys).
+func TestSessionMetricsJSON_RateLimitFields(t *testing.T) {
+	eta := int64(1778761800)
+	m := &SessionMetrics{
+		RateLimit: &RateLimitSnapshot{
+			SampledAt: 1700000000,
+			PlanType:  "max",
+			Windows: []RateLimitWindow{
+				{UsedPercent: 47.5, WindowMinutes: 300, ResetsAt: 1778761800},
+				{UsedPercent: 14.0, WindowMinutes: 10080, ResetsAt: 1779188400},
+			},
+		},
+		RateLimitForecastEta: &eta,
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(out)
+
+	for _, want := range []string{
+		`"rate_limit":`,
+		`"plan_type":"max"`,
+		`"windows":[`,
+		`"used_percent":47.5`,
+		`"window_minutes":300`,
+		`"resets_at":1778761800`,
+		`"rate_limit_forecast_eta":1778761800`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("expected JSON to contain %q, got %s", want, s)
+		}
+	}
+}
+
+func TestSessionMetricsJSON_NilRateLimitOmitted(t *testing.T) {
+	m := &SessionMetrics{
+		// No RateLimit, no RateLimitForecastEta.
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	if strings.Contains(s, "rate_limit") {
+		t.Errorf("expected nil rate_limit fields to be omitted, got %s", s)
+	}
+}

--- a/core/domain/session/rate_limit_test.go
+++ b/core/domain/session/rate_limit_test.go
@@ -1,0 +1,111 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+func TestImminentWindow_PicksHighestPercent(t *testing.T) {
+	snap := &RateLimitSnapshot{
+		Windows: []RateLimitWindow{
+			{UsedPercent: 14, WindowMinutes: 10080, ResetsAt: 2000},
+			{UsedPercent: 47, WindowMinutes: 300, ResetsAt: 1000},
+		},
+	}
+	imm := snap.ImminentWindow()
+	if imm == nil {
+		t.Fatal("expected non-nil window")
+	}
+	if imm.WindowMinutes != 300 {
+		t.Fatalf("expected 5h window (300), got %d", imm.WindowMinutes)
+	}
+}
+
+func TestImminentWindow_AllZeroReturnsNil(t *testing.T) {
+	snap := &RateLimitSnapshot{
+		Windows: []RateLimitWindow{
+			{UsedPercent: 0, WindowMinutes: 300, ResetsAt: 1000},
+			{UsedPercent: 0, WindowMinutes: 10080, ResetsAt: 2000},
+		},
+	}
+	if snap.ImminentWindow() != nil {
+		t.Fatal("expected nil for all-zero windows")
+	}
+}
+
+func TestForecastCap_LinearProjection(t *testing.T) {
+	// Burn 10% over 600 seconds (10 minutes) → 1% per minute.
+	// At 30%, the cap is 70% away → 4200 seconds → 70 min from latest sample.
+	base := time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC)
+	history := []RateLimitSnapshot{
+		{
+			SampledAt: base.Unix(),
+			Windows:   []RateLimitWindow{{UsedPercent: 20, WindowMinutes: 300, ResetsAt: base.Add(2 * time.Hour).Unix()}},
+		},
+		{
+			SampledAt: base.Add(10 * time.Minute).Unix(),
+			Windows:   []RateLimitWindow{{UsedPercent: 30, WindowMinutes: 300, ResetsAt: base.Add(2 * time.Hour).Unix()}},
+		},
+	}
+	eta := ForecastCap(history, base.Add(10*time.Minute))
+	if eta == nil {
+		t.Fatal("expected non-nil eta")
+	}
+	want := base.Add(10*time.Minute + 70*time.Minute)
+	if !eta.Equal(want) {
+		t.Fatalf("expected eta %v, got %v", want, *eta)
+	}
+}
+
+func TestForecastCap_WontHitCapReturnsNil(t *testing.T) {
+	// 1% per 10 minutes → cap is 99% away → 990 minutes. Window resets in
+	// 60 minutes, so forecast must return nil.
+	base := time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC)
+	history := []RateLimitSnapshot{
+		{
+			SampledAt: base.Unix(),
+			Windows:   []RateLimitWindow{{UsedPercent: 0, WindowMinutes: 300, ResetsAt: base.Add(1 * time.Hour).Unix()}},
+		},
+		{
+			SampledAt: base.Add(10 * time.Minute).Unix(),
+			Windows:   []RateLimitWindow{{UsedPercent: 1, WindowMinutes: 300, ResetsAt: base.Add(1 * time.Hour).Unix()}},
+		},
+	}
+	if eta := ForecastCap(history, base.Add(10*time.Minute)); eta != nil {
+		t.Fatalf("expected nil eta when burn is too slow, got %v", *eta)
+	}
+}
+
+func TestForecastCap_FlatBurnReturnsNil(t *testing.T) {
+	base := time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC)
+	history := []RateLimitSnapshot{
+		{SampledAt: base.Unix(), Windows: []RateLimitWindow{{UsedPercent: 30, WindowMinutes: 300, ResetsAt: base.Add(1 * time.Hour).Unix()}}},
+		{SampledAt: base.Add(10 * time.Minute).Unix(), Windows: []RateLimitWindow{{UsedPercent: 30, WindowMinutes: 300, ResetsAt: base.Add(1 * time.Hour).Unix()}}},
+	}
+	if eta := ForecastCap(history, base.Add(10*time.Minute)); eta != nil {
+		t.Fatalf("expected nil for flat burn, got %v", *eta)
+	}
+}
+
+func TestForecastCap_SingleSampleReturnsNil(t *testing.T) {
+	base := time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC)
+	history := []RateLimitSnapshot{
+		{SampledAt: base.Unix(), Windows: []RateLimitWindow{{UsedPercent: 30, WindowMinutes: 300, ResetsAt: base.Add(1 * time.Hour).Unix()}}},
+	}
+	if eta := ForecastCap(history, base); eta != nil {
+		t.Fatalf("expected nil for single sample, got %v", *eta)
+	}
+}
+
+func TestForecastCap_ToleratesOffByOneWindowMinutes(t *testing.T) {
+	// Codex v1 quirk: earliest sample reports 299, latest reports 300.
+	// ImminentWindow uses 300; matching must tolerate ±1.
+	base := time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC)
+	history := []RateLimitSnapshot{
+		{SampledAt: base.Unix(), Windows: []RateLimitWindow{{UsedPercent: 20, WindowMinutes: 299, ResetsAt: base.Add(2 * time.Hour).Unix()}}},
+		{SampledAt: base.Add(10 * time.Minute).Unix(), Windows: []RateLimitWindow{{UsedPercent: 30, WindowMinutes: 300, ResetsAt: base.Add(2 * time.Hour).Unix()}}},
+	}
+	if eta := ForecastCap(history, base.Add(10*time.Minute)); eta == nil {
+		t.Fatal("expected forecast despite 299/300 window-minute mismatch")
+	}
+}

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -132,6 +132,20 @@ type SessionMetrics struct {
 	// Nil for sessions that have not used TaskCreate (including non-Claude-Code
 	// adapters).
 	Tasks []Task `json:"tasks,omitempty"`
+
+	// RateLimit is the most recent subscription quota snapshot observed for
+	// this session. Populated by the Codex parser (from token_count events)
+	// and by the Claude Code statusline hook. Nil when the underlying
+	// provider doesn't surface quota (API-key Claude Code, Bedrock, Vertex)
+	// or when no snapshot has arrived yet.
+	RateLimit *RateLimitSnapshot `json:"rate_limit,omitempty"`
+
+	// RateLimitForecastEta is the projected wall-clock time (Unix seconds)
+	// at which the most-imminent rate-limit window will hit 100%, computed
+	// from a rolling history of changed snapshots. Nil when forecasting is
+	// not possible — insufficient history, flat or decreasing burn rate,
+	// or the projected ETA exceeds the window's ResetsAt.
+	RateLimitForecastEta *int64 `json:"rate_limit_forecast_eta,omitempty"`
 }
 
 // SubagentCompletion is the domain mirror of tailer.SubagentCompletion. The
@@ -493,6 +507,8 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 		CumCacheCreationTokens: newM.CumCacheCreationTokens,
 		Tasks:                  newM.Tasks,
 		NoSubstantiveActivity:  newM.NoSubstantiveActivity,
+		RateLimit:              newM.RateLimit,
+		RateLimitForecastEta:   newM.RateLimitForecastEta,
 	}
 	if merged.ContextWindow == 0 && oldM.ContextWindow > 0 {
 		merged.ContextWindow = oldM.ContextWindow
@@ -541,6 +557,14 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 	// nil Tasks = "no data yet"; non-nil empty slice = "no tasks" — overwrite only for the latter.
 	if merged.Tasks == nil && oldM.Tasks != nil {
 		merged.Tasks = oldM.Tasks
+	}
+	// Rate-limit snapshots arrive sporadically — preserve the previous one
+	// across passes that didn't observe a fresh sample.
+	if merged.RateLimit == nil && oldM.RateLimit != nil {
+		merged.RateLimit = oldM.RateLimit
+	}
+	if merged.RateLimitForecastEta == nil && oldM.RateLimitForecastEta != nil {
+		merged.RateLimitForecastEta = oldM.RateLimitForecastEta
 	}
 	return merged
 }

--- a/core/e2e/e2e_helpers_test.go
+++ b/core/e2e/e2e_helpers_test.go
@@ -172,6 +172,8 @@ func (m *stubMetrics) ComputeMetrics(_, _ string) (*session.SessionMetrics, erro
 
 func (m *stubMetrics) PruneEntry(_ string) {}
 
+func (m *stubMetrics) IngestRateLimit(_ string, _ *session.RateLimitSnapshot) {}
+
 // testIdentity is the shared Identity value e2e tests stamp on every
 // watcher they hand to NewSessionDetector. NewSessionDetector's panic
 // guard requires a non-zero Identity; the actual Name doesn't matter to

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -135,6 +135,38 @@ type ParsedEvent struct {
 	ContentChars     int64  // character count for token estimation
 	CWD              string // working directory if found
 	PermissionMode   string // Claude Code only
+
+	// RateLimit, when non-nil, is a subscription-quota snapshot extracted from
+	// this event. Codex emits one per token_count event_msg; Claude Code feeds
+	// them in via the statusline hook (different path — parser only fills this
+	// for in-band transcript signals).
+	RateLimit *RateLimitSnapshot
+}
+
+// RateLimitSnapshot mirrors session.RateLimitSnapshot inside the tailer
+// package so parsers can emit snapshots without importing the domain. The
+// adapter glue (core/adapters/outbound/metrics) converts to the domain type
+// at the same boundary it converts Task and SubagentCompletion.
+type RateLimitSnapshot struct {
+	Windows     []RateLimitWindow
+	PlanType    string
+	Credits     *CreditsSnapshot
+	ReachedType string
+	SampledAt   int64
+}
+
+// RateLimitWindow mirrors session.RateLimitWindow.
+type RateLimitWindow struct {
+	UsedPercent   float64
+	WindowMinutes int
+	ResetsAt      int64
+}
+
+// CreditsSnapshot mirrors session.CreditsSnapshot.
+type CreditsSnapshot struct {
+	HasCredits bool
+	Unlimited  bool
+	Balance    float64
 }
 
 // TokenSnapshot holds a token breakdown from a single event.

--- a/core/pkg/tailer/rate_limit_test.go
+++ b/core/pkg/tailer/rate_limit_test.go
@@ -2,6 +2,7 @@ package tailer
 
 import (
 	"testing"
+	"time"
 )
 
 func newTailerForRateLimitTest(t *testing.T) *TranscriptTailer {
@@ -89,5 +90,36 @@ func TestIngestRateLimit_NilNoOp(t *testing.T) {
 	tt.IngestRateLimit(nil)
 	if tt.rateLimit != nil || len(tt.rateLimitHistory) != 0 {
 		t.Fatal("nil snapshot must be a no-op")
+	}
+}
+
+func TestRateLimitFullyStale(t *testing.T) {
+	now := time.Unix(2000, 0)
+	cases := []struct {
+		name string
+		snap *RateLimitSnapshot
+		want bool
+	}{
+		{"nil snapshot", nil, false},
+		{"no windows", &RateLimitSnapshot{}, false},
+		{"all future resets", &RateLimitSnapshot{Windows: []RateLimitWindow{
+			{ResetsAt: 3000}, {ResetsAt: 4000},
+		}}, false},
+		{"any past reset triggers stale", &RateLimitSnapshot{Windows: []RateLimitWindow{
+			{ResetsAt: 1000}, {ResetsAt: 4000},
+		}}, true},
+		{"all past", &RateLimitSnapshot{Windows: []RateLimitWindow{
+			{ResetsAt: 1000}, {ResetsAt: 1500},
+		}}, true},
+		{"zero ResetsAt ignored (treated as no data)", &RateLimitSnapshot{Windows: []RateLimitWindow{
+			{ResetsAt: 0}, {ResetsAt: 0},
+		}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rateLimitFullyStale(tc.snap, now); got != tc.want {
+				t.Errorf("rateLimitFullyStale = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/core/pkg/tailer/rate_limit_test.go
+++ b/core/pkg/tailer/rate_limit_test.go
@@ -1,6 +1,8 @@
 package tailer
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -93,7 +95,38 @@ func TestIngestRateLimit_NilNoOp(t *testing.T) {
 	}
 }
 
-func TestRateLimitFullyStale(t *testing.T) {
+// TestComputeMetrics_NullsStaleSnapshot wires the stale-check through
+// the real TailAndProcess path: ingest a snapshot with a past
+// resets_at, run a pass against an empty transcript, and assert the
+// surfaced metrics.RateLimit is nil. Catches regressions where the
+// stale logic is renamed/moved but the call-site isn't updated.
+func TestComputeMetrics_NullsStaleSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tt := NewTranscriptTailer(path, nil, "test")
+	staleResets := time.Now().Add(-1 * time.Hour).Unix()
+	tt.IngestRateLimit(&RateLimitSnapshot{
+		SampledAt: time.Now().Add(-2 * time.Hour).Unix(),
+		Windows: []RateLimitWindow{
+			{UsedPercent: 47, WindowMinutes: 300, ResetsAt: staleResets},
+		},
+	})
+	m, err := tt.TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+	if m.RateLimit != nil {
+		t.Errorf("expected stale snapshot to be nulled, got %+v", m.RateLimit)
+	}
+	if len(m.RateLimitHistory) != 0 {
+		t.Errorf("expected history to be cleared, got %d entries", len(m.RateLimitHistory))
+	}
+}
+
+func TestRateLimitHasStaleWindow(t *testing.T) {
 	now := time.Unix(2000, 0)
 	cases := []struct {
 		name string
@@ -117,8 +150,8 @@ func TestRateLimitFullyStale(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := rateLimitFullyStale(tc.snap, now); got != tc.want {
-				t.Errorf("rateLimitFullyStale = %v, want %v", got, tc.want)
+			if got := rateLimitHasStaleWindow(tc.snap, now); got != tc.want {
+				t.Errorf("rateLimitHasStaleWindow = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/core/pkg/tailer/rate_limit_test.go
+++ b/core/pkg/tailer/rate_limit_test.go
@@ -95,12 +95,13 @@ func TestIngestRateLimit_NilNoOp(t *testing.T) {
 	}
 }
 
-// TestComputeMetrics_NullsStaleSnapshot wires the stale-check through
-// the real TailAndProcess path: ingest a snapshot with a past
-// resets_at, run a pass against an empty transcript, and assert the
-// surfaced metrics.RateLimit is nil. Catches regressions where the
-// stale logic is renamed/moved but the call-site isn't updated.
-func TestComputeMetrics_NullsStaleSnapshot(t *testing.T) {
+// TestComputeMetrics_PreservesStaleSnapshot pins the post-iteration
+// behaviour: the daemon used to null stale snapshots, but that left
+// the macOS overlay header empty when Claude Code's statusline
+// stuttered. The UI now decorates stale data with a dimmer chip; the
+// daemon must surface the snapshot unchanged so the UI has data to
+// decorate.
+func TestComputeMetrics_PreservesStaleSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "transcript.jsonl")
 	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
@@ -108,51 +109,21 @@ func TestComputeMetrics_NullsStaleSnapshot(t *testing.T) {
 	}
 	tt := NewTranscriptTailer(path, nil, "test")
 	staleResets := time.Now().Add(-1 * time.Hour).Unix()
-	tt.IngestRateLimit(&RateLimitSnapshot{
+	snap := &RateLimitSnapshot{
 		SampledAt: time.Now().Add(-2 * time.Hour).Unix(),
 		Windows: []RateLimitWindow{
 			{UsedPercent: 47, WindowMinutes: 300, ResetsAt: staleResets},
 		},
-	})
+	}
+	tt.IngestRateLimit(snap)
 	m, err := tt.TailAndProcess()
 	if err != nil {
 		t.Fatalf("TailAndProcess: %v", err)
 	}
-	if m.RateLimit != nil {
-		t.Errorf("expected stale snapshot to be nulled, got %+v", m.RateLimit)
+	if m.RateLimit == nil {
+		t.Fatal("expected stale snapshot to be preserved on metrics, got nil")
 	}
-	if len(m.RateLimitHistory) != 0 {
-		t.Errorf("expected history to be cleared, got %d entries", len(m.RateLimitHistory))
-	}
-}
-
-func TestRateLimitHasStaleWindow(t *testing.T) {
-	now := time.Unix(2000, 0)
-	cases := []struct {
-		name string
-		snap *RateLimitSnapshot
-		want bool
-	}{
-		{"nil snapshot", nil, false},
-		{"no windows", &RateLimitSnapshot{}, false},
-		{"all future resets", &RateLimitSnapshot{Windows: []RateLimitWindow{
-			{ResetsAt: 3000}, {ResetsAt: 4000},
-		}}, false},
-		{"any past reset triggers stale", &RateLimitSnapshot{Windows: []RateLimitWindow{
-			{ResetsAt: 1000}, {ResetsAt: 4000},
-		}}, true},
-		{"all past", &RateLimitSnapshot{Windows: []RateLimitWindow{
-			{ResetsAt: 1000}, {ResetsAt: 1500},
-		}}, true},
-		{"zero ResetsAt ignored (treated as no data)", &RateLimitSnapshot{Windows: []RateLimitWindow{
-			{ResetsAt: 0}, {ResetsAt: 0},
-		}}, false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := rateLimitHasStaleWindow(tc.snap, now); got != tc.want {
-				t.Errorf("rateLimitHasStaleWindow = %v, want %v", got, tc.want)
-			}
-		})
+	if m.RateLimit.Windows[0].UsedPercent != 47 {
+		t.Errorf("unexpected snapshot mutation: %+v", m.RateLimit)
 	}
 }

--- a/core/pkg/tailer/rate_limit_test.go
+++ b/core/pkg/tailer/rate_limit_test.go
@@ -1,0 +1,93 @@
+package tailer
+
+import (
+	"testing"
+)
+
+func newTailerForRateLimitTest(t *testing.T) *TranscriptTailer {
+	t.Helper()
+	// Path doesn't need to exist for IngestRateLimit / ingestRateLimit —
+	// they don't touch the file system. Parser is unused but must be non-nil
+	// for the constructor's invariants.
+	return NewTranscriptTailer("/nonexistent", nil, "test")
+}
+
+func TestIngestRateLimit_FirstSampleAppended(t *testing.T) {
+	tt := newTailerForRateLimitTest(t)
+	snap := &RateLimitSnapshot{
+		SampledAt: 1000,
+		Windows:   []RateLimitWindow{{UsedPercent: 30, WindowMinutes: 300, ResetsAt: 2000}},
+	}
+	tt.IngestRateLimit(snap)
+	if tt.rateLimit != snap {
+		t.Fatal("expected latest snapshot to be retained")
+	}
+	if len(tt.rateLimitHistory) != 1 {
+		t.Fatalf("expected history length 1, got %d", len(tt.rateLimitHistory))
+	}
+}
+
+func TestIngestRateLimit_DuplicateNotAppended(t *testing.T) {
+	tt := newTailerForRateLimitTest(t)
+	snap1 := &RateLimitSnapshot{
+		SampledAt: 1000,
+		Windows:   []RateLimitWindow{{UsedPercent: 30, WindowMinutes: 300, ResetsAt: 2000}},
+	}
+	snap2 := &RateLimitSnapshot{
+		SampledAt: 1100, // different timestamp, same readings
+		Windows:   []RateLimitWindow{{UsedPercent: 30, WindowMinutes: 300, ResetsAt: 2000}},
+	}
+	tt.IngestRateLimit(snap1)
+	tt.IngestRateLimit(snap2)
+	if len(tt.rateLimitHistory) != 1 {
+		t.Fatalf("expected duplicate to be deduped, history len = %d", len(tt.rateLimitHistory))
+	}
+}
+
+func TestIngestRateLimit_RolloverResetsHistory(t *testing.T) {
+	tt := newTailerForRateLimitTest(t)
+	tt.IngestRateLimit(&RateLimitSnapshot{
+		SampledAt: 1000,
+		Windows:   []RateLimitWindow{{UsedPercent: 80, WindowMinutes: 300, ResetsAt: 2000}},
+	})
+	tt.IngestRateLimit(&RateLimitSnapshot{
+		SampledAt: 1500,
+		Windows:   []RateLimitWindow{{UsedPercent: 95, WindowMinutes: 300, ResetsAt: 2000}},
+	})
+	// Window rolls over: ResetsAt advances, percent drops back near zero.
+	tt.IngestRateLimit(&RateLimitSnapshot{
+		SampledAt: 2100,
+		Windows:   []RateLimitWindow{{UsedPercent: 2, WindowMinutes: 300, ResetsAt: 20000}},
+	})
+	if len(tt.rateLimitHistory) != 1 {
+		t.Fatalf("expected history reset on rollover; got %d entries", len(tt.rateLimitHistory))
+	}
+	if tt.rateLimitHistory[0].SampledAt != 2100 {
+		t.Errorf("expected post-rollover history to start at the new sample, got SampledAt=%d", tt.rateLimitHistory[0].SampledAt)
+	}
+}
+
+func TestIngestRateLimit_HistoryCappedAtFive(t *testing.T) {
+	tt := newTailerForRateLimitTest(t)
+	for i := range 10 {
+		tt.IngestRateLimit(&RateLimitSnapshot{
+			SampledAt: int64(1000 + i*60),
+			Windows:   []RateLimitWindow{{UsedPercent: float64(i + 1), WindowMinutes: 300, ResetsAt: 99999}},
+		})
+	}
+	if len(tt.rateLimitHistory) != rateLimitHistoryCap {
+		t.Fatalf("expected history capped at %d, got %d", rateLimitHistoryCap, len(tt.rateLimitHistory))
+	}
+	// Oldest dropped: the first retained sample is i=5 → UsedPercent=6.
+	if tt.rateLimitHistory[0].Windows[0].UsedPercent != 6 {
+		t.Errorf("expected oldest dropped, first window pct = %v", tt.rateLimitHistory[0].Windows[0].UsedPercent)
+	}
+}
+
+func TestIngestRateLimit_NilNoOp(t *testing.T) {
+	tt := newTailerForRateLimitTest(t)
+	tt.IngestRateLimit(nil)
+	if tt.rateLimit != nil || len(tt.rateLimitHistory) != 0 {
+		t.Fatal("nil snapshot must be a no-op")
+	}
+}

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -144,6 +144,20 @@ type SessionMetrics struct {
 	// TaskCreate / TaskUpdate tool_use events in the Claude Code transcript.
 	// Nil for sessions that have not called TaskCreate.
 	Tasks []Task `json:"tasks,omitempty"`
+
+	// RateLimit is the most recent rate-limit snapshot observed for this
+	// session. Populated by parsers that surface subscription quota (codex
+	// from token_count events) and by the Claude Code statusline hook
+	// receiver (which calls IngestRateLimit directly). Nil when no
+	// snapshot has been seen.
+	RateLimit *RateLimitSnapshot `json:"rate_limit,omitempty"`
+
+	// RateLimitHistory is a small rolling buffer of changed snapshots used
+	// to compute a burn-rate forecast. Sample-on-change: duplicates of the
+	// most recent used_percent values are dropped before append, so the
+	// slope calculation isn't diluted by zero-delta statusline ticks
+	// (issue #309). Capped at rateLimitHistoryCap entries.
+	RateLimitHistory []RateLimitSnapshot `json:"-"`
 }
 
 // TranscriptTailer monitors transcript files and computes metrics.
@@ -238,7 +252,20 @@ type TranscriptTailer struct {
 	// synthesize turn_done when the file has been quiet long enough. Zero
 	// means no line has been seen yet.
 	lastLineSeenAt time.Time
+
+	// rateLimit is the most recent snapshot observed; rateLimitHistory holds
+	// the rolling sample-on-change buffer (capped at rateLimitHistoryCap).
+	// In-memory only — after a daemon restart, the next few token_count or
+	// statusline events repopulate the history before forecasting resumes.
+	rateLimit        *RateLimitSnapshot
+	rateLimitHistory []RateLimitSnapshot
 }
+
+// rateLimitHistoryCap caps the rolling history at a small number of changed
+// samples. Larger windows blur the slope across burn-rate regime changes; a
+// 5-sample window is responsive to recent activity without being thrown off
+// by a single jumpy reading.
+const rateLimitHistoryCap = 5
 
 // NewTranscriptTailer creates a new tailer for the given transcript path.
 // The parser handles format-specific line parsing; adapter is used for model

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -79,6 +79,30 @@ func (t *TranscriptTailer) rateLimitChanged(snap *RateLimitSnapshot) bool {
 	return false
 }
 
+// rateLimitFullyStale reports whether any window in snap has a ResetsAt
+// strictly before now — the signal that at least one window has rolled
+// over since the last statusline tick and our cached percent reading no
+// longer matches the provider's current state. The whole snapshot is
+// dropped (rather than just the stale window) because `sampled_at` is
+// shared across windows, so a stale 5h means the whole snapshot pre-
+// dates whatever the provider currently reports.
+//
+// A nil receiver or empty Windows is not stale (nothing to invalidate).
+// Windows with ResetsAt == 0 are treated as "no expiry data, can't
+// judge" — also not stale.
+func rateLimitFullyStale(snap *RateLimitSnapshot, now time.Time) bool {
+	if snap == nil || len(snap.Windows) == 0 {
+		return false
+	}
+	nowUnix := now.Unix()
+	for _, w := range snap.Windows {
+		if w.ResetsAt > 0 && w.ResetsAt <= nowUnix {
+			return true
+		}
+	}
+	return false
+}
+
 // rateLimitRolledOver returns true when any window's ResetsAt has advanced
 // since the most recent history entry — the signal that the provider rolled
 // over to a fresh quota window and previous slope data is stale.
@@ -352,6 +376,17 @@ func (t *TranscriptTailer) computeMetrics() {
 	t.metrics.LastWasToolDenial = t.lastWasToolDenial
 	t.metrics.LastCWD = t.lastCWD
 	t.metrics.LastAssistantText = t.lastAssistantText
+	// Drop snapshots once any window has rolled over but no fresh
+	// statusline tick has arrived. Our cached percent reading then
+	// describes a window the provider has already reset, and the
+	// tooltip would render "resets in 0m" while the real reset
+	// happened minutes ago. Better to surface "no chip" until the
+	// next tick lands than to render stale data (issue #309 phase-5
+	// hotfix).
+	if rateLimitFullyStale(t.rateLimit, time.Now()) {
+		t.rateLimit = nil
+		t.rateLimitHistory = nil
+	}
 	t.metrics.RateLimit = t.rateLimit
 	if len(t.rateLimitHistory) > 0 {
 		t.metrics.RateLimitHistory = append([]RateLimitSnapshot(nil), t.rateLimitHistory...)

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -17,6 +17,85 @@ func (t *TranscriptTailer) applyMetadata(parsed *ParsedEvent) {
 	if parsed.PermissionMode != "" {
 		t.metrics.PermissionMode = parsed.PermissionMode
 	}
+	if parsed.RateLimit != nil {
+		t.ingestRateLimit(parsed.RateLimit)
+	}
+}
+
+// IngestRateLimit accepts an externally-sourced snapshot (the Claude Code
+// statusline hook receiver calls this with each POST payload). Identical to
+// the parser-driven path that runs inside applyMetadata; broken out so the
+// HTTP handler can update a session without driving the parser.
+func (t *TranscriptTailer) IngestRateLimit(snap *RateLimitSnapshot) {
+	if snap == nil {
+		return
+	}
+	t.ingestRateLimit(snap)
+}
+
+// ingestRateLimit updates the latest snapshot and appends to the rolling
+// history when the reading has actually changed. Sample-on-change is critical
+// for Claude Code's statusline path where the hook fires on every assistant
+// message regardless of whether the rate-limit counters moved — a naive
+// every-tick append would dilute the slope with zero-delta noise (issue #309).
+//
+// When a window's ResetsAt changes (the window rolled over and used_percent
+// snapped back to zero), the pre-rollover slope no longer applies to the new
+// window — the history is reset so the next forecast rebuilds from clean
+// post-rollover samples. A brief "no forecast yet" gap is preferable to a
+// nonsense projection that mixes two distinct windows.
+func (t *TranscriptTailer) ingestRateLimit(snap *RateLimitSnapshot) {
+	t.rateLimit = snap
+	if t.rateLimitRolledOver(snap) {
+		t.rateLimitHistory = nil
+	}
+	if t.rateLimitChanged(snap) {
+		t.rateLimitHistory = append(t.rateLimitHistory, *snap)
+		if len(t.rateLimitHistory) > rateLimitHistoryCap {
+			t.rateLimitHistory = t.rateLimitHistory[len(t.rateLimitHistory)-rateLimitHistoryCap:]
+		}
+	}
+}
+
+// rateLimitChanged returns true when snap differs materially from the most
+// recent history entry. Comparison is on (UsedPercent, WindowMinutes,
+// ResetsAt) for every window — anything else (plan_type, credits) doesn't
+// affect the forecast.
+func (t *TranscriptTailer) rateLimitChanged(snap *RateLimitSnapshot) bool {
+	if len(t.rateLimitHistory) == 0 {
+		return true
+	}
+	prev := t.rateLimitHistory[len(t.rateLimitHistory)-1]
+	if len(prev.Windows) != len(snap.Windows) {
+		return true
+	}
+	for i := range prev.Windows {
+		pw := prev.Windows[i]
+		nw := snap.Windows[i]
+		if pw.UsedPercent != nw.UsedPercent || pw.WindowMinutes != nw.WindowMinutes || pw.ResetsAt != nw.ResetsAt {
+			return true
+		}
+	}
+	return false
+}
+
+// rateLimitRolledOver returns true when any window's ResetsAt has advanced
+// since the most recent history entry — the signal that the provider rolled
+// over to a fresh quota window and previous slope data is stale.
+func (t *TranscriptTailer) rateLimitRolledOver(snap *RateLimitSnapshot) bool {
+	if len(t.rateLimitHistory) == 0 {
+		return false
+	}
+	prev := t.rateLimitHistory[len(t.rateLimitHistory)-1]
+	for i := range snap.Windows {
+		if i >= len(prev.Windows) {
+			break
+		}
+		if snap.Windows[i].ResetsAt > prev.Windows[i].ResetsAt {
+			return true
+		}
+	}
+	return false
 }
 
 // applyModelMetadata records the model name (with the [1m] extended-context
@@ -273,6 +352,12 @@ func (t *TranscriptTailer) computeMetrics() {
 	t.metrics.LastWasToolDenial = t.lastWasToolDenial
 	t.metrics.LastCWD = t.lastCWD
 	t.metrics.LastAssistantText = t.lastAssistantText
+	t.metrics.RateLimit = t.rateLimit
+	if len(t.rateLimitHistory) > 0 {
+		t.metrics.RateLimitHistory = append([]RateLimitSnapshot(nil), t.rateLimitHistory...)
+	} else {
+		t.metrics.RateLimitHistory = nil
+	}
 	if len(t.tasks) > 0 {
 		t.metrics.Tasks = append([]Task(nil), t.tasks...)
 	} else {

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -79,30 +79,6 @@ func (t *TranscriptTailer) rateLimitChanged(snap *RateLimitSnapshot) bool {
 	return false
 }
 
-// rateLimitHasStaleWindow reports whether snap contains at least one
-// window whose ResetsAt is at or before now — the signal that the
-// provider has rolled that window over since the last statusline tick
-// and our cached percent reading no longer matches reality. The whole
-// snapshot is treated as stale (rather than just the offending window)
-// because `sampled_at` is shared across windows: a stale 5h means the
-// whole snapshot pre-dates whatever the provider currently reports.
-//
-// A nil receiver or empty Windows is not stale (nothing to invalidate).
-// Windows with ResetsAt == 0 are treated as "no expiry data, can't
-// judge" — also not stale.
-func rateLimitHasStaleWindow(snap *RateLimitSnapshot, now time.Time) bool {
-	if snap == nil || len(snap.Windows) == 0 {
-		return false
-	}
-	nowUnix := now.Unix()
-	for _, w := range snap.Windows {
-		if w.ResetsAt > 0 && w.ResetsAt <= nowUnix {
-			return true
-		}
-	}
-	return false
-}
-
 // rateLimitRolledOver returns true when any window's ResetsAt has advanced
 // since the most recent history entry — the signal that the provider rolled
 // over to a fresh quota window and previous slope data is stale.
@@ -325,6 +301,19 @@ func (t *TranscriptTailer) computeMetrics() {
 	// more output). Skipping this would return CumInputTokens=0 in that window.
 	t.computeCumulativeTokens()
 
+	// Rate-limit snapshot has the same "must run even on empty pass"
+	// property — Claude Code's statusline hook can populate t.rateLimit
+	// out of band (no transcript line drives it), and the surface
+	// metrics need to expose that even on the first poll before any
+	// transcript activity exists. Lives above the early-return guard
+	// so an idle session still surfaces its last-known snapshot.
+	t.metrics.RateLimit = t.rateLimit
+	if len(t.rateLimitHistory) > 0 {
+		t.metrics.RateLimitHistory = append([]RateLimitSnapshot(nil), t.rateLimitHistory...)
+	} else {
+		t.metrics.RateLimitHistory = nil
+	}
+
 	if len(t.metrics.MessageHistory) == 0 {
 		t.metrics.MessagesPerMinute = 0
 		t.metrics.ElapsedSeconds = 0
@@ -376,23 +365,9 @@ func (t *TranscriptTailer) computeMetrics() {
 	t.metrics.LastWasToolDenial = t.lastWasToolDenial
 	t.metrics.LastCWD = t.lastCWD
 	t.metrics.LastAssistantText = t.lastAssistantText
-	// Drop snapshots once any window has rolled over but no fresh
-	// statusline tick has arrived. Our cached percent reading then
-	// describes a window the provider has already reset, and the
-	// tooltip would render "resets in 0m" while the real reset
-	// happened minutes ago. Better to surface "no chip" until the
-	// next tick lands than to render stale data (issue #309 phase-5
-	// hotfix).
-	if rateLimitHasStaleWindow(t.rateLimit, time.Now()) {
-		t.rateLimit = nil
-		t.rateLimitHistory = nil
-	}
-	t.metrics.RateLimit = t.rateLimit
-	if len(t.rateLimitHistory) > 0 {
-		t.metrics.RateLimitHistory = append([]RateLimitSnapshot(nil), t.rateLimitHistory...)
-	} else {
-		t.metrics.RateLimitHistory = nil
-	}
+	// (rate-limit fields are populated above the empty-MessageHistory
+	// early return so an idle session still surfaces its last-known
+	// snapshot — UI decorates staleness rather than dropping it.)
 	if len(t.tasks) > 0 {
 		t.metrics.Tasks = append([]Task(nil), t.tasks...)
 	} else {

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -79,18 +79,18 @@ func (t *TranscriptTailer) rateLimitChanged(snap *RateLimitSnapshot) bool {
 	return false
 }
 
-// rateLimitFullyStale reports whether any window in snap has a ResetsAt
-// strictly before now — the signal that at least one window has rolled
-// over since the last statusline tick and our cached percent reading no
-// longer matches the provider's current state. The whole snapshot is
-// dropped (rather than just the stale window) because `sampled_at` is
-// shared across windows, so a stale 5h means the whole snapshot pre-
-// dates whatever the provider currently reports.
+// rateLimitHasStaleWindow reports whether snap contains at least one
+// window whose ResetsAt is at or before now — the signal that the
+// provider has rolled that window over since the last statusline tick
+// and our cached percent reading no longer matches reality. The whole
+// snapshot is treated as stale (rather than just the offending window)
+// because `sampled_at` is shared across windows: a stale 5h means the
+// whole snapshot pre-dates whatever the provider currently reports.
 //
 // A nil receiver or empty Windows is not stale (nothing to invalidate).
 // Windows with ResetsAt == 0 are treated as "no expiry data, can't
 // judge" — also not stale.
-func rateLimitFullyStale(snap *RateLimitSnapshot, now time.Time) bool {
+func rateLimitHasStaleWindow(snap *RateLimitSnapshot, now time.Time) bool {
 	if snap == nil || len(snap.Windows) == 0 {
 		return false
 	}
@@ -383,7 +383,7 @@ func (t *TranscriptTailer) computeMetrics() {
 	// happened minutes ago. Better to surface "no chip" until the
 	// next tick lands than to render stale data (issue #309 phase-5
 	// hotfix).
-	if rateLimitFullyStale(t.rateLimit, time.Now()) {
+	if rateLimitHasStaleWindow(t.rateLimit, time.Now()) {
 		t.rateLimit = nil
 		t.rateLimitHistory = nil
 	}

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -94,6 +94,13 @@ type MetricsCollector interface {
 	// cache and the on-disk ledger file — when a session ends. Idempotent
 	// on a missing or already-removed entry.
 	PruneEntry(transcriptPath string)
+	// IngestRateLimit attaches a subscription-quota snapshot to the session
+	// associated with transcriptPath, when a tailer already exists for it.
+	// Used by the Claude Code statusline hook, which delivers rate-limit
+	// data out-of-band from the transcript stream. No-op when the tailer
+	// hasn't been created yet — the next ComputeMetrics will create one
+	// and the next statusline tick will populate it.
+	IngestRateLimit(transcriptPath string, snap *session.RateLimitSnapshot)
 }
 
 // PushBroadcaster fans out session state changes to subscribers (e.g. WebSocket clients).

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -59,6 +59,112 @@ struct SessionTask: Codable, Hashable {
     }
 }
 
+/// Subscription-quota window emitted by Anthropic / OpenAI subscription
+/// providers. Two windows typically arrive together (5h primary, 7d
+/// secondary). UsedPercent is the provider value as-is (may carry
+/// floating-point noise like 14.000000000000002 — round at render time,
+/// not at decode).
+struct RateLimitWindowInfo: Codable, Hashable {
+    let usedPercent: Double
+    let windowMinutes: Int
+    let resetsAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case usedPercent = "used_percent"
+        case windowMinutes = "window_minutes"
+        case resetsAt = "resets_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        usedPercent = try c.decode(Double.self, forKey: .usedPercent)
+        windowMinutes = try c.decode(Int.self, forKey: .windowMinutes)
+        let epoch = try c.decode(Double.self, forKey: .resetsAt)
+        resetsAt = Date(timeIntervalSince1970: epoch)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(usedPercent, forKey: .usedPercent)
+        try c.encode(windowMinutes, forKey: .windowMinutes)
+        try c.encode(resetsAt.timeIntervalSince1970, forKey: .resetsAt)
+    }
+}
+
+/// Prepaid credits balance, populated only when the user is on the API-key
+/// / usage path. Subscription users see `credits == nil`.
+struct CreditsInfo: Codable, Hashable {
+    let hasCredits: Bool
+    let unlimited: Bool?
+    let balance: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case hasCredits = "has_credits"
+        case unlimited, balance
+    }
+}
+
+/// One subscription-quota snapshot for a session. Mirrors
+/// session.RateLimitSnapshot in the Go daemon (issue #309). Carried under
+/// SessionMetrics.rateLimit; nil for sessions that don't surface a quota
+/// (API-key Claude Code, Bedrock, Vertex).
+struct RateLimitInfo: Codable, Hashable {
+    let windows: [RateLimitWindowInfo]
+    let planType: String?
+    let credits: CreditsInfo?
+    let reachedType: String?
+    let sampledAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case windows
+        case planType = "plan_type"
+        case credits
+        case reachedType = "reached_type"
+        case sampledAt = "sampled_at"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        windows = try c.decodeIfPresent([RateLimitWindowInfo].self, forKey: .windows) ?? []
+        planType = try c.decodeIfPresent(String.self, forKey: .planType)
+        credits = try c.decodeIfPresent(CreditsInfo.self, forKey: .credits)
+        reachedType = try c.decodeIfPresent(String.self, forKey: .reachedType)
+        let epoch = try c.decode(Double.self, forKey: .sampledAt)
+        sampledAt = Date(timeIntervalSince1970: epoch)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(windows, forKey: .windows)
+        try c.encodeIfPresent(planType, forKey: .planType)
+        try c.encodeIfPresent(credits, forKey: .credits)
+        try c.encodeIfPresent(reachedType, forKey: .reachedType)
+        try c.encode(sampledAt.timeIntervalSince1970, forKey: .sampledAt)
+    }
+
+    /// The window with the highest UsedPercent — the natural "next to hit
+    /// the cap" pick for the header display. Returns nil when no windows
+    /// carry a non-zero reading.
+    var imminentWindow: RateLimitWindowInfo? {
+        let nonZero = windows.filter { $0.usedPercent > 0 }
+        return nonZero.max { $0.usedPercent < $1.usedPercent }
+    }
+
+    /// Returns a friendly tier label for tooltip / display, e.g. "Claude
+    /// Max", "ChatGPT Plus", or nil when planType is empty/unset.
+    var planTypeLabel: String? {
+        guard let pt = planType, !pt.isEmpty else { return nil }
+        switch pt {
+        case "max": return "Claude Max"
+        case "pro": return "Claude Pro"
+        case "plus": return "ChatGPT Plus"
+        case "team": return "Team"
+        case "enterprise": return "Enterprise"
+        default: return pt.capitalized
+        }
+    }
+}
+
 // Performance metrics from transcript analysis
 struct SessionMetrics: Codable {
     let elapsedSeconds: Int64       // elapsed time when metrics were computed (for ready sessions)
@@ -71,6 +177,8 @@ struct SessionMetrics: Codable {
     let estimatedCostUSD: Double?   // estimated session cost in USD (nil if not available)
     let lastAssistantText: String?  // last assistant message text, truncated (~200 chars)
     let tasks: [SessionTask]?              // Claude Code task list (nil when TaskCreate never called)
+    let rateLimit: RateLimitInfo?          // subscription-quota snapshot (nil for API-key / Bedrock / Vertex)
+    let rateLimitForecastEta: Date?        // projected wall-clock time when the imminent window hits 100% (nil when unforecastable)
 
     enum CodingKeys: String, CodingKey {
         case elapsedSeconds = "elapsed_seconds"
@@ -83,6 +191,75 @@ struct SessionMetrics: Codable {
         case estimatedCostUSD = "estimated_cost_usd"
         case lastAssistantText = "last_assistant_text"
         case tasks
+        case rateLimit = "rate_limit"
+        case rateLimitForecastEta = "rate_limit_forecast_eta"
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        elapsedSeconds = try c.decodeIfPresent(Int64.self, forKey: .elapsedSeconds) ?? 0
+        totalTokens = try c.decodeIfPresent(Int64.self, forKey: .totalTokens) ?? 0
+        modelName = try c.decodeIfPresent(String.self, forKey: .modelName) ?? ""
+        contextWindow = try c.decodeIfPresent(Int64.self, forKey: .contextWindow)
+        contextUtilization = try c.decodeIfPresent(Double.self, forKey: .contextUtilization) ?? 0
+        pressureLevel = try c.decodeIfPresent(String.self, forKey: .pressureLevel) ?? "unknown"
+        contextWindowUnknown = try c.decodeIfPresent(Bool.self, forKey: .contextWindowUnknown)
+        estimatedCostUSD = try c.decodeIfPresent(Double.self, forKey: .estimatedCostUSD)
+        lastAssistantText = try c.decodeIfPresent(String.self, forKey: .lastAssistantText)
+        tasks = try c.decodeIfPresent([SessionTask].self, forKey: .tasks)
+        rateLimit = try c.decodeIfPresent(RateLimitInfo.self, forKey: .rateLimit)
+        if let epoch = try c.decodeIfPresent(Double.self, forKey: .rateLimitForecastEta) {
+            rateLimitForecastEta = Date(timeIntervalSince1970: epoch)
+        } else {
+            rateLimitForecastEta = nil
+        }
+    }
+
+    /// Explicit memberwise initializer for SwiftUI previews and tests that
+    /// build SessionMetrics in-process. New fields default to nil so existing
+    /// call sites compile without changes.
+    init(
+        elapsedSeconds: Int64,
+        totalTokens: Int64,
+        modelName: String,
+        contextWindow: Int64?,
+        contextUtilization: Double,
+        pressureLevel: String,
+        contextWindowUnknown: Bool?,
+        estimatedCostUSD: Double?,
+        lastAssistantText: String?,
+        tasks: [SessionTask]?,
+        rateLimit: RateLimitInfo? = nil,
+        rateLimitForecastEta: Date? = nil
+    ) {
+        self.elapsedSeconds = elapsedSeconds
+        self.totalTokens = totalTokens
+        self.modelName = modelName
+        self.contextWindow = contextWindow
+        self.contextUtilization = contextUtilization
+        self.pressureLevel = pressureLevel
+        self.contextWindowUnknown = contextWindowUnknown
+        self.estimatedCostUSD = estimatedCostUSD
+        self.lastAssistantText = lastAssistantText
+        self.tasks = tasks
+        self.rateLimit = rateLimit
+        self.rateLimitForecastEta = rateLimitForecastEta
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(elapsedSeconds, forKey: .elapsedSeconds)
+        try c.encode(totalTokens, forKey: .totalTokens)
+        try c.encode(modelName, forKey: .modelName)
+        try c.encodeIfPresent(contextWindow, forKey: .contextWindow)
+        try c.encode(contextUtilization, forKey: .contextUtilization)
+        try c.encode(pressureLevel, forKey: .pressureLevel)
+        try c.encodeIfPresent(contextWindowUnknown, forKey: .contextWindowUnknown)
+        try c.encodeIfPresent(estimatedCostUSD, forKey: .estimatedCostUSD)
+        try c.encodeIfPresent(lastAssistantText, forKey: .lastAssistantText)
+        try c.encodeIfPresent(tasks, forKey: .tasks)
+        try c.encodeIfPresent(rateLimit, forKey: .rateLimit)
+        try c.encodeIfPresent(rateLimitForecastEta.map { $0.timeIntervalSince1970 }, forKey: .rateLimitForecastEta)
     }
     
     // Computed properties for UI display

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -163,6 +163,72 @@ struct RateLimitInfo: Codable, Hashable {
         default: return pt.capitalized
         }
     }
+
+    /// Provider identity inferred from planType (when populated) or the
+    /// adapter that produced this snapshot. The bucket is account-scoped
+    /// at the subscription provider, not the CLI — multiple agents (Claude
+    /// Code + Pi(anthropic) + OpenCode(anthropic-oauth)) share a single
+    /// Anthropic subscription, so the chip should brand by provider.
+    ///
+    /// Returns "anthropic" / "openai" for known providers, or nil when
+    /// the snapshot doesn't tell us enough (rare: usually planType or the
+    /// adapter is enough). Callers fall back to the adapter icon when nil.
+    func providerKey(adapter: String?) -> String? {
+        switch planType {
+        case "max", "pro": return "anthropic"
+        case "plus": return "openai"
+        default: break
+        }
+        switch adapter {
+        case "claude-code": return "anthropic"
+        case "codex": return "openai"
+        default: return nil
+        }
+    }
+}
+
+/// Hardcoded provider-level icons, picked by RateLimitInfo.providerKey for
+/// the quota chip. These are subscription-provider icons (Anthropic,
+/// OpenAI) — distinct from the agent CLI icons in AgentRegistry, since
+/// many CLIs can share one subscription.
+///
+/// Lives Swift-side rather than in the Go AgentRegistry because providers
+/// don't have agent adapters in irrlicht; they are an orthogonal axis.
+enum ProviderIconRegistry {
+    /// Anthropic logomark — three angled strokes forming a stylized "A",
+    /// matched to the mockup in issue #309. White-on-transparent so it
+    /// inherits the foreground color when rendered as a template.
+    static let anthropicSVG = """
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24">
+      <path d="M14.83 4.5h-3.49l5.83 15h3.5l-5.84-15zM6.49 4.5l-5.83 15h3.57l1.19-3.13h6.09l1.2 3.13h3.57l-5.83-15H6.49zm-.05 8.98l1.99-5.2 1.99 5.2H6.44z" fill="currentColor"/>
+    </svg>
+    """
+
+    /// OpenAI mark — a simplified knot/whirl glyph.
+    static let openaiSVG = """
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24">
+      <path d="M22.28 9.821a5.985 5.985 0 0 0-.515-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.142-.08 4.774-2.758a.795.795 0 0 0 .392-.681v-6.737l2.018 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.488 4.493zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.778 2.758a.795.795 0 0 0 .787 0l5.832-3.367v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.077.077 0 0 1-.062 0l-4.83-2.79A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.077.077 0 0 1 .062 0l4.83 2.79a4.5 4.5 0 0 1-.676 8.05v-5.678a.79.79 0 0 0-.398-.66zm2.01-3.023l-.142-.085-4.774-2.782a.776.776 0 0 0-.787 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.504 4.504 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.392.681v6.737zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" fill="currentColor"/>
+    </svg>
+    """
+
+    /// Render the SVG for the given key into an NSImage sized to fit the
+    /// chip icon slot. Returns nil for unknown keys; callers fall back to
+    /// the adapter icon.
+    @MainActor
+    static func image(forKey key: String?) -> NSImage? {
+        guard let key = key else { return nil }
+        let svg: String
+        switch key {
+        case "anthropic": svg = anthropicSVG
+        case "openai": svg = openaiSVG
+        default: return nil
+        }
+        guard let data = svg.data(using: .utf8),
+              let img = NSImage(data: data) else { return nil }
+        img.isTemplate = true
+        img.size = NSSize(width: 14, height: 14)
+        return img
+    }
 }
 
 // Performance metrics from transcript analysis

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -187,6 +187,40 @@ struct RateLimitInfo: Codable, Hashable {
     }
 }
 
+/// Per-provider display preference, stored in @AppStorage under
+/// `providerMode_<key>`. Issue #309's maintainer comment asked for an
+/// explicit toggle so a user with multiple paths into the same provider
+/// (e.g. Anthropic Pro **and** Bedrock API key) can pick which view the
+/// chip should render. `auto` defers to snapshot detection — the
+/// default and the right choice for the typical single-path user.
+enum ProviderModePreference: String, CaseIterable, Identifiable {
+    case auto         // infer from snapshot.planType / snapshot.credits
+    case subscription // force the bars chip
+    case usage        // force the spend chip
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .auto: return "Auto"
+        case .subscription: return "Subscription"
+        case .usage: return "Usage"
+        }
+    }
+
+    /// AppStorage key for this provider. Stable across app launches.
+    static func storageKey(providerKey: String) -> String {
+        "providerMode_\(providerKey)"
+    }
+
+    /// Read the persisted preference for a provider. Falls back to
+    /// `.auto` for unknown keys or unparseable values.
+    static func current(for providerKey: String) -> ProviderModePreference {
+        let raw = UserDefaults.standard.string(forKey: storageKey(providerKey: providerKey)) ?? ""
+        return ProviderModePreference(rawValue: raw) ?? .auto
+    }
+}
+
 /// Hardcoded provider-level icons, picked by RateLimitInfo.providerKey for
 /// the quota chip. These are subscription-provider icons (Anthropic,
 /// OpenAI) — distinct from the agent CLI icons in AgentRegistry, since

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -887,16 +887,11 @@ struct SessionListView: View {
     }
     
     private var statusIndicator: some View {
-        HStack(spacing: 4) {
-            Circle()
-                .fill(statusColor)
-                .frame(width: 6, height: 6)
-                .shadow(color: statusColor.opacity(0.5), radius: 3)
-            Text(statusLabel)
-                .font(.caption2)
-                .foregroundColor(.secondary)
-        }
-        .tooltip(sessionManager.connectionState.tooltip)
+        Circle()
+            .fill(statusColor)
+            .frame(width: 6, height: 6)
+            .shadow(color: statusColor.opacity(0.5), radius: 3)
+            .tooltip(sessionManager.connectionState.tooltip)
     }
 
     private var statusColor: Color {
@@ -904,15 +899,6 @@ struct SessionListView: View {
         case .connected: return IrrColors.wsConnected
         case .connecting, .reconnecting: return IrrColors.wsConnecting
         case .disconnected: return IrrColors.wsDisconnected
-        }
-    }
-
-    private var statusLabel: String {
-        switch sessionManager.connectionState {
-        case .connected: return "watching"
-        case .connecting: return "connecting"
-        case .reconnecting: return "reconnecting"
-        case .disconnected: return "disconnected"
         }
     }
     

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -302,10 +302,10 @@ struct SessionListView: View {
             HStack(spacing: 6) {
                 headerTitleView
 
-                // Em-dash + glyphs are visually redundant once the quota
+                // Em-dash + glyphs are visually redundant once any quota
                 // chip is filling the slot — the chip already implies
-                // session activity. Hide them while the chip is present.
-                if quotaWidgetData == nil || !showQuotaForecast {
+                // session activity. Hide them while a chip is present.
+                if quotaChipData.isEmpty || !showQuotaForecast {
                     Text("—")
                         .foregroundColor(.secondary)
 
@@ -347,59 +347,76 @@ struct SessionListView: View {
         }
     }
     
-    /// Header slot shown to the left of the session glyphs. When any
-    /// visible session carries a rate-limit snapshot (and the user hasn't
-    /// hidden the quota chip in Settings), we render a provider chip with
-    /// stacked 5h/7d progress bars — matching the design mockup in
-    /// issue #309. Otherwise the slot is empty; the app version is
-    /// reachable from Settings rather than the header.
-    ///
-    /// Aggregation: pick the snapshot with the highest UsedPercent across
-    /// all visible sessions. The subscription bucket is account-scoped, so
-    /// every session on a single account reports the same numbers; `max`
-    /// is just robust to per-session staleness during the first few
-    /// post-restart ticks.
+    /// Header slot shown to the left of the session glyphs. Renders one
+    /// chip per subscription provider whose sessions have surfaced quota
+    /// data (Anthropic, OpenAI, …) — matching mockup 2 in issue #309.
+    /// Empty when no provider has a snapshot; the app version lives in
+    /// Settings rather than competing for this slot.
     @ViewBuilder
     private var headerTitleView: some View {
-        if showQuotaForecast, let widget = quotaWidgetData {
-            quotaChipView(widget)
+        if showQuotaForecast {
+            let chips = quotaChipData
+            if !chips.isEmpty {
+                HStack(spacing: 8) {
+                    ForEach(chips) { chip in
+                        quotaChipView(chip, compact: chips.count > 1)
+                    }
+                }
+            } else {
+                EmptyView()
+            }
         } else {
             EmptyView()
         }
     }
 
-    /// Snapshot picked for the header chip plus the adapter that produced
-    /// it (so the chip can render the correct provider icon). Nil when no
-    /// session has a usable snapshot.
-    private struct QuotaWidgetData {
+    /// One chip's worth of data: a representative snapshot for the
+    /// provider, the session that carries it (for icon lookup and forecast
+    /// access), and the most-imminent window for sort + headline display.
+    /// `id` is the providerKey so SwiftUI ForEach has a stable identity.
+    private struct QuotaWidgetData: Identifiable {
+        let id: String
         let snapshot: RateLimitInfo
         let session: SessionState
         let imminent: RateLimitWindowInfo
     }
 
-    private var quotaWidgetData: QuotaWidgetData? {
-        var best: QuotaWidgetData?
+    /// All chips to render, one per subscription provider. Groups
+    /// sessions by provider, picks the most-stressed snapshot within
+    /// each group as the representative reading (the bucket is
+    /// account-scoped, so every same-account session reports identical
+    /// numbers — `max` is just robust to per-session staleness).
+    /// Sorted by `imminent.usedPercent` descending so the provider
+    /// closest to its cap is leftmost.
+    private var quotaChipData: [QuotaWidgetData] {
+        var byProvider: [String: QuotaWidgetData] = [:]
         for session in sessionManager.sessions {
             guard let snap = session.metrics?.rateLimit else { continue }
             guard let imm = snap.imminentWindow else { continue }
-            let candidate = QuotaWidgetData(snapshot: snap, session: session, imminent: imm)
-            if let current = best {
-                if imm.usedPercent > current.imminent.usedPercent {
-                    best = candidate
+            // Without a providerKey the chip has no brand and shouldn't be
+            // aggregated — fall back to "unknown" so wrapper sessions
+            // (Pi, OpenCode) with subscription-shaped data still render
+            // their own chip rather than be silently dropped.
+            let key = snap.providerKey(adapter: session.adapter) ?? "unknown:\(session.adapter ?? "")"
+            let candidate = QuotaWidgetData(id: key, snapshot: snap, session: session, imminent: imm)
+            if let existing = byProvider[key] {
+                if imm.usedPercent > existing.imminent.usedPercent {
+                    byProvider[key] = candidate
                 }
             } else {
-                best = candidate
+                byProvider[key] = candidate
             }
         }
-        return best
+        return byProvider.values.sorted { $0.imminent.usedPercent > $1.imminent.usedPercent }
     }
 
-    /// The chip-style header widget: provider icon on the left, two
-    /// horizontal progress bars stacked on the right (5h primary + 7d
-    /// secondary). Each bar carries its window label, percent, and reset
-    /// time inline. Matches mockup 1 in issue #309.
+    /// The chip-style header widget: provider icon + stacked 5h/7d bars.
+    /// Matches mockup 1 (single chip) and mockup 2 (multiple chips
+    /// side-by-side) in issue #309. The `compact` flag tightens spacing
+    /// and drops the inline reset time when several chips share the
+    /// header — full info is always available in the tooltip.
     @ViewBuilder
-    private func quotaChipView(_ d: QuotaWidgetData) -> some View {
+    private func quotaChipView(_ d: QuotaWidgetData, compact: Bool) -> some View {
         HStack(spacing: 6) {
             // Provider icon (Anthropic / OpenAI) when we can infer one;
             // otherwise fall back to the adapter icon so the chip never
@@ -413,17 +430,18 @@ struct SessionListView: View {
             }
             VStack(alignment: .leading, spacing: 1) {
                 ForEach(d.snapshot.windows, id: \.windowMinutes) { window in
-                    quotaWindowRow(window)
+                    quotaWindowRow(window, compact: compact)
                 }
             }
         }
         .tooltip(quotaTooltip(d))
     }
 
-    /// One row inside the chip: window label · filled bar · percent · reset
-    /// time. Bar fill color comes from the pressure ramp.
+    /// One row inside a chip. In compact mode (multiple chips visible)
+    /// the inline reset time is dropped — it lives in the tooltip — and
+    /// the bar shrinks so two or three chips fit in the 380pt header.
     @ViewBuilder
-    private func quotaWindowRow(_ w: RateLimitWindowInfo) -> some View {
+    private func quotaWindowRow(_ w: RateLimitWindowInfo, compact: Bool) -> some View {
         HStack(spacing: 6) {
             Text(quotaWindowLabel(w.windowMinutes))
                 .font(.system(size: 9, weight: .medium, design: .monospaced))
@@ -431,18 +449,20 @@ struct SessionListView: View {
                 .frame(width: 14, alignment: .leading)
 
             quotaBar(percent: w.usedPercent, color: barColor(w.usedPercent))
-                .frame(width: 70, height: 5)
+                .frame(width: compact ? 40 : 70, height: 5)
 
             Text("\(Int(w.usedPercent.rounded()))%")
                 .font(.system(size: 9, weight: .medium, design: .monospaced))
                 .foregroundColor(.primary)
                 .frame(width: 28, alignment: .trailing)
 
-            Text("resets \(formatResetTime(w.resetsAt))")
-                .font(.system(size: 9, design: .monospaced))
-                .foregroundColor(.secondary)
-                .lineLimit(1)
-                .truncationMode(.tail)
+            if !compact {
+                Text("resets \(formatResetTime(w.resetsAt))")
+                    .font(.system(size: 9, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
         }
     }
 

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -437,6 +437,7 @@ struct SessionListView: View {
         let session: SessionState
         let imminent: RateLimitWindowInfo?
         let totalCostUSD: Double
+        let isStale: Bool
     }
 
     /// All chips to render, one per subscription/usage provider. See
@@ -459,6 +460,12 @@ struct SessionListView: View {
         var imminent: RateLimitWindowInfo?
         var totalCostUSD: Double
         var mode: QuotaMode
+        /// True when any window's resetsAt is at or before now — the
+        /// snapshot describes a window the provider has rolled over
+        /// without us seeing a fresh tick. Surfaced via dimmer chip
+        /// rendering + tooltip note rather than dropped entirely, so
+        /// users see the last-known state instead of an empty header.
+        var isStale: Bool
 
         func toWidgetData(id: String) -> QuotaWidgetData {
             QuotaWidgetData(
@@ -467,7 +474,8 @@ struct SessionListView: View {
                 snapshot: snapshot,
                 session: session,
                 imminent: imminent,
-                totalCostUSD: totalCostUSD
+                totalCostUSD: totalCostUSD,
+                isStale: isStale
             )
         }
     }
@@ -496,7 +504,8 @@ struct SessionListView: View {
     /// daemon-side per-provider cost tracker (issue #385).
     private func mergeIntoBuckets(session: SessionState, into buckets: inout [String: ChipBucket]) {
         guard let snap = session.metrics?.rateLimit else { return }
-        if snap.windows.contains(where: { $0.resetsAt <= Date() }) { return }
+        let now = Date()
+        let snapIsStale = snap.windows.contains(where: { $0.resetsAt <= now })
         let key = snap.providerKey(adapter: session.adapter)
             ?? "unknown:\(session.adapter ?? "")"
         let mode = resolveChipMode(snap: snap, providerKey: key)
@@ -511,7 +520,17 @@ struct SessionListView: View {
                 existing.snapshot = snap
                 existing.session = session
                 existing.imminent = imminent
-            } else if snap.sampledAt > existing.snapshot.sampledAt {
+                existing.isStale = snapIsStale
+            } else if existing.isStale && !snapIsStale {
+                // Always prefer a fresh snapshot over a stale one,
+                // regardless of which has the higher sampledAt — a
+                // pre-rollover snapshot can be "newer" by timestamp
+                // but still describe a window that already reset.
+                existing.snapshot = snap
+                existing.session = session
+                existing.imminent = imminent
+                existing.isStale = false
+            } else if existing.isStale == snapIsStale && snap.sampledAt > existing.snapshot.sampledAt {
                 existing.snapshot = snap
                 existing.session = session
                 existing.imminent = imminent
@@ -524,7 +543,8 @@ struct SessionListView: View {
                 session: session,
                 imminent: imminent,
                 totalCostUSD: sessionCost,
-                mode: mode
+                mode: mode,
+                isStale: snapIsStale
             )
         }
     }
@@ -581,6 +601,11 @@ struct SessionListView: View {
                 quotaUsageBody(d, compact: compact)
             }
         }
+        // Stale snapshots render at half opacity so the user can tell
+        // the data pre-dates the current window — the values are still
+        // visible (better than an empty header) but visibly muted, and
+        // the tooltip names the staleness explicitly.
+        .opacity(d.isStale ? 0.5 : 1.0)
         .tooltip(quotaTooltip(d))
     }
 
@@ -634,7 +659,9 @@ struct SessionListView: View {
                 .foregroundColor(.secondary)
                 .frame(width: 14, alignment: .leading)
 
-            quotaBar(percent: w.usedPercent, color: barColor(w.usedPercent))
+            quotaBar(percent: w.usedPercent,
+                     color: barColor(used: w.usedPercent, pace: quotaPacePercent(w)),
+                     pacePercent: quotaPacePercent(w))
                 .frame(width: compact ? 40 : 70, height: 5)
 
             Text("\(Int(w.usedPercent.rounded()))%")
@@ -652,11 +679,35 @@ struct SessionListView: View {
         }
     }
 
-    /// A simple rounded-rect progress bar. ZStack so the fill and the
-    /// track render with the same corner radius without clipping
+    /// "Expected percent used if you've been pacing evenly through the
+    /// window so far." Anchored to current wall-clock time, not the
+    /// snapshot's `sampledAt` — the marker should always reflect where
+    /// the user *should be* right now, independent of when the
+    /// snapshot was last refreshed.
+    ///
+    /// Returns nil when the window can't be paced: zero-duration,
+    /// missing `resetsAt`, or a `resetsAt` that's already in the past
+    /// (which the daemon's stale-check should have dropped, but
+    /// belt-and-braces here too).
+    private func quotaPacePercent(_ w: RateLimitWindowInfo) -> Double? {
+        guard w.windowMinutes > 0 else { return nil }
+        guard w.resetsAt.timeIntervalSince1970 > 0 else { return nil }
+        let windowSeconds = Double(w.windowMinutes) * 60
+        let windowStart = w.resetsAt.addingTimeInterval(-windowSeconds)
+        let elapsed = Date().timeIntervalSince(windowStart)
+        let pct = (elapsed / windowSeconds) * 100.0
+        return min(100, max(0, pct))
+    }
+
+    /// A rounded-rect progress bar with an optional vertical pace
+    /// marker (thin red line at `pacePercent`). The marker reads
+    /// "where you should be if you've been pacing evenly" — fill past
+    /// the marker means burning quota faster than the window's linear
+    /// rate; fill behind it means headroom. ZStack so the fill, track,
+    /// and marker render with the same corner radius without clipping
     /// artifacts at small sizes.
     @ViewBuilder
-    private func quotaBar(percent: Double, color: Color) -> some View {
+    private func quotaBar(percent: Double, color: Color, pacePercent: Double?) -> some View {
         GeometryReader { geo in
             ZStack(alignment: .leading) {
                 RoundedRectangle(cornerRadius: 2.5)
@@ -664,6 +715,12 @@ struct SessionListView: View {
                 RoundedRectangle(cornerRadius: 2.5)
                     .fill(color)
                     .frame(width: geo.size.width * min(1.0, max(0.0, percent / 100.0)))
+                if let pace = pacePercent, (0...100).contains(pace) {
+                    Rectangle()
+                        .fill(Color.red)
+                        .frame(width: 1)
+                        .offset(x: geo.size.width * (pace / 100.0) - 0.5)
+                }
             }
         }
     }
@@ -672,6 +729,9 @@ struct SessionListView: View {
         var lines: [String] = []
         if let plan = d.snapshot.planTypeLabel {
             lines.append(plan)
+        }
+        if d.isStale {
+            lines.append("⚠️ snapshot pre-dates current window — waiting for next statusline tick")
         }
         switch d.mode {
         case .subscription:
@@ -684,7 +744,17 @@ struct SessionListView: View {
                 let pct = "\(Int(w.usedPercent.rounded()))%"
                 let label = quotaWindowLabel(w.windowMinutes)
                 let resets = formatTimeUntil(w.resetsAt)
-                lines.append("\(label): \(pct) · resets in \(resets)")
+                var line = "\(label): \(pct) · resets in \(resets)"
+                if let pace = quotaPacePercent(w) {
+                    let paceInt = Int(pace.rounded())
+                    let delta = Int(w.usedPercent.rounded()) - paceInt
+                    let verdict: String
+                    if delta > 0 { verdict = "ahead by \(delta)pt" }
+                    else if delta < 0 { verdict = "behind by \(-delta)pt" }
+                    else { verdict = "on pace" }
+                    line += " · pace \(paceInt)% (\(verdict))"
+                }
+                lines.append(line)
             }
             if let eta = d.session.metrics?.rateLimitForecastEta {
                 lines.append("Projected cap: \(formatClockTime(eta))")
@@ -721,13 +791,43 @@ struct SessionListView: View {
         }
     }
 
-    private func barColor(_ pct: Double) -> Color {
-        switch pct {
-        case 90...: return IrrColors.pressureCritical
-        case 80..<90: return IrrColors.pressureHigh
-        case 60..<80: return IrrColors.pressureMedium
-        default: return IrrColors.pressureLow
+    /// Pace-aware bar tint. The ramp is driven by how far the fill is
+    /// *ahead of* the steady-state pace marker rather than by raw
+    /// `used_percent` alone — burning 60% in the first hour of a 5h
+    /// window is more alarming than burning 60% in the fourth hour.
+    ///
+    /// Red is intentionally absent from the fill palette so it doesn't
+    /// blur into the red pace marker: high-severity states use orange.
+    /// Note: the `IrrColors.pressure*` tokens are misnamed —
+    /// `pressureMedium` is system orange and `pressureHigh` is system
+    /// red — so we bypass them and use SwiftUI's `.yellow` / `.orange`
+    /// directly for unambiguous intent.
+    ///
+    /// Rules:
+    ///   - `used - pace` ≥ 15pt, or `used` ≥ 85% → orange: you're
+    ///     burning fast enough to blow the window before reset, or
+    ///     the cap is imminent regardless of pace.
+    ///   - `used - pace` ≥ 5pt                   → yellow: noticeable
+    ///     overshoot but recoverable.
+    ///   - otherwise                              → green: on pace or
+    ///     behind, plenty of headroom.
+    ///
+    /// When `pace` is nil (no expiry data on the window) we fall back
+    /// to a purely absolute ramp so the chip still has a sensible
+    /// color in that edge case.
+    private func barColor(used: Double, pace: Double?) -> Color {
+        if used >= 85 { return .orange }
+        guard let pace = pace else {
+            switch used {
+            case 70...: return .orange
+            case 50...: return .yellow
+            default: return IrrColors.pressureLow
+            }
         }
+        let delta = used - pace
+        if delta >= 15 { return .orange }
+        if delta >= 5 { return .yellow }
+        return IrrColors.pressureLow
     }
 
     private func formatClockTime(_ date: Date) -> String {

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -662,7 +662,7 @@ struct SessionListView: View {
             quotaBar(percent: w.usedPercent,
                      color: barColor(used: w.usedPercent, pace: quotaPacePercent(w)),
                      pacePercent: quotaPacePercent(w))
-                .frame(width: compact ? 40 : 70, height: 5)
+                .frame(width: compact ? 60 : 70, height: 5)
 
             Text("\(Int(w.usedPercent.rounded()))%")
                 .font(.system(size: 9, weight: .medium, design: .monospaced))

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -683,7 +683,12 @@ struct SessionListView: View {
         switch d.mode {
         case .subscription:
             for w in d.snapshot.windows {
-                let pct = String(format: "%.1f%%", w.usedPercent)
+                // Provider data is integer-precision (any decimals are
+                // floating-point noise from a JSON marshal/unmarshal
+                // round-trip on the daemon side, e.g. 7.000000000000001
+                // for a value the provider reported as 7). Render as
+                // whole percent so the tooltip matches the chip body.
+                let pct = "\(Int(w.usedPercent.rounded()))%"
                 let label = quotaWindowLabel(w.windowMinutes)
                 let resets = formatTimeUntil(w.resetsAt)
                 lines.append("\(label): \(pct) · resets in \(resets)")

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -386,8 +386,13 @@ struct SessionListView: View {
     /// each group as the representative reading (the bucket is
     /// account-scoped, so every same-account session reports identical
     /// numbers — `max` is just robust to per-session staleness).
-    /// Sorted by `imminent.usedPercent` descending so the provider
-    /// closest to its cap is leftmost.
+    ///
+    /// Sort order is **stable by provider key** (anthropic < openai <
+    /// unknown:…). An earlier version sorted by `usedPercent` descending
+    /// to surface the most-stressed provider first, but that made chips
+    /// swap positions every few seconds as percents updated — the
+    /// flicker drowned out the actual signal. A fixed alphabetical
+    /// order also matches the layout in mockup 2 (Anthropic leftmost).
     private var quotaChipData: [QuotaWidgetData] {
         var byProvider: [String: QuotaWidgetData] = [:]
         for session in sessionManager.sessions {
@@ -407,7 +412,7 @@ struct SessionListView: View {
                 byProvider[key] = candidate
             }
         }
-        return byProvider.values.sorted { $0.imminent.usedPercent > $1.imminent.usedPercent }
+        return byProvider.values.sorted { $0.id < $1.id }
     }
 
     /// The chip-style header widget: provider icon + stacked 5h/7d bars.

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -439,116 +439,109 @@ struct SessionListView: View {
         let totalCostUSD: Double
     }
 
-    /// All chips to render, one per subscription/usage provider. Groups
-    /// sessions by provider, then per group decides whether to render a
-    /// subscription chip (snapshot has `planType`) or a usage chip
-    /// (snapshot has `credits` populated — Codex API-key path).
+    /// All chips to render, one per subscription/usage provider. See
+    /// `bucketForChips` for the bucketing rules.
+    private var quotaChipData: [QuotaWidgetData] {
+        var byProvider: [String: ChipBucket] = [:]
+        for session in sessionManager.sessions {
+            mergeIntoBuckets(session: session, into: &byProvider)
+        }
+        return byProvider
+            .map { id, b in b.toWidgetData(id: id) }
+            .sorted { $0.id < $1.id }
+    }
+
+    /// Mutable accumulator for one provider bucket while folding
+    /// sessions into chips.
+    private struct ChipBucket {
+        var snapshot: RateLimitInfo
+        var session: SessionState
+        var imminent: RateLimitWindowInfo?
+        var totalCostUSD: Double
+        var mode: QuotaMode
+
+        func toWidgetData(id: String) -> QuotaWidgetData {
+            QuotaWidgetData(
+                id: id,
+                mode: mode,
+                snapshot: snapshot,
+                session: session,
+                imminent: imminent,
+                totalCostUSD: totalCostUSD
+            )
+        }
+    }
+
+    /// Fold one session's snapshot into the provider buckets.
     ///
-    /// Within a subscription bucket the representative snapshot is the
-    /// **freshest** sample (largest `sampledAt`). The earlier rule —
-    /// "highest `usedPercent`" — locked the chip onto stale ready
-    /// sessions: a finished Anthropic session whose 5h window had
-    /// rolled over at 16% used would beat every fresh active session
-    /// reading 2% post-rollover, leaving the chip stuck on the bad
-    /// data forever. The bucket is account-scoped so all live sessions
-    /// on a single account report identical numbers anyway; freshness
-    /// only matters when one session has gone stale.
+    /// Skips sessions without a snapshot and snapshots with any window
+    /// past `resetsAt` — same rule as the daemon-side stale check, but
+    /// applied here too because persisted ready sessions retain their
+    /// last-known data on disk and bypass the daemon recompute.
     ///
-    /// Snapshots whose any window has already passed `resetsAt` are
-    /// filtered out before bucketing — they describe a provider state
-    /// the agent has long since exited (issue #309 phase-5 hotfix).
-    /// Defense in depth: the daemon also nulls stale snapshots in its
-    /// own metrics path, but persisted ready sessions retain their
-    /// last-known data on disk and bypass that check.
+    /// Within a bucket the representative snapshot is the **freshest**
+    /// sample (largest `sampledAt`). An earlier rule — "highest
+    /// `usedPercent`" — locked the chip onto stale ready sessions: a
+    /// finished Anthropic session whose 5h window had rolled over at
+    /// 16% would beat every fresh active session reading 2% post-
+    /// rollover, leaving the chip stuck on the bad data forever. The
+    /// bucket is account-scoped so all live sessions on a single
+    /// account report identical numbers anyway; freshness only matters
+    /// when one session has gone stale.
     ///
     /// For usage chips, `totalCostUSD` sums cumulative
     /// `estimatedCostUSD` across every matching session — close enough
     /// to "what the user has spent on this provider lately" for the
-    /// typical session-lifetime; proper daily rollup needs a
-    /// daemon-side per-provider cost tracker (deferred).
-    ///
-    /// Sort order is **stable by provider key** (anthropic < openai <
-    /// unknown:…). A `usedPercent` sort made chips swap positions
-    /// every few seconds as percents updated — alphabetical also
-    /// matches mockup 2's Anthropic-leftmost layout.
-    private var quotaChipData: [QuotaWidgetData] {
-        struct Bucket {
-            var snapshot: RateLimitInfo
-            var session: SessionState
-            var imminent: RateLimitWindowInfo?
-            var totalCostUSD: Double
-            var mode: QuotaMode
-        }
-        let now = Date()
-        var byProvider: [String: Bucket] = [:]
-        for session in sessionManager.sessions {
-            guard let snap = session.metrics?.rateLimit else { continue }
-            // Drop snapshots with any window past its reset. Same rule
-            // as the daemon-side stale check; applied here so stale
-            // persisted-but-ready sessions don't pollute the bucket.
-            if snap.windows.contains(where: { $0.resetsAt <= now }) {
-                continue
+    /// typical session-lifetime. Proper daily rollup needs a
+    /// daemon-side per-provider cost tracker (issue #385).
+    private func mergeIntoBuckets(session: SessionState, into buckets: inout [String: ChipBucket]) {
+        guard let snap = session.metrics?.rateLimit else { return }
+        if snap.windows.contains(where: { $0.resetsAt <= Date() }) { return }
+        let key = snap.providerKey(adapter: session.adapter)
+            ?? "unknown:\(session.adapter ?? "")"
+        let mode = resolveChipMode(snap: snap, providerKey: key)
+        let imminent = snap.imminentWindow
+        let sessionCost = session.metrics?.estimatedCostUSD ?? 0
+        if var existing = buckets[key] {
+            // Subscription wins over usage when both paths are seen
+            // (rare — one OAuth account on both subscription and API
+            // key): the bars are the richer signal.
+            if existing.mode == .usage && mode == .subscription {
+                existing.mode = .subscription
+                existing.snapshot = snap
+                existing.session = session
+                existing.imminent = imminent
+            } else if snap.sampledAt > existing.snapshot.sampledAt {
+                existing.snapshot = snap
+                existing.session = session
+                existing.imminent = imminent
             }
-            // Without a providerKey the chip has no brand — fall back to
-            // a per-adapter unknown bucket so wrapper sessions (Pi,
-            // OpenCode) with subscription-shaped data still render their
-            // own chip rather than being silently dropped.
-            let key = snap.providerKey(adapter: session.adapter) ?? "unknown:\(session.adapter ?? "")"
-            // Per-provider mode preference (Settings → Providers): when
-            // set to `.subscription` or `.usage` it overrides snapshot
-            // detection, so a user with multiple paths into the same
-            // provider can pin the display to the view they care about.
-            let preference = ProviderModePreference.current(for: key)
-            let inferredMode: QuotaMode = (snap.credits != nil && (snap.planType ?? "").isEmpty)
+            existing.totalCostUSD += sessionCost
+            buckets[key] = existing
+        } else {
+            buckets[key] = ChipBucket(
+                snapshot: snap,
+                session: session,
+                imminent: imminent,
+                totalCostUSD: sessionCost,
+                mode: mode
+            )
+        }
+    }
+
+    /// Resolve which chip variant to render for a snapshot, honouring
+    /// the user's per-provider preference (Settings → Providers) and
+    /// falling back to auto-detection from snapshot shape.
+    private func resolveChipMode(snap: RateLimitInfo, providerKey: String) -> QuotaMode {
+        let preference = ProviderModePreference.current(for: providerKey)
+        switch preference {
+        case .subscription: return .subscription
+        case .usage: return .usage
+        case .auto:
+            return (snap.credits != nil && (snap.planType ?? "").isEmpty)
                 ? .usage
                 : .subscription
-            let mode: QuotaMode
-            switch preference {
-            case .auto: mode = inferredMode
-            case .subscription: mode = .subscription
-            case .usage: mode = .usage
-            }
-            let imminent = snap.imminentWindow
-            let sessionCost = session.metrics?.estimatedCostUSD ?? 0
-            if var existing = byProvider[key] {
-                // Subscription wins over usage when both paths are seen
-                // (rare — one OAuth account on both subscription and API
-                // key) since the bars are the richer signal.
-                if existing.mode == .usage && mode == .subscription {
-                    existing.mode = .subscription
-                    existing.snapshot = snap
-                    existing.session = session
-                    existing.imminent = imminent
-                } else if snap.sampledAt > existing.snapshot.sampledAt {
-                    // Freshest snapshot wins within the bucket.
-                    existing.snapshot = snap
-                    existing.session = session
-                    existing.imminent = imminent
-                }
-                existing.totalCostUSD += sessionCost
-                byProvider[key] = existing
-            } else {
-                byProvider[key] = Bucket(
-                    snapshot: snap,
-                    session: session,
-                    imminent: imminent,
-                    totalCostUSD: sessionCost,
-                    mode: mode
-                )
-            }
         }
-        return byProvider
-            .map { key, b in
-                QuotaWidgetData(
-                    id: key,
-                    mode: b.mode,
-                    snapshot: b.snapshot,
-                    session: b.session,
-                    imminent: b.imminent,
-                    totalCostUSD: b.totalCostUSD
-                )
-            }
-            .sorted { $0.id < $1.id }
     }
 
     /// The chip-style header widget. Dispatches on mode:

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -397,19 +397,33 @@ struct SessionListView: View {
     /// subscription chip (snapshot has `planType`) or a usage chip
     /// (snapshot has `credits` populated — Codex API-key path).
     ///
-    /// For subscription chips, the bucket is account-scoped so all
-    /// same-account sessions report identical numbers — `max` over
-    /// `usedPercent` is robust to per-session staleness. For usage
-    /// chips, `totalCostUSD` sums cumulative `estimatedCostUSD` across
-    /// every matching session — close enough to "what the user has
-    /// spent on this provider lately" for the typical session-lifetime;
-    /// proper daily rollup needs a daemon-side per-provider cost
-    /// tracker (deferred).
+    /// Within a subscription bucket the representative snapshot is the
+    /// **freshest** sample (largest `sampledAt`). The earlier rule —
+    /// "highest `usedPercent`" — locked the chip onto stale ready
+    /// sessions: a finished Anthropic session whose 5h window had
+    /// rolled over at 16% used would beat every fresh active session
+    /// reading 2% post-rollover, leaving the chip stuck on the bad
+    /// data forever. The bucket is account-scoped so all live sessions
+    /// on a single account report identical numbers anyway; freshness
+    /// only matters when one session has gone stale.
+    ///
+    /// Snapshots whose any window has already passed `resetsAt` are
+    /// filtered out before bucketing — they describe a provider state
+    /// the agent has long since exited (issue #309 phase-5 hotfix).
+    /// Defense in depth: the daemon also nulls stale snapshots in its
+    /// own metrics path, but persisted ready sessions retain their
+    /// last-known data on disk and bypass that check.
+    ///
+    /// For usage chips, `totalCostUSD` sums cumulative
+    /// `estimatedCostUSD` across every matching session — close enough
+    /// to "what the user has spent on this provider lately" for the
+    /// typical session-lifetime; proper daily rollup needs a
+    /// daemon-side per-provider cost tracker (deferred).
     ///
     /// Sort order is **stable by provider key** (anthropic < openai <
-    /// unknown:…). A `usedPercent` sort made chips swap positions every
-    /// few seconds as percents updated — alphabetical also matches
-    /// mockup 2's Anthropic-leftmost layout.
+    /// unknown:…). A `usedPercent` sort made chips swap positions
+    /// every few seconds as percents updated — alphabetical also
+    /// matches mockup 2's Anthropic-leftmost layout.
     private var quotaChipData: [QuotaWidgetData] {
         struct Bucket {
             var snapshot: RateLimitInfo
@@ -418,9 +432,16 @@ struct SessionListView: View {
             var totalCostUSD: Double
             var mode: QuotaMode
         }
+        let now = Date()
         var byProvider: [String: Bucket] = [:]
         for session in sessionManager.sessions {
             guard let snap = session.metrics?.rateLimit else { continue }
+            // Drop snapshots with any window past its reset. Same rule
+            // as the daemon-side stale check; applied here so stale
+            // persisted-but-ready sessions don't pollute the bucket.
+            if snap.windows.contains(where: { $0.resetsAt <= now }) {
+                continue
+            }
             // Without a providerKey the chip has no brand — fall back to
             // a per-adapter unknown bucket so wrapper sessions (Pi,
             // OpenCode) with subscription-shaped data still render their
@@ -451,12 +472,11 @@ struct SessionListView: View {
                     existing.snapshot = snap
                     existing.session = session
                     existing.imminent = imminent
-                }
-                if let imm = imminent,
-                   let existingImm = existing.imminent,
-                   imm.usedPercent > existingImm.usedPercent {
-                    existing.imminent = imm
+                } else if snap.sampledAt > existing.snapshot.sampledAt {
+                    // Freshest snapshot wins within the bucket.
                     existing.snapshot = snap
+                    existing.session = session
+                    existing.imminent = imminent
                 }
                 existing.totalCostUSD += sessionCost
                 byProvider[key] = existing

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -840,20 +840,38 @@ struct SessionListView: View {
     /// to a purely absolute ramp so the chip still has a sensible
     /// color in that edge case.
     ///
+    /// Named thresholds for the bar-color ramp. Centralised so tuning
+    /// the boundaries doesn't require hunting through the function
+    /// body — and so the XCTest reads them by name when it asserts
+    /// the boundary behaviour.
+    enum QuotaBarThreshold {
+        /// Absolute used-percent at which the bar flips to orange
+        /// regardless of pace — the cap itself is imminent.
+        static let absoluteOrange: Double = 85
+        /// `used - pace` overshoot at which the bar flips to orange.
+        static let paceDeltaOrange: Double = 15
+        /// `used - pace` overshoot at which the bar flips to yellow.
+        static let paceDeltaYellow: Double = 5
+        /// Absolute used-percent thresholds used as a fallback when
+        /// the window has no `resetsAt` and we can't compute a pace.
+        static let fallbackOrange: Double = 70
+        static let fallbackYellow: Double = 50
+    }
+
     /// `static` + non-private so XCTests can table-drive the threshold
     /// boundaries without instantiating the view.
     static func barColor(used: Double, pace: Double?) -> Color {
-        if used >= 85 { return .orange }
+        if used >= QuotaBarThreshold.absoluteOrange { return .orange }
         guard let pace = pace else {
             switch used {
-            case 70...: return .orange
-            case 50...: return .yellow
+            case QuotaBarThreshold.fallbackOrange...: return .orange
+            case QuotaBarThreshold.fallbackYellow...: return .yellow
             default: return IrrColors.pressureLow
             }
         }
         let delta = used - pace
-        if delta >= 15 { return .orange }
-        if delta >= 5 { return .yellow }
+        if delta >= QuotaBarThreshold.paceDeltaOrange { return .orange }
+        if delta >= QuotaBarThreshold.paceDeltaYellow { return .yellow }
         return IrrColors.pressureLow
     }
 

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -357,7 +357,7 @@ struct SessionListView: View {
         if showQuotaForecast {
             let chips = quotaChipData
             if !chips.isEmpty {
-                HStack(spacing: 8) {
+                HStack(alignment: .top, spacing: 8) {
                     ForEach(chips) { chip in
                         quotaChipView(chip, compact: chips.count > 1)
                     }
@@ -421,14 +421,25 @@ struct SessionListView: View {
         var byProvider: [String: Bucket] = [:]
         for session in sessionManager.sessions {
             guard let snap = session.metrics?.rateLimit else { continue }
-            let mode: QuotaMode = (snap.credits != nil && (snap.planType ?? "").isEmpty)
-                ? .usage
-                : .subscription
             // Without a providerKey the chip has no brand — fall back to
             // a per-adapter unknown bucket so wrapper sessions (Pi,
             // OpenCode) with subscription-shaped data still render their
             // own chip rather than being silently dropped.
             let key = snap.providerKey(adapter: session.adapter) ?? "unknown:\(session.adapter ?? "")"
+            // Per-provider mode preference (Settings → Providers): when
+            // set to `.subscription` or `.usage` it overrides snapshot
+            // detection, so a user with multiple paths into the same
+            // provider can pin the display to the view they care about.
+            let preference = ProviderModePreference.current(for: key)
+            let inferredMode: QuotaMode = (snap.credits != nil && (snap.planType ?? "").isEmpty)
+                ? .usage
+                : .subscription
+            let mode: QuotaMode
+            switch preference {
+            case .auto: mode = inferredMode
+            case .subscription: mode = .subscription
+            case .usage: mode = .usage
+            }
             let imminent = snap.imminentWindow
             let sessionCost = session.metrics?.estimatedCostUSD ?? 0
             if var existing = byProvider[key] {
@@ -483,10 +494,20 @@ struct SessionListView: View {
             // otherwise fall back to the adapter icon so the chip never
             // appears iconless. The quota bucket is provider-scoped, so
             // the provider mark is the more meaningful brand.
+            //
+            // `.resizable().frame(...)` is load-bearing: `NSImage(data:)`
+            // on an SVG decodes inconsistently depending on the path's
+            // complexity — the Anthropic single-path mark lands at the
+            // SVG's declared 14×14 size, but the OpenAI multi-path knot
+            // decoded at viewBox-native 24×24, dominating the chip and
+            // pushing the body out of view. Forcing the SwiftUI frame
+            // normalises both regardless of underlying decode quirks.
             if let icon = ProviderIconRegistry.image(forKey: d.snapshot.providerKey(adapter: d.session.adapter))
                 ?? d.session.adapterIcon {
                 Image(nsImage: icon)
+                    .resizable()
                     .renderingMode(.template)
+                    .frame(width: 14, height: 14)
                     .foregroundColor(.primary)
             }
             switch d.mode {
@@ -504,22 +525,32 @@ struct SessionListView: View {
     }
 
     /// Usage-mode chip body — cumulative spend across all sessions on
-    /// this provider, with a "spend" subtitle. Honest label rather than
-    /// the mockup's "$X / day · spend today": proper daily attribution
-    /// needs a daemon-side per-provider cost tracker (deferred). For
-    /// short-lived sessions (the common case) cumulative ≈ today.
+    /// this provider, with a "spend" subtitle. Always 2 lines so the
+    /// chip has the same height as the subscription variant (5h + 7d
+    /// rows) and the two render cleanly side-by-side in the header.
+    ///
+    /// Zero-state: when no spend has accumulated, render an em-dash and
+    /// "no spend yet" rather than "$0.00 / spend". The data path is
+    /// wired up, just nothing to report — important when a user has
+    /// forced-usage mode on a subscription-only session, where
+    /// `totalCostUSD` legitimately stays at zero.
+    ///
+    /// A `minWidth: 88` matches the subscription chip's row width
+    /// (label + 40pt bar + percent) so a usage chip with a short
+    /// headline doesn't collapse to an icon-only sliver next to a
+    /// bars chip.
     @ViewBuilder
     private func quotaUsageBody(_ d: QuotaWidgetData, compact: Bool) -> some View {
+        let hasSpend = d.totalCostUSD > 0
         VStack(alignment: .leading, spacing: 1) {
-            Text(formatUsageCost(d.totalCostUSD))
-                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+            Text(hasSpend ? formatUsageCost(d.totalCostUSD) : "—")
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
                 .foregroundColor(.primary)
-            if !compact {
-                Text("spend")
-                    .font(.system(size: 9, design: .monospaced))
-                    .foregroundColor(.secondary)
-            }
+            Text(hasSpend ? "spend" : "no spend yet")
+                .font(.system(size: 9, design: .monospaced))
+                .foregroundColor(.secondary)
         }
+        .frame(minWidth: 88, alignment: .leading)
     }
 
     /// Format the cost headline: tiny costs render `<$0.01`, normal

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -370,56 +370,112 @@ struct SessionListView: View {
         }
     }
 
-    /// One chip's worth of data: a representative snapshot for the
-    /// provider, the session that carries it (for icon lookup and forecast
-    /// access), and the most-imminent window for sort + headline display.
-    /// `id` is the providerKey so SwiftUI ForEach has a stable identity.
+    /// Render mode for a provider chip. Subscription chips show the
+    /// 5h/7d bars; usage chips show cumulative spend across all
+    /// sessions on that provider.
+    private enum QuotaMode {
+        case subscription
+        case usage
+    }
+
+    /// One chip's worth of data: render mode, a representative snapshot
+    /// for icon + tooltip lookup, the session that carries it, the
+    /// most-imminent window (subscription only), and the summed spend
+    /// (usage only). `id` is the providerKey so SwiftUI ForEach has a
+    /// stable identity.
     private struct QuotaWidgetData: Identifiable {
         let id: String
+        let mode: QuotaMode
         let snapshot: RateLimitInfo
         let session: SessionState
-        let imminent: RateLimitWindowInfo
+        let imminent: RateLimitWindowInfo?
+        let totalCostUSD: Double
     }
 
-    /// All chips to render, one per subscription provider. Groups
-    /// sessions by provider, picks the most-stressed snapshot within
-    /// each group as the representative reading (the bucket is
-    /// account-scoped, so every same-account session reports identical
-    /// numbers — `max` is just robust to per-session staleness).
+    /// All chips to render, one per subscription/usage provider. Groups
+    /// sessions by provider, then per group decides whether to render a
+    /// subscription chip (snapshot has `planType`) or a usage chip
+    /// (snapshot has `credits` populated — Codex API-key path).
+    ///
+    /// For subscription chips, the bucket is account-scoped so all
+    /// same-account sessions report identical numbers — `max` over
+    /// `usedPercent` is robust to per-session staleness. For usage
+    /// chips, `totalCostUSD` sums cumulative `estimatedCostUSD` across
+    /// every matching session — close enough to "what the user has
+    /// spent on this provider lately" for the typical session-lifetime;
+    /// proper daily rollup needs a daemon-side per-provider cost
+    /// tracker (deferred).
     ///
     /// Sort order is **stable by provider key** (anthropic < openai <
-    /// unknown:…). An earlier version sorted by `usedPercent` descending
-    /// to surface the most-stressed provider first, but that made chips
-    /// swap positions every few seconds as percents updated — the
-    /// flicker drowned out the actual signal. A fixed alphabetical
-    /// order also matches the layout in mockup 2 (Anthropic leftmost).
+    /// unknown:…). A `usedPercent` sort made chips swap positions every
+    /// few seconds as percents updated — alphabetical also matches
+    /// mockup 2's Anthropic-leftmost layout.
     private var quotaChipData: [QuotaWidgetData] {
-        var byProvider: [String: QuotaWidgetData] = [:]
+        struct Bucket {
+            var snapshot: RateLimitInfo
+            var session: SessionState
+            var imminent: RateLimitWindowInfo?
+            var totalCostUSD: Double
+            var mode: QuotaMode
+        }
+        var byProvider: [String: Bucket] = [:]
         for session in sessionManager.sessions {
             guard let snap = session.metrics?.rateLimit else { continue }
-            guard let imm = snap.imminentWindow else { continue }
-            // Without a providerKey the chip has no brand and shouldn't be
-            // aggregated — fall back to "unknown" so wrapper sessions
-            // (Pi, OpenCode) with subscription-shaped data still render
-            // their own chip rather than be silently dropped.
+            let mode: QuotaMode = (snap.credits != nil && (snap.planType ?? "").isEmpty)
+                ? .usage
+                : .subscription
+            // Without a providerKey the chip has no brand — fall back to
+            // a per-adapter unknown bucket so wrapper sessions (Pi,
+            // OpenCode) with subscription-shaped data still render their
+            // own chip rather than being silently dropped.
             let key = snap.providerKey(adapter: session.adapter) ?? "unknown:\(session.adapter ?? "")"
-            let candidate = QuotaWidgetData(id: key, snapshot: snap, session: session, imminent: imm)
-            if let existing = byProvider[key] {
-                if imm.usedPercent > existing.imminent.usedPercent {
-                    byProvider[key] = candidate
+            let imminent = snap.imminentWindow
+            let sessionCost = session.metrics?.estimatedCostUSD ?? 0
+            if var existing = byProvider[key] {
+                // Subscription wins over usage when both paths are seen
+                // (rare — one OAuth account on both subscription and API
+                // key) since the bars are the richer signal.
+                if existing.mode == .usage && mode == .subscription {
+                    existing.mode = .subscription
+                    existing.snapshot = snap
+                    existing.session = session
+                    existing.imminent = imminent
                 }
+                if let imm = imminent,
+                   let existingImm = existing.imminent,
+                   imm.usedPercent > existingImm.usedPercent {
+                    existing.imminent = imm
+                    existing.snapshot = snap
+                }
+                existing.totalCostUSD += sessionCost
+                byProvider[key] = existing
             } else {
-                byProvider[key] = candidate
+                byProvider[key] = Bucket(
+                    snapshot: snap,
+                    session: session,
+                    imminent: imminent,
+                    totalCostUSD: sessionCost,
+                    mode: mode
+                )
             }
         }
-        return byProvider.values.sorted { $0.id < $1.id }
+        return byProvider
+            .map { key, b in
+                QuotaWidgetData(
+                    id: key,
+                    mode: b.mode,
+                    snapshot: b.snapshot,
+                    session: b.session,
+                    imminent: b.imminent,
+                    totalCostUSD: b.totalCostUSD
+                )
+            }
+            .sorted { $0.id < $1.id }
     }
 
-    /// The chip-style header widget: provider icon + stacked 5h/7d bars.
-    /// Matches mockup 1 (single chip) and mockup 2 (multiple chips
-    /// side-by-side) in issue #309. The `compact` flag tightens spacing
-    /// and drops the inline reset time when several chips share the
-    /// header — full info is always available in the tooltip.
+    /// The chip-style header widget. Dispatches on mode:
+    ///   - subscription → provider icon + stacked 5h/7d bars (mockup 1/2)
+    ///   - usage        → provider icon + cumulative spend (mockup 2)
     @ViewBuilder
     private func quotaChipView(_ d: QuotaWidgetData, compact: Bool) -> some View {
         HStack(spacing: 6) {
@@ -433,13 +489,47 @@ struct SessionListView: View {
                     .renderingMode(.template)
                     .foregroundColor(.primary)
             }
-            VStack(alignment: .leading, spacing: 1) {
-                ForEach(d.snapshot.windows, id: \.windowMinutes) { window in
-                    quotaWindowRow(window, compact: compact)
+            switch d.mode {
+            case .subscription:
+                VStack(alignment: .leading, spacing: 1) {
+                    ForEach(d.snapshot.windows, id: \.windowMinutes) { window in
+                        quotaWindowRow(window, compact: compact)
+                    }
                 }
+            case .usage:
+                quotaUsageBody(d, compact: compact)
             }
         }
         .tooltip(quotaTooltip(d))
+    }
+
+    /// Usage-mode chip body — cumulative spend across all sessions on
+    /// this provider, with a "spend" subtitle. Honest label rather than
+    /// the mockup's "$X / day · spend today": proper daily attribution
+    /// needs a daemon-side per-provider cost tracker (deferred). For
+    /// short-lived sessions (the common case) cumulative ≈ today.
+    @ViewBuilder
+    private func quotaUsageBody(_ d: QuotaWidgetData, compact: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(formatUsageCost(d.totalCostUSD))
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundColor(.primary)
+            if !compact {
+                Text("spend")
+                    .font(.system(size: 9, design: .monospaced))
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    /// Format the cost headline: tiny costs render `<$0.01`, normal
+    /// costs render with two decimals, ≥ $100 drops to integer dollars
+    /// to keep the chip from growing.
+    private func formatUsageCost(_ cost: Double) -> String {
+        if cost <= 0 { return "$0.00" }
+        if cost < 0.01 { return "<$0.01" }
+        if cost >= 100 { return String(format: "$%.0f", cost) }
+        return String(format: "$%.2f", cost)
     }
 
     /// One row inside a chip. In compact mode (multiple chips visible)
@@ -492,16 +582,30 @@ struct SessionListView: View {
         if let plan = d.snapshot.planTypeLabel {
             lines.append(plan)
         }
-        for w in d.snapshot.windows {
-            let pct = String(format: "%.1f%%", w.usedPercent)
-            let label = quotaWindowLabel(w.windowMinutes)
-            let resets = formatTimeUntil(w.resetsAt)
-            lines.append("\(label): \(pct) · resets in \(resets)")
-        }
-        if let eta = d.session.metrics?.rateLimitForecastEta {
-            lines.append("Projected cap: \(formatClockTime(eta))")
-        } else if d.snapshot.windows.contains(where: { $0.usedPercent > 0 }) {
-            lines.append("Forecast: won't hit cap this window")
+        switch d.mode {
+        case .subscription:
+            for w in d.snapshot.windows {
+                let pct = String(format: "%.1f%%", w.usedPercent)
+                let label = quotaWindowLabel(w.windowMinutes)
+                let resets = formatTimeUntil(w.resetsAt)
+                lines.append("\(label): \(pct) · resets in \(resets)")
+            }
+            if let eta = d.session.metrics?.rateLimitForecastEta {
+                lines.append("Projected cap: \(formatClockTime(eta))")
+            } else if d.snapshot.windows.contains(where: { $0.usedPercent > 0 }) {
+                lines.append("Forecast: won't hit cap this window")
+            }
+        case .usage:
+            lines.append("\(formatUsageCost(d.totalCostUSD)) · cumulative spend across active sessions")
+            if let credits = d.snapshot.credits {
+                if credits.unlimited == true {
+                    lines.append("Credits: unlimited")
+                } else if let balance = credits.balance {
+                    lines.append(String(format: "Credits balance: $%.2f", balance))
+                } else if credits.hasCredits {
+                    lines.append("Credits: available")
+                }
+            }
         }
         if let reached = d.snapshot.reachedType, !reached.isEmpty {
             lines.append("⚠️ rate limit reached: \(reached)")

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -514,7 +514,12 @@ struct SessionListView: View {
         if var existing = buckets[key] {
             // Subscription wins over usage when both paths are seen
             // (rare — one OAuth account on both subscription and API
-            // key): the bars are the richer signal.
+            // key): the bars are the richer signal. Trade-off: this
+            // can replace a fresh usage entry with a stale subscription
+            // one, losing recency in service of richer rendering. The
+            // mixed-mode case is uncommon enough that we accept it
+            // rather than introduce a "prefer fresh except when…"
+            // tiebreaker.
             if existing.mode == .usage && mode == .subscription {
                 existing.mode = .subscription
                 existing.snapshot = snap
@@ -653,6 +658,10 @@ struct SessionListView: View {
     /// the bar shrinks so two or three chips fit in the 380pt header.
     @ViewBuilder
     private func quotaWindowRow(_ w: RateLimitWindowInfo, compact: Bool) -> some View {
+        // Compute once per row — SwiftUI re-invokes view bodies on every
+        // SessionManager publish, and calling quotaPacePercent twice
+        // would also let two Date() captures disagree by microseconds.
+        let pace = quotaPacePercent(w)
         HStack(spacing: 6) {
             Text(quotaWindowLabel(w.windowMinutes))
                 .font(.system(size: 9, weight: .medium, design: .monospaced))
@@ -660,8 +669,8 @@ struct SessionListView: View {
                 .frame(width: 14, alignment: .leading)
 
             quotaBar(percent: w.usedPercent,
-                     color: barColor(used: w.usedPercent, pace: quotaPacePercent(w)),
-                     pacePercent: quotaPacePercent(w))
+                     color: Self.barColor(used: w.usedPercent, pace: pace),
+                     pacePercent: pace)
                 .frame(width: compact ? 60 : 70, height: 5)
 
             Text("\(Int(w.usedPercent.rounded()))%")
@@ -685,10 +694,16 @@ struct SessionListView: View {
     /// the user *should be* right now, independent of when the
     /// snapshot was last refreshed.
     ///
-    /// Returns nil when the window can't be paced: zero-duration,
-    /// missing `resetsAt`, or a `resetsAt` that's already in the past
-    /// (which the daemon's stale-check should have dropped, but
-    /// belt-and-braces here too).
+    /// Returns nil when the window can't be paced: zero-duration or
+    /// missing `resetsAt`. A `resetsAt` already in the past produces a
+    /// clamped 100% (marker pinned to the right edge) which combined
+    /// with the chip's stale-opacity tint reads naturally as "this
+    /// snapshot pre-dates the current window."
+    ///
+    /// Codex's v1 minute-window quirk (`299` instead of `300`,
+    /// `10079` instead of `10080`) is left as-is here — the
+    /// ≤60-second drift in the implied window-start time is well
+    /// below the resolution the marker conveys visually.
     private func quotaPacePercent(_ w: RateLimitWindowInfo) -> Double? {
         guard w.windowMinutes > 0 else { return nil }
         guard w.resetsAt.timeIntervalSince1970 > 0 else { return nil }
@@ -741,18 +756,27 @@ struct SessionListView: View {
                 // round-trip on the daemon side, e.g. 7.000000000000001
                 // for a value the provider reported as 7). Render as
                 // whole percent so the tooltip matches the chip body.
-                let pct = "\(Int(w.usedPercent.rounded()))%"
+                //
+                // Line template:
+                //   <window>: <used>% used · <pace verdict> · resets in <when>
+                //
+                // The earlier shape included an explicit "pace 42%
+                // (behind by 26pt)" suffix that grew long enough to
+                // wrap mid-parenthesis at the macOS tooltip width.
+                // The pace percent is redundant — the delta is the
+                // load-bearing signal — so we drop it and put the
+                // verdict inline, no parentheses.
+                let used = Int(w.usedPercent.rounded())
                 let label = quotaWindowLabel(w.windowMinutes)
                 let resets = formatTimeUntil(w.resetsAt)
-                var line = "\(label): \(pct) · resets in \(resets)"
+                var line = "\(label): \(used)% used · resets in \(resets)"
                 if let pace = quotaPacePercent(w) {
-                    let paceInt = Int(pace.rounded())
-                    let delta = Int(w.usedPercent.rounded()) - paceInt
+                    let delta = used - Int(pace.rounded())
                     let verdict: String
-                    if delta > 0 { verdict = "ahead by \(delta)pt" }
-                    else if delta < 0 { verdict = "behind by \(-delta)pt" }
+                    if delta > 0 { verdict = "\(delta)pt over pace" }
+                    else if delta < 0 { verdict = "\(-delta)pt under pace" }
                     else { verdict = "on pace" }
-                    line += " · pace \(paceInt)% (\(verdict))"
+                    line = "\(label): \(used)% used · \(verdict) · resets in \(resets)"
                 }
                 lines.append(line)
             }
@@ -815,7 +839,10 @@ struct SessionListView: View {
     /// When `pace` is nil (no expiry data on the window) we fall back
     /// to a purely absolute ramp so the chip still has a sensible
     /// color in that edge case.
-    private func barColor(used: Double, pace: Double?) -> Color {
+    ///
+    /// `static` + non-private so XCTests can table-drive the threshold
+    /// boundaries without instantiating the view.
+    static func barColor(used: Double, pace: Double?) -> Color {
         if used >= 85 { return .orange }
         guard let pace = pace else {
             switch used {
@@ -892,6 +919,10 @@ struct SessionListView: View {
             .frame(width: 6, height: 6)
             .shadow(color: statusColor.opacity(0.5), radius: 3)
             .tooltip(sessionManager.connectionState.tooltip)
+            // The dot is the only visible affordance now; VoiceOver
+            // needs an explicit label since "Circle" alone tells the
+            // user nothing about connection state.
+            .accessibilityLabel("Connection: \(sessionManager.connectionState.tooltip)")
     }
 
     private var statusColor: Color {

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -375,7 +375,13 @@ struct SessionListView: View {
                 EmptyView()
             }
         } else {
-            EmptyView()
+            // User opted out of the quota chip in Settings — show the
+            // app name so the header isn't a bare em-dash. Version is
+            // still tucked into the Settings footer per the maintainer's
+            // request from #309.
+            Text("Irrlicht")
+                .font(.headline)
+                .foregroundColor(.primary)
         }
     }
 

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -299,13 +299,18 @@ struct SessionListView: View {
 
     private var sessionHeaderView: some View {
         HStack {
-            HStack(spacing: 4) {
+            HStack(spacing: 6) {
                 headerTitleView
 
-                Text("—")
-                    .foregroundColor(.secondary)
+                // Em-dash + glyphs are visually redundant once the quota
+                // chip is filling the slot — the chip already implies
+                // session activity. Hide them while the chip is present.
+                if quotaWidgetData == nil || !showQuotaForecast {
+                    Text("—")
+                        .foregroundColor(.secondary)
 
-                sessionIconsView
+                    sessionIconsView
+                }
             }
 
             Spacer()
@@ -342,32 +347,34 @@ struct SessionListView: View {
         }
     }
     
-    /// Header text shown to the left of the session glyphs. Defaults to the
-    /// app version; when any visible session carries a rate-limit snapshot
-    /// (and the user hasn't hidden the quota forecast in settings), we swap
-    /// in the burn-rate widget instead. Subscription users see live quota;
-    /// API-key / Bedrock / Vertex users keep the version string. Aggregation
-    /// rule: pick the snapshot with the highest UsedPercent across sessions.
-    /// The bucket is account-scoped so all subscription sessions on a single
-    /// account should agree, but `max` is robust to per-session staleness.
+    /// Header slot shown to the left of the session glyphs. When any
+    /// visible session carries a rate-limit snapshot (and the user hasn't
+    /// hidden the quota chip in Settings), we render a provider chip with
+    /// stacked 5h/7d progress bars — matching the design mockup in
+    /// issue #309. Otherwise the slot is empty; the app version is
+    /// reachable from Settings rather than the header.
+    ///
+    /// Aggregation: pick the snapshot with the highest UsedPercent across
+    /// all visible sessions. The subscription bucket is account-scoped, so
+    /// every session on a single account reports the same numbers; `max`
+    /// is just robust to per-session staleness during the first few
+    /// post-restart ticks.
     @ViewBuilder
     private var headerTitleView: some View {
         if showQuotaForecast, let widget = quotaWidgetData {
-            quotaWidgetView(widget)
+            quotaChipView(widget)
         } else {
-            Text("Irrlicht v\(appVersion)")
-                .font(.headline)
-                .foregroundColor(.primary)
+            EmptyView()
         }
     }
 
-    /// Snapshot + forecast pair selected for the header — the imminent
-    /// window plus the matching session's projected ETA. Nil when no
+    /// Snapshot picked for the header chip plus the adapter that produced
+    /// it (so the chip can render the correct provider icon). Nil when no
     /// session has a usable snapshot.
     private struct QuotaWidgetData {
         let snapshot: RateLimitInfo
+        let session: SessionState
         let imminent: RateLimitWindowInfo
-        let forecastEta: Date?
     }
 
     private var quotaWidgetData: QuotaWidgetData? {
@@ -375,11 +382,7 @@ struct SessionListView: View {
         for session in sessionManager.sessions {
             guard let snap = session.metrics?.rateLimit else { continue }
             guard let imm = snap.imminentWindow else { continue }
-            let candidate = QuotaWidgetData(
-                snapshot: snap,
-                imminent: imm,
-                forecastEta: session.metrics?.rateLimitForecastEta
-            )
+            let candidate = QuotaWidgetData(snapshot: snap, session: session, imminent: imm)
             if let current = best {
                 if imm.usedPercent > current.imminent.usedPercent {
                     best = candidate
@@ -391,25 +394,72 @@ struct SessionListView: View {
         return best
     }
 
+    /// The chip-style header widget: provider icon on the left, two
+    /// horizontal progress bars stacked on the right (5h primary + 7d
+    /// secondary). Each bar carries its window label, percent, and reset
+    /// time inline. Matches mockup 1 in issue #309.
     @ViewBuilder
-    private func quotaWidgetView(_ d: QuotaWidgetData) -> some View {
-        let primary = quotaPrimaryLabel(d)
-        Text(primary)
-            .font(.headline)
-            .foregroundColor(quotaWidgetColor(d))
-            .tooltip(quotaTooltip(d))
+    private func quotaChipView(_ d: QuotaWidgetData) -> some View {
+        HStack(spacing: 6) {
+            // Provider icon (Anthropic / OpenAI) when we can infer one;
+            // otherwise fall back to the adapter icon so the chip never
+            // appears iconless. The quota bucket is provider-scoped, so
+            // the provider mark is the more meaningful brand.
+            if let icon = ProviderIconRegistry.image(forKey: d.snapshot.providerKey(adapter: d.session.adapter))
+                ?? d.session.adapterIcon {
+                Image(nsImage: icon)
+                    .renderingMode(.template)
+                    .foregroundColor(.primary)
+            }
+            VStack(alignment: .leading, spacing: 1) {
+                ForEach(d.snapshot.windows, id: \.windowMinutes) { window in
+                    quotaWindowRow(window)
+                }
+            }
+        }
+        .tooltip(quotaTooltip(d))
     }
 
-    private func quotaPrimaryLabel(_ d: QuotaWidgetData) -> String {
-        let pct = Int(d.imminent.usedPercent.rounded())
-        let windowLabel = quotaWindowLabel(d.imminent.windowMinutes)
-        if let eta = d.forecastEta {
-            return "\(windowLabel): \(pct)% · cap at \(formatClockTime(eta))"
+    /// One row inside the chip: window label · filled bar · percent · reset
+    /// time. Bar fill color comes from the pressure ramp.
+    @ViewBuilder
+    private func quotaWindowRow(_ w: RateLimitWindowInfo) -> some View {
+        HStack(spacing: 6) {
+            Text(quotaWindowLabel(w.windowMinutes))
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .foregroundColor(.secondary)
+                .frame(width: 14, alignment: .leading)
+
+            quotaBar(percent: w.usedPercent, color: barColor(w.usedPercent))
+                .frame(width: 70, height: 5)
+
+            Text("\(Int(w.usedPercent.rounded()))%")
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .foregroundColor(.primary)
+                .frame(width: 28, alignment: .trailing)
+
+            Text("resets \(formatResetTime(w.resetsAt))")
+                .font(.system(size: 9, design: .monospaced))
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
         }
-        // No forecast yet (insufficient history, flat burn, or "won't hit cap").
-        // Still surface the current % so users see ambient quota even before
-        // we have a slope.
-        return "\(windowLabel): \(pct)%"
+    }
+
+    /// A simple rounded-rect progress bar. ZStack so the fill and the
+    /// track render with the same corner radius without clipping
+    /// artifacts at small sizes.
+    @ViewBuilder
+    private func quotaBar(percent: Double, color: Color) -> some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 2.5)
+                    .fill(Color.secondary.opacity(0.2))
+                RoundedRectangle(cornerRadius: 2.5)
+                    .fill(color)
+                    .frame(width: geo.size.width * min(1.0, max(0.0, percent / 100.0)))
+            }
+        }
     }
 
     private func quotaTooltip(_ d: QuotaWidgetData) -> String {
@@ -423,7 +473,9 @@ struct SessionListView: View {
             let resets = formatTimeUntil(w.resetsAt)
             lines.append("\(label): \(pct) · resets in \(resets)")
         }
-        if d.forecastEta == nil, d.snapshot.windows.contains(where: { $0.usedPercent > 0 }) {
+        if let eta = d.session.metrics?.rateLimitForecastEta {
+            lines.append("Projected cap: \(formatClockTime(eta))")
+        } else if d.snapshot.windows.contains(where: { $0.usedPercent > 0 }) {
             lines.append("Forecast: won't hit cap this window")
         }
         if let reached = d.snapshot.reachedType, !reached.isEmpty {
@@ -444,13 +496,12 @@ struct SessionListView: View {
         }
     }
 
-    private func quotaWidgetColor(_ d: QuotaWidgetData) -> Color {
-        if d.snapshot.reachedType?.isEmpty == false { return IrrColors.pressureCritical }
-        switch d.imminent.usedPercent {
+    private func barColor(_ pct: Double) -> Color {
+        switch pct {
         case 90...: return IrrColors.pressureCritical
         case 80..<90: return IrrColors.pressureHigh
         case 60..<80: return IrrColors.pressureMedium
-        default: return .primary
+        default: return IrrColors.pressureLow
         }
     }
 
@@ -458,6 +509,22 @@ struct SessionListView: View {
         let f = DateFormatter()
         f.dateStyle = .none
         f.timeStyle = .short
+        return f.string(from: date)
+    }
+
+    /// Compact reset label for the chip row. Same-day resets render as
+    /// "HH:MM"; resets later in the week render as "EEE HH:MM" (e.g.
+    /// "Fri 9:00"). Mirrors mockup 1's "resets 11:14" / "resets Fri 9:00".
+    private func formatResetTime(_ date: Date) -> String {
+        let cal = Calendar.current
+        let now = Date()
+        let f = DateFormatter()
+        if cal.isDate(date, inSameDayAs: now) {
+            f.dateStyle = .none
+            f.timeStyle = .short
+        } else {
+            f.dateFormat = "EEE H:mm"
+        }
         return f.string(from: date)
     }
 

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -188,6 +188,7 @@ struct SessionListView: View {
     @State private var isSettingsButtonHovered = false
     @State private var showSettings = false
     @AppStorage("displayMode") private var displayModeRaw: String = DisplayMode.context.rawValue
+    @AppStorage("showQuotaForecast") private var showQuotaForecast: Bool = true
 
     private var displayMode: DisplayMode { DisplayMode(rawValue: displayModeRaw) ?? .context }
 
@@ -299,9 +300,7 @@ struct SessionListView: View {
     private var sessionHeaderView: some View {
         HStack {
             HStack(spacing: 4) {
-                Text("Irrlicht v\(appVersion)")
-                    .font(.headline)
-                    .foregroundColor(.primary)
+                headerTitleView
 
                 Text("—")
                     .foregroundColor(.secondary)
@@ -343,6 +342,138 @@ struct SessionListView: View {
         }
     }
     
+    /// Header text shown to the left of the session glyphs. Defaults to the
+    /// app version; when any visible session carries a rate-limit snapshot
+    /// (and the user hasn't hidden the quota forecast in settings), we swap
+    /// in the burn-rate widget instead. Subscription users see live quota;
+    /// API-key / Bedrock / Vertex users keep the version string. Aggregation
+    /// rule: pick the snapshot with the highest UsedPercent across sessions.
+    /// The bucket is account-scoped so all subscription sessions on a single
+    /// account should agree, but `max` is robust to per-session staleness.
+    @ViewBuilder
+    private var headerTitleView: some View {
+        if showQuotaForecast, let widget = quotaWidgetData {
+            quotaWidgetView(widget)
+        } else {
+            Text("Irrlicht v\(appVersion)")
+                .font(.headline)
+                .foregroundColor(.primary)
+        }
+    }
+
+    /// Snapshot + forecast pair selected for the header — the imminent
+    /// window plus the matching session's projected ETA. Nil when no
+    /// session has a usable snapshot.
+    private struct QuotaWidgetData {
+        let snapshot: RateLimitInfo
+        let imminent: RateLimitWindowInfo
+        let forecastEta: Date?
+    }
+
+    private var quotaWidgetData: QuotaWidgetData? {
+        var best: QuotaWidgetData?
+        for session in sessionManager.sessions {
+            guard let snap = session.metrics?.rateLimit else { continue }
+            guard let imm = snap.imminentWindow else { continue }
+            let candidate = QuotaWidgetData(
+                snapshot: snap,
+                imminent: imm,
+                forecastEta: session.metrics?.rateLimitForecastEta
+            )
+            if let current = best {
+                if imm.usedPercent > current.imminent.usedPercent {
+                    best = candidate
+                }
+            } else {
+                best = candidate
+            }
+        }
+        return best
+    }
+
+    @ViewBuilder
+    private func quotaWidgetView(_ d: QuotaWidgetData) -> some View {
+        let primary = quotaPrimaryLabel(d)
+        Text(primary)
+            .font(.headline)
+            .foregroundColor(quotaWidgetColor(d))
+            .tooltip(quotaTooltip(d))
+    }
+
+    private func quotaPrimaryLabel(_ d: QuotaWidgetData) -> String {
+        let pct = Int(d.imminent.usedPercent.rounded())
+        let windowLabel = quotaWindowLabel(d.imminent.windowMinutes)
+        if let eta = d.forecastEta {
+            return "\(windowLabel): \(pct)% · cap at \(formatClockTime(eta))"
+        }
+        // No forecast yet (insufficient history, flat burn, or "won't hit cap").
+        // Still surface the current % so users see ambient quota even before
+        // we have a slope.
+        return "\(windowLabel): \(pct)%"
+    }
+
+    private func quotaTooltip(_ d: QuotaWidgetData) -> String {
+        var lines: [String] = []
+        if let plan = d.snapshot.planTypeLabel {
+            lines.append(plan)
+        }
+        for w in d.snapshot.windows {
+            let pct = String(format: "%.1f%%", w.usedPercent)
+            let label = quotaWindowLabel(w.windowMinutes)
+            let resets = formatTimeUntil(w.resetsAt)
+            lines.append("\(label): \(pct) · resets in \(resets)")
+        }
+        if d.forecastEta == nil, d.snapshot.windows.contains(where: { $0.usedPercent > 0 }) {
+            lines.append("Forecast: won't hit cap this window")
+        }
+        if let reached = d.snapshot.reachedType, !reached.isEmpty {
+            lines.append("⚠️ rate limit reached: \(reached)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func quotaWindowLabel(_ minutes: Int) -> String {
+        // Tolerate Codex v1's 299 / 10079 off-by-one quirk.
+        switch minutes {
+        case 299, 300: return "5h"
+        case 10079, 10080: return "7d"
+        default:
+            if minutes >= 1440 { return "\(minutes / 1440)d" }
+            if minutes >= 60 { return "\(minutes / 60)h" }
+            return "\(minutes)m"
+        }
+    }
+
+    private func quotaWidgetColor(_ d: QuotaWidgetData) -> Color {
+        if d.snapshot.reachedType?.isEmpty == false { return IrrColors.pressureCritical }
+        switch d.imminent.usedPercent {
+        case 90...: return IrrColors.pressureCritical
+        case 80..<90: return IrrColors.pressureHigh
+        case 60..<80: return IrrColors.pressureMedium
+        default: return .primary
+        }
+    }
+
+    private func formatClockTime(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateStyle = .none
+        f.timeStyle = .short
+        return f.string(from: date)
+    }
+
+    private func formatTimeUntil(_ date: Date) -> String {
+        let seconds = max(0, Int(date.timeIntervalSinceNow))
+        let h = seconds / 3600
+        let m = (seconds % 3600) / 60
+        if h >= 24 {
+            let d = h / 24
+            let rh = h % 24
+            return rh == 0 ? "\(d)d" : "\(d)d \(rh)h"
+        }
+        if h > 0 { return "\(h)h \(m)m" }
+        return "\(m)m"
+    }
+
     private var sessionIconsView: some View {
         HStack(spacing: 2) {
             if sessionManager.sessions.isEmpty {

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -349,17 +349,26 @@ struct SessionListView: View {
     
     /// Header slot shown to the left of the session glyphs. Renders one
     /// chip per subscription provider whose sessions have surfaced quota
-    /// data (Anthropic, OpenAI, …) — matching mockup 2 in issue #309.
-    /// Empty when no provider has a snapshot; the app version lives in
-    /// Settings rather than competing for this slot.
+    /// data (Anthropic, OpenAI, …) — matching mockups 2 and 3 in
+    /// issue #309. When more chips exist than the 380pt header can fit
+    /// comfortably, the first `maxVisibleChips` render normally and the
+    /// rest collapse into a single "+N more" chip whose tooltip lists
+    /// what's hidden (mockup 3). Empty when no provider has a snapshot;
+    /// the app version lives in Settings rather than competing for
+    /// this slot.
     @ViewBuilder
     private var headerTitleView: some View {
         if showQuotaForecast {
             let chips = quotaChipData
             if !chips.isEmpty {
+                let visible = Array(chips.prefix(Self.maxVisibleQuotaChips))
+                let hidden = Array(chips.dropFirst(Self.maxVisibleQuotaChips))
                 HStack(alignment: .top, spacing: 8) {
-                    ForEach(chips) { chip in
+                    ForEach(visible) { chip in
                         quotaChipView(chip, compact: chips.count > 1)
+                    }
+                    if !hidden.isEmpty {
+                        quotaOverflowChip(hidden: hidden)
                     }
                 }
             } else {
@@ -367,6 +376,44 @@ struct SessionListView: View {
             }
         } else {
             EmptyView()
+        }
+    }
+
+    /// Cap on chips rendered inline in the header before overflow kicks
+    /// in. Two compact chips at ~110pt each plus an 8pt gap is already
+    /// most of the 380pt panel width once the mode button and status
+    /// indicator are factored in; a third would overflow visibly.
+    private static let maxVisibleQuotaChips = 2
+
+    /// The "+N more" chip: a small grey pill showing the hidden chip
+    /// count, whose tooltip lists each hidden provider with its
+    /// headline metric. Matches mockup 3 in issue #309.
+    @ViewBuilder
+    private func quotaOverflowChip(hidden: [QuotaWidgetData]) -> some View {
+        Text("+\(hidden.count) more")
+            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .foregroundColor(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.secondary.opacity(0.15))
+            .cornerRadius(IrrRadius.sm)
+            .tooltip(hidden.map { quotaOverflowSummary($0) }.joined(separator: "\n"))
+    }
+
+    /// One line in the overflow tooltip: "<plan or provider>: <headline>".
+    /// Subscription chips show the imminent window's percent; usage chips
+    /// show the cumulative spend headline.
+    private func quotaOverflowSummary(_ d: QuotaWidgetData) -> String {
+        let label = d.snapshot.planTypeLabel ?? d.id.capitalized
+        switch d.mode {
+        case .subscription:
+            if let imm = d.imminent {
+                return "\(label): \(Int(imm.usedPercent.rounded()))%"
+            }
+            return label
+        case .usage:
+            let cost = d.totalCostUSD > 0 ? formatUsageCost(d.totalCostUSD) : "—"
+            return "\(label): \(cost)"
         }
     }
 

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -122,14 +122,19 @@ struct SettingsView: View {
 
             Spacer()
 
+            Divider()
+
             HStack {
+                Text("Irrlicht v\(appVersion)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
                 Spacer()
                 Button("Done") { isPresented = false }
                     .keyboardShortcut(.defaultAction)
             }
         }
         .padding(20)
-        .frame(width: 360, height: 520)
+        .frame(width: 360, height: 640)
         .background(Color(NSColor.windowBackgroundColor))
         .toggleStyle(IrrlichtSwitchToggleStyle())
     }

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @Binding var isPresented: Bool
     @AppStorage("debugMode") private var debugMode: Bool = false
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
+    @AppStorage("showQuotaForecast") private var showQuotaForecast: Bool = true
     @AppStorage("launchAtLogin") private var launchAtLogin: Bool = true
     @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = true
     @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = true
@@ -32,6 +33,15 @@ struct SettingsView: View {
                 LeadingToggle(isOn: $showCostDisplay, label: "Show Estimated Cost")
 
                 Text("Display estimated USD cost per session and per project group. Cost estimates are approximate.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                LeadingToggle(isOn: $showQuotaForecast, label: "Show Quota Forecast")
+
+                Text("Replace the app version in the header with a live burn-rate forecast against your Pro/Max or ChatGPT subscription cap. Only appears when a subscription session is active.")
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -8,6 +8,8 @@ struct SettingsView: View {
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
     @AppStorage("showQuotaForecast") private var showQuotaForecast: Bool = true
     @AppStorage("launchAtLogin") private var launchAtLogin: Bool = true
+    @AppStorage("providerMode_anthropic") private var providerModeAnthropic: String = ProviderModePreference.auto.rawValue
+    @AppStorage("providerMode_openai") private var providerModeOpenAI: String = ProviderModePreference.auto.rawValue
     @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = true
     @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = true
     @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = true
@@ -45,6 +47,15 @@ struct SettingsView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                if showQuotaForecast {
+                    providerModeRow(label: "Anthropic", selection: $providerModeAnthropic)
+                    providerModeRow(label: "OpenAI", selection: $providerModeOpenAI)
+                    Text("Auto picks the chip variant from the snapshot; override when you have multiple paths into one provider.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
             VStack(alignment: .leading, spacing: 8) {
@@ -134,9 +145,29 @@ struct SettingsView: View {
             }
         }
         .padding(20)
-        .frame(width: 360, height: 640)
+        .frame(width: 360, height: 740)
         .background(Color(NSColor.windowBackgroundColor))
         .toggleStyle(IrrlichtSwitchToggleStyle())
+    }
+
+    /// One row of the Providers section: provider name + segmented
+    /// picker. Bound to the raw AppStorage string so SwiftUI re-renders
+    /// downstream views (SessionListView's chip) as soon as the user
+    /// flips it.
+    @ViewBuilder
+    private func providerModeRow(label: String, selection: Binding<String>) -> some View {
+        HStack {
+            Text(label)
+                .font(.callout)
+                .frame(width: 80, alignment: .leading)
+            Picker("", selection: selection) {
+                ForEach(ProviderModePreference.allCases) { mode in
+                    Text(mode.label).tag(mode.rawValue)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+        }
     }
 
     private func checkNotificationAuth() {

--- a/platforms/macos/Tests/QuotaChipBarColorTests.swift
+++ b/platforms/macos/Tests/QuotaChipBarColorTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import SwiftUI
+@testable import Irrlicht
+
+/// Table-driven coverage for SessionListView.barColor — the pace-aware
+/// ramp that drives quota bar fill color. Keeps the threshold
+/// boundaries pinned (issue #309): a change here that flips one of
+/// these cases should be deliberate, not accidental.
+@MainActor
+final class QuotaChipBarColorTests: XCTestCase {
+
+    private static let green = IrrColors.pressureLow
+
+    func testBarColorPaceAwareThresholds() {
+        let cases: [(name: String, used: Double, pace: Double?, want: Color)] = [
+            ("on pace",                  30, 30,   Self.green),
+            ("4pt ahead — still green",  34, 30,   Self.green),
+            ("5pt ahead — yellow edge",  35, 30,   .yellow),
+            ("14pt ahead — still yellow",44, 30,   .yellow),
+            ("15pt ahead — orange edge", 45, 30,   .orange),
+            ("far ahead",                70, 30,   .orange),
+            ("behind pace",              20, 40,   Self.green),
+
+            // Absolute cap dominates regardless of pace
+            ("at cap (85%)",             85, 50,   .orange),
+            ("over cap",                 99, 95,   .orange),
+            ("84% — boundary just below",84, 50,   .orange), // 34pt over pace, orange via pace rule
+
+            // Pace nil → absolute ramp
+            ("nil pace, low usage",      30, nil,  Self.green),
+            ("nil pace, 50% — yellow",   50, nil,  .yellow),
+            ("nil pace, 70% — orange",   70, nil,  .orange),
+            ("nil pace, 90% — orange",   90, nil,  .orange),
+        ]
+        for c in cases {
+            let got = SessionListView.barColor(used: c.used, pace: c.pace)
+            XCTAssertEqual(got, c.want,
+                "\(c.name): barColor(used: \(c.used), pace: \(String(describing: c.pace))) = \(got), want \(c.want)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes #309. Surfaces subscription/usage quota for every coding-agent session in the macOS menu-bar overlay, matching the three design mockups in the ticket (single chip · multi-provider · `+N more` overflow). Five phases landed:

- **Phase 1 — Ingestion** (7bc2cc6). Codex parser extracts `payload.rate_limits` from `token_count` events (handles v1/v2/v3 schemas + the 299/10079 minute-window quirk). Claude Code's statusline JSON is captured via a new `statusLine.command` POST receiver at `/api/v1/hooks/claudecode/statusline`. Hook installer chains any pre-existing user statusline via `bash -c 'tee >(user-cmd) | curl …'` (276eb3f).
- **Phase 2 — Single-provider chip** (77acc84). Replaces the "Irrlicht v…" header text with a provider chip — icon + stacked 5h/7d progress bars, color-graded by the pressure ramp, percent + reset time inline. Version moves to a footer in Settings. New "Show Quota Forecast" toggle.
- **Phase 3 — Multi-provider header** (6566ca8, 8e0bf4b). Aggregates snapshots by provider key; renders multiple chips side-by-side with compact bars when more than one is present. Stable alphabetical sort (Anthropic leftmost) so chips don't swap positions every few seconds.
- **Phase 3b — Usage-mode variant** (1fb37f5). API-key paths (snapshot.credits populated) render `$X.YZ` + "spend" subtitle instead of bars. Subscription wins over usage when both are seen for one provider. Hotfix-pass (9b56202): forced-usage chips with zero spend render `—` / "no spend yet" instead of degenerate `$0.00`.
- **Phase 4 — Overflow** (c3b1d96). Caps inline at 2 chips; everything beyond collapses into a `+N more` pill whose tooltip lists hidden providers. Sensible default until a third subscription provider lands and we have data on what users want pinned.
- **Phase 5 — Per-provider settings** (9b56202). Auto / Subscription / Usage picker per known provider in Settings, persisted via `@AppStorage("providerMode_<key>")`. Overrides snapshot-based auto-detection for users with multiple paths into one provider.
- **Phase 6 — Cross-account inheritance** (415ece7). Wrapper sessions (Pi, OpenCode) inherit the snapshot from a first-party CLI authenticated to the same OAuth account. Donor map: Claude Code → Anthropic singleton (account anchor in keychain), Codex → `("openai", auth.tokens.account_id)`. Recipients: Pi via `~/.pi/agent/auth.json`, OpenCode via `~/.local/share/opencode/auth.json`.

### Hotfixes also bundled

- **bash-c statusline wrap** (276eb3f). `tee >(…)` is bash-only; Claude Code invokes statusLine via POSIX sh, so the v1 wrap silently failed for any user with a pre-existing statusline. Re-wrap in `bash -c '…'`; existing v1 wraps auto-migrate on next daemon start.
- **Stable chip sort** (8e0bf4b). Sort by provider key, not by percent — the percent-based sort made chips swap positions every few seconds.
- **Icon size enforcement** (9b56202). `Image(nsImage:)` decodes complex SVGs at viewBox-native sizes; forcing `.resizable().frame(14×14)` normalises every provider icon.
- **Stale-snapshot drop** (9b56202). Daemon nulls a snapshot once any window has rolled past its `resets_at` without a fresh tick — was rendering "resets in 0m" with pre-rollover percentages.
- **Freshest-snapshot wins** (48b64b8). Within a provider bucket the aggregator picks the latest `sampled_at`, not the highest `used_percent` — the latter locked the chip onto stale ready sessions and never updated as long as one persisted.

## Test coverage

- Domain forecast helper + JSON serialization
- Codex parser (v1/v2/v3 schemas + 299/10079 quirk + absence + only-on-token_count)
- Tailer ingestion (first/dup/rollover/cap/nil + stale-snapshot null)
- Statusline handler (success/empty/missing-path/method) + installer (chain/idempotent/wrap/unchain/v1-migration)
- Cross-account inheritance (OpenAI account_id match, mismatch, Anthropic singleton, OpenAI-over-Anthropic preference, freshest-wins, no-overwrite, no-donor noop, API-key-no-donate)
- `go test ./core/... -race -count=1` clean (one pre-existing flaky test passes in isolation)
- `tools/replay-fixtures.sh` clean, no fixture drift
- `swift build` clean
- End-to-end manual: forced statusline POST + Codex token_count + Pi/OpenCode auth files exercised via dev stack

## Intentional follow-ups (filed)

- #384 — OpenCode→OpenAI inheritance via JWT account_id extraction
- #385 — per-provider daily cost rollup for usage chips ("$X / day · spend today" label fidelity)
- #386 — disable usage toggle when only subscription data exists
- #387 — port the provider chip to the web dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)