### PR TITLE
fix(macos): eliminate Settings panel jank (~2fps, high CPU) — #729

### DIFF
--- a/platforms/macos/Irrlicht/Models/SpokenVoice.swift
+++ b/platforms/macos/Irrlicht/Models/SpokenVoice.swift
@@ -52,6 +52,12 @@ enum SpokenVoice: String, CaseIterable {
     /// quality. Drives the "Install voice…" affordance in Settings.
     /// `.default` always reports `true` because the system-language voice
     /// is always available.
+    ///
+    /// - Important: calls `AVSpeechSynthesisVoice.speechVoices()`, which boots
+    ///   the TextToSpeech/AXSpeech subsystem and does per-voice ICU locale work.
+    ///   It is far too slow for a SwiftUI `body` — doing so dropped the Settings
+    ///   panel to ~2fps (issue #729). Resolve it off the main thread (e.g. a
+    ///   `.task` + `Task.detached`) and render from cached state; never in `body`.
     var isInstalled: Bool {
         guard canonicalName != nil else { return true }
         return AVSpeechSynthesisVoice.speechVoices().contains { matches(installedName: $0.name) }

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -249,10 +249,8 @@ struct SessionListView: View {
             if showSettings {
                 SettingsView(
                     isPresented: $showSettings,
-                    onReviewPermissions: {
-                        showSettings = false
-                        showPermissionsReview = true
-                    }
+                    showPermissionsReview: $showPermissionsReview,
+                    sessionManager: sessionManager
                 )
             } else if showPermissionsReview {
                 PermissionWizardView(mode: .review, onClose: { showPermissionsReview = false })

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -5,11 +5,17 @@ import UserNotifications
 
 struct SettingsView: View {
     @Binding var isPresented: Bool
-    /// Opens the permission wizard in review mode (issue #570). Wired by
-    /// SessionListView, which owns the panel-body swap.
-    var onReviewPermissions: () -> Void = {}
+    /// Swaps the panel body to the permission wizard in review mode (issue #570).
+    /// A binding (not a closure) so SettingsView's inputs stay diff-stable — the
+    /// parent re-renders every WebSocket tick, and a fresh closure each time would
+    /// defeat SwiftUI's render-skip and re-evaluate this whole view (issue #729).
+    @Binding var showPermissionsReview: Bool
     @EnvironmentObject var updateManager: UpdateManager
-    @EnvironmentObject var sessionManager: SessionManager
+    /// Plain, non-observing reference: SettingsView only calls
+    /// `relayTokenDidChange()` and feeds the relay status dot subview. Observing
+    /// SessionManager here (it was an @EnvironmentObject) made this static form
+    /// re-render on every session/history push — the ~2fps storm in issue #729.
+    let sessionManager: SessionManager
     @EnvironmentObject var daemonManager: DaemonManager
     @AppStorage("debugMode") private var debugMode: Bool = false
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
@@ -140,7 +146,8 @@ struct SettingsView: View {
                             Spacer()
                         }
                         Button("Review agent permissions…") {
-                            onReviewPermissions()
+                            isPresented = false
+                            showPermissionsReview = true
                         }
                         .controlSize(.small)
                         .tooltip("Open the per-agent permission toggles")
@@ -368,10 +375,7 @@ struct SettingsView: View {
                                                 }
                                             }
                                         if useRelayServer {
-                                            Circle()
-                                                .fill(sessionManager.relayConnectionState.dotColor)
-                                                .frame(width: 8, height: 8)
-                                                .tooltip("Subscribe: \(sessionManager.relayConnectionState.shortLabel)")
+                                            RelaySubscribeStatusDot(sessionManager: sessionManager)
                                         }
                                     }
                                     SecureField("Relay token (leave empty if the relay has no auth)", text: $relayTokenDraft)
@@ -524,6 +528,22 @@ struct SettingsView: View {
                 }
             }
         }
+    }
+}
+
+/// Live relay-subscribe connection dot. Isolated into its own @ObservedObject
+/// view so it stays reactive while the parent SettingsView holds SessionManager
+/// only as a non-observing reference — only this 8pt dot repaints per push, not
+/// the whole settings form (issue #729). Rendered only when Advanced → Sources
+/// is expanded and "Relay server" is on.
+private struct RelaySubscribeStatusDot: View {
+    @ObservedObject var sessionManager: SessionManager
+
+    var body: some View {
+        Circle()
+            .fill(sessionManager.relayConnectionState.dotColor)
+            .frame(width: 8, height: 8)
+            .tooltip("Subscribe: \(sessionManager.relayConnectionState.shortLabel)")
     }
 }
 

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -769,6 +769,10 @@ private struct NotificationEventRow: View {
         let installed = await Task.detached(priority: .userInitiated) {
             voice.isInstalled
         }.value
+        // The detached task outlives `.task(id:)` cancellation, so a selection
+        // change mid-flight could otherwise let this stale result overwrite the
+        // newer one. Drop it if our task was cancelled.
+        guard !Task.isCancelled else { return }
         voiceToInstall = installed ? nil : voice
     }
 

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -693,6 +693,12 @@ private struct NotificationEventRow: View {
     let onImportError: (String) -> Void
 
     @State private var selection: SoundChoice = .default
+    /// The non-default speak voice that isn't installed yet, if any — drives the
+    /// "Install voice…" affordance. Resolved off the main thread (#729): the
+    /// equivalent `SpokenVoice.isInstalled` check enumerates system voices via
+    /// the TextToSpeech subsystem, which is far too slow to run from `body` on
+    /// every render (it pegged the CPU and dropped Settings to ~2fps).
+    @State private var voiceToInstall: SpokenVoice?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -731,15 +737,13 @@ private struct NotificationEventRow: View {
                 .tooltip("Preview")
             }
 
-            if case .speak(let voice) = selection,
-               voice != .default,
-               !voice.isInstalled {
+            if let voiceToInstall {
                 Button {
                     Self.openSpokenContentSettings()
                 } label: {
                     HStack(spacing: 4) {
                         Image(systemName: "arrow.down.circle")
-                        Text("Install \(voice.displayName) in System Settings")
+                        Text("Install \(voiceToInstall.displayName) in System Settings")
                     }
                     .font(.caption)
                 }
@@ -749,6 +753,23 @@ private struct NotificationEventRow: View {
             }
         }
         .onAppear { loadFromDefaults() }
+        .task(id: selection) { await refreshVoiceInstallState() }
+    }
+
+    /// Resolve whether the selected speak-voice needs installing, off the main
+    /// thread. `SpokenVoice.isInstalled` calls `AVSpeechSynthesisVoice.speechVoices()`
+    /// — expensive enough that running it from `body` dropped Settings to ~2fps and
+    /// pegged the CPU (#729). Re-runs whenever the selection changes, so the
+    /// affordance also stays correct after the user installs a voice.
+    private func refreshVoiceInstallState() async {
+        guard case .speak(let voice) = selection, voice != .default else {
+            voiceToInstall = nil
+            return
+        }
+        let installed = await Task.detached(priority: .userInitiated) {
+            voice.isInstalled
+        }.value
+        voiceToInstall = installed ? nil : voice
     }
 
     private static func openSpokenContentSettings() {

--- a/platforms/macos/Tests/SettingsViewTests.swift
+++ b/platforms/macos/Tests/SettingsViewTests.swift
@@ -18,9 +18,10 @@ final class SettingsViewTests: XCTestCase {
         // SettingsView requires its environment objects (crashes without
         // them). startingUpdater: false keeps Sparkle from starting its
         // update cycle, which would fail outside an app bundle.
-        let view = SettingsView(isPresented: .constant(true))
+        let view = SettingsView(isPresented: .constant(true),
+                                showPermissionsReview: .constant(false),
+                                sessionManager: SessionManager())
             .environmentObject(UpdateManager(startingUpdater: false))
-            .environmentObject(SessionManager())
             .environmentObject(DaemonManager())
         let hosting = NSHostingView(rootView: view)
         // Pin to dark aqua so NSColor.windowBackgroundColor resolves


### PR DESCRIPTION
Fixes #729.

## Symptoms
The Settings panel rendered at ~2fps with high CPU, was slow to open, and was **worst right after opening** — easing over time.

## Root cause (found via a live `sample` profile)
The dominant cost was **`AVSpeechSynthesisVoice.speechVoices()` being called from a SwiftUI `body` on every render**. Each `NotificationEventRow`'s "Install voice…" affordance evaluated `SpokenVoice.isInstalled`, whose getter enumerates system voices — spinning up the whole TextToSpeech/AXSpeech subsystem plus per-voice ICU locale work. A 5s profile of the live app showed **~68% of all CPU samples on the main thread inside that single call**. It eased over time only because the speech subsystem warms up — which is exactly the "worst at the beginning" behavior.

A secondary issue: `SettingsView` observed the chatty `SessionManager` (via `@EnvironmentObject`), and the parent passed a fresh non-equatable closure each tick, so the static form re-rendered on every session/history WebSocket push.

## Fix
Two commits:

1. **Move the voice-install check off the render path** (the real fix). Resolve install state in a `.task(id: selection)` off the main thread and render from a cached `@State` — `body` never calls `speechVoices()`. Re-runs on selection change so the affordance stays correct after a voice is installed.
2. **Render-isolate `SettingsView` from `SessionManager`.** Hold the manager as a plain non-observing reference, move the one live read (relay connection dot) into a tiny `@ObservedObject` subview, and replace the closure input with a binding so the view's inputs are diff-stable. The static form no longer re-renders on the session stream.

## Verification
- `swift build` clean; full `swift test` suite green (155 tests, 5 display-gated skips).
- Live-tested a dev build against real session data: re-profiled with Settings open after the fix — the `speechVoices()` hot path is gone, and the panel opens promptly / scrolls smoothly. Confirmed by the reporter ("looks good now").

🤖 Generated with [Claude Code](https://claude.com/claude-code)