### PR TITLE
fix(web): render rows of a single collapsed group (#564)

### DIFF
--- a/platforms/web/irrlicht.gastown.test.js
+++ b/platforms/web/irrlicht.gastown.test.js
@@ -1,0 +1,72 @@
+import { describe, test, expect } from 'vitest'
+
+// Regression test for the gastown agent-less group crash: a gastown
+// orchestrator group whose agents all live in rig sub-groups serializes
+// WITHOUT an `agents` field (json omitempty on AgentGroup.Agents,
+// core/domain/session/grouped.go). rebuildIndex()/render() iterated
+// g.agents unconditionally, so one such group in the /api/v1/sessions
+// payload threw `g.agents is not iterable` inside the initial-load
+// .then — render() never ran and the whole dashboard stayed blank,
+// including every normal project group.
+//
+// Own test file: the payload is consumed at module load, and vitest's
+// per-file isolation gives this file a fresh module instance.
+
+const sessionsPayload = {
+  groups: [
+    {
+      // No `agents` key — exactly what the daemon sends for this shape.
+      name: 'Gas Town',
+      type: 'gastown',
+      groups: [
+        {
+          name: 'app',
+          agents: [
+            { session_id: 'proc-rig', state: 'working', project_name: 'app', metrics: {} },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'webapp',
+      agents: [
+        {
+          session_id: 'proc-app',
+          state: 'ready',
+          project_name: 'webapp',
+          git_branch: 'main',
+          metrics: { estimated_cost_usd: 0.05 },
+        },
+      ],
+    },
+  ],
+  provider_costs: {},
+}
+
+describe('agent-less group in the sessions payload', () => {
+  test('does not blank the dashboard — other groups still render', async () => {
+    global.fetch = (url) => {
+      const u = String(url)
+      if (u.includes('/api/v1/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(sessionsPayload) })
+      }
+      if (u.includes('/api/v1/agents')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve(null) })
+    }
+
+    await import('./irrlicht.js')
+    await new Promise((r) => setTimeout(r, 0))
+
+    // The normal project group's row must render despite the agent-less
+    // gastown group earlier in the payload.
+    const rows = document.querySelectorAll('#session-list .session-row')
+    expect(rows.length).toBe(1)
+    expect(rows[0].dataset.sessionId).toBe('proc-app')
+    // Two groups → both headers render (the gastown one with zero direct
+    // agents; its rig sub-groups are a known display gap, not a crash).
+    expect(document.querySelectorAll('#session-list .group-hdr').length).toBe(2)
+    expect(document.getElementById('empty-state').style.display).toBe('none')
+  })
+})

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1325,6 +1325,13 @@
       }
       if (resp) {
         dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
+        // A group with no direct agents (e.g. a gastown orchestrator group
+        // whose agents all live in rig sub-groups) omits `agents` entirely
+        // (json omitempty). Normalize once at ingest so every consumer —
+        // rebuildIndex, render, group headers — can iterate unconditionally.
+        for (const g of dashboardGroups) {
+          if (g && !g.agents) g.agents = [];
+        }
         dashboardProviderCosts = (resp && !Array.isArray(resp) && resp.provider_costs) || {};
         rebuildIndex();
       }

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1052,7 +1052,11 @@
           if (showHeaders) {
             items.push({type: 'group', key: 'g:' + g.name, group: g});
           }
-          if (!collapsedGroups.has(g.name)) {
+          // Collapse only applies while a header exists to un-collapse it
+          // (#564): with a single group no header renders, so a stale
+          // persisted collapse would otherwise blank the dashboard with no
+          // way to recover.
+          if (!showHeaders || !collapsedGroups.has(g.name)) {
             for (const a of g.agents) {
               if (isShadowedRemote(a, localIds)) continue;
               agentNum++;

--- a/platforms/web/irrlicht.render.test.js
+++ b/platforms/web/irrlicht.render.test.js
@@ -1,0 +1,99 @@
+import { describe, test, expect } from 'vitest'
+
+// Regression test for #564: the dashboard went blank — sessions present in the
+// /api/v1/sessions payload but no .session-row rendered — because a persisted
+// collapsed group (localStorage irrlicht_collapsedGroups) became the ONLY
+// group. With a single group no header renders (showHeaders=false), so the
+// collapse both hid every row and left no chevron to un-collapse it.
+//
+// This lives in its own test file (not irrlicht.test.js) because irrlicht.js
+// reads the collapsed set from localStorage at module load, and vitest's
+// per-file module isolation is what lets us seed localStorage BEFORE import.
+
+// Representative /api/v1/sessions payload (wrapped shape, one group).
+const sessionsPayload = {
+  groups: [
+    {
+      name: 'irrlicht',
+      agents: [
+        {
+          session_id: 'proc-1',
+          state: 'working',
+          project_name: 'irrlicht',
+          git_branch: 'main',
+          adapter: 'claude-code',
+          first_seen: 1764800000,
+          metrics: {
+            model_name: 'claude-opus-4-8',
+            estimated_cost_usd: 0.12,
+            context_utilization_percentage: 45,
+            pressure_level: 'low',
+            total_tokens: 2400,
+            elapsed_seconds: 120,
+          },
+        },
+        {
+          session_id: 'proc-2',
+          state: 'ready',
+          project_name: 'irrlicht',
+          git_branch: 'feat/x',
+          adapter: 'claude-code',
+          first_seen: 1764800100,
+          metrics: {},
+        },
+      ],
+      costs: { day: 0.5 },
+    },
+  ],
+  provider_costs: {},
+}
+
+describe('session row rendering (#564)', () => {
+  test('initial payload renders rows even when the single group is persisted as collapsed', async () => {
+    // The trap: groups collapsed earlier (when several projects were active)
+    // survive in localStorage; later only one of them is left in the payload.
+    localStorage.setItem('irrlicht_collapsedGroups', JSON.stringify(['irrlicht', 'articles']))
+
+    global.fetch = (url) => {
+      const u = String(url)
+      if (u.includes('/api/v1/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(sessionsPayload) })
+      }
+      if (u.includes('/api/v1/agents')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve(null) })
+    }
+
+    await import('./irrlicht.js')
+    // Let the initial Promise.all(fetch…).then(render) settle.
+    await new Promise((r) => setTimeout(r, 0))
+
+    const rows = document.querySelectorAll('#session-list .session-row')
+    expect(rows.length).toBe(2)
+    expect(rows[0].dataset.sessionId).toBe('proc-1')
+    expect(rows[1].dataset.sessionId).toBe('proc-2')
+    // Single group → no header rendered; the rows must show regardless of the
+    // stale collapse entry.
+    expect(document.querySelectorAll('#session-list .group-hdr').length).toBe(0)
+    expect(document.getElementById('empty-state').style.display).toBe('none')
+  })
+
+  test('a second project restores headers and the persisted collapse', () => {
+    // Same module instance as above (per-file isolation): a WS session_update
+    // for another project brings the dashboard to two groups.
+    const ws = global.lastMockWebSocket
+    ws.simulateOpen()
+    ws.simulateMessage({
+      type: 'session_update',
+      session: { session_id: 'proc-3', state: 'ready', project_name: 'webapp' },
+    })
+
+    // Headers are back, so the collapsed 'irrlicht' group legitimately hides
+    // its rows again — collapse semantics unchanged when a header exists.
+    expect(document.querySelectorAll('#session-list .group-hdr').length).toBe(2)
+    const rows = document.querySelectorAll('#session-list .session-row')
+    expect(rows.length).toBe(1)
+    expect(rows[0].dataset.sessionId).toBe('proc-3')
+  })
+})

--- a/platforms/web/vitest.setup.js
+++ b/platforms/web/vitest.setup.js
@@ -19,6 +19,14 @@ document.body.innerHTML = `
   <div id="settings-perm-note"></div>
 `;
 
+// jsdom has no canvas — give paintRowHistory the minimal 2D context it uses
+// so tests that render session rows don't trip an unhandled rejection.
+HTMLCanvasElement.prototype.getContext = () => ({
+  setTransform: () => {},
+  clearRect: () => {},
+  fillRect: () => {},
+});
+
 // jsdom has no matchMedia — provide a stub
 if (!window.matchMedia) {
   window.matchMedia = (query) => ({


### PR DESCRIPTION
## Summary

Fixes #564 — the web dashboard rendered its header (quota bars, state icons, green **watching**) but the session list stayed completely blank, with no empty-state either. Two distinct blank-dashboard causes are fixed, each with a regression test that fails on the old code.

### 1. Single collapsed group (the live #564 bug)

**Root cause** (confirmed live on the production dashboard): `localStorage.irrlicht_collapsedGroups` contained `["articles","irrlicht"]` from an earlier multi-project session. Once `irrlicht` became the *only* group in the `/api/v1/sessions` payload:

- `render()` hides group headers for a single group (`showHeaders = dashboardGroups.length > 1`),
- but the collapse check still skipped every agent row,
- leaving zero rows, the empty-state hidden (data branch taken), and **no chevron to ever un-collapse** — persisted across reloads by localStorage.

**Fix:** collapse only applies while a header exists to toggle it:

```js
if (!showHeaders || !collapsedGroups.has(g.name)) {
```

The localStorage entry is kept: when a second project appears, headers return and the persisted collapse resumes meaning. Matches macOS, where `GroupView` always renders the header and `collapsedGroupNames` is in-memory only, so this trap can't occur there.

### 2. Agent-less group crashes render (latent, found during the same investigation)

A gastown orchestrator group whose agents all live in rig sub-groups serializes **without** an `agents` field (`json:"agents,omitempty"` on `AgentGroup.Agents`, grouped.go). `rebuildIndex()`/`render()`/group headers iterated `g.agents` unconditionally → `TypeError: g.agents is not iterable` inside the initial-load `.then` → `render()` never ran and every normal project group went blank with it.

**Fix:** normalize once at the single payload-ingest point (missing `agents` → `[]`). Client-built groups already always carry an `agents` array. Rendering the rig sub-groups themselves stays a separate display-parity gap (#559).

## Regression tests (issue requirement)

Each in its own file because the payload/localStorage are consumed at module load — vitest's per-file isolation gives each a fresh module instance:

- `irrlicht.render.test.js` — seeds the stale collapse, serves a representative `/api/v1/sessions` payload through a fetch stub, asserts `.session-row` elements render (**old code: 0 rows where 2 expected**); a second test confirms collapse semantics are unchanged once a WS `session_update` brings back a second group.
- `irrlicht.gastown.test.js` — payload with an agent-less gastown group plus a normal project group; asserts the normal rows render (**old code: `g.agents is not iterable`, 0 rows**).
- `vitest.setup.js` gains a minimal canvas-2D stub (jsdom has none) for the now-exercised `paintRowHistory` path.

## Testing

- `npm test` in `platforms/web/`: 49/49 pass across 3 files, no unhandled errors (both new tests verified red before their fix, green after).
- Web-only change; Go/replay/factory suites unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)