### PR TITLE
chore(test-mac): add separate/replace mode selection + Sparkle embed

### DIFF
--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -1,32 +1,59 @@
 ---
 name: ir:test-mac
 description: >
-  Build and run a dev irrlicht daemon + macOS Swift app for local testing,
-  alongside the production Irrlicht.app (which keeps running). The dev instance
-  uses an isolated state dir (IRRLICHT_HOME) and a separate port (7838), so it
-  never disturbs production on port 7837. Use when the user says "test mac",
+  Build and run a dev irrlicht daemon + macOS Swift app for local testing.
+  Asks whether to run a SEPARATE instance alongside production (isolated state,
+  port 7838 — production keeps running) or to REPLACE the running production
+  versions (production port 7837 + production state, so the statusline quota
+  feed and existing sessions show up). Use when the user says "test mac",
   "restart mac", "rebuild mac", or "/ir:test-mac".
 ---
 
-# Build & Run macOS Dev Stack (alongside production)
+# Build & Run macOS Dev Stack (separate or replace)
 
-Build the irrlicht daemon and Swift app and run them as a **dev instance that
-coexists with production**. Production stays up the whole time: the dev daemon
-binds port **7838** (vs production's 7837) and stores its state under a
-worktree-local `IRRLICHT_HOME`, and the dev app is told to connect to 7838 via
-`IRRLICHT_DAEMON_PORT`. Only prior *dev* instances are replaced on rerun.
+Build the irrlicht daemon and Swift app, then run them in one of two modes the
+user chooses up front:
+
+- **separate** (default, recommended) — a dev instance that **coexists with
+  production**. The dev daemon binds port **7838** and stores its state under a
+  worktree-local `IRRLICHT_HOME`; the dev app connects to 7838 via
+  `IRRLICHT_DAEMON_PORT`. Production stays up untouched on 7837. Only prior
+  *dev* instances are replaced on rerun. Note: the Claude Code statusline hook
+  is hardcoded to POST quota data to 7837, so a separate dev instance shows the
+  **subscription empty-state** (no rate-limit data) — that's expected.
+- **replace** — take over from production. Kill the running production app +
+  daemon (and any dev instance), then run the freshly built dev binaries on the
+  **production port 7837** with the **production state dir** (no `IRRLICHT_HOME`
+  override). Because it's on 7837 it receives the statusline quota feed and sees
+  the same on-disk sessions/cost data — i.e. it behaves like production but runs
+  your dev code. There is only one instance afterward.
 
 ## Steps
 
-0. **Detect repo root and set the dev instance config** — use the worktree root if running in a worktree, otherwise the main repo
+0. **Ask the user which mode, then set the run config.** Use `AskUserQuestion`
+   with two options — "Separate (alongside production)" (recommended, first) and
+   "Replace production" — unless the user already said which one they want in
+   their message. Then set the config below from the answer. All later steps
+   read `$MODE`, `$REPO_ROOT`, `$PORT`, `$DEV_HOME`, `$SOCK`, `$DEV_APP`, and
+   `$IRRLICHTD_BIN`.
    ```bash
-   REPO_ROOT="$(git rev-parse --show-toplevel)"
-   DEV_PORT=7838
-   DEV_HOME="$REPO_ROOT/.build/irrlicht-home"   # isolated state dir (IRRLICHT_HOME)
-   IRRLICHTD_BIN="/Users/ingo/projects/irrlicht/core/bin/irrlichd"  # one path: build target == launch target
-   mkdir -p "$DEV_HOME"
+   REPO_ROOT="$(git rev-parse --show-toplevel)"        # worktree root if in a worktree, else main repo
+   IRRLICHTD_BIN="/Users/ingo/projects/irrlicht/core/bin/irrlichd"  # stable path: build target == launch target
+   DEV_APP="/tmp/IrrlichtDev.app"
+   MODE="separate"        # <-- set to "separate" or "replace" from the user's answer
+
+   if [ "$MODE" = "replace" ]; then
+     PORT=7837                                          # production port (statusline quota hook targets this)
+     DEV_HOME=""                                        # no IRRLICHT_HOME override → production state dir
+     SOCK="$HOME/.local/share/irrlicht/irrlichd.sock"   # production socket
+   else
+     PORT=7838                                          # isolated dev port
+     DEV_HOME="$REPO_ROOT/.build/irrlicht-home"         # isolated state dir (IRRLICHT_HOME)
+     SOCK="$DEV_HOME/irrlichd.sock"
+     mkdir -p "$DEV_HOME"
+   fi
+   echo "MODE=$MODE PORT=$PORT DEV_HOME=${DEV_HOME:-<production>}"
    ```
-   All subsequent steps use `$REPO_ROOT`, `$DEV_PORT`, `$DEV_HOME`, and `$IRRLICHTD_BIN`.
    `$IRRLICHTD_BIN` is the main repo's bin (a stable absolute path) so the build
    and launch steps always agree even when `$REPO_ROOT` is a worktree — the
    source compiled is still the worktree's (`go build` runs in `$REPO_ROOT/core`).
@@ -37,19 +64,27 @@ worktree-local `IRRLICHT_HOME`, and the dev app is told to connect to 7838 via
    ```
    Note: the binary is built from the worktree's source but placed at the stable `$IRRLICHTD_BIN` path that step 5 launches.
 
-2. **Build the Swift app and assemble .app bundle**
+2. **Build the Swift app and assemble .app bundle** (identical in both modes)
    ```bash
    cd "$REPO_ROOT/platforms/macos" && swift build 2>&1 | tail -5
    ```
    Then assemble a proper `.app` bundle so that `UNUserNotificationCenter` (desktop notifications) works:
    ```bash
-   DEV_APP="/tmp/IrrlichtDev.app"
    rm -rf "$DEV_APP"
    mkdir -p "$DEV_APP/Contents/MacOS" "$DEV_APP/Contents/Resources"
    cp "$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht" "$DEV_APP/Contents/MacOS/Irrlicht"
    cp "$REPO_ROOT/platforms/macos/Irrlicht/Resources/AppIcon.icns" "$DEV_APP/Contents/Resources/AppIcon.icns"
    # Copy the SwiftPM resource bundle so Bundle.module works at runtime
    cp -R "$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht_Irrlicht.bundle" "$DEV_APP/Contents/Resources/Irrlicht_Irrlicht.bundle" 2>/dev/null || true
+   # Embed Sparkle.framework (required since v0.4.7 auto-update integration)
+   mkdir -p "$DEV_APP/Contents/Frameworks"
+   cp -R "$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug/Sparkle.framework" "$DEV_APP/Contents/Frameworks/"
+   # The SwiftPM debug binary links Sparkle as @rpath/Sparkle.framework but only
+   # carries an @loader_path rpath (= Contents/MacOS) — it lacks the bundle-layout
+   # rpath a release .app build adds. Without this, dyld can't find the embedded
+   # framework and the app crashes at launch. (Must run BEFORE the codesign step
+   # below, since it mutates the binary and invalidates the signature.)
+   install_name_tool -add_rpath @executable_path/../Frameworks "$DEV_APP/Contents/MacOS/Irrlicht"
    cat > "$DEV_APP/Contents/Info.plist" << 'PLIST'
    <?xml version="1.0" encoding="UTF-8"?>
    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -95,45 +130,82 @@ worktree-local `IRRLICHT_HOME`, and the dev app is told to connect to 7838 via
    fi
    ```
 
-3. **Kill only the prior DEV instances** — leave production (Irrlicht.app + its daemon on 7837) untouched. The dev daemon runs from `$IRRLICHTD_BIN` (`…/core/bin/irrlichd`); production runs from inside the `.app` bundle, so matching that path reaps the dev daemon in ANY state (even if it isn't currently bound to the dev port) without touching production.
+3. **Kill the instances this mode replaces.**
+   - **separate**: only prior *dev* instances; production (on 7837) stays up.
+   - **replace**: the production app + ALL daemons (prod is named `irrlichd`,
+     exactly like dev) + any prior dev app, so only the fresh build remains.
    ```bash
-   pkill -f "IrrlichtDev" 2>/dev/null            # prior dev app
-   pkill -f "core/bin/irrlichd" 2>/dev/null      # prior dev daemon (NOT production, which runs from the .app bundle)
-   DEV_PIDS="$(lsof -ti tcp:$DEV_PORT 2>/dev/null)"   # belt-and-suspenders: anything still on the dev port
-   [ -n "$DEV_PIDS" ] && kill $DEV_PIDS 2>/dev/null
+   if [ "$MODE" = "replace" ]; then
+     pkill -f "Irrlicht.app/Contents/MacOS/Irrlicht" 2>/dev/null   # production app (NOT IrrlichtDev.app — different folder)
+     pkill -f "IrrlichtDev"                          2>/dev/null   # any prior dev app
+     pkill -x "irrlichd"                             2>/dev/null   # ALL daemons by exact name (prod bundle + dev)
+   else
+     pkill -f "IrrlichtDev"                          2>/dev/null   # prior dev app only
+     pkill -f "core/bin/irrlichd"                    2>/dev/null   # prior dev daemon (NOT production, which runs from the .app bundle)
+   fi
+   PORT_PIDS="$(lsof -ti tcp:$PORT 2>/dev/null)"   # belt-and-suspenders: anything still on the target port
+   [ -n "$PORT_PIDS" ] && kill $PORT_PIDS 2>/dev/null
    sleep 2
    ```
 
-4. **Clean up the stale DEV socket** (under the isolated state dir, never production's)
+4. **Clean up the stale socket** for the target instance.
    ```bash
-   rm -f "$DEV_HOME/irrlichd.sock"
+   rm -f "$SOCK"
    ```
 
-5. **Start the dev daemon** — isolated state (`IRRLICHT_HOME`) on the dev port, with `--record` for lifecycle event capture
+5. **Start the daemon** with `--record` for lifecycle event capture. In
+   **separate** mode it gets `IRRLICHT_HOME` (isolated state); in **replace**
+   mode `IRRLICHT_HOME` is omitted so it reads/writes the production state dir.
    ```bash
-   IRRLICHT_HOME="$DEV_HOME" IRRLICHT_BIND_ADDR=127.0.0.1:$DEV_PORT \
-     nohup "$IRRLICHTD_BIN" --record > /tmp/irrlichd-dev.log 2>&1 & disown
+   if [ "$MODE" = "replace" ]; then
+     IRRLICHT_BIND_ADDR=127.0.0.1:$PORT \
+       nohup "$IRRLICHTD_BIN" --record > /tmp/irrlichd-dev.log 2>&1 & disown
+   else
+     IRRLICHT_HOME="$DEV_HOME" IRRLICHT_BIND_ADDR=127.0.0.1:$PORT \
+       nohup "$IRRLICHTD_BIN" --record > /tmp/irrlichd-dev.log 2>&1 & disown
+   fi
    ```
 
-6. **Wait for daemon to be ready** — confirm the dev port is listening before launching the app
+6. **Wait for the daemon to be reachable** before launching the app. In replace
+   mode this matters extra: the app adopts an already-reachable daemon on 7837
+   and skips its own spawn/pkill, so the manually started `--record` daemon must
+   be up first (otherwise the app would `pkill -x irrlichd` it and respawn one
+   without `--record`).
    ```bash
-   sleep 2 && lsof -iTCP:$DEV_PORT -sTCP:LISTEN -P -n 2>/dev/null
+   for i in 1 2 3 4 5; do
+     curl -fsS --max-time 1 "http://127.0.0.1:$PORT/state" >/dev/null 2>&1 && break
+     sleep 1
+   done
+   lsof -iTCP:$PORT -sTCP:LISTEN -P -n 2>/dev/null
    ```
 
-7. **Start the dev Swift app** — launched via LaunchServices so `Bundle.main` resolves correctly. `IRRLICHT_DAEMON_PORT` points it at the dev daemon (not production's 7837); `IRRLICHT_HOME` is also passed so that if the app ever spawns its OWN daemon (when the step-5 daemon isn't reachable), that daemon stays isolated instead of writing to the production state dir.
+7. **Start the dev Swift app** — launched via LaunchServices so `Bundle.main`
+   resolves correctly. In **separate** mode, `IRRLICHT_DAEMON_PORT`/`IRRLICHT_HOME`
+   point it at the isolated dev daemon. In **replace** mode, no env overrides are
+   passed: the app uses the default port 7837 + production state and, finding the
+   daemon from step 5 already reachable, adopts it instead of spawning its own.
    ```bash
-   open --env IRRLICHT_DAEMON_PORT=$DEV_PORT --env IRRLICHT_HOME="$DEV_HOME" \
-     --stdout /tmp/irrlicht-app-dev.log --stderr /tmp/irrlicht-app-dev.log /tmp/IrrlichtDev.app
+   if [ "$MODE" = "replace" ]; then
+     open --stdout /tmp/irrlicht-app-dev.log --stderr /tmp/irrlicht-app-dev.log "$DEV_APP"
+   else
+     open --env IRRLICHT_DAEMON_PORT=$PORT --env IRRLICHT_HOME="$DEV_HOME" \
+       --stdout /tmp/irrlicht-app-dev.log --stderr /tmp/irrlicht-app-dev.log "$DEV_APP"
+   fi
    ```
 
-8. **Verify** — confirm the dev processes are running and the dev daemon is serving sessions (production on 7837 is unaffected)
+8. **Verify** — dev daemon + app are running and the daemon is serving sessions.
+   In replace mode, also confirm quota data is present (the whole point of 7837).
    ```bash
-   pgrep -f "bin/irrlichd" && pgrep -f "IrrlichtDev" && curl -s http://127.0.0.1:$DEV_PORT/api/v1/sessions | head -1
+   pgrep -f "bin/irrlichd" && pgrep -f "IrrlichtDev" && curl -s http://127.0.0.1:$PORT/api/v1/sessions | head -c 200
+   if [ "$MODE" = "replace" ]; then
+     echo; echo "rate-limit mentions (expect >0 once a statusline tick lands):" \
+       "$(curl -s http://127.0.0.1:$PORT/api/v1/sessions | grep -o 'rate_limit\|used_percent' | wc -l | tr -d ' ')"
+   fi
    ```
 
 ## Notes
-- **Production keeps running.** The production Irrlicht.app (from DMG) and its bundled daemon stay on port 7837 with state under `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/`. The dev instance binds port `$DEV_PORT` (7838) and routes its WRITTEN state — socket, recordings, history, session store, ledgers, and cost store — beneath `IRRLICHT_HOME=$DEV_HOME`, so it never prunes or mutates production's session/cost data. The dev app reaches the dev daemon because `IRRLICHT_DAEMON_PORT` (via `open --env`) overrides the hardcoded default; `DaemonManager` also skips its global `pkill` when a custom port is set, so it can't take production down.
-- **What the dev instance still shares with production:** it reads the same `~/.claude` transcripts (so the dev UI shows the same live sessions — intended for "see the UI render" testing) and appends to the same `~/Library/Application Support/Irrlicht/logs/events.log`. It does NOT share the on-disk session/ledger/cost stores.
-- Daemon logs: `/tmp/irrlichd-dev.log`
-- Swift app logs: `/tmp/irrlicht-app-dev.log`
+- **separate mode — production keeps running.** The production Irrlicht.app (from DMG) and its bundled daemon stay on port 7837 with state under `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/`. The dev instance binds port 7838 and routes its WRITTEN state — socket, recordings, history, session store, ledgers, and cost store — beneath `IRRLICHT_HOME=$DEV_HOME`, so it never prunes or mutates production's session/cost data. The dev app reaches the dev daemon because `IRRLICHT_DAEMON_PORT` (via `open --env`) overrides the hardcoded default; `DaemonManager` also skips its global `pkill` when a custom port is set, so it can't take production down.
+- **separate mode shares with production:** it reads the same `~/.claude` transcripts (so the dev UI shows the same live sessions) and appends to the same `~/Library/Application Support/Irrlicht/logs/events.log`. It does NOT share the on-disk session/ledger/cost stores — and it does NOT receive the statusline quota feed (that hook posts only to 7837), so the subscription panel shows its empty-state.
+- **replace mode — single instance on production's footprint.** Runs the dev binaries on port 7837 with the production state dir (no `IRRLICHT_HOME`), so the statusline quota feed and the production session/cost/ledger stores all apply. Because the dev daemon runs with `--record`, recordings land in the production recordings dir (`~/.local/share/irrlicht/recordings/`) for the duration. To return to the real production build, relaunch `/Applications/Irrlicht.app` (it will reclaim 7837 after this dev instance is stopped).
+- Daemon logs: `/tmp/irrlichd-dev.log` · Swift app logs: `/tmp/irrlicht-app-dev.log`
 - **TCC stability**: run `tools/dev-sign-setup.sh` once to install the `"Irrlicht Dev"` self-signed code signing identity. The skill automatically signs with it when present, giving the app a stable designated requirement so Accessibility/Automation grants persist across rebuilds. Without it, every rebuild invalidates TCC and requires re-granting in System Settings.

--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -30,17 +30,25 @@ user chooses up front:
 
 ## Steps
 
-0. **Ask the user which mode, then set the run config.** Use `AskUserQuestion`
-   with two options — "Separate (alongside production)" (recommended, first) and
-   "Replace production" — unless the user already said which one they want in
-   their message. Then set the config below from the answer. All later steps
-   read `$MODE`, `$REPO_ROOT`, `$PORT`, `$DEV_HOME`, `$SOCK`, `$DEV_APP`, and
-   `$IRRLICHTD_BIN`.
+0. **Decide the mode, then set the run config.** If the user typed an explicit
+   `separate` or `replace` argument (e.g. `/ir:test-mac replace`), use it. Otherwise
+   ask with `AskUserQuestion` — two options, "Separate (alongside production)"
+   (recommended, first) and "Replace production". **`replace` is destructive** (it
+   kills production and lets a dev binary read/write production state) — never
+   default to it; when in doubt, pick `separate`.
+
+   Then edit the `MODE=` line below to the chosen value before running the block —
+   it is a placeholder, not a default to run verbatim. Every later step branches on
+   `$MODE`/`$PORT`/`$DEV_HOME`/`$SOCK`. **These are shell variables, and each fenced
+   block runs in a fresh shell**, so when you execute a later step you must carry the
+   step-0 values forward (re-declare them, or inline the literal port/path) — an
+   empty `$PORT` makes the daemon bind `127.0.0.1:` (invalid) and an empty `$SOCK`
+   turns the socket cleanup into a no-op.
    ```bash
    REPO_ROOT="$(git rev-parse --show-toplevel)"        # worktree root if in a worktree, else main repo
    IRRLICHTD_BIN="/Users/ingo/projects/irrlicht/core/bin/irrlichd"  # stable path: build target == launch target
    DEV_APP="/tmp/IrrlichtDev.app"
-   MODE="separate"        # <-- set to "separate" or "replace" from the user's answer
+   MODE="separate"        # PLACEHOLDER — set to the user's choice ("separate" or "replace") before running
 
    if [ "$MODE" = "replace" ]; then
      PORT=7837                                          # production port (statusline quota hook targets this)
@@ -136,7 +144,7 @@ user chooses up front:
      exactly like dev) + any prior dev app, so only the fresh build remains.
    ```bash
    if [ "$MODE" = "replace" ]; then
-     pkill -f "Irrlicht.app/Contents/MacOS/Irrlicht" 2>/dev/null   # production app (NOT IrrlichtDev.app — different folder)
+     pkill -f "Irrlicht\.app/Contents/MacOS/Irrlicht" 2>/dev/null  # production app (\. is literal; NOT IrrlichtDev.app — different folder)
      pkill -f "IrrlichtDev"                          2>/dev/null   # any prior dev app
      pkill -x "irrlichd"                             2>/dev/null   # ALL daemons by exact name (prod bundle + dev)
    else
@@ -166,16 +174,25 @@ user chooses up front:
    fi
    ```
 
-6. **Wait for the daemon to be reachable** before launching the app. In replace
-   mode this matters extra: the app adopts an already-reachable daemon on 7837
-   and skips its own spawn/pkill, so the manually started `--record` daemon must
-   be up first (otherwise the app would `pkill -x irrlichd` it and respawn one
-   without `--record`).
+6. **Wait for the daemon to be reachable — and HARD-ABORT if it isn't.** This is a
+   gate, not a courtesy sleep. In replace mode the app adopts an already-reachable
+   daemon on 7837 and skips its own spawn/pkill; if our `--record` daemon is NOT up
+   yet when the app launches, the app (port 7837 ⇒ `isCustomPort` false) runs
+   `pkill -x irrlichd` — killing our daemon — and respawns one **without** `--record`,
+   silently defeating the whole point. So if `/state` never answers, stop here and do
+   not launch the app.
    ```bash
-   for i in 1 2 3 4 5; do
-     curl -fsS --max-time 1 "http://127.0.0.1:$PORT/state" >/dev/null 2>&1 && break
+   READY=""
+   for i in 1 2 3 4 5 6 7 8; do
+     curl -fsS --max-time 1 "http://127.0.0.1:$PORT/state" >/dev/null 2>&1 && { READY=1; break; }
      sleep 1
    done
+   if [ -z "$READY" ]; then
+     echo "ABORT: daemon never became reachable on $PORT — not launching the app." >&2
+     echo "       (Launching now would let the app pkill our daemon and respawn one without --record.)" >&2
+     echo "       Check /tmp/irrlichd-dev.log." >&2
+     return 1 2>/dev/null || exit 1
+   fi
    lsof -iTCP:$PORT -sTCP:LISTEN -P -n 2>/dev/null
    ```
 
@@ -198,14 +215,33 @@ user chooses up front:
    ```bash
    pgrep -f "bin/irrlichd" && pgrep -f "IrrlichtDev" && curl -s http://127.0.0.1:$PORT/api/v1/sessions | head -c 200
    if [ "$MODE" = "replace" ]; then
-     echo; echo "rate-limit mentions (expect >0 once a statusline tick lands):" \
+     # 0 is normal right after launch — quota data only appears once Claude Code's
+     # statusline posts its next tick to 7837 (seconds to a minute). Re-run to confirm.
+     echo; echo "rate-limit mentions (0 now is fine; should climb after the next statusline tick):" \
        "$(curl -s http://127.0.0.1:$PORT/api/v1/sessions | grep -o 'rate_limit\|used_percent' | wc -l | tr -d ' ')"
    fi
+   ```
+
+9. **Tearing down (replace mode) — REQUIRED to get production back.** Quitting the
+   dev app is NOT enough: in replace mode the app only *adopted* the daemon started
+   in step 5 (it never owns the process — `DaemonManager.start()` returns early on a
+   reachable daemon without recording it, so its `terminateProcess()` is a no-op),
+   and that daemon was `nohup`/`disown`'d, so it keeps running on 7837 after the app
+   exits. If you then relaunch `/Applications/Irrlicht.app`, production finds the
+   leftover dev daemon still reachable and **adopts it** — you'd be running the
+   production UI against the dev `--record` daemon without realizing it. So to
+   return to production: quit the dev app, then explicitly kill the daemon and
+   confirm the port is free *before* relaunching production.
+   ```bash
+   pkill -f "IrrlichtDev" 2>/dev/null     # quit the dev app
+   pkill -x "irrlichd"    2>/dev/null     # stop the adopted dev daemon (the app won't)
+   sleep 1
+   lsof -iTCP:7837 -sTCP:LISTEN -P -n 2>/dev/null && echo "WARNING: 7837 still held — production will adopt whatever is there" || echo "7837 free — safe to relaunch /Applications/Irrlicht.app"
    ```
 
 ## Notes
 - **separate mode — production keeps running.** The production Irrlicht.app (from DMG) and its bundled daemon stay on port 7837 with state under `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/`. The dev instance binds port 7838 and routes its WRITTEN state — socket, recordings, history, session store, ledgers, and cost store — beneath `IRRLICHT_HOME=$DEV_HOME`, so it never prunes or mutates production's session/cost data. The dev app reaches the dev daemon because `IRRLICHT_DAEMON_PORT` (via `open --env`) overrides the hardcoded default; `DaemonManager` also skips its global `pkill` when a custom port is set, so it can't take production down.
 - **separate mode shares with production:** it reads the same `~/.claude` transcripts (so the dev UI shows the same live sessions) and appends to the same `~/Library/Application Support/Irrlicht/logs/events.log`. It does NOT share the on-disk session/ledger/cost stores — and it does NOT receive the statusline quota feed (that hook posts only to 7837), so the subscription panel shows its empty-state.
-- **replace mode — single instance on production's footprint.** Runs the dev binaries on port 7837 with the production state dir (no `IRRLICHT_HOME`), so the statusline quota feed and the production session/cost/ledger stores all apply. Because the dev daemon runs with `--record`, recordings land in the production recordings dir (`~/.local/share/irrlicht/recordings/`) for the duration. To return to the real production build, relaunch `/Applications/Irrlicht.app` (it will reclaim 7837 after this dev instance is stopped).
+- **replace mode — single instance on production's footprint.** Runs the dev binaries on port 7837 with the production state dir (no `IRRLICHT_HOME`), so the statusline quota feed and the production session/cost/ledger stores all apply. Because the dev daemon runs with `--record`, recordings land in the production recordings dir (`~/.local/share/irrlicht/recordings/`). **⚠️ The dev daemon mutates production data.** Without `IRRLICHT_HOME` its startup sweeps (`PruneStale` / dead-proc / orphan-ledger / cost prune) run against the real `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/` stores — this is exactly the isolation #448 added, deliberately removed here. Only use replace mode when the dev build's on-disk schema matches the installed production build; a dev branch mid-migration can prune or rewrite production sessions/ledgers/cost rows that the production binary then misreads. **Returning to production requires the step-9 teardown** — quitting the app does NOT stop the adopted daemon, and a relaunched production app will silently adopt the leftover dev daemon on 7837 if you skip it.
 - Daemon logs: `/tmp/irrlichd-dev.log` · Swift app logs: `/tmp/irrlicht-app-dev.log`
 - **TCC stability**: run `tools/dev-sign-setup.sh` once to install the `"Irrlicht Dev"` self-signed code signing identity. The skill automatically signs with it when present, giving the app a stable designated requirement so Accessibility/Automation grants persist across rebuilds. Without it, every rebuild invalidates TCC and requires re-granting in System Settings.


### PR DESCRIPTION
## What

`/ir:test-mac` now supports two run modes, chosen up front (or via an arg, e.g. `/ir:test-mac replace`):

- **separate** (default) — dev instance alongside production: port **7838**, isolated `IRRLICHT_HOME`. Production stays up on 7837. This is the existing behavior.
- **replace** — take over production: port **7837** + the production state dir (no `IRRLICHT_HOME`). Kills the production app + all `irrlichd` daemons + any dev instance, then runs the dev binaries in their place.

## Why

Two reasons:

1. **Quota/subscription data.** The Claude Code statusline hook is hardcoded to POST `rate_limits` to `localhost:7837`. A separate dev instance on 7838 therefore never receives it and shows the subscription empty-state. Replace mode runs on 7837, so the quota feed (and the production session/cost/ledger stores) all apply — the dev build behaves like production but runs your code.
2. **Sparkle launch crash.** Since the v0.4.7 auto-update integration, the app links `@rpath/Sparkle.framework`. The assembled dev bundle was missing both the framework and the `@executable_path/../Frameworks` rpath (the SwiftPM debug binary only carries `@loader_path`), so the app crashed at launch with `dyld: Library not loaded`.

## How replace mode stays correct

`DaemonManager.start()` adopts an already-reachable daemon (`isDaemonReachable()`) and skips its spawn/`pkill`. So replace mode starts the dev `--record` daemon on 7837 **first**, then launches the app with no env overrides — the app adopts the running `--record` daemon instead of `pkill -x irrlichd`-ing it and respawning one without `--record`. Step 6 is a **hard gate**: it polls `/state` and aborts before launching the app if the daemon never comes up, so the app can't fall through to that respawn path.

## Replace mode is destructive — guardrails

Replace mode deliberately drops the `IRRLICHT_HOME` isolation that #448 added, so the skill is explicit about the consequences:

- **It mutates production data.** With no `IRRLICHT_HOME`, the dev daemon's startup sweeps (`PruneStale` / dead-proc / orphan-ledger / cost prune) run against the real session/ledger/cost stores. Only safe when the dev build's on-disk schema matches the installed production build. Documented with a ⚠️ in Notes.
- **The app adopts but never owns the daemon.** `start()` returns early on a reachable daemon without recording the process, so `terminateProcess()` is a no-op; the `nohup`/`disown`'d daemon outlives the app. A new **step 9 teardown** is required to return to production — it `pkill`s the daemon and confirms 7837 is free, because otherwise a relaunched production app silently adopts the leftover dev daemon.

## Changes

- Step 0 takes a `MODE` (asks via `AskUserQuestion`, or honors a `separate`/`replace` arg; `replace` is never the default) and derives `$PORT` / `$DEV_HOME` / `$SOCK`. `MODE=` is marked a placeholder, and the cross-block fresh-shell caveat is noted.
- Kill, daemon-launch, app-launch, and verify steps branch on `$MODE`.
- Embed `Sparkle.framework` + add the Frameworks rpath before codesign.
- Notes document both modes, the quota implication, the production-data warning, and the teardown.

## Code review + fixes

Ran an extra-high-effort review (`/code-review`) on the branch. It surfaced a cluster of real defects in the replace path, all fixed in the second commit:

- step 9 teardown + corrected the (previously wrong) "relaunch Irrlicht.app reclaims 7837" note;
- ⚠️ production-data-mutation warning (the #448 hazard, reintroduced intentionally);
- step 6 turned into a hard abort gate;
- `MODE=` placeholder + fresh-shell threading caveat;
- escaped the regex metachar in the prod-app `pkill` pattern (`Irrlicht\.app`);
- reworded verify so `0` quota mentions right after launch isn't read as failure.

Two findings were refuted in review (the `${DEV_HOME:-…}` expansion and a `pgrep` false-positive) and left as-is.

## Testing

- All 11 bash blocks pass `bash -n`.
- Ran `/ir:test-mac replace` end-to-end: production taken down, dev daemon on 7837 (`{"version":"dev"}`), app adopted it (no respawn), no dyld crash, and `rate_limit` data present in `/api/v1/sessions` (was 0 in separate mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
