### PR TITLE
test: per-worktree state isolation + web vitest in discipline + daemon startup smoke (#443)

### DIFF
--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -23,15 +23,19 @@ worktree-local `IRRLICHT_HOME`, and the dev app is told to connect to 7838 via
    REPO_ROOT="$(git rev-parse --show-toplevel)"
    DEV_PORT=7838
    DEV_HOME="$REPO_ROOT/.build/irrlicht-home"   # isolated state dir (IRRLICHT_HOME)
+   IRRLICHTD_BIN="/Users/ingo/projects/irrlicht/core/bin/irrlichd"  # one path: build target == launch target
    mkdir -p "$DEV_HOME"
    ```
-   All subsequent steps use `$REPO_ROOT`, `$DEV_PORT`, and `$DEV_HOME`.
+   All subsequent steps use `$REPO_ROOT`, `$DEV_PORT`, `$DEV_HOME`, and `$IRRLICHTD_BIN`.
+   `$IRRLICHTD_BIN` is the main repo's bin (a stable absolute path) so the build
+   and launch steps always agree even when `$REPO_ROOT` is a worktree — the
+   source compiled is still the worktree's (`go build` runs in `$REPO_ROOT/core`).
 
 1. **Build the Go daemon** — the daemon resolves the dashboard from `platforms/web/index.html` at runtime via a walk-up search from its own executable; no embed, no codegen.
    ```bash
-   cd "$REPO_ROOT/core" && go build -o /Users/ingo/projects/irrlicht/core/bin/irrlichd ./cmd/irrlichd
+   cd "$REPO_ROOT/core" && go build -o "$IRRLICHTD_BIN" ./cmd/irrlichd
    ```
-   Note: the binary is always placed in the main repo's `bin/` so the launch step has a stable path.
+   Note: the binary is built from the worktree's source but placed at the stable `$IRRLICHTD_BIN` path that step 5 launches.
 
 2. **Build the Swift app and assemble .app bundle**
    ```bash
@@ -91,10 +95,12 @@ worktree-local `IRRLICHT_HOME`, and the dev app is told to connect to 7838 via
    fi
    ```
 
-3. **Kill only the prior DEV instances** — leave production (Irrlicht.app + its daemon on 7837) untouched. Target the dev app and whatever holds the dev port.
+3. **Kill only the prior DEV instances** — leave production (Irrlicht.app + its daemon on 7837) untouched. The dev daemon runs from `$IRRLICHTD_BIN` (`…/core/bin/irrlichd`); production runs from inside the `.app` bundle, so matching that path reaps the dev daemon in ANY state (even if it isn't currently bound to the dev port) without touching production.
    ```bash
-   pkill -f "IrrlichtDev" 2>/dev/null
-   lsof -ti tcp:$DEV_PORT 2>/dev/null | xargs kill 2>/dev/null
+   pkill -f "IrrlichtDev" 2>/dev/null            # prior dev app
+   pkill -f "core/bin/irrlichd" 2>/dev/null      # prior dev daemon (NOT production, which runs from the .app bundle)
+   DEV_PIDS="$(lsof -ti tcp:$DEV_PORT 2>/dev/null)"   # belt-and-suspenders: anything still on the dev port
+   [ -n "$DEV_PIDS" ] && kill $DEV_PIDS 2>/dev/null
    sleep 2
    ```
 
@@ -105,9 +111,8 @@ worktree-local `IRRLICHT_HOME`, and the dev app is told to connect to 7838 via
 
 5. **Start the dev daemon** — isolated state (`IRRLICHT_HOME`) on the dev port, with `--record` for lifecycle event capture
    ```bash
-   cd "$REPO_ROOT/core" && \
-     IRRLICHT_HOME="$DEV_HOME" IRRLICHT_BIND_ADDR=127.0.0.1:$DEV_PORT \
-     nohup ./bin/irrlichd --record > /tmp/irrlichd-dev.log 2>&1 & disown
+   IRRLICHT_HOME="$DEV_HOME" IRRLICHT_BIND_ADDR=127.0.0.1:$DEV_PORT \
+     nohup "$IRRLICHTD_BIN" --record > /tmp/irrlichd-dev.log 2>&1 & disown
    ```
 
 6. **Wait for daemon to be ready** — confirm the dev port is listening before launching the app
@@ -115,9 +120,10 @@ worktree-local `IRRLICHT_HOME`, and the dev app is told to connect to 7838 via
    sleep 2 && lsof -iTCP:$DEV_PORT -sTCP:LISTEN -P -n 2>/dev/null
    ```
 
-7. **Start the dev Swift app** — launched via LaunchServices so `Bundle.main` resolves correctly; `--env` tells it to connect to the dev daemon on `$DEV_PORT` instead of production's 7837
+7. **Start the dev Swift app** — launched via LaunchServices so `Bundle.main` resolves correctly. `IRRLICHT_DAEMON_PORT` points it at the dev daemon (not production's 7837); `IRRLICHT_HOME` is also passed so that if the app ever spawns its OWN daemon (when the step-5 daemon isn't reachable), that daemon stays isolated instead of writing to the production state dir.
    ```bash
-   open --env IRRLICHT_DAEMON_PORT=$DEV_PORT --stdout /tmp/irrlicht-app-dev.log --stderr /tmp/irrlicht-app-dev.log /tmp/IrrlichtDev.app
+   open --env IRRLICHT_DAEMON_PORT=$DEV_PORT --env IRRLICHT_HOME="$DEV_HOME" \
+     --stdout /tmp/irrlicht-app-dev.log --stderr /tmp/irrlicht-app-dev.log /tmp/IrrlichtDev.app
    ```
 
 8. **Verify** — confirm the dev processes are running and the dev daemon is serving sessions (production on 7837 is unaffected)
@@ -126,8 +132,8 @@ worktree-local `IRRLICHT_HOME`, and the dev app is told to connect to 7838 via
    ```
 
 ## Notes
-- **Production keeps running.** The production Irrlicht.app (from DMG) and its bundled daemon stay on port 7837 with state under `~/.local/share/irrlicht/`. The dev instance is fully isolated: port `$DEV_PORT` (7838) + `IRRLICHT_HOME=$DEV_HOME`. The dev app reaches the dev daemon because `IRRLICHT_DAEMON_PORT` (via `open --env`) overrides the hardcoded default; `DaemonManager` also skips its global `pkill` when a custom port is set, so it can't take production down.
-- Both daemons watch the same `~/.claude` transcripts, so the dev UI shows the same live sessions as production — that's intended for "see the UI render" testing.
+- **Production keeps running.** The production Irrlicht.app (from DMG) and its bundled daemon stay on port 7837 with state under `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/`. The dev instance binds port `$DEV_PORT` (7838) and routes its WRITTEN state — socket, recordings, history, session store, ledgers, and cost store — beneath `IRRLICHT_HOME=$DEV_HOME`, so it never prunes or mutates production's session/cost data. The dev app reaches the dev daemon because `IRRLICHT_DAEMON_PORT` (via `open --env`) overrides the hardcoded default; `DaemonManager` also skips its global `pkill` when a custom port is set, so it can't take production down.
+- **What the dev instance still shares with production:** it reads the same `~/.claude` transcripts (so the dev UI shows the same live sessions — intended for "see the UI render" testing) and appends to the same `~/Library/Application Support/Irrlicht/logs/events.log`. It does NOT share the on-disk session/ledger/cost stores.
 - Daemon logs: `/tmp/irrlichd-dev.log`
 - Swift app logs: `/tmp/irrlicht-app-dev.log`
 - **TCC stability**: run `tools/dev-sign-setup.sh` once to install the `"Irrlicht Dev"` self-signed code signing identity. The skill automatically signs with it when present, giving the app a stable designated requirement so Accessibility/Automation grants persist across rebuilds. Without it, every rebuild invalidates TCC and requires re-granting in System Settings.

--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -1,23 +1,31 @@
 ---
 name: ir:test-mac
 description: >
-  Build and restart the irrlicht daemon and macOS Swift app for local testing.
-  Compiles the Go daemon, builds the Swift app, kills all running instances
-  (including production Irrlicht.app), and launches the freshly built versions.
-  Use when the user says "test mac", "restart mac", "rebuild mac", or "/ir:test-mac".
+  Build and run a dev irrlicht daemon + macOS Swift app for local testing,
+  alongside the production Irrlicht.app (which keeps running). The dev instance
+  uses an isolated state dir (IRRLICHT_HOME) and a separate port (7838), so it
+  never disturbs production on port 7837. Use when the user says "test mac",
+  "restart mac", "rebuild mac", or "/ir:test-mac".
 ---
 
-# Build & Restart macOS Dev Stack
+# Build & Run macOS Dev Stack (alongside production)
 
-Build the irrlicht daemon and Swift app, then replace all running instances with the new builds.
+Build the irrlicht daemon and Swift app and run them as a **dev instance that
+coexists with production**. Production stays up the whole time: the dev daemon
+binds port **7838** (vs production's 7837) and stores its state under a
+worktree-local `IRRLICHT_HOME`, and the dev app is told to connect to 7838 via
+`IRRLICHT_DAEMON_PORT`. Only prior *dev* instances are replaced on rerun.
 
 ## Steps
 
-0. **Detect repo root** — use the worktree root if running in a worktree, otherwise the main repo
+0. **Detect repo root and set the dev instance config** — use the worktree root if running in a worktree, otherwise the main repo
    ```bash
    REPO_ROOT="$(git rev-parse --show-toplevel)"
+   DEV_PORT=7838
+   DEV_HOME="$REPO_ROOT/.build/irrlicht-home"   # isolated state dir (IRRLICHT_HOME)
+   mkdir -p "$DEV_HOME"
    ```
-   All subsequent steps use `$REPO_ROOT` instead of hardcoded paths.
+   All subsequent steps use `$REPO_ROOT`, `$DEV_PORT`, and `$DEV_HOME`.
 
 1. **Build the Go daemon** — the daemon resolves the dashboard from `platforms/web/index.html` at runtime via a walk-up search from its own executable; no embed, no codegen.
    ```bash
@@ -83,42 +91,43 @@ Build the irrlicht daemon and Swift app, then replace all running instances with
    fi
    ```
 
-3. **Kill all running irrlicht processes** (production app, production daemon, debug app, debug daemon)
+3. **Kill only the prior DEV instances** — leave production (Irrlicht.app + its daemon on 7837) untouched. Target the dev app and whatever holds the dev port.
    ```bash
-   pkill -f "Irrlicht.app" 2>/dev/null
    pkill -f "IrrlichtDev" 2>/dev/null
-   pkill -f "\.build.*Irrlicht" 2>/dev/null
-   pkill -f irrlichd 2>/dev/null
+   lsof -ti tcp:$DEV_PORT 2>/dev/null | xargs kill 2>/dev/null
    sleep 2
    ```
 
-4. **Clean up stale socket**
+4. **Clean up the stale DEV socket** (under the isolated state dir, never production's)
    ```bash
-   rm -f /Users/ingo/.local/share/irrlicht/irrlichd.sock
+   rm -f "$DEV_HOME/irrlichd.sock"
    ```
 
-5. **Start the dev daemon** (with `--record` for lifecycle event capture)
+5. **Start the dev daemon** — isolated state (`IRRLICHT_HOME`) on the dev port, with `--record` for lifecycle event capture
    ```bash
-   cd /Users/ingo/projects/irrlicht/core && nohup ./bin/irrlichd --record > /tmp/irrlichd-dev.log 2>&1 & disown
+   cd "$REPO_ROOT/core" && \
+     IRRLICHT_HOME="$DEV_HOME" IRRLICHT_BIND_ADDR=127.0.0.1:$DEV_PORT \
+     nohup ./bin/irrlichd --record > /tmp/irrlichd-dev.log 2>&1 & disown
    ```
 
-6. **Wait for daemon to be ready** — confirm port 7837 is listening before launching the app
+6. **Wait for daemon to be ready** — confirm the dev port is listening before launching the app
    ```bash
-   sleep 2 && lsof -iTCP:7837 -sTCP:LISTEN -P -n 2>/dev/null
+   sleep 2 && lsof -iTCP:$DEV_PORT -sTCP:LISTEN -P -n 2>/dev/null
    ```
 
-7. **Start the dev Swift app** (from the .app bundle via LaunchServices so `Bundle.main` resolves correctly)
+7. **Start the dev Swift app** — launched via LaunchServices so `Bundle.main` resolves correctly; `--env` tells it to connect to the dev daemon on `$DEV_PORT` instead of production's 7837
    ```bash
-   open --stdout /tmp/irrlicht-app-dev.log --stderr /tmp/irrlicht-app-dev.log /tmp/IrrlichtDev.app
+   open --env IRRLICHT_DAEMON_PORT=$DEV_PORT --stdout /tmp/irrlicht-app-dev.log --stderr /tmp/irrlicht-app-dev.log /tmp/IrrlichtDev.app
    ```
 
-8. **Verify** — confirm both processes are running and the daemon is serving sessions
+8. **Verify** — confirm the dev processes are running and the dev daemon is serving sessions (production on 7837 is unaffected)
    ```bash
-   pgrep -f "bin/irrlichd" && pgrep -f "IrrlichtDev" && curl -s http://localhost:7837/api/v1/sessions | head -1
+   pgrep -f "bin/irrlichd" && pgrep -f "IrrlichtDev" && curl -s http://127.0.0.1:$DEV_PORT/api/v1/sessions | head -1
    ```
 
 ## Notes
-- The production Irrlicht.app (from DMG) bundles its own daemon. It MUST be killed before starting the dev daemon, otherwise port 7837 will be occupied.
+- **Production keeps running.** The production Irrlicht.app (from DMG) and its bundled daemon stay on port 7837 with state under `~/.local/share/irrlicht/`. The dev instance is fully isolated: port `$DEV_PORT` (7838) + `IRRLICHT_HOME=$DEV_HOME`. The dev app reaches the dev daemon because `IRRLICHT_DAEMON_PORT` (via `open --env`) overrides the hardcoded default; `DaemonManager` also skips its global `pkill` when a custom port is set, so it can't take production down.
+- Both daemons watch the same `~/.claude` transcripts, so the dev UI shows the same live sessions as production — that's intended for "see the UI render" testing.
 - Daemon logs: `/tmp/irrlichd-dev.log`
 - Swift app logs: `/tmp/irrlicht-app-dev.log`
 - **TCC stability**: run `tools/dev-sign-setup.sh` once to install the `"Irrlicht Dev"` self-signed code signing identity. The skill automatically signs with it when present, giving the app a stable designated requirement so Accessibility/Automation grants persist across rebuilds. Without it, every rebuild invalidates TCC and requires re-granting in System Settings.

--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -5,12 +5,18 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tree:
+          - platforms/web
+          - tools/agent-onboarding/internal/viewer/web
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
       - run: npm ci
-        working-directory: platforms/web
+        working-directory: ${{ matrix.tree }}
       - run: npm test
-        working-directory: platforms/web
+        working-directory: ${{ matrix.tree }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,5 +108,13 @@ fswatcher roots, process scanners, parser-factory map, PID-discovery map
 
 Before marking a ticket done, run the full suite — all three layers must pass:
 
-- Unit + e2e: `go test ./core/... -race -count=1`
+- Unit + e2e: `go test ./core/... -race -count=1` (includes the headless
+  daemon startup smoke test — boots a real `irrlichd` on an ephemeral port
+  under `t.TempDir()`, so it never touches the production daemon).
 - Replay: `tools/replay-fixtures.sh`
+- Web (only when touching a `web/` tree): `npm test` in that tree. There are
+  two independent suites, each with its own `node_modules`:
+  - `platforms/web/` — the dashboard.
+  - `tools/agent-onboarding/internal/viewer/web/` — the onboarding viewer.
+
+  `npm test` runs `vitest run` (single CI-shaped pass, no watch).

--- a/core/adapters/outbound/metrics/ledger.go
+++ b/core/adapters/outbound/metrics/ledger.go
@@ -20,6 +20,17 @@ const LedgerSuffix = ".ledger.json"
 
 var ledgerDirOnce sync.Once
 
+// ledgerDirOverride, when non-empty, replaces the default ledger directory.
+// Set once at daemon startup via SetLedgerDir so a dev/test instance with
+// IRRLICHT_HOME set keeps its per-session ledgers isolated from production
+// rather than reading/pruning ~/.local/share/irrlicht/sessions.
+var ledgerDirOverride string
+
+// SetLedgerDir overrides the per-session ledger directory. Must be called
+// before the first ledger operation (i.e. during startup, before ensureLedgerDir
+// runs). A no-op when dir is empty.
+func SetLedgerDir(dir string) { ledgerDirOverride = dir }
+
 // ensureLedgerDir creates the ledger directory on the first call; subsequent
 // calls are no-ops. Silent on error — a missing dir causes saveLedger to fail
 // silently, which is acceptable.
@@ -35,6 +46,9 @@ func ensureLedgerDir() {
 
 // ledgerDir returns the directory where per-session ledger files are stored.
 func ledgerDir() (string, error) {
+	if ledgerDirOverride != "" {
+		return ledgerDirOverride, nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err

--- a/core/cmd/irrlichd/daemon_smoke_test.go
+++ b/core/cmd/irrlichd/daemon_smoke_test.go
@@ -52,12 +52,17 @@ func TestDaemonStartupSmoke(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start daemon: %v", err)
 	}
-	// Backstop: kill the child if anything below fails before SIGTERM.
-	killed := false
+	// A single reaper goroutine owns cmd.Wait(); the backstop and the SIGTERM
+	// path coordinate through `exited` rather than calling Wait themselves, so
+	// Wait is never invoked twice (which `go test -race` flags as "Wait was
+	// already called").
+	exited := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(exited) }()
+	stopped := false
+	stop := func() { _ = cmd.Process.Kill(); <-exited }
 	defer func() {
-		if !killed {
-			_ = cmd.Process.Kill()
-			_, _ = cmd.Process.Wait()
+		if !stopped {
+			stop()
 		}
 	}()
 	dumpLogsOnFail(t, homeDir)
@@ -78,12 +83,25 @@ func TestDaemonStartupSmoke(t *testing.T) {
 	}}
 	assertAgentsEndpoint(t, unixClient, "http://unix/api/v1/agents")
 
-	// 3. Clean shutdown on SIGTERM.
+	// Drop client-side keep-alive conns so the daemon's graceful shutdown isn't
+	// waiting on them, then SIGTERM and confirm a clean exit.
+	http.DefaultClient.CloseIdleConnections()
+	unixClient.CloseIdleConnections()
+
+	// 3. Clean shutdown on SIGTERM. The timeout exceeds the daemon's own 5s
+	// graceful-shutdown budget so a clean (but not instant) shutdown isn't
+	// mistaken for a hang.
 	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 		t.Fatalf("send SIGTERM: %v", err)
 	}
-	waitExit(t, cmd, 3*time.Second)
-	killed = true
+	select {
+	case <-exited:
+	case <-time.After(6 * time.Second):
+		stop()
+		stopped = true
+		t.Fatalf("daemon did not exit within 6s of SIGTERM")
+	}
+	stopped = true
 	if _, err := os.Stat(addrPath); !os.IsNotExist(err) {
 		t.Errorf("addr file %s should be removed after shutdown, stat err = %v", addrPath, err)
 	}
@@ -146,20 +164,6 @@ func assertAgentsEndpoint(t *testing.T, client *http.Client, url string) {
 		if got[i] != want[i] {
 			t.Fatalf("GET %s agent names = %v, want %v", url, got, want)
 		}
-	}
-}
-
-// waitExit fails the test if the daemon doesn't exit within timeout.
-func waitExit(t *testing.T, cmd *exec.Cmd, timeout time.Duration) {
-	t.Helper()
-	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
-	select {
-	case <-done:
-		// Exited (a non-nil error from the signal-terminated process is fine).
-	case <-time.After(timeout):
-		_ = cmd.Process.Kill()
-		t.Fatalf("daemon did not exit within %s of SIGTERM", timeout)
 	}
 }
 

--- a/core/cmd/irrlichd/daemon_smoke_test.go
+++ b/core/cmd/irrlichd/daemon_smoke_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"irrlicht/core/adapters/inbound/agents"
+)
+
+// TestDaemonStartupSmoke boots a real irrlichd in a child process and verifies
+// the socket protocol survives every commit. It is fully hermetic and parallel-
+// safe: HOME and IRRLICHT_HOME both point at fresh temp dirs (so it neither
+// reads nor mutates the production install or the user's ~/.claude config), and
+// IRRLICHT_BIND_ADDR=127.0.0.1:0 binds an OS-assigned port (so N worktrees can
+// run it at once). IRRLICHT_DEMO_MODE=1 keeps the file/process watchers off so
+// the daemon serves only what's wired at startup — exactly the surface we want
+// to smoke-test.
+//
+// What it asserts:
+//   - the daemon publishes its resolved port to IRRLICHT_HOME/irrlichd.addr,
+//   - GET /api/v1/agents over TCP returns the full adapter registry,
+//   - the same endpoint works over the unix socket,
+//   - SIGTERM shuts it down cleanly and removes the addr file.
+func TestDaemonStartupSmoke(t *testing.T) {
+	homeDir := t.TempDir()  // isolates ~/.claude hooks + Application Support logs
+	stateDir := t.TempDir() // IRRLICHT_HOME: socket, addr file, recordings, history
+
+	// Build the daemon binary. Done lazily here (not in TestMain) so unrelated
+	// `go test -run …` invocations don't pay the build cost.
+	bin := filepath.Join(t.TempDir(), "irrlichd")
+	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+		t.Fatalf("build irrlichd: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(bin)
+	cmd.Env = append(os.Environ(),
+		"HOME="+homeDir,
+		"IRRLICHT_HOME="+stateDir,
+		"IRRLICHT_BIND_ADDR=127.0.0.1:0",
+		"IRRLICHT_DEMO_MODE=1",
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start daemon: %v", err)
+	}
+	// Backstop: kill the child if anything below fails before SIGTERM.
+	killed := false
+	defer func() {
+		if !killed {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	}()
+	dumpLogsOnFail(t, homeDir)
+
+	// The daemon writes its resolved address here once listening.
+	addrPath := filepath.Join(stateDir, "irrlichd.addr")
+	addr := waitForAddr(t, addrPath, 5*time.Second)
+
+	// 1. TCP round-trip.
+	assertAgentsEndpoint(t, http.DefaultClient, "http://"+addr+"/api/v1/agents")
+
+	// 2. Unix socket round-trip.
+	sockPath := filepath.Join(stateDir, "irrlichd.sock")
+	unixClient := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+		},
+	}}
+	assertAgentsEndpoint(t, unixClient, "http://unix/api/v1/agents")
+
+	// 3. Clean shutdown on SIGTERM.
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+	waitExit(t, cmd, 3*time.Second)
+	killed = true
+	if _, err := os.Stat(addrPath); !os.IsNotExist(err) {
+		t.Errorf("addr file %s should be removed after shutdown, stat err = %v", addrPath, err)
+	}
+}
+
+// waitForAddr polls until the addr file exists and is non-empty, returning its
+// contents (host:port). Fails the test if it never appears.
+func waitForAddr(t *testing.T, path string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(path); err == nil {
+			if addr := strings.TrimSpace(string(b)); addr != "" {
+				return addr
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("daemon never wrote addr file %s within %s", path, timeout)
+	return ""
+}
+
+// assertAgentsEndpoint GETs /api/v1/agents through the given client and checks
+// the returned adapter names exactly match agents.All() — the registry the
+// dashboard and Swift app rely on.
+func assertAgentsEndpoint(t *testing.T, client *http.Client, url string) {
+	t.Helper()
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status %d, want 200", url, resp.StatusCode)
+	}
+	var entries []struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode %s: %v", url, err)
+	}
+
+	got := make([]string, len(entries))
+	for i, e := range entries {
+		got[i] = e.Name
+	}
+	want := make([]string, 0)
+	for _, a := range agents.All() {
+		want = append(want, a.Identity.Name)
+	}
+	if len(want) == 0 {
+		t.Fatal("agents.All() is empty — test cannot verify the registry")
+	}
+	sort.Strings(got)
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("GET %s returned %d agents %v, want %d %v", url, len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("GET %s agent names = %v, want %v", url, got, want)
+		}
+	}
+}
+
+// waitExit fails the test if the daemon doesn't exit within timeout.
+func waitExit(t *testing.T, cmd *exec.Cmd, timeout time.Duration) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+		// Exited (a non-nil error from the signal-terminated process is fine).
+	case <-time.After(timeout):
+		_ = cmd.Process.Kill()
+		t.Fatalf("daemon did not exit within %s of SIGTERM", timeout)
+	}
+}
+
+// dumpLogsOnFail registers a cleanup that prints the daemon's event log when
+// the test fails, so CI failures aren't silent.
+func dumpLogsOnFail(t *testing.T, homeDir string) {
+	t.Helper()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		logPath := filepath.Join(homeDir, "Library", "Application Support", "Irrlicht", "logs", "events.log")
+		if b, err := os.ReadFile(logPath); err == nil {
+			t.Logf("daemon events.log:\n%s", b)
+		}
+	})
+}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -276,11 +276,22 @@ func main() {
 	}
 
 	// TCP listener — default loopback; override with IRRLICHT_BIND_ADDR.
+	// IRRLICHT_BIND_ADDR=127.0.0.1:0 binds an ephemeral port (used by the
+	// startup smoke test so N daemons can run in parallel).
 	bindAddr := resolveBindAddr(os.Getenv("IRRLICHT_BIND_ADDR"))
 	tcpL, err := net.Listen("tcp", bindAddr)
 	if err != nil {
 		logger.LogError("startup", "", fmt.Sprintf("failed to listen on TCP %s: %v", bindAddr, err))
 		os.Exit(1)
+	}
+	// resolvedAddr is the actual address (with the OS-assigned port when the
+	// request was :0). Publish it to <dataDir>/irrlichd.addr so tooling and
+	// the smoke test can find a daemon bound to an ephemeral port; the file
+	// also doubles as a "daemon is up" signal. Removed on shutdown.
+	resolvedAddr := tcpL.Addr().String()
+	addrPath := filepath.Join(filepath.Dir(sockPath), "irrlichd.addr")
+	if err := os.WriteFile(addrPath, []byte(resolvedAddr+"\n"), 0600); err != nil {
+		logger.LogError("startup", "", fmt.Sprintf("failed to write addr file %s: %v", addrPath, err))
 	}
 
 	go func() { _ = srv.Serve(unixL) }()
@@ -445,7 +456,7 @@ func main() {
 		}()
 	}
 
-	logger.LogInfo("startup", "", fmt.Sprintf("irrlichd %s listening on unix:%s and tcp:%s", Version, sockPath, bindAddr))
+	logger.LogInfo("startup", "", fmt.Sprintf("irrlichd %s listening on unix:%s and tcp:%s", Version, sockPath, resolvedAddr))
 
 	// Wait for SIGTERM or SIGINT.
 	sig := make(chan os.Signal, 1)
@@ -453,6 +464,10 @@ func main() {
 	<-sig
 
 	logger.LogInfo("shutdown", "", "signal received, shutting down")
+
+	// Remove the addr file so it can't outlive the daemon and mislead tooling
+	// into connecting to a dead port.
+	os.Remove(addrPath)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -290,8 +291,13 @@ func main() {
 	// also doubles as a "daemon is up" signal. Removed on shutdown.
 	resolvedAddr := tcpL.Addr().String()
 	addrPath := filepath.Join(filepath.Dir(sockPath), "irrlichd.addr")
-	if err := os.WriteFile(addrPath, []byte(resolvedAddr+"\n"), 0600); err != nil {
-		logger.LogError("startup", "", fmt.Sprintf("failed to write addr file %s: %v", addrPath, err))
+	// Write atomically (temp + rename) so a reader polling the file can never
+	// observe a half-written, truncated host:port.
+	tmpAddr := addrPath + ".tmp"
+	if err := os.WriteFile(tmpAddr, []byte(resolvedAddr+"\n"), 0600); err != nil {
+		logger.LogError("startup", "", fmt.Sprintf("failed to write addr file %s: %v", tmpAddr, err))
+	} else if err := os.Rename(tmpAddr, addrPath); err != nil {
+		logger.LogError("startup", "", fmt.Sprintf("failed to publish addr file %s: %v", addrPath, err))
 	}
 
 	go func() { _ = srv.Serve(unixL) }()
@@ -301,7 +307,16 @@ func main() {
 	// broadcasting the daemon on networks the user did not intend to share on.
 	var mdnsAdv *mdns.Advertiser
 	if os.Getenv("IRRLICHT_MDNS") == "1" {
-		mdnsAdv, err = mdns.New(tcpPort)
+		// Advertise the port we actually bound (resolvedAddr), not the compile-time
+		// default — otherwise a daemon on a custom/ephemeral port would point
+		// discovery clients at 7837 (a dead or production port).
+		advPort := tcpPort
+		if _, p, err := net.SplitHostPort(resolvedAddr); err == nil {
+			if n, err := strconv.Atoi(p); err == nil {
+				advPort = n
+			}
+		}
+		mdnsAdv, err = mdns.New(advPort)
 		if err != nil {
 			logger.LogError("startup", "", fmt.Sprintf("mDNS advertisement failed (non-fatal): %v", err))
 		} else {
@@ -526,11 +541,14 @@ func runCapacityRefreshLoop(ctx context.Context, logger outbound.Logger, initial
 // home should come from os.UserHomeDir(); pass "" only when the lookup
 // failed.
 //
-// IRRLICHT_HOME overrides the entire state tree — socket, history rollups,
-// the on-disk web fallback, and recordings all live beneath it. This lets a
-// dev/test daemon run fully isolated from the production install (and from
-// other worktrees) without touching ~/.local/share/irrlicht/. Recordings
-// still honor the narrower IRRLICHT_RECORDINGS_DIR override when set.
+// IRRLICHT_HOME relocates this tree — socket, addr file, history rollups,
+// the on-disk web fallback, and recordings all live beneath it. The session
+// store, per-session ledgers, and cost store live under different roots
+// (Application Support); stateStoreDir routes those through IRRLICHT_HOME too,
+// so a dev/test daemon is fully isolated from the production install (and from
+// other worktrees) without touching ~/.local/share/irrlicht/ or
+// ~/Library/Application Support/Irrlicht/. Recordings still honor the narrower
+// IRRLICHT_RECORDINGS_DIR override when set.
 func dataDir(home string) string {
 	if v := os.Getenv("IRRLICHT_HOME"); v != "" {
 		return v
@@ -541,12 +559,25 @@ func dataDir(home string) string {
 	return filepath.Join(home, ".local", "share", "irrlicht")
 }
 
-// socketPath returns the Unix socket path for irrlichd.
-func socketPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "/tmp/irrlichd.sock"
+// stateStoreDir returns the directory for a named state store (e.g. "instances",
+// "cost", "sessions") when IRRLICHT_HOME is set, so every store nests beneath it
+// for full isolation. Returns "" when IRRLICHT_HOME is unset, signaling the
+// caller to keep its production-default location unchanged. Needed because the
+// session repo and cost store root under ~/Library/Application Support/Irrlicht
+// and ledgers under ~/.local/share/irrlicht/sessions — none of which flow
+// through dataDir.
+func stateStoreDir(sub string) string {
+	if v := os.Getenv("IRRLICHT_HOME"); v != "" {
+		return filepath.Join(v, sub)
 	}
+	return ""
+}
+
+// socketPath returns the Unix socket path for irrlichd. It routes through
+// dataDir so the IRRLICHT_HOME override is honored even when os.UserHomeDir()
+// fails (dataDir maps an empty home to /tmp/irrlicht when no override is set).
+func socketPath() string {
+	home, _ := os.UserHomeDir()
 	return filepath.Join(dataDir(home), "irrlichd.sock")
 }
 
@@ -630,10 +661,22 @@ const costAttachTTL = 5 * time.Second
 // (returned as the outbound.SessionRepository interface since the concrete
 // cached type is unexported).
 func initSessionStorage(logger outbound.Logger, cfg config.Config) (*filesystem.SessionRepository, outbound.SessionRepository) {
-	fsRepo, err := filesystem.New()
-	if err != nil {
-		logger.LogError("startup", "", fmt.Sprintf("failed to init filesystem repo: %v", err))
-		os.Exit(1)
+	// Honor IRRLICHT_HOME for full isolation: a dev/test daemon must not prune
+	// or mutate the production session store. Ledgers route through the same
+	// override (set before the orphan-ledger sweep below reads LedgerDir).
+	if dir := stateStoreDir("sessions"); dir != "" {
+		metrics.SetLedgerDir(dir)
+	}
+	var fsRepo *filesystem.SessionRepository
+	if dir := stateStoreDir("instances"); dir != "" {
+		fsRepo = filesystem.NewWithDir(dir)
+	} else {
+		var err error
+		fsRepo, err = filesystem.New()
+		if err != nil {
+			logger.LogError("startup", "", fmt.Sprintf("failed to init filesystem repo: %v", err))
+			os.Exit(1)
+		}
 	}
 
 	pruned, err := fsRepo.PruneStale(cfg.MaxSessionAge)
@@ -724,10 +767,16 @@ func pruneDeadProcSessions(fsRepo *filesystem.SessionRepository, logger outbound
 // records a baseline row for every existing session so rates are
 // computable without waiting for new activity.
 func initCostTracker(logger outbound.Logger, fsRepo *filesystem.SessionRepository) outbound.CostTracker {
-	costTracker, err := filesystem.NewCostTracker()
-	if err != nil {
-		logger.LogError("startup", "", fmt.Sprintf("failed to init cost tracker: %v", err))
-		return nil
+	var costTracker *filesystem.CostTracker
+	if dir := stateStoreDir("cost"); dir != "" {
+		costTracker = filesystem.NewCostTrackerWithDir(dir)
+	} else {
+		var err error
+		costTracker, err = filesystem.NewCostTracker()
+		if err != nil {
+			logger.LogError("startup", "", fmt.Sprintf("failed to init cost tracker: %v", err))
+			return nil
+		}
 	}
 	// Attribute wrapper agents (pi, opencode) to the subscription they
 	// inherit, so per-provider spend matches the dashboard's quota chip

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -398,9 +398,10 @@ func main() {
 		claudecode.NewStatuslineHandler(metricsCollector, logger))
 
 	// Lifecycle recording: opt-in via --record flag or IRRLICHT_RECORD=1.
-	// IRRLICHT_RECORDINGS_DIR overrides the default directory so test
-	// harnesses (e.g. the ir:onboard-agent skill) can isolate recordings
-	// from the user's real ~/.local/share/irrlicht/recordings/.
+	// Recordings default to <dataDir>/recordings, so IRRLICHT_HOME already
+	// isolates them. IRRLICHT_RECORDINGS_DIR is the narrower override that
+	// wins even when IRRLICHT_HOME is set, so test harnesses (e.g. the
+	// ir:onboard-agent skill) can pin recordings somewhere specific.
 	if recordEnabled {
 		recordingsDir := os.Getenv("IRRLICHT_RECORDINGS_DIR")
 		if recordingsDir == "" {
@@ -509,7 +510,16 @@ func runCapacityRefreshLoop(ctx context.Context, logger outbound.Logger, initial
 // dataDir returns the irrlichd state directory (~/.local/share/irrlicht).
 // home should come from os.UserHomeDir(); pass "" only when the lookup
 // failed.
+//
+// IRRLICHT_HOME overrides the entire state tree — socket, history rollups,
+// the on-disk web fallback, and recordings all live beneath it. This lets a
+// dev/test daemon run fully isolated from the production install (and from
+// other worktrees) without touching ~/.local/share/irrlicht/. Recordings
+// still honor the narrower IRRLICHT_RECORDINGS_DIR override when set.
 func dataDir(home string) string {
+	if v := os.Getenv("IRRLICHT_HOME"); v != "" {
+		return v
+	}
 	if home == "" {
 		return "/tmp/irrlicht"
 	}

--- a/core/cmd/irrlichd/main_test.go
+++ b/core/cmd/irrlichd/main_test.go
@@ -228,6 +228,37 @@ func TestResolveBindAddr(t *testing.T) {
 	}
 }
 
+func TestDataDir(t *testing.T) {
+	// Default: derived from the passed-in home dir.
+	t.Run("default", func(t *testing.T) {
+		t.Setenv("IRRLICHT_HOME", "")
+		want := filepath.Join("/home/alice", ".local", "share", "irrlicht")
+		if got := dataDir("/home/alice"); got != want {
+			t.Errorf("dataDir(home) = %q, want %q", got, want)
+		}
+	})
+
+	// Default with empty home (lookup failed): /tmp fallback.
+	t.Run("empty home", func(t *testing.T) {
+		t.Setenv("IRRLICHT_HOME", "")
+		if got := dataDir(""); got != "/tmp/irrlicht" {
+			t.Errorf("dataDir(\"\") = %q, want /tmp/irrlicht", got)
+		}
+	})
+
+	// IRRLICHT_HOME overrides the whole tree and ignores the home arg.
+	t.Run("override", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("IRRLICHT_HOME", dir)
+		if got := dataDir("/home/alice"); got != dir {
+			t.Errorf("dataDir with IRRLICHT_HOME = %q, want %q", got, dir)
+		}
+		if got := dataDir(""); got != dir {
+			t.Errorf("dataDir(\"\") with IRRLICHT_HOME = %q, want %q", got, dir)
+		}
+	})
+}
+
 // TestGate_GetState verifies that GET /state returns the compact debug-state format.
 func TestGate_GetState(t *testing.T) {
 	srv, repo := newTestStack(t)

--- a/core/cmd/irrlichd/main_test.go
+++ b/core/cmd/irrlichd/main_test.go
@@ -259,6 +259,30 @@ func TestDataDir(t *testing.T) {
 	})
 }
 
+func TestStateStoreDir(t *testing.T) {
+	// Without IRRLICHT_HOME, returns "" so callers keep their production default.
+	t.Run("unset keeps default", func(t *testing.T) {
+		t.Setenv("IRRLICHT_HOME", "")
+		for _, sub := range []string{"instances", "cost", "sessions"} {
+			if got := stateStoreDir(sub); got != "" {
+				t.Errorf("stateStoreDir(%q) = %q, want \"\" when IRRLICHT_HOME unset", sub, got)
+			}
+		}
+	})
+
+	// With IRRLICHT_HOME, every store nests beneath it for full isolation.
+	t.Run("override nests stores", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("IRRLICHT_HOME", dir)
+		for _, sub := range []string{"instances", "cost", "sessions"} {
+			want := filepath.Join(dir, sub)
+			if got := stateStoreDir(sub); got != want {
+				t.Errorf("stateStoreDir(%q) = %q, want %q", sub, got, want)
+			}
+		}
+	})
+}
+
 // TestGate_GetState verifies that GET /state returns the compact debug-state format.
 func TestGate_GetState(t *testing.T) {
 	srv, repo := newTestStack(t)

--- a/platforms/macos/Irrlicht/Managers/DaemonEndpoint.swift
+++ b/platforms/macos/Irrlicht/Managers/DaemonEndpoint.swift
@@ -13,13 +13,22 @@ enum DaemonEndpoint {
     static let defaultPort = 7837
 
     /// The resolved daemon port: `IRRLICHT_DAEMON_PORT` if set to a positive
-    /// integer, otherwise the default.
+    /// integer, otherwise the default. Whitespace is trimmed first — Swift's
+    /// `Int("7838\n")` returns nil, and silently falling back to 7837 would
+    /// flip `isCustomPort` to false and re-enable `DaemonManager`'s global
+    /// `pkill`, which could take the production daemon down.
     static let port: Int = {
-        if let v = ProcessInfo.processInfo.environment["IRRLICHT_DAEMON_PORT"],
-           let p = Int(v), p > 0 {
-            return p
+        guard let raw = ProcessInfo.processInfo.environment["IRRLICHT_DAEMON_PORT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty
+        else {
+            return defaultPort
         }
-        return defaultPort
+        guard let p = Int(raw), p > 0 else {
+            FileHandle.standardError.write(Data(
+                "irrlicht: IRRLICHT_DAEMON_PORT=\"\(raw)\" is not a valid port; using default \(defaultPort)\n".utf8))
+            return defaultPort
+        }
+        return p
     }()
 
     /// True when an explicit non-default port was requested — i.e. we're a dev

--- a/platforms/macos/Irrlicht/Managers/DaemonEndpoint.swift
+++ b/platforms/macos/Irrlicht/Managers/DaemonEndpoint.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Centralizes where the dashboard talks to `irrlichd`.
+///
+/// The port defaults to 7837 but can be overridden with the
+/// `IRRLICHT_DAEMON_PORT` environment variable. This lets a dev build connect
+/// to an isolated daemon (e.g. port 7838, started with its own `IRRLICHT_HOME`)
+/// while the production app keeps talking to 7837 — so `/ir:test-mac` can run a
+/// dev UI alongside production without taking it down. The matching daemon-side
+/// knobs are `IRRLICHT_BIND_ADDR` (port) and `IRRLICHT_HOME` (state dir).
+enum DaemonEndpoint {
+    /// The port the production daemon binds by default.
+    static let defaultPort = 7837
+
+    /// The resolved daemon port: `IRRLICHT_DAEMON_PORT` if set to a positive
+    /// integer, otherwise the default.
+    static let port: Int = {
+        if let v = ProcessInfo.processInfo.environment["IRRLICHT_DAEMON_PORT"],
+           let p = Int(v), p > 0 {
+            return p
+        }
+        return defaultPort
+    }()
+
+    /// True when an explicit non-default port was requested — i.e. we're a dev
+    /// instance coexisting with production and must not disturb it.
+    static var isCustomPort: Bool { port != defaultPort }
+
+    /// Base URL for HTTP requests, e.g. `http://127.0.0.1:7837`.
+    static var httpBase: String { "http://127.0.0.1:\(port)" }
+
+    /// Base URL for WebSocket requests, e.g. `ws://127.0.0.1:7837`.
+    static var wsBase: String { "ws://127.0.0.1:\(port)" }
+}

--- a/platforms/macos/Irrlicht/Managers/DaemonManager.swift
+++ b/platforms/macos/Irrlicht/Managers/DaemonManager.swift
@@ -14,7 +14,6 @@ final class DaemonManager: ObservableObject {
     private var healthTask: Task<Void, Never>?
     private var restartCount = 0
     private let maxRestartDelay: TimeInterval = 30
-    private let daemonPort = 7837
 
     private let logger = Logger(subsystem: "io.irrlicht.app", category: "DaemonManager")
 
@@ -45,6 +44,13 @@ final class DaemonManager: ObservableObject {
     /// Kill any `irrlichd` processes left over from a previous app launch,
     /// LaunchAgent, or manual invocation so we start with a clean slate.
     private func killStaleDaemons() {
+        // On a custom port we're a dev instance coexisting with the production
+        // daemon (port 7837). pkill matches by process name and can't target a
+        // port, so a global kill here would take production down too — skip it.
+        if DaemonEndpoint.isCustomPort {
+            logger.info("Custom daemon port \(DaemonEndpoint.port) — skipping global pkill to leave production running")
+            return
+        }
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
         task.arguments = ["-x", "irrlichd"]
@@ -64,7 +70,7 @@ final class DaemonManager: ObservableObject {
 
     /// Returns true if an irrlichd instance is already listening on the expected port.
     func isDaemonReachable() async -> Bool {
-        guard let url = URL(string: "http://127.0.0.1:\(daemonPort)/state") else { return false }
+        guard let url = URL(string: "\(DaemonEndpoint.httpBase)/state") else { return false }
         var request = URLRequest(url: url)
         request.timeoutInterval = 2
         do {
@@ -103,6 +109,11 @@ final class DaemonManager: ObservableObject {
         proc.executableURL = daemonURL
         proc.standardOutput = FileHandle.nullDevice
         proc.standardError = FileHandle.nullDevice
+        // Bind the same port the app connects to. Inherits the app's
+        // environment so IRRLICHT_HOME (if set for a dev instance) propagates.
+        var env = ProcessInfo.processInfo.environment
+        env["IRRLICHT_BIND_ADDR"] = "127.0.0.1:\(DaemonEndpoint.port)"
+        proc.environment = env
 
         proc.terminationHandler = { [weak self] terminated in
             Task { @MainActor [weak self] in

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -175,7 +175,7 @@ class SessionManager: ObservableObject {
         await hydrateAgents()
         await hydrateSessions()
 
-        guard let url = URL(string: "ws://localhost:7837/api/v1/sessions/stream") else { return }
+        guard let url = URL(string: "\(DaemonEndpoint.wsBase)/api/v1/sessions/stream") else { return }
         let task = URLSession.shared.webSocketTask(with: url)
         webSocketTask = task
         task.resume()
@@ -418,7 +418,7 @@ class SessionManager: ObservableObject {
     /// If a future change ships hot-loadable adapters, add a refresh hook
     /// (or push the registry over the WebSocket).
     private func hydrateAgents() async {
-        guard let url = URL(string: "http://localhost:7837/api/v1/agents") else { return }
+        guard let url = URL(string: "\(DaemonEndpoint.httpBase)/api/v1/agents") else { return }
         do {
             let (data, response) = try await URLSession.shared.data(from: url)
             guard (response as? HTTPURLResponse)?.statusCode == 200 else { return }
@@ -431,7 +431,7 @@ class SessionManager: ObservableObject {
     }
 
     private func hydrateSessions() async {
-        guard let url = URL(string: "http://localhost:7837/api/v1/sessions") else { return }
+        guard let url = URL(string: "\(DaemonEndpoint.httpBase)/api/v1/sessions") else { return }
         do {
             let (data, response) = try await URLSession.shared.data(from: url)
             guard (response as? HTTPURLResponse)?.statusCode == 200 else { return }

--- a/tools/agent-onboarding/internal/viewer/web/.gitignore
+++ b/tools/agent-onboarding/internal/viewer/web/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tools/build-dev.sh
+++ b/tools/build-dev.sh
@@ -52,4 +52,7 @@ case "${1:-irrlichd}" in
     ;;
 esac
 
-echo "done. Run with: cd core && ./bin/irrlichd --record"
+echo "done."
+echo "Run isolated from the production daemon (separate state dir + port):"
+echo "  IRRLICHT_HOME=\"\$PWD/.build/irrlicht-home\" IRRLICHT_BIND_ADDR=127.0.0.1:7838 \\"
+echo "    core/bin/irrlichd --record"

--- a/tools/run-daemon-smoke.sh
+++ b/tools/run-daemon-smoke.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# run-daemon-smoke.sh — boot a real irrlichd in full isolation and verify the
+# socket protocol end-to-end, without touching the production daemon.
+#
+# Mirrors the Go startup smoke test (core/cmd/irrlichd/daemon_smoke_test.go)
+# for manual / pre-release use. It:
+#   1. builds the dev daemon binary,
+#   2. starts it with HOME + IRRLICHT_HOME pointed at throwaway temp dirs and
+#      IRRLICHT_BIND_ADDR=127.0.0.1:0 (an OS-assigned port) and
+#      IRRLICHT_DEMO_MODE=1 (no file/process watchers),
+#   3. reads the resolved port from IRRLICHT_HOME/irrlichd.addr,
+#   4. GETs /api/v1/agents over TCP and over the unix socket,
+#   5. sends SIGTERM and confirms a clean exit + the addr file is gone.
+#
+# Because HOME and IRRLICHT_HOME are temp dirs, the production install at
+# ~/.local/share/irrlicht/ and the user's ~/.claude config are never touched —
+# run this while the production daemon/app keeps running.
+#
+# Usage: tools/run-daemon-smoke.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+WORK="$(mktemp -d)"
+HOME_DIR="$WORK/home"
+STATE_DIR="$WORK/state"
+mkdir -p "$HOME_DIR" "$STATE_DIR"
+
+BIN="$WORK/irrlichd"
+DAEMON_PID=""
+
+cleanup() {
+  if [[ -n "$DAEMON_PID" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+  fi
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  if [[ -f "$HOME_DIR/Library/Application Support/Irrlicht/logs/events.log" ]]; then
+    echo "--- daemon events.log ---" >&2
+    cat "$HOME_DIR/Library/Application Support/Irrlicht/logs/events.log" >&2
+  fi
+  exit 1
+}
+
+echo "building dev daemon…"
+( cd "$ROOT_DIR/core" && go build -o "$BIN" ./cmd/irrlichd )
+
+echo "starting isolated daemon…"
+HOME="$HOME_DIR" \
+IRRLICHT_HOME="$STATE_DIR" \
+IRRLICHT_BIND_ADDR=127.0.0.1:0 \
+IRRLICHT_DEMO_MODE=1 \
+  "$BIN" >"$WORK/daemon.out" 2>&1 &
+DAEMON_PID=$!
+
+# Wait for the addr file (resolved host:port), up to 5s.
+ADDR_FILE="$STATE_DIR/irrlichd.addr"
+ADDR=""
+for _ in $(seq 1 250); do
+  if [[ -s "$ADDR_FILE" ]]; then
+    ADDR="$(tr -d '[:space:]' < "$ADDR_FILE")"
+    break
+  fi
+  if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+    fail "daemon exited before writing $ADDR_FILE"
+  fi
+  sleep 0.02
+done
+[[ -n "$ADDR" ]] || fail "daemon never wrote $ADDR_FILE within 5s"
+echo "daemon listening on $ADDR"
+
+# 1. TCP round-trip.
+echo -n "GET /api/v1/agents over TCP… "
+TCP_BODY="$(curl -fsS "http://$ADDR/api/v1/agents")" || fail "TCP request failed"
+echo "$TCP_BODY" | grep -q '"name"' || fail "TCP response has no agents: $TCP_BODY"
+echo "ok"
+
+# 2. Unix socket round-trip.
+echo -n "GET /api/v1/agents over unix socket… "
+SOCK="$STATE_DIR/irrlichd.sock"
+UNIX_BODY="$(curl -fsS --unix-socket "$SOCK" "http://unix/api/v1/agents")" || fail "unix socket request failed"
+echo "$UNIX_BODY" | grep -q '"name"' || fail "unix response has no agents: $UNIX_BODY"
+echo "ok"
+
+# 3. Clean shutdown on SIGTERM.
+echo -n "SIGTERM clean shutdown… "
+kill -TERM "$DAEMON_PID"
+for _ in $(seq 1 150); do
+  kill -0 "$DAEMON_PID" 2>/dev/null || break
+  sleep 0.02
+done
+if kill -0 "$DAEMON_PID" 2>/dev/null; then
+  fail "daemon did not exit within 3s of SIGTERM"
+fi
+DAEMON_PID=""
+[[ ! -e "$ADDR_FILE" ]] || fail "addr file $ADDR_FILE should be removed after shutdown"
+echo "ok"
+
+echo "PASS: daemon startup smoke clean"


### PR DESCRIPTION
Closes #443.

Makes every test/dev path run as an **isolated irrlicht instance** so the production daemon (port 7837, `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/`, Irrlicht.app) keeps running **untouched** the whole time.

## What landed

### 1. `IRRLICHT_HOME` — isolated state (`feat(daemon)` + `fix(daemon)`)
`dataDir()` honors `IRRLICHT_HOME` for the `~/.local/share/irrlicht` tree (socket, addr, history, recordings, web fallback). **Crucially**, the session store (`instances/`), per-session ledgers (`sessions/`), and cost store (`cost/`) live under *different* roots and resolve from `os.UserHomeDir()` — so `stateStoreDir()` routes those through `IRRLICHT_HOME` too (via `NewWithDir`/`NewCostTrackerWithDir`/`metrics.SetLedgerDir`). Without this, a dev daemon (which keeps the real `HOME`) would prune/mutate production session+cost data. Default behavior unchanged; `IRRLICHT_RECORDINGS_DIR` still wins for recordings. Unit-tested (`TestDataDir`, `TestStateStoreDir`).

### 2. Web vitest in the discipline + CI (`docs(test)`)
AGENTS.md Testing lists both vitest suites (`platforms/web`, `tools/agent-onboarding/internal/viewer/web`) and the smoke note. `web-test.yml` now matrixes **both** trees — the viewer suite was previously uncovered. Added the missing `.gitignore` for the viewer tree.

> ⚠️ The matrix renames the GitHub check from `test` → `test (platforms/web)` / `test (…viewer/web)`. If branch protection on `main` requires a check literally named `test`, update the required-check name.

### 3. Headless daemon startup smoke (`test(daemon)`)
Daemon publishes its resolved port to `<IRRLICHT_HOME>/irrlichd.addr` (logs the real port; atomic temp+rename write), removed on shutdown. `daemon_smoke_test.go` spawns a real `irrlichd` — hermetic + parallel-safe (temp `HOME`+`IRRLICHT_HOME`, ephemeral port `:0`, demo mode) — and round-trips `GET /api/v1/agents` over **TCP and the unix socket** plus a clean SIGTERM. A single reaper goroutine owns `Wait()` (no double-Wait race under `-race`); the shutdown timeout exceeds the daemon's 5s drain budget. Runs under `go test ./core/...` in ~0.6s. `tools/run-daemon-smoke.sh` mirrors it.

### 4. Dev/prod coexistence for `/ir:test-mac` (`feat(macos)` + `fix(macos)` + `fix(skill)`)
New `DaemonEndpoint` reads `IRRLICHT_DAEMON_PORT` (default 7837, whitespace-trimmed + validated so a malformed value can't silently re-enable the production-killing `pkill`); both Swift managers use it. On a custom port `DaemonManager` skips its global `pkill` and binds the spawned daemon to that port. `/ir:test-mac` runs the dev daemon on **7838 + worktree-local `IRRLICHT_HOME`** (passed to the app via `open --env` so an app-spawned daemon stays isolated too), reaps prior dev daemons by binary path without touching production, and uses one stable `$IRRLICHTD_BIN` for build+launch. `build-dev.sh` run-hint updated.

## Review-driven hardening
This PR was self-reviewed (`/code-review`, extra-high recall); the second set of commits fixes everything confirmed:
- **Severe:** `IRRLICHT_HOME` now isolates session/ledger/cost stores (was `dataDir`-only) — a dev daemon no longer prunes production session data.
- Robust `IRRLICHT_DAEMON_PORT` parsing (whitespace → was a silent 7837 fallback that re-enabled `pkill`).
- `/ir:test-mac` build/launch path agreement in worktrees; reliable stale-dev-daemon reaping; `open --env IRRLICHT_HOME`.
- Smoke-test double-`Wait()` race removed; idle conns closed; timeout > daemon drain budget.
- `socketPath` honors the override on home-lookup failure; atomic addr write; mDNS advertises the resolved port.

## Testing
- `go build ./core/...` + `go test ./core/... -race -count=1` — green except the **pre-existing** `TestFixtureReplayByteIdentity` (missing replay goldens — #421/#442/#440), confirmed identical on a clean baseline.
- Smoke test stable 3× under `-race`; `tools/run-daemon-smoke.sh` green end-to-end.
- Both vitest suites green (23 + 7); `swift build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)