### PR TITLE
fix(macos): dedupe relay echo of local projects in sidebar (#746)

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -633,8 +633,17 @@ class SessionManager: ObservableObject {
     /// Rebuilds the published `apiGroups` from the local groups plus
     /// client-side groups for relay-only sessions, and refreshes
     /// `groupedSessionIds` (used by the local patch guard) from the local set.
+    ///
+    /// Local-wins name-collapse (#746): a relay group whose project name already
+    /// exists locally is dropped, so a project the local daemon publishes — then
+    /// echoes back via the relay it publishes to — renders once. The collapse
+    /// keys on project *name*, not session_id: the echoed/ghost relay rows carry
+    /// drifted ids that escape `relayGroups()`'s id-only filter. Relay-only
+    /// projects (no local group of that name) still appear.
     private func recomposeApiGroups() {
-        apiGroups = orderedGroups(localApiGroups) + relayGroups()
+        let localNames = Set(localApiGroups.map(\.name))
+        apiGroups = orderedGroups(localApiGroups)
+            + relayGroups().filter { !localNames.contains($0.name) }
         groupedSessionIds = Set(localApiGroups.flatMap { collectSessionIds(from: $0) })
     }
 

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -375,6 +375,36 @@ final class SessionManagerApiGroupsTests: XCTestCase {
         XCTAssertNil(sut.sessions.first { $0.id == "proc-1234" }?.daemonID, "the surviving row is the local one")
     }
 
+    // MARK: - Relay echo dedupe (#746)
+
+    /// A project present locally that echoes back via the relay (under a drifted
+    /// session_id, so it escapes the id-only filter) renders exactly once — the
+    /// local copy wins; the relay group of the same name is suppressed.
+    func testRelayEcho_sameProjectName_driftedId_collapsesToLocal() {
+        sut.seedLocalApiGroups([AgentGroup(name: "irrlicht", agents: [makeSession(id: "local-1")])])
+        // Relay echoes the same project under a ghost daemon + drifted id.
+        sut.handleRelayMessage(relayPush(source: "ghostDaemon", sessionId: "drifted-9", project: "irrlicht"))
+
+        let irrlicht = sut.apiGroups.filter { $0.name == "irrlicht" }
+        XCTAssertEqual(irrlicht.count, 1, "a project present locally renders exactly once (local-wins)")
+        XCTAssertTrue(
+            irrlicht.first?.agents?.allSatisfy { $0.daemonID == nil } ?? false,
+            "the surviving group is the local copy (no relay daemonID on its rows)"
+        )
+    }
+
+    /// A relay-only project with no local equivalent still appears — the
+    /// name-collapse only suppresses collisions, not genuine remote projects.
+    func testRelayOnly_differentProject_stillAppears() {
+        sut.seedLocalApiGroups([AgentGroup(name: "irrlicht", agents: [makeSession(id: "local-1")])])
+        sut.handleRelayMessage(relayPush(source: "daemonB", sessionId: "remote-1", project: "otherproj"))
+
+        XCTAssertTrue(
+            sut.apiGroups.contains { $0.name == "otherproj" },
+            "a relay-only project with no local equivalent still appears"
+        )
+    }
+
     // MARK: - Origin glyph (#538)
 
     /// A relay session carries a daemonID, and the relay's snapshot label map


### PR DESCRIPTION
## Problem

Closes #746. In the macOS app, when both **Local daemon** and **Relay** are enabled (`useLocalDaemon=1`, `useRelayServer=1`, `publishToRelay=1`), the local daemon publishes its own sessions to the relay the app subscribes to — so they echo back and the same project (e.g. `irrlicht`) shows up **twice** in the sidebar.

Server-side grouping is correct (`GET /api/v1/sessions` returns one group). The duplication is **client-side**: `SessionManager.recomposeApiGroups()` built `apiGroups = orderedGroups(localApiGroups) + relayGroups()` with no unification by group name, so `relayGroups()` emitted a second group also named `irrlicht`.

The existing id-only dedup in `relayGroups()` (`!localIDs.contains($0.id)`) does **not** catch this: the echoed/ghost relay rows carry **drifted session_ids** (restarted dev `--record` daemon; claude ids rotate on /clear/resume/compact), so they escape an id-based filter.

## Fix

`recomposeApiGroups()` now collapses top-level groups by project **name** with **local-wins**: a relay group whose name already exists locally is suppressed.

```swift
let localNames = Set(localApiGroups.map(\.name))
apiGroups = orderedGroups(localApiGroups)
    + relayGroups().filter { !localNames.contains($0.name) }
```

- Keys on **name**, not session_id — the drifted ids would escape an id merge.
- Matches the issue's stated expected behavior: "a project present locally is rendered exactly once, using the local copy."
- Relay-only projects with no local equivalent still appear; per-row remote rows keep their cloud/host badge (`SessionListView.swift:1189`).
- `relayGroups()` is left unchanged (it stays focused on building; recompose owns the unification). The id/rowID-level dedup and #537 compound-keying for two daemons sharing a session_id are untouched.

## Tests

Two regression tests in `SessionManagerApiGroupsTests.swift`:
- `testRelayEcho_sameProjectName_driftedId_collapsesToLocal` — local `irrlicht` + relay echo under a drifted id ⇒ exactly one `irrlicht` group, and the survivor is the local copy.
- `testRelayOnly_differentProject_stillAppears` — a relay-only project still appears (guards against over-suppression).

`swift test --filter SessionManagerApiGroupsTests` → 26 tests, 0 failures (existing #537/#538/#540 relay tests still green).

## Out of scope (follow-up)

The relay-side root cause — the relay replaying stale snapshots / ghost daemon registrations under drifted ids (likely a restarted dev `--record` daemon on `funken.io`) — is a separate follow-up (relay-side stale-daemon cleanup), not required for this display fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)