### PR TITLE
feat(onboard): Tier-3 onboarding-factory efficiency (#666)

### DIFF
--- a/.claude/skills/ir:onboarding-factory/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/SKILL.md
@@ -97,8 +97,9 @@ of status --json                      # the whole matrix
 
 The cells whose `display_state` is **`pending-record`** are the record
 work-list; cells with no assessment yet are the assess work-list. Dispatch
-**one Agent per cell**, then re-run `of status` to confirm none remain before
-reporting "done". `display_state` ∈ `observed` (terminal),
+**one Agent per assess cell**; **`record` cells may be batched a few per
+subagent** (see the parallelism rules). Then re-run `of status` to confirm none
+remain before reporting "done". `display_state` ∈ `observed` (terminal),
 `pending-record` (→ assess or record), `blocked-daemon` / `blocked-driver` /
 `unobservable` / `n.a.` (terminal — documented, no recording), `unknown`
 (→ assess). A sweep is finished only when every cell is terminal.
@@ -118,6 +119,11 @@ reporting "done". `display_state` ∈ `observed` (terminal),
   single `--attach` daemon; concurrent recordings on one daemon interleave. Run
   record cells one at a time. Because record is serial there is no commit race,
   so the record subagent commits its own recording (part of its contract).
+- **Batch a few serial cells per `record` subagent.** A record subagent records
+  one cell at a time internally, so handing it ~4 cells per dispatch is far
+  cheaper on dispatcher context/turns than strict one-subagent-per-cell, with no
+  downside (the recordings still serialize). Keep batches small enough that the
+  ≤7-line returns stay legible — one return block per cell in the batch.
 - **Commit every assessment before the first record.** Cell `metadata.json` +
   `expected.jsonl` dirty `replaydata/`; the recording precheck refuses a dirty
   tree. So land all the parent-side assessment commits first, then record.

--- a/.claude/skills/ir:onboarding-factory/create-agent/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/create-agent/SKILL.md
@@ -93,20 +93,23 @@ column.
 
 ### 3. Scaffold the interactive driver
 
-Copy the template into the agent folder and adapt the three agent-specific
-seams (input mechanism, turn/effect detection, transcript export):
+Copy the template into the agent folder and substitute the agent slug:
 
 ```bash
 cp tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl \
    replaydata/agents/<slug>/driver-interactive.sh
+sed -i '' 's/__AGENT__/<slug>/g' replaydata/agents/<slug>/driver-interactive.sh
 chmod +x replaydata/agents/<slug>/driver-interactive.sh
 ```
 
-Start with the sparsest grammar that works (`send` / `wait_turn` / `sleep`) —
-new agents grow richer step types (`keys`, `interrupt`, `restart`,
-`reset_session`, …) as scenarios demand them. `record` ports each missing step
-from the claudecode/codex reference drivers when it hits a gap. Sanity-check:
-`bash -n replaydata/agents/<slug>/driver-interactive.sh`.
+The template scaffolds EVERY standard step-type arm (the multi-session ones
+stubbed `not_implemented`) and sources the shared `_lib/drive` slot model
+(`slots.sh` + `contracts.sh`), so a new column starts ON that model instead of
+needing a mid-run refactor. Fill the three agent-specific seams — launch,
+turn/effect detection, and session-id + transcript resolution
+(`SES_TRANSCRIPT[$ACTIVE]`) — then `record` ports each remaining multi-session
+arm from a slot-model reference driver (codex / gemini-cli) when a recipe hits a
+gap. Sanity-check: `bash -n replaydata/agents/<slug>/driver-interactive.sh`.
 
 ### 4. Predict driver-needs (the punch-list)
 

--- a/tools/onboarding-factory/cmd/of/recipe.go
+++ b/tools/onboarding-factory/cmd/of/recipe.go
@@ -74,6 +74,34 @@ func defaultRecipeFields(cell *shard.ShardAgent) {
 	}
 }
 
+// recipeTurnCount estimates how many agent turns (≈ requests) a recipe drives:
+// the count of wait_turn steps in its script. A recipe with no script (a
+// headless prompt cell) or one that doesn't parse counts as a single turn. Used
+// by `of record prereq-check` to size a column's request budget before a sweep.
+func recipeTurnCount(recipe json.RawMessage) int {
+	if len(recipe) == 0 {
+		return 1
+	}
+	var r struct {
+		Script []struct {
+			Type string `json:"type"`
+		} `json:"script"`
+	}
+	if json.Unmarshal(recipe, &r) != nil {
+		return 1
+	}
+	turns := 0
+	for _, s := range r.Script {
+		if s.Type == "wait_turn" {
+			turns++
+		}
+	}
+	if turns == 0 {
+		return 1
+	}
+	return turns
+}
+
 // recipeTimeoutFinding returns a validate finding when a recipe that would be
 // driven omits a positive numeric timeout_seconds — the field whose absence
 // crashed a driver. Empty string means no finding. settings is defaulted on

--- a/tools/onboarding-factory/cmd/of/record.go
+++ b/tools/onboarding-factory/cmd/of/record.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"irrlicht/tools/onboarding-factory/internal/matrix"
 	"irrlicht/tools/onboarding-factory/internal/shard"
 )
 
@@ -95,13 +96,45 @@ func runRecordPrereq(args []string, stdout, stderr io.Writer) int {
 	prereqs := readPrereqs(*repoRoot, *agent)
 	if len(prereqs) == 0 {
 		fmt.Fprintf(stdout, "%s: no recording prerequisites declared\n", *agent)
-		return exitOK
+	} else {
+		fmt.Fprintf(stdout, "%s recording prerequisites (verify before recording):\n", *agent)
+		for _, p := range prereqs {
+			fmt.Fprintf(stdout, "  - %s\n", p)
+		}
 	}
-	fmt.Fprintf(stdout, "%s recording prerequisites (verify before recording):\n", *agent)
-	for _, p := range prereqs {
-		fmt.Fprintf(stdout, "  - %s\n", p)
+	// Request-budget estimate: how many recordings the column's pending-record
+	// cells need, and a rough agent-request count (≈ turns across their recipes),
+	// so a per-day rate limit can be planned around BEFORE the sweep (the gemini
+	// free tier's 20-RPD wall hit mid-run). Informational — never a gate.
+	if cells, turns := estimateColumnBudget(*repoRoot, *agent); cells > 0 {
+		fmt.Fprintf(stdout, "recording budget: %d cell(s) pending-record, ~%d agent request(s) "+
+			"(turns across their recipes) — check this against any per-day rate limit before starting\n", cells, turns)
 	}
 	return exitOK
+}
+
+// estimateColumnBudget counts an agent's pending-record cells and sums their
+// estimated turns (≈ requests). Best-effort: a load error yields (0, 0), so
+// prereq-check degrades to listing prerequisites only.
+func estimateColumnBudget(repoRoot, agent string) (cells, turns int) {
+	m, err := matrix.LoadRepo(repoRoot)
+	if err != nil {
+		return 0, 0
+	}
+	recipes := shard.LoadAdapterCells(repoRoot, agent) // keyed by scenario_id (= name)
+	for _, sh := range shard.LoadAll(repoRoot) {
+		cs, ok := m.Cell(agent, sh.Name)
+		if !ok || cs.DisplayState != "pending-record" {
+			continue
+		}
+		cells++
+		if cell, ok := recipes[sh.Name]; ok {
+			turns += recipeTurnCount(cell.Details.Recipe)
+		} else {
+			turns++ // no recipe yet → assume one turn
+		}
+	}
+	return cells, turns
 }
 
 func runRecordRun(args []string, stdout, stderr io.Writer) int {

--- a/tools/onboarding-factory/cmd/of/record_test.go
+++ b/tools/onboarding-factory/cmd/of/record_test.go
@@ -63,6 +63,24 @@ func TestRecordPrereqCheck(t *testing.T) {
 	}
 }
 
+func TestRecordPrereqBudget(t *testing.T) {
+	root := recordRepo(t)
+	// An assessed-but-unrecorded claudecode cell for basic-turn (2 wait_turns)
+	// → pending-record, so prereq-check estimates the recording budget.
+	cell := filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", "2-1_basic-turn")
+	write(t, filepath.Join(cell, "metadata.json"), `{"scenario_id":"basic-turn","details":{`+
+		`"assessment":{"agent_supports":"yes","daemon_capability":"full","driver_capability":"ready"},`+
+		`"recipe":{"timeout_seconds":120,"settings":{},"script":[`+
+		`{"type":"send","text":"hi"},{"type":"wait_turn"},{"type":"send","text":"more"},{"type":"wait_turn"}]}}}`)
+	code, out, _ := runOf("record", "prereq-check", "--agent", "claudecode", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d out=%s", code, out)
+	}
+	if !strings.Contains(out, "1 cell(s) pending-record") || !strings.Contains(out, "~2 agent request") {
+		t.Fatalf("budget estimate missing/wrong: %s", out)
+	}
+}
+
 func TestRecordVerifyAlias(t *testing.T) {
 	root := recordRepo(t)
 	// give the session-start cell a golden + observations so verify has something

--- a/tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl
+++ b/tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl
@@ -6,14 +6,21 @@
 # which primitives still need porting, and the matrix can't silently freeze a
 # cell on a missing arm.
 #
+# It also starts ON the shared _lib/drive slot model (slots.sh + contracts.sh):
+# the multi-session bookkeeping and the staging-contract emission are already
+# wired, so porting a multi-session step is "fill the seam + call
+# alloc_slot/load_slot", never a mid-run refactor onto the slot model (#666).
+#
 # HOW TO USE THIS TEMPLATE
 #   cp scripts/templates/drive-interactive.sh.tmpl \
 #      scripts/drive-<agent>-interactive.sh
 #   sed -i '' 's/__AGENT__/<agent>/g' scripts/drive-<agent>-interactive.sh
 #   chmod +x scripts/drive-<agent>-interactive.sh
 # Then fill the three AGENT-SPECIFIC SEAMS marked TODO(__AGENT__) below by
-# porting from the reference drivers (drive-claudecode-interactive.sh, the
-# fullest; drive-codex-interactive.sh adds `fork`).
+# porting from the reference drivers. For the slot-model multi-session arms
+# (restart / resume / reset_session / start_session / session) read a slot-model
+# driver — drive-codex-interactive.sh or drive-gemini-cli-interactive.sh;
+# claudecode uses a different slot scheme and does NOT source _lib/drive.
 #
 # IMPORTANT — how a stubbed arm is caught: every standard arm is PRESENT here
 # (so recipe-lint's GRAMMAR check treats it as handled and will NOT report a
@@ -77,6 +84,25 @@ SCRIPT_JSON="$5"
 mkdir -p "$STAGING"
 DRIVER_LOG="$STAGING/driver.log"
 
+# Shared multi-session slot bookkeeping + staging-contract emission (#508 #3).
+# The scaffolded driver lives at replaydata/agents/<agent>/driver-interactive.sh,
+# so the lib is two dirs up under replaydata/_lib/drive. Sourcing it means a new
+# column starts ON the slot model: porting a multi-session step is "wire the seam
+# + call alloc_slot/load_slot", not rebuilding the slot bookkeeping (#666).
+_DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
+DRIVE_MARKER_PREFIX="$STAGING/.__AGENT__-marker"
+# shellcheck source=/dev/null
+source "$_DRIVE_LIB/slots.sh"
+# shellcheck source=/dev/null
+source "$_DRIVE_LIB/contracts.sh"
+
+# Slot state the lib reads/writes (the driver owns these globals). A run starts
+# with zero slots; launch_repl allocs slot 1, and restart/start_session alloc
+# more. ACTIVE indexes the live slot; SESSION/TRANSCRIPT/UUID mirror it.
+N_SLOTS=0; ACTIVE=0
+SES_SESSION=(); SES_TRANSCRIPT=(); SES_UUID=(); SES_EXPECTED=()
+SES_MARKER=(); SES_CWD=(); SES_ALIVE=()
+
 # recipe-lint contract (#508 #4): the step types this driver genuinely ELICITS,
 # read directly by recipe-lint (no separate manifest). Start with ONLY the seams
 # that actually work in this scaffold (send/slash/sleep) and add each primitive
@@ -105,7 +131,10 @@ not_implemented() { # <step-type>
 # (including a `set -e` abort mid-launch) and tear tmux down if a session was
 # started. Set EXIT_REASON before a failing `exit` so the reason is accurate.
 cleanup() {
-  [[ -n "$SESSION" ]] && tmux kill-session -t "$SESSION" 2>/dev/null || true
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
 trap cleanup EXIT
@@ -116,14 +145,19 @@ trap cleanup EXIT
 # preferred UUID if the agent accepts one. The cleanup trap above tears it down.
 launch_repl() {
   command -v tmux >/dev/null 2>&1 || { echo "[driver] tmux required" >&2; EXIT_REASON="nonzero(2)"; exit 1; }
-  SESSION="__AGENT__drv-$$-$(date +%s)"
+  # alloc_slot mints a fresh slot, points SESSION at its tmux name and ACTIVE at
+  # it, and clears the slot's TRANSCRIPT/UUID. restart/start_session call it again
+  # to open another session; per-slot stdout (.stdout.$ACTIVE) feeds the contract.
+  alloc_slot "__AGENT__drv-$$-$(date +%s)-$((N_SLOTS + 1))" "$RUN_CWD"
   tmux kill-session -t "$SESSION" 2>/dev/null || true
   # `|| { … exit … }` keeps a launch failure from aborting under set -e WITHOUT
   # an accurate exit-reason — the cleanup trap then records nonzero(2).
-  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "$RUN_CWD" "__AGENT__" \
-    >>"$DRIVER_LOG.stdout" 2>>"$DRIVER_LOG.stderr" \
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "__AGENT__" \
+    >>"$DRIVER_LOG.stdout.$ACTIVE" 2>>"$DRIVER_LOG.stderr" \
     || { echo "[driver] failed to launch __AGENT__ under tmux" >&2; EXIT_REASON="nonzero(2)"; exit 1; }
-  : # TODO(__AGENT__): resolve & record SESSION_ID + transcript path (SEAM 3) once the session is live
+  : # TODO(__AGENT__): resolve the live session_id + transcript path and store it
+    #   on the active slot — SES_TRANSCRIPT[$ACTIVE]=<abs path> (SEAM 3). The
+    #   staging contract + multi-session lists are derived from SES_TRANSCRIPT.
 }
 
 # --- AGENT-SPECIFIC SEAM 2: detect a completed turn --------------------------
@@ -152,22 +186,26 @@ while IFS= read -r step; do
     sleep)           sleep "$(jq -r '.seconds // 1' <<<"$step")" ;;
     interrupt)       not_implemented interrupt || break ;;       # TODO(__AGENT__): Escape/Ctrl-C the in-flight turn
     keys)            not_implemented keys || break ;;            # TODO(__AGENT__): tmux send-keys raw sequence
-    reset_session)   not_implemented reset_session || break ;;   # TODO(__AGENT__): in-REPL /clear|/new → new session id
-    restart)         not_implemented restart || break ;;         # TODO(__AGENT__): end + fresh session (new id, new cwd)
-    resume)          not_implemented resume || break ;;          # TODO(__AGENT__): relaunch same id+cwd
-    sigkill)         not_implemented sigkill || break ;;         # TODO(__AGENT__): kill -9 the session PID
+    reset_session)   not_implemented reset_session || break ;;   # TODO(__AGENT__): in-REPL /clear|/new → new id, SAME slot; re-resolve SES_TRANSCRIPT[$ACTIVE] (SEAM 3)
+    restart)         not_implemented restart || break ;;         # TODO(__AGENT__): save_active; alloc_slot <name> <new-cwd>; launch — new slot carries the new id
+    resume)          not_implemented resume || break ;;          # TODO(__AGENT__): relaunch same id+cwd (1 session, 2 PIDs) — reuse the active slot
+    sigkill)         not_implemented sigkill || break ;;         # TODO(__AGENT__): kill -9 the active slot's PID
     exit_clean)      not_implemented exit_clean || break ;;      # TODO(__AGENT__): Ctrl-D graceful shutdown
-    start_session)   not_implemented start_session || break ;;   # TODO(__AGENT__): concurrent session, keep first alive
-    session)         not_implemented session || break ;;         # TODO(__AGENT__): switch active slot
+    start_session)   not_implemented start_session || break ;;   # TODO(__AGENT__): save_active; alloc_slot; launch a CONCURRENT session, keep the first alive
+    session)         not_implemented session || break ;;         # TODO(__AGENT__): save_active; load_slot N — switch the active slot
     *)               echo "[driver] unknown step type: $type" >&2; EXIT_REASON="nonzero(2)"; break ;;
   esac
   (( $(remaining_seconds) <= 0 )) && { EXIT_REASON="timeout"; break; }
 done < <(jq -c '.[]' <<<"$SCRIPT_JSON")
 
-# --- Write the staging contract ----------------------------------------------
-# driver.exit-reason is written by the cleanup trap on exit (so it's recorded
-# even on an early failure). TODO(__AGENT__): write session.uuid(s) +
-# transcript.path(s) the daemon keyed on, exactly like the reference driver
-# (single-session: session.uuid + transcript.path; multi-session
-# reset/restart/start: session.uuids + transcript.paths, one per line).
-[[ "$EXIT_REASON" == "ok" ]] && exit 0 || exit 1
+# --- Write the staging contract (shared) -------------------------------------
+# emit_session_contract writes session.uuid + transcript.path (slot 1) plus the
+# multi-session session.uuids / transcript.paths lists from SES_TRANSCRIPT, and
+# combines the per-slot stdout (_lib/drive/contracts.sh). It needs each slot's
+# SES_TRANSCRIPT[$i] populated by SEAM 3; until that's ported the paths are empty
+# — the contract SHAPE is already correct, the scaffold just records nothing
+# useful yet. The primary id is the daemon's session_id — daemon_sid of the
+# transcript path; switch to the first-line UUID if __AGENT__ keys on that (see
+# drive-pi-interactive.sh). drive_exit maps EXIT_REASON → the process exit code.
+emit_session_contract "$(daemon_sid "${SES_TRANSCRIPT[1]}")"
+drive_exit


### PR DESCRIPTION
Tier 3 of #666 — efficiency fixes from the gemini-cli column run. **Stacked on #683 (Tier 2), which is stacked on #682 (Tier 1).** Merge #682 → #683 → this, retargeting each to `main` as its parent lands.

## Changes

**8. Driver scaffold starts on the shared slot model** (`scripts/templates/drive-interactive.sh.tmpl`, `create-agent/SKILL.md`) — the template now sources `_lib/drive/{slots.sh,contracts.sh}`, allocs slot 1 in `launch_repl`, tears down all slots in `cleanup`, and emits the staging contract via `emit_session_contract` + `drive_exit`. The multi-session arms stay `not_implemented`, but their TODOs now point at the slot helpers (`alloc_slot`/`save_active`/`load_slot`), so a new column ports a step by wiring the seam — not by refactoring onto the slot model mid-run (which a column had to do during the gemini run). `create-agent` step 3 updated, and it now substitutes `__AGENT__`.

**9. `of record prereq-check` estimates the request budget** (`cmd/of/record.go`, `recipe.go`) — counts the column's `pending-record` cells and sums their turns (≈ requests) so a per-day rate limit can be planned around up front (the gemini free-tier 20-RPD wall hit after 12 recordings). **Informational, never a gate** (per the no-cost-safeguards convention).

**10. Batching note** (`SKILL.md`) — a record subagent may batch ~4 serial cells (it serializes internally) — far cheaper on dispatcher context/turns with no downside.

## Verification
- `go test ./tools/onboarding-factory/... -race -count=1` ✓ (incl. a new `TestRecordPrereqBudget`)
- `of validate` ✓
- `bash tools/onboarding-factory/scripts/smoke-test.sh` ✓
- `bash -n` on the scaffolded template (raw + `__AGENT__`-substituted) ✓ — the `.tmpl` isn't covered by smoke-test's `*.sh` glob, so checked manually
- Live: `of record prereq-check --agent aider` → `recording budget: 1 cell(s) pending-record, ~4 agent request(s)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)