### PR TITLE
fix(claudecode): strip trailing period from background-process output path

### DIFF
--- a/core/adapters/inbound/agents/claudecode/background_process_test.go
+++ b/core/adapters/inbound/agents/claudecode/background_process_test.go
@@ -48,8 +48,14 @@ func bgSpawnResult(toolUseID, bashID, content string) map[string]interface{} {
 
 func TestParser_BackgroundSpawn_FromResultText(t *testing.T) {
 	p := &Parser{}
+	// Claude Code's real launch message is a full sentence: the path is
+	// followed by a period and more prose ("…output. You will be notified…").
+	// The captured path must NOT absorb that trailing period — otherwise the
+	// daemon's lsof liveness probe dereferences a non-existent "…output." file,
+	// finds no writer, and wrongly settles a still-running background session to
+	// `ready` (the live working↔ready flapping this guards against).
 	ev := p.ParseLine(bgSpawnResult("toolu_1", "bc1h56v8v",
-		"Command running in background with ID: bc1h56v8v. Output is being written to: /private/tmp/claude-501/x/tasks/bc1h56v8v.output"))
+		"Command running in background with ID: bc1h56v8v. Output is being written to: /private/tmp/claude-501/x/tasks/bc1h56v8v.output. You will be notified when it completes. To check interim output, use Read on that file path."))
 	if len(ev.BackgroundSpawns) != 1 {
 		t.Fatalf("BackgroundSpawns = %d, want 1", len(ev.BackgroundSpawns))
 	}
@@ -58,7 +64,19 @@ func TestParser_BackgroundSpawn_FromResultText(t *testing.T) {
 		t.Errorf("BashID = %q, want bc1h56v8v", sp.BashID)
 	}
 	if sp.OutputPath != "/private/tmp/claude-501/x/tasks/bc1h56v8v.output" {
-		t.Errorf("OutputPath = %q", sp.OutputPath)
+		t.Errorf("OutputPath = %q (must not include the sentence-ending period)", sp.OutputPath)
+	}
+
+	// Detection must not depend on the file ending in ".output": the trailing
+	// period is stripped from whatever single-token path Claude reports, so a
+	// differently-named output file is still captured cleanly.
+	ev2 := p.ParseLine(bgSpawnResult("toolu_2", "bd2m99zzz",
+		"Command running in background with ID: bd2m99zzz. Output is being written to: /private/tmp/claude-501/x/tasks/bd2m99zzz.log. You will be notified when it completes."))
+	if len(ev2.BackgroundSpawns) != 1 {
+		t.Fatalf("non-.output spawn: BackgroundSpawns = %d, want 1", len(ev2.BackgroundSpawns))
+	}
+	if got := ev2.BackgroundSpawns[0].OutputPath; got != "/private/tmp/claude-501/x/tasks/bd2m99zzz.log" {
+		t.Errorf("non-.output OutputPath = %q (must not include the sentence-ending period)", got)
 	}
 }
 
@@ -124,7 +142,7 @@ func writeBgTranscript(t *testing.T, lines []map[string]interface{}) string {
 }
 
 func TestTailer_BackgroundProcessCount_SpawnAndTerminate(t *testing.T) {
-	spawnResult := "Command running in background with ID: bc1h56v8v. Output is being written to: /tmp/x/tasks/bc1h56v8v.output"
+	spawnResult := "Command running in background with ID: bc1h56v8v. Output is being written to: /tmp/x/tasks/bc1h56v8v.output. You will be notified when it completes. To check interim output, use Read on that file path."
 
 	t.Run("alive while only spawned", func(t *testing.T) {
 		path := writeBgTranscript(t, []map[string]interface{}{
@@ -258,7 +276,7 @@ func TestParser_TaskNotification_TerminatesBackgroundProcess(t *testing.T) {
 }
 
 func TestTailer_BackgroundProcessCount_ClearedByTaskNotification(t *testing.T) {
-	spawnResult := "Command running in background with ID: bc1h56v8v. Output is being written to: /tmp/x/tasks/bc1h56v8v.output"
+	spawnResult := "Command running in background with ID: bc1h56v8v. Output is being written to: /tmp/x/tasks/bc1h56v8v.output. You will be notified when it completes. To check interim output, use Read on that file path."
 	for _, tc := range []struct {
 		name      string
 		completed map[string]interface{}

--- a/core/adapters/inbound/agents/claudecode/background_process_test.go
+++ b/core/adapters/inbound/agents/claudecode/background_process_test.go
@@ -80,6 +80,43 @@ func TestParser_BackgroundSpawn_FromResultText(t *testing.T) {
 	}
 }
 
+// TestParser_BackgroundSpawn_OutputPathIsStatable closes the parser↔probe
+// contract that the trailing-period bug broke: the path extracted from Claude's
+// launch text must be the real on-disk file, because the daemon's lsof liveness
+// probe (anyLiveOutputWriter) checks that exact path. A corrupted "…output."
+// path is silently un-stat-able, so lsof finds no writer and a still-running
+// background session flips to `ready`. This asserts a real file embedded in the
+// full launch sentence round-trips back to a path os.Stat can resolve — the
+// property the probe relies on, expressed without a live process. See #445.
+func TestParser_BackgroundSpawn_OutputPathIsStatable(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "tasks", "bc1h56v8v.output")
+	if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(out, []byte("partial output\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// The exact shape Claude Code writes: the path mid-sentence, trailing prose.
+	text := "Command running in background with ID: bc1h56v8v. Output is being written to: " +
+		out + ". You will be notified when it completes. To check interim output, use Read on that file path."
+	ev := (&Parser{}).ParseLine(bgSpawnResult("toolu_1", "bc1h56v8v", text))
+	if len(ev.BackgroundSpawns) != 1 {
+		t.Fatalf("BackgroundSpawns = %d, want 1", len(ev.BackgroundSpawns))
+	}
+
+	got := ev.BackgroundSpawns[0].OutputPath
+	if got != out {
+		t.Errorf("OutputPath = %q, want %q", got, out)
+	}
+	// The decisive assertion: the recorded path must resolve to the real file.
+	// With the trailing period left in ("…output."), this os.Stat fails — which
+	// is exactly how lsof misses the live writer in production.
+	if _, err := os.Stat(got); err != nil {
+		t.Errorf("recorded path is not stat-able (lsof probe would miss the live writer): %v", err)
+	}
+}
+
 func TestParser_NoPhantomSpawnFromArbitraryText(t *testing.T) {
 	p := &Parser{}
 	// The same launch phrase, but with NO structured toolUseResult.backgroundTaskId

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -15,12 +15,21 @@ const eventTypeAssistantStreaming = "assistant_streaming"
 // backgroundSpawnRe matches the text Claude Code writes in a `Bash`
 // tool_result when the command was launched with `run_in_background: true`:
 //
-//	Command running in background with ID: bc1h56v8v. Output is being written to: /private/tmp/.../tasks/bc1h56v8v.output
+//	Command running in background with ID: bc1h56v8v. Output is being written to: /private/tmp/.../tasks/bc1h56v8v.output. You will be notified when it completes. To check interim output, use Read on that file path.
 //
 // Group 1 is the background id; group 2 is the output-file path. The
 // background id and output path are read from the *result* because the Bash
 // tool_use input carries only the run_in_background flag — the id is assigned
 // at launch and reported back here. See issue #445.
+//
+// The path is a single whitespace-delimited token, but Claude writes it
+// mid-sentence ("…output. You will be notified…"), so `(\S+)` captures the
+// sentence-ending period as a trailing ".". collectToolResult strips that one
+// trailing period; leaving it in yields a non-existent "…output." path on which
+// the daemon's lsof liveness probe finds no writer, wrongly settling a
+// still-running background session to `ready`. Matching the whole token (rather
+// than anchoring on a `.output` suffix) keeps detection working even if Claude
+// ever names the file differently.
 var backgroundSpawnRe = regexp.MustCompile(`running in background with ID: (\S+?)\.\s+Output is being written to:\s+(\S+)`)
 
 // Parser implements tailer.TranscriptParser for Claude Code transcripts.
@@ -472,8 +481,11 @@ func collectToolResult(block map[string]interface{}, ev *tailer.ParsedEvent, bgT
 	if bgTaskID != "" {
 		if m := backgroundSpawnRe.FindStringSubmatch(text); m != nil {
 			ev.BackgroundSpawns = append(ev.BackgroundSpawns, tailer.BackgroundSpawn{
-				BashID:     bgTaskID,
-				OutputPath: m[2],
+				BashID: bgTaskID,
+				// Strip the sentence-ending period the launch text places after
+				// the path ("…output. You will be notified…") so the recorded
+				// path is the real file the lsof liveness probe must check.
+				OutputPath: strings.TrimSuffix(m[2], "."),
 			})
 		}
 	}


### PR DESCRIPTION
## Problem

A live session running a long-running `run_in_background` Bash process (e.g. `npx tsx … | tee /tmp/x.log`) constantly flips **working → ready → working** on every `turn_done`, instead of being held `working` while the process is alive (issue #445).

## Root cause

The daemon holds a session `working` past a turn's end while a background process is alive by `lsof`-probing the process's `tasks/<id>.output` file. The parser extracts that path from Claude Code's launch message:

```
Command running in background with ID: bq6j0pxbd. Output is being written to: /private/tmp/…/tasks/bq6j0pxbd.output. You will be notified when it completes. To check interim output, use Read on that file path.
```

The path is written **mid-sentence**, so `backgroundSpawnRe`'s greedy `(\S+)` captured the trailing sentence-ending period: `…/bq6j0pxbd.output.`. The daemon then probed that **non-existent** path, `lsof` found no writer, the working-hold gate released, and every `turn_done` settled the session to `ready`.

Verified live: while the process was running, `lsof` on the real `…/bq6j0pxbd.output` returned live writers, while the recorded `…output.` path didn't exist.

### Why it slipped through

- **Replay can't catch it** — the `lsof` liveness probe is daemon-only; replay derives state purely from transcript metrics via `ClassifyState`, so the corrupted path is never dereferenced (the `background-process` fixture stays green).
- **Unit fixtures masked it** — every parser test truncated the message right after `.output`, so the greedy capture had nothing to over-consume.

## Fix

Strip the one trailing period at the capture site (`strings.TrimSuffix(m[2], ".")`) so the recorded path is the real file the probe checks. Matching the whole whitespace-delimited token — rather than anchoring on a `.output` suffix — keeps detection working even if Claude ever names the file differently.

## Tests

- Parser regression tests now use Claude's **full** launch sentence and assert no trailing period, including a non-`.output` filename case to lock in the suffix decoupling.
- Updated both end-to-end tailer fixtures to the realistic full message (they previously truncated right after `.output`, which hid the bug).
- Added `TestParser_BackgroundSpawn_OutputPathIsStatable`, which closes the parser↔probe contract: a real file embedded in the full launch sentence must round-trip back to a path `os.Stat` resolves — the exact property the daemon's `lsof` probe relies on, expressed without a live process. The corrupted `…output.` path fails this `Stat`, which is how the probe misses a live writer in production.

Verification: `go test ./core/... -race -count=1` ✅ · `tools/replay-fixtures.sh` ✅ · `go build ./core/cmd/irrlichd/` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)