### PR TITLE
perf(macos): coalesce WebSocket UI refreshes — ~100% → ~31% CPU under 40+ agents (#690)

### DIFF
--- a/go.work
+++ b/go.work
@@ -4,4 +4,5 @@ use (
 	./core
 	./tools/onboarding-factory
 	./tools/seed-demo-sessions
+	./tools/wsload
 )

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -1042,7 +1042,7 @@ class SessionManager: ObservableObject {
     /// (reset on every (re)connect). See #600.
     private var lastPushSeq: UInt64 = 0
 
-    private func handleWsMessage(_ text: String) {
+    func handleWsMessage(_ text: String) {
         guard let data = text.data(using: .utf8) else { return }
         do {
             let envelope = try JSONDecoder().decode(WsEnvelope.self, from: data)
@@ -1072,17 +1072,23 @@ class SessionManager: ObservableObject {
                         session = session.preservingRole(from: existing)
                     }
                     sessionMap[session.id] = session
-                    rebuildSessionsFromMap()
                     if isDebugMode {
                         let cost = session.metrics?.estimatedCostUSD ?? 0
                         let ctx = session.metrics?.contextUtilization ?? 0
                         let inGroups = groupedSessionIds.contains(session.id)
                         print("📨 session_updated id=\(session.id) state=\(session.state.rawValue) cost=\(cost) ctx=\(ctx) inGroupedIds=\(inGroups)")
                     }
-                    patchApiGroups(session: session)
+                    let stateChanged = oldState != nil && oldState != session.state
                     if let old = oldState, old != session.state {
                         checkStateTransitionNotification(session: session, previousState: old)
                     }
+                    // #690: coalesce the expensive rebuild + apiGroups patch. With
+                    // 40+ working agents each ticking metrics, this case used to
+                    // re-render the whole (eager, non-virtualized) list once per
+                    // push. Batch pure-metric updates into one refresh per window;
+                    // flush state transitions immediately so they stay snappy
+                    // (transitions fire at human pace, not metric-tick rate).
+                    enqueueUIRefresh(for: session.id, immediate: stateChanged)
                 }
             case "session_deleted":
                 if let session = envelope.session {
@@ -1232,6 +1238,67 @@ class SessionManager: ObservableObject {
             guard !Task.isCancelled else { return }
             await hydrateSessions()
         }
+    }
+
+    // MARK: - Coalesced UI refresh (#690)
+    //
+    // With 40+ working agents each emitting frequent metric ticks, every
+    // `session_updated` used to run a full `rebuildSessionsFromMap()` +
+    // `patchApiGroups()` and reassign @Published surfaces. Because each WS
+    // message resumes as its own @MainActor turn, SwiftUI re-rendered the whole
+    // (eager, non-virtualized) session list once per message — O(N) work × N
+    // pushes/sec. We coalesce pure-metric updates: accumulate dirty session ids
+    // and apply one rebuild + patch per refresh window, so render volume is
+    // bounded by the window, not the push rate. State transitions and the
+    // notifications that depend on them still fire synchronously at message
+    // time, so alerts and sounds are never delayed.
+
+    /// Session ids touched since the last flush.
+    private var pendingDirtySessionIDs = Set<String>()
+    /// True while a trailing flush is already scheduled (dedupes timers).
+    private var uiRefreshScheduled = false
+    /// Refresh window. Injectable so tests can flush deterministically.
+    var uiRefreshInterval: TimeInterval = 0.1
+    /// Count of coalesced flushes performed — test seam proving a burst of N
+    /// pushes collapses into far fewer renders.
+    private(set) var uiRefreshFlushCount = 0
+
+    /// Queue a session for the next coalesced UI refresh. `immediate` bypasses
+    /// the window (used for state transitions, which are rare and want to feel
+    /// instant); the metric-tick storm always coalesces.
+    private func enqueueUIRefresh(for sessionID: String, immediate: Bool) {
+        pendingDirtySessionIDs.insert(sessionID)
+        if immediate {
+            flushUIRefresh()
+            return
+        }
+        guard !uiRefreshScheduled else { return }
+        uiRefreshScheduled = true
+        Timer.scheduledTimer(withTimeInterval: uiRefreshInterval, repeats: false) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.flushUIRefresh() }
+        }
+    }
+
+    /// Apply all pending session updates in one pass: a single flat-surface
+    /// rebuild plus an in-place apiGroups patch per dirty session. The multiple
+    /// @Published mutations in this one synchronous turn coalesce into a single
+    /// SwiftUI render.
+    private func flushUIRefresh() {
+        uiRefreshScheduled = false
+        guard !pendingDirtySessionIDs.isEmpty else { return }
+        let dirty = pendingDirtySessionIDs
+        pendingDirtySessionIDs.removeAll()
+        uiRefreshFlushCount += 1
+        rebuildSessionsFromMap()
+        for id in dirty {
+            guard let session = sessionMap[id] else { continue }
+            patchApiGroups(session: session)
+        }
+    }
+
+    /// Test seam: synchronously apply any pending coalesced refresh.
+    func flushPendingUIRefreshForTests() {
+        flushUIRefresh()
     }
 
     private func rebuildSessionsFromMap() {
@@ -1546,7 +1613,9 @@ class SessionManager: ObservableObject {
 
         orderedSessions.append(contentsOf: sortedNewSessions)
 
-        print("🔢 Sorted \(orderedSessions.count) sessions (\(sessionOrder.count) from saved order, \(sortedNewSessions.count) new)")
+        if irrlichtVerboseLogging {
+            print("🔢 Sorted \(orderedSessions.count) sessions (\(sessionOrder.count) from saved order, \(sortedNewSessions.count) new)")
+        }
         return orderedSessions
     }
 

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -1248,10 +1248,11 @@ class SessionManager: ObservableObject {
     // message resumes as its own @MainActor turn, SwiftUI re-rendered the whole
     // (eager, non-virtualized) session list once per message — O(N) work × N
     // pushes/sec. We coalesce pure-metric updates: accumulate dirty session ids
-    // and apply one rebuild + patch per refresh window, so render volume is
-    // bounded by the window, not the push rate. State transitions and the
-    // notifications that depend on them still fire synchronously at message
-    // time, so alerts and sounds are never delayed.
+    // and apply one rebuild + one batched patch per refresh window, so render
+    // volume is bounded by the window, not the push rate. State transitions and
+    // the notifications that depend on them (ready/waiting sounds and banners)
+    // still fire synchronously at message time; only context-pressure alerts —
+    // which ride `rebuildSessionsFromMap` — are deferred, by at most one window.
 
     /// Session ids touched since the last flush.
     private var pendingDirtySessionIDs = Set<String>()
@@ -1280,9 +1281,8 @@ class SessionManager: ObservableObject {
     }
 
     /// Apply all pending session updates in one pass: a single flat-surface
-    /// rebuild plus an in-place apiGroups patch per dirty session. The multiple
-    /// @Published mutations in this one synchronous turn coalesce into a single
-    /// SwiftUI render.
+    /// rebuild plus one batched apiGroups patch. Both surfaces reassign in this
+    /// one synchronous turn, so SwiftUI coalesces them into a single render.
     private func flushUIRefresh() {
         uiRefreshScheduled = false
         guard !pendingDirtySessionIDs.isEmpty else { return }
@@ -1290,9 +1290,24 @@ class SessionManager: ObservableObject {
         pendingDirtySessionIDs.removeAll()
         uiRefreshFlushCount += 1
         rebuildSessionsFromMap()
-        for id in dirty {
-            guard let session = sessionMap[id] else { continue }
-            patchApiGroups(session: session)
+        patchApiGroups(sessions: dirty.compactMap { sessionMap[$0] })
+    }
+
+    /// Batch counterpart to `patchApiGroups(session:)` for the coalesced flush:
+    /// applies every dirty session to the group tree in a single map pass and
+    /// recomposes once, rather than one full map + recompose per session (#690).
+    /// A session with no row yet (created mid-window) self-heals via the same
+    /// debounced rehydration the single-session path uses.
+    private func patchApiGroups(sessions: [SessionState]) {
+        let present = sessions.filter { groupedSessionIds.contains($0.id) }
+        if !present.isEmpty {
+            localApiGroups = localApiGroups.map { group in
+                present.reduce(group) { patchGroup($0, with: $1) }
+            }
+            recomposeApiGroups()
+        }
+        if sessions.contains(where: { !groupedSessionIds.contains($0.id) }) {
+            scheduleRehydration()
         }
     }
 
@@ -1783,9 +1798,7 @@ class SessionManager: ObservableObject {
 
     // MARK: - Debug State Dump (IRRLICHT_DEBUG=1)
 
-    private var isDebugMode: Bool {
-        ProcessInfo.processInfo.environment["IRRLICHT_DEBUG"] == "1"
-    }
+    private var isDebugMode: Bool { irrlichtVerboseLogging }
 
     /// Writes current session state to ~/.irrlicht/debug-state.json when IRRLICHT_DEBUG=1.
     /// Agents can verify UI state with: cat ~/.irrlicht/debug-state.json

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -3,6 +3,12 @@ import Foundation
 import SwiftUI
 import os
 
+/// Verbose per-message/per-render debug logging, enabled with `IRRLICHT_DEBUG=1`.
+/// A global initializes lazily exactly once, so the hot decode/render path — which
+/// runs on every WebSocket push — reads a cached flag instead of re-checking the
+/// environment per call (#690).
+let irrlichtVerboseLogging = ProcessInfo.processInfo.environment["IRRLICHT_DEBUG"] == "1"
+
 /// Branding for one inbound agent adapter, served by the daemon's
 /// GET /api/v1/agents endpoint. Co-locating display name + icon SVGs with
 /// the Go adapter (issue #260) lets a Go-only contributor add a new adapter
@@ -726,14 +732,12 @@ struct SessionState: Identifiable, Codable {
             updatedAt = Date()
         }
         
-        // Log session data for debugging (after all properties are set)
-        let sessionId = id
-        let sessionState = state.rawValue
-        let topLevelModel = model
-        let metricsModelName = metrics?.modelName ?? "nil"
-        let safeEventCount = eventCount ?? 0
-        let safeLastEvent = lastEvent ?? "nil"
-        print("🔍 Decoded session: id=\(sessionId), state=\(sessionState), topLevelModel=\(topLevelModel), metricsModel=\(metricsModelName), eventCount=\(safeEventCount), lastEvent=\(safeLastEvent)")
+        // Log session data for debugging (after all properties are set). Gated:
+        // this fires on every decode (one per WebSocket push), so leaving it
+        // unconditional burns real CPU under many-agent load (#690).
+        if irrlichtVerboseLogging {
+            print("🔍 Decoded session: id=\(id), state=\(state.rawValue), topLevelModel=\(model), metricsModel=\(metrics?.modelName ?? "nil"), eventCount=\(eventCount ?? 0), lastEvent=\(lastEvent ?? "nil")")
+        }
     }
     
     // Regular initializer for testing/preview purposes
@@ -900,7 +904,9 @@ struct SessionState: Identifiable, Codable {
     var effectiveModel: String {
         // Prefer metrics.model_name if available, otherwise fall back to top-level model
         let effective = metrics?.modelName.isEmpty == false ? metrics!.modelName : model
-        print("🎯 effectiveModel for \(shortId): using '\(effective)' (metrics='\(metrics?.modelName ?? "nil")', topLevel='\(model)')")
+        if irrlichtVerboseLogging {
+            print("🎯 effectiveModel for \(shortId): using '\(effective)' (metrics='\(metrics?.modelName ?? "nil")', topLevel='\(model)')")
+        }
         return effective
     }
     

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1705,17 +1705,11 @@ struct SubagentRowView: View {
 
             Spacer()
 
-            // Duration
+            // Duration — driven by the shared 1 Hz DurationClock so N subagent
+            // rows cost one timer, not N independent TimelineView schedulers (#690).
             if let metrics = session.metrics {
                 let isActive = session.state == .working || session.state == .waiting
-                TimelineView(.periodic(from: .now, by: 1.0)) { timeline in
-                    let _ = timeline.date
-                    Text(isActive
-                        ? metrics.formattedRealtimeElapsedTime(sessionFirstSeen: session.firstSeen)
-                        : (metrics.elapsedSeconds > 0 ? metrics.formattedElapsedTime : "—"))
-                        .font(.caption2)
-                        .foregroundColor(.secondary.opacity(0.7))
-                }
+                LiveDurationText(isActive: isActive, metrics: metrics, firstSeen: session.firstSeen)
             } else {
                 Text("—")
                     .font(.caption2)
@@ -1732,6 +1726,44 @@ struct SubagentRowView: View {
         }
         .accessibilityIdentifier("subagent-card-\(session.id)")
         .accessibilityLabel("subagent \(session.state.rawValue)")
+    }
+}
+
+// MARK: - Shared duration clock (#690)
+
+/// One 1 Hz clock shared by every live duration label. Replaces the per-row
+/// `TimelineView(.periodic)` schedulers so N visible rows cost a single timer
+/// instead of N. Only the leaf `LiveDurationText` views observe it, so a tick
+/// re-renders just those labels — never their parent rows.
+@MainActor
+final class DurationClock: ObservableObject {
+    static let shared = DurationClock()
+    /// Bumped every second purely to invalidate observing labels; the duration
+    /// strings read the wall clock themselves, so the value is never consumed.
+    @Published private(set) var tick: UInt64 = 0
+    private var timer: Timer?
+
+    private init() {
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick &+= 1 }
+        }
+    }
+}
+
+/// A duration label that refreshes once per second off the shared `DurationClock`.
+/// Active sessions show realtime elapsed; finished ones show their frozen total.
+private struct LiveDurationText: View {
+    @ObservedObject private var clock = DurationClock.shared
+    let isActive: Bool
+    let metrics: SessionMetrics
+    let firstSeen: Date
+
+    var body: some View {
+        Text(isActive
+            ? metrics.formattedRealtimeElapsedTime(sessionFirstSeen: firstSeen)
+            : (metrics.elapsedSeconds > 0 ? metrics.formattedElapsedTime : "—"))
+            .font(.caption2)
+            .foregroundColor(.secondary.opacity(0.7))
     }
 }
 

--- a/platforms/macos/Tests/SessionManagerCoalescingTests.swift
+++ b/platforms/macos/Tests/SessionManagerCoalescingTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import Irrlicht
+import Foundation
+
+/// Regression coverage for the #690 coalesced UI refresh.
+///
+/// Background: with 40+ working agents, each `session_updated` push used to run
+/// a full `rebuildSessionsFromMap()` + `patchApiGroups()` and reassign the
+/// @Published surfaces — and because every WS message resumes as its own
+/// @MainActor turn, SwiftUI re-rendered the whole (eager, non-virtualized)
+/// session list once per message. That O(N) work × N pushes/sec was the ~25%
+/// CPU. These tests pin the fix: a burst of pure-metric pushes must collapse
+/// into a single render pass, while a state transition still flushes
+/// immediately so the UI stays snappy.
+@MainActor
+final class SessionManagerCoalescingTests: XCTestCase {
+    typealias AgentGroup = SessionManager.AgentGroup
+
+    private var sut: SessionManager!
+    private var originalProjectGroupOrder: Any?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        // seedLocalApiGroups persists projectGroupOrder to UserDefaults; snapshot
+        // + restore so the developer's real order survives the run (same pattern
+        // as the apiGroups tests).
+        originalProjectGroupOrder = UserDefaults.standard.object(forKey: "projectGroupOrder")
+        sut = SessionManager()
+        // Long window so the trailing timer never fires mid-test — flushes are
+        // driven explicitly via flushPendingUIRefreshForTests().
+        sut.uiRefreshInterval = 1000
+    }
+
+    override func tearDown() async throws {
+        if let originalProjectGroupOrder {
+            UserDefaults.standard.set(originalProjectGroupOrder, forKey: "projectGroupOrder")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "projectGroupOrder")
+        }
+        sut = nil
+        try await super.tearDown()
+    }
+
+    /// A storm of pure-metric updates (state unchanged) must not render once per
+    /// message — they coalesce into exactly one flush, and every update lands.
+    func testMetricStorm_coalescesIntoSingleFlush() {
+        let ids = (0..<40).map { "s\($0)" }
+        seedWorkingSessions(ids)
+
+        for (n, id) in ids.enumerated() {
+            sut.handleWsMessage(updatedEnvelope(id: id, seq: UInt64(n + 1), cost: Double(n)))
+        }
+
+        XCTAssertEqual(sut.uiRefreshFlushCount, 0,
+                       "40 metric pushes must not render synchronously — they coalesce")
+
+        sut.flushPendingUIRefreshForTests()
+
+        XCTAssertEqual(sut.uiRefreshFlushCount, 1,
+                       "the coalesced burst must apply in exactly one render pass")
+        let costByID = sut.apiGroups
+            .flatMap { $0.agents ?? [] }
+            .reduce(into: [String: Double]()) { $0[$1.id] = $1.metrics?.estimatedCostUSD ?? -1 }
+        XCTAssertEqual(costByID.count, 40, "all 40 sessions present after flush")
+        XCTAssertEqual(costByID["s39"], 39, "the last update for each session is applied on flush")
+    }
+
+    /// A state transition (working → waiting) bypasses the window so the row
+    /// updates immediately — transitions fire at human pace, not the metric rate.
+    func testStateChange_flushesImmediately() {
+        seedWorkingSessions(["a", "b"])
+
+        sut.handleWsMessage(updatedEnvelope(id: "a", seq: 1, cost: 1, state: "waiting"))
+
+        XCTAssertEqual(sut.uiRefreshFlushCount, 1,
+                       "a state transition flushes immediately, without waiting for the window")
+        let stateA = sut.apiGroups.flatMap { $0.agents ?? [] }.first { $0.id == "a" }?.state
+        XCTAssertEqual(stateA, .waiting, "the transition is reflected in the list-view surface")
+    }
+
+    // MARK: - Helpers
+
+    /// Seed `ids` as working sessions present in both surfaces so WS updates
+    /// patch in place (and `groupedSessionIds` contains them).
+    private func seedWorkingSessions(_ ids: [String]) {
+        let agents = ids.map { decodeSession(sessionObject(id: $0, cost: 0)) }
+        for s in agents { sut.sessionMap[s.id] = s }
+        sut.seedLocalApiGroups([AgentGroup(name: "proj", agents: agents)])
+    }
+
+    private func decodeSession(_ json: String) -> SessionState {
+        // swiftlint:disable:next force_try
+        try! JSONDecoder().decode(SessionState.self, from: Data(json.utf8))
+    }
+
+    private func sessionObject(id: String, cost: Double, state: String = "working") -> String {
+        """
+        {"session_id":"\(id)","state":"\(state)","model":"m","cwd":"/tmp","project_name":"proj",\
+        "first_seen":0,"updated_at":0,"metrics":{"elapsed_seconds":0,"total_tokens":0,"model_name":"m",\
+        "context_utilization_percentage":0,"pressure_level":"safe","estimated_cost_usd":\(cost)}}
+        """
+    }
+
+    private func updatedEnvelope(id: String, seq: UInt64, cost: Double, state: String = "working") -> String {
+        """
+        {"type":"session_updated","seq":\(seq),"session":\(sessionObject(id: id, cost: cost, state: state))}
+        """
+    }
+}

--- a/tools/wsload/go.mod
+++ b/tools/wsload/go.mod
@@ -1,0 +1,5 @@
+module irrlicht/tools/wsload
+
+go 1.25.0
+
+require github.com/gorilla/websocket v1.5.3

--- a/tools/wsload/go.sum
+++ b/tools/wsload/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/tools/wsload/main.go
+++ b/tools/wsload/main.go
@@ -1,0 +1,176 @@
+// Command wsload is a throwaway CPU-measurement harness for issue #690.
+//
+// It impersonates just enough of the irrlichd HTTP+WebSocket surface to drive
+// the macOS app under a realistic many-agent load, so app CPU can be measured
+// before/after the session-update coalescing change. It serves:
+//
+//	GET /api/v1/agents          -> [] (no custom branding)
+//	GET /api/v1/permissions     -> 404 (pre-#570 shape; app leaves snapshot nil)
+//	GET /api/v1/sessions        -> N working sessions spread across -groups groups
+//	GET /api/v1/sessions/stream -> a session_updated storm at -rate pushes/sec
+//
+// Usage:
+//
+//	go run . -port 7838 -sessions 40 -rate 200
+//	# then launch the app pointed at the harness:
+//	IRRLICHT_DAEMON_PORT=7838 open -n /path/to/Irrlicht.app
+//	# measure steady-state app CPU, e.g.:
+//	ps -o %cpu,rss,comm -p "$(pgrep -x Irrlicht)"
+//
+// The push storm keeps every session in the "working" state and only mutates
+// metrics (cost climbs, context oscillates) — i.e. the exact pure-metric churn
+// that used to re-render the whole list once per message. Compare CPU on `main`
+// vs `fix/690-macos-cpu` at the same -sessions/-rate to quantify the fix.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var (
+	port     = flag.Int("port", 7838, "port to listen on (point the app at it via IRRLICHT_DAEMON_PORT)")
+	sessions = flag.Int("sessions", 40, "number of working sessions to advertise")
+	groups   = flag.Int("groups", 4, "number of project groups to spread sessions across")
+	rate     = flag.Int("rate", 200, "total session_updated pushes per second across all sessions")
+)
+
+var upgrader = websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+// seq is the daemon-global monotonic push counter the app uses for slow-drop
+// detection (#593). Incrementing it by 1 per push keeps the app from triggering
+// a re-hydration on a perceived gap.
+var seq uint64
+
+func main() {
+	flag.Parse()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agents", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "[]")
+	})
+	mux.HandleFunc("/api/v1/permissions", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+	mux.HandleFunc("/api/v1/sessions", handleSessions)
+	mux.HandleFunc("/api/v1/sessions/stream", handleStream)
+
+	addr := fmt.Sprintf("127.0.0.1:%d", *port)
+	log.Printf("wsload: %d sessions across %d groups, %d pushes/sec on http://%s", *sessions, *groups, *rate, addr)
+	log.Printf("wsload: launch the app with IRRLICHT_DAEMON_PORT=%d", *port)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+func projectName(i int) string { return fmt.Sprintf("proj%d", i%*groups) }
+
+func sessionID(i int) string { return fmt.Sprintf("wsload-%03d", i) }
+
+// sessionJSON renders one session object. cost/ctx vary per push so the app
+// does real diff/render work; everything else is stable.
+func sessionJSON(i int, cost, ctx float64, now int64) string {
+	return fmt.Sprintf(
+		`{"session_id":"%s","state":"working","model":"claude-opus-4-8","cwd":"/tmp/%s",`+
+			`"project_name":"%s","first_seen":%d,"updated_at":%d,`+
+			`"metrics":{"elapsed_seconds":%d,"total_tokens":%d,"model_name":"claude-opus-4-8",`+
+			`"context_window":200000,"context_utilization_percentage":%.2f,"pressure_level":"safe",`+
+			`"estimated_cost_usd":%.4f}}`,
+		sessionID(i), projectName(i), projectName(i),
+		now-300, now, int64(300), int64(ctx*2000), ctx, cost,
+	)
+}
+
+// handleSessions returns the initial hierarchy so the app's apiGroups (the
+// list-view surface) is fully populated — without this the WS updates would
+// miss the patch guard and only the flat surface would exercise.
+func handleSessions(w http.ResponseWriter, _ *http.Request) {
+	now := time.Now().Unix()
+	byGroup := make([][]string, *groups)
+	for i := 0; i < *sessions; i++ {
+		g := i % *groups
+		byGroup[g] = append(byGroup[g], sessionJSON(i, 0.01, 5, now))
+	}
+	groupsJSON := ""
+	for g := 0; g < *groups; g++ {
+		if len(byGroup[g]) == 0 {
+			continue
+		}
+		if groupsJSON != "" {
+			groupsJSON += ","
+		}
+		agents := ""
+		for j, s := range byGroup[g] {
+			if j > 0 {
+				agents += ","
+			}
+			agents += s
+		}
+		groupsJSON += fmt.Sprintf(`{"name":"proj%d","agents":[%s]}`, g, agents)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, `{"groups":[%s],"provider_costs":{}}`, groupsJSON)
+}
+
+// handleStream upgrades to WebSocket and pushes a round-robin session_updated
+// storm at the configured rate until the client disconnects.
+func handleStream(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("wsload: upgrade failed: %v", err)
+		return
+	}
+	defer conn.Close()
+	log.Printf("wsload: client connected — streaming")
+
+	// Reader pump: discard inbound frames, detect close.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	interval := time.Second / time.Duration(max(*rate, 1))
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var pushes uint64
+	logEvery := time.NewTicker(5 * time.Second)
+	defer logEvery.Stop()
+
+	i := 0
+	for {
+		select {
+		case <-done:
+			log.Printf("wsload: client disconnected after %d pushes", atomic.LoadUint64(&pushes))
+			return
+		case <-logEvery.C:
+			log.Printf("wsload: %d pushes sent", atomic.LoadUint64(&pushes))
+		case <-ticker.C:
+			now := time.Now().Unix()
+			n := atomic.AddUint64(&seq, 1)
+			// Cost climbs slowly; context oscillates 5–95% so percentage and
+			// pressure rendering churn like a real session.
+			cost := 0.01 + float64(n)*0.0001
+			ctx := 50 + 45*math.Sin(float64(n)/20)
+			env := fmt.Sprintf(`{"type":"session_updated","seq":%d,"session":%s}`,
+				n, sessionJSON(i, cost, ctx, now))
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(env)); err != nil {
+				log.Printf("wsload: write failed: %v", err)
+				return
+			}
+			atomic.AddUint64(&pushes, 1)
+			i = (i + 1) % *sessions
+		}
+	}
+}


### PR DESCRIPTION
Fixes #690.

## Diagnosis

The daemon is cheap; the **app** paid an O(N)-per-message cost on a hot stream. Every `session_updated` push ran, synchronously per message, a full `rebuildSessionsFromMap()` (sort + re-index + reassign `@Published sessions`/`allSessions`) **and** `patchApiGroups()` → `recomposeApiGroups()` (reassign `@Published apiGroups`). Because each WS message resumes as its **own `@MainActor` turn**, SwiftUI re-rendered the whole session list — an **eager `VStack`** (not lazy, `.fixedSize` popover sizing) — once per message. With 40 agents each ticking metrics, that's ≈ N messages/sec × O(N) render ≈ **O(N²)**, saturating a core.

## Changes

- **Coalesce UI refreshes (the fix).** `session_updated` now accumulates dirty session ids and flushes **once per ~100 ms window** instead of rebuilding+rendering per message. Map mutations and `checkStateTransitionNotification` stay synchronous (sounds/alerts never delayed); **state transitions flush immediately** so they stay snappy while the metric-tick storm coalesces. Injectable interval + `flushPendingUIRefreshForTests()` seam.
- **Shared 1 Hz duration clock.** Replaced the per-subagent-row `TimelineView(.periodic)` with one `DurationClock` observed only by the leaf `LiveDurationText` — N timers → 1, identical render scope (the old `TimelineView` discarded its date anyway).
- **Gate per-message debug `print()`s** (`🔍 Decoded session`, `🎯 effectiveModel`, `🔢 Sorted`) behind `IRRLICHT_DEBUG`. Log hygiene — 200+ lines/sec is wrong in a shipping app. Honest note: this is **not** a measured CPU win (see below); kept for production logging volume.
- **`tools/wsload`** — a harness that serves a faithful slice of the daemon HTTP+WS surface and drives the app under a configurable `session_updated` storm, for reproducible before/after CPU measurement. Plus a deterministic coalescing regression test.

## Measured results

Harness: 40 sessions / 4 groups, 200 `session_updated`/sec, release builds, 12 `top` samples/pass (**100% = one core**):

| Build | median | max |
|---|---|---|
| **BEFORE** (`main`) | **100.6%** | ~101% |
| **AFTER** (this branch) | **~31%** | ~33% |

**≈69% reduction — a fully saturated core down to a steady ~31%**, reproducible across passes. The residual ~31% is per-message JSON decode + the now-coalesced render (the harness sends stdout to `/dev/null`, so the gated prints show no CPU delta there — the gating is log hygiene, not the win). Closed-popover *averages* are noisy due to macOS App Nap throttling the hidden list's re-render; the sustained median is the stable signal.

## Out of scope (noted, not attempted)

- `LazyVStack` virtualization — blocked by the `.fixedSize(vertical:)` popover height reporting; high risk, low marginal value once coalescing lands.
- Daemon changes — already low-CPU per the issue.

## Testing

- macOS Swift suite: **140 tests, 0 failures** (5 expected launcher skips), snapshot suites included.
- New `SessionManagerCoalescingTests`: proves 40 pushes → one flush, and that a state change flushes immediately.
- `go build`/`go vet` clean for `tools/wsload`; core Go untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)