### PR TITLE
feat(onboard): Tier-1 onboarding-factory process fixes (#666)

### DIFF
--- a/.claude/skills/ir:onboarding-factory/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/SKILL.md
@@ -55,13 +55,23 @@ ports the missing step from the reference driver before it drives.
 
 For `create-scenario`, `create-agent`, `assess`, and `record`, spawn ONE
 `general-purpose` Agent and let it run the corresponding self-contained
-`SKILL.md`. Brief it minimally — the SKILL.md carries the full contract:
+`SKILL.md`. Brief it minimally — the SKILL.md carries the full contract — but
+ALWAYS bind its working directory explicitly. A spawned agent does **not**
+inherit the dispatcher's cwd: it starts in the main checkout even when you are
+in a worktree. Pass the absolute repo root and make the subagent `cd` there and
+assert the branch BEFORE any `git` or `of` write. Skipping this once landed 43
+cells on `main` instead of the worktree. Compute the root once
+(`git rev-parse --show-toplevel`) and substitute it for `<repo-root>`:
 
 ```
 Agent(
   subagent_type: "general-purpose",
   description: "<verb> <agent>/<scenario>",
   prompt: "Read and execute .claude/skills/ir:onboarding-factory/<verb>/SKILL.md.
+           Repo root: <repo-root>. FIRST cd there, then assert
+           `git rev-parse --show-toplevel` == <repo-root> and
+           `git branch --show-current` == <branch>; abort if either differs.
+           Run every of/git command from that root.
            Inputs: agent=<agent> scenario=<scenario>.
            Follow it exactly and return ONLY the summary it specifies."
 )
@@ -95,15 +105,22 @@ reporting "done". `display_state` ∈ `observed` (terminal),
 
 ## Parallelism + ordering rules for sweeps
 
-- **`assess` fans out.** It is read-only (web + file research, no daemon), so
-  dispatch assess cells in parallel waves to save wall-clock.
-- **`record` is serialized.** It drives a live CLI under the single
-  `--attach` daemon; concurrent recordings on one daemon interleave. Run record
-  cells one at a time.
-- **Commit assessments before the first record.** `assess` writes cell
-  `metadata.json` + `expected.jsonl` via `of`, dirtying `replaydata/`; the
-  recording precheck refuses a dirty `replaydata/` tree. So land the assessment
-  commits first, then record.
+- **`assess` fans out; the PARENT commits.** assess is read-only of the live
+  system (web + file research, no daemon), so dispatch assess cells in parallel
+  waves to save wall-clock. But an assess subagent only WRITES its cell (via
+  `of cell write` / `of cell spec`) — it does **not** commit. N parallel
+  `git commit`s on one worktree race, scramble attribution, and once stranded a
+  wave mid-`reset`. After each wave returns, the parent stages and commits the
+  cells serially (one commit per cell). Committing is version control, not
+  authoring — the iron rule forbids the parent *authoring* `replaydata/`, not
+  committing what the subagents already wrote through `of`.
+- **`record` is serialized and self-commits.** It drives a live CLI under the
+  single `--attach` daemon; concurrent recordings on one daemon interleave. Run
+  record cells one at a time. Because record is serial there is no commit race,
+  so the record subagent commits its own recording (part of its contract).
+- **Commit every assessment before the first record.** Cell `metadata.json` +
+  `expected.jsonl` dirty `replaydata/`; the recording precheck refuses a dirty
+  tree. So land all the parent-side assessment commits first, then record.
 - After a `record` subagent returns, the recording is already committed (part
   of its contract). Don't re-stage, re-diff, or re-commit — just relay the
   summary.
@@ -116,6 +133,23 @@ asks the dispatcher a question — it runs to a terminal outcome and returns
 `status: prereq_blocked` with the concrete blocker in `notes`. The dispatcher
 surfaces that line to the human and moves on to the next cell. `of record
 prereq-check --agent <agent>` lists an agent's known prerequisites up front.
+
+## Filing daemon-bug issues (parent step, with consent)
+
+A `record` subagent CANNOT file GitHub issues — outward-facing writes are denied
+in its permission context, so for a `daemon=bug` cell it returns an `issue:`
+payload (a temp-file body + a one-line title) instead of filing it. When a
+record return carries a non-`none` `issue:`, the dispatcher — not the subagent —
+files it: show the user the title + body, and ONLY on their confirmation run
+
+```bash
+gh issue create --repo ingo-eichhorst/Irrlicht --label bug \
+  --title "<title from the payload>" --body-file "<path from the payload>"
+```
+
+Report the new issue number to the user. Wiring the number back into the cell,
+if wanted, is a follow-up `assess`/`record` touch (a subagent) — the dispatcher
+never authors `replaydata/`.
 
 ## Orchestrators (inline — no subagent)
 

--- a/.claude/skills/ir:onboarding-factory/assess/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/assess/SKILL.md
@@ -99,8 +99,8 @@ would prove this?" then "does this adapter's parser produce that event today?"
 
 - yes for all, handled correctly → `daemon=full`.
 - a trace exists but the daemon mis-handles a spec-required observable →
-  `daemon=bug` (cite the event; the cell records `known_failing` and an issue is
-  filed in `record`).
+  `daemon=bug` (cite the event; the cell records `known_failing`, and `record`
+  hands an `issue:` payload back for the dispatcher to file).
 - no trace at all (cloud session with no local file; behavior the 3-state model
   can't represent) → `daemon=incapable`.
 
@@ -122,6 +122,14 @@ claudecode's recipe for the same scenario when one exists. For a cell asserting
 the full lifecycle arc, prefer an INTERACTIVE recipe when the agent's headless
 mode exits at turn completion (the process must outlive the daemon's observation
 window, or the settle/teardown phases validate as missing).
+
+Every interactive (`script`) recipe MUST carry the two fields the driver reads
+positionally: **`timeout_seconds`** (the per-cell turn budget in seconds — size
+it to the scenario; 120 is the floor) and **`settings`** (the agent settings
+blob, or `{}` when none). `of cell write` defaults both when omitted and `of
+validate` REJECTS a script recipe missing `timeout_seconds` — its absence once
+reached a driver as the literal `null` and crashed it. Headless (`prompt`) and
+`applicable:false` recipes don't need them.
 
 Then judge the **driver** pillar against the agent's interactive driver:
 
@@ -195,32 +203,29 @@ mirror. (`of cell write` also forces `scenario_id`.)
       "caveats": ["..."],
       "sources": [{"kind":"url|file","ref":"...","note":"..."}]
     },
-    "recipe": { "script": [ {"type":"send","text":"..."}, {"type":"wait_turn"}, {"type":"sleep","seconds":10} ] }
+    "recipe": { "timeout_seconds": 120, "settings": {}, "script": [ {"type":"send","text":"..."}, {"type":"wait_turn"}, {"type":"sleep","seconds":10} ] }
   }
 }
 ```
 
-### 7. Surface recording prerequisites + commit
+### 7. Surface recording prerequisites — but do NOT commit
 
 If recording this cell needs a human action (auth switch, env var, mock,
 unavailable provider) name it — it becomes `prereqs` in your return and the
 dispatcher relays it to the human. If the cell is recordable now, `prereqs:
 none`.
 
-```bash
-git add replaydata/agents/<agent>/scenarios/
-git commit -m "feat(onboard): assess <agent>/<scenario> (recipe+spec)"
-git rev-parse --short HEAD
-```
+**Do NOT `git commit`.** You ran in a parallel assess wave, and N subagents
+committing the one worktree at once race (scrambled attribution, stranded
+resets). Write both artifacts via `of` and return — the **dispatcher** stages
+and commits each cell serially after the wave (it knows your cell from the
+dispatch). Leaving `replaydata/` dirty for the parent is correct here.
 
-> End commit messages with the trailer
-> `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
-
-**If the route is `frozen`, stop after the commit** — the metadata documents
-*why* the cell is frozen and what would unblock it; no spec phases are needed
-beyond the meta. **`driver-gap`** and **`record` / `record-known-failing`** all
-keep the recipe + spec so `record` can proceed (the driver-gap cell records the
-moment `record` ports the missing step).
+**If the route is `frozen`, you're done after the write** — the metadata
+documents *why* the cell is frozen and what would unblock it; no spec phases are
+needed beyond the meta. **`driver-gap`** and **`record` / `record-known-failing`**
+all keep the recipe + spec so `record` can proceed (the driver-gap cell records
+the moment `record` ports the missing step).
 
 ## Return contract
 
@@ -231,9 +236,8 @@ Return ONLY this (≤6 lines). Shared semantics + envelope rules live in
 verdict: agent=<v> daemon=<full|bug|incapable|n/a> driver=<ready|gap:*> (confidence <n>)
 route: record | record-known-failing | driver-gap | frozen
 summary: <one sentence — the load-bearing reason, citing the anchoring event/code for any non-full/non-ready verdict>
-wrote: metadata.json + expected.jsonl (via of cell write / of cell spec)
+wrote: metadata.json + expected.jsonl (via of cell write / of cell spec) — UNCOMMITTED; the dispatcher commits
 prereqs: <human action recording needs, or "none">
-commit_sha: <short sha>
 ```
 
 ## Anti-patterns

--- a/.claude/skills/ir:onboarding-factory/record/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/record/SKILL.md
@@ -145,14 +145,22 @@ of cell write --agent <agent> --scenario <scenario> --file /tmp/<agent>-<scenari
 ```
 
 Update the affected pillar, add a caveat citing the recording that proved it,
-and set `observability_correction` in your return. For a `daemon=bug` cell, file
-the issue and put its number in the spec meta `notes` + your return:
+and set `observability_correction` in your return. For a `daemon=bug` cell, do
+**not** run `gh issue create` — outward-facing writes are denied in your
+subagent permission context, so it silently degrades to a cell note and files
+nothing. Instead, write the issue body to a temp file and hand it back for the
+**dispatcher** to file (with the user's consent):
 
 ```bash
-gh issue create --repo ingo-eichhorst/Irrlicht --label bug \
-  --title "<agent>/<scenario>: daemon mis-handles <observable>" \
-  --body "<cited events.jsonl evidence + what the spec requires>"
+cat > /tmp/<agent>-<scenario>.issue.md <<'EOF'
+<cited events.jsonl evidence + what the spec requires>
+EOF
 ```
+
+Return it as the `issue:` payload (the path + a one-line title). Keep
+`known_failing` set in the spec meta with the bug behavior cited in `notes`; the
+issue number is wired into the cell by a later touch, once the dispatcher has
+filed it.
 
 ### 5. Refresh the replay golden (mandatory)
 
@@ -187,7 +195,7 @@ now also gates recording completeness — the newest recording must carry
 
 ## Return contract
 
-Return ONLY this (≤6 lines). Shared semantics + envelope rules live in
+Return ONLY this (≤7 lines). Shared semantics + envelope rules live in
 [`../return-contract.md`](../return-contract.md):
 
 ```
@@ -196,7 +204,8 @@ commit_sha: <short sha>            # the recording commit (or driver commit), "n
 pass_rate: <N/M phases>            # "n/a" for non-pass statuses
 observations: model=<ok|MISMATCH> cost=<ok|zero> tokens=<ok|zero> agent=<ok|MISMATCH>
 observability_correction: <none | the live recording overrode the assess verdict — e.g. assessed daemon=full but the store proved no trace (→ incapable/bug)>
-notes: <one or two sentences — drift flag, retry count, issue #, or infra/prereq reason>
+issue: <none | /tmp/<agent>-<scenario>.issue.md title="<one-line title>">   # daemon=bug only; the dispatcher files it
+notes: <one or two sentences — drift flag, retry count, infra/prereq reason>
 ```
 
 ## Anti-patterns
@@ -211,6 +220,9 @@ notes: <one or two sentences — drift flag, retry count, issue #, or infra/prer
   step won't appear on a re-run; port it (Step 1) or return.
 - **Don't rebase `expected.jsonl`** to make a failing verify pass — flag the
   drift, don't paper over it.
+- **Don't run `gh issue create`** — outward-facing writes are denied in your
+  context, so it files nothing. Return the `issue:` payload and let the
+  dispatcher file it with the user's consent.
 - **Don't run an isolated daemon while production `irrlichd` is up** — use
   `--attach`.
 - **Don't skip the golden refresh**, and **don't blanket-regenerate** goldens —

--- a/.claude/skills/ir:onboarding-factory/return-contract.md
+++ b/.claude/skills/ir:onboarding-factory/return-contract.md
@@ -38,6 +38,11 @@ lists its exact field set and points here for shared semantics.
   non-`none` value MUST be written back into the cell via `of cell write` in
   the SAME commit (correct the pillar, add a citing caveat) — the backflow
   loop, not a cue. `none` when the recording matched the assessment.
+- **`issue:`** (`record`) — a daemon-bug issue the subagent CANNOT file:
+  outward-facing writes are denied in the subagent context. The record subagent
+  writes the issue body to a temp file and returns `issue: <path> title="..."`;
+  the DISPATCHER files it via `gh issue create` with the user's consent (see the
+  dispatcher's issue-filing step). `none` for any cell that isn't `daemon=bug`.
 
 ## The three pillars (the assessment axes)
 
@@ -74,4 +79,4 @@ The canonical field list lives in each verb's own `## Return contract`:
 | `create-scenario` | `scenario_id:` | `wrote`, `acceptance`, `next` |
 | `create-agent` | `agent:` | `provider`, `prereqs`, `driver_needs`, `next` |
 | `assess` | `verdict:` + `route:` | `summary`, `wrote`, `prereqs` |
-| `record` | `status:` | `commit_sha`, `pass_rate`, `observations`, `observability_correction` |
+| `record` | `status:` | `commit_sha`, `pass_rate`, `observations`, `observability_correction`, `issue` |

--- a/replaydata/agents/aider/scenarios/5-8_task-estimate-marker/metadata.json
+++ b/replaydata/agents/aider/scenarios/5-8_task-estimate-marker/metadata.json
@@ -71,11 +71,6 @@
         "tmux available — the interactive driver runs aider in a tmux REPL so it stays alive across turns (the working→ready settle is idle-flush-bound and must be observed before teardown).",
         "irrlichd is recording — run-cell.sh in isolated mode, or --attach against a daemon started with --record."
       ],
-      "setup": [
-        "The interactive driver git-inits a fresh per-run cwd under <staging>/cwd/ and launches `aider --no-auto-commits --yes-always --no-gitignore` (plus --model if IRRLICHT_AIDER_MODEL is set) in a tmux session, waiting for the `> Repo-map:` banner before sending the first prompt.",
-        "The marker FORMAT rule lives in the human-seeded persistent CONVENTIONS.md (via ~/.aider.conf.yml `read:`), which survives into the run; the prompts below CUE each round so completed_rounds advances. As a belt-and-suspenders fallback the first send also restates the marker fenced so a stripped-config run still sees the literal HTML comment.",
-        "DAEMON NOW HANDLES THIS (was known_failing): commit 1ae457d9 ported the marker scan to the aider adapter — closeModelCall scans the full prose buffer before truncation, so a working aider session emits task_estimate. The spec asserts the correct behavior and record verifies it against the live recording (provisional on model emission only)."
-      ],
       "script": [
         {
           "type": "send",
@@ -109,7 +104,14 @@
           "type": "sleep",
           "seconds": 10
         }
-      ]
+      ],
+      "settings": {},
+      "setup": [
+        "The interactive driver git-inits a fresh per-run cwd under <staging>/cwd/ and launches `aider --no-auto-commits --yes-always --no-gitignore` (plus --model if IRRLICHT_AIDER_MODEL is set) in a tmux session, waiting for the `> Repo-map:` banner before sending the first prompt.",
+        "The marker FORMAT rule lives in the human-seeded persistent CONVENTIONS.md (via ~/.aider.conf.yml `read:`), which survives into the run; the prompts below CUE each round so completed_rounds advances. As a belt-and-suspenders fallback the first send also restates the marker fenced so a stripped-config run still sees the literal HTML comment.",
+        "DAEMON NOW HANDLES THIS (was known_failing): commit 1ae457d9 ported the marker scan to the aider adapter — closeModelCall scans the full prose buffer before truncation, so a working aider session emits task_estimate. The spec asserts the correct behavior and record verifies it against the live recording (provisional on model emission only)."
+      ],
+      "timeout_seconds": 120
     }
   }
 }

--- a/replaydata/agents/gemini-cli/scenarios/2-14_turn-aborted-by-error/metadata.json
+++ b/replaydata/agents/gemini-cli/scenarios/2-14_turn-aborted-by-error/metadata.json
@@ -75,7 +75,9 @@
           "type": "sleep",
           "seconds": 15
         }
-      ]
+      ],
+      "settings": {},
+      "timeout_seconds": 120
     }
   }
 }

--- a/replaydata/agents/gemini-cli/scenarios/2-1_basic-turn/metadata.json
+++ b/replaydata/agents/gemini-cli/scenarios/2-1_basic-turn/metadata.json
@@ -62,7 +62,9 @@
           "type": "sleep",
           "seconds": 8
         }
-      ]
+      ],
+      "settings": {},
+      "timeout_seconds": 120
     }
   }
 }

--- a/replaydata/agents/gemini-cli/scenarios/2-9_token-quota-exhausted/metadata.json
+++ b/replaydata/agents/gemini-cli/scenarios/2-9_token-quota-exhausted/metadata.json
@@ -109,6 +109,8 @@
           "seconds": 12
         }
       ],
+      "settings": {},
+      "timeout_seconds": 120,
       "verify": [
         "events.jsonl shows session_birth → prompt1 ready→working→ready arc (mock returns 200 + generateContent reply) → prompt2 ready→working arc (mock returns 429)",
         "prompt2 ends in process_exited (or a post-sweep working→ready) without sticking in working",

--- a/replaydata/agents/kiro-cli/scenarios/2-21_streaming-partial-writes/metadata.json
+++ b/replaydata/agents/kiro-cli/scenarios/2-21_streaming-partial-writes/metadata.json
@@ -72,7 +72,9 @@
           "type": "sleep",
           "seconds": 12
         }
-      ]
+      ],
+      "settings": {},
+      "timeout_seconds": 120
     }
   }
 }

--- a/replaydata/agents/opencode/scenarios/5-8_task-estimate-marker/metadata.json
+++ b/replaydata/agents/opencode/scenarios/5-8_task-estimate-marker/metadata.json
@@ -128,7 +128,9 @@
           "type": "sleep",
           "seconds": 12
         }
-      ]
+      ],
+      "settings": {},
+      "timeout_seconds": 120
     }
   }
 }

--- a/tools/onboarding-factory/cmd/of/main_test.go
+++ b/tools/onboarding-factory/cmd/of/main_test.go
@@ -181,6 +181,12 @@ func TestValidateCatchesViolations(t *testing.T) {
 			_ = os.Remove(filepath.Join(r, "replaydata", "agents", "claudecode",
 				"scenarios", "1-1_session-start", "recordings", "r1", "transcript.jsonl.replay.json.golden"))
 		}, "incomplete recording: missing transcript.jsonl.replay.json.golden"},
+		{"script recipe without timeout_seconds", func(r string) {
+			// A recipe that would be driven (non-empty script, not record_blocked)
+			// must carry a timeout_seconds — its absence crashed a driver.
+			write(t, filepath.Join(r, "replaydata", "agents", "claudecode", "scenarios", "1-1_session-start", "metadata.json"),
+				`{"scenario_id":"session-start","details":{"recipe":{"script":[{"type":"send","text":"hi"}]}}}`)
+		}, "omits timeout_seconds"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tools/onboarding-factory/cmd/of/recipe.go
+++ b/tools/onboarding-factory/cmd/of/recipe.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"irrlicht/tools/onboarding-factory/internal/shard"
+)
+
+// A recipe (details.recipe) is the per-cell driver program run-cell.sh feeds to
+// the agent's interactive driver. The driver reads timeout_seconds and settings
+// positionally; a recipe that carried a script but omitted timeout_seconds once
+// reached a driver as the literal "null" and crashed it (`null: unbound
+// variable`). These helpers make the factory — the only sanctioned writer —
+// default those fields on write and reject a missing timeout_seconds on
+// validate, so a malformed recipe never reaches a driver.
+
+// recipeWouldDrive reports whether a recipe will actually be driven: it carries
+// a non-empty script AND is not record_blocked (applicable:false). Headless and
+// record_blocked recipes never reach a driver, so their fields aren't required.
+func recipeWouldDrive(r map[string]json.RawMessage) bool {
+	if raw, ok := r["applicable"]; ok {
+		var b *bool
+		if json.Unmarshal(raw, &b) == nil && b != nil && !*b {
+			return false // applicable:false → record_blocked, never driven
+		}
+	}
+	if raw, ok := r["script"]; ok {
+		var steps []json.RawMessage
+		if json.Unmarshal(raw, &steps) == nil && len(steps) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultRecipeFields fills the driver-consumed fields a script recipe omits:
+// timeout_seconds (→ 120, the same floor run-cell.sh applies at runtime) and
+// settings (→ {}). It only touches a recipe that would actually be driven, and
+// only adds an ABSENT field — an explicit value is never overwritten. No-op when
+// the cell has no recipe or the recipe isn't a JSON object (validate surfaces
+// the latter).
+func defaultRecipeFields(cell *shard.ShardAgent) {
+	if len(cell.Details.Recipe) == 0 {
+		return
+	}
+	var r map[string]json.RawMessage
+	if json.Unmarshal(cell.Details.Recipe, &r) != nil {
+		return
+	}
+	if !recipeWouldDrive(r) {
+		return
+	}
+	changed := false
+	if _, ok := r["timeout_seconds"]; !ok {
+		r["timeout_seconds"] = json.RawMessage("120")
+		changed = true
+	}
+	if _, ok := r["settings"]; !ok {
+		r["settings"] = json.RawMessage("{}")
+		changed = true
+	}
+	if changed {
+		// Match the repo's writer style: don't HTML-escape <, >, & — recipes
+		// carry literal markers like the <!-- irrlicht-eta --> task marker, and
+		// the rest of of writes them unescaped (writeJSONFileAtomic does too).
+		var buf bytes.Buffer
+		enc := json.NewEncoder(&buf)
+		enc.SetEscapeHTML(false)
+		if enc.Encode(r) == nil {
+			cell.Details.Recipe = bytes.TrimRight(buf.Bytes(), "\n")
+		}
+	}
+}
+
+// recipeTimeoutFinding returns a validate finding when a recipe that would be
+// driven omits a positive numeric timeout_seconds — the field whose absence
+// crashed a driver. Empty string means no finding. settings is defaulted on
+// write but not gated here: a missing settings writes an empty file, not a
+// crash.
+func recipeTimeoutFinding(recipe json.RawMessage) string {
+	if len(recipe) == 0 {
+		return ""
+	}
+	var r map[string]json.RawMessage
+	if json.Unmarshal(recipe, &r) != nil {
+		return ""
+	}
+	if !recipeWouldDrive(r) {
+		return ""
+	}
+	raw, ok := r["timeout_seconds"]
+	if !ok {
+		return "recipe drives a script but omits timeout_seconds (the driver needs it; `of cell write` defaults it to 120)"
+	}
+	var n float64
+	if json.Unmarshal(raw, &n) != nil || n <= 0 {
+		return fmt.Sprintf("recipe timeout_seconds must be a positive number, got %s", string(raw))
+	}
+	return ""
+}

--- a/tools/onboarding-factory/cmd/of/validate.go
+++ b/tools/onboarding-factory/cmd/of/validate.go
@@ -178,6 +178,11 @@ func validateCells(repoRoot string, names map[string]bool, add func(path, msg st
 			} else if !names[cell.ScenarioID] {
 				add(rel+"/metadata.json", fmt.Sprintf("scenario_id %q not in the catalog", cell.ScenarioID))
 			}
+			// A recipe the driver will run must carry the fields the driver reads
+			// positionally — a missing timeout_seconds once crashed a driver.
+			if msg := recipeTimeoutFinding(cell.Details.Recipe); msg != "" {
+				add(rel+"/metadata.json", msg)
+			}
 			// A cell is "recorded" iff NewestRecordingDir resolves one — the SAME
 			// definition matrix.cellRecorded uses, so the two never disagree.
 			// (hasRecordings/dirHasChildren above is only for orphan detection:

--- a/tools/onboarding-factory/cmd/of/write.go
+++ b/tools/onboarding-factory/cmd/of/write.go
@@ -410,6 +410,9 @@ func runCellWrite(args []string, stdout, stderr io.Writer) int {
 	// overview tier so the two tiers can't drift — the author only has to get
 	// details.assessment right.
 	mirrorAssessmentPillars(&cell)
+	// Default the driver-consumed recipe fields a script recipe omits
+	// (timeout_seconds, settings) so a malformed recipe never reaches a driver.
+	defaultRecipeFields(&cell)
 	fold := resolveCellFolder(*repoRoot, *agent, sh, *folder)
 	metaPath := filepath.Join(*repoRoot, "replaydata", "agents", *agent, "scenarios", fold, "metadata.json")
 	if err := writeJSONFileAtomic(metaPath, cell); err != nil {

--- a/tools/onboarding-factory/cmd/of/write_test.go
+++ b/tools/onboarding-factory/cmd/of/write_test.go
@@ -110,6 +110,44 @@ func TestCellWriteFK(t *testing.T) {
 	}
 }
 
+func TestCellWriteDefaultsRecipeFields(t *testing.T) {
+	// writeRecipe writes a cell whose details.recipe is the given JSON, then
+	// returns the rendered metadata.json so callers assert on the defaults.
+	writeRecipe := func(t *testing.T, root, recipe string) string {
+		t.Helper()
+		cellFile := filepath.Join(t.TempDir(), "cell.json")
+		if err := os.WriteFile(cellFile, []byte(`{"details":{"recipe":`+recipe+`}}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if code, _, errs := runOf("cell", "write", "--agent", "claudecode", "--scenario", "basic-turn", "--file", cellFile, "--repo-root", root); code != exitOK {
+			t.Fatalf("cell write failed: %d %s", code, errs)
+		}
+		b, _ := os.ReadFile(filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", "2-1_basic-turn", "metadata.json"))
+		return string(b)
+	}
+	t.Run("script recipe gets timeout+settings defaults", func(t *testing.T) {
+		got := writeRecipe(t, validRepo(t), `{"script":[{"type":"send","text":"hi"}]}`)
+		if !strings.Contains(got, `"timeout_seconds": 120`) {
+			t.Fatalf("timeout_seconds not defaulted:\n%s", got)
+		}
+		if !strings.Contains(got, `"settings": {}`) {
+			t.Fatalf("settings not defaulted:\n%s", got)
+		}
+	})
+	t.Run("explicit values are preserved", func(t *testing.T) {
+		got := writeRecipe(t, validRepo(t), `{"timeout_seconds":240,"settings":{"k":"v"},"script":[{"type":"send","text":"hi"}]}`)
+		if !strings.Contains(got, `"timeout_seconds": 240`) {
+			t.Fatalf("explicit timeout overwritten:\n%s", got)
+		}
+	})
+	t.Run("record_blocked recipe is left alone", func(t *testing.T) {
+		got := writeRecipe(t, validRepo(t), `{"applicable":false,"script":[{"type":"send","text":"hi"}]}`)
+		if strings.Contains(got, `"timeout_seconds"`) {
+			t.Fatalf("record_blocked recipe should not be defaulted:\n%s", got)
+		}
+	})
+}
+
 func TestCellSpec(t *testing.T) {
 	root := validRepo(t)
 	specFile := filepath.Join(t.TempDir(), "expected.jsonl")


### PR DESCRIPTION
Tier 1 of #666 — the four `ir:onboarding-factory` process problems that caused real rework during the gemini-cli column run. (Tier 2/3 to follow as separate PRs.)

## Changes

**1. Subagent cwd/branch contract** (`SKILL.md`) — the "Dispatching a subagent" template now passes an absolute repo root and makes the subagent `cd` there and assert `git rev-parse --show-toplevel` + `git branch --show-current` before any `git`/`of` write. A spawned agent does **not** inherit the dispatcher's worktree — this once landed 43 cells on `main`.

**2. Parallel-assess vs per-subagent-commit contradiction** (`SKILL.md`, `assess/SKILL.md`) — assess subagents now **write but never commit**; the parent commits serially after each wave (N parallel `git commit`s on one worktree race). `record` stays serial and self-commits. Dropped `commit_sha` from the assess return, aligning with `return-contract.md`.

**3. Recipe field validation/default** (`cmd/of/recipe.go`, `write.go`, `validate.go`, `assess/SKILL.md`) — `of cell write` defaults the driver-consumed fields a script recipe omits (`timeout_seconds`→120, `settings`→`{}`); `of validate` rejects a script recipe missing `timeout_seconds`. Its absence once reached a driver as the literal `null` and crashed it (`null: unbound variable`). Guarded to recipes that actually reach a driver (non-empty `script`, not `applicable:false`); explicit values are never overwritten. Backfills the **6 latent cells** that lacked it (3 gemini-cli, kiro-cli, opencode, aider). Both fields documented as mandatory in the assess SKILL.

**4. Issue-filing dead code** (`record/SKILL.md`, `return-contract.md`, `SKILL.md`) — outward-facing writes are denied in the record subagent, so `gh issue create` there filed nothing. record now returns a structured `issue:` payload (temp-file body + title); a new dispatcher step files it **with the user's consent**.

## Verification
- `go test ./tools/onboarding-factory/... -race -count=1` ✓
- `of validate` ✓ (confirmed it flags exactly the 6 cells before the backfill)
- `bash tools/onboarding-factory/scripts/smoke-test.sh` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)