### PR TITLE
fix(fswatcher): add Ready() signal to kill e2e attach-race flake

### DIFF
--- a/core/adapters/inbound/agents/fswatcher/watcher.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher.go
@@ -26,6 +26,34 @@ type Watcher struct {
 
 	subMu sync.Mutex
 	subs  []chan agent.Event
+
+	readyMu   sync.Mutex
+	readyOnce sync.Once
+	ready     chan struct{} // closed once the root watch is attached
+}
+
+// Ready returns a channel that is closed once Watch has attached the
+// underlying fsnotify watch to the root (and any pre-existing subdirs).
+// After it is readable, file mutations under the tree are guaranteed to be
+// observed — tests and wiring can wait on it instead of sleeping a guessed
+// interval to dodge the attach race. The channel never sends; it is only
+// closed. Safe to call before, during, or after Watch.
+func (w *Watcher) Ready() <-chan struct{} { return w.readyChan() }
+
+// readyChan lazily creates the ready channel so the literal constructors
+// (New, NewWithRoot) don't each have to initialize it.
+func (w *Watcher) readyChan() chan struct{} {
+	w.readyMu.Lock()
+	defer w.readyMu.Unlock()
+	if w.ready == nil {
+		w.ready = make(chan struct{})
+	}
+	return w.ready
+}
+
+// signalReady closes the ready channel exactly once.
+func (w *Watcher) signalReady() {
+	w.readyOnce.Do(func() { close(w.readyChan()) })
 }
 
 // WithIdentity sets the full agent.Identity for this watcher so it
@@ -111,6 +139,10 @@ func (w *Watcher) Watch(ctx context.Context) error {
 	if err := watcher.Add(w.root); err != nil {
 		return err
 	}
+
+	// The watch is now live for the root and all pre-existing subdirs;
+	// unblock anyone waiting on Ready() before mutating files.
+	w.signalReady()
 
 	for {
 		select {

--- a/core/e2e/fswatcher_test.go
+++ b/core/e2e/fswatcher_test.go
@@ -31,8 +31,14 @@ func TestFSWatcher_EmitsEventsForTranscriptCreateAndModify(t *testing.T) {
 	watchDone := make(chan struct{})
 	go func() { _ = w.Watch(ctx); close(watchDone) }()
 
-	// Give the watcher a moment to attach kqueue/inotify before we touch files.
-	time.Sleep(100 * time.Millisecond)
+	// Wait until the watcher has actually attached kqueue/inotify before we
+	// touch files — a fixed sleep races the attach on a loaded CI runner and
+	// drops the create event (flaky TestFSWatcher failures on macOS CI).
+	select {
+	case <-w.Ready():
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher did not become ready within 5s")
+	}
 
 	transcriptPath := filepath.Join(root, projectDir, "abc-create.jsonl")
 	if err := os.WriteFile(transcriptPath, []byte(`{"type":"user"}`+"\n"), 0644); err != nil {


### PR DESCRIPTION
## Problem

The `Tests` job failed on the #478 main push: `TestFSWatcher_EmitsEventsForTranscriptCreateAndModify` timed out at ~2.1s waiting for the first create event. The next main commit happened to pass — classic flake.

**Root cause:** the e2e test sleeps a fixed `100ms` to let kqueue/inotify attach, then writes the transcript. On a loaded macOS CI runner the `os.WriteFile` beats `watcher.Add(root)`, so the CREATE event is never delivered and the 2s wait times out.

## Fix

Expose `Watcher.Ready()` — a channel closed once `Watch` has attached the fsnotify watch to the root (and any pre-existing subdirs). The e2e test now blocks on `Ready()` (5s guard) instead of guessing an interval, which removes the attach race entirely.

- Channel is **lazily created** (`readyChan`) so the `New`/`NewWithRoot` literal constructors stay untouched.
- Closed **exactly once** via `sync.Once`.
- The `Watch(ctx) error` **port signature is unchanged** — `Ready()` is an extra on the concrete `*Watcher`. It's also useful for production wiring that wants to know the watch is live before acting.

## Verification

- `go test ./core/... -race -count=1` → pass (exit 0)
- Formerly-flaky test holds **30×** under `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)