### PR TITLE
fix(tailer): remove dead ContentChars pipeline, pin kiro tool-status semantics

### DIFF
--- a/core/adapters/inbound/agents/aider/parser.go
+++ b/core/adapters/inbound/agents/aider/parser.go
@@ -102,7 +102,6 @@ func (p *Parser) ParseLineRaw(line string) *tailer.ParsedEvent {
 		return &tailer.ParsedEvent{
 			EventType:      "user_message",
 			AssistantText:  truncate(text),
-			ContentChars:   int64(len(text)),
 			ClearToolNames: true,
 		}
 	}
@@ -133,7 +132,7 @@ func (p *Parser) ParseLineRaw(line string) *tailer.ParsedEvent {
 	}
 
 	// Plain prose: assistant response. Buffer it for the next model-call
-	// flush. ContentChars updates run on flush, not per line.
+	// flush.
 	if p.turnOpen {
 		if p.assistantBuffer.Len() > 0 {
 			p.assistantBuffer.WriteString(" ")
@@ -169,7 +168,6 @@ func (p *Parser) closeModelCall(m []string) *tailer.ParsedEvent {
 	}
 
 	text := strings.TrimSpace(p.assistantBuffer.String())
-	contentChars := int64(len(text))
 	p.assistantBuffer.Reset()
 	// turnOpen intentionally stays true: another model call may follow.
 
@@ -183,7 +181,6 @@ func (p *Parser) closeModelCall(m []string) *tailer.ParsedEvent {
 		EventType:     "assistant_message",
 		ModelName:     p.model,
 		AssistantText: truncate(text),
-		ContentChars:  contentChars,
 		Contribution:  contribution,
 		TaskEstimate:  taskEstimate,
 		Tokens: &tailer.TokenSnapshot{
@@ -208,7 +205,6 @@ func (p *Parser) flushErrorTurn(line string) *tailer.ParsedEvent {
 		EventType:     "turn_done",
 		ModelName:     p.model,
 		AssistantText: truncate(errText),
-		ContentChars:  int64(len(errText)),
 	}
 }
 

--- a/core/adapters/inbound/agents/aider/parser_test.go
+++ b/core/adapters/inbound/agents/aider/parser_test.go
@@ -189,9 +189,6 @@ func TestParser_EmptyTurn_NoCrash(t *testing.T) {
 	if asst.AssistantText != "" {
 		t.Errorf("expected empty assistant text, got %q", asst.AssistantText)
 	}
-	if asst.ContentChars != 0 {
-		t.Errorf("expected 0 ContentChars, got %d", asst.ContentChars)
-	}
 }
 
 func TestParser_BlockquoteNoise_Skipped(t *testing.T) {
@@ -314,9 +311,6 @@ func TestParser_LLMError_EndsTurn(t *testing.T) {
 	}
 	if !strings.Contains(done.AssistantText, "BadRequestError") {
 		t.Errorf("expected error text in AssistantText, got %q", done.AssistantText)
-	}
-	if done.ContentChars == 0 {
-		t.Errorf("expected non-zero ContentChars for error turn")
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -65,7 +65,6 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 	ev.ModelName, ev.ContextWindow = extractClaudeCodeModel(raw)
 	ev.Tokens = extractClaudeCodeTokens(raw)
 	p.applyRequestIDContribution(raw, ev)
-	ev.ContentChars = tailer.ExtractContentChars(raw)
 
 	eventType = resolveAssistantStreaming(raw, eventType)
 

--- a/core/adapters/inbound/agents/codex/parser.go
+++ b/core/adapters/inbound/agents/codex/parser.go
@@ -121,9 +121,6 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 		ev.CumulativeTokens = ev.Tokens
 	}
 
-	// Content character count.
-	ev.ContentChars = extractCodexContentChars(raw)
-
 	// Map event types to normalized forms.
 	switch eventType {
 	case "message":
@@ -282,17 +279,6 @@ func parseCodexFunctionCallOutput(raw map[string]interface{}, ev *tailer.ParsedE
 	if callID, ok := raw["call_id"].(string); ok && callID != "" {
 		ev.ToolResultIDs = []string{callID}
 	}
-}
-
-func extractCodexContentChars(raw map[string]interface{}) int64 {
-	if payload, ok := raw["payload"].(map[string]interface{}); ok {
-		return extractCodexContentChars(payload)
-	}
-	chars := tailer.ExtractContentChars(raw)
-	if message, ok := raw["message"].(string); ok {
-		chars += int64(len(message))
-	}
-	return chars
 }
 
 // extractCodexMetadata extracts model, context window, and token info from Codex events.

--- a/core/adapters/inbound/agents/kirocli/adapter_test.go
+++ b/core/adapters/inbound/agents/kirocli/adapter_test.go
@@ -1,9 +1,0 @@
-package kirocli
-
-import "testing"
-
-func TestSessionsDir(t *testing.T) {
-	if got := sessionsDir(); got != defaultRootDir {
-		t.Errorf("sessionsDir() = %q, want %q", got, defaultRootDir)
-	}
-}

--- a/core/adapters/inbound/agents/kirocli/parser.go
+++ b/core/adapters/inbound/agents/kirocli/parser.go
@@ -35,7 +35,7 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 	}
 
 	data, _ := raw["data"].(map[string]interface{})
-	content, _ := dataContent(data)
+	content := dataContent(data)
 
 	switch kind {
 	case "Prompt":
@@ -96,6 +96,14 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 			if id, _ := d["toolUseId"].(string); id != "" {
 				ev.ToolResultIDs = append(ev.ToolResultIDs, id)
 			}
+			// status is the tool HARNESS verdict, not the command's: a shell
+			// command exiting non-zero is still status:"success" (the exit
+			// code is payload data), while tool-input validation failures AND
+			// user-cancelled tools (Esc) are both status:"error" — kiro has
+			// no separate cancelled status (live-probed on 2.6.0, #592
+			// finding 3). A cancellation is distinguishable only via
+			// data.results[id].result == "Cancelled", should that ever
+			// matter.
 			if status, _ := d["status"].(string); status != "" && status != "success" {
 				ev.IsError = true
 			}
@@ -112,14 +120,19 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 		return ev
 	}
 
-	ev.ContentChars = tailer.ExtractContentChars(raw)
-
 	return ev
 }
 
 // parseKiroTimestamp reads data.meta.timestamp (epoch seconds — present on
 // Prompt events only), falling back to tailer.ParseTimestamp for any
 // top-level timestamp shape, which itself falls back to time.Now().
+//
+// The fallback means non-Prompt events are stamped with parse time: accurate
+// while tailing live, but on BACKFILL of a pre-existing transcript every
+// AssistantMessage/ToolResults event lands at scan time — a rescued session's
+// LastMessageAt reads as "just now" rather than its real last activity.
+// SessionStartAt stays correct (the first Prompt carries a real timestamp).
+// Nothing better is available in the JSONL (#592, finding 2).
 func parseKiroTimestamp(raw map[string]interface{}) time.Time {
 	if data, ok := raw["data"].(map[string]interface{}); ok {
 		if meta, ok := data["meta"].(map[string]interface{}); ok {
@@ -132,10 +145,10 @@ func parseKiroTimestamp(raw map[string]interface{}) time.Time {
 }
 
 // dataContent returns data.content as a slice, tolerating absent fields.
-func dataContent(data map[string]interface{}) ([]interface{}, bool) {
+func dataContent(data map[string]interface{}) []interface{} {
 	if data == nil {
-		return nil, false
+		return nil
 	}
-	content, ok := data["content"].([]interface{})
-	return content, ok
+	content, _ := data["content"].([]interface{})
+	return content
 }

--- a/core/adapters/inbound/agents/kirocli/parser_test.go
+++ b/core/adapters/inbound/agents/kirocli/parser_test.go
@@ -83,11 +83,40 @@ func TestParser_ToolResults_ClosesTool(t *testing.T) {
 	}
 }
 
+// The three ToolResults status shapes below are verbatim lines from a live
+// kiro-cli 2.6.0 probe (#592 finding 3), trimmed to the fields under test.
+// kiro's status field is the tool HARNESS verdict: {success, error} is the
+// complete vocabulary — there is no cancelled/denied status.
+
+// A shell command exiting non-zero is still status:"success" (the exit code
+// is payload data), so it must NOT raise IsError.
+func TestParser_ToolResults_FailedCommandIsNotError(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(line(t, `{"version":"v1","kind":"ToolResults","data":{"content":[{"kind":"toolResult","data":{"toolUseId":"tooluse_bn9siHin4aEo6wnCF1c9te","content":[{"kind":"json","data":{"exit_status":"exit status: 1","stdout":"","stderr":"cat: /nonexistent-file-probe-592: No such file or directory\n"}}],"status":"success"}}]}}`))
+	if ev.IsError {
+		t.Error("IsError = true for a non-zero-exit command recorded as status=success")
+	}
+}
+
+// Tool-input validation failure → status:"error".
 func TestParser_ToolResults_ErrorStatus(t *testing.T) {
 	p := &Parser{}
-	ev := p.ParseLine(line(t, `{"version":"v1","kind":"ToolResults","data":{"content":[{"kind":"toolResult","data":{"toolUseId":"tooluse_x","status":"error"}}]}}`))
+	ev := p.ParseLine(line(t, `{"version":"v1","kind":"ToolResults","data":{"content":[{"kind":"toolResult","data":{"toolUseId":"tooluse_egAL467aQyT8eei5xhtBMa","content":[{"kind":"text","data":"Failed to parse the tool use: The tool arguments failed validation: '/nonexistent-probe-592-direct.txt' does not exist"}],"status":"error"}}]}}`))
 	if !ev.IsError {
 		t.Error("expected IsError for status=error")
+	}
+}
+
+// A user-cancelled tool (Esc mid-flight) is ALSO status:"error" — kiro's own
+// classification; only data.results[id].result == "Cancelled" distinguishes it.
+func TestParser_ToolResults_CancelledIsError(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(line(t, `{"version":"v1","kind":"ToolResults","data":{"content":[{"kind":"toolResult","data":{"toolUseId":"tooluse_eL1H20njj3mlLOKK9Wml7w","content":[{"kind":"text","data":"Tool use was cancelled by the user"}],"status":"error"}}],"results":{"tooluse_eL1H20njj3mlLOKK9Wml7w":{"tool":null,"result":"Cancelled"}}}}`))
+	if !ev.IsError {
+		t.Error("expected IsError for a cancelled tool (kiro records it as status=error)")
+	}
+	if len(ev.ToolResultIDs) != 1 || ev.ToolResultIDs[0] != "tooluse_eL1H20njj3mlLOKK9Wml7w" {
+		t.Errorf("ToolResultIDs = %v, want the cancelled tool's id (cancellation must still close the tool)", ev.ToolResultIDs)
 	}
 }
 

--- a/core/adapters/inbound/agents/opencode/parser.go
+++ b/core/adapters/inbound/agents/opencode/parser.go
@@ -214,7 +214,6 @@ func parseTextPart(raw map[string]interface{}, ev *tailer.ParsedEvent) *tailer.P
 		} else {
 			ev.AssistantText = text
 		}
-		ev.ContentChars = int64(len(text))
 	}
 	return ev
 }

--- a/core/adapters/inbound/agents/opencode/parser_test.go
+++ b/core/adapters/inbound/agents/opencode/parser_test.go
@@ -200,9 +200,6 @@ func TestParser_TextPart_LongTruncated(t *testing.T) {
 	if !strings.HasPrefix(ev.AssistantText, "…") {
 		t.Errorf("AssistantText = %q, want leading …", ev.AssistantText)
 	}
-	if ev.ContentChars != 300 {
-		t.Errorf("ContentChars = %d, want 300", ev.ContentChars)
-	}
 }
 
 func TestParser_TextPart_UserMessage(t *testing.T) {

--- a/core/adapters/inbound/agents/pi/parser.go
+++ b/core/adapters/inbound/agents/pi/parser.go
@@ -144,9 +144,6 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 		return ev
 	}
 
-	// Content character count.
-	ev.ContentChars = tailer.ExtractContentChars(raw)
-
 	return ev
 }
 

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -180,7 +180,6 @@ type ParsedEvent struct {
 	CumulativeTokens *TokenSnapshot
 	RequestID        string
 	AssistantText    string // ≤200 chars, for waiting-state display
-	ContentChars     int64  // character count for token estimation
 	CWD              string // working directory if found
 	PermissionMode   string // Claude Code only
 
@@ -473,40 +472,6 @@ func ExtractAssistantText(raw map[string]interface{}) string {
 		return "…" + string(runes[len(runes)-200:])
 	}
 	return text
-}
-
-// ExtractContentChars returns the total character count of text content in
-// a transcript event, checking common content locations across formats.
-func ExtractContentChars(raw map[string]interface{}) int64 {
-	var chars int64
-	addContentChars := func(arr []interface{}) {
-		for _, item := range arr {
-			if block, ok := item.(map[string]interface{}); ok {
-				if text, ok := block["text"].(string); ok {
-					chars += int64(len(text))
-				}
-			}
-		}
-	}
-	// Top-level content array (Codex newer format)
-	if arr, ok := raw["content"].([]interface{}); ok {
-		addContentChars(arr)
-	}
-	// Nested message.content array (Claude Code format)
-	if msg, ok := raw["message"].(map[string]interface{}); ok {
-		if arr, ok := msg["content"].([]interface{}); ok {
-			addContentChars(arr)
-		}
-	}
-	// Codex function_call arguments
-	if args, ok := raw["arguments"].(string); ok {
-		chars += int64(len(args))
-	}
-	// Codex function_call_output
-	if output, ok := raw["output"].(string); ok {
-		chars += int64(len(output))
-	}
-	return chars
 }
 
 // ExtractUsage pulls token breakdown fields from a usage map.

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -224,10 +224,6 @@ type TranscriptTailer struct {
 	// parallel tool closures. See issue #117.
 	openToolCalls map[string]string
 
-	// contentChars accumulates character count from message content for
-	// token estimation when explicit token counts aren't available.
-	contentChars int64
-
 	// Token breakdown accumulators (latest snapshot, not cumulative).
 	// Used for context utilization — always reflects the most recent API turn.
 	inputTokens         int64
@@ -938,8 +934,6 @@ func (t *TranscriptTailer) processParsedEvent(parsed *ParsedEvent, sawUserBlocki
 		t.lastTaskEstimate = nil
 		t.firstTaskEstimate = nil
 	}
-
-	t.contentChars += parsed.ContentChars
 
 	t.addMessageEvent(MessageEvent{
 		Timestamp: parsed.Timestamp,

--- a/core/pkg/tailer/tool_call_test.go
+++ b/core/pkg/tailer/tool_call_test.go
@@ -218,8 +218,6 @@ func (p *testParser) ParseLine(raw map[string]interface{}) *ParsedEvent {
 			ev.ContextWindow = int64(cw)
 		}
 	}
-	ev.ContentChars = ExtractContentChars(raw)
-
 	// Filter non-message events.
 	switch eventType {
 	case "user_message", "assistant_message", "tool_call", "tool_result",


### PR DESCRIPTION
Closes #592.

Follow-ups from the post-merge review of #590. See the [verdict table on the issue](https://github.com/ingo-eichhorst/Irrlicht/issues/592) for the per-finding outcomes.

## Changes

- **Dead-code removal (finding 1, scope widened):** `t.contentChars` was write-only — accumulated in the tailer, read by nothing. Removed the whole pipeline: `ParsedEvent.ContentChars`, `tailer.ExtractContentChars`, codex's `extractCodexContentChars`, the accumulator, and all six adapters' population of it (−93 lines). `ParsedEvent` is never serialized, so replay goldens are byte-identical — verified.
- **Backfill timestamp contract documented (finding 2):** `parseKiroTimestamp` comment now spells out that non-Prompt events get parse-time stamps, what that means for backfilled sessions, and why nothing better is available.
- **Kiro tool-status semantics pinned (finding 3):** live-probed kiro-cli 2.6.0 — `{success, error}` is the full status vocabulary and it's the harness verdict, not the command's: non-zero-exit shell command = `success`; validation failure and user-cancelled tool both = `error` (`data.results[id].result == "Cancelled"` is the only discriminator, noted in the comment as the future seam). Three verbatim-line tests pin the shapes; the conservative `status != "success" → IsError` check stays.
- **Nits:** `dataContent` returns just the slice; tautological `kirocli/adapter_test.go` dropped.

## Gates

- `go test ./core/... -race -count=1` ✅
- `go test ./tools/onboarding-factory/... -race -count=1` ✅
- `tools/replay-fixtures.sh` ✅ (0 failures, cell-integrity green, goldens unchanged)
- `go run ./tools/onboarding-factory/cmd/of validate` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)