### PR TITLE
fix(installer): avoid GitHub API 403 on version detection

### DIFF
--- a/site/install.sh
+++ b/site/install.sh
@@ -151,9 +151,10 @@ command -v shasum >/dev/null 2>&1 || fail "shasum is required but not found."
 
 if [ -z "$VERSION" ]; then
     step "Detecting latest version"
-    VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
-        | awk -F'"' '/"tag_name"/ {print $4; exit}' \
-        | sed 's/^v//')
+    # Follow the /releases/latest redirect to avoid GitHub API rate limits
+    VERSION=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+        "https://github.com/$REPO/releases/latest" \
+        | grep -oE '[0-9]+\.[0-9]+\.[0-9]+$')
     [ -n "$VERSION" ] || fail "Could not detect latest version"
     printf 'v%s\n' "$VERSION"
 fi


### PR DESCRIPTION
## Summary

- Replaces `api.github.com/repos/.../releases/latest` with a redirect-follow on `github.com/.../releases/latest` to extract the version from the final URL
- GitHub's unauthenticated API returns 403 on secondary rate limits; the HTML redirect approach has no rate limit exposure and requires no token

## Test plan

- [ ] `curl -fsSL https://irrlicht.io/install.sh | sh` completes version detection without 403
- [ ] `--version X.Y.Z` flag still works (bypasses detection entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)