### PR TITLE
refactor(adapters): share the todo-snapshot reconciler

### DIFF
--- a/core/adapters/inbound/agents/geminicli/parser.go
+++ b/core/adapters/inbound/agents/geminicli/parser.go
@@ -2,7 +2,6 @@ package geminicli
 
 import (
 	"regexp"
-	"strconv"
 	"strings"
 
 	"irrlicht/core/pkg/tailer"
@@ -41,13 +40,11 @@ type Parser struct {
 	cwd       string
 	committed map[string]tailer.UsageBreakdown
 
-	// write_todos snapshot state. Gemini-2 models register a `write_todos`
-	// tool that rewrites the whole todo list on every call (full-list
-	// replace, like codex `update_plan` / opencode `todowrite`). Todos carry
-	// no stable ID, so they're keyed by their `description` text and assigned
-	// a synthetic monotonic ID matching the tailer's Create-time numbering.
-	todoIDByDesc map[string]string
-	nextTaskID   int
+	// todos reconciles the `write_todos` snapshot Gemini-2 models emit (a
+	// full-list-replace tool, like codex `update_plan` / opencode
+	// `todowrite`) into task-progress deltas. Todos carry no stable ID, so
+	// they're keyed by their `description` text.
+	todos tailer.TodoReconciler
 }
 
 // workspaceRe pulls the first workspace directory out of the bootstrap
@@ -421,53 +418,18 @@ func (p *Parser) appendWriteTodosDeltas(tcm map[string]interface{}, ev *tailer.P
 	if args == nil {
 		return
 	}
-	todos, _ := args["todos"].([]interface{})
-	if len(todos) == 0 {
-		return
-	}
-	if p.todoIDByDesc == nil {
-		p.todoIDByDesc = make(map[string]string)
-	}
-	snapshot := make([]tailer.TaskSnapshotEntry, 0, len(todos))
-	for _, raw := range todos {
+	rawTodos, _ := args["todos"].([]interface{})
+	todos := make([]tailer.Todo, 0, len(rawTodos))
+	for _, raw := range rawTodos {
 		todo, _ := raw.(map[string]interface{})
 		if todo == nil {
 			continue
 		}
 		desc, _ := todo["description"].(string)
 		status, _ := todo["status"].(string)
-		if desc == "" {
-			continue
-		}
-		id, seen := p.todoIDByDesc[desc]
-		if !seen {
-			p.nextTaskID++
-			id = strconv.Itoa(p.nextTaskID)
-			p.todoIDByDesc[desc] = id
-			ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
-				Op:      tailer.TaskOpCreate,
-				Subject: desc,
-			})
-		}
-		// Create starts a task at pending; an Update is required to move it
-		// forward. Reversions back to pending are handled by the snapshot
-		// reconcile below (the delta-only path silently skips them).
-		if status != "" && status != tailer.TaskStatusPending {
-			ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
-				Op:     tailer.TaskOpUpdate,
-				ID:     id,
-				Status: status,
-			})
-		}
-		snapshot = append(snapshot, tailer.TaskSnapshotEntry{
-			ID:      id,
-			Subject: desc,
-			Status:  status,
-		})
+		todos = append(todos, tailer.Todo{Key: desc, Status: status})
 	}
-	if len(snapshot) > 0 {
-		ev.TaskSnapshot = &snapshot
-	}
+	p.todos.Reconcile(todos, ev)
 }
 
 // workspaceFromContent finds the first workspace directory inside a message's

--- a/core/adapters/inbound/agents/opencode/parser.go
+++ b/core/adapters/inbound/agents/opencode/parser.go
@@ -1,7 +1,6 @@
 package opencode
 
 import (
-	"strconv"
 	"time"
 
 	"irrlicht/core/pkg/tailer"
@@ -34,13 +33,10 @@ import (
 // Each Parser instance corresponds to one transcript/session scan; state
 // resets across scans because ComputeMetrics constructs a fresh Parser.
 type Parser struct {
-	// nextTaskID mirrors the tailer's monotonic taskSeq so emitted Update
-	// IDs match the IDs the tailer assigns at Create time.
-	nextTaskID int
-	// todoIDByContent maps a todo's `content` field to the synthetic ID
-	// assigned on first sight. OpenCode todos have no stable identifier;
-	// content is the closest thing to identity. Lazily initialized.
-	todoIDByContent map[string]string
+	// todos reconciles OpenCode's todowrite snapshots into task-progress
+	// deltas. OpenCode todos have no stable identifier, so they're keyed by
+	// `content` — the closest thing to identity.
+	todos tailer.TodoReconciler
 }
 
 // ParseLine parses a raw map representing one OpenCode part row into a
@@ -282,55 +278,18 @@ func (p *Parser) appendTodowriteDeltas(state map[string]interface{}, ev *tailer.
 	if input == nil {
 		return
 	}
-	todos, _ := input["todos"].([]interface{})
-	if len(todos) == 0 {
-		return
-	}
-	snapshot := make([]tailer.TaskSnapshotEntry, 0, len(todos))
-	for _, raw := range todos {
+	rawTodos, _ := input["todos"].([]interface{})
+	todos := make([]tailer.Todo, 0, len(rawTodos))
+	for _, raw := range rawTodos {
 		todo, _ := raw.(map[string]interface{})
 		if todo == nil {
 			continue
 		}
 		content, _ := todo["content"].(string)
 		status, _ := todo["status"].(string)
-		if content == "" {
-			continue
-		}
-		id, seen := p.todoIDByContent[content]
-		if !seen {
-			p.nextTaskID++
-			id = strconv.Itoa(p.nextTaskID)
-			if p.todoIDByContent == nil {
-				p.todoIDByContent = make(map[string]string)
-			}
-			p.todoIDByContent[content] = id
-			ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
-				Op:      tailer.TaskOpCreate,
-				Subject: content,
-			})
-		}
-		// Emit an Update for any non-pending status — the tailer's Create
-		// path always starts a task at pending, so an Update is required
-		// to move it forward. Pending updates are handled by the snapshot
-		// reconcile below (it can drive a task BACK to pending, which the
-		// delta-only path silently skips).
-		if status != "" && status != tailer.TaskStatusPending {
-			ev.TaskDeltas = append(ev.TaskDeltas, tailer.TaskDelta{
-				Op:     tailer.TaskOpUpdate,
-				ID:     id,
-				Status: status,
-			})
-		}
-		snapshot = append(snapshot, tailer.TaskSnapshotEntry{
-			ID:      id,
-			Subject: content,
-			Status:  status,
-		})
+		todos = append(todos, tailer.Todo{Key: content, Status: status})
 	}
-	if len(snapshot) > 0 {
-		ev.TaskSnapshot = &snapshot
-	}
+	p.todos.Reconcile(todos, ev)
 }
 
 // extractCost reads the top-level "cost" field from a part data map.

--- a/core/pkg/tailer/todo_reconciler.go
+++ b/core/pkg/tailer/todo_reconciler.go
@@ -1,0 +1,75 @@
+// todo_reconciler.go translates an agent's authoritative todo-list snapshot into
+// the task-progress deltas the tailer folds into session metrics. Agents whose
+// "rewrite the whole list every call" todo tool (opencode `todowrite`,
+// gemini-cli `write_todos`, codex `update_plan`) carries no stable per-todo ID
+// share this: each adapter extracts its format-specific todos and hands them
+// over keyed by the user-visible label.
+package tailer
+
+import "strconv"
+
+// Todo is one entry of an agent's todo-list snapshot, normalized across formats.
+// Key is the stable-enough identity — the user-visible label (opencode's
+// `content`, gemini-cli's `description`); Status is the agent's raw status
+// string ("" | pending | in_progress | completed | …).
+type Todo struct {
+	Key    string
+	Status string
+}
+
+// TodoReconciler turns successive whole-list todo snapshots into the minimal
+// TaskCreate/TaskUpdate delta sequence plus a TaskSnapshot, assigning each
+// distinct Key a synthetic monotonic ID that matches the tailer's Create-time
+// numbering. Hold one per Parser — its zero value is ready to use.
+//
+// Two todos sharing a Key collapse into one tracked task: a silent, acceptable
+// trade-off, since the Key is the label the agent's own UI shows.
+type TodoReconciler struct {
+	idByKey map[string]string
+	nextID  int
+}
+
+// Reconcile appends the Create/Update deltas for todos to ev.TaskDeltas and sets
+// ev.TaskSnapshot to the full tracked list. A Create starts a task at pending, so
+// a non-pending status emits an Update to move it forward; reversions back to
+// pending are left to the tailer's snapshot reconcile (the delta path skips them
+// by design). Empty-Key todos are skipped; an empty slice is a no-op.
+func (r *TodoReconciler) Reconcile(todos []Todo, ev *ParsedEvent) {
+	if len(todos) == 0 {
+		return
+	}
+	if r.idByKey == nil {
+		r.idByKey = make(map[string]string)
+	}
+	snapshot := make([]TaskSnapshotEntry, 0, len(todos))
+	for _, todo := range todos {
+		if todo.Key == "" {
+			continue
+		}
+		id, seen := r.idByKey[todo.Key]
+		if !seen {
+			r.nextID++
+			id = strconv.Itoa(r.nextID)
+			r.idByKey[todo.Key] = id
+			ev.TaskDeltas = append(ev.TaskDeltas, TaskDelta{
+				Op:      TaskOpCreate,
+				Subject: todo.Key,
+			})
+		}
+		if todo.Status != "" && todo.Status != TaskStatusPending {
+			ev.TaskDeltas = append(ev.TaskDeltas, TaskDelta{
+				Op:     TaskOpUpdate,
+				ID:     id,
+				Status: todo.Status,
+			})
+		}
+		snapshot = append(snapshot, TaskSnapshotEntry{
+			ID:      id,
+			Subject: todo.Key,
+			Status:  todo.Status,
+		})
+	}
+	if len(snapshot) > 0 {
+		ev.TaskSnapshot = &snapshot
+	}
+}

--- a/core/pkg/tailer/todo_reconciler_test.go
+++ b/core/pkg/tailer/todo_reconciler_test.go
@@ -1,0 +1,81 @@
+package tailer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTodoReconciler_CreateThenStableIDs(t *testing.T) {
+	var r TodoReconciler
+
+	ev1 := &ParsedEvent{}
+	r.Reconcile([]Todo{
+		{Key: "write tests", Status: "pending"},
+		{Key: "ship it", Status: "in_progress"},
+	}, ev1)
+
+	// Two Creates (each starts at pending); the in_progress one also gets an
+	// Update to move it forward. A pending todo gets no Update.
+	want1 := []TaskDelta{
+		{Op: TaskOpCreate, Subject: "write tests"},
+		{Op: TaskOpCreate, Subject: "ship it"},
+		{Op: TaskOpUpdate, ID: "2", Status: "in_progress"},
+	}
+	if !reflect.DeepEqual(ev1.TaskDeltas, want1) {
+		t.Errorf("deltas =\n %+v\nwant\n %+v", ev1.TaskDeltas, want1)
+	}
+	if ev1.TaskSnapshot == nil || len(*ev1.TaskSnapshot) != 2 {
+		t.Fatalf("snapshot = %v, want 2 entries", ev1.TaskSnapshot)
+	}
+
+	// Second call: keys keep their first-seen IDs; only status changes emit Updates.
+	ev2 := &ParsedEvent{}
+	r.Reconcile([]Todo{
+		{Key: "write tests", Status: "completed"},
+		{Key: "ship it", Status: "in_progress"},
+	}, ev2)
+	want2 := []TaskDelta{
+		{Op: TaskOpUpdate, ID: "1", Status: "completed"},
+		{Op: TaskOpUpdate, ID: "2", Status: "in_progress"},
+	}
+	if !reflect.DeepEqual(ev2.TaskDeltas, want2) {
+		t.Errorf("second-call deltas =\n %+v\nwant\n %+v", ev2.TaskDeltas, want2)
+	}
+}
+
+func TestTodoReconciler_DedupAndEmptyKeySkip(t *testing.T) {
+	var r TodoReconciler
+	ev := &ParsedEvent{}
+	r.Reconcile([]Todo{
+		{Key: "dup", Status: "pending"},
+		{Key: "", Status: "in_progress"},  // empty key → skipped
+		{Key: "dup", Status: "completed"}, // same key collapses to one task
+	}, ev)
+
+	want := []TaskDelta{
+		{Op: TaskOpCreate, Subject: "dup"},
+		{Op: TaskOpUpdate, ID: "1", Status: "completed"},
+	}
+	if !reflect.DeepEqual(ev.TaskDeltas, want) {
+		t.Errorf("deltas =\n %+v\nwant\n %+v", ev.TaskDeltas, want)
+	}
+	// Snapshot keeps both "dup" rows (empty-key one skipped), sharing id "1".
+	if ev.TaskSnapshot == nil || len(*ev.TaskSnapshot) != 2 {
+		t.Fatalf("snapshot = %v, want 2 entries (empty-key skipped)", ev.TaskSnapshot)
+	}
+	for _, e := range *ev.TaskSnapshot {
+		if e.ID != "1" {
+			t.Errorf("snapshot entry id = %q, want 1 (deduped)", e.ID)
+		}
+	}
+}
+
+func TestTodoReconciler_EmptyIsNoop(t *testing.T) {
+	var r TodoReconciler
+	ev := &ParsedEvent{}
+	r.Reconcile(nil, ev)
+	r.Reconcile([]Todo{}, ev)
+	if ev.TaskDeltas != nil || ev.TaskSnapshot != nil {
+		t.Errorf("empty reconcile mutated ev: deltas=%v snapshot=%v", ev.TaskDeltas, ev.TaskSnapshot)
+	}
+}


### PR DESCRIPTION
## What

Collapses the duplicated todo-snapshot reconciliation in `opencode` and
`gemini-cli` into one stateful deep module, `tailer.TodoReconciler`.

Both adapters' "rewrite the whole list every call" todo tools (`todowrite` /
`write_todos`) carry no stable per-todo ID, so each had its own ~40-line copy
that:
- keyed todos by their label (`content` / `description`) → synthetic monotonic ID,
- emitted the minimal `TaskCreate`/`TaskUpdate` sequence,
- built a `TaskSnapshot` for the tailer's reconcile pass.

The gemini-cli copy's own comment admitted it: *"Mirrors opencode's todowrite
handling."* The two differed **only** in the todos' extraction path and key
field.

## After

```go
// tailer
type Todo struct{ Key, Status string }
type TodoReconciler struct { /* idByKey, nextID */ }
func (r *TodoReconciler) Reconcile(todos []Todo, ev *ParsedEvent)
```

Each adapter now just extracts its format-specific todos into `[]tailer.Todo`
and calls `Reconcile`. The ID-map, counter, delta and snapshot logic live in one
place; a third caller (codex `update_plan`) becomes trivial. The `Parser` structs
drop their `todoIDBy*`/`nextTaskID` fields for one `tailer.TodoReconciler`, and
two now-unused `strconv` imports are removed.

## Pure refactor — no behavior change

Behavior-identical, so unlike the truncation PR there is **zero replay-golden
churn**. Verified by:
- the **unchanged** opencode/gemini parser tests still passing,
- new `TestTodoReconciler` (create, stable IDs across calls, update-on-non-pending, pending-no-update, dedup on same key, empty-key skip, empty-slice no-op),
- `tools/onboarding-factory/cmd/replay` green with no golden diff,
- `of validate` OK.

`go test ./core/... -count=1` is green apart from two unrelated timing flakes
(`TestDebounce_FirstEventFiresImmediately`, `TestFSWatcher_EmitsEventsForTranscriptCreateAndModify`) — both pass 3/3 in isolation and touch neither parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
