### PR TITLE
fix(daemon): keep Claude Code session waiting across daemon restart (#705)

### DIFF
--- a/core/pkg/tailer/ledger_assistant_text_test.go
+++ b/core/pkg/tailer/ledger_assistant_text_test.go
@@ -1,0 +1,62 @@
+package tailer
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestLedger_PersistsLastAssistantText is the issue #705 regression: a session
+// whose turn ended on a question is persisted as `waiting`. A daemon restart
+// resumes the tailer at LastOffset; when the transcript hasn't grown the pass
+// processes zero lines. Unless the ledger carries LastAssistantText, the
+// recomputed metrics carry an empty question text, IsWaitingForUserInput()
+// returns false, and the seed re-classification demotes the session to `ready`.
+func TestLedger_PersistsLastAssistantText(t *testing.T) {
+	const question = "Should I proceed with the migration?"
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "user", "timestamp": ts(0)},
+		{"type": "assistant", "timestamp": ts(1), "message": map[string]interface{}{
+			"role": "assistant",
+			"content": []interface{}{
+				map[string]interface{}{"type": "text", "text": question},
+			},
+		}},
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(2)},
+	})
+
+	tl1 := newTestTailer(path)
+	m, err := tl1.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.LastAssistantText != question {
+		t.Fatalf("pre-restart LastAssistantText = %q, want question text", m.LastAssistantText)
+	}
+
+	ledger := tl1.GetLedgerState()
+	if ledger.LastAssistantText != question {
+		t.Fatalf("ledger LastAssistantText = %q, want question text", ledger.LastAssistantText)
+	}
+
+	// Restart: a fresh tailer rehydrated from the ledger resumes at EOF — zero
+	// lines processed — and must still recover the question text so the session
+	// stays classified as waiting.
+	tl2 := newTestTailer(path)
+	tl2.SetLedgerState(ledger)
+	m, err = tl2.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.LastAssistantText != question {
+		t.Errorf("post-restart LastAssistantText = %q, want question text (resume-at-EOF must not forget the question)", m.LastAssistantText)
+	}
+
+	// The downstream classifier reads LastAssistantText via the domain helper:
+	// without the persisted text it would report not-waiting and rule 2b would
+	// demote waiting → ready on startup (issue #705).
+	dm := &session.SessionMetrics{LastEventType: m.LastEventType, LastAssistantText: m.LastAssistantText}
+	if !dm.IsWaitingForUserInput() {
+		t.Error("IsWaitingForUserInput() = false after restart, want true (question text must survive the ledger round-trip)")
+	}
+}

--- a/core/pkg/tailer/ledger_assistant_text_test.go
+++ b/core/pkg/tailer/ledger_assistant_text_test.go
@@ -52,6 +52,14 @@ func TestLedger_PersistsLastAssistantText(t *testing.T) {
 		t.Errorf("post-restart LastAssistantText = %q, want question text (resume-at-EOF must not forget the question)", m.LastAssistantText)
 	}
 
+	// The restored text must also re-persist so a *second* restart survives.
+	// This pins the private-field half of SetLedgerState: restoring only
+	// t.metrics would satisfy the assertions above (the empty pass keeps
+	// metrics) yet leave GetLedgerState reading an empty t.lastAssistantText.
+	if got := tl2.GetLedgerState().LastAssistantText; got != question {
+		t.Errorf("re-persisted LastAssistantText = %q, want %q (private field must be restored too)", got, question)
+	}
+
 	// The downstream classifier reads LastAssistantText via the domain helper:
 	// without the persisted text it would report not-waiting and rule 2b would
 	// demote waiting → ready on startup (issue #705).

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -370,8 +370,11 @@ type TranscriptPathAware interface {
 //
 // History: 3 — #615 (authoritative task IDs + TaskSeq);
 // 4 — #649 (LastEventType persisted; the bump also heals sessions stranded
-// in `working` by pre-#642 parsers, since the re-scan reclassifies them).
-const LedgerSchemaVersion = 4
+// in `working` by pre-#642 parsers, since the re-scan reclassifies them);
+// 5 — #705 (LastAssistantText persisted; the bump also heals sessions
+// mis-demoted from `waiting` to `ready` on restart, since the re-scan
+// recovers the question text IsWaitingForUserInput needs).
+const LedgerSchemaVersion = 5
 
 // LedgerState is the durable portion of a tailer's accumulation state, written
 // to disk after every TailAndProcess pass so that daemon restarts don't reset
@@ -422,6 +425,12 @@ type LedgerState struct {
 	// an empty LastEventType, IsAgentDone can never fire, and no future
 	// activity arrives to re-classify. See issue #649.
 	LastEventType string `json:"last_event_type,omitempty"`
+	// LastAssistantText persists the tail of the most recent assistant message
+	// so a daemon restart that resumes at LastOffset (zero new lines) can still
+	// answer IsWaitingForUserInput. Without it, a session persisted as `waiting`
+	// (turn ended on a question) loses the question text on restart and the seed
+	// re-classification demotes it to `ready`. See issue #705.
+	LastAssistantText string `json:"last_assistant_text,omitempty"`
 }
 
 // --- Shared helpers used by multiple parsers ---

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -404,6 +404,7 @@ func (t *TranscriptTailer) GetLedgerState() LedgerState {
 		CumProviderCostUSD: t.cumProviderCostUSD,
 		ModelName:          t.metrics.ModelName,
 		LastEventType:      t.metrics.LastEventType,
+		LastAssistantText:  t.lastAssistantText,
 	}
 	if len(t.cumByModel) > 0 {
 		// Direct assignment is safe: the caller JSON-marshals immediately
@@ -469,6 +470,17 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 	// a finished turn (issue #649).
 	if s.LastEventType != "" {
 		t.metrics.LastEventType = s.LastEventType
+	}
+	// Restore the question text the same way: a resume-at-EOF pass would
+	// otherwise leave it empty and IsWaitingForUserInput would mis-classify a
+	// persisted `waiting` turn as `ready` (issue #705). Set both — t.metrics
+	// directly so the value survives computeMetrics' empty-MessageHistory early
+	// return on this resume-at-EOF pass (which skips the lastAssistantText
+	// copy), and the private field so it stays the source of truth for the next
+	// ledger write and for computeMetrics on later passes that carry new lines.
+	if s.LastAssistantText != "" {
+		t.lastAssistantText = s.LastAssistantText
+		t.metrics.LastAssistantText = s.LastAssistantText
 	}
 	if s.ParserState != nil {
 		if pp, ok := t.parser.(ParserStateProvider); ok {


### PR DESCRIPTION
Fixes #705.

## Problem

A Claude Code session whose turn ends on a question is persisted as `waiting`. On a **daemon restart** it was incorrectly demoted to `ready`.

Ground truth from the reported session (`a3937818`, daemon `0.5.2`):

```
07:30:34  session-detector       "turn ended with question or cue → waiting"            ✅
08:50:38  session-detector-seed  "re-evaluated agent finished turn → ready on startup"  ❌
```

The `away_summary` recap was incidental — the live path correctly held `waiting`; the only flip was at the **08:50 restart/seed**.

## Root cause

`LedgerState` persisted `LastEventType` (#649) but **not** `LastAssistantText`. On restart the tailer resumes at `LastOffset` (zero new lines), so metrics come from the ledger: `LastEventType=turn_done` (→ `IsAgentDone()`=true) but `LastAssistantText=""` (→ `IsWaitingForUserInput()`=false). The seed re-classification (`session_detector_lifecycle.go`) then runs `ClassifyState(waiting, …)` → rule 2b `agent finished turn → ready`.

## Fix

Persist `LastAssistantText` in the ledger, mirroring the #649 `LastEventType` precedent:

- `parser.go` — add `LastAssistantText` to `LedgerState`; bump `LedgerSchemaVersion` 4→5 (the one-time re-scan self-heals sessions already stranded by an older daemon, exactly as #649 did).
- `tailer.go` — `GetLedgerState` persists it; `SetLedgerState` restores **both** `t.metrics` (survives `computeMetrics`' empty-`MessageHistory` early return on the resume-at-EOF pass, which skips the `lastAssistantText` copy) **and** the private `t.lastAssistantText` (source of truth for the next ledger write + later passes carrying new lines).

## Tests

- New regression `core/pkg/tailer/ledger_assistant_text_test.go`: question turn → ledger round-trip → restart resume-at-EOF → `LastAssistantText` survives and `IsWaitingForUserInput()` stays true. Confirmed it fails without the `SetLedgerState` change.
- `go test ./core/... -race -count=1` green.
- `tools/replay-fixtures.sh` green (no replay-output change — the ledger is live-daemon-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)