### PR TITLE
fix(eta): widen point ETA into a pinned-high range between markers

### DIFF
--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1459,8 +1459,10 @@ struct SessionRowView: View {
     /// Decides the task-completion ETA chip (issue #558) — mirrors the web's
     /// taskEtaPresentation. Nil hides the chip: session not working or no
     /// estimate. Zero completed rounds renders a progress-only "estimating…"
-    /// chip (#602); with progress, a point estimate once half the rounds are
-    /// done, a range below that, and stale dimming when the last marker is
+    /// chip (#602); with progress, a range whose high bound stays pinned at
+    /// the last marker — 1.5× padded below half the rounds, bare at/above
+    /// half so it collapses to a point right at a marker and widens instead
+    /// of counting down (#616) — and stale dimming when the last marker is
     /// older than 3 minutes.
     private func taskEtaPresentation(now: Date = Date()) -> TaskEtaPresentation? {
         guard session.state == .working,
@@ -1484,16 +1486,19 @@ struct SessionRowView: View {
         let remaining = max(0, eta.timeIntervalSince(now))
         let frac = est.totalRounds > 0 ? Double(est.completedRounds) / Double(est.totalRounds) : 0
         // The eta is anchored at the marker (daemon-side): the LOW bound
-        // counts down between marker updates while the HIGH bound — 1.5×
-        // the remaining time as projected AT the marker — stays pinned
-        // until the agent reports fresh progress.
+        // counts down between marker updates while the HIGH bound stays
+        // pinned at the marker until the agent reports fresh progress —
+        // 1.5× the projected remaining time while the rate is barely
+        // measurable (below half the rounds), the bare projected remaining
+        // once it's trusted, so the point estimate widens instead of
+        // counting down naked (#616). No marker timestamp at/above half →
+        // nothing to pin to, keep the point estimate.
+        let factor = frac < 0.5 ? 1.5 : 1.0
         var highSecs: TimeInterval? = nil
-        if frac < 0.5 {
-            if let updated = est.updatedAt {
-                highSecs = max(remaining, eta.timeIntervalSince(updated) * 1.5)
-            } else {
-                highSecs = remaining * 1.5
-            }
+        if let updated = est.updatedAt {
+            highSecs = max(remaining, eta.timeIntervalSince(updated) * factor)
+        } else if frac < 0.5 {
+            highSecs = remaining * 1.5
         }
         let text = etaText(remaining: remaining, highSecs: highSecs)
         var stale = false

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -408,16 +408,20 @@
     // taskEtaPresentation decides the task-completion ETA chip for a session
     // (issue #558, agent-authored estimate). Returns null when the chip must
     // be hidden: session not `working`, no estimate, no reported progress, or
-    // no projected eta. Otherwise { text, stale, title }: a point estimate
-    // ("~12m left") once half the rounds are done, a range ("~8m–12m left")
-    // below that, and stale=true when the last marker is older than 3min so
-    // the chip degrades instead of letting the ETA drift.
+    // no projected eta. Otherwise { text, stale, title }: a range whose HIGH
+    // bound is pinned at the last marker — 1.5× the projected remaining time
+    // below half the rounds ("~8m–12m left"), the bare projected remaining
+    // at/above half (#616) — and stale=true when the last marker is older
+    // than 3min so the chip degrades instead of letting the ETA drift.
     //
     // The eta is anchored at the marker (daemon-side), so the LOW bound
     // counts down in real time between marker updates while the HIGH bound
-    // — 1.5× the remaining time as projected AT the marker — stays pinned
-    // until the agent reports fresh progress: "~3m–5m left" becomes
-    // "~2m–5m left" a minute later, never the other way around.
+    // stays pinned until the agent reports fresh progress: "~3m–5m left"
+    // becomes "~2m–5m left" a minute later, never the other way around.
+    // At/above half the rounds low == high right at a marker, so the range
+    // collapses to a point ("~5m left") and widens as wall clock passes
+    // without fresh progress — never a bare countdown (#616). Mirrored in
+    // SessionListView.swift's taskEtaPresentation.
     function taskEtaPresentation(metrics, state, nowSec) {
       const est = metrics && metrics.task_estimate;
       const eta = metrics && metrics.task_completion_eta;
@@ -436,11 +440,15 @@
       if (!eta) return null;
       const remaining = Math.max(0, Math.floor(eta - nowSec));
       const frac = est.total_rounds > 0 ? est.completed_rounds / est.total_rounds : 0;
+      // 1.5× padding while the rate is barely measurable, bare projected
+      // remaining once it's trusted; no marker timestamp at/above half →
+      // nothing to pin to, keep the point estimate.
+      const factor = frac < 0.5 ? 1.5 : 1;
       let highSecs = null;
-      if (frac < 0.5) {
-        highSecs = est.updated_at > 0
-          ? Math.max(remaining, Math.floor((eta - est.updated_at) * 1.5))
-          : Math.floor(remaining * 1.5);
+      if (est.updated_at > 0) {
+        highSecs = Math.max(remaining, Math.floor((eta - est.updated_at) * factor));
+      } else if (frac < 0.5) {
+        highSecs = Math.floor(remaining * 1.5);
       }
       const text = fmtEtaText(remaining, highSecs);
       const ageSec = est.updated_at > 0 ? Math.max(0, Math.floor(nowSec - est.updated_at)) : 0;

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -349,12 +349,19 @@ describe('taskEtaPresentation', () => {
     ...((over && over.metrics) || {}),
   })
 
-  test('point estimate once half the rounds are done', () => {
-    const info = taskEtaPresentation(metricsFor(), 'working', now)
+  test('point estimate at the marker once half the rounds are done', () => {
+    const info = taskEtaPresentation(metricsFor({ est: { updated_at: now } }), 'working', now)
     expect(info).not.toBeNull()
     expect(info.text).toBe('~12m left')
     expect(info.stale).toBe(false)
     expect(info.title).toContain('6/10 rounds')
+  })
+
+  test('point estimate widens into a range between markers — high pinned, no bare countdown (#616)', () => {
+    const m = metricsFor({ est: { updated_at: now } })
+    expect(taskEtaPresentation(m, 'working', now).text).toBe('~12m left')
+    expect(taskEtaPresentation(m, 'working', now + 120).text).toBe('~10m–12m left')
+    expect(taskEtaPresentation(m, 'working', now + 300).text).toBe('~7m–12m left')
   })
 
   test('range when completed fraction is below half — high pinned at the marker', () => {
@@ -420,7 +427,7 @@ describe('taskEtaPresentation', () => {
   })
 
   test('hour-scale remaining uses h+m resolution', () => {
-    const info = taskEtaPresentation(metricsFor({ metrics: { task_completion_eta: now + 5400 } }), 'working', now)
+    const info = taskEtaPresentation(metricsFor({ est: { updated_at: now }, metrics: { task_completion_eta: now + 5400 } }), 'working', now)
     expect(info.text).toBe('~1h30m left')
   })
 })

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -364,6 +364,13 @@ describe('taskEtaPresentation', () => {
     expect(taskEtaPresentation(m, 'working', now + 300).text).toBe('~7m–12m left')
   })
 
+  test('no marker timestamp at/above half keeps the bare point countdown', () => {
+    // Nothing to pin a high bound to (pre-#604 daemon) — old behavior.
+    const m = metricsFor({ est: { updated_at: 0 } })
+    expect(taskEtaPresentation(m, 'working', now).text).toBe('~12m left')
+    expect(taskEtaPresentation(m, 'working', now + 120).text).toBe('~10m left')
+  })
+
   test('range when completed fraction is below half — high pinned at the marker', () => {
     // high = 1.5 × (eta − updated_at) = 1.5 × 750s = 1125s → 19m
     const info = taskEtaPresentation(metricsFor({ est: { completed_rounds: 2 } }), 'working', now)
@@ -424,6 +431,14 @@ describe('taskEtaPresentation', () => {
   test('eta in the past clamps to <1m, never negative — one sign only', () => {
     const info = taskEtaPresentation(metricsFor({ metrics: { task_completion_eta: now - 5 } }), 'working', now)
     expect(info.text).toBe('<1m left')
+  })
+
+  test('long overdue: upper bound is the at-marker projection, not a stuck <1m (#616)', () => {
+    // Marker 10min ago projected 5min of work; the eta passed 5min ago.
+    // Worst case the full projected 5m still lies ahead — never a
+    // confident "<1m left" while the agent may be stuck.
+    const m = metricsFor({ est: { updated_at: now - 600 }, metrics: { task_completion_eta: now - 300 } })
+    expect(taskEtaPresentation(m, 'working', now).text).toBe('<5m left')
   })
 
   test('hour-scale remaining uses h+m resolution', () => {


### PR DESCRIPTION
Fixes #616

## Problem

Once half the rounds are done, the task-ETA chip rendered a bare point estimate that counted down with wall clock between markers (`~5m → ~4m → ~3m`) — false precision: without fresh progress markers there is no evidence the task is on schedule, yet the chip confidently shrank toward zero. The <50% range regime already pinned its high bound; only the point regime counted down naked.

## Change

Pin a HIGH bound at the last marker in **both** regimes of `taskEtaPresentation()`:

- below half the rounds: 1.5× the projected remaining (unchanged),
- at/above half: the bare projected remaining (`max(remaining, eta − updated_at)`, new).

Right at a marker `low == high`, so the existing degenerate-range collapse in `fmtEtaText`/`etaText` renders a point ("~5m left"); as wall clock passes without fresh progress the range widens (`~4m–5m left`, `~3m–5m left`). A fresh marker collapses it back. No marker timestamp → point countdown as before. Formatters untouched; web and Swift implementations stay mirrored.

- `platforms/web/irrlicht.js` — `taskEtaPresentation()` high-bound computation + doc comment
- `platforms/macos/Irrlicht/Views/SessionListView.swift` — mirrored, doc comments state the rule
- `platforms/web/irrlicht.test.js` — new widening test (high pinned across +120s/+300s); two existing point tests moved their marker to `now` since a 30s-old marker now correctly renders a range

### Secondary effect (intended)

A long-overdue session (eta passed, marker stale) previously sat at a confident `<1m left`; it now shows the at-marker projection as its upper bound (e.g. `<5m left`) — the "stuck at <1m" reading was exactly the false precision #616 complains about. Covered by a dedicated test.

## Test plan

- [x] `platforms/web`: `npm test` — 82/82 (incl. no-timestamp point fallback + long-overdue upper bound from review)
- [x] `platforms/macos`: `swift test` — no regression (5 `GroupViewSnapshotTests` failures are pre-existing on clean main, unrelated chevron snapshots)
- [x] `go test ./core/... -race -count=1`
- [x] `go test ./tools/onboarding-factory/... -race -count=1`, `of validate`, `tools/replay-fixtures.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
