### PR TITLE
chore: gofmt session.go, document replay-golden regen step in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,11 @@ Before marking a ticket done, run the full suite — every layer must pass:
   under `t.TempDir()`, so it never touches the production daemon).
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh`
+- Replay goldens (when a recording or replay-output change is in play):
+  regenerate with `UPDATE_REPLAY_GOLDENS=1 go test
+  ./tools/onboarding-factory/cmd/replay/... -count=1` (the `-count=1`
+  matters — without it the cached test result skips the write). Commit only
+  the goldens of the adapter you touched.
 - replaydata integrity: `go run ./tools/onboarding-factory/cmd/of validate`
   (schema + referential integrity over the catalog + cells — a CI gate). When a
   `web/` or recording-rig change is in play, also `bash

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -626,19 +626,19 @@ type SessionState struct {
 	State     string `json:"state"`
 	// Adapter identifies the source agent (e.g. "claude-code", "codex").
 	// Empty means Claude Code (for backwards compatibility).
-	Adapter         string          `json:"adapter,omitempty"`
-	Model           string          `json:"model,omitempty"`
-	CWD             string          `json:"cwd,omitempty"`
-	TranscriptPath  string          `json:"transcript_path,omitempty"`
-	GitBranch       string          `json:"git_branch,omitempty"`
-	ProjectName     string          `json:"project_name,omitempty"`
-	FirstSeen       int64           `json:"first_seen"`
-	UpdatedAt       int64           `json:"updated_at"`
-	Confidence      string          `json:"confidence"`
-	EventCount      int             `json:"event_count"`
-	LastEvent       string          `json:"last_event"`
-	LastMatcher     string          `json:"last_matcher,omitempty"`
-	Metrics         *SessionMetrics `json:"metrics,omitempty"`
+	Adapter        string          `json:"adapter,omitempty"`
+	Model          string          `json:"model,omitempty"`
+	CWD            string          `json:"cwd,omitempty"`
+	TranscriptPath string          `json:"transcript_path,omitempty"`
+	GitBranch      string          `json:"git_branch,omitempty"`
+	ProjectName    string          `json:"project_name,omitempty"`
+	FirstSeen      int64           `json:"first_seen"`
+	UpdatedAt      int64           `json:"updated_at"`
+	Confidence     string          `json:"confidence"`
+	EventCount     int             `json:"event_count"`
+	LastEvent      string          `json:"last_event"`
+	LastMatcher    string          `json:"last_matcher,omitempty"`
+	Metrics        *SessionMetrics `json:"metrics,omitempty"`
 
 	// PID of the Claude Code process that owns this session (set on SessionStart).
 	PID int `json:"pid,omitempty"`


### PR DESCRIPTION
Housekeeping from the 5-bug fix sweep (#597/#586/#588/#589/#606):

- **gofmt** the `SessionSummary` struct-tag block in `core/domain/session/session.go` (~line 626) — alignment drifted from an earlier field rename. `gofmt -w`, zero semantic change. (Note: `gofmt -l core/` flags 15 more files on main; left untouched to avoid whitespace conflicts with in-flight branches — candidate for a coordinated sweep + CI gate later.)
- **AGENTS.md**: the replay-golden regeneration step was undocumented; the test moved to `tools/onboarding-factory/cmd/replay/` in the #521 restructure. Added under Testing with the `-count=1` caveat and adapter-scoped-commit rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)