### PR TITLE
refactor(onboard-agent): split skill into focused subagents + README (#434)

### DIFF
--- a/.claude/skills/ir:onboard-agent/README.md
+++ b/.claude/skills/ir:onboard-agent/README.md
@@ -1,232 +1,205 @@
 # ir:onboard-agent
 
-Developer documentation for the fixture-matrix refresh skill.
+Developer guide for the scenario × adapter fixture-matrix skill.
+
+## Which command do I want?
+
+| I want to… | Run | Cost |
+|---|---|---|
+| see the matrix status | `/ir:onboard-agent` (no args) | free |
+| **track a new behavior** the matrix doesn't have yet | `/ir:onboard-agent scenario-create <slug>` | free |
+| **check if `<agent>` supports `<scenario>`** | `/ir:onboard-agent assess <agent> <scenario>` | free (research only) |
+| **capture how `<agent>` does `<scenario>`** | `/ir:onboard-agent implement <agent> <scenario>` | spends agent CLI tokens |
+| **re-record** after a daemon change | `/ir:onboard-agent implement <agent> <scenario> --re-record` | spends agent CLI tokens |
+| **onboard a brand-new agent CLI** | `/ir:onboard-agent --new <slug>` | free (web research) |
+| **verify nothing regressed** | `tools/replay-fixtures.sh` | free |
+
+The first three are the everyday loop: **`scenario-create`** adds a matrix
+ROW, **`--new`** adds a matrix COLUMN, **`assess`** judges one cell, and
+**`implement`** fills it (recipe → spec → record → validate → commit).
 
 ## What this skill does
 
-Produces or refreshes the canonical scenario × adapter fixture matrix in
-`replaydata/agents/`. Scenarios are defined once, agent-agnostically; each
-scenario declares required capabilities. Each adapter declares what it
-supports in `core/adapters/inbound/agents/<adapter>/config.go:Capabilities`.
-Cells fall out: a cell is applicable when the adapter's capabilities satisfy
-the scenario's `requires`.
+It maintains the canonical scenario × adapter fixture matrix in
+`replaydata/agents/`. Scenarios are defined once, agent-agnostically;
+each declares the capabilities it `requires`. Each adapter declares what
+it supports in its `capabilities.json`. A cell is applicable when the
+adapter's capabilities satisfy the scenario's requirements. The skill is
+a slim dispatcher: it routes your intent to one of three focused
+subagents, each of which exhausts its OWN context window and returns a
+≤5-line summary — so a large sweep doesn't drown the parent session in
+per-cell `events.jsonl` / `transcript.jsonl` output.
 
-The skill unifies four operations:
-- **Discover** (`--new <slug>`) — research a previously unknown agent on
-  the web via subagents and propose `replaydata/agents/<slug>/capabilities.json`.
-  See `discovery-instructions.md`.
-- **Refresh** (`<adapter>` or `<adapter> <scenario>`) — re-record an
-  existing committed fixture to pick up upstream agent format changes.
-- **Bootstrap** — record a fixture for a cell that applies but has no
-  committed file yet (same invocation as Refresh; the skill detects
-  "no committed fixture" and treats it as first-record).
-- **Onboard a new adapter** — after adding the Go adapter scaffold under
-  `core/adapters/inbound/agents/<name>/` plus `replaydata/agents/<name>/capabilities.json`
-  (or via `--new` discovery), run `<adapter>` to populate every matching cell.
+## The three subagents
 
-## Vision and overhaul
+Each is a self-contained prompt under its own directory; the dispatcher
+spawns it with a one-line brief and relays its summary.
 
-The current skill is the result of the onboard-agent overhaul; see
-`/Users/ingo/projects/irrlicht/.specs/onboard-agent-overhaul.md` for the
-high-level plan and `.specs/onboard-agent/NN-*.md` for per-workstream
-deep plans.
+- **`scenario-create/SKILL.md`** — adds a new agent-agnostic scenario:
+  a `scenarios[]` + `catalog[]` entry (top-level only, no recipe), a
+  `scenario-meanings.md` glossary block, a coverage-matrix row with every
+  adapter `unknown`, and a new `features.json` capability if needed.
+  One-shot, no CLI, no recording. Returns `{scenario_id, capability_ids,
+  files_changed}`.
+- **`assess/SKILL.md`** — researches one cell and writes
+  `assessment.json` (verdict + body + caveats + sources). Returns
+  `{verdict, applicable, summary}`. If `applicable` is `no`/`n/a`, the
+  cell is frozen — no recipe, no recording. (Also has `--column <agent>`
+  / `--row <scenario>` batch-candidate modes.)
+- **`implement/SKILL.md`** — the full pipeline for one cell: authors the
+  spec + recipe, records against a live daemon, validates, promotes, and
+  commits. Retries a drive timeout exactly once, then degrades to
+  `applicable: false` with a `scope_note`; returns `driver_gap`
+  immediately when the recipe needs a step type the agent's driver lacks
+  (no retry); **always commits before returning**. Returns `{commit_sha,
+  pass_rate, status}` where status is `pass | applicable_false |
+  driver_gap | infra_fail`.
 
-## Setup
+## Worked example — a new scenario, end to end
 
-Auth is configured out-of-band per adapter — see `install-instructions.md`
-for the per-adapter install + auth recipe.
+Say you want to track "the agent queues a message the user typed
+mid-turn" for claudecode.
 
-When a recording fails, the skill runs `scripts/lib/classify-failure.sh`
-to categorize the failure (cli_not_found / cli_too_old / auth_failed /
-daemon_dirty / working_tree_dirty / transcript_missing / timeout /
-unknown), then uses `AskUserQuestion` to surface the relevant install or
-auth instructions and waits for the user to retry.
+1. **Create the row** (free, one-shot):
+   ```
+   /ir:onboard-agent scenario-create mid-turn-message-queued
+   ```
+   Adds the scenario to `scenarios.json` + `catalog`, writes its
+   `scenario-meanings.md` block, and adds a coverage row where every
+   adapter (claudecode, codex, pi, aider, opencode) is `unknown`.
+   Returns the `scenario_id` and the `requires` capability ids.
+
+2. **Assess the cell you care about** (free):
+   ```
+   /ir:onboard-agent assess claudecode mid-turn-message-queued
+   ```
+   Researches claudecode's docs + the adapter transport, writes
+   `assessment.json`, and returns e.g. `applicable: yes`. (If it returned
+   `no`/`n/a`, you'd stop here — the assessment documents why.)
+
+3. **Implement it** (spends tokens, needs a recording daemon):
+   ```
+   /ir:onboard-agent implement claudecode mid-turn-message-queued
+   ```
+   Authors `expected.jsonl` then the `by_adapter.claudecode` recipe,
+   commits them, drives the live `claude` CLI under your running
+   `irrlichd --record`, validates the recording against the spec,
+   promotes it, and commits. Returns `{commit_sha, pass_rate: "8/8",
+   status: pass}`.
+
+4. **Later, after a daemon change**, refresh the recording without
+   re-authoring anything:
+   ```
+   /ir:onboard-agent implement claudecode mid-turn-message-queued --re-record
+   ```
+
+To fill the same scenario across every applicable adapter, ask the
+dispatcher to sweep — it computes the cell list and runs one `assess`
+(then one `implement`) subagent per cell, collecting each summary.
+
+## Has anything broken? — `tools/replay-fixtures.sh`
+
+```
+tools/replay-fixtures.sh
+```
+
+No agent, no tokens, no daemon. It walks every committed
+`expected.jsonl` and re-validates the latest recording (and archives)
+against the current daemon, then writes JSON + Markdown reports under
+`replaydata/agents/_reports/`. **This is the CI gate** — it exits
+non-zero on a regression, so CI catches a daemon change that drifts a
+fixture before users see it on the dashboard. Run it after any change to
+the daemon's parsers/classifier, and it's part of the "before marking a
+ticket done" suite alongside `go test ./core/... -race -count=1`.
+
+## Building blocks (stage-level mechanics)
+
+`implement` bundles four stages; their per-stage `SKILL.md` docs are the
+detailed mechanics, useful when a cell needs hand-holding or when you're
+extending a driver:
+
+- [`recipe/SKILL.md`](recipe/SKILL.md) — Stage 2: author the
+  deterministic `by_adapter.<agent>` driver script (step grammar,
+  multi-variant chaining, adapter quirks, determinism budget).
+- [`spec/SKILL.md`](spec/SKILL.md) — Stage 3: author `expected.jsonl`
+  (the phase DSL the validator runs against every recording).
+- [`record/SKILL.md`](record/SKILL.md) — Stage 4: `--attach` mode,
+  the run-cell → promote pipeline, the determinism re-record check.
+- [`validate/SKILL.md`](validate/SKILL.md) — Stage 5: the
+  `expected-validate` decision tree, `known_failing`, drift detection.
+- [`cell-lifecycle.md`](cell-lifecycle.md) — how the five stages fit
+  together, with a worked `claudecode/session-reset` walkthrough.
+- [`scenario-meanings.md`](scenario-meanings.md) — the committed prose
+  glossary every scenario must have a block in.
+- [`discovery-instructions.md`](discovery-instructions.md) — the
+  `--new <slug>` recipe for onboarding a brand-new agent CLI.
 
 ## Correctness guards
 
-Not cost-related — these prevent broken runs, not unintended spend:
+Not cost-related — these prevent broken runs:
 
-- `pgrep -x irrlichd` refusal — port 7837 would clash with a running
-  production daemon.
-- Git-clean check on `replaydata/agents/` — refuses if uncommitted fixture
-  changes exist, so you don't layer confusion.
+- `pgrep -x irrlichd` refusal in isolated mode (port 7837 clash); the
+  subagents use `--attach` against your running daemon instead.
+- Git-clean check on `replaydata/agents/` before recording — which is
+  why `implement` commits the spec + recipe before it records.
 - CLI version minimum check against `scenarios.json.min_versions`.
-- Wall-clock `timeout` per cell (hang protection, not spend cap).
-- Staged outputs only — skill never writes to `replaydata/` directly.
+- Wall-clock `timeout` per cell (hang protection).
 
 ## File layout
 
 ```
 .claude/skills/ir:onboard-agent/
-  skill.md          — the orchestration the user invokes via /ir:onboard-agent
-  scenarios.json              — canonical scenario catalogue
-  discovery-instructions.md   — discovery-mode (--new) recipe (WS04)
-  install-instructions.md     — per-adapter install + auth recipes (WS06)
-  scripts/
-    precheck.sh               — fail-fast precondition bundle
-    drive-{claudecode,codex,pi,gastown}.sh — adapter-specific drivers
-    run-cell.sh               — glue: precheck → daemon → driver → curate → replay
-    discover-agent.sh         — render discovery preamble for --new mode (WS04)
-    lib/
-      assert-staging-path.sh  — path-traversal guard
-      classify-failure.sh     — categorize a failed staging dir (WS06)
+  skill.md                    — the dispatcher (routing + matrix status)
   README.md                   — this file
+  scenario-create/SKILL.md    — agent #1: add a matrix row
+  assess/SKILL.md             — agent #2: judge one cell (+ batch modes)
+  implement/SKILL.md          — agent #3: fill one cell end-to-end
+  recipe|spec|record|validate/SKILL.md — stage-level building blocks
+  scenario-meanings.md        — committed scenario glossary
+  scenarios.json              — canonical scenario catalogue
+  agent-scenarios-coverage.json — rollup matrix (maintainer-owned)
+  discovery-instructions.md   — --new (new agent column) recipe
+  install-instructions.md     — per-adapter install + auth recipes
+  scripts/
+    run-cell.sh               — precheck → daemon → driver → curate → replay
+    precheck.sh               — fail-fast preconditions
+    drive-<agent>[-interactive].sh — per-adapter drivers
+    discover-agent.sh         — discovery preamble renderer
+    lib/{assert-staging-path,classify-failure}.sh
+
+replaydata/agents/
+  features.json               — canonical capability catalog
+  <adapter>/
+    capabilities.json         — per-adapter feature support
+    scenarios/<scenario>/
+      assessment.json         — Stage 1 artifact
+      expected.jsonl          — Stage 3 spec
+      events.jsonl            — Stage 4 lifecycle events (latest)
+      transcript.jsonl        — Stage 4 agent transcript (latest)
+      manifest.json           — daemon/CLI/recipe versions + pass rate
+      recordings/<ts>_irrlichd-<ver>/ — archived prior recordings
 ```
-
-The canonical features list and per-adapter capabilities live outside the
-skill, alongside the scenario fixtures, in `replaydata/`:
-
-```
-replaydata/
-  agents/
-    features.json                     — canonical feature catalog (WS01)
-    <adapter>/
-      capabilities.json               — per-adapter feature support (WS03);
-                                        optional top-level `transcript_extension`
-                                        (default "jsonl") names the curated
-                                        fixture's extension (e.g. "md" for aider)
-      scenarios/<scenario>/
-        transcript.jsonl              — agent transcript (raw)
-        events.jsonl                  — lifecycle events
-        transcript.jsonl.replay.json.golden
-        subagents/                    — child sessions, when applicable
-        # Reserved by WS07–10 (emission deferred):
-        # process.jsonl, files.jsonl, hooks.jsonl, recording.json
-  orchestrators/
-    features.json                     — canonical orchestrator features
-    <orchestrator>/
-      capabilities.json
-      scenarios/<scenario>/
-        input/, golden/, scenario.json
-```
-
-Staged outputs:
-```
-.build/refresh/<adapter>/<scenario>-<UTC-ts>/
-  recordings/                           — raw daemon recording
-  replaydata/agents/<adapter>/scenarios/<scenario>/{transcript,events}.jsonl
-  reports/
-    staged.json                         — replay over staged fixture
-    committed.json                      — replay over current replaydata (if any)
-  settings.json                         — scenario's settings blob
-  driver.log, driver.exit-reason
-  daemon.log, daemon.shutdown
-  run-manifest.json                     — summary the skill reads
-```
-
-## `scenarios.json` schema
-
-```json
-{
-  "min_versions": {
-    "claudecode": "2.0.0",
-    "codex": "0.50.0",
-    "pi": "1.0.0"
-  },
-  "scenarios": [
-    {
-      "name": "<slug>",                 — stable, doubles as fixture filename
-      "description": "<one-liner>",
-      "requires": ["<capability>", ...],
-      "verify": { ... },                — structural assertions, adapter-agnostic
-      "by_adapter": {
-        "<adapter>": {
-          "prompt": "...",
-          "settings": { ... },          — adapter settings blob (JSON)
-          "timeout_seconds": 180
-        }
-      }
-    }
-  ]
-}
-```
-
-## Adding a scenario
-
-1. Pick a slug (kebab-case, stable — it becomes the fixture filename).
-2. Identify the `requires` capabilities. If you need a new capability,
-   add it to `core/adapters/inbound/agents/config.go` first.
-3. Define `verify` as structural invariants only — transition topology,
-   tool-call category presence, hook firings. Never match exact text or
-   per-event latency; those vary between model versions.
-4. Start with `by_adapter.claudecode` (the only driver today). Add a
-   per-adapter entry for every adapter that supports the `requires`
-   capabilities.
-5. Run `/ir:onboard-agent <adapter> <new-scenario>` to bootstrap the cell.
-6. Review the staged fixture, then copy into `replaydata/` and commit.
-
-## Adding an adapter column
-
-When a new adapter (say, `aider`) is supported:
-
-0. Run discovery: `/ir:onboard-agent --new aider` → review proposed
-   capabilities → merge into `replaydata/agents/<name>/capabilities.json`.
-1. Add the **stub adapter** (~50–100 LOC) under
-   `core/adapters/inbound/agents/<name>/` with the right combination of
-   `Config` fields per the agent's shape. See "Adapter shape decision
-   tree" in `discovery-instructions.md → Post-discovery gate` — different
-   agent shapes (native binary vs Python wrapper, fixed root vs per-CWD
-   transcript) need different field combinations:
-   - `ProcessName` for native binaries (`pgrep -x`)
-   - `CommandLineMatch: "/<name>"` for wrapper-launched (Python via
-     `pipx`/`uv`, npx, etc.)
-   - `TranscriptFilename: ".<name>.history.<ext>"` for agents that
-     write per-project transcripts in CWD instead of under
-     `$HOME/.<name>/`
-2. Wire into `core/cmd/irrlichd/main.go` agentCfgs slice (one line).
-3. **Run the post-discovery live recording smoke** against the stub.
-   Confirm PASS-level detection (`pid_discovered` + `transcript_new`
-   with path + `transcript_activity` + `process_exited`). If anything
-   is missing, fix the stub before writing the parser.
-4. Write the real parser (`parser.go` — adapter-specific transcript
-   format → `tailer.ParsedEvent` events).
-5. Write `.claude/skills/ir:onboard-agent/scripts/drive-<name>.sh`.
-6. Update `scripts/precheck.sh` to add the `<name>` case.
-7. For every scenario whose `requires` matches `<name>`'s capabilities,
-   add `by_adapter.<name>` with the eliciting prompt/settings.
-8. Run `/ir:onboard-agent <name>` to populate its column.
-
-The order matters: discover → stub + smoke → parser → driver. Trying
-to write the parser first against an unverified daemon-detection
-chain wastes a parser PR's worth of work when the daemon turns out to
-need format/discovery widening (this is exactly what happened during
-aider onboarding; the smoke caught two distinct gaps that would have
-otherwise surfaced after the parser was written).
-
-## Interpreting cell states
-
-- **OK** — fixture matches the scenario's expected behavior.
-- **stale** — refresh run produced a materially different report. Review
-  and decide: accept (adapter changed) or reject (we regressed).
-- **never-recorded** — prompt exists, fixture doesn't. Run the cell.
-- **missing-prompt** — capabilities match but no `by_adapter` entry. Add
-  one to `scenarios.json`.
-- **N/A (no <capability>)** — adapter cannot run this scenario.
 
 ## Troubleshooting
 
-- **"another irrlichd is running"** — stop the production daemon before
-  running: `launchctl unload ~/Library/LaunchAgents/…` or kill the
-  menu-bar app.
-- **"replaydata/agents/ has uncommitted changes"** — commit or stash your
-  current staged fixtures before refreshing.
-- **"claude X.Y.Z is below pinned minimum"** — update `claude` CLI, or
-  bump the minimum in `scenarios.json` if intentional.
-- **"transcript_or_recording_missing"** — the daemon didn't see the
-  agent's session. Check `daemon.log` in staging for recorder errors;
-  check `driver.log` for CLI failures. Often caused by the CLI exiting
-  too quickly — the scenario prompt may need to keep the session alive
-  longer.
-- **Every cell shows "CHANGED" on the first refresh** — check the
-  normalization step in `skill.md`. UUID/timestamp drift will make every
-  refresh look broken.
+- **"another irrlichd is running"** — the subagents use `--attach`;
+  ensure your daemon was started with `--record`. Isolated mode refuses
+  while a production daemon is up.
+- **"replaydata/agents/ has uncommitted changes"** — commit or stash
+  first. `implement` commits its own spec/recipe before recording, so a
+  dirty tree means a half-finished manual edit.
+- **"claude X.Y.Z is below pinned minimum"** — update the CLI, or bump
+  the minimum in `scenarios.json` if intentional.
+- **`implement` returned `infra_fail`** — environment problem (CLI
+  missing/old, no recording daemon, auth). The cell verdict is
+  unchanged; fix the environment and re-run.
+- **`implement` returned `driver_gap`** — the recipe needs a driver step
+  type that agent doesn't implement. Extending the interactive driver is
+  a developer task (out of scope for the skill).
 
 ## See also
 
-- `tools/curate-lifecycle-fixture.sh` — the underlying curator (accepts
-  `-d <agents-root>` for staging).
-- `core/cmd/replay/main.go` — the replay engine that produces reports.
-- `core/cmd/replay/main_test.go` — the golden-fixture regression tests
-  that consume these fixtures.
-- Phase 0 contract: `core/adapters/inbound/agents/config.go` (Capabilities
-  declared here).
+- `tools/promote-recording.sh` — archives the previous recording and
+  re-validates the new one (invoked by `implement`).
+- `tools/curate-lifecycle-fixture.sh` — the underlying fixture curator.
+- `core/cmd/replay/main.go` — the replay engine behind the reports.

--- a/.claude/skills/ir:onboard-agent/assess/SKILL.md
+++ b/.claude/skills/ir:onboard-agent/assess/SKILL.md
@@ -14,7 +14,14 @@ description: >
   every adapter. Re-runs overwrite silently — git preserves history.
 ---
 
-# Assessment (Stage 1)
+# assess (Agent #2 / Stage 1)
+
+> **You are running as a focused subagent with no parent context.**
+> Everything you need is in this file and the repo. Do the research
+> YOURSELF (you have web search + file access) — don't bounce the work
+> back to the dispatcher. The single-cell form spends no API tokens on
+> agent CLIs and runs no recording. When done, return only the summary
+> in the "Return contract" section.
 
 Produces the artifact for **Stage 1 of the cell lifecycle**: a
 structured, dated, sourced record of "does this agent support this
@@ -136,25 +143,35 @@ The steps below cover the **single-cell** form. For
 
 ### Step 1 — Read the prose spec
 
+Canonical source (committed, always present):
+
 ```
-.specs/agent-scenarios.md
+.claude/skills/ir:onboard-agent/scenario-meanings.md   →   ### <scenario-id>
 ```
 
-Find the `### Feature:` heading whose kebab slug matches
-`<scenario-id>`. Capture every `Scenario:` paragraph and every
-`Expected:` bullet. These are the canonical assertions the verdict
-must judge against.
+Read the `### <scenario-id>` block and capture all five fields
+(Essence, User-observable signal, Primitive exercised, Not to be
+confused with, Conceptual flow). The **User-observable signal** lines
+are the candidate assertions you judge `irrlicht_observes` against; the
+**Primitive exercised** field is the canonical capability-key anchor
+(use it in Step 4 to pick the right `capabilities.json` key).
 
-If `.specs/` isn't in this checkout (it's gitignored), the maintainer
-must copy it in or you fall back to `/api/catalog` (the viewer's
-rollup of the same data). Don't fabricate a scenario.
+If the scenario ID is missing from `scenario-meanings.md` — STOP. The
+row hasn't been created. Surface "run `scenario-create <slug>` first" in
+your summary and return.
+
+If a richer `.specs/agent-scenarios.md` happens to be present (it's
+gitignored, so usually absent), also read its `### Feature:` block whose
+kebab slug matches — capture every `Scenario:` paragraph and `Expected:`
+bullet for extra precision. Don't fabricate a scenario if it's absent;
+`scenario-meanings.md` is sufficient.
 
 ► **Verify before moving on:**
-- [ ] Found the Feature: heading. If not, the `<scenario-id>` is
-  wrong or the spec is missing — stop and surface the gap.
-- [ ] Located the `### <scenario-id>` section in `.claude/skills/ir:onboard-agent/scenario-meanings.md` and captured the **Primitive exercised** field verbatim. This field is the canonical capability key anchor — use it in Step 4 to drive `capabilities.json` assignment. If the scenario ID is missing from `scenario-meanings.md` — STOP and ask the maintainer to add it.
-- [ ] Captured every Expected: bullet. Each one is a candidate
-  assertion you'll judge `irrlicht_observes` against.
+- [ ] Found the `### <scenario-id>` block in `scenario-meanings.md` and
+  captured the **Primitive exercised** field verbatim.
+- [ ] Captured every User-observable signal (and any `.specs/` Expected:
+  bullet, if present). Each is a candidate assertion for
+  `irrlicht_observes`.
 
 ### Step 2 — Read the current matrix verdict
 
@@ -256,53 +273,50 @@ FilesUnderRoot watch can see the session).
 - [ ] For each Expected: bullet, you can name the event(s) the daemon
   would emit (or honestly say "no event would prove this").
 
-### Step 4 — Dispatch a focused research subagent
+### Step 4 — Research the verdict (you do this directly)
 
-Spawn ONE general-purpose subagent (`Agent` tool with
-`subagent_type: general-purpose`) and brief it with:
-
-1. The scenario's full spec text (from Step 1).
-2. The current matrix verdict (from Step 2).
-3. A pointer to the adapter source you read (from Step 3).
-4. The output schema from "Output" above.
-5. The two caveat patterns from `cell-lifecycle.md`:
-   feature-invisible-but-spec-compliant, metric-drift-downstream.
-6. The two worked examples (`checkpoint-rewind`,
-   `cloud-background-agent`) as anchors for prose style.
-
-Ask it to:
+You are the research agent. Using the spec text (Step 1), the matrix
+verdict (Step 2), and the adapter transport read (Step 3):
 
 - Read the agent's official docs site, changelog/release notes, and
-  source files relevant to the feature.
-- Decide `agent_supports` honestly.
-- Derive `irrlicht_observes` from the transport read (Step 3) and
-  whatever it learns about the agent's emission shape.
-- Map the **Primitive exercised** field from Step 1 to the matching
-  key in `replaydata/agents/<agent>/capabilities.json`. Use the
-  primitive text to identify the correct feature flag — do NOT infer
-  a capability key from general knowledge; derive it directly from
-  the primitive text and the existing keys in `capabilities.json`.
-  Update or confirm that key in the output.
-- Identify caveats — name each one explicitly with the pattern it
-  fits.
+  source files relevant to the feature. Use web search + fetch.
+- Decide `agent_supports` honestly (see the three rules above and the
+  Step 2.5 strings-scan guard before any `no`).
+- Derive `irrlicht_observes` from the transport read (Step 3) and what
+  you learn about the agent's emission shape. The agent emitting an
+  event ≠ the daemon parsing it — ground this claim in `config.go` +
+  the parser source, not docs alone.
+- Map the **Primitive exercised** field from Step 1 to the matching key
+  in `replaydata/agents/<agent>/capabilities.json`. Derive the key
+  directly from the primitive text and the existing keys — do NOT infer
+  it from general knowledge. Confirm (or correct) that key.
+- Identify caveats, naming each with the pattern it fits
+  (feature-invisible-but-spec-compliant; metric-drift-downstream — both
+  defined in `cell-lifecycle.md`).
 - Calibrate `confidence` (`0.9+` only when behavior is documented
-  explicitly).
-- Cite at least one source per claim. URL for docs/changelog; `file`
-  with a path for source.
-- Output the full JSON document conforming to the schema. No
-  surrounding markdown, no commentary.
+  explicitly; `0.7–0.85` is the honest band for a thorough multi-source
+  read).
+- Cite at least one source per claim — URL for docs/changelog, `file`
+  with a path for source. The two committed worked examples
+  (`checkpoint-rewind`, `cloud-background-agent`) are anchors for prose
+  style.
 
-The subagent's prompt should explicitly forbid:
+Forbidden:
 
 - Made-up sources.
-- Downgrading verdicts to "be safe" — the matrix authoring rule is
-  honest verdicts + caveats, not defensive `partial`s.
+- Downgrading verdicts to "be safe" — the authoring rule is honest
+  verdicts + caveats, not defensive `partial`s.
 - Reasoning purely from general LLM knowledge — every claim needs a
   primary source.
 
+If the research is broad enough to threaten your own context window,
+you MAY fan a single `general-purpose` Agent out for the docs/source
+sweep and synthesize its findings — but the verdict and the written
+artifact are yours.
+
 ### Step 5 — Synthesize + write
 
-Read the subagent's JSON. Sanity-check:
+Assemble the JSON document conforming to the "Output" schema. Sanity-check:
 
 - `schema_version: 1`.
 - `scenario_id`, `agent`, `assessed_at` correct.
@@ -314,35 +328,41 @@ Read the subagent's JSON. Sanity-check:
 - `sources` is an array with at least one entry; each entry has
   `kind`, `ref`, `note`.
 
-If any check fails, push back on the subagent (one re-roll max) or
-hand-edit before writing.
+If any check fails, fix the document before writing (re-run the
+research for the specific gap if needed).
 
 Write the final JSON to
 `replaydata/agents/<agent>/scenarios/<scenario>/assessment.json`,
 overwriting silently if a file exists. Use 2-space indent for
 readability — the viewer parses any valid JSON shape.
 
-### Step 6 — Report
+### Step 6 — Return contract
 
-Print to stdout:
+Compute `applicable` from the two verdicts — this is the signal
+`implement` keys on to decide whether to proceed:
+
+| agent_supports | irrlicht_observes | `applicable` | meaning |
+|---|---|---|---|
+| `yes` / `partial` | `yes` / `partial` | `yes`  | proceed to `implement` |
+| `no`              | (any)             | `no`   | agent lacks the feature — pipeline frozen |
+| `yes` / `partial` | `n/a` / `no`      | `n/a`  | agent has it, irrlicht can't observe it — no recording |
+| `unknown`         | (any)             | `n/a`  | inconclusive — re-assess after the gap named in `body` closes |
+
+Return ONLY this (≤5 lines), no transcripts:
 
 ```
-✓ wrote replaydata/agents/<agent>/scenarios/<scenario>/assessment.json
-  verdict: <agent_supports> / <irrlicht_observes> (confidence <n>)
-  caveats: <count>
-  sources: <count>
+verdict: <agent_supports> / <irrlicht_observes> (confidence <n>)
+applicable: yes | no | n/a
+summary: <one sentence — the load-bearing reason for the verdict>
+wrote: replaydata/agents/<agent>/scenarios/<scenario>/assessment.json
+matrix_drift: none | matrix says <old>/<old>, coverage row should update
 ```
 
-Then a transcription hint IF the new verdict differs from the matrix
-(from Step 2):
-
-```
-ⓘ matrix says <old_supports>/<old_observes>; consider updating
-  .claude/skills/ir:onboard-agent/agent-scenarios-coverage.json -> .scenarios[<id>].coverage.<agent>
-```
-
-The matrix update is the maintainer's call — this skill never writes
-`.specs/`.
+**If `applicable` is `no` or `n/a`, stop here.** There is no recipe or
+recording follow-up — the assessment.json documents *why* the cell is
+frozen and what would unblock it. The maintainer transcribes the
+verdict into the coverage matrix; this stage never writes
+`agent-scenarios-coverage.json`.
 
 ## Column and row batch modes
 

--- a/.claude/skills/ir:onboard-agent/implement/SKILL.md
+++ b/.claude/skills/ir:onboard-agent/implement/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: ir:onboard-agent/implement
+description: >
+  Agent #3 of the ir:onboard-agent pipeline. Takes one (agent, scenario)
+  cell from an assessed `applicable: yes` verdict all the way to a
+  committed recording: authors the spec + per-adapter recipe, drives the
+  live agent CLI under a recording daemon, validates against the spec,
+  promotes the recording, and commits — leaving no dirty tree. Bundles
+  the recipe / spec / record / validate building blocks behind one
+  contract with retry, driver-gap, and degrade-to-applicable:false
+  handling. Invoked as `/ir:onboard-agent implement <agent> <scenario>
+  [--re-record]`.
+---
+
+# implement (Agent #3)
+
+> **You are running as a focused subagent with no parent context.**
+> Everything you need is here or in the building-block docs named below.
+> Don't ask the dispatcher anything. This stage DRIVES A LIVE AGENT CLI
+> and SPENDS API TOKENS — but auth is set up out-of-band, so run it
+> without ceremony (no key checks, no "this will spend money" prompts).
+> When done, return only the "Return contract" block.
+
+## What this does
+
+Carries one cell from `applicable: yes` to a committed recording. It
+bundles four building-block stages — you READ their docs for mechanics
+and follow them here:
+
+- Stage 2 recipe → [`../recipe/SKILL.md`](../recipe/SKILL.md)
+- Stage 3 spec → [`../spec/SKILL.md`](../spec/SKILL.md)
+- Stage 4 record → [`../record/SKILL.md`](../record/SKILL.md)
+- Stage 5 validate → [`../validate/SKILL.md`](../validate/SKILL.md)
+- End-to-end map → [`../cell-lifecycle.md`](../cell-lifecycle.md)
+
+## Inputs
+
+- `<agent>` — adapter slug (`claudecode`, `codex`, `pi`, `aider`,
+  `opencode`).
+- `<scenario>` — scenario id (matches `scenarios[].name` /
+  `coverage_id`).
+- `--re-record` (optional) — skip recipe + spec authoring; reuse the
+  existing `by_adapter.<agent>` recipe and committed `expected.jsonl`,
+  and just capture a fresh recording. Use after a daemon change.
+
+## Preconditions
+
+1. **An assessment exists.**
+   `replaydata/agents/<agent>/scenarios/<scenario>/assessment.json` must
+   be present. If it isn't, spawn `assess` first (`Agent` tool,
+   `subagent_type: general-purpose`, prompt = "Read and execute
+   `.claude/skills/ir:onboard-agent/assess/SKILL.md` for agent=<agent>
+   scenario=<scenario>; return your summary."). Wait for it, then read
+   the written `assessment.json`.
+2. **The verdict is actionable.** Refuse unless `assess`'s `applicable`
+   is `yes` (`agent_supports ∈ {yes, partial}` AND `irrlicht_observes ∈
+   {yes, partial}`). For `no`/`n/a`, STOP — return status
+   `applicable_false`, change nothing, note the frozen reason from the
+   assessment body. There is no recipe or recording for a frozen cell.
+3. **The daemon is recording.** This stage uses `--attach` against the
+   user's running `irrlichd --record` (the dashboard stays connected and
+   the scenario shows up live). `pgrep -x irrlichd` must return a PID and
+   its recordings dir must be non-empty, else `run-cell.sh`'s precheck
+   refuses — that's an `infra_fail`, not a cell problem.
+4. **`--re-record` only:** `by_adapter.<agent>` (with `script` or
+   `prompt`) AND `expected.jsonl` must already exist. If either is
+   missing, return `infra_fail` ("nothing to re-record; run without
+   --re-record first").
+
+## Full-mode pipeline
+
+### 1. Author the spec FIRST (Stage 3)
+
+Follow [`../spec/SKILL.md`](../spec/SKILL.md) to write
+`replaydata/agents/<agent>/scenarios/<scenario>/expected.jsonl`.
+Spec-before-recipe is deliberate: the recipe's plain-English `verify`
+items map onto concrete spec phases, so the spec must exist first.
+
+### 2. Author the recipe (Stage 2)
+
+Follow [`../recipe/SKILL.md`](../recipe/SKILL.md) to write
+`by_adapter.<agent>` into
+`.claude/skills/ir:onboard-agent/scenarios.json`. **Template from
+claudecode's recipe for the same scenario** when one exists — copy its
+shape and adapt the step grammar / quirks to `<agent>`. Validate JSON:
+`jq '.' .claude/skills/ir:onboard-agent/scenarios.json > /dev/null`.
+
+### 3. Driver-gap pre-flight (before any recording)
+
+Compare the recipe's step types to what the agent's interactive driver
+implements:
+
+```bash
+SK=.claude/skills/ir:onboard-agent
+# step types the recipe needs:
+jq -r '.scenarios[] | select(.name=="<scenario>") | .by_adapter["<agent>"].script[]?.type' \
+  $SK/scenarios.json | sort -u
+# step types the driver handles (case labels):
+grep -oE '^\s*(send|slash|wait_turn|sleep|interrupt|keys|restart|resume|sigkill|exit_clean|reset_session)\)' \
+  $SK/scripts/drive-<agent>-interactive.sh | tr -d ' )' | sort -u
+```
+
+If any needed step type is **not** in the driver's set →
+**`driver_gap`**: this is a developer task (extend the driver), out of
+scope here. Set `by_adapter.<agent> = {"applicable": false, "notes":
+"<scope_note naming the missing step type, e.g. 'aider driver lacks
+exit_clean'>"}`, commit recipe(applicable:false) + spec + assessment,
+and return `driver_gap`. **Do NOT record, and do NOT retry against a
+known-missing primitive.** (Headless `prompt` cells have no step types
+and can't hit this.)
+
+### 4. Commit the authored artifacts
+
+`expected.jsonl` lives under `replaydata/agents/`, and `precheck.sh`
+refuses to record with a dirty `replaydata/` tree. So commit the spec +
+recipe now — this is also what keeps the tree clean per the contract:
+
+```bash
+git add .claude/skills/ir:onboard-agent/scenarios.json \
+        replaydata/agents/<agent>/scenarios/<scenario>/expected.jsonl \
+        replaydata/agents/<agent>/scenarios/<scenario>/assessment.json
+git commit -m "feat(onboard): author <agent>/<scenario> recipe+spec"
+```
+
+(For `--re-record` mode, skip steps 1–4 entirely — the recipe + spec are
+already committed and the tree is clean.)
+
+### 5. Record (Stage 4)
+
+```bash
+SK=.claude/skills/ir:onboard-agent
+$SK/scripts/run-cell.sh --attach <agent> <scenario>
+# capture the staging dir from the final "manifest: <path>" line:
+#   STAGING = dirname of that manifest path
+```
+
+Read `<STAGING>/run-manifest.json`. Classify the outcome — when in
+doubt run `$SK/scripts/lib/classify-failure.sh <STAGING>` (codes:
+`cli_not_found`, `cli_too_old`, `auth_failed`, `daemon_dirty`,
+`working_tree_dirty`, `transcript_missing`, `timeout`, `unknown`):
+
+| Outcome | Action |
+|---|---|
+| manifest `verdict: STAGED` (success) | proceed to step 6 |
+| `timeout` / `transcript_missing`, **first** time | **retry once** — re-run the same `run-cell.sh --attach`. Often a lazy-transcript nudge or trailing-sleep timing issue. |
+| `timeout` / `transcript_missing`, **second** time | degrade → **`applicable_false`** (see below) |
+| `cli_not_found` / `cli_too_old` / `auth_failed` / daemon-not-running | **`infra_fail`** — environment problem, not a cell verdict. Don't retry, don't mark applicable_false. Tree is already clean (spec+recipe committed). Return. |
+
+**Retry exactly once.** Never loop a third attempt.
+
+**Degrade to `applicable_false`:** the recipe can't reliably elicit the
+behavior. Set `by_adapter.<agent>.applicable = false` and add `notes`
+with a `scope_note` explaining what failed (e.g. "two consecutive
+drive timeouts — agent never reaches the waiting episode the spec
+asserts"). Commit recipe(applicable:false) — the spec stays as the
+documented target. Return `applicable_false`.
+
+### 6. Promote + validate (Stages 4→5)
+
+```bash
+tools/promote-recording.sh <STAGING> <agent> <scenario>
+```
+
+This archives the previous recording, copies the staged
+`events.jsonl` + `transcript.jsonl` + `manifest.json` into the scenario
+root, and **re-runs `expected-validate`** (Stage 5). It exits non-zero
+if validation fails but **leaves the new files in place**. Read the
+manifest's `expected_pass_rate` — that is the authoritative
+`pass_rate` for your return.
+
+- `pass_rate == 100%` (or all failures are `known_failing`) → status
+  `pass`.
+- `pass_rate < 100%` and not `known_failing` → still commit (the
+  recording is real captured data and `replay-fixtures.sh` should flag
+  the drift), status `pass`, but the `notes` MUST say **"VALIDATION
+  DRIFT — N/M phases; needs editorial review (do not assume green)."**
+  Do NOT rebase `expected.jsonl` to make it pass — that's the trap the
+  whole pipeline avoids; resolving real drift is a separate maintainer
+  task.
+
+For `--re-record`, also sanity-check structural determinism vs the
+archived previous recording (per [`../record/SKILL.md`](../record/SKILL.md)):
+state_transition order, distinct session_id count, and `process_exited`
+count must match. UUIDs / PIDs / timestamps / token counts may differ.
+Note any structural change in the return.
+
+### 7. Commit the recording (mandatory before returning)
+
+```bash
+git add replaydata/agents/<agent>/scenarios/<scenario>/
+git commit -m "feat(onboard): record <agent>/<scenario> (<pass_rate>)"
+git rev-parse --short HEAD   # → commit_sha for the return
+```
+
+**Always commit before returning.** A batched run (the dispatcher
+calling `implement` across many cells) must never leave a dirty tree
+under `replaydata/agents/` — the next cell's `precheck.sh` would refuse.
+If you somehow reach the end with uncommitted changes you can't justify,
+commit them with an explanatory message rather than leaving them
+dangling.
+
+> Repo commit convention: end commit messages with the trailer
+> `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+
+## Return contract
+
+Return ONLY this (≤6 lines), no transcripts:
+
+```
+status: pass | applicable_false | driver_gap | infra_fail
+commit_sha: <short sha>            # the recording commit (or the recipe/spec/applicable_false commit)
+pass_rate: <N/M phases>            # "n/a" for non-pass statuses
+agent: <agent>   scenario: <scenario>   mode: full | re-record
+notes: <one or two sentences — drift flag, scope_note, retry count, or infra reason>
+```
+
+Status meanings:
+
+- **`pass`** — recording captured, promoted, and committed. `pass_rate`
+  is the truth; a sub-100% rate with status `pass` means
+  committed-but-drifting (flagged in notes).
+- **`applicable_false`** — recipe can't elicit the behavior after one
+  retry, or the cell was assessed `no`/`n/a`. `by_adapter.<agent>` marked
+  `applicable: false` with a `scope_note`; recipe + spec + assessment
+  committed; no recording.
+- **`driver_gap`** — the recipe needs a step type the agent's driver
+  doesn't implement. Recipe marked `applicable: false`; committed; no
+  recording; no retry.
+- **`infra_fail`** — environment problem (CLI missing/old, auth, no
+  recording daemon). Nothing about the cell verdict changed; tree left
+  clean.
+
+## Anti-patterns
+
+- **Don't retry more than once.** One retry on timeout/transcript-missing,
+  then degrade. Never loop.
+- **Don't retry a driver gap.** A missing step type won't appear on a
+  re-run. Detect it in the pre-flight and return `driver_gap` immediately.
+- **Don't record on a dirty `replaydata/` tree.** Commit spec + recipe
+  first (step 4) — `precheck.sh` refuses otherwise.
+- **Don't rebase `expected.jsonl` to make a failing validation pass.**
+  A real drift is a signal to commit-and-flag, not to paper over.
+- **Don't author a recipe for an `applicable: no`/`n/a` cell.** Refuse at
+  the precondition check.
+- **Don't return without committing.** A dirty tree breaks the next
+  cell in a batch.
+- **Don't write the coverage matrix.** `agent-scenarios-coverage.json` is
+  the maintainer's editorial truth; surface drift in `notes`, don't edit it.

--- a/.claude/skills/ir:onboard-agent/scenario-create/SKILL.md
+++ b/.claude/skills/ir:onboard-agent/scenario-create/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: ir:onboard-agent/scenario-create
+description: >
+  Agent #1 of the ir:onboard-agent pipeline. Adds a brand-new scenario
+  ROW to the canonical matrix: a `scenarios[]` + `catalog[]` entry in
+  scenarios.json (top-level only — no per-adapter recipe), a
+  `scenario-meanings.md` glossary block, a coverage-matrix row with
+  every adapter `unknown`, and a new capability in features.json if one
+  is needed. One-shot, agent-agnostic, no agent CLI invocation, no live
+  recording. Invoked as `/ir:onboard-agent scenario-create <slug>`.
+---
+
+# scenario-create (Agent #1)
+
+> **You are running as a focused subagent with no parent context.**
+> Everything you need is in this file and the repo. Do not ask the
+> dispatcher for clarification — read the files named below, make the
+> edits, and return the summary in the "Return contract" section. This
+> task spends NO API tokens on agent CLIs and runs NO recording.
+
+## What this does
+
+Adds one new agent-agnostic scenario to the matrix so later stages
+(`assess`, then `implement`) have a row to fill. A scenario is defined
+ONCE, agent-agnostically, with `requires: [capability]`; per-adapter
+recipes and recordings are added later by `implement`. After you run,
+the new scenario shows up in the matrix as a row of `unknown` cells —
+no recipe, no recording, nothing claimed about any adapter yet.
+
+This is the matrix-ROW counterpart to discovery mode (`--new <slug>`),
+which adds matrix COLUMNS (a whole new agent). Don't confuse them.
+
+## Inputs
+
+- `<slug>` — kebab-case scenario id (stable; becomes the fixture dir
+  name and the `coverage_id`). E.g. `mid-turn-message-queued`.
+- A one-paragraph description of the behavior being captured. If the
+  dispatcher didn't pass one, derive it from the slug and state your
+  assumption in the summary.
+
+## Files you read
+
+- `.claude/skills/ir:onboard-agent/scenarios.json` — `catalog[]` (public
+  scenario list) and `scenarios[]` (declarations + recipes). Read a few
+  existing `scenarios[]` entries to copy the shape.
+- `.claude/skills/ir:onboard-agent/scenario-meanings.md` — the committed
+  prose glossary. Every scenario MUST have a block here (the canonical
+  `.specs/agent-scenarios.md` is gitignored/absent in most checkouts, so
+  this file is the source-of-record downstream stages read).
+- `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json` — the
+  rollup matrix. Read `agents[]` (the adapter list) and one
+  `scenarios[]` row for shape.
+- `replaydata/agents/features.json` — the canonical capability catalog.
+  `requires` IDs must exist here.
+
+## Files you write
+
+1. **`scenarios.json`** — two edits, in this one file:
+   - Append a `catalog[]` row: `{id, section, feature}`. Pick the
+     `section` from an existing catalog entry that fits (e.g. "Session
+     lifecycle", "Tool & permission interaction"); `feature` is the
+     human title.
+   - Append a `scenarios[]` entry with **top-level fields only**:
+     ```jsonc
+     {
+       "name": "<slug>",
+       "coverage_id": "<slug>",
+       "description": "<one paragraph: what behavior, why it matters>",
+       "requires": ["<capability-id>", ...],
+       "verify": { ... }            // agent-agnostic structural invariants
+     }
+     ```
+     **Do NOT add `by_adapter`.** Recipes are `implement`'s job. A
+     `scenarios[]` entry without `by_adapter` is valid — it declares the
+     scenario and its requirements; `run-cell.sh` simply reports
+     "missing-prompt" until a recipe lands.
+2. **`scenario-meanings.md`** — append a block in the same format as
+   existing blocks (read one first). Required fields:
+   - **Essence** — one sentence.
+   - **User-observable signal** — what a user SEES (state badge, count,
+     link, lifecycle, metric). User-observable only — never internal
+     event kinds or classifier rules.
+   - **Primitive exercised** — the underlying mechanism + the capability
+     it requires (e.g. "Requires `permission_hooks`."). Downstream
+     `assess`/`recipe`/`spec` read this field verbatim to pick the
+     capability key, so name the `requires` capability here explicitly.
+   - **Not to be confused with** — 1–2 sibling scenarios + the
+     distinction.
+   - **Conceptual flow** — numbered steps.
+3. **`agent-scenarios-coverage.json`** — append a `scenarios[]` row:
+   ```jsonc
+   {
+     "id": "<slug>",
+     "section": "<same section as the catalog row>",
+     "feature": "<same feature title>",
+     "coverage": {
+       // one entry per slug in the top-level `agents[]` array:
+       "<agent>": {"agent_supports": "unknown", "irrlicht_observes": "unknown", "notes": ""}
+     }
+   }
+   ```
+   Every adapter starts `unknown`/`unknown` — you are not assessing here.
+4. **`replaydata/agents/features.json`** — ONLY if `requires` needs a
+   capability that doesn't exist yet. Append a `features[]` entry
+   `{id, title, category, description, added_in}` (category = one of the
+   existing `categories[]` ids). Set `added_in` to today's date.
+
+## Choosing `requires`
+
+Map the description to capability IDs already in `features.json`. Be
+conservative: most scenarios require exactly one capability (often
+`headless_mode` for anything driven by a script). Add a NEW capability
+only when no existing one names the mechanism — and when you do, the
+`scenario-meanings.md` "Primitive exercised" line must mention it so the
+assess stage can resolve it.
+
+## Authoring `verify`
+
+Keep it agent-agnostic and structural — the per-adapter `verify` strings
+and the machine-checkable `expected.jsonl` come later from `implement`.
+A minimal honest block for most scenarios:
+
+```jsonc
+"verify": {
+  "transitions_topology": ["ready", "working", "ready"],
+  "final_state": "ready",
+  "tool_calls_max": 0
+}
+```
+
+Adjust topology/final_state to the description (e.g. a blocking-question
+scenario ends `waiting`; a tool scenario allows `tool_calls_max > 0`).
+Don't invent matchers that aren't in existing scenarios' `verify` blocks.
+
+## Validation before you return
+
+```bash
+SK=.claude/skills/ir:onboard-agent
+jq '.' $SK/scenarios.json > /dev/null                      # valid JSON
+jq '.' $SK/agent-scenarios-coverage.json > /dev/null       # valid JSON
+jq '.' replaydata/agents/features.json > /dev/null         # valid JSON
+# every requires id resolves:
+comm -23 \
+  <(jq -r '.scenarios[] | select(.name=="<slug>") | .requires[]' $SK/scenarios.json | sort -u) \
+  <(jq -r '.features[].id' replaydata/agents/features.json | sort -u)
+# ^ must print nothing. Any output = a requires id missing from features.json.
+```
+
+Confirm the slug now appears in all four artifacts: `catalog[]`,
+`scenarios[]`, `scenario-meanings.md`, and the coverage row.
+
+## Return contract
+
+Return ONLY this (≤5 lines), no transcripts:
+
+```
+scenario_id: <slug>
+capability_ids: [<id>, ...]            # requires; mark any you ADDED to features.json
+files_changed: scenarios.json, scenario-meanings.md, agent-scenarios-coverage.json[, features.json]
+verify: <one-line summary of the topology you wrote>
+next: assess <agent> <slug>  (per adapter, to fill the row)
+```
+
+## Anti-patterns
+
+- **Don't write `by_adapter`.** No recipes, no prompts, no scripts. That
+  is `implement`'s job and requires per-adapter knowledge you don't have
+  here.
+- **Don't assess.** Every coverage cell stays `unknown`. You are
+  declaring the row exists, not judging any agent against it.
+- **Don't skip `scenario-meanings.md`.** Without the block, `assess` and
+  `recipe` STOP with "scenario missing from scenario-meanings.md".
+- **Don't invent a capability when an existing one fits.** A bloated
+  `features.json` makes the matrix harder to reason about. Add one only
+  when the mechanism genuinely has no existing key.
+- **Don't run a recording or invoke an agent CLI.** This stage is pure
+  catalogue editing.

--- a/.claude/skills/ir:onboard-agent/skill.md
+++ b/.claude/skills/ir:onboard-agent/skill.md
@@ -1,538 +1,187 @@
 ---
 name: ir:onboard-agent
 description: >
-  Produce the canonical scenario × adapter fixture matrix for irrlicht. Drives
-  the real `claude` CLI (and future codex/pi drivers) through a shared scenario
-  catalogue, records lifecycle events, stages curated fixtures under
-  `.build/refresh/`, and summarizes material changes vs. committed fixtures.
-  Unifies three operations: refresh, bootstrap, and new-agent onboarding.
-  Use when user says "/ir:onboard-agent", "refresh fixtures", "onboard agent",
-  "regenerate recordings", or "update replay fixtures".
+  Maintain the canonical scenario × adapter fixture matrix for irrlicht.
+  A slim dispatcher that routes intent to three focused subagents —
+  `scenario-create` (add a matrix row), `assess` (judge one cell), and
+  `implement` (recipe→spec→record→validate→commit one cell) — plus
+  `--new <slug>` discovery (add a matrix column) and a no-arg matrix
+  status report. Each subagent returns a ≤5-line summary, so the parent
+  keeps its context for strategic decisions instead of drowning in
+  per-cell tool output. Use when the user says "/ir:onboard-agent",
+  "refresh fixtures", "onboard agent", "regenerate recordings", "add a
+  scenario", or "update replay fixtures".
 ---
 
-# Irrlicht Agent Onboarding
+# Irrlicht Agent Onboarding — dispatcher
 
-Produce or refresh the canonical scenario × adapter fixture matrix. There
-are two parallel axes:
+This skill maintains the scenario × adapter fixture matrix across two
+axes:
 
-1. **Agent scenarios** in `scenarios.json -> scenarios[]`. Agent-agnostic
-   declarations with `requires: [capability]`; per-adapter prompt under
-   `by_adapter`. Adapters declare `Capabilities` in
-   `core/adapters/inbound/agents/<adapter>/config.go`. Valid cells run a
-   real CLI under an isolated daemon and capture transcripts.
-2. **Orchestrator scenarios** in `scenarios.json -> orchestrator_scenarios[]`.
-   Per-orchestrator inputs under `by_orchestrator`. Each scenario
-   references a `fixture_dir` under `replaydata/orchestrators/<adapter>/`
-   containing seeded `gt`-style responses, sidecar files, and golden
-   `orchestrator.State` snapshots. Verification is a Go test against the
-   committed goldens.
+1. **Agent scenarios** (`scenarios.json -> scenarios[]`) — agent-agnostic
+   declarations with `requires: [capability]`; per-adapter recipes under
+   `by_adapter`. A cell is applicable when the adapter's
+   `capabilities.json` satisfies the scenario's `requires`. Valid cells
+   run a real CLI under a recording daemon and capture transcripts.
+2. **Orchestrator scenarios** (`scenarios.json -> orchestrator_scenarios[]`)
+   — per-orchestrator inputs under `by_orchestrator`, verified by a Go
+   test against committed goldens. Hermetic; no live CLI, no auth.
 
-The matrix of valid cells falls out automatically; running this skill
-populates or refreshes them.
+**Why a dispatcher of subagents:** a single onboarding sweep used to run
+hundreds of shell invocations and dump every `events.jsonl` /
+`transcript.jsonl` into one transcript, exhausting the parent's context
+long before the work was done. Now each mechanical operation is one
+`Agent` call that exhausts its OWN context and returns a short summary.
+The parent decides *which* cells to touch; the subagents do the work.
 
-Auth is the user's responsibility — `claude` subscription login, `codex`
-auth, etc. are set up out-of-band. If a CLI isn't authenticated it will say
-so on stderr and the run will fail cleanly. Orchestrator scenarios are
-hermetic and don't need auth.
+See [`README.md`](README.md) for the user-facing decision tree and a
+worked example, and [`cell-lifecycle.md`](cell-lifecycle.md) for the
+five-stage pipeline the subagents implement.
 
-## Invocations
+## Routing — pick the operation
 
-- **`/ir:onboard-agent`** — no args: compute and print the matrix status (see
-  Step 2). No cost spent.
-- **`/ir:onboard-agent <adapter>`** — run every cell that applies to
-  `<adapter>`. E.g. `/ir:onboard-agent claudecode` or
-  `/ir:onboard-agent gastown`.
-- **`/ir:onboard-agent <adapter> <scenario>`** — run one specific cell. E.g.
-  `/ir:onboard-agent claudecode basic-turn` or
-  `/ir:onboard-agent gastown agent-discovery`.
-- **`/ir:onboard-agent --attach <adapter> [<scenario>]`** — attached
-  mode. Uses the user's already-running `irrlichd --record` instead of
-  spawning an isolated daemon on port 7837. The dashboard stays
-  connected for the whole recording — the scenario's session shows up
-  live alongside the user's other work. Requirements:
-  - `pgrep -x irrlichd` returns a PID (else the precheck refuses).
-  - The daemon was started with `--record` (else its recordings dir is
-    empty and the precheck refuses).
-  - Optional: `IRRLICHT_RECORDINGS_DIR=<path>` if the daemon's recording
-    dir isn't the default `~/.local/share/irrlicht/recordings/`.
-  
-  After the driver returns, run-cell sleeps 6 seconds for the
-  recorder's 5s periodic flush + 1s slack, then curates the staged
-  fixture from the daemon's recording file. The daemon is never
-  signalled; it keeps observing whatever sessions the user has open.
-- **`/ir:onboard-agent --diff`** — re-summarize the latest staged runs
-  (under `.build/refresh/<adapter>/<scenario>-*/`) without re-running.
-- **`/ir:onboard-agent --new <slug>`** — discover mode. Researches a
-  previously unknown agent on the web via subagents and proposes a
-  `capabilities.json`. See `discovery-instructions.md` for the dispatch
-  recipe. No live agent CLI is invoked.
-### Per-stage subcommands (one per UI pipeline segment)
+| The user wants to… | Command | You dispatch |
+|---|---|---|
+| see matrix status (no cost) | `/ir:onboard-agent` (no args) | nothing — compute inline (below) |
+| track a NEW behavior the matrix lacks | `scenario-create <slug>` | `scenario-create` subagent |
+| judge whether `<agent>` supports `<scenario>` | `assess <agent> <scenario>` | `assess` subagent |
+| capture how `<agent>` does `<scenario>` | `implement <agent> <scenario>` | `implement` subagent |
+| re-record after a daemon change | `implement <agent> <scenario> --re-record` | `implement` subagent |
+| onboard a brand-NEW agent CLI | `--new <slug>` | discovery (see below) |
+| verify nothing regressed | `tools/replay-fixtures.sh` | nothing — pure script |
+| run an orchestrator scenario | `<orch> [<scenario>]` | inline (see Orchestrators) |
 
-The five `cell-lifecycle.md` stages each have a dedicated subcommand
-that maps 1:1 to the viewer's pipeline strip (⚙ ◉ ✎ § N ✓). Run
-them in order; later stages refuse to proceed if earlier stages
-haven't landed their artifact.
+The legacy per-stage verbs (`assess`/`recipe`/`spec`/`record`/`validate`)
+still exist as building blocks under their own `SKILL.md` files;
+`implement` bundles recipe→spec→record→validate behind one contract, so
+you rarely invoke the middle three directly.
 
-- **`/ir:onboard-agent assess`** — **Stage 1**. Three scopes share
-  the same verb:
-  - `assess <agent> <scenario>` — single cell. Writes a rich
-    `replaydata/agents/<agent>/scenarios/<scenario>/assessment.json`
-    (verdict + body + caveats + sources).
-  - `assess --column <agent>` — one agent, all scenarios. Writes a
-    candidate column at `.specs/agent-assess-<agent>.json` for the
-    maintainer to transcribe into the rollup matrix. (Replaces the
-    former `survey` skill.)
-  - `assess --row <scenario>` — one scenario, all adapters. Writes
-    a candidate row at `.specs/scenario-assess-<scenario>.json`.
-  See `assess/SKILL.md`.
-- **`/ir:onboard-agent recipe <agent> <scenario>`** — **Stage 2**.
-  Authors the deterministic driver script (preconditions, `script`
-  steps, verify items) into `scenarios.json -> scenarios[].by_adapter[<agent>]`.
-  See `recipe/SKILL.md`. (Renamed from `translate`.)
-- **`/ir:onboard-agent spec <agent> <scenario>`** — **Stage 3**.
-  Authors `replaydata/agents/<agent>/scenarios/<scenario>/expected.jsonl`
-  — the phase DSL that every recording is validated against. See
-  `spec/SKILL.md`. Author this BEFORE the recipe so the recipe's
-  `verify` items line up with concrete spec phases.
-- **`/ir:onboard-agent record <agent> <scenario>`** — **Stage 4**.
-  Drives the recipe against a live agent CLI + `irrlichd --record`,
-  archives the previous capture, promotes the new one. `--attach`
-  flag uses the user's running daemon. See `record/SKILL.md`.
-  (Alias for the bare `/ir:onboard-agent <agent> <scenario>` form
-  below.)
-- **`/ir:onboard-agent validate <agent> <scenario>`** — **Stage 5**.
-  Runs `expected-validate` against the latest recording (or a
-  specific archive) and reports per-phase pass/fail. Auto-invoked
-  by `record`; re-runnable by hand for drift detection. See
-  `validate/SKILL.md`.
+## Dispatching a subagent
 
-The adapter argument disambiguates which axis is being run: agent adapters
-(`claudecode`, `codex`, `pi`) match `scenarios[].by_adapter`; orchestrator
-adapters (`gastown`) match `orchestrator_scenarios[].by_orchestrator`.
-
-## Cell lifecycle — end-to-end workflow for ONE (agent × scenario)
-
-Every cell moves through a 5-stage pipeline. The viewer renders these
-stages as a strip per cell (`●● ✎ § N ✓`); the doc below is the
-canonical walkthrough.
+For `scenario-create`, `assess`, and `implement`, spawn ONE
+`general-purpose` Agent and let it run the corresponding self-contained
+`SKILL.md`. Brief it minimally — the SKILL.md carries the full contract:
 
 ```
-1. Assessment  →  2. Recipe       →  3. Spec          →  4. Recording      →  5. Validation
-   matrix verdict   scenarios.json     expected.jsonl      events.jsonl +       pass/fail per
-                    by_adapter[a]      phase DSL           transcript.jsonl     phase
-        │                │                  │                    │                    │
-        ▼                ▼                  ▼                    ▼                    ▼
-    /assess          /recipe            /spec               /record              /validate
+Agent(
+  subagent_type: "general-purpose",
+  description: "<verb> <agent>/<scenario>",
+  prompt: "Read and execute .claude/skills/ir:onboard-agent/<verb>/SKILL.md.
+           Inputs: agent=<agent> scenario=<scenario> [--re-record].
+           Follow it exactly and return ONLY the summary it specifies."
+)
 ```
 
-See [`cell-lifecycle.md`](cell-lifecycle.md) for:
+When the user asks for a column/row sweep (e.g. "assess every scenario
+for codex", "implement all never-recorded claudecode cells"), compute
+the cell list from the matrix status below, then dispatch **one Agent
+per cell**. Collect each subagent's ≤5-line summary into a table for the
+user. Don't run the per-cell mechanics yourself — that's what blows the
+context budget.
 
-- the canonical artifact + tool + success criterion per stage
-- the phase DSL field reference (`expected_state`, `same_session_as`,
-  `new_session`, etc.)
-- iteration loops (recording loop, daemon-fix loop, drift-detection)
-- a worked example (`claudecode/session-reset`)
-- explicit out-of-scope items
+After dispatching `implement`, the recording is already committed (that
+is part of its contract). Don't re-stage, re-diff, or re-commit; just
+relay its summary.
 
-When in doubt about a stage, jump to that section in
-`cell-lifecycle.md`. The subskills (`assess/`, `recipe/`, `spec/`,
-`record/`, `validate/`) implement individual stages. The lifecycle
-doc is how they fit together.
+## Matrix status (`list` — the no-arg path)
 
-## Step 1: Understand the task
-
-Parse the invocation into one of:
-- `list` — no args
-- `run_all` — one adapter
-- `run_one` — one adapter + one scenario
-- `diff_only` — `--diff` flag
-- `discover` — `--new <slug>`; load `discovery-instructions.md` and follow that recipe instead of Steps 2–5 below
-- `assess` — `assess <agent> <scenario>` (single) | `assess --column <agent>` | `assess --row <scenario>`; load `assess/SKILL.md` (Stage 1)
-- `recipe` — `recipe <agent> <scenario>`; load `recipe/SKILL.md` (Stage 2)
-- `spec` — `spec <agent> <scenario>`; load `spec/SKILL.md` (Stage 3)
-- `record` — `record <agent> <scenario>`; load `record/SKILL.md` (Stage 4)
-- `validate` — `validate <agent> <scenario>`; load `validate/SKILL.md` (Stage 5)
-- `pipeline` — `pipeline <agent> [<scenario>]`; load `pipeline/SKILL.md` and follow that recipe instead of Steps 2–5 below
-
-If the invocation is ambiguous, ask the user which mode to run.
-
-## Step 2: Compute matrix status
-
-Before any run (or as the sole output of `list`), compute the current state
-of **both** matrices.
+Compute and print the state of both matrices. No cost.
 
 ### Cross-reference check (run first)
 
-Every feature ID referenced by `scenarios.json -> scenarios[].requires` must
-exist in `replaydata/agents/features.json`; same for
-`orchestrator_scenarios[].requires` against
-`replaydata/orchestrators/features.json`. Unknown IDs are a hard error:
-report them as `scenario <name> requires <id> which is not in the canonical
-features list — add the feature or fix the typo`. Do not proceed with
-matrix computation until every reference resolves.
+Every `requires` id must exist in the canonical features list, else the
+matrix is undefined:
 
 ```bash
+SK=.claude/skills/ir:onboard-agent
 comm -23 \
-  <(jq -r '.scenarios[].requires[]' .claude/skills/ir:onboard-agent/scenarios.json | sort -u) \
+  <(jq -r '.scenarios[].requires[]' $SK/scenarios.json | sort -u) \
   <(jq -r '.features[].id' replaydata/agents/features.json | sort -u)
-# any output = unknown IDs — block.
+# any output = a scenario requires an unknown capability — block and report it.
 ```
 
 ### Agent matrix (`scenarios[]` × agent adapters)
 
-Each cell's state is one of:
+A scenario is applicable to an adapter iff every id in `requires` maps to
+`true` in that adapter's `capabilities.json -> features` (`false` and
+`"unknown"` both block). Per-cell state:
 
-- **OK** — fixture committed at `replaydata/agents/<adapter>/scenarios/<scenario>/{transcript,events}.jsonl`, and this session has not refreshed it.
-- **stale** — fixture committed, this session refreshed it, and the summarize step found material change.
-- **never-recorded** — capabilities match, `by_adapter.<adapter>` entry exists in `scenarios.json`, but no committed fixture.
-- **missing-prompt** — capabilities match but `by_adapter.<adapter>` is absent from `scenarios.json`. Actionable: add the entry.
-- **N/A (no <capability>)** — adapter's `capabilities.json` does not declare every required feature as `true`. Document which feature is missing or `unknown`.
+- **OK** — fixture committed at
+  `replaydata/agents/<adapter>/scenarios/<scenario>/{transcript,events}.jsonl`.
+- **never-recorded** — applicable + `by_adapter.<adapter>` recipe exists,
+  but no committed fixture. → `implement <adapter> <scenario>`.
+- **missing-recipe** — applicable but no `by_adapter.<adapter>` entry. →
+  `implement` (which authors it) once `assess` says `applicable: yes`.
+- **unassessed** — no `assessment.json` yet. → `assess` first.
+- **N/A (no <capability>)** — adapter's capabilities don't satisfy
+  `requires`.
 
 ```bash
-SCENARIOS_JSON=.claude/skills/ir:onboard-agent/scenarios.json
-
-# Per-adapter capabilities (one file per adapter):
-for a in claudecode codex pi; do
+SK=.claude/skills/ir:onboard-agent
+for a in claudecode codex pi aider opencode; do
   echo "== $a =="
-  jq -r '.features | to_entries[] | "\(.key)=\(.value)"' \
-    replaydata/agents/$a/capabilities.json
+  jq -r '.features | to_entries[] | "\(.key)=\(.value)"' replaydata/agents/$a/capabilities.json
 done
-
-# Committed scenario fixtures:
-ls replaydata/agents/{claudecode,codex,pi}/scenarios/ 2>/dev/null
+ls replaydata/agents/*/scenarios/ 2>/dev/null
 ```
 
-Cell applicability rule: a scenario is applicable to an adapter iff every
-ID in `scenarios[].requires` maps to `true` in the adapter's
-`capabilities.json -> features`. `false` and `"unknown"` both block.
+Print a table (rows = adapters, columns = scenarios) with a one-line hint
+on every non-OK cell.
 
-Print a table: rows = agent adapters, columns = scenario names. For any
-**missing-prompt** or **never-recorded** cell, append a one-line hint.
-
-### Orchestrator matrix (`orchestrator_scenarios[]` × orchestrator adapters)
-
-Each cell's state is one of:
-
-- **OK** — committed `golden/state-NNN.json` files cover all `poll_ticks` declared in `by_orchestrator.<adapter>`.
-- **stale** — this session ran `drive-gastown.sh` and the summarize step reported `verdict: CHANGED`.
-- **never-recorded** — `by_orchestrator.<adapter>` entry exists but the scenario's `golden/` directory is empty or missing.
-- **missing-fixture** — `by_orchestrator.<adapter>` entry exists but `replaydata/orchestrators/<adapter>/<scenario>/input/` is missing. Actionable: add the input fixtures.
+### Orchestrator matrix (`orchestrator_scenarios[]` × orchestrators)
 
 ```bash
-# Orchestrator scenarios + their fixture dirs:
 jq -r '.orchestrator_scenarios[] | "\(.name)\t\(.by_orchestrator.gastown.fixture_dir)\t\(.by_orchestrator.gastown.poll_ticks)"' \
-  $SCENARIOS_JSON
-
-# Existing goldens:
+  .claude/skills/ir:onboard-agent/scenarios.json
 find replaydata/orchestrators/gastown/scenarios -name 'state-*.json' 2>/dev/null | sort
 ```
 
-Print a second table: rows = orchestrator adapters (currently just `gastown`),
-columns = orchestrator scenario names.
+States: **OK** (goldens cover all `poll_ticks`), **never-recorded** (no
+`golden/`), **missing-fixture** (no `input/`).
 
-## Step 3: Execute cells
+## Orchestrators (inline — no subagent)
 
-Dispatch by adapter type:
+Orchestrator scenarios are hermetic, so the parent runs them directly
+(they're cheap and produce no live-agent token cost):
 
-### Agent cells
-
-For each (agent-adapter, scenario) cell, invoke
-`scripts/run-cell.sh <adapter> <scenario>`. The script handles:
-- `scripts/precheck.sh` (pgrep, git-clean, CLI version, build daemon)
-- isolated daemon launch with `IRRLICHT_RECORDINGS_DIR`
-- driver invocation via `scripts/drive-<adapter>.sh`
-- graceful shutdown (SIGINT → 6s → SIGTERM → SIGKILL)
-- transcript resolution via session UUID
-- `tools/curate-lifecycle-fixture.sh -d <staging>/replaydata/agents …`
-- replay report generation (staged + committed, if any)
-- `run-manifest.json` writeback
-
-**Pre-cell gate** (only relevant for agents new to irrlicht): if the
-adapter has a `replaydata/agents/<name>/capabilities.json` but no entry
-in `core/cmd/irrlichd/main.go:agentCfgs` yet, the daemon literally
-cannot see it. Before running cells for a new adapter, complete the
-post-discovery live recording smoke described in
-`discovery-instructions.md → Post-discovery gate`. That step adds the
-minimum stub adapter, drives the agent in tmux, and produces a recording
-that classifies the daemon's detection as PASS / PARTIAL / FAIL.
-
-**Post-cell UI gate** (also new-adapter only): once cells pass, walk
-the macOS UI checklist in
-`discovery-instructions.md → Post-onboarding macOS UI checklist` to
-add the adapter's icon, display name, and verify the session row
-renders icon + name + short model + context + cost correctly. Skipping
-this leaves the row showing the Claude Code mascot and the literal
-provider/route prefix on the model — confusing for users.
-
-**On cell failure**: when `run-cell.sh` exits nonzero or the manifest's
-`error` field is set, run `scripts/lib/classify-failure.sh <staging>`. The
-output is `{"code": "<code>", "summary": "...", "evidence": "..."}`. Look
-up `<code>` in `install-instructions.md` for the matching action recipe.
-Use `AskUserQuestion` to present three options: "show install/auth
-instructions", "I'll fix manually — wait", "skip this adapter". On
-"show", paste the relevant install-instructions.md section verbatim and
-pause. On "wait", continue paused until the user says "retry". On "skip",
-mark the cell `BLOCKED` in the Step 4 summary and move on.
-
-### Orchestrator cells
-
-For each (orchestrator-adapter, orchestrator-scenario) cell, invoke
-`scripts/drive-<adapter>.sh <scenario>` directly (no run-cell.sh wrapper —
-orchestrator scenarios are hermetic and don't need a live daemon). For
-gastown, the script:
-
-- Stages a writable copy of `replaydata/orchestrators/gastown/scenarios/<scenario>/` under `.build/refresh/gastown/<scenario>-<UTC-ts>/fixtures/<scenario>/`.
-- Runs `go test -run TestGastownReplay/<scenario> -update-goldens` against the staged copy via `GASTOWN_FIXTURES_DIR`.
-- Diffs the regenerated staged goldens against the committed `replaydata/` goldens.
-- Writes `run-manifest.json` with `verdict` (`OK` / `CHANGED` / `ERROR`) and the list of differing golden files.
-
-Stream the script's output as it runs. On nonzero exit, read
-`<staging>/run-manifest.json` and report the failing step specifically. Stop
-the batch on first failure.
-
-## Step 4: Summarize (the important step — read carefully)
-
-### Agent cells
-
-For each staged cell, read `<staging>/reports/staged.json` and (if present)
-`<staging>/reports/committed.json`. Produce a structured diff and a verdict.
-
-### Normalization rules
-
-Replay reports contain values that vary between runs even when behavior is
-identical. **Normalize both sides identically before comparing**, otherwise
-every refresh will look broken:
-
-1. **`generated_at`** — strip entirely. It's the replay wall clock.
-2. **UUIDs** — rewrite each distinct UUID seen (anywhere — `session_id`,
-   `session_uuid`, ids embedded in reasons) to `UUID_1`, `UUID_2`, … in
-   order of first appearance. Do this **per side independently**, not across
-   sides — the goal is to collapse UUID identity to "first UUID seen in
-   transitions," "second UUID seen," etc. If the two sides produce the
-   same normalized sequence, UUIDs don't count as a change.
-3. **Absolute timestamps** — replace with offsets (ms) from the first event's
-   timestamp in that report.
-4. **Durations** — quantize into 100ms buckets (`round(d/100)*100`). Small
-   timing jitter shouldn't register as change.
-5. **`virtual_time`** — likewise relative-to-first.
-6. **File paths** — strip the `.build/refresh/<adapter>/<scenario>-<ts>/`
-   prefix down to the scenario-relative path.
-
-Do the normalization in your reasoning step — don't write a normalizer
-script. The reports are JSON and usually under 2 KB per scenario; normalize
-by reading the JSON and mentally rewriting the fields.
-
-### Diff dimensions to report
-
-After normalizing, compare the two reports on these dimensions only:
-
-- **State transition sequence** — the list of `(prev_state, new_state)` pairs.
-  This is the load-bearing one.
-- **Flicker count** — `summary.flicker_count`.
-- **Tool call presence** — did any tool fire? Which category (Bash / Write /
-  Read / WebFetch / mcp__* / other)?
-- **Hook firings** — which hook `kind`s appear in `extended_check`?
-- **Final state** — last entry in transitions.
-- **Session count** — number of sessions in `sessions[]`.
-- **Estimated cost USD** — raw delta, not normalized.
-
-Do NOT diff exact transition-reason strings, per-event latencies, or model
-output text. Those are nondeterministic.
-
-### Evaluating `verify` matchers
-
-The scenario's `verify` block lists structural assertions you check against
-the staged report (and, for new fixtures, against the transcript). Most are
-self-explanatory — `final_state`, `has_waiting_state`, `tool_calls_max`,
-`contains_tool_call`, `contains_hook`, `transitions_topology`,
-`tool_call_failed`, `parent_linked_min`, `subagent_transcripts_min`. Three
-matchers introduced for the aider scenarios in #217 are less obvious because
-they require reading the staged transcript directly:
-
-- **`min_turns: N`** — count `> Tokens:` lines in the staged transcript (or
-  count transitions whose `last_event_type == "turn_done"` in the report).
-  Pass if ≥ N.
-- **`contains_interrupt: true`** — pass if the transcript shows more `####`
-  user-prompt markers than `> Tokens:` turn-close markers (the missing
-  Tokens line is the interrupt signature). Equivalent: at least one
-  `####` block has no `> Tokens:` before the next `####`.
-- **`model_changed: true`** — pass if the transcript contains two or more
-  distinct `> Model:` lines, OR if the report's transitions show two
-  different `model_name` values across turns.
-
-### Verdict for each cell
-
-Pick one:
-
-- **OK: no material change** — staged matches committed on every dimension
-  above.
-- **CHANGED (review)** — at least one dimension differs. List specifically
-  which dimension(s) and on which transition index. Example: "transitions[4]:
-  prev_state changed from `working` to `waiting` — investigate the tailer
-  change in PR #nnn."
-- **FIRST-RECORD (new fixture)** — no committed fixture existed; verify the
-  scenario's `verify` assertions against the staged report and report which
-  passed.
-- **VERIFY-FAIL** — staged report violates the scenario's `verify`
-  assertions. Block the commit suggestion.
-- **ERROR: <reason>** — `run-manifest.json` contains an error (transcript
-  not found, daemon shutdown SIGKILL, etc.).
-
-### Per-cell output format (agent)
-
-```
-[claudecode / basic-turn]  verdict: OK
-  transitions: 6 → 6 (sequence unchanged)
-  flicker_count: 0 → 0
-  tool_calls: (none) → (none)
-  final_state: ready → ready
+```bash
+.claude/skills/ir:onboard-agent/scripts/drive-gastown.sh <scenario>
 ```
 
-### Orchestrator cells
+The script stages a writable copy, runs
+`go test -run TestGastownReplay/<scenario> -update-goldens` against it,
+and writes `run-manifest.json` with `verdict` (`OK`/`CHANGED`/`ERROR`)
++ the differing golden files. Read the manifest, diff staged vs
+committed goldens for any `CHANGED` cell, and cross-check the scenario's
+`verify` block. Unlike agent cells, the maintainer reviews and commits
+orchestrator goldens by hand:
 
-The driver already produced the verdict. Read `<staging>/run-manifest.json`:
-
-- `verdict: OK` → no material change. The poller produced byte-identical
-  goldens against committed.
-- `verdict: CHANGED` → list `manifest.diffs` (the differing
-  `state-NNN.json` filenames). For each, also produce a structural diff
-  against the same dimensions used for agents where applicable: codebase
-  count/names, worker counts by role, global-agent presence, top-level
-  `running` flag. Diff the staged JSON against the committed JSON in
-  `<scenario>/golden/` to surface specifically which fields moved.
-- `verdict: ERROR` → read `<staging>/test.log` for the Go test failure and
-  surface the relevant test output (panic, missing fixture, parse error,
-  etc.).
-
-Cross-check the scenario's `verify` block in `scenarios.json` against the
-staged goldens:
-
-- `codebases_count`, `codebases_names`, `global_agents_roles` — direct field comparison on `state-001.json`.
-- `running`, `codebase_statuses` — direct field comparison.
-- `polecat_count_per_tick`, `boot_present_per_tick`, `codebases_count_per_tick` — read each tick's `state-NNN.json`, derive the array, compare.
-- `workers_with_session_min`, `expected_session_ids` — sum across worktrees and report.
-
-A `verify` failure with `verdict: OK` should be flagged as a
-**VERIFY-FAIL** verdict that blocks commit (the goldens reproduce, but
-they no longer match the scenario's intent — fixture inputs likely need
-adjusting).
-
-### Per-cell output format (orchestrator)
-
-```
-[gastown / agent-discovery]  verdict: OK
-  ticks: 1
-  codebases: 2 [gastown, irrlicht]
-  global_agents: 3 [mayor, deacon, boot]
-  verify: PASS
-
-[gastown / polling-lifecycle]  verdict: CHANGED
-  ticks: 3
-  diffs: state-002.json
-  delta: tick 2 — boot_present went true→false (regression: gt-fail
-         fallback path no longer drops the boot agent)
-  verify: PASS  (the verify block accepts the change, so this is a real
-                 regression in the poller, not a verify drift)
-```
-
-## Step 5: Next steps
-
-After summarizing, print the concrete commands the maintainer runs to
-commit accepted cells.
-
-### Agent cells
-
-```
-# Review each staged fixture vs current committed one:
-diff replaydata/agents/claudecode/basic-turn.jsonl \
-     .build/refresh/claudecode/basic-turn-20260424-152301/replaydata/agents/claudecode/basic-turn.jsonl
-
-# If satisfied, copy into replaydata/:
-cp .build/refresh/claudecode/basic-turn-*/replaydata/agents/claudecode/basic-turn.* \
-   replaydata/agents/claudecode/
-
-# Verify replay tests still pass:
-go test ./core/cmd/replay/... -run TestReplayWithSidecar
-
-# Commit:
-git add replaydata/agents/claudecode/basic-turn.* && git commit -m "..."
-```
-
-### Orchestrator cells
-
-```
-# Review the regenerated goldens vs committed:
-diff -r replaydata/orchestrators/gastown/scenarios/agent-discovery/golden \
-        .build/refresh/gastown/agent-discovery-20260425-101500/fixtures/agent-discovery/golden
-
-# If accepted, regenerate goldens in place (touches replaydata/ only):
+```bash
 go test ./core/adapters/inbound/orchestrators/gastown/ \
-        -run TestGastownReplay/agent-discovery -update-goldens
-
-# Verify the test now passes against committed:
-go test ./core/adapters/inbound/orchestrators/gastown/ -run TestGastownReplay
-
-# Commit:
-git add replaydata/orchestrators/gastown/scenarios/agent-discovery/ && git commit -m "..."
+        -run TestGastownReplay/<scenario> -update-goldens
+git add replaydata/orchestrators/gastown/scenarios/<scenario>/ && git commit -m "..."
 ```
 
-Do NOT run the `cp`, `-update-goldens`, or `git commit` yourself. The
-maintainer reviews and commits by hand — this skill never touches
-`replaydata/` directly.
+## Discovery mode (`--new <slug>`)
 
-## Authoring scenarios
-
-When adding a new entry to `scenarios.json` or fixing an existing one,
-keep these step-script rules in mind. The four interactive drivers
-(`drive-claudecode-interactive.sh`, `drive-aider-interactive.sh`,
-`drive-codex-interactive.sh`, `drive-pi-interactive.sh`) all share the
-same step grammar:
-
-- `{"type": "send", "text": "…"}` — type text + press Enter.
-- `{"type": "wait_turn"}` — block until the agent finishes the current
-  turn (criteria differs per adapter; e.g. claudecode waits for
-  `stop_reason: "end_turn"` in the transcript).
-- `{"type": "sleep", "seconds": N}` — pause N seconds. Two mandatory
-  uses in multi-turn scenarios:
-  1. **Between every `wait_turn` and the next `send`** (≥ 3s). Without
-     it, drivers fire the next prompt within 100–800ms of the assistant
-     finishing, which is below the state classifier's transcript-activity
-     debounce window — the recorder coalesces all turns into one
-     `working` → `ready` span and the replayed state band can't show
-     per-turn cycles.
-  2. **After the LAST `wait_turn`** (≥ 4s). `run-cell.sh` kills the
-     daemon as soon as the driver returns. If the final
-     `working`→`ready` transition hasn't fired yet (still within the
-     classifier's dwell window) the recording ends mid-turn. Trailing
-     sleep lets the classifier emit the final `ready` before SIGINT.
-- `{"type": "slash", "text": "/cmd"}` — same as `send`, semantically a
-  slash command.
-- `{"type": "interrupt"}` — Escape mid-turn (claudecode only).
-
-Single-turn scenarios (`basic-turn`, `permission-hook-denial`, etc.)
-use the simpler `"prompt": "…"` field — no script needed.
+Adds a matrix COLUMN (a whole new agent), as opposed to
+`scenario-create` which adds a ROW. Load
+[`discovery-instructions.md`](discovery-instructions.md) and follow that
+recipe — it researches the agent on the web, proposes a
+`capabilities.json`, and walks the stub-adapter + smoke-recording gate.
+No live agent CLI runs during discovery itself.
 
 ## Anti-patterns
 
-- **Don't** skip normalization in Step 4. UUID/timestamp drift will make
-  every refresh look like a break. This is the single most important
-  instruction.
-- **Don't** write fixtures directly to `replaydata/agents/`. All writes go to
-  `.build/refresh/`; maintainer copies manually.
-- **Don't** run with an existing `irrlichd` up. Both daemons would race on
-  port 7837 and hooks would route to the wrong one. `precheck.sh` refuses;
-  don't override.
-- **Don't** invent prompts for adapters that don't have `by_adapter`
-  entries. Report "missing-prompt" as actionable state — the user adds the
-  prompt by editing `scenarios.json` and runs again.
-- **Don't** author a multi-turn script with back-to-back `wait_turn` →
-  `send` steps. The classifier won't register the intermediate `ready`
-  state and the recording loses per-turn fidelity. Insert
-  `{"type":"sleep","seconds":3}` after every `wait_turn` that is
-  followed by another `send`.
-- **Don't** diff exact text from transition reasons, assistant output, or
-  tool-call arguments. Only structural invariants are stable across runs.
-- **Don't** run `go test -update-goldens` against `replaydata/orchestrators/`
-  yourself. Always go through `drive-gastown.sh`, which writes to
-  `.build/refresh/`. The maintainer chooses when (and whether) to
-  regenerate the committed goldens.
+- **Don't run per-cell mechanics in the parent.** Authoring recipes,
+  driving CLIs, curating fixtures, diffing reports — all of that belongs
+  inside an `implement` subagent. The parent routes and summarizes.
+- **Don't re-commit after `implement`.** It commits as part of its
+  contract; a clean tree is the handoff signal.
+- **Don't dispatch `implement` for an `applicable: no`/`n/a` cell.** It
+  refuses anyway — check the assessment first and save the round-trip.
+- **Don't run with an isolated daemon while a production `irrlichd` is
+  up.** Use `--attach` (the subagents do). `precheck.sh` enforces this.
+- **Don't edit `agent-scenarios-coverage.json` from the parent.** It's
+  the maintainer's editorial rollup; subagents surface drift in their
+  summaries.


### PR DESCRIPTION
Closes #434.

Long onboarding sessions exhausted the parent's context — the recent 12-cell sweep ran ~700 tool calls inline, dumping every `events.jsonl`/`transcript.jsonl` into one transcript. This restructures `ir:onboard-agent` so each mechanical operation is one `Agent` call that exhausts its OWN context and returns a ≤5-line summary; the parent only routes and summarizes.

## Changes

- **`scenario-create/SKILL.md`** (new) — adds a matrix ROW: `scenarios[]`+`catalog[]` entry (top-level only, no `by_adapter`), a `scenario-meanings.md` block, a coverage row of `unknown`, and a `features.json` capability if needed. Returns `{scenario_id, capability_ids, files_changed}`.
- **`assess/SKILL.md`** (refactored) — single-cell form is now a self-contained subagent that researches directly; adds the `{verdict, applicable, summary}` return contract and the `applicable` mapping (stops at `no`/`n/a`). Column/row batch modes preserved.
- **`implement/SKILL.md`** (new) — bundles spec→recipe→record→validate→commit. Retries a drive timeout **exactly once** then degrades to `applicable:false` with a `scope_note`; returns `driver_gap` immediately (no retry); **always commits before returning**. Commits spec+recipe *before* recording because `precheck.sh` refuses a dirty `replaydata/` tree.
- **`skill.md`** — slimmed 538→187 lines to a router (intent table + `Agent` dispatch recipe + matrix status + orchestrator path).
- **`README.md`** — decision tree is now the first scannable section; worked end-to-end example; building-block pointers; `tools/replay-fixtures.sh` documented as the CI gate.

## Notes vs. the issue spec

- The coverage matrix lives at `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json` (not `.specs/`); `README.md` already existed (restructured, not created); `scenario-create` also writes a `scenario-meanings.md` block since `.specs/agent-scenarios.md` is gitignored/absent and downstream stages read the committed glossary.

## Acceptance criteria

- [x] Three self-contained subagent prompts; README decision-tree-first; dispatcher routes intent.
- [x] `implement` retry-once → `applicable:false`+`scope_note`; immediate `driver_gap`; always-commit / no dirty tree.
- [x] **Smoke test passed live**: `implement claudecode user-blocking-question --re-record` recorded via `--attach`, validated **3/3**, produced a commit equivalent to a manual run (structurally identical to the archived recording; reverted to keep this PR scoped to the refactor).
- [x] `tools/replay-fixtures.sh` documented as the CI gate; green (`user-blocking-question PASS`).
- [ ] `go test ./core/...` — ⚠️ a **pre-existing** `TestFixtureReplayByteIdentity` failure in `core/cmd/replay` (golden `transitions_by_reason`/`model_name` drift) reproduces with all PR changes stashed, so it is on `main` and unrelated to this docs-only PR. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)