### PR TITLE
fix(detector): sweep superseded proc- pre-sessions periodically, not only at seed

### DIFF
--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -719,6 +719,10 @@ func (pm *PIDManager) snapshotLivenessStates() []livenessSnapshot {
 // sweep then acts on the immutable snapshot, never holding assignMu across a
 // delete callback (the invariant documented on assignMu).
 func (pm *PIDManager) CheckPIDLiveness() bool {
+	// Retire proc-* ghosts whose real session was PID-bound to a sibling
+	// process — the seed-time sweep can't reach them (issue #645).
+	pm.sweepSupersededPreSessionsPeriodic()
+
 	snaps := pm.snapshotLivenessStates()
 	foundDead := false
 	for _, snap := range snaps {
@@ -963,9 +967,34 @@ func isDedupDeleteCandidate(state *session.SessionState, pid int, newest *sessio
 	return state.ParentSessionID == "" && !strings.HasPrefix(state.SessionID, "proc-")
 }
 
+// preSessionSweepGrace is how long a proc-* pre-session must exist before the
+// periodic sweep is allowed to retire it via the adapter+CWD fallback. The
+// PID-strict scanner check (HasRealSessionForPID, issue #113) deliberately
+// keeps a freshly-opened process's pre-session alive even when an active
+// session already exists in the same cwd (two claude instances in one dir).
+// The periodic CWD fallback would kill such a legitimate pre-session on sight,
+// so it waits out this grace window — long enough for normal transcript
+// creation + PID binding to complete — before treating an unbound proc-* as a
+// permanent ghost. The PID-match path needs no grace and is exempt.
+const preSessionSweepGrace = 90 * time.Second
+
+// presessionMatch reports the kind of real session that supersedes a proc-*
+// pre-session. The two paths carry different safety properties, so the periodic
+// sweep gates them differently (PID = always safe; CWD = grace-period guarded).
+type presessionMatch int
+
+const (
+	matchNone presessionMatch = iota
+	matchPID                  // a real session is PID-bound to the same process
+	matchCWD                  // same adapter + cwd, but a different (or no) PID
+)
+
 // sweepSupersededPreSessions deletes proc-* pre-sessions once a matching
 // real session exists. Match is by PID (preferred) or by adapter + CWD for
-// adapters like Codex whose PID discovery may not have completed yet.
+// adapters like Codex whose PID discovery may not have completed yet. This is
+// the seed-time variant: it runs once during startup before the event loop and
+// the SweepDeadPIDs goroutine begin, so it needs no grace period or locking.
+// The periodic equivalent is sweepSupersededPreSessionsPeriodic.
 func (pm *PIDManager) sweepSupersededPreSessions(states []*session.SessionState) {
 	for _, proc := range states {
 		if !strings.HasPrefix(proc.SessionID, "proc-") {
@@ -974,7 +1003,7 @@ func (pm *PIDManager) sweepSupersededPreSessions(states []*session.SessionState)
 		if s, _ := pm.repo.Load(proc.SessionID); s == nil {
 			continue
 		}
-		if candidate := findSupersedingSession(proc, states); candidate != nil {
+		if candidate, _ := findSupersedingSession(proc, states); candidate != nil {
 			pm.log.LogInfo("session-detector-seed", proc.SessionID,
 				fmt.Sprintf("pre-session superseded by %s — deleting", candidate.SessionID))
 			if pm.onSessionDeleted != nil {
@@ -986,21 +1015,103 @@ func (pm *PIDManager) sweepSupersededPreSessions(states []*session.SessionState)
 	}
 }
 
+// sweepSupersededPreSessionsPeriodic retires proc-* pre-sessions whose real
+// session was PID-bound to a sibling process (issue #645). The seed-time sweep
+// only runs once at startup, before the scanner's first poll mints the ghost;
+// and the scanner's own live check (HasRealSessionForPID) is PID-strict, so a
+// proc-A pre-session whose session bound to a distinct PID B is never retired.
+//
+// It reuses findSupersedingSession (the single matching policy) and gates the
+// adapter+CWD fallback behind two #113 guards: the pre-session must be older
+// than preSessionSweepGrace, and the superseding session's PID must be alive
+// and distinct from the proc-* PID (the ghost signature — a real session
+// running under a sibling process). The PID-match path is always safe and
+// retires with no grace, mirroring the seed-time behaviour.
+//
+// Runs off the event loop (CheckPIDLiveness, on the SweepDeadPIDs ticker). It
+// snapshots the session list and the proc-* identity fields under assignMu so
+// its reads never race a concurrent discovery goroutine's assignPIDLocked
+// write of state.PID (issue #628); the snapshot is then acted on without the
+// lock held across delete callbacks. Deletion routes through onSessionDeleted
+// (which records the proc-* id in deletedSessions) so the scanner — whose own
+// PID-strict check would never mark this ghost superseded — cannot re-mint it.
+func (pm *PIDManager) sweepSupersededPreSessionsPeriodic() {
+	pm.assignMu.Lock()
+	states, err := pm.repo.ListAll()
+	if err != nil {
+		pm.assignMu.Unlock()
+		return
+	}
+	type victim struct {
+		state     *session.SessionState
+		candidate string
+	}
+	var victims []victim
+	now := time.Now()
+	for _, proc := range states {
+		if !strings.HasPrefix(proc.SessionID, "proc-") {
+			continue
+		}
+		candidate, kind := findSupersedingSession(proc, states)
+		if kind == matchNone {
+			continue
+		}
+		if kind == matchCWD {
+			// #113 guard: a freshly-opened process in a dir that already has an
+			// active session must keep its pre-session. Only retire after the
+			// grace window AND when the superseding session is bound to a live,
+			// distinct PID (the ghost signature, not a not-yet-bound sibling).
+			if now.Sub(time.Unix(proc.FirstSeen, 0)) < preSessionSweepGrace {
+				continue
+			}
+			if candidate.PID <= 0 || candidate.PID == proc.PID {
+				continue
+			}
+			if syscall.Kill(candidate.PID, 0) == syscall.ESRCH {
+				continue
+			}
+		}
+		victims = append(victims, victim{state: proc, candidate: candidate.SessionID})
+	}
+	pm.assignMu.Unlock()
+
+	for _, v := range victims {
+		if s, _ := pm.repo.Load(v.state.SessionID); s == nil {
+			continue
+		}
+		pm.log.LogInfo("session-detector", v.state.SessionID,
+			fmt.Sprintf("pre-session superseded by %s (PID-bound to a sibling) — deleting", v.candidate))
+		if pm.onSessionDeleted != nil {
+			pm.onSessionDeleted(v.state.SessionID)
+		}
+		_ = pm.repo.Delete(v.state.SessionID)
+		pm.broadcast(outbound.PushTypeDeleted, v.state)
+	}
+}
+
 // findSupersedingSession returns the first real (non-proc) session that
-// matches proc by PID or adapter+CWD, or nil when no candidate matches.
-func findSupersedingSession(proc *session.SessionState, states []*session.SessionState) *session.SessionState {
+// supersedes proc, plus the kind of match. PID match takes precedence over the
+// adapter+CWD fallback (the fallback covers adapters like Codex whose PID
+// discovery may not have completed yet). Returns (nil, matchNone) when nothing
+// matches. This is the canonical superseding-match policy — both the seed-time
+// and periodic sweeps delegate here so the predicate can't drift.
+func findSupersedingSession(proc *session.SessionState, states []*session.SessionState) (*session.SessionState, presessionMatch) {
+	var cwdMatch *session.SessionState
 	for _, candidate := range states {
 		if strings.HasPrefix(candidate.SessionID, "proc-") || candidate.TranscriptPath == "" {
 			continue
 		}
 		if proc.PID > 0 && proc.PID == candidate.PID {
-			return candidate
+			return candidate, matchPID
 		}
-		if proc.CWD != "" && proc.Adapter == candidate.Adapter && proc.CWD == candidate.CWD {
-			return candidate
+		if cwdMatch == nil && proc.CWD != "" && proc.Adapter == candidate.Adapter && proc.CWD == candidate.CWD {
+			cwdMatch = candidate
 		}
 	}
-	return nil
+	if cwdMatch != nil {
+		return cwdMatch, matchCWD
+	}
+	return nil, matchNone
 }
 
 // broadcast sends a push notification if a broadcaster is configured.

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -715,3 +715,154 @@ func TestHandleProcessExit_EvictsChildrenViaFunnel(t *testing.T) {
 		t.Errorf("onSessionDeleted not fired for parent; got %v", deleted)
 	}
 }
+
+// TestCheckPIDLiveness_GhostPreSession_PIDBoundToSibling reproduces issue #645:
+// a real session is PID-bound to a sibling process (a cc-daemon --resume copy),
+// so the scanner's PID-strict live check never marks the original TUI's proc-*
+// pre-session superseded. The seed-time sweep ran once before the ghost was
+// minted, so it's permanent. The periodic sweep must retire it — and it must
+// stay gone on the next sweep (a flapping ghost is a failed fix).
+func TestCheckPIDLiveness_GhostPreSession_PIDBoundToSibling(t *testing.T) {
+	tmp := t.TempDir()
+	transcript := filepath.Join(tmp, "real.jsonl")
+	writeTranscript(t, transcript, time.Now())
+
+	ghostPID := os.Getpid()    // the original TUI — alive
+	siblingPID := os.Getppid() // the --resume copy that won the binding — alive, distinct
+	if siblingPID == ghostPID || siblingPID <= 0 {
+		t.Skip("need a distinct alive parent PID for the sibling-binding scenario")
+	}
+
+	repo := newMockRepo()
+	// Real session, PID-bound to the sibling (not the ghost's PID).
+	repo.states["bb9f6ebf"] = &session.SessionState{
+		SessionID:      "bb9f6ebf",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		PID:            siblingPID,
+		CWD:            tmp,
+		TranscriptPath: transcript,
+		UpdatedAt:      time.Now().Unix(),
+	}
+	// Ghost pre-session for the original TUI: same adapter+CWD, distinct alive
+	// PID, minted well past the grace window.
+	repo.states["proc-ghost"] = &session.SessionState{
+		SessionID: "proc-ghost",
+		Adapter:   "claude-code",
+		State:     session.StateReady,
+		PID:       ghostPID,
+		CWD:       tmp,
+		FirstSeen: time.Now().Add(-5 * time.Minute).Unix(),
+		UpdatedAt: time.Now().Unix(),
+	}
+
+	var deleted []string
+	pm := newPIDManagerForTestWithDeleteSpy(repo, &deleted)
+	pm.CheckPIDLiveness()
+
+	if repo.states["proc-ghost"] != nil {
+		t.Fatal("ghost pre-session should be swept (real session PID-bound to a sibling)")
+	}
+	if repo.states["bb9f6ebf"] == nil {
+		t.Fatal("real session must survive the sweep")
+	}
+	if !slices.Contains(deleted, "proc-ghost") {
+		t.Errorf("onSessionDeleted not fired for ghost; got %v", deleted)
+	}
+
+	// Stays gone: a second sweep must not see it (it's deleted from the repo)
+	// and must not error. This guards against a delete→re-mint→delete flap.
+	pm.CheckPIDLiveness()
+	if repo.states["proc-ghost"] != nil {
+		t.Fatal("ghost re-appeared after a second sweep — flapping")
+	}
+}
+
+// TestCheckPIDLiveness_FreshPreSession_NotSwept is the issue #113 guard: a
+// freshly-opened process in a dir that already has an active session must keep
+// its pre-session (two claude instances in one cwd). The PID-strict scanner
+// check protects this at poll time; the periodic CWD-fallback sweep must not
+// undo it — within the grace window it leaves the young pre-session alone even
+// though the adapter+CWD match (and a distinct alive PID) are present.
+func TestCheckPIDLiveness_FreshPreSession_NotSwept(t *testing.T) {
+	tmp := t.TempDir()
+	transcript := filepath.Join(tmp, "real.jsonl")
+	writeTranscript(t, transcript, time.Now())
+
+	existingPID := os.Getppid()
+	freshPID := os.Getpid()
+	if existingPID == freshPID || existingPID <= 0 {
+		t.Skip("need a distinct alive parent PID for the two-instances scenario")
+	}
+
+	repo := newMockRepo()
+	repo.states["existing"] = &session.SessionState{
+		SessionID:      "existing",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		PID:            existingPID,
+		CWD:            tmp,
+		TranscriptPath: transcript,
+		UpdatedAt:      time.Now().Unix(),
+	}
+	// A second claude just opened in the same dir; its pre-session was minted
+	// moments ago. Its own transcript + PID binding haven't landed yet.
+	repo.states["proc-fresh"] = &session.SessionState{
+		SessionID: "proc-fresh",
+		Adapter:   "claude-code",
+		State:     session.StateReady,
+		PID:       freshPID,
+		CWD:       tmp,
+		FirstSeen: time.Now().Unix(), // within the grace window
+		UpdatedAt: time.Now().Unix(),
+	}
+
+	newPIDManagerForTest(repo).CheckPIDLiveness()
+
+	if repo.states["proc-fresh"] == nil {
+		t.Fatal("fresh pre-session swept within grace window — #113 regression")
+	}
+	if repo.states["existing"] == nil {
+		t.Fatal("existing session must survive")
+	}
+}
+
+// TestCheckPIDLiveness_PIDMatchPreSession_SweptImmediately: when the proc-*
+// pre-session and a real session share the SAME PID, that's ordinary
+// supersession (PID discovery completed). It's always safe and needs no grace
+// — sweep it on the first periodic pass even if it's brand new.
+func TestCheckPIDLiveness_PIDMatchPreSession_SweptImmediately(t *testing.T) {
+	tmp := t.TempDir()
+	transcript := filepath.Join(tmp, "real.jsonl")
+	writeTranscript(t, transcript, time.Now())
+
+	pid := os.Getpid()
+	repo := newMockRepo()
+	repo.states["real"] = &session.SessionState{
+		SessionID:      "real",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		PID:            pid,
+		CWD:            tmp,
+		TranscriptPath: transcript,
+		UpdatedAt:      time.Now().Unix(),
+	}
+	repo.states["proc-same"] = &session.SessionState{
+		SessionID: "proc-same",
+		Adapter:   "claude-code",
+		State:     session.StateReady,
+		PID:       pid, // same PID as the real session
+		CWD:       tmp,
+		FirstSeen: time.Now().Unix(), // brand new — but PID match is grace-exempt
+		UpdatedAt: time.Now().Unix(),
+	}
+
+	newPIDManagerForTest(repo).CheckPIDLiveness()
+
+	if repo.states["proc-same"] != nil {
+		t.Fatal("PID-matched pre-session should be swept immediately (no grace)")
+	}
+	if repo.states["real"] == nil {
+		t.Fatal("real session must survive")
+	}
+}


### PR DESCRIPTION
## Root cause

A `proc-<pid>` pre-session minted **after** daemon startup was never retired when its real session got PID-bound to a *different* process.

Real case (from #645): the original besenkammer TUI (pid `16298`) owns session `bb9f6ebf-…`, but a cc-daemon-spawned `--resume bb9f6ebf-…` copy (pid `84992`, started later) won the PID binding. So `bb9f6ebf.PID == 84992 ≠ 16298`, and the ghost `proc-16298` persisted forever.

Two supersede paths existed, neither covered this:

1. **Scanner live check** — on every poll, `hasActiveSession → HasRealSessionForPID` (`processlifecycle/scanner.go`) is **PID-strict** by design (#113): it needs a real session with `s.PID == pid`. `bb9f6ebf.PID == 84992 ≠ 16298` → never true → ghost stays.
2. **adapter+CWD fallback sweep** — `findSupersedingSession`'s CWD fallback *would* match, but `sweepSupersededPreSessions` only ran from `SeedPIDs` (once at startup, **before** the scanner's first poll mints the ghost).

`cleanupPreSessionsForProject` doesn't help either: it only fires when a *new* real transcript arrives, and the real session predates the ghost.

## Fix

Run the sweep **periodically** from `CheckPIDLiveness` (the existing `SweepDeadPIDs` ticker, 5–15s) instead of seed-only — `sweepSupersededPreSessionsPeriodic`. It reuses `findSupersedingSession` as the **single matching policy** (refactored to also report match *kind*) so the seed-time and periodic predicates can't drift — honoring the "canonical predicate, one place" intent documented on `HasRealSessionForPID`.

## Sweep policy & #113 guard

The PID-strict scanner check exists (#113) so a *freshly-opened* process in a dir that already has an active session still keeps its pre-session (two claude instances in one cwd). A naive periodic CWD-fallback sweep would kill those on sight. Mitigations, applied **only to the CWD-fallback branch**:

- **Grace period** — the proc- pre-session must be older than `preSessionSweepGrace` (90s) before the CWD fallback can retire it. 90s is long enough for normal transcript creation + PID binding to complete; chosen in the family of existing detector timing (5s refresh, 30s fast-delete).
- **Live + distinct PID** — the superseding session's PID must be **alive** and **distinct** from the proc- PID. That's the exact ghost signature (a real session running under a sibling process), and it excludes a not-yet-bound sibling.

The **PID-match** branch (`proc.PID == candidate.PID`) is ordinary supersession — always safe, grace-exempt, retires on the first periodic pass.

## Anti-flap (stays gone)

A flapping ghost (delete → re-mint → delete) would be a failed fix. The daemon-side deletion routes through `onSessionDeleted` (wired to `removeFromProjectSessions`, which records the proc- id in `deletedSessions`). The scanner keeps the PID in its own `tracked` map; its `alreadyTracked` branch only re-marks a tracked PID superseded via its **PID-strict** `hasActiveSession` (which is exactly what fails to fire for this ghost), and it never re-emits `EventNewSession` for an already-tracked PID — so the ghost is **not** re-minted. The regression test asserts a second sweep keeps it gone.

## Thread-safety

`sweepSupersededPreSessionsPeriodic` runs off the event loop. It snapshots the session list + proc- identity fields under `assignMu` (the same lock `assignPIDLocked` takes), exactly mirroring `snapshotLivenessStates`, so its `state.PID`/`FirstSeen` reads don't race a concurrent discovery write (#628). Delete callbacks run after the lock is released — the documented `assignMu` invariant.

## Tests

- `TestCheckPIDLiveness_GhostPreSession_PIDBoundToSibling` — the #645 reproduction: real session PID-bound to a distinct alive sibling; proc- ghost (same adapter+CWD, distinct alive PID, past grace) is swept, real session survives, `onSessionDeleted` fires, **and a second sweep keeps it gone**.
- `TestCheckPIDLiveness_FreshPreSession_NotSwept` — the #113 guard: a freshly-minted proc- pre-session within the grace window is NOT swept despite an adapter+CWD match and a distinct alive PID.
- `TestCheckPIDLiveness_PIDMatchPreSession_SweptImmediately` — PID-match supersession is grace-exempt and retires on the first pass.

All pass with `-race`. Full suite green: `go test ./core/... -race -count=1`, `tools/replay-fixtures.sh` (incl. `4-1_multiple-sessions-same-cwd`), `of validate`. No replay goldens changed (pure daemon-logic change).

Fixes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)