### PR TITLE
fix(session): BuildAgentGroups no longer mutates its input sessions (#572)

### DIFF
--- a/core/domain/session/grouped.go
+++ b/core/domain/session/grouped.go
@@ -156,8 +156,19 @@ func BuildDashboard(sessions []*SessionState, orch *orchestrator.State) []*Agent
 }
 
 // buildAgent recursively creates an Agent tree from a session and its children.
+//
+// The Agent embeds a shallow COPY of the session, not the caller's pointer:
+// unifySubagents writes Subagents through the embedded SessionState, and the
+// input sessions are routinely shared with concurrent JSON marshals (the
+// daemon's websocket fan-out, the relay hub's push encode) — writing in place
+// is a data race (#572: TSan flagged hub.go's encode racing this write via
+// the relay's /api/v1/sessions handler). The group tree owning its own
+// structs makes BuildAgentGroups non-mutating; nothing reads the input's
+// Subagents afterwards (the detector populates session.Subagents itself
+// before save/broadcast — session_detector_subagent.go).
 func buildAgent(s *SessionState, workerMap map[string]*workerInfo, parentChildren map[string][]*SessionState) *Agent {
-	agent := &Agent{SessionState: s}
+	cp := *s
+	agent := &Agent{SessionState: &cp}
 
 	// Annotate with orchestrator role.
 	if wi, ok := workerMap[s.SessionID]; ok {

--- a/core/domain/session/grouped_test.go
+++ b/core/domain/session/grouped_test.go
@@ -1,8 +1,10 @@
 package session
 
 import (
-	"irrlicht/core/domain/orchestrator"
+	"encoding/json"
 	"testing"
+
+	"irrlicht/core/domain/orchestrator"
 )
 
 func TestBuildDashboard_NoOrchestrator(t *testing.T) {
@@ -286,4 +288,61 @@ func TestBuildDashboard_RecursiveChildren(t *testing.T) {
 	if p.Children[0].SessionID != "child" {
 		t.Error("wrong grandchild")
 	}
+}
+
+// TestBuildDashboard_DoesNotMutateInput is the deterministic half of the
+// #572 regression: BuildAgentGroups used to write the unified Subagents
+// summary through the embedded *SessionState into the CALLER's session —
+// racing every concurrent JSON marshal of those shared pointers (daemon
+// websocket fan-out, relay hub push). The group tree must own copies.
+func TestBuildDashboard_DoesNotMutateInput(t *testing.T) {
+	parent := &SessionState{
+		SessionID: "parent", State: StateWorking, ProjectName: "proj",
+		Metrics: &SessionMetrics{OpenSubagents: 2},
+	}
+	sessions := []*SessionState{
+		parent,
+		{SessionID: "child1", State: StateWorking, ParentSessionID: "parent"},
+	}
+
+	groups := BuildDashboard(sessions, nil)
+
+	if got := groups[0].Agents[0].Subagents; got == nil {
+		t.Fatal("group tree should carry the unified subagents summary")
+	}
+	if parent.Subagents != nil {
+		t.Fatalf("BuildDashboard mutated its input: parent.Subagents = %+v", *parent.Subagents)
+	}
+}
+
+// TestBuildDashboard_ConcurrentWithMarshal is the racing half of the #572
+// regression: build the dashboard while another goroutine JSON-encodes the
+// same shared sessions, exactly like the relay's /api/v1/sessions handler
+// racing the hub's websocket push encode. Run under -race this fails
+// without the copy in buildAgent.
+func TestBuildDashboard_ConcurrentWithMarshal(t *testing.T) {
+	sessions := []*SessionState{
+		{
+			SessionID: "parent", State: StateWorking, ProjectName: "proj",
+			Metrics: &SessionMetrics{OpenSubagents: 2},
+		},
+		{SessionID: "child1", State: StateWorking, ParentSessionID: "parent"},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 200; i++ {
+			for _, s := range sessions {
+				if _, err := json.Marshal(s); err != nil {
+					t.Errorf("marshal: %v", err)
+					return
+				}
+			}
+		}
+	}()
+	for i := 0; i < 200; i++ {
+		BuildDashboard(sessions, nil)
+	}
+	<-done
 }


### PR DESCRIPTION
Closes #572.

## What

`session.Agent` embeds `*SessionState`, and `unifySubagents` wrote the unified `Subagents` summary **through that pointer into the caller's session** — so `BuildAgentGroups`/`BuildDashboard` mutated their input. The relay hands the same `*SessionState` pointers to both its `/api/v1/sessions` handler (which builds groups) and the hub's websocket push encode → data race, surfaced as a flaky `TestRelayRoundTrip` under `-race` on PR #571's CI (which touches neither file). The daemon has the same structural hazard wherever repo-cached pointers meet the websocket fan-out.

## How

`buildAgent` now embeds a **shallow copy** of the session, so the group tree owns its structs and the builders are non-mutating. The in-place write was also unnecessary: the detector populates `session.Subagents` itself before save/broadcast (`session_detector_subagent.go:22`); the dashboard response reads the summary from the group tree.

## Testing

- `TestBuildDashboard_DoesNotMutateInput` — deterministic: fails on the old code (input's `Subagents` was set)
- `TestBuildDashboard_ConcurrentWithMarshal` — reproduces the TSan race; verified it **fails under `-race` without the fix** and passes with it
- `go test ./core/cmd/irrlichtrelay/ -count=20 -race` ✓ (previously flaky)
- Full `go test ./core/... -race` ✓ · `tools/replay-fixtures.sh` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)