### PR TITLE
Onboarding factory P4: of CLI — read-side status/validate/coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ tools/onboarding-factory/matrix
 tools/onboarding-factory/viewer
 tools/onboarding-factory/expected-validate
 tools/onboarding-factory/replay
+tools/onboarding-factory/of
 
 # Gas Town runtime directories
 .beads/

--- a/tools/onboarding-factory/cmd/of/coverage.go
+++ b/tools/onboarding-factory/cmd/of/coverage.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"irrlicht/tools/onboarding-factory/internal/matrix"
+)
+
+// runCoverage emits the derived coverage rollup. Since the committed
+// agent-scenarios-coverage.json was retired (#524), this is computed in-memory
+// from the assessments every time — there is no file to read or keep in sync.
+// An empty overlay means generated_at falls back to the max assessed_at.
+func runCoverage(args []string, stdout, stderr io.Writer) int {
+	fs := newFlagSet("of coverage")
+	var (
+		asJSON   = fs.Bool("json", false, "emit JSON (the rollup is JSON either way)")
+		repoRoot = fs.String("repo-root", ".", "repository root")
+	)
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	_ = asJSON // the rollup is JSON; the flag exists for CLI symmetry
+
+	m, err := matrix.LoadRepo(*repoRoot)
+	if err != nil {
+		fmt.Fprintf(stderr, "of coverage: %v\n", err)
+		return exitUsage
+	}
+	b, err := matrix.MarshalRollup(m.BuildRollup(matrix.RollupOverlay{}))
+	if err != nil {
+		fmt.Fprintf(stderr, "of coverage: marshal: %v\n", err)
+		return exitUsage
+	}
+	stdout.Write(b)
+	fmt.Fprintln(stdout)
+	return exitOK
+}

--- a/tools/onboarding-factory/cmd/of/main.go
+++ b/tools/onboarding-factory/cmd/of/main.go
@@ -1,0 +1,176 @@
+// Command of is the onboarding-factory CLI — the single entry point the
+// onboarding skill drives for everything under replaydata/. It NEVER lets the
+// skill touch replaydata files directly: read-side commands derive their answer
+// from the canonical matrix model (internal/matrix) + the catalog shards
+// (internal/shard); write-side commands (added in a later phase) are the sole
+// writers and validate before they touch disk.
+//
+// Read-side commands (this phase):
+//
+//	of status   [--agent a] [--scenario s] [--runs] [--json]   coverage / run status
+//	of validate [--json]                                        schema + referential integrity
+//	of coverage [--json]                                        derived rollup (in-memory)
+//
+// Exit codes (matching the sibling cmd tools):
+//
+//	0  — success / validation clean
+//	1  — validation failed (schema / referential violations)
+//	2  — usage or configuration error
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"irrlicht/tools/onboarding-factory/internal/matrix"
+	"irrlicht/tools/onboarding-factory/internal/shard"
+)
+
+const (
+	exitOK    = 0
+	exitFail  = 1
+	exitUsage = 2
+)
+
+const usage = `usage:
+  of status   [--agent a] [--scenario s] [--runs] [--json] [--repo-root .]
+  of validate [--json] [--repo-root .]
+  of coverage [--json] [--repo-root .]`
+
+func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
+
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, usage)
+		return exitUsage
+	}
+	switch args[0] {
+	case "status":
+		return runStatus(args[1:], stdout, stderr)
+	case "validate":
+		return runValidate(args[1:], stdout, stderr)
+	case "coverage":
+		return runCoverage(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintln(stderr, usage)
+		return exitUsage
+	}
+}
+
+func writeJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// cellView is the per-cell projection `of status` emits: the matrix display
+// state + the 3 pillars (agent / daemon / driver) the issue wants surfaced.
+type cellView struct {
+	DisplayState     string `json:"display_state"`
+	Recorded         bool   `json:"recorded"`
+	Route            string `json:"route"`
+	Disposition      string `json:"disposition"`
+	AgentSupports    string `json:"agent_supports,omitempty"`
+	DaemonCapability string `json:"daemon_capability,omitempty"`
+	DriverCapability string `json:"driver_capability,omitempty"`
+}
+
+type scenarioView struct {
+	ID    string              `json:"id"`
+	Name  string              `json:"name"`
+	Cells map[string]cellView `json:"cells"`
+}
+
+type statusView struct {
+	Agents    []string       `json:"agents"`
+	Scenarios []scenarioView `json:"scenarios"`
+}
+
+func cellViewOf(cs matrix.CellState) cellView {
+	v := cellView{
+		DisplayState: cs.DisplayState,
+		Recorded:     cs.Recorded,
+		Route:        string(cs.Route),
+		Disposition:  string(cs.Disposition),
+	}
+	if cs.Assessment != nil {
+		v.AgentSupports = cs.Assessment.AgentSupports
+		v.DaemonCapability = cs.Assessment.DaemonCapability
+		v.DriverCapability = cs.Assessment.DriverCapability
+	}
+	return v
+}
+
+func runStatus(args []string, stdout, stderr io.Writer) int {
+	fs := newFlagSet("of status")
+	var (
+		agent    = fs.String("agent", "", "filter to one agent column")
+		scenario = fs.String("scenario", "", "filter to one scenario (by name or id)")
+		runs     = fs.Bool("runs", false, "show the factory run-log instead of coverage")
+		asJSON   = fs.Bool("json", false, "emit JSON")
+		repoRoot = fs.String("repo-root", ".", "repository root")
+	)
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	if *runs {
+		return runStatusRuns(*repoRoot, *asJSON, stdout, stderr)
+	}
+
+	m, err := matrix.LoadRepo(*repoRoot)
+	if err != nil {
+		fmt.Fprintf(stderr, "of status: %v\n", err)
+		return exitUsage
+	}
+	agents := m.Agents()
+	if *agent != "" {
+		if !m.HasAgent(*agent) {
+			fmt.Fprintf(stderr, "of status: %q is not an onboarded agent\n", *agent)
+			return exitUsage
+		}
+		agents = []string{*agent}
+	}
+
+	view := statusView{Agents: agents}
+	for _, sh := range shard.LoadAll(*repoRoot) {
+		if *scenario != "" && sh.Name != *scenario && sh.ID != *scenario {
+			continue
+		}
+		sv := scenarioView{ID: sh.ID, Name: sh.Name, Cells: map[string]cellView{}}
+		for _, a := range agents {
+			if cs, ok := m.Cell(a, sh.Name); ok {
+				sv.Cells[a] = cellViewOf(cs)
+			}
+		}
+		view.Scenarios = append(view.Scenarios, sv)
+	}
+
+	if *asJSON {
+		if err := writeJSON(stdout, view); err != nil {
+			fmt.Fprintf(stderr, "of status: encode: %v\n", err)
+			return exitUsage
+		}
+		return exitOK
+	}
+	printStatusText(stdout, view)
+	return exitOK
+}
+
+func printStatusText(stdout io.Writer, view statusView) {
+	fmt.Fprintf(stdout, "scenarios × agents — %d × %d (display state per cell)\n\n", len(view.Scenarios), len(view.Agents))
+	for _, sv := range view.Scenarios {
+		fmt.Fprintf(stdout, "%-6s %-34s", sv.ID, sv.Name)
+		for _, a := range view.Agents {
+			c, ok := sv.Cells[a]
+			st := "—"
+			if ok {
+				st = c.DisplayState
+			}
+			fmt.Fprintf(stdout, "  %s=%s", a, st)
+		}
+		fmt.Fprintln(stdout)
+	}
+}

--- a/tools/onboarding-factory/cmd/of/main_test.go
+++ b/tools/onboarding-factory/cmd/of/main_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// validRepo writes a minimal, schema-valid repo: a 2-scenario catalog and one
+// recorded+assessed claudecode cell (so status shows the 3 pillars and validate
+// passes).
+func validRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	write(t, filepath.Join(root, "replaydata", "agents", "scenarios.json"), `{
+  "meta": {"min_versions": {"claudecode": "2.0.0"}},
+  "scenarios": [
+    {"id": "1.1", "name": "session-start", "description": "d", "process": "p", "acceptance_criteria": "a"},
+    {"id": "2.1", "name": "basic-turn", "description": "d", "process": "p", "acceptance_criteria": "a"}
+  ]
+}`)
+	cell := filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", "1-1_session-start")
+	write(t, filepath.Join(cell, "metadata.json"), `{
+  "scenario_id": "session-start",
+  "artifacts": {"recordings": ["claudecode/scenarios/1-1_session-start/recordings/r1"]},
+  "details": {"assessment": {"agent_supports": "yes", "daemon_capability": "full", "driver_capability": "ready"}}
+}`)
+	write(t, filepath.Join(cell, "expected.jsonl"), `{"schema_version":1}`+"\n")
+	write(t, filepath.Join(cell, "recordings", "r1", "events.jsonl"), "\n")
+	return root
+}
+
+func runOf(args ...string) (int, string, string) {
+	var out, errb bytes.Buffer
+	code := run(args, &out, &errb)
+	return code, out.String(), errb.String()
+}
+
+func TestStatusJSON(t *testing.T) {
+	root := validRepo(t)
+	code, out, errs := runOf("status", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d stderr=%s", code, errs)
+	}
+	var v statusView
+	if err := json.Unmarshal([]byte(out), &v); err != nil {
+		t.Fatalf("bad json: %v\n%s", err, out)
+	}
+	if len(v.Scenarios) != 2 {
+		t.Fatalf("want 2 scenarios, got %d", len(v.Scenarios))
+	}
+	// session-start cell carries the 3 pillars from the assessment.
+	var ss *scenarioView
+	for i := range v.Scenarios {
+		if v.Scenarios[i].Name == "session-start" {
+			ss = &v.Scenarios[i]
+		}
+	}
+	if ss == nil {
+		t.Fatal("session-start scenario missing")
+	}
+	c, ok := ss.Cells["claudecode"]
+	if !ok {
+		t.Fatal("claudecode cell missing")
+	}
+	if c.AgentSupports != "yes" || c.DaemonCapability != "full" || c.DriverCapability != "ready" {
+		t.Fatalf("pillars wrong: %+v", c)
+	}
+	if !c.Recorded {
+		t.Fatalf("session-start should be recorded: %+v", c)
+	}
+}
+
+func TestStatusAgentFilter(t *testing.T) {
+	root := validRepo(t)
+	code, _, errs := runOf("status", "--agent", "nope", "--repo-root", root)
+	if code != exitUsage {
+		t.Fatalf("unknown agent should be usage error; exit=%d stderr=%s", code, errs)
+	}
+	code, out, _ := runOf("status", "--agent", "claudecode", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d", code)
+	}
+	var v statusView
+	_ = json.Unmarshal([]byte(out), &v)
+	if len(v.Agents) != 1 || v.Agents[0] != "claudecode" {
+		t.Fatalf("agent filter not applied: %v", v.Agents)
+	}
+}
+
+func TestStatusScenarioFilter(t *testing.T) {
+	root := validRepo(t)
+	code, out, _ := runOf("status", "--scenario", "basic-turn", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d", code)
+	}
+	var v statusView
+	_ = json.Unmarshal([]byte(out), &v)
+	if len(v.Scenarios) != 1 || v.Scenarios[0].Name != "basic-turn" {
+		t.Fatalf("scenario filter not applied: %d", len(v.Scenarios))
+	}
+}
+
+func TestStatusRuns(t *testing.T) {
+	root := validRepo(t)
+	// No run-log → graceful.
+	code, out, _ := runOf("status", "--runs", "--repo-root", root)
+	if code != exitOK || !strings.Contains(out, "no factory runs") {
+		t.Fatalf("empty runs: exit=%d out=%q", code, out)
+	}
+	// With a run-log → JSON echoes the record.
+	write(t, runLogPath(root), `{"id":"r1","started_at":"2026-05-30T00:00:00Z","verb":"record","agent":"claudecode","scenario":"session-start","outcome":"recorded"}`+"\n")
+	code, out, _ = runOf("status", "--runs", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d", code)
+	}
+	var recs []RunRecord
+	if err := json.Unmarshal([]byte(out), &recs); err != nil || len(recs) != 1 || recs[0].Outcome != "recorded" {
+		t.Fatalf("run-log not echoed: %v / %s", err, out)
+	}
+}
+
+func TestValidateClean(t *testing.T) {
+	root := validRepo(t)
+	code, out, _ := runOf("validate", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("clean repo should validate; exit=%d out=%s", code, out)
+	}
+}
+
+func TestValidateCatchesViolations(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(root string)
+		want   string
+	}{
+		{"bad id", func(r string) {
+			write(t, filepath.Join(r, "replaydata", "agents", "scenarios.json"),
+				`{"meta":{"min_versions":{"claudecode":"2.0.0"}},"scenarios":[{"id":"x","name":"n","description":"d","process":"p","acceptance_criteria":"a"}]}`)
+		}, "is not <section>.<index>"},
+		{"unknown field", func(r string) {
+			write(t, filepath.Join(r, "replaydata", "agents", "scenarios.json"),
+				`{"meta":{"min_versions":{"claudecode":"2.0.0"}},"scenarios":[{"id":"1.1","name":"n","section":"S"}]}`)
+		}, "unexpected field"},
+		{"missing scenario_id", func(r string) {
+			write(t, filepath.Join(r, "replaydata", "agents", "claudecode", "scenarios", "1-1_session-start", "metadata.json"),
+				`{"artifacts":{"recordings":["x/r1"]}}`)
+		}, "missing scenario_id"},
+		{"dangling scenario_id", func(r string) {
+			write(t, filepath.Join(r, "replaydata", "agents", "claudecode", "scenarios", "1-1_session-start", "metadata.json"),
+				`{"scenario_id":"ghost","artifacts":{"recordings":["x/r1"]}}`)
+		}, "not in the catalog"},
+		{"recorded without expected", func(r string) {
+			_ = os.Remove(filepath.Join(r, "replaydata", "agents", "claudecode", "scenarios", "1-1_session-start", "expected.jsonl"))
+		}, "missing expected.jsonl"},
+		{"orphan recording folder", func(r string) {
+			write(t, filepath.Join(r, "replaydata", "agents", "claudecode", "scenarios", "9-9_orphan", "recordings", "r1", "events.jsonl"), "\n")
+		}, "orphan recording folder"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := validRepo(t)
+			tc.mutate(root)
+			code, _, errs := runOf("validate", "--repo-root", root)
+			if code != exitFail {
+				t.Fatalf("want exitFail; exit=%d", code)
+			}
+			if !strings.Contains(errs, tc.want) {
+				t.Fatalf("want %q in stderr, got:\n%s", tc.want, errs)
+			}
+		})
+	}
+}
+
+func TestCoverageJSON(t *testing.T) {
+	root := validRepo(t)
+	code, out, errs := runOf("coverage", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d stderr=%s", code, errs)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("coverage not JSON: %v\n%s", err, out)
+	}
+	if _, ok := doc["scenarios"]; !ok {
+		t.Fatalf("coverage missing scenarios: %s", out)
+	}
+}
+
+func TestUsage(t *testing.T) {
+	if code, _, _ := runOf(); code != exitUsage {
+		t.Fatalf("no args should be usage error, got %d", code)
+	}
+	if code, _, _ := runOf("bogus"); code != exitUsage {
+		t.Fatalf("unknown subcommand should be usage error, got %d", code)
+	}
+}

--- a/tools/onboarding-factory/cmd/of/runlog.go
+++ b/tools/onboarding-factory/cmd/of/runlog.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// newFlagSet returns a ContinueOnError flag set that writes errors to stderr,
+// so a bad flag yields exitUsage rather than a panic.
+func newFlagSet(name string) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	return fs
+}
+
+// RunRecord is one line of the factory run-log. The write-side verbs (assess /
+// record, added in a later phase) append one per cell touched; `of status
+// --runs` reads them back so the skill can ask "what happened last sweep"
+// without re-deriving. Kept deliberately flat (every object has an id).
+type RunRecord struct {
+	ID       string `json:"id"`        // unique run-step id
+	StartedAt string `json:"started_at"`
+	Verb     string `json:"verb"`     // assess | record | ...
+	Agent    string `json:"agent,omitempty"`
+	Scenario string `json:"scenario,omitempty"`
+	Outcome  string `json:"outcome"`  // recorded | verify_failed | prereq_blocked | ...
+	Note     string `json:"note,omitempty"`
+}
+
+// runLogPath is the append-only factory run-log. Lives under _reports/ (already
+// gitignored) so run history never pollutes the committed fixtures.
+func runLogPath(repoRoot string) string {
+	return filepath.Join(repoRoot, "replaydata", "agents", "_reports", "runs.jsonl")
+}
+
+// readRunLog returns every parseable RunRecord, newest last. A missing file is
+// not an error — it just means no runs have happened yet.
+func readRunLog(repoRoot string) ([]RunRecord, error) {
+	f, err := os.Open(runLogPath(repoRoot))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	var out []RunRecord
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var r RunRecord
+		if json.Unmarshal(line, &r) == nil {
+			out = append(out, r)
+		}
+	}
+	return out, sc.Err()
+}
+
+func runStatusRuns(repoRoot string, asJSON bool, stdout, stderr io.Writer) int {
+	recs, err := readRunLog(repoRoot)
+	if err != nil {
+		fmt.Fprintf(stderr, "of status --runs: %v\n", err)
+		return exitUsage
+	}
+	if asJSON {
+		if recs == nil {
+			recs = []RunRecord{}
+		}
+		if err := writeJSON(stdout, recs); err != nil {
+			fmt.Fprintf(stderr, "of status --runs: encode: %v\n", err)
+			return exitUsage
+		}
+		return exitOK
+	}
+	if len(recs) == 0 {
+		fmt.Fprintln(stdout, "no factory runs recorded yet")
+		return exitOK
+	}
+	for _, r := range recs {
+		fmt.Fprintf(stdout, "%s  %-8s %-12s %-26s %s  %s\n",
+			r.StartedAt, r.Verb, r.Agent, r.Scenario, r.Outcome, r.Note)
+	}
+	return exitOK
+}

--- a/tools/onboarding-factory/cmd/of/validate.go
+++ b/tools/onboarding-factory/cmd/of/validate.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+
+	"irrlicht/tools/onboarding-factory/internal/shard"
+)
+
+var (
+	idRe   = regexp.MustCompile(`^\d+\.\d+$`)
+	nameRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+)
+
+// allowedScenarioKeys is the exact MECE field set for a catalog scenario. Any
+// other key is a schema violation (the factory keeps the structure minimal).
+var allowedScenarioKeys = map[string]bool{
+	"id": true, "name": true, "description": true,
+	"acceptance_criteria": true, "process": true,
+}
+
+// finding is one validation violation. path locates it; msg explains it.
+type finding struct {
+	Path string `json:"path"`
+	Msg  string `json:"msg"`
+}
+
+// runValidate checks the whole replaydata tree for schema + referential
+// integrity: the catalog parses and every scenario is the minimal 5-field
+// shape with a well-formed unique id/name; every agent cell parses, links to a
+// real scenario, and (when recorded) carries an expected.jsonl; no orphan
+// recording folders sit under scenarios/. Exit 1 + findings on any violation.
+func runValidate(args []string, stdout, stderr io.Writer) int {
+	fs := newFlagSet("of validate")
+	var (
+		asJSON   = fs.Bool("json", false, "emit findings as JSON")
+		repoRoot = fs.String("repo-root", ".", "repository root")
+	)
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	var findings []finding
+	add := func(path, msg string) { findings = append(findings, finding{Path: path, Msg: msg}) }
+
+	names := validateCatalog(*repoRoot, add)
+	validateCells(*repoRoot, names, add)
+
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Path != findings[j].Path {
+			return findings[i].Path < findings[j].Path
+		}
+		return findings[i].Msg < findings[j].Msg
+	})
+
+	if *asJSON {
+		out := map[string]any{"ok": len(findings) == 0, "findings": findings}
+		if findings == nil {
+			out["findings"] = []finding{}
+		}
+		_ = writeJSON(stdout, out)
+	} else if len(findings) == 0 {
+		fmt.Fprintln(stdout, "of validate: OK — catalog + cells are schema-valid and referentially consistent")
+	} else {
+		fmt.Fprintf(stderr, "of validate: %d violation(s):\n", len(findings))
+		for _, f := range findings {
+			fmt.Fprintf(stderr, "  %s: %s\n", f.Path, f.Msg)
+		}
+	}
+	if len(findings) > 0 {
+		return exitFail
+	}
+	return exitOK
+}
+
+// validateCatalog parses replaydata/agents/scenarios.json, enforces the 5-field
+// scenario schema + id/name well-formedness + uniqueness, and returns the set
+// of valid scenario names for the referential checks.
+func validateCatalog(repoRoot string, add func(path, msg string)) map[string]bool {
+	names := map[string]bool{}
+	path := shard.File(repoRoot)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		add("replaydata/agents/scenarios.json", fmt.Sprintf("cannot read catalog: %v", err))
+		return names
+	}
+	var doc struct {
+		Meta      json.RawMessage   `json:"meta"`
+		Scenarios []json.RawMessage `json:"scenarios"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		add("replaydata/agents/scenarios.json", fmt.Sprintf("catalog is not valid JSON: %v", err))
+		return names
+	}
+	if len(doc.Scenarios) == 0 {
+		add("replaydata/agents/scenarios.json", "catalog has no scenarios")
+	}
+	seenID := map[string]bool{}
+	for _, raw := range doc.Scenarios {
+		var fields map[string]json.RawMessage
+		if json.Unmarshal(raw, &fields) != nil {
+			add("replaydata/agents/scenarios.json", "a scenario entry is not a JSON object")
+			continue
+		}
+		var s struct{ ID, Name string }
+		_ = json.Unmarshal(raw, &s)
+		loc := "scenario " + s.Name
+		if s.Name == "" {
+			loc = "scenario id=" + s.ID
+		}
+		for k := range fields {
+			if !allowedScenarioKeys[k] {
+				add(loc, fmt.Sprintf("unexpected field %q (allowed: id, name, description, acceptance_criteria, process)", k))
+			}
+		}
+		if s.ID == "" {
+			add(loc, "missing id")
+		} else if !idRe.MatchString(s.ID) {
+			add(loc, fmt.Sprintf("id %q is not <section>.<index>", s.ID))
+		} else if seenID[s.ID] {
+			add(loc, fmt.Sprintf("duplicate id %q", s.ID))
+		}
+		seenID[s.ID] = true
+		if s.Name == "" {
+			add(loc, "missing name")
+		} else {
+			if !nameRe.MatchString(s.Name) {
+				add(loc, fmt.Sprintf("name %q is not a kebab slug", s.Name))
+			}
+			if names[s.Name] {
+				add(loc, fmt.Sprintf("duplicate name %q", s.Name))
+			}
+			names[s.Name] = true
+		}
+	}
+	return names
+}
+
+// validateCells checks each agent's scenarios/ cells: metadata.json parses,
+// links to a real scenario (scenario_id FK), and recorded cells carry an
+// expected.jsonl. Orphan folders (recordings but no metadata.json) are flagged.
+func validateCells(repoRoot string, names map[string]bool, add func(path, msg string)) {
+	for _, agent := range shard.Agents(repoRoot) {
+		scenDir := filepath.Join(repoRoot, "replaydata", "agents", agent, "scenarios")
+		entries, err := os.ReadDir(scenDir)
+		if err != nil {
+			continue // adapter may have no scenarios/ tree yet
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			folder := e.Name()
+			rel := filepath.Join("replaydata/agents", agent, "scenarios", folder)
+			metaPath := filepath.Join(scenDir, folder, "metadata.json")
+			hasRecordings := dirHasChildren(filepath.Join(scenDir, folder, "recordings"))
+
+			mb, err := os.ReadFile(metaPath)
+			if err != nil {
+				if hasRecordings {
+					add(rel, "orphan recording folder: has recordings/ but no metadata.json")
+				}
+				continue
+			}
+			var cell shard.ShardAgent
+			if err := json.Unmarshal(mb, &cell); err != nil {
+				add(rel+"/metadata.json", fmt.Sprintf("not valid JSON: %v", err))
+				continue
+			}
+			if cell.ScenarioID == "" {
+				add(rel+"/metadata.json", "missing scenario_id (the cell→catalog foreign key)")
+			} else if !names[cell.ScenarioID] {
+				add(rel+"/metadata.json", fmt.Sprintf("scenario_id %q not in the catalog", cell.ScenarioID))
+			}
+			recorded := len(cell.Artifacts.Recordings) > 0
+			if recorded && !fileExists(filepath.Join(scenDir, folder, "expected.jsonl")) {
+				add(rel, "recorded cell is missing expected.jsonl")
+			}
+		}
+	}
+}
+
+func dirHasChildren(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	return err == nil && len(entries) > 0
+}
+
+func fileExists(p string) bool {
+	st, err := os.Stat(p)
+	return err == nil && !st.IsDir()
+}


### PR DESCRIPTION
Phase 4 of the onboarding-factory roadmap (#521). Closes #525.

**Stacked on #533** (P3) — targets `onboarding-factory-p3-schema`.

Stands up **`of`**, the factory CLI the onboarding skill drives so it never reads/writes `replaydata/` directly. Read-side commands this phase (write verbs land in P5):

## `of status [--agent a] [--scenario s] [--runs] [--json]`
Derived coverage from `internal/matrix` — per (scenario, agent) cell: display state + the **3 pillars** (`agent_supports` / `daemon_capability` / `driver_capability`) + route / disposition / recorded. `--agent`/`--scenario` filter a column/row; `--runs` reads the factory run-log (`replaydata/agents/_reports/runs.jsonl`, empty-graceful — the write verbs append to it in P5/P6).

## `of validate [--json]`
Schema + referential integrity — the factory's "structure is always correct" guarantee:
- catalog parses; every scenario is the **minimal 5-field shape** (rejects unknown keys) with a well-formed, unique `id`/`name`;
- every agent cell parses, carries a `scenario_id` that **resolves to a catalog scenario** (FK), and (when recorded) has an `expected.jsonl`;
- **orphan** recording folders under `scenarios/` are flagged.

Exit 1 + findings on any violation. **Passes clean on the migrated tree** (a nice independent confirmation that P3's 41 scenarios + 181 cells are consistent).

## `of coverage [--json]`
The derived rollup, in-memory (reuses the `BuildRollup` P3 kept after retiring the committed coverage json).

## Scope note (vs #525's original text)
The `agent-scenarios-coverage.json` **deletion was already done in P3** (#524) — it was entangled with gutting `section`/`feature`. So this phase is purely the new read-side CLI.

## Verification
- `go test ./tools/onboarding-factory/cmd/of/... -race` — status filters, runs (empty + populated), coverage, + **6 validate-violation cases** (bad id, unknown field, missing/dangling `scenario_id`, recorded-without-expected, orphan folder) ✅
- full tool suite green ✅
- all three commands smoke-tested against the real repo ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
