### PR TITLE
fix(detector): synchronize PID assignment with the detector loop (#606)

### DIFF
--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -82,13 +82,16 @@ type PIDManager struct {
 	pendingMu   sync.Mutex
 	pendingPIDs map[string]int
 
-	// assignMu serializes the PID-assignment critical sections that read and
-	// write the repo's shared *SessionState pointers — HandlePIDAssigned's
-	// load-modify-save + same-PID cleanup scan, and claimedPIDs' scan. Without
-	// it, two concurrent discoveries (two same-named agents starting together)
-	// race on state.PID: one writes its session's PID while the other reads it
-	// in a ListAll scan. Never held across detector callbacks (see
-	// HandlePIDAssigned) so it can't invert with the SessionDetector lock.
+	// assignMu serializes every critical section that reads or writes the repo's
+	// shared *SessionState pointers: HandlePIDAssigned's load-modify-save +
+	// same-PID cleanup scan, claimedPIDs' scan, AND the SessionDetector event
+	// loop's own load-modify-save in processActivity (via WithSessionStateLock).
+	// The PID-discovery goroutine spawned by processActivity runs concurrently
+	// with that same processActivity call; without a shared lock, assignPIDLocked
+	// writes state.PID while processActivity writes state.State on the same
+	// pointer (issue #606). Never held across detector callbacks (Watch/delete
+	// run after assignPIDLocked releases it) so it can't invert with any
+	// SessionDetector lock.
 	assignMu sync.Mutex
 
 	// recorder captures lifecycle events for offline replay (optional).
@@ -498,6 +501,19 @@ func (pm *PIDManager) ConsumePendingPID(sessionID string) (int, bool) {
 		delete(pm.pendingPIDs, sessionID)
 	}
 	return pid, ok
+}
+
+// WithSessionStateLock runs fn while holding assignMu, the lock that also
+// guards assignPIDLocked's write to the shared *SessionState. The SessionDetector
+// event loop wraps its own load-modify-save of session state in this so the
+// PID-discovery goroutine it spawns can't write state.PID concurrently with the
+// loop writing state.State on the same pointer (issue #606). fn must not call
+// back into any PIDManager method that takes assignMu (assignPIDLocked,
+// claimedPIDs) — those run only from the spawned goroutine, never inline.
+func (pm *PIDManager) WithSessionStateLock(fn func()) {
+	pm.assignMu.Lock()
+	defer pm.assignMu.Unlock()
+	fn()
 }
 
 // claimedPIDs returns the set of PIDs already assigned to sessions other than

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -157,22 +157,28 @@ func (d *SessionDetector) onNewSession(id agent.Identity, ev agent.Event) {
 		// processActivity fallback (debounce/refresh) created the session
 		// without an identity. The watcher's identity on the next real
 		// transcript event is the authoritative source.
-		changed := false
-		if existing.TranscriptPath == "" {
-			existing.TranscriptPath = ev.TranscriptPath
-			changed = true
-		}
-		if existing.Adapter == "" && id.Name != "" {
-			existing.Adapter = id.Name
-			changed = true
-		}
-		if changed {
-			existing.UpdatedAt = now
-			if err := d.repo.Save(existing); err != nil {
-				d.log.LogError("session-detector", ev.SessionID,
-					fmt.Sprintf("failed to update existing session: %v", err))
+		//
+		// Under the PIDManager's state lock: a discovery goroutine spawned by
+		// the earlier event may still be in flight, and its assignPIDLocked
+		// writes state.PID/UpdatedAt on this same pointer (issue #606).
+		d.pidMgr.WithSessionStateLock(func() {
+			changed := false
+			if existing.TranscriptPath == "" {
+				existing.TranscriptPath = ev.TranscriptPath
+				changed = true
 			}
-		}
+			if existing.Adapter == "" && id.Name != "" {
+				existing.Adapter = id.Name
+				changed = true
+			}
+			if changed {
+				existing.UpdatedAt = now
+				if err := d.repo.Save(existing); err != nil {
+					d.log.LogError("session-detector", ev.SessionID,
+						fmt.Sprintf("failed to update existing session: %v", err))
+				}
+			}
+		})
 	}
 
 	// PID discovery (async). Each adapter has its own strategy:

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -331,6 +331,21 @@ func (d *SessionDetector) processActivity(id agent.Identity, ev agent.Event) {
 		return
 	}
 
+	// Run the load-modify-save of this existing session under the PIDManager's
+	// state lock. processActivity spawns a PID-discovery goroutine below
+	// (state.PID == 0 branch); that goroutine's assignPIDLocked writes state.PID
+	// on the same *SessionState pointer this loop mutates. Sharing assignMu makes
+	// the two mutually exclusive (issue #606).
+	d.pidMgr.WithSessionStateLock(func() {
+		d.processActivityLocked(state, ev)
+	})
+}
+
+// processActivityLocked performs the content-based classification and
+// load-modify-save for an already-loaded existing session. It MUST be called
+// under PIDManager.WithSessionStateLock so the PID-discovery goroutine it spawns
+// can't write state.PID concurrently with this loop's writes (issue #606).
+func (d *SessionDetector) processActivityLocked(state *session.SessionState, ev agent.Event) {
 	// Apply any deferred PID from background discovery goroutines.
 	// This must happen before ClassifyState so that the PID and state
 	// transition are saved atomically, avoiding the race where

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -39,6 +39,20 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 		return
 	}
 
+	// Run the load-modify-save under the PIDManager's state lock — a
+	// PID-discovery goroutine spawned for this session may still be in
+	// flight, and its assignPIDLocked writes state.PID/UpdatedAt on the same
+	// *SessionState pointer this path mutates (issue #606).
+	d.pidMgr.WithSessionStateLock(func() {
+		d.onRemovedLocked(state, ev)
+	})
+}
+
+// onRemovedLocked finishes removal handling for an already-loaded session. It
+// MUST be called under PIDManager.WithSessionStateLock so a still-running
+// PID-discovery goroutine can't write state.PID concurrently with this path's
+// writes (issue #606).
+func (d *SessionDetector) onRemovedLocked(state *session.SessionState, ev agent.Event) {
 	// Pre-sessions (no transcript) are deleted entirely — the user never
 	// sent a message, so there is no useful state to keep.
 	if state.TranscriptPath == "" {

--- a/core/application/services/session_detector_no_substantive_test.go
+++ b/core/application/services/session_detector_no_substantive_test.go
@@ -61,7 +61,11 @@ func TestSessionDetector_Activity_NoSubstantiveActivity_HoldsState(t *testing.T)
 		TranscriptPath: "/home/.claude/projects/-Users-test/away1.jsonl",
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	// Poll for the activity pass to land (EventCount bumped 5→6) instead of a
+	// fixed sleep — the session intentionally stays ready so waitForSessionState
+	// can't observe a transition; EventCount is the race-free completion signal
+	// (issue #606).
+	waitForCondition(func() bool { return repo.eventCountOf("away1") >= 6 }, time.Second)
 	cancel()
 	<-done
 
@@ -126,7 +130,18 @@ func TestSessionDetector_Activity_SubstantivePass_StillClassifies(t *testing.T) 
 		TranscriptPath: "/home/.claude/projects/-Users-test/real1.jsonl",
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	// Poll the (mutex-safe) recorder for the transition instead of a fixed
+	// sleep — under parallel load the event may not be processed within a
+	// fixed window (issue #606).
+	recordedTransition := func() bool {
+		for _, ev := range rec.snapshot() {
+			if ev.SessionID == "real1" && ev.Kind == lifecycle.KindStateTransition {
+				return true
+			}
+		}
+		return false
+	}
+	waitForCondition(recordedTransition, time.Second)
 	cancel()
 	<-done
 
@@ -134,13 +149,7 @@ func TestSessionDetector_Activity_SubstantivePass_StillClassifies(t *testing.T) 
 	// proves the force-bounce / classifier path ran. The final state is
 	// not asserted: it depends on classifier rules that aren't the subject
 	// of this test.
-	sawTransition := false
-	for _, ev := range rec.snapshot() {
-		if ev.SessionID == "real1" && ev.Kind == lifecycle.KindStateTransition {
-			sawTransition = true
-		}
-	}
-	if !sawTransition {
+	if !recordedTransition() {
 		t.Errorf("expected at least one state-transition lifecycle event for real1, got none")
 	}
 }

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -889,7 +889,10 @@ func TestSessionDetector_Removed_TransitionsToReady(t *testing.T) {
 		SessionID: "rm1",
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	// Poll for the removal transition instead of a fixed sleep — under
+	// parallel-load scheduling the Run loop may not have processed the event
+	// within a fixed window (issue #606 flaky sibling).
+	waitForSessionState(repo, "rm1", session.StateReady, time.Second)
 	cancel()
 	<-done
 
@@ -926,12 +929,23 @@ func TestSessionDetector_Removed_PrunesMetricsLedger(t *testing.T) {
 
 	tw.ch <- agent.Event{Type: agent.EventRemoved, SessionID: "rm-prune"}
 
-	time.Sleep(50 * time.Millisecond)
+	// Poll for the prune instead of a fixed sleep — under parallel-load
+	// scheduling the Run loop may not have reached PruneMetrics within a fixed
+	// window (issue #606 flaky sibling). PruneEntry runs after the ready Save,
+	// so wait on the prune log directly.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if len(mm.prunedSnapshot()) >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 	cancel()
 	<-done
 
-	if len(mm.pruned) != 1 || mm.pruned[0] != transcriptPath {
-		t.Errorf("PruneEntry calls: got %v, want [%q]", mm.pruned, transcriptPath)
+	pruned := mm.prunedSnapshot()
+	if len(pruned) != 1 || pruned[0] != transcriptPath {
+		t.Errorf("PruneEntry calls: got %v, want [%q]", pruned, transcriptPath)
 	}
 }
 
@@ -1644,8 +1658,11 @@ func TestSessionDetector_CWDFallback_DoesNotAssignDuplicatePID(t *testing.T) {
 		CWD:            cwd,
 	}
 
-	// Wait for first session's PID discovery retry goroutine to complete.
-	time.Sleep(200 * time.Millisecond)
+	// Wait for the first session's PID to be assigned before sending the
+	// second — sess-b's discovery must see sess-a's PID already claimed for
+	// the disambiguation under test. Poll instead of a fixed sleep so it's
+	// robust under parallel load (issue #606).
+	waitForPID(repo, "sess-a", time.Second)
 
 	tw.ch <- agent.Event{
 		Type:           agent.EventNewSession,
@@ -1655,8 +1672,10 @@ func TestSessionDetector_CWDFallback_DoesNotAssignDuplicatePID(t *testing.T) {
 		CWD:            cwd,
 	}
 
-	// Wait for second session's PID discovery.
-	time.Sleep(200 * time.Millisecond)
+	// Wait for the second session's PID before inspecting state — the
+	// discovery goroutine writes state.PID on the shared pointer, so reading
+	// it before the write completes both flakes and races (issue #606).
+	waitForPID(repo, "sess-b", time.Second)
 	cancel()
 	<-done
 
@@ -1741,7 +1760,14 @@ func TestSessionDetector_CWDFallback_CleansUpOldSessionOnClear(t *testing.T) {
 		TranscriptPath: "/home/.claude/projects/-Users-test/sess-b.jsonl",
 	}
 
-	time.Sleep(200 * time.Millisecond)
+	// Wait for sess-b's PID assignment before inspecting — the discovery
+	// goroutine writes state.PID on the shared pointer, so a fixed sleep both
+	// flakes and races it under parallel load (issue #606).
+	waitForPID(repo, "sess-b", time.Second)
+	// The same-PID cleanup deletes sess-a in the same discovery goroutine,
+	// right after the PID write — poll for that too so we don't read before
+	// the goroutine finishes.
+	waitForSessionDeleted(repo, "sess-a", time.Second)
 	cancel()
 	<-done
 
@@ -1853,10 +1879,13 @@ func TestSessionDetector_ClearWithStaleMetadata_DeletesOldSessionImmediately(t *
 		TranscriptPath: newTranscript,
 	}
 
-	// 300ms covers the immediate synchronous discovery attempt; retries at
-	// 500ms/1s/2s aren't needed — DiscoverPID must succeed on the first try
-	// once the mtime gate lets it past the stale metadata.
-	time.Sleep(300 * time.Millisecond)
+	// Poll for discovery to complete instead of a fixed sleep — the spawned
+	// discovery goroutine writes state.PID on the shared pointer, so reading
+	// it before the write finishes both flakes and races under parallel load
+	// (issue #606). sess-new's PID write happens first, then the same-PID
+	// cleanup deletes sess-old in the same goroutine.
+	waitForPID(repo, "sess-new", time.Second)
+	waitForSessionDeleted(repo, "sess-old", time.Second)
 	cancel()
 	<-done
 
@@ -2167,7 +2196,15 @@ func TestSessionDetector_OrphanedSubagentsFinishWhenParentTurnDone(t *testing.T)
 		TranscriptPath: parentPath,
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	// Poll for the parent reaching ready instead of a fixed sleep — under
+	// parallel-load scheduling the event loop may not have finished the
+	// processActivity pass within a fixed window, which both flakes the
+	// assertion and races the in-place state mutation (issue #606). The
+	// children are fast-forwarded and saved within that same pass, before the
+	// parent's own ready Save, so this is a sufficient barrier.
+	waitForSessionState(repo, "parent-orphans", session.StateReady, time.Second)
+	cancel()
+	<-done
 
 	parent, _ := repo.Load("parent-orphans")
 	if parent == nil {
@@ -2186,9 +2223,6 @@ func TestSessionDetector_OrphanedSubagentsFinishWhenParentTurnDone(t *testing.T)
 			t.Errorf("child %q state: got %q, want ready", childID, child.State)
 		}
 	}
-
-	cancel()
-	<-done
 }
 
 // TestSessionDetector_BackgroundSubagentsNotFastForwarded captures the

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -90,6 +90,74 @@ func (r *mockRepo) ListAll() ([]*session.SessionState, error) {
 	return out, nil
 }
 
+// pidOf reads a session's PID under r.mu. Background PID-discovery goroutines
+// write state.PID on the shared *SessionState pointer, so a bare Load().PID
+// read would race them (issue #606); this locked read is the race-free probe
+// for waitForPID.
+func (r *mockRepo) pidOf(sessionID string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s, ok := r.states[sessionID]; ok {
+		return s.PID
+	}
+	return 0
+}
+
+// eventCountOf reads a session's EventCount under r.mu — the race-free probe
+// tests use to wait for an activity pass to complete (issue #606).
+func (r *mockRepo) eventCountOf(sessionID string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s, ok := r.states[sessionID]; ok {
+		return s.EventCount
+	}
+	return 0
+}
+
+// waitForCondition polls fn until it returns true or the timeout elapses. The
+// generic poll-for-condition replacement for fixed sleeps in tests whose
+// completion signal isn't a saved State value (issue #606).
+func waitForCondition(fn func() bool, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// waitForPID polls until the session's PID is non-zero (PID discovery
+// completed), or the timeout elapses. Lets tests wait for the detached
+// discovery goroutine spawned by onNewSession/processActivity to finish its
+// write before inspecting state — a fixed sleep is too short under
+// parallel-load scheduling (issue #606).
+func waitForPID(repo *mockRepo, sessionID string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if repo.pidOf(sessionID) != 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// waitForSessionDeleted polls until the session no longer exists in the repo,
+// or the timeout elapses. Used to wait out the same-PID cleanup that runs in a
+// background discovery goroutine after a PID is assigned (issue #606).
+func waitForSessionDeleted(repo *mockRepo, sessionID string, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		repo.mu.Lock()
+		_, ok := repo.states[sessionID]
+		repo.mu.Unlock()
+		if !ok {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 // waitForSessionState polls the repo's Save snapshot until the session was
 // last saved with state want, or the timeout elapses. Lets tests wait for the
 // detector's Run loop to finish async event processing without a fixed sleep
@@ -151,7 +219,12 @@ type cwdGit struct {
 
 func (g *cwdGit) GetCWDFromTranscript(path string) string { return g.cwd }
 
+// mockMetrics records PruneEntry calls. Safe for concurrent use: PruneEntry
+// fires on the detector's Run goroutine while tests poll prunedSnapshot from
+// the test goroutine (issue #606 flaky-sibling fix replaced a fixed sleep with
+// a poll).
 type mockMetrics struct {
+	mu     sync.Mutex
 	pruned []string
 }
 
@@ -163,7 +236,21 @@ func (m *mockMetrics) ComputeMetricsTimeline(path, adapter string) ([]session.Me
 	return nil, nil
 }
 
-func (m *mockMetrics) PruneEntry(path string) { m.pruned = append(m.pruned, path) }
+func (m *mockMetrics) PruneEntry(path string) {
+	m.mu.Lock()
+	m.pruned = append(m.pruned, path)
+	m.mu.Unlock()
+}
+
+// prunedSnapshot returns a race-free copy of the PruneEntry call log so tests
+// can poll for the prune without racing the Run goroutine.
+func (m *mockMetrics) prunedSnapshot() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.pruned))
+	copy(out, m.pruned)
+	return out
+}
 
 func (m *mockMetrics) IngestRateLimit(path string, snap *session.RateLimitSnapshot) {}
 


### PR DESCRIPTION
## The race

`processActivity` runs on the single detector event-loop goroutine. When a session has no PID yet it spawns a background discovery goroutine (`go d.pidMgr.DiscoverPIDWithRetry` in `onNewSession`, `go d.pidMgr.TryDiscoverPID` in `processActivity`). That goroutine reaches `HandlePIDAssigned → assignPIDLocked`, which loads the session and writes `state.PID` / `state.UpdatedAt` / `state.Launcher` on the **shared `*SessionState` pointer**. Meanwhile the same `processActivity` pass writes `state.State` / `state.UpdatedAt` on that same pointer.

`assignMu` — despite the "Locked" in `assignPIDLocked` — only serialized the PID-assignment critical sections **against each other** (two concurrent discoveries) and against `claimedPIDs`. It did **not** synchronize with the detector loop's own load-modify-save. So under `-race` scheduling pressure the two writers collided:

```
Write by goroutine X:  assignPIDLocked            pid_manager.go
  ← HandlePIDAssigned ← TryDiscoverPID
  ← processActivity.gowrap1 (spawned goroutine)   session_detector_activity.go
Previous write by goroutine Y: processActivity     session_detector_activity.go
  ← onActivity ← handleTranscriptEvent ← Run
```

It reproduced only under full-suite `-race` load; targeted reruns passed.

## The fix (synchronization, no sleeps)

Extend `assignMu` to also guard the detector loop's per-event load-modify-save. `processActivity`'s post-load body moved into `processActivityLocked`, which now runs under the new `PIDManager.WithSessionStateLock` — the helper that holds `assignMu`, the same lock `assignPIDLocked` takes. The spawned discovery goroutine and the event loop are now mutually exclusive on the shared state: the goroutine simply blocks on `assignMu` until the loop releases it.

- No new mutex, no widened state — reuses `assignMu`, whose doc is updated to reflect the broadened responsibility.
- No lock inversion: none of the inline helpers `processActivityLocked` calls (`cleanupChildren`, `reevaluateParent`, `finishOrphanedChildren`, `ConsumePendingPID`, `captureLauncher`, …) take `assignMu`; the only `assignMu` consumer it reaches is the *spawned* `go TryDiscoverPID`, which runs on its own goroutine.
- Scope matches the existing lock: `assignPIDLocked` already held `assignMu` across `repo.Save` + `repo.ListAll`, so holding it across the detector's save is consistent.

## Test robustness (the flaky siblings)

The two tests named in the issue plus several same-family tests used fixed `time.Sleep` waits and, in some cases, read shared state a *detached* discovery goroutine still owned — flaking (and racing) only under parallel full-suite load. Replaced the fixed waits with poll-for-condition helpers, mirroring the existing `waitForSessionState` pattern (#578):

- `Removed_TransitionsToReady`, `Removed_PrunesMetricsLedger` (named in #606)
- `CWDFallback_DoesNotAssignDuplicatePID`, `CWDFallback_CleansUpOldSessionOnClear`, `ClearWithStaleMetadata_DeletesOldSessionImmediately`, `OrphanedSubagentsFinishWhenParentTurnDone`, `Activity_NoSubstantiveActivity_HoldsState`, `Activity_SubstantivePass_StillClassifies`

New helpers: `waitForPID`, `waitForSessionDeleted`, `waitForCondition`, locked `pidOf`/`eventCountOf` probes, and a mutex-guarded `mockMetrics` with `prunedSnapshot`. None of these change production behavior.

## Test evidence

- `go test ./core/application/services/ -race -count=10` — green (was a reliable race repro before the fix).
- Same package green under **3 concurrent test processes + 8 `yes` CPU burners** (heavy scheduling pressure); the touched tests green at `-count=40`.
- `go test ./core/... -race -count=1` — green **three times** (all 35 packages, including the daemon smoke test and e2e; no `TestGastownReplay`/#586 flake observed in these runs).
- `go vet ./core/...` clean.

Note: under deliberately absurd oversubscription (4 concurrent processes + 10 burners on 10 cores) one unrelated test, `TestSessionDetector_ParentBadgeCleared_WhenChildSweptWhileParentWaiting`, flaked once with **no data race** — a pre-existing tight-`readyTTL` (1s) vs wall-clock fragility untouched by this PR (passes targeted at `-count=30`). Out of scope here.

Fixes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)