### PR TITLE
feat(relay): hot-reload the publish forwarder without a daemon relaunch (#722)

### DIFF
--- a/core/adapters/outbound/relay/controller.go
+++ b/core/adapters/outbound/relay/controller.go
@@ -1,0 +1,112 @@
+package relay
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"irrlicht/core/ports/outbound"
+)
+
+// PublishController owns the relay forwarder's lifecycle so publishing can be
+// turned on, off, or reconfigured on a running daemon without a relaunch
+// (issue #722). The macOS app drives it over the daemon's loopback
+// PUT /api/v1/relay/publish; a headless/standalone daemon seeds it once from
+// IRRLICHT_RELAY_URL / IRRLICHT_RELAY_TOKEN at startup (Apply below), so its
+// behavior is unchanged from the env-only path that preceded this.
+//
+// At most one Forwarder runs at a time. Reconfiguring cancels the current
+// forwarder's context and starts a fresh one — the forwarder is already
+// ctx-cancelable, so this reuses its existing shutdown path.
+type PublishController struct {
+	parentCtx context.Context
+	identity  Identity
+	push      outbound.PushBroadcaster
+	snapshot  SnapshotFunc
+	logger    outbound.Logger
+
+	mu     sync.Mutex
+	fwd    *Forwarder         // non-nil only while publishing is enabled
+	cancel context.CancelFunc // cancels fwd's Run; nil when stopped
+	url    string             // last applied (trimmed) url, for idempotency
+	token  string             // last applied (trimmed) token, for idempotency
+}
+
+// NewPublishController builds a controller in the stopped state. parentCtx
+// bounds every forwarder it starts, so cancelling it (on daemon shutdown)
+// stops publishing. identity, push, and snapshot are the forwarder
+// dependencies that never change across reconfigures; logger may be nil.
+func NewPublishController(parentCtx context.Context, id Identity, push outbound.PushBroadcaster, snapshot SnapshotFunc, logger outbound.Logger) *PublishController {
+	return &PublishController{
+		parentCtx: parentCtx,
+		identity:  id,
+		push:      push,
+		snapshot:  snapshot,
+		logger:    logger,
+	}
+}
+
+// Apply reconciles the running forwarder to the requested publish config.
+// enabled with a non-empty url starts (or reconfigures) the forwarder; either
+// flag falsy stops it. It is idempotent: re-applying the config already in
+// effect is a no-op, so the macOS app can POST on every settings nudge without
+// churning the relay link. Mutex-guarded so concurrent PUTs serialize.
+func (c *PublishController) Apply(enabled bool, url, token string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	url = strings.TrimSpace(url)
+	token = strings.TrimSpace(token)
+	// A blank URL means "off" even when the toggle is on — mirrors the macOS
+	// env builder's old semantics so an empty URL never activates a forwarder.
+	wantOn := enabled && url != ""
+
+	if !wantOn {
+		if c.fwd == nil {
+			return // already stopped — nothing to do
+		}
+		c.cancel()
+		c.cancel = nil
+		c.fwd = nil
+		c.logInfo("relay publishing stopped")
+		return
+	}
+
+	// Running with the same effective config — leave the link untouched.
+	if c.fwd != nil && c.url == url && c.token == token {
+		return
+	}
+
+	// Start fresh: stop any existing forwarder first so only one link runs.
+	if c.cancel != nil {
+		c.cancel()
+	}
+	fwd := NewForwarder(url, c.identity, token, c.push, c.snapshot, c.logger)
+	ctx, cancel := context.WithCancel(c.parentCtx)
+	c.fwd = fwd
+	c.cancel = cancel
+	c.url = url
+	c.token = token
+	go fwd.Run(ctx)
+	c.logInfo(fmt.Sprintf("relay publishing → %s (daemon %q / %s)", fwd.Status().URL, c.identity.DaemonLabel, c.identity.DaemonID))
+}
+
+// Status reports whether publishing is enabled and, when it is, the live link
+// state of the running forwarder. When stopped it returns (false, zero Status)
+// so the endpoint renders {"enabled":false}.
+func (c *PublishController) Status() (enabled bool, status Status) {
+	c.mu.Lock()
+	fwd := c.fwd
+	c.mu.Unlock()
+	if fwd == nil {
+		return false, Status{}
+	}
+	return true, fwd.Status()
+}
+
+func (c *PublishController) logInfo(msg string) {
+	if c.logger != nil {
+		c.logger.LogInfo("relay-publish", "", msg)
+	}
+}

--- a/core/adapters/outbound/relay/controller_test.go
+++ b/core/adapters/outbound/relay/controller_test.go
@@ -1,0 +1,102 @@
+package relay
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// waitForControllerState polls the controller's reported link state until it
+// reaches want, failing the test if it doesn't within a generous deadline.
+func waitForControllerState(t *testing.T, c *PublishController, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if enabled, st := c.Status(); enabled && st.State == want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	_, st := c.Status()
+	t.Fatalf("controller did not reach state %q (last state %q, lastError %q)", want, st.State, st.LastError)
+}
+
+// TestPublishControllerStartStop verifies Apply(true) starts a forwarder that
+// connects, and Apply(false) stops it so Status() reports disabled again.
+func TestPublishControllerStartStop(t *testing.T) {
+	tr := newTestRelay(t)
+	bc := newFakeBroadcaster()
+	snap := func() ([]*session.SessionState, []AgentInfo) { return nil, nil }
+	c := NewPublishController(t.Context(), Identity{DaemonID: "d1", DaemonLabel: "lap"}, bc, snap, nil)
+
+	if enabled, _ := c.Status(); enabled {
+		t.Fatal("a fresh controller must report disabled")
+	}
+
+	c.Apply(true, tr.url, "")
+	waitForControllerState(t, c, PublishConnected)
+
+	c.Apply(false, tr.url, "")
+	if enabled, _ := c.Status(); enabled {
+		t.Fatal("Apply(false) must stop publishing")
+	}
+}
+
+// TestPublishControllerIdempotent verifies re-applying the config already in
+// effect keeps the same forwarder instance — no needless relay reconnect.
+func TestPublishControllerIdempotent(t *testing.T) {
+	tr := newTestRelay(t)
+	bc := newFakeBroadcaster()
+	snap := func() ([]*session.SessionState, []AgentInfo) { return nil, nil }
+	c := NewPublishController(t.Context(), Identity{DaemonID: "d1"}, bc, snap, nil)
+
+	c.Apply(true, tr.url, "tok")
+	c.mu.Lock()
+	first := c.fwd
+	c.mu.Unlock()
+
+	c.Apply(true, tr.url, "tok")
+	c.mu.Lock()
+	second := c.fwd
+	c.mu.Unlock()
+
+	if first == nil || first != second {
+		t.Fatalf("re-applying the same config must not restart the forwarder (first=%p second=%p)", first, second)
+	}
+}
+
+// TestPublishControllerReconfigure verifies changing the URL tears down the old
+// link and connects to the new relay without a daemon relaunch.
+func TestPublishControllerReconfigure(t *testing.T) {
+	tr1 := newTestRelay(t)
+	tr2 := newTestRelay(t)
+	bc := newFakeBroadcaster()
+	snap := func() ([]*session.SessionState, []AgentInfo) { return nil, nil }
+	c := NewPublishController(t.Context(), Identity{DaemonID: "d1"}, bc, snap, nil)
+
+	c.Apply(true, tr1.url, "")
+	select {
+	case <-tr1.conns:
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwarder did not connect to the first relay")
+	}
+
+	c.Apply(true, tr2.url, "")
+	select {
+	case <-tr2.conns:
+	case <-time.After(2 * time.Second):
+		t.Fatal("forwarder did not connect to the new relay after reconfigure")
+	}
+}
+
+// TestPublishControllerEmptyURLActsAsOff verifies enabled=true with a blank URL
+// does not start a forwarder (mirrors the macOS env builder's old semantics).
+func TestPublishControllerEmptyURLActsAsOff(t *testing.T) {
+	bc := newFakeBroadcaster()
+	c := NewPublishController(t.Context(), Identity{DaemonID: "d1"}, bc, nil, nil)
+	c.Apply(true, "   ", "tok")
+	if enabled, _ := c.Status(); enabled {
+		t.Fatal("enabled with a blank URL must not activate publishing")
+	}
+}

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -236,34 +236,66 @@ func handleGetAgents(allAgents []agent.Agent) http.HandlerFunc {
 	}
 }
 
+// publishStatusResp is the shared shape of the GET and PUT
+// /api/v1/relay/publish responses: {"enabled":false} when publishing is off,
+// otherwise the forwarder's live link state.
+type publishStatusResp struct {
+	Enabled     bool   `json:"enabled"`
+	URL         string `json:"url,omitempty"`
+	State       string `json:"state,omitempty"`
+	LastError   string `json:"lastError,omitempty"`
+	DaemonID    string `json:"daemonId,omitempty"`
+	DaemonLabel string `json:"daemonLabel,omitempty"`
+}
+
+// writePublishStatus encodes the controller's current publish state as JSON.
+func writePublishStatus(w http.ResponseWriter, controller *relay.PublishController) {
+	w.Header().Set("Content-Type", "application/json")
+	enabled, s := controller.Status()
+	if !enabled {
+		json.NewEncoder(w).Encode(publishStatusResp{Enabled: false})
+		return
+	}
+	json.NewEncoder(w).Encode(publishStatusResp{
+		Enabled:     true,
+		URL:         s.URL,
+		State:       s.State,
+		LastError:   s.LastError,
+		DaemonID:    s.DaemonID,
+		DaemonLabel: s.DaemonLabel,
+	})
+}
+
 // handleGetPublishStatus serves the daemon → relay forwarder's live link state
 // so the macOS app can show a publish-connection indicator (issue #718). The
-// forwarder runs only when publishing is enabled (IRRLICHT_RELAY_URL set); when
-// it is off, fwd is nil and the endpoint reports {"enabled":false}.
-func handleGetPublishStatus(fwd *relay.Forwarder) http.HandlerFunc {
-	type publishStatusResp struct {
-		Enabled     bool   `json:"enabled"`
-		URL         string `json:"url,omitempty"`
-		State       string `json:"state,omitempty"`
-		LastError   string `json:"lastError,omitempty"`
-		DaemonID    string `json:"daemonId,omitempty"`
-		DaemonLabel string `json:"daemonLabel,omitempty"`
+// forwarder runs only while publishing is enabled; when it is off the controller
+// reports {"enabled":false}.
+func handleGetPublishStatus(controller *relay.PublishController) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writePublishStatus(w, controller)
+	}
+}
+
+// handlePutPublishStatus reconfigures publishing on the running daemon (issue
+// #722): the macOS app PUTs {enabled,url,token} when its publish settings change
+// instead of relaunching the daemon. Apply is idempotent, so the app can POST on
+// every nudge. Responds with the resulting status (same shape as GET) so the
+// caller sees the effect immediately. Registered loopback-only in main.go — it
+// mutates forwarder config and carries the relay token in its body.
+func handlePutPublishStatus(controller *relay.PublishController) http.HandlerFunc {
+	type publishConfigReq struct {
+		Enabled bool   `json:"enabled"`
+		URL     string `json:"url"`
+		Token   string `json:"token"`
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if fwd == nil {
-			json.NewEncoder(w).Encode(publishStatusResp{Enabled: false})
+		var req publishConfigReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid JSON body", http.StatusBadRequest)
 			return
 		}
-		s := fwd.Status()
-		json.NewEncoder(w).Encode(publishStatusResp{
-			Enabled:     true,
-			URL:         s.URL,
-			State:       s.State,
-			LastError:   s.LastError,
-			DaemonID:    s.DaemonID,
-			DaemonLabel: s.DaemonLabel,
-		})
+		controller.Apply(req.Enabled, req.URL, req.Token)
+		writePublishStatus(w, controller)
 	}
 }
 

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -177,46 +177,45 @@ func main() {
 	// during replay without duplicating the construction.
 	allAgents := agents.All()
 
-	// Outbound relay forwarder (opt-in via IRRLICHT_RELAY_URL): subscribe to
-	// the same push broadcaster the local WebSocket uses and push every
-	// session event out to a standalone irrlichtrelay, so remote clients see
-	// this daemon's sessions through the relay. Pushing out means the daemon
-	// needs no inbound reachability (works behind NAT). No-op when unset.
-	// publishForwarder is non-nil only while publishing is enabled; the
-	// /api/v1/relay/publish handler (registered after the mux is built) reports
-	// its live link state, or {"enabled":false} when this stays nil.
-	var publishForwarder *relay.Forwarder
-	if relayURL := os.Getenv("IRRLICHT_RELAY_URL"); relayURL != "" {
-		home, _ := os.UserHomeDir()
-		identity, err := relay.LoadOrCreateIdentity(dataDir(home))
+	// Outbound relay publishing: subscribe to the same push broadcaster the
+	// local WebSocket uses and push every session event out to a standalone
+	// irrlichtrelay, so remote clients see this daemon's sessions through the
+	// relay. Pushing out means the daemon needs no inbound reachability (works
+	// behind NAT). The PublishController owns the forwarder's lifecycle so the
+	// macOS app can start/stop/reconfigure publishing live over the loopback
+	// PUT /api/v1/relay/publish — no daemon relaunch (issue #722). The
+	// controller is always constructed (so the endpoint can turn publishing on
+	// later); it is seeded once below from IRRLICHT_RELAY_URL /
+	// IRRLICHT_RELAY_TOKEN so headless/standalone daemons keep working as before.
+	relayBaseCtx, relayBaseCancel := context.WithCancel(context.Background())
+	defer relayBaseCancel()
+	relayHome, _ := os.UserHomeDir()
+	relayIdentity, err := relay.LoadOrCreateIdentity(dataDir(relayHome))
+	if err != nil {
+		logger.LogError("startup", "", fmt.Sprintf("relay identity persistence failed (using ephemeral id): %v", err))
+	}
+	relaySnapshot := func() ([]*session.SessionState, []relay.AgentInfo) {
+		sessions, err := cachedRepo.ListAll()
 		if err != nil {
-			logger.LogError("startup", "", fmt.Sprintf("relay identity persistence failed (using ephemeral id): %v", err))
+			sessions = nil
 		}
-		// Bearer token for an auth-enabled relay: IRRLICHT_RELAY_TOKEN or
-		// <dataDir>/relay-token.json (mode 0600). Empty against a no-auth relay.
-		relayToken := relay.LoadDaemonToken(dataDir(home))
-		snapshot := func() ([]*session.SessionState, []relay.AgentInfo) {
-			sessions, err := cachedRepo.ListAll()
-			if err != nil {
-				sessions = nil
-			}
-			infos := make([]relay.AgentInfo, 0, len(allAgents))
-			for _, a := range allAgents {
-				infos = append(infos, relay.AgentInfo{
-					Name:         a.Identity.Name,
-					DisplayName:  a.Identity.DisplayName,
-					IconSVGLight: a.Identity.IconSVGLight,
-					IconSVGDark:  a.Identity.IconSVGDark,
-				})
-			}
-			return sessions, infos
+		infos := make([]relay.AgentInfo, 0, len(allAgents))
+		for _, a := range allAgents {
+			infos = append(infos, relay.AgentInfo{
+				Name:         a.Identity.Name,
+				DisplayName:  a.Identity.DisplayName,
+				IconSVGLight: a.Identity.IconSVGLight,
+				IconSVGDark:  a.Identity.IconSVGDark,
+			})
 		}
-		fwd := relay.NewForwarder(relayURL, identity, relayToken, push, snapshot, logger)
-		publishForwarder = fwd
-		relayCtx, relayCancel := context.WithCancel(context.Background())
-		defer relayCancel()
-		go fwd.Run(relayCtx)
-		logger.LogInfo("startup", "", fmt.Sprintf("relay forwarder enabled → %s (daemon %q / %s)", relayURL, identity.DaemonLabel, identity.DaemonID))
+		return sessions, infos
+	}
+	publishController := relay.NewPublishController(relayBaseCtx, relayIdentity, push, relaySnapshot, logger)
+	// Seed from the env opt-in (backward compatible with the pre-#722 path).
+	// Bearer token for an auth-enabled relay: IRRLICHT_RELAY_TOKEN or
+	// <dataDir>/relay-token.json (mode 0600). Empty against a no-auth relay.
+	if relayURL := os.Getenv("IRRLICHT_RELAY_URL"); relayURL != "" {
+		publishController.Apply(true, relayURL, relay.LoadDaemonToken(dataDir(relayHome)))
 	}
 
 	// Shared adapters for SessionDetector.
@@ -272,7 +271,10 @@ func main() {
 	mux.HandleFunc("GET /api/v1/sessions/stream", hub.ServeWS)
 	mux.HandleFunc("GET /api/v1/agents", handleGetAgents(allAgents))
 	mux.HandleFunc("GET /api/v1/version", handleGetVersion(Version))
-	mux.HandleFunc("GET /api/v1/relay/publish", handleGetPublishStatus(publishForwarder))
+	mux.HandleFunc("GET /api/v1/relay/publish", handleGetPublishStatus(publishController))
+	// PUT reconfigures publishing on the running daemon (issue #722). Loopback
+	// only: it mutates forwarder config and carries the relay token in its body.
+	mux.HandleFunc("PUT /api/v1/relay/publish", localhostOnly(handlePutPublishStatus(publishController)))
 
 	// pprof debug endpoints for runtime profiling (localhost only).
 	mux.HandleFunc("GET /debug/pprof/", localhostOnly(pprof.Index))

--- a/core/cmd/irrlichd/publish_status_endpoint_test.go
+++ b/core/cmd/irrlichd/publish_status_endpoint_test.go
@@ -8,10 +8,12 @@ import (
 	"testing"
 
 	"irrlicht/core/adapters/outbound/relay"
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/session"
 )
 
-// publishStatusPayload mirrors the GET /api/v1/relay/publish response so tests
-// assert its shape independently of the handler's private struct.
+// publishStatusPayload mirrors the GET/PUT /api/v1/relay/publish response so
+// tests assert its shape independently of the handler's private struct.
 type publishStatusPayload struct {
 	Enabled     bool   `json:"enabled"`
 	URL         string `json:"url"`
@@ -21,12 +23,25 @@ type publishStatusPayload struct {
 	DaemonLabel string `json:"daemonLabel"`
 }
 
-// TestPublishStatusEndpoint_Disabled: when publishing is off the forwarder is
-// nil and the endpoint reports enabled=false with no leaked fields.
+// newTestController builds a controller bound to the test's context so any
+// forwarder it starts is torn down at cleanup (no lingering dial goroutines).
+func newTestController(t *testing.T) *relay.PublishController {
+	t.Helper()
+	return relay.NewPublishController(
+		t.Context(),
+		relay.Identity{DaemonID: "d1", DaemonLabel: "lap"},
+		services.NewPushService(),
+		func() ([]*session.SessionState, []relay.AgentInfo) { return nil, nil },
+		nil,
+	)
+}
+
+// TestPublishStatusEndpoint_Disabled: when publishing is off the controller has
+// no forwarder and the endpoint reports enabled=false with no leaked fields.
 func TestPublishStatusEndpoint_Disabled(t *testing.T) {
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/relay/publish", nil)
-	handleGetPublishStatus(nil)(rr, req)
+	handleGetPublishStatus(newTestController(t))(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200", rr.Code)
@@ -39,22 +54,25 @@ func TestPublishStatusEndpoint_Disabled(t *testing.T) {
 		t.Fatalf("unmarshal %q: %v", rr.Body.Bytes(), err)
 	}
 	if payload.Enabled {
-		t.Fatalf("nil forwarder must report enabled=false, got %+v", payload)
+		t.Fatalf("no forwarder must report enabled=false, got %+v", payload)
 	}
 	if payload.State != "" || payload.URL != "" {
 		t.Fatalf("disabled response must omit link fields, got %+v", payload)
 	}
 }
 
-// TestPublishStatusEndpoint_Enabled: with a forwarder present the endpoint
-// surfaces its live state and identity. A freshly-built forwarder reports
-// PublishConnecting before it has dialed.
+// TestPublishStatusEndpoint_Enabled: once publishing is enabled the endpoint
+// surfaces the forwarder's URL and identity. State is some live link state — we
+// don't assert which, since the forwarder is dialing concurrently.
 func TestPublishStatusEndpoint_Enabled(t *testing.T) {
-	fwd := relay.NewForwarder("wss://funken.io", relay.Identity{DaemonID: "d1", DaemonLabel: "lap"}, "", nil, nil, nil)
+	c := newTestController(t)
+	// 127.0.0.1:1 refuses fast, so no real relay is needed and the dial loop
+	// stays local; the test context cancels it at cleanup.
+	c.Apply(true, "ws://127.0.0.1:1", "")
 
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/relay/publish", nil)
-	handleGetPublishStatus(fwd)(rr, req)
+	handleGetPublishStatus(c)(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200", rr.Code)
@@ -64,15 +82,56 @@ func TestPublishStatusEndpoint_Enabled(t *testing.T) {
 		t.Fatalf("unmarshal %q: %v", rr.Body.Bytes(), err)
 	}
 	if !payload.Enabled {
-		t.Fatalf("forwarder present must report enabled=true, got %+v", payload)
-	}
-	if payload.State != relay.PublishConnecting {
-		t.Fatalf("state: got %q, want %q", payload.State, relay.PublishConnecting)
+		t.Fatalf("enabled publishing must report enabled=true, got %+v", payload)
 	}
 	if payload.DaemonID != "d1" || payload.DaemonLabel != "lap" {
 		t.Fatalf("identity not surfaced: %+v", payload)
 	}
 	if payload.URL == "" {
 		t.Fatalf("url must be populated, got %+v", payload)
+	}
+}
+
+// TestPublishStatusEndpoint_PutTogglesPublishing: a PUT enabling then disabling
+// publishing flips the reported status, proving the hot-reload path (issue #722)
+// works end-to-end through the HTTP layer with no daemon relaunch.
+func TestPublishStatusEndpoint_PutTogglesPublishing(t *testing.T) {
+	c := newTestController(t)
+	handler := handlePutPublishStatus(c)
+
+	put := func(body string) publishStatusPayload {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/relay/publish", strings.NewReader(body))
+		handler(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("PUT %s: status got %d, want 200", body, rr.Code)
+		}
+		var p publishStatusPayload
+		if err := json.Unmarshal(rr.Body.Bytes(), &p); err != nil {
+			t.Fatalf("unmarshal %q: %v", rr.Body.Bytes(), err)
+		}
+		return p
+	}
+
+	on := put(`{"enabled":true,"url":"ws://127.0.0.1:1","token":""}`)
+	if !on.Enabled || on.URL == "" {
+		t.Fatalf("PUT enabled=true must turn publishing on, got %+v", on)
+	}
+
+	off := put(`{"enabled":false,"url":"ws://127.0.0.1:1","token":""}`)
+	if off.Enabled || off.URL != "" {
+		t.Fatalf("PUT enabled=false must turn publishing off, got %+v", off)
+	}
+}
+
+// TestPublishStatusEndpoint_PutRejectsBadBody: a malformed body is a 400, not a
+// silent no-op that the caller mistakes for success.
+func TestPublishStatusEndpoint_PutRejectsBadBody(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/relay/publish", strings.NewReader("not json"))
+	handlePutPublishStatus(newTestController(t))(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("malformed body: status got %d, want 400", rr.Code)
 	}
 }

--- a/platforms/macos/Irrlicht/Managers/DaemonManager.swift
+++ b/platforms/macos/Irrlicht/Managers/DaemonManager.swift
@@ -12,14 +12,18 @@ final class DaemonManager: ObservableObject {
 
     private var process: Process?
     private var healthTask: Task<Void, Never>?
+    /// Bounded "PUT publish config once the daemon answers" task (issue #722),
+    /// tracked so it can be cancelled on stop and never overlaps itself.
+    private var publishSyncTask: Task<Void, Never>?
     private var restartCount = 0
     private let maxRestartDelay: TimeInterval = 30
 
     private let logger = Logger(subsystem: "io.irrlicht.app", category: "DaemonManager")
 
-    /// Last publish config the running daemon was launched with, so a settings
-    /// nudge relaunches only when the effective config actually changed.
-    private var lastPublishConfig = ""
+    /// Test-only view of the app-owned daemon process (nil when none), so tests
+    /// can assert the POST-based publish reconfigure never spawns or relaunches
+    /// a daemon (issue #722). Internal: visible only via `@testable import`.
+    var currentProcessForTesting: Process? { process }
 
     // MARK: - Relay publish settings
 
@@ -27,89 +31,66 @@ final class DaemonManager: ObservableObject {
     /// UserDefaults (shared with the relay *subscribe* direction); the token
     /// lives in the Keychain — same store the subscribe path uses.
     private var publishEnabled: Bool { UserDefaults.standard.bool(forKey: "publishToRelay") }
-    // Trimmed at the source so the change-detection signature and the launched
-    // env derive from identical values (buildDaemonEnv trims again defensively
-    // for its standalone callers/tests).
     private var relayURL: String {
         (UserDefaults.standard.string(forKey: "relayServerURL") ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
-    private var relayToken: String {
-        KeychainStore.get(account: "relayToken").trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    /// Signature of the publish-relevant settings. The token is reduced to a
-    /// hash so the plaintext secret isn't retained, while a token change still
-    /// shows up as a different signature.
-    private var publishConfigSignature: String {
-        let token = relayToken
-        return "\(publishEnabled)|\(relayURL)|\(token.isEmpty ? "none" : String(token.hashValue))"
-    }
 
     /// Builds the daemon's launch environment from a base (the app's own
-    /// environment) plus the relay-publish settings. When publishing is on with
-    /// a non-empty URL it sets `IRRLICHT_RELAY_URL` (which activates the daemon's
-    /// outbound forwarder) and, when a token is present, `IRRLICHT_RELAY_TOKEN`.
-    /// When publishing is off it strips both, so a value inherited from the
-    /// app's own environment can't silently keep forwarding on. `bindAddr` is
-    /// always set so the daemon listens on the port the app connects to.
-    static func buildDaemonEnv(
-        base: [String: String],
-        bindAddr: String,
-        publishEnabled: Bool,
-        relayURL: String,
-        relayToken: String
-    ) -> [String: String] {
+    /// environment). Only `IRRLICHT_BIND_ADDR` is layered on, so the daemon
+    /// listens on the port the app connects to. Relay publishing is no longer
+    /// passed as launch env — the app drives it live over the daemon's loopback
+    /// `PUT /api/v1/relay/publish` instead (issue #722).
+    static func buildDaemonEnv(base: [String: String], bindAddr: String) -> [String: String] {
         var env = base
         env["IRRLICHT_BIND_ADDR"] = bindAddr
-        let url = relayURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        let token = relayToken.trimmingCharacters(in: .whitespacesAndNewlines)
-        if publishEnabled && !url.isEmpty {
-            env["IRRLICHT_RELAY_URL"] = url
-            if token.isEmpty {
-                env.removeValue(forKey: "IRRLICHT_RELAY_TOKEN")
-            } else {
-                env["IRRLICHT_RELAY_TOKEN"] = token
-            }
-        } else {
-            env.removeValue(forKey: "IRRLICHT_RELAY_URL")
-            env.removeValue(forKey: "IRRLICHT_RELAY_TOKEN")
-        }
         return env
     }
 
     /// Called by Settings when a publish-relevant setting changes (the toggle,
     /// the relay URL, or the Keychain token — the last fires no UserDefaults
-    /// notification, so Settings nudges us explicitly). Relaunches the embedded
-    /// daemon so its startup-wired forwarder picks up the new env, but only when
-    /// the effective config actually changed.
+    /// notification, so Settings nudges us explicitly). POSTs the new config to
+    /// the running daemon so it reconfigures its forwarder live — no relaunch,
+    /// and it works whether this app spawned the daemon or adopted an
+    /// already-running one (issue #722).
     func publishSettingsDidChange() {
-        let sig = publishConfigSignature
-        guard sig != lastPublishConfig else { return }
-        lastPublishConfig = sig
-        relaunch()
+        pushPublishConfig()
     }
 
-    /// Relaunches the embedded daemon to apply changed launch settings. Only a
-    /// daemon this app spawned is relaunched; an external or custom-port dev
-    /// daemon the app didn't start is left untouched (its env is owned wherever
-    /// it was launched). The crash-restart path is not triggered:
-    /// terminateProcess() clears `process`, and the terminationHandler restarts
-    /// only when the terminated process is still the current one.
-    private func relaunch() {
-        guard process != nil else {
-            logger.info("Publish settings changed but no app-owned daemon to relaunch")
-            return
+    /// PUT the current publish settings to the daemon now (fire-and-forget).
+    /// Used when the daemon is already known to be reachable (the adopt path and
+    /// settings nudges). The daemon's Apply is idempotent, so re-POSTing the
+    /// config already in effect is a cheap no-op.
+    ///
+    /// The UserDefaults flags are read on the main actor (cheap), but the
+    /// Keychain token read and the network call run on a detached task: Keychain
+    /// access can be slow, and blocking the main actor on it would stutter the
+    /// UI (and stall anything awaiting the run loop).
+    private func pushPublishConfig() {
+        let enabled = publishEnabled
+        let url = relayURL
+        Task.detached {
+            let token = KeychainStore.get(account: "relayToken")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            await PublishClient.apply(enabled: enabled, url: url, token: token)
         }
-        logger.info("Relaunching embedded daemon to apply relay-publish settings")
-        terminateProcess()
-        healthTask?.cancel()
-        healthTask = Task { [weak self] in
-            // Brief grace so the listening socket frees before the new daemon binds.
-            try? await Task.sleep(nanoseconds: 700_000_000)
-            guard let self, !Task.isCancelled else { return }
-            self.restartCount = 0
-            self.spawnDaemon()
+    }
+
+    /// After a spawn/restart, wait (bounded) for the daemon to answer, then PUT
+    /// the current publish settings. A freshly-spawned daemon starts with
+    /// publishing off (the app no longer passes the relay env, issue #722), so
+    /// this brings it in line with the app's settings without a manual toggle.
+    private func syncPublishWhenReachable() {
+        publishSyncTask?.cancel()
+        publishSyncTask = Task { [weak self] in
+            for _ in 0..<25 { // up to ~5s (25 × 200ms)
+                guard let self, !Task.isCancelled else { return }
+                if await self.isDaemonReachable() {
+                    self.pushPublishConfig()
+                    return
+                }
+                try? await Task.sleep(nanoseconds: 200_000_000)
+            }
         }
     }
 
@@ -122,6 +103,9 @@ final class DaemonManager: ObservableObject {
             if await self.isDaemonReachable() {
                 self.daemonRunning = true
                 self.logger.info("External daemon already reachable — skipping spawn")
+                // Adopt path: bring the already-running daemon in line with our
+                // publish settings (it may have been started without them).
+                self.pushPublishConfig()
                 return
             }
             self.killStaleDaemons()
@@ -132,6 +116,8 @@ final class DaemonManager: ObservableObject {
     func stop() {
         healthTask?.cancel()
         healthTask = nil
+        publishSyncTask?.cancel()
+        publishSyncTask = nil
         terminateProcess()
     }
 
@@ -206,14 +192,12 @@ final class DaemonManager: ObservableObject {
         proc.standardOutput = FileHandle.nullDevice
         proc.standardError = FileHandle.nullDevice
         // Bind the same port the app connects to. Inherits the app's
-        // environment so IRRLICHT_HOME (if set for a dev instance) propagates,
-        // then layers on the relay-publish env from Settings (issue #718).
+        // environment so IRRLICHT_HOME (if set for a dev instance) propagates.
+        // Relay publishing is applied live over loopback after launch, not via
+        // env (issue #722) — see syncPublishWhenReachable below.
         proc.environment = Self.buildDaemonEnv(
             base: ProcessInfo.processInfo.environment,
-            bindAddr: "127.0.0.1:\(DaemonEndpoint.port)",
-            publishEnabled: publishEnabled,
-            relayURL: relayURL,
-            relayToken: relayToken
+            bindAddr: "127.0.0.1:\(DaemonEndpoint.port)"
         )
 
         proc.terminationHandler = { [weak self] terminated in
@@ -240,10 +224,10 @@ final class DaemonManager: ObservableObject {
             process = proc
             daemonRunning = true
             restartCount = 0
-            // Record the publish config this daemon launched with, so a later
-            // settings nudge relaunches only on an actual change.
-            lastPublishConfig = publishConfigSignature
             logger.info("Spawned embedded daemon (pid \(proc.processIdentifier))")
+            // The spawned daemon starts with publishing off; once it answers,
+            // POST the app's publish settings so it matches without a relaunch.
+            syncPublishWhenReachable()
         } catch {
             logger.error("Failed to launch daemon: \(error.localizedDescription)")
             scheduleRestart()

--- a/platforms/macos/Irrlicht/Managers/DaemonManager.swift
+++ b/platforms/macos/Irrlicht/Managers/DaemonManager.swift
@@ -37,13 +37,19 @@ final class DaemonManager: ObservableObject {
     }
 
     /// Builds the daemon's launch environment from a base (the app's own
-    /// environment). Only `IRRLICHT_BIND_ADDR` is layered on, so the daemon
-    /// listens on the port the app connects to. Relay publishing is no longer
-    /// passed as launch env — the app drives it live over the daemon's loopback
-    /// `PUT /api/v1/relay/publish` instead (issue #722).
+    /// environment). `IRRLICHT_BIND_ADDR` is layered on so the daemon listens on
+    /// the port the app connects to. Relay publishing is no longer passed as
+    /// launch env — the app drives it live over the daemon's loopback
+    /// `PUT /api/v1/relay/publish` (issue #722) — so any `IRRLICHT_RELAY_URL` /
+    /// `IRRLICHT_RELAY_TOKEN` inherited from the app's own environment is
+    /// stripped. The daemon self-seeds its forwarder from those vars at boot, so
+    /// without this an app-spawned daemon would start publishing to a relay the
+    /// user never configured in the UI until the app's corrective PUT landed.
     static func buildDaemonEnv(base: [String: String], bindAddr: String) -> [String: String] {
         var env = base
         env["IRRLICHT_BIND_ADDR"] = bindAddr
+        env.removeValue(forKey: "IRRLICHT_RELAY_URL")
+        env.removeValue(forKey: "IRRLICHT_RELAY_TOKEN")
         return env
     }
 
@@ -57,10 +63,15 @@ final class DaemonManager: ObservableObject {
         pushPublishConfig()
     }
 
-    /// PUT the current publish settings to the daemon now (fire-and-forget).
-    /// Used when the daemon is already known to be reachable (the adopt path and
-    /// settings nudges). The daemon's Apply is idempotent, so re-POSTing the
-    /// config already in effect is a cheap no-op.
+    /// PUT the current publish settings to the daemon now. Used when the daemon
+    /// is already known to be reachable (the adopt path and settings nudges). The
+    /// daemon's Apply is idempotent, so re-POSTing the config already in effect is
+    /// a cheap no-op.
+    ///
+    /// Best-effort with a few retries: publishing now depends entirely on this
+    /// PUT (the app no longer seeds the daemon via launch env, issue #722), so a
+    /// single dropped request must not strand the daemon in the wrong publish
+    /// state — nothing else re-pushes the config until the next settings change.
     ///
     /// The UserDefaults flags are read on the main actor (cheap), but the
     /// Keychain token read and the network call run on a detached task: Keychain
@@ -72,7 +83,12 @@ final class DaemonManager: ObservableObject {
         Task.detached {
             let token = KeychainStore.get(account: "relayToken")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            await PublishClient.apply(enabled: enabled, url: url, token: token)
+            for attempt in 0..<3 {
+                if await PublishClient.apply(enabled: enabled, url: url, token: token) {
+                    return
+                }
+                if attempt < 2 { try? await Task.sleep(nanoseconds: 300_000_000) }
+            }
         }
     }
 

--- a/platforms/macos/Irrlicht/Managers/PublishClient.swift
+++ b/platforms/macos/Irrlicht/Managers/PublishClient.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Pushes the app's relay-publish settings to the running daemon's loopback
+/// `PUT /api/v1/relay/publish` so toggling "Publish to relay" — or editing the
+/// URL/token — reconfigures the live forwarder without a daemon relaunch
+/// (issue #722). The daemon owns the forwarder's lifecycle; this client only
+/// tells it the desired `{enabled, url, token}`, which works whether the app
+/// spawned the daemon or adopted an already-running one.
+enum PublishClient {
+    static let path = "/api/v1/relay/publish"
+
+    /// Wire shape of the PUT body. The relay token travels in this loopback
+    /// body rather than a spawn-time env var (issue #722); the daemon binds
+    /// 127.0.0.1 only, so this is the same trust boundary as every other
+    /// daemon endpoint.
+    struct Config: Codable, Equatable {
+        let enabled: Bool
+        let url: String
+        let token: String
+    }
+
+    /// Builds the PUT request. Internal (not private) so tests can assert the
+    /// wire shape without a live daemon. Returns nil only if the endpoint URL
+    /// can't be formed.
+    static func makeRequest(enabled: Bool, url: String, token: String) -> URLRequest? {
+        guard let endpoint = URL(string: "\(DaemonEndpoint.httpBase)\(path)") else { return nil }
+        var req = URLRequest(url: endpoint, timeoutInterval: 2)
+        req.httpMethod = "PUT"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try? JSONEncoder().encode(Config(enabled: enabled, url: url, token: token))
+        return req
+    }
+
+    /// Send the desired publish config to the daemon. Best-effort: a failure
+    /// (daemon not yet reachable) is swallowed — the caller re-syncs once the
+    /// daemon answers, and the Settings poll reflects the true state regardless.
+    /// Returns true on a 200.
+    @discardableResult
+    static func apply(enabled: Bool, url: String, token: String) async -> Bool {
+        guard let req = makeRequest(enabled: enabled, url: url, token: token) else { return false }
+        do {
+            let (_, resp) = try await URLSession.shared.data(for: req)
+            return (resp as? HTTPURLResponse)?.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+}

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -362,8 +362,8 @@ struct SettingsView: View {
                                                     try? await Task.sleep(nanoseconds: 600_000_000)
                                                     guard !Task.isCancelled else { return }
                                                     relayServerURL = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
-                                                    // The daemon's forwarder is wired at startup, so a
-                                                    // URL change needs a relaunch to take effect.
+                                                    // POST the new URL to the running daemon so it
+                                                    // reconfigures its forwarder live (issue #722).
                                                     daemonManager.publishSettingsDidChange()
                                                 }
                                             }
@@ -382,7 +382,8 @@ struct SettingsView: View {
                                             KeychainStore.set(newValue.trimmingCharacters(in: .whitespacesAndNewlines), account: "relayToken")
                                             // Keychain writes don't fire UserDefaults.didChangeNotification,
                                             // so nudge both directions to pick up the new token: the
-                                            // subscribe link reconnects, the daemon relaunches to republish.
+                                            // subscribe link reconnects, and we POST the new token to the
+                                            // daemon so it republishes with it (issue #722).
                                             sessionManager.relayTokenDidChange()
                                             daemonManager.publishSettingsDidChange()
                                         }

--- a/platforms/macos/Tests/DaemonManagerTests.swift
+++ b/platforms/macos/Tests/DaemonManagerTests.swift
@@ -49,17 +49,21 @@ final class DaemonManagerTests: XCTestCase {
         XCTAssertEqual(env["PATH"], "/usr/bin", "base environment must be preserved")
     }
 
-    func testBuildDaemonEnvNoLongerLayersRelayPublishVars() {
-        // Relay publishing now travels over loopback (issue #722), not launch
-        // env: buildDaemonEnv must not inject IRRLICHT_RELAY_* of its own. An
-        // inherited value is left untouched (the app's own environment), but the
-        // builder adds nothing.
+    func testBuildDaemonEnvStripsInheritedRelayVars() {
+        // Relay publishing travels over loopback now (issue #722), not launch
+        // env, and the daemon self-seeds its forwarder from IRRLICHT_RELAY_URL at
+        // boot. So buildDaemonEnv must both add no relay vars of its own AND strip
+        // any inherited from the app's environment — otherwise an app-spawned
+        // daemon would publish to a stale relay the user never configured until
+        // the app's corrective PUT landed.
         let env = DaemonManager.buildDaemonEnv(
-            base: [:],
+            base: ["IRRLICHT_RELAY_URL": "wss://stale", "IRRLICHT_RELAY_TOKEN": "stale", "PATH": "/usr/bin"],
             bindAddr: "127.0.0.1:7837"
         )
-        XCTAssertNil(env["IRRLICHT_RELAY_URL"])
-        XCTAssertNil(env["IRRLICHT_RELAY_TOKEN"])
+        XCTAssertNil(env["IRRLICHT_RELAY_URL"], "inherited relay URL must be stripped")
+        XCTAssertNil(env["IRRLICHT_RELAY_TOKEN"], "inherited relay token must be stripped")
+        XCTAssertEqual(env["IRRLICHT_BIND_ADDR"], "127.0.0.1:7837")
+        XCTAssertEqual(env["PATH"], "/usr/bin", "unrelated base vars must be preserved")
     }
 
     func testPublishSettingsDidChangeDoesNotRelaunchDaemon() {

--- a/platforms/macos/Tests/DaemonManagerTests.swift
+++ b/platforms/macos/Tests/DaemonManagerTests.swift
@@ -38,81 +38,39 @@ final class DaemonManagerTests: XCTestCase {
         XCTAssertFalse(manager.daemonRunning)
     }
 
-    // MARK: - Relay-publish env wiring (issue #718)
+    // MARK: - Daemon launch env (issue #722)
 
-    func testBuildDaemonEnvPublishOnWithToken() {
+    func testBuildDaemonEnvSetsBindAddrAndPreservesBase() {
         let env = DaemonManager.buildDaemonEnv(
             base: ["PATH": "/usr/bin"],
-            bindAddr: "127.0.0.1:7837",
-            publishEnabled: true,
-            relayURL: "wss://funken.io",
-            relayToken: "tok"
+            bindAddr: "127.0.0.1:7838"
         )
-        XCTAssertEqual(env["IRRLICHT_BIND_ADDR"], "127.0.0.1:7837")
-        XCTAssertEqual(env["IRRLICHT_RELAY_URL"], "wss://funken.io")
-        XCTAssertEqual(env["IRRLICHT_RELAY_TOKEN"], "tok")
+        XCTAssertEqual(env["IRRLICHT_BIND_ADDR"], "127.0.0.1:7838")
         XCTAssertEqual(env["PATH"], "/usr/bin", "base environment must be preserved")
     }
 
-    func testBuildDaemonEnvPublishOnWithoutTokenStripsInheritedToken() {
-        // Publishing on, but no token configured: an inherited IRRLICHT_RELAY_TOKEN
-        // must not leak through (no-auth relay, or token cleared in Settings).
+    func testBuildDaemonEnvNoLongerLayersRelayPublishVars() {
+        // Relay publishing now travels over loopback (issue #722), not launch
+        // env: buildDaemonEnv must not inject IRRLICHT_RELAY_* of its own. An
+        // inherited value is left untouched (the app's own environment), but the
+        // builder adds nothing.
         let env = DaemonManager.buildDaemonEnv(
-            base: ["IRRLICHT_RELAY_TOKEN": "stale"],
-            bindAddr: "127.0.0.1:7837",
-            publishEnabled: true,
-            relayURL: "wss://funken.io",
-            relayToken: ""
-        )
-        XCTAssertEqual(env["IRRLICHT_RELAY_URL"], "wss://funken.io")
-        XCTAssertNil(env["IRRLICHT_RELAY_TOKEN"])
-    }
-
-    func testBuildDaemonEnvPublishOffStripsInheritedVars() {
-        // Toggling publish off must truly stop forwarding even if the app was
-        // launched with the relay vars already set in its environment.
-        let env = DaemonManager.buildDaemonEnv(
-            base: ["IRRLICHT_RELAY_URL": "wss://stale", "IRRLICHT_RELAY_TOKEN": "stale"],
-            bindAddr: "127.0.0.1:7837",
-            publishEnabled: false,
-            relayURL: "wss://funken.io",
-            relayToken: "tok"
+            base: [:],
+            bindAddr: "127.0.0.1:7837"
         )
         XCTAssertNil(env["IRRLICHT_RELAY_URL"])
         XCTAssertNil(env["IRRLICHT_RELAY_TOKEN"])
-        XCTAssertEqual(env["IRRLICHT_BIND_ADDR"], "127.0.0.1:7837")
     }
 
-    func testBuildDaemonEnvEmptyURLActsAsOff() {
-        let env = DaemonManager.buildDaemonEnv(
-            base: [:],
-            bindAddr: "127.0.0.1:7837",
-            publishEnabled: true,
-            relayURL: "   ",
-            relayToken: "tok"
-        )
-        XCTAssertNil(env["IRRLICHT_RELAY_URL"], "enabled with a blank URL must not activate the forwarder")
-        XCTAssertNil(env["IRRLICHT_RELAY_TOKEN"])
-    }
-
-    func testBuildDaemonEnvTrimsURLAndToken() {
-        let env = DaemonManager.buildDaemonEnv(
-            base: [:],
-            bindAddr: "127.0.0.1:7837",
-            publishEnabled: true,
-            relayURL: "  wss://funken.io  ",
-            relayToken: "  tok  "
-        )
-        XCTAssertEqual(env["IRRLICHT_RELAY_URL"], "wss://funken.io")
-        XCTAssertEqual(env["IRRLICHT_RELAY_TOKEN"], "tok")
-    }
-
-    func testPublishSettingsDidChangeIsSafeWithoutOwnedDaemon() {
-        // Under xctest there's no daemon binary, so no app-owned process: the
-        // relaunch path must be a safe no-op (and idempotent), never a crash.
+    func testPublishSettingsDidChangeDoesNotRelaunchDaemon() {
+        // The toggle now POSTs to the running daemon instead of relaunching it.
+        // Under xctest there's no daemon binary and no app-owned process, so the
+        // call must be a safe fire-and-forget no-op — never spawn or crash.
+        XCTAssertNil(manager.currentProcessForTesting, "precondition: no app-owned daemon")
         manager.publishSettingsDidChange()
         manager.publishSettingsDidChange()
-        XCTAssertFalse(manager.daemonRunning)
+        XCTAssertFalse(manager.daemonRunning, "publishSettingsDidChange must not launch a daemon")
+        XCTAssertNil(manager.currentProcessForTesting, "publishSettingsDidChange must not spawn a process")
     }
 
     // MARK: - Bundle Path Tests

--- a/platforms/macos/Tests/PublishClientTests.swift
+++ b/platforms/macos/Tests/PublishClientTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import Irrlicht
+import Foundation
+
+final class PublishClientTests: XCTestCase {
+
+    func testMakeRequestEncodesConfigAsPutJSON() throws {
+        let req = try XCTUnwrap(PublishClient.makeRequest(
+            enabled: true, url: "ws://localhost:7839", token: "tok"))
+
+        XCTAssertEqual(req.httpMethod, "PUT")
+        XCTAssertEqual(req.url?.path, PublishClient.path)
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = try XCTUnwrap(req.httpBody)
+        let decoded = try JSONDecoder().decode(PublishClient.Config.self, from: body)
+        XCTAssertEqual(decoded, PublishClient.Config(enabled: true, url: "ws://localhost:7839", token: "tok"))
+    }
+
+    func testMakeRequestCarriesDisableAndEmptyToken() throws {
+        // Turning publish off must still send a well-formed body the daemon can
+        // act on (enabled=false), not omit fields.
+        let req = try XCTUnwrap(PublishClient.makeRequest(enabled: false, url: "", token: ""))
+        let body = try XCTUnwrap(req.httpBody)
+        let decoded = try JSONDecoder().decode(PublishClient.Config.self, from: body)
+        XCTAssertEqual(decoded, PublishClient.Config(enabled: false, url: "", token: ""))
+    }
+}


### PR DESCRIPTION
Closes #722. Follow-up to #718 (merged via #721).

## Problem

The macOS **"Publish to relay"** toggle applied changes by **relaunching the app-owned daemon** (`publishSettingsDidChange()` → `relaunch()`, guarded on `process != nil`). Two problems:

1. **No-op when the app adopted the daemon.** When the app adopts an already-running daemon (LaunchAgent, or `/ir:test-mac replace`), `relaunch()` does nothing — the toggle goes green but `GET /api/v1/relay/publish` stays `{"enabled":false}`.
2. **Heavyweight when it works.** Relaunching tears down and reconnects every session's monitoring just to start/stop one outbound WebSocket.

## What changed

### Daemon (`scope:daemon`)
- New `relay.PublishController` owns the forwarder lifecycle: `Apply(enabled, url, token)` starts / stops / reconfigures a single forwarder (cancel the ctx + start a fresh `relay.NewForwarder`). Idempotent when the effective config is unchanged; mutex-guarded so concurrent PUTs serialize. A blank URL counts as "off" (mirrors the old env-builder semantics).
- The controller is **always constructed** and **seeded once at startup** from `IRRLICHT_RELAY_URL` / `IRRLICHT_RELAY_TOKEN`, so headless/standalone daemons keep working exactly as before.
- New loopback-only `PUT /api/v1/relay/publish` accepting `{enabled,url,token}` → `Apply(...)` → returns the resulting status (same shape as `GET`). `GET` now reads the controller too.

### macOS app (`scope:macos`)
- `DaemonManager.publishSettingsDidChange()` now **PUTs** `{enabled,url,token}` to the running daemon (new `PublishClient`) instead of relaunching — works whether the app spawned or adopted the daemon.
- Re-syncs publish state **on spawn** (once the daemon answers) and **on adopt**, so the daemon matches the app's settings without a manual toggle.
- `buildDaemonEnv` no longer layers the relay env (keeps `IRRLICHT_BIND_ADDR`). The `process === terminated` crash-restart guard from #718 stays (general correctness).

## Token delivery (decision, per the issue)

The relay token moves from a spawn-time **env var** to the **loopback PUT body**. The daemon binds `127.0.0.1` only — same trust boundary as every other daemon endpoint (hooks, permissions/answer, focus) — and the token is already readable from the user's Keychain. No auth added to the loopback API (out of scope).

## Tests

- **Go** (`go test ./core/... -race -count=1`): `PublishController` start/stop, idempotent re-apply, live reconfigure (URL change reconnects to a new relay), blank-URL-acts-as-off; `PUT` handler toggles publishing on/off end-to-end and rejects a malformed body with 400. Full core suite green (the `TestDebounce_FirstEventFiresImmediately` timing test is a pre-existing flake under full `-race` load — passes in isolation; untouched by this change).
- **Swift**: `PublishClient` PUT wire shape (enabled + disabled bodies); `publishSettingsDidChange` does not spawn/relaunch a daemon.

## Acceptance criteria status

- [x] Toggle/URL/token changes apply to the **already-running** daemon with no relaunch — both spawned and adopted paths (PUT + on-adopt/on-spawn re-sync).
- [x] No session monitoring interrupted by toggling publish (no restart).
- [x] Headless/standalone daemons still start from `IRRLICHT_RELAY_URL`/`IRRLICHT_RELAY_TOKEN` (controller seeded at startup).
- [x] Turning publish off stops forwarding; bad token still surfaces as `auth_failed` (forwarder status path unchanged).
- [ ] Live auth-enabled-relay E2E re-run on a real device — **not run in this worktree** (no relay/Keychain here); flagged for manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
