### PR TITLE
chore(domain): remove unused CompactionState field

### DIFF
--- a/core/adapters/outbound/filesystem/testdata/session_state.golden.json
+++ b/core/adapters/outbound/filesystem/testdata/session_state.golden.json
@@ -3,7 +3,6 @@
   "session_id": "00000000-0000-0000-0000-000000000001",
   "state": "working",
   "adapter": "claude-code",
-  "compaction_state": "not_compacting",
   "model": "claude-sonnet-4-6",
   "cwd": "/tmp/test-cwd",
   "transcript_path": "/tmp/test-transcript.jsonl",

--- a/core/cmd/irrlichd/testdata/push/focus_requested.golden.json
+++ b/core/cmd/irrlichd/testdata/push/focus_requested.golden.json
@@ -5,7 +5,6 @@
     "session_id": "00000000-0000-0000-0000-000000000001",
     "state": "working",
     "adapter": "claude-code",
-    "compaction_state": "not_compacting",
     "model": "claude-sonnet-4-6",
     "cwd": "/tmp/test-cwd",
     "transcript_path": "/tmp/test-transcript.jsonl",

--- a/core/cmd/irrlichd/testdata/push/session_created.golden.json
+++ b/core/cmd/irrlichd/testdata/push/session_created.golden.json
@@ -5,7 +5,6 @@
     "session_id": "00000000-0000-0000-0000-000000000001",
     "state": "working",
     "adapter": "claude-code",
-    "compaction_state": "not_compacting",
     "model": "claude-sonnet-4-6",
     "cwd": "/tmp/test-cwd",
     "transcript_path": "/tmp/test-transcript.jsonl",

--- a/core/cmd/irrlichd/testdata/push/session_deleted.golden.json
+++ b/core/cmd/irrlichd/testdata/push/session_deleted.golden.json
@@ -5,7 +5,6 @@
     "session_id": "00000000-0000-0000-0000-000000000001",
     "state": "working",
     "adapter": "claude-code",
-    "compaction_state": "not_compacting",
     "model": "claude-sonnet-4-6",
     "cwd": "/tmp/test-cwd",
     "transcript_path": "/tmp/test-transcript.jsonl",

--- a/core/cmd/irrlichd/testdata/push/session_updated.golden.json
+++ b/core/cmd/irrlichd/testdata/push/session_updated.golden.json
@@ -5,7 +5,6 @@
     "session_id": "00000000-0000-0000-0000-000000000001",
     "state": "working",
     "adapter": "claude-code",
-    "compaction_state": "not_compacting",
     "model": "claude-sonnet-4-6",
     "cwd": "/tmp/test-cwd",
     "transcript_path": "/tmp/test-transcript.jsonl",

--- a/core/cmd/irrlicht-ls/main.go
+++ b/core/cmd/irrlicht-ls/main.go
@@ -66,6 +66,6 @@ func printSessions(sessions []*session.SessionState) {
 		}
 
 		fmt.Printf("%-8s %-20s %s%s%s  (%s ago)\n",
-			s.StringState(), project, s.SessionID[:8], model, ctx, age)
+			s.State, project, s.SessionID[:8], model, ctx, age)
 	}
 }

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -12,10 +12,6 @@ const (
 	StateWorking = "working" // Agent actively processing (tools, text generation, hooks, compaction, or a live Bash background process)
 	StateWaiting = "waiting" // Agent finished turn, waiting for user input
 	StateReady   = "ready"   // Session inactive (process exited, transcript removed, cancelled)
-
-	CompactionStateNotCompacting = "not_compacting"
-	CompactionStateCompacting    = "compacting"
-	CompactionStatePostCompact   = "post_compact"
 )
 
 // IsCanonicalState reports whether s is one of the three valid lifecycle
@@ -547,7 +543,6 @@ type SessionState struct {
 	// Adapter identifies the source agent (e.g. "claude-code", "codex").
 	// Empty means Claude Code (for backwards compatibility).
 	Adapter         string          `json:"adapter,omitempty"`
-	CompactionState string          `json:"compaction_state,omitempty"`
 	Model           string          `json:"model,omitempty"`
 	CWD             string          `json:"cwd,omitempty"`
 	TranscriptPath  string          `json:"transcript_path,omitempty"`
@@ -593,14 +588,6 @@ func (s *SessionState) IsStale(maxAge time.Duration) bool {
 		return false
 	}
 	return time.Since(time.Unix(s.UpdatedAt, 0)) > maxAge
-}
-
-// StringState returns a display-friendly state string including compaction state.
-func (s *SessionState) StringState() string {
-	if s.CompactionState != "" && s.CompactionState != CompactionStateNotCompacting {
-		return s.State + "(" + s.CompactionState + ")"
-	}
-	return s.State
 }
 
 // MergeMetrics merges new metrics with old, preserving old values when new are zero/empty.

--- a/core/internal/contracttesting/fixtures.go
+++ b/core/internal/contracttesting/fixtures.go
@@ -60,7 +60,6 @@ func BuildFullSessionState() *session.SessionState {
 		SessionID:       "00000000-0000-0000-0000-000000000001",
 		State:           session.StateWorking,
 		Adapter:         "claude-code",
-		CompactionState: session.CompactionStateNotCompacting,
 		Model:           "claude-sonnet-4-6",
 		CWD:             "/tmp/test-cwd",
 		TranscriptPath:  "/tmp/test-transcript.jsonl",

--- a/site/docs/api-reference.html
+++ b/site/docs/api-reference.html
@@ -242,11 +242,6 @@
             <td>One of <code>claude-code</code>, <code>codex</code>, <code>pi</code>, <code>aider</code>, <code>opencode</code>, or empty (legacy / unknown)</td>
           </tr>
           <tr>
-            <td><code>compaction_state</code></td>
-            <td>string</td>
-            <td>Current compaction state, if any</td>
-          </tr>
-          <tr>
             <td><code>cwd</code></td>
             <td>string</td>
             <td>Working directory of the session</td>

--- a/site/docs/state-machine.html
+++ b/site/docs/state-machine.html
@@ -315,31 +315,6 @@
       <h2>Orthogonal Axes</h2>
       <p>Beyond the three core states, the state machine tracks several orthogonal dimensions that do not affect the primary state transition logic but provide additional context.</p>
 
-      <h3>CompactionState</h3>
-      <p>Tracks whether the agent is compacting its context window:</p>
-      <table>
-        <thead>
-          <tr>
-            <th>Value</th>
-            <th>Meaning</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>not_compacting</code></td>
-            <td>Normal operation. No compaction in progress.</td>
-          </tr>
-          <tr>
-            <td><code>compacting</code></td>
-            <td>Agent is actively summarizing context to fit within the window.</td>
-          </tr>
-          <tr>
-            <td><code>post_compact</code></td>
-            <td>Compaction just completed. Transient state before reverting to <code>not_compacting</code>.</td>
-          </tr>
-        </tbody>
-      </table>
-
       <h3>Adapter</h3>
       <p>Identifies which AI coding agent is running:</p>
       <ul>


### PR DESCRIPTION
## What

Removes the `CompactionState` field (and its three constants) from `SessionState`. It was a never-wired placeholder from the hexagonal-architecture refactor.

## Why

Audited every reference:

- **Writers:** none. No adapter (claudecode, codex, pi, aider, opencode), tailer, or service ever set it to a non-default value — it was always `not_compacting`.
- **Readers:** only `StringState()`, which appended `(compacting)` to a debug string it never saw.
- **Frontend:** neither `platforms/web/` nor the onboarding viewer reference compaction.
- **Pi** — the one agent that emits compaction events — folds them into normal `working` activity via the state classifier (`pi/parser.go`), never touching this field.

The contract is three states only (`working`/`waiting`/`ready`), so a compaction sub-annotation has no consumer by design.

## Changes

- Remove the 3 constants + `SessionState.CompactionState` field (`core/domain/session/session.go`).
- Remove the now-trivial `StringState()` helper; `irrlicht-ls` uses `s.State` directly.
- Drop the field from the contract-test fixture and regenerate 5 contract goldens.
- Remove the `compaction_state` row from `site/docs/api-reference.html`.

Recorded `replaydata/**/transcript.jsonl` fixtures that mention `compaction_state` are left untouched — those are recorded agent sessions that happened to read `session.go`, not irrlicht output.

## Tests

- `go test ./core/... -race -count=1` — pass
- `tools/replay-fixtures.sh` — all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)