### PR TITLE
fix(tailer): authoritative task IDs from TaskCreate results; clear pruned task lists

### DIFF
--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -363,6 +363,7 @@ func scanMessageContent(raw map[string]interface{}, ev *tailer.ParsedEvent) stri
 	// background with ID: …" from creating a phantom background process.
 	// See issue #445.
 	bgTaskID := backgroundTaskIDOf(raw)
+	createdTaskID := createdTaskIDOf(raw)
 	var askUserQuestion string
 	for _, item := range contentArr {
 		block, ok := item.(map[string]interface{})
@@ -375,7 +376,7 @@ func scanMessageContent(raw map[string]interface{}, ev *tailer.ParsedEvent) stri
 				askUserQuestion = q
 			}
 		case "tool_result":
-			collectToolResult(block, ev, bgTaskID)
+			collectToolResult(block, ev, bgTaskID, createdTaskID)
 		case "text":
 			// Task-estimate markers live in the agent's own prose, so only
 			// assistant events qualify (a user pasting a marker must not feed
@@ -417,6 +418,10 @@ func collectToolUse(block map[string]interface{}, ev *tailer.ParsedEvent) string
 			Subject:     subject,
 			Description: desc,
 			ActiveForm:  activeForm,
+			// The authoritative task ID only exists in the tool_result
+			// (`toolUseResult.task.id`); carry the tool_use id so the tailer
+			// can pair the later assign_id delta with this create. See #615.
+			ToolUseID: id,
 		})
 	case "TaskUpdate":
 		taskID, _ := input["taskId"].(string)
@@ -473,13 +478,23 @@ func backgroundID(input map[string]interface{}) string {
 // `toolUseResult.backgroundTaskId` ("" when absent) — a spawn is recorded only
 // when it is present, so arbitrary tool output echoing the launch phrase can't
 // fabricate a background process. See issue #445.
-func collectToolResult(block map[string]interface{}, ev *tailer.ParsedEvent, bgTaskID string) {
+// createdTaskID is the event's structured `toolUseResult.task.id` ("" when
+// absent) — the authoritative ID of a task created by the matching TaskCreate
+// tool_use; forwarded to the tailer as an assign_id delta. See issue #615.
+func collectToolResult(block map[string]interface{}, ev *tailer.ParsedEvent, bgTaskID, createdTaskID string) {
 	toolUseID, _ := block["tool_use_id"].(string)
 	if toolUseID != "" {
 		ev.ToolResultIDs = append(ev.ToolResultIDs, toolUseID)
 	}
 	if isErr, ok := block["is_error"].(bool); ok && isErr {
 		ev.IsError = true
+	}
+	if createdTaskID != "" && toolUseID != "" {
+		ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
+			Op:        tailer.TaskOpAssignID,
+			ID:        createdTaskID,
+			ToolUseID: toolUseID,
+		})
 	}
 
 	text := toolResultText(block)
@@ -521,6 +536,24 @@ func backgroundTaskIDOf(raw map[string]interface{}) string {
 		return ""
 	}
 	id, _ := tur["backgroundTaskId"].(string)
+	return id
+}
+
+// createdTaskIDOf returns the structured `toolUseResult.task.id` from a Claude
+// Code event, or "" when absent. This top-level field is Claude Code's
+// authoritative record of the ID assigned by a TaskCreate — the tool_use input
+// carries no ID, and reconstructing it by counting creates desyncs whenever a
+// tailer starts mid-session (issue #615).
+func createdTaskIDOf(raw map[string]interface{}) string {
+	tur, ok := raw["toolUseResult"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	task, ok := tur["task"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	id, _ := task["id"].(string)
 	return id
 }
 

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -1340,9 +1340,13 @@ func TestParser_TaskCreate_EmitsTaskDelta(t *testing.T) {
 	if d.ActiveForm != "Writing tests" {
 		t.Errorf("ActiveForm = %q", d.ActiveForm)
 	}
-	// ID is empty on create — the tailer assigns it sequentially.
+	// ID is empty on create — the authoritative one arrives in the
+	// tool_result (assign_id delta); the tailer numbers provisionally.
 	if d.ID != "" {
 		t.Errorf("ID should be empty on create, got %q", d.ID)
+	}
+	if d.ToolUseID != "tu_1" {
+		t.Errorf("ToolUseID = %q, want tu_1 (pairs the create with its result)", d.ToolUseID)
 	}
 }
 
@@ -1652,5 +1656,240 @@ func TestTailer_TaskReminder_SyncsDivergingStatus(t *testing.T) {
 	}
 	if len(m.Tasks) != 1 || m.Tasks[0].Status != tailer.TaskStatusCompleted {
 		t.Errorf("expected task 1 reconciled to completed, got %+v", m.Tasks)
+	}
+}
+
+// --- authoritative task IDs from TaskCreate tool_results (issue #615) ---
+
+// makeTaskCreateResultEvent builds the user event Claude Code writes for a
+// TaskCreate's tool_result: the assigned ID lives in the structured
+// `toolUseResult.task.id` (sibling to `message`), not in the tool_use input.
+func makeTaskCreateResultEvent(toolUseID, taskID string) map[string]interface{} {
+	return map[string]interface{}{
+		"type":      "user",
+		"timestamp": "2026-04-05T22:00:01Z",
+		"message": map[string]interface{}{
+			"role": "user",
+			"content": []interface{}{
+				map[string]interface{}{
+					"type":        "tool_result",
+					"tool_use_id": toolUseID,
+					"content":     "Task #" + taskID + " created successfully",
+				},
+			},
+		},
+		"toolUseResult": map[string]interface{}{
+			"task": map[string]interface{}{"id": taskID, "subject": "whatever"},
+		},
+	}
+}
+
+// appendTranscript appends more JSONL lines to an existing transcript, so a
+// test can model new activity arriving between TailAndProcess passes.
+func appendTranscript(t *testing.T, path string, lines []map[string]interface{}) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, line := range lines {
+		if err := enc.Encode(line); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestParser_TaskCreateResult_EmitsAssignIDDelta(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(makeTaskCreateResultEvent("tu_1", "10"))
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if len(ev.TaskDeltas) != 1 {
+		t.Fatalf("TaskDeltas len = %d, want 1", len(ev.TaskDeltas))
+	}
+	d := ev.TaskDeltas[0]
+	if d.Op != tailer.TaskOpAssignID {
+		t.Errorf("Op = %q, want %q", d.Op, tailer.TaskOpAssignID)
+	}
+	if d.ID != "10" {
+		t.Errorf("ID = %q, want 10", d.ID)
+	}
+	if d.ToolUseID != "tu_1" {
+		t.Errorf("ToolUseID = %q, want tu_1", d.ToolUseID)
+	}
+}
+
+func TestParser_PlainToolResult_NoAssignIDDelta(t *testing.T) {
+	// A tool_result without toolUseResult.task (any non-TaskCreate tool)
+	// must not fabricate an assign_id delta.
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type":      "user",
+		"timestamp": "2026-04-05T22:00:01Z",
+		"message": map[string]interface{}{
+			"role": "user",
+			"content": []interface{}{
+				map[string]interface{}{
+					"type":        "tool_result",
+					"tool_use_id": "tu_9",
+					"content":     "ok",
+				},
+			},
+		},
+		"toolUseResult": map[string]interface{}{"success": true},
+	})
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if len(ev.TaskDeltas) != 0 {
+		t.Errorf("TaskDeltas = %+v, want none", ev.TaskDeltas)
+	}
+}
+
+// TestTailer_TaskCreateResult_AlignsIDsMidSession models the #615 trigger: a
+// tailer that starts mid-session (live-session adoption, daemon restart with
+// a pruned ledger) cannot reconstruct Claude's monotonic task numbering by
+// counting creates. The result-carried IDs must win, so TaskUpdates and
+// task_reminder snapshots referencing the real IDs keep matching.
+func TestTailer_TaskCreateResult_AlignsIDsMidSession(t *testing.T) {
+	// Transcript begins at Claude's third batch — IDs 10..12.
+	events := []map[string]interface{}{
+		makeToolUseEvent("tu_1", "TaskCreate", map[string]interface{}{
+			"subject": "Scripts", "activeForm": "Scripting",
+		}),
+		makeTaskCreateResultEvent("tu_1", "10"),
+		makeToolUseEvent("tu_2", "TaskCreate", map[string]interface{}{
+			"subject": "Swift", "activeForm": "Swifting",
+		}),
+		makeTaskCreateResultEvent("tu_2", "11"),
+		makeToolUseEvent("tu_3", "TaskCreate", map[string]interface{}{
+			"subject": "Docs", "activeForm": "Docsing",
+		}),
+		makeTaskCreateResultEvent("tu_3", "12"),
+		makeToolUseEvent("tu_4", "TaskUpdate", map[string]interface{}{
+			"taskId": "10", "status": "completed",
+		}),
+		makeToolUseEvent("tu_5", "TaskUpdate", map[string]interface{}{
+			"taskId": "11", "status": "in_progress",
+		}),
+		// Reminder carries the real IDs — with counter-derived IDs (1..3)
+		// this snapshot used to prune the whole batch.
+		makeReminderEvent([]map[string]interface{}{
+			{"id": "10", "subject": "Scripts", "status": "completed"},
+			{"id": "11", "subject": "Swift", "status": "in_progress"},
+			{"id": "12", "subject": "Docs", "status": "pending"},
+		}),
+	}
+
+	m, err := newCCTailer(writeTranscript(t, events)).TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+	if len(m.Tasks) != 3 {
+		t.Fatalf("Tasks len = %d, want 3; tasks=%+v", len(m.Tasks), m.Tasks)
+	}
+	want := []struct{ id, status string }{
+		{"10", tailer.TaskStatusCompleted},
+		{"11", tailer.TaskStatusInProgress},
+		{"12", tailer.TaskStatusPending},
+	}
+	for i, w := range want {
+		if m.Tasks[i].ID != w.id || m.Tasks[i].Status != w.status {
+			t.Errorf("task[%d] = %+v, want id=%s status=%s", i, m.Tasks[i], w.id, w.status)
+		}
+	}
+}
+
+// TestTailer_TaskSeq_SurvivesLedgerRestart pins the counter-fallback half of
+// #615: even for transcripts whose results carry no toolUseResult.task.id,
+// the provisional counter must survive a daemon restart. Restoring it as
+// len(Tasks) understated it after completed batches were pruned, so the next
+// batch reused low IDs and every TaskUpdate missed.
+func TestTailer_TaskSeq_SurvivesLedgerRestart(t *testing.T) {
+	path := writeTranscript(t, []map[string]interface{}{
+		// Batch 1 — IDs 1 and 2, completed, pruned by the empty reminder.
+		makeToolUseEvent("tu_1", "TaskCreate", map[string]interface{}{
+			"subject": "Old A", "activeForm": "Old-Aing",
+		}),
+		makeToolUseEvent("tu_2", "TaskCreate", map[string]interface{}{
+			"subject": "Old B", "activeForm": "Old-Bing",
+		}),
+		makeToolUseEvent("tu_3", "TaskUpdate", map[string]interface{}{
+			"taskId": "1", "status": "completed",
+		}),
+		makeToolUseEvent("tu_4", "TaskUpdate", map[string]interface{}{
+			"taskId": "2", "status": "completed",
+		}),
+		makeReminderEvent([]map[string]interface{}{}),
+	})
+	tl1 := newCCTailer(path)
+	if _, err := tl1.TailAndProcess(); err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+
+	// Persist + rehydrate through JSON, as the daemon's ledger store does.
+	raw, err := json.Marshal(tl1.GetLedgerState())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored tailer.LedgerState
+	if err := json.Unmarshal(raw, &restored); err != nil {
+		t.Fatal(err)
+	}
+	if restored.TaskSeq != 2 {
+		t.Fatalf("persisted TaskSeq = %d, want 2", restored.TaskSeq)
+	}
+
+	// Batch 2 arrives after the restart — Claude numbers it 3 and 4.
+	appendTranscript(t, path, []map[string]interface{}{
+		makeToolUseEvent("tu_5", "TaskCreate", map[string]interface{}{
+			"subject": "New A", "activeForm": "New-Aing",
+		}),
+		makeToolUseEvent("tu_6", "TaskCreate", map[string]interface{}{
+			"subject": "New B", "activeForm": "New-Bing",
+		}),
+		makeToolUseEvent("tu_7", "TaskUpdate", map[string]interface{}{
+			"taskId": "3", "status": "completed",
+		}),
+	})
+	tl2 := newCCTailer(path)
+	tl2.SetLedgerState(restored)
+	m, err := tl2.TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess after restart: %v", err)
+	}
+	if len(m.Tasks) != 2 {
+		t.Fatalf("Tasks len = %d, want 2; tasks=%+v", len(m.Tasks), m.Tasks)
+	}
+	if m.Tasks[0].ID != "3" || m.Tasks[0].Status != tailer.TaskStatusCompleted {
+		t.Errorf("task[0] = %+v, want id=3 completed (update must match)", m.Tasks[0])
+	}
+	if m.Tasks[1].ID != "4" || m.Tasks[1].Status != tailer.TaskStatusPending {
+		t.Errorf("task[1] = %+v, want id=4 pending", m.Tasks[1])
+	}
+}
+
+// TestTailer_PrunedToEmpty_EmitsNonNilTasks pins the bug-B half of #615: once
+// a session has seen tasks, an emptied list must surface as a non-nil empty
+// slice. MergeMetrics reads nil as "no data yet" and would resurrect the
+// stale pre-prune list in the session record forever.
+func TestTailer_PrunedToEmpty_EmitsNonNilTasks(t *testing.T) {
+	m, err := newCCTailer(writeTranscript(t, []map[string]interface{}{
+		makeToolUseEvent("tu_1", "TaskCreate", map[string]interface{}{
+			"subject": "A", "activeForm": "Aing",
+		}),
+		makeReminderEvent([]map[string]interface{}{}),
+	})).TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+	if m.Tasks == nil {
+		t.Fatal("Tasks = nil after prune-to-empty, want non-nil empty slice")
+	}
+	if len(m.Tasks) != 0 {
+		t.Fatalf("Tasks = %+v, want empty", m.Tasks)
 	}
 }

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -1803,6 +1803,60 @@ func TestTailer_TaskCreateResult_AlignsIDsMidSession(t *testing.T) {
 	}
 }
 
+// TestTailer_ParallelTaskCreates_NoIDCollision pins the assign-loop scan
+// direction: with parallel TaskCreates (one assistant message, several
+// tool_use blocks) and a provisional counter lagging Claude's numbering by
+// less than the batch size, an already-assigned authoritative ID collides
+// with a later create's provisional one. A forward scan re-assigned the
+// earlier (authoritative) task, silently swapping subject↔ID pairs; the
+// reverse scan always finds the still-provisional task, which is created
+// later than any authoritative holder of the same ID. See issue #615.
+func TestTailer_ParallelTaskCreates_NoIDCollision(t *testing.T) {
+	// Transcript opens mid-session: Claude's numbering continues at 3 while
+	// the tailer's counter starts at 0. Three creates land in ONE assistant
+	// message before any result — provisionals 1/2/3 vs authoritative 3/4/5,
+	// so authoritative "3" collides with the third create's provisional "3".
+	parallelCreates := map[string]interface{}{
+		"type":      "assistant",
+		"timestamp": "2026-04-05T22:00:00Z",
+		"message": map[string]interface{}{
+			"role":        "assistant",
+			"stop_reason": "tool_use",
+			"content": []interface{}{
+				map[string]interface{}{"type": "tool_use", "id": "tu_1", "name": "TaskCreate",
+					"input": map[string]interface{}{"subject": "Alpha", "activeForm": "Alphaing"}},
+				map[string]interface{}{"type": "tool_use", "id": "tu_2", "name": "TaskCreate",
+					"input": map[string]interface{}{"subject": "Beta", "activeForm": "Betaing"}},
+				map[string]interface{}{"type": "tool_use", "id": "tu_3", "name": "TaskCreate",
+					"input": map[string]interface{}{"subject": "Gamma", "activeForm": "Gammaing"}},
+			},
+		},
+	}
+	m, err := newCCTailer(writeTranscript(t, []map[string]interface{}{
+		parallelCreates,
+		makeTaskCreateResultEvent("tu_1", "3"),
+		makeTaskCreateResultEvent("tu_2", "4"),
+		makeTaskCreateResultEvent("tu_3", "5"),
+	})).TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+	if len(m.Tasks) != 3 {
+		t.Fatalf("Tasks len = %d, want 3; tasks=%+v", len(m.Tasks), m.Tasks)
+	}
+	want := []struct{ id, subject string }{
+		{"3", "Alpha"},
+		{"4", "Beta"},
+		{"5", "Gamma"},
+	}
+	for i, w := range want {
+		if m.Tasks[i].ID != w.id || m.Tasks[i].Subject != w.subject {
+			t.Errorf("task[%d] = id=%s subject=%q, want id=%s subject=%q",
+				i, m.Tasks[i].ID, m.Tasks[i].Subject, w.id, w.subject)
+		}
+	}
+}
+
 // TestTailer_TaskSeq_SurvivesLedgerRestart pins the counter-fallback half of
 // #615: even for transcripts whose results carry no toolUseResult.task.id,
 // the provisional counter must survive a daemon restart. Restoring it as

--- a/core/adapters/outbound/metrics/ledger.go
+++ b/core/adapters/outbound/metrics/ledger.go
@@ -11,7 +11,11 @@ import (
 	"irrlicht/core/pkg/tailer"
 )
 
-const ledgerSchemaVersion = 2 // bumped to force re-scan for task support
+// Bumped to 3 for #615 (authoritative task IDs from TaskCreate results +
+// persisted TaskSeq): invalidating pre-fix ledgers forces a full re-scan that
+// rebuilds desynced task lists with correct IDs. Must match the version
+// stamped by tailer.GetLedgerState.
+const ledgerSchemaVersion = 3
 
 // LedgerSuffix is the filename suffix used for per-session ledger files.
 // Exposed so the daemon-startup orphan sweep can filter directory entries

--- a/core/domain/session/session_test.go
+++ b/core/domain/session/session_test.go
@@ -330,6 +330,24 @@ func TestMergeMetrics_CumFields(t *testing.T) {
 	}
 }
 
+// MergeMetrics task-list semantics: nil = "no data yet" (carry the old list),
+// non-nil empty = "no tasks" (clear it). The tailer emits the empty slice
+// after a prune-to-empty — without the distinction the stale pre-prune list
+// was resurrected in the session record forever. See issue #615.
+func TestMergeMetrics_Tasks_EmptyClearsStaleNilCarries(t *testing.T) {
+	oldM := &SessionMetrics{Tasks: []Task{{ID: "5", Subject: "stale", Status: "pending"}}}
+
+	carried := MergeMetrics(&SessionMetrics{Tasks: nil}, oldM)
+	if len(carried.Tasks) != 1 || carried.Tasks[0].ID != "5" {
+		t.Errorf("nil Tasks must carry the old list, got %+v", carried.Tasks)
+	}
+
+	cleared := MergeMetrics(&SessionMetrics{Tasks: []Task{}}, oldM)
+	if cleared.Tasks == nil || len(cleared.Tasks) != 0 {
+		t.Errorf("empty Tasks must clear the old list, got %+v", cleared.Tasks)
+	}
+}
+
 func TestSessionState_LauncherJSONRoundTrip(t *testing.T) {
 	// With Launcher present.
 	in := &SessionState{

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -34,6 +34,12 @@ const (
 
 	TaskOpCreate = "create"
 	TaskOpUpdate = "update"
+	// TaskOpAssignID carries the authoritative task ID from a TaskCreate
+	// tool_result back to the provisionally-numbered task created by the
+	// matching tool_use (paired via ToolUseID). Claude Code's task IDs are
+	// monotonic per session, so a tailer that starts (or restarts) mid-session
+	// cannot reconstruct them by counting creates — see issue #615.
+	TaskOpAssignID = "assign_id"
 )
 
 // Task represents a single item in the session's Claude Code task list,
@@ -52,14 +58,16 @@ type Task struct {
 }
 
 // TaskDelta is emitted by the Claude Code parser for each TaskCreate or
-// TaskUpdate tool_use block. The tailer folds deltas into its tasks slice.
+// TaskUpdate tool_use block, and for each TaskCreate tool_result carrying the
+// authoritative task ID. The tailer folds deltas into its tasks slice.
 type TaskDelta struct {
-	Op          string // "create" | "update"
-	ID          string // set on update (matches taskId input); empty on create
+	Op          string // "create" | "update" | "assign_id"
+	ID          string // update: taskId input; assign_id: toolUseResult.task.id; empty on create
 	Subject     string // TaskCreate only
 	Description string // TaskCreate only
 	ActiveForm  string // TaskCreate only
 	Status      string // TaskUpdate only; "pending" on create is applied by tailer
+	ToolUseID   string // create: the TaskCreate tool_use id; assign_id: the result's tool_use_id
 }
 
 // TaskSnapshotEntry is one row in a Claude Code task_reminder attachment, an
@@ -357,6 +365,15 @@ type LedgerState struct {
 	CumProviderCostUSD float64                    `json:"cum_provider_cost_usd,omitempty"`
 	ParserState        *ParserLedger              `json:"parser_state,omitempty"`
 	Tasks              []Task                     `json:"tasks,omitempty"`
+	// TaskSeq persists the provisional-ID counter. Claude Code's task IDs are
+	// monotonic per session while completed batches are pruned from Tasks, so
+	// len(Tasks) understates the counter after a restart and every subsequent
+	// TaskUpdate would miss its target. See issue #615.
+	TaskSeq int `json:"task_seq,omitempty"`
+	// PendingTaskCreates persists in-flight TaskCreate calls (tool_use id →
+	// provisional task ID) so a restart between a create's tool_use and its
+	// result can still apply the authoritative ID. See issue #615.
+	PendingTaskCreates map[string]string `json:"pending_task_creates,omitempty"`
 	// BackgroundProcs persists the open-background-process set (background id
 	// → output path) so a daemon restart keeps holding the session `working`
 	// for processes still alive. See issue #445.

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -284,9 +284,18 @@ type TranscriptTailer struct {
 	// tasks accumulates the session's task list from TaskCreate / TaskUpdate
 	// tool_use events parsed by the Claude Code adapter.
 	tasks []Task
-	// taskSeq is the next sequential ID to assign on TaskCreate.
-	// Invariant: taskSeq == len(tasks) always (tasks are never removed).
+	// taskSeq is the provisional ID counter for TaskCreate. The authoritative
+	// ID arrives one line later in the create's tool_result (assign_id delta)
+	// and replaces the provisional one; the counter is only the fallback for
+	// transcripts that never carry toolUseResult.task.id. NOT len(tasks):
+	// completed batches are pruned by reconcileTaskSnapshot while Claude's
+	// numbering keeps climbing. See issue #615.
 	taskSeq int
+	// pendingTaskCreates maps a TaskCreate's tool_use id to the provisional
+	// task ID it was assigned, so the tool_result's authoritative ID
+	// (assign_id delta) can be applied to the right task. Entries resolve on
+	// the result line either way. See issue #615.
+	pendingTaskCreates map[string]string
 
 	// openBackgroundProcs is the set of agent-spawned background processes
 	// still believed running, keyed by background id with the output-file
@@ -335,6 +344,7 @@ func NewTranscriptTailer(path string, parser TranscriptParser, adapter string) *
 		openToolCalls:       make(map[string]string),
 		openBackgroundProcs: make(map[string]string),
 		pendingBashPolls:    make(map[string]string),
+		pendingTaskCreates:  make(map[string]string),
 		cumByModel:          make(map[string]*UsageBreakdown),
 		metrics: &SessionMetrics{
 			MessageHistory: make([]MessageEvent, 0),
@@ -356,7 +366,7 @@ func (t *TranscriptTailer) DisableModelConfigFallback() {
 // can be persisted to disk and rehydrated after a daemon restart.
 func (t *TranscriptTailer) GetLedgerState() LedgerState {
 	s := LedgerState{
-		SchemaVersion:      2,
+		SchemaVersion:      3,
 		LastOffset:         t.lastOffset,
 		CumProviderCostUSD: t.cumProviderCostUSD,
 		ModelName:          t.metrics.ModelName,
@@ -373,6 +383,12 @@ func (t *TranscriptTailer) GetLedgerState() LedgerState {
 	}
 	if len(t.tasks) > 0 {
 		s.Tasks = append([]Task(nil), t.tasks...)
+	}
+	s.TaskSeq = t.taskSeq
+	if len(t.pendingTaskCreates) > 0 {
+		ptc := make(map[string]string, len(t.pendingTaskCreates))
+		maps.Copy(ptc, t.pendingTaskCreates)
+		s.PendingTaskCreates = ptc
 	}
 	if len(t.openBackgroundProcs) > 0 {
 		bp := make(map[string]string, len(t.openBackgroundProcs))
@@ -421,7 +437,16 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 	}
 	if len(s.Tasks) > 0 {
 		t.tasks = append([]Task(nil), s.Tasks...)
-		t.taskSeq = len(t.tasks)
+	}
+	// Restore the provisional-ID counter from the persisted value, falling
+	// back to len(Tasks) only for pre-#615 ledgers that didn't carry TaskSeq.
+	// len(Tasks) alone understates the counter once completed batches have
+	// been pruned, desyncing every later TaskCreate from Claude's monotonic
+	// numbering (issue #615).
+	t.taskSeq = max(s.TaskSeq, len(t.tasks))
+	if len(s.PendingTaskCreates) > 0 {
+		t.pendingTaskCreates = make(map[string]string, len(s.PendingTaskCreates))
+		maps.Copy(t.pendingTaskCreates, s.PendingTaskCreates)
 	}
 	if len(s.BackgroundProcs) > 0 {
 		t.openBackgroundProcs = make(map[string]string, len(s.BackgroundProcs))
@@ -486,6 +511,7 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 		t.cumProviderCostUSD = 0
 		t.tasks = nil
 		t.taskSeq = 0
+		t.pendingTaskCreates = make(map[string]string)
 		// Background-process set belongs to the prior file; drop it so a
 		// rotated/truncated transcript doesn't keep a stale session `working`.
 		// See issue #445.
@@ -751,9 +777,10 @@ func (t *TranscriptTailer) FlushIdle() (*SessionMetrics, bool) {
 //     that emitted any deltas for that turn.
 //
 // Snapshots that mention IDs we never saw a TaskCreate for are ignored;
-// the reconcile only acts on pre-existing tasks. t.taskSeq is never reset,
-// so monotonic IDs continue to match Claude's sequential numbering across
-// pruned batches. See issues #282 and #389.
+// the reconcile only acts on pre-existing tasks. Task IDs come from the
+// TaskCreate tool_result (assign_id delta), so they match Claude's
+// numbering even when the tailer started mid-session (issue #615).
+// See issues #282 and #389.
 // eventUnix is the unix-seconds time of a parsed event, 0 when the event
 // carries no timestamp (a 0 CompletedAt means "unstamped", never a stamp at
 // the zero time).
@@ -832,14 +859,40 @@ func (t *TranscriptTailer) processParsedEvent(parsed *ParsedEvent, sawUserBlocki
 	for _, d := range parsed.TaskDeltas {
 		switch d.Op {
 		case TaskOpCreate:
+			// The ID assigned here is provisional — the authoritative one
+			// arrives in the create's tool_result as an assign_id delta and
+			// replaces it. The counter only carries transcripts whose results
+			// don't include toolUseResult.task.id. See issue #615.
 			t.taskSeq++
+			provisional := strconv.Itoa(t.taskSeq)
 			t.tasks = append(t.tasks, Task{
-				ID:          strconv.Itoa(t.taskSeq),
+				ID:          provisional,
 				Subject:     d.Subject,
 				Description: d.Description,
 				ActiveForm:  d.ActiveForm,
 				Status:      TaskStatusPending,
 			})
+			if d.ToolUseID != "" {
+				t.pendingTaskCreates[d.ToolUseID] = provisional
+			}
+		case TaskOpAssignID:
+			provisional, ok := t.pendingTaskCreates[d.ToolUseID]
+			if !ok || d.ID == "" {
+				break
+			}
+			delete(t.pendingTaskCreates, d.ToolUseID)
+			for i := range t.tasks {
+				if t.tasks[i].ID == provisional {
+					t.tasks[i].ID = d.ID
+					break
+				}
+			}
+			// Keep the provisional counter at least at Claude's numbering so
+			// a create whose result never lands (interrupt) still gets a
+			// non-colliding, aligned fallback ID.
+			if n, err := strconv.Atoi(d.ID); err == nil && n > t.taskSeq {
+				t.taskSeq = n
+			}
 		case TaskOpUpdate:
 			for i := range t.tasks {
 				if t.tasks[i].ID == d.ID {
@@ -853,6 +906,14 @@ func (t *TranscriptTailer) processParsedEvent(parsed *ParsedEvent, sawUserBlocki
 				}
 			}
 		}
+	}
+	// A create's pending entry resolves when its tool_result arrives — via
+	// the assign_id delta above when the result carried the ID, or here for
+	// results that didn't (error results), so the map only ever holds
+	// in-flight creates. Runs after the delta loop: the assign_id delta and
+	// its ToolResultID arrive on the same parsed event.
+	for _, id := range parsed.ToolResultIDs {
+		delete(t.pendingTaskCreates, id)
 	}
 
 	// Background-process tracking (Bash run_in_background). A spawn adds the

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -881,7 +881,13 @@ func (t *TranscriptTailer) processParsedEvent(parsed *ParsedEvent, sawUserBlocki
 				break
 			}
 			delete(t.pendingTaskCreates, d.ToolUseID)
-			for i := range t.tasks {
+			// Scan in reverse: when the provisional counter lags Claude's
+			// numbering by less than a parallel-create batch, an already
+			// assigned authoritative ID can collide with a later task's
+			// provisional one. The authoritative holder was necessarily
+			// created earlier (smaller provisional, earlier result), so the
+			// last match is always the still-provisional task.
+			for i := len(t.tasks) - 1; i >= 0; i-- {
 				if t.tasks[i].ID == provisional {
 					t.tasks[i].ID = d.ID
 					break

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -393,9 +393,16 @@ func (t *TranscriptTailer) computeMetrics() {
 	// (rate-limit fields are populated above the empty-MessageHistory
 	// early return so an idle session still surfaces its last-known
 	// snapshot — UI decorates staleness rather than dropping it.)
-	if len(t.tasks) > 0 {
+	switch {
+	case len(t.tasks) > 0:
 		t.metrics.Tasks = append([]Task(nil), t.tasks...)
-	} else {
+	case t.taskSeq > 0:
+		// Had tasks this session but the list emptied (snapshot prune). A
+		// non-nil empty slice tells MergeMetrics "no tasks" — nil would read
+		// as "no data yet" and resurrect the stale pre-prune list in the
+		// session record forever. See issue #615.
+		t.metrics.Tasks = []Task{}
+	default:
 		t.metrics.Tasks = nil
 	}
 


### PR DESCRIPTION
Closes #615.

## What

Session task tracking desynced after any mid-session daemon restart (verified live on session `ab9b9199…`: Claude showed 2 done / 1 working, irrlicht froze on 3 × pending). Two compounding bugs:

### Bug A — task-ID desync (root cause)
Task IDs were reconstructed by **counting TaskCreate deltas**, assuming alignment with Claude Code's monotonic per-session numbering. `SetLedgerState` restored the counter as `len(tasks)` — understated once completed batches were pruned — so after a restart the next batch got low IDs (5/6/7 instead of 10/11/12), every `TaskUpdate` missed, and the reminder snapshot pruned the whole batch.

**Fix:** read the authoritative ID from the TaskCreate **tool_result** (`toolUseResult.task.id`) via a new `assign_id` delta, paired through the create's `tool_use` id. The counter remains only as fallback for transcripts whose results carry no ID, and is now persisted in the ledger (`task_seq`, plus in-flight creates) so the fallback survives restarts too.

### Bug B — stale-list resurrection
A prune-to-empty set `metrics.Tasks = nil`, which `MergeMetrics` treats as "no data yet" and carries the old list forward — the "non-nil empty = no tasks" branch was dead code because the tailer never emitted an empty slice. The frozen `[5,6,7 pending]` list survived multiple restarts via the instance file.

**Fix:** once a session has seen tasks (`taskSeq > 0`), an emptied list surfaces as a non-nil empty slice, so the merge clears the record.

### Migration
Ledger schema bumped 2 → 3: pre-fix ledgers are invalidated and re-scan from offset 0 on the next daemon restart, rebuilding currently-desynced sessions with correct IDs (same mechanism the 1→2 bump used for the original task support).

## Behavior change
After a batch fully completes and Claude's `task_reminder` goes empty, the session's task list now clears (previously the completed batch stayed visible until the next batch). This is the reminder-is-authoritative semantics the prune was built for — it just never reached the session record.

## Tests
- `TestTailer_TaskCreateResult_AlignsIDsMidSession` — the exact #615 shape: tailer adopting a session at batch 3 (IDs 10–12), updates + snapshot must match.
- `TestTailer_TaskSeq_SurvivesLedgerRestart` — counter-fallback half: batch → complete → prune → ledger JSON roundtrip → next batch numbered 3/4, update matches.
- `TestTailer_PrunedToEmpty_EmitsNonNilTasks` + `TestMergeMetrics_Tasks_EmptyClearsStaleNilCarries` — bug B contract on both sides.
- Parser units for `assign_id` extraction + negative case; `ToolUseID` on create deltas.

## Gates
- `go test ./core/... -race -count=1` ✅
- `go test ./tools/onboarding-factory/... -race -count=1` ✅
- `tools/replay-fixtures.sh` ✅ (no golden drift)
- `of validate` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)