### PR TITLE
fix(adapters): unify assistant-text truncation into one tailer rule

### DIFF
--- a/core/adapters/inbound/agents/aider/parser.go
+++ b/core/adapters/inbound/agents/aider/parser.go
@@ -102,7 +102,7 @@ func (p *Parser) ParseLineRaw(line string) *tailer.ParsedEvent {
 		text := strings.TrimPrefix(line, "#### ")
 		return &tailer.ParsedEvent{
 			EventType:      "user_message",
-			AssistantText:  truncate(text),
+			AssistantText:  tailer.TruncateAssistantText(text),
 			ClearToolNames: true,
 		}
 	}
@@ -181,7 +181,7 @@ func (p *Parser) closeModelCall(m []string) *tailer.ParsedEvent {
 	return &tailer.ParsedEvent{
 		EventType:     "assistant_message",
 		ModelName:     p.model,
-		AssistantText: truncate(text),
+		AssistantText: tailer.TruncateAssistantText(text),
 		Contribution:  contribution,
 		TaskEstimate:  taskEstimate,
 		Tokens: &tailer.TokenSnapshot{
@@ -205,7 +205,7 @@ func (p *Parser) flushErrorTurn(line string) *tailer.ParsedEvent {
 	return &tailer.ParsedEvent{
 		EventType:     "turn_done",
 		ModelName:     p.model,
-		AssistantText: truncate(errText),
+		AssistantText: tailer.TruncateAssistantText(errText),
 	}
 }
 
@@ -265,13 +265,4 @@ func parseTokenCount(s string) int64 {
 		return 0
 	}
 	return int64(v * float64(mult))
-}
-
-func truncate(s string) string {
-	const max = 200
-	runes := []rune(strings.TrimSpace(s))
-	if len(runes) <= max {
-		return string(runes)
-	}
-	return "…" + string(runes[len(runes)-max:])
 }

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -634,12 +634,7 @@ func applyAssistantText(raw map[string]interface{}, ev *tailer.ParsedEvent, even
 	case "assistant", eventTypeAssistantStreaming, "assistant_message", "assistant_output":
 		ev.AssistantText = tailer.ExtractAssistantText(raw)
 		if ev.AssistantText == "" && askUserQuestion != "" {
-			runes := []rune(askUserQuestion)
-			if len(runes) > 200 {
-				ev.AssistantText = "…" + string(runes[len(runes)-200:])
-			} else {
-				ev.AssistantText = askUserQuestion
-			}
+			ev.AssistantText = tailer.TruncateAssistantText(askUserQuestion)
 		}
 	case "user", "user_message", "user_input":
 		ev.ClearToolNames = true

--- a/core/adapters/inbound/agents/geminicli/parser.go
+++ b/core/adapters/inbound/agents/geminicli/parser.go
@@ -198,7 +198,7 @@ var terminalInfoMarkers = []string{
 func (p *Parser) parseError(raw map[string]interface{}, ev *tailer.ParsedEvent) bool {
 	content, _ := raw["content"].(string)
 	ev.EventType = "turn_done"
-	ev.AssistantText = tailTruncate(content, 200)
+	ev.AssistantText = tailer.TruncateAssistantText(content)
 	ev.IsError = true
 	return true
 }
@@ -294,7 +294,7 @@ func (p *Parser) parseAssistant(raw map[string]interface{}, ev *tailer.ParsedEve
 	ev.EventType = "assistant_message"
 
 	content, _ := raw["content"].(string)
-	ev.AssistantText = tailTruncate(content, 200)
+	ev.AssistantText = tailer.TruncateAssistantText(content)
 	if est := tailer.ScanTaskEstimate(content, ev.Timestamp); est != nil {
 		ev.TaskEstimate = est
 	}
@@ -491,16 +491,6 @@ func workspaceFromContent(content interface{}) string {
 		}
 	}
 	return ""
-}
-
-// tailTruncate keeps the last n runes of s — matching the waiting-display
-// convention of the other adapters (most-recent words win).
-func tailTruncate(s string, n int) string {
-	r := []rune(s)
-	if len(r) <= n {
-		return s
-	}
-	return string(r[len(r)-n:])
 }
 
 // intFromAny coerces a JSON number (decoded as float64) to int64.

--- a/core/adapters/inbound/agents/kirocli/parser.go
+++ b/core/adapters/inbound/agents/kirocli/parser.go
@@ -103,10 +103,7 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 			ev.EventType = "turn_done"
 			p.applySidecarMetrics(ev)
 		}
-		if runes := []rune(lastText); len(runes) > 200 {
-			lastText = string(runes[:200])
-		}
-		ev.AssistantText = lastText
+		ev.AssistantText = tailer.TruncateAssistantText(lastText)
 
 	case "ToolResults":
 		ev.EventType = "tool_result"

--- a/core/adapters/inbound/agents/kirocli/parser_test.go
+++ b/core/adapters/inbound/agents/kirocli/parser_test.go
@@ -173,8 +173,13 @@ func TestParser_AssistantTextTruncated(t *testing.T) {
 		},
 	}
 	ev := p.ParseLine(raw)
-	if got := len([]rune(ev.AssistantText)); got != 200 {
-		t.Errorf("AssistantText length = %d, want 200", got)
+	// Tail truncation keeps the trailing 200 runes with a leading ellipsis
+	// (the shared tailer.TruncateAssistantText rule) — not the head.
+	if got := len([]rune(ev.AssistantText)); got != 201 {
+		t.Errorf("AssistantText rune count = %d, want 201 (… + 200 runes)", got)
+	}
+	if !strings.HasPrefix(ev.AssistantText, "…") {
+		t.Errorf("AssistantText = %q, want leading … (tail truncation)", ev.AssistantText)
 	}
 }
 

--- a/core/adapters/inbound/agents/opencode/parser.go
+++ b/core/adapters/inbound/agents/opencode/parser.go
@@ -208,12 +208,7 @@ func parseTextPart(raw map[string]interface{}, ev *tailer.ParsedEvent) *tailer.P
 		if est := tailer.ScanTaskEstimate(text, ev.Timestamp); est != nil {
 			ev.TaskEstimate = est
 		}
-		runes := []rune(text)
-		if len(runes) > 200 {
-			ev.AssistantText = "…" + string(runes[len(runes)-200:])
-		} else {
-			ev.AssistantText = text
-		}
+		ev.AssistantText = tailer.TruncateAssistantText(text)
 	}
 	return ev
 }

--- a/core/adapters/inbound/agents/pi/parser.go
+++ b/core/adapters/inbound/agents/pi/parser.go
@@ -197,8 +197,5 @@ func extractPiAssistantText(piMsg map[string]interface{}) string {
 			}
 		}
 	}
-	if len([]rune(text)) > 200 {
-		return string([]rune(text)[:200])
-	}
-	return text
+	return tailer.TruncateAssistantText(text)
 }

--- a/core/adapters/inbound/agents/pi/parser_test.go
+++ b/core/adapters/inbound/agents/pi/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -502,6 +503,27 @@ func TestParser_BashExecutionSkipped_PreservesLastEvent(t *testing.T) {
 	}
 	if m.LastEventType != "turn_done" {
 		t.Errorf("LastEventType = %q, want turn_done (bashExecution should be skipped)", m.LastEventType)
+	}
+}
+
+// extractPiAssistantText keeps the trailing 200 runes with a leading ellipsis
+// (the shared tailer.TruncateAssistantText rule). Tail, not head: the latest
+// words — including a trailing "?" that waiting-state detection reads — survive.
+func TestExtractPiAssistantText_TailTruncated(t *testing.T) {
+	piMsg := map[string]interface{}{
+		"content": []interface{}{
+			map[string]interface{}{"type": "text", "text": strings.Repeat("x", 300) + "?"},
+		},
+	}
+	got := extractPiAssistantText(piMsg)
+	if n := len([]rune(got)); n != 201 {
+		t.Errorf("rune count = %d, want 201 (… + 200 runes)", n)
+	}
+	if !strings.HasPrefix(got, "…") {
+		t.Errorf("got %q, want leading … (tail truncation)", got)
+	}
+	if !strings.HasSuffix(got, "?") {
+		t.Error("trailing question mark dropped — head truncated instead of tail")
 	}
 }
 

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -521,19 +521,26 @@ func ExtractAssistantText(raw map[string]interface{}) string {
 		collectText(arr)
 	}
 
-	var text string
-	switch len(parts) {
-	case 0:
-		return ""
-	case 1:
-		text = strings.TrimSpace(parts[0])
-	default:
-		text = strings.TrimSpace(strings.Join(parts, " "))
-	}
+	return TruncateAssistantText(strings.Join(parts, " "))
+}
 
+// MaxAssistantTextRunes caps the assistant text kept for waiting-state display.
+const MaxAssistantTextRunes = 200
+
+// TruncateAssistantText reduces s to the assistant text kept for waiting-state
+// display: trimmed, then at most the trailing MaxAssistantTextRunes runes with a
+// leading ellipsis when it drops text. Keeping the tail (not the head) preserves
+// the agent's most recent words — the part that signals whether it is waiting on
+// the user, and where a trailing question mark lands.
+//
+// This is the single display-truncation rule shared by every agent adapter.
+// Adapters MUST scan the full text for markers (ScanTaskEstimate) BEFORE calling
+// this — the dropped head can carry a task-estimate marker.
+func TruncateAssistantText(s string) string {
+	text := strings.TrimSpace(s)
 	runes := []rune(text)
-	if len(runes) > 200 {
-		return "…" + string(runes[len(runes)-200:])
+	if len(runes) > MaxAssistantTextRunes {
+		return "…" + string(runes[len(runes)-MaxAssistantTextRunes:])
 	}
 	return text
 }

--- a/core/pkg/tailer/truncate_assistant_text_test.go
+++ b/core/pkg/tailer/truncate_assistant_text_test.go
@@ -1,0 +1,54 @@
+package tailer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTruncateAssistantText(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"short unchanged", "waiting for input?", "waiting for input?"},
+		{"trims surrounding whitespace", "  hi there \n", "hi there"},
+		{"exactly max, no ellipsis", strings.Repeat("x", MaxAssistantTextRunes), strings.Repeat("x", MaxAssistantTextRunes)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TruncateAssistantText(tc.in); got != tc.want {
+				t.Errorf("TruncateAssistantText(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTruncateAssistantText_LongKeepsTailWithEllipsis(t *testing.T) {
+	// The head must be dropped and the tail kept: a trailing "?" is what
+	// waiting-state detection reads, so it has to survive truncation.
+	long := strings.Repeat("a", 50) + " " + strings.Repeat("b", 300) + "?"
+	got := TruncateAssistantText(long)
+
+	if !strings.HasPrefix(got, "…") {
+		t.Errorf("want leading ellipsis, got %q…", string([]rune(got)[:10]))
+	}
+	if !strings.HasSuffix(got, "?") {
+		t.Error("trailing question mark dropped — tail not preserved")
+	}
+	if strings.Contains(got, "a") {
+		t.Error("head 'a' run leaked through — truncation kept the head, not the tail")
+	}
+	if n := len([]rune(got)); n != MaxAssistantTextRunes+1 {
+		t.Errorf("rune count = %d, want %d (ellipsis + %d runes)", n, MaxAssistantTextRunes+1, MaxAssistantTextRunes)
+	}
+}
+
+func TestTruncateAssistantText_CountsRunesNotBytes(t *testing.T) {
+	// Multi-byte runes are counted as runes, not bytes.
+	got := TruncateAssistantText(strings.Repeat("é", MaxAssistantTextRunes+50))
+	if n := len([]rune(got)); n != MaxAssistantTextRunes+1 {
+		t.Errorf("rune count = %d, want %d", n, MaxAssistantTextRunes+1)
+	}
+}

--- a/replaydata/agents/gemini-cli/scenarios/2-21_streaming-partial-writes/recordings/2026-06-12-10-45-31_irrlichd-0.5.1+d08e499/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/gemini-cli/scenarios/2-21_streaming-partial-writes/recordings/2026-06-12-10-45-31_irrlichd-0.5.1+d08e499/transcript.jsonl.replay.json.golden
@@ -71,7 +71,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "hing shifted.\nThe next brushstroke curved with a newfound grace, mimicking the s…"
+      "last_assistant_text_head": "…hing shifted.\nThe next brushstroke curved with a newfound grace, mimicking th…"
     }
   ]
 }

--- a/replaydata/agents/gemini-cli/scenarios/2-8_autonomous-loop-iteration-limit/recordings/2026-06-12-11-00-58_irrlichd-0.5.1+03b030b/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/gemini-cli/scenarios/2-8_autonomous-loop-iteration-limit/recordings/2026-06-12-11-00-58_irrlichd-0.5.1+03b030b/transcript.jsonl.replay.json.golden
@@ -101,7 +101,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "orced to choose, the number zero is the closest candidate, as it is historically…"
+      "last_assistant_text_head": "…orced to choose, the number zero is the closest candidate, as it is historica…"
     },
     {
       "index": 5,

--- a/replaydata/agents/gemini-cli/scenarios/5-8_task-estimate-marker/recordings/2026-06-12-11-32-36_irrlichd-0.5.1+293beef/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/gemini-cli/scenarios/5-8_task-estimate-marker/recordings/2026-06-12-11-32-36_irrlichd-0.5.1+293beef/transcript.jsonl.replay.json.golden
@@ -72,7 +72,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "ts, before concluding with actionable strategies to cultivate a healthy, sustain…"
+      "last_assistant_text_head": "…ts, before concluding with actionable strategies to cultivate a healthy, sust…"
     },
     {
       "index": 3,
@@ -101,7 +101,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": " absolute confidence, and construct resilient continuous integration pipelines t…"
+      "last_assistant_text_head": "… absolute confidence, and construct resilient continuous integration pipeline…"
     },
     {
       "index": 5,
@@ -130,7 +130,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "ases, improve performance, and cleanly integrate new capabilities, knowing that …"
+      "last_assistant_text_head": "…ases, improve performance, and cleanly integrate new capabilities, knowing th…"
     },
     {
       "index": 7,
@@ -159,7 +159,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "ssertions, teams can build a sustainable testing culture that keeps codebases ag…"
+      "last_assistant_text_head": "…ssertions, teams can build a sustainable testing culture that keeps codebases…"
     },
     {
       "index": 9,

--- a/replaydata/agents/kiro-cli/scenarios/5-8_task-estimate-marker/recordings/2026-06-05-03-29-30_irrlichd-0.4.8+cdefa05.dirty/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/kiro-cli/scenarios/5-8_task-estimate-marker/recordings/2026-06-05-03-29-30_irrlichd-0.4.8+cdefa05.dirty/transcript.jsonl.replay.json.golden
@@ -47,7 +47,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "\u003c!-- {\"marker\":\"irrlicht-eta\",\"total_rounds\":3,\"completed_rounds\":3} --\u003e\n\nAll 3 …"
+      "last_assistant_text_head": "…eted_rounds\":3} --\u003e\n\nAll 3 rounds complete. The planning task produced: a lis…"
     },
     {
       "index": 2,
@@ -62,7 +62,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "\u003c!-- {\"marker\":\"irrlicht-eta\",\"total_rounds\":3,\"completed_rounds\":3} --\u003e\n\nAll 3 …"
+      "last_assistant_text_head": "…eted_rounds\":3} --\u003e\n\nAll 3 rounds complete. The planning task produced: a lis…"
     }
   ]
 }

--- a/replaydata/agents/opencode/scenarios/5-3_model-switch-midsession/recordings/2026-05-29-23-39-07_irrlichd-0.4.7+c56c426.dirty/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/opencode/scenarios/5-3_model-switch-midsession/recordings/2026-05-29-23-39-07_irrlichd-0.4.7+c56c426.dirty/transcript.jsonl.replay.json.golden
@@ -99,7 +99,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "\n\ntwo"
+      "last_assistant_text_head": "two"
     }
   ]
 }

--- a/replaydata/agents/pi/regressions/01-example-session/recordings/2026-04-06-16-22-10_irrlichd-unknown/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/regressions/01-example-session/recordings/2026-04-06-16-22-10_irrlichd-unknown/transcript.jsonl.replay.json.golden
@@ -15,19 +15,19 @@
     "last_event_time": "2026-04-06T20:39:45.037Z",
     "wall_clock_session_duration": 15454196000000,
     "state_durations": {
-      "ready": 11872449000000,
-      "waiting": 652890000000,
+      "ready": 11421081000000,
+      "waiting": 1104258000000,
       "working": 2928857000000
     },
-    "flicker_count": 11,
+    "flicker_count": 10,
     "flickers_by_category": {
       "ready_between_working": 1,
-      "working_between_ready": 9,
+      "working_between_ready": 8,
       "working_between_waiting": 1
     },
     "flickers_by_reason": {
       "agent finished turn → ready": 1,
-      "force ready→working on first activity": 9,
+      "force ready→working on first activity": 8,
       "transcript activity (waiting → working)": 1
     },
     "cum_input_tokens": 910869,
@@ -106,7 +106,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Done — committed and pushed.\n\n- **Commit:** `b1a70a8`\n- **Message:** `Simplify…"
+      "last_assistant_text_head": "…mport AGENTS.md`\n- **Branch:** `test/subagent-display-regression-88`\n- **Push…"
     },
     {
       "index": 5,
@@ -135,7 +135,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Merged and synced successfully ✅\n\nWhat I did:\n\n1. Checked out `main`\n2. Pulled…"
+      "last_assistant_text_head": "…ed `test/subagent-display-regression-88` into `main`\n4. Pushed `main` to orig…"
     },
     {
       "index": 7,
@@ -164,7 +164,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Done — I followed the `ir:test-mac` flow and rebuilt/restarted the local mac d…"
+      "last_assistant_text_head": "…PID: `17808`\n- App PID: `18073`\n- `curl http://localhost:7837/api/v1/sessions…"
     },
     {
       "index": 9,
@@ -179,7 +179,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Done — I followed the `ir:test-mac` flow and rebuilt/restarted the local mac d…"
+      "last_assistant_text_head": "…PID: `17808`\n- App PID: `18073`\n- `curl http://localhost:7837/api/v1/sessions…"
     },
     {
       "index": 10,
@@ -194,7 +194,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Done — I followed the `ir:test-mac` flow and rebuilt/restarted the local mac d…"
+      "last_assistant_text_head": "…PID: `17808`\n- App PID: `18073`\n- `curl http://localhost:7837/api/v1/sessions…"
     },
     {
       "index": 11,
@@ -223,7 +223,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Found it. Root cause is in the **Pi parser/state pipeline**, not your session fi…"
+      "last_assistant_text_head": "…ion appears `ready` while compact is running.\n\nIf you want, I can patch this …"
     },
     {
       "index": 13,
@@ -252,7 +252,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Done — I created a branch, implemented the fix with tests, verified it, and op…"
+      "last_assistant_text_head": "…o test ./... -count=1` ✅\n\n### Commit\n- `5a634bf`\n- Message: **Treat Pi comp…"
     },
     {
       "index": 15,
@@ -281,7 +281,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "I checked that exact Pi session transcript and the detector logic.  \nThe main is…"
+      "last_assistant_text_head": "…ressively for Pi’s normal tool durations + missing permission-mode signal f…"
     },
     {
       "index": 17,
@@ -310,7 +310,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Yes — your instinct is right.\n\n## Verdict\n**Adapter-specific waiting logic is …"
+      "last_assistant_text_head": "…orrectly entering `waiting` during normal long-running `bash/read/write` tool…"
     },
     {
       "index": 19,
@@ -339,7 +339,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Implemented ✅ — adapter-specific waiting logic is now in place.\n\n### What I …"
+      "last_assistant_text_head": "…cd core \u0026\u0026 go test ./... -count=1` ✅\n\n---\n\n### Commit \u0026 PR\n\n- **Commit:** `…"
     },
     {
       "index": 21,
@@ -368,7 +368,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Done — I merged the latest `main` into your branch and pushed it.\n\n- Branch: `…"
+      "last_assistant_text_head": "…ushed it.\n\n- Branch: `fix/pi-compaction-working-state`\n- Merged: `origin/main…"
     },
     {
       "index": 23,
@@ -397,7 +397,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Done — local dev stack rebuilt and restarted.\n\n### Executed\n- Built daemon: `c…"
+      "last_assistant_text_head": "…rocess + API response\n\n### Running now\n- Daemon PID: `85218`\n- App PID: `8565…"
     },
     {
       "index": 25,
@@ -483,7 +483,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Found the root cause in that session’s latest task.\n\n### What’s wrong\n\nIn tr…"
+      "last_assistant_text_head": "…i model behavior issue; it’s a **tailer ingestion bug with oversized JSONL …"
     },
     {
       "index": 31,
@@ -540,7 +540,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Continued and applied the fix.\n\nI found this could not be fixed purely in `pi/pa…"
+      "last_assistant_text_head": "…rlichd` + debug macOS app), so you can test immediately.\n\nIf you want, I can …"
     },
     {
       "index": 35,
@@ -569,7 +569,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Rebuilt and redeployed both ✅\n\n- Daemon rebuilt to: `/tmp/irrlichd`\n- Swift ap…"
+      "last_assistant_text_head": "…ocket cleaned\n- Dev daemon restarted\n- Dev app restarted\n- Verified running +…"
     },
     {
       "index": 37,
@@ -627,7 +627,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Done — I triggered **two very long JSONL tool results in a row** in this same …"
+      "last_assistant_text_head": "…i/agent/sessions/--Users-ingo-projects-irrlicht--/2026-04-06T16-22-10-841Z_25…"
     },
     {
       "index": 41,
@@ -642,7 +642,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Done — I triggered **two very long JSONL tool results in a row** in this same …"
+      "last_assistant_text_head": "…i/agent/sessions/--Users-ingo-projects-irrlicht--/2026-04-06T16-22-10-841Z_25…"
     },
     {
       "index": 42,
@@ -657,7 +657,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Done — I triggered **two very long JSONL tool results in a row** in this same …"
+      "last_assistant_text_head": "…i/agent/sessions/--Users-ingo-projects-irrlicht--/2026-04-06T16-22-10-841Z_25…"
     },
     {
       "index": 43,
@@ -714,7 +714,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Great catch — you’re exactly right.\n\n### Where the data points came from\n\nFo…"
+      "last_assistant_text_head": "…used: `35650 / 200000 = 17.8%` (wrong basis)\n- should be with 256k: `35650 / …"
     },
     {
       "index": 47,
@@ -743,7 +743,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Good fix is:\n\n### 1) Add the missing model mapping (root cause)\n`core/pkg/capaci…"
+      "last_assistant_text_head": "…loying, restart daemon / re-tail session so cached metrics are recomputed fro…"
     },
     {
       "index": 49,
@@ -772,7 +772,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Updated ✅ — I applied the fix for the Codex 5.3 context window miscalculatio…"
+      "last_assistant_text_head": "…=1`\n- `cd core \u0026\u0026 go test ./pkg/capacity ./pkg/tailer -count=1`\n\nAll passing.…"
     },
     {
       "index": 51,
@@ -801,7 +801,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Done — committed and pushed to the PR branch.\n\n### Pushed\n- **Branch:** `fix/p…"
+      "last_assistant_text_head": "…*Message:** `Fix Codex gpt-5.3 context window mapping to 256K`\n\n### Includes\n…"
     },
     {
       "index": 53,
@@ -830,7 +830,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Merged and pushed to `main` ✅\n\n- Merged branch: `fix/pi-compaction-working-sta…"
+      "last_assistant_text_head": "…n` ✅\n\n- Merged branch: `fix/pi-compaction-working-state`\n- Merge commit on …"
     },
     {
       "index": 55,
@@ -881,23 +881,23 @@
       "virtual_time": "2026-04-06T19:03:24.203Z",
       "cause": "event",
       "prev_state": "working",
-      "new_state": "ready",
-      "reason": "agent finished turn → ready",
+      "new_state": "waiting",
+      "reason": "turn ended with question or cue → waiting",
       "last_event_type": "turn_done",
       "has_open_tool": false,
       "is_agent_done": true,
       "needs_user_attention": false,
-      "waiting_for_user_input": false,
-      "last_assistant_text_head": "Easy way: add it as a **skill**.\n\nI checked the skills index and found web-searc…"
+      "waiting_for_user_input": true,
+      "last_assistant_text_head": "…lls need an API key (depends on provider: Brave/Exa/etc.).\n- Check the skill …"
     },
     {
       "index": 59,
       "event_index": 518,
       "virtual_time": "2026-04-06T19:10:55.571Z",
       "cause": "event",
-      "prev_state": "ready",
+      "prev_state": "waiting",
       "new_state": "working",
-      "reason": "force ready→working on first activity",
+      "reason": "transcript activity (waiting → working)",
       "last_event_type": "user_message",
       "has_open_tool": false,
       "is_agent_done": false,
@@ -1149,7 +1149,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "Created both issues in `bd`:\n\n1. **irrlicht-ahy** — *Update README images*  \n2…"
+      "last_assistant_text_head": "… issues in `bd`:\n\n1. **irrlicht-ahy** — *Update README images*  \n2. **irrli…"
     },
     {
       "index": 77,

--- a/replaydata/agents/pi/scenarios/2-16_oversized-transcript-line/recordings/2026-05-25-02-36-28_irrlichd-0.4.7+6ab9f88/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/scenarios/2-16_oversized-transcript-line/recordings/2026-05-25-02-36-28_irrlichd-0.4.7+6ab9f88/transcript.jsonl.replay.json.golden
@@ -68,7 +68,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": false,
-      "last_assistant_text_head": "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30…"
+      "last_assistant_text_head": "…\n351\n352\n353\n354\n355\n356\n357\n358\n359\n360\n361\n362\n363\n364\n365\n366\n367\n368\n369\n…"
     }
   ]
 }


### PR DESCRIPTION
## What

Collapses the assistant-text display-truncation logic — duplicated across six
adapters with **drifted rules** — into one deep module in the `tailer` seam:

```go
const MaxAssistantTextRunes = 200
func TruncateAssistantText(s string) string // trim → trailing 200 runes → ellipsis
```

`ExtractAssistantText` now delegates to it; `aider`, `gemini-cli`, `kiro-cli`,
`pi` and `opencode` call it; the orphaned `aider.truncate` and
`gemini-cli.tailTruncate` are deleted. `codex`/`claude-code` already rode
`ExtractAssistantText`.

Format-specific *extraction* stays in the adapters (parsers belong in adapters);
only the cross-cutting truncation rule is concentrated.

## Why — this fixes a real bug

The rules had drifted: **`kiro-cli` and `pi` kept the first 200 runes**, while
`aider`, `opencode`, `gemini-cli` and the tailer kept the last 200. Head
truncation drops the agent's most recent words — exactly what waiting-state
question/cue detection reads — so a question at the **end** of a long message was
missed. Tail truncation is the documented convention (`pi` and `gemini-cli`'s own
comments say "most-recent words win").

Adapters still scan the **full** text for the task-estimate marker (`#558`)
*before* truncating, so estimate detection is unchanged (verified: the
task-estimate goldens changed only in display text, not in any estimate field).

## ⚠️ Behavioral change to review — pi state classification

This corrects pi's waiting detection, and the **pi regression fixture
(`01-example-session`) shifted as a result**: one turn now classifies as
**`waiting`** instead of `ready` (total `waiting` +0.45s, `flicker_count` 11→10).

Cause: pi used to truncate to the head, hiding the turn's *ending* from the
classifier. With the tail, the classifier's "question or cue → waiting" rule
fires. The truncation change feeds the classifier the architecturally correct
input — but that turn's full message ends with an instruction/config block, not a
literal `?`, so **whether this specific flip is a true positive is a
classifier-heuristic question worth a look**. If the cue heuristic is over-firing
on non-question tails, that's a separate follow-up, independent of this PR.

## Changes

- `core/pkg/tailer/parser.go` — new `TruncateAssistantText` + `MaxAssistantTextRunes`; `ExtractAssistantText` delegates (behavior-identical)
- 5 adapter parsers migrated; 2 orphaned helpers deleted
- Tests: new `TestTruncateAssistantText` (the interface is the test surface); kiro-cli test flipped to assert tail+ellipsis; new pi tail-truncation guard
- 7 replay goldens regenerated — touched adapters only (`gemini-cli` ×3, `pi` ×2, `kiro-cli`, `opencode`)

## Verification

- `go test ./core/... -race -count=1` — green (one unrelated flaky timing test, `TestDebounce_FirstEventFiresImmediately`, passes 5/5 in isolation)
- `go test ./tools/onboarding-factory/... -count=1` — green
- `tools/replay-fixtures.sh` — green · `of validate` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
