### PR TITLE
chore(test-mac): add restore-prod.sh teardown + relaunch script

### DIFF
--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -232,16 +232,27 @@ user chooses up front:
    production UI against the dev `--record` daemon without realizing it. So to
    return to production: quit the dev app, then explicitly kill the daemon and
    confirm the port is free *before* relaunching production.
+
+   Use the bundled **`restore-prod.sh`** — it does the whole sequence (kill dev
+   app → kill dev daemon → GATE on 7837 actually freeing → launch
+   `/Applications/Irrlicht.app` → confirm prod's own daemon comes up). Note: the
+   installer does NOT replace this teardown — it swaps the app bundle but leaves
+   the dev daemon running on 7837, which the new prod app would still adopt; run
+   this script (or at least the `pkill -x irrlichd`) regardless.
+   ```bash
+   "$(git rev-parse --show-toplevel)/.claude/skills/ir:test-mac/restore-prod.sh"
+   ```
+   Equivalent by hand, if you want to see each step:
    ```bash
    pkill -f "IrrlichtDev" 2>/dev/null     # quit the dev app
    pkill -x "irrlichd"    2>/dev/null     # stop the adopted dev daemon (the app won't)
    sleep 1
-   lsof -iTCP:7837 -sTCP:LISTEN -P -n 2>/dev/null && echo "WARNING: 7837 still held — production will adopt whatever is there" || echo "7837 free — safe to relaunch /Applications/Irrlicht.app"
+   lsof -iTCP:7837 -sTCP:LISTEN -P -n 2>/dev/null && echo "WARNING: 7837 still held — production will adopt whatever is there" || open /Applications/Irrlicht.app
    ```
 
 ## Notes
 - **separate mode — production keeps running.** The production Irrlicht.app (from DMG) and its bundled daemon stay on port 7837 with state under `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/`. The dev instance binds port 7838 and routes its WRITTEN state — socket, recordings, history, session store, ledgers, and cost store — beneath `IRRLICHT_HOME=$DEV_HOME`, so it never prunes or mutates production's session/cost data. The dev app reaches the dev daemon because `IRRLICHT_DAEMON_PORT` (via `open --env`) overrides the hardcoded default; `DaemonManager` also skips its global `pkill` when a custom port is set, so it can't take production down.
 - **separate mode shares with production:** it reads the same `~/.claude` transcripts (so the dev UI shows the same live sessions) and appends to the same `~/Library/Application Support/Irrlicht/logs/events.log`. It does NOT share the on-disk session/ledger/cost stores — and it does NOT receive the statusline quota feed (that hook posts only to 7837), so the subscription panel shows its empty-state.
-- **replace mode — single instance on production's footprint.** Runs the dev binaries on port 7837 with the production state dir (no `IRRLICHT_HOME`), so the statusline quota feed and the production session/cost/ledger stores all apply. Because the dev daemon runs with `--record`, recordings land in the production recordings dir (`~/.local/share/irrlicht/recordings/`). **⚠️ The dev daemon mutates production data.** Without `IRRLICHT_HOME` its startup sweeps (`PruneStale` / dead-proc / orphan-ledger / cost prune) run against the real `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/` stores — this is exactly the isolation #448 added, deliberately removed here. Only use replace mode when the dev build's on-disk schema matches the installed production build; a dev branch mid-migration can prune or rewrite production sessions/ledgers/cost rows that the production binary then misreads. **Returning to production requires the step-9 teardown** — quitting the app does NOT stop the adopted daemon, and a relaunched production app will silently adopt the leftover dev daemon on 7837 if you skip it.
+- **replace mode — single instance on production's footprint.** Runs the dev binaries on port 7837 with the production state dir (no `IRRLICHT_HOME`), so the statusline quota feed and the production session/cost/ledger stores all apply. Because the dev daemon runs with `--record`, recordings land in the production recordings dir (`~/.local/share/irrlicht/recordings/`). **⚠️ The dev daemon mutates production data.** Without `IRRLICHT_HOME` its startup sweeps (`PruneStale` / dead-proc / orphan-ledger / cost prune) run against the real `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/` stores — this is exactly the isolation #448 added, deliberately removed here. Only use replace mode when the dev build's on-disk schema matches the installed production build; a dev branch mid-migration can prune or rewrite production sessions/ledgers/cost rows that the production binary then misreads. **Returning to production requires the step-9 teardown** (run `restore-prod.sh`) — quitting the app does NOT stop the adopted daemon, and a relaunched (or freshly *reinstalled*) production app will silently adopt the leftover dev daemon on 7837 if you skip it. Running the installer is not a substitute: it replaces the app bundle, not the running daemon.
 - Daemon logs: `/tmp/irrlichd-dev.log` · Swift app logs: `/tmp/irrlicht-app-dev.log`
 - **TCC stability**: run `tools/dev-sign-setup.sh` once to install the `"Irrlicht Dev"` self-signed code signing identity. The skill automatically signs with it when present, giving the app a stable designated requirement so Accessibility/Automation grants persist across rebuilds. Without it, every rebuild invalidates TCC and requires re-granting in System Settings.

--- a/.claude/skills/ir:test-mac/restore-prod.sh
+++ b/.claude/skills/ir:test-mac/restore-prod.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# restore-prod.sh — return to the installed production Irrlicht after a
+# `replace`-mode dev session (see SKILL.md step 9).
+#
+# Why a dedicated script: quitting the dev app is NOT enough. In replace mode
+# the app only *adopted* the nohup/disown'd dev `--record` daemon on 7837
+# (DaemonManager.start() returns early on a reachable daemon and never records
+# the process, so terminateProcess() is a no-op). That daemon therefore
+# survives the app's exit, and a relaunched production app finds it still
+# reachable on 7837 and silently adopts it — you'd be running the production UI
+# against the dev `--record` daemon. This script kills both, GATES on the port
+# actually being free, then launches production so it spawns its OWN bundled
+# daemon.
+#
+# Usage:  .claude/skills/ir:test-mac/restore-prod.sh
+set -euo pipefail
+
+PROD_APP="/Applications/Irrlicht.app"
+PORT=7837
+
+echo "Stopping dev app + daemon…"
+pkill -f "IrrlichtDev" 2>/dev/null || true   # the dev app
+pkill -x "irrlichd"    2>/dev/null || true   # the adopted dev --record daemon (the app won't)
+
+# pkill is async — wait for the listener to actually disappear before deciding.
+for _ in 1 2 3 4 5; do
+  lsof -iTCP:"$PORT" -sTCP:LISTEN -P -n >/dev/null 2>&1 || break
+  sleep 1
+done
+
+if lsof -iTCP:"$PORT" -sTCP:LISTEN -P -n >/dev/null 2>&1; then
+  echo "ERROR: port $PORT still held after teardown — refusing to launch production." >&2
+  echo "       (Production would adopt whatever daemon is on $PORT.) Current holder:" >&2
+  lsof -iTCP:"$PORT" -sTCP:LISTEN -P -n >&2 || true
+  exit 1
+fi
+echo "Port $PORT free."
+
+if [ ! -d "$PROD_APP" ]; then
+  echo "ERROR: $PROD_APP is not installed — run the DMG/PKG installer first, then re-run this script." >&2
+  exit 1
+fi
+
+echo "Launching production $PROD_APP …"
+open "$PROD_APP"
+
+# Production spawns its own bundled daemon (no --record) now that 7837 is free.
+for _ in 1 2 3 4 5 6 7 8; do
+  curl -fsS --max-time 1 "http://127.0.0.1:$PORT/state" >/dev/null 2>&1 && {
+    echo "Production daemon reachable on $PORT — restored."
+    exit 0
+  }
+  sleep 1
+done
+echo "WARNING: production launched but daemon not reachable on $PORT yet — check the menu-bar app." >&2


### PR DESCRIPTION
## Problem

After a `replace`-mode `/ir:test-mac` session, quitting the dev app does **not** return you to production. In replace mode the dev app only *adopted* the `nohup`/`disown`'d dev `--record` daemon on 7837 (`DaemonManager.start()` returns early on a reachable daemon and never records the process, so `terminateProcess()` is a no-op). That daemon therefore survives the app's exit, and a relaunched — or freshly *reinstalled* — production app finds it still reachable on 7837 and silently adopts it. You'd be running the production UI against the dev `--record` daemon without realizing it.

Running the DMG/PKG installer is not a substitute: it swaps the app bundle, not the running daemon.

## Change

Add `.claude/skills/ir:test-mac/restore-prod.sh`, a one-shot "return to production":

1. Kill the dev app + the adopted dev daemon.
2. **Gate** on port 7837 actually freeing (poll `lsof`); refuse to launch production if it's still held — otherwise prod would just adopt whatever is there.
3. Launch `/Applications/Irrlicht.app`.
4. Confirm production's own bundled daemon (no `--record`) comes up on 7837.

Wire it into `SKILL.md` step 9 (one-shot script + by-hand equivalent) and the Notes teardown line, and spell out that the installer is not a substitute for the teardown.

## Verification

Ran the script live this session: it tore down the replace-mode dev stack, freed 7837, and launched production, which spawned its own non-recording daemon (`/Applications/Irrlicht.app/Contents/MacOS/irrlichd`, no `--record`). Dev app + dev daemon confirmed gone afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)