### PR TITLE
docs: correct permissions.json path in configuration.html

### DIFF
--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -230,7 +230,7 @@ launchctl setenv IRRLICHT_DEBUG 1
 
       <ul>
         <li><strong>Session instances:</strong> <code>~/Library/Application Support/Irrlicht/instances/</code></li>
-        <li><strong>Permissions:</strong> <code>~/Library/Application Support/Irrlicht/permissions.json</code> &mdash; the per-agent consent answers behind the permission wizard. A missing file (or a missing key) means pending: the wizard re-asks and nothing is monitored until granted</li>
+        <li><strong>Permissions:</strong> <code>~/.local/share/irrlicht/permissions.json</code> &mdash; the per-agent consent answers behind the permission wizard. A missing file (or a missing key) means pending: the wizard re-asks and nothing is monitored until granted</li>
         <li><strong>Logs:</strong> <code>~/Library/Application Support/Irrlicht/logs/</code></li>
         <li><strong>Unix socket:</strong> <code>~/.local/share/irrlicht/irrlichd.sock</code></li>
       </ul>


### PR DESCRIPTION
The v0.5.0 release docs placed `permissions.json` under `~/Library/Application Support/Irrlicht/`; the permission store actually persists it under the daemon data dir (`~/.local/share/irrlicht/permissions.json`, or `$IRRLICHT_HOME` when set) — see `core/adapters/outbound/filesystem/permission_store.go` and `activation_migration.go`. One-line path correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)