### PR TITLE
fix(opencode): eliminate ~2.5s working→ready tail latency (#278)

### DIFF
--- a/core/adapters/inbound/agents/opencode/parser.go
+++ b/core/adapters/inbound/agents/opencode/parser.go
@@ -148,6 +148,9 @@ func parseStepFinish(raw map[string]interface{}, ev *tailer.ParsedEvent) *tailer
 	case "error":
 		// API or other error — the agent stopped generating.
 		ev.EventType = "turn_done"
+	case "content-filter":
+		// Model output was filtered — generation is definitively done.
+		ev.EventType = "turn_done"
 	default:
 		// Unknown reason — conservatively treat as assistant_message.
 		ev.EventType = "assistant_message"

--- a/core/adapters/inbound/agents/opencode/watcher.go
+++ b/core/adapters/inbound/agents/opencode/watcher.go
@@ -3,6 +3,7 @@ package opencode
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -419,6 +420,24 @@ func (w *Watcher) emitRemovedForArchivedSessions(db *sql.DB) {
 	}
 }
 
+// isTerminalPart reports whether a part JSON blob is a step-finish with a
+// turn-ending reason (stop / interrupted / length / error). Returns false for
+// tool-calls pauses or any parse failure — fail-open.
+func isTerminalPart(data string) bool {
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(data), &raw); err != nil {
+		return false
+	}
+	if t, _ := raw["type"].(string); t != "step-finish" {
+		return false
+	}
+	switch reason, _ := raw["reason"].(string); reason {
+	case "stop", "interrupted", "length", "error":
+		return true
+	}
+	return false
+}
+
 // scanParts queries new/updated part rows for a session since lastCursor and
 // emits EventActivity events. Updates the cursor on success.
 //
@@ -449,6 +468,7 @@ func (w *Watcher) scanParts(db *sql.DB, sessionID, directory string, cur *sessio
 
 	var maxSeen int64
 	hasActivity := false
+	hasTerminal := false
 	newSeenIDs := make(map[string]struct{})
 
 	for rows.Next() {
@@ -472,7 +492,9 @@ func (w *Watcher) scanParts(db *sql.DB, sessionID, directory string, cur *sessio
 			newSeenIDs[partID] = struct{}{}
 		}
 		hasActivity = true
-		_ = partData // activity signalled via EventActivity; parsing in metrics collector
+		if isTerminalPart(partData) {
+			hasTerminal = true
+		}
 		_ = msgData
 	}
 
@@ -493,6 +515,7 @@ func (w *Watcher) scanParts(db *sql.DB, sessionID, directory string, cur *sessio
 			ProjectDir:     filepath.Base(directory),
 			TranscriptPath: w.dbPath + "-wal" + "?session=" + sessionID,
 			CWD:            directory,
+			Terminal:       hasTerminal,
 		})
 	}
 }

--- a/core/adapters/inbound/agents/opencode/watcher.go
+++ b/core/adapters/inbound/agents/opencode/watcher.go
@@ -432,7 +432,7 @@ func isTerminalPart(data string) bool {
 		return false
 	}
 	switch reason, _ := raw["reason"].(string); reason {
-	case "stop", "interrupted", "length", "error":
+	case "stop", "interrupted", "length", "error", "content-filter":
 		return true
 	}
 	return false
@@ -492,7 +492,7 @@ func (w *Watcher) scanParts(db *sql.DB, sessionID, directory string, cur *sessio
 			newSeenIDs[partID] = struct{}{}
 		}
 		hasActivity = true
-		if isTerminalPart(partData) {
+		if !hasTerminal && isTerminalPart(partData) {
 			hasTerminal = true
 		}
 		_ = msgData

--- a/core/adapters/inbound/agents/opencode/watcher_test.go
+++ b/core/adapters/inbound/agents/opencode/watcher_test.go
@@ -571,3 +571,29 @@ func drainEvents(ch <-chan agent.Event) {
 		}
 	}
 }
+
+func TestIsTerminalPart(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{"stop", `{"type":"step-finish","reason":"stop"}`, true},
+		{"interrupted", `{"type":"step-finish","reason":"interrupted"}`, true},
+		{"length", `{"type":"step-finish","reason":"length"}`, true},
+		{"error", `{"type":"step-finish","reason":"error"}`, true},
+		{"content-filter", `{"type":"step-finish","reason":"content-filter"}`, true},
+		{"tool-calls", `{"type":"step-finish","reason":"tool-calls"}`, false},
+		{"unknown-reason", `{"type":"step-finish","reason":"unknown"}`, false},
+		{"not-step-finish", `{"type":"text","text":"hello"}`, false},
+		{"malformed-json", `{not valid json`, false},
+		{"empty", `{}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTerminalPart(tc.data); got != tc.want {
+				t.Errorf("isTerminalPart(%q) = %v, want %v", tc.data, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/application/services/debounce_test.go
+++ b/core/application/services/debounce_test.go
@@ -243,3 +243,52 @@ func TestDebounce_TerminalEventShortCircuits(t *testing.T) {
 	cancel()
 	<-done
 }
+
+func TestDebounce_FirstEventTerminalFiresImmediately(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	repo.Save(&session.SessionState{
+		SessionID:      "term2",
+		State:          session.StateWorking,
+		TranscriptPath: "/home/.claude/projects/-Users-test/term2.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     1,
+	})
+
+	savesBefore := repo.saves
+
+	// First event for the session is already terminal — should fire immediately
+	// via the leading-edge path (no prior debounce entry).
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "term2",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: "/home/.claude/projects/-Users-test/term2.jsonl",
+		Terminal:       true,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	repo.mu.Lock()
+	savesAfter := repo.saves
+	repo.mu.Unlock()
+
+	if savesAfter <= savesBefore {
+		t.Errorf("first terminal event should fire immediately: saves before=%d after=%d", savesBefore, savesAfter)
+	}
+
+	cancel()
+	<-done
+}

--- a/core/application/services/debounce_test.go
+++ b/core/application/services/debounce_test.go
@@ -183,3 +183,63 @@ func TestDebounce_RemovedCleansUpTimer(t *testing.T) {
 	cancel()
 	<-done
 }
+
+func TestDebounce_TerminalEventShortCircuits(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	repo.Save(&session.SessionState{
+		SessionID:      "term1",
+		State:          session.StateWorking,
+		TranscriptPath: "/home/.claude/projects/-Users-test/term1.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     1,
+	})
+
+	// First non-terminal event — fires immediately (leading edge) and starts the 2s timer.
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "term1",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: "/home/.claude/projects/-Users-test/term1.jsonl",
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	repo.mu.Lock()
+	savesAfterFirst := repo.saves
+	repo.mu.Unlock()
+
+	// Terminal event mid-window — should fire immediately, not after 2s.
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "term1",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: "/home/.claude/projects/-Users-test/term1.jsonl",
+		Terminal:       true,
+	}
+
+	// Wait well under the 2s debounce window.
+	time.Sleep(100 * time.Millisecond)
+
+	repo.mu.Lock()
+	savesAfterTerminal := repo.saves
+	repo.mu.Unlock()
+
+	if savesAfterTerminal <= savesAfterFirst {
+		t.Errorf("terminal event should trigger processActivity immediately: saves before=%d after=%d", savesAfterFirst, savesAfterTerminal)
+	}
+
+	cancel()
+	<-done
+}

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -217,7 +217,17 @@ func (d *SessionDetector) onActivity(id agent.Identity, ev agent.Event) {
 		return
 	}
 
-	// Subsequent event within the debounce window — coalesce.
+	// Subsequent event within the debounce window.
+	if ev.Terminal {
+		// Turn-end signal: short-circuit the debounce, fire immediately.
+		entry.timer.Stop()
+		delete(d.debounce, sid)
+		d.debounceMu.Unlock()
+		d.processActivity(id, ev)
+		return
+	}
+
+	// Coalesce.
 	entry.latest = ev
 	entry.pending = true
 	entry.timer.Reset(activityDebounceWindow)

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -223,6 +223,7 @@ func (d *SessionDetector) onActivity(id agent.Identity, ev agent.Event) {
 		entry.timer.Stop()
 		delete(d.debounce, sid)
 		d.debounceMu.Unlock()
+		d.record(lifecycle.Event{Kind: lifecycle.KindDebounceTerminal, SessionID: ev.SessionID})
 		d.processActivity(id, ev)
 		return
 	}

--- a/core/cmd/replay/replay_transcript.go
+++ b/core/cmd/replay/replay_transcript.go
@@ -242,6 +242,9 @@ func loadEvents(path string) ([]rawEvent, error) {
 				} else if parsed, err := time.Parse("2006-01-02T15:04:05.000Z", v); err == nil {
 					ts = parsed
 				}
+			} else if v, ok := raw["_ts"].(float64); ok && v > 0 {
+				// OpenCode transcripts carry _ts as Unix milliseconds.
+				ts = time.UnixMilli(int64(v)).UTC()
 			}
 		}
 

--- a/core/domain/agent/event.go
+++ b/core/domain/agent/event.go
@@ -25,4 +25,5 @@ type Event struct {
 	Size            int64  // Current file size in bytes (0 for removals)
 	CWD             string // Working directory of the agent process (set by process scanner)
 	ParentSessionID string // Parent session ID for subagent sessions (empty for top-level)
+	Terminal        bool   // true when this activity event ends the agent's turn (fast-path debounce)
 }

--- a/core/domain/lifecycle/event.go
+++ b/core/domain/lifecycle/event.go
@@ -33,6 +33,8 @@ const (
 
 	// Debounce: records coalescing for faithful replay.
 	KindDebounceCoalesced Kind = "debounce_coalesced"
+	// Terminal event bypassed the debounce window entirely.
+	KindDebounceTerminal Kind = "debounce_terminal"
 
 	// Agent hooks (future: issue #108).
 	KindHookReceived Kind = "hook_received"

--- a/replaydata/agents/opencode/regression/fast-ready/transcript.jsonl
+++ b/replaydata/agents/opencode/regression/fast-ready/transcript.jsonl
@@ -1,0 +1,4 @@
+{"type":"text","text":"What is 2+2?","_role":"user","_cwd":"/Users/test/myproject","_ts":1700000000000}
+{"type":"step-start","snapshot":"abc123","_role":"assistant","_cwd":"/Users/test/myproject","_ts":1700000000100}
+{"type":"text","text":"4","_role":"assistant","_cwd":"/Users/test/myproject","_ts":1700000000500}
+{"type":"step-finish","reason":"stop","tokens":{"input":100,"output":5,"reasoning":0,"total":105,"cache":{"read":0,"write":0}},"cost":0.001,"_model":"claude-sonnet-4-5","_role":"assistant","_cwd":"/Users/test/myproject","_ts":1700000003000}

--- a/replaydata/agents/opencode/regression/fast-ready/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/opencode/regression/fast-ready/transcript.jsonl.replay.json.golden
@@ -11,23 +11,28 @@
     "total_events": 4,
     "consumed_events": 4,
     "total_transitions": 3,
-    "first_event_time": "2025-04-26T09:49:00.296Z",
-    "last_event_time": "2025-04-26T09:49:01.961Z",
-    "wall_clock_session_duration": 1665000000,
+    "first_event_time": "2023-11-14T22:13:20Z",
+    "last_event_time": "2023-11-14T22:13:23Z",
+    "wall_clock_session_duration": 3000000000,
     "state_durations": {
-      "ready": 1665000000
+      "ready": 500000000,
+      "working": 2500000000
     },
-    "flicker_count": 0,
-    "flickers_by_category": {},
-    "flickers_by_reason": {},
-    "estimated_cost_usd": 0.012345,
+    "flicker_count": 1,
+    "flickers_by_category": {
+      "working_between_ready": 1
+    },
+    "flickers_by_reason": {
+      "force ready→working on first activity": 1
+    },
+    "estimated_cost_usd": 0.001,
     "model_name": "claude-sonnet-4-5"
   },
   "transitions": [
     {
       "index": 0,
       "event_index": -1,
-      "virtual_time": "2025-04-26T09:49:00.296Z",
+      "virtual_time": "2023-11-14T22:13:20Z",
       "cause": "init",
       "prev_state": "",
       "new_state": "ready",
@@ -40,24 +45,24 @@
     },
     {
       "index": 1,
-      "event_index": 3,
-      "virtual_time": "2025-04-26T09:49:01.961Z",
+      "event_index": 2,
+      "virtual_time": "2023-11-14T22:13:20.5Z",
       "cause": "debounce_coalesce",
       "prev_state": "ready",
       "new_state": "working",
       "reason": "force ready→working on first activity",
-      "last_event_type": "turn_done",
+      "last_event_type": "assistant_message",
       "has_open_tool": false,
-      "is_agent_done": true,
+      "is_agent_done": false,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "ok"
+      "last_assistant_text_head": "4"
     },
     {
       "index": 2,
       "event_index": 3,
-      "virtual_time": "2025-04-26T09:49:01.961Z",
-      "cause": "debounce_coalesce",
+      "virtual_time": "2023-11-14T22:13:23Z",
+      "cause": "event",
       "prev_state": "working",
       "new_state": "ready",
       "reason": "agent finished turn → ready",
@@ -66,7 +71,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "ok"
+      "last_assistant_text_head": "4"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `Terminal bool` to `agent.Event`; OpenCode watcher sets it when a `step-finish` with a terminal reason (`stop/interrupted/length/error`) is found in the scanned parts
- Session detector `onActivity` short-circuits the 2s debounce window immediately on `Terminal == true`, instead of waiting 2s after the last part write
- Teaches the replay's `loadEvents` to parse OpenCode's `_ts` (Unix ms) timestamps so scenarios get real virtual times; adds `fast-ready` fixture to pin that `working → ready` lands with `cause=event` (not `debounce_coalesce`) when step-finish is in its own replay batch

## Test plan

- [ ] `go test ./core/... -race -count=1` — all pass, including new `TestDebounce_TerminalEventShortCircuits`
- [ ] `tools/replay-fixtures.sh` — no new failures; `baseline-hello` golden updated with real timestamps; `fast-ready` golden added
- [ ] Manual: after `ir:test-mac`, typing a prompt in OpenCode shows `working → ready` within ~500ms of turn end (down from ~2.5s)

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)