### PR TITLE
feat(quota): per-provider windowed usage spend + subscription empty-state (#386)

### DIFF
--- a/core/adapters/outbound/filesystem/cost_tracker.go
+++ b/core/adapters/outbound/filesystem/cost_tracker.go
@@ -256,85 +256,88 @@ func (t *CostTracker) projectCostsInWindow(windowSeconds int64) (map[string]floa
 	return all[k], nil
 }
 
-// ProjectCostsInWindows returns per-timeframe cost maps in a single pass over
-// each project file. The returned map keys mirror the keys of windowSeconds;
-// each inner map is projectName → USD for that window. O(files × rows) once,
-// regardless of how many windows are requested — the per-row aggregator
-// maintains one `windowAgg` tuple per requested window.
+// ProjectCostsInWindows returns per-timeframe cost maps keyed by project name.
+// Convenience wrapper around CostsInWindows for callers (and tests) that only
+// need the project axis.
 func (t *CostTracker) ProjectCostsInWindows(windowSeconds map[string]int64) (map[string]map[string]float64, error) {
-	out := make(map[string]map[string]float64, len(windowSeconds))
-	for k := range windowSeconds {
-		out[k] = make(map[string]float64)
-	}
-	if len(windowSeconds) == 0 {
-		return out, nil
-	}
-	entries, err := os.ReadDir(t.dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return out, nil
-		}
-		return nil, err
-	}
-	now := time.Now().Unix()
-	cutoffs := make(map[string]int64, len(windowSeconds))
-	for k, secs := range windowSeconds {
-		cutoffs[k] = now - secs
-	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if !strings.HasSuffix(name, ".jsonl") {
-			continue
-		}
-		fallback := strings.TrimSuffix(name, ".jsonl")
-		if err := t.sumProjectWindows(filepath.Join(t.dir, name), cutoffs, fallback, out); err != nil {
-			return nil, err
-		}
-	}
-	return out, nil
+	byProject, _, err := t.CostsInWindows(windowSeconds)
+	return byProject, err
 }
 
-// ProviderCostsInWindows mirrors ProjectCostsInWindows but buckets each
-// session's contribution by its billing provider ("anthropic", "openai")
-// rather than its project. A single project can mix providers (e.g. Claude
-// Code + Codex in one repo), so providers cannot be re-derived from the
-// per-project map client-side without double-counting. Rows with an empty
-// provider (pre-schema rows, wrapper agents) are excluded from the result.
+// ProviderCostsInWindows returns per-timeframe cost maps keyed by billing
+// provider. Convenience wrapper around CostsInWindows for callers (and tests)
+// that only need the provider axis.
 func (t *CostTracker) ProviderCostsInWindows(windowSeconds map[string]int64) (map[string]map[string]float64, error) {
-	out := make(map[string]map[string]float64, len(windowSeconds))
-	for k := range windowSeconds {
-		out[k] = make(map[string]float64)
-	}
+	_, byProvider, err := t.CostsInWindows(windowSeconds)
+	return byProvider, err
+}
+
+// CostsInWindows returns per-timeframe cost maps bucketed by project AND by
+// provider in a single pass over each cost file: byProject keys each inner map
+// by project name (falling back to the filename when a row carries no
+// project); byProvider keys by billing provider ("anthropic"/"openai"),
+// excluding rows with no known provider (pre-schema rows, unattributed
+// wrappers). A project can mix providers, so the provider axis can't be
+// re-derived from the project map client-side without double-counting — and
+// the sessions handler needs both for one response, so computing them together
+// halves the I/O vs. two separate scans. O(files × rows) once, regardless of
+// how many windows are requested.
+func (t *CostTracker) CostsInWindows(windowSeconds map[string]int64) (byProject, byProvider map[string]map[string]float64, err error) {
+	byProject = newWindowMap(windowSeconds)
+	byProvider = newWindowMap(windowSeconds)
 	if len(windowSeconds) == 0 {
-		return out, nil
+		return byProject, byProvider, nil
 	}
 	entries, err := os.ReadDir(t.dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return out, nil
+			return byProject, byProvider, nil
 		}
-		return nil, err
+		return nil, nil, err
 	}
+	cutoffs := cutoffsFor(windowSeconds)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		agg, err := t.scanWindows(filepath.Join(t.dir, e.Name()), cutoffs)
+		if err != nil {
+			return nil, nil, err
+		}
+		fallback := strings.TrimSuffix(e.Name(), ".jsonl")
+		for _, s := range agg {
+			projectKey := s.project
+			if projectKey == "" {
+				projectKey = fallback
+			}
+			addContributions(s, projectKey, byProject)
+			if s.provider != "" {
+				addContributions(s, s.provider, byProvider)
+			}
+		}
+	}
+	return byProject, byProvider, nil
+}
+
+// newWindowMap allocates an outer timeframe→inner-map structure with one empty
+// inner map per requested window.
+func newWindowMap(windowSeconds map[string]int64) map[string]map[string]float64 {
+	out := make(map[string]map[string]float64, len(windowSeconds))
+	for k := range windowSeconds {
+		out[k] = make(map[string]float64)
+	}
+	return out
+}
+
+// cutoffsFor converts trailing-window durations into absolute cutoff
+// timestamps anchored at a single `now`.
+func cutoffsFor(windowSeconds map[string]int64) map[string]int64 {
 	now := time.Now().Unix()
 	cutoffs := make(map[string]int64, len(windowSeconds))
 	for k, secs := range windowSeconds {
 		cutoffs[k] = now - secs
 	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		if !strings.HasSuffix(e.Name(), ".jsonl") {
-			continue
-		}
-		if err := t.sumProviderWindows(filepath.Join(t.dir, e.Name()), cutoffs, out); err != nil {
-			return nil, err
-		}
-	}
-	return out, nil
+	return cutoffs
 }
 
 // windowAgg accumulates the baseline/max needed to compute one session's
@@ -438,40 +441,6 @@ func addContributions(s *sessionWindows, key string, out map[string]map[string]f
 		}
 		out[tf][key] += d
 	}
-}
-
-// sumProjectWindows scans a project file and buckets each session's
-// contribution under its project name (falling back to the filename when a
-// row carries no project).
-func (t *CostTracker) sumProjectWindows(path string, cutoffs map[string]int64, fallbackName string, out map[string]map[string]float64) error {
-	agg, err := t.scanWindows(path, cutoffs)
-	if err != nil {
-		return err
-	}
-	for _, s := range agg {
-		key := s.project
-		if key == "" {
-			key = fallbackName
-		}
-		addContributions(s, key, out)
-	}
-	return nil
-}
-
-// sumProviderWindows scans a cost file and buckets each session's
-// contribution under its provider, skipping sessions with no known provider.
-func (t *CostTracker) sumProviderWindows(path string, cutoffs map[string]int64, out map[string]map[string]float64) error {
-	agg, err := t.scanWindows(path, cutoffs)
-	if err != nil {
-		return err
-	}
-	for _, s := range agg {
-		if s.provider == "" {
-			continue
-		}
-		addContributions(s, s.provider, out)
-	}
-	return nil
 }
 
 // Prune rewrites each project file to drop rows older than olderThanDays.

--- a/core/adapters/outbound/filesystem/cost_tracker.go
+++ b/core/adapters/outbound/filesystem/cost_tracker.go
@@ -28,7 +28,8 @@ const (
 // per line (JSONL).
 type snapshotRow struct {
 	TS        int64   `json:"ts"`
-	Project   string  `json:"project,omitempty"` // raw SessionState.ProjectName (filename is sanitized)
+	Project   string  `json:"project,omitempty"`  // raw SessionState.ProjectName (filename is sanitized)
+	Provider  string  `json:"provider,omitempty"` // "anthropic", "openai", or "" (unknown); see providerForSession
 	Session   string  `json:"session"`
 	Cost      float64 `json:"cost"`
 	CumIn     int64   `json:"cum_in,omitempty"`
@@ -37,10 +38,34 @@ type snapshotRow struct {
 	CumCreate int64   `json:"cum_create,omitempty"`
 }
 
+// providerForSession maps a session's source adapter to the billing provider
+// whose subscription/usage its cost draws from. Only first-party CLIs are
+// mapped today: wrapper agents (pi, opencode) resolve their provider
+// dynamically via rate-limit inheritance at request time, which isn't
+// available here at write time, so they record "" (unknown). Rows written
+// before this field existed also read back as "". Such rows are excluded from
+// the per-provider rollup but still counted in the per-project totals.
+func providerForSession(state *session.SessionState) string {
+	switch state.Adapter {
+	case "claude-code":
+		return "anthropic"
+	case "codex":
+		return "openai"
+	default:
+		return ""
+	}
+}
+
 // CostTracker persists per-session cost snapshots in append-only JSONL files,
 // one file per project, under <appSupport>/cost/.
 type CostTracker struct {
 	dir string
+
+	// providerOf resolves a session's billing provider for the snapshot row.
+	// Defaults to providerForSession (first-party adapters only); the daemon
+	// injects a resolver that also attributes wrapper agents — see
+	// SetProviderResolver.
+	providerOf func(*session.SessionState) string
 
 	// mu guards fileMus and lastWrite.
 	mu        sync.Mutex
@@ -62,14 +87,26 @@ func NewCostTracker() (*CostTracker, error) {
 // (useful for tests).
 func NewCostTrackerWithDir(dir string) *CostTracker {
 	return &CostTracker{
-		dir:       dir,
-		fileMus:   make(map[string]*sync.Mutex),
-		lastWrite: make(map[string]snapshotRow),
+		dir:        dir,
+		providerOf: providerForSession,
+		fileMus:    make(map[string]*sync.Mutex),
+		lastWrite:  make(map[string]snapshotRow),
 	}
 }
 
 // Dir returns the directory where cost files live.
 func (t *CostTracker) Dir() string { return t.dir }
+
+// SetProviderResolver overrides how snapshot rows are attributed to a billing
+// provider. The daemon injects a resolver backed by services.ProviderForSession
+// so wrapper agents (pi, opencode) attribute to the subscription they inherit;
+// the built-in default handles only first-party adapters. Call once at wiring
+// time — not safe to call concurrently with RecordSnapshot.
+func (t *CostTracker) SetProviderResolver(fn func(*session.SessionState) string) {
+	if fn != nil {
+		t.providerOf = fn
+	}
+}
 
 // RecordSnapshot appends a row for the session if cost or any cumulative
 // token count has changed since the last stored row, and at least
@@ -88,6 +125,7 @@ func (t *CostTracker) RecordSnapshot(state *session.SessionState) error {
 	row := snapshotRow{
 		TS:        time.Now().Unix(),
 		Project:   state.ProjectName,
+		Provider:  t.providerOf(state),
 		Session:   state.SessionID,
 		Cost:      m.EstimatedCostUSD,
 		CumIn:     m.CumInputTokens,
@@ -163,6 +201,7 @@ func (t *CostTracker) RecordBaseline(state *session.SessionState) error {
 	row := snapshotRow{
 		TS:        ts,
 		Project:   state.ProjectName,
+		Provider:  t.providerOf(state),
 		Session:   state.SessionID,
 		Cost:      m.EstimatedCostUSD,
 		CumIn:     m.CumInputTokens,
@@ -258,35 +297,83 @@ func (t *CostTracker) ProjectCostsInWindows(windowSeconds map[string]int64) (map
 	return out, nil
 }
 
-// sumProjectWindows streams a project file once and, per session, maintains
-// a window-agg tuple per timeframe. Each timeframe's contribution follows
-// the same rules as the single-window case:
+// ProviderCostsInWindows mirrors ProjectCostsInWindows but buckets each
+// session's contribution by its billing provider ("anthropic", "openai")
+// rather than its project. A single project can mix providers (e.g. Claude
+// Code + Codex in one repo), so providers cannot be re-derived from the
+// per-project map client-side without double-counting. Rows with an empty
+// provider (pre-schema rows, wrapper agents) are excluded from the result.
+func (t *CostTracker) ProviderCostsInWindows(windowSeconds map[string]int64) (map[string]map[string]float64, error) {
+	out := make(map[string]map[string]float64, len(windowSeconds))
+	for k := range windowSeconds {
+		out[k] = make(map[string]float64)
+	}
+	if len(windowSeconds) == 0 {
+		return out, nil
+	}
+	entries, err := os.ReadDir(t.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return out, nil
+		}
+		return nil, err
+	}
+	now := time.Now().Unix()
+	cutoffs := make(map[string]int64, len(windowSeconds))
+	for k, secs := range windowSeconds {
+		cutoffs[k] = now - secs
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		if err := t.sumProviderWindows(filepath.Join(t.dir, e.Name()), cutoffs, out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// windowAgg accumulates the baseline/max needed to compute one session's
+// contribution to one trailing window. Shared by the project and provider
+// rollups via scanWindows.
+type windowAgg struct {
+	baseline       float64
+	hasBaseline    bool
+	baselineInside bool
+	max            float64
+	hasMax         bool
+}
+
+// sessionWindows holds a single session's per-timeframe aggregators plus the
+// project and provider it belongs to (both constant across a session's rows).
+type sessionWindows struct {
+	project  string
+	provider string
+	windows  map[string]*windowAgg
+}
+
+// scanWindows streams one cost file once and returns per-session window
+// aggregators. The same scan feeds both the per-project and per-provider
+// rollups; callers pick which key to bucket by. Each timeframe's contribution
+// follows the same rules as the single-window case:
 //   - baseline = cost at the row just before cutoff if one exists, otherwise
 //     the minimum cost observed inside the window.
 //   - contribution = max(0, MAX(cost) − baseline).
-func (t *CostTracker) sumProjectWindows(path string, cutoffs map[string]int64, fallbackName string, out map[string]map[string]float64) error {
+func (t *CostTracker) scanWindows(path string, cutoffs map[string]int64) (map[string]*sessionWindows, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return nil, nil
 		}
-		return err
+		return nil, err
 	}
 	defer f.Close()
 
-	type windowAgg struct {
-		baseline       float64
-		hasBaseline    bool
-		baselineInside bool
-		max            float64
-		hasMax         bool
-	}
-	type perSession struct {
-		project string
-		windows map[string]*windowAgg
-	}
-	agg := make(map[string]*perSession)
-
+	agg := make(map[string]*sessionWindows)
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 	for scanner.Scan() {
@@ -300,7 +387,7 @@ func (t *CostTracker) sumProjectWindows(path string, cutoffs map[string]int64, f
 		}
 		s := agg[r.Session]
 		if s == nil {
-			s = &perSession{windows: make(map[string]*windowAgg, len(cutoffs))}
+			s = &sessionWindows{windows: make(map[string]*windowAgg, len(cutoffs))}
 			for k := range cutoffs {
 				s.windows[k] = &windowAgg{}
 			}
@@ -308,6 +395,9 @@ func (t *CostTracker) sumProjectWindows(path string, cutoffs map[string]int64, f
 		}
 		if r.Project != "" {
 			s.project = r.Project
+		}
+		if r.Provider != "" {
+			s.provider = r.Provider
 		}
 		for k, cutoff := range cutoffs {
 			w := s.windows[k]
@@ -331,24 +421,55 @@ func (t *CostTracker) sumProjectWindows(path string, cutoffs map[string]int64, f
 		}
 	}
 	if err := scanner.Err(); err != nil && err != io.EOF {
+		return nil, err
+	}
+	return agg, nil
+}
+
+// addContributions folds one session's per-window deltas into out under key.
+func addContributions(s *sessionWindows, key string, out map[string]map[string]float64) {
+	for tf, w := range s.windows {
+		if !w.hasMax {
+			continue
+		}
+		d := w.max - w.baseline
+		if d <= 0 {
+			continue
+		}
+		out[tf][key] += d
+	}
+}
+
+// sumProjectWindows scans a project file and buckets each session's
+// contribution under its project name (falling back to the filename when a
+// row carries no project).
+func (t *CostTracker) sumProjectWindows(path string, cutoffs map[string]int64, fallbackName string, out map[string]map[string]float64) error {
+	agg, err := t.scanWindows(path, cutoffs)
+	if err != nil {
 		return err
 	}
-
 	for _, s := range agg {
 		key := s.project
 		if key == "" {
 			key = fallbackName
 		}
-		for tf, w := range s.windows {
-			if !w.hasMax {
-				continue
-			}
-			d := w.max - w.baseline
-			if d <= 0 {
-				continue
-			}
-			out[tf][key] += d
+		addContributions(s, key, out)
+	}
+	return nil
+}
+
+// sumProviderWindows scans a cost file and buckets each session's
+// contribution under its provider, skipping sessions with no known provider.
+func (t *CostTracker) sumProviderWindows(path string, cutoffs map[string]int64, out map[string]map[string]float64) error {
+	agg, err := t.scanWindows(path, cutoffs)
+	if err != nil {
+		return err
+	}
+	for _, s := range agg {
+		if s.provider == "" {
+			continue
 		}
+		addContributions(s, s.provider, out)
 	}
 	return nil
 }

--- a/core/adapters/outbound/filesystem/cost_tracker_test.go
+++ b/core/adapters/outbound/filesystem/cost_tracker_test.go
@@ -368,3 +368,74 @@ func abs(f float64) float64 {
 	}
 	return f
 }
+
+func TestRecordSnapshot_StampsProvider(t *testing.T) {
+	tr := newTestTracker(t)
+	state := &session.SessionState{
+		SessionID:   "s1",
+		ProjectName: "proj-a",
+		Adapter:     "codex",
+		Metrics:     &session.SessionMetrics{EstimatedCostUSD: 0.10},
+	}
+	if err := tr.RecordSnapshot(state); err != nil {
+		t.Fatal(err)
+	}
+	rows := readRows(t, tr.filePath("proj-a"))
+	if len(rows) != 1 || rows[0].Provider != "openai" {
+		t.Fatalf("want one row with provider openai, got %+v", rows)
+	}
+}
+
+func TestRecordSnapshot_UsesInjectedProviderResolver(t *testing.T) {
+	tr := newTestTracker(t)
+	// pi resolves to "" under the default resolver; the injected one
+	// attributes it (mirrors the daemon wiring for wrapper agents).
+	tr.SetProviderResolver(func(s *session.SessionState) string { return "anthropic" })
+	state := &session.SessionState{
+		SessionID:   "s1",
+		ProjectName: "proj-a",
+		Adapter:     "pi",
+		Metrics:     &session.SessionMetrics{EstimatedCostUSD: 0.10},
+	}
+	if err := tr.RecordSnapshot(state); err != nil {
+		t.Fatal(err)
+	}
+	rows := readRows(t, tr.filePath("proj-a"))
+	if len(rows) != 1 || rows[0].Provider != "anthropic" {
+		t.Fatalf("want one row with injected provider anthropic, got %+v", rows)
+	}
+}
+
+// TestProviderCostsInWindows_BucketsByProvider verifies that a single project
+// file mixing providers attributes each session to its own provider (the
+// reason the rollup can't be derived from the per-project map), and that
+// sessions with no known provider are excluded.
+func TestProviderCostsInWindows_BucketsByProvider(t *testing.T) {
+	tr := newTestTracker(t)
+	now := time.Now().Unix()
+	// Each session: a pre-window baseline + an in-window max ⇒ contribution
+	// is max−baseline. All three live in one project file.
+	writeRow(t, tr, "proj-a", snapshotRow{TS: now - 10*3600, Provider: "anthropic", Session: "a1", Cost: 1.00})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: now - 1*3600, Provider: "anthropic", Session: "a1", Cost: 1.25})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: now - 10*3600, Provider: "openai", Session: "o1", Cost: 2.00})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: now - 1*3600, Provider: "openai", Session: "o1", Cost: 2.50})
+	// Unknown-provider session (pre-schema row / wrapper agent) — excluded.
+	writeRow(t, tr, "proj-a", snapshotRow{TS: now - 10*3600, Session: "u1", Cost: 5.00})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: now - 1*3600, Session: "u1", Cost: 9.00})
+
+	got, err := tr.ProviderCostsInWindows(map[string]int64{"day": 24 * 3600, "week": 7 * 24 * 3600})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tf := range []string{"day", "week"} {
+		if v := got[tf]["anthropic"]; abs(v-0.25) > 0.01 {
+			t.Errorf("%s anthropic: want ≈0.25, got %v", tf, v)
+		}
+		if v := got[tf]["openai"]; abs(v-0.50) > 0.01 {
+			t.Errorf("%s openai: want ≈0.50, got %v", tf, v)
+		}
+		if v, ok := got[tf][""]; ok {
+			t.Errorf("%s: empty-provider bucket must be excluded, got %v", tf, v)
+		}
+	}
+}

--- a/core/application/services/quotainherit.go
+++ b/core/application/services/quotainherit.go
@@ -246,6 +246,38 @@ func recipientKey(s *session.SessionState, home string) (AccountKey, bool) {
 	return AccountKey{}, false
 }
 
+// ProviderForSession resolves the billing provider ("anthropic"/"openai", or
+// "" when unknown) a session's cost should be attributed to. First-party CLIs
+// map directly by adapter; wrapper agents (pi, opencode) resolve via the same
+// auth.json inspection used for rate-limit inheritance (recipientKey), so
+// their spend lands on the subscription they're actually billed against —
+// and on the same provider key the dashboard's quota chip uses for that
+// wrapper. `userHome` "" uses the real home (mirrors InheritRateLimits).
+func ProviderForSession(s *session.SessionState, userHome string) string {
+	if s == nil {
+		return ""
+	}
+	switch s.Adapter {
+	case "claude-code":
+		return ProviderAnthropic
+	case "codex":
+		return ProviderOpenAI
+	case "pi", "opencode":
+		home := userHome
+		if home == "" {
+			h, err := os.UserHomeDir()
+			if err != nil {
+				return ""
+			}
+			home = h
+		}
+		if key, ok := recipientKey(s, home); ok {
+			return key.Provider
+		}
+	}
+	return ""
+}
+
 // readCodexAccountID parses ~/.codex/auth.json and returns
 // tokens.account_id when the auth_mode is "chatgpt" (the OAuth/
 // subscription path). Returns "" for API-key users or any read/parse

--- a/core/application/services/quotainherit_test.go
+++ b/core/application/services/quotainherit_test.go
@@ -423,3 +423,46 @@ func TestInheritRateLimits_CodexAPIKeyDoesNotDonate(t *testing.T) {
 		t.Fatal("api-key codex should not donate to pi")
 	}
 }
+
+func TestProviderForSession(t *testing.T) {
+	// First-party adapters map directly and never read home (the switch
+	// returns before the home lookup), so userHome "" is safe here.
+	if got := ProviderForSession(&session.SessionState{Adapter: "claude-code"}, ""); got != ProviderAnthropic {
+		t.Errorf("claude-code: got %q, want %q", got, ProviderAnthropic)
+	}
+	if got := ProviderForSession(&session.SessionState{Adapter: "codex"}, ""); got != ProviderOpenAI {
+		t.Errorf("codex: got %q, want %q", got, ProviderOpenAI)
+	}
+	if got := ProviderForSession(&session.SessionState{Adapter: "aider"}, ""); got != "" {
+		t.Errorf("aider (unmapped): got %q, want \"\"", got)
+	}
+	if got := ProviderForSession(nil, ""); got != "" {
+		t.Errorf("nil: got %q, want \"\"", got)
+	}
+
+	// Wrapper agents resolve via the same auth.json inspection as
+	// rate-limit inheritance, so cost attributes to the right subscription.
+	piHome := stageAuth(t, map[string]any{
+		".pi/agent/auth.json": map[string]any{
+			"anthropic": map[string]any{"type": "oauth"},
+		},
+	})
+	if got := ProviderForSession(emptyWrapper("pi", "pi-1"), piHome); got != ProviderAnthropic {
+		t.Errorf("pi (anthropic auth): got %q, want %q", got, ProviderAnthropic)
+	}
+
+	jwt := makeJWT(fmt.Sprintf(`{%q:%q}`, "https://api.openai.com/auth.chatgpt_account_id", "acct-jwt"))
+	ocHome := stageAuth(t, map[string]any{
+		".local/share/opencode/auth.json": map[string]any{
+			"openai-oauth": map[string]any{"type": "oauth", "access_token": jwt},
+		},
+	})
+	if got := ProviderForSession(emptyWrapper("opencode", "oc-1"), ocHome); got != ProviderOpenAI {
+		t.Errorf("opencode (openai auth): got %q, want %q", got, ProviderOpenAI)
+	}
+
+	// Wrapper with no resolvable auth falls back to "".
+	if got := ProviderForSession(emptyWrapper("pi", "pi-2"), t.TempDir()); got != "" {
+		t.Errorf("pi (no auth): got %q, want \"\"", got)
+	}
+}

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -78,25 +78,17 @@ func handleGetSessions(repo outbound.SessionRepository, orchMonitor *services.Or
 }
 
 // costMaps returns the per-project and per-provider trailing-window cost maps,
-// recomputing both via the tracker when the cache is cold or stale. Either map
-// may be nil if its scan failed; callers must tolerate nil. A single per-file
-// scan of each kind keeps I/O bounded under concurrent polling.
+// recomputing both via a single tracker scan when the cache is cold or stale.
+// Either map is nil if the scan failed; callers must tolerate nil. The single
+// scan keeps I/O bounded under concurrent polling.
 func costMaps(tracker outbound.CostTracker, cache *costAttachCache) (byProject, byProvider map[string]map[string]float64) {
 	now := time.Now()
 	if p, pv, ok := cache.get(now); ok {
 		return p, pv
 	}
-	p, err := tracker.ProjectCostsInWindows(costTimeframeSeconds)
+	p, pv, err := tracker.CostsInWindows(costTimeframeSeconds)
 	if err != nil {
 		return nil, nil
-	}
-	pv, err := tracker.ProviderCostsInWindows(costTimeframeSeconds)
-	if err != nil {
-		// Don't cache a failed provider scan as authoritative — serve the
-		// project costs for this request but leave the cache cold so the
-		// next request retries the provider scan, instead of suppressing
-		// provider_costs for the whole TTL after one transient error.
-		return p, nil
 	}
 	cache.put(now, p, pv)
 	return p, pv

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -13,28 +13,40 @@ import (
 	"irrlicht/core/ports/outbound"
 )
 
-// costAttachCache caches the last ProjectCostsInWindows result so successive
-// /api/v1/sessions hits within costAttachTTL reuse one scan. Shared across
-// requests; the zero value is an empty cache.
+// sessionsResponse is the /api/v1/sessions payload. Groups is the dashboard
+// hierarchy (per-project group costs live on each group's `costs` field);
+// ProviderCosts holds per-provider trailing-window spend
+// (providerKey → timeframe → USD) so clients can render windowed usage chips
+// without re-attributing project costs — a single project can mix providers.
+type sessionsResponse struct {
+	Groups        []*session.AgentGroup         `json:"groups"`
+	ProviderCosts map[string]map[string]float64 `json:"provider_costs,omitempty"`
+}
+
+// costAttachCache caches the last project + provider cost scans so successive
+// /api/v1/sessions hits within costAttachTTL reuse them. A single TTL governs
+// both maps. Shared across requests; the zero value is an empty cache.
 type costAttachCache struct {
 	mu          sync.RWMutex
 	generatedAt time.Time
-	byTimeframe map[string]map[string]float64
+	byProject   map[string]map[string]float64 // timeframe → project → USD
+	byProvider  map[string]map[string]float64 // timeframe → provider → USD
 }
 
-func (c *costAttachCache) get(now time.Time) (map[string]map[string]float64, bool) {
+func (c *costAttachCache) get(now time.Time) (byProject, byProvider map[string]map[string]float64, ok bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	if c.byTimeframe == nil || now.Sub(c.generatedAt) > costAttachTTL {
-		return nil, false
+	if c.byProject == nil || now.Sub(c.generatedAt) > costAttachTTL {
+		return nil, nil, false
 	}
-	return c.byTimeframe, true
+	return c.byProject, c.byProvider, true
 }
 
-func (c *costAttachCache) put(now time.Time, v map[string]map[string]float64) {
+func (c *costAttachCache) put(now time.Time, byProject, byProvider map[string]map[string]float64) {
 	c.mu.Lock()
 	c.generatedAt = now
-	c.byTimeframe = v
+	c.byProject = byProject
+	c.byProvider = byProvider
 	c.mu.Unlock()
 }
 
@@ -53,30 +65,50 @@ func handleGetSessions(repo outbound.SessionRepository, orchMonitor *services.Or
 		// builder then sees the inherited snapshots and the chip
 		// renders for the wrapper just like it does for the donor.
 		services.InheritRateLimits(sessions, "")
-		resp := session.BuildDashboard(sessions, orchMonitor.State("gastown"))
+		groups := session.BuildDashboard(sessions, orchMonitor.State("gastown"))
+		resp := sessionsResponse{Groups: groups}
 		if tracker != nil {
-			attachGroupCosts(resp, tracker, cache)
+			byProject, byProvider := costMaps(tracker, cache)
+			attachGroupCosts(groups, byProject)
+			resp.ProviderCosts = providerCostsByProvider(byProvider)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
 	}
 }
 
+// costMaps returns the per-project and per-provider trailing-window cost maps,
+// recomputing both via the tracker when the cache is cold or stale. Either map
+// may be nil if its scan failed; callers must tolerate nil. A single per-file
+// scan of each kind keeps I/O bounded under concurrent polling.
+func costMaps(tracker outbound.CostTracker, cache *costAttachCache) (byProject, byProvider map[string]map[string]float64) {
+	now := time.Now()
+	if p, pv, ok := cache.get(now); ok {
+		return p, pv
+	}
+	p, err := tracker.ProjectCostsInWindows(costTimeframeSeconds)
+	if err != nil {
+		return nil, nil
+	}
+	pv, err := tracker.ProviderCostsInWindows(costTimeframeSeconds)
+	if err != nil {
+		// Don't cache a failed provider scan as authoritative — serve the
+		// project costs for this request but leave the cache cold so the
+		// next request retries the provider scan, instead of suppressing
+		// provider_costs for the whole TTL after one transient error.
+		return p, nil
+	}
+	cache.put(now, p, pv)
+	return p, pv
+}
+
 // attachGroupCosts populates each top-level group's Costs map with the
 // trailing-window cost for day/week/month/year. Orchestrator groups are
 // skipped — their agents span projects, so group-level aggregation is
-// ambiguous. Uses a single per-file scan (ProjectCostsInWindows) + a small
-// per-handler TTL cache to keep I/O bounded under concurrent polling.
-func attachGroupCosts(groups []*session.AgentGroup, tracker outbound.CostTracker, cache *costAttachCache) {
-	now := time.Now()
-	byTf, ok := cache.get(now)
-	if !ok {
-		m, err := tracker.ProjectCostsInWindows(costTimeframeSeconds)
-		if err != nil {
-			return
-		}
-		cache.put(now, m)
-		byTf = m
+// ambiguous.
+func attachGroupCosts(groups []*session.AgentGroup, byTf map[string]map[string]float64) {
+	if byTf == nil {
+		return
 	}
 	for _, g := range groups {
 		if g == nil || g.Type == "gastown" {
@@ -92,6 +124,34 @@ func attachGroupCosts(groups []*session.AgentGroup, tracker outbound.CostTracker
 			g.Costs = costs
 		}
 	}
+}
+
+// providerCostsByProvider inverts the tracker's timeframe→provider→USD map
+// into the response shape providerKey→timeframe→USD (e.g.
+// {"anthropic": {"day": 0.5, ...}}). Empty-provider buckets are dropped.
+// Returns nil when there's nothing to report so the field is omitted.
+func providerCostsByProvider(byTf map[string]map[string]float64) map[string]map[string]float64 {
+	if byTf == nil {
+		return nil
+	}
+	out := make(map[string]map[string]float64)
+	for tf, perProvider := range byTf {
+		for provider, v := range perProvider {
+			if provider == "" {
+				continue
+			}
+			m := out[provider]
+			if m == nil {
+				m = make(map[string]float64, len(costTimeframeSeconds))
+				out[provider] = m
+			}
+			m[tf] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // handleGetVersion serves the daemon's build version. Frontends use it to

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net"
 	"mime"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
@@ -33,6 +33,7 @@ import (
 	wshub "irrlicht/core/adapters/outbound/websocket"
 	"irrlicht/core/application/services"
 	"irrlicht/core/domain/config"
+	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/capacity"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/ports/inbound"
@@ -703,6 +704,12 @@ func initCostTracker(logger outbound.Logger, fsRepo *filesystem.SessionRepositor
 		logger.LogError("startup", "", fmt.Sprintf("failed to init cost tracker: %v", err))
 		return nil
 	}
+	// Attribute wrapper agents (pi, opencode) to the subscription they
+	// inherit, so per-provider spend matches the dashboard's quota chip
+	// instead of going unattributed.
+	costTracker.SetProviderResolver(func(s *session.SessionState) string {
+		return services.ProviderForSession(s, "")
+	})
 	if err := costTracker.Prune(400); err != nil {
 		logger.LogError("startup", "", fmt.Sprintf("cost tracker prune failed: %v", err))
 	}

--- a/core/cmd/irrlichd/main_test.go
+++ b/core/cmd/irrlichd/main_test.go
@@ -357,6 +357,65 @@ func TestHandleGetSessions_AttachesGroupCosts(t *testing.T) {
 	}
 }
 
+// TestHandleGetSessions_AttachesProviderCosts verifies that /api/v1/sessions
+// surfaces the top-level provider_costs map (providerKey → timeframe → USD),
+// keyed by the row's provider rather than its project.
+func TestHandleGetSessions_AttachesProviderCosts(t *testing.T) {
+	repoDir := t.TempDir()
+	costDir := filepath.Join(t.TempDir(), "cost")
+	if err := os.MkdirAll(costDir, 0o700); err != nil {
+		t.Fatalf("mkdir cost dir: %v", err)
+	}
+
+	// Anthropic-stamped rows: $1.00 baseline (10h ago) → $1.25 now ⇒ $0.25
+	// in every trailing window.
+	now := time.Now().Unix()
+	writeCostRowWithProvider(t, costDir, "proj-a", "anthropic", now-10*3600, "sess-1", 1.00)
+	writeCostRowWithProvider(t, costDir, "proj-a", "anthropic", now-1*3600, "sess-1", 1.25)
+
+	repo := filesystem.NewWithDir(repoDir)
+	tracker := filesystem.NewCostTrackerWithDir(costDir)
+	if err := repo.Save(&session.SessionState{
+		SessionID:   "sess-1",
+		State:       session.StateReady,
+		ProjectName: "proj-a",
+		FirstSeen:   now - 10*3600,
+		UpdatedAt:   now,
+	}); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	push := services.NewPushService()
+	orchMonitor := services.NewOrchestratorMonitor(nil, push, nil)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(repo, orchMonitor, tracker))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/sessions")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	var payload sessionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	anthropic := payload.ProviderCosts["anthropic"]
+	if anthropic == nil {
+		t.Fatalf("provider_costs missing anthropic key: %+v", payload.ProviderCosts)
+	}
+	for _, tf := range []string{"day", "week", "month", "year"} {
+		if v, ok := anthropic[tf]; !ok || v < 0.24 || v > 0.26 {
+			t.Errorf("provider_costs[anthropic][%q]: want ≈0.25, got %v (ok=%v)", tf, v, ok)
+		}
+	}
+}
+
 // TestHandleGetSessions_OmitsCostsWhenTrackerNil keeps the no-tracker path
 // honest: the response must parse cleanly and groups must not carry a
 // costs field.
@@ -391,6 +450,22 @@ func TestHandleGetSessions_OmitsCostsWhenTrackerNil(t *testing.T) {
 func writeCostRow(t *testing.T, costDir, project string, ts int64, sessionID string, cost float64) {
 	t.Helper()
 	line := fmt.Sprintf(`{"ts":%d,"project":%q,"session":%q,"cost":%g}`+"\n", ts, project, sessionID, cost)
+	path := filepath.Join(costDir, project+".jsonl")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// writeCostRowWithProvider is writeCostRow with the provider field set, for
+// exercising the per-provider rollup surfaced as provider_costs.
+func writeCostRowWithProvider(t *testing.T, costDir, project, provider string, ts int64, sessionID string, cost float64) {
+	t.Helper()
+	line := fmt.Sprintf(`{"ts":%d,"project":%q,"provider":%q,"session":%q,"cost":%g}`+"\n", ts, project, provider, sessionID, cost)
 	path := filepath.Join(costDir, project+".jsonl")
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {

--- a/core/cmd/irrlichd/main_test.go
+++ b/core/cmd/irrlichd/main_test.go
@@ -95,10 +95,11 @@ func TestGate_GetSessions(t *testing.T) {
 		t.Fatalf("GET status: got %d, want 200", resp.StatusCode)
 	}
 
-	var groups []*session.AgentGroup
-	if err := json.NewDecoder(resp.Body).Decode(&groups); err != nil {
+	var payload sessionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
+	groups := payload.Groups
 	if len(groups) == 0 {
 		t.Fatal("expected at least one group")
 	}
@@ -326,20 +327,20 @@ func TestHandleGetSessions_AttachesGroupCosts(t *testing.T) {
 		t.Fatalf("status: got %d, want 200", resp.StatusCode)
 	}
 
-	var groups []*session.AgentGroup
-	if err := json.NewDecoder(resp.Body).Decode(&groups); err != nil {
+	var payload sessionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 
 	var projA *session.AgentGroup
-	for _, g := range groups {
+	for _, g := range payload.Groups {
 		if g.Name == "proj-a" {
 			projA = g
 			break
 		}
 	}
 	if projA == nil {
-		t.Fatalf("proj-a group missing from response: %+v", groups)
+		t.Fatalf("proj-a group missing from response: %+v", payload.Groups)
 	}
 	if projA.Costs == nil {
 		t.Fatalf("proj-a.Costs must not be nil")
@@ -370,11 +371,14 @@ func TestHandleGetSessions_OmitsCostsWhenTrackerNil(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	var groups []*session.AgentGroup
-	if err := json.NewDecoder(resp.Body).Decode(&groups); err != nil {
+	var payload sessionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	for _, g := range groups {
+	if payload.ProviderCosts != nil {
+		t.Errorf("provider_costs must be nil when tracker is nil, got %+v", payload.ProviderCosts)
+	}
+	for _, g := range payload.Groups {
 		if g.Costs != nil {
 			t.Errorf("group %q: Costs must be nil when tracker is nil, got %+v", g.Name, g.Costs)
 		}

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -141,6 +141,11 @@ type CostTracker interface {
 	// → USD for that window.
 	ProjectCostsInWindows(windowSeconds map[string]int64) (map[string]map[string]float64, error)
 
+	// ProviderCostsInWindows mirrors ProjectCostsInWindows but keys each
+	// inner map by billing provider ("anthropic", "openai") instead of
+	// project. Rows with no known provider are excluded.
+	ProviderCostsInWindows(windowSeconds map[string]int64) (map[string]map[string]float64, error)
+
 	// Prune drops snapshot rows older than the given number of days.
 	// Safe to call periodically (e.g. daemon startup).
 	Prune(olderThanDays int) error

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -135,16 +135,12 @@ type CostTracker interface {
 	// metrics or a project name.
 	RecordSnapshot(state *session.SessionState) error
 
-	// ProjectCostsInWindows returns per-timeframe cost maps in a single
-	// pass over each project file. The returned map keys mirror the
-	// caller-supplied windowSeconds keys; each inner map is projectName
-	// → USD for that window.
-	ProjectCostsInWindows(windowSeconds map[string]int64) (map[string]map[string]float64, error)
-
-	// ProviderCostsInWindows mirrors ProjectCostsInWindows but keys each
-	// inner map by billing provider ("anthropic", "openai") instead of
-	// project. Rows with no known provider are excluded.
-	ProviderCostsInWindows(windowSeconds map[string]int64) (map[string]map[string]float64, error)
+	// CostsInWindows returns per-timeframe cost maps in a single pass over
+	// each cost file. The returned map keys mirror the caller-supplied
+	// windowSeconds keys. byProject keys each inner map by projectName;
+	// byProvider keys by billing provider ("anthropic"/"openai"), excluding
+	// rows with no known provider. Both axes come from one scan.
+	CostsInWindows(windowSeconds map[string]int64) (byProject, byProvider map[string]map[string]float64, err error)
 
 	// Prune drops snapshot rows older than the given number of days.
 	// Safe to call periodically (e.g. daemon startup).

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -27,6 +27,7 @@ class SessionManager: ObservableObject {
     @Published var connectionState: ConnectionState = .disconnected
     @Published var lastError: String?
     @Published var apiGroups: [AgentGroup] = []  // recursive group structure from API
+    @Published var providerCosts: [String: [String: Double]] = [:]  // providerKey → timeframe → USD (windowed)
     @Published var stateHistory: [String: [String]] = [:]  // session_id → oldest→newest state strings (active granularity)
     @Published var historyBucketCount: Int = 60          // matches HistoryBucketCount on the daemon
 
@@ -210,6 +211,19 @@ class SessionManager: ObservableObject {
 
         reconnectDelay = min(reconnectDelay * 2, maxReconnectDelay)
         scheduleConnect(after: delay)
+    }
+
+    /// Top-level /api/v1/sessions payload: the dashboard hierarchy plus
+    /// per-provider trailing-window spend. `provider_costs` is keyed
+    /// providerKey → timeframe ("day"/"week"/"month"/"year") → USD.
+    struct SessionsResponse: Decodable {
+        let groups: [AgentGroup]
+        let providerCosts: [String: [String: Double]]?
+
+        enum CodingKeys: String, CodingKey {
+            case groups
+            case providerCosts = "provider_costs"
+        }
     }
 
     /// Recursive group structure from the sessions API.
@@ -422,7 +436,9 @@ class SessionManager: ObservableObject {
             let (data, response) = try await URLSession.shared.data(from: url)
             guard (response as? HTTPURLResponse)?.statusCode == 200 else { return }
             let decoder = JSONDecoder()
-            let topGroups = try decoder.decode([AgentGroup].self, from: data)
+            let payload = try decoder.decode(SessionsResponse.self, from: data)
+            let topGroups = payload.groups
+            providerCosts = payload.providerCosts ?? [:]
 
             apiGroups = orderedGroups(topGroups)
             groupedSessionIds = Set(topGroups.flatMap { collectSessionIds(from: $0) })

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -191,8 +191,13 @@ struct SessionListView: View {
     @State private var showSettings = false
     @AppStorage("displayMode") private var displayModeRaw: String = DisplayMode.context.rawValue
     @AppStorage("showQuotaForecast") private var showQuotaForecast: Bool = true
+    // Shared timeframe for all provider usage chips; clicking any chip cycles
+    // it. Independent of the project-cost timeframe (`projectCostTimeframe`).
+    @AppStorage("usageCostTimeframe") private var usageCostTimeframeRaw: String = CostTimeframe.day.rawValue
 
     private var displayMode: DisplayMode { DisplayMode(rawValue: displayModeRaw) ?? .context }
+    private var usageCostTimeframe: CostTimeframe { .from(usageCostTimeframeRaw) }
+    private func cycleUsageTimeframe() { usageCostTimeframeRaw = usageCostTimeframe.next().rawValue }
 
     var body: some View {
         if showSettings {
@@ -521,11 +526,11 @@ struct SessionListView: View {
     /// account report identical numbers anyway; freshness only matters
     /// when one session has gone stale.
     ///
-    /// For usage chips, `totalCostUSD` sums cumulative
-    /// `estimatedCostUSD` across every matching session — close enough
-    /// to "what the user has spent on this provider lately" for the
-    /// typical session-lifetime. Proper daily rollup needs a
-    /// daemon-side per-provider cost tracker (issue #385).
+    /// `totalCostUSD` sums cumulative `estimatedCostUSD` across every
+    /// matching session; it now feeds only the tooltip / accessibility
+    /// label ("cumulative spend across active sessions"). The usage chip
+    /// itself renders the daemon's windowed per-provider rollup
+    /// (`SessionManager.providerCosts`), not this cumulative figure.
     private func mergeIntoBuckets(session: SessionState, into buckets: inout [String: ChipBucket]) {
         guard let snap = session.metrics?.rateLimit else { return }
         let now = Date()
@@ -595,7 +600,7 @@ struct SessionListView: View {
 
     /// The chip-style header widget. Dispatches on mode:
     ///   - subscription → provider icon + stacked 5h/7d bars (mockup 1/2)
-    ///   - usage        → provider icon + cumulative spend (mockup 2)
+    ///   - usage        → provider icon + windowed spend, click-to-cycle (mockup 2)
     @ViewBuilder
     private func quotaChipView(_ d: QuotaWidgetData, compact: Bool) -> some View {
         HStack(spacing: 6) {
@@ -621,9 +626,19 @@ struct SessionListView: View {
             }
             switch d.mode {
             case .subscription:
-                VStack(alignment: .leading, spacing: 1) {
-                    ForEach(d.snapshot.windows, id: \.windowMinutes) { window in
-                        quotaWindowRow(window, compact: compact)
+                if d.snapshot.windows.isEmpty {
+                    // Subscription forced (or auto-detected) but the snapshot
+                    // carries no rate-limit windows. Symmetric with the usage
+                    // zero-state: a short phrase rather than an empty chip.
+                    Text("no subscription data")
+                        .font(.system(size: 9, design: .monospaced))
+                        .foregroundColor(.secondary)
+                        .frame(minWidth: 88, alignment: .leading)
+                } else {
+                    VStack(alignment: .leading, spacing: 1) {
+                        ForEach(d.snapshot.windows, id: \.windowMinutes) { window in
+                            quotaWindowRow(window, compact: compact)
+                        }
                     }
                 }
             case .usage:
@@ -638,16 +653,20 @@ struct SessionListView: View {
         .tooltip(quotaTooltip(d))
     }
 
-    /// Usage-mode chip body — cumulative spend across all sessions on
-    /// this provider, with a "spend" subtitle. Always 2 lines so the
-    /// chip has the same height as the subscription variant (5h + 7d
-    /// rows) and the two render cleanly side-by-side in the header.
+    /// Usage-mode chip body — windowed spend on this provider for the
+    /// currently selected timeframe, with a "spend" subtitle. Click to
+    /// cycle the timeframe (day → week → month → year), mirroring the
+    /// project-group cost text; the choice is shared across all usage
+    /// chips via `usageCostTimeframe`. Always 2 lines so the chip has the
+    /// same height as the subscription variant (5h + 7d rows) and the two
+    /// render cleanly side-by-side in the header.
     ///
-    /// Zero-state: when no spend has accumulated, render an em-dash and
-    /// "no spend yet" rather than "$0.00 / spend". The data path is
-    /// wired up, just nothing to report — important when a user has
-    /// forced-usage mode on a subscription-only session, where
-    /// `totalCostUSD` legitimately stays at zero.
+    /// Sourced from the daemon's per-provider cost rollup (`provider_costs`),
+    /// keyed by the chip's providerKey (`d.id`). A project can mix providers,
+    /// so this can't be re-derived from group costs client-side. When a
+    /// provider has no spend in the window we render `$0 / <frame>` — a
+    /// windowed zero is honest (matches the project cost display), so there's
+    /// no separate em-dash zero-state.
     ///
     /// A `minWidth: 88` matches the subscription chip's row width
     /// (label + 40pt bar + percent) so a usage chip with a short
@@ -655,23 +674,29 @@ struct SessionListView: View {
     /// bars chip.
     @ViewBuilder
     private func quotaUsageBody(_ d: QuotaWidgetData, compact: Bool) -> some View {
-        let hasSpend = d.totalCostUSD > 0
-        VStack(alignment: .leading, spacing: 1) {
-            Text(hasSpend ? formatUsageCost(d.totalCostUSD) : "—")
-                .font(.system(size: 10, weight: .semibold, design: .monospaced))
-                .foregroundColor(.primary)
-            Text(hasSpend ? "spend" : "no spend yet")
-                .font(.system(size: 9, design: .monospaced))
-                .foregroundColor(.secondary)
+        let spend = sessionManager.providerCosts[d.id]?[usageCostTimeframe.rawValue] ?? 0
+        Button(action: cycleUsageTimeframe) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text(formatUsageCost(spend) + usageCostTimeframe.suffix)
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .foregroundColor(.primary)
+                Text("spend")
+                    .font(.system(size: 9, design: .monospaced))
+                    .foregroundColor(.secondary)
+            }
+            .frame(minWidth: 88, alignment: .leading)
+            .contentShape(Rectangle())
         }
-        .frame(minWidth: 88, alignment: .leading)
+        .buttonStyle(.plain)
+        .tooltip("Click to cycle time frame (day → week → month → year)")
     }
 
-    /// Format the cost headline: tiny costs render `<$0.01`, normal
-    /// costs render with two decimals, ≥ $100 drops to integer dollars
-    /// to keep the chip from growing.
+    /// Format the cost headline: zero renders `$0`, tiny costs render
+    /// `<$0.01`, normal costs render with two decimals, ≥ $100 drops to
+    /// integer dollars to keep the chip from growing. Matches GroupView's
+    /// project-cost formatting so the suffix (` / day`, …) reads the same.
     private func formatUsageCost(_ cost: Double) -> String {
-        if cost <= 0 { return "$0.00" }
+        if cost <= 0 { return "$0" }
         if cost < 0.01 { return "<$0.01" }
         if cost >= 100 { return String(format: "$%.0f", cost) }
         return String(format: "$%.2f", cost)

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1,5 +1,8 @@
     // --- State ---
     let dashboardGroups = [];
+    // Per-provider trailing-window spend (providerKey → timeframe → USD) from
+    // the /api/v1/sessions `provider_costs` field. Feeds the usage chips.
+    let dashboardProviderCosts = {};
     let orchestrator = null;   // OrchestratorSummary from initial load
     let orchFull = null;       // Full orchestrator.State (global_agents, codebases) from WS / secondary fetch
     // Adapter branding from /api/v1/agents — keyed by adapter `name`
@@ -193,6 +196,12 @@
     ];
     let currentTimeframe = localStorage.getItem('irrlicht_costTimeframe') || 'day';
     if (!COST_TIMEFRAMES.find(t => t.key === currentTimeframe)) currentTimeframe = 'day';
+
+    // Usage chips share one timeframe, cycled by clicking any of them and
+    // persisted independently of the project-cost timeframe above — mirrors
+    // macOS's separate usageCostTimeframe (#386).
+    let currentUsageTimeframe = localStorage.getItem('irrlicht_usageCostTimeframe') || 'day';
+    if (!COST_TIMEFRAMES.find(t => t.key === currentUsageTimeframe)) currentUsageTimeframe = 'day';
 
     // --- Timeline / history state (WebSocket-streamed, see history_snapshot/tick/upgrade) ---
     let timelineHistory = new Map(); // session_id -> {label, states: string[]} for the active granularity
@@ -705,6 +714,22 @@
       currentTimeframe = COST_TIMEFRAMES[(idx + 1) % COST_TIMEFRAMES.length].key;
       localStorage.setItem('irrlicht_costTimeframe', currentTimeframe);
       render();
+    }
+
+    function cycleUsageTimeframe() {
+      const idx = COST_TIMEFRAMES.findIndex(t => t.key === currentUsageTimeframe);
+      currentUsageTimeframe = COST_TIMEFRAMES[(idx + 1) % COST_TIMEFRAMES.length].key;
+      localStorage.setItem('irrlicht_usageCostTimeframe', currentUsageTimeframe);
+      render();
+    }
+
+    // Windowed spend for a usage chip, keyed by providerKey (chip.key, e.g.
+    // "anthropic"/"openai") and the selected timeframe. 0 when the daemon has
+    // no provider_costs entry for that provider/window.
+    function usageSpendForChip(chip) {
+      const byTf = dashboardProviderCosts[chip.key];
+      const v = byTf && byTf[currentUsageTimeframe];
+      return typeof v === 'number' ? v : 0;
     }
 
     function updateGroupHeader(el, group) {
@@ -1254,6 +1279,7 @@
       }
       if (resp) {
         dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
+        dashboardProviderCosts = (resp && !Array.isArray(resp) && resp.provider_costs) || {};
         rebuildIndex();
       }
       render();
@@ -1308,6 +1334,13 @@
               if (a.children) mergeRateLimit(a.children);
             }
           })(g.agents);
+        }
+        // Refresh per-provider windowed spend the same way as group costs —
+        // it rides this response, not the WebSocket deltas.
+        const freshProviderCosts = (!Array.isArray(resp) && resp.provider_costs) || {};
+        if (JSON.stringify(freshProviderCosts) !== JSON.stringify(dashboardProviderCosts)) {
+          dashboardProviderCosts = freshProviderCosts;
+          changed = true;
         }
         if (changed) render();
       });
@@ -1555,7 +1588,7 @@
     }
 
     function formatUsageCost(cost) {
-      if (!cost || cost <= 0) return '$0.00';
+      if (!cost || cost <= 0) return '$0';
       if (cost < 0.01) return '<$0.01';
       if (cost >= 100) return '$' + Math.round(cost);
       return '$' + cost.toFixed(2);
@@ -1765,15 +1798,22 @@
           body.appendChild(buildQuotaRowDOM(w, compact, nowMs));
         }
       } else {
-        const hasSpend = chip.totalCostUSD > 0;
+        // Windowed per-provider spend for the selected timeframe, click-to-
+        // cycle — mirrors the project-group cost text and the macOS usage
+        // chip (#386). $0/<frame> is honest for a windowed zero, so there's
+        // no separate em-dash zero-state.
+        const tf = COST_TIMEFRAMES.find(t => t.key === currentUsageTimeframe) || COST_TIMEFRAMES[0];
         const head = document.createElement('span');
         head.className = 'quota-usage-headline';
-        head.textContent = hasSpend ? formatUsageCost(chip.totalCostUSD) : '—';
+        head.textContent = formatUsageCost(usageSpendForChip(chip)) + tf.suffix;
         const sub = document.createElement('span');
         sub.className = 'quota-usage-sublabel';
-        sub.textContent = hasSpend ? 'spend' : 'no spend yet';
+        sub.textContent = 'spend';
         body.appendChild(head);
         body.appendChild(sub);
+        body.style.cursor = 'pointer';
+        body.title = 'Click to cycle time frame (day → week → month → year)';
+        body.addEventListener('click', (e) => { e.stopPropagation(); cycleUsageTimeframe(); });
       }
       root.appendChild(body);
       return root;
@@ -1783,6 +1823,7 @@
       const pill = document.createElement('span');
       pill.className = 'quota-overflow';
       pill.textContent = '+' + hidden.length + ' more';
+      const usageTf = COST_TIMEFRAMES.find(t => t.key === currentUsageTimeframe) || COST_TIMEFRAMES[0];
       pill.title = hidden.map(h => {
         const label = planTypeLabel(h.snapshot.plan_type)
                    || (h.key.charAt(0).toUpperCase() + h.key.slice(1));
@@ -1790,7 +1831,7 @@
           const imm = h.imminent;
           return imm ? (label + ': ' + Math.round(imm.used_percent || 0) + '%') : label;
         }
-        return label + ': ' + (h.totalCostUSD > 0 ? formatUsageCost(h.totalCostUSD) : '—');
+        return label + ': ' + formatUsageCost(usageSpendForChip(h)) + usageTf.suffix;
       }).join('\n');
       return pill;
     }
@@ -1996,6 +2037,6 @@
 
 export {
   resolvedTheme, rowLabel, maybeNotifyOnUpdate,
-  formatCost, pressureClass, historyPriorityForState,
+  formatCost, formatUsageCost, pressureClass, historyPriorityForState,
   lastNotifiedPressure,
 };

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -4,6 +4,7 @@ import {
   rowLabel,
   maybeNotifyOnUpdate,
   formatCost,
+  formatUsageCost,
   pressureClass,
   historyPriorityForState,
   lastNotifiedPressure,
@@ -120,5 +121,28 @@ describe('historyPriorityForState', () => {
     expect(historyPriorityForState('working')).toBe(1)
     expect(historyPriorityForState('ready')).toBe(0)
     expect(historyPriorityForState('unknown')).toBe(-1)
+  })
+})
+
+describe('formatUsageCost', () => {
+  // Windowed usage chip headline (#386). Zero renders "$0" (a windowed zero
+  // is honest) to match the macOS chip, not "$0.00".
+  test('zero and falsy render "$0"', () => {
+    expect(formatUsageCost(0)).toBe('$0')
+    expect(formatUsageCost(undefined)).toBe('$0')
+    expect(formatUsageCost(-5)).toBe('$0')
+  })
+
+  test('sub-cent renders "<$0.01"', () => {
+    expect(formatUsageCost(0.004)).toBe('<$0.01')
+  })
+
+  test('normal costs render with two decimals', () => {
+    expect(formatUsageCost(1.2)).toBe('$1.20')
+    expect(formatUsageCost(0.5)).toBe('$0.50')
+  })
+
+  test('>= $100 drops to integer dollars', () => {
+    expect(formatUsageCost(105.3)).toBe('$105')
   })
 })

--- a/tools/agent-onboarding/internal/viewer/playback.go
+++ b/tools/agent-onboarding/internal/viewer/playback.go
@@ -301,16 +301,16 @@ func (m *PlaybackManager) StartViewerInternal(agent, subtree, scenario string, s
 	ctx, cancel := context.WithCancel(context.Background())
 
 	pb := &Playback{
-		ID:          newPlaybackID(),
-		Agent:       agent,
-		Subtree:     subtree,
-		Scenario:    scenario,
-		Mode:        "viewer-internal",
-		Speed:       speed,
-		StartedAt:   time.Now().UTC(),
-		broadcaster: m.broadcaster,
-		machine:     machine,
-		cancel:      cancel,
+		ID:           newPlaybackID(),
+		Agent:        agent,
+		Subtree:      subtree,
+		Scenario:     scenario,
+		Mode:         "viewer-internal",
+		Speed:        speed,
+		StartedAt:    time.Now().UTC(),
+		broadcaster:  m.broadcaster,
+		machine:      machine,
+		cancel:       cancel,
 		DashboardURL: "/dashboard",
 		EventsDir:    eventsDir,
 		Recording:    recording,
@@ -637,10 +637,12 @@ func normalizeAdapter(a string) string {
 	return a
 }
 
-// handleSessions returns the current synthetic session list in the
-// EXACT shape the dashboard expects — which is whatever the daemon's
-// session.BuildDashboard produces. Reuse rather than reinvent so the
-// dashboard's render path Just Works against our synthetic state.
+// handleSessions returns the current synthetic session list in the EXACT
+// shape the daemon's GET /api/v1/sessions produces: an object with a `groups`
+// array (session.BuildDashboard output). The real daemon also carries
+// `provider_costs`; the replay viewer has no cost tracker, so that field is
+// omitted. Reuse rather than reinvent so the dashboard's render path Just
+// Works against our synthetic state.
 func (m *PlaybackManager) handleSessions(w http.ResponseWriter, r *http.Request) {
 	// Normalize adapter spellings BEFORE BuildDashboard runs so the
 	// dashboard's session→agent matching keys correctly. Historical
@@ -665,7 +667,7 @@ func (m *PlaybackManager) handleSessions(w http.ResponseWriter, r *http.Request)
 		// hydrate it from session_created messages.
 		groups = []*session.AgentGroup{}
 	}
-	writeJSON(w, groups)
+	writeJSON(w, map[string]any{"groups": groups})
 }
 
 // inferProjectName derives a fallback project name from the session's
@@ -759,4 +761,3 @@ const wsDiagScript = `<script>
 })();
 </script>
 `
-

--- a/tools/agent-onboarding/internal/viewer/playback_test.go
+++ b/tools/agent-onboarding/internal/viewer/playback_test.go
@@ -67,8 +67,8 @@ func TestPlayback_startEndToEnd(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("sessions: status=%d body=%s", rr.Code, rr.Body)
 	}
-	// The viewer now returns the daemon's BuildDashboard shape:
-	// [{"name": "<project>", "agents": [{"session_id": "...", ...}]}]
+	// The viewer returns the daemon's /api/v1/sessions envelope:
+	// {"groups": [{"name": "<project>", "agents": [{"session_id": "...", ...}]}]}
 	if !strings.Contains(rr.Body.String(), `"session_id":"s1"`) {
 		t.Errorf("expected session s1 in /api/v1/sessions: %s", rr.Body)
 	}


### PR DESCRIPTION
Closes #386.

Replaces the cumulative all-time "spend" usage chip with **windowed per-provider spend** (day/week/month/year, click-to-cycle), adds a daemon-side per-provider cost rollup, and brings the subscription chip a "no subscription data" empty-state.

## Daemon (`scope:daemon`)
- `snapshotRow` gains a `provider` field, stamped at write time. First-party adapters map by name; **wrapper agents (pi, opencode) attribute to the subscription they inherit** via the same `auth.json` inspection used for rate-limit inheritance (`services.ProviderForSession`, injected into the cost tracker). Old rows read provider `""` and are excluded from the rollup.
- New `CostTracker.ProviderCostsInWindows`, sharing the single-pass window-agg machinery (`scanWindows`/`addContributions`) with the per-project rollup — a project can mix providers, so this can't be re-derived client-side.
- `/api/v1/sessions` now returns `{ "groups": [...], "provider_costs": { providerKey: {day,week,month,year} } }` instead of a bare group array.

## macOS (`scope:macos`)
- Usage chip renders windowed `$X / frame` (click-to-cycle, `@AppStorage("usageCostTimeframe")`, reusing `CostTimeframe`); `$0 / frame` zero-state.
- Subscription chip shows **"no subscription data"** when the snapshot has no windows.
- `SessionManager` decodes the new wrapper into `providerCosts`.

## Web
- Usage chip ported to the same windowed display + click-to-cycle (`irrlicht_usageCostTimeframe`), reading `provider_costs` — keeps web/macOS usage numbers identical (#417 parity). Subscription empty-state remains macOS-only.

## Replay viewer
- Emits the same `{groups}` envelope as the daemon.

## Testing
- `go test ./core/... -race` and the viewer suite pass. New unit tests: provider rollup, provider resolution (incl. pi/opencode auth), injected resolver, web `formatUsageCost`. Web vitest 23/23.
- ⚠️ The `core/cmd/replay` golden tests are red on `main` already (stale snapshot-serialization goldens, unrelated to this PR — verified the failing-subtest count is identical with these changes stashed). Not regenerated here to avoid bundling an unrelated diff.

## Coordination
- #369 (History tab) also plans a `provider` column on `snapshotRow`; this PR lands it first — #369 should rebase onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)