### PR TITLE
feat(diagnostics): built-in diagnostics bundle — /debug/bundle + --diagnose (#736)

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/liveness_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/liveness_other.go
@@ -1,0 +1,8 @@
+//go:build !darwin && !linux
+
+package processlifecycle
+
+// IsAlive is a conservative stub on platforms without a real process observer
+// (newObserver returns stubObserver there). It reports nothing as alive so the
+// diagnostics bundle never claims liveness it can't verify.
+func IsAlive(pid int) bool { return false }

--- a/core/adapters/inbound/agents/processlifecycle/liveness_unix.go
+++ b/core/adapters/inbound/agents/processlifecycle/liveness_unix.go
@@ -1,0 +1,18 @@
+//go:build darwin || linux
+
+package processlifecycle
+
+import "syscall"
+
+// IsAlive reports whether pid names a live process, probed with signal 0 — the
+// same liveness check the claudecode PID binder uses. A pid <= 0 is never
+// alive. EPERM means the process exists but is owned by another user, which
+// still counts as alive (the diagnostics bundle, #736, only needs to know the
+// claimed PID is occupied, not that it's signalable).
+func IsAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/core/adapters/inbound/agents/processlifecycle/process.go
+++ b/core/adapters/inbound/agents/processlifecycle/process.go
@@ -9,3 +9,8 @@ import "irrlicht/core/ports/outbound"
 // LiveCWDs, DiscoverPIDByTranscriptWriter) and the Scanner routes through
 // this single seam, so adding a platform never touches orchestration.
 var osProc outbound.ProcessObserver = newObserver()
+
+// Observer exposes the platform process observer so callers outside this
+// package — the diagnostics bundle (#736) — can read argv/cwd through the same
+// seam the scanner uses, rather than re-deriving the OS coupling.
+func Observer() outbound.ProcessObserver { return osProc }

--- a/core/adapters/outbound/logging/logger.go
+++ b/core/adapters/outbound/logging/logger.go
@@ -37,13 +37,24 @@ type structuredLogger struct {
 	mu          sync.Mutex
 }
 
-// New creates a structuredLogger writing to the default Irrlicht log directory.
-func New() (*structuredLogger, error) {
+// LogDir returns the directory the daemon writes its event logs to. Exposed
+// so the diagnostics bundle (#736) reads from the exact directory New() writes
+// to. Not IRRLICHT_HOME-aware — logs always live under Application Support,
+// matching the daemon's own behavior.
+func LogDir() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get home directory: %w", err)
+		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
-	logsDir := filepath.Join(homeDir, appSupportDir, "logs")
+	return filepath.Join(homeDir, appSupportDir, "logs"), nil
+}
+
+// New creates a structuredLogger writing to the default Irrlicht log directory.
+func New() (*structuredLogger, error) {
+	logsDir, err := LogDir()
+	if err != nil {
+		return nil, err
+	}
 	if err := os.MkdirAll(logsDir, 0700); err != nil {
 		return nil, fmt.Errorf("failed to create logs directory: %w", err)
 	}

--- a/core/application/services/diagnostics_redact.go
+++ b/core/application/services/diagnostics_redact.go
@@ -1,0 +1,74 @@
+package services
+
+import (
+	"regexp"
+	"strings"
+)
+
+// tokenPatterns mask credential-shaped strings before they reach the
+// diagnostics bundle (#736). The set is deliberately allow-listed to the three
+// families the issue calls out — it is not an exhaustive secret scanner, and
+// novel shapes can slip through. Each match is replaced wholesale with the
+// REDACTED marker.
+var tokenPatterns = []*regexp.Regexp{
+	// OpenAI / Anthropic API keys: sk-…, sk-proj-…, sk-ant-… . The 16+ tail
+	// avoids masking a bare "sk-" that happens to start a word.
+	regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{16,}`),
+	// GitHub tokens: ghp_ (PAT), gho_ (OAuth), ghu_/ghs_ (app), ghr_ (refresh).
+	regexp.MustCompile(`\bgh[pousr]_[A-Za-z0-9]{20,}`),
+}
+
+// bearerPattern masks the credential after a "Bearer " scheme while keeping the
+// scheme word visible, so a reader can still see an Authorization header was
+// present. Case-insensitive on the scheme; the token charset covers JWTs.
+var bearerPattern = regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._-]+`)
+
+// redactedMarker is what every masked secret collapses to.
+const redactedMarker = "[REDACTED]"
+
+// Redactor scrubs diagnostics content server-side: it rewrites the user's home
+// directory to "~" and masks token-shaped strings. Construct one per bundle so
+// the home prefix is captured once. The zero value is unusable — use
+// NewRedactor.
+type Redactor struct {
+	home string
+}
+
+// NewRedactor returns a Redactor that rewrites home → "~". A home of "" or "/"
+// disables path rewriting (token masking still applies).
+func NewRedactor(home string) *Redactor {
+	if home == "/" {
+		home = ""
+	}
+	return &Redactor{home: strings.TrimRight(home, "/")}
+}
+
+// String scrubs a single string: home-path rewrite first, then token masking.
+func (r *Redactor) String(s string) string {
+	if r.home != "" {
+		s = strings.ReplaceAll(s, r.home, "~")
+	}
+	for _, re := range tokenPatterns {
+		s = re.ReplaceAllString(s, redactedMarker)
+	}
+	s = bearerPattern.ReplaceAllString(s, "${1}"+redactedMarker)
+	return s
+}
+
+// Bytes scrubs a byte slice (logs, marshaled JSON) and returns a new slice.
+func (r *Redactor) Bytes(b []byte) []byte {
+	return []byte(r.String(string(b)))
+}
+
+// Argv scrubs every element of an argument vector, returning a new slice. A nil
+// argv returns nil so callers can distinguish "unreadable" from "empty".
+func (r *Redactor) Argv(argv []string) []string {
+	if argv == nil {
+		return nil
+	}
+	out := make([]string, len(argv))
+	for i, a := range argv {
+		out[i] = r.String(a)
+	}
+	return out
+}

--- a/core/application/services/diagnostics_redact_test.go
+++ b/core/application/services/diagnostics_redact_test.go
@@ -1,0 +1,63 @@
+package services
+
+import "testing"
+
+func TestRedactorString(t *testing.T) {
+	r := NewRedactor("/Users/ingo")
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"home path to tilde", "/Users/ingo/projects/foo", "~/projects/foo"},
+		{"home only", "/Users/ingo", "~"},
+		{"non-home path untouched", "/opt/irrlicht/bin", "/opt/irrlicht/bin"},
+		{"openai key", "key=sk-abcdef0123456789ABCDEF tail", "key=[REDACTED] tail"},
+		{"anthropic key", "ANTHROPIC_API_KEY=sk-ant-api03-AAaa0011BBbb2233CCcc", "ANTHROPIC_API_KEY=[REDACTED]"},
+		{"github pat", "token ghp_0123456789abcdefABCDEF0123456789abcd done", "token [REDACTED] done"},
+		{"github oauth", "gho_0123456789abcdefABCDEF0123456789abcd", "[REDACTED]"},
+		{"bearer keeps scheme", "Authorization: Bearer eyJhbG.payload.sig", "Authorization: Bearer [REDACTED]"},
+		{"bearer lowercase", "authorization: bearer abc.def.ghi", "authorization: bearer [REDACTED]"},
+		{"bare sk- not masked", "do sk- this", "do sk- this"},
+		{"home and token together", "/Users/ingo ran with sk-abcdef0123456789ABCDEF", "~ ran with [REDACTED]"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := r.String(tt.in); got != tt.want {
+				t.Errorf("String(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactorEmptyHomeDisablesPathRewrite(t *testing.T) {
+	for _, home := range []string{"", "/"} {
+		r := NewRedactor(home)
+		// Root path must not be rewritten, but tokens still are.
+		if got := r.String("/Users/ingo sk-abcdef0123456789ABCDEF"); got != "/Users/ingo [REDACTED]" {
+			t.Errorf("home=%q: got %q", home, got)
+		}
+	}
+}
+
+func TestRedactorArgv(t *testing.T) {
+	r := NewRedactor("/Users/ingo")
+	if got := r.Argv(nil); got != nil {
+		t.Errorf("Argv(nil) = %v, want nil", got)
+	}
+	in := []string{"claude", "--cwd", "/Users/ingo/p", "--token", "ghp_0123456789abcdefABCDEF0123456789abcd"}
+	want := []string{"claude", "--cwd", "~/p", "--token", "[REDACTED]"}
+	got := r.Argv(in)
+	if len(got) != len(want) {
+		t.Fatalf("Argv len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Argv[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	// Input must not be mutated in place.
+	if in[2] != "/Users/ingo/p" {
+		t.Errorf("Argv mutated its input: %v", in)
+	}
+}

--- a/core/application/services/diagnostics_service.go
+++ b/core/application/services/diagnostics_service.go
@@ -7,12 +7,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -27,10 +25,6 @@ import (
 // predictable while preserving the newest activity (the tail), which is what a
 // fresh bug report needs.
 const maxBundleLogBytes = 10 * 1024 * 1024
-
-// defaultAdapterName is the adapter a session with an empty Adapter belongs to
-// (Claude Code, for backwards compatibility — see session.SessionState.Adapter).
-const defaultAdapterName = "claude-code"
 
 // DiagnosticsPaths are the resolved, IRRLICHT_HOME-aware locations the bundle
 // reads from. The daemon computes them once at wiring time so the service stays
@@ -48,56 +42,42 @@ type DiagnosticsPaths struct {
 // GET /debug/bundle endpoint and the irrlichd --diagnose CLI. All file paths
 // are injected via DiagnosticsPaths; the service performs no path resolution.
 type DiagnosticsService struct {
-	repo    outbound.SessionRepository
-	obs     outbound.ProcessObserver
-	isAlive func(int) bool
-	agents  []agent.Agent
-	cfg     config.Config
-	version string
-	paths   DiagnosticsPaths
-	now     func() time.Time
+	repo           outbound.SessionRepository
+	obs            outbound.ProcessObserver
+	isAlive        func(int) bool
+	agents         []agent.Agent
+	defaultAdapter string // adapter a session with an empty Adapter belongs to
+	cfg            config.Config
+	version        string
+	paths          DiagnosticsPaths
 }
 
 // NewDiagnosticsService wires the service. isAlive is the per-PID liveness probe
 // (processlifecycle.IsAlive in production); agents supply both the process
 // matchers (for the full landscape) and the per-adapter infra-argv predicates
-// (for the ghost-session diagnosis).
+// (for the ghost-session diagnosis). defaultAdapter is the adapter an
+// empty-Adapter session belongs to (claudecode.AdapterName), injected so the
+// application layer needn't import the inbound adapter.
 func NewDiagnosticsService(
 	repo outbound.SessionRepository,
 	obs outbound.ProcessObserver,
 	isAlive func(int) bool,
 	agents []agent.Agent,
+	defaultAdapter string,
 	cfg config.Config,
 	version string,
 	paths DiagnosticsPaths,
 ) *DiagnosticsService {
 	return &DiagnosticsService{
-		repo:    repo,
-		obs:     obs,
-		isAlive: isAlive,
-		agents:  agents,
-		cfg:     cfg,
-		version: version,
-		paths:   paths,
-		now:     time.Now,
+		repo:           repo,
+		obs:            obs,
+		isAlive:        isAlive,
+		agents:         agents,
+		defaultAdapter: defaultAdapter,
+		cfg:            cfg,
+		version:        version,
+		paths:          paths,
 	}
-}
-
-// HandleBundle serves the bundle over HTTP. It must be wrapped in localhostOnly
-// by the caller — the bundle carries session paths and (pre-redaction) argv.
-// The bundle is bounded, so it is built in memory: a build failure returns a
-// clean 500 instead of a truncated download.
-func (s *DiagnosticsService) HandleBundle(w http.ResponseWriter, r *http.Request) {
-	var buf bytes.Buffer
-	if err := s.WriteBundle(&buf); err != nil {
-		http.Error(w, "failed to build diagnostics bundle", http.StatusInternalServerError)
-		return
-	}
-	w.Header().Set("Content-Type", "application/gzip")
-	w.Header().Set("Content-Disposition",
-		fmt.Sprintf(`attachment; filename="irrlicht-diag-%s.tar.gz"`, fileSafe(s.version)))
-	w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
-	_, _ = w.Write(buf.Bytes())
 }
 
 // WriteBundle writes the gzip+tar bundle to w. Per-artifact failures are
@@ -107,9 +87,9 @@ func (s *DiagnosticsService) HandleBundle(w http.ResponseWriter, r *http.Request
 func (s *DiagnosticsService) WriteBundle(w io.Writer) error {
 	gz := gzip.NewWriter(w)
 	tw := tar.NewWriter(gz)
-	b := &bundleBuilder{tw: tw, red: NewRedactor(s.paths.Home), now: s.now()}
+	b := &bundleBuilder{tw: tw, red: NewRedactor(s.paths.Home), now: time.Now()}
 
-	b.addText("version.txt", s.versionText())
+	b.addText("version.txt", s.versionText(b.now))
 	b.addText("system.txt", systemText())
 	b.addJSON("config.json", s.configView())
 	b.addRawFile("permissions.json", s.paths.PermissionsFile)
@@ -217,23 +197,32 @@ func (s *DiagnosticsService) copyDir(b *bundleBuilder, dir, prefix string, match
 	}
 }
 
-// addLogs writes a single, size-bounded events.log: the newest bytes across
-// events.log and its rotations (events.log.1…5), emitted oldest-first.
+// addLogs writes a single, size-bounded events.log into the bundle.
 func (s *DiagnosticsService) addLogs(b *bundleBuilder) {
-	if s.paths.LogsDir == "" {
-		return
+	if data := gatherTrimmedLog(s.paths.LogsDir, maxBundleLogBytes); data != nil {
+		b.addBytes("events.log", b.red.Bytes(data))
+	}
+}
+
+// gatherTrimmedLog returns at most budget bytes of event log: the newest bytes
+// across events.log and its rotations (events.log.1…5), concatenated
+// oldest-first. The newest file wins the budget first; when a file overflows
+// the remaining budget, only its newest tail (from a line boundary) is kept.
+// Returns nil when logsDir is empty or no log files exist.
+func gatherTrimmedLog(logsDir string, budget int) []byte {
+	if logsDir == "" {
+		return nil
 	}
 	names := []string{"events.log"}
 	for i := 1; i <= 5; i++ {
 		names = append(names, fmt.Sprintf("events.log.%d", i))
 	}
-	budget := maxBundleLogBytes
 	var chunks [][]byte // newest-first
 	for _, n := range names {
 		if budget <= 0 {
 			break
 		}
-		data, err := os.ReadFile(filepath.Join(s.paths.LogsDir, n))
+		data, err := os.ReadFile(filepath.Join(logsDir, n))
 		if err != nil {
 			continue // a missing rotation is normal
 		}
@@ -246,13 +235,13 @@ func (s *DiagnosticsService) addLogs(b *bundleBuilder) {
 		chunks = append(chunks, data)
 	}
 	if len(chunks) == 0 {
-		return
+		return nil
 	}
 	var buf bytes.Buffer
 	for i := len(chunks) - 1; i >= 0; i-- { // oldest-first
 		buf.Write(chunks[i])
 	}
-	b.addBytes("events.log", b.red.Bytes(buf.Bytes()))
+	return buf.Bytes()
 }
 
 // processInfo is the per-PID liveness/argv view shared by liveness.json (bound
@@ -362,15 +351,15 @@ func (s *DiagnosticsService) excluderByAdapter() func(adapter string) func([]str
 	}
 	return func(adapter string) func([]string) bool {
 		if adapter == "" {
-			adapter = defaultAdapterName
+			adapter = s.defaultAdapter
 		}
 		return m[adapter]
 	}
 }
 
-func (s *DiagnosticsService) versionText() string {
+func (s *DiagnosticsService) versionText(now time.Time) string {
 	return fmt.Sprintf("irrlichd version %s\ngenerated %s\n",
-		s.version, s.now().UTC().Format(time.RFC3339))
+		s.version, now.UTC().Format(time.RFC3339))
 }
 
 func systemText() string {
@@ -427,19 +416,4 @@ func tailFromLineBoundary(data []byte, n int) []byte {
 		tail = tail[i+1:]
 	}
 	return tail
-}
-
-// fileSafe makes a version string safe for a download filename.
-func fileSafe(s string) string {
-	if s == "" {
-		return "unknown"
-	}
-	return strings.Map(func(r rune) rune {
-		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
-			return r
-		default:
-			return '-'
-		}
-	}, s)
 }

--- a/core/application/services/diagnostics_service.go
+++ b/core/application/services/diagnostics_service.go
@@ -1,0 +1,445 @@
+package services
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/config"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// maxBundleLogBytes caps the trimmed event log included in a diagnostics
+// bundle. Raw logs reach ~58 MB on a busy machine; this keeps the bundle
+// predictable while preserving the newest activity (the tail), which is what a
+// fresh bug report needs.
+const maxBundleLogBytes = 10 * 1024 * 1024
+
+// defaultAdapterName is the adapter a session with an empty Adapter belongs to
+// (Claude Code, for backwards compatibility — see session.SessionState.Adapter).
+const defaultAdapterName = "claude-code"
+
+// DiagnosticsPaths are the resolved, IRRLICHT_HOME-aware locations the bundle
+// reads from. The daemon computes them once at wiring time so the service stays
+// free of path-resolution logic and is trivially testable with t.TempDir().
+type DiagnosticsPaths struct {
+	Home            string // user home, rewritten to "~" in redacted output
+	InstancesDir    string // persisted session files (<id>.json)
+	LedgerDir       string // per-session ledgers (*.ledger.json)
+	LogsDir         string // event logs (events.log*)
+	PermissionsFile string // consent state (permissions.json)
+}
+
+// DiagnosticsService assembles a redacted .tar.gz snapshot of daemon state for
+// bug reports (#736). It streams to any io.Writer, so the same engine backs the
+// GET /debug/bundle endpoint and the irrlichd --diagnose CLI. All file paths
+// are injected via DiagnosticsPaths; the service performs no path resolution.
+type DiagnosticsService struct {
+	repo    outbound.SessionRepository
+	obs     outbound.ProcessObserver
+	isAlive func(int) bool
+	agents  []agent.Agent
+	cfg     config.Config
+	version string
+	paths   DiagnosticsPaths
+	now     func() time.Time
+}
+
+// NewDiagnosticsService wires the service. isAlive is the per-PID liveness probe
+// (processlifecycle.IsAlive in production); agents supply both the process
+// matchers (for the full landscape) and the per-adapter infra-argv predicates
+// (for the ghost-session diagnosis).
+func NewDiagnosticsService(
+	repo outbound.SessionRepository,
+	obs outbound.ProcessObserver,
+	isAlive func(int) bool,
+	agents []agent.Agent,
+	cfg config.Config,
+	version string,
+	paths DiagnosticsPaths,
+) *DiagnosticsService {
+	return &DiagnosticsService{
+		repo:    repo,
+		obs:     obs,
+		isAlive: isAlive,
+		agents:  agents,
+		cfg:     cfg,
+		version: version,
+		paths:   paths,
+		now:     time.Now,
+	}
+}
+
+// HandleBundle serves the bundle over HTTP. It must be wrapped in localhostOnly
+// by the caller — the bundle carries session paths and (pre-redaction) argv.
+// The bundle is bounded, so it is built in memory: a build failure returns a
+// clean 500 instead of a truncated download.
+func (s *DiagnosticsService) HandleBundle(w http.ResponseWriter, r *http.Request) {
+	var buf bytes.Buffer
+	if err := s.WriteBundle(&buf); err != nil {
+		http.Error(w, "failed to build diagnostics bundle", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition",
+		fmt.Sprintf(`attachment; filename="irrlicht-diag-%s.tar.gz"`, fileSafe(s.version)))
+	w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+	_, _ = w.Write(buf.Bytes())
+}
+
+// WriteBundle writes the gzip+tar bundle to w. Per-artifact failures are
+// recorded into a collection-errors.txt entry rather than aborting the bundle —
+// a partial snapshot still helps. Only a failure of the tar/gzip writer itself
+// returns an error.
+func (s *DiagnosticsService) WriteBundle(w io.Writer) error {
+	gz := gzip.NewWriter(w)
+	tw := tar.NewWriter(gz)
+	b := &bundleBuilder{tw: tw, red: NewRedactor(s.paths.Home), now: s.now()}
+
+	b.addText("version.txt", s.versionText())
+	b.addText("system.txt", systemText())
+	b.addJSON("config.json", s.configView())
+	b.addRawFile("permissions.json", s.paths.PermissionsFile)
+
+	sessions, err := s.repo.ListAll()
+	if err != nil {
+		b.errf("sessions.json: ListAll: %v", err)
+		sessions = nil
+	}
+	b.addJSON("state.json", stateView(sessions, b.now))
+	b.addJSON("sessions.json", sessions)
+	s.addInstances(b)
+	s.addLedgers(b)
+	b.addJSON("liveness.json", s.liveness(sessions, b.red))
+	b.addJSON("processes.json", s.processes(b.red))
+	s.addLogs(b)
+
+	if errs := b.errs; len(errs) > 0 {
+		b.addText("collection-errors.txt", strings.Join(errs, "\n")+"\n")
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return gz.Close()
+}
+
+// bundleBuilder accumulates tar entries, redacting every payload, and collects
+// per-artifact errors for an in-band collection-errors.txt.
+type bundleBuilder struct {
+	tw   *tar.Writer
+	red  *Redactor
+	now  time.Time
+	errs []string
+}
+
+func (b *bundleBuilder) errf(format string, a ...any) {
+	b.errs = append(b.errs, fmt.Sprintf(format, a...))
+}
+
+func (b *bundleBuilder) addBytes(name string, data []byte) {
+	hdr := &tar.Header{Name: name, Mode: 0o600, Size: int64(len(data)), ModTime: b.now}
+	if err := b.tw.WriteHeader(hdr); err != nil {
+		b.errf("%s: header: %v", name, err)
+		return
+	}
+	if _, err := b.tw.Write(data); err != nil {
+		b.errf("%s: write: %v", name, err)
+	}
+}
+
+func (b *bundleBuilder) addText(name, s string) { b.addBytes(name, b.red.Bytes([]byte(s))) }
+
+func (b *bundleBuilder) addJSON(name string, v any) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		b.errf("%s: marshal: %v", name, err)
+		return
+	}
+	b.addBytes(name, b.red.Bytes(data))
+}
+
+// addRawFile copies a file verbatim (then redacted). A missing file is not an
+// error — the artifact simply doesn't exist on this install.
+func (b *bundleBuilder) addRawFile(name, path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			b.errf("%s: read %s: %v", name, path, err)
+		}
+		return
+	}
+	b.addBytes(name, b.red.Bytes(data))
+}
+
+func (s *DiagnosticsService) addInstances(b *bundleBuilder) {
+	s.copyDir(b, s.paths.InstancesDir, "instances/", func(name string) bool {
+		return strings.HasSuffix(name, ".json") && !strings.Contains(name, ".tmp")
+	})
+}
+
+func (s *DiagnosticsService) addLedgers(b *bundleBuilder) {
+	s.copyDir(b, s.paths.LedgerDir, "ledgers/", func(name string) bool {
+		return strings.HasSuffix(name, ".ledger.json")
+	})
+}
+
+// copyDir copies every matching top-level file from dir into the bundle under
+// prefix. A missing dir is silently skipped; a readdir error is recorded.
+func (s *DiagnosticsService) copyDir(b *bundleBuilder, dir, prefix string, match func(name string) bool) {
+	if dir == "" {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			b.errf("%sreaddir %s: %v", prefix, dir, err)
+		}
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() || !match(e.Name()) {
+			continue
+		}
+		b.addRawFile(prefix+e.Name(), filepath.Join(dir, e.Name()))
+	}
+}
+
+// addLogs writes a single, size-bounded events.log: the newest bytes across
+// events.log and its rotations (events.log.1…5), emitted oldest-first.
+func (s *DiagnosticsService) addLogs(b *bundleBuilder) {
+	if s.paths.LogsDir == "" {
+		return
+	}
+	names := []string{"events.log"}
+	for i := 1; i <= 5; i++ {
+		names = append(names, fmt.Sprintf("events.log.%d", i))
+	}
+	budget := maxBundleLogBytes
+	var chunks [][]byte // newest-first
+	for _, n := range names {
+		if budget <= 0 {
+			break
+		}
+		data, err := os.ReadFile(filepath.Join(s.paths.LogsDir, n))
+		if err != nil {
+			continue // a missing rotation is normal
+		}
+		if len(data) > budget {
+			data = tailFromLineBoundary(data, budget)
+			budget = 0
+		} else {
+			budget -= len(data)
+		}
+		chunks = append(chunks, data)
+	}
+	if len(chunks) == 0 {
+		return
+	}
+	var buf bytes.Buffer
+	for i := len(chunks) - 1; i >= 0; i-- { // oldest-first
+		buf.Write(chunks[i])
+	}
+	b.addBytes("events.log", b.red.Bytes(buf.Bytes()))
+}
+
+// processInfo is the per-PID liveness/argv view shared by liveness.json (bound
+// sessions) and processes.json (the full per-adapter landscape).
+type processInfo struct {
+	PID                   int      `json:"pid"`
+	Alive                 bool     `json:"alive"`
+	Argv                  []string `json:"argv,omitempty"`
+	CWD                   string   `json:"cwd,omitempty"`
+	IsInfraArgv           bool     `json:"is_infra_argv"`
+	MatchesAdapterPattern bool     `json:"matches_adapter_pattern"`
+}
+
+func (s *DiagnosticsService) procInfo(pid int, exclude func([]string) bool, red *Redactor) processInfo {
+	argv, _ := s.obs.ArgvOf(pid)
+	cwd, _ := s.obs.CWDOf(pid)
+	alive := s.isAlive(pid)
+	isInfra := exclude != nil && exclude(argv)
+	return processInfo{
+		PID:                   pid,
+		Alive:                 alive,
+		Argv:                  red.Argv(argv),
+		CWD:                   red.String(cwd),
+		IsInfraArgv:           isInfra,
+		MatchesAdapterPattern: alive && !isInfra,
+	}
+}
+
+type livenessEntry struct {
+	SessionID             string   `json:"session_id"`
+	Adapter               string   `json:"adapter"`
+	ClaimedPID            int      `json:"claimed_pid"`
+	Alive                 bool     `json:"alive"`
+	CurrentArgv           []string `json:"current_argv,omitempty"`
+	CurrentCWD            string   `json:"current_cwd,omitempty"`
+	IsInfraArgv           bool     `json:"is_infra_argv"`
+	MatchesAdapterPattern bool     `json:"matches_adapter_pattern"`
+}
+
+// liveness reports, per PID-bound session, whether the claimed PID is still the
+// session it was bound to — the direct #727 diagnosis: a live process whose
+// argv the adapter rejects (is_infra_argv:true, matches_adapter_pattern:false)
+// is a ghost binding.
+func (s *DiagnosticsService) liveness(sessions []*session.SessionState, red *Redactor) []livenessEntry {
+	excluder := s.excluderByAdapter()
+	out := make([]livenessEntry, 0, len(sessions))
+	for _, ss := range sessions {
+		if ss.PID <= 0 {
+			continue
+		}
+		info := s.procInfo(ss.PID, excluder(ss.Adapter), red)
+		out = append(out, livenessEntry{
+			SessionID:             ss.SessionID,
+			Adapter:               ss.Adapter,
+			ClaimedPID:            ss.PID,
+			Alive:                 info.Alive,
+			CurrentArgv:           info.Argv,
+			CurrentCWD:            info.CWD,
+			IsInfraArgv:           info.IsInfraArgv,
+			MatchesAdapterPattern: info.MatchesAdapterPattern,
+		})
+	}
+	return out
+}
+
+type adapterProcesses struct {
+	Adapter   string        `json:"adapter"`
+	Processes []processInfo `json:"processes"`
+}
+
+// processes enumerates every live process matching each adapter's matcher — the
+// superset of liveness's bound PIDs. It catches unbound infra processes that
+// became ghost pre-sessions (#644/#645), which the session-scoped view misses.
+func (s *DiagnosticsService) processes(red *Redactor) []adapterProcesses {
+	out := make([]adapterProcesses, 0, len(s.agents))
+	for _, a := range s.agents {
+		var pids []int
+		switch m := a.Process.Match.(type) {
+		case agent.ExactName:
+			pids, _ = s.obs.FindByName(m.Name)
+		case agent.CommandPattern:
+			if m.Regex != nil {
+				pids, _ = s.obs.FindByCmdline(m.Regex.String())
+			}
+		}
+		if len(pids) == 0 {
+			continue
+		}
+		sort.Ints(pids)
+		procs := make([]processInfo, 0, len(pids))
+		for _, pid := range pids {
+			procs = append(procs, s.procInfo(pid, a.Process.ExcludeArgv, red))
+		}
+		out = append(out, adapterProcesses{Adapter: a.Identity.Name, Processes: procs})
+	}
+	return out
+}
+
+// excluderByAdapter resolves an adapter name to its infra-argv predicate (or
+// nil if it declares none). An empty adapter name resolves to Claude Code.
+func (s *DiagnosticsService) excluderByAdapter() func(adapter string) func([]string) bool {
+	m := make(map[string]func([]string) bool, len(s.agents))
+	for _, a := range s.agents {
+		if a.Process.ExcludeArgv != nil {
+			m[a.Identity.Name] = a.Process.ExcludeArgv
+		}
+	}
+	return func(adapter string) func([]string) bool {
+		if adapter == "" {
+			adapter = defaultAdapterName
+		}
+		return m[adapter]
+	}
+}
+
+func (s *DiagnosticsService) versionText() string {
+	return fmt.Sprintf("irrlichd version %s\ngenerated %s\n",
+		s.version, s.now().UTC().Format(time.RFC3339))
+}
+
+func systemText() string {
+	host, _ := os.Hostname()
+	return fmt.Sprintf("os: %s\narch: %s\ngo: %s\nnum_cpu: %d\nhostname: %s\n",
+		runtime.GOOS, runtime.GOARCH, runtime.Version(), runtime.NumCPU(), host)
+}
+
+func (s *DiagnosticsService) configView() any {
+	return struct {
+		MaxSessionAge   string `json:"max_session_age"`
+		ReadySessionTTL string `json:"ready_session_ttl"`
+		PermissionMode  string `json:"permission_mode"`
+	}{
+		MaxSessionAge:   s.cfg.MaxSessionAge.String(),
+		ReadySessionTTL: s.cfg.ReadySessionTTL.String(),
+		PermissionMode:  s.cfg.PermissionMode,
+	}
+}
+
+func stateView(sessions []*session.SessionState, now time.Time) any {
+	view := struct {
+		SessionCount int    `json:"session_count"`
+		WorkingCount int    `json:"working_count"`
+		WaitingCount int    `json:"waiting_count"`
+		ReadyCount   int    `json:"ready_count"`
+		GeneratedAt  string `json:"generated_at"`
+	}{
+		SessionCount: len(sessions),
+		GeneratedAt:  now.UTC().Format(time.RFC3339),
+	}
+	for _, ss := range sessions {
+		switch ss.State {
+		case session.StateWorking:
+			view.WorkingCount++
+		case session.StateWaiting:
+			view.WaitingCount++
+		case session.StateReady:
+			view.ReadyCount++
+		}
+	}
+	return view
+}
+
+// tailFromLineBoundary returns the last n bytes of data, advanced to the first
+// newline so the slice never begins mid-line. data shorter than n is returned
+// whole.
+func tailFromLineBoundary(data []byte, n int) []byte {
+	if len(data) <= n {
+		return data
+	}
+	tail := data[len(data)-n:]
+	if i := bytes.IndexByte(tail, '\n'); i >= 0 && i+1 < len(tail) {
+		tail = tail[i+1:]
+	}
+	return tail
+}
+
+// fileSafe makes a version string safe for a download filename.
+func fileSafe(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, s)
+}

--- a/core/application/services/diagnostics_service_test.go
+++ b/core/application/services/diagnostics_service_test.go
@@ -1,0 +1,247 @@
+package services
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/config"
+	"irrlicht/core/domain/session"
+)
+
+// --- fakes -------------------------------------------------------------------
+
+type diagFakeRepo struct{ sessions []*session.SessionState }
+
+func (f *diagFakeRepo) Load(string) (*session.SessionState, error) { return nil, nil }
+func (f *diagFakeRepo) Save(*session.SessionState) error           { return nil }
+func (f *diagFakeRepo) Delete(string) error                        { return nil }
+func (f *diagFakeRepo) ListAll() ([]*session.SessionState, error)  { return f.sessions, nil }
+
+type diagFakeObserver struct {
+	argv   map[int][]string
+	cwd    map[int]string
+	byName map[string][]int
+}
+
+func (f *diagFakeObserver) FindByName(n string) ([]int, error)   { return f.byName[n], nil }
+func (f *diagFakeObserver) FindByCmdline(string) ([]int, error)  { return nil, nil }
+func (f *diagFakeObserver) ArgvOf(pid int) ([]string, error)     { return f.argv[pid], nil }
+func (f *diagFakeObserver) CWDOf(pid int) (string, error)        { return f.cwd[pid], nil }
+func (f *diagFakeObserver) WriterOf(string) (int, error)         { return 0, nil }
+func (f *diagFakeObserver) EnvOf(int) (map[string]string, error) { return nil, nil }
+
+// excludeBgSpare mimics claudecode.IsInfraArgv: a "--bg-spare" element marks an
+// infra process that must never be bound as a session.
+func excludeBgSpare(argv []string) bool {
+	for _, a := range argv {
+		if a == "--bg-spare" {
+			return true
+		}
+	}
+	return false
+}
+
+func untar(t *testing.T, b []byte) map[string][]byte {
+	t.Helper()
+	gz, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("gzip.NewReader: %v", err)
+	}
+	tr := tar.NewReader(gz)
+	out := map[string][]byte{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar.Next: %v", err)
+		}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("read %s: %v", hdr.Name, err)
+		}
+		out[hdr.Name] = data
+	}
+	return out
+}
+
+// buildTestService wires a DiagnosticsService over a temp dir populated with one
+// instance file, one ledger, a log, and a permissions file — all containing a
+// home path and a token to prove redaction is applied.
+func buildTestService(t *testing.T) *DiagnosticsService {
+	t.Helper()
+	home := "/Users/test"
+	dir := t.TempDir()
+	instancesDir := filepath.Join(dir, "instances")
+	ledgerDir := filepath.Join(dir, "sessions")
+	logsDir := filepath.Join(dir, "logs")
+	for _, d := range []string{instancesDir, ledgerDir, logsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(p, content string) {
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(instancesDir, "sess-a.json"), `{"cwd":"/Users/test/proj","token":"sk-abcdef0123456789ABCDEF"}`)
+	write(filepath.Join(instancesDir, "tmp.tmp.json"), `should be skipped`)
+	write(filepath.Join(ledgerDir, "abc.ledger.json"), `{"last":"/Users/test/x"}`)
+	write(filepath.Join(logsDir, "events.log"), "line in /Users/test with ghp_0123456789abcdefABCDEF0123456789abcd\n")
+	permFile := filepath.Join(dir, "permissions.json")
+	write(permFile, `{"version":1,"agents":{}}`)
+
+	sessions := []*session.SessionState{
+		{SessionID: "a", State: session.StateWorking, Adapter: "claude-code", PID: 100, CWD: "/Users/test/proj"},
+		{SessionID: "b", State: session.StateReady, Adapter: "claude-code", PID: 200},
+		{SessionID: "c", State: session.StateWaiting, Adapter: "claude-code", PID: 0}, // no PID → not in liveness
+	}
+	obs := &diagFakeObserver{
+		argv: map[int][]string{
+			100: {"claude", "--bg-spare"}, // ghost: infra bound as a session
+			200: {"claude"},               // healthy session
+			300: {"claude", "--bg-spare"}, // unbound infra (landscape only)
+		},
+		cwd:    map[int]string{100: "/Users/test/proj", 200: "/Users/test/p2"},
+		byName: map[string][]int{"claude": {100, 200, 300}},
+	}
+	isAlive := func(pid int) bool { return pid == 100 || pid == 200 || pid == 300 }
+	agents := []agent.Agent{{
+		Identity: agent.Identity{Name: "claude-code"},
+		Process:  agent.Process{Match: agent.ExactName{Name: "claude"}, ExcludeArgv: excludeBgSpare},
+	}}
+	cfg := config.Config{MaxSessionAge: 5 * 24 * time.Hour, ReadySessionTTL: 30 * time.Minute, PermissionMode: "ask"}
+
+	return NewDiagnosticsService(&diagFakeRepo{sessions}, obs, isAlive, agents, cfg, "9.9.9+test", DiagnosticsPaths{
+		Home:            home,
+		InstancesDir:    instancesDir,
+		LedgerDir:       ledgerDir,
+		LogsDir:         logsDir,
+		PermissionsFile: permFile,
+	})
+}
+
+func TestWriteBundleContents(t *testing.T) {
+	var buf bytes.Buffer
+	if err := buildTestService(t).WriteBundle(&buf); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	files := untar(t, buf.Bytes())
+
+	for _, want := range []string{
+		"version.txt", "system.txt", "config.json", "permissions.json",
+		"state.json", "sessions.json", "liveness.json", "processes.json",
+		"events.log", "instances/sess-a.json", "ledgers/abc.ledger.json",
+	} {
+		if _, ok := files[want]; !ok {
+			t.Errorf("bundle missing %s (have %v)", want, keys(files))
+		}
+	}
+	if _, ok := files["instances/tmp.tmp.json"]; ok {
+		t.Error("bundle included a .tmp instance file")
+	}
+	if _, ok := files["collection-errors.txt"]; ok {
+		t.Errorf("unexpected collection errors:\n%s", files["collection-errors.txt"])
+	}
+}
+
+func TestWriteBundleRedaction(t *testing.T) {
+	var buf bytes.Buffer
+	if err := buildTestService(t).WriteBundle(&buf); err != nil {
+		t.Fatal(err)
+	}
+	files := untar(t, buf.Bytes())
+	for name, data := range files {
+		s := string(data)
+		if strings.Contains(s, "/Users/test") {
+			t.Errorf("%s leaked home path: %s", name, s)
+		}
+		if strings.Contains(s, "sk-abcdef") || strings.Contains(s, "ghp_0123") {
+			t.Errorf("%s leaked a token: %s", name, s)
+		}
+	}
+}
+
+func TestLivenessFlagsGhostBinding(t *testing.T) {
+	var buf bytes.Buffer
+	if err := buildTestService(t).WriteBundle(&buf); err != nil {
+		t.Fatal(err)
+	}
+	files := untar(t, buf.Bytes())
+
+	var entries []livenessEntry
+	if err := json.Unmarshal(files["liveness.json"], &entries); err != nil {
+		t.Fatalf("liveness.json: %v", err)
+	}
+	byID := map[string]livenessEntry{}
+	for _, e := range entries {
+		byID[e.SessionID] = e
+	}
+	if len(entries) != 2 {
+		t.Fatalf("liveness has %d entries, want 2 (PID-bound only): %+v", len(entries), entries)
+	}
+	if _, ok := byID["c"]; ok {
+		t.Error("session c (PID 0) should not appear in liveness")
+	}
+	// Ghost: infra argv bound as a session.
+	a := byID["a"]
+	if !a.Alive || !a.IsInfraArgv || a.MatchesAdapterPattern {
+		t.Errorf("session a should be alive+infra+!matches, got %+v", a)
+	}
+	// Healthy session.
+	b := byID["b"]
+	if !b.Alive || b.IsInfraArgv || !b.MatchesAdapterPattern {
+		t.Errorf("session b should be alive+!infra+matches, got %+v", b)
+	}
+}
+
+func TestProcessesCatchesUnboundInfra(t *testing.T) {
+	var buf bytes.Buffer
+	if err := buildTestService(t).WriteBundle(&buf); err != nil {
+		t.Fatal(err)
+	}
+	files := untar(t, buf.Bytes())
+
+	var groups []adapterProcesses
+	if err := json.Unmarshal(files["processes.json"], &groups); err != nil {
+		t.Fatalf("processes.json: %v", err)
+	}
+	if len(groups) != 1 || groups[0].Adapter != "claude-code" {
+		t.Fatalf("want one claude-code group, got %+v", groups)
+	}
+	if len(groups[0].Processes) != 3 {
+		t.Fatalf("landscape should list all 3 matched PIDs (incl. unbound 300), got %d", len(groups[0].Processes))
+	}
+	// PID 300 is unbound infra — present in the landscape but no session claims it.
+	var found300 bool
+	for _, p := range groups[0].Processes {
+		if p.PID == 300 {
+			found300 = true
+			if !p.IsInfraArgv {
+				t.Errorf("PID 300 should be flagged infra: %+v", p)
+			}
+		}
+	}
+	if !found300 {
+		t.Error("unbound infra PID 300 missing from processes.json")
+	}
+}
+
+func keys(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/core/application/services/diagnostics_service_test.go
+++ b/core/application/services/diagnostics_service_test.go
@@ -123,7 +123,7 @@ func buildTestService(t *testing.T) *DiagnosticsService {
 	}}
 	cfg := config.Config{MaxSessionAge: 5 * 24 * time.Hour, ReadySessionTTL: 30 * time.Minute, PermissionMode: "ask"}
 
-	return NewDiagnosticsService(&diagFakeRepo{sessions}, obs, isAlive, agents, cfg, "9.9.9+test", DiagnosticsPaths{
+	return NewDiagnosticsService(&diagFakeRepo{sessions}, obs, isAlive, agents, "claude-code", cfg, "9.9.9+test", DiagnosticsPaths{
 		Home:            home,
 		InstancesDir:    instancesDir,
 		LedgerDir:       ledgerDir,
@@ -235,6 +235,45 @@ func TestProcessesCatchesUnboundInfra(t *testing.T) {
 	}
 	if !found300 {
 		t.Error("unbound infra PID 300 missing from processes.json")
+	}
+}
+
+func TestGatherTrimmedLog(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("events.log", "newA\nnewB\nnewC\n") // 15 bytes, newest
+	write("events.log.1", "old1\nold2\n")     // 10 bytes, older rotation
+
+	// Ample budget: every rotation, concatenated oldest-first.
+	if got := string(gatherTrimmedLog(dir, 1000)); got != "old1\nold2\nnewA\nnewB\nnewC\n" {
+		t.Errorf("full gather = %q", got)
+	}
+	// Budget smaller than the newest file: bounded to its tail, trimmed to a
+	// line boundary (no partial leading line), newest wins the budget.
+	if got := string(gatherTrimmedLog(dir, 10)); got != "newC\n" {
+		t.Errorf("trimmed gather = %q, want %q", got, "newC\n")
+	}
+	// Missing dir and unset dir both yield nil (absent logs are not an error).
+	if gatherTrimmedLog(t.TempDir(), 1000) != nil {
+		t.Error("empty dir should yield nil")
+	}
+	if gatherTrimmedLog("", 1000) != nil {
+		t.Error("empty logsDir should yield nil")
+	}
+}
+
+func TestTailFromLineBoundary(t *testing.T) {
+	// Shorter than n → returned whole.
+	if got := string(tailFromLineBoundary([]byte("abc"), 10)); got != "abc" {
+		t.Errorf("short data = %q, want abc", got)
+	}
+	// A single line longer than n with no newline → returned as-is (best effort).
+	if got := string(tailFromLineBoundary([]byte("abcdefghij"), 4)); got != "ghij" {
+		t.Errorf("no-newline tail = %q, want ghij", got)
 	}
 }
 

--- a/core/cmd/irrlichd/daemon_smoke_test.go
+++ b/core/cmd/irrlichd/daemon_smoke_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -55,6 +59,9 @@ func TestDaemonStartupSmoke(t *testing.T) {
 			},
 		}}
 		assertAgentsEndpoint(t, unixClient, "http://unix/api/v1/agents")
+
+		// 3. Diagnostics bundle (#736): localhost GET returns a valid .tar.gz.
+		assertBundleEndpoint(t, http.DefaultClient, "http://"+d.addr+"/debug/bundle")
 
 		unixClient.CloseIdleConnections()
 		d.shutdown(t)
@@ -210,6 +217,49 @@ func assertAgentsEndpoint(t *testing.T, client *http.Client, url string) {
 		if got[i] != want[i] {
 			t.Fatalf("GET %s agent names = %v, want %v", url, got, want)
 		}
+	}
+}
+
+// assertBundleEndpoint GETs /debug/bundle and verifies it streams a gzip+tar
+// that decodes and contains version.txt — the diagnostics bundle (#736) over
+// the loopback path the reporter's one-line curl uses.
+func assertBundleEndpoint(t *testing.T, client *http.Client, url string) {
+	t.Helper()
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status %d, want 200", url, resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/gzip" {
+		t.Errorf("GET %s: Content-Type = %q, want application/gzip", url, ct)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read %s: %v", url, err)
+	}
+	gz, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("bundle is not valid gzip: %v", err)
+	}
+	tr := tar.NewReader(gz)
+	var hasVersion bool
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("bundle is not a valid tar: %v", err)
+		}
+		if hdr.Name == "version.txt" {
+			hasVersion = true
+		}
+	}
+	if !hasVersion {
+		t.Errorf("bundle from %s missing version.txt", url)
 	}
 }
 

--- a/core/cmd/irrlichd/diagnostics_test.go
+++ b/core/cmd/irrlichd/diagnostics_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestLocalhostOnlyGuardsDebugBundle pins the security boundary the diagnostics
+// bundle (#736) relies on: a request from a non-loopback address is rejected
+// before the wrapped handler runs, while a loopback request passes through. A
+// real TCP connection to 127.0.0.1 can never exercise the off-loopback branch,
+// so this forges RemoteAddr directly.
+func TestLocalhostOnlyGuardsDebugBundle(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		remoteAddr string
+		wantStatus int
+		wantCalled bool
+	}{
+		{"off-loopback rejected", "203.0.113.5:54321", http.StatusForbidden, false},
+		{"loopback allowed", "127.0.0.1:54321", http.StatusOK, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			h := localhostOnly(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				w.WriteHeader(http.StatusOK)
+			})
+			req := httptest.NewRequest(http.MethodGet, "/debug/bundle", nil)
+			req.RemoteAddr = tc.remoteAddr
+			rec := httptest.NewRecorder()
+			h(rec, req)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if called != tc.wantCalled {
+				t.Errorf("handler called = %v, want %v", called, tc.wantCalled)
+			}
+		})
+	}
+}

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -401,6 +405,41 @@ func handleGetState(repo outbound.SessionRepository) http.HandlerFunc {
 		enc.SetIndent("", "  ")
 		enc.Encode(resp)
 	}
+}
+
+// handleDiagnosticsBundle serves the diagnostics bundle (#736) as a gzip+tar
+// download. Must be wrapped in localhostOnly by the caller — the bundle carries
+// session paths and (pre-redaction) process argv. The bundle is bounded, so it
+// builds in memory: a build failure returns a clean 500 rather than a truncated
+// download.
+func handleDiagnosticsBundle(svc *services.DiagnosticsService) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		if err := svc.WriteBundle(&buf); err != nil {
+			http.Error(w, "failed to build diagnostics bundle", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Header().Set("Content-Disposition",
+			fmt.Sprintf(`attachment; filename="irrlicht-diag-%s.tar.gz"`, fileSafe(Version)))
+		w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
+		_, _ = w.Write(buf.Bytes())
+	}
+}
+
+// fileSafe makes a version string safe for use in a download filename.
+func fileSafe(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, s)
 }
 
 // localhostOnly wraps an HTTP handler to reject requests not originating from

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -336,7 +336,7 @@ func main() {
 	// only — it carries session paths and (pre-redaction) process argv. Reads
 	// fsRepo directly for a fresh, uncached snapshot.
 	diagSvc := buildDiagnostics(fsRepo, allAgents, cfg)
-	mux.HandleFunc("GET /debug/bundle", localhostOnly(diagSvc.HandleBundle))
+	mux.HandleFunc("GET /debug/bundle", localhostOnly(handleDiagnosticsBundle(diagSvc)))
 
 	// Ensure web assets are served with correct Content-Type regardless of the
 	// host OS mime.types database (absent on stripped Linux images). Go's
@@ -857,6 +857,21 @@ func stateStoreDir(sub string) string {
 	return ""
 }
 
+// resolveSessionRepo resolves the on-disk session store, honoring IRRLICHT_HOME
+// for both the instances dir and the per-session ledger dir. It performs no
+// pruning or sweeps — the daemon layers those on at startup; --diagnose must
+// not mutate state. Shared so a diagnostics snapshot reads exactly the stores
+// the daemon writes (no IRRLICHT_HOME drift between the two paths).
+func resolveSessionRepo() (*filesystem.SessionRepository, error) {
+	if dir := stateStoreDir("sessions"); dir != "" {
+		metrics.SetLedgerDir(dir)
+	}
+	if dir := stateStoreDir("instances"); dir != "" {
+		return filesystem.NewWithDir(dir), nil
+	}
+	return filesystem.New()
+}
+
 // buildDiagnostics constructs the diagnostics bundle service (issue #736) from
 // the daemon's resolved stores. Shared by the GET /debug/bundle handler and the
 // --diagnose CLI so both snapshot the exact same locations. fsRepo supplies both
@@ -871,6 +886,7 @@ func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Ag
 		processlifecycle.Observer(),
 		processlifecycle.IsAlive,
 		allAgents,
+		claudecode.AdapterName,
 		cfg,
 		Version,
 		services.DiagnosticsPaths{
@@ -888,18 +904,9 @@ func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Ag
 // resolves the same stores the daemon would (honoring IRRLICHT_HOME) without
 // starting the daemon.
 func runDiagnose() {
-	if dir := stateStoreDir("sessions"); dir != "" {
-		metrics.SetLedgerDir(dir)
-	}
-	var fsRepo *filesystem.SessionRepository
-	if dir := stateStoreDir("instances"); dir != "" {
-		fsRepo = filesystem.NewWithDir(dir)
-	} else {
-		var err error
-		fsRepo, err = filesystem.New()
-		if err != nil {
-			log.Fatalf("diagnose: init session repo: %v", err)
-		}
+	fsRepo, err := resolveSessionRepo()
+	if err != nil {
+		log.Fatalf("diagnose: init session repo: %v", err)
 	}
 	cfg := config.Default()
 	if v := os.Getenv("IRRLICHT_MAX_SESSION_AGE"); v != "" {
@@ -1008,22 +1015,12 @@ const costAttachTTL = 5 * time.Second
 // (returned as the outbound.SessionRepository interface since the concrete
 // cached type is unexported).
 func initSessionStorage(logger outbound.Logger, cfg config.Config) (*filesystem.SessionRepository, outbound.SessionRepository) {
-	// Honor IRRLICHT_HOME for full isolation: a dev/test daemon must not prune
-	// or mutate the production session store. Ledgers route through the same
-	// override (set before the orphan-ledger sweep below reads LedgerDir).
-	if dir := stateStoreDir("sessions"); dir != "" {
-		metrics.SetLedgerDir(dir)
-	}
-	var fsRepo *filesystem.SessionRepository
-	if dir := stateStoreDir("instances"); dir != "" {
-		fsRepo = filesystem.NewWithDir(dir)
-	} else {
-		var err error
-		fsRepo, err = filesystem.New()
-		if err != nil {
-			logger.LogError("startup", "", fmt.Sprintf("failed to init filesystem repo: %v", err))
-			os.Exit(1)
-		}
+	// Resolve the store (IRRLICHT_HOME-aware) then layer the daemon's startup
+	// pruning/sweeps on top — see resolveSessionRepo, shared with --diagnose.
+	fsRepo, err := resolveSessionRepo()
+	if err != nil {
+		logger.LogError("startup", "", fmt.Sprintf("failed to init filesystem repo: %v", err))
+		os.Exit(1)
 	}
 
 	pruned, err := fsRepo.PruneStale(cfg.MaxSessionAge)

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -146,6 +146,11 @@ func main() {
 		os.Exit(0)
 	}
 
+	if hasFlag("--diagnose") {
+		runDiagnose()
+		os.Exit(0)
+	}
+
 	recordEnabled := hasFlag("--record") || os.Getenv("IRRLICHT_RECORD") == "1"
 
 	logger, err := logging.New()
@@ -325,6 +330,13 @@ func main() {
 	mux.HandleFunc("GET /debug/pprof/profile", localhostOnly(pprof.Profile))
 	mux.HandleFunc("GET /debug/pprof/symbol", localhostOnly(pprof.Symbol))
 	mux.HandleFunc("GET /debug/pprof/trace", localhostOnly(pprof.Trace))
+
+	// Diagnostics bundle (issue #736): a redacted .tar.gz of session state,
+	// per-PID liveness, trimmed logs, and config for bug reports. Localhost
+	// only — it carries session paths and (pre-redaction) process argv. Reads
+	// fsRepo directly for a fresh, uncached snapshot.
+	diagSvc := buildDiagnostics(fsRepo, allAgents, cfg)
+	mux.HandleFunc("GET /debug/bundle", localhostOnly(diagSvc.HandleBundle))
 
 	// Ensure web assets are served with correct Content-Type regardless of the
 	// host OS mime.types database (absent on stripped Linux images). Go's
@@ -843,6 +855,69 @@ func stateStoreDir(sub string) string {
 		return filepath.Join(v, sub)
 	}
 	return ""
+}
+
+// buildDiagnostics constructs the diagnostics bundle service (issue #736) from
+// the daemon's resolved stores. Shared by the GET /debug/bundle handler and the
+// --diagnose CLI so both snapshot the exact same locations. fsRepo supplies both
+// the (uncached) session list and the instances dir; ledger and log dirs honor
+// IRRLICHT_HOME via the same accessors the daemon writes through.
+func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Agent, cfg config.Config) *services.DiagnosticsService {
+	home, _ := os.UserHomeDir()
+	ledgerDir, _ := metrics.LedgerDir()
+	logsDir, _ := logging.LogDir()
+	return services.NewDiagnosticsService(
+		fsRepo,
+		processlifecycle.Observer(),
+		processlifecycle.IsAlive,
+		allAgents,
+		cfg,
+		Version,
+		services.DiagnosticsPaths{
+			Home:            home,
+			InstancesDir:    fsRepo.InstancesDir(),
+			LedgerDir:       ledgerDir,
+			LogsDir:         logsDir,
+			PermissionsFile: filepath.Join(dataDir(home), "permissions.json"),
+		},
+	)
+}
+
+// runDiagnose writes a diagnostics bundle to the current directory and exits.
+// For headless / curl-only installs that can't hit GET /debug/bundle. It
+// resolves the same stores the daemon would (honoring IRRLICHT_HOME) without
+// starting the daemon.
+func runDiagnose() {
+	if dir := stateStoreDir("sessions"); dir != "" {
+		metrics.SetLedgerDir(dir)
+	}
+	var fsRepo *filesystem.SessionRepository
+	if dir := stateStoreDir("instances"); dir != "" {
+		fsRepo = filesystem.NewWithDir(dir)
+	} else {
+		var err error
+		fsRepo, err = filesystem.New()
+		if err != nil {
+			log.Fatalf("diagnose: init session repo: %v", err)
+		}
+	}
+	cfg := config.Default()
+	if v := os.Getenv("IRRLICHT_MAX_SESSION_AGE"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.MaxSessionAge = d
+		}
+	}
+	const out = "irrlicht-diag.tar.gz"
+	f, err := os.Create(out)
+	if err != nil {
+		log.Fatalf("diagnose: create %s: %v", out, err)
+	}
+	defer f.Close()
+	if err := buildDiagnostics(fsRepo, agents.All(), cfg).WriteBundle(f); err != nil {
+		log.Fatalf("diagnose: write bundle: %v", err)
+	}
+	abs, _ := filepath.Abs(out)
+	fmt.Printf("Wrote diagnostics bundle to %s\n", abs)
 }
 
 // socketPath returns the Unix socket path for irrlichd. It routes through


### PR DESCRIPTION
## What

Built-in diagnostics bundle for bug reports (motivated by #727). A `DiagnosticsService` streams a **redacted** `.tar.gz` snapshot of daemon state, exposed two ways:

- `GET /debug/bundle` — localhost-only (beside the pprof handlers). The #727 copy-paste shell bundle collapses to:
  ```
  curl -s http://127.0.0.1:7837/debug/bundle -o ~/Desktop/irrlicht-diag.tar.gz
  ```
- `irrlichd --diagnose` — writes `irrlicht-diag.tar.gz` to the cwd, for headless / curl-only installs.

## Bundle contents

All redacted server-side (`$HOME` → `~`; `sk-`/`sk-ant-`/`gh[pousr]_`/`Bearer` tokens masked):

| Artifact | Purpose |
|---|---|
| `state.json`, `sessions.json` | current snapshot + per-session state |
| `instances/*.json` | raw persisted session files (ground truth) |
| `ledgers/*.ledger.json` | per-session ledgers — restart/persistence bugs (#705/#649/#615) |
| `permissions.json`, `config.json` | consent state + effective config — "not monitoring" bugs |
| `liveness.json` | per PID-bound session: claimed PID vs live argv/cwd + `is_infra_argv`/`matches_adapter_pattern` — the **#727 ghost-binding diagnosis** |
| `processes.json` | full per-adapter process landscape — catches **unbound** infra that became ghost pre-sessions (#644/#645) |
| `events.log` | newest bytes, trimmed to a ~10 MB cap |
| `version.txt`, `system.txt` | build + host info |

Absent artifacts are skipped silently; per-artifact failures land in an in-band `collection-errors.txt` rather than aborting the bundle.

## Scope

This is **MVP + cheap artifacts** (ledgers / permissions / config / full process landscape added beyond the issue's MVP, since they reuse the same engine and close the largest historical bug classes — restart, "not monitoring", unbound-infra). **Deferred to a follow-on PR:** the macOS "Collect Diagnostics…" menu item (Swift) and bounded transcript tails.

## Seams added

`logging.LogDir()`; `processlifecycle.Observer()` / `IsAlive()` (build-tagged unix/other).

## Testing

- **New diagnostics code is green and deterministic:** redaction table tests; service tests (contents, redaction, ghost-binding liveness, unbound-infra landscape); `localhostOnly` 403/200 boundary; daemon smoke test asserts `GET /debug/bundle` streams a valid `tar.gz` over loopback. `processlifecycle`, `logging`, `cmd/irrlichd` all pass.
- **Verified end-to-end** via a real `--diagnose` run: 0 home-path/token leaks, infra detection flagged the live `claude daemon run`, landscape enumerated 13 claude + 1 codex procs with 0 sessions.
- **Heads-up on the full `-race` suite:** it intermittently flakes on pre-existing session-detector/relay races (`session_detector_activity.go`/`pid_manager.go` = #606; relay = #572) in code this PR does not touch — those tests pass in isolation. Not introduced here.

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)
