### PR TITLE
fix(detector): stale subagent state — waiting-path cleanup, summary ordering, observable deletions, history leak

### DIFF
--- a/core/application/services/history_tracker.go
+++ b/core/application/services/history_tracker.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -515,6 +516,13 @@ func (h *HistoryTracker) Load() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	for sid, granMap := range hf.Sessions {
+		// Subagent histories are transient — their sessions are deleted when
+		// the parent finishes, so a restored entry can only be a leak. Also
+		// one-time-heals files bloated by the pre-#593 eviction gap (deletion
+		// paths in PIDManager never evicted history).
+		if strings.HasPrefix(sid, "agent-") {
+			continue
+		}
 		sb := newSessionBuffers()
 		for gStr, states := range granMap {
 			g, err := strconv.Atoi(gStr)

--- a/core/application/services/history_tracker_test.go
+++ b/core/application/services/history_tracker_test.go
@@ -196,6 +196,24 @@ func TestHistoryTracker_LoadCorruptFile(t *testing.T) {
 	}
 }
 
+func TestHistoryTracker_LoadDropsSubagentEntries(t *testing.T) {
+	dir := t.TempDir()
+	// Subagent histories are transient — restoring them can only leak (#593:
+	// 1,151 dead agent-* entries measured in a production history.json).
+	payload := `{"version":1,"sessions":{"agent-a013c0a83ecd892bd":{"1":["working"]},"fe48f71f":{"1":["working"]}}}`
+	if err := os.WriteFile(filepath.Join(dir, "history.json"), []byte(payload), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ht := NewHistoryTrackerWithDir(dir)
+	ht.Load()
+	if _, ok := ht.Snapshot("agent-a013c0a83ecd892bd", 1); ok {
+		t.Error("agent-* entry should be dropped on Load")
+	}
+	if _, ok := ht.Snapshot("fe48f71f", 1); !ok {
+		t.Error("non-subagent entry should survive Load")
+	}
+}
+
 func TestHistoryTracker_LoadVersionMismatch(t *testing.T) {
 	dir := t.TempDir()
 	// Valid JSON, but schema version we don't support.

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -333,18 +333,39 @@ func (pm *PIDManager) isStartupZombie(state *session.SessionState, liveLookup fu
 	return isStaleTranscript(state.TranscriptPath)
 }
 
+// deleteSession removes one session through a single choke point: caller-side
+// tracking is evicted via onSessionDeleted (history rings, projectSessions —
+// the leak in #593), the removal is logged and recorded for offline replay
+// (same transcript_removed convention as the same-PID cleanup, issue #169),
+// and the deletion is broadcast so clients drop the row. Every PIDManager
+// session removal must route through here so no path leaks history again.
+func (pm *PIDManager) deleteSession(s *session.SessionState, reason string) {
+	pm.record(lifecycle.Event{
+		Kind:           lifecycle.KindTranscriptRemoved,
+		SessionID:      s.SessionID,
+		Adapter:        s.Adapter,
+		TranscriptPath: s.TranscriptPath,
+		Reason:         reason,
+	})
+	if pm.onSessionDeleted != nil {
+		pm.onSessionDeleted(s.SessionID)
+	}
+	_ = pm.repo.Delete(s.SessionID)
+	pm.log.LogInfo("session-cleanup", s.SessionID,
+		fmt.Sprintf("deleted (%s, state=%s)", reason, s.State))
+	pm.broadcast(outbound.PushTypeDeleted, s)
+}
+
 // deleteWithChildren removes a session and all its child sessions (subagents).
 func (pm *PIDManager) deleteWithChildren(state *session.SessionState) {
 	if states, err := pm.repo.ListAll(); err == nil {
 		for _, s := range states {
 			if s.ParentSessionID == state.SessionID {
-				_ = pm.repo.Delete(s.SessionID)
-				pm.broadcast(outbound.PushTypeDeleted, s)
+				pm.deleteSession(s, "parent deleted")
 			}
 		}
 	}
-	_ = pm.repo.Delete(state.SessionID)
-	pm.broadcast(outbound.PushTypeDeleted, state)
+	pm.deleteSession(state, "session deleted")
 }
 
 // cleanupChildren removes all child sessions of the given parent.
@@ -355,8 +376,7 @@ func (pm *PIDManager) cleanupChildren(parentID string) {
 	}
 	for _, s := range states {
 		if s.ParentSessionID == parentID && !strings.Contains(s.TranscriptPath, "?session=") {
-			_ = pm.repo.Delete(s.SessionID)
-			pm.broadcast(outbound.PushTypeDeleted, s)
+			pm.deleteSession(s, "parent finished — child cleanup")
 		}
 	}
 }
@@ -660,8 +680,11 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 				if !strings.Contains(state.TranscriptPath, "?session=") &&
 					(state.State == session.StateReady || isStaleTranscript(state.TranscriptPath)) {
 					parentID := state.ParentSessionID
-					_ = pm.repo.Delete(state.SessionID)
-					pm.broadcast(outbound.PushTypeDeleted, state)
+					reason := "child ready — liveness sweep"
+					if state.State != session.StateReady {
+						reason = "child transcript stale — liveness sweep"
+					}
+					pm.deleteSession(state, reason)
 					// Re-evaluate the parent: it may have been held in
 					// `working` only because of this child. Without this
 					// nudge the parent stays stuck until its own next

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"syscall"
 	"testing"
 	"time"
@@ -621,5 +622,96 @@ func TestTryDiscoverPID_ProcSession_BypassesDiscoverFn(t *testing.T) {
 
 	if repo.states["neighbor-uuid"] == nil {
 		t.Fatal("neighbor-uuid was evicted by same-PID cleanup — issue #345 regression")
+	}
+}
+
+// newPIDManagerForTestWithDeleteSpy builds a PIDManager whose onSessionDeleted
+// callback records every evicted session ID — the seam main.go wires to the
+// detector's history/projectSessions eviction helper. Locks the #593 deletion
+// funnel: every PIDManager removal must fire it, or history rings leak.
+func newPIDManagerForTestWithDeleteSpy(repo *mockRepo, deleted *[]string) *services.PIDManager {
+	return services.NewPIDManager(
+		nil,
+		repo,
+		&mockLogger{},
+		nil,
+		10*time.Minute,
+		nil,
+		nil,
+		nil,
+		func(sid string) { *deleted = append(*deleted, sid) },
+	)
+}
+
+// TestCheckPIDLiveness_ChildSweep_EvictsHistory: before #593 the liveness
+// sweep deleted finished children straight from the repo, bypassing
+// onSessionDeleted — their history rings leaked into history.json forever.
+func TestCheckPIDLiveness_ChildSweep_EvictsHistory(t *testing.T) {
+	tmp := t.TempDir()
+	parentTranscript := filepath.Join(tmp, "parent.jsonl")
+	writeTranscript(t, parentTranscript, time.Now())
+	childTranscript := filepath.Join(tmp, "agent-abc.jsonl")
+	writeTranscript(t, childTranscript, time.Now())
+
+	repo := newMockRepo()
+	repo.states["parent"] = &session.SessionState{
+		SessionID:      "parent",
+		Adapter:        "claude-code",
+		State:          session.StateWorking,
+		TranscriptPath: parentTranscript,
+		UpdatedAt:      time.Now().Unix(),
+	}
+	repo.states["agent-abc"] = &session.SessionState{
+		SessionID:       "agent-abc",
+		Adapter:         "claude-code",
+		State:           session.StateReady,
+		ParentSessionID: "parent",
+		TranscriptPath:  childTranscript,
+		UpdatedAt:       time.Now().Unix(),
+	}
+
+	var deleted []string
+	newPIDManagerForTestWithDeleteSpy(repo, &deleted).CheckPIDLiveness()
+
+	if repo.states["agent-abc"] != nil {
+		t.Fatal("ready child should be swept")
+	}
+	if !slices.Contains(deleted, "agent-abc") {
+		t.Errorf("onSessionDeleted not fired for swept child; got %v", deleted)
+	}
+	if repo.states["parent"] == nil {
+		t.Fatal("parent must survive the child sweep")
+	}
+}
+
+// TestHandleProcessExit_EvictsChildrenViaFunnel: deleteWithChildren must route
+// both the children and the session itself through the deletion funnel so
+// caller-side tracking (history rings) is evicted for every removal (#593).
+func TestHandleProcessExit_EvictsChildrenViaFunnel(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["parent"] = &session.SessionState{
+		SessionID: "parent",
+		Adapter:   "claude-code",
+		State:     session.StateReady,
+		PID:       4242,
+	}
+	repo.states["agent-kid"] = &session.SessionState{
+		SessionID:       "agent-kid",
+		Adapter:         "claude-code",
+		State:           session.StateWorking,
+		ParentSessionID: "parent",
+	}
+
+	var deleted []string
+	newPIDManagerForTestWithDeleteSpy(repo, &deleted).HandleProcessExit(4242, "parent")
+
+	if len(repo.states) != 0 {
+		t.Fatalf("parent and child should both be gone, repo has %d sessions", len(repo.states))
+	}
+	if !slices.Contains(deleted, "agent-kid") {
+		t.Errorf("onSessionDeleted not fired for child; got %v", deleted)
+	}
+	if !slices.Contains(deleted, "parent") {
+		t.Errorf("onSessionDeleted not fired for parent; got %v", deleted)
 	}
 }

--- a/core/application/services/push_service.go
+++ b/core/application/services/push_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"irrlicht/core/ports/outbound"
 )
@@ -10,6 +11,7 @@ import (
 // It implements ports/outbound.PushBroadcaster.
 type pushService struct {
 	mu   sync.Mutex
+	seq  atomic.Uint64
 	subs []chan outbound.PushMessage
 }
 
@@ -53,7 +55,11 @@ func (p *pushService) Subscribers() int {
 }
 
 // Broadcast sends the message to all subscribers. Slow subscribers are skipped.
+// Each message is stamped with a monotonic Seq before fan-out, so a client
+// that was skipped sees a gap in the received sequence and can re-hydrate
+// instead of keeping phantom state (#593).
 func (p *pushService) Broadcast(msg outbound.PushMessage) {
+	msg.Seq = p.seq.Add(1)
 	p.mu.Lock()
 	subs := make([]chan outbound.PushMessage, len(p.subs))
 	copy(subs, p.subs)

--- a/core/application/services/push_service_test.go
+++ b/core/application/services/push_service_test.go
@@ -1,0 +1,67 @@
+package services_test
+
+import (
+	"testing"
+
+	"irrlicht/core/application/services"
+	"irrlicht/core/ports/outbound"
+)
+
+// TestPushService_BroadcastStampsMonotonicSeq: every subscriber sees the
+// same, gap-free Seq per broadcast (#593).
+func TestPushService_BroadcastStampsMonotonicSeq(t *testing.T) {
+	p := services.NewPushService()
+	a := p.Subscribe()
+	b := p.Subscribe()
+
+	for range 3 {
+		p.Broadcast(outbound.PushMessage{Type: outbound.PushTypeUpdated})
+	}
+
+	for want := uint64(1); want <= 3; want++ {
+		ma := <-a
+		mb := <-b
+		if ma.Seq != want || mb.Seq != want {
+			t.Fatalf("broadcast %d: subscriber seqs = %d/%d, want both %d", want, ma.Seq, mb.Seq, want)
+		}
+	}
+}
+
+// TestPushService_SeqSurvivesSlowSubscriberDrop: a full subscriber is
+// skipped, but numbering keeps advancing — the fast subscriber receives a
+// contiguous sequence while the slow one sees a gap, which is exactly the
+// signal a client needs to re-hydrate instead of keeping phantom state
+// (#593).
+func TestPushService_SeqSurvivesSlowSubscriberDrop(t *testing.T) {
+	p := services.NewPushService()
+	slow := p.Subscribe()
+	// Fill the slow subscriber's 64-slot buffer.
+	for range 64 {
+		p.Broadcast(outbound.PushMessage{Type: outbound.PushTypeUpdated})
+	}
+	fast := p.Subscribe()
+	// These two broadcasts drop for slow, deliver to fast.
+	p.Broadcast(outbound.PushMessage{Type: outbound.PushTypeDeleted})
+	p.Broadcast(outbound.PushMessage{Type: outbound.PushTypeDeleted})
+
+	m1 := <-fast
+	m2 := <-fast
+	if m1.Seq != 65 || m2.Seq != 66 {
+		t.Fatalf("fast subscriber seqs = %d,%d; want 65,66", m1.Seq, m2.Seq)
+	}
+
+	// The slow subscriber got 1..64 and then nothing — its last received
+	// Seq (64) trails the stream, so the gap is client-observable.
+	var last uint64
+	for range 64 {
+		last = (<-slow).Seq
+	}
+	if last != 64 {
+		t.Fatalf("slow subscriber last seq = %d, want 64", last)
+	}
+	select {
+	case m := <-slow:
+		t.Fatalf("slow subscriber unexpectedly received seq %d", m.Seq)
+	default:
+	}
+}

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -432,15 +432,33 @@ func (d *SessionDetector) processActivity(id agent.Identity, ev agent.Event) {
 		// in-process subagents). Since the parent's own turn is done,
 		// those subagents' work is definitionally complete: the parent's
 		// final assistant message already incorporated their results.
+		//
+		// The fast-forward also fires when the turn ends in waiting with a
+		// question/cue (#593) — IsAgentDone gates it, so permission-prompt
+		// waiting (open tool call) is excluded. Without this, a parent whose
+		// overnight run ends by asking a question leaves its finished
+		// children stuck in working until the liveness sweep. The waiting
+		// branch only fast-forwards: no hold (the parent legitimately waits
+		// on the user) and no cleanupChildren (background children may still
+		// be running; finishOrphanedChildren's quiet-window and open-tool
+		// guards leave those alone).
 		parentHeldWorking := false
-		if newState == session.StateReady && state.ParentSessionID == "" {
-			d.finishOrphanedChildren(state.SessionID)
-			if d.hasActiveChildren(state.SessionID) {
-				d.log.LogInfo("session-detector", ev.SessionID,
-					"holding parent working — active children still running")
-				newState = session.StateWorking
-				reason = ""
-				parentHeldWorking = true
+		if state.ParentSessionID == "" {
+			switch {
+			case newState == session.StateReady:
+				d.finishOrphanedChildren(state.SessionID)
+				if d.hasActiveChildren(state.SessionID) {
+					d.log.LogInfo("session-detector", ev.SessionID,
+						"holding parent working — active children still running")
+					newState = session.StateWorking
+					reason = ""
+					parentHeldWorking = true
+				}
+			case newState == session.StateWaiting && state.Metrics != nil && state.Metrics.IsAgentDone():
+				// Turn-done waiting (question/cue) — fast-forward only.
+				// Permission-prompt waiting never reaches here: its open
+				// tool call makes IsAgentDone return false.
+				d.finishOrphanedChildren(state.SessionID)
 			}
 		}
 
@@ -506,7 +524,22 @@ func (d *SessionDetector) processActivity(id agent.Identity, ev agent.Event) {
 
 	// When a parent session finishes, clean up all its child sessions.
 	if state.State == session.StateReady && state.ParentSessionID == "" {
+		prevSummary := state.Subagents
 		d.pidMgr.cleanupChildren(state.SessionID)
+		// The broadcast above carried a summary counting children that were
+		// just deleted. Refresh, persist, and re-push so the turn's final
+		// parent message has the cleared badge AND the repo copy is clean —
+		// hook-path transitions re-broadcast the persisted summary as-is
+		// (#593). Gated on the summary changing so the common no-children
+		// case adds no push traffic.
+		d.refreshSubagentSummary(state)
+		if !state.Subagents.Equal(prevSummary) {
+			if err := d.repo.Save(state); err != nil {
+				d.log.LogError("session-detector", ev.SessionID,
+					fmt.Sprintf("failed to persist cleared subagent summary: %v", err))
+			}
+			d.broadcast(outbound.PushTypeUpdated, state)
+		}
 	}
 
 	// When a child session changes state, re-evaluate the parent — it may

--- a/core/application/services/session_detector_subagent.go
+++ b/core/application/services/session_detector_subagent.go
@@ -177,6 +177,17 @@ func (d *SessionDetector) reevaluateParent(parentID string) {
 	// e.g. the liveness sweep removing a child of a waiting/ready parent
 	// (#593). Refresh, persist, and re-push, gated on the summary actually
 	// changing so routine child events add no push traffic.
+	//
+	// Gate coupling: when this runs from a child's processActivity pass,
+	// the child broadcast (session_detector_helpers.go) has already
+	// refreshed this parent's summary in place — the repo shares
+	// SessionState pointers — AND re-pushed the parent, so prevSummary
+	// compares fresh-vs-fresh and the gate skips the duplicate push. The
+	// skip path therefore depends on that child-broadcast parent refresh
+	// staying in place (locked by the NoRedundantParentBroadcast storm-
+	// guard test). With a deep-copy repo the gate would instead compare
+	// against the persisted summary and fire on staleness — correct in
+	// both worlds.
 	prevSummary := parent.Subagents
 	d.refreshSubagentSummary(parent)
 	if !parent.Subagents.Equal(prevSummary) {

--- a/core/application/services/session_detector_subagent.go
+++ b/core/application/services/session_detector_subagent.go
@@ -172,6 +172,20 @@ func (d *SessionDetector) reevaluateParent(parentID string) {
 	if err != nil || parent == nil {
 		return
 	}
+	// A child just changed state or was deleted: the parent's persisted
+	// badge may be stale even when the parent itself won't transition —
+	// e.g. the liveness sweep removing a child of a waiting/ready parent
+	// (#593). Refresh, persist, and re-push, gated on the summary actually
+	// changing so routine child events add no push traffic.
+	prevSummary := parent.Subagents
+	d.refreshSubagentSummary(parent)
+	if !parent.Subagents.Equal(prevSummary) {
+		if err := d.repo.Save(parent); err != nil {
+			d.log.LogError("session-detector", parentID,
+				fmt.Sprintf("failed to persist refreshed subagent summary: %v", err))
+		}
+		d.broadcast(outbound.PushTypeUpdated, parent)
+	}
 	// Only re-evaluate parents that are being held in working.
 	if parent.State != session.StateWorking {
 		return
@@ -214,8 +228,19 @@ func (d *SessionDetector) reevaluateParent(parentID string) {
 	}
 	d.broadcast(outbound.PushTypeUpdated, parent)
 
-	// If the parent transitioned to ready, clean up its children.
+	// If the parent transitioned to ready, clean up its children — then
+	// refresh, persist, and re-push the now-cleared summary so the final
+	// parent message doesn't count children deleted a moment ago (#593).
 	if parent.State == session.StateReady {
+		prev := parent.Subagents
 		d.pidMgr.cleanupChildren(parentID)
+		d.refreshSubagentSummary(parent)
+		if !parent.Subagents.Equal(prev) {
+			if err := d.repo.Save(parent); err != nil {
+				d.log.LogError("session-detector", parentID,
+					fmt.Sprintf("failed to persist cleared subagent summary: %v", err))
+			}
+			d.broadcast(outbound.PushTypeUpdated, parent)
+		}
 	}
 }

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -15,6 +15,7 @@ import (
 	"irrlicht/core/domain/lifecycle"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/inbound"
+	"irrlicht/core/ports/outbound"
 )
 
 // --- tests -------------------------------------------------------------------
@@ -2638,5 +2639,672 @@ func TestSessionDetector_SeedFromDisk_ConsentGated(t *testing.T) {
 	}
 	if read["/tmp/pending-session.jsonl"] {
 		t.Error("un-consented adapter's transcript was read at seed — consent gate bypassed")
+	}
+}
+
+// TestSessionDetector_OrphanedChildrenFinish_WhenParentEndsWaitingWithQuestion
+// is the core #593 reproduction: a parent whose turn ends by asking a
+// question lands in waiting, not ready — before the fix the child
+// fast-forward only ran on the ready path, so finished children stayed
+// stuck in working until the liveness sweep.
+func TestSessionDetector_OrphanedChildrenFinish_WhenParentEndsWaitingWithQuestion(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	tmpDir := t.TempDir()
+
+	parentPath := filepath.Join(tmpDir, "parent-asks.jsonl")
+	if err := os.WriteFile(parentPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo.Save(&session.SessionState{
+		SessionID:      "parent-asks",
+		State:          session.StateWorking,
+		TranscriptPath: parentPath,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     10,
+		Metrics: &session.SessionMetrics{
+			LastEventType:     "assistant",
+			HasOpenToolCall:   false,
+			LastAssistantText: "All stages recorded. Should I open the PR now?",
+		},
+	})
+
+	// Orphaned child: stale transcript (60s > SubagentQuietWindow), no open
+	// tools — its work is done, only the stop_reason:null quirk keeps it
+	// classified as working.
+	staleMtime := time.Now().Add(-60 * time.Second)
+	childPath := filepath.Join(tmpDir, "child-of-asker.jsonl")
+	if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(childPath, staleMtime, staleMtime); err != nil {
+		t.Fatal(err)
+	}
+	repo.Save(&session.SessionState{
+		SessionID:       "child-of-asker",
+		State:           session.StateWorking,
+		ParentSessionID: "parent-asks",
+		TranscriptPath:  childPath,
+		FirstSeen:       now,
+		UpdatedAt:       now,
+		EventCount:      5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:   "assistant_streaming",
+			HasOpenToolCall: false,
+		},
+	})
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "parent-asks",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: parentPath,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	parent, _ := repo.Load("parent-asks")
+	if parent == nil {
+		t.Fatal("parent session should still exist")
+	}
+	if parent.State != session.StateWaiting {
+		t.Errorf("parent state: got %q, want waiting — question/cue turn end", parent.State)
+	}
+
+	// No cleanup runs on the waiting path, so the child must still exist —
+	// fast-forwarded to ready (the sweep deletes it later).
+	child, _ := repo.Load("child-of-asker")
+	if child == nil {
+		t.Fatal("child should not be deleted on the waiting path")
+	}
+	if child.State != session.StateReady {
+		t.Errorf("child state: got %q, want ready — orphan fast-forward must fire on turn-done waiting", child.State)
+	}
+
+	cancel()
+	<-done
+}
+
+// TestSessionDetector_PermissionWaitingDoesNotFastForwardChildren locks the
+// #593 gating constraint: waiting caused by an open user-blocking tool
+// (permission prompt, AskUserQuestion) means the parent's turn is NOT done —
+// children must be left alone.
+func TestSessionDetector_PermissionWaitingDoesNotFastForwardChildren(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	tmpDir := t.TempDir()
+
+	parentPath := filepath.Join(tmpDir, "parent-perm.jsonl")
+	if err := os.WriteFile(parentPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo.Save(&session.SessionState{
+		SessionID:      "parent-perm",
+		State:          session.StateWorking,
+		TranscriptPath: parentPath,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     10,
+		Metrics: &session.SessionMetrics{
+			LastEventType:     "tool_use",
+			HasOpenToolCall:   true,
+			LastOpenToolNames: []string{"AskUserQuestion"},
+		},
+	})
+
+	staleMtime := time.Now().Add(-60 * time.Second)
+	childPath := filepath.Join(tmpDir, "child-of-perm.jsonl")
+	if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(childPath, staleMtime, staleMtime); err != nil {
+		t.Fatal(err)
+	}
+	repo.Save(&session.SessionState{
+		SessionID:       "child-of-perm",
+		State:           session.StateWorking,
+		ParentSessionID: "parent-perm",
+		TranscriptPath:  childPath,
+		FirstSeen:       now,
+		UpdatedAt:       now,
+		EventCount:      5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:   "assistant_streaming",
+			HasOpenToolCall: false,
+		},
+	})
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "parent-perm",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: parentPath,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	parent, _ := repo.Load("parent-perm")
+	if parent == nil {
+		t.Fatal("parent session should still exist")
+	}
+	if parent.State != session.StateWaiting {
+		t.Errorf("parent state: got %q, want waiting — user-blocking tool open", parent.State)
+	}
+
+	child, _ := repo.Load("child-of-perm")
+	if child == nil {
+		t.Fatal("child should not be deleted")
+	}
+	if child.State != session.StateWorking {
+		t.Errorf("child state: got %q, want working — open-tool waiting must not fast-forward children", child.State)
+	}
+
+	cancel()
+	<-done
+}
+
+// TestSessionDetector_WaitingParent_DoesNotCleanupBackgroundChildren: a
+// background child still writing its transcript (within SubagentQuietWindow)
+// survives the parent's turn-done-waiting transition untouched (#593).
+func TestSessionDetector_WaitingParent_DoesNotCleanupBackgroundChildren(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	tmpDir := t.TempDir()
+
+	parentPath := filepath.Join(tmpDir, "parent-asks-bg.jsonl")
+	if err := os.WriteFile(parentPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo.Save(&session.SessionState{
+		SessionID:      "parent-asks-bg",
+		State:          session.StateWorking,
+		TranscriptPath: parentPath,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     10,
+		Metrics: &session.SessionMetrics{
+			LastEventType:     "assistant",
+			HasOpenToolCall:   false,
+			LastAssistantText: "Kicked off the background review. Want a summary when it lands?",
+		},
+	})
+
+	// Background child: transcript freshly written (within the 30s quiet
+	// window) — must be left alone even though it has no open tool call.
+	childPath := filepath.Join(tmpDir, "child-bg.jsonl")
+	if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	repo.Save(&session.SessionState{
+		SessionID:       "child-bg",
+		State:           session.StateWorking,
+		ParentSessionID: "parent-asks-bg",
+		TranscriptPath:  childPath,
+		FirstSeen:       now,
+		UpdatedAt:       now,
+		EventCount:      5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:   "assistant_streaming",
+			HasOpenToolCall: false,
+		},
+	})
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "parent-asks-bg",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: parentPath,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	parent, _ := repo.Load("parent-asks-bg")
+	if parent == nil {
+		t.Fatal("parent session should still exist")
+	}
+	if parent.State != session.StateWaiting {
+		t.Errorf("parent state: got %q, want waiting", parent.State)
+	}
+
+	child, _ := repo.Load("child-bg")
+	if child == nil {
+		t.Fatal("background child should not be deleted")
+	}
+	if child.State != session.StateWorking {
+		t.Errorf("background child state: got %q, want working — quiet-window guard", child.State)
+	}
+
+	cancel()
+	<-done
+}
+
+// TestSessionDetector_ParentBadgeCleared_AfterReadyCleanup locks the #593
+// ordering fix: the turn's FINAL parent push must carry the post-cleanup
+// (empty) subagent summary, and the repo copy must be cleared too — the
+// pre-fix order was refresh → broadcast → cleanupChildren, so the last
+// message of the turn counted children deleted a moment later and the
+// stale summary stayed persisted for hook-path re-broadcasts.
+func TestSessionDetector_ParentBadgeCleared_AfterReadyCleanup(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det, bc := newDetectorWithBroadcaster(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	tmpDir := t.TempDir()
+
+	parentPath := filepath.Join(tmpDir, "parent-clears.jsonl")
+	if err := os.WriteFile(parentPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	repo.Save(&session.SessionState{
+		SessionID:      "parent-clears",
+		State:          session.StateWorking,
+		TranscriptPath: parentPath,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     10,
+		Metrics: &session.SessionMetrics{
+			LastEventType:     "assistant",
+			HasOpenToolCall:   false,
+			LastAssistantText: "All waves complete.",
+		},
+	})
+
+	staleMtime := time.Now().Add(-60 * time.Second)
+	childPath := filepath.Join(tmpDir, "child-cleared.jsonl")
+	if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(childPath, staleMtime, staleMtime); err != nil {
+		t.Fatal(err)
+	}
+	repo.Save(&session.SessionState{
+		SessionID:       "child-cleared",
+		State:           session.StateWorking,
+		ParentSessionID: "parent-clears",
+		TranscriptPath:  childPath,
+		FirstSeen:       now,
+		UpdatedAt:       now,
+		EventCount:      5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:   "assistant_streaming",
+			HasOpenToolCall: false,
+		},
+	})
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "parent-clears",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: parentPath,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Quiesce the detector before reading shared state.
+	cancel()
+	<-done
+
+	parent, _ := repo.Load("parent-clears")
+	if parent == nil {
+		t.Fatal("parent session should still exist")
+	}
+	if parent.State != session.StateReady {
+		t.Fatalf("parent state: got %q, want ready", parent.State)
+	}
+	if parent.Subagents != nil {
+		t.Errorf("persisted parent summary: got %+v, want nil after cleanup", parent.Subagents)
+	}
+	if child, _ := repo.Load("child-cleared"); child != nil {
+		t.Errorf("child should be deleted by parent-ready cleanup, still in state %q", child.State)
+	}
+
+	// The LAST broadcast for the parent must carry the cleared summary.
+	var last *outbound.PushMessage
+	for _, m := range bc.messages() {
+		if m.Type == outbound.PushTypeUpdated && m.Session != nil && m.Session.SessionID == "parent-clears" {
+			mm := m
+			last = &mm
+		}
+	}
+	if last == nil {
+		t.Fatal("no session_updated broadcast for parent")
+	}
+	if last.Session.Subagents != nil {
+		t.Errorf("final parent push summary: got %+v, want nil", last.Session.Subagents)
+	}
+}
+
+// TestSessionDetector_ParentBadgeCleared_WhenChildSweptWhileParentWaiting
+// locks the #593 sweep-case fix: when the liveness sweep deletes a stuck
+// child of a parent that is NOT held in working (it's waiting on the user),
+// the parent's persisted summary must still be refreshed and re-pushed.
+// Pre-fix, reevaluateParent early-returned before touching the summary, so
+// a waiting parent kept its stale badge until its own next transcript event.
+func TestSessionDetector_ParentBadgeCleared_WhenChildSweptWhileParentWaiting(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	// The child-sweep path in PIDManager is gated on readyTTL > 0; wire a
+	// capturing broadcaster to assert the corrective parent push.
+	bc := &mockBroadcaster{}
+	det := services.NewSessionDetector(
+		[]inbound.Watcher{tw}, pw, repo,
+		&mockLogger{}, &mockGit{}, &mockMetrics{}, bc,
+		"test", 1*time.Second, nil, nil, nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	tmpDir := t.TempDir()
+
+	parentPath := filepath.Join(tmpDir, "parent-waiting.jsonl")
+	if err := os.WriteFile(parentPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	parent := &session.SessionState{
+		SessionID:      "parent-waiting",
+		State:          session.StateWaiting,
+		TranscriptPath: parentPath,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     10,
+		Metrics: &session.SessionMetrics{
+			LastEventType:     "assistant",
+			HasOpenToolCall:   false,
+			LastAssistantText: "Should I continue?",
+		},
+	}
+
+	// Stuck child: transcript went stale 5+ minutes ago, so the sweep
+	// deletes it on its next pass.
+	staleTime := time.Now().Add(-5 * time.Minute)
+	childPath := filepath.Join(tmpDir, "stuck-child.jsonl")
+	if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(childPath, staleTime, staleTime); err != nil {
+		t.Fatal(err)
+	}
+	child := &session.SessionState{
+		SessionID:       "stuck-child",
+		State:           session.StateWorking,
+		ParentSessionID: "parent-waiting",
+		TranscriptPath:  childPath,
+		FirstSeen:       now,
+		UpdatedAt:       now,
+		EventCount:      3,
+		Metrics: &session.SessionMetrics{
+			LastEventType: "tool_use",
+		},
+	}
+
+	// The parent's persisted badge counts the stuck child.
+	parent.Subagents = session.ComputeSubagentSummary(parent, []*session.SessionState{child})
+	repo.Save(parent)
+	repo.Save(child)
+
+	// Trigger the sweep directly instead of waiting the real ticker.
+	det.RunPIDLivenessSweepForTest()
+	time.Sleep(30 * time.Millisecond)
+
+	// Quiesce the detector before reading shared state.
+	cancel()
+	<-done
+
+	got, _ := repo.Load("parent-waiting")
+	if got == nil {
+		t.Fatal("parent session should still exist")
+	}
+	if got.State != session.StateWaiting {
+		t.Errorf("parent state: got %q, want waiting (no transition)", got.State)
+	}
+	if got.Subagents != nil {
+		t.Errorf("persisted parent summary: got %+v, want nil after child swept", got.Subagents)
+	}
+	if c, _ := repo.Load("stuck-child"); c != nil {
+		t.Errorf("child should have been swept, still in state %q", c.State)
+	}
+
+	// The corrective parent push must carry the cleared summary.
+	var last *outbound.PushMessage
+	for _, m := range bc.messages() {
+		if m.Type == outbound.PushTypeUpdated && m.Session != nil && m.Session.SessionID == "parent-waiting" {
+			mm := m
+			last = &mm
+		}
+	}
+	if last == nil {
+		t.Fatal("no corrective session_updated broadcast for the waiting parent")
+	}
+	if last.Session.Subagents != nil {
+		t.Errorf("corrective parent push summary: got %+v, want nil", last.Session.Subagents)
+	}
+}
+
+// TestSessionDetector_NoRedundantParentBroadcast_OnUnchangedSummary is the
+// #593 storm guard: a child event that doesn't change the parent's badge
+// must not add a second parent push on top of the existing child-broadcast
+// parent refresh (session_detector_helpers.go).
+func TestSessionDetector_NoRedundantParentBroadcast_OnUnchangedSummary(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det, bc := newDetectorWithBroadcaster(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	tmpDir := t.TempDir()
+
+	parentPath := filepath.Join(tmpDir, "parent-stable.jsonl")
+	if err := os.WriteFile(parentPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	parent := &session.SessionState{
+		SessionID:      "parent-stable",
+		State:          session.StateWaiting,
+		TranscriptPath: parentPath,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     10,
+		Metrics: &session.SessionMetrics{
+			LastEventType:     "assistant",
+			HasOpenToolCall:   false,
+			LastAssistantText: "Should I continue?",
+		},
+	}
+
+	childPath := filepath.Join(tmpDir, "busy-child.jsonl")
+	if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	child := &session.SessionState{
+		SessionID:       "busy-child",
+		State:           session.StateWorking,
+		ParentSessionID: "parent-stable",
+		TranscriptPath:  childPath,
+		FirstSeen:       now,
+		UpdatedAt:       now,
+		EventCount:      5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:   "tool_use",
+			HasOpenToolCall: true,
+		},
+	}
+
+	// Persisted badge already matches reality: one working child.
+	parent.Subagents = session.ComputeSubagentSummary(parent, []*session.SessionState{child})
+	repo.Save(parent)
+	repo.Save(child)
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "busy-child",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: childPath,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	<-done
+
+	parentPushes := 0
+	for _, m := range bc.messages() {
+		if m.Type == outbound.PushTypeUpdated && m.Session != nil && m.Session.SessionID == "parent-stable" {
+			parentPushes++
+		}
+	}
+	if parentPushes != 1 {
+		t.Errorf("parent pushes after one no-change child event: got %d, want 1 (child-broadcast refresh only)", parentPushes)
+	}
+}
+
+// TestSessionDetector_ChildDeletionIsRecorded: child cleanup must leave a
+// lifecycle trace (#593) — pre-fix, cleanupChildren and the liveness sweep
+// deleted silently, so recordings showed children that "leaked" forever.
+func TestSessionDetector_ChildDeletionIsRecorded(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+	rec := &mockRecorder{}
+	det.SetRecorder(rec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	tmpDir := t.TempDir()
+
+	parentPath := filepath.Join(tmpDir, "parent-records.jsonl")
+	if err := os.WriteFile(parentPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	repo.Save(&session.SessionState{
+		SessionID:      "parent-records",
+		State:          session.StateWorking,
+		TranscriptPath: parentPath,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     10,
+		Metrics: &session.SessionMetrics{
+			LastEventType:     "assistant",
+			HasOpenToolCall:   false,
+			LastAssistantText: "All waves complete.",
+		},
+	})
+
+	staleMtime := time.Now().Add(-60 * time.Second)
+	childPath := filepath.Join(tmpDir, "child-recorded.jsonl")
+	if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(childPath, staleMtime, staleMtime); err != nil {
+		t.Fatal(err)
+	}
+	repo.Save(&session.SessionState{
+		SessionID:       "child-recorded",
+		State:           session.StateWorking,
+		ParentSessionID: "parent-records",
+		TranscriptPath:  childPath,
+		FirstSeen:       now,
+		UpdatedAt:       now,
+		EventCount:      5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:   "assistant_streaming",
+			HasOpenToolCall: false,
+		},
+	})
+
+	// Parent finishes its turn → ready → cleanupChildren deletes the child.
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "parent-records",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: parentPath,
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+	<-done
+
+	if child, _ := repo.Load("child-recorded"); child != nil {
+		t.Fatalf("child should be deleted, still in state %q", child.State)
+	}
+
+	found := false
+	for _, ev := range rec.snapshot() {
+		if ev.Kind == lifecycle.KindTranscriptRemoved && ev.SessionID == "child-recorded" {
+			found = true
+			if ev.Reason == "" {
+				t.Error("recorded child deletion should carry a reason")
+			}
+		}
+	}
+	if !found {
+		t.Error("no transcript_removed lifecycle event recorded for the cleaned-up child")
 	}
 }

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -339,3 +339,50 @@ func newDetectorWithCWDDiscovery(
 		"test", 0, discovers, nil, nil,
 	)
 }
+
+// mockBroadcaster captures every Broadcast for assertions. Safe for
+// concurrent use — the detector broadcasts from multiple goroutines.
+type mockBroadcaster struct {
+	mu   sync.Mutex
+	msgs []outbound.PushMessage
+}
+
+func (b *mockBroadcaster) Broadcast(msg outbound.PushMessage) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Deep-enough copy: the detector keeps mutating the *SessionState it
+	// broadcasts, so snapshot the fields assertions need.
+	if msg.Session != nil {
+		s := *msg.Session
+		msg.Session = &s
+	}
+	b.msgs = append(b.msgs, msg)
+}
+
+func (b *mockBroadcaster) Subscribe() chan outbound.PushMessage     { return nil }
+func (b *mockBroadcaster) Unsubscribe(ch chan outbound.PushMessage) {}
+
+// messages returns a snapshot of everything broadcast so far.
+func (b *mockBroadcaster) messages() []outbound.PushMessage {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]outbound.PushMessage, len(b.msgs))
+	copy(out, b.msgs)
+	return out
+}
+
+// newDetectorWithBroadcaster builds a SessionDetector whose pushes land in
+// the returned mockBroadcaster (#593 summary-clearing assertions).
+func newDetectorWithBroadcaster(
+	tw *mockAgentWatcher,
+	pw *mockProcessWatcher,
+	repo *mockRepo,
+) (*services.SessionDetector, *mockBroadcaster) {
+	b := &mockBroadcaster{}
+	det := services.NewSessionDetector(
+		[]inbound.Watcher{tw}, pw, repo,
+		&mockLogger{}, &mockGit{}, &mockMetrics{}, b,
+		"test", 0, nil, nil, nil,
+	)
+	return det, b
+}

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -565,6 +565,16 @@ type subagentSummary struct {
 	Ready   int `json:"ready"`
 }
 
+// Equal reports whether two summaries carry the same counts. Nil receivers
+// and arguments are handled — two nils are equal. Used to skip redundant
+// parent re-broadcasts when a child event didn't change the badge (#593).
+func (s *subagentSummary) Equal(o *subagentSummary) bool {
+	if s == nil || o == nil {
+		return s == o
+	}
+	return *s == *o
+}
+
 // Launcher identifies the terminal emulator or IDE that spawned the session's
 // agent process. Captured once from the process env when the PID is first
 // known (see processlifecycle.ReadLauncherEnv). Fields are best-effort —

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -16,6 +16,13 @@ type PushMessage struct {
 	Type    string                `json:"type"`
 	Session *session.SessionState `json:"session,omitempty"`
 
+	// Seq is a daemon-global monotonic sequence number stamped by
+	// pushService.Broadcast before fan-out — every subscriber sees the same
+	// Seq for a given message, so a gap in received Seq tells a client it
+	// missed a drop (slow-subscriber skip) and should re-hydrate (#593).
+	// 0 = unstamped: connect-time hub snapshots, or an older daemon.
+	Seq uint64 `json:"seq,omitempty"`
+
 	// History-message fields. SessionID identifies the target row for
 	// snapshot/upgrade messages; tick messages use the per-session entries
 	// in Buckets instead. History maps granularity ("1"/"10"/"60") → 20-char


### PR DESCRIPTION
Closes #593. Follow-up for client-side seq-gap adoption: #600.

## What

Four related daemon fixes from the #593 investigation (a ready parent showing a stale "4 subagents" badge the morning after an overnight run):

1. **Deletion funnel** — every PIDManager session removal routes through a new `deleteSession` choke point: `onSessionDeleted` eviction (history rings, projectSessions), a `session-cleanup` log line, a `transcript_removed` lifecycle record (same convention as the #169 same-PID cleanup), and the deletion broadcast. Pre-fix, `deleteWithChildren`, `cleanupChildren`, and the liveness child-sweep deleted silently and never evicted history.
2. **History leak** — `HistoryTracker.Load()` drops `agent-*` keys. Measured live: history.json had grown to 2,031 sessions (1,151 dead subagents) since April, shipped as ~2,021 `history_snapshot` messages on every WS connect. One-time-heals existing files on next daemon start; no format/version bump.
3. **Waiting-path fast-forward** — a parent whose turn ends with a question/cue (`waiting` + `IsAgentDone`) now fast-forwards orphaned children; pre-fix only the ready path did, so overnight runs ending in a question left finished children stuck in `working` for the sweep. Permission-prompt waiting is excluded automatically (open tool call ⇒ `IsAgentDone` false). No hold and no `cleanupChildren` on the waiting path — background children stay protected by the existing quiet-window + open-tool guards.
4. **Summary ordering** — the parent's post-cleanup subagent summary is refreshed, persisted, and re-pushed (activity path + `reevaluateParent`), and a child change now refreshes a non-working parent's badge too (the sweep-while-waiting case). Gated on the summary actually changing, so steady-state push volume is unchanged (locked by a storm-guard test).

Plus groundwork for drop detection: `PushMessage.Seq`, a daemon-global monotonic sequence stamped in `pushService.Broadcast` — a gap in received seq tells a client it was skipped (64-slot slow-subscriber drop) and should re-hydrate. Client adoption is #600; `omitempty` keeps old clients/daemons compatible.

## Tests

- 11 new tests: waiting-path fast-forward (3: question-waiting fires, permission-waiting doesn't, background child survives), summary clearing (3: ready-cleanup, swept-while-waiting via `RunPIDLivenessSweepForTest`, no-redundant-push storm guard), deletion funnel (2 spy tests + recorded-deletion), history load drop, push seq (2: monotonic across subscribers, gap observable after drops).
- New shared test infra: capturing `mockBroadcaster` + `newDetectorWithBroadcaster`.

## Verification

- `go test ./core/... -race -count=1` ✅
- `go test ./tools/onboarding-factory/... -race -count=1` ✅
- `tools/replay-fixtures.sh` ✅ (replay synthesizes its own events from transcripts — the new `transcript_removed` emissions don't perturb fixtures, and the replay state machine already treats that kind as session-removal)
- `go run ./tools/onboarding-factory/cmd/of validate` ✅
- Web suites not run — no `web/` tree touched (client seq adoption is #600).

🤖 Generated with [Claude Code](https://claude.com/claude-code)