### PR TITLE
fix(test): poll for child ready instead of fixed 50ms sleep (#578)

### DIFF
--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -2335,7 +2335,10 @@ func TestSessionDetector_Activity_SubagentCompletion_TransitionsChildToReady(t *
 		TranscriptPath: parentTranscript,
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	// Poll instead of a fixed sleep: under full-suite -race load the Run
+	// loop can take >50ms to process the event, and cancelling too early
+	// kills the detector before the transition lands (#578).
+	waitForSessionState(repo, childID, session.StateReady, 3*time.Second)
 	cancel()
 	<-done
 

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -39,16 +39,16 @@ func (r *mockRecorder) snapshot() []lifecycle.Event {
 // --- shared mock implementations for tests -----------------------------------
 
 type mockRepo struct {
-	mu     sync.Mutex
-	states map[string]*session.SessionState
-	saved  map[string]string // sessionID → State at last Save; race-free snapshot for polling
-	saves  int
+	mu             sync.Mutex
+	states         map[string]*session.SessionState
+	lastSavedState map[string]string // sessionID → State at last Save; race-free snapshot for polling
+	saves          int
 }
 
 func newMockRepo() *mockRepo {
 	return &mockRepo{
-		states: make(map[string]*session.SessionState),
-		saved:  make(map[string]string),
+		states:         make(map[string]*session.SessionState),
+		lastSavedState: make(map[string]string),
 	}
 }
 
@@ -66,7 +66,7 @@ func (r *mockRepo) Save(s *session.SessionState) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.states[s.SessionID] = s
-	r.saved[s.SessionID] = s.State
+	r.lastSavedState[s.SessionID] = s.State
 	r.saves++
 	return nil
 }
@@ -75,6 +75,7 @@ func (r *mockRepo) Delete(sessionID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.states, sessionID)
+	delete(r.lastSavedState, sessionID)
 	return nil
 }
 
@@ -98,7 +99,7 @@ func waitForSessionState(repo *mockRepo, sessionID, want string, timeout time.Du
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		repo.mu.Lock()
-		got := repo.saved[sessionID]
+		got := repo.lastSavedState[sessionID]
 		repo.mu.Unlock()
 		if got == want {
 			return

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"irrlicht/core/application/services"
 	"irrlicht/core/domain/agent"
@@ -40,11 +41,15 @@ func (r *mockRecorder) snapshot() []lifecycle.Event {
 type mockRepo struct {
 	mu     sync.Mutex
 	states map[string]*session.SessionState
+	saved  map[string]string // sessionID → State at last Save; race-free snapshot for polling
 	saves  int
 }
 
 func newMockRepo() *mockRepo {
-	return &mockRepo{states: make(map[string]*session.SessionState)}
+	return &mockRepo{
+		states: make(map[string]*session.SessionState),
+		saved:  make(map[string]string),
+	}
 }
 
 func (r *mockRepo) Load(sessionID string) (*session.SessionState, error) {
@@ -61,6 +66,7 @@ func (r *mockRepo) Save(s *session.SessionState) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.states[s.SessionID] = s
+	r.saved[s.SessionID] = s.State
 	r.saves++
 	return nil
 }
@@ -80,6 +86,25 @@ func (r *mockRepo) ListAll() ([]*session.SessionState, error) {
 		out = append(out, s)
 	}
 	return out, nil
+}
+
+// waitForSessionState polls the repo's Save snapshot until the session was
+// last saved with state want, or the timeout elapses. Lets tests wait for the
+// detector's Run loop to finish async event processing without a fixed sleep
+// (#578). Polling Load instead would race: the detector mutates session
+// structs in place before calling Save, so the only race-free observation
+// point is the state captured inside Save.
+func waitForSessionState(repo *mockRepo, sessionID, want string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		repo.mu.Lock()
+		got := repo.saved[sessionID]
+		repo.mu.Unlock()
+		if got == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 }
 
 type mockLogger struct {


### PR DESCRIPTION
## Problem

`TestSessionDetector_Activity_SubagentCompletion_TransitionsChildToReady` flaked under full-suite `-race` load (#578): `child state: got "working", want ready`. It passed in isolation.

The test gave the detector's Run loop a fixed 50ms (`time.Sleep`) before `cancel()`. Under parallel package load, the event pipeline (drainWatcher → merged channel → Run select → `processActivity` → `applySubagentCompletions`) can exceed that window — the context was cancelled before the child→ready transition landed.

## Fix (test-only)

- **`testhelpers_test.go`**: add `waitForSessionState` poll helper + a `saved` sessionID→state snapshot map written inside `mockRepo.Save`.
  - Why the snapshot: naive `Load()`-polling introduces a real data race — the detector mutates session structs in place at `session_detector_subagent.go:126` *before* taking the repo mutex in `Save` (confirmed by an actual `-race` hit on the first attempt). The detector's field write happens-before its `Save` call (program order), so the state captured inside `Save` under the mutex is the only race-free observation point.
- **`session_detector_test.go`**: replace the 50ms sleep with `waitForSessionState(repo, childID, session.StateReady, 3*time.Second)`. Happy path stays fast (~ms); under load the test waits instead of failing. Final assertion unchanged.

Sibling tests use the same fixed-sleep pattern (e.g. lines 1766, 1831, 2264) — left untouched per surgical scope; they can adopt the helper if they ever flake.

## Verification

- `go test ./core/application/services/ -race -count=5 -run 'TestSessionDetector_Activity_SubagentCompletion_TransitionsChildToReady'` → pass, race-clean
- `go test ./core/... -race -count=1` → all packages pass

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)