### PR TITLE
feat(onboard): catalog-drift gate + wire subscription-detection/quota-burndown rows

### DIFF
--- a/.claude/skills/ir:onboard-agent/scenarios.json
+++ b/.claude/skills/ir:onboard-agent/scenarios.json
@@ -206,6 +206,16 @@
       "id": "provider-failover-midturn",
       "section": "Metrics",
       "feature": "Provider failover mid-turn"
+    },
+    {
+      "id": "subscription-detection",
+      "section": "Metrics",
+      "feature": "Subscription / billing-model detection"
+    },
+    {
+      "id": "quota-burndown",
+      "section": "Metrics",
+      "feature": "Quota burndown (rate-limit usage)"
     }
   ],
   "scenarios": [

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+# Pass/fail gate for Go tests on every PR and on pushes to main. This is the
+# enforcement the coverage workflow never provided: coverage.yml runs only on
+# push-to-main, covers the `core` module alone, and swallows test failures
+# (it parses coverage out of a discarded run). Without this, module tests —
+# including the catalog-drift gate in tools/agent-onboarding — were verified
+# locally only and could not block a PR.
+#
+# Both Go modules are exercised. They share a go.work, so the runner resolves
+# cross-module packages without per-module `go mod download`.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      # core carries the headless daemon smoke test + concurrency paths, so it
+      # runs under -race (matches the documented local command in AGENTS.md).
+      - name: Test core module
+        run: go test ./core/... -race -count=1
+
+      # tools/agent-onboarding holds the viewer + replay/validate packages and
+      # the TestScenarioCatalogNoDrift gate that keeps the overview matrix in
+      # sync with scenarios.json's catalog[] and the on-disk recordings.
+      - name: Test agent-onboarding module
+        run: go test ./tools/agent-onboarding/... -count=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,13 @@ on:
 
 jobs:
   go-test:
-    runs-on: ubuntu-latest
+    # macOS, not ubuntu: the core daemon is a macOS product and its process
+    # death-detection (processlifecycle/monitor.go) calls kqueue syscalls
+    # (syscall.Kqueue/Kevent/EVFILT_PROC) that don't exist on Linux, so core
+    # does not even compile there. This matches the platform developers build
+    # and run the suite on. (coverage.yml runs on ubuntu but silently swallows
+    # the resulting build failure.)
+    runs-on: macos-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -3,6 +3,7 @@ package services_test
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -1099,12 +1100,16 @@ func TestSessionDetector_SeedFromDisk_DeletesDeadPIDs(t *testing.T) {
 	pw := newMockProcessWatcher()
 	repo := newMockRepo()
 
-	// PIDs 42 and 99 don't exist as real processes, so syscall.Kill(pid, 0)
-	// returns ESRCH. All sessions with dead PIDs should be deleted.
+	// Derive PIDs that are GUARANTEED dead: spawn a process, reap it, reuse the
+	// now-defunct PID. syscall.Kill(pid, 0) on it returns ESRCH — the signal the
+	// detector uses to classify a seeded session's process as dead. Hardcoded
+	// low PIDs are not reliable here: 42/99 are live system daemons on some
+	// hosts (notably CI macOS runners), which made this test fail there.
+	deadPID1, deadPID2 := deadPID(t), deadPID(t)
 	repo.states["seed1"] = &session.SessionState{
 		SessionID:      "seed1",
 		State:          session.StateWorking,
-		PID:            42,
+		PID:            deadPID1,
 		TranscriptPath: "/home/.claude/projects/-Users-test/seed1.jsonl",
 		FirstSeen:      time.Now().Unix(),
 		UpdatedAt:      time.Now().Unix(),
@@ -1112,7 +1117,7 @@ func TestSessionDetector_SeedFromDisk_DeletesDeadPIDs(t *testing.T) {
 	repo.states["seed2"] = &session.SessionState{
 		SessionID: "seed2",
 		State:     session.StateReady,
-		PID:       99,
+		PID:       deadPID2,
 		FirstSeen: time.Now().Unix(),
 		UpdatedAt: time.Now().Unix(),
 	}
@@ -1129,20 +1134,33 @@ func TestSessionDetector_SeedFromDisk_DeletesDeadPIDs(t *testing.T) {
 
 	// seed1 has a dead PID — should be deleted.
 	if state, _ := repo.Load("seed1"); state != nil {
-		t.Error("seed1 should be deleted (PID 42 is dead)")
+		t.Errorf("seed1 should be deleted (PID %d is dead)", deadPID1)
 	}
 	// seed2 has a dead PID — should be deleted.
 	if state, _ := repo.Load("seed2"); state != nil {
-		t.Error("seed2 should be deleted (PID 99 is dead)")
+		t.Errorf("seed2 should be deleted (PID %d is dead)", deadPID2)
 	}
 
 	// Dead PIDs should NOT be registered with ProcessWatcher.
-	if _, ok := pw.watched[42]; ok {
-		t.Error("PID 42 should not be watched (dead process)")
+	if _, ok := pw.watched[deadPID1]; ok {
+		t.Errorf("PID %d should not be watched (dead process)", deadPID1)
 	}
-	if _, ok := pw.watched[99]; ok {
-		t.Error("PID 99 should not be watched (dead process)")
+	if _, ok := pw.watched[deadPID2]; ok {
+		t.Errorf("PID %d should not be watched (dead process)", deadPID2)
 	}
+}
+
+// deadPID spawns a trivial process, waits for it to exit (which reaps it), and
+// returns its now-defunct PID. Because the child has been reaped,
+// syscall.Kill(pid, 0) returns ESRCH — exactly what the detector treats as a
+// dead process — without relying on the host's low PIDs being unused.
+func deadPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("spawn dead-pid helper: %v", err)
+	}
+	return cmd.Process.Pid
 }
 
 // TestSessionDetector_HandlePermissionHook_PreToolUseTransitionsToWaiting is

--- a/replaydata/agents/aider/scenarios/quota-burndown/assessment.json
+++ b/replaydata/agents/aider/scenarios/quota-burndown/assessment.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "scenario_id": "quota-burndown",
+  "agent": "aider",
+  "assessed_at": "2026-05-25T00:00:00Z",
+  "agent_supports": "no",
+  "irrlicht_observes": "n/a",
+  "confidence": 0.9,
+  "body": "## Verdict\n\nagent_supports: no\nirrlicht_observes: n/a\n\n## Reasoning\n\nQuota burndown asks whether the agent surfaces a rate-limit usage window that rises monotonically as the session consumes its quota. Codex supports it: each `token_count` event carries a `rate_limits` map whose `used` / `UsedPercent` climb across turns (extractCodexRateLimits in core/adapters/inbound/agents/codex/parser.go), and irrlicht stores the latest RateLimitSnapshot per session.\n\nAider has no provider-managed quota window in its output. It runs against the user's own API key (or a local model), so any rate limiting happens at the provider boundary and is never reflected as a burndown signal in Aider's transcript. The aider adapter has zero rate-limit / quota extraction — `grep -ri 'rate_limit|quota|credits' core/adapters/inbound/agents/aider/` returns nothing.\n\nBecause agent_supports = no, irrlicht_observes is `n/a` per the matrix convention: there is no usage window in the transcript and no parser code path that could observe one.\n\n## What irrlicht does NOT see (and why that's OK)\n\nAny quota / rate-limit progression. Aider does not emit a usage window, so there is nothing to burn down and nothing to miss — the absence of observation is correct, not a gap.",
+  "caveats": [
+    "agent_supports=no, so this cell is authored as an assessment only — no recording, expected.jsonl, or transcript.jsonl.",
+    "Distinct from token-accounting (per-turn token counts, which Aider does emit) — quota-burndown is specifically a provider rate-limit window, which Aider does not surface."
+  ],
+  "sources": [
+    {"kind": "file", "ref": "core/adapters/inbound/agents/aider/", "note": "No rate-limit / quota / credits extraction exists in the aider adapter — no usage window to track burndown against."},
+    {"kind": "file", "ref": "core/adapters/inbound/agents/codex/parser.go", "note": "Contrast: Codex re-reads the rate_limits snapshot from each token_count event, the signal quota-burndown asserts, absent in Aider."}
+  ]
+}

--- a/replaydata/agents/aider/scenarios/subscription-detection/assessment.json
+++ b/replaydata/agents/aider/scenarios/subscription-detection/assessment.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": 1,
+  "scenario_id": "subscription-detection",
+  "agent": "aider",
+  "assessed_at": "2026-05-25T00:00:00Z",
+  "agent_supports": "no",
+  "irrlicht_observes": "n/a",
+  "confidence": 0.9,
+  "body": "## Verdict\n\nagent_supports: no\nirrlicht_observes: n/a\n\n## Reasoning\n\nSubscription detection asks whether the agent surfaces a billing-model signal — a subscription plan vs. an API-key/credits path. The two adapters that support it do so because the agent emits the data: Codex carries `plan_type` / `credits` in its `rate_limits` map (`extractCodexRateLimits` in core/adapters/inbound/agents/codex/parser.go), and Claude Code's statusline hook includes a `rate_limits` block for subscription users (statuslineToSnapshot in core/adapters/inbound/agents/claudecode/statusline.go).\n\nAider has no such concept. It is a local CLI that talks to a provider using the user's own API key (or a local model); there is no Aider-managed subscription tier, no plan-type field, and no credits ledger in its output. The aider adapter accordingly has zero rate-limit / plan-type / credits / subscription extraction — `grep -ri 'rate_limit|plan_type|quota|credits|subscription' core/adapters/inbound/agents/aider/` returns nothing.\n\nBecause agent_supports = no, irrlicht_observes is `n/a` per the matrix convention: there is no signal in the transcript and no parser code path that could ever observe one.\n\n## What irrlicht does NOT see (and why that's OK)\n\nEverything billing-related. The feature does not exist in the agent under test — Aider's BYO-key model has no subscription state to report — so the absence of observation is correct, not a gap.",
+  "caveats": [
+    "agent_supports=no, so this cell is authored as an assessment only — no recording, expected.jsonl, or transcript.jsonl.",
+    "A future Aider release that introduced a hosted/subscription mode emitting plan data would change this verdict."
+  ],
+  "sources": [
+    {"kind": "file", "ref": "core/adapters/inbound/agents/aider/", "note": "No rate-limit / plan-type / credits / subscription extraction exists in the aider adapter — nothing to parse a billing-model signal from."},
+    {"kind": "file", "ref": "core/adapters/inbound/agents/codex/parser.go", "note": "Contrast: Codex extracts plan_type/credits from rate_limits — the signal subscription-detection asserts, absent in Aider."}
+  ]
+}

--- a/tools/agent-onboarding/internal/viewer/catalog_drift_test.go
+++ b/tools/agent-onboarding/internal/viewer/catalog_drift_test.go
@@ -1,0 +1,102 @@
+package viewer
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestScenarioCatalogNoDrift guards the three sources of truth that the
+// overview matrix depends on staying in sync. The matrix is projected ONLY
+// from scenarios.json's catalog[] (buildCatalogJSON), and annotateCatalogCodes
+// derives each row's section.index from that same list — so a scenario with
+// no catalog row is invisible AND gets no index number. The three sources:
+//
+//   - catalog[]   — the only thing the overview renders; drives row + index.
+//   - scenarios[] — the recipe registry; each entry's coverage_id must name a
+//     real catalog row, else the recipe folds into a nonexistent cell.
+//   - replaydata/agents/<agent>/scenarios/<folder> — recorded fixtures; each
+//     must resolve to a catalog row either directly (folder == catalog id) or
+//     via a registry entry whose name == folder and whose coverage_id is a
+//     catalog id (the deliberate-alias case, e.g. multi-turn-conversation →
+//     basic-turn).
+//
+// A folder resolving to neither is the drift this test catches — exactly how
+// quota-burndown / subscription-detection sat invisible after being committed
+// as raw folders with no catalog or registry entry. Retired fixtures live
+// under <agent>/regression/, a SIBLING of scenarios/, so the glob below leaves
+// them out of scope by construction.
+func TestScenarioCatalogNoDrift(t *testing.T) {
+	root := filepath.Join("..", "..", "..", "..")
+	scenariosPath := filepath.Join(root, ".claude", "skills", "ir:onboard-agent", "scenarios.json")
+	b, err := os.ReadFile(scenariosPath)
+	if err != nil {
+		t.Skipf("scenarios.json not reachable from test cwd (hermetic build?): %v", err)
+	}
+	var doc struct {
+		Catalog []struct {
+			ID string `json:"id"`
+		} `json:"catalog"`
+		Scenarios []struct {
+			Name       string `json:"name"`
+			CoverageID string `json:"coverage_id"`
+		} `json:"scenarios"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("parse scenarios.json: %v", err)
+	}
+
+	catalogIDs := make(map[string]bool, len(doc.Catalog))
+	for _, c := range doc.Catalog {
+		catalogIDs[c.ID] = true
+	}
+	coverageByName := make(map[string]string, len(doc.Scenarios)) // registry folder name → coverage_id
+	for _, s := range doc.Scenarios {
+		coverageByName[s.Name] = s.CoverageID
+	}
+
+	// Guard 1: every registry coverage_id names a real catalog row. A dangling
+	// coverage_id silently routes a recipe to a matrix cell that never renders.
+	for _, s := range doc.Scenarios {
+		switch {
+		case s.CoverageID == "":
+			t.Errorf("registry scenario %q has empty coverage_id", s.Name)
+		case !catalogIDs[s.CoverageID]:
+			t.Errorf("registry scenario %q -> coverage_id %q has no catalog[] row", s.Name, s.CoverageID)
+		}
+	}
+
+	// Guard 2: every recorded scenario folder resolves to a catalog row.
+	folders, _ := filepath.Glob(filepath.Join(root, "replaydata", "agents", "*", "scenarios", "*"))
+	if len(folders) == 0 {
+		t.Skip("no replaydata scenario folders reachable; skipping on-disk drift check")
+	}
+	var orphans []string
+	for _, dir := range folders {
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		folder := filepath.Base(dir)
+		resolves := catalogIDs[folder]
+		if !resolves {
+			if cov, ok := coverageByName[folder]; ok && catalogIDs[cov] {
+				resolves = true
+			}
+		}
+		if !resolves {
+			// path shape: …/<agent>/scenarios/<folder>
+			agent := filepath.Base(filepath.Dir(filepath.Dir(dir)))
+			orphans = append(orphans, agent+"/"+folder)
+		}
+	}
+	if len(orphans) > 0 {
+		sort.Strings(orphans)
+		t.Errorf("orphan scenario folders with no catalog[] row and no registry alias to one — "+
+			"invisible in the overview matrix, no index number. Fix by adding a catalog[] entry, "+
+			"or a scenarios[] recipe whose coverage_id names a catalog row, or retiring the folder "+
+			"to <agent>/regression/:\n  %v", orphans)
+	}
+}


### PR DESCRIPTION
## Problem

The overview matrix is projected **only** from `scenarios.json`'s `catalog[]`, and the `section.index` codes (1.1, 2.3…) are derived from that same list — so a scenario folder with no catalog row is **invisible** in the overview *and* gets **no index number**.

Three recorded folders had drifted into that state — committed as raw `replaydata` folders (`assessment.json` + `expected.jsonl`) with no `catalog[]` row and no `scenarios[]` registry entry:

- `claudecode/subscription-detection`
- `codex/subscription-detection`
- `codex/quota-burndown`

Nothing reconciled the three sources of truth (`catalog[]` ↔ registry ↔ on-disk folders), so the drift was silent — and no CI job ran `go test` as a gate, so it could never have been caught automatically.

## Changes

**1. Drift gate** — `TestScenarioCatalogNoDrift` (`internal/viewer/catalog_drift_test.go`):
- Guard 1: every registry `coverage_id` names a real `catalog[]` row.
- Guard 2: every on-disk `replaydata/agents/<agent>/scenarios/<folder>` resolves to a catalog row — directly (`folder == id`) or via a registry alias (`name==folder`, `coverage_id` ∈ catalog). `<agent>/regression/` is a sibling of `scenarios/`, so retired fixtures are out of scope by construction.
- Ran **RED** on the three orphans before the fix; **GREEN** after.

**2. Wire the two scenario types into `catalog[]`** (Metrics section, appended at the end so existing indices don't shift):
- **5.6** `subscription-detection` — Subscription / billing-model detection
- **5.7** `quota-burndown` — Quota burndown (rate-limit usage)

**3. CI enforcement** (`.github/workflows/test.yml`): a `pull_request` + push-to-main **Tests** gate running `go test` across **both** Go modules via `go.work` (core under `-race` per AGENTS.md; `tools/agent-onboarding` plain). Previously the only Go-test workflow was `coverage.yml` — push-to-main only, `core`-only, and it swallows failures. With this, the drift gate (and the rest of the suite) actually blocks a PR.

**4. Capability-gating for the new rows.** Non-supporting adapters were rendering `unknown`. N/A is an explicit `assessment.json`/overlay verdict (not derived from `requires`), so authored grounded `no / n.a.` assessments for **aider** on both scenarios: aider is a BYO-key local CLI with no subscription/quota model, and the aider adapter has **zero** rate-limit/plan/credits extraction → irrlicht has no code path to observe either signal (assessment-only cells, no recording, per convention).

## Result (live matrix)

| row | codex | claudecode | aider | pi | opencode |
|---|---|---|---|---|---|
| 5.6 subscription-detection | yes/yes | yes/yes | **no/n.a.** | unknown | unknown |
| 5.7 quota-burndown | yes/partial | unknown | **no/n.a.** | unknown | unknown |

The remaining `unknown` cells (pi & opencode on both; claudecode on quota-burndown) are **left as `unknown` on purpose** — whether those agents emit the signal is an empirical maintainer verdict, not something to fabricate. Codex×{subscription-detection, quota-burndown} and claudecode×subscription-detection still lack an `events.jsonl` recording (they show `no_recording`); that's the real remaining onboarding gap.

## Test plan

- `go test ./core/... ./tools/agent-onboarding/... -count=1` — all pass (exit 0)
- Drift test: RED on the 3 orphans → GREEN after catalog wiring
- Viewer overview: 41 rows; new Metrics rows render with codes 5.6 / 5.7 and aider = n/a
- `test.yml` validated as well-formed YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)