### PR TITLE
fix(claudecode): skip compact-summary user events so /compact doesn't strand sessions in working

### DIFF
--- a/core/adapters/inbound/agents/claudecode/compaction_test.go
+++ b/core/adapters/inbound/agents/claudecode/compaction_test.go
@@ -1,0 +1,93 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"irrlicht/core/pkg/tailer"
+)
+
+// --- Parser + tailer end-to-end: manual /compact tail (issue #641) ---
+
+func compactionTS(offset int) string {
+	return time.Now().Add(time.Duration(offset) * time.Second).Format(time.RFC3339)
+}
+
+func appendTranscriptLine(t *testing.T, path string, line map[string]interface{}) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(line); err != nil {
+		t.Fatalf("append line: %v", err)
+	}
+}
+
+// TestTailer_ManualCompactTail_NoSubstantiveActivity is the issue #641
+// regression at the parser+tailer integration level. A manual /compact
+// writes a synthetic tail — compact_boundary, the isCompactSummary user
+// summary, the isMeta caveat, and the command wrappers — with no assistant
+// event or turn_done following. Every entry must be skipped so the pass
+// reports NoSubstantiveActivity=true and LastEventType stays at the prior
+// turn_done; the detector then ignores the pass and the session stays
+// ready (that half of the chain is pinned by
+// session_detector_no_substantive_test.go). Pre-fix, the summary leaked
+// through as a real user turn and stranded the session in working.
+// Entry shapes mirror the live session bb9f6ebf that surfaced the bug.
+func TestTailer_ManualCompactTail_NoSubstantiveActivity(t *testing.T) {
+	path := writeBgTranscript(t, []map[string]interface{}{
+		{"type": "user", "timestamp": compactionTS(0), "message": map[string]interface{}{
+			"role": "user", "content": "do the thing",
+		}},
+		{"type": "assistant", "timestamp": compactionTS(1), "message": map[string]interface{}{
+			"role": "assistant", "stop_reason": "end_turn",
+			"content": []interface{}{map[string]interface{}{"type": "text", "text": "done."}},
+		}},
+		{"type": "system", "subtype": "turn_duration", "timestamp": compactionTS(2)},
+	})
+
+	tl := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	if m.LastEventType != "turn_done" {
+		t.Fatalf("pass 1 LastEventType = %q, want turn_done", m.LastEventType)
+	}
+
+	for _, ln := range []map[string]interface{}{
+		{"type": "system", "subtype": "compact_boundary", "content": "Conversation compacted",
+			"timestamp": compactionTS(120)},
+		{"type": "user", "isCompactSummary": true, "isVisibleInTranscriptOnly": true,
+			"timestamp": compactionTS(120), "message": map[string]interface{}{
+				"role":    "user",
+				"content": "This session is being continued from a previous conversation that ran out of context.",
+			}},
+		{"type": "user", "isMeta": true, "timestamp": compactionTS(120), "message": map[string]interface{}{
+			"role": "user", "content": "<local-command-caveat>Caveat: …</local-command-caveat>",
+		}},
+		{"type": "user", "timestamp": compactionTS(120), "message": map[string]interface{}{
+			"role": "user", "content": "<command-name>/compact</command-name>",
+		}},
+		{"type": "user", "timestamp": compactionTS(121), "message": map[string]interface{}{
+			"role": "user", "content": "<local-command-stdout>Compacted (ctrl+o to see full summary)</local-command-stdout>",
+		}},
+	} {
+		appendTranscriptLine(t, path, ln)
+	}
+
+	m, err = tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	if !m.NoSubstantiveActivity {
+		t.Errorf("pass 2 NoSubstantiveActivity = false, want true (every compaction-tail entry must be skipped)")
+	}
+	if m.LastEventType != "turn_done" {
+		t.Errorf("pass 2 LastEventType = %q, want turn_done (compact summary must not register as a user turn)", m.LastEventType)
+	}
+}

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -197,11 +197,20 @@ func handleSystemEvent(raw map[string]interface{}, ev *tailer.ParsedEvent) {
 }
 
 // handleUserEvent handles the user event variants that should short-circuit
-// the parser (isMeta, task-notification, local-command wrappers). Returns
-// true when caller should return ev immediately. Interrupts are recorded on
-// ev but do NOT short-circuit.
+// the parser (isMeta, compact summary, task-notification, local-command
+// wrappers). Returns true when caller should return ev immediately.
+// Interrupts are recorded on ev but do NOT short-circuit.
 func handleUserEvent(raw map[string]interface{}, ev *tailer.ParsedEvent) bool {
 	if isMeta, ok := raw["isMeta"].(bool); ok && isMeta {
+		ev.Skip = true
+		return true
+	}
+	// The synthetic continuation summary written when the conversation is
+	// compacted ("This session is being continued from a previous
+	// conversation…") is not a real user turn. A manual /compact writes it
+	// with no assistant event or turn_done following, so letting it through
+	// flipped ready → working with nothing to transition back (issue #641).
+	if isCompact, ok := raw["isCompactSummary"].(bool); ok && isCompact {
 		ev.Skip = true
 		return true
 	}

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -174,6 +174,28 @@ func TestParser_IsMeta_Skip(t *testing.T) {
 	}
 }
 
+func TestParser_CompactSummary_Skip(t *testing.T) {
+	// The synthetic continuation summary written after a compaction
+	// (issue #641). It carries plain string content with no command
+	// prefix, so without the isCompactSummary check it parses as a real
+	// user turn and flips a ready session to working with no follow-up
+	// event to transition it back.
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type":                      "user",
+		"isCompactSummary":          true,
+		"isVisibleInTranscriptOnly": true,
+		"timestamp":                 "2026-06-07T11:46:42.961Z",
+		"message": map[string]interface{}{
+			"role":    "user",
+			"content": "This session is being continued from a previous conversation that ran out of context.",
+		},
+	})
+	if ev == nil || !ev.Skip {
+		t.Error("expected isCompactSummary user event to be skipped")
+	}
+}
+
 func TestParser_LocalCommand_Skip(t *testing.T) {
 	p := &Parser{}
 	ev := p.ParseLine(map[string]interface{}{


### PR DESCRIPTION
Fixes #641.

## Problem

After a manual `/compact`, the session sticks in **working** forever (live repro: session `bb9f6ebf`, stuck since 11:46Z). The compaction tail writes a synthetic `user` event with `isCompactSummary: true` ("This session is being continued from a previous conversation…"). `handleUserEvent` skips `isMeta`, task-notifications, and `<command-name>`/`<local-command-*>` wrappers — but not this one: plain string content, no command prefix, so it parses as a real user turn. The classifier's default rule flips `ready → working`, and since a manual compaction never produces an assistant event or `turn_done`, nothing transitions it back.

## Fix

Skip `user` events with `isCompactSummary: true` in `handleUserEvent`, same treatment as `isMeta`. Test-first: `TestParser_CompactSummary_Skip` reproduces the exact transcript shape from the live session and failed before the fix.

Mid-task auto-compact writes the same entry shape but is followed immediately by real assistant events, so skipping the summary loses nothing there.

## Testing

- `go test ./core/... -race -count=1` ✓
- `go test ./tools/onboarding-factory/... -race -count=1` ✓
- `tools/replay-fixtures.sh` ✓ (existing goldens unchanged — no recording contains a compact summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)