### PR TITLE
fix(test): widen gastown replay settle window to survive -race load

### DIFF
--- a/core/adapters/inbound/orchestrators/gastown/poller.go
+++ b/core/adapters/inbound/orchestrators/gastown/poller.go
@@ -21,21 +21,29 @@ type sessionLister interface {
 	ListAll() ([]*session.SessionState, error)
 }
 
+// defaultFetchTimeout bounds each gt CLI subprocess call in production.
+const defaultFetchTimeout = 5 * time.Second
+
 // poller queries the gt CLI for rig, polecat, dog, and boot state and maps
 // the results to the standardised orchestrator.State model.
 type poller struct {
 	collector *collector
 	gtBin     string
 	sessions  sessionLister
+	// fetchTimeout bounds each gt CLI call. Defaults to defaultFetchTimeout;
+	// the replay test raises it so a load-starved fake-gt subprocess can't
+	// falsely time out into the fallback path (#586).
+	fetchTimeout time.Duration
 }
 
 // newPoller creates a poller that reads from the given collector and
 // shells out to gtBin for rig/polecat state.
 func newPoller(collector *collector, gtBin string, sessions sessionLister) *poller {
 	return &poller{
-		collector: collector,
-		gtBin:     gtBin,
-		sessions:  sessions,
+		collector:    collector,
+		gtBin:        gtBin,
+		sessions:     sessions,
+		fetchTimeout: defaultFetchTimeout,
 	}
 }
 
@@ -337,7 +345,7 @@ func (p *poller) gtCommand(ctx context.Context, args ...string) *exec.Cmd {
 }
 
 func (p *poller) fetchRigs(ctx context.Context) []rigState {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, p.fetchTimeout)
 	defer cancel()
 
 	out, err := p.gtCommand(ctx, "rig", "list", "--json").Output()
@@ -353,7 +361,7 @@ func (p *poller) fetchRigs(ctx context.Context) []rigState {
 }
 
 func (p *poller) fetchPolecats(ctx context.Context) []polecatState {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, p.fetchTimeout)
 	defer cancel()
 
 	out, err := p.gtCommand(ctx, "polecat", "list", "--all", "--json").Output()
@@ -368,7 +376,7 @@ func (p *poller) fetchPolecats(ctx context.Context) []polecatState {
 }
 
 func (p *poller) fetchDogs(ctx context.Context) []dogState {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, p.fetchTimeout)
 	defer cancel()
 
 	out, err := p.gtCommand(ctx, "dog", "list", "--json").Output()
@@ -383,7 +391,7 @@ func (p *poller) fetchDogs(ctx context.Context) []dogState {
 }
 
 func (p *poller) fetchBootStatus(ctx context.Context) *bootStatus {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, p.fetchTimeout)
 	defer cancel()
 
 	out, err := p.gtCommand(ctx, "boot", "status", "--json").Output()

--- a/core/adapters/inbound/orchestrators/gastown/replay_test.go
+++ b/core/adapters/inbound/orchestrators/gastown/replay_test.go
@@ -122,6 +122,13 @@ func runScenario(t *testing.T, scenarioDir string) {
 		t.Fatalf("collector did not detect scratch GT_ROOT %s", gtRoot)
 	}
 	p := newPoller(c, fakeGT, &fakeSessionLister{sessions: sessions})
+	// The fixtures are deterministic and the fake-gt shim returns instantly,
+	// so the only thing the per-fetch deadline guards against here is a real
+	// hang. Under full-suite -race load, spawning the bash shim and reading
+	// its output can blow past the production 5s budget, falsely tipping a
+	// healthy tick into the fallback path and corrupting the golden compare
+	// (#586). Poll-style generous cap: never hit in practice, still bounded.
+	p.fetchTimeout = 60 * time.Second
 
 	goldenDir := filepath.Join(scenarioDir, "golden")
 	if *updateGoldens {
@@ -133,7 +140,10 @@ func runScenario(t *testing.T, scenarioDir string) {
 	for tick := 1; tick <= cfg.PollTicks; tick++ {
 		writeTick(t, tickFile, tick)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		// Generous outer cap matching the per-fetch budget above: under
+		// load the subprocess fan-out must not be guillotined mid-flight
+		// (#586). This bounds a genuine hang without racing the parallel sweep.
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		state := p.BuildOrchestratorState(ctx)
 		cancel()
 


### PR DESCRIPTION
## Diagnosis

`TestGastownReplay` subtests flaked intermittently under full-suite `go test ./core/... -race -count=1` with a ~5s timeout signature, on a *different* subtest each run (polling-lifecycle / state-aggregation / agent-discovery), yet were rock-solid in isolation (`-count=3` passes).

The ~5s settle window is the poller's **per-fetch deadline**, not anything in the test loop. `BuildOrchestratorState` fans out four `gt` CLI calls (`fetchRigs` / `fetchPolecats` / `fetchDogs` / `fetchBootStatus`), each wrapped in a hardcoded `context.WithTimeout(ctx, 5*time.Second)`. In the replay test those calls `exec.CommandContext` a deterministic fake-`gt` bash shim that returns instantly.

Under ~16 packages of concurrent `-race` testing the machine is CPU-starved, so spawning the bash shim and reading its output can exceed 5s. When it does, `.Output()` returns an error and the fetch **silently falls back** — cached `rigs.json` for rigs, or `nil` for polecats/dogs/boot — producing an `orchestrator.State` that mismatches the committed golden. That's the failure: not a Go-level deadlock but a starved subprocess tipping a *healthy* tick into the fallback path. The 5.01s / 7.58s timings in the report are exactly these per-fetch deadlines (and the outer 10s per-tick deadline) firing. #575's event-driven polling fix reduced but didn't eliminate the starvation window (run 2 in the issue was on a tree with #575 merged).

## Fix

Following the #582 poll-for-condition spirit (not a bare number bump): the per-fetch budget becomes a `poller.fetchTimeout` field, **defaulting to the production 5s** (`defaultFetchTimeout`) so daemon behavior is byte-for-byte unchanged. The replay test raises it to a generous **60s** cap, with a matching 60s outer per-tick context. The fixtures are deterministic and the shim is instant, so the only thing these deadlines legitimately guard *in the test* is a genuine hang — 60s is never reached in practice yet still bounds a real deadlock.

Two files, +26/-8, no production behavior change.

## Test evidence

Run on macOS (darwin 25.5.0), machine **genuinely loaded** (4 other agents running concurrently; load average climbing to ~37 during the stress runs — the issue's repro condition):

- `go test ./core/adapters/inbound/orchestrators/gastown/ -run TestGastownReplay -race -count=5` → **green** (10.9s)
- `go test ./core/adapters/inbound/orchestrators/gastown/ -race -count=3` (whole package) → **green**
- **Load-condition reruns:** with a background `go test ./core/... -race` running concurrently, ran the gastown replay test 5 more times (`-count=3` each = 15 replay invocations) → **all green**; individual runs took up to **21.5s and 29.7s**, far past the old 5s/10s fixed deadlines that would have falsely failed
- Full `go test ./core/... -race -count=1` → gastown green at 14.8s and (in the concurrent background run) 18.9s

### Unrelated known flake noted (not chased)

In the heavily-loaded background full-suite run, `core/application/services` reported two failures — `TestSessionDetector_Removed_TransitionsToReady` and `TestSessionDetector_HandlePermissionHook_PreToolUseTransitionsToWaiting`, both `got "working", want ready/waiting`. This is the known load-induced SessionDetector race family (#606, being fixed separately). Confirmed targeted: `go test ./core/application/services/ -run '...' -race -count=3` → **green**. Unrelated to this change.

Fixes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)