### PR TITLE
feat(release): notarize macOS DMG with Developer ID signing

### DIFF
--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -392,10 +392,11 @@ on any unauthorized link:
 
 ```bash
 # Each entry is "framework-name | reason | fix-pointer".
-# Add more here as we discover them. When DevID is in (#233) the
-# entitlement-bearing entries can be removed from this list.
+# Static Intents.framework is still forbidden even with DevID: FocusMonitor.swift
+# intentionally uses NSClassFromString dispatch to avoid the TCC preflight.
+# Remove this entry once #357 restores the static import Intents path.
 FORBIDDEN_FRAMEWORKS=(
-  "Intents.framework|preflights kTCCServiceListenEvent at startup; needs com.apple.developer.focus-status (DevID-gated)|FocusMonitor.swift uses NSClassFromString dispatch since #358 — keep that pattern"
+  "Intents.framework|preflights kTCCServiceListenEvent at startup; FocusMonitor.swift uses NSClassFromString dispatch — keep that pattern until #357 restores static import|do not add import Intents statically until #357"
 )
 
 violations=0
@@ -468,29 +469,13 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
    the full template below verbatim, substituting only `$NEW_VERSION` and
    the build number.
 
-   **Coupling rule (counterintuitive — read this before changing the
-   template):** the relationship between `Irrlicht.entitlements`, the
-   Info.plist `NS*UsageDescription` keys, and the linked frameworks is
-   *inverted* for ad-hoc-signed builds.
-
-   - **Apple-restricted entitlements** (e.g. `com.apple.developer.focus-status`)
-     cannot be claimed by an ad-hoc-signed binary — AMFI rejects the
-     bundle at launch with `launchd POSIX 153` / "Launchd job spawn
-     failed" (v0.4.3 crash, fixed in #356).
-   - **`NS*UsageDescription` keys for those entitlements** can still
-     trigger a TCC SIGABRT if the matching framework is *statically
-     linked* — TCC preflights `kTCCServiceListenEvent` (and similar)
-     at process startup whenever it sees the framework, regardless of
-     whether any API is actually called. **`NSFocusStatusUsageDescription`
-     in particular crashes ad-hoc-signed builds that link
-     `Intents.framework`** (v0.4.3 crash, fixed in #358).
-   - **The fix is structural, not declarative.** Source code must not
-     statically link those frameworks on ad-hoc builds. `FocusMonitor.swift`
-     uses a Developer-ID-signature runtime gate + `NSClassFromString`
-     dispatch for exactly this reason (#357 tracks the eventual
-     restoration of the static path once Developer ID lands).
-
-   For the Info.plist template below, the practical consequences are:
+   **Coupling rule:** the build now uses Developer ID signing with the
+   entitlements file, so `com.apple.developer.focus-status` is properly
+   claimed. `FocusMonitor.swift` detects the Developer ID signature at
+   runtime and loads `INFocusStatusCenter` via `NSClassFromString` —
+   no static `Intents.framework` link. (#357 tracks the eventual cleanup
+   to static `import Intents` once we confirm the dynamic gate is no
+   longer needed.)
 
    | Key | Include for ad-hoc? | Include for DevID (current)? |
    |---|---|---|
@@ -539,18 +524,38 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
    </plist>
    ```
 
-7. Developer-ID code sign with hardened runtime and entitlements.
+7. **Sign with Developer ID, then notarize and staple the DMG.**
+
+   One-time credential setup (skip if already done):
+   ```bash
+   xcrun notarytool store-credentials irrlicht-notarytool \
+       --apple-id <your@apple.id> --team-id 93Y3GMJAMV
+   ```
+
+   Sign and verify:
    ```bash
    DEVID="Developer ID Application: Ingo Eichhorst (93Y3GMJAMV)"
    ENTITLEMENTS="$(pwd)/platforms/macos/Irrlicht/Resources/Irrlicht.entitlements"
-   codesign --force --deep --sign "$DEVID" --options runtime --timestamp \
-     "$APP_STAGING/Contents/MacOS/irrlichd"
+
    codesign --force --sign "$DEVID" --options runtime --timestamp \
-     --entitlements "$ENTITLEMENTS" "$APP_STAGING"
+       "$APP_STAGING/Contents/MacOS/irrlichd"
+   codesign --force --sign "$DEVID" --options runtime --timestamp \
+       "$APP_STAGING/Contents/MacOS/irrlicht-focus"
+   codesign --force --sign "$DEVID" --options runtime --timestamp \
+       --entitlements "$ENTITLEMENTS" "$APP_STAGING"
    codesign --verify --deep --strict "$APP_STAGING"
    codesign -d --entitlements - "$APP_STAGING" 2>&1 | grep -q 'com.apple.developer.focus-status' \
      && echo "OK: focus-status entitlement present" \
      || { echo "FAIL: focus-status entitlement missing"; exit 1; }
+   ```
+
+   Notarize and staple the DMG after packaging (step 9):
+   ```bash
+   xcrun notarytool submit /tmp/Irrlicht-${NEW_VERSION}.dmg \
+       --keychain-profile irrlicht-notarytool --wait
+   xcrun stapler staple /tmp/Irrlicht-${NEW_VERSION}.dmg
+   xcrun stapler validate /tmp/Irrlicht-${NEW_VERSION}.dmg
+   spctl -a -t open --context context:primary-signature -v /tmp/Irrlicht-${NEW_VERSION}.dmg
    ```
 8. **Smoke test before packaging** — launch the built app, wait ~2s, confirm
    the process is still alive, has spawned `irrlichd`, and that the daemon
@@ -628,9 +633,10 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
       the API or framework the preflight checked.
    3. Compare `codesign -d --entitlements -` output against the prior
       release. The DevID-signed binary should carry exactly
-      `com.apple.developer.focus-status` (plus `get-task-allow` in dev
-      builds). Extra or missing entitlements vs. `Irrlicht.entitlements`
-      indicate a codesign step error — fix and re-sign before shipping.
+      `com.apple.developer.focus-status`. Extra or missing entitlements
+      vs. `Irrlicht.entitlements` indicate a codesign step error — fix
+      and re-sign before shipping (v0.4.3 mode: AMFI kills mismatched
+      entitlements with POSIX 153, fixed in #356).
    4. If steps 1–3 all clear, copy the bundle to `/Applications/` (kill
       the prior install first) and retry. A real shipping defect will
       crash from both paths; an environment-only failure will only crash
@@ -657,7 +663,7 @@ pkgbuild --root "$APP_STAGING" --identifier io.irrlicht.app --version $NEW_VERSI
 
 ### ZIP archive (for curl installer)
 Used by `https://irrlicht.io/install.sh`. Must be created with `ditto` so
-macOS metadata (including the ad-hoc code signature) is preserved.
+macOS metadata (including the code signature) is preserved.
 
 ```bash
 ditto -c -k --sequesterRsrc --keepParent "$APP_STAGING" /tmp/Irrlicht-$NEW_VERSION.zip

--- a/platforms/macos/Irrlicht/Resources/Irrlicht.entitlements
+++ b/platforms/macos/Irrlicht/Resources/Irrlicht.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.get-task-allow</key>
-    <true/>
     <key>com.apple.developer.focus-status</key>
     <true/>
 </dict>

--- a/site/install.sh
+++ b/site/install.sh
@@ -237,10 +237,6 @@ step "Installing to /Applications"
 ditto -xk "$TMPDIR/$ASSET" /Applications/ || fail "Extract failed"
 ok
 
-step "Stripping quarantine attribute"
-xattr -dr com.apple.quarantine /Applications/Irrlicht.app 2>/dev/null || true
-ok
-
 step "Registering with LaunchServices"
 "/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister" \
     -f /Applications/Irrlicht.app 2>/dev/null || true

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -152,6 +152,30 @@ PLIST
 
 echo "  Created $APP_BUNDLE"
 
+# ── 3b. Sign app bundle ────────────────────────────────────────────────
+echo ""
+ENTITLEMENTS="platforms/macos/Irrlicht/Resources/Irrlicht.entitlements"
+if [ -n "${DEVELOPER_ID:-}" ]; then
+    echo "Signing app bundle with Developer ID..."
+    SIGN_IDENTITY="Developer ID Application: ${DEVELOPER_ID}"
+    codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
+        "$APP_CONTENTS/MacOS/${DAEMON_NAME}"
+    codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
+        "$APP_CONTENTS/MacOS/irrlicht-focus"
+    codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
+        --entitlements "$ENTITLEMENTS" "$APP_BUNDLE"
+    codesign --verify --deep --strict "$APP_BUNDLE"
+    codesign -d --entitlements - "$APP_BUNDLE" 2>&1 | grep -q "focus-status" \
+        || { echo "ERROR: focus-status entitlement not present in signed bundle"; exit 1; }
+    echo "  Signed $APP_BUNDLE (Developer ID)"
+else
+    echo "Signing app bundle (ad-hoc — set DEVELOPER_ID to use Developer ID cert)..."
+    codesign --force --deep --sign - "$APP_CONTENTS/MacOS/${DAEMON_NAME}"
+    codesign --force --deep --sign - "$APP_BUNDLE"
+    codesign --verify --deep --strict "$APP_BUNDLE"
+    echo "  Ad-hoc signed $APP_BUNDLE"
+fi
+
 # ── 4. Create DMG (primary distribution) ──────────────────────────────
 echo ""
 echo "Creating DMG..."
@@ -170,6 +194,23 @@ hdiutil create -volname "Irrlicht $VERSION" \
 
 rm -rf "$DMG_STAGING"
 echo "  Created $BUILD_DIR/$DMG_NAME"
+
+# ── 4b. Notarize and staple DMG ────────────────────────────────────────
+if [ -n "${NOTARYTOOL_KEYCHAIN_PROFILE:-}" ]; then
+    echo ""
+    echo "Notarizing DMG..."
+    xcrun notarytool submit "$BUILD_DIR/$DMG_NAME" \
+        --keychain-profile "${NOTARYTOOL_KEYCHAIN_PROFILE}" \
+        --wait
+    echo "  Stapling notarization ticket..."
+    xcrun stapler staple "$BUILD_DIR/$DMG_NAME"
+    xcrun stapler validate "$BUILD_DIR/$DMG_NAME"
+    echo "  Notarized and stapled $DMG_NAME"
+elif [ -n "${DEVELOPER_ID:-}" ]; then
+    echo ""
+    echo "NOTE: DEVELOPER_ID is set but NOTARYTOOL_KEYCHAIN_PROFILE is not — skipping notarization."
+    echo "      Create a profile with: xcrun notarytool store-credentials <profile>"
+fi
 
 # ── 5. Create LaunchAgent plist (optional, for power users) ──────────
 echo ""

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -207,9 +207,10 @@ if [ -n "${NOTARYTOOL_KEYCHAIN_PROFILE:-}" ]; then
     xcrun stapler validate "$BUILD_DIR/$DMG_NAME"
     echo "  Notarized and stapled $DMG_NAME"
 elif [ -n "${DEVELOPER_ID:-}" ]; then
-    echo ""
-    echo "NOTE: DEVELOPER_ID is set but NOTARYTOOL_KEYCHAIN_PROFILE is not — skipping notarization."
-    echo "      Create a profile with: xcrun notarytool store-credentials <profile>"
+    echo "ERROR: DEVELOPER_ID is set but NOTARYTOOL_KEYCHAIN_PROFILE is not."
+    echo "       A Developer ID-signed DMG must be notarized — without it Gatekeeper blocks launch."
+    echo "       Create a profile first: xcrun notarytool store-credentials <profile>"
+    exit 1
 fi
 
 # ── 5. Create LaunchAgent plist (optional, for power users) ──────────

--- a/tools/homebrew-tap/Casks/irrlicht.rb
+++ b/tools/homebrew-tap/Casks/irrlicht.rb
@@ -17,15 +17,6 @@ cask "irrlicht" do
 
   app "Irrlicht.app"
 
-  # The DMG is ad-hoc signed but not Apple-notarized. Strip the quarantine
-  # attribute so Gatekeeper won't block first launch. Remove this once the
-  # release flow notarizes (issue #187 follow-up).
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Irrlicht.app"],
-                   sudo: false
-  end
-
   # The cask install path doesn't register a LaunchAgent — the menu-bar app
   # spawns the embedded daemon itself. Power users who installed the
   # optional plist by hand can rm it themselves.


### PR DESCRIPTION
Closes #233.

## Summary

- **`tools/build-release.sh`**: sign app bundle with Developer ID + hardened runtime + entitlements when `DEVELOPER_ID` env var is set (falls back to ad-hoc for dev builds without a cert); notarize + staple DMG when `NOTARYTOOL_KEYCHAIN_PROFILE` is also set
- **`platforms/macos/Irrlicht/Resources/Irrlicht.entitlements`**: remove `get-task-allow: true` — notarization rejects binaries with this debug entitlement; release builds only need `focus-status`
- **`tools/homebrew-tap/Casks/irrlicht.rb`**: drop `postflight` quarantine-strip block — no longer needed once the DMG is notarized
- **`site/install.sh`**: drop "Stripping quarantine attribute" step for the same reason
- **`.claude/skills/ir:release/skill.md`**: step 7 → Developer ID signing + notarize/staple instructions; add `NSFocusStatusUsageDescription` to Info.plist template (safe because `FocusMonitor.swift` uses `NSClassFromString` dispatch, not a static `Intents.framework` link); canary check now asserts `focus-status` entitlement IS present

## Usage (once Apple Developer prereqs are in place)

```bash
# One-time credential setup
xcrun notarytool store-credentials irrlicht-notarytool \
    --apple-id <your@apple.id> --team-id <TEAMID>

# Full signed + notarized build
DEVELOPER_ID="Your Name (TEAMID)" \
NOTARYTOOL_KEYCHAIN_PROFILE="irrlicht-notarytool" \
tools/build-release.sh
```

## Blocked on (maintainer actions before this can be tested end-to-end)

- Apple Developer Program enrollment
- Developer ID Application certificate installed in keychain
- `xcrun notarytool store-credentials irrlicht-notarytool` configured

## Test plan

- [ ] `DEVELOPER_ID="..." NOTARYTOOL_KEYCHAIN_PROFILE="irrlicht-notarytool" tools/build-release.sh` produces a signed + notarized + stapled DMG
- [ ] `spctl -a -t open --context context:primary-signature -v Irrlicht-$VERSION.dmg` returns "accepted"
- [ ] `xcrun stapler validate Irrlicht-$VERSION.dmg` passes
- [ ] `brew install --cask irrlicht` on a clean Mac launches without Gatekeeper warning (no postflight needed)
- [ ] `curl -fsSL https://irrlicht.io/install.sh | bash` installs without quarantine warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)