### PR TITLE
fix(ci): use three-dot diff in replaydata deletion guard

### DIFF
--- a/.github/workflows/replaydata-deletion-guard.yml
+++ b/.github/workflows/replaydata-deletion-guard.yml
@@ -35,14 +35,21 @@ jobs:
           set -euo pipefail
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
-          echo "Comparing base $base ..head $head"
+          echo "Comparing merge-base($base, $head) ...head $head"
 
+          # Three-dot (base...head) diffs from the MERGE BASE of the two commits
+          # to head, i.e. only what this PR branch actually changed since it
+          # forked. A two-dot diff (base head) would also surface files added to
+          # the base branch AFTER the fork point as phantom "deletions" whenever
+          # the PR branch is behind base — a false positive that fails the guard
+          # on stale branches that never touched replaydata at all.
+          #
           # --diff-filter=D selects deletions only.
           # `git diff` treats a rename as a (D, A) pair only if -M is below the
           # threshold; with -M (the default for `git diff`) renames stay as
           # renames and do NOT count as deletions. We pass --find-renames=50%
           # explicitly so the threshold is documented and stable.
-          deletions=$(git diff --name-only --diff-filter=D --find-renames=50% "$base" "$head" -- \
+          deletions=$(git diff --name-only --diff-filter=D --find-renames=50% "$base...$head" -- \
             'replaydata/agents/*/scenarios/*' \
             'replaydata/agents/*/regression/*' \
             'replaydata/orchestrators/*/scenarios/*' \


### PR DESCRIPTION
## Problem

The replaydata deletion guard failed on [run 26369882597](https://github.com/ingo-eichhorst/Irrlicht/actions/runs/26369882597) for PR #464 — a **codex-only** fix that never touched `replaydata/`. The guard reported `claudecode` and `opencode` `task-list` scenarios as "deleted load-bearing recording files."

Root cause: the guard used a **two-dot** diff:

```sh
git diff --name-only --diff-filter=D ... "$base" "$head"
```

A two-dot `base head` diff surfaces *every* difference between the base-branch tip and the PR head — including files added to main **after** the PR branch's fork point. PR #464 branched from `83509be5`, before the `task-list` scenarios landed in #458, so comparing it against recent main made those fixtures look deleted. They were never on the branch to delete; they just hadn't been merged in yet. (The squash-merge onto current main was clean — main retains every fixture. The red guard was purely a comparison artifact, and the PR was merged through it.)

## Fix

Switch to a **three-dot** diff:

```sh
git diff --name-only --diff-filter=D ... "$base...$head"
```

Three-dot diffs from the **merge-base** of `base` and `head` to `head` — exactly what the PR branch changed since it forked, which is the same semantics GitHub's own "Files changed" view uses. Phantom deletions from a stale branch disappear; real deletions on the branch are still reported.

`actions/checkout@v4` with `fetch-depth: 0` fetches all history for all branches and tags, so the merge-base is always present.

## Verification

Against repo history:

- **False positive gone** — `base...head` for run 26369882597's SHAs lists zero deletions (two-dot listed all six task-list files).
- **Real deletions still caught** — `base...head` across #458 (the `task-tool`/`todowrite` → `task-list` consolidation, a genuine fixture removal) still reports the deleted files under `--diff-filter=D`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)