### PR TITLE
fix(claudecode): exclude cc-daemon infra processes (daemon run, --bg-pty-host, --bg-spare) from session matching

### DIFF
--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -56,11 +56,15 @@ func Agent() agent.Agent {
 				Kind:            permission.KindObserve,
 				Title:           "Read session transcripts",
 				FeatureUnlocked: "Session list, timeline, cost & token metrics",
-				Touches:         "Reads session transcripts under ~/.claude/projects/",
+				Touches: "Reads session transcripts under ~/.claude/projects/ and " +
+					"basic info (working directory, command line) of running claude processes",
 				Detail: "Tails *.jsonl transcript files under ~/.claude/projects/ " +
-					"to derive session state, cost, and token metrics. Read-only — " +
-					"no transcript file is ever modified. Toggling off stops all " +
-					"reading immediately.",
+					"to derive session state, cost, and token metrics. Also scans " +
+					"for running claude processes and reads their working directory " +
+					"and command line — to show a session before its first message " +
+					"and to skip Claude Code's background daemon processes. " +
+					"Read-only — no transcript file is ever modified. Toggling off " +
+					"stops all reading immediately.",
 			},
 			{
 				Key:             PermissionKeyHooks,

--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -42,6 +42,7 @@ func Agent() agent.Agent {
 		Process: agent.Process{
 			Match:         agent.ExactName{Name: ProcessName},
 			PIDForSession: DiscoverPID,
+			ExcludeArgv:   IsInfraArgv,
 		},
 		Source: agent.FilesUnderRoot{
 			Dir: transcriptsDir(),

--- a/core/adapters/inbound/agents/claudecode/process.go
+++ b/core/adapters/inbound/agents/claudecode/process.go
@@ -1,0 +1,37 @@
+package claudecode
+
+// IsInfraArgv reports whether a `claude`-binary process is Claude Code's
+// background infrastructure rather than an interactive session. Claude Code
+// 2.1.168 introduced a background-daemon architecture ("cc-daemon"): a
+// long-lived `claude daemon run`, PTY-host wrappers (`--bg-pty-host`), and
+// pre-warmed spares (`--bg-spare`). All run the `claude` binary, so the
+// ExactName process matcher accepts them and the lifecycle scanner would mint
+// permanent `proc-<pid>` ghost pre-sessions for them — they never own a
+// transcript, so nothing ever supersedes them (issue #644).
+//
+// The match is intentionally positional / flag-position based, never a blanket
+// substring scan, so a user prompt that merely mentions these tokens — e.g.
+// `claude -p "explain --bg-pty-host"` — is not excluded:
+//
+//   - argv[1]=="daemon" && argv[2]=="run"  (the cc-daemon itself)
+//   - any argv element (after argv[0]) equal to "--bg-pty-host" or "--bg-spare"
+//     (the PTY-host wrappers and pre-warmed spares; a flag occupies its own
+//     argv slot, whereas a prompt string is a single slot that won't equal the
+//     flag exactly)
+//
+// A nil/empty argv (unreadable, e.g. a hardened-runtime process) is treated as
+// a session — we never exclude on the absence of evidence.
+func IsInfraArgv(argv []string) bool {
+	if len(argv) < 2 {
+		return false
+	}
+	if len(argv) >= 3 && argv[1] == "daemon" && argv[2] == "run" {
+		return true
+	}
+	for _, a := range argv[1:] {
+		if a == "--bg-pty-host" || a == "--bg-spare" {
+			return true
+		}
+	}
+	return false
+}

--- a/core/adapters/inbound/agents/claudecode/process.go
+++ b/core/adapters/inbound/agents/claudecode/process.go
@@ -21,6 +21,12 @@ package claudecode
 //
 // A nil/empty argv (unreadable, e.g. a hardened-runtime process) is treated as
 // a session — we never exclude on the absence of evidence.
+//
+// NOTE: this is a denylist of the infra flags shipped in 2.1.168. If a later
+// Claude Code release adds a new background flag, its processes mint ghost
+// pre-sessions again (the #644 symptom) until that flag is added here — when
+// ghosts reappear after an upstream release, check for new `--bg-*` flags or
+// daemon subcommands first.
 func IsInfraArgv(argv []string) bool {
 	if len(argv) < 2 {
 		return false

--- a/core/adapters/inbound/agents/claudecode/process_test.go
+++ b/core/adapters/inbound/agents/claudecode/process_test.go
@@ -1,0 +1,73 @@
+package claudecode
+
+import "testing"
+
+func TestIsInfraArgv(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want bool
+	}{
+		// --- cc-daemon infrastructure (issue #644) → excluded ---
+		{
+			name: "cc-daemon run",
+			argv: []string{"claude", "daemon", "run", "--origin", "transient",
+				`--spawned-by`, `{"label":"claude","cwd":".../besenkammer","pid":16298}`},
+			want: true,
+		},
+		{
+			name: "bg-pty-host wrapper",
+			argv: []string{
+				"/Applications/ClaudeCode.app/Contents/MacOS/claude",
+				"--bg-pty-host", "/tmp/cc-daemon-501/abc/pty/ab5f01f8.sock", "86", "34",
+				"--", "/Users/x/.claude/versions/2.1.168",
+				"--resume", "bb9f6ebf-1234", "--permission-mode", "auto",
+			},
+			want: true,
+		},
+		{
+			name: "bg-spare claim host",
+			argv: []string{
+				"/Users/x/.claude/versions/2.1.168",
+				"--bg-spare", "/tmp/cc-daemon-501/spare/x.sock",
+			},
+			want: true,
+		},
+
+		// --- real interactive sessions → matched (not excluded) ---
+		{name: "plain claude", argv: []string{"claude"}, want: false},
+		{name: "claude resume", argv: []string{"claude", "--resume", "bb9f6ebf-1234"}, want: false},
+		{
+			name: "claude with model + dangerous skip",
+			argv: []string{"claude", "--model", "opus", "--dangerously-skip-permissions"},
+			want: false,
+		},
+		{
+			name: "prompt that merely mentions the infra flags is NOT excluded",
+			argv: []string{"claude", "-p", "explain --bg-pty-host and --bg-spare"},
+			want: false,
+		},
+		{
+			name: "prompt that mentions daemon run is NOT excluded",
+			argv: []string{"claude", "-p", "how do I use daemon run?"},
+			want: false,
+		},
+		{
+			name: "daemon as a prompt word (not the subcommand) is NOT excluded",
+			argv: []string{"claude", "--resume", "daemon", "run"},
+			want: false,
+		},
+
+		// --- defensive: unreadable / degenerate argv → treated as a session ---
+		{name: "nil argv", argv: nil, want: false},
+		{name: "argv0 only", argv: []string{"claude"}, want: false},
+		{name: "empty", argv: []string{}, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsInfraArgv(tc.argv); got != tc.want {
+				t.Errorf("IsInfraArgv(%v) = %v, want %v", tc.argv, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -221,3 +221,37 @@ func parseProcargs2(buf []byte) map[string]string {
 	}
 	return out
 }
+
+// parseProcargs2Argv extracts the argv portion of a KERN_PROCARGS2 sysctl
+// buffer (same layout as parseProcargs2 documents above). Returns nil for an
+// empty or truncated buffer — hardened-runtime processes strip argv, so
+// callers must treat a nil argv as "unknown", not "no args".
+func parseProcargs2Argv(buf []byte) []string {
+	if len(buf) < 4 {
+		return nil
+	}
+	argc := int(binary.LittleEndian.Uint32(buf[:4]))
+	p := 4
+	// Skip exec path (NUL-terminated) and any alignment NULs before argv[0].
+	for p < len(buf) && buf[p] != 0 {
+		p++
+	}
+	for p < len(buf) && buf[p] == 0 {
+		p++
+	}
+	argv := make([]string, 0, argc)
+	for i := 0; i < argc && p < len(buf); i++ {
+		start := p
+		for p < len(buf) && buf[p] != 0 {
+			p++
+		}
+		argv = append(argv, string(buf[start:p]))
+		if p < len(buf) {
+			p++ // skip NUL
+		}
+	}
+	if len(argv) == 0 {
+		return nil
+	}
+	return argv
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -177,17 +177,9 @@ func ReadLauncherEnv(pid int) *session.Launcher {
 // non-cgo / non-TCC path to read another process's env.
 func parseProcargs2(buf []byte) map[string]string {
 	out := map[string]string{}
-	if len(buf) < 4 {
+	argc, p, ok := procargs2ArgvOffset(buf)
+	if !ok {
 		return out
-	}
-	argc := int(binary.LittleEndian.Uint32(buf[:4]))
-	p := 4
-	// Skip exec path (NUL-terminated) and any alignment NULs before argv[0].
-	for p < len(buf) && buf[p] != 0 {
-		p++
-	}
-	for p < len(buf) && buf[p] == 0 {
-		p++
 	}
 	// Skip argv entries.
 	for i := 0; i < argc && p < len(buf); i++ {
@@ -222,15 +214,17 @@ func parseProcargs2(buf []byte) map[string]string {
 	return out
 }
 
-// parseProcargs2Argv extracts the argv portion of a KERN_PROCARGS2 sysctl
-// buffer (same layout as parseProcargs2 documents above). Returns nil for an
-// empty or truncated buffer — hardened-runtime processes strip argv, so
-// callers must treat a nil argv as "unknown", not "no args".
-func parseProcargs2Argv(buf []byte) []string {
+// procargs2ArgvOffset reads the int32 argc header of a KERN_PROCARGS2 buffer
+// and skips the NUL-terminated exec path plus alignment padding, returning
+// argc and the byte offset of argv[0]. ok is false when the buffer is too
+// short to contain the header. Shared by parseProcargs2 (env) and
+// parseProcargs2Argv (argv) so the two parsers of the same layout cannot
+// drift.
+func procargs2ArgvOffset(buf []byte) (argc, offset int, ok bool) {
 	if len(buf) < 4 {
-		return nil
+		return 0, 0, false
 	}
-	argc := int(binary.LittleEndian.Uint32(buf[:4]))
+	argc = int(binary.LittleEndian.Uint32(buf[:4]))
 	p := 4
 	// Skip exec path (NUL-terminated) and any alignment NULs before argv[0].
 	for p < len(buf) && buf[p] != 0 {
@@ -238,6 +232,22 @@ func parseProcargs2Argv(buf []byte) []string {
 	}
 	for p < len(buf) && buf[p] == 0 {
 		p++
+	}
+	return argc, p, true
+}
+
+// parseProcargs2Argv extracts the argv portion of a KERN_PROCARGS2 sysctl
+// buffer (same layout as parseProcargs2 documents above). Returns nil when
+// the buffer holds no argv at all — hardened-runtime processes strip it, so
+// callers must treat a nil argv as "unknown", not "no args". A buffer
+// truncated mid-argv (argc promises more strings than the buffer holds, e.g.
+// args+env exceeding ARG_MAX) yields the partial argv that is present —
+// fail-open: an exclusion predicate then sees an incomplete command line and
+// treats the process as a session, the pre-filter status quo.
+func parseProcargs2Argv(buf []byte) []string {
+	argc, p, ok := procargs2ArgvOffset(buf)
+	if !ok {
+		return nil
 	}
 	argv := make([]string, 0, argc)
 	for i := 0; i < argc && p < len(buf); i++ {

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -110,6 +110,60 @@ func TestParseProcargs2(t *testing.T) {
 	}
 }
 
+func TestParseProcargs2Argv(t *testing.T) {
+	// Same KERN_PROCARGS2 layout as TestParseProcargs2:
+	//   argc (int32 LE) | exec_path\0 | argv...\0 | envp...\0
+	makeBuf := func(argc int32, execPath string, argv []string, envp []string) []byte {
+		var b []byte
+		b = append(b, byte(argc), byte(argc>>8), byte(argc>>16), byte(argc>>24))
+		b = append(b, []byte(execPath)...)
+		b = append(b, 0)
+		for _, a := range argv {
+			b = append(b, []byte(a)...)
+			b = append(b, 0)
+		}
+		for _, e := range envp {
+			b = append(b, []byte(e)...)
+			b = append(b, 0)
+		}
+		return b
+	}
+
+	tests := []struct {
+		name string
+		buf  []byte
+		want []string
+	}{
+		{name: "empty buffer", buf: nil, want: nil},
+		{
+			name: "argv extracted, env ignored",
+			buf: makeBuf(3, "/usr/local/bin/claude",
+				[]string{"claude", "--resume", "abc-123"},
+				[]string{"HOME=/Users/alice", "PATH=/usr/bin"}),
+			want: []string{"claude", "--resume", "abc-123"},
+		},
+		{
+			name: "cc-daemon argv with no env",
+			buf: makeBuf(3, "/Applications/ClaudeCode.app/Contents/MacOS/claude",
+				[]string{"claude", "daemon", "run"}, nil),
+			want: []string{"claude", "daemon", "run"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseProcargs2Argv(tc.buf)
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseProcargs2Argv: want %v, got %v", tc.want, got)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("argv[%d]: want %q, got %q", i, tc.want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
 func TestReadLauncherEnv_InvalidPID(t *testing.T) {
 	if l := ReadLauncherEnv(0); l != nil {
 		t.Errorf("pid 0: want nil, got %+v", l)

--- a/core/adapters/inbound/agents/processlifecycle/process_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/process_darwin.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	"irrlicht/core/ports/outbound"
 )
 
@@ -55,6 +57,18 @@ func (darwinObserver) FindByCmdline(pattern string) ([]int, error) {
 		out = append(out, p)
 	}
 	return out, nil
+}
+
+// ArgvOf returns the argument vector of pid via KERN_PROCARGS2 sysctl
+// (the same raw buffer readProcessEnv parses for env). Per the port
+// contract an unreadable argv — hardened-runtime processes strip it — is a
+// nil slice, not an error.
+func (darwinObserver) ArgvOf(pid int) ([]string, error) {
+	buf, err := unix.SysctlRaw("kern.procargs2", pid)
+	if err != nil {
+		return nil, nil
+	}
+	return parseProcargs2Argv(buf), nil
 }
 
 // CWDOf returns the working directory of pid via `lsof -d cwd`.

--- a/core/adapters/inbound/agents/processlifecycle/process_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/process_linux.go
@@ -101,6 +101,21 @@ func (linuxObserver) FindByCmdline(pattern string) ([]int, error) {
 	return out, nil
 }
 
+// ArgvOf returns the argument vector of pid from /proc/<pid>/cmdline (a
+// NUL-separated argv). Per the port contract an unreadable argv (process
+// exited, root-owned) is a nil slice, not an error.
+func (linuxObserver) ArgvOf(pid int) ([]string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return nil, nil
+	}
+	fields := strings.Split(strings.TrimRight(string(data), "\x00"), "\x00")
+	if len(fields) == 1 && fields[0] == "" {
+		return nil, nil
+	}
+	return fields, nil
+}
+
 // CWDOf returns the working directory of pid via the /proc/<pid>/cwd symlink.
 func (linuxObserver) CWDOf(pid int) (string, error) {
 	cwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))

--- a/core/adapters/inbound/agents/processlifecycle/process_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/process_other.go
@@ -20,6 +20,7 @@ func newObserver() outbound.ProcessObserver { return stubObserver{} }
 
 func (stubObserver) FindByName(string) ([]int, error)    { return nil, nil }
 func (stubObserver) FindByCmdline(string) ([]int, error) { return nil, nil }
+func (stubObserver) ArgvOf(int) ([]string, error)        { return nil, nil }
 
 func (stubObserver) CWDOf(pid int) (string, error) {
 	return "", fmt.Errorf("process observation unsupported on %s", runtime.GOOS)

--- a/core/adapters/inbound/agents/processlifecycle/scanner.go
+++ b/core/adapters/inbound/agents/processlifecycle/scanner.go
@@ -59,7 +59,13 @@ type Scanner struct {
 
 	mu      sync.Mutex
 	tracked map[int]trackedProc // pid → pre-session
-	subs    []chan agent.Event
+
+	// argvVerdicts caches the per-PID argvFilter verdict — argv is immutable
+	// for a process's lifetime, so each PID pays at most one ArgvOf read.
+	// poll prunes entries whose PID no longer matches, so a recycled PID
+	// cannot inherit a stale verdict. See argvExcluded.
+	argvVerdicts map[int]bool
+	subs         []chan agent.Event
 
 	// Adaptive backoff: back off to backoffInterval when PID set is stable.
 	lastPIDCount int
@@ -79,10 +85,11 @@ func NewScanner(processName, adapter string, interval time.Duration) *Scanner {
 		interval = defaultInterval
 	}
 	return &Scanner{
-		processName: processName,
-		adapter:     adapter,
-		interval:    interval,
-		tracked:     make(map[int]trackedProc),
+		processName:  processName,
+		adapter:      adapter,
+		interval:     interval,
+		tracked:      make(map[int]trackedProc),
+		argvVerdicts: make(map[int]bool),
 	}
 }
 
@@ -258,11 +265,9 @@ func (s *Scanner) poll() {
 		// Drop it from the live set too so it isn't treated as a tracked PID
 		// that "exited" on the next poll. A nil argv (unreadable) is passed
 		// through; the predicate must default to not-excluding in that case.
-		if s.argvFilter != nil {
-			if argv, _ := osProc.ArgvOf(pid); s.argvFilter(argv) {
-				delete(live, pid)
-				continue
-			}
+		if s.argvFilter != nil && s.argvExcluded(pid) {
+			delete(live, pid)
+			continue
 		}
 
 		s.mu.Lock()
@@ -413,6 +418,70 @@ func (s *Scanner) poll() {
 			ProjectDir: proc.projectDir,
 		})
 	}
+
+	// Prune argv-verdict cache entries whose PID no longer matches (process
+	// exited). Compare against the full matched set, not live — excluded
+	// PIDs were dropped from live but are still running and must keep their
+	// cached verdict.
+	s.mu.Lock()
+	if len(s.argvVerdicts) > 0 {
+		matched := make(map[int]bool, len(pids))
+		for _, pid := range pids {
+			matched[pid] = true
+		}
+		for pid := range s.argvVerdicts {
+			if !matched[pid] {
+				delete(s.argvVerdicts, pid)
+			}
+		}
+	}
+	s.mu.Unlock()
+}
+
+// argvExcluded reports whether pid's argv marks it as agent infrastructure
+// per s.argvFilter. Verdicts are cached — argv is immutable for a process's
+// lifetime — so each PID pays at most one ArgvOf read. A nil argv
+// (unreadable, possibly transiently) is never cached: the predicate sees nil
+// (and must not exclude on it) and the read is retried on the next poll.
+//
+// The first excluded verdict also retires any pre-session already minted for
+// this PID — by an earlier poll that couldn't read argv, or persisted by a
+// daemon predating the argv filter (issue #644) — with a single
+// EventRemoved. The detector deletes pre-sessions on removal and treats a
+// removal for an unknown session as a no-op, so the emission is safe when no
+// pre-session exists. When no subscriber is attached yet (startup race with
+// SessionDetector.Run), the excluded verdict is left uncached so the next
+// poll retries the emission instead of silently dropping it.
+func (s *Scanner) argvExcluded(pid int) bool {
+	s.mu.Lock()
+	excluded, cached := s.argvVerdicts[pid]
+	s.mu.Unlock()
+	if cached {
+		return excluded
+	}
+
+	argv, _ := osProc.ArgvOf(pid)
+	excluded = s.argvFilter(argv)
+
+	s.mu.Lock()
+	proc := s.tracked[pid]
+	if excluded {
+		delete(s.tracked, pid)
+	}
+	hasSubs := len(s.subs) > 0
+	if argv != nil && (!excluded || hasSubs) {
+		s.argvVerdicts[pid] = excluded
+	}
+	s.mu.Unlock()
+
+	if excluded && hasSubs {
+		s.broadcast(agent.Event{
+			Type:       agent.EventRemoved,
+			SessionID:  fmt.Sprintf("proc-%d", pid),
+			ProjectDir: proc.projectDir,
+		})
+	}
+	return excluded
 }
 
 // hasActiveSession returns true iff the injected sessionChecker reports a

--- a/core/adapters/inbound/agents/processlifecycle/scanner.go
+++ b/core/adapters/inbound/agents/processlifecycle/scanner.go
@@ -48,6 +48,15 @@ type Scanner struct {
 	// Callers typically delegate to HasRealSessionForPID.
 	sessionChecker func(projectDir string, pid int) bool
 
+	// argvFilter is an optional per-adapter predicate that excludes a matched
+	// PID by inspecting its argv. Set via WithArgvFilter from the adapter's
+	// Process.ExcludeArgv declaration. When it returns true the scanner mints
+	// no pre-session for that PID — the binary matched but it's infrastructure
+	// (e.g. a background daemon/wrapper running the same binary), not a
+	// session. Keeping the predicate here (not in poll's matcher) keeps the
+	// scanner generic; the format-specific argv shapes live in the adapter.
+	argvFilter func(argv []string) bool
+
 	mu      sync.Mutex
 	tracked map[int]trackedProc // pid → pre-session
 	subs    []chan agent.Event
@@ -116,6 +125,15 @@ func (s *Scanner) WithTranscriptFilename(name string) *Scanner {
 // new pre-sessions for freshly-opened processes.
 func (s *Scanner) WithSessionChecker(fn func(projectDir string, pid int) bool) *Scanner {
 	s.sessionChecker = fn
+	return s
+}
+
+// WithArgvFilter sets a per-adapter predicate that excludes a matched PID by
+// its argv (the adapter's Process.ExcludeArgv). When fn reports true the
+// scanner skips the PID entirely — no pre-session is minted and it is never
+// tracked. Returns the scanner for chaining.
+func (s *Scanner) WithArgvFilter(fn func(argv []string) bool) *Scanner {
+	s.argvFilter = fn
 	return s
 }
 
@@ -235,6 +253,18 @@ func (s *Scanner) poll() {
 
 	// --- handle newly-seen PIDs ---
 	for _, pid := range pids {
+		// Per-adapter argv exclusion: a matched binary that is the agent's
+		// background infrastructure (daemon/wrapper) rather than a session.
+		// Drop it from the live set too so it isn't treated as a tracked PID
+		// that "exited" on the next poll. A nil argv (unreadable) is passed
+		// through; the predicate must default to not-excluding in that case.
+		if s.argvFilter != nil {
+			if argv, _ := osProc.ArgvOf(pid); s.argvFilter(argv) {
+				delete(live, pid)
+				continue
+			}
+		}
+
 		s.mu.Lock()
 		_, alreadyTracked := s.tracked[pid]
 		s.mu.Unlock()

--- a/core/adapters/inbound/agents/processlifecycle/scanner_argvfilter_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/scanner_argvfilter_test.go
@@ -1,6 +1,7 @@
 package processlifecycle
 
 import (
+	"fmt"
 	"testing"
 
 	"irrlicht/core/domain/agent"
@@ -22,6 +23,37 @@ func (f fakeObserver) CWDOf(pid int) (string, error)       { return f.cwd[pid], 
 func (f fakeObserver) WriterOf(string) (int, error)        { return 0, nil }
 func (f fakeObserver) EnvOf(int) (map[string]string, error) {
 	return map[string]string{}, nil
+}
+
+// stubInfraFilter is a deliberately simple stand-in for an adapter's
+// Process.ExcludeArgv predicate: these seam tests verify that the scanner
+// honors whatever predicate the adapter declares. The real
+// claudecode.IsInfraArgv rule is table-tested in its own package and
+// intentionally not duplicated here (importing it from this internal test
+// would also create an import cycle — claudecode imports processlifecycle).
+func stubInfraFilter(argv []string) bool {
+	for _, a := range argv {
+		if a == "daemon" || a == "--bg-pty-host" || a == "--bg-spare" {
+			return true
+		}
+	}
+	return false
+}
+
+// countingObserver wraps fakeObserver, counting ArgvOf calls per PID and
+// optionally simulating a transiently unreadable argv (nil on first read).
+type countingObserver struct {
+	fakeObserver
+	argvCalls map[int]int
+	nilFirst  map[int]bool
+}
+
+func (c *countingObserver) ArgvOf(pid int) ([]string, error) {
+	c.argvCalls[pid]++
+	if c.nilFirst[pid] && c.argvCalls[pid] == 1 {
+		return nil, nil
+	}
+	return c.fakeObserver.argv[pid], nil
 }
 
 // TestPoll_ArgvFilterExcludesInfra verifies that the scanner mints a
@@ -54,23 +86,8 @@ func TestPoll_ArgvFilterExcludesInfra(t *testing.T) {
 	t.Cleanup(func() { osProc = prev })
 
 	s := NewScanner("claude", "claude-code", 0)
-	// Mirror the adapter wiring: Process.ExcludeArgv → WithArgvFilter. The
-	// predicate matches claudecode.IsInfraArgv's rule (kept here to avoid a
-	// cross-package import in this seam test).
-	s.WithArgvFilter(func(argv []string) bool {
-		if len(argv) < 2 {
-			return false
-		}
-		if len(argv) >= 3 && argv[1] == "daemon" && argv[2] == "run" {
-			return true
-		}
-		for _, a := range argv[1:] {
-			if a == "--bg-pty-host" || a == "--bg-spare" {
-				return true
-			}
-		}
-		return false
-	})
+	// Mirror the adapter wiring: Process.ExcludeArgv → WithArgvFilter.
+	s.WithArgvFilter(stubInfraFilter)
 
 	ch := s.Subscribe()
 	s.poll()
@@ -118,4 +135,154 @@ func pidFromTracked(s *Scanner, sessionID string) int {
 		}
 	}
 	return -1
+}
+
+// TestPoll_ArgvVerdictCachedPerPID verifies that the scanner reads a PID's
+// argv at most once — argv is immutable for a process's lifetime, so the
+// verdict is cached and repeated polls must not repeat the (sysctl-backed)
+// ArgvOf read for either included or excluded PIDs.
+func TestPoll_ArgvVerdictCachedPerPID(t *testing.T) {
+	const (
+		realPID  = 100
+		infraPID = 200
+	)
+	obs := &countingObserver{
+		fakeObserver: fakeObserver{
+			pids: []int{realPID, infraPID},
+			cwd:  map[int]string{realPID: "/Users/x/proj", infraPID: "/Users/x"},
+			argv: map[int][]string{
+				realPID:  {"claude", "--resume", "abc"},
+				infraPID: {"claude", "daemon", "run"},
+			},
+		},
+		argvCalls: map[int]int{},
+		nilFirst:  map[int]bool{},
+	}
+	prev := osProc
+	osProc = obs
+	t.Cleanup(func() { osProc = prev })
+
+	s := NewScanner("claude", "claude-code", 0).WithArgvFilter(stubInfraFilter)
+	_ = s.Subscribe()
+
+	for i := 0; i < 3; i++ {
+		s.poll()
+	}
+
+	for _, pid := range []int{realPID, infraPID} {
+		if got := obs.argvCalls[pid]; got != 1 {
+			t.Errorf("pid %d: ArgvOf called %d times across 3 polls, want 1 (verdict cached)", pid, got)
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.tracked[infraPID]; ok {
+		t.Errorf("infra pid %d tracked despite cached excluded verdict", infraPID)
+	}
+	if _, ok := s.tracked[realPID]; !ok {
+		t.Errorf("real pid %d should remain tracked", realPID)
+	}
+}
+
+// TestPoll_ExcludedPIDRetiresPreSessionMintedOnNilArgv: a transiently
+// unreadable argv (nil) must not be cached as "not infrastructure". Poll 1
+// mints a pre-session because there is no evidence to exclude on; poll 2
+// reads the real argv, excludes the PID, retires the just-minted pre-session
+// with exactly one EventRemoved, and poll 3 serves the cached verdict without
+// re-minting or re-removing.
+func TestPoll_ExcludedPIDRetiresPreSessionMintedOnNilArgv(t *testing.T) {
+	const infraPID = 200
+
+	obs := &countingObserver{
+		fakeObserver: fakeObserver{
+			pids: []int{infraPID},
+			cwd:  map[int]string{infraPID: "/Users/x"},
+			argv: map[int][]string{infraPID: {"claude", "daemon", "run"}},
+		},
+		argvCalls: map[int]int{},
+		nilFirst:  map[int]bool{infraPID: true}, // poll 1: argv unreadable
+	}
+	prev := osProc
+	osProc = obs
+	t.Cleanup(func() { osProc = prev })
+
+	s := NewScanner("claude", "claude-code", 0).WithArgvFilter(stubInfraFilter)
+	ch := s.Subscribe()
+
+	s.poll() // argv nil → no evidence → pre-session minted
+	s.poll() // argv readable → excluded → pre-session retired
+	s.poll() // cached verdict → no further events
+
+	var minted, removed int
+	for {
+		select {
+		case ev := <-ch:
+			switch ev.Type {
+			case agent.EventNewSession:
+				minted++
+			case agent.EventRemoved:
+				removed++
+				if want := fmt.Sprintf("proc-%d", infraPID); ev.SessionID != want {
+					t.Errorf("removal for %q, want %q", ev.SessionID, want)
+				}
+			}
+		default:
+			goto done
+		}
+	}
+done:
+
+	if minted != 1 {
+		t.Errorf("got %d new_session events, want 1 (nil argv mints once)", minted)
+	}
+	if removed != 1 {
+		t.Errorf("got %d removed events, want exactly 1 (retire once, no flapping)", removed)
+	}
+	if got := obs.argvCalls[infraPID]; got != 2 {
+		t.Errorf("ArgvOf called %d times, want 2 (nil verdict not cached, real verdict cached)", got)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.tracked[infraPID]; ok {
+		t.Errorf("excluded pid %d must not remain tracked", infraPID)
+	}
+}
+
+// TestPoll_ExcludedPIDEmitsRetirementForPersistedGhost: a daemon upgraded to
+// the argv filter may still hold a persisted proc-<pid> session minted by
+// the pre-filter version (issue #644's live ghosts). The scanner has no
+// in-memory state for those, so on the first excluded verdict it must emit
+// one retirement EventRemoved for proc-<pid> — the detector deletes the
+// persisted pre-session, or no-ops when none exists — and none afterwards.
+func TestPoll_ExcludedPIDEmitsRetirementForPersistedGhost(t *testing.T) {
+	const infraPID = 200
+	prev := osProc
+	osProc = fakeObserver{
+		pids: []int{infraPID},
+		cwd:  map[int]string{infraPID: "/Users/x"},
+		argv: map[int][]string{infraPID: {"claude", "daemon", "run"}},
+	}
+	t.Cleanup(func() { osProc = prev })
+
+	s := NewScanner("claude", "claude-code", 0).WithArgvFilter(stubInfraFilter)
+	ch := s.Subscribe()
+	s.poll()
+	s.poll() // cached verdict — must not emit a second removal
+
+	var removed []string
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Type == agent.EventRemoved {
+				removed = append(removed, ev.SessionID)
+			}
+		default:
+			goto done
+		}
+	}
+done:
+	if len(removed) != 1 || removed[0] != fmt.Sprintf("proc-%d", infraPID) {
+		t.Fatalf("expected exactly one retirement removal for proc-%d, got %v", infraPID, removed)
+	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/scanner_argvfilter_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/scanner_argvfilter_test.go
@@ -1,0 +1,121 @@
+package processlifecycle
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/agent"
+)
+
+// fakeObserver is a minimal ProcessObserver for exercising the scanner's
+// per-adapter argv exclusion. Only FindByName, CWDOf, and ArgvOf are used by
+// poll(); the rest satisfy the interface.
+type fakeObserver struct {
+	pids []int
+	cwd  map[int]string
+	argv map[int][]string
+}
+
+func (f fakeObserver) FindByName(string) ([]int, error)    { return f.pids, nil }
+func (f fakeObserver) FindByCmdline(string) ([]int, error) { return nil, nil }
+func (f fakeObserver) ArgvOf(pid int) ([]string, error)    { return f.argv[pid], nil }
+func (f fakeObserver) CWDOf(pid int) (string, error)       { return f.cwd[pid], nil }
+func (f fakeObserver) WriterOf(string) (int, error)        { return 0, nil }
+func (f fakeObserver) EnvOf(int) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+// TestPoll_ArgvFilterExcludesInfra verifies that the scanner mints a
+// pre-session for a real `claude` session PID but not for cc-daemon
+// infrastructure PIDs whose argv the adapter predicate rejects (issue #644).
+func TestPoll_ArgvFilterExcludesInfra(t *testing.T) {
+	const (
+		realPID   = 100 // plain interactive `claude` → expect new_session
+		daemonPID = 200 // `claude daemon run ...`     → excluded
+		ptyPID    = 300 // `... --bg-pty-host ...`     → excluded
+		sparePID  = 400 // `... --bg-spare ...`        → excluded
+	)
+
+	prev := osProc
+	osProc = fakeObserver{
+		pids: []int{realPID, daemonPID, ptyPID, sparePID},
+		cwd: map[int]string{
+			realPID:   "/Users/x/proj",
+			daemonPID: "/Users/x",
+			ptyPID:    "/Users/x/proj",
+			sparePID:  "/Users/x",
+		},
+		argv: map[int][]string{
+			realPID:   {"claude", "--resume", "abc"},
+			daemonPID: {"claude", "daemon", "run", "--origin", "transient"},
+			ptyPID:    {"claude", "--bg-pty-host", "/tmp/x.sock", "86", "34", "--", "claude", "--resume", "abc"},
+			sparePID:  {"claude", "--bg-spare", "/tmp/y.sock"},
+		},
+	}
+	t.Cleanup(func() { osProc = prev })
+
+	s := NewScanner("claude", "claude-code", 0)
+	// Mirror the adapter wiring: Process.ExcludeArgv → WithArgvFilter. The
+	// predicate matches claudecode.IsInfraArgv's rule (kept here to avoid a
+	// cross-package import in this seam test).
+	s.WithArgvFilter(func(argv []string) bool {
+		if len(argv) < 2 {
+			return false
+		}
+		if len(argv) >= 3 && argv[1] == "daemon" && argv[2] == "run" {
+			return true
+		}
+		for _, a := range argv[1:] {
+			if a == "--bg-pty-host" || a == "--bg-spare" {
+				return true
+			}
+		}
+		return false
+	})
+
+	ch := s.Subscribe()
+	s.poll()
+
+	var newSessions []int
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Type == agent.EventNewSession {
+				// SessionID is "proc-<pid>"; recover the PID from the tracked map.
+				newSessions = append(newSessions, pidFromTracked(s, ev.SessionID))
+			}
+		default:
+			goto done
+		}
+	}
+done:
+
+	if len(newSessions) != 1 || newSessions[0] != realPID {
+		t.Fatalf("expected exactly one new_session for pid %d, got %v", realPID, newSessions)
+	}
+
+	// The infra PIDs must never be tracked — otherwise a later poll would treat
+	// them as "exited" and emit a spurious removal.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, infra := range []int{daemonPID, ptyPID, sparePID} {
+		if _, ok := s.tracked[infra]; ok {
+			t.Errorf("infra pid %d was tracked but should have been excluded", infra)
+		}
+	}
+	if _, ok := s.tracked[realPID]; !ok {
+		t.Errorf("real session pid %d should be tracked", realPID)
+	}
+}
+
+// pidFromTracked finds the PID whose tracked pre-session has the given
+// SessionID. Returns -1 if absent.
+func pidFromTracked(s *Scanner, sessionID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for pid, proc := range s.tracked {
+		if proc.sessionID == sessionID {
+			return pid
+		}
+	}
+	return -1
+}

--- a/core/cmd/irrlichd/wiring.go
+++ b/core/cmd/irrlichd/wiring.go
@@ -55,6 +55,9 @@ func buildAgentWatchers(
 	if m, ok := a.Process.Match.(agent.CommandPattern); ok {
 		scanner.WithCommandLineMatch(m.Regex.String())
 	}
+	if a.Process.ExcludeArgv != nil {
+		scanner.WithArgvFilter(a.Process.ExcludeArgv)
+	}
 	if s, ok := a.Source.(agent.FilesUnderCWD); ok {
 		scanner.WithTranscriptFilename(s.Filename)
 	}

--- a/core/domain/agent/declaration.go
+++ b/core/domain/agent/declaration.go
@@ -52,4 +52,14 @@ type Identity struct {
 type Process struct {
 	Match         ProcessMatcher
 	PIDForSession PIDDiscoverFunc
+
+	// ExcludeArgv, when non-nil, lets an adapter reject a matched process by
+	// inspecting its argv. The process scanner consults it after a PID
+	// matches Match: returning true means "this is the agent's binary but not
+	// a session" (e.g. a background daemon / wrapper that runs the same
+	// binary) and no pre-session is minted. The format-specific argv shapes
+	// live in the adapter package; the scanner stays generic. A nil argv
+	// (unreadable, e.g. hardened-runtime) is passed through, so an adapter's
+	// predicate must default to *not* excluding when it can't tell.
+	ExcludeArgv func(argv []string) bool
 }

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -227,6 +227,11 @@ type ProcessObserver interface {
 	// FindByCmdline returns the PIDs whose full command line matches the
 	// given pattern. Returns nil, nil when none match.
 	FindByCmdline(pattern string) ([]int, error)
+	// ArgvOf returns the argument vector of pid (argv[0] is the executable
+	// as invoked). Returns nil, nil when the argv is unreadable (e.g. a
+	// hardened-runtime process that strips it) — an empty argv is not an
+	// error, the same way EnvOf treats an unreadable env.
+	ArgvOf(pid int) ([]string, error)
 	// CWDOf returns the working directory of pid.
 	CWDOf(pid int) (string, error)
 	// WriterOf returns the PID that currently has path open for writing, or


### PR DESCRIPTION
## Root cause

Claude Code 2.1.168 introduced a background-daemon architecture (**cc-daemon**): a long-lived `claude daemon run`, PTY-host wrappers (`--bg-pty-host`), and pre-warmed spares (`--bg-spare`). All of these run the `claude` binary, so the claudecode `ExactName{"claude"}` process matcher accepts them and `processlifecycle/scanner.go` mints `proc-<pid>` pre-sessions for them. These infrastructure processes never own a transcript, so the pre-sessions can never be superseded — they're **permanent ghosts** in the dashboard until the process exits.

Observed ghost shapes:
- `claude daemon run --origin transient --spawned-by {...}` (the cc-daemon, cwd `$HOME`)
- `.../ClaudeCode.app/Contents/MacOS/claude --bg-pty-host /tmp/cc-daemon-501/<id>/pty/<x>.sock 86 34 -- .../versions/2.1.168 --resume <sid> ...` (PTY-host wrapper)
- `.../versions/<ver> --bg-pty-host ...` / `--bg-spare ...` (pre-warmed spares)

## Fix

Add a per-adapter **argv exclusion seam**, keeping format-specific logic in the adapter and the scanner generic:

- `ports.ProcessObserver` gains `ArgvOf(pid) ([]string, error)` — implemented per platform (darwin: `KERN_PROCARGS2` argv parse; linux: `/proc/<pid>/cmdline`; other: stub). A nil argv (hardened-runtime processes strip it) is not an error.
- `agent.Process` gains an optional `ExcludeArgv func(argv []string) bool` predicate.
- The scanner consults it (`WithArgvFilter`) at the top of its per-PID loop and skips matched-but-excluded PIDs entirely — no pre-session minted, never tracked (so it can't later be reported as "exited").
- The claudecode package declares the predicate `IsInfraArgv` and wires `ExcludeArgv: IsInfraArgv` in `Agent()`.

PID-discovery for the *real* hosted session (resumed under `versions/<ver>`) is unaffected — this PR only removes the wrapper/daemon matcher noise.

## Exclusion rule

Positional / flag-position based, **never a blanket substring scan**, so a user prompt that merely mentions these tokens is not excluded:

- `argv[1] == "daemon" && argv[2] == "run"` (the cc-daemon itself), **OR**
- any element of `argv[1:]` exactly equal to `--bg-pty-host` or `--bg-spare` (a flag occupies its own argv slot; a prompt string is a single slot that won't equal the flag exactly).

A nil/empty/unreadable argv is treated as a **session** — we never exclude on absence of evidence. So `claude -p "explain --bg-pty-host"`, plain `claude`, `claude --resume <sid> ...`, and `claude --model ... --dangerously-skip-permissions` all stay matched.

## Tests

- `claudecode/process_test.go` — table-driven `IsInfraArgv`: the 3 infra shapes (excluded) + plain/resume/model-flag sessions, prompt-string false-positive guards, and degenerate argv (matched).
- `processlifecycle/scanner_argvfilter_test.go` — fake `ProcessObserver`; verifies exactly one `new_session` for the real PID and that the 3 infra PIDs are neither emitted nor tracked.
- `processlifecycle/osutil_test.go` — `TestParseProcargs2Argv` for the darwin-shape argv parser (cross-platform).

Suite results (all green):
- `go test ./core/... -race -count=1`
- `tools/replay-fixtures.sh`
- `go run ./tools/onboarding-factory/cmd/of validate`
- `GOOS=linux` and `GOOS=windows` cross-compiles (build-tag coverage)

Fixes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)