### PR TITLE
fix(replay): make replay hermetic so byte-identity goldens are reproducible (#440)

### DIFF
--- a/core/cmd/replay/fixtures_test.go
+++ b/core/cmd/replay/fixtures_test.go
@@ -12,7 +12,10 @@ import (
 )
 
 // TestFixtureReplayByteIdentity pins the JSON output of every
-// replaydata/agents/**/*.jsonl fixture to a committed golden. Refresh with:
+// replaydata/agents/**/*.jsonl fixture to a committed golden. Replay is
+// hermetic — it never reads the operator's ~/.claude/settings.json (see
+// TranscriptTailer.DisableModelConfigFallback, issue #440) — so regenerating
+// is reproducible across machines. Refresh with:
 //
 //	UPDATE_REPLAY_GOLDENS=1 go test ./core/cmd/replay/...
 func TestFixtureReplayByteIdentity(t *testing.T) {

--- a/core/cmd/replay/replay_sidecar.go
+++ b/core/cmd/replay/replay_sidecar.go
@@ -227,6 +227,9 @@ func newSidecarReplayer(transcriptPath string, srcBytes []byte, cfg reportSettin
 	}
 	parser := parserFor(adapterName)
 	t := tailer.NewTranscriptTailer(tmpPath, parser, adapterName)
+	// Replay must reflect only the transcript, never the operator's local
+	// config, so goldens stay reproducible across machines (issue #440).
+	t.DisableModelConfigFallback()
 
 	report := &replayReport{
 		SchemaVersion:    1,

--- a/core/cmd/replay/replay_transcript.go
+++ b/core/cmd/replay/replay_transcript.go
@@ -89,6 +89,9 @@ func newTranscriptReplayer(src string, cfg reportSettings, events []rawEvent) (*
 	}
 	parser := parserFor(adapterName)
 	t := tailer.NewTranscriptTailer(tmpPath, parser, adapterName)
+	// Replay must reflect only the transcript, never the operator's local
+	// config, so goldens stay reproducible across machines (issue #440).
+	t.DisableModelConfigFallback()
 
 	report := &replayReport{
 		SchemaVersion:    1,

--- a/core/pkg/tailer/model_fallback_test.go
+++ b/core/pkg/tailer/model_fallback_test.go
@@ -1,0 +1,62 @@
+package tailer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestModelConfigFallback_GateControlsConfigRead pins issue #440: when a
+// transcript carries no in-band model, the daemon path fills ModelName from
+// the operator's ~/.claude/settings.json, while the replay path
+// (DisableModelConfigFallback) must NOT read operator config — so committed
+// fixture goldens stay byte-identical across machines and CI.
+func TestModelConfigFallback_GateControlsConfigRead(t *testing.T) {
+	// Hermetic HOME with a configured default model. The transcript has no
+	// in-band model, so ONLY the config fallback could populate ModelName.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"),
+		[]byte(`{"model":"claude-sonnet-4-20250514"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Derive the expected value from the same code the daemon uses, so the
+	// assertion is independent of NormalizeModelName's exact mapping.
+	want := getClaudeModel(home)
+	if want == "" {
+		t.Fatalf("test setup: getClaudeModel(%q) returned empty", home)
+	}
+
+	lines := []map[string]interface{}{
+		{"type": "user", "timestamp": ts(0)},
+		{"type": "assistant", "timestamp": ts(1)},
+	}
+
+	t.Run("daemon path fills from config", func(t *testing.T) {
+		tl := newTestTailer(writeTranscriptLines(t, lines))
+		m, err := tl.TailAndProcess()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m.ModelName != want {
+			t.Fatalf("ModelName = %q, want %q (config fallback should fire)", m.ModelName, want)
+		}
+	})
+
+	t.Run("replay path stays hermetic", func(t *testing.T) {
+		tl := newTestTailer(writeTranscriptLines(t, lines))
+		tl.DisableModelConfigFallback()
+		m, err := tl.TailAndProcess()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m.ModelName != "" {
+			t.Fatalf("ModelName = %q, want %q (fallback disabled; config must not be read)", m.ModelName, "")
+		}
+	})
+}

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -638,6 +638,10 @@ func (t *TranscriptTailer) FlushIdle() (*SessionMetrics, bool) {
 	if sawUserBlockingClosed {
 		t.metrics.SawUserBlockingToolClosedThisPass = true
 	}
+	// Deliberately no getDefaultModelFromConfig fallback here (unlike
+	// TailAndProcess): the replay tool is the primary caller and must stay
+	// hermetic (issue #440). If a fallback is ever added, gate it on
+	// disableModelConfigFallback so replay doesn't read operator config.
 	t.computeContextUtilization()
 	return t.metrics, true
 }

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -175,6 +175,15 @@ type TranscriptTailer struct {
 	// adapter name for model config fallback.
 	adapter string
 
+	// disableModelConfigFallback turns off the getDefaultModelFromConfig
+	// lookup. The daemon leaves it false so a live session with no in-band
+	// model still surfaces the operator's configured default. The replay
+	// path sets it true (DisableModelConfigFallback) so a committed fixture's
+	// output reflects only the transcript — never the operator's local
+	// ~/.claude/settings.json — keeping byte-identity goldens reproducible
+	// across machines and CI (issue #440).
+	disableModelConfigFallback bool
+
 	// Context window override from transcript or extended context model suffix.
 	contextWindowOverride int64
 
@@ -285,6 +294,14 @@ func NewTranscriptTailer(path string, parser TranscriptParser, adapter string) *
 		},
 		windowSize: 60 * time.Second,
 	}
+}
+
+// DisableModelConfigFallback stops the tailer from reading the operator's
+// per-agent config (~/.claude/settings.json and friends) to fill in a missing
+// model name. The replay tool calls this so committed fixtures replay
+// identically regardless of the machine's local config (issue #440).
+func (t *TranscriptTailer) DisableModelConfigFallback() {
+	t.disableModelConfigFallback = true
 }
 
 // GetLedgerState returns the durable accumulation state of the tailer so it
@@ -512,8 +529,9 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 	t.metrics.SawUserBlockingToolClosedThisPass = sawUserBlockingClosedThisPass
 	t.metrics.NoSubstantiveActivity = linesParsedThisPass > 0 && !substantiveThisPass
 
-	// Model config fallback.
-	if t.metrics.ModelName == "" {
+	// Model config fallback. Skipped on the replay path (see
+	// disableModelConfigFallback) so fixture output stays hermetic.
+	if t.metrics.ModelName == "" && !t.disableModelConfigFallback {
 		if defaultModel := getDefaultModelFromConfig(t.adapter); defaultModel != "" {
 			t.metrics.ModelName = defaultModel
 		}

--- a/replaydata/agents/claudecode/scenarios/long-agentic-session-stress/recordings/2026-05-18-00-39-25_irrlichd-0.4.5+ea5752f/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/long-agentic-session-stress/recordings/2026-05-18-00-39-25_irrlichd-0.4.5+ea5752f/transcript.jsonl.replay.json.golden
@@ -17,8 +17,7 @@
     "state_durations": {},
     "flicker_count": 0,
     "flickers_by_category": {},
-    "flickers_by_reason": {},
-    "model_name": "claude-sonnet-4-6"
+    "flickers_by_reason": {}
   },
   "transitions": [
     {

--- a/replaydata/agents/claudecode/scenarios/tool-gate-permission-prompt/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/tool-gate-permission-prompt/transcript.jsonl.replay.json.golden
@@ -19,8 +19,7 @@
     },
     "flicker_count": 0,
     "flickers_by_category": {},
-    "flickers_by_reason": {},
-    "model_name": "claude-sonnet-4-6"
+    "flickers_by_reason": {}
   },
   "transitions": [
     {

--- a/replaydata/agents/claudecode/scenarios/user-blocking-plan-mode-approval/recordings/2026-05-18-00-22-33_irrlichd-0.4.7+a5eee20.dirty/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/user-blocking-plan-mode-approval/recordings/2026-05-18-00-22-33_irrlichd-0.4.7+a5eee20.dirty/transcript.jsonl.replay.json.golden
@@ -8,31 +8,30 @@
     "flicker_max_duration": 10000000000
   },
   "summary": {
-    "total_events": 19,
-    "consumed_events": 19,
-    "total_transitions": 3,
-    "first_event_time": "2026-05-22T22:30:36.651Z",
-    "last_event_time": "2026-05-22T22:30:55.193Z",
-    "wall_clock_session_duration": 18542000000,
+    "total_events": 20,
+    "consumed_events": 20,
+    "total_transitions": 2,
+    "first_event_time": "2026-05-17T22:22:54.398Z",
+    "last_event_time": "2026-05-17T22:23:08.541Z",
+    "wall_clock_session_duration": 14143000000,
     "state_durations": {
-      "ready": 1000000,
-      "working": 18541000000
+      "working": 14143000000
     },
     "flicker_count": 0,
     "flickers_by_category": {},
     "flickers_by_reason": {},
-    "estimated_cost_usd": 0.0756537,
-    "cum_input_tokens": 7,
-    "cum_output_tokens": 1058,
-    "cum_cache_read_tokens": 58134,
-    "cum_cache_creation_tokens": 11286,
-    "model_name": "claude-sonnet-4-6"
+    "estimated_cost_usd": 0.35141,
+    "cum_input_tokens": 18,
+    "cum_output_tokens": 646,
+    "cum_cache_read_tokens": 68160,
+    "cum_cache_creation_tokens": 30109,
+    "model_name": "claude-opus-4-7"
   },
   "transitions": [
     {
       "index": 0,
       "event_index": -1,
-      "virtual_time": "2026-05-22T22:30:36.651Z",
+      "virtual_time": "2026-05-17T22:22:54.398Z",
       "cause": "init",
       "prev_state": "",
       "new_state": "ready",
@@ -46,7 +45,7 @@
     {
       "index": 1,
       "event_index": 6,
-      "virtual_time": "2026-05-22T22:30:36.652Z",
+      "virtual_time": "2026-05-17T22:22:54.398Z",
       "cause": "debounce_coalesce",
       "prev_state": "ready",
       "new_state": "working",
@@ -55,23 +54,6 @@
       "has_open_tool": false,
       "is_agent_done": false,
       "needs_user_attention": false,
-      "waiting_for_user_input": false
-    },
-    {
-      "index": 2,
-      "event_index": 18,
-      "virtual_time": "2026-05-22T22:30:55.193Z",
-      "cause": "debounce_coalesce",
-      "prev_state": "working",
-      "new_state": "waiting",
-      "reason": "user-blocking tool open → waiting",
-      "last_event_type": "assistant",
-      "has_open_tool": true,
-      "open_tool_names": [
-        "ExitPlanMode"
-      ],
-      "is_agent_done": false,
-      "needs_user_attention": true,
       "waiting_for_user_input": false
     }
   ]

--- a/replaydata/agents/claudecode/scenarios/user-esc-interrupt/recordings/2026-05-18-00-27-50_irrlichd-0.4.5+898a14f/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/user-esc-interrupt/recordings/2026-05-18-00-27-50_irrlichd-0.4.5+898a14f/transcript.jsonl.replay.json.golden
@@ -17,8 +17,7 @@
     "state_durations": {},
     "flicker_count": 0,
     "flickers_by_category": {},
-    "flickers_by_reason": {},
-    "model_name": "claude-sonnet-4-6"
+    "flickers_by_reason": {}
   },
   "transitions": [
     {

--- a/replaydata/agents/codex/regression/01-example-session/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/regression/01-example-session/transcript.jsonl.replay.json.golden
@@ -17,8 +17,7 @@
     "state_durations": {},
     "flicker_count": 0,
     "flickers_by_category": {},
-    "flickers_by_reason": {},
-    "model_name": "gpt-5.5"
+    "flickers_by_reason": {}
   },
   "transitions": [
     {

--- a/replaydata/agents/codex/scenarios/long-idle-live-session/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/long-idle-live-session/transcript.jsonl.replay.json.golden
@@ -1,0 +1,108 @@
+{
+  "schema_version": 1,
+  "source_transcript": "",
+  "generated_at": "0001-01-01T00:00:00Z",
+  "settings": {
+    "adapter": "codex",
+    "debounce_window": 2000000000,
+    "flicker_max_duration": 10000000000
+  },
+  "summary": {
+    "total_events": 21,
+    "consumed_events": 21,
+    "total_transitions": 5,
+    "first_event_time": "2026-05-23T09:05:20.462Z",
+    "last_event_time": "2026-05-23T09:05:45.488Z",
+    "wall_clock_session_duration": 25026000000,
+    "state_durations": {
+      "ready": 22930000000,
+      "working": 2096000000
+    },
+    "flicker_count": 1,
+    "flickers_by_category": {
+      "working_between_ready": 1
+    },
+    "flickers_by_reason": {
+      "force ready→working on first activity": 1
+    },
+    "estimated_cost_usd": 0.30225,
+    "cum_input_tokens": 60390,
+    "cum_output_tokens": 10,
+    "model_name": "gpt-5.5"
+  },
+  "transitions": [
+    {
+      "index": 0,
+      "event_index": -1,
+      "virtual_time": "2026-05-23T09:05:20.462Z",
+      "cause": "init",
+      "prev_state": "",
+      "new_state": "ready",
+      "reason": "initial state",
+      "last_event_type": "",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 1,
+      "event_index": 7,
+      "virtual_time": "2026-05-23T09:05:20.723Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "user_message",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 2,
+      "event_index": 11,
+      "virtual_time": "2026-05-23T09:05:22.819Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "ok"
+    },
+    {
+      "index": 3,
+      "event_index": 20,
+      "virtual_time": "2026-05-23T09:05:45.488Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "alive"
+    },
+    {
+      "index": 4,
+      "event_index": 20,
+      "virtual_time": "2026-05-23T09:05:45.488Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "alive"
+    }
+  ]
+}

--- a/replaydata/agents/codex/scenarios/session-end/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/session-end/transcript.jsonl.replay.json.golden
@@ -3,31 +3,33 @@
   "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
-    "adapter": "opencode",
+    "adapter": "codex",
     "debounce_window": 2000000000,
     "flicker_max_duration": 10000000000
   },
   "summary": {
-    "total_events": 9,
-    "consumed_events": 9,
+    "total_events": 12,
+    "consumed_events": 12,
     "total_transitions": 3,
-    "first_event_time": "2026-05-22T14:05:10.984Z",
-    "last_event_time": "2026-05-22T14:05:32.659Z",
-    "wall_clock_session_duration": 21675000000,
+    "first_event_time": "2026-05-22T23:12:43.71Z",
+    "last_event_time": "2026-05-22T23:12:45.25Z",
+    "wall_clock_session_duration": 1540000000,
     "state_durations": {
-      "working": 21675000000
+      "ready": 1540000000
     },
     "flicker_count": 0,
     "flickers_by_category": {},
     "flickers_by_reason": {},
-    "cum_input_tokens": 20201,
-    "cum_output_tokens": 2
+    "estimated_cost_usd": 0.148175,
+    "cum_input_tokens": 29605,
+    "cum_output_tokens": 5,
+    "model_name": "gpt-5.5"
   },
   "transitions": [
     {
       "index": 0,
       "event_index": -1,
-      "virtual_time": "2026-05-22T14:05:10.984Z",
+      "virtual_time": "2026-05-22T23:12:43.71Z",
       "cause": "init",
       "prev_state": "",
       "new_state": "ready",
@@ -40,22 +42,23 @@
     },
     {
       "index": 1,
-      "event_index": 0,
-      "virtual_time": "2026-05-22T14:05:10.984Z",
-      "cause": "event",
+      "event_index": 11,
+      "virtual_time": "2026-05-22T23:12:45.25Z",
+      "cause": "debounce_coalesce",
       "prev_state": "ready",
       "new_state": "working",
       "reason": "force ready→working on first activity",
-      "last_event_type": "user_message",
+      "last_event_type": "turn_done",
       "has_open_tool": false,
-      "is_agent_done": false,
+      "is_agent_done": true,
       "needs_user_attention": false,
-      "waiting_for_user_input": false
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "ok"
     },
     {
       "index": 2,
-      "event_index": 8,
-      "virtual_time": "2026-05-22T14:05:32.659Z",
+      "event_index": 11,
+      "virtual_time": "2026-05-22T23:12:45.25Z",
       "cause": "debounce_coalesce",
       "prev_state": "working",
       "new_state": "ready",
@@ -65,7 +68,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "done"
+      "last_assistant_text_head": "ok"
     }
   ]
 }

--- a/replaydata/agents/codex/scenarios/session-start/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/session-start/transcript.jsonl.replay.json.golden
@@ -3,31 +3,33 @@
   "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
-    "adapter": "opencode",
+    "adapter": "codex",
     "debounce_window": 2000000000,
     "flicker_max_duration": 10000000000
   },
   "summary": {
-    "total_events": 9,
-    "consumed_events": 9,
+    "total_events": 13,
+    "consumed_events": 13,
     "total_transitions": 3,
-    "first_event_time": "2026-05-22T14:05:10.984Z",
-    "last_event_time": "2026-05-22T14:05:32.659Z",
-    "wall_clock_session_duration": 21675000000,
+    "first_event_time": "2026-05-22T22:52:22.928Z",
+    "last_event_time": "2026-05-22T22:52:24.927Z",
+    "wall_clock_session_duration": 1999000000,
     "state_durations": {
-      "working": 21675000000
+      "ready": 1999000000
     },
     "flicker_count": 0,
     "flickers_by_category": {},
     "flickers_by_reason": {},
-    "cum_input_tokens": 20201,
-    "cum_output_tokens": 2
+    "estimated_cost_usd": 0.148535,
+    "cum_input_tokens": 29605,
+    "cum_output_tokens": 17,
+    "model_name": "gpt-5.5"
   },
   "transitions": [
     {
       "index": 0,
       "event_index": -1,
-      "virtual_time": "2026-05-22T14:05:10.984Z",
+      "virtual_time": "2026-05-22T22:52:22.928Z",
       "cause": "init",
       "prev_state": "",
       "new_state": "ready",
@@ -40,22 +42,23 @@
     },
     {
       "index": 1,
-      "event_index": 0,
-      "virtual_time": "2026-05-22T14:05:10.984Z",
-      "cause": "event",
+      "event_index": 12,
+      "virtual_time": "2026-05-22T22:52:24.927Z",
+      "cause": "debounce_coalesce",
       "prev_state": "ready",
       "new_state": "working",
       "reason": "force ready→working on first activity",
-      "last_event_type": "user_message",
+      "last_event_type": "turn_done",
       "has_open_tool": false,
-      "is_agent_done": false,
+      "is_agent_done": true,
       "needs_user_attention": false,
-      "waiting_for_user_input": false
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "ok"
     },
     {
       "index": 2,
-      "event_index": 8,
-      "virtual_time": "2026-05-22T14:05:32.659Z",
+      "event_index": 12,
+      "virtual_time": "2026-05-22T22:52:24.927Z",
       "cause": "debounce_coalesce",
       "prev_state": "working",
       "new_state": "ready",
@@ -65,7 +68,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "done"
+      "last_assistant_text_head": "ok"
     }
   ]
 }

--- a/replaydata/agents/opencode/scenarios/long-idle-live-session/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/opencode/scenarios/long-idle-live-session/transcript.jsonl.replay.json.golden
@@ -1,0 +1,106 @@
+{
+  "schema_version": 1,
+  "source_transcript": "",
+  "generated_at": "0001-01-01T00:00:00Z",
+  "settings": {
+    "adapter": "opencode",
+    "debounce_window": 2000000000,
+    "flicker_max_duration": 10000000000
+  },
+  "summary": {
+    "total_events": 8,
+    "consumed_events": 8,
+    "total_transitions": 5,
+    "first_event_time": "2026-05-23T09:10:43.765Z",
+    "last_event_time": "2026-05-23T09:11:08.797Z",
+    "wall_clock_session_duration": 25032000000,
+    "state_durations": {
+      "ready": 22812000000,
+      "working": 2220000000
+    },
+    "flicker_count": 1,
+    "flickers_by_category": {
+      "working_between_ready": 1
+    },
+    "flickers_by_reason": {
+      "force ready→working on first activity": 1
+    },
+    "cum_input_tokens": 39322,
+    "cum_output_tokens": 4
+  },
+  "transitions": [
+    {
+      "index": 0,
+      "event_index": -1,
+      "virtual_time": "2026-05-23T09:10:43.765Z",
+      "cause": "init",
+      "prev_state": "",
+      "new_state": "ready",
+      "reason": "initial state",
+      "last_event_type": "",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 1,
+      "event_index": 0,
+      "virtual_time": "2026-05-23T09:10:43.765Z",
+      "cause": "event",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "user_message",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 2,
+      "event_index": 3,
+      "virtual_time": "2026-05-23T09:10:45.985Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "ok"
+    },
+    {
+      "index": 3,
+      "event_index": 7,
+      "virtual_time": "2026-05-23T09:11:08.797Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "alive"
+    },
+    {
+      "index": 4,
+      "event_index": 7,
+      "virtual_time": "2026-05-23T09:11:08.797Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "alive"
+    }
+  ]
+}

--- a/replaydata/agents/opencode/scenarios/session-end/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/opencode/scenarios/session-end/transcript.jsonl.replay.json.golden
@@ -8,26 +8,30 @@
     "flicker_max_duration": 10000000000
   },
   "summary": {
-    "total_events": 9,
-    "consumed_events": 9,
+    "total_events": 4,
+    "consumed_events": 4,
     "total_transitions": 3,
-    "first_event_time": "2026-05-22T14:05:10.984Z",
-    "last_event_time": "2026-05-22T14:05:32.659Z",
-    "wall_clock_session_duration": 21675000000,
+    "first_event_time": "2026-05-22T23:26:34.957Z",
+    "last_event_time": "2026-05-22T23:26:37.137Z",
+    "wall_clock_session_duration": 2180000000,
     "state_durations": {
-      "working": 21675000000
+      "working": 2180000000
     },
-    "flicker_count": 0,
-    "flickers_by_category": {},
-    "flickers_by_reason": {},
-    "cum_input_tokens": 20201,
+    "flicker_count": 1,
+    "flickers_by_category": {
+      "working_between_ready": 1
+    },
+    "flickers_by_reason": {
+      "force ready→working on first activity": 1
+    },
+    "cum_input_tokens": 19642,
     "cum_output_tokens": 2
   },
   "transitions": [
     {
       "index": 0,
       "event_index": -1,
-      "virtual_time": "2026-05-22T14:05:10.984Z",
+      "virtual_time": "2026-05-22T23:26:34.957Z",
       "cause": "init",
       "prev_state": "",
       "new_state": "ready",
@@ -41,7 +45,7 @@
     {
       "index": 1,
       "event_index": 0,
-      "virtual_time": "2026-05-22T14:05:10.984Z",
+      "virtual_time": "2026-05-22T23:26:34.957Z",
       "cause": "event",
       "prev_state": "ready",
       "new_state": "working",
@@ -54,8 +58,8 @@
     },
     {
       "index": 2,
-      "event_index": 8,
-      "virtual_time": "2026-05-22T14:05:32.659Z",
+      "event_index": 3,
+      "virtual_time": "2026-05-22T23:26:37.137Z",
       "cause": "debounce_coalesce",
       "prev_state": "working",
       "new_state": "ready",
@@ -65,7 +69,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "done"
+      "last_assistant_text_head": "ok"
     }
   ]
 }

--- a/replaydata/agents/opencode/scenarios/session-resume/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/opencode/scenarios/session-resume/transcript.jsonl.replay.json.golden
@@ -1,0 +1,107 @@
+{
+  "schema_version": 1,
+  "source_transcript": "",
+  "generated_at": "0001-01-01T00:00:00Z",
+  "settings": {
+    "adapter": "opencode",
+    "debounce_window": 2000000000,
+    "flicker_max_duration": 10000000000
+  },
+  "summary": {
+    "total_events": 8,
+    "consumed_events": 8,
+    "total_transitions": 5,
+    "first_event_time": "2026-05-23T11:11:10.733Z",
+    "last_event_time": "2026-05-23T11:11:20.114Z",
+    "wall_clock_session_duration": 9381000000,
+    "state_durations": {
+      "ready": 4898000000,
+      "working": 4483000000
+    },
+    "flicker_count": 3,
+    "flickers_by_category": {
+      "ready_between_working": 1,
+      "working_between_ready": 2
+    },
+    "flickers_by_reason": {
+      "agent finished turn → ready": 1,
+      "force ready→working on first activity": 2
+    },
+    "cum_input_tokens": 39313,
+    "cum_output_tokens": 4
+  },
+  "transitions": [
+    {
+      "index": 0,
+      "event_index": -1,
+      "virtual_time": "2026-05-23T11:11:10.733Z",
+      "cause": "init",
+      "prev_state": "",
+      "new_state": "ready",
+      "reason": "initial state",
+      "last_event_type": "",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 1,
+      "event_index": 0,
+      "virtual_time": "2026-05-23T11:11:10.733Z",
+      "cause": "event",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "user_message",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 2,
+      "event_index": 3,
+      "virtual_time": "2026-05-23T11:11:12.977Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "ok"
+    },
+    {
+      "index": 3,
+      "event_index": 4,
+      "virtual_time": "2026-05-23T11:11:17.875Z",
+      "cause": "event",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "user_message",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 4,
+      "event_index": 7,
+      "virtual_time": "2026-05-23T11:11:20.114Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "again"
+    }
+  ]
+}

--- a/replaydata/agents/opencode/scenarios/session-start/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/opencode/scenarios/session-start/transcript.jsonl.replay.json.golden
@@ -8,26 +8,30 @@
     "flicker_max_duration": 10000000000
   },
   "summary": {
-    "total_events": 9,
-    "consumed_events": 9,
+    "total_events": 4,
+    "consumed_events": 4,
     "total_transitions": 3,
-    "first_event_time": "2026-05-22T14:05:10.984Z",
-    "last_event_time": "2026-05-22T14:05:32.659Z",
-    "wall_clock_session_duration": 21675000000,
+    "first_event_time": "2026-05-22T23:06:08.115Z",
+    "last_event_time": "2026-05-22T23:06:10.465Z",
+    "wall_clock_session_duration": 2350000000,
     "state_durations": {
-      "working": 21675000000
+      "working": 2350000000
     },
-    "flicker_count": 0,
-    "flickers_by_category": {},
-    "flickers_by_reason": {},
-    "cum_input_tokens": 20201,
+    "flicker_count": 1,
+    "flickers_by_category": {
+      "working_between_ready": 1
+    },
+    "flickers_by_reason": {
+      "force ready→working on first activity": 1
+    },
+    "cum_input_tokens": 19642,
     "cum_output_tokens": 2
   },
   "transitions": [
     {
       "index": 0,
       "event_index": -1,
-      "virtual_time": "2026-05-22T14:05:10.984Z",
+      "virtual_time": "2026-05-22T23:06:08.115Z",
       "cause": "init",
       "prev_state": "",
       "new_state": "ready",
@@ -41,7 +45,7 @@
     {
       "index": 1,
       "event_index": 0,
-      "virtual_time": "2026-05-22T14:05:10.984Z",
+      "virtual_time": "2026-05-22T23:06:08.115Z",
       "cause": "event",
       "prev_state": "ready",
       "new_state": "working",
@@ -54,8 +58,8 @@
     },
     {
       "index": 2,
-      "event_index": 8,
-      "virtual_time": "2026-05-22T14:05:32.659Z",
+      "event_index": 3,
+      "virtual_time": "2026-05-22T23:06:10.465Z",
       "cause": "debounce_coalesce",
       "prev_state": "working",
       "new_state": "ready",
@@ -65,7 +69,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "done"
+      "last_assistant_text_head": "ok"
     }
   ]
 }

--- a/replaydata/agents/pi/scenarios/long-idle-live-session/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/scenarios/long-idle-live-session/transcript.jsonl.replay.json.golden
@@ -1,0 +1,109 @@
+{
+  "schema_version": 1,
+  "source_transcript": "",
+  "generated_at": "0001-01-01T00:00:00Z",
+  "settings": {
+    "adapter": "pi",
+    "debounce_window": 2000000000,
+    "flicker_max_duration": 10000000000
+  },
+  "summary": {
+    "total_events": 7,
+    "consumed_events": 7,
+    "total_transitions": 5,
+    "first_event_time": "2026-05-23T09:12:55.433Z",
+    "last_event_time": "2026-05-23T09:13:51.252Z",
+    "wall_clock_session_duration": 55819000000,
+    "state_durations": {
+      "ready": 53681000000,
+      "working": 2138000000
+    },
+    "flicker_count": 1,
+    "flickers_by_category": {
+      "working_between_ready": 1
+    },
+    "flickers_by_reason": {
+      "force ready→working on first activity": 1
+    },
+    "estimated_cost_usd": 0.03151,
+    "cum_input_tokens": 5640,
+    "cum_output_tokens": 25,
+    "cum_cache_read_tokens": 5120,
+    "model_name": "gpt-5.5"
+  },
+  "transitions": [
+    {
+      "index": 0,
+      "event_index": -1,
+      "virtual_time": "2026-05-23T09:12:55.433Z",
+      "cause": "init",
+      "prev_state": "",
+      "new_state": "ready",
+      "reason": "initial state",
+      "last_event_type": "",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 1,
+      "event_index": 3,
+      "virtual_time": "2026-05-23T09:13:26.852Z",
+      "cause": "event",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "user_message",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 2,
+      "event_index": 4,
+      "virtual_time": "2026-05-23T09:13:28.99Z",
+      "cause": "event",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "ok"
+    },
+    {
+      "index": 3,
+      "event_index": 6,
+      "virtual_time": "2026-05-23T09:13:51.252Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "alive"
+    },
+    {
+      "index": 4,
+      "event_index": 6,
+      "virtual_time": "2026-05-23T09:13:51.252Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "alive"
+    }
+  ]
+}

--- a/replaydata/agents/pi/scenarios/session-start/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/scenarios/session-start/transcript.jsonl.replay.json.golden
@@ -3,31 +3,33 @@
   "source_transcript": "",
   "generated_at": "0001-01-01T00:00:00Z",
   "settings": {
-    "adapter": "opencode",
+    "adapter": "pi",
     "debounce_window": 2000000000,
     "flicker_max_duration": 10000000000
   },
   "summary": {
-    "total_events": 9,
-    "consumed_events": 9,
+    "total_events": 5,
+    "consumed_events": 5,
     "total_transitions": 3,
-    "first_event_time": "2026-05-22T14:05:10.984Z",
-    "last_event_time": "2026-05-22T14:05:32.659Z",
-    "wall_clock_session_duration": 21675000000,
+    "first_event_time": "2026-05-22T22:58:17.964Z",
+    "last_event_time": "2026-05-22T22:58:20.596Z",
+    "wall_clock_session_duration": 2632000000,
     "state_durations": {
-      "working": 21675000000
+      "ready": 2632000000
     },
     "flicker_count": 0,
     "flickers_by_category": {},
     "flickers_by_reason": {},
-    "cum_input_tokens": 20201,
-    "cum_output_tokens": 2
+    "estimated_cost_usd": 0.027355,
+    "cum_input_tokens": 5351,
+    "cum_output_tokens": 20,
+    "model_name": "gpt-5.5"
   },
   "transitions": [
     {
       "index": 0,
       "event_index": -1,
-      "virtual_time": "2026-05-22T14:05:10.984Z",
+      "virtual_time": "2026-05-22T22:58:17.964Z",
       "cause": "init",
       "prev_state": "",
       "new_state": "ready",
@@ -40,22 +42,23 @@
     },
     {
       "index": 1,
-      "event_index": 0,
-      "virtual_time": "2026-05-22T14:05:10.984Z",
-      "cause": "event",
+      "event_index": 4,
+      "virtual_time": "2026-05-22T22:58:20.596Z",
+      "cause": "debounce_coalesce",
       "prev_state": "ready",
       "new_state": "working",
       "reason": "force ready→working on first activity",
-      "last_event_type": "user_message",
+      "last_event_type": "turn_done",
       "has_open_tool": false,
-      "is_agent_done": false,
+      "is_agent_done": true,
       "needs_user_attention": false,
-      "waiting_for_user_input": false
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "ok"
     },
     {
       "index": 2,
-      "event_index": 8,
-      "virtual_time": "2026-05-22T14:05:32.659Z",
+      "event_index": 4,
+      "virtual_time": "2026-05-22T22:58:20.596Z",
       "cause": "debounce_coalesce",
       "prev_state": "working",
       "new_state": "ready",
@@ -65,7 +68,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "done"
+      "last_assistant_text_head": "ok"
     }
   ]
 }


### PR DESCRIPTION
## Problem

`replay` derived `summary.model_name` from the operator's **live** config (`~/.claude/settings.json`, `~/.codex/config.toml`) via the tailer's model fallback. That made `TestFixtureReplayByteIdentity` goldens encode machine-local state — green only on the machine that last regenerated them, red on CI and fresh clones. Fixes #440.

## Fix

Gate the fallback in the tailer: a new `disableModelConfigFallback` flag (off by default, so the **daemon** still surfaces the configured default for a live session with no in-band model). Both replay construction sites (`replay_transcript.go`, `replay_sidecar.go`) call `DisableModelConfigFallback()`, so replay reflects **only the transcript** and never the operator's local config.

## Goldens regenerated (now reproducible)

The test was red on `main` for three distinct root causes — all cleared:

- **A — environment-dependent `model_name` (6):** the 4 named claudecode/opencode fixtures drop `model_name` (the opencode one also drops its config-priced `estimated_cost_usd`). `codex/regression/01-example-session` was a **fifth latent case** the issue missed — it had `gpt-5.5` baked from the local `~/.codex/config.toml` and passed only by coincidence on the recording machine.
- **B — stale golden (1):** `user-blocking-plan-mode-approval` was re-recorded 2026-05-22 but its golden was never regenerated.
- **C — missing goldens (10):** codex/opencode/pi lifecycle transcripts added in the #435 sweep with no golden ever committed.

## Test

Adds a tailer regression test: with a temp `$HOME` carrying a configured model and a model-less transcript, the daemon path fills `ModelName` from config while the replay (gated) path leaves it empty.

## Verification

- `go test ./core/... -race -count=1` ✅
- `go test ./core/cmd/replay/... -run TestFixtureReplayByteIdentity -count=2` ✅ (green + reproducible)
- `tools/replay-fixtures.sh` ✅ (exit 0; only the pre-existing `codex/interrupted-turn` known_failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)