### PR TITLE
refactor(daemon): exhaustive Source→watcher dispatch in buildAgentWatchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ bin/
 core/bin/
 core/irrlicht-ls
 /irrlichtrelay
+# stray daemon binary from `go build ./core/...` (anchored so it never
+# matches the core/cmd/irrlichd/ source dir)
+/irrlichd
+core/irrlichd
 
 # Xcode
 *.xcodeproj

--- a/core/cmd/irrlichd/wiring.go
+++ b/core/cmd/irrlichd/wiring.go
@@ -36,19 +36,29 @@ func buildAgentWatchers(
 		labels   []string
 	)
 
-	if s, ok := a.Source.(agent.FilesUnderRoot); ok {
+	// Source-specific watcher. FilesUnderRoot gets an fswatcher rooted at its
+	// Dir; ProcessOwnedStore gets its dedicated store watcher; FilesUnderCWD
+	// gets none here — its transcript is discovered by the process scanner
+	// below, configured with the variant's Filename. A new Source variant that
+	// reaches the default fails loudly rather than silently running
+	// scanner-only (grant-all daemons exercise every factory at boot, so CI
+	// catches it).
+	switch s := a.Source.(type) {
+	case agent.FilesUnderRoot:
 		w := fswatcher.New(s.RootDirFor(runtime.GOOS), a.Identity.Name, maxSessionAge).WithIdentity(a.Identity)
 		watchers = append(watchers, w)
 		labels = append(labels, fmt.Sprintf("%s (%s)", a.Identity.Name, w.Root()))
-	}
-
-	if _, ok := a.Source.(agent.ProcessOwnedStore); ok {
+	case agent.ProcessOwnedStore:
 		if a.Identity.Name != opencode.AdapterName {
 			panic(fmt.Sprintf("buildAgentWatchers: no store watcher wired for ProcessOwnedStore adapter %q — add its construction here", a.Identity.Name))
 		}
 		w := opencode.New(maxSessionAge).WithIdentity(a.Identity)
 		watchers = append(watchers, w)
 		labels = append(labels, fmt.Sprintf("%s-db (%s)", a.Identity.Name, w.Root()))
+	case agent.FilesUnderCWD:
+		// Scanner-only (configured below); no dedicated file watcher.
+	default:
+		panic(fmt.Sprintf("buildAgentWatchers: unhandled agent.Source variant %T for adapter %q — add its watcher construction here", a.Source, a.Identity.Name))
 	}
 
 	scanner := processlifecycle.NewScanner(processNameFor(a), a.Identity.Name, 0).WithIdentity(a.Identity)

--- a/core/cmd/irrlichd/wiring_test.go
+++ b/core/cmd/irrlichd/wiring_test.go
@@ -5,25 +5,57 @@ import (
 	"time"
 
 	"irrlicht/core/adapters/inbound/agents"
+	"irrlicht/core/adapters/inbound/agents/fswatcher"
+	"irrlicht/core/adapters/inbound/agents/opencode"
+	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	"irrlicht/core/domain/agent"
 )
 
 // buildAgentWatchers must dispatch every registered adapter's Source variant
-// without panicking, and produce the right watcher set: a process scanner for
-// every adapter, plus a dedicated file/store watcher for FilesUnderRoot and
-// ProcessOwnedStore. FilesUnderCWD is scanner-only.
+// without panicking and build the right watcher set: exactly one process
+// scanner for every adapter, plus the variant's dedicated watcher — an
+// fswatcher for FilesUnderRoot, the opencode store watcher for
+// ProcessOwnedStore, and none for FilesUnderCWD (scanner-only). The set is
+// checked by concrete type, not just count, so wiring the wrong watcher is
+// caught.
 func TestBuildAgentWatchers_PerSourceVariant(t *testing.T) {
 	noCheck := func(string, int) bool { return true }
 	for _, a := range agents.All() {
-		a := a
 		t.Run(a.Identity.Name, func(t *testing.T) {
 			watchers, _ := buildAgentWatchers(a, time.Minute, noCheck)
-			want := 2 // file/store watcher + scanner
-			if _, ok := a.Source.(agent.FilesUnderCWD); ok {
-				want = 1 // scanner only
+
+			var scanners, fswatchers, stores int
+			for _, w := range watchers {
+				switch w.(type) {
+				case *processlifecycle.Scanner:
+					scanners++
+				case *fswatcher.Watcher:
+					fswatchers++
+				case *opencode.Watcher:
+					stores++
+				default:
+					t.Errorf("%s: unexpected watcher type %T", a.Identity.Name, w)
+				}
 			}
-			if len(watchers) != want {
-				t.Errorf("%s (%T): got %d watchers, want %d", a.Identity.Name, a.Source, len(watchers), want)
+
+			if scanners != 1 {
+				t.Errorf("%s: got %d process scanners, want 1", a.Identity.Name, scanners)
+			}
+			switch a.Source.(type) {
+			case agent.FilesUnderRoot:
+				if fswatchers != 1 || stores != 0 {
+					t.Errorf("%s (FilesUnderRoot): fswatchers=%d stores=%d, want 1/0", a.Identity.Name, fswatchers, stores)
+				}
+			case agent.ProcessOwnedStore:
+				if stores != 1 || fswatchers != 0 {
+					t.Errorf("%s (ProcessOwnedStore): stores=%d fswatchers=%d, want 1/0", a.Identity.Name, stores, fswatchers)
+				}
+			case agent.FilesUnderCWD:
+				if fswatchers != 0 || stores != 0 {
+					t.Errorf("%s (FilesUnderCWD): want scanner-only, got fswatchers=%d stores=%d", a.Identity.Name, fswatchers, stores)
+				}
+			default:
+				t.Fatalf("%s: unhandled Source variant %T — update this test", a.Identity.Name, a.Source)
 			}
 		})
 	}

--- a/core/cmd/irrlichd/wiring_test.go
+++ b/core/cmd/irrlichd/wiring_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/adapters/inbound/agents"
+	"irrlicht/core/domain/agent"
+)
+
+// buildAgentWatchers must dispatch every registered adapter's Source variant
+// without panicking, and produce the right watcher set: a process scanner for
+// every adapter, plus a dedicated file/store watcher for FilesUnderRoot and
+// ProcessOwnedStore. FilesUnderCWD is scanner-only.
+func TestBuildAgentWatchers_PerSourceVariant(t *testing.T) {
+	noCheck := func(string, int) bool { return true }
+	for _, a := range agents.All() {
+		a := a
+		t.Run(a.Identity.Name, func(t *testing.T) {
+			watchers, _ := buildAgentWatchers(a, time.Minute, noCheck)
+			want := 2 // file/store watcher + scanner
+			if _, ok := a.Source.(agent.FilesUnderCWD); ok {
+				want = 1 // scanner only
+			}
+			if len(watchers) != want {
+				t.Errorf("%s (%T): got %d watchers, want %d", a.Identity.Name, a.Source, len(watchers), want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`buildAgentWatchers` (the daemon composition root) dispatched the agent's
`Source` variant with a chain of independent `if v, ok := a.Source.(T)`
type-asserts. Two problems:

- An **unknown** variant fell through every `if` and silently got a process
  scanner only — no file/store watcher, no error.
- A `ProcessOwnedStore` adapter other than opencode hit a **stringly name-check
  panic**.

This converts the chain to a single `switch a.Source.(type)` with a `default`
panic, making the dispatch **exhaustive**: a new variant nobody wired fails
loudly at boot (grant-all daemons exercise every watcher factory, so the smoke
test / CI catches it) instead of running scanner-only.

The shared process scanner is still built **exactly once**; the opencode
store-watcher guard is unchanged.

## On the candidate's framing

The original review suggested letting each `Source` variant "build its own
watcher." That's a **hexagonal layering violation** — `agent.Source` is *domain*,
watchers (`fswatcher`, `opencode`, `processlifecycle`) are *adapters*, and a
domain method returning adapter watchers would invert the `domain → adapter`
dependency. And `opencode.New` ignores the `ProcessOwnedStore` fields, so the
store watcher can't be generically constructed from the variant either. So the
scoped, layering-respecting win is the exhaustive switch — construction stays in
the composition root.

## Behavior

**Identical** for all three existing variants. The only new behavior is the
`default` panic for a hypothetical unwired variant (none exist today).

- `TestDaemonStartupSmoke` (demo + ask modes) — every agent wires without panic.
- New `wiring_test.go` — asserts the watcher set for **every** registered
  adapter: FilesUnderRoot ×5 → 2 watchers, opencode (ProcessOwnedStore) → 2,
  aider (FilesUnderCWD) → 1.

Composition-root only — no parser/output change, so no replay-golden churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
