### PR TITLE
fix(install): verify download before removing existing install

### DIFF
--- a/site/install.sh
+++ b/site/install.sh
@@ -194,13 +194,15 @@ if [ -z "$VERSION" ]; then
     printf 'v%s\n' "$VERSION"
 fi
 
-# ─── Remove any existing install ───────────────────────────────────────────
-
-step "Removing any existing install"
-uninstall_previous
-ok
-
 # ─── Work dir ──────────────────────────────────────────────────────────────
+#
+# Note: the existing install is NOT removed here. We download and verify the
+# new artifact into TMPDIR first, and only remove the old install immediately
+# before extracting the verified bytes (full-install path below). This keeps
+# the working install intact when a download fails — a transient GitHub CDN
+# 504 used to leave the user with nothing because removal happened up front.
+# The --daemon-only path never removes /Applications/Irrlicht.app at all (it
+# installs irrlichd under ~/.local and overwrites in place).
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT INT TERM
@@ -302,6 +304,12 @@ ok
 
 step "Verifying checksum"
 sha256_verify "$TMPDIR" "$ASSET" || fail "Checksum mismatch — aborting"
+ok
+
+# Only now that we hold verified bytes do we remove the previous install —
+# a failed download above can never leave the user without a working app.
+step "Removing any existing install"
+uninstall_previous
 ok
 
 step "Installing to /Applications"


### PR DESCRIPTION
## What happened

A user hit a transient GitHub CDN `504` mid-install:

```
Removing any existing install… ✓
Downloading Irrlicht-0.5.1.zip… curl: (56) The requested URL returned error: 504
✗ Download failed
```

The `.zip` asset was fine (504 was a gateway timeout; immediate retry returned 200), but because the installer **removed `/Applications/Irrlicht.app` before downloading**, the failed download left the machine with no install.

## Fix

- Move `uninstall_previous` to run **after** the download + checksum verification succeed, right before extraction — a failed download now aborts with the existing install intact.
- Side fix: the early removal was unconditional, so `--daemon-only` (which installs `irrlichd` under `~/.local`) was needlessly deleting the user's GUI app. It no longer touches `/Applications` at all.

## Verification

`sh -n` clean. Ordering confirmed: verify checksum → remove old → install. The `--uninstall` flag path is unchanged. Transient 504s are now safely fixed by re-running the installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)