### PR TITLE
fix(macos): match premium voices whose names carry a quality suffix

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SoundPlayer.swift
+++ b/platforms/macos/Irrlicht/Managers/SoundPlayer.swift
@@ -68,15 +68,17 @@ enum SoundPlayer {
 
     /// Resolves a SpokenVoice to a concrete AVSpeechSynthesisVoice. Picks
     /// the highest-installed quality (premium > enhanced > default) for the
-    /// canonical name, so once the user downloads Ava-Premium / Tom-Premium
-    /// in System Settings the upgrade is automatic. Falls back to the
-    /// system en-US voice when no name match exists at all.
+    /// canonical name, so once the user downloads Zoe/Jamie Premium in
+    /// System Settings the upgrade is automatic. Matching goes through
+    /// `SpokenVoice.matches(installedName:)` because newer macOS reports
+    /// names with the quality suffixed ("Zoe (Premium)"). Falls back to
+    /// the system en-US voice when no name match exists at all.
     static func voice(for spoken: SpokenVoice) -> AVSpeechSynthesisVoice? {
-        guard let name = spoken.canonicalName else {
+        guard spoken.canonicalName != nil else {
             return AVSpeechSynthesisVoice(language: "en-US")
         }
         if let best = AVSpeechSynthesisVoice.speechVoices()
-            .filter({ $0.name == name })
+            .filter({ spoken.matches(installedName: $0.name) })
             .max(by: { $0.quality.rawValue < $1.quality.rawValue }) {
             return best
         }

--- a/platforms/macos/Irrlicht/Models/SpokenVoice.swift
+++ b/platforms/macos/Irrlicht/Models/SpokenVoice.swift
@@ -37,12 +37,21 @@ enum SpokenVoice: String, CaseIterable {
         }
     }
 
+    /// Whether an installed voice's reported name refers to this voice.
+    /// macOS 26.x suffixes the quality into the name — "Zoe (Premium)" —
+    /// where earlier releases reported bare "Zoe", so accept both shapes.
+    /// The " (" requirement keeps near-miss names (e.g. "Zoey") out.
+    func matches(installedName: String) -> Bool {
+        guard let name = canonicalName else { return false }
+        return installedName == name || installedName.hasPrefix(name + " (")
+    }
+
     /// Whether a voice matching `canonicalName` is installed at any
     /// quality. Drives the "Install voice…" affordance in Settings.
     /// `.default` always reports `true` because the system-language voice
     /// is always available.
     var isInstalled: Bool {
-        guard let name = canonicalName else { return true }
-        return AVSpeechSynthesisVoice.speechVoices().contains { $0.name == name }
+        guard canonicalName != nil else { return true }
+        return AVSpeechSynthesisVoice.speechVoices().contains { matches(installedName: $0.name) }
     }
 }

--- a/platforms/macos/Irrlicht/Models/SpokenVoice.swift
+++ b/platforms/macos/Irrlicht/Models/SpokenVoice.swift
@@ -41,6 +41,8 @@ enum SpokenVoice: String, CaseIterable {
     /// macOS 26.x suffixes the quality into the name — "Zoe (Premium)" —
     /// where earlier releases reported bare "Zoe", so accept both shapes.
     /// The " (" requirement keeps near-miss names (e.g. "Zoey") out.
+    /// `.default` has no canonical name and matches nothing — callers
+    /// (`isInstalled`, `SoundPlayer.voice(for:)`) special-case it first.
     func matches(installedName: String) -> Bool {
         guard let name = canonicalName else { return false }
         return installedName == name || installedName.hasPrefix(name + " (")

--- a/platforms/macos/Tests/SoundPlayerTests.swift
+++ b/platforms/macos/Tests/SoundPlayerTests.swift
@@ -39,7 +39,7 @@ final class SoundPlayerTests: XCTestCase {
 
     func testVoiceForEachSpokenVoiceIsNonNil() {
         // Every variant must resolve to a usable voice: when the canonical
-        // name (Ava / Tom) is installed we get the best-quality variant of
+        // name (Zoe / Jamie) is installed we get the best-quality variant of
         // it; when it isn't, we fall back to AVSpeechSynthesisVoice(
         // language: "en-US") which is always present.
         for v in SpokenVoice.allCases {

--- a/platforms/macos/Tests/SoundPlayerTests.swift
+++ b/platforms/macos/Tests/SoundPlayerTests.swift
@@ -52,6 +52,25 @@ final class SoundPlayerTests: XCTestCase {
             ".default has no canonical name and must always report installed")
     }
 
+    func testMatchesAcceptsBareAndQualitySuffixedNames() {
+        // macOS 26.x reports premium/enhanced voices with the quality in
+        // the name ("Zoe (Premium)"); older releases report bare "Zoe".
+        XCTAssertTrue(SpokenVoice.female.matches(installedName: "Zoe"))
+        XCTAssertTrue(SpokenVoice.female.matches(installedName: "Zoe (Premium)"))
+        XCTAssertTrue(SpokenVoice.female.matches(installedName: "Zoe (Enhanced)"))
+        XCTAssertTrue(SpokenVoice.male.matches(installedName: "Jamie"))
+        XCTAssertTrue(SpokenVoice.male.matches(installedName: "Jamie (Premium)"))
+    }
+
+    func testMatchesRejectsOtherNames() {
+        XCTAssertFalse(SpokenVoice.female.matches(installedName: "Zoey"),
+            "near-miss names must not match")
+        XCTAssertFalse(SpokenVoice.female.matches(installedName: "Jamie (Premium)"))
+        XCTAssertFalse(SpokenVoice.male.matches(installedName: "Zoe (Premium)"))
+        XCTAssertFalse(SpokenVoice.default.matches(installedName: "Zoe"),
+            ".default has no canonical name and matches nothing")
+    }
+
     func testResolveMissingCustomFallsBackToPing() {
         let defaults = UserDefaults.standard
         let event = NotificationEvent.contextPressure


### PR DESCRIPTION
## Summary

macOS 26.5 (25F71) reports premium voices with the quality suffixed into the name — `Zoe (Premium)`, `Jamie (Premium)` — where older releases reported bare `Zoe` / `Jamie`. Two call sites matched by exact name and both broke:

- `SpokenVoice.isInstalled` → Settings showed the bogus orange "Install Zoe, Premium in System Settings" hint for voices that are installed (the reported symptom)
- `SoundPlayer.voice(for:)` → notifications silently spoke with the default en-US voice instead of the selected premium one

## Fix

One shared helper, `SpokenVoice.matches(installedName:)`, accepts both name shapes: exact match or prefix-match on `"Name ("` (so `Zoe (Premium)` / `Zoe (Enhanced)` match but near-misses like `Zoey` don't). Both call sites now use it; the existing highest-quality-wins tie-break in `voice(for:)` is unchanged.

Identifier-based matching was not an option — Jamie's identifier is `com.apple.voice.premium.en-GB.Malcolm` (no "Jamie" anywhere).

## Testing

- New pure-function tests for `matches(installedName:)` (bare, suffixed, and negative cases) — no dependency on which voices the test machine has installed
- `swift test --filter SoundPlayerTests`: 12/12 pass
- Live check on macOS 26.5: the new rule resolves `Zoe (Premium)` / `Jamie (Premium)` at quality 3 for both voices
- Note: `SessionRowSnapshotTests` fails identically on a clean tree (pre-existing OS-update rendering drift, unrelated)

Fixes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)