### PR TITLE
feat(relay): irrlichtrelay v0 — daemon → relay → macOS + web round-trip (#479)

### DIFF
--- a/core/adapters/outbound/relay/envelope.go
+++ b/core/adapters/outbound/relay/envelope.go
@@ -1,0 +1,124 @@
+// Package relay implements the daemon's outbound relay forwarder and the
+// shared wire envelope spoken between irrlichd, the standalone irrlichtrelay
+// server, and relay-connected clients. The envelope wraps the daemon's
+// existing outbound.PushMessage so the load-bearing daemon → relay link
+// reuses the same payloads the local WebSocket already serves; clients read
+// Push.Msg and process it exactly as a raw daemon frame.
+//
+// See docs/relay-protocol.md for the on-the-wire documentation. Only the
+// frames defined here are built; auth, seq, and resume remain reserved.
+package relay
+
+import (
+	"encoding/json"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// ProtocolVersion is the relay wire-format version. Bumped only on a breaking
+// change to the frames below.
+const ProtocolVersion = 1
+
+// Frame type tags carried in every envelope's "type" field.
+const (
+	MsgHello          = "hello"
+	MsgHelloAck       = "hello_ack"
+	MsgDaemonSnapshot = "daemon_snapshot"
+	MsgSnapshot       = "snapshot"
+	MsgDaemonStatus   = "daemon_status"
+	MsgPush           = "push"
+)
+
+// Peer roles announced in a hello.
+const (
+	RoleDaemon = "daemon"
+	RoleClient = "client"
+)
+
+// Daemon connection states reported to clients.
+const (
+	StatusConnected    = "connected"
+	StatusDisconnected = "disconnected"
+)
+
+// Hello is the first frame a peer sends after the socket opens. Daemons set
+// the Daemon* fields; clients leave them empty.
+type Hello struct {
+	Type            string `json:"type"`
+	ProtocolVersion int    `json:"protocol_version"`
+	Role            string `json:"role"`
+	DaemonID        string `json:"daemon_id,omitempty"`
+	DaemonLabel     string `json:"daemon_label,omitempty"`
+}
+
+// HelloAck is the relay's reply to a hello, echoing the negotiated version.
+type HelloAck struct {
+	Type            string `json:"type"`
+	AcceptedVersion int    `json:"accepted_version"`
+}
+
+// DaemonSnapshot reconciles the relay's cache with a daemon's full current
+// state. A daemon sends it once, immediately after its hello, then streams
+// deltas as Push frames.
+type DaemonSnapshot struct {
+	Type     string                  `json:"type"`
+	Sessions []*session.SessionState `json:"sessions"`
+	Agents   []AgentInfo             `json:"agents"`
+}
+
+// DaemonInfo identifies a connected daemon in the client-facing snapshot and
+// status frames (drives the connection-status tooltip).
+type DaemonInfo struct {
+	DaemonID    string `json:"daemon_id"`
+	DaemonLabel string `json:"daemon_label"`
+	Status      string `json:"status"`
+}
+
+// Snapshot tells a freshly-connected client which daemons the relay currently
+// knows about.
+type Snapshot struct {
+	Type    string       `json:"type"`
+	Daemons []DaemonInfo `json:"daemons"`
+}
+
+// DaemonStatus is a live delta: a daemon connected to or disconnected from the
+// relay. Keeps the client tooltip current without a full re-snapshot.
+type DaemonStatus struct {
+	Type        string `json:"type"`
+	DaemonID    string `json:"daemon_id"`
+	DaemonLabel string `json:"daemon_label"`
+	Status      string `json:"status"`
+	Since       int64  `json:"since"`
+}
+
+// Push wraps one daemon outbound.PushMessage for relay → client fan-out.
+// Source is the originating daemon_id; TS is unix seconds. Clients unwrap Msg
+// and process it exactly as today's raw daemon frames.
+type Push struct {
+	Type   string               `json:"type"`
+	Source string               `json:"source"`
+	TS     int64                `json:"ts"`
+	Msg    outbound.PushMessage `json:"msg"`
+}
+
+// AgentInfo is the adapter branding the relay re-serves at /api/v1/agents.
+// Mirrors the daemon's agentEntry shape byte-for-byte so frontends key off it
+// identically whether they fetched it from a daemon or a relay.
+type AgentInfo struct {
+	Name         string `json:"name"`
+	DisplayName  string `json:"display_name"`
+	IconSVGLight string `json:"icon_svg_light"`
+	IconSVGDark  string `json:"icon_svg_dark"`
+}
+
+// FrameType extracts the "type" tag from a raw relay frame without fully
+// decoding it, so a reader can dispatch on the frame kind before committing to
+// a typed unmarshal. Returns "" when the frame isn't valid JSON or omits type.
+func FrameType(data []byte) string {
+	var e struct {
+		Type string `json:"type"`
+	}
+	_ = json.Unmarshal(data, &e)
+	return e.Type
+}

--- a/core/adapters/outbound/relay/forwarder.go
+++ b/core/adapters/outbound/relay/forwarder.go
@@ -1,0 +1,215 @@
+package relay
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+const forwardWriteTimeout = 10 * time.Second
+
+// streamPath is the relay's WebSocket endpoint, shared with the daemon and
+// every client.
+const streamPath = "/api/v1/sessions/stream"
+
+// normalizeRelayURL turns IRRLICHT_RELAY_URL into a dialable WebSocket URL:
+// it supplies a ws:// scheme (rewriting http(s)://) and appends the stream
+// path when absent, so the env var can be a bare base like ws://host:7838.
+func normalizeRelayURL(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return s
+	}
+	switch {
+	case strings.HasPrefix(s, "http://"):
+		s = "ws://" + strings.TrimPrefix(s, "http://")
+	case strings.HasPrefix(s, "https://"):
+		s = "wss://" + strings.TrimPrefix(s, "https://")
+	case !strings.HasPrefix(s, "ws://") && !strings.HasPrefix(s, "wss://"):
+		s = "ws://" + s
+	}
+	s = strings.TrimRight(s, "/")
+	if !strings.HasSuffix(s, streamPath) {
+		s += streamPath
+	}
+	return s
+}
+
+// SnapshotFunc returns the daemon's current sessions and adapter registry,
+// captured to build the daemon_snapshot sent on each (re)connect so the relay
+// reconciles its cache without waiting for the next per-session delta.
+type SnapshotFunc func() ([]*session.SessionState, []AgentInfo)
+
+// Forwarder subscribes to the daemon's push broadcaster and pushes every
+// session event out to a relay server over a WebSocket, reconnecting with
+// exponential backoff. Pushing out (rather than accepting inbound) means the
+// daemon needs no reachable address — it works behind NAT.
+type Forwarder struct {
+	url      string
+	identity Identity
+	push     outbound.PushBroadcaster
+	snapshot SnapshotFunc
+	logger   outbound.Logger
+
+	dialer     *websocket.Dialer
+	minBackoff time.Duration
+	maxBackoff time.Duration
+}
+
+// NewForwarder builds a Forwarder targeting relayURL. push and snapshot are
+// required; logger may be nil.
+func NewForwarder(relayURL string, id Identity, push outbound.PushBroadcaster, snapshot SnapshotFunc, logger outbound.Logger) *Forwarder {
+	return &Forwarder{
+		url:        normalizeRelayURL(relayURL),
+		identity:   id,
+		push:       push,
+		snapshot:   snapshot,
+		logger:     logger,
+		dialer:     websocket.DefaultDialer,
+		minBackoff: time.Second,
+		maxBackoff: 30 * time.Second,
+	}
+}
+
+// Run connects to the relay and forwards push events until ctx is cancelled.
+// Each connection failure backs off exponentially (with jitter to decorrelate
+// reconnect storms); a connection that stayed up past maxBackoff is treated as
+// healthy and resets the delay so a long-lived link reconnects promptly.
+func (f *Forwarder) Run(ctx context.Context) {
+	backoff := f.minBackoff
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		start := time.Now()
+		err := f.runOnce(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			f.logError(fmt.Sprintf("relay link to %s ended: %v", f.url, err))
+		}
+		if time.Since(start) > f.maxBackoff {
+			backoff = f.minBackoff
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff + jitter(backoff)):
+		}
+		if backoff *= 2; backoff > f.maxBackoff {
+			backoff = f.maxBackoff
+		}
+	}
+}
+
+// runOnce establishes one relay connection: hello → daemon_snapshot → forward
+// the push stream until the relay drops, ctx cancels, or a write fails.
+func (f *Forwarder) runOnce(ctx context.Context) error {
+	conn, _, err := f.dialer.DialContext(ctx, f.url, nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if err := conn.WriteJSON(Hello{
+		Type:            MsgHello,
+		ProtocolVersion: ProtocolVersion,
+		Role:            RoleDaemon,
+		DaemonID:        f.identity.DaemonID,
+		DaemonLabel:     f.identity.DaemonLabel,
+	}); err != nil {
+		return err
+	}
+
+	sessions, agentInfos := f.snapshotState()
+	if err := conn.WriteJSON(DaemonSnapshot{
+		Type:     MsgDaemonSnapshot,
+		Sessions: sessions,
+		Agents:   agentInfos,
+	}); err != nil {
+		return err
+	}
+	f.logInfo(fmt.Sprintf("connected to relay %s as %q (%s)", f.url, f.identity.DaemonLabel, f.identity.DaemonID))
+
+	ch := f.push.Subscribe()
+	defer f.push.Unsubscribe(ch)
+
+	// Read pump: surface the relay closing the socket (and drain any
+	// hello_ack / control frames, which v0 does not act on).
+	readErr := make(chan error, 1)
+	go func() {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				readErr <- err
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-readErr:
+			return err
+		case msg, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			if !shouldForward(msg) {
+				continue
+			}
+			conn.SetWriteDeadline(time.Now().Add(forwardWriteTimeout))
+			if err := conn.WriteJSON(Push{
+				Type:   MsgPush,
+				Source: f.identity.DaemonID,
+				TS:     time.Now().Unix(),
+				Msg:    msg,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (f *Forwarder) snapshotState() ([]*session.SessionState, []AgentInfo) {
+	if f.snapshot == nil {
+		return nil, nil
+	}
+	return f.snapshot()
+}
+
+// shouldForward drops messages meaningless across hosts. focus_requested asks a
+// client to raise the local terminal/IDE window of a session — nonsensical for
+// a session on a different machine, so the forwarder filters it (wiki §5.4).
+func shouldForward(msg outbound.PushMessage) bool {
+	return msg.Type != outbound.PushTypeFocusRequested
+}
+
+// jitter returns a random duration in [0, d/2] to spread reconnect attempts.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int63n(int64(d/2) + 1))
+}
+
+func (f *Forwarder) logInfo(msg string) {
+	if f.logger != nil {
+		f.logger.LogInfo("relay-forwarder", "", msg)
+	}
+}
+
+func (f *Forwarder) logError(msg string) {
+	if f.logger != nil {
+		f.logger.LogError("relay-forwarder", "", msg)
+	}
+}

--- a/core/adapters/outbound/relay/forwarder.go
+++ b/core/adapters/outbound/relay/forwarder.go
@@ -129,6 +129,14 @@ func (f *Forwarder) runOnce(ctx context.Context) error {
 		return err
 	}
 
+	// Subscribe BEFORE capturing the snapshot. Otherwise a broadcast that
+	// fires between snapshotState() and Subscribe() is in neither the snapshot
+	// (captured earlier) nor the delta stream (subscribed later) and is lost
+	// until that session's next change. With this order a change reflected in
+	// both the snapshot and the stream is just an idempotent upsert on the relay.
+	ch := f.push.Subscribe()
+	defer f.push.Unsubscribe(ch)
+
 	sessions, agentInfos := f.snapshotState()
 	if err := conn.WriteJSON(DaemonSnapshot{
 		Type:     MsgDaemonSnapshot,
@@ -138,9 +146,6 @@ func (f *Forwarder) runOnce(ctx context.Context) error {
 		return err
 	}
 	f.logInfo(fmt.Sprintf("connected to relay %s as %q (%s)", f.url, f.identity.DaemonLabel, f.identity.DaemonID))
-
-	ch := f.push.Subscribe()
-	defer f.push.Unsubscribe(ch)
 
 	// Read pump: surface the relay closing the socket (and drain any
 	// hello_ack / control frames, which v0 does not act on).

--- a/core/adapters/outbound/relay/forwarder.go
+++ b/core/adapters/outbound/relay/forwarder.go
@@ -21,7 +21,7 @@ const streamPath = "/api/v1/sessions/stream"
 
 // normalizeRelayURL turns IRRLICHT_RELAY_URL into a dialable WebSocket URL:
 // it supplies a ws:// scheme (rewriting http(s)://) and appends the stream
-// path when absent, so the env var can be a bare base like ws://host:7838.
+// path when absent, so the env var can be a bare base like ws://host:7839.
 func normalizeRelayURL(raw string) string {
 	s := strings.TrimSpace(raw)
 	if s == "" {

--- a/core/adapters/outbound/relay/forwarder_test.go
+++ b/core/adapters/outbound/relay/forwarder_test.go
@@ -1,0 +1,217 @@
+package relay
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// fakeBroadcaster is a minimal PushBroadcaster backed by a single buffered
+// channel, so a test controls exactly which messages the forwarder sees.
+type fakeBroadcaster struct {
+	ch chan outbound.PushMessage
+}
+
+func newFakeBroadcaster() *fakeBroadcaster {
+	return &fakeBroadcaster{ch: make(chan outbound.PushMessage, 16)}
+}
+
+func (f *fakeBroadcaster) Subscribe() chan outbound.PushMessage  { return f.ch }
+func (f *fakeBroadcaster) Unsubscribe(chan outbound.PushMessage) {}
+func (f *fakeBroadcaster) Broadcast(msg outbound.PushMessage)    { f.ch <- msg }
+
+// testRelay is a minimal WebSocket server standing in for irrlichtrelay: it
+// upgrades each connection and forwards every received frame onto frames.
+type testRelay struct {
+	url    string
+	frames chan []byte
+	conns  chan *websocket.Conn
+}
+
+func newTestRelay(t *testing.T) *testRelay {
+	t.Helper()
+	tr := &testRelay{
+		frames: make(chan []byte, 64),
+		conns:  make(chan *websocket.Conn, 8),
+	}
+	up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		tr.conns <- c
+		for {
+			_, data, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+			tr.frames <- data
+		}
+	}))
+	t.Cleanup(srv.Close)
+	tr.url = "ws" + strings.TrimPrefix(srv.URL, "http")
+	return tr
+}
+
+func (tr *testRelay) next(t *testing.T) []byte {
+	t.Helper()
+	select {
+	case f := <-tr.frames:
+		return f
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for a relay frame")
+		return nil
+	}
+}
+
+func mustUnmarshal(t *testing.T, data []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", data, err)
+	}
+}
+
+func TestForwarderHelloSnapshotAndPush(t *testing.T) {
+	tr := newTestRelay(t)
+	bc := newFakeBroadcaster()
+	snap := func() ([]*session.SessionState, []AgentInfo) {
+		return []*session.SessionState{{SessionID: "s1", State: "working"}},
+			[]AgentInfo{{Name: "claude-code", DisplayName: "Claude Code"}}
+	}
+	f := NewForwarder(tr.url, Identity{DaemonID: "d-123", DaemonLabel: "laptop"}, bc, snap, nil)
+	go f.Run(t.Context())
+
+	var hello Hello
+	mustUnmarshal(t, tr.next(t), &hello)
+	if hello.Type != MsgHello || hello.Role != RoleDaemon || hello.DaemonID != "d-123" || hello.ProtocolVersion != ProtocolVersion {
+		t.Fatalf("unexpected hello: %+v", hello)
+	}
+
+	var ds DaemonSnapshot
+	mustUnmarshal(t, tr.next(t), &ds)
+	if ds.Type != MsgDaemonSnapshot || len(ds.Sessions) != 1 || ds.Sessions[0].SessionID != "s1" || len(ds.Agents) != 1 {
+		t.Fatalf("unexpected daemon_snapshot: %+v", ds)
+	}
+
+	bc.Broadcast(outbound.PushMessage{Type: outbound.PushTypeUpdated, Session: &session.SessionState{SessionID: "s1", State: "ready"}})
+	var p Push
+	mustUnmarshal(t, tr.next(t), &p)
+	if p.Type != MsgPush || p.Source != "d-123" || p.TS == 0 {
+		t.Fatalf("unexpected push envelope: %+v", p)
+	}
+	if p.Msg.Type != outbound.PushTypeUpdated || p.Msg.Session == nil || p.Msg.Session.SessionID != "s1" {
+		t.Fatalf("push did not carry the unchanged PushMessage: %+v", p.Msg)
+	}
+}
+
+func TestForwarderFiltersFocusRequested(t *testing.T) {
+	tr := newTestRelay(t)
+	bc := newFakeBroadcaster()
+	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, bc, nil, nil)
+	go f.Run(t.Context())
+
+	tr.next(t) // hello
+	tr.next(t) // daemon_snapshot
+
+	// focus_requested is host-local and must be dropped; the following
+	// update must still arrive, proving the filter skips rather than stalls.
+	bc.Broadcast(outbound.PushMessage{Type: outbound.PushTypeFocusRequested, Session: &session.SessionState{SessionID: "s1"}})
+	bc.Broadcast(outbound.PushMessage{Type: outbound.PushTypeUpdated, Session: &session.SessionState{SessionID: "s2"}})
+
+	var p Push
+	mustUnmarshal(t, tr.next(t), &p)
+	if p.Msg.Type != outbound.PushTypeUpdated || p.Msg.Session.SessionID != "s2" {
+		t.Fatalf("expected focus_requested filtered, next push was %+v", p.Msg)
+	}
+}
+
+func TestForwarderReconnects(t *testing.T) {
+	tr := newTestRelay(t)
+	bc := newFakeBroadcaster()
+	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, bc, nil, nil)
+	f.minBackoff = 10 * time.Millisecond
+	f.maxBackoff = 20 * time.Millisecond
+	go f.Run(t.Context())
+
+	c1 := <-tr.conns
+	tr.next(t) // hello
+	tr.next(t) // daemon_snapshot
+	c1.Close() // simulate the relay dropping the daemon
+
+	select {
+	case <-tr.conns:
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwarder did not reconnect after the relay dropped")
+	}
+	var hello Hello
+	mustUnmarshal(t, tr.next(t), &hello)
+	if hello.Type != MsgHello {
+		t.Fatalf("expected a fresh hello on reconnect, got %+v", hello)
+	}
+}
+
+func TestLoadOrCreateIdentityPersists(t *testing.T) {
+	dir := t.TempDir()
+	id1, err := LoadOrCreateIdentity(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id1.DaemonID == "" || id1.DaemonLabel == "" {
+		t.Fatalf("incomplete identity: %+v", id1)
+	}
+	id2, err := LoadOrCreateIdentity(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id2.DaemonID != id1.DaemonID {
+		t.Fatalf("daemon_id not stable across loads: %q vs %q", id1.DaemonID, id2.DaemonID)
+	}
+}
+
+func TestFrameType(t *testing.T) {
+	if got := FrameType([]byte(`{"type":"push","source":"x"}`)); got != "push" {
+		t.Fatalf("FrameType = %q, want push", got)
+	}
+	if got := FrameType([]byte(`not json`)); got != "" {
+		t.Fatalf("FrameType on garbage = %q, want empty", got)
+	}
+}
+
+func TestNormalizeRelayURL(t *testing.T) {
+	cases := map[string]string{
+		"ws://localhost:7838":                        "ws://localhost:7838/api/v1/sessions/stream",
+		"localhost:7838":                             "ws://localhost:7838/api/v1/sessions/stream",
+		"http://relay.example:7838":                  "ws://relay.example:7838/api/v1/sessions/stream",
+		"https://relay.example/":                     "wss://relay.example/api/v1/sessions/stream",
+		"ws://localhost:7838/api/v1/sessions/stream": "ws://localhost:7838/api/v1/sessions/stream",
+		"": "",
+	}
+	for in, want := range cases {
+		if got := normalizeRelayURL(in); got != want {
+			t.Errorf("normalizeRelayURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestShouldForward(t *testing.T) {
+	if shouldForward(outbound.PushMessage{Type: outbound.PushTypeFocusRequested}) {
+		t.Fatal("focus_requested must not be forwarded")
+	}
+	for _, ty := range []string{
+		outbound.PushTypeCreated, outbound.PushTypeUpdated, outbound.PushTypeDeleted,
+		outbound.PushTypeHistoryTick, outbound.PushTypeHistorySnapshot,
+	} {
+		if !shouldForward(outbound.PushMessage{Type: ty}) {
+			t.Fatalf("%s should be forwarded", ty)
+		}
+	}
+}

--- a/core/adapters/outbound/relay/forwarder_test.go
+++ b/core/adapters/outbound/relay/forwarder_test.go
@@ -188,11 +188,11 @@ func TestFrameType(t *testing.T) {
 
 func TestNormalizeRelayURL(t *testing.T) {
 	cases := map[string]string{
-		"ws://localhost:7838":                        "ws://localhost:7838/api/v1/sessions/stream",
-		"localhost:7838":                             "ws://localhost:7838/api/v1/sessions/stream",
-		"http://relay.example:7838":                  "ws://relay.example:7838/api/v1/sessions/stream",
+		"ws://localhost:7839":                        "ws://localhost:7839/api/v1/sessions/stream",
+		"localhost:7839":                             "ws://localhost:7839/api/v1/sessions/stream",
+		"http://relay.example:7839":                  "ws://relay.example:7839/api/v1/sessions/stream",
 		"https://relay.example/":                     "wss://relay.example/api/v1/sessions/stream",
-		"ws://localhost:7838/api/v1/sessions/stream": "ws://localhost:7838/api/v1/sessions/stream",
+		"ws://localhost:7839/api/v1/sessions/stream": "ws://localhost:7839/api/v1/sessions/stream",
 		"": "",
 	}
 	for in, want := range cases {

--- a/core/adapters/outbound/relay/identity.go
+++ b/core/adapters/outbound/relay/identity.go
@@ -1,0 +1,75 @@
+package relay
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// identityFilename is the basename of the persisted relay identity, written
+// under the daemon's data dir (honors IRRLICHT_HOME via the caller).
+const identityFilename = "relay-identity.json"
+
+// Identity is a daemon's stable relay identity: a minted UUID that survives
+// restarts plus a human label (defaults to the hostname).
+type Identity struct {
+	DaemonID    string `json:"daemon_id"`
+	DaemonLabel string `json:"daemon_label"`
+}
+
+// LoadOrCreateIdentity reads the daemon's relay identity from
+// <dir>/relay-identity.json, minting and persisting a new one on first use so
+// the daemon_id is stable across restarts (clients dedupe sessions by it). A
+// write failure is returned alongside the in-memory identity so the daemon can
+// still forward this run; it just won't persist the id.
+func LoadOrCreateIdentity(dir string) (Identity, error) {
+	path := filepath.Join(dir, identityFilename)
+	if data, err := os.ReadFile(path); err == nil {
+		var id Identity
+		if err := json.Unmarshal(data, &id); err == nil && id.DaemonID != "" {
+			if id.DaemonLabel == "" {
+				id.DaemonLabel = hostnameLabel()
+			}
+			return id, nil
+		}
+	}
+
+	id := Identity{DaemonID: newUUID(), DaemonLabel: hostnameLabel()}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return id, err
+	}
+	data, err := json.MarshalIndent(id, "", "  ")
+	if err != nil {
+		return id, err
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return id, err
+	}
+	return id, nil
+}
+
+// hostnameLabel returns the machine hostname, falling back to a constant when
+// the lookup fails so a daemon_label is never empty on the wire.
+func hostnameLabel() string {
+	h, err := os.Hostname()
+	if err != nil || h == "" {
+		return "irrlicht-daemon"
+	}
+	return h
+}
+
+// newUUID returns a random RFC-4122 v4 UUID string. Avoids a dependency on
+// google/uuid (an indirect-only module dependency) for the single id we mint.
+func newUUID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failing is catastrophic; a zero id is still unique
+		// enough for a single-node v0 and never silently corrupts state.
+		return "00000000-0000-4000-8000-000000000000"
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -31,6 +31,7 @@ import (
 	"irrlicht/core/adapters/outbound/mdns"
 	"irrlicht/core/adapters/outbound/metrics"
 	"irrlicht/core/adapters/outbound/recorder"
+	"irrlicht/core/adapters/outbound/relay"
 	wshub "irrlicht/core/adapters/outbound/websocket"
 	"irrlicht/core/application/services"
 	"irrlicht/core/domain/config"
@@ -155,6 +156,40 @@ func main() {
 	// so the agent-onboarding viewer can build the same metrics Registry
 	// during replay without duplicating the construction.
 	allAgents := agents.All()
+
+	// Outbound relay forwarder (opt-in via IRRLICHT_RELAY_URL): subscribe to
+	// the same push broadcaster the local WebSocket uses and push every
+	// session event out to a standalone irrlichtrelay, so remote clients see
+	// this daemon's sessions through the relay. Pushing out means the daemon
+	// needs no inbound reachability (works behind NAT). No-op when unset.
+	if relayURL := os.Getenv("IRRLICHT_RELAY_URL"); relayURL != "" {
+		home, _ := os.UserHomeDir()
+		identity, err := relay.LoadOrCreateIdentity(dataDir(home))
+		if err != nil {
+			logger.LogError("startup", "", fmt.Sprintf("relay identity persistence failed (using ephemeral id): %v", err))
+		}
+		snapshot := func() ([]*session.SessionState, []relay.AgentInfo) {
+			sessions, err := cachedRepo.ListAll()
+			if err != nil {
+				sessions = nil
+			}
+			infos := make([]relay.AgentInfo, 0, len(allAgents))
+			for _, a := range allAgents {
+				infos = append(infos, relay.AgentInfo{
+					Name:         a.Identity.Name,
+					DisplayName:  a.Identity.DisplayName,
+					IconSVGLight: a.Identity.IconSVGLight,
+					IconSVGDark:  a.Identity.IconSVGDark,
+				})
+			}
+			return sessions, infos
+		}
+		fwd := relay.NewForwarder(relayURL, identity, push, snapshot, logger)
+		relayCtx, relayCancel := context.WithCancel(context.Background())
+		defer relayCancel()
+		go fwd.Run(relayCtx)
+		logger.LogInfo("startup", "", fmt.Sprintf("relay forwarder enabled → %s (daemon %q / %s)", relayURL, identity.DaemonLabel, identity.DaemonID))
+	}
 
 	// Shared adapters for SessionDetector.
 	gitResolver := git.New()

--- a/core/cmd/irrlichtrelay/handlers.go
+++ b/core/cmd/irrlichtrelay/handlers.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"irrlicht/core/domain/session"
+)
+
+// handleSessions re-serves the daemon's /api/v1/sessions shape, built from the
+// relay's flattened session cache. No orchestrator state is forwarded in v0,
+// so the dashboard groups by project name (BuildDashboard with nil orch).
+func handleSessions(h *hub) http.HandlerFunc {
+	type sessionsResponse struct {
+		Groups []*session.AgentGroup `json:"groups"`
+	}
+	return func(w http.ResponseWriter, _ *http.Request) {
+		groups := session.BuildDashboard(h.buildSessions(), nil)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sessionsResponse{Groups: groups})
+	}
+}
+
+// handleAgents re-serves /api/v1/agents as the union of every connected
+// daemon's adapter registry, matching the daemon's agentEntry shape.
+func handleAgents(h *hub) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(h.buildAgents())
+	}
+}
+
+// handleVersion serves the relay's own build version.
+func handleVersion(version string) http.HandlerFunc {
+	type versionResp struct {
+		Version string `json:"version"`
+	}
+	body, _ := json.Marshal(versionResp{Version: version})
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}
+}

--- a/core/cmd/irrlichtrelay/hub.go
+++ b/core/cmd/irrlichtrelay/hub.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"sync"
 	"time"
@@ -82,7 +83,13 @@ func (h *hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var hello relay.Hello
-	_ = json.Unmarshal(data, &hello)
+	if err := json.Unmarshal(data, &hello); err != nil {
+		// Lenient: a peer with an unparseable opening frame is still served as
+		// a client (a daemon always sends a well-formed hello), but log it so a
+		// daemon misconfiguration isn't silently indistinguishable from a stock
+		// dashboard.
+		log.Printf("relay: opening frame is not a valid hello (%v); treating peer as a client", err)
+	}
 	if hello.Type == relay.MsgHello && hello.Role == relay.RoleDaemon {
 		h.serveDaemon(conn, hello)
 		return
@@ -94,6 +101,7 @@ func (h *hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 
 func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello) {
 	if hello.DaemonID == "" {
+		log.Printf("relay: refusing daemon hello with empty daemon_id")
 		return // untracked, undedupable — refuse
 	}
 	id, label := hello.DaemonID, hello.DaemonLabel
@@ -256,7 +264,15 @@ func (h *hub) serveClient(conn *websocket.Conn) {
 	defer h.removeClient(cc)
 
 	if data, err := json.Marshal(h.clientSnapshot()); err == nil {
-		cc.send <- data // buffered; never blocks on the first frame
+		// Non-blocking, like every other send: the write pump that drains
+		// cc.send only starts below, so a blocking send to a buffer already
+		// filled by concurrent fan-out (between registration and here) would
+		// hang the connection forever. Worst case the tooltip seeds from the
+		// next daemon_status instead of this snapshot.
+		select {
+		case cc.send <- data:
+		default:
+		}
 	}
 	// Replay cached session state so a client that connected after a daemon
 	// hydrates its list over the WebSocket alone — no cross-origin HTTP needed

--- a/core/cmd/irrlichtrelay/hub.go
+++ b/core/cmd/irrlichtrelay/hub.go
@@ -1,0 +1,439 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"irrlicht/core/adapters/outbound/relay"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+const (
+	helloTimeout = 10 * time.Second
+	pingInterval = 30 * time.Second
+	pongTimeout  = 45 * time.Second
+	writeTimeout = 10 * time.Second
+)
+
+// hub is the relay's in-memory core: it tracks connected daemons, caches the
+// latest session state per (daemon_id, session_id) and the per-daemon adapter
+// registry, and fans daemon push frames out to all connected clients. Single
+// node, no auth, no persistence — everything here is lost on restart and
+// rebuilt from each daemon's reconnect daemon_snapshot.
+type hub struct {
+	mu       sync.Mutex
+	clients  map[*clientConn]struct{}
+	daemons  map[string]*daemonState                     // daemon_id → liveness
+	sessions map[string]map[string]*session.SessionState // daemon_id → session_id → state
+	agents   map[string][]relay.AgentInfo                // daemon_id → adapter registry
+	upgrader websocket.Upgrader
+}
+
+// daemonState tracks one daemon's connection liveness. conns counts live
+// connections so a flapping reconnect (new connects before old read-error
+// surfaces) doesn't prematurely mark the daemon disconnected.
+type daemonState struct {
+	label string
+	since int64
+	conns int
+}
+
+// clientConn is a connected client. send buffers outbound frames; done is
+// closed by the read pump when the socket drops so the write pump exits
+// promptly instead of waiting for the next ping tick.
+type clientConn struct {
+	conn *websocket.Conn
+	send chan []byte
+	done chan struct{}
+}
+
+func newHub() *hub {
+	return &hub{
+		clients:  make(map[*clientConn]struct{}),
+		daemons:  make(map[string]*daemonState),
+		sessions: make(map[string]map[string]*session.SessionState),
+		agents:   make(map[string][]relay.AgentInfo),
+		// Permissive origin policy: v0 is localhost-only with no auth, and the
+		// dashboard served from a different port than the WS endpoint is
+		// cross-origin. Tighten alongside auth in a later phase.
+		upgrader: websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+	}
+}
+
+// ServeWS upgrades the connection, reads the opening hello, and dispatches to
+// the daemon or client path by role. A peer that doesn't announce a daemon
+// hello is treated as a client (lenient), so a stock dashboard still streams.
+func (h *hub) ServeWS(w http.ResponseWriter, r *http.Request) {
+	conn, err := h.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	conn.SetReadDeadline(time.Now().Add(helloTimeout))
+	_, data, err := conn.ReadMessage()
+	conn.SetReadDeadline(time.Time{}) // clear; per-path deadlines take over
+	if err != nil {
+		return
+	}
+	var hello relay.Hello
+	_ = json.Unmarshal(data, &hello)
+	if hello.Type == relay.MsgHello && hello.Role == relay.RoleDaemon {
+		h.serveDaemon(conn, hello)
+		return
+	}
+	h.serveClient(conn)
+}
+
+// --- daemon side ---
+
+func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello) {
+	if hello.DaemonID == "" {
+		return // untracked, undedupable — refuse
+	}
+	id, label := hello.DaemonID, hello.DaemonLabel
+
+	conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+	if err := conn.WriteJSON(relay.HelloAck{Type: relay.MsgHelloAck, AcceptedVersion: relay.ProtocolVersion}); err != nil {
+		return
+	}
+
+	h.daemonConnected(id, label)
+	defer h.daemonDisconnected(id)
+
+	// Ping the daemon so an idle link stays alive (and dead ones are detected
+	// at pongTimeout). Sole writer after the hello_ack above, satisfying
+	// gorilla's one-concurrent-writer rule.
+	done := make(chan struct{})
+	defer close(done)
+	go h.pingLoop(conn, done)
+
+	conn.SetReadDeadline(time.Now().Add(pongTimeout))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(pongTimeout))
+		return nil
+	})
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		h.handleDaemonFrame(id, data)
+	}
+}
+
+func (h *hub) handleDaemonFrame(daemonID string, data []byte) {
+	switch relay.FrameType(data) {
+	case relay.MsgDaemonSnapshot:
+		var ds relay.DaemonSnapshot
+		if json.Unmarshal(data, &ds) == nil {
+			h.applyDaemonSnapshot(daemonID, ds)
+		}
+	case relay.MsgPush:
+		var p relay.Push
+		if json.Unmarshal(data, &p) == nil {
+			h.applyPush(daemonID, p)
+		}
+	}
+}
+
+// applyDaemonSnapshot replaces the daemon's cached sessions with the snapshot
+// and reconciles clients: a session_updated for each session present and a
+// session_deleted for each that vanished since the prior snapshot. This lets a
+// client that connected before the daemon (or before a reconnect) converge
+// live, without depending on an HTTP re-poll.
+func (h *hub) applyDaemonSnapshot(daemonID string, ds relay.DaemonSnapshot) {
+	newMap := make(map[string]*session.SessionState, len(ds.Sessions))
+	for _, s := range ds.Sessions {
+		if s != nil && s.SessionID != "" {
+			newMap[s.SessionID] = s
+		}
+	}
+
+	h.mu.Lock()
+	old := h.sessions[daemonID]
+	h.sessions[daemonID] = newMap
+	h.agents[daemonID] = ds.Agents
+	h.mu.Unlock()
+
+	for _, s := range newMap {
+		h.fanoutPush(daemonID, outbound.PushMessage{Type: outbound.PushTypeUpdated, Session: s})
+	}
+	for sid, s := range old {
+		if _, ok := newMap[sid]; !ok {
+			h.fanoutPush(daemonID, outbound.PushMessage{Type: outbound.PushTypeDeleted, Session: s})
+		}
+	}
+}
+
+// applyPush updates the session cache for session_* frames (so /api/v1/sessions
+// reflects live state) and fans every frame out to clients. History frames
+// carry no Session and are forwarded but not cached — history re-hydration of
+// late-joining clients is deferred to a later phase.
+func (h *hub) applyPush(daemonID string, p relay.Push) {
+	msg := p.Msg
+	if msg.Session != nil && msg.Session.SessionID != "" {
+		sid := msg.Session.SessionID
+		h.mu.Lock()
+		m := h.sessions[daemonID]
+		if m == nil {
+			m = make(map[string]*session.SessionState)
+			h.sessions[daemonID] = m
+		}
+		if msg.Type == outbound.PushTypeDeleted {
+			delete(m, sid)
+		} else {
+			m[sid] = msg.Session
+		}
+		h.mu.Unlock()
+	}
+	h.fanoutPush(daemonID, msg)
+}
+
+func (h *hub) daemonConnected(id, label string) {
+	now := time.Now().Unix()
+	h.mu.Lock()
+	d := h.daemons[id]
+	if d == nil {
+		d = &daemonState{label: label, since: now}
+		h.daemons[id] = d
+	} else {
+		d.label = label
+		if d.conns == 0 {
+			d.since = now
+		}
+	}
+	d.conns++
+	h.mu.Unlock()
+	h.broadcastDaemonStatus(id, label, relay.StatusConnected, now)
+}
+
+func (h *hub) daemonDisconnected(id string) {
+	now := time.Now().Unix()
+	h.mu.Lock()
+	d := h.daemons[id]
+	if d == nil {
+		h.mu.Unlock()
+		return
+	}
+	d.conns--
+	label := d.label
+	if d.conns > 0 {
+		h.mu.Unlock()
+		return // another live connection for this daemon remains
+	}
+	sessions := h.sessions[id]
+	delete(h.daemons, id)
+	delete(h.sessions, id)
+	delete(h.agents, id)
+	h.mu.Unlock()
+
+	// v0 deletes the daemon's rows on disconnect ("fade don't delete" is a
+	// deferred enhancement), then announces the disconnect for the tooltip.
+	for _, s := range sessions {
+		h.fanoutPush(id, outbound.PushMessage{Type: outbound.PushTypeDeleted, Session: s})
+	}
+	h.broadcastDaemonStatus(id, label, relay.StatusDisconnected, now)
+}
+
+// --- client side ---
+
+func (h *hub) serveClient(conn *websocket.Conn) {
+	cc := &clientConn{conn: conn, send: make(chan []byte, 64), done: make(chan struct{})}
+
+	// Register before snapshotting so no daemon_status fired between the two
+	// is missed: any daemon present at snapshot time is in the snapshot, any
+	// connecting after registration arrives as a (possibly duplicate, but
+	// idempotent) daemon_status.
+	h.mu.Lock()
+	h.clients[cc] = struct{}{}
+	h.mu.Unlock()
+	defer h.removeClient(cc)
+
+	if data, err := json.Marshal(h.clientSnapshot()); err == nil {
+		cc.send <- data // buffered; never blocks on the first frame
+	}
+	// Replay cached session state so a client that connected after a daemon
+	// hydrates its list over the WebSocket alone — no cross-origin HTTP needed
+	// for a remote relay source. History is not replayed (deferred); bars fill
+	// in from live ticks.
+	h.replaySessions(cc)
+
+	go h.clientReadPump(cc)
+	h.clientWritePump(cc)
+}
+
+// replaySessions enqueues the relay's cached sessions to one client as
+// source-stamped session_updated pushes. Best-effort: frames beyond the send
+// buffer are dropped (the same-origin HTTP cache and the next delta cover the
+// gap), mirroring the slow-consumer policy.
+func (h *hub) replaySessions(cc *clientConn) {
+	type item struct {
+		daemonID string
+		state    *session.SessionState
+	}
+	h.mu.Lock()
+	items := make([]item, 0)
+	for did, m := range h.sessions {
+		for _, s := range m {
+			items = append(items, item{did, s})
+		}
+	}
+	h.mu.Unlock()
+
+	for _, it := range items {
+		data, err := json.Marshal(relay.Push{
+			Type: relay.MsgPush, Source: it.daemonID, TS: time.Now().Unix(),
+			Msg: outbound.PushMessage{Type: outbound.PushTypeUpdated, Session: it.state},
+		})
+		if err != nil {
+			continue
+		}
+		select {
+		case cc.send <- data:
+		default:
+		}
+	}
+}
+
+func (h *hub) removeClient(cc *clientConn) {
+	h.mu.Lock()
+	delete(h.clients, cc)
+	h.mu.Unlock()
+}
+
+func (h *hub) clientReadPump(cc *clientConn) {
+	defer close(cc.done)
+	cc.conn.SetReadDeadline(time.Now().Add(pongTimeout))
+	cc.conn.SetPongHandler(func(string) error {
+		cc.conn.SetReadDeadline(time.Now().Add(pongTimeout))
+		return nil
+	})
+	for {
+		if _, _, err := cc.conn.ReadMessage(); err != nil {
+			return
+		}
+	}
+}
+
+func (h *hub) clientWritePump(cc *clientConn) {
+	ticker := time.NewTicker(pingInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-cc.done:
+			return
+		case data := <-cc.send:
+			cc.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+			if err := cc.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+				return
+			}
+		case <-ticker.C:
+			cc.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+			if err := cc.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// --- fan-out + snapshots ---
+
+func (h *hub) fanoutPush(daemonID string, msg outbound.PushMessage) {
+	data, err := json.Marshal(relay.Push{Type: relay.MsgPush, Source: daemonID, TS: time.Now().Unix(), Msg: msg})
+	if err != nil {
+		return
+	}
+	h.fanout(data)
+}
+
+func (h *hub) broadcastDaemonStatus(id, label, status string, since int64) {
+	data, err := json.Marshal(relay.DaemonStatus{
+		Type: relay.MsgDaemonStatus, DaemonID: id, DaemonLabel: label, Status: status, Since: since,
+	})
+	if err != nil {
+		return
+	}
+	h.fanout(data)
+}
+
+// fanout delivers one frame to every client, dropping it for any client whose
+// buffer is full (mirrors the daemon push service's slow-consumer policy).
+func (h *hub) fanout(data []byte) {
+	h.mu.Lock()
+	targets := make([]*clientConn, 0, len(h.clients))
+	for cc := range h.clients {
+		targets = append(targets, cc)
+	}
+	h.mu.Unlock()
+	for _, cc := range targets {
+		select {
+		case cc.send <- data:
+		default: // slow client — drop
+		}
+	}
+}
+
+func (h *hub) clientSnapshot() relay.Snapshot {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	daemons := make([]relay.DaemonInfo, 0, len(h.daemons))
+	for id, d := range h.daemons {
+		daemons = append(daemons, relay.DaemonInfo{DaemonID: id, DaemonLabel: d.label, Status: relay.StatusConnected})
+	}
+	return relay.Snapshot{Type: relay.MsgSnapshot, Daemons: daemons}
+}
+
+// buildSessions flattens the per-daemon caches into one list for the HTTP
+// /api/v1/sessions handler.
+func (h *hub) buildSessions() []*session.SessionState {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var all []*session.SessionState
+	for _, m := range h.sessions {
+		for _, s := range m {
+			all = append(all, s)
+		}
+	}
+	return all
+}
+
+// buildAgents returns the union of every daemon's adapter registry, deduped by
+// adapter name (frontends key off Name). Always non-nil so the JSON is [].
+func (h *hub) buildAgents() []relay.AgentInfo {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	seen := make(map[string]bool)
+	out := []relay.AgentInfo{}
+	for _, infos := range h.agents {
+		for _, a := range infos {
+			if seen[a.Name] {
+				continue
+			}
+			seen[a.Name] = true
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func (h *hub) pingLoop(conn *websocket.Conn, done <-chan struct{}) {
+	ticker := time.NewTicker(pingInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}
+}

--- a/core/cmd/irrlichtrelay/hub_test.go
+++ b/core/cmd/irrlichtrelay/hub_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"irrlicht/core/adapters/outbound/relay"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+func newTestServer(t *testing.T) (wsURL, baseURL string) {
+	t.Helper()
+	h := newHub()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/sessions/stream", h.ServeWS)
+	mux.HandleFunc("GET /api/v1/sessions", handleSessions(h))
+	mux.HandleFunc("GET /api/v1/agents", handleAgents(h))
+	mux.HandleFunc("GET /api/v1/version", handleVersion("test"))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return "ws" + strings.TrimPrefix(srv.URL, "http") + "/api/v1/sessions/stream", srv.URL
+}
+
+func dial(t *testing.T, wsURL string) *websocket.Conn {
+	t.Helper()
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial %s: %v", wsURL, err)
+	}
+	t.Cleanup(func() { c.Close() })
+	return c
+}
+
+// readUntil reads frames until one of the wanted type arrives, so a test is
+// robust to interleaved control/other frames.
+func readUntil(t *testing.T, c *websocket.Conn, typ string) []byte {
+	t.Helper()
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	for {
+		_, data, err := c.ReadMessage()
+		if err != nil {
+			t.Fatalf("waiting for %q frame: %v", typ, err)
+		}
+		if relay.FrameType(data) == typ {
+			return data
+		}
+	}
+}
+
+func mustJSON(t *testing.T, data []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", data, err)
+	}
+}
+
+func httpGet(t *testing.T, url string) []byte {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return body
+}
+
+func TestRelayRoundTrip(t *testing.T) {
+	wsURL, baseURL := newTestServer(t)
+
+	// Client connects first — no daemons yet, so the snapshot is empty.
+	client := dial(t, wsURL)
+	if err := client.WriteJSON(relay.Hello{Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion, Role: relay.RoleClient}); err != nil {
+		t.Fatal(err)
+	}
+	var snap relay.Snapshot
+	mustJSON(t, readUntil(t, client, relay.MsgSnapshot), &snap)
+	if len(snap.Daemons) != 0 {
+		t.Fatalf("expected no daemons initially, got %+v", snap.Daemons)
+	}
+
+	// Daemon connects, handshakes, and reconciles one session.
+	daemon := dial(t, wsURL)
+	if err := daemon.WriteJSON(relay.Hello{
+		Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion,
+		Role: relay.RoleDaemon, DaemonID: "d1", DaemonLabel: "laptop",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var ack relay.HelloAck
+	if err := daemon.ReadJSON(&ack); err != nil || ack.Type != relay.MsgHelloAck || ack.AcceptedVersion != relay.ProtocolVersion {
+		t.Fatalf("hello_ack: err=%v ack=%+v", err, ack)
+	}
+	if err := daemon.WriteJSON(relay.DaemonSnapshot{
+		Type:     relay.MsgDaemonSnapshot,
+		Sessions: []*session.SessionState{{SessionID: "s1", State: "working", ProjectName: "proj"}},
+		Agents:   []relay.AgentInfo{{Name: "claude-code", DisplayName: "Claude Code"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The pre-existing client sees the daemon appear and its session arrive live.
+	var ds relay.DaemonStatus
+	mustJSON(t, readUntil(t, client, relay.MsgDaemonStatus), &ds)
+	if ds.DaemonID != "d1" || ds.DaemonLabel != "laptop" || ds.Status != relay.StatusConnected {
+		t.Fatalf("unexpected daemon_status: %+v", ds)
+	}
+	var p relay.Push
+	mustJSON(t, readUntil(t, client, relay.MsgPush), &p)
+	if p.Source != "d1" || p.Msg.Session == nil || p.Msg.Session.SessionID != "s1" {
+		t.Fatalf("snapshot reconciliation push wrong: %+v", p)
+	}
+
+	// HTTP mirrors the cache: the session and the agent union.
+	if body := httpGet(t, baseURL+"/api/v1/sessions"); !bytes.Contains(body, []byte(`"session_id":"s1"`)) {
+		t.Fatalf("/api/v1/sessions missing s1: %s", body)
+	}
+	if body := httpGet(t, baseURL+"/api/v1/agents"); !bytes.Contains(body, []byte(`"name":"claude-code"`)) {
+		t.Fatalf("/api/v1/agents missing claude-code: %s", body)
+	}
+
+	// A live delta forwards through, source-stamped.
+	if err := daemon.WriteJSON(relay.Push{
+		Type: relay.MsgPush, Source: "ignored-by-relay",
+		Msg: outbound.PushMessage{Type: outbound.PushTypeUpdated, Session: &session.SessionState{SessionID: "s2", State: "ready"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	mustJSON(t, readUntil(t, client, relay.MsgPush), &p)
+	if p.Source != "d1" || p.Msg.Session == nil || p.Msg.Session.SessionID != "s2" {
+		t.Fatalf("live delta push wrong (source must be stamped d1): %+v", p)
+	}
+
+	// Daemon drops → the relay deletes its rows and announces disconnect.
+	daemon.Close()
+	sawDisconnect := false
+	deadline := time.Now().Add(2 * time.Second)
+	for !sawDisconnect && time.Now().Before(deadline) {
+		client.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, data, err := client.ReadMessage()
+		if err != nil {
+			t.Fatalf("reading after daemon close: %v", err)
+		}
+		if relay.FrameType(data) == relay.MsgDaemonStatus {
+			var d relay.DaemonStatus
+			mustJSON(t, data, &d)
+			if d.DaemonID == "d1" && d.Status == relay.StatusDisconnected {
+				sawDisconnect = true
+			}
+		}
+	}
+	if !sawDisconnect {
+		t.Fatal("never observed the daemon disconnect status")
+	}
+}
+
+func TestRelayReplaysCacheToLateClient(t *testing.T) {
+	wsURL, _ := newTestServer(t)
+
+	// Daemon connects and caches a session first.
+	daemon := dial(t, wsURL)
+	if err := daemon.WriteJSON(relay.Hello{
+		Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion,
+		Role: relay.RoleDaemon, DaemonID: "d1", DaemonLabel: "laptop",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var ack relay.HelloAck
+	if err := daemon.ReadJSON(&ack); err != nil {
+		t.Fatal(err)
+	}
+	if err := daemon.WriteJSON(relay.DaemonSnapshot{
+		Type:     relay.MsgDaemonSnapshot,
+		Sessions: []*session.SessionState{{SessionID: "s1", State: "working", ProjectName: "proj"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Let the relay ingest the snapshot before the client connects.
+	time.Sleep(50 * time.Millisecond)
+
+	// A client connecting now must still receive s1 over the WS via replay.
+	client := dial(t, wsURL)
+	if err := client.WriteJSON(relay.Hello{Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion, Role: relay.RoleClient}); err != nil {
+		t.Fatal(err)
+	}
+	var p relay.Push
+	mustJSON(t, readUntil(t, client, relay.MsgPush), &p)
+	if p.Source != "d1" || p.Msg.Session == nil || p.Msg.Session.SessionID != "s1" {
+		t.Fatalf("expected replayed s1 push, got %+v", p)
+	}
+}
+
+func TestResolveUIDirEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveUIDirFor(dir, "", ""); got != dir {
+		t.Fatalf("resolveUIDirFor env = %q, want %q", got, dir)
+	}
+	if got := resolveUIDirFor("/nonexistent", "", ""); got != "" {
+		t.Fatalf("resolveUIDirFor miss = %q, want empty", got)
+	}
+}

--- a/core/cmd/irrlichtrelay/hub_test.go
+++ b/core/cmd/irrlichtrelay/hub_test.go
@@ -201,6 +201,78 @@ func TestRelayReplaysCacheToLateClient(t *testing.T) {
 	}
 }
 
+func TestRelayDaemonDisconnectDeletesSessions(t *testing.T) {
+	wsURL, baseURL := newTestServer(t)
+
+	client := dial(t, wsURL)
+	if err := client.WriteJSON(relay.Hello{Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion, Role: relay.RoleClient}); err != nil {
+		t.Fatal(err)
+	}
+	readUntil(t, client, relay.MsgSnapshot)
+
+	daemon := dial(t, wsURL)
+	if err := daemon.WriteJSON(relay.Hello{
+		Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion,
+		Role: relay.RoleDaemon, DaemonID: "d1", DaemonLabel: "laptop",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var ack relay.HelloAck
+	if err := daemon.ReadJSON(&ack); err != nil {
+		t.Fatal(err)
+	}
+	if err := daemon.WriteJSON(relay.DaemonSnapshot{
+		Type:     relay.MsgDaemonSnapshot,
+		Sessions: []*session.SessionState{{SessionID: "s1", State: "working", ProjectName: "proj"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drain the connect status + the snapshot-reconciliation push, and confirm
+	// the session is cached.
+	readUntil(t, client, relay.MsgDaemonStatus)
+	readUntil(t, client, relay.MsgPush)
+	if body := httpGet(t, baseURL+"/api/v1/sessions"); !bytes.Contains(body, []byte(`"session_id":"s1"`)) {
+		t.Fatalf("expected s1 cached before disconnect, got %s", body)
+	}
+
+	// Daemon drops → the relay must fan out a session_deleted for its cached
+	// session and a disconnected status, and evict the session from the cache.
+	daemon.Close()
+	sawDelete, sawDisconnect := false, false
+	deadline := time.Now().Add(2 * time.Second)
+	for (!sawDelete || !sawDisconnect) && time.Now().Before(deadline) {
+		client.SetReadDeadline(time.Now().Add(2 * time.Second))
+		_, data, err := client.ReadMessage()
+		if err != nil {
+			t.Fatalf("reading after daemon close: %v", err)
+		}
+		switch relay.FrameType(data) {
+		case relay.MsgPush:
+			var p relay.Push
+			mustJSON(t, data, &p)
+			if p.Msg.Type == outbound.PushTypeDeleted && p.Msg.Session != nil && p.Msg.Session.SessionID == "s1" {
+				sawDelete = true
+			}
+		case relay.MsgDaemonStatus:
+			var ds relay.DaemonStatus
+			mustJSON(t, data, &ds)
+			if ds.DaemonID == "d1" && ds.Status == relay.StatusDisconnected {
+				sawDisconnect = true
+			}
+		}
+	}
+	if !sawDelete {
+		t.Fatal("no session_deleted push for the disconnected daemon's session")
+	}
+	if !sawDisconnect {
+		t.Fatal("no daemon disconnect status")
+	}
+	if body := httpGet(t, baseURL+"/api/v1/sessions"); bytes.Contains(body, []byte(`"session_id":"s1"`)) {
+		t.Fatalf("s1 should be evicted from the cache after daemon disconnect, got %s", body)
+	}
+}
+
 func TestResolveUIDirEnvOverride(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("ok"), 0o644); err != nil {

--- a/core/cmd/irrlichtrelay/main.go
+++ b/core/cmd/irrlichtrelay/main.go
@@ -1,0 +1,142 @@
+// Command irrlichtrelay is the standalone relay server: daemons push their
+// session events to it over a WebSocket, and it fans them out to connected
+// macOS/web clients while re-serving the dashboard and the daemon's HTTP API
+// (/api/v1/sessions, /api/v1/agents, /api/v1/version) from an in-memory cache.
+//
+// v0 is deliberately thin: single node, in-memory only, no auth, no TLS, no
+// persistence. State is rebuilt from each daemon's reconnect daemon_snapshot.
+// See docs/relay-protocol.md.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"mime"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"time"
+)
+
+// Version is injected at build time via -ldflags "-X main.Version=x.y.z".
+var Version = "dev"
+
+const envUIDir = "IRRLICHT_UI_DIR"
+
+func main() {
+	args := os.Args[1:]
+	if len(args) > 0 && (args[0] == "--version" || args[0] == "-v") {
+		fmt.Printf("irrlichtrelay version %s\n", Version)
+		fmt.Printf("Built with %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		return
+	}
+	// Accept an optional "serve" subcommand for forward-compatibility with
+	// later verbs (e.g. token issue); v0 has only serve.
+	if len(args) > 0 && args[0] == "serve" {
+		args = args[1:]
+	}
+	fs := flag.NewFlagSet("irrlichtrelay", flag.ExitOnError)
+	addr := fs.String("addr", ":7838", "TCP address to listen on (e.g. :7838)")
+	_ = fs.Parse(args)
+
+	// Serve web assets with correct Content-Type regardless of the host OS
+	// mime database (matches irrlichd).
+	_ = mime.AddExtensionType(".js", "application/javascript")
+	_ = mime.AddExtensionType(".css", "text/css")
+
+	h := newHub()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/sessions/stream", h.ServeWS)
+	mux.HandleFunc("GET /api/v1/sessions", handleSessions(h))
+	mux.HandleFunc("GET /api/v1/agents", handleAgents(h))
+	mux.HandleFunc("GET /api/v1/version", handleVersion(Version))
+
+	if uiDir := resolveUIDir(); uiDir != "" {
+		log.Printf("serving dashboard from %s", uiDir)
+		mux.Handle("/", http.FileServer(http.Dir(uiDir)))
+	} else {
+		log.Printf("dashboard UI not found — set %s to the directory containing index.html", envUIDir)
+		mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "dashboard UI not found", http.StatusServiceUnavailable)
+		})
+	}
+
+	// WS connections are hijacked by gorilla after the upgrade, so the only
+	// server-level timeout that applies is the header read.
+	srv := &http.Server{
+		Addr:              *addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		log.Printf("irrlichtrelay %s listening on %s", Version, *addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("listen on %s failed: %v", *addr, err)
+		}
+	}()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	<-sig
+	log.Print("shutting down")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(ctx)
+}
+
+// resolveUIDir locates the dashboard's index.html, mirroring irrlichd's search
+// order so the relay serves the same three-file dashboard in dev and packaged
+// installs: env override → app bundle Resources → daemon curl-install dir →
+// walk up from the executable to the repo root for platforms/web/.
+func resolveUIDir() string {
+	exe, _ := os.Executable()
+	home, _ := os.UserHomeDir()
+	return resolveUIDirFor(os.Getenv(envUIDir), exe, home)
+}
+
+func resolveUIDirFor(env, exe, home string) string {
+	hasIndex := func(dir string) bool {
+		if dir == "" {
+			return false
+		}
+		_, err := os.Stat(filepath.Join(dir, "index.html"))
+		return err == nil
+	}
+	if hasIndex(env) {
+		return env
+	}
+	if exe != "" {
+		if cand := filepath.Join(filepath.Dir(exe), "..", "Resources", "web"); hasIndex(cand) {
+			return cand
+		}
+	}
+	if home != "" {
+		if cand := filepath.Join(home, ".local", "share", "irrlicht", "web"); hasIndex(cand) {
+			return cand
+		}
+	}
+	if exe != "" {
+		dir := filepath.Dir(exe)
+		for range 8 {
+			if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+				if cand := filepath.Join(dir, "platforms", "web"); hasIndex(cand) {
+					return cand
+				}
+				return "" // repo root found, no UI inside — don't escape it
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+	return ""
+}

--- a/core/cmd/irrlichtrelay/main.go
+++ b/core/cmd/irrlichtrelay/main.go
@@ -41,7 +41,11 @@ func main() {
 		args = args[1:]
 	}
 	fs := flag.NewFlagSet("irrlichtrelay", flag.ExitOnError)
-	addr := fs.String("addr", ":7839", "TCP address to listen on (e.g. :7839)")
+	// Loopback by default: v0 has no auth and a permissive WS origin policy, so
+	// it must not be reachable from the LAN unless explicitly asked. Pass
+	// --addr 0.0.0.0:7839 (or a specific interface) to expose it — and only
+	// once bearer-token auth lands. Mirrors the daemon's loopback default.
+	addr := fs.String("addr", "127.0.0.1:7839", "TCP address to listen on; defaults to loopback (use 0.0.0.0:7839 to expose on the LAN)")
 	_ = fs.Parse(args)
 
 	// Serve web assets with correct Content-Type regardless of the host OS

--- a/core/cmd/irrlichtrelay/main.go
+++ b/core/cmd/irrlichtrelay/main.go
@@ -41,7 +41,7 @@ func main() {
 		args = args[1:]
 	}
 	fs := flag.NewFlagSet("irrlichtrelay", flag.ExitOnError)
-	addr := fs.String("addr", ":7838", "TCP address to listen on (e.g. :7838)")
+	addr := fs.String("addr", ":7839", "TCP address to listen on (e.g. :7839)")
 	_ = fs.Parse(args)
 
 	// Serve web assets with correct Content-Type regardless of the host OS

--- a/docs/relay-protocol.md
+++ b/docs/relay-protocol.md
@@ -1,0 +1,156 @@
+# Relay wire protocol (v0)
+
+The relay link lets an `irrlichd` daemon push its session events to a standalone
+`irrlichtrelay` server, which fans them out to macOS and web clients. The daemon
+pushes **out** to the relay, so it needs no inbound reachability (works behind
+NAT). Hub-mode inside `irrlichd` was rejected — the relay is always its own
+binary. See the [Relay-Server wiki](https://github.com/ingo-eichhorst/Irrlicht/wiki/Relay-Server).
+
+This document covers **only what v0 builds**. Fields marked _reserved_ are named
+here so the shape is stable, but they are neither sent nor honored yet.
+
+## Topology
+
+```
+irrlichd ──(daemon role)──▶ irrlichtrelay ◀──(client role)── macOS app / web dashboard
+```
+
+- One WebSocket endpoint, `GET /api/v1/sessions/stream`, carries both roles; the
+  opening `hello.role` selects the path.
+- A client may connect to the local daemon **and/or** a relay at once and merges
+  the sessions into one list. The daemon speaks **raw** `PushMessage` frames (no
+  handshake); the relay speaks the **envelope** below.
+- v0 is deliberately thin: **no auth, no TLS, no persistence, single node, one
+  relay per daemon.** Relay state is in-memory and rebuilt from each daemon's
+  reconnect `daemon_snapshot`.
+
+## Versioning
+
+`hello.protocol_version` is the wire version (currently `1`); the relay echoes
+the negotiated value in `hello_ack.accepted_version`. Bump only on a breaking
+change to the frames below.
+
+## Frames
+
+Every frame is a JSON text message with a `type` tag.
+
+### `hello` (peer → relay, both roles)
+
+```jsonc
+{ "type": "hello", "protocol_version": 1, "role": "daemon" | "client",
+  "daemon_id": "uuid", "daemon_label": "laptop" }   // daemon_* set by daemons only
+```
+
+A daemon mints `daemon_id` once and persists it at
+`~/.local/share/irrlicht/relay-identity.json` (relocated by `IRRLICHT_HOME`), so
+the id is stable across restarts; clients dedupe by it. `daemon_label` defaults
+to the hostname. The relay **refuses** a daemon `hello` with an empty
+`daemon_id`. A client `hello` omits the daemon fields.
+
+### `hello_ack` (relay → peer)
+
+```jsonc
+{ "type": "hello_ack", "accepted_version": 1 }
+```
+
+### `daemon_snapshot` (daemon → relay, after the ack)
+
+```jsonc
+{ "type": "daemon_snapshot",
+  "sessions": [ <SessionState>, ... ],   // the daemon's current sessions
+  "agents":   [ <AgentInfo>, ... ] }     // its adapter registry (/api/v1/agents shape)
+```
+
+Sent once per (re)connect to reconcile the relay's cache. The relay replaces
+that daemon's cached sessions with the snapshot and reconciles connected
+clients: a `session_updated` push for each session present, a `session_deleted`
+for each that vanished since the prior snapshot.
+
+### `snapshot` (relay → client, after the ack)
+
+```jsonc
+{ "type": "snapshot",
+  "daemons": [ { "daemon_id": "uuid", "daemon_label": "laptop", "status": "connected" }, ... ] }
+```
+
+The identity + status list that seeds the client's connection-status tooltip.
+
+### `daemon_status` (relay → clients, on daemon connect/disconnect)
+
+```jsonc
+{ "type": "daemon_status", "daemon_id": "uuid", "daemon_label": "laptop",
+  "status": "connected" | "disconnected", "since": 1778800000 }
+```
+
+Keeps the tooltip live without a full re-`snapshot`.
+
+### `push` (daemon → relay → client; the live channel)
+
+```jsonc
+{ "type": "push", "source": "daemon-uuid", "ts": 1778800000,
+  "msg": { ...existing outbound.PushMessage, UNCHANGED... } }
+```
+
+The daemon wraps each `PushMessage` it would send on its own WebSocket. The relay
+stamps `source` with the originating `daemon_id` (authoritative — it does not
+trust the daemon's stamp) and re-emits to every client. **Clients read `.msg`
+and process it exactly as a raw daemon frame.** `focus_requested` is filtered at
+the forwarder (host-local; meaningless cross-host, wiki §5.4).
+
+## Client behavior
+
+A single client handler covers both source kinds: it always sends a client
+`hello` (a daemon ignores unexpected frames; a relay requires it) and dispatches
+by frame type — `push` unwraps `.msg`, `snapshot`/`daemon_status` feed the
+tooltip, and anything else is a raw daemon frame. On WS connect the relay also
+**replays its cached session state** to that client as `session_updated` pushes,
+so a client that connects after a daemon hydrates over the socket alone (no
+cross-origin HTTP needed).
+
+Sessions are keyed by `session_id`. The same daemon reached over both the local
+socket and a relay collapses to one row automatically. **Caveat:** two
+*different* daemons that share a `session_id` (e.g. `proc-<pid>`) would merge —
+per-source keying and row-level source badges are deferred.
+
+## HTTP
+
+The relay re-serves the daemon's read API from its cache so clients render
+without an empty first paint, and serves the `platforms/web/` dashboard:
+
+| Endpoint              | Body                                                            |
+| --------------------- | -------------------------------------------------------------- |
+| `GET /api/v1/sessions` | `{ "groups": [...] }` — `BuildDashboard` over the cached sessions (grouped by project; no orchestrator state in v0). |
+| `GET /api/v1/agents`   | union of every connected daemon's registry, deduped by `name`. |
+| `GET /api/v1/version`  | the relay's own build version.                                 |
+| `GET /` (+ assets)     | the dashboard, served from disk (`IRRLICHT_UI_DIR` override, else dev/bundle lookup). |
+
+WebSocket `CheckOrigin` is permissive in v0 (localhost-only, no auth; the
+dashboard served from a different port is cross-origin). Tighten alongside auth.
+
+## Running it
+
+```sh
+irrlichd                                    # daemon on :7837 (its default)
+IRRLICHT_RELAY_URL=ws://localhost:7838 irrlichd   # …also forwards to the relay
+irrlichtrelay serve --addr :7838            # the relay
+```
+
+> **Port note:** `--addr :7838` is the relay's default, but `7838` is also the
+> conventional **dev daemon** coexist port (`IRRLICHT_DAEMON_PORT`/`BIND_ADDR`).
+> Don't run a coexisting dev daemon and the relay on the same port — give one of
+> them a different port.
+
+Then in **Settings → Sources** (macOS or web) enable **Local** and/or enter the
+**Relay server URL**; both clients show the union of sessions, live, and the
+connection-status tooltip lists the connected daemon(s).
+
+## Reserved (named, not built)
+
+- `auth` / bearer tokens, `token issue|list|revoke` CLI.
+- `seq` (per-source sequence numbers) and `resume` (reconnect cursor) for
+  gap-free reconnection.
+- Multiple relays per daemon; multi-node relays; persistence; TLS.
+- Row-level source badges and "fade, don't delete" on daemon-offline (v0 deletes
+  a disconnected daemon's rows).
+- History re-hydration of late-joining relay clients (bars fill from live ticks;
+  session state *is* replayed, history snapshots are not).

--- a/docs/relay-protocol.md
+++ b/docs/relay-protocol.md
@@ -131,14 +131,16 @@ dashboard served from a different port is cross-origin). Tighten alongside auth.
 
 ```sh
 irrlichd                                    # daemon on :7837 (its default)
-IRRLICHT_RELAY_URL=ws://localhost:7838 irrlichd   # …also forwards to the relay
-irrlichtrelay serve --addr :7838            # the relay
+IRRLICHT_RELAY_URL=ws://localhost:7839 irrlichd   # …also forwards to the relay
+irrlichtrelay serve --addr :7839            # the relay
 ```
 
-> **Port note:** `--addr :7838` is the relay's default, but `7838` is also the
-> conventional **dev daemon** coexist port (`IRRLICHT_DAEMON_PORT`/`BIND_ADDR`).
-> Don't run a coexisting dev daemon and the relay on the same port — give one of
-> them a different port.
+> **Port choice:** irrlicht uses three contiguous ports — `7837` (production
+> daemon), `7838` (dev-daemon coexist via `IRRLICHT_DAEMON_PORT`/`BIND_ADDR`),
+> and `7839` (relay default). All three sit in the `7836–7850` band, which has
+> no IANA-notable service and is effectively never seen open in the wild (per
+> nmap-services frequency data), so collisions are unlikely. Override any of
+> them — `--addr` for the relay — if your environment already uses one.
 
 Then in **Settings → Sources** (macOS or web) enable **Local** and/or enter the
 **Relay server URL**; both clients show the union of sessions, live, and the

--- a/docs/relay-protocol.md
+++ b/docs/relay-protocol.md
@@ -130,17 +130,23 @@ dashboard served from a different port is cross-origin). Tighten alongside auth.
 ## Running it
 
 ```sh
-irrlichd                                    # daemon on :7837 (its default)
+irrlichd                                          # daemon on :7837 (its default)
 IRRLICHT_RELAY_URL=ws://localhost:7839 irrlichd   # …also forwards to the relay
-irrlichtrelay serve --addr :7839            # the relay
+irrlichtrelay serve                               # the relay on 127.0.0.1:7839
 ```
+
+> **Bind:** the relay listens on **`127.0.0.1:7839`** by default. v0 has no auth
+> and a permissive WS origin policy, so it stays loopback-only until bearer-token
+> auth lands. To watch sessions across machines, opt in explicitly with
+> `irrlichtrelay serve --addr 0.0.0.0:7839` (or a specific interface) — aware
+> that anyone who can reach that address can read every session and inject as a
+> daemon. This mirrors the daemon's own loopback-by-default posture.
 
 > **Port choice:** irrlicht uses three contiguous ports — `7837` (production
 > daemon), `7838` (dev-daemon coexist via `IRRLICHT_DAEMON_PORT`/`BIND_ADDR`),
 > and `7839` (relay default). All three sit in the `7836–7850` band, which has
 > no IANA-notable service and is effectively never seen open in the wild (per
-> nmap-services frequency data), so collisions are unlikely. Override any of
-> them — `--addr` for the relay — if your environment already uses one.
+> nmap-services frequency data), so collisions are unlikely.
 
 Then in **Settings → Sources** (macOS or web) enable **Local** and/or enter the
 **Relay server URL**; both clients show the union of sessions, live, and the

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -103,7 +103,13 @@ class SessionManager: ObservableObject {
     /// Relay-sourced sessions, keyed by session id.
     private var relaySessionMap: [String: SessionState] = [:]
     /// Daemons the relay reports connected: daemon_id → label, for the tooltip.
-    private var relayDaemons: [String: String] = [:]
+    /// Drives `connectionTooltip` (a computed property read by the view) but
+    /// isn't @Published, so nudge SwiftUI on every change — otherwise a
+    /// daemon_status update with no accompanying session change leaves the
+    /// tooltip stale.
+    private var relayDaemons: [String: String] = [:] {
+        willSet { objectWillChange.send() }
+    }
     /// The relay URL currently connected, so a URL change forces a reconnect.
     private var activeRelayURL: String = ""
     /// Local groups before relay groups are appended. `apiGroups` (published)
@@ -219,6 +225,10 @@ class SessionManager: ObservableObject {
         connectTask = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
         webSocketTask = nil
+        // Cancel a pending debounced rehydration too, so disabling the Local
+        // source can't be undone ~0.5s later by an in-flight hydrateSessions().
+        rehydrationTask?.cancel()
+        rehydrationTask = nil
         connectionState = .disconnected
     }
 
@@ -354,7 +364,6 @@ class SessionManager: ObservableObject {
         let task = URLSession.shared.webSocketTask(with: url)
         relayWebSocketTask = task
         task.resume()
-        relayReconnectDelay = 1.0
         relayConnectionState = .connected
         print("🔌 Relay connected to \(activeRelayURL)")
 
@@ -363,8 +372,17 @@ class SessionManager: ObservableObject {
         try? await task.send(.string(#"{"type":"hello","protocol_version":1,"role":"client"}"#))
 
         do {
+            var confirmed = false
             while !Task.isCancelled {
                 let message = try await task.receive()
+                // Reset the backoff only once the relay actually delivers a
+                // frame. resume() returns before the connection is known good,
+                // so resetting there would defeat the backoff and spin a ~1/s
+                // reconnect loop against an unreachable relay.
+                if !confirmed {
+                    confirmed = true
+                    relayReconnectDelay = 1.0
+                }
                 switch message {
                 case .string(let text):
                     handleRelayMessage(text)
@@ -379,7 +397,18 @@ class SessionManager: ObservableObject {
         }
 
         guard relayConnectionState != .disconnected && !Task.isCancelled else { return }
+        // While the link is down we no longer know the remote state, so drop
+        // the relay's daemons and sessions — otherwise a remote session that
+        // ended during the outage lingers as a ghost row (the relay's replay
+        // can only re-add survivors, never signal the deletions we missed).
+        // The relay's replay rebuilds the live set on reconnect; sessions also
+        // present locally stay (they live in sessionMap, which local wins).
         relayDaemons.removeAll()
+        if !relaySessionMap.isEmpty {
+            relaySessionMap.removeAll()
+            rebuildSessionsFromMap()
+            recomposeApiGroups()
+        }
         let jitter = Double.random(in: 0...(relayReconnectDelay * 0.2))
         let delay = relayReconnectDelay + jitter
         relayConnectionState = .reconnecting
@@ -468,6 +497,12 @@ class SessionManager: ObservableObject {
         switch env.type {
         case "session_created", "session_updated":
             if let s = env.session {
+                // Notify on a state transition for a relay-only session. One
+                // also present locally is handled by the local path, so
+                // notifying here too would double-fire.
+                if sessionMap[s.id] == nil, let old = relaySessionMap[s.id]?.state, old != s.state {
+                    checkStateTransitionNotification(session: s, previousState: old)
+                }
                 relaySessionMap[s.id] = s
                 rebuildSessionsFromMap()
                 recomposeApiGroups()
@@ -500,10 +535,14 @@ class SessionManager: ObservableObject {
         guard !relaySessionMap.isEmpty else { return [] }
         let localIDs = Set(sessionMap.keys)
         let relayOnly = relaySessionMap.values.filter { !localIDs.contains($0.id) }
-        let relayIDs = Set(relayOnly.map { $0.id })
+        // A relay session is top-level only if its parent is unknown in BOTH
+        // maps — matching rebuildSessionsFromMap, which excludes any session
+        // whose parent it can see. Keeps a relay child of a local parent from
+        // surfacing as a stray top-level row that the flat list omits.
+        let knownIDs = localIDs.union(relaySessionMap.keys)
         let topLevel = relayOnly.filter { s in
             guard let pid = s.parentSessionId else { return true }
-            return !relayIDs.contains(pid)
+            return !knownIDs.contains(pid)
         }
         guard !topLevel.isEmpty else { return [] }
         var byProject: [String: [SessionState]] = [:]
@@ -768,6 +807,11 @@ class SessionManager: ObservableObject {
     }
 
     private func hydrateSessions() async {
+        // The Local source feeds sessionMap/localApiGroups from the local
+        // daemon's REST API. When Local is disabled this must not run, or the
+        // 30s cost-poll timer (and any pending rehydration) would silently
+        // re-add the local sessions that disabling the source just cleared.
+        guard useLocalDaemon else { return }
         guard let url = URL(string: "\(DaemonEndpoint.httpBase)/api/v1/sessions") else { return }
         do {
             let (data, response) = try await URLSession.shared.data(from: url)

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -18,6 +18,17 @@ enum ConnectionState {
         case .disconnected: return "Daemon disconnected"
         }
     }
+
+    /// Compact one-word label for the per-source line in the multi-source
+    /// connection tooltip (e.g. "Local — connected").
+    var shortLabel: String {
+        switch self {
+        case .connected:    return "connected"
+        case .connecting:   return "connecting"
+        case .reconnecting: return "reconnecting"
+        case .disconnected: return "disconnected"
+        }
+    }
 }
 
 @MainActor
@@ -76,6 +87,39 @@ class SessionManager: ObservableObject {
     private let maxReconnectDelay: TimeInterval = 30.0
     var sessionMap: [String: SessionState] = [:]
 
+    // MARK: - Relay source (multi-source)
+    // A second, optional connection to a standalone irrlichtrelay. It speaks
+    // the relay envelope (a `hello` handshake, then `push`-wrapped frames);
+    // the local connection above speaks raw daemon frames. Relay sessions are
+    // held in their own map so the 30s local re-hydration — which replaces
+    // `sessionMap` wholesale — can never drop them. A relay session whose id
+    // also exists locally collapses to the local copy on merge, so the same
+    // daemon reached over both paths shows once.
+
+    private var relayWebSocketTask: URLSessionWebSocketTask?
+    private var relayConnectTask: Task<Void, Never>?
+    private var relayReconnectDelay: TimeInterval = 1.0
+    @Published var relayConnectionState: ConnectionState = .disconnected
+    /// Relay-sourced sessions, keyed by session id.
+    private var relaySessionMap: [String: SessionState] = [:]
+    /// Daemons the relay reports connected: daemon_id → label, for the tooltip.
+    private var relayDaemons: [String: String] = [:]
+    /// The relay URL currently connected, so a URL change forces a reconnect.
+    private var activeRelayURL: String = ""
+    /// Local groups before relay groups are appended. `apiGroups` (published)
+    /// is always `orderedGroups(localApiGroups) + relayGroups()`.
+    private var localApiGroups: [AgentGroup] = []
+    /// Last-applied source configuration, so the UserDefaults observer only
+    /// reconnects when a Sources setting actually changed.
+    private var lastSourceConfig: String = ""
+
+    private var useLocalDaemon: Bool { UserDefaults.standard.bool(forKey: "useLocalDaemon") }
+    private var useRelayServer: Bool { UserDefaults.standard.bool(forKey: "useRelayServer") }
+    private var relayServerURL: String {
+        (UserDefaults.standard.string(forKey: "relayServerURL") ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     /// GasTownProvider reference for forwarding Gas Town availability.
     weak var gasTownProvider: GasTownProvider? {
         didSet {
@@ -118,6 +162,11 @@ class SessionManager: ObservableObject {
         var defaultsSeed: [String: Any] = [
             "launchAtLogin": true,
             "didApplyDefaultLoginItem": false,
+            // Sources: local on by default, relay opt-in by URL (mirrors the
+            // web dashboard's enableLocalSource / enableRelaySource / relayUrl).
+            "useLocalDaemon": true,
+            "useRelayServer": false,
+            "relayServerURL": "",
         ]
         for event in NotificationEvent.allCases {
             defaultsSeed[event.enabledKey] = true
@@ -125,11 +174,20 @@ class SessionManager: ObservableObject {
         }
         UserDefaults.standard.register(defaults: defaultsSeed)
 
+        // Reconnect sources live when a Sources setting changes (no relaunch).
+        // didChangeNotification fires for any default; sourcesSettingsChanged
+        // diffs and only reconnects on an actual source-config change.
+        NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.sourcesSettingsChanged() }
+        }
+
         Task {
             loadSessionOrder()
             loadProjectGroupOrder()
             requestNotificationPermission()
-            self.startWebSocket()
+            self.sourcesSettingsChanged()
             self.startProjectCostsPolling()
         }
     }
@@ -139,6 +197,10 @@ class SessionManager: ObservableObject {
         connectTask = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
         webSocketTask = nil
+        relayConnectTask?.cancel()
+        relayConnectTask = nil
+        relayWebSocketTask?.cancel(with: .normalClosure, reason: nil)
+        relayWebSocketTask = nil
         projectCostsTimer?.invalidate()
         projectCostsTimer = nil
     }
@@ -211,6 +273,281 @@ class SessionManager: ObservableObject {
 
         reconnectDelay = min(reconnectDelay * 2, maxReconnectDelay)
         scheduleConnect(after: delay)
+    }
+
+    // MARK: - Sources reconciliation
+
+    /// Diffs the current Sources config against the last applied one and
+    /// reconnects only on change. Cheap to call on every UserDefaults change.
+    private func sourcesSettingsChanged() {
+        let cfg = "\(useLocalDaemon)|\(useRelayServer)|\(relayServerURL)"
+        guard cfg != lastSourceConfig else { return }
+        lastSourceConfig = cfg
+        reconcileSources()
+    }
+
+    /// Brings the live connections in line with the Sources settings: starts
+    /// or stops the local and relay links, restarting the relay if its URL
+    /// changed.
+    private func reconcileSources() {
+        if useLocalDaemon {
+            if connectionState == .disconnected { startWebSocket() }
+        } else if connectionState != .disconnected {
+            stopWebSocket()
+            sessionMap.removeAll()
+            localApiGroups.removeAll()
+            rebuildSessionsFromMap()
+            recomposeApiGroups()
+        }
+
+        let url = relayServerURL
+        if useRelayServer && !url.isEmpty {
+            if relayConnectionState == .disconnected || url != activeRelayURL {
+                stopRelay()
+                activeRelayURL = url
+                startRelay()
+            }
+        } else if relayConnectionState != .disconnected {
+            stopRelay()
+        }
+    }
+
+    // MARK: - Relay WebSocket
+
+    func startRelay() {
+        guard relayConnectionState == .disconnected else { return }
+        relayConnectionState = .connecting
+        relayReconnectDelay = 1.0
+        scheduleRelayConnect(after: 0)
+    }
+
+    func stopRelay() {
+        relayConnectTask?.cancel()
+        relayConnectTask = nil
+        relayWebSocketTask?.cancel(with: .normalClosure, reason: nil)
+        relayWebSocketTask = nil
+        relayConnectionState = .disconnected
+        relayDaemons.removeAll()
+        if !relaySessionMap.isEmpty {
+            relaySessionMap.removeAll()
+            rebuildSessionsFromMap()
+            recomposeApiGroups()
+        }
+    }
+
+    private func scheduleRelayConnect(after delay: TimeInterval) {
+        relayConnectTask = Task { [weak self] in
+            guard let self else { return }
+            if delay > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+            guard !Task.isCancelled else { return }
+            await self.relayConnect()
+        }
+    }
+
+    private func relayConnect() async {
+        guard let url = relayStreamURL(activeRelayURL) else {
+            relayConnectionState = .disconnected
+            return
+        }
+        let task = URLSession.shared.webSocketTask(with: url)
+        relayWebSocketTask = task
+        task.resume()
+        relayReconnectDelay = 1.0
+        relayConnectionState = .connected
+        print("🔌 Relay connected to \(activeRelayURL)")
+
+        // Announce as a client so the relay streams enveloped frames. Harmless
+        // if the URL actually points at a daemon (it ignores the frame).
+        try? await task.send(.string(#"{"type":"hello","protocol_version":1,"role":"client"}"#))
+
+        do {
+            while !Task.isCancelled {
+                let message = try await task.receive()
+                switch message {
+                case .string(let text):
+                    handleRelayMessage(text)
+                case .data(let data):
+                    if let text = String(data: data, encoding: .utf8) { handleRelayMessage(text) }
+                @unknown default:
+                    break
+                }
+            }
+        } catch {
+            print("🔌 Relay disconnected: \(error.localizedDescription)")
+        }
+
+        guard relayConnectionState != .disconnected && !Task.isCancelled else { return }
+        relayDaemons.removeAll()
+        let jitter = Double.random(in: 0...(relayReconnectDelay * 0.2))
+        let delay = relayReconnectDelay + jitter
+        relayConnectionState = .reconnecting
+        relayReconnectDelay = min(relayReconnectDelay * 2, maxReconnectDelay)
+        scheduleRelayConnect(after: delay)
+    }
+
+    /// Normalizes a user-entered relay address into a ws(s):// stream URL.
+    /// Accepts http(s)://, ws(s)://, or a bare host[:port], with or without
+    /// the stream path. Mirrors the web dashboard's relayWsUrl().
+    private func relayStreamURL(_ raw: String) -> URL? {
+        var s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !s.isEmpty else { return nil }
+        if s.hasPrefix("http://") { s = "ws://" + s.dropFirst("http://".count) }
+        else if s.hasPrefix("https://") { s = "wss://" + s.dropFirst("https://".count) }
+        if !s.hasPrefix("ws://") && !s.hasPrefix("wss://") { s = "ws://" + s }
+        while s.hasSuffix("/") { s.removeLast() }
+        if !s.hasSuffix("/api/v1/sessions/stream") { s += "/api/v1/sessions/stream" }
+        return URL(string: s)
+    }
+
+    private struct RelayFrameType: Decodable { let type: String }
+
+    private struct RelayPush: Decodable {
+        let type: String
+        let source: String?
+        let msg: WsEnvelope?
+    }
+
+    private struct RelayDaemonInfo: Decodable {
+        let daemonID: String
+        let daemonLabel: String?
+        let status: String?
+        enum CodingKeys: String, CodingKey {
+            case daemonID = "daemon_id"
+            case daemonLabel = "daemon_label"
+            case status
+        }
+    }
+
+    private struct RelayControl: Decodable {
+        let type: String
+        let daemons: [RelayDaemonInfo]?
+        let daemonID: String?
+        let daemonLabel: String?
+        let status: String?
+        enum CodingKeys: String, CodingKey {
+            case type, daemons, status
+            case daemonID = "daemon_id"
+            case daemonLabel = "daemon_label"
+        }
+    }
+
+    private func handleRelayMessage(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let kind = (try? JSONDecoder().decode(RelayFrameType.self, from: data))?.type else { return }
+        switch kind {
+        case "push":
+            if let push = try? JSONDecoder().decode(RelayPush.self, from: data), let inner = push.msg {
+                applyRelayInner(inner)
+            }
+        case "snapshot":
+            if let ctrl = try? JSONDecoder().decode(RelayControl.self, from: data) {
+                relayDaemons.removeAll()
+                for d in ctrl.daemons ?? [] { relayDaemons[d.daemonID] = d.daemonLabel ?? d.daemonID }
+            }
+        case "daemon_status":
+            if let ctrl = try? JSONDecoder().decode(RelayControl.self, from: data), let id = ctrl.daemonID {
+                if ctrl.status == "disconnected" { relayDaemons.removeValue(forKey: id) }
+                else { relayDaemons[id] = ctrl.daemonLabel ?? id }
+            }
+        case "hello_ack":
+            break
+        default:
+            // The URL pointed at a daemon (raw frames): handle it like one.
+            if let inner = try? JSONDecoder().decode(WsEnvelope.self, from: data) {
+                applyRelayInner(inner)
+            }
+        }
+    }
+
+    /// Applies a relay session frame into the relay-only map. History and
+    /// focus frames are ignored for relay sources in v0 (history bars for
+    /// relay-only sessions are deferred; focus is host-local).
+    private func applyRelayInner(_ env: WsEnvelope) {
+        switch env.type {
+        case "session_created", "session_updated":
+            if let s = env.session {
+                relaySessionMap[s.id] = s
+                rebuildSessionsFromMap()
+                recomposeApiGroups()
+            }
+        case "session_deleted":
+            if let s = env.session, relaySessionMap.removeValue(forKey: s.id) != nil {
+                rebuildSessionsFromMap()
+                recomposeApiGroups()
+            }
+        default:
+            break
+        }
+    }
+
+    // MARK: - apiGroups composition (local + relay)
+
+    /// Rebuilds the published `apiGroups` from the local groups plus
+    /// client-side groups for relay-only sessions, and refreshes
+    /// `groupedSessionIds` (used by the local patch guard) from the local set.
+    private func recomposeApiGroups() {
+        apiGroups = orderedGroups(localApiGroups) + relayGroups()
+        groupedSessionIds = Set(localApiGroups.flatMap { collectSessionIds(from: $0) })
+    }
+
+    /// Groups relay-only sessions (ids not present locally) by project name.
+    /// No orchestrator handling or child nesting in v0; the common same-daemon
+    /// case yields no relay-only rows, so this only renders a genuine second
+    /// daemon's sessions.
+    private func relayGroups() -> [AgentGroup] {
+        guard !relaySessionMap.isEmpty else { return [] }
+        let localIDs = Set(sessionMap.keys)
+        let relayOnly = relaySessionMap.values.filter { !localIDs.contains($0.id) }
+        let relayIDs = Set(relayOnly.map { $0.id })
+        let topLevel = relayOnly.filter { s in
+            guard let pid = s.parentSessionId else { return true }
+            return !relayIDs.contains(pid)
+        }
+        guard !topLevel.isEmpty else { return [] }
+        var byProject: [String: [SessionState]] = [:]
+        var order: [String] = []
+        for s in topLevel.sorted(by: { $0.id < $1.id }) {
+            let key = s.projectName ?? "unknown"
+            if byProject[key] == nil { order.append(key) }
+            byProject[key, default: []].append(s)
+        }
+        return order.map { AgentGroup(name: $0, agents: byProject[$0]) }
+    }
+
+    /// One line per source for the connection-status tooltip: the local daemon
+    /// (when enabled) plus each daemon the relay reports. Falls back to the
+    /// single-source tooltip when nothing is configured.
+    var connectionTooltip: String {
+        var lines: [String] = []
+        if useLocalDaemon {
+            lines.append("Local — \(connectionState.shortLabel)")
+        }
+        if useRelayServer && !relayServerURL.isEmpty {
+            if relayConnectionState == .connected && !relayDaemons.isEmpty {
+                for label in relayDaemons.values.sorted() {
+                    lines.append("\(label) — connected")
+                }
+            } else {
+                lines.append("\(relayServerURL) — \(relayConnectionState.shortLabel)")
+            }
+        }
+        return lines.isEmpty ? connectionState.tooltip : lines.joined(separator: "\n")
+    }
+
+    /// Aggregate connection state across enabled sources for the header dot:
+    /// connected wins, then connecting, then reconnecting, else disconnected.
+    var aggregateConnectionState: ConnectionState {
+        let states = [
+            useLocalDaemon ? connectionState : nil,
+            (useRelayServer && !relayServerURL.isEmpty) ? relayConnectionState : nil,
+        ].compactMap { $0 }
+        if states.isEmpty { return .disconnected }
+        if states.contains(.connected) { return .connected }
+        if states.contains(.connecting) { return .connecting }
+        if states.contains(.reconnecting) { return .reconnecting }
+        return .disconnected
     }
 
     /// Top-level /api/v1/sessions payload: the dashboard hierarchy plus
@@ -440,8 +777,8 @@ class SessionManager: ObservableObject {
             let topGroups = payload.groups
             providerCosts = payload.providerCosts ?? [:]
 
-            apiGroups = orderedGroups(topGroups)
-            groupedSessionIds = Set(topGroups.flatMap { collectSessionIds(from: $0) })
+            localApiGroups = topGroups
+            recomposeApiGroups()
             if isDebugMode {
                 print("💧 hydrate: groupedSessionIds=\(groupedSessionIds.count) ids, sample=\(groupedSessionIds.prefix(3))")
             }
@@ -577,7 +914,8 @@ class SessionManager: ObservableObject {
             scheduleRehydration()
             return
         }
-        apiGroups = apiGroups.map { patchGroup($0, with: session) }
+        localApiGroups = localApiGroups.map { patchGroup($0, with: session) }
+        recomposeApiGroups()
     }
 
     func patchGroup(_ group: AgentGroup, with session: SessionState) -> AgentGroup {
@@ -623,12 +961,13 @@ class SessionManager: ObservableObject {
     /// overlay can't render a stale row while the menu bar is already idle.
     func removeFromApiGroups(sessionId: String) {
         guard groupedSessionIds.contains(sessionId) else { return }
-        apiGroups = apiGroups.compactMap { pruneGroup($0, removing: sessionId) }
-        // Rebuild rather than `remove(sessionId)` — pruning a parent or a
-        // nested group transitively orphans embedded ids that must also leave
-        // `groupedSessionIds`, otherwise `patchApiGroups` will pass the guard
+        // Prune the local groups, then recompose. Rebuilding groupedSessionIds
+        // (inside recompose) rather than `remove(sessionId)` matters because
+        // pruning a parent or nested group transitively orphans embedded ids
+        // that must also leave the set, else `patchApiGroups` passes its guard
         // for sessions that no longer have a row.
-        groupedSessionIds = Set(apiGroups.flatMap { collectSessionIds(from: $0) })
+        localApiGroups = localApiGroups.compactMap { pruneGroup($0, removing: sessionId) }
+        recomposeApiGroups()
     }
 
     /// Returns `nil` when the group has nothing left to render — except
@@ -670,7 +1009,14 @@ class SessionManager: ObservableObject {
     }
 
     private func rebuildSessionsFromMap() {
-        let all = Array(sessionMap.values)
+        // Merge relay-only sessions (ids not present locally) so the cycle and
+        // menu-bar counts include other machines' sessions. Local wins on id
+        // collision — the same daemon reached via both sources shows once.
+        var combined = sessionMap
+        for (id, s) in relaySessionMap where combined[id] == nil {
+            combined[id] = s
+        }
+        let all = Array(combined.values)
         let ids = Set(all.map { $0.id })
 
         // Exclude child sessions (subagents) from the main session list
@@ -1089,7 +1435,7 @@ class SessionManager: ObservableObject {
         guard let i = projectGroupOrder.firstIndex(of: name), i > 0 else { return }
         projectGroupOrder.swapAt(i, i - 1)
         saveProjectGroupOrder()
-        apiGroups = orderedGroups(apiGroups)
+        recomposeApiGroups()
     }
 
     func moveProjectGroupDown(name: String) {
@@ -1097,7 +1443,7 @@ class SessionManager: ObservableObject {
               i < projectGroupOrder.count - 1 else { return }
         projectGroupOrder.swapAt(i, i + 1)
         saveProjectGroupOrder()
-        apiGroups = orderedGroups(apiGroups)
+        recomposeApiGroups()
     }
 
     // MARK: - Duplicate Session Handling

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -983,15 +983,17 @@ struct SessionListView: View {
             .fill(statusColor)
             .frame(width: 6, height: 6)
             .shadow(color: statusColor.opacity(0.5), radius: 3)
-            .tooltip(sessionManager.connectionState.tooltip)
+            // Multi-source: one line per source — "Local — connected" and, for
+            // a relay, one line per connected daemon by label.
+            .tooltip(sessionManager.connectionTooltip)
             // The dot is the only visible affordance now; VoiceOver
             // needs an explicit label since "Circle" alone tells the
             // user nothing about connection state.
-            .accessibilityLabel("Connection: \(sessionManager.connectionState.tooltip)")
+            .accessibilityLabel("Connection: \(sessionManager.connectionTooltip)")
     }
 
     private var statusColor: Color {
-        switch sessionManager.connectionState {
+        switch sessionManager.aggregateConnectionState {
         case .connected: return IrrColors.wsConnected
         case .connecting, .reconnecting: return IrrColors.wsConnecting
         case .disconnected: return IrrColors.wsDisconnected

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -96,7 +96,7 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
 
                 if useRelayServer {
-                    TextField("ws://localhost:7838", text: $relayURLDraft)
+                    TextField("ws://localhost:7839", text: $relayURLDraft)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.caption, design: .monospaced))
                         .autocorrectionDisabled(true)

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -14,6 +14,13 @@ struct SettingsView: View {
     @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = true
     @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = true
     @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = true
+    // Sources (multi-source): mirror the web dashboard's keys. The relay URL is
+    // edited in a draft and committed on Return so the connection doesn't churn
+    // on every keystroke.
+    @AppStorage("useLocalDaemon") private var useLocalDaemon: Bool = true
+    @AppStorage("useRelayServer") private var useRelayServer: Bool = false
+    @AppStorage("relayServerURL") private var relayServerURL: String = ""
+    @State private var relayURLDraft: String = ""
     @State private var notificationsDenied = false
     @State private var customImportError: String?
 
@@ -68,6 +75,39 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             .onChange(of: launchAtLogin) { newValue in LoginItemManager.setEnabled(newValue) }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Sources")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                LeadingToggle(isOn: $useLocalDaemon, label: "Local")
+                Text("Watch the daemon this app connects to directly.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                LeadingToggle(isOn: $useRelayServer, label: "Relay server")
+                Text("Also connect to a relay to see sessions from other machines.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if useRelayServer {
+                    TextField("ws://localhost:7838", text: $relayURLDraft)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.caption, design: .monospaced))
+                        .autocorrectionDisabled(true)
+                        .onSubmit { commitRelayURL() }
+                    Text("Press Return to apply.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .onAppear { relayURLDraft = relayServerURL }
+            .onChange(of: useRelayServer) { on in if on { commitRelayURL() } }
 
             Divider()
 
@@ -216,6 +256,12 @@ struct SettingsView: View {
             .pickerStyle(.segmented)
             .labelsHidden()
         }
+    }
+
+    /// Commits the relay URL draft to @AppStorage (trimmed), which the
+    /// SessionManager observes to (re)connect the relay source.
+    private func commitRelayURL() {
+        relayServerURL = relayURLDraft.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func checkNotificationAuth() {

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -67,10 +67,10 @@
       <label class="settings-text-row">
         <span class="settings-label-text">
           <span class="settings-title">Relay server URL</span>
-          <span class="settings-hint">e.g. ws://localhost:7838</span>
+          <span class="settings-hint">e.g. ws://localhost:7839</span>
         </span>
         <input type="text" class="settings-text-input" data-setting="relayUrl"
-               placeholder="ws://localhost:7838" spellcheck="false" autocomplete="off">
+               placeholder="ws://localhost:7839" spellcheck="false" autocomplete="off">
       </label>
 
       <h2>Provider quota</h2>

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -49,6 +49,30 @@
         </span>
       </label>
 
+      <h2>Sources</h2>
+      <label>
+        <input type="checkbox" data-setting="enableLocalSource">
+        <span class="settings-label-text">
+          <span class="settings-title">Local</span>
+          <span class="settings-hint">Watch the daemon (or relay) that served this page.</span>
+        </span>
+      </label>
+      <label>
+        <input type="checkbox" data-setting="enableRelaySource">
+        <span class="settings-label-text">
+          <span class="settings-title">Relay server</span>
+          <span class="settings-hint">Also connect to a relay to see other machines' sessions.</span>
+        </span>
+      </label>
+      <label class="settings-text-row">
+        <span class="settings-label-text">
+          <span class="settings-title">Relay server URL</span>
+          <span class="settings-hint">e.g. ws://localhost:7838</span>
+        </span>
+        <input type="text" class="settings-text-input" data-setting="relayUrl"
+               placeholder="ws://localhost:7838" spellcheck="false" autocomplete="off">
+      </label>
+
       <h2>Provider quota</h2>
       <label>
         <input type="checkbox" data-quota-setting="showQuotaForecast">

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1081,6 +1081,20 @@
     .settings-modal .settings-label-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
     .settings-modal .settings-label-text .settings-title { color: var(--text-bright); font-weight: 500; }
     .settings-modal .settings-label-text .settings-hint { color: var(--muted); font-size: 11px; }
+    /* Relay URL row: label text stacked above a full-width text field. */
+    .settings-modal label.settings-text-row { flex-direction: column; align-items: stretch; gap: 6px; cursor: default; }
+    .settings-modal .settings-text-input {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 6px 8px;
+      font-size: 12px;
+      font-family: inherit;
+      color: var(--text-bright);
+      background: var(--surface-hover);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+    }
+    .settings-modal .settings-text-input:focus { outline: none; border-color: var(--working); }
     .settings-modal .settings-modal-footer {
       display: flex;
       justify-content: space-between;

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -119,7 +119,16 @@
       notifyOnReady: false,
       notifyOnWaiting: false,
       notifyOnContextPressure: false,
+      // Sources: the local source (the origin that served this page) is on by
+      // default; a relay source is opt-in by URL. Mirrors the macOS
+      // useLocalDaemon / useRelayServer / relayServerURL @AppStorage keys.
+      enableLocalSource: true,
+      enableRelaySource: false,
+      relayUrl: '',
     };
+    // Settings keys that change the live source connections (vs. display-only
+    // toggles), so the change handler knows to reconnect.
+    const SOURCE_SETTING_KEYS = new Set(['enableLocalSource', 'enableRelaySource', 'relayUrl']);
     function loadSettings() {
       try {
         const raw = localStorage.getItem(SETTINGS_KEY);
@@ -1357,32 +1366,222 @@
       });
     }, 30000);
 
-    // --- WebSocket ---
-    let ws = null;
-    let reconnectDelay = 1000;
+    // --- Sources & connections (multi-source) ---
+    // The dashboard connects to one or more sources at once: the local source
+    // (the origin that served this page — a daemon or a relay) and/or a relay
+    // server entered in Settings → Sources. A daemon speaks raw PushMessage
+    // frames; a relay wraps them in a `push` envelope behind a `hello`
+    // handshake. One handler covers both: we always send a client `hello` (a
+    // daemon ignores unexpected frames; a relay requires it) and dispatch by
+    // frame type — `push` unwraps `.msg`, relay control frames
+    // (`snapshot`/`daemon_status`) feed the connection tooltip, and anything
+    // else is a raw daemon frame processed exactly as the single socket was.
+    //
+    // Sessions are keyed by `session_id` (the existing model), so the same
+    // daemon reached over both the local socket and a relay collapses to one
+    // row automatically. Two *different* daemons that happen to share a
+    // session_id (e.g. proc-<pid>) would merge — a documented v0 caveat;
+    // per-source keying is deferred with row-level source badges.
 
-    // Status labels mirror the overlay's statusIndicator at SessionListView.swift:387:
-    // connected → "watching", reconnecting → "reconnecting", else state name.
-    function setWsStatus(status) {
+    // relayFrameKind classifies an incoming frame so the handler can branch.
+    // Pure; exported for tests.
+    function relayFrameKind(msg) {
+      if (!msg || typeof msg.type !== 'string') return 'raw';
+      switch (msg.type) {
+        case 'hello_ack': return 'hello_ack';
+        case 'snapshot': return 'snapshot';
+        case 'daemon_status': return 'daemon_status';
+        case 'push': return 'push';
+        default: return 'raw';
+      }
+    }
+
+    // aggregateConnState reduces per-source states into the single header dot:
+    // connected wins (we're watching at least one source), then connecting,
+    // then reconnecting, else disconnected. Pure; exported for tests.
+    function aggregateConnState(states) {
+      if (!states || states.length === 0) return 'disconnected';
+      if (states.some(s => s === 'connected')) return 'connected';
+      if (states.some(s => s === 'connecting')) return 'connecting';
+      if (states.some(s => s === 'reconnecting')) return 'reconnecting';
+      return 'disconnected';
+    }
+
+    // relayWsUrl normalizes a user-entered relay address into a ws(s):// stream
+    // URL. Accepts http(s)://, ws(s)://, or a bare host[:port], with or without
+    // the stream path. Pure; exported for tests. Returns '' for empty input.
+    function relayWsUrl(raw) {
+      let u = (raw || '').trim();
+      if (!u) return '';
+      u = u.replace(/^http:/i, 'ws:').replace(/^https:/i, 'wss:');
+      if (!/^wss?:\/\//i.test(u)) u = 'ws://' + u;
+      u = u.replace(/\/+$/, '');
+      if (!/\/api\/v1\/sessions\/stream$/.test(u)) u += '/api/v1/sessions/stream';
+      return u;
+    }
+
+    function localWsUrl() {
+      const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+      return proto + '://' + location.host + '/api/v1/sessions/stream';
+    }
+
+    // Active sources, keyed by a stable id. Each: { id, label, kind, wsUrl,
+    // state, ws, reconnectDelay, closing, daemons: Map<id,{label,status}> }.
+    const sources = new Map();
+
+    function desiredSources() {
+      const out = [];
+      if (settings.enableLocalSource) {
+        out.push({ id: 'local', label: 'Local', kind: 'local', wsUrl: localWsUrl() });
+      }
+      if (settings.enableRelaySource) {
+        const wsUrl = relayWsUrl(settings.relayUrl);
+        if (wsUrl) out.push({ id: 'relay:' + wsUrl, label: settings.relayUrl || 'Relay', kind: 'relay', wsUrl });
+      }
+      return out;
+    }
+
+    // rebuildSources reconciles the live connections with the configured
+    // sources, closing dropped ones and opening new ones. Called on load and
+    // whenever a Sources setting changes, so toggling reconnects without a
+    // page reload.
+    function rebuildSources() {
+      const desired = desiredSources();
+      const desiredById = new Map(desired.map(s => [s.id, s]));
+      for (const [id, src] of [...sources]) {
+        if (!desiredById.has(id)) {
+          src.closing = true;
+          try { if (src.ws) src.ws.close(); } catch (e) {}
+          sources.delete(id);
+        }
+      }
+      for (const d of desired) {
+        if (!sources.has(d.id)) {
+          const src = Object.assign({ state: 'connecting', ws: null, reconnectDelay: 1000, closing: false, daemons: new Map() }, d);
+          sources.set(d.id, src);
+          connectSource(src);
+        }
+      }
+      updateWsStatus();
+    }
+
+    function connectSource(src) {
+      src.state = src.ws ? 'reconnecting' : 'connecting';
+      updateWsStatus();
+      let ws;
+      try { ws = new WebSocket(src.wsUrl); } catch (e) { scheduleReconnect(src); return; }
+      src.ws = ws;
+      ws.onopen = function() {
+        src.state = 'connected';
+        src.reconnectDelay = 1000;
+        try { ws.send(JSON.stringify({ type: 'hello', protocol_version: 1, role: 'client' })); } catch (e) {}
+        updateWsStatus();
+      };
+      ws.onmessage = function(evt) {
+        let msg;
+        try { msg = JSON.parse(evt.data); } catch (e) { return; }
+        handleSourceFrame(src, msg);
+      };
+      ws.onerror = function() {};
+      ws.onclose = function() {
+        if (src.closing) return;
+        src.state = 'disconnected';
+        src.daemons.clear();
+        updateWsStatus();
+        scheduleReconnect(src);
+      };
+    }
+
+    function scheduleReconnect(src) {
+      if (src.closing) return;
+      const delay = src.reconnectDelay;
+      src.reconnectDelay = Math.min(src.reconnectDelay * 2, 30000);
+      setTimeout(() => { if (!src.closing && sources.get(src.id) === src) connectSource(src); }, delay);
+    }
+
+    function handleSourceFrame(src, msg) {
+      if (!msg) return;
+      switch (relayFrameKind(msg)) {
+        case 'hello_ack':
+          return;
+        case 'snapshot':
+          src.daemons.clear();
+          for (const d of (msg.daemons || [])) {
+            if (d && d.daemon_id) src.daemons.set(d.daemon_id, { label: d.daemon_label || d.daemon_id, status: d.status || 'connected' });
+          }
+          updateWsStatus();
+          return;
+        case 'daemon_status':
+          if (msg.daemon_id) {
+            if (msg.status === 'disconnected') src.daemons.delete(msg.daemon_id);
+            else src.daemons.set(msg.daemon_id, { label: msg.daemon_label || msg.daemon_id, status: msg.status || 'connected' });
+          }
+          updateWsStatus();
+          return;
+        case 'push':
+          if (msg.msg) dispatchRawFrame(msg.msg);
+          return;
+        default:
+          dispatchRawFrame(msg);
+      }
+    }
+
+    // dispatchRawFrame processes a raw daemon PushMessage — the local frame
+    // format, or a relay push's unwrapped `.msg`. Both source kinds funnel
+    // here, so the render/history/notification paths are unchanged.
+    function dispatchRawFrame(msg) {
+      if (!msg) return;
+      if (msg.type === 'orchestrator_state' && msg.orchestrator) {
+        const orch = msg.orchestrator;
+        orchestrator = orch.running ? orch : null;
+        orchFull = orch.running ? orch : null;
+        render();
+        return;
+      }
+      if (msg.type === 'history_snapshot' && msg.session_id && msg.history) {
+        applyHistorySnapshot(msg.session_id, msg.history, msg.generations);
+        repaintHistory();
+        return;
+      }
+      if (msg.type === 'history_tick' && typeof msg.granularity_sec === 'number' && msg.buckets) {
+        applyHistoryTick(msg.granularity_sec, msg.buckets, msg.bucket_generations);
+        if (msg.granularity_sec === currentGranularity) repaintHistory();
+        return;
+      }
+      if (msg.type === 'history_upgrade' && msg.session_id && typeof msg.priority === 'number') {
+        applyHistoryUpgrade(msg.session_id, msg.priority);
+        repaintHistory();
+        return;
+      }
+      if (!msg.session) return;
+      var s = msg.session;
+      if (msg.type === 'session_deleted') {
+        applySessionDelete(s.session_id);
+      } else {
+        applySessionUpdate(s);
+      }
+      render();
+    }
+
+    // --- Connection status (header dot + banner + tooltip) ---
+    function setDotLabel(status) {
       const dot = document.getElementById('ws-dot');
       const label = document.getElementById('ws-label');
-      dot.className = 'ws-dot ' + status;
+      if (dot) dot.className = 'ws-dot ' + status;
       let text;
       if (status === 'connected') text = 'watching';
       else if (status === 'reconnecting') text = 'reconnecting';
       else if (status === 'connecting') text = 'connecting';
       else text = 'disconnected';
-      label.textContent = text;
-      // Surface a full-width banner over the session list when the daemon
-      // connection is impaired — the header dot alone is easy to miss.
+      if (label) label.textContent = text;
       const banner = document.getElementById('connection-banner');
       if (banner) {
         if (status === 'reconnecting') {
           banner.className = 'reconnecting';
-          banner.textContent = 'Reconnecting to daemon…';
+          banner.textContent = 'Reconnecting…';
         } else if (status === 'disconnected') {
           banner.className = 'disconnected';
-          banner.textContent = 'Disconnected — the irrlicht daemon is unreachable. Check that it is running.';
+          banner.textContent = 'Disconnected — no configured source is reachable. Check that the daemon (or relay) is running.';
         } else {
           banner.className = '';
           banner.textContent = '';
@@ -1390,64 +1589,31 @@
       }
     }
 
-    function connect() {
-      // ws is non-null on every subsequent reconnect attempt; use that to
-      // distinguish the initial "connecting" from a "reconnecting" cycle.
-      setWsStatus(ws ? 'reconnecting' : 'connecting');
-      const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-      ws = new WebSocket(proto + '://' + location.host + '/api/v1/sessions/stream');
-
-      ws.onopen = function() {
-        setWsStatus('connected');
-        reconnectDelay = 1000;
-      };
-
-      ws.onmessage = function(evt) {
-        var msg;
-        try { msg = JSON.parse(evt.data); } catch(e) { return; }
-        if (!msg) return;
-        if (msg.type === 'orchestrator_state' && msg.orchestrator) {
-          const orch = msg.orchestrator;
-          orchestrator = orch.running ? orch : null;
-          orchFull = orch.running ? orch : null;
-          render();
-          return;
-        }
-        if (msg.type === 'history_snapshot' && msg.session_id && msg.history) {
-          applyHistorySnapshot(msg.session_id, msg.history, msg.generations);
-          repaintHistory();
-          return;
-        }
-        if (msg.type === 'history_tick' && typeof msg.granularity_sec === 'number' && msg.buckets) {
-          applyHistoryTick(msg.granularity_sec, msg.buckets, msg.bucket_generations);
-          if (msg.granularity_sec === currentGranularity) repaintHistory();
-          return;
-        }
-        if (msg.type === 'history_upgrade' && msg.session_id && typeof msg.priority === 'number') {
-          applyHistoryUpgrade(msg.session_id, msg.priority);
-          repaintHistory();
-          return;
-        }
-        if (!msg.session) return;
-        var s = msg.session;
-        if (msg.type === 'session_deleted') {
-          applySessionDelete(s.session_id);
+    // sourceTooltipLines builds the connection tooltip: one line per source. A
+    // connected relay lists its daemons by label; everything else shows the
+    // source's own label and state. Pure-ish (reads the sources map).
+    function sourceTooltipLines() {
+      const lines = [];
+      for (const src of sources.values()) {
+        if (src.kind === 'relay' && src.state === 'connected' && src.daemons.size > 0) {
+          for (const d of src.daemons.values()) {
+            lines.push(d.label + ' — ' + (d.status === 'connected' ? 'connected' : d.status));
+          }
         } else {
-          applySessionUpdate(s);
+          lines.push(src.label + ' — ' + src.state);
         }
-        render();
-      };
-
-      ws.onerror = function() {};
-
-      ws.onclose = function() {
-        setWsStatus('disconnected');
-        setTimeout(connect, reconnectDelay);
-        reconnectDelay = Math.min(reconnectDelay * 2, 30000);
-      };
+      }
+      return lines;
     }
 
-    connect();
+    function updateWsStatus() {
+      const states = [...sources.values()].map(s => s.state);
+      setDotLabel(aggregateConnState(states));
+      const wrap = document.querySelector('.ws-status');
+      if (wrap) wrap.title = sourceTooltipLines().join('\n');
+    }
+
+    rebuildSources();
 
     // Granularity is derived from the display-mode cycle — no need to
     // persist it separately; restoring irrlicht_displayMode re-derives it.
@@ -1951,7 +2117,9 @@
     function syncSettingsForm() {
       for (const el of document.querySelectorAll('[data-setting]')) {
         const key = el.dataset.setting;
-        if (key in settings) el.checked = !!settings[key];
+        if (!(key in settings)) continue;
+        if (el.type === 'checkbox') el.checked = !!settings[key];
+        else el.value = settings[key] != null ? String(settings[key]) : '';
       }
       for (const el of document.querySelectorAll('[data-quota-setting="showQuotaForecast"]')) {
         el.checked = showQuotaForecast();
@@ -2033,10 +2201,12 @@
             return;
           }
         }
-        settings[key] = this.checked;
+        settings[key] = (this.type === 'checkbox') ? this.checked : this.value;
         persistSettings();
         applySettings();
         refreshPermNote();
+        // Source toggles/URL reconnect live, no page reload.
+        if (SOURCE_SETTING_KEYS.has(key)) rebuildSources();
       });
     }
 
@@ -2050,4 +2220,5 @@ export {
   resolvedTheme, rowLabel, maybeNotifyOnUpdate,
   formatCost, formatUsageCost, pressureClass, historyPriorityForState,
   lastNotifiedPressure,
+  relayFrameKind, aggregateConnState, relayWsUrl,
 };

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -8,6 +8,9 @@ import {
   pressureClass,
   historyPriorityForState,
   lastNotifiedPressure,
+  relayFrameKind,
+  aggregateConnState,
+  relayWsUrl,
 } from './irrlicht.js'
 
 describe('resolvedTheme', () => {
@@ -144,5 +147,59 @@ describe('formatUsageCost', () => {
 
   test('>= $100 drops to integer dollars', () => {
     expect(formatUsageCost(105.3)).toBe('$105')
+  })
+})
+
+describe('relayFrameKind', () => {
+  test('classifies relay envelope frames', () => {
+    expect(relayFrameKind({ type: 'push', msg: {} })).toBe('push')
+    expect(relayFrameKind({ type: 'snapshot', daemons: [] })).toBe('snapshot')
+    expect(relayFrameKind({ type: 'daemon_status' })).toBe('daemon_status')
+    expect(relayFrameKind({ type: 'hello_ack' })).toBe('hello_ack')
+  })
+
+  test('treats raw daemon frames (and junk) as raw', () => {
+    expect(relayFrameKind({ type: 'session_updated', session: {} })).toBe('raw')
+    expect(relayFrameKind({ type: 'history_tick' })).toBe('raw')
+    expect(relayFrameKind(null)).toBe('raw')
+    expect(relayFrameKind({})).toBe('raw')
+  })
+})
+
+describe('aggregateConnState', () => {
+  test('connected wins over any other source state', () => {
+    expect(aggregateConnState(['connected', 'reconnecting'])).toBe('connected')
+    expect(aggregateConnState(['disconnected', 'connected'])).toBe('connected')
+  })
+
+  test('falls through connecting → reconnecting → disconnected', () => {
+    expect(aggregateConnState(['connecting', 'reconnecting'])).toBe('connecting')
+    expect(aggregateConnState(['reconnecting', 'disconnected'])).toBe('reconnecting')
+    expect(aggregateConnState(['disconnected'])).toBe('disconnected')
+  })
+
+  test('no sources reads as disconnected', () => {
+    expect(aggregateConnState([])).toBe('disconnected')
+  })
+})
+
+describe('relayWsUrl', () => {
+  test('empty input yields empty', () => {
+    expect(relayWsUrl('')).toBe('')
+    expect(relayWsUrl('   ')).toBe('')
+  })
+
+  test('bare host gets ws:// scheme and the stream path', () => {
+    expect(relayWsUrl('localhost:7838')).toBe('ws://localhost:7838/api/v1/sessions/stream')
+  })
+
+  test('http(s) is rewritten to ws(s)', () => {
+    expect(relayWsUrl('http://relay.example:7838')).toBe('ws://relay.example:7838/api/v1/sessions/stream')
+    expect(relayWsUrl('https://relay.example')).toBe('wss://relay.example/api/v1/sessions/stream')
+  })
+
+  test('an explicit stream path is preserved (not doubled)', () => {
+    expect(relayWsUrl('ws://localhost:7838/api/v1/sessions/stream'))
+      .toBe('ws://localhost:7838/api/v1/sessions/stream')
   })
 })

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -190,16 +190,16 @@ describe('relayWsUrl', () => {
   })
 
   test('bare host gets ws:// scheme and the stream path', () => {
-    expect(relayWsUrl('localhost:7838')).toBe('ws://localhost:7838/api/v1/sessions/stream')
+    expect(relayWsUrl('localhost:7839')).toBe('ws://localhost:7839/api/v1/sessions/stream')
   })
 
   test('http(s) is rewritten to ws(s)', () => {
-    expect(relayWsUrl('http://relay.example:7838')).toBe('ws://relay.example:7838/api/v1/sessions/stream')
+    expect(relayWsUrl('http://relay.example:7839')).toBe('ws://relay.example:7839/api/v1/sessions/stream')
     expect(relayWsUrl('https://relay.example')).toBe('wss://relay.example/api/v1/sessions/stream')
   })
 
   test('an explicit stream path is preserved (not doubled)', () => {
-    expect(relayWsUrl('ws://localhost:7838/api/v1/sessions/stream'))
-      .toBe('ws://localhost:7838/api/v1/sessions/stream')
+    expect(relayWsUrl('ws://localhost:7839/api/v1/sessions/stream'))
+      .toBe('ws://localhost:7839/api/v1/sessions/stream')
   })
 })


### PR DESCRIPTION
Closes #479.

First runnable version of the standalone **`irrlichtrelay`**: a daemon forwards its session events out to the relay (NAT-friendly — no inbound on the daemon), and both the macOS app and the web dashboard receive them back. Built on the real wire envelope wrapping the existing `outbound.PushMessage`, so the load-bearing `daemon → relay` link is not throwaway.

## Deliverables

**1. Daemon outbound Forwarder** — `core/adapters/outbound/relay/`
- `envelope.go` (wire types + `FrameType`), `identity.go` (minted/persisted `daemon_id` at `dataDir/relay-identity.json`, `crypto/rand` UUID — no new deps), `forwarder.go` (subscribe → `hello` + `daemon_snapshot` → `push`-wrap each frame, filter `focus_requested`, reconnect with backoff+jitter; URL normalized to the stream path).
- Wired in `irrlichd` behind `IRRLICHT_RELAY_URL` (no-op when unset).

**2. `irrlichtrelay` binary** — `core/cmd/irrlichtrelay/`
- `serve --addr :7839`; gorilla WS hub routing by `hello.role`; per-`(daemon_id, session_id)` cache; daemon tracking via `snapshot`/`daemon_status`; HTTP `/api/v1/{sessions,agents,version}` from cache; serves `platforms/web/`; replays cached sessions to new clients so a relay client hydrates over WS alone.

**3. Multi-source clients** — web + macOS
- A unified WS handler that always sends a client `hello` and dispatches both raw daemon frames and relay envelopes; a **Sources** setting (Local toggle + Relay URL) on both clients; a connection-status **tooltip** listing the connected daemon(s), fed by `daemon_status`.

**Docs:** `docs/relay-protocol.md` documents the built frames; `auth`/`seq`/`resume` remain reserved.

## Acceptance demo

```sh
irrlichd                                          # daemon on :7837
IRRLICHT_RELAY_URL=ws://localhost:7839 irrlichd   # …also forwards to the relay
irrlichtrelay serve --addr :7839                  # the relay
```
Then in **Settings → Sources** enable Local and/or enter the relay URL → both clients show the union of sessions, live; hover the connection indicator → tooltip lists the connected daemon(s); restart the relay → the daemon reconnects and clients re-hydrate.

## Key decisions

- **Security/bind:** the relay binds **`127.0.0.1:7839`** by default (no auth + permissive WS origin in v0, so loopback-only until auth lands); `--addr 0.0.0.0:7839` is the explicit opt-in for cross-machine use, matching the daemon's posture.
- **Ports:** relay defaults to `7839` (not the issue's `:7838`, which collides with the dev-daemon coexist port). irrlicht now uses contiguous `7837`/`7838`/`7839`, all in a band with no observed real-world usage (nmap-services).
- **Session keying:** clients key by `session_id` (not a compound `(source, session_id)` key). This cleanly collapses the same daemon reached via local+relay — the exact demo scenario and the issue's stated dedup goal. Documented caveat: two *different* daemons sharing a `session_id` (e.g. `proc-<pid>`) would merge; per-source keying + row badges stay deferred.

## Verification

- `go test ./core/... -race -count=1` — pass (incl. new packages, daemon startup smoke + e2e).
- `tools/replay-fixtures.sh` — 104 pass, no unexpected failures.
- `npm test` (`platforms/web/`) — 32 pass.
- `swift build` — clean (the macOS full `SessionStream` refactor is out of scope per the issue).
- Headless `daemon → relay` round-trip with the real binaries: relay's `/api/v1/agents` returns the union of all adapters.

## Code review

A multi-angle review (5 finder angles + sweep) ran on the branch; the bounded, clearly-correct findings are fixed in `5a163587`: a hub blocking-send hang, the macOS "Local" toggle being defeated by the cost-poll timer, a forwarder lost-delta window, relay-session ghosts on a relay outage, missing relay-session notifications, a reconnect storm against an unreachable relay, and diagnostics. Delete-reconciliation across a relay outage on the **web** client and slow-client delete recovery are deferred — they need the reserved per-source `resume`/reconnect-cursor work rather than a rushed cross-platform reconciliation. A follow-up (`18f552e2`) defaults the relay to loopback (closing a LAN-exposure note) and adds a hub test for the daemon-disconnect `session_deleted` fan-out + cache eviction.

> Sub-divided per deliverable was an option; delivered as one PR at the maintainer's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)