### PR TITLE
fix(macos): make Settings text fields editable (relay URL + token)

### DIFF
--- a/examples/coding-factory/README.md
+++ b/examples/coding-factory/README.md
@@ -87,6 +87,18 @@ docker compose -f docker-compose.yml exec -it codex-1 tmux attach -t codex
 - **Baked dashboard.** The relay image bakes a snapshot of `platforms/web/`;
   dashboard edits need an image rebuild (`--build`).
 
+## Stop
+
+```bash
+docker compose -f examples/coding-factory/docker-compose.yml down
+```
+
+To stop without removing containers (preserves state for a quick restart):
+
+```bash
+docker compose -f examples/coding-factory/docker-compose.yml stop
+```
+
 → Simpler single-agent demo: [`../roundtrip/`](../roundtrip/) ·
 Protocol reference: [`../../docs/relay-protocol.md`](../../docs/relay-protocol.md) ·
 Deploy/ops: [`../relay/DEPLOY.md`](../relay/DEPLOY.md)

--- a/examples/coding-factory/drive.sh
+++ b/examples/coding-factory/drive.sh
@@ -6,40 +6,13 @@
 # (.claude/skills/ir:onboard-agent/scripts/drive-codex-interactive.sh).
 #
 # Attach to watch/take over:  docker compose exec -it <svc> tmux attach -t codex
-set -euo pipefail
+set -uo pipefail   # -e deliberately omitted: the while loop handles errors itself
 
 SESSION="codex"
 CWD="$HOME/work"
 LOG="$HOME/codex.pane.log"
 TASK="${AGENT_TASK:-Make a small improvement to README.md and commit it.}"
 SESSIONS_DIR="${CODEX_HOME:-$HOME/.codex}/sessions"
-
-# --no-alt-screen keeps codex inline so tmux pipe-pane can capture it (alt-screen
-# would clear the pane and hide the banner/trust prompt).
-tmux new-session -d -s "$SESSION" -c "$CWD" codex --no-alt-screen
-tmux pipe-pane -t "$SESSION" -o "cat >> '$LOG'"
-
-# Accept the one-time "Do you trust the contents of this directory?" prompt
-# (poll the LIVE pane — it can render before pipe-pane flushes to the log).
-for _ in $(seq 1 60); do
-  if tmux capture-pane -t "$SESSION" -p -S -40 2>/dev/null | grep -q 'Do you trust'; then
-    tmux send-keys -t "$SESSION" "1"
-    sleep 0.3
-    tmux send-keys -t "$SESSION" Enter
-    echo "[drive] accepted trust dialog" >&2
-    break
-  fi
-  sleep 1
-done
-
-# Wait for the "OpenAI Codex" banner, then for the "Booting MCP" phase to clear
-# (keystrokes typed during boot have their Enter silently swallowed).
-for _ in $(seq 1 120); do grep -aq 'OpenAI Codex' "$LOG" 2>/dev/null && break; sleep 1; done
-for _ in $(seq 1 60); do
-  tmux capture-pane -t "$SESSION" -p -S -20 2>/dev/null | grep -q 'Booting MCP' || break
-  sleep 1
-done
-echo "[drive] codex booted — starting task loop" >&2
 
 # Count completed turns across the session's rollout(s): the canonical turn-done
 # signal is event_msg/task_complete.
@@ -49,16 +22,66 @@ turns() {
     | wc -l | tr -d ' '
 }
 
+# Start (or restart) codex in tmux and wait until it is ready for input.
+# Truncates the log so banner-detection doesn't match an old run.
+boot_codex() {
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  > "$LOG"   # fresh log so 'OpenAI Codex' detection doesn't hit the old banner
+
+  # --no-alt-screen keeps codex inline so tmux pipe-pane can capture it (alt-screen
+  # would clear the pane and hide the banner/trust prompt).
+  tmux new-session -d -s "$SESSION" -c "$CWD" codex --no-alt-screen
+  tmux pipe-pane -t "$SESSION" -o "cat >> '$LOG'"
+
+  # Accept the one-time "Do you trust the contents of this directory?" prompt
+  # (poll the LIVE pane — it can render before pipe-pane flushes to the log).
+  for _ in $(seq 1 60); do
+    if tmux capture-pane -t "$SESSION" -p -S -40 2>/dev/null | grep -q 'Do you trust'; then
+      tmux send-keys -t "$SESSION" "1"
+      sleep 0.3
+      tmux send-keys -t "$SESSION" Enter
+      echo "[drive] accepted trust dialog" >&2
+      break
+    fi
+    sleep 1
+  done
+
+  # Wait for the "OpenAI Codex" banner, then for the "Booting MCP" phase to clear
+  # (keystrokes typed during boot have their Enter silently swallowed).
+  for _ in $(seq 1 120); do grep -aq 'OpenAI Codex' "$LOG" 2>/dev/null && break; sleep 1; done
+  for _ in $(seq 1 60); do
+    tmux capture-pane -t "$SESSION" -p -S -20 2>/dev/null | grep -q 'Booting MCP' || break
+    sleep 1
+  done
+  echo "[drive] codex booted — starting task loop" >&2
+}
+
+boot_codex
+
 # Coding-factory loop: send the task, wait for the turn to complete, let the row
 # settle to `ready` so it's visible, then go again.
 while true; do
+  # If codex exited (user Ctrl-C, crash, API error), restart it instead of
+  # crashing the container (which would cause a restart loop).
+  if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+    echo "[drive] codex exited — restarting in 5s" >&2
+    sleep 5
+    boot_codex
+    continue
+  fi
+
   before="$(turns)"
-  tmux send-keys -t "$SESSION" -l -- "$TASK"
+  if ! tmux send-keys -t "$SESSION" -l -- "$TASK" 2>/dev/null; then
+    sleep 2
+    continue
+  fi
   sleep 0.3                                   # let the text land before Enter (Ink input race)
-  tmux send-keys -t "$SESSION" Enter
+  tmux send-keys -t "$SESSION" Enter 2>/dev/null || true
   echo "[drive] sent task; waiting for turn to complete" >&2
   for _ in $(seq 1 180); do
     [ "$(turns)" -gt "$before" ] && break
+    # If codex died mid-task, stop waiting and let the outer loop restart it
+    tmux has-session -t "$SESSION" 2>/dev/null || break
     sleep 1
   done
   sleep 20                                    # dwell on `ready` before the next task

--- a/examples/coding-factory/entrypoint.sh
+++ b/examples/coding-factory/entrypoint.sh
@@ -15,6 +15,14 @@ rm -f "$state_dir/relay-identity.json"
 mkdir -p "$HOME/.codex"
 printf 'model = "%s"\n' "${CODEX_MODEL:-gpt-4o-mini}" > "$HOME/.codex/config.toml"
 
+# Pre-authenticate codex so the first-run API key wizard doesn't appear in the
+# tmux session before the driver is ready to handle it. `--with-api-key` reads
+# from stdin and stores the key in ~/.codex/; OPENAI_API_KEY in the env suffices
+# for inference itself, but without this the interactive wizard fires first.
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+  echo "$OPENAI_API_KEY" | codex login --with-api-key 2>/dev/null || true
+fi
+
 echo "[entrypoint] irrlichd → ${IRRLICHT_RELAY_URL:-<unset>} (token: ${IRRLICHT_RELAY_TOKEN:+set}, model: ${CODEX_MODEL:-gpt-4o-mini})"
 irrlichd &
 daemon=$!

--- a/platforms/macos/Irrlicht/App/MenuBarController.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarController.swift
@@ -15,6 +15,14 @@ import SwiftUI
 ///   re-anchor the panel top under the status item.
 /// - Re-anchoring uses `setFrame(_:display:animate:)` with animate=false
 ///   so content change + size change + origin change land in one pass.
+// NSWindow.canBecomeKey returns false for .borderless windows by default, so
+// makeKey() is a no-op on the stock NSPanel. Override to allow Settings text
+// fields to receive keyboard input when we explicitly activate.
+private final class IrrlichtPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
 @MainActor
 final class MenuBarController: NSObject {
     private let daemonManager: DaemonManager
@@ -23,7 +31,7 @@ final class MenuBarController: NSObject {
     private let updateManager: UpdateManager
 
     private let statusItem: NSStatusItem
-    private let panel: NSPanel
+    private let panel: IrrlichtPanel
     private let hostingController: NSHostingController<AnyView>
 
     private var imageSubscription: AnyCancellable?
@@ -52,7 +60,7 @@ final class MenuBarController: NSObject {
             .environmentObject(updateManager)
         self.hostingController = NSHostingController(rootView: AnyView(root))
 
-        self.panel = NSPanel(
+        self.panel = IrrlichtPanel(
             contentRect: NSRect(x: 0, y: 0, width: SessionListView.panelWidth, height: 200),
             styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
             backing: .buffered,

--- a/platforms/macos/Irrlicht/IrrlichtApp.swift
+++ b/platforms/macos/Irrlicht/IrrlichtApp.swift
@@ -26,6 +26,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var menuBarController: MenuBarController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // LSUIElement apps have no visible menu bar, but NSApp still routes key
+        // equivalents through NSApp.mainMenu. Without an Edit menu, Cmd+V/X/C/Z/A
+        // don't reach text fields. Set one up invisibly so standard text-editing
+        // shortcuts work in SettingsView.
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(withTitle: "Undo", action: #selector(UndoManager.undo), keyEquivalent: "z")
+        editMenu.addItem(withTitle: "Redo", action: #selector(UndoManager.redo), keyEquivalent: "Z")
+        editMenu.addItem(.separator())
+        editMenu.addItem(withTitle: "Cut",        action: #selector(NSText.cut(_:)),       keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy",       action: #selector(NSText.copy(_:)),      keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste",      action: #selector(NSText.paste(_:)),     keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        let editItem = NSMenuItem()
+        editItem.submenu = editMenu
+        let mainMenu = NSMenu()
+        mainMenu.addItem(editItem)
+        NSApp.mainMenu = mainMenu
+
         // Try Bundle.module (SwiftPM resource bundle) first, then Bundle.main (.app bundle)
         let iconURL = Bundle.module.url(forResource: "AppIcon", withExtension: "icns", subdirectory: "Resources")
             ?? Bundle.main.url(forResource: "AppIcon", withExtension: "icns")

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -276,6 +276,15 @@ struct SettingsView: View {
         .frame(width: 360)
         .background(Color(NSColor.windowBackgroundColor))
         .toggleStyle(IrrlichtSwitchToggleStyle())
+        .background(
+            WindowAccessor { window in
+                // The panel is .borderless + .nonactivatingPanel + orderFrontRegardless(),
+                // so canBecomeKey is false by default and the app is never active.
+                // Activate + makeKey here so Settings text fields are editable.
+                NSApp.activate(ignoringOtherApps: true)
+                window.makeKey()
+            }
+        )
     }
 
     private var lastCheckedDescription: String {
@@ -327,6 +336,19 @@ struct SettingsView: View {
             }
         }
     }
+}
+
+private struct WindowAccessor: NSViewRepresentable {
+    let onWindow: (NSWindow) -> Void
+    func makeNSView(context: Context) -> NSView {
+        let v = NSView()
+        // Defer one runloop so NSView.window is populated (nil during makeNSView).
+        DispatchQueue.main.async { [weak v] in
+            if let w = v?.window { onWindow(w) }
+        }
+        return v
+    }
+    func updateNSView(_ nsView: NSView, context: Context) {}
 }
 
 /// One row in the Settings notifications section: enable toggle, sound


### PR DESCRIPTION
## Summary

- **Settings text fields were not editable** — relay server address and token fields could not be clicked into or typed/pasted into.

Three-part fix:

1. **`IrrlichtPanel` subclass** (`MenuBarController.swift`) — `NSWindow.canBecomeKey` returns `false` for `.borderless` windows by default, making `makeKey()` a silent no-op. Subclass overrides this to `true` while keeping `canBecomeMain = false`.

2. **`WindowAccessor` NSViewRepresentable** (`SettingsView.swift`) — defers one runloop tick after the view is placed in the window hierarchy, then calls `NSApp.activate(ignoringOtherApps: true)` + `window.makeKey()`. The panel is `.nonactivatingPanel` so the app is never active by default; this activates it + promotes the panel to key window when Settings opens.

3. **Edit menu** (`IrrlichtApp.swift`) — `LSUIElement` apps have no visible menu bar but `NSApp` still routes key equivalents (Cmd+V/X/C/Z/A) through `NSApp.mainMenu`. Without an Edit submenu those shortcuts were dropped before reaching the text fields. Added an invisible main menu with standard edit items.

Also includes `examples/coding-factory` fixes (pre-auth codex, resilient driver).

## Test plan

- [x] Open Settings → enable Relay server toggle → click relay URL field → can type
- [x] Cmd+V pastes into the relay URL field
- [x] Cmd+Z undoes, Cmd+A selects all
- [x] Token field also editable
- [x] Done button returns to session list; panel behaves normally (non-activating) for session rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)