### PR TITLE
feat(onboard-agent): add scenario semantic blocks and track coverage matrix

### DIFF
--- a/.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json
+++ b/.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json
@@ -1,0 +1,1261 @@
+{
+  "version": 1,
+  "generated_at": "2026-05-14",
+  "source_catalog": ".specs/agent-scenarios.md",
+  "legend": {
+    "agent_supports": [
+      "yes",
+      "no",
+      "partial",
+      "unknown"
+    ],
+    "irrlicht_observes": [
+      "yes",
+      "no",
+      "partial",
+      "unknown",
+      "n/a"
+    ],
+    "notes": "Free-form. Empty when crystal clear. Otherwise names the gotcha, the issue number, or the unmet condition."
+  },
+  "agents": [
+    {
+      "id": "claudecode",
+      "onboarded": true
+    },
+    {
+      "id": "codex",
+      "onboarded": true
+    },
+    {
+      "id": "pi",
+      "onboarded": true
+    },
+    {
+      "id": "aider",
+      "onboarded": true
+    },
+    {
+      "id": "opencode",
+      "onboarded": true
+    }
+  ],
+  "scenarios": [
+    {
+      "id": "session-start",
+      "section": "Session lifecycle",
+      "feature": "Session start",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "markdown transcript discovered lazily per cwd; session row appears only after first user message lands in .aider.chat.history.md"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "SQLite-backed; no PID binding required"
+        }
+      }
+    },
+    {
+      "id": "session-end",
+      "section": "Session lifecycle",
+      "feature": "Session end",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "clean exit + SIGKILL OK; crash mid-turn covered indirectly via sweep. #321 zombie-on-restart fixed in 0.4.x \u2014 recipe now passes 11/11 phases."
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "idle-flush turn-end adds ~5s before ready settles; markdown file persists after exit"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "#296 ghost sessions when no process; #278 ~2.5s tail latency on working\u2192ready"
+        }
+      }
+    },
+    {
+      "id": "long-idle-live-session",
+      "section": "Session lifecycle",
+      "feature": "Long-idle live session",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "PID liveness check holds session past readyTTL"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "no PID binding \u2014 liveness relies on DB watcher signal"
+        }
+      }
+    },
+    {
+      "id": "session-resume",
+      "section": "Session lifecycle",
+      "feature": "Session resume",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "--continue / --resume; transcript appended"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "/resume command + picker (2026)"
+        },
+        "pi": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "unknown",
+          "notes": "aider re-loads chat history from .aider.chat.history.md but no formal session-id concept"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "capabilities.json declares yes; ParentSessionID not populated recursively for resume chains"
+        }
+      }
+    },
+    {
+      "id": "session-reset",
+      "section": "Session lifecycle",
+      "feature": "Session reset (/clear, /new)",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "/clear rotates UUID; daemon emits transcript_removed for old UUID via PIDManager's same-PID cleanup (commit 56c4667 / issue #169). ~50ms overlap between new session's transcript_new and old session's transcript_removed is bounded by spec at 1s. Eliminating overlap entirely conflicts with multi-session-same-cwd support."
+        },
+        "codex": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": "aider has no /clear analogue; restart creates new history file"
+        },
+        "opencode": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "checkpoint-rewind",
+      "section": "Session lifecycle",
+      "feature": "Checkpoint rewind",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "/rewind (alias /checkpoint, also Esc+Esc) restores files and/or conversation to any earlier user prompt; auto-checkpointed per prompt. https://code.claude.com/docs/en/checkpointing. First recording (2026-05-16) drives 3 turns with an Esc+Esc keystroke between turns 2 and 3 \u2014 irrlicht observes 3 clean ready\u2192working\u2192ready arcs on the same UUID with no transcript_removed (the daemon handles whatever Esc+Esc did to the TUI without losing session continuity), BUT the recording's transcript shows a linear parentUuid chain so the rewind never actually fired. Follow-up: drive the /rewind picker UI to capture an ACTUAL transcript truncation event, then upgrade to yes/no."
+        },
+        "codex": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": "No native rewind as of v0.130 (May 2026). Open feature requests #11626 + #12558 explicitly model after Claude Code; community discussion #9618 confirms status. Reassess on next major Codex release."
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": "Stock Pi CLI has no rewind (pi-mono discussion #1223). Third-party `pi-rewind` extension exists at arpagon/pi-rewind but isn't part of the default install, so irrlicht's observation target \u2014 stock Pi \u2014 has nothing to record."
+        },
+        "aider": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "no",
+          "notes": "/undo reverts the last aider git commit; /reset wipes files + chat; /clear clears chat history. No multi-point checkpoint picker. The /undo path surfaces as a normal chat turn in the transcript and a git HEAD movement \u2014 distinguishable from a regular turn only via the slash-command marker, not via session_id change."
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "/undo + /redo perform a git-snapshot session revert: rewinds to a previous message point, restores files from the snapshot, removes subsequent messages from the session DB. https://opencode.ai/docs/commands/. Multi-point picker tracked at #7794. Irrlicht observability untested \u2014 same session_id, transcript shrinks then grows; record before marking yes."
+        }
+      }
+    },
+    {
+      "id": "cloud-background-agent",
+      "section": "Session lifecycle",
+      "feature": "Cloud / background agent (remote process)",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": "local CLI only; no first-party cloud variant"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "no",
+          "notes": "Codex Cloud exists; irrlicht has no API-based watcher"
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "opencode": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "basic-turn",
+      "section": "Turn shape",
+      "feature": "Basic turn",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "idle-flush turn-end (~5s effective latency on working\u2192ready)"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "auto-executed-tool-call",
+      "section": "Turn shape",
+      "feature": "Auto-executed tool call",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "tool calls reduced to '> Applied edit' / '> Running' markdown markers; coarse-grained"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "self-correction-iteration",
+      "section": "Turn shape",
+      "feature": "Self-correction iteration",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "aider retries across turns rather than within; idle-flush splits attempts"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "synchronous-slash-command",
+      "section": "Turn shape",
+      "feature": "Synchronous slash command (no LLM call)",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "/help, /cost, /status \u2014 does irrlicht stay ready? Not validated"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "long-agentic-session-stress",
+      "section": "Turn shape",
+      "feature": "Long agentic session (stress)",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "#102 historical flicker (closed); long sessions stable on current adapter"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "#105 stale-tool timer flicker (closed); task_complete dependence creates fallback risk"
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "compaction events risk working\u2192ready\u2192working flicker"
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "idle-flush windows compound on long sessions"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "autonomous-loop",
+      "section": "Turn shape",
+      "feature": "Autonomous loop (self-prompting)",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "unknown",
+          "notes": "no built-in autonomous loop; can be driven externally"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "Codex /goal command (Ralph loop)"
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "unknown",
+          "notes": "architect mode does limited multi-step but not continuous self-prompt"
+        },
+        "opencode": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "autonomous-loop-iteration-limit",
+      "section": "Turn shape",
+      "feature": "Autonomous loop iteration limit reached",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "/goal has caps"
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "opencode": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "token-quota-exhausted",
+      "section": "Turn shape",
+      "feature": "Token / quota budget exhausted",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "5-hour budget hits do happen; state transition on quota end not specifically tested"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "LLM error blockquote treated as turn_done (#262); quota errors land in same path"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "step-finish reason=error covers"
+        }
+      }
+    },
+    {
+      "id": "mid-turn-message-queued",
+      "section": "Turn shape",
+      "feature": "Mid-turn user message queued",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "queue feature; state should stay working but not validated"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": "TUI-based, no queue concept"
+        },
+        "opencode": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "auto-classified-permission",
+      "section": "Turn shape",
+      "feature": "Auto-classified permission approval",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "Auto Mode shipped March 2026; irrlicht's PermissionPending path covers waiting on risky calls, but Auto-Mode classifier internals are agent-side"
+        },
+        "codex": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "n/a",
+          "notes": "/yes-always is blanket, not classifier-based"
+        },
+        "opencode": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "context-compaction",
+      "section": "Turn shape",
+      "feature": "Context compaction",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "/compact runs as a turn; transitions should stay working then ready \u2014 not specifically validated"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "Compaction events emitted as bare 'assistant' (not turn-done); risk of working\u2192ready\u2192working flicker per exploration"
+        },
+        "aider": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "opencode": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "turn-end-terminal-text",
+      "section": "Turn shape",
+      "feature": "Turn end via terminal text",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "stop_reason=end_turn handled"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "task_complete handled"
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "stopReason=stop handled (#119 fixed)"
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "idle-flush is the de-facto terminal signal; ~5s lag"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "step-finish reason=stop"
+        }
+      }
+    },
+    {
+      "id": "turn-aborted-by-error",
+      "section": "Turn shape",
+      "feature": "Turn aborted by error",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "#262 fixed \u2014 error blockquote emits turn_done early"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "step-finish reason=error"
+        }
+      }
+    },
+    {
+      "id": "shell-escape-command",
+      "section": "Turn shape",
+      "feature": "Shell escape command",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "#62 closed; ! prefix handled; BashExecution events skipped"
+        },
+        "codex": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "/run command available; observability folds into '> Running' tool marker"
+        },
+        "opencode": {
+          "agent_supports": "unknown",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "oversized-transcript-line",
+      "section": "Turn shape",
+      "feature": "Oversized transcript line",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "#270 closed; stuck-working risk fixed but worth regression testing"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "RawLineParser; behavior on very long lines unvalidated"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "user-blocking-question",
+      "section": "Turn shape",
+      "feature": "User-blocking tool call (question)",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "AskUserQuestion detected explicitly; #150 + #307 fswatcher/JSONL race scenarios fixed"
+        },
+        "codex": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": "no question tool in schema"
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "no",
+          "notes": "aider can ask via /ask interactively but no JSONL-style tool marker; not detected"
+        },
+        "opencode": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": "no AskUserQuestion equivalent matched"
+        }
+      }
+    },
+    {
+      "id": "user-blocking-plan-mode-approval",
+      "section": "Turn shape",
+      "feature": "User-blocking tool call (plan-mode approval)",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "ExitPlanMode tool detected; #152 fixed"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "no",
+          "notes": "#322 OPEN \u2014 <proposed_plan> turns end as 'ready' instead of 'waiting'; #325 OPEN \u2014 dismissal leaves session stuck in waiting"
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "no",
+          "notes": "plan_mode declared in capabilities.json but not detected in parser"
+        },
+        "opencode": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "no",
+          "notes": "Plan agent exists but not surfaced as waiting state"
+        }
+      }
+    },
+    {
+      "id": "tool-gate-permission-prompt",
+      "section": "Turn shape",
+      "feature": "Tool gate via permission prompt",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "PreToolUse/PostToolUse hooks wired via HTTP receiver; #204 closed (late hook bounce-back)"
+        },
+        "codex": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": "capabilities.json: permission_hooks: false"
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "no",
+          "notes": "aider's confirm prompts are stdin/TUI; not visible to irrlicht via transcript"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "capabilities.json declares permission_hooks: true; wiring/validation status unclear"
+        }
+      }
+    },
+    {
+      "id": "user-esc-interrupt",
+      "section": "Turn shape",
+      "feature": "User ESC interrupt",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "tool-denial + ESC marker recognized; #13 fixed"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "Ctrl-C in aider TUI; abort markdown signature may differ from claude ESC pattern"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "step-finish reason=interrupted handled"
+        }
+      }
+    },
+    {
+      "id": "streaming-partial-writes",
+      "section": "Turn shape",
+      "feature": "Streaming partial writes",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "task_complete fallback to assistant_message risks mid-stream flicker"
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "compaction event interspersing risks flicker"
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "idle-flush may fire during slow remote model calls causing premature ready"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "foreground-subagent",
+      "section": "Subagents",
+      "feature": "Foreground subagent",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "file-based child transcripts; ParentSessionID inferred from filesystem; #133/#134 stop_reason=null fixed; #88 closed"
+        },
+        "codex": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": "capabilities.json: subagents: false"
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "explicit DB parent_session_id column; agent teams"
+        }
+      }
+    },
+    {
+      "id": "background-subagent",
+      "section": "Subagents",
+      "feature": "Background subagent",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "SendMessage continuation; parent-not-held semantics rely on surviveTurnDone list; per-flow validation incomplete"
+        },
+        "codex": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "peer-messaging agent teams; not validated as 'background' specifically"
+        }
+      }
+    },
+    {
+      "id": "background-process",
+      "section": "Subagents",
+      "feature": "Background process",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "no",
+          "notes": "Bash run_in_background:true tool exists; irrlicht has no BackgroundProcessCount and does not track child PIDs from Bash"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "no",
+          "notes": "shell tool can spawn background process; not tracked"
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "no",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "no",
+          "notes": ""
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "no",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "subagent-orphan-cleanup",
+      "section": "Subagents",
+      "feature": "Subagent orphan cleanup",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "deleteWithChildren + orphan transcript predicates"
+        },
+        "codex": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "DB-backed children \u2014 cleanup path differs from PID-based; validation status unclear"
+        }
+      }
+    },
+    {
+      "id": "multiple-sessions-same-cwd",
+      "section": "Multi-session and multi-agent",
+      "feature": "Multiple sessions in same cwd",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "#60 / #109 fixes landed; PID-cwd disambiguation can still flap under odd timing"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "no",
+          "notes": "aider uses a single .aider.chat.history.md per cwd; two aiders in same cwd would race that file"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "DB-keyed sessions; cwd not the disambiguator"
+        }
+      }
+    },
+    {
+      "id": "multiple-agents-same-workspace",
+      "section": "Multi-session and multi-agent",
+      "feature": "Multiple agents in same workspace",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "claudecode + codex/pi/aider/opencode coexistence \u2014 adapter labels are independent"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        }
+      }
+    },
+    {
+      "id": "token-accounting",
+      "section": "Metrics",
+      "feature": "Token accounting",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "full per-turn deltas via request-ID dedup; cache_read routed to cache bucket"
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "cumulative cursor \u2192 delta math; cached_tokens deducted to avoid double-count"
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "message.usage with cacheRead/cacheWrite; per-turn cost when present"
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "regex-parsed '> Tokens: N sent, M received'; no cache-bucket distinction"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "step-finish.tokens nested cache object; 5m + 1h cache creation tracked separately"
+        }
+      }
+    },
+    {
+      "id": "model-identification",
+      "section": "Metrics",
+      "feature": "Model identification",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "from message.model"
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "regex-parsed '> Model:' / '> Main model:'"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "step-finish.model"
+        }
+      }
+    },
+    {
+      "id": "model-switch-midsession",
+      "section": "Metrics",
+      "feature": "Model switch mid-session",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "codex": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "no",
+          "notes": "no model change detection between turns per parser exploration"
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "architect/editor pair detected per turn but inter-turn switch may not refresh"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "yes",
+          "notes": "mixed-model agent teams; per-step model captured"
+        }
+      }
+    },
+    {
+      "id": "architect-editor-pair",
+      "section": "Metrics",
+      "feature": "Architect/Editor model pair",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": "single Anthropic model per turn"
+        },
+        "codex": {
+          "agent_supports": "partial",
+          "irrlicht_observes": "unknown",
+          "notes": "planning agent + executor exists; unclear if surfaced as two contributions"
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "--architect ships two-model pair; markdown parser sees two '> Model:' lines but contribution attribution incomplete"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "partial",
+          "notes": "agent teams can mix models; per-child captured but parent.ModelName semantics unclear"
+        }
+      }
+    },
+    {
+      "id": "provider-failover-midturn",
+      "section": "Metrics",
+      "feature": "Provider failover mid-turn",
+      "coverage": {
+        "claudecode": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": "single provider per session"
+        },
+        "codex": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "pi": {
+          "agent_supports": "no",
+          "irrlicht_observes": "n/a",
+          "notes": ""
+        },
+        "aider": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "aider can configure fallback models; mid-turn switch surfaced in transcript via '> Switching to model \u2026' (untested in irrlicht)"
+        },
+        "opencode": {
+          "agent_supports": "yes",
+          "irrlicht_observes": "unknown",
+          "notes": "multi-provider model packs; failover observability not validated"
+        }
+      }
+    }
+  ]
+}

--- a/.claude/skills/ir:onboard-agent/assess/SKILL.md
+++ b/.claude/skills/ir:onboard-agent/assess/SKILL.md
@@ -36,7 +36,7 @@ verb:
   across all 5 adapters.
 
 The column and row forms produce CANDIDATES for the maintainer to
-review and transcribe into `.specs/agent-scenarios-coverage.json`.
+review and transcribe into `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`.
 The single-cell form is the source-of-record artifact the viewer
 displays — typically you use it AFTER a column or row scan flagged
 the cell as interesting (low confidence, surprising verdict, etc.).
@@ -54,7 +54,7 @@ the cell as interesting (low confidence, surprising verdict, etc.).
 A cell's `assessment.json` is the source-of-record for "what we
 believe about this cell right now, and why." A maintainer transcribes
 the verdict + a one-line note into the rollup matrix
-(`.specs/agent-scenarios-coverage.json`), but the artifact is what
+(`.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`), but the artifact is what
 the viewer renders on the detail page and what later audits read.
 
 Three rules:
@@ -82,7 +82,7 @@ Three rules:
 
 - `<agent>` — adapter slug (`claudecode`, `codex`, `pi`, `aider`,
   `opencode`).
-- `<scenario-id>` — coverage id from `.specs/agent-scenarios-coverage.json`
+- `<scenario-id>` — coverage id from `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`
   (e.g. `checkpoint-rewind`, `cloud-background-agent`).
 
 Worked examples committed:
@@ -152,13 +152,14 @@ rollup of the same data). Don't fabricate a scenario.
 ► **Verify before moving on:**
 - [ ] Found the Feature: heading. If not, the `<scenario-id>` is
   wrong or the spec is missing — stop and surface the gap.
+- [ ] Located the `### <scenario-id>` section in `.claude/skills/ir:onboard-agent/scenario-meanings.md` and captured the **Primitive exercised** field verbatim. This field is the canonical capability key anchor — use it in Step 4 to drive `capabilities.json` assignment. If the scenario ID is missing from `scenario-meanings.md` — STOP and ask the maintainer to add it.
 - [ ] Captured every Expected: bullet. Each one is a candidate
   assertion you'll judge `irrlicht_observes` against.
 
 ### Step 2 — Read the current matrix verdict
 
 ```
-.specs/agent-scenarios-coverage.json   →   .scenarios[].coverage[<agent>]
+.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json   →   .scenarios[].coverage[<agent>]
 ```
 
 Or `curl http://127.0.0.1:8765/api/catalog | jq` when `.specs/` is
@@ -276,6 +277,12 @@ Ask it to:
 - Decide `agent_supports` honestly.
 - Derive `irrlicht_observes` from the transport read (Step 3) and
   whatever it learns about the agent's emission shape.
+- Map the **Primitive exercised** field from Step 1 to the matching
+  key in `replaydata/agents/<agent>/capabilities.json`. Use the
+  primitive text to identify the correct feature flag — do NOT infer
+  a capability key from general knowledge; derive it directly from
+  the primitive text and the existing keys in `capabilities.json`.
+  Update or confirm that key in the output.
 - Identify caveats — name each one explicitly with the pattern it
   fits.
 - Calibrate `confidence` (`0.9+` only when behavior is documented
@@ -331,7 +338,7 @@ Then a transcription hint IF the new verdict differs from the matrix
 
 ```
 ⓘ matrix says <old_supports>/<old_observes>; consider updating
-  .specs/agent-scenarios-coverage.json -> .scenarios[<id>].coverage.<agent>
+  .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json -> .scenarios[<id>].coverage.<agent>
 ```
 
 The matrix update is the maintainer's call — this skill never writes
@@ -388,7 +395,7 @@ scenario in the canonical catalog. Steps:
    ```
    Writes `.specs/agent-assess-<agent>.json` (backs up any prior
    version to `.bak`). Still gitignored; the maintainer transcribes
-   into `.specs/agent-scenarios-coverage.json` after review.
+   into `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json` after review.
 6. **Surface low-confidence cells.**
    ```bash
    jq -r '.scenarios | to_entries[]
@@ -456,7 +463,7 @@ column prompt covers when to omit vs include with `"unknown"`.
   has the exact behavior." `0.7-0.85` is the honest band for a
   thorough multi-source read.
 - **Don't write the matrix.** Phase 2 here is the artifact; the
-  rollup in `.specs/agent-scenarios-coverage.json` is maintainer-
+  rollup in `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json` is maintainer-
   owned. Report the transcription hint and stop.
 - **Don't dispatch the subagent without the adapter-transport read.**
   Step 3 is what grounds the `irrlicht_observes` claim. A subagent
@@ -478,7 +485,7 @@ column prompt covers when to omit vs include with `"unknown"`.
 
 ## What this mode does NOT do
 
-- It does not modify `.specs/agent-scenarios-coverage.json`. The
+- It does not modify `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`. The
   matrix is the maintainer's editorial truth.
 - It does not produce the recipe — that's
   [`../recipe/SKILL.md`](../recipe/SKILL.md).

--- a/.claude/skills/ir:onboard-agent/assess/prompts/column.md
+++ b/.claude/skills/ir:onboard-agent/assess/prompts/column.md
@@ -1,6 +1,6 @@
 # Agent applicability assessment (column mode)
 
-You are surveying ONE coding-agent CLI to decide, for each scenario in irrlicht's catalog, whether that agent **as-shipped** supports the behavior the scenario tests. Your output becomes a candidate `coverage[<agent>]` column for the maintainer to review and merge into `.specs/agent-scenarios-coverage.json`. You do not modify that file directly.
+You are surveying ONE coding-agent CLI to decide, for each scenario in irrlicht's catalog, whether that agent **as-shipped** supports the behavior the scenario tests. Your output becomes a candidate `coverage[<agent>]` column for the maintainer to review and merge into `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`. You do not modify that file directly.
 
 ## Inputs you will be given
 
@@ -8,7 +8,7 @@ You are surveying ONE coding-agent CLI to decide, for each scenario in irrlicht'
 - `AGENT_VERSION` — the agent's published version at survey time, if known (e.g. `2.1.140`). If unknown, write `"unknown"`.
 - The full scenario catalog, supplied in two forms:
   - `.specs/agent-scenarios.md` — prose `Feature → Scenario → Expected` triples.
-  - `.specs/agent-scenarios-coverage.json` — the canonical list of scenario IDs (the `id` field of each entry in `scenarios[]`).
+  - `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json` — the canonical list of scenario IDs (the `id` field of each entry in `scenarios[]`).
 
 Read both. The IDs in the JSON are authoritative for output keys; the prose in the markdown is where the actual behavior is described.
 
@@ -48,7 +48,7 @@ Write a single JSON document validating against `assess/schema/column.schema.jso
 }
 ```
 
-**Every scenario ID from `.specs/agent-scenarios-coverage.json` must appear exactly once.** Missing or extra keys cause `run-batch.sh` to reject the output.
+**Every scenario ID from `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json` must appear exactly once.** Missing or extra keys cause `run-batch.sh` to reject the output.
 
 ### Each verdict
 

--- a/.claude/skills/ir:onboard-agent/assess/prompts/row.md
+++ b/.claude/skills/ir:onboard-agent/assess/prompts/row.md
@@ -1,14 +1,14 @@
 # Scenario applicability assessment (row mode)
 
-You are assessing ONE irrlicht scenario across every coding-agent CLI in the catalog. Your output becomes a candidate matrix-row for the maintainer to review and merge into `.specs/agent-scenarios-coverage.json`. You do not modify that file directly.
+You are assessing ONE irrlicht scenario across every coding-agent CLI in the catalog. Your output becomes a candidate matrix-row for the maintainer to review and merge into `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`. You do not modify that file directly.
 
 ## Inputs you will be given
 
 - `SCENARIO_ID` — the kebab-case scenario slug (e.g. `basic-turn`, `session-resume`, `cloud-background-agent`).
-- The list of adapter slugs (`agents[]` in `.specs/agent-scenarios-coverage.json`).
+- The list of adapter slugs (`agents[]` in `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`).
 - The full scenario catalog, supplied in two forms:
   - `.specs/agent-scenarios.md` — prose `Feature → Scenario → Expected` block for the scenario you're assessing. Read this carefully.
-  - `.specs/agent-scenarios-coverage.json` — canonical adapter list.
+  - `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json` — canonical adapter list.
 
 Read both. The IDs in the JSON are authoritative for output keys.
 

--- a/.claude/skills/ir:onboard-agent/assess/run-batch.sh
+++ b/.claude/skills/ir:onboard-agent/assess/run-batch.sh
@@ -21,7 +21,7 @@ ROW_SCHEMA="$ASSESS_DIR/schema/row.schema.json"
 COLUMN_PROMPT="$ASSESS_DIR/prompts/column.md"
 ROW_PROMPT="$ASSESS_DIR/prompts/row.md"
 CATALOG_MD="$REPO_ROOT/.specs/agent-scenarios.md"
-CATALOG_JSON="$REPO_ROOT/.specs/agent-scenarios-coverage.json"
+CATALOG_JSON="$REPO_ROOT/.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json"
 
 die() { echo "error: $*" >&2; exit 2; }
 
@@ -189,11 +189,11 @@ cmd_commit() {
   echo "Maintainer next steps:"
   if [[ "$mode" == "--column" ]]; then
     echo "  1. Review verdicts: jq '.scenarios | to_entries[] | select(.value.confidence < 0.7)' $dst"
-    echo "  2. Update .specs/agent-scenarios-coverage.json column for agent \"$target\" where verdict + confidence look right."
+    echo "  2. Update .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json column for agent \"$target\" where verdict + confidence look right."
     echo "  3. Re-run column assess on agent version bump."
   else
     echo "  1. Review verdicts: jq '.adapters | to_entries[] | select(.value.confidence < 0.7)' $dst"
-    echo "  2. Update .specs/agent-scenarios-coverage.json row for scenario \"$target\" where verdict + confidence look right."
+    echo "  2. Update .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json row for scenario \"$target\" where verdict + confidence look right."
     echo "  3. Re-run row assess when the scenario's prose spec changes."
   fi
 }

--- a/.claude/skills/ir:onboard-agent/assess/schema/column.schema.json
+++ b/.claude/skills/ir:onboard-agent/assess/schema/column.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/ingo-eichhorst/Irrlicht/.claude/skills/ir:onboard-agent/assess/schema/column.schema.json",
   "title": "Agent applicability assessment result (column mode)",
-  "description": "Output of `/ir:onboard-agent assess --column <agent>`. Maps every scenario in .specs/agent-scenarios.md to a candidate applicability verdict for one agent, with citations. Consumed by the maintainer to update the coverage matrix; never auto-applied. Schema validates structural shape only — cross-referencing against the canonical scenario IDs (in .specs/agent-scenarios-coverage.json) is done at runtime by run-batch.sh.",
+  "description": "Output of `/ir:onboard-agent assess --column <agent>`. Maps every scenario in .specs/agent-scenarios.md to a candidate applicability verdict for one agent, with citations. Consumed by the maintainer to update the coverage matrix; never auto-applied. Schema validates structural shape only — cross-referencing against the canonical scenario IDs (in .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json) is done at runtime by run-batch.sh.",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "agent", "agent_version", "surveyed_at", "scenarios"],
@@ -36,7 +36,7 @@
     },
     "scenarios": {
       "type": "object",
-      "description": "Keyed by scenario ID (kebab-case slug from .specs/agent-scenarios-coverage.json). run-batch.sh enforces that every key resolves to a known scenario ID and that every scenario in the catalog appears.",
+      "description": "Keyed by scenario ID (kebab-case slug from .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json). run-batch.sh enforces that every key resolves to a known scenario ID and that every scenario in the catalog appears.",
       "additionalProperties": { "$ref": "#/definitions/scenarioVerdict" }
     }
   },
@@ -49,7 +49,7 @@
         "agent_supports": {
           "type": "string",
           "enum": ["yes", "no", "partial", "unknown"],
-          "description": "Mirrors the `agent_supports` axis of .specs/agent-scenarios-coverage.json so the survey can be diffed against the committed matrix cell-for-cell."
+          "description": "Mirrors the `agent_supports` axis of .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json so the survey can be diffed against the committed matrix cell-for-cell."
         },
         "confidence": {
           "type": "number",

--- a/.claude/skills/ir:onboard-agent/assess/schema/row.schema.json
+++ b/.claude/skills/ir:onboard-agent/assess/schema/row.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/ingo-eichhorst/Irrlicht/.claude/skills/ir:onboard-agent/assess/schema/row.schema.json",
   "title": "Scenario applicability assessment result (row mode)",
-  "description": "Output of `/ir:onboard-agent assess --row <scenario>`. Maps every adapter in .specs/agent-scenarios-coverage.json -> agents[] to a candidate applicability verdict for one scenario, with citations. Consumed by the maintainer to update the coverage matrix row-by-row; never auto-applied. Schema validates structural shape only — cross-referencing against canonical adapter IDs is done at runtime by run-batch.sh.",
+  "description": "Output of `/ir:onboard-agent assess --row <scenario>`. Maps every adapter in .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json -> agents[] to a candidate applicability verdict for one scenario, with citations. Consumed by the maintainer to update the coverage matrix row-by-row; never auto-applied. Schema validates structural shape only — cross-referencing against canonical adapter IDs is done at runtime by run-batch.sh.",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "scenario", "surveyed_at", "adapters"],
@@ -15,7 +15,7 @@
     "scenario": {
       "type": "string",
       "pattern": "^[a-z][a-z0-9_-]*$",
-      "description": "Scenario ID (kebab-case slug from .specs/agent-scenarios-coverage.json -> scenarios[].id)."
+      "description": "Scenario ID (kebab-case slug from .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json -> scenarios[].id)."
     },
     "scenario_version": {
       "type": "string",
@@ -36,7 +36,7 @@
     },
     "adapters": {
       "type": "object",
-      "description": "Keyed by adapter ID (lowercase slug from .specs/agent-scenarios-coverage.json -> agents[].id). Not every adapter has to appear — adapters whose capabilities[] don't include the scenario's required features may be omitted, with the implicit verdict 'n/a'. run-batch.sh checks that every key resolves to a known adapter ID.",
+      "description": "Keyed by adapter ID (lowercase slug from .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json -> agents[].id). Not every adapter has to appear — adapters whose capabilities[] don't include the scenario's required features may be omitted, with the implicit verdict 'n/a'. run-batch.sh checks that every key resolves to a known adapter ID.",
       "additionalProperties": { "$ref": "#/definitions/adapterVerdict" }
     }
   },
@@ -49,7 +49,7 @@
         "agent_supports": {
           "type": "string",
           "enum": ["yes", "no", "partial", "unknown"],
-          "description": "Mirrors the `agent_supports` axis of .specs/agent-scenarios-coverage.json so the row can be diffed against the committed matrix cell-for-cell."
+          "description": "Mirrors the `agent_supports` axis of .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json so the row can be diffed against the committed matrix cell-for-cell."
         },
         "confidence": {
           "type": "number",

--- a/.claude/skills/ir:onboard-agent/cell-lifecycle.md
+++ b/.claude/skills/ir:onboard-agent/cell-lifecycle.md
@@ -30,7 +30,7 @@ observe it?
 
 **Files:**
 
-- `.specs/agent-scenarios-coverage.json` — current-state rollup
+- `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json` — current-state rollup
   (gitignored, maintainer-owned in the main checkout). The matrix
   the overview reads.
 - `replaydata/agents/<agent>/scenarios/<scenario>/assessment.json` —
@@ -114,7 +114,7 @@ sources, and writes the JSON. Re-runs overwrite silently. See
 worked examples.
 
 **Transcription:** the maintainer copies the verdict + a one-line
-note from `assessment.json` into `.specs/agent-scenarios-coverage.json`.
+note from `assessment.json` into `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`.
 The artifact is the source-of-record; the matrix is the rollup the
 overview reads.
 

--- a/.claude/skills/ir:onboard-agent/recipe/SKILL.md
+++ b/.claude/skills/ir:onboard-agent/recipe/SKILL.md
@@ -102,7 +102,7 @@ maintainer fills the gap.
 
 - `<agent>` — the adapter slug (`claudecode`, `codex`, `pi`, `aider`,
   `opencode`).
-- `<scenario-id>` — the kebab id used in `.specs/agent-scenarios-coverage.json`
+- `<scenario-id>` — the kebab id used in `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`
   (e.g. `session-start`, `user-esc-interrupt`, `auto-executed-tool-call`).
 
 Worked examples committed (both under `scenarios.json -> scenarios[]`):
@@ -124,7 +124,7 @@ A single entry in `scenarios.json -> scenarios[]` with this shape:
 {
   "name": "<scenario-id>",                  // same as coverage_id by default
   "description": "<one-paragraph what+why>",// drawn from the spec's Scenario: text
-  "coverage_id": "<scenario-id>",           // joins to .specs/agent-scenarios-coverage.json
+  "coverage_id": "<scenario-id>",           // joins to .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json
   "idle_only": true|false,                  // true when there's no `send` step
   "requires": [...],                        // capability requirements
   "verify": {...},                          // top-level invariants
@@ -169,6 +169,8 @@ prerequisites, different agent CLIs) that can't share one
 recording.
 
 ► **Verify before moving on:**
+- [ ] Located the `### <scenario-id>` section in `.claude/skills/ir:onboard-agent/scenario-meanings.md` and read all five fields (Essence, User-observable signal, Primitive exercised, Not to be confused with, Conceptual flow).
+- [ ] If the scenario ID is missing from `scenario-meanings.md` — STOP. Ask the maintainer to add the entry before proceeding.
 - [ ] Captured every word of the Scenario: paragraph(s) and every
   Expected: bullet — paraphrasing loses precision.
 - [ ] Counted the number of variants. If >1, decide chain-in-one vs
@@ -182,7 +184,7 @@ recording.
 ### Step 2 — Read the verdict
 
 ```
-.specs/agent-scenarios-coverage.json   →   .scenarios[].coverage[<agent>]
+.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json   →   .scenarios[].coverage[<agent>]
 ```
 
 - `agent_supports == "yes"` → produce the recipe normally.
@@ -199,7 +201,7 @@ recording.
 
 ► **Verify before moving on:**
 - [ ] The verdict cell exists for `<agent>` in
-  `.specs/agent-scenarios-coverage.json` — no fabricating a column.
+  `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json` — no fabricating a column.
 - [ ] If `agent_supports == "partial"`, the coverage `notes` field
   is non-empty AND you understand the caveat well enough to mirror
   it into `preconditions`. If the notes are vague (e.g. "needs
@@ -613,7 +615,7 @@ the driver controls completion timing instead of inferring it from
 - It does not run the recording. After the recipe is in
   `scenarios.json`, the maintainer runs `/ir:onboard-agent <agent>
   <scenario>` (or `--attach <agent> <scenario>`) to actually record.
-- It does not modify `.specs/agent-scenarios-coverage.json`. The
+- It does not modify `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`. The
   coverage file is the maintainer's editorial truth; the recipe in
   `scenarios.json` is the operational instance.
 - It does not edit `.specs/agent-scenarios.md`. The recipe skill

--- a/.claude/skills/ir:onboard-agent/record/SKILL.md
+++ b/.claude/skills/ir:onboard-agent/record/SKILL.md
@@ -186,5 +186,5 @@ mv "$LATEST_ARCHIVE"/{events,transcript,manifest}.json[l]* "$SCENARIO_DIR"/
   [`../spec/SKILL.md`](../spec/SKILL.md). Without `expected.jsonl`,
   promote-recording.sh skips validation and just stamps the
   manifest with `expected_pass_rate: "no spec"`.
-- It does not modify `.specs/agent-scenarios-coverage.json`. The
+- It does not modify `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`. The
   matrix rollup is the maintainer's editorial truth.

--- a/.claude/skills/ir:onboard-agent/scenario-meanings.md
+++ b/.claude/skills/ir:onboard-agent/scenario-meanings.md
@@ -1,0 +1,595 @@
+# Scenario Meanings
+
+Canonical semantic spec for every scenario in the catalog. Each section is keyed by scenario ID (the kebab slug used in `scenarios.json` and `replaydata/`).
+
+**Recipe and assess skills:** read this file at Step 1 to get the "What this means" block before reading the Scenario/Expected text from `.specs/agent-scenarios.md` (or the `/api/catalog` fallback). If a scenario ID is missing from this file, stop and ask the maintainer to add it.
+
+Five fields per scenario:
+- **Essence** — one sentence: what user action or system event is being exercised.
+- **User-observable signal** — what appears in the dashboard proving this happened.
+- **Primitive exercised** — the capability this depends on; maps to a `capabilities.json` key. Name the specific API surface.
+- **Not to be confused with** — adjacent scenarios and the distinction.
+- **Conceptual flow** — ordered bullets at user/agent/dashboard level. No event-kind names, no tmux commands.
+
+---
+
+### session-start
+
+- **Essence:** The daemon discovers a newly launched agent process and surfaces a visible session row before the agent does anything.
+- **User-observable signal:** Session row appears in `ready` within 1 second of agent launch; PID is bound.
+- **Primitive exercised:** Process discovery via PID scan + first transcript write detection. Requires `headless_mode`.
+- **Not to be confused with:** `session-resume` — an existing `session_id` reappears under a new PID; `session-reset` — a new session follows an intentional in-app reset.
+- **Conceptual flow:**
+  1. User launches the agent in a fresh directory.
+  2. Daemon's PID scanner picks up the new process.
+  3. Daemon tails the agent's transcript file.
+  4. Session row appears in the dashboard in state `ready`.
+  5. PID is bound to the session.
+
+---
+
+### session-end
+
+- **Essence:** The daemon correctly removes a session after the agent exits cleanly, is killed, or crashes mid-turn.
+- **User-observable signal:** Session row disappears within the expected TTL; state immediately before disappearing is `ready`.
+- **Primitive exercised:** Process-exit detection (SIGKILL, clean exit, crash) plus idle-TTL expiry. No special agent capability beyond `headless_mode`.
+- **Not to be confused with:** `session-resume` — a killed session reappears with the same `session_id`; `session-reset` — user triggers a new session inside the running agent.
+- **Conceptual flow:**
+  1. Agent exits, is killed, or crashes.
+  2. Daemon detects process exit within one sweep interval.
+  3. If state was `working`, it resolves to `ready`.
+  4. Session row disappears within `readyTTL`.
+
+---
+
+### long-idle-live-session
+
+- **Essence:** A session whose agent process is still alive is NOT pruned even after `readyTTL`, and resumes normally on the next prompt.
+- **User-observable signal:** Session row persists in `ready` past `readyTTL`; `ready → working` resumes correctly on the next user prompt.
+- **Primitive exercised:** Process-liveness check — daemon polls the PID to distinguish "idle but alive" from "dead and eligible for pruning". Requires `headless_mode`.
+- **Not to be confused with:** `session-end` via SIGKILL-mid-idle — process is actually dead; `token-quota-exhausted` — session is alive but agent can't produce new turns.
+- **Conceptual flow:**
+  1. Agent finishes a turn and enters `ready`.
+  2. User sends no prompts for an extended period (past `readyTTL`).
+  3. Daemon checks the PID — process is still alive.
+  4. Session row remains visible in `ready`.
+  5. User eventually sends a prompt; `ready → working` resumes normally.
+
+---
+
+### session-resume
+
+- **Essence:** When an agent is re-launched pointing at a prior session, irrlicht presents a single continuous session row across multiple PID lifetimes.
+- **User-observable signal:** Same `session_id` row reappears after relaunch; state and history are preserved; each new PID lifetime drives its own state transitions correctly.
+- **Primitive exercised:** `session_id_assignment` — agent uses a stable session ID across PID lifetimes (via `--resume` flag or equivalent).
+- **Not to be confused with:** `session-start` — fresh session with a brand-new `session_id`; `session-reset` — intentional new-ID restart inside the running agent.
+- **Conceptual flow:**
+  1. Agent runs, does work, and exits cleanly.
+  2. User re-launches the agent with a resume flag pointing at the prior session.
+  3. Daemon sees the same `session_id` become active under a new PID.
+  4. Dashboard shows the original session row — not a new one.
+  5. New turns proceed; each lifetime's arc is independently correct.
+
+---
+
+### session-reset
+
+- **Essence:** User deliberately abandons the current conversation inside the running agent and gets a clean slate with a new session ID.
+- **User-observable signal:** Old session row disappears; a new session row appears with a different `session_id` in `ready`.
+- **Primitive exercised:** `slash_commands` — agent's reset command (`/clear`, `/new`, `/reset`) ends the current session in-process and starts a fresh one without relaunching the binary.
+- **Not to be confused with:** Quitting and relaunching (which looks similar but is `session-end` + `session-start`); `checkpoint-rewind` — rewinds history but keeps the same `session_id`.
+- **Conceptual flow:**
+  1. User is in an active session.
+  2. User issues the agent's reset command.
+  3. Old session row disappears.
+  4. New session row appears with a new `session_id` in `ready`.
+
+---
+
+### checkpoint-rewind
+
+- **Essence:** User rolls back files and/or conversation state to an earlier checkpoint; irrlicht reflects the restored state correctly and subsequent turns proceed from the rewound point.
+- **User-observable signal:** Session row shows state `ready` after rewind; same `session_id` if rewound in place, or a linked new `session_id` if the adapter forks; turns after the rewind follow a clean arc.
+- **Primitive exercised:** Checkpoint/branch capability (adapter-specific: Cline shadow-git rewind, Plandex plan branches, Replit checkpoint, Cursor rewind). Maps to `checkpoint_rewind` in `capabilities.json` when present.
+- **Not to be confused with:** `session-reset` — discards history and starts fresh; `session-resume` — resumes after exit rather than rewinding within a running session.
+- **Conceptual flow:**
+  1. Agent is in `ready` after some turns.
+  2. User triggers the adapter's rewind to an earlier checkpoint.
+  3. Files and/or conversation state are restored.
+  4. Session row reflects state `ready`.
+  5. Next user prompt starts cleanly from the rewound point: `ready → working → ready`.
+
+---
+
+### cloud-background-agent
+
+- **Essence:** Agent runs in a cloud VM or container with no local PID; irrlicht tracks it via an API feed or sidecar rather than process scanning.
+- **User-observable signal:** Session appears with PID = 0 or absent; state transitions mirror the remote agent's progress; session disappears when the remote run completes or errors.
+- **Primitive exercised:** Remote-process transport (API feed, sidecar, webhook). Maps to `cloud_agent` in `capabilities.json` when present. Requires an adapter that does NOT rely on `FilesUnderRoot` or `FilesUnderCWD`.
+- **Not to be confused with:** `background-subagent` — runs a local agent session detached from the parent; `session-start` — relies on local PID discovery.
+- **Conceptual flow:**
+  1. User triggers a cloud/remote agent run.
+  2. Daemon connects to the remote feed.
+  3. Session appears in the dashboard with PID = 0 or absent.
+  4. State transitions mirror the remote agent's progress.
+  5. Session disappears when the remote run completes, errors, or is dismissed.
+
+---
+
+### basic-turn
+
+- **Essence:** The simplest possible turn — one user message, one assistant reply, no tool use — validates that the parser correctly identifies a turn boundary.
+- **User-observable signal:** `ready → working → ready`; `TotalTokens > 0` after the turn.
+- **Primitive exercised:** Transcript turn-end detection — parser identifies the end of an assistant message as a complete turn boundary. Requires `headless_mode`.
+- **Not to be confused with:** `auto-executed-tool-call` — same state arc but with tool calls; `synchronous-slash-command` — no LLM call at all; `streaming-partial-writes` — focuses on partial flush behavior.
+- **Conceptual flow:**
+  1. Agent is in `ready`.
+  2. User sends a simple prompt.
+  3. State transitions `ready → working`.
+  4. Agent emits one assistant reply and the turn-end signal.
+  5. State returns to `ready`. Token count is non-zero.
+
+---
+
+### auto-executed-tool-call
+
+- **Essence:** Agent uses tools mid-turn but completes without ever blocking on user input — state never enters `waiting`.
+- **User-observable signal:** `ready → working → ready`; state never entered `waiting`.
+- **Primitive exercised:** `tool_calls` — agent can invoke tools and resume autonomously without user approval for any of them.
+- **Not to be confused with:** `user-blocking-question` — a tool triggers a user question; `tool-gate-permission-prompt` — a tool requires explicit permission; `auto-classified-permission` — some but not all tools auto-approve.
+- **Conceptual flow:**
+  1. Agent is in `ready`.
+  2. User sends a prompt requiring tool use.
+  3. State transitions `ready → working`.
+  4. Agent calls one or more tools; all auto-resolve without user input.
+  5. Agent emits the turn-end signal; state returns to `ready`.
+
+---
+
+### self-correction-iteration
+
+- **Essence:** Agent fails a tool call, interprets the failure, and retries with corrected input — multiple cycles within one turn — with no state flicker between retries.
+- **User-observable signal:** State stays continuously `working` across all retry cycles; no flicker to `ready` or `waiting` between attempts; final state is `ready` (or `waiting` if the agent gives up and asks).
+- **Primitive exercised:** `tool_calls` + iterative retry within a single turn. The key irrlicht primitive is the classifier holding the session in `working` across multi-step retry chains that span multiple tool-call/result pairs without an intervening turn boundary.
+- **Not to be confused with:** `long-agentic-session-stress` — many separate turns driven by user prompts; `turn-aborted-by-error` — agent gives up and provider error closes the turn.
+- **Conceptual flow:**
+  1. Agent is in `ready`.
+  2. User asks the agent to run tests, build, or lint.
+  3. State transitions `ready → working`.
+  4. Agent runs the tool; result is a failure.
+  5. Agent retries with corrected input — state stays `working`, no flicker.
+  6. Retry cycles repeat until success or give-up.
+  7. State returns to `ready` (or `waiting` if the agent asks the user).
+
+---
+
+### synchronous-slash-command
+
+- **Essence:** User invokes a slash command that responds locally without calling the model; the session stays `ready` throughout with no `→ working` transition.
+- **User-observable signal:** State stays `ready`; no `→ working` transition recorded for the slash command itself.
+- **Primitive exercised:** `slash_commands` — agent has in-process commands (`/help`, `/cost`, `/status`, `/model`) that respond without an LLM round-trip.
+- **Not to be confused with:** `context-compaction` — `/compact` DOES call the model; `session-reset` — `/clear` or `/new` ends the session; `basic-turn` — always calls the model.
+- **Conceptual flow:**
+  1. Agent is in `ready`.
+  2. User invokes a no-LLM slash command (e.g. `/help`, `/cost`).
+  3. Agent responds locally with no model call.
+  4. State stays `ready` throughout.
+
+---
+
+### long-agentic-session-stress
+
+- **Essence:** A realistic multi-turn session with complex tool use validates that state tracking stays coherent over a large transcript volume — no flicker, no stuck states.
+- **User-observable signal:** Within each turn, state stays continuously `working`; between turns, clean `working → ready` and `ready → working` transitions; state never stuck.
+- **Primitive exercised:** `tool_calls` + `headless_mode`. Stress-tests the transcript parser's ability to stay coherent across a large volume of interleaved assistant messages and tool-call/result pairs.
+- **Not to be confused with:** `autonomous-loop` — no user prompts between iterations; `self-correction-iteration` — retry cycles within one turn, not across many turns.
+- **Conceptual flow:**
+  1. Agent starts in `ready`.
+  2. User sends a complex prompt; state transitions `ready → working`.
+  3. Agent calls multiple tools, emits multiple assistant fragments — state stays `working`.
+  4. Turn ends; state transitions `working → ready`.
+  5. Repeat for many turns.
+  6. After the final turn: state reaches `ready` and stays there.
+
+---
+
+### autonomous-loop
+
+- **Essence:** Agent drives itself through an entire task goal with no user prompts between internal iterations; irrlicht keeps the session in `working` for the whole autonomous run.
+- **User-observable signal:** `ready → working` at loop start; state stays `working` for the entire run with no `ready` between internal iterations; `working → ready` when the goal is reached.
+- **Primitive exercised:** Autonomous-mode / self-prompting capability (Codex `/goal`, Plandex full-auto, SWE-agent, Goose recipe). Maps to `autonomous_mode` in `capabilities.json`. The key irrlicht primitive is keeping the session in `working` across internally-generated turn boundaries where no user prompt separates iterations.
+- **Not to be confused with:** `autonomous-loop-iteration-limit` — same primitive but stops at a cap before completion; `long-agentic-session-stress` — user-driven turns, no self-prompting.
+- **Conceptual flow:**
+  1. User starts the agent in autonomous mode (e.g. `/goal <condition>`).
+  2. State transitions `ready → working`.
+  3. Agent generates and executes its own next steps with no user prompts.
+  4. State stays `working` throughout all internal iterations.
+  5. Agent reaches the stated goal; state transitions `working → ready`.
+
+---
+
+### autonomous-loop-iteration-limit
+
+- **Essence:** Autonomous-mode agent hits its max-iteration cap before completing; irrlicht resolves to `ready` cleanly rather than getting stuck.
+- **User-observable signal:** State reaches `ready` even though the agent did not fully succeed; does not stick in `working`.
+- **Primitive exercised:** Iteration cap enforcement — the agent CLI has a configurable max-step limit and emits a clean turn-end signal when it hits the cap. Maps to `autonomous_mode` in `capabilities.json`.
+- **Not to be confused with:** `token-quota-exhausted` — a cost/token budget limit, not an iteration count; `turn-aborted-by-error` — an unplanned provider error rather than a planned cap.
+- **Conceptual flow:**
+  1. Agent is running in autonomous mode; state is `working`.
+  2. Agent reaches its configured max-iteration count.
+  3. Agent emits a terminal turn signal and stops self-prompting.
+  4. State transitions `working → ready`.
+
+---
+
+### token-quota-exhausted
+
+- **Essence:** Agent hits a hard token or subscription cost cap mid-turn; session resolves cleanly to `ready` and does not re-enter `working` until the budget resets.
+- **User-observable signal:** State reaches `ready`; subsequent user prompts stay `ready` until the budget resets.
+- **Primitive exercised:** Budget enforcement — the agent CLI enforces a token or time budget and emits a turn-end signal when the cap is hit. Maps to the adapter's standard turn-end path.
+- **Not to be confused with:** `autonomous-loop-iteration-limit` — iteration count cap, not a cost/token cap; `turn-aborted-by-error` — unexpected provider error, not a self-imposed budget.
+- **Conceptual flow:**
+  1. Agent is `working` through a long turn.
+  2. Agent hits its token or cost budget.
+  3. Agent emits a turn-end signal and stops.
+  4. State transitions `working → ready`.
+  5. Further user prompts keep the session in `ready` until budget resets.
+
+---
+
+### mid-turn-message-queued
+
+- **Essence:** User sends a follow-up while the agent is mid-turn; the agent runtime queues it and keeps processing, with no state flicker on arrival.
+- **User-observable signal:** State stays `working` when the queued message arrives; no `→ ready` flicker; cycle eventually ends at `ready`.
+- **Primitive exercised:** Message-queue handling — the agent's runtime buffers a user message during an active turn without emitting a turn boundary. The irrlicht primitive is that the transcript does NOT emit a turn boundary when the queued message arrives.
+- **Not to be confused with:** `user-blocking-question` — AGENT pauses for user input, not user sending unsolicited mid-turn input; `streaming-partial-writes` — about partial assistant content, not queued user input.
+- **Conceptual flow:**
+  1. Agent is `working` through a long turn.
+  2. User types a follow-up message.
+  3. Agent runtime queues it; the transcript shows no turn boundary.
+  4. State stays `working` throughout.
+  5. Agent finishes the current turn; picks up the queued message; cycle ends at `ready`.
+
+---
+
+### auto-classified-permission
+
+- **Essence:** An internal classifier auto-approves safe tool calls but gates risky ones, producing a `waiting` state only for risky ones.
+- **User-observable signal:** Safe calls: `ready → working → ready`, never entering `waiting`; risky call: `working → waiting`; after user approval, `waiting → working → ready`.
+- **Primitive exercised:** `permission_hooks` — agent's auto-permission classifier distinguishes safe from risky tool calls and selectively prompts the user only for risky ones.
+- **Not to be confused with:** `tool-gate-permission-prompt` — EVERY tool call requires explicit approval; `auto-executed-tool-call` — ALL calls auto-approve with no gating.
+- **Conceptual flow:**
+  1. Agent is in `ready`.
+  2. User sends a prompt involving both safe edits and one risky shell command.
+  3. Safe tool calls execute; state stays `working`, never entering `waiting`.
+  4. Risky tool call: state transitions `working → waiting`.
+  5. User approves; state transitions `waiting → working → ready`.
+
+---
+
+### context-compaction
+
+- **Essence:** Context window fills or user invokes compaction; the agent summarizes the conversation in place (via an LLM call) and irrlicht keeps the session in `working` throughout.
+- **User-observable signal:** `ready → working` at compaction start; state stays `working` throughout; `working → ready` when done; no further transitions until the next user prompt.
+- **Primitive exercised:** `context_curation` / compaction command (e.g. Claude Code `/compact`). Agent makes an LLM call to summarize context and emits a turn-end signal when complete.
+- **Not to be confused with:** `synchronous-slash-command` — uses no LLM; `basic-turn` — normal user-driven turn with no compaction; `autonomous-loop` — self-prompting is not compaction.
+- **Conceptual flow:**
+  1. Agent is in `ready`.
+  2. User invokes `/compact` or auto-compaction triggers.
+  3. State transitions `ready → working`.
+  4. Agent makes an LLM summarization call; state stays `working`.
+  5. Agent emits the turn-end signal; state transitions `working → ready`.
+
+---
+
+### turn-end-terminal-text
+
+- **Essence:** The parser correctly detects adapter-specific end-of-turn signals and resolves the session to `ready` regardless of which adapter's terminal token ends the turn.
+- **User-observable signal:** `ready → working → ready`; state reaches `ready` regardless of which adapter-specific signal closes the turn.
+- **Primitive exercised:** Turn-end parsing — adapter emits or parser detects the correct end-of-turn token (`stop_reason: end_turn`, `task_complete`, `stopReason: stop`, etc.).
+- **Not to be confused with:** `turn-aborted-by-error` — no normal end signal arrives; `streaming-partial-writes` — focuses on partial flushes before the final end signal; `basic-turn` — the claudecode baseline.
+- **Conceptual flow:**
+  1. Agent is in `ready`.
+  2. User sends a prompt; state transitions `ready → working`.
+  3. Agent emits the adapter-specific turn-end signal.
+  4. Parser recognizes the signal; state returns to `ready`.
+
+---
+
+### turn-aborted-by-error
+
+- **Essence:** The model call fails mid-turn with no turn-end signal; the daemon's sweep detects the stall and resolves the session to `ready`.
+- **User-observable signal:** State reaches `ready` within one sweep interval after the failure; does not stick in `working`.
+- **Primitive exercised:** Sweep-based stall detection — daemon's periodic sweep identifies sessions stuck in `working` after a process event or timeout and forces a `→ ready` transition.
+- **Not to be confused with:** `autonomous-loop-iteration-limit` — planned cap exit; `token-quota-exhausted` — self-imposed budget exit; `user-esc-interrupt` — user-driven cancel.
+- **Conceptual flow:**
+  1. Agent is `working` through a turn.
+  2. Provider call fails (network error, 5xx, timeout); no turn-end signal is emitted.
+  3. Agent gives up.
+  4. Daemon's sweep detects the session stuck in `working`.
+  5. State resolves to `ready` within the sweep interval.
+
+---
+
+### shell-escape-command
+
+- **Essence:** Agent runs a shell command outside the formal tool framework; irrlicht stays `working` during execution and resolves to `ready` when the command exits.
+- **User-observable signal:** `ready → working → ready`; state does not stick in `working` after the shell command exits.
+- **Primitive exercised:** Shell-escape mechanism (Claude Code `!cmd`, or analogous). The irrlicht primitive is that the parser handles shell-escape output (distinct from a formal tool-call/result pair) and still resolves to `ready`.
+- **Not to be confused with:** `auto-executed-tool-call` — uses the formal tool framework; `background-process` — a detached process that keeps the session `working` past the turn.
+- **Conceptual flow:**
+  1. Agent is in `ready`.
+  2. User sends a prompt containing a shell escape (e.g. `!ls`).
+  3. State transitions `ready → working`.
+  4. Shell command runs and exits.
+  5. State returns to `ready`.
+
+---
+
+### oversized-transcript-line
+
+- **Essence:** A single transcript event is unusually large; the parser handles it without stalling and the session resolves to `ready` normally.
+- **User-observable signal:** `ready → working → ready`; no parser stall causing stuck `working`.
+- **Primitive exercised:** Parser robustness — transcript tailer and line parser correctly handle lines exceeding normal size (>2 MB). No special agent capability required.
+- **Not to be confused with:** `long-agentic-session-stress` — many turns with large total volume, not a single oversized line; `streaming-partial-writes` — partial assistant content flushes.
+- **Conceptual flow:**
+  1. Agent is in `ready`.
+  2. User sends a prompt triggering very large tool output (e.g. a base64 artifact or long diff).
+  3. State transitions `ready → working`.
+  4. The oversized transcript line is buffered and parsed without stalling.
+  5. State returns to `ready`.
+
+---
+
+### user-blocking-question
+
+- **Essence:** Agent pauses mid-turn to ask the user a question via a dedicated question tool; the dashboard enters `waiting` and stays there until the user replies.
+- **User-observable signal:** `ready → working → waiting`; after user replies, `waiting → working → ready`; the `waiting` episode is visible (no skip-over).
+- **Primitive exercised:** `tool_calls` + AskUserQuestion (or adapter equivalent) — agent can pause mid-turn and await structured user input via a dedicated question tool call.
+- **Not to be confused with:** `tool-gate-permission-prompt` — a tool requires explicit permission, not a question; `user-blocking-plan-mode-approval` — pause is for plan review; `mid-turn-message-queued` — USER sends unsolicited input, agent doesn't request it.
+- **Conceptual flow:**
+  1. Agent is `working` through a turn.
+  2. Agent calls AskUserQuestion and pauses.
+  3. State transitions `working → waiting`.
+  4. User sees the question and types a reply.
+  5. State transitions `waiting → working`; agent completes the turn.
+  6. State reaches `ready`.
+
+---
+
+### user-blocking-plan-mode-approval
+
+- **Essence:** Agent emits a plan and halts for user approval; irrlicht shows `waiting` during the approval pause and never enters `ready` between plan emission and the user's response.
+- **User-observable signal:** `ready → working → waiting`; state never entered `ready` between plan emission and user reply; after approval, `waiting → working → ready`.
+- **Primitive exercised:** `plan_mode` — agent has a plan-review gate (Claude Code `ExitPlanMode`, Codex `<proposed_plan>` block) that blocks further progress until the user approves or dismisses.
+- **Not to be confused with:** `user-blocking-question` — pause is an AskUserQuestion call; `tool-gate-permission-prompt` — pause is a tool permission request.
+- **Conceptual flow:**
+  1. Agent is `working`.
+  2. Agent emits a plan and enters plan-mode pause.
+  3. State transitions `working → waiting`.
+  4. User reviews the plan and approves (or dismisses with a new prompt).
+  5. State transitions `waiting → working → ready`.
+
+---
+
+### tool-gate-permission-prompt
+
+- **Essence:** A tool call triggers an explicit permission prompt; the dashboard enters `waiting` until the user resolves it, and a late post-tool hook does NOT bounce the session back.
+- **User-observable signal:** `ready → working → waiting`; after user resolves, `waiting → working → ready`; a delayed post-tool hook arriving after `→ ready` does NOT change state.
+- **Primitive exercised:** `permission_hooks` — agent's tool framework has an explicit permission prompt that blocks execution until the user approves or denies.
+- **Not to be confused with:** `auto-classified-permission` — safe calls auto-approve and only risky ones gate; `user-blocking-question` — pause is an AskUserQuestion call, not a permission gate.
+- **Conceptual flow:**
+  1. Agent is `working`.
+  2. Agent attempts a tool call requiring permission; state transitions `working → waiting`.
+  3. User approves or denies; state transitions `waiting → working`.
+  4. Agent completes the turn; state reaches `ready`.
+  5. A delayed PostToolUse hook arrives; state stays `ready`.
+
+---
+
+### user-esc-interrupt
+
+- **Essence:** User cancels a running turn mid-response with the interrupt key before the agent finishes; state resolves cleanly to `ready`, and the next prompt proves the parser reset.
+- **User-observable signal:** `ready → working → ready`; state does not stick in `working` post-interrupt.
+- **Primitive exercised:** Interrupt-during-turn — agent CLI exposes a cancel signal (ESC for claudecode/codex/pi, Ctrl-C for aider) and resets cleanly so the next prompt drives a fresh `ready → working → ready` arc.
+- **Not to be confused with:** Pressing ESC while the agent is already idle (no-op, state stays `ready`); `turn-aborted-by-error` — turn ends without user action due to a provider error.
+- **Conceptual flow:**
+  1. Agent is idle in `ready`.
+  2. User sends a prompt that will take >2s to answer.
+  3. State transitions `ready → working`.
+  4. Before the agent emits a turn-done marker, user presses the interrupt key.
+  5. State transitions `working → ready`.
+  6. Next user prompt drives a clean `ready → working → ready` arc (proving the parser reset).
+
+---
+
+### streaming-partial-writes
+
+- **Essence:** The assistant message arrives in multiple partial flushes before the turn-end signal; state stays `working` across all flushes with no premature `→ ready`.
+- **User-observable signal:** `ready → working → ready`; state stays `working` across all partial flushes — no flicker to `ready` before the turn-end signal arrives.
+- **Primitive exercised:** `streaming_output` — agent emits assistant content in incremental chunks before the final turn-end signal. The irrlicht primitive is that partial flushes do NOT trigger a `→ ready` transition.
+- **Not to be confused with:** `basic-turn` — arrives as a single flush; `mid-turn-message-queued` — partial state is about queued user input, not streamed assistant output.
+- **Conceptual flow:**
+  1. Agent is in `ready`; user sends a prompt.
+  2. State transitions `ready → working`.
+  3. Agent emits the first partial chunk — state stays `working`.
+  4. Agent emits additional chunks — no flicker.
+  5. Agent emits the turn-end signal; state transitions `working → ready`.
+
+---
+
+### foreground-subagent
+
+- **Essence:** Parent agent spawns one or more child agents in the foreground; parent stays `working` until all children complete; children are linked by `ParentSessionID` and counted in `SubagentCount`.
+- **User-observable signal:** Child sessions appear with `ParentSessionID = parent.session_id`; `SubagentCount(parent) = N` while N children are alive; `SubagentCount` decreases as each child finishes; parent transitions `working → ready` only after the last child ends.
+- **Primitive exercised:** `subagents` — agent can spawn child sessions (Agent/Task tool) that run in a forked context, are linked to the parent by `session_id`, and hold the parent in `working` until they complete.
+- **Not to be confused with:** `background-subagent` — parent returns to `ready` while child continues independently; `background-process` — a shell process, not an agent session; `task-tool` — the todo-list variant of task management, not subagent spawning.
+- **Conceptual flow:**
+  1. Parent is `working`.
+  2. Parent spawns one or more foreground children via Agent/Task tool.
+  3. Child sessions appear in the dashboard, linked to the parent by `ParentSessionID`.
+  4. `SubagentCount(parent)` reflects the live child count.
+  5. Each child completes; `SubagentCount` decreases.
+  6. Parent transitions `working → ready` once the last child ends.
+
+---
+
+### task-tool
+
+- **Essence:** Agent uses the Task tool to create and manage a todo list within its own session, without spawning separate child sessions.
+- **User-observable signal:** State follows a normal `ready → working → ready` arc; `SubagentCount` stays at 0 — no child sessions appear.
+- **Primitive exercised:** Task/todo-list management via the Task tool (internal to the agent's own session). Distinct from the Agent tool which actually spawns child sessions.
+- **Not to be confused with:** `foreground-subagent` — the Agent tool spawns real child sessions with their own `session_id`; `background-subagent` — a detached child session.
+- **Conceptual flow:**
+  1. Agent is in `ready`.
+  2. User asks the agent to plan and track work.
+  3. State transitions `ready → working`.
+  4. Agent creates/reads/updates todo items via the Task tool — no child sessions appear.
+  5. State transitions `working → ready`; `SubagentCount` remains 0.
+
+---
+
+### background-subagent
+
+- **Essence:** Parent delegates to a background child via SendMessage and returns to `ready`; the child continues running independently without holding the parent.
+- **User-observable signal:** Parent transitions `working → ready` at turn end; child state is unchanged by parent's transition; `SubagentCount(parent)` excludes the background child.
+- **Primitive exercised:** `subagents` + background dispatch (SendMessage or equivalent) — agent can spawn a child that runs without holding the parent session open.
+- **Not to be confused with:** `foreground-subagent` — parent waits for the child before going `ready`; `background-process` — a shell process, not an agent session.
+- **Conceptual flow:**
+  1. Parent is `working`.
+  2. Parent sends a message to a background child and ends its own turn.
+  3. Parent transitions `working → ready` at turn end.
+  4. Background child continues running independently.
+  5. Background child eventually completes; its session disappears within `readyTTL`.
+
+---
+
+### background-process
+
+- **Essence:** Agent spawns a long-running shell process detached from the turn; the session stays `working` while the background process is alive and resolves only when it exits.
+- **User-observable signal:** `ready → working`; `BackgroundProcessCount > 0` while any background process is alive; agent stays `working` until the last background process exits; then `→ ready`.
+- **Primitive exercised:** Background process management (`run_in_background: true` or shell `&`) — agent can launch detached shell processes and the daemon tracks their liveness separately from transcript turn boundaries.
+- **Not to be confused with:** `background-subagent` — an agent session with a `session_id`, not a shell process; `auto-executed-tool-call` — tools complete synchronously before the turn ends.
+- **Conceptual flow:**
+  1. Agent is `working`.
+  2. Agent calls a tool with `run_in_background: true` (or equivalent); tool returns immediately.
+  3. `BackgroundProcessCount > 0` appears in the dashboard.
+  4. Background process eventually exits.
+  5. Agent transitions `working → ready`.
+
+---
+
+### subagent-orphan-cleanup
+
+- **Essence:** After a daemon restart, all orphaned session transcripts (no matching live PID) are correctly cleaned up; state never transitions to `working` during cleanup.
+- **User-observable signal:** All orphaned sessions disappear after the restart sweep; state never transitioned to `working` during cleanup.
+- **Primitive exercised:** Orphan detection — daemon's startup sweep identifies sessions whose PIDs no longer exist and removes them without re-entering `working`.
+- **Not to be confused with:** `session-end` via SIGKILL — handled during normal daemon operation, not on restart; `background-subagent` ending — expected child sessions that complete normally.
+- **Conceptual flow:**
+  1. Multiple parent + child sessions are running.
+  2. Daemon restarts.
+  3. Daemon performs a startup sweep of all known session transcripts.
+  4. Sessions whose PIDs no longer exist are identified as orphans.
+  5. All orphaned sessions disappear; no `working` transition during cleanup.
+
+---
+
+### multiple-sessions-same-cwd
+
+- **Essence:** Two agent instances sharing a working directory are tracked as independent sessions without state flapping or PID cross-contamination.
+- **User-observable signal:** Two distinct session rows appear with separate `session_id`s and PIDs; each transitions state independently; no flapping between rows.
+- **Primitive exercised:** PID-based session isolation — daemon correctly binds each session to its own PID even when multiple agents share the same transcript directory and filename pattern.
+- **Not to be confused with:** `session-resume` — one `session_id` reuses a directory across PID lifetimes; `multiple-agents-same-workspace` — different agent types, not duplicate instances of the same agent.
+- **Conceptual flow:**
+  1. Two instances of the same agent are launched in the same directory.
+  2. Two distinct session rows appear in the dashboard.
+  3. Each session's state transitions independently.
+  4. PID-to-session binding is stable and does not cross-contaminate.
+
+---
+
+### multiple-agents-same-workspace
+
+- **Essence:** Different agent types running concurrently in the same project directory are each shown with the correct adapter label and fully independent state and metrics.
+- **User-observable signal:** Each session appears with its correct adapter label; states transition independently; no cross-contamination of metrics, parent linkage, or subagent counts.
+- **Primitive exercised:** Multi-adapter coexistence — daemon handles simultaneous sessions from different agent types without merging their metrics, state, or subagent counts.
+- **Not to be confused with:** `multiple-sessions-same-cwd` — duplicate instances of the same agent; `foreground-subagent` — intentional parent-child relationships between sessions.
+- **Conceptual flow:**
+  1. One instance of Agent A and one instance of Agent B are launched in the same project directory.
+  2. Each appears in the dashboard with its correct adapter label.
+  3. Turns in Agent A do not affect Agent B's state, and vice versa.
+  4. Metrics (tokens, model, subagent counts) are tracked separately per session.
+
+---
+
+### token-accounting
+
+- **Essence:** Token counts accumulate correctly across turns and accurately reflect cache usage when a cached turn runs.
+- **User-observable signal:** `TotalTokens > 0` after turn 1; `TotalTokens` non-decreasing after turn 2; `CacheReadTokens > 0` and fresh input tokens = 0 for a fully-cached turn.
+- **Primitive exercised:** Token reporting — agent's transcript includes per-turn token counts (input, output, cache read/write) in a field the parser can extract. Requires `headless_mode` with token data in the transcript format.
+- **Not to be confused with:** `model-identification` — validates model name and context window, not token counts; `token-quota-exhausted` — hitting a limit, not measuring cumulative usage.
+- **Conceptual flow:**
+  1. Agent runs turn 1; after turn 1: `TotalTokens > 0` in the dashboard.
+  2. Agent runs turn 2; after turn 2: `TotalTokens` ≥ turn-1 total.
+  3. Agent runs a turn that fits entirely in prompt cache.
+  4. `CacheReadTokens > 0`; fresh input tokens for that turn = 0.
+
+---
+
+### model-identification
+
+- **Essence:** The dashboard correctly shows the model name and context window for the model the agent was launched with — not "unknown".
+- **User-observable signal:** `ModelName = <launch model>` (not `"unknown"`); `ContextWindow` matches the model's published window.
+- **Primitive exercised:** Model metadata reporting — agent's transcript includes the model name and context window size in a field the parser can extract.
+- **Not to be confused with:** `model-switch-midsession` — tests model changes between turns; `architect-editor-pair` — tests two simultaneous models within one turn.
+- **Conceptual flow:**
+  1. Agent is launched with a specific non-default model.
+  2. Agent completes a turn.
+  3. `ModelName` in the dashboard reflects the configured model (not `"unknown"`).
+  4. `ContextWindow` matches the model's published context window size.
+
+---
+
+### model-switch-midsession
+
+- **Essence:** Agent changes its model between turns; the dashboard updates `ModelName` to reflect the latest model used, and token counts continue accumulating.
+- **User-observable signal:** After turn 1: `ModelName = <model A>`; after turn 2: `ModelName = <model B>`; `TotalTokens` after turn 2 > after turn 1.
+- **Primitive exercised:** Per-turn model selection — agent can change models between turns (via `/model` or config) and the transcript reflects the new model in each turn's usage metadata.
+- **Not to be confused with:** `model-identification` — static model throughout the session; `architect-editor-pair` — two models simultaneously within one turn; `provider-failover-midturn` — automatic failover, not user-driven switching.
+- **Conceptual flow:**
+  1. Agent runs turn 1 with model A.
+  2. User changes the model (via `/model` or config).
+  3. Agent runs turn 2 with model B.
+  4. Dashboard shows `ModelName = <model B>` after turn 2.
+  5. `TotalTokens` after turn 2 > after turn 1 (accumulates across model changes).
+
+---
+
+### architect-editor-pair
+
+- **Essence:** One turn uses two models — a reasoning architect and a cheaper editor — and irrlicht reports both token contributions correctly within the single turn.
+- **User-observable signal:** `ModelName` reflects the architect model (or the adapter's chosen primary); `TotalTokens` accumulates from both models in the same turn; state follows a clean `ready → working → ready` arc with no flicker from the model handoff.
+- **Primitive exercised:** `multi_model_orchestration` — specifically two models used within a single turn boundary (e.g. Aider `--architect`). The irrlicht primitive is accumulating token contributions from multiple model calls within one turn without treating the handoff as a turn boundary.
+- **Not to be confused with:** `model-switch-midsession` — user-driven model change between turns; `provider-failover-midturn` — automatic failover mid-turn, not intentional dual-model orchestration.
+- **Conceptual flow:**
+  1. Agent is in `ready`; user sends a prompt.
+  2. State transitions `ready → working`.
+  3. Architect model plans the response (internal to the turn).
+  4. Editor model emits the actual edits (internal to the turn).
+  5. Dashboard accumulates token counts from both model calls.
+  6. State transitions `working → ready`; `ModelName` reflects the primary model.
+
+---
+
+### provider-failover-midturn
+
+- **Essence:** Primary model fails mid-turn; agent falls back to a secondary model and completes the turn; `ModelName` updates to the fallback and state stays continuous through the switch.
+- **User-observable signal:** `ModelName` changes mid-turn without user action; state stays `working` through the failover; after turn completes, `→ ready` with the fallback model name visible.
+- **Primitive exercised:** `multi_model_orchestration` with automatic failover (Aider auto-fallback, Crush, Goose). The irrlicht primitive is that `ModelName` updates to the fallback model mid-turn without state flickering to `ready`.
+- **Not to be confused with:** `model-switch-midsession` — user-driven switching between turns; `turn-aborted-by-error` — no fallback, the turn fails entirely.
+- **Conceptual flow:**
+  1. Agent is `working` through a turn.
+  2. Primary model returns an error (rate limit, 5xx, timeout).
+  3. Agent switches to the secondary model automatically; `ModelName` updates.
+  4. Agent completes the turn with the fallback model.
+  5. State transitions `working → ready`; dashboard shows the fallback model name.

--- a/.claude/skills/ir:onboard-agent/spec/SKILL.md
+++ b/.claude/skills/ir:onboard-agent/spec/SKILL.md
@@ -42,7 +42,7 @@ indefinitely.
   `opencode`). Different agents may need different phase names
   (e.g. lazy-transcript adapters add a `pid_bind` phase tied to
   `transcript_new`); the spec is per-cell, not agent-agnostic.
-- `<scenario-id>` — kebab id from `.specs/agent-scenarios-coverage.json`.
+- `<scenario-id>` — kebab id from `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`.
 
 ## Output
 

--- a/tools/agent-onboarding/internal/viewer/server.go
+++ b/tools/agent-onboarding/internal/viewer/server.go
@@ -90,7 +90,7 @@ func (s *Server) staticHandler() http.Handler {
 }
 
 // handleCatalog serves the maintainer-curated scenario coverage
-// catalog at `.specs/agent-scenarios-coverage.json` — the source of
+// catalog at `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json` — the source of
 // truth for the per-agent applicability matrix (38 scenarios × 5
 // agents, each with agent_supports / irrlicht_observes verdicts and
 // notes). Falls back to `.claude/skills/ir:onboard-agent/scenarios.json`
@@ -115,7 +115,7 @@ func (s *Server) handleCatalog(w http.ResponseWriter, r *http.Request) {
 	//   2. Per-cell verdict (agent_supports, irrlicht_observes, notes,
 	//      confidence) comes from assessment.json when present (the
 	//      committed Stage-1 artifact).
-	//   3. If .specs/agent-scenarios-coverage.json is reachable, it
+	//   3. If .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json is reachable, it
 	//      provides FALLBACK verdicts for cells that lack assessment.json.
 	//      Optional — maintainers without .specs/ see "unknown" until
 	//      assessments are authored.
@@ -274,7 +274,7 @@ func buildCellVerdict(repoRoot, agentSlug, scenarioID string, overlay map[string
 	return cell
 }
 
-// loadSpecsOverlay reads .specs/agent-scenarios-coverage.json (if it
+// loadSpecsOverlay reads .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json (if it
 // exists) and returns a flat map keyed by scenarioID → agentSlug →
 // verdict fields. Returns nil if the file is unreachable or malformed
 // — callers treat nil as "no overlay" and rely on assessment.json plus
@@ -886,7 +886,7 @@ func parseScenarioSpec(md string, id string) *ScenarioSpec {
 // "Session reset (`/clear`, `/new`)" into the kebab id "session-reset"
 // the coverage JSON uses. Strip parenthetical examples, lowercase,
 // keep alnum + hyphens. The mapping must match
-// .specs/agent-scenarios-coverage.json — there's a custom alias map
+// .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json — there's a custom alias map
 // for the handful of features whose canonical id diverges (e.g.
 // "User-blocking tool call (question)" → "user-blocking-question").
 func slugifyFeature(f string) string {
@@ -920,7 +920,7 @@ func slugifyFeature(f string) string {
 
 // featureSlugAliases handles the cases where the markdown Feature
 // heading wording doesn't slugify cleanly into the coverage id. Keep
-// this in sync with .specs/agent-scenarios-coverage.json — every id
+// this in sync with .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json — every id
 // not derivable via slugifyFeature's default rule must have an entry.
 var featureSlugAliases = map[string]string{
 	"User-blocking tool call (question)":         "user-blocking-question",
@@ -1039,12 +1039,12 @@ func dedupeRecipesByCoverageID(raw []byte, repoRoot string) ([]byte, error) {
 }
 
 // resolveCoveragePath finds the maintainer's
-// .specs/agent-scenarios-coverage.json. Looks in the repo root first,
+// .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json. Looks in the repo root first,
 // then in the main checkout when the repo root is a git worktree.
 // Returns "" if neither has the file.
 func (s *Server) resolveCoveragePath() string {
 	// Direct hit (main checkout, or a worktree the user has populated).
-	direct := filepath.Join(s.RepoRoot, ".specs", "agent-scenarios-coverage.json")
+	direct := filepath.Join(s.RepoRoot, ".claude", "skills", "ir:onboard-agent", "agent-scenarios-coverage.json")
 	if _, err := os.Stat(direct); err == nil {
 		return direct
 	}
@@ -1070,7 +1070,7 @@ func (s *Server) resolveCoveragePath() string {
 	// gitdir = <main>/.git/worktrees/<id>; main checkout = grandparent
 	// of grandparent (worktrees/<id> → worktrees → .git → <main>).
 	main := filepath.Dir(filepath.Dir(filepath.Dir(gitdir)))
-	candidate := filepath.Join(main, ".specs", "agent-scenarios-coverage.json")
+	candidate := filepath.Join(main, ".claude", "skills", "ir:onboard-agent", "agent-scenarios-coverage.json")
 	if _, err := os.Stat(candidate); err == nil {
 		return candidate
 	}
@@ -1135,7 +1135,7 @@ type ScenarioDetail struct {
 // (per cell-lifecycle.md). One file per (agent, scenario) at
 // replaydata/agents/<agent>/scenarios/<scenario>/assessment.json,
 // overwritten on re-assessment — git is the history. The matrix in
-// .specs/agent-scenarios-coverage.json is the current-state rollup;
+// .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json is the current-state rollup;
 // this struct preserves when and why the verdict was reached.
 type AssessmentReport struct {
 	SchemaVersion    int                `json:"schema_version"`

--- a/tools/agent-onboarding/internal/viewer/web/viewer.js
+++ b/tools/agent-onboarding/internal/viewer/web/viewer.js
@@ -269,7 +269,7 @@ function scrollFocusInto(focus) {
 // loadOverview swaps the main pane to the scenario coverage matrix.
 // Two catalog shapes are supported:
 //
-//   coverage  (.specs/agent-scenarios-coverage.json, source of truth):
+//   coverage  (.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json, source of truth):
 //     38 scenarios × 5 agents. Each cell has agent_supports +
 //     irrlicht_observes verdicts (yes/no/partial/unknown) plus a notes
 //     field. Cell badge colors reflect the verdict combo.
@@ -288,7 +288,7 @@ function loadOverview() {
   document.title = "Irrlicht — Scenarios";
   document.getElementById("title").textContent = "Scenario coverage";
   const sourceLabel = catalogSource === "coverage"
-    ? ".specs/agent-scenarios-coverage.json (source of truth)"
+    ? ".claude/skills/ir:onboard-agent/agent-scenarios-coverage.json (source of truth)"
     : ".claude/skills/ir:onboard-agent/scenarios.json (fallback)";
   document.getElementById("breadcrumb").textContent =
     catalog ? `from ${sourceLabel} — refresh to pick up edits` : "catalog unavailable";
@@ -519,7 +519,7 @@ function renderCoverageMatrix(detail) {
 
 // loadCoverageDetail shows the per-agent testing plan for one
 // scenario from the coverage catalog. Combines:
-//   - Coverage data (.specs/agent-scenarios-coverage.json) — verdicts
+//   - Coverage data (.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json) — verdicts
 //     and maintainer notes per agent.
 //   - Recording recipe (scenarios.json) — joined by coverage_id —
 //     showing the actual driver (interactive tmux vs headless print),
@@ -1090,7 +1090,7 @@ function renderMeasurementChip(meas, sup, obs) {
 }
 
 // renderScenariosMatrix paints the older 8×5 by_adapter view from
-// scenarios.json (fallback when .specs/agent-scenarios-coverage.json
+// scenarios.json (fallback when .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json
 // isn't reachable).
 function renderScenariosMatrix(detail) {
   const adapterSet = new Set();
@@ -1466,7 +1466,7 @@ function renderAssessmentFallback(coverageEntry) {
   subtitle.textContent = "from matrix verdict — no point-in-time assessment.json on disk yet";
   p.appendChild(subtitle);
   if (!coverageEntry) {
-    p.appendChild(text("Coverage matrix has no entry for this cell. Add one in .specs/agent-scenarios-coverage.json."));
+    p.appendChild(text("Coverage matrix has no entry for this cell. Add one in .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json."));
     return p;
   }
   const row = document.createElement("div");


### PR DESCRIPTION
## Summary

Closes #428.

- **`scenario-meanings.md`** — new tracked file in the skill with 5-field "What this means" blocks for all 38 scenarios (Essence, User-observable signal, Primitive exercised, Not to be confused with, Conceptual flow). Replaces the semantic content that previously lived in gitignored `.specs/agent-scenarios.md`.
- **Recipe gate** — `recipe/SKILL.md` Step 1 now requires the scenario's entry in `scenario-meanings.md` to be present before proceeding; missing entry → stop and ask maintainer.
- **Assess anchor** — `assess/SKILL.md` Step 1 captures the **Primitive exercised** field from `scenario-meanings.md`; Step 4 uses it to map to `capabilities.json` keys deterministically rather than inferring from general knowledge.
- **`agent-scenarios-coverage.json`** — committed into `.claude/skills/ir:onboard-agent/` (was gitignored under `.specs/`). All path references updated: skill markdown files, `run-batch.sh`, prompts, schemas, viewer `server.go`, and `viewer.js`.

## Test plan

- [ ] `grep -c "### " .claude/skills/ir:onboard-agent/scenario-meanings.md` returns 38
- [ ] `tools/replay-fixtures.sh` passes (no Go changes to daemon)
- [ ] Viewer loads `/api/catalog` correctly with the new coverage path (viewer's `resolveCoveragePath` updated in `server.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)