### PR TITLE
fix(e2e): deflake TestFSWatcher — 10s event timeout for loaded CI runners

### DIFF
--- a/core/e2e/fswatcher_test.go
+++ b/core/e2e/fswatcher_test.go
@@ -11,6 +11,11 @@ import (
 	"irrlicht/core/domain/agent"
 )
 
+// fsEventTimeout bounds each event wait. Generous because kqueue/inotify
+// delivery on a loaded CI runner can take well over 2s (flaky timeout on
+// macos-latest); the wait only burns the full duration on failure.
+const fsEventTimeout = 10 * time.Second
+
 // TestFSWatcher_EmitsEventsForTranscriptCreateAndModify drives the
 // fswatcher adapter against a real temp directory using kqueue/inotify and
 // asserts the canonical event sequence (NewSession → Activity) for a
@@ -45,7 +50,7 @@ func TestFSWatcher_EmitsEventsForTranscriptCreateAndModify(t *testing.T) {
 		t.Fatalf("write transcript: %v", err)
 	}
 
-	ev := waitForFSEvent(t, ch, 2*time.Second)
+	ev := waitForFSEvent(t, ch, fsEventTimeout)
 	if ev.Type != agent.EventNewSession {
 		t.Errorf("create event type: got %q, want %q", ev.Type, agent.EventNewSession)
 	}
@@ -69,7 +74,7 @@ func TestFSWatcher_EmitsEventsForTranscriptCreateAndModify(t *testing.T) {
 		t.Fatalf("append write: %v", err)
 	}
 
-	ev = waitForFSEvent(t, ch, 2*time.Second)
+	ev = waitForFSEvent(t, ch, fsEventTimeout)
 	if ev.Type != agent.EventActivity {
 		t.Errorf("modify event type: got %q, want %q", ev.Type, agent.EventActivity)
 	}


### PR DESCRIPTION
## Summary

Tests run [27016884187](https://github.com/ingo-eichhorst/Irrlicht/actions/runs/27016884187) on `main` (commit `949e299`, a gofmt/docs chore commit) failed with:

```
--- FAIL: TestFSWatcher_EmitsEventsForTranscriptCreateAndModify (2.00s)
    fswatcher_test.go:72: timeout: no fswatcher event within 2s
```

The create → `NewSession` event arrived fine; the append → `Activity` (fsnotify Write) missed the fixed **2s** timeout on a loaded `macos-latest` runner — kqueue delivery can take well over 2s under load. Not a regression: the immediately following runs on main were green.

The test already guards the *attach* race (the `Ready()` gate), but the per-event delivery timeout was still a tight 2s.

## Change

- New `fsEventTimeout = 10 * time.Second` constant shared by both event waits (create → `NewSession`, append → `Activity`).
- Waits only burn the full duration on failure, so the happy path stays fast (~1.4s locally).
- Untouched: the 5s `Ready()` gate and the 2s watcher-exit wait (cancel propagation isn't fs-event-delivery-dependent and has never flaked).

## Testing

- `go test ./core/e2e/ -race -count=1` — full package passes
- gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)