### PR TITLE
feat(focus): generic GUI-host fallback for click-to-focus (#728)

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/hosts_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/hosts_darwin.go
@@ -63,3 +63,35 @@ func termProgramForAppPath(cmdPath string) string {
 	appName := filepath.Base(head)
 	return termProgramByAppName[appName]
 }
+
+// topLevelAppPath returns the path of the top-level application bundle whose
+// main executable is cmdPath, or "" when cmdPath is not the main executable of
+// a real top-level `.app`. It backs the generic host fallback (for embedded
+// terminals whose host isn't in termProgramByAppName, e.g. Obsidian).
+//
+// "Top-level" means the `.app` that directly wraps the executable
+// (`<App>.app/Contents/MacOS/<binary>`) is NOT itself nested inside another
+// `.app`, a `.framework`, or a `Contents/Frameworks/` directory. That nesting
+// test is what rejects the two ancestors a naive walk would wrongly latch onto:
+//   - Electron helper processes — `Foo.app/Contents/Frameworks/Foo Helper.app/...`
+//   - framework-embedded interpreters — a Python PTY helper at
+//     `Xcode.app/.../Python3.framework/.../Python.app/...`
+//
+// Neither is the GUI app a click should bring forward, so both return "" and
+// the ancestry walk continues to the real owner. (termProgramForAppPath keys
+// off the *first* `.app/` instead, which is correct for curated hosts because
+// the map only matches known top-level apps.)
+func topLevelAppPath(cmdPath string) string {
+	const marker = ".app/Contents/MacOS/"
+	idx := strings.Index(cmdPath, marker)
+	if idx < 0 {
+		return ""
+	}
+	prefix := cmdPath[:idx] // everything up to (not including) the wrapping ".app"
+	if strings.Contains(prefix, ".app/") ||
+		strings.Contains(prefix, ".framework/") ||
+		strings.Contains(prefix, "Contents/Frameworks/") {
+		return ""
+	}
+	return cmdPath[:idx+len(".app")]
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -128,6 +128,15 @@ func ReadLauncherEnv(pid int) *session.Launcher {
 	if l.TermProgram == "" {
 		l.TermProgram, _ = ancestry()
 	}
+	// Generic host fallback: when no curated host matched (TermProgram still
+	// empty), resolve the first top-level `.app` ancestor's bundle id so the
+	// client can bring an embedded-terminal GUI host (e.g. Obsidian) to the
+	// front without a per-app registry entry. Purely additive — it only runs
+	// on a map miss, so every curated host keeps its exact behavior. Darwin-
+	// only; other platforms return "" and this is a no-op.
+	if l.TermProgram == "" {
+		l.HostBundleID, _ = resolveHostBundleIDFromAncestry(pid)
+	}
 	// Back-fill kitty fields for sessions whose own env is unreadable
 	// (Apple-signed agents like `pi`, hardened-runtime binaries). If kitty
 	// is the host per ancestry walk but env yielded no kitty signals,

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -90,6 +90,60 @@ func resolveHostFromAncestry(pid int) (termProgram string, hostPID int) {
 	return "", 0
 }
 
+// bundleIDForAppPath returns the CFBundleIdentifier of the application bundle
+// at appPath (".../<App>.app"), or "" when it can't be read. Uses `plutil`,
+// which ships with macOS and reads both XML and binary Info.plists; bundles
+// under /Applications are world-readable so this needs no TCC consent. Same
+// bounded 2-second exec ceiling as the sibling ps helpers.
+func bundleIDForAppPath(appPath string) string {
+	if appPath == "" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	plist := appPath + "/Contents/Info.plist"
+	out, err := exec.CommandContext(ctx, "plutil", "-extract", "CFBundleIdentifier", "raw", "-o", "-", plist).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// resolveHostBundleIDFromAncestry walks the parent-process chain of pid and
+// returns the CFBundleIdentifier of the first top-level application bundle it
+// finds, plus that app's PID. It is the generic fallback used when the curated
+// termProgramByAppName map matches no ancestor — it lets the UI bring an
+// embedded-terminal GUI host (e.g. Obsidian) to the front without a per-app
+// registry entry. Returns ("", 0) when no top-level app appears within
+// maxAncestry levels.
+//
+// The walk starts at pid's *parent*: the agent runs inside the host and is
+// never the host itself, and an agent whose own binary lives in a top-level
+// bundle (e.g. ClaudeCode.app) must not be mistaken for it.
+func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int) {
+	ppid, _, err := readProcInfo(pid)
+	if err != nil || ppid <= 1 {
+		return "", 0
+	}
+	cur := ppid
+	for i := 0; i < maxAncestry && cur > 1; i++ {
+		pp, cmd, err := readProcInfo(cur)
+		if err != nil {
+			return "", 0
+		}
+		if appPath := topLevelAppPath(cmd); appPath != "" {
+			if bid := bundleIDForAppPath(appPath); bid != "" {
+				return bid, cur
+			}
+		}
+		if pp == cur || pp <= 1 {
+			return "", 0
+		}
+		cur = pp
+	}
+	return "", 0
+}
+
 // resolveTermProgramFromAncestry is a thin wrapper that discards the host
 // PID. Kept for the existing call site that only cares whether kitty (or any
 // other host) appears in the chain; callers that also need the host PID

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 )
@@ -252,6 +253,51 @@ func TestTermProgramForAppPath(t *testing.T) {
 		if got := termProgramForAppPath(tc.in); got != tc.want {
 			t.Errorf("termProgramForAppPath(%q): got %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestTopLevelAppPath(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		// Real top-level apps: the wrapping .app is not nested.
+		{"obsidian main", "/Applications/Obsidian.app/Contents/MacOS/Obsidian", "/Applications/Obsidian.app"},
+		{"vscode main", "/Applications/Visual Studio Code.app/Contents/MacOS/Code", "/Applications/Visual Studio Code.app"},
+		{"iterm", "/Applications/iTerm.app/Contents/MacOS/iTerm2", "/Applications/iTerm.app"},
+		{"user-dir app", "/Users/ingo/Applications/GoLand.app/Contents/MacOS/goland", "/Users/ingo/Applications/GoLand.app"},
+		// Electron helper: wrapping .app sits inside Contents/Frameworks — skip.
+		{"obsidian renderer helper", "/Applications/Obsidian.app/Contents/Frameworks/Obsidian Helper (Renderer).app/Contents/MacOS/Obsidian Helper (Renderer)", ""},
+		{"vscode code helper", "/Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper", ""},
+		// Framework-embedded interpreter (the ghostty-terminal Python PTY
+		// helper): wrapping .app sits inside a .framework — skip, even though
+		// the outer Xcode.app and inner Python.app are both real GUI bundles.
+		{"python in xcode framework", "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/Resources/Python.app/Contents/MacOS/Python", ""},
+		// Not the main executable of a bundle: no .app/Contents/MacOS/ marker.
+		{"resources binary", "/Applications/Obsidian.app/Contents/Resources/helper", ""},
+		{"plain shell", "/bin/zsh", ""},
+		{"versioned binary", "/Users/ingo/.local/share/claude/versions/2.1.114", ""},
+		{"app-like fragment", "/tmp/not.appended/bin/thing", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range tests {
+		if got := topLevelAppPath(tc.in); got != tc.want {
+			t.Errorf("%s: topLevelAppPath(%q) = %q, want %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestResolveHostBundleIDFromAncestry_Self walks the ancestry of the running
+// test binary. We don't know what launched the developer's `go test`, so we
+// only assert the helper returns cleanly — a plausibly-shaped bundle id (it
+// contains a dot) or "" — never errors or panics. The deterministic path
+// logic is covered by TestTopLevelAppPath.
+func TestResolveHostBundleIDFromAncestry_Self(t *testing.T) {
+	bid, hostPID := resolveHostBundleIDFromAncestry(os.Getpid())
+	if bid == "" {
+		return // no top-level .app ancestor (e.g. CI/tmux/ssh) — valid.
+	}
+	if !strings.Contains(bid, ".") || hostPID <= 1 {
+		t.Errorf("resolveHostBundleIDFromAncestry = (%q, %d); want a dotted bundle id and a real host PID", bid, hostPID)
 	}
 }
 

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -37,8 +37,9 @@ func processTTY(pid int) string { return "" }
 // resolveTermProgramFromAncestry / resolveHostFromAncestry are darwin-only
 // fallbacks for hardened-runtime processes that hide env from sysctl. Linux
 // reads /proc/<pid>/environ directly, so these stubs are unused.
-func resolveTermProgramFromAncestry(pid int) string           { return "" }
-func resolveHostFromAncestry(pid int) (term string, host int) { return "", 0 }
+func resolveTermProgramFromAncestry(pid int) string                       { return "" }
+func resolveHostFromAncestry(pid int) (term string, host int)             { return "", 0 }
+func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int) { return "", 0 }
 
 // Stubs for the kitty "no readable env" enrichment helpers. Linux can read
 // /proc/<pid>/environ for any process the user owns, so the back-fill path

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -13,8 +13,9 @@ func processTTY(pid int) string { return "" }
 
 // resolveTermProgramFromAncestry / resolveHostFromAncestry are darwin-only
 // fallbacks; other platforms return zero values.
-func resolveTermProgramFromAncestry(pid int) string           { return "" }
-func resolveHostFromAncestry(pid int) (term string, host int) { return "", 0 }
+func resolveTermProgramFromAncestry(pid int) string                       { return "" }
+func resolveHostFromAncestry(pid int) (term string, host int)             { return "", 0 }
+func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int) { return "", 0 }
 
 // Stubs for the kitty "no readable env" enrichment helpers — darwin-only.
 func kittyAncestryPID(pid int) int                             { return 0 }

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -647,6 +647,7 @@ type Launcher struct {
 	KittyListenOn  string `json:"kitty_listen_on,omitempty"`  // $KITTY_LISTEN_ON — kitty remote-control socket path
 	KittyWindowID  string `json:"kitty_window_id,omitempty"`  // $KITTY_WINDOW_ID — kitty window identifier
 	KittyPID       int    `json:"kitty_pid,omitempty"`        // $KITTY_PID — kitty.app process id (lets the activator target this specific instance when multiple kitties run)
+	HostBundleID   string `json:"host_bundle_id,omitempty"`   // CFBundleIdentifier of the host app resolved by process-ancestry when no curated TermProgram matched (e.g. md.obsidian for an in-Obsidian terminal). Unlike TermProgram, this is derived server-side because the client has no map for arbitrary embedded-terminal hosts; the client builds a generic title-match activator from it.
 }
 
 // IsEmpty reports whether the launcher carries no identifying information
@@ -656,7 +657,8 @@ func (l *Launcher) IsEmpty() bool {
 	return l == nil || (l.TermProgram == "" && l.ITermSessionID == "" &&
 		l.TermSessionID == "" && l.TmuxPane == "" &&
 		l.TmuxSocket == "" && l.VSCodePID == 0 && l.TTY == "" &&
-		l.KittyListenOn == "" && l.KittyWindowID == "" && l.KittyPID == 0)
+		l.KittyListenOn == "" && l.KittyWindowID == "" && l.KittyPID == 0 &&
+		l.HostBundleID == "")
 }
 
 // SessionState represents the current state of a Claude Code or Copilot session.

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -635,7 +635,10 @@ func (s *subagentSummary) Equal(o *subagentSummary) bool {
 //
 // TermProgram is the primary identifier; clients map it to a platform-native
 // activator (e.g. the macOS menu-bar app derives an app bundle ID from it).
-// Keeping that derivation client-side avoids persisting redundant state.
+// Keeping that derivation client-side avoids persisting redundant state. The
+// exception is HostBundleID: when no curated TermProgram matches, the daemon
+// resolves the host bundle id by process ancestry (which the client can't do)
+// and carries it here.
 type Launcher struct {
 	TermProgram    string `json:"term_program,omitempty"`     // $TERM_PROGRAM (e.g. iTerm.app, Apple_Terminal, vscode, cursor, ghostty, WezTerm, Hyper)
 	ITermSessionID string `json:"iterm_session_id,omitempty"` // $ITERM_SESSION_ID

--- a/core/domain/session/session_test.go
+++ b/core/domain/session/session_test.go
@@ -374,6 +374,24 @@ func TestSessionState_LauncherJSONRoundTrip(t *testing.T) {
 		t.Errorf("launcher round-trip mismatch: %+v", out.Launcher)
 	}
 
+	// Generic host fallback: only HostBundleID set (e.g. an in-Obsidian
+	// terminal where no curated TermProgram matched). IsEmpty must keep it.
+	generic := &Launcher{HostBundleID: "md.obsidian"}
+	if generic.IsEmpty() {
+		t.Error("launcher with only HostBundleID should not be empty")
+	}
+	gdata, err := json.Marshal(&SessionState{SessionID: "obs", State: StateWorking, Launcher: generic})
+	if err != nil {
+		t.Fatalf("marshal generic: %v", err)
+	}
+	var gout SessionState
+	if err := json.Unmarshal(gdata, &gout); err != nil {
+		t.Fatalf("unmarshal generic: %v", err)
+	}
+	if gout.Launcher == nil || gout.Launcher.HostBundleID != "md.obsidian" {
+		t.Errorf("host_bundle_id lost in round-trip: %+v", gout.Launcher)
+	}
+
 	// Without Launcher — backwards compat with pre-170 session JSON files.
 	legacy := []byte(`{"session_id":"xyz","state":"ready","pid":99}`)
 	var legacyOut SessionState

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -45,20 +45,31 @@ enum SessionLauncher {
     /// Safe to call on the main thread — activators dispatch any blocking
     /// work themselves.
     static func jump(_ session: SessionState) {
-        guard let tp = session.launcher?.termProgram else {
-            logger.info("no launcher for session \(session.id, privacy: .public)")
+        guard let activator = resolveActivator(for: session.launcher) else {
+            logger.info("no activator or host bundle id for session \(session.id, privacy: .public)")
             return
         }
-        guard let base = activators.first(where: { $0.termProgram == tp }) else {
-            logger.info("no activator for term program \(tp, privacy: .public)")
-            return
-        }
-        // Wrap with TmuxActivator when the session lives inside a tmux pane
-        // so the correct pane is selected before the host window is raised.
-        let activator: HostActivator = session.launcher?.tmuxPane != nil
-            ? TmuxActivator(inner: base)
-            : base
         _ = activator.activate(session)
+    }
+
+    /// Selects the activator for a launcher without performing activation
+    /// (exposed for tests). A registered activator keyed by `term_program`
+    /// wins; otherwise a generic `AXTitleMatchActivator` built from the
+    /// daemon-resolved host bundle id handles embedded-terminal hosts that
+    /// have no registry entry (e.g. a terminal inside Obsidian) — bringing the
+    /// host app/window to the front, not a specific pane. The result is wrapped
+    /// in `TmuxActivator` when the session lives in a tmux pane so the correct
+    /// pane is selected before the host window is raised.
+    static func resolveActivator(for launcher: Launcher?) -> HostActivator? {
+        var base: HostActivator?
+        if let tp = launcher?.termProgram {
+            base = activators.first(where: { $0.termProgram == tp })
+        }
+        if base == nil, let bundleID = launcher?.hostBundleID, !bundleID.isEmpty {
+            base = AXTitleMatchActivator(termProgram: launcher?.termProgram ?? "", bundleID: bundleID)
+        }
+        guard let base = base else { return nil }
+        return launcher?.tmuxPane != nil ? TmuxActivator(inner: base) : base
     }
 
     /// Returns the macOS bundle ID for a `$TERM_PROGRAM` value, or nil

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -46,7 +46,9 @@ enum SessionLauncher {
     /// work themselves.
     static func jump(_ session: SessionState) {
         guard let activator = resolveActivator(for: session.launcher) else {
-            logger.info("no activator or host bundle id for session \(session.id, privacy: .public)")
+            let tp = session.launcher?.termProgram ?? "nil"
+            let bid = session.launcher?.hostBundleID ?? "nil"
+            logger.info("no activator for session \(session.id, privacy: .public) (term_program=\(tp, privacy: .public), host_bundle_id=\(bid, privacy: .public))")
             return
         }
         _ = activator.activate(session)

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -583,6 +583,11 @@ struct Launcher: Codable, Hashable {
     let kittyListenOn: String?
     let kittyWindowID: String?
     let kittyPID: Int?
+    /// CFBundleIdentifier of the host app the daemon resolved by process
+    /// ancestry when no curated `termProgram` matched (e.g. `md.obsidian` for a
+    /// terminal embedded in Obsidian). Lets `SessionLauncher` build a generic
+    /// title-match activator for hosts that have no registry entry.
+    let hostBundleID: String?
 
     enum CodingKeys: String, CodingKey {
         case termProgram    = "term_program"
@@ -594,6 +599,7 @@ struct Launcher: Codable, Hashable {
         case kittyListenOn  = "kitty_listen_on"
         case kittyWindowID  = "kitty_window_id"
         case kittyPID       = "kitty_pid"
+        case hostBundleID   = "host_bundle_id"
     }
 }
 

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -382,6 +382,34 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertNil(SessionLauncher.bundleID(for: "unknown-terminal"))
     }
 
+    // The generic host fallback (issue #728): when the daemon resolved a host
+    // bundle id by process ancestry (e.g. a terminal embedded in Obsidian) and
+    // no curated term_program matched, the launcher dispatches to a runtime
+    // AXTitleMatchActivator built from that bundle id. Also pins the
+    // host_bundle_id wire contract and the curated-host precedence.
+    func testResolveActivatorGenericHostBundleIDFallback() throws {
+        func launcher(_ json: String) throws -> Launcher {
+            try JSONDecoder().decode(Launcher.self, from: Data(json.utf8))
+        }
+
+        // Wire contract: host_bundle_id decodes onto hostBundleID.
+        let obsidian = try launcher(#"{"host_bundle_id":"md.obsidian"}"#)
+        XCTAssertEqual(obsidian.hostBundleID, "md.obsidian")
+
+        // No curated term_program → generic title-match activator on that bundle.
+        let generic = SessionLauncher.resolveActivator(for: obsidian)
+        XCTAssertTrue(generic is AXTitleMatchActivator)
+        XCTAssertEqual(generic?.bundleID, "md.obsidian")
+
+        // Curated host wins even when a host_bundle_id is also present.
+        let iterm = try launcher(#"{"term_program":"iTerm.app","host_bundle_id":"md.obsidian"}"#)
+        XCTAssertEqual(SessionLauncher.resolveActivator(for: iterm)?.bundleID, "com.googlecode.iterm2")
+
+        // Nothing identifying → no activator (silent no-op, as before).
+        XCTAssertNil(SessionLauncher.resolveActivator(for: try launcher("{}")))
+        XCTAssertNil(SessionLauncher.resolveActivator(for: nil))
+    }
+
     func testJetBrainsActivatorRunningBundleIDIsNilOrKnown() {
         let bid = JetBrainsActivator.runningBundleID()
         guard let bid else { return } // no IDE running — nothing to assert


### PR DESCRIPTION
Closes #728.

## Problem
Click-to-focus only recognized hosts in the curated `termProgramByAppName` allowlist. An agent running in an embedded terminal with no registry entry — e.g. a terminal inside Obsidian — resolved to nothing, so clicking the session row did nothing.

## Approach
A **generic fallback that fires only on a curated-map miss**, so it's purely additive — known hosts keep their exact behavior and this only turns today's silent no-ops into best-effort focus.

- **Daemon (Go):** when no curated `TermProgram` matched, walk the agent's ancestry (starting at its *parent*) for the first **top-level `.app`** — one whose executable is `<App>.app/Contents/MacOS/<exe>` and is *not* nested inside a `.framework`, `Contents/Frameworks`, or another `.app`. That nesting test rejects the two ancestors a naive walk would wrongly latch onto:
  - a framework-embedded interpreter (the ghostty-terminal Python PTY helper lives at `Xcode.app/.../Python3.framework/.../Python.app/...`)
  - Electron helper processes (`Foo.app/Contents/Frameworks/Foo Helper.app/...`)

  Its `CFBundleIdentifier` (read via `plutil`) is carried on `Launcher.HostBundleID`.
- **App (Swift):** `SessionLauncher` builds a runtime `AXTitleMatchActivator(bundleID:)` from `hostBundleID` when no registered activator matches.

This subsumes Obsidian (and Tabby, future embedded GUI hosts) with no per-app code.

### Why not the simpler heuristics
On a real machine the agent in an Obsidian terminal sits under `Obsidian → Obsidian Helper (Renderer).app → Python.app (pty_helper) → zsh → agent`. "First foreground-GUI `.app`" picks `Xcode.app`; "innermost `.app` + skip LSUIElement" picks `Python.app` (`com.apple.python3`, not LSUIElement). Static `Info.plist` `LSUIElement` is unreliable in both directions. The top-level-`.app` rule sidesteps all of it.

## Limitation
Brings the host **window** forward, not a specific terminal **pane** — Obsidian exposes no per-pane targeting handle. (Same caveat noted in the issue.) Only applies to *integrated* terminal plugins where the shell is an Obsidian descendant; external-terminal profiles can't be reached by ancestry.

## Testing
- `go test ./core/... -race -count=1` — green. New table-driven `TestTopLevelAppPath` (real Obsidian/Python/Xcode/VS Code paths), launcher JSON round-trip + `IsEmpty` for `host_bundle_id`.
- `swift test` — 156 tests, 0 failures. New test pins the `host_bundle_id` wire contract, the generic-fallback dispatch, and curated-host precedence.
- **Live end-to-end:** ran the resolver against a real shell in the in-Obsidian terminal → resolves to `md.obsidian` (host PID = Obsidian main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)