### PR TITLE
fix(tailer): prune absent tasks from task_reminder snapshot

### DIFF
--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -1520,28 +1520,51 @@ func TestParser_TaskReminder_NonTaskReminderIgnored(t *testing.T) {
 	}
 }
 
-// TestTailer_TaskReminder_DemotesPhantomInProgress models the real-session
-// failure mode from issue #282: TaskUpdate marks task 1 in_progress, then a
-// later task_reminder snapshot that omits task 1 arrives; the tailer must
-// demote the stuck in_progress to completed so allDone goes true in the UI.
-func TestTailer_TaskReminder_DemotesPhantomInProgress(t *testing.T) {
+// TestTailer_TaskReminder_PrunesAbsentTasks covers the dual role of the
+// snapshot reconcile: long-session pruning (#389) and the original phantom
+// in_progress fix (#282). A task whose ID is absent from the latest
+// task_reminder snapshot is removed from metrics.tasks entirely — Claude
+// Code's UI mirrors only the current batch, and so do we. As a side effect
+// of that policy, a stale TaskUpdate(taskId=…) that never receives a
+// matching completed can no longer leave a stuck in_progress entry: when
+// Claude drops the ID from its snapshot, we drop the row.
+func TestTailer_TaskReminder_PrunesAbsentTasks(t *testing.T) {
 	events := []map[string]interface{}{
+		// First batch — three tasks, all eventually completed.
 		makeToolUseEvent("tu_1", "TaskCreate", map[string]interface{}{
-			"subject": "Stale task", "activeForm": "Stale-tasking",
+			"subject": "Old A", "activeForm": "Old-Aing",
 		}),
 		makeToolUseEvent("tu_2", "TaskCreate", map[string]interface{}{
-			"subject": "New task", "activeForm": "New-tasking",
+			"subject": "Old B", "activeForm": "Old-Bing",
 		}),
-		// Bogus TaskUpdate against a stale ID — never followed by completed.
-		makeToolUseEvent("tu_3", "TaskUpdate", map[string]interface{}{
-			"taskId": "1", "status": "in_progress",
+		makeToolUseEvent("tu_3", "TaskCreate", map[string]interface{}{
+			"subject": "Old C", "activeForm": "Old-Cing",
 		}),
 		makeToolUseEvent("tu_4", "TaskUpdate", map[string]interface{}{
+			"taskId": "1", "status": "completed",
+		}),
+		makeToolUseEvent("tu_5", "TaskUpdate", map[string]interface{}{
 			"taskId": "2", "status": "completed",
 		}),
-		// Snapshot omits task 1 entirely — Claude's view doesn't track it.
+		// Stale TaskUpdate for ID 3 — never gets a matching completed,
+		// the kind of phantom drift that motivated #282.
+		makeToolUseEvent("tu_6", "TaskUpdate", map[string]interface{}{
+			"taskId": "3", "status": "in_progress",
+		}),
+		// Second batch — IDs 4 and 5 (taskSeq monotonic across batches).
+		makeToolUseEvent("tu_7", "TaskCreate", map[string]interface{}{
+			"subject": "New A", "activeForm": "New-Aing",
+		}),
+		makeToolUseEvent("tu_8", "TaskCreate", map[string]interface{}{
+			"subject": "New B", "activeForm": "New-Bing",
+		}),
+		makeToolUseEvent("tu_9", "TaskUpdate", map[string]interface{}{
+			"taskId": "4", "status": "in_progress",
+		}),
+		// Snapshot reflects only the new batch — IDs 1, 2, 3 are gone.
 		makeReminderEvent([]map[string]interface{}{
-			{"id": "2", "subject": "New task", "status": "completed"},
+			{"id": "4", "subject": "New A", "status": "in_progress"},
+			{"id": "5", "subject": "New B", "status": "pending"},
 		}),
 	}
 
@@ -1550,29 +1573,27 @@ func TestTailer_TaskReminder_DemotesPhantomInProgress(t *testing.T) {
 		t.Fatalf("TailAndProcess: %v", err)
 	}
 	if len(m.Tasks) != 2 {
-		t.Fatalf("Tasks len = %d, want 2", len(m.Tasks))
+		t.Fatalf("Tasks len = %d, want 2 (only current batch); tasks=%+v", len(m.Tasks), m.Tasks)
 	}
-	if m.Tasks[0].ID != "1" || m.Tasks[0].Status != tailer.TaskStatusCompleted {
-		t.Errorf("phantom task 1 not reconciled: %+v", m.Tasks[0])
+	if m.Tasks[0].ID != "4" || m.Tasks[0].Status != tailer.TaskStatusInProgress {
+		t.Errorf("task[0] = %+v, want id=4 in_progress", m.Tasks[0])
 	}
-	if m.Tasks[1].ID != "2" || m.Tasks[1].Status != tailer.TaskStatusCompleted {
-		t.Errorf("task 2 = %+v", m.Tasks[1])
+	if m.Tasks[1].ID != "5" || m.Tasks[1].Status != tailer.TaskStatusPending {
+		t.Errorf("task[1] = %+v, want id=5 pending", m.Tasks[1])
 	}
-	allDone := true
 	for _, task := range m.Tasks {
-		if task.Status != tailer.TaskStatusCompleted {
-			allDone = false
+		if task.ID == "3" {
+			t.Errorf("phantom in_progress task 3 must not survive snapshot; tasks=%+v", m.Tasks)
 		}
-	}
-	if !allDone {
-		t.Errorf("expected allDone=true after reconciliation; tasks=%+v", m.Tasks)
 	}
 }
 
-// TestTailer_TaskReminder_EmptySnapshotDemotesAll covers the legitimate
-// "nothing active" reminder — a `content:[]` snapshot must demote every
-// in_progress task to completed.
-func TestTailer_TaskReminder_EmptySnapshotDemotesAll(t *testing.T) {
+// TestTailer_TaskReminder_EmptySnapshotPrunesAll covers the "nothing active"
+// reminder — a `content:[]` snapshot is the explicit "no current batch"
+// signal Claude Code emits at turn boundaries, and it must clear the slice
+// completely. Mirrors the empty-content task_reminder attachments observed
+// in real transcripts (see #282 timeline, 11:00–11:06).
+func TestTailer_TaskReminder_EmptySnapshotPrunesAll(t *testing.T) {
 	events := []map[string]interface{}{
 		makeToolUseEvent("tu_1", "TaskCreate", map[string]interface{}{
 			"subject": "A", "activeForm": "Aing",
@@ -1593,10 +1614,8 @@ func TestTailer_TaskReminder_EmptySnapshotDemotesAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TailAndProcess: %v", err)
 	}
-	for i, task := range m.Tasks {
-		if task.Status != tailer.TaskStatusCompleted {
-			t.Errorf("task[%d] %+v should be completed after empty reminder", i, task)
-		}
+	if len(m.Tasks) != 0 {
+		t.Errorf("expected empty Tasks after empty reminder; got %+v", m.Tasks)
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -1581,11 +1581,8 @@ func TestTailer_TaskReminder_PrunesAbsentTasks(t *testing.T) {
 	if m.Tasks[1].ID != "5" || m.Tasks[1].Status != tailer.TaskStatusPending {
 		t.Errorf("task[1] = %+v, want id=5 pending", m.Tasks[1])
 	}
-	for _, task := range m.Tasks {
-		if task.ID == "3" {
-			t.Errorf("phantom in_progress task 3 must not survive snapshot; tasks=%+v", m.Tasks)
-		}
-	}
+	// The len=2 + ID-4 + ID-5 assertions above prove the stale in_progress
+	// task 3 was pruned (the #282 phantom case).
 }
 
 // TestTailer_TaskReminder_EmptySnapshotPrunesAll covers the "nothing active"

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -644,10 +644,7 @@ func (t *TranscriptTailer) FlushIdle() (*SessionMetrics, bool) {
 // so monotonic IDs continue to match Claude's sequential numbering across
 // pruned batches. See issues #282 and #389.
 func (t *TranscriptTailer) reconcileTaskSnapshot(parsed *ParsedEvent) {
-	if parsed == nil || parsed.TaskSnapshot == nil {
-		return
-	}
-	if len(t.tasks) == 0 {
+	if parsed == nil || parsed.TaskSnapshot == nil || len(t.tasks) == 0 {
 		return
 	}
 	snapByID := make(map[string]TaskSnapshotEntry, len(*parsed.TaskSnapshot))

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -626,42 +626,48 @@ func (t *TranscriptTailer) FlushIdle() (*SessionMetrics, bool) {
 
 // reconcileTaskSnapshot applies a Claude Code task_reminder snapshot from
 // parsed (when present) to the running tasks slice. Reminders are
-// authoritative over local state in two ways:
+// authoritative over local state:
 //
-//  1. Phantom demotion: a local in_progress task whose ID is missing from
-//     the snapshot is set to completed (Claude has dropped it from active
-//     tracking) — this is the primary fix for the stale TaskUpdate bug.
+//  1. Prune: a local task whose ID is missing from the snapshot is removed.
+//     Claude Code's UI only shows the current batch — when it stops tracking
+//     a task, we drop it too. This both fixes the phantom in_progress bug
+//     from #282 (no entry means no stuck status) and prevents unbounded dot
+//     accumulation in long sessions (#389).
 //  2. Present divergence: for any ID present in the snapshot whose status
-//     differs from local state, the snapshot's status wins. Strictly more
-//     than a "phantom only" rule — Claude's view is authoritative whenever
-//     it speaks. Safe under transcript ordering because reminders appear
-//     on user turns, after the assistant tool_use that emitted any deltas
-//     for that turn.
+//     differs from local state, the snapshot's status wins. Claude's view
+//     is authoritative whenever it speaks. Safe under transcript ordering
+//     because reminders appear on user turns, after the assistant tool_use
+//     that emitted any deltas for that turn.
 //
 // Snapshots that mention IDs we never saw a TaskCreate for are ignored;
-// the reconcile only updates pre-existing tasks. See issue #282.
+// the reconcile only acts on pre-existing tasks. t.taskSeq is never reset,
+// so monotonic IDs continue to match Claude's sequential numbering across
+// pruned batches. See issues #282 and #389.
 func (t *TranscriptTailer) reconcileTaskSnapshot(parsed *ParsedEvent) {
-	if parsed == nil || parsed.TaskSnapshot == nil || len(t.tasks) == 0 {
+	if parsed == nil || parsed.TaskSnapshot == nil {
+		return
+	}
+	if len(t.tasks) == 0 {
 		return
 	}
 	snapByID := make(map[string]TaskSnapshotEntry, len(*parsed.TaskSnapshot))
 	for _, entry := range *parsed.TaskSnapshot {
 		snapByID[entry.ID] = entry
 	}
+	kept := make([]Task, 0, len(t.tasks))
 	for i := range t.tasks {
 		entry, present := snapByID[t.tasks[i].ID]
 		if !present {
-			if t.tasks[i].Status == TaskStatusInProgress {
-				log.Printf("irrlicht/tailer: reconciling phantom in_progress task id=%s subject=%q → completed (not in task_reminder snapshot) in %s", t.tasks[i].ID, t.tasks[i].Subject, t.path)
-				t.tasks[i].Status = TaskStatusCompleted
-			}
+			log.Printf("irrlicht/tailer: pruning task id=%s subject=%q status=%s (absent from task_reminder snapshot) in %s", t.tasks[i].ID, t.tasks[i].Subject, t.tasks[i].Status, t.path)
 			continue
 		}
 		if entry.Status != "" && entry.Status != t.tasks[i].Status {
 			log.Printf("irrlicht/tailer: reconciling task id=%s status %s → %s from task_reminder in %s", t.tasks[i].ID, t.tasks[i].Status, entry.Status, t.path)
 			t.tasks[i].Status = entry.Status
 		}
+		kept = append(kept, t.tasks[i])
 	}
+	t.tasks = kept
 }
 
 // processParsedEvent applies a single non-skipped ParsedEvent to the tailer's

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -655,7 +655,13 @@ func (t *TranscriptTailer) reconcileTaskSnapshot(parsed *ParsedEvent) {
 	for i := range t.tasks {
 		entry, present := snapByID[t.tasks[i].ID]
 		if !present {
-			log.Printf("irrlicht/tailer: pruning task id=%s subject=%q status=%s (absent from task_reminder snapshot) in %s", t.tasks[i].ID, t.tasks[i].Subject, t.tasks[i].Status, t.path)
+			// Quiet on the common case (completed tasks pruned at batch
+			// turnover). Pending/in_progress prunes still log — they're
+			// the #282-style "Claude dropped a task it claimed to track"
+			// signal worth surfacing.
+			if t.tasks[i].Status != TaskStatusCompleted {
+				log.Printf("irrlicht/tailer: pruning %s task id=%s subject=%q (absent from task_reminder snapshot) in %s", t.tasks[i].Status, t.tasks[i].ID, t.tasks[i].Subject, t.path)
+			}
 			continue
 		}
 		if entry.Status != "" && entry.Status != t.tasks[i].Status {


### PR DESCRIPTION
## Summary

- Flip `reconcileTaskSnapshot` from demote-only to **prune**: tasks whose IDs aren't in the latest `task_reminder` snapshot are removed from `metrics.tasks`, mirroring Claude Code's "current batch only" UI.
- The macOS and web renderers (plus the `done / total` counter) derive entirely from `metrics.tasks` length+status, so the dot strip caps at the current batch automatically — no Swift or HTML diff needed.
- `t.taskSeq` is not reset; monotonic IDs continue to match Claude's sequential numbering across pruned batches.

Fixes #389. Subsumes the #282 phantom-`in_progress` fix as a side effect: a stale `TaskUpdate` that never completes can no longer leave a stuck row, because Claude dropping the ID from its snapshot now drops the row entirely.

## Behavior on existing sessions

The fix is reactive — `reconcileTaskSnapshot` only fires when a new `task_reminder` attachment arrives in the live transcript. On daemon restart the tailer resumes from a persisted `lastOffset`, so it doesn't re-play history. Practical consequence:

- **Already-affected sessions** with 90+ dots **will not shrink on daemon restart alone**. They collapse on the next turn — every user message Claude Code sends carries a fresh `task_reminder` snapshot, which triggers the prune.
- **New sessions** (and existing sessions after their next turn) behave correctly from that point onward — each batch turnover prunes the prior batch as it ends.

Verified live on the dev build: an existing accumulated session collapsed to its current batch immediately on the next user turn.

## Test plan

- [x] `go test ./core/... -race -count=1` — full suite green
- [x] `tools/replay-fixtures.sh` — all 30+ fixtures replay cleanly; goldens unchanged (replay schema captures `summary` + `transitions`, not `metrics.tasks`)
- [x] New test `TestTailer_TaskReminder_PrunesAbsentTasks` — multi-batch scenario with embedded #282 phantom case; asserts only current batch survives and stale `in_progress` row is gone
- [x] Renamed `TestTailer_TaskReminder_EmptySnapshotPrunesAll` — empty `content:[]` clears the slice
- [x] Preserved `TestTailer_TaskReminder_SyncsDivergingStatus` — #282 status-sync regression guard
- [x] Live dev-build verification: existing long-running session collapses to current batch on next turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)