### PR TITLE
Onboarding factory P5: of write verbs + go-test-style verify engine

### DIFF
--- a/tools/onboarding-factory/cmd/of/main.go
+++ b/tools/onboarding-factory/cmd/of/main.go
@@ -37,7 +37,11 @@ const (
 const usage = `usage:
   of status   [--agent a] [--scenario s] [--runs] [--json] [--repo-root .]
   of validate [--json] [--repo-root .]
-  of coverage [--json] [--repo-root .]`
+  of coverage [--json] [--repo-root .]
+  of scenario add|update --name n [--id i] [--description d] [--process-file f] [--acceptance-file f]
+  of agent add --id i --name n --provider p [--min-version v] [--prereq p]...
+  of cell write --agent a --scenario s --file metadata.json [--folder f]
+  of verify --agent a --scenario s [--folder f] [--json]`
 
 func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
 
@@ -53,6 +57,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return runValidate(args[1:], stdout, stderr)
 	case "coverage":
 		return runCoverage(args[1:], stdout, stderr)
+	case "scenario":
+		return runScenario(args[1:], stdout, stderr)
+	case "agent":
+		return runAgent(args[1:], stdout, stderr)
+	case "cell":
+		return runCell(args[1:], stdout, stderr)
+	case "verify":
+		return runVerify(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintln(stderr, usage)
 		return exitUsage

--- a/tools/onboarding-factory/cmd/of/main_test.go
+++ b/tools/onboarding-factory/cmd/of/main_test.go
@@ -39,7 +39,8 @@ func validRepo(t *testing.T) string {
   "details": {"assessment": {"agent_supports": "yes", "daemon_capability": "full", "driver_capability": "ready"}}
 }`)
 	write(t, filepath.Join(cell, "expected.jsonl"), `{"schema_version":1}`+"\n")
-	write(t, filepath.Join(cell, "recordings", "r1", "events.jsonl"), "\n")
+	write(t, filepath.Join(cell, "recordings", "r1", "events.jsonl"),
+		`{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"pid_discovered","session_id":"s"}`+"\n")
 	return root
 }
 

--- a/tools/onboarding-factory/cmd/of/verify.go
+++ b/tools/onboarding-factory/cmd/of/verify.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"irrlicht/tools/onboarding-factory/internal/shard"
+	"irrlicht/tools/onboarding-factory/internal/validate"
+)
+
+// runVerify is the go-test-style verify for one (agent, scenario) cell: replay
+// the newest recording and check BOTH the lifecycle-state phases (expected.jsonl
+// definitions) AND the metric vector (model/cost/tokens — hard asserts from the
+// spec's observations block + a soft-diff vs the prior recording). Exit 1 when a
+// state phase fails (unless known_failing) or a hard metric assertion fails;
+// metric drifts are reported but never fail. (`of record verify` in P6 calls the
+// same engine after capturing a fresh recording.)
+func runVerify(args []string, stdout, stderr io.Writer) int {
+	fs := newFlagSet("of verify")
+	var (
+		agent    = fs.String("agent", "", "agent id")
+		scenario = fs.String("scenario", "", "scenario name")
+		folder   = fs.String("folder", "", "override on-disk folder (default: <dashed-id>_<name>)")
+		asJSON   = fs.Bool("json", false, "emit the combined report as JSON")
+		repoRoot = fs.String("repo-root", ".", "repository root")
+	)
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *agent == "" || *scenario == "" {
+		fmt.Fprintln(stderr, "of verify: --agent and --scenario are required")
+		return exitUsage
+	}
+	fold := *folder
+	if fold == "" {
+		if sh, ok := shard.Load(*repoRoot, *scenario); ok {
+			fold = filepath.Base(shard.FolderForScenario(*repoRoot, sh.Name))
+		} else {
+			fmt.Fprintf(stderr, "of verify: scenario %q not in the catalog\n", *scenario)
+			return exitFail
+		}
+	}
+	cellDir := shard.AgentCellDir(*repoRoot, *agent, fold)
+
+	state, err := validate.ValidateExpected(cellDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "of verify: state validation: %v\n", err)
+		return exitUsage
+	}
+	obs, err := validate.ValidateObservations(cellDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "of verify: observation validation: %v\n", err)
+		return exitUsage
+	}
+
+	stateOK := state == nil || state.Pass || state.Meta.KnownFailing
+	obsOK := obs == nil || obs.Pass
+
+	if *asJSON {
+		_ = writeJSON(stdout, map[string]any{
+			"agent": *agent, "scenario": *scenario,
+			"state_pass": stateOK, "observations_pass": obsOK,
+			"state": state, "observations": obs,
+		})
+	} else {
+		printVerifyText(stdout, *agent, *scenario, state, obs)
+	}
+	if !stateOK || !obsOK {
+		return exitFail
+	}
+	return exitOK
+}
+
+func printVerifyText(stdout io.Writer, agent, scenario string, state *validate.ExpectedReport, obs *validate.ObservationReport) {
+	fmt.Fprintf(stdout, "verify %s / %s\n", agent, scenario)
+	switch {
+	case state == nil:
+		fmt.Fprintln(stdout, "  state:        (no spec / no recording)")
+	case state.Pass:
+		fmt.Fprintf(stdout, "  state:        PASS — %s\n", state.Summary)
+	case state.Meta.KnownFailing:
+		fmt.Fprintf(stdout, "  state:        known_failing — %s\n", state.Summary)
+	default:
+		fmt.Fprintf(stdout, "  state:        FAIL — %s\n", state.Summary)
+	}
+	switch {
+	case obs == nil || obs.Skipped:
+		note := "no golden"
+		if obs != nil && obs.Note != "" {
+			note = obs.Note
+		}
+		fmt.Fprintf(stdout, "  observations: skipped (%s)\n", note)
+	default:
+		verdict := "PASS"
+		if !obs.Pass {
+			verdict = "FAIL"
+		}
+		fmt.Fprintf(stdout, "  observations: %s — %d assert(s), %d drift(s)\n", verdict, len(obs.Asserts), len(obs.Drifts))
+		for _, a := range obs.Asserts {
+			mark := "✓"
+			if !a.OK {
+				mark = "✗"
+			}
+			fmt.Fprintf(stdout, "    %s %s: want %s got %s\n", mark, a.Field, a.Expected, a.Actual)
+		}
+		for _, d := range obs.Drifts {
+			fmt.Fprintf(stdout, "    ~ %s: %s → %s (drift vs prior)\n", d.Field, d.Prior, d.Current)
+		}
+	}
+}

--- a/tools/onboarding-factory/cmd/of/write.go
+++ b/tools/onboarding-factory/cmd/of/write.go
@@ -1,0 +1,337 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"irrlicht/tools/onboarding-factory/internal/shard"
+)
+
+// flagPassed reports whether name was explicitly set on the command line (so an
+// update can tell "--description ”" (clear it) from "not passed" (leave it)).
+func flagPassed(fs *flag.FlagSet, name string) bool {
+	found := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
+}
+
+// writeCatalog is the writable shape of replaydata/agents/scenarios.json. Meta
+// is kept as a raw blob so it round-trips byte-for-byte (we never touch
+// min_versions/transcript_extensions/capability_vocab from a scenario write).
+type writeCatalog struct {
+	Meta      json.RawMessage `json:"meta"`
+	Scenarios []shard.Shard   `json:"scenarios"`
+}
+
+// writeJSONFileAtomic marshals v (2-space indent) and replaces path atomically
+// via a temp file + rename, so a crashed write never leaves a half file.
+func writeJSONFileAtomic(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func loadWriteCatalog(repoRoot string) (*writeCatalog, error) {
+	b, err := os.ReadFile(shard.File(repoRoot))
+	if err != nil {
+		return nil, err
+	}
+	var c writeCatalog
+	if err := json.Unmarshal(b, &c); err != nil {
+		return nil, fmt.Errorf("catalog is not valid JSON: %w", err)
+	}
+	return &c, nil
+}
+
+func (c *writeCatalog) sortByID() {
+	sort.SliceStable(c.Scenarios, func(i, j int) bool {
+		ai, ax, aok := shard.SplitID(c.Scenarios[i].ID)
+		bi, bx, bok := shard.SplitID(c.Scenarios[j].ID)
+		if !aok || !bok {
+			return c.Scenarios[i].ID < c.Scenarios[j].ID
+		}
+		if ai != bi {
+			return ai < bi
+		}
+		return ax < bx
+	})
+}
+
+// readFileArg returns the trimmed contents of path, or "" when path is empty.
+func readFileArg(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(b), "\n"), nil
+}
+
+// --- of scenario add|update ---
+
+func runScenario(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "usage: of scenario add|update ...")
+		return exitUsage
+	}
+	verb := args[0]
+	fs := newFlagSet("of scenario " + verb)
+	var (
+		id       = fs.String("id", "", "scenario id <section>.<index> (add only)")
+		name     = fs.String("name", "", "scenario name (kebab slug)")
+		desc     = fs.String("description", "", "one-line description")
+		procF    = fs.String("process-file", "", "markdown file for the process block")
+		accF     = fs.String("acceptance-file", "", "markdown file for the acceptance_criteria block")
+		repoRoot = fs.String("repo-root", ".", "repository root")
+	)
+	if err := fs.Parse(args[1:]); err != nil {
+		return exitUsage
+	}
+	if *name == "" {
+		fmt.Fprintln(stderr, "of scenario: --name is required")
+		return exitUsage
+	}
+	process, err := readFileArg(*procF)
+	if err != nil {
+		fmt.Fprintf(stderr, "of scenario: %v\n", err)
+		return exitUsage
+	}
+	acceptance, err := readFileArg(*accF)
+	if err != nil {
+		fmt.Fprintf(stderr, "of scenario: %v\n", err)
+		return exitUsage
+	}
+
+	cat, err := loadWriteCatalog(*repoRoot)
+	if err != nil {
+		fmt.Fprintf(stderr, "of scenario: %v\n", err)
+		return exitUsage
+	}
+
+	idx := -1
+	for i := range cat.Scenarios {
+		if cat.Scenarios[i].Name == *name {
+			idx = i
+			break
+		}
+	}
+
+	switch verb {
+	case "add":
+		if idx >= 0 {
+			fmt.Fprintf(stderr, "of scenario add: %q already exists (use update)\n", *name)
+			return exitFail
+		}
+		if *id == "" {
+			fmt.Fprintln(stderr, "of scenario add: --id is required")
+			return exitUsage
+		}
+		if !idRe.MatchString(*id) {
+			fmt.Fprintf(stderr, "of scenario add: id %q is not <section>.<index>\n", *id)
+			return exitFail
+		}
+		if !nameRe.MatchString(*name) {
+			fmt.Fprintf(stderr, "of scenario add: name %q is not a kebab slug\n", *name)
+			return exitFail
+		}
+		for _, s := range cat.Scenarios {
+			if s.ID == *id {
+				fmt.Fprintf(stderr, "of scenario add: id %q already in use by %q\n", *id, s.Name)
+				return exitFail
+			}
+		}
+		cat.Scenarios = append(cat.Scenarios, shard.Shard{
+			ID: *id, Name: *name, Description: *desc,
+			Process: process, AcceptanceCriteria: acceptance,
+		})
+	case "update":
+		if idx < 0 {
+			fmt.Fprintf(stderr, "of scenario update: %q not found (use add)\n", *name)
+			return exitFail
+		}
+		s := &cat.Scenarios[idx]
+		if flagPassed(fs, "description") {
+			s.Description = *desc
+		}
+		if *procF != "" {
+			s.Process = process
+		}
+		if *accF != "" {
+			s.AcceptanceCriteria = acceptance
+		}
+	default:
+		fmt.Fprintln(stderr, "of scenario: verb must be add or update")
+		return exitUsage
+	}
+
+	cat.sortByID()
+	if err := writeJSONFileAtomic(shard.File(*repoRoot), cat); err != nil {
+		fmt.Fprintf(stderr, "of scenario: write: %v\n", err)
+		return exitUsage
+	}
+	fmt.Fprintf(stdout, "of scenario %s: %s ok\n", verb, *name)
+	return exitOK
+}
+
+// --- of agent add ---
+
+// agentMeta is replaydata/agents/<id>/metadata.json: the column descriptor.
+type agentMeta struct {
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	Provider      string   `json:"provider"`
+	Prerequisites []string `json:"prerequisites,omitempty"`
+}
+
+type prereqFlag []string
+
+func (p *prereqFlag) String() string     { return strings.Join(*p, ",") }
+func (p *prereqFlag) Set(v string) error { *p = append(*p, v); return nil }
+
+func runAgent(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] != "add" {
+		fmt.Fprintln(stderr, "usage: of agent add --id --name --provider [--min-version v] [--prereq p]...")
+		return exitUsage
+	}
+	fs := newFlagSet("of agent add")
+	var prereqs prereqFlag
+	var (
+		id       = fs.String("id", "", "agent id (kebab slug)")
+		name     = fs.String("name", "", "display name")
+		provider = fs.String("provider", "", "provider (e.g. anthropic, openai)")
+		minVer   = fs.String("min-version", "0.0.0", "minimum supported agent version (column registration)")
+		repoRoot = fs.String("repo-root", ".", "repository root")
+	)
+	fs.Var(&prereqs, "prereq", "a recording prerequisite (repeatable)")
+	if err := fs.Parse(args[1:]); err != nil {
+		return exitUsage
+	}
+	if *id == "" || *name == "" || *provider == "" {
+		fmt.Fprintln(stderr, "of agent add: --id, --name, --provider are all required")
+		return exitUsage
+	}
+	if !nameRe.MatchString(*id) {
+		fmt.Fprintf(stderr, "of agent add: id %q is not a kebab slug\n", *id)
+		return exitFail
+	}
+	metaPath := filepath.Join(*repoRoot, "replaydata", "agents", *id, "metadata.json")
+	if fileExists(metaPath) {
+		fmt.Fprintf(stderr, "of agent add: agent %q already exists\n", *id)
+		return exitFail
+	}
+	// Register the column in scenarios.json meta.min_versions so the viewer
+	// shows it and the matrix treats it as onboarded.
+	if rc := registerAgentColumn(*repoRoot, *id, *minVer, stderr); rc != exitOK {
+		return rc
+	}
+	am := agentMeta{ID: *id, Name: *name, Provider: *provider, Prerequisites: prereqs}
+	if err := writeJSONFileAtomic(metaPath, am); err != nil {
+		fmt.Fprintf(stderr, "of agent add: write: %v\n", err)
+		return exitUsage
+	}
+	fmt.Fprintf(stdout, "of agent add: %s ok (provider=%s, prereqs=%d)\n", *id, *provider, len(prereqs))
+	return exitOK
+}
+
+// registerAgentColumn adds id→minVer to scenarios.json meta.min_versions,
+// preserving the rest of meta (transcript_extensions, capability_vocab).
+func registerAgentColumn(repoRoot, id, minVer string, stderr io.Writer) int {
+	cat, err := loadWriteCatalog(repoRoot)
+	if err != nil {
+		fmt.Fprintf(stderr, "of agent add: %v\n", err)
+		return exitUsage
+	}
+	var meta map[string]json.RawMessage
+	if err := json.Unmarshal(cat.Meta, &meta); err != nil {
+		fmt.Fprintf(stderr, "of agent add: meta is not a JSON object: %v\n", err)
+		return exitFail
+	}
+	mv := map[string]string{}
+	if raw, ok := meta["min_versions"]; ok {
+		_ = json.Unmarshal(raw, &mv)
+	}
+	mv[id] = minVer
+	b, _ := json.Marshal(mv)
+	meta["min_versions"] = b
+	mb, _ := json.Marshal(meta)
+	cat.Meta = mb
+	if err := writeJSONFileAtomic(shard.File(repoRoot), cat); err != nil {
+		fmt.Fprintf(stderr, "of agent add: write catalog: %v\n", err)
+		return exitUsage
+	}
+	return exitOK
+}
+
+// --- of cell write ---
+
+func runCell(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] != "write" {
+		fmt.Fprintln(stderr, "usage: of cell write --agent a --scenario s --file metadata.json [--folder f]")
+		return exitUsage
+	}
+	fs := newFlagSet("of cell write")
+	var (
+		agent    = fs.String("agent", "", "agent id")
+		scenario = fs.String("scenario", "", "scenario name (the FK)")
+		file     = fs.String("file", "", "metadata.json content to write")
+		folder   = fs.String("folder", "", "override on-disk folder (default: <dashed-id>_<name>)")
+		repoRoot = fs.String("repo-root", ".", "repository root")
+	)
+	if err := fs.Parse(args[1:]); err != nil {
+		return exitUsage
+	}
+	if *agent == "" || *scenario == "" || *file == "" {
+		fmt.Fprintln(stderr, "of cell write: --agent, --scenario, --file are required")
+		return exitUsage
+	}
+	sh, ok := shard.Load(*repoRoot, *scenario)
+	if !ok {
+		fmt.Fprintf(stderr, "of cell write: scenario %q not in the catalog\n", *scenario)
+		return exitFail
+	}
+	b, err := os.ReadFile(*file)
+	if err != nil {
+		fmt.Fprintf(stderr, "of cell write: %v\n", err)
+		return exitUsage
+	}
+	var cell shard.ShardAgent
+	if err := json.Unmarshal(b, &cell); err != nil {
+		fmt.Fprintf(stderr, "of cell write: --file is not valid metadata.json: %v\n", err)
+		return exitFail
+	}
+	// Force the FK so the cell always links back to its catalog row.
+	cell.ScenarioID = *scenario
+	fold := *folder
+	if fold == "" {
+		fold = strings.ReplaceAll(sh.ID, ".", "-") + "_" + sh.Name
+	}
+	metaPath := filepath.Join(*repoRoot, "replaydata", "agents", *agent, "scenarios", fold, "metadata.json")
+	if err := writeJSONFileAtomic(metaPath, cell); err != nil {
+		fmt.Fprintf(stderr, "of cell write: write: %v\n", err)
+		return exitUsage
+	}
+	fmt.Fprintf(stdout, "of cell write: %s/%s ok\n", *agent, fold)
+	return exitOK
+}

--- a/tools/onboarding-factory/cmd/of/write_test.go
+++ b/tools/onboarding-factory/cmd/of/write_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScenarioAddThenValidate(t *testing.T) {
+	root := validRepo(t)
+	proc := filepath.Join(t.TempDir(), "p.md")
+	_ = os.WriteFile(proc, []byte("1. do a thing\n"), 0o644)
+	code, out, errs := runOf("scenario", "add", "--id", "9.1", "--name", "new-scn",
+		"--description", "d", "--process-file", proc, "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("add failed: %d %s", code, errs)
+	}
+	if !strings.Contains(out, "new-scn ok") {
+		t.Fatalf("unexpected out: %s", out)
+	}
+	// present + tree still valid
+	if code, _, _ := runOf("validate", "--repo-root", root); code != exitOK {
+		t.Fatal("validate failed after add")
+	}
+	b, _ := os.ReadFile(filepath.Join(root, "replaydata", "agents", "scenarios.json"))
+	if !strings.Contains(string(b), `"new-scn"`) || !strings.Contains(string(b), "1. do a thing") {
+		t.Fatalf("scenario not written with process: %s", b)
+	}
+}
+
+func TestScenarioAddRejectsDupAndBadID(t *testing.T) {
+	root := validRepo(t)
+	if code, _, _ := runOf("scenario", "add", "--id", "1.1", "--name", "x", "--repo-root", root); code != exitFail {
+		t.Fatal("dup id must fail")
+	}
+	if code, _, _ := runOf("scenario", "add", "--id", "bad", "--name", "y", "--repo-root", root); code != exitFail {
+		t.Fatal("bad id must fail")
+	}
+	if code, _, _ := runOf("scenario", "add", "--id", "9.9", "--name", "session-start", "--repo-root", root); code != exitFail {
+		t.Fatal("dup name must fail")
+	}
+}
+
+func TestScenarioUpdate(t *testing.T) {
+	root := validRepo(t)
+	acc := filepath.Join(t.TempDir(), "a.md")
+	_ = os.WriteFile(acc, []byte("- new crit\n"), 0o644)
+	code, _, errs := runOf("scenario", "update", "--name", "session-start", "--acceptance-file", acc, "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("update failed: %d %s", code, errs)
+	}
+	b, _ := os.ReadFile(filepath.Join(root, "replaydata", "agents", "scenarios.json"))
+	if !strings.Contains(string(b), "new crit") {
+		t.Fatalf("update not applied: %s", b)
+	}
+	if code, _, _ := runOf("scenario", "update", "--name", "ghost", "--repo-root", root); code != exitFail {
+		t.Fatal("update of missing scenario must fail")
+	}
+}
+
+func TestAgentAdd(t *testing.T) {
+	root := validRepo(t)
+	code, _, errs := runOf("agent", "add", "--id", "newcli", "--name", "New CLI", "--provider", "acme",
+		"--prereq", "set ACME_API_KEY", "--prereq", "install acme", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("agent add failed: %d %s", code, errs)
+	}
+	var am agentMeta
+	b, _ := os.ReadFile(filepath.Join(root, "replaydata", "agents", "newcli", "metadata.json"))
+	if json.Unmarshal(b, &am) != nil || am.Provider != "acme" || len(am.Prerequisites) != 2 {
+		t.Fatalf("agent metadata wrong: %s", b)
+	}
+	// registered as a column
+	_, out, _ := runOf("status", "--json", "--repo-root", root)
+	var v statusView
+	_ = json.Unmarshal([]byte(out), &v)
+	found := false
+	for _, a := range v.Agents {
+		if a == "newcli" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("newcli not registered as column: %v", v.Agents)
+	}
+	// idempotency guard
+	if code, _, _ := runOf("agent", "add", "--id", "newcli", "--name", "x", "--provider", "y", "--repo-root", root); code != exitFail {
+		t.Fatal("duplicate agent add must fail")
+	}
+}
+
+func TestCellWriteFK(t *testing.T) {
+	root := validRepo(t)
+	cellFile := filepath.Join(t.TempDir(), "cell.json")
+	_ = os.WriteFile(cellFile, []byte(`{"details":{"assessment":{"agent_supports":"yes"}}}`), 0o644)
+	// dangling scenario → fail
+	if code, _, _ := runOf("cell", "write", "--agent", "claudecode", "--scenario", "ghost", "--file", cellFile, "--repo-root", root); code != exitFail {
+		t.Fatal("cell write with unknown scenario must fail")
+	}
+	// real scenario → ok, FK forced
+	code, _, errs := runOf("cell", "write", "--agent", "claudecode", "--scenario", "basic-turn", "--file", cellFile, "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("cell write failed: %d %s", code, errs)
+	}
+	b, _ := os.ReadFile(filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", "2-1_basic-turn", "metadata.json"))
+	if !strings.Contains(string(b), `"scenario_id": "basic-turn"`) {
+		t.Fatalf("scenario_id FK not forced: %s", b)
+	}
+}
+
+func TestVerifyCommand(t *testing.T) {
+	root := validRepo(t)
+	cell := filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", "1-1_session-start")
+	// validRepo's newest recording is "r1" (has a non-empty events.jsonl). Drop
+	// the golden summary there so it's the one ValidateObservations reads.
+	rec := filepath.Join(cell, "recordings", "r1")
+	_ = os.WriteFile(filepath.Join(rec, "transcript.jsonl.replay.json.golden"),
+		[]byte(`{"schema_version":1,"summary":{"estimated_cost_usd":0.1,"cum_input_tokens":5,"cum_output_tokens":5,"model_name":"claude-opus-4-7"}}`), 0o644)
+	// expected.jsonl with a passing observations block + a trivially-passing state spec
+	_ = os.WriteFile(filepath.Join(cell, "expected.jsonl"),
+		[]byte(`{"schema_version":1,"scenario_id":"session-start","observations":{"model":"claude-opus-4-7","cost_nonzero":true}}`+"\n"), 0o644)
+
+	code, out, errs := runOf("verify", "--agent", "claudecode", "--scenario", "session-start", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("verify should pass: code=%d out=%s err=%s", code, out, errs)
+	}
+	if !strings.Contains(out, "observations: PASS") {
+		t.Fatalf("expected observations PASS: %s", out)
+	}
+
+	// flip the asserted model → verify must fail
+	_ = os.WriteFile(filepath.Join(cell, "expected.jsonl"),
+		[]byte(`{"schema_version":1,"scenario_id":"session-start","observations":{"model":"WRONG"}}`+"\n"), 0o644)
+	if code, _, _ := runOf("verify", "--agent", "claudecode", "--scenario", "session-start", "--repo-root", root); code != exitFail {
+		t.Fatalf("verify must fail on model mismatch, got %d", code)
+	}
+}

--- a/tools/onboarding-factory/internal/validate/expected.go
+++ b/tools/onboarding-factory/internal/validate/expected.go
@@ -70,6 +70,22 @@ type ExpectedMeta struct {
 	Source        string `json:"source"`
 	Notes         string `json:"notes,omitempty"`
 	KnownFailing  bool   `json:"known_failing,omitempty"`
+	// Observations carries the go-test-style assertions over the recording's
+	// metric vector (model / cost / tokens), beyond the lifecycle-state phases.
+	// Absent → no hard metric assertions (the soft-diff vs the prior recording
+	// still runs in ValidateObservations).
+	Observations *ObservationSpec `json:"observations,omitempty"`
+}
+
+// ObservationSpec is the optional metric-assertion block of an expected.jsonl
+// meta line. Categorical fields (model) assert exact equality; numeric fields
+// assert nonzero. The full vector is additionally soft-diffed against the prior
+// recording within TolerancePct — see ValidateObservations.
+type ObservationSpec struct {
+	Model         string  `json:"model,omitempty"`          // exact-match assertion (categorical)
+	CostNonzero   bool    `json:"cost_nonzero,omitempty"`   // estimated_cost_usd > 0
+	TokensNonzero bool    `json:"tokens_nonzero,omitempty"` // cum_input+output > 0
+	TolerancePct  float64 `json:"tolerance_pct,omitempty"`  // soft-diff band vs prior (default 50)
 }
 
 // ExpectedPhase is one line of expected.jsonl after the meta line.

--- a/tools/onboarding-factory/internal/validate/observations.go
+++ b/tools/onboarding-factory/internal/validate/observations.go
@@ -1,0 +1,215 @@
+package validate
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// defaultTolerancePct is the soft-diff band for cost/token drift vs the prior
+// recording when the spec doesn't set one. Live agent runs jitter run-to-run,
+// so equality would flap; 50% catches order-of-magnitude regressions without
+// firing on normal variance.
+const defaultTolerancePct = 50.0
+
+// replaySummary is the metric vector the offline replay computes into each
+// recording's *.replay.json.golden `summary` block. This is where token / cost
+// / model live (the daemon's events.jsonl is lifecycle-only).
+type replaySummary struct {
+	EstimatedCostUSD       float64 `json:"estimated_cost_usd"`
+	CumInputTokens         int64   `json:"cum_input_tokens"`
+	CumOutputTokens        int64   `json:"cum_output_tokens"`
+	CumCacheReadTokens     int64   `json:"cum_cache_read_tokens"`
+	CumCacheCreationTokens int64   `json:"cum_cache_creation_tokens"`
+	ModelName              string  `json:"model_name"`
+}
+
+func (s replaySummary) totalTokens() int64 { return s.CumInputTokens + s.CumOutputTokens }
+
+// ObsAssert is one hard metric assertion from the spec's observations block.
+type ObsAssert struct {
+	Field    string `json:"field"`
+	Expected string `json:"expected"`
+	Actual   string `json:"actual"`
+	OK       bool   `json:"ok"`
+}
+
+// ObsDrift is one soft-diff finding: a metric that moved vs the prior recording
+// beyond tolerance (categorical: any change; numeric: > TolerancePct). Drifts
+// are reported but never fail the run (live jitter is expected).
+type ObsDrift struct {
+	Field    string  `json:"field"`
+	Prior    string  `json:"prior"`
+	Current  string  `json:"current"`
+	PctDelta float64 `json:"pct_delta,omitempty"`
+}
+
+// ObservationReport is the result of comparing a recording's metric vector
+// against the spec (hard) and the prior recording (soft). Pass is false only
+// when a hard assertion fails; drifts never flip it.
+type ObservationReport struct {
+	Pass    bool        `json:"pass"`
+	Skipped bool        `json:"skipped,omitempty"` // no golden to read
+	Note    string      `json:"note,omitempty"`
+	Asserts []ObsAssert `json:"asserts,omitempty"`
+	Drifts  []ObsDrift  `json:"drifts,omitempty"`
+}
+
+// sortedRecordingDirs returns the cell's recording dirs newest-first (names are
+// timestamp-prefixed, so reverse-lexical == reverse-chronological).
+func sortedRecordingDirs(scenarioDir string) []string {
+	entries, err := os.ReadDir(filepath.Join(scenarioDir, "recordings"))
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(names)))
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = filepath.Join(scenarioDir, "recordings", n)
+	}
+	return out
+}
+
+// readGoldenSummary reads the `summary` block of the *.replay.json.golden in a
+// recording dir. ok is false when no golden is present or it doesn't parse.
+func readGoldenSummary(recDir string) (replaySummary, bool) {
+	matches, _ := filepath.Glob(filepath.Join(recDir, "*.replay.json.golden"))
+	if len(matches) == 0 {
+		return replaySummary{}, false
+	}
+	b, err := os.ReadFile(matches[0])
+	if err != nil {
+		return replaySummary{}, false
+	}
+	var doc struct {
+		Summary replaySummary `json:"summary"`
+	}
+	if json.Unmarshal(b, &doc) != nil {
+		return replaySummary{}, false
+	}
+	return doc.Summary, true
+}
+
+// loadObservationSpec reads the optional observations block from a cell's
+// expected.jsonl meta line. Absent file/block → nil (soft-diff only).
+func loadObservationSpec(scenarioDir string) *ObservationSpec {
+	b, err := os.ReadFile(filepath.Join(scenarioDir, "expected.jsonl"))
+	if err != nil {
+		return nil
+	}
+	for _, line := range splitLines(b) {
+		if len(line) == 0 {
+			continue
+		}
+		var m ExpectedMeta
+		if json.Unmarshal(line, &m) == nil && m.SchemaVersion != 0 {
+			return m.Observations
+		}
+		break // first non-empty line is the meta line
+	}
+	return nil
+}
+
+// ValidateObservations runs the go-test-style metric verify for a cell: it
+// reads the newest recording's replay summary, hard-asserts the spec's
+// observations block (exact model / nonzero cost+tokens), and soft-diffs the
+// FULL vector against the prior recording within tolerance — so a cost/model/
+// token regression is surfaced even for a scenario whose spec doesn't assert
+// that field. No newest golden → Skipped (Pass=true).
+func ValidateObservations(scenarioDir string) (*ObservationReport, error) {
+	rep := &ObservationReport{Pass: true}
+	dirs := sortedRecordingDirs(scenarioDir)
+	if len(dirs) == 0 {
+		rep.Skipped, rep.Note = true, "no recordings"
+		return rep, nil
+	}
+	cur, ok := readGoldenSummary(dirs[0])
+	if !ok {
+		rep.Skipped, rep.Note = true, "newest recording has no replay golden"
+		return rep, nil
+	}
+
+	// Hard assertions from the spec.
+	if spec := loadObservationSpec(scenarioDir); spec != nil {
+		if spec.Model != "" {
+			ok := cur.ModelName == spec.Model
+			rep.Asserts = append(rep.Asserts, ObsAssert{"model", spec.Model, cur.ModelName, ok})
+			rep.Pass = rep.Pass && ok
+		}
+		if spec.CostNonzero {
+			ok := cur.EstimatedCostUSD > 0
+			rep.Asserts = append(rep.Asserts, ObsAssert{"cost_usd", ">0", fmt.Sprintf("%g", cur.EstimatedCostUSD), ok})
+			rep.Pass = rep.Pass && ok
+		}
+		if spec.TokensNonzero {
+			ok := cur.totalTokens() > 0
+			rep.Asserts = append(rep.Asserts, ObsAssert{"tokens", ">0", fmt.Sprintf("%d", cur.totalTokens()), ok})
+			rep.Pass = rep.Pass && ok
+		}
+	}
+
+	// Soft-diff the full vector vs the prior recording.
+	tol := defaultTolerancePct
+	if spec := loadObservationSpec(scenarioDir); spec != nil && spec.TolerancePct > 0 {
+		tol = spec.TolerancePct
+	}
+	if len(dirs) > 1 {
+		if prior, ok := readGoldenSummary(dirs[1]); ok {
+			if cur.ModelName != prior.ModelName {
+				rep.Drifts = append(rep.Drifts, ObsDrift{Field: "model", Prior: prior.ModelName, Current: cur.ModelName})
+			}
+			addNumDrift(rep, "cost_usd", prior.EstimatedCostUSD, cur.EstimatedCostUSD, tol)
+			addNumDrift(rep, "input_tokens", float64(prior.CumInputTokens), float64(cur.CumInputTokens), tol)
+			addNumDrift(rep, "output_tokens", float64(prior.CumOutputTokens), float64(cur.CumOutputTokens), tol)
+			addNumDrift(rep, "cache_read_tokens", float64(prior.CumCacheReadTokens), float64(cur.CumCacheReadTokens), tol)
+		}
+	}
+	return rep, nil
+}
+
+// addNumDrift records a drift when current deviates from prior by > tolPct. A
+// zero→nonzero (or nonzero→zero) flip is always a drift (infinite pct).
+func addNumDrift(rep *ObservationReport, field string, prior, cur, tolPct float64) {
+	if prior == 0 && cur == 0 {
+		return
+	}
+	var pct float64
+	if prior == 0 {
+		pct = math.Inf(1)
+	} else {
+		pct = math.Abs(cur-prior) / math.Abs(prior) * 100
+	}
+	if pct > tolPct {
+		rep.Drifts = append(rep.Drifts, ObsDrift{
+			Field:    field,
+			Prior:    fmt.Sprintf("%g", prior),
+			Current:  fmt.Sprintf("%g", cur),
+			PctDelta: pct,
+		})
+	}
+}
+
+// splitLines splits raw JSONL into per-line byte slices (trailing newline ok).
+func splitLines(b []byte) [][]byte {
+	var out [][]byte
+	start := 0
+	for i := 0; i < len(b); i++ {
+		if b[i] == '\n' {
+			out = append(out, b[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(b) {
+		out = append(out, b[start:])
+	}
+	return out
+}

--- a/tools/onboarding-factory/internal/validate/observations_test.go
+++ b/tools/onboarding-factory/internal/validate/observations_test.go
@@ -1,0 +1,115 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeRec writes a recording dir with a replay golden carrying the given
+// summary, under scenarioDir/recordings/<name>/.
+func mkGoldenRec(t *testing.T, scenarioDir, name, summaryJSON string) {
+	t.Helper()
+	dir := filepath.Join(scenarioDir, "recordings", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	golden := `{"schema_version":1,"summary":` + summaryJSON + `}`
+	if err := os.WriteFile(filepath.Join(dir, "transcript.jsonl.replay.json.golden"), []byte(golden), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeExpected(t *testing.T, scenarioDir, meta string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(scenarioDir, "expected.jsonl"), []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestObservationsSkippedNoRecording(t *testing.T) {
+	rep, err := ValidateObservations(t.TempDir())
+	if err != nil || !rep.Skipped || !rep.Pass {
+		t.Fatalf("want skipped+pass, got %+v err=%v", rep, err)
+	}
+}
+
+func TestObservationsHardAssertsPass(t *testing.T) {
+	dir := t.TempDir()
+	mkGoldenRec(t, dir, "2026-05-01-00-00-00_x", `{"estimated_cost_usd":0.12,"cum_input_tokens":10,"cum_output_tokens":20,"model_name":"claude-opus-4-7"}`)
+	writeExpected(t, dir, `{"schema_version":1,"scenario_id":"s","observations":{"model":"claude-opus-4-7","cost_nonzero":true,"tokens_nonzero":true}}`)
+	rep, err := ValidateObservations(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.Pass || len(rep.Asserts) != 3 {
+		t.Fatalf("want pass + 3 asserts, got %+v", rep)
+	}
+	for _, a := range rep.Asserts {
+		if !a.OK {
+			t.Fatalf("assert %s should pass: %+v", a.Field, a)
+		}
+	}
+}
+
+func TestObservationsModelMismatchFails(t *testing.T) {
+	dir := t.TempDir()
+	mkGoldenRec(t, dir, "2026-05-01-00-00-00_x", `{"estimated_cost_usd":0.12,"model_name":"gpt-5"}`)
+	writeExpected(t, dir, `{"schema_version":1,"scenario_id":"s","observations":{"model":"claude-opus-4-7"}}`)
+	rep, _ := ValidateObservations(dir)
+	if rep.Pass {
+		t.Fatalf("model mismatch must fail: %+v", rep)
+	}
+}
+
+func TestObservationsCostNonzeroFails(t *testing.T) {
+	dir := t.TempDir()
+	mkGoldenRec(t, dir, "2026-05-01-00-00-00_x", `{"estimated_cost_usd":0,"model_name":"m"}`)
+	writeExpected(t, dir, `{"schema_version":1,"scenario_id":"s","observations":{"cost_nonzero":true}}`)
+	rep, _ := ValidateObservations(dir)
+	if rep.Pass {
+		t.Fatalf("zero cost must fail cost_nonzero: %+v", rep)
+	}
+}
+
+func TestObservationsSoftDriftReportedNotFailed(t *testing.T) {
+	dir := t.TempDir()
+	// prior cheaper; current 3× → > default 50% band → drift, but no hard assert.
+	mkGoldenRec(t, dir, "2026-05-01-00-00-00_a", `{"estimated_cost_usd":0.10,"cum_input_tokens":100,"model_name":"m"}`)
+	mkGoldenRec(t, dir, "2026-05-02-00-00-00_b", `{"estimated_cost_usd":0.30,"cum_input_tokens":105,"model_name":"m"}`)
+	rep, _ := ValidateObservations(dir)
+	if !rep.Pass {
+		t.Fatalf("drift must NOT fail (soft): %+v", rep)
+	}
+	var costDrift bool
+	for _, d := range rep.Drifts {
+		if d.Field == "cost_usd" {
+			costDrift = true
+		}
+		if d.Field == "input_tokens" {
+			t.Fatalf("5%% token change should be within tolerance, not a drift: %+v", d)
+		}
+	}
+	if !costDrift {
+		t.Fatalf("3× cost change should be a drift: %+v", rep.Drifts)
+	}
+}
+
+func TestObservationsModelDrift(t *testing.T) {
+	dir := t.TempDir()
+	mkGoldenRec(t, dir, "2026-05-01-00-00-00_a", `{"model_name":"claude-opus-4-7"}`)
+	mkGoldenRec(t, dir, "2026-05-02-00-00-00_b", `{"model_name":"claude-opus-4-8"}`)
+	rep, _ := ValidateObservations(dir)
+	if !rep.Pass {
+		t.Fatalf("model drift is soft, must not fail: %+v", rep)
+	}
+	found := false
+	for _, d := range rep.Drifts {
+		if d.Field == "model" && d.Prior == "claude-opus-4-7" && d.Current == "claude-opus-4-8" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("want model drift, got %+v", rep.Drifts)
+	}
+}


### PR DESCRIPTION
Phase 5 of the onboarding-factory roadmap (#521). Closes #526.

**Stacked on #534** (P4) — targets `onboarding-factory-p4-cli`.

Two halves: the write surface (the **sole writer** of `replaydata/`) and the metric-verify engine.

## Write verbs (validate-then-write, atomic temp+rename)
- **`of scenario add|update`** — mutate `replaydata/agents/scenarios.json`. `add` rejects dup id/name + malformed id; `update` patches description/process/acceptance from files; the catalog is re-sorted by id. Meta rides along byte-for-byte.
- **`of agent add`** — write `replaydata/agents/<id>/metadata.json` `{id, name, provider, prerequisites[]}` **and** register the column in `meta.min_versions` so the viewer/matrix treat it as onboarded. Idempotency-guarded.
- **`of cell write`** — write a cell `metadata.json`, FK-checking the scenario exists and **forcing `scenario_id`** so the cell always links back to its row.

## Verify engine ("go-test-style verify")
**Design refinement:** the metric vector (cost/tokens/model) is **not** in the daemon's `events.jsonl` (lifecycle-only) — it lives in each recording's `*.replay.json.golden` `summary`. So the verify reads the golden summary.

- `internal/validate/observations.go` + `ExpectedMeta.Observations`: a cell's `expected.jsonl` meta may carry an `observations` block — exact-match `model` (categorical), nonzero cost/tokens. `ValidateObservations` **hard-asserts** those AND **soft-diffs the full vector** (cost/tokens/model) against the **prior recording** within a tolerance band (default 50%) — so a regression surfaces even for a scenario whose spec doesn't assert that field. Hard asserts fail; drifts are reported but never fail (live jitter is expected). **This is the tolerance-band + class-assert policy you chose.**
- **`of verify --agent --scenario`** runs BOTH the lifecycle-state phases (`ValidateExpected`, honoring `known_failing`) AND the observation layer; exit 1 on a state failure or a hard metric-assert failure. (`of record verify` in P6 calls the same engine after capturing a fresh recording.)

## Note (vs #526's text)
The coverage.json deletion was done in P3, not here.

## Verification
- `go test ./tools/onboarding-factory/... -race` — write-verb round-trips + dup/FK rejection + **6 observation cases** (hard-assert pass/fail, model/cost-nonzero, soft-drift reported-not-failed, model drift) + the `of verify` command ✅
- all write verbs + `of verify` smoke-tested against the real repo (verify `token-accounting`: state 7/7 + observations pass) ✅
- `replay-fixtures.sh` exit 0 (the additive `Observations` field is backward-compatible) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
