### PR TITLE
feat(settings): collapsible Advanced Settings group + Beta badges (#694)

### DIFF
--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -265,6 +265,9 @@ struct SettingsView: View {
                             .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
+                        .tooltip("Show debug, task-estimate markers, sources, and the command-line tool")
+                        .accessibilityElement(children: .combine)
+                        .accessibilityValue(advancedSettingsExpanded ? "expanded" : "collapsed")
 
                         if advancedSettingsExpanded {
                             LeadingToggle(
@@ -690,7 +693,7 @@ struct BetaBadge: View {
             .foregroundColor(IrrColors.working)
             .padding(.horizontal, 5)
             .padding(.vertical, 1)
-            .background(Capsule().fill(IrrColors.working.opacity(0.15)))
+            .background(Capsule().fill(IrrColors.workingDim))
             .accessibilityLabel("Beta feature")
     }
 }

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -15,6 +15,10 @@ struct SettingsView: View {
     @AppStorage("showQuotaForecast") private var showQuotaForecast: Bool = true
     @AppStorage("launchAtLogin") private var launchAtLogin: Bool = true
     @AppStorage("taskEtaActivation") private var taskEtaActivation: Bool = false
+    // Advanced Settings disclosure state (#694) — collapsed by default; the
+    // power-user / still-maturing controls (debug, task-eta, sources, CLI tool)
+    // live under it.
+    @AppStorage("advancedSettingsExpanded") private var advancedSettingsExpanded: Bool = false
     @AppStorage("providerMode_anthropic") private var providerModeAnthropic: String = ProviderModePreference.auto.rawValue
     @AppStorage("providerMode_openai") private var providerModeOpenAI: String = ProviderModePreference.auto.rawValue
     @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = false
@@ -58,12 +62,6 @@ struct SettingsView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    LeadingToggle(
-                        isOn: $debugMode,
-                        label: "Debug Mode",
-                        info: "Show session IDs, creation time, and time since last update."
-                    )
-
                     LeadingToggle(
                         isOn: $showCostDisplay,
                         label: "Show Estimated Cost",
@@ -123,102 +121,6 @@ struct SettingsView: View {
                         }
                     }
                     .onAppear { refreshLoginItemStatus() }
-
-                    // Task-eta global activation (issue #558). The daemon is
-                    // the source of truth: the toggle posts the flip and then
-                    // mirrors the daemon's answer, so a failed install never
-                    // shows as "on".
-                    LeadingToggle(
-                        isOn: $taskEtaActivation,
-                        label: "Task-Estimate Markers",
-                        info: "Add a managed emission rule to ~/.claude/CLAUDE.md so agents report task progress and sessions show a completion ETA. Only the Irrlicht-managed block is written; the rest of the file is untouched. Turning this off removes the block."
-                    )
-                    .onChange(of: taskEtaActivation) { newValue in
-                        // Swallow the change we made ourselves while reconciling
-                        // from the daemon — only a real user toggle should write.
-                        if taskEtaReconciling { taskEtaReconciling = false; return }
-                        Task {
-                            // nil = daemon unreachable: leave the toggle where the
-                            // user put it; the next open reconciles. Only correct
-                            // the toggle on a definite, differing answer.
-                            if let actual = await ActivationClient.set(enabled: newValue), actual != newValue {
-                                taskEtaReconciling = true
-                                taskEtaActivation = actual
-                            }
-                        }
-                    }
-                    .onAppear {
-                        Task {
-                            // Only reconcile on a definite answer — an unreachable
-                            // daemon (nil) must NOT flip the toggle off and trigger
-                            // a spurious uninstall of the managed CLAUDE.md block.
-                            if let actual = await ActivationClient.status(), actual != taskEtaActivation {
-                                taskEtaReconciling = true
-                                taskEtaActivation = actual
-                            }
-                        }
-                    }
-
-                    Divider()
-
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Sources")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-
-                        LeadingToggle(
-                            isOn: $useLocalDaemon,
-                            label: "Local",
-                            info: "Watch the daemon this app connects to directly."
-                        )
-
-                        LeadingToggle(
-                            isOn: $useRelayServer,
-                            label: "Relay server",
-                            info: "Also connect to a relay to see sessions from other machines."
-                        )
-
-                        if useRelayServer {
-                            HStack(spacing: 6) {
-                                TextField("ws://localhost:7839", text: $relayURLDraft)
-                                    .textFieldStyle(.roundedBorder)
-                                    .font(.system(.caption, design: .monospaced))
-                                    .autocorrectionDisabled(true)
-                                    .onChange(of: relayURLDraft) { newValue in
-                                        relayURLDebounceTask?.cancel()
-                                        relayURLDebounceTask = Task {
-                                            try? await Task.sleep(nanoseconds: 600_000_000)
-                                            guard !Task.isCancelled else { return }
-                                            relayServerURL = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                                        }
-                                    }
-                                Circle()
-                                    .fill(sessionManager.relayConnectionState.dotColor)
-                                    .frame(width: 8, height: 8)
-                                    .tooltip(sessionManager.relayConnectionState.shortLabel)
-                            }
-                            SecureField("Relay token (leave empty if the relay has no auth)", text: $relayTokenDraft)
-                                .textFieldStyle(.roundedBorder)
-                                .font(.system(.caption, design: .monospaced))
-                                .autocorrectionDisabled(true)
-                                .onChange(of: relayTokenDraft) { newValue in
-                                    KeychainStore.set(newValue.trimmingCharacters(in: .whitespacesAndNewlines), account: "relayToken")
-                                    // Keychain writes don't fire UserDefaults.didChangeNotification,
-                                    // so nudge the relay to reconnect with the new token.
-                                    sessionManager.relayTokenDidChange()
-                                }
-                        }
-                    }
-                    .onAppear {
-                        relayURLDraft = relayServerURL
-                        relayTokenDraft = KeychainStore.get(account: "relayToken")
-                    }
-                    .onChange(of: useRelayServer) { on in
-                        if on && relayURLDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                            relayURLDraft = "ws://localhost:7839"
-                        }
-                        commitRelayURL()
-                    }
 
                     Divider()
 
@@ -341,7 +243,138 @@ struct SettingsView: View {
 
                     Divider()
 
-                    CLIToolSection()
+                    // Advanced Settings (#694): power-user and still-maturing
+                    // controls, collapsed by default. Disclosure state persists
+                    // via @AppStorage("advancedSettingsExpanded").
+                    VStack(alignment: .leading, spacing: 12) {
+                        Button {
+                            withAnimation(IrrMotion.easeOut(duration: IrrMotion.fast)) {
+                                advancedSettingsExpanded.toggle()
+                            }
+                        } label: {
+                            HStack(spacing: 6) {
+                                Image(systemName: "chevron.right")
+                                    .font(.caption2.weight(.semibold))
+                                    .foregroundColor(.secondary)
+                                    .rotationEffect(.degrees(advancedSettingsExpanded ? 90 : 0))
+                                Text("Advanced Settings")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                Spacer()
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+
+                        if advancedSettingsExpanded {
+                            LeadingToggle(
+                                isOn: $debugMode,
+                                label: "Debug Mode",
+                                info: "Show session IDs, creation time, and time since last update."
+                            )
+
+                            // Task-eta global activation (issue #558). The daemon is
+                            // the source of truth: the toggle posts the flip and then
+                            // mirrors the daemon's answer, so a failed install never
+                            // shows as "on".
+                            LeadingToggle(
+                                isOn: $taskEtaActivation,
+                                label: "Task-Estimate Markers",
+                                info: "Add a managed emission rule to ~/.claude/CLAUDE.md so agents report task progress and sessions show a completion ETA. Only the Irrlicht-managed block is written; the rest of the file is untouched. Turning this off removes the block.",
+                                beta: true
+                            )
+                            .onChange(of: taskEtaActivation) { newValue in
+                                // Swallow the change we made ourselves while reconciling
+                                // from the daemon — only a real user toggle should write.
+                                if taskEtaReconciling { taskEtaReconciling = false; return }
+                                Task {
+                                    // nil = daemon unreachable: leave the toggle where the
+                                    // user put it; the next open reconciles. Only correct
+                                    // the toggle on a definite, differing answer.
+                                    if let actual = await ActivationClient.set(enabled: newValue), actual != newValue {
+                                        taskEtaReconciling = true
+                                        taskEtaActivation = actual
+                                    }
+                                }
+                            }
+                            .onAppear {
+                                Task {
+                                    // Only reconcile on a definite answer — an unreachable
+                                    // daemon (nil) must NOT flip the toggle off and trigger
+                                    // a spurious uninstall of the managed CLAUDE.md block.
+                                    if let actual = await ActivationClient.status(), actual != taskEtaActivation {
+                                        taskEtaReconciling = true
+                                        taskEtaActivation = actual
+                                    }
+                                }
+                            }
+
+                            VStack(alignment: .leading, spacing: 8) {
+                                HStack(spacing: 6) {
+                                    Text("Sources")
+                                        .font(.subheadline)
+                                        .fontWeight(.medium)
+                                    BetaBadge()
+                                    Spacer()
+                                }
+
+                                LeadingToggle(
+                                    isOn: $useLocalDaemon,
+                                    label: "Local",
+                                    info: "Watch the daemon this app connects to directly."
+                                )
+
+                                LeadingToggle(
+                                    isOn: $useRelayServer,
+                                    label: "Relay server",
+                                    info: "Also connect to a relay to see sessions from other machines."
+                                )
+
+                                if useRelayServer {
+                                    HStack(spacing: 6) {
+                                        TextField("ws://localhost:7839", text: $relayURLDraft)
+                                            .textFieldStyle(.roundedBorder)
+                                            .font(.system(.caption, design: .monospaced))
+                                            .autocorrectionDisabled(true)
+                                            .onChange(of: relayURLDraft) { newValue in
+                                                relayURLDebounceTask?.cancel()
+                                                relayURLDebounceTask = Task {
+                                                    try? await Task.sleep(nanoseconds: 600_000_000)
+                                                    guard !Task.isCancelled else { return }
+                                                    relayServerURL = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                                                }
+                                            }
+                                        Circle()
+                                            .fill(sessionManager.relayConnectionState.dotColor)
+                                            .frame(width: 8, height: 8)
+                                            .tooltip(sessionManager.relayConnectionState.shortLabel)
+                                    }
+                                    SecureField("Relay token (leave empty if the relay has no auth)", text: $relayTokenDraft)
+                                        .textFieldStyle(.roundedBorder)
+                                        .font(.system(.caption, design: .monospaced))
+                                        .autocorrectionDisabled(true)
+                                        .onChange(of: relayTokenDraft) { newValue in
+                                            KeychainStore.set(newValue.trimmingCharacters(in: .whitespacesAndNewlines), account: "relayToken")
+                                            // Keychain writes don't fire UserDefaults.didChangeNotification,
+                                            // so nudge the relay to reconnect with the new token.
+                                            sessionManager.relayTokenDidChange()
+                                        }
+                                }
+                            }
+                            .onAppear {
+                                relayURLDraft = relayServerURL
+                                relayTokenDraft = KeychainStore.get(account: "relayToken")
+                            }
+                            .onChange(of: useRelayServer) { on in
+                                if on && relayURLDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                    relayURLDraft = "ws://localhost:7839"
+                                }
+                                commitRelayURL()
+                            }
+
+                            CLIToolSection()
+                        }
+                    }
                 }
                 .padding(.horizontal, 20)
                 .padding(.vertical, 16)
@@ -629,6 +662,8 @@ struct LeadingToggle: View {
     @Binding var isOn: Bool
     let label: String
     var info: String? = nil
+    /// Flags a still-maturing feature with a "BETA" pill after the label (#694).
+    var beta: Bool = false
 
     var body: some View {
         HStack(spacing: 6) {
@@ -637,8 +672,26 @@ struct LeadingToggle: View {
             if let info {
                 InfoIcon(text: info)
             }
+            if beta {
+                BetaBadge()
+            }
             Spacer()
         }
+    }
+}
+
+/// Small "BETA" pill flagging a feature that's still maturing (#694). Mirrors
+/// the web dashboard's `.beta-badge`.
+struct BetaBadge: View {
+    var body: some View {
+        Text("BETA")
+            .font(.system(size: 9, weight: .bold))
+            .tracking(0.5)
+            .foregroundColor(IrrColors.working)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(Capsule().fill(IrrColors.working.opacity(0.15)))
+            .accessibilityLabel("Beta feature")
     }
 }
 

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -41,45 +41,6 @@
           <span class="settings-hint">Display the per-session running cost in each row.</span>
         </span>
       </label>
-      <label>
-        <input type="checkbox" data-setting="debugMode">
-        <span class="settings-label-text">
-          <span class="settings-title">Debug mode</span>
-          <span class="settings-hint">Show session IDs and elapsed time in each row.</span>
-        </span>
-      </label>
-
-      <h2>Sources</h2>
-      <label>
-        <input type="checkbox" data-setting="enableLocalSource">
-        <span class="settings-label-text">
-          <span class="settings-title">Local</span>
-          <span class="settings-hint">Watch the daemon (or relay) that served this page.</span>
-        </span>
-      </label>
-      <label>
-        <input type="checkbox" data-setting="enableRelaySource">
-        <span class="settings-label-text">
-          <span class="settings-title">Relay server</span>
-          <span class="settings-hint">Also connect to a relay to see other machines' sessions.</span>
-        </span>
-      </label>
-      <label class="settings-text-row">
-        <span class="settings-label-text">
-          <span class="settings-title">Relay server URL</span>
-          <span class="settings-hint">e.g. ws://localhost:7839</span>
-        </span>
-        <input type="text" class="settings-text-input" data-setting="relayUrl"
-               placeholder="ws://localhost:7839" spellcheck="false" autocomplete="off">
-      </label>
-      <label class="settings-text-row">
-        <span class="settings-label-text">
-          <span class="settings-title">Relay token</span>
-          <span class="settings-hint">Only if the relay requires auth; leave empty otherwise.</span>
-        </span>
-        <input type="password" class="settings-text-input" data-setting="relayToken"
-               placeholder="bearer token" spellcheck="false" autocomplete="off">
-      </label>
 
       <h2>Permissions</h2>
       <div class="settings-action-row">
@@ -122,6 +83,51 @@
           <span class="settings-hint">Heads-up when a session approaches its context limit.</span>
         </span>
       </label>
+
+      <details class="settings-advanced" id="settings-advanced">
+        <summary>
+          <span class="settings-advanced-title">Advanced Settings</span>
+        </summary>
+        <label>
+          <input type="checkbox" data-setting="debugMode">
+          <span class="settings-label-text">
+            <span class="settings-title">Debug mode</span>
+            <span class="settings-hint">Show session IDs and elapsed time in each row.</span>
+          </span>
+        </label>
+
+        <h2>Sources <span class="beta-badge">Beta</span></h2>
+        <label>
+          <input type="checkbox" data-setting="enableLocalSource">
+          <span class="settings-label-text">
+            <span class="settings-title">Local</span>
+            <span class="settings-hint">Watch the daemon (or relay) that served this page.</span>
+          </span>
+        </label>
+        <label>
+          <input type="checkbox" data-setting="enableRelaySource">
+          <span class="settings-label-text">
+            <span class="settings-title">Relay server</span>
+            <span class="settings-hint">Also connect to a relay to see other machines' sessions.</span>
+          </span>
+        </label>
+        <label class="settings-text-row">
+          <span class="settings-label-text">
+            <span class="settings-title">Relay server URL</span>
+            <span class="settings-hint">e.g. ws://localhost:7839</span>
+          </span>
+          <input type="text" class="settings-text-input" data-setting="relayUrl"
+                 placeholder="ws://localhost:7839" spellcheck="false" autocomplete="off">
+        </label>
+        <label class="settings-text-row">
+          <span class="settings-label-text">
+            <span class="settings-title">Relay token</span>
+            <span class="settings-hint">Only if the relay requires auth; leave empty otherwise.</span>
+          </span>
+          <input type="password" class="settings-text-input" data-setting="relayToken"
+                 placeholder="bearer token" spellcheck="false" autocomplete="off">
+        </label>
+      </details>
 
       <div class="settings-modal-footer">
         <span class="settings-perm-note" id="settings-perm-note"></span>

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -945,6 +945,48 @@
       margin-bottom: 10px;
     }
     .settings-modal h2:not(:first-child) { margin-top: 14px; }
+    /* "BETA" pill flagging a still-maturing feature (#694); mirrors macOS. */
+    .beta-badge {
+      display: inline-block;
+      font-family: var(--font-mono);
+      font-size: 9px;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--working);
+      background: var(--working-dim);
+      border-radius: 6px;
+      padding: 1px 5px;
+      margin-left: 6px;
+      vertical-align: middle;
+    }
+    /* Advanced Settings disclosure (#694): collapsed by default, expandable. */
+    .settings-modal details.settings-advanced { margin-top: 14px; }
+    .settings-modal details.settings-advanced > summary {
+      list-style: none;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      user-select: none;
+      padding: 2px 0;
+    }
+    .settings-modal details.settings-advanced > summary::-webkit-details-marker { display: none; }
+    .settings-modal details.settings-advanced > summary::before {
+      content: '\25B8';
+      color: var(--muted);
+      font-size: 10px;
+      transition: transform 0.15s;
+    }
+    .settings-modal details.settings-advanced[open] > summary::before { transform: rotate(90deg); }
+    .settings-modal details.settings-advanced > summary .settings-advanced-title {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
     .settings-modal label {
       display: flex;
       align-items: flex-start;

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -2579,6 +2579,17 @@
       });
     }
 
+    // Advanced Settings disclosure (#694): collapsed by default, but its
+    // open/closed choice persists across reloads (native <details> forgets).
+    // Mirrors the macOS @AppStorage("advancedSettingsExpanded") behavior.
+    const advancedDetails = document.getElementById('settings-advanced');
+    if (advancedDetails) {
+      try { advancedDetails.open = localStorage.getItem('irrlicht_advancedSettingsExpanded') === 'true'; } catch (e) {}
+      advancedDetails.addEventListener('toggle', () => {
+        try { localStorage.setItem('irrlicht_advancedSettingsExpanded', advancedDetails.open ? 'true' : 'false'); } catch (e) {}
+      });
+    }
+
     // --- Daemon version (Irrlicht v$VERSION in the header) ---
     fetch('/api/v1/version').then(r => r.ok ? r.json() : null).catch(() => null).then(v => {
       const el = document.getElementById('app-version');


### PR DESCRIPTION
Closes #694.

## What

Reorganizes Settings on both platforms so power-user / still-maturing controls live under a single **Advanced Settings** disclosure (collapsed by default, expanded-state persisted), and introduces a reusable **Beta** badge.

### Advanced Settings group
- **macOS** (`SettingsView.swift`): custom chevron disclosure bound to `@AppStorage("advancedSettingsExpanded")`, placed last in the panel. Holds **Debug Mode**, **Task-Estimate Markers**, **Sources**, and **Command-Line Tool**.
- **Web** (`index.html` + `irrlicht.js`): native `<details id="settings-advanced">`; open/closed state persists to `localStorage("irrlicht_advancedSettingsExpanded")` (native `<details>` forgets across reloads). Holds **Debug mode** and **Sources**.

### Beta categorization
- New reusable badge — macOS `BetaBadge` view + optional `beta:` flag on `LeadingToggle`; web `.beta-badge` built from the existing `--working` / `--working-dim` tokens.
- "BETA" pill on **Task-Estimate Markers** (macOS) and **Sources** (both platforms).

## Scope decision
Per the issue's open question: **Task-Estimate Markers** and **Command-Line Tool** stay **macOS-only** — they have no web backend, so adding web toggles would be net-new wiring beyond a settings reshuffle. **Debug Mode** and **Sources** are the shared controls and now sit under Advanced consistently on both platforms.

## Behavior note
The moved controls now live inside a collapsed disclosure, so their `.onAppear` (task-eta daemon reconcile, relay draft load) fires on **first expand** rather than on settings-open. The live relay connection is unaffected — it's driven by stored prefs, not UI visibility.

## Testing
- Swift build clean; macOS suite: **138 passed, 5 skipped, 0 failures** (incl. the SettingsView opacity regression test).
- Web: **88/88 vitest passed**.
- Surgical diff across 4 files; all moves preserve existing `.onChange`/`.onAppear` daemon-reconcile and relay logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)