### PR TITLE
fix(viewer): serve dashboard's irrlicht.css/js so recording preview is styled (#459)

### DIFF
--- a/tools/agent-onboarding/internal/viewer/playback.go
+++ b/tools/agent-onboarding/internal/viewer/playback.go
@@ -465,14 +465,10 @@ func (m *PlaybackManager) registerPlaybackRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/sessions/stream", m.hub.ServeWS)
 
 	mux.HandleFunc("GET /dashboard", m.handleDashboard)
-
-	// Dashboard sibling assets. index.html references irrlicht.css/js
-	// relatively (split out of the former inline <style>/<script> in
-	// #418), so the iframe requests them at the server root. Serve them
-	// from <repoRoot>/platforms/web/ — mirroring handleDashboard's
-	// read-from-disk approach — or the preview renders unstyled.
-	mux.HandleFunc("GET /irrlicht.css", m.handleWebAsset)
-	mux.HandleFunc("GET /irrlicht.js", m.handleWebAsset)
+	// The dashboard's sibling assets (irrlicht.css/js, referenced
+	// relatively from index.html since #418) are served by the "/"
+	// catch-all's platforms/web/ fallback in Server.staticHandler — no
+	// per-asset route needed here.
 }
 
 type startReq struct {
@@ -715,17 +711,6 @@ func (m *PlaybackManager) handleDashboard(w http.ResponseWriter, r *http.Request
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(html))
-}
-
-// handleWebAsset serves a sibling of the dashboard's index.html (e.g.
-// irrlicht.css, irrlicht.js) from <repoRoot>/platforms/web/. Reads from
-// disk at request time like handleDashboard so a `git pull` Just Works.
-// filepath.Base pins the request to a single file under platforms/web/,
-// so the fixed-path routes can never traverse out of that directory;
-// http.ServeFile sets Content-Type from the extension and 404s a miss.
-func (m *PlaybackManager) handleWebAsset(w http.ResponseWriter, r *http.Request) {
-	name := filepath.Base(r.URL.Path)
-	http.ServeFile(w, r, filepath.Join(m.repoRoot, "platforms", "web", name))
 }
 
 // handleDiag returns the recent broadcast log captured by the

--- a/tools/agent-onboarding/internal/viewer/playback.go
+++ b/tools/agent-onboarding/internal/viewer/playback.go
@@ -465,6 +465,14 @@ func (m *PlaybackManager) registerPlaybackRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/sessions/stream", m.hub.ServeWS)
 
 	mux.HandleFunc("GET /dashboard", m.handleDashboard)
+
+	// Dashboard sibling assets. index.html references irrlicht.css/js
+	// relatively (split out of the former inline <style>/<script> in
+	// #418), so the iframe requests them at the server root. Serve them
+	// from <repoRoot>/platforms/web/ — mirroring handleDashboard's
+	// read-from-disk approach — or the preview renders unstyled.
+	mux.HandleFunc("GET /irrlicht.css", m.handleWebAsset)
+	mux.HandleFunc("GET /irrlicht.js", m.handleWebAsset)
 }
 
 type startReq struct {
@@ -707,6 +715,17 @@ func (m *PlaybackManager) handleDashboard(w http.ResponseWriter, r *http.Request
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write([]byte(html))
+}
+
+// handleWebAsset serves a sibling of the dashboard's index.html (e.g.
+// irrlicht.css, irrlicht.js) from <repoRoot>/platforms/web/. Reads from
+// disk at request time like handleDashboard so a `git pull` Just Works.
+// filepath.Base pins the request to a single file under platforms/web/,
+// so the fixed-path routes can never traverse out of that directory;
+// http.ServeFile sets Content-Type from the extension and 404s a miss.
+func (m *PlaybackManager) handleWebAsset(w http.ResponseWriter, r *http.Request) {
+	name := filepath.Base(r.URL.Path)
+	http.ServeFile(w, r, filepath.Join(m.repoRoot, "platforms", "web", name))
 }
 
 // handleDiag returns the recent broadcast log captured by the

--- a/tools/agent-onboarding/internal/viewer/playback_test.go
+++ b/tools/agent-onboarding/internal/viewer/playback_test.go
@@ -49,6 +49,9 @@ test dashboard
 	os.WriteFile(filepath.Join(dashboardDir, "index.html"), []byte(indexHTML), 0o644)
 	os.WriteFile(filepath.Join(dashboardDir, "irrlicht.css"), []byte(":root{--marker:css}"), 0o644)
 	os.WriteFile(filepath.Join(dashboardDir, "irrlicht.js"), []byte("export const marker = 'js';"), 0o644)
+	// An arbitrarily-named sibling: the viewer serves platforms/web/ as a
+	// fallback, so any dashboard asset resolves — not just irrlicht.css/js.
+	os.WriteFile(filepath.Join(dashboardDir, "vendor.css"), []byte(".vendor{--marker:vendor}"), 0o644)
 	return root
 }
 
@@ -112,9 +115,10 @@ func TestPlayback_startEndToEnd(t *testing.T) {
 }
 
 // TestPlayback_servesDashboardAssets guards #459: the dashboard's
-// index.html references irrlicht.css/js relatively, so the viewer must
-// serve those siblings from platforms/web/ or the recording preview
-// renders unstyled (the iframe 404s the assets).
+// index.html references its assets relatively, so the viewer must serve
+// the platforms/web/ siblings or the recording preview renders unstyled
+// (the iframe 404s the assets). The vendor.css case proves the fallback
+// resolves any sibling, not just the irrlicht.css/js pair.
 func TestPlayback_servesDashboardAssets(t *testing.T) {
 	root := fixtureRoot(t)
 	s := &Server{RepoRoot: root}
@@ -127,6 +131,7 @@ func TestPlayback_servesDashboardAssets(t *testing.T) {
 	}{
 		{"/irrlicht.css", "--marker:css", "text/css"},
 		{"/irrlicht.js", "marker = 'js'", "javascript"},
+		{"/vendor.css", "--marker:vendor", "text/css"},
 	}
 	for _, tc := range cases {
 		rr := httptest.NewRecorder()
@@ -141,6 +146,18 @@ func TestPlayback_servesDashboardAssets(t *testing.T) {
 		if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, tc.wantCTParts) {
 			t.Errorf("%s: Content-Type=%q want substring %q", tc.path, ct, tc.wantCTParts)
 		}
+	}
+
+	// The platforms/web/ fallback must not shadow the embedded viewer SPA:
+	// GET / serves the embedded index.html (the Recording Viewer), never
+	// the fixture's platforms/web/index.html "test dashboard" marker.
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest("GET", "/", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /: status=%d", rr.Code)
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "Recording Viewer") || strings.Contains(body, "test dashboard") {
+		t.Errorf("GET / should serve the embedded viewer SPA, not the dashboard fixture: %.120q", body)
 	}
 }
 

--- a/tools/agent-onboarding/internal/viewer/playback_test.go
+++ b/tools/agent-onboarding/internal/viewer/playback_test.go
@@ -29,10 +29,26 @@ func fixtureRoot(t *testing.T) string {
 	if err := os.WriteFile(filepath.Join(scenarioDir, "events.jsonl"), []byte(events), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// platforms/web/index.html — minimal so dashboard handler can serve.
+	// platforms/web/{index.html,irrlicht.css,irrlicht.js} — a realistic
+	// dashboard tree: index.html references its siblings relatively (as
+	// the real one does since #418), so the viewer must serve the assets
+	// too or the iframe renders unstyled (#459). The "test dashboard"
+	// marker is kept for TestPlayback_startEndToEnd's body assertion.
 	dashboardDir := filepath.Join(root, "platforms", "web")
 	os.MkdirAll(dashboardDir, 0o755)
-	os.WriteFile(filepath.Join(dashboardDir, "index.html"), []byte("<html>test dashboard</html>"), 0o644)
+	indexHTML := `<!DOCTYPE html>
+<html>
+<head>
+<link rel="stylesheet" href="irrlicht.css">
+</head>
+<body>
+test dashboard
+<script type="module" src="irrlicht.js"></script>
+</body>
+</html>`
+	os.WriteFile(filepath.Join(dashboardDir, "index.html"), []byte(indexHTML), 0o644)
+	os.WriteFile(filepath.Join(dashboardDir, "irrlicht.css"), []byte(":root{--marker:css}"), 0o644)
+	os.WriteFile(filepath.Join(dashboardDir, "irrlicht.js"), []byte("export const marker = 'js';"), 0o644)
 	return root
 }
 
@@ -92,6 +108,39 @@ func TestPlayback_startEndToEnd(t *testing.T) {
 	h.ServeHTTP(rr, httptest.NewRequest("POST", "/api/replay/stop", nil))
 	if rr.Code != http.StatusNoContent {
 		t.Errorf("stop status: %d", rr.Code)
+	}
+}
+
+// TestPlayback_servesDashboardAssets guards #459: the dashboard's
+// index.html references irrlicht.css/js relatively, so the viewer must
+// serve those siblings from platforms/web/ or the recording preview
+// renders unstyled (the iframe 404s the assets).
+func TestPlayback_servesDashboardAssets(t *testing.T) {
+	root := fixtureRoot(t)
+	s := &Server{RepoRoot: root}
+	h := s.Handler()
+
+	cases := []struct {
+		path        string
+		wantBody    string
+		wantCTParts string
+	}{
+		{"/irrlicht.css", "--marker:css", "text/css"},
+		{"/irrlicht.js", "marker = 'js'", "javascript"},
+	}
+	for _, tc := range cases {
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, httptest.NewRequest("GET", tc.path, nil))
+		if rr.Code != http.StatusOK {
+			t.Errorf("%s: status=%d body=%s", tc.path, rr.Code, rr.Body)
+			continue
+		}
+		if !strings.Contains(rr.Body.String(), tc.wantBody) {
+			t.Errorf("%s: body %q missing %q", tc.path, rr.Body, tc.wantBody)
+		}
+		if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, tc.wantCTParts) {
+			t.Errorf("%s: Content-Type=%q want substring %q", tc.path, ct, tc.wantCTParts)
+		}
 	}
 }
 

--- a/tools/agent-onboarding/internal/viewer/server.go
+++ b/tools/agent-onboarding/internal/viewer/server.go
@@ -25,6 +25,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -78,7 +79,17 @@ func (s *Server) Handler() http.Handler {
 	return mux
 }
 
-// staticHandler serves the embedded web/ tree at /.
+// staticHandler serves the viewer SPA from the embedded web/ tree at /,
+// falling back to the on-disk dashboard tree (platforms/web/) for any
+// path the embedded tree doesn't carry.
+//
+// The /dashboard iframe loads platforms/web/index.html, whose assets are
+// referenced relatively (irrlicht.css/js, split out in #418), so the
+// browser requests them at the server root — e.g. GET /irrlicht.css.
+// Serving platforms/web/ as a fallback resolves the whole sibling set
+// without hardcoding asset names, mirroring how the production daemon
+// serves that directory. Embedded wins on overlap (e.g. index.html) so
+// the viewer's own SPA is never shadowed.
 func (s *Server) staticHandler() http.Handler {
 	sub, err := fs.Sub(webFS, "web")
 	if err != nil {
@@ -87,7 +98,29 @@ func (s *Server) staticHandler() http.Handler {
 			http.Error(w, "embedded UI unavailable", http.StatusInternalServerError)
 		})
 	}
-	return http.FileServerFS(sub)
+	embedded := http.FileServerFS(sub)
+	disk := http.FileServer(http.Dir(filepath.Join(s.RepoRoot, "platforms", "web")))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if embeddedHas(sub, r.URL.Path) {
+			embedded.ServeHTTP(w, r)
+			return
+		}
+		disk.ServeHTTP(w, r)
+	})
+}
+
+// embeddedHas reports whether the embedded viewer FS carries a regular
+// file for urlPath (root maps to index.html). Used to give the embedded
+// SPA priority over the on-disk platforms/web/ fallback. http.Dir in the
+// disk handler guards traversal independently, so this only decides which
+// tree wins, not access control.
+func embeddedHas(fsys fs.FS, urlPath string) bool {
+	name := strings.TrimPrefix(path.Clean(urlPath), "/")
+	if name == "" || name == "." {
+		name = "index.html"
+	}
+	info, err := fs.Stat(fsys, name)
+	return err == nil && !info.IsDir()
 }
 
 // handleCatalog serves the maintainer-curated scenario coverage


### PR DESCRIPTION
## Problem

Playing a recording in the onboarding/replay viewer rendered the embedded dashboard **unstyled** — no CSS, raw HTML. Closes #459.

The viewer serves `platforms/web/index.html` at `GET /dashboard`, but had no way to serve its sibling assets. Since #418 split the dashboard's inline `<style>`/`<script>` into `irrlicht.css`/`irrlicht.js` referenced **relatively**, the iframe's requests for `/irrlicht.css` and `/irrlicht.js` fell through to the catch-all `/` handler (which serves the embedded *viewer* `web/` tree, not the dashboard assets) → **404** → unstyled preview.

This is viewer-only. The production daemon serves all of `platforms/web/` as a directory, so the real dashboard was unaffected.

## Fix

Make the `/` catch-all (`Server.staticHandler`) serve the embedded viewer SPA first and **fall back to `platforms/web/` on disk** for any path the embedded tree doesn't carry:

- Resolves the *whole* dashboard sibling set, not just `irrlicht.css`/`irrlicht.js` — a future relative asset can't silently 404 and reintroduce #459. Mirrors how the production daemon serves that directory.
- `embeddedHas()` gives the embedded SPA priority on overlap (e.g. `index.html`), so `GET /` still serves the viewer, never `platforms/web/index.html`.
- `http.Dir` guards path traversal on the fallback.

(Earlier in this branch this was two hard-coded `GET /irrlicht.css|js` routes; that was generalized to the directory fallback to avoid the per-asset allowlist.)

## Test

`fixtureRoot` now writes a realistic `index.html` (relative asset links, keeping the `test dashboard` marker the existing test asserts) plus `irrlicht.css`/`irrlicht.js` and an arbitrarily-named `vendor.css`. `TestPlayback_servesDashboardAssets` asserts all three return **200** with the fixture content and a sensible `Content-Type` (the `vendor.css` case proves the fallback isn't limited to two names), and guards that `GET /` serves the embedded viewer SPA rather than the dashboard fixture. **Fails (404) before the fix, passes after** — verified by stashing the change.

## Verification

- `go test ./core/... ./tools/agent-onboarding/... -race -count=1` — green
- `tools/replay-fixtures.sh` — all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)