### PR TITLE
fix(eta): v3 instruction — mandatory per-phase marker via Bash description

### DIFF
--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -45,6 +45,13 @@ const (
 // survive the claude ≥2.1.162 transcript text-drop that eats mid-task prose.
 // patchManagedBlock's content compare upgrades installed v1 blocks in place
 // on the next daemon start.
+//
+// v3 (#617): the v2 "you may also" phrasing under-binds in prose-less
+// sessions — a live debugging session (ad880389) emitted the first 0/5
+// marker and then nothing across 41 Bash calls and two prose blocks,
+// pinning the chip at "estimating…" for its whole duration. v3 makes the
+// per-phase update mandatory and names the Bash `description` field as the
+// required carrier when no response text is coming.
 const managedTaskEtaBlock = taskEtaBeginSentinel + `
 ## Task progress markers (managed by Irrlicht)
 
@@ -58,9 +65,11 @@ your response text, and update it as you make progress:
 
 ` + "`total_rounds`" + ` is your estimate of the task's phases; ` + "`completed_rounds`" + `
 is how many you've finished. Emit the first marker in your first response,
-right before your first tool call. Update every few steps; you may also
-append the marker to the ` + "`description`" + ` of a Bash call you are
-already making (never to the command itself).
+right before your first tool call. After each phase you complete, emit
+the updated marker: append it to the ` + "`description`" + ` of the next Bash call
+you make (never to the command itself), or include it in your response
+text when no Bash call is coming — long tool-call stretches with no prose
+must still carry markers via the description field.
 ` + taskEtaEndSentinel
 
 // claudeMemoryPath returns the user-level Claude Code instruction file path.

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -51,7 +51,9 @@ const (
 // marker and then nothing across 41 Bash calls and two prose blocks,
 // pinning the chip at "estimating…" for its whole duration. v3 makes the
 // per-phase update mandatory and names the Bash `description` field as the
-// required carrier when no response text is coming.
+// required carrier when no response text is coming. No extra reinforcement
+// clause beyond that: the 2026-05-31 emission experiment found the lightest
+// phrasing binds best, so v3 adds obligation, not length.
 const managedTaskEtaBlock = taskEtaBeginSentinel + `
 ## Task progress markers (managed by Irrlicht)
 
@@ -68,8 +70,7 @@ is how many you've finished. Emit the first marker in your first response,
 right before your first tool call. After each phase you complete, emit
 the updated marker: append it to the ` + "`description`" + ` of the next Bash call
 you make (never to the command itself), or include it in your response
-text when no Bash call is coming — long tool-call stretches with no prose
-must still carry markers via the description field.
+text when no Bash call is coming.
 ` + taskEtaEndSentinel
 
 // claudeMemoryPath returns the user-level Claude Code instruction file path.

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -112,10 +112,29 @@ func TestEnsureTaskEtaBlock_UpgradesStaleBlock(t *testing.T) {
 	}
 }
 
-func TestEnsureTaskEtaBlock_V1BlockUpgradesToV2(t *testing.T) {
+// assertCurrentEtaContract checks the phrases every shipped-block upgrade
+// must land on: first marker before any tool call (#604/#602), the Bash
+// description carrier as the mandatory per-phase update channel (#617), and
+// the command-field prohibition (permission matching).
+func assertCurrentEtaContract(t *testing.T, content string) {
+	t.Helper()
+	if !strings.Contains(content, "first marker in your first response") {
+		t.Error("block must ask for the first marker before any tool call")
+	}
+	if !strings.Contains(content, "After each phase you complete") {
+		t.Error("block must make the per-phase update mandatory")
+	}
+	if !strings.Contains(content, "`description` of the next Bash call") {
+		t.Error("block must name the Bash description carrier as the update channel")
+	}
+	if !strings.Contains(content, "never to the command itself") {
+		t.Error("block must forbid the command field (permission matching)")
+	}
+}
+
+func TestEnsureTaskEtaBlock_V1BlockUpgrades(t *testing.T) {
 	// The exact v1 block (shipped with #558) must upgrade in place to the
-	// v2 contract (#604/#602): first marker before any tool call + the Bash
-	// description carrier.
+	// current contract.
 	home := withTempHome(t)
 	path := memoryPathFor(home)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -144,18 +163,55 @@ is how many you've finished. Update every few steps.
 		t.Fatal(err)
 	}
 	if !modified {
-		t.Fatal("v1 block should upgrade to v2")
+		t.Fatal("v1 block should upgrade in place")
+	}
+	assertCurrentEtaContract(t, readFileString(t, path))
+}
+
+func TestEnsureTaskEtaBlock_V2BlockUpgradesToV3(t *testing.T) {
+	// The exact v2 block (shipped with #604/#602) must upgrade in place to
+	// the v3 contract (#617): the description carrier becomes the mandatory
+	// per-phase update channel instead of an optional one — v2's "you may
+	// also" under-bound in prose-less sessions, pinning the chip at
+	// "estimating…" (session ad880389).
+	home := withTempHome(t)
+	path := memoryPathFor(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v2 := taskEtaBeginSentinel + `
+## Task progress markers (managed by Irrlicht)
+
+As you work on a multi-step task, periodically emit a hidden progress marker
+so tools can show a task-completion estimate. Emit it as an HTML comment in
+your response text, and update it as you make progress:
+
+` + "```" + `
+<!-- {"marker":"irrlicht-eta","total_rounds":N,"completed_rounds":M} -->
+` + "```" + `
+
+` + "`total_rounds`" + ` is your estimate of the task's phases; ` + "`completed_rounds`" + `
+is how many you've finished. Emit the first marker in your first response,
+right before your first tool call. Update every few steps; you may also
+append the marker to the ` + "`description`" + ` of a Bash call you are
+already making (never to the command itself).
+` + taskEtaEndSentinel
+	if err := os.WriteFile(path, []byte(v2+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureTaskEtaBlockInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("v2 block should upgrade to v3")
 	}
 	content := readFileString(t, path)
-	if !strings.Contains(content, "first marker in your first response") {
-		t.Error("v2 block must ask for the first marker before any tool call")
+	if strings.Contains(content, "you may also") {
+		t.Error("v2's permissive carrier phrasing survived the upgrade")
 	}
-	if !strings.Contains(content, "`description` of a Bash call") {
-		t.Error("v2 block must permit the Bash description carrier")
-	}
-	if !strings.Contains(content, "never to the command itself") {
-		t.Error("v2 block must forbid the command field (permission matching)")
-	}
+	assertCurrentEtaContract(t, content)
 }
 
 func TestPatchManagedBlock_AppendAddsSingleBlankLine(t *testing.T) {


### PR DESCRIPTION
Closes #617.

## Problem

The v2 installed instruction phrases the drop-proof carrier as optional ("you may also append the marker to the `description` of a Bash call"). In heads-down sessions — long thinking+tool_use chains with almost no prose — that under-binds: session `ad880389` emitted the first `0/5` marker and then nothing across **41 Bash calls** (0/41 descriptions carried a marker) and 2 prose blocks, so `completed_rounds` stayed 0 and the chip showed "estimating…" for the entire session.

## Change

- `instructioninstaller.go`: v3 block text — after each completed phase the agent **must** emit the updated marker, appended to the next Bash call's `description` (or in response text when no Bash call is coming). v1 marker contract unchanged; `hooks.go`'s tool-input scan already picks descriptions up, and `patchManagedBlock`'s content compare upgrades installed v1/v2 blocks in place on next daemon start.
- Tests: shared `assertCurrentEtaContract` helper; v1-upgrade test retargeted to the current contract; new exact-v2→v3 upgrade test that also asserts the permissive phrasing is gone.

## Testing

- `go test ./core/... -race -count=1` ✓
- `go test ./tools/onboarding-factory/... -race -count=1` ✓
- `tools/replay-fixtures.sh` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)