### PR TITLE
feat(eta): drop-proof task ETA — tasks-derived fallback, hook marker carrier, 0/N chip

### DIFF
--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -12,7 +12,10 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"irrlicht/core/domain/session"
+	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/ports/outbound"
 )
 
@@ -53,6 +56,58 @@ type HookTarget interface {
 	HandlePermissionHook(sessionID, transcriptPath, hookEventName string)
 }
 
+// MarkerTarget is the narrow interface for hook-carried task-estimate
+// markers (#604) — the same method shape as the MetricsCollector port, so
+// the metrics adapter satisfies it directly (mirrors RateLimitTarget in
+// statusline.go). Nil disables the scan (tests).
+type MarkerTarget interface {
+	IngestTaskEstimate(transcriptPath string, est *session.TaskEstimate)
+}
+
+// scanToolInputForMarker walks the decoded tool_input and scans its string
+// values for a task-estimate marker. The raw JSON can't be scanned directly:
+// inside a JSON string the marker's quotes are escaped (\"marker\") and the
+// captured comment body would not unmarshal. Tool inputs are small, shallow
+// objects — the walk recurses into nested objects/arrays for completeness.
+func scanToolInputForMarker(raw json.RawMessage, observedAt time.Time) *tailer.TaskEstimate {
+	if len(raw) == 0 {
+		return nil
+	}
+	// Fast reject before decoding. The comment opener survives JSON string
+	// escaping (a backslash-quote doesn't touch "<!--"), but HTML-escaping
+	// encoders write "<" as a unicode escape — Go's json.Marshal does,
+	// Claude Code's JSON.stringify doesn't. Accept both encodings; the
+	// raw-string needle below is the escaped opener byte-for-byte.
+	htmlEscapedOpener := `\u003c!--`
+	if s := string(raw); !strings.Contains(s, "<!--") && !strings.Contains(s, htmlEscapedOpener) {
+		return nil
+	}
+	var decoded interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil
+	}
+	var est *tailer.TaskEstimate
+	var walk func(v interface{})
+	walk = func(v interface{}) {
+		switch val := v.(type) {
+		case string:
+			if found := tailer.ScanTaskEstimate(val, observedAt); found != nil {
+				est = found // latest valid wins, matching the transcript scan
+			}
+		case map[string]interface{}:
+			for _, child := range val {
+				walk(child)
+			}
+		case []interface{}:
+			for _, child := range val {
+				walk(child)
+			}
+		}
+	}
+	walk(decoded)
+	return est
+}
+
 // ConsentGate reports whether the user has granted a permission (issue
 // #570). Satisfied by *services.PermissionService. Hooks installed by a
 // pre-consent daemon version keep firing until answered, so the receivers
@@ -80,10 +135,16 @@ func sessionIDFromTranscriptPath(p string) string {
 // PermissionRequest, an empty response means Claude Code shows its normal
 // permission prompt (no auto-approve/deny).
 //
+// markers receives task-estimate markers found in PreToolUse tool inputs
+// (#604) — a transport that bypasses the transcript writer, which drops
+// mid-task assistant text on claude ≥2.1.162. The marker scan runs for ALL
+// tools; the permission dispatch below stays strictly gated to the
+// user-input tools — two independent paths, not a relaxation of the gate.
+//
 // gate is the consent check for the "hooks" permission; while not granted
 // the payload is dropped with 200 (so the curl hook stays quiet). A nil
 // gate means no gating — used by tests.
-func NewHookHandler(target HookTarget, gate ConsentGate, log outbound.Logger) http.HandlerFunc {
+func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGate, log outbound.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -117,6 +178,23 @@ func NewHookHandler(target HookTarget, gate ConsentGate, log outbound.Logger) ht
 		case HookPermissionRequest, HookPostToolUse, HookPostToolUseFailure:
 			dispatch()
 		case HookPreToolUse:
+			// Marker scan first, for ALL tools (#604): the rules block lets
+			// the agent carry its progress marker in a tool input (e.g. the
+			// Bash description), and the payload reaches the daemon even
+			// when the transcript drops the surrounding prose.
+			if markers != nil {
+				if est := scanToolInputForMarker(payload.ToolInput, time.Now()); est != nil {
+					log.LogInfo("hook-receiver", sessionID,
+						fmt.Sprintf("task-estimate marker via %s tool input: %d/%d", payload.ToolName, est.CompletedRounds, est.TotalRounds))
+					markers.IngestTaskEstimate(payload.TranscriptPath, &session.TaskEstimate{
+						TotalRounds:     est.TotalRounds,
+						CompletedRounds: est.CompletedRounds,
+						Risk:            est.Risk,
+						Confidence:      est.Confidence,
+						UpdatedAt:       est.ObservedAt,
+					})
+				}
+			}
 			// Only dispatch for user-input tools; reject anything else even
 			// if the settings.json matcher was misconfigured to be broader.
 			if payload.ToolName == toolAskUserQuestion || payload.ToolName == toolExitPlanMode {

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+
+	"irrlicht/core/domain/session"
 )
 
 // mockTarget records calls to HandlePermissionHook for assertions.
@@ -59,7 +61,7 @@ func TestSessionIDFromTranscriptPath(t *testing.T) {
 
 func TestHookHandler_PermissionRequest(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, nil, mockLogger{})
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-123.jsonl",
@@ -90,7 +92,7 @@ func TestHookHandler_PermissionRequest(t *testing.T) {
 
 func TestHookHandler_PostToolUse(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, nil, mockLogger{})
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-456.jsonl",
@@ -115,7 +117,7 @@ func TestHookHandler_PostToolUse(t *testing.T) {
 
 func TestHookHandler_PreToolUse(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, nil, mockLogger{})
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-pre.jsonl",
@@ -150,7 +152,7 @@ func TestHookHandler_PreToolUse(t *testing.T) {
 // the sole filter.
 func TestHookHandler_PreToolUse_RejectsUnexpectedTool(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, nil, mockLogger{})
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-x.jsonl",
@@ -174,7 +176,7 @@ func TestHookHandler_PreToolUse_RejectsUnexpectedTool(t *testing.T) {
 
 func TestHookHandler_PostToolUseFailure(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, nil, mockLogger{})
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-789.jsonl",
@@ -199,7 +201,7 @@ func TestHookHandler_PostToolUseFailure(t *testing.T) {
 
 func TestHookHandler_UnrecognizedEvent(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, nil, mockLogger{})
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess.jsonl",
@@ -222,7 +224,7 @@ func TestHookHandler_UnrecognizedEvent(t *testing.T) {
 
 func TestHookHandler_MissingTranscriptPath(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, nil, mockLogger{})
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
 		HookEventName: "PermissionRequest",
@@ -241,7 +243,7 @@ func TestHookHandler_MissingTranscriptPath(t *testing.T) {
 
 func TestHookHandler_WrongMethod(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, nil, mockLogger{})
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/hooks/claudecode", nil)
 	rec := httptest.NewRecorder()
@@ -254,7 +256,7 @@ func TestHookHandler_WrongMethod(t *testing.T) {
 
 func TestHookHandler_MalformedJSON(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, nil, mockLogger{})
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader([]byte("not json")))
 	rec := httptest.NewRecorder()
@@ -272,7 +274,7 @@ func (g fakeGate) Granted(_, _ string) bool { return bool(g) }
 
 func TestHookHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, fakeGate(false), mockLogger{})
+	handler := NewHookHandler(target, nil, fakeGate(false), mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-123.jsonl",
@@ -295,7 +297,7 @@ func TestHookHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 
 func TestHookHandler_ConsentGatePassesWhenGranted(t *testing.T) {
 	target := &mockTarget{}
-	handler := NewHookHandler(target, fakeGate(true), mockLogger{})
+	handler := NewHookHandler(target, nil, fakeGate(true), mockLogger{})
 
 	payload := hookPayload{
 		TranscriptPath: "/Users/u/.claude/projects/p/sess-123.jsonl",
@@ -312,5 +314,117 @@ func TestHookHandler_ConsentGatePassesWhenGranted(t *testing.T) {
 	}
 	if calls := target.getCalls(); len(calls) != 1 {
 		t.Fatalf("calls = %d, want 1", len(calls))
+	}
+}
+
+// mockMarkerTarget records IngestTaskEstimate calls for assertions (#604).
+type mockMarkerTarget struct {
+	mu    sync.Mutex
+	calls []markerCall
+}
+
+type markerCall struct {
+	transcriptPath string
+	est            *session.TaskEstimate
+}
+
+func (m *mockMarkerTarget) IngestTaskEstimate(transcriptPath string, est *session.TaskEstimate) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, markerCall{transcriptPath, est})
+}
+
+func (m *mockMarkerTarget) getCalls() []markerCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]markerCall{}, m.calls...)
+}
+
+func postHook(t *testing.T, handler http.HandlerFunc, payload hookPayload) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	return rec
+}
+
+func TestHookHandler_PreToolUse_MarkerInBashDescription(t *testing.T) {
+	// The #604 carrier: a marker in a Bash description rides the PreToolUse
+	// payload to the daemon, bypassing the transcript writer. The escaped
+	// JSON-in-JSON shape is exactly what Claude Code sends.
+	target := &mockTarget{}
+	markers := &mockMarkerTarget{}
+	handler := NewHookHandler(target, markers, nil, mockLogger{})
+
+	rec := postHook(t, handler, hookPayload{
+		TranscriptPath: "/Users/u/.claude/projects/p/sess-eta.jsonl",
+		HookEventName:  "PreToolUse",
+		ToolName:       "Bash",
+		ToolInput:      json.RawMessage(`{"command":"go test ./...","description":"Run tests <!-- {\"marker\":\"irrlicht-eta\",\"total_rounds\":7,\"completed_rounds\":3} -->"}`),
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	calls := markers.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("got %d IngestTaskEstimate calls, want 1", len(calls))
+	}
+	if calls[0].transcriptPath != "/Users/u/.claude/projects/p/sess-eta.jsonl" {
+		t.Errorf("transcriptPath = %q", calls[0].transcriptPath)
+	}
+	if calls[0].est.TotalRounds != 7 || calls[0].est.CompletedRounds != 3 {
+		t.Errorf("est = %+v, want 3/7", calls[0].est)
+	}
+	if calls[0].est.UpdatedAt == 0 {
+		t.Error("est.UpdatedAt must be stamped at receipt")
+	}
+	// The permission dispatch stays gated to user-input tools: a Bash
+	// PreToolUse must NOT reach HandlePermissionHook.
+	if got := target.getCalls(); len(got) != 0 {
+		t.Errorf("HandlePermissionHook calls = %d, want 0 (two-path split)", len(got))
+	}
+}
+
+func TestHookHandler_PreToolUse_NoMarkerNoIngest(t *testing.T) {
+	markers := &mockMarkerTarget{}
+	handler := NewHookHandler(&mockTarget{}, markers, nil, mockLogger{})
+
+	postHook(t, handler, hookPayload{
+		TranscriptPath: "/Users/u/.claude/projects/p/sess-1.jsonl",
+		HookEventName:  "PreToolUse",
+		ToolName:       "Bash",
+		ToolInput:      json.RawMessage(`{"command":"ls","description":"List files"}`),
+	})
+	// A plain HTML comment without the marker key must not ingest either.
+	postHook(t, handler, hookPayload{
+		TranscriptPath: "/Users/u/.claude/projects/p/sess-1.jsonl",
+		HookEventName:  "PreToolUse",
+		ToolName:       "Write",
+		ToolInput:      json.RawMessage(`{"file_path":"/tmp/x.html","content":"<!-- a comment -->"}`),
+	})
+	if got := markers.getCalls(); len(got) != 0 {
+		t.Errorf("IngestTaskEstimate calls = %d, want 0", len(got))
+	}
+}
+
+func TestHookHandler_PreToolUse_UserInputToolStillDispatchesWithMarkerScan(t *testing.T) {
+	// AskUserQuestion keeps its permission dispatch; an embedded marker in
+	// its input is also picked up — the two paths are independent.
+	target := &mockTarget{}
+	markers := &mockMarkerTarget{}
+	handler := NewHookHandler(target, markers, nil, mockLogger{})
+
+	postHook(t, handler, hookPayload{
+		TranscriptPath: "/Users/u/.claude/projects/p/sess-q.jsonl",
+		HookEventName:  "PreToolUse",
+		ToolName:       "AskUserQuestion",
+		ToolInput:      json.RawMessage(`{"questions":[{"question":"Proceed? <!-- {\"marker\":\"irrlicht-eta\",\"total_rounds\":4,\"completed_rounds\":2} -->"}]}`),
+	})
+	if got := target.getCalls(); len(got) != 1 || got[0].hookEventName != "PreToolUse" {
+		t.Errorf("HandlePermissionHook calls = %+v, want one PreToolUse dispatch", got)
+	}
+	if got := markers.getCalls(); len(got) != 1 || got[0].est.CompletedRounds != 2 {
+		t.Errorf("IngestTaskEstimate calls = %+v, want one 2/4 ingest (nested input walk)", got)
 	}
 }

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -38,6 +38,13 @@ const (
 // file patching, not for the model). Per-agent equivalents
 // (~/.codex/AGENTS.md, ~/.config/opencode/AGENTS.md, ~/.gemini/GEMINI.md)
 // are documented in the issue but not written in v1.
+//
+// v2 (#604/#602): asks for the first marker BEFORE any tool call (drives the
+// 0/N "estimating…" chip within seconds) and permits carrying the marker in
+// a Bash description — text directly before a tool call and tool inputs both
+// survive the claude ≥2.1.162 transcript text-drop that eats mid-task prose.
+// patchManagedBlock's content compare upgrades installed v1 blocks in place
+// on the next daemon start.
 const managedTaskEtaBlock = taskEtaBeginSentinel + `
 ## Task progress markers (managed by Irrlicht)
 
@@ -50,7 +57,10 @@ your response text, and update it as you make progress:
 ` + "```" + `
 
 ` + "`total_rounds`" + ` is your estimate of the task's phases; ` + "`completed_rounds`" + `
-is how many you've finished. Update every few steps.
+is how many you've finished. Emit the first marker in your first response,
+right before your first tool call. Update every few steps; you may also
+append the marker to the ` + "`description`" + ` of a Bash call you are
+already making (never to the command itself).
 ` + taskEtaEndSentinel
 
 // claudeMemoryPath returns the user-level Claude Code instruction file path.

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -112,6 +112,52 @@ func TestEnsureTaskEtaBlock_UpgradesStaleBlock(t *testing.T) {
 	}
 }
 
+func TestEnsureTaskEtaBlock_V1BlockUpgradesToV2(t *testing.T) {
+	// The exact v1 block (shipped with #558) must upgrade in place to the
+	// v2 contract (#604/#602): first marker before any tool call + the Bash
+	// description carrier.
+	home := withTempHome(t)
+	path := memoryPathFor(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v1 := taskEtaBeginSentinel + `
+## Task progress markers (managed by Irrlicht)
+
+As you work on a multi-step task, periodically emit a hidden progress marker
+so tools can show a task-completion estimate. Emit it as an HTML comment in
+your response text, and update it as you make progress:
+
+` + "```" + `
+<!-- {"marker":"irrlicht-eta","total_rounds":N,"completed_rounds":M} -->
+` + "```" + `
+
+` + "`total_rounds`" + ` is your estimate of the task's phases; ` + "`completed_rounds`" + `
+is how many you've finished. Update every few steps.
+` + taskEtaEndSentinel
+	if err := os.WriteFile(path, []byte(v1+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureTaskEtaBlockInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("v1 block should upgrade to v2")
+	}
+	content := readFileString(t, path)
+	if !strings.Contains(content, "first marker in your first response") {
+		t.Error("v2 block must ask for the first marker before any tool call")
+	}
+	if !strings.Contains(content, "`description` of a Bash call") {
+		t.Error("v2 block must permit the Bash description carrier")
+	}
+	if !strings.Contains(content, "never to the command itself") {
+		t.Error("v2 block must forbid the command field (permission matching)")
+	}
+}
+
 func TestPatchManagedBlock_AppendAddsSingleBlankLine(t *testing.T) {
 	for _, existing := range []string{"content", "content\n", "content\n\n\n"} {
 		got, changed := patchManagedBlock(existing, managedTaskEtaBlock)

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -173,10 +173,19 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 			result.RateLimitForecastEta = &etaUnix
 		}
 	}
+	// A fresh in-band marker is the agent's own holistic estimate and wins;
+	// when none survives (claude ≥2.1.162 drops mid-task text blocks, #604)
+	// the estimate is derived from the task list's completion stamps.
+	var estBase *session.TaskEstimate
 	if m.TaskEstimate != nil {
 		result.TaskEstimate = tailerTaskEstimateToDomain(m.TaskEstimate)
-		base := tailerTaskEstimateToDomain(m.TaskEstimateBase)
-		if eta := session.ForecastTaskCompletion(result.TaskEstimate, base, m.ElapsedSeconds, time.Now()); eta != nil {
+		result.TaskEstimate.Source = "marker"
+		estBase = tailerTaskEstimateToDomain(m.TaskEstimateBase)
+	} else {
+		result.TaskEstimate, estBase = session.TaskEstimateFromTasks(result.Tasks)
+	}
+	if result.TaskEstimate != nil {
+		if eta := session.ForecastTaskCompletion(result.TaskEstimate, estBase, m.ElapsedSeconds, time.Now()); eta != nil {
 			etaUnix := eta.Unix()
 			result.TaskCompletionEta = &etaUnix
 		}
@@ -251,6 +260,32 @@ func (a *Adapter) IngestRateLimit(transcriptPath string, snap *session.RateLimit
 	tailerSnap := domainRateLimitToTailer(snap)
 	lt.mu.Lock()
 	lt.t.IngestRateLimit(tailerSnap)
+	lt.mu.Unlock()
+}
+
+// IngestTaskEstimate implements ports/outbound.MetricsCollector. Mirrors
+// IngestRateLimit: hook-delivered estimates (#604) reach the session's
+// tailer when one exists; otherwise no-op — the next ComputeMetrics creates
+// the tailer and the next hook delivery lands.
+func (a *Adapter) IngestTaskEstimate(transcriptPath string, est *session.TaskEstimate) {
+	if transcriptPath == "" || est == nil {
+		return
+	}
+	a.mu.Lock()
+	lt, ok := a.tailers[transcriptPath]
+	a.mu.Unlock()
+	if !ok {
+		return
+	}
+	tailerEst := &tailer.TaskEstimate{
+		TotalRounds:     est.TotalRounds,
+		CompletedRounds: est.CompletedRounds,
+		Risk:            est.Risk,
+		Confidence:      est.Confidence,
+		ObservedAt:      est.UpdatedAt,
+	}
+	lt.mu.Lock()
+	lt.t.IngestTaskEstimate(tailerEst)
 	lt.mu.Unlock()
 }
 
@@ -379,6 +414,7 @@ func tailerTasksToDomain(src []tailer.Task) []session.Task {
 			Description: t.Description,
 			ActiveForm:  t.ActiveForm,
 			Status:      t.Status,
+			CompletedAt: t.CompletedAt,
 		}
 	}
 	return dst

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -126,45 +126,11 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 	if err != nil || m == nil {
 		return nil, nil //nolint:nilerr — absent transcript is not an error
 	}
-	result := &session.SessionMetrics{
-		ElapsedSeconds:                    m.ElapsedSeconds,
-		TotalTokens:                       m.TotalTokens,
-		ModelName:                         m.ModelName,
-		ContextWindow:                     m.ContextWindow,
-		ContextUtilization:                m.ContextUtilization,
-		PressureLevel:                     m.PressureLevel,
-		ContextWindowUnknown:              m.ContextWindowUnknown,
-		HasOpenToolCall:                   m.HasOpenToolCall,
-		OpenToolCallCount:                 m.OpenToolCallCount,
-		OpenSubagents:                     a.countOpenSubagents(adapter, m),
-		BackgroundProcessCount:            m.BackgroundProcessCount,
-		BackgroundProcessOutputs:          m.BackgroundProcessOutputs,
-		LastEventType:                     m.LastEventType,
-		LastOpenToolNames:                 m.LastOpenToolNames,
-		LastWasUserInterrupt:              m.LastWasUserInterrupt,
-		LastWasToolDenial:                 m.LastWasToolDenial,
-		EstimatedCostUSD:                  m.EstimatedCostUSD,
-		CumInputTokens:                    m.CumInputTokens,
-		CumOutputTokens:                   m.CumOutputTokens,
-		CumCacheReadTokens:                m.CumCacheReadTokens,
-		CumCacheCreationTokens:            m.CumCacheCreationTokens,
-		LastCWD:                           m.LastCWD,
-		LastAssistantText:                 m.LastAssistantText,
-		PermissionMode:                    m.PermissionMode,
-		SawUserBlockingToolClosedThisPass: m.SawUserBlockingToolClosedThisPass,
-		NoSubstantiveActivity:             m.NoSubstantiveActivity,
-	}
-	if len(m.SubagentCompletions) > 0 {
-		result.SubagentCompletions = make([]session.SubagentCompletion, len(m.SubagentCompletions))
-		for i, c := range m.SubagentCompletions {
-			result.SubagentCompletions[i] = session.SubagentCompletion{
-				AgentID:   c.AgentID,
-				ToolUseID: c.ToolUseID,
-				Status:    c.Status,
-			}
-		}
-	}
-	result.Tasks = tailerTasksToDomain(m.Tasks)
+	// Plain field copies live in replayengine.TailerToDomain — the single
+	// tailer→domain conversion shared with the replay paths. Everything
+	// below is a live-only enrichment.
+	result := replayengine.TailerToDomain(m)
+	result.OpenSubagents = a.countOpenSubagents(adapter, m)
 	if m.RateLimit != nil {
 		result.RateLimit = tailerRateLimitToDomain(m.RateLimit)
 		history := tailerRateLimitHistoryToDomain(m.RateLimitHistory)
@@ -195,12 +161,6 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 	}
 	if result.PressureLevel == "" {
 		result.PressureLevel = "unknown"
-	}
-	// Trim the rendered snippet to just the question sentence when one is
-	// present, so the macOS overlay shows "What would you like?" instead of
-	// the full surrounding paragraph (issue #236).
-	if snippet := session.ExtractQuestionSnippet(result.LastAssistantText); snippet != "" {
-		result.LastAssistantText = snippet
 	}
 	return result, nil
 }
@@ -401,21 +361,3 @@ func tailerRateLimitHistoryToDomain(src []tailer.RateLimitSnapshot) []session.Ra
 	return dst
 }
 
-// tailerTasksToDomain converts a tailer task slice to the domain mirror type.
-func tailerTasksToDomain(src []tailer.Task) []session.Task {
-	if len(src) == 0 {
-		return nil
-	}
-	dst := make([]session.Task, len(src))
-	for i, t := range src {
-		dst[i] = session.Task{
-			ID:          t.ID,
-			Subject:     t.Subject,
-			Description: t.Description,
-			ActiveForm:  t.ActiveForm,
-			Status:      t.Status,
-			CompletedAt: t.CompletedAt,
-		}
-	}
-	return dst
-}

--- a/core/adapters/outbound/metrics/taskestimate_fallback_test.go
+++ b/core/adapters/outbound/metrics/taskestimate_fallback_test.go
@@ -1,0 +1,175 @@
+package metrics
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/adapters/inbound/agents"
+	"irrlicht/core/adapters/inbound/agents/claudecode"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/pkg/tailer"
+)
+
+// newClaudeCodeAdapter returns a metrics Adapter wired with the real
+// claudecode parser, with HOME pointed at a temp dir so ledger writes stay
+// off the developer's real state.
+func newClaudeCodeAdapter(t *testing.T) *Adapter {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	return New(Registry{
+		Parsers: map[string]agents.ParserFactory{
+			"claude-code": func() tailer.TranscriptParser { return &claudecode.Parser{} },
+		},
+		FallbackName: "claude-code",
+	})
+}
+
+func writeJSONL(t *testing.T, events []map[string]interface{}) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc := json.NewEncoder(f)
+	for _, e := range events {
+		if err := enc.Encode(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	f.Close()
+	return path
+}
+
+func ccToolUse(at time.Time, id, name string, input map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type":      "assistant",
+		"timestamp": at.Format(time.RFC3339),
+		"message": map[string]interface{}{
+			"role":        "assistant",
+			"stop_reason": "tool_use",
+			"content": []interface{}{
+				map[string]interface{}{"type": "tool_use", "id": id, "name": name, "input": input},
+			},
+		},
+	}
+}
+
+func ccText(at time.Time, text string) map[string]interface{} {
+	return map[string]interface{}{
+		"type":      "assistant",
+		"timestamp": at.Format(time.RFC3339),
+		"message": map[string]interface{}{
+			"role":    "assistant",
+			"content": []interface{}{map[string]interface{}{"type": "text", "text": text}},
+		},
+	}
+}
+
+func TestComputeMetrics_TasksFallbackEstimate(t *testing.T) {
+	// No surviving marker (the claude ≥2.1.162 text-drop, #604): the
+	// estimate derives from task completion stamps — 2 of 3 tasks done 60s
+	// apart → 2/3 rounds, source "tasks", projected eta.
+	start := time.Now().Add(-10 * time.Minute).Truncate(time.Second)
+	path := writeJSONL(t, []map[string]interface{}{
+		ccToolUse(start, "tu_1", "TaskCreate", map[string]interface{}{"subject": "one"}),
+		ccToolUse(start, "tu_2", "TaskCreate", map[string]interface{}{"subject": "two"}),
+		ccToolUse(start, "tu_3", "TaskCreate", map[string]interface{}{"subject": "three"}),
+		ccToolUse(start.Add(60*time.Second), "tu_4", "TaskUpdate", map[string]interface{}{"taskId": "1", "status": "completed"}),
+		ccToolUse(start.Add(120*time.Second), "tu_5", "TaskUpdate", map[string]interface{}{"taskId": "2", "status": "completed"}),
+	})
+	m, err := newClaudeCodeAdapter(t).ComputeMetrics(path, "claude-code")
+	if err != nil || m == nil {
+		t.Fatalf("ComputeMetrics: m=%v err=%v", m, err)
+	}
+	if m.TaskEstimate == nil {
+		t.Fatal("expected tasks-derived TaskEstimate, got nil")
+	}
+	if m.TaskEstimate.Source != "tasks" {
+		t.Errorf("Source = %q, want \"tasks\"", m.TaskEstimate.Source)
+	}
+	if m.TaskEstimate.TotalRounds != 3 || m.TaskEstimate.CompletedRounds != 2 {
+		t.Errorf("rounds = %d/%d, want 2/3", m.TaskEstimate.CompletedRounds, m.TaskEstimate.TotalRounds)
+	}
+	if m.TaskEstimate.UpdatedAt != start.Add(120*time.Second).Unix() {
+		t.Errorf("UpdatedAt = %d, want latest completion stamp", m.TaskEstimate.UpdatedAt)
+	}
+	if m.TaskCompletionEta == nil {
+		t.Fatal("expected projected TaskCompletionEta, got nil")
+	}
+	// Delta rate: 60s per task, 1 remaining → eta = latest completion + 60s.
+	if want := start.Add(180 * time.Second).Unix(); *m.TaskCompletionEta != want {
+		t.Errorf("TaskCompletionEta = %d, want %d", *m.TaskCompletionEta, want)
+	}
+}
+
+func TestComputeMetrics_MarkerWinsOverTasks(t *testing.T) {
+	// A surviving in-band marker is the agent's holistic estimate and takes
+	// precedence over the task-list derivation.
+	start := time.Now().Add(-10 * time.Minute).Truncate(time.Second)
+	path := writeJSONL(t, []map[string]interface{}{
+		ccToolUse(start, "tu_1", "TaskCreate", map[string]interface{}{"subject": "one"}),
+		ccToolUse(start.Add(30*time.Second), "tu_2", "TaskUpdate", map[string]interface{}{"taskId": "1", "status": "completed"}),
+		ccText(start.Add(60*time.Second), `Progress. <!-- {"marker":"irrlicht-eta","total_rounds":10,"completed_rounds":4} -->`),
+	})
+	m, err := newClaudeCodeAdapter(t).ComputeMetrics(path, "claude-code")
+	if err != nil || m == nil {
+		t.Fatalf("ComputeMetrics: m=%v err=%v", m, err)
+	}
+	if m.TaskEstimate == nil || m.TaskEstimate.Source != "marker" {
+		t.Fatalf("TaskEstimate = %+v, want marker-sourced", m.TaskEstimate)
+	}
+	if m.TaskEstimate.TotalRounds != 10 || m.TaskEstimate.CompletedRounds != 4 {
+		t.Errorf("rounds = %d/%d, want 4/10 (marker, not 1/1 tasks)", m.TaskEstimate.CompletedRounds, m.TaskEstimate.TotalRounds)
+	}
+}
+
+func TestIngestTaskEstimate_SurfacesOnNextComputeMetrics(t *testing.T) {
+	// A hook-delivered marker (#604) lands in the session's tailer and
+	// shows up — marker-sourced — on the next ComputeMetrics pass.
+	start := time.Now().Add(-2 * time.Minute).Truncate(time.Second)
+	path := writeJSONL(t, []map[string]interface{}{
+		ccText(start, "Working without persisted markers."),
+		// A second event so the session has nonzero elapsed time — the
+		// single-marker forecast path rates against session elapsed.
+		ccText(start.Add(60*time.Second), "Still working."),
+	})
+	a := newClaudeCodeAdapter(t)
+
+	// Unknown path: no tailer yet → silent no-op (matches IngestRateLimit).
+	a.IngestTaskEstimate("/nonexistent.jsonl", &session.TaskEstimate{TotalRounds: 5, CompletedRounds: 1})
+
+	if _, err := a.ComputeMetrics(path, "claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	a.IngestTaskEstimate(path, &session.TaskEstimate{
+		TotalRounds: 5, CompletedRounds: 2, UpdatedAt: start.Add(30 * time.Second).Unix(),
+	})
+	m, err := a.ComputeMetrics(path, "claude-code")
+	if err != nil || m == nil {
+		t.Fatalf("ComputeMetrics: m=%v err=%v", m, err)
+	}
+	if m.TaskEstimate == nil || m.TaskEstimate.CompletedRounds != 2 || m.TaskEstimate.Source != "marker" {
+		t.Fatalf("TaskEstimate = %+v, want hook-ingested 2/5 source=marker", m.TaskEstimate)
+	}
+	if m.TaskCompletionEta == nil {
+		t.Error("expected projected eta from the ingested estimate")
+	}
+}
+
+func TestComputeMetrics_NoMarkerNoTasksNoEstimate(t *testing.T) {
+	start := time.Now().Add(-time.Minute).Truncate(time.Second)
+	path := writeJSONL(t, []map[string]interface{}{
+		ccText(start, "Just working, no tasks, no marker."),
+	})
+	m, err := newClaudeCodeAdapter(t).ComputeMetrics(path, "claude-code")
+	if err != nil || m == nil {
+		t.Fatalf("ComputeMetrics: m=%v err=%v", m, err)
+	}
+	if m.TaskEstimate != nil || m.TaskCompletionEta != nil {
+		t.Errorf("estimate = %+v eta = %v, want nil/nil", m.TaskEstimate, m.TaskCompletionEta)
+	}
+}

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -6,9 +6,12 @@ import (
 )
 
 // TailerToDomain converts the tailer's metrics struct into the domain type
-// consumed by services.ClassifyState. Shared by the replay CLI (both its
-// transcript and sidecar paths) and this engine so the conversion has a
-// single definition.
+// consumed by services.ClassifyState. THE single tailer→domain plain-copy:
+// shared by the replay CLI (both its transcript and sidecar paths), this
+// engine, and the live metrics adapter — which layers its live-only
+// enrichments (subagent counter, rate-limit + ETA forecasts, presentation
+// defaults) on top. Plain field copies belong here so the live and replay
+// paths can't drift (#604 review).
 func TailerToDomain(m *tailer.SessionMetrics) *session.SessionMetrics {
 	if m == nil {
 		return nil
@@ -23,6 +26,8 @@ func TailerToDomain(m *tailer.SessionMetrics) *session.SessionMetrics {
 		ContextWindowUnknown:              m.ContextWindowUnknown,
 		HasOpenToolCall:                   m.HasOpenToolCall,
 		OpenToolCallCount:                 m.OpenToolCallCount,
+		BackgroundProcessCount:            m.BackgroundProcessCount,
+		BackgroundProcessOutputs:          m.BackgroundProcessOutputs,
 		LastEventType:                     m.LastEventType,
 		LastOpenToolNames:                 copyStrings(m.LastOpenToolNames),
 		LastWasUserInterrupt:              m.LastWasUserInterrupt,
@@ -32,10 +37,21 @@ func TailerToDomain(m *tailer.SessionMetrics) *session.SessionMetrics {
 		CumOutputTokens:                   m.CumOutputTokens,
 		CumCacheReadTokens:                m.CumCacheReadTokens,
 		CumCacheCreationTokens:            m.CumCacheCreationTokens,
+		LastCWD:                           m.LastCWD,
 		LastAssistantText:                 m.LastAssistantText,
 		PermissionMode:                    m.PermissionMode,
 		SawUserBlockingToolClosedThisPass: m.SawUserBlockingToolClosedThisPass,
 		NoSubstantiveActivity:             m.NoSubstantiveActivity,
+	}
+	if len(m.SubagentCompletions) > 0 {
+		result.SubagentCompletions = make([]session.SubagentCompletion, len(m.SubagentCompletions))
+		for i, c := range m.SubagentCompletions {
+			result.SubagentCompletions[i] = session.SubagentCompletion{
+				AgentID:   c.AgentID,
+				ToolUseID: c.ToolUseID,
+				Status:    c.Status,
+			}
+		}
 	}
 	if len(m.Tasks) > 0 {
 		result.Tasks = make([]session.Task, len(m.Tasks))

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -46,6 +46,7 @@ func TailerToDomain(m *tailer.SessionMetrics) *session.SessionMetrics {
 				Description: t.Description,
 				ActiveForm:  t.ActiveForm,
 				Status:      t.Status,
+				CompletedAt: t.CompletedAt,
 			}
 		}
 	}

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -167,6 +167,8 @@ func (m *mockMetrics) PruneEntry(path string) { m.pruned = append(m.pruned, path
 
 func (m *mockMetrics) IngestRateLimit(path string, snap *session.RateLimitSnapshot) {}
 
+func (m *mockMetrics) IngestTaskEstimate(path string, est *session.TaskEstimate) {}
+
 // funcMetrics is a metrics collector whose ComputeMetrics behaviour can be
 // configured per test. Used to simulate a tailer that returns refreshed
 // metrics for already-persisted sessions during seedFromDisk.
@@ -188,6 +190,8 @@ func (m *funcMetrics) ComputeMetricsTimeline(path, adapter string) ([]session.Me
 func (m *funcMetrics) PruneEntry(path string) {}
 
 func (m *funcMetrics) IngestRateLimit(path string, snap *session.RateLimitSnapshot) {}
+
+func (m *funcMetrics) IngestTaskEstimate(path string, est *session.TaskEstimate) {}
 
 // --- AgentWatcher mock -------------------------------------------------------
 

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -556,7 +556,7 @@ func main() {
 	// Consent-gated: hooks installed by a pre-consent daemon keep firing
 	// until the wizard is answered, so payloads are dropped while pending.
 	mux.HandleFunc("POST /api/v1/hooks/claudecode",
-		claudecode.NewHookHandler(detector, permService, logger))
+		claudecode.NewHookHandler(detector, metricsCollector, permService, logger))
 
 	// Statusline receiver: Claude Code's per-tick statusline JSON, carrying
 	// rate_limits for Pro/Max subscribers (issue #309). Routes to the

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -219,6 +219,10 @@ type Task struct {
 	Description string `json:"description,omitempty"`
 	ActiveForm  string `json:"active_form,omitempty"`
 	Status      string `json:"status"` // "pending" | "in_progress" | "completed"
+	// CompletedAt is the unix-seconds transcript-event time the task was
+	// observed transitioning to "completed" (0 = unstamped, e.g. completed
+	// before stamping existed). Feeds the tasks-derived ETA rate (#604).
+	CompletedAt int64 `json:"completed_at,omitempty"`
 }
 
 // NeedsUserAttention returns true when a user-blocking tool is open — one

--- a/core/domain/session/task_estimate.go
+++ b/core/domain/session/task_estimate.go
@@ -22,6 +22,63 @@ type TaskEstimate struct {
 	// marker was last observed in. UIs use it to degrade a stale estimate
 	// ("updated 42s ago") instead of letting the ETA drift forever.
 	UpdatedAt int64 `json:"updated_at"`
+	// Source is where the estimate came from: "marker" for the agent's
+	// in-band self-report, "tasks" when derived from the task list (#604).
+	// UIs use it to attribute the estimate in tooltips.
+	Source string `json:"source,omitempty"`
+}
+
+// TaskEstimateFromTasks derives a fallback estimate from the session's task
+// list (#604): claude ≥2.1.162 drops assistant text blocks followed by
+// interleaved thinking from the transcript, so in-band markers rarely
+// survive mid-task — but TaskCreate/TaskUpdate tool calls always persist.
+// One task ≈ one round. Returns (nil, nil) until a task has completed.
+//
+// The pair feeds ForecastTaskCompletion unchanged: est.UpdatedAt anchors at
+// the latest stamped completion, and base reconstructs the state at the
+// FIRST stamped completion so the delta rate spans (latest − first) over
+// the completions between them. Tasks completed before stamping existed
+// (CompletedAt == 0, e.g. restored from an older ledger) still count toward
+// progress but are treated as completed before the first stamp.
+func TaskEstimateFromTasks(tasks []Task) (est, base *TaskEstimate) {
+	completed, stamped := 0, 0
+	var first, latest int64
+	for _, t := range tasks {
+		if t.Status != "completed" {
+			continue
+		}
+		completed++
+		if t.CompletedAt <= 0 {
+			continue
+		}
+		stamped++
+		if first == 0 || t.CompletedAt < first {
+			first = t.CompletedAt
+		}
+		if t.CompletedAt > latest {
+			latest = t.CompletedAt
+		}
+	}
+	if completed == 0 {
+		return nil, nil
+	}
+	est = &TaskEstimate{
+		TotalRounds:     len(tasks),
+		CompletedRounds: completed,
+		UpdatedAt:       latest,
+		Source:          "tasks",
+	}
+	if stamped >= 2 {
+		// At the first stamp, every unstamped completion plus that task
+		// itself was done: perRound = (latest − first) / (stamped − 1).
+		base = &TaskEstimate{
+			TotalRounds:     len(tasks),
+			CompletedRounds: completed - stamped + 1,
+			UpdatedAt:       first,
+			Source:          "tasks",
+		}
+	}
+	return est, base
 }
 
 // ForecastTaskCompletion projects the wall-clock completion time from the

--- a/core/domain/session/task_estimate_test.go
+++ b/core/domain/session/task_estimate_test.go
@@ -100,6 +100,92 @@ func TestForecastTaskCompletion_AllRoundsDone(t *testing.T) {
 	}
 }
 
+func TestTaskEstimateFromTasks_NoCompletions(t *testing.T) {
+	if est, base := TaskEstimateFromTasks(nil); est != nil || base != nil {
+		t.Errorf("no tasks: got (%+v, %+v), want (nil, nil)", est, base)
+	}
+	pending := []Task{{ID: "1", Status: "pending"}, {ID: "2", Status: "in_progress"}}
+	if est, base := TaskEstimateFromTasks(pending); est != nil || base != nil {
+		t.Errorf("no completed tasks: got (%+v, %+v), want (nil, nil)", est, base)
+	}
+}
+
+func TestTaskEstimateFromTasks_DeltaRateThroughForecast(t *testing.T) {
+	// 4 tasks, 2 completed 90s apart → est anchors at the latest completion,
+	// base reconstructs the first → ForecastTaskCompletion's delta rate:
+	// perRound = 90s, remaining 2 → eta = latest + 180s.
+	t1 := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	t2 := t1.Add(90 * time.Second)
+	tasks := []Task{
+		{ID: "1", Status: "completed", CompletedAt: t1.Unix()},
+		{ID: "2", Status: "completed", CompletedAt: t2.Unix()},
+		{ID: "3", Status: "in_progress"},
+		{ID: "4", Status: "pending"},
+	}
+	est, base := TaskEstimateFromTasks(tasks)
+	if est == nil || est.TotalRounds != 4 || est.CompletedRounds != 2 || est.UpdatedAt != t2.Unix() {
+		t.Fatalf("est = %+v, want 2/4 anchored at latest completion", est)
+	}
+	if est.Source != "tasks" {
+		t.Errorf("est.Source = %q, want \"tasks\"", est.Source)
+	}
+	if base == nil || base.CompletedRounds != 1 || base.UpdatedAt != t1.Unix() {
+		t.Fatalf("base = %+v, want 1/4 at first completion", base)
+	}
+	eta := ForecastTaskCompletion(est, base, 9999 /* poisoned session elapsed */, t2.Add(10*time.Second))
+	want := t2.Add(180 * time.Second)
+	if eta == nil || !eta.Equal(want) {
+		t.Errorf("eta = %v, want %v (delta rate from completion stamps)", eta, want)
+	}
+}
+
+func TestTaskEstimateFromTasks_SingleCompletionFallsBack(t *testing.T) {
+	// One stamped completion: no delta to measure → nil base, and the
+	// forecast uses the marker-anchored session-elapsed rate.
+	t1 := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	tasks := []Task{
+		{ID: "1", Status: "completed", CompletedAt: t1.Unix()},
+		{ID: "2", Status: "pending"},
+	}
+	est, base := TaskEstimateFromTasks(tasks)
+	if est == nil || est.CompletedRounds != 1 || base != nil {
+		t.Fatalf("got (%+v, %+v), want (1/2 est, nil base)", est, base)
+	}
+	// 1 round in 60s elapsed → remaining 1 → eta = completion + 60s.
+	eta := ForecastTaskCompletion(est, base, 60, t1)
+	want := t1.Add(60 * time.Second)
+	if eta == nil || !eta.Equal(want) {
+		t.Errorf("eta = %v, want %v (elapsed fallback)", eta, want)
+	}
+}
+
+func TestTaskEstimateFromTasks_UnstampedCompletionsCountAsPreFirst(t *testing.T) {
+	// A completion restored from an older ledger has no stamp: it still
+	// counts toward progress, and the base treats it as done before the
+	// first stamp — rate spans only the stamped interval.
+	t1 := time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC)
+	t2 := t1.Add(40 * time.Second)
+	tasks := []Task{
+		{ID: "1", Status: "completed"}, // unstamped
+		{ID: "2", Status: "completed", CompletedAt: t1.Unix()},
+		{ID: "3", Status: "completed", CompletedAt: t2.Unix()},
+		{ID: "4", Status: "pending"},
+	}
+	est, base := TaskEstimateFromTasks(tasks)
+	if est == nil || est.CompletedRounds != 3 || est.UpdatedAt != t2.Unix() {
+		t.Fatalf("est = %+v, want 3/4 anchored at latest stamp", est)
+	}
+	if base == nil || base.CompletedRounds != 2 || base.UpdatedAt != t1.Unix() {
+		t.Fatalf("base = %+v, want 2/4 at first stamp", base)
+	}
+	// perRound = (t2−t1)/(3−2) = 40s, remaining 1 → eta = t2 + 40s.
+	eta := ForecastTaskCompletion(est, base, 9999, t2)
+	want := t2.Add(40 * time.Second)
+	if eta == nil || !eta.Equal(want) {
+		t.Errorf("eta = %v, want %v", eta, want)
+	}
+}
+
 func TestMergeMetrics_TaskEstimateResetPropagates(t *testing.T) {
 	// No nil carry-over for the estimate: the tailer persists the last-seen
 	// marker itself, so a nil in fresh metrics is a real reset (a new user

--- a/core/e2e/e2e_helpers_test.go
+++ b/core/e2e/e2e_helpers_test.go
@@ -178,6 +178,8 @@ func (m *stubMetrics) PruneEntry(_ string) {}
 
 func (m *stubMetrics) IngestRateLimit(_ string, _ *session.RateLimitSnapshot) {}
 
+func (m *stubMetrics) IngestTaskEstimate(_ string, _ *session.TaskEstimate) {}
+
 // testIdentity is the shared Identity value e2e tests stamp on every
 // watcher they hand to NewSessionDetector. NewSessionDetector's panic
 // guard requires a non-zero Identity; the actual Name doesn't matter to

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -44,6 +44,11 @@ type Task struct {
 	Description string `json:"description,omitempty"`
 	ActiveForm  string `json:"active_form,omitempty"`
 	Status      string `json:"status"` // TaskStatusPending | TaskStatusInProgress | TaskStatusCompleted
+	// CompletedAt is the unix-seconds event time of the observed transition
+	// to TaskStatusCompleted (0 = unstamped, e.g. restored from a pre-#604
+	// ledger). Stamped on the edge only — re-asserted completions keep the
+	// original stamp. Feeds the tasks-derived ETA rate.
+	CompletedAt int64 `json:"completed_at,omitempty"`
 }
 
 // TaskDelta is emitted by the Claude Code parser for each TaskCreate or

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -755,6 +755,16 @@ func (t *TranscriptTailer) FlushIdle() (*SessionMetrics, bool) {
 // the reconcile only acts on pre-existing tasks. t.taskSeq is never reset,
 // so monotonic IDs continue to match Claude's sequential numbering across
 // pruned batches. See issues #282 and #389.
+// eventUnix is the unix-seconds time of a parsed event, 0 when the event
+// carries no timestamp (a 0 CompletedAt means "unstamped", never a stamp at
+// the zero time).
+func eventUnix(parsed *ParsedEvent) int64 {
+	if parsed == nil || parsed.Timestamp.IsZero() {
+		return 0
+	}
+	return parsed.Timestamp.Unix()
+}
+
 func (t *TranscriptTailer) reconcileTaskSnapshot(parsed *ParsedEvent) {
 	if parsed == nil || parsed.TaskSnapshot == nil || len(t.tasks) == 0 {
 		return
@@ -778,6 +788,9 @@ func (t *TranscriptTailer) reconcileTaskSnapshot(parsed *ParsedEvent) {
 		}
 		if entry.Status != "" && entry.Status != t.tasks[i].Status {
 			log.Printf("irrlicht/tailer: reconciling task id=%s status %s → %s from task_reminder in %s", t.tasks[i].ID, t.tasks[i].Status, entry.Status, t.path)
+			if entry.Status == TaskStatusCompleted {
+				t.tasks[i].CompletedAt = eventUnix(parsed)
+			}
 			t.tasks[i].Status = entry.Status
 		}
 		kept = append(kept, t.tasks[i])
@@ -832,6 +845,9 @@ func (t *TranscriptTailer) processParsedEvent(parsed *ParsedEvent, sawUserBlocki
 			for i := range t.tasks {
 				if t.tasks[i].ID == d.ID {
 					if d.Status != "" {
+						if d.Status == TaskStatusCompleted && t.tasks[i].Status != TaskStatusCompleted {
+							t.tasks[i].CompletedAt = eventUnix(parsed)
+						}
 						t.tasks[i].Status = d.Status
 					}
 					break
@@ -921,11 +937,7 @@ func (t *TranscriptTailer) processParsedEvent(parsed *ParsedEvent, sawUserBlocki
 		t.lastAssistantText = ""
 	}
 	if parsed.TaskEstimate != nil {
-		if t.firstTaskEstimate == nil ||
-			(t.lastTaskEstimate != nil && parsed.TaskEstimate.CompletedRounds < t.lastTaskEstimate.CompletedRounds) {
-			t.firstTaskEstimate = parsed.TaskEstimate
-		}
-		t.lastTaskEstimate = parsed.TaskEstimate
+		t.applyTaskEstimate(parsed.TaskEstimate)
 	}
 	if parsed.ClearToolNames && len(parsed.ToolResultIDs) == 0 {
 		// A REAL user message (new prompt, ESC, answer) starts a new task or
@@ -945,4 +957,36 @@ func (t *TranscriptTailer) processParsedEvent(parsed *ParsedEvent, sawUserBlocki
 		Timestamp: parsed.Timestamp,
 		EventType: parsed.EventType,
 	})
+}
+
+// applyTaskEstimate runs the marker anchor bookkeeping shared by the
+// transcript scan and the hook ingest path (#604): track the CURRENT task's
+// first marker (re-anchored when completed_rounds goes backwards — an
+// agent-initiated new count) and let the latest marker win. An estimate
+// observed BEFORE the current latest is dropped — a late hook delivery must
+// not regress a fresher transcript marker (and a stale re-delivery must not
+// falsely re-anchor the rate base). The user-message reset stays in
+// processParsedEvent: it is transcript-line-driven.
+func (t *TranscriptTailer) applyTaskEstimate(est *TaskEstimate) {
+	if est == nil {
+		return
+	}
+	if t.lastTaskEstimate != nil && est.ObservedAt < t.lastTaskEstimate.ObservedAt {
+		return
+	}
+	if t.firstTaskEstimate == nil ||
+		(t.lastTaskEstimate != nil && est.CompletedRounds < t.lastTaskEstimate.CompletedRounds) {
+		t.firstTaskEstimate = est
+	}
+	t.lastTaskEstimate = est
+}
+
+// IngestTaskEstimate feeds an out-of-band task-progress estimate into the
+// same anchor/reset/ledger state as a transcript-scanned marker. Used by the
+// Claude Code hook receiver (#604): markers carried in tool inputs reach the
+// daemon via PreToolUse payloads, bypassing the transcript writer that drops
+// mid-task text blocks on claude ≥2.1.162. Caller (the metrics adapter)
+// holds the per-tailer lock, mirroring IngestRateLimit.
+func (t *TranscriptTailer) IngestTaskEstimate(est *TaskEstimate) {
+	t.applyTaskEstimate(est)
 }

--- a/core/pkg/tailer/task_estimate_test.go
+++ b/core/pkg/tailer/task_estimate_test.go
@@ -45,6 +45,65 @@ func newTaskEstimateTestTailer(path string) *TranscriptTailer {
 	return tl
 }
 
+func TestTailer_IngestTaskEstimate_AnchorsLikeScannedMarker(t *testing.T) {
+	// Hook-delivered estimates (#604) run the same first/last bookkeeping
+	// as transcript-scanned markers: first ingest anchors the base, later
+	// ones advance the latest.
+	path := writeTranscriptLines(t, []map[string]interface{}{{"timestamp": ts(0)}})
+	tl := newTaskEstimateTestTailer(path)
+	tl.IngestTaskEstimate(&TaskEstimate{TotalRounds: 10, CompletedRounds: 3, ObservedAt: 1000})
+	tl.IngestTaskEstimate(&TaskEstimate{TotalRounds: 10, CompletedRounds: 5, ObservedAt: 1060})
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.TaskEstimate == nil || m.TaskEstimate.CompletedRounds != 5 {
+		t.Fatalf("TaskEstimate = %+v, want latest 5/10", m.TaskEstimate)
+	}
+	if m.TaskEstimateBase == nil || m.TaskEstimateBase.CompletedRounds != 3 || m.TaskEstimateBase.ObservedAt != 1000 {
+		t.Fatalf("TaskEstimateBase = %+v, want first ingest 3/10@1000", m.TaskEstimateBase)
+	}
+}
+
+func TestTailer_IngestTaskEstimate_StaleDeliveryIgnored(t *testing.T) {
+	// A late hook delivery older than the current latest must not regress
+	// the estimate or falsely re-anchor the base (its lower CompletedRounds
+	// would otherwise look like an agent-initiated new count).
+	path := writeTranscriptLines(t, []map[string]interface{}{{"timestamp": ts(0)}})
+	tl := newTaskEstimateTestTailer(path)
+	tl.IngestTaskEstimate(&TaskEstimate{TotalRounds: 10, CompletedRounds: 5, ObservedAt: 1060})
+	tl.IngestTaskEstimate(&TaskEstimate{TotalRounds: 10, CompletedRounds: 2, ObservedAt: 900})
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.TaskEstimate == nil || m.TaskEstimate.CompletedRounds != 5 || m.TaskEstimate.ObservedAt != 1060 {
+		t.Fatalf("TaskEstimate = %+v, want 5/10@1060 (stale ingest dropped)", m.TaskEstimate)
+	}
+	if m.TaskEstimateBase == nil || m.TaskEstimateBase.ObservedAt != 1060 {
+		t.Fatalf("TaskEstimateBase = %+v, want unchanged first=latest", m.TaskEstimateBase)
+	}
+}
+
+func TestTailer_IngestTaskEstimate_SurvivesLedgerRoundTrip(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{{"timestamp": ts(0)}})
+	tl := newTaskEstimateTestTailer(path)
+	tl.IngestTaskEstimate(&TaskEstimate{TotalRounds: 8, CompletedRounds: 4, ObservedAt: 2000})
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatal(err)
+	}
+
+	restored := newTaskEstimateTestTailer(path)
+	restored.SetLedgerState(tl.GetLedgerState())
+	m, err := restored.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.TaskEstimate == nil || m.TaskEstimate.CompletedRounds != 4 {
+		t.Fatalf("TaskEstimate = %+v, want ingested 4/8 after restart", m.TaskEstimate)
+	}
+}
+
 func TestTailer_TaskEstimate_SurfacedOnMetrics(t *testing.T) {
 	path := writeTranscriptLines(t, []map[string]interface{}{
 		{"timestamp": ts(0)},

--- a/core/pkg/tailer/task_stamp_test.go
+++ b/core/pkg/tailer/task_stamp_test.go
@@ -1,0 +1,126 @@
+package tailer
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/pkg/capacity"
+)
+
+// taskStampTestParser lifts synthetic "task" / "snap" fields off the line
+// into ParsedEvent task deltas and snapshots, so these tests exercise only
+// the tailer's stamping of CompletedAt (#604) — real TaskCreate/TaskUpdate
+// parsing is covered in the claudecode adapter package.
+type taskStampTestParser struct{}
+
+func (p *taskStampTestParser) ParseLine(raw map[string]interface{}) *ParsedEvent {
+	ev := &ParsedEvent{Timestamp: ParseTimestamp(raw), EventType: "assistant_message"}
+	if v, ok := raw["task"].(map[string]interface{}); ok {
+		d := TaskDelta{}
+		d.Op, _ = v["op"].(string)
+		d.ID, _ = v["id"].(string)
+		d.Subject, _ = v["subject"].(string)
+		d.Status, _ = v["status"].(string)
+		ev.TaskDeltas = []TaskDelta{d}
+	}
+	if v, ok := raw["snap"].([]interface{}); ok {
+		snap := make([]TaskSnapshotEntry, 0, len(v))
+		for _, e := range v {
+			m, _ := e.(map[string]interface{})
+			id, _ := m["id"].(string)
+			status, _ := m["status"].(string)
+			snap = append(snap, TaskSnapshotEntry{ID: id, Status: status})
+		}
+		ev.TaskSnapshot = &snap
+	}
+	return ev
+}
+
+func newTaskStampTestTailer(path string) *TranscriptTailer {
+	tl := NewTranscriptTailer(path, &taskStampTestParser{}, "claude-code")
+	tl.capacityMgr = capacity.NewForTest(testCapacityFixture)
+	return tl
+}
+
+// tsUnix parses the ts(offset)-formatted string back to unix seconds so the
+// expected stamp matches what the parser saw.
+func tsUnix(t *testing.T, stamp string) int64 {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return parsed.Unix()
+}
+
+func TestTailer_TaskCompletedAt_StampedOnDeltaEdge(t *testing.T) {
+	doneAt := ts(5)
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"timestamp": ts(0), "task": map[string]interface{}{"op": "create", "subject": "build"}},
+		{"timestamp": ts(2), "task": map[string]interface{}{"op": "update", "id": "1", "status": "in_progress"}},
+		{"timestamp": doneAt, "task": map[string]interface{}{"op": "update", "id": "1", "status": "completed"}},
+	})
+	m, err := newTaskStampTestTailer(path).TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Tasks) != 1 || m.Tasks[0].Status != TaskStatusCompleted {
+		t.Fatalf("tasks = %+v, want one completed task", m.Tasks)
+	}
+	if got, want := m.Tasks[0].CompletedAt, tsUnix(t, doneAt); got != want {
+		t.Errorf("CompletedAt = %d, want %d (event time of the completed transition)", got, want)
+	}
+}
+
+func TestTailer_TaskCompletedAt_EdgeOnly(t *testing.T) {
+	// A re-asserted completed status must not move the original stamp, and
+	// an in_progress transition must not stamp at all.
+	doneAt := ts(3)
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"timestamp": ts(0), "task": map[string]interface{}{"op": "create", "subject": "build"}},
+		{"timestamp": doneAt, "task": map[string]interface{}{"op": "update", "id": "1", "status": "completed"}},
+		{"timestamp": ts(9), "task": map[string]interface{}{"op": "update", "id": "1", "status": "completed"}},
+	})
+	tl := newTaskStampTestTailer(path)
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := m.Tasks[0].CompletedAt, tsUnix(t, doneAt); got != want {
+		t.Errorf("CompletedAt = %d, want %d (re-assert must keep the first stamp)", got, want)
+	}
+
+	appendTranscriptLine(t, path, map[string]interface{}{
+		"timestamp": ts(10), "task": map[string]interface{}{"op": "create", "subject": "test"},
+	})
+	appendTranscriptLine(t, path, map[string]interface{}{
+		"timestamp": ts(11), "task": map[string]interface{}{"op": "update", "id": "2", "status": "in_progress"},
+	})
+	m, err = tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Tasks[1].CompletedAt != 0 {
+		t.Errorf("CompletedAt = %d, want 0 (in_progress must not stamp)", m.Tasks[1].CompletedAt)
+	}
+}
+
+func TestTailer_TaskCompletedAt_StampedOnSnapshotReconcile(t *testing.T) {
+	// A task_reminder snapshot flipping a task to completed stamps the
+	// reconciling event's time (issue #282 path).
+	snapAt := ts(7)
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"timestamp": ts(0), "task": map[string]interface{}{"op": "create", "subject": "build"}},
+		{"timestamp": snapAt, "snap": []interface{}{map[string]interface{}{"id": "1", "status": "completed"}}},
+	})
+	m, err := newTaskStampTestTailer(path).TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Tasks) != 1 || m.Tasks[0].Status != TaskStatusCompleted {
+		t.Fatalf("tasks = %+v, want one completed task", m.Tasks)
+	}
+	if got, want := m.Tasks[0].CompletedAt, tsUnix(t, snapAt); got != want {
+		t.Errorf("CompletedAt = %d, want %d (snapshot reconcile must stamp)", got, want)
+	}
+}

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -124,6 +124,13 @@ type MetricsCollector interface {
 	// hasn't been created yet — the next ComputeMetrics will create one
 	// and the next statusline tick will populate it.
 	IngestRateLimit(transcriptPath string, snap *session.RateLimitSnapshot)
+	// IngestTaskEstimate attaches an out-of-band task-progress estimate to
+	// the session associated with transcriptPath (#604). Used by the Claude
+	// Code hook receiver for markers carried in PreToolUse tool inputs —
+	// they bypass the transcript writer, which drops mid-task text blocks
+	// on claude ≥2.1.162. Same no-op-without-tailer semantics as
+	// IngestRateLimit.
+	IngestTaskEstimate(transcriptPath string, est *session.TaskEstimate)
 }
 
 // PushBroadcaster fans out session state changes to subscribers (e.g. WebSocket clients).

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -117,6 +117,7 @@ struct TaskEstimateInfo: Codable, Hashable {
     let risk: String?
     let confidence: Double?
     let updatedAt: Date?    // when the marker was last observed (staleness degrade)
+    let source: String?     // "marker" | "tasks" — attribution for the tooltip (#604)
 
     enum CodingKeys: String, CodingKey {
         case totalRounds = "total_rounds"
@@ -124,14 +125,16 @@ struct TaskEstimateInfo: Codable, Hashable {
         case risk
         case confidence
         case updatedAt = "updated_at"
+        case source
     }
 
-    init(totalRounds: Int, completedRounds: Int, risk: String? = nil, confidence: Double? = nil, updatedAt: Date? = nil) {
+    init(totalRounds: Int, completedRounds: Int, risk: String? = nil, confidence: Double? = nil, updatedAt: Date? = nil, source: String? = nil) {
         self.totalRounds = totalRounds
         self.completedRounds = completedRounds
         self.risk = risk
         self.confidence = confidence
         self.updatedAt = updatedAt
+        self.source = source
     }
 
     init(from decoder: Decoder) throws {
@@ -145,6 +148,7 @@ struct TaskEstimateInfo: Codable, Hashable {
         } else {
             updatedAt = nil
         }
+        source = try c.decodeIfPresent(String.self, forKey: .source)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -154,6 +158,7 @@ struct TaskEstimateInfo: Codable, Hashable {
         try c.encodeIfPresent(risk, forKey: .risk)
         try c.encodeIfPresent(confidence, forKey: .confidence)
         try c.encodeIfPresent(updatedAt.map { $0.timeIntervalSince1970 }, forKey: .updatedAt)
+        try c.encodeIfPresent(source, forKey: .source)
     }
 }
 

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1457,16 +1457,30 @@ struct SessionRowView: View {
     }
 
     /// Decides the task-completion ETA chip (issue #558) — mirrors the web's
-    /// taskEtaPresentation. Nil hides the chip: session not working, no
-    /// estimate, or no reported progress. A point estimate once half the
-    /// rounds are done, a range below that, and stale dimming when the last
-    /// marker is older than 3 minutes.
+    /// taskEtaPresentation. Nil hides the chip: session not working or no
+    /// estimate. Zero completed rounds renders a progress-only "estimating…"
+    /// chip (#602); with progress, a point estimate once half the rounds are
+    /// done, a range below that, and stale dimming when the last marker is
+    /// older than 3 minutes.
     private func taskEtaPresentation(now: Date = Date()) -> TaskEtaPresentation? {
         guard session.state == .working,
               let metrics = session.metrics,
-              let est = metrics.taskEstimate,
-              let eta = metrics.taskCompletionEta,
-              est.completedRounds > 0 else { return nil }
+              let est = metrics.taskEstimate else { return nil }
+        let sourceLabel = est.source == "tasks" ? "from task list" : "agent-reported"
+        guard est.completedRounds > 0 else {
+            // No measurable rate yet, but the agent committed to a plan —
+            // immediate feedback beats waiting for the first round (#602).
+            guard est.totalRounds > 0 else { return nil }
+            var stale = false
+            var title = "Task ETA — \(sourceLabel) 0/\(est.totalRounds) rounds"
+            if let updated = est.updatedAt {
+                let age = max(0, now.timeIntervalSince(updated))
+                stale = age > 180
+                title += ", updated \(Int(age))s ago"
+            }
+            return TaskEtaPresentation(text: "estimating…", stale: stale, title: title)
+        }
+        guard let eta = metrics.taskCompletionEta else { return nil }
         let remaining = max(0, eta.timeIntervalSince(now))
         let frac = est.totalRounds > 0 ? Double(est.completedRounds) / Double(est.totalRounds) : 0
         // The eta is anchored at the marker (daemon-side): the LOW bound
@@ -1483,7 +1497,7 @@ struct SessionRowView: View {
         }
         let text = etaText(remaining: remaining, highSecs: highSecs)
         var stale = false
-        var title = "Task ETA — agent-reported \(est.completedRounds)/\(est.totalRounds) rounds"
+        var title = "Task ETA — \(sourceLabel) \(est.completedRounds)/\(est.totalRounds) rounds"
         if let updated = est.updatedAt {
             let age = max(0, now.timeIntervalSince(updated))
             stale = age > 180

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -62,6 +62,40 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertEqual(session.lastEvent, "UserPromptSubmit")
     }
     
+    func testTaskEstimateSourceDecodes() throws {
+        // The estimate's source ("marker" | "tasks", #604) attributes the
+        // tooltip; absent source (pre-#604 daemon) decodes as nil.
+        let jsonData = """
+        {
+            "session_id": "sess_eta",
+            "state": "working",
+            "metrics": {
+                "task_estimate": {"total_rounds": 5, "completed_rounds": 2, "updated_at": 1769000000, "source": "tasks"}
+            }
+        }
+        """.data(using: .utf8)!
+
+        let session = try JSONDecoder().decode(SessionState.self, from: jsonData)
+        let est = try XCTUnwrap(session.metrics?.taskEstimate)
+        XCTAssertEqual(est.source, "tasks")
+        XCTAssertEqual(est.totalRounds, 5)
+        XCTAssertEqual(est.completedRounds, 2)
+
+        let noSource = """
+        {
+            "session_id": "sess_eta2",
+            "state": "working",
+            "metrics": {
+                "task_estimate": {"total_rounds": 5, "completed_rounds": 0}
+            }
+        }
+        """.data(using: .utf8)!
+        let session2 = try JSONDecoder().decode(SessionState.self, from: noSource)
+        let est2 = try XCTUnwrap(session2.metrics?.taskEstimate)
+        XCTAssertNil(est2.source)
+        XCTAssertEqual(est2.completedRounds, 0)
+    }
+
     func testInvalidJSONHandling() {
         let invalidJSON = """
         {

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -421,7 +421,19 @@
     function taskEtaPresentation(metrics, state, nowSec) {
       const est = metrics && metrics.task_estimate;
       const eta = metrics && metrics.task_completion_eta;
-      if (state !== 'working' || !est || !eta || !(est.completed_rounds > 0)) return null;
+      if (state !== 'working' || !est) return null;
+      const sourceLabel = est.source === 'tasks' ? 'from task list' : 'agent-reported';
+      // No completed rounds yet: no measurable rate, but the agent HAS
+      // committed to a plan — show a progress-only chip so the user gets
+      // feedback within seconds of the first marker (issue #604/#602).
+      if (!(est.completed_rounds > 0)) {
+        if (!(est.total_rounds > 0)) return null;
+        const age = est.updated_at > 0 ? Math.max(0, Math.floor(nowSec - est.updated_at)) : 0;
+        let zeroTitle = 'Task ETA — ' + sourceLabel + ' 0/' + est.total_rounds + ' rounds';
+        if (est.updated_at > 0) zeroTitle += ', updated ' + fmtDuration(age) + ' ago';
+        return { text: 'estimating…', stale: est.updated_at > 0 && age > 180, title: zeroTitle };
+      }
+      if (!eta) return null;
       const remaining = Math.max(0, Math.floor(eta - nowSec));
       const frac = est.total_rounds > 0 ? est.completed_rounds / est.total_rounds : 0;
       let highSecs = null;
@@ -433,7 +445,7 @@
       const text = fmtEtaText(remaining, highSecs);
       const ageSec = est.updated_at > 0 ? Math.max(0, Math.floor(nowSec - est.updated_at)) : 0;
       const stale = est.updated_at > 0 && ageSec > 180;
-      let title = 'Task ETA — agent-reported ' + est.completed_rounds + '/' + est.total_rounds + ' rounds';
+      let title = 'Task ETA — ' + sourceLabel + ' ' + est.completed_rounds + '/' + est.total_rounds + ' rounds';
       if (est.updated_at > 0) title += ', updated ' + fmtDuration(ageSec) + ' ago';
       return { text: text, stale: stale, title: title };
     }
@@ -972,7 +984,7 @@
         etaEl.textContent = etaInfo.text;
         etaEl.title = etaInfo.title;
         etaEl.classList.toggle('stale', etaInfo.stale);
-        etaEl.dataset.eta = metrics.task_completion_eta;
+        etaEl.dataset.eta = metrics.task_completion_eta || '';
         etaEl.dataset.total = metrics.task_estimate.total_rounds;
         etaEl.dataset.completed = metrics.task_estimate.completed_rounds;
         etaEl.dataset.updatedAt = metrics.task_estimate.updated_at || '';

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -385,10 +385,33 @@ describe('taskEtaPresentation', () => {
     expect(taskEtaPresentation(metricsFor(), 'ready', now)).toBeNull()
   })
 
-  test('suppressed without estimate, eta, or reported progress', () => {
+  test('suppressed without estimate, or with progress but no eta', () => {
     expect(taskEtaPresentation({}, 'working', now)).toBeNull()
     expect(taskEtaPresentation(metricsFor({ metrics: { task_completion_eta: undefined } }), 'working', now)).toBeNull()
-    expect(taskEtaPresentation(metricsFor({ est: { completed_rounds: 0 } }), 'working', now)).toBeNull()
+  })
+
+  test('zero completed rounds renders a progress-only chip (#602)', () => {
+    // No measurable rate yet, but the agent committed to a plan — show
+    // "estimating…" immediately instead of waiting for the first round.
+    const m = metricsFor({ est: { completed_rounds: 0 }, metrics: { task_completion_eta: undefined } })
+    const info = taskEtaPresentation(m, 'working', now)
+    expect(info).not.toBeNull()
+    expect(info.text).toBe('estimating…')
+    expect(info.stale).toBe(false)
+    expect(info.title).toContain('0/10 rounds')
+  })
+
+  test('zero completed rounds: stale past 3min, hidden without total or while not working', () => {
+    const zero = (over) => metricsFor({ est: { completed_rounds: 0, ...(over || {}) }, metrics: { task_completion_eta: undefined } })
+    expect(taskEtaPresentation(zero({ updated_at: now - 200 }), 'working', now).stale).toBe(true)
+    expect(taskEtaPresentation(zero({ total_rounds: 0 }), 'working', now)).toBeNull()
+    expect(taskEtaPresentation(zero(), 'ready', now)).toBeNull()
+  })
+
+  test('tooltip attributes the estimate source (#604)', () => {
+    expect(taskEtaPresentation(metricsFor(), 'working', now).title).toContain('agent-reported')
+    const tasks = metricsFor({ est: { source: 'tasks' } })
+    expect(taskEtaPresentation(tasks, 'working', now).title).toContain('from task list')
   })
 
   test('eta in the past clamps to <1m, never negative — one sign only', () => {


### PR DESCRIPTION
Closes #604, closes #602.

## Why

claude ≥2.1.162 drops assistant text blocks followed by interleaved thinking from the transcript JSONL (`[thinking, text, thinking, tools]` → `[thinking, thinking, tools]`). The #558 ETA markers ride in exactly those blocks, so mid-task markers rarely reach the daemon and the chip (gated on `working && completed_rounds>0 && eta`) effectively never rendered. `tool_use` blocks are NOT dropped — all three layers lean on that.

## What

**A — tasks-derived fallback** (primary; agent does nothing special)
- `CompletedAt` stamped on the →completed edge in the tailer (delta apply + `task_reminder` snapshot reconcile), event-time, edge-only; ledger-additive, no schema bump
- `session.TaskEstimateFromTasks(tasks)` synthesizes est+base from completion stamps — rate spans the stamped interval; unstamped pre-#604 completions count as pre-first-stamp progress
- metrics adapter precedence: surviving marker wins (`source:"marker"`), task list fills the gap (`source:"tasks"`); same `ForecastTaskCompletion` seam

**C — instant feedback (#602)**
- 0/N renders a progress-only `estimating…` chip while working, web + macOS in lockstep; tooltips attribute the source ("agent-reported" / "from task list")
- managed rules block **v2**: first marker before any tool call (a drop-surviving text slot) + Bash-`description` carrier; installed v1 blocks auto-upgrade via the existing stale-block patch

**B — hook marker carrier** (bypasses the transcript writer)
- `NewHookHandler` gains a `MarkerTarget` (mirrors statusline's `RateLimitTarget`); PreToolUse `tool_input` is scanned for markers across ALL tools while the permission dispatch stays strictly gated to `AskUserQuestion`/`ExitPlanMode` — two independent paths, not a gate relaxation
- scan decodes the input and walks string values (escaped quotes defeat raw-byte scanning); fast-reject accepts plain and HTML-escaped comment openers
- `IngestTaskEstimate` port → metrics adapter → `tailer.IngestTaskEstimate` shares the exact anchor/re-anchor/ledger path as transcript markers + an out-of-order guard (a late hook delivery can't regress a fresher marker or falsely re-anchor the rate base)

## Verification

- `go test ./core/... -race -count=1` ✅ (2 `services` tests are load-flaky under full-suite race, pass clean on rerun — pre-existing, #578 family)
- factory suite ✅ · `tools/replay-fixtures.sh` ✅ with `replaydata/` byte-stable · `of validate` ✅
- web `npm test` 79/79 ✅ · Swift: new decode test ✅ (5 `GroupViewSnapshot` failures reproduce on clean main — environment, unrelated)
- **Live e2e** (isolated daemon): tasks-only session → `source:"tasks"`, eta = latest completion + measured per-task delta, exactly; synthetic PreToolUse marker POST → `source:"marker"` override with fresh eta on next recompute

🤖 Generated with [Claude Code](https://claude.com/claude-code)