### PR TITLE
fix(detector): backfill empty Adapter on activity path so no-identity startup race can't poison sessions

### DIFF
--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -359,7 +359,7 @@ func (d *SessionDetector) processActivity(id agent.Identity, ev agent.Event) {
 	// on the same *SessionState pointer this loop mutates. Sharing assignMu makes
 	// the two mutually exclusive (issue #606).
 	d.pidMgr.WithSessionStateLock(func() {
-		d.processActivityLocked(state, ev)
+		d.processActivityLocked(id, state, ev)
 	})
 }
 
@@ -367,7 +367,25 @@ func (d *SessionDetector) processActivity(id agent.Identity, ev agent.Event) {
 // load-modify-save for an already-loaded existing session. It MUST be called
 // under PIDManager.WithSessionStateLock so the PID-discovery goroutine it spawns
 // can't write state.PID concurrently with this loop's writes (issue #606).
-func (d *SessionDetector) processActivityLocked(state *session.SessionState, ev agent.Event) {
+//
+// id is the watcher's identity on the first event of a debounce window and
+// empty on the coalesced/refresh paths — see processActivity.
+func (d *SessionDetector) processActivityLocked(id agent.Identity, state *session.SessionState, ev agent.Event) {
+	// Backfill an empty Adapter from the watcher's identity. A session created
+	// via the no-identity fallback (debounce-coalesced / synthetic refresh
+	// during the startup race, see processActivity → onNewSession) starts with
+	// Adapter="" and never sees another transcript-NEW event while it stays
+	// continuously active, so onNewSession's existing-session backfill never
+	// fires. Doing it here unblocks PID discovery (TryDiscoverPID keys off the
+	// adapter) and the ghost sweep on the very next identity-carrying activity
+	// event (issue #643). Runs under WithSessionStateLock with the other
+	// existing-session writes (issue #606).
+	if state.Adapter == "" && id.Name != "" {
+		state.Adapter = id.Name
+		d.log.LogInfo("session-detector", ev.SessionID,
+			fmt.Sprintf("backfilled empty adapter=%s on activity", id.Name))
+	}
+
 	// Apply any deferred PID from background discovery goroutines.
 	// This must happen before ClassifyState so that the PID and state
 	// transition are saved atomically, avoiding the race where

--- a/core/application/services/session_detector_adapter_backfill_test.go
+++ b/core/application/services/session_detector_adapter_backfill_test.go
@@ -1,0 +1,83 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+)
+
+// TestSessionDetector_ActivityBackfillsEmptyAdapter reproduces issue #643: a
+// session created via the no-identity fallback (debounce-coalesced / synthetic
+// refresh during the startup race) persists Adapter="" forever, because the
+// only backfill lived in onNewSession's existing-session branch and a
+// continuously-active transcript never produces another transcript-NEW event.
+//
+// The next identity-carrying activity event must backfill Adapter — which also
+// unblocks PID discovery, since TryDiscoverPID keys off the adapter name.
+func TestSessionDetector_ActivityBackfillsEmptyAdapter(t *testing.T) {
+	tw := newMockAgentWatcher() // identity = "claude-code"
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	cwd := t.TempDir() // #321 — daemon rejects sessions with missing cwd
+
+	// CWD discovery is registered only for "claude-code". While Adapter=="" the
+	// session can never reach it (TryDiscoverPID returns false on a nil
+	// discoverFn); once backfilled, the state.PID==0 retry binds the PID.
+	cwdFn := func(string, func([]int) int) (int, error) { return 64180, nil }
+	det := newDetectorWithCWDDiscovery(tw, pw, repo, cwdFn)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	// Wait for seedFromDisk before injecting the poisoned session.
+	time.Sleep(20 * time.Millisecond)
+
+	// Seed a session exactly as the no-identity fallback would create it:
+	// Adapter="" and PID==0, continuously active (working).
+	now := time.Now().Unix()
+	repo.Save(&session.SessionState{
+		Version:        1,
+		SessionID:      "poisoned",
+		State:          session.StateWorking,
+		Adapter:        "",
+		PID:            0,
+		TranscriptPath: "/home/.claude/projects/-Users-test/poisoned.jsonl",
+		CWD:            cwd,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     1,
+	})
+
+	// Deliver an identity-carrying activity event (leading-edge of a debounce
+	// window forwards the watcher's identity to processActivity).
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "poisoned",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: "/home/.claude/projects/-Users-test/poisoned.jsonl",
+		CWD:            cwd,
+	}
+
+	// PID discovery is the downstream signal that the backfill took effect —
+	// it can only succeed once Adapter is set. Poll race-free (#606).
+	waitForPID(repo, "poisoned", time.Second)
+
+	cancel()
+	<-done
+
+	state, _ := repo.Load("poisoned")
+	if state == nil {
+		t.Fatal("poisoned session should still exist")
+	}
+	if state.Adapter != "claude-code" {
+		t.Errorf("Adapter: got %q, want %q (backfill on activity path)", state.Adapter, "claude-code")
+	}
+	if state.PID != 64180 {
+		t.Errorf("PID: got %d, want 64180 (discovery unblocked by backfill)", state.PID)
+	}
+}


### PR DESCRIPTION
## Root cause (issue #643)

A session created during the daemon-startup race via the **no-identity fallback** kept `Adapter == ""` for its entire lifetime.

1. `processActivity`'s "session not tracked yet" branch calls `onNewSession(id, ev)` — but the debounce-coalesced and synthetic-refresh paths pass an empty `agent.Identity{}` (via `processActivityWithoutIdentity`), so the session is created with `Adapter: ""`.
2. The only backfill lived in `onNewSession`'s **existing-session** branch (`existing.Adapter == "" && id.Name != ""`), which only fires on a transcript-NEW event. A continuously-active transcript never produces another transcript-NEW event, so the backfill never ran. `processActivityLocked` never backfilled.

### Cascade
- **No PID**: `TryDiscoverPID` looks up `pm.pidDiscovers[adapter]` — nil for `""` → returns false. The session never binds its PID.
- **Unsweepable ghost**: `findSupersedingSession` can't retire the `proc-<pid>` ghost twin — candidate PID is 0 and the adapter+CWD fallback mismatches (`proc.Adapter="claude-code"` ≠ `""`).

Real-world instance `31ddf9aa-…` showed "?" in the UI and persisted `adapter: null, pid: null`, while its subagent children correctly had `adapter: claude-code`.

## Fix

Backfill `state.Adapter` from the watcher's identity inside `processActivityLocked` when it's empty. The **first (non-debounced) activity event** per debounce window carries the watcher's identity (`onActivity` → `processActivity(id, ev)`), so the backfill fires within seconds of the bad creation.

- The existing `state.PID == 0` retry below already passes `state.Adapter`, so **PID discovery and the ghost sweep unblock on the same pass** — no extra threading needed.
- The write runs under `WithSessionStateLock` alongside the other existing-session mutations, so the in-flight PID-discovery goroutine can't race it (issue #606).

Diff is confined to the `processActivity` → `processActivityLocked` boundary; **pid_manager.go is untouched** (keeps clear of the concurrent #645 work).

## Tests

New regression test `session_detector_adapter_backfill_test.go`: seeds a session exactly as the no-identity fallback would (`Adapter=""`, `PID=0`, continuously active), delivers an identity-carrying activity event, and asserts **both** the adapter backfill **and** that PID discovery (registered only for `"claude-code"`) now binds. Verified **red without the fix** (both assertions fail), **green with it**.

- `go test ./core/... -race -count=1` — PASS
- `go test ./tools/onboarding-factory/... -race -count=1` — PASS
- `tools/replay-fixtures.sh` — exit 0 (only pre-existing informational drift / known_failing entries; no goldens changed)
- `go test ./tools/onboarding-factory/cmd/replay/... -count=1` — PASS (no golden drift; the fix only affects the no-identity startup-race path, which no recorded fixture exercises, so no golden regeneration needed)
- `go run ./tools/onboarding-factory/cmd/of validate` — OK

Fixes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)