### PR TITLE
feat(claudecode): badge detached background agents instead of phantom rows (#744)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/pid.go
+++ b/core/adapters/inbound/agents/claudecode/pid.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -37,6 +38,12 @@ func defaultSessionsDir() string {
 type claudeSessionMeta struct {
 	PID       int    `json:"pid"`
 	SessionID string `json:"sessionId"`
+	// Kind is "interactive" for normal sessions and "bg" for background agents
+	// spawned via Agent View (which keep running detached in the daemon pool).
+	Kind string `json:"kind"`
+	// Name is the human-readable label Claude assigns a background agent's job
+	// (e.g. "Add guiding colors to quest cards"); empty for interactive sessions.
+	Name string `json:"name"`
 }
 
 // DiscoverPID finds the Claude Code process owning a session. It prefers an
@@ -173,6 +180,25 @@ func readSessionMeta(path string) (claudeSessionMeta, bool) {
 		return claudeSessionMeta{}, false
 	}
 	return meta, true
+}
+
+// ReadBackgroundMeta reports whether pid owns a Claude background-agent
+// (kind:"bg") session — one started via Agent View that keeps running detached
+// in the `claude daemon run` pool after its window is closed (#744). It reads
+// the same ~/.claude/sessions/<pid>.json registry file DiscoverPID uses and
+// returns (name, true) for a background agent, where name is Claude's
+// human-readable job label (may be ""), or ("", false) for an interactive
+// session, a missing/garbage file, or any other kind. Non-Claude PIDs have no
+// such file, so this is a safe no-op for every other adapter.
+func ReadBackgroundMeta(pid int) (name string, ok bool) {
+	if pid <= 0 || sessionsDir == "" {
+		return "", false
+	}
+	meta, found := readSessionMeta(filepath.Join(sessionsDir, strconv.Itoa(pid)+".json"))
+	if !found || meta.Kind != "bg" {
+		return "", false
+	}
+	return meta.Name, true
 }
 
 // pidAlive returns true if signal 0 can be delivered to pid (i.e. the process

--- a/core/adapters/inbound/agents/claudecode/pid_background_test.go
+++ b/core/adapters/inbound/agents/claudecode/pid_background_test.go
@@ -1,0 +1,56 @@
+package claudecode
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// TestReadBackgroundMeta verifies the #744 registry read: a kind:"bg" entry is
+// reported as a background agent (carrying Claude's job name), while interactive
+// sessions, missing files, and garbage are not.
+func TestReadBackgroundMeta(t *testing.T) {
+	dir := withTestDeps(t, map[int]bool{}, nil) // overrides sessionsDir to a temp dir
+	write := func(pid int, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, strconv.Itoa(pid)+".json"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write meta: %v", err)
+		}
+	}
+	write(100, `{"pid":100,"sessionId":"s-bg","kind":"bg","name":"Add guiding colors"}`)
+	write(101, `{"pid":101,"sessionId":"s-int","kind":"interactive"}`)
+	write(102, `{"pid":102,"sessionId":"s-bg-noname","kind":"bg"}`)
+	write(103, `not json`)
+
+	t.Run("bg with name", func(t *testing.T) {
+		if name, ok := ReadBackgroundMeta(100); !ok || name != "Add guiding colors" {
+			t.Errorf("got (%q, %v), want (\"Add guiding colors\", true)", name, ok)
+		}
+	})
+	t.Run("interactive is not background", func(t *testing.T) {
+		if _, ok := ReadBackgroundMeta(101); ok {
+			t.Error("interactive session reported as background")
+		}
+	})
+	t.Run("bg without a name is still background", func(t *testing.T) {
+		if name, ok := ReadBackgroundMeta(102); !ok || name != "" {
+			t.Errorf("got (%q, %v), want (\"\", true)", name, ok)
+		}
+	})
+	t.Run("garbage file is ignored", func(t *testing.T) {
+		if _, ok := ReadBackgroundMeta(103); ok {
+			t.Error("garbage file reported as background")
+		}
+	})
+	t.Run("missing file", func(t *testing.T) {
+		if _, ok := ReadBackgroundMeta(999); ok {
+			t.Error("missing file reported as background")
+		}
+	})
+	t.Run("non-positive pid", func(t *testing.T) {
+		if _, ok := ReadBackgroundMeta(0); ok {
+			t.Error("pid<=0 reported as background")
+		}
+	})
+}

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -35,6 +35,13 @@ type LiveCWDsFunc func(processName string) (map[string]struct{}, error)
 // processlifecycle adapter and is injected to preserve the hexagonal layering.
 type LauncherEnvReader func(pid int) *session.Launcher
 
+// BackgroundReader reports adapter-specific background-agent metadata for a PID
+// (e.g. Claude Code's kind:"bg" registry entry for an Agent-View background
+// agent). Returns nil for ordinary interactive sessions or PIDs the adapter
+// doesn't recognize. The real reader lives in the claudecode adapter and is
+// injected to preserve the hexagonal layering (#744).
+type BackgroundReader func(pid int) *session.BackgroundAgent
+
 // PIDManager manages the process lifecycle for sessions. It discovers PIDs,
 // registers them with ProcessWatcher, handles exits, and sweeps dead processes.
 type PIDManager struct {
@@ -63,6 +70,10 @@ type PIDManager struct {
 
 	// launcherEnv reads launcher env from a PID. Optional — nil skips capture.
 	launcherEnv LauncherEnvReader
+
+	// background reads background-agent metadata from a PID. Optional — nil
+	// skips capture (#744).
+	background BackgroundReader
 
 	// argvExcluders maps adapter name → its Process.ExcludeArgv predicate, and
 	// readArgv reads a live PID's argv. Together they let the liveness sweep
@@ -161,6 +172,13 @@ func (pm *PIDManager) SetLauncherEnvReader(fn LauncherEnvReader) {
 	pm.launcherEnv = fn
 }
 
+// SetBackgroundReader installs a reader that flags a session as a background
+// agent (e.g. a detached Claude Code Agent View bg agent) when its PID is
+// assigned. Nil disables the check. Called once at startup (#744).
+func (pm *PIDManager) SetBackgroundReader(fn BackgroundReader) {
+	pm.background = fn
+}
+
 // SetInfraReaper installs the seam the liveness sweep uses to reap a session
 // bound to a still-alive PID that is the adapter's background infrastructure
 // rather than the interactive session (issue #727). excluders maps adapter name
@@ -181,6 +199,25 @@ func (pm *PIDManager) captureLauncher(state *session.SessionState, pid int) {
 	if l := pm.launcherEnv(pid); l != nil {
 		state.Launcher = l
 	}
+}
+
+// captureBackground flags state as a background agent when the reader recognizes
+// its PID, stamping Detached from the captured Launcher TTY. Must run AFTER
+// captureLauncher so the controlling TTY is known. Set-once: a no-op once
+// Background is already set, when no reader is installed, or for an unrecognized
+// PID. Returns true when it set Background so callers can persist (#744).
+func (pm *PIDManager) captureBackground(state *session.SessionState, pid int) bool {
+	if pm.background == nil || state == nil || state.Background != nil || pid <= 0 {
+		return false
+	}
+	bg := pm.background(pid)
+	if bg == nil {
+		return false
+	}
+	// No controlling terminal ⇒ no window/tab owns it — the "detached" signature.
+	bg.Detached = state.Launcher == nil || state.Launcher.TTY == ""
+	state.Background = bg
+	return true
 }
 
 // record emits a lifecycle event if recording is enabled.
@@ -494,6 +531,7 @@ func (pm *PIDManager) assignPIDLocked(pid int, sessionID string) (*session.Sessi
 
 	state.PID = pid
 	pm.captureLauncher(state, pid)
+	pm.captureBackground(state, pid) // after captureLauncher: needs the TTY (#744)
 	state.UpdatedAt = time.Now().Unix()
 	_ = pm.repo.Save(state)
 
@@ -933,6 +971,13 @@ func (pm *PIDManager) handleAlivePIDState(state *session.SessionState) bool {
 		}
 	}
 	pm.backfillLauncher(state)
+	// Re-attach the background-agent badge to sessions persisted before the
+	// field existed, or restored after a daemon restart (#744). Runs after
+	// backfillLauncher so Detached reflects the refreshed TTY.
+	if pm.captureBackground(state, state.PID) {
+		state.UpdatedAt = time.Now().Unix()
+		_ = pm.repo.Save(state)
+	}
 	return true
 }
 

--- a/core/application/services/pid_manager_background_test.go
+++ b/core/application/services/pid_manager_background_test.go
@@ -1,0 +1,89 @@
+package services_test
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestHandlePIDAssigned_BackgroundCapture exercises the #744 capture seam:
+// captureBackground flags a session from the injected reader, derives Detached
+// from the controlling TTY (captured by captureLauncher just before it), and is
+// a set-once no-op when no reader / no match.
+func TestHandlePIDAssigned_BackgroundCapture(t *testing.T) {
+	newReady := func() *session.SessionState {
+		return &session.SessionState{SessionID: "s", State: session.StateReady, UpdatedAt: time.Now().Unix()}
+	}
+
+	t.Run("detached when no controlling tty", func(t *testing.T) {
+		repo := newMockRepo()
+		repo.states["s"] = newReady()
+		pm := newPIDManagerForTest(repo)
+		var calls int
+		pm.SetBackgroundReader(func(pid int) *session.BackgroundAgent {
+			calls++
+			return &session.BackgroundAgent{Name: "bg job"}
+		})
+
+		pm.HandlePIDAssigned(42, "s")
+		bg := repo.states["s"].Background
+		if bg == nil {
+			t.Fatal("background not captured")
+		}
+		if bg.Name != "bg job" {
+			t.Errorf("name: got %q, want \"bg job\"", bg.Name)
+		}
+		if !bg.Detached {
+			t.Error("Detached: got false, want true (no launcher TTY)")
+		}
+
+		// Set-once: a later PID with Background already set must not re-invoke.
+		pm.HandlePIDAssigned(99, "s")
+		if calls != 1 {
+			t.Errorf("reader re-invoked: %d calls, want 1", calls)
+		}
+	})
+
+	t.Run("attached when controlling tty present", func(t *testing.T) {
+		repo := newMockRepo()
+		repo.states["s"] = newReady()
+		pm := newPIDManagerForTest(repo)
+		pm.SetLauncherEnvReader(func(pid int) *session.Launcher {
+			return &session.Launcher{TTY: "/dev/ttys003"}
+		})
+		pm.SetBackgroundReader(func(pid int) *session.BackgroundAgent {
+			return &session.BackgroundAgent{Name: "bg job"}
+		})
+
+		pm.HandlePIDAssigned(42, "s")
+		bg := repo.states["s"].Background
+		if bg == nil {
+			t.Fatal("background not captured")
+		}
+		if bg.Detached {
+			t.Error("Detached: got true, want false (launcher TTY present)")
+		}
+	})
+
+	t.Run("nil reader is a no-op", func(t *testing.T) {
+		repo := newMockRepo()
+		repo.states["s"] = newReady()
+		pm := newPIDManagerForTest(repo)
+		pm.HandlePIDAssigned(42, "s")
+		if repo.states["s"].Background != nil {
+			t.Error("Background set without a reader installed")
+		}
+	})
+
+	t.Run("nil result leaves interactive sessions unmarked", func(t *testing.T) {
+		repo := newMockRepo()
+		repo.states["s"] = newReady()
+		pm := newPIDManagerForTest(repo)
+		pm.SetBackgroundReader(func(pid int) *session.BackgroundAgent { return nil })
+		pm.HandlePIDAssigned(42, "s")
+		if repo.states["s"].Background != nil {
+			t.Error("Background set for an unrecognized (nil-result) PID")
+		}
+	})
+}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -323,6 +323,13 @@ func (d *SessionDetector) SetLauncherEnvReader(fn LauncherEnvReader) {
 	d.pidMgr.SetLauncherEnvReader(fn)
 }
 
+// SetBackgroundReader installs a reader that flags a session as a detached
+// background agent (e.g. a Claude Code Agent View bg agent) when its PID is
+// first assigned (#744).
+func (d *SessionDetector) SetBackgroundReader(fn BackgroundReader) {
+	d.pidMgr.SetBackgroundReader(fn)
+}
+
 // SetInfraReaper installs the liveness-sweep seam that reaps a session bound to
 // a still-alive PID which is actually the adapter's background infrastructure
 // (e.g. Claude Code's --bg-spare helper) rather than the session (#727). Both

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -397,10 +397,13 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 			d.log.LogInfo("session-detector", ev.SessionID,
 				fmt.Sprintf("applied deferred pid %d", pid))
 		}
-		// Capture launcher identity idempotently — HandlePIDAssigned
-		// normally populates it, but this path runs first in startup
-		// races where the pending PID is applied before the direct save.
+		// Capture launcher identity + background-agent marker idempotently —
+		// HandlePIDAssigned normally populates them, but this path runs first in
+		// startup races where the pending PID is applied before the direct save.
+		// captureBackground must follow captureLauncher: it derives Detached from
+		// the just-captured TTY (#744).
 		d.pidMgr.captureLauncher(state, pid)
+		d.pidMgr.captureBackground(state, pid)
 	}
 
 	// Retry PID discovery if not yet known.

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -605,6 +605,20 @@ func main() {
 		}
 		return processlifecycle.ReadLauncherEnv(pid)
 	})
+	// Flag detached Claude Code background agents (Agent View bg agents that keep
+	// running in the daemon pool) so the UI can badge them instead of showing a
+	// phantom row (#744). Reads ~/.claude/sessions/<pid>.json, gated by the same
+	// transcripts/observe consent as other claude process reads (#570).
+	detector.SetBackgroundReader(func(pid int) *session.BackgroundAgent {
+		if !permService.Granted(claudecode.AdapterName, claudecode.PermissionKeyTranscripts) {
+			return nil
+		}
+		name, ok := claudecode.ReadBackgroundMeta(pid)
+		if !ok {
+			return nil
+		}
+		return &session.BackgroundAgent{Name: name}
+	})
 	// Let the liveness sweep reap a session bound to a still-alive PID that is
 	// the adapter's background infra rather than the session — Claude Code's
 	// --bg-spare pool helper outlives every session, so a mis-bound session

--- a/core/domain/session/background_test.go
+++ b/core/domain/session/background_test.go
@@ -1,0 +1,37 @@
+package session
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSessionState_BackgroundJSON locks the #744 client contract: nil Background
+// is omitted (so existing goldens are unchanged), a populated one serializes as
+// {name, detached}, and detached=false is dropped by omitempty.
+func TestSessionState_BackgroundJSON(t *testing.T) {
+	s := &SessionState{SessionID: "s", State: StateReady}
+
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "background") {
+		t.Errorf("nil Background must be omitted, got: %s", b)
+	}
+
+	s.Background = &BackgroundAgent{Name: "bg job", Detached: true}
+	b, _ = json.Marshal(s)
+	js := string(b)
+	if !strings.Contains(js, `"background":{`) ||
+		!strings.Contains(js, `"name":"bg job"`) ||
+		!strings.Contains(js, `"detached":true`) {
+		t.Errorf("background JSON shape wrong: %s", js)
+	}
+
+	s.Background = &BackgroundAgent{Name: "bg job"} // Detached false
+	b, _ = json.Marshal(s)
+	if strings.Contains(string(b), "detached") {
+		t.Errorf("detached=false must be omitted, got: %s", b)
+	}
+}

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -660,6 +660,21 @@ type Launcher struct {
 	HostBundleID   string `json:"host_bundle_id,omitempty"`   // CFBundleIdentifier of the host app resolved by process-ancestry when no curated TermProgram matched (e.g. md.obsidian for an in-Obsidian terminal). Unlike TermProgram, this is derived server-side because the client has no map for arbitrary embedded-terminal hosts; the client builds a generic title-match activator from it.
 }
 
+// BackgroundAgent marks a session as a background agent spawned by the agent's
+// own orchestration (Claude Code Agent View). Such an agent keeps running
+// detached in the `claude daemon run` pool after its window/terminal is closed,
+// so it shows up as a live session with no terminal the user can see (#744).
+// Nil for normal interactive sessions. Clients render a "background" badge when
+// present and emphasize "detached" when the agent has no controlling terminal.
+type BackgroundAgent struct {
+	// Name is Claude's human-readable label for the background job
+	// (e.g. "Add guiding colors to quest cards"); may be empty.
+	Name string `json:"name,omitempty"`
+	// Detached is true when the agent has no controlling terminal — i.e. no
+	// window/tab owns it. Computed by the daemon from the captured Launcher TTY.
+	Detached bool `json:"detached,omitempty"`
+}
+
 // IsEmpty reports whether the launcher carries no identifying information
 // — i.e. every field is zero. Capture helpers use this to decide whether to
 // return nil rather than attach a meaningless struct to the session.
@@ -699,6 +714,10 @@ type SessionState struct {
 	// Captured once when PID is first assigned; nil if env capture failed
 	// or no recognized env vars were present.
 	Launcher *Launcher `json:"launcher,omitempty"`
+
+	// Background marks a detached background agent (e.g. a Claude Code Agent
+	// View bg agent living in the daemon pool). Nil for normal sessions (#744).
+	Background *BackgroundAgent `json:"background,omitempty"`
 
 	// ParentSessionID links a subagent session to its spawning parent session.
 	// Derived from file path or heuristic matching in SessionDetector.

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -576,6 +576,20 @@ struct SubagentSummary: Codable {
     let ready: Int
 }
 
+/// BackgroundAgent marks a session as a background agent spawned via the agent's
+/// own orchestration (Claude Code Agent View). Such an agent keeps running
+/// detached in the daemon pool after its window/terminal is closed, so it shows
+/// up as a live session with no terminal the user can see (#744). Nil for normal
+/// interactive sessions.
+struct BackgroundAgent: Codable, Hashable {
+    /// Claude's human-readable label for the background job
+    /// (e.g. "Add guiding colors to quest cards"); may be nil/empty.
+    let name: String?
+    /// True when the agent has no controlling terminal — i.e. no window/tab
+    /// owns it. Computed by the daemon from the captured launcher TTY.
+    let detached: Bool?
+}
+
 /// Launcher identifies the terminal or IDE that spawned the session's agent.
 /// Captured by the daemon when the PID is first assigned. All fields optional —
 /// clients must fall back to the session CWD when nothing identifies the host.
@@ -635,6 +649,7 @@ struct SessionState: Identifiable, Codable {
     let children: [SessionState]? // nested child sessions from API (optional)
     let launcher: Launcher?     // terminal/IDE that spawned this session (optional)
     let controllable: Bool?     // daemon would accept input/interrupt now (backchannel, #724)
+    let background: BackgroundAgent? // detached background agent marker (#744)
 
     // For duplicate handling (not stored in JSON, computed by SessionManager)
     var duplicateIndex: Int? = nil
@@ -676,6 +691,7 @@ struct SessionState: Identifiable, Codable {
         case children
         case launcher
         case controllable
+        case background
     }
     
     // Custom decoder to handle multiple date formats and missing fields
@@ -711,6 +727,7 @@ struct SessionState: Identifiable, Codable {
         children = try container.decodeIfPresent([SessionState].self, forKey: .children)
         launcher = try container.decodeIfPresent(Launcher.self, forKey: .launcher)
         controllable = try container.decodeIfPresent(Bool.self, forKey: .controllable)
+        background = try container.decodeIfPresent(BackgroundAgent.self, forKey: .background)
 
         // Handle firstSeen date (unix timestamp format)
         if let timestamp = try? container.decode(Double.self, forKey: .firstSeen) {
@@ -756,7 +773,7 @@ struct SessionState: Identifiable, Codable {
     }
     
     // Regular initializer for testing/preview purposes
-    init(id: String, state: State, model: String, cwd: String, transcriptPath: String? = nil, gitBranch: String? = nil, projectName: String? = nil, firstSeen: Date, updatedAt: Date, eventCount: Int? = nil, lastEvent: String? = nil, metrics: SessionMetrics? = nil, pid: Int? = nil, parentSessionId: String? = nil, subagents: SubagentSummary? = nil, adapter: String? = nil, daemonVersion: String? = nil, role: String? = nil, roleIcon: String? = nil, roleDescription: String? = nil, workerName: String? = nil, workerID: String? = nil, children: [SessionState]? = nil, launcher: Launcher? = nil, controllable: Bool? = nil) {
+    init(id: String, state: State, model: String, cwd: String, transcriptPath: String? = nil, gitBranch: String? = nil, projectName: String? = nil, firstSeen: Date, updatedAt: Date, eventCount: Int? = nil, lastEvent: String? = nil, metrics: SessionMetrics? = nil, pid: Int? = nil, parentSessionId: String? = nil, subagents: SubagentSummary? = nil, adapter: String? = nil, daemonVersion: String? = nil, role: String? = nil, roleIcon: String? = nil, roleDescription: String? = nil, workerName: String? = nil, workerID: String? = nil, children: [SessionState]? = nil, launcher: Launcher? = nil, controllable: Bool? = nil, background: BackgroundAgent? = nil) {
         self.id = id
         self.state = state
         self.model = model
@@ -782,6 +799,7 @@ struct SessionState: Identifiable, Codable {
         self.children = children
         self.launcher = launcher
         self.controllable = controllable
+        self.background = background
     }
 
     enum State: String, CaseIterable, Codable {

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1308,16 +1308,32 @@ struct SessionRowView: View {
                         .tooltip("\(activeSubagentCount) active subagent\(activeSubagentCount == 1 ? "" : "s")")
                 }
 
-                // Branch name — column shrinks when a subagent badge is present so
+                // Background-agent badge (#744) — a moon marks a Claude Code Agent
+                // View background agent running detached in the daemon pool after
+                // its window closed. Amber "zzz" moon when no window owns it
+                // (detached); a muted moon when a window is still open.
+                if let bg = session.background {
+                    let detached = bg.detached ?? false
+                    let label = (bg.name?.isEmpty == false) ? " (\(bg.name!))" : ""
+                    Image(systemName: detached ? "moon.zzz.fill" : "moon.fill")
+                        .font(.system(size: 9))
+                        .foregroundColor(detached ? IrrColors.waiting : .secondary)
+                        .frame(width: 14, height: 14)
+                        .tooltip(detached
+                            ? "Detached background agent\(label) — no open window; runs in the Claude Code daemon pool"
+                            : "Background agent\(label)")
+                }
+
+                // Branch name — column shrinks when a leading badge is present so
                 // the context-bar column downstream starts at the same x on every row.
-                // Badge occupies 14pt + 6pt spacing = 20pt, which is exactly the amount
-                // we drop from the branch column here.
+                // Each badge occupies 14pt + 6pt spacing = 20pt; we drop that from
+                // the branch column here.
                 Text(session.gitBranch ?? "—")
                     .font(.system(.caption, design: .monospaced))
                     .foregroundColor(.primary)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                    .frame(width: activeSubagentCount > 0 ? 44 : 64, alignment: .leading)
+                    .frame(width: (activeSubagentCount > 0 || session.background != nil) ? 44 : 64, alignment: .leading)
                     .tooltip(session.gitBranch ?? "—")
 
                 if displayMode == .context {

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1314,7 +1314,8 @@ struct SessionRowView: View {
                 // (detached); a muted moon when a window is still open.
                 if let bg = session.background {
                     let detached = bg.detached ?? false
-                    let label = (bg.name?.isEmpty == false) ? " (\(bg.name!))" : ""
+                    let trimmedName = (bg.name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+                    let label = trimmedName.isEmpty ? "" : " (\(trimmedName))"
                     Image(systemName: detached ? "moon.zzz.fill" : "moon.fill")
                         .font(.system(size: 9))
                         .foregroundColor(detached ? IrrColors.waiting : .secondary)
@@ -1324,16 +1325,17 @@ struct SessionRowView: View {
                             : "Background agent\(label)")
                 }
 
-                // Branch name — column shrinks when a leading badge is present so
-                // the context-bar column downstream starts at the same x on every row.
-                // Each badge occupies 14pt + 6pt spacing = 20pt; we drop that from
-                // the branch column here.
+                // Branch name — column shrinks by one badge's width (14pt + 6pt
+                // spacing = 20pt) for EACH leading badge present (subagent count
+                // and/or background-agent), so the context-bar column downstream
+                // starts at the same x on every row regardless of how many badges
+                // a row carries.
                 Text(session.gitBranch ?? "—")
                     .font(.system(.caption, design: .monospaced))
                     .foregroundColor(.primary)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                    .frame(width: (activeSubagentCount > 0 || session.background != nil) ? 44 : 64, alignment: .leading)
+                    .frame(width: 64 - CGFloat(20 * ((activeSubagentCount > 0 ? 1 : 0) + (session.background != nil ? 1 : 0))), alignment: .leading)
                     .tooltip(session.gitBranch ?? "—")
 
                 if displayMode == .context {

--- a/platforms/web/irrlicht.bgbadge.test.js
+++ b/platforms/web/irrlicht.bgbadge.test.js
@@ -84,5 +84,11 @@ describe('background-agent badge (#744)', () => {
 
     // Ordinary session: no badge.
     expect(shown(bgBadge('normal'))).toBe(false)
+
+    // Branch column shrinks for bg rows (has-bg) so columns stay aligned;
+    // ordinary rows keep the full-width branch.
+    expect(rowById('bg-detached').classList.contains('has-bg')).toBe(true)
+    expect(rowById('bg-attached').classList.contains('has-bg')).toBe(true)
+    expect(rowById('normal').classList.contains('has-bg')).toBe(false)
   })
 })

--- a/platforms/web/irrlicht.bgbadge.test.js
+++ b/platforms/web/irrlicht.bgbadge.test.js
@@ -1,0 +1,88 @@
+import { describe, test, expect } from 'vitest'
+
+// #744: a Claude Code Agent View background agent (kind:bg) keeps running
+// detached in the daemon pool after its window closes. The daemon flags it with
+// a `background` object ({name, detached}); the dashboard must render a
+// .row-bg-badge for it (and only it), with .is-detached when no window owns it.
+//
+// Own file so irrlicht.js loads fresh (per-file module isolation) against a
+// payload crafted for this case.
+
+const sessionsPayload = {
+  groups: [
+    {
+      name: 'irrlicht',
+      agents: [
+        {
+          session_id: 'bg-detached',
+          state: 'ready',
+          project_name: 'irrlicht',
+          adapter: 'claude-code',
+          first_seen: 1764800000,
+          metrics: {},
+          background: { name: 'Add guiding colors to quest cards', detached: true },
+        },
+        {
+          session_id: 'bg-attached',
+          state: 'working',
+          project_name: 'irrlicht',
+          adapter: 'claude-code',
+          first_seen: 1764800100,
+          metrics: {},
+          background: { name: 'Tidy imports' },
+        },
+        {
+          session_id: 'normal',
+          state: 'ready',
+          project_name: 'irrlicht',
+          adapter: 'claude-code',
+          first_seen: 1764800200,
+          metrics: {},
+        },
+      ],
+      costs: {},
+    },
+  ],
+  provider_costs: {},
+}
+
+const rowById = (id) =>
+  [...document.querySelectorAll('#session-list .session-row')].find((r) => r.dataset.sessionId === id)
+const bgBadge = (id) => rowById(id).querySelector('.row-bg-badge')
+const shown = (el) => el && el.style.display !== 'none'
+
+describe('background-agent badge (#744)', () => {
+  test('badge shows for kind:bg sessions and emphasizes detached', async () => {
+    global.fetch = (url) => {
+      const u = String(url)
+      if (u.includes('/api/v1/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(sessionsPayload) })
+      }
+      if (u.includes('/api/v1/agents')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve(null) })
+    }
+
+    await import('./irrlicht.js')
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(document.querySelectorAll('#session-list .session-row').length).toBe(3)
+
+    // Detached bg agent: badge shown, amber-emphasized, descriptive tooltip.
+    const detached = bgBadge('bg-detached')
+    expect(shown(detached)).toBe(true)
+    expect(detached.classList.contains('is-detached')).toBe(true)
+    expect(detached.title).toContain('Detached background agent')
+    expect(detached.title).toContain('Add guiding colors to quest cards')
+
+    // Attached bg agent: badge shown, NOT detached.
+    const attached = bgBadge('bg-attached')
+    expect(shown(attached)).toBe(true)
+    expect(attached.classList.contains('is-detached')).toBe(false)
+    expect(attached.title).toBe('Background agent (Tidy imports)')
+
+    // Ordinary session: no badge.
+    expect(shown(bgBadge('normal'))).toBe(false)
+  })
+})

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -600,7 +600,13 @@
       min-width: 64px;
       max-width: 220px;
     }
+    /* Each leading badge (subagent count and/or background-agent) drops the
+       branch column by one badge's width (14px + 6px gap = 20px) so the
+       context-bar column downstream lines up across rows regardless of badge
+       count. Both badges present → drop 40px. */
     .session-row.has-sub .row-branch { flex: 1 1 44px; min-width: 44px; }
+    .session-row.has-bg .row-branch { flex: 1 1 44px; min-width: 44px; }
+    .session-row.has-sub.has-bg .row-branch { flex: 1 1 24px; min-width: 24px; }
 
     /* Small subagent count badge — filled circle with running-count number,
        sized to fit alongside the row's mono text. Mirrors macOS at

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -619,6 +619,27 @@
       font-family: var(--font-sans);
     }
 
+    /* Background-agent badge (#744) — a moon glyph marks a Claude Code Agent
+       View background agent running detached in the daemon pool. Square (not the
+       circular subagent badge) and muted; .is-detached turns it amber to
+       emphasize that no open window owns it. */
+    .row-bg-badge {
+      width: 14px;
+      height: 14px;
+      flex: 0 0 14px;
+      border-radius: 3px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--ctx-bar-track);
+      color: var(--muted);
+    }
+    .row-bg-badge svg { display: block; }
+    .row-bg-badge.is-detached {
+      background: var(--waiting);
+      color: #fff;
+    }
+
     .row-spacer { flex: 1 1 auto; min-width: 4px; }
 
     /* Context bar — floor mirrors macOS ContextBar at SessionListView.swift:420

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -812,6 +812,7 @@ import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collap
         '<span class="row-state-icon"></span>' +
         '<span class="row-num"></span>' +
         '<span class="row-sub-badge" style="display:none"></span>' +
+        '<span class="row-bg-badge" style="display:none"></span>' +
         '<span class="row-role-badge" style="display:none"></span>' +
         '<span class="row-origin" style="display:none"></span>' +
         '<span class="row-branch"></span>' +
@@ -941,6 +942,28 @@ import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collap
       } else {
         subBadge.style.display = 'none';
         el.classList.remove('has-sub');
+      }
+
+      // Background-agent badge (#744) — a moon glyph marks a Claude Code Agent
+      // View background agent that keeps running detached in the daemon pool
+      // after its window is closed. Always shown for kind:bg; the amber
+      // .is-detached state emphasizes "no open window owns this".
+      const bgBadge = el.querySelector('.row-bg-badge');
+      const bg = agent.background;
+      if (bg) {
+        if (!bgBadge.dataset.on) {
+          bgBadge.innerHTML = '<svg viewBox="0 0 24 24" width="11" height="11" fill="currentColor" aria-hidden="true"><path d="M12.74 2.02a.6.6 0 0 0-.66.86 7 7 0 1 1-9.2 9.2.6.6 0 0 0-.86.66A8.5 8.5 0 1 0 12.74 2.02z"/></svg>';
+          bgBadge.dataset.on = '1';
+        }
+        bgBadge.style.display = '';
+        const detached = !!bg.detached;
+        bgBadge.classList.toggle('is-detached', detached);
+        const label = bg.name ? ' (' + bg.name + ')' : '';
+        bgBadge.title = detached
+          ? 'Detached background agent' + label + ' — no open window; runs in the Claude Code daemon pool'
+          : 'Background agent' + label;
+      } else if (bgBadge.style.display !== 'none') {
+        bgBadge.style.display = 'none';
       }
 
       // Context bar

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -958,12 +958,16 @@ import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collap
         bgBadge.style.display = '';
         const detached = !!bg.detached;
         bgBadge.classList.toggle('is-detached', detached);
-        const label = bg.name ? ' (' + bg.name + ')' : '';
+        const name = (bg.name || '').trim();
+        const label = name ? ' (' + name + ')' : '';
         bgBadge.title = detached
           ? 'Detached background agent' + label + ' — no open window; runs in the Claude Code daemon pool'
           : 'Background agent' + label;
-      } else if (bgBadge.style.display !== 'none') {
+        el.classList.add('has-bg');
+      } else {
         bgBadge.style.display = 'none';
+        bgBadge.classList.remove('is-detached');
+        el.classList.remove('has-bg');
       }
 
       // Context bar


### PR DESCRIPTION
## What

Claude Code **Agent View background agents** (`kind:bg`) keep running **detached** in the persistent `claude daemon run` pool after their window/terminal closes. They're genuinely alive — so the #734/#644 infra-reaper correctly leaves them — but from the user's seat they read as "phantom" rows in the list and menu bar.

This applies the issue's **recommended option 1: distinguish, don't reap**. Reaping would be wrong (the supervisor just respawns them ~13s later, per the issue's own follow-up). Instead we surface them with a **"background" badge**, emphasized **"detached"** when no terminal owns the agent.

## How

A single reader set once at startup, mirroring the existing `SetLauncherEnvReader` seam:

- **`claudecode/pid.go`** — `claudeSessionMeta` gains `Kind`/`Name`; new `ReadBackgroundMeta(pid) (name, ok)` reads `~/.claude/sessions/<pid>.json` and returns `ok` only for `kind:"bg"`. Non-Claude PIDs have no such file → harmless no-op.
- **`domain/session/session.go`** — new `BackgroundAgent{Name, Detached}` + `SessionState.Background` (`omitempty` → existing JSON goldens unchanged).
- **`application/services/pid_manager.go`** — `BackgroundReader` type, `SetBackgroundReader`, and `captureBackground` which runs **after** `captureLauncher` so it stamps `Detached` **server-side** from the captured controlling TTY (clients don't guess from a possibly-nil `Launcher`). Also re-attaches on the restart backfill path.
- **`session_detector.go` + `main.go`** — passthrough + wiring, gated by the existing `transcripts`/observe consent (#570).
- **Web** (`irrlicht.js`/`.css`) — `.row-bg-badge` moon glyph; `.is-detached` turns it amber with a descriptive tooltip carrying the bg job's name.
- **macOS** (`SessionState.swift`/`SessionListView.swift`) — `moon.fill`/`moon.zzz.fill` badge, amber when detached.

**Product decision:** badge **all** `kind:bg` sessions, **emphasize detached**.

## Out of scope
- Options 2 (hide toggle) and 3 (idle-timeout reap) — issue marks both secondary/risky.
- Orphaned-supervisor "no owning session" detection (dead `--spawned-by` PID) — possible follow-up.

## Testing
- `go test ./core/... -race -count=1` — full suite green, incl. new `ReadBackgroundMeta`, `captureBackground`, and JSON-shape tests. `irrlichd`/`filesystem` golden tests pass (nil `Background` + `omitempty` ⇒ goldens unchanged).
- `npm test` (web) — 94 pass, incl. new `irrlicht.bgbadge.test.js`.
- `swift build` (macOS) — clean compile.

Closes #744.

🤖 Generated with [Claude Code](https://claude.com/claude-code)