### PR TITLE
fix(claudecode): preserve user statusLine output in wrapped command

### DIFF
--- a/core/adapters/inbound/agents/claudecode/statusline_installer.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_installer.go
@@ -177,8 +177,8 @@ func chainStatuslineCommand(current string) string {
 // wrapStatuslineCommand builds the canonical chained form for the given
 // user command. Single-quotes inside the user's command are escaped so the
 // command can be embedded in `bash -c '…'` without breaking quoting.
-// curl sits in a process substitution so its stdin (and stdout via
-// >/dev/null) don't interfere with the main pipeline; the user command
+// curl sits in a process substitution so its stdout (silenced via
+// >/dev/null) doesn't sit in the main pipeline; the user command
 // runs last so its stdout reaches Claude Code directly.
 func wrapStatuslineCommand(user string) string {
 	escaped := strings.ReplaceAll(user, "'", `'\''`)
@@ -195,7 +195,10 @@ func wrapStatuslineCommand(user string) string {
 //
 // v1 and v2 are still recognised for migration; new installs always emit v3.
 func unchainStatuslineCommand(current string) string {
-	// v3: user command is after the fixed curl-in-sub prefix.
+	// v3: user command follows the fixed curl-in-sub prefix and a closing quote.
+	// Note: v2 also ends with "'" (its bash -c closing quote), but v2 starts
+	// with `bash -c 'tee >(user`, not `bash -c 'tee >(curl`, so the HasPrefix
+	// check is unambiguous.
 	if strings.HasPrefix(current, v3WrapPrefix) && strings.HasSuffix(current, "'") {
 		inner := current[len(v3WrapPrefix) : len(current)-1]
 		return strings.ReplaceAll(inner, `'\''`, "'")

--- a/core/adapters/inbound/agents/claudecode/statusline_installer.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_installer.go
@@ -11,10 +11,15 @@ import (
 )
 
 // unchainBoundary matches the boundary between the user's tee-fed
-// command and our trailing curl pipeline. Whitespace-tolerant so a
-// hand-edited wrap with extra spaces still round-trips through
-// unchainStatuslineCommand.
+// command and the trailing curl pipeline in the legacy v1/v2 wrap format.
+// Whitespace-tolerant so a hand-edited wrap with extra spaces still
+// round-trips through unchainStatuslineCommand.
 var unchainBoundary = regexp.MustCompile(`\)\s*\|\s*curl\s`)
+
+// v3WrapPrefix is the fixed leading literal of the current wrap format.
+// The user's command follows immediately after this prefix and is
+// terminated by a closing single quote.
+const v3WrapPrefix = `bash -c 'tee >(` + installedStatuslineCommand + `) | `
 
 // statuslineSentinel is the substring that identifies an irrlicht-managed
 // statusline command. Used for idempotency checks and chained-command
@@ -141,11 +146,14 @@ func writeStatuslineCommand(settings map[string]interface{}, cmd string) {
 //
 // Internal shape, inside `bash -c "…"`:
 //
-//	tee >(<user command>) | curl -fsS … >/dev/null 2>&1 || true
+//	tee >(curl -fsS … >/dev/null 2>&1 || true) | <user command>
 //
-// The user's command sees a copy of stdin via `tee`; the trailing curl
-// branch carries stdin onward to our endpoint. The `|| true` keeps the
-// overall command status zero so Claude Code doesn't surface a failure.
+// curl runs in a process substitution so it receives a copy of stdin
+// without sitting in the main pipeline. The user's command runs last in
+// the pipeline, so its stdout flows directly back to Claude Code, which
+// reads it to display the status line text. Prior wrap formats (v1: bare
+// tee pipeline; v2: user command in the process sub) are migrated on the
+// next daemon start via unchainStatuslineCommand + re-chain.
 func chainStatuslineCommand(current string) string {
 	if current == "" || current == installedStatuslineCommand {
 		return installedStatuslineCommand
@@ -169,21 +177,30 @@ func chainStatuslineCommand(current string) string {
 // wrapStatuslineCommand builds the canonical chained form for the given
 // user command. Single-quotes inside the user's command are escaped so the
 // command can be embedded in `bash -c '…'` without breaking quoting.
+// curl sits in a process substitution so its stdin (and stdout via
+// >/dev/null) don't interfere with the main pipeline; the user command
+// runs last so its stdout reaches Claude Code directly.
 func wrapStatuslineCommand(user string) string {
 	escaped := strings.ReplaceAll(user, "'", `'\''`)
-	return `bash -c 'tee >(` + escaped + `) | curl -fsS --max-time 1 -X POST --data-binary @- ` +
-		`http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true'`
+	return v3WrapPrefix + escaped + `'`
 }
 
 // unchainStatuslineCommand returns the user's original command when current
 // was a chained wrap, or "" otherwise (standalone install, unknown shape).
 //
-// Recognises both wrap formats:
-//   - v1 (broken under sh): `tee >(<user>) | curl … sentinel … || true`
-//   - v2 (canonical):       `bash -c 'tee >(<user>) | curl … sentinel … || true'`
+// Recognises three wrap formats:
+//   - v3 (current):  `bash -c 'tee >(<curl+sentinel>) | <user>'`
+//   - v2 (legacy):   `bash -c 'tee >(<user>) | curl … sentinel … || true'`
+//   - v1 (broken):   `tee >(<user>) | curl … sentinel … || true`
 //
-// The v1 form is still recognised for migration; new installs always emit v2.
+// v1 and v2 are still recognised for migration; new installs always emit v3.
 func unchainStatuslineCommand(current string) string {
+	// v3: user command is after the fixed curl-in-sub prefix.
+	if strings.HasPrefix(current, v3WrapPrefix) && strings.HasSuffix(current, "'") {
+		inner := current[len(v3WrapPrefix) : len(current)-1]
+		return strings.ReplaceAll(inner, `'\''`, "'")
+	}
+	// v1/v2: user command is before the `) | curl ` boundary.
 	for _, prefix := range []string{`bash -c 'tee >(`, `tee >(`} {
 		if !strings.HasPrefix(current, prefix) {
 			continue

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -179,12 +179,17 @@ func TestUnchainStatuslineCommand_StandaloneReturnsEmpty(t *testing.T) {
 }
 
 func TestChainStatuslineCommand_WrapUsesBashEnvelope(t *testing.T) {
-	got := chainStatuslineCommand("/usr/local/bin/my-statusline")
+	user := "/usr/local/bin/my-statusline"
+	got := chainStatuslineCommand(user)
 	if !strings.HasPrefix(got, `bash -c 'tee >(`) {
 		t.Errorf("expected bash -c envelope, got %q", got)
 	}
-	if !strings.HasSuffix(got, `|| true'`) {
-		t.Errorf("expected trailing `|| true'`, got %q", got)
+	// v3: curl sits in the process sub; user command is last (ends with user+quote).
+	if !strings.HasSuffix(got, user+`'`) {
+		t.Errorf("expected user command at end of pipeline, got %q", got)
+	}
+	if !strings.Contains(got, statuslineSentinel) {
+		t.Errorf("expected sentinel in process sub, got %q", got)
 	}
 }
 
@@ -234,15 +239,21 @@ func TestUnchainStatuslineCommand_ToleratesExtraWhitespace(t *testing.T) {
 	}
 }
 
-func TestChainStatuslineCommand_MigratesV1WrapToV2(t *testing.T) {
+func TestChainStatuslineCommand_MigratesOldWrapsToV3(t *testing.T) {
 	userCmd := "bash ~/.claude/interplay-statusline.sh"
+	// v1 (no bash envelope)
 	v1 := "tee >(" + userCmd + ") | curl -fsS --max-time 1 -X POST --data-binary @- " +
 		"http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true"
-	got := chainStatuslineCommand(v1)
-	if !strings.HasPrefix(got, `bash -c 'tee >(`) {
-		t.Fatalf("expected v2 (bash -c) form after migration, got %q", got)
-	}
-	if !strings.Contains(got, userCmd) {
-		t.Errorf("expected user command to survive migration, got %q", got)
+	// v2 (user command in process sub)
+	v2 := `bash -c 'tee >(` + userCmd + `) | curl -fsS --max-time 1 -X POST --data-binary @- ` +
+		`http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true'`
+	for _, old := range []string{v1, v2} {
+		got := chainStatuslineCommand(old)
+		if !strings.HasPrefix(got, v3WrapPrefix) {
+			t.Errorf("expected v3 form after migration, got %q", got)
+		}
+		if !strings.Contains(got, userCmd) {
+			t.Errorf("expected user command to survive migration, got %q", got)
+		}
 	}
 }

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -246,6 +246,11 @@ cd Irrlicht
         The daemon listens on <code>127.0.0.1:7837</code> by default. This port is not exposed to the network. See the <a href="configuration.html">Configuration</a> page to change the bind address or port.
       </div>
 
+      <div class="callout callout-tip">
+        <strong>Status line takes effect in new sessions</strong>
+        On first launch, Irrlicht registers a <code>statusLine.command</code> entry in <code>~/.claude/settings.json</code>. The change is read at Claude Code startup &mdash; a session already running when Irrlicht first launched won't pick it up until it is closed and reopened.
+      </div>
+
       <!-- ── Uninstalling ── -->
       <h2 id="uninstalling">Uninstalling</h2>
 

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -247,8 +247,8 @@ cd Irrlicht
       </div>
 
       <div class="callout callout-tip">
-        <strong>Status line takes effect in new sessions</strong>
-        On first launch, Irrlicht registers a <code>statusLine.command</code> entry in <code>~/.claude/settings.json</code>. The change is read at Claude Code startup &mdash; a session already running when Irrlicht first launched won't pick it up until it is closed and reopened.
+        <strong>Restart Claude Code after first launch</strong>
+        On first launch, Irrlicht registers a <code>statusLine.command</code> entry in <code>~/.claude/settings.json</code>. Any Claude Code session already running at that point won't pick it up &mdash; close and reopen it once to activate the integration.
       </div>
 
       <!-- ── Uninstalling ── -->


### PR DESCRIPTION
## Summary

Fixes #403. The install was silently swallowing the user's status line output on every terminal (not kitty-specific), leaving the status bar blank after installation.

**Root cause:** The v2 wrap format placed the user's command inside a process substitution on the left side of a pipeline:

```
bash -c 'tee >(user_cmd) | curl … >/dev/null 2>&1 || true'
```

Process substitutions inside a pipeline stage inherit that stage's stdout — the pipe going to curl. So `user_cmd`'s output was sent to curl and discarded, never reaching Claude Code.

**Fix (v3 format):** Swap positions — curl goes into the process substitution, user command becomes the last pipeline stage, so its stdout flows directly back to Claude Code:

```
bash -c 'tee >(curl … >/dev/null 2>&1 || true) | user_cmd'
```

Verified with `bash -c 'tee >(cat > /dev/null) | cat'` vs `bash -c 'tee >(cat) | cat > /dev/null'`: only the v3 form captures stdout.

## Changes

- `statusline_installer.go` — new `v3WrapPrefix` constant; `wrapStatuslineCommand` emits v3; `unchainStatuslineCommand` detects v3 first, falls through to legacy v1/v2 regex for migration
- `statusline_test.go` — updated two tests to match v3 format; migration test now covers both v1 and v2 → v3
- `site/docs/installation.html` — adds a terminal-agnostic note that the `settings.json` change takes effect in new Claude Code sessions

Existing v1 and v2 installs migrate automatically on the next daemon start.

## Test plan

- [ ] `go test ./core/... -race -count=1` passes
- [ ] `tools/replay-fixtures.sh` passes (pre-existing opencode golden failure unrelated)
- [ ] Start Claude Code with a custom `statusLine.command` already configured → confirm it still displays after daemon restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)