### PR TITLE
fix(antigravity): read tokens from the conversation store so the context bar renders (#719)

### DIFF
--- a/core/adapters/inbound/agents/antigravity/agent.go
+++ b/core/adapters/inbound/agents/antigravity/agent.go
@@ -63,16 +63,18 @@ func Agent() agent.Agent {
 				Key:             PermissionKeyTranscripts,
 				Kind:            permission.KindObserve,
 				Title:           "Read session transcripts",
-				FeatureUnlocked: "Session list, timeline, and state",
-				Touches: "Reads session transcripts under ~/.gemini/antigravity-cli/ " +
-					"and ~/.gemini/antigravity/ and the working directory of running " +
-					"agy processes",
+				FeatureUnlocked: "Session list, timeline, state, and context-window usage",
+				Touches: "Reads session transcripts and conversation stores under " +
+					"~/.gemini/antigravity-cli/ and ~/.gemini/antigravity/ and the " +
+					"working directory of running agy processes",
 				Detail: "Tails transcript.jsonl files under " +
 					"~/.gemini/antigravity{,-cli}/brain/<conversation>/.system_generated/logs/ " +
-					"to derive session state, model, and timeline. Also scans for " +
-					"running agy CLI processes and reads their working directory to " +
-					"bind a session to its process. Read-only — no file is ever " +
-					"modified. Toggling off stops all reading immediately.",
+					"to derive session state, model, and timeline, and reads the sibling " +
+					"conversation store ~/.gemini/antigravity{,-cli}/conversations/<conversation>.db " +
+					"for token counts and the canonical model name (context-window usage). " +
+					"Also scans for running agy CLI processes and reads their working " +
+					"directory to bind a session to its process. Read-only — no file is " +
+					"ever modified. Toggling off stops all reading immediately.",
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/antigravity/dbmetrics.go
+++ b/core/adapters/inbound/agents/antigravity/dbmetrics.go
@@ -1,0 +1,226 @@
+package antigravity
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// Antigravity keeps token usage and the canonical model id in a per-conversation
+// SQLite store that sits beside the transcript — the transcript.jsonl itself
+// carries only the human-readable model display name and no usage at all. For a
+// transcript at
+//
+//	<root>/brain/<conv-id>/.system_generated/logs/transcript.jsonl
+//
+// the store is <root>/conversations/<conv-id>.db. Reading it lights up the
+// context bar (#719); without it every Antigravity session reports zero tokens,
+// so ComputeContextUtilization returns pressure "unknown" and both UIs hide the
+// bar. A missing or unreadable store degrades to no-usage — the pre-#719 state.
+
+// dbModelTokens is one read of the conversation store: the canonical model id
+// and the latest generation's context-token count. Either may be zero/empty
+// when the store's shape is unrecognized; the caller then emits no usage.
+type dbModelTokens struct {
+	model         string
+	contextTokens int64
+}
+
+// dbCache memoizes one store read keyed by (mtime, size) so a backfill of a
+// long transcript — every historical turn_done re-reading the same growing
+// .db — costs one query per change, not one per turn (mirrors kirocli's
+// sidecarCache).
+type dbCache struct {
+	mtime time.Time
+	size  int64
+	val   dbModelTokens
+	ok    bool
+}
+
+// storePathForTranscript maps a transcript path to its sibling conversation
+// store, or "" when the path is not a recognized Antigravity transcript. The
+// <conv-id> directory is shared between the brain transcript and the
+// conversations store, so it is the join key.
+func storePathForTranscript(transcriptPath string) string {
+	conv := sessionIDFromPath(transcriptPath)
+	if conv == "" {
+		return ""
+	}
+	// Climb to <root>: transcript.jsonl → logs → .system_generated → <conv-id>
+	// → brain → <root>.
+	root := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(transcriptPath)))))
+	return filepath.Join(root, "conversations", conv+".db")
+}
+
+// readStoreModelTokens opens the conversation store read-only and returns the
+// canonical model id plus the latest generation's context-token count, memoized
+// by (mtime, size). The bool is false when the store is missing, locked, or its
+// gen_metadata shape is unrecognized — callers degrade to no-usage.
+func readStoreModelTokens(transcriptPath string, cache *dbCache) (dbModelTokens, bool) {
+	dbPath := storePathForTranscript(transcriptPath)
+	if dbPath == "" {
+		return dbModelTokens{}, false
+	}
+	fi, err := os.Stat(dbPath)
+	if err != nil {
+		return dbModelTokens{}, false
+	}
+	if cache != nil && cache.ok && fi.ModTime().Equal(cache.mtime) && fi.Size() == cache.size {
+		return cache.val, true
+	}
+
+	// Read-only, WAL-aware, short timeout so a live agy write never blocks the
+	// daemon (mirrors the opencode metrics reader).
+	db, err := sql.Open("sqlite", dbPath+"?mode=ro&_journal=WAL&_timeout=500")
+	if err != nil {
+		return dbModelTokens{}, false
+	}
+	defer db.Close()
+
+	// gen_metadata holds one protobuf blob per generation; the highest idx is
+	// the most recent, whose prompt-token count is the current context fill.
+	var blob []byte
+	if err := db.QueryRow(`SELECT data FROM gen_metadata ORDER BY idx DESC LIMIT 1`).Scan(&blob); err != nil {
+		return dbModelTokens{}, false
+	}
+
+	val := decodeGenMetadata(blob)
+	if cache != nil {
+		*cache = dbCache{mtime: fi.ModTime(), size: fi.Size(), val: val, ok: true}
+	}
+	return val, true
+}
+
+// gen_metadata protobuf field numbers, reverse-engineered from agy's store (no
+// .proto ships with Antigravity). Empirically stable across the 0.5.x CLI:
+//
+//	msg(top) #1              → the generation's usage submessage
+//	  usage  #4              → token-count block
+//	    block #5  varint     → prompt tokens = current context-window occupancy
+//	  usage  #19 string      → canonical model id ("gemini-3.1-pro-low")
+//
+// Field #21 carries the human display name ("Gemini 3.1 Pro (Low)"); #19 is
+// preferred because only the dash-form id resolves in the capacity context-
+// window map.
+const (
+	fieldUsage          = 1
+	fieldTokenBlock     = 4
+	fieldPromptTokens   = 5
+	fieldCanonicalModel = 19
+)
+
+// decodeGenMetadata extracts the canonical model id and context-token count
+// from one gen_metadata protobuf blob. Any field absent leaves its zero value,
+// so an unrecognized shape yields an empty result rather than an error.
+func decodeGenMetadata(blob []byte) dbModelTokens {
+	usage := protoBytesField(blob, fieldUsage)
+	if usage == nil {
+		return dbModelTokens{}
+	}
+	var out dbModelTokens
+	if model := protoBytesField(usage, fieldCanonicalModel); model != nil {
+		out.model = string(model)
+	}
+	if block := protoBytesField(usage, fieldTokenBlock); block != nil {
+		out.contextTokens = protoVarintField(block, fieldPromptTokens)
+	}
+	return out
+}
+
+// protoBytesField returns the value of the first length-delimited field with
+// the given number, or nil. protoVarintField returns the first varint field's
+// value, or 0. Hand-rolled because agy ships no .proto and we need only a few
+// fields — a dependency-free walker beats pulling in protobuf reflection.
+func protoBytesField(buf []byte, field int) []byte {
+	var out []byte
+	walkProto(buf, func(f, wire int, data []byte, _ uint64) bool {
+		if f == field && wire == 2 {
+			out = data
+			return true
+		}
+		return false
+	})
+	return out
+}
+
+func protoVarintField(buf []byte, field int) int64 {
+	var out int64
+	walkProto(buf, func(f, wire int, _ []byte, num uint64) bool {
+		if f == field && wire == 0 {
+			out = int64(num)
+			return true
+		}
+		return false
+	})
+	return out
+}
+
+// walkProto iterates a protobuf message's top-level fields, calling fn with each
+// field's number, wire type, and payload (LEN bytes in data; varint value in
+// num). It stops when fn returns true and returns silently on truncated or
+// malformed input, so a missing field reads as "no data".
+func walkProto(buf []byte, fn func(field, wire int, data []byte, num uint64) bool) {
+	for i := 0; i < len(buf); {
+		tag, n := readVarint(buf[i:])
+		if n == 0 {
+			return
+		}
+		i += n
+		field, wire := int(tag>>3), int(tag&7)
+		switch wire {
+		case 0: // varint
+			v, n := readVarint(buf[i:])
+			if n == 0 {
+				return
+			}
+			i += n
+			if fn(field, wire, nil, v) {
+				return
+			}
+		case 2: // length-delimited
+			l, n := readVarint(buf[i:])
+			if n == 0 {
+				return
+			}
+			i += n
+			if i+int(l) > len(buf) {
+				return
+			}
+			if fn(field, wire, buf[i:i+int(l)], 0) {
+				return
+			}
+			i += int(l)
+		case 1: // 64-bit
+			if i+8 > len(buf) {
+				return
+			}
+			i += 8
+		case 5: // 32-bit
+			if i+4 > len(buf) {
+				return
+			}
+			i += 4
+		default:
+			return
+		}
+	}
+}
+
+// readVarint decodes a base-128 varint, returning the value and bytes consumed
+// (0, 0 on truncation or overflow).
+func readVarint(b []byte) (uint64, int) {
+	var v uint64
+	for i := 0; i < len(b); i++ {
+		v |= uint64(b[i]&0x7f) << (7 * uint(i))
+		if b[i]&0x80 == 0 {
+			return v, i + 1
+		}
+		if i >= 9 {
+			return 0, 0 // overflow
+		}
+	}
+	return 0, 0 // truncated
+}

--- a/core/adapters/inbound/agents/antigravity/dbmetrics.go
+++ b/core/adapters/inbound/agents/antigravity/dbmetrics.go
@@ -29,15 +29,18 @@ type dbModelTokens struct {
 	contextTokens int64
 }
 
-// dbCache memoizes one store read keyed by (mtime, size) so a backfill of a
-// long transcript — every historical turn_done re-reading the same growing
-// .db — costs one query per change, not one per turn (mirrors kirocli's
-// sidecarCache).
+// dbCache memoizes one store read keyed by the store's (mtime, size) plus the
+// -wal file size, so a backfill of a long transcript — every historical
+// turn_done re-reading the same growing .db — costs one query per change, not
+// one per turn (mirrors kirocli's sidecarCache). The -wal size is part of the
+// key because live agy writes land in the WAL before any checkpoint; without it
+// an active session's bar would freeze on the first read (see readStoreModelTokens).
 type dbCache struct {
-	mtime time.Time
-	size  int64
-	val   dbModelTokens
-	ok    bool
+	mtime   time.Time
+	size    int64
+	walSize int64
+	val     dbModelTokens
+	ok      bool
 }
 
 // storePathForTranscript maps a transcript path to its sibling conversation
@@ -68,7 +71,17 @@ func readStoreModelTokens(transcriptPath string, cache *dbCache) (dbModelTokens,
 	if err != nil {
 		return dbModelTokens{}, false
 	}
-	if cache != nil && cache.ok && fi.ModTime().Equal(cache.mtime) && fi.Size() == cache.size {
+	// Live agy writes land in the -wal file; the main .db's mtime/size only move
+	// on checkpoint, so the WAL must be part of the freshness key or an active
+	// session's bar would freeze until SQLite next checkpoints. Use its size, not
+	// mtime, so our own read-only opens (which may touch -wal/-shm) don't
+	// spuriously invalidate the cache and re-trigger an O(N) backfill.
+	var walSize int64
+	if wfi, werr := os.Stat(dbPath + "-wal"); werr == nil {
+		walSize = wfi.Size()
+	}
+	if cache != nil && cache.ok &&
+		fi.ModTime().Equal(cache.mtime) && fi.Size() == cache.size && walSize == cache.walSize {
 		return cache.val, true
 	}
 
@@ -89,7 +102,7 @@ func readStoreModelTokens(transcriptPath string, cache *dbCache) (dbModelTokens,
 
 	val := decodeGenMetadata(blob)
 	if cache != nil {
-		*cache = dbCache{mtime: fi.ModTime(), size: fi.Size(), val: val, ok: true}
+		*cache = dbCache{mtime: fi.ModTime(), size: fi.Size(), walSize: walSize, val: val, ok: true}
 	}
 	return val, true
 }

--- a/core/adapters/inbound/agents/antigravity/dbmetrics_test.go
+++ b/core/adapters/inbound/agents/antigravity/dbmetrics_test.go
@@ -1,0 +1,194 @@
+package antigravity
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"irrlicht/core/pkg/tailer"
+)
+
+// Compile-time proof the parser opts into transcript-path injection, the seam
+// that lets turn_done locate the sibling conversation store.
+var _ tailer.TranscriptPathAware = (*Parser)(nil)
+
+// --- protobuf builders (mirror agy's gen_metadata wire shape) ----------------
+
+func encodeVarint(v uint64) []byte {
+	var out []byte
+	for v >= 0x80 {
+		out = append(out, byte(v)|0x80)
+		v >>= 7
+	}
+	return append(out, byte(v))
+}
+
+func pbTag(field, wire int) []byte { return encodeVarint(uint64(field)<<3 | uint64(wire)) }
+
+func pbVarint(field int, v uint64) []byte { return append(pbTag(field, 0), encodeVarint(v)...) }
+
+func pbBytes(field int, b []byte) []byte {
+	out := append(pbTag(field, 2), encodeVarint(uint64(len(b)))...)
+	return append(out, b...)
+}
+
+// genBlob builds a gen_metadata blob carrying a context-token count and a
+// canonical model id, in the nested shape the decoder expects:
+//
+//	#1 usage { #4 block { #5 = promptTokens }; #19 = model; #21 = displayName }
+func genBlob(promptTokens uint64, model string) []byte {
+	block := pbVarint(fieldPromptTokens, promptTokens)
+	usage := pbBytes(fieldTokenBlock, block)
+	usage = append(usage, pbBytes(fieldCanonicalModel, []byte(model))...)
+	usage = append(usage, pbBytes(21, []byte("Gemini 3.1 Pro (Low)"))...) // display — ignored
+	return pbBytes(fieldUsage, usage)
+}
+
+// writeStore creates a conversations/<conv>.db with the given gen_metadata rows
+// (idx → blob) and returns the matching transcript path.
+func writeStore(t *testing.T, root, conv string, rows map[int][]byte) string {
+	t.Helper()
+	convDir := filepath.Join(root, "conversations")
+	if err := os.MkdirAll(convDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(convDir, conv+".db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE gen_metadata (idx integer primary key, data blob, size integer)`); err != nil {
+		t.Fatal(err)
+	}
+	for idx, blob := range rows {
+		if _, err := db.Exec(`INSERT INTO gen_metadata (idx, data, size) VALUES (?, ?, ?)`, idx, blob, len(blob)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(root, "brain", conv, ".system_generated", "logs", transcriptFilename)
+}
+
+// --- tests -------------------------------------------------------------------
+
+func TestDecodeGenMetadata(t *testing.T) {
+	got := decodeGenMetadata(genBlob(16353, "gemini-3.1-pro-low"))
+	if got.contextTokens != 16353 {
+		t.Errorf("contextTokens = %d, want 16353", got.contextTokens)
+	}
+	if got.model != "gemini-3.1-pro-low" {
+		t.Errorf("model = %q, want gemini-3.1-pro-low", got.model)
+	}
+
+	// An unrecognized blob yields a zero result, not a panic.
+	if got := decodeGenMetadata([]byte{0xff, 0x01, 0x02}); got.model != "" || got.contextTokens != 0 {
+		t.Errorf("garbage blob: got %+v, want zero", got)
+	}
+}
+
+func TestStorePathForTranscript(t *testing.T) {
+	tp := "/home/u/.gemini/antigravity-cli/brain/abc-123/.system_generated/logs/transcript.jsonl"
+	want := "/home/u/.gemini/antigravity-cli/conversations/abc-123.db"
+	if got := storePathForTranscript(tp); got != want {
+		t.Errorf("storePathForTranscript = %q, want %q", got, want)
+	}
+	// A non-transcript path yields "".
+	if got := storePathForTranscript("/tmp/transcript_full.jsonl"); got != "" {
+		t.Errorf("non-transcript path: got %q, want empty", got)
+	}
+}
+
+func TestReadStoreModelTokens(t *testing.T) {
+	root := t.TempDir()
+	conv := "abc-123"
+	// idx 1 (latest) is the current context; idx 0 is an earlier, smaller turn.
+	tp := writeStore(t, root, conv, map[int][]byte{
+		0: genBlob(8106, "gemini-3.1-pro-low"),
+		1: genBlob(16353, "gemini-3.1-pro-low"),
+	})
+
+	var cache dbCache
+	got, ok := readStoreModelTokens(tp, &cache)
+	if !ok {
+		t.Fatal("readStoreModelTokens: ok=false, want a successful read")
+	}
+	if got.contextTokens != 16353 {
+		t.Errorf("contextTokens = %d, want 16353 (highest idx)", got.contextTokens)
+	}
+	if got.model != "gemini-3.1-pro-low" {
+		t.Errorf("model = %q, want gemini-3.1-pro-low", got.model)
+	}
+	if !cache.ok {
+		t.Error("cache should be populated after a read")
+	}
+
+	// Second read hits the cache (same mtime/size) and returns the same value.
+	if got2, ok2 := readStoreModelTokens(tp, &cache); !ok2 || got2 != got {
+		t.Errorf("cached read = (%+v, %v), want (%+v, true)", got2, ok2, got)
+	}
+
+	// A transcript whose store does not exist degrades to no-usage.
+	missing := filepath.Join(root, "brain", "no-such-conv", ".system_generated", "logs", transcriptFilename)
+	if _, ok := readStoreModelTokens(missing, &dbCache{}); ok {
+		t.Error("absent store: ok=true, want false")
+	}
+}
+
+// TestTurnDoneEnrichesFromStore is the end-to-end check: a turn_done event picks
+// up tokens + the canonical model from the store, and the canonical id sticks so
+// later working-phase events stay resolvable (the bar doesn't blink off).
+func TestTurnDoneEnrichesFromStore(t *testing.T) {
+	root := t.TempDir()
+	conv := "abc-123"
+	tp := writeStore(t, root, conv, map[int][]byte{0: genBlob(16353, "gemini-3.1-pro-low")})
+
+	p := &Parser{}
+	p.SetTranscriptPath(tp)
+
+	// Boot the session on the display-form model — which alone does NOT resolve.
+	p.ParseLine(line("USER_EXPLICIT", "USER_INPUT", 0,
+		"<USER_REQUEST>\nhi\n</USER_REQUEST>\n<USER_SETTINGS_CHANGE>\nThe user changed setting `Model Selection` from None to Gemini 3.1 Pro (Low).\n</USER_SETTINGS_CHANGE>", nil))
+	work := p.ParseLine(line("MODEL", "PLANNER_RESPONSE", 1, "I will run it.", runCommand("/repo")))
+	if work.Tokens != nil {
+		t.Error("a working assistant event must not carry tokens (store read is turn_done only)")
+	}
+
+	// Terminal line → turn_done → store enrichment.
+	done := p.ParseLine(line("MODEL", "PLANNER_RESPONSE", 2, "", nil))
+	if done.EventType != "turn_done" {
+		t.Fatalf("got type=%q, want turn_done", done.EventType)
+	}
+	if done.Tokens == nil || done.Tokens.Total != 16353 {
+		t.Fatalf("turn_done Tokens = %+v, want Total=16353 from the store", done.Tokens)
+	}
+	if done.ModelName != "gemini-3.1-pro-low" {
+		t.Errorf("turn_done ModelName = %q, want the store's canonical gemini-3.1-pro-low", done.ModelName)
+	}
+
+	// No-flicker: the next turn's working event reports the canonical id too, so
+	// ComputeContextUtilization keeps resolving the window between turns.
+	p.ParseLine(line("USER_EXPLICIT", "USER_INPUT", 3, "<USER_REQUEST>\nmore\n</USER_REQUEST>", nil))
+	next := p.ParseLine(line("MODEL", "PLANNER_RESPONSE", 4, "Working", runCommand("/repo")))
+	if next.ModelName != "gemini-3.1-pro-low" {
+		t.Errorf("post-store working event ModelName = %q, want gemini-3.1-pro-low (no flicker)", next.ModelName)
+	}
+}
+
+// TestTurnDoneNoStoreIsHarmless proves the pre-#719 behavior survives when the
+// store is absent: turn_done still fires, just without tokens.
+func TestTurnDoneNoStoreIsHarmless(t *testing.T) {
+	p := &Parser{}
+	p.SetTranscriptPath("/no/such/brain/conv/.system_generated/logs/transcript.jsonl")
+	done := p.ParseLine(line("MODEL", "PLANNER_RESPONSE", 0, "", nil))
+	if done.EventType != "turn_done" {
+		t.Fatalf("got type=%q, want turn_done", done.EventType)
+	}
+	if done.Tokens != nil {
+		t.Errorf("absent store must leave Tokens nil, got %+v", done.Tokens)
+	}
+}

--- a/core/adapters/inbound/agents/antigravity/dbmetrics_test.go
+++ b/core/adapters/inbound/agents/antigravity/dbmetrics_test.go
@@ -74,6 +74,22 @@ func writeStore(t *testing.T, root, conv string, rows map[int][]byte) string {
 	return filepath.Join(root, "brain", conv, ".system_generated", "logs", transcriptFilename)
 }
 
+// upsertGen opens an existing store and inserts/replaces one gen_metadata row,
+// changing the main .db's mtime/size so a stale cache must invalidate.
+func upsertGen(t *testing.T, dbPath string, idx int, blob []byte) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT OR REPLACE INTO gen_metadata (idx, data, size) VALUES (?, ?, ?)`, idx, blob, len(blob)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // --- tests -------------------------------------------------------------------
 
 func TestDecodeGenMetadata(t *testing.T) {
@@ -190,5 +206,70 @@ func TestTurnDoneNoStoreIsHarmless(t *testing.T) {
 	}
 	if done.Tokens != nil {
 		t.Errorf("absent store must leave Tokens nil, got %+v", done.Tokens)
+	}
+}
+
+// TestStoreCacheFreshness proves the cache returns fresh data when the store
+// changes: a new gen_metadata row (main .db grows) and, separately, a grown
+// -wal file (where live agy writes land before any checkpoint) both invalidate.
+func TestStoreCacheFreshness(t *testing.T) {
+	root := t.TempDir()
+	conv := "abc-123"
+	tp := writeStore(t, root, conv, map[int][]byte{0: genBlob(8106, "gemini-3.1-pro-low")})
+	dbPath := storePathForTranscript(tp)
+
+	var cache dbCache
+	if got, _ := readStoreModelTokens(tp, &cache); got.contextTokens != 8106 {
+		t.Fatalf("first read = %d, want 8106", got.contextTokens)
+	}
+
+	// A new, higher generation must be picked up (not served stale from cache).
+	upsertGen(t, dbPath, 1, genBlob(16353, "gemini-3.1-pro-low"))
+	if got, _ := readStoreModelTokens(tp, &cache); got.contextTokens != 16353 {
+		t.Errorf("after new row, read = %d, want 16353 (cache must invalidate on .db change)", got.contextTokens)
+	}
+
+	// A grown -wal must invalidate too: in WAL mode the committed write sits in
+	// the -wal while the main .db is unchanged, so without this an active
+	// session's bar would freeze. After the read above, cache.walSize == 0 (no
+	// -wal existed). Growing the -wal changes the freshness key, so a correct
+	// cache must NOT serve a hit — i.e. it must not return (ok && walSize still
+	// 0). (We don't assert the value: a synthetic -wal is not a real SQLite WAL,
+	// so the re-read may legitimately succeed or fail; either way it's not a hit.)
+	if err := os.WriteFile(dbPath+"-wal", []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := readStoreModelTokens(tp, &cache); ok && cache.walSize == 0 {
+		t.Errorf("grown -wal served stale from cache (got %d); walSize must be part of the freshness key", got.contextTokens)
+	}
+}
+
+// TestModelSwitchSurvivesStore proves the store write-back does NOT clobber a
+// mid-session model switch: the switch is captured by parseUserInput and the
+// next turn_done canonicalizes it to the switched-to model, not the prior one.
+func TestModelSwitchSurvivesStore(t *testing.T) {
+	root := t.TempDir()
+	conv := "abc-123"
+	tp := writeStore(t, root, conv, map[int][]byte{0: genBlob(5000, "gemini-3.5-flash-low")})
+	dbPath := storePathForTranscript(tp)
+
+	p := &Parser{}
+	p.SetTranscriptPath(tp)
+
+	// Turn 1 on Flash → turn_done canonicalizes to the store's flash id.
+	p.ParseLine(line("USER_EXPLICIT", "USER_INPUT", 0,
+		"<USER_REQUEST>\nhi\n</USER_REQUEST>\n<USER_SETTINGS_CHANGE>\nThe user changed setting `Model Selection` from None to Gemini 3.5 Flash (Low).\n</USER_SETTINGS_CHANGE>", nil))
+	d1 := p.ParseLine(line("MODEL", "PLANNER_RESPONSE", 1, "", nil))
+	if d1.ModelName != "gemini-3.5-flash-low" {
+		t.Fatalf("turn 1 ModelName = %q, want gemini-3.5-flash-low", d1.ModelName)
+	}
+
+	// Turn 2: user switches to Pro; the store's next generation reflects it.
+	upsertGen(t, dbPath, 1, genBlob(6000, "gemini-3.1-pro-low"))
+	p.ParseLine(line("USER_EXPLICIT", "USER_INPUT", 2,
+		"<USER_REQUEST>\nmore\n</USER_REQUEST>\n<USER_SETTINGS_CHANGE>\nThe user changed setting `Model Selection` from Gemini 3.5 Flash (Low) to Gemini 3.1 Pro (Low).\n</USER_SETTINGS_CHANGE>", nil))
+	d2 := p.ParseLine(line("MODEL", "PLANNER_RESPONSE", 3, "", nil))
+	if d2.ModelName != "gemini-3.1-pro-low" {
+		t.Errorf("turn 2 ModelName = %q, want gemini-3.1-pro-low — the switch must survive the store write-back", d2.ModelName)
 	}
 }

--- a/core/adapters/inbound/agents/antigravity/parser.go
+++ b/core/adapters/inbound/agents/antigravity/parser.go
@@ -160,8 +160,8 @@ func (p *Parser) parsePlannerResponse(raw map[string]any, ev *tailer.ParsedEvent
 // and canonical model id from the sibling conversation store (#719). The
 // transcript carries neither — only the display model name and no usage — so
 // without this the context bar never appears for Antigravity. The store is read
-// once per turn_done (memoized by mtime/size); a missing or unreadable store
-// leaves the event unchanged.
+// once per turn_done (memoized while the store is unchanged); a missing or
+// unreadable store leaves the event unchanged.
 //
 // The store's canonical id (e.g. "gemini-3.1-pro-low") is preferred over the
 // transcript's display name ("Gemini 3.1 Pro") because only the dash form

--- a/core/adapters/inbound/agents/antigravity/parser.go
+++ b/core/adapters/inbound/agents/antigravity/parser.go
@@ -29,22 +29,34 @@ import (
 //     failure from the result text.
 //   - source "SYSTEM" (CONVERSATION_HISTORY, CHECKPOINT) — skipped.
 //
-// Tokens/cost are not in the JSONL (they live in the per-conversation SQLite
-// protobuf store), so the parser surfaces no usage; state, cwd, model, and
-// tool/timeline activity all derive from the transcript alone.
+// Cost is not surfaced (the JSONL carries no per-turn pricing), but token usage
+// and the canonical model id ARE read on turn_done from the sibling per-
+// conversation SQLite store (see dbmetrics.go) so the context bar can render
+// (#719); state, cwd, the display model, and tool/timeline activity all derive
+// from the transcript alone.
 //
 // Statefulness:
 //   - cwd: harvested from a run_command tool call's Cwd arg and attached to
 //     every emitted event so PID discovery can match the owning agy process.
 //   - model: harvested from the first <USER_SETTINGS_CHANGE> and attached to
-//     subsequent assistant events.
+//     subsequent assistant events; replaced by the store's canonical id once
+//     read so the model stays resolvable and the context bar doesn't flicker.
 //   - openToolID: the synthetic ID of the currently-open tool call, closed by
 //     the next result line (and swept by the tailer on turn_done).
+//   - path: the transcript path, injected via tailer.TranscriptPathAware, used
+//     to locate the sibling conversation store on turn_done.
+//   - db: memoizes the last store read by (mtime, size).
 type Parser struct {
 	cwd        string
 	model      string
 	openToolID string
+	path       string
+	db         dbCache
 }
+
+// SetTranscriptPath implements tailer.TranscriptPathAware: the tailer injects
+// the transcript path so turn_done can locate the sibling conversation store.
+func (p *Parser) SetTranscriptPath(path string) { p.path = path }
 
 // userSettingsModelRe pulls the model name out of a <USER_SETTINGS_CHANGE>
 // block, e.g. "changed setting `Model Selection` from None to Gemini 3.5 Flash
@@ -117,8 +129,10 @@ func (p *Parser) parsePlannerResponse(raw map[string]any, ev *tailer.ParsedEvent
 
 	if len(toolCalls) == 0 {
 		// No tool call follows — the turn is over (the terminal line is usually
-		// an empty PLANNER_RESPONSE).
+		// an empty PLANNER_RESPONSE). The store has the completed generation's
+		// usage by now, so harvest tokens + the canonical model here.
 		ev.EventType = "turn_done"
+		p.applyDBMetrics(ev)
 		return
 	}
 
@@ -139,6 +153,35 @@ func (p *Parser) parsePlannerResponse(raw map[string]any, ev *tailer.ParsedEvent
 		if cwd := cwdFromToolCall(tcm); cwd != "" {
 			p.cwd = cwd
 		}
+	}
+}
+
+// applyDBMetrics enriches a turn_done event with the latest context-token count
+// and canonical model id from the sibling conversation store (#719). The
+// transcript carries neither — only the display model name and no usage — so
+// without this the context bar never appears for Antigravity. The store is read
+// once per turn_done (memoized by mtime/size); a missing or unreadable store
+// leaves the event unchanged.
+//
+// The store's canonical id (e.g. "gemini-3.1-pro-low") is preferred over the
+// transcript's display name ("Gemini 3.1 Pro") because only the dash form
+// resolves in the capacity context-window map. It is written back to p.model so
+// later working-phase events report the same resolvable id and the bar stays
+// lit between turns rather than blinking off.
+func (p *Parser) applyDBMetrics(ev *tailer.ParsedEvent) {
+	if p.path == "" {
+		return
+	}
+	val, ok := readStoreModelTokens(p.path, &p.db)
+	if !ok {
+		return
+	}
+	if val.model != "" {
+		p.model = tailer.NormalizeModelName(val.model)
+		ev.ModelName = p.model
+	}
+	if val.contextTokens > 0 {
+		ev.Tokens = &tailer.TokenSnapshot{Total: val.contextTokens}
 	}
 }
 

--- a/core/pkg/capacity/aliases.go
+++ b/core/pkg/capacity/aliases.go
@@ -100,12 +100,18 @@ var modelAliases = map[string]string{
 	"kimi-code":       "moonshot.kimi-k2-thinking", // LOCAL_OVERRIDE: codeburn → kimi-k2-thinking (not in LiteLLM).
 	"kimi-for-coding": "moonshot.kimi-k2-thinking", // LOCAL_OVERRIDE: codeburn → kimi-k2-thinking (not in LiteLLM).
 
-	// Antigravity Gemini IDs resolve to preview-priced entries.
+	// Antigravity Gemini IDs resolve to preview-priced entries. The conversation
+	// store also emits ids the transcript never shows: "gemini-pro-default" (the
+	// unpinned default Pro) and "gemini-3-flash-a" (the short agent-flash form).
+	// All gemini-3.x share the 1M context window, so the context bar resolves
+	// regardless of which preview tier they price as.
 	"gemini-3.1-pro":         "gemini-3.1-pro-preview",
 	"gemini-3-flash":         "gemini-3-flash-preview",
 	"gemini-3.1-pro-high":    "gemini-3.1-pro-preview",
 	"gemini-3.1-pro-low":     "gemini-3.1-pro-preview",
 	"gemini-3-flash-agent":   "gemini-3-flash-preview",
+	"gemini-3-flash-a":       "gemini-3-flash-preview",
+	"gemini-pro-default":     "gemini-3.1-pro-preview",
 	"gemini-3-pro":           "gemini-3-pro-preview",
 	"gemini-3.1-flash-image": "gemini-3.1-flash-image-preview",
 	"gemini-3.1-flash-lite":  "gemini-3.1-flash-lite-preview",
@@ -117,6 +123,10 @@ var modelAliases = map[string]string{
 	"Gemini 3.5 Flash (High)":   "gemini-3.5-flash",
 	"Gemini 3.5 Flash (Medium)": "gemini-3.5-flash",
 	"Gemini 3.5 Flash (Low)":    "gemini-3.5-flash",
+	// Antigravity also routes OpenAI's open gpt-oss models; the reasoning-effort
+	// suffix ("-medium") rides on the base id. Resolve to the LiteLLM key for the
+	// 128k context window.
+	"gpt-oss-120b-medium": "openai.gpt-oss-120b-1:0",
 
 	// Warp — auto-router slugs plus the literal "GPT-5.3 Codex (… reasoning)"
 	// display strings Warp emits. codeburn maps the codex tier to


### PR DESCRIPTION
Fixes #719.

## Problem
Antigravity sessions never show the **context bar**. `ComputeContextUtilization` returns `pressure_level="unknown"` whenever `totalTokens == 0`, and the adapter emitted zero tokens: `transcript.jsonl` carries only the human display model name and no usage at all.

## Root cause
Tokens + the canonical model id live in a sibling per-conversation SQLite store, not the transcript:

- transcript: `~/.gemini/antigravity{,-cli}/brain/<conv-id>/.system_generated/logs/transcript.jsonl`
- store: `~/.gemini/antigravity{,-cli}/conversations/<conv-id>.db` — table `gen_metadata`, one protobuf blob per generation (highest `idx` = current context).

## Fix (kiro-cli sidecar pattern)
- **`dbmetrics.go`** (new) — on `turn_done`, opens the store read-only (WAL-aware, memoized by mtime/size) and decodes the latest `gen_metadata` blob with a dependency-free protobuf wire walker: `#1→#4→#5` = prompt/context tokens, `#1→#19` = canonical model id. A missing/unreadable store degrades to no-usage (pre-#719 behavior).
- **`parser.go`** — opt into `tailer.TranscriptPathAware` (`SetTranscriptPath`) and call `applyDBMetrics` on `turn_done`. The canonical id (e.g. `gemini-3.1-pro-low`) is written back to `p.model` so it stays capacity-resolvable between turns and the bar doesn't flicker off — the transcript's display form (`Gemini 3.1 Pro`) alone does not resolve.
- **`aliases.go`** — a real-data sweep (52 conversations) showed the store also emits `gemini-pro-default` (26), `gemini-3-flash-a` (14), and `gpt-oss-120b-medium` (10); added capacity aliases for those (gemini-3.x → 1M window, gpt-oss-120b → 128k).
- **`agent.go`** — permission `Touches`/`Detail` extended to consent-gate the new `.db` read.

## Verification
- Decoder validated against **real** on-disk stores: `16353 / gemini-3.1-pro-low` and `94240 / gemini-pro-default` → resolve to a `1048576` window → ~1.6% / ~9% "safe".
- New unit tests: protobuf decode, store-path derivation, a real temp-SQLite read (latest-idx + cache hit + graceful absence), and an end-to-end `turn_done` test (token + canonical-model enrichment, no-flicker, store-absent harmless).
- Full `go test ./core/... -race -count=1`, `tools/replay-fixtures.sh` (exit 0), and `of validate` (OK) all pass.

## Scope notes
- **Replay is a deliberate no-op** — recordings capture only the transcript, not the `.db`, so the antigravity `tokens_nonzero:false` goldens stay valid. Proof is the synthetic-store unit tests, not a re-record.
- Cost stays $0 (only `Tokens.Total` is set, no pricing contribution).
- 6/52 sampled conversations carry no canonical model id in the store and remain bar-less (transcript display form doesn't resolve) — a minor tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)