### PR TITLE
fix(classifier): case-insensitive permission-gated edit-tool match (#588)

### DIFF
--- a/core/application/services/session_detector_stalled_test.go
+++ b/core/application/services/session_detector_stalled_test.go
@@ -41,6 +41,17 @@ func TestMarkStalledEditTool(t *testing.T) {
 		}
 	})
 
+	// kiro-cli's pending write-approval picker holds an open lowercase `write`
+	// tool; it must flag stalled just like claudecode's PascalCase Write (#588).
+	t.Run("lowercase write (kiro) open past window is flagged", func(t *testing.T) {
+		d := &SessionDetector{editToolOpenSince: map[string]int64{"s": 1000}}
+		m := &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"write"}}
+		d.markStalledEditTool("s", m, 1000+threshold)
+		if !m.OpenToolStalled {
+			t.Fatalf("lowercase write open for %ds must be flagged stalled", threshold)
+		}
+	})
+
 	t.Run("edit tool just under window is not flagged", func(t *testing.T) {
 		d := &SessionDetector{editToolOpenSince: map[string]int64{"s": 1000}}
 		m := editOpen()

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -269,9 +269,17 @@ func (m *SessionMetrics) HasOpenEditPermissionTool() bool {
 
 // isPermissionGatedEditTool reports whether name is a fast, in-process
 // file-edit tool that prompts for permission by default.
+//
+// The match is case-insensitive because adapters name the same tool
+// differently: claudecode emits PascalCase (Edit/Write/MultiEdit/
+// NotebookEdit) while kiro-cli and pi emit lowercase (write/edit). All
+// are fast in-process file edits, so an open one that lingers is the same
+// "blocked on a permission prompt" signal regardless of casing (#588). No
+// adapter names a long-running tool (bash/read/web_search/MCP) with one of
+// these spellings, so case-folding introduces no false positives.
 func isPermissionGatedEditTool(name string) bool {
-	switch name {
-	case "Edit", "Write", "MultiEdit", "NotebookEdit":
+	switch strings.ToLower(name) {
+	case "edit", "write", "multiedit", "notebookedit":
 		return true
 	default:
 		return false

--- a/core/domain/session/session_test.go
+++ b/core/domain/session/session_test.go
@@ -194,6 +194,12 @@ func TestHasOpenEditPermissionTool(t *testing.T) {
 		{"open Write", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Write"}}, true},
 		{"open MultiEdit", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"MultiEdit"}}, true},
 		{"open NotebookEdit", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"NotebookEdit"}}, true},
+		// Lowercase variants emitted by kiro-cli and pi must gate too (#588) —
+		// the same fast in-process edit tools, just a different casing.
+		{"open lowercase write (kiro)", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"write"}}, true},
+		{"open lowercase edit (pi)", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"edit"}}, true},
+		{"open lowercase multiedit", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"multiedit"}}, true},
+		{"open lowercase notebookedit", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"notebookedit"}}, true},
 		// Tools that can legitimately run long must NOT qualify — duration
 		// can't distinguish "blocked on prompt" from "executing" for them.
 		{"open Bash", &SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Bash"}}, false},


### PR DESCRIPTION
## Root cause

A pending **kiro-cli write-approval picker** classified as `working` and never reached the spec-required `waiting`. While kiro held an open lowercase `write` tool awaiting the user's approval, the daemon kept the session `working` and went straight to `ready` on completion — a watcher could not tell kiro was blocked on a permission prompt.

kiro emits no permission hook (so `metrics.PermissionPending` never sets → `state_classifier.go` rule 0 can't fire) and its tool is `write` not `AskUserQuestion`/`ExitPlanMode`/`question` (so rule 1 can't fire). The **only** remaining path to `waiting` for a held edit-permission on a hookless agent is the **OpenToolStalled** transcript fallback (#488), gated by `HasOpenEditPermissionTool` → `isPermissionGatedEditTool`. That allowlist matched only the exact **PascalCase** claudecode names:

```go
case "Edit", "Write", "MultiEdit", "NotebookEdit":
```

kiro's lowercase `write` missed it, so `OpenToolStalled` was never set and the classifier fell through to rule 4 (`HasOpenToolCall` → `working`). The session sat `working` for the entire pending-approval window.

## Fix

Match **case-insensitively** via `strings.ToLower` in `isPermissionGatedEditTool` (`core/domain/session/session.go`). The same tools are named PascalCase by claudecode and lowercase by kiro-cli and pi; all are fast in-process file edits, so a lingering open one is the same "blocked on a permission prompt" signal regardless of casing. (A per-adapter name set was the alternative the issue floated; case-folding is the minimal correct change since the spellings only differ by case.)

## False-positive analysis

Scanned every inbound adapter's emitted tool names against the gated set:

- **Lowercase edit/write spellings come only from kiro (`write`) and pi (`edit`/`write`)** — both are genuine fast in-process file-edit tools (pi's `edit` carries `edits[].oldText/newText`), exactly the tools that SHOULD gate.
- **No adapter** names a legitimately long-running tool (`bash`/`read`/`web_search`/`apply_patch`/MCP) with an `edit`/`write`/`multiedit`/`notebookedit` spelling. So case-folding introduces **no false positives** — the Bash/WebFetch/MCP exclusion rationale in the doc comment still holds.
- Desirable side effect: pi's lowercase `edit`/`write` now also reach the OpenToolStalled fallback (it had the same latent miss).

## Test evidence

- `TestHasOpenEditPermissionTool` extended with lowercase `write`/`edit`/`multiedit`/`notebookedit` (all expected `true`); existing `Bash`/`WebFetch`/`Read`/`mcp__*` cases still expected `false`.
- `TestMarkStalledEditTool` gains a lowercase-`write` case exercising the live stale-window path (flags `OpenToolStalled` past the threshold).

Full suite (4 other agents ran concurrently on the machine):

- `go test ./core/... -race -count=1` — passes. One load-induced flake of `TestSessionDetector_Removed_TransitionsToReady` (50ms-sleep timing test, no edit-tool path involved — the known #606 SessionDetector race family); the `services` package and the `Removed` family both pass cleanly in isolation (5/5 reruns, full-package rerun green).
- `tools/replay-fixtures.sh` — clean, all cells `ok`, cell-integrity gate green.
- `go run ./tools/onboarding-factory/cmd/of validate` — `OK — catalog + cells are schema-valid and referentially consistent`.
- `go test ./tools/onboarding-factory/... -race -count=1` — passes.
- `UPDATE_REPLAY_GOLDENS=1 go test ./cmd/replay/... -count=1` (in `tools/onboarding-factory`) — **no golden changes**.

## Fixture status

The `known_failing` fixture (`replaydata/agents/kiro-cli/scenarios/2-11_auto-classified-permission/`) is **left as known_failing** — deliberately and correctly:

- Its `events.jsonl` is a static **live** capture from before the fix and still shows no `waiting`.
- The replay engine does **not** simulate the 5s `editToolOpenSince` stale-refresh window, so the synthetic `waiting` only materialises in the live daemon (via `refreshStaleSessions` → `markStalledEditTool`). Replay output for this fixture is unchanged (`ready → working → ready`).
- Flipping `known_failing` to `false` now would make `of verify` / the expected-validator assert a `waiting` phase the static `events.jsonl` doesn't contain → red. The honest state is: the daemon bug is fixed (proven by the live-path unit tests), and the fixture stays `known_failing` until it is **re-recorded live** against the fixed daemon (`of record verify --agent kiro-cli --scenario auto-classified-permission`, which needs a live agent).

## Unrelated observation (not touched)

`gofmt -l` flags a pre-existing struct-field-alignment misformat in the `SessionState` block of `session.go` (~line 626), present on `main` before this change. Left alone per surgical-changes convention.

Fixes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)