### PR TITLE
fix(test): deterministic cursor-GC aging in opencode watcher test

### DIFF
--- a/core/adapters/inbound/agents/opencode/watcher_test.go
+++ b/core/adapters/inbound/agents/opencode/watcher_test.go
@@ -415,8 +415,12 @@ func TestScanSessions_GCsExpiredCursors(t *testing.T) {
 	ch := w.Subscribe()
 	defer w.Unsubscribe(ch)
 
-	// Tight maxAge so we don't have to backdate by days.
-	w.maxAge = 100 * time.Millisecond
+	// Generous maxAge so no realistic scheduler stall can push the fresh
+	// session across the boundary. The old version used maxAge=100ms and a
+	// 150ms sleep — under -race on a loaded CI runner, >100ms could elapse
+	// between stamping ses_recent fresh and scanSessions' row filter, aging
+	// the FRESH session out too (flaked on the Linux runner).
+	w.maxAge = time.Hour
 
 	// Two sessions with distinct CWDs, both fresh enough to appear in scan.
 	now := time.Now().UnixMilli()
@@ -432,13 +436,18 @@ func TestScanSessions_GCsExpiredCursors(t *testing.T) {
 	}
 	w.mu.Unlock()
 
-	// Bump only ses_recent's time_updated past the maxAge boundary; leave
-	// ses_will_age frozen at its original timestamp so it ages out.
-	time.Sleep(150 * time.Millisecond)
-	fresh := time.Now().UnixMilli()
-	if _, err := db.Exec(`UPDATE session SET time_updated = ? WHERE id = ?`, fresh, "ses_recent"); err != nil {
-		t.Fatalf("bump time_updated: %v", err)
+	// Age ses_will_age out deterministically — backdate instead of sleep:
+	// its DB row leaves the scan window (row filter + SQL cutoff), and its
+	// cursor's lastObserved (what gcExpiredCursors actually checks) predates
+	// the cutoff. ses_recent's row stays at `now`, comfortably within the
+	// hour-wide window.
+	past := time.Now().Add(-2 * time.Hour)
+	if _, err := db.Exec(`UPDATE session SET time_updated = ? WHERE id = ?`, past.UnixMilli(), "ses_will_age"); err != nil {
+		t.Fatalf("backdate time_updated: %v", err)
 	}
+	w.mu.Lock()
+	w.cursors["ses_will_age"].lastObserved = past
+	w.mu.Unlock()
 
 	w.scanSessions()
 


### PR DESCRIPTION
## Problem

`TestScanSessions_GCsExpiredCursors` flaked on the Linux `-race` runner (failed PR #612's CI): with `maxAge=100ms` and a 150ms sleep, the test assumes <100ms elapses between stamping `ses_recent` fresh and the row filter inside `scanSessions()` (`watcher.go:297-301`). On a loaded runner that window gets crossed → the *fresh* session falls out of the scan → its `lastObserved` stays stale → `gcExpiredCursors` (keyed on `lastObserved`, `watcher.go:362-372`) deletes it → `"ses_recent cursor was GC'd but it's within maxAge"`.

## Fix

Deterministic aging — backdate, don't sleep:
- `maxAge = 1h` (no realistic scheduler stall crosses it)
- the aging session is moved 2h into the past on **both** axes the code checks: its DB `time_updated` (scan window) and its cursor's `lastObserved` (the GC key)
- the 150ms sleep is gone — test is faster and has zero wall-clock dependence

Semantics preserved: cursor created while fresh → session leaves the window → GC drops exactly that cursor, keeps the fresh one.

## Verification

`go test ./core/adapters/inbound/agents/opencode/ -race -run TestScanSessions_GCsExpiredCursors -count=20` ✅ + full package `-race` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)