### PR TITLE
fix(session): rescue stale transcripts owned by a live process at backfill (#576)

### DIFF
--- a/core/application/services/helpers.go
+++ b/core/application/services/helpers.go
@@ -37,6 +37,40 @@ func isStaleTranscript(path string) bool {
 	return time.Since(info.ModTime()) > orphanTranscriptAge
 }
 
+// isNewestTranscriptInDir reports whether the transcript at path has the
+// newest mtime among the sibling .jsonl files in its directory. Used as the
+// ghost-guard for the stale-transcript rescue (issue #576): a live agent
+// process corresponds to at most one transcript per project directory — the
+// most recently written one — so older stale siblings must never be rescued.
+// Ties (>=) count as newest so coarse mtime granularity can't exclude the
+// event's own file. Fails open (true) on ReadDir/stat errors — the
+// downstream cwd and process-liveness checks still gate the rescue.
+func isNewestTranscriptInDir(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	mtime := info.ModTime()
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		return true
+	}
+	base := filepath.Base(path)
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == base || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		sibling, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if sibling.ModTime().After(mtime) {
+			return false
+		}
+	}
+	return true
+}
+
 // cwdMissing reports whether cwd refers to a directory that no longer
 // exists. Returns false for empty or relative paths to avoid second-guessing
 // callers when the cwd metadata is incomplete.

--- a/core/application/services/helpers.go
+++ b/core/application/services/helpers.go
@@ -43,8 +43,10 @@ func isStaleTranscript(path string) bool {
 // process corresponds to at most one transcript per project directory — the
 // most recently written one — so older stale siblings must never be rescued.
 // Ties (>=) count as newest so coarse mtime granularity can't exclude the
-// event's own file. Fails open (true) on ReadDir/stat errors — the
-// downstream cwd and process-liveness checks still gate the rescue.
+// event's own file. Fails open (true) on ReadDir or sibling-stat errors —
+// the downstream cwd and process-liveness checks still gate the rescue. A
+// stat failure on path itself returns false (unreachable in practice: the
+// caller only gets here after isStaleTranscript stat'd the same path).
 func isNewestTranscriptInDir(path string) bool {
 	info, err := os.Stat(path)
 	if err != nil {

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -7,6 +7,7 @@ package services
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -273,6 +274,34 @@ func (pm *PIDManager) newLiveLookupCache() func(adapter string) map[string]struc
 		cache[adapter] = live
 		return live
 	}
+}
+
+// HasLiveProcessInCWD reports whether a live process of adapter's binary
+// currently has cwd as its working directory. Used by the stale-transcript
+// rescue (issue #576): when consent is granted after sessions started, the
+// backfill sweep sees idle transcripts whose process is still alive. Returns
+// false when the lookup is unavailable or fails — "unknown" must preserve
+// the orphan-skip behavior, never force a session into existence. The cwd is
+// canonicalized via EvalSymlinks before the membership test because LiveCWDs
+// builds its set from OS-canonical CWDOf paths, while transcript-derived
+// cwds may carry symlink components (macOS /var → /private/var).
+func (pm *PIDManager) HasLiveProcessInCWD(adapter, cwd string) bool {
+	if pm.liveCWDs == nil || cwd == "" {
+		return false
+	}
+	name, ok := pm.processNames[adapter]
+	if !ok || name == "" {
+		return false
+	}
+	live, err := pm.liveCWDs(name)
+	if err != nil || len(live) == 0 {
+		return false
+	}
+	if resolved, err := filepath.EvalSymlinks(cwd); err == nil {
+		cwd = resolved
+	}
+	_, alive := live[cwd]
+	return alive
 }
 
 // isStartupZombie returns true for sessions whose process is provably gone.

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -64,11 +64,18 @@ func (d *SessionDetector) onNewSession(id agent.Identity, ev agent.Event) {
 			return
 		}
 
-		// Skip orphan transcripts left by exited Claude Code processes.
+		// Skip orphan transcripts left by exited Claude Code processes —
+		// unless a live agent process still owns the transcript's cwd
+		// (issue #576: consent granted after sessions started makes
+		// "stale at first sight" the canonical backfill path).
 		if isStaleTranscript(ev.TranscriptPath) {
+			if !d.isLiveStaleSession(id.Name, ev) {
+				d.log.LogInfo("session-detector", ev.SessionID,
+					"skipping orphan transcript")
+				return
+			}
 			d.log.LogInfo("session-detector", ev.SessionID,
-				"skipping orphan transcript")
-			return
+				"stale transcript but live process owns its cwd — creating session")
 		}
 
 		// Skip zombie sessions whose worktree has been deleted from disk.
@@ -176,6 +183,35 @@ func (d *SessionDetector) onNewSession(id agent.Identity, ev agent.Event) {
 		transcriptPath = existing.TranscriptPath
 	}
 	go d.pidMgr.DiscoverPIDWithRetry(ev.SessionID, cwd, transcriptPath, adapter)
+}
+
+// isLiveStaleSession reports whether a stale transcript should still produce
+// a session because a live agent process owns its cwd (issue #576). Checks
+// run cheapest-first:
+//  1. Subagent transcripts are never rescued — they have no process of their
+//     own, and finished subagents are routinely stale.
+//  2. Only the newest .jsonl in its directory qualifies — the watcher's
+//     initial scan emits every transcript younger than MaxSessionAge, and a
+//     single live process can only correspond to the most recent one.
+//  3. The transcript must yield a cwd (from the event for scanner-sourced
+//     sessions, from transcript content for fswatcher events, which carry
+//     no CWD).
+//  4. A live process of this adapter's binary must own that cwd.
+func (d *SessionDetector) isLiveStaleSession(adapter string, ev agent.Event) bool {
+	if deriveParentSessionID(ev.TranscriptPath) != "" {
+		return false
+	}
+	if !isNewestTranscriptInDir(ev.TranscriptPath) {
+		return false
+	}
+	cwd := ev.CWD
+	if cwd == "" {
+		cwd = d.enricher.git.GetCWDFromTranscript(ev.TranscriptPath)
+	}
+	if cwd == "" {
+		return false
+	}
+	return d.pidMgr.HasLiveProcessInCWD(adapter, cwd)
 }
 
 // onActivity debounces transcript activity events per session. The first event

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -69,10 +69,17 @@ func (d *SessionDetector) onNewSession(id agent.Identity, ev agent.Event) {
 		// (issue #576: consent granted after sessions started makes
 		// "stale at first sight" the canonical backfill path).
 		if isStaleTranscript(ev.TranscriptPath) {
-			if !d.isLiveStaleSession(id.Name, ev) {
+			liveCWD, live := d.isLiveStaleSession(id.Name, ev)
+			if !live {
 				d.log.LogInfo("session-detector", ev.SessionID,
 					"skipping orphan transcript")
 				return
+			}
+			// Thread the transcript-derived cwd into the event so
+			// EnrichNewSession doesn't re-read the transcript for it (and
+			// PID discovery gets a usable cwd for its fallback).
+			if ev.CWD == "" {
+				ev.CWD = liveCWD
 			}
 			d.log.LogInfo("session-detector", ev.SessionID,
 				"stale transcript but live process owns its cwd — creating session")
@@ -197,21 +204,24 @@ func (d *SessionDetector) onNewSession(id agent.Identity, ev agent.Event) {
 //     sessions, from transcript content for fswatcher events, which carry
 //     no CWD).
 //  4. A live process of this adapter's binary must own that cwd.
-func (d *SessionDetector) isLiveStaleSession(adapter string, ev agent.Event) bool {
+//
+// The resolved cwd is returned alongside the verdict so the caller can reuse
+// it instead of re-extracting it from the transcript during enrichment.
+func (d *SessionDetector) isLiveStaleSession(adapter string, ev agent.Event) (string, bool) {
 	if deriveParentSessionID(ev.TranscriptPath) != "" {
-		return false
+		return "", false
 	}
 	if !isNewestTranscriptInDir(ev.TranscriptPath) {
-		return false
+		return "", false
 	}
 	cwd := ev.CWD
 	if cwd == "" {
 		cwd = d.enricher.git.GetCWDFromTranscript(ev.TranscriptPath)
 	}
 	if cwd == "" {
-		return false
+		return "", false
 	}
-	return d.pidMgr.HasLiveProcessInCWD(adapter, cwd)
+	return cwd, d.pidMgr.HasLiveProcessInCWD(adapter, cwd)
 }
 
 // onActivity debounces transcript activity events per session. The first event

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -140,6 +140,243 @@ func TestSessionDetector_NewSession_SkipsWhenCWDDeleted(t *testing.T) {
 	}
 }
 
+// --- stale-transcript rescue (issue #576) -------------------------------------
+//
+// When observe consent is granted after agent sessions are already running,
+// the backfill sweep sees transcripts idle beyond orphanTranscriptAge whose
+// process is still alive. These tests cover the rescue path that creates the
+// session anyway when a live process owns the transcript's cwd.
+
+// writeOldTranscript writes a .jsonl transcript whose mtime is age in the past.
+func writeOldTranscript(t *testing.T, path string, age time.Duration) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(`{"type":"user"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-age)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// liveCWDSet returns a LiveCWDsFunc reporting the given cwds as owned by
+// live processes, regardless of binary name.
+func liveCWDSet(cwds ...string) services.LiveCWDsFunc {
+	return func(string) (map[string]struct{}, error) {
+		set := make(map[string]struct{}, len(cwds))
+		for _, c := range cwds {
+			set[c] = struct{}{}
+		}
+		return set, nil
+	}
+}
+
+// claudeProcessNames maps the default test watcher identity to a binary name
+// so HasLiveProcessInCWD's processNames lookup succeeds.
+func claudeProcessNames() map[string]string {
+	return map[string]string{"claude-code": "claude"}
+}
+
+// rescueCWD returns an existing directory in OS-canonical form — LiveCWDs
+// builds its set from symlink-resolved CWDOf paths, so the test set must be
+// keyed the same way (t.TempDir is a symlink on macOS: /var → /private/var).
+func rescueCWD(t *testing.T) string {
+	t.Helper()
+	cwd, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cwd
+}
+
+func TestSessionDetector_NewSession_RescuesStaleTranscriptWithLiveProcess(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	cwd := rescueCWD(t)
+	det := newDetectorWithLiveCWDs(tw, pw, repo, nil, claudeProcessNames(), liveCWDSet(cwd))
+
+	transcriptPath := filepath.Join(t.TempDir(), "idle1.jsonl")
+	writeOldTranscript(t, transcriptPath, 10*time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "idle1",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: transcriptPath,
+		CWD:            cwd,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	state, err := repo.Load("idle1")
+	if err != nil {
+		t.Fatalf("stale transcript with live process should be rescued: %v", err)
+	}
+	if state.State != session.StateReady {
+		t.Errorf("state: got %q, want ready", state.State)
+	}
+}
+
+func TestSessionDetector_NewSession_NoRescueWithoutLiveProcess(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	cwd := rescueCWD(t)
+	det := newDetectorWithLiveCWDs(tw, pw, repo, nil, claudeProcessNames(), liveCWDSet( /* none */ ))
+
+	transcriptPath := filepath.Join(t.TempDir(), "idle2.jsonl")
+	writeOldTranscript(t, transcriptPath, 10*time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "idle2",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: transcriptPath,
+		CWD:            cwd,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if state, _ := repo.Load("idle2"); state != nil {
+		t.Errorf("stale transcript without live process should be skipped, got state %q", state.State)
+	}
+}
+
+// Only the newest transcript in a project directory may be rescued — the
+// watcher's initial scan emits every transcript younger than MaxSessionAge,
+// and a single live process corresponds to at most the most recent one.
+// Older stale siblings rescued alongside it would be ghost sessions.
+func TestSessionDetector_NewSession_NoRescueWhenNotNewestInDir(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	cwd := rescueCWD(t)
+	det := newDetectorWithLiveCWDs(tw, pw, repo, nil, claudeProcessNames(), liveCWDSet(cwd))
+
+	projectDir := t.TempDir()
+	olderPath := filepath.Join(projectDir, "older.jsonl")
+	writeOldTranscript(t, olderPath, 10*time.Minute)
+	newerPath := filepath.Join(projectDir, "newer.jsonl")
+	writeOldTranscript(t, newerPath, 5*time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "older",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: olderPath,
+		CWD:            cwd,
+	}
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "newer",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: newerPath,
+		CWD:            cwd,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if state, _ := repo.Load("older"); state != nil {
+		t.Errorf("older stale sibling should not be rescued, got state %q", state.State)
+	}
+	if _, err := repo.Load("newer"); err != nil {
+		t.Errorf("newest stale transcript with live process should be rescued: %v", err)
+	}
+}
+
+func TestSessionDetector_NewSession_NoRescueForSubagentTranscript(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	cwd := rescueCWD(t)
+	det := newDetectorWithLiveCWDs(tw, pw, repo, nil, claudeProcessNames(), liveCWDSet(cwd))
+
+	subagentsDir := filepath.Join(t.TempDir(), "parent-1", "subagents")
+	if err := os.MkdirAll(subagentsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	transcriptPath := filepath.Join(subagentsDir, "sub1.jsonl")
+	writeOldTranscript(t, transcriptPath, 10*time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "sub1",
+		ProjectDir:     "subagents",
+		TranscriptPath: transcriptPath,
+		CWD:            cwd,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if state, _ := repo.Load("sub1"); state != nil {
+		t.Errorf("stale subagent transcript should not be rescued, got state %q", state.State)
+	}
+}
+
+// In production, fswatcher events carry no CWD — the rescue must fall back to
+// extracting the cwd from transcript content (GetCWDFromTranscript).
+func TestSessionDetector_NewSession_RescueUsesGetCWDFromTranscript(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	cwd := rescueCWD(t)
+	det := newDetectorWithLiveCWDs(tw, pw, repo, &cwdGit{cwd: cwd},
+		claudeProcessNames(), liveCWDSet(cwd))
+
+	transcriptPath := filepath.Join(t.TempDir(), "idle3.jsonl")
+	writeOldTranscript(t, transcriptPath, 10*time.Minute)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "idle3",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: transcriptPath,
+		// CWD intentionally empty — the fswatcher never sets it.
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if _, err := repo.Load("idle3"); err != nil {
+		t.Fatalf("rescue should fall back to transcript-derived cwd: %v", err)
+	}
+}
+
 func TestSessionDetector_Activity_TransitionsToWaiting_WhenToolUseOpen(t *testing.T) {
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -10,6 +10,7 @@ import (
 	"irrlicht/core/domain/lifecycle"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/inbound"
+	"irrlicht/core/ports/outbound"
 )
 
 // mockRecorder captures lifecycle events for assertions. Safe for
@@ -113,6 +114,16 @@ func (g *mockGit) GetProjectName(dir string) string {
 func (g *mockGit) GetGitRoot(dir string) string               { return "" }
 func (g *mockGit) GetBranchFromTranscript(path string) string { return "" }
 func (g *mockGit) GetCWDFromTranscript(path string) string    { return "" }
+
+// cwdGit is a mockGit whose GetCWDFromTranscript returns a fixed cwd. It
+// mimics the production fswatcher path, where EventNewSession carries no
+// CWD and the cwd comes from transcript content (issue #576 rescue).
+type cwdGit struct {
+	mockGit
+	cwd string
+}
+
+func (g *cwdGit) GetCWDFromTranscript(path string) string { return g.cwd }
 
 type mockMetrics struct {
 	pruned []string
@@ -258,6 +269,28 @@ func newDetectorWithMetrics(
 		[]inbound.Watcher{tw}, pw, repo,
 		&mockLogger{}, &mockGit{}, metrics, nil,
 		"test", 0, nil, nil, nil,
+	)
+}
+
+// newDetectorWithLiveCWDs builds a SessionDetector with a process-name map
+// and a live-CWD lookup injected, for stale-transcript rescue tests
+// (issue #576). git may be nil, defaulting to mockGit (whose
+// GetCWDFromTranscript returns "").
+func newDetectorWithLiveCWDs(
+	tw *mockAgentWatcher,
+	pw *mockProcessWatcher,
+	repo *mockRepo,
+	git outbound.GitResolver,
+	processNames map[string]string,
+	liveCWDs services.LiveCWDsFunc,
+) *services.SessionDetector {
+	if git == nil {
+		git = &mockGit{}
+	}
+	return services.NewSessionDetector(
+		[]inbound.Watcher{tw}, pw, repo,
+		&mockLogger{}, git, &mockMetrics{}, nil,
+		"test", 0, nil, processNames, liveCWDs,
 	)
 }
 


### PR DESCRIPTION
Fixes #576.

## Problem

When observe consent is granted **after** agent sessions are already running (the canonical first-run path since the consent-first gate #570/#571), the watcher-start backfill classified any transcript idle > `orphanTranscriptAge` (2 min) as an orphan and skipped it — even though process discovery had registered a live agent process in the same cwd milliseconds earlier in the same sweep (as a `proc-<pid>` pre-session). The session was never created or tailed; every first-run onboarding with idle sessions showed an empty dashboard.

## Fix

`onNewSession` now cross-checks process liveness before declaring a stale transcript an orphan (`isLiveStaleSession`, cheapest-first):

1. **Subagent guard** — `.../subagents/*.jsonl` transcripts are never rescued (no process of their own).
2. **Newest-in-dir ghost-guard** — the fswatcher's initial scan emits *every* transcript younger than `MaxSessionAge` (5 days); a single live process corresponds to at most the most recent one per project dir. Without this gate, one live process would rescue days of stale siblings as ghost sessions.
3. **cwd extraction** — from the event for scanner-sourced sessions, falling back to `GetCWDFromTranscript` (fswatcher events carry no CWD).
4. **`PIDManager.HasLiveProcessInCWD`** — new method over the already-injected `processNames` + `LiveCWDsFunc`, with `EvalSymlinks` canonicalization (`LiveCWDs` keys are OS-canonical; transcript cwds may carry symlink components, e.g. macOS `/var` → `/private/var`). Unknown/error ⇒ false ⇒ old skip behavior.

The liveness query goes to the OS directly rather than vetoing on an existing `proc-*` pre-session, so the fix does not depend on the racy scanner-before-fswatcher event ordering in the merged channel. A rescued session flows the normal path: saved as `ready` → `cleanupPreSessionsForProject` absorbs the pre-session → `DiscoverPIDWithRetry` binds the PID (~3.5s, well inside the 30s PID=0 reaper window).

No constructor or wiring changes — `processNames`/`liveCWDs` were already injected into `NewSessionDetector`.

## Known limitations (accepted per issue)

- A rescued session enters `ready` and only reclassifies on its next transcript write — a pre-grant pending AskUserQuestion stays undetected until the next interaction (hooks are snapshotted at session start; out of scope).
- Seconds-wide ghost edge: dead-newest transcript + live process whose own transcript doesn't exist yet → one ghost rescue, self-healed by same-PID cleanup / 30s reaper.
- The latent symlink mismatch in the DB-backed-orphan branch (`pid_manager.go`) is pre-existing and not touched here.

## Tests

- 5 new unit tests mirroring the existing orphan-skip pattern: rescue with live process, no rescue without, no rescue for non-newest sibling (ghost-guard), no rescue for subagent transcripts, and the production `GetCWDFromTranscript` fallback path.
- Full suite green: `go test ./core/... -race -count=1`, `go test ./tools/onboarding-factory/... -race -count=1`, `tools/replay-fixtures.sh`, `of validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)