### PR TITLE
feat(macos): menu-bar attention icon for pending permission items

### DIFF
--- a/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
@@ -2,14 +2,42 @@ import AppKit
 
 @MainActor
 enum MenuBarImageBuilder {
+    /// Which icon family the status item shows. Pure decision, extracted so
+    /// the priority order is unit-testable without a SessionManager.
+    enum IconState: Equatable {
+        case attention // pending permission items — human must act
+        case dots      // session-state circles
+        case off       // no sessions, nothing pending
+    }
+
+    /// Pending consent outranks everything: while items are unanswered the
+    /// daemon isn't monitoring those agents, so the bar must say "act to
+    /// make me work again" — not show dots or the idle flame.
+    static func iconState(pendingConsentCount: Int, sessionCount: Int) -> IconState {
+        if pendingConsentCount > 0 { return .attention }
+        if sessionCount > 0 { return .dots }
+        return .off
+    }
+
     static func build(
         sessionManager: SessionManager,
         gasTownProvider: GasTownProvider
     ) -> NSImage {
-        if let combined = combinedImage(sessionManager: sessionManager, gasTownProvider: gasTownProvider) {
-            return combined
+        switch iconState(
+            pendingConsentCount: sessionManager.pendingWizardAgents.count,
+            sessionCount: sessionManager.sessions.count
+        ) {
+        case .attention:
+            // Full replacement — also suppresses the Gas Town badge so the
+            // "do something" signal stays unambiguous; it returns once all
+            // items are answered.
+            return OffFlameImage.attention
+        case .dots, .off:
+            if let combined = combinedImage(sessionManager: sessionManager, gasTownProvider: gasTownProvider) {
+                return combined
+            }
+            return OffFlameImage.menuBar
         }
-        return OffFlameImage.menuBar
     }
 
     private static func combinedImage(

--- a/platforms/macos/Irrlicht/App/OffFlameImage.swift
+++ b/platforms/macos/Irrlicht/App/OffFlameImage.swift
@@ -4,9 +4,14 @@ import AppKit
 enum OffFlameImage {
     static let menuBar = build(pointSize: 18, config: .menuBar)
     static let overlaySlashed = build(pointSize: 24, config: .overlaySlashed)
+    static let attention = build(pointSize: 18, config: .attention)
 
-    private struct Config {
+    // Internal (not private) so tests can assert on the generated SVG —
+    // same text-assertion pattern as MenuBarStatusRendererTests.
+    struct Config {
         let bodyStops: String
+        // Extra SVG painted after the flame path (document order = z-order):
+        // the slashed overlay's strike-through, the attention badge, etc.
         let slash: String
         let accessibilityDescription: String?
 
@@ -34,11 +39,43 @@ enum OffFlameImage {
             // Surrounding Text already announces the empty state.
             accessibilityDescription: nil
         )
+
+        // "Action required" (#593 follow-up): pending permission items mean
+        // monitoring is paused until the human answers the wizard. Orange
+        // flame (waiting hue) + red exclamation badge — must read as "do
+        // something", clearly distinct from the gray no-sessions flame.
+        static let attention = Config(
+            bodyStops: """
+            <stop offset="0%" stop-color="#FF9500" stop-opacity="0.95"/>
+            <stop offset="100%" stop-color="#FF7A00" stop-opacity="0.95"/>
+            """,
+            // Red badge bottom-right with a white exclamation. White outline
+            // separates the badge from the orange flame at 18 pt.
+            slash: """
+            <circle cx="990" cy="990" r="240" fill="#FF3B30" stroke="#FFFFFF" stroke-width="40"/>
+            <line x1="990" y1="860" x2="990" y2="1040" stroke="#FFFFFF" stroke-width="72" stroke-linecap="round"/>
+            <circle cx="990" cy="1125" r="46" fill="#FFFFFF"/>
+            """,
+            accessibilityDescription: "Irrlicht — action required: permission pending"
+        )
     }
 
     private static func build(pointSize: CGFloat, config: Config) -> NSImage {
+        let svg = buildSVG(pointSize: pointSize, config: config)
+        guard let data = svg.data(using: .utf8),
+              let image = NSImage(data: data) else {
+            return NSImage()
+        }
+        image.isTemplate = false
+        image.size = NSSize(width: pointSize, height: pointSize)
+        image.accessibilityDescription = config.accessibilityDescription
+        return image
+    }
+
+    // Internal so tests can assert on the markup without rendering.
+    static func buildSVG(pointSize: CGFloat, config: Config) -> String {
         let size = Int(pointSize.rounded())
-        let svg = """
+        return """
         <svg xmlns="http://www.w3.org/2000/svg" width="\(size)" height="\(size)" viewBox="0 0 1254 1254">
         <defs>
         <linearGradient id="wisp-off-body" x1="50%" y1="100%" x2="50%" y2="0%">
@@ -49,13 +86,5 @@ enum OffFlameImage {
         \(config.slash)
         </svg>
         """
-        guard let data = svg.data(using: .utf8),
-              let image = NSImage(data: data) else {
-            return NSImage()
-        }
-        image.isTemplate = false
-        image.size = NSSize(width: pointSize, height: pointSize)
-        image.accessibilityDescription = config.accessibilityDescription
-        return image
     }
 }

--- a/platforms/macos/Tests/MenuBarImageBuilderTests.swift
+++ b/platforms/macos/Tests/MenuBarImageBuilderTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Irrlicht
+
+/// Menu-bar attention indicator for pending permission items: while any
+/// consent item is unanswered the icon is fully replaced by the orange
+/// attention flame — dots/off return once everything is answered.
+@MainActor
+final class MenuBarImageBuilderTests: XCTestCase {
+    func testIconStatePicksAttentionWhenConsentPending() {
+        // Attention outranks dots — even with live sessions.
+        XCTAssertEqual(
+            MenuBarImageBuilder.iconState(pendingConsentCount: 1, sessionCount: 3),
+            .attention
+        )
+    }
+
+    func testIconStateReturnsDotsWhenNoPendingConsent() {
+        XCTAssertEqual(
+            MenuBarImageBuilder.iconState(pendingConsentCount: 0, sessionCount: 2),
+            .dots
+        )
+    }
+
+    func testIconStateReturnsOffWhenIdle() {
+        XCTAssertEqual(
+            MenuBarImageBuilder.iconState(pendingConsentCount: 0, sessionCount: 0),
+            .off
+        )
+    }
+
+    func testAttentionSVGUsesOrangeBodyAndExclamationBadge() {
+        let svg = OffFlameImage.buildSVG(pointSize: 18, config: .attention)
+        // Orange flame body — not the gray no-sessions stops.
+        XCTAssertTrue(svg.contains("#FF9500"), "attention body should be orange")
+        XCTAssertFalse(svg.contains("#9ca3af"), "attention must not reuse the gray no-sessions stops")
+        // Red badge with the white exclamation (stem + dot).
+        XCTAssertTrue(svg.contains("#FF3B30"), "badge should be red")
+        XCTAssertTrue(svg.contains("stroke-linecap=\"round\""), "exclamation stem should be present")
+        XCTAssertTrue(svg.contains("<circle cx=\"990\" cy=\"1125\""), "exclamation dot should be present")
+    }
+
+    func testAttentionImageCarriesAccessibilityDescription() {
+        XCTAssertEqual(
+            OffFlameImage.attention.accessibilityDescription,
+            "Irrlicht — action required: permission pending"
+        )
+    }
+}


### PR DESCRIPTION
## What

Since the consent-first permission wizard (#570/#571), pending consent items mean the daemon monitors **nothing** for those agents until the human answers — but the menu bar gave no signal. This replaces the menu-bar icon with an **orange eyed-flame + red exclamation badge** while anything is pending: "hey human, do something to make me work again." Status dots / the idle flame return the moment every item is answered (granted *or* denied — only `pending` triggers).

## How

- **`OffFlameImage`**: extracted `buildSVG(pointSize:config:)` (internal, text-assertable like `MenuBarStatusRenderer`), added a `.attention` config — orange body stops (`#FF9500→#FF7A00`), red `#FF3B30` badge with white-stroked exclamation, painted through the existing post-path SVG injection point. Accessibility: *"Irrlicht — action required: permission pending"*.
- **`MenuBarImageBuilder`**: pure `IconState` decision (`attention > dots > off`) fed by `sessionManager.pendingWizardAgents` — that property already handles every edge case (nil snapshot, `grant-all` mode, undetected agents) and is `@Published`-driven, so the existing `MenuBarController` rebuild subscription needed no change. The attention branch returns before `combinedImage`, deliberately suppressing the Gas Town ⛽ badge while pending (single unambiguous signal; it returns automatically).

## Tests

5 new tests in `MenuBarImageBuilderTests`: IconState priority ×3 (attention wins over dots; dots; off), attention-SVG markup (orange + red badge + exclamation, no gray no-sessions stops), accessibility description.

## Verification

- `swift build` + `swift test --filter "MenuBarImageBuilder|MenuBarStatusRenderer"` — 12/12 green.
- Full `swift test`: the 5 `GroupViewSnapshotTests` failures are **pre-existing on pristine main** on this machine (environment-sensitive snapshot references) — verified by running them on an untouched main checkout; unrelated to this change.
- Live: isolated daemon on 7838 with a fresh `IRRLICHT_HOME` and no grant-all → 6 detected agents pending → attention icon replaces the menu-bar icon; user-confirmed visually ("looks fantastic"). Production stack on 7837 untouched throughout.
- Only `platforms/macos` touched — Go/web gates unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)