### PR TITLE
fix(detector): de-flake ParentBadgeCleared test via poll-for-condition (#624)

### DIFF
--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -3131,7 +3131,19 @@ func TestSessionDetector_ParentBadgeCleared_WhenChildSweptWhileParentWaiting(t *
 
 	// Trigger the sweep directly instead of waiting the real ticker.
 	det.RunPIDLivenessSweepForTest()
-	time.Sleep(30 * time.Millisecond)
+
+	// Poll for the sweep's effects instead of a fixed sleep — the tight
+	// readyTTL (1s) can be outrun by scheduling starvation under parallel
+	// load, so a fixed window flakes (issue #624). The corrective parent
+	// re-evaluation clears the badge and deletes the child; wait on both via
+	// race-free repo probes before quiescing.
+	waitForSessionDeleted(repo, "stuck-child", time.Second)
+	waitForCondition(func() bool {
+		repo.mu.Lock()
+		defer repo.mu.Unlock()
+		p, ok := repo.states["parent-waiting"]
+		return ok && p.Subagents == nil
+	}, time.Second)
 
 	// Quiesce the detector before reading shared state.
 	cancel()


### PR DESCRIPTION
## The flake

`TestSessionDetector_ParentBadgeCleared_WhenChildSweptWhileParentWaiting`
triggered the liveness sweep via `RunPIDLivenessSweepForTest()` and then
slept a fixed **30ms** before quiescing the detector and asserting the
child was swept and the parent badge cleared.

That fixed window is a wall-clock fragility, **not a data race** — it
failed once during #606 verification under deliberately extreme
oversubscription (4 concurrent `go test ./core/... -race` processes + 10
CPU burners on 10 cores) with no race report. The sweep's corrective
parent re-evaluation runs synchronously, but the concurrent
`Run`/`seedFromDisk` goroutine started 20ms earlier can still be settling,
and under scheduling starvation the fixed sleep can be outrun. It was
explicitly called out as out-of-scope in #618.

## The fix

Apply #618's established poll-for-condition treatment — the same
`waitForSessionDeleted` / `waitForCondition` helpers (in
`testhelpers_test.go`) that converted the eight sibling tests from fixed
sleeps. Replace the 30ms sleep with race-free repo probes that wait for:

- the stuck child to be deleted (`waitForSessionDeleted`), and
- the parent's persisted `Subagents` badge to clear (`waitForCondition`
  over a locked read).

Surgical: only this test is touched, no new helpers, no production change.

## Verification

- `go test ./core/application/services/ -race -run TestSessionDetector_ParentBadgeCleared_WhenChildSweptWhileParentWaiting -count=30` — green.
- `go test ./core/application/services/ -race -count=1` — green.
- `go test ./core/... -race -count=1` — green (all packages, incl. daemon smoke + e2e).
- `go vet ./core/application/services/` — clean.

Fixes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)