### PR TITLE
feat(permissions): notifications opt-in by default + kitty remote-control consent patch

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/kitty_permission.go
+++ b/core/adapters/inbound/agents/processlifecycle/kitty_permission.go
@@ -8,6 +8,7 @@
 package processlifecycle
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,15 @@ import (
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/permission"
 )
+
+// errKittyBlockMalformed guards the hand-edited-file case: a dangling
+// start or end marker means block matching could span user-authored lines
+// and swallow them on the next apply/remove, so both operations refuse
+// instead. The effect error is logged by the permission service; the file
+// is left exactly as found.
+var errKittyBlockMalformed = errors.New(
+	"kitty.conf contains an unbalanced irrlicht marker block — remove or complete the '" +
+		kittyBlockStart + "' / '" + kittyBlockEnd + "' lines by hand")
 
 // KittyName identifies the kitty config-patch pseudo-entry in the
 // permission store and wizard.
@@ -58,10 +68,12 @@ func KittyPermissionDeclaration() agent.Agent {
 				kittyBlockEnd + "\" markers containing `allow_remote_control yes` " +
 				"and `listen_on unix:/tmp/kitty` to ~/.config/kitty/kitty.conf " +
 				"(XDG_CONFIG_HOME honored; file created if missing). kitty picks " +
-				"the change up the next time it starts. Revoking removes exactly " +
-				"that block — lines you wrote yourself are never modified. " +
-				"Without the grant, clicking a kitty session still raises the " +
-				"right kitty instance but stays on its last-focused tab.",
+				"the change up the next time it starts. Note: while enabled, any " +
+				"process running as your user can control kitty through that " +
+				"socket — not just irrlicht. Revoking removes exactly that block " +
+				"— lines you wrote yourself are never modified. Without the " +
+				"grant, clicking a kitty session still raises the right kitty " +
+				"instance but stays on its last-focused tab.",
 			Apply:  func() error { _, err := EnsureKittyConfigPatched(); return err },
 			Remove: func() error { _, err := UninstallKittyConfig(); return err },
 		}},
@@ -74,15 +86,14 @@ func KittyPermissionDeclaration() agent.Agent {
 // permission is pending, so kitty installed (or first launched) later still
 // surfaces the prompt.
 func KittyDetected() bool {
-	if HasLiveProcess(agent.ExactName{Name: "kitty"}) {
-		return true
+	// Config-dir stat first: ~free, and true for virtually every real kitty
+	// user — the pgrep fork only runs for config-less setups.
+	if dir, err := kittyConfigDir(); err == nil {
+		if _, err := os.Stat(dir); err == nil {
+			return true
+		}
 	}
-	dir, err := kittyConfigDir()
-	if err != nil {
-		return false
-	}
-	_, err = os.Stat(dir)
-	return err == nil
+	return HasLiveProcess(agent.ExactName{Name: "kitty"})
 }
 
 // EnsureKittyConfigPatched adds (or refreshes) the irrlicht-managed block in
@@ -98,7 +109,10 @@ func EnsureKittyConfigPatched() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	stripped, _ := removeKittyBlock(content)
+	stripped, _, err := stripKittyBlocks(content)
+	if err != nil {
+		return false, err
+	}
 	updated := appendKittyBlock(stripped)
 	if updated == content {
 		return false, nil
@@ -120,7 +134,10 @@ func UninstallKittyConfig() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	stripped, found := removeKittyBlock(string(data))
+	stripped, found, err := stripKittyBlocks(string(data))
+	if err != nil {
+		return false, err
+	}
 	if !found {
 		return false, nil
 	}
@@ -160,13 +177,37 @@ func readKittyConf(path string) (string, error) {
 }
 
 // appendKittyBlock appends the canonical managed block, separated from any
-// existing content by one blank line.
+// existing content by one blank line. TrimRight collapses extra trailing
+// blank lines of user content on the first apply — a deliberate, harmless
+// normalization so apply→remove round-trips byte-identically afterwards.
 func appendKittyBlock(content string) string {
 	base := strings.TrimRight(content, "\n")
 	if base == "" {
 		return kittyManagedBlock
 	}
 	return base + "\n\n" + kittyManagedBlock
+}
+
+// stripKittyBlocks removes every balanced marker block from content. It
+// errors when a marker survives the strip — a dangling start or end means
+// the block was hand-edited, and matching across it could swallow
+// user-authored lines (the start marker would pair with a later block's
+// end). Callers must not rewrite the file in that state.
+func stripKittyBlocks(content string) (string, bool, error) {
+	stripped := content
+	found := false
+	for {
+		next, ok := removeKittyBlock(stripped)
+		if !ok {
+			break
+		}
+		stripped = next
+		found = true
+	}
+	if strings.Contains(stripped, kittyBlockStart) || strings.Contains(stripped, kittyBlockEnd) {
+		return "", false, errKittyBlockMalformed
+	}
+	return stripped, found, nil
 }
 
 // removeKittyBlock cuts the marker-delimited block (inclusive) plus the

--- a/core/adapters/inbound/agents/processlifecycle/kitty_permission.go
+++ b/core/adapters/inbound/agents/processlifecycle/kitty_permission.go
@@ -1,0 +1,212 @@
+// kitty_permission.go declares the consent surface for irrlicht's kitty
+// remote-control config patch (issue #425). Tab-precise click-to-focus needs
+// kitty started with allow_remote_control + listen_on; instead of pointing
+// the user at docs after the feature silently degrades, the wizard offers a
+// managed, reversible patch. Apply/Remove own a sentinel-delimited block in
+// kitty.conf so grant and revoke round-trip without touching user-authored
+// lines.
+package processlifecycle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+)
+
+// KittyName identifies the kitty config-patch pseudo-entry in the
+// permission store and wizard.
+const KittyName = "kitty"
+
+// PermissionKeyKittyConfig gates the kitty.conf remote-control patch.
+const PermissionKeyKittyConfig = "remote-control"
+
+// Sentinel markers delimiting the irrlicht-managed block in kitty.conf.
+// Used by install (idempotency + stale-content upgrade) and uninstall.
+const (
+	kittyBlockStart = "# >>> irrlicht remote control >>>"
+	kittyBlockEnd   = "# <<< irrlicht remote control <<<"
+)
+
+// kittyManagedBlock is the canonical block the patch maintains. listen_on
+// makes kitty export KITTY_LISTEN_ON to child processes; the macOS
+// activator uses that socket for `kitten @ focus-window`
+// (KittyActivator.swift). kitty options are last-one-wins, so appending at
+// the end of kitty.conf also overrides an earlier conflicting value — which
+// is what an explicit grant asks for.
+const kittyManagedBlock = kittyBlockStart + "\n" +
+	"allow_remote_control yes\n" +
+	"listen_on unix:/tmp/kitty\n" +
+	kittyBlockEnd + "\n"
+
+// KittyPermissionDeclaration returns the consent declaration for the kitty
+// config patch. Like the launcher entry it isn't a coding-agent adapter (no
+// Source/Process axes) — it's a host-integration capability gated through
+// the same wizard.
+func KittyPermissionDeclaration() agent.Agent {
+	return agent.Agent{
+		Identity: agent.Identity{Name: KittyName, DisplayName: "kitty"},
+		Permissions: []agent.Permission{{
+			Key:             PermissionKeyKittyConfig,
+			Kind:            permission.KindModify,
+			Title:           "Enable kitty remote control",
+			FeatureUnlocked: "Tab-precise click-to-focus: clicking a session row raises the exact kitty window and tab that runs it",
+			Touches:         "Adds allow_remote_control + listen_on to ~/.config/kitty/kitty.conf",
+			Detail: "Appends a block between \"" + kittyBlockStart + "\" and \"" +
+				kittyBlockEnd + "\" markers containing `allow_remote_control yes` " +
+				"and `listen_on unix:/tmp/kitty` to ~/.config/kitty/kitty.conf " +
+				"(XDG_CONFIG_HOME honored; file created if missing). kitty picks " +
+				"the change up the next time it starts. Revoking removes exactly " +
+				"that block — lines you wrote yourself are never modified. " +
+				"Without the grant, clicking a kitty session still raises the " +
+				"right kitty instance but stays on its last-focused tab.",
+			Apply:  func() error { _, err := EnsureKittyConfigPatched(); return err },
+			Remove: func() error { _, err := UninstallKittyConfig(); return err },
+		}},
+	}
+}
+
+// KittyDetected reports whether kitty is in use on this machine — a live
+// kitty process or an existing kitty config directory. Drives when the
+// wizard shows the kitty entry; the detection poller re-checks while the
+// permission is pending, so kitty installed (or first launched) later still
+// surfaces the prompt.
+func KittyDetected() bool {
+	if HasLiveProcess(agent.ExactName{Name: "kitty"}) {
+		return true
+	}
+	dir, err := kittyConfigDir()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(dir)
+	return err == nil
+}
+
+// EnsureKittyConfigPatched adds (or refreshes) the irrlicht-managed block in
+// kitty.conf. Creates the file if it doesn't exist; a stale block (markers
+// present but content drifted) is rewritten to the canonical form. Returns
+// true if the file was modified, false if the block was already current.
+func EnsureKittyConfigPatched() (bool, error) {
+	path, err := kittyConfPath()
+	if err != nil {
+		return false, err
+	}
+	content, err := readKittyConf(path)
+	if err != nil {
+		return false, err
+	}
+	stripped, _ := removeKittyBlock(content)
+	updated := appendKittyBlock(stripped)
+	if updated == content {
+		return false, nil
+	}
+	return true, atomicWriteFile(path, []byte(updated))
+}
+
+// UninstallKittyConfig removes the irrlicht-managed block from kitty.conf.
+// Returns true if the file was modified, false if no block was found.
+func UninstallKittyConfig() (bool, error) {
+	path, err := kittyConfPath()
+	if err != nil {
+		return false, err
+	}
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	stripped, found := removeKittyBlock(string(data))
+	if !found {
+		return false, nil
+	}
+	return true, atomicWriteFile(path, []byte(stripped))
+}
+
+// --- helpers ---
+
+func kittyConfigDir() (string, error) {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return filepath.Join(dir, "kitty"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "kitty"), nil
+}
+
+func kittyConfPath() (string, error) {
+	dir, err := kittyConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "kitty.conf"), nil
+}
+
+func readKittyConf(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// appendKittyBlock appends the canonical managed block, separated from any
+// existing content by one blank line.
+func appendKittyBlock(content string) string {
+	base := strings.TrimRight(content, "\n")
+	if base == "" {
+		return kittyManagedBlock
+	}
+	return base + "\n\n" + kittyManagedBlock
+}
+
+// removeKittyBlock cuts the marker-delimited block (inclusive) plus the
+// blank separator line appendKittyBlock added before it. Returns the
+// remaining content and whether a block was found.
+func removeKittyBlock(content string) (string, bool) {
+	startIdx := strings.Index(content, kittyBlockStart)
+	if startIdx == -1 {
+		return content, false
+	}
+	endIdx := strings.Index(content[startIdx:], kittyBlockEnd)
+	if endIdx == -1 {
+		return content, false
+	}
+	endIdx += startIdx + len(kittyBlockEnd)
+	if endIdx < len(content) && content[endIdx] == '\n' {
+		endIdx++
+	}
+	before := content[:startIdx]
+	after := content[endIdx:]
+	// Drop the blank separator line so apply→remove restores the original.
+	if strings.HasSuffix(before, "\n\n") {
+		before = before[:len(before)-1]
+	}
+	merged := before + after
+	if strings.TrimSpace(merged) == "" {
+		merged = ""
+	}
+	return merged, true
+}
+
+// atomicWriteFile writes data to path via a temp file + rename, creating
+// the parent dir. Mirrors the claudecode installer's writer.
+func atomicWriteFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
@@ -1,0 +1,213 @@
+package processlifecycle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withTempKittyConfig points kitty config resolution at a temp dir via
+// XDG_CONFIG_HOME and returns the kitty.conf path inside it.
+func withTempKittyConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return filepath.Join(dir, "kitty", "kitty.conf")
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func TestEnsureKittyConfigPatchedCreatesFile(t *testing.T) {
+	path := withTempKittyConfig(t)
+
+	modified, err := EnsureKittyConfigPatched()
+	if err != nil {
+		t.Fatalf("EnsureKittyConfigPatched: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true on first install")
+	}
+	if got := readFile(t, path); got != kittyManagedBlock {
+		t.Errorf("content = %q, want managed block only", got)
+	}
+}
+
+func TestEnsureKittyConfigPatchedIsIdempotent(t *testing.T) {
+	path := withTempKittyConfig(t)
+
+	if _, err := EnsureKittyConfigPatched(); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	before := readFile(t, path)
+
+	modified, err := EnsureKittyConfigPatched()
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if modified {
+		t.Error("expected modified=false on re-install")
+	}
+	if got := readFile(t, path); got != before {
+		t.Errorf("content changed on re-install: %q -> %q", before, got)
+	}
+}
+
+func TestEnsureKittyConfigPatchedPreservesUserContent(t *testing.T) {
+	path := withTempKittyConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	user := "font_size 12\nallow_remote_control no\n"
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureKittyConfigPatched()
+	if err != nil {
+		t.Fatalf("EnsureKittyConfigPatched: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true")
+	}
+	got := readFile(t, path)
+	want := strings.TrimRight(user, "\n") + "\n\n" + kittyManagedBlock
+	if got != want {
+		t.Errorf("content = %q, want user lines + managed block", got)
+	}
+}
+
+func TestEnsureKittyConfigPatchedUpgradesStaleBlock(t *testing.T) {
+	path := withTempKittyConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := "font_size 12\n\n" + kittyBlockStart + "\n" +
+		"allow_remote_control socket-only\n" +
+		kittyBlockEnd + "\n"
+	if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureKittyConfigPatched()
+	if err != nil {
+		t.Fatalf("EnsureKittyConfigPatched: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true for stale block")
+	}
+	got := readFile(t, path)
+	if want := "font_size 12\n\n" + kittyManagedBlock; got != want {
+		t.Errorf("content = %q, want canonical block after user lines", got)
+	}
+	if strings.Count(got, kittyBlockStart) != 1 {
+		t.Errorf("expected exactly one managed block, got %q", got)
+	}
+}
+
+func TestUninstallKittyConfigRestoresOriginal(t *testing.T) {
+	path := withTempKittyConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	user := "font_size 12\nscrollback_lines 4000\n"
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureKittyConfigPatched(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	modified, err := UninstallKittyConfig()
+	if err != nil {
+		t.Fatalf("UninstallKittyConfig: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true on uninstall")
+	}
+	if got := readFile(t, path); got != user {
+		t.Errorf("content = %q, want original %q", got, user)
+	}
+}
+
+func TestUninstallKittyConfigBlockOnlyFileEmpties(t *testing.T) {
+	path := withTempKittyConfig(t)
+
+	if _, err := EnsureKittyConfigPatched(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := UninstallKittyConfig(); err != nil {
+		t.Fatalf("UninstallKittyConfig: %v", err)
+	}
+	if got := readFile(t, path); got != "" {
+		t.Errorf("content = %q, want empty file", got)
+	}
+}
+
+func TestUninstallKittyConfigNoBlockIsNoop(t *testing.T) {
+	path := withTempKittyConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	user := "font_size 12\n"
+	if err := os.WriteFile(path, []byte(user), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := UninstallKittyConfig()
+	if err != nil {
+		t.Fatalf("UninstallKittyConfig: %v", err)
+	}
+	if modified {
+		t.Error("expected modified=false without a managed block")
+	}
+	if got := readFile(t, path); got != user {
+		t.Errorf("content = %q, want untouched %q", got, user)
+	}
+}
+
+func TestUninstallKittyConfigMissingFileIsNoop(t *testing.T) {
+	withTempKittyConfig(t)
+
+	modified, err := UninstallKittyConfig()
+	if err != nil {
+		t.Fatalf("UninstallKittyConfig: %v", err)
+	}
+	if modified {
+		t.Error("expected modified=false for missing file")
+	}
+}
+
+func TestKittyDetectedByConfigDir(t *testing.T) {
+	path := withTempKittyConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !KittyDetected() {
+		t.Error("expected KittyDetected=true with existing config dir")
+	}
+}
+
+func TestKittyPermissionDeclarationShape(t *testing.T) {
+	decl := KittyPermissionDeclaration()
+	if decl.Identity.Name != KittyName {
+		t.Errorf("Name = %q, want %q", decl.Identity.Name, KittyName)
+	}
+	if len(decl.Permissions) != 1 {
+		t.Fatalf("expected 1 permission, got %d", len(decl.Permissions))
+	}
+	p := decl.Permissions[0]
+	if p.Key != PermissionKeyKittyConfig {
+		t.Errorf("Key = %q, want %q", p.Key, PermissionKeyKittyConfig)
+	}
+	if p.Apply == nil || p.Remove == nil {
+		t.Error("modify-kind permission must carry Apply and Remove closures")
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
@@ -173,6 +173,76 @@ func TestUninstallKittyConfigNoBlockIsNoop(t *testing.T) {
 	}
 }
 
+func TestEnsureKittyConfigPatchedDanglingStartErrors(t *testing.T) {
+	path := withTempKittyConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// User hand-deleted the bottom half of the block: appending a fresh
+	// block here would make the dangling start pair with the new block's
+	// end on the next strip, swallowing user lines in between.
+	mangled := "font_size 12\n" + kittyBlockStart + "\nuser_line yes\n"
+	if err := os.WriteFile(path, []byte(mangled), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureKittyConfigPatched()
+	if err == nil {
+		t.Fatal("expected error for dangling start marker")
+	}
+	if modified {
+		t.Error("expected modified=false on malformed block")
+	}
+	if got := readFile(t, path); got != mangled {
+		t.Errorf("file rewritten despite malformed block: %q", got)
+	}
+}
+
+func TestUninstallKittyConfigDanglingEndErrors(t *testing.T) {
+	path := withTempKittyConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mangled := kittyBlockEnd + "\nfont_size 12\n"
+	if err := os.WriteFile(path, []byte(mangled), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := UninstallKittyConfig()
+	if err == nil {
+		t.Fatal("expected error for dangling end marker")
+	}
+	if modified {
+		t.Error("expected modified=false on malformed block")
+	}
+	if got := readFile(t, path); got != mangled {
+		t.Errorf("file rewritten despite malformed block: %q", got)
+	}
+}
+
+func TestEnsureKittyConfigPatchedCollapsesDuplicateBlocks(t *testing.T) {
+	path := withTempKittyConfig(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	double := "font_size 12\n\n" + kittyManagedBlock + "\n" + kittyManagedBlock
+	if err := os.WriteFile(path, []byte(double), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureKittyConfigPatched()
+	if err != nil {
+		t.Fatalf("EnsureKittyConfigPatched: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true for duplicate blocks")
+	}
+	got := readFile(t, path)
+	if want := "font_size 12\n\n" + kittyManagedBlock; got != want {
+		t.Errorf("content = %q, want single canonical block", got)
+	}
+}
+
 func TestUninstallKittyConfigMissingFileIsNoop(t *testing.T) {
 	withTempKittyConfig(t)
 

--- a/core/cmd/irrlichd/daemon_smoke_test.go
+++ b/core/cmd/irrlichd/daemon_smoke_test.go
@@ -242,10 +242,10 @@ func assertPermissionsAllPending(t *testing.T, client *http.Client, url string) 
 	if snap.Mode != "ask" {
 		t.Fatalf("permission mode = %q, want ask", snap.Mode)
 	}
-	// Every agent adapter with declared permissions, plus the two daemon-
+	// Every agent adapter with declared permissions, plus the three daemon-
 	// wide entries wired in main.go outside agents.All(): the Gas Town
-	// orchestrator and launcher-identity capture.
-	declared := 2
+	// orchestrator, launcher-identity capture, and the kitty config patch.
+	declared := 3
 	for _, a := range agents.All() {
 		if len(a.Permissions) > 0 {
 			declared++

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -498,13 +498,16 @@ func main() {
 	if !demoMode {
 		hasLive = processlifecycle.HasLiveProcess
 	}
-	// The consent catalog is the agent adapters plus two daemon-wide
+	// The consent catalog is the agent adapters plus three daemon-wide
 	// entries with no Source/Process axes: the Gas Town orchestrator
-	// (reads ~/gt) and launcher-identity capture (reads whitelisted env
-	// vars from agent processes for click-to-focus).
+	// (reads ~/gt), launcher-identity capture (reads whitelisted env
+	// vars from agent processes for click-to-focus), and the kitty
+	// remote-control config patch (writes kitty.conf for tab-precise
+	// click-to-focus, #425).
 	permissionAgents := append(append([]agent.Agent{}, allAgents...),
 		gastownadapter.PermissionDeclaration(startGastown, stopGastown),
-		processlifecycle.LauncherPermissionDeclaration())
+		processlifecycle.LauncherPermissionDeclaration(),
+		processlifecycle.KittyPermissionDeclaration())
 	permService := services.NewPermissionService(
 		permissionAgents, permStore, push, logger,
 		cfg.PermissionMode, detector, watcherFactories, hasLive,
@@ -524,6 +527,9 @@ func main() {
 		}
 		return false
 	})
+	// kitty is a host integration, not an agent: detected by a live kitty
+	// process or an existing kitty config directory.
+	permService.SetDetectionProbe(processlifecycle.KittyName, processlifecycle.KittyDetected)
 
 	// Capture terminal/IDE identity at first PID assignment so the menu-bar
 	// app can jump back to the launching terminal on row/notification click.

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -189,10 +189,12 @@ class SessionManager: ObservableObject {
         self.instancesPath = supportPath.appendingPathComponent("instances")
         self.orderFilePath = supportPath.appendingPathComponent("session-order.json")
 
-        // Out-of-the-box defaults. Notifications: all three events enabled,
-        // each with a distinguishable sound (Ready=Funk, Waiting=Ping,
-        // Context=Sosumi). Login item: opt the user in on first launch, with
-        // the gate flag tracking that we've applied the default once.
+        // Out-of-the-box defaults. Notifications: all three events disabled —
+        // the macOS permission prompt only appears when the user first switches
+        // one on in Settings (#425). Sounds stay pre-picked so enabling an
+        // event is one click (Ready=Funk, Waiting=Ping, Context=Sosumi).
+        // Login item: opt the user in on first launch, with the gate flag
+        // tracking that we've applied the default once.
         // register(defaults:) only seeds unset keys, so it never overrides a
         // user who has explicitly picked something else.
         var defaultsSeed: [String: Any] = [
@@ -205,7 +207,7 @@ class SessionManager: ObservableObject {
             "relayServerURL": "",
         ]
         for event in NotificationEvent.allCases {
-            defaultsSeed[event.enabledKey] = true
+            defaultsSeed[event.enabledKey] = false
             defaultsSeed[event.soundKey] = event.defaultSound.rawValue
         }
         UserDefaults.standard.register(defaults: defaultsSeed)
@@ -222,7 +224,7 @@ class SessionManager: ObservableObject {
         Task {
             loadSessionOrder()
             loadProjectGroupOrder()
-            requestNotificationPermission()
+            setupNotificationDelegate()
             self.sourcesSettingsChanged()
             self.startProjectCostsPolling()
         }
@@ -1277,12 +1279,15 @@ class SessionManager: ObservableObject {
         return Bundle.main.bundleURL.pathExtension == "app"
     }
 
-    private func requestNotificationPermission() {
+    /// Registers the notification click-forwarder delegate. Does NOT request
+    /// macOS notification authorization — events default to off, and the
+    /// permission prompt fires from Settings when the user first switches a
+    /// notification on (#425, `SettingsView.checkNotificationAuth`).
+    private func setupNotificationDelegate() {
         guard canUseUserNotifications else {
             print("⚠️ Skipping notification setup outside app bundle")
             return
         }
-        let center = UNUserNotificationCenter.current()
 
         // Register the click-forwarder delegate before the first notification
         // is scheduled, otherwise macOS drops notification taps silently.
@@ -1294,62 +1299,7 @@ class SessionManager: ObservableObject {
                 focusMonitor: focusMonitor
             )
             notificationForwarder = forwarder
-            center.delegate = forwarder
-        }
-        center.getNotificationSettings { settings in
-            switch settings.authorizationStatus {
-            case .notDetermined:
-                // LSUIElement apps can't show the permission prompt — temporarily
-                // become a regular app with a visible window so macOS presents the dialog.
-                DispatchQueue.main.async {
-                    Self.requestWithTemporaryWindow(center: center)
-                }
-            case .authorized, .provisional, .ephemeral:
-                print("✅ Notification permission already granted")
-            case .denied:
-                print("⚠️ Notification permission denied — user can re-enable in System Settings")
-            @unknown default:
-                break
-            }
-        }
-    }
-
-    /// Temporarily becomes a regular app with a visible window so macOS will present
-    /// the notification permission dialog. Restores LSUIElement behavior afterwards.
-    /// Note: ad-hoc signed dev builds won't get the prompt — macOS silently denies them.
-    /// The dialog works correctly with Developer ID / notarized builds (release flow).
-    private static func requestWithTemporaryWindow(center: UNUserNotificationCenter) {
-        NSApp.setActivationPolicy(.regular)
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 340, height: 80),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
-        )
-        window.title = "Irrlicht — Notification Setup"
-        window.center()
-        window.isReleasedWhenClosed = false
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
-
-        // Give LaunchServices time to register the policy change and window
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            center.requestAuthorization(options: [.alert, .sound]) { granted, error in
-                DispatchQueue.main.async {
-                    window.close()
-                    NSApp.setActivationPolicy(.accessory)
-                }
-                if granted {
-                    print("✅ Notification permission granted")
-                } else if let error = error {
-                    print("⚠️ Notification permission denied: \(error.localizedDescription)")
-                    print("ℹ️ Enable notifications in System Settings → Notifications → Irrlicht")
-                } else {
-                    print("⚠️ Notification permission denied")
-                    print("ℹ️ Enable notifications in System Settings → Notifications → Irrlicht")
-                }
-            }
+            UNUserNotificationCenter.current().delegate = forwarder
         }
     }
 

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -17,9 +17,9 @@ struct SettingsView: View {
     @AppStorage("taskEtaActivation") private var taskEtaActivation: Bool = false
     @AppStorage("providerMode_anthropic") private var providerModeAnthropic: String = ProviderModePreference.auto.rawValue
     @AppStorage("providerMode_openai") private var providerModeOpenAI: String = ProviderModePreference.auto.rawValue
-    @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = true
-    @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = true
-    @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = true
+    @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = false
+    @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = false
+    @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = false
     // Sources (multi-source): mirror the web dashboard's keys.
     @AppStorage("useLocalDaemon") private var useLocalDaemon: Bool = true
     @AppStorage("useRelayServer") private var useRelayServer: Bool = false


### PR DESCRIPTION
Closes #425.

## What

Finishes the open half of #425 — the agent-config consent half already shipped via the permission wizard (#570/#571). Scope settled with the maintainer:

### Notifications: opt-in, prompt on first enable
- All three notification events (`ready`/`waiting`/`contextPressure`) now **default to off**.
- The macOS authorization prompt fires **only when the user first switches an event on** in Settings (`SettingsView.checkNotificationAuth` — the JIT path already existed).
- The startup prompt and its temporary-window/activation-policy dance are removed; startup now only registers the notification click-forwarder delegate.
- Note: `register(defaults:)` covers unset keys only, so existing users who never touched the toggles flip to off too (accepted — no migration marker).

### kitty remote control as a wizard permission
- New `kitty` pseudo-entry in the consent catalog (`KindModify`), alongside the Gas Town and launcher entries.
- **Apply** maintains a sentinel-delimited block in `~/.config/kitty/kitty.conf` (`allow_remote_control yes` + `listen_on unix:/tmp/kitty`, XDG honored, file created if missing) — idempotent, stale-block upgrading. **Remove** strips exactly that block; user-authored lines are never touched.
- Unlocks tab-precise click-to-focus (`kitten @ focus-window` via `KITTY_LISTEN_ON` in `KittyActivator.swift`); without it, clicking still raises the right kitty instance but stays on the last-focused tab.
- Detected via live kitty process or existing kitty config dir; both wizards (macOS + web) are data-driven, so **zero UI changes**.

### Explicitly dropped from #425
- **Per-target Automation rows** — macOS already prompts JIT per controlled app on first click-to-focus; accepted that a one-time denial requires System Settings.
- **Accessibility row** — already JIT on first use.
- **FDA / Focus auto-sync + `NSFocusStatusUsageDescription` cleanup** — stale issue items: Focus auto-silencing already works without FDA via `FocusMonitor`'s dynamic `INFocusStatusCenter` resolution (#339/#358/#406), and that path needs the plist key, so it stays.
- **`irrlicht doctor` CLI** — was already noted as optional in the issue.

## Testing

- `go test ./core/... -race -count=1` ✅ (smoke test updated: consent catalog is now 3 daemon-wide entries)
- New `kitty_permission_test.go`: create/append/idempotency/stale-upgrade/uninstall-restore/no-op paths
- Factory tests, `tools/replay-fixtures.sh`, `of validate` ✅
- `swift build` ✅; `swift test`: SessionRowSnapshot failures + SettingsViewTests crash **pre-exist on main** (verified on a clean tree, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)