### PR TITLE
docs(site): document all environment variables in configuration.html (#695)

### DIFF
--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -166,6 +166,66 @@
             <td><code>ask</code></td>
             <td>Consent behavior. <code>ask</code> (production default) keeps every per-agent permission pending until answered via the wizard &mdash; nothing is read or modified before a grant. <code>grant-all</code> auto-grants everything in-memory for demo / recording / test daemons; it is never persisted</td>
           </tr>
+          <tr>
+            <td><code>IRRLICHT_READY_SESSION_TTL</code></td>
+            <td>Duration</td>
+            <td><code>30m</code></td>
+            <td>How long an idle <code>ready</code> session is kept before automatic deletion. Used by test harnesses to expire long-idle sessions in seconds rather than half an hour</td>
+          </tr>
+          <tr>
+            <td><code>IRRLICHT_HOME</code></td>
+            <td>Path</td>
+            <td><code>~/.local/share/irrlicht</code></td>
+            <td>Relocate the daemon's entire state tree &mdash; socket, addr file, history rollups, session/cost/ledger stores, and recordings &mdash; for a fully isolated dev / test daemon that never touches the production install</td>
+          </tr>
+          <tr>
+            <td><code>IRRLICHT_DEMO_MODE</code></td>
+            <td>Boolean (1/0)</td>
+            <td>unset</td>
+            <td>When <code>1</code>, disables the process watcher and per-adapter file watchers &mdash; the daemon serves only seeded session state. For demos and screenshots</td>
+          </tr>
+          <tr>
+            <td><code>IRRLICHT_RECORD</code></td>
+            <td>Boolean (1/0)</td>
+            <td>unset</td>
+            <td>When <code>1</code> (equivalent to the <code>--record</code> flag), records the session lifecycle event stream to JSONL for replay fixtures</td>
+          </tr>
+          <tr>
+            <td><code>IRRLICHT_RECORDINGS_DIR</code></td>
+            <td>Path</td>
+            <td><code>&lt;dataDir&gt;/recordings</code></td>
+            <td>Override the directory lifecycle recordings are written to. Wins even when <code>IRRLICHT_HOME</code> is set, so a recording run can be pinned somewhere specific (only used while recording is enabled)</td>
+          </tr>
+          <tr>
+            <td><code>IRRLICHT_RELAY_URL</code></td>
+            <td>URL</td>
+            <td>unset</td>
+            <td>Opt-in outbound relay: forward this daemon's session events to a standalone <code>irrlichtrelay</code> so remote clients can see them. Accepts a bare base (e.g. <code>ws://host:7839</code>); <code>http(s)://</code> is rewritten to <code>ws(s)://</code> and the stream path is appended automatically</td>
+          </tr>
+          <tr>
+            <td><code>IRRLICHT_RELAY_TOKEN</code></td>
+            <td>String</td>
+            <td>unset</td>
+            <td>Bearer token for an auth-enabled relay. Overrides the <code>token</code> field of <code>&lt;dataDir&gt;/relay-token.json</code>; leave unset against a no-auth relay</td>
+          </tr>
+          <tr>
+            <td><code>IRRLICHT_MODEL_CAPACITY_CACHE</code></td>
+            <td>Path</td>
+            <td>auto-detect</td>
+            <td>Override the model capacity / pricing cache file with an explicit path. An escape hatch used by replay tests to pin pricing to a committed snapshot so cost resolution can't drift</td>
+          </tr>
+          <tr>
+            <td><code>NO_COLOR</code></td>
+            <td>Boolean (presence)</td>
+            <td>unset</td>
+            <td>Standard <a href="https://no-color.org/">no-color</a> convention &mdash; when set to any value, the <code>irrlicht-ls</code> CLI disables ANSI color in its text output</td>
+          </tr>
+          <tr>
+            <td><code>GT_ROOT</code></td>
+            <td>Path</td>
+            <td><code>~/gt</code></td>
+            <td>Override the Gas Town root directory the orchestrator adapter probes for <code>daemon/state.json</code> and rig layout</td>
+          </tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
## Summary

The Environment Variables table in `site/docs/configuration.html` documented only 5 of the 15 user-facing config variables. This adds a table row for each of the 10 missing variables, in the existing 4-column format (Variable / Type / Default / Description).

### Variables added (with source of the authoritative default)

| Variable | Type | Default | Source |
|---|---|---|---|
| `IRRLICHT_READY_SESSION_TTL` | Duration | `30m` | `core/domain/config/config.go` |
| `IRRLICHT_HOME` | Path | `~/.local/share/irrlicht` | `core/cmd/irrlichd/main.go` |
| `IRRLICHT_DEMO_MODE` | Boolean (1/0) | unset | `core/cmd/irrlichd/main.go` |
| `IRRLICHT_RECORD` | Boolean (1/0) | unset | `core/cmd/irrlichd/main.go` |
| `IRRLICHT_RECORDINGS_DIR` | Path | `<dataDir>/recordings` | `core/cmd/irrlichd/main.go` |
| `IRRLICHT_RELAY_URL` | URL | unset | `core/cmd/irrlichd/main.go`, `core/adapters/outbound/relay/forwarder.go` |
| `IRRLICHT_RELAY_TOKEN` | String | unset | `core/adapters/outbound/relay/token.go` |
| `IRRLICHT_MODEL_CAPACITY_CACHE` | Path | auto-detect | `core/pkg/capacity/remote.go` |
| `NO_COLOR` | Boolean (presence) | unset | `core/cmd/irrlicht-ls/main.go` |
| `GT_ROOT` | Path | `~/gt` | `core/adapters/inbound/orchestrators/gastown/collector.go` |

All defaults were read from code, not invented.

## Verification

```
grep -rhoE 'os\.Getenv\("(IRRLICHT_[A-Z_]+|NO_COLOR|GT_BIN|GT_ROOT)"\)' core --include='*.go' | grep -v _test.go | sort -u
```

lists exactly 15 variables. Each now has its own `<td><code>VAR</code></td>` row in `configuration.html` (confirmed one dedicated cell per variable). HTML well-formedness checked: `<tr>`/`</tr>` balanced (21/21), `<td>`/`</td>` balanced (80/80), single `<table>`/`</table>`.

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)