### PR TITLE
fix(claudecode): move first ETA marker onto the Bash description carrier (instruction v4)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -61,7 +61,7 @@ const (
 // mitigate), and PRE-tool-call prose is exactly the vulnerable shape. v3's
 // "first marker in your first response, right before your first tool call"
 // rode the one path known to be lossy. v4 moves the first marker onto the
-// Bash ` + "`description`" + ` carrier too — tool inputs reach the daemon via the
+// Bash `description` carrier too — tool inputs reach the daemon via the
 // PreToolUse hook (#604) regardless of text-block fate. End-of-turn text
 // survives upstream, so the no-Bash fallback stays response text.
 const managedTaskEtaBlock = taskEtaBeginSentinel + `

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -54,23 +54,33 @@ const (
 // required carrier when no response text is coming. No extra reinforcement
 // clause beyond that: the 2026-05-31 emission experiment found the lightest
 // phrasing binds best, so v3 adds obligation, not length.
+//
+// v4 (anthropics/claude-code#65620 feedback): upstream diagnosis revised —
+// the text-drop is server-side (the model composes prose in thinking and
+// never emits the text block; onset ~2026-06-04, version pinning does not
+// mitigate), and PRE-tool-call prose is exactly the vulnerable shape. v3's
+// "first marker in your first response, right before your first tool call"
+// rode the one path known to be lossy. v4 moves the first marker onto the
+// Bash ` + "`description`" + ` carrier too — tool inputs reach the daemon via the
+// PreToolUse hook (#604) regardless of text-block fate. End-of-turn text
+// survives upstream, so the no-Bash fallback stays response text.
 const managedTaskEtaBlock = taskEtaBeginSentinel + `
 ## Task progress markers (managed by Irrlicht)
 
 As you work on a multi-step task, periodically emit a hidden progress marker
-so tools can show a task-completion estimate. Emit it as an HTML comment in
-your response text, and update it as you make progress:
+so tools can show a task-completion estimate. Emit it as an HTML comment,
+and update it as you make progress:
 
 ` + "```" + `
 <!-- {"marker":"irrlicht-eta","total_rounds":N,"completed_rounds":M} -->
 ` + "```" + `
 
 ` + "`total_rounds`" + ` is your estimate of the task's phases; ` + "`completed_rounds`" + `
-is how many you've finished. Emit the first marker in your first response,
-right before your first tool call. After each phase you complete, emit
-the updated marker: append it to the ` + "`description`" + ` of the next Bash call
-you make (never to the command itself), or include it in your response
-text when no Bash call is coming.
+is how many you've finished. Emit the first marker by appending it to the
+` + "`description`" + ` of your first Bash call (never to the command itself).
+After each phase you complete, emit the updated marker the same way:
+appended to the ` + "`description`" + ` of the next Bash call you make, or in your
+response text when no Bash call is coming.
 ` + taskEtaEndSentinel
 
 // claudeMemoryPath returns the user-level Claude Code instruction file path.

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -113,13 +113,14 @@ func TestEnsureTaskEtaBlock_UpgradesStaleBlock(t *testing.T) {
 }
 
 // assertCurrentEtaContract checks the phrases every shipped-block upgrade
-// must land on: first marker before any tool call (#604/#602), the Bash
-// description carrier as the mandatory per-phase update channel (#617), and
-// the command-field prohibition (permission matching).
+// must land on: first marker on the Bash description carrier
+// (anthropics/claude-code#65620 — pre-tool-call prose is lossy upstream),
+// the Bash description carrier as the mandatory per-phase update channel
+// (#617), and the command-field prohibition (permission matching).
 func assertCurrentEtaContract(t *testing.T, content string) {
 	t.Helper()
-	if !strings.Contains(content, "first marker in your first response") {
-		t.Error("block must ask for the first marker before any tool call")
+	if !strings.Contains(content, "`description` of your first Bash call") {
+		t.Error("block must put the first marker on the Bash description carrier")
 	}
 	if !strings.Contains(content, "After each phase you complete") {
 		t.Error("block must make the per-phase update mandatory")
@@ -210,6 +211,53 @@ already making (never to the command itself).
 	content := readFileString(t, path)
 	if strings.Contains(content, "you may also") {
 		t.Error("v2's permissive carrier phrasing survived the upgrade")
+	}
+	assertCurrentEtaContract(t, content)
+}
+
+func TestEnsureTaskEtaBlock_V3BlockUpgradesToV4(t *testing.T) {
+	// The exact v3 block (shipped with #617) must upgrade in place to the v4
+	// contract (anthropics/claude-code#65620): the first marker moves from
+	// pre-tool-call response text — the shape upstream loses since
+	// ~2026-06-04 — onto the Bash description carrier, which reaches the
+	// daemon via the PreToolUse hook regardless of text-block fate.
+	home := withTempHome(t)
+	path := memoryPathFor(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	v3 := taskEtaBeginSentinel + `
+## Task progress markers (managed by Irrlicht)
+
+As you work on a multi-step task, periodically emit a hidden progress marker
+so tools can show a task-completion estimate. Emit it as an HTML comment in
+your response text, and update it as you make progress:
+
+` + "```" + `
+<!-- {"marker":"irrlicht-eta","total_rounds":N,"completed_rounds":M} -->
+` + "```" + `
+
+` + "`total_rounds`" + ` is your estimate of the task's phases; ` + "`completed_rounds`" + `
+is how many you've finished. Emit the first marker in your first response,
+right before your first tool call. After each phase you complete, emit
+the updated marker: append it to the ` + "`description`" + ` of the next Bash call
+you make (never to the command itself), or include it in your response
+text when no Bash call is coming.
+` + taskEtaEndSentinel
+	if err := os.WriteFile(path, []byte(v3+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureTaskEtaBlockInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("v3 block should upgrade to v4")
+	}
+	content := readFileString(t, path)
+	if strings.Contains(content, "first marker in your first response") {
+		t.Error("v3's pre-tool-call first-marker phrasing survived the upgrade")
 	}
 	assertCurrentEtaContract(t, content)
 }


### PR DESCRIPTION
## Summary

Feedback on [anthropics/claude-code#65620](https://github.com/anthropics/claude-code/issues/65620) revised the text-drop diagnosis: it is **server-side** — the model composes prose in thinking and never emits the text block (onset ~2026-06-04; same client 2.1.161 went 0/426 → 22/124 lost overnight, so **version pinning does not mitigate**). Only **pre-tool-call** prose is affected; end-of-turn text and tool inputs always survive.

The v3 managed block asked for the first marker "in your first response, right before your first tool call" — exactly the lossy shape. v4 moves the first marker onto the Bash `description` carrier, same as the per-phase updates: tool inputs reach the daemon via the PreToolUse hook (#604) regardless of text-block fate.

## Changes

- `instructioninstaller.go`: v4 managed block — first marker appended to the `description` of the first Bash call; intro no longer claims "in your response text"; v4 rationale documented in the version-history comment.
- `instructioninstaller_test.go`: `assertCurrentEtaContract` now requires the first-marker description carrier; new `TestEnsureTaskEtaBlock_V3BlockUpgradesToV4` seeds the exact shipped v3 block and asserts in-place upgrade (v1→v4 and v2→v4 paths re-asserted via the shared contract helper).

Installed v3 blocks upgrade in place on the next daemon start via `patchManagedBlock`'s content compare — no user action needed.

## Testing

- `go test ./core/... -race -count=1` ✅
- `go test ./tools/onboarding-factory/... -race -count=1` ✅
- `tools/replay-fixtures.sh` ✅
- `gofmt -l` clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)