### PR TITLE
chore(capacity): sync BUILTIN_ALIASES with codeburn

### DIFF
--- a/core/pkg/capacity/aliases.go
+++ b/core/pkg/capacity/aliases.go
@@ -153,4 +153,15 @@ var modelAliases = map[string]string{
 	"claude-4-6-sonnet-high-fast": "claude-sonnet-4-6",
 	"claude-4-7-opus-xhigh":       "claude-opus-4-7",
 	"claude-4-7-opus-xhigh-fast":  "claude-opus-4-7",
+
+	// Zhipu GLM — codeburn maps "GLM-5.2" to "glm-5p1", which LiteLLM does not
+	// ship (it carries zai.glm-5, with no context window populated yet). Kept
+	// as codeburn's canonical; resolves to a zero-value capacity and logs the
+	// mapping on miss until LiteLLM prices it.
+	"GLM-5.2": "glm-5p1",
+
+	// xAI Grok — codeburn's "grok-build-0.1" canonical isn't in LiteLLM (no
+	// grok-build pricing yet). Zero-value capacity + log on miss until the key
+	// lands upstream.
+	"grok-build": "grok-build-0.1",
 }


### PR DESCRIPTION
Sync `core/pkg/capacity/aliases.go` against codeburn's `BUILTIN_ALIASES` (`getagentseal/codeburn@main/src/models.ts`), run via `/ir:refresh-aliases`.

The map was already nearly in sync (88 upstream entries, 88 local before this change). Only two keys were genuinely new upstream:

```
codeburn BUILTIN_ALIASES sync (2026-06-21)

Added (2):
  "GLM-5.2"    → "glm-5p1"          [LiteLLM: MISSING — has zai.glm-5, no ctx window]
  "grok-build" → "grok-build-0.1"   [LiteLLM: MISSING — no grok-build pricing]

Skipped (1):
  "gpt-4.1" → "gpt-4.1"   self-alias / no-op; the file header already documents this intentional omission

Changed (0)
Override drift (0)

Removed (3) — in irrlicht, NOT upstream — intentionally kept (local Antigravity additions, documented in-file):
  "gemini-3-flash-a"     → "gemini-3-flash-preview"
  "gemini-pro-default"   → "gemini-3.1-pro-preview"
  "gpt-oss-120b-medium"  → "openai.gpt-oss-120b-1:0"

Overrides (8) — unchanged, still diverging from codeburn (codeburn canonical not in LiteLLM):
  copilot-openai-auto, claude-4-sonnet, claude-4-sonnet-1m, claude-4-opus,
  gpt-5.1-codex-high, kimi-auto, kimi-code, kimi-for-coding
```

**Caveat (surfaced per skill Step 5):** both new canonicals are absent from the LiteLLM table the daemon caches, so these two aliases resolve to a zero-value capacity and log the mapping on miss — same as the existing Warp `gpt-5.3-codex` entries. No pricing benefit yet; they're added for literal parity with codeburn and become live automatically once LiteLLM ships `glm-5p1` / `grok-build-0.1` pricing. `zai.glm-5` exists in LiteLLM but currently has no populated context window, so an override to it would give no real capacity either — left on codeburn's canonical.

Exact-match only; no prefix/fuzzy logic. `go test ./core/pkg/capacity/... -race -count=1` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
