### PR TITLE
feat(relay): #535 v1·A secure exposure — TLS/wss, bearer-token auth + token CLI, origin allowlist

### DIFF
--- a/core/adapters/outbound/relay/envelope.go
+++ b/core/adapters/outbound/relay/envelope.go
@@ -42,14 +42,24 @@ const (
 	StatusDisconnected = "disconnected"
 )
 
+// CloseRevoked is the WebSocket close code the relay sends when a peer's bearer
+// token is missing/invalid at handshake, or revoked while connected. Chosen in
+// the application-private 4000–4999 range; clients treat it as "auth failed,
+// don't keep reconnecting" rather than a transient drop.
+const CloseRevoked = 4401
+
 // Hello is the first frame a peer sends after the socket opens. Daemons set
-// the Daemon* fields; clients leave them empty.
+// the Daemon* fields; clients leave them empty. Token carries the bearer token
+// when the relay runs with --auth; it is the only auth channel (works from a
+// browser, which can't set request headers on a WebSocket) and is omitted on a
+// no-auth (trusted-LAN) relay.
 type Hello struct {
 	Type            string `json:"type"`
 	ProtocolVersion int    `json:"protocol_version"`
 	Role            string `json:"role"`
 	DaemonID        string `json:"daemon_id,omitempty"`
 	DaemonLabel     string `json:"daemon_label,omitempty"`
+	Token           string `json:"token,omitempty"`
 }
 
 // HelloAck is the relay's reply to a hello, echoing the negotiated version.

--- a/core/adapters/outbound/relay/forwarder.go
+++ b/core/adapters/outbound/relay/forwarder.go
@@ -54,6 +54,7 @@ type SnapshotFunc func() ([]*session.SessionState, []AgentInfo)
 type Forwarder struct {
 	url      string
 	identity Identity
+	token    string
 	push     outbound.PushBroadcaster
 	snapshot SnapshotFunc
 	logger   outbound.Logger
@@ -64,11 +65,13 @@ type Forwarder struct {
 }
 
 // NewForwarder builds a Forwarder targeting relayURL. push and snapshot are
-// required; logger may be nil.
-func NewForwarder(relayURL string, id Identity, push outbound.PushBroadcaster, snapshot SnapshotFunc, logger outbound.Logger) *Forwarder {
+// required; logger may be nil. token is sent in the hello for an auth-enabled
+// relay and may be empty (a no-auth relay ignores it).
+func NewForwarder(relayURL string, id Identity, token string, push outbound.PushBroadcaster, snapshot SnapshotFunc, logger outbound.Logger) *Forwarder {
 	return &Forwarder{
 		url:        normalizeRelayURL(relayURL),
 		identity:   id,
+		token:      token,
 		push:       push,
 		snapshot:   snapshot,
 		logger:     logger,
@@ -125,6 +128,7 @@ func (f *Forwarder) runOnce(ctx context.Context) error {
 		Role:            RoleDaemon,
 		DaemonID:        f.identity.DaemonID,
 		DaemonLabel:     f.identity.DaemonLabel,
+		Token:           f.token,
 	}); err != nil {
 		return err
 	}

--- a/core/adapters/outbound/relay/forwarder_test.go
+++ b/core/adapters/outbound/relay/forwarder_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -87,7 +89,7 @@ func TestForwarderHelloSnapshotAndPush(t *testing.T) {
 		return []*session.SessionState{{SessionID: "s1", State: "working"}},
 			[]AgentInfo{{Name: "claude-code", DisplayName: "Claude Code"}}
 	}
-	f := NewForwarder(tr.url, Identity{DaemonID: "d-123", DaemonLabel: "laptop"}, bc, snap, nil)
+	f := NewForwarder(tr.url, Identity{DaemonID: "d-123", DaemonLabel: "laptop"}, "", bc, snap, nil)
 	go f.Run(t.Context())
 
 	var hello Hello
@@ -116,7 +118,7 @@ func TestForwarderHelloSnapshotAndPush(t *testing.T) {
 func TestForwarderFiltersFocusRequested(t *testing.T) {
 	tr := newTestRelay(t)
 	bc := newFakeBroadcaster()
-	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, bc, nil, nil)
+	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, "", bc, nil, nil)
 	go f.Run(t.Context())
 
 	tr.next(t) // hello
@@ -137,7 +139,7 @@ func TestForwarderFiltersFocusRequested(t *testing.T) {
 func TestForwarderReconnects(t *testing.T) {
 	tr := newTestRelay(t)
 	bc := newFakeBroadcaster()
-	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, bc, nil, nil)
+	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, "", bc, nil, nil)
 	f.minBackoff = 10 * time.Millisecond
 	f.maxBackoff = 20 * time.Millisecond
 	go f.Run(t.Context())
@@ -213,5 +215,44 @@ func TestShouldForward(t *testing.T) {
 		if !shouldForward(outbound.PushMessage{Type: ty}) {
 			t.Fatalf("%s should be forwarded", ty)
 		}
+	}
+}
+
+// TestForwarderSendsToken verifies a configured bearer token is carried in the
+// daemon hello so an auth-enabled relay can authenticate it.
+func TestForwarderSendsToken(t *testing.T) {
+	tr := newTestRelay(t)
+	bc := newFakeBroadcaster()
+	snap := func() ([]*session.SessionState, []AgentInfo) { return nil, nil }
+	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, "s3cr3t-token", bc, snap, nil)
+	go f.Run(t.Context())
+
+	var hello Hello
+	mustUnmarshal(t, tr.next(t), &hello)
+	if hello.Type != MsgHello || hello.Role != RoleDaemon {
+		t.Fatalf("first frame is not a daemon hello: %+v", hello)
+	}
+	if hello.Token != "s3cr3t-token" {
+		t.Fatalf("hello.Token = %q, want the configured token", hello.Token)
+	}
+}
+
+// TestLoadDaemonToken covers env-var precedence and the tokens.json fallback.
+func TestLoadDaemonToken(t *testing.T) {
+	dir := t.TempDir()
+	if got := LoadDaemonToken(dir); got != "" {
+		t.Fatalf("no env, no file: got %q want empty", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "relay-token.json"), []byte(`{"token":"from-file"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := LoadDaemonToken(dir); got != "from-file" {
+		t.Fatalf("file fallback: got %q want from-file", got)
+	}
+
+	t.Setenv("IRRLICHT_RELAY_TOKEN", "from-env")
+	if got := LoadDaemonToken(dir); got != "from-env" {
+		t.Fatalf("env precedence: got %q want from-env", got)
 	}
 }

--- a/core/adapters/outbound/relay/token.go
+++ b/core/adapters/outbound/relay/token.go
@@ -1,0 +1,42 @@
+package relay
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// daemonTokenFilename is the basename of the daemon's relay bearer token,
+// stored under the daemon data dir at mode 0600. Unlike the relay server's
+// tokens file (a list of hashed records named tokens.json), this holds the
+// daemon's own single plaintext token — it must send it on the wire, so it
+// cannot be hashed. It deliberately uses a DIFFERENT filename so that running
+// both irrlichd and `irrlichtrelay` under one $IRRLICHT_HOME (the dev/test
+// coexist pattern) can't make one clobber the other's incompatible JSON shape.
+const daemonTokenFilename = "relay-token.json"
+
+// daemonToken is the on-disk shape of the daemon's relay token file.
+type daemonToken struct {
+	Token string `json:"token"`
+}
+
+// LoadDaemonToken returns the daemon's relay bearer token: the
+// IRRLICHT_RELAY_TOKEN env var if set, else the "token" field of
+// <dir>/relay-token.json. Best-effort — returns "" when neither is present (a
+// no-auth relay needs no token), and never errors so a missing/garbled file
+// just means "no token".
+func LoadDaemonToken(dir string) string {
+	if v := strings.TrimSpace(os.Getenv("IRRLICHT_RELAY_TOKEN")); v != "" {
+		return v
+	}
+	data, err := os.ReadFile(filepath.Join(dir, daemonTokenFilename))
+	if err != nil {
+		return ""
+	}
+	var t daemonToken
+	if err := json.Unmarshal(data, &t); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(t.Token)
+}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -176,6 +176,9 @@ func main() {
 		if err != nil {
 			logger.LogError("startup", "", fmt.Sprintf("relay identity persistence failed (using ephemeral id): %v", err))
 		}
+		// Bearer token for an auth-enabled relay: IRRLICHT_RELAY_TOKEN or
+		// <dataDir>/relay-token.json (mode 0600). Empty against a no-auth relay.
+		relayToken := relay.LoadDaemonToken(dataDir(home))
 		snapshot := func() ([]*session.SessionState, []relay.AgentInfo) {
 			sessions, err := cachedRepo.ListAll()
 			if err != nil {
@@ -192,7 +195,7 @@ func main() {
 			}
 			return sessions, infos
 		}
-		fwd := relay.NewForwarder(relayURL, identity, push, snapshot, logger)
+		fwd := relay.NewForwarder(relayURL, identity, relayToken, push, snapshot, logger)
 		relayCtx, relayCancel := context.WithCancel(context.Background())
 		defer relayCancel()
 		go fwd.Run(relayCtx)

--- a/core/cmd/irrlichtrelay/hub.go
+++ b/core/cmd/irrlichtrelay/hub.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +35,12 @@ type hub struct {
 	sessions map[string]map[string]*session.SessionState // daemon_id → session_id → state
 	agents   map[string][]relay.AgentInfo                // daemon_id → adapter registry
 	upgrader websocket.Upgrader
+
+	// auth is nil when the relay runs with --auth off (trusted-LAN default):
+	// every hello is accepted. When set, both daemon and client hellos must
+	// carry a valid bearer token, and a token revoked mid-session closes the
+	// peer with relay.CloseRevoked on its next frame.
+	auth *authStore
 }
 
 // daemonState tracks one daemon's connection liveness. conns counts live
@@ -48,21 +56,53 @@ type daemonState struct {
 // closed by the read pump when the socket drops so the write pump exits
 // promptly instead of waiting for the next ping tick.
 type clientConn struct {
-	conn *websocket.Conn
-	send chan []byte
-	done chan struct{}
+	conn    *websocket.Conn
+	send    chan []byte
+	done    chan struct{}
+	tokenID string // bearer-token id (empty on a no-auth relay); watched for revoke
 }
 
-func newHub() *hub {
+// newHub builds a no-auth, all-origins hub (the loopback default and the shape
+// the tests use).
+func newHub() *hub { return newHubWithAuth(nil, nil) }
+
+// newHubWithAuth builds a hub with optional bearer-token auth and an optional
+// browser-Origin allowlist. A nil auth accepts every hello; an empty allowlist
+// accepts every Origin (loopback-safe, unchanged from v0).
+func newHubWithAuth(auth *authStore, allowedOrigins []string) *hub {
 	return &hub{
 		clients:  make(map[*clientConn]struct{}),
 		daemons:  make(map[string]*daemonState),
 		sessions: make(map[string]map[string]*session.SessionState),
 		agents:   make(map[string][]relay.AgentInfo),
-		// Permissive origin policy: v0 is localhost-only with no auth, and the
-		// dashboard served from a different port than the WS endpoint is
-		// cross-origin. Tighten alongside auth in a later phase.
-		upgrader: websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }},
+		auth:     auth,
+		upgrader: websocket.Upgrader{CheckOrigin: originChecker(allowedOrigins)},
+	}
+}
+
+// originChecker gates the WS upgrade by the request Origin. An empty allowlist
+// keeps the permissive v0 behavior (localhost dev served cross-origin from a
+// different port). A non-empty allowlist admits only listed hosts; requests
+// without an Origin header (native daemons, curl — non-browser peers) are
+// always allowed since browsers always send one and auth still gates them.
+func originChecker(allowed []string) func(*http.Request) bool {
+	if len(allowed) == 0 {
+		return func(*http.Request) bool { return true }
+	}
+	set := make(map[string]bool, len(allowed))
+	for _, o := range allowed {
+		set[strings.ToLower(strings.TrimSpace(o))] = true
+	}
+	return func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return true
+		}
+		u, err := url.Parse(origin)
+		if err != nil {
+			return false
+		}
+		return set[strings.ToLower(u.Host)]
 	}
 }
 
@@ -90,16 +130,58 @@ func (h *hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 		// dashboard.
 		log.Printf("relay: opening frame is not a valid hello (%v); treating peer as a client", err)
 	}
+
+	// Bearer-token gate (both roles). On a no-auth relay h.auth is nil and the
+	// token is ignored. Otherwise the hello.token must hash to a known token;
+	// an empty/invalid token closes the socket with relay.CloseRevoked.
+	tokenID := ""
+	if h.auth != nil {
+		id, ok := h.auth.validate(hello.Token)
+		if !ok {
+			closeWith(conn, relay.CloseRevoked, "unauthorized")
+			return
+		}
+		tokenID = id
+	}
+
 	if hello.Type == relay.MsgHello && hello.Role == relay.RoleDaemon {
-		h.serveDaemon(conn, hello)
+		h.serveDaemon(conn, hello, tokenID)
 		return
 	}
-	h.serveClient(conn)
+	h.serveClient(conn, tokenID)
+}
+
+// closeWith sends a WebSocket close frame with the given code and reason, then
+// lets the deferred conn.Close() tear down the socket. Best-effort.
+func closeWith(conn *websocket.Conn, code int, reason string) {
+	_ = conn.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(code, reason),
+		time.Now().Add(writeTimeout),
+	)
+}
+
+// revoked reports whether an authenticated connection's token has since been
+// revoked. Always false on a no-auth relay or an unauthenticated (token-less)
+// connection.
+func (h *hub) revoked(tokenID string) bool {
+	return h.auth != nil && tokenID != "" && !h.auth.valid(tokenID)
+}
+
+// closeIfRevoked closes conn with CloseRevoked and returns true when tokenID has
+// been revoked, so each read/write loop can guard with a single line and the
+// check+close+return triplet lives in one place.
+func (h *hub) closeIfRevoked(conn *websocket.Conn, tokenID string) bool {
+	if h.revoked(tokenID) {
+		closeWith(conn, relay.CloseRevoked, "token revoked")
+		return true
+	}
+	return false
 }
 
 // --- daemon side ---
 
-func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello) {
+func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello, tokenID string) {
 	if hello.DaemonID == "" {
 		log.Printf("relay: refusing daemon hello with empty daemon_id")
 		return // untracked, undedupable — refuse
@@ -119,7 +201,7 @@ func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello) {
 	// gorilla's one-concurrent-writer rule.
 	done := make(chan struct{})
 	defer close(done)
-	go h.pingLoop(conn, done)
+	go h.pingLoop(conn, done, tokenID)
 
 	conn.SetReadDeadline(time.Now().Add(pongTimeout))
 	conn.SetPongHandler(func(string) error {
@@ -129,6 +211,9 @@ func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello) {
 	for {
 		_, data, err := conn.ReadMessage()
 		if err != nil {
+			return
+		}
+		if h.closeIfRevoked(conn, tokenID) {
 			return
 		}
 		h.handleDaemonFrame(id, data)
@@ -251,8 +336,8 @@ func (h *hub) daemonDisconnected(id string) {
 
 // --- client side ---
 
-func (h *hub) serveClient(conn *websocket.Conn) {
-	cc := &clientConn{conn: conn, send: make(chan []byte, 64), done: make(chan struct{})}
+func (h *hub) serveClient(conn *websocket.Conn, tokenID string) {
+	cc := &clientConn{conn: conn, send: make(chan []byte, 64), done: make(chan struct{}), tokenID: tokenID}
 
 	// Register before snapshotting so no daemon_status fired between the two
 	// is missed: any daemon present at snapshot time is in the snapshot, any
@@ -345,11 +430,20 @@ func (h *hub) clientWritePump(cc *clientConn) {
 		case <-cc.done:
 			return
 		case data := <-cc.send:
+			// A client mostly receives, so its read pump rarely runs; check for a
+			// mid-session revoke here (and on the ping tick) so a revoked client is
+			// closed within one fan-out frame or ping interval.
+			if h.closeIfRevoked(cc.conn, cc.tokenID) {
+				return
+			}
 			cc.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 			if err := cc.conn.WriteMessage(websocket.TextMessage, data); err != nil {
 				return
 			}
 		case <-ticker.C:
+			if h.closeIfRevoked(cc.conn, cc.tokenID) {
+				return
+			}
 			cc.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 			if err := cc.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
 				return
@@ -438,7 +532,7 @@ func (h *hub) buildAgents() []relay.AgentInfo {
 	return out
 }
 
-func (h *hub) pingLoop(conn *websocket.Conn, done <-chan struct{}) {
+func (h *hub) pingLoop(conn *websocket.Conn, done <-chan struct{}, tokenID string) {
 	ticker := time.NewTicker(pingInterval)
 	defer ticker.Stop()
 	for {
@@ -446,6 +540,13 @@ func (h *hub) pingLoop(conn *websocket.Conn, done <-chan struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
+			// An idle daemon sends no frames, so the read loop's per-frame revoke
+			// check never fires. Re-check here each tick (WriteControl is
+			// concurrent-safe with these pings) so a revoked but quiet daemon is
+			// closed within one ping interval rather than lingering authenticated.
+			if h.closeIfRevoked(conn, tokenID) {
+				return
+			}
 			conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
 				return

--- a/core/cmd/irrlichtrelay/hub_test.go
+++ b/core/cmd/irrlichtrelay/hub_test.go
@@ -273,6 +273,203 @@ func TestRelayDaemonDisconnectDeletesSessions(t *testing.T) {
 	}
 }
 
+// newTestServerWithAuth starts a relay with bearer-token auth backed by a
+// tokens file seeded with the given labels, returning the ws URL and the
+// plaintext token for each label.
+func newTestServerWithAuth(t *testing.T, labels ...string) (wsURL string, tokens map[string]string, tokensPath string, store *authStore) {
+	t.Helper()
+	tokensPath = filepath.Join(t.TempDir(), "tokens.json")
+	tokens = make(map[string]string, len(labels))
+	for _, l := range labels {
+		_, plaintext, err := issueToken(tokensPath, l)
+		if err != nil {
+			t.Fatalf("seed token %q: %v", l, err)
+		}
+		tokens[l] = plaintext
+	}
+	store, err := newAuthStore(tokensPath)
+	if err != nil {
+		t.Fatalf("newAuthStore: %v", err)
+	}
+	h := newHubWithAuth(store, nil)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/sessions/stream", h.ServeWS)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return "ws" + strings.TrimPrefix(srv.URL, "http") + "/api/v1/sessions/stream", tokens, tokensPath, store
+}
+
+// expectClose4401 reads from c expecting the relay to close with CloseRevoked.
+func expectClose4401(t *testing.T, c *websocket.Conn) {
+	t.Helper()
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	for {
+		_, _, err := c.ReadMessage()
+		if err == nil {
+			continue // skip any buffered data frames until the close arrives
+		}
+		if ce, ok := err.(*websocket.CloseError); ok {
+			if ce.Code != relay.CloseRevoked {
+				t.Fatalf("close code = %d, want %d", ce.Code, relay.CloseRevoked)
+			}
+			return
+		}
+		t.Fatalf("expected a 4401 close, got: %v", err)
+	}
+}
+
+func TestAuthDaemonAcceptedWithValidToken(t *testing.T) {
+	wsURL, tokens, _, _ := newTestServerWithAuth(t, "daemon")
+	c := dial(t, wsURL)
+	if err := c.WriteJSON(relay.Hello{
+		Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion,
+		Role: relay.RoleDaemon, DaemonID: "d1", DaemonLabel: "laptop", Token: tokens["daemon"],
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var ack relay.HelloAck
+	c.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if err := c.ReadJSON(&ack); err != nil || ack.Type != relay.MsgHelloAck {
+		t.Fatalf("expected hello_ack for a valid token: err=%v ack=%+v", err, ack)
+	}
+}
+
+func TestAuthRejectsMissingAndBadToken(t *testing.T) {
+	wsURL, tokens, _, _ := newTestServerWithAuth(t, "good")
+
+	// Daemon with no token.
+	d := dial(t, wsURL)
+	if err := d.WriteJSON(relay.Hello{Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion, Role: relay.RoleDaemon, DaemonID: "d1"}); err != nil {
+		t.Fatal(err)
+	}
+	expectClose4401(t, d)
+
+	// Client with a wrong token.
+	c := dial(t, wsURL)
+	if err := c.WriteJSON(relay.Hello{Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion, Role: relay.RoleClient, Token: tokens["good"] + "x"}); err != nil {
+		t.Fatal(err)
+	}
+	expectClose4401(t, c)
+}
+
+func TestAuthRevokeClosesLiveDaemon(t *testing.T) {
+	wsURL, tokens, tokensPath, store := newTestServerWithAuth(t, "daemon")
+	recs, _ := loadTokens(tokensPath)
+	id := recs[0].ID
+
+	d := dial(t, wsURL)
+	if err := d.WriteJSON(relay.Hello{
+		Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion,
+		Role: relay.RoleDaemon, DaemonID: "d1", DaemonLabel: "laptop", Token: tokens["daemon"],
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var ack relay.HelloAck
+	if err := d.ReadJSON(&ack); err != nil {
+		t.Fatal(err)
+	}
+
+	// Revoke the token out-of-band and reload the live store as the poll loop
+	// would. The daemon's next frame must then be closed with 4401.
+	if ok, err := revokeToken(tokensPath, id); err != nil || !ok {
+		t.Fatalf("revoke: ok=%v err=%v", ok, err)
+	}
+	if err := store.reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	// Send a frame to trigger the read loop's revocation check.
+	if err := d.WriteJSON(relay.DaemonSnapshot{Type: relay.MsgDaemonSnapshot}); err != nil {
+		t.Fatal(err)
+	}
+	expectClose4401(t, d)
+}
+
+func TestOriginChecker(t *testing.T) {
+	// Empty allowlist: every origin (and none) is allowed.
+	allow := originChecker(nil)
+	if !allow(reqWithOrigin("https://evil.example")) || !allow(reqWithOrigin("")) {
+		t.Fatal("empty allowlist should allow all origins")
+	}
+
+	// Non-empty allowlist: only listed hosts; non-browser (no Origin) allowed.
+	allow = originChecker([]string{"app.irrlicht.dev", "localhost:7839"})
+	cases := []struct {
+		origin string
+		want   bool
+	}{
+		{"https://app.irrlicht.dev", true},
+		{"http://localhost:7839", true},
+		{"https://evil.example", false},
+		{"", true}, // native daemon / curl: no Origin header
+		{"://malformed", false},
+	}
+	for _, c := range cases {
+		if got := allow(reqWithOrigin(c.origin)); got != c.want {
+			t.Errorf("origin %q: got %v, want %v", c.origin, got, c.want)
+		}
+	}
+}
+
+func reqWithOrigin(origin string) *http.Request {
+	r := httptest.NewRequest("GET", "/api/v1/sessions/stream", nil)
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	return r
+}
+
+func TestRequireTokenGatesHTTP(t *testing.T) {
+	tokensPath := filepath.Join(t.TempDir(), "tokens.json")
+	_, plaintext, err := issueToken(tokensPath, "http")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := newAuthStore(tokensPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok := func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }
+
+	// Auth off: pass-through, no token needed.
+	rec := httptest.NewRecorder()
+	requireToken(nil, ok)(rec, httptest.NewRequest("GET", "/api/v1/sessions", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("auth off should pass through, got %d", rec.Code)
+	}
+
+	gated := requireToken(store, ok)
+
+	// No token → 401.
+	rec = httptest.NewRecorder()
+	gated(rec, httptest.NewRequest("GET", "/api/v1/sessions", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("missing token should be 401, got %d", rec.Code)
+	}
+
+	// Valid token via query param → 200.
+	rec = httptest.NewRecorder()
+	gated(rec, httptest.NewRequest("GET", "/api/v1/sessions?token="+plaintext, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("valid ?token should be 200, got %d", rec.Code)
+	}
+
+	// Valid token via Authorization header → 200.
+	rec = httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/sessions", nil)
+	r.Header.Set("Authorization", "Bearer "+plaintext)
+	gated(rec, r)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("valid Bearer header should be 200, got %d", rec.Code)
+	}
+
+	// Wrong token → 401.
+	rec = httptest.NewRecorder()
+	gated(rec, httptest.NewRequest("GET", "/api/v1/sessions?token=nope", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("bad token should be 401, got %d", rec.Code)
+	}
+}
+
 func TestResolveUIDirEnvOverride(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("ok"), 0o644); err != nil {

--- a/core/cmd/irrlichtrelay/main.go
+++ b/core/cmd/irrlichtrelay/main.go
@@ -14,11 +14,13 @@ import (
 	"fmt"
 	"log"
 	"mime"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -28,6 +30,10 @@ var Version = "dev"
 
 const envUIDir = "IRRLICHT_UI_DIR"
 
+// tokenReloadInterval is how often a serving relay re-checks the tokens file's
+// mtime so `token revoke` (a separate process) propagates without a restart.
+const tokenReloadInterval = 2 * time.Second
+
 func main() {
 	args := os.Args[1:]
 	if len(args) > 0 && (args[0] == "--version" || args[0] == "-v") {
@@ -35,29 +41,109 @@ func main() {
 		fmt.Printf("Built with %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		return
 	}
-	// Accept an optional "serve" subcommand for forward-compatibility with
-	// later verbs (e.g. token issue); v0 has only serve.
-	if len(args) > 0 && args[0] == "serve" {
-		args = args[1:]
+	// Subcommand dispatch: `serve` (the default when the first arg is a flag or
+	// absent) runs the relay; `token issue|list|revoke` manages the bearer-token
+	// store. Anything else is an error.
+	cmd := "serve"
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		cmd, args = args[0], args[1:]
 	}
-	fs := flag.NewFlagSet("irrlichtrelay", flag.ExitOnError)
-	// Loopback by default: v0 has no auth and a permissive WS origin policy, so
-	// it must not be reachable from the LAN unless explicitly asked. Pass
-	// --addr 0.0.0.0:7839 (or a specific interface) to expose it — and only
-	// once bearer-token auth lands. Mirrors the daemon's loopback default.
+	switch cmd {
+	case "serve":
+		runServe(args)
+	case "token":
+		runToken(args)
+	default:
+		fmt.Fprintf(os.Stderr, "irrlichtrelay: unknown command %q (want serve|token)\n", cmd)
+		os.Exit(2)
+	}
+}
+
+// dataDir is the relay's per-user state directory, mirroring irrlichd's: the
+// IRRLICHT_HOME override, else ~/.local/share/irrlicht. It holds the hashed
+// tokens file when --auth tokens-file is given without an explicit path.
+func dataDir() string {
+	if v := os.Getenv("IRRLICHT_HOME"); v != "" {
+		return v
+	}
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return "/tmp/irrlicht"
+	}
+	return filepath.Join(home, ".local", "share", "irrlicht")
+}
+
+// runServe parses the serve flags and runs the relay until SIGINT/SIGTERM.
+func runServe(args []string) {
+	fs := flag.NewFlagSet("irrlichtrelay serve", flag.ExitOnError)
+	// Loopback by default: a no-auth relay must not be reachable from the LAN
+	// unless explicitly asked. Pass --addr 0.0.0.0:7839 to expose it — and only
+	// with --auth or behind a TLS-terminating reverse proxy. Mirrors irrlichd.
 	addr := fs.String("addr", "127.0.0.1:7839", "TCP address to listen on; defaults to loopback (use 0.0.0.0:7839 to expose on the LAN)")
+	tlsCert := fs.String("tls-cert", "", "PEM certificate file for native TLS (wss://); pair with --tls-key")
+	tlsKey := fs.String("tls-key", "", "PEM private-key file for native TLS (wss://); pair with --tls-cert")
+	auth := fs.String("auth", "off", "authentication: 'off' (trusted LAN, accept any hello) or 'tokens-file[:PATH]' (verify a hashed bearer token; PATH defaults to <data-dir>/tokens.json)")
+	originAllowlist := fs.String("origin-allowlist", "", "comma-separated Origin hosts allowed for browser WS clients (empty = allow all, loopback-safe)")
+	dataDirFlag := fs.String("data-dir", "", "state directory for the tokens file (default: $IRRLICHT_HOME or ~/.local/share/irrlicht)")
 	_ = fs.Parse(args)
+
+	if (*tlsCert == "") != (*tlsKey == "") {
+		log.Fatal("--tls-cert and --tls-key must be given together")
+	}
+	tlsEnabled := *tlsCert != ""
+
+	ddir := *dataDirFlag
+	if ddir == "" {
+		ddir = dataDir()
+	}
+
+	var store *authStore
+	switch {
+	case *auth == "off":
+		// no auth
+	case *auth == "tokens-file" || strings.HasPrefix(*auth, "tokens-file:"):
+		// TrimPrefix leaves a bare "tokens-file" (no colon) untouched and turns
+		// "tokens-file:PATH" into PATH; both the bare form and an empty PATH mean
+		// "use the default path".
+		path := strings.TrimPrefix(*auth, "tokens-file:")
+		if path == "" || path == "tokens-file" {
+			path = filepath.Join(ddir, tokensFilename)
+		}
+		s, err := newAuthStore(path)
+		if err != nil {
+			log.Fatalf("loading tokens file %s: %v", path, err)
+		}
+		store = s
+		log.Printf("auth enabled: %d token(s) loaded from %s", len(s.hashes), path)
+	default:
+		log.Fatalf("invalid --auth %q (want off | tokens-file[:PATH])", *auth)
+	}
+
+	allowedOrigins := splitCSV(*originAllowlist)
+
+	// Loud warning when exposed without authentication. TLS encrypts the wire
+	// but does NOT authenticate the peer, so a non-loopback bind without --auth
+	// is wide open regardless of TLS — anyone who can reach it reads every
+	// session and can inject as a daemon. (A reverse proxy that terminates TLS
+	// still binds the relay on loopback, so this only fires on a real exposure.)
+	if !isLoopback(*addr) && store == nil {
+		log.Printf("WARNING: binding %s with no --auth — anyone who can reach this address can read every session and inject as a daemon. Enable --auth (TLS alone does not authenticate), or restrict access at the network layer.", *addr)
+	}
 
 	// Serve web assets with correct Content-Type regardless of the host OS
 	// mime database (matches irrlichd).
 	_ = mime.AddExtensionType(".js", "application/javascript")
 	_ = mime.AddExtensionType(".css", "text/css")
 
-	h := newHub()
+	h := newHubWithAuth(store, allowedOrigins)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/v1/sessions/stream", h.ServeWS)
-	mux.HandleFunc("GET /api/v1/sessions", handleSessions(h))
-	mux.HandleFunc("GET /api/v1/agents", handleAgents(h))
+	// The data endpoints carry the same session content as the WS stream, so
+	// they get the same bearer-token gate when --auth is on; otherwise the WS
+	// would be authenticated while a plain `curl /api/v1/sessions` leaked
+	// everything. version stays open as an unauthenticated health check.
+	mux.HandleFunc("GET /api/v1/sessions", requireToken(store, handleSessions(h)))
+	mux.HandleFunc("GET /api/v1/agents", requireToken(store, handleAgents(h)))
 	mux.HandleFunc("GET /api/v1/version", handleVersion(Version))
 
 	if uiDir := resolveUIDir(); uiDir != "" {
@@ -70,6 +156,11 @@ func main() {
 		})
 	}
 
+	stop := make(chan struct{})
+	if store != nil {
+		go store.watch(stop, tokenReloadInterval)
+	}
+
 	// WS connections are hijacked by gorilla after the upgrade, so the only
 	// server-level timeout that applies is the header read.
 	srv := &http.Server{
@@ -79,8 +170,18 @@ func main() {
 	}
 
 	go func() {
-		log.Printf("irrlichtrelay %s listening on %s", Version, *addr)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		scheme := "ws"
+		if tlsEnabled {
+			scheme = "wss"
+		}
+		log.Printf("irrlichtrelay %s listening on %s (%s://)", Version, *addr, scheme)
+		var err error
+		if tlsEnabled {
+			err = srv.ListenAndServeTLS(*tlsCert, *tlsKey)
+		} else {
+			err = srv.ListenAndServe()
+		}
+		if err != nil && err != http.ErrServerClosed {
 			log.Fatalf("listen on %s failed: %v", *addr, err)
 		}
 	}()
@@ -89,10 +190,128 @@ func main() {
 	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
 	<-sig
 	log.Print("shutting down")
+	close(stop)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = srv.Shutdown(ctx)
+}
+
+// runToken implements `token issue|list|revoke`, operating directly on the
+// hashed tokens file (no running relay required).
+func runToken(args []string) {
+	if len(args) == 0 {
+		log.Fatal("token: want a subcommand (issue|list|revoke)")
+	}
+	sub, rest := args[0], args[1:]
+	fs := flag.NewFlagSet("irrlichtrelay token "+sub, flag.ExitOnError)
+	tokensFile := fs.String("tokens-file", "", "path to the tokens file (default: <data-dir>/tokens.json)")
+	dataDirFlag := fs.String("data-dir", "", "state directory for the tokens file (default: $IRRLICHT_HOME or ~/.local/share/irrlicht)")
+	label := fs.String("label", "", "human label for the issued token (issue only)")
+	_ = fs.Parse(rest)
+
+	path := *tokensFile
+	if path == "" {
+		ddir := *dataDirFlag
+		if ddir == "" {
+			ddir = dataDir()
+		}
+		path = filepath.Join(ddir, tokensFilename)
+	}
+
+	switch sub {
+	case "issue":
+		id, plaintext, err := issueToken(path, *label)
+		if err != nil {
+			log.Fatalf("token issue: %v", err)
+		}
+		fmt.Printf("token %s issued (label %q)\n", id, *label)
+		fmt.Printf("  %s\n", plaintext)
+		fmt.Println("Store it now — it is shown only once and only its hash is kept.")
+	case "list":
+		recs, err := sortedRecords(path)
+		if err != nil {
+			log.Fatalf("token list: %v", err)
+		}
+		if len(recs) == 0 {
+			fmt.Println("no tokens issued")
+			return
+		}
+		for _, r := range recs {
+			fmt.Printf("%s\t%s\t%s\n", r.ID, time.Unix(r.Created, 0).Format(time.RFC3339), r.Label)
+		}
+	case "revoke":
+		if len(fs.Args()) == 0 {
+			log.Fatal("token revoke: want a token id")
+		}
+		id := fs.Args()[0]
+		ok, err := revokeToken(path, id)
+		if err != nil {
+			log.Fatalf("token revoke: %v", err)
+		}
+		if !ok {
+			log.Fatalf("token revoke: no token with id %q", id)
+		}
+		fmt.Printf("token %s revoked; the peer's next frame will be closed with %d\n", id, 4401)
+	default:
+		log.Fatalf("token: unknown subcommand %q (want issue|list|revoke)", sub)
+	}
+}
+
+// requireToken wraps an HTTP API handler with the bearer-token gate. With auth
+// off (store == nil) it is a pass-through, so existing no-auth deployments are
+// unchanged. With auth on, the request must carry a valid token in either an
+// `Authorization: Bearer <t>` header or a `?token=<t>` query param (the WS
+// endpoint authenticates via the hello frame instead and is not wrapped).
+func requireToken(store *authStore, next http.HandlerFunc) http.HandlerFunc {
+	if store == nil {
+		return next
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := store.validate(bearerToken(r)); !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next(w, r)
+	}
+}
+
+// bearerToken extracts a token from an Authorization: Bearer header, falling
+// back to the `token` query param (browsers can't set headers on some requests
+// and the dashboard hydrates same-origin).
+func bearerToken(r *http.Request) string {
+	if h := r.Header.Get("Authorization"); strings.HasPrefix(h, "Bearer ") {
+		return strings.TrimSpace(strings.TrimPrefix(h, "Bearer "))
+	}
+	return r.URL.Query().Get("token")
+}
+
+// splitCSV trims and drops empties from a comma-separated flag value.
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// isLoopback reports whether a listen address binds only the loopback
+// interface, so the exposure warning fires only on a LAN/public bind.
+func isLoopback(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	if host == "" {
+		return false // empty host means all interfaces
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // resolveUIDir locates the dashboard's index.html, mirroring irrlichd's search

--- a/core/cmd/irrlichtrelay/tokens.go
+++ b/core/cmd/irrlichtrelay/tokens.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Bearer-token auth for the relay. Tokens are minted by the `token issue` CLI,
+// printed in plaintext exactly once, and stored only as a SHA-256 hash so the
+// tokens file is useless to read at rest (wiki §7). A running `serve` loads the
+// hashed set and re-reads it when the file changes, so `token revoke` takes
+// effect on the next frame from the revoked peer (closed with CloseRevoked).
+
+// tokensFilename is the basename of the relay's hashed token store, written
+// under the relay data dir (honors IRRLICHT_HOME via the caller).
+const tokensFilename = "tokens.json"
+
+// TokenRecord is one issued token. Hash is the hex SHA-256 of the plaintext;
+// the plaintext itself is never persisted. Label and Created are operator
+// metadata for `token list`.
+type TokenRecord struct {
+	ID      string `json:"id"`
+	Label   string `json:"label"`
+	Hash    string `json:"hash"`
+	Created int64  `json:"created"`
+}
+
+// hashToken returns the hex SHA-256 of a plaintext token — the only form stored
+// at rest and the key used for constant-time lookup.
+func hashToken(plaintext string) string {
+	sum := sha256.Sum256([]byte(plaintext))
+	return hex.EncodeToString(sum[:])
+}
+
+// loadTokens reads the hashed token store. A missing file is not an error (an
+// auth-enabled relay with no tokens yet simply rejects everyone).
+func loadTokens(path string) ([]TokenRecord, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var recs []TokenRecord
+	if err := json.Unmarshal(data, &recs); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return recs, nil
+}
+
+// saveTokens writes the hashed token store atomically-ish at mode 0600 (it
+// holds credential hashes), creating the data dir if needed.
+func saveTokens(path string, recs []TokenRecord) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(recs, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+// issueToken mints a new 256-bit token, appends its hash to the store, and
+// returns the id plus the plaintext (shown to the operator once and never
+// recoverable thereafter).
+func issueToken(path, label string) (id, plaintext string, err error) {
+	recs, err := loadTokens(path)
+	if err != nil {
+		return "", "", err
+	}
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", "", err
+	}
+	plaintext = base64.RawURLEncoding.EncodeToString(raw[:])
+
+	var idb [6]byte
+	if _, err := rand.Read(idb[:]); err != nil {
+		return "", "", err
+	}
+	id = hex.EncodeToString(idb[:])
+
+	recs = append(recs, TokenRecord{ID: id, Label: label, Hash: hashToken(plaintext), Created: time.Now().Unix()})
+	if err := saveTokens(path, recs); err != nil {
+		return "", "", err
+	}
+	return id, plaintext, nil
+}
+
+// revokeToken removes the record with the given id. Returns false (no error)
+// when no such id exists so the CLI can report it cleanly.
+func revokeToken(path, id string) (bool, error) {
+	recs, err := loadTokens(path)
+	if err != nil {
+		return false, err
+	}
+	out := make([]TokenRecord, 0, len(recs))
+	found := false
+	for _, r := range recs {
+		if r.ID == id {
+			found = true
+			continue
+		}
+		out = append(out, r)
+	}
+	if !found {
+		return false, nil
+	}
+	return true, saveTokens(path, out)
+}
+
+// authStore is the relay's live view of valid tokens while serving. It is
+// reloaded from disk whenever the tokens file's mtime changes so `token revoke`
+// (a separate process editing the file) propagates without a restart.
+type authStore struct {
+	path string
+
+	mu     sync.RWMutex
+	hashes map[string]string // token hash → id
+	byID   map[string]struct{}
+	mtime  time.Time
+}
+
+// newAuthStore builds a store bound to path and loads it once. A load error is
+// returned so `serve` refuses to start with an unreadable tokens file rather
+// than silently accepting no one.
+func newAuthStore(path string) (*authStore, error) {
+	a := &authStore{path: path, hashes: map[string]string{}, byID: map[string]struct{}{}}
+	if err := a.reload(); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// reload re-reads the tokens file and swaps in the new hashed set.
+func (a *authStore) reload() error {
+	recs, err := loadTokens(a.path)
+	if err != nil {
+		return err
+	}
+	hashes := make(map[string]string, len(recs))
+	byID := make(map[string]struct{}, len(recs))
+	for _, r := range recs {
+		hashes[r.Hash] = r.ID
+		byID[r.ID] = struct{}{}
+	}
+	var mtime time.Time
+	if fi, err := os.Stat(a.path); err == nil {
+		mtime = fi.ModTime()
+	}
+	a.mu.Lock()
+	a.hashes = hashes
+	a.byID = byID
+	a.mtime = mtime
+	a.mu.Unlock()
+	return nil
+}
+
+// reloadIfChanged reloads only when the tokens file's mtime advanced, so the
+// poll loop is cheap on an idle file.
+func (a *authStore) reloadIfChanged() {
+	fi, err := os.Stat(a.path)
+	if err != nil {
+		return // file vanished/unreadable: keep the last good set
+	}
+	a.mu.RLock()
+	unchanged := fi.ModTime().Equal(a.mtime)
+	a.mu.RUnlock()
+	if unchanged {
+		return
+	}
+	_ = a.reload()
+}
+
+// watch polls the tokens file for changes until ctx-equivalent stop is closed.
+func (a *authStore) watch(stop <-chan struct{}, every time.Duration) {
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-t.C:
+			a.reloadIfChanged()
+		}
+	}
+}
+
+// validate reports the token id for a plaintext token, ok=false if the token is
+// empty or unknown. The store is keyed by the SHA-256 hash of the token, so a
+// direct map lookup of the candidate's hash is O(1) and leaks no
+// secret-dependent timing (the hashing already happened; the lookup key is a
+// fixed-width digest of an unguessable 256-bit token).
+func (a *authStore) validate(plaintext string) (string, bool) {
+	if plaintext == "" {
+		return "", false
+	}
+	want := hashToken(plaintext)
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	id, ok := a.hashes[want]
+	return id, ok
+}
+
+// valid reports whether a token id is still present, used by connection read
+// loops to detect a mid-session revoke.
+func (a *authStore) valid(id string) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	_, ok := a.byID[id]
+	return ok
+}
+
+// sortedRecords returns the on-disk records sorted by creation time for stable
+// `token list` output.
+func sortedRecords(path string) ([]TokenRecord, error) {
+	recs, err := loadTokens(path)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(recs, func(i, j int) bool { return recs[i].Created < recs[j].Created })
+	return recs, nil
+}

--- a/core/cmd/irrlichtrelay/tokens_test.go
+++ b/core/cmd/irrlichtrelay/tokens_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestIssueValidateRevoke(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.json")
+
+	id, plaintext, err := issueToken(path, "laptop")
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if id == "" || plaintext == "" {
+		t.Fatalf("issue returned empty id/plaintext: %q %q", id, plaintext)
+	}
+
+	store, err := newAuthStore(path)
+	if err != nil {
+		t.Fatalf("newAuthStore: %v", err)
+	}
+	gotID, ok := store.validate(plaintext)
+	if !ok || gotID != id {
+		t.Fatalf("validate(plaintext) = %q,%v; want %q,true", gotID, ok, id)
+	}
+	if _, ok := store.validate("bogus"); ok {
+		t.Fatal("validate accepted a bogus token")
+	}
+	if _, ok := store.validate(""); ok {
+		t.Fatal("validate accepted an empty token")
+	}
+	if !store.valid(id) {
+		t.Fatalf("valid(%q) = false before revoke", id)
+	}
+
+	// Revoke + reload: the token is no longer valid.
+	revoked, err := revokeToken(path, id)
+	if err != nil || !revoked {
+		t.Fatalf("revoke: ok=%v err=%v", revoked, err)
+	}
+	if err := store.reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if _, ok := store.validate(plaintext); ok {
+		t.Fatal("validate accepted a revoked token after reload")
+	}
+	if store.valid(id) {
+		t.Fatalf("valid(%q) = true after revoke", id)
+	}
+
+	// Revoking a missing id is a clean false, not an error.
+	if revoked, err := revokeToken(path, "deadbeef"); err != nil || revoked {
+		t.Fatalf("revoke(missing) = %v,%v; want false,nil", revoked, err)
+	}
+}
+
+func TestTokensFileHashedAtRest(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	_, plaintext, err := issueToken(path, "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) == "" {
+		t.Fatal("tokens file is empty")
+	}
+	if contains(data, plaintext) {
+		t.Fatalf("plaintext token leaked into tokens file at rest:\n%s", data)
+	}
+	if !contains(data, hashToken(plaintext)) {
+		t.Fatalf("tokens file is missing the token hash:\n%s", data)
+	}
+}
+
+func TestTokensFileMode0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes not meaningful on Windows")
+	}
+	path := filepath.Join(t.TempDir(), "tokens.json")
+	if _, _, err := issueToken(path, "x"); err != nil {
+		t.Fatal(err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("tokens file mode = %o, want 600", perm)
+	}
+}
+
+func TestLoadTokensMissingFileIsEmpty(t *testing.T) {
+	recs, err := loadTokens(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil {
+		t.Fatalf("loadTokens(missing) errored: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("loadTokens(missing) = %d records, want 0", len(recs))
+	}
+}
+
+func contains(haystack []byte, needle string) bool {
+	return len(needle) > 0 && bytesIndex(haystack, needle) >= 0
+}
+
+func bytesIndex(h []byte, n string) int {
+	hs, ns := string(h), n
+	for i := 0; i+len(ns) <= len(hs); i++ {
+		if hs[i:i+len(ns)] == ns {
+			return i
+		}
+	}
+	return -1
+}

--- a/docs/relay-protocol.md
+++ b/docs/relay-protocol.md
@@ -38,7 +38,8 @@ Every frame is a JSON text message with a `type` tag.
 
 ```jsonc
 { "type": "hello", "protocol_version": 1, "role": "daemon" | "client",
-  "daemon_id": "uuid", "daemon_label": "laptop" }   // daemon_* set by daemons only
+  "daemon_id": "uuid", "daemon_label": "laptop",     // daemon_* set by daemons only
+  "token": "…" }                                      // both roles, when --auth is on
 ```
 
 A daemon mints `daemon_id` once and persists it at
@@ -46,6 +47,12 @@ A daemon mints `daemon_id` once and persists it at
 the id is stable across restarts; clients dedupe by it. `daemon_label` defaults
 to the hostname. The relay **refuses** a daemon `hello` with an empty
 `daemon_id`. A client `hello` omits the daemon fields.
+
+`token` carries the bearer token, sent by **both** roles. It is omitted against
+a `--auth off` relay (the trusted-LAN default) and required against an
+auth-enabled one (see [Auth, TLS, and origins](#auth-tls-and-origins)). The
+token rides in the `hello` rather than an HTTP header because a browser cannot
+set headers on a WebSocket — one channel serves daemon, macOS, and web alike.
 
 ### `hello_ack` (relay → peer)
 
@@ -112,6 +119,10 @@ socket and a relay collapses to one row automatically. **Caveat:** two
 *different* daemons that share a `session_id` (e.g. `proc-<pid>`) would merge —
 per-source keying and row-level source badges are deferred.
 
+Against an auth-enabled relay a client includes its `token` in that `hello`. A
+WS close with code **4401** means the token was missing, invalid, or revoked;
+clients treat it as "auth failed" and stop reconnecting rather than looping.
+
 ## HTTP
 
 The relay re-serves the daemon's read API from its cache so clients render
@@ -124,8 +135,49 @@ without an empty first paint, and serves the `platforms/web/` dashboard:
 | `GET /api/v1/version`  | the relay's own build version.                                 |
 | `GET /` (+ assets)     | the dashboard, served from disk (`IRRLICHT_UI_DIR` override, else dev/bundle lookup). |
 
-WebSocket `CheckOrigin` is permissive in v0 (localhost-only, no auth; the
-dashboard served from a different port is cross-origin). Tighten alongside auth.
+WebSocket `CheckOrigin` is permissive by default (the dashboard served from a
+different port is cross-origin). `serve --origin-allowlist host1,host2`
+restricts which browser `Origin`s may open the socket; non-browser peers send
+no `Origin` and are always admitted, with auth still gating them.
+
+## Auth, TLS, and origins
+
+The relay is safe to expose once these are in place.
+
+**TLS (`wss://`).** Two supported patterns:
+
+- *Reverse-proxy termination (recommended).* Front the relay with
+  Caddy/nginx/traefik terminating TLS and passing the WS upgrade through to the
+  relay on loopback. The relay itself binds `127.0.0.1`.
+- *Native TLS.* `irrlichtrelay serve --tls-cert cert.pem --tls-key key.pem`
+  serves `wss://` directly (`ListenAndServeTLS`); both flags are required
+  together. The daemon dialer already upgrades `https://`→`wss://`.
+
+**Bearer tokens (`--auth`).** `off` (default) accepts any `hello` — the
+trusted-LAN posture. `tokens-file[:PATH]` verifies the `hello`'s `token` for
+both roles against a store hashed at rest (SHA-256); default path
+`<data-dir>/tokens.json` (`$IRRLICHT_HOME` or `~/.local/share/irrlicht`).
+
+```
+irrlichtrelay token issue --label "ingo-laptop"   # prints the plaintext ONCE
+irrlichtrelay token list                          # id, created, label
+irrlichtrelay token revoke <id>                    # next frame closed with 4401
+```
+
+A serving relay re-reads the tokens file when it changes, so `revoke` takes
+effect without a restart: the revoked peer's next frame is closed with WS code
+**4401** (`relay.CloseRevoked`), the same code that rejects a missing/invalid
+token at handshake. The daemon presents its token via `IRRLICHT_RELAY_TOKEN` or
+a `<data-dir>/relay-token.json` `{"token":"…"}` file (mode 0600 — a different
+basename from the relay server's hashed `tokens.json` so the two never collide
+under a shared `$IRRLICHT_HOME`); macOS uses the Keychain (URL/enabled stay in
+UserDefaults); web keeps it in `localStorage`.
+
+When `--auth` is on the gate also covers the read endpoints `GET
+/api/v1/sessions` and `/api/v1/agents` — they carry the same session content as
+the WS stream, so a token is required via `Authorization: Bearer <t>` or a
+`?token=<t>` query param. `GET /api/v1/version` stays open as a health check.
+`/api/v1/tokens` REST management is deferred — CLI-only for now.
 
 ## Running it
 
@@ -135,12 +187,13 @@ IRRLICHT_RELAY_URL=ws://localhost:7839 irrlichd   # …also forwards to the rela
 irrlichtrelay serve                               # the relay on 127.0.0.1:7839
 ```
 
-> **Bind:** the relay listens on **`127.0.0.1:7839`** by default. v0 has no auth
-> and a permissive WS origin policy, so it stays loopback-only until bearer-token
-> auth lands. To watch sessions across machines, opt in explicitly with
-> `irrlichtrelay serve --addr 0.0.0.0:7839` (or a specific interface) — aware
-> that anyone who can reach that address can read every session and inject as a
-> daemon. This mirrors the daemon's own loopback-by-default posture.
+> **Bind:** the relay listens on **`127.0.0.1:7839`** by default. With no
+> `--auth` and no TLS it must stay loopback-only — anyone who can reach an
+> exposed address can read every session and inject as a daemon. To expose it,
+> bind a routable address *and* enable auth + TLS (or front it with a
+> TLS-terminating reverse proxy), e.g. `irrlichtrelay serve --addr 0.0.0.0:7839
+> --tls-cert cert.pem --tls-key key.pem --auth tokens-file`. This mirrors the
+> daemon's own loopback-by-default posture.
 
 > **Port choice:** irrlicht uses three contiguous ports — `7837` (production
 > daemon), `7838` (dev-daemon coexist via `IRRLICHT_DAEMON_PORT`/`BIND_ADDR`),
@@ -154,10 +207,10 @@ connection-status tooltip lists the connected daemon(s).
 
 ## Reserved (named, not built)
 
-- `auth` / bearer tokens, `token issue|list|revoke` CLI.
 - `seq` (per-source sequence numbers) and `resume` (reconnect cursor) for
   gap-free reconnection.
-- Multiple relays per daemon; multi-node relays; persistence; TLS.
+- `/api/v1/tokens` REST management (POST/DELETE); token management is CLI-only.
+- Multiple relays per daemon; multi-node relays; persistence.
 - Row-level source badges and "fade, don't delete" on daemon-offline (v0 deletes
   a disconnected daemon's rows).
 - History re-hydration of late-joining relay clients (bars fill from live ticks;

--- a/platforms/macos/Irrlicht/Managers/KeychainStore.swift
+++ b/platforms/macos/Irrlicht/Managers/KeychainStore.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Security
+
+/// A tiny generic-password Keychain wrapper for credential-grade secrets.
+///
+/// The relay bearer token lives here rather than in UserDefaults (which is the
+/// plist-on-disk, world-readable-within-the-sandbox store) — UserDefaults keeps
+/// only non-secret relay metadata (URL, enabled). Per the relay protocol doc:
+/// "macOS uses the Keychain; UserDefaults for metadata only."
+enum KeychainStore {
+    /// Service identifier namespacing irrlicht's Keychain items.
+    private static let service = "ai.irrlicht.relay"
+
+    /// Stores `value` for `account`, replacing any existing item. An empty
+    /// `value` deletes the item (so clearing the token field forgets it).
+    @discardableResult
+    static func set(_ value: String, account: String) -> Bool {
+        if value.isEmpty {
+            delete(account: account)
+            return true
+        }
+        guard let data = value.data(using: .utf8) else { return false }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        // Replace: delete-then-add keeps the call idempotent without juggling
+        // SecItemUpdate's attributes-vs-query split.
+        SecItemDelete(query as CFDictionary)
+        var attrs = query
+        attrs[kSecValueData as String] = data
+        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        return SecItemAdd(attrs as CFDictionary, nil) == errSecSuccess
+    }
+
+    /// Returns the stored secret for `account`, or "" when absent.
+    static func get(account: String) -> String {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        return value
+    }
+
+    /// Removes the stored secret for `account` (no-op if absent).
+    static func delete(account: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -332,6 +332,18 @@ class SessionManager: ObservableObject {
         }
     }
 
+    /// Called when the relay bearer token changes in Settings. The token lives
+    /// in the Keychain, not UserDefaults, so it never fires the didChangeNotification
+    /// that drives sourcesSettingsChanged — and after a 4401 the relay is parked
+    /// in .disconnected with reconnect disabled. Force a fresh connect with the
+    /// new credential so correcting the token recovers without an app restart.
+    func relayTokenDidChange() {
+        guard useRelayServer, !relayServerURL.isEmpty else { return }
+        stopRelay()
+        activeRelayURL = relayServerURL
+        startRelay()
+    }
+
     // MARK: - Relay WebSocket
 
     func startRelay() {
@@ -379,7 +391,13 @@ class SessionManager: ObservableObject {
 
         // Announce as a client so the relay streams enveloped frames. Harmless
         // if the URL actually points at a daemon (it ignores the frame).
-        try? await task.send(.string(#"{"type":"hello","protocol_version":1,"role":"client"}"#))
+        var hello: [String: Any] = ["type": "hello", "protocol_version": 1, "role": "client"]
+        let relayToken = KeychainStore.get(account: "relayToken")
+        if !relayToken.isEmpty { hello["token"] = relayToken }
+        if let helloData = try? JSONSerialization.data(withJSONObject: hello),
+           let helloStr = String(data: helloData, encoding: .utf8) {
+            try? await task.send(.string(helloStr))
+        }
 
         do {
             var confirmed = false
@@ -406,19 +424,29 @@ class SessionManager: ObservableObject {
             print("🔌 Relay disconnected: \(error.localizedDescription)")
         }
 
-        guard relayConnectionState != .disconnected && !Task.isCancelled else { return }
-        // While the link is down we no longer know the remote state, so drop
-        // the relay's daemons and sessions — otherwise a remote session that
-        // ended during the outage lingers as a ghost row (the relay's replay
-        // can only re-add survivors, never signal the deletions we missed).
-        // The relay's replay rebuilds the live set on reconnect; sessions also
-        // present locally stay (they live in sessionMap, which local wins).
+        // The link is down, so we no longer know the remote state: drop the
+        // relay's daemons and sessions in BOTH the reconnect and the auth-failed
+        // path — otherwise a remote session that ended during the outage lingers
+        // as a ghost row (the relay's replay can only re-add survivors, never
+        // signal the deletions we missed). The relay's replay rebuilds the live
+        // set on reconnect; sessions also present locally stay (they live in
+        // sessionMap, which local wins).
         relayDaemons.removeAll()
         if !relaySessionMap.isEmpty {
             relaySessionMap.removeAll()
             rebuildSessionsFromMap()
             recomposeApiGroups()
         }
+
+        // A 4401 close means the relay rejected or revoked our bearer token.
+        // Retrying with the same credential just loops, so stop reconnecting and
+        // wait for the user to fix the token (relayTokenDidChange restarts us).
+        if task.closeCode.rawValue == 4401 {
+            relayConnectionState = .disconnected
+            print("🔌 Relay auth failed (4401) — check the relay token in Settings; not reconnecting")
+            return
+        }
+        guard relayConnectionState != .disconnected && !Task.isCancelled else { return }
         let jitter = Double.random(in: 0...(relayReconnectDelay * 0.2))
         let delay = relayReconnectDelay + jitter
         relayConnectionState = .reconnecting

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -21,6 +21,9 @@ struct SettingsView: View {
     @AppStorage("relayServerURL") private var relayServerURL: String = ""
     @State private var relayURLDraft: String = ""
     @State private var relayURLDebounceTask: Task<Void, Never>? = nil
+    // Relay bearer token lives in the Keychain (not @AppStorage); this draft
+    // mirrors it for the field, loaded on appear and written on change.
+    @State private var relayTokenDraft: String = ""
     @State private var notificationsDenied = false
     @State private var customImportError: String?
 
@@ -124,9 +127,22 @@ struct SettingsView: View {
                                     .frame(width: 8, height: 8)
                                     .help(sessionManager.relayConnectionState.shortLabel)
                             }
+                            SecureField("Relay token (leave empty if the relay has no auth)", text: $relayTokenDraft)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(.caption, design: .monospaced))
+                                .autocorrectionDisabled(true)
+                                .onChange(of: relayTokenDraft) { newValue in
+                                    KeychainStore.set(newValue.trimmingCharacters(in: .whitespacesAndNewlines), account: "relayToken")
+                                    // Keychain writes don't fire UserDefaults.didChangeNotification,
+                                    // so nudge the relay to reconnect with the new token.
+                                    sessionManager.relayTokenDidChange()
+                                }
                         }
                     }
-                    .onAppear { relayURLDraft = relayServerURL }
+                    .onAppear {
+                        relayURLDraft = relayServerURL
+                        relayTokenDraft = KeychainStore.get(account: "relayToken")
+                    }
                     .onChange(of: useRelayServer) { on in
                         if on && relayURLDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                             relayURLDraft = "ws://localhost:7839"

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -72,6 +72,14 @@
         <input type="text" class="settings-text-input" data-setting="relayUrl"
                placeholder="ws://localhost:7839" spellcheck="false" autocomplete="off">
       </label>
+      <label class="settings-text-row">
+        <span class="settings-label-text">
+          <span class="settings-title">Relay token</span>
+          <span class="settings-hint">Only if the relay requires auth; leave empty otherwise.</span>
+        </span>
+        <input type="password" class="settings-text-input" data-setting="relayToken"
+               placeholder="bearer token" spellcheck="false" autocomplete="off">
+      </label>
 
       <h2>Provider quota</h2>
       <label>

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -125,10 +125,11 @@
       enableLocalSource: true,
       enableRelaySource: false,
       relayUrl: '',
+      relayToken: '',
     };
     // Settings keys that change the live source connections (vs. display-only
     // toggles), so the change handler knows to reconnect.
-    const SOURCE_SETTING_KEYS = new Set(['enableLocalSource', 'enableRelaySource', 'relayUrl']);
+    const SOURCE_SETTING_KEYS = new Set(['enableLocalSource', 'enableRelaySource', 'relayUrl', 'relayToken']);
     function loadSettings() {
       try {
         const raw = localStorage.getItem(SETTINGS_KEY);
@@ -1436,7 +1437,7 @@
       }
       if (settings.enableRelaySource) {
         const wsUrl = relayWsUrl(settings.relayUrl);
-        if (wsUrl) out.push({ id: 'relay:' + wsUrl, label: settings.relayUrl || 'Relay', kind: 'relay', wsUrl });
+        if (wsUrl) out.push({ id: 'relay:' + wsUrl, label: settings.relayUrl || 'Relay', kind: 'relay', wsUrl, token: settings.relayToken || '' });
       }
       return out;
     }
@@ -1449,7 +1450,14 @@
       const desired = desiredSources();
       const desiredById = new Map(desired.map(s => [s.id, s]));
       for (const [id, src] of [...sources]) {
-        if (!desiredById.has(id)) {
+        const want = desiredById.get(id);
+        // Drop a source that's no longer desired, OR a relay source whose token
+        // changed / is parked in 'unauthorized'. The source id is keyed by URL
+        // only, so without this a corrected token would never reconnect (the id
+        // still matches) and an auth-failed relay would stay stuck. Tearing it
+        // down here lets the loop below recreate it with the new credential.
+        const stale = want && src.kind === 'relay' && (src.token !== want.token || src.state === 'unauthorized');
+        if (!want || stale) {
           src.closing = true;
           try { if (src.ws) src.ws.close(); } catch (e) {}
           sources.delete(id);
@@ -1474,7 +1482,11 @@
       ws.onopen = function() {
         src.state = 'connected';
         src.reconnectDelay = 1000;
-        try { ws.send(JSON.stringify({ type: 'hello', protocol_version: 1, role: 'client' })); } catch (e) {}
+        // A browser can't set request headers on a WebSocket, so an auth-enabled
+        // relay's bearer token rides in this first frame (relay sources only).
+        const hello = { type: 'hello', protocol_version: 1, role: 'client' };
+        if (src.kind === 'relay' && settings.relayToken) hello.token = settings.relayToken;
+        try { ws.send(JSON.stringify(hello)); } catch (e) {}
         updateWsStatus();
       };
       ws.onmessage = function(evt) {
@@ -1483,10 +1495,13 @@
         handleSourceFrame(src, msg);
       };
       ws.onerror = function() {};
-      ws.onclose = function() {
+      ws.onclose = function(ev) {
         if (src.closing) return;
-        src.state = 'disconnected';
         src.daemons.clear();
+        // 4401 = auth failed/revoked: retrying with the same token just loops, so
+        // stop reconnecting (until settings change) instead of a tight loop.
+        if (ev && ev.code === 4401) { src.state = 'unauthorized'; updateWsStatus(); return; }
+        src.state = 'disconnected';
         updateWsStatus();
         scheduleReconnect(src);
       };


### PR DESCRIPTION
Closes #535. Work item **A — Secure exposure** of the relay v1 epic (#532): the blockers that must land before any non-loopback relay bind is recommended.

## What landed

### Server (`core/cmd/irrlichtrelay`)
- **Native TLS** via `serve --tls-cert <f> --tls-key <f>` (`ListenAndServeTLS`); reverse-proxy TLS termination stays documented as the recommended pattern.
- **Hashed bearer-token store** (`tokens.go`): `token issue|list|revoke`, SHA-256 at rest, mode-0600 file, mtime-poll live reload so `revoke` propagates without a restart.
- **Auth gate in the `hello` for both roles**; missing/invalid/revoked → WS close **4401**. Idle daemons are re-checked on the ping tick so a quiet revoked link still closes within one interval.
- **HTTP read endpoints** (`/api/v1/sessions`, `/agents`) get the same token gate when `--auth` is on (`Authorization: Bearer` or `?token=`); `/version` stays open as a health check.
- **`--origin-allowlist`** restricts browser `Origin`s; non-browser peers (no Origin) are admitted with auth still gating them.

### Wire + daemon
- `relay.Hello` gains `Token`; `relay.CloseRevoked = 4401`.
- Daemon presents a token via `IRRLICHT_RELAY_TOKEN` or `<data-dir>/relay-token.json` — a distinct filename from the relay's hashed `tokens.json` so a shared `$IRRLICHT_HOME` can't collide.

### Clients
- **macOS**: `KeychainStore` for the token (URL/enabled stay in UserDefaults); client hello carries it; a `4401` stops the reconnect storm and editing the token reconnects via `relayTokenDidChange()`.
- **web**: `relayToken` setting + password field; token in the hello; `4401` → `unauthorized` state, and `rebuildSources` reconnects on a token change.

## Acceptance
- Relay exposable on a non-loopback address only with `--auth` (or the documented reverse-proxy path); traffic encryptable via TLS/`wss://`; origin allowlisted; revoked tokens closed with `4401`.
- `--auth off` (default) keeps every existing loopback deployment working unchanged.
- `go test ./core/... -race -count=1` green; `swift build` green.

## Tests
`tokens` (issue/validate/revoke, hash-at-rest, 0600), hub auth (accept/reject/revoke-4401, origin allow/deny), HTTP token gate, forwarder token. `docs/relay-protocol.md` updated (auth/token CLI moved out of Reserved; TLS + origin sections added).

## Review
Ran a high-effort multi-agent review and fixed all confirmed findings before this PR — notably the HTTP-endpoint auth bypass, the TLS-suppressed exposure warning, the `tokens.json` filename collision, idle-daemon revoke, an `mtime` data race, and the macOS/web 4401-recovery paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)