### PR TITLE
feat(quota): OpenCode→OpenAI rate-limit inheritance via JWT account_id

### DIFF
--- a/core/application/services/quotainherit.go
+++ b/core/application/services/quotainherit.go
@@ -22,9 +22,11 @@
 package services
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -56,9 +58,10 @@ type authCacheEntry struct {
 	// One of the parsed-doc fields below is populated, depending on
 	// which reader filled the entry. Distinguishing by path keeps the
 	// readers type-safe without a generic any-typed payload.
-	codexAccountID string
-	piDoc          map[string]piAuthEntry
-	openCodeDoc    map[string]openCodeAuthEntry
+	codexAccountID        string
+	piDoc                 map[string]piAuthEntry
+	openCodeDoc           map[string]openCodeAuthEntry
+	openCodeOpenAIAccount string // extracted from JWT on parse, "" if absent/invalid
 }
 
 type piAuthEntry struct {
@@ -67,7 +70,8 @@ type piAuthEntry struct {
 }
 
 type openCodeAuthEntry struct {
-	Type string `json:"type"`
+	Type        string `json:"type"`
+	AccessToken string `json:"access_token"`
 }
 
 // readAuthCache returns the parsed entry for path, populating the
@@ -305,23 +309,18 @@ func parsePiAuth(data []byte) (authCacheEntry, bool) {
 // readOpenCodeInheritKey parses ~/.local/share/opencode/auth.json.
 // OpenCode names OAuth providers `anthropic-oauth` and `openai-oauth`
 // per its upstream docs; we map them onto irrlicht's canonical
-// "anthropic" / "openai" provider keys. Account anchor isn't surfaced
-// in the file we've seen — Anthropic always lands on the singleton
-// key, OpenAI is best-effort (would need to read the JWT to recover
-// the chatgpt account_id; out of scope for v1, so OpenCode→OpenAI
-// just doesn't inherit until that lands).
+// "anthropic" / "openai" provider keys. Anthropic uses a singleton key
+// (no account anchor). OpenAI account_id is recovered from the JWT
+// access_token's payload via openCodeJWTAccountID.
 func readOpenCodeInheritKey(home string) (AccountKey, bool) {
 	entry, ok := readAuthCache(filepath.Join(home, ".local", "share", "opencode", "auth.json"), parseOpenCodeAuth)
 	if !ok {
 		return AccountKey{}, false
 	}
 	if v, ok := entry.openCodeDoc["openai-oauth"]; ok && v.Type == "oauth" {
-		// AccountID unavailable in the OpenCode auth file shape
-		// observed so far — would need to decode the JWT access token
-		// to recover it. Leave inheritance disabled for this branch
-		// until we have data to verify the JWT extraction against.
-		// See issue #384.
-		return AccountKey{}, false
+		if entry.openCodeOpenAIAccount != "" {
+			return AccountKey{Provider: ProviderOpenAI, AccountID: entry.openCodeOpenAIAccount}, true
+		}
 	}
 	if v, ok := entry.openCodeDoc["anthropic-oauth"]; ok && v.Type == "oauth" {
 		return AccountKey{Provider: ProviderAnthropic}, true
@@ -334,5 +333,36 @@ func parseOpenCodeAuth(data []byte) (authCacheEntry, bool) {
 	if err := json.Unmarshal(data, &doc); err != nil {
 		return authCacheEntry{}, false
 	}
-	return authCacheEntry{openCodeDoc: doc}, true
+	entry := authCacheEntry{openCodeDoc: doc}
+	if v, ok := doc["openai-oauth"]; ok {
+		entry.openCodeOpenAIAccount = openCodeJWTAccountID(v.AccessToken)
+	}
+	return entry, true
+}
+
+// openCodeJWTAccountID extracts https://api.openai.com/auth.chatgpt_account_id
+// from the payload segment of an OpenID Connect access token. The signature is
+// not verified — we only need the identity claim.
+func openCodeJWTAccountID(token string) string {
+	parts := strings.SplitN(token, ".", 3)
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	raw, ok := claims["https://api.openai.com/auth.chatgpt_account_id"]
+	if !ok {
+		return ""
+	}
+	var id string
+	if err := json.Unmarshal(raw, &id); err != nil {
+		return ""
+	}
+	return id
 }

--- a/core/application/services/quotainherit_test.go
+++ b/core/application/services/quotainherit_test.go
@@ -1,7 +1,9 @@
 package services
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -288,6 +290,114 @@ func TestReadCodexAccountID_ErrorPaths(t *testing.T) {
 func TestReadCodexAccountID_MissingFileReturnsEmpty(t *testing.T) {
 	if got := readCodexAccountID(t.TempDir()); got != "" {
 		t.Errorf("expected empty for missing file, got %q", got)
+	}
+}
+
+// makeJWT builds a synthetic JWT with the given JSON payload string.
+// The signature is junk — we never verify it.
+func makeJWT(payloadJSON string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(payloadJSON))
+	return fmt.Sprintf("%s.%s.fakesig", header, payload)
+}
+
+func TestOpenCodeJWTAccountID(t *testing.T) {
+	claimKey := "https://api.openai.com/auth.chatgpt_account_id"
+	cases := []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{
+			name:  "valid jwt with claim",
+			token: makeJWT(fmt.Sprintf(`{%q:"acct-jwt123"}`, claimKey)),
+			want:  "acct-jwt123",
+		},
+		{
+			name:  "valid jwt missing claim",
+			token: makeJWT(`{"sub":"user@example.com"}`),
+			want:  "",
+		},
+		{
+			name:  "too few segments",
+			token: "header.payload",
+			want:  "",
+		},
+		{
+			name:  "bad base64 in payload",
+			token: "header.!!!.sig",
+			want:  "",
+		},
+		{
+			name:  "claim value is not a string",
+			token: makeJWT(fmt.Sprintf(`{%q:42}`, claimKey)),
+			want:  "",
+		},
+		{
+			name:  "empty token",
+			token: "",
+			want:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := openCodeJWTAccountID(tc.token); got != tc.want {
+				t.Errorf("openCodeJWTAccountID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestInheritRateLimits_OpenCodeOpenAIInheritsFromCodex(t *testing.T) {
+	const accountID = "acct-jwt123"
+	claimKey := "https://api.openai.com/auth.chatgpt_account_id"
+	jwt := makeJWT(fmt.Sprintf(`{%q:%q}`, claimKey, accountID))
+
+	home := stageAuth(t, map[string]any{
+		".codex/auth.json": map[string]any{
+			"auth_mode": "chatgpt",
+			"tokens":    map[string]any{"account_id": accountID},
+		},
+		".local/share/opencode/auth.json": map[string]any{
+			"openai-oauth": map[string]any{
+				"type":         "oauth",
+				"access_token": jwt,
+			},
+		},
+	})
+
+	codex := donorCodex(1000, 35)
+	opencode := emptyWrapper("opencode", "opencode-1")
+	InheritRateLimits([]*session.SessionState{codex, opencode}, home)
+
+	if opencode.Metrics.RateLimit == nil {
+		t.Fatal("expected opencode session to inherit codex snapshot via JWT account_id")
+	}
+	if opencode.Metrics.RateLimit.SampledAt != 1000 {
+		t.Errorf("inherited snapshot timestamp mismatch: got %d", opencode.Metrics.RateLimit.SampledAt)
+	}
+}
+
+func TestInheritRateLimits_OpenCodeOpenAINoInheritWhenJWTMissing(t *testing.T) {
+	home := stageAuth(t, map[string]any{
+		".codex/auth.json": map[string]any{
+			"auth_mode": "chatgpt",
+			"tokens":    map[string]any{"account_id": "acct-xyz"},
+		},
+		".local/share/opencode/auth.json": map[string]any{
+			"openai-oauth": map[string]any{
+				"type": "oauth",
+				// no access_token field
+			},
+		},
+	})
+
+	codex := donorCodex(1000, 35)
+	opencode := emptyWrapper("opencode", "opencode-1")
+	InheritRateLimits([]*session.SessionState{codex, opencode}, home)
+
+	if opencode.Metrics.RateLimit != nil {
+		t.Fatal("expected no inheritance when access_token is absent")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extracts `chatgpt_account_id` from the `openai-oauth` access token's JWT payload in `readOpenCodeInheritKey`, enabling OpenCode sessions to inherit Codex CLI rate-limit snapshots when both are authed to the same ChatGPT account
- JWT parsing runs once per `auth.json` modification inside `parseOpenCodeAuth` and the result is cached in `authCacheEntry.openCodeOpenAIAccount` — no per-request overhead on `/api/v1/sessions`
- Adds `openCodeJWTAccountID` helper (base64-RawURL-decode middle segment → unmarshal JSON → read namespaced claim `https://api.openai.com/auth.chatgpt_account_id`)

## Test plan

- [ ] `TestOpenCodeJWTAccountID` — 6 subtests covering valid JWT, missing claim, too-few segments, bad base64, non-string claim value, empty token
- [ ] `TestInheritRateLimits_OpenCodeOpenAIInheritsFromCodex` — end-to-end: Codex donor + OpenCode with synthetic JWT → snapshot inherited
- [ ] `TestInheritRateLimits_OpenCodeOpenAINoInheritWhenJWTMissing` — no `access_token` field → no inheritance
- [ ] `go test ./core/... -race -count=1` passes
- [ ] End-to-end with a real OpenCode install authed to a ChatGPT subscription is a separate confirmation step (noted in issue)

Closes #384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)