### PR TITLE
fix(claudecode): manual /compact working-during, ready-after lifecycle (#656, #657)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ beyond), see the [Roadmap](https://irrlicht.io/docs/roadmap.html).
   - **Existing installs** pick up the "working during compaction" half on the
     next daemon restart — `EnsureHooksInstalled` adds the new `PreCompact` entry
     to `~/.claude/settings.json` automatically.
+  - An interrupted compaction that never finishes is bounded by a timeout, so a
+    cancelled `/compact` can't strand the session in "working" either.
 
 ## [0.5.1] — 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ beyond), see the [Roadmap](https://irrlicht.io/docs/roadmap.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- A manual `/compact` now shows the full lifecycle: the session goes **working**
+  for the whole compaction window and returns to **ready** when it finishes.
+  Previously the compaction window (which writes nothing to the transcript)
+  stayed frozen at the pre-compact state, and a `/compact` invoked mid tool-use
+  was stranded in "working" forever. The fix adds a Claude Code `PreCompact`
+  hook (forces working during) and treats the manual `compact_boundary` as a
+  turn boundary (releases to ready after). (#656, #657; follow-up to #641)
+  - **Existing installs** pick up the "working during compaction" half on the
+    next daemon restart — `EnsureHooksInstalled` adds the new `PreCompact` entry
+    to `~/.claude/settings.json` automatically.
+
 ## [0.5.1] — 2026-06-07
 
 ### Ghost sessions and stuck states fixed: /compact strandings, Claude Code 2.1.168's background daemon, and restart amnesia.

--- a/core/adapters/inbound/agents/claudecode/compaction_test.go
+++ b/core/adapters/inbound/agents/claudecode/compaction_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"irrlicht/core/application/replayengine"
 	"irrlicht/core/pkg/tailer"
 )
 
@@ -27,18 +28,42 @@ func appendTranscriptLine(t *testing.T, path string, line map[string]interface{}
 	}
 }
 
-// TestTailer_ManualCompactTail_NoSubstantiveActivity is the issue #641
-// regression at the parser+tailer integration level. A manual /compact
-// writes a synthetic tail — compact_boundary, the isCompactSummary user
-// summary, the isMeta caveat, and the command wrappers — with no assistant
-// event or turn_done following. Every entry must be skipped so the pass
-// reports NoSubstantiveActivity=true and LastEventType stays at the prior
-// turn_done; the detector then ignores the pass and the session stays
-// ready (that half of the chain is pinned by
-// session_detector_no_substantive_test.go). Pre-fix, the summary leaked
-// through as a real user turn and stranded the session in working.
-// Entry shapes mirror the live session bb9f6ebf that surfaced the bug.
-func TestTailer_ManualCompactTail_NoSubstantiveActivity(t *testing.T) {
+// manualCompactTail is the synthetic block Claude Code burst-writes when a
+// manual /compact finishes: the compact_boundary (carrying
+// compactMetadata.trigger="manual"), the isCompactSummary continuation, the
+// isMeta caveat, and the command wrappers. Only the boundary is substantive
+// (#656); the rest stay skipped (#641).
+func manualCompactTail(trigger string) []map[string]interface{} {
+	return []map[string]interface{}{
+		{"type": "system", "subtype": "compact_boundary", "content": "Conversation compacted",
+			"compactMetadata": map[string]interface{}{"trigger": trigger, "preTokens": 655773},
+			"timestamp":       compactionTS(120)},
+		{"type": "user", "isCompactSummary": true, "isVisibleInTranscriptOnly": true,
+			"timestamp": compactionTS(120), "message": map[string]interface{}{
+				"role":    "user",
+				"content": "This session is being continued from a previous conversation that ran out of context.",
+			}},
+		{"type": "user", "isMeta": true, "timestamp": compactionTS(120), "message": map[string]interface{}{
+			"role": "user", "content": "<local-command-caveat>Caveat: …</local-command-caveat>",
+		}},
+		{"type": "user", "timestamp": compactionTS(120), "message": map[string]interface{}{
+			"role": "user", "content": "<command-name>/compact</command-name>",
+		}},
+		{"type": "user", "timestamp": compactionTS(121), "message": map[string]interface{}{
+			"role": "user", "content": "<local-command-stdout>Compacted (ctrl+o to see full summary)</local-command-stdout>",
+		}},
+	}
+}
+
+// TestTailer_ManualCompactTail_AfterReadyTurn pins the #641 ready→ready half
+// under the new #656 semantics. The prior turn closed cleanly with turn_done.
+// A manual /compact's burst-written boundary is now substantive (its
+// compactMetadata.trigger=="manual" promotes it to turn_done), so the pass is
+// NOT NoSubstantiveActivity — but the observable outcome is unchanged: the
+// session still ends at turn_done (IsAgentDone), so ready→ready holds. The
+// boundary surfaces as SawManualCompactBoundary so the detector can clear any
+// PreCompact hold (#657).
+func TestTailer_ManualCompactTail_AfterReadyTurn(t *testing.T) {
 	path := writeBgTranscript(t, []map[string]interface{}{
 		{"type": "user", "timestamp": compactionTS(0), "message": map[string]interface{}{
 			"role": "user", "content": "do the thing",
@@ -59,23 +84,190 @@ func TestTailer_ManualCompactTail_NoSubstantiveActivity(t *testing.T) {
 		t.Fatalf("pass 1 LastEventType = %q, want turn_done", m.LastEventType)
 	}
 
+	for _, ln := range manualCompactTail("manual") {
+		appendTranscriptLine(t, path, ln)
+	}
+
+	m, err = tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	if m.NoSubstantiveActivity {
+		t.Errorf("pass 2 NoSubstantiveActivity = true, want false (the manual compact_boundary is substantive)")
+	}
+	if !m.SawManualCompactBoundary {
+		t.Errorf("pass 2 SawManualCompactBoundary = false, want true")
+	}
+	if m.LastEventType != "turn_done" {
+		t.Errorf("pass 2 LastEventType = %q, want turn_done", m.LastEventType)
+	}
+	if m.HasOpenToolCall {
+		t.Errorf("pass 2 HasOpenToolCall = true, want false (ready→ready preserved)")
+	}
+}
+
+// TestTailer_ManualCompactTail_AfterMidToolUse is the #656 primary case. The
+// prior turn was stranded mid tool-use with a still-open tool call (assistant
+// tool_use, no tool_result, no turn_done) — pre-fix HasOpenToolCall pinned the
+// session in working forever. The manual compact_boundary now promotes to
+// turn_done, sweeping the lingering open call. LastEventType=="turn_done" with
+// HasOpenToolCall==false is exactly what session.IsAgentDone() reads as done,
+// so the session releases working→ready.
+func TestTailer_ManualCompactTail_AfterMidToolUse(t *testing.T) {
+	path := writeBgTranscript(t, []map[string]interface{}{
+		{"type": "user", "timestamp": compactionTS(0), "message": map[string]interface{}{
+			"role": "user", "content": "do the thing",
+		}},
+		bashToolUse("tu_mid", "Bash", map[string]interface{}{"command": "echo hi"}),
+	})
+
+	tl := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	if !m.HasOpenToolCall {
+		t.Fatalf("pass 1 HasOpenToolCall = false, want true (open tool call, the stuck-working condition)")
+	}
+	if m.LastEventType == "turn_done" {
+		t.Fatalf("pass 1 LastEventType = turn_done, want a mid-turn type (no turn_done yet)")
+	}
+
+	for _, ln := range manualCompactTail("manual") {
+		appendTranscriptLine(t, path, ln)
+	}
+
+	m, err = tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	if m.NoSubstantiveActivity {
+		t.Errorf("pass 2 NoSubstantiveActivity = true, want false")
+	}
+	if !m.SawManualCompactBoundary {
+		t.Errorf("pass 2 SawManualCompactBoundary = false, want true")
+	}
+	if m.LastEventType != "turn_done" {
+		t.Errorf("pass 2 LastEventType = %q, want turn_done", m.LastEventType)
+	}
+	if m.HasOpenToolCall {
+		t.Errorf("pass 2 HasOpenToolCall = true, want false (turn_done swept the open call → working→ready, #656)")
+	}
+}
+
+// TestTailer_AutoCompactTail_StaysSkipped guards the gate: an auto-compaction
+// boundary (compactMetadata.trigger="auto") must stay skipped — it fires
+// mid-turn and the agent continues, so promoting it would emit a spurious
+// ready-blip. The prior mid-tool-use turn must remain not-done.
+func TestTailer_AutoCompactTail_StaysSkipped(t *testing.T) {
+	path := writeBgTranscript(t, []map[string]interface{}{
+		{"type": "user", "timestamp": compactionTS(0), "message": map[string]interface{}{
+			"role": "user", "content": "do the thing",
+		}},
+		bashToolUse("tu_auto", "Bash", map[string]interface{}{"command": "echo hi"}),
+	})
+
+	tl := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+
+	for _, ln := range manualCompactTail("auto") {
+		appendTranscriptLine(t, path, ln)
+	}
+
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("pass 2: %v", err)
+	}
+	if !m.NoSubstantiveActivity {
+		t.Errorf("pass 2 NoSubstantiveActivity = false, want true (auto boundary must stay skipped)")
+	}
+	if m.SawManualCompactBoundary {
+		t.Errorf("pass 2 SawManualCompactBoundary = true, want false (auto, not manual)")
+	}
+	if m.LastEventType == "turn_done" {
+		t.Errorf("pass 2 LastEventType = turn_done, want unchanged (auto boundary not promoted)")
+	}
+	if !m.HasOpenToolCall {
+		t.Errorf("pass 2 HasOpenToolCall = false, want true (auto compaction must not sweep the open call)")
+	}
+}
+
+// TestTailer_ManualCompact_Issue656Regression replays the exact tail of the
+// live session that surfaced #656 (fa5751bf, Claude Code 2.1.168, manual
+// /compact). The last real turn ended mid tool-use — assistant tool_use →
+// tool_result, NO turn_done — so LastEventType was pinned at the tool_result
+// user event and the session was stranded in "working" forever. Faithful to the
+// report, the compaction block is burst-written with NON-monotonic, back-dated
+// timestamps (the /compact invocation predates the tool turn), and a trailing
+// system/away_summary recap proves the session went idle and still never
+// released. The regression bar: after the manual compact_boundary is parsed,
+// the session classifies as agent-done (→ ready), not stuck working.
+func TestTailer_ManualCompact_Issue656Regression(t *testing.T) {
+	// ts builds an absolute RFC3339 timestamp at a fixed wall-clock so the
+	// back-dating is literal, not relative to time.Now().
+	ts := func(h, m, s int) string {
+		return time.Date(2026, 6, 10, h, m, s, 0, time.UTC).Format(time.RFC3339)
+	}
+
+	path := writeBgTranscript(t, []map[string]interface{}{
+		{"type": "user", "timestamp": ts(19, 57, 30), "message": map[string]interface{}{
+			"role": "user", "content": "run the build",
+		}},
+		// Last real assistant turn: a tool_use (ts 19:57:42) ...
+		{"type": "assistant", "timestamp": ts(19, 57, 42), "message": map[string]interface{}{
+			"role": "assistant", "stop_reason": "tool_use",
+			"content": []interface{}{
+				map[string]interface{}{"type": "tool_use", "id": "tu_656", "name": "Bash",
+					"input": map[string]interface{}{"command": "go build ./..."}},
+			},
+		}},
+		// ... whose tool_result (ts 19:57:48) is the last NON-skipped event
+		// before compaction — a "user" event, NO turn_done. This is the pin
+		// that stranded the session in working.
+		{"type": "user", "timestamp": ts(19, 57, 48), "message": map[string]interface{}{
+			"role": "user",
+			"content": []interface{}{
+				map[string]interface{}{"type": "tool_result", "tool_use_id": "tu_656", "content": "ok"},
+			},
+		}},
+	})
+
+	tl := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code")
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	// Pre-compaction: the bug condition — not done, pinned at the tool_result.
+	if replayengine.TailerToDomain(m).IsAgentDone() {
+		t.Fatalf("pass 1 IsAgentDone = true, want false (mid tool-use, no turn_done — the stuck-working condition)")
+	}
+
+	// The manual /compact burst, back-dated: the compact_boundary and the
+	// /compact invocation carry timestamps BEFORE the 19:57 tool turn (file
+	// order is what the tailer honours, not these timestamps).
 	for _, ln := range []map[string]interface{}{
-		{"type": "system", "subtype": "compact_boundary", "content": "Conversation compacted",
-			"timestamp": compactionTS(120)},
+		{"type": "system", "subtype": "compact_boundary",
+			"compactMetadata": map[string]interface{}{"trigger": "manual", "preTokens": 655773},
+			"timestamp":       ts(17, 21, 23)},
 		{"type": "user", "isCompactSummary": true, "isVisibleInTranscriptOnly": true,
-			"timestamp": compactionTS(120), "message": map[string]interface{}{
-				"role":    "user",
-				"content": "This session is being continued from a previous conversation that ran out of context.",
+			"timestamp": ts(17, 21, 23), "message": map[string]interface{}{
+				"role": "user", "content": "This session is being continued from a previous conversation …",
 			}},
-		{"type": "user", "isMeta": true, "timestamp": compactionTS(120), "message": map[string]interface{}{
+		{"type": "user", "isMeta": true, "timestamp": ts(17, 18, 42), "message": map[string]interface{}{
 			"role": "user", "content": "<local-command-caveat>Caveat: …</local-command-caveat>",
 		}},
-		{"type": "user", "timestamp": compactionTS(120), "message": map[string]interface{}{
+		{"type": "user", "timestamp": ts(17, 18, 42), "message": map[string]interface{}{
 			"role": "user", "content": "<command-name>/compact</command-name>",
 		}},
-		{"type": "user", "timestamp": compactionTS(121), "message": map[string]interface{}{
+		{"type": "user", "timestamp": ts(17, 18, 43), "message": map[string]interface{}{
 			"role": "user", "content": "<local-command-stdout>Compacted (ctrl+o to see full summary)</local-command-stdout>",
 		}},
+		// away_summary recap proves the session went idle after compaction; it
+		// must not bounce the classification back to working.
+		{"type": "system", "subtype": "away_summary", "timestamp": ts(17, 39, 44),
+			"content": "Session idle recap …"},
 	} {
 		appendTranscriptLine(t, path, ln)
 	}
@@ -84,10 +276,17 @@ func TestTailer_ManualCompactTail_NoSubstantiveActivity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pass 2: %v", err)
 	}
-	if !m.NoSubstantiveActivity {
-		t.Errorf("pass 2 NoSubstantiveActivity = false, want true (every compaction-tail entry must be skipped)")
+	if !m.SawManualCompactBoundary {
+		t.Errorf("pass 2 SawManualCompactBoundary = false, want true")
 	}
 	if m.LastEventType != "turn_done" {
-		t.Errorf("pass 2 LastEventType = %q, want turn_done (compact summary must not register as a user turn)", m.LastEventType)
+		t.Errorf("pass 2 LastEventType = %q, want turn_done (manual compact_boundary ends the turn)", m.LastEventType)
+	}
+	if m.HasOpenToolCall {
+		t.Errorf("pass 2 HasOpenToolCall = true, want false")
+	}
+	// The regression assertion: the session is no longer stranded in working.
+	if !replayengine.TailerToDomain(m).IsAgentDone() {
+		t.Errorf("pass 2 IsAgentDone = false, want true — session must release working→ready after manual /compact (#656)")
 	}
 }

--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -38,20 +38,35 @@ const hookMatcher = "Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*|Ask
 // Bash/Write/… would set permissionPending on every tool call. (Issue #307.)
 const hookMatcherPreToolUse = "AskUserQuestion|ExitPlanMode"
 
+// hookMatcherPreCompact is the matcher for the PreCompact event. Unlike the
+// other events (whose matcher is a tool-name regex), Claude Code's PreCompact
+// matcher matches the compaction *trigger* — "manual" or "auto". We install
+// "manual" so the hook fires only for a user-invoked /compact, gating at the
+// source: auto-compaction fires mid-turn while the session is already working,
+// so forcing working there would be a spurious blip (#657).
+const hookMatcherPreCompact = "manual"
+
 // installedHookEvents are the Claude Code hook events we install handlers for.
 var installedHookEvents = []string{
 	HookPermissionRequest,
 	HookPreToolUse,
 	HookPostToolUse,
 	HookPostToolUseFailure,
+	HookPreCompact,
 }
 
-// matcherForEvent returns the tool matcher we install for the given event.
+// matcherForEvent returns the matcher we install for the given event. For most
+// events this is a tool-name regex; for PreCompact it is the compaction trigger
+// ("manual").
 func matcherForEvent(event string) string {
-	if event == HookPreToolUse {
+	switch event {
+	case HookPreToolUse:
 		return hookMatcherPreToolUse
+	case HookPreCompact:
+		return hookMatcherPreCompact
+	default:
+		return hookMatcher
 	}
-	return hookMatcher
 }
 
 // HookDeliveryAvailable reports whether the tool the installed hook command

--- a/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
@@ -289,6 +289,64 @@ func TestEnsureHooksInstalled_InstallsPreToolUseAndExpandedMatcher(t *testing.T)
 	if m, _ := postGroup["matcher"].(string); m != hookMatcher {
 		t.Errorf("PostToolUse matcher = %q, want %q", m, hookMatcher)
 	}
+
+	// PreCompact: one group whose matcher is the compaction trigger "manual"
+	// (not a tool-name regex), so the hook fires only for a user /compact (#657).
+	preCompact, ok := hooksMap[HookPreCompact].([]interface{})
+	if !ok || len(preCompact) != 1 {
+		t.Fatalf("expected 1 PreCompact group, got %d", len(preCompact))
+	}
+	preCompactGroup := preCompact[0].(map[string]interface{})
+	if m, _ := preCompactGroup["matcher"].(string); m != hookMatcherPreCompact {
+		t.Errorf("PreCompact matcher = %q, want %q", m, hookMatcherPreCompact)
+	}
+}
+
+// TestEnsureHooksInstalled_AddsPreCompactToExistingInstall verifies the
+// idempotent installer adds the newly-listed PreCompact event to a settings.json
+// that already carries the original four events, without duplicating them — the
+// upgrade path for existing installs (#657).
+func TestEnsureHooksInstalled_AddsPreCompactToExistingInstall(t *testing.T) {
+	home := withTempHome(t)
+
+	// Seed settings.json with the original four managed hooks (no PreCompact).
+	existing := map[string]interface{}{"hooks": map[string]interface{}{}}
+	hooks := existing["hooks"].(map[string]interface{})
+	for _, ev := range []string{HookPermissionRequest, HookPreToolUse, HookPostToolUse, HookPostToolUseFailure} {
+		hooks[ev] = []interface{}{makeHookGroup(matcherForEvent(ev), installedHookCommand)}
+	}
+	path := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(existing)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatalf("expected modified=true (PreCompact was missing)")
+	}
+
+	settings := readJSON(t, filepath.Join(home, ".claude", "settings.json"))
+	hooksMap := settings["hooks"].(map[string]interface{})
+	preCompact, ok := hooksMap[HookPreCompact].([]interface{})
+	if !ok || len(preCompact) != 1 {
+		t.Fatalf("expected exactly 1 PreCompact group after upgrade, got %d", len(preCompact))
+	}
+
+	// Re-running must be a no-op now that all five events are present.
+	modified, err = EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modified {
+		t.Errorf("expected modified=false on second run (already installed)")
+	}
 }
 
 // TestEnsureHooksInstalled_MigratesLegacyMatchers simulates a pre-#307

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -20,13 +20,19 @@ import (
 )
 
 // Hook event names. Claude Code fires these; the daemon recognizes only
-// these four and ignores everything else.
+// these five and ignores everything else.
 const (
 	HookPermissionRequest  = "PermissionRequest"
 	HookPreToolUse         = "PreToolUse"
 	HookPostToolUse        = "PostToolUse"
 	HookPostToolUseFailure = "PostToolUseFailure"
+	HookPreCompact         = "PreCompact"
 )
+
+// compactTriggerManual is the PreCompact trigger value for a user-invoked
+// /compact (as opposed to "auto"). Only manual compaction forces working — an
+// auto-compaction fires mid-turn while the session is already working (#657).
+const compactTriggerManual = "manual"
 
 // Tool names that suspend the agent waiting for user input. PreToolUse hooks
 // must match one of these — anything else is rejected by the handler, even
@@ -48,12 +54,19 @@ type hookPayload struct {
 	PermissionMode string          `json:"permission_mode,omitempty"`
 	IsInterrupt    bool            `json:"is_interrupt,omitempty"`
 	ToolInput      json.RawMessage `json:"tool_input,omitempty"`
+	// Trigger is "manual" or "auto" on PreCompact events (the compaction
+	// cause). Empty on other hook events.
+	Trigger string `json:"trigger,omitempty"`
 }
 
 // HookTarget is the interface the handler calls into. Satisfied by
 // *services.SessionDetector without importing the services package.
 type HookTarget interface {
 	HandlePermissionHook(sessionID, transcriptPath, hookEventName string)
+	// HandleCompactHook forces a session to working for the duration of a
+	// manual /compact, whose compaction window writes nothing to the transcript
+	// (#657). trigger is the PreCompact cause ("manual" / "auto").
+	HandleCompactHook(sessionID, transcriptPath, trigger string)
 }
 
 // MarkerTarget is the narrow interface for hook-carried task-estimate
@@ -177,6 +190,23 @@ func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGate, l
 		switch payload.HookEventName {
 		case HookPermissionRequest, HookPostToolUse, HookPostToolUseFailure:
 			dispatch()
+		case HookPreCompact:
+			// A manual /compact replaces the context; the compaction window
+			// (tens of seconds to minutes) writes nothing to the transcript, so
+			// without this hook the session stays frozen in its pre-compact
+			// state instead of showing working (#657). Force working now; the
+			// compact_boundary then releases it back to ready (#656). The
+			// installer matches "manual"; the trigger check here is
+			// defense-in-depth so an auto-compaction (already working, fires
+			// mid-turn) never gets a spurious working blip.
+			if payload.Trigger == compactTriggerManual {
+				log.LogInfo("hook-receiver", sessionID,
+					fmt.Sprintf("received %s (trigger=%s)", payload.HookEventName, payload.Trigger))
+				target.HandleCompactHook(sessionID, payload.TranscriptPath, payload.Trigger)
+			} else {
+				log.LogInfo("hook-receiver", sessionID,
+					fmt.Sprintf("ignored %s (trigger=%q, not manual)", payload.HookEventName, payload.Trigger))
+			}
 		case HookPreToolUse:
 			// Marker scan first, for ALL tools (#604): the rules block lets
 			// the agent carry its progress marker in a tool input (e.g. the

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -11,14 +11,20 @@ import (
 	"irrlicht/core/domain/session"
 )
 
-// mockTarget records calls to HandlePermissionHook for assertions.
+// mockTarget records calls to HandlePermissionHook and HandleCompactHook for
+// assertions.
 type mockTarget struct {
-	mu    sync.Mutex
-	calls []hookCall
+	mu           sync.Mutex
+	calls        []hookCall
+	compactCalls []compactCall
 }
 
 type hookCall struct {
 	sessionID, transcriptPath, hookEventName string
+}
+
+type compactCall struct {
+	sessionID, transcriptPath, trigger string
 }
 
 func (m *mockTarget) HandlePermissionHook(sessionID, transcriptPath, hookEventName string) {
@@ -27,10 +33,22 @@ func (m *mockTarget) HandlePermissionHook(sessionID, transcriptPath, hookEventNa
 	m.calls = append(m.calls, hookCall{sessionID, transcriptPath, hookEventName})
 }
 
+func (m *mockTarget) HandleCompactHook(sessionID, transcriptPath, trigger string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.compactCalls = append(m.compactCalls, compactCall{sessionID, transcriptPath, trigger})
+}
+
 func (m *mockTarget) getCalls() []hookCall {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return append([]hookCall{}, m.calls...)
+}
+
+func (m *mockTarget) getCompactCalls() []compactCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]compactCall{}, m.compactCalls...)
 }
 
 // mockLogger satisfies outbound.Logger.
@@ -171,6 +189,68 @@ func TestHookHandler_PreToolUse_RejectsUnexpectedTool(t *testing.T) {
 	}
 	if len(target.getCalls()) != 0 {
 		t.Errorf("PreToolUse for Bash should not dispatch; got %d calls", len(target.getCalls()))
+	}
+}
+
+// TestHookHandler_PreCompactManual verifies a manual /compact PreCompact hook
+// routes to HandleCompactHook so the detector can force working for the
+// compaction window (#657).
+func TestHookHandler_PreCompactManual(t *testing.T) {
+	target := &mockTarget{}
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
+
+	payload := hookPayload{
+		TranscriptPath: "/Users/u/.claude/projects/p/sess-comp.jsonl",
+		HookEventName:  "PreCompact",
+		Trigger:        "manual",
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if len(target.getCalls()) != 0 {
+		t.Errorf("PreCompact must not reach HandlePermissionHook; got %+v", target.getCalls())
+	}
+	compact := target.getCompactCalls()
+	if len(compact) != 1 {
+		t.Fatalf("got %d HandleCompactHook calls, want 1", len(compact))
+	}
+	if compact[0].sessionID != "sess-comp" {
+		t.Errorf("sessionID = %q, want %q", compact[0].sessionID, "sess-comp")
+	}
+	if compact[0].trigger != "manual" {
+		t.Errorf("trigger = %q, want %q", compact[0].trigger, "manual")
+	}
+}
+
+// TestHookHandler_PreCompactAuto verifies an auto-compaction PreCompact hook is
+// accepted but ignored — the session is already working mid-turn, so forcing it
+// would be a spurious blip (#657).
+func TestHookHandler_PreCompactAuto(t *testing.T) {
+	target := &mockTarget{}
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
+
+	payload := hookPayload{
+		TranscriptPath: "/Users/u/.claude/projects/p/sess-auto.jsonl",
+		HookEventName:  "PreCompact",
+		Trigger:        "auto",
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (accept but ignore)", rec.Code, http.StatusOK)
+	}
+	if got := target.getCompactCalls(); len(got) != 0 {
+		t.Errorf("auto PreCompact should not dispatch; got %+v", got)
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -179,8 +179,8 @@ func handleAttachmentEvent(raw map[string]interface{}, ev *tailer.ParsedEvent) {
 	ev.TaskSnapshot = &snap
 }
 
-// handleSystemEvent maps turn_duration / stop_hook_summary subtypes to
-// turn_done; everything else is skipped.
+// handleSystemEvent maps turn_duration / stop_hook_summary and the manual
+// compact_boundary subtypes to turn_done; everything else is skipped.
 //
 // The skip branch covers purely informational subtypes that Claude Code
 // writes after a turn has already ended — most notably `away_summary`,
@@ -188,10 +188,28 @@ func handleAttachmentEvent(raw map[string]interface{}, ev *tailer.ParsedEvent) {
 // promoted to turn_done: they describe what happened, they aren't a turn
 // completion themselves. The tailer's per-pass NoSubstantiveActivity flag
 // then lets the detector ignore the resulting mtime touch (issue #329).
+//
+// A manual /compact is the exception: its compact_boundary replaces the
+// context and definitively ends the prior turn — even one stranded mid
+// tool-use with no turn_done of its own. Promoting it to turn_done sweeps any
+// lingering open tool call so the session releases working → ready (#656), and
+// flags IsManualCompactBoundary so the detector can clear its force-working
+// hold (#657). Auto-compaction fires mid-turn and continues, so it stays
+// skipped — promoting it would emit a spurious ready-blip.
 func handleSystemEvent(raw map[string]interface{}, ev *tailer.ParsedEvent) {
-	if subtype, _ := raw["subtype"].(string); subtype == "turn_duration" || subtype == "stop_hook_summary" {
+	subtype, _ := raw["subtype"].(string)
+	if subtype == "turn_duration" || subtype == "stop_hook_summary" {
 		ev.EventType = "turn_done"
 		return
+	}
+	if subtype == "compact_boundary" {
+		if meta, ok := raw["compactMetadata"].(map[string]interface{}); ok {
+			if trigger, _ := meta["trigger"].(string); trigger == "manual" {
+				ev.EventType = "turn_done"
+				ev.IsManualCompactBoundary = true
+				return
+			}
+		}
 	}
 	ev.Skip = true
 }

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -42,6 +42,7 @@ func TailerToDomain(m *tailer.SessionMetrics) *session.SessionMetrics {
 		PermissionMode:                    m.PermissionMode,
 		SawUserBlockingToolClosedThisPass: m.SawUserBlockingToolClosedThisPass,
 		NoSubstantiveActivity:             m.NoSubstantiveActivity,
+		SawManualCompactBoundary:          m.SawManualCompactBoundary,
 	}
 	if len(m.SubagentCompletions) > 0 {
 		result.SubagentCompletions = make([]session.SubagentCompletion, len(m.SubagentCompletions))

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -132,6 +132,14 @@ type SessionDetector struct {
 	permMu            sync.Mutex
 	permissionPending map[string]bool // sessionID → true
 
+	// compactPending tracks sessions in a manual /compact, set by
+	// HandleCompactHook (PreCompact hook) and cleared when the
+	// compact_boundary lands (SawManualCompactBoundary). While set,
+	// processActivity overlays CompactInProgress so ClassifyState holds the
+	// session in working through the silent compaction window (#657). Guarded
+	// by permMu — same goroutine-crossing story as permissionPending.
+	compactPending map[string]bool // sessionID → true
+
 	// editToolOpenSince tracks, per session, the Unix time a permission-gated
 	// file-edit tool first appeared open. Guarded by permMu. Drives the
 	// OpenToolStalled transcript fallback (#488): an edit tool open past
@@ -206,6 +214,7 @@ func NewSessionDetector(
 		debouncedEvents:   make(chan agent.Event, 64),
 		deletedCooldown:   10 * time.Second,
 		permissionPending: make(map[string]bool),
+		compactPending:    make(map[string]bool),
 		editToolOpenSince: make(map[string]int64),
 		bgLiveProbe:       anyLiveOutputWriter,
 		bgLive:            make(map[string]bool),

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -40,6 +40,16 @@ const activityDebounceWindow = 2 * time.Second
 // transcript on this interval catches the missed events.
 const staleWorkingRefreshInterval = 5 * time.Second
 
+// compactHoldTimeout bounds the PreCompact force-working hold (#657). Normally
+// the hold clears when the manual compact_boundary lands, but an interrupted or
+// failed /compact may never write one — without a ceiling the session would be
+// re-held working on every refreshStaleSessions tick and stranded forever (the
+// very failure #656 fixed). A real manual compaction runs at most a few minutes
+// (the #656 live evidence was ~161s), so this timeout sits comfortably beyond
+// any genuine window: after it elapses an orphaned hold is dropped and the
+// session re-classifies normally.
+const compactHoldTimeout = 5 * time.Minute
+
 // SubagentQuietWindow is how long a subagent's transcript must have been
 // silent before finishOrphanedChildren will promote it to ready.
 //
@@ -132,13 +142,15 @@ type SessionDetector struct {
 	permMu            sync.Mutex
 	permissionPending map[string]bool // sessionID → true
 
-	// compactPending tracks sessions in a manual /compact, set by
-	// HandleCompactHook (PreCompact hook) and cleared when the
-	// compact_boundary lands (SawManualCompactBoundary). While set,
-	// processActivity overlays CompactInProgress so ClassifyState holds the
-	// session in working through the silent compaction window (#657). Guarded
-	// by permMu — same goroutine-crossing story as permissionPending.
-	compactPending map[string]bool // sessionID → true
+	// compactPending tracks sessions in a manual /compact: sessionID → the Unix
+	// time the PreCompact hook fired. Set by HandleCompactHook; cleared when the
+	// compact_boundary lands (SawManualCompactBoundary) or compactHoldTimeout
+	// elapses (the safety net for an interrupted compaction that never writes a
+	// boundary). While set, processActivity overlays CompactInProgress so
+	// ClassifyState holds the session in working through the silent compaction
+	// window (#657). Guarded by permMu — same goroutine-crossing story as
+	// permissionPending.
+	compactPending map[string]int64 // sessionID → unix seconds (hook fire time)
 
 	// editToolOpenSince tracks, per session, the Unix time a permission-gated
 	// file-edit tool first appeared open. Guarded by permMu. Drives the
@@ -214,7 +226,7 @@ func NewSessionDetector(
 		debouncedEvents:   make(chan agent.Event, 64),
 		deletedCooldown:   10 * time.Second,
 		permissionPending: make(map[string]bool),
-		compactPending:    make(map[string]bool),
+		compactPending:    make(map[string]int64),
 		editToolOpenSince: make(map[string]int64),
 		bgLiveProbe:       anyLiveOutputWriter,
 		bgLive:            make(map[string]bool),

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -468,21 +468,10 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 				state.Metrics.PermissionPending = true
 			}
 		}
-		// Overlay the PreCompact force-working hold (#657). The compact_boundary
-		// that ends a manual /compact lands as SawManualCompactBoundary — clear
-		// the hold the same pass so ClassifyState can release working → ready
-		// (#656) instead of holding. Otherwise, while the hook recorded a
-		// pending compaction, force CompactInProgress so the session shows
-		// working through the silent compaction window. The map persists the
-		// hold across the no-op re-evaluations between the hook and the boundary.
-		if state.Metrics != nil {
-			if state.Metrics.SawManualCompactBoundary {
-				delete(d.compactPending, ev.SessionID)
-			} else if d.compactPending[ev.SessionID] {
-				state.Metrics.CompactInProgress = true
-			}
-		}
 		d.permMu.Unlock()
+
+		// Overlay the PreCompact force-working hold (#657).
+		d.applyCompactHold(ev.SessionID, state.Metrics, time.Now().Unix())
 
 		// Overlay the transcript-based stalled-edit-tool fallback (#488).
 		d.markStalledEditTool(ev.SessionID, state.Metrics, time.Now().Unix())
@@ -714,6 +703,39 @@ func (d *SessionDetector) applyBackgroundLiveness(state *session.SessionState) {
 // lets a held prompt flip without any new transcript write. The flag is
 // redundant once PermissionPending fired (the classifier prefers the hook),
 // so it is skipped then. now is injected for testability.
+// applyCompactHold maintains the PreCompact force-working hold (#657) for one
+// session. While a manual /compact is in flight the transcript receives no
+// writes, so this overlays CompactInProgress to keep the session in working
+// (ClassifyState rule 0b) through that silent window.
+//
+// The hold clears on the first of:
+//   - the manual compact_boundary landing (SawManualCompactBoundary): the
+//     normal path — compaction finished, release working → ready (#656);
+//   - compactHoldTimeout elapsing since the PreCompact hook fired: the safety
+//     net for a /compact that was interrupted or errored with no boundary ever
+//     written. Without it an orphaned hold would be re-armed on every
+//     refreshStaleSessions tick and strand the session in working forever — the
+//     very failure #656 fixed.
+//
+// now is injected for testability. Mirrors markStalledEditTool's shape.
+func (d *SessionDetector) applyCompactHold(sessionID string, m *session.SessionMetrics, now int64) {
+	if m == nil {
+		return
+	}
+	d.permMu.Lock()
+	defer d.permMu.Unlock()
+
+	since, ok := d.compactPending[sessionID]
+	if !ok {
+		return
+	}
+	if m.SawManualCompactBoundary || now-since >= int64(compactHoldTimeout.Seconds()) {
+		delete(d.compactPending, sessionID)
+		return
+	}
+	m.CompactInProgress = true
+}
+
 func (d *SessionDetector) markStalledEditTool(sessionID string, m *session.SessionMetrics, now int64) {
 	d.permMu.Lock()
 	defer d.permMu.Unlock()

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -468,6 +468,20 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 				state.Metrics.PermissionPending = true
 			}
 		}
+		// Overlay the PreCompact force-working hold (#657). The compact_boundary
+		// that ends a manual /compact lands as SawManualCompactBoundary — clear
+		// the hold the same pass so ClassifyState can release working → ready
+		// (#656) instead of holding. Otherwise, while the hook recorded a
+		// pending compaction, force CompactInProgress so the session shows
+		// working through the silent compaction window. The map persists the
+		// hold across the no-op re-evaluations between the hook and the boundary.
+		if state.Metrics != nil {
+			if state.Metrics.SawManualCompactBoundary {
+				delete(d.compactPending, ev.SessionID)
+			} else if d.compactPending[ev.SessionID] {
+				state.Metrics.CompactInProgress = true
+			}
+		}
 		d.permMu.Unlock()
 
 		// Overlay the transcript-based stalled-edit-tool fallback (#488).

--- a/core/application/services/session_detector_compact_hold_test.go
+++ b/core/application/services/session_detector_compact_hold_test.go
@@ -1,0 +1,72 @@
+package services
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestApplyCompactHold covers the PreCompact force-working hold (#657): a fresh
+// hold overlays CompactInProgress, the manual compact_boundary clears it
+// (normal release, #656), and — the safety net this test pins — an interrupted
+// /compact that never writes a boundary is dropped once compactHoldTimeout
+// elapses instead of stranding the session in working forever. White-box so it
+// can drive the unexported method + compactPending map directly, injecting
+// `now` rather than sleeping out the real multi-minute timeout.
+func TestApplyCompactHold(t *testing.T) {
+	const sid = "s"
+	timeout := int64(compactHoldTimeout.Seconds())
+
+	t.Run("fresh hold forces working", func(t *testing.T) {
+		d := &SessionDetector{compactPending: map[string]int64{sid: 1000}}
+		m := &session.SessionMetrics{LastEventType: "turn_done"}
+		d.applyCompactHold(sid, m, 1000+timeout-1) // just inside the window
+		if !m.CompactInProgress {
+			t.Fatal("CompactInProgress must be set while the hold is live")
+		}
+		if _, ok := d.compactPending[sid]; !ok {
+			t.Fatal("hold must persist until boundary or timeout")
+		}
+	})
+
+	t.Run("boundary clears the hold without forcing working", func(t *testing.T) {
+		d := &SessionDetector{compactPending: map[string]int64{sid: 1000}}
+		m := &session.SessionMetrics{LastEventType: "turn_done", SawManualCompactBoundary: true}
+		d.applyCompactHold(sid, m, 1000+1)
+		if m.CompactInProgress {
+			t.Fatal("CompactInProgress must NOT be set the pass the boundary lands (release → ready)")
+		}
+		if _, ok := d.compactPending[sid]; ok {
+			t.Fatal("boundary must clear the hold")
+		}
+	})
+
+	t.Run("timeout drops an orphaned hold (interrupted /compact, no boundary)", func(t *testing.T) {
+		d := &SessionDetector{compactPending: map[string]int64{sid: 1000}}
+		m := &session.SessionMetrics{LastEventType: "turn_done"} // no boundary ever arrived
+		d.applyCompactHold(sid, m, 1000+timeout)
+		if m.CompactInProgress {
+			t.Fatal("CompactInProgress must NOT be set after timeout — the session must re-classify, not stay held")
+		}
+		if _, ok := d.compactPending[sid]; ok {
+			t.Fatal("timeout must drop the orphaned hold so it can't be re-armed every tick")
+		}
+	})
+
+	t.Run("no pending hold is a no-op", func(t *testing.T) {
+		d := &SessionDetector{compactPending: map[string]int64{}}
+		m := &session.SessionMetrics{LastEventType: "turn_done", SawManualCompactBoundary: true}
+		d.applyCompactHold(sid, m, 5000)
+		if m.CompactInProgress {
+			t.Fatal("a session with no recorded hold must not be forced working")
+		}
+	})
+
+	t.Run("nil metrics is a no-op", func(t *testing.T) {
+		d := &SessionDetector{compactPending: map[string]int64{sid: 1000}}
+		d.applyCompactHold(sid, nil, 9999) // must not panic
+		if _, ok := d.compactPending[sid]; !ok {
+			t.Fatal("nil metrics must leave the hold untouched")
+		}
+	})
+}

--- a/core/application/services/session_detector_compact_test.go
+++ b/core/application/services/session_detector_compact_test.go
@@ -1,0 +1,149 @@
+package services_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+)
+
+// TestSessionDetector_CompactHook_HoldsWorkingThenReleases is the end-to-end
+// #657 lifecycle. A manual /compact writes nothing to the transcript during the
+// compaction window, so the PreCompact hook (HandleCompactHook) must force the
+// session to working and hold it there across re-evaluations until the
+// compact_boundary lands — which surfaces as SawManualCompactBoundary and
+// releases the session back to ready (the #656 half).
+func TestSessionDetector_CompactHook_HoldsWorkingThenReleases(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	const path = "/home/.claude/projects/-Users-test/comp1.jsonl"
+
+	// sawBoundary toggles whether ComputeMetrics reports the manual
+	// compact_boundary for this pass. Pre-boundary the transcript still ends at
+	// the pre-compact turn_done; once the boundary lands we flip it true.
+	var mu sync.Mutex
+	sawBoundary := false
+	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return &session.SessionMetrics{
+			LastEventType:            "turn_done",
+			HasOpenToolCall:          false,
+			SawManualCompactBoundary: sawBoundary,
+		}, nil
+	}}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+
+	// Session sits ready after a clean prior turn (turn_done). Without the hook
+	// overlay, ClassifyState would keep it ready forever during compaction.
+	repo.states["comp1"] = &session.SessionState{
+		SessionID:      "comp1",
+		State:          session.StateReady,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+		Metrics:        &session.SessionMetrics{LastEventType: "turn_done"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	defer func() { cancel(); <-done }()
+
+	time.Sleep(20 * time.Millisecond) // let seedFromDisk finish
+
+	// PreCompact hook fires for the manual /compact → force working.
+	det.HandleCompactHook("comp1", path, "manual")
+	waitForSessionState(repo, "comp1", session.StateWorking, time.Second)
+
+	repo.mu.Lock()
+	got := repo.lastSavedState["comp1"]
+	repo.mu.Unlock()
+	if got != session.StateWorking {
+		t.Fatalf("after PreCompact hook: state = %q, want working (forced for compaction window)", got)
+	}
+
+	// A re-evaluation mid-window (no boundary yet) must HOLD working — the
+	// stale turn_done must not leak the session back to ready.
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "comp1",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: path,
+	}
+	// Give the pass time to land, then assert it's still working.
+	waitForCondition(func() bool { return repo.eventCountOf("comp1") >= 1 }, time.Second)
+	repo.mu.Lock()
+	got = repo.lastSavedState["comp1"]
+	repo.mu.Unlock()
+	if got != session.StateWorking {
+		t.Fatalf("mid-window re-eval: state = %q, want working (hold must survive re-evaluation)", got)
+	}
+
+	// Compaction finishes: the boundary lands. The next pass clears the hold
+	// and releases working → ready (#656).
+	mu.Lock()
+	sawBoundary = true
+	mu.Unlock()
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "comp1",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: path,
+	}
+	waitForSessionState(repo, "comp1", session.StateReady, time.Second)
+
+	repo.mu.Lock()
+	got = repo.lastSavedState["comp1"]
+	repo.mu.Unlock()
+	if got != session.StateReady {
+		t.Errorf("after compact_boundary: state = %q, want ready (working→ready release)", got)
+	}
+}
+
+// TestSessionDetector_CompactHook_AutoIgnored guards the gate at the detector
+// level: an auto-compaction PreCompact hook must not force working — the
+// session is already mid-turn and a forced blip would be spurious (#657).
+func TestSessionDetector_CompactHook_AutoIgnored(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	const path = "/home/.claude/projects/-Users-test/comp2.jsonl"
+
+	det := newDetector(tw, pw, repo)
+
+	repo.states["comp2"] = &session.SessionState{
+		SessionID:      "comp2",
+		State:          session.StateReady,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+		Metrics:        &session.SessionMetrics{LastEventType: "turn_done"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	defer func() { cancel(); <-done }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	det.HandleCompactHook("comp2", path, "auto")
+
+	// Auto compaction must not transition the session. Give the loop a beat,
+	// then confirm it never left ready.
+	waitForSessionState(repo, "comp2", session.StateWorking, 200*time.Millisecond)
+	repo.mu.Lock()
+	got := repo.lastSavedState["comp2"]
+	repo.mu.Unlock()
+	if got == session.StateWorking {
+		t.Errorf("auto PreCompact forced working; want session to stay ready")
+	}
+}

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -170,7 +170,7 @@ func (d *SessionDetector) HandleCompactHook(sessionID, transcriptPath, trigger s
 	}
 
 	d.permMu.Lock()
-	d.compactPending[sessionID] = true
+	d.compactPending[sessionID] = time.Now().Unix()
 	d.permMu.Unlock()
 
 	// Flip the session to working immediately — there is no transcript flush

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -31,6 +31,7 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	// keep the entry forever, and a recycled session ID would inherit it.
 	d.permMu.Lock()
 	delete(d.permissionPending, ev.SessionID)
+	delete(d.compactPending, ev.SessionID)
 	delete(d.editToolOpenSince, ev.SessionID)
 	d.permMu.Unlock()
 
@@ -122,15 +123,23 @@ func (d *SessionDetector) HandlePermissionHook(sessionID, transcriptPath, hookEv
 	}
 	d.permMu.Unlock()
 
+	// processActivity overlays PermissionPending onto the metrics before
+	// calling ClassifyState.
+	d.dispatchHookActivity(sessionID, transcriptPath, hookEventName)
+}
+
+// dispatchHookActivity records a hook-received lifecycle event and injects a
+// synthetic activity event so the event loop re-classifies the session now —
+// without waiting on a transcript flush. Shared by the permission and
+// compaction hook handlers, whose only differences are which pending map they
+// set (done by the caller) and the hook name.
+func (d *SessionDetector) dispatchHookActivity(sessionID, transcriptPath, hookName string) {
 	d.record(lifecycle.Event{
 		Kind:      lifecycle.KindHookReceived,
 		SessionID: sessionID,
-		HookName:  hookEventName,
+		HookName:  hookName,
 	})
 
-	// Inject synthetic activity event so the event loop re-evaluates the
-	// session. processActivity will overlay PermissionPending onto the
-	// metrics before calling ClassifyState.
 	select {
 	case d.debouncedEvents <- agent.Event{
 		Type:           agent.EventActivity,
@@ -139,8 +148,34 @@ func (d *SessionDetector) HandlePermissionHook(sessionID, transcriptPath, hookEv
 	}:
 	default:
 		d.log.LogError("hook-receiver", sessionID,
-			"debouncedEvents channel full, permission event dropped")
+			fmt.Sprintf("debouncedEvents channel full, %s hook event dropped", hookName))
 	}
+}
+
+// HandleCompactHook processes a Claude Code PreCompact hook for a manual
+// /compact. The compaction window writes nothing to the transcript, so without
+// an out-of-band push the session stays frozen in its pre-compact state instead
+// of showing working (issue #657). Marking compactPending makes processActivity
+// overlay CompactInProgress so ClassifyState holds the session in working until
+// the compact_boundary lands (which #656 turns into turn_done → ready).
+//
+// Only manual compaction is handled: auto-compaction fires mid-turn while the
+// session is already working, so a forced working blip would be spurious. The
+// HTTP handler already gates on trigger=="manual"; this re-checks defensively.
+//
+// Safe to call from any goroutine (e.g. HTTP handler).
+func (d *SessionDetector) HandleCompactHook(sessionID, transcriptPath, trigger string) {
+	if trigger != "manual" {
+		return
+	}
+
+	d.permMu.Lock()
+	d.compactPending[sessionID] = true
+	d.permMu.Unlock()
+
+	// Flip the session to working immediately — there is no transcript flush
+	// coming during the compaction window to trigger a natural re-evaluation.
+	d.dispatchHookActivity(sessionID, transcriptPath, "PreCompact")
 }
 
 // seedFromDisk populates the projectSessions map from existing sessions,

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -36,6 +36,19 @@ func ClassifyState(currentState string, metrics *session.SessionMetrics) (string
 		return currentState, ""
 	}
 
+	// 0b. Manual /compact in progress (PreCompact hook) → working, regardless
+	// of the stale pre-compact turn_done that IsAgentDone() would otherwise read
+	// as ready. Compaction writes nothing to the transcript for tens of seconds
+	// to minutes; this overlay holds the session busy for that window (#657).
+	// The detector clears it the pass the manual compact_boundary lands, which
+	// then routes to ready via rule 2 (#656).
+	if metrics.CompactInProgress {
+		if currentState != session.StateWorking {
+			return session.StateWorking, "manual /compact in progress → working"
+		}
+		return currentState, ""
+	}
+
 	// 1. User-blocking tool open → waiting.
 	if metrics.NeedsUserAttention() {
 		if currentState != session.StateWaiting {

--- a/core/application/services/state_classifier_test.go
+++ b/core/application/services/state_classifier_test.go
@@ -55,6 +55,40 @@ func TestClassifyState(t *testing.T) {
 			wantState:  session.StateWaiting,
 			wantReason: true,
 		},
+		// Rule 0b: CompactInProgress (manual /compact) → working, holding the
+		// session busy through the silent compaction window (#657).
+		{
+			name:    "ready → working (compact in progress)",
+			current: session.StateReady,
+			metrics: &session.SessionMetrics{
+				CompactInProgress: true,
+				// The pre-compact turn_done that would otherwise read as ready.
+				LastEventType: "turn_done",
+			},
+			wantState:  session.StateWorking,
+			wantReason: true,
+		},
+		{
+			name:    "working stays working (compact in progress, already working)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				CompactInProgress: true,
+				LastEventType:     "turn_done",
+			},
+			wantState: session.StateWorking,
+		},
+		{
+			// Once the boundary lands the detector clears CompactInProgress, so
+			// the same turn_done metrics route to ready via rule 2 (#656).
+			name:    "working → ready (compact cleared, turn_done)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				CompactInProgress: false,
+				LastEventType:     "turn_done",
+			},
+			wantState:  session.StateReady,
+			wantReason: true,
+		},
 		{
 			// Regression guard: Bash open without permission pending must NOT
 			// trigger waiting — only the hook signal does.

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -163,6 +163,22 @@ type SessionMetrics struct {
 	// serialized state.
 	NoSubstantiveActivity bool `json:"-"`
 
+	// SawManualCompactBoundary reflects the last tailer pass: true when it
+	// parsed a manual compact_boundary (user /compact), the marker Claude Code
+	// burst-writes when compaction finishes. The detector uses it to clear the
+	// PreCompact force-working hold so the session releases working → ready
+	// (#657, paired with #656). Per-pass: MergeMetrics copies it from newM with
+	// no fallback, and json:"-" keeps it out of serialized state.
+	SawManualCompactBoundary bool `json:"-"`
+
+	// CompactInProgress is an overlay flag set by the detector (NOT the parser)
+	// while a manual /compact is running: the PreCompact hook recorded a pending
+	// compaction and no compact_boundary has landed yet. ClassifyState forces
+	// working while it is set, holding the session busy through the silent
+	// compaction window where the transcript receives no writes (#657). Cleared
+	// the pass SawManualCompactBoundary fires. Transient, never persisted.
+	CompactInProgress bool `json:"-"`
+
 	// SubagentCompletions surfaces parent-side "subagent done" signals
 	// from the most recent transcript scan (origin.kind="task-notification"
 	// lines parsed by the Claude Code adapter). Per-pass and transient —
@@ -714,6 +730,7 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 		CumCacheCreationTokens:   newM.CumCacheCreationTokens,
 		Tasks:                    newM.Tasks,
 		NoSubstantiveActivity:    newM.NoSubstantiveActivity,
+		SawManualCompactBoundary: newM.SawManualCompactBoundary,
 		RateLimit:                newM.RateLimit,
 		RateLimitForecastEta:     newM.RateLimitForecastEta,
 		TaskEstimate:             newM.TaskEstimate,

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -122,6 +122,14 @@ type ParsedEvent struct {
 	// with no matches, a failing build, etc.). See issue #102 Bug B.
 	IsUserInterrupt bool
 
+	// IsManualCompactBoundary is true only for a compact_boundary system event
+	// whose compactMetadata.trigger == "manual" — a user-invoked /compact. The
+	// parser also sets EventType="turn_done" for it (the context was replaced,
+	// the prior turn is definitively over). The tailer surfaces it as the
+	// per-pass SessionMetrics.SawManualCompactBoundary so the detector can clear
+	// the PreCompact force-working hold (#657). Auto-compaction never sets this.
+	IsManualCompactBoundary bool
+
 	// IsToolDenial is true when the user denied a permission prompt for a
 	// tool call ("[Request interrupted by user for tool use]" text marker).
 	// This is a *different* signal from IsUserInterrupt: a tool denial does

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -152,6 +152,14 @@ type SessionMetrics struct {
 	// (issue #329).
 	NoSubstantiveActivity bool `json:"-"`
 
+	// SawManualCompactBoundary is true when this pass parsed a manual
+	// compact_boundary (user-invoked /compact) — the burst-written marker
+	// Claude Code flushes when compaction finishes. Per-pass transient; the
+	// detector uses it to clear the PreCompact force-working hold so the
+	// session releases working → ready (#657, paired with #656). Auto-compaction
+	// never sets it.
+	SawManualCompactBoundary bool `json:"-"`
+
 	// Tasks is the current task list for this session, accumulated from
 	// TaskCreate / TaskUpdate tool_use events in the Claude Code transcript.
 	// Nil for sessions that have not called TaskCreate.
@@ -497,6 +505,7 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 	// re-classify against stale metrics. See issue #329.
 	linesParsedThisPass := 0
 	substantiveThisPass := false
+	sawManualCompactThisPass := false
 
 	// Per-pass signals must be cleared so the detector only drains events
 	// discovered in this scan (see issue #134).
@@ -628,6 +637,9 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 		}
 		linesParsedThisPass++
 		substantiveThisPass = true
+		if parsed.IsManualCompactBoundary {
+			sawManualCompactThisPass = true
+		}
 		t.processParsedEvent(parsed, &sawUserBlockingClosedThisPass)
 	}
 
@@ -650,6 +662,7 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 	t.computeMetrics()
 	t.metrics.SawUserBlockingToolClosedThisPass = sawUserBlockingClosedThisPass
 	t.metrics.NoSubstantiveActivity = linesParsedThisPass > 0 && !substantiveThisPass
+	t.metrics.SawManualCompactBoundary = sawManualCompactThisPass
 
 	// Model config fallback. Skipped on the replay path (see
 	// disableModelConfigFallback) so fixture output stays hermetic.


### PR DESCRIPTION
## Summary

A manual `/compact` was invisible to irrlicht's state machine in two complementary ways. This PR restores the full lifecycle you'd expect — **working for the whole compaction window, then ready once it finishes** — by fixing both halves together (the issues cross-reference each other).

| Phase | Transcript | State | Delivered by |
|-------|-----------|-------|--------------|
| `/compact` invoked | (nothing yet) | **working** | #657 PreCompact hook |
| compaction running (~60–160s) | (nothing written) | **working** (holds) | #657 overlay |
| compaction finishes | burst-write `compact_boundary{manual}` | **working → ready** | #656 parser → `turn_done` |

### #656 — release `working → ready` after compaction
When the last pre-compact turn was stranded mid tool-use (`tool_use → tool_result`, no `turn_done`), the burst-written compaction tail was entirely skip-able, so the parser never emitted `turn_done`; the lingering open tool call was never swept and the session stuck in **working** forever.

`handleSystemEvent` now promotes a `compact_boundary` whose `compactMetadata.trigger == "manual"` to `turn_done` (auto stays skipped), reusing the existing open-tool-call sweep so `IsAgentDone()` reports done.

### #657 — show `working` during compaction
The compaction window writes nothing to the transcript, so transcript-only detection fundamentally can't surface it. A new **`PreCompact` hook** (installed with matcher `"manual"`) forces the session to working via `HandleCompactHook`, which sets a `compactPending` hold; `processActivity` overlays `CompactInProgress` and `ClassifyState` rule 0b holds working until the manual `compact_boundary` lands (surfaced as `SawManualCompactBoundary`), which clears the hold and routes to ready.

Both halves gate **strictly on manual** compaction — auto-compaction fires mid-turn while the session is already working, so it must not blip.

> ⚠️ **Existing installs** pick up the "working during compaction" half automatically on the next daemon restart — `EnsureHooksInstalled` is idempotent and adds the missing `PreCompact` entry to `~/.claude/settings.json`. No manual re-onboarding needed.

This is a follow-up to #641 (the ready→working half), whose observable outcome is preserved.

## Test plan
- `go test ./core/... -race -count=1` — full suite green.
- `tools/replay-fixtures.sh` — passes, no golden drift (incl. `2-12_context-compaction`).
- New coverage:
  - Parser/tailer: working→ready, ready→ready (#641 preserved), auto-skipped — plus a faithful `fa5751bf`-shaped regression (non-monotonic back-dated burst + trailing `away_summary`) **proven to fail without the parser fix**.
  - Hook dispatch: manual routes to `HandleCompactHook`, auto ignored.
  - Installer: `PreCompact` matcher `"manual"` + idempotent add to an existing four-event install.
  - Classifier rule 0b; end-to-end detector hold→release.

Closes #656
Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)