### PR TITLE
perf(onboard): slice catalogs + step-grammar ref to cut subagent tokens (#460)

### DIFF
--- a/.claude/skills/ir:onboard-agent/assess/SKILL.md
+++ b/.claude/skills/ir:onboard-agent/assess/SKILL.md
@@ -141,46 +141,44 @@ The steps below cover the **single-cell** form. For
 [`--column`](#column-and-row-batch-modes) and `--row`, jump to
 "Batch modes" further down.
 
-### Step 1 — Read the prose spec
-
-Canonical source (committed, always present):
+### Step 1 — Slice the cell
 
 ```
-.claude/skills/ir:onboard-agent/scenario-meanings.md   →   ### <scenario-id>
+.claude/skills/ir:onboard-agent/scripts/slice-cell.sh <scenario-id> <agent>
 ```
 
-Read the `### <scenario-id>` block and capture all five fields
-(Essence, User-observable signal, Primitive exercised, Not to be
-confused with, Conceptual flow). The **User-observable signal** lines
-are the candidate assertions you judge `irrlicht_observes` against; the
-**Primitive exercised** field is the canonical capability-key anchor
-(use it in Step 4 to pick the right `capabilities.json` key).
+One call prints exactly three things and nothing else — the
+`scenarios.json` entry, the `### <scenario-id>` scenario-meanings block,
+and the `agent-scenarios-coverage.json` cell — so you slice instead of
+reading the whole catalogs. Step 2 reads the coverage cell from this same
+output.
 
-If the scenario ID is missing from `scenario-meanings.md` — STOP. The
-row hasn't been created. Surface "run `scenario-create <slug>` first" in
-your summary and return.
+From the scenario-meanings block capture all five fields (Essence,
+User-observable signal, Primitive exercised, Not to be confused with,
+Conceptual flow). The **User-observable signal** lines are the candidate
+assertions you judge `irrlicht_observes` against; **Primitive exercised**
+is the canonical capability-key anchor (use it in Step 4 to pick the
+right `capabilities.json` key).
 
-If a richer `.specs/agent-scenarios.md` happens to be present (it's
-gitignored, so usually absent), also read its `### Feature:` block whose
-kebab slug matches — capture every `Scenario:` paragraph and `Expected:`
-bullet for extra precision. Don't fabricate a scenario if it's absent;
-`scenario-meanings.md` is sufficient.
+`slice-cell.sh` exits non-zero if the scenario is missing from
+`scenarios.json`/`scenario-meanings.md` — the row hasn't been created, so
+STOP and surface "run `scenario-create <slug>` first". If a richer
+`.specs/agent-scenarios.md` happens to be present (gitignored, usually
+absent), read its matching `### Feature:` block for extra precision; the
+slice is sufficient without it.
 
 ► **Verify before moving on:**
-- [ ] Found the `### <scenario-id>` block in `scenario-meanings.md` and
-  captured the **Primitive exercised** field verbatim.
+- [ ] Ran `slice-cell.sh` and captured the **Primitive exercised** field
+  verbatim from the scenario-meanings block.
 - [ ] Captured every User-observable signal (and any `.specs/` Expected:
   bullet, if present). Each is a candidate assertion for
   `irrlicht_observes`.
 
 ### Step 2 — Read the current matrix verdict
 
-```
-.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json   →   .scenarios[].coverage[<agent>]
-```
-
-Or `curl http://127.0.0.1:8765/api/catalog | jq` when `.specs/` is
-absent.
+Use the coverage cell already printed by `slice-cell.sh` in Step 1
+(`agent-scenarios-coverage.json → .scenarios[].coverage[<agent>]`). Or
+`curl http://127.0.0.1:8765/api/catalog | jq` against a running daemon.
 
 You're not bound by the existing verdict — the whole point of
 re-assessing is to confirm or refine. But knowing the prior verdict

--- a/.claude/skills/ir:onboard-agent/cell-lifecycle.md
+++ b/.claude/skills/ir:onboard-agent/cell-lifecycle.md
@@ -173,22 +173,11 @@ for this specific agent CLI?
 }
 ```
 
-**Step types** (from `scripts/drive-claudecode-interactive.sh` and
-peers):
-
-- `send` — types text + Enter, increments turn counter
-- `wait_turn` — blocks until expected turn count reached
-- `sleep` — wall-clock pause (use ≥4s after last interaction for
-  classifier debounce)
-- `interrupt` — sends Escape (claudecode binds Esc to cancel turn)
-- `keys` — raw tmux key sequence ("Escape Escape", "Up Up Enter")
-  for driving picker UIs
-- `restart` — tears down + relaunches the agent (used in session-end /
-  session-resume chains)
-- `resume` — relaunch with `--resume <uuid>` (claudecode-specific)
-- `sigkill` — SIGKILL the agent (crash-mid-turn scenarios)
-- `exit_clean` — C-d to exit cleanly
-- `reset_session` — `/clear` (claudecode-specific)
+**Step types:** see [`step-grammar.md`](step-grammar.md) for the full
+step vocabulary (each step's fields + which drivers support it) — that is
+the single source of truth; don't reverse-engineer the driver. Authoring
+tip: use a `sleep` of ≥4s after the last interaction so the classifier
+debounce settles before the recording ends.
 
 **Why this is per-adapter:** same scenario shape (e.g. "session-start")
 needs different driver scripts per agent. claudecode needs a 1-token

--- a/.claude/skills/ir:onboard-agent/recipe/SKILL.md
+++ b/.claude/skills/ir:onboard-agent/recipe/SKILL.md
@@ -149,15 +149,24 @@ facing documentation.
 
 ## Process
 
-### Step 1 — Read the prose spec
+### Step 1 — Slice the cell
 
 ```
-.specs/agent-scenarios.md
+.claude/skills/ir:onboard-agent/scripts/slice-cell.sh <scenario-id> <agent>
 ```
 
-Find the `### Feature:` heading whose kebab slug matches
-`<scenario-id>`. Capture every `Scenario:` paragraph and every
-`Expected:` bullet under it.
+One call prints exactly three things and nothing else — the
+`scenarios.json` entry + this agent's existing recipe (if any), the
+`### <scenario-id>` block from `scenario-meanings.md`, and the
+`agent-scenarios-coverage.json` cell. Use it instead of reading the
+whole catalogs; Step 2 reads the coverage cell from this same output.
+
+From the scenario-meanings block capture all five fields (Essence,
+User-observable signal, Primitive exercised, Not to be confused with,
+Conceptual flow) — the **User-observable signal** lines are what your
+recipe's `verify` bullets must make observable. (A gitignored
+`.specs/agent-scenarios.md`, if present, adds `Scenario:`/`Expected:`
+precision — usually absent, and the slice is sufficient.)
 
 A heading can have **multiple** Scenario/Expected sub-blocks (e.g.
 `session-end` has three: clean exit, SIGKILL mid-idle, crash
@@ -169,8 +178,8 @@ prerequisites, different agent CLIs) that can't share one
 recording.
 
 ► **Verify before moving on:**
-- [ ] Located the `### <scenario-id>` section in `.claude/skills/ir:onboard-agent/scenario-meanings.md` and read all five fields (Essence, User-observable signal, Primitive exercised, Not to be confused with, Conceptual flow).
-- [ ] If the scenario ID is missing from `scenario-meanings.md` — STOP. Ask the maintainer to add the entry before proceeding.
+- [ ] Ran `slice-cell.sh` and read all five scenario-meanings fields from its output.
+- [ ] `slice-cell.sh` exited non-zero (scenario missing from `scenarios.json` or `scenario-meanings.md`) — STOP and ask the maintainer to run `scenario-create` first.
 - [ ] Captured every word of the Scenario: paragraph(s) and every
   Expected: bullet — paraphrasing loses precision.
 - [ ] Counted the number of variants. If >1, decide chain-in-one vs
@@ -183,9 +192,9 @@ recording.
 
 ### Step 2 — Read the verdict
 
-```
-.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json   →   .scenarios[].coverage[<agent>]
-```
+Use the coverage cell already printed by `slice-cell.sh` in Step 1
+(`agent-scenarios-coverage.json → .scenarios[].coverage[<agent>]`) — no
+second read.
 
 - `agent_supports == "yes"` → produce the recipe normally.
 - `agent_supports == "partial"` → produce the recipe; mirror the
@@ -200,8 +209,8 @@ recording.
   merges the resulting assessment into the matrix.
 
 ► **Verify before moving on:**
-- [ ] The verdict cell exists for `<agent>` in
-  `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json` — no fabricating a column.
+- [ ] The verdict cell exists for `<agent>` in the slice output — no
+  fabricating a column.
 - [ ] If `agent_supports == "partial"`, the coverage `notes` field
   is non-empty AND you understand the caveat well enough to mirror
   it into `preconditions`. If the notes are vague (e.g. "needs
@@ -216,28 +225,22 @@ For the chosen agent, read in order:
 1. `core/adapters/inbound/agents/<agent>/config.go` — `ProcessName`,
    `TranscriptFilename`, `Capabilities`, and any `DiscoverPID`
    wiring. Defines what irrlicht sees.
-2. `.claude/skills/ir:onboard-agent/scripts/drive-<agent>-interactive.sh`
-   — the supported step grammar and CLI flags the driver passes.
-   Your `script` must stay inside this grammar. Currently supported
-   step types (claudecode is the reference; other drivers implement
-   a subset):
-
-   | type           | semantics                                                      | drivers           |
-   |---             |---                                                              |---                 |
-   | `send`         | type text + Enter; bumps expected-turn count                    | all interactive    |
-   | `slash`        | same as `send`, used for `/cmd`-style slash commands            | all interactive    |
-   | `wait_turn`    | block until the agent finishes the current LLM round            | all interactive    |
-   | `sleep`        | pause N seconds (field: `seconds`)                              | all interactive    |
-   | `interrupt`    | send Escape (claudecode/codex/pi) or Ctrl-C (aider) mid-turn    | all interactive    |
-   | `restart`      | kill current tmux, mint new UUID + fresh cwd, re-init session   | claudecode         |
-   | `sigkill`      | `kill -9` the current agent process (forced termination)        | claudecode         |
-   | `exit_clean`   | Ctrl-D to the TUI for a graceful shutdown                       | claudecode         |
+2. `.claude/skills/ir:onboard-agent/step-grammar.md` — the shared step
+   vocabulary (`send`, `slash`, `wait_turn`, `sleep`, `interrupt`,
+   `keys`, `restart`, `resume`, `reset_session`, `fork`, `sigkill`,
+   `exit_clean`, `start_session`, `session`) with each step's fields and
+   which drivers support it. Your `script` must stay inside this grammar.
+   Read this one-page reference instead of the ~600-line driver; only
+   open `drive-<agent>-interactive.sh` for a per-agent quirk the grammar
+   doesn't cover.
 3. `.claude/skills/ir:onboard-agent/install-instructions.md` — any
    per-agent gates (LM Studio for aider, API auth for codex/claudecode,
    etc.). These become `preconditions` entries.
-4. Existing recipes under `scenarios.json -> scenarios[].by_adapter`
-   for the same agent — they encode hard-won quirks (CLI flags,
-   trust dialogs, timing) you should reuse rather than re-discover.
+4. This cell's prior recipe (if any) is already in the Step 1 slice. To
+   reuse hard-won quirks (CLI flags, trust dialogs, timing) from one of
+   the agent's OTHER scenarios, run `slice-cell.sh <other-scenario>
+   <agent>` for that specific scenario rather than reading all of
+   `scenarios.json`.
 
 For the headless variant (`drive-<agent>.sh`, single-shot
 `--print`-style invocation), the recipe uses `prompt: "..."` instead

--- a/.claude/skills/ir:onboard-agent/record/SKILL.md
+++ b/.claude/skills/ir:onboard-agent/record/SKILL.md
@@ -188,3 +188,7 @@ mv "$LATEST_ARCHIVE"/{events,transcript,manifest}.json[l]* "$SCENARIO_DIR"/
   manifest with `expected_pass_rate: "no spec"`.
 - It does not modify `.claude/skills/ir:onboard-agent/agent-scenarios-coverage.json`. The
   matrix rollup is the maintainer's editorial truth.
+- It does not read the catalogs into model context — so there is no
+  `slice-cell.sh` step here (unlike `recipe`/`assess`/`spec`).
+  `run-cell.sh` extracts just this cell's recipe from `scenarios.json`
+  with `jq` at the script level; no whole-catalog read happens.

--- a/.claude/skills/ir:onboard-agent/scripts/slice-cell.sh
+++ b/.claude/skills/ir:onboard-agent/scripts/slice-cell.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# slice-cell.sh — print just the catalog slices one (scenario, adapter)
+# cell needs, instead of making a subagent read three whole catalogs.
+#
+# A single recipe/assess/spec call only touches ~1/44th of each catalog
+# (scenarios.json ~60k tok, scenario-meanings.md ~11k, coverage ~10k).
+# This emits three labeled sections — the scenario entry + that adapter's
+# recipe, the scenario-meanings block, and the coverage cell — and nothing
+# else, so the caller spends ~3k tokens where a full read spent ~80k.
+#
+# Usage:
+#   slice-cell.sh <scenario-id> <adapter>
+#
+#   scenario-id: the kebab id (e.g. session-start, auto-executed-tool-call).
+#                Matched against scenarios.json `name`, mirroring run-cell.sh
+#                (`select(.name == $s)`); falls back to `coverage_id` so the
+#                7 scenarios whose name != coverage_id still resolve.
+#   adapter:     claudecode | codex | pi | aider | opencode
+#
+# The scenario entry's own `coverage_id` (which == name for recorded cells)
+# is then used to key the scenario-meanings block and the coverage cell, so
+# all three slices describe the same cell even when name != coverage_id.
+#
+# Exit 1 when the scenario isn't in scenarios.json or has no
+# scenario-meanings block — the same STOP signal the SKILL.md steps expect.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: slice-cell.sh <scenario-id> <adapter>" >&2
+  exit 2
+fi
+
+SCENARIO="$1"
+ADAPTER="$2"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCENARIOS_JSON="$SKILL_DIR/scenarios.json"
+MEANINGS_MD="$SKILL_DIR/scenario-meanings.md"
+COVERAGE_JSON="$SKILL_DIR/agent-scenarios-coverage.json"
+
+fail() {
+  echo "slice-cell: $*" >&2
+  exit 1
+}
+
+# Match by name first (what run-cell.sh records against), then by
+# coverage_id. Reused for both the projection and the coverage_id lookup.
+JQ_MATCH='([.scenarios[] | select(.name == $s)]) as $byname
+  | (if ($byname | length) > 0 then $byname
+     else [.scenarios[] | select(.coverage_id == $s)] end)'
+
+# --- 1. scenarios.json entry + this adapter's recipe -------------------
+SCENARIO_SLICE="$(jq --arg s "$SCENARIO" --arg a "$ADAPTER" "
+  $JQ_MATCH
+  | .[]
+  | {name, description, coverage_id, idle_only, requires, verify, recipe: .by_adapter[\$a]}
+" "$SCENARIOS_JSON")"
+
+if [[ -z "$SCENARIO_SLICE" ]]; then
+  # The arg order here is <scenario-id> <adapter>, scenario first — the
+  # reverse of run-cell.sh / the dispatcher (`<agent> <scenario>`). If the
+  # first arg is an adapter slug, the caller most likely swapped them.
+  case "$SCENARIO" in
+    claudecode|codex|pi|aider|opencode)
+      fail "'$SCENARIO' is an adapter slug, not a scenario. Args are <scenario-id> <adapter> (scenario first) — did you swap them?" ;;
+    *)
+      fail "scenario not found in scenarios.json: $SCENARIO (run scenario-create first?)" ;;
+  esac
+fi
+
+# Canonical coverage id for the meanings + coverage lookups. Defaults to
+# name when no coverage_id is set; equals name for every recorded cell.
+COVERAGE_ID="$(jq -r --arg s "$SCENARIO" "
+  $JQ_MATCH
+  | .[0]
+  | if has(\"coverage_id\") and .coverage_id != null then .coverage_id else .name end
+" "$SCENARIOS_JSON")"
+
+# When the input is a scenario NAME whose coverage_id differs (the 7
+# name != coverage_id scenarios), the recipe below is this scenario's but
+# the meanings + coverage sections describe the shared coverage cell —
+# which may belong to a different same-coverage_id scenario. Warn so the
+# caller doesn't author a spec against a contradictory meaning. Pass the
+# coverage id (what the matrix + run-cell.sh use) for a consistent slice.
+if [[ "$COVERAGE_ID" != "$SCENARIO" ]]; then
+  echo "slice-cell: note — '$SCENARIO' resolves to coverage_id '$COVERAGE_ID'; the scenario-meanings and coverage sections below describe cell '$COVERAGE_ID', not '$SCENARIO' specifically. Pass the coverage id for a self-consistent slice." >&2
+fi
+
+echo "=== scenarios.json — $SCENARIO / $ADAPTER ==="
+echo "$SCENARIO_SLICE"
+echo
+
+# --- 2. scenario-meanings.md `### <coverage_id>` block -----------------
+# awk: print from the matching header up to (not including) the next `### `.
+MEANINGS_BLOCK="$(awk -v id="$COVERAGE_ID" '
+  $0 == "### " id { grab = 1; print; next }
+  grab && /^### / { exit }
+  grab { print }
+' "$MEANINGS_MD")"
+
+if [[ -z "$MEANINGS_BLOCK" ]]; then
+  fail "no '### $COVERAGE_ID' block in scenario-meanings.md (run scenario-create first?)"
+fi
+
+echo "=== scenario-meanings.md — ### $COVERAGE_ID ==="
+echo "$MEANINGS_BLOCK"
+echo
+
+# --- 3. agent-scenarios-coverage.json cell -----------------------------
+COVERAGE_CELL="$(jq --arg s "$COVERAGE_ID" --arg a "$ADAPTER" '
+  .scenarios[] | select(.id == $s) | .coverage[$a]
+' "$COVERAGE_JSON")"
+
+echo "=== agent-scenarios-coverage.json — $COVERAGE_ID / $ADAPTER ==="
+if [[ -z "$COVERAGE_CELL" || "$COVERAGE_CELL" == "null" ]]; then
+  echo '"no coverage entry for this (scenario, adapter) — flag to maintainer"'
+else
+  echo "$COVERAGE_CELL"
+fi

--- a/.claude/skills/ir:onboard-agent/spec/SKILL.md
+++ b/.claude/skills/ir:onboard-agent/spec/SKILL.md
@@ -91,15 +91,18 @@ Schema: one meta line + N phase lines.
 
 ## Steps
 
-### Step 1 — Read the prose spec
+### Step 1 — Slice the cell
 
 ```
-.specs/agent-scenarios.md
+.claude/skills/ir:onboard-agent/scripts/slice-cell.sh <scenario-id> <agent>
 ```
 
-Find the `### Feature:` heading whose kebab slug matches
-`<scenario-id>`. Capture every `Scenario:` paragraph and every
-`Expected:` bullet. The bullets are what each phase will assert.
+Read the `### <scenario-id>` scenario-meanings block from the output —
+its **User-observable signal** lines are what each phase will assert (one
+phase per signal). The slice also prints the recipe and coverage cell for
+context. If a richer `.specs/agent-scenarios.md` happens to be present
+(gitignored, usually absent), use its `Scenario:`/`Expected:` bullets for
+extra precision; the scenario-meanings signals are sufficient without it.
 
 ### Step 2 — One phase per Expected bullet
 

--- a/.claude/skills/ir:onboard-agent/step-grammar.md
+++ b/.claude/skills/ir:onboard-agent/step-grammar.md
@@ -1,0 +1,44 @@
+# Recipe step grammar
+
+The `script` array in a `by_adapter.<agent>` recipe is a list of step
+objects, each `{"type": "...", ...}`. The interactive drivers
+(`scripts/drive-<agent>-interactive.sh`) all dispatch on `type`. This is
+the shared vocabulary — author recipes against it instead of reverse-
+engineering the ~600-line driver. Stay inside it; an unknown `type` is
+logged and skipped.
+
+| type            | extra fields            | semantics                                                                 | drivers                          |
+|---              |---                      |---                                                                        |---                                |
+| `send`          | `text`                  | type `text` + Enter; bumps the expected-turn count                        | all interactive                  |
+| `slash`         | `text`                  | alias of `send` for `/cmd` slash commands                                 | all except opencode              |
+| `wait_turn`     | —                       | block until the agent finishes the current LLM round                      | all interactive                  |
+| `sleep`         | `seconds` (default `1`) | pause N seconds (idle dwell, lazy-transcript settle)                      | all interactive                  |
+| `interrupt`     | —                       | Escape (claudecode/codex/pi) or Ctrl-C (aider) mid-turn; un-bumps the turn count | all except opencode        |
+| `keys`          | `keys`                  | raw tmux key names, space-separated (e.g. `"Down Down Enter"`) for picker UIs like `/model` | claudecode, codex   |
+| `restart`       | —                       | kill current tmux, mint a new UUID + fresh cwd, re-init the session       | claudecode                       |
+| `resume`        | —                       | kill current tmux, relaunch the SAME UUID + cwd with `--resume`           | claudecode, codex                |
+| `reset_session` | —                       | in-app reset (`/clear`); keep the process alive, pick up the new UUID/transcript | claudecode, codex         |
+| `fork`          | —                       | `/fork`; clone the conversation into a new rollout (eager — materializes at once) | codex                    |
+| `sigkill`       | —                       | `kill -9` the agent process (forced termination)                          | claudecode                       |
+| `exit_clean`    | —                       | Ctrl-D to the TUI for a graceful shutdown                                 | claudecode, codex                |
+| `start_session` | `cwd` (optional)        | launch a concurrent session WITHOUT killing the current one (same cwd unless overridden) | claudecode        |
+| `session`       | `session` (slot N)      | switch focus to an existing session slot N (use after `start_session`)    | claudecode                       |
+
+Notes:
+
+- **Turn counting.** `send`/`slash` bump an expected-turn counter;
+  `wait_turn` blocks until the agent has completed that many turns;
+  `interrupt` decrements it (an interrupted turn never reaches `end_turn`).
+  Always pair each `send` with a later `wait_turn` (or an `interrupt`).
+- **Multi-variant / multi-session recordings.** `restart`, `sigkill`,
+  `exit_clean`, `resume`, `reset_session`, `start_session` are how one
+  recording chains several session lifetimes. The driver tracks every
+  session UUID across these so the curator can pull them all.
+- **Idle-only scenarios** (no prompts) use a single `sleep`-only script.
+- **opencode** has the narrowest driver — it implements only `send`,
+  `wait_turn`, and `sleep`. Any other step type aborts the recording, so
+  opencode recipes can't use interrupts, slash commands, or multi-session
+  steps.
+- Per-agent quirks (CLI flags, trust dialogs, exact key sequences for a
+  picker) live in the driver; if a step you need isn't in this table, ask
+  the maintainer rather than inventing a `type`.

--- a/.claude/skills/ir:onboard-agent/step-grammar.md
+++ b/.claude/skills/ir:onboard-agent/step-grammar.md
@@ -4,8 +4,9 @@ The `script` array in a `by_adapter.<agent>` recipe is a list of step
 objects, each `{"type": "...", ...}`. The interactive drivers
 (`scripts/drive-<agent>-interactive.sh`) all dispatch on `type`. This is
 the shared vocabulary — author recipes against it instead of reverse-
-engineering the ~600-line driver. Stay inside it; an unknown `type` is
-logged and skipped.
+engineering the ~600-line driver. Stay inside it: an unknown `type`
+**aborts the recording** — every driver logs it and exits non-zero
+(`nonzero(2)`), so a typo'd step won't silently no-op.
 
 | type            | extra fields            | semantics                                                                 | drivers                          |
 |---              |---                      |---                                                                        |---                                |


### PR DESCRIPTION
Closes #460.

## Problem

The `ir:onboard-agent` subagents each read three full catalogs (~80k tokens) to use ~1/44th of each, plus a ~600-line driver script for an 8-word step vocabulary — paid **per cell** across a matrix refresh.

## Changes

- **`scripts/slice-cell.sh <scenario-id> <adapter>`** — prints exactly three labeled sections (scenarios.json entry + that adapter's recipe, the `### <id>` scenario-meanings block, the coverage cell) and nothing else. **~324k chars → ~3.5k per cell (~92×).** Mirrors `run-cell.sh`'s name-first match, re-derives `coverage_id` for the meanings/coverage slices, and exits non-zero on a missing row (the STOP signal the SKILL.md steps already expect).
- **`step-grammar.md`** — the shared step vocabulary documented once, with each step's fields and accurate per-driver support.
- **Rewired `recipe`/`assess`/`spec` SKILL.md** to call the slicer + grammar doc instead of reading whole catalogs. Bonus: `spec` Step 1 no longer points at the gitignored/absent `.specs/agent-scenarios.md`.
- **`record`**: note only — `run-cell.sh` already jq-slices the recipe at the script level, so it never loads a whole catalog into model context.
- **`cell-lifecycle.md`**: folded its drifted inline step-type list into a pointer to `step-grammar.md` (single source).

## Notable design decisions

- The canonical `<scenario>` everywhere (fixture dirs, coverage.json, meanings headers) is the **coverage_id**, while `run-cell.sh` records by scenario **name** — and the two diverge for 7 scenarios. The slicer matches scenarios.json by name (mirroring the recorder), then re-derives that entry's `coverage_id` for the meanings/coverage sections so all three slices line up.

## Review hardening (from a high-effort self-review)

- Fixed two factual errors in the grammar table: `slash` is supported by all interactive drivers except opencode (not claudecode-only); `interrupt` aborts on opencode (which handles only `send`/`wait_turn`/`sleep`).
- Slicer now **warns** when a scenario *name* resolves to a different `coverage_id` (avoids authoring a spec against a contradictory meaning for the 7 divergent scenarios).
- Slicer **detects swapped `<adapter> <scenario>` args** (it's scenario-first, unlike `run-cell.sh`) and fails with a clear message instead of a misleading "run scenario-create".

## Testing

- `bash -n` clean; `shellcheck` unavailable on this machine.
- Byte-equivalence verified: each slice (recipe, verify, meanings block, coverage cell) diffs IDENTICAL against direct jq/awk on the full files.
- Smoke-tested across all five adapters + a multi-variant scenario; error/STOP, arg-swap, and shadow-name-warning paths all confirmed.
- Live `assess`/`recipe` runs left as the maintainer's final gate (they invoke real agent CLIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)