### PR TITLE
feat(relay) v1·B: hardening — read-limit cap + per-IP/connection caps (#536)

### DIFF
--- a/core/adapters/outbound/relay/forwarder.go
+++ b/core/adapters/outbound/relay/forwarder.go
@@ -15,6 +15,11 @@ import (
 
 const forwardWriteTimeout = 10 * time.Second
 
+// maxRelayFrameBytes caps a single inbound frame from the relay so a malicious
+// or buggy relay can't exhaust daemon memory. The daemon only reads hello_ack
+// and control frames, so this is generous headroom.
+const maxRelayFrameBytes = 1 << 20
+
 // streamPath is the relay's WebSocket endpoint, shared with the daemon and
 // every client.
 const streamPath = "/api/v1/sessions/stream"
@@ -153,6 +158,7 @@ func (f *Forwarder) runOnce(ctx context.Context) error {
 
 	// Read pump: surface the relay closing the socket (and drain any
 	// hello_ack / control frames, which v0 does not act on).
+	conn.SetReadLimit(maxRelayFrameBytes)
 	readErr := make(chan error, 1)
 	go func() {
 		for {

--- a/core/cmd/irrlichtrelay/caps_test.go
+++ b/core/cmd/irrlichtrelay/caps_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"irrlicht/core/adapters/outbound/relay"
+	"irrlicht/core/domain/session"
+)
+
+// dialDaemonHolding dials wsURL, completes a daemon hello, and reads the
+// hello_ack — so the caller knows the connection has passed the cap check and
+// is holding its slot before opening a second connection.
+func dialDaemonHolding(t *testing.T, wsURL, id string) *websocket.Conn {
+	t.Helper()
+	c := dial(t, wsURL)
+	if err := c.WriteJSON(relay.Hello{
+		Type:            relay.MsgHello,
+		ProtocolVersion: relay.ProtocolVersion,
+		Role:            relay.RoleDaemon,
+		DaemonID:        id,
+		DaemonLabel:     "test",
+	}); err != nil {
+		t.Fatalf("write daemon hello: %v", err)
+	}
+	readUntil(t, c, relay.MsgHelloAck)
+	return c
+}
+
+// expectClose asserts the next read on c fails with a WebSocket close of the
+// given code (the connection was rejected/closed by the server).
+func expectClose(t *testing.T, c *websocket.Conn, code int) {
+	t.Helper()
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	for {
+		_, _, err := c.ReadMessage()
+		if err == nil {
+			continue // skip any frame delivered before the close
+		}
+		var ce *websocket.CloseError
+		if !errors.As(err, &ce) {
+			t.Fatalf("expected close code %d, got non-close error: %v", code, err)
+		}
+		if ce.Code != code {
+			t.Fatalf("expected close code %d, got %d (%q)", code, ce.Code, ce.Text)
+		}
+		return
+	}
+}
+
+func TestRelayRejectsOverGlobalCap(t *testing.T) {
+	// One total connection allowed; per-IP disabled so only the global cap can trip.
+	wsURL, _ := newTestServerWithLimits(t, limits{maxConns: 1})
+
+	held := dialDaemonHolding(t, wsURL, "d1")
+	defer held.Close()
+
+	// The second connection exceeds the total cap and is closed with 1013.
+	over := dial(t, wsURL)
+	expectClose(t, over, websocket.CloseTryAgainLater)
+}
+
+func TestRelayRejectsOverPerIPCap(t *testing.T) {
+	// Total disabled; one connection per IP. httptest binds 127.0.0.1, so both
+	// dials share an IP and the second trips the per-IP cap, not the global one.
+	wsURL, _ := newTestServerWithLimits(t, limits{maxConnsPerIP: 1})
+
+	held := dialDaemonHolding(t, wsURL, "d1")
+	defer held.Close()
+
+	over := dial(t, wsURL)
+	expectClose(t, over, websocket.CloseTryAgainLater)
+}
+
+func TestRelayPerIPSlotReleasedOnDisconnect(t *testing.T) {
+	// Closing a connection frees its per-IP slot so a later dial succeeds.
+	wsURL, _ := newTestServerWithLimits(t, limits{maxConnsPerIP: 1})
+
+	first := dialDaemonHolding(t, wsURL, "d1")
+	first.Close()
+
+	// Give the server's deferred release time to run.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c := dial(t, wsURL)
+		if err := c.WriteJSON(relay.Hello{
+			Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion,
+			Role: relay.RoleDaemon, DaemonID: "d2", DaemonLabel: "test",
+		}); err != nil {
+			c.Close()
+			t.Fatalf("write daemon hello: %v", err)
+		}
+		c.SetReadDeadline(time.Now().Add(time.Second))
+		_, data, err := c.ReadMessage()
+		if err == nil && relay.FrameType(data) == relay.MsgHelloAck {
+			c.Close()
+			return // slot was released — success
+		}
+		c.Close()
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("per-IP slot was not released after the holder disconnected")
+}
+
+func TestRelayAcceptsLargeDaemonSnapshot(t *testing.T) {
+	// The strict client-frame cap must not clamp the trusted daemon path: a
+	// daemon_snapshot larger than maxMsgBytes must still be ingested (else a busy
+	// daemon loops snapshot-too-big → close → reconnect forever).
+	wsURL, baseURL := newTestServerWithLimits(t, limits{maxMsgBytes: 4 << 10, maxConns: 8, maxConnsPerIP: 8})
+
+	daemon := dial(t, wsURL)
+	if err := daemon.WriteJSON(relay.Hello{
+		Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion,
+		Role: relay.RoleDaemon, DaemonID: "d1", DaemonLabel: "busy",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	readUntil(t, daemon, relay.MsgHelloAck)
+
+	// Build a snapshot well past the 4 KiB client cap.
+	sessions := make([]*session.SessionState, 0, 64)
+	for i := range 64 {
+		sessions = append(sessions, &session.SessionState{
+			SessionID:   "s" + strconv.Itoa(i),
+			State:       "working",
+			ProjectName: strings.Repeat("p", 256),
+		})
+	}
+	if err := daemon.WriteJSON(relay.DaemonSnapshot{Type: relay.MsgDaemonSnapshot, Sessions: sessions}); err != nil {
+		t.Fatal(err)
+	}
+
+	// If the cap had clamped the daemon path, the read would have errored and
+	// the cache stayed empty; instead the sessions must surface over HTTP.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if body := httpGet(t, baseURL+"/api/v1/sessions"); strings.Contains(string(body), `"session_id":"s63"`) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("large daemon snapshot was not ingested — client cap leaked onto the daemon path")
+}
+
+func TestRelayRejectsOversizedFrame(t *testing.T) {
+	// A tiny message cap; an oversized inbound frame is closed with 1009.
+	wsURL, _ := newTestServerWithLimits(t, limits{maxMsgBytes: 16})
+
+	c := dial(t, wsURL)
+	if err := c.WriteMessage(websocket.TextMessage, []byte(strings.Repeat("x", 1024))); err != nil {
+		t.Fatalf("write oversized frame: %v", err)
+	}
+	expectClose(t, c, websocket.CloseMessageTooBig)
+}

--- a/core/cmd/irrlichtrelay/hub.go
+++ b/core/cmd/irrlichtrelay/hub.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -21,7 +22,36 @@ const (
 	pingInterval = 30 * time.Second
 	pongTimeout  = 45 * time.Second
 	writeTimeout = 10 * time.Second
+
+	// rejectLogInterval throttles over-cap rejection logging so a connection
+	// flood can't itself become a log flood.
+	rejectLogInterval = time.Second
 )
+
+// limits bounds resource use on an exposed listener: maxMsgBytes caps a single
+// inbound WebSocket frame (memory-exhaustion guard), maxConns the total live
+// connections, and maxConnsPerIP the live connections from one remote IP. A
+// non-positive value disables that cap.
+type limits struct {
+	maxMsgBytes   int64
+	maxConns      int
+	maxConnsPerIP int
+}
+
+// defaultLimits are the built-in caps used when no flag/env overrides them.
+func defaultLimits() limits {
+	return limits{maxMsgBytes: 1 << 20, maxConns: 256, maxConnsPerIP: 32}
+}
+
+// maxDaemonMsgBytes caps a frame on the trusted daemon path, which the strict
+// maxMsgBytes (a client-frame guard) must not constrain: a daemon's
+// daemon_snapshot is one JSON frame whose size scales with its live session
+// count, so the small client cap would put a busy daemon into an unrecoverable
+// "snapshot too big → close → reconnect → resend" loop. This bound is large
+// enough for any realistic snapshot yet still finite, since the v0 daemon hello
+// is unauthenticated — an attacker that sends a daemon hello must not unlock an
+// unbounded read.
+const maxDaemonMsgBytes = 32 << 20
 
 // hub is the relay's in-memory core: it tracks connected daemons, caches the
 // latest session state per (daemon_id, session_id) and the per-daemon adapter
@@ -41,6 +71,11 @@ type hub struct {
 	// carry a valid bearer token, and a token revoked mid-session closes the
 	// peer with relay.CloseRevoked on its next frame.
 	auth *authStore
+
+	limits        limits
+	totalConns    int            // live connections across all peers
+	ipConns       map[string]int // remote IP → live connections
+	lastRejectLog time.Time      // throttle for over-cap rejection logs
 }
 
 // daemonState tracks one daemon's connection liveness. conns counts live
@@ -62,20 +97,23 @@ type clientConn struct {
 	tokenID string // bearer-token id (empty on a no-auth relay); watched for revoke
 }
 
-// newHub builds a no-auth, all-origins hub (the loopback default and the shape
-// the tests use).
-func newHub() *hub { return newHubWithAuth(nil, nil) }
+// newHub builds a no-auth, all-origins hub with the given connection limits
+// (the loopback default and the shape the tests use).
+func newHub(lim limits) *hub { return newHubWithAuth(nil, nil, lim) }
 
-// newHubWithAuth builds a hub with optional bearer-token auth and an optional
-// browser-Origin allowlist. A nil auth accepts every hello; an empty allowlist
-// accepts every Origin (loopback-safe, unchanged from v0).
-func newHubWithAuth(auth *authStore, allowedOrigins []string) *hub {
+// newHubWithAuth builds a hub with optional bearer-token auth, an optional
+// browser-Origin allowlist, and connection limits. A nil auth accepts every
+// hello; an empty allowlist accepts every Origin (loopback-safe, unchanged
+// from v0).
+func newHubWithAuth(auth *authStore, allowedOrigins []string, lim limits) *hub {
 	return &hub{
 		clients:  make(map[*clientConn]struct{}),
 		daemons:  make(map[string]*daemonState),
 		sessions: make(map[string]map[string]*session.SessionState),
 		agents:   make(map[string][]relay.AgentInfo),
 		auth:     auth,
+		limits:   lim,
+		ipConns:  make(map[string]int),
 		upgrader: websocket.Upgrader{CheckOrigin: originChecker(allowedOrigins)},
 	}
 }
@@ -115,6 +153,25 @@ func (h *hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer conn.Close()
+
+	// Cap a single inbound frame before any read so an oversized payload is
+	// closed by gorilla (code 1009) instead of buffered unbounded. This strict
+	// cap governs the pre-dispatch hello read and the client read pump; the
+	// trusted daemon path raises it in serveDaemon (see maxDaemonMsgBytes).
+	if h.limits.maxMsgBytes > 0 {
+		conn.SetReadLimit(h.limits.maxMsgBytes)
+	}
+
+	// Enforce connection caps before the hello read. A WebSocket close frame
+	// requires a completed handshake, so we upgrade first, then close over-cap
+	// peers cleanly with code 1013 (try-again-later) and a diagnostic reason.
+	ip := remoteIP(r)
+	if reason, ok := h.acquire(ip); !ok {
+		closeWith(conn, websocket.CloseTryAgainLater, reason)
+		h.logReject(ip, reason)
+		return
+	}
+	defer h.release(ip)
 
 	conn.SetReadDeadline(time.Now().Add(helloTimeout))
 	_, data, err := conn.ReadMessage()
@@ -179,6 +236,62 @@ func (h *hub) closeIfRevoked(conn *websocket.Conn, tokenID string) bool {
 	return false
 }
 
+// acquire reserves a connection slot for ip, enforcing the total and per-IP
+// caps. It returns (reason, false) without reserving when a cap is hit, so the
+// caller closes the connection; otherwise (",", true) and the caller must
+// release(ip) on exit.
+func (h *hub) acquire(ip string) (string, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.limits.maxConns > 0 && h.totalConns >= h.limits.maxConns {
+		return "relay at capacity", false
+	}
+	if h.limits.maxConnsPerIP > 0 && h.ipConns[ip] >= h.limits.maxConnsPerIP {
+		return "per-IP connection limit reached", false
+	}
+	h.totalConns++
+	h.ipConns[ip]++
+	return "", true
+}
+
+// release frees the slot reserved by a matching acquire.
+func (h *hub) release(ip string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.totalConns > 0 {
+		h.totalConns--
+	}
+	if n := h.ipConns[ip]; n <= 1 {
+		delete(h.ipConns, ip)
+	} else {
+		h.ipConns[ip] = n - 1
+	}
+}
+
+// logReject logs an over-cap rejection at most once per rejectLogInterval so a
+// connection flood doesn't become a log flood.
+func (h *hub) logReject(ip, reason string) {
+	now := time.Now()
+	h.mu.Lock()
+	throttled := now.Sub(h.lastRejectLog) < rejectLogInterval
+	if !throttled {
+		h.lastRejectLog = now
+	}
+	h.mu.Unlock()
+	if !throttled {
+		log.Printf("relay: rejected connection from %s: %s", ip, reason)
+	}
+}
+
+// remoteIP extracts the host portion of the request's remote address. v1 trusts
+// no proxy headers (X-Forwarded-For), so this is the direct peer address.
+func remoteIP(r *http.Request) string {
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}
+
 // --- daemon side ---
 
 func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello, tokenID string) {
@@ -187,6 +300,10 @@ func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello, tokenID strin
 		return // untracked, undedupable — refuse
 	}
 	id, label := hello.DaemonID, hello.DaemonLabel
+
+	// Relax the strict client-frame cap: the daemon_snapshot read below scales
+	// with the daemon's session count and must not be clamped by maxMsgBytes.
+	conn.SetReadLimit(maxDaemonMsgBytes)
 
 	conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 	if err := conn.WriteJSON(relay.HelloAck{Type: relay.MsgHelloAck, AcceptedVersion: relay.ProtocolVersion}); err != nil {

--- a/core/cmd/irrlichtrelay/hub_test.go
+++ b/core/cmd/irrlichtrelay/hub_test.go
@@ -21,7 +21,12 @@ import (
 
 func newTestServer(t *testing.T) (wsURL, baseURL string) {
 	t.Helper()
-	h := newHub()
+	return newTestServerWithLimits(t, defaultLimits())
+}
+
+func newTestServerWithLimits(t *testing.T, lim limits) (wsURL, baseURL string) {
+	t.Helper()
+	h := newHub(lim)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/sessions/stream", h.ServeWS)
 	mux.HandleFunc("GET /api/v1/sessions", handleSessions(h))
@@ -291,7 +296,7 @@ func newTestServerWithAuth(t *testing.T, labels ...string) (wsURL string, tokens
 	if err != nil {
 		t.Fatalf("newAuthStore: %v", err)
 	}
-	h := newHubWithAuth(store, nil)
+	h := newHubWithAuth(store, nil, defaultLimits())
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/sessions/stream", h.ServeWS)
 	srv := httptest.NewServer(mux)

--- a/core/cmd/irrlichtrelay/main.go
+++ b/core/cmd/irrlichtrelay/main.go
@@ -20,6 +20,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -28,7 +29,28 @@ import (
 // Version is injected at build time via -ldflags "-X main.Version=x.y.z".
 var Version = "dev"
 
-const envUIDir = "IRRLICHT_UI_DIR"
+const (
+	envUIDir         = "IRRLICHT_UI_DIR"
+	envMaxMsgBytes   = "IRRLICHT_RELAY_MAX_MSG_BYTES"
+	envMaxConns      = "IRRLICHT_RELAY_MAX_CONNS"
+	envMaxConnsPerIP = "IRRLICHT_RELAY_MAX_CONNS_PER_IP"
+)
+
+// envInt64 returns the int64 value of env var name, or def when unset/unparseable.
+func envInt64(name string, def int64) int64 {
+	if v, err := strconv.ParseInt(os.Getenv(name), 10, 64); err == nil {
+		return v
+	}
+	return def
+}
+
+// envInt returns the int value of env var name, or def when unset/unparseable.
+func envInt(name string, def int) int {
+	if v, err := strconv.Atoi(os.Getenv(name)); err == nil {
+		return v
+	}
+	return def
+}
 
 // tokenReloadInterval is how often a serving relay re-checks the tokens file's
 // mtime so `token revoke` (a separate process) propagates without a restart.
@@ -85,7 +107,17 @@ func runServe(args []string) {
 	auth := fs.String("auth", "off", "authentication: 'off' (trusted LAN, accept any hello) or 'tokens-file[:PATH]' (verify a hashed bearer token; PATH defaults to <data-dir>/tokens.json)")
 	originAllowlist := fs.String("origin-allowlist", "", "comma-separated Origin hosts allowed for browser WS clients (empty = allow all, loopback-safe)")
 	dataDirFlag := fs.String("data-dir", "", "state directory for the tokens file (default: $IRRLICHT_HOME or ~/.local/share/irrlicht)")
+	// Connection-hardening caps for an exposed listener. Flag defaults are
+	// seeded from env when set (env < flag), mirroring IRRLICHT_UI_DIR.
+	def := defaultLimits()
+	maxMsgBytes := fs.Int64("max-msg-bytes", envInt64(envMaxMsgBytes, def.maxMsgBytes), "max inbound WebSocket message size in bytes (0 disables)")
+	maxConns := fs.Int("max-conns", envInt(envMaxConns, def.maxConns), "max total concurrent connections (0 disables)")
+	// Keyed on the direct peer address (X-Forwarded-For is not trusted in v1), so
+	// behind a reverse proxy or shared NAT every client collapses to one IP and
+	// this becomes a de-facto global cap — set 0 to disable it in that topology.
+	maxConnsPerIP := fs.Int("max-conns-per-ip", envInt(envMaxConnsPerIP, def.maxConnsPerIP), "max concurrent connections per remote IP (0 disables; meaningless behind a proxy/NAT — see --max-conns)")
 	_ = fs.Parse(args)
+	lim := limits{maxMsgBytes: *maxMsgBytes, maxConns: *maxConns, maxConnsPerIP: *maxConnsPerIP}
 
 	if (*tlsCert == "") != (*tlsKey == "") {
 		log.Fatal("--tls-cert and --tls-key must be given together")
@@ -135,7 +167,7 @@ func runServe(args []string) {
 	_ = mime.AddExtensionType(".js", "application/javascript")
 	_ = mime.AddExtensionType(".css", "text/css")
 
-	h := newHubWithAuth(store, allowedOrigins)
+	h := newHubWithAuth(store, allowedOrigins, lim)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/sessions/stream", h.ServeWS)
 	// The data endpoints carry the same session content as the WS stream, so


### PR DESCRIPTION
Closes #536. Part of the relay v1 epic (#532).

Hardens the exposed relay listener (`core/cmd/irrlichtrelay`) against memory exhaustion and connection abuse — the server-side slice of "safe to expose publicly," pairing with #535 (secure exposure).

## What

- **Per-message read cap.** `SetReadLimit` was never set on the WebSocket read pumps, so an unbounded inbound frame was a memory-exhaustion vector. The strict cap (`--max-msg-bytes`, default 1 MiB) now governs the untrusted **pre-dispatch hello read** and the **client read pump**. gorilla closes an over-cap peer with code 1009.
- **Trusted daemon path is separate.** A daemon's `daemon_snapshot` is one JSON frame whose size scales with its live session count, so clamping it with the small client cap would loop a busy daemon `snapshot-too-big → close → reconnect → resend` forever. `serveDaemon` raises the limit to a generous-but-finite **32 MiB** — large enough for any realistic snapshot, still bounded because the v0 daemon hello is unauthenticated (a fake-daemon hello must not unlock an unbounded read).
- **Connection + per-IP caps.** Enforced at the single `ServeWS` choke point before the hello read: over-cap peers get a clean WebSocket close (`1013` try-again-later) and a rate-limited diagnostic log (≤1/sec, so a flood isn't a log flood). `--max-conns` (256) and `--max-conns-per-ip` (32).
- **Daemon-side forwarder** caps inbound frames from the relay too (defense against a malicious/buggy relay).
- **Config:** flags with `IRRLICHT_RELAY_MAX_*` env fallbacks (env < flag), mirroring the `IRRLICHT_UI_DIR` pattern. `0` disables a cap.

## Known caveat (documented, deferred)

Per-IP caps key on the direct peer address — X-Forwarded-For is intentionally **not** trusted in v1. Behind a reverse proxy (where the TLS of #535 typically terminates) or a shared NAT, every client collapses to one IP and `--max-conns-per-ip` becomes a de-facto global cap. The flag help says so; set it to `0` in that topology and rely on `--max-conns`. Trusted-proxy header handling belongs with the exposure work, not bolted on here.

## Tests

`caps_test.go`: global-cap rejection (1013), per-IP-cap rejection (1013), per-IP slot release on disconnect, oversized-frame closure (1009), and a **large-daemon-snapshot regression** (64-session snapshot past a 4 KiB client cap must still ingest — would hang under the naive single-cap approach).

- `go test ./core/... -race -count=1` ✅ green
- `go vet` clean, `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)