### PR TITLE
feat(install): ship irrlicht-ls in the default install

### DIFF
--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -347,8 +347,10 @@ All tests must pass before proceeding.
 > tools/build-release.sh
 > ```
 >
-> It builds the universal daemon + `irrlicht-focus`, the Linux tarballs,
-> assembles + DevID-signs the bundle, notarizes + staples the DMG, builds the
+> It builds the universal daemon + `irrlicht-focus` + `irrlicht-ls` (embedded
+> in the bundle; the PKG postinstall symlinks `irrlicht-ls` into
+> `/usr/local/bin` — #608), the Linux tarballs, assembles + DevID-signs the
+> bundle, notarizes + staples the DMG, builds the
 > PKG, and writes `.build/checksums.sha256`. It does **NOT** do four things —
 > do them by hand afterward:
 > 1. **ZIP**: `ditto -c -k --sequesterRsrc --keepParent .build/Irrlicht.app .build/Irrlicht-$NEW_VERSION.zip`

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Stages: `stable` production-ready · `beta` feature-complete, edge cases remain 
 | --------------------- | ------- | ------------------------- |
 | macOS (menu bar app)  | beta    | [Releases](https://github.com/ingo-eichhorst/Irrlicht/releases/latest) |
 | Web dashboard         | beta    | `http://127.0.0.1:7837`   |
-| CLI                   | alpha   | `irrlicht-ls` (`-w` for watch) |
+| CLI                   | alpha   | `irrlicht-ls` (`-w` for watch) — on PATH after install; DMG drag-installs: Settings → Install Command-Line Tool |
 | VS Code extension     | planned | tracked in [#350](https://github.com/ingo-eichhorst/Irrlicht/issues/350) |
 | Linux (daemon-only)   | alpha   | `curl -fsSL https://irrlicht.io/install.sh \| sh` |
 | Windows               | planned | —                         |

--- a/platforms/macos/Irrlicht/Managers/CLIToolInstaller.swift
+++ b/platforms/macos/Irrlicht/Managers/CLIToolInstaller.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Installs the bundle-embedded `irrlicht-ls` CLI onto the user's PATH via a
+/// symlink. Consent-first (#608): nothing happens at launch — the PKG
+/// installer and `install.sh` link automatically, and DMG drag-install users
+/// click "Install Command-Line Tool" in Settings, which lands here.
+enum CLIToolInstaller {
+    /// Candidate bin directories, in preference order. `/usr/local/bin` is on
+    /// the default PATH but usually root-owned; `/opt/homebrew/bin` is
+    /// user-writable on Apple Silicon Homebrew setups.
+    static let defaultCandidates = ["/usr/local/bin", "/opt/homebrew/bin"]
+
+    enum Status: Equatable {
+        case unavailable          // binary not in this bundle (dev builds)
+        case notInstalled
+        case installed(path: String)
+    }
+
+    enum InstallResult: Equatable {
+        case installed(path: String)
+        case failed(message: String)
+    }
+
+    /// The embedded CLI binary — same aux-executable pattern as
+    /// DaemonManager.bundledDaemonURL. Nil in SwiftPM dev bundles, which
+    /// don't embed the Go binaries.
+    static var bundledLs: URL? {
+        guard let url = Bundle.main.url(forAuxiliaryExecutable: "irrlicht-ls"),
+              FileManager.default.isExecutableFile(atPath: url.path) else {
+            return nil
+        }
+        return url
+    }
+
+    static func status(candidates: [String] = defaultCandidates) -> Status {
+        guard let source = bundledLs else { return .unavailable }
+        let fm = FileManager.default
+        for dir in candidates {
+            let link = dir + "/irrlicht-ls"
+            if let dest = try? fm.destinationOfSymbolicLink(atPath: link),
+               URL(fileURLWithPath: dest).standardizedFileURL == source.standardizedFileURL {
+                return .installed(path: link)
+            }
+        }
+        return .notInstalled
+    }
+
+    /// First writable candidate directory, or nil when none qualifies.
+    /// Pure given the injected writability check — the unit-test seam.
+    static func chooseTarget(
+        candidates: [String],
+        isWritableDir: (String) -> Bool = { dir in
+            var isDir: ObjCBool = false
+            return FileManager.default.fileExists(atPath: dir, isDirectory: &isDir)
+                && isDir.boolValue
+                && FileManager.default.isWritableFile(atPath: dir)
+        }
+    ) -> String? {
+        candidates.first(where: isWritableDir)
+    }
+
+    /// Create (or refresh) the symlink in the first writable candidate.
+    /// Refuses to replace a regular file — only stale symlinks are replaced.
+    static func install(candidates: [String] = defaultCandidates) -> InstallResult {
+        guard let source = bundledLs else {
+            return .failed(message: "irrlicht-ls is not embedded in this build")
+        }
+        guard let dir = chooseTarget(candidates: candidates) else {
+            return .failed(message: "No writable bin directory found. Run: sudo ln -sf \"\(source.path)\" /usr/local/bin/irrlicht-ls")
+        }
+        let link = dir + "/irrlicht-ls"
+        let fm = FileManager.default
+        if fm.fileExists(atPath: link) {
+            guard (try? fm.destinationOfSymbolicLink(atPath: link)) != nil else {
+                return .failed(message: "\(link) exists and is not a symlink — refusing to replace it")
+            }
+            try? fm.removeItem(atPath: link)
+        }
+        do {
+            try fm.createSymbolicLink(atPath: link, withDestinationPath: source.path)
+            return .installed(path: link)
+        } catch {
+            return .failed(message: "Could not create \(link): \(error.localizedDescription)")
+        }
+    }
+}

--- a/platforms/macos/Irrlicht/Managers/CLIToolInstaller.swift
+++ b/platforms/macos/Irrlicht/Managers/CLIToolInstaller.swift
@@ -59,8 +59,27 @@ enum CLIToolInstaller {
         candidates.first(where: isWritableDir)
     }
 
+    /// Clears the way for the symlink at `link`: any existing symlink is
+    /// removed — including a DANGLING one, which `fileExists` can't see
+    /// (it traverses the link, so a stale link to a deleted bundle would
+    /// otherwise make createSymbolicLink fail with "file exists"). A regular
+    /// file is left alone and reported. Returns a user-facing error message,
+    /// or nil when the site is clear.
+    static func clearLinkSite(_ link: String) -> String? {
+        let fm = FileManager.default
+        // lstat semantics: succeeds for any symlink, valid or dangling.
+        if (try? fm.destinationOfSymbolicLink(atPath: link)) != nil {
+            try? fm.removeItem(atPath: link)
+            return nil
+        }
+        if fm.fileExists(atPath: link) {
+            return "\(link) exists and is not a symlink — refusing to replace it"
+        }
+        return nil
+    }
+
     /// Create (or refresh) the symlink in the first writable candidate.
-    /// Refuses to replace a regular file — only stale symlinks are replaced.
+    /// Refuses to replace a regular file — only symlinks are replaced.
     static func install(candidates: [String] = defaultCandidates) -> InstallResult {
         guard let source = bundledLs else {
             return .failed(message: "irrlicht-ls is not embedded in this build")
@@ -69,15 +88,11 @@ enum CLIToolInstaller {
             return .failed(message: "No writable bin directory found. Run: sudo ln -sf \"\(source.path)\" /usr/local/bin/irrlicht-ls")
         }
         let link = dir + "/irrlicht-ls"
-        let fm = FileManager.default
-        if fm.fileExists(atPath: link) {
-            guard (try? fm.destinationOfSymbolicLink(atPath: link)) != nil else {
-                return .failed(message: "\(link) exists and is not a symlink — refusing to replace it")
-            }
-            try? fm.removeItem(atPath: link)
+        if let message = clearLinkSite(link) {
+            return .failed(message: message)
         }
         do {
-            try fm.createSymbolicLink(atPath: link, withDestinationPath: source.path)
+            try FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: source.path)
             return .installed(path: link)
         } catch {
             return .failed(message: "Could not create \(link): \(error.localizedDescription)")

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -338,6 +338,10 @@ struct SettingsView: View {
                         .controlSize(.small)
                     }
                     .onAppear { updateManager.refresh() }
+
+                    Divider()
+
+                    CLIToolSection()
                 }
                 .padding(.horizontal, 20)
                 .padding(.vertical, 16)
@@ -431,6 +435,60 @@ struct SettingsView: View {
                 }
             }
         }
+    }
+}
+
+/// Settings subsection for putting the bundle-embedded irrlicht-ls CLI on
+/// PATH (#608). Consent-first: the link is only created when the user clicks
+/// the button — installers handle the automatic path; this covers DMG
+/// drag-installs. Hidden in dev builds (binary not embedded).
+private struct CLIToolSection: View {
+    @State private var status: CLIToolInstaller.Status = .unavailable
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Command-Line Tool")
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            switch status {
+            case .unavailable:
+                Text("irrlicht-ls is not embedded in this build.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            case .installed(let path):
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+                        .font(.caption)
+                    Text("irrlicht-ls installed at \(path)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            case .notInstalled:
+                Text("Make the irrlicht-ls session list available in your terminal.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Button("Install Command-Line Tool") {
+                    switch CLIToolInstaller.install() {
+                    case .installed:
+                        errorMessage = nil
+                    case .failed(let message):
+                        errorMessage = message
+                    }
+                    status = CLIToolInstaller.status()
+                }
+                .controlSize(.small)
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+        .onAppear { status = CLIToolInstaller.status() }
     }
 }
 

--- a/platforms/macos/Tests/CLIToolInstallerTests.swift
+++ b/platforms/macos/Tests/CLIToolInstallerTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import Irrlicht
+
+final class CLIToolInstallerTests: XCTestCase {
+    func testChooseTargetPicksFirstWritableCandidate() {
+        let target = CLIToolInstaller.chooseTarget(
+            candidates: ["/nope/a", "/yes/b", "/yes/c"],
+            isWritableDir: { $0.hasPrefix("/yes") }
+        )
+        XCTAssertEqual(target, "/yes/b")
+    }
+
+    func testChooseTargetFallsBackToSecondCandidate() {
+        // The /usr/local/bin → /opt/homebrew/bin ladder: first not writable.
+        let target = CLIToolInstaller.chooseTarget(
+            candidates: ["/usr/local/bin", "/opt/homebrew/bin"],
+            isWritableDir: { $0 == "/opt/homebrew/bin" }
+        )
+        XCTAssertEqual(target, "/opt/homebrew/bin")
+    }
+
+    func testChooseTargetReturnsNilWhenNothingWritable() {
+        XCTAssertNil(CLIToolInstaller.chooseTarget(
+            candidates: ["/a", "/b"],
+            isWritableDir: { _ in false }
+        ))
+    }
+
+    func testInstallRefusesToReplaceRegularFile() throws {
+        // Real temp dir with a regular file squatting on the link name —
+        // install() must refuse rather than delete user data. bundledLs is
+        // nil in the test bundle, so exercise the guard order first: with
+        // no embedded binary the failure is "not embedded".
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        FileManager.default.createFile(atPath: dir + "/irrlicht-ls", contents: Data("real".utf8))
+
+        let result = CLIToolInstaller.install(candidates: [dir])
+        guard case .failed(let message) = result else {
+            return XCTFail("install must fail in the test bundle, got \(result)")
+        }
+        // SwiftPM test bundles don't embed the Go binary — the unavailable
+        // guard fires before any filesystem mutation.
+        XCTAssertTrue(message.contains("not embedded"), "unexpected failure: \(message)")
+        // The squatting file is untouched either way.
+        XCTAssertEqual(
+            try String(contentsOfFile: dir + "/irrlicht-ls", encoding: .utf8), "real"
+        )
+    }
+
+    func testStatusIsUnavailableInTestBundle() {
+        // SwiftPM test bundles carry no auxiliary executables; the Settings
+        // section must land on .unavailable (section shows the dev-build
+        // note instead of a dead button).
+        XCTAssertEqual(CLIToolInstaller.status(), .unavailable)
+    }
+
+    private func makeTempDir() throws -> String {
+        let dir = NSTemporaryDirectory() + "cli-tool-test-" + UUID().uuidString
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/platforms/macos/Tests/CLIToolInstallerTests.swift
+++ b/platforms/macos/Tests/CLIToolInstallerTests.swift
@@ -55,6 +55,47 @@ final class CLIToolInstallerTests: XCTestCase {
         XCTAssertEqual(CLIToolInstaller.status(), .unavailable)
     }
 
+    func testClearLinkSiteRemovesDanglingSymlink() throws {
+        // The review-found bug: fileExists() traverses symlinks, so a
+        // dangling link (bundle moved/deleted) was invisible to the old
+        // check and createSymbolicLink failed with "file exists".
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let link = dir + "/irrlicht-ls"
+        try FileManager.default.createSymbolicLink(
+            atPath: link, withDestinationPath: dir + "/gone-bundle/irrlicht-ls"
+        )
+
+        XCTAssertNil(CLIToolInstaller.clearLinkSite(link), "dangling symlink must be cleared, not reported")
+        XCTAssertNil(try? FileManager.default.destinationOfSymbolicLink(atPath: link), "link should be gone")
+    }
+
+    func testClearLinkSiteRemovesValidSymlink() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let target = dir + "/target"
+        FileManager.default.createFile(atPath: target, contents: Data("bin".utf8))
+        let link = dir + "/irrlicht-ls"
+        try FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: target)
+
+        XCTAssertNil(CLIToolInstaller.clearLinkSite(link))
+        XCTAssertNil(try? FileManager.default.destinationOfSymbolicLink(atPath: link))
+        // Removing the link never touches its target.
+        XCTAssertEqual(try String(contentsOfFile: target, encoding: .utf8), "bin")
+    }
+
+    func testClearLinkSiteRefusesRegularFile() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let link = dir + "/irrlicht-ls"
+        FileManager.default.createFile(atPath: link, contents: Data("real".utf8))
+
+        let message = CLIToolInstaller.clearLinkSite(link)
+        XCTAssertNotNil(message)
+        XCTAssertTrue(message?.contains("not a symlink") ?? false)
+        XCTAssertEqual(try String(contentsOfFile: link, encoding: .utf8), "real", "regular file must be untouched")
+    }
+
     private func makeTempDir() throws -> String {
         let dir = NSTemporaryDirectory() + "cli-tool-test-" + UUID().uuidString
         try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)

--- a/site/docs/cli-tools.html
+++ b/site/docs/cli-tools.html
@@ -162,6 +162,10 @@ ready    api-server   e5f6g7h8 gpt-5 3% 400k codex  (1m ago)</code></pre>
 
       <p>Reads session JSON files from <code>~/Library/Application Support/Irrlicht/instances/</code> and builds the same hierarchical dashboard as the API. Works independently of the daemon.</p>
 
+      <h3>Installation</h3>
+
+      <p><code>irrlicht-ls</code> ships inside <code>Irrlicht.app</code> and lands on your PATH automatically: the PKG installer and the <code>curl … | sh</code> installer symlink it to <code>/usr/local/bin/irrlicht-ls</code>. If you installed by dragging the DMG, open the menu bar panel → Settings → <em>Install Command-Line Tool</em>. Building from source: <code>go build ./cmd/irrlicht-ls/</code>.</p>
+
       <!-- ── Building CLI Tools ── -->
       <h2>Building CLI Tools</h2>
 

--- a/site/install.sh
+++ b/site/install.sh
@@ -320,6 +320,23 @@ step "Registering with LaunchServices"
 spctl -a -t exec /Applications/Irrlicht.app 2>/dev/null || true
 ok
 
+# Put the irrlicht-ls CLI on PATH (#608). Runs as the invoking user — no
+# sudo escalation: try /usr/local/bin, fall back to Homebrew's bin (user-
+# writable on Apple Silicon), otherwise print the one-liner. The app's
+# Settings panel offers the same install for drag-install users.
+step "Linking irrlicht-ls CLI"
+if [ -d /usr/local/bin ] && [ -w /usr/local/bin ]; then
+    ln -sf /Applications/Irrlicht.app/Contents/MacOS/irrlicht-ls /usr/local/bin/irrlicht-ls
+    ok
+elif [ -d /opt/homebrew/bin ] && [ -w /opt/homebrew/bin ]; then
+    ln -sf /Applications/Irrlicht.app/Contents/MacOS/irrlicht-ls /opt/homebrew/bin/irrlicht-ls
+    ok
+else
+    printf '%sskipped%s\n' "$YELLOW" "$RESET"
+    warn "No user-writable bin dir found for the irrlicht-ls CLI. Add it with:"
+    warn "  sudo ln -sf /Applications/Irrlicht.app/Contents/MacOS/irrlicht-ls /usr/local/bin/irrlicht-ls"
+fi
+
 step "Launching Irrlicht"
 open /Applications/Irrlicht.app
 ok

--- a/tools/build-dev.sh
+++ b/tools/build-dev.sh
@@ -14,6 +14,7 @@
 # Usage:
 #   tools/build-dev.sh          — builds irrlichd
 #   tools/build-dev.sh focus    — also builds irrlicht-focus
+#   tools/build-dev.sh ls       — also builds irrlicht-ls
 #   tools/build-dev.sh all      — builds everything in core/cmd/
 
 set -euo pipefail
@@ -39,6 +40,10 @@ case "${1:-irrlichd}" in
     build_one "./cmd/irrlichd"       "irrlichd"
     build_one "./cmd/irrlicht-focus" "irrlicht-focus"
     ;;
+  ls)
+    build_one "./cmd/irrlichd"       "irrlichd"
+    build_one "./cmd/irrlicht-ls"    "irrlicht-ls"
+    ;;
   all)
     for d in cmd/*/; do
       pkg="./$d"
@@ -47,7 +52,7 @@ case "${1:-irrlichd}" in
     done
     ;;
   *)
-    echo "usage: build-dev.sh [irrlichd|focus|all]" >&2
+    echo "usage: build-dev.sh [irrlichd|focus|ls|all]" >&2
     exit 2
     ;;
 esac

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -47,6 +47,7 @@ build_universal() {
 cd core
 build_universal "./cmd/irrlichd/"       "$DAEMON_NAME"
 build_universal "./cmd/irrlicht-focus/" "irrlicht-focus"
+build_universal "./cmd/irrlicht-ls/"    "irrlicht-ls"
 cd ..
 
 echo "  Testing daemon..."
@@ -143,7 +144,9 @@ cp "$BUILD_DIR/${DAEMON_NAME}-darwin-universal" "$APP_CONTENTS/MacOS/${DAEMON_NA
 chmod 755 "$APP_CONTENTS/MacOS/${DAEMON_NAME}"
 cp "$BUILD_DIR/irrlicht-focus-darwin-universal" "$APP_CONTENTS/MacOS/irrlicht-focus"
 chmod 755 "$APP_CONTENTS/MacOS/irrlicht-focus"
-echo "  Embedded daemon and irrlicht-focus in app bundle"
+cp "$BUILD_DIR/irrlicht-ls-darwin-universal" "$APP_CONTENTS/MacOS/irrlicht-ls"
+chmod 755 "$APP_CONTENTS/MacOS/irrlicht-ls"
+echo "  Embedded daemon, irrlicht-focus, and irrlicht-ls in app bundle"
 
 # Embed Sparkle.framework so the Sparkle auto-updater finds itself at runtime.
 # SwiftPM copies Sparkle.framework next to the executable in its build output;
@@ -272,6 +275,8 @@ if [ -n "${DEVELOPER_ID:-}" ]; then
     codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
         "$APP_CONTENTS/MacOS/irrlicht-focus"
     codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
+        "$APP_CONTENTS/MacOS/irrlicht-ls"
+    codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
         --entitlements "$ENTITLEMENTS" "$APP_BUNDLE"
     codesign --verify --deep --strict "$APP_BUNDLE"
     # Value-aware XPath: a <false/> declaration on get-task-allow is harmless
@@ -289,6 +294,7 @@ else
     codesign --force --sign - "$APP_CONTENTS/Resources/Irrlicht_Irrlicht.bundle"
     codesign --force --sign - "$APP_CONTENTS/MacOS/${DAEMON_NAME}"
     codesign --force --sign - "$APP_CONTENTS/MacOS/irrlicht-focus"
+    codesign --force --sign - "$APP_CONTENTS/MacOS/irrlicht-ls"
     codesign --force --sign - "$APP_BUNDLE"
     codesign --verify --deep --strict "$APP_BUNDLE"
     echo "  Ad-hoc signed $APP_BUNDLE"
@@ -375,6 +381,11 @@ cp -R "$APP_BUNDLE" "$PKG_ROOT/Applications/${APP_NAME}.app"
 mkdir -p "$PKG_SCRIPTS"
 cat > "$PKG_SCRIPTS/postinstall" <<'SCRIPT'
 #!/bin/bash
+# Put the irrlicht-ls CLI on PATH (#608). Runs as root, so /usr/local/bin
+# is always writable; ln -sf keeps reinstalls/upgrades idempotent. Guarded
+# with || true — a failed symlink must never fail the install.
+mkdir -p /usr/local/bin 2>/dev/null || true
+ln -sf /Applications/Irrlicht.app/Contents/MacOS/irrlicht-ls /usr/local/bin/irrlicht-ls 2>/dev/null || true
 # The app manages its own daemon lifecycle — no LaunchAgent needed.
 # Just open the app so the user sees it in the menu bar immediately.
 CURRENT_USER=$(stat -f "%Su" /dev/console)


### PR DESCRIPTION
Closes #608.

## What

`irrlicht-ls` becomes part of the default install across all three install paths — consent-first (no launch-time writes; the app only acts on an explicit button click):

| Install path | Mechanism |
|---|---|
| **PKG** | postinstall (root) symlinks `/usr/local/bin/irrlicht-ls` → bundle binary — idempotent, `\|\| true`-guarded |
| **`curl … \| sh`** | new "Linking irrlicht-ls CLI" step: `/usr/local/bin` if writable → `/opt/homebrew/bin` fallback → warn + sudo one-liner |
| **DMG drag-install** | Settings → **Install Command-Line Tool** (new `CLIToolInstaller` + Settings section) |

Plus: `build-release.sh` builds/embeds/signs the universal binary (both DevID and ad-hoc paths); `build-dev.sh ls` dev target; docs (README, `cli-tools.html` Installation section, `ir:release` skill).

## Safety semantics

- `install()` ladder: first writable candidate dir wins; **refuses to replace a regular file** (only symlinks are refreshed); clear error surfaced inline in Settings.
- Dev/SwiftPM bundles don't embed the binary → section shows an informational note instead of a dead button (`.unavailable`).
- `irrlicht-ls` reads the session store from disk (daemon-independent), so install is just PATH placement — no port coordination.

## Tests & verification

- `CLIToolInstallerTests` (5): chooseTarget ladder ×3, guard order on squatting regular file, `.unavailable` in test bundles. `swift build` + suite green.
- `bash -n` on all three scripts; `tools/build-dev.sh ls` produces a working binary.
- **Live-verified**: dev bundle with the binary embedded → Settings button correctly fell back `/usr/local/bin` (not writable) → `/opt/homebrew/bin`, replaced an existing symlink, status flipped to installed — user-confirmed.
- Full release/PKG path is exercised by the next `/ir:release` run; the postinstall addition cannot fail the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)