### PR TITLE
fix(tailer): persist LastEventType in the ledger so restarts can't strand working sessions

### DIFF
--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -256,6 +256,30 @@ func (a *Adapter) IngestTaskEstimate(transcriptPath string, est *session.TaskEst
 	lt.mu.Unlock()
 }
 
+// PurgeDeadBackgroundProcs implements ports/outbound.MetricsCollector. The
+// session detector calls it when its lsof liveness probe finds no live writer
+// on any of the session's background-process output files: the processes died
+// without a transcript-observable termination, so the tailer's open set (and
+// the ledger persisting it) would otherwise resurrect them as phantom open
+// processes on every restart. The ledger is saved immediately so the purge
+// survives a restart that happens before the next TailAndProcess pass.
+// No-op when no tailer exists for the path. See issue #649.
+func (a *Adapter) PurgeDeadBackgroundProcs(transcriptPath string) {
+	if transcriptPath == "" {
+		return
+	}
+	a.mu.Lock()
+	lt, ok := a.tailers[transcriptPath]
+	a.mu.Unlock()
+	if !ok {
+		return
+	}
+	lt.mu.Lock()
+	lt.t.PurgeBackgroundProcs()
+	saveLedger(lt.lp, lt.t.GetLedgerState())
+	lt.mu.Unlock()
+}
+
 // domainRateLimitToTailer is the inbound counterpart to tailerRateLimitToDomain
 // — used by IngestRateLimit when the HTTP layer hands us a domain-typed
 // snapshot that has to land inside the tailer's mirror type.

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -258,14 +258,16 @@ func (a *Adapter) IngestTaskEstimate(transcriptPath string, est *session.TaskEst
 
 // PurgeDeadBackgroundProcs implements ports/outbound.MetricsCollector. The
 // session detector calls it when its lsof liveness probe finds no live writer
-// on any of the session's background-process output files: the processes died
-// without a transcript-observable termination, so the tailer's open set (and
-// the ledger persisting it) would otherwise resurrect them as phantom open
-// processes on every restart. The ledger is saved immediately so the purge
-// survives a restart that happens before the next TailAndProcess pass.
-// No-op when no tailer exists for the path. See issue #649.
-func (a *Adapter) PurgeDeadBackgroundProcs(transcriptPath string) {
-	if transcriptPath == "" {
+// on any of the probed output files: those processes died without a
+// transcript-observable termination, so the tailer's open set (and the ledger
+// persisting it) would otherwise resurrect them as phantom open processes on
+// every restart. Only entries matching the probed outputs are dropped — a
+// process spawned after the probe's snapshot must survive. The ledger is
+// saved immediately so the purge survives a restart that happens before the
+// next TailAndProcess pass. No-op when no tailer exists for the path.
+// See issue #649.
+func (a *Adapter) PurgeDeadBackgroundProcs(transcriptPath string, outputs []string) {
+	if transcriptPath == "" || len(outputs) == 0 {
 		return
 	}
 	a.mu.Lock()
@@ -275,7 +277,7 @@ func (a *Adapter) PurgeDeadBackgroundProcs(transcriptPath string) {
 		return
 	}
 	lt.mu.Lock()
-	lt.t.PurgeBackgroundProcs()
+	lt.t.PurgeBackgroundProcs(outputs)
 	saveLedger(lt.lp, lt.t.GetLedgerState())
 	lt.mu.Unlock()
 }

--- a/core/adapters/outbound/metrics/ledger.go
+++ b/core/adapters/outbound/metrics/ledger.go
@@ -11,11 +11,10 @@ import (
 	"irrlicht/core/pkg/tailer"
 )
 
-// Bumped to 3 for #615 (authoritative task IDs from TaskCreate results +
-// persisted TaskSeq): invalidating pre-fix ledgers forces a full re-scan that
-// rebuilds desynced task lists with correct IDs. Must match the version
-// stamped by tailer.GetLedgerState.
-const ledgerSchemaVersion = 3
+// ledgerSchemaVersion aliases the canonical version stamped by
+// tailer.GetLedgerState so load-side validation can never drift from the
+// write side. See tailer.LedgerSchemaVersion for the bump history.
+const ledgerSchemaVersion = tailer.LedgerSchemaVersion
 
 // LedgerSuffix is the filename suffix used for per-session ledger files.
 // Exposed so the daemon-startup orphan sweep can filter directory entries

--- a/core/adapters/outbound/metrics/ledger_test.go
+++ b/core/adapters/outbound/metrics/ledger_test.go
@@ -72,7 +72,7 @@ func TestPurgeDeadBackgroundProcs_ClearsTailerAndLedger(t *testing.T) {
 	lp := ledgerPath(transcript)
 	a.tailers[transcript] = &lockedTailer{t: tl, lp: lp}
 
-	a.PurgeDeadBackgroundProcs(transcript)
+	a.PurgeDeadBackgroundProcs(transcript, []string{"/tmp/x/tasks/bbw7rzpa0.output"})
 
 	if got := tl.GetLedgerState().BackgroundProcs; len(got) != 0 {
 		t.Errorf("tailer BackgroundProcs after purge = %v, want empty", got)
@@ -88,6 +88,8 @@ func TestPurgeDeadBackgroundProcs_ClearsTailerAndLedger(t *testing.T) {
 
 func TestPurgeDeadBackgroundProcs_NoTailerNoop(t *testing.T) {
 	a := New(Registry{})
-	a.PurgeDeadBackgroundProcs("/never/seen.jsonl") // must not panic
-	a.PurgeDeadBackgroundProcs("")                  // must not panic
+	outputs := []string{"/tmp/x/tasks/x.output"}
+	a.PurgeDeadBackgroundProcs("/never/seen.jsonl", outputs) // must not panic
+	a.PurgeDeadBackgroundProcs("", outputs)                  // must not panic
+	a.PurgeDeadBackgroundProcs("/never/seen.jsonl", nil)     // must not panic
 }

--- a/core/adapters/outbound/metrics/ledger_test.go
+++ b/core/adapters/outbound/metrics/ledger_test.go
@@ -1,0 +1,93 @@
+package metrics
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/pkg/tailer"
+)
+
+// TestLoadLedger_RejectsOldSchema pins the #649 migration: a ledger written
+// by an older daemon (schema 3, no last_event_type) must be discarded on
+// load, forcing a full transcript re-scan under the current parser. The
+// re-scan is what heals sessions stranded in `working` by pre-#642 parsers.
+func TestLoadLedger_RejectsOldSchema(t *testing.T) {
+	dir := t.TempDir()
+	lp := filepath.Join(dir, "old.ledger.json")
+	v3 := []byte(`{"schema_version":3,"last_offset":3115960,"background_procs":{"bbw7rzpa0":"/tmp/x/tasks/bbw7rzpa0.output"}}`)
+	if err := os.WriteFile(lp, v3, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if s := loadLedger(lp); s != nil {
+		t.Errorf("loadLedger accepted a schema-3 ledger: %+v (must discard → full re-scan)", s)
+	}
+}
+
+func TestLoadLedger_AcceptsCurrentSchema(t *testing.T) {
+	dir := t.TempDir()
+	lp := filepath.Join(dir, "current.ledger.json")
+	data, err := json.Marshal(tailer.LedgerState{
+		SchemaVersion: tailer.LedgerSchemaVersion,
+		LastOffset:    42,
+		LastEventType: "turn_done",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lp, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := loadLedger(lp)
+	if s == nil {
+		t.Fatal("loadLedger rejected a current-schema ledger")
+	}
+	if s.LastEventType != "turn_done" {
+		t.Errorf("LastEventType = %q, want turn_done", s.LastEventType)
+	}
+}
+
+// TestPurgeDeadBackgroundProcs_ClearsTailerAndLedger covers the adapter half
+// of the #649 dead-verdict cleanup: the tailer's open set is dropped and the
+// ledger is rewritten immediately, so the phantom processes cannot resurrect
+// on a restart that happens before the next TailAndProcess pass.
+func TestPurgeDeadBackgroundProcs_ClearsTailerAndLedger(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	dir := filepath.Join(tmpHome, ".local", "share", "irrlicht", "sessions")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	transcript := filepath.Join(tmpHome, "transcript.jsonl")
+
+	tl := tailer.NewTranscriptTailer(transcript, nil, "claude-code")
+	tl.SetLedgerState(tailer.LedgerState{
+		SchemaVersion:   tailer.LedgerSchemaVersion,
+		BackgroundProcs: map[string]string{"bbw7rzpa0": "/tmp/x/tasks/bbw7rzpa0.output"},
+	})
+
+	a := New(Registry{})
+	lp := ledgerPath(transcript)
+	a.tailers[transcript] = &lockedTailer{t: tl, lp: lp}
+
+	a.PurgeDeadBackgroundProcs(transcript)
+
+	if got := tl.GetLedgerState().BackgroundProcs; len(got) != 0 {
+		t.Errorf("tailer BackgroundProcs after purge = %v, want empty", got)
+	}
+	saved := loadLedger(lp)
+	if saved == nil {
+		t.Fatal("expected the purge to write the ledger immediately")
+	}
+	if len(saved.BackgroundProcs) != 0 {
+		t.Errorf("persisted BackgroundProcs after purge = %v, want empty", saved.BackgroundProcs)
+	}
+}
+
+func TestPurgeDeadBackgroundProcs_NoTailerNoop(t *testing.T) {
+	a := New(Registry{})
+	a.PurgeDeadBackgroundProcs("/never/seen.jsonl") // must not panic
+	a.PurgeDeadBackgroundProcs("")                  // must not panic
+}

--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -128,3 +128,61 @@ func TestSessionDetector_BackgroundProcess_HoldsWorkingThenReady(t *testing.T) {
 	cancel()
 	<-done
 }
+
+// A dead probe verdict must also purge the processes from the tailer's open
+// set and ledger — they died without a transcript-observable termination, and
+// the persisted entries would otherwise resurrect as phantom open processes
+// on every daemon restart. See issue #649.
+func TestSessionDetector_BackgroundProcess_DeadVerdictPurgesLedger(t *testing.T) {
+	const sid = "bg2"
+	const path = "/home/.claude/projects/-Users-test/bg2.jsonl"
+
+	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		return &session.SessionMetrics{
+			LastEventType:            "turn_done",
+			BackgroundProcessCount:   1,
+			BackgroundProcessOutputs: []string{"/tmp/x/tasks/bbw7rzpa0.output"},
+		}, nil
+	}}
+
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	repo.states[sid] = &session.SessionState{
+		SessionID:      sid,
+		State:          session.StateWorking,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	det.SetBackgroundProbeForTest(func(paths []string) bool { return false })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      sid,
+		ProjectDir:     "-Users-test",
+		TranscriptPath: path,
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if purged := metrics.purgedSnapshot(); len(purged) > 0 {
+			if purged[0] != path {
+				t.Errorf("purged transcript = %q, want %q", purged[0], path)
+			}
+			cancel()
+			<-done
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	<-done
+	t.Fatal("dead probe verdict did not trigger PurgeDeadBackgroundProcs within deadline")
+}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -92,6 +92,7 @@ type SessionDetector struct {
 	pidMgr         *PIDManager
 	costTracker    outbound.CostTracker    // optional; nil = disabled
 	historyTracker outbound.HistoryTracker // optional; nil = disabled
+	metrics        outbound.MetricsCollector
 
 	// projectSessions tracks sessionID → projectDir for pre-session cleanup.
 	mu              sync.Mutex
@@ -198,6 +199,7 @@ func NewSessionDetector(
 		broadcaster:       broadcaster,
 		version:           version,
 		enricher:          newMetadataEnricher(git, metrics),
+		metrics:           metrics,
 		projectSessions:   make(map[string]string),
 		deletedSessions:   make(map[string]int64),
 		debounce:          make(map[string]*debounceEntry),

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -639,6 +639,14 @@ func (d *SessionDetector) applyBackgroundLiveness(state *session.SessionState) {
 	transcriptPath := state.TranscriptPath
 	go func() {
 		live := d.bgLiveProbe(outputs)
+		// Dead verdict: drop the processes from the tailer's open set and
+		// the ledger. They died without a transcript-observable termination
+		// (e.g. the process exited with its parent shell), so the ledger
+		// entry would otherwise resurrect them as phantom open processes on
+		// every daemon restart, re-running this probe forever. See issue #649.
+		if !live && d.metrics != nil {
+			d.metrics.PurgeDeadBackgroundProcs(transcriptPath)
+		}
 		d.bgMu.Lock()
 		prev, had := d.bgLive[sid]
 		d.bgLive[sid] = live

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -639,13 +639,15 @@ func (d *SessionDetector) applyBackgroundLiveness(state *session.SessionState) {
 	transcriptPath := state.TranscriptPath
 	go func() {
 		live := d.bgLiveProbe(outputs)
-		// Dead verdict: drop the processes from the tailer's open set and
-		// the ledger. They died without a transcript-observable termination
-		// (e.g. the process exited with its parent shell), so the ledger
-		// entry would otherwise resurrect them as phantom open processes on
-		// every daemon restart, re-running this probe forever. See issue #649.
+		// Dead verdict: drop the probed processes from the tailer's open set
+		// and the ledger. They died without a transcript-observable
+		// termination (e.g. the process exited with its parent shell), so
+		// the ledger entry would otherwise resurrect them as phantom open
+		// processes on every daemon restart, re-running this probe forever.
+		// Scoped to this probe's output snapshot — a process spawned since
+		// must survive and be judged by its own probe. See issue #649.
 		if !live && d.metrics != nil {
-			d.metrics.PurgeDeadBackgroundProcs(transcriptPath)
+			d.metrics.PurgeDeadBackgroundProcs(transcriptPath, outputs)
 		}
 		d.bgMu.Lock()
 		prev, had := d.bgLive[sid]

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -257,7 +257,7 @@ func (m *mockMetrics) IngestRateLimit(path string, snap *session.RateLimitSnapsh
 
 func (m *mockMetrics) IngestTaskEstimate(path string, est *session.TaskEstimate) {}
 
-func (m *mockMetrics) PurgeDeadBackgroundProcs(path string) {
+func (m *mockMetrics) PurgeDeadBackgroundProcs(path string, _ []string) {
 	m.mu.Lock()
 	m.purged = append(m.purged, path)
 	m.mu.Unlock()
@@ -300,7 +300,7 @@ func (m *funcMetrics) IngestRateLimit(path string, snap *session.RateLimitSnapsh
 
 func (m *funcMetrics) IngestTaskEstimate(path string, est *session.TaskEstimate) {}
 
-func (m *funcMetrics) PurgeDeadBackgroundProcs(path string) {
+func (m *funcMetrics) PurgeDeadBackgroundProcs(path string, _ []string) {
 	m.purgeMu.Lock()
 	m.purged = append(m.purged, path)
 	m.purgeMu.Unlock()

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -226,6 +226,7 @@ func (g *cwdGit) GetCWDFromTranscript(path string) string { return g.cwd }
 type mockMetrics struct {
 	mu     sync.Mutex
 	pruned []string
+	purged []string
 }
 
 func (m *mockMetrics) ComputeMetrics(path, adapter string) (*session.SessionMetrics, error) {
@@ -256,11 +257,30 @@ func (m *mockMetrics) IngestRateLimit(path string, snap *session.RateLimitSnapsh
 
 func (m *mockMetrics) IngestTaskEstimate(path string, est *session.TaskEstimate) {}
 
+func (m *mockMetrics) PurgeDeadBackgroundProcs(path string) {
+	m.mu.Lock()
+	m.purged = append(m.purged, path)
+	m.mu.Unlock()
+}
+
+// purgedSnapshot returns a race-free copy of the PurgeDeadBackgroundProcs call
+// log so tests can poll for the purge without racing the probe goroutine.
+func (m *mockMetrics) purgedSnapshot() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.purged))
+	copy(out, m.purged)
+	return out
+}
+
 // funcMetrics is a metrics collector whose ComputeMetrics behaviour can be
 // configured per test. Used to simulate a tailer that returns refreshed
 // metrics for already-persisted sessions during seedFromDisk.
 type funcMetrics struct {
 	fn func(path, adapter string) (*session.SessionMetrics, error)
+
+	purgeMu sync.Mutex
+	purged  []string
 }
 
 func (m *funcMetrics) ComputeMetrics(path, adapter string) (*session.SessionMetrics, error) {
@@ -279,6 +299,22 @@ func (m *funcMetrics) PruneEntry(path string) {}
 func (m *funcMetrics) IngestRateLimit(path string, snap *session.RateLimitSnapshot) {}
 
 func (m *funcMetrics) IngestTaskEstimate(path string, est *session.TaskEstimate) {}
+
+func (m *funcMetrics) PurgeDeadBackgroundProcs(path string) {
+	m.purgeMu.Lock()
+	m.purged = append(m.purged, path)
+	m.purgeMu.Unlock()
+}
+
+// purgedSnapshot returns a race-free copy of the purge call log so tests can
+// poll for the dead-verdict cleanup without racing the probe goroutine.
+func (m *funcMetrics) purgedSnapshot() []string {
+	m.purgeMu.Lock()
+	defer m.purgeMu.Unlock()
+	out := make([]string, len(m.purged))
+	copy(out, m.purged)
+	return out
+}
 
 // --- AgentWatcher mock -------------------------------------------------------
 

--- a/core/e2e/e2e_helpers_test.go
+++ b/core/e2e/e2e_helpers_test.go
@@ -180,6 +180,8 @@ func (m *stubMetrics) IngestRateLimit(_ string, _ *session.RateLimitSnapshot) {}
 
 func (m *stubMetrics) IngestTaskEstimate(_ string, _ *session.TaskEstimate) {}
 
+func (m *stubMetrics) PurgeDeadBackgroundProcs(_ string) {}
+
 // testIdentity is the shared Identity value e2e tests stamp on every
 // watcher they hand to NewSessionDetector. NewSessionDetector's panic
 // guard requires a non-zero Identity; the actual Name doesn't matter to

--- a/core/e2e/e2e_helpers_test.go
+++ b/core/e2e/e2e_helpers_test.go
@@ -180,7 +180,7 @@ func (m *stubMetrics) IngestRateLimit(_ string, _ *session.RateLimitSnapshot) {}
 
 func (m *stubMetrics) IngestTaskEstimate(_ string, _ *session.TaskEstimate) {}
 
-func (m *stubMetrics) PurgeDeadBackgroundProcs(_ string) {}
+func (m *stubMetrics) PurgeDeadBackgroundProcs(_ string, _ []string) {}
 
 // testIdentity is the shared Identity value e2e tests stamp on every
 // watcher they hand to NewSessionDetector. NewSessionDetector's panic

--- a/core/pkg/tailer/ledger_event_type_test.go
+++ b/core/pkg/tailer/ledger_event_type_test.go
@@ -1,0 +1,81 @@
+package tailer
+
+import (
+	"testing"
+)
+
+// TestLedger_PersistsLastEventType is the issue #649 regression: a daemon
+// restart resumes the tailer from the persisted ledger at LastOffset. When
+// the transcript hasn't grown, the pass processes zero lines — so unless the
+// ledger carries LastEventType, the recomputed metrics can never satisfy
+// IsAgentDone and a session persisted as `working` is stranded there forever.
+func TestLedger_PersistsLastEventType(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "user", "timestamp": ts(0)},
+		{"type": "assistant", "timestamp": ts(1)},
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(2)},
+	})
+
+	tl1 := newTestTailer(path)
+	m, err := tl1.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.LastEventType != "turn_done" {
+		t.Fatalf("pre-restart LastEventType = %q, want turn_done", m.LastEventType)
+	}
+
+	ledger := tl1.GetLedgerState()
+	if ledger.LastEventType != "turn_done" {
+		t.Fatalf("ledger LastEventType = %q, want turn_done", ledger.LastEventType)
+	}
+	if ledger.SchemaVersion != LedgerSchemaVersion {
+		t.Fatalf("ledger SchemaVersion = %d, want %d", ledger.SchemaVersion, LedgerSchemaVersion)
+	}
+
+	// Restart: a fresh tailer rehydrated from the ledger resumes at EOF —
+	// zero lines processed — and must still report the pre-restart event type.
+	tl2 := newTestTailer(path)
+	tl2.SetLedgerState(ledger)
+	m, err = tl2.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.LastEventType != "turn_done" {
+		t.Errorf("post-restart LastEventType = %q, want turn_done (resume-at-EOF must not forget the classification anchor)", m.LastEventType)
+	}
+}
+
+// TestTailer_PurgeBackgroundProcs verifies the dead-verdict cleanup path
+// (issue #649): purging drops the open set and the next ledger snapshot no
+// longer persists the entries, so they cannot resurrect on a later restart.
+func TestTailer_PurgeBackgroundProcs(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "user", "timestamp": ts(0)},
+	})
+
+	tl := newTestTailer(path)
+	tl.SetLedgerState(LedgerState{
+		SchemaVersion:   LedgerSchemaVersion,
+		BackgroundProcs: map[string]string{"bbw7rzpa0": "/tmp/x/tasks/bbw7rzpa0.output"},
+	})
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatal(err)
+	}
+	if got := tl.GetLedgerState().BackgroundProcs; len(got) != 1 {
+		t.Fatalf("precondition: BackgroundProcs = %v, want the rehydrated entry", got)
+	}
+
+	tl.PurgeBackgroundProcs()
+
+	if got := tl.GetLedgerState().BackgroundProcs; len(got) != 0 {
+		t.Errorf("BackgroundProcs after purge = %v, want empty", got)
+	}
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.BackgroundProcessCount != 0 {
+		t.Errorf("BackgroundProcessCount after purge = %d, want 0", m.BackgroundProcessCount)
+	}
+}

--- a/core/pkg/tailer/ledger_event_type_test.go
+++ b/core/pkg/tailer/ledger_event_type_test.go
@@ -47,8 +47,10 @@ func TestLedger_PersistsLastEventType(t *testing.T) {
 }
 
 // TestTailer_PurgeBackgroundProcs verifies the dead-verdict cleanup path
-// (issue #649): purging drops the open set and the next ledger snapshot no
-// longer persists the entries, so they cannot resurrect on a later restart.
+// (issue #649): purging drops the probed entries from the open set and the
+// next ledger snapshot no longer persists them, so they cannot resurrect on
+// a later restart — while an entry the probe never saw (a process spawned
+// after the probe's snapshot) survives untouched.
 func TestTailer_PurgeBackgroundProcs(t *testing.T) {
 	path := writeTranscriptLines(t, []map[string]interface{}{
 		{"type": "user", "timestamp": ts(0)},
@@ -56,26 +58,33 @@ func TestTailer_PurgeBackgroundProcs(t *testing.T) {
 
 	tl := newTestTailer(path)
 	tl.SetLedgerState(LedgerState{
-		SchemaVersion:   LedgerSchemaVersion,
-		BackgroundProcs: map[string]string{"bbw7rzpa0": "/tmp/x/tasks/bbw7rzpa0.output"},
+		SchemaVersion: LedgerSchemaVersion,
+		BackgroundProcs: map[string]string{
+			"bbw7rzpa0": "/tmp/x/tasks/bbw7rzpa0.output", // probed, dead
+			"bnewspawn": "/tmp/x/tasks/bnewspawn.output", // spawned after the snapshot
+		},
 	})
 	if _, err := tl.TailAndProcess(); err != nil {
 		t.Fatal(err)
 	}
-	if got := tl.GetLedgerState().BackgroundProcs; len(got) != 1 {
-		t.Fatalf("precondition: BackgroundProcs = %v, want the rehydrated entry", got)
+	if got := tl.GetLedgerState().BackgroundProcs; len(got) != 2 {
+		t.Fatalf("precondition: BackgroundProcs = %v, want both rehydrated entries", got)
 	}
 
-	tl.PurgeBackgroundProcs()
+	tl.PurgeBackgroundProcs([]string{"/tmp/x/tasks/bbw7rzpa0.output"})
 
-	if got := tl.GetLedgerState().BackgroundProcs; len(got) != 0 {
-		t.Errorf("BackgroundProcs after purge = %v, want empty", got)
+	got := tl.GetLedgerState().BackgroundProcs
+	if _, dead := got["bbw7rzpa0"]; dead {
+		t.Errorf("probed-dead entry survived the purge: %v", got)
+	}
+	if _, alive := got["bnewspawn"]; !alive {
+		t.Errorf("unprobed entry was purged: %v (a process spawned after the probe snapshot must survive)", got)
 	}
 	m, err := tl.TailAndProcess()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if m.BackgroundProcessCount != 0 {
-		t.Errorf("BackgroundProcessCount after purge = %d, want 0", m.BackgroundProcessCount)
+	if m.BackgroundProcessCount != 1 {
+		t.Errorf("BackgroundProcessCount after scoped purge = %d, want 1", m.BackgroundProcessCount)
 	}
 }

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -355,6 +355,16 @@ type TranscriptPathAware interface {
 	SetTranscriptPath(path string)
 }
 
+// LedgerSchemaVersion is the current ledger schema. A persisted ledger with a
+// different version is discarded on load, forcing a full transcript re-scan
+// under the current parser. Bump it whenever a LedgerState change (or a parser
+// fix) makes previously persisted state misleading.
+//
+// History: 3 — #615 (authoritative task IDs + TaskSeq);
+// 4 — #649 (LastEventType persisted; the bump also heals sessions stranded
+// in `working` by pre-#642 parsers, since the re-scan reclassifies them).
+const LedgerSchemaVersion = 4
+
 // LedgerState is the durable portion of a tailer's accumulation state, written
 // to disk after every TailAndProcess pass so that daemon restarts don't reset
 // cumulative cost to zero for in-flight sessions.
@@ -397,6 +407,13 @@ type LedgerState struct {
 	// model — codex token_count) still routes to the right pricing bucket
 	// after a daemon restart, before the next model-bearing event arrives.
 	ModelName string `json:"model_name,omitempty"`
+	// LastEventType persists the most recent substantive event type so a
+	// daemon restart that resumes at LastOffset (zero new lines) can still
+	// answer IsAgentDone. Without it, a session persisted as `working` whose
+	// transcript never grows again is stranded: the recomputed metrics carry
+	// an empty LastEventType, IsAgentDone can never fire, and no future
+	// activity arrives to re-classify. See issue #649.
+	LastEventType string `json:"last_event_type,omitempty"`
 }
 
 // --- Shared helpers used by multiple parsers ---

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -366,10 +366,11 @@ func (t *TranscriptTailer) DisableModelConfigFallback() {
 // can be persisted to disk and rehydrated after a daemon restart.
 func (t *TranscriptTailer) GetLedgerState() LedgerState {
 	s := LedgerState{
-		SchemaVersion:      3,
+		SchemaVersion:      LedgerSchemaVersion,
 		LastOffset:         t.lastOffset,
 		CumProviderCostUSD: t.cumProviderCostUSD,
 		ModelName:          t.metrics.ModelName,
+		LastEventType:      t.metrics.LastEventType,
 	}
 	if len(t.cumByModel) > 0 {
 		// Direct assignment is safe: the caller JSON-marshals immediately
@@ -429,6 +430,12 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 	t.cumProviderCostUSD = s.CumProviderCostUSD
 	if s.ModelName != "" {
 		t.metrics.ModelName = s.ModelName
+	}
+	// Restore the classification anchor: a resume-at-EOF pass processes no
+	// events, and IsAgentDone needs the pre-restart event type to recognise
+	// a finished turn (issue #649).
+	if s.LastEventType != "" {
+		t.metrics.LastEventType = s.LastEventType
 	}
 	if s.ParserState != nil {
 		if pp, ok := t.parser.(ParserStateProvider); ok {
@@ -1053,4 +1060,15 @@ func (t *TranscriptTailer) applyTaskEstimate(est *TaskEstimate) {
 // holds the per-tailer lock, mirroring IngestRateLimit.
 func (t *TranscriptTailer) IngestTaskEstimate(est *TaskEstimate) {
 	t.applyTaskEstimate(est)
+}
+
+// PurgeBackgroundProcs drops every tracked background process. Called when
+// the detector's liveness probe verdicts them dead (no live writer on any
+// output file): the transcript never recorded a termination — the process
+// died with its parent shell — so without this the entries persist in the
+// ledger and resurrect as phantom open processes on every daemon restart.
+// Caller (the metrics adapter) holds the per-tailer lock, mirroring
+// IngestRateLimit. See issue #649.
+func (t *TranscriptTailer) PurgeBackgroundProcs() {
+	t.openBackgroundProcs = make(map[string]string)
 }

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -1062,13 +1062,26 @@ func (t *TranscriptTailer) IngestTaskEstimate(est *TaskEstimate) {
 	t.applyTaskEstimate(est)
 }
 
-// PurgeBackgroundProcs drops every tracked background process. Called when
-// the detector's liveness probe verdicts them dead (no live writer on any
-// output file): the transcript never recorded a termination — the process
-// died with its parent shell — so without this the entries persist in the
-// ledger and resurrect as phantom open processes on every daemon restart.
-// Caller (the metrics adapter) holds the per-tailer lock, mirroring
-// IngestRateLimit. See issue #649.
-func (t *TranscriptTailer) PurgeBackgroundProcs() {
-	t.openBackgroundProcs = make(map[string]string)
+// PurgeBackgroundProcs drops the tracked background processes whose output
+// path is in outputs. Called when the detector's liveness probe verdicts them
+// dead (no live writer on any probed output file): the transcript never
+// recorded a termination — the process died with its parent shell — so
+// without this the entries persist in the ledger and resurrect as phantom
+// open processes on every daemon restart. Scoped to the probed outputs, not
+// purge-all: the probe runs async, and a process spawned after the snapshot
+// was taken must survive (its own probe will judge it). Caller (the metrics
+// adapter) holds the per-tailer lock, mirroring IngestRateLimit. See #649.
+func (t *TranscriptTailer) PurgeBackgroundProcs(outputs []string) {
+	if len(outputs) == 0 {
+		return
+	}
+	dead := make(map[string]bool, len(outputs))
+	for _, o := range outputs {
+		dead[o] = true
+	}
+	for id, path := range t.openBackgroundProcs {
+		if dead[path] {
+			delete(t.openBackgroundProcs, id)
+		}
+	}
 }

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -138,6 +138,12 @@ type MetricsCollector interface {
 	// on claude ≥2.1.162. Same no-op-without-tailer semantics as
 	// IngestRateLimit.
 	IngestTaskEstimate(transcriptPath string, est *session.TaskEstimate)
+	// PurgeDeadBackgroundProcs drops the session's tracked background
+	// processes after the detector's liveness probe verdicts them dead —
+	// they died without a transcript-observable termination, and the ledger
+	// would otherwise resurrect them on every restart (#649). Same
+	// no-op-without-tailer semantics as IngestRateLimit.
+	PurgeDeadBackgroundProcs(transcriptPath string)
 }
 
 // PushBroadcaster fans out session state changes to subscribers (e.g. WebSocket clients).

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -139,11 +139,13 @@ type MetricsCollector interface {
 	// IngestRateLimit.
 	IngestTaskEstimate(transcriptPath string, est *session.TaskEstimate)
 	// PurgeDeadBackgroundProcs drops the session's tracked background
-	// processes after the detector's liveness probe verdicts them dead —
-	// they died without a transcript-observable termination, and the ledger
-	// would otherwise resurrect them on every restart (#649). Same
+	// processes whose output path is in outputs, after the detector's
+	// liveness probe verdicts them dead — they died without a
+	// transcript-observable termination, and the ledger would otherwise
+	// resurrect them on every restart (#649). Scoped to the probed outputs
+	// so a process spawned after the probe's snapshot survives. Same
 	// no-op-without-tailer semantics as IngestRateLimit.
-	PurgeDeadBackgroundProcs(transcriptPath string)
+	PurgeDeadBackgroundProcs(transcriptPath string, outputs []string)
 }
 
 // PushBroadcaster fans out session state changes to subscribers (e.g. WebSocket clients).


### PR DESCRIPTION
Fixes #649.

## Problem

A daemon restart resumes each tailer from its persisted ledger at `LastOffset`. When the transcript never grows again, the pass processes zero lines and the recomputed metrics carried an **empty `LastEventType`** — `IsAgentDone()` could never fire, so a session persisted as `working` stayed there across every restart, forever. The #642 parser fix prevents *new* strandings but couldn't heal sessions already persisted as working (live repro: `bb9f6ebf`, stranded since the 11:46 compaction despite running a fixed daemon).

A second leak compounds it: `background_procs` entries for processes that died **without a transcript-observable termination** (e.g. killed with their parent shell) resurrect from the ledger on every restart as phantom open processes — the lsof probe re-kills the in-memory flag each time, but the ledger garbage is permanent.

## Fix

1. **Persist `LastEventType`** in `LedgerState`, restore it in `SetLedgerState`. Schema bumped to 4 via a canonical exported `tailer.LedgerSchemaVersion`; the metrics adapter's load-side check aliases it so write/read can never drift (they were two hand-synced literals before).
2. **Migration for free**: `loadLedger` already discards version-mismatched ledgers → first post-upgrade restart does a one-time full re-scan under the current (#642-fixed) parser, which heals already-stranded sessions: re-scan lands on `turn_done` → seed re-classifies → ready.
3. **Purge dead background procs, scoped to the probe's snapshot**: new `MetricsCollector.PurgeDeadBackgroundProcs(transcriptPath, outputs)`, called from the detector's probe goroutine on a dead verdict (mirrors the `IngestRateLimit` pattern). Drops only the entries whose output path was actually probed — a process spawned after the snapshot survives and is judged by its own probe (closes the TOCTOU window flagged in review) — and rewrites the ledger immediately, so the entries can't resurrect even if the daemon restarts before the next pass.

## Tests (red-checked)

- `TestLedger_PersistsLastEventType` — restart simulation: resume-at-EOF must keep the classification anchor. **Fails without the restore** (`LastEventType = ""`), passes with it.
- `TestTailer_PurgeBackgroundProcs` — scoped purge: the probed-dead entry is dropped, an entry the probe never saw survives.
- `TestPurgeDeadBackgroundProcs_ClearsTailerAndLedger` (+ no-tailer/empty no-ops) — purge clears the open set and the persisted ledger immediately.
- `TestLoadLedger_RejectsOldSchema` / `TestLoadLedger_AcceptsCurrentSchema` — pins the migration gate with a literal v3 payload.
- `TestSessionDetector_BackgroundProcess_DeadVerdictPurgesLedger` — end-to-end through the detector: dead probe verdict → purge called with the right transcript path.

## Verification

- `go test ./core/... -race -count=1` ✓
- `go test ./tools/onboarding-factory/... -race -count=1` ✓
- `tools/replay-fixtures.sh` ✓
- **Live acceptance**: daemon built from this branch on port 7837 healed the stranded session on startup — `working` → `ready` (`"agent finished turn → ready"`), ledger rewritten at schema 4 with `last_event_type: "turn_done"` and no `background_procs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)