### PR TITLE
fix(detector): reap ghost sessions bound to a claude --bg-spare infra PID (#727)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/pid.go
+++ b/core/adapters/inbound/agents/claudecode/pid.go
@@ -184,6 +184,13 @@ var pidAlive = func(pid int) bool {
 	return syscall.Kill(pid, 0) == nil
 }
 
-// discoverByCWD is the fallback CWD-matching implementation. It's a package
-// variable so tests can inject a stub in place of the real pgrep+lsof call.
-var discoverByCWD = processlifecycle.DiscoverPIDByCWD
+// discoverByCWD is the fallback CWD-matching implementation, with Claude Code's
+// background infrastructure (daemon run / --bg-pty-host / --bg-spare) dropped by
+// argv (IsInfraArgv). These run the `claude` binary in the session's cwd, so
+// without the filter a long-lived `--bg-spare` pool helper sharing the cwd can be
+// bound as the session PID — and because it outlives every session, the liveness
+// sweep never reaps it (the ghost session in #727). It's a package variable so
+// tests can inject a stub in place of the real pgrep+lsof call.
+var discoverByCWD = func(processName, cwd string, disambiguate func([]int) int) (int, error) {
+	return processlifecycle.DiscoverPIDByCWDExcludingArgv(processName, cwd, disambiguate, IsInfraArgv)
+}

--- a/core/adapters/inbound/agents/maps.go
+++ b/core/adapters/inbound/agents/maps.go
@@ -84,6 +84,22 @@ func ProcessNames(agents []agent.Agent) map[string]string {
 	return m
 }
 
+// ArgvExcluders produces the adapter-name → Process.ExcludeArgv map consumed by
+// the liveness sweep's infra re-validation: a session bound to a still-alive PID
+// whose argv the adapter rejects (e.g. Claude Code's --bg-spare pool helper) is a
+// ghost and must be reaped (#727). Only adapters that declare a non-nil
+// Process.ExcludeArgv appear (today: claude-code); the rest get no entry, so the
+// sweep leaves their sessions untouched.
+func ArgvExcluders(agents []agent.Agent) map[string]func([]string) bool {
+	m := make(map[string]func([]string) bool)
+	for _, a := range agents {
+		if a.Process.ExcludeArgv != nil {
+			m[a.Identity.Name] = a.Process.ExcludeArgv
+		}
+	}
+	return m
+}
+
 // SubagentCounters produces the adapter-name → SubagentCounter map
 // consumed by metrics.Adapter. Only adapters whose LineParser implements
 // agent.SubagentCounter (currently: claudecode) appear in the map.

--- a/core/adapters/inbound/agents/processlifecycle/discovery.go
+++ b/core/adapters/inbound/agents/processlifecycle/discovery.go
@@ -31,12 +31,39 @@ func HasLiveProcess(m agent.ProcessMatcher) bool {
 // directory. When multiple processes match, disambiguate selects one.
 // Returns 0, nil when no matching process is found.
 func DiscoverPIDByCWD(processName, cwd string, disambiguate func([]int) int) (int, error) {
+	return DiscoverPIDByCWDExcludingArgv(processName, cwd, disambiguate, nil)
+}
+
+// DiscoverPIDByCWDExcludingArgv is DiscoverPIDByCWD with an extra per-PID argv
+// filter applied before disambiguation. excludeArgv mirrors the adapter's
+// Process.ExcludeArgv predicate (the same one the Scanner runs via argvExcluded):
+// when it returns true the PID is dropped from the candidate set, so a same-name
+// infrastructure process — e.g. Claude Code's `--bg-spare` pre-warmed pool helper,
+// which runs the `claude` binary in the session's cwd — never reaches the
+// disambiguator and is never bound as the session PID (the ghost in #727).
+//
+// argv is read through the same ProcessObserver seam (osProc.ArgvOf); a
+// nil/unreadable argv is passed through to the predicate, which per the
+// ExcludeArgv contract must not exclude on it. A nil excludeArgv disables
+// filtering — the legacy DiscoverPIDByCWD behaviour.
+func DiscoverPIDByCWDExcludingArgv(processName, cwd string, disambiguate func([]int) int, excludeArgv func([]string) bool) (int, error) {
 	if cwd == "" || processName == "" {
 		return 0, nil
 	}
 	pids, err := osProc.FindByName(processName)
 	if err != nil {
 		return 0, fmt.Errorf("find %s processes: %w", processName, err)
+	}
+	if excludeArgv != nil {
+		kept := make([]int, 0, len(pids))
+		for _, pid := range pids {
+			argv, _ := osProc.ArgvOf(pid)
+			if excludeArgv(argv) {
+				continue
+			}
+			kept = append(kept, pid)
+		}
+		pids = kept
 	}
 	return narrowByCWD(pids, cwd, disambiguate), nil
 }

--- a/core/adapters/inbound/agents/processlifecycle/discovery_argvfilter_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/discovery_argvfilter_test.go
@@ -103,3 +103,79 @@ func TestDiscoverExcludingArgv_NilArgvNotExcluded(t *testing.T) {
 		t.Fatalf("got pid %d, want %d (nil argv must not be excluded)", got, nilArgvPID)
 	}
 }
+
+// TestDiscoverByCWDExcludingArgv_DropsBgSpareBeforeDisambiguate is the
+// name-based mirror of the cmdline case above, for claude-code's discovery
+// (which matches by FindByName, not FindByCmdline). A real interactive
+// `claude` session and a long-lived `--bg-spare` pool helper share the
+// session's cwd; the default disambiguator (highest PID) would otherwise bind
+// the spare — the ghost session in #727. The excludeArgv predicate must drop
+// the spare before disambiguation and return the session PID.
+func TestDiscoverByCWDExcludingArgv_DropsBgSpareBeforeDisambiguate(t *testing.T) {
+	const (
+		sessionPID = 100 // interactive `claude` session
+		sparePID   = 400 // `claude --bg-spare ...`, higher PID, same cwd
+	)
+	const cwd = "/Users/x/proj"
+
+	prev := osProc
+	osProc = fakeObserver{
+		pids: []int{sessionPID, sparePID},
+		cwd:  map[int]string{sessionPID: cwd, sparePID: cwd},
+		argv: map[int][]string{
+			sessionPID: {"claude", "--resume", "abc"},
+			sparePID:   {"claude", "--bg-spare", "/tmp/y.sock"},
+		},
+	}
+	defer func() { osProc = prev }()
+
+	var seenByDisambiguate []int
+	disambiguate := func(pids []int) int {
+		seenByDisambiguate = append(seenByDisambiguate, pids...)
+		best := 0
+		for _, p := range pids {
+			if p > best {
+				best = p
+			}
+		}
+		return best
+	}
+
+	got, err := DiscoverPIDByCWDExcludingArgv("claude", cwd, disambiguate, stubInfraFilter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, p := range seenByDisambiguate {
+		if p == sparePID {
+			t.Errorf("excluded --bg-spare pid %d reached disambiguate (%v)", sparePID, seenByDisambiguate)
+		}
+	}
+	if got != sessionPID {
+		t.Fatalf("got pid %d, want session %d (--bg-spare must be filtered before disambiguation)", got, sessionPID)
+	}
+}
+
+// TestDiscoverByCWDExcludingArgv_NilArgvNotExcluded asserts the name-based
+// variant also honors the nil-argv-never-excludes contract.
+func TestDiscoverByCWDExcludingArgv_NilArgvNotExcluded(t *testing.T) {
+	const nilArgvPID = 100
+	const cwd = "/Users/x/proj"
+
+	prev := osProc
+	osProc = fakeObserver{
+		pids: []int{nilArgvPID},
+		cwd:  map[int]string{nilArgvPID: cwd},
+		argv: map[int][]string{nilArgvPID: nil},
+	}
+	defer func() { osProc = prev }()
+
+	excludeArgv := func(argv []string) bool { return len(argv) > 0 }
+
+	got, err := DiscoverPIDByCWDExcludingArgv("claude", cwd, nil, excludeArgv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nilArgvPID {
+		t.Fatalf("got pid %d, want %d (nil argv must not be excluded)", got, nilArgvPID)
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -156,6 +156,19 @@ func ReadLauncherEnv(pid int) *session.Launcher {
 	return l
 }
 
+// ReadArgv returns pid's argument vector (argv[0] is the executable as invoked),
+// or nil when it can't be read (hardened-runtime process, already exited). It
+// wraps the platform ProcessObserver so the services-layer liveness sweep can
+// apply an adapter's ExcludeArgv predicate to a bound PID without importing the
+// observer. Mirrors ReadLauncherEnv's contract: never blocks long, never prompts.
+func ReadArgv(pid int) []string {
+	if pid <= 0 {
+		return nil
+	}
+	argv, _ := osProc.ArgvOf(pid)
+	return argv
+}
+
 // processTTY is the controlling-TTY half of the host-enrichment capability;
 // it is darwin-only (ps-based, osutil_darwin.go) and a no-op stub elsewhere
 // (osutil_linux.go, osutil_other.go). Like the kitty/ancestry helpers, it

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -64,6 +64,15 @@ type PIDManager struct {
 	// launcherEnv reads launcher env from a PID. Optional — nil skips capture.
 	launcherEnv LauncherEnvReader
 
+	// argvExcluders maps adapter name → its Process.ExcludeArgv predicate, and
+	// readArgv reads a live PID's argv. Together they let the liveness sweep
+	// reap a session bound to a still-alive PID that is actually the adapter's
+	// background infra (e.g. Claude Code's --bg-spare pool helper sharing the
+	// session's cwd) rather than the interactive process — the ghost in #727.
+	// Both nil disables the check; installed once at startup via SetInfraReaper.
+	argvExcluders map[string]func([]string) bool
+	readArgv      func(pid int) []string
+
 	// onSessionDeleted is called when a session is deleted so the caller can
 	// clean up its own tracking structures (e.g. projectSessions map).
 	onSessionDeleted func(sessionID string)
@@ -150,6 +159,16 @@ func (pm *PIDManager) SetChildDeletedHandler(fn func(parentID string)) {
 // Nil disables launcher capture.
 func (pm *PIDManager) SetLauncherEnvReader(fn LauncherEnvReader) {
 	pm.launcherEnv = fn
+}
+
+// SetInfraReaper installs the seam the liveness sweep uses to reap a session
+// bound to a still-alive PID that is the adapter's background infrastructure
+// rather than the interactive session (issue #727). excluders maps adapter name
+// → Process.ExcludeArgv; readArgv reads a PID's argv. Both nil (the default, and
+// what tests/demo mode leave) disables the check. Called once at startup.
+func (pm *PIDManager) SetInfraReaper(excluders map[string]func([]string) bool, readArgv func(pid int) []string) {
+	pm.argvExcluders = excluders
+	pm.readArgv = readArgv
 }
 
 // captureLauncher invokes the launcher-env reader if one is installed and
@@ -682,6 +701,7 @@ type livenessSnapshot struct {
 	updatedAt       int64
 	parentSessionID string
 	transcriptPath  string
+	adapter         string
 }
 
 // snapshotLivenessStates reads every session's liveness-relevant fields under
@@ -704,6 +724,7 @@ func (pm *PIDManager) snapshotLivenessStates() []livenessSnapshot {
 			updatedAt:       state.UpdatedAt,
 			parentSessionID: state.ParentSessionID,
 			transcriptPath:  state.TranscriptPath,
+			adapter:         state.Adapter,
 		})
 	}
 	return snaps
@@ -728,6 +749,18 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 	for _, snap := range snaps {
 		if snap.pid > 0 {
 			if err := syscall.Kill(snap.pid, 0); err == syscall.ESRCH {
+				pm.HandleProcessExit(snap.pid, snap.state.SessionID)
+				foundDead = true
+				continue
+			}
+			// The PID is alive but may be the adapter's background infra (e.g.
+			// Claude Code's --bg-spare pool helper) that discovery mis-bound, not
+			// the interactive session. Such a helper outlives every session, so
+			// the ESRCH path above never fires — reap the ghost here (#727).
+			if pm.isBoundToInfra(snap) {
+				pm.log.LogInfo("session-detector", snap.state.SessionID,
+					fmt.Sprintf("pid %d is %s background infra, not the session — reaping ghost",
+						snap.pid, snap.adapter))
 				pm.HandleProcessExit(snap.pid, snap.state.SessionID)
 				foundDead = true
 			}
@@ -802,6 +835,31 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 		}
 	}
 	return foundDead
+}
+
+// isBoundToInfra reports whether snap's still-alive bound PID is one of the
+// adapter's background-infra processes (per its Process.ExcludeArgv) rather than
+// the interactive session — AND the session has been inert long enough that
+// reaping cannot interrupt real work. It returns false when no reaper is wired,
+// the adapter declares no ExcludeArgv, the PID's argv is unreadable (never reap
+// on absence of evidence — the ExcludeArgv contract), the session is a subagent
+// (it shares the parent's PID), or either staleness guard fails. The two guards
+// (stale transcript AND stale UpdatedAt) make this strictly narrower than the
+// TTL-branch reap below: a genuinely active session — including one blocked on a
+// permission prompt, which is bound to the real `claude` PID, not infra — is
+// never reaped here.
+func (pm *PIDManager) isBoundToInfra(snap livenessSnapshot) bool {
+	if pm.readArgv == nil || snap.pid <= 0 || snap.parentSessionID != "" {
+		return false
+	}
+	exclude := pm.argvExcluders[snap.adapter]
+	if exclude == nil {
+		return false
+	}
+	if !isStaleTranscript(snap.transcriptPath) || !isStaleUpdatedAt(snap.updatedAt, pm.readyTTL) {
+		return false
+	}
+	return exclude(pm.readArgv(snap.pid))
 }
 
 // isStaleUpdatedAt mirrors SessionState.IsStale on a snapshotted UpdatedAt so

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/application/services"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
@@ -154,6 +155,134 @@ func deadPIDForTest(t *testing.T) int {
 		t.Skipf("dead PID %d was recycled before test could observe it", pid)
 	}
 	return pid
+}
+
+// liveProcessForTest spawns a long-lived child and returns its PID; the process
+// is killed at cleanup. Gives the sweep a PID for which syscall.Kill(pid, 0)
+// succeeds — the infra-ghost signature (alive, but not the real session).
+func liveProcessForTest(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd.Process.Pid
+}
+
+// newPIDManagerForTestWithInfraReaper wires Fix B's infra-reaper seam (#727):
+// the sweep reaps a session bound to a still-alive PID whose argv the adapter's
+// ExcludeArgv rejects.
+func newPIDManagerForTestWithInfraReaper(repo *mockRepo, readArgv func(int) []string) *services.PIDManager {
+	pm := newPIDManagerForTest(repo)
+	pm.SetInfraReaper(
+		map[string]func([]string) bool{"claude-code": claudecode.IsInfraArgv},
+		readArgv,
+	)
+	return pm
+}
+
+// infraGhostState builds a working claude-code session bound to a live PID with
+// a stale transcript and stale UpdatedAt — the persisted ghost shape from #727
+// (a session mis-bound to a --bg-spare pool helper that outlives it).
+func infraGhostState(t *testing.T, pid int, transcriptMtime time.Time) *session.SessionState {
+	t.Helper()
+	transcript := filepath.Join(t.TempDir(), "ghost.jsonl")
+	writeTranscript(t, transcript, transcriptMtime)
+	return &session.SessionState{
+		SessionID:      "ghost",
+		Adapter:        "claude-code",
+		State:          session.StateWorking,
+		PID:            pid,
+		TranscriptPath: transcript,
+		UpdatedAt:      time.Now().Add(-11 * time.Minute).Unix(), // > 10m readyTTL
+	}
+}
+
+// TestCheckPIDLiveness_GhostBoundToInfra_Reaped is the core #727 fix: a working
+// session bound to a still-alive PID that is Claude Code's --bg-spare pool helper
+// (per the real argv shape: path argv[0] + --bg-spare) is reaped by the sweep
+// even though syscall.Kill on its PID succeeds.
+func TestCheckPIDLiveness_GhostBoundToInfra_Reaped(t *testing.T) {
+	pid := liveProcessForTest(t)
+	repo := newMockRepo()
+	repo.states["ghost"] = infraGhostState(t, pid, time.Now().Add(-10*time.Minute))
+
+	readArgv := func(int) []string {
+		return []string{"/Users/x/.local/share/claude/versions/2.1.185", "--bg-spare", "/tmp/x.claim.sock"}
+	}
+	newPIDManagerForTestWithInfraReaper(repo, readArgv).CheckPIDLiveness()
+
+	if repo.states["ghost"] != nil {
+		t.Fatal("session bound to a live --bg-spare infra PID should be reaped (#727)")
+	}
+}
+
+// TestCheckPIDLiveness_LiveInfraFreshTranscript_NotReaped: even when the bound
+// PID's argv is infra, a fresh transcript means the session is plausibly active
+// — the staleness guard must keep it.
+func TestCheckPIDLiveness_LiveInfraFreshTranscript_NotReaped(t *testing.T) {
+	pid := liveProcessForTest(t)
+	repo := newMockRepo()
+	st := infraGhostState(t, pid, time.Now()) // fresh transcript
+	st.UpdatedAt = time.Now().Unix()          // and fresh UpdatedAt
+	repo.states["ghost"] = st
+
+	readArgv := func(int) []string { return []string{"claude", "--bg-spare", "/tmp/x.sock"} }
+	newPIDManagerForTestWithInfraReaper(repo, readArgv).CheckPIDLiveness()
+
+	if repo.states["ghost"] == nil {
+		t.Fatal("active session (fresh transcript/UpdatedAt) must not be reaped even if its PID looks infra")
+	}
+}
+
+// TestCheckPIDLiveness_LiveSessionRealArgv_NotReaped: a stale session bound to a
+// live PID whose argv is a real interactive `claude` (not infra) must be kept —
+// the bound process IS the session (e.g. a long idle agent / permission prompt).
+func TestCheckPIDLiveness_LiveSessionRealArgv_NotReaped(t *testing.T) {
+	pid := liveProcessForTest(t)
+	repo := newMockRepo()
+	repo.states["ghost"] = infraGhostState(t, pid, time.Now().Add(-10*time.Minute))
+
+	readArgv := func(int) []string { return []string{"claude", "-p", "do the thing"} }
+	newPIDManagerForTestWithInfraReaper(repo, readArgv).CheckPIDLiveness()
+
+	if repo.states["ghost"] == nil {
+		t.Fatal("session bound to a real (non-infra) live claude PID must not be reaped")
+	}
+}
+
+// TestCheckPIDLiveness_NilArgv_NotReaped: an unreadable argv must never trip the
+// reaper — we never reap on absence of evidence (the ExcludeArgv contract).
+func TestCheckPIDLiveness_NilArgv_NotReaped(t *testing.T) {
+	pid := liveProcessForTest(t)
+	repo := newMockRepo()
+	repo.states["ghost"] = infraGhostState(t, pid, time.Now().Add(-10*time.Minute))
+
+	readArgv := func(int) []string { return nil }
+	newPIDManagerForTestWithInfraReaper(repo, readArgv).CheckPIDLiveness()
+
+	if repo.states["ghost"] == nil {
+		t.Fatal("session with unreadable argv must not be reaped (no reap on absence of evidence)")
+	}
+}
+
+// TestCheckPIDLiveness_NoReaperWired_NoChange: with no infra reaper installed
+// (demo mode / pre-Fix-B), a stale working session bound to a live PID is left
+// untouched — the sweep's pre-existing behavior.
+func TestCheckPIDLiveness_NoReaperWired_NoChange(t *testing.T) {
+	pid := liveProcessForTest(t)
+	repo := newMockRepo()
+	repo.states["ghost"] = infraGhostState(t, pid, time.Now().Add(-10*time.Minute))
+
+	newPIDManagerForTest(repo).CheckPIDLiveness() // no SetInfraReaper
+
+	if repo.states["ghost"] == nil {
+		t.Fatal("without an infra reaper the live-PID working session must be kept (pre-Fix-B behavior)")
+	}
 }
 
 // TestSeedAlivePIDs_DeletesWhenCWDMissing is the seed-time half of issue

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -307,6 +307,14 @@ func (d *SessionDetector) SetLauncherEnvReader(fn LauncherEnvReader) {
 	d.pidMgr.SetLauncherEnvReader(fn)
 }
 
+// SetInfraReaper installs the liveness-sweep seam that reaps a session bound to
+// a still-alive PID which is actually the adapter's background infrastructure
+// (e.g. Claude Code's --bg-spare helper) rather than the session (#727). Both
+// args nil disables the check. Call before Run.
+func (d *SessionDetector) SetInfraReaper(excluders map[string]func([]string) bool, readArgv func(pid int) []string) {
+	d.pidMgr.SetInfraReaper(excluders, readArgv)
+}
+
 // SetConsentGate installs the per-adapter observe-consent check (#570).
 // Call before Run. Production wires PermissionService.ObserveGranted; nil
 // (the default) allows everything.

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -537,6 +537,14 @@ func main() {
 		}
 		return processlifecycle.ReadLauncherEnv(pid)
 	})
+	// Let the liveness sweep reap a session bound to a still-alive PID that is
+	// the adapter's background infra rather than the session — Claude Code's
+	// --bg-spare pool helper outlives every session, so a mis-bound session
+	// would otherwise never be reaped (#727). Demo mode never tracks live
+	// processes, so leave the reaper unwired there.
+	if !demoMode {
+		detector.SetInfraReaper(agents.ArgvExcluders(allAgents), processlifecycle.ReadArgv)
+	}
 	// Consent gate for the detector's own transcript reads (startup seed +
 	// stale-working refresh of PERSISTED sessions) — the watcher pipeline
 	// is gated by construction, but these two paths read repo-listed


### PR DESCRIPTION
## Problem

Irrlicht shows sessions as **active** after the agent has exited (#727). Reproduced from live state — ghost session `8bd7ed5d` (adapter `claude-code`, state `working`) was bound to **PID 9141, a long-lived `claude … --bg-spare …claim.sock` background-pool helper**, not the interactive session process. The real session ended ~28h ago (transcript cold, `updated_at == first_seen`), but the `--bg-spare` helper stays alive for days, so `syscall.Kill(9141, 0)` keeps succeeding and the liveness sweep never reaps the session.

## Root cause

`claudecode.DiscoverPID`'s CWD fallback called `processlifecycle.DiscoverPIDByCWD`, which applies **no argv filter**. The adapter declares `ExcludeArgv: IsInfraArgv` (which correctly rejects `--bg-spare` / `--bg-pty-host` / `daemon run`), but that predicate was only ever honored by the **Scanner** (proc-* pre-sessions), never by **PID discovery**.

Not a regression from recent releases (relay/macOS commits don't touch discovery) — a long-standing gap exposed by Claude Code 2.1.168+ spawning a `--bg-spare` pool in the session's cwd.

## Fix

**Fix A — root cause.** New `DiscoverPIDByCWDExcludingArgv` (name-based mirror of the cmdline `…ExcludingArgv` variant gemini-cli already uses for its heap-bump worker, #664); claude-code's `discoverByCWD` now passes `IsInfraArgv`. New mis-bindings can no longer happen.

**Fix B — self-healing.** The liveness sweep (`CheckPIDLiveness`) now re-validates a still-alive bound PID against the adapter's `ExcludeArgv` (new `PIDManager.SetInfraReaper` seam + `agents.ArgvExcluders` + `processlifecycle.ReadArgv`). A session bound to infra is reaped **only behind both stale-transcript AND stale-UpdatedAt guards**, so a genuinely active session — including one blocked on a permission prompt, which is bound to the *real* `claude` PID — is never reaped. This:
- clears **already-persisted** ghosts without a restart (seed-time trusts the stored PID, so Fix A alone wouldn't), and
- self-heals if a future Claude Code release adds a new `--bg-*` flag (the denylist-gap class `claudecode/process.go` warns about).

## Scope

- **Not affected:** `codex` (`DiscoverPIDByTranscriptWriter` — a bg-spare doesn't hold the codex transcript open), `kirocli` / `pi` / `opencode` (no infra pool).
- **Separate follow-up:** #727's *antigravity* ghost is a distinct transcript-first `PID==0` reaping path, not this bug — tracked separately.

## Verification

- 7 new tests (Fix A: name-based argv exclusion + nil-argv contract; Fix B: ghost-bound-to-infra reaped, fresh transcript kept, real argv kept, nil argv kept, no-reaper-wired no-op). `go test ./core/... -race -count=1` green.
- Read-only confirmation against the live ghost: PID 9141 still `--bg-spare`, session still `working`/`claude-code`, transcript + `updated_at` both ~28h stale → `isBoundToInfra` returns true → reaped on the first sweep after deploy (no restart / manual delete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)