### PR TITLE
feat(onboard): Tier-2 onboarding-factory assess/create-agent defaults (#666)

### DIFF
--- a/.claude/skills/ir:onboarding-factory/assess/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/assess/SKILL.md
@@ -160,13 +160,34 @@ subsequent lines are phases:
 (`of cell spec` forces `scenario_id` onto the meta line — you don't write it.)
 
 - **Phases** assert the user-observable arc only: state transitions, distinct
-  session counts, parent-links, lifecycle. Anchor the FIRST phase to `"start"`
-  UNPINNED so a transient `proc-<PID>` presession row can't steal the birth and
-  cascade failures. No internal flags, event kinds, reasons, or rule numbers.
+  session counts, parent-links, lifecycle. No internal flags, event kinds,
+  reasons, or rule numbers. Anchor the birth by the adapter's session model:
+  - **Single-birth adapters** (a stable session_id from launch — e.g.
+    claudecode): anchor the FIRST phase to `"start"` UNPINNED so a transient
+    `proc-<PID>` presession row can't steal the birth and cascade failures.
+  - **Presession adapters** (a transient `proc-<PID>` row reconciles into a real
+    session with a DIFFERENT session_id — codex, gemini-cli): model the birth as
+    TWO phases and anchor every post-birth phase to the REAL session, never the
+    presession row (which never goes `working`):
+    ```jsonl
+    {"phase":"presession_birth","expected_state":"ready","relative_to":"start"}
+    {"phase":"session_birth","expected_state":"ready","relative_to":"presession_birth","new_session":true}
+    ... every later phase: "same_session_as":"session_birth" ...
+    ```
+    Collapsing these into a single birth (so `session_birth` lands on the
+    presession proc-row, which never goes `working`) is the miss that verified
+    nearly every multi-phase presession cell PARTIAL until `record` re-anchored
+    it. Template from the codex sibling spec.
 - **Observations** assert the websocket metric vector the verify engine checks —
   exact-match categorical fields (`model`, `agent`), non-zero + tolerance for
   `cost`/`tokens`. This is the widened verify the factory added: a recording is
   verified on token/usage/cost/model, not just lifecycle state.
+  **Don't hard-pin a doc-guessed `model`.** Vendor docs lag the binary, and a
+  wrong `model` exact-match fails every recording until `record` corrects it
+  (assessed `gemini-3-flash-preview`; reality `gemini-3.5-flash`). Pin `model`
+  only when you can confirm it from the live surface (the binary's strings, a
+  shipped config default); otherwise leave it provisional and let `record` fill
+  it from the recording. Never pin a `cost` figure — assert non-zero only.
 - For a `daemon=bug` cell, set `known_failing` in the meta and keep the spec
   asserting the CORRECT behavior — never weaken it to match the bug.
 
@@ -251,6 +272,9 @@ prereqs: <human action recording needs, or "none">
   mislabeling routes the fix to the wrong owner.
 - **Don't fabricate sources.** An empty/honest `sources` with low `confidence`
   beats a fake citation that poisons future re-assessments.
+- **Don't pin a doc-guessed `model`/`cost`.** Confirm `model` from the live
+  surface or leave it provisional for `record` to fill; assert `cost` non-zero,
+  never a figure. A doc-derived model string fails every recording's verify.
 - **Don't set `confidence` ≥ 0.9 from general knowledge.** That band is for "the
   docs literally say this" / "the source has the exact behavior." `0.7–0.85` is
   the honest band for a thorough multi-source read.

--- a/.claude/skills/ir:onboarding-factory/create-agent/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/create-agent/SKILL.md
@@ -76,6 +76,21 @@ of agent add --id <slug> --name "<Display Name>" --provider <provider> \
 of validate
 ```
 
+**Also register the slug in the tooling that hard-codes the adapter list.**
+There is no shared adapter registry yet, so a new column is invisible to two
+tools until its slug is added by hand (both rejected `gemini-cli` until patched):
+
+1. `tools/onboarding-factory/scripts/precheck.sh` — add `<slug>` to BOTH `case`
+   tables: the adapter-validation allowlist (`claudecode|codex|…)`) and the
+   CLI-bin/version table (`<slug>) CLI_BIN="<binary>"; VER_FIELD=<n> ;;`).
+2. `tools/onboarding-factory/cmd/replay/main.go` — add `<slug>.Agent()` to the
+   `allAgents` slice, add a `detectAdapter` case matching the agent's
+   session-storage path AND `replaydata/agents/<slug>/`, and — only if the
+   adapter needs a non-default transcript parser — a `parserFactories` entry.
+
+Until both are patched, `of record`'s precheck and the `replay` CLI reject the
+column.
+
 ### 3. Scaffold the interactive driver
 
 Copy the template into the agent folder and adapt the three agent-specific


### PR DESCRIPTION
Tier 2 of #666 — per-cell friction fixes from the gemini-cli column run. **Stacked on #682 (Tier 1)**; the base will retarget to `main` once #682 merges. Skill prose only.

## Changes

**5. Two-tier presession anchoring default** (`assess/SKILL.md`) — for adapters whose transient `proc-<PID>` row reconciles into a real session with a *different* session_id (codex, gemini-cli), the assess default is now `presession_birth` + `session_birth` (`new_session:true`), with every post-birth phase anchored to the REAL `session_birth` — never the presession proc-row (which never goes `working`). Collapsing them onto the proc-row is the miss that verified nearly every multi-phase presession cell PARTIAL. Single-birth adapters (claudecode) keep the unpinned-`start` rule.

**6. Don't pin doc-guessed observables** (`assess/SKILL.md`) — vendor docs lag the binary, so a wrong `model` exact-match fails every recording until `record` corrects it (assessed `gemini-3-flash-preview`; reality `gemini-3.5-flash`). Pin `model` only when confirmed from the live surface; otherwise leave it provisional for `record`. Assert `cost` non-zero, never a figure.

**7. New-column registration checklist** (`create-agent/SKILL.md`) — there is no shared adapter registry, so a new slug must be hand-added to `precheck.sh`'s two `case` tables and `replay`'s `allAgents` + `detectAdapter` (+ `parserFactories`), or both tools reject the column. (Chose the checklist over a shared-registry refactor — the latter is a larger follow-up.)

## Verification
- `of validate` ✓
- `bash tools/onboarding-factory/scripts/smoke-test.sh` ✓ (no script changes; prose only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)