### PR TITLE
fix(codex): treat turn_aborted as turn-end so interrupted turns settle (#453)

### DIFF
--- a/core/adapters/inbound/agents/codex/parser.go
+++ b/core/adapters/inbound/agents/codex/parser.go
@@ -154,16 +154,21 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 
 	case "event_msg":
 		// Most event_msg payloads are metadata (token_count, task_started,
-		// exec_command_*) that we skip. The one exception is `task_complete`:
-		// this is Codex's canonical "turn finished" signal and must be emitted
-		// as `turn_done` so IsAgentDone() fires via the primary path.
+		// exec_command_*) that we skip. Two payloads signal a turn boundary
+		// and must be emitted as `turn_done` so IsAgentDone() fires via the
+		// primary path: `task_complete` (the canonical "turn finished" signal)
+		// and `turn_aborted` (the turn was cancelled via ESC or errored
+		// mid-flight — Codex emits it *instead of* task_complete, so without
+		// it an interrupted turn never settles and the session sticks in
+		// `working` until the process exits or an idle sweep fires).
 		//
-		// Without this, codex falls into the assistant_message fallback and
+		// Treating task_complete as terminal also prevents flicker: codex
+		// falls into the assistant_message fallback otherwise and
 		// flickers working→ready→working every time the agent writes an
 		// intermediate assistant message before calling a tool (typical at
 		// the start of a turn).
 		if payload, ok := raw["payload"].(map[string]interface{}); ok {
-			if pt, _ := payload["type"].(string); pt == "task_complete" {
+			if pt, _ := payload["type"].(string); pt == "task_complete" || pt == "turn_aborted" {
 				ev.EventType = "turn_done"
 				return ev
 			}

--- a/core/adapters/inbound/agents/codex/parser_test.go
+++ b/core/adapters/inbound/agents/codex/parser_test.go
@@ -573,6 +573,104 @@ func TestParser_TurnCompleteEmitsTurnDone(t *testing.T) {
 	}
 }
 
+// TestParser_TurnAbortedEmitsTurnDone is a regression test for #453: codex
+// emits `event_msg/turn_aborted` (no task_complete) when a turn is cancelled
+// (user ESC) or errors mid-flight. The parser must treat it as a turn-end
+// signal — map it to LastEventType == "turn_done" — so the interrupted turn
+// settles instead of sticking in `working` until the process exits.
+func TestParser_TurnAbortedEmitsTurnDone(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"timestamp": ts(0),
+		"type":      "event_msg",
+		"payload": map[string]interface{}{
+			"type":         "turn_aborted",
+			"turn_id":      "019e3291-4d64-7e80-b513-d0a57d8169c1",
+			"reason":       "interrupted",
+			"completed_at": float64(1778964847),
+			"duration_ms":  float64(4011),
+		},
+	})
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if ev.Skip {
+		t.Fatal("turn_aborted must not be skipped; it is a turn-end signal")
+	}
+	if ev.EventType != "turn_done" {
+		t.Errorf("EventType = %q, want turn_done", ev.EventType)
+	}
+}
+
+// TestParser_InterruptedTurnSettles drives the full interrupted-turn shape as
+// recorded from a real codex session: a turn opens (assistant message + a
+// function call with no matching output because the user hit ESC), then codex
+// writes the synthetic <turn_aborted> user message and the
+// event_msg/turn_aborted boundary. End-to-end through the tailer this must
+// leave LastEventType == "turn_done" so the session settles to ready rather
+// than freezing in working (#453).
+func TestParser_InterruptedTurnSettles(t *testing.T) {
+	path := writeLines(t, []map[string]interface{}{
+		{
+			"timestamp": ts(0),
+			"type":      "turn_context",
+			"payload":   map[string]interface{}{"model": "gpt-5.2-codex"},
+		},
+		{
+			"timestamp": ts(1),
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type": "message",
+				"role": "assistant",
+				"content": []interface{}{
+					map[string]interface{}{"type": "output_text", "text": "running a long command"},
+				},
+			},
+		},
+		// Tool call opens but is never answered — the user interrupted it.
+		{
+			"timestamp": ts(2),
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type":    "function_call",
+				"name":    "shell",
+				"call_id": "call_interrupted",
+			},
+		},
+		// Synthetic user message codex injects after an interrupt.
+		{
+			"timestamp": ts(3),
+			"type":      "response_item",
+			"payload": map[string]interface{}{
+				"type": "message",
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "input_text", "text": "<turn_aborted>\nThe user interrupted the previous turn on purpose.\n</turn_aborted>"},
+				},
+			},
+		},
+		// The turn boundary: no task_complete, only turn_aborted.
+		{
+			"timestamp": ts(4),
+			"type":      "event_msg",
+			"payload": map[string]interface{}{
+				"type":    "turn_aborted",
+				"turn_id": "019e3291-4d64-7e80-b513-d0a57d8169c1",
+				"reason":  "interrupted",
+			},
+		},
+	})
+
+	tl := tailer.NewTranscriptTailer(path, &Parser{}, "codex")
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.LastEventType != "turn_done" {
+		t.Errorf("LastEventType = %q, want turn_done (interrupted turn must settle)", m.LastEventType)
+	}
+}
+
 func TestParser_ProposedPlan_SynthesizesExitPlanMode(t *testing.T) {
 	p := &Parser{}
 	ev := p.ParseLine(map[string]interface{}{

--- a/replaydata/agents/codex/scenarios/interrupted-turn/recordings/2026-05-14-23-36-59_irrlichd-dev/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/interrupted-turn/recordings/2026-05-14-23-36-59_irrlichd-dev/transcript.jsonl.replay.json.golden
@@ -10,17 +10,23 @@
   "summary": {
     "total_events": 20,
     "consumed_events": 20,
-    "total_transitions": 3,
+    "total_transitions": 5,
     "first_event_time": "2026-05-14T21:37:13.049Z",
     "last_event_time": "2026-05-14T21:37:49.083Z",
     "wall_clock_session_duration": 36034000000,
     "state_durations": {
-      "ready": 220000000,
-      "working": 35814000000
+      "ready": 4613000000,
+      "working": 31421000000
     },
-    "flicker_count": 0,
-    "flickers_by_category": {},
-    "flickers_by_reason": {},
+    "flicker_count": 2,
+    "flickers_by_category": {
+      "ready_between_working": 1,
+      "working_between_ready": 1
+    },
+    "flickers_by_reason": {
+      "agent finished turn → ready": 1,
+      "force ready→working on first activity": 1
+    },
     "estimated_cost_usd": 0.0679875,
     "cum_input_tokens": 27045,
     "cum_output_tokens": 25,
@@ -57,6 +63,34 @@
     },
     {
       "index": 2,
+      "event_index": 9,
+      "virtual_time": "2026-05-14T21:37:17.03Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 3,
+      "event_index": 13,
+      "virtual_time": "2026-05-14T21:37:21.423Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "user_message",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 4,
       "event_index": 19,
       "virtual_time": "2026-05-14T21:37:49.083Z",
       "cause": "debounce_coalesce",

--- a/replaydata/agents/codex/scenarios/interrupted-turn/recordings/2026-05-16-18-49-32_irrlichd-dev/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/interrupted-turn/recordings/2026-05-16-18-49-32_irrlichd-dev/transcript.jsonl.replay.json.golden
@@ -10,17 +10,23 @@
   "summary": {
     "total_events": 21,
     "consumed_events": 21,
-    "total_transitions": 3,
+    "total_transitions": 5,
     "first_event_time": "2026-05-16T16:49:48.292Z",
     "last_event_time": "2026-05-16T16:50:23.871Z",
     "wall_clock_session_duration": 35579000000,
     "state_durations": {
-      "ready": 298000000,
-      "working": 35281000000
+      "ready": 4671000000,
+      "working": 30908000000
     },
-    "flicker_count": 0,
-    "flickers_by_category": {},
-    "flickers_by_reason": {},
+    "flicker_count": 2,
+    "flickers_by_category": {
+      "ready_between_working": 1,
+      "working_between_ready": 1
+    },
+    "flickers_by_reason": {
+      "agent finished turn → ready": 1,
+      "force ready→working on first activity": 1
+    },
     "estimated_cost_usd": 0.14643,
     "cum_input_tokens": 29190,
     "cum_output_tokens": 16,
@@ -57,6 +63,34 @@
     },
     {
       "index": 2,
+      "event_index": 10,
+      "virtual_time": "2026-05-16T16:49:52.263Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 3,
+      "event_index": 14,
+      "virtual_time": "2026-05-16T16:49:56.636Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "user_message",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 4,
       "event_index": 20,
       "virtual_time": "2026-05-16T16:50:23.871Z",
       "cause": "debounce_coalesce",

--- a/replaydata/agents/codex/scenarios/interrupted-turn/recordings/2026-05-16-22-53-47_irrlichd-0.3.13+4662be4/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/interrupted-turn/recordings/2026-05-16-22-53-47_irrlichd-0.3.13+4662be4/transcript.jsonl.replay.json.golden
@@ -10,17 +10,23 @@
   "summary": {
     "total_events": 21,
     "consumed_events": 21,
-    "total_transitions": 3,
+    "total_transitions": 5,
     "first_event_time": "2026-05-16T20:54:03.934Z",
     "last_event_time": "2026-05-16T20:54:41.019Z",
     "wall_clock_session_duration": 37085000000,
     "state_durations": {
-      "ready": 250000000,
-      "working": 36835000000
+      "ready": 4639000000,
+      "working": 32446000000
     },
-    "flicker_count": 0,
-    "flickers_by_category": {},
-    "flickers_by_reason": {},
+    "flicker_count": 2,
+    "flickers_by_category": {
+      "ready_between_working": 1,
+      "working_between_ready": 1
+    },
+    "flickers_by_reason": {
+      "agent finished turn → ready": 1,
+      "force ready→working on first activity": 1
+    },
     "estimated_cost_usd": 0.147445,
     "cum_input_tokens": 29417,
     "cum_output_tokens": 12,
@@ -57,6 +63,34 @@
     },
     {
       "index": 2,
+      "event_index": 10,
+      "virtual_time": "2026-05-16T20:54:07.895Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 3,
+      "event_index": 14,
+      "virtual_time": "2026-05-16T20:54:12.284Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "user_message",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 4,
       "event_index": 20,
       "virtual_time": "2026-05-16T20:54:41.019Z",
       "cause": "debounce_coalesce",

--- a/replaydata/agents/codex/scenarios/interrupted-turn/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/interrupted-turn/transcript.jsonl.replay.json.golden
@@ -10,17 +10,23 @@
   "summary": {
     "total_events": 20,
     "consumed_events": 20,
-    "total_transitions": 3,
+    "total_transitions": 5,
     "first_event_time": "2026-05-16T20:57:12.532Z",
     "last_event_time": "2026-05-16T20:59:14.457Z",
     "wall_clock_session_duration": 121925000000,
     "state_durations": {
-      "ready": 692000000,
-      "working": 121233000000
+      "ready": 5064000000,
+      "working": 116861000000
     },
-    "flicker_count": 0,
-    "flickers_by_category": {},
-    "flickers_by_reason": {},
+    "flicker_count": 2,
+    "flickers_by_category": {
+      "ready_between_working": 1,
+      "working_between_ready": 1
+    },
+    "flickers_by_reason": {
+      "agent finished turn → ready": 1,
+      "force ready→working on first activity": 1
+    },
     "estimated_cost_usd": 0.147535,
     "cum_input_tokens": 29417,
     "cum_output_tokens": 15,
@@ -57,6 +63,34 @@
     },
     {
       "index": 2,
+      "event_index": 9,
+      "virtual_time": "2026-05-16T20:57:16.498Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 3,
+      "event_index": 13,
+      "virtual_time": "2026-05-16T20:57:20.87Z",
+      "cause": "debounce_coalesce",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "user_message",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 4,
       "event_index": 19,
       "virtual_time": "2026-05-16T20:59:14.457Z",
       "cause": "debounce_coalesce",


### PR DESCRIPTION
## Problem

Fixes #453. The codex parser (`core/adapters/inbound/agents/codex/parser.go`) only treated `event_msg/task_complete` as a turn-end signal. Codex emits `event_msg/turn_aborted` **instead of** `task_complete` when a turn is cancelled (ESC) or errors mid-flight, so an aborted turn never produced a `turn_done` — the session stuck in `working` until the process exited or an idle sweep fired.

## Fix

One condition now maps both `task_complete` and `turn_aborted` to `turn_done`:

```go
if pt, _ := payload["type"].(string); pt == "task_complete" || pt == "turn_aborted" {
    ev.EventType = "turn_done"
    return ev
}
```

Downstream, the tailer's `turn_done` sweep (`tailer.go:860`) clears any dangling non-user-blocking open tool call, so even an **error**-abort with an unanswered `function_call` (and no synthetic user message to clear it) settles cleanly to `ready` — verified by tracing the lifecycle path.

## Tests

- **`TestParser_TurnAbortedEmitsTurnDone`** — unit: a `turn_aborted` payload is not skipped and emits `turn_done`.
- **`TestParser_InterruptedTurnSettles`** — end-to-end through the tailer using the real recorded interrupted-turn shape (assistant msg → orphan tool call → `<turn_aborted>` user msg → `turn_aborted` boundary).

Both fail with the fix reverted (the turn ends as `user_message`, stuck in `working`).

Regenerated the four codex `interrupted-turn` replay goldens, which now show the `working → ready` settle (3 → 5 transitions, `is_agent_done: true`).

## Verification

- `go test ./core/... -race -count=1` — green
- `tools/replay-fixtures.sh` — green

## Follow-up (not in this PR)

Dropping `known_failing` on the `interrupted-turn` scenario and recording `user-esc-interrupt` / `turn-aborted-by-error` requires re-recording against a daemon with this fix via the `ir:onboard-agent` pipeline — the validator checks each scenario's recorded `events.jsonl` (captured at record time), not the re-parsed transcript, so the parser fix alone can't retroactively change those recordings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)