### PR TITLE
feat(claudecode): track Bash background processes so the session stays working (#445)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/background_process_test.go
+++ b/core/adapters/inbound/agents/claudecode/background_process_test.go
@@ -1,0 +1,212 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/pkg/tailer"
+)
+
+// --- Parser-level: Bash run_in_background signal extraction (issue #445) ---
+
+// bashToolUse builds an assistant event carrying one Bash-family tool_use.
+func bashToolUse(id, name string, input map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type": "assistant",
+		"message": map[string]interface{}{
+			"stop_reason": "tool_use",
+			"content": []interface{}{
+				map[string]interface{}{"type": "tool_use", "id": id, "name": name, "input": input},
+			},
+		},
+	}
+}
+
+// toolResult builds a user event carrying one tool_result with string content.
+func toolResult(toolUseID, content string) map[string]interface{} {
+	return map[string]interface{}{
+		"type": "user",
+		"message": map[string]interface{}{
+			"content": []interface{}{
+				map[string]interface{}{"type": "tool_result", "tool_use_id": toolUseID, "content": content},
+			},
+		},
+	}
+}
+
+// bgSpawnResult builds the user event Claude Code writes for a Bash
+// run_in_background launch: a tool_result with the launch text plus the
+// authoritative top-level toolUseResult.backgroundTaskId that gates spawn
+// detection.
+func bgSpawnResult(toolUseID, bashID, content string) map[string]interface{} {
+	ev := toolResult(toolUseID, content)
+	ev["toolUseResult"] = map[string]interface{}{"backgroundTaskId": bashID}
+	return ev
+}
+
+func TestParser_BackgroundSpawn_FromResultText(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(bgSpawnResult("toolu_1", "bc1h56v8v",
+		"Command running in background with ID: bc1h56v8v. Output is being written to: /private/tmp/claude-501/x/tasks/bc1h56v8v.output"))
+	if len(ev.BackgroundSpawns) != 1 {
+		t.Fatalf("BackgroundSpawns = %d, want 1", len(ev.BackgroundSpawns))
+	}
+	sp := ev.BackgroundSpawns[0]
+	if sp.BashID != "bc1h56v8v" {
+		t.Errorf("BashID = %q, want bc1h56v8v", sp.BashID)
+	}
+	if sp.OutputPath != "/private/tmp/claude-501/x/tasks/bc1h56v8v.output" {
+		t.Errorf("OutputPath = %q", sp.OutputPath)
+	}
+}
+
+func TestParser_NoPhantomSpawnFromArbitraryText(t *testing.T) {
+	p := &Parser{}
+	// The same launch phrase, but with NO structured toolUseResult.backgroundTaskId
+	// (e.g. a Read/Grep over a log that echoes it). Must not fabricate a process.
+	ev := p.ParseLine(toolResult("toolu_x",
+		"Command running in background with ID: bc1h56v8v. Output is being written to: /tmp/x/tasks/bc1h56v8v.output"))
+	if len(ev.BackgroundSpawns) != 0 {
+		t.Errorf("phantom spawn from un-gated text: %+v", ev.BackgroundSpawns)
+	}
+}
+
+func TestParser_BashOutputPoll_AndTerminatedStatus(t *testing.T) {
+	p := &Parser{}
+
+	poll := p.ParseLine(bashToolUse("toolu_poll", "BashOutput", map[string]interface{}{"bash_id": "bc1h56v8v"}))
+	if len(poll.BashOutputPolls) != 1 || poll.BashOutputPolls[0].BashID != "bc1h56v8v" ||
+		poll.BashOutputPolls[0].ToolUseID != "toolu_poll" {
+		t.Fatalf("BashOutputPolls = %+v, want one {toolu_poll, bc1h56v8v}", poll.BashOutputPolls)
+	}
+
+	// running → not terminated
+	running := p.ParseLine(toolResult("toolu_poll", "<status>running</status>\npartial output"))
+	if len(running.TerminatedBashOutputIDs) != 0 {
+		t.Errorf("running status should not be terminated, got %v", running.TerminatedBashOutputIDs)
+	}
+
+	// completed → terminated, attributed to the poll's tool_use id
+	done := p.ParseLine(toolResult("toolu_poll", "<status>completed</status>\nfinal output"))
+	if len(done.TerminatedBashOutputIDs) != 1 || done.TerminatedBashOutputIDs[0] != "toolu_poll" {
+		t.Errorf("TerminatedBashOutputIDs = %v, want [toolu_poll]", done.TerminatedBashOutputIDs)
+	}
+}
+
+func TestParser_KillShell(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(bashToolUse("toolu_kill", "KillShell", map[string]interface{}{"shell_id": "bc1h56v8v"}))
+	if len(ev.KilledShellIDs) != 1 || ev.KilledShellIDs[0] != "bc1h56v8v" {
+		t.Fatalf("KilledShellIDs = %v, want [bc1h56v8v]", ev.KilledShellIDs)
+	}
+}
+
+// --- Parser + tailer end-to-end: open-background-process accounting ---
+
+func writeBgTranscript(t *testing.T, lines []map[string]interface{}) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create transcript: %v", err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, ln := range lines {
+		if err := enc.Encode(ln); err != nil {
+			t.Fatalf("encode line: %v", err)
+		}
+	}
+	return path
+}
+
+func TestTailer_BackgroundProcessCount_SpawnAndTerminate(t *testing.T) {
+	spawnResult := "Command running in background with ID: bc1h56v8v. Output is being written to: /tmp/x/tasks/bc1h56v8v.output"
+
+	t.Run("alive while only spawned", func(t *testing.T) {
+		path := writeBgTranscript(t, []map[string]interface{}{
+			bashToolUse("toolu_1", "Bash", map[string]interface{}{"command": "sleep 100", "run_in_background": true}),
+			bgSpawnResult("toolu_1", "bc1h56v8v", spawnResult),
+		})
+		tl := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+		m, err := tl.TailAndProcess()
+		if err != nil {
+			t.Fatalf("TailAndProcess: %v", err)
+		}
+		if m.BackgroundProcessCount != 1 {
+			t.Fatalf("BackgroundProcessCount = %d, want 1", m.BackgroundProcessCount)
+		}
+		if len(m.BackgroundProcessOutputs) != 1 || m.BackgroundProcessOutputs[0] != "/tmp/x/tasks/bc1h56v8v.output" {
+			t.Errorf("BackgroundProcessOutputs = %v", m.BackgroundProcessOutputs)
+		}
+	})
+
+	t.Run("cleared after observed termination", func(t *testing.T) {
+		path := writeBgTranscript(t, []map[string]interface{}{
+			bashToolUse("toolu_1", "Bash", map[string]interface{}{"command": "sleep 100", "run_in_background": true}),
+			bgSpawnResult("toolu_1", "bc1h56v8v", spawnResult),
+			bashToolUse("toolu_poll", "BashOutput", map[string]interface{}{"bash_id": "bc1h56v8v"}),
+			toolResult("toolu_poll", "<status>completed</status>\nfinal output"),
+		})
+		tl := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+		m, err := tl.TailAndProcess()
+		if err != nil {
+			t.Fatalf("TailAndProcess: %v", err)
+		}
+		if m.BackgroundProcessCount != 0 {
+			t.Fatalf("BackgroundProcessCount = %d, want 0 after termination", m.BackgroundProcessCount)
+		}
+		if len(m.BackgroundProcessOutputs) != 0 {
+			t.Errorf("BackgroundProcessOutputs = %v, want empty", m.BackgroundProcessOutputs)
+		}
+	})
+
+	t.Run("open set survives a ledger round-trip (daemon restart)", func(t *testing.T) {
+		path := writeBgTranscript(t, []map[string]interface{}{
+			bashToolUse("toolu_1", "Bash", map[string]interface{}{"command": "sleep 100", "run_in_background": true}),
+			bgSpawnResult("toolu_1", "bc1h56v8v", spawnResult),
+		})
+		tl1 := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+		if _, err := tl1.TailAndProcess(); err != nil {
+			t.Fatalf("first pass: %v", err)
+		}
+		ledger := tl1.GetLedgerState()
+		if len(ledger.BackgroundProcs) != 1 {
+			t.Fatalf("ledger BackgroundProcs = %v, want one entry", ledger.BackgroundProcs)
+		}
+
+		// Restart: a fresh tailer rehydrated from the ledger reports the open
+		// background process even though it reads no new transcript lines.
+		tl2 := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+		tl2.SetLedgerState(ledger)
+		m, err := tl2.TailAndProcess()
+		if err != nil {
+			t.Fatalf("post-restart pass: %v", err)
+		}
+		if m.BackgroundProcessCount != 1 {
+			t.Errorf("BackgroundProcessCount after restart = %d, want 1", m.BackgroundProcessCount)
+		}
+		if len(m.BackgroundProcessOutputs) != 1 {
+			t.Errorf("BackgroundProcessOutputs after restart = %v, want one path", m.BackgroundProcessOutputs)
+		}
+	})
+
+	t.Run("cleared after KillShell", func(t *testing.T) {
+		path := writeBgTranscript(t, []map[string]interface{}{
+			bashToolUse("toolu_1", "Bash", map[string]interface{}{"command": "sleep 100", "run_in_background": true}),
+			bgSpawnResult("toolu_1", "bc1h56v8v", spawnResult),
+			bashToolUse("toolu_kill", "KillShell", map[string]interface{}{"shell_id": "bc1h56v8v"}),
+		})
+		tl := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+		m, err := tl.TailAndProcess()
+		if err != nil {
+			t.Fatalf("TailAndProcess: %v", err)
+		}
+		if m.BackgroundProcessCount != 0 {
+			t.Fatalf("BackgroundProcessCount = %d, want 0 after KillShell", m.BackgroundProcessCount)
+		}
+	})
+}

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -1,6 +1,7 @@
 package claudecode
 
 import (
+	"regexp"
 	"strings"
 
 	"irrlicht/core/pkg/tailer"
@@ -10,6 +11,17 @@ import (
 // eventTypeAssistantStreaming is emitted for intermediate Claude Code assistant
 // messages (thinking blocks, partial text) that should not trigger IsAgentDone().
 const eventTypeAssistantStreaming = "assistant_streaming"
+
+// backgroundSpawnRe matches the text Claude Code writes in a `Bash`
+// tool_result when the command was launched with `run_in_background: true`:
+//
+//	Command running in background with ID: bc1h56v8v. Output is being written to: /private/tmp/.../tasks/bc1h56v8v.output
+//
+// Group 1 is the background id; group 2 is the output-file path. The
+// background id and output path are read from the *result* because the Bash
+// tool_use input carries only the run_in_background flag — the id is assigned
+// at launch and reported back here. See issue #445.
+var backgroundSpawnRe = regexp.MustCompile(`running in background with ID: (\S+?)\.\s+Output is being written to:\s+(\S+)`)
 
 // Parser implements tailer.TranscriptParser for Claude Code transcripts.
 // Claude Code events use top-level "type" fields ("user", "assistant", "system")
@@ -314,6 +326,13 @@ func scanMessageContent(raw map[string]interface{}, ev *tailer.ParsedEvent) stri
 	if !ok {
 		return ""
 	}
+	// Claude Code's authoritative marker that this tool_result is a Bash
+	// run_in_background launch: a sibling `toolUseResult.backgroundTaskId`.
+	// Gating spawn detection on this (rather than regexing arbitrary result
+	// prose) prevents a foreground tool that merely echoes "running in
+	// background with ID: …" from creating a phantom background process.
+	// See issue #445.
+	bgTaskID := backgroundTaskIDOf(raw)
 	var askUserQuestion string
 	for _, item := range contentArr {
 		block, ok := item.(map[string]interface{})
@@ -326,7 +345,7 @@ func scanMessageContent(raw map[string]interface{}, ev *tailer.ParsedEvent) stri
 				askUserQuestion = q
 			}
 		case "tool_result":
-			collectToolResult(block, ev)
+			collectToolResult(block, ev, bgTaskID)
 		}
 	}
 	return askUserQuestion
@@ -372,18 +391,123 @@ func collectToolUse(block map[string]interface{}, ev *tailer.ParsedEvent) string
 				}
 			}
 		}
+	case "BashOutput":
+		// The agent is polling a background process by id; remember the
+		// pairing so a terminated status on the matching tool_result can be
+		// attributed to the right background process. See issue #445.
+		if bashID := backgroundID(input); bashID != "" && id != "" {
+			ev.BashOutputPolls = append(ev.BashOutputPolls, tailer.BashOutputPoll{
+				ToolUseID: id,
+				BashID:    bashID,
+			})
+		}
+	case "KillShell":
+		// Explicit, single-event termination of a background process.
+		if bashID := backgroundID(input); bashID != "" {
+			ev.KilledShellIDs = append(ev.KilledShellIDs, bashID)
+		}
 	}
 	return ""
 }
 
-// collectToolResult records a tool_result's matching id and the is_error flag.
-func collectToolResult(block map[string]interface{}, ev *tailer.ParsedEvent) {
-	if toolUseID, ok := block["tool_use_id"].(string); ok && toolUseID != "" {
+// backgroundID reads the background-process id from a BashOutput / KillShell
+// tool input. Claude Code names the field `bash_id` on BashOutput and
+// `shell_id` on KillShell; accept either so one helper covers both.
+func backgroundID(input map[string]interface{}) string {
+	if v, _ := input["bash_id"].(string); v != "" {
+		return v
+	}
+	if v, _ := input["shell_id"].(string); v != "" {
+		return v
+	}
+	return ""
+}
+
+// collectToolResult records a tool_result's matching id and the is_error flag,
+// and mines the result text for background-process signals: a Bash
+// run_in_background launch (spawn) and a BashOutput poll reporting a
+// terminated status. bgTaskID is the event's structured
+// `toolUseResult.backgroundTaskId` ("" when absent) — a spawn is recorded only
+// when it is present, so arbitrary tool output echoing the launch phrase can't
+// fabricate a background process. See issue #445.
+func collectToolResult(block map[string]interface{}, ev *tailer.ParsedEvent, bgTaskID string) {
+	toolUseID, _ := block["tool_use_id"].(string)
+	if toolUseID != "" {
 		ev.ToolResultIDs = append(ev.ToolResultIDs, toolUseID)
 	}
 	if isErr, ok := block["is_error"].(bool); ok && isErr {
 		ev.IsError = true
 	}
+
+	text := toolResultText(block)
+	if text == "" {
+		return
+	}
+	// A real Bash run_in_background launch (gated on the structured
+	// backgroundTaskId). The output path comes from the result text; we record
+	// the spawn only when both the id and a path are known, so the
+	// transcript-derived count never includes a process the daemon can't probe.
+	if bgTaskID != "" {
+		if m := backgroundSpawnRe.FindStringSubmatch(text); m != nil {
+			ev.BackgroundSpawns = append(ev.BackgroundSpawns, tailer.BackgroundSpawn{
+				BashID:     bgTaskID,
+				OutputPath: m[2],
+			})
+		}
+	}
+	// A BashOutput poll reports the process status. Any status other than
+	// "running" (e.g. completed / killed / failed) means the background
+	// process has terminated; the tailer attributes it to the polled id (and
+	// acts only when that id is a tracked poll, so a stray <status> elsewhere
+	// is a no-op).
+	if toolUseID != "" && backgroundStatusTerminated(text) {
+		ev.TerminatedBashOutputIDs = append(ev.TerminatedBashOutputIDs, toolUseID)
+	}
+}
+
+// backgroundTaskIDOf returns the structured `toolUseResult.backgroundTaskId`
+// from a Claude Code event, or "" when absent. This top-level field (sibling
+// to `message`) is Claude Code's authoritative marker that a Bash tool_result
+// was a run_in_background launch. See issue #445.
+func backgroundTaskIDOf(raw map[string]interface{}) string {
+	tur, ok := raw["toolUseResult"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	id, _ := tur["backgroundTaskId"].(string)
+	return id
+}
+
+// toolResultText flattens a tool_result's content into plain text. Claude Code
+// writes the content either as a bare string or as an array of
+// {type:"text", text:…} blocks.
+func toolResultText(block map[string]interface{}) string {
+	switch c := block["content"].(type) {
+	case string:
+		return c
+	case []interface{}:
+		var parts []string
+		for _, item := range c {
+			if b, ok := item.(map[string]interface{}); ok {
+				if t, _ := b["text"].(string); t != "" {
+					parts = append(parts, t)
+				}
+			}
+		}
+		return strings.Join(parts, "\n")
+	}
+	return ""
+}
+
+// backgroundStatusTerminated reports whether a BashOutput tool_result's text
+// indicates the background process is no longer running. Claude Code surfaces
+// the process state in a `<status>…</status>` field; only "running" means
+// alive, so any other present value is treated as terminated. Matching on
+// "not running" rather than a specific terminal word keeps this robust to the
+// exact wording (completed / killed / failed). See issue #445.
+func backgroundStatusTerminated(text string) bool {
+	status := strings.ToLower(strings.TrimSpace(extractXMLField(text, "status")))
+	return status != "" && status != "running"
 }
 
 // applyAssistantText fills AssistantText for assistant/streaming events,

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -136,6 +136,8 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 		HasOpenToolCall:                   m.HasOpenToolCall,
 		OpenToolCallCount:                 m.OpenToolCallCount,
 		OpenSubagents:                     a.countOpenSubagents(adapter, m),
+		BackgroundProcessCount:            m.BackgroundProcessCount,
+		BackgroundProcessOutputs:          m.BackgroundProcessOutputs,
 		LastEventType:                     m.LastEventType,
 		LastOpenToolNames:                 m.LastOpenToolNames,
 		LastWasUserInterrupt:              m.LastWasUserInterrupt,

--- a/core/application/services/background_probe.go
+++ b/core/application/services/background_probe.go
@@ -1,0 +1,60 @@
+package services
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// backgroundProbe answers "does any of these output files still have a live
+// writer?" — the daemon's authoritative liveness check for Claude Code Bash
+// background processes (run_in_background). Claude Code reports a background
+// process's exit only on demand (when the agent polls via BashOutput), so the
+// transcript alone can't tell us when one dies; this probe walks the live
+// process state instead. Modeled as a field so tests can inject a fake.
+// See issue #445.
+type backgroundProbe func(outputPaths []string) bool
+
+// anyLiveOutputWriter reports whether any of the given background output files
+// is currently held open by a live process. Each backgrounded command's
+// stdout/stderr is redirected to its tasks/<bash_id>.output file, so the file
+// is held open exactly as long as the process (or its shell) is alive — `lsof`
+// listing a holder means the process is still running, an empty result means
+// it has exited. The output paths are unique per session, so any holder is the
+// session's own background process.
+//
+// A single `lsof -t -- path…` over all paths returns the union of holder PIDs
+// on stdout; if any PID is printed, at least one background process is alive.
+//
+// Crucially we read STDOUT regardless of lsof's exit code. lsof exits 1 when
+// ANY named path has no open holder (a background process that already exited
+// but whose .output file remains, or a stale/deleted path) — yet it still
+// prints the holder PIDs of the OTHER paths to stdout. Branching on the error
+// would discard those PIDs and wrongly report a still-running process as dead,
+// flipping the session to `ready` while it's alive (issue #445 review). lsof's
+// diagnostics and usage text go to stderr (dropped by .Output()), and `-t`
+// prints only PIDs to stdout, so we additionally require an all-digit line to
+// guard against any unexpected stdout noise. A timeout or a missing lsof yields
+// empty stdout → "no live writer", which is the safe ("don't pin forever")
+// degradation.
+func anyLiveOutputWriter(outputPaths []string) bool {
+	if len(outputPaths) == 0 {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	args := append([]string{"-t", "--"}, outputPaths...)
+	out, _ := exec.CommandContext(ctx, "lsof", args...).Output() //nolint:errcheck — exit 1 (some path unheld) still carries live PIDs on stdout
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if _, err := strconv.Atoi(line); err == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/core/application/services/background_probe_internal_test.go
+++ b/core/application/services/background_probe_internal_test.go
@@ -1,0 +1,65 @@
+package services
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// anyLiveOutputWriter must report a real background process as alive while it
+// holds its output file open and dead once it exits — the production liveness
+// signal for Bash run_in_background. Exercises the lsof path end-to-end with a
+// real child process. See issue #445.
+func TestAnyLiveOutputWriter_RealProcess(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available")
+	}
+	out := filepath.Join(t.TempDir(), "bc1h56v8v.output")
+
+	// `exec sleep` so the shell's child (sleep) directly holds `out` open for
+	// writing; the parent test process never opens it, so the only holder is
+	// the background process — exactly the run_in_background shape.
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("exec sleep 30 > %q", out))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start background process: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	// Give the shell a moment to open the file before probing.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !anyLiveOutputWriter([]string{out}) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !anyLiveOutputWriter([]string{out}) {
+		t.Fatalf("probe reported no live writer while background process is running")
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill background process: %v", err)
+	}
+	_, _ = cmd.Process.Wait()
+
+	// After exit the fd is closed; the probe should report dead.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && anyLiveOutputWriter([]string{out}) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if anyLiveOutputWriter([]string{out}) {
+		t.Fatalf("probe still reports a live writer after the background process exited")
+	}
+}
+
+func TestAnyLiveOutputWriter_EmptyAndMissing(t *testing.T) {
+	if anyLiveOutputWriter(nil) {
+		t.Error("nil paths should report no live writer")
+	}
+	missing := filepath.Join(t.TempDir(), "does-not-exist.output")
+	if anyLiveOutputWriter([]string{missing}) {
+		t.Error("a non-existent output file should report no live writer")
+	}
+}

--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -1,0 +1,130 @@
+package services_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+)
+
+// readyTransitions counts recorded working/waiting→ready transitions for sid.
+// Asserting on the thread-safe recorder (rather than reading the repo's shared
+// SessionState pointer) avoids racing with the off-loop liveness probe, which
+// nudges processActivity to mutate state concurrently.
+func readyTransitions(rec *mockRecorder, sid string) int {
+	n := 0
+	for _, ev := range rec.snapshot() {
+		if ev.Kind == lifecycle.KindStateTransition && ev.SessionID == sid && ev.NewState == session.StateReady {
+			n++
+		}
+	}
+	return n
+}
+
+// waitForReadyTransition polls the recorder until a →ready transition for sid
+// is observed, or fails at the deadline.
+func waitForReadyTransition(t *testing.T, rec *mockRecorder, sid string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if readyTransitions(rec, sid) > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("session %s: no →ready transition recorded within deadline", sid)
+}
+
+// ClassifyState must hold a session `working` when the liveness probe has
+// confirmed a background process is still alive, even though the turn ended.
+// See issue #445.
+func TestClassifyState_HeldByLiveBackgroundProcess(t *testing.T) {
+	live := &session.SessionMetrics{LastEventType: "turn_done", HasLiveBackgroundProcess: true}
+	if got, _ := services.ClassifyState(session.StateWorking, live); got != session.StateWorking {
+		t.Errorf("with live background process: got %q, want working", got)
+	}
+	dead := &session.SessionMetrics{LastEventType: "turn_done", HasLiveBackgroundProcess: false}
+	if got, _ := services.ClassifyState(session.StateWorking, dead); got != session.StateReady {
+		t.Errorf("with no live background process: got %q, want ready", got)
+	}
+}
+
+// End-to-end through the detector: a working session whose transcript shows an
+// open background process stays working while the probe reports it alive, and
+// flips to ready once the probe reports it gone — the path the 5s
+// refreshStaleSessions ticker exercises in production. See issue #445.
+func TestSessionDetector_BackgroundProcess_HoldsWorkingThenReady(t *testing.T) {
+	const sid = "bg1"
+	const path = "/home/.claude/projects/-Users-test/bg1.jsonl"
+
+	// Metrics always show a finished turn with one open background process.
+	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		return &session.SessionMetrics{
+			LastEventType:            "turn_done",
+			BackgroundProcessCount:   1,
+			BackgroundProcessOutputs: []string{"/tmp/x/tasks/bc1h56v8v.output"},
+		}, nil
+	}}
+
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	repo.states[sid] = &session.SessionState{
+		SessionID:      sid,
+		State:          session.StateWorking,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	rec := &mockRecorder{}
+	det.SetRecorder(rec)
+
+	// probeLive is read from the probe goroutine, so guard it with atomic.
+	var probeLive atomic.Bool
+	probeLive.Store(true)
+	det.SetBackgroundProbeForTest(func(paths []string) bool {
+		return probeLive.Load()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	// activity drives one re-evaluation. The first event for a session fires
+	// processActivity immediately; later events within the 2s debounce window
+	// coalesce, so we mark the follow-up Terminal to short-circuit the
+	// debounce (production's periodic re-probe bypasses debounce the same way
+	// via processActivityWithoutIdentity).
+	activity := func(terminal bool) {
+		tw.ch <- agent.Event{
+			Type:           agent.EventActivity,
+			SessionID:      sid,
+			ProjectDir:     "-Users-test",
+			TranscriptPath: path,
+			Terminal:       terminal,
+		}
+	}
+
+	// Probe reports the process alive → session stays working: no →ready
+	// transition should be recorded even though the turn ended (turn_done).
+	activity(false)
+	time.Sleep(250 * time.Millisecond) // allow the async probe + any self-trigger to settle
+	if n := readyTransitions(rec, sid); n != 0 {
+		t.Fatalf("session flipped to ready %d time(s) while background process is alive", n)
+	}
+
+	// Background process exits — probe now reports it gone → session goes ready.
+	probeLive.Store(false)
+	activity(true)
+	waitForReadyTransition(t, rec, sid)
+
+	cancel()
+	<-done
+}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -123,6 +123,21 @@ type SessionDetector struct {
 	// goroutine), read by processActivity (event-loop goroutine).
 	permMu            sync.Mutex
 	permissionPending map[string]bool // sessionID → true
+
+	// bgLiveProbe answers "does this session still have a live background
+	// process?" from its output-file paths. Defaults to anyLiveOutputWriter
+	// (lsof); tests override it. See issue #445.
+	bgLiveProbe backgroundProbe
+
+	// bgMu guards bgLive / bgProbing. The probe (lsof) runs off the event-loop
+	// goroutine so a slow filesystem can't stall every other session's
+	// processing; processActivity reads the last-known liveness from bgLive
+	// (optimistically alive on first sight) and a completed probe nudges the
+	// event loop to re-classify. bgProbing is the per-session in-flight guard.
+	// See issue #445.
+	bgMu      sync.Mutex
+	bgLive    map[string]bool
+	bgProbing map[string]bool
 }
 
 // NewSessionDetector creates a SessionDetector with all required
@@ -165,6 +180,9 @@ func NewSessionDetector(
 		debouncedEvents:   make(chan agent.Event, 64),
 		deletedCooldown:   10 * time.Second,
 		permissionPending: make(map[string]bool),
+		bgLiveProbe:       anyLiveOutputWriter,
+		bgLive:            make(map[string]bool),
+		bgProbing:         make(map[string]bool),
 	}
 	det.pidMgr = NewPIDManager(
 		pw, repo, log, broadcaster, readyTTL,
@@ -178,6 +196,13 @@ func NewSessionDetector(
 // Intended for tests that need immediate re-creation.
 func (d *SessionDetector) SetDeletedCooldown(dur time.Duration) {
 	d.deletedCooldown = dur
+}
+
+// SetBackgroundProbeForTest overrides the background-process liveness probe so
+// tests can simulate live / dead background processes without real lsof. See
+// issue #445.
+func (d *SessionDetector) SetBackgroundProbeForTest(p func(outputPaths []string) bool) {
+	d.bgLiveProbe = p
 }
 
 // RunPIDLivenessSweepForTest runs one iteration of the liveness sweep

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -309,6 +309,16 @@ func (d *SessionDetector) processActivity(id agent.Identity, ev agent.Event) {
 	// Refresh CWD/branch/project and metrics from transcript.
 	d.enricher.RefreshOnActivity(state, ev.TranscriptPath)
 
+	// Probe Bash background-process liveness (run_in_background). Must run
+	// after RefreshOnActivity (which recomputes metrics, clearing the flag)
+	// and before ClassifyState (whose IsAgentDone check reads it). Gated on
+	// the transcript-derived count, so only sessions that launched a
+	// background process ever shell out. The 5s refreshStaleSessions ticker
+	// re-runs this path for working sessions, so a process that exits with no
+	// further transcript activity still flips the session ready on re-probe.
+	// See issue #445.
+	d.applyBackgroundLiveness(state)
+
 	// Drain authoritative subagent-completion signals harvested from this
 	// parent's transcript (origin.kind="task-notification" lines parsed by
 	// the Claude Code adapter). This is the event-based path to ready for
@@ -455,6 +465,78 @@ func (d *SessionDetector) processActivity(id agent.Identity, ev agent.Event) {
 	if state.ParentSessionID != "" {
 		d.reevaluateParent(state.ParentSessionID)
 	}
+}
+
+// applyBackgroundLiveness sets HasLiveBackgroundProcess on the session's
+// metrics from the last-known liveness of its Bash background processes
+// (run_in_background), and kicks off an off-loop refresh of that knowledge.
+// When true, IsAgentDone returns false and the classifier holds the session
+// `working` past end_turn until the process exits.
+//
+// Two deliberate choices (issue #445 review):
+//   - Gated on state == working. The feature only ever needs to PREVENT a
+//     working→ready transition; it must never RESURRECT a session the user
+//     already cancelled (ESC → ready) just because a detached process is still
+//     alive. Non-working sessions clear their cache and the flag.
+//   - The lsof probe runs in a goroutine, not inline, so a slow filesystem
+//     can't stall the single event-loop goroutine (and thus every other
+//     session). processActivity uses the last-known value — optimistically
+//     "alive" on first sight so a not-yet-probed process is never prematurely
+//     declared dead — and a completed probe whose verdict changed nudges the
+//     event loop (via debouncedEvents) to re-classify promptly.
+func (d *SessionDetector) applyBackgroundLiveness(state *session.SessionState) {
+	sid := state.SessionID
+	m := state.Metrics
+	if m == nil || state.State != session.StateWorking ||
+		m.BackgroundProcessCount == 0 || len(m.BackgroundProcessOutputs) == 0 || d.bgLiveProbe == nil {
+		d.bgMu.Lock()
+		delete(d.bgLive, sid)
+		delete(d.bgProbing, sid)
+		d.bgMu.Unlock()
+		if m != nil {
+			m.HasLiveBackgroundProcess = false
+		}
+		return
+	}
+
+	d.bgMu.Lock()
+	known, seen := d.bgLive[sid]
+	alive := true // optimistic on first sight — never flip to ready before probing
+	if seen {
+		alive = known
+	}
+	startProbe := !d.bgProbing[sid]
+	if startProbe {
+		d.bgProbing[sid] = true
+	}
+	d.bgMu.Unlock()
+
+	m.HasLiveBackgroundProcess = alive
+	if !startProbe {
+		return
+	}
+
+	outputs := append([]string(nil), m.BackgroundProcessOutputs...) // copy: goroutine must not alias state
+	transcriptPath := state.TranscriptPath
+	go func() {
+		live := d.bgLiveProbe(outputs)
+		d.bgMu.Lock()
+		prev, had := d.bgLive[sid]
+		d.bgLive[sid] = live
+		d.bgProbing[sid] = false
+		d.bgMu.Unlock()
+		// On a changed (or first) verdict, nudge the event loop to re-classify
+		// now rather than waiting for the next refresh tick. The send mirrors
+		// the debounce-timer path (single event-loop goroutine owns
+		// processActivity); drop if the buffer is full — the 5s refresh is the
+		// backstop.
+		if !had || prev != live {
+			select {
+			case d.debouncedEvents <- agent.Event{Type: agent.EventActivity, SessionID: sid, TranscriptPath: transcriptPath}:
+			default:
+			}
+		}
+	}()
 }
 
 // refreshStaleSessions re-reads transcripts for working sessions that haven't

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -15,6 +15,14 @@ func (d *SessionDetector) removeFromProjectSessions(sessionID string) {
 	delete(d.projectSessions, sessionID)
 	d.deletedSessions[sessionID] = time.Now().Unix()
 	d.mu.Unlock()
+	// Drop the background-process liveness cache for the gone session — a
+	// deleted session is never re-observed as non-working, so
+	// applyBackgroundLiveness would otherwise never reclaim these entries
+	// (issue #445).
+	d.bgMu.Lock()
+	delete(d.bgLive, sessionID)
+	delete(d.bgProbing, sessionID)
+	d.bgMu.Unlock()
 	if d.historyTracker != nil {
 		d.historyTracker.Remove(sessionID)
 	}

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -160,6 +160,15 @@ func (d *SessionDetector) seedFromDisk() {
 		}
 		d.enricher.RefreshMetrics(state)
 
+		// Probe background-process liveness before re-classifying so a session
+		// persisted as `working` solely because a Bash run_in_background
+		// process is still alive (its open set rehydrated from the ledger) is
+		// not wrongly demoted to ready on startup. Without this, IsAgentDone
+		// would return true (count alone doesn't gate) and the session would
+		// flip to ready and never re-probe (refreshStaleSessions is
+		// working-only). See issue #445.
+		d.applyBackgroundLiveness(state)
+
 		newState, reason := ClassifyState(state.State, state.Metrics)
 		// Only apply transitions to waiting or ready (not working promotion)
 		// because seed is re-evaluating persisted state, not responding to

--- a/core/domain/session/background_process_test.go
+++ b/core/domain/session/background_process_test.go
@@ -1,0 +1,53 @@
+package session
+
+import "testing"
+
+// IsAgentDone must treat a live background process like an open tool call:
+// the turn's end_turn fired, but the session is not idle. See issue #445.
+func TestIsAgentDone_HeldByLiveBackgroundProcess(t *testing.T) {
+	cases := []struct {
+		name string
+		m    *SessionMetrics
+		want bool
+	}{
+		{
+			name: "turn_done with live background process → not done",
+			m:    &SessionMetrics{LastEventType: "turn_done", HasLiveBackgroundProcess: true},
+			want: false,
+		},
+		{
+			name: "turn_done with no live background process → done",
+			m:    &SessionMetrics{LastEventType: "turn_done", HasLiveBackgroundProcess: false},
+			want: true,
+		},
+		{
+			name: "background count without confirmed liveness does not gate",
+			m:    &SessionMetrics{LastEventType: "turn_done", BackgroundProcessCount: 2, HasLiveBackgroundProcess: false},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.m.IsAgentDone(); got != tc.want {
+				t.Errorf("IsAgentDone() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// MergeMetrics carries the background-process fields from the freshly computed
+// metrics (they are recomputed from the transcript every pass). See issue #445.
+func TestMergeMetrics_BackgroundProcessFields(t *testing.T) {
+	newM := &SessionMetrics{
+		BackgroundProcessCount:   1,
+		BackgroundProcessOutputs: []string{"/tmp/x/tasks/a.output"},
+	}
+	old := &SessionMetrics{BackgroundProcessCount: 0}
+	merged := MergeMetrics(newM, old)
+	if merged.BackgroundProcessCount != 1 {
+		t.Errorf("BackgroundProcessCount = %d, want 1", merged.BackgroundProcessCount)
+	}
+	if len(merged.BackgroundProcessOutputs) != 1 {
+		t.Errorf("BackgroundProcessOutputs = %v, want one path", merged.BackgroundProcessOutputs)
+	}
+}

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -9,7 +9,7 @@ import (
 // State constants — three MECE states for session lifecycle.
 // See STATES.md for the formal state machine specification.
 const (
-	StateWorking = "working" // Agent actively processing (tools, text generation, hooks, compaction)
+	StateWorking = "working" // Agent actively processing (tools, text generation, hooks, compaction, or a live Bash background process)
 	StateWaiting = "waiting" // Agent finished turn, waiting for user input
 	StateReady   = "ready"   // Session inactive (process exited, transcript removed, cancelled)
 

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -53,6 +53,31 @@ type SessionMetrics struct {
 	// domain model is agnostic to how each adapter represents subagents.
 	OpenSubagents int `json:"open_subagents,omitempty"`
 
+	// BackgroundProcessCount is the number of agent-spawned background
+	// processes the transcript shows as still open — for Claude Code, a
+	// `Bash` tool call with `run_in_background: true` that has not yet been
+	// observed terminating (via a `BashOutput` status or a `KillShell`).
+	// Deterministic from the transcript, so it is stable across replay. It
+	// is the agent's *claimed* open count; HasLiveBackgroundProcess is the
+	// daemon's authoritative liveness verdict. See issue #445.
+	BackgroundProcessCount int `json:"background_process_count,omitempty"`
+
+	// HasLiveBackgroundProcess is the daemon's authoritative answer to "does
+	// this session still have a running background process?", set by the
+	// liveness probe in processActivity (lsof on each background process's
+	// output file). It gates IsAgentDone so a session stays `working` past
+	// end_turn while a background process is alive. Transient — set by the
+	// detector, never derived from the transcript, so it is absent under
+	// replay (where there is no live process to probe). See issue #445.
+	HasLiveBackgroundProcess bool `json:"-"`
+
+	// BackgroundProcessOutputs holds the output-file paths of the currently
+	// open background processes (Claude Code writes each backgrounded
+	// command's stdout/stderr to `tasks/<bash_id>.output`). The liveness
+	// probe lsof's these to find a live writer. Transient — recomputed from
+	// the transcript each pass, not persisted in session JSON.
+	BackgroundProcessOutputs []string `json:"-"`
+
 	// LastEventType is the type of the most recent transcript event
 	// (e.g. "assistant", "user", "tool_use", "tool_result").
 	LastEventType string `json:"last_event_type,omitempty"`
@@ -447,6 +472,13 @@ func (m *SessionMetrics) IsAgentDone() bool {
 	if m.HasOpenToolCall {
 		return false
 	}
+	// A live background process (Bash run_in_background) outlives the turn
+	// that spawned it: Claude Code writes end_turn the instant the Bash tool
+	// returns, but the process keeps running. The daemon's liveness probe
+	// confirms it is still alive, so the session is NOT idle. See issue #445.
+	if m.HasLiveBackgroundProcess {
+		return false
+	}
 	// Primary: Claude Code writes a system/turn_duration event at end of turn.
 	if m.LastEventType == "turn_done" {
 		return true
@@ -580,32 +612,39 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 		return newM
 	}
 	merged := &SessionMetrics{
-		ElapsedSeconds:         newM.ElapsedSeconds,
-		TotalTokens:            newM.TotalTokens,
-		ModelName:              newM.ModelName,
-		ContextWindow:          newM.ContextWindow,
-		ContextUtilization:     newM.ContextUtilization,
-		PressureLevel:          newM.PressureLevel,
-		ContextWindowUnknown:   newM.ContextWindowUnknown,
-		HasOpenToolCall:        newM.HasOpenToolCall,
-		OpenToolCallCount:      newM.OpenToolCallCount,
-		OpenSubagents:          newM.OpenSubagents,
-		LastEventType:          newM.LastEventType,
-		LastOpenToolNames:      newM.LastOpenToolNames,
-		LastWasUserInterrupt:   newM.LastWasUserInterrupt,
-		LastWasToolDenial:      newM.LastWasToolDenial,
-		EstimatedCostUSD:       newM.EstimatedCostUSD,
-		LastAssistantText:      newM.LastAssistantText,
-		PermissionMode:         newM.PermissionMode,
-		SubagentCompletions:    newM.SubagentCompletions,
-		CumInputTokens:         newM.CumInputTokens,
-		CumOutputTokens:        newM.CumOutputTokens,
-		CumCacheReadTokens:     newM.CumCacheReadTokens,
-		CumCacheCreationTokens: newM.CumCacheCreationTokens,
-		Tasks:                  newM.Tasks,
-		NoSubstantiveActivity:  newM.NoSubstantiveActivity,
-		RateLimit:              newM.RateLimit,
-		RateLimitForecastEta:   newM.RateLimitForecastEta,
+		ElapsedSeconds:       newM.ElapsedSeconds,
+		TotalTokens:          newM.TotalTokens,
+		ModelName:            newM.ModelName,
+		ContextWindow:        newM.ContextWindow,
+		ContextUtilization:   newM.ContextUtilization,
+		PressureLevel:        newM.PressureLevel,
+		ContextWindowUnknown: newM.ContextWindowUnknown,
+		HasOpenToolCall:      newM.HasOpenToolCall,
+		OpenToolCallCount:    newM.OpenToolCallCount,
+		OpenSubagents:        newM.OpenSubagents,
+		// Background-process fields are recomputed from the transcript every
+		// pass (count + output paths) — copy the new values verbatim.
+		// HasLiveBackgroundProcess is set by the detector's probe *after* this
+		// merge, so newM always carries its zero value here.
+		BackgroundProcessCount:   newM.BackgroundProcessCount,
+		BackgroundProcessOutputs: newM.BackgroundProcessOutputs,
+		HasLiveBackgroundProcess: newM.HasLiveBackgroundProcess,
+		LastEventType:            newM.LastEventType,
+		LastOpenToolNames:        newM.LastOpenToolNames,
+		LastWasUserInterrupt:     newM.LastWasUserInterrupt,
+		LastWasToolDenial:        newM.LastWasToolDenial,
+		EstimatedCostUSD:         newM.EstimatedCostUSD,
+		LastAssistantText:        newM.LastAssistantText,
+		PermissionMode:           newM.PermissionMode,
+		SubagentCompletions:      newM.SubagentCompletions,
+		CumInputTokens:           newM.CumInputTokens,
+		CumOutputTokens:          newM.CumOutputTokens,
+		CumCacheReadTokens:       newM.CumCacheReadTokens,
+		CumCacheCreationTokens:   newM.CumCacheCreationTokens,
+		Tasks:                    newM.Tasks,
+		NoSubstantiveActivity:    newM.NoSubstantiveActivity,
+		RateLimit:                newM.RateLimit,
+		RateLimitForecastEta:     newM.RateLimitForecastEta,
 	}
 	if merged.ContextWindow == 0 && oldM.ContextWindow > 0 {
 		merged.ContextWindow = oldM.ContextWindow

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -68,6 +68,27 @@ type TaskSnapshotEntry struct {
 	Status     string // "pending" | "in_progress" | "completed"
 }
 
+// BackgroundSpawn signals that a `Bash` tool call with `run_in_background:
+// true` reported its background id. Claude Code returns this in the Bash
+// tool_result text ("Command running in background with ID: <id>. Output is
+// being written to: <path>"), so the parser reads it off the result rather
+// than the tool_use input (which carries only the run_in_background flag).
+// The tailer folds these into its open-background-process set. See issue #445.
+type BackgroundSpawn struct {
+	BashID     string // the background shell id (e.g. "bc1h56v8v")
+	OutputPath string // tasks/<bash_id>.output — where stdout/stderr is written
+}
+
+// BashOutputPoll records a `BashOutput` tool_use: the agent polling a
+// background process by id. ToolUseID is the poll call's own id; BashID is
+// the background process it targets. The tailer remembers the pairing so a
+// later tool_result reporting a terminated status (TerminatedBashOutputIDs)
+// can be attributed to the right background process. See issue #445.
+type BashOutputPoll struct {
+	ToolUseID string
+	BashID    string
+}
+
 // ParsedEvent is the normalized output from a format-specific transcript parser.
 // Each parser maps its native event structure into these fields.
 type ParsedEvent struct {
@@ -107,6 +128,25 @@ type ParsedEvent struct {
 	// TaskDeltas are TaskCreate / TaskUpdate events from the Claude Code
 	// transcript. The tailer folds them into a running tasks slice.
 	TaskDeltas []TaskDelta
+
+	// BackgroundSpawns are Bash run_in_background launches observed in this
+	// event (read from the Bash tool_result text). The tailer adds each to
+	// its open-background-process set. See issue #445.
+	BackgroundSpawns []BackgroundSpawn
+
+	// BashOutputPolls are BashOutput tool_use calls in this event, pairing the
+	// poll's tool_use id with the background id it targets. See issue #445.
+	BashOutputPolls []BashOutputPoll
+
+	// TerminatedBashOutputIDs are tool_result ids whose content reports a
+	// terminated background-process status (anything other than "running").
+	// The tailer matches each against a remembered BashOutputPoll to drop the
+	// corresponding background process from its open set. See issue #445.
+	TerminatedBashOutputIDs []string
+
+	// KilledShellIDs are background ids named by a KillShell tool_use in this
+	// event — an explicit, single-event termination signal. See issue #445.
+	KilledShellIDs []string
 
 	// TaskSnapshot, when non-nil, is the authoritative list of tasks Claude
 	// Code is currently tracking, parsed from a task_reminder attachment.
@@ -272,6 +312,15 @@ type LedgerState struct {
 	CumProviderCostUSD float64                    `json:"cum_provider_cost_usd,omitempty"`
 	ParserState        *ParserLedger              `json:"parser_state,omitempty"`
 	Tasks              []Task                     `json:"tasks,omitempty"`
+	// BackgroundProcs persists the open-background-process set (background id
+	// → output path) so a daemon restart keeps holding the session `working`
+	// for processes still alive. See issue #445.
+	BackgroundProcs map[string]string `json:"background_procs,omitempty"`
+	// PendingBashPolls persists in-flight BashOutput polls (poll tool_use id →
+	// background id) so a restart between a poll's tool_use and its terminated
+	// tool_result can still attribute the termination and clear the process.
+	// See issue #445.
+	PendingBashPolls map[string]string `json:"pending_bash_polls,omitempty"`
 	// ModelName is the last observed model for the session. Persisted so that
 	// applyContribution's fallback (used when a contribution event carries no
 	// model — codex token_count) still routes to the right pricing bucket

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"maps"
 	"os"
 	"strconv"
 	"strings"
@@ -75,6 +76,17 @@ type SessionMetrics struct {
 	// running. The tailer leaves this at zero; adapters populate it from
 	// LastOpenToolNames or whatever adapter-specific signal they use.
 	OpenSubagents int `json:"open_subagents,omitempty"`
+
+	// BackgroundProcessCount is the number of agent-spawned background
+	// processes the transcript shows as still open (Bash run_in_background
+	// launches not yet observed terminating). Derived from the
+	// openBackgroundProcs set. See issue #445.
+	BackgroundProcessCount int `json:"background_process_count,omitempty"`
+
+	// BackgroundProcessOutputs holds the output-file paths of those open
+	// background processes, sorted for determinism. The daemon's liveness
+	// probe lsof's them. Not serialized — recomputed each pass. See issue #445.
+	BackgroundProcessOutputs []string `json:"-"`
 
 	// SubagentCompletions surfaces parent-side "subagent done" signals
 	// discovered during the most recent TailAndProcess() pass. Cleared at
@@ -247,6 +259,17 @@ type TranscriptTailer struct {
 	// Invariant: taskSeq == len(tasks) always (tasks are never removed).
 	taskSeq int
 
+	// openBackgroundProcs is the set of agent-spawned background processes
+	// still believed running, keyed by background id with the output-file
+	// path as value. A BackgroundSpawn inserts; a matched terminated
+	// BashOutput poll or a KillShell removes. BackgroundProcessCount and
+	// BackgroundProcessOutputs are derived from it. See issue #445.
+	openBackgroundProcs map[string]string
+	// pendingBashPolls maps a BashOutput poll's tool_use id to the background
+	// id it targets, so a later tool_result reporting a terminated status can
+	// be attributed to the right background process. See issue #445.
+	pendingBashPolls map[string]string
+
 	// lastLineSeenAt is the wall-clock time at which the parser last consumed
 	// a transcript line. Used by idleFlusher-implementing parsers (aider) to
 	// synthesize turn_done when the file has been quiet long enough. Zero
@@ -272,13 +295,15 @@ const rateLimitHistoryCap = 5
 // config fallback.
 func NewTranscriptTailer(path string, parser TranscriptParser, adapter string) *TranscriptTailer {
 	return &TranscriptTailer{
-		path:          path,
-		lastOffset:    0,
-		capacityMgr:   capacity.DefaultCapacityManager(),
-		parser:        parser,
-		adapter:       adapter,
-		openToolCalls: make(map[string]string),
-		cumByModel:    make(map[string]*UsageBreakdown),
+		path:                path,
+		lastOffset:          0,
+		capacityMgr:         capacity.DefaultCapacityManager(),
+		parser:              parser,
+		adapter:             adapter,
+		openToolCalls:       make(map[string]string),
+		openBackgroundProcs: make(map[string]string),
+		pendingBashPolls:    make(map[string]string),
+		cumByModel:          make(map[string]*UsageBreakdown),
 		metrics: &SessionMetrics{
 			MessageHistory: make([]MessageEvent, 0),
 			SessionStartAt: time.Time{},
@@ -308,6 +333,16 @@ func (t *TranscriptTailer) GetLedgerState() LedgerState {
 	}
 	if len(t.tasks) > 0 {
 		s.Tasks = append([]Task(nil), t.tasks...)
+	}
+	if len(t.openBackgroundProcs) > 0 {
+		bp := make(map[string]string, len(t.openBackgroundProcs))
+		maps.Copy(bp, t.openBackgroundProcs)
+		s.BackgroundProcs = bp
+	}
+	if len(t.pendingBashPolls) > 0 {
+		pp := make(map[string]string, len(t.pendingBashPolls))
+		maps.Copy(pp, t.pendingBashPolls)
+		s.PendingBashPolls = pp
 	}
 	return s
 }
@@ -342,6 +377,14 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 	if len(s.Tasks) > 0 {
 		t.tasks = append([]Task(nil), s.Tasks...)
 		t.taskSeq = len(t.tasks)
+	}
+	if len(s.BackgroundProcs) > 0 {
+		t.openBackgroundProcs = make(map[string]string, len(s.BackgroundProcs))
+		maps.Copy(t.openBackgroundProcs, s.BackgroundProcs)
+	}
+	if len(s.PendingBashPolls) > 0 {
+		t.pendingBashPolls = make(map[string]string, len(s.PendingBashPolls))
+		maps.Copy(t.pendingBashPolls, s.PendingBashPolls)
 	}
 }
 
@@ -396,6 +439,11 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 		t.cumProviderCostUSD = 0
 		t.tasks = nil
 		t.taskSeq = 0
+		// Background-process set belongs to the prior file; drop it so a
+		// rotated/truncated transcript doesn't keep a stale session `working`.
+		// See issue #445.
+		t.openBackgroundProcs = make(map[string]string)
+		t.pendingBashPolls = make(map[string]string)
 		// Drop the pre-rotation idle anchor so the post-scan idleFlusher
 		// hook doesn't synthesize a phantom turn_done against stale time.
 		t.lastLineSeenAt = time.Time{}
@@ -727,6 +775,36 @@ func (t *TranscriptTailer) processParsedEvent(parsed *ParsedEvent, sawUserBlocki
 			}
 		}
 	}
+
+	// Background-process tracking (Bash run_in_background). A spawn adds the
+	// background id; a matched terminated BashOutput poll or a KillShell
+	// removes it. The set is the source of truth for BackgroundProcessCount.
+	// See issue #445.
+	for _, sp := range parsed.BackgroundSpawns {
+		if sp.BashID != "" {
+			t.openBackgroundProcs[sp.BashID] = sp.OutputPath
+		}
+	}
+	for _, poll := range parsed.BashOutputPolls {
+		if poll.ToolUseID != "" && poll.BashID != "" {
+			t.pendingBashPolls[poll.ToolUseID] = poll.BashID
+		}
+	}
+	for _, id := range parsed.TerminatedBashOutputIDs {
+		if bashID, ok := t.pendingBashPolls[id]; ok {
+			delete(t.openBackgroundProcs, bashID)
+		}
+	}
+	// A poll is resolved once its tool_result arrives (terminated OR still
+	// running) — drop the pairing either way so pendingBashPolls only ever
+	// holds in-flight polls (bounded by concurrent polls, not total polls).
+	for _, id := range parsed.ToolResultIDs {
+		delete(t.pendingBashPolls, id)
+	}
+	for _, bashID := range parsed.KilledShellIDs {
+		delete(t.openBackgroundProcs, bashID)
+	}
+
 	t.reconcileTaskSnapshot(parsed)
 
 	// turn_done is the authoritative end-of-turn signal. By definition most

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -1,6 +1,7 @@
 package tailer
 
 import (
+	"slices"
 	"strings"
 	"time"
 
@@ -312,6 +313,25 @@ func (t *TranscriptTailer) computeMetrics() {
 		t.metrics.RateLimitHistory = append([]RateLimitSnapshot(nil), t.rateLimitHistory...)
 	} else {
 		t.metrics.RateLimitHistory = nil
+	}
+
+	// Background-process count + output paths share the rate-limit block's
+	// "must run even on an empty pass" property: the open set can be
+	// rehydrated from the ledger after a daemon restart and must surface
+	// before any new transcript line arrives, so a still-running background
+	// process keeps holding the session `working`. See issue #445.
+	t.metrics.BackgroundProcessCount = len(t.openBackgroundProcs)
+	if len(t.openBackgroundProcs) > 0 {
+		outs := make([]string, 0, len(t.openBackgroundProcs))
+		for _, p := range t.openBackgroundProcs {
+			if p != "" {
+				outs = append(outs, p)
+			}
+		}
+		slices.Sort(outs)
+		t.metrics.BackgroundProcessOutputs = outs
+	} else {
+		t.metrics.BackgroundProcessOutputs = nil
 	}
 
 	if len(t.metrics.MessageHistory) == 0 {

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -966,16 +966,27 @@
       }
 
       // Active tool label — shown only when agent is working and inside a tool call.
+      // When no tool is open but the session is held working by a live Bash
+      // background process (run_in_background), surface that instead so the row
+      // explains why it's still working past the turn's end. See issue #445.
       const toolEl = el.querySelector('.row-tool');
       const tools = metrics.last_open_tool_names || [];
+      const bgCount = metrics.background_process_count || 0;
       if (metrics.has_open_tool_call && tools[0] && state === 'working') {
         const raw = tools[0];
         const isUser = raw === 'AskUserQuestion' || raw === 'ExitPlanMode';
         toolEl.style.display = '';
         toolEl.textContent = toolLabel[raw] || raw.slice(0, 12);
         toolEl.className = 'row-tool' + (isUser ? ' tool-user' : '');
+        toolEl.title = '';
+      } else if (bgCount > 0 && state === 'working') {
+        toolEl.style.display = '';
+        toolEl.textContent = '⚙ ' + bgCount + ' bg';
+        toolEl.className = 'row-tool';
+        toolEl.title = bgCount + ' background process' + (bgCount === 1 ? '' : 'es') + ' running';
       } else {
         toolEl.style.display = 'none';
+        toolEl.title = '';
       }
 
       // Per-row history canvas is repainted by repaintHistory() on the

--- a/replaydata/agents/claudecode/capabilities.json
+++ b/replaydata/agents/claudecode/capabilities.json
@@ -27,6 +27,7 @@
     "linting_test_automation": "unknown",
     "edit_strategy_selection": "unknown",
     "context_curation": "unknown",
-    "cost_tracking": true
+    "cost_tracking": true,
+    "background_process": true
   }
 }


### PR DESCRIPTION
Closes #445.

A `Bash` tool call with `run_in_background: true` outlives the turn that spawned it, but irrlicht flipped the session to `ready` at end_turn the instant the Bash tool returned. This makes the session stay `working` until the background process actually exits.

## How it works

- **Parser** (`claudecode`): snapshots each background process from the structured `toolUseResult.backgroundTaskId` (+ its `tasks/<id>.output` path), and drops it on an observed `BashOutput`-terminated status or a `KillShell`. Gating on the structured field (not free-text) avoids phantom processes from tool output that merely echoes the launch phrase.
- **Tailer**: keeps the open-process set (and in-flight `BashOutput` polls), persisted in the ledger so a daemon restart keeps holding `working`. Surfaces as `SessionMetrics.BackgroundProcessCount`.
- **Daemon**: confirms *real* liveness by `lsof`'ing the output files and gates `IsAgentDone` on `HasLiveBackgroundProcess`. The probe runs **off the event-loop goroutine** (cached, optimistic-on-first-sight) so a slow filesystem can't stall other sessions, and re-classifies promptly on a changed verdict. Wired into both the activity path and the daemon-restart seed path; gated to `working` sessions only (never resurrects a cancelled one).
- **Web UI**: shows a `⚙ N bg` badge in the working row.

`lsof` stdout is read regardless of exit code — lsof exits 1 when any named path is unheld while still printing the live PIDs of the others, so branching on the error would wrongly report a running process as dead.

## Testing

- `go test ./core/... -race -count=1` — green (incl. parser/tailer accounting, ledger round-trip across restart, async hold→ready via the recorder, real-`lsof` e2e with a live child process, phantom-spawn prevention, `IsAgentDone`/`ClassifyState` gating).
- `tools/replay-fixtures.sh` + replay golden test — green (existing fixtures unaffected; the new metric is `omitempty` and the liveness flag is `json:"-"`, absent under replay).
- Declared `background_process: true` in `capabilities.json`.

## Known follow-up

The `BashOutput` terminated-status text (`<status>…</status>`) is unconfirmed against a real transcript — the next `ir:onboard-agent` recording of the `background-process` cell should validate it (and flip that cell's `assessment.json` to `irrlicht_observes: yes`). Not blocking: the `lsof` probe is the authoritative liveness signal regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)