### PR TITLE
feat(clients): detect push Seq gaps and re-hydrate immediately (#600)

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -285,6 +285,7 @@ class SessionManager: ObservableObject {
         webSocketTask = task
         task.resume()
 
+        lastPushSeq = 0 // fresh stream, fresh seq cursor (#600)
         reconnectDelay = 1.0
         connectionState = .connected
         print("🔌 WebSocket connected to irrlichd")
@@ -1007,6 +1008,9 @@ class SessionManager: ObservableObject {
     private struct WsEnvelope: Decodable {
         let type: String
         let session: SessionState?
+        // Daemon-global monotonic push counter (#593). Optional so connect
+        // snapshots and older daemons (no seq) still decode.
+        let seq: UInt64?
 
         // History-message fields (snapshot/tick/upgrade).
         let sessionID: String?
@@ -1023,6 +1027,7 @@ class SessionManager: ObservableObject {
         enum CodingKeys: String, CodingKey {
             case type
             case session
+            case seq
             case sessionID         = "session_id"
             case history
             case granularitySec    = "granularity_sec"
@@ -1033,10 +1038,25 @@ class SessionManager: ObservableObject {
         }
     }
 
+    /// Last stamped push `seq` received on the stream. 0 = fresh cursor
+    /// (reset on every (re)connect). See #600.
+    private var lastPushSeq: UInt64 = 0
+
     private func handleWsMessage(_ text: String) {
         guard let data = text.data(using: .utf8) else { return }
         do {
             let envelope = try JSONDecoder().decode(WsEnvelope.self, from: data)
+            // A gap in the daemon-global push seq means the daemon skipped this
+            // client (slow-subscriber drop) — re-hydrate now instead of waiting
+            // for the next structural event (#600). seq 0/absent = unstamped
+            // (connect snapshots, older daemons); a backward jump is a daemon
+            // restart — adopt the cursor without rehydrating.
+            if let seq = envelope.seq, seq > 0 {
+                if lastPushSeq > 0 && seq > lastPushSeq + 1 {
+                    scheduleRehydration()
+                }
+                lastPushSeq = seq
+            }
             switch envelope.type {
             case "session_created":
                 if let session = envelope.session {

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1811,11 +1811,19 @@
     // immediate rehydrate instead of waiting for the 30s cadence (#600). The
     // cursor is keyed per daemon: a relay socket interleaves multiple daemons'
     // independent counters, so a per-socket cursor would gap on every switch.
+    // Gap-triggered rehydrates are leading-edge throttled: the first gap heals
+    // immediately, refires from a sustained drop burst ride the same fetch
+    // (macOS gets the same coalescing from its debounced scheduleRehydration).
+    let lastSeqGapRehydrate = 0;
     function trackPushSeq(src, key, seq) {
       if (!seq) return; // unstamped: connect snapshots, relay replays, older daemons
       const last = src.seqCursors.get(key) || 0;
       src.seqCursors.set(key, seq);
-      if (seqGap(last, seq)) rehydratePoll();
+      if (!seqGap(last, seq)) return;
+      const now = Date.now();
+      if (now - lastSeqGapRehydrate < 1000) return;
+      lastSeqGapRehydrate = now;
+      rehydratePoll();
     }
 
     function handleSourceFrame(src, msg) {

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1658,6 +1658,15 @@
       }
     }
 
+    // seqGap reports whether a stamped push seq skipped ahead of the last one
+    // received — the daemon (or relay) dropped frames for this client (#600).
+    // 0/absent means unstamped (connect snapshots, relay replays, older
+    // daemons) and never gaps; a backward jump is a daemon restart, not a
+    // gap. Pure; exported for tests.
+    function seqGap(last, seq) {
+      return seq > 0 && last > 0 && seq > last + 1;
+    }
+
     // aggregateConnState reduces per-source states into the single header dot:
     // connected wins (we're watching at least one source), then connecting,
     // then reconnecting, else disconnected. Pure; exported for tests.
@@ -1738,7 +1747,7 @@
       }
       for (const d of desired) {
         if (!sources.has(d.id)) {
-          const src = Object.assign({ state: 'connecting', ws: null, reconnectDelay: 1000, closing: false, daemons: new Map() }, d);
+          const src = Object.assign({ state: 'connecting', ws: null, reconnectDelay: 1000, closing: false, daemons: new Map(), seqCursors: new Map() }, d);
           sources.set(d.id, src);
           connectSource(src);
         }
@@ -1771,6 +1780,7 @@
       ws.onclose = function(ev) {
         if (src.closing) return;
         src.daemons.clear();
+        src.seqCursors.clear();
         // 4401 = auth failed/revoked: retrying with the same token just loops, so
         // stop reconnecting (until settings change) instead of a tight loop.
         if (ev && ev.code === 4401) { src.state = 'unauthorized'; updateWsStatus(); return; }
@@ -1797,6 +1807,17 @@
       if (ids.length) render();
     }
 
+    // trackPushSeq advances one daemon's seq cursor and, on a gap, triggers an
+    // immediate rehydrate instead of waiting for the 30s cadence (#600). The
+    // cursor is keyed per daemon: a relay socket interleaves multiple daemons'
+    // independent counters, so a per-socket cursor would gap on every switch.
+    function trackPushSeq(src, key, seq) {
+      if (!seq) return; // unstamped: connect snapshots, relay replays, older daemons
+      const last = src.seqCursors.get(key) || 0;
+      src.seqCursors.set(key, seq);
+      if (seqGap(last, seq)) rehydratePoll();
+    }
+
     function handleSourceFrame(src, msg) {
       if (!msg) return;
       switch (relayFrameKind(msg)) {
@@ -1813,6 +1834,7 @@
           if (msg.daemon_id) {
             if (msg.status === 'disconnected') {
               src.daemons.delete(msg.daemon_id);
+              src.seqCursors.delete(msg.daemon_id);
               purgeDaemonSessions(msg.daemon_id);   // #540: relay no longer deletes them for us
             } else {
               src.daemons.set(msg.daemon_id, { label: msg.daemon_label || msg.daemon_id, status: msg.status || 'connected' });
@@ -1821,9 +1843,13 @@
           updateWsStatus();
           return;
         case 'push':
-          if (msg.msg) dispatchRawFrame(normalizeSourcedFrame(msg.source, msg.msg));
+          if (msg.msg) {
+            trackPushSeq(src, msg.source || '', msg.msg.seq);
+            dispatchRawFrame(normalizeSourcedFrame(msg.source, msg.msg));
+          }
           return;
         default:
+          trackPushSeq(src, '', msg.seq);
           dispatchRawFrame(msg);
       }
     }
@@ -2802,7 +2828,7 @@ export {
   formatCost, formatUsageCost, pressureClass, historyPriorityForState,
   taskEtaPresentation,
   lastNotifiedPressure,
-  relayFrameKind, aggregateConnState, relayWsUrl,
+  relayFrameKind, aggregateConnState, relayWsUrl, seqGap,
   compoundSessionId, displaySessionId,
   sessionOrigin, sourceIdOf, localBareIds, isShadowedRemote,
   daemonSessionIds, structureSignature,

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -13,6 +13,7 @@ import {
   historyPriorityForState,
   lastNotifiedPressure,
   relayFrameKind,
+  seqGap,
   aggregateConnState,
   relayWsUrl,
   compoundSessionId,
@@ -175,6 +176,31 @@ describe('relayFrameKind', () => {
     expect(relayFrameKind({ type: 'history_tick' })).toBe('raw')
     expect(relayFrameKind(null)).toBe('raw')
     expect(relayFrameKind({})).toBe('raw')
+  })
+})
+
+describe('seqGap', () => {
+  test('gaps when a stamped seq skips ahead of the cursor', () => {
+    expect(seqGap(5, 7)).toBe(true)
+    expect(seqGap(1, 100)).toBe(true)
+  })
+
+  test('contiguous delivery never gaps', () => {
+    expect(seqGap(5, 6)).toBe(false)
+    expect(seqGap(5, 5)).toBe(false) // duplicate
+  })
+
+  test('first stamped message after a fresh cursor never gaps', () => {
+    expect(seqGap(0, 42)).toBe(false)
+  })
+
+  test('backward jump (daemon restart) is not a gap', () => {
+    expect(seqGap(100, 3)).toBe(false)
+  })
+
+  test('unstamped frames (older daemons, snapshots) never gap', () => {
+    expect(seqGap(5, 0)).toBe(false)
+    expect(seqGap(5, undefined)).toBe(false)
   })
 })
 


### PR DESCRIPTION
Closes #600 (follow-up to #593).

A gap in the daemon-global push `seq` means the daemon skipped this client (slow-subscriber drop, 64-slot buffer) — phantom state may remain client-side until the next periodic rehydration. Both clients now track a seq cursor and trigger their existing rehydration path immediately on a gap: heal in ~0s instead of ≤30s. Latency improvement, not a correctness fix — periodic self-heal stays in place.

## Changes

**Web** (`platforms/web/irrlicht.js`)
- Pure exported `seqGap(last, seq)` helper: gap iff both stamped and `seq > last + 1`.
- `trackPushSeq()` in `handleSourceFrame`: cursors keyed per (source, daemon) — a relay socket interleaves multiple daemons' independent counters, so a per-socket cursor would false-positive on every interleave. Raw local frames key `''`; relay push frames key `msg.source`.
- On gap → `rehydratePoll()` directly (the 30s loop is recursive-setTimeout, no double-schedule).
- Resets: `seqCursors.clear()` on WS close; `seqCursors.delete(daemon_id)` on relay `daemon_status: disconnected`.

**macOS** (`SessionManager.swift`)
- `WsEnvelope` decodes optional `seq`; `lastPushSeq` gap-check at the top of `handleWsMessage` → existing 0.5s-debounced `scheduleRehydration()`; cursor reset in `connect()`.

**Edge rules (both clients)**
- `seq` 0/absent = unstamped (connect snapshots, relay-synthesized replays `irrlichtrelay/hub.go:509`, older daemons) → skipped, never gaps.
- Backward jump = daemon restart → adopt cursor, no rehydrate.
- Relay forwards the daemon's `PushMessage` verbatim (`irrlichtrelay/hub.go:576`), so gap detection also catches relay-side drops.

## Testing

- `npm test` (platforms/web): 88/88 — incl. 5 new `seqGap` cases (gap, contiguous/duplicate, fresh cursor, backward, unstamped)
- `swift build` platforms/macos: clean
- `go test ./core/... -race -count=1` and `./tools/onboarding-factory/...`: pass
- `tools/replay-fixtures.sh` + rig `smoke-test.sh`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)