### PR TITLE
chore: ignore .env files anywhere (**/*.env)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,5 @@ replaydata/agents/_reports/
 # OpenCode session metadata (auto-created by the daemon)
 opencode.json
 /expected-validate
+
+**/*.env


### PR DESCRIPTION
Adds `**/*.env` to `.gitignore` so agent/relay example env files (e.g. `examples/*/.env`) stay out of git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)