### PR TITLE
fix(gastown): log gt fetch timeouts instead of silent fallback (#625)

### DIFF
--- a/core/adapters/inbound/orchestrators/gastown/adapter.go
+++ b/core/adapters/inbound/orchestrators/gastown/adapter.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"irrlicht/core/domain/orchestrator"
+	"irrlicht/core/ports/outbound"
 )
 
 // Adapter implements inbound.OrchestratorWatcher for Gas Town.
@@ -19,6 +20,7 @@ type Adapter struct {
 	collector *collector
 	gtBin     string
 	sessions  sessionLister
+	logger    outbound.Logger
 
 	mu    sync.RWMutex
 	state *orchestrator.State
@@ -30,11 +32,13 @@ type Adapter struct {
 // NewAdapter creates a Gas Town OrchestratorWatcher adapter.
 // gtBin is the resolved path to the gt binary (may be empty).
 // sessions provides active session data for CWD matching (may be nil).
-func NewAdapter(gtBin string, sessions sessionLister) *Adapter {
+// logger records gt fetch timeouts so silent fallback is observable (may be nil).
+func NewAdapter(gtBin string, sessions sessionLister, logger outbound.Logger) *Adapter {
 	return &Adapter{
 		collector: New(),
 		gtBin:     gtBin,
 		sessions:  sessions,
+		logger:    logger,
 	}
 }
 
@@ -77,6 +81,7 @@ func (a *Adapter) Watch(ctx context.Context) error {
 
 	// Run poller loop.
 	poller := newPoller(a.collector, a.gtBin, a.sessions)
+	poller.logger = a.logger
 	return a.runPoller(ctx, poller)
 }
 

--- a/core/adapters/inbound/orchestrators/gastown/poller.go
+++ b/core/adapters/inbound/orchestrators/gastown/poller.go
@@ -6,6 +6,7 @@ package gastown
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -14,6 +15,7 @@ import (
 
 	"irrlicht/core/domain/orchestrator"
 	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
 )
 
 // sessionLister provides read access to active sessions for CWD matching.
@@ -34,6 +36,13 @@ type poller struct {
 	// the replay test raises it so a load-starved fake-gt subprocess can't
 	// falsely time out into the fallback path (#586).
 	fetchTimeout time.Duration
+	// logger records gt fetch timeouts (and recoveries) so silent fallback to
+	// cached/empty state is observable in production. May be nil (e.g. tests).
+	logger outbound.Logger
+	// timeoutMu guards timingOut, which tracks per-fetch consecutive-timeout
+	// streaks so a wedged gt binary logs once per streak, not every tick (#625).
+	timeoutMu sync.Mutex
+	timingOut map[string]bool
 }
 
 // newPoller creates a poller that reads from the given collector and
@@ -44,6 +53,7 @@ func newPoller(collector *collector, gtBin string, sessions sessionLister) *poll
 		gtBin:        gtBin,
 		sessions:     sessions,
 		fetchTimeout: defaultFetchTimeout,
+		timingOut:    make(map[string]bool),
 	}
 }
 
@@ -344,6 +354,46 @@ func (p *poller) gtCommand(ctx context.Context, args ...string) *exec.Cmd {
 	return cmd
 }
 
+// noteFetchTimeout logs a gt fetch timeout exactly once per consecutive-timeout
+// streak so a wedged gt binary can't spam the log every tick (#625). fetch names
+// the timed-out call (e.g. "rig list") and fellBackTo describes the degraded
+// result it composed instead ("cached rigs" / "empty"). A non-timeout error
+// (bad JSON, gt missing) clears the streak via clearFetchTimeout so the next
+// genuine timeout logs again.
+func (p *poller) noteFetchTimeout(fetch, fellBackTo string) {
+	if p.logger == nil {
+		return
+	}
+	p.timeoutMu.Lock()
+	already := p.timingOut[fetch]
+	p.timingOut[fetch] = true
+	p.timeoutMu.Unlock()
+	if already {
+		return
+	}
+	p.logger.LogError("gastown-poller", "",
+		"gt "+fetch+" timed out after "+p.fetchTimeout.String()+
+			"; falling back to "+fellBackTo+" state (rig/polecat counts may be stale)")
+}
+
+// clearFetchTimeout resets a fetch's timeout streak after a non-timeout outcome
+// (success or a non-deadline error) so a later timeout is logged afresh.
+func (p *poller) clearFetchTimeout(fetch string) {
+	p.timeoutMu.Lock()
+	delete(p.timingOut, fetch)
+	p.timeoutMu.Unlock()
+}
+
+// recordFetch inspects a failed gt fetch: on a deadline timeout it logs the
+// degraded fallback (rate-limited per streak); otherwise it clears the streak.
+func (p *poller) recordFetch(ctx context.Context, fetch, fellBackTo string) {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		p.noteFetchTimeout(fetch, fellBackTo)
+		return
+	}
+	p.clearFetchTimeout(fetch)
+}
+
 func (p *poller) fetchRigs(ctx context.Context) []rigState {
 	ctx, cancel := context.WithTimeout(ctx, p.fetchTimeout)
 	defer cancel()
@@ -351,8 +401,10 @@ func (p *poller) fetchRigs(ctx context.Context) []rigState {
 	out, err := p.gtCommand(ctx, "rig", "list", "--json").Output()
 	if err != nil {
 		// Fallback to collector's cached rigs from rigs.json.
+		p.recordFetch(ctx, "rig list", "cached rigs.json")
 		return p.collector.Rigs()
 	}
+	p.clearFetchTimeout("rig list")
 	var rigs []rigState
 	if err := json.Unmarshal(out, &rigs); err != nil {
 		return p.collector.Rigs()
@@ -366,8 +418,10 @@ func (p *poller) fetchPolecats(ctx context.Context) []polecatState {
 
 	out, err := p.gtCommand(ctx, "polecat", "list", "--all", "--json").Output()
 	if err != nil {
+		p.recordFetch(ctx, "polecat list", "empty")
 		return nil
 	}
+	p.clearFetchTimeout("polecat list")
 	var polecats []polecatState
 	if err := json.Unmarshal(out, &polecats); err != nil {
 		return nil
@@ -381,8 +435,10 @@ func (p *poller) fetchDogs(ctx context.Context) []dogState {
 
 	out, err := p.gtCommand(ctx, "dog", "list", "--json").Output()
 	if err != nil {
+		p.recordFetch(ctx, "dog list", "empty")
 		return nil
 	}
+	p.clearFetchTimeout("dog list")
 	var dogs []dogState
 	if err := json.Unmarshal(out, &dogs); err != nil {
 		return nil
@@ -396,8 +452,10 @@ func (p *poller) fetchBootStatus(ctx context.Context) *bootStatus {
 
 	out, err := p.gtCommand(ctx, "boot", "status", "--json").Output()
 	if err != nil {
+		p.recordFetch(ctx, "boot status", "empty")
 		return nil
 	}
+	p.clearFetchTimeout("boot status")
 	var boot bootStatus
 	if err := json.Unmarshal(out, &boot); err != nil {
 		return nil

--- a/core/adapters/inbound/orchestrators/gastown/poller.go
+++ b/core/adapters/inbound/orchestrators/gastown/poller.go
@@ -36,8 +36,8 @@ type poller struct {
 	// the replay test raises it so a load-starved fake-gt subprocess can't
 	// falsely time out into the fallback path (#586).
 	fetchTimeout time.Duration
-	// logger records gt fetch timeouts (and recoveries) so silent fallback to
-	// cached/empty state is observable in production. May be nil (e.g. tests).
+	// logger records gt fetch timeouts so silent fallback to cached/empty
+	// state is observable in production. May be nil (e.g. tests).
 	logger outbound.Logger
 	// timeoutMu guards timingOut, which tracks per-fetch consecutive-timeout
 	// streaks so a wedged gt binary logs once per streak, not every tick (#625).

--- a/core/adapters/inbound/orchestrators/gastown/poller_timeout_test.go
+++ b/core/adapters/inbound/orchestrators/gastown/poller_timeout_test.go
@@ -1,0 +1,111 @@
+package gastown
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingLogger captures LogError lines so the timeout-logging path is
+// observable in tests. It satisfies outbound.Logger.
+type recordingLogger struct {
+	mu     sync.Mutex
+	errors []string
+}
+
+func (l *recordingLogger) LogInfo(eventType, sessionID, message string) {}
+func (l *recordingLogger) LogError(eventType, sessionID, errorMsg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.errors = append(l.errors, eventType+": "+errorMsg)
+}
+func (l *recordingLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (l *recordingLogger) Close() error                                         { return nil }
+
+func (l *recordingLogger) snapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.errors))
+	copy(out, l.errors)
+	return out
+}
+
+// timedOutCtx returns a context whose deadline has already elapsed, so
+// ctx.Err() == context.DeadlineExceeded — the exact signal recordFetch keys on
+// to distinguish a fetch timeout from a non-timeout failure (bad JSON, gt gone).
+func timedOutCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	t.Cleanup(cancel)
+	<-ctx.Done()
+	return ctx
+}
+
+func TestRecordFetchLogsOncePerTimeoutStreak(t *testing.T) {
+	logger := &recordingLogger{}
+	p := &poller{
+		fetchTimeout: 5 * time.Second,
+		logger:       logger,
+		timingOut:    make(map[string]bool),
+	}
+	deadlineCtx := timedOutCtx(t)
+
+	// Two consecutive timed-out fetches: the streak logs exactly once.
+	p.recordFetch(deadlineCtx, "rig list", "cached rigs.json")
+	p.recordFetch(deadlineCtx, "rig list", "cached rigs.json")
+
+	got := logger.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 log for a consecutive timeout streak, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "gastown-poller") ||
+		!strings.Contains(got[0], "rig list") ||
+		!strings.Contains(got[0], "timed out") ||
+		!strings.Contains(got[0], "cached rigs.json") {
+		t.Fatalf("log line missing fetch/fallback detail: %q", got[0])
+	}
+
+	// gt recovers (success clears the streak via clearFetchTimeout).
+	p.clearFetchTimeout("rig list")
+	if n := len(logger.snapshot()); n != 1 {
+		t.Fatalf("clearing a streak must not log; got %d lines", n)
+	}
+
+	// gt wedges again: a fresh streak logs once more.
+	p.recordFetch(deadlineCtx, "rig list", "cached rigs.json")
+	if n := len(logger.snapshot()); n != 2 {
+		t.Fatalf("a new timeout streak must log again; got %d lines", n)
+	}
+}
+
+func TestRecordFetchNonTimeoutDoesNotLogAndResetsStreak(t *testing.T) {
+	logger := &recordingLogger{}
+	p := &poller{
+		fetchTimeout: 5 * time.Second,
+		logger:       logger,
+		timingOut:    make(map[string]bool),
+	}
+
+	// A non-deadline failure (e.g. bad JSON, gt missing) must not log a timeout
+	// and must leave no streak armed, so a later genuine timeout still logs.
+	p.recordFetch(context.Background(), "polecat list", "empty")
+	if n := len(logger.snapshot()); n != 0 {
+		t.Fatalf("non-timeout failure must not log a timeout; got %d lines", n)
+	}
+
+	p.recordFetch(timedOutCtx(t), "polecat list", "empty")
+	if n := len(logger.snapshot()); n != 1 {
+		t.Fatalf("a genuine timeout after a non-timeout failure must log; got %d lines", n)
+	}
+}
+
+func TestRecordFetchNilLoggerNoPanic(t *testing.T) {
+	p := &poller{
+		fetchTimeout: 5 * time.Second,
+		timingOut:    make(map[string]bool),
+	}
+	// logger left nil — must be a no-op, not a panic.
+	p.recordFetch(timedOutCtx(t), "boot status", "empty")
+}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -393,7 +393,7 @@ func main() {
 		if gtWatchCancel != nil {
 			return nil
 		}
-		gtAdapter := gastownadapter.NewAdapter(gtResolver.Path(), cachedRepo)
+		gtAdapter := gastownadapter.NewAdapter(gtResolver.Path(), cachedRepo, logger)
 		if !gtAdapter.Detected() {
 			logger.LogInfo("permissions", "", "gastown granted but no Gas Town root detected — nothing to watch")
 			return nil


### PR DESCRIPTION
## Problem

Each `gt` CLI fetch in the gastown poller (`fetchRigs`/`fetchPolecats`/`fetchDogs`/`fetchBootStatus`) is bounded by `fetchTimeout` (5s in production). On timeout the fetch **silently** fell back — cached `rigs.json` or `nil` — and `BuildOrchestratorState` composed a state that looked healthy but was partially stale. That silent degradation is exactly what made #586 hard to diagnose: the replay test's golden mismatch was the only symptom. In production the same starvation would show as quietly wrong rig/polecat counts with nothing in the log.

## Change

Observability-only — no behavior change:

- Thread the daemon `Logger` (`outbound.Logger`) into the poller via `NewAdapter`; nil-safe so tests and the replay path are untouched.
- Emit one `LogError` per timed-out fetch identifying **which** fetch timed out and **what** it fell back to (cached `rigs.json` vs empty).
- Distinguish a genuine deadline timeout (`context.DeadlineExceeded`) from a non-timeout failure (bad JSON, `gt` missing) — only timeouts are logged.
- Rate-limit per consecutive-timeout streak via a small per-fetch flag map, so a wedged `gt` binary logs once per streak instead of every tick; a successful fetch clears the streak so a later timeout logs afresh.

## Tests

- New `poller_timeout_test.go` drives `recordFetch` with controlled contexts (already-elapsed deadline vs fresh) to lock down: logs once per streak, recovery resets the streak, a non-timeout failure doesn't log a timeout but still arms the next one, and nil logger is a no-op.
- `go test ./core/... -race -count=1` — pass.
- `tools/replay-fixtures.sh` — pass, **goldens unchanged** (logging does not alter replay output).
- Diff kept surgical per the in-flight gofmt sweep (#629): only `poller.go`/`adapter.go` lines I added; the pre-existing trailing-newline gofmt flag on `adapter.go` is left alone.

Fixes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)