### PR TITLE
feat(permissions): consent-first permission wizard (#570)

### DIFF
--- a/.claude/skills/ir:onboarding-factory/record/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/record/SKILL.md
@@ -38,6 +38,10 @@ description: >
 4. **A recording daemon is up.** Use `--attach` against the user's running
    `irrlichd --record` (the dashboard stays connected; the session shows up
    live). The precheck refuses if no `--record` daemon is found — `infra_fail`.
+   A recording daemon must run with `IRRLICHT_PERMISSION_MODE=grant-all` —
+   the consent-first gate (#570) otherwise leaves a fresh daemon monitoring
+   nothing until its wizard is answered. (run-cell.sh / run-cell-multi.sh
+   set it on the daemons they spawn.)
 
 ## Steps
 

--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -162,14 +162,20 @@ user chooses up front:
    ```
 
 5. **Start the daemon** with `--record` for lifecycle event capture. In
-   **separate** mode it gets `IRRLICHT_HOME` (isolated state); in **replace**
-   mode `IRRLICHT_HOME` is omitted so it reads/writes the production state dir.
+   **separate** mode it gets `IRRLICHT_HOME` (isolated state) plus
+   `IRRLICHT_PERMISSION_MODE=grant-all` — a fresh isolated state dir has no
+   consent answers (#570), so without it the daemon monitors nothing until
+   the permission wizard is answered. Drop that variable when the point of
+   the session is to test the wizard itself. In **replace** mode
+   `IRRLICHT_HOME` is omitted so it reads/writes the production state dir —
+   including the user's real permission answers (no grant-all there).
    ```bash
    if [ "$MODE" = "replace" ]; then
      IRRLICHT_BIND_ADDR=127.0.0.1:$PORT \
        nohup "$IRRLICHTD_BIN" --record > /tmp/irrlichd-dev.log 2>&1 & disown
    else
      IRRLICHT_HOME="$DEV_HOME" IRRLICHT_BIND_ADDR=127.0.0.1:$PORT \
+       IRRLICHT_PERMISSION_MODE=grant-all \
        nohup "$IRRLICHTD_BIN" --record > /tmp/irrlichd-dev.log 2>&1 & disown
    fi
    ```

--- a/core/adapters/inbound/agents/aider/agent.go
+++ b/core/adapters/inbound/agents/aider/agent.go
@@ -4,7 +4,11 @@ import (
 	"regexp"
 
 	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
 )
+
+// PermissionKeyHistory gates all Aider monitoring (issue #570).
+const PermissionKeyHistory = "history"
 
 // Aider's actual OS process is `python` invoking the aider script (uv/pipx
 // wrapper), so `pgrep -x aider` finds nothing. The leading slash anchors
@@ -46,6 +50,19 @@ func Agent() agent.Agent {
 			Filename: transcriptFilename,
 			Parser: agent.RawLineParser{
 				NewParser: func() agent.RawParser { return &Parser{} },
+			},
+		},
+		Permissions: []agent.Permission{
+			{
+				Key:             PermissionKeyHistory,
+				Kind:            permission.KindObserve,
+				Title:           "Read chat history",
+				FeatureUnlocked: "Session list, timeline, cost & token metrics",
+				Touches:         "Reads " + transcriptFilename + " in each project directory",
+				Detail: "Tails the " + transcriptFilename + " file Aider writes in " +
+					"the working directory of each running aider process. Read-only " +
+					"— no file is ever modified. Toggling off stops all reading " +
+					"immediately.",
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -2,7 +2,16 @@ package claudecode
 
 import (
 	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
 	"irrlicht/core/pkg/tailer"
+)
+
+// Permission keys for the consent wizard (issue #570). Referenced by the
+// hook/statusline HTTP handlers' consent gates and the daemon wiring.
+const (
+	PermissionKeyHooks       = "hooks"
+	PermissionKeyStatusline  = "statusline"
+	PermissionKeyTranscripts = "transcripts"
 )
 
 // Claude Code mascot — pixel-art rectangular creature with eyes and legs.
@@ -37,6 +46,47 @@ func Agent() agent.Agent {
 			Dir: transcriptsDir(),
 			Parser: agent.JSONLineParser{
 				NewParser: func() agent.LineParser { return &Parser{} },
+			},
+		},
+		Permissions: []agent.Permission{
+			{
+				Key:             PermissionKeyTranscripts,
+				Kind:            permission.KindObserve,
+				Title:           "Read session transcripts",
+				FeatureUnlocked: "Session list, timeline, cost & token metrics",
+				Touches:         "Reads session transcripts under ~/.claude/projects/",
+				Detail: "Tails *.jsonl transcript files under ~/.claude/projects/ " +
+					"to derive session state, cost, and token metrics. Read-only — " +
+					"no transcript file is ever modified. Toggling off stops all " +
+					"reading immediately.",
+			},
+			{
+				Key:             PermissionKeyHooks,
+				Kind:            permission.KindModify,
+				Title:           "Install status hooks",
+				FeatureUnlocked: "Instant waiting-state detection (permission prompts, plan approval, questions)",
+				Touches:         "Writes 4 hook entries to ~/.claude/settings.json",
+				Detail: "Adds PermissionRequest, PreToolUse, PostToolUse, and " +
+					"PostToolUseFailure hook entries whose command is: " +
+					installedHookCommand + " — each POSTs the hook payload to the " +
+					"local daemon. Toggling off removes exactly these entries " +
+					"(also available via `irrlichd --uninstall-hooks`).",
+				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
+				Remove: func() error { _, err := UninstallHooks(); return err },
+			},
+			{
+				Key:             PermissionKeyStatusline,
+				Kind:            permission.KindModify,
+				Title:           "Install statusline feed",
+				FeatureUnlocked: "Rate-limit / quota forecast for Pro & Max subscriptions",
+				Touches:         "Sets statusLine.command in ~/.claude/settings.json",
+				Detail: "Sets statusLine.command to: " + installedStatuslineCommand +
+					" — POSTs Claude Code's statusline JSON (carrying rate-limit " +
+					"data) to the local daemon. An existing user statusline is " +
+					"chained, not replaced. Toggling off restores the previous " +
+					"command (or removes the entry if irrlicht installed it).",
+				Apply:  func() error { _, err := EnsureStatuslineInstalled(); return err },
+				Remove: func() error { _, err := UninstallStatusline(); return err },
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -53,6 +53,14 @@ type HookTarget interface {
 	HandlePermissionHook(sessionID, transcriptPath, hookEventName string)
 }
 
+// ConsentGate reports whether the user has granted a permission (issue
+// #570). Satisfied by *services.PermissionService. Hooks installed by a
+// pre-consent daemon version keep firing until answered, so the receivers
+// drop payloads while their permission is pending or denied.
+type ConsentGate interface {
+	Granted(agentName, key string) bool
+}
+
 // sessionIDFromTranscriptPath extracts irrlicht's session ID (the UUID
 // filename stem) from a Claude Code transcript path. The hook payload's
 // session_id may differ from the transcript filename, so we always derive
@@ -71,10 +79,19 @@ func sessionIDFromTranscriptPath(p string) string {
 // The handler returns 200 with an empty body for recognized events. For
 // PermissionRequest, an empty response means Claude Code shows its normal
 // permission prompt (no auto-approve/deny).
-func NewHookHandler(target HookTarget, log outbound.Logger) http.HandlerFunc {
+//
+// gate is the consent check for the "hooks" permission; while not granted
+// the payload is dropped with 200 (so the curl hook stays quiet). A nil
+// gate means no gating — used by tests.
+func NewHookHandler(target HookTarget, gate ConsentGate, log outbound.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if gate != nil && !gate.Granted(AdapterName, PermissionKeyHooks) {
+			w.WriteHeader(http.StatusOK)
 			return
 		}
 

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -59,7 +59,7 @@ func TestSessionIDFromTranscriptPath(t *testing.T) {
 
 func TestHookHandler_PermissionRequest(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, mockLogger{})
+	handler := NewHookHandler(target, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-123.jsonl",
@@ -90,7 +90,7 @@ func TestHookHandler_PermissionRequest(t *testing.T) {
 
 func TestHookHandler_PostToolUse(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, mockLogger{})
+	handler := NewHookHandler(target, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-456.jsonl",
@@ -115,7 +115,7 @@ func TestHookHandler_PostToolUse(t *testing.T) {
 
 func TestHookHandler_PreToolUse(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, mockLogger{})
+	handler := NewHookHandler(target, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-pre.jsonl",
@@ -150,7 +150,7 @@ func TestHookHandler_PreToolUse(t *testing.T) {
 // the sole filter.
 func TestHookHandler_PreToolUse_RejectsUnexpectedTool(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, mockLogger{})
+	handler := NewHookHandler(target, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-x.jsonl",
@@ -174,7 +174,7 @@ func TestHookHandler_PreToolUse_RejectsUnexpectedTool(t *testing.T) {
 
 func TestHookHandler_PostToolUseFailure(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, mockLogger{})
+	handler := NewHookHandler(target, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-789.jsonl",
@@ -199,7 +199,7 @@ func TestHookHandler_PostToolUseFailure(t *testing.T) {
 
 func TestHookHandler_UnrecognizedEvent(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, mockLogger{})
+	handler := NewHookHandler(target, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess.jsonl",
@@ -222,7 +222,7 @@ func TestHookHandler_UnrecognizedEvent(t *testing.T) {
 
 func TestHookHandler_MissingTranscriptPath(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, mockLogger{})
+	handler := NewHookHandler(target, nil, mockLogger{})
 
 	payload := hookPayload{
 		HookEventName: "PermissionRequest",
@@ -241,7 +241,7 @@ func TestHookHandler_MissingTranscriptPath(t *testing.T) {
 
 func TestHookHandler_WrongMethod(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, mockLogger{})
+	handler := NewHookHandler(target, nil, mockLogger{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/hooks/claudecode", nil)
 	rec := httptest.NewRecorder()
@@ -254,7 +254,7 @@ func TestHookHandler_WrongMethod(t *testing.T) {
 
 func TestHookHandler_MalformedJSON(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, mockLogger{})
+	handler := NewHookHandler(target, nil, mockLogger{})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader([]byte("not json")))
 	rec := httptest.NewRecorder()
@@ -262,5 +262,55 @@ func TestHookHandler_MalformedJSON(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+	}
+}
+
+// fakeGate is a ConsentGate with a fixed answer.
+type fakeGate bool
+
+func (g fakeGate) Granted(_, _ string) bool { return bool(g) }
+
+func TestHookHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
+	target := &mockTarget{}
+	handler := NewHookHandler(target, fakeGate(false), mockLogger{})
+
+	payload := hookPayload{
+		TranscriptPath: "/Users/u/.claude/projects/p/sess-123.jsonl",
+		HookEventName:  "PermissionRequest",
+		ToolName:       "Bash",
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	// 200 keeps the curl hook quiet, but nothing is dispatched.
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if calls := target.getCalls(); len(calls) != 0 {
+		t.Fatalf("dispatched %d calls while permission not granted", len(calls))
+	}
+}
+
+func TestHookHandler_ConsentGatePassesWhenGranted(t *testing.T) {
+	target := &mockTarget{}
+	handler := NewHookHandler(target, fakeGate(true), mockLogger{})
+
+	payload := hookPayload{
+		TranscriptPath: "/Users/u/.claude/projects/p/sess-123.jsonl",
+		HookEventName:  "PermissionRequest",
+		ToolName:       "Bash",
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if calls := target.getCalls(); len(calls) != 1 {
+		t.Fatalf("calls = %d, want 1", len(calls))
 	}
 }

--- a/core/adapters/inbound/agents/claudecode/statusline.go
+++ b/core/adapters/inbound/agents/claudecode/statusline.go
@@ -67,10 +67,19 @@ type RateLimitTarget interface {
 // empty body on success; on bad input or missing transcript_path it returns
 // the appropriate 4xx. It never blocks: target.IngestRateLimit is a no-op
 // when the session hasn't been seen yet, so the handler returns immediately.
-func NewStatuslineHandler(target RateLimitTarget, log outbound.Logger) http.HandlerFunc {
+//
+// gate is the consent check for the "statusline" permission; while not
+// granted the payload is dropped with 200. A nil gate means no gating —
+// used by tests.
+func NewStatuslineHandler(target RateLimitTarget, gate ConsentGate, log outbound.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if gate != nil && !gate.Granted(AdapterName, PermissionKeyStatusline) {
+			w.WriteHeader(http.StatusOK)
 			return
 		}
 

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -34,7 +34,7 @@ func (silentLogger) Close() error                                       { return
 
 func TestStatuslineHandler_IngestsRateLimits(t *testing.T) {
 	target := &fakeRateLimitTarget{}
-	h := NewStatuslineHandler(target, silentLogger{})
+	h := NewStatuslineHandler(target, nil, silentLogger{})
 
 	body := `{
 		"session_id": "abc",
@@ -71,7 +71,7 @@ func TestStatuslineHandler_IngestsRateLimits(t *testing.T) {
 
 func TestStatuslineHandler_NoRateLimitsBlockIsOk(t *testing.T) {
 	target := &fakeRateLimitTarget{}
-	h := NewStatuslineHandler(target, silentLogger{})
+	h := NewStatuslineHandler(target, nil, silentLogger{})
 
 	body := `{"session_id":"abc","transcript_path":"/tmp/abc.jsonl"}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", bytes.NewBufferString(body))
@@ -87,7 +87,7 @@ func TestStatuslineHandler_NoRateLimitsBlockIsOk(t *testing.T) {
 }
 
 func TestStatuslineHandler_RejectsMissingTranscriptPath(t *testing.T) {
-	h := NewStatuslineHandler(&fakeRateLimitTarget{}, silentLogger{})
+	h := NewStatuslineHandler(&fakeRateLimitTarget{}, nil, silentLogger{})
 	body := `{"session_id":"abc"}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", bytes.NewBufferString(body))
 	rr := httptest.NewRecorder()
@@ -98,7 +98,7 @@ func TestStatuslineHandler_RejectsMissingTranscriptPath(t *testing.T) {
 }
 
 func TestStatuslineHandler_RejectsNonPost(t *testing.T) {
-	h := NewStatuslineHandler(&fakeRateLimitTarget{}, silentLogger{})
+	h := NewStatuslineHandler(&fakeRateLimitTarget{}, nil, silentLogger{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", nil)
 	rr := httptest.NewRecorder()
 	h(rr, req)
@@ -114,7 +114,7 @@ func TestStatuslineHandler_SampledAtUsesClock(t *testing.T) {
 	t.Cleanup(func() { statuslineNow = prev })
 
 	target := &fakeRateLimitTarget{}
-	h := NewStatuslineHandler(target, silentLogger{})
+	h := NewStatuslineHandler(target, nil, silentLogger{})
 	body := `{"transcript_path":"/tmp/x.jsonl","rate_limits":{"five_hour":{"used_percentage":1,"resets_at":2}}}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", bytes.NewBufferString(body))
 	rr := httptest.NewRecorder()
@@ -255,5 +255,28 @@ func TestChainStatuslineCommand_MigratesOldWrapsToV3(t *testing.T) {
 		if !strings.Contains(got, userCmd) {
 			t.Errorf("expected user command to survive migration, got %q", got)
 		}
+	}
+}
+
+func TestStatuslineHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
+	target := &fakeRateLimitTarget{}
+	h := NewStatuslineHandler(target, fakeGate(false), silentLogger{})
+
+	body := `{
+		"session_id": "abc",
+		"transcript_path": "/tmp/sessions/abc.jsonl",
+		"rate_limits": {
+			"five_hour": {"used_percentage": 47, "resets_at": 1778761800}
+		}
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode/statusline", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if len(target.calls) != 0 {
+		t.Fatalf("ingested %d snapshots while permission not granted", len(target.calls))
 	}
 }

--- a/core/adapters/inbound/agents/codex/agent.go
+++ b/core/adapters/inbound/agents/codex/agent.go
@@ -1,6 +1,12 @@
 package codex
 
-import "irrlicht/core/domain/agent"
+import (
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+)
+
+// PermissionKeyTranscripts gates all Codex monitoring (issue #570).
+const PermissionKeyTranscripts = "transcripts"
 
 // Codex — circle with >_ terminal prompt. Color picks contrast against
 // the surrounding chrome: near-black on light themes, near-white on dark.
@@ -33,6 +39,19 @@ func Agent() agent.Agent {
 			Dir: sessionsDir(),
 			Parser: agent.JSONLineParser{
 				NewParser: func() agent.LineParser { return &Parser{} },
+			},
+		},
+		Permissions: []agent.Permission{
+			{
+				Key:             PermissionKeyTranscripts,
+				Kind:            permission.KindObserve,
+				Title:           "Read session transcripts",
+				FeatureUnlocked: "Session list, timeline, cost & token metrics",
+				Touches:         "Reads session transcripts under ~/.codex/sessions/",
+				Detail: "Tails *.jsonl session files under ~/.codex/sessions/YYYY/MM/DD/ " +
+					"to derive session state, cost, and token metrics. Read-only — " +
+					"no file is ever modified. Toggling off stops all reading " +
+					"immediately.",
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/opencode/agent.go
+++ b/core/adapters/inbound/agents/opencode/agent.go
@@ -2,8 +2,12 @@ package opencode
 
 import (
 	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
 	"irrlicht/core/domain/session"
 )
+
+// PermissionKeyDatabase gates all OpenCode monitoring (issue #570).
+const PermissionKeyDatabase = "database"
 
 // OpenCode — curly braces { } in a circle, rendered in OpenCode's brand blue.
 // Background swaps for theme so the icon doesn't blow out against light or
@@ -46,6 +50,19 @@ func Agent() agent.Agent {
 				panic("opencode.Agent().Source.PathForPID: resolver not installed")
 			},
 			Reader: metricsReader{},
+		},
+		Permissions: []agent.Permission{
+			{
+				Key:             PermissionKeyDatabase,
+				Kind:            permission.KindObserve,
+				Title:           "Read session database",
+				FeatureUnlocked: "Session list, timeline, cost & token metrics",
+				Touches:         "Reads ~/.local/share/opencode/opencode.db (read-only polling)",
+				Detail: "Polls OpenCode's SQLite database at " +
+					"~/.local/share/opencode/opencode.db in read-only mode to derive " +
+					"session state, cost, and token metrics. No row is ever written. " +
+					"Toggling off stops all polling immediately.",
+			},
 		},
 	}
 }

--- a/core/adapters/inbound/agents/pi/agent.go
+++ b/core/adapters/inbound/agents/pi/agent.go
@@ -1,6 +1,12 @@
 package pi
 
-import "irrlicht/core/domain/agent"
+import (
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+)
+
+// PermissionKeyTranscripts gates all Pi monitoring (issue #570).
+const PermissionKeyTranscripts = "transcripts"
 
 // Pi coding agent — Greek letter pi in a circle. Color picks contrast against
 // the surrounding chrome: near-black on light themes, near-white on dark.
@@ -35,6 +41,19 @@ func Agent() agent.Agent {
 			Dir: sessionsDir(),
 			Parser: agent.JSONLineParser{
 				NewParser: func() agent.LineParser { return &Parser{} },
+			},
+		},
+		Permissions: []agent.Permission{
+			{
+				Key:             PermissionKeyTranscripts,
+				Kind:            permission.KindObserve,
+				Title:           "Read session transcripts",
+				FeatureUnlocked: "Session list, timeline, cost & token metrics",
+				Touches:         "Reads session transcripts under ~/.pi/agent/sessions/",
+				Detail: "Tails *.jsonl session files under ~/.pi/agent/sessions/ to " +
+					"derive session state, cost, and token metrics. Read-only — no " +
+					"file is ever modified. Toggling off stops all reading " +
+					"immediately.",
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/processlifecycle/discovery.go
+++ b/core/adapters/inbound/agents/processlifecycle/discovery.go
@@ -4,7 +4,28 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"irrlicht/core/domain/agent"
 )
+
+// HasLiveProcess reports whether at least one running process matches m.
+// It is the always-on detection primitive behind the consent wizard
+// (issue #570): pure observation through the ProcessObserver seam, with
+// no session side-effects — unlike the Scanner, which emits proc-<pid>
+// pre-sessions and is therefore permission-gated.
+func HasLiveProcess(m agent.ProcessMatcher) bool {
+	var pids []int
+	var err error
+	switch v := m.(type) {
+	case agent.ExactName:
+		pids, err = osProc.FindByName(v.Name)
+	case agent.CommandPattern:
+		pids, err = osProc.FindByCmdline(v.Regex.String())
+	default:
+		return false
+	}
+	return err == nil && len(pids) > 0
+}
 
 // DiscoverPIDByCWD finds a process by exact name whose CWD matches the given
 // directory. When multiple processes match, disambiguate selects one.

--- a/core/adapters/inbound/agents/processlifecycle/launcher_permission.go
+++ b/core/adapters/inbound/agents/processlifecycle/launcher_permission.go
@@ -1,0 +1,45 @@
+// launcher_permission.go declares the consent surface for launcher-identity
+// capture (issue #570). ReadLauncherEnv reads a whitelist of environment
+// variables from agent processes — a distinct read kind the wizard must
+// name, even though it only ever runs for sessions that already passed an
+// agent's observe gate. The daemon wires the actual gate as a Granted()
+// check around the reader, so no Apply/Remove closures are needed.
+package processlifecycle
+
+import (
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+)
+
+// LauncherName identifies the launcher-capture pseudo-entry in the
+// permission store and wizard.
+const LauncherName = "launcher"
+
+// PermissionKeyLauncherEnv gates the launcher-identity env capture.
+const PermissionKeyLauncherEnv = "env"
+
+// LauncherPermissionDeclaration returns the consent declaration for
+// launcher-identity capture. Like the Gas Town orchestrator it isn't a
+// coding-agent adapter (no Source/Process axes) — it's a daemon-wide
+// capability gated through the same wizard.
+func LauncherPermissionDeclaration() agent.Agent {
+	return agent.Agent{
+		Identity: agent.Identity{Name: LauncherName, DisplayName: "Terminal focus"},
+		Permissions: []agent.Permission{{
+			Key:             PermissionKeyLauncherEnv,
+			Kind:            permission.KindObserve,
+			Title:           "Capture terminal identity",
+			FeatureUnlocked: "Click-to-focus: jump from a session row or notification straight to the terminal window that runs it",
+			Touches:         "Reads a fixed whitelist of environment variables from detected agent processes (TERM_PROGRAM, KITTY_*, TMUX, …)",
+			Detail: "When a session is linked to its process, irrlicht reads only " +
+				"these variables from that process's environment: TERM_PROGRAM, " +
+				"ITERM_SESSION_ID, TERM_SESSION_ID, TMUX, TMUX_PANE, VSCODE_PID, " +
+				"TERMINAL_EMULATOR, KITTY_PID, KITTY_LISTEN_ON, KITTY_WINDOW_ID — " +
+				"never the full environment. Focusing itself only happens when you " +
+				"click a session (kitty remote control / AppleScript, additionally " +
+				"gated by macOS automation prompts). Toggling off stops the capture " +
+				"immediately; without it, click-to-focus falls back to app-level " +
+				"activation.",
+		}},
+	}
+}

--- a/core/adapters/inbound/orchestrators/gastown/adapter.go
+++ b/core/adapters/inbound/orchestrators/gastown/adapter.go
@@ -42,7 +42,7 @@ func NewAdapter(gtBin string, interval time.Duration, sessions sessionLister) *A
 }
 
 // Name returns the orchestrator identifier.
-func (a *Adapter) Name() string { return "gastown" }
+func (a *Adapter) Name() string { return Name }
 
 // Detected returns true if a valid Gas Town installation was found.
 func (a *Adapter) Detected() bool { return a.collector.Detected() }

--- a/core/adapters/inbound/orchestrators/gastown/permission.go
+++ b/core/adapters/inbound/orchestrators/gastown/permission.go
@@ -1,0 +1,49 @@
+// permission.go declares Gas Town's consent surface (issue #570). The
+// orchestrator isn't a coding-agent adapter — it has no Source/Process
+// axes — but it reads the user's ~/gt state and execs the gt binary, so
+// its monitoring is consent-gated exactly like the agent adapters'.
+package gastown
+
+import (
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+)
+
+// Name is the orchestrator identifier used on events, in the permission
+// store, and by the wizard.
+const Name = "gastown"
+
+// PermissionKeyState gates all Gas Town monitoring.
+const PermissionKeyState = "state"
+
+// RootDetected reports whether a Gas Town root exists (GT_ROOT env var or
+// ~/gt) — a stat-only probe with no file reads, safe before consent. The
+// permission service uses it as the wizard's detection signal; the full
+// adapter, whose construction reads state files, is only built on grant.
+func RootDetected() bool {
+	root := resolveRoot()
+	return root != "" && isGasTownRoot(root)
+}
+
+// PermissionDeclaration returns the consent declaration for Gas Town.
+// start/stop are wired by the daemon: they construct the adapter (whose
+// construction reads ~/gt) and start/stop its watcher.
+func PermissionDeclaration(start, stop func() error) agent.Agent {
+	return agent.Agent{
+		Identity: agent.Identity{Name: Name, DisplayName: "Gas Town"},
+		Permissions: []agent.Permission{{
+			Key:             PermissionKeyState,
+			Kind:            permission.KindObserve,
+			Title:           "Read Gas Town state",
+			FeatureUnlocked: "Orchestrator view: rigs, polecats, and convoy status",
+			Touches:         "Reads ~/gt (daemon/state.json, rigs.json) and runs `gt … list` subcommands",
+			Detail: "Watches Gas Town's daemon/state.json and rigs.json under " +
+				"GT_ROOT (default ~/gt) and periodically runs read-only " +
+				"`gt rig/polecat/dog/boot list` commands to populate the " +
+				"orchestrator view. Toggling off stops all reading and gt " +
+				"invocations immediately.",
+			Apply:  start,
+			Remove: stop,
+		}},
+	}
+}

--- a/core/adapters/inbound/permissions/handlers.go
+++ b/core/adapters/inbound/permissions/handlers.go
@@ -1,0 +1,70 @@
+// Package permissions provides the HTTP handlers for the consent-first
+// permission wizard (issue #570): GET /api/v1/permissions serves every
+// agent's declared permissions with their consent state, and
+// POST /api/v1/permissions/answer applies the user's decisions.
+package permissions
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	services "irrlicht/core/application/services"
+	"irrlicht/core/ports/outbound"
+)
+
+// target is the interface both handlers call into. Satisfied by
+// *services.PermissionService.
+type target interface {
+	Snapshot() services.PermissionsSnapshot
+	Answer(answers []services.PermissionAnswer) error
+}
+
+// answerRequest is the POST /api/v1/permissions/answer body.
+type answerRequest struct {
+	Answers []services.PermissionAnswer `json:"answers"`
+}
+
+// NewGetHandler returns the handler for GET /api/v1/permissions.
+func NewGetHandler(t target, log outbound.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeSnapshot(w, t, log)
+	}
+}
+
+// NewAnswerHandler returns the handler for POST /api/v1/permissions/answer.
+// The first surface to answer wins: the service broadcasts
+// permissions_updated so the other surface dismisses its wizard live, and
+// a duplicate submission of the same answer is a no-op.
+//
+// Responses:
+//   - 200: answers applied; body is the updated permissions snapshot
+//   - 400: malformed JSON or unknown agent/permission pair
+func NewAnswerHandler(t target, log outbound.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req answerRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
+			return
+		}
+		if err := t.Answer(req.Answers); err != nil {
+			log.LogError("permissions", "", err.Error())
+			if errors.Is(err, services.ErrUnknownPermission) {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		// Return the updated snapshot so the answering surface refreshes
+		// without a second round-trip.
+		writeSnapshot(w, t, log)
+	}
+}
+
+func writeSnapshot(w http.ResponseWriter, t target, log outbound.Logger) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(t.Snapshot()); err != nil {
+		log.LogError("permissions", "", err.Error())
+	}
+}

--- a/core/adapters/inbound/permissions/handlers_test.go
+++ b/core/adapters/inbound/permissions/handlers_test.go
@@ -1,0 +1,109 @@
+package permissions
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	services "irrlicht/core/application/services"
+)
+
+type fakeTarget struct {
+	snapshot services.PermissionsSnapshot
+	answered [][]services.PermissionAnswer
+	err      error
+}
+
+func (t *fakeTarget) Snapshot() services.PermissionsSnapshot { return t.snapshot }
+func (t *fakeTarget) Answer(a []services.PermissionAnswer) error {
+	t.answered = append(t.answered, a)
+	return t.err
+}
+
+type silentLogger struct{}
+
+func (silentLogger) LogInfo(_, _, _ string)                                  {}
+func (silentLogger) LogError(_, _, _ string)                                 {}
+func (silentLogger) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
+func (silentLogger) Close() error                                            { return nil }
+
+func testSnapshot() services.PermissionsSnapshot {
+	return services.PermissionsSnapshot{
+		Mode: "ask",
+		Agents: []services.AgentPermissions{{
+			Name:        "claude-code",
+			DisplayName: "Claude Code",
+			Detected:    true,
+			Permissions: []services.PermissionView{{
+				Key: "hooks", Kind: "modify", State: "pending",
+				Title: "Install status hooks",
+			}},
+		}},
+	}
+}
+
+func TestGetHandlerServesSnapshot(t *testing.T) {
+	target := &fakeTarget{snapshot: testSnapshot()}
+	rec := httptest.NewRecorder()
+	NewGetHandler(target, silentLogger{})(rec, httptest.NewRequest(http.MethodGet, "/api/v1/permissions", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type = %q", ct)
+	}
+	var got services.PermissionsSnapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Mode != "ask" || len(got.Agents) != 1 || got.Agents[0].Name != "claude-code" ||
+		!got.Agents[0].Detected || got.Agents[0].Permissions[0].State != "pending" {
+		t.Fatalf("unexpected snapshot: %+v", got)
+	}
+}
+
+func TestAnswerHandlerAppliesAndReturnsSnapshot(t *testing.T) {
+	target := &fakeTarget{snapshot: testSnapshot()}
+	body := `{"answers":[{"agent":"claude-code","permission":"hooks","grant":true}]}`
+	rec := httptest.NewRecorder()
+	NewAnswerHandler(target, silentLogger{})(rec, httptest.NewRequest(http.MethodPost, "/api/v1/permissions/answer", strings.NewReader(body)))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(target.answered) != 1 || len(target.answered[0]) != 1 {
+		t.Fatalf("answered = %+v", target.answered)
+	}
+	ans := target.answered[0][0]
+	if ans.Agent != "claude-code" || ans.Permission != "hooks" || !ans.Grant {
+		t.Fatalf("answer = %+v", ans)
+	}
+	var got services.PermissionsSnapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Mode != "ask" {
+		t.Fatalf("response is not the snapshot: %+v", got)
+	}
+}
+
+func TestAnswerHandlerMalformedJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	NewAnswerHandler(&fakeTarget{}, silentLogger{})(rec, httptest.NewRequest(http.MethodPost, "/api/v1/permissions/answer", strings.NewReader("{nope")))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestAnswerHandlerUnknownPermissionIs400(t *testing.T) {
+	target := &fakeTarget{err: services.ErrUnknownPermission}
+	body := `{"answers":[{"agent":"nope","permission":"nope","grant":true}]}`
+	rec := httptest.NewRecorder()
+	NewAnswerHandler(target, silentLogger{})(rec, httptest.NewRequest(http.MethodPost, "/api/v1/permissions/answer", strings.NewReader(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}

--- a/core/adapters/outbound/filesystem/atomic.go
+++ b/core/adapters/outbound/filesystem/atomic.go
@@ -1,0 +1,24 @@
+package filesystem
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// writeFileAtomic writes data to path via a temp file + rename so a reader
+// can never observe a torn write. The temp name carries pid+nanotime —
+// matching the repository and cost-tracker writers — so two processes
+// (e.g. two daemons mistakenly sharing one IRRLICHT_HOME) can't clobber
+// each other's in-flight temp file.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	tmp := fmt.Sprintf("%s.tmp.%d.%d", path, os.Getpid(), time.Now().UnixNano())
+	if err := os.WriteFile(tmp, data, perm); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}

--- a/core/adapters/outbound/filesystem/permission_store.go
+++ b/core/adapters/outbound/filesystem/permission_store.go
@@ -1,0 +1,74 @@
+// permission_store.go persists the user's consent answers for the
+// permission transparency wizard (issue #570) as JSON under the daemon
+// data dir. A missing file means every permission is pending — which is
+// both the fresh-install state and the upgrade migration: existing
+// installs pause all monitoring until the wizard is answered.
+package filesystem
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"irrlicht/core/domain/permission"
+)
+
+// permissionFileVersion is bumped if the on-disk shape ever changes.
+const permissionFileVersion = 1
+
+// permissionFile is the on-disk JSON shape of permissions.json.
+type permissionFile struct {
+	Version int            `json:"version"`
+	Agents  permission.Set `json:"agents"`
+}
+
+// PermissionStore persists permission.Set to <dir>/permissions.json with
+// atomic temp+rename writes. Safe for concurrent use.
+type PermissionStore struct {
+	mu   sync.Mutex
+	path string
+}
+
+// NewPermissionStore returns a store rooted at dir (the daemon data dir,
+// IRRLICHT_HOME-aware via the caller).
+func NewPermissionStore(dir string) *PermissionStore {
+	return &PermissionStore{path: filepath.Join(dir, "permissions.json")}
+}
+
+// Load reads the persisted permission set. A missing file returns an
+// empty set (all pending), not an error.
+func (s *PermissionStore) Load() (permission.Set, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return permission.Set{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var f permissionFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, err
+	}
+	if f.Agents == nil {
+		f.Agents = permission.Set{}
+	}
+	return f.Agents, nil
+}
+
+// Save writes the permission set atomically (temp file + rename).
+func (s *PermissionStore) Save(set permission.Set) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(permissionFile{Version: permissionFileVersion, Agents: set}, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return writeFileAtomic(s.path, data, 0o600)
+}

--- a/core/adapters/outbound/filesystem/permission_store_test.go
+++ b/core/adapters/outbound/filesystem/permission_store_test.go
@@ -1,0 +1,70 @@
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/domain/permission"
+)
+
+func TestPermissionStoreMissingFileIsEmptySet(t *testing.T) {
+	s := NewPermissionStore(t.TempDir())
+	set, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(set) != 0 {
+		t.Fatalf("expected empty set, got %v", set)
+	}
+	// Empty set means everything pending — the consent-first migration.
+	if got := set.Get("claude-code", "hooks"); got != permission.StatePending {
+		t.Fatalf("Get = %q, want pending", got)
+	}
+}
+
+func TestPermissionStoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := NewPermissionStore(dir)
+
+	set := permission.Set{}
+	set.Put("claude-code", "hooks", permission.StateGranted)
+	set.Put("claude-code", "statusline", permission.StateDenied)
+	set.Put("codex", "transcripts", permission.StateGranted)
+	if err := s.Save(set); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// No stray temp file left behind by the atomic write.
+	if leftovers, _ := filepath.Glob(filepath.Join(dir, "permissions.json.tmp*")); len(leftovers) > 0 {
+		t.Fatalf("temp files left behind: %v", leftovers)
+	}
+
+	loaded, err := NewPermissionStore(dir).Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := loaded.Get("claude-code", "hooks"); got != permission.StateGranted {
+		t.Fatalf("hooks = %q, want granted", got)
+	}
+	if got := loaded.Get("claude-code", "statusline"); got != permission.StateDenied {
+		t.Fatalf("statusline = %q, want denied", got)
+	}
+	if got := loaded.Get("codex", "transcripts"); got != permission.StateGranted {
+		t.Fatalf("codex = %q, want granted", got)
+	}
+	// Unanswered pair still pending after round-trip.
+	if got := loaded.Get("pi", "transcripts"); got != permission.StatePending {
+		t.Fatalf("pi = %q, want pending", got)
+	}
+}
+
+func TestPermissionStoreCorruptFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "permissions.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewPermissionStore(dir).Load(); err == nil {
+		t.Fatal("expected error on corrupt file")
+	}
+}

--- a/core/adapters/outbound/relay/forwarder.go
+++ b/core/adapters/outbound/relay/forwarder.go
@@ -205,8 +205,12 @@ func (f *Forwarder) snapshotState() ([]*session.SessionState, []AgentInfo) {
 // shouldForward drops messages meaningless across hosts. focus_requested asks a
 // client to raise the local terminal/IDE window of a session — nonsensical for
 // a session on a different machine, so the forwarder filters it (wiki §5.4).
+// permissions_updated is likewise host-local (#570): consent is managed on the
+// daemon's own machine, and a forwarded copy would make remote dashboards
+// re-fetch (and potentially re-open) their LOCAL wizard on this host's churn.
 func shouldForward(msg outbound.PushMessage) bool {
-	return msg.Type != outbound.PushTypeFocusRequested
+	return msg.Type != outbound.PushTypeFocusRequested &&
+		msg.Type != outbound.PushTypePermissionsUpdated
 }
 
 // jitter returns a random duration in [0, d/2] to spread reconnect attempts.

--- a/core/adapters/outbound/relay/forwarder_test.go
+++ b/core/adapters/outbound/relay/forwarder_test.go
@@ -208,6 +208,9 @@ func TestShouldForward(t *testing.T) {
 	if shouldForward(outbound.PushMessage{Type: outbound.PushTypeFocusRequested}) {
 		t.Fatal("focus_requested must not be forwarded")
 	}
+	if shouldForward(outbound.PushMessage{Type: outbound.PushTypePermissionsUpdated}) {
+		t.Fatal("permissions_updated is host-local consent state and must not be forwarded")
+	}
 	for _, ty := range []string{
 		outbound.PushTypeCreated, outbound.PushTypeUpdated, outbound.PushTypeDeleted,
 		outbound.PushTypeHistoryTick, outbound.PushTypeHistorySnapshot,

--- a/core/application/services/orchestrator_monitor.go
+++ b/core/application/services/orchestrator_monitor.go
@@ -20,6 +20,12 @@ type OrchestratorMonitor struct {
 	broadcaster outbound.PushBroadcaster
 	log         outbound.Logger
 
+	// merged is created at construction (not in Run) so watchers can be
+	// registered via AddWatcher before or after Run starts — orchestrator
+	// monitoring is consent-gated and starts/stops at grant/revoke time
+	// (#570). Never closed; Run exits on ctx cancellation.
+	merged chan orchestrator.State
+
 	mu     sync.RWMutex
 	states map[string]*orchestrator.State // name → latest state
 }
@@ -34,7 +40,40 @@ func NewOrchestratorMonitor(
 		watchers:    watchers,
 		broadcaster: broadcaster,
 		log:         log,
+		merged:      make(chan orchestrator.State, 4),
 		states:      make(map[string]*orchestrator.State),
+	}
+}
+
+// AddWatcher registers an orchestrator watcher with the running (or
+// not-yet-running) monitor: a drain goroutine forwards its state snapshots
+// into the merged channel until ctx is cancelled. The caller owns the
+// watcher's Watch lifecycle under the same ctx — this is how the
+// permission service starts/stops orchestrator monitoring on grant/revoke
+// (#570).
+func (m *OrchestratorMonitor) AddWatcher(ctx context.Context, w inbound.OrchestratorWatcher) {
+	go m.drainWatcher(ctx, w)
+}
+
+// drainWatcher subscribes to one watcher and forwards its snapshots into
+// the merged channel until ctx is cancelled or the subscription closes.
+func (m *OrchestratorMonitor) drainWatcher(ctx context.Context, w inbound.OrchestratorWatcher) {
+	ch := w.Subscribe()
+	defer w.Unsubscribe(ch)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case state, ok := <-ch:
+			if !ok {
+				return
+			}
+			select {
+			case m.merged <- state:
+			case <-ctx.Done():
+				return
+			}
+		}
 	}
 }
 
@@ -49,45 +88,13 @@ func (m *OrchestratorMonitor) State(name string) *orchestrator.State {
 	return nil
 }
 
-// Run subscribes to all OrchestratorWatcher event streams, fans them into a
-// single channel, and broadcasts updates. It blocks until ctx is cancelled.
+// Run drains all OrchestratorWatcher event streams into the merged channel
+// and records state updates. It blocks until ctx is cancelled. Watchers
+// registered later via AddWatcher feed the same channel.
 func (m *OrchestratorMonitor) Run(ctx context.Context) error {
-	if len(m.watchers) == 0 {
-		<-ctx.Done()
-		return ctx.Err()
-	}
-
-	merged := make(chan orchestrator.State, 4)
-	var wg sync.WaitGroup
-
 	for _, w := range m.watchers {
-		ch := w.Subscribe()
-		wg.Add(1)
-		go func(watcher inbound.OrchestratorWatcher, ch <-chan orchestrator.State) {
-			defer wg.Done()
-			defer watcher.Unsubscribe(ch)
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case state, ok := <-ch:
-					if !ok {
-						return
-					}
-					select {
-					case merged <- state:
-					case <-ctx.Done():
-						return
-					}
-				}
-			}
-		}(w, ch)
+		go m.drainWatcher(ctx, w)
 	}
-
-	go func() {
-		wg.Wait()
-		close(merged)
-	}()
 
 	m.log.LogInfo("orchestrator-monitor", "", fmt.Sprintf("started — watching %d orchestrator(s)", len(m.watchers)))
 
@@ -95,10 +102,7 @@ func (m *OrchestratorMonitor) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case state, ok := <-merged:
-			if !ok {
-				return nil
-			}
+		case state := <-m.merged:
 			m.mu.Lock()
 			cp := state
 			m.states[state.Adapter] = &cp

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -360,6 +360,20 @@ func (s *PermissionService) runEffects(effects []pendingEffect) {
 	s.effectMu.Lock()
 	defer s.effectMu.Unlock()
 	for _, e := range effects {
+		// A conflicting answer may have superseded this effect while the
+		// batch waited on effectMu: state mutations serialize under mu,
+		// effect batches under effectMu, and the two orders can differ
+		// when both surfaces answer the same permission near-
+		// simultaneously. Skip stale effects so the executed side effects
+		// always converge to the recorded state — the superseding answer
+		// carries its own effect.
+		s.mu.Lock()
+		current := s.set.Get(e.agentName, e.perm.Key)
+		s.mu.Unlock()
+		if current != e.target {
+			s.log.LogInfo("permissions", "", fmt.Sprintf("%s/%s: skipping stale %s effect (state is now %s)", e.agentName, e.perm.Key, e.target, current))
+			continue
+		}
 		s.runClosureEffect(e)
 		if e.perm.Kind == permission.KindObserve {
 			if e.target == permission.StateGranted {

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -1,0 +1,508 @@
+// PermissionService is the single source of truth for the consent-first
+// permission wizard (issue #570). Every read and modification irrlicht
+// performs on the user's system is declared as a per-agent permission
+// (agent.Permission); this service holds the answered state, exercises
+// grants (installs hooks, starts watchers), actively undoes revokes, and
+// arbitrates between the macOS and web wizards — the first answer wins
+// and a PushTypePermissionsUpdated broadcast dismisses the other surface.
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/config"
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/ports/inbound"
+	"irrlicht/core/ports/outbound"
+)
+
+// detectionPollInterval is how often the always-on detection poller checks
+// for live agent processes. Detection is the consent-free baseline: it only
+// feeds the wizard's "detected" flag and never creates sessions.
+const detectionPollInterval = 5 * time.Second
+
+// ErrUnknownPermission is returned by Answer for an agent/permission pair
+// that no adapter declares. The HTTP handler maps it to 400.
+var ErrUnknownPermission = errors.New("unknown agent or permission")
+
+// WatcherFactory constructs the observe-gated watchers for one agent.
+// Called fresh on every grant — watchers hold per-run state (e.g. the
+// scanner's tracked-PID map) and are rebuilt rather than restarted.
+type WatcherFactory func() []inbound.Watcher
+
+// watcherRegistrar is the slice of *SessionDetector the service needs:
+// registering a watcher's event stream with the running detector.
+type watcherRegistrar interface {
+	AddWatcher(ctx context.Context, w inbound.Watcher)
+}
+
+// HasLiveProcessFunc reports whether any running process matches m.
+// Production injects processlifecycle.HasLiveProcess.
+type HasLiveProcessFunc func(m agent.ProcessMatcher) bool
+
+// PermissionAnswer is one user decision submitted via
+// POST /api/v1/permissions/answer.
+type PermissionAnswer struct {
+	Agent      string `json:"agent"`
+	Permission string `json:"permission"`
+	Grant      bool   `json:"grant"`
+}
+
+// PermissionView is the API projection of one declared permission plus
+// its current consent state.
+type PermissionView struct {
+	Key             string `json:"key"`
+	Kind            string `json:"kind"`
+	State           string `json:"state"`
+	Title           string `json:"title"`
+	FeatureUnlocked string `json:"feature_unlocked"`
+	Touches         string `json:"touches"`
+	Detail          string `json:"detail"`
+}
+
+// AgentPermissions groups one agent's permissions for the API.
+type AgentPermissions struct {
+	Name        string           `json:"name"`
+	DisplayName string           `json:"display_name"`
+	Detected    bool             `json:"detected"`
+	Permissions []PermissionView `json:"permissions"`
+}
+
+// PermissionsSnapshot is the GET /api/v1/permissions response body.
+type PermissionsSnapshot struct {
+	Mode   string             `json:"mode"`
+	Agents []AgentPermissions `json:"agents"`
+}
+
+// PermissionService gates every agent-monitoring capability behind user
+// consent. Construct with NewPermissionService, then call Start once the
+// daemon context exists.
+type PermissionService struct {
+	agents    []agent.Agent
+	store     outbound.PermissionStore
+	push      outbound.PushBroadcaster
+	log       outbound.Logger
+	mode      string
+	registrar watcherRegistrar
+	factories map[string]WatcherFactory
+	hasLive   HasLiveProcessFunc
+
+	// detectInterval is detectionPollInterval in production; tests shorten
+	// it via SetDetectionPollIntervalForTest before Start.
+	detectInterval time.Duration
+
+	// probes overrides process-matcher detection for agents whose presence
+	// is detected another way (Gas Town: GT_ROOT directory probe). Set via
+	// SetDetectionProbe before Start.
+	probes map[string]func() bool
+
+	// effectMu serializes effect execution (hook installs, watcher
+	// start/stop). Effects run OUTSIDE mu so the hot Granted() gate never
+	// blocks on file I/O; this mutex keeps two concurrent Answer batches
+	// from racing the same installer. Lock order: effectMu before mu —
+	// nothing under mu may take effectMu.
+	effectMu sync.Mutex
+
+	// mu guards the consent state below. Never held across file I/O or
+	// broadcasts — Granted() sits on the hook/statusline hot path.
+	mu       sync.Mutex
+	set      permission.Set
+	detected map[string]bool
+	watching map[string]context.CancelFunc // agent name → cancel for its running watchers
+	parent   context.Context               // daemon-lifetime ctx, set by Start
+}
+
+// pendingEffect is one consent effect collected under mu and executed
+// outside it.
+type pendingEffect struct {
+	agentName string
+	perm      agent.Permission
+	target    permission.State
+}
+
+// SetDetectionPollIntervalForTest overrides the detection poll cadence.
+// Call before Start.
+func (s *PermissionService) SetDetectionPollIntervalForTest(d time.Duration) {
+	s.detectInterval = d
+}
+
+// NewPermissionService loads the persisted consent state and returns the
+// service. factories may be nil (demo mode: no watchers ever start);
+// hasLive may be nil (no detection poller — nothing is ever "detected").
+func NewPermissionService(
+	agents []agent.Agent,
+	store outbound.PermissionStore,
+	push outbound.PushBroadcaster,
+	log outbound.Logger,
+	mode string,
+	registrar watcherRegistrar,
+	factories map[string]WatcherFactory,
+	hasLive HasLiveProcessFunc,
+) *PermissionService {
+	set, err := store.Load()
+	if err != nil {
+		log.LogError("permissions", "", fmt.Sprintf("failed to load permission state (treating all as pending): %v", err))
+		set = permission.Set{}
+	}
+	return &PermissionService{
+		agents:         agents,
+		store:          store,
+		push:           push,
+		log:            log,
+		mode:           mode,
+		registrar:      registrar,
+		factories:      factories,
+		hasLive:        hasLive,
+		detectInterval: detectionPollInterval,
+		probes:         make(map[string]func() bool),
+		set:            set,
+		detected:       make(map[string]bool),
+		watching:       make(map[string]context.CancelFunc),
+	}
+}
+
+// SetDetectionProbe overrides process-matcher detection for one agent —
+// used for adapters detected by filesystem presence rather than a live
+// process (Gas Town's GT_ROOT). Call before Start.
+func (s *PermissionService) SetDetectionProbe(agentName string, probe func() bool) {
+	s.probes[agentName] = probe
+}
+
+// Start exercises every granted permission (re-applies modify effects so
+// stale hook entries are upgraded, starts watchers for observe grants) and
+// launches the detection poller. In grant-all mode every declared
+// permission is granted in memory first — without persisting, so a later
+// ask-mode daemon still sees the user's real answers. Effects run
+// synchronously so a grant-all daemon is fully monitoring before the
+// caller proceeds (recording fixtures must not race the grant).
+//
+// The detection poller only runs in ask mode and only while some
+// permission is still pending: at runtime pending-ness can only decrease
+// (answers move to granted/denied, never back), so once nothing is
+// pending there is no wizard to trigger and the per-agent process scans
+// would be pure waste. Grant-all suppresses the wizard entirely, so it
+// never polls.
+func (s *PermissionService) Start(ctx context.Context) {
+	s.mu.Lock()
+	s.parent = ctx
+	if s.mode == config.PermissionModeGrantAll {
+		for _, a := range s.agents {
+			for _, p := range a.Permissions {
+				s.set.Put(a.Identity.Name, p.Key, permission.StateGranted)
+			}
+		}
+		s.log.LogInfo("permissions", "", "IRRLICHT_PERMISSION_MODE=grant-all — all permissions granted, wizard suppressed")
+	}
+	var effects []pendingEffect
+	for _, a := range s.agents {
+		for _, p := range a.Permissions {
+			if s.set.Get(a.Identity.Name, p.Key) == permission.StateGranted {
+				effects = append(effects, pendingEffect{a.Identity.Name, p, permission.StateGranted})
+			}
+		}
+	}
+	runPoller := s.hasLive != nil && s.mode != config.PermissionModeGrantAll && s.anyPendingLocked()
+	s.mu.Unlock()
+
+	s.runEffects(effects)
+
+	if runPoller {
+		go s.runDetectionLoop(ctx)
+	}
+}
+
+// anyPendingLocked reports whether any declared permission is still
+// unanswered. Caller holds s.mu.
+func (s *PermissionService) anyPendingLocked() bool {
+	for _, a := range s.agents {
+		for _, p := range a.Permissions {
+			if s.set.Get(a.Identity.Name, p.Key) == permission.StatePending {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Granted reports whether the agent/key permission is currently granted.
+// Used as the consent gate by the hook/statusline HTTP handlers.
+func (s *PermissionService) Granted(agentName, key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.set.Get(agentName, key) == permission.StateGranted
+}
+
+// Snapshot returns the full consent state for GET /api/v1/permissions.
+func (s *PermissionService) Snapshot() PermissionsSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := PermissionsSnapshot{Mode: s.mode}
+	for _, a := range s.agents {
+		if len(a.Permissions) == 0 {
+			continue
+		}
+		ap := AgentPermissions{
+			Name:        a.Identity.Name,
+			DisplayName: a.Identity.DisplayName,
+			Detected:    s.detected[a.Identity.Name],
+		}
+		for _, p := range a.Permissions {
+			ap.Permissions = append(ap.Permissions, PermissionView{
+				Key:             p.Key,
+				Kind:            string(p.Kind),
+				State:           string(s.set.Get(a.Identity.Name, p.Key)),
+				Title:           p.Title,
+				FeatureUnlocked: p.FeatureUnlocked,
+				Touches:         p.Touches,
+				Detail:          p.Detail,
+			})
+		}
+		out.Agents = append(out.Agents, ap)
+	}
+	return out
+}
+
+// Answer applies a batch of user decisions: state is recorded, modify
+// effects are applied/undone, observe watchers are started/stopped, the
+// set is persisted, and a permissions_updated broadcast dismisses the
+// wizard on whichever surface didn't answer. Re-answering with the same
+// state is a no-op, so the losing surface's duplicate submission is
+// harmless. Returns ErrUnknownPermission (wrapped) when any entry names
+// an undeclared agent/permission pair; nothing is applied in that case.
+//
+// State mutation happens under s.mu, but effects, persistence, and the
+// broadcast run after release — Granted() gates every hook/statusline
+// POST and must never wait on file I/O. In grant-all mode nothing is
+// persisted: the auto-granted set is in-memory only, and saving it here
+// would leak every auto-grant into a later ask-mode daemon's state.
+func (s *PermissionService) Answer(answers []PermissionAnswer) error {
+	if len(answers) == 0 {
+		return nil
+	}
+	s.mu.Lock()
+
+	// Validate the whole batch before mutating so a malformed entry can't
+	// half-apply.
+	perms := make([]agent.Permission, len(answers))
+	for i, ans := range answers {
+		p, ok := s.declared(ans.Agent, ans.Permission)
+		if !ok {
+			s.mu.Unlock()
+			return fmt.Errorf("%w: %s/%s", ErrUnknownPermission, ans.Agent, ans.Permission)
+		}
+		perms[i] = p
+	}
+
+	var effects []pendingEffect
+	for i, ans := range answers {
+		target := permission.StateDenied
+		if ans.Grant {
+			target = permission.StateGranted
+		}
+		if s.set.Get(ans.Agent, ans.Permission) == target {
+			continue
+		}
+		s.set.Put(ans.Agent, ans.Permission, target)
+		effects = append(effects, pendingEffect{ans.Agent, perms[i], target})
+	}
+	var toSave permission.Set
+	if len(effects) > 0 && s.mode != config.PermissionModeGrantAll {
+		toSave = s.set.Clone()
+	}
+	s.mu.Unlock()
+
+	if len(effects) == 0 {
+		return nil
+	}
+	s.runEffects(effects)
+	if toSave != nil {
+		if err := s.store.Save(toSave); err != nil {
+			s.log.LogError("permissions", "", fmt.Sprintf("failed to persist permission state: %v", err))
+		}
+	}
+	s.push.Broadcast(outbound.PushMessage{Type: outbound.PushTypePermissionsUpdated})
+	return nil
+}
+
+// declared returns the declaration for the agent/key pair.
+func (s *PermissionService) declared(agentName, key string) (agent.Permission, bool) {
+	for _, a := range s.agents {
+		if a.Identity.Name != agentName {
+			continue
+		}
+		for _, p := range a.Permissions {
+			if p.Key == key {
+				return p, true
+			}
+		}
+	}
+	return agent.Permission{}, false
+}
+
+// runEffects executes consent effects sequentially under effectMu (NOT
+// under s.mu — Granted() must never wait on file I/O; effectMu keeps two
+// concurrent Answer batches from racing the same installer). Modify-kind
+// permissions run their Apply/Remove closures; observe-kind permissions
+// start/stop the agent's watchers — and may additionally carry
+// Apply/Remove closures when their monitoring isn't watcher-factory based
+// (the Gas Town orchestrator). Effect errors are logged, never propagated
+// — the recorded state stands and effects are re-applied on the next
+// daemon start.
+func (s *PermissionService) runEffects(effects []pendingEffect) {
+	if len(effects) == 0 {
+		return
+	}
+	s.effectMu.Lock()
+	defer s.effectMu.Unlock()
+	for _, e := range effects {
+		s.runClosureEffect(e)
+		if e.perm.Kind == permission.KindObserve {
+			if e.target == permission.StateGranted {
+				s.startWatching(e.agentName)
+			} else {
+				s.stopWatching(e.agentName)
+			}
+		}
+	}
+}
+
+// runClosureEffect runs the effect's Apply/Remove closure, if any.
+func (s *PermissionService) runClosureEffect(e pendingEffect) {
+	effect, verb := e.perm.Apply, "apply"
+	if e.target != permission.StateGranted {
+		effect, verb = e.perm.Remove, "remove"
+	}
+	if effect == nil {
+		return
+	}
+	if err := effect(); err != nil {
+		s.log.LogError("permissions", "", fmt.Sprintf("failed to %s %s/%s: %v", verb, e.agentName, e.perm.Key, err))
+		return
+	}
+	s.log.LogInfo("permissions", "", fmt.Sprintf("%s/%s: %sd", e.agentName, e.perm.Key, verb))
+}
+
+// startWatching constructs the agent's watchers fresh, registers their
+// event streams with the detector, and starts their Watch loops under a
+// per-agent cancellable context. Takes s.mu internally (callers hold
+// effectMu, never mu).
+func (s *PermissionService) startWatching(agentName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, running := s.watching[agentName]; running {
+		return
+	}
+	factory := s.factories[agentName]
+	if factory == nil || s.registrar == nil {
+		return
+	}
+	parent := s.parent
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	for _, w := range factory() {
+		s.registrar.AddWatcher(ctx, w)
+		go func(w inbound.Watcher) {
+			if err := w.Watch(ctx); err != nil && err != context.Canceled {
+				s.log.LogError("agent-watcher", "", fmt.Sprintf("%s watcher error: %v", agentName, err))
+			}
+		}(w)
+	}
+	s.watching[agentName] = cancel
+	s.log.LogInfo("permissions", "", fmt.Sprintf("monitoring started for %s", agentName))
+}
+
+// stopWatching cancels the agent's watcher context: Watch loops and
+// detector drains exit, so existing sessions stop updating immediately.
+// Takes s.mu internally (callers hold effectMu, never mu).
+func (s *PermissionService) stopWatching(agentName string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cancel, running := s.watching[agentName]
+	if !running {
+		return
+	}
+	cancel()
+	delete(s.watching, agentName)
+	s.log.LogInfo("permissions", "", fmt.Sprintf("monitoring stopped for %s", agentName))
+}
+
+// runDetectionLoop polls for live agent processes and broadcasts a
+// permissions_updated message whenever any agent's detected flag flips —
+// that is what makes the wizard appear when a new agent shows up. The
+// loop exits for good once nothing is pending: answers only ever move
+// pending → granted/denied at runtime, so with nothing left to prompt
+// for, the per-agent process scans would run forever for no consumer.
+func (s *PermissionService) runDetectionLoop(ctx context.Context) {
+	ticker := time.NewTicker(s.detectInterval)
+	defer ticker.Stop()
+	for {
+		s.mu.Lock()
+		done := !s.anyPendingLocked()
+		s.mu.Unlock()
+		if done {
+			s.log.LogInfo("permissions", "", "all permissions answered — detection poller stopped")
+			return
+		}
+		s.pollDetection()
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// pollDetection runs one detection pass. The (potentially slow) process
+// scans happen outside the lock. Agents with a registered probe (Gas
+// Town's GT_ROOT directory check) use it instead of the process matcher.
+func (s *PermissionService) pollDetection() {
+	cur := make(map[string]bool, len(s.agents))
+	for _, a := range s.agents {
+		if probe, ok := s.probes[a.Identity.Name]; ok {
+			cur[a.Identity.Name] = probe()
+			continue
+		}
+		cur[a.Identity.Name] = s.hasLive(a.Process.Match)
+	}
+	s.mu.Lock()
+	changed := false
+	for name, live := range cur {
+		if s.detected[name] != live {
+			s.detected[name] = live
+			changed = true
+		}
+	}
+	s.mu.Unlock()
+	if changed {
+		s.push.Broadcast(outbound.PushMessage{Type: outbound.PushTypePermissionsUpdated})
+	}
+}
+
+// ObserveGranted reports whether the agent's observe-kind permission is
+// granted. This is the per-adapter consent gate for transcript reads that
+// happen OUTSIDE the watcher path — the detector's startup seed and its
+// stale-session refresh both re-read persisted sessions' transcripts and
+// must honor consent too. Unknown adapters (or agents with no observe
+// permission) read as not granted: consent-first defaults closed.
+func (s *PermissionService) ObserveGranted(agentName string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, a := range s.agents {
+		if a.Identity.Name != agentName {
+			continue
+		}
+		for _, p := range a.Permissions {
+			if p.Kind == permission.KindObserve {
+				return s.set.Get(agentName, p.Key) == permission.StateGranted
+			}
+		}
+	}
+	return false
+}

--- a/core/application/services/permission_service_test.go
+++ b/core/application/services/permission_service_test.go
@@ -1,0 +1,533 @@
+package services_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/config"
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/ports/inbound"
+	"irrlicht/core/ports/outbound"
+)
+
+// --- mocks --------------------------------------------------------------
+
+type mockPermStore struct {
+	mu    sync.Mutex
+	set   permission.Set
+	saves int
+}
+
+func (s *mockPermStore) Load() (permission.Set, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.set == nil {
+		return permission.Set{}, nil
+	}
+	return s.set, nil
+}
+
+func (s *mockPermStore) Save(set permission.Set) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.set = set
+	s.saves++
+	return nil
+}
+
+func (s *mockPermStore) saveCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.saves
+}
+
+type mockPush struct {
+	mu   sync.Mutex
+	msgs []outbound.PushMessage
+}
+
+func (p *mockPush) Broadcast(m outbound.PushMessage) {
+	p.mu.Lock()
+	p.msgs = append(p.msgs, m)
+	p.mu.Unlock()
+}
+func (p *mockPush) Subscribe() chan outbound.PushMessage     { return nil }
+func (p *mockPush) Unsubscribe(ch chan outbound.PushMessage) {}
+
+func (p *mockPush) count(typ string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := 0
+	for _, m := range p.msgs {
+		if m.Type == typ {
+			n++
+		}
+	}
+	return n
+}
+
+type mockRegistrar struct {
+	mu    sync.Mutex
+	added []inbound.Watcher
+}
+
+func (r *mockRegistrar) AddWatcher(ctx context.Context, w inbound.Watcher) {
+	r.mu.Lock()
+	r.added = append(r.added, w)
+	r.mu.Unlock()
+}
+
+func (r *mockRegistrar) addedCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.added)
+}
+
+// signalWatcher reports when its Watch loop starts and stops.
+type signalWatcher struct {
+	*mockAgentWatcher
+	started chan struct{}
+	stopped chan struct{}
+}
+
+func newSignalWatcher() *signalWatcher {
+	return &signalWatcher{
+		mockAgentWatcher: newMockAgentWatcher(),
+		started:          make(chan struct{}),
+		stopped:          make(chan struct{}),
+	}
+}
+
+func (w *signalWatcher) Watch(ctx context.Context) error {
+	close(w.started)
+	<-ctx.Done()
+	close(w.stopped)
+	return ctx.Err()
+}
+
+// --- helpers ------------------------------------------------------------
+
+type effectCounter struct {
+	mu      sync.Mutex
+	applied int
+	removed int
+}
+
+func (c *effectCounter) apply() error  { c.mu.Lock(); c.applied++; c.mu.Unlock(); return nil }
+func (c *effectCounter) remove() error { c.mu.Lock(); c.removed++; c.mu.Unlock(); return nil }
+func (c *effectCounter) counts() (int, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.applied, c.removed
+}
+
+func testAgentDecl(c *effectCounter) agent.Agent {
+	return agent.Agent{
+		Identity: agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
+		Process:  agent.Process{Match: agent.ExactName{Name: "testagent"}},
+		Permissions: []agent.Permission{
+			{Key: "config", Kind: permission.KindModify, Title: "Modify config",
+				Apply: c.apply, Remove: c.remove},
+			{Key: "transcripts", Kind: permission.KindObserve, Title: "Read transcripts"},
+		},
+	}
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// --- tests --------------------------------------------------------------
+
+func TestPermissionServiceFreshStateIsAllPendingAndInert(t *testing.T) {
+	c := &effectCounter{}
+	store := &mockPermStore{}
+	reg := &mockRegistrar{}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, store, &mockPush{}, &mockLogger{},
+		config.PermissionModeAsk, reg, nil, nil,
+	)
+	svc.Start(context.Background())
+
+	if svc.Granted("testagent", "config") || svc.Granted("testagent", "transcripts") {
+		t.Fatal("fresh state must not grant anything")
+	}
+	applied, removed := c.counts()
+	if applied != 0 || removed != 0 {
+		t.Fatalf("fresh start ran effects: applied=%d removed=%d", applied, removed)
+	}
+	if reg.addedCount() != 0 {
+		t.Fatal("fresh start registered watchers")
+	}
+	snap := svc.Snapshot()
+	if snap.Mode != config.PermissionModeAsk {
+		t.Fatalf("mode = %q", snap.Mode)
+	}
+	for _, a := range snap.Agents {
+		for _, p := range a.Permissions {
+			if p.State != string(permission.StatePending) {
+				t.Fatalf("%s/%s state = %q, want pending", a.Name, p.Key, p.State)
+			}
+		}
+	}
+}
+
+func TestPermissionServiceGrantAppliesAndDenyRemoves(t *testing.T) {
+	c := &effectCounter{}
+	store := &mockPermStore{}
+	push := &mockPush{}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, store, push, &mockLogger{},
+		config.PermissionModeAsk, &mockRegistrar{}, nil, nil,
+	)
+	svc.Start(context.Background())
+
+	if err := svc.Answer([]services.PermissionAnswer{
+		{Agent: "testagent", Permission: "config", Grant: true},
+	}); err != nil {
+		t.Fatalf("Answer: %v", err)
+	}
+	if applied, _ := c.counts(); applied != 1 {
+		t.Fatalf("applied = %d, want 1", applied)
+	}
+	if !svc.Granted("testagent", "config") {
+		t.Fatal("not granted after grant")
+	}
+	if store.saveCount() != 1 {
+		t.Fatalf("saves = %d, want 1", store.saveCount())
+	}
+	if push.count(outbound.PushTypePermissionsUpdated) != 1 {
+		t.Fatal("expected one permissions_updated broadcast")
+	}
+
+	// Revoke actively undoes.
+	if err := svc.Answer([]services.PermissionAnswer{
+		{Agent: "testagent", Permission: "config", Grant: false},
+	}); err != nil {
+		t.Fatalf("Answer: %v", err)
+	}
+	if _, removed := c.counts(); removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	if svc.Granted("testagent", "config") {
+		t.Fatal("still granted after deny")
+	}
+}
+
+func TestPermissionServiceReAnswerIsIdempotent(t *testing.T) {
+	c := &effectCounter{}
+	store := &mockPermStore{}
+	push := &mockPush{}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, store, push, &mockLogger{},
+		config.PermissionModeAsk, &mockRegistrar{}, nil, nil,
+	)
+	svc.Start(context.Background())
+
+	ans := []services.PermissionAnswer{{Agent: "testagent", Permission: "config", Grant: true}}
+	if err := svc.Answer(ans); err != nil {
+		t.Fatal(err)
+	}
+	// The losing surface submits the same answer after the race — no-op.
+	if err := svc.Answer(ans); err != nil {
+		t.Fatal(err)
+	}
+	if applied, _ := c.counts(); applied != 1 {
+		t.Fatalf("applied = %d, want 1 (re-answer must not re-run effects)", applied)
+	}
+	if store.saveCount() != 1 {
+		t.Fatalf("saves = %d, want 1", store.saveCount())
+	}
+	if push.count(outbound.PushTypePermissionsUpdated) != 1 {
+		t.Fatal("re-answer must not re-broadcast")
+	}
+}
+
+func TestPermissionServiceUnknownPermissionRejectsWholeBatch(t *testing.T) {
+	c := &effectCounter{}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, &mockPush{}, &mockLogger{},
+		config.PermissionModeAsk, &mockRegistrar{}, nil, nil,
+	)
+	svc.Start(context.Background())
+
+	err := svc.Answer([]services.PermissionAnswer{
+		{Agent: "testagent", Permission: "config", Grant: true},
+		{Agent: "testagent", Permission: "nope", Grant: true},
+	})
+	if !errors.Is(err, services.ErrUnknownPermission) {
+		t.Fatalf("err = %v, want ErrUnknownPermission", err)
+	}
+	// Nothing from the batch applied.
+	if applied, _ := c.counts(); applied != 0 {
+		t.Fatalf("applied = %d, want 0", applied)
+	}
+	if svc.Granted("testagent", "config") {
+		t.Fatal("valid entry of invalid batch was applied")
+	}
+}
+
+func TestPermissionServiceObserveGrantStartsAndDenyStopsWatchers(t *testing.T) {
+	c := &effectCounter{}
+	w := newSignalWatcher()
+	reg := &mockRegistrar{}
+	factories := map[string]services.WatcherFactory{
+		"testagent": func() []inbound.Watcher { return []inbound.Watcher{w} },
+	}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, &mockPush{}, &mockLogger{},
+		config.PermissionModeAsk, reg, factories, nil,
+	)
+	svc.Start(context.Background())
+
+	if err := svc.Answer([]services.PermissionAnswer{
+		{Agent: "testagent", Permission: "transcripts", Grant: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "watcher start", func() bool {
+		select {
+		case <-w.started:
+			return true
+		default:
+			return false
+		}
+	})
+	if reg.addedCount() != 1 {
+		t.Fatalf("registered watchers = %d, want 1", reg.addedCount())
+	}
+
+	if err := svc.Answer([]services.PermissionAnswer{
+		{Agent: "testagent", Permission: "transcripts", Grant: false},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-w.stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not stop after deny")
+	}
+}
+
+func TestPermissionServiceGrantedStateResumesAtStart(t *testing.T) {
+	c := &effectCounter{}
+	set := permission.Set{}
+	set.Put("testagent", "config", permission.StateGranted)
+	set.Put("testagent", "transcripts", permission.StateGranted)
+	store := &mockPermStore{set: set}
+	w := newSignalWatcher()
+	factories := map[string]services.WatcherFactory{
+		"testagent": func() []inbound.Watcher { return []inbound.Watcher{w} },
+	}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, store, &mockPush{}, &mockLogger{},
+		config.PermissionModeAsk, &mockRegistrar{}, factories, nil,
+	)
+	svc.Start(context.Background())
+
+	// Persisted grants are exercised on boot: modify re-applied (hook
+	// upgrade path), observe watchers started.
+	if applied, _ := c.counts(); applied != 1 {
+		t.Fatalf("applied = %d, want 1", applied)
+	}
+	waitFor(t, "watcher start", func() bool {
+		select {
+		case <-w.started:
+			return true
+		default:
+			return false
+		}
+	})
+}
+
+func TestPermissionServiceGrantAllMode(t *testing.T) {
+	c := &effectCounter{}
+	store := &mockPermStore{}
+	w := newSignalWatcher()
+	factories := map[string]services.WatcherFactory{
+		"testagent": func() []inbound.Watcher { return []inbound.Watcher{w} },
+	}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, store, &mockPush{}, &mockLogger{},
+		config.PermissionModeGrantAll, &mockRegistrar{}, factories, nil,
+	)
+	svc.Start(context.Background())
+
+	if !svc.Granted("testagent", "config") || !svc.Granted("testagent", "transcripts") {
+		t.Fatal("grant-all must grant everything")
+	}
+	if applied, _ := c.counts(); applied != 1 {
+		t.Fatalf("applied = %d, want 1", applied)
+	}
+	waitFor(t, "watcher start", func() bool {
+		select {
+		case <-w.started:
+			return true
+		default:
+			return false
+		}
+	})
+	// Auto-grants are in-memory only: a later ask-mode daemon must still
+	// see the user's real (unanswered) state.
+	if store.saveCount() != 0 {
+		t.Fatalf("grant-all persisted auto-grants (saves=%d)", store.saveCount())
+	}
+}
+
+func TestPermissionServiceDetectionFlagsAndBroadcasts(t *testing.T) {
+	c := &effectCounter{}
+	push := &mockPush{}
+	var mu sync.Mutex
+	live := false
+	hasLive := func(agent.ProcessMatcher) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return live
+	}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, push, &mockLogger{},
+		config.PermissionModeAsk, &mockRegistrar{}, nil, hasLive,
+	)
+	svc.SetDetectionPollIntervalForTest(10 * time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc.Start(ctx)
+
+	// Not live: detected stays false, no broadcast.
+	time.Sleep(20 * time.Millisecond)
+	if push.count(outbound.PushTypePermissionsUpdated) != 0 {
+		t.Fatal("broadcast while nothing detected")
+	}
+
+	mu.Lock()
+	live = true
+	mu.Unlock()
+	waitFor(t, "detection broadcast", func() bool {
+		return push.count(outbound.PushTypePermissionsUpdated) >= 1
+	})
+	snap := svc.Snapshot()
+	if len(snap.Agents) != 1 || !snap.Agents[0].Detected {
+		t.Fatalf("snapshot not detected: %+v", snap.Agents)
+	}
+}
+
+func TestPermissionServiceGrantAllAnswerDoesNotPersist(t *testing.T) {
+	c := &effectCounter{}
+	store := &mockPermStore{}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, store, &mockPush{}, &mockLogger{},
+		config.PermissionModeGrantAll, &mockRegistrar{}, nil, nil,
+	)
+	svc.Start(context.Background())
+
+	// A user answer on a grant-all daemon applies in memory but must not
+	// write the auto-granted set to disk — a later ask-mode daemon on the
+	// same home would otherwise inherit grants the user never gave it.
+	if err := svc.Answer([]services.PermissionAnswer{
+		{Agent: "testagent", Permission: "config", Grant: false},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if svc.Granted("testagent", "config") {
+		t.Fatal("deny not applied in memory")
+	}
+	if store.saveCount() != 0 {
+		t.Fatalf("grant-all Answer persisted state (saves=%d)", store.saveCount())
+	}
+}
+
+func TestPermissionServiceObserveGranted(t *testing.T) {
+	c := &effectCounter{}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, &mockPush{}, &mockLogger{},
+		config.PermissionModeAsk, &mockRegistrar{}, nil, nil,
+	)
+	svc.Start(context.Background())
+
+	if svc.ObserveGranted("testagent") {
+		t.Fatal("pending observe permission must read as not granted")
+	}
+	// Granting the MODIFY permission must not unlock observe reads.
+	if err := svc.Answer([]services.PermissionAnswer{
+		{Agent: "testagent", Permission: "config", Grant: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if svc.ObserveGranted("testagent") {
+		t.Fatal("modify grant must not satisfy the observe gate")
+	}
+	if err := svc.Answer([]services.PermissionAnswer{
+		{Agent: "testagent", Permission: "transcripts", Grant: true},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !svc.ObserveGranted("testagent") {
+		t.Fatal("observe grant not reflected")
+	}
+	// Unknown adapters default closed.
+	if svc.ObserveGranted("ghost") {
+		t.Fatal("unknown adapter must read as not granted")
+	}
+}
+
+func TestPermissionServiceDetectionStopsWhenNothingPending(t *testing.T) {
+	c := &effectCounter{}
+	set := permission.Set{}
+	set.Put("testagent", "config", permission.StateGranted)
+	set.Put("testagent", "transcripts", permission.StateDenied)
+	var mu sync.Mutex
+	calls := 0
+	hasLive := func(agent.ProcessMatcher) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		return true
+	}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{set: set}, &mockPush{}, &mockLogger{},
+		config.PermissionModeAsk, &mockRegistrar{}, nil, hasLive,
+	)
+	svc.SetDetectionPollIntervalForTest(5 * time.Millisecond)
+	svc.Start(context.Background())
+
+	// Everything is answered at boot — the poller must not run at all.
+	time.Sleep(40 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 0 {
+		t.Fatalf("detection polled %d times with nothing pending", calls)
+	}
+}
+
+func TestPermissionServiceDetectionProbeOverride(t *testing.T) {
+	c := &effectCounter{}
+	push := &mockPush{}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, push, &mockLogger{},
+		config.PermissionModeAsk, &mockRegistrar{}, nil,
+		func(agent.ProcessMatcher) bool { return false },
+	)
+	svc.SetDetectionProbe("testagent", func() bool { return true })
+	svc.SetDetectionPollIntervalForTest(5 * time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc.Start(ctx)
+
+	waitFor(t, "probe-driven detection", func() bool {
+		snap := svc.Snapshot()
+		return len(snap.Agents) == 1 && snap.Agents[0].Detected
+	})
+}

--- a/core/application/services/permission_service_test.go
+++ b/core/application/services/permission_service_test.go
@@ -116,14 +116,35 @@ type effectCounter struct {
 	mu      sync.Mutex
 	applied int
 	removed int
+	last    string // "apply" or "remove" — the last executed closure effect
 }
 
-func (c *effectCounter) apply() error  { c.mu.Lock(); c.applied++; c.mu.Unlock(); return nil }
-func (c *effectCounter) remove() error { c.mu.Lock(); c.removed++; c.mu.Unlock(); return nil }
+func (c *effectCounter) apply() error {
+	c.mu.Lock()
+	c.applied++
+	c.last = "apply"
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *effectCounter) remove() error {
+	c.mu.Lock()
+	c.removed++
+	c.last = "remove"
+	c.mu.Unlock()
+	return nil
+}
+
 func (c *effectCounter) counts() (int, int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.applied, c.removed
+}
+
+func (c *effectCounter) lastEffect() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.last
 }
 
 func testAgentDecl(c *effectCounter) agent.Agent {
@@ -530,4 +551,44 @@ func TestPermissionServiceDetectionProbeOverride(t *testing.T) {
 		snap := svc.Snapshot()
 		return len(snap.Agents) == 1 && snap.Agents[0].Detected
 	})
+}
+
+// TestPermissionServiceConflictingAnswersConverge stresses the race where
+// both surfaces answer the SAME permission near-simultaneously with
+// opposite decisions. State mutations serialize under the state mutex and
+// effect batches under the effect mutex, so without the stale-effect skip
+// the last EXECUTED effect could belong to the losing answer (state
+// granted but Remove ran last, or vice versa). The invariant: after both
+// answers settle, the last executed closure effect always matches the
+// recorded state.
+func TestPermissionServiceConflictingAnswersConverge(t *testing.T) {
+	c := &effectCounter{}
+	svc := services.NewPermissionService(
+		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, &mockPush{}, &mockLogger{},
+		config.PermissionModeAsk, &mockRegistrar{}, nil, nil,
+	)
+	svc.Start(context.Background())
+
+	for i := 0; i < 100; i++ {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = svc.Answer([]services.PermissionAnswer{{Agent: "testagent", Permission: "config", Grant: true}})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = svc.Answer([]services.PermissionAnswer{{Agent: "testagent", Permission: "config", Grant: false}})
+		}()
+		wg.Wait()
+
+		granted := svc.Granted("testagent", "config")
+		last := c.lastEffect()
+		if granted && last != "apply" {
+			t.Fatalf("round %d: state granted but last executed effect was %q", i, last)
+		}
+		if !granted && last != "remove" {
+			t.Fatalf("round %d: state denied but last executed effect was %q", i, last)
+		}
+	}
 }

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -81,6 +81,13 @@ type SessionDetector struct {
 	broadcaster outbound.PushBroadcaster // optional
 	version     string                   // daemon version stamped on new sessions
 
+	// merged is the fan-in channel every per-watcher drain goroutine sends
+	// into and Run consumes. Created at construction (not in Run) so
+	// watchers can be registered via AddWatcher before or after Run starts
+	// — the consent wizard grants/revokes monitoring at any time (#570).
+	// Never closed; Run exits on ctx cancellation instead.
+	merged chan identifiedEvent
+
 	enricher       *metadataEnricher
 	pidMgr         *PIDManager
 	costTracker    outbound.CostTracker    // optional; nil = disabled
@@ -146,6 +153,14 @@ type SessionDetector struct {
 	bgMu      sync.Mutex
 	bgLive    map[string]bool
 	bgProbing map[string]bool
+
+	// consentGate (optional) reports whether an adapter's transcripts may
+	// be read (#570). Gates the two paths that read PERSISTED sessions'
+	// transcripts outside the (already consent-gated) watcher pipeline:
+	// the startup seed and the stale-working refresh. Nil = allow all —
+	// tests and replay tooling that construct detectors directly are not
+	// consent-managed.
+	consentGate func(adapter string) bool
 }
 
 // NewSessionDetector creates a SessionDetector with all required
@@ -177,6 +192,7 @@ func NewSessionDetector(
 	}
 	det := &SessionDetector{
 		watchers:          watchers,
+		merged:            make(chan identifiedEvent, 16),
 		repo:              repo,
 		log:               log,
 		broadcaster:       broadcaster,
@@ -255,6 +271,18 @@ func (d *SessionDetector) SetLauncherEnvReader(fn LauncherEnvReader) {
 	d.pidMgr.SetLauncherEnvReader(fn)
 }
 
+// SetConsentGate installs the per-adapter observe-consent check (#570).
+// Call before Run. Production wires PermissionService.ObserveGranted; nil
+// (the default) allows everything.
+func (d *SessionDetector) SetConsentGate(fn func(adapter string) bool) {
+	d.consentGate = fn
+}
+
+// observeAllowed reports whether the adapter's transcripts may be read.
+func (d *SessionDetector) observeAllowed(adapter string) bool {
+	return d.consentGate == nil || d.consentGate(adapter)
+}
+
 // recordCost is a helper that calls the optional CostTracker and logs but
 // does not propagate errors — cost tracking must never block the detector.
 func (d *SessionDetector) recordCost(state *session.SessionState) {
@@ -286,7 +314,46 @@ func (d *SessionDetector) record(ev lifecycle.Event) {
 	d.recorder.Record(ev)
 }
 
-// Run subscribes to all Watcher event streams, fans them into a single
+// AddWatcher registers a watcher with the running (or not-yet-running)
+// detector: a drain goroutine subscribes to the watcher's events and fans
+// them into the merged channel until ctx is cancelled. The caller owns the
+// watcher's Watch lifecycle and shares the same ctx, so cancelling it stops
+// both the watcher and its drain — this is how the permission service
+// starts/stops per-agent monitoring on grant/revoke (#570).
+//
+// Panics on a zero-value Identity, matching the NewSessionDetector contract.
+func (d *SessionDetector) AddWatcher(ctx context.Context, w inbound.Watcher) {
+	if w.Identity() == (agent.Identity{}) {
+		panic(fmt.Sprintf("session_detector: AddWatcher(%T) has no Identity — call .WithIdentity() first", w))
+	}
+	go d.drainWatcher(ctx, w)
+}
+
+// drainWatcher subscribes to one watcher and forwards its events (tagged
+// with the watcher's Identity) into the merged channel until ctx is
+// cancelled or the watcher closes the subscription.
+func (d *SessionDetector) drainWatcher(ctx context.Context, w inbound.Watcher) {
+	ch := w.Subscribe()
+	defer w.Unsubscribe(ch)
+	id := w.Identity()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			select {
+			case d.merged <- identifiedEvent{Identity: id, Event: ev}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// Run subscribes to all Watcher event streams, fans them into the merged
 // channel, and processes events until ctx is cancelled. It blocks for the
 // lifetime of the detector.
 //
@@ -295,39 +362,9 @@ func (d *SessionDetector) record(ev lifecycle.Event) {
 // channel; this is how the adapter name reaches handleTranscriptEvent
 // for lifecycle recording and SessionState bootstrap.
 func (d *SessionDetector) Run(ctx context.Context) error {
-	merged := make(chan identifiedEvent, 16)
-	var wg sync.WaitGroup
-
 	for _, w := range d.watchers {
-		ch := w.Subscribe()
-		wg.Add(1)
-		go func(watcher inbound.Watcher, ch <-chan agent.Event) {
-			defer wg.Done()
-			defer watcher.Unsubscribe(ch)
-			id := watcher.Identity()
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case ev, ok := <-ch:
-					if !ok {
-						return
-					}
-					select {
-					case merged <- identifiedEvent{Identity: id, Event: ev}:
-					case <-ctx.Done():
-						return
-					}
-				}
-			}
-		}(w, ch)
+		go d.drainWatcher(ctx, w)
 	}
-
-	// Close merged when all watcher goroutines exit.
-	go func() {
-		wg.Wait()
-		close(merged)
-	}()
 
 	// Seed project sessions map from existing sessions on disk.
 	d.seedFromDisk()
@@ -350,12 +387,7 @@ func (d *SessionDetector) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case idEv, ok := <-merged:
-			if !ok {
-				// Watcher goroutines exited (usually because ctx was cancelled).
-				// Return the context error if set, nil otherwise.
-				return ctx.Err()
-			}
+		case idEv := <-d.merged:
 			d.handleTranscriptEvent(idEv.Identity, idEv.Event)
 		case ev := <-d.debouncedEvents:
 			// Coalesced events from debounce timers — process in the event

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -591,6 +591,14 @@ func (d *SessionDetector) refreshStaleSessions() {
 		if state.TranscriptPath == "" {
 			continue
 		}
+		// Consent-gated per adapter (#570): this refresh re-reads the
+		// transcript independently of the (gated) watcher pipeline. After
+		// a revoke, persisted working sessions would otherwise keep being
+		// re-read and re-broadcast every tick — "existing sessions stop
+		// updating" must hold.
+		if !d.observeAllowed(state.Adapter) {
+			continue
+		}
 		if now.Sub(time.Unix(state.UpdatedAt, 0)) < staleWorkingRefreshInterval {
 			continue
 		}

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -155,8 +155,16 @@ func (d *SessionDetector) seedFromDisk() {
 	// that stale persisted metrics from an older daemon version (e.g. pre-
 	// PR #110 codex cumulative token counts) are overwritten with a fresh
 	// recomputation under the current parser.
+	//
+	// Consent-gated per adapter (#570): RefreshMetrics re-reads the
+	// transcript file, which a pending/denied observe permission forbids —
+	// the upgrade contract is that previously monitored agents pause until
+	// the wizard is answered. Un-consented sessions stay persisted as-is.
 	for _, state := range states {
 		if state.TranscriptPath == "" {
+			continue
+		}
+		if !d.observeAllowed(state.Adapter) {
 			continue
 		}
 		d.enricher.RefreshMetrics(state)
@@ -192,8 +200,15 @@ func (d *SessionDetector) seedFromDisk() {
 	}
 
 	// Backfill ProjectName / CWD / GitBranch for sessions that were saved
-	// before these fields were populated.
-	for _, state := range d.enricher.BackfillMetadata(states) {
+	// before these fields were populated. Same consent gate as above —
+	// BackfillMetadata reads transcripts (GetCWDFromTranscript).
+	allowed := states[:0:0]
+	for _, state := range states {
+		if d.observeAllowed(state.Adapter) {
+			allowed = append(allowed, state)
+		}
+	}
+	for _, state := range d.enricher.BackfillMetadata(allowed) {
 		state.UpdatedAt = time.Now().Unix()
 		if err := d.repo.Save(state); err != nil {
 			d.log.LogError("session-detector-seed", state.SessionID,

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -2341,5 +2342,61 @@ func TestSessionDetector_Activity_SubagentCompletion_TransitionsChildToReady(t *
 	child, _ := repo.Load(childID)
 	if child.State != session.StateReady {
 		t.Errorf("child state: got %q, want ready (parent task-notification should transition child)", child.State)
+	}
+}
+
+// TestSessionDetector_SeedFromDisk_ConsentGated verifies the #570 consent
+// gate: persisted sessions of an un-consented adapter must NOT have their
+// transcripts re-read at startup (the upgrade contract — previously
+// monitored agents pause until the wizard is answered), while consented
+// adapters keep the normal seed refresh.
+func TestSessionDetector_SeedFromDisk_ConsentGated(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	myPID := os.Getpid()
+
+	mk := func(id, adapter string) *session.SessionState {
+		return &session.SessionState{
+			SessionID:      id,
+			State:          session.StateReady,
+			Adapter:        adapter,
+			PID:            myPID,
+			TranscriptPath: "/tmp/" + id + ".jsonl",
+			FirstSeen:      time.Now().Unix(),
+			UpdatedAt:      time.Now().Unix(),
+		}
+	}
+	repo.states["granted-session"] = mk("granted-session", "codex")
+	repo.states["pending-session"] = mk("pending-session", "claude-code")
+
+	var mu sync.Mutex
+	read := map[string]bool{}
+	metrics := &funcMetrics{
+		fn: func(path, adapter string) (*session.SessionMetrics, error) {
+			mu.Lock()
+			read[path] = true
+			mu.Unlock()
+			return nil, nil
+		},
+	}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	det.SetConsentGate(func(adapter string) bool { return adapter == "codex" })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !read["/tmp/granted-session.jsonl"] {
+		t.Error("consented adapter's transcript was not refreshed at seed")
+	}
+	if read["/tmp/pending-session.jsonl"] {
+		t.Error("un-consented adapter's transcript was read at seed — consent gate bypassed")
 	}
 }

--- a/core/cmd/irrlichd/daemon_smoke_test.go
+++ b/core/cmd/irrlichd/daemon_smoke_test.go
@@ -17,93 +17,139 @@ import (
 	"irrlicht/core/adapters/inbound/agents"
 )
 
-// TestDaemonStartupSmoke boots a real irrlichd in a child process and verifies
-// the socket protocol survives every commit. It is fully hermetic and parallel-
-// safe: HOME and IRRLICHT_HOME both point at fresh temp dirs (so it neither
-// reads nor mutates the production install or the user's ~/.claude config), and
-// IRRLICHT_BIND_ADDR=127.0.0.1:0 binds an OS-assigned port (so N worktrees can
-// run it at once). IRRLICHT_DEMO_MODE=1 keeps the file/process watchers off so
-// the daemon serves only what's wired at startup — exactly the surface we want
-// to smoke-test.
+// TestDaemonStartupSmoke boots real irrlichd daemons in child processes and
+// verifies the startup surface survives every commit. It is fully hermetic
+// and parallel-safe: HOME and IRRLICHT_HOME both point at fresh temp dirs
+// (so it neither reads nor mutates the production install or the user's
+// ~/.claude config), and IRRLICHT_BIND_ADDR=127.0.0.1:0 binds an OS-assigned
+// port (so N worktrees can run it at once).
 //
-// What it asserts:
-//   - the daemon publishes its resolved port to IRRLICHT_HOME/irrlichd.addr,
-//   - GET /api/v1/agents over TCP returns the full adapter registry,
-//   - the same endpoint works over the unix socket,
-//   - SIGTERM shuts it down cleanly and removes the addr file.
+// Two boots:
+//   - demo: IRRLICHT_DEMO_MODE=1 (watchers off; the daemon serves only
+//     what's wired at startup). Asserts the addr file, GET /api/v1/agents
+//     over TCP and the unix socket, and clean SIGTERM shutdown.
+//   - ask: production permission mode WITHOUT demo. Asserts consent-first
+//     (#570) on the path where effects could actually run — every declared
+//     permission is pending and ~/.claude/settings.json was never created
+//     (the pre-#570 daemon auto-created it at startup; demo mode skips the
+//     install path entirely, so asserting there would prove nothing).
 func TestDaemonStartupSmoke(t *testing.T) {
-	homeDir := t.TempDir()  // isolates ~/.claude hooks + Application Support logs
-	stateDir := t.TempDir() // IRRLICHT_HOME: socket, addr file, recordings, history
-
-	// Build the daemon binary. Done lazily here (not in TestMain) so unrelated
-	// `go test -run …` invocations don't pay the build cost.
+	// Build the daemon binary once for both boots. Done lazily here (not in
+	// TestMain) so unrelated `go test -run …` invocations don't pay the cost.
 	bin := filepath.Join(t.TempDir(), "irrlichd")
 	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
 		t.Fatalf("build irrlichd: %v\n%s", err, out)
 	}
 
-	cmd := exec.Command(bin)
-	cmd.Env = append(os.Environ(),
-		"HOME="+homeDir,
-		"IRRLICHT_HOME="+stateDir,
+	t.Run("demo", func(t *testing.T) {
+		d := bootSmokeDaemon(t, bin, "IRRLICHT_DEMO_MODE=1")
+
+		// 1. TCP round-trip.
+		assertAgentsEndpoint(t, http.DefaultClient, "http://"+d.addr+"/api/v1/agents")
+
+		// 2. Unix socket round-trip.
+		sockPath := filepath.Join(d.stateDir, "irrlichd.sock")
+		unixClient := &http.Client{Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+			},
+		}}
+		assertAgentsEndpoint(t, unixClient, "http://unix/api/v1/agents")
+
+		unixClient.CloseIdleConnections()
+		d.shutdown(t)
+	})
+
+	t.Run("ask", func(t *testing.T) {
+		d := bootSmokeDaemon(t, bin)
+
+		// Consent-first: a fresh install answers nothing, so every declared
+		// permission is pending and no file under the user's home was
+		// modified — in particular ~/.claude/settings.json must not exist.
+		// This boot runs the REAL ask-mode startup (permService.Start), so a
+		// regression re-introducing boot-time hook install is caught here.
+		assertPermissionsAllPending(t, http.DefaultClient, "http://"+d.addr+"/api/v1/permissions")
+		if _, err := os.Stat(filepath.Join(d.homeDir, ".claude", "settings.json")); !os.IsNotExist(err) {
+			t.Errorf("~/.claude/settings.json exists on a fresh consent-first install (stat err = %v)", err)
+		}
+
+		d.shutdown(t)
+	})
+}
+
+// smokeDaemon is one booted child daemon plus its teardown handles.
+type smokeDaemon struct {
+	cmd      *exec.Cmd
+	exited   chan struct{}
+	stopped  bool
+	homeDir  string
+	stateDir string
+	addrPath string
+	addr     string
+}
+
+// bootSmokeDaemon starts the built daemon with fresh HOME/IRRLICHT_HOME temp
+// dirs, an ephemeral port, and any extra env entries, then waits for the
+// addr file. A kill-backstop is registered via t.Cleanup.
+func bootSmokeDaemon(t *testing.T, bin string, extraEnv ...string) *smokeDaemon {
+	t.Helper()
+	d := &smokeDaemon{
+		homeDir:  t.TempDir(), // isolates ~/.claude hooks + Application Support logs
+		stateDir: t.TempDir(), // IRRLICHT_HOME: socket, addr file, recordings, history
+		exited:   make(chan struct{}),
+	}
+	d.cmd = exec.Command(bin)
+	d.cmd.Env = append(os.Environ(),
+		"HOME="+d.homeDir,
+		"IRRLICHT_HOME="+d.stateDir,
 		"IRRLICHT_BIND_ADDR=127.0.0.1:0",
-		"IRRLICHT_DEMO_MODE=1",
 	)
-	if err := cmd.Start(); err != nil {
+	d.cmd.Env = append(d.cmd.Env, extraEnv...)
+	if err := d.cmd.Start(); err != nil {
 		t.Fatalf("start daemon: %v", err)
 	}
 	// A single reaper goroutine owns cmd.Wait(); the backstop and the SIGTERM
 	// path coordinate through `exited` rather than calling Wait themselves, so
 	// Wait is never invoked twice (which `go test -race` flags as "Wait was
 	// already called").
-	exited := make(chan struct{})
-	go func() { _ = cmd.Wait(); close(exited) }()
-	stopped := false
-	stop := func() { _ = cmd.Process.Kill(); <-exited }
-	defer func() {
-		if !stopped {
-			stop()
+	go func() { _ = d.cmd.Wait(); close(d.exited) }()
+	t.Cleanup(func() {
+		if !d.stopped {
+			_ = d.cmd.Process.Kill()
+			<-d.exited
 		}
-	}()
-	dumpLogsOnFail(t, homeDir)
+	})
+	dumpLogsOnFail(t, d.homeDir)
 
 	// The daemon writes its resolved address here once listening.
-	addrPath := filepath.Join(stateDir, "irrlichd.addr")
-	addr := waitForAddr(t, addrPath, 5*time.Second)
+	d.addrPath = filepath.Join(d.stateDir, "irrlichd.addr")
+	d.addr = waitForAddr(t, d.addrPath, 5*time.Second)
+	return d
+}
 
-	// 1. TCP round-trip.
-	assertAgentsEndpoint(t, http.DefaultClient, "http://"+addr+"/api/v1/agents")
-
-	// 2. Unix socket round-trip.
-	sockPath := filepath.Join(stateDir, "irrlichd.sock")
-	unixClient := &http.Client{Transport: &http.Transport{
-		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
-		},
-	}}
-	assertAgentsEndpoint(t, unixClient, "http://unix/api/v1/agents")
-
-	// Drop client-side keep-alive conns so the daemon's graceful shutdown isn't
-	// waiting on them, then SIGTERM and confirm a clean exit.
+// shutdown SIGTERMs the daemon, asserts a clean exit, and checks the addr
+// file was removed. The timeout exceeds the daemon's own 5s graceful-
+// shutdown budget so a clean (but not instant) shutdown isn't mistaken for
+// a hang.
+func (d *smokeDaemon) shutdown(t *testing.T) {
+	t.Helper()
+	// Drop client-side keep-alive conns so the daemon's graceful shutdown
+	// isn't waiting on them.
 	http.DefaultClient.CloseIdleConnections()
-	unixClient.CloseIdleConnections()
-
-	// 3. Clean shutdown on SIGTERM. The timeout exceeds the daemon's own 5s
-	// graceful-shutdown budget so a clean (but not instant) shutdown isn't
-	// mistaken for a hang.
-	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+	if err := d.cmd.Process.Signal(syscall.SIGTERM); err != nil {
 		t.Fatalf("send SIGTERM: %v", err)
 	}
 	select {
-	case <-exited:
+	case <-d.exited:
 	case <-time.After(6 * time.Second):
-		stop()
-		stopped = true
+		_ = d.cmd.Process.Kill()
+		<-d.exited
+		d.stopped = true
 		t.Fatalf("daemon did not exit within 6s of SIGTERM")
 	}
-	stopped = true
-	if _, err := os.Stat(addrPath); !os.IsNotExist(err) {
-		t.Errorf("addr file %s should be removed after shutdown, stat err = %v", addrPath, err)
+	d.stopped = true
+	if _, err := os.Stat(d.addrPath); !os.IsNotExist(err) {
+		t.Errorf("addr file %s should be removed after shutdown, stat err = %v", d.addrPath, err)
 	}
 }
 
@@ -163,6 +209,59 @@ func assertAgentsEndpoint(t *testing.T, client *http.Client, url string) {
 	for i := range want {
 		if got[i] != want[i] {
 			t.Fatalf("GET %s agent names = %v, want %v", url, got, want)
+		}
+	}
+}
+
+// assertPermissionsAllPending GETs /api/v1/permissions and checks that every
+// agent with declared permissions appears and every permission is pending —
+// the consent-first fresh-install state.
+func assertPermissionsAllPending(t *testing.T, client *http.Client, url string) {
+	t.Helper()
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status %d, want 200", url, resp.StatusCode)
+	}
+	var snap struct {
+		Mode   string `json:"mode"`
+		Agents []struct {
+			Name        string `json:"name"`
+			Permissions []struct {
+				Key   string `json:"key"`
+				State string `json:"state"`
+			} `json:"permissions"`
+		} `json:"agents"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&snap); err != nil {
+		t.Fatalf("decode %s: %v", url, err)
+	}
+	if snap.Mode != "ask" {
+		t.Fatalf("permission mode = %q, want ask", snap.Mode)
+	}
+	// Every agent adapter with declared permissions, plus the Gas Town
+	// orchestrator's consent declaration (wired in main.go, not part of
+	// agents.All()).
+	declared := 1
+	for _, a := range agents.All() {
+		if len(a.Permissions) > 0 {
+			declared++
+		}
+	}
+	if len(snap.Agents) != declared {
+		t.Fatalf("GET %s returned %d agents, want %d", url, len(snap.Agents), declared)
+	}
+	for _, a := range snap.Agents {
+		if len(a.Permissions) == 0 {
+			t.Errorf("agent %s has no permissions in the snapshot", a.Name)
+		}
+		for _, p := range a.Permissions {
+			if p.State != "pending" {
+				t.Errorf("%s/%s state = %q, want pending on fresh install", a.Name, p.Key, p.State)
+			}
 		}
 	}
 }

--- a/core/cmd/irrlichd/daemon_smoke_test.go
+++ b/core/cmd/irrlichd/daemon_smoke_test.go
@@ -242,10 +242,10 @@ func assertPermissionsAllPending(t *testing.T, client *http.Client, url string) 
 	if snap.Mode != "ask" {
 		t.Fatalf("permission mode = %q, want ask", snap.Mode)
 	}
-	// Every agent adapter with declared permissions, plus the Gas Town
-	// orchestrator's consent declaration (wired in main.go, not part of
-	// agents.All()).
-	declared := 1
+	// Every agent adapter with declared permissions, plus the two daemon-
+	// wide entries wired in main.go outside agents.All(): the Gas Town
+	// orchestrator and launcher-identity capture.
+	declared := 2
 	for _, a := range agents.All() {
 		if len(a.Permissions) > 0 {
 			declared++

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -20,9 +20,9 @@ import (
 	"irrlicht/core/adapters/inbound/agents"
 	"irrlicht/core/adapters/inbound/agents/agentwiring"
 	"irrlicht/core/adapters/inbound/agents/claudecode"
-	"irrlicht/core/adapters/inbound/agents/opencode"
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	gastownadapter "irrlicht/core/adapters/inbound/orchestrators/gastown"
+	permissionshandler "irrlicht/core/adapters/inbound/permissions"
 	sessionshandler "irrlicht/core/adapters/inbound/sessions"
 	"irrlicht/core/adapters/outbound/filesystem"
 	"irrlicht/core/adapters/outbound/git"
@@ -34,7 +34,9 @@ import (
 	"irrlicht/core/adapters/outbound/relay"
 	wshub "irrlicht/core/adapters/outbound/websocket"
 	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/config"
+	"irrlicht/core/domain/permission"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/capacity"
 	"irrlicht/core/ports/inbound"
@@ -89,6 +91,21 @@ func main() {
 		} else {
 			fmt.Println("No irrlicht hooks found in ~/.claude/settings.json")
 		}
+		// Record the decision in the consent store (#570) — a persisted
+		// "granted" would otherwise re-install the hooks on the next
+		// daemon start, silently reverting this explicit opt-out.
+		uhHome, _ := os.UserHomeDir()
+		uhStore := filesystem.NewPermissionStore(dataDir(uhHome))
+		if set, err := uhStore.Load(); err == nil {
+			if set.Get(claudecode.AdapterName, claudecode.PermissionKeyHooks) == permission.StateGranted {
+				set.Put(claudecode.AdapterName, claudecode.PermissionKeyHooks, permission.StateDenied)
+				if err := uhStore.Save(set); err != nil {
+					fmt.Printf("warning: failed to record hooks permission as denied: %v\n", err)
+				} else {
+					fmt.Println("Recorded the hooks permission as denied (re-grant via the permission wizard)")
+				}
+			}
+		}
 		os.Exit(0)
 	}
 
@@ -100,29 +117,10 @@ func main() {
 	}
 	defer logger.Close()
 
-	// Auto-install Claude Code hooks for permission-pending detection.
-	if modified, err := claudecode.EnsureHooksInstalled(); err != nil {
-		logger.LogError("startup", "", fmt.Sprintf("failed to install hooks: %v", err))
-	} else if modified {
-		logger.LogInfo("startup", "", "installed Claude Code hooks for permission tracking")
-	}
-
-	// The installed hooks POST via curl; without it they silently no-op and
-	// tool-use permission prompts never surface as `waiting`. Warn loudly so
-	// this isn't an invisible failure (the transcript heuristic still covers
-	// held file-edit prompts). See #488.
-	if !claudecode.HookDeliveryAvailable() {
-		logger.LogError("startup", "", "curl not found on PATH — Claude Code permission-prompt detection is degraded: hooks POST via curl, so without it permission prompts may not surface as 'waiting'. Install curl to restore full detection (#488).")
-	}
-
-	// Auto-install Claude Code statusLine.command for rate-limit ingestion
-	// (issue #309). Chains any user-configured statusline so we don't clobber
-	// it.
-	if modified, err := claudecode.EnsureStatuslineInstalled(); err != nil {
-		logger.LogError("startup", "", fmt.Sprintf("failed to install statusline: %v", err))
-	} else if modified {
-		logger.LogInfo("startup", "", "installed Claude Code statusline hook for rate-limit ingestion")
-	}
+	// Hook + statusline installation is consent-gated (issue #570): the
+	// PermissionService applies them when (and only when) the user grants
+	// the corresponding permission — see permService.Start below. Nothing
+	// under the user's home is modified before that.
 
 	// Configuration.
 	cfg := config.Default()
@@ -358,33 +356,51 @@ func main() {
 		logger.LogInfo("startup", "", "mDNS: disabled (set IRRLICHT_MDNS=1 to advertise)")
 	}
 
-	// Orchestrator adapters: detect and watch multi-agent orchestration systems.
-	gtAdapter := gastownadapter.NewAdapter(gtResolver.Path(), 5*time.Second, cachedRepo)
-	var orchWatchers []inbound.OrchestratorWatcher
-	if gtAdapter.Detected() {
-		logger.LogInfo("startup", "", fmt.Sprintf("Gas Town detected at %s", gtAdapter.Root()))
-		orchWatchers = append(orchWatchers, gtAdapter)
-	} else {
-		logger.LogInfo("startup", "", "Gas Town not detected — skipping orchestrator watcher")
-	}
-
-	orchMonitor := services.NewOrchestratorMonitor(orchWatchers, push, logger)
-	{
-		orchCtx, orchCancel := context.WithCancel(context.Background())
-		defer orchCancel()
-		// Start each orchestrator watcher.
-		for _, ow := range orchWatchers {
-			go func() {
-				if err := ow.Watch(orchCtx); err != nil && err != context.Canceled {
-					logger.LogError("orchestrator-watcher", "", fmt.Sprintf("watcher error: %v", err))
-				}
-			}()
+	// Orchestrator adapters: detect and watch multi-agent orchestration
+	// systems. Gas Town is consent-gated (#570): even constructing the
+	// adapter reads ~/gt state files, so nothing is built until the
+	// "gastown/state" permission is granted — the PermissionService runs
+	// the start/stop closures below as that permission's effects. The
+	// monitor runs regardless (idle until a watcher registers) so
+	// /api/v1/sessions can always consult it.
+	orchMonitor := services.NewOrchestratorMonitor(nil, push, logger)
+	orchCtx, orchCancel := context.WithCancel(context.Background())
+	defer orchCancel()
+	go func() {
+		if err := orchMonitor.Run(orchCtx); err != nil && err != context.Canceled {
+			logger.LogError("orchestrator-monitor", "", fmt.Sprintf("monitor error: %v", err))
 		}
+	}()
+
+	// Effect closures for the gastown/state permission. The service
+	// serializes effect execution, so no extra locking around gtWatchCancel.
+	var gtWatchCancel context.CancelFunc
+	startGastown := func() error {
+		if gtWatchCancel != nil {
+			return nil
+		}
+		gtAdapter := gastownadapter.NewAdapter(gtResolver.Path(), 5*time.Second, cachedRepo)
+		if !gtAdapter.Detected() {
+			logger.LogInfo("permissions", "", "gastown granted but no Gas Town root detected — nothing to watch")
+			return nil
+		}
+		logger.LogInfo("permissions", "", fmt.Sprintf("Gas Town detected at %s", gtAdapter.Root()))
+		watchCtx, cancel := context.WithCancel(orchCtx)
+		gtWatchCancel = cancel
+		orchMonitor.AddWatcher(watchCtx, gtAdapter)
 		go func() {
-			if err := orchMonitor.Run(orchCtx); err != nil && err != context.Canceled {
-				logger.LogError("orchestrator-monitor", "", fmt.Sprintf("monitor error: %v", err))
+			if err := gtAdapter.Watch(watchCtx); err != nil && err != context.Canceled {
+				logger.LogError("orchestrator-watcher", "", fmt.Sprintf("watcher error: %v", err))
 			}
 		}()
+		return nil
+	}
+	stopGastown := func() error {
+		if gtWatchCancel != nil {
+			gtWatchCancel()
+			gtWatchCancel = nil
+		}
+		return nil
 	}
 
 	// Register API endpoints (after orchMonitor is available).
@@ -405,33 +421,31 @@ func main() {
 		return processlifecycle.HasRealSessionForPID(sessions, projectDir, pid)
 	}
 
-	// Per-adapter inbound wiring: dispatch on each Agent's Source variant via
-	// buildAgentWatchers (see wiring.go). FilesUnderRoot adapters get both an
-	// fswatcher and a process scanner; FilesUnderCWD and ProcessOwnedStore
-	// adapters get only a scanner. Skipped entirely under IRRLICHT_DEMO_MODE=1
-	// — daemon serves only what's already on disk in instances/.
-	var watchers []inbound.Watcher
-	watcherRoots := make([]string, 0, len(allAgents))
+	// Per-adapter inbound wiring is consent-gated (issue #570): instead of
+	// starting every agent's watchers at boot, each agent gets a factory
+	// (dispatching on its Source variant via buildAgentWatchers, see
+	// wiring.go) that the PermissionService invokes when the user grants
+	// that agent's observe permission — and cancels on revoke. Skipped
+	// entirely under IRRLICHT_DEMO_MODE=1 — daemon serves only what's
+	// already on disk in instances/.
+	var watcherFactories map[string]services.WatcherFactory
 	if !demoMode {
+		watcherFactories = make(map[string]services.WatcherFactory, len(allAgents))
 		for _, a := range allAgents {
-			aws, labels := buildAgentWatchers(a, cfg.MaxSessionAge, realSessionCheck)
-			watchers = append(watchers, aws...)
-			watcherRoots = append(watcherRoots, labels...)
+			watcherFactories[a.Identity.Name] = func() []inbound.Watcher {
+				ws, _ := buildAgentWatchers(a, cfg.MaxSessionAge, realSessionCheck)
+				return ws
+			}
 		}
-
-		// OpenCode uses a SQLite database instead of JSONL files, so it needs
-		// its own dedicated watcher in addition to the process scanner above.
-		ocw := opencode.New(cfg.MaxSessionAge).WithIdentity(opencode.Agent().Identity)
-		watchers = append(watchers, ocw)
-		watcherRoots = append(watcherRoots, fmt.Sprintf("%s-db (%s)", opencode.AdapterName, ocw.Root()))
 	}
 
 	pidDiscovers := agents.PIDDiscoverers(allAgents)
 	processNames := agents.ProcessNames(allAgents)
 
-	// SessionDetector: orchestrates Watchers + ProcessWatcher.
+	// SessionDetector: orchestrates Watchers + ProcessWatcher. Watchers
+	// register dynamically via AddWatcher as permissions are granted.
 	detector = services.NewSessionDetector(
-		watchers, pwPort,
+		nil, pwPort,
 		cachedRepo, logger, gitResolver, metricsCollector, push,
 		Version, cfg.ReadySessionTTL,
 		pidDiscovers, processNames, processlifecycle.LiveCWDs,
@@ -444,16 +458,56 @@ func main() {
 	// app can jump back to the launching terminal on row/notification click.
 	detector.SetLauncherEnvReader(processlifecycle.ReadLauncherEnv)
 
+	// PermissionService: single source of truth for consent state (issue
+	// #570). Exercises grants (hook install, watcher start), undoes
+	// revokes, arbitrates wizard answers between the macOS and web UIs,
+	// and feeds the always-on detection poller that makes the wizard
+	// appear when a new agent shows up. Under demo mode the factories and
+	// detection are nil — the daemon never monitors anything live.
+	home, _ := os.UserHomeDir()
+	permStore := filesystem.NewPermissionStore(dataDir(home))
+	var hasLive services.HasLiveProcessFunc
+	if !demoMode {
+		hasLive = processlifecycle.HasLiveProcess
+	}
+	// The consent catalog is the agent adapters plus the Gas Town
+	// orchestrator — gastown isn't in agents.All() (it has no Source/
+	// Process axes) but its ~/gt reads are consent-gated all the same.
+	permissionAgents := append(append([]agent.Agent{}, allAgents...),
+		gastownadapter.PermissionDeclaration(startGastown, stopGastown))
+	permService := services.NewPermissionService(
+		permissionAgents, permStore, push, logger,
+		cfg.PermissionMode, detector, watcherFactories, hasLive,
+	)
+	// Gas Town is detected by root-directory presence (stat-only), not by
+	// a live process matcher.
+	permService.SetDetectionProbe(gastownadapter.Name, gastownadapter.RootDetected)
+	// Consent gate for the detector's own transcript reads (startup seed +
+	// stale-working refresh of PERSISTED sessions) — the watcher pipeline
+	// is gated by construction, but these two paths read repo-listed
+	// transcripts directly and must honor per-adapter consent too (#570).
+	// Demo mode keeps the gate open: it serves synthetic seeded sessions
+	// and never reads live agent files in the first place.
+	if !demoMode {
+		detector.SetConsentGate(permService.ObserveGranted)
+	}
+	mux.HandleFunc("GET /api/v1/permissions",
+		permissionshandler.NewGetHandler(permService, logger))
+	mux.HandleFunc("POST /api/v1/permissions/answer",
+		permissionshandler.NewAnswerHandler(permService, logger))
+
 	// Hook receiver: Claude Code PermissionRequest/PostToolUse events.
 	// The detector satisfies claudecode.HookTarget via HandlePermissionHook.
+	// Consent-gated: hooks installed by a pre-consent daemon keep firing
+	// until the wizard is answered, so payloads are dropped while pending.
 	mux.HandleFunc("POST /api/v1/hooks/claudecode",
-		claudecode.NewHookHandler(detector, logger))
+		claudecode.NewHookHandler(detector, permService, logger))
 
 	// Statusline receiver: Claude Code's per-tick statusline JSON, carrying
 	// rate_limits for Pro/Max subscribers (issue #309). Routes to the
 	// metrics adapter so the snapshot lands in the right session's tailer.
 	mux.HandleFunc("POST /api/v1/hooks/claudecode/statusline",
-		claudecode.NewStatuslineHandler(metricsCollector, logger))
+		claudecode.NewStatuslineHandler(metricsCollector, permService, logger))
 
 	// Lifecycle recording: opt-in via --record flag or IRRLICHT_RECORD=1.
 	// Recordings default to <dataDir>/recordings, so IRRLICHT_HOME already
@@ -488,19 +542,29 @@ func main() {
 	{
 		detectorCtx, detectorCancel := context.WithCancel(context.Background())
 		defer detectorCancel()
-		logger.LogInfo("startup", "", fmt.Sprintf("watching %s", strings.Join(watcherRoots, ", ")))
-		for _, w := range watchers {
-			go func() {
-				if err := w.Watch(detectorCtx); err != nil && err != context.Canceled {
-					logger.LogError("agent-watcher", "", fmt.Sprintf("watcher error: %v", err))
-				}
-			}()
-		}
 		go func() {
 			if err := detector.Run(detectorCtx); err != nil && err != context.Canceled {
 				logger.LogError("session-detector", "", fmt.Sprintf("detector error: %v", err))
 			}
 		}()
+
+		// Exercise granted permissions (re-apply hook/statusline installs,
+		// start watchers) and launch the detection poller. Effects run
+		// synchronously so a grant-all daemon (demo/record/test) is fully
+		// monitoring before startup proceeds. Skipped under demo mode —
+		// nothing live is watched, so consent effects must not run either.
+		if !demoMode {
+			permService.Start(detectorCtx)
+			// The installed hooks POST via curl; without it they silently
+			// no-op and tool-use permission prompts never surface as
+			// `waiting`. Warn loudly so this isn't an invisible failure
+			// (the transcript heuristic still covers held file-edit
+			// prompts). See #488.
+			if permService.Granted(claudecode.AdapterName, claudecode.PermissionKeyHooks) &&
+				!claudecode.HookDeliveryAvailable() {
+				logger.LogError("startup", "", "curl not found on PATH — Claude Code permission-prompt detection is degraded: hooks POST via curl, so without it permission prompts may not surface as 'waiting'. Install curl to restore full detection (#488).")
+			}
+		}
 	}
 
 	logger.LogInfo("startup", "", fmt.Sprintf("irrlichd %s listening on unix:%s and tcp:%s", Version, sockPath, resolvedAddr))

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -454,9 +454,6 @@ func main() {
 		detector.SetCostTracker(costTracker)
 	}
 	detector.SetHistoryTracker(historyTracker)
-	// Capture terminal/IDE identity at first PID assignment so the menu-bar
-	// app can jump back to the launching terminal on row/notification click.
-	detector.SetLauncherEnvReader(processlifecycle.ReadLauncherEnv)
 
 	// PermissionService: single source of truth for consent state (issue
 	// #570). Exercises grants (hook install, watcher start), undoes
@@ -470,11 +467,13 @@ func main() {
 	if !demoMode {
 		hasLive = processlifecycle.HasLiveProcess
 	}
-	// The consent catalog is the agent adapters plus the Gas Town
-	// orchestrator — gastown isn't in agents.All() (it has no Source/
-	// Process axes) but its ~/gt reads are consent-gated all the same.
+	// The consent catalog is the agent adapters plus two daemon-wide
+	// entries with no Source/Process axes: the Gas Town orchestrator
+	// (reads ~/gt) and launcher-identity capture (reads whitelisted env
+	// vars from agent processes for click-to-focus).
 	permissionAgents := append(append([]agent.Agent{}, allAgents...),
-		gastownadapter.PermissionDeclaration(startGastown, stopGastown))
+		gastownadapter.PermissionDeclaration(startGastown, stopGastown),
+		processlifecycle.LauncherPermissionDeclaration())
 	permService := services.NewPermissionService(
 		permissionAgents, permStore, push, logger,
 		cfg.PermissionMode, detector, watcherFactories, hasLive,
@@ -482,6 +481,30 @@ func main() {
 	// Gas Town is detected by root-directory presence (stat-only), not by
 	// a live process matcher.
 	permService.SetDetectionProbe(gastownadapter.Name, gastownadapter.RootDetected)
+	// Launcher capture is relevant whenever ANY agent runs, so its wizard
+	// row appears alongside the first detected agent's. Short-circuits on
+	// the first live match, and the detection poller only runs while
+	// something is pending, so the extra scans are bounded.
+	permService.SetDetectionProbe(processlifecycle.LauncherName, func() bool {
+		for _, a := range allAgents {
+			if processlifecycle.HasLiveProcess(a.Process.Match) {
+				return true
+			}
+		}
+		return false
+	})
+
+	// Capture terminal/IDE identity at first PID assignment so the menu-bar
+	// app can jump back to the launching terminal on row/notification click.
+	// Consent-gated per capture (#570): checked on every call so a revoke
+	// takes effect immediately; without the grant, click-to-focus falls
+	// back to app-level activation.
+	detector.SetLauncherEnvReader(func(pid int) *session.Launcher {
+		if !permService.Granted(processlifecycle.LauncherName, processlifecycle.PermissionKeyLauncherEnv) {
+			return nil
+		}
+		return processlifecycle.ReadLauncherEnv(pid)
+	})
 	// Consent gate for the detector's own transcript reads (startup seed +
 	// stale-working refresh of PERSISTED sessions) — the watcher pipeline
 	// is gated by construction, but these two paths read repo-listed

--- a/core/cmd/irrlichd/wiring.go
+++ b/core/cmd/irrlichd/wiring.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"irrlicht/core/adapters/inbound/agents/fswatcher"
+	"irrlicht/core/adapters/inbound/agents/opencode"
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/ports/inbound"
@@ -18,8 +19,10 @@ import (
 // Dir and a process scanner keyed on the matcher. FilesUnderCWD adapters
 // get only a scanner, configured with the variant's Filename so it emits
 // transcript_new events on first appearance of the per-process file
-// inside CWD. ProcessOwnedStore adapters get only a scanner; their
-// dedicated DB-aware watcher is constructed separately by main.go.
+// inside CWD. ProcessOwnedStore adapters get a scanner plus their
+// dedicated store watcher (OpenCode's SQLite poller — panics loudly for
+// any other ProcessOwnedStore adapter, which must wire its watcher here;
+// grant-all daemons exercise every factory at boot, so CI catches it).
 //
 // Returns the list of watchers and a human-readable label for the
 // startup log line ("<adapter> (<root>)").
@@ -37,6 +40,15 @@ func buildAgentWatchers(
 		w := fswatcher.New(s.RootDirFor(runtime.GOOS), a.Identity.Name, maxSessionAge).WithIdentity(a.Identity)
 		watchers = append(watchers, w)
 		labels = append(labels, fmt.Sprintf("%s (%s)", a.Identity.Name, w.Root()))
+	}
+
+	if _, ok := a.Source.(agent.ProcessOwnedStore); ok {
+		if a.Identity.Name != opencode.AdapterName {
+			panic(fmt.Sprintf("buildAgentWatchers: no store watcher wired for ProcessOwnedStore adapter %q — add its construction here", a.Identity.Name))
+		}
+		w := opencode.New(maxSessionAge).WithIdentity(a.Identity)
+		watchers = append(watchers, w)
+		labels = append(labels, fmt.Sprintf("%s-db (%s)", a.Identity.Name, w.Root()))
 	}
 
 	scanner := processlifecycle.NewScanner(processNameFor(a), a.Identity.Name, 0).WithIdentity(a.Identity)

--- a/core/domain/agent/declaration.go
+++ b/core/domain/agent/declaration.go
@@ -1,16 +1,39 @@
 package agent
 
+import "irrlicht/core/domain/permission"
+
 // Agent is the registration record each inbound agent adapter exports.
-// It collapses identity, process recognition, and session source into
-// three orthogonal axes. Each adapter package's Agent() constructor
-// returns one value; the daemon wires per-adapter behavior off it via
-// the map projections in core/adapters/inbound/agents (Parsers,
-// PIDDiscoverers, ProcessNames, SubagentCounters, MetricsProviders) and
-// the Source-variant dispatch in core/cmd/irrlichd/wiring.go.
+// It collapses identity, process recognition, session source, and
+// consent-gated permissions into four orthogonal axes. Each adapter
+// package's Agent() constructor returns one value; the daemon wires
+// per-adapter behavior off it via the map projections in
+// core/adapters/inbound/agents (Parsers, PIDDiscoverers, ProcessNames,
+// SubagentCounters, MetricsProviders) and the Source-variant dispatch
+// in core/cmd/irrlichd/wiring.go.
 type Agent struct {
-	Identity Identity
-	Process  Process
-	Source   Source
+	Identity    Identity
+	Process     Process
+	Source      Source
+	Permissions []Permission
+}
+
+// Permission declares one consent-gated capability of an adapter: what
+// it touches, what feature it unlocks, and (for modify-kind entries) how
+// to apply and undo the modification. The daemon exercises nothing — no
+// install, no read — until the user grants the permission (issue #570).
+type Permission struct {
+	Key             string          // stable identifier, e.g. "hooks", "transcripts"
+	Kind            permission.Kind // modify (writes a file) or observe (reads only)
+	Title           string          // short label for the wizard row
+	FeatureUnlocked string          // what granting enables
+	Touches         string          // what the daemon reads/writes when granted
+	Detail          string          // expanded (i) text: exact paths/commands, how to undo
+
+	// Apply performs the modification on grant; Remove undoes it on
+	// revoke. Nil for observe-kind permissions — their effect (starting
+	// and stopping the agent's watchers) is owned by the daemon wiring.
+	Apply  func() error
+	Remove func() error
 }
 
 // Identity is the always-required adapter metadata served via

--- a/core/domain/config/config.go
+++ b/core/domain/config/config.go
@@ -22,14 +22,26 @@ const defaultMaxSessionAge = 5 * 24 * time.Hour
 // remains 30 min.
 const defaultReadySessionTTL = 30 * time.Minute
 
+// Permission-wizard modes (issue #570). Ask is the production default:
+// nothing is read or written until the user grants each permission.
+// GrantAll auto-grants every declared permission at startup and never
+// prompts — for demo, recording, and test daemons where fixtures must not
+// hang on consent. Set via IRRLICHT_PERMISSION_MODE.
+const (
+	PermissionModeAsk      = "ask"
+	PermissionModeGrantAll = "grant-all"
+)
+
 // Config holds daemon-wide runtime configuration.
 type Config struct {
 	MaxSessionAge   time.Duration
 	ReadySessionTTL time.Duration
+	PermissionMode  string
 }
 
 // Default returns a Config populated with production defaults, with the
-// IRRLICHT_READY_SESSION_TTL env override applied if set.
+// IRRLICHT_READY_SESSION_TTL and IRRLICHT_PERMISSION_MODE env overrides
+// applied if set.
 func Default() Config {
 	ttl := defaultReadySessionTTL
 	if raw := os.Getenv("IRRLICHT_READY_SESSION_TTL"); raw != "" {
@@ -37,8 +49,13 @@ func Default() Config {
 			ttl = parsed
 		}
 	}
+	mode := PermissionModeAsk
+	if os.Getenv("IRRLICHT_PERMISSION_MODE") == PermissionModeGrantAll {
+		mode = PermissionModeGrantAll
+	}
 	return Config{
 		MaxSessionAge:   defaultMaxSessionAge,
 		ReadySessionTTL: ttl,
+		PermissionMode:  mode,
 	}
 }

--- a/core/domain/permission/permission.go
+++ b/core/domain/permission/permission.go
@@ -1,0 +1,66 @@
+// Package permission models the consent state behind the permission
+// transparency wizard (issue #570). Every read or modification irrlicht
+// performs on the user's system is declared as a per-agent permission;
+// the daemon exercises nothing — no hook install, no transcript tailing,
+// no DB polling — until the user grants it.
+package permission
+
+import "maps"
+
+// State is the consent status of one agent permission.
+type State string
+
+const (
+	// StatePending means the user has never answered. Treated like denied
+	// for gating; differs only in wizard display (pending items re-prompt).
+	StatePending State = "pending"
+	StateGranted State = "granted"
+	StateDenied  State = "denied"
+)
+
+// Kind classifies what exercising a permission does.
+type Kind string
+
+const (
+	// KindModify covers permissions that write files outside the daemon
+	// home (e.g. hook entries in ~/.claude/settings.json). Grant performs
+	// the modification; revoke actively undoes it.
+	KindModify Kind = "modify"
+	// KindObserve covers read-only monitoring (transcript tailing, DB
+	// polling). Grant starts the agent's watchers; revoke stops them.
+	KindObserve Kind = "observe"
+)
+
+// Set holds the answered state of every agent × permission pair.
+// Keys: agent name → permission key → state. Absent keys are pending,
+// which is also the upgrade path: a permission newly declared by a later
+// daemon version simply resolves to pending until answered, while
+// previously answered keys are untouched.
+type Set map[string]map[string]State
+
+// Get returns the recorded state for the agent/key pair, defaulting to
+// StatePending when the pair has never been answered.
+func (s Set) Get(agent, key string) State {
+	if st, ok := s[agent][key]; ok {
+		return st
+	}
+	return StatePending
+}
+
+// Put records an answer for the agent/key pair.
+func (s Set) Put(agent, key string, st State) {
+	if s[agent] == nil {
+		s[agent] = make(map[string]State)
+	}
+	s[agent][key] = st
+}
+
+// Clone returns a deep copy, so a caller can persist a stable snapshot
+// outside the lock that guards the live set.
+func (s Set) Clone() Set {
+	out := make(Set, len(s))
+	for agent, perms := range s {
+		out[agent] = maps.Clone(perms)
+	}
+	return out
+}

--- a/core/domain/permission/permission_test.go
+++ b/core/domain/permission/permission_test.go
@@ -1,0 +1,31 @@
+package permission
+
+import "testing"
+
+func TestGetDefaultsToPending(t *testing.T) {
+	s := Set{}
+	if got := s.Get("claude-code", "hooks"); got != StatePending {
+		t.Fatalf("Get on empty set = %q, want %q", got, StatePending)
+	}
+}
+
+func TestPutThenGet(t *testing.T) {
+	s := Set{}
+	s.Put("claude-code", "hooks", StateGranted)
+	s.Put("claude-code", "statusline", StateDenied)
+
+	if got := s.Get("claude-code", "hooks"); got != StateGranted {
+		t.Fatalf("hooks = %q, want granted", got)
+	}
+	if got := s.Get("claude-code", "statusline"); got != StateDenied {
+		t.Fatalf("statusline = %q, want denied", got)
+	}
+	// A key never answered stays pending — the upgrade path for
+	// permissions declared by a later daemon version.
+	if got := s.Get("claude-code", "transcripts"); got != StatePending {
+		t.Fatalf("transcripts = %q, want pending", got)
+	}
+	if got := s.Get("codex", "transcripts"); got != StatePending {
+		t.Fatalf("codex/transcripts = %q, want pending", got)
+	}
+}

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/permission"
 	"irrlicht/core/domain/session"
 )
 
@@ -54,7 +55,23 @@ const (
 	// client merges the priority into the current bucket of all three
 	// rings using max-priority aggregation.
 	PushTypeHistoryUpgrade = "history_upgrade"
+
+	// PushTypePermissionsUpdated signals that consent state changed
+	// (agent detected, answer applied, or new permission declared). The
+	// envelope carries no payload: clients re-fetch GET /api/v1/permissions
+	// and show or dismiss the wizard accordingly — which is also how the
+	// surface that answered second dismisses live (issue #570).
+	PushTypePermissionsUpdated = "permissions_updated"
 )
+
+// PermissionStore persists the user's per-agent consent answers for the
+// permission wizard (issue #570).
+type PermissionStore interface {
+	// Load returns the persisted set; a missing file yields an empty set
+	// (every declared permission pending).
+	Load() (permission.Set, error)
+	Save(permission.Set) error
+}
 
 // SessionRepository loads, saves, and deletes session state files.
 type SessionRepository interface {

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -52,6 +52,19 @@ class SessionManager: ObservableObject {
     @Published var stateHistory: [String: [String]] = [:]  // session_id → oldest→newest state strings (active granularity)
     @Published var historyBucketCount: Int = 60          // matches HistoryBucketCount on the daemon
 
+    /// Consent state for the permission wizard (issue #570). Refreshed on
+    /// connect and on every `permissions_updated` push — which is also how
+    /// the wizard dismisses live when the web dashboard answers first.
+    @Published var permissionsSnapshot: PermissionsSnapshot?
+
+    /// Agents the auto wizard should show: detected, with at least one
+    /// pending permission, in ask mode. Empty in grant-all mode (wizard
+    /// suppressed for demo/record/test daemons).
+    var pendingWizardAgents: [AgentPermissions] {
+        guard let snap = permissionsSnapshot, snap.mode == "ask" else { return [] }
+        return snap.agents.filter(\.needsWizard)
+    }
+
     /// All three granularities held in parallel so toggling 1s/10s/60s is
     /// instant — the WebSocket streams every granularity continuously, the
     /// view just picks which dict to mirror into `stateHistory`.
@@ -263,6 +276,7 @@ class SessionManager: ObservableObject {
     private func connect() async {
         await hydrateAgents()
         await hydrateSessions()
+        await refreshPermissions()
 
         guard let url = URL(string: "\(DaemonEndpoint.wsBase)/api/v1/sessions/stream") else { return }
         let task = URLSession.shared.webSocketTask(with: url)
@@ -898,6 +912,46 @@ class SessionManager: ObservableObject {
         }
     }
 
+    /// Fetches the consent state from the local daemon. Older daemons
+    /// (pre-#570) have no /api/v1/permissions — the snapshot stays nil and
+    /// no wizard ever appears.
+    func refreshPermissions() async {
+        guard let url = URL(string: "\(DaemonEndpoint.httpBase)/api/v1/permissions") else { return }
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else { return }
+            permissionsSnapshot = try JSONDecoder().decode(PermissionsSnapshot.self, from: data)
+        } catch {
+            print("🔐 Permissions refresh failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Submits wizard/Settings decisions. The daemon applies effects
+    /// (installs/uninstalls hooks, starts/stops watchers), persists, and
+    /// broadcasts `permissions_updated` so the web dashboard dismisses its
+    /// wizard — first answer wins. The response body is the updated
+    /// snapshot, applied immediately so the UI doesn't wait on the push.
+    /// Returns false on failure so the wizard can stay up for a retry
+    /// instead of silently losing the user's consent decisions.
+    @discardableResult
+    func answerPermissions(_ answers: [PermissionAnswer]) async -> Bool {
+        guard !answers.isEmpty,
+              let url = URL(string: "\(DaemonEndpoint.httpBase)/api/v1/permissions/answer") else { return false }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        do {
+            request.httpBody = try JSONEncoder().encode(["answers": answers])
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else { return false }
+            permissionsSnapshot = try JSONDecoder().decode(PermissionsSnapshot.self, from: data)
+            return true
+        } catch {
+            print("🔐 Permissions answer failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
     private func hydrateSessions() async {
         // The Local source feeds sessionMap/localApiGroups from the local
         // daemon's REST API. When Local is disabled this must not run, or the
@@ -1026,6 +1080,11 @@ class SessionManager: ObservableObject {
                 if let sid = envelope.sessionID, let prio = envelope.priority {
                     applyHistoryUpgrade(sessionID: sid, priority: prio)
                 }
+            case "permissions_updated":
+                // Consent state changed (agent detected, or the web
+                // dashboard answered the wizard). Dataless by design —
+                // re-fetch; pendingWizardAgents drives the overlay (#570).
+                Task { await refreshPermissions() }
             default:
                 break
             }

--- a/platforms/macos/Irrlicht/Models/AgentPermissions.swift
+++ b/platforms/macos/Irrlicht/Models/AgentPermissions.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Consent state for the permission transparency wizard (issue #570),
+/// mirroring GET /api/v1/permissions. The daemon is the single source of
+/// truth: nothing is read or modified on the user's system until the
+/// corresponding permission is granted.
+struct PermissionsSnapshot: Decodable, Equatable {
+    /// "ask" (production) or "grant-all" (demo/record/test daemons —
+    /// wizard suppressed).
+    let mode: String
+    let agents: [AgentPermissions]
+}
+
+struct AgentPermissions: Decodable, Equatable, Identifiable {
+    let name: String
+    let displayName: String
+    /// True while the daemon's detection poller sees a live process for
+    /// this agent. Detection is the consent-free baseline — it never reads
+    /// files or creates sessions.
+    let detected: Bool
+    let permissions: [PermissionItem]
+
+    var id: String { name }
+
+    /// True when the auto wizard should include this agent: it is running
+    /// and has at least one unanswered permission.
+    var needsWizard: Bool {
+        detected && permissions.contains { $0.state == .pending }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case displayName = "display_name"
+        case detected
+        case permissions
+    }
+}
+
+struct PermissionItem: Decodable, Equatable, Identifiable {
+    enum State: String, Decodable {
+        case pending, granted, denied
+    }
+
+    let key: String
+    /// "modify" (writes a file outside the daemon home) or "observe"
+    /// (read-only monitoring).
+    let kind: String
+    let state: State
+    let title: String
+    let featureUnlocked: String
+    let touches: String
+    let detail: String
+
+    var id: String { key }
+
+    enum CodingKeys: String, CodingKey {
+        case key, kind, state, title, touches, detail
+        case featureUnlocked = "feature_unlocked"
+    }
+}
+
+/// One decision in the POST /api/v1/permissions/answer body.
+struct PermissionAnswer: Encodable {
+    let agent: String
+    let permission: String
+    let grant: Bool
+}

--- a/platforms/macos/Irrlicht/Views/PermissionWizardView.swift
+++ b/platforms/macos/Irrlicht/Views/PermissionWizardView.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+/// Consent wizard for the permission transparency model (issue #570).
+///
+/// Auto mode appears when a detected agent has unanswered permissions. Its
+/// agent set is LOCKED at presentation time (`lockedAgents`, captured by
+/// SessionListView): an agent detected mid-decision never injects rows into
+/// an open wizard — it gets its own prompt after this one resolves. The
+/// locked set also keeps the wizard up if the agent's process exits while
+/// the user is deciding; only answers dismiss it (SessionListView's
+/// reconcile watches the snapshot), which is equally how the wizard closes
+/// live when the web dashboard answers first.
+///
+/// Review mode (Settings → "Review agent permissions…") shows every agent
+/// and every permission with the current grants preloaded, so any decision
+/// can be changed later.
+struct PermissionWizardView: View {
+    enum Mode {
+        case auto, review
+    }
+
+    let mode: Mode
+    /// Agent names the auto wizard presents (ignored in review mode).
+    var lockedAgents: [String] = []
+    let onClose: () -> Void
+    @EnvironmentObject var sessionManager: SessionManager
+
+    /// Toggle drafts keyed "agent/permission". Nothing is sent until Apply
+    /// — the explicit click is the consent. Unset keys read as
+    /// `defaultValue(for:)`, the single authority for toggle defaults.
+    @State private var draft: [String: Bool] = [:]
+    /// True while an Apply POST is in flight; guards double submission.
+    @State private var submitting = false
+
+    private var agents: [AgentPermissions] {
+        let all = sessionManager.permissionsSnapshot?.agents ?? []
+        switch mode {
+        case .review:
+            return all
+        case .auto:
+            // Locked set, NOT pendingWizardAgents: membership must survive
+            // the agent's process exiting mid-decision (detected flips
+            // false) and must exclude agents detected after presentation.
+            return all.filter { lockedAgents.contains($0.name) }
+        }
+    }
+
+    /// The permissions shown for one agent: pending only in auto mode,
+    /// everything in review mode.
+    private func visiblePermissions(of agent: AgentPermissions) -> [PermissionItem] {
+        mode == .auto ? agent.permissions.filter { $0.state == .pending } : agent.permissions
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(mode == .auto ? "Agent detected" : "Agent permissions")
+                .font(.headline)
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+                .padding(.bottom, 6)
+
+            Text(mode == .auto
+                ? "irrlicht monitors coding agents only with your consent. Choose what it may do for each detected agent."
+                : "Everything irrlicht may read or modify, per agent. Toggling a grant off undoes the modification and stops all reading.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 12)
+
+            Divider()
+                .padding(.horizontal, 20)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    ForEach(agents) { agent in
+                        agentSection(agent)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
+            }
+            .frame(maxHeight: 520)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Divider()
+                .padding(.horizontal, 20)
+
+            HStack {
+                Text("Nothing is read or modified until you grant it.")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                Spacer()
+                if mode == .auto {
+                    Button("Decide Later") { onClose() }
+                        .disabled(submitting)
+                        .tooltip("Keep everything paused; the wizard returns from Settings or when the agent is seen again")
+                }
+                Button("Apply") { apply() }
+                    .disabled(submitting)
+                    .keyboardShortcut(.defaultAction)
+                    .tooltip("Apply these grants now")
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .padding(.bottom, 20)
+        }
+        .frame(width: 360)
+        .background(Color(NSColor.windowBackgroundColor))
+        .toggleStyle(IrrlichtSwitchToggleStyle())
+    }
+
+    @ViewBuilder
+    private func agentSection(_ agent: AgentPermissions) -> some View {
+        let perms = visiblePermissions(of: agent)
+        if !perms.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 6) {
+                    Text(agent.displayName)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    if agent.detected {
+                        Text("running")
+                            .font(.caption2)
+                            .foregroundColor(IrrColors.working)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 3)
+                                    .stroke(IrrColors.working, lineWidth: 1)
+                            )
+                            .tooltip("A live \(agent.displayName) process was detected")
+                    }
+                    Spacer()
+                }
+                ForEach(perms) { perm in
+                    permissionRow(agent: agent, perm: perm)
+                }
+            }
+        }
+    }
+
+    private func permissionRow(agent: AgentPermissions, perm: PermissionItem) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            LeadingToggle(
+                isOn: draftBinding(agent: agent, perm: perm),
+                label: perm.title,
+                info: "\(perm.touches). \(perm.detail)"
+            )
+            Text(perm.featureUnlocked)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.leading, 38)
+        }
+    }
+
+    private func draftKey(_ agent: AgentPermissions, _ perm: PermissionItem) -> String {
+        "\(agent.name)/\(perm.key)"
+    }
+
+    private func draftBinding(agent: AgentPermissions, perm: PermissionItem) -> Binding<Bool> {
+        let key = draftKey(agent, perm)
+        return Binding(
+            get: { draft[key] ?? defaultValue(for: perm) },
+            set: { draft[key] = $0 }
+        )
+    }
+
+    /// Pending items default on (granting is the value proposition; the
+    /// explicit Apply click is the consent). Answered items show their
+    /// current state.
+    private func defaultValue(for perm: PermissionItem) -> Bool {
+        perm.state == .pending ? true : perm.state == .granted
+    }
+
+    /// Builds the answer batch: in auto mode every displayed pending item
+    /// is answered explicitly (off = deny); in review mode only changes
+    /// against the current state are submitted.
+    ///
+    /// Auto mode does NOT close on Apply — the daemon's response snapshot
+    /// resolves the locked agents' pending items and SessionListView's
+    /// reconcile dismisses the wizard. A failed POST therefore keeps the
+    /// wizard up for a retry instead of silently dropping the consent
+    /// decisions while monitoring stays paused.
+    private func apply() {
+        var answers: [PermissionAnswer] = []
+        for agent in agents {
+            for perm in visiblePermissions(of: agent) {
+                let grant = draft[draftKey(agent, perm)] ?? defaultValue(for: perm)
+                switch perm.state {
+                case .pending:
+                    answers.append(PermissionAnswer(agent: agent.name, permission: perm.key, grant: grant))
+                case .granted, .denied:
+                    if grant != (perm.state == .granted) {
+                        answers.append(PermissionAnswer(agent: agent.name, permission: perm.key, grant: grant))
+                    }
+                }
+            }
+        }
+        guard !answers.isEmpty else {
+            onClose()
+            return
+        }
+        submitting = true
+        let manager = sessionManager
+        let isReview = mode == .review
+        Task {
+            let ok = await manager.answerPermissions(answers)
+            submitting = false
+            if isReview && ok {
+                onClose()
+            }
+        }
+    }
+}

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -189,6 +189,20 @@ struct SessionListView: View {
     @State private var isSettingsButtonHovered = false
     @State private var isUpdatesButtonHovered = false
     @State private var showSettings = false
+    /// Settings → "Review agent permissions…" swaps the panel body to the
+    /// wizard in review mode (issue #570).
+    @State private var showPermissionsReview = false
+    /// Non-nil while the auto consent wizard is presented: the agent set
+    /// LOCKED at presentation time. Locking means a mid-decision detection
+    /// flip (agent process exits) can't tear the wizard down, and a newly
+    /// detected agent can't inject default-on rows into an open wizard —
+    /// it gets its own prompt once this one resolves. reconcileAutoWizard
+    /// owns the lifecycle.
+    @State private var autoWizardAgents: [String]?
+    /// "Decide Later" remembers which agent set was dismissed so the auto
+    /// wizard doesn't bounce right back; a different agent appearing (new
+    /// signature) re-triggers it.
+    @State private var dismissedWizardSignature: String?
     @AppStorage("displayMode") private var displayModeRaw: String = DisplayMode.context.rawValue
     @AppStorage("showQuotaForecast") private var showQuotaForecast: Bool = true
     // Shared timeframe for all provider usage chips; clicking any chip cycles
@@ -199,10 +213,71 @@ struct SessionListView: View {
     private var usageCostTimeframe: CostTimeframe { .from(usageCostTimeframeRaw) }
     private func cycleUsageTimeframe() { usageCostTimeframeRaw = usageCostTimeframe.next().rawValue }
 
+    /// Stable identity of the current pending-wizard agent set, for the
+    /// "Decide Later" suppression above.
+    private var wizardSignature: String {
+        sessionManager.pendingWizardAgents.map(\.name).sorted().joined(separator: ",")
+    }
+
+    /// Reconciles auto-wizard visibility with the consent snapshot (#570).
+    /// Presentation: a detected agent has pending permissions and the set
+    /// wasn't just dismissed. Dismissal: every LOCKED agent has no pending
+    /// permissions left — i.e. answered, here or on the web dashboard
+    /// (first answer wins). A detection flip alone (agent exited while the
+    /// user is deciding) never dismisses an open wizard.
+    private func reconcileAutoWizard() {
+        let snapAgents = sessionManager.permissionsSnapshot?.agents ?? []
+        if let locked = autoWizardAgents {
+            let stillPending = locked.contains { name in
+                snapAgents.first(where: { $0.name == name })?
+                    .permissions.contains { $0.state == .pending } ?? false
+            }
+            if !stillPending {
+                autoWizardAgents = nil
+            }
+        }
+        if autoWizardAgents == nil {
+            let names = sessionManager.pendingWizardAgents.map(\.name).sorted()
+            if !names.isEmpty && dismissedWizardSignature != names.joined(separator: ",") {
+                autoWizardAgents = names
+            }
+        }
+    }
+
     var body: some View {
-        if showSettings {
-            SettingsView(isPresented: $showSettings)
-        } else {
+        Group {
+            if showSettings {
+                SettingsView(
+                    isPresented: $showSettings,
+                    onReviewPermissions: {
+                        showSettings = false
+                        showPermissionsReview = true
+                    }
+                )
+            } else if showPermissionsReview {
+                PermissionWizardView(mode: .review, onClose: { showPermissionsReview = false })
+            } else if let locked = autoWizardAgents {
+                PermissionWizardView(
+                    mode: .auto,
+                    lockedAgents: locked,
+                    onClose: {
+                        // "Decide Later": suppress until the pending set
+                        // changes (or next app launch — consent stays
+                        // pending daemon-side).
+                        dismissedWizardSignature = wizardSignature
+                        autoWizardAgents = nil
+                    }
+                )
+            } else {
+                mainPanel
+            }
+        }
+        .onAppear { reconcileAutoWizard() }
+        .onChange(of: sessionManager.permissionsSnapshot) { _ in reconcileAutoWizard() }
+    }
+
+    private var mainPanel: some View {
+        Group {
             VStack(alignment: .leading, spacing: 0) {
                 if sessionManager.apiGroups.isEmpty && sessionManager.sessions.isEmpty {
                     emptyStateView

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -5,6 +5,9 @@ import UserNotifications
 
 struct SettingsView: View {
     @Binding var isPresented: Bool
+    /// Opens the permission wizard in review mode (issue #570). Wired by
+    /// SessionListView, which owns the panel-body swap.
+    var onReviewPermissions: () -> Void = {}
     @EnvironmentObject var updateManager: UpdateManager
     @EnvironmentObject var sessionManager: SessionManager
     @AppStorage("debugMode") private var debugMode: Bool = false
@@ -176,6 +179,23 @@ struct SettingsView: View {
                             relayURLDraft = "ws://localhost:7839"
                         }
                         commitRelayURL()
+                    }
+
+                    Divider()
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 6) {
+                            Text("Permissions")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            InfoIcon(text: "Everything irrlicht may read or modify, per agent. Toggling a grant off undoes the modification and stops all reading.")
+                            Spacer()
+                        }
+                        Button("Review agent permissions…") {
+                            onReviewPermissions()
+                        }
+                        .controlSize(.small)
+                        .tooltip("Open the per-agent permission toggles")
                     }
 
                     Divider()
@@ -507,7 +527,8 @@ private struct NotificationEventRow: View {
 /// Left-aligned switch + label, rendered by `IrrlichtSwitchToggleStyle`.
 /// An optional `info` string adds a hover-reveal ⓘ next to the label so the
 /// explanation doesn't cost a permanent block of caption text below the row.
-private struct LeadingToggle: View {
+/// Internal (not private): PermissionWizardView reuses it.
+struct LeadingToggle: View {
     @Binding var isOn: Bool
     let label: String
     var info: String? = nil
@@ -526,7 +547,8 @@ private struct LeadingToggle: View {
 
 /// Small ⓘ affordance: reveals a one-line explainer on hover instead of
 /// spending vertical space on a caption paragraph under every control.
-private struct InfoIcon: View {
+/// Internal (not private): PermissionWizardView reuses it.
+struct InfoIcon: View {
     let text: String
 
     var body: some View {
@@ -542,7 +564,8 @@ private struct InfoIcon: View {
 /// white knob. Replaces `ToggleStyle.switch` because macOS's NSSwitch-backed
 /// switch ignores `.tint(_:)` — its on color is locked to the system accent.
 /// Drawing the pill ourselves makes the color independent of System Settings.
-private struct IrrlichtSwitchToggleStyle: ToggleStyle {
+/// Internal (not private): PermissionWizardView applies it too.
+struct IrrlichtSwitchToggleStyle: ToggleStyle {
     func makeBody(configuration: Configuration) -> some View {
         HStack(spacing: 8) {
             ZStack(alignment: configuration.isOn ? .trailing : .leading) {

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -81,6 +81,15 @@
                placeholder="bearer token" spellcheck="false" autocomplete="off">
       </label>
 
+      <h2>Permissions</h2>
+      <div class="settings-action-row">
+        <span class="settings-label-text">
+          <span class="settings-title">Agent permissions</span>
+          <span class="settings-hint">Review what irrlicht may read or modify, per agent.</span>
+        </span>
+        <button class="settings-action-btn" id="settings-review-permissions" type="button">Review…</button>
+      </div>
+
       <h2>Provider quota</h2>
       <label>
         <input type="checkbox" data-quota-setting="showQuotaForecast">
@@ -117,6 +126,18 @@
       <div class="settings-modal-footer">
         <span class="settings-perm-note" id="settings-perm-note"></span>
         <button class="settings-modal-close" id="settings-close" type="button">Done</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="settings-modal-backdrop" id="permissions-backdrop" role="dialog" aria-modal="true" aria-label="Agent permissions">
+    <div class="settings-modal permissions-modal">
+      <h2 id="permissions-title">Agent permissions</h2>
+      <p class="permissions-intro" id="permissions-intro"></p>
+      <div id="permissions-body"></div>
+      <div class="settings-modal-footer">
+        <span class="settings-perm-note">Nothing is read or modified until you grant it.</span>
+        <button class="settings-modal-close" id="permissions-apply" type="button">Apply</button>
       </div>
     </div>
   </div>

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1009,6 +1009,77 @@
       color: var(--muted);
       flex: 1;
     }
+    /* Settings row with a trailing action button (Review permissions…). */
+    .settings-modal .settings-action-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 6px 4px;
+    }
+    .settings-modal .settings-action-btn {
+      font-family: inherit;
+      font-size: 11px;
+      color: var(--text-bright);
+      background: var(--surface-hover);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 4px 10px;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+    .settings-modal .settings-action-btn:hover { border-color: var(--working); }
+
+    /* Permission wizard (issue #570) — shares the settings modal chrome. */
+    .permissions-modal .permissions-intro {
+      font-size: 12px;
+      color: var(--muted);
+      margin-bottom: 10px;
+      line-height: 1.45;
+    }
+    .permissions-modal .perm-agent h3 {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      font-weight: 700;
+      color: var(--text-bright);
+      margin: 12px 0 6px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .permissions-modal .perm-agent:first-child h3 { margin-top: 0; }
+    .permissions-modal .perm-detected {
+      font-size: 9px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--working);
+      border: 1px solid var(--working);
+      border-radius: 3px;
+      padding: 1px 5px;
+    }
+    .permissions-modal .perm-row { padding: 2px 0 6px; }
+    .permissions-modal .perm-details {
+      margin: 2px 0 0 44px;
+      font-size: 11px;
+      color: var(--muted);
+    }
+    .permissions-modal .perm-details summary {
+      cursor: pointer;
+      list-style: none;
+      user-select: none;
+    }
+    .permissions-modal .perm-details summary::-webkit-details-marker { display: none; }
+    .permissions-modal .perm-details[open] summary { color: var(--text); }
+    .permissions-modal .perm-detail-text {
+      margin-top: 4px;
+      padding: 6px 8px;
+      background: var(--surface-hover);
+      border: 1px solid var(--border-subtle);
+      border-radius: 4px;
+      line-height: 1.5;
+      word-break: break-word;
+    }
     .settings-modal .settings-modal-close {
       background: none;
       border: 1px solid var(--border);

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1712,6 +1712,13 @@
     // here, so the render/history/notification paths are unchanged.
     function dispatchRawFrame(msg) {
       if (!msg) return;
+      if (msg.type === 'permissions_updated') {
+        // Consent state changed (agent detected, or the other surface
+        // answered the wizard). Dataless by design — re-fetch and let
+        // updatePermissionsWizard open/dismiss the overlay (#570).
+        refreshPermissions();
+        return;
+      }
       if (msg.type === 'history_snapshot' && msg.session_id && msg.history) {
         applyHistorySnapshot(msg.session_id, msg.history, msg.generations);
         repaintHistory();
@@ -2394,6 +2401,252 @@
       if (el && v && v.version) el.textContent = 'v' + v.version;
     });
 
+    // --- Permission wizard (issue #570) ---
+    // The daemon is consent-first: every read/modification it performs is a
+    // declared per-agent permission, and the wizard collects the answers.
+    // State lives with the daemon (GET /api/v1/permissions); this overlay
+    // appears when a detected agent has pending permissions and dismisses
+    // live when the other surface (macOS app) answers first — the daemon
+    // broadcasts `permissions_updated` and we re-fetch.
+    let permissionsSnapshot = null;
+    // 'auto' = new-agent wizard (pending items only); 'review' = Settings
+    // re-entry (all items, toggles preloaded with current grants).
+    let permissionsWizardMode = null;
+    // Agent names LOCKED into the open auto wizard at presentation time:
+    // a mid-decision detection flip (the agent's process exited) can't
+    // tear it down, and a newly detected agent can't inject rows into it —
+    // it gets its own prompt once this one resolves.
+    let permissionsWizardAgents = null;
+
+    // pendingWizardAgents returns the agents that should trigger the auto
+    // wizard: detected, with at least one pending permission, in ask mode.
+    // Pure; exported for tests.
+    function pendingWizardAgents(snap) {
+      if (!snap || snap.mode !== 'ask' || !Array.isArray(snap.agents)) return [];
+      return snap.agents.filter(a =>
+        a.detected && (a.permissions || []).some(p => p.state === 'pending'));
+    }
+
+    // stillPendingForAgents reports whether any of the named agents still
+    // has a pending permission. Drives auto-wizard dismissal: only answers
+    // dismiss an open wizard (submitted here or on the macOS app — first
+    // answer wins); a detection flip alone must not. Pure; exported for
+    // tests.
+    function stillPendingForAgents(snap, names) {
+      if (!snap || !Array.isArray(snap.agents) || !Array.isArray(names)) return false;
+      return snap.agents.some(a => names.includes(a.name) &&
+        (a.permissions || []).some(p => p.state === 'pending'));
+    }
+
+    // buildPermissionAnswers computes the POST payload from the wizard's
+    // toggle states. draft maps "agent/key" → bool. In onlyPending mode
+    // (auto wizard) every displayed pending item is answered explicitly;
+    // in review mode unchanged already-answered items are skipped. Pure;
+    // exported for tests.
+    function buildPermissionAnswers(snap, draft, onlyPending) {
+      const out = [];
+      if (!snap || !Array.isArray(snap.agents)) return out;
+      for (const a of snap.agents) {
+        for (const p of (a.permissions || [])) {
+          const k = a.name + '/' + p.key;
+          if (!(k in draft)) continue;
+          const grant = !!draft[k];
+          if (p.state === 'pending') {
+            out.push({ agent: a.name, permission: p.key, grant });
+            continue;
+          }
+          if (onlyPending) continue;
+          if (grant !== (p.state === 'granted')) {
+            out.push({ agent: a.name, permission: p.key, grant });
+          }
+        }
+      }
+      return out;
+    }
+
+    function refreshPermissions() {
+      return fetch('/api/v1/permissions')
+        .then(r => r.ok ? r.json() : null)
+        .catch(() => null)
+        .then(snap => {
+          if (!snap) return;
+          permissionsSnapshot = snap;
+          updatePermissionsWizard();
+        });
+    }
+
+    // updatePermissionsWizard reconciles overlay visibility with the
+    // snapshot: opens the auto wizard when a detected agent has pending
+    // permissions, and dismisses it once its LOCKED agents have no pending
+    // items left — answered here or on the macOS app (first answer wins).
+    // A detection flip alone never dismisses an open wizard, and an open
+    // wizard is not re-rendered, so in-flight toggling isn't clobbered.
+    function updatePermissionsWizard() {
+      const backdrop = document.getElementById('permissions-backdrop');
+      if (!backdrop) return;
+      if (backdrop.classList.contains('open')) {
+        if (permissionsWizardMode !== 'auto') return;
+        if (stillPendingForAgents(permissionsSnapshot, permissionsWizardAgents)) return;
+        closePermissionsWizard();
+        // Fall through: another agent may be waiting for its own prompt.
+      }
+      if (pendingWizardAgents(permissionsSnapshot).length > 0) openPermissionsWizard('auto');
+    }
+
+    function openPermissionsWizard(mode) {
+      const backdrop = document.getElementById('permissions-backdrop');
+      if (!backdrop || !permissionsSnapshot) return;
+      permissionsWizardMode = mode;
+      permissionsWizardAgents = mode === 'auto'
+        ? pendingWizardAgents(permissionsSnapshot).map(a => a.name)
+        : null;
+      renderPermissionsWizard();
+      backdrop.classList.add('open');
+    }
+
+    function closePermissionsWizard() {
+      const backdrop = document.getElementById('permissions-backdrop');
+      if (backdrop) backdrop.classList.remove('open');
+      permissionsWizardMode = null;
+      permissionsWizardAgents = null;
+    }
+
+    // renderPermissionsWizard rebuilds the overlay body. Auto mode shows
+    // the LOCKED agents' unanswered items only (an upgrade that adds one
+    // new permission re-asks just that one); review mode shows everything
+    // with current grants preloaded.
+    function renderPermissionsWizard() {
+      const body = document.getElementById('permissions-body');
+      const title = document.getElementById('permissions-title');
+      const intro = document.getElementById('permissions-intro');
+      if (!body || !permissionsSnapshot) return;
+      const auto = permissionsWizardMode === 'auto';
+      const agents = auto
+        ? (permissionsSnapshot.agents || []).filter(a =>
+            (permissionsWizardAgents || []).includes(a.name))
+        : (permissionsSnapshot.agents || []);
+      if (title) title.textContent = auto ? 'Agent detected — choose permissions' : 'Agent permissions';
+      if (intro) {
+        intro.textContent = auto
+          ? 'irrlicht monitors coding agents only with your consent. Choose what it may do for each detected agent.'
+          : 'Everything irrlicht may read or modify, per agent. Toggling off undoes the modification and stops all reading.';
+      }
+      body.innerHTML = '';
+      for (const a of agents) {
+        const perms = auto ? a.permissions.filter(p => p.state === 'pending') : a.permissions;
+        if (!perms.length) continue;
+        const section = document.createElement('div');
+        section.className = 'perm-agent';
+        const h = document.createElement('h3');
+        h.textContent = a.display_name || a.name;
+        if (a.detected) {
+          const badge = document.createElement('span');
+          badge.className = 'perm-detected';
+          badge.textContent = 'running';
+          h.appendChild(badge);
+        }
+        section.appendChild(h);
+        for (const p of perms) {
+          section.appendChild(renderPermissionRow(a, p));
+        }
+        body.appendChild(section);
+      }
+    }
+
+    function renderPermissionRow(a, p) {
+      const row = document.createElement('div');
+      row.className = 'perm-row';
+      const label = document.createElement('label');
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.dataset.permAgent = a.name;
+      cb.dataset.permKey = p.key;
+      // Pending items default on (granting is the value proposition; the
+      // explicit Apply click is the consent). Answered items show their
+      // current state.
+      cb.checked = p.state === 'pending' ? true : p.state === 'granted';
+      const text = document.createElement('span');
+      text.className = 'settings-label-text';
+      const titleEl = document.createElement('span');
+      titleEl.className = 'settings-title';
+      titleEl.textContent = p.title || p.key;
+      const hint = document.createElement('span');
+      hint.className = 'settings-hint';
+      hint.textContent = p.feature_unlocked || '';
+      text.appendChild(titleEl);
+      text.appendChild(hint);
+      label.appendChild(cb);
+      label.appendChild(text);
+      row.appendChild(label);
+      // The (i) affordance: an expander with what it touches + full detail.
+      const details = document.createElement('details');
+      details.className = 'perm-details';
+      const summary = document.createElement('summary');
+      summary.textContent = 'ⓘ ' + (p.touches || 'details');
+      const detail = document.createElement('div');
+      detail.className = 'perm-detail-text';
+      detail.textContent = p.detail || '';
+      details.appendChild(summary);
+      details.appendChild(detail);
+      row.appendChild(details);
+      return row;
+    }
+
+    function submitPermissionsWizard() {
+      const body = document.getElementById('permissions-body');
+      if (!body) return;
+      const draft = {};
+      for (const cb of body.querySelectorAll('input[data-perm-agent]')) {
+        draft[cb.dataset.permAgent + '/' + cb.dataset.permKey] = cb.checked;
+      }
+      const answers = buildPermissionAnswers(permissionsSnapshot, draft, permissionsWizardMode === 'auto');
+      if (!answers.length) {
+        closePermissionsWizard();
+        return;
+      }
+      // Keep the wizard up until the daemon confirms: a failed POST must
+      // not silently drop consent decisions while monitoring stays paused
+      // — the user can just hit Apply again.
+      const applyBtn = document.getElementById('permissions-apply');
+      if (applyBtn) applyBtn.disabled = true;
+      const review = permissionsWizardMode === 'review';
+      fetch('/api/v1/permissions/answer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ answers }),
+      }).then(r => r.ok ? r.json() : null).catch(() => null).then(snap => {
+        if (applyBtn) applyBtn.disabled = false;
+        if (!snap) return; // failed — wizard stays for retry
+        permissionsSnapshot = snap;
+        if (review) closePermissionsWizard();
+        updatePermissionsWizard();
+      });
+    }
+
+    {
+      const applyBtn = document.getElementById('permissions-apply');
+      if (applyBtn) applyBtn.addEventListener('click', submitPermissionsWizard);
+      const backdrop = document.getElementById('permissions-backdrop');
+      if (backdrop) backdrop.addEventListener('click', (e) => {
+        if (e.target.id === 'permissions-backdrop') closePermissionsWizard();
+      });
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && backdrop && backdrop.classList.contains('open')) {
+          closePermissionsWizard();
+        }
+      });
+      const review = document.getElementById('settings-review-permissions');
+      if (review) review.addEventListener('click', () => {
+        closeSettings();
+        // Re-fetch so the review view reflects the live state, then open.
+        refreshPermissions().then(() => {
+          if (permissionsSnapshot) openPermissionsWizard('review');
+        });
+      });
+    }
+
+    refreshPermissions();
+
 export {
   resolvedTheme, rowLabel, maybeNotifyOnUpdate,
   formatCost, formatUsageCost, pressureClass, historyPriorityForState,
@@ -2402,4 +2655,5 @@ export {
   compoundSessionId, displaySessionId,
   sessionOrigin, sourceIdOf, localBareIds, isShadowedRemote,
   daemonSessionIds, structureSignature,
+  pendingWizardAgents, buildPermissionAnswers, stillPendingForAgents,
 };

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -1,5 +1,8 @@
 import { describe, test, expect, beforeEach } from 'vitest'
 import {
+  pendingWizardAgents,
+  stillPendingForAgents,
+  buildPermissionAnswers,
   resolvedTheme,
   rowLabel,
   maybeNotifyOnUpdate,
@@ -402,5 +405,119 @@ describe('structureSignature (#559 — detects nesting/role changes the WS delta
       ]},
     ]
     expect(structureSignature(nested)).not.toBe(structureSignature(flat))
+  })
+})
+
+describe('permission wizard (#570)', () => {
+  const snap = (overrides = {}) => ({
+    mode: 'ask',
+    agents: [
+      {
+        name: 'claude-code', display_name: 'Claude Code', detected: true,
+        permissions: [
+          { key: 'transcripts', kind: 'observe', state: 'pending', title: 'Read transcripts' },
+          { key: 'hooks', kind: 'modify', state: 'pending', title: 'Install hooks' },
+        ],
+      },
+      {
+        name: 'codex', display_name: 'Codex', detected: false,
+        permissions: [{ key: 'transcripts', kind: 'observe', state: 'pending' }],
+      },
+      {
+        name: 'pi', display_name: 'Pi', detected: true,
+        permissions: [{ key: 'transcripts', kind: 'observe', state: 'granted' }],
+      },
+    ],
+    ...overrides,
+  })
+
+  test('pendingWizardAgents: only detected agents with pending permissions', () => {
+    const got = pendingWizardAgents(snap())
+    expect(got.map(a => a.name)).toEqual(['claude-code'])
+  })
+
+  test('pendingWizardAgents: empty in grant-all mode (wizard suppressed)', () => {
+    expect(pendingWizardAgents(snap({ mode: 'grant-all' }))).toEqual([])
+  })
+
+  test('pendingWizardAgents: tolerates null/missing fields', () => {
+    expect(pendingWizardAgents(null)).toEqual([])
+    expect(pendingWizardAgents({})).toEqual([])
+    expect(pendingWizardAgents({ mode: 'ask', agents: [{ name: 'x', detected: true }] })).toEqual([])
+  })
+
+  test('pendingWizardAgents: an upgrade-added pending item re-triggers for an answered agent', () => {
+    const s = snap()
+    s.agents[2].permissions.push({ key: 'newthing', kind: 'observe', state: 'pending' })
+    expect(pendingWizardAgents(s).map(a => a.name)).toEqual(['claude-code', 'pi'])
+  })
+
+  test('buildPermissionAnswers: auto mode answers every displayed pending item explicitly', () => {
+    const draft = {
+      'claude-code/transcripts': true,
+      'claude-code/hooks': false,
+    }
+    const got = buildPermissionAnswers(snap(), draft, true)
+    expect(got).toEqual([
+      { agent: 'claude-code', permission: 'transcripts', grant: true },
+      { agent: 'claude-code', permission: 'hooks', grant: false },
+    ])
+  })
+
+  test('buildPermissionAnswers: auto mode never touches already-answered items', () => {
+    const draft = { 'pi/transcripts': false } // answered (granted) — not in the auto wizard
+    expect(buildPermissionAnswers(snap(), draft, true)).toEqual([])
+  })
+
+  test('buildPermissionAnswers: review mode submits only changes', () => {
+    const draft = {
+      'pi/transcripts': false,        // granted → off: revoke
+      'claude-code/hooks': true,      // pending → answered grant
+      'codex/transcripts': false,     // pending → answered deny
+    }
+    const got = buildPermissionAnswers(snap(), draft, false)
+    expect(got).toContainEqual({ agent: 'pi', permission: 'transcripts', grant: false })
+    expect(got).toContainEqual({ agent: 'claude-code', permission: 'hooks', grant: true })
+    expect(got).toContainEqual({ agent: 'codex', permission: 'transcripts', grant: false })
+    expect(got).toHaveLength(3)
+  })
+
+  test('buildPermissionAnswers: review mode skips unchanged grants', () => {
+    const draft = { 'pi/transcripts': true } // granted → on: unchanged
+    expect(buildPermissionAnswers(snap(), draft, false)).toEqual([])
+  })
+
+  test('buildPermissionAnswers: ignores draft keys not in the snapshot', () => {
+    const draft = { 'ghost/agent': true }
+    expect(buildPermissionAnswers(snap(), draft, false)).toEqual([])
+    expect(buildPermissionAnswers(null, draft, false)).toEqual([])
+  })
+})
+
+describe('stillPendingForAgents (#570 locked-set dismissal)', () => {
+  const snap = (state) => ({
+    mode: 'ask',
+    agents: [
+      { name: 'claude-code', detected: false, // process exited mid-decision
+        permissions: [{ key: 'transcripts', state }] },
+      { name: 'codex', detected: true,
+        permissions: [{ key: 'transcripts', state: 'pending' }] },
+    ],
+  })
+
+  test('locked agent still pending keeps the wizard up even when undetected', () => {
+    expect(stillPendingForAgents(snap('pending'), ['claude-code'])).toBe(true)
+  })
+
+  test('locked agent fully answered dismisses (other agents do not count)', () => {
+    // codex is still pending but was NOT locked into this wizard.
+    expect(stillPendingForAgents(snap('granted'), ['claude-code'])).toBe(false)
+    expect(stillPendingForAgents(snap('denied'), ['claude-code'])).toBe(false)
+  })
+
+  test('tolerates null/missing input', () => {
+    expect(stillPendingForAgents(null, ['x'])).toBe(false)
+    expect(stillPendingForAgents({}, ['x'])).toBe(false)
+    expect(stillPendingForAgents(snap('pending'), null)).toBe(false)
   })
 })

--- a/platforms/web/vitest.setup.js
+++ b/platforms/web/vitest.setup.js
@@ -17,6 +17,13 @@ document.body.innerHTML = `
   <div id="gt-container" style="display:none"></div>
   <div id="connection-banner"></div>
   <div id="settings-perm-note"></div>
+  <button id="settings-review-permissions"></button>
+  <div id="permissions-backdrop">
+    <h2 id="permissions-title"></h2>
+    <p id="permissions-intro"></p>
+    <div id="permissions-body"></div>
+    <button id="permissions-apply"></button>
+  </div>
 `;
 
 // jsdom has no matchMedia — provide a stub

--- a/tools/build-dev.sh
+++ b/tools/build-dev.sh
@@ -53,6 +53,8 @@ case "${1:-irrlichd}" in
 esac
 
 echo "done."
-echo "Run isolated from the production daemon (separate state dir + port):"
+echo "Run isolated from the production daemon (separate state dir + port)."
+echo "grant-all is needed on a fresh state dir — without it the consent"
+echo "gate (#570) leaves the daemon monitoring nothing:"
 echo "  IRRLICHT_HOME=\"\$PWD/.build/irrlicht-home\" IRRLICHT_BIND_ADDR=127.0.0.1:7838 \\"
-echo "    core/bin/irrlichd --record"
+echo "    IRRLICHT_PERMISSION_MODE=grant-all core/bin/irrlichd --record"

--- a/tools/linux-parity-check.sh
+++ b/tools/linux-parity-check.sh
@@ -19,8 +19,12 @@
 # then discard it. Nothing per-OS is committed; the corpus stays OS-neutral.
 #
 # Procedure on the Linux host:
-#   1. Build + run a dev recording daemon (the prod daemon has no --record):
+#   1. Build + run a dev recording daemon (the prod daemon has no --record).
+#      IRRLICHT_PERMISSION_MODE=grant-all is required: a fresh IRRLICHT_HOME
+#      has no consent answers (#570), so without it the daemon monitors
+#      nothing and events.jsonl comes out empty:
 #        tools/build-dev.sh && IRRLICHT_HOME=$(mktemp -d) \
+#          IRRLICHT_PERMISSION_MODE=grant-all \
 #          IRRLICHT_DAEMON_PORT=7838 core/bin/irrlichd --record /tmp/rec &
 #   2. Drive the cell's recipe (tmux send-keys; never human-in-loop) so the
 #      live Linux sensor emits the event stream into /tmp/rec/.../events.jsonl.

--- a/tools/onboarding-factory/scripts/run-cell-multi.sh
+++ b/tools/onboarding-factory/scripts/run-cell-multi.sh
@@ -168,9 +168,12 @@ write_error_manifest() {
 
 # --- Spawn ONE isolated --record daemon ---------------------------------
 DAEMON_LOG="$STAGING/daemon.log"
+# grant-all: the consent-first permission gate (#570) would otherwise leave
+# a fresh recording daemon monitoring nothing until a wizard is answered.
 env IRRLICHT_RECORDINGS_DIR="$STAGING/recordings" \
   IRRLICHT_BIND_ADDR="$ONBOARD_BIND" \
   IRRLICHT_HOME="$ONBOARD_HOME" \
+  IRRLICHT_PERMISSION_MODE=grant-all \
   "$DAEMON" --record >"$DAEMON_LOG" 2>&1 &
 DAEMON_PID=$!
 echo "daemon started (pid $DAEMON_PID, bind=$ONBOARD_BIND, home=$ONBOARD_HOME)"

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -224,6 +224,20 @@ if [[ "$ATTACH" == "1" ]]; then
     echo "        is the running irrlichd in --record mode?" >&2
     exit 1
   fi
+  # Consent gate (#570): an attached ask-mode daemon with unanswered/denied
+  # permissions monitors nothing and would record an EMPTY fixture that the
+  # .jsonl check above can't catch (prior recordings satisfy it). Accept
+  # grant-all mode, a fully-granted daemon, or a pre-#570 daemon (no
+  # /api/v1/permissions endpoint → empty response → skip the check).
+  PERM_JSON="$(curl -fsS --max-time 2 "http://$ONBOARD_BIND/api/v1/permissions" 2>/dev/null || true)"
+  if [[ -n "$PERM_JSON" ]]; then
+    PERM_OK="$(jq -r '(.mode == "grant-all") or ([.agents[].permissions[].state] | all(. == "granted"))' <<<"$PERM_JSON" 2>/dev/null || echo false)"
+    if [[ "$PERM_OK" != "true" ]]; then
+      echo "attach: daemon at $ONBOARD_BIND has unanswered/denied permissions — it would monitor nothing and record an empty fixture" >&2
+      echo "        restart it with IRRLICHT_PERMISSION_MODE=grant-all (or grant every permission via the wizard)" >&2
+      exit 1
+    fi
+  fi
   echo "attach: using running daemon's recordings at $ATTACHED_RECORDINGS_DIR"
 else
   DAEMON_LOG="$STAGING/daemon.log"
@@ -231,8 +245,12 @@ else
   # (e.g. an IRRLICHT_HOME path with a space) stays one word — an
   # unquoted ${ONBOARD_HOME:+VAR="$ONBOARD_HOME"} would word-split on it.
   # IRRLICHT_HOME is only added when ONBOARD_HOME is non-empty.
+  # grant-all: the consent-first permission gate (#570) would otherwise
+  # leave a fresh recording daemon monitoring nothing until a wizard is
+  # answered — fixtures must never hang on consent.
   DAEMON_ENV=(IRRLICHT_RECORDINGS_DIR="$STAGING/recordings"
-              IRRLICHT_BIND_ADDR="$ONBOARD_BIND")
+              IRRLICHT_BIND_ADDR="$ONBOARD_BIND"
+              IRRLICHT_PERMISSION_MODE=grant-all)
   [[ -n "$ONBOARD_HOME" ]] && DAEMON_ENV+=(IRRLICHT_HOME="$ONBOARD_HOME")
   env "${DAEMON_ENV[@]}" "$DAEMON" --record >"$DAEMON_LOG" 2>&1 &
   DAEMON_PID=$!


### PR DESCRIPTION
Closes #570.

## What

Every read and modification irrlicht performs on the user's system is now a declared per-agent **permission** (`pending` / `granted` / `denied`), and the daemon exercises **nothing** until the user grants it — no hook install, no statusline wrap, no transcript tailing, no DB polling, no Gas Town state reads. A consent wizard appears on **both the macOS app and the web dashboard** when an agent is detected; the daemon arbitrates (**first answer wins**, the other surface dismisses live); revoke **actively undoes** (uninstalls hooks, stops watchers, monitoring goes dark).

## How

**Daemon (single source of truth)**
- `core/domain/permission`: `State`/`Kind`/`Set` — an absent key reads as `pending`, which is also the upgrade path (a permission added by a later daemon re-prompts just that item)
- Adapters declare `Permissions` on `agent.Agent` with `Apply`/`Remove` effect closures: claude-code `transcripts`/`hooks`/`statusline`, codex+pi `transcripts`, aider `history`, opencode `database`, **gastown `state`** (the orchestrator reads `~/gt` and execs `gt`, so it is gated like everyone else — even adapter construction is deferred to grant), and **launcher `env`** ("Terminal focus": the whitelisted env-var capture — TERM_PROGRAM, KITTY_*, TMUX, … — that powers click-to-focus; gated per call, prompted alongside the first detected agent)
- `PermissionService` exercises grants (re-applies installs at boot for upgrades), undoes revokes, persists `permissions.json` under the daemon home, broadcasts a dataless `permissions_updated` push, and runs a detection poller (pgrep / GT_ROOT stat — zero session side-effects) **only while something is pending in ask mode**
- `SessionDetector` + `OrchestratorMonitor` gained `AddWatcher` seams: monitoring starts/stops dynamically at grant/revoke. The detector's startup seed and 5s stale-working refresh honor per-adapter consent for **persisted** sessions too — upgrades pause until answered, and revoke truly stops updates
- `GET /api/v1/permissions`, `POST /api/v1/permissions/answer`; hook/statusline receivers drop payloads (200) while not granted, so pre-upgrade hooks fire harmlessly until the user decides
- `IRRLICHT_PERMISSION_MODE=grant-all` for demo/record/test daemons — strictly **in-memory** (neither `Start` nor `Answer` persists), so a later ask-mode daemon on the same home only sees real answers
- `--uninstall-hooks` also records `hooks=denied` — a restart cannot silently reinstall

**macOS + web wizards**
- Auto wizard locks its agent set at presentation: a mid-decision detection flip (agent exited) or a newly detected agent never disturbs an open wizard — only answers dismiss it. Apply keeps the wizard up until the daemon confirms (a failed POST never silently drops consent)
- Settings → "Review agent permissions…" re-opens everything as live toggles with active undo
- `permissions_updated` is **not** relay-forwarded — consent is host-local

**Migration**: no permissions file ⇒ everything pending ⇒ monitoring paused until answered (no grandfathering).

**Rigs/tooling**: `run-cell.sh` / `run-cell-multi.sh` / `ir:test-mac` (separate mode) export grant-all; `run-cell --attach` refuses an ask-mode daemon with unanswered permissions (it would record an empty fixture); `build-dev.sh` / `linux-parity-check.sh` recipes updated.

## Deliberate product calls

- Pending wizard toggles default **ON** — the explicit Apply click is the consent act (opt-out per item, not opt-in)
- The Settings "running" badge freezes once every permission is answered (the detection poller stops by design — nothing left to prompt for)
- "Decide Later" suppression is per-app-run; the wizard returns next launch while consent stays pending daemon-side

## Testing

- `go test ./core/... -race` ✓ — incl. a rewritten startup smoke test that boots **both** demo and ask modes; the ask boot asserts the consent contract where install effects could actually fire (all pending + `~/.claude/settings.json` never created)
- Unit coverage: domain set semantics, store round-trip/atomic write, service (grant/revoke effects, grant-all in-memory, idempotent re-answer, batch validation, detection probe/stop), detector consent gate, dynamic watcher seams, handler 200/400s, hook/statusline consent drops, relay filter
- Factory tests ✓ · `tools/replay-fixtures.sh` ✓ · `of validate` ✓ · rig `smoke-test.sh` ✓ · web vitest 64/64 ✓ · Swift build + suite (identical to main baseline) ✓
- Live e2e against an isolated daemon: fresh = all pending + no settings.json; grant → hooks/statusline installed; revoke → removed; observe grant/revoke → monitoring started/stopped; restart → grants resume, denies hold; `--uninstall-hooks` → denied + no reinstall on restart; grant-all → all granted, nothing persisted; gastown in the catalog with stat-only detection
- A self-review (9-angle, adversarially verified) was run on the diff; all 15 findings are fixed in this PR

Suggested manual QA before release: open the macOS sheet and web overlay side-by-side and answer on one — the other should dismiss live (logic is unit-tested on both surfaces; the visual race wasn't manually exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
