### PR TITLE
fix(release): codesign the DMG before notarization

### DIFF
--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -319,6 +319,20 @@ hdiutil create -volname "Irrlicht $VERSION" \
 rm -rf "$DMG_STAGING"
 echo "  Created $BUILD_DIR/$DMG_NAME"
 
+# ── 4a. Sign the DMG file itself ──────────────────────────────────────
+# The app inside is already Developer ID-signed, but an unsigned DMG fails
+# `spctl -a -t open --context context:primary-signature` (v0.4.5–v0.5.0
+# shipped unsigned DMGs; harmless for Gatekeeper, but the release-skill
+# verification flags it). Must happen BEFORE notarization so the ticket
+# covers the signed bytes — signing after stapling would invalidate it.
+if [ -n "${DEVELOPER_ID:-}" ]; then
+    echo "  Signing DMG with Developer ID..."
+    codesign --force --sign "Developer ID Application: ${DEVELOPER_ID}" \
+        --timestamp "$BUILD_DIR/$DMG_NAME"
+    codesign --verify "$BUILD_DIR/$DMG_NAME"
+    echo "  Signed $DMG_NAME"
+fi
+
 # ── 4b. Notarize and staple DMG ────────────────────────────────────────
 if [ -n "${NOTARYTOOL_KEYCHAIN_PROFILE:-}" ]; then
     echo ""


### PR DESCRIPTION
The DMG file itself was never codesigned (only the app bundle inside), so `spctl -a -t open --context context:primary-signature` rejected every shipped DMG with *no usable signature* — flagged during the v0.5.1 release verification. This signs the DMG with the Developer ID immediately after creation and **before** notarytool submission, so the notarization ticket covers the signed bytes (signing after stapling would invalidate the ticket).

Verified: `bash -n` clean; the codesign+verify step tested against a scratch copy of the v0.5.1 DMG (TeamIdentifier 93Y3GMJAMV). The full sign→notarize→staple→spctl chain gets exercised on the next release.

Gated on `DEVELOPER_ID` like the rest of the signing pipeline — ad-hoc/dev builds skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)