### PR TITLE
feat(relay): native multi-tenant workspace isolation (#709)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 bin/
 core/bin/
 core/irrlicht-ls
+/irrlichtrelay
 
 # Xcode
 *.xcodeproj

--- a/core/cmd/irrlichtrelay/handlers.go
+++ b/core/cmd/irrlichtrelay/handlers.go
@@ -1,32 +1,50 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
 	"irrlicht/core/domain/session"
 )
 
+// workspaceCtxKey carries the validated workspace from requireToken to the read
+// handlers. Its own type avoids collisions with any other context value.
+type workspaceCtxKey struct{}
+
+// withWorkspace attaches the token's workspace to a request context.
+func withWorkspace(ctx context.Context, workspace string) context.Context {
+	return context.WithValue(ctx, workspaceCtxKey{}, workspace)
+}
+
+// workspaceOf reads the workspace requireToken attached, or "" (the default
+// workspace) on a no-auth relay where the gate is a pass-through.
+func workspaceOf(r *http.Request) string {
+	ws, _ := r.Context().Value(workspaceCtxKey{}).(string)
+	return ws
+}
+
 // handleSessions re-serves the daemon's /api/v1/sessions shape, built from the
-// relay's flattened session cache. No orchestrator state is forwarded in v0,
-// so the dashboard groups by project name (BuildDashboard with nil orch).
+// caller's workspace slice of the relay's session cache. No orchestrator state
+// is forwarded in v0, so the dashboard groups by project name (BuildDashboard
+// with nil orch).
 func handleSessions(h *hub) http.HandlerFunc {
 	type sessionsResponse struct {
 		Groups []*session.AgentGroup `json:"groups"`
 	}
-	return func(w http.ResponseWriter, _ *http.Request) {
-		groups := session.BuildDashboard(h.buildSessions(), nil)
+	return func(w http.ResponseWriter, r *http.Request) {
+		groups := session.BuildDashboard(h.buildSessions(workspaceOf(r)), nil)
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(sessionsResponse{Groups: groups})
 	}
 }
 
-// handleAgents re-serves /api/v1/agents as the union of every connected
-// daemon's adapter registry, matching the daemon's agentEntry shape.
+// handleAgents re-serves /api/v1/agents as the union of the caller's workspace
+// daemons' adapter registries, matching the daemon's agentEntry shape.
 func handleAgents(h *hub) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(h.buildAgents())
+		_ = json.NewEncoder(w).Encode(h.buildAgents(workspaceOf(r)))
 	}
 }
 

--- a/core/cmd/irrlichtrelay/hub.go
+++ b/core/cmd/irrlichtrelay/hub.go
@@ -54,17 +54,21 @@ func defaultLimits() limits {
 const maxDaemonMsgBytes = 32 << 20
 
 // hub is the relay's in-memory core: it tracks connected daemons, caches the
-// latest session state per (daemon_id, session_id) and the per-daemon adapter
-// registry, and fans daemon push frames out to all connected clients. Single
-// node, no auth, no persistence — everything here is lost on restart and
-// rebuilt from each daemon's reconnect daemon_snapshot.
+// latest session state per (workspace, daemon_id, session_id) and the per-
+// daemon adapter registry, and fans daemon push frames out to the clients in
+// the matching workspace. Single node, no auth, no persistence — everything
+// here is lost on restart and rebuilt from each daemon's reconnect
+// daemon_snapshot.
 type hub struct {
-	mu       sync.Mutex
-	clients  map[*clientConn]struct{}
-	daemons  map[string]*daemonState                     // daemon_id → liveness
-	sessions map[string]map[string]*session.SessionState // daemon_id → session_id → state
-	agents   map[string][]relay.AgentInfo                // daemon_id → adapter registry
-	upgrader websocket.Upgrader
+	mu      sync.Mutex
+	clients map[*clientConn]struct{}
+	// workspaces partitions all cached state by tenant. A connection's
+	// workspace is server-derived from its bearer token (never client-supplied),
+	// so a daemon in one workspace can neither read nor overwrite another's slot
+	// even if it claims a colliding daemon_id. "" is the default workspace used
+	// by no-auth relays and by tokens issued without an explicit workspace.
+	workspaces map[string]*workspaceState
+	upgrader   websocket.Upgrader
 
 	// auth is nil when the relay runs with --auth off (trusted-LAN default):
 	// every hello is accepted. When set, both daemon and client hellos must
@@ -76,6 +80,23 @@ type hub struct {
 	totalConns    int            // live connections across all peers
 	ipConns       map[string]int // remote IP → live connections
 	lastRejectLog time.Time      // throttle for over-cap rejection logs
+}
+
+// workspaceState holds one tenant's view: the daemons connected under that
+// workspace's tokens, their cached sessions, and their adapter registries. It
+// mirrors the hub's pre-multi-tenant per-daemon maps, one set per workspace.
+type workspaceState struct {
+	daemons  map[string]*daemonState                     // daemon_id → liveness
+	sessions map[string]map[string]*session.SessionState // daemon_id → session_id → state
+	agents   map[string][]relay.AgentInfo                // daemon_id → adapter registry
+}
+
+func newWorkspaceState() *workspaceState {
+	return &workspaceState{
+		daemons:  make(map[string]*daemonState),
+		sessions: make(map[string]map[string]*session.SessionState),
+		agents:   make(map[string][]relay.AgentInfo),
+	}
 }
 
 // daemonState tracks one daemon's connection liveness. conns counts live
@@ -91,10 +112,11 @@ type daemonState struct {
 // closed by the read pump when the socket drops so the write pump exits
 // promptly instead of waiting for the next ping tick.
 type clientConn struct {
-	conn    *websocket.Conn
-	send    chan []byte
-	done    chan struct{}
-	tokenID string // bearer-token id (empty on a no-auth relay); watched for revoke
+	conn      *websocket.Conn
+	send      chan []byte
+	done      chan struct{}
+	tokenID   string // bearer-token id (empty on a no-auth relay); watched for revoke
+	workspace string // tenant scope from the bearer token (server-derived)
 }
 
 // newHub builds a no-auth, all-origins hub with the given connection limits
@@ -107,15 +129,24 @@ func newHub(lim limits) *hub { return newHubWithAuth(nil, nil, lim) }
 // from v0).
 func newHubWithAuth(auth *authStore, allowedOrigins []string, lim limits) *hub {
 	return &hub{
-		clients:  make(map[*clientConn]struct{}),
-		daemons:  make(map[string]*daemonState),
-		sessions: make(map[string]map[string]*session.SessionState),
-		agents:   make(map[string][]relay.AgentInfo),
-		auth:     auth,
-		limits:   lim,
-		ipConns:  make(map[string]int),
-		upgrader: websocket.Upgrader{CheckOrigin: originChecker(allowedOrigins)},
+		clients:    make(map[*clientConn]struct{}),
+		workspaces: make(map[string]*workspaceState),
+		auth:       auth,
+		limits:     lim,
+		ipConns:    make(map[string]int),
+		upgrader:   websocket.Upgrader{CheckOrigin: originChecker(allowedOrigins)},
 	}
+}
+
+// wsLocked returns the workspace's state, creating it on first use. The caller
+// must hold h.mu.
+func (h *hub) wsLocked(workspace string) *workspaceState {
+	ws := h.workspaces[workspace]
+	if ws == nil {
+		ws = newWorkspaceState()
+		h.workspaces[workspace] = ws
+	}
+	return ws
 }
 
 // originChecker gates the WS upgrade by the request Origin. An empty allowlist
@@ -192,20 +223,22 @@ func (h *hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 	// token is ignored. Otherwise the hello.token must hash to a known token;
 	// an empty/invalid token closes the socket with relay.CloseRevoked.
 	tokenID := ""
+	workspace := ""
 	if h.auth != nil {
-		id, ok := h.auth.validate(hello.Token)
+		id, ws, ok := h.auth.validate(hello.Token)
 		if !ok {
 			closeWith(conn, relay.CloseRevoked, "unauthorized")
 			return
 		}
 		tokenID = id
+		workspace = ws
 	}
 
 	if hello.Type == relay.MsgHello && hello.Role == relay.RoleDaemon {
-		h.serveDaemon(conn, hello, tokenID)
+		h.serveDaemon(conn, hello, tokenID, workspace)
 		return
 	}
-	h.serveClient(conn, tokenID)
+	h.serveClient(conn, tokenID, workspace)
 }
 
 // closeWith sends a WebSocket close frame with the given code and reason, then
@@ -294,7 +327,7 @@ func remoteIP(r *http.Request) string {
 
 // --- daemon side ---
 
-func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello, tokenID string) {
+func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello, tokenID, workspace string) {
 	if hello.DaemonID == "" {
 		log.Printf("relay: refusing daemon hello with empty daemon_id")
 		return // untracked, undedupable — refuse
@@ -310,8 +343,8 @@ func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello, tokenID strin
 		return
 	}
 
-	h.daemonConnected(id, label)
-	defer h.daemonDisconnected(id)
+	h.daemonConnected(workspace, id, label)
+	defer h.daemonDisconnected(workspace, id)
 
 	// Ping the daemon so an idle link stays alive (and dead ones are detected
 	// at pongTimeout). Sole writer after the hello_ack above, satisfying
@@ -333,21 +366,21 @@ func (h *hub) serveDaemon(conn *websocket.Conn, hello relay.Hello, tokenID strin
 		if h.closeIfRevoked(conn, tokenID) {
 			return
 		}
-		h.handleDaemonFrame(id, data)
+		h.handleDaemonFrame(workspace, id, data)
 	}
 }
 
-func (h *hub) handleDaemonFrame(daemonID string, data []byte) {
+func (h *hub) handleDaemonFrame(workspace, daemonID string, data []byte) {
 	switch relay.FrameType(data) {
 	case relay.MsgDaemonSnapshot:
 		var ds relay.DaemonSnapshot
 		if json.Unmarshal(data, &ds) == nil {
-			h.applyDaemonSnapshot(daemonID, ds)
+			h.applyDaemonSnapshot(workspace, daemonID, ds)
 		}
 	case relay.MsgPush:
 		var p relay.Push
 		if json.Unmarshal(data, &p) == nil {
-			h.applyPush(daemonID, p)
+			h.applyPush(workspace, daemonID, p)
 		}
 	}
 }
@@ -357,7 +390,7 @@ func (h *hub) handleDaemonFrame(daemonID string, data []byte) {
 // session_deleted for each that vanished since the prior snapshot. This lets a
 // client that connected before the daemon (or before a reconnect) converge
 // live, without depending on an HTTP re-poll.
-func (h *hub) applyDaemonSnapshot(daemonID string, ds relay.DaemonSnapshot) {
+func (h *hub) applyDaemonSnapshot(workspace, daemonID string, ds relay.DaemonSnapshot) {
 	newMap := make(map[string]*session.SessionState, len(ds.Sessions))
 	for _, s := range ds.Sessions {
 		if s != nil && s.SessionID != "" {
@@ -366,17 +399,18 @@ func (h *hub) applyDaemonSnapshot(daemonID string, ds relay.DaemonSnapshot) {
 	}
 
 	h.mu.Lock()
-	old := h.sessions[daemonID]
-	h.sessions[daemonID] = newMap
-	h.agents[daemonID] = ds.Agents
+	ws := h.wsLocked(workspace)
+	old := ws.sessions[daemonID]
+	ws.sessions[daemonID] = newMap
+	ws.agents[daemonID] = ds.Agents
 	h.mu.Unlock()
 
 	for _, s := range newMap {
-		h.fanoutPush(daemonID, outbound.PushMessage{Type: outbound.PushTypeUpdated, Session: s})
+		h.fanoutPush(workspace, daemonID, outbound.PushMessage{Type: outbound.PushTypeUpdated, Session: s})
 	}
 	for sid, s := range old {
 		if _, ok := newMap[sid]; !ok {
-			h.fanoutPush(daemonID, outbound.PushMessage{Type: outbound.PushTypeDeleted, Session: s})
+			h.fanoutPush(workspace, daemonID, outbound.PushMessage{Type: outbound.PushTypeDeleted, Session: s})
 		}
 	}
 }
@@ -385,15 +419,16 @@ func (h *hub) applyDaemonSnapshot(daemonID string, ds relay.DaemonSnapshot) {
 // reflects live state) and fans every frame out to clients. History frames
 // carry no Session and are forwarded but not cached — history re-hydration of
 // late-joining clients is deferred to a later phase.
-func (h *hub) applyPush(daemonID string, p relay.Push) {
+func (h *hub) applyPush(workspace, daemonID string, p relay.Push) {
 	msg := p.Msg
 	if msg.Session != nil && msg.Session.SessionID != "" {
 		sid := msg.Session.SessionID
 		h.mu.Lock()
-		m := h.sessions[daemonID]
+		ws := h.wsLocked(workspace)
+		m := ws.sessions[daemonID]
 		if m == nil {
 			m = make(map[string]*session.SessionState)
-			h.sessions[daemonID] = m
+			ws.sessions[daemonID] = m
 		}
 		if msg.Type == outbound.PushTypeDeleted {
 			delete(m, sid)
@@ -402,16 +437,17 @@ func (h *hub) applyPush(daemonID string, p relay.Push) {
 		}
 		h.mu.Unlock()
 	}
-	h.fanoutPush(daemonID, msg)
+	h.fanoutPush(workspace, daemonID, msg)
 }
 
-func (h *hub) daemonConnected(id, label string) {
+func (h *hub) daemonConnected(workspace, id, label string) {
 	now := time.Now().Unix()
 	h.mu.Lock()
-	d := h.daemons[id]
+	ws := h.wsLocked(workspace)
+	d := ws.daemons[id]
 	if d == nil {
 		d = &daemonState{label: label, since: now}
-		h.daemons[id] = d
+		ws.daemons[id] = d
 	} else {
 		d.label = label
 		if d.conns == 0 {
@@ -420,13 +456,18 @@ func (h *hub) daemonConnected(id, label string) {
 	}
 	d.conns++
 	h.mu.Unlock()
-	h.broadcastDaemonStatus(id, label, relay.StatusConnected, now)
+	h.broadcastDaemonStatus(workspace, id, label, relay.StatusConnected, now)
 }
 
-func (h *hub) daemonDisconnected(id string) {
+func (h *hub) daemonDisconnected(workspace, id string) {
 	now := time.Now().Unix()
 	h.mu.Lock()
-	d := h.daemons[id]
+	ws := h.workspaces[workspace]
+	if ws == nil {
+		h.mu.Unlock()
+		return
+	}
+	d := ws.daemons[id]
 	if d == nil {
 		h.mu.Unlock()
 		return
@@ -437,9 +478,20 @@ func (h *hub) daemonDisconnected(id string) {
 		h.mu.Unlock()
 		return // another live connection for this daemon remains
 	}
-	delete(h.daemons, id)
-	delete(h.sessions, id)
-	delete(h.agents, id)
+	delete(ws.daemons, id)
+	delete(ws.sessions, id)
+	delete(ws.agents, id)
+	// Drop the tenant's container once its last daemon leaves so a churn of
+	// short-lived workspaces doesn't grow the map unbounded; it is recreated
+	// lazily on the next daemon hello. daemons is the authoritative lifecycle
+	// key — every sessions/agents entry is keyed by a connected daemon's id and
+	// deleted above — so an empty daemons map means the container is empty. A
+	// client still connected to this workspace keeps receiving live frames via
+	// fanout (which filters by the client's own workspace, independent of this
+	// map).
+	if len(ws.daemons) == 0 {
+		delete(h.workspaces, workspace)
+	}
 	h.mu.Unlock()
 
 	// Announce the disconnect and let clients decide how to present the now-
@@ -449,13 +501,13 @@ func (h *hub) daemonDisconnected(id string) {
 	// dashboard drops them. The cache is still evicted, so /api/v1/sessions and
 	// any late-joining client reflect only live daemons, and a reconnect
 	// reconciles via a fresh daemon_snapshot.
-	h.broadcastDaemonStatus(id, label, relay.StatusDisconnected, now)
+	h.broadcastDaemonStatus(workspace, id, label, relay.StatusDisconnected, now)
 }
 
 // --- client side ---
 
-func (h *hub) serveClient(conn *websocket.Conn, tokenID string) {
-	cc := &clientConn{conn: conn, send: make(chan []byte, 64), done: make(chan struct{}), tokenID: tokenID}
+func (h *hub) serveClient(conn *websocket.Conn, tokenID, workspace string) {
+	cc := &clientConn{conn: conn, send: make(chan []byte, 64), done: make(chan struct{}), tokenID: tokenID, workspace: workspace}
 
 	// Register before snapshotting so no daemon_status fired between the two
 	// is missed: any daemon present at snapshot time is in the snapshot, any
@@ -466,7 +518,7 @@ func (h *hub) serveClient(conn *websocket.Conn, tokenID string) {
 	h.mu.Unlock()
 	defer h.removeClient(cc)
 
-	if data, err := json.Marshal(h.clientSnapshot()); err == nil {
+	if data, err := json.Marshal(h.clientSnapshot(workspace)); err == nil {
 		// Non-blocking, like every other send: the write pump that drains
 		// cc.send only starts below, so a blocking send to a buffer already
 		// filled by concurrent fan-out (between registration and here) would
@@ -498,9 +550,11 @@ func (h *hub) replaySessions(cc *clientConn) {
 	}
 	h.mu.Lock()
 	items := make([]item, 0)
-	for did, m := range h.sessions {
-		for _, s := range m {
-			items = append(items, item{did, s})
+	if ws := h.workspaces[cc.workspace]; ws != nil {
+		for did, m := range ws.sessions {
+			for _, s := range m {
+				items = append(items, item{did, s})
+			}
 		}
 	}
 	h.mu.Unlock()
@@ -572,31 +626,35 @@ func (h *hub) clientWritePump(cc *clientConn) {
 
 // --- fan-out + snapshots ---
 
-func (h *hub) fanoutPush(daemonID string, msg outbound.PushMessage) {
+func (h *hub) fanoutPush(workspace, daemonID string, msg outbound.PushMessage) {
 	data, err := json.Marshal(relay.Push{Type: relay.MsgPush, Source: daemonID, TS: time.Now().Unix(), Msg: msg})
 	if err != nil {
 		return
 	}
-	h.fanout(data)
+	h.fanout(workspace, data)
 }
 
-func (h *hub) broadcastDaemonStatus(id, label, status string, since int64) {
+func (h *hub) broadcastDaemonStatus(workspace, id, label, status string, since int64) {
 	data, err := json.Marshal(relay.DaemonStatus{
 		Type: relay.MsgDaemonStatus, DaemonID: id, DaemonLabel: label, Status: status, Since: since,
 	})
 	if err != nil {
 		return
 	}
-	h.fanout(data)
+	h.fanout(workspace, data)
 }
 
-// fanout delivers one frame to every client, dropping it for any client whose
-// buffer is full (mirrors the daemon push service's slow-consumer policy).
-func (h *hub) fanout(data []byte) {
+// fanout delivers one frame to every client in workspace, dropping it for any
+// client whose buffer is full (mirrors the daemon push service's slow-consumer
+// policy). Scoping by workspace is the isolation boundary: a daemon's frames
+// never reach a client outside its tenant.
+func (h *hub) fanout(workspace string, data []byte) {
 	h.mu.Lock()
 	targets := make([]*clientConn, 0, len(h.clients))
 	for cc := range h.clients {
-		targets = append(targets, cc)
+		if cc.workspace == workspace {
+			targets = append(targets, cc)
+		}
 	}
 	h.mu.Unlock()
 	for _, cc := range targets {
@@ -607,44 +665,52 @@ func (h *hub) fanout(data []byte) {
 	}
 }
 
-func (h *hub) clientSnapshot() relay.Snapshot {
+func (h *hub) clientSnapshot(workspace string) relay.Snapshot {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	daemons := make([]relay.DaemonInfo, 0, len(h.daemons))
-	for id, d := range h.daemons {
-		daemons = append(daemons, relay.DaemonInfo{DaemonID: id, DaemonLabel: d.label, Status: relay.StatusConnected})
+	daemons := make([]relay.DaemonInfo, 0)
+	if ws := h.workspaces[workspace]; ws != nil {
+		for id, d := range ws.daemons {
+			daemons = append(daemons, relay.DaemonInfo{DaemonID: id, DaemonLabel: d.label, Status: relay.StatusConnected})
+		}
 	}
 	return relay.Snapshot{Type: relay.MsgSnapshot, Daemons: daemons}
 }
 
-// buildSessions flattens the per-daemon caches into one list for the HTTP
-// /api/v1/sessions handler.
-func (h *hub) buildSessions() []*session.SessionState {
+// buildSessions flattens one workspace's per-daemon caches into a list for the
+// HTTP /api/v1/sessions handler. The workspace is the caller's token scope, so
+// the response carries only that tenant's sessions.
+func (h *hub) buildSessions(workspace string) []*session.SessionState {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	var all []*session.SessionState
-	for _, m := range h.sessions {
-		for _, s := range m {
-			all = append(all, s)
+	if ws := h.workspaces[workspace]; ws != nil {
+		for _, m := range ws.sessions {
+			for _, s := range m {
+				all = append(all, s)
+			}
 		}
 	}
 	return all
 }
 
-// buildAgents returns the union of every daemon's adapter registry, deduped by
-// adapter name (frontends key off Name). Always non-nil so the JSON is [].
-func (h *hub) buildAgents() []relay.AgentInfo {
+// buildAgents returns the union of one workspace's daemon adapter registries,
+// deduped by adapter name (frontends key off Name). Always non-nil so the JSON
+// is [].
+func (h *hub) buildAgents(workspace string) []relay.AgentInfo {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	seen := make(map[string]bool)
 	out := []relay.AgentInfo{}
-	for _, infos := range h.agents {
-		for _, a := range infos {
-			if seen[a.Name] {
-				continue
+	if ws := h.workspaces[workspace]; ws != nil {
+		for _, infos := range ws.agents {
+			for _, a := range infos {
+				if seen[a.Name] {
+					continue
+				}
+				seen[a.Name] = true
+				out = append(out, a)
 			}
-			seen[a.Name] = true
-			out = append(out, a)
 		}
 	}
 	return out

--- a/core/cmd/irrlichtrelay/hub_test.go
+++ b/core/cmd/irrlichtrelay/hub_test.go
@@ -81,6 +81,45 @@ func httpGet(t *testing.T, url string) []byte {
 	return body
 }
 
+// httpGetAuth issues a bearer-authenticated GET, asserting a 200, and returns
+// the body. Used to read a workspace-scoped slice of /api/v1/sessions.
+func httpGetAuth(t *testing.T, url, token string) []byte {
+	t.Helper()
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status %d", url, resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	return body
+}
+
+// assertNeverSeesSession reads frames from c until within elapses and fails if
+// a push for sid arrives — the core cross-tenant leakage assertion. A read
+// deadline (or close) ends the wait cleanly with no leak observed.
+func assertNeverSeesSession(t *testing.T, c *websocket.Conn, sid string, within time.Duration) {
+	t.Helper()
+	c.SetReadDeadline(time.Now().Add(within))
+	for {
+		_, data, err := c.ReadMessage()
+		if err != nil {
+			return // deadline or close: nothing leaked
+		}
+		if relay.FrameType(data) != relay.MsgPush {
+			continue
+		}
+		var p relay.Push
+		if json.Unmarshal(data, &p) == nil && p.Msg.Session != nil && p.Msg.Session.SessionID == sid {
+			t.Fatalf("workspace leak: client saw session %q from another tenant", sid)
+		}
+	}
+}
+
 func TestRelayRoundTrip(t *testing.T) {
 	wsURL, baseURL := newTestServer(t)
 
@@ -284,7 +323,7 @@ func newTestServerWithAuth(t *testing.T, labels ...string) (wsURL string, tokens
 	tokensPath = filepath.Join(t.TempDir(), "tokens.json")
 	tokens = make(map[string]string, len(labels))
 	for _, l := range labels {
-		_, plaintext, err := issueToken(tokensPath, l)
+		_, plaintext, err := issueToken(tokensPath, l, "")
 		if err != nil {
 			t.Fatalf("seed token %q: %v", l, err)
 		}
@@ -387,6 +426,113 @@ func TestAuthRevokeClosesLiveDaemon(t *testing.T) {
 	expectClose4401(t, d)
 }
 
+// TestWorkspaceIsolation proves a connection only ever sees its own tenant's
+// sessions — over WS replay, over a live push, and over the HTTP read API —
+// even when a daemon in another workspace claims a colliding daemon_id.
+func TestWorkspaceIsolation(t *testing.T) {
+	tokensPath := filepath.Join(t.TempDir(), "tokens.json")
+	mint := func(label, ws string) string {
+		_, pt, err := issueToken(tokensPath, label, ws)
+		if err != nil {
+			t.Fatalf("issue %s: %v", label, err)
+		}
+		return pt
+	}
+	daemonA := mint("daemon-a", "ws-a")
+	clientA := mint("client-a", "ws-a")
+	daemonB := mint("daemon-b", "ws-b")
+	clientB := mint("client-b", "ws-b")
+
+	store, err := newAuthStore(tokensPath)
+	if err != nil {
+		t.Fatalf("newAuthStore: %v", err)
+	}
+	h := newHubWithAuth(store, nil, defaultLimits())
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/sessions/stream", h.ServeWS)
+	mux.HandleFunc("GET /api/v1/sessions", requireToken(store, handleSessions(h)))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/api/v1/sessions/stream"
+
+	// Both daemons claim the SAME daemon_id "d1" but authenticate into different
+	// workspaces, so a colliding id must not let one tenant read or overwrite
+	// the other's slot.
+	connectDaemon := func(token, sid, proj string) *websocket.Conn {
+		d := dial(t, wsURL)
+		if err := d.WriteJSON(relay.Hello{
+			Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion,
+			Role: relay.RoleDaemon, DaemonID: "d1", DaemonLabel: "host", Token: token,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		var ack relay.HelloAck
+		if err := d.ReadJSON(&ack); err != nil {
+			t.Fatal(err)
+		}
+		if err := d.WriteJSON(relay.DaemonSnapshot{
+			Type:     relay.MsgDaemonSnapshot,
+			Sessions: []*session.SessionState{{SessionID: sid, State: "working", ProjectName: proj}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return d
+	}
+	connectDaemon(daemonA, "sa", "proj-a")
+	dB := connectDaemon(daemonB, "sb", "proj-b")
+	// Let both snapshots ingest before the clients connect (the replay path).
+	time.Sleep(50 * time.Millisecond)
+
+	// Client A replays only ws-a's session, never ws-b's.
+	ca := dial(t, wsURL)
+	if err := ca.WriteJSON(relay.Hello{Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion, Role: relay.RoleClient, Token: clientA}); err != nil {
+		t.Fatal(err)
+	}
+	var p relay.Push
+	mustJSON(t, readUntil(t, ca, relay.MsgPush), &p)
+	if p.Msg.Session == nil || p.Msg.Session.SessionID != "sa" {
+		t.Fatalf("client A replay = %+v; want session sa", p.Msg.Session)
+	}
+
+	cb := dial(t, wsURL)
+	if err := cb.WriteJSON(relay.Hello{Type: relay.MsgHello, ProtocolVersion: relay.ProtocolVersion, Role: relay.RoleClient, Token: clientB}); err != nil {
+		t.Fatal(err)
+	}
+	mustJSON(t, readUntil(t, cb, relay.MsgPush), &p)
+	if p.Msg.Session == nil || p.Msg.Session.SessionID != "sb" {
+		t.Fatalf("client B replay = %+v; want session sb", p.Msg.Session)
+	}
+
+	// HTTP reads are scoped by the bearer token's workspace, both directions.
+	bodyA := httpGetAuth(t, srv.URL+"/api/v1/sessions", clientA)
+	if !bytes.Contains(bodyA, []byte(`"session_id":"sa"`)) {
+		t.Fatalf("client A HTTP missing sa: %s", bodyA)
+	}
+	if bytes.Contains(bodyA, []byte(`"session_id":"sb"`)) {
+		t.Fatalf("client A HTTP leaked ws-b's sb: %s", bodyA)
+	}
+	bodyB := httpGetAuth(t, srv.URL+"/api/v1/sessions", clientB)
+	if !bytes.Contains(bodyB, []byte(`"session_id":"sb"`)) {
+		t.Fatalf("client B HTTP missing sb: %s", bodyB)
+	}
+	if bytes.Contains(bodyB, []byte(`"session_id":"sa"`)) {
+		t.Fatalf("client B HTTP leaked ws-a's sa: %s", bodyB)
+	}
+
+	// A live delta in ws-b reaches client B but never client A.
+	if err := dB.WriteJSON(relay.Push{
+		Type: relay.MsgPush,
+		Msg:  outbound.PushMessage{Type: outbound.PushTypeUpdated, Session: &session.SessionState{SessionID: "sb2", State: "ready"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	mustJSON(t, readUntil(t, cb, relay.MsgPush), &p)
+	if p.Msg.Session == nil || p.Msg.Session.SessionID != "sb2" {
+		t.Fatalf("client B live delta = %+v; want sb2", p.Msg.Session)
+	}
+	assertNeverSeesSession(t, ca, "sb2", 300*time.Millisecond)
+}
+
 func TestOriginChecker(t *testing.T) {
 	// Empty allowlist: every origin (and none) is allowed.
 	allow := originChecker(nil)
@@ -423,7 +569,7 @@ func reqWithOrigin(origin string) *http.Request {
 
 func TestRequireTokenGatesHTTP(t *testing.T) {
 	tokensPath := filepath.Join(t.TempDir(), "tokens.json")
-	_, plaintext, err := issueToken(tokensPath, "http")
+	_, plaintext, err := issueToken(tokensPath, "http", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/cmd/irrlichtrelay/main.go
+++ b/core/cmd/irrlichtrelay/main.go
@@ -240,6 +240,7 @@ func runToken(args []string) {
 	tokensFile := fs.String("tokens-file", "", "path to the tokens file (default: <data-dir>/tokens.json)")
 	dataDirFlag := fs.String("data-dir", "", "state directory for the tokens file (default: $IRRLICHT_HOME or ~/.local/share/irrlicht)")
 	label := fs.String("label", "", "human label for the issued token (issue only)")
+	workspace := fs.String("workspace", "", "tenant workspace the issued token is scoped to (issue only; empty = default single-tenant workspace)")
 	_ = fs.Parse(rest)
 
 	path := *tokensFile
@@ -253,11 +254,11 @@ func runToken(args []string) {
 
 	switch sub {
 	case "issue":
-		id, plaintext, err := issueToken(path, *label)
+		id, plaintext, err := issueToken(path, *label, *workspace)
 		if err != nil {
 			log.Fatalf("token issue: %v", err)
 		}
-		fmt.Printf("token %s issued (label %q)\n", id, *label)
+		fmt.Printf("token %s issued (label %q, workspace %q)\n", id, *label, *workspace)
 		fmt.Printf("  %s\n", plaintext)
 		fmt.Println("Store it now — it is shown only once and only its hash is kept.")
 	case "list":
@@ -270,7 +271,11 @@ func runToken(args []string) {
 			return
 		}
 		for _, r := range recs {
-			fmt.Printf("%s\t%s\t%s\n", r.ID, time.Unix(r.Created, 0).Format(time.RFC3339), r.Label)
+			ws := r.Workspace
+			if ws == "" {
+				ws = "-"
+			}
+			fmt.Printf("%s\t%s\t%s\t%s\n", r.ID, time.Unix(r.Created, 0).Format(time.RFC3339), ws, r.Label)
 		}
 	case "revoke":
 		if len(fs.Args()) == 0 {
@@ -294,17 +299,20 @@ func runToken(args []string) {
 // off (store == nil) it is a pass-through, so existing no-auth deployments are
 // unchanged. With auth on, the request must carry a valid token in either an
 // `Authorization: Bearer <t>` header or a `?token=<t>` query param (the WS
-// endpoint authenticates via the hello frame instead and is not wrapped).
+// endpoint authenticates via the hello frame instead and is not wrapped). The
+// token's workspace is attached to the request context so the handler reads
+// only that tenant's sessions.
 func requireToken(store *authStore, next http.HandlerFunc) http.HandlerFunc {
 	if store == nil {
 		return next
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
-		if _, ok := store.validate(bearerToken(r)); !ok {
+		_, workspace, ok := store.validate(bearerToken(r))
+		if !ok {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
-		next(w, r)
+		next(w, r.WithContext(withWorkspace(r.Context(), workspace)))
 	}
 }
 

--- a/core/cmd/irrlichtrelay/tokens.go
+++ b/core/cmd/irrlichtrelay/tokens.go
@@ -27,12 +27,15 @@ const tokensFilename = "tokens.json"
 
 // TokenRecord is one issued token. Hash is the hex SHA-256 of the plaintext;
 // the plaintext itself is never persisted. Label and Created are operator
-// metadata for `token list`.
+// metadata for `token list`. Workspace is the tenant scope a connection
+// presenting this token is bound to; "" is the default workspace (single-
+// tenant, the behavior of every token issued before this field existed).
 type TokenRecord struct {
-	ID      string `json:"id"`
-	Label   string `json:"label"`
-	Hash    string `json:"hash"`
-	Created int64  `json:"created"`
+	ID        string `json:"id"`
+	Label     string `json:"label"`
+	Hash      string `json:"hash"`
+	Created   int64  `json:"created"`
+	Workspace string `json:"workspace,omitempty"`
 }
 
 // hashToken returns the hex SHA-256 of a plaintext token — the only form stored
@@ -72,10 +75,10 @@ func saveTokens(path string, recs []TokenRecord) error {
 	return os.WriteFile(path, data, 0o600)
 }
 
-// issueToken mints a new 256-bit token, appends its hash to the store, and
-// returns the id plus the plaintext (shown to the operator once and never
-// recoverable thereafter).
-func issueToken(path, label string) (id, plaintext string, err error) {
+// issueToken mints a new 256-bit token bound to workspace, appends its hash to
+// the store, and returns the id plus the plaintext (shown to the operator once
+// and never recoverable thereafter). An empty workspace is the default tenant.
+func issueToken(path, label, workspace string) (id, plaintext string, err error) {
 	recs, err := loadTokens(path)
 	if err != nil {
 		return "", "", err
@@ -92,7 +95,7 @@ func issueToken(path, label string) (id, plaintext string, err error) {
 	}
 	id = hex.EncodeToString(idb[:])
 
-	recs = append(recs, TokenRecord{ID: id, Label: label, Hash: hashToken(plaintext), Created: time.Now().Unix()})
+	recs = append(recs, TokenRecord{ID: id, Label: label, Hash: hashToken(plaintext), Created: time.Now().Unix(), Workspace: workspace})
 	if err := saveTokens(path, recs); err != nil {
 		return "", "", err
 	}
@@ -121,6 +124,13 @@ func revokeToken(path, id string) (bool, error) {
 	return true, saveTokens(path, out)
 }
 
+// tokenIdentity is what a valid token resolves to: its id (for revoke
+// detection) and the workspace the connection is scoped to.
+type tokenIdentity struct {
+	id        string
+	workspace string
+}
+
 // authStore is the relay's live view of valid tokens while serving. It is
 // reloaded from disk whenever the tokens file's mtime changes so `token revoke`
 // (a separate process editing the file) propagates without a restart.
@@ -128,7 +138,7 @@ type authStore struct {
 	path string
 
 	mu     sync.RWMutex
-	hashes map[string]string // token hash → id
+	hashes map[string]tokenIdentity // token hash → identity
 	byID   map[string]struct{}
 	mtime  time.Time
 }
@@ -137,7 +147,7 @@ type authStore struct {
 // returned so `serve` refuses to start with an unreadable tokens file rather
 // than silently accepting no one.
 func newAuthStore(path string) (*authStore, error) {
-	a := &authStore{path: path, hashes: map[string]string{}, byID: map[string]struct{}{}}
+	a := &authStore{path: path, hashes: map[string]tokenIdentity{}, byID: map[string]struct{}{}}
 	if err := a.reload(); err != nil {
 		return nil, err
 	}
@@ -150,10 +160,10 @@ func (a *authStore) reload() error {
 	if err != nil {
 		return err
 	}
-	hashes := make(map[string]string, len(recs))
+	hashes := make(map[string]tokenIdentity, len(recs))
 	byID := make(map[string]struct{}, len(recs))
 	for _, r := range recs {
-		hashes[r.Hash] = r.ID
+		hashes[r.Hash] = tokenIdentity{id: r.ID, workspace: r.Workspace}
 		byID[r.ID] = struct{}{}
 	}
 	var mtime time.Time
@@ -198,20 +208,22 @@ func (a *authStore) watch(stop <-chan struct{}, every time.Duration) {
 	}
 }
 
-// validate reports the token id for a plaintext token, ok=false if the token is
-// empty or unknown. The store is keyed by the SHA-256 hash of the token, so a
-// direct map lookup of the candidate's hash is O(1) and leaks no
-// secret-dependent timing (the hashing already happened; the lookup key is a
-// fixed-width digest of an unguessable 256-bit token).
-func (a *authStore) validate(plaintext string) (string, bool) {
+// validate reports the token id and workspace for a plaintext token, ok=false
+// if the token is empty or unknown. The workspace is server-derived from the
+// stored record, never client-supplied — the connection's tenant scope cannot
+// be spoofed. The store is keyed by the SHA-256 hash of the token, so a direct
+// map lookup of the candidate's hash is O(1) and leaks no secret-dependent
+// timing (the hashing already happened; the lookup key is a fixed-width digest
+// of an unguessable 256-bit token).
+func (a *authStore) validate(plaintext string) (id, workspace string, ok bool) {
 	if plaintext == "" {
-		return "", false
+		return "", "", false
 	}
 	want := hashToken(plaintext)
 	a.mu.RLock()
 	defer a.mu.RUnlock()
-	id, ok := a.hashes[want]
-	return id, ok
+	ident, ok := a.hashes[want]
+	return ident.id, ident.workspace, ok
 }
 
 // valid reports whether a token id is still present, used by connection read

--- a/core/cmd/irrlichtrelay/tokens_test.go
+++ b/core/cmd/irrlichtrelay/tokens_test.go
@@ -10,7 +10,7 @@ import (
 func TestIssueValidateRevoke(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "tokens.json")
 
-	id, plaintext, err := issueToken(path, "laptop")
+	id, plaintext, err := issueToken(path, "laptop", "")
 	if err != nil {
 		t.Fatalf("issue: %v", err)
 	}
@@ -22,14 +22,14 @@ func TestIssueValidateRevoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newAuthStore: %v", err)
 	}
-	gotID, ok := store.validate(plaintext)
+	gotID, _, ok := store.validate(plaintext)
 	if !ok || gotID != id {
 		t.Fatalf("validate(plaintext) = %q,%v; want %q,true", gotID, ok, id)
 	}
-	if _, ok := store.validate("bogus"); ok {
+	if _, _, ok := store.validate("bogus"); ok {
 		t.Fatal("validate accepted a bogus token")
 	}
-	if _, ok := store.validate(""); ok {
+	if _, _, ok := store.validate(""); ok {
 		t.Fatal("validate accepted an empty token")
 	}
 	if !store.valid(id) {
@@ -44,7 +44,7 @@ func TestIssueValidateRevoke(t *testing.T) {
 	if err := store.reload(); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	if _, ok := store.validate(plaintext); ok {
+	if _, _, ok := store.validate(plaintext); ok {
 		t.Fatal("validate accepted a revoked token after reload")
 	}
 	if store.valid(id) {
@@ -57,9 +57,36 @@ func TestIssueValidateRevoke(t *testing.T) {
 	}
 }
 
+func TestTokenWorkspaceRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tokens.json")
+
+	_, wsPlain, err := issueToken(path, "tenant-a", "ws-a")
+	if err != nil {
+		t.Fatalf("issue ws token: %v", err)
+	}
+	_, defPlain, err := issueToken(path, "legacy", "")
+	if err != nil {
+		t.Fatalf("issue default token: %v", err)
+	}
+
+	// A fresh store (as `serve` builds) must surface the persisted workspace,
+	// proving it survives the marshal → file → reload path, not just the
+	// in-memory issue call.
+	store, err := newAuthStore(path)
+	if err != nil {
+		t.Fatalf("newAuthStore: %v", err)
+	}
+	if _, ws, ok := store.validate(wsPlain); !ok || ws != "ws-a" {
+		t.Fatalf("validate(ws token) = workspace %q ok=%v; want \"ws-a\",true", ws, ok)
+	}
+	if _, ws, ok := store.validate(defPlain); !ok || ws != "" {
+		t.Fatalf("validate(default token) = workspace %q ok=%v; want \"\",true", ws, ok)
+	}
+}
+
 func TestTokensFileHashedAtRest(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "tokens.json")
-	_, plaintext, err := issueToken(path, "x")
+	_, plaintext, err := issueToken(path, "x", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +110,7 @@ func TestTokensFileMode0600(t *testing.T) {
 		t.Skip("POSIX file modes not meaningful on Windows")
 	}
 	path := filepath.Join(t.TempDir(), "tokens.json")
-	if _, _, err := issueToken(path, "x"); err != nil {
+	if _, _, err := issueToken(path, "x", ""); err != nil {
 		t.Fatal(err)
 	}
 	fi, err := os.Stat(path)

--- a/docs/relay-protocol.md
+++ b/docs/relay-protocol.md
@@ -159,9 +159,10 @@ both roles against a store hashed at rest (SHA-256); default path
 `<data-dir>/tokens.json` (`$IRRLICHT_HOME` or `~/.local/share/irrlicht`).
 
 ```
-irrlichtrelay token issue --label "ingo-laptop"   # prints the plaintext ONCE
-irrlichtrelay token list                          # id, created, label
-irrlichtrelay token revoke <id>                    # next frame closed with 4401
+irrlichtrelay token issue --label "ingo-laptop"             # prints the plaintext ONCE
+irrlichtrelay token issue --label "acme" --workspace acme   # scoped to a tenant
+irrlichtrelay token list                                    # id, created, workspace, label
+irrlichtrelay token revoke <id>                             # next frame closed with 4401
 ```
 
 A serving relay re-reads the tokens file when it changes, so `revoke` takes
@@ -178,6 +179,19 @@ When `--auth` is on the gate also covers the read endpoints `GET
 the WS stream, so a token is required via `Authorization: Bearer <t>` or a
 `?token=<t>` query param. `GET /api/v1/version` stays open as a health check.
 `/api/v1/tokens` REST management is deferred — CLI-only for now.
+
+**Workspaces (multi-tenant isolation).** A token may be scoped to a *workspace*
+(`token issue --workspace <id>`); the workspace is stored with the token's hash
+and is **server-derived at every handshake** — it is never read from the wire,
+so it cannot be spoofed (the `hello` frame has no workspace field, and daemons
+need no change). The relay partitions all cached state by
+`(workspace, daemon_id, session_id)` and scopes both the WS fan-out and the
+HTTP reads to the connection's own workspace, so a peer only ever sees its own
+tenant's sessions — even if a daemon in another workspace claims a colliding
+`daemon_id`. Isolation is on routing metadata only; payloads stay unread. A
+token issued without `--workspace` (and every connection on a `--auth off`
+relay) lives in the default workspace `""`, i.e. single-tenant — the behavior of
+every relay before workspaces existed.
 
 ## Running it
 


### PR DESCRIPTION
Closes #709.

## Problem
The relay was single-tenant: any valid bearer token saw **every** daemon's sessions across the WS fan-out and the HTTP read API. For a hosted multi-tenant deployment that is cross-tenant (BOLA) leakage.

## Approach
Bind each token to a **workspace, server-side**, and partition all relay state by it. The workspace is derived from the authenticated token at every handshake — **never read from the wire**, so it can't be spoofed. No wire-protocol change and **no daemon-side change** (the `hello` frame is untouched).

Because `daemon_id` is client-supplied in the `hello`, the cache is partitioned by the *authenticated* workspace rather than trusting `daemon_id` to be unique across tenants — a daemon in one workspace can neither read nor overwrite another's slot even with a colliding `daemon_id`.

## Changes
- **`tokens.go`** — `TokenRecord.Workspace`; `authStore` maps token hash → `{id, workspace}`; `validate` returns `(id, workspace, ok)`; `issueToken` takes a workspace.
- **`main.go`** — `token issue --workspace`; `token list` shows the workspace; `requireToken` attaches the validated workspace to the request context.
- **`hub.go`** — cache partitioned into per-tenant `workspaceState` keyed by `(workspace, daemon_id, session_id)`; workspace threads through the daemon path; `clientConn.workspace` scopes fan-out, snapshot, replay, and the read builders. Empty workspaces are reclaimed on last-daemon disconnect.
- **`handlers.go`** — `/api/v1/sessions` and `/api/v1/agents` return only the caller's workspace slice.
- **`docs/relay-protocol.md`** — new "Workspaces" section + CLI examples.

## Backward compatibility
No-auth relays and tokens issued without `--workspace` fall into the default workspace `""` (single-tenant, unchanged behavior).

## Tests
- `TestWorkspaceIsolation` — two tenants whose daemons **both claim `daemon_id "d1"`**; asserts no leakage across WS replay, a live push, and the HTTP read API, both directions.
- `TestTokenWorkspaceRoundTrips` — workspace survives issue → file → reload → validate; default-workspace tokens resolve to `""`.
- Existing round-trip/auth tests still pass (prove default-workspace backward compat).

Verified: `go test ./core/... -race -count=1` (full suite green), gofmt + go vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)