### PR TITLE
feat(cli): irrlicht-ls dashboard parity — hierarchy, cost/context/adapter columns, filters, JSON (#554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ beyond), see the [Roadmap](https://irrlicht.io/docs/roadmap.html).
 
 ## [Unreleased]
 
+### Added — CLI
+- `irrlicht-ls` dashboard parity (#554): hierarchical subagent display with
+  indented children and `[N agents: Ww/Rr]` badges, project group headers,
+  context-utilization percent color-coded by pressure level, cost and adapter
+  columns, waiting-question and `N/M completed` task-progress detail lines,
+  `--format json` (grouped `/api/v1/sessions` shape), and `--id`/`--state`/
+  `--project`/`--adapter` filters. Still file-only — no daemon required.
+
 ## [0.4.8] — 2026-05-30
 
 ### Watch your agents from any machine — the `irrlichtrelay` ships, alongside a Linux daemon and per-provider quota tracking.

--- a/core/cmd/irrlicht-ls/main.go
+++ b/core/cmd/irrlicht-ls/main.go
@@ -61,13 +61,13 @@ func main() {
 		}
 
 		sessions = filterSessions(sessions, f)
-		sort.Slice(sessions, func(i, j int) bool {
+		sort.SliceStable(sessions, func(i, j int) bool {
 			return sessions[i].UpdatedAt > sessions[j].UpdatedAt
 		})
 		groups := session.BuildDashboard(sessions, nil)
 
-		if watch {
-			fmt.Print("\033[H\033[2J") // clear screen
+		if watch && format != "json" {
+			fmt.Print("\033[H\033[2J") // clear screen — never into a JSON stream
 		}
 
 		if format == "json" {

--- a/core/cmd/irrlicht-ls/main.go
+++ b/core/cmd/irrlicht-ls/main.go
@@ -1,24 +1,57 @@
 package main
 
 import (
+	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"irrlicht/core/adapters/outbound/filesystem"
 	"irrlicht/core/domain/session"
 )
 
+// filterSpec holds the per-session filter flags.
+type filterSpec struct {
+	idPrefix string
+	state    string
+	project  string
+	adapter  string
+}
+
 func main() {
-	watch := len(os.Args) > 1 && (os.Args[1] == "-w" || os.Args[1] == "--watch")
+	var (
+		watch  bool
+		format string
+		f      filterSpec
+	)
+	flag.BoolVar(&watch, "w", false, "watch mode — refresh every second")
+	flag.BoolVar(&watch, "watch", false, "watch mode — refresh every second")
+	flag.StringVar(&format, "format", "text", `output format: "text" or "json"`)
+	flag.StringVar(&f.idPrefix, "id", "", "filter: session ID prefix")
+	flag.StringVar(&f.state, "state", "", "filter: session state (working|waiting|ready)")
+	flag.StringVar(&f.project, "project", "", "filter: project name substring")
+	flag.StringVar(&f.adapter, "adapter", "", "filter: agent adapter (e.g. claude-code, codex)")
+	flag.Parse()
+
+	if format != "text" && format != "json" {
+		fmt.Fprintf(os.Stderr, "error: unknown format %q (want text or json)\n", format)
+		os.Exit(1)
+	}
+	if f.state != "" && f.state != session.StateWorking && f.state != session.StateWaiting && f.state != session.StateReady {
+		fmt.Fprintf(os.Stderr, "error: unknown state %q (want working, waiting or ready)\n", f.state)
+		os.Exit(1)
+	}
 
 	repo, err := filesystem.New()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
+
+	useColor := format == "text" && stdoutIsTTY() && os.Getenv("NO_COLOR") == ""
 
 	for {
 		sessions, err := repo.ListAll()
@@ -27,14 +60,30 @@ func main() {
 			os.Exit(1)
 		}
 
+		sessions = filterSessions(sessions, f)
+		sort.Slice(sessions, func(i, j int) bool {
+			return sessions[i].UpdatedAt > sessions[j].UpdatedAt
+		})
+		groups := session.BuildDashboard(sessions, nil)
+
 		if watch {
 			fmt.Print("\033[H\033[2J") // clear screen
 		}
 
-		if len(sessions) == 0 {
+		if format == "json" {
+			if groups == nil {
+				groups = []*session.AgentGroup{}
+			}
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(map[string]any{"groups": groups}); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				os.Exit(1)
+			}
+		} else if len(groups) == 0 {
 			fmt.Println("no sessions")
 		} else {
-			printSessions(sessions)
+			renderGroups(os.Stdout, groups, useColor)
 		}
 
 		if !watch {
@@ -44,28 +93,34 @@ func main() {
 	}
 }
 
-func printSessions(sessions []*session.SessionState) {
-	sort.Slice(sessions, func(i, j int) bool {
-		return sessions[i].UpdatedAt > sessions[j].UpdatedAt
-	})
-
-	for _, s := range sessions {
-		age := time.Since(time.Unix(s.UpdatedAt, 0)).Truncate(time.Second)
-		project := s.ProjectName
-		if project == "" {
-			project = filepath.Base(s.CWD)
-		}
-
-		model := ""
-		ctx := ""
-		if s.Metrics != nil && s.Metrics.ModelName != "" {
-			model = " " + s.Metrics.ModelName
-			if s.Metrics.ContextWindow > 0 {
-				ctx = fmt.Sprintf(" %dk", s.Metrics.ContextWindow/1000)
-			}
-		}
-
-		fmt.Printf("%-8s %-20s %s%s%s  (%s ago)\n",
-			s.State, project, s.SessionID[:8], model, ctx, age)
+// filterSessions returns the sessions matching every set filter. A child
+// whose parent is filtered out is promoted to a top-level row by
+// BuildDashboard (it only nests children whose parent is in the input set).
+func filterSessions(sessions []*session.SessionState, f filterSpec) []*session.SessionState {
+	if f.idPrefix == "" && f.state == "" && f.project == "" && f.adapter == "" {
+		return sessions
 	}
+	out := make([]*session.SessionState, 0, len(sessions))
+	for _, s := range sessions {
+		if f.idPrefix != "" && !strings.HasPrefix(strings.ToLower(s.SessionID), strings.ToLower(f.idPrefix)) {
+			continue
+		}
+		if f.state != "" && s.State != f.state {
+			continue
+		}
+		if f.project != "" && !strings.Contains(strings.ToLower(projectName(s)), strings.ToLower(f.project)) {
+			continue
+		}
+		if f.adapter != "" && adapterName(s) != f.adapter {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// stdoutIsTTY reports whether stdout is a terminal (vs a pipe or file).
+func stdoutIsTTY() bool {
+	fi, err := os.Stdout.Stat()
+	return err == nil && fi.Mode()&os.ModeCharDevice != 0
 }

--- a/core/cmd/irrlicht-ls/main_test.go
+++ b/core/cmd/irrlicht-ls/main_test.go
@@ -54,6 +54,38 @@ func TestGoRunFromRepoRoot(t *testing.T) {
 			t.Fatalf("output %q does not contain %q", got, want)
 		}
 	}
+
+	// --format json emits the grouped tree.
+	cmd = exec.Command("go", "run", "./core/cmd/irrlicht-ls", "--format", "json")
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"HOME="+homeDir,
+		"GOCACHE="+t.TempDir(),
+		"GOPATH="+goPath,
+	)
+	out, err = cmd.Output()
+	if err != nil {
+		t.Fatalf("go run ./core/cmd/irrlicht-ls --format json: %v\n%s", err, out)
+	}
+
+	var payload struct {
+		Groups []struct {
+			Name   string `json:"name"`
+			Agents []struct {
+				SessionID string `json:"session_id"`
+				State     string `json:"state"`
+			} `json:"agents"`
+		} `json:"groups"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		t.Fatalf("unmarshal json output: %v\n%s", err, out)
+	}
+	if len(payload.Groups) != 1 || payload.Groups[0].Name != "fixture-project" {
+		t.Fatalf("json groups = %+v, want one group named fixture-project", payload.Groups)
+	}
+	if len(payload.Groups[0].Agents) != 1 || payload.Groups[0].Agents[0].SessionID != state.SessionID {
+		t.Fatalf("json agents = %+v, want the fixture session", payload.Groups[0].Agents)
+	}
 }
 
 func repoRoot(t *testing.T) string {

--- a/core/cmd/irrlicht-ls/render.go
+++ b/core/cmd/irrlicht-ls/render.go
@@ -67,6 +67,18 @@ func adapterName(s *session.SessionState) string {
 	return s.Adapter
 }
 
+// sanitizeTerminal strips control characters (ANSI/OSC escapes, BEL, …)
+// from transcript-derived text so agent output cannot inject terminal
+// sequences into the user's terminal.
+func sanitizeTerminal(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 func shortID(id string) string {
 	if len(id) > 8 {
 		return id[:8]
@@ -113,7 +125,7 @@ func renderAgent(w io.Writer, a *session.Agent, depth int, useColor bool) {
 
 	detailIndent := indent + "    "
 	if a.State == session.StateWaiting && a.Metrics != nil && a.Metrics.LastAssistantText != "" {
-		text := strings.Join(strings.Fields(a.Metrics.LastAssistantText), " ")
+		text := sanitizeTerminal(strings.Join(strings.Fields(a.Metrics.LastAssistantText), " "))
 		fmt.Fprintf(w, "%s? %s\n", detailIndent, text)
 	}
 	if a.Metrics != nil && len(a.Metrics.Tasks) > 0 {

--- a/core/cmd/irrlicht-ls/render.go
+++ b/core/cmd/irrlicht-ls/render.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+const (
+	ansiReset     = "\033[0m"
+	ansiGreen     = "\033[32m"
+	ansiYellow    = "\033[33m"
+	ansiRed       = "\033[31m"
+	ansiBrightRed = "\033[91m"
+)
+
+// pressureColor maps a context pressure level to an ANSI color, mirroring
+// the web dashboard's pressureColor (platforms/web/irrlicht.js).
+func pressureColor(level string) string {
+	switch level {
+	case "critical":
+		return ansiRed
+	case "warning", "high":
+		return ansiBrightRed
+	case "caution", "medium":
+		return ansiYellow
+	default: // safe, unknown, empty
+		return ansiGreen
+	}
+}
+
+// colorize wraps s in the pressure level's ANSI color when useColor is set.
+func colorize(s, level string, useColor bool) string {
+	if !useColor {
+		return s
+	}
+	return pressureColor(level) + s + ansiReset
+}
+
+// formatCostUSD mirrors the web dashboard's formatCost: "$X.XX", empty for
+// non-positive values.
+func formatCostUSD(usd float64) string {
+	if usd <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("$%.2f", usd)
+}
+
+// projectName returns the display project, falling back to the CWD basename.
+func projectName(s *session.SessionState) string {
+	if s.ProjectName != "" {
+		return s.ProjectName
+	}
+	return filepath.Base(s.CWD)
+}
+
+// adapterName returns the session's adapter, mapping the legacy empty value
+// to "claude-code".
+func adapterName(s *session.SessionState) string {
+	if s.Adapter == "" {
+		return "claude-code"
+	}
+	return s.Adapter
+}
+
+func shortID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
+}
+
+// renderGroups renders the dashboard group tree. Group headers are shown
+// only when there is more than one group (web parity).
+func renderGroups(w io.Writer, groups []*session.AgentGroup, useColor bool) {
+	showHeaders := len(groups) > 1
+	for i, g := range groups {
+		if showHeaders {
+			if i > 0 {
+				fmt.Fprintln(w)
+			}
+			n := countAgents(g.Agents)
+			noun := "sessions"
+			if n == 1 {
+				noun = "session"
+			}
+			fmt.Fprintf(w, "%s (%d %s)\n", g.Name, n, noun)
+		}
+		for _, a := range g.Agents {
+			renderAgent(w, a, 0, useColor)
+		}
+	}
+}
+
+// countAgents counts agents including nested children.
+func countAgents(agents []*session.Agent) int {
+	n := 0
+	for _, a := range agents {
+		n += 1 + countAgents(a.Children)
+	}
+	return n
+}
+
+// renderAgent renders one session row, its detail lines (waiting question,
+// task progress), then its children indented one level deeper.
+func renderAgent(w io.Writer, a *session.Agent, depth int, useColor bool) {
+	indent := strings.Repeat("  ", depth)
+	fmt.Fprintf(w, "%s%s\n", indent, formatRow(a, useColor))
+
+	detailIndent := indent + "    "
+	if a.State == session.StateWaiting && a.Metrics != nil && a.Metrics.LastAssistantText != "" {
+		text := strings.Join(strings.Fields(a.Metrics.LastAssistantText), " ")
+		fmt.Fprintf(w, "%s? %s\n", detailIndent, text)
+	}
+	if a.Metrics != nil && len(a.Metrics.Tasks) > 0 {
+		done := 0
+		for _, t := range a.Metrics.Tasks {
+			if t.Status == "completed" {
+				done++
+			}
+		}
+		fmt.Fprintf(w, "%s%d/%d completed\n", detailIndent, done, len(a.Metrics.Tasks))
+	}
+
+	for _, c := range a.Children {
+		renderAgent(w, c, depth+1, useColor)
+	}
+}
+
+// formatRow renders a single session line:
+// state project id model ctx% Nk $cost adapter [N agents: Ww/Rr] (age ago)
+func formatRow(a *session.Agent, useColor bool) string {
+	s := a.SessionState
+	age := time.Since(time.Unix(s.UpdatedAt, 0)).Truncate(time.Second)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%-8s %-20s %s", s.State, projectName(s), shortID(s.SessionID))
+
+	if m := s.Metrics; m != nil {
+		if m.ModelName != "" {
+			sb.WriteString(" " + m.ModelName)
+		}
+		if m.ContextWindow > 0 {
+			pct := colorize(fmt.Sprintf("%.0f%%", m.ContextUtilization), m.PressureLevel, useColor)
+			fmt.Fprintf(&sb, " %s %dk", pct, m.ContextWindow/1000)
+		}
+		if cost := formatCostUSD(m.EstimatedCostUSD); cost != "" {
+			sb.WriteString(" " + cost)
+		}
+	}
+
+	sb.WriteString(" " + adapterName(s))
+
+	if sub := s.Subagents; sub != nil && sub.Total > 0 {
+		noun := "agents"
+		if sub.Total == 1 {
+			noun = "agent"
+		}
+		fmt.Fprintf(&sb, " [%d %s: %dw/%dr]", sub.Total, noun, sub.Working, sub.Ready)
+	}
+
+	fmt.Fprintf(&sb, "  (%s ago)", age)
+	return sb.String()
+}

--- a/core/cmd/irrlicht-ls/render_test.go
+++ b/core/cmd/irrlicht-ls/render_test.go
@@ -183,6 +183,23 @@ func TestRenderGroupsWaitingQuestion(t *testing.T) {
 	}
 }
 
+// Transcript-derived text must not smuggle terminal escapes into the output.
+func TestWaitingQuestionStripsControlChars(t *testing.T) {
+	s := fixture("wait-12345678", session.StateWaiting, "proj")
+	s.Metrics = &session.SessionMetrics{
+		LastAssistantText: "evil \x1b]52;c;cGF5bG9hZA==\x07 title \x1b[31mred?",
+	}
+
+	out := render(t, []*session.SessionState{s}, false)
+
+	if strings.ContainsAny(out, "\x1b\x07") {
+		t.Errorf("output contains control characters:\n%q", out)
+	}
+	if !strings.Contains(out, "? evil ]52;c;cGF5bG9hZA== title [31mred?") {
+		t.Errorf("sanitized question text mangled beyond control-char removal:\n%s", out)
+	}
+}
+
 func TestRenderGroupsTaskProgress(t *testing.T) {
 	s := fixture("task-12345678", session.StateWorking, "proj")
 	s.Metrics = &session.SessionMetrics{Tasks: []session.Task{

--- a/core/cmd/irrlicht-ls/render_test.go
+++ b/core/cmd/irrlicht-ls/render_test.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+func fixture(id, state, project string) *session.SessionState {
+	return &session.SessionState{
+		SessionID:   id,
+		State:       state,
+		ProjectName: project,
+		UpdatedAt:   time.Now().Unix(),
+	}
+}
+
+func render(t *testing.T, sessions []*session.SessionState, useColor bool) string {
+	t.Helper()
+	var sb strings.Builder
+	renderGroups(&sb, session.BuildDashboard(sessions, nil), useColor)
+	return sb.String()
+}
+
+func TestPressureColor(t *testing.T) {
+	cases := map[string]string{
+		"critical": ansiRed,
+		"warning":  ansiBrightRed,
+		"high":     ansiBrightRed,
+		"caution":  ansiYellow,
+		"medium":   ansiYellow,
+		"safe":     ansiGreen,
+		"unknown":  ansiGreen,
+		"":         ansiGreen,
+	}
+	for level, want := range cases {
+		if got := pressureColor(level); got != want {
+			t.Errorf("pressureColor(%q) = %q, want %q", level, got, want)
+		}
+	}
+}
+
+func TestColorizeDisabled(t *testing.T) {
+	if got := colorize("42%", "critical", false); got != "42%" {
+		t.Errorf("colorize with useColor=false = %q, want plain string", got)
+	}
+}
+
+func TestFormatCostUSD(t *testing.T) {
+	cases := []struct {
+		usd  float64
+		want string
+	}{
+		{0, ""},
+		{-1, ""},
+		{1.5, "$1.50"},
+		{0.004, "$0.00"},
+		{12.345, "$12.35"},
+	}
+	for _, c := range cases {
+		if got := formatCostUSD(c.usd); got != c.want {
+			t.Errorf("formatCostUSD(%v) = %q, want %q", c.usd, got, c.want)
+		}
+	}
+}
+
+func TestShortID(t *testing.T) {
+	if got := shortID("ab"); got != "ab" {
+		t.Errorf("shortID short input = %q, want %q", got, "ab")
+	}
+	if got := shortID("0123456789"); got != "01234567" {
+		t.Errorf("shortID long input = %q, want %q", got, "01234567")
+	}
+}
+
+func TestFormatRowNilMetrics(t *testing.T) {
+	a := &session.Agent{SessionState: fixture("abcd1234-rest", session.StateReady, "proj")}
+	row := formatRow(a, false)
+	for _, want := range []string{"ready", "proj", "abcd1234", "claude-code", "ago"} {
+		if !strings.Contains(row, want) {
+			t.Errorf("row %q does not contain %q", row, want)
+		}
+	}
+	for _, banned := range []string{"$", "%"} {
+		if strings.Contains(row, banned) {
+			t.Errorf("row %q unexpectedly contains %q", row, banned)
+		}
+	}
+}
+
+func TestFormatRowFullMetrics(t *testing.T) {
+	s := fixture("abcd1234-rest", session.StateWorking, "proj")
+	s.Adapter = "codex"
+	s.Metrics = &session.SessionMetrics{
+		ModelName:          "gpt-5",
+		ContextWindow:      400000,
+		ContextUtilization: 47.4,
+		PressureLevel:      "caution",
+		EstimatedCostUSD:   3.21,
+	}
+	row := formatRow(&session.Agent{SessionState: s}, true)
+	for _, want := range []string{"gpt-5", ansiYellow + "47%" + ansiReset, "400k", "$3.21", "codex"} {
+		if !strings.Contains(row, want) {
+			t.Errorf("row %q does not contain %q", row, want)
+		}
+	}
+
+	plain := formatRow(&session.Agent{SessionState: s}, false)
+	if strings.Contains(plain, "\033[") {
+		t.Errorf("row %q contains ANSI escapes with useColor=false", plain)
+	}
+}
+
+func TestRenderGroupsHierarchy(t *testing.T) {
+	parent := fixture("parent-12345678", session.StateWorking, "proj")
+	childA := fixture("child-a-12345678", session.StateWorking, "proj")
+	childA.ParentSessionID = parent.SessionID
+	childB := fixture("child-b-12345678", session.StateReady, "proj")
+	childB.ParentSessionID = parent.SessionID
+	standalone := fixture("solo-12345678", session.StateReady, "proj")
+
+	out := render(t, []*session.SessionState{parent, childA, childB, standalone}, false)
+
+	// Single group: no header.
+	if strings.Contains(out, "(4 sessions)") {
+		t.Errorf("single group should not render a header:\n%s", out)
+	}
+	// Parent carries the badge.
+	if !strings.Contains(out, "[2 agents: 1w/1r]") {
+		t.Errorf("output missing subagent badge:\n%s", out)
+	}
+	// Children are indented.
+	for _, child := range []string{"child-a-", "child-b-"} {
+		found := false
+		for _, line := range strings.Split(out, "\n") {
+			if strings.Contains(line, child) && strings.HasPrefix(line, "  ") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("child %q not rendered indented:\n%s", child, out)
+		}
+	}
+	// Standalone is not indented.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "solo-123") && strings.HasPrefix(line, " ") {
+			t.Errorf("standalone session unexpectedly indented:\n%s", out)
+		}
+	}
+}
+
+func TestRenderGroupsHeaders(t *testing.T) {
+	parent := fixture("parent-12345678", session.StateWorking, "alpha")
+	child := fixture("child-12345678", session.StateWorking, "alpha")
+	child.ParentSessionID = parent.SessionID
+	other := fixture("other-12345678", session.StateReady, "beta")
+
+	out := render(t, []*session.SessionState{parent, child, other}, false)
+
+	if !strings.Contains(out, "alpha (2 sessions)") {
+		t.Errorf("missing alpha header with child counted:\n%s", out)
+	}
+	if !strings.Contains(out, "beta (1 session)") {
+		t.Errorf("missing singular beta header:\n%s", out)
+	}
+}
+
+func TestRenderGroupsWaitingQuestion(t *testing.T) {
+	waiting := fixture("wait-12345678", session.StateWaiting, "proj")
+	waiting.Metrics = &session.SessionMetrics{LastAssistantText: "Should I delete\nthe legacy migration?"}
+	working := fixture("work-12345678", session.StateWorking, "proj")
+	working.Metrics = &session.SessionMetrics{LastAssistantText: "On it."}
+
+	out := render(t, []*session.SessionState{waiting, working}, false)
+
+	if !strings.Contains(out, "? Should I delete the legacy migration?") {
+		t.Errorf("missing waiting question line (newlines collapsed):\n%s", out)
+	}
+	if strings.Contains(out, "On it.") {
+		t.Errorf("non-waiting session should not render its last text:\n%s", out)
+	}
+}
+
+func TestRenderGroupsTaskProgress(t *testing.T) {
+	s := fixture("task-12345678", session.StateWorking, "proj")
+	s.Metrics = &session.SessionMetrics{Tasks: []session.Task{
+		{ID: "1", Subject: "a", Status: "completed"},
+		{ID: "2", Subject: "b", Status: "in_progress"},
+		{ID: "3", Subject: "c", Status: "pending"},
+	}}
+
+	out := render(t, []*session.SessionState{s}, false)
+	if !strings.Contains(out, "1/3 completed") {
+		t.Errorf("missing task progress line:\n%s", out)
+	}
+}
+
+func TestFilterSessions(t *testing.T) {
+	a := fixture("AAAA1111-x", session.StateWorking, "irrlicht")
+	a.Adapter = "" // legacy claude-code
+	b := fixture("bbbb2222-x", session.StateWaiting, "api-server")
+	b.Adapter = "codex"
+	child := fixture("cccc3333-x", session.StateWorking, "irrlicht")
+	child.ParentSessionID = a.SessionID
+	all := []*session.SessionState{a, b, child}
+
+	cases := []struct {
+		name string
+		f    filterSpec
+		want []string
+	}{
+		{"none", filterSpec{}, []string{"AAAA1111-x", "bbbb2222-x", "cccc3333-x"}},
+		{"id case-insensitive prefix", filterSpec{idPrefix: "aaaa"}, []string{"AAAA1111-x"}},
+		{"state", filterSpec{state: session.StateWaiting}, []string{"bbbb2222-x"}},
+		{"project substring", filterSpec{project: "irr"}, []string{"AAAA1111-x", "cccc3333-x"}},
+		{"adapter exact", filterSpec{adapter: "codex"}, []string{"bbbb2222-x"}},
+		{"adapter claude-code matches empty", filterSpec{adapter: "claude-code"}, []string{"AAAA1111-x", "cccc3333-x"}},
+	}
+	for _, c := range cases {
+		got := filterSessions(all, c.f)
+		var ids []string
+		for _, s := range got {
+			ids = append(ids, s.SessionID)
+		}
+		if strings.Join(ids, ",") != strings.Join(c.want, ",") {
+			t.Errorf("%s: got %v, want %v", c.name, ids, c.want)
+		}
+	}
+}
+
+// A child whose parent is filtered away is promoted to a top-level row.
+func TestFilteredChildPromoted(t *testing.T) {
+	parent := fixture("parent-12345678", session.StateReady, "proj")
+	child := fixture("child-12345678", session.StateWorking, "proj")
+	child.ParentSessionID = parent.SessionID
+
+	filtered := filterSessions([]*session.SessionState{parent, child}, filterSpec{state: session.StateWorking})
+	out := render(t, filtered, false)
+
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "child-12") && strings.HasPrefix(line, " ") {
+			t.Errorf("orphaned child should render at top level:\n%s", out)
+		}
+	}
+	if !strings.Contains(out, "child-12") {
+		t.Errorf("filtered child missing from output:\n%s", out)
+	}
+}

--- a/site/docs/cli-tools.html
+++ b/site/docs/cli-tools.html
@@ -133,19 +133,30 @@
 
       <ul>
         <li><code>-w</code>, <code>--watch</code> &mdash; Watch mode &mdash; updates every second (clears screen between refreshes)</li>
+        <li><code>--format text|json</code> &mdash; Output format; <code>json</code> emits the same grouped tree as <code>GET /api/v1/sessions</code> (minus cost aggregation)</li>
+        <li><code>--id &lt;prefix&gt;</code> &mdash; Filter by session ID prefix (case-insensitive)</li>
+        <li><code>--state working|waiting|ready</code> &mdash; Filter by session state</li>
+        <li><code>--project &lt;substring&gt;</code> &mdash; Filter by project name (case-insensitive substring)</li>
+        <li><code>--adapter &lt;name&gt;</code> &mdash; Filter by agent adapter (e.g. <code>claude-code</code>, <code>codex</code>)</li>
       </ul>
 
       <h3>Output Format</h3>
 
-      <p>Columns: state, project name, session ID (8 chars), model, context window, subagent badge, age. Child sessions are indented below their parent.</p>
+      <p>Columns: state, project name, session ID (8 chars), model, context utilization (percent, color-coded by pressure level on a TTY; set <code>NO_COLOR</code> to disable) with context window, cost (USD), adapter, subagent badge, age. Child sessions are indented below their parent. When sessions span multiple projects, each project gets a header line with its session count. <code>waiting</code> sessions show the assistant's last message beneath the row; sessions with a task list show <code>N/M completed</code>.</p>
 
       <p>Example output:</p>
 
-      <pre><code>working  irrlicht     52d087d1 claude-opus-4-6 1000k [3 agents: 3w/0r]  (2s ago)
-  working  irrlicht     agent-a1 claude-haiku-4-5 200k  (5s ago)
-  working  irrlicht     agent-a4 claude-haiku-4-5 200k  (8s ago)
-  working  irrlicht     agent-ab claude-haiku-4-5 200k  (6s ago)
-ready    api-server   e5f6g7h8 claude-opus-4-6 1000k  (1m ago)</code></pre>
+      <pre><code>irrlicht (5 sessions)
+working  irrlicht     52d087d1 claude-opus-4-6 47% 1000k $3.21 claude-code [3 agents: 3w/0r]  (2s ago)
+  working  irrlicht     agent-a1 claude-haiku-4-5 8% 200k $0.04 claude-code  (5s ago)
+  working  irrlicht     agent-a4 claude-haiku-4-5 6% 200k $0.03 claude-code  (8s ago)
+  working  irrlicht     agent-ab claude-haiku-4-5 5% 200k $0.02 claude-code  (6s ago)
+waiting  irrlicht     99887766 claude-opus-4-6 92% 1000k $7.80 claude-code  (12s ago)
+    ? Should I delete the legacy migration before running the suite?
+    2/5 completed
+
+api-server (1 session)
+ready    api-server   e5f6g7h8 gpt-5 3% 400k codex  (1m ago)</code></pre>
 
       <h3>Data Source</h3>
 


### PR DESCRIPTION
## Summary

Implements the agreed scope of #554 (priorities 1–4 + display extras, **file-only** — no daemon HTTP/WS):

- **Hierarchical display** — reuses `session.BuildDashboard(sessions, nil)`: children indented under parents, `[N agents: Ww/Rr]` badge (docs format), project group headers `project (N sessions)` when sessions span multiple projects (web parity: no header for a single group).
- **New columns** — context utilization % color-coded by pressure level (direct port of the web `pressureColor`: critical→red, warning→bright red, caution→yellow, else green; TTY-gated, `NO_COLOR` honored), cost `$X.XX` (web `formatCost` semantics), adapter (legacy empty → `claude-code`).
- **Detail lines** — `waiting` sessions show the assistant's last message; task lists render `N/M completed`.
- **`--format json`** — emits the grouped `/api/v1/sessions` shape (`{"groups": [...]}`, minus cost aggregation which only the daemon handler attaches).
- **Filters** — `--id` (case-insensitive prefix), `--state` (validated), `--project` (substring), `--adapter` (`claude-code` matches legacy empty). A child whose parent is filtered out is promoted to a top-level row.
- Flag parsing moved to stdlib `flag` (`-w`/`--watch` both kept); fixes a latent `SessionID[:8]` panic on short IDs.

Deferred (need daemon API): relay merge, WS streaming, quota chips, Gas Town view, per-group cost timeframes, sort flags.

## Test plan

- [x] `go test ./core/... -race -count=1` green (one unrelated flake observed once, filed as #578)
- [x] 11 new unit tests: pressure colors, cost formatting, nil-Metrics row, hierarchy + badge, headers, waiting line, task progress, all filters, filtered-child promotion
- [x] e2e `TestGoRunFromRepoRoot` extended with a `--format json` round-trip (nil-Metrics fixture doubles as the degraded-row guard)
- [x] Manual against live instance files: group headers/columns/task lines, every filter, invalid `--state` errors (exit 1), green ANSI under pseudo-TTY, plain when piped, `--format json | jq` parses, `-w` loops and clears

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)