### PR TITLE
feat(web): port provider quota chip from macOS overlay

### DIFF
--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -153,6 +153,123 @@
     .app-title .app-version { font-weight: 400; color: var(--muted); font-variant-numeric: tabular-nums; }
     .app-title .app-sep { color: var(--muted); padding: 0 2px; }
 
+    /* Quota chips — provider-scoped rate-limit display that REPLACES the
+       app-title strip when one or more sessions carry a rate_limit snapshot.
+       Ports the macOS overlay's quotaChipView (SessionListView.swift:600) so
+       opening the popover and the web dashboard side-by-side shows identical
+       state for the same session list. */
+    .quota-chips {
+      display: none;
+      align-items: flex-start;
+      gap: 10px;
+      font-family: var(--font-mono);
+    }
+    header.has-quota-chips .app-title { display: none; }
+    header.has-quota-chips .quota-chips { display: flex; }
+
+    .quota-chip {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 1px 0;
+    }
+    .quota-chip-icon {
+      display: inline-flex;
+      width: 14px;
+      height: 14px;
+      flex-shrink: 0;
+      color: var(--text-bright);
+    }
+    .quota-chip-icon svg,
+    .quota-chip-icon img { width: 14px; height: 14px; display: block; }
+    .quota-chip-body {
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+      min-width: 88px;
+    }
+    .quota-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      height: 11px;
+    }
+    .quota-row-label {
+      font-size: 9px;
+      font-weight: 500;
+      color: var(--muted);
+      width: 14px;
+      text-align: left;
+    }
+    .quota-bar {
+      position: relative;
+      height: 5px;
+      width: 60px;
+      border-radius: 2.5px;
+      background: var(--ctx-bar-track);
+      overflow: hidden;
+      flex-shrink: 0;
+    }
+    /* Single visible chip gets a slightly wider bar (matches macOS compact
+       vs. non-compact width: 60 vs 70). */
+    .quota-chips--single .quota-bar { width: 70px; }
+    .quota-bar-fill {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      border-radius: 2.5px;
+    }
+    .quota-bar-fill--green  { background: var(--pressure-low); }
+    .quota-bar-fill--yellow { background: #FFCC00; }
+    .quota-bar-fill--orange { background: var(--pressure-medium); }
+    /* Pace marker — thin red vertical bar at "where you should be if pacing
+       evenly through the window." Red is reserved for the marker so the
+       fill ramp (green→yellow→orange) doesn't visually blend with it. */
+    .quota-bar-pace {
+      position: absolute;
+      top: 0;
+      width: 1px;
+      height: 100%;
+      background: var(--pressure-high);
+    }
+    .quota-row-percent {
+      font-size: 9px;
+      font-weight: 500;
+      color: var(--text-bright);
+      font-variant-numeric: tabular-nums;
+      min-width: 28px;
+      text-align: right;
+    }
+    .quota-row-reset {
+      font-size: 9px;
+      color: var(--muted);
+      white-space: nowrap;
+    }
+    .quota-usage-headline {
+      font-size: 10px;
+      font-weight: 600;
+      color: var(--text-bright);
+      font-variant-numeric: tabular-nums;
+    }
+    .quota-usage-sublabel {
+      font-size: 9px;
+      color: var(--muted);
+    }
+    .quota-overflow {
+      display: inline-flex;
+      align-items: center;
+      align-self: center;
+      font-size: 10px;
+      font-weight: 500;
+      color: var(--muted);
+      padding: 2px 6px;
+      border-radius: 4px;
+      background: var(--surface-hover);
+      cursor: default;
+    }
+    .quota-stale { opacity: 0.5; }
+
     /* Aggregated state icons — up to 3 per-session glyphs colored by state,
        or "N sessions" text when there are more. Mirrors `sessionIconsView` in
        SessionListView.swift:346. */
@@ -849,6 +966,11 @@
       main { padding: 8px 10px; }
       .row-cost { display: none; }
       .app-state-icons { display: none; }
+      /* Two quota chips at ~108px each + gap + right-side header buttons
+         overflow narrow viewports. Mirror the .app-state-icons rule above:
+         hide the chip strip and restore the version title underneath. */
+      header.has-quota-chips .quota-chips { display: none; }
+      header.has-quota-chips .app-title { display: flex; }
     }
 
     @media (max-width: 360px) {
@@ -992,6 +1114,49 @@
       cursor: pointer;
     }
     .settings-modal .settings-modal-close:hover { border-color: var(--working); color: var(--text-bright); }
+
+    /* Provider quota — per-provider mode selectors. Auto-populates the
+       observed-provider list (Anthropic / OpenAI / ...) whenever the
+       settings modal opens. Mirrors macOS Settings → Providers. */
+    .settings-modal .provider-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 6px 4px;
+      border-radius: 4px;
+      font-size: 12px;
+      color: var(--text);
+    }
+    .settings-modal .provider-row:hover { background: var(--surface-hover); }
+    .settings-modal .provider-row .provider-name {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--text-bright);
+    }
+    .settings-modal .provider-row .provider-name svg,
+    .settings-modal .provider-row .provider-name img {
+      width: 14px;
+      height: 14px;
+      color: var(--text-bright);
+      display: block;
+    }
+    .settings-modal .provider-row select {
+      background: var(--surface);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      padding: 3px 6px;
+      cursor: pointer;
+    }
+    .settings-modal .provider-empty {
+      font-size: 11px;
+      color: var(--muted);
+      padding: 4px 4px 0;
+    }
   </style>
 </head>
 <body>
@@ -1002,6 +1167,7 @@
         <span class="app-version" id="app-version"></span>
         <span class="app-sep">—</span>
       </div>
+      <div class="quota-chips" id="quota-chips" aria-label="Provider quota"></div>
       <div class="app-state-icons" id="app-state-icons" aria-label="Active sessions"></div>
     </div>
     <div class="header-right">
@@ -1035,6 +1201,16 @@
           <span class="settings-hint">Show session IDs and elapsed time in each row.</span>
         </span>
       </label>
+
+      <h2>Provider quota</h2>
+      <label>
+        <input type="checkbox" data-quota-setting="showQuotaForecast">
+        <span class="settings-label-text">
+          <span class="settings-title">Show quota forecast in header</span>
+          <span class="settings-hint">Replace the version line with provider 5h/7d bars when rate-limit data is available.</span>
+        </span>
+      </label>
+      <div id="settings-providers"></div>
 
       <h2>Notifications</h2>
       <label>
@@ -2129,6 +2305,7 @@
         collectAll(g.agents);
       }
       updateSummary(all, topLevel);
+      renderHeaderTitle();
     }
 
     function createAlertRow(pressure) {
@@ -2256,6 +2433,12 @@
     }
     setInterval(tickElapsed, 1000);
 
+    // Re-paint the quota chip strip every 30s so the pace marker, "resets
+    // in …" labels, and forecast ETA tick forward even when no session
+    // update arrives. Same cadence as the trailing-window cost re-hydrate
+    // below — well under the 5-minute window-rollover horizon.
+    setInterval(renderHeaderTitle, 30000);
+
     // --- Per-row history bar ---
     // The overlay shows history only as per-row mini-bars (no global heatmap).
     // We mirror that here; the daemon's bucket priorities drive the per-row
@@ -2332,20 +2515,50 @@
     // carry individual session updates. We only copy the `costs` field —
     // replacing the whole array would shuffle WS-added sessions back into
     // the daemon's UUID order, which is the position-jump the user flagged.
+    //
+    // We additionally merge per-agent `metrics.rate_limit` and
+    // `metrics.rate_limit_forecast_eta` for any agent already in our state.
+    // The quota chip strip would otherwise stay pinned to the last value
+    // a WS message left in place during a WS disconnect.
     setInterval(() => {
       fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
         if (!resp) return;
         const fresh = Array.isArray(resp) ? resp : (resp.groups || []);
         const byName = new Map();
         for (const g of fresh) if (g && g.name) byName.set(g.name, g);
+        const freshAgents = new Map();
+        (function indexAgents(arr) {
+          for (const a of arr || []) {
+            if (a && a.session_id) freshAgents.set(a.session_id, a);
+            if (a && a.children) indexAgents(a.children);
+          }
+        })(fresh.flatMap(g => g.agents || []));
         let changed = false;
         for (const g of dashboardGroups) {
           const f = byName.get(g.name);
-          if (!f || !f.costs) continue;
-          if (JSON.stringify(g.costs) !== JSON.stringify(f.costs)) {
+          if (f && f.costs && JSON.stringify(g.costs) !== JSON.stringify(f.costs)) {
             g.costs = f.costs;
             changed = true;
           }
+          (function mergeRateLimit(arr) {
+            for (const a of arr || []) {
+              const fa = freshAgents.get(a.session_id);
+              if (fa && fa.metrics) {
+                if (!a.metrics) a.metrics = {};
+                const newRL = fa.metrics.rate_limit || null;
+                const newETA = fa.metrics.rate_limit_forecast_eta || null;
+                if (JSON.stringify(a.metrics.rate_limit || null) !== JSON.stringify(newRL)) {
+                  a.metrics.rate_limit = newRL;
+                  changed = true;
+                }
+                if ((a.metrics.rate_limit_forecast_eta || null) !== newETA) {
+                  a.metrics.rate_limit_forecast_eta = newETA;
+                  changed = true;
+                }
+              }
+              if (a.children) mergeRateLimit(a.children);
+            }
+          })(g.agents);
         }
         if (changed) render();
       });
@@ -2451,6 +2664,470 @@
       repaintHistory();
     }
 
+    // --- Provider quota chips ---
+    // Port of the macOS overlay's quotaChipView (SessionListView.swift:378-900)
+    // and ProviderModePreference (SessionState.swift:190-262). Bucketing,
+    // mode resolution, bar coloring, and tooltip text mirror the Swift
+    // sources so opening the popover and the dashboard side-by-side shows
+    // identical state for the same `/api/v1/sessions` response.
+
+    // localStorage keys are unprefixed to match macOS @AppStorage names —
+    // not because the storages are shared (UserDefaults and localStorage
+    // are not), but so the same documentation, screenshots, and mental
+    // model apply to both surfaces.
+    const QUOTA_FORECAST_KEY = 'showQuotaForecast';
+
+    function showQuotaForecast() {
+      // Default ON, mirroring macOS @AppStorage("showQuotaForecast") default.
+      const v = localStorage.getItem(QUOTA_FORECAST_KEY);
+      if (v === '0' || v === 'false') return false;
+      return true;
+    }
+    function setShowQuotaForecast(on) {
+      // Safari Private mode and storage-disabled contexts throw on
+      // setItem — swallow per the project pattern (see persistCollapsedGroups
+      // at line ~1099 and the settings save loop).
+      try { localStorage.setItem(QUOTA_FORECAST_KEY, on ? '1' : '0'); } catch (e) {}
+    }
+
+    // Provider-icon registry. SVGs are byte-for-byte copies of
+    // ProviderIconRegistry.anthropicSVG / openaiSVG in Swift so both
+    // surfaces ship the same mark.
+    const PROVIDER_ICON_SVG = {
+      anthropic: '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"><path d="M14.83 4.5h-3.49l5.83 15h3.5l-5.84-15zM6.49 4.5l-5.83 15h3.57l1.19-3.13h6.09l1.2 3.13h3.57l-5.83-15H6.49zm-.05 8.98l1.99-5.2 1.99 5.2H6.44z" fill="currentColor"/></svg>',
+      openai: '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"><path d="M22.28 9.821a5.985 5.985 0 0 0-.515-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.142-.08 4.774-2.758a.795.795 0 0 0 .392-.681v-6.737l2.018 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.488 4.493zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.778 2.758a.795.795 0 0 0 .787 0l5.832-3.367v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.077.077 0 0 1-.062 0l-4.83-2.79A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.077.077 0 0 1 .062 0l4.83 2.79a4.5 4.5 0 0 1-.676 8.05v-5.678a.79.79 0 0 0-.398-.66zm2.01-3.023l-.142-.085-4.774-2.782a.776.776 0 0 0-.787 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.504 4.504 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.392.681v6.737zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" fill="currentColor"/></svg>',
+    };
+    function providerIconHTML(key) { return PROVIDER_ICON_SVG[key] || ''; }
+
+    function providerKeyFor(snap, adapter) {
+      if (!snap) return null;
+      switch (snap.plan_type) {
+        case 'max':
+        case 'pro':  return 'anthropic';
+        case 'plus': return 'openai';
+      }
+      switch (adapter) {
+        case 'claude-code': return 'anthropic';
+        case 'codex':       return 'openai';
+        default:            return null;
+      }
+    }
+
+    function planTypeLabel(planType) {
+      if (!planType) return null;
+      switch (planType) {
+        case 'max':        return 'Claude Max';
+        case 'pro':        return 'Claude Pro';
+        case 'plus':       return 'ChatGPT Plus';
+        case 'team':       return 'Team';
+        case 'enterprise': return 'Enterprise';
+        default:           return planType.charAt(0).toUpperCase() + planType.slice(1);
+      }
+    }
+
+    function providerModeStorageKey(providerKey) {
+      // Mirrors ProviderModePreference.storageKey(providerKey:) in Swift.
+      return 'providerMode_' + providerKey;
+    }
+    function providerModePreference(providerKey) {
+      const raw = localStorage.getItem(providerModeStorageKey(providerKey)) || '';
+      if (raw === 'subscription' || raw === 'usage' || raw === 'auto') return raw;
+      return 'auto';
+    }
+    function setProviderModePreference(providerKey, mode) {
+      try {
+        if (mode === 'auto') localStorage.removeItem(providerModeStorageKey(providerKey));
+        else localStorage.setItem(providerModeStorageKey(providerKey), mode);
+      } catch (e) {}
+    }
+
+    function chipModeFor(snap, providerKey) {
+      const pref = providerModePreference(providerKey);
+      if (pref === 'subscription') return 'subscription';
+      if (pref === 'usage')        return 'usage';
+      // Auto: a credits balance without a plan tier means the API-key /
+      // usage path; everything else (plan_type set or no credits) renders
+      // bars. Same rule as Swift's resolveChipMode.
+      if (snap && snap.credits && !snap.plan_type) return 'usage';
+      return 'subscription';
+    }
+
+    function imminentWindow(snap) {
+      if (!snap || !Array.isArray(snap.windows) || snap.windows.length === 0) return null;
+      let best = null;
+      for (const w of snap.windows) {
+        if (!w) continue;
+        if (!best || (w.used_percent || 0) > (best.used_percent || 0)) best = w;
+      }
+      if (!best || (best.used_percent || 0) <= 0) return null;
+      return best;
+    }
+
+    // Returns where the user *should be* in the window if pacing evenly,
+    // anchored to now (not sampled_at) — matches macOS quotaPacePercent.
+    function paceFor(w, nowMs) {
+      if (!w || !w.window_minutes || w.window_minutes <= 0) return null;
+      if (!w.resets_at || w.resets_at <= 0) return null;
+      const windowMs = w.window_minutes * 60 * 1000;
+      const startMs = w.resets_at * 1000 - windowMs;
+      const pct = ((nowMs - startMs) / windowMs) * 100;
+      return Math.min(100, Math.max(0, pct));
+    }
+
+    // Pace-aware bar color. Thresholds match QuotaBarThreshold in
+    // SessionListView.swift so the two surfaces flip color in lockstep.
+    const QUOTA_BAR_THRESHOLDS = {
+      absoluteOrange:  85,
+      paceDeltaOrange: 15,
+      paceDeltaYellow: 5,
+      fallbackOrange:  70,
+      fallbackYellow:  50,
+    };
+    function barColorClass(used, pace) {
+      if (used >= QUOTA_BAR_THRESHOLDS.absoluteOrange) return 'quota-bar-fill--orange';
+      if (pace == null) {
+        if (used >= QUOTA_BAR_THRESHOLDS.fallbackOrange) return 'quota-bar-fill--orange';
+        if (used >= QUOTA_BAR_THRESHOLDS.fallbackYellow) return 'quota-bar-fill--yellow';
+        return 'quota-bar-fill--green';
+      }
+      const delta = used - pace;
+      if (delta >= QUOTA_BAR_THRESHOLDS.paceDeltaOrange) return 'quota-bar-fill--orange';
+      if (delta >= QUOTA_BAR_THRESHOLDS.paceDeltaYellow) return 'quota-bar-fill--yellow';
+      return 'quota-bar-fill--green';
+    }
+
+    function quotaWindowLabel(minutes) {
+      // Tolerate Codex v1's 299 / 10079 off-by-one quirk.
+      if (minutes === 299 || minutes === 300) return '5h';
+      if (minutes === 10079 || minutes === 10080) return '7d';
+      if (minutes >= 1440) return Math.floor(minutes / 1440) + 'd';
+      if (minutes >= 60)   return Math.floor(minutes / 60) + 'h';
+      return minutes + 'm';
+    }
+
+    function formatUsageCost(cost) {
+      if (!cost || cost <= 0) return '$0.00';
+      if (cost < 0.01) return '<$0.01';
+      if (cost >= 100) return '$' + Math.round(cost);
+      return '$' + cost.toFixed(2);
+    }
+    function formatTimeUntil(unixSec) {
+      let s = unixSec - Date.now() / 1000;
+      if (s < 0) s = 0;
+      const h = Math.floor(s / 3600);
+      const m = Math.floor((s % 3600) / 60);
+      if (h > 0) return h + 'h ' + m + 'm';
+      return m + 'm';
+    }
+    function formatClockTime(unixSec) {
+      return new Date(unixSec * 1000).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+    }
+
+    function collectFlatSessions() {
+      const out = [];
+      function visit(arr) {
+        if (!Array.isArray(arr)) return;
+        for (const a of arr) {
+          out.push(a);
+          if (a.children) visit(a.children);
+        }
+      }
+      for (const g of dashboardGroups) visit(g.agents || []);
+      return out;
+    }
+
+    // Fold session snapshots into one bucket per provider. Rules mirror
+    // macOS mergeIntoBuckets: subscription beats usage; fresh beats stale;
+    // among same-staleness snapshots, the highest sampled_at wins.
+    function bucketChips(sessions, nowMs) {
+      const buckets = new Map();
+      for (const s of sessions) {
+        const snap = s && s.metrics && s.metrics.rate_limit;
+        if (!snap) continue;
+        // Match Swift's mergeIntoBuckets stale rule exactly: any window
+        // whose resets_at is in the past (or zero — Date(0) is 1970, well
+        // before now) makes the snapshot stale. An earlier truthy guard
+        // on resets_at let resets_at=0 windows slip through as "fresh"
+        // here while macOS marked them stale.
+        const stale = Array.isArray(snap.windows) && snap.windows.some(w => w && w.resets_at * 1000 <= nowMs);
+        const key = providerKeyFor(snap, s.adapter) || ('unknown:' + (s.adapter || ''));
+        const mode = chipModeFor(snap, key);
+        const imm = imminentWindow(snap);
+        const cost = (s.metrics && s.metrics.estimated_cost_usd) || 0;
+        const existing = buckets.get(key);
+        if (!existing) {
+          buckets.set(key, {
+            key: key,
+            snapshot: snap,
+            session: s,
+            imminent: imm,
+            totalCostUSD: cost,
+            mode: mode,
+            isStale: stale,
+          });
+          continue;
+        }
+        // Subscription wins over usage when both are seen (rare — one OAuth
+        // account on both paths). Bars are the richer signal.
+        if (existing.mode === 'usage' && mode === 'subscription') {
+          existing.mode = 'subscription';
+          existing.snapshot = snap;
+          existing.session = s;
+          existing.imminent = imm;
+          existing.isStale = stale;
+        } else if (existing.isStale && !stale) {
+          // Always prefer fresh over stale, regardless of sampled_at.
+          existing.snapshot = snap;
+          existing.session = s;
+          existing.imminent = imm;
+          existing.isStale = false;
+        } else if (existing.isStale === stale && (snap.sampled_at || 0) > (existing.snapshot.sampled_at || 0)) {
+          existing.snapshot = snap;
+          existing.session = s;
+          existing.imminent = imm;
+        }
+        existing.totalCostUSD += cost;
+      }
+      return Array.from(buckets.values()).sort((a, b) =>
+        a.key < b.key ? -1 : a.key > b.key ? 1 : 0
+      );
+    }
+
+    function quotaTooltip(chip, nowMs) {
+      const lines = [];
+      const plan = planTypeLabel(chip.snapshot.plan_type);
+      if (plan) lines.push(plan);
+      if (chip.isStale) lines.push('⚠️ snapshot pre-dates current window — waiting for next statusline tick');
+      if (chip.mode === 'subscription') {
+        for (const w of (chip.snapshot.windows || [])) {
+          const used = Math.round(w.used_percent || 0);
+          const label = quotaWindowLabel(w.window_minutes || 0);
+          const pace = paceFor(w, nowMs);
+          let line = label + ': ' + used + '% used';
+          if (pace != null) {
+            const delta = used - Math.round(pace);
+            const verdict = delta > 0 ? (delta + 'pt over pace')
+                          : delta < 0 ? ((-delta) + 'pt under pace')
+                          : 'on pace';
+            line += ' · ' + verdict;
+          }
+          if (w.resets_at) line += ' · resets in ' + formatTimeUntil(w.resets_at);
+          lines.push(line);
+        }
+        const eta = chip.session && chip.session.metrics && chip.session.metrics.rate_limit_forecast_eta;
+        if (eta) lines.push('Projected cap: ' + formatClockTime(eta));
+        else if ((chip.snapshot.windows || []).some(w => (w.used_percent || 0) > 0))
+          lines.push("Forecast: won't hit cap this window");
+      } else {
+        lines.push(formatUsageCost(chip.totalCostUSD) + ' · cumulative spend across active sessions');
+        const c = chip.snapshot.credits;
+        if (c) {
+          if (c.unlimited === true) lines.push('Credits: unlimited');
+          else if (typeof c.balance === 'number') lines.push('Credits balance: $' + c.balance.toFixed(2));
+          else if (c.has_credits) lines.push('Credits: available');
+        }
+      }
+      if (chip.snapshot.reached_type) lines.push('⚠️ rate limit reached: ' + chip.snapshot.reached_type);
+      return lines.join('\n');
+    }
+
+    const MAX_VISIBLE_QUOTA_CHIPS = 2;
+
+    function adapterIconHTML(adapterKey) {
+      // Adapter SVGs are bytes from the daemon's /api/v1/agents response —
+      // not source code we control. Sandbox them through a base64 data-URL
+      // <img>, the same pattern the row adapter icon uses (line ~2063), so
+      // no inline event handler or <script> can escape into the page.
+      // Hardcoded provider icons above are trusted and stay as raw inline
+      // SVG (currentColor template-fill is load-bearing for them).
+      const branding = adapterKey ? agentRegistry[adapterKey] : null;
+      if (!branding) return '';
+      const theme = resolvedTheme();
+      const svg = (theme === 'dark' ? branding.icon_svg_dark : branding.icon_svg_light)
+               || branding.icon_svg_light
+               || branding.icon_svg_dark
+               || '';
+      if (!svg) return '';
+      try { return '<img alt="" src="data:image/svg+xml;base64,' + btoa(svg) + '">'; }
+      catch (e) { return ''; }
+    }
+
+    function buildQuotaRowDOM(w, compact, nowMs) {
+      const row = document.createElement('span');
+      row.className = 'quota-row';
+
+      const label = document.createElement('span');
+      label.className = 'quota-row-label';
+      label.textContent = quotaWindowLabel(w.window_minutes || 0);
+      row.appendChild(label);
+
+      const used = w.used_percent || 0;
+      const pace = paceFor(w, nowMs);
+      const bar = document.createElement('span');
+      bar.className = 'quota-bar';
+
+      const fill = document.createElement('span');
+      fill.className = 'quota-bar-fill ' + barColorClass(used, pace);
+      fill.style.width = Math.max(0, Math.min(100, used)).toFixed(2) + '%';
+      bar.appendChild(fill);
+
+      if (pace != null) {
+        const marker = document.createElement('span');
+        marker.className = 'quota-bar-pace';
+        marker.style.left = 'calc(' + Math.max(0, Math.min(100, pace)).toFixed(2) + '% - 0.5px)';
+        bar.appendChild(marker);
+      }
+      row.appendChild(bar);
+
+      const pct = document.createElement('span');
+      pct.className = 'quota-row-percent';
+      pct.textContent = Math.round(used) + '%';
+      row.appendChild(pct);
+
+      if (!compact && w.resets_at) {
+        const reset = document.createElement('span');
+        reset.className = 'quota-row-reset';
+        reset.textContent = 'resets ' + formatClockTime(w.resets_at);
+        row.appendChild(reset);
+      }
+      return row;
+    }
+
+    function buildQuotaChipDOM(chip, compact, nowMs) {
+      const root = document.createElement('div');
+      root.className = 'quota-chip' + (chip.isStale ? ' quota-stale' : '');
+      root.title = quotaTooltip(chip, nowMs);
+
+      const icon = document.createElement('span');
+      icon.className = 'quota-chip-icon';
+      const svg = providerIconHTML(chip.key)
+                || adapterIconHTML(chip.session && chip.session.adapter);
+      if (svg) icon.innerHTML = svg;
+      root.appendChild(icon);
+
+      const body = document.createElement('span');
+      body.className = 'quota-chip-body';
+      if (chip.mode === 'subscription') {
+        for (const w of (chip.snapshot.windows || [])) {
+          body.appendChild(buildQuotaRowDOM(w, compact, nowMs));
+        }
+      } else {
+        const hasSpend = chip.totalCostUSD > 0;
+        const head = document.createElement('span');
+        head.className = 'quota-usage-headline';
+        head.textContent = hasSpend ? formatUsageCost(chip.totalCostUSD) : '—';
+        const sub = document.createElement('span');
+        sub.className = 'quota-usage-sublabel';
+        sub.textContent = hasSpend ? 'spend' : 'no spend yet';
+        body.appendChild(head);
+        body.appendChild(sub);
+      }
+      root.appendChild(body);
+      return root;
+    }
+
+    function buildOverflowChipDOM(hidden) {
+      const pill = document.createElement('span');
+      pill.className = 'quota-overflow';
+      pill.textContent = '+' + hidden.length + ' more';
+      pill.title = hidden.map(h => {
+        const label = planTypeLabel(h.snapshot.plan_type)
+                   || (h.key.charAt(0).toUpperCase() + h.key.slice(1));
+        if (h.mode === 'subscription') {
+          const imm = h.imminent;
+          return imm ? (label + ': ' + Math.round(imm.used_percent || 0) + '%') : label;
+        }
+        return label + ': ' + (h.totalCostUSD > 0 ? formatUsageCost(h.totalCostUSD) : '—');
+      }).join('\n');
+      return pill;
+    }
+
+    function renderHeaderTitle() {
+      const host = document.getElementById('quota-chips');
+      const header = document.querySelector('header');
+      if (!host || !header) return;
+      // Error-boundary: a malformed snapshot or a localStorage failure
+      // inside any helper would otherwise unwind out of render() and skip
+      // the rest of the surrounding render pass. Fail soft: clear the chip
+      // strip, log to console, and leave the version line visible.
+      try {
+        host.innerHTML = '';
+        host.classList.remove('quota-chips--single');
+        if (!showQuotaForecast()) {
+          header.classList.remove('has-quota-chips');
+          return;
+        }
+        const nowMs = Date.now();
+        const chips = bucketChips(collectFlatSessions(), nowMs);
+        if (chips.length === 0) {
+          header.classList.remove('has-quota-chips');
+          return;
+        }
+        const visible = chips.slice(0, MAX_VISIBLE_QUOTA_CHIPS);
+        const hidden = chips.slice(MAX_VISIBLE_QUOTA_CHIPS);
+        const compact = chips.length > 1;
+        if (chips.length === 1) host.classList.add('quota-chips--single');
+        for (const c of visible) host.appendChild(buildQuotaChipDOM(c, compact, nowMs));
+        if (hidden.length > 0) host.appendChild(buildOverflowChipDOM(hidden));
+        header.classList.add('has-quota-chips');
+      } catch (e) {
+        try { console.error('quota chip render failed:', e); } catch (_) {}
+        host.innerHTML = '';
+        header.classList.remove('has-quota-chips');
+      }
+    }
+
+    // Per-provider mode selectors in the settings modal. Populated whenever
+    // settings opens with the providers we've actually observed in the
+    // current session list — same set the chip strip would render. If
+    // we've never seen a rate_limit snapshot, the section explains why.
+    function refreshProviderSettings() {
+      const host = document.getElementById('settings-providers');
+      if (!host) return;
+      host.innerHTML = '';
+      const chips = bucketChips(collectFlatSessions(), Date.now());
+      if (chips.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'provider-empty';
+        empty.textContent = 'No provider quota data observed yet.';
+        host.appendChild(empty);
+        return;
+      }
+      for (const c of chips) {
+        const row = document.createElement('div');
+        row.className = 'provider-row';
+
+        const name = document.createElement('span');
+        name.className = 'provider-name';
+        const iconSvg = providerIconHTML(c.key) || adapterIconHTML(c.session && c.session.adapter);
+        if (iconSvg) {
+          const iconSpan = document.createElement('span');
+          iconSpan.innerHTML = iconSvg;
+          name.appendChild(iconSpan);
+        }
+        const labelText = document.createElement('span');
+        labelText.textContent = planTypeLabel(c.snapshot.plan_type)
+                             || (c.key.charAt(0).toUpperCase() + c.key.slice(1));
+        name.appendChild(labelText);
+        row.appendChild(name);
+
+        const sel = document.createElement('select');
+        for (const opt of [['auto','Auto'], ['subscription','Subscription'], ['usage','Usage']]) {
+          const o = document.createElement('option');
+          o.value = opt[0];
+          o.textContent = opt[1];
+          sel.appendChild(o);
+        }
+        sel.value = providerModePreference(c.key);
+        sel.addEventListener('change', function() {
+          setProviderModePreference(c.key, this.value);
+          renderHeaderTitle();
+        });
+        row.appendChild(sel);
+        host.appendChild(row);
+      }
+    }
+
     // --- Header controls: theme toggle + display-mode cycle + settings ---
     document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
     document.getElementById('view-mode-cycle').addEventListener('click', cycleDisplayMode);
@@ -2459,11 +3136,22 @@
     applyDisplayMode();
 
     // --- Settings modal ---
+    // The settings form has two attribute namespaces:
+    //   * [data-setting=X]        — X is a key inside the bundled
+    //                               irrlicht_settings localStorage object.
+    //   * [data-quota-setting=X]  — X is its own top-level localStorage
+    //                               key, matching a macOS @AppStorage
+    //                               name verbatim (e.g. "showQuotaForecast").
+    // Any settings export/import/reset helper should iterate BOTH.
     function syncSettingsForm() {
       for (const el of document.querySelectorAll('[data-setting]')) {
         const key = el.dataset.setting;
         if (key in settings) el.checked = !!settings[key];
       }
+      for (const el of document.querySelectorAll('[data-quota-setting="showQuotaForecast"]')) {
+        el.checked = showQuotaForecast();
+      }
+      refreshProviderSettings();
       refreshPermNote();
     }
     function refreshPermNote() {
@@ -2509,6 +3197,16 @@
         closeSettings();
       }
     });
+    // Quota-forecast master toggle — flips visibility of the chip strip
+    // header-wide. Persisted to `showQuotaForecast` (matching macOS).
+    const quotaToggle = document.querySelector('[data-quota-setting="showQuotaForecast"]');
+    if (quotaToggle) {
+      quotaToggle.addEventListener('change', function() {
+        setShowQuotaForecast(this.checked);
+        renderHeaderTitle();
+      });
+    }
+
     // Wire each checkbox so toggling persists immediately and applies its
     // body-class effect (or, for notification toggles, kicks off the
     // permission prompt the first time).


### PR DESCRIPTION
## Summary

- Mirror macOS overlay's provider quota chip in the web dashboard so popover and dashboard show identical state for the same `/api/v1/sessions` response. Daemon-side ingestion + forecast (7bc2cc6 / 276eb3f) already landed; this is a single-file port to `platforms/web/index.html`.
- Subscription mode renders stacked 5h/7d bars with a pace marker and the same color thresholds as `QuotaBarThreshold` in `SessionListView.swift`; usage mode shows cumulative spend. Up to 2 chips visible plus a `+N more` overflow pill.
- Settings modal gains a Provider-quota section: master toggle (`showQuotaForecast`) and per-provider auto/subscription/usage select (`providerMode_<key>`), keys matching the macOS @AppStorage names verbatim.

## Test plan

- [x] `go test ./core/... -race -count=1`
- [x] `tools/replay-fixtures.sh`
- [x] `node --check` on extracted inline JS
- [ ] Visual cross-surface check with a live Claude Code session: popover and dashboard show same provider icon, same 5h/7d percentages, same `resets …` label, same forecast ETA in tooltip. To run: `IRRLICHT_UI_DIR=$(pwd)/platforms/web ./core/bin/irrlichd` (or `/ir:test-mac`) then open `http://localhost:7837/`.
- [ ] Settings → "Show quota forecast" toggle hides/shows the chip strip.
- [ ] Flip a provider to Usage → chip switches to spend headline; back to Auto → bars return.
- [ ] Narrow viewport (<420px) restores the version line and hides the chip strip.

Closes #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)