### PR TITLE
fix(macos): pin GroupView snapshot host to dark aqua

### DIFF
--- a/platforms/macos/Tests/GroupViewSnapshotTests.swift
+++ b/platforms/macos/Tests/GroupViewSnapshotTests.swift
@@ -64,6 +64,9 @@ final class GroupViewSnapshotTests: XCTestCase {
             .frame(width: 350, height: height)
             .background(Color(NSColor.windowBackgroundColor))
         let hosting = NSHostingView(rootView: wrapped)
+        // Pin to dark aqua so snapshots don't depend on the current system
+        // appearance (Color(NSColor.windowBackgroundColor) adapts otherwise).
+        hosting.appearance = NSAppearance(named: .darkAqua)
         hosting.frame = CGRect(x: 0, y: 0, width: 350, height: height)
         hosting.layoutSubtreeIfNeeded()
         return hosting


### PR DESCRIPTION
## Problem

All 5 `GroupViewSnapshotTests` failed ("Snapshot does not match reference") on a clean `main` checkout when the Mac runs in **light mode**.

`GroupViewSnapshotTests.host()` built its `NSHostingView` without pinning `hosting.appearance`, so `Color(NSColor.windowBackgroundColor)` adapted to the current system appearance. The committed reference PNGs were recorded in dark mode, so the rendering diverged on light-mode machines.

## Fix

Apply the same one-line appearance pin that `SessionRowSnapshotTests.host()` already uses — pin the hosting view to `.darkAqua` so the background color is deterministic regardless of system appearance.

No reference PNGs were re-recorded: the existing dark-mode references match unchanged once the host is pinned.

## Test evidence

Verified on a **light-mode** machine (`AppleInterfaceStyle` key absent).

- `swift test --filter GroupViewSnapshotTests` → all 5 pass:
  ```
  Test Suite 'GroupViewSnapshotTests' passed
  Executed 5 tests, with 0 failures (0 unexpected)
  ```
- Full suite `swift test` → all suites pass, 0 failures (the 5 skipped tests are the `TEST_HARNESS`-gated `LauncherTestHarness`).
- `git diff --stat`: only `GroupViewSnapshotTests.swift` changed (+3), no PNGs touched.

Fixes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)