### PR TITLE
fix(detector): freeze updated_at on no-op refresh so dead sessions age out (#667)

### DIFF
--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -112,6 +112,33 @@ func TestCheckPIDLiveness_StaleTranscript_Deleted(t *testing.T) {
 	}
 }
 
+// TestCheckPIDLiveness_DeadProcessWorking_Reaped guards the end-state the #667
+// fix relies on: once UpdatedAt is allowed to age (the activity bump no longer
+// refreshes it on no-op refresh passes), a working session with pid=0 whose
+// UpdatedAt is past readyTTL is reaped by the existing sweep — even with a fresh
+// transcript on disk, since the daemon can't probe liveness of a pid=0 session.
+func TestCheckPIDLiveness_DeadProcessWorking_Reaped(t *testing.T) {
+	tmp := t.TempDir()
+	transcript := filepath.Join(tmp, "gem.jsonl")
+	writeTranscript(t, transcript, time.Now()) // fresh transcript; only UpdatedAt is stale
+
+	repo := newMockRepo()
+	repo.states["gem"] = &session.SessionState{
+		SessionID:      "gem",
+		Adapter:        "gemini-cli",
+		State:          session.StateWorking,
+		PID:            0,
+		TranscriptPath: transcript,
+		UpdatedAt:      time.Now().Add(-11 * time.Minute).Unix(), // > 10m readyTTL
+	}
+
+	newPIDManagerForTest(repo).CheckPIDLiveness()
+
+	if repo.states["gem"] != nil {
+		t.Fatal("dead-process working session (pid=0, UpdatedAt past readyTTL) should be reaped")
+	}
+}
+
 // deadPIDForTest spawns and reaps a short-lived process, returning its PID.
 // Skips the test if the kernel races us and recycles the PID before we can
 // confirm it is dead — keeps the test deterministic.

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -410,6 +411,23 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 	// Refresh CWD/branch/project and metrics from transcript.
 	d.enricher.RefreshOnActivity(state, ev.TranscriptPath)
 
+	// Did this pass observe new transcript bytes? The 5s refreshStaleSessions
+	// ticker re-reads working sessions to recover missed tool-call events, but
+	// for a frozen transcript (e.g. a gemini-cli session whose process died
+	// mid-turn, pid=0) that re-read sees nothing new — yet the unconditional
+	// UpdatedAt bump below would refresh it to wall-clock "now" every tick,
+	// defeating the ready-TTL age-out that reaps dead sessions (issue #667).
+	// Track size on the persisted LastTranscriptSize so UpdatedAt advances only
+	// on real activity. Fail-open: a stat error counts as growth so we only ever
+	// suppress the bump when we positively confirm the transcript is unchanged.
+	transcriptGrew := true
+	if ev.TranscriptPath != "" {
+		if fi, err := os.Stat(ev.TranscriptPath); err == nil {
+			transcriptGrew = fi.Size() != state.LastTranscriptSize
+			state.LastTranscriptSize = fi.Size()
+		}
+	}
+
 	// Probe Bash background-process liveness (run_in_background). Must run
 	// after RefreshOnActivity (which recomputes metrics, clearing the flag)
 	// and before ClassifyState (whose IsAgentDone check reads it). Gated on
@@ -576,7 +594,6 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 			if newState == session.StateWaiting {
 				state.WaitingStartTime = &now
 			} else if newState == session.StateWorking {
-				state.LastTranscriptSize = 0
 				state.WaitingStartTime = nil
 			}
 		}
@@ -586,8 +603,15 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 	// plus file-based children from the repo). See ComputeSubagentSummary.
 	d.refreshSubagentSummary(state)
 
-	state.UpdatedAt = time.Now().Unix()
-	state.EventCount++
+	// Only treat this pass as an activity event when the transcript actually
+	// grew. A bare refresh-tick re-read of a frozen transcript leaves UpdatedAt
+	// alone so the ready-TTL age-out can reap dead sessions (issue #667). A real
+	// state transition still bumps UpdatedAt via the write inside the classify
+	// block above, so #445's process-exit settle is unaffected.
+	if transcriptGrew {
+		state.UpdatedAt = time.Now().Unix()
+		state.EventCount++
+	}
 	state.LastEvent = "transcript_activity"
 
 	if err := d.repo.Save(state); err != nil {

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -604,15 +604,16 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 	d.refreshSubagentSummary(state)
 
 	// Only treat this pass as an activity event when the transcript actually
-	// grew. A bare refresh-tick re-read of a frozen transcript leaves UpdatedAt
-	// alone so the ready-TTL age-out can reap dead sessions (issue #667). A real
-	// state transition still bumps UpdatedAt via the write inside the classify
-	// block above, so #445's process-exit settle is unaffected.
+	// grew. A bare refresh-tick re-read of a frozen transcript leaves the
+	// activity markers (UpdatedAt / EventCount / LastEvent) alone so the
+	// ready-TTL age-out can reap dead sessions (issue #667). A real state
+	// transition still bumps UpdatedAt via the write inside the classify block
+	// above, so #445's process-exit settle is unaffected.
 	if transcriptGrew {
 		state.UpdatedAt = time.Now().Unix()
 		state.EventCount++
+		state.LastEvent = "transcript_activity"
 	}
-	state.LastEvent = "transcript_activity"
 
 	if err := d.repo.Save(state); err != nil {
 		d.log.LogError("session-detector", ev.SessionID,

--- a/core/application/services/session_detector_dead_process_test.go
+++ b/core/application/services/session_detector_dead_process_test.go
@@ -1,0 +1,112 @@
+package services_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+)
+
+// TestSessionDetector_Activity_FrozenTranscript_DoesNotBumpUpdatedAt is the
+// regression test for issue #667. A gemini-cli session whose process died
+// mid-turn (pid=0, transcript frozen on a function_call_output) stays working,
+// and the 5s refreshStaleSessions ticker re-reads its frozen transcript. That
+// re-read used to refresh UpdatedAt to wall-clock "now" every pass, so the
+// ready-TTL age-out (which measures now-UpdatedAt) never fired and the session
+// was pinned working forever (~23h observed).
+//
+// The fix gates the activity bump on real transcript growth. A no-op refresh
+// over a frozen transcript must touch neither UpdatedAt nor EventCount; a pass
+// that observes new bytes must bump both. The state machine still runs every
+// pass, so a genuine transition is unaffected.
+func TestSessionDetector_Activity_FrozenTranscript_DoesNotBumpUpdatedAt(t *testing.T) {
+	dir := t.TempDir()
+	tp := filepath.Join(dir, "gem.jsonl")
+	if err := os.WriteFile(tp, []byte("{\"type\":\"user\"}\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	tw := newMockAgentWatcher().withIdentity(agent.Identity{Name: "gemini-cli"})
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	det := newDetector(tw, pw, repo)
+
+	// gemini-cli dead-process shape: working, pid=0, last real event was a tool
+	// result. LastTranscriptSize=0 so the first activity pass sees growth.
+	oldTs := time.Now().Add(-time.Hour).Unix()
+	repo.states["gem"] = &session.SessionState{
+		SessionID:          "gem",
+		Adapter:            "gemini-cli",
+		State:              session.StateWorking,
+		PID:                0,
+		TranscriptPath:     tp,
+		FirstSeen:          oldTs,
+		UpdatedAt:          oldTs,
+		LastTranscriptSize: 0,
+		Metrics: &session.SessionMetrics{
+			HasOpenToolCall: false,
+			LastEventType:   "function_call_output",
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	defer func() { cancel(); <-done }()
+
+	// Let seedFromDisk finish (it re-reads metrics but never bumps EventCount /
+	// LastTranscriptSize) before injecting activity.
+	time.Sleep(50 * time.Millisecond)
+
+	// Terminal:true bypasses the activity debounce so each event is processed
+	// immediately and synchronously on the Run goroutine — no 2s coalescing
+	// timer, so the frozen-vs-grown passes are deterministic. Terminal is read
+	// only by the debounce fast-path; it does not affect classification.
+	activity := func() agent.Event {
+		return agent.Event{Type: agent.EventActivity, SessionID: "gem", TranscriptPath: tp, Terminal: true}
+	}
+
+	// Pass A — the transcript grew (0 → S1): UpdatedAt and EventCount must bump.
+	tw.ch <- activity()
+	waitForCondition(func() bool { return repo.eventCountOf("gem") == 1 }, 2*time.Second)
+	if got := repo.eventCountOf("gem"); got != 1 {
+		t.Fatalf("grown transcript: EventCount = %d, want 1", got)
+	}
+	tsA := repo.updatedAtOf("gem")
+	if tsA <= oldTs {
+		t.Fatalf("grown transcript did not advance UpdatedAt: got %d, want > %d", tsA, oldTs)
+	}
+
+	// Pass B — the transcript is frozen (size unchanged): no bump. The pass
+	// produces no observable field change, so wait on the Save count.
+	savesBefore := repo.savesCount()
+	tw.ch <- activity()
+	waitForCondition(func() bool { return repo.savesCount() > savesBefore }, 2*time.Second)
+	if got := repo.eventCountOf("gem"); got != 1 {
+		t.Fatalf("frozen transcript bumped EventCount: got %d, want 1 (unchanged)", got)
+	}
+	if got := repo.updatedAtOf("gem"); got != tsA {
+		t.Fatalf("frozen-transcript refresh bumped UpdatedAt: got %d, want %d (unchanged)", got, tsA)
+	}
+
+	// Pass C — append new bytes, then refresh: bumping must resume.
+	f, err := os.OpenFile(tp, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open transcript for append: %v", err)
+	}
+	if _, err := f.WriteString("{\"type\":\"assistant\"}\n"); err != nil {
+		t.Fatalf("append transcript: %v", err)
+	}
+	_ = f.Close()
+
+	tw.ch <- activity()
+	waitForCondition(func() bool { return repo.eventCountOf("gem") == 2 }, 2*time.Second)
+	if got := repo.eventCountOf("gem"); got != 2 {
+		t.Fatalf("grown transcript after freeze: EventCount = %d, want 2", got)
+	}
+}

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -114,6 +114,26 @@ func (r *mockRepo) eventCountOf(sessionID string) int {
 	return 0
 }
 
+// savesCount reads the total Save count under r.mu — the race-free signal a
+// test uses to wait out a processActivity pass that produces no observable
+// field change (e.g. a no-op refresh that is gated from bumping EventCount).
+func (r *mockRepo) savesCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.saves
+}
+
+// updatedAtOf reads a session's UpdatedAt under r.mu (race-free; background
+// goroutines mutate the shared *SessionState — issue #606).
+func (r *mockRepo) updatedAtOf(sessionID string) int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s, ok := r.states[sessionID]; ok {
+		return s.UpdatedAt
+	}
+	return 0
+}
+
 // waitForCondition polls fn until it returns true or the timeout elapses. The
 // generic poll-for-condition replacement for fixed sleeps in tests whose
 // completion signal isn't a saved State value (issue #606).


### PR DESCRIPTION
Fixes #667.

## Problem

A gemini-cli session whose process died mid-turn (`pid=0`, transcript frozen on a `function_call_output` tool result with no following assistant turn-completion) stayed pinned to `working` **forever** (observed ~23h).

The 5s `refreshStaleSessions` ticker re-reads each working session's transcript to recover missed tool-call events. For a **frozen** transcript that pass finds nothing new, yet `processActivityLocked` unconditionally ran `state.UpdatedAt = time.Now().Unix()`. So `updated_at` tracked the poll clock, not real events, and the ready-TTL age-out in `CheckPIDLiveness` (which measures `now - updated_at`) never crossed `readyTTL` (30m) and never reaped the dead session.

## Fix

Gate the activity-timestamp bump on **real transcript growth**, reusing the previously-dead `LastTranscriptSize` field as the baseline:

- A no-op refresh over a frozen transcript no longer touches `UpdatedAt`/`EventCount`.
- **Fail-open**: a `stat` error counts as growth, so the bump is suppressed only when the transcript is *positively* confirmed unchanged (existing tests with synthetic paths are unaffected).
- A genuine state transition still bumps `UpdatedAt` via the classify block, so #445's background-process-exit settle and #329's away-summary path are unaffected.

Once `updated_at` is allowed to age, the **existing** `CheckPIDLiveness` sweep reaps the `working`/`pid=0` session ~30m after its last real event — no change to the sweep. This is the issue's "fix b" (restore `updated_at` semantics); the user-chosen outcome is reap (the issue accepts "ready *or* reaped").

## Tests

- `session_detector_dead_process_test.go` (new) — a frozen re-read leaves `UpdatedAt`/`EventCount` unchanged while a grown transcript bumps them. Verified to **fail** without the gate (frozen pass bumps `EventCount`) and pass with it.
- `pid_manager_test.go` — guard locking in that a `working`+`pid=0` session past `readyTTL` is reaped.

`go test ./core/... -race -count=1` green; `go vet ./core/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)