### PR TITLE
feat(viewer): animate cost/tokens across the recording playhead

### DIFF
--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"irrlicht/core/adapters/inbound/agents"
+	"irrlicht/core/application/replayengine"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 )
@@ -185,6 +186,43 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 		result.LastAssistantText = snippet
 	}
 	return result, nil
+}
+
+// ComputeMetricsTimeline returns cumulative SessionMetrics snapshots — one per
+// transcript turn/accumulation point, ascending by VirtualTime — so a replay
+// viewer can animate cost/tokens across the playhead instead of showing only
+// the final total. It drives a throwaway replayengine pass on a private tailer
+// (its own scratch file), so it never touches the per-path tailer cache or the
+// on-disk ledger that ComputeMetrics maintains.
+//
+// Returns nil for an absent/empty transcript and for adapters backed by a
+// MetricsProvider (e.g. OpenCode's SQLite store) which have no transcript-line
+// stream to accumulate over — callers fall back to a single ComputeMetrics.
+func (a *Adapter) ComputeMetricsTimeline(transcriptPath, adapter string) ([]session.MetricsTimelinePoint, error) {
+	if transcriptPath == "" {
+		return nil, nil
+	}
+	if _, ok := a.metricsProviders[adapter]; ok {
+		return nil, nil // no transcript-line stream; caller uses single-shot
+	}
+	parser := a.parserFor(adapter)
+	if parser == nil {
+		return nil, nil
+	}
+	res, err := replayengine.ReplayTranscript(transcriptPath, replayengine.Options{
+		Adapter:                    adapter,
+		Parser:                     parser,
+		DisableModelConfigFallback: true,
+		EmitMetricsTimeline:        true,
+	})
+	if err != nil || res == nil || len(res.MetricsTimeline) == 0 {
+		return nil, err //nolint:nilerr — absent/empty transcript is not an error
+	}
+	out := make([]session.MetricsTimelinePoint, 0, len(res.MetricsTimeline))
+	for _, s := range res.MetricsTimeline {
+		out = append(out, session.MetricsTimelinePoint{VirtualTime: s.VirtualTime, Metrics: s.Metrics})
+	}
+	return out, nil
 }
 
 // IngestRateLimit pushes a rate-limit snapshot into the tailer for

--- a/core/application/replayengine/engine.go
+++ b/core/application/replayengine/engine.go
@@ -68,6 +68,19 @@ type Options struct {
 	// DisableModelConfigFallback keeps replays reproducible across machines
 	// by ignoring the operator's local model config (issue #440).
 	DisableModelConfigFallback bool
+	// EmitMetricsTimeline records a cumulative metrics snapshot after every
+	// batch into Result.MetricsTimeline. Off by default so the transition
+	// stream (and the replay CLI goldens) are untouched; the viewer turns it
+	// on to animate cost/tokens across a recording's playhead.
+	EmitMetricsTimeline bool
+}
+
+// MetricsSnapshot is the cumulative SessionMetrics observed up to a point in a
+// replayed transcript, tagged with that point's transcript-relative timestamp.
+// Emitted only when Options.EmitMetricsTimeline is set.
+type MetricsSnapshot struct {
+	VirtualTime time.Time
+	Metrics     *session.SessionMetrics
 }
 
 // Result is the outcome of replaying a transcript.
@@ -81,6 +94,9 @@ type Result struct {
 	// LastMetrics is the tailer metrics after the final pass, used by the
 	// replay CLI to fill the report's cost/token summary.
 	LastMetrics *tailer.SessionMetrics
+	// MetricsTimeline holds one cumulative snapshot per batch (ascending by
+	// VirtualTime) when Options.EmitMetricsTimeline is set; otherwise nil.
+	MetricsTimeline []MetricsSnapshot
 }
 
 // rawEvent is one line from the source transcript paired with its timestamp.
@@ -125,10 +141,11 @@ func ReplayTranscript(src string, opts Options) (*Result, error) {
 type replayer struct {
 	tmp         *os.File
 	tailer      *tailer.TranscriptTailer
-	result      *Result
-	state       string
-	consumed    int
-	lastMetrics *tailer.SessionMetrics
+	result       *Result
+	state        string
+	consumed     int
+	lastMetrics  *tailer.SessionMetrics
+	emitTimeline bool
 }
 
 func newReplayer(opts Options, events []rawEvent) (*replayer, func(), error) {
@@ -153,10 +170,11 @@ func newReplayer(opts Options, events []rawEvent) (*replayer, func(), error) {
 	}
 
 	r := &replayer{
-		tmp:    tmp,
-		tailer: t,
-		result: &Result{},
-		state:  session.StateReady,
+		tmp:          tmp,
+		tailer:       t,
+		result:       &Result{},
+		state:        session.StateReady,
+		emitTimeline: opts.EmitMetricsTimeline,
 	}
 	// Synthetic initial-state transition mirrors the live detector seeding
 	// a session as ready before any activity.
@@ -188,6 +206,14 @@ func (r *replayer) runBatches(batches [][]rawEvent) error {
 			return fmt.Errorf("batch %d: %w", bi, err)
 		}
 		r.lastMetrics = metrics
+		if r.emitTimeline {
+			// TailerToDomain allocates a fresh struct per call, so the snapshot
+			// never aliases the tailer's mutable cumulative state.
+			r.result.MetricsTimeline = append(r.result.MetricsTimeline, MetricsSnapshot{
+				VirtualTime: nextEventTime,
+				Metrics:     TailerToDomain(metrics),
+			})
+		}
 		cause := CauseEvent
 		if len(batch) > 1 {
 			cause = CauseDebounceCoalesce
@@ -202,6 +228,12 @@ func (r *replayer) runBatches(batches [][]rawEvent) error {
 		if metrics, flushed := r.tailer.FlushIdle(); flushed {
 			r.lastMetrics = metrics
 			last := batches[len(batches)-1]
+			if r.emitTimeline {
+				r.result.MetricsTimeline = append(r.result.MetricsTimeline, MetricsSnapshot{
+					VirtualTime: last[len(last)-1].Time,
+					Metrics:     TailerToDomain(metrics),
+				})
+			}
 			r.classifyBatch(last[len(last)-1].Index, last[len(last)-1].Time, CauseIdleFlush, TailerToDomain(metrics))
 		}
 	}

--- a/core/application/replayengine/engine_test.go
+++ b/core/application/replayengine/engine_test.go
@@ -92,3 +92,63 @@ func TestReplayTranscript_emptyTranscript(t *testing.T) {
 		t.Fatalf("expected nil result for empty transcript, got %+v", res)
 	}
 }
+
+// TestReplayTranscript_metricsTimelineClimbs guards the viewer-playback fix:
+// EmitMetricsTimeline must yield cumulative, monotonically non-decreasing
+// snapshots (ascending time, non-shrinking tokens + cost) so the recording
+// viewer can animate cost/tokens turn-by-turn instead of showing the final
+// total at frame 1. Uses the real 3-turn token-accounting fixture whose cache
+// tokens accumulate across turns. Token accumulation is asserted directly
+// (pricing-independent); cost is asserted only as non-decreasing because the
+// LiteLLM pricing cache may be absent in a bare `go test`.
+func TestReplayTranscript_metricsTimelineClimbs(t *testing.T) {
+	src := filepath.Join(repoRoot(t),
+		"replaydata", "agents", "claudecode", "scenarios", "token-accounting", "transcript.jsonl")
+
+	res, err := replayengine.ReplayTranscript(src, replayengine.Options{
+		Adapter:                    claudecode.AdapterName,
+		Parser:                     &claudecode.Parser{},
+		DisableModelConfigFallback: true,
+		EmitMetricsTimeline:        true,
+	})
+	if err != nil {
+		t.Fatalf("ReplayTranscript: %v", err)
+	}
+	if res == nil || len(res.MetricsTimeline) < 2 {
+		t.Fatalf("expected a multi-point metrics timeline, got %d points", len(res.MetricsTimeline))
+	}
+
+	var prevTime = res.MetricsTimeline[0].VirtualTime
+	var prevTokens int64
+	var prevCost float64
+	for i, p := range res.MetricsTimeline {
+		if p.Metrics == nil {
+			t.Fatalf("timeline point %d has nil metrics", i)
+		}
+		if p.VirtualTime.Before(prevTime) {
+			t.Errorf("point %d goes back in time: %v < %v", i, p.VirtualTime, prevTime)
+		}
+		prevTime = p.VirtualTime
+		if p.Metrics.TotalTokens < prevTokens {
+			t.Errorf("point %d TotalTokens shrank: %d < %d", i, p.Metrics.TotalTokens, prevTokens)
+		}
+		prevTokens = p.Metrics.TotalTokens
+		if p.Metrics.EstimatedCostUSD < prevCost {
+			t.Errorf("point %d cost shrank: %v < %v", i, p.Metrics.EstimatedCostUSD, prevCost)
+		}
+		prevCost = p.Metrics.EstimatedCostUSD
+	}
+
+	// The whole point: the final snapshot carries strictly more tokens than the
+	// first — i.e. metrics genuinely accumulate, not a flat final blob.
+	first, last := res.MetricsTimeline[0].Metrics, res.MetricsTimeline[len(res.MetricsTimeline)-1].Metrics
+	if last.TotalTokens <= first.TotalTokens {
+		t.Errorf("expected tokens to climb across the timeline: first=%d last=%d", first.TotalTokens, last.TotalTokens)
+	}
+
+	// Tail parity: the timeline's final cost must equal a single whole-transcript
+	// ComputeMetrics — the timeline is the same accumulation, just sampled.
+	if lm := res.LastMetrics; lm != nil && last.EstimatedCostUSD != lm.EstimatedCostUSD {
+		t.Errorf("final timeline cost %v != LastMetrics cost %v", last.EstimatedCostUSD, lm.EstimatedCostUSD)
+	}
+}

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -122,6 +122,10 @@ func (m *mockMetrics) ComputeMetrics(path, adapter string) (*session.SessionMetr
 	return nil, nil
 }
 
+func (m *mockMetrics) ComputeMetricsTimeline(path, adapter string) ([]session.MetricsTimelinePoint, error) {
+	return nil, nil
+}
+
 func (m *mockMetrics) PruneEntry(path string) { m.pruned = append(m.pruned, path) }
 
 func (m *mockMetrics) IngestRateLimit(path string, snap *session.RateLimitSnapshot) {}
@@ -138,6 +142,10 @@ func (m *funcMetrics) ComputeMetrics(path, adapter string) (*session.SessionMetr
 		return nil, nil
 	}
 	return m.fn(path, adapter)
+}
+
+func (m *funcMetrics) ComputeMetricsTimeline(path, adapter string) ([]session.MetricsTimelinePoint, error) {
+	return nil, nil
 }
 
 func (m *funcMetrics) PruneEntry(path string) {}

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -20,6 +20,15 @@ func IsCanonicalState(s string) bool {
 	return s == StateWorking || s == StateWaiting || s == StateReady
 }
 
+// MetricsTimelinePoint is one cumulative SessionMetrics snapshot tagged with
+// the transcript-relative timestamp it was observed at. A MetricsCollector can
+// return an ordered timeline of these so a replay viewer can show cost/tokens
+// climbing turn-by-turn instead of jumping straight to the final total.
+type MetricsTimelinePoint struct {
+	VirtualTime time.Time
+	Metrics     *SessionMetrics
+}
+
 // SessionMetrics holds computed performance metrics from transcript analysis.
 type SessionMetrics struct {
 	ElapsedSeconds     int64   `json:"elapsed_seconds"`

--- a/core/e2e/e2e_helpers_test.go
+++ b/core/e2e/e2e_helpers_test.go
@@ -170,6 +170,10 @@ func (m *stubMetrics) ComputeMetrics(_, _ string) (*session.SessionMetrics, erro
 	return nil, nil
 }
 
+func (m *stubMetrics) ComputeMetricsTimeline(_, _ string) ([]session.MetricsTimelinePoint, error) {
+	return nil, nil
+}
+
 func (m *stubMetrics) PruneEntry(_ string) {}
 
 func (m *stubMetrics) IngestRateLimit(_ string, _ *session.RateLimitSnapshot) {}

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -90,6 +90,12 @@ type GitResolver interface {
 // "codex", "pi") so the correct parser is used.
 type MetricsCollector interface {
 	ComputeMetrics(transcriptPath, adapter string) (*session.SessionMetrics, error)
+	// ComputeMetricsTimeline returns cumulative metrics snapshots (ascending by
+	// VirtualTime), one per transcript turn, so a replay viewer can animate
+	// cost/tokens across the playhead. Returns nil for transcripts that can't
+	// be accumulated turn-by-turn (absent/empty, or provider-backed adapters);
+	// callers fall back to ComputeMetrics.
+	ComputeMetricsTimeline(transcriptPath, adapter string) ([]session.MetricsTimelinePoint, error)
 	// PruneEntry releases per-session state — both the in-memory tailer
 	// cache and the on-disk ledger file — when a session ends. Idempotent
 	// on a missing or already-removed entry.

--- a/tools/agent-onboarding/internal/replay/state_machine.go
+++ b/tools/agent-onboarding/internal/replay/state_machine.go
@@ -3,6 +3,7 @@ package replay
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"irrlicht/core/domain/lifecycle"
@@ -46,6 +47,11 @@ type StateMachine struct {
 	playheadMs       float64
 	lastTickWall     time.Time
 	playheadRunning  bool
+	// playheadAtomicMs mirrors playheadMs for LOCK-FREE reads. The metrics
+	// enricher reads the playhead from inside Broadcast, which the machine
+	// calls while holding mu — so it can't take mu (LivePlayheadMs would
+	// deadlock). Every site that writes playheadMs under mu also stores here.
+	playheadAtomicMs atomic.Int64
 
 	speedMu sync.RWMutex
 	speed   float64 // 1.0, 2.0, 5.0, …; >0 always
@@ -98,6 +104,16 @@ func (m *StateMachine) tickPlayheadLocked() {
 		}
 	}
 	m.lastTickWall = now
+	m.playheadAtomicMs.Store(int64(m.playheadMs))
+}
+
+// PlayheadMsLockFree returns the last-computed playhead offset (ms) without
+// taking mu, so callers invoked from within Broadcast (which runs under mu)
+// can read it without deadlocking. It reflects the value as of the most
+// recent tick/seek — accurate enough to pick the cumulative metrics snapshot
+// for the current frame.
+func (m *StateMachine) PlayheadMsLockFree() int64 {
+	return m.playheadAtomicMs.Load()
 }
 
 // totalDurationMsLocked returns the recording's total span in ms.
@@ -208,6 +224,7 @@ func (m *StateMachine) Run(ctx context.Context) {
 	m.lastTickWall = time.Now()
 	m.playheadRunning = true
 	m.playheadMs = 0
+	m.playheadAtomicMs.Store(0)
 	m.mu.Unlock()
 	paused := false
 
@@ -235,6 +252,7 @@ func (m *StateMachine) Run(ctx context.Context) {
 			m.seekTo(c.seekToMs, anchor)
 			m.mu.Lock()
 			m.playheadMs = float64(c.seekToMs)
+			m.playheadAtomicMs.Store(c.seekToMs)
 			m.lastTickWall = time.Now()
 			m.mu.Unlock()
 		}

--- a/tools/agent-onboarding/internal/viewer/metrics_broadcast.go
+++ b/tools/agent-onboarding/internal/viewer/metrics_broadcast.go
@@ -10,6 +10,7 @@ import (
 	"irrlicht/core/adapters/outbound/metrics"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/outbound"
+	"irrlicht/tools/agent-onboarding/internal/replay"
 )
 
 // buildMetricsCollector constructs the production metrics.Adapter the
@@ -31,18 +32,31 @@ func buildMetricsCollector() outbound.MetricsCollector {
 // total_tokens / context_utilization_percentage / estimated_cost_usd
 // from agent.metrics.*; the enricher just fills those fields in.
 //
-// The recorded transcript.jsonl is static — every ComputeMetrics call
-// returns the same SessionMetrics. We cache per sessionID to avoid
-// hammering the tailer once per broadcast. Limitation: multi-session
-// recordings (e.g. session-reset with v1 → /clear → v2) share a single
-// transcript file, so all sessions see the same final metrics blob.
+// When a StateMachine is attached (attachMachine), the enricher builds a
+// per-turn metrics TIMELINE from the transcript (ComputeMetricsTimeline) and,
+// on every broadcast, returns the cumulative snapshot at the machine's current
+// playhead — so cost/tokens climb turn-by-turn and follow seeks instead of
+// jumping straight to the final total. Adapters with no transcript-line stream
+// (e.g. OpenCode) yield no timeline and fall back to a single cached
+// ComputeMetrics. Limitation: multi-session recordings (session-reset v1 →
+// /new → v2) share one transcript file, so both sessions share one timeline.
 type metricsEnricher struct {
 	inner          outbound.PushBroadcaster
 	collector      outbound.MetricsCollector
 	transcriptPath string
 
-	mu    sync.Mutex
-	cache map[string]*session.SessionMetrics
+	mu       sync.Mutex
+	machine  *replay.StateMachine // nil → no playhead; fall back to single-shot
+	tlBuilt  bool                 // timeline build attempted (built lazily on first broadcast)
+	timeline []timelinePoint      // ascending by offsetMs; empty → fall back
+	cache    map[string]*session.SessionMetrics
+}
+
+// timelinePoint is a cumulative metrics snapshot at a recording-relative
+// offset (ms from the playback anchor).
+type timelinePoint struct {
+	offsetMs int64
+	metrics  *session.SessionMetrics
 }
 
 func newMetricsEnricher(inner outbound.PushBroadcaster, collector outbound.MetricsCollector, eventsDir string) *metricsEnricher {
@@ -53,7 +67,8 @@ func newMetricsEnricher(inner outbound.PushBroadcaster, collector outbound.Metri
 	// replay: a recorded transcript never grows, so a stale lastOffset
 	// at EOF would have the next ComputeMetrics call read zero bytes
 	// and return total_tokens=0 / no model. Deleting the ledger forces
-	// a fresh full scan on the next call.
+	// a fresh full scan on the next call. (Only the single-shot fallback
+	// uses this ledger; ComputeMetricsTimeline drives a private tailer.)
 	if ledgerDir, err := metrics.LedgerDir(); err == nil {
 		_ = os.Remove(filepath.Join(ledgerDir, metrics.LedgerFilename(transcriptPath)))
 	}
@@ -63,6 +78,15 @@ func newMetricsEnricher(inner outbound.PushBroadcaster, collector outbound.Metri
 		transcriptPath: transcriptPath,
 		cache:          map[string]*session.SessionMetrics{},
 	}
+}
+
+// attachMachine wires the playback state machine so the enricher can read the
+// live playhead (LivePlayheadMs) and the recording anchor (Anchor). Called
+// after replay.New and before the machine runs.
+func (e *metricsEnricher) attachMachine(m *replay.StateMachine) {
+	e.mu.Lock()
+	e.machine = m
+	e.mu.Unlock()
 }
 
 func (e *metricsEnricher) Broadcast(msg outbound.PushMessage) {
@@ -76,15 +100,75 @@ func (e *metricsEnricher) Broadcast(msg outbound.PushMessage) {
 	e.inner.Broadcast(msg)
 }
 
+// lookup returns the metrics to stamp onto a session broadcast (or Snapshot).
+// With a playhead it returns the cumulative timeline snapshot at the current
+// position (animated); otherwise it falls back to a single cached
+// ComputeMetrics over the whole transcript.
 func (e *metricsEnricher) lookup(sessionID, adapter string) *session.SessionMetrics {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+
+	if e.machine != nil {
+		e.ensureTimelineLocked(adapter)
+		if len(e.timeline) > 0 {
+			// Lock-free playhead read: this runs inside Broadcast, which the
+			// state machine calls while holding its mutex; LivePlayheadMs would
+			// deadlock by re-taking it.
+			return selectAtPlayhead(e.timeline, e.machine.PlayheadMsLockFree())
+		}
+		// No timeline for this adapter (e.g. OpenCode) → single-shot below.
+	}
+
 	if m, ok := e.cache[sessionID]; ok {
 		return m
 	}
 	m, _ := e.collector.ComputeMetrics(e.transcriptPath, adapter)
 	e.cache[sessionID] = m // cache the nil result too — no transcript means no metrics, forever for this session
 	return m
+}
+
+// ensureTimelineLocked builds the per-turn timeline once, using the same
+// adapter string the broadcast carries (so parser resolution matches the
+// proven ComputeMetrics path) and the machine's anchor to convert each
+// snapshot's virtual time into a playback offset. e.mu must be held.
+func (e *metricsEnricher) ensureTimelineLocked(adapter string) {
+	if e.tlBuilt {
+		return
+	}
+	e.tlBuilt = true
+	tl, err := e.collector.ComputeMetricsTimeline(e.transcriptPath, adapter)
+	if err != nil || len(tl) == 0 {
+		return
+	}
+	anchor := e.machine.Anchor()
+	pts := make([]timelinePoint, 0, len(tl))
+	for _, p := range tl {
+		off := p.VirtualTime.Sub(anchor).Milliseconds()
+		if off < 0 {
+			off = 0
+		}
+		pts = append(pts, timelinePoint{offsetMs: off, metrics: p.Metrics})
+	}
+	e.timeline = pts
+}
+
+// selectAtPlayhead returns a copy of the last timeline snapshot whose offset is
+// at or before posMs. Returns nil while the playhead precedes the first
+// snapshot (show "no metrics yet" rather than a final-ish total at t=0).
+func selectAtPlayhead(pts []timelinePoint, posMs int64) *session.SessionMetrics {
+	var chosen *session.SessionMetrics
+	for _, p := range pts {
+		if p.offsetMs <= posMs {
+			chosen = p.metrics
+		} else {
+			break
+		}
+	}
+	if chosen == nil {
+		return nil
+	}
+	cp := *chosen // fresh pointer per broadcast; fields are read-only downstream
+	return &cp
 }
 
 func (e *metricsEnricher) Subscribe() chan outbound.PushMessage {

--- a/tools/agent-onboarding/internal/viewer/metrics_broadcast_test.go
+++ b/tools/agent-onboarding/internal/viewer/metrics_broadcast_test.go
@@ -1,0 +1,68 @@
+package viewer
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestSelectAtPlayhead pins the playhead → snapshot selection that animates
+// cost/tokens during recording playback: return the last snapshot at or before
+// the playhead, and nil while the playhead precedes the first snapshot (so the
+// dashboard shows "no metrics yet" instead of a final-ish total at t=0).
+func TestSelectAtPlayhead(t *testing.T) {
+	tl := []timelinePoint{
+		{offsetMs: 0, metrics: &session.SessionMetrics{EstimatedCostUSD: 0.01, TotalTokens: 100}},
+		{offsetMs: 1000, metrics: &session.SessionMetrics{EstimatedCostUSD: 0.05, TotalTokens: 500}},
+		{offsetMs: 2000, metrics: &session.SessionMetrics{EstimatedCostUSD: 0.12, TotalTokens: 1200}},
+	}
+
+	cases := []struct {
+		name     string
+		pos      int64
+		wantNil  bool
+		wantCost float64
+	}{
+		{"before first", -1, true, 0},
+		{"at first", 0, false, 0.01},
+		{"between first and second", 500, false, 0.01},
+		{"at second", 1000, false, 0.05},
+		{"between second and third", 1500, false, 0.05},
+		{"past last clamps to last", 5000, false, 0.12},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := selectAtPlayhead(tl, tc.pos)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("pos=%d: want nil, got %+v", tc.pos, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("pos=%d: want cost %v, got nil", tc.pos, tc.wantCost)
+			}
+			if got.EstimatedCostUSD != tc.wantCost {
+				t.Errorf("pos=%d: cost=%v, want %v", tc.pos, got.EstimatedCostUSD, tc.wantCost)
+			}
+		})
+	}
+}
+
+// TestSelectAtPlayhead_returnsCopy verifies each selection is a fresh pointer,
+// so a downstream broadcast can't mutate a shared timeline snapshot.
+func TestSelectAtPlayhead_returnsCopy(t *testing.T) {
+	orig := &session.SessionMetrics{EstimatedCostUSD: 0.07}
+	tl := []timelinePoint{{offsetMs: 0, metrics: orig}}
+	got := selectAtPlayhead(tl, 100)
+	if got == nil {
+		t.Fatal("expected a snapshot")
+	}
+	if got == orig {
+		t.Fatal("selectAtPlayhead must return a copy, not the shared timeline pointer")
+	}
+	got.EstimatedCostUSD = 99
+	if orig.EstimatedCostUSD != 0.07 {
+		t.Errorf("mutating the returned copy leaked into the timeline: %v", orig.EstimatedCostUSD)
+	}
+}

--- a/tools/agent-onboarding/internal/viewer/playback.go
+++ b/tools/agent-onboarding/internal/viewer/playback.go
@@ -306,6 +306,14 @@ func (m *PlaybackManager) StartViewerInternal(agent, subtree, scenario string, s
 		bc = enricher
 	}
 	machine := replay.New(events, bc, speed)
+	// Let the enricher read the live playhead + anchor so it can animate
+	// cost/tokens across the recording instead of showing the final total
+	// at every frame. The timeline itself is built lazily on the first
+	// broadcast (using the session's adapter), so this only hands over the
+	// machine reference.
+	if enricher != nil {
+		enricher.attachMachine(machine)
+	}
 	// Apply event 0 synchronously BEFORE returning to the frontend so
 	// the dashboard's initial /api/v1/sessions fetch sees a non-empty
 	// snapshot. Otherwise there's a race window where Run()'s


### PR DESCRIPTION
## What

A recording's **cost** (and `total_tokens`) stayed flat during playback — e.g.
claudecode `token-accounting` showed `$0.18` from frame 1, even though tokens
accumulate across its 3 turns. The recording's `events.jsonl` is lifecycle-only,
so the viewer re-derives metrics from the transcript — but the enricher called
`ComputeMetrics` **once over the whole transcript**, cached the single *final*
`SessionMetrics`, and stamped it onto **every** frame. Only the end state was
ever shown. (Reported: validation asserts token monotonicity, yet the viewer's
cost never moves.)

Now the enricher builds a per-turn metrics **timeline** and returns the
cumulative snapshot at the current playhead on every broadcast, so cost/tokens
climb turn-by-turn and follow seeks. No frontend change — `irrlicht.js` already
renders `metrics.*` live.

## How
- **replayengine**: opt-in `Options.EmitMetricsTimeline` → `Result.MetricsTimeline`,
  one cumulative snapshot per batch, reusing the existing tailer accumulation.
  Default transition stream untouched ⇒ `core/cmd/replay` goldens byte-identical.
- **metrics.Adapter.ComputeMetricsTimeline** drives a throwaway replayengine pass
  on a private tailer (no per-path cache/ledger side effects); added to the
  `MetricsCollector` port. Returns nil for absent transcripts + provider-backed
  adapters (OpenCode) → caller falls back to single-shot.
- **viewer enricher**: builds the timeline lazily on first broadcast (using the
  session's adapter, matching the proven `ComputeMetrics` path), normalizes each
  snapshot's virtual time to a playhead offset vs the machine anchor, and selects
  the last snapshot ≤ the live playhead per broadcast. `Snapshot()` (REST) and the
  WebSocket stream both route through it; seeks re-select for free.
- **replay StateMachine**: lock-free atomic playhead mirror (`PlayheadMsLockFree`).
  The enricher reads the playhead from inside `Broadcast`, which the machine calls
  while holding its mutex — `LivePlayheadMs` would deadlock by re-taking it.

## Verification
- End-to-end: seeking `token-accounting` now reports `cost=null/tokens=0` early and
  `cost≈$0.16/tokens=31280` late (was a flat `$0.18` at every offset).
- New tests: replayengine timeline climbs + tail-parity (real fixture); enricher
  playhead selection + copy-safety.
- `go test ./core/... -race` green; `core/cmd/replay` goldens unchanged; viewer SPA
  suite green; replay+viewer race-clean (deadlock guard).

## Out of scope
- Cost-monotonic assertion in `expected.jsonl` (validation checks tokens only).
- Per-session metrics split for multi-session recordings (both sessions share one
  climbing timeline — still strictly better than the old shared flat blob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)