### PR TITLE
feat(relay): v1 epic — compound keying, origin glyph, deploy artifacts, fade, coding-factory demo (#537–#541)

### DIFF
--- a/core/cmd/irrlichtrelay/hub.go
+++ b/core/cmd/irrlichtrelay/hub.go
@@ -320,17 +320,18 @@ func (h *hub) daemonDisconnected(id string) {
 		h.mu.Unlock()
 		return // another live connection for this daemon remains
 	}
-	sessions := h.sessions[id]
 	delete(h.daemons, id)
 	delete(h.sessions, id)
 	delete(h.agents, id)
 	h.mu.Unlock()
 
-	// v0 deletes the daemon's rows on disconnect ("fade don't delete" is a
-	// deferred enhancement), then announces the disconnect for the tooltip.
-	for _, s := range sessions {
-		h.fanoutPush(id, outbound.PushMessage{Type: outbound.PushTypeDeleted, Session: s})
-	}
+	// Announce the disconnect and let clients decide how to present the now-
+	// orphaned rows (#540 "fade, don't delete"): the relay no longer fans out a
+	// session_deleted per session, so a flapping link doesn't yank rows out from
+	// under a client. macOS fades them and restores on reconnect; the web
+	// dashboard drops them. The cache is still evicted, so /api/v1/sessions and
+	// any late-joining client reflect only live daemons, and a reconnect
+	// reconciles via a fresh daemon_snapshot.
 	h.broadcastDaemonStatus(id, label, relay.StatusDisconnected, now)
 }
 

--- a/core/cmd/irrlichtrelay/hub_test.go
+++ b/core/cmd/irrlichtrelay/hub_test.go
@@ -201,7 +201,7 @@ func TestRelayReplaysCacheToLateClient(t *testing.T) {
 	}
 }
 
-func TestRelayDaemonDisconnectDeletesSessions(t *testing.T) {
+func TestRelayDaemonDisconnectKeepsRowsClientSide(t *testing.T) {
 	wsURL, baseURL := newTestServer(t)
 
 	client := dial(t, wsURL)
@@ -236,12 +236,13 @@ func TestRelayDaemonDisconnectDeletesSessions(t *testing.T) {
 		t.Fatalf("expected s1 cached before disconnect, got %s", body)
 	}
 
-	// Daemon drops → the relay must fan out a session_deleted for its cached
-	// session and a disconnected status, and evict the session from the cache.
+	// Daemon drops → the relay announces the disconnect but must NOT fan out a
+	// session_deleted (#540 "fade, don't delete"): clients keep the rows and
+	// decide how to present them. The cache is still evicted.
 	daemon.Close()
-	sawDelete, sawDisconnect := false, false
+	sawDisconnect := false
 	deadline := time.Now().Add(2 * time.Second)
-	for (!sawDelete || !sawDisconnect) && time.Now().Before(deadline) {
+	for !sawDisconnect && time.Now().Before(deadline) {
 		client.SetReadDeadline(time.Now().Add(2 * time.Second))
 		_, data, err := client.ReadMessage()
 		if err != nil {
@@ -252,7 +253,7 @@ func TestRelayDaemonDisconnectDeletesSessions(t *testing.T) {
 			var p relay.Push
 			mustJSON(t, data, &p)
 			if p.Msg.Type == outbound.PushTypeDeleted && p.Msg.Session != nil && p.Msg.Session.SessionID == "s1" {
-				sawDelete = true
+				t.Fatal("unexpected session_deleted on disconnect — rows must fade, not delete (#540)")
 			}
 		case relay.MsgDaemonStatus:
 			var ds relay.DaemonStatus
@@ -261,9 +262,6 @@ func TestRelayDaemonDisconnectDeletesSessions(t *testing.T) {
 				sawDisconnect = true
 			}
 		}
-	}
-	if !sawDelete {
-		t.Fatal("no session_deleted push for the disconnected daemon's session")
 	}
 	if !sawDisconnect {
 		t.Fatal("no daemon disconnect status")

--- a/examples/coding-factory/.env.example
+++ b/examples/coding-factory/.env.example
@@ -1,0 +1,12 @@
+# Copy to .env (./up.sh does this for you) and fill in.
+
+# Required: an OpenAI API key for codex. Set up out-of-band — no cost gate here;
+# use a small/cheap model to keep the demo inexpensive.
+OPENAI_API_KEY=
+
+# The codex model the agents run. Set to a small/cheap model your account has.
+CODEX_MODEL=gpt-4o-mini
+
+# Bearer token for the auth-enabled relay. ./up.sh issues one and writes it here;
+# all three agents share it. (The relay tracks them apart by daemon_id, not token.)
+IRRLICHT_RELAY_TOKEN=

--- a/examples/coding-factory/README.md
+++ b/examples/coding-factory/README.md
@@ -1,0 +1,92 @@
+# Coding factory — 3× codex over an authenticated relay
+
+A multi-agent testbed: **three** containers, each running the OpenAI **codex**
+CLI driven via **tmux**, with a co-located [`irrlichd`](../../docs/relay-protocol.md)
+that forwards **out** to **one auth-enabled** [`irrlichtrelay`](../relay/). All
+three surface live on the macOS app and the web dashboard as **three distinct
+rows** — exercising the relay's bearer-token auth, multi-daemon fan-in,
+compound `(daemon_id, session_id)` keying, and the remote-origin glyph in one
+demo. Builds on the single-agent [`../roundtrip/`](../roundtrip/) (1× claude).
+
+```
+  codex-1  ─ irrlichd ─┐
+  codex-2  ─ irrlichd ─┼─ ws push (Bearer token) ─▶  irrlichtrelay :7839  ◀─ macOS app / browser
+  codex-3  ─ irrlichd ─┘        (internal network)     (auth on, loopback)      (token in Settings)
+```
+
+Each agent dials *out*, so this works through NAT; only the relay needs a
+reachable port. Each container mints its **own** `daemon_id`, so the three never
+collapse into one row.
+
+## Run
+
+You need an `OPENAI_API_KEY` (set up out-of-band — use a small/cheap model to
+keep it inexpensive). The one-command bootstrap brings up the relay, issues a
+bearer token, and starts the three agents sharing it:
+
+```bash
+cd examples/coding-factory
+OPENAI_API_KEY=sk-... ./up.sh        # or put OPENAI_API_KEY in .env first
+```
+
+Then on the **Mac** (Settings → Sources) or **web**, add the relay as a source
+with the token `up.sh` printed:
+
+```
+Relay URL:  ws://localhost:7839
+Token:      <printed by up.sh>
+```
+
+…or just open the relay-served dashboard at **http://localhost:7839** (it will
+prompt for the token).
+
+### Manual bootstrap (what `up.sh` automates)
+
+```bash
+cp .env.example .env && $EDITOR .env          # set OPENAI_API_KEY (+ optional CODEX_MODEL)
+docker compose -f docker-compose.yml up -d --build relay
+docker compose -f docker-compose.yml exec relay \
+  sh -c 'IRRLICHT_HOME=/var/lib/irrlichtrelay irrlichtrelay token issue --label coding-factory'
+# copy the printed token into IRRLICHT_RELAY_TOKEN in .env, then:
+docker compose -f docker-compose.yml up -d --build codex-1 codex-2 codex-3
+```
+
+## What you should see
+
+- **Three rows** labelled `codex-1`, `codex-2`, `codex-3`, each with the **cloud
+  origin glyph** (they arrived over the relay, not a local socket), cycling
+  **working → ready** as the tmux auto-driver feeds each codex a small task on a
+  loop. The connection-status tooltip lists the three connected daemons.
+- A `waiting` dip if codex holds for a tool-use approval (the `curl`
+  PermissionRequest hook, #488 — `curl` ships in the image).
+- **Kill one agent** (`docker compose … stop codex-2`) → its rows **fade** in
+  place rather than vanishing (#540); they restore when you start it again.
+
+### Drive one by hand
+
+The agents auto-drive, but you can attach and take over any codex TUI:
+
+```bash
+docker compose -f docker-compose.yml exec -it codex-1 tmux attach -t codex
+```
+
+## Notes
+
+- **Auth is on.** The relay runs `--auth tokens-file`; the agents present the
+  token via `IRRLICHT_RELAY_TOKEN`. `token revoke <id>` takes effect within ~2s
+  without a restart. To expose the dashboard beyond loopback, front it with TLS
+  — see [`../relay/DEPLOY.md`](../relay/DEPLOY.md).
+- **Fresh identity per agent.** Agent state is ephemeral (no volume) and the
+  entrypoint deletes `relay-identity.json`, so every container mints a new
+  `daemon_id` → three distinct daemons. Never bake an already-connected
+  daemon's identity into an image (the cloned-VM gotcha — `DEPLOY.md`).
+- **Cheap model.** Set `CODEX_MODEL` in `.env` to a small model your account
+  has; the agents write it to `~/.codex/config.toml` at start.
+- **`down` vs `down -v`.** `down` keeps the relay's token volume; `down -v`
+  wipes it (you'll re-issue a token next `up`).
+- **Baked dashboard.** The relay image bakes a snapshot of `platforms/web/`;
+  dashboard edits need an image rebuild (`--build`).
+
+→ Simpler single-agent demo: [`../roundtrip/`](../roundtrip/) ·
+Protocol reference: [`../../docs/relay-protocol.md`](../../docs/relay-protocol.md) ·
+Deploy/ops: [`../relay/DEPLOY.md`](../relay/DEPLOY.md)

--- a/examples/coding-factory/agent.Dockerfile
+++ b/examples/coding-factory/agent.Dockerfile
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1
+#
+# Coding-factory agent image: a Linux irrlichd co-located with the OpenAI Codex
+# CLI in one container. The daemon observes `codex` via /proc + pidfd (same PID
+# namespace) and reads ~/.codex/sessions on the same filesystem; it forwards OUT
+# to an auth-enabled relay (IRRLICHT_RELAY_URL + IRRLICHT_RELAY_TOKEN). A tmux
+# auto-driver (drive.sh) feeds codex small tasks so the row cycles live without
+# a human. Mirrors examples/roundtrip/ (which does the same for claude).
+#
+# Build context is the REPO ROOT (compose sets `context: ../..`).
+ARG GO_VERSION=1.25
+ARG NODE_VERSION=22
+ARG VERSION=docker
+
+# ---- builder: compile a static Linux irrlichd ----
+FROM golang:${GO_VERSION}-bookworm AS build
+ARG VERSION
+ENV CGO_ENABLED=0
+WORKDIR /src/core
+COPY core/ ./
+RUN go build -trimpath -ldflags "-X main.Version=${VERSION}" \
+    -o /out/irrlichd ./cmd/irrlichd
+
+# ---- runtime: Node (Codex CLI) + the daemon, run as a non-root user ----
+FROM node:${NODE_VERSION}-bookworm-slim AS runtime
+# git: the scratch repo codex edits. tini: PID-1 reaper/signals. procps: debug.
+# tmux + jq: the auto-driver drives codex's TUI via tmux and watches the rollout
+# for `task_complete` with jq. curl: REQUIRED — the daemon's auto-installed hook
+# POSTs via `curl … || true`; without it the hook silently no-ops and tool-use
+# permission prompts never surface as `waiting` (#488).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates git tini procps curl tmux jq \
+    && rm -rf /var/lib/apt/lists/*
+# OpenAI Codex CLI (the real agent this testbed observes).
+RUN npm install -g @openai/codex
+
+# Non-root `agent` — both codex and irrlichd run as this user, sharing $HOME so
+# the daemon can read codex's transcripts under ~/.codex/sessions.
+RUN useradd --create-home --shell /bin/bash agent
+COPY --from=build /out/irrlichd /usr/local/bin/irrlichd
+COPY examples/coding-factory/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY examples/coding-factory/drive.sh /usr/local/bin/drive.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/drive.sh
+
+USER agent
+ENV HOME=/home/agent
+# Seed a throwaway git repo for codex to operate on. Baked into the image (not a
+# volume) so every container starts fresh. Codex launches here, so the session
+# shows up under the project name "work".
+RUN git config --global user.email "agent@coding-factory" \
+    && git config --global user.name "agent" \
+    && git config --global init.defaultBranch main \
+    && mkdir -p /home/agent/work \
+    && cd /home/agent/work \
+    && git init -q \
+    && printf '# scratch\n\nA throwaway repo for the irrlicht coding-factory demo.\n' > README.md \
+    && git add -A \
+    && git commit -qm "seed scratch repo"
+WORKDIR /home/agent/work
+
+# Agent state is intentionally NOT a volume: each container mints a FRESH
+# relay-identity.json on start, so the three agents show as three distinct
+# daemons/rows (#539/item E — cloned images that share an identity collapse into
+# one). The entrypoint also rm's it defensively.
+RUN mkdir -p /home/agent/.local/share/irrlicht /home/agent/.codex
+
+# Defaults; overridden by compose. Loopback daemon bind (127.0.0.1:7837) is fine.
+ENV IRRLICHT_RELAY_URL=ws://relay:7839
+ENV CODEX_MODEL=gpt-4o-mini
+ENTRYPOINT ["tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/examples/coding-factory/docker-compose.yml
+++ b/examples/coding-factory/docker-compose.yml
@@ -1,0 +1,57 @@
+# Coding factory: 3× codex agents, each = irrlichd + codex co-located, all
+# forwarding into ONE auth-enabled irrlichtrelay, surfaced live on macOS/web as
+# three distinct rows. Builds on examples/roundtrip/ (1× claude).
+#
+# Quickstart:  ./up.sh        (brings up the relay, issues a token, starts the 3)
+# Manual:      see README.md.  Needs OPENAI_API_KEY (set in .env).
+name: irrlicht-coding-factory
+
+services:
+  # The hub, with bearer-token auth on. Loopback-published for the host
+  # dashboard; the agents reach it over the internal docker network.
+  relay:
+    build:
+      context: ../..
+      dockerfile: examples/relay/Dockerfile
+    image: irrlicht-relay
+    environment:
+      IRRLICHT_HOME: /var/lib/irrlichtrelay
+    command: ["irrlichtrelay", "serve", "--addr", "0.0.0.0:7839", "--auth", "tokens-file"]
+    ports:
+      - "127.0.0.1:7839:7839"
+    volumes:
+      - relay-state:/var/lib/irrlichtrelay      # persists tokens.json across restarts
+
+  codex-1:
+    <<: &agent
+      build:
+        context: ../..
+        dockerfile: examples/coding-factory/agent.Dockerfile
+      image: irrlicht-coding-factory-agent
+      depends_on: [relay]                       # start ordering; the daemon's backoff handles readiness
+      restart: unless-stopped
+    hostname: codex-1                           # → the daemon label / row name on the Mac
+    environment:
+      <<: &agent-env
+        IRRLICHT_RELAY_URL: ws://relay:7839
+        IRRLICHT_RELAY_TOKEN: ${IRRLICHT_RELAY_TOKEN:?run ./up.sh, or set IRRLICHT_RELAY_TOKEN in .env}
+        OPENAI_API_KEY: ${OPENAI_API_KEY:?set OPENAI_API_KEY in .env}
+        CODEX_MODEL: ${CODEX_MODEL:-gpt-4o-mini}
+      AGENT_TASK: "Add a short, helpful comment to README.md and commit it."
+
+  codex-2:
+    <<: *agent
+    hostname: codex-2
+    environment:
+      <<: *agent-env
+      AGENT_TASK: "Create a small utility function in util.py with a docstring, then commit."
+
+  codex-3:
+    <<: *agent
+    hostname: codex-3
+    environment:
+      <<: *agent-env
+      AGENT_TASK: "Append a dated entry to CHANGELOG.md and commit."
+
+volumes:
+  relay-state:

--- a/examples/coding-factory/drive.sh
+++ b/examples/coding-factory/drive.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Coding-factory tmux auto-driver: launch codex in a tmux session and feed it a
+# small task on a loop, so the agent's row cycles working→ready live without a
+# human. The cadence (trust dialog, boot waits, type→pause→Enter, task_complete
+# turn detection) mirrors the project's proven codex driver
+# (.claude/skills/ir:onboard-agent/scripts/drive-codex-interactive.sh).
+#
+# Attach to watch/take over:  docker compose exec -it <svc> tmux attach -t codex
+set -euo pipefail
+
+SESSION="codex"
+CWD="$HOME/work"
+LOG="$HOME/codex.pane.log"
+TASK="${AGENT_TASK:-Make a small improvement to README.md and commit it.}"
+SESSIONS_DIR="${CODEX_HOME:-$HOME/.codex}/sessions"
+
+# --no-alt-screen keeps codex inline so tmux pipe-pane can capture it (alt-screen
+# would clear the pane and hide the banner/trust prompt).
+tmux new-session -d -s "$SESSION" -c "$CWD" codex --no-alt-screen
+tmux pipe-pane -t "$SESSION" -o "cat >> '$LOG'"
+
+# Accept the one-time "Do you trust the contents of this directory?" prompt
+# (poll the LIVE pane — it can render before pipe-pane flushes to the log).
+for _ in $(seq 1 60); do
+  if tmux capture-pane -t "$SESSION" -p -S -40 2>/dev/null | grep -q 'Do you trust'; then
+    tmux send-keys -t "$SESSION" "1"
+    sleep 0.3
+    tmux send-keys -t "$SESSION" Enter
+    echo "[drive] accepted trust dialog" >&2
+    break
+  fi
+  sleep 1
+done
+
+# Wait for the "OpenAI Codex" banner, then for the "Booting MCP" phase to clear
+# (keystrokes typed during boot have their Enter silently swallowed).
+for _ in $(seq 1 120); do grep -aq 'OpenAI Codex' "$LOG" 2>/dev/null && break; sleep 1; done
+for _ in $(seq 1 60); do
+  tmux capture-pane -t "$SESSION" -p -S -20 2>/dev/null | grep -q 'Booting MCP' || break
+  sleep 1
+done
+echo "[drive] codex booted — starting task loop" >&2
+
+# Count completed turns across the session's rollout(s): the canonical turn-done
+# signal is event_msg/task_complete.
+turns() {
+  find "$SESSIONS_DIR" -name 'rollout-*.jsonl' -exec cat {} + 2>/dev/null \
+    | jq -r 'select(.type=="event_msg" and .payload.type=="task_complete") | "x"' 2>/dev/null \
+    | wc -l | tr -d ' '
+}
+
+# Coding-factory loop: send the task, wait for the turn to complete, let the row
+# settle to `ready` so it's visible, then go again.
+while true; do
+  before="$(turns)"
+  tmux send-keys -t "$SESSION" -l -- "$TASK"
+  sleep 0.3                                   # let the text land before Enter (Ink input race)
+  tmux send-keys -t "$SESSION" Enter
+  echo "[drive] sent task; waiting for turn to complete" >&2
+  for _ in $(seq 1 180); do
+    [ "$(turns)" -gt "$before" ] && break
+    sleep 1
+  done
+  sleep 20                                    # dwell on `ready` before the next task
+done

--- a/examples/coding-factory/entrypoint.sh
+++ b/examples/coding-factory/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Coding-factory agent entrypoint: give this container a fresh relay identity,
+# point codex at a small model, start irrlichd in the background (logging to the
+# container's stdout), then hand off to the tmux auto-driver.
+set -euo pipefail
+
+state_dir="${IRRLICHT_HOME:-$HOME/.local/share/irrlicht}"
+
+# Fresh daemon_id per container so the three agents are three distinct rows on
+# the Mac/web — never share relay-identity.json across replicas (#539/item E).
+rm -f "$state_dir/relay-identity.json"
+
+# Codex reads its model from ~/.codex/config.toml; auth rides OPENAI_API_KEY
+# from the environment (no key on disk).
+mkdir -p "$HOME/.codex"
+printf 'model = "%s"\n' "${CODEX_MODEL:-gpt-4o-mini}" > "$HOME/.codex/config.toml"
+
+echo "[entrypoint] irrlichd → ${IRRLICHT_RELAY_URL:-<unset>} (token: ${IRRLICHT_RELAY_TOKEN:+set}, model: ${CODEX_MODEL:-gpt-4o-mini})"
+irrlichd &
+daemon=$!
+
+# If the daemon dies, say so on stderr instead of failing silently — otherwise
+# "nothing shows up on the Mac" is undebuggable.
+(
+  while kill -0 "$daemon" 2>/dev/null; do sleep 5; done
+  echo "[entrypoint] WARNING: irrlichd exited — container still up for debugging" >&2
+) &
+
+# Drive codex in tmux (keeps the container alive; attach with
+# `docker compose exec -it <svc> tmux attach -t codex`).
+exec /usr/local/bin/drive.sh

--- a/examples/coding-factory/up.sh
+++ b/examples/coding-factory/up.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# One-command bootstrap for the coding-factory demo: bring up the auth-enabled
+# relay, mint a bearer token, then start the three codex agents sharing it.
+#
+#   OPENAI_API_KEY=sk-... ./up.sh
+#   # ...or put OPENAI_API_KEY in .env first.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+compose() { docker compose -f docker-compose.yml "$@"; }
+
+[ -f .env ] || cp .env.example .env
+
+# OPENAI_API_KEY may come from the environment or .env; make sure it's in .env so
+# compose (which reads .env) sees it.
+if ! grep -q '^OPENAI_API_KEY=.\+' .env; then
+  if [ -n "${OPENAI_API_KEY:-}" ]; then
+    grep -v '^OPENAI_API_KEY=' .env > .env.tmp || true
+    { cat .env.tmp; echo "OPENAI_API_KEY=$OPENAI_API_KEY"; } > .env
+    rm -f .env.tmp
+  else
+    echo "error: set OPENAI_API_KEY (in the environment or .env) — codex needs it." >&2
+    exit 1
+  fi
+fi
+
+echo "[up] starting the relay…"
+# A placeholder token lets compose interpolate while we bring up only the relay.
+IRRLICHT_RELAY_TOKEN=bootstrap compose up -d --build relay
+
+echo "[up] issuing a bearer token…"
+issue="$(compose exec -T relay sh -c \
+  'IRRLICHT_HOME=/var/lib/irrlichtrelay irrlichtrelay token issue --label coding-factory')"
+# The plaintext token is the indented second line of the issue output.
+token="$(printf '%s\n' "$issue" | awk 'NR==2 {print $1}')"
+if [ -z "$token" ]; then
+  echo "error: could not parse the issued token from:" >&2
+  printf '%s\n' "$issue" >&2
+  exit 1
+fi
+
+# Persist the token into .env for the agents (and future `docker compose` runs).
+grep -v '^IRRLICHT_RELAY_TOKEN=' .env > .env.tmp || true
+{ cat .env.tmp; echo "IRRLICHT_RELAY_TOKEN=$token"; } > .env
+rm -f .env.tmp
+
+echo "[up] starting the 3 codex agents…"
+compose up -d --build codex-1 codex-2 codex-3
+
+cat <<EOF
+
+[up] coding factory is up.
+     Dashboard:  http://localhost:7839
+     Relay URL:  ws://localhost:7839     (add as a Source on macOS/web)
+     Token:      $token
+
+Watch three rows — codex-1, codex-2, codex-3 — appear with the remote (cloud)
+origin glyph, cycling working→ready over the authenticated relay. Attach to one:
+     docker compose -f examples/coding-factory/docker-compose.yml exec -it codex-1 tmux attach -t codex
+EOF

--- a/examples/relay/DEPLOY.md
+++ b/examples/relay/DEPLOY.md
@@ -1,0 +1,172 @@
+# Deploying `irrlichtrelay`
+
+Operator guide for running the standalone [`irrlichtrelay`](../../docs/relay-protocol.md) hub in
+production — auth, TLS, systemd, and the cloned-replica gotcha. For the wire protocol itself, see
+[`docs/relay-protocol.md`](../../docs/relay-protocol.md); for a one-command Docker run, the sibling
+[`README.md`](./README.md).
+
+```
+  irrlichd ──ws push──▶  reverse proxy (wss://, TLS)  ──▶  irrlichtrelay :7839 (loopback)
+ (any host, NAT-ok)                                              ▲
+                                          macOS app / browser ───┘  read (Bearer token)
+```
+
+Daemons dial **out** to the relay, so only the relay needs a reachable port; the daemon side works
+through NAT with no inbound port.
+
+## Build the binary
+
+Built from source — there is no published release yet:
+
+```bash
+cd core
+go build -trimpath -ldflags "-X main.Version=$(git describe --tags --always)" \
+  -o /usr/local/bin/irrlichtrelay ./cmd/irrlichtrelay
+irrlichtrelay --version
+```
+
+Or run it in a container — see [`README.md`](./README.md) / [`Dockerfile`](./Dockerfile).
+
+## Two postures
+
+| | Trusted-LAN / dev | Production (exposed) |
+|---|---|---|
+| Bind | `127.0.0.1:7839` (default) | routable, behind TLS |
+| Auth | `--auth off` (default) | `--auth tokens-file` |
+| TLS | none (http/ws) | reverse proxy **or** `--tls-cert`/`--tls-key` |
+
+```bash
+irrlichtrelay serve                                   # trusted-LAN: loopback, no auth
+irrlichtrelay serve --addr 127.0.0.1:7839 --auth tokens-file   # production, behind a TLS proxy
+```
+
+> ⚠️ A non-loopback bind **without `--auth` is wide open** — anyone who can reach it reads every session
+> and can inject as a daemon. **TLS encrypts the wire but does not authenticate the peer**, so always pair
+> exposure with `--auth`. The relay logs a loud warning if you bind a routable address with no auth.
+
+## Bearer tokens
+
+With `--auth tokens-file`, the relay verifies a hashed bearer token. Tokens live in
+`$IRRLICHT_HOME/tokens.json` (mode `0600`, hashes only — plaintext is shown once) and are managed with the
+`token` subcommand. Run it **as the same user/`IRRLICHT_HOME`** the relay uses, so both read one file:
+
+```bash
+export IRRLICHT_HOME=/var/lib/irrlichtrelay
+irrlichtrelay token issue --label "ingo-laptop"   # prints the secret ONCE — store it now
+irrlichtrelay token list                          # id  created  label
+irrlichtrelay token revoke <id>                   # peer's next frame closes with WS 4401
+```
+
+The running relay polls the file every ~2s, so `issue`/`revoke` take effect **without a restart**.
+
+Each daemon and client then presents the token:
+
+- **daemon** (`irrlichd`): `IRRLICHT_RELAY_TOKEN=<token>` env, or `<dataDir>/relay-token.json`
+  (`{"token":"…"}`, mode `0600`).
+- **macOS / web**: enter it under **Settings → Sources** next to the relay URL.
+
+## TLS
+
+### Reverse-proxy termination (recommended)
+
+Keep the relay on loopback and let a proxy terminate TLS and forward the WebSocket upgrade.
+
+**nginx:**
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name relay.example.com;
+    ssl_certificate     /etc/letsencrypt/live/relay.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/relay.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:7839;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;   # required for the WS upgrade
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host       $host;
+        proxy_read_timeout 1h;                        # keep idle session streams open
+    }
+}
+```
+
+**Caddy** (auto-TLS):
+
+```caddy
+relay.example.com {
+    reverse_proxy 127.0.0.1:7839
+}
+```
+
+Daemons/clients then use `wss://relay.example.com` (the proxy handles `:443`).
+
+### Native TLS
+
+Skip the proxy and serve `wss://` directly — both flags are required together (still keep `--auth`):
+
+```bash
+irrlichtrelay serve --addr 0.0.0.0:7839 --auth tokens-file \
+  --tls-cert /etc/irrlichtrelay/cert.pem --tls-key /etc/irrlichtrelay/key.pem
+```
+
+### Browser origin allowlist
+
+For browser WS clients on a public origin, restrict who may connect:
+
+```bash
+irrlichtrelay serve … --origin-allowlist relay.example.com,dash.example.com
+```
+
+Empty (default) allows all origins — fine for loopback, not for a public bind.
+
+## systemd
+
+A ready-to-edit unit ships at [`irrlichtrelay.service`](./irrlichtrelay.service) (binds loopback + auth;
+front it with one of the TLS proxies above). Install:
+
+```bash
+# binary at /usr/local/bin/irrlichtrelay (see "Build the binary")
+useradd --system --no-create-home --home /var/lib/irrlichtrelay irrlichtrelay
+cp examples/relay/irrlichtrelay.service /etc/systemd/system/
+
+install -d -o irrlichtrelay -g irrlichtrelay /var/lib/irrlichtrelay
+sudo -u irrlichtrelay IRRLICHT_HOME=/var/lib/irrlichtrelay \
+  irrlichtrelay token issue --label "first-daemon"
+
+systemctl daemon-reload
+systemctl enable --now irrlichtrelay
+journalctl -u irrlichtrelay -f
+```
+
+The unit sets `StateDirectory=irrlichtrelay` (`/var/lib/irrlichtrelay`) and `IRRLICHT_HOME` to match, so
+`tokens.json` persists and the `token` CLI (run as `irrlichtrelay`) and the service share one file.
+
+## Cloned VMs / replicas: `relay-identity.json` collision
+
+This is the most common multi-instance footgun, and it concerns the **daemons that forward in**, not the
+relay host.
+
+Each daemon mints a stable `daemon_id` (a UUID) **once** and persists it at
+`$IRRLICHT_HOME/relay-identity.json` (default `~/.local/share/irrlicht/relay-identity.json`). The relay
+keys daemons by that id. If you build a VM/container image with a daemon that has **already connected
+once**, every clone ships the **same** `relay-identity.json` → every replica announces the **same
+`daemon_id`** → the relay merges them all into **one** daemon, and their sessions clobber each other.
+
+**Fix — give each replica a fresh identity before its first relay connect:**
+
+```bash
+rm -f "${IRRLICHT_HOME:-$HOME/.local/share/irrlicht}/relay-identity.json"
+```
+
+The daemon mints a new UUID on next start. Do this in the image's first-boot hook (cloud-init, an
+ENTRYPOINT step, a `systemd` `ExecStartPre`, etc.), or simply **never bake a daemon that has already run**
+into the golden image. Critical for any autoscaled or multi-container deploy (and for the cross-host demo
+in [`../roundtrip/`](../roundtrip/)).
+
+---
+
+→ Protocol reference: [`docs/relay-protocol.md`](../../docs/relay-protocol.md)
+([Auth, TLS, and origins](../../docs/relay-protocol.md#auth-tls-and-origins)) ·
+Live cross-host demo: [`../roundtrip/`](../roundtrip/) ·
+One-command Docker run: [`README.md`](./README.md)

--- a/examples/relay/Dockerfile
+++ b/examples/relay/Dockerfile
@@ -32,6 +32,8 @@ COPY platforms/web/index.html platforms/web/irrlicht.css platforms/web/irrlicht.
 ENV IRRLICHT_UI_DIR=/web
 EXPOSE 7839
 # Bind 0.0.0.0 (NOT the loopback default) so the published port is reachable
-# from outside the container. v0 relay has no auth/TLS — only publish it to a
-# trusted host loopback.
+# from outside the container; the compose file publishes it on the host
+# loopback. Auth/TLS are OFF here — fine for a trusted host. Before exposing on
+# a LAN/the internet, add `--auth tokens-file` and front it with TLS (or
+# `--tls-cert`/`--tls-key`); see DEPLOY.md.
 CMD ["irrlichtrelay", "serve", "--addr", "0.0.0.0:7839"]

--- a/examples/relay/README.md
+++ b/examples/relay/README.md
@@ -28,8 +28,19 @@ IRRLICHT_RELAY_URL=ws://<relay-host>:7839 irrlichd
 
 ## Notes
 
-- **No auth, no TLS** (relay v0). Publish `7839` only to a trusted host
-  loopback, or front it with your own TLS-terminating proxy.
+- **Auth & TLS are off by default** — fine for this loopback-published demo. To
+  expose the relay, enable a bearer token and front it with TLS:
+
+  ```bash
+  docker compose -f examples/relay/docker-compose.yml exec relay \
+    irrlichtrelay token issue --label laptop      # secret shown once
+  ```
+
+  then uncomment the `--auth tokens-file` block in `docker-compose.yml` and put
+  a TLS-terminating proxy in front. Full recipes (auth, TLS, systemd, the
+  cloned-VM identity gotcha) → **[DEPLOY.md](./DEPLOY.md)**.
+- For a non-container deploy, a system unit ships at
+  [`irrlichtrelay.service`](./irrlichtrelay.service).
 - The image **bakes a snapshot** of `platforms/web/`. Dashboard edits need an
   image rebuild (`--build`) — unlike the daemon, which serves the dashboard
   live from disk.

--- a/examples/relay/docker-compose.yml
+++ b/examples/relay/docker-compose.yml
@@ -12,6 +12,21 @@ services:
       dockerfile: examples/relay/Dockerfile
     image: irrlicht-relay
     ports:
-      # Loopback-only: v0 relay is no-auth/no-TLS, so don't expose it on the LAN.
+      # Loopback-only by default: auth/TLS are off, so don't expose this on the
+      # LAN as-is. To expose it, enable auth (below) + front it with TLS and
+      # publish "7839:7839". See DEPLOY.md.
       - "127.0.0.1:7839:7839"
     restart: unless-stopped
+    # --- Optional: bearer-token auth ---------------------------------------
+    # Persist tokens across rebuilds and turn on auth, then issue a token into
+    # the same volume the relay reads:
+    #   docker compose -f examples/relay/docker-compose.yml exec relay \
+    #     irrlichtrelay token issue --label laptop      # prints the secret once
+    # Daemons present it via IRRLICHT_RELAY_TOKEN; clients in Settings → Sources.
+    # environment:
+    #   IRRLICHT_HOME: /var/lib/irrlichtrelay
+    # command: ["irrlichtrelay", "serve", "--addr", "0.0.0.0:7839", "--auth", "tokens-file"]
+    # volumes:
+    #   - relay-state:/var/lib/irrlichtrelay
+# volumes:
+#   relay-state:

--- a/examples/relay/irrlichtrelay.service
+++ b/examples/relay/irrlichtrelay.service
@@ -1,0 +1,57 @@
+# systemd unit for the standalone irrlichtrelay hub (issue #539).
+#
+# Install (run as root):
+#   1. Build/copy the binary to /usr/local/bin/irrlichtrelay
+#        (cd core && go build -trimpath -ldflags "-X main.Version=$(git describe --tags --always)" \
+#           -o /usr/local/bin/irrlichtrelay ./cmd/irrlichtrelay)
+#   2. Create the service user (StateDirectory needs it to exist):
+#        useradd --system --no-create-home --home /var/lib/irrlichtrelay irrlichtrelay
+#   3. Install this file:  cp examples/relay/irrlichtrelay.service /etc/systemd/system/
+#   4. Issue a bearer token (as the service user, into the shared state dir):
+#        install -d -o irrlichtrelay -g irrlichtrelay /var/lib/irrlichtrelay
+#        sudo -u irrlichtrelay IRRLICHT_HOME=/var/lib/irrlichtrelay \
+#          irrlichtrelay token issue --label "first-daemon"
+#   5. systemctl daemon-reload && systemctl enable --now irrlichtrelay
+#        journalctl -u irrlichtrelay -f
+#
+# This binds loopback + bearer-token auth — the secure default. Terminate TLS in
+# a reverse proxy in front (see DEPLOY.md), or swap ExecStart for the native-TLS
+# variant below. `token revoke <id>` takes effect within ~2s without a restart.
+
+[Unit]
+Description=Irrlicht relay — cross-host session hub
+Documentation=https://github.com/ingo-eichhorst/Irrlicht/blob/main/examples/relay/DEPLOY.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=irrlichtrelay
+Group=irrlichtrelay
+# Creates + owns /var/lib/irrlichtrelay (mode 0700); holds tokens.json.
+StateDirectory=irrlichtrelay
+StateDirectoryMode=0700
+Environment=IRRLICHT_HOME=/var/lib/irrlichtrelay
+ExecStart=/usr/local/bin/irrlichtrelay serve --addr 127.0.0.1:7839 --auth tokens-file
+# Native TLS instead of a reverse proxy — bind a routable address and serve wss://
+# directly (keep --auth; TLS encrypts but does not authenticate the peer):
+# ExecStart=/usr/local/bin/irrlichtrelay serve --addr 0.0.0.0:7839 --auth tokens-file --tls-cert /etc/irrlichtrelay/cert.pem --tls-key /etc/irrlichtrelay/key.pem
+Restart=on-failure
+RestartSec=2
+
+# Hardening — the relay only needs a network socket and its state dir.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -500,13 +500,13 @@ class SessionManager: ObservableObject {
         }
     }
 
-    private func handleRelayMessage(_ text: String) {
+    func handleRelayMessage(_ text: String) {
         guard let data = text.data(using: .utf8),
               let kind = (try? JSONDecoder().decode(RelayFrameType.self, from: data))?.type else { return }
         switch kind {
         case "push":
             if let push = try? JSONDecoder().decode(RelayPush.self, from: data), let inner = push.msg {
-                applyRelayInner(inner)
+                applyRelayInner(inner, daemonID: push.source)
             }
         case "snapshot":
             if let ctrl = try? JSONDecoder().decode(RelayControl.self, from: data) {
@@ -522,8 +522,9 @@ class SessionManager: ObservableObject {
             break
         default:
             // The URL pointed at a daemon (raw frames): handle it like one.
+            // A raw daemon frame has no envelope source, so it has no daemon id.
             if let inner = try? JSONDecoder().decode(WsEnvelope.self, from: data) {
-                applyRelayInner(inner)
+                applyRelayInner(inner, daemonID: nil)
             }
         }
     }
@@ -531,24 +532,33 @@ class SessionManager: ObservableObject {
     /// Applies a relay session frame into the relay-only map. History and
     /// focus frames are ignored for relay sources in v0 (history bars for
     /// relay-only sessions are deferred; focus is host-local).
-    private func applyRelayInner(_ env: WsEnvelope) {
+    ///
+    /// The relay Push envelope's `source` (daemon id) is stamped onto the
+    /// session and folded into its `rowID`, so two daemons sharing a session_id
+    /// stay distinct in `relaySessionMap` instead of colliding (#537). The
+    /// local-collapse dedup still compares bare `id` against `sessionMap`.
+    private func applyRelayInner(_ env: WsEnvelope, daemonID: String?) {
         switch env.type {
         case "session_created", "session_updated":
-            if let s = env.session {
+            if var s = env.session {
+                s.daemonID = daemonID
                 // Notify on a state transition for a relay-only session. One
                 // also present locally is handled by the local path, so
                 // notifying here too would double-fire.
-                if sessionMap[s.id] == nil, let old = relaySessionMap[s.id]?.state, old != s.state {
+                if sessionMap[s.id] == nil, let old = relaySessionMap[s.rowID]?.state, old != s.state {
                     checkStateTransitionNotification(session: s, previousState: old)
                 }
-                relaySessionMap[s.id] = s
+                relaySessionMap[s.rowID] = s
                 rebuildSessionsFromMap()
                 recomposeApiGroups()
             }
         case "session_deleted":
-            if let s = env.session, relaySessionMap.removeValue(forKey: s.id) != nil {
-                rebuildSessionsFromMap()
-                recomposeApiGroups()
+            if var s = env.session {
+                s.daemonID = daemonID
+                if relaySessionMap.removeValue(forKey: s.rowID) != nil {
+                    rebuildSessionsFromMap()
+                    recomposeApiGroups()
+                }
             }
         default:
             break
@@ -573,19 +583,23 @@ class SessionManager: ObservableObject {
         guard !relaySessionMap.isEmpty else { return [] }
         let localIDs = Set(sessionMap.keys)
         let relayOnly = relaySessionMap.values.filter { !localIDs.contains($0.id) }
-        // A relay session is top-level only if its parent is unknown in BOTH
-        // maps — matching rebuildSessionsFromMap, which excludes any session
-        // whose parent it can see. Keeps a relay child of a local parent from
-        // surfacing as a stray top-level row that the flat list omits.
-        let knownIDs = localIDs.union(relaySessionMap.keys)
+        // A relay session is top-level only if its parent is unknown within its
+        // own daemon (rowIDs are "daemon/id") and is not a local session —
+        // matching rebuildSessionsFromMap. Keeps a relay child from surfacing as
+        // a stray top-level row, while two daemons sharing a session_id stay
+        // distinct (#537).
+        let relayParentKeys = Set(relaySessionMap.keys)
         let topLevel = relayOnly.filter { s in
             guard let pid = s.parentSessionId else { return true }
-            return !knownIDs.contains(pid)
+            if let dID = s.daemonID {
+                return !relayParentKeys.contains("\(dID)/\(pid)")
+            }
+            return !localIDs.contains(pid)
         }
         guard !topLevel.isEmpty else { return [] }
         var byProject: [String: [SessionState]] = [:]
         var order: [String] = []
-        for s in topLevel.sorted(by: { $0.id < $1.id }) {
+        for s in topLevel.sorted(by: { $0.rowID < $1.rowID }) {
             let key = s.projectName ?? "unknown"
             if byProject[key] == nil { order.append(key) }
             byProject[key, default: []].append(s)
@@ -1094,18 +1108,24 @@ class SessionManager: ObservableObject {
         // Merge relay-only sessions (ids not present locally) so the cycle and
         // menu-bar counts include other machines' sessions. Local wins on id
         // collision — the same daemon reached via both sources shows once.
-        var combined = sessionMap
-        for (id, s) in relaySessionMap where combined[id] == nil {
-            combined[id] = s
-        }
-        let all = Array(combined.values)
-        let ids = Set(all.map { $0.id })
+        let localIDs = Set(sessionMap.keys)
+        // Two different relay daemons sharing a session_id stay distinct (keyed
+        // by compound rowID), so build a flat array rather than a bare-id dict
+        // — a dict would collide them back into one row (#537).
+        let relayOnly = relaySessionMap.values.filter { !localIDs.contains($0.id) }
+        let all = Array(sessionMap.values) + relayOnly
 
-        // Exclude child sessions (subagents) from the main session list
-        // so they don't appear in the cycle or as separate rows.
+        // Exclude child sessions (subagents) from the main session list so they
+        // don't appear in the cycle or as separate rows. A parent must resolve
+        // within the same scope: a relay child against its own daemon's
+        // sessions (rowIDs are "daemon/id"), a local child against the local set.
+        let relayParentKeys = Set(relaySessionMap.keys)
         var topLevel = all.filter { session in
             guard let pid = session.parentSessionId else { return true }
-            return !ids.contains(pid)
+            if let dID = session.daemonID {
+                return !relayParentKeys.contains("\(dID)/\(pid)")
+            }
+            return !localIDs.contains(pid)
         }
         topLevel = sortSessionsByOrder(topLevel)
         updateSessionOrder(with: topLevel)
@@ -1417,8 +1437,10 @@ class SessionManager: ObservableObject {
     }
 
     private func sortSessionsByOrder(_ sessions: [SessionState]) -> [SessionState] {
-        // Create a map of session ID to session for quick lookup
-        let sessionMap = Dictionary(uniqueKeysWithValues: sessions.map { ($0.id, $0) })
+        // Key by rowID (compound for relay sessions): two daemons sharing a
+        // session_id would otherwise trap `uniqueKeysWithValues` on the dup
+        // key (#537). rowID == id for local sessions, so order is unchanged.
+        let sessionMap = Dictionary(uniqueKeysWithValues: sessions.map { ($0.rowID, $0) })
 
         var orderedSessions: [SessionState] = []
 
@@ -1431,7 +1453,7 @@ class SessionManager: ObservableObject {
 
         // Then add any new sessions that aren't in the saved order yet
         let orderedIds = Set(sessionOrder)
-        let newSessions = sessions.filter { !orderedIds.contains($0.id) }
+        let newSessions = sessions.filter { !orderedIds.contains($0.rowID) }
 
         // Sort new sessions: active first, then by recency (as fallback for new sessions)
         let sortedNewSessions = newSessions.sorted { lhs, rhs in
@@ -1451,8 +1473,8 @@ class SessionManager: ObservableObject {
     }
 
     private func updateSessionOrder(with sessions: [SessionState]) {
-        let currentSessionIds = Set(sessions.map { $0.id })
-        let orderedSessionIds = sessions.map { $0.id }
+        let currentSessionIds = Set(sessions.map { $0.rowID })
+        let orderedSessionIds = sessions.map { $0.rowID }
 
         // Only update if the order has changed
         if sessionOrder != orderedSessionIds {
@@ -1475,7 +1497,7 @@ class SessionManager: ObservableObject {
         sessions.insert(session, at: adjustedDestination)
 
         // Update the order array to match
-        sessionOrder = sessions.map { $0.id }
+        sessionOrder = sessions.map { $0.rowID }
         saveSessionOrder()
 
         print("🔄 Reordered session \(session.shortId) from \(sourceIndex) to \(adjustedDestination)")

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -113,11 +113,11 @@ class SessionManager: ObservableObject {
     /// Relay-sourced sessions, keyed by session id.
     private var relaySessionMap: [String: SessionState] = [:]
     /// Daemons the relay reports connected: daemon_id → label, for the tooltip.
-    /// Drives `connectionTooltip` (a computed property read by the view) but
-    /// isn't @Published, so nudge SwiftUI on every change — otherwise a
-    /// daemon_status update with no accompanying session change leaves the
-    /// tooltip stale.
-    private var relayDaemons: [String: String] = [:] {
+    /// Drives `connectionTooltip` and the per-row origin glyph tooltip (#538) —
+    /// both read by the view. Not @Published, so nudge SwiftUI on every change —
+    /// otherwise a daemon_status update with no accompanying session change
+    /// leaves the tooltip stale.
+    var relayDaemons: [String: String] = [:] {
         willSet { objectWillChange.send() }
     }
     /// The relay URL currently connected, so a URL change forces a reconnect.

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -120,6 +120,13 @@ class SessionManager: ObservableObject {
     var relayDaemons: [String: String] = [:] {
         willSet { objectWillChange.send() }
     }
+    /// Daemons that disconnected but whose rows we keep on screen, faded, until
+    /// they reconnect (#540 "fade, don't delete"): daemon_id → label, so the
+    /// faded rows keep their hostname tooltip even though the daemon left
+    /// `relayDaemons`. A session is faded when its `daemonID` is a key here.
+    var offlineDaemons: [String: String] = [:] {
+        willSet { objectWillChange.send() }
+    }
     /// The relay URL currently connected, so a URL change forces a reconnect.
     private var activeRelayURL: String = ""
     /// Local groups before relay groups are appended. `apiGroups` (published)
@@ -511,12 +518,26 @@ class SessionManager: ObservableObject {
         case "snapshot":
             if let ctrl = try? JSONDecoder().decode(RelayControl.self, from: data) {
                 relayDaemons.removeAll()
-                for d in ctrl.daemons ?? [] { relayDaemons[d.daemonID] = d.daemonLabel ?? d.daemonID }
+                for d in ctrl.daemons ?? [] {
+                    relayDaemons[d.daemonID] = d.daemonLabel ?? d.daemonID
+                    // A daemon we were fading is back — drop its stale rows and
+                    // the offline mark; its fresh state arrives as pushes.
+                    if offlineDaemons[d.daemonID] != nil { restoreDaemon(d.daemonID) }
+                }
             }
         case "daemon_status":
             if let ctrl = try? JSONDecoder().decode(RelayControl.self, from: data), let id = ctrl.daemonID {
-                if ctrl.status == "disconnected" { relayDaemons.removeValue(forKey: id) }
-                else { relayDaemons[id] = ctrl.daemonLabel ?? id }
+                if ctrl.status == "disconnected" {
+                    // Fade, don't delete (#540): keep the daemon's rows on screen
+                    // (the relay no longer deletes them) and remember its label so
+                    // the faded rows keep their tooltip. The view dims them via
+                    // `isOffline`.
+                    let label = relayDaemons.removeValue(forKey: id) ?? offlineDaemons[id] ?? id
+                    offlineDaemons[id] = label
+                } else {
+                    relayDaemons[id] = ctrl.daemonLabel ?? id
+                    if offlineDaemons[id] != nil { restoreDaemon(id) }
+                }
             }
         case "hello_ack":
             break
@@ -562,6 +583,25 @@ class SessionManager: ObservableObject {
             }
         default:
             break
+        }
+    }
+
+    /// A relay session is faded when its daemon is currently offline (#540).
+    func isOffline(_ session: SessionState) -> Bool {
+        guard let id = session.daemonID else { return false }
+        return offlineDaemons[id] != nil
+    }
+
+    /// A faded daemon reconnected: drop its kept rows (any that ended while it
+    /// was offline are gone for good; live ones re-arrive as fresh pushes) and
+    /// clear the offline mark so its rows render solid again.
+    private func restoreDaemon(_ id: String) {
+        offlineDaemons.removeValue(forKey: id)
+        let before = relaySessionMap.count
+        relaySessionMap = relaySessionMap.filter { $0.value.daemonID != id }
+        if relaySessionMap.count != before {
+            rebuildSessionsFromMap()
+            recomposeApiGroups()
         }
     }
 

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -546,6 +546,17 @@ struct SessionState: Identifiable, Codable {
     // For duplicate handling (not stored in JSON, computed by SessionManager)
     var duplicateIndex: Int? = nil
 
+    // Relay daemon that emitted this session (not stored in JSON; stamped by
+    // SessionManager from the relay Push envelope `source`). Disambiguates two
+    // daemons that share a session_id — see `rowID`. nil for local sessions.
+    var daemonID: String? = nil
+
+    /// Render/identity key (#537). Compound `(daemon, session_id)` for relay
+    /// sessions with a known daemon, else the bare `id` — so local rows and the
+    /// persisted session order are unchanged. Only ever compared/keyed, never
+    /// split, so a "/" delimiter is safe.
+    var rowID: String { daemonID.map { "\($0)/\(id)" } ?? id }
+
     private static let logger = Logger(subsystem: "io.irrlicht.app", category: "SessionState")
 
     // Custom coding keys to match JSON from irrlichd
@@ -760,6 +771,7 @@ struct SessionState: Identifiable, Codable {
             children: newChildren, launcher: launcher
         )
         copy.duplicateIndex = duplicateIndex
+        copy.daemonID = daemonID
         return copy
     }
 
@@ -779,6 +791,7 @@ struct SessionState: Identifiable, Codable {
             children: children, launcher: launcher
         )
         copy.duplicateIndex = duplicateIndex
+        copy.daemonID = daemonID
         return copy
     }
 

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -967,7 +967,7 @@ struct SessionListView: View {
                     .font(.system(.body, design: .monospaced))
                     .foregroundColor(.primary)
             } else if sessionManager.sessions.count <= 3 {
-                ForEach(sessionManager.sessions.prefix(3)) { session in
+                ForEach(sessionManager.sessions.prefix(3), id: \.rowID) { session in
                     SessionStateIcon(state: session.state, size: 12)
                 }
             } else {
@@ -1592,7 +1592,7 @@ struct GroupView: View {
             .padding(.vertical, isTopLevel ? 4 : 3)
 
             if isExpanded {
-                ForEach(Array((group.agents ?? []).enumerated()), id: \.element.id) { index, session in
+                ForEach(Array((group.agents ?? []).enumerated()), id: \.element.rowID) { index, session in
                     SessionRowView(
                         session: session,
                         agentNumber: index + 1,

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1082,6 +1082,20 @@ struct SessionRowView: View {
                         .frame(width: 12, alignment: .trailing)
                 }
 
+                // Origin glyph (#538) — a cloud marks a session delivered by a
+                // remote relay daemon; local sessions show nothing, so a
+                // local-only dashboard is visually unchanged. A session that is
+                // also present locally is filtered to the local row upstream
+                // (relayOnly), so any row with a daemonID is genuinely remote.
+                // Tooltip = the daemon's hostname (from the relay's label map).
+                if let daemonID = session.daemonID {
+                    Image(systemName: "cloud")
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                        .frame(width: 14, alignment: .center)
+                        .tooltip(sessionManager.relayDaemons[daemonID] ?? daemonID)
+                }
+
                 // Active subagent count badge
                 if activeSubagentCount > 0 {
                     Text("\(activeSubagentCount)")

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1089,11 +1089,14 @@ struct SessionRowView: View {
                 // (relayOnly), so any row with a daemonID is genuinely remote.
                 // Tooltip = the daemon's hostname (from the relay's label map).
                 if let daemonID = session.daemonID {
-                    Image(systemName: "cloud")
+                    let host = sessionManager.relayDaemons[daemonID]
+                        ?? sessionManager.offlineDaemons[daemonID] ?? daemonID
+                    let offline = sessionManager.isOffline(session)
+                    Image(systemName: offline ? "cloud.slash" : "cloud")
                         .font(.system(size: 9))
                         .foregroundColor(.secondary)
                         .frame(width: 14, alignment: .center)
-                        .tooltip(sessionManager.relayDaemons[daemonID] ?? daemonID)
+                        .tooltip(offline ? "\(host) — offline" : host)
                 }
 
                 // Active subagent count badge
@@ -1274,6 +1277,11 @@ struct SessionRowView: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 4)
+        // Fade, don't delete (#540): a row whose relay daemon has gone offline
+        // dims in place and restores on reconnect, so a flapping link doesn't
+        // yank rows. Local sessions are never offline.
+        .opacity(sessionManager.isOffline(session) ? 0.4 : 1)
+        .animation(IrrMotion.easeOut(duration: IrrMotion.fast), value: sessionManager.isOffline(session))
         .background(isHovered ? IrrColors.surfaceHover : Color.clear)
         .contentShape(Rectangle())
         .onHover { hovering in

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -392,6 +392,32 @@ final class SessionManagerApiGroupsTests: XCTestCase {
         XCTAssertNil(local.daemonID, "a local session has no daemonID — no glyph")
     }
 
+    // MARK: - Offline fade (#540)
+
+    /// A relay daemon going offline fades its rows (keeps them, marks offline)
+    /// instead of deleting them; reconnect restores them solid.
+    func testOffline_disconnectFadesRows_reconnectRestores() {
+        sut.handleRelayMessage(relaySnapshot(daemonID: "daemonA", label: "ingo-mini.local"))
+        sut.handleRelayMessage(relayPush(source: "daemonA", sessionId: "proc-1234", project: "alpha"))
+        let row = { self.sut.sessions.first { $0.id == "proc-1234" } }
+        XCTAssertNotNil(row(), "row present while the daemon is connected")
+        XCTAssertFalse(sut.isOffline(row()!), "not offline while connected")
+
+        // Daemon drops — the row stays, marked offline (faded), not deleted.
+        sut.handleRelayMessage(daemonStatus(daemonID: "daemonA", status: "disconnected"))
+        XCTAssertNotNil(row(), "row must remain after disconnect (fade, don't delete)")
+        XCTAssertTrue(sut.isOffline(row()!), "row is offline/faded after disconnect")
+        XCTAssertEqual(sut.offlineDaemons["daemonA"], "ingo-mini.local", "offline label kept for the tooltip")
+        XCTAssertNil(sut.relayDaemons["daemonA"], "an offline daemon is not in the connected set")
+
+        // Reconnect — offline mark clears; fresh state re-arrives as a push.
+        sut.handleRelayMessage(daemonStatus(daemonID: "daemonA", status: "connected", label: "ingo-mini.local"))
+        XCTAssertNil(sut.offlineDaemons["daemonA"], "reconnect clears the offline mark")
+        sut.handleRelayMessage(relayPush(source: "daemonA", sessionId: "proc-1234", project: "alpha"))
+        XCTAssertNotNil(row(), "row restored after reconnect")
+        XCTAssertFalse(sut.isOffline(row()!), "row is solid again after reconnect")
+    }
+
     // MARK: - Helpers
 
     /// Builds a relay `snapshot` control frame announcing a connected daemon
@@ -399,6 +425,13 @@ final class SessionManagerApiGroupsTests: XCTestCase {
     private func relaySnapshot(daemonID: String, label: String) -> String {
         """
         {"type":"snapshot","daemons":[{"daemon_id":"\(daemonID)","daemon_label":"\(label)","status":"connected"}]}
+        """
+    }
+
+    /// Builds a relay `daemon_status` control frame (connect/disconnect).
+    private func daemonStatus(daemonID: String, status: String, label: String = "") -> String {
+        """
+        {"type":"daemon_status","daemon_id":"\(daemonID)","daemon_label":"\(label)","status":"\(status)"}
         """
     }
 

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -375,7 +375,32 @@ final class SessionManagerApiGroupsTests: XCTestCase {
         XCTAssertNil(sut.sessions.first { $0.id == "proc-1234" }?.daemonID, "the surviving row is the local one")
     }
 
+    // MARK: - Origin glyph (#538)
+
+    /// A relay session carries a daemonID, and the relay's snapshot label map
+    /// resolves it to a hostname — the data the per-row origin glyph + tooltip
+    /// render from. A local session has no daemonID (no glyph).
+    func testOriginGlyph_remoteSessionResolvesHostnameTooltip() {
+        sut.handleRelayMessage(relaySnapshot(daemonID: "daemonA", label: "ingo-mini.local"))
+        sut.handleRelayMessage(relayPush(source: "daemonA", sessionId: "proc-1234", project: "alpha"))
+
+        let remote = sut.sessions.first { $0.id == "proc-1234" }
+        XCTAssertEqual(remote?.daemonID, "daemonA", "relay session carries the daemon id (glyph shows)")
+        XCTAssertEqual(sut.relayDaemons["daemonA"], "ingo-mini.local", "daemon id resolves to the hostname tooltip")
+
+        let local = makeSession(id: "local-1")
+        XCTAssertNil(local.daemonID, "a local session has no daemonID — no glyph")
+    }
+
     // MARK: - Helpers
+
+    /// Builds a relay `snapshot` control frame announcing a connected daemon
+    /// and its hostname label (populates `relayDaemons`).
+    private func relaySnapshot(daemonID: String, label: String) -> String {
+        """
+        {"type":"snapshot","daemons":[{"daemon_id":"\(daemonID)","daemon_label":"\(label)","status":"connected"}]}
+        """
+    }
 
     /// Builds a relay Push frame (envelope `source` + inner session_created)
     /// as the hub would forward it.

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -338,7 +338,54 @@ final class SessionManagerApiGroupsTests: XCTestCase {
         XCTAssertEqual(cleared.metrics?.estimatedCostUSD, 1.00)
     }
 
+    // MARK: - Relay compound keying (#537)
+
+    /// Two daemons emitting the same session_id must render as two distinct
+    /// rows, keyed by the compound (daemon_id, session_id) — not merged.
+    func testRelay_sameSessionId_differentDaemons_yieldsTwoRows() {
+        sut.handleRelayMessage(relayPush(source: "daemonA", sessionId: "proc-1234", project: "alpha"))
+        sut.handleRelayMessage(relayPush(source: "daemonB", sessionId: "proc-1234", project: "beta"))
+
+        XCTAssertEqual(sut.sessions.count, 2, "two daemons sharing a session_id must be two rows")
+        XCTAssertEqual(Set(sut.sessions.map { $0.rowID }).count, 2, "rowIDs must be distinct")
+        XCTAssertEqual(Set(sut.sessions.map { $0.id }), ["proc-1234"], "bare session_id is preserved on both")
+        XCTAssertEqual(Set(sut.sessions.compactMap { $0.daemonID }), ["daemonA", "daemonB"])
+        // apiGroups (the list-view surface): both rows present across the groups.
+        let groupAgentRowIDs = sut.apiGroups.flatMap { $0.agents ?? [] }.map { $0.rowID }
+        XCTAssertEqual(Set(groupAgentRowIDs), ["daemonA/proc-1234", "daemonB/proc-1234"])
+    }
+
+    /// The same daemon re-emitting a session_id updates in place (one row),
+    /// so a daemon reached over both paths never doubles.
+    func testRelay_sameDaemonSameId_updatesInPlace() {
+        sut.handleRelayMessage(relayPush(source: "daemonA", sessionId: "proc-1234", project: "alpha"))
+        sut.handleRelayMessage(relayPush(source: "daemonA", sessionId: "proc-1234", project: "alpha", state: "waiting"))
+
+        XCTAssertEqual(sut.sessions.count, 1)
+        XCTAssertEqual(sut.sessions.first?.state, .waiting)
+    }
+
+    /// A relay session whose id is also present locally collapses to the local
+    /// row (local wins) — the v0 "same daemon over both paths shows once" guard.
+    func testRelay_idAlsoPresentLocally_collapsesToLocal() {
+        sut.sessionMap["proc-1234"] = makeSession(id: "proc-1234")     // local, no daemonID
+        sut.handleRelayMessage(relayPush(source: "daemonA", sessionId: "proc-1234", project: "alpha"))
+
+        XCTAssertEqual(sut.sessions.filter { $0.id == "proc-1234" }.count, 1, "local wins; relay copy suppressed")
+        XCTAssertNil(sut.sessions.first { $0.id == "proc-1234" }?.daemonID, "the surviving row is the local one")
+    }
+
     // MARK: - Helpers
+
+    /// Builds a relay Push frame (envelope `source` + inner session_created)
+    /// as the hub would forward it.
+    private func relayPush(source: String, sessionId: String, project: String, state: String = "working") -> String {
+        """
+        {"type":"push","source":"\(source)","msg":{"type":"session_created",\
+        "session":{"session_id":"\(sessionId)","state":"\(state)","model":"m",\
+        "cwd":"/tmp","project_name":"\(project)","first_seen":0,"updated_at":0}}}
+        """
+    }
 
     private func makeSession(
         id: String,

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -917,6 +917,15 @@
       flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
       max-width: 100px;
     }
+    /* Origin glyph (#538) — a cloud marking a session delivered by a relay
+       (remote daemon). Hidden for local sessions, so a local-only dashboard
+       is visually unchanged. Muted to read as secondary metadata. */
+    .row-origin {
+      width: 14px; height: 14px; flex-shrink: 0;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); opacity: 0.85;
+    }
+    .row-origin svg { display: block; }
     /* Active tool indicator — hidden for now (the overlay doesn't surface it
        in the default row either). Keep the rule + JS update path so we can
        re-enable later, but force-hide via CSS. */

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1463,6 +1463,21 @@
       return sessionOrigin(a) === 'remote' && localIds.has(displaySessionId(a.session_id));
     }
 
+    // daemonSessionIds returns the session ids delivered by one relay daemon.
+    // Used to drop its rows when it disconnects (#540): the relay no longer
+    // deletes them per-session, so the web dashboard removes them itself to keep
+    // its existing behaviour (macOS fades instead). Pure; exported for tests.
+    function daemonSessionIds(groups, daemonId) {
+      const out = [];
+      if (!daemonId) return out;
+      for (const g of (groups || [])) {
+        for (const a of (g.agents || [])) {
+          if (sourceIdOf(a.session_id) === daemonId) out.push(a.session_id);
+        }
+      }
+      return out;
+    }
+
     // relayFrameKind classifies an incoming frame so the handler can branch.
     // Pure; exported for tests.
     function relayFrameKind(msg) {
@@ -1605,6 +1620,16 @@
       setTimeout(() => { if (!src.closing && sources.get(src.id) === src) connectSource(src); }, delay);
     }
 
+    // purgeDaemonSessions drops every row from one relay daemon — the web
+    // dashboard's response to a daemon disconnect (#540). The relay stopped
+    // fanning out per-session deletes on disconnect, so we reproduce the prior
+    // behaviour here (macOS fades the rows instead).
+    function purgeDaemonSessions(daemonId) {
+      const ids = daemonSessionIds(dashboardGroups, daemonId);
+      for (const sid of ids) applySessionDelete(sid);
+      if (ids.length) render();
+    }
+
     function handleSourceFrame(src, msg) {
       if (!msg) return;
       switch (relayFrameKind(msg)) {
@@ -1619,8 +1644,12 @@
           return;
         case 'daemon_status':
           if (msg.daemon_id) {
-            if (msg.status === 'disconnected') src.daemons.delete(msg.daemon_id);
-            else src.daemons.set(msg.daemon_id, { label: msg.daemon_label || msg.daemon_id, status: msg.status || 'connected' });
+            if (msg.status === 'disconnected') {
+              src.daemons.delete(msg.daemon_id);
+              purgeDaemonSessions(msg.daemon_id);   // #540: relay no longer deletes them for us
+            } else {
+              src.daemons.set(msg.daemon_id, { label: msg.daemon_label || msg.daemon_id, status: msg.status || 'connected' });
+            }
           }
           updateWsStatus();
           return;
@@ -2358,4 +2387,5 @@ export {
   relayFrameKind, aggregateConnState, relayWsUrl,
   compoundSessionId, displaySessionId,
   sessionOrigin, sourceIdOf, localBareIds, isShadowedRemote,
+  daemonSessionIds,
 };

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -168,7 +168,7 @@
       const proj = s && s.project_name ? s.project_name : '';
       const branch = s && s.git_branch ? s.git_branch : '';
       if (proj && branch) return proj + ' · ' + branch;
-      return proj || branch || (s && s.session_id ? s.session_id.slice(0, 8) : 'session');
+      return proj || branch || (s && s.session_id ? displaySessionId(s.session_id).slice(0, 8) : 'session');
     }
     function maybeNotifyOnUpdate(prev, next) {
       if (!next) return;
@@ -374,7 +374,7 @@
       return '';
     }
 
-    function shortID(id) { return id ? id.slice(0, 6) : ''; }
+    function shortID(id) { return id ? displaySessionId(id).slice(0, 6) : ''; }
 
     function pressureClass(level) {
       if (level === 'critical') return 'critical';
@@ -1378,11 +1378,32 @@
     // (`snapshot`/`daemon_status`) feed the connection tooltip, and anything
     // else is a raw daemon frame processed exactly as the single socket was.
     //
-    // Sessions are keyed by `session_id` (the existing model), so the same
-    // daemon reached over both the local socket and a relay collapses to one
-    // row automatically. Two *different* daemons that happen to share a
-    // session_id (e.g. proc-<pid>) would merge — a documented v0 caveat;
-    // per-source keying is deferred with row-level source badges.
+    // Relay sessions are keyed by the compound `(daemon_id, session_id)` (#537):
+    // the relay Push envelope carries the authoritative `source` (daemon id),
+    // which `normalizeSourcedFrame` folds into the inner frame's id at the push
+    // boundary so two *different* daemons sharing a session_id (e.g. proc-<pid>)
+    // never merge into one row. Local-socket frames keep their bare id (daemon =
+    // self), so the same daemon reached over both the local socket and a relay
+    // still collapses to one row.
+
+    // compoundSessionId folds a relay daemon id into a daemon-local session_id
+    // to make a globally-unique, client-internal id. NUL-delimited so it can't
+    // collide with a real id (daemon ids may be arbitrary labels) and never
+    // renders; a falsy daemon id (local frames) yields the bare session id.
+    // Pure; exported for tests.
+    function compoundSessionId(daemonId, sessionId) {
+      if (!daemonId) return sessionId || '';
+      return daemonId + ' ' + (sessionId || '');
+    }
+
+    // displaySessionId is the inverse used for display slices — it recovers the
+    // daemon-local id and passes bare (local) ids through unchanged.
+    // Pure; exported for tests.
+    function displaySessionId(id) {
+      if (!id) return '';
+      const i = id.indexOf(' ');
+      return i === -1 ? id : id.slice(i + 1);
+    }
 
     // relayFrameKind classifies an incoming frame so the handler can branch.
     // Pure; exported for tests.
@@ -1534,11 +1555,40 @@
           updateWsStatus();
           return;
         case 'push':
-          if (msg.msg) dispatchRawFrame(msg.msg);
+          if (msg.msg) dispatchRawFrame(normalizeSourcedFrame(msg.source, msg.msg));
           return;
         default:
           dispatchRawFrame(msg);
       }
+    }
+
+    // normalizeSourcedFrame folds a relay Push envelope's `source` (daemon id)
+    // into the inner frame's session identity, so two daemons sharing a
+    // session_id stay distinct downstream (#537). Mutates the inner frame in
+    // place — it's freshly JSON.parsed per message and not reused. A frame with
+    // no source (or an un-sourced relay) passes through unchanged. Orchestrator
+    // state is global, not per-daemon, so it's left alone.
+    function normalizeSourcedFrame(source, inner) {
+      if (!source || !inner) return inner;
+      if (inner.session) {
+        if (inner.session.session_id) inner.session.session_id = compoundSessionId(source, inner.session.session_id);
+        if (inner.session.parent_session_id) inner.session.parent_session_id = compoundSessionId(source, inner.session.parent_session_id);
+      } else if (inner.type === 'history_snapshot' || inner.type === 'history_upgrade') {
+        if (inner.session_id) inner.session_id = compoundSessionId(source, inner.session_id);
+      } else if (inner.type === 'history_tick') {
+        inner.buckets = remapSourcedKeys(source, inner.buckets);
+        inner.bucket_generations = remapSourcedKeys(source, inner.bucket_generations);
+      }
+      return inner;
+    }
+
+    // remapSourcedKeys returns a fresh object with each session_id key folded
+    // with the daemon source. history_tick keys its bucket maps by session_id.
+    function remapSourcedKeys(source, obj) {
+      if (!obj || typeof obj !== 'object') return obj;
+      const out = {};
+      for (const k of Object.keys(obj)) out[compoundSessionId(source, k)] = obj[k];
+      return out;
     }
 
     // dispatchRawFrame processes a raw daemon PushMessage — the local frame
@@ -2236,4 +2286,5 @@ export {
   formatCost, formatUsageCost, pressureClass, historyPriorityForState,
   lastNotifiedPressure,
   relayFrameKind, aggregateConnState, relayWsUrl,
+  compoundSessionId, displaySessionId,
 };

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -787,6 +787,7 @@
         '<span class="row-num"></span>' +
         '<span class="row-sub-badge" style="display:none"></span>' +
         '<span class="row-role-badge" style="display:none"></span>' +
+        '<span class="row-origin" style="display:none"></span>' +
         '<span class="row-branch"></span>' +
         '<span class="row-tool" style="display:none"></span>' +
         '<span class="row-ctx-bar"><span class="row-ctx-fill"></span><span class="row-ctx-label"></span></span>' +
@@ -890,6 +891,21 @@
       // SessionListView.swift:481-490. Toggling .has-sub on the row
       // shrinks the branch column so columns downstream still align with
       // rows that don't have a badge.
+      // Origin glyph (#538) — a cloud marks a session delivered by a relay
+      // (remote daemon); local-socket sessions show nothing, so a local-only
+      // dashboard is visually unchanged. Tooltip = the daemon's hostname.
+      const originEl = el.querySelector('.row-origin');
+      if (sessionOrigin(agent) === 'remote') {
+        if (!originEl.dataset.on) {
+          originEl.innerHTML = '<svg viewBox="0 0 24 24" width="11" height="11" fill="currentColor" aria-hidden="true"><path d="M19 18H6a4 4 0 0 1-.55-7.96 5 5 0 0 1 9.65-1.65A4 4 0 0 1 19 18z"/></svg>';
+          originEl.dataset.on = '1';
+        }
+        originEl.style.display = '';
+        originEl.title = daemonLabelFor(sourceIdOf(agent.session_id));
+      } else if (originEl.style.display !== 'none') {
+        originEl.style.display = 'none';
+      }
+
       const subBadge = el.querySelector('.row-sub-badge');
       const activeSubs = activeSubagentCount(agent);
       if (activeSubs > 0) {
@@ -1028,12 +1044,17 @@
         const showHeaders = dashboardGroups.length > 1;
         let agentNum = 0;
 
+        // Local-wins (#538): a relay session whose bare id is also delivered by
+        // a local source collapses to the local row — skip the relay duplicate.
+        const localIds = localBareIds(dashboardGroups);
+
         for (const g of dashboardGroups) {
           if (showHeaders) {
             items.push({type: 'group', key: 'g:' + g.name, group: g});
           }
           if (!collapsedGroups.has(g.name)) {
             for (const a of g.agents) {
+              if (isShadowedRemote(a, localIds)) continue;
               agentNum++;
               items.push({type: 'agent', key: 'a:' + a.session_id, agent: a, num: agentNum, isChild: false});
               // Pressure alert
@@ -1405,6 +1426,43 @@
       return i === -1 ? id : id.slice(i + 1);
     }
 
+    // sessionOrigin classifies a session by its id (#538): a relay session's id
+    // is compound (its bare form differs), a local-socket session's id is bare.
+    // Derives from displaySessionId so it never embeds the delimiter literal.
+    // Pure; exported for tests.
+    function sessionOrigin(a) {
+      const id = a && a.session_id;
+      return id && displaySessionId(id) !== id ? 'remote' : 'local';
+    }
+
+    // sourceIdOf recovers the relay daemon id (the compound prefix) from a
+    // session id, or '' for a bare/local id. Pure; exported for tests.
+    function sourceIdOf(id) {
+      if (!id) return '';
+      const bare = displaySessionId(id);
+      return bare === id ? '' : id.slice(0, id.length - bare.length - 1);
+    }
+
+    // localBareIds collects the bare session ids delivered by a local source,
+    // so a relay duplicate of the same session collapses to the local row
+    // (local wins, #538). Pure; exported for tests.
+    function localBareIds(groups) {
+      const out = new Set();
+      for (const g of (groups || [])) {
+        for (const a of (g.agents || [])) {
+          if (sessionOrigin(a) === 'local' && a.session_id) out.add(a.session_id);
+        }
+      }
+      return out;
+    }
+
+    // isShadowedRemote is true when a relay session is also present locally —
+    // the same daemon reached over both paths shows once, as the local row.
+    // Pure; exported for tests.
+    function isShadowedRemote(a, localIds) {
+      return sessionOrigin(a) === 'remote' && localIds.has(displaySessionId(a.session_id));
+    }
+
     // relayFrameKind classifies an incoming frame so the handler can branch.
     // Pure; exported for tests.
     function relayFrameKind(msg) {
@@ -1450,6 +1508,18 @@
     // Active sources, keyed by a stable id. Each: { id, label, kind, wsUrl,
     // state, ws, reconnectDelay, closing, daemons: Map<id,{label,status}> }.
     const sources = new Map();
+
+    // daemonLabelFor resolves a relay daemon id to its hostname label for the
+    // origin-glyph tooltip (#538), scanning the live per-source daemon maps
+    // (populated from snapshot/daemon_status). Falls back to the id itself.
+    function daemonLabelFor(daemonId) {
+      if (!daemonId) return '';
+      for (const src of sources.values()) {
+        const d = src.daemons && src.daemons.get(daemonId);
+        if (d && d.label) return d.label;
+      }
+      return daemonId;
+    }
 
     function desiredSources() {
       const out = [];
@@ -2287,4 +2357,5 @@ export {
   lastNotifiedPressure,
   relayFrameKind, aggregateConnState, relayWsUrl,
   compoundSessionId, displaySessionId,
+  sessionOrigin, sourceIdOf, localBareIds, isShadowedRemote,
 };

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -13,6 +13,10 @@ import {
   relayWsUrl,
   compoundSessionId,
   displaySessionId,
+  sessionOrigin,
+  sourceIdOf,
+  localBareIds,
+  isShadowedRemote,
 } from './irrlicht.js'
 
 describe('resolvedTheme', () => {
@@ -247,5 +251,58 @@ describe('compound keying keeps two daemons distinct in an index', () => {
     idx.set(k2, { daemon: 'B' })
     expect(idx.size).toBe(2)                  // would be 1 under bare session_id keying
     expect('a:' + k1).not.toBe('a:' + k2)     // distinct reconciliation render keys
+  })
+})
+
+describe('sessionOrigin / sourceIdOf (#538 origin glyph)', () => {
+  test('a compound (relay) id is remote; a bare (local) id is local', () => {
+    expect(sessionOrigin({ session_id: compoundSessionId('daemon-A', 'proc-1') })).toBe('remote')
+    expect(sessionOrigin({ session_id: 'proc-1' })).toBe('local')
+    expect(sessionOrigin({})).toBe('local')
+    expect(sessionOrigin(null)).toBe('local')
+  })
+
+  test('sourceIdOf recovers the daemon id from a compound id, else empty', () => {
+    expect(sourceIdOf(compoundSessionId('daemon-A', 'proc-1'))).toBe('daemon-A')
+    expect(sourceIdOf(compoundSessionId('my:weird/label', 'proc-9'))).toBe('my:weird/label')
+    expect(sourceIdOf('proc-1')).toBe('')
+    expect(sourceIdOf('')).toBe('')
+  })
+})
+
+describe('local-wins shadowing (#538)', () => {
+  const groups = [{
+    name: 'proj',
+    agents: [
+      { session_id: 'proc-1' },                                      // local
+      { session_id: compoundSessionId('daemon-A', 'proc-1') },       // relay dup of the local one
+      { session_id: compoundSessionId('daemon-B', 'proc-9') },       // relay-only
+    ],
+  }]
+
+  test('localBareIds collects only local-origin ids', () => {
+    expect(localBareIds(groups)).toEqual(new Set(['proc-1']))
+  })
+
+  test('a relay session whose bare id is local is shadowed (collapses to local)', () => {
+    const localIds = localBareIds(groups)
+    expect(isShadowedRemote({ session_id: compoundSessionId('daemon-A', 'proc-1') }, localIds)).toBe(true)
+  })
+
+  test('a relay-only session and a plain local session are not shadowed', () => {
+    const localIds = localBareIds(groups)
+    expect(isShadowedRemote({ session_id: compoundSessionId('daemon-B', 'proc-9') }, localIds)).toBe(false)
+    expect(isShadowedRemote({ session_id: 'proc-1' }, localIds)).toBe(false)
+  })
+
+  test('two different-daemon remotes sharing a session_id both survive (neither local)', () => {
+    const g = [{ name: 'p', agents: [
+      { session_id: compoundSessionId('daemon-A', 'proc-7') },
+      { session_id: compoundSessionId('daemon-B', 'proc-7') },
+    ]}]
+    const localIds = localBareIds(g)
+    expect(localIds.size).toBe(0)
+    expect(isShadowedRemote(g[0].agents[0], localIds)).toBe(false)
+    expect(isShadowedRemote(g[0].agents[1], localIds)).toBe(false)
   })
 })

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -11,6 +11,8 @@ import {
   relayFrameKind,
   aggregateConnState,
   relayWsUrl,
+  compoundSessionId,
+  displaySessionId,
 } from './irrlicht.js'
 
 describe('resolvedTheme', () => {
@@ -201,5 +203,49 @@ describe('relayWsUrl', () => {
   test('an explicit stream path is preserved (not doubled)', () => {
     expect(relayWsUrl('ws://localhost:7839/api/v1/sessions/stream'))
       .toBe('ws://localhost:7839/api/v1/sessions/stream')
+  })
+})
+
+describe('compoundSessionId', () => {
+  test('prefixes a relay daemon_id so colliding session_ids stay distinct', () => {
+    const a = compoundSessionId('daemon-A', 'proc-1234')
+    const b = compoundSessionId('daemon-B', 'proc-1234')
+    expect(a).not.toBe(b)            // two daemons sharing a session_id never merge
+    expect(a).toContain('proc-1234')
+  })
+
+  test('local / un-sourced frames keep the bare session_id', () => {
+    expect(compoundSessionId('', 'proc-1234')).toBe('proc-1234')
+    expect(compoundSessionId(undefined, 'proc-1234')).toBe('proc-1234')
+  })
+
+  test('delimiter cannot collide with a label-style daemon_id', () => {
+    // daemon_ids can be arbitrary labels; a printable delimiter could split
+    // wrong. The NUL delimiter keeps the boundary unambiguous.
+    const id = compoundSessionId('my:weird/daemon|id', 'proc-1')
+    expect(displaySessionId(id)).toBe('proc-1')
+  })
+})
+
+describe('displaySessionId', () => {
+  test('recovers the daemon-local id for display', () => {
+    expect(displaySessionId(compoundSessionId('daemon-A', 'proc-1234'))).toBe('proc-1234')
+  })
+
+  test('passes bare (local) ids through unchanged', () => {
+    expect(displaySessionId('proc-1234')).toBe('proc-1234')
+    expect(displaySessionId('')).toBe('')
+  })
+})
+
+describe('compound keying keeps two daemons distinct in an index', () => {
+  test('same session_id + different daemon_id → two map entries / render keys', () => {
+    const idx = new Map()
+    const k1 = compoundSessionId('daemon-A', 'proc-1234')
+    const k2 = compoundSessionId('daemon-B', 'proc-1234')
+    idx.set(k1, { daemon: 'A' })
+    idx.set(k2, { daemon: 'B' })
+    expect(idx.size).toBe(2)                  // would be 1 under bare session_id keying
+    expect('a:' + k1).not.toBe('a:' + k2)     // distinct reconciliation render keys
   })
 })

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -17,6 +17,7 @@ import {
   sourceIdOf,
   localBareIds,
   isShadowedRemote,
+  daemonSessionIds,
 } from './irrlicht.js'
 
 describe('resolvedTheme', () => {
@@ -304,5 +305,33 @@ describe('local-wins shadowing (#538)', () => {
     expect(localIds.size).toBe(0)
     expect(isShadowedRemote(g[0].agents[0], localIds)).toBe(false)
     expect(isShadowedRemote(g[0].agents[1], localIds)).toBe(false)
+  })
+})
+
+describe('daemonSessionIds (#540 drop a disconnected daemon\'s rows)', () => {
+  const groups = [{
+    name: 'proj',
+    agents: [
+      { session_id: 'proc-1' },                                 // local — untouched
+      { session_id: compoundSessionId('daemon-A', 'proc-2') },  // daemon A
+      { session_id: compoundSessionId('daemon-A', 'proc-3') },  // daemon A
+      { session_id: compoundSessionId('daemon-B', 'proc-4') },  // daemon B
+    ],
+  }]
+
+  test('returns only the target daemon\'s session ids', () => {
+    expect(daemonSessionIds(groups, 'daemon-A')).toEqual([
+      compoundSessionId('daemon-A', 'proc-2'),
+      compoundSessionId('daemon-A', 'proc-3'),
+    ])
+    expect(daemonSessionIds(groups, 'daemon-B')).toEqual([
+      compoundSessionId('daemon-B', 'proc-4'),
+    ])
+  })
+
+  test('never matches local sessions, and is empty for an unknown/empty daemon', () => {
+    expect(daemonSessionIds(groups, 'daemon-Z')).toEqual([])
+    expect(daemonSessionIds(groups, '')).toEqual([])
+    expect(daemonSessionIds(groups, undefined)).toEqual([])
   })
 })


### PR DESCRIPTION
Implements the remaining **relay server v1** epic (#532) items **C–G**, stacked on top of #535 (item A — auth/TLS, already on `main`). Each item is one commit; review commit-by-commit or as a whole.

## Items

| Item | Issue | What |
|---|---|---|
| **C** — multi-machine correctness | #537 | Compound `(daemon_id, session_id)` keying in **both** clients, off the envelope's authoritative `push.source`, so two daemons emitting the same `session_id` (e.g. `proc-1234`) no longer merge into one row. Web: normalize-at-boundary (relay ids carry a NUL delimiter); macOS: client-internal `daemonID`/`rowID` (also threads through the ordering layer to avoid a `uniqueKeysWithValues` trap). Local-wins collapse preserved. |
| **D** — origin glyph | #538 | A per-row cloud glyph marking sessions delivered by a **remote relay** vs the local socket, with the daemon hostname as tooltip; shown only when a remote is present (local-only UI unchanged). Origin is a pure function of the compound id. macOS additive; web adds local-wins suppression. |
| **E** — deploy artifacts & docs | #539 | A system-level `irrlichtrelay.service` unit, an operator `examples/relay/DEPLOY.md` (build, postures, token workflow, TLS via reverse proxy or native, the cloned-VM `relay-identity.json` collision gotcha), and revised `examples/relay/` Dockerfile/compose/README for the post-auth posture. |
| **F** — fade, don't delete | #540 | A disconnected relay daemon's rows **fade** in place and restore on reconnect instead of vanishing. The hub stops fanning out per-session deletes on disconnect (sends only `daemon_status`); macOS fades, web preserves its delete-on-disconnect UX. |
| **G** — coding-factory demo | #541 | New `examples/coding-factory/`: 3× codex agents driven via tmux, each with a co-located daemon forwarding into one auth-enabled relay → three distinct live rows. Exercises C/D/E/F in one demo. |

## Testing

- **Web:** `npm test` in `platforms/web/` green (46 tests, incl. new compound-keying / origin / shadowing / daemon-purge helpers).
- **Go:** `go test ./core/... -race` green; relay package incl. the rewritten disconnect test.
- **macOS:** `swift build` clean; new relay/offline tests in `SessionManagerApiGroupsTests` pass. (Several pre-existing snapshot + async-`apiGroups` tests fail in a headless local env independent of these changes — confirmed by stashing; rerun in CI for a clean pass.)
- **Examples (#539/#541):** `docker compose config` parses; documented build + `token issue/list` commands verified; scripts pass `bash -n`. Full end-to-end demos need credentials out-of-band (`OPENAI_API_KEY` / `claude login`), like the existing roundtrip.

## Notes

- No wire-protocol changes for C/D — `source` stays on the envelope (wiki §5.4); clients derive identity/origin from it.
- F is the only shared-hub behavior change; D's web half and C are required to avoid regressing the multi-source web dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)