### PR TITLE
fix(detector): age out antigravity PID==0 ghost sessions (#735)

### DIFF
--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -428,21 +428,19 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 		}
 	}
 
-	// A PID==0 session is transcript-first — discovered from its on-disk
-	// transcript with no agent process to liveness-check (an Antigravity IDE
-	// conversation is the canonical case). Its transcript can be a system log
-	// that keeps appending SYSTEM steps (CONVERSATION_HISTORY/CHECKPOINT, all
-	// parsed as Skip=true) after the agent has stopped, so the raw byte-growth
-	// check above stays true and re-bumps UpdatedAt to wall-clock "now" on every
-	// refresh tick. now-UpdatedAt then never crosses readyTTL, the PID==0 sweep
-	// (PIDManager.CheckPIDLiveness) can never reap it, and the session lingers as
-	// a ghost until a daemon restart (issue #735). When this pass consumed only
-	// non-substantive lines, treat it as no growth so UpdatedAt can go stale and
-	// the session ages out the same way a dead-process one does (see
-	// TestCheckPIDLiveness_DeadProcessWorking_Reaped). Scoped to PID==0: a
-	// PID-bound session is reaped by process liveness instead, and keeps the
-	// activity bump for noisy post-turn recaps so its "last activity" stays fresh
-	// (issue #329).
+	// Extend the #667 byte-growth suppression above to a second ghost shape. A
+	// PID==0 session is transcript-first — discovered from its on-disk transcript
+	// with no agent process to liveness-check (an Antigravity IDE conversation is
+	// the canonical case). Its transcript can be a system log that keeps appending
+	// SYSTEM steps (CONVERSATION_HISTORY/CHECKPOINT, all parsed Skip=true) after
+	// the agent stopped, so #667's size check stays true and re-bumps UpdatedAt
+	// forever — now-UpdatedAt never crosses readyTTL and the PID==0 sweep
+	// (PIDManager.CheckPIDLiveness) can never reap it (issue #735). When this pass
+	// consumed only non-substantive lines, treat it as no growth so it ages out
+	// like a dead-process session (see TestCheckPIDLiveness_DeadProcessWorking_Reaped).
+	// Scoped to PID==0: a PID-bound session is reaped by process liveness instead,
+	// and keeps the activity bump for noisy post-turn recaps so its "last activity"
+	// stays fresh (issue #329).
 	if state.PID == 0 && state.Metrics != nil && state.Metrics.NoSubstantiveActivity {
 		transcriptGrew = false
 	}

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -428,6 +428,25 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 		}
 	}
 
+	// A PID==0 session is transcript-first — discovered from its on-disk
+	// transcript with no agent process to liveness-check (an Antigravity IDE
+	// conversation is the canonical case). Its transcript can be a system log
+	// that keeps appending SYSTEM steps (CONVERSATION_HISTORY/CHECKPOINT, all
+	// parsed as Skip=true) after the agent has stopped, so the raw byte-growth
+	// check above stays true and re-bumps UpdatedAt to wall-clock "now" on every
+	// refresh tick. now-UpdatedAt then never crosses readyTTL, the PID==0 sweep
+	// (PIDManager.CheckPIDLiveness) can never reap it, and the session lingers as
+	// a ghost until a daemon restart (issue #735). When this pass consumed only
+	// non-substantive lines, treat it as no growth so UpdatedAt can go stale and
+	// the session ages out the same way a dead-process one does (see
+	// TestCheckPIDLiveness_DeadProcessWorking_Reaped). Scoped to PID==0: a
+	// PID-bound session is reaped by process liveness instead, and keeps the
+	// activity bump for noisy post-turn recaps so its "last activity" stays fresh
+	// (issue #329).
+	if state.PID == 0 && state.Metrics != nil && state.Metrics.NoSubstantiveActivity {
+		transcriptGrew = false
+	}
+
 	// Probe Bash background-process liveness (run_in_background). Must run
 	// after RefreshOnActivity (which recomputes metrics, clearing the flag)
 	// and before ClassifyState (whose IsAgentDone check reads it). Gated on

--- a/core/application/services/session_detector_dead_process_test.go
+++ b/core/application/services/session_detector_dead_process_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -108,5 +109,123 @@ func TestSessionDetector_Activity_FrozenTranscript_DoesNotBumpUpdatedAt(t *testi
 	waitForCondition(func() bool { return repo.eventCountOf("gem") == 2 }, 2*time.Second)
 	if got := repo.eventCountOf("gem"); got != 2 {
 		t.Fatalf("grown transcript after freeze: EventCount = %d, want 2", got)
+	}
+}
+
+// TestSessionDetector_Activity_PID0_NonSubstantiveGrowth_DoesNotBumpUpdatedAt is
+// the regression test for issue #735. An Antigravity IDE conversation is
+// transcript-first (PID==0). Its transcript is a system log that keeps appending
+// SYSTEM steps (CONVERSATION_HISTORY/CHECKPOINT — the parser marks them Skip=true)
+// after the agent has stopped, so the file keeps growing with no agent turn.
+// Raw byte growth used to re-bump UpdatedAt to wall-clock "now" on every refresh
+// tick, so now-UpdatedAt never crossed readyTTL and the PID==0 liveness sweep
+// could never reap the session — it lingered as a ghost until a daemon restart.
+//
+// The fix gates the activity bump on substantive parse activity for PID==0
+// sessions: a pass that consumed only skipped lines (NoSubstantiveActivity) must
+// leave UpdatedAt and EventCount untouched even though the file grew, so the
+// session can age out via the existing PID==0 sweep (which
+// TestCheckPIDLiveness_DeadProcessWorking_Reaped covers). A pass carrying a real
+// agent event still bumps.
+func TestSessionDetector_Activity_PID0_NonSubstantiveGrowth_DoesNotBumpUpdatedAt(t *testing.T) {
+	dir := t.TempDir()
+	tp := filepath.Join(dir, "transcript.jsonl")
+	if err := os.WriteFile(tp, []byte("{\"source\":\"MODEL\",\"type\":\"RUN_COMMAND\"}\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	// funcMetrics simulates the Antigravity tailer: the `substantive` flag drives
+	// NoSubstantiveActivity, mirroring the real parser (real agent lines are
+	// substantive; SYSTEM-log noise is Skip=true → non-substantive). LastEventType
+	// stays mid-turn (function_call_output) so the session remains working — the
+	// stuck-ghost shape — and no state transition muddies UpdatedAt.
+	var substantive atomic.Bool
+	substantive.Store(true)
+	fm := &funcMetrics{fn: func(path, adapter string) (*session.SessionMetrics, error) {
+		return &session.SessionMetrics{
+			LastEventType:         "function_call_output",
+			NoSubstantiveActivity: !substantive.Load(),
+		}, nil
+	}}
+
+	tw := newMockAgentWatcher().withIdentity(agent.Identity{Name: "antigravity"})
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	det := newDetectorWithMetrics(tw, pw, repo, fm)
+
+	// Antigravity IDE ghost shape: working, pid=0. LastTranscriptSize=0 so the
+	// first activity pass sees growth.
+	oldTs := time.Now().Add(-time.Hour).Unix()
+	repo.states["agy"] = &session.SessionState{
+		SessionID:          "agy",
+		Adapter:            "antigravity",
+		State:              session.StateWorking,
+		PID:                0,
+		TranscriptPath:     tp,
+		FirstSeen:          oldTs,
+		UpdatedAt:          oldTs,
+		LastTranscriptSize: 0,
+		Metrics:            &session.SessionMetrics{LastEventType: "function_call_output"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	defer func() { cancel(); <-done }()
+
+	// Let seedFromDisk finish before injecting activity.
+	time.Sleep(50 * time.Millisecond)
+
+	activity := func() agent.Event {
+		return agent.Event{Type: agent.EventActivity, SessionID: "agy", TranscriptPath: tp, Terminal: true}
+	}
+	appendLine := func(s string) {
+		f, err := os.OpenFile(tp, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			t.Fatalf("open transcript for append: %v", err)
+		}
+		if _, err := f.WriteString(s); err != nil {
+			t.Fatalf("append transcript: %v", err)
+		}
+		_ = f.Close()
+	}
+
+	// Pass A — a real agent event grew the transcript: UpdatedAt and EventCount bump.
+	substantive.Store(true)
+	appendLine("{\"source\":\"USER_EXPLICIT\",\"type\":\"USER_INPUT\"}\n")
+	tw.ch <- activity()
+	waitForCondition(func() bool { return repo.eventCountOf("agy") == 1 }, 2*time.Second)
+	if got := repo.eventCountOf("agy"); got != 1 {
+		t.Fatalf("substantive growth: EventCount = %d, want 1", got)
+	}
+	tsA := repo.updatedAtOf("agy")
+	if tsA <= oldTs {
+		t.Fatalf("substantive growth did not advance UpdatedAt: got %d, want > %d", tsA, oldTs)
+	}
+
+	// Pass B — the transcript GREW (size changes) but only with skipped SYSTEM-log
+	// noise (NoSubstantiveActivity). The bump must be suppressed so UpdatedAt can
+	// age out. This is the #735 regression: before the fix, byte growth bumped
+	// UpdatedAt here and pinned the session perpetually fresh.
+	substantive.Store(false)
+	appendLine("{\"source\":\"SYSTEM\",\"type\":\"CONVERSATION_HISTORY\"}\n")
+	savesBefore := repo.savesCount()
+	tw.ch <- activity()
+	waitForCondition(func() bool { return repo.savesCount() > savesBefore }, 2*time.Second)
+	if got := repo.eventCountOf("agy"); got != 1 {
+		t.Fatalf("noise-only growth bumped EventCount: got %d, want 1 (unchanged)", got)
+	}
+	if got := repo.updatedAtOf("agy"); got != tsA {
+		t.Fatalf("noise-only growth bumped UpdatedAt: got %d, want %d (unchanged)", got, tsA)
+	}
+
+	// Pass C — a real agent event again: bumping resumes.
+	substantive.Store(true)
+	appendLine("{\"source\":\"MODEL\",\"type\":\"RUN_COMMAND\"}\n")
+	tw.ch <- activity()
+	waitForCondition(func() bool { return repo.eventCountOf("agy") == 2 }, 2*time.Second)
+	if got := repo.eventCountOf("agy"); got != 2 {
+		t.Fatalf("substantive growth after noise: EventCount = %d, want 2", got)
 	}
 }

--- a/core/application/services/session_detector_dead_process_test.go
+++ b/core/application/services/session_detector_dead_process_test.go
@@ -12,6 +12,21 @@ import (
 	"irrlicht/core/domain/session"
 )
 
+// appendTranscriptLine appends one line to the transcript at path, failing the
+// test on any I/O error. Used by the refresh-pass tests to grow a transcript
+// between activity events.
+func appendTranscriptLine(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open transcript for append: %v", err)
+	}
+	if _, err := f.WriteString(line); err != nil {
+		t.Fatalf("append transcript: %v", err)
+	}
+	_ = f.Close()
+}
+
 // TestSessionDetector_Activity_FrozenTranscript_DoesNotBumpUpdatedAt is the
 // regression test for issue #667. A gemini-cli session whose process died
 // mid-turn (pid=0, transcript frozen on a function_call_output) stays working,
@@ -96,14 +111,7 @@ func TestSessionDetector_Activity_FrozenTranscript_DoesNotBumpUpdatedAt(t *testi
 	}
 
 	// Pass C — append new bytes, then refresh: bumping must resume.
-	f, err := os.OpenFile(tp, os.O_APPEND|os.O_WRONLY, 0o644)
-	if err != nil {
-		t.Fatalf("open transcript for append: %v", err)
-	}
-	if _, err := f.WriteString("{\"type\":\"assistant\"}\n"); err != nil {
-		t.Fatalf("append transcript: %v", err)
-	}
-	_ = f.Close()
+	appendTranscriptLine(t, tp, "{\"type\":\"assistant\"}\n")
 
 	tw.ch <- activity()
 	waitForCondition(func() bool { return repo.eventCountOf("gem") == 2 }, 2*time.Second)
@@ -180,20 +188,10 @@ func TestSessionDetector_Activity_PID0_NonSubstantiveGrowth_DoesNotBumpUpdatedAt
 	activity := func() agent.Event {
 		return agent.Event{Type: agent.EventActivity, SessionID: "agy", TranscriptPath: tp, Terminal: true}
 	}
-	appendLine := func(s string) {
-		f, err := os.OpenFile(tp, os.O_APPEND|os.O_WRONLY, 0o644)
-		if err != nil {
-			t.Fatalf("open transcript for append: %v", err)
-		}
-		if _, err := f.WriteString(s); err != nil {
-			t.Fatalf("append transcript: %v", err)
-		}
-		_ = f.Close()
-	}
 
 	// Pass A — a real agent event grew the transcript: UpdatedAt and EventCount bump.
 	substantive.Store(true)
-	appendLine("{\"source\":\"USER_EXPLICIT\",\"type\":\"USER_INPUT\"}\n")
+	appendTranscriptLine(t, tp, "{\"source\":\"USER_EXPLICIT\",\"type\":\"USER_INPUT\"}\n")
 	tw.ch <- activity()
 	waitForCondition(func() bool { return repo.eventCountOf("agy") == 1 }, 2*time.Second)
 	if got := repo.eventCountOf("agy"); got != 1 {
@@ -209,7 +207,7 @@ func TestSessionDetector_Activity_PID0_NonSubstantiveGrowth_DoesNotBumpUpdatedAt
 	// age out. This is the #735 regression: before the fix, byte growth bumped
 	// UpdatedAt here and pinned the session perpetually fresh.
 	substantive.Store(false)
-	appendLine("{\"source\":\"SYSTEM\",\"type\":\"CONVERSATION_HISTORY\"}\n")
+	appendTranscriptLine(t, tp, "{\"source\":\"SYSTEM\",\"type\":\"CONVERSATION_HISTORY\"}\n")
 	savesBefore := repo.savesCount()
 	tw.ch <- activity()
 	waitForCondition(func() bool { return repo.savesCount() > savesBefore }, 2*time.Second)
@@ -222,7 +220,7 @@ func TestSessionDetector_Activity_PID0_NonSubstantiveGrowth_DoesNotBumpUpdatedAt
 
 	// Pass C — a real agent event again: bumping resumes.
 	substantive.Store(true)
-	appendLine("{\"source\":\"MODEL\",\"type\":\"RUN_COMMAND\"}\n")
+	appendTranscriptLine(t, tp, "{\"source\":\"MODEL\",\"type\":\"RUN_COMMAND\"}\n")
 	tw.ch <- activity()
 	waitForCondition(func() bool { return repo.eventCountOf("agy") == 2 }, 2*time.Second)
 	if got := repo.eventCountOf("agy"); got != 2 {

--- a/core/application/services/session_detector_no_substantive_test.go
+++ b/core/application/services/session_detector_no_substantive_test.go
@@ -32,10 +32,18 @@ func TestSessionDetector_Activity_NoSubstantiveActivity_HoldsState(t *testing.T)
 	// Session in ready with a fully-formed prior turn — these metrics would
 	// satisfy the force-bounce predicate (LastEventType != "") if the
 	// short-circuit didn't apply.
+	//
+	// PID is set non-zero: #329's real scenario is a Claude Code session (which
+	// is PID-bound) emitting a post-turn `system/away_summary` recap, so it keeps
+	// the UI-freshness activity bump on a non-substantive pass. A PID==0
+	// transcript-first session (Antigravity IDE) intentionally suppresses that
+	// bump so it can age out — see #735 and
+	// TestSessionDetector_Activity_PID0_NonSubstantiveGrowth_DoesNotBumpUpdatedAt.
 	beforeUpdate := time.Now().Add(-10 * time.Second).Unix()
 	repo.states["away1"] = &session.SessionState{
 		SessionID:      "away1",
 		State:          session.StateReady,
+		PID:            4242,
 		TranscriptPath: "/home/.claude/projects/-Users-test/away1.jsonl",
 		FirstSeen:      time.Now().Unix(),
 		UpdatedAt:      beforeUpdate,

--- a/core/application/services/session_detector_no_substantive_test.go
+++ b/core/application/services/session_detector_no_substantive_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -39,11 +40,17 @@ func TestSessionDetector_Activity_NoSubstantiveActivity_HoldsState(t *testing.T)
 	// transcript-first session (Antigravity IDE) intentionally suppresses that
 	// bump so it can age out — see #735 and
 	// TestSessionDetector_Activity_PID0_NonSubstantiveGrowth_DoesNotBumpUpdatedAt.
+	//
+	// Use this process's own (live) PID, not an arbitrary literal: the
+	// SweepDeadPIDs goroutine's CheckPIDLiveness reaps any pid>0 whose
+	// syscall.Kill(pid,0) returns ESRCH, and that branch is not readyTTL-gated.
+	// A dead literal would let a sweep tick delete away1 mid-test and nil-panic
+	// the post-cancel Load; a live PID is never reaped.
 	beforeUpdate := time.Now().Add(-10 * time.Second).Unix()
 	repo.states["away1"] = &session.SessionState{
 		SessionID:      "away1",
 		State:          session.StateReady,
-		PID:            4242,
+		PID:            os.Getpid(),
 		TranscriptPath: "/home/.claude/projects/-Users-test/away1.jsonl",
 		FirstSeen:      time.Now().Unix(),
 		UpdatedAt:      beforeUpdate,


### PR DESCRIPTION
## Summary

Fixes #735 — antigravity (transcript-first, PID==0) ghost sessions that persist in the active list after the agent/IDE exits, only clearing on a daemon restart.

Follow-up to #727/#734 (the *claude-code* `--bg-spare` ghost). This is a **different mechanism**: there is no process to liveness-check, so the #734 infra-PID re-validation doesn't apply.

## Root cause (confirmed in code)

`processActivityLocked` measures activity as raw transcript **byte growth** (`fi.Size() != state.LastTranscriptSize`) and bumps `UpdatedAt` on it. Antigravity's transcript is a `…/.system_generated/logs/transcript.jsonl` **system log** whose `SYSTEM` steps (`CONVERSATION_HISTORY`/`CHECKPOINT` — the parser marks them `Skip=true`) keep appending after the agent stops. So byte growth pinned `UpdatedAt` perpetually fresh, and the PID==0 `readyTTL` sweep in `CheckPIDLiveness` could never reap it.

## Fix (surgical, scoped to PID==0)

One gate in `session_detector_activity.go`:

```go
if state.PID == 0 && state.Metrics != nil && state.Metrics.NoSubstantiveActivity {
    transcriptGrew = false
}
```

`NoSubstantiveActivity` (`tailer.go` = `linesParsed>0 && !substantive`) already means *exactly* "the file grew but only with skipped/noise lines", and is already computed and consumed in this same function. With the bump suppressed, `UpdatedAt` goes stale and the **existing** PID==0 sweep reaps the ghost — the end-state already covered by `TestCheckPIDLiveness_DeadProcessWorking_Reaped`. No new field, no fingerprint, no parser change.

## Reconciliation with #329

#329 *deliberately* bumps `UpdatedAt` on non-substantive passes (UI "last activity" freshness for Claude Code's `system/away_summary` recap). That's a PID-bound scenario, so scoping the fix to PID==0 preserves it. The #329 test's `away1` session is updated to `PID>0` to reflect its real (PID-bound) shape; all its assertions still hold.

## Caveat

The reporter's live diagnostic bundle was lost to a reboot (see #727), so the bug is not currently reproducible. This is a **defensive fix validated by a synthetic regression test**. It assumes the noise lines parse as `Skip=true` (true for antigravity SYSTEM steps); if a future bundle shows otherwise, the activity signal would need refining — but the root mechanism is confirmed in code.

## Testing

- New `TestSessionDetector_Activity_PID0_NonSubstantiveGrowth_DoesNotBumpUpdatedAt` — verified it **fails without** the fix and passes with it.
- `go test ./core/... -race -count=1` ✓ · onboarding-factory ✓ · `replay-fixtures.sh` ✓ · `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
