### PR TITLE
fix(daemon): surface claudecode tool-use permission prompts as `waiting` (#488)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -7,6 +7,7 @@ package claudecode
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -51,6 +52,17 @@ func matcherForEvent(event string) string {
 		return hookMatcherPreToolUse
 	}
 	return hookMatcher
+}
+
+// HookDeliveryAvailable reports whether the tool the installed hook command
+// relies on to reach the daemon is on PATH. installedHookCommand POSTs via
+// `curl`, so a missing curl means every hook silently no-ops (the trailing
+// `|| true` swallows "command not found") and permission prompts never
+// surface as `waiting`. main.go calls this at startup to turn that otherwise
+// invisible failure into a logged warning (#488).
+func HookDeliveryAvailable() bool {
+	_, err := exec.LookPath("curl")
+	return err == nil
 }
 
 // EnsureHooksInstalled adds irrlicht hook entries to ~/.claude/settings.json

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -124,6 +124,14 @@ type SessionDetector struct {
 	permMu            sync.Mutex
 	permissionPending map[string]bool // sessionID → true
 
+	// editToolOpenSince tracks, per session, the Unix time a permission-gated
+	// file-edit tool first appeared open. Guarded by permMu. Drives the
+	// OpenToolStalled transcript fallback (#488): an edit tool open past
+	// staleWorkingRefreshInterval means the agent is blocked on a permission
+	// prompt, not executing. Cleared when the tool closes or the session is
+	// removed.
+	editToolOpenSince map[string]int64 // sessionID → unix seconds
+
 	// bgLiveProbe answers "does this session still have a live background
 	// process?" from its output-file paths. Defaults to anyLiveOutputWriter
 	// (lsof); tests override it. See issue #445.
@@ -180,6 +188,7 @@ func NewSessionDetector(
 		debouncedEvents:   make(chan agent.Event, 64),
 		deletedCooldown:   10 * time.Second,
 		permissionPending: make(map[string]bool),
+		editToolOpenSince: make(map[string]int64),
 		bgLiveProbe:       anyLiveOutputWriter,
 		bgLive:            make(map[string]bool),
 		bgProbing:         make(map[string]bool),

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -369,6 +369,9 @@ func (d *SessionDetector) processActivity(id agent.Identity, ev agent.Event) {
 		}
 		d.permMu.Unlock()
 
+		// Overlay the transcript-based stalled-edit-tool fallback (#488).
+		d.markStalledEditTool(ev.SessionID, state.Metrics, time.Now().Unix())
+
 		// Content-based state detection.
 		now := time.Now().Unix()
 		newState, reason := ClassifyState(state.State, state.Metrics)
@@ -537,6 +540,38 @@ func (d *SessionDetector) applyBackgroundLiveness(state *session.SessionState) {
 			}
 		}
 	}()
+}
+
+// markStalledEditTool maintains the per-session editToolOpenSince window and
+// sets metrics.OpenToolStalled when a permission-gated edit tool
+// (Edit/Write/MultiEdit/NotebookEdit) has been open past the stale-refresh
+// interval — the transcript-based fallback for a held permission prompt when
+// the curl-delivered PermissionRequest hook can't reach the daemon (#488).
+//
+// Those tools run in-process and complete near-instantly, so one still open
+// after the window means the agent is blocked on the prompt, not executing.
+// The window is tracked from first observation (not state.UpdatedAt), so a
+// fresh tool_use write is never flagged on the spot — only the 5s
+// refreshStaleSessions re-evaluation of a lingering open tool is, which also
+// lets a held prompt flip without any new transcript write. The flag is
+// redundant once PermissionPending fired (the classifier prefers the hook),
+// so it is skipped then. now is injected for testability.
+func (d *SessionDetector) markStalledEditTool(sessionID string, m *session.SessionMetrics, now int64) {
+	d.permMu.Lock()
+	defer d.permMu.Unlock()
+
+	if m == nil || !m.HasOpenEditPermissionTool() {
+		delete(d.editToolOpenSince, sessionID)
+		return
+	}
+	since, ok := d.editToolOpenSince[sessionID]
+	if !ok {
+		since = now
+		d.editToolOpenSince[sessionID] = since
+	}
+	if !m.PermissionPending && now-since >= int64(staleWorkingRefreshInterval.Seconds()) {
+		m.OpenToolStalled = true
+	}
 }
 
 // refreshStaleSessions re-reads transcripts for working sessions that haven't

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -31,6 +31,7 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	// keep the entry forever, and a recycled session ID would inherit it.
 	d.permMu.Lock()
 	delete(d.permissionPending, ev.SessionID)
+	delete(d.editToolOpenSince, ev.SessionID)
 	d.permMu.Unlock()
 
 	state, err := d.repo.Load(ev.SessionID)

--- a/core/application/services/session_detector_stalled_test.go
+++ b/core/application/services/session_detector_stalled_test.go
@@ -1,0 +1,120 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestMarkStalledEditTool covers the transcript-based stalled-edit-tool
+// fallback (#488): an open permission-gated edit tool that lingers past the
+// stale-refresh interval is flagged OpenToolStalled, while a fresh one, a
+// non-edit tool, or one already covered by the hook is not. White-box so it
+// can exercise the unexported method + editToolOpenSince map directly,
+// injecting `now` instead of sleeping out the real 5s window.
+func TestMarkStalledEditTool(t *testing.T) {
+	threshold := int64(staleWorkingRefreshInterval.Seconds())
+
+	editOpen := func() *session.SessionMetrics {
+		return &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Edit"}}
+	}
+
+	t.Run("fresh edit tool is not flagged, window recorded", func(t *testing.T) {
+		d := &SessionDetector{editToolOpenSince: map[string]int64{}}
+		m := editOpen()
+		d.markStalledEditTool("s", m, 1000)
+		if m.OpenToolStalled {
+			t.Fatal("fresh edit tool must not be flagged stalled")
+		}
+		if got, ok := d.editToolOpenSince["s"]; !ok || got != 1000 {
+			t.Fatalf("open-since window: got (%d,%v), want (1000,true)", got, ok)
+		}
+	})
+
+	t.Run("edit tool open past window is flagged", func(t *testing.T) {
+		d := &SessionDetector{editToolOpenSince: map[string]int64{"s": 1000}}
+		m := editOpen()
+		d.markStalledEditTool("s", m, 1000+threshold)
+		if !m.OpenToolStalled {
+			t.Fatalf("edit tool open for %ds must be flagged stalled", threshold)
+		}
+	})
+
+	t.Run("edit tool just under window is not flagged", func(t *testing.T) {
+		d := &SessionDetector{editToolOpenSince: map[string]int64{"s": 1000}}
+		m := editOpen()
+		d.markStalledEditTool("s", m, 1000+threshold-1)
+		if m.OpenToolStalled {
+			t.Fatal("edit tool under the window must not be flagged stalled")
+		}
+	})
+
+	t.Run("permission-pending edit tool defers to the hook", func(t *testing.T) {
+		d := &SessionDetector{editToolOpenSince: map[string]int64{"s": 1000}}
+		m := editOpen()
+		m.PermissionPending = true
+		d.markStalledEditTool("s", m, 1000+threshold+100)
+		if m.OpenToolStalled {
+			t.Fatal("must not set OpenToolStalled when PermissionPending already fired")
+		}
+	})
+
+	t.Run("non-edit tool is never flagged and clears the window", func(t *testing.T) {
+		d := &SessionDetector{editToolOpenSince: map[string]int64{"s": 1000}}
+		m := &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Bash"}}
+		d.markStalledEditTool("s", m, 1000+threshold+100)
+		if m.OpenToolStalled {
+			t.Fatal("a long-running Bash must not be flagged stalled")
+		}
+		if _, ok := d.editToolOpenSince["s"]; ok {
+			t.Fatal("non-edit tool must clear the open-since window")
+		}
+	})
+
+	t.Run("closing the tool clears the window", func(t *testing.T) {
+		d := &SessionDetector{editToolOpenSince: map[string]int64{"s": 1000}}
+		m := &session.SessionMetrics{HasOpenToolCall: false}
+		d.markStalledEditTool("s", m, 1000+threshold+100)
+		if m.OpenToolStalled {
+			t.Fatal("a closed tool must not be flagged stalled")
+		}
+		if _, ok := d.editToolOpenSince["s"]; ok {
+			t.Fatal("closing the tool must clear the open-since window")
+		}
+	})
+
+	t.Run("nil metrics clears the window safely", func(t *testing.T) {
+		d := &SessionDetector{editToolOpenSince: map[string]int64{"s": 1000}}
+		d.markStalledEditTool("s", nil, 9999)
+		if _, ok := d.editToolOpenSince["s"]; ok {
+			t.Fatal("nil metrics must clear the open-since window")
+		}
+	})
+
+	// Realistic sequence: a held Edit prompt observed across two passes flips
+	// to stalled on the second (a stale-refresh) pass; an arriving tool_result
+	// then clears the window.
+	t.Run("held prompt sequence", func(t *testing.T) {
+		d := &SessionDetector{editToolOpenSince: map[string]int64{}}
+		start := time.Now().Unix()
+
+		m1 := editOpen()
+		d.markStalledEditTool("s", m1, start) // live tool_use write
+		if m1.OpenToolStalled {
+			t.Fatal("first observation must not be stalled")
+		}
+
+		m2 := editOpen()
+		d.markStalledEditTool("s", m2, start+threshold) // stale-refresh
+		if !m2.OpenToolStalled {
+			t.Fatal("second (stale) observation must be stalled")
+		}
+
+		m3 := &session.SessionMetrics{HasOpenToolCall: false} // approval → tool_result
+		d.markStalledEditTool("s", m3, start+threshold+1)
+		if _, ok := d.editToolOpenSince["s"]; ok {
+			t.Fatal("approval must clear the window")
+		}
+	})
+}

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -44,6 +44,19 @@ func ClassifyState(currentState string, metrics *session.SessionMetrics) (string
 		return currentState, ""
 	}
 
+	// 1b. A permission-gated file-edit tool has been open and idle long enough
+	// that the agent is almost certainly blocked on a permission prompt →
+	// waiting. Transcript-based fallback for when the curl-delivered
+	// PermissionRequest hook can't reach the daemon (#488). The detector sets
+	// OpenToolStalled only after the open tool has lingered with no transcript
+	// progress, so this never fires on a tool that is actively executing.
+	if metrics.OpenToolStalled {
+		if currentState != session.StateWaiting {
+			return session.StateWaiting, "stalled edit tool → likely permission prompt → waiting"
+		}
+		return currentState, ""
+	}
+
 	// 2. Agent finished turn — check if waiting for user input first.
 	if metrics.IsAgentDone() {
 		// 2a. Turn ended with a question or imperative cue (e.g. "let me

--- a/core/application/services/state_classifier_test.go
+++ b/core/application/services/state_classifier_test.go
@@ -68,6 +68,41 @@ func TestClassifyState(t *testing.T) {
 			wantState: session.StateWorking,
 		},
 
+		// Rule 1b: OpenToolStalled → waiting (transcript fallback, #488).
+		{
+			name:    "working → waiting (stalled edit tool)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				HasOpenToolCall:   true,
+				LastOpenToolNames: []string{"Edit"},
+				OpenToolStalled:   true,
+			},
+			wantState:  session.StateWaiting,
+			wantReason: true,
+		},
+		{
+			name:    "waiting stays waiting (stalled edit tool, already waiting)",
+			current: session.StateWaiting,
+			metrics: &session.SessionMetrics{
+				HasOpenToolCall:   true,
+				LastOpenToolNames: []string{"Write"},
+				OpenToolStalled:   true,
+			},
+			wantState: session.StateWaiting,
+		},
+		{
+			// Regression guard: an open edit tool the detector has NOT yet
+			// flagged stalled must stay working (no premature waiting flicker).
+			name:    "working stays working (edit open, not stalled)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				HasOpenToolCall:   true,
+				LastOpenToolNames: []string{"Edit"},
+				OpenToolStalled:   false,
+			},
+			wantState: session.StateWorking,
+		},
+
 		// Rule 1: NeedsUserAttention → waiting.
 		{
 			name:    "working → waiting (AskUserQuestion)",

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -107,6 +107,14 @@ func main() {
 		logger.LogInfo("startup", "", "installed Claude Code hooks for permission tracking")
 	}
 
+	// The installed hooks POST via curl; without it they silently no-op and
+	// tool-use permission prompts never surface as `waiting`. Warn loudly so
+	// this isn't an invisible failure (the transcript heuristic still covers
+	// held file-edit prompts). See #488.
+	if !claudecode.HookDeliveryAvailable() {
+		logger.LogError("startup", "", "curl not found on PATH — Claude Code permission-prompt detection is degraded: hooks POST via curl, so without it permission prompts may not surface as 'waiting'. Install curl to restore full detection (#488).")
+	}
+
 	// Auto-install Claude Code statusLine.command for rate-limit ingestion
 	// (issue #309). Chains any user-configured statusline so we don't clobber
 	// it.

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -131,6 +131,17 @@ type SessionMetrics struct {
 	// episode (issue #150). Transient — per-pass, not persisted.
 	SawUserBlockingToolClosedThisPass bool `json:"-"`
 
+	// OpenToolStalled is a transient, live-only signal set by the detector
+	// when a permission-gated file-edit tool (Edit/Write/MultiEdit/
+	// NotebookEdit) has stayed open with no transcript progress long enough
+	// that the agent is almost certainly blocked on a permission prompt
+	// rather than mid-execution (those tools complete near-instantly). It is
+	// the transcript-based fallback for permission detection when the
+	// curl-delivered PermissionRequest hook can't reach the daemon (#488).
+	// Like HasLiveBackgroundProcess it is wall-clock derived and never set
+	// under replay. Read by ClassifyState.
+	OpenToolStalled bool `json:"-"`
+
 	// NoSubstantiveActivity reflects the last tailer pass: true when the
 	// pass consumed new transcript content but produced no state-relevant
 	// change (every line was Skip=true with no SubagentCompletions and no
@@ -210,6 +221,36 @@ func (m *SessionMetrics) NeedsUserAttention() bool {
 // trigger the "waiting" state.
 func isUserBlockingTool(name string) bool {
 	return name == "AskUserQuestion" || name == "ExitPlanMode" || name == "question"
+}
+
+// HasOpenEditPermissionTool reports whether an open tool call is a
+// permission-gated file-edit tool (Edit/Write/MultiEdit/NotebookEdit). These
+// run in-process and complete near-instantly, so an open one that lingers is
+// a strong signal the agent is blocked on a permission prompt — the basis for
+// the OpenToolStalled fallback (#488). Bash/WebFetch/MCP are deliberately
+// excluded: they can legitimately run for seconds, so duration alone can't
+// distinguish "blocked" from "executing" for them (they rely on the hook).
+func (m *SessionMetrics) HasOpenEditPermissionTool() bool {
+	if m == nil || !m.HasOpenToolCall {
+		return false
+	}
+	for _, name := range m.LastOpenToolNames {
+		if isPermissionGatedEditTool(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// isPermissionGatedEditTool reports whether name is a fast, in-process
+// file-edit tool that prompts for permission by default.
+func isPermissionGatedEditTool(name string) bool {
+	switch name {
+	case "Edit", "Write", "MultiEdit", "NotebookEdit":
+		return true
+	default:
+		return false
+	}
 }
 
 // trailingMarkdownNoise are characters that commonly appear AFTER a

--- a/core/domain/session/session_test.go
+++ b/core/domain/session/session_test.go
@@ -182,6 +182,37 @@ func TestIsWaitingForUserInput_ImperativeCues(t *testing.T) {
 	}
 }
 
+func TestHasOpenEditPermissionTool(t *testing.T) {
+	tests := []struct {
+		name    string
+		metrics *SessionMetrics
+		want    bool
+	}{
+		{"nil metrics", nil, false},
+		{"no open tools", &SessionMetrics{HasOpenToolCall: false, LastOpenToolNames: []string{"Edit"}}, false},
+		{"open Edit", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Edit"}}, true},
+		{"open Write", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Write"}}, true},
+		{"open MultiEdit", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"MultiEdit"}}, true},
+		{"open NotebookEdit", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"NotebookEdit"}}, true},
+		// Tools that can legitimately run long must NOT qualify — duration
+		// can't distinguish "blocked on prompt" from "executing" for them.
+		{"open Bash", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Bash"}}, false},
+		{"open WebFetch", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"WebFetch"}}, false},
+		{"open Read", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Read"}}, false},
+		{"open mcp tool", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"mcp__server__do"}}, false},
+		{"open AskUserQuestion", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"AskUserQuestion"}}, false},
+		{"mixed: Bash + Edit", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Bash", "Edit"}}, true},
+		{"open tool, no names", &SessionMetrics{HasOpenToolCall: true}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.metrics.HasOpenEditPermissionTool(); got != tt.want {
+				t.Errorf("HasOpenEditPermissionTool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsStale(t *testing.T) {
 	now := time.Now().Unix()
 

--- a/examples/roundtrip/README.md
+++ b/examples/roundtrip/README.md
@@ -56,15 +56,21 @@ docker compose -f examples/roundtrip/docker-compose.yml exec -it agent claude
 **Expected on the Mac, live:**
 
 - a new session appears under daemon **`linux-dev`**, project **`work`**;
-- it transitions **`working → ready`** as the turn runs and settles, with live
-  **cost/tokens** (a one-edit turn ran ~$0.14 / 25.8k tokens, model
-  `claude-opus-4-7`);
+- it transitions **`working → waiting → working → ready`** as the turn runs:
+  it dips to **`waiting`** while a tool-use **permission prompt** is held open
+  ("Do you want to proceed?"), returns to `working` on approval, and settles
+  `ready` when the turn ends — with live **cost/tokens** (a one-edit turn ran
+  ~$0.14 / 25.8k tokens, model `claude-opus-4-7`);
 - hovering the connection-status indicator shows **`linux-dev — connected`**.
 
-> **Note:** claude 2.x's tool-use **permission prompts stay `working`**, not
-> `waiting` — so you'll see `working → ready`, not a `waiting` dip. (Surfacing
-> the permission prompt as `waiting` is a separate daemon-side gap, not a fault
-> of this testbed.)
+> **Permission prompts and `curl`.** The `waiting` dip on a permission prompt
+> is driven by Claude Code's `PermissionRequest` hook, which the daemon
+> auto-installs as a `curl … || true` POST to itself. The agent image
+> therefore **must** ship `curl` — without it the hook silently no-ops and
+> prompts stay `working` (this was #488). On any host where the daemon
+> observes `claude` but `curl` is absent, the daemon logs a startup warning
+> and falls back to a transcript heuristic that still flags a held file-edit
+> prompt (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) as `waiting`.
 
 ```bash
 # Relay restart: the daemon reconnects (backoff) and the Mac re-hydrates,

--- a/examples/roundtrip/agent.Dockerfile
+++ b/examples/roundtrip/agent.Dockerfile
@@ -27,9 +27,13 @@ RUN go build -trimpath -ldflags "-X main.Version=${VERSION}" \
 # ---- runtime: Node (Claude Code) + the daemon, run as a non-root user ----
 FROM node:${NODE_VERSION}-bookworm-slim AS runtime
 # git: the scratch repo + Claude's own tooling. tini: PID-1 reaper/signals.
-# procps: handy for debugging inside the container.
+# procps: handy for debugging inside the container. curl: REQUIRED — the
+# daemon's auto-installed Claude Code hooks POST to the daemon via
+# `curl … || true`; without curl the hook silently no-ops (the `|| true`
+# swallows "command not found"), so PermissionRequest never reaches the
+# daemon and tool-use permission prompts never surface as `waiting` (#488).
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git tini procps \
+    && apt-get install -y --no-install-recommends ca-certificates git tini procps curl \
     && rm -rf /var/lib/apt/lists/*
 # Claude Code CLI (the real agent this testbed observes).
 RUN npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
Fixes #488.

## Root cause — not the daemon

The bug was filed as a daemon classifier gap; it isn't. Driving real `claude` **2.1.150** turns on macOS prod, the daemon already produces the correct cycle: `working → waiting(Bash prompt) → working → waiting(Edit prompt) → working → ready`, driven by the `PermissionRequest` hook → `permissionPending` → `ClassifyState`.

The #486 roundtrip **agent image ships without `curl`**. irrlicht's auto-installed hook is `curl … || true`; with curl absent it runs `curl: not found` and exits 0 (the `|| true` swallows it), so `PermissionRequest` never reaches the daemon and prompts stay `working`.

**Proven empirically:** in-container the daemon is up and reachable via `node fetch` (`{"version":"docker"}`), `command -v curl` → not found, and the exact installed hook command exits 0 silently. After `apt-get install curl`, that same hook command returns `HTTP 200`.

## What changed

1. **Testbed** — `examples/roundtrip/agent.Dockerfile` now installs `curl`; the README note that misdiagnosed this as "a separate daemon-side gap, not a fault of this testbed" is corrected (the demo now shows the `waiting` dip).
2. **Robustness — visible failure** — `irrlichd` logs a startup warning when `curl` is not on PATH (`claudecode.HookDeliveryAvailable`), so this silent no-op can't recur unnoticed.
3. **Robustness — transcript fallback** — a permission-gated **fast-edit** tool (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) left open past the 5s stale-refresh window is flagged `OpenToolStalled` → `waiting`, so a held file-edit prompt surfaces even when the hook can't reach the daemon (no curl, or genuine cross-host observation). Live-only/wall-clock (like `HasLiveBackgroundProcess`) so replay goldens are unaffected.

## Tool-scoping — reviewer decision (my recommendation: keep it fast-edit-only)

The fallback deliberately **excludes** `Bash`, `WebFetch`, and `mcp__*`. Those can legitimately run for many seconds, so "open tool past N seconds" cannot distinguish *blocked on a permission prompt* from *executing* — including them would flag a long `Bash`/`npm test` as `waiting` and erode trust in the signal. The four fast-edit tools run in-process and complete in <100ms, so an open one that lingers is almost certainly a held prompt → near-zero false positives. Bash-style prompts remain covered deterministically by the hook (restored by the curl fix on any curl-equipped host).

**Recommendation:** keep the fast-edit scope as-is. If we later want `Bash` prompts covered *without* the hook (true cross-host), the robust path is a **process-tree signal** (open `Bash` tool_use + no child process under the claude PID ⇒ blocked, using the #478 `ProcessObserver`), not a longer duration threshold. I'd leave that to a follow-up if/when a hook-less cross-host setup actually needs it. The single scoping point is `isPermissionGatedEditTool` in `core/domain/session/session.go`, easy to extend.

## Validation

- `go test ./core/... -race -count=1` ✅ (incl. daemon smoke + e2e)
- `tools/replay-fixtures.sh` ✅ (only the pre-existing expected `known_failing`)
- `go vet` clean
- New tests: classifier `OpenToolStalled` rule, `HasOpenEditPermissionTool` tool-gating, white-box `markStalledEditTool` window/clear/hook-defer logic (injected time, no real sleeps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)