### PR TITLE
feat(macos): toggle to publish the daemon's sessions to a remote relay (#718)

### DIFF
--- a/core/adapters/outbound/relay/forwarder.go
+++ b/core/adapters/outbound/relay/forwarder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -14,6 +15,23 @@ import (
 )
 
 const forwardWriteTimeout = 10 * time.Second
+
+// helloAckTimeout bounds the wait for the relay's reply to our hello. The relay
+// answers immediately (a hello_ack on success, a CloseRevoked close on a bad
+// token), so this only guards against a hung or incompatible relay.
+const helloAckTimeout = 10 * time.Second
+
+// Publish link states reported by Status() and surfaced over the daemon's
+// /api/v1/relay/publish endpoint so the macOS app can show a publish-connection
+// indicator (issue #718). PublishAuthFailed is kept distinct from
+// PublishDisconnected so the app can tell "relay rejected the token" apart from
+// a transient network drop.
+const (
+	PublishConnecting   = "connecting"
+	PublishConnected    = "connected"
+	PublishAuthFailed   = "auth_failed"
+	PublishDisconnected = "disconnected"
+)
 
 // maxRelayFrameBytes caps a single inbound frame from the relay so a malicious
 // or buggy relay can't exhaust daemon memory. The daemon only reads hello_ack
@@ -67,6 +85,10 @@ type Forwarder struct {
 	dialer     *websocket.Dialer
 	minBackoff time.Duration
 	maxBackoff time.Duration
+
+	mu      sync.Mutex
+	state   string // one of the Publish* constants
+	lastErr string
 }
 
 // NewForwarder builds a Forwarder targeting relayURL. push and snapshot are
@@ -83,7 +105,40 @@ func NewForwarder(relayURL string, id Identity, token string, push outbound.Push
 		dialer:     websocket.DefaultDialer,
 		minBackoff: time.Second,
 		maxBackoff: 30 * time.Second,
+		// The forwarder is created only when publishing is enabled and Run()
+		// dials immediately, so "connecting" is the truthful initial state for a
+		// status read that races ahead of the first dial.
+		state: PublishConnecting,
 	}
+}
+
+// Status type for the daemon's publish-status endpoint.
+type Status struct {
+	URL         string `json:"url"`
+	State       string `json:"state"`
+	LastError   string `json:"lastError,omitempty"`
+	DaemonID    string `json:"daemonId"`
+	DaemonLabel string `json:"daemonLabel"`
+}
+
+// Status returns the forwarder's current link state for /api/v1/relay/publish.
+func (f *Forwarder) Status() Status {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return Status{
+		URL:         f.url,
+		State:       f.state,
+		LastError:   f.lastErr,
+		DaemonID:    f.identity.DaemonID,
+		DaemonLabel: f.identity.DaemonLabel,
+	}
+}
+
+func (f *Forwarder) setState(state, lastErr string) {
+	f.mu.Lock()
+	f.state = state
+	f.lastErr = lastErr
+	f.mu.Unlock()
 }
 
 // Run connects to the relay and forwards push events until ctx is cancelled.
@@ -101,8 +156,18 @@ func (f *Forwarder) Run(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		if err != nil {
+		// Classify the just-ended link for Status(): a CloseRevoked (4401) close
+		// — whether seen while reading the hello reply or mid-stream after a
+		// revoke — is auth_failed; anything else is a transient disconnect.
+		switch {
+		case websocket.IsCloseError(err, CloseRevoked):
+			f.setState(PublishAuthFailed, "relay rejected the token")
+			f.logError(fmt.Sprintf("relay link to %s rejected the token (auth failed)", f.url))
+		case err != nil:
+			f.setState(PublishDisconnected, err.Error())
 			f.logError(fmt.Sprintf("relay link to %s ended: %v", f.url, err))
+		default:
+			f.setState(PublishDisconnected, "")
 		}
 		if time.Since(start) > f.maxBackoff {
 			backoff = f.minBackoff
@@ -118,9 +183,11 @@ func (f *Forwarder) Run(ctx context.Context) {
 	}
 }
 
-// runOnce establishes one relay connection: hello → daemon_snapshot → forward
-// the push stream until the relay drops, ctx cancels, or a write fails.
+// runOnce establishes one relay connection: hello → (await hello_ack) →
+// daemon_snapshot → forward the push stream until the relay drops, ctx cancels,
+// or a write fails.
 func (f *Forwarder) runOnce(ctx context.Context) error {
+	f.setState(PublishConnecting, "")
 	conn, _, err := f.dialer.DialContext(ctx, f.url, nil)
 	if err != nil {
 		return err
@@ -138,6 +205,20 @@ func (f *Forwarder) runOnce(ctx context.Context) error {
 		return err
 	}
 
+	// Wait for the relay's reply before declaring the link up. The relay sends
+	// a hello_ack once it has accepted our token; an auth-enabled relay that
+	// rejects the token closes here with CloseRevoked (4401) instead. Reading
+	// this reply before sending the snapshot makes the auth verdict race-free:
+	// Run classifies a CloseRevoked close as auth_failed regardless of whether
+	// it arrives now or mid-stream. We don't act on the ack's contents (v1 has
+	// nothing to negotiate), only on whether the relay accepted us.
+	conn.SetReadLimit(maxRelayFrameBytes)
+	conn.SetReadDeadline(time.Now().Add(helloAckTimeout))
+	if _, _, err := conn.ReadMessage(); err != nil {
+		return err
+	}
+	conn.SetReadDeadline(time.Time{}) // clear; the read pump reads with no deadline
+
 	// Subscribe BEFORE capturing the snapshot. Otherwise a broadcast that
 	// fires between snapshotState() and Subscribe() is in neither the snapshot
 	// (captured earlier) nor the delta stream (subscribed later) and is lost
@@ -154,11 +235,11 @@ func (f *Forwarder) runOnce(ctx context.Context) error {
 	}); err != nil {
 		return err
 	}
+	f.setState(PublishConnected, "")
 	f.logInfo(fmt.Sprintf("connected to relay %s as %q (%s)", f.url, f.identity.DaemonLabel, f.identity.DaemonID))
 
-	// Read pump: surface the relay closing the socket (and drain any
-	// hello_ack / control frames, which v0 does not act on).
-	conn.SetReadLimit(maxRelayFrameBytes)
+	// Read pump: surface the relay closing the socket (and drain control
+	// frames / a mid-stream revoke close).
 	readErr := make(chan error, 1)
 	go func() {
 		for {

--- a/core/adapters/outbound/relay/forwarder_test.go
+++ b/core/adapters/outbound/relay/forwarder_test.go
@@ -51,6 +51,10 @@ func newTestRelay(t *testing.T) *testRelay {
 			return
 		}
 		tr.conns <- c
+		// Mirror the real relay: acknowledge the daemon's hello so the forwarder
+		// declares the link up and proceeds to send its snapshot. (The forwarder
+		// now waits for this reply before sending the snapshot.)
+		_ = c.WriteJSON(HelloAck{Type: MsgHelloAck, AcceptedVersion: ProtocolVersion})
 		for {
 			_, data, err := c.ReadMessage()
 			if err != nil {
@@ -238,6 +242,73 @@ func TestForwarderSendsToken(t *testing.T) {
 	if hello.Token != "s3cr3t-token" {
 		t.Fatalf("hello.Token = %q, want the configured token", hello.Token)
 	}
+}
+
+// waitForState polls f.Status() until it reaches want, failing the test if it
+// doesn't within a generous deadline.
+func waitForState(t *testing.T, f *Forwarder, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if f.Status().State == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	s := f.Status()
+	t.Fatalf("forwarder did not reach state %q (last state %q, lastError %q)", want, s.State, s.LastError)
+}
+
+// TestForwarderStatusConnected verifies the forwarder reports PublishConnected
+// once the relay has acked its hello and it has sent its snapshot, with the
+// identity carried through to Status().
+func TestForwarderStatusConnected(t *testing.T) {
+	tr := newTestRelay(t)
+	bc := newFakeBroadcaster()
+	snap := func() ([]*session.SessionState, []AgentInfo) { return nil, nil }
+	f := NewForwarder(tr.url, Identity{DaemonID: "d1", DaemonLabel: "lap"}, "", bc, snap, nil)
+	go f.Run(t.Context())
+
+	tr.next(t) // hello
+	tr.next(t) // daemon_snapshot — only sent after the ack was read
+
+	waitForState(t, f, PublishConnected)
+	if s := f.Status(); s.DaemonID != "d1" || s.DaemonLabel != "lap" || s.URL == "" || s.LastError != "" {
+		t.Fatalf("unexpected status: %+v", s)
+	}
+}
+
+// TestForwarderStatusAuthFailed verifies a relay that rejects the token with a
+// CloseRevoked (4401) close moves the forwarder to PublishAuthFailed — the
+// distinct state that lets the app show a "bad token" indicator rather than a
+// generic reconnecting one.
+func TestForwarderStatusAuthFailed(t *testing.T) {
+	up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		// Reject like an auth-enabled relay handed a bad/revoked token.
+		_ = c.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(CloseRevoked, "unauthorized"),
+			time.Now().Add(time.Second),
+		)
+		// Complete the close handshake so the forwarder reliably reads the close
+		// frame (and its 4401 code) before the TCP teardown.
+		_, _, _ = c.ReadMessage()
+		_ = c.Close()
+	}))
+	defer srv.Close()
+
+	bc := newFakeBroadcaster()
+	f := NewForwarder("ws"+strings.TrimPrefix(srv.URL, "http"), Identity{DaemonID: "d1"}, "bad-token", bc, nil, nil)
+	f.minBackoff = 10 * time.Millisecond
+	f.maxBackoff = 20 * time.Millisecond
+	go f.Run(t.Context())
+
+	waitForState(t, f, PublishAuthFailed)
 }
 
 // TestLoadDaemonToken covers env-var precedence and the tokens.json fallback.

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"irrlicht/core/adapters/outbound/httputil"
+	"irrlicht/core/adapters/outbound/relay"
 	"irrlicht/core/application/services"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
@@ -232,6 +233,37 @@ func handleGetAgents(allAgents []agent.Agent) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(entries)
+	}
+}
+
+// handleGetPublishStatus serves the daemon → relay forwarder's live link state
+// so the macOS app can show a publish-connection indicator (issue #718). The
+// forwarder runs only when publishing is enabled (IRRLICHT_RELAY_URL set); when
+// it is off, fwd is nil and the endpoint reports {"enabled":false}.
+func handleGetPublishStatus(fwd *relay.Forwarder) http.HandlerFunc {
+	type publishStatusResp struct {
+		Enabled     bool   `json:"enabled"`
+		URL         string `json:"url,omitempty"`
+		State       string `json:"state,omitempty"`
+		LastError   string `json:"lastError,omitempty"`
+		DaemonID    string `json:"daemonId,omitempty"`
+		DaemonLabel string `json:"daemonLabel,omitempty"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if fwd == nil {
+			json.NewEncoder(w).Encode(publishStatusResp{Enabled: false})
+			return
+		}
+		s := fwd.Status()
+		json.NewEncoder(w).Encode(publishStatusResp{
+			Enabled:     true,
+			URL:         s.URL,
+			State:       s.State,
+			LastError:   s.LastError,
+			DaemonID:    s.DaemonID,
+			DaemonLabel: s.DaemonLabel,
+		})
 	}
 }
 

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -182,6 +182,10 @@ func main() {
 	// session event out to a standalone irrlichtrelay, so remote clients see
 	// this daemon's sessions through the relay. Pushing out means the daemon
 	// needs no inbound reachability (works behind NAT). No-op when unset.
+	// publishForwarder is non-nil only while publishing is enabled; the
+	// /api/v1/relay/publish handler (registered after the mux is built) reports
+	// its live link state, or {"enabled":false} when this stays nil.
+	var publishForwarder *relay.Forwarder
 	if relayURL := os.Getenv("IRRLICHT_RELAY_URL"); relayURL != "" {
 		home, _ := os.UserHomeDir()
 		identity, err := relay.LoadOrCreateIdentity(dataDir(home))
@@ -208,6 +212,7 @@ func main() {
 			return sessions, infos
 		}
 		fwd := relay.NewForwarder(relayURL, identity, relayToken, push, snapshot, logger)
+		publishForwarder = fwd
 		relayCtx, relayCancel := context.WithCancel(context.Background())
 		defer relayCancel()
 		go fwd.Run(relayCtx)
@@ -267,6 +272,7 @@ func main() {
 	mux.HandleFunc("GET /api/v1/sessions/stream", hub.ServeWS)
 	mux.HandleFunc("GET /api/v1/agents", handleGetAgents(allAgents))
 	mux.HandleFunc("GET /api/v1/version", handleGetVersion(Version))
+	mux.HandleFunc("GET /api/v1/relay/publish", handleGetPublishStatus(publishForwarder))
 
 	// pprof debug endpoints for runtime profiling (localhost only).
 	mux.HandleFunc("GET /debug/pprof/", localhostOnly(pprof.Index))

--- a/core/cmd/irrlichd/publish_status_endpoint_test.go
+++ b/core/cmd/irrlichd/publish_status_endpoint_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"irrlicht/core/adapters/outbound/relay"
+)
+
+// publishStatusPayload mirrors the GET /api/v1/relay/publish response so tests
+// assert its shape independently of the handler's private struct.
+type publishStatusPayload struct {
+	Enabled     bool   `json:"enabled"`
+	URL         string `json:"url"`
+	State       string `json:"state"`
+	LastError   string `json:"lastError"`
+	DaemonID    string `json:"daemonId"`
+	DaemonLabel string `json:"daemonLabel"`
+}
+
+// TestPublishStatusEndpoint_Disabled: when publishing is off the forwarder is
+// nil and the endpoint reports enabled=false with no leaked fields.
+func TestPublishStatusEndpoint_Disabled(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/relay/publish", nil)
+	handleGetPublishStatus(nil)(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("content-type: got %q, want application/json", ct)
+	}
+	var payload publishStatusPayload
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal %q: %v", rr.Body.Bytes(), err)
+	}
+	if payload.Enabled {
+		t.Fatalf("nil forwarder must report enabled=false, got %+v", payload)
+	}
+	if payload.State != "" || payload.URL != "" {
+		t.Fatalf("disabled response must omit link fields, got %+v", payload)
+	}
+}
+
+// TestPublishStatusEndpoint_Enabled: with a forwarder present the endpoint
+// surfaces its live state and identity. A freshly-built forwarder reports
+// PublishConnecting before it has dialed.
+func TestPublishStatusEndpoint_Enabled(t *testing.T) {
+	fwd := relay.NewForwarder("wss://funken.io", relay.Identity{DaemonID: "d1", DaemonLabel: "lap"}, "", nil, nil, nil)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/relay/publish", nil)
+	handleGetPublishStatus(fwd)(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rr.Code)
+	}
+	var payload publishStatusPayload
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal %q: %v", rr.Body.Bytes(), err)
+	}
+	if !payload.Enabled {
+		t.Fatalf("forwarder present must report enabled=true, got %+v", payload)
+	}
+	if payload.State != relay.PublishConnecting {
+		t.Fatalf("state: got %q, want %q", payload.State, relay.PublishConnecting)
+	}
+	if payload.DaemonID != "d1" || payload.DaemonLabel != "lap" {
+		t.Fatalf("identity not surfaced: %+v", payload)
+	}
+	if payload.URL == "" {
+		t.Fatalf("url must be populated, got %+v", payload)
+	}
+}

--- a/platforms/macos/Irrlicht/Managers/DaemonManager.swift
+++ b/platforms/macos/Irrlicht/Managers/DaemonManager.swift
@@ -17,6 +17,102 @@ final class DaemonManager: ObservableObject {
 
     private let logger = Logger(subsystem: "io.irrlicht.app", category: "DaemonManager")
 
+    /// Last publish config the running daemon was launched with, so a settings
+    /// nudge relaunches only when the effective config actually changed.
+    private var lastPublishConfig = ""
+
+    // MARK: - Relay publish settings
+
+    /// Relay-publish settings (issue #718). URL + enabled flag live in
+    /// UserDefaults (shared with the relay *subscribe* direction); the token
+    /// lives in the Keychain — same store the subscribe path uses.
+    private var publishEnabled: Bool { UserDefaults.standard.bool(forKey: "publishToRelay") }
+    // Trimmed at the source so the change-detection signature and the launched
+    // env derive from identical values (buildDaemonEnv trims again defensively
+    // for its standalone callers/tests).
+    private var relayURL: String {
+        (UserDefaults.standard.string(forKey: "relayServerURL") ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    private var relayToken: String {
+        KeychainStore.get(account: "relayToken").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Signature of the publish-relevant settings. The token is reduced to a
+    /// hash so the plaintext secret isn't retained, while a token change still
+    /// shows up as a different signature.
+    private var publishConfigSignature: String {
+        let token = relayToken
+        return "\(publishEnabled)|\(relayURL)|\(token.isEmpty ? "none" : String(token.hashValue))"
+    }
+
+    /// Builds the daemon's launch environment from a base (the app's own
+    /// environment) plus the relay-publish settings. When publishing is on with
+    /// a non-empty URL it sets `IRRLICHT_RELAY_URL` (which activates the daemon's
+    /// outbound forwarder) and, when a token is present, `IRRLICHT_RELAY_TOKEN`.
+    /// When publishing is off it strips both, so a value inherited from the
+    /// app's own environment can't silently keep forwarding on. `bindAddr` is
+    /// always set so the daemon listens on the port the app connects to.
+    static func buildDaemonEnv(
+        base: [String: String],
+        bindAddr: String,
+        publishEnabled: Bool,
+        relayURL: String,
+        relayToken: String
+    ) -> [String: String] {
+        var env = base
+        env["IRRLICHT_BIND_ADDR"] = bindAddr
+        let url = relayURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        let token = relayToken.trimmingCharacters(in: .whitespacesAndNewlines)
+        if publishEnabled && !url.isEmpty {
+            env["IRRLICHT_RELAY_URL"] = url
+            if token.isEmpty {
+                env.removeValue(forKey: "IRRLICHT_RELAY_TOKEN")
+            } else {
+                env["IRRLICHT_RELAY_TOKEN"] = token
+            }
+        } else {
+            env.removeValue(forKey: "IRRLICHT_RELAY_URL")
+            env.removeValue(forKey: "IRRLICHT_RELAY_TOKEN")
+        }
+        return env
+    }
+
+    /// Called by Settings when a publish-relevant setting changes (the toggle,
+    /// the relay URL, or the Keychain token — the last fires no UserDefaults
+    /// notification, so Settings nudges us explicitly). Relaunches the embedded
+    /// daemon so its startup-wired forwarder picks up the new env, but only when
+    /// the effective config actually changed.
+    func publishSettingsDidChange() {
+        let sig = publishConfigSignature
+        guard sig != lastPublishConfig else { return }
+        lastPublishConfig = sig
+        relaunch()
+    }
+
+    /// Relaunches the embedded daemon to apply changed launch settings. Only a
+    /// daemon this app spawned is relaunched; an external or custom-port dev
+    /// daemon the app didn't start is left untouched (its env is owned wherever
+    /// it was launched). The crash-restart path is not triggered:
+    /// terminateProcess() clears `process`, and the terminationHandler restarts
+    /// only when the terminated process is still the current one.
+    private func relaunch() {
+        guard process != nil else {
+            logger.info("Publish settings changed but no app-owned daemon to relaunch")
+            return
+        }
+        logger.info("Relaunching embedded daemon to apply relay-publish settings")
+        terminateProcess()
+        healthTask?.cancel()
+        healthTask = Task { [weak self] in
+            // Brief grace so the listening socket frees before the new daemon binds.
+            try? await Task.sleep(nanoseconds: 700_000_000)
+            guard let self, !Task.isCancelled else { return }
+            self.restartCount = 0
+            self.spawnDaemon()
+        }
+    }
+
     // MARK: - Public
 
     func start() {
@@ -110,16 +206,25 @@ final class DaemonManager: ObservableObject {
         proc.standardOutput = FileHandle.nullDevice
         proc.standardError = FileHandle.nullDevice
         // Bind the same port the app connects to. Inherits the app's
-        // environment so IRRLICHT_HOME (if set for a dev instance) propagates.
-        var env = ProcessInfo.processInfo.environment
-        env["IRRLICHT_BIND_ADDR"] = "127.0.0.1:\(DaemonEndpoint.port)"
-        proc.environment = env
+        // environment so IRRLICHT_HOME (if set for a dev instance) propagates,
+        // then layers on the relay-publish env from Settings (issue #718).
+        proc.environment = Self.buildDaemonEnv(
+            base: ProcessInfo.processInfo.environment,
+            bindAddr: "127.0.0.1:\(DaemonEndpoint.port)",
+            publishEnabled: publishEnabled,
+            relayURL: relayURL,
+            relayToken: relayToken
+        )
 
         proc.terminationHandler = { [weak self] terminated in
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.daemonRunning = false
 
+                // An intentional stop or relaunch clears or replaces `process`
+                // before the handler runs, so treat this as a crash worth
+                // restarting only when the terminated process is still current.
+                guard self.process === terminated else { return }
                 // Only restart if we haven't been told to stop.
                 guard self.healthTask != nil, !Task.isCancelled else { return }
 
@@ -135,6 +240,9 @@ final class DaemonManager: ObservableObject {
             process = proc
             daemonRunning = true
             restartCount = 0
+            // Record the publish config this daemon launched with, so a later
+            // settings nudge relaunches only on an actual change.
+            lastPublishConfig = publishConfigSignature
             logger.info("Spawned embedded daemon (pid \(proc.processIdentifier))")
         } catch {
             logger.error("Failed to launch daemon: \(error.localizedDescription)")

--- a/platforms/macos/Irrlicht/Managers/PublishStatusMonitor.swift
+++ b/platforms/macos/Irrlicht/Managers/PublishStatusMonitor.swift
@@ -1,0 +1,103 @@
+import Foundation
+import SwiftUI
+
+/// Polls the local daemon's `GET /api/v1/relay/publish` endpoint so Settings can
+/// show whether this Mac's sessions are actually reaching the relay (issue
+/// #718). The forwarder lives inside `irrlichd`, so its true link state — most
+/// importantly an auth failure from a bad token — is only observable via this
+/// endpoint, not from anything the app holds locally.
+@MainActor
+final class PublishStatusMonitor: ObservableObject {
+    /// UI-facing publish link state. Mirrors the daemon's forwarder states plus
+    /// `off` (publishing disabled) and `unknown` (daemon unreachable / response
+    /// unparseable, e.g. during the brief relaunch gap).
+    enum State: Equatable {
+        case off
+        case connecting
+        case connected
+        case authFailed
+        case disconnected
+        case unknown
+
+        /// Maps the endpoint's `{enabled, state}` fields to a UI state. Pure, so
+        /// it is unit-tested without a live daemon.
+        static func from(enabled: Bool, state: String?) -> State {
+            guard enabled else { return .off }
+            switch state {
+            case "connected":    return .connected
+            case "connecting":   return .connecting
+            case "auth_failed":  return .authFailed
+            case "disconnected": return .disconnected
+            default:             return .unknown
+            }
+        }
+
+        var dotColor: Color {
+            switch self {
+            case .connected:              return .green
+            case .connecting:             return .yellow
+            case .authFailed:             return .red
+            case .disconnected, .unknown: return .yellow
+            case .off:                    return Color(.tertiaryLabelColor)
+            }
+        }
+
+        /// Compact one-word label for the "Publishing — …" status line.
+        var label: String {
+            switch self {
+            case .off:          return "off"
+            case .connecting:   return "connecting"
+            case .connected:    return "connected"
+            case .authFailed:   return "token rejected"
+            case .disconnected: return "disconnected"
+            case .unknown:      return "unknown"
+            }
+        }
+    }
+
+    @Published private(set) var state: State = .off
+
+    private var pollTask: Task<Void, Never>?
+    private let pollInterval: TimeInterval = 3
+
+    /// Begins polling (idempotent). Stop with `stop()` when Settings closes.
+    func start() {
+        guard pollTask == nil else { return }
+        let interval = pollInterval
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                await self.poll()
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+            }
+        }
+    }
+
+    func stop() {
+        pollTask?.cancel()
+        pollTask = nil
+        state = .off
+    }
+
+    private func poll() async {
+        guard let url = URL(string: "\(DaemonEndpoint.httpBase)/api/v1/relay/publish") else { return }
+        var req = URLRequest(url: url)
+        req.timeoutInterval = 2
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: req)
+            guard (resp as? HTTPURLResponse)?.statusCode == 200 else {
+                state = .unknown
+                return
+            }
+            let decoded = try JSONDecoder().decode(PublishStatusResponse.self, from: data)
+            state = State.from(enabled: decoded.enabled, state: decoded.state)
+        } catch {
+            state = .unknown
+        }
+    }
+}
+
+private struct PublishStatusResponse: Decodable {
+    let enabled: Bool
+    let state: String?
+}

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -204,6 +204,8 @@ class SessionManager: ObservableObject {
             // web dashboard's enableLocalSource / enableRelaySource / relayUrl).
             "useLocalDaemon": true,
             "useRelayServer": false,
+            // Publish direction (issue #718): off by default; shares relayServerURL.
+            "publishToRelay": false,
             "relayServerURL": "",
             // Context-fill alert threshold (#689): default 80% preserves the
             // historical first-alert point for existing users.

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     var onReviewPermissions: () -> Void = {}
     @EnvironmentObject var updateManager: UpdateManager
     @EnvironmentObject var sessionManager: SessionManager
+    @EnvironmentObject var daemonManager: DaemonManager
     @AppStorage("debugMode") private var debugMode: Bool = false
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
     @AppStorage("showQuotaForecast") private var showQuotaForecast: Bool = true
@@ -27,9 +28,15 @@ struct SettingsView: View {
     // Sources (multi-source): mirror the web dashboard's keys.
     @AppStorage("useLocalDaemon") private var useLocalDaemon: Bool = true
     @AppStorage("useRelayServer") private var useRelayServer: Bool = false
+    // Publish direction (issue #718): forward this Mac's sessions to the relay.
+    // Independent of useRelayServer (subscribe); both share relayServerURL + the
+    // Keychain token.
+    @AppStorage("publishToRelay") private var publishToRelay: Bool = false
     @AppStorage("relayServerURL") private var relayServerURL: String = ""
     @State private var relayURLDraft: String = ""
     @State private var relayURLDebounceTask: Task<Void, Never>? = nil
+    // Live publish-link state, polled from the daemon's /api/v1/relay/publish.
+    @StateObject private var publishStatus = PublishStatusMonitor()
     // Set just before a programmatic reconcile of taskEtaActivation so the
     // .onChange it triggers is swallowed instead of re-POSTing to the daemon.
     @State private var taskEtaReconciling = false
@@ -335,7 +342,15 @@ struct SettingsView: View {
                                     info: "Also connect to a relay to see sessions from other machines."
                                 )
 
-                                if useRelayServer {
+                                LeadingToggle(
+                                    isOn: $publishToRelay,
+                                    label: "Publish to relay",
+                                    info: "Forward this Mac's sessions to the relay so machines signed in with a token from the same account can see them. Keeps serving locally too."
+                                )
+
+                                // URL + token are shared by both directions: show
+                                // them whenever either subscribe or publish is on.
+                                if useRelayServer || publishToRelay {
                                     HStack(spacing: 6) {
                                         TextField("ws://localhost:7839", text: $relayURLDraft)
                                             .textFieldStyle(.roundedBorder)
@@ -347,12 +362,17 @@ struct SettingsView: View {
                                                     try? await Task.sleep(nanoseconds: 600_000_000)
                                                     guard !Task.isCancelled else { return }
                                                     relayServerURL = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                                                    // The daemon's forwarder is wired at startup, so a
+                                                    // URL change needs a relaunch to take effect.
+                                                    daemonManager.publishSettingsDidChange()
                                                 }
                                             }
-                                        Circle()
-                                            .fill(sessionManager.relayConnectionState.dotColor)
-                                            .frame(width: 8, height: 8)
-                                            .tooltip(sessionManager.relayConnectionState.shortLabel)
+                                        if useRelayServer {
+                                            Circle()
+                                                .fill(sessionManager.relayConnectionState.dotColor)
+                                                .frame(width: 8, height: 8)
+                                                .tooltip("Subscribe: \(sessionManager.relayConnectionState.shortLabel)")
+                                        }
                                     }
                                     SecureField("Relay token (leave empty if the relay has no auth)", text: $relayTokenDraft)
                                         .textFieldStyle(.roundedBorder)
@@ -361,20 +381,50 @@ struct SettingsView: View {
                                         .onChange(of: relayTokenDraft) { newValue in
                                             KeychainStore.set(newValue.trimmingCharacters(in: .whitespacesAndNewlines), account: "relayToken")
                                             // Keychain writes don't fire UserDefaults.didChangeNotification,
-                                            // so nudge the relay to reconnect with the new token.
+                                            // so nudge both directions to pick up the new token: the
+                                            // subscribe link reconnects, the daemon relaunches to republish.
                                             sessionManager.relayTokenDidChange()
+                                            daemonManager.publishSettingsDidChange()
                                         }
+
+                                    if publishToRelay {
+                                        HStack(spacing: 6) {
+                                            Circle()
+                                                .fill(publishStatus.state.dotColor)
+                                                .frame(width: 8, height: 8)
+                                            Text("Publishing — \(publishStatus.state.label)")
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                            Spacer()
+                                        }
+                                    }
+
+                                    Text("Publish and subscribe must use tokens from the same account to see each other's sessions.")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
                                 }
                             }
                             .onAppear {
                                 relayURLDraft = relayServerURL
                                 relayTokenDraft = KeychainStore.get(account: "relayToken")
+                                if publishToRelay { publishStatus.start() }
+                            }
+                            .onDisappear {
+                                publishStatus.stop()
                             }
                             .onChange(of: useRelayServer) { on in
                                 if on && relayURLDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                                     relayURLDraft = "ws://localhost:7839"
                                 }
                                 commitRelayURL()
+                            }
+                            .onChange(of: publishToRelay) { on in
+                                if on && relayURLDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                    relayURLDraft = "ws://localhost:7839"
+                                }
+                                commitRelayURL()
+                                daemonManager.publishSettingsDidChange()
+                                if on { publishStatus.start() } else { publishStatus.stop() }
                             }
 
                             CLIToolSection()

--- a/platforms/macos/Tests/DaemonManagerTests.swift
+++ b/platforms/macos/Tests/DaemonManagerTests.swift
@@ -38,6 +38,83 @@ final class DaemonManagerTests: XCTestCase {
         XCTAssertFalse(manager.daemonRunning)
     }
 
+    // MARK: - Relay-publish env wiring (issue #718)
+
+    func testBuildDaemonEnvPublishOnWithToken() {
+        let env = DaemonManager.buildDaemonEnv(
+            base: ["PATH": "/usr/bin"],
+            bindAddr: "127.0.0.1:7837",
+            publishEnabled: true,
+            relayURL: "wss://funken.io",
+            relayToken: "tok"
+        )
+        XCTAssertEqual(env["IRRLICHT_BIND_ADDR"], "127.0.0.1:7837")
+        XCTAssertEqual(env["IRRLICHT_RELAY_URL"], "wss://funken.io")
+        XCTAssertEqual(env["IRRLICHT_RELAY_TOKEN"], "tok")
+        XCTAssertEqual(env["PATH"], "/usr/bin", "base environment must be preserved")
+    }
+
+    func testBuildDaemonEnvPublishOnWithoutTokenStripsInheritedToken() {
+        // Publishing on, but no token configured: an inherited IRRLICHT_RELAY_TOKEN
+        // must not leak through (no-auth relay, or token cleared in Settings).
+        let env = DaemonManager.buildDaemonEnv(
+            base: ["IRRLICHT_RELAY_TOKEN": "stale"],
+            bindAddr: "127.0.0.1:7837",
+            publishEnabled: true,
+            relayURL: "wss://funken.io",
+            relayToken: ""
+        )
+        XCTAssertEqual(env["IRRLICHT_RELAY_URL"], "wss://funken.io")
+        XCTAssertNil(env["IRRLICHT_RELAY_TOKEN"])
+    }
+
+    func testBuildDaemonEnvPublishOffStripsInheritedVars() {
+        // Toggling publish off must truly stop forwarding even if the app was
+        // launched with the relay vars already set in its environment.
+        let env = DaemonManager.buildDaemonEnv(
+            base: ["IRRLICHT_RELAY_URL": "wss://stale", "IRRLICHT_RELAY_TOKEN": "stale"],
+            bindAddr: "127.0.0.1:7837",
+            publishEnabled: false,
+            relayURL: "wss://funken.io",
+            relayToken: "tok"
+        )
+        XCTAssertNil(env["IRRLICHT_RELAY_URL"])
+        XCTAssertNil(env["IRRLICHT_RELAY_TOKEN"])
+        XCTAssertEqual(env["IRRLICHT_BIND_ADDR"], "127.0.0.1:7837")
+    }
+
+    func testBuildDaemonEnvEmptyURLActsAsOff() {
+        let env = DaemonManager.buildDaemonEnv(
+            base: [:],
+            bindAddr: "127.0.0.1:7837",
+            publishEnabled: true,
+            relayURL: "   ",
+            relayToken: "tok"
+        )
+        XCTAssertNil(env["IRRLICHT_RELAY_URL"], "enabled with a blank URL must not activate the forwarder")
+        XCTAssertNil(env["IRRLICHT_RELAY_TOKEN"])
+    }
+
+    func testBuildDaemonEnvTrimsURLAndToken() {
+        let env = DaemonManager.buildDaemonEnv(
+            base: [:],
+            bindAddr: "127.0.0.1:7837",
+            publishEnabled: true,
+            relayURL: "  wss://funken.io  ",
+            relayToken: "  tok  "
+        )
+        XCTAssertEqual(env["IRRLICHT_RELAY_URL"], "wss://funken.io")
+        XCTAssertEqual(env["IRRLICHT_RELAY_TOKEN"], "tok")
+    }
+
+    func testPublishSettingsDidChangeIsSafeWithoutOwnedDaemon() {
+        // Under xctest there's no daemon binary, so no app-owned process: the
+        // relaunch path must be a safe no-op (and idempotent), never a crash.
+        manager.publishSettingsDidChange()
+        manager.publishSettingsDidChange()
+        XCTAssertFalse(manager.daemonRunning)
+    }
+
     // MARK: - Bundle Path Tests
 
     func testBundledDaemonURLNilInTestHost() {

--- a/platforms/macos/Tests/PublishStatusMonitorTests.swift
+++ b/platforms/macos/Tests/PublishStatusMonitorTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+import SwiftUI
+@testable import Irrlicht
+
+@MainActor
+final class PublishStatusMonitorTests: XCTestCase {
+
+    func testStateMappingFromEndpointFields() {
+        typealias S = PublishStatusMonitor.State
+        // enabled=false always reads as off, regardless of the reported state.
+        XCTAssertEqual(S.from(enabled: false, state: "connected"), .off)
+        XCTAssertEqual(S.from(enabled: false, state: nil), .off)
+        // enabled=true maps the daemon's forwarder states 1:1.
+        XCTAssertEqual(S.from(enabled: true, state: "connected"), .connected)
+        XCTAssertEqual(S.from(enabled: true, state: "connecting"), .connecting)
+        XCTAssertEqual(S.from(enabled: true, state: "auth_failed"), .authFailed)
+        XCTAssertEqual(S.from(enabled: true, state: "disconnected"), .disconnected)
+        // An unrecognized or missing state is surfaced as unknown, not a crash.
+        XCTAssertEqual(S.from(enabled: true, state: "weird"), .unknown)
+        XCTAssertEqual(S.from(enabled: true, state: nil), .unknown)
+    }
+
+    func testAuthFailedIsVisuallyDistinct() {
+        // The whole point of the daemon endpoint: surface a bad token as red.
+        XCTAssertEqual(PublishStatusMonitor.State.authFailed.dotColor, .red)
+        XCTAssertEqual(PublishStatusMonitor.State.connected.dotColor, .green)
+    }
+
+    func testLabels() {
+        XCTAssertEqual(PublishStatusMonitor.State.off.label, "off")
+        XCTAssertEqual(PublishStatusMonitor.State.connected.label, "connected")
+        XCTAssertEqual(PublishStatusMonitor.State.authFailed.label, "token rejected")
+    }
+}

--- a/platforms/macos/Tests/SettingsViewTests.swift
+++ b/platforms/macos/Tests/SettingsViewTests.swift
@@ -15,12 +15,13 @@ final class SettingsViewTests: XCTestCase {
     // samples the four corners + center of the resulting bitmap, and asserts
     // every sampled pixel is fully opaque.
     func testSettingsViewBackgroundIsOpaque() throws {
-        // SettingsView requires both environment objects (crashes without
+        // SettingsView requires its environment objects (crashes without
         // them). startingUpdater: false keeps Sparkle from starting its
         // update cycle, which would fail outside an app bundle.
         let view = SettingsView(isPresented: .constant(true))
             .environmentObject(UpdateManager(startingUpdater: false))
             .environmentObject(SessionManager())
+            .environmentObject(DaemonManager())
         let hosting = NSHostingView(rootView: view)
         // Pin to dark aqua so NSColor.windowBackgroundColor resolves
         // deterministically — the test verifies opacity, not hue, but


### PR DESCRIPTION
## Summary

Implements #718 — the last piece to operate Irrlicht against **funken.io**: a macOS toggle that makes the local daemon **publish** its sessions to a hosted relay, in addition to serving them locally. Most of the machinery (the daemon's outbound forwarder, token loading, the app's relay-subscribe path) already existed; this is the wiring + UX that activates it from the app, plus a daemon endpoint so the app can show real link state.

## What changed

**Daemon (`scope:daemon`)**
- New `GET /api/v1/relay/publish` exposing the forwarder's live link state (`{enabled,url,state,lastError,daemonId,daemonLabel}`), or `{"enabled":false}` when publishing is off.
- The forwarder now reads the relay's `hello_ack` before declaring `connected`, so a `CloseRevoked` (4401) token rejection is classified as `auth_failed` race-free rather than a generic drop.

**macOS app (`scope:macos`)**
- New **"Publish to relay"** toggle in Settings → Advanced → Sources, independent of the existing "Relay server" (subscribe) toggle; both share the relay URL (UserDefaults) + token (Keychain).
- `DaemonManager.buildDaemonEnv` layers `IRRLICHT_RELAY_URL`/`IRRLICHT_RELAY_TOKEN` onto the daemon launch and **strips** them when publish is off; `publishSettingsDidChange()` relaunches the app-owned daemon on change. A `process === terminated` guard prevents an intentional relaunch from being misread as a crash-restart.
- `PublishStatusMonitor` polls the new endpoint for a status dot (red on token rejection).
- Same-account help text so users don't pair mismatched tokens.

No relay-side or funken-side changes — the publish endpoint, multi-tenancy, and token issuance already support the full loop.

## Testing

- `go test ./core/... -race -count=1` ✓ (incl. new forwarder status + handler tests)
- `swift test` (platforms/macos) ✓ (incl. `buildDaemonEnv`, `PublishStatusMonitor`, SettingsView opacity regression)
- End-to-end against an **auth-enabled** relay (`irrlichtrelay --auth`): valid token → `connected`; same-account bearer → 200, wrong → 401; bad token → `auth_failed`
- **Live run against funken.io**: daemon authenticated, sessions published, status dot connected

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)
