### PR TITLE
feat(macos): configurable context-fill alert threshold (#689)

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -205,6 +205,10 @@ class SessionManager: ObservableObject {
             "useLocalDaemon": true,
             "useRelayServer": false,
             "relayServerURL": "",
+            // Context-fill alert threshold (#689): default 80% preserves the
+            // historical first-alert point for existing users.
+            ContextPressureThreshold.valueKey: ContextPressureThreshold.defaultValue,
+            ContextPressureThreshold.unitKey: ContextPressureThreshold.defaultUnit.rawValue,
         ]
         for event in NotificationEvent.allCases {
             defaultsSeed[event.enabledKey] = false
@@ -1332,36 +1336,59 @@ class SessionManager: ObservableObject {
         }
     }
 
-    /// Checks active sessions for context utilization crossing 80% or 95% thresholds.
-    /// Fires a macOS notification the first time each threshold is crossed per session.
+    /// Checks active sessions for context usage reaching the configured alert
+    /// threshold (#689). Fires a macOS notification the first time the threshold
+    /// is reached per session. The fired-set is keyed by the active threshold
+    /// value, so changing the setting naturally re-arms the alert.
     private func checkContextPressureAlerts(sessions: [SessionState]) {
-        let thresholds = [80, 95]
+        let threshold = ContextPressureThreshold.current
+        let key = Int(threshold.value)
         for session in sessions {
             guard session.state == .working || session.state == .waiting,
                   let metrics = session.metrics,
-                  metrics.contextUtilization > 0 else { continue }
+                  threshold.isExceeded(by: metrics) else { continue }
 
-            let utilization = metrics.contextUtilization
             var fired = notifiedThresholds[session.id] ?? Set<Int>()
-
-            for threshold in thresholds where Double(threshold) <= utilization && !fired.contains(threshold) {
-                fired.insert(threshold)
-                notifiedThresholds[session.id] = fired
-                sendContextPressureNotification(session: session, threshold: threshold, utilization: utilization)
-            }
+            guard !fired.contains(key) else { continue }
+            fired.insert(key)
+            notifiedThresholds[session.id] = fired
+            sendContextPressureNotification(session: session, threshold: threshold, metrics: metrics)
         }
     }
 
-    private func sendContextPressureNotification(session: SessionState, threshold: Int, utilization: Double) {
+    private func sendContextPressureNotification(session: SessionState, threshold: ContextPressureThreshold, metrics: SessionMetrics) {
         guard UserDefaults.standard.bool(forKey: NotificationEvent.contextPressure.enabledKey) else { return }
         let label = session.projectName ?? session.shortId
+
+        let title: String
+        switch threshold.unit {
+        case .percent:
+            title = "Context pressure: \(Int(threshold.value))% threshold reached"
+        case .tokens:
+            title = "Context pressure: \(Self.formatTokens(Int64(threshold.value))) tokens reached"
+        }
+
+        // Prefer the percentage when the model's context window is known,
+        // otherwise report the raw token count so token-mode alerts on
+        // unknown-window models still read sensibly.
+        let usage = metrics.contextUtilization > 0
+            ? "at \(String(format: "%.1f%%", metrics.contextUtilization)) context"
+            : "at \(Self.formatTokens(metrics.totalTokens)) tokens"
+
         sendNotification(
-            identifier: "irrlicht-context-\(session.id)-\(threshold)",
-            title: "Context pressure: \(threshold)% threshold reached",
-            body: "\(label) is at \(String(format: "%.1f%%", utilization)) context. Consider switching to a fresh session.",
+            identifier: "irrlicht-context-\(session.id)-\(Int(threshold.value))",
+            title: title,
+            body: "\(label) is \(usage). Consider switching to a fresh session.",
             sessionID: session.id,
             event: .contextPressure
         )
+    }
+
+    /// Compact token count for notification copy (e.g. 150000 → "150K").
+    private static func formatTokens(_ count: Int64) -> String {
+        if count < 1000 { return "\(count)" }
+        if count < 1_000_000 { return String(format: "%.0fK", Double(count) / 1000) }
+        return String(format: "%.1fM", Double(count) / 1_000_000)
     }
 
     // MARK: - State Transition Notifications

--- a/platforms/macos/Irrlicht/Models/ContextPressureThreshold.swift
+++ b/platforms/macos/Irrlicht/Models/ContextPressureThreshold.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// The user-configurable threshold at which a session's context-fill alert
+/// fires — both the in-app row badge and the desktop notification. A single
+/// threshold, entered either as a percentage of the context window or as an
+/// absolute token count (issue #689).
+struct ContextPressureThreshold: Equatable {
+    enum Unit: String {
+        case percent
+        case tokens
+    }
+
+    var value: Double
+    var unit: Unit
+
+    static let defaultValue: Double = 80
+    static let defaultUnit: Unit = .percent
+
+    static let valueKey = "contextPressureThresholdValue"
+    static let unitKey = "contextPressureThresholdUnit"
+
+    /// A sensible starting value for each unit, used when the user switches the
+    /// unit in Settings (so percent→tokens doesn't leave "80 tokens" behind).
+    static func defaultValue(for unit: Unit) -> Double {
+        switch unit {
+        case .percent: return 80
+        case .tokens: return 150_000
+        }
+    }
+
+    /// Snapshot of the current config from `UserDefaults`. Falls back to the
+    /// defaults when unset or non-positive, so callers never read a 0 threshold
+    /// that would alert on every session.
+    static var current: ContextPressureThreshold {
+        let defaults = UserDefaults.standard
+        let raw = defaults.double(forKey: valueKey)
+        let value = raw > 0 ? raw : defaultValue
+        let unit = Unit(rawValue: defaults.string(forKey: unitKey) ?? "") ?? defaultUnit
+        return ContextPressureThreshold(value: value, unit: unit)
+    }
+
+    /// True once a session's context usage has reached the configured threshold.
+    /// Pure (no `UserDefaults`) so it is directly unit-testable. In percent mode
+    /// an unknown context window leaves `contextUtilization` at 0 and never
+    /// fires; token mode keys off the raw count and works regardless.
+    func isExceeded(by metrics: SessionMetrics) -> Bool {
+        switch unit {
+        case .percent:
+            return metrics.contextUtilization > 0 && metrics.contextUtilization >= value
+        case .tokens:
+            return metrics.totalTokens > 0 && Double(metrics.totalTokens) >= value
+        }
+    }
+}

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1131,10 +1131,19 @@ struct SessionRowView: View {
     @AppStorage("debugMode") private var debugMode: Bool = false
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
     @AppStorage("displayMode") private var displayModeRaw: String = DisplayMode.context.rawValue
+    @AppStorage(ContextPressureThreshold.valueKey) private var contextThresholdValue: Double = ContextPressureThreshold.defaultValue
+    @AppStorage(ContextPressureThreshold.unitKey) private var contextThresholdUnitRaw: String = ContextPressureThreshold.defaultUnit.rawValue
     @EnvironmentObject var sessionManager: SessionManager
     @State private var isHovered = false
 
     private var displayMode: DisplayMode { DisplayMode(rawValue: displayModeRaw) ?? .context }
+
+    private var contextThreshold: ContextPressureThreshold {
+        ContextPressureThreshold(
+            value: contextThresholdValue > 0 ? contextThresholdValue : ContextPressureThreshold.defaultValue,
+            unit: ContextPressureThreshold.Unit(rawValue: contextThresholdUnitRaw) ?? ContextPressureThreshold.defaultUnit
+        )
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -1321,14 +1330,13 @@ struct SessionRowView: View {
                     .tooltip(text)
             }
 
-            // Context pressure alert (80%+, active sessions only)
+            // Context pressure alert (configurable threshold, active sessions only — #689)
             if let metrics = session.metrics,
                (session.state == .working || session.state == .waiting),
-               metrics.contextUtilization >= 80 {
-                let isCritical = metrics.contextUtilization >= 95
-                let alertColor = isCritical ? IrrColors.pressureCritical : IrrColors.pressureHigh
+               contextThreshold.isExceeded(by: metrics) {
+                let alertColor = IrrColors.pressureHigh
                 HStack(spacing: 4) {
-                    Image(systemName: isCritical ? "exclamationmark.triangle.fill" : "exclamationmark.triangle")
+                    Image(systemName: "exclamationmark.triangle")
                         .font(.system(size: 9))
                         .foregroundColor(alertColor)
                     Text("Switch to a fresh session soon")
@@ -1341,7 +1349,7 @@ struct SessionRowView: View {
                 .background(alertColor.opacity(0.08))
                 .cornerRadius(IrrRadius.sm)
                 .padding(.top, 2)
-                .tooltip(isCritical ? "Context window critically full" : "Context window nearing limit")
+                .tooltip("Context window nearing limit")
             }
 
             // Task progress + completion ETA share one line: dots left, ETA

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -266,6 +266,8 @@ struct SettingsView: View {
                             sampleText: "Context pressure: 80% threshold reached",
                             onImportError: { customImportError = $0 }
                         )
+                        ContextThresholdRow(enabled: notifyOnContextPressure)
+                            .padding(.leading, 18)
 
                         if let error = customImportError {
                             Text(error)
@@ -503,6 +505,67 @@ private struct WindowAccessor: NSViewRepresentable {
         return v
     }
     func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+/// The "Alert at [value] [% / tokens]" control under the context-pressure
+/// notification row. One threshold, entered as a percentage of the context
+/// window or as an absolute token count (issue #689).
+private struct ContextThresholdRow: View {
+    @AppStorage(ContextPressureThreshold.valueKey) private var value: Double = ContextPressureThreshold.defaultValue
+    @AppStorage(ContextPressureThreshold.unitKey) private var unitRaw: String = ContextPressureThreshold.defaultUnit.rawValue
+    let enabled: Bool
+
+    @State private var draft: String = ""
+
+    private var unit: ContextPressureThreshold.Unit {
+        ContextPressureThreshold.Unit(rawValue: unitRaw) ?? ContextPressureThreshold.defaultUnit
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text("Alert at")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            TextField("", text: $draft)
+                .textFieldStyle(.roundedBorder)
+                .multilineTextAlignment(.trailing)
+                .font(.system(.caption, design: .monospaced))
+                .frame(width: 72)
+                .onChange(of: draft) { _ in commit() }
+                .onSubmit { commit(); draft = formatted(value) }
+                .tooltip(unit == .percent
+                    ? "Alert when context reaches this % of the window"
+                    : "Alert when the session reaches this many tokens")
+
+            Picker("", selection: $unitRaw) {
+                Text("%").tag(ContextPressureThreshold.Unit.percent.rawValue)
+                Text("tokens").tag(ContextPressureThreshold.Unit.tokens.rawValue)
+            }
+            .labelsHidden()
+            .frame(width: 92)
+            .onChange(of: unitRaw) { newRaw in
+                let newUnit = ContextPressureThreshold.Unit(rawValue: newRaw) ?? ContextPressureThreshold.defaultUnit
+                value = ContextPressureThreshold.defaultValue(for: newUnit)
+                draft = formatted(value)
+            }
+
+            Spacer()
+        }
+        .disabled(!enabled)
+        .onAppear { draft = formatted(value) }
+    }
+
+    private func formatted(_ v: Double) -> String { "\(Int(v))" }
+
+    private func commit() {
+        let trimmed = draft.trimmingCharacters(in: .whitespaces)
+        guard let parsed = Double(trimmed) else { return }
+        switch unit {
+        case .percent: value = min(max(parsed, 1), 99)
+        case .tokens: value = max(parsed, 1)
+        }
+    }
 }
 
 /// One row in the Settings notifications section: enable toggle, sound

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -516,6 +516,7 @@ private struct ContextThresholdRow: View {
     let enabled: Bool
 
     @State private var draft: String = ""
+    @FocusState private var fieldFocused: Bool
 
     private var unit: ContextPressureThreshold.Unit {
         ContextPressureThreshold.Unit(rawValue: unitRaw) ?? ContextPressureThreshold.defaultUnit
@@ -532,8 +533,11 @@ private struct ContextThresholdRow: View {
                 .multilineTextAlignment(.trailing)
                 .font(.system(.caption, design: .monospaced))
                 .frame(width: 72)
-                .onChange(of: draft) { _ in commit() }
-                .onSubmit { commit(); draft = formatted(value) }
+                .focused($fieldFocused)
+                .onSubmit { commit() }
+                .onChange(of: fieldFocused) { focused in
+                    if !focused { commit() }
+                }
                 .tooltip(unit == .percent
                     ? "Alert when context reaches this % of the window"
                     : "Alert when the session reaches this many tokens")
@@ -558,13 +562,18 @@ private struct ContextThresholdRow: View {
 
     private func formatted(_ v: Double) -> String { "\(Int(v))" }
 
+    /// Parse, clamp, and persist the draft, then reformat the field from the
+    /// stored value so it never displays a number that wasn't saved (an empty
+    /// or unparseable entry reverts to the current value).
     private func commit() {
         let trimmed = draft.trimmingCharacters(in: .whitespaces)
-        guard let parsed = Double(trimmed) else { return }
-        switch unit {
-        case .percent: value = min(max(parsed, 1), 99)
-        case .tokens: value = max(parsed, 1)
+        if let parsed = Double(trimmed) {
+            switch unit {
+            case .percent: value = min(max(parsed, 1), 99)
+            case .tokens: value = max(parsed, 1)
+            }
         }
+        draft = formatted(value)
     }
 }
 

--- a/platforms/macos/Tests/ContextPressureThresholdTests.swift
+++ b/platforms/macos/Tests/ContextPressureThresholdTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import Irrlicht
+
+final class ContextPressureThresholdTests: XCTestCase {
+
+    private func metrics(utilization: Double, tokens: Int64) -> SessionMetrics {
+        SessionMetrics(
+            elapsedSeconds: 0,
+            totalTokens: tokens,
+            modelName: "test",
+            contextWindow: nil,
+            contextUtilization: utilization,
+            pressureLevel: "unknown",
+            contextWindowUnknown: nil,
+            estimatedCostUSD: nil,
+            lastAssistantText: nil,
+            tasks: nil
+        )
+    }
+
+    // MARK: - Percent mode
+
+    func testPercentFiresAtAndAboveThreshold() {
+        let threshold = ContextPressureThreshold(value: 80, unit: .percent)
+        XCTAssertTrue(threshold.isExceeded(by: metrics(utilization: 80, tokens: 1000)))   // == fires
+        XCTAssertTrue(threshold.isExceeded(by: metrics(utilization: 92.5, tokens: 1000))) // above fires
+    }
+
+    func testPercentBelowThresholdDoesNotFire() {
+        let threshold = ContextPressureThreshold(value: 80, unit: .percent)
+        XCTAssertFalse(threshold.isExceeded(by: metrics(utilization: 79.9, tokens: 1000)))
+    }
+
+    func testPercentZeroUtilizationNeverFires() {
+        // An unknown context window leaves utilization at 0 — percent mode must
+        // not fire even when the raw token count is large.
+        let threshold = ContextPressureThreshold(value: 80, unit: .percent)
+        XCTAssertFalse(threshold.isExceeded(by: metrics(utilization: 0, tokens: 500_000)))
+    }
+
+    // MARK: - Tokens mode
+
+    func testTokensFiresAtAndAboveThreshold() {
+        let threshold = ContextPressureThreshold(value: 150_000, unit: .tokens)
+        // == fires, and works even when the window (percentage) is unknown.
+        XCTAssertTrue(threshold.isExceeded(by: metrics(utilization: 0, tokens: 150_000)))
+        XCTAssertTrue(threshold.isExceeded(by: metrics(utilization: 10, tokens: 200_000)))
+    }
+
+    func testTokensBelowThresholdDoesNotFire() {
+        let threshold = ContextPressureThreshold(value: 150_000, unit: .tokens)
+        XCTAssertFalse(threshold.isExceeded(by: metrics(utilization: 99, tokens: 149_999)))
+    }
+
+    func testTokensZeroNeverFires() {
+        let threshold = ContextPressureThreshold(value: 150_000, unit: .tokens)
+        XCTAssertFalse(threshold.isExceeded(by: metrics(utilization: 0, tokens: 0)))
+    }
+
+    // MARK: - Defaults
+
+    func testDefaultsPerUnit() {
+        XCTAssertEqual(ContextPressureThreshold.defaultValue(for: .percent), 80)
+        XCTAssertEqual(ContextPressureThreshold.defaultValue(for: .tokens), 150_000)
+        XCTAssertEqual(ContextPressureThreshold.defaultValue, 80)
+        XCTAssertEqual(ContextPressureThreshold.defaultUnit, .percent)
+    }
+}


### PR DESCRIPTION
Closes #689.

## What

The context-pressure alert — both the session-row badge ("Switch to a fresh session soon") and the desktop notification — was hardcoded to **80% / 95%**. This makes it a single **user-configurable threshold**, enterable as either a **percentage** of the context window or an **absolute token count**.

## Design decision

Per the issue's open question, collapsed to **one** threshold rather than two. This removes the old 95% "critical" escalation tier (red badge variant + second notification). Default stays **80%**, so existing users keep the familiar first alert.

Token mode also closes a real gap: percentage alerts can never fire when the model's context window is unknown (`contextWindowUnknown` → `contextUtilization` stays 0); a token threshold works regardless.

## Changes

- **New `ContextPressureThreshold`** value type (`value` + `unit`) as the single source of truth, with a pure, unit-testable `isExceeded(by:)`.
- **`SessionManager`** — seeds the 80%/percent default, drives `checkContextPressureAlerts` off the configured value (fires once per session; re-arms when the setting changes), and adapts the notification title/body to the unit (e.g. *"150K tokens reached"*, reporting raw tokens when no percentage is available).
- **`SessionListView`** — the row badge reads the threshold via `@AppStorage` (live-updating) and collapses to a single tier.
- **`SettingsView`** — new "Alert at `[value]` `[% / tokens]`" control under the context-pressure notification row, disabled when that notification is off.

## Testing

- New `ContextPressureThresholdTests` (7 cases): both units, boundaries (`==` fires, just-below doesn't), zero/unknown-window handling.
- Full macOS suite: **145 passed**, 0 failures (incl. snapshot + tooltip-lint suites).
- `go test ./core/... -race -count=1` ✅ (no Go changed; standard gate).
- Manually verified live via `/ir:test-mac`: badge + notification respond to the configured value, and unit-switching resets to a sensible default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)