### PR TITLE
feat(metrics): detect cache-creation regressions, attribute to upstream agent versions (#374)

### DIFF
--- a/core/adapters/inbound/agents/aider/parser.go
+++ b/core/adapters/inbound/agents/aider/parser.go
@@ -65,6 +65,8 @@ var (
 	// `> Weak model: …` is intentionally not matched (aider's internal
 	// quick-summary model, not the main turn).
 	modelRE = regexp.MustCompile(`^>\s*(?:Main\s+)?[Mm]odel:\s*(\S+)`)
+	// `> Aider v0.86.2` — the version banner aider prints once at startup.
+	aiderVersionRE = regexp.MustCompile(`^>\s*Aider v(\S+)`)
 	// `> Applied edit to <file>` — file edit tool call
 	appliedEditRE = regexp.MustCompile(`^>\s*Applied edit to\s+`)
 	// `> Running <cmd>` or `> Running shell command:` — shell tool call
@@ -105,6 +107,10 @@ func (p *Parser) ParseLineRaw(line string) *tailer.ParsedEvent {
 			AssistantText:  tailer.TruncateAssistantText(text),
 			ClearToolNames: true,
 		}
+	}
+
+	if m := aiderVersionRE.FindStringSubmatch(line); m != nil {
+		return &tailer.ParsedEvent{Skip: true, AgentVersion: m[1]}
 	}
 
 	if m := modelRE.FindStringSubmatch(line); m != nil {

--- a/core/adapters/inbound/agents/aider/parser_test.go
+++ b/core/adapters/inbound/agents/aider/parser_test.go
@@ -56,9 +56,28 @@ func TestParser_BaselineHello_FullTurn(t *testing.T) {
 		t.Fatalf("expected at least 3 events (model, user, assistant), got %d", len(events))
 	}
 
-	// First non-nil event: the model declaration (Skip with ModelName).
-	if !events[0].Skip || events[0].ModelName == "" {
-		t.Errorf("first event should be Skip+ModelName, got %+v", events[0])
+	// The version banner emits a Skip event carrying AgentVersion (#374).
+	var verEv *tailer.ParsedEvent
+	for _, e := range events {
+		if e.AgentVersion != "" {
+			verEv = e
+			break
+		}
+	}
+	if verEv == nil || verEv.AgentVersion != "0.86.2" {
+		t.Errorf("expected a Skip event with AgentVersion=0.86.2, got %+v", verEv)
+	}
+
+	// The model declaration is a Skip event carrying ModelName.
+	var modelEv *tailer.ParsedEvent
+	for _, e := range events {
+		if e.ModelName != "" {
+			modelEv = e
+			break
+		}
+	}
+	if modelEv == nil || !modelEv.Skip {
+		t.Errorf("expected a Skip event with ModelName, got %+v", modelEv)
 	}
 
 	// User message.
@@ -192,15 +211,27 @@ func TestParser_EmptyTurn_NoCrash(t *testing.T) {
 }
 
 func TestParser_BlockquoteNoise_Skipped(t *testing.T) {
+	// `> Aider vX.Y.Z` is no longer noise — it emits a version event (#374),
+	// covered by TestParser_AiderVersion_Captured.
 	p := &Parser{}
 	for _, line := range []string{
-		"> Aider v0.86.2",
 		"> Use /help for commands",
 		"> Repo-map can't include /tmp/foo (permission)",
 	} {
 		if ev := p.ParseLineRaw(line); ev != nil {
 			t.Errorf("expected nil for noise line %q, got %+v", line, ev)
 		}
+	}
+}
+
+func TestParser_AiderVersion_Captured(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLineRaw("> Aider v0.86.2")
+	if ev == nil || ev.AgentVersion != "0.86.2" {
+		t.Fatalf("expected AgentVersion=0.86.2, got %+v", ev)
+	}
+	if !ev.Skip {
+		t.Error("version event should be Skip=true (no message-event impact)")
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -55,6 +55,12 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 	if cwd := transcript.ExtractCWDFromLine(raw); cwd != "" {
 		ev.CWD = cwd
 	}
+	// The Claude Code CLI stamps its own version on every user/assistant line
+	// (e.g. "2.1.186"). Read it before the early-return paths so it is captured
+	// even from system/user events. The tailer keeps the first non-empty value.
+	if v, ok := raw["version"].(string); ok {
+		ev.AgentVersion = v
+	}
 
 	eventType := resolveEventType(raw)
 

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -10,6 +10,21 @@ import (
 	"irrlicht/core/pkg/tailer"
 )
 
+// TestParser_AgentVersion_Captured pins that the top-level `version` field the
+// Claude Code CLI stamps on user/assistant lines is surfaced on the parsed
+// event for the cache-bloat detector's version attribution (#374).
+func TestParser_AgentVersion_Captured(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type":    "user",
+		"version": "2.1.186",
+		"message": map[string]interface{}{"role": "user", "content": "hi"},
+	})
+	if ev == nil || ev.AgentVersion != "2.1.186" {
+		t.Fatalf("expected AgentVersion=2.1.186, got %+v", ev)
+	}
+}
+
 // --- Contribution / cost tests ---
 
 func TestParser_Contribution_RequestIDDedup(t *testing.T) {

--- a/core/adapters/inbound/agents/codex/parser.go
+++ b/core/adapters/inbound/agents/codex/parser.go
@@ -174,6 +174,14 @@ func (p *Parser) ParseLine(raw map[string]interface{}) *tailer.ParsedEvent {
 		return ev
 
 	case "session_meta", "turn_context":
+		// session_meta.payload.cli_version carries the Codex CLI version (e.g.
+		// "0.137.0"). Capture it before skipping — the tailer applies metadata
+		// from Skip=true events too.
+		if payload, ok := raw["payload"].(map[string]interface{}); ok {
+			if v, ok := payload["cli_version"].(string); ok {
+				ev.AgentVersion = v
+			}
+		}
 		ev.Skip = true
 		return ev
 

--- a/core/adapters/inbound/agents/codex/parser_test.go
+++ b/core/adapters/inbound/agents/codex/parser_test.go
@@ -42,6 +42,24 @@ func TestParser_SessionHeader_Skip(t *testing.T) {
 	}
 }
 
+// TestParser_AgentVersion_Captured pins that session_meta.payload.cli_version
+// is surfaced on the parsed event for the cache-bloat detector (#374), even
+// though the event is itself skipped.
+func TestParser_AgentVersion_Captured(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type":      "session_meta",
+		"timestamp": ts(0),
+		"payload":   map[string]interface{}{"cli_version": "0.137.0"},
+	})
+	if ev == nil || !ev.Skip {
+		t.Fatalf("session_meta should be skipped, got %+v", ev)
+	}
+	if ev.AgentVersion != "0.137.0" {
+		t.Errorf("expected AgentVersion=0.137.0, got %q", ev.AgentVersion)
+	}
+}
+
 func TestParser_RecordTypeState_Skip(t *testing.T) {
 	p := &Parser{}
 	ev := p.ParseLine(map[string]interface{}{

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -20,6 +20,7 @@ func TailerToDomain(m *tailer.SessionMetrics) *session.SessionMetrics {
 		ElapsedSeconds:                    m.ElapsedSeconds,
 		TotalTokens:                       m.TotalTokens,
 		ModelName:                         m.ModelName,
+		AgentVersion:                      m.AgentVersion,
 		ContextWindow:                     m.ContextWindow,
 		ContextUtilization:                m.ContextUtilization,
 		PressureLevel:                     m.PressureLevel,

--- a/core/application/services/cache_bloat_detector.go
+++ b/core/application/services/cache_bloat_detector.go
@@ -122,7 +122,7 @@ func (c *CacheBloatDetector) OnActivity(state *session.SessionState) {
 	if !ok {
 		return
 	}
-	baseline, ok := c.computeBaseline(state.ProjectName, state.Adapter)
+	baseline, ok := c.computeBaseline(state.ProjectName, state.Adapter, sid)
 	if !ok || baseline <= 0 {
 		return // cold start: no comparable history yet, can't judge
 	}
@@ -183,8 +183,10 @@ func (c *CacheBloatDetector) snapshot() []*session.SessionState {
 
 // computeBaseline returns the p25 of "cache creation per completed turn" over
 // the project's completed sessions of the same adapter within the lookback
-// window. ok is false when there is no usable history.
-func (c *CacheBloatDetector) computeBaseline(project, adapter string) (float64, bool) {
+// window, excluding the session under evaluation (excludeID) so a bloated
+// session can't raise the baseline it's judged against. ok is false when there
+// is no usable history.
+func (c *CacheBloatDetector) computeBaseline(project, adapter, excludeID string) (float64, bool) {
 	if project == "" {
 		return 0, false
 	}
@@ -192,7 +194,7 @@ func (c *CacheBloatDetector) computeBaseline(project, adapter string) (float64, 
 	cutoff := c.now() - int64(c.cfg.BaselineDays)*secondsPerDay
 	var samples []float64
 	for _, s := range all {
-		if !c.eligible(s, project, adapter, cutoff) {
+		if !c.eligible(s, project, adapter, cutoff) || s.SessionID == excludeID {
 			continue
 		}
 		samples = append(samples, perTurnCacheCreation(s))
@@ -219,7 +221,8 @@ func (c *CacheBloatDetector) attributeVersion(state *session.SessionState, curre
 	}
 	groups := map[string]*group{}
 	for _, s := range all {
-		if !c.eligible(s, state.ProjectName, state.Adapter, cutoff) || s.Metrics.AgentVersion == "" {
+		if !c.eligible(s, state.ProjectName, state.Adapter, cutoff) ||
+			s.SessionID == state.SessionID || s.Metrics.AgentVersion == "" {
 			continue
 		}
 		g := groups[s.Metrics.AgentVersion]

--- a/core/application/services/cache_bloat_detector.go
+++ b/core/application/services/cache_bloat_detector.go
@@ -1,0 +1,333 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/domain/stats"
+	"irrlicht/core/ports/outbound"
+)
+
+const secondsPerDay = 86400
+
+// maxDeltaWindow bounds the per-session per-turn samples kept for the live
+// rolling median, so a marathon session reflects recent behaviour (and memory
+// stays bounded) rather than averaging over its entire lifetime.
+const maxDeltaWindow = 50
+
+// snapshotTTLSecs caps how often the detector re-scans the session repository
+// for the baseline. The baseline is computed over completed sessions in a
+// multi-day window, so it changes slowly — re-scanning on every turn boundary
+// of every active session would be needless disk I/O.
+const snapshotTTLSecs = 60
+
+// sessionLister is the read-only slice of the SessionRepository that the
+// cache-bloat detector needs: the project's completed sessions, for the
+// rolling baseline and per-version grouping.
+type sessionLister interface {
+	ListAll() ([]*session.SessionState, error)
+}
+
+// cacheBloatEventSink emits the structured cache_bloat_detected lifecycle
+// event. Satisfied by outbound.EventRecorder; narrowed so the detector can be
+// unit-tested without the full recorder.
+type cacheBloatEventSink interface {
+	Record(ev lifecycle.Event)
+}
+
+// CacheBloatConfig holds the cache-regression detector tunables (issue #374).
+type CacheBloatConfig struct {
+	BaselineDays       int     // rolling baseline lookback window
+	Threshold          float64 // trip multiplier; <= 0 disables the rule
+	VersionDeltaTokens int64   // min per-version median delta to attribute
+	MinTurns           int     // variance guard: turns before the rule fires
+}
+
+// CacheBloatDetector flags a working session whose median cache-creation per
+// turn exceeds its project's p25 baseline × threshold, attributes the
+// regression to an upstream agent version when the project's history spans two
+// versions, and emits a structured event the first time it sees each
+// (project, regressing_version) pair within a daemon process lifetime.
+//
+// It is driven once per processActivity pass via OnActivity and runs entirely
+// on the detector's single event-loop goroutine, so its maps need no locking.
+type CacheBloatDetector struct {
+	lister   sessionLister
+	recorder cacheBloatEventSink
+	cfg      CacheBloatConfig
+	now      func() int64 // injectable clock for tests
+
+	lastDone map[string]bool      // sessionID -> IsAgentDone last pass (rising-edge)
+	prevCum  map[string]int64     // sessionID -> CumCacheCreationTokens at last boundary
+	deltas   map[string][]float64 // sessionID -> per-turn cache-creation deltas
+	fired    map[string]struct{}  // "project|version" -> already emitted this process
+
+	cached   []*session.SessionState // short-TTL snapshot of ListAll
+	cachedAt int64                   // unix secs the snapshot was taken
+}
+
+// NewCacheBloatDetector builds a detector. recorder may be nil (the glyph still
+// fires; only the structured event is suppressed).
+func NewCacheBloatDetector(lister sessionLister, recorder cacheBloatEventSink, cfg CacheBloatConfig) *CacheBloatDetector {
+	return &CacheBloatDetector{
+		lister:   lister,
+		recorder: recorder,
+		cfg:      cfg,
+		now:      func() int64 { return time.Now().Unix() },
+		lastDone: map[string]bool{},
+		prevCum:  map[string]int64{},
+		deltas:   map[string][]float64{},
+		fired:    map[string]struct{}{},
+	}
+}
+
+// OnActivity is called once per processActivity pass. On a turn boundary (a
+// rising edge of IsAgentDone) it counts the turn, samples the turn's
+// cache-creation delta, and re-evaluates the regression rule against the
+// project baseline. A no-op on non-boundary passes and when disabled.
+func (c *CacheBloatDetector) OnActivity(state *session.SessionState) {
+	if c == nil || c.cfg.Threshold <= 0 || state == nil || state.Metrics == nil {
+		return // kill switch, or nothing to measure
+	}
+	sid := state.SessionID
+	done := state.Metrics.IsAgentDone()
+	wasDone := c.lastDone[sid]
+	c.lastDone[sid] = done
+	if !done || wasDone {
+		return // still working, or this finished turn was already counted
+	}
+
+	// A turn just completed. Count it and sample this turn's cache creation as
+	// the delta of the cumulative total since the previous boundary.
+	state.Metrics.CompletedTurns++
+	cum := state.Metrics.CumCacheCreationTokens
+	delta := cum - c.prevCum[sid]
+	if delta < 0 {
+		delta = 0 // cumulative reset (e.g. /clear) — don't emit a negative turn
+	}
+	c.prevCum[sid] = cum
+	c.deltas[sid] = append(c.deltas[sid], float64(delta))
+	if len(c.deltas[sid]) > maxDeltaWindow {
+		c.deltas[sid] = c.deltas[sid][len(c.deltas[sid])-maxDeltaWindow:]
+	}
+
+	// Variance guard: need a few turns before the per-session median is stable.
+	if len(c.deltas[sid]) < c.cfg.MinTurns {
+		return
+	}
+	currentMedian, ok := stats.Median(c.deltas[sid])
+	if !ok {
+		return
+	}
+	baseline, ok := c.computeBaseline(state.ProjectName, state.Adapter)
+	if !ok || baseline <= 0 {
+		return // cold start: no comparable history yet, can't judge
+	}
+
+	if currentMedian <= baseline*c.cfg.Threshold {
+		// Below threshold — clear any prior verdict (re-evaluated each turn).
+		state.Metrics.CacheBloat = false
+		state.Metrics.CacheBloatTooltip = ""
+		return
+	}
+
+	// Regression tripped. Set the glyph and (when possible) name the version.
+	state.Metrics.CacheBloat = true
+	tooltip, regressing, prior, deltaTokens := c.attributeVersion(state, currentMedian)
+	state.Metrics.CacheBloatTooltip = tooltip
+
+	// Emit the structured event once per (project, regressing_version) pair
+	// within this process. regressing is "" when no attribution is possible,
+	// which dedupes per project.
+	key := state.ProjectName + "|" + regressing
+	if _, seen := c.fired[key]; seen {
+		return
+	}
+	c.fired[key] = struct{}{}
+	if c.recorder != nil {
+		c.recorder.Record(lifecycle.Event{
+			Kind:              lifecycle.KindCacheBloatDetected,
+			SessionID:         sid,
+			Adapter:           state.Adapter,
+			Project:           state.ProjectName,
+			RegressingVersion: regressing,
+			PriorVersion:      prior,
+			DeltaTokens:       deltaTokens,
+			BaselineMedian:    baseline,
+			CurrentMedian:     currentMedian,
+		})
+	}
+}
+
+// snapshot returns the session repository's sessions, cached for snapshotTTLSecs
+// so a busy session's per-turn evaluations don't re-scan the repository on
+// every turn boundary. Returns nil on a lister error.
+func (c *CacheBloatDetector) snapshot() []*session.SessionState {
+	if c.lister == nil {
+		return nil
+	}
+	now := c.now()
+	if c.cached != nil && now-c.cachedAt < snapshotTTLSecs {
+		return c.cached
+	}
+	all, err := c.lister.ListAll()
+	if err != nil {
+		return nil
+	}
+	c.cached, c.cachedAt = all, now
+	return all
+}
+
+// computeBaseline returns the p25 of "cache creation per completed turn" over
+// the project's completed sessions of the same adapter within the lookback
+// window. ok is false when there is no usable history.
+func (c *CacheBloatDetector) computeBaseline(project, adapter string) (float64, bool) {
+	if project == "" {
+		return 0, false
+	}
+	all := c.snapshot()
+	cutoff := c.now() - int64(c.cfg.BaselineDays)*secondsPerDay
+	var samples []float64
+	for _, s := range all {
+		if !c.eligible(s, project, adapter, cutoff) {
+			continue
+		}
+		samples = append(samples, perTurnCacheCreation(s))
+	}
+	return stats.Percentile(samples, 0.25)
+}
+
+// attributeVersion groups the project's completed sessions by AgentVersion and,
+// when the window spans ≥2 versions whose per-version median cache-creation
+// differs by more than VersionDeltaTokens, returns a tooltip naming the
+// regressing (current) version. Otherwise it returns empty strings — no false
+// attribution.
+func (c *CacheBloatDetector) attributeVersion(state *session.SessionState, currentMedian float64) (tooltip, regressing, prior string, deltaTokens int64) {
+	newest := state.Metrics.AgentVersion
+	if newest == "" {
+		return "", "", "", 0
+	}
+	all := c.snapshot()
+	cutoff := c.now() - int64(c.cfg.BaselineDays)*secondsPerDay
+
+	type group struct {
+		samples  []float64
+		lastSeen int64
+	}
+	groups := map[string]*group{}
+	for _, s := range all {
+		if !c.eligible(s, state.ProjectName, state.Adapter, cutoff) || s.Metrics.AgentVersion == "" {
+			continue
+		}
+		g := groups[s.Metrics.AgentVersion]
+		if g == nil {
+			g = &group{}
+			groups[s.Metrics.AgentVersion] = g
+		}
+		g.samples = append(g.samples, perTurnCacheCreation(s))
+		if s.UpdatedAt > g.lastSeen {
+			g.lastSeen = s.UpdatedAt
+		}
+	}
+	if len(groups) < 2 {
+		return "", "", "", 0 // single version → no attribution
+	}
+
+	// Prior version = the most-recently-seen version other than the newest.
+	var priorLastSeen int64 = -1
+	for v, g := range groups {
+		if v == newest {
+			continue
+		}
+		if g.lastSeen > priorLastSeen {
+			priorLastSeen, prior = g.lastSeen, v
+		}
+	}
+	if prior == "" {
+		return "", "", "", 0
+	}
+
+	// Newest-version median: prefer the project's history; fall back to the
+	// live session's running median when the newest version has no completed
+	// sessions persisted yet.
+	newestMedian := currentMedian
+	if g := groups[newest]; g != nil {
+		if m, ok := stats.Median(g.samples); ok {
+			newestMedian = m
+		}
+	}
+	priorMedian, ok := stats.Median(groups[prior].samples)
+	if !ok {
+		return "", "", "", 0
+	}
+
+	delta := newestMedian - priorMedian
+	if delta <= float64(c.cfg.VersionDeltaTokens) {
+		return "", "", "", 0 // versions don't differ enough
+	}
+	deltaTokens = int64(delta)
+	tooltip = fmt.Sprintf("%s %s +%dK cache tokens vs %s", state.Adapter, newest, deltaTokens/1000, prior)
+	return tooltip, newest, prior, deltaTokens
+}
+
+// eligible reports whether a stored session counts toward the project's
+// baseline / version groups: same project + adapter, recent enough, and with
+// enough completed turns to be statistically meaningful.
+func (c *CacheBloatDetector) eligible(s *session.SessionState, project, adapter string, cutoff int64) bool {
+	return s != nil && s.Metrics != nil &&
+		s.ProjectName == project && s.Adapter == adapter &&
+		s.UpdatedAt >= cutoff &&
+		s.Metrics.CompletedTurns >= c.cfg.MinTurns
+}
+
+// perTurnCacheCreation is a completed session's mean cache-creation per turn —
+// the per-session statistic the baseline and version groups are built from.
+func perTurnCacheCreation(s *session.SessionState) float64 {
+	if s.Metrics.CompletedTurns <= 0 {
+		return 0
+	}
+	return float64(s.Metrics.CumCacheCreationTokens) / float64(s.Metrics.CompletedTurns)
+}
+
+// LoggerCacheBloatSink writes cache_bloat_detected findings to the structured
+// events.log via the Logger port — the always-on sink the ir:agent-releases
+// workflow consumes. The event's fields are encoded as a JSON message under
+// the cache_bloat_detected event type. Satisfies cacheBloatEventSink.
+type LoggerCacheBloatSink struct{ log outbound.Logger }
+
+// NewLoggerCacheBloatSink wraps a Logger as the detector's emission sink.
+func NewLoggerCacheBloatSink(log outbound.Logger) *LoggerCacheBloatSink {
+	return &LoggerCacheBloatSink{log: log}
+}
+
+func (s *LoggerCacheBloatSink) Record(ev lifecycle.Event) {
+	if s == nil || s.log == nil {
+		return
+	}
+	payload, err := json.Marshal(struct {
+		Project           string  `json:"project,omitempty"`
+		Adapter           string  `json:"adapter,omitempty"`
+		RegressingVersion string  `json:"regressing_version,omitempty"`
+		PriorVersion      string  `json:"prior_version,omitempty"`
+		DeltaTokens       int64   `json:"delta_tokens,omitempty"`
+		BaselineMedian    float64 `json:"baseline_median,omitempty"`
+		CurrentMedian     float64 `json:"current_median,omitempty"`
+		SessionID         string  `json:"session_id,omitempty"`
+	}{
+		Project:           ev.Project,
+		Adapter:           ev.Adapter,
+		RegressingVersion: ev.RegressingVersion,
+		PriorVersion:      ev.PriorVersion,
+		DeltaTokens:       ev.DeltaTokens,
+		BaselineMedian:    ev.BaselineMedian,
+		CurrentMedian:     ev.CurrentMedian,
+		SessionID:         ev.SessionID,
+	})
+	if err != nil {
+		return
+	}
+	s.log.LogInfo(string(lifecycle.KindCacheBloatDetected), ev.SessionID, string(payload))
+}

--- a/core/application/services/cache_bloat_detector_test.go
+++ b/core/application/services/cache_bloat_detector_test.go
@@ -224,6 +224,52 @@ func TestCacheBloat_BaselineExcludesOldSessions(t *testing.T) {
 	}
 }
 
+// The glyph clears on a later turn boundary once the rolling median drops back
+// under the threshold (the rule is re-evaluated every turn).
+func TestCacheBloat_ClearsWhenMedianDropsBack(t *testing.T) {
+	hist := []*session.SessionState{
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 3*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 2*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 1*secondsPerDay),
+	}
+	d := newDetector(&fakeLister{hist}, &fakeRecorder{}, testCfg())
+
+	live := liveSession("proj", "claude-code", "1.0.0")
+	driveTurns(d, live, 20000, 3) // baseline 5000, median 20000 → trips
+	if !live.Metrics.CacheBloat {
+		t.Fatal("expected glyph to fire after bloated turns")
+	}
+	driveTurns(d, live, 1000, 4) // median falls to 1000 → below 5000×1.4
+	if live.Metrics.CacheBloat {
+		t.Error("glyph should clear once median drops back under threshold")
+	}
+	if live.Metrics.CacheBloatTooltip != "" {
+		t.Errorf("tooltip should clear too, got %q", live.Metrics.CacheBloatTooltip)
+	}
+}
+
+// A bloated prior snapshot of the SAME session must not raise the baseline it's
+// judged against (self-exclusion). With few samples, including it would lift
+// p25 enough to mask the regression.
+func TestCacheBloat_ExcludesSelfFromBaseline(t *testing.T) {
+	selfSnapshot := histSession("proj", "claude-code", "1.0.0", 4, 20000, 1*secondsPerDay)
+	selfSnapshot.SessionID = "live-1" // same id as the live session
+	hist := []*session.SessionState{
+		histSession("proj", "claude-code", "1.0.0", 4, 5000, 2*secondsPerDay), // SID ""
+		selfSnapshot,
+	}
+	d := newDetector(&fakeLister{hist}, &fakeRecorder{}, testCfg())
+
+	live := liveSession("proj", "claude-code", "1.0.0") // SessionID "live-1"
+	driveTurns(d, live, 10000, 3)                       // median 10000
+
+	// Excluding self → baseline p25 = 5000 → trips (10000 > 7000). Including
+	// self (20000) would push p25 to ~8750 → trip needs >12250 → no trip.
+	if !live.Metrics.CacheBloat {
+		t.Error("self snapshot must be excluded from baseline; rule should trip")
+	}
+}
+
 type capturingLogger struct {
 	eventType, sessionID, message string
 	calls                         int

--- a/core/application/services/cache_bloat_detector_test.go
+++ b/core/application/services/cache_bloat_detector_test.go
@@ -1,0 +1,298 @@
+package services
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+)
+
+const testNow int64 = 2_000_000_000
+
+type fakeLister struct{ sessions []*session.SessionState }
+
+func (f *fakeLister) ListAll() ([]*session.SessionState, error) { return f.sessions, nil }
+
+type fakeRecorder struct{ events []lifecycle.Event }
+
+func (f *fakeRecorder) Record(ev lifecycle.Event) { f.events = append(f.events, ev) }
+
+func testCfg() CacheBloatConfig {
+	return CacheBloatConfig{BaselineDays: 14, Threshold: 1.4, VersionDeltaTokens: 10000, MinTurns: 3}
+}
+
+func newDetector(lister sessionLister, rec cacheBloatEventSink, cfg CacheBloatConfig) *CacheBloatDetector {
+	d := NewCacheBloatDetector(lister, rec, cfg)
+	d.now = func() int64 { return testNow }
+	return d
+}
+
+// histSession builds a completed session for the baseline/version history.
+func histSession(project, adapter, version string, turns int, perTurn, ageSecs int64) *session.SessionState {
+	return &session.SessionState{
+		ProjectName: project,
+		Adapter:     adapter,
+		UpdatedAt:   testNow - ageSecs,
+		Metrics: &session.SessionMetrics{
+			AgentVersion:           version,
+			CompletedTurns:         turns,
+			CumCacheCreationTokens: perTurn * int64(turns),
+		},
+	}
+}
+
+func liveSession(project, adapter, version string) *session.SessionState {
+	return &session.SessionState{
+		SessionID:   "live-1",
+		ProjectName: project,
+		Adapter:     adapter,
+		Metrics:     &session.SessionMetrics{AgentVersion: version},
+	}
+}
+
+// driveTurns simulates n completed turns, each adding perTurn cache-creation
+// tokens: a working pass (IsAgentDone=false) then a turn_done pass (rising edge).
+func driveTurns(d *CacheBloatDetector, st *session.SessionState, perTurn int64, n int) {
+	for i := 0; i < n; i++ {
+		st.Metrics.LastEventType = "user_message"
+		d.OnActivity(st)
+		st.Metrics.CumCacheCreationTokens += perTurn
+		st.Metrics.LastEventType = "turn_done"
+		d.OnActivity(st)
+	}
+}
+
+// Scenario A: two adapter versions, the newer one bloated → glyph fires,
+// tooltip names the version, exactly one cache_bloat_detected event.
+func TestCacheBloat_ScenarioA_VersionAttribution(t *testing.T) {
+	hist := []*session.SessionState{
+		histSession("proj", "claude-code", "1.0.0", 4, 5000, 10*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 4, 5000, 9*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 4, 5000, 8*secondsPerDay),
+		histSession("proj", "claude-code", "2.0.0", 4, 20000, 2*secondsPerDay),
+		histSession("proj", "claude-code", "2.0.0", 4, 20000, 1*secondsPerDay),
+		histSession("proj", "claude-code", "2.0.0", 4, 20000, 1*secondsPerDay),
+	}
+	rec := &fakeRecorder{}
+	d := newDetector(&fakeLister{hist}, rec, testCfg())
+
+	live := liveSession("proj", "claude-code", "2.0.0")
+	driveTurns(d, live, 20000, 3)
+
+	if !live.Metrics.CacheBloat {
+		t.Fatal("expected CacheBloat glyph to fire")
+	}
+	tip := live.Metrics.CacheBloatTooltip
+	if !strings.Contains(tip, "2.0.0") || !strings.Contains(tip, "1.0.0") || !strings.Contains(tip, "claude-code") {
+		t.Errorf("tooltip should name both versions and adapter, got %q", tip)
+	}
+	if len(rec.events) != 1 {
+		t.Fatalf("expected exactly 1 event, got %d", len(rec.events))
+	}
+	ev := rec.events[0]
+	if ev.Kind != lifecycle.KindCacheBloatDetected {
+		t.Errorf("wrong event kind: %s", ev.Kind)
+	}
+	if ev.RegressingVersion != "2.0.0" || ev.PriorVersion != "1.0.0" {
+		t.Errorf("version fields wrong: regressing=%q prior=%q", ev.RegressingVersion, ev.PriorVersion)
+	}
+	if ev.DeltaTokens != 15000 {
+		t.Errorf("delta_tokens = %d, want 15000", ev.DeltaTokens)
+	}
+	if ev.Project != "proj" || ev.Adapter != "claude-code" {
+		t.Errorf("project/adapter wrong: %q %q", ev.Project, ev.Adapter)
+	}
+}
+
+// Scenario B: one adapter version, bloated → glyph fires WITHOUT version
+// attribution (no false naming).
+func TestCacheBloat_ScenarioB_NoFalseAttribution(t *testing.T) {
+	hist := []*session.SessionState{
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 5*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 4*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 3*secondsPerDay),
+	}
+	rec := &fakeRecorder{}
+	d := newDetector(&fakeLister{hist}, rec, testCfg())
+
+	live := liveSession("proj", "claude-code", "1.0.0")
+	driveTurns(d, live, 10000, 3)
+
+	if !live.Metrics.CacheBloat {
+		t.Fatal("expected CacheBloat glyph to fire")
+	}
+	if live.Metrics.CacheBloatTooltip != "" {
+		t.Errorf("tooltip must be empty (no attribution), got %q", live.Metrics.CacheBloatTooltip)
+	}
+	if len(rec.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(rec.events))
+	}
+	if rec.events[0].RegressingVersion != "" {
+		t.Errorf("regressing_version must be empty, got %q", rec.events[0].RegressingVersion)
+	}
+}
+
+// Scenario C: threshold=0 disables the rule entirely (kill switch).
+func TestCacheBloat_ScenarioC_KillSwitch(t *testing.T) {
+	hist := []*session.SessionState{
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 3*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 2*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 1*secondsPerDay),
+	}
+	cfg := testCfg()
+	cfg.Threshold = 0
+	rec := &fakeRecorder{}
+	d := newDetector(&fakeLister{hist}, rec, cfg)
+
+	live := liveSession("proj", "claude-code", "1.0.0")
+	driveTurns(d, live, 1_000_000, 6) // absurdly bloated
+
+	if live.Metrics.CacheBloat {
+		t.Error("kill switch: glyph must not fire")
+	}
+	if len(rec.events) != 0 {
+		t.Errorf("kill switch: no events, got %d", len(rec.events))
+	}
+}
+
+// Scenario D: only 2 completed turns with high cache_creation → no glyph
+// (variance guard fires below MinTurns).
+func TestCacheBloat_ScenarioD_VarianceGuard(t *testing.T) {
+	hist := []*session.SessionState{
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 3*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 2*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 1*secondsPerDay),
+	}
+	rec := &fakeRecorder{}
+	d := newDetector(&fakeLister{hist}, rec, testCfg())
+
+	live := liveSession("proj", "claude-code", "1.0.0")
+	driveTurns(d, live, 100000, 2) // 2 turns only
+
+	if live.Metrics.CacheBloat {
+		t.Error("variance guard: glyph must not fire below MinTurns")
+	}
+	if live.Metrics.CompletedTurns != 2 {
+		t.Errorf("CompletedTurns = %d, want 2", live.Metrics.CompletedTurns)
+	}
+	if len(rec.events) != 0 {
+		t.Errorf("variance guard: no events, got %d", len(rec.events))
+	}
+}
+
+// Dedupe: repeated detection on the same (project, version) emits one event.
+func TestCacheBloat_DedupePerProjectVersion(t *testing.T) {
+	hist := []*session.SessionState{
+		histSession("proj", "claude-code", "1.0.0", 4, 5000, 10*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 4, 5000, 9*secondsPerDay),
+		histSession("proj", "claude-code", "2.0.0", 4, 20000, 2*secondsPerDay),
+		histSession("proj", "claude-code", "2.0.0", 4, 20000, 1*secondsPerDay),
+	}
+	rec := &fakeRecorder{}
+	d := newDetector(&fakeLister{hist}, rec, testCfg())
+
+	live := liveSession("proj", "claude-code", "2.0.0")
+	driveTurns(d, live, 20000, 8) // keep tripping
+
+	if len(rec.events) != 1 {
+		t.Fatalf("expected 1 event despite repeated detection, got %d", len(rec.events))
+	}
+}
+
+// Baseline lookback: sessions older than the window are excluded, so a stale
+// low baseline can't suppress detection (and vice versa).
+func TestCacheBloat_BaselineExcludesOldSessions(t *testing.T) {
+	hist := []*session.SessionState{
+		// In-window, low → baseline ~5000.
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 3*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 2*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 1*secondsPerDay),
+		// Out-of-window, huge — must be ignored (else baseline balloons and
+		// the live session would never trip).
+		histSession("proj", "claude-code", "1.0.0", 5, 10_000_000, 30*secondsPerDay),
+	}
+	rec := &fakeRecorder{}
+	d := newDetector(&fakeLister{hist}, rec, testCfg())
+
+	live := liveSession("proj", "claude-code", "1.0.0")
+	driveTurns(d, live, 10000, 3)
+
+	if !live.Metrics.CacheBloat {
+		t.Error("old huge session should be excluded from baseline; rule should trip")
+	}
+}
+
+type capturingLogger struct {
+	eventType, sessionID, message string
+	calls                         int
+}
+
+func (c *capturingLogger) LogInfo(eventType, sessionID, message string) {
+	c.eventType, c.sessionID, c.message = eventType, sessionID, message
+	c.calls++
+}
+func (c *capturingLogger) LogError(string, string, string)                      {}
+func (c *capturingLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (c *capturingLogger) Close() error                                         { return nil }
+
+// The events.log sink writes a parseable cache_bloat_detected JSON line
+// carrying the issue's field set — the ir:agent-releases consumer's contract.
+func TestLoggerCacheBloatSink_WritesStructuredEvent(t *testing.T) {
+	lg := &capturingLogger{}
+	sink := NewLoggerCacheBloatSink(lg)
+	sink.Record(lifecycle.Event{
+		Kind:              lifecycle.KindCacheBloatDetected,
+		SessionID:         "sess-9",
+		Adapter:           "claude-code",
+		Project:           "proj",
+		RegressingVersion: "2.0.0",
+		PriorVersion:      "1.0.0",
+		DeltaTokens:       15000,
+		BaselineMedian:    5000,
+		CurrentMedian:     20000,
+	})
+	if lg.calls != 1 {
+		t.Fatalf("expected 1 LogInfo call, got %d", lg.calls)
+	}
+	if lg.eventType != "cache_bloat_detected" {
+		t.Errorf("eventType = %q, want cache_bloat_detected", lg.eventType)
+	}
+	if lg.sessionID != "sess-9" {
+		t.Errorf("sessionID = %q", lg.sessionID)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(lg.message), &got); err != nil {
+		t.Fatalf("message is not valid JSON: %v (%q)", err, lg.message)
+	}
+	for k, want := range map[string]any{
+		"project": "proj", "adapter": "claude-code",
+		"regressing_version": "2.0.0", "prior_version": "1.0.0",
+		"delta_tokens": float64(15000), "session_id": "sess-9",
+	} {
+		if got[k] != want {
+			t.Errorf("field %q = %v, want %v", k, got[k], want)
+		}
+	}
+}
+
+// A different adapter's history must not contaminate the baseline.
+func TestCacheBloat_BaselineFiltersByAdapter(t *testing.T) {
+	hist := []*session.SessionState{
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 3*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 2*secondsPerDay),
+		histSession("proj", "claude-code", "1.0.0", 5, 5000, 1*secondsPerDay),
+		// Same project, different adapter, huge — must not affect claude-code.
+		histSession("proj", "codex", "9.9.9", 5, 10_000_000, 1*secondsPerDay),
+	}
+	rec := &fakeRecorder{}
+	d := newDetector(&fakeLister{hist}, rec, testCfg())
+
+	live := liveSession("proj", "claude-code", "1.0.0")
+	driveTurns(d, live, 10000, 3)
+
+	if !live.Metrics.CacheBloat {
+		t.Error("other-adapter history must not raise the claude-code baseline")
+	}
+}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -103,6 +103,7 @@ type SessionDetector struct {
 	pidMgr         *PIDManager
 	costTracker    outbound.CostTracker    // optional; nil = disabled
 	historyTracker outbound.HistoryTracker // optional; nil = disabled
+	cacheBloat     *CacheBloatDetector     // optional; nil = disabled (#374)
 	metrics        outbound.MetricsCollector
 
 	// projectSessions tracks sessionID → projectDir for pre-session cleanup.
@@ -315,6 +316,14 @@ func (d *SessionDetector) SetCostTracker(c outbound.CostTracker) {
 // state-transition timelines in memory. Pass nil to disable.
 func (d *SessionDetector) SetHistoryTracker(h outbound.HistoryTracker) {
 	d.historyTracker = h
+}
+
+// SetCacheBloatDetector wires the optional cache-creation regression detector
+// (#374). When set, each processActivity pass drives it so it can flag a
+// session whose cache-creation per turn regresses against the project baseline.
+// Pass nil to disable.
+func (d *SessionDetector) SetCacheBloatDetector(c *CacheBloatDetector) {
+	d.cacheBloat = c
 }
 
 // SetLauncherEnvReader installs a reader that captures terminal/IDE identity

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -614,6 +614,13 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 				state.WaitingStartTime = nil
 			}
 		}
+
+		// Cache-creation regression detection (#374). Driven every substantive
+		// pass; the detector itself recognises turn boundaries (rising edge of
+		// IsAgentDone) and is a no-op otherwise or when disabled.
+		if d.cacheBloat != nil {
+			d.cacheBloat.OnActivity(state)
+		}
 	}
 
 	// Refresh the unified sub-agent summary (in-process from the adapter

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -541,6 +541,20 @@ func main() {
 	}
 	detector.SetHistoryTracker(historyTracker)
 
+	// Cache-creation regression detector (#374): per-project baseline from the
+	// session repo; findings logged to events.log for the ir:agent-releases
+	// consumer. Self-disables when cacheBloatThreshold <= 0 (the kill switch).
+	detector.SetCacheBloatDetector(services.NewCacheBloatDetector(
+		cachedRepo,
+		services.NewLoggerCacheBloatSink(logger),
+		services.CacheBloatConfig{
+			BaselineDays:       cfg.CacheBloatBaselineDays,
+			Threshold:          cfg.CacheBloatThreshold,
+			VersionDeltaTokens: cfg.CacheBloatVersionDeltaTokens,
+			MinTurns:           cfg.CacheBloatMinTurns,
+		},
+	))
+
 	// PermissionService: single source of truth for consent state (issue
 	// #570). Exercises grants (hook install, watcher start), undoes
 	// revokes, arbitrates wizard answers between the macOS and web UIs,

--- a/core/domain/config/config.go
+++ b/core/domain/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -32,11 +33,32 @@ const (
 	PermissionModeGrantAll = "grant-all"
 )
 
+// Cache-bloat detector defaults (issue #374). The per-project p25 baseline of
+// cache-creation-per-turn is computed over completed sessions in the trailing
+// CacheBloatBaselineDays window; a working session trips the rule when its
+// median cache-creation-per-turn exceeds baseline × CacheBloatThreshold, but
+// not before CacheBloatMinTurns completed turns (variance guard). Version
+// attribution fires only when two versions differ by more than
+// CacheBloatVersionDeltaTokens. A threshold of 0 (or negative) disables the
+// whole rule — the kill switch.
+const (
+	defaultCacheBloatBaselineDays      = 14
+	defaultCacheBloatThreshold         = 1.4
+	defaultCacheBloatVersionDeltaToken = 10000
+	defaultCacheBloatMinTurns          = 3
+)
+
 // Config holds daemon-wide runtime configuration.
 type Config struct {
 	MaxSessionAge   time.Duration
 	ReadySessionTTL time.Duration
 	PermissionMode  string
+
+	// Cache-bloat detector knobs (issue #374), overridable via env vars.
+	CacheBloatBaselineDays       int
+	CacheBloatThreshold          float64
+	CacheBloatVersionDeltaTokens int64
+	CacheBloatMinTurns           int
 }
 
 // Default returns a Config populated with production defaults, with the
@@ -57,5 +79,32 @@ func Default() Config {
 		MaxSessionAge:   defaultMaxSessionAge,
 		ReadySessionTTL: ttl,
 		PermissionMode:  mode,
+
+		CacheBloatBaselineDays:       envInt("IRRLICHT_CACHE_BLOAT_BASELINE_DAYS", defaultCacheBloatBaselineDays),
+		CacheBloatThreshold:          envFloat("IRRLICHT_CACHE_BLOAT_THRESHOLD", defaultCacheBloatThreshold),
+		CacheBloatVersionDeltaTokens: int64(envInt("IRRLICHT_CACHE_BLOAT_VERSION_DELTA", defaultCacheBloatVersionDeltaToken)),
+		CacheBloatMinTurns:           envInt("IRRLICHT_CACHE_BLOAT_MIN_TURNS", defaultCacheBloatMinTurns),
 	}
+}
+
+// envInt reads a non-negative integer env override, falling back to def when
+// unset or unparseable. Negative values are rejected (fall back to def).
+func envInt(key string, def int) int {
+	if raw := os.Getenv(key); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil && v >= 0 {
+			return v
+		}
+	}
+	return def
+}
+
+// envFloat reads a float env override, falling back to def when unset or
+// unparseable. Zero and negative values are honored (0 = kill switch).
+func envFloat(key string, def float64) float64 {
+	if raw := os.Getenv(key); raw != "" {
+		if v, err := strconv.ParseFloat(raw, 64); err == nil {
+			return v
+		}
+	}
+	return def
 }

--- a/core/domain/lifecycle/event.go
+++ b/core/domain/lifecycle/event.go
@@ -55,6 +55,13 @@ const (
 	// capture (pipe-pane + a screen-buffer parser) and is not emitted yet.
 	KindUIDetected    Kind = "ui_detected"
 	KindTerminalFrame Kind = "terminal_frame"
+
+	// Cache-creation regression (issue #374). Emitted once per
+	// (project, regressing_version) pair within a daemon process lifetime when
+	// the detector first finds a working session's median cache-creation per
+	// turn exceeding the project's p25 baseline × threshold. The named
+	// consumer is the ir:agent-releases workflow.
+	KindCacheBloatDetected Kind = "cache_bloat_detected"
 )
 
 // Event is a single recorded lifecycle signal. The Kind field discriminates
@@ -107,4 +114,12 @@ type Event struct {
 	// Terminal-backend read-back (KindUIDetected). The UI state read off the
 	// rendered terminal screen, e.g. "trust_dialog". Empty on the clearing edge.
 	UIKind string `json:"ui_kind,omitempty"`
+
+	// Cache-creation regression (KindCacheBloatDetected, issue #374).
+	Project           string  `json:"project,omitempty"`
+	RegressingVersion string  `json:"regressing_version,omitempty"`
+	PriorVersion      string  `json:"prior_version,omitempty"`
+	DeltaTokens       int64   `json:"delta_tokens,omitempty"`
+	BaselineMedian    float64 `json:"baseline_median,omitempty"`
+	CurrentMedian     float64 `json:"current_median,omitempty"`
 }

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -130,9 +130,10 @@ type SessionMetrics struct {
 	CumCacheReadTokens     int64 `json:"cum_cache_read_tokens,omitempty"`
 	CumCacheCreationTokens int64 `json:"cum_cache_creation_tokens,omitempty"`
 
-	// CompletedTurns counts the working→waiting transitions observed for this
-	// session — i.e. how many agent turns have finished. The cache-bloat
-	// detector (issue #374) uses it both as the per-session denominator for
+	// CompletedTurns counts the finished agent turns for this session — each
+	// rising edge of IsAgentDone (a turn ending in ready, or in waiting on a
+	// question), not just working→waiting. The cache-bloat detector (issue
+	// #374) maintains it and uses it both as the per-session denominator for
 	// "cache creation per turn" and as a variance guard (the rule does not
 	// fire until ≥3 turns). Incremented by the detector on each turn boundary
 	// and persisted so the per-project baseline can be computed over completed

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -31,9 +31,18 @@ type MetricsTimelinePoint struct {
 
 // SessionMetrics holds computed performance metrics from transcript analysis.
 type SessionMetrics struct {
-	ElapsedSeconds     int64   `json:"elapsed_seconds"`
-	TotalTokens        int64   `json:"total_tokens"`
-	ModelName          string  `json:"model_name"`
+	ElapsedSeconds int64  `json:"elapsed_seconds"`
+	TotalTokens    int64  `json:"total_tokens"`
+	ModelName      string `json:"model_name"`
+
+	// AgentVersion is the upstream agent CLI's own version (e.g. Claude Code
+	// "2.1.143"), distinct from DaemonVersion (irrlichd's version). Captured
+	// from the transcript by adapters that expose it (claudecode, codex,
+	// aider); empty for adapters whose transcript omits it. The cache-bloat
+	// detector (issue #374) groups a project's completed sessions by this
+	// value to attribute a regression to a specific version.
+	AgentVersion string `json:"agent_version,omitempty"`
+
 	ContextWindow      int64   `json:"context_window,omitempty"`
 	ContextUtilization float64 `json:"context_utilization_percentage"`
 	PressureLevel      string  `json:"pressure_level"`
@@ -120,6 +129,30 @@ type SessionMetrics struct {
 	CumOutputTokens        int64 `json:"cum_output_tokens,omitempty"`
 	CumCacheReadTokens     int64 `json:"cum_cache_read_tokens,omitempty"`
 	CumCacheCreationTokens int64 `json:"cum_cache_creation_tokens,omitempty"`
+
+	// CompletedTurns counts the working→waiting transitions observed for this
+	// session — i.e. how many agent turns have finished. The cache-bloat
+	// detector (issue #374) uses it both as the per-session denominator for
+	// "cache creation per turn" and as a variance guard (the rule does not
+	// fire until ≥3 turns). Incremented by the detector on each turn boundary
+	// and persisted so the per-project baseline can be computed over completed
+	// sessions.
+	CompletedTurns int `json:"completed_turns,omitempty"`
+
+	// CacheBloat is true when the cache-creation regression detector (issue
+	// #374) has found this working session's median cache-creation per turn
+	// exceeding the project's p25 baseline × threshold. Both UIs render it as
+	// a "↑" glyph on the row. Set by the detector; never derived from the
+	// transcript.
+	CacheBloat bool `json:"cache_bloat,omitempty"`
+
+	// CacheBloatTooltip is the human-readable hover text for the CacheBloat
+	// glyph, composed daemon-side so both UIs stay dumb. When the project's
+	// lookback window contains ≥2 distinct agent versions with a large enough
+	// per-version delta, it names the regressing version, e.g.
+	// "claude-code 2.1.143 +14K cache tokens vs 2.1.98". Empty when no version
+	// attribution is possible (no false attribution).
+	CacheBloatTooltip string `json:"cache_bloat_tooltip,omitempty"`
 
 	// LastCWD is the most recent working directory extracted from the
 	// transcript during metrics parsing. Used to avoid a separate file read.
@@ -731,6 +764,7 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 		ElapsedSeconds:       newM.ElapsedSeconds,
 		TotalTokens:          newM.TotalTokens,
 		ModelName:            newM.ModelName,
+		AgentVersion:         newM.AgentVersion,
 		ContextWindow:        newM.ContextWindow,
 		ContextUtilization:   newM.ContextUtilization,
 		PressureLevel:        newM.PressureLevel,
@@ -759,6 +793,9 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 		CumOutputTokens:          newM.CumOutputTokens,
 		CumCacheReadTokens:       newM.CumCacheReadTokens,
 		CumCacheCreationTokens:   newM.CumCacheCreationTokens,
+		CompletedTurns:           newM.CompletedTurns,
+		CacheBloat:               newM.CacheBloat,
+		CacheBloatTooltip:        newM.CacheBloatTooltip,
 		Tasks:                    newM.Tasks,
 		NoSubstantiveActivity:    newM.NoSubstantiveActivity,
 		SawManualCompactBoundary: newM.SawManualCompactBoundary,
@@ -810,6 +847,25 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 	}
 	if merged.CumCacheCreationTokens == 0 && oldM.CumCacheCreationTokens > 0 {
 		merged.CumCacheCreationTokens = oldM.CumCacheCreationTokens
+	}
+	// AgentVersion appears once in the transcript header — carry it across the
+	// many markerless passes that follow, exactly like ModelName.
+	if merged.AgentVersion == "" && oldM.AgentVersion != "" {
+		merged.AgentVersion = oldM.AgentVersion
+	}
+	// CompletedTurns is incremented by the detector on the SessionState *after*
+	// this merge; the tailer never sets it, so newM always carries 0. Carry the
+	// accumulated count forward or every pass would reset it to zero.
+	if merged.CompletedTurns == 0 && oldM.CompletedTurns > 0 {
+		merged.CompletedTurns = oldM.CompletedTurns
+	}
+	// CacheBloat / CacheBloatTooltip are overlay flags set by the detector on
+	// turn boundaries (newM never carries them). Keep the last verdict sticky
+	// across mid-turn passes so the glyph doesn't flicker; the detector
+	// overwrites it on the next turn boundary.
+	if !merged.CacheBloat && oldM.CacheBloat {
+		merged.CacheBloat = oldM.CacheBloat
+		merged.CacheBloatTooltip = oldM.CacheBloatTooltip
 	}
 	// nil Tasks = "no data yet"; non-nil empty slice = "no tasks" — overwrite only for the latter.
 	if merged.Tasks == nil && oldM.Tasks != nil {

--- a/core/domain/stats/percentile.go
+++ b/core/domain/stats/percentile.go
@@ -1,0 +1,43 @@
+// Package stats provides small statistical helpers used by the cost and
+// cache-regression detectors. The helpers operate on copies of their input
+// so callers' slices are never mutated.
+package stats
+
+import "sort"
+
+// Percentile returns the p-th percentile of xs using linear interpolation
+// between the two closest ranks (the same method as NumPy's default). p is a
+// fraction in [0,1]; values outside that range are clamped. The second return
+// value is false when xs is empty (no percentile is defined).
+func Percentile(xs []float64, p float64) (float64, bool) {
+	if len(xs) == 0 {
+		return 0, false
+	}
+	if p < 0 {
+		p = 0
+	}
+	if p > 1 {
+		p = 1
+	}
+	sorted := make([]float64, len(xs))
+	copy(sorted, xs)
+	sort.Float64s(sorted)
+
+	if len(sorted) == 1 {
+		return sorted[0], true
+	}
+	// Rank position on a 0-based index scale.
+	rank := p * float64(len(sorted)-1)
+	lo := int(rank)
+	if lo >= len(sorted)-1 {
+		return sorted[len(sorted)-1], true
+	}
+	frac := rank - float64(lo)
+	return sorted[lo] + frac*(sorted[lo+1]-sorted[lo]), true
+}
+
+// Median returns the 50th percentile of xs. The second return value is false
+// when xs is empty.
+func Median(xs []float64) (float64, bool) {
+	return Percentile(xs, 0.5)
+}

--- a/core/domain/stats/percentile_test.go
+++ b/core/domain/stats/percentile_test.go
@@ -1,0 +1,60 @@
+package stats
+
+import (
+	"math"
+	"testing"
+)
+
+func almostEqual(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func TestPercentileEmpty(t *testing.T) {
+	if _, ok := Percentile(nil, 0.25); ok {
+		t.Fatal("expected ok=false for empty input")
+	}
+	if _, ok := Median([]float64{}); ok {
+		t.Fatal("expected ok=false for empty median")
+	}
+}
+
+func TestPercentileSingle(t *testing.T) {
+	v, ok := Percentile([]float64{42}, 0.25)
+	if !ok || v != 42 {
+		t.Fatalf("single-element: got %v ok=%v", v, ok)
+	}
+}
+
+func TestPercentileInterpolation(t *testing.T) {
+	xs := []float64{1, 2, 3, 4}
+	// p25 over [1,2,3,4]: rank = 0.25*3 = 0.75 → 1 + 0.75*(2-1) = 1.75
+	if v, _ := Percentile(xs, 0.25); !almostEqual(v, 1.75) {
+		t.Fatalf("p25 = %v, want 1.75", v)
+	}
+	// median over [1,2,3,4]: rank = 0.5*3 = 1.5 → 2 + 0.5*(3-2) = 2.5
+	if v, _ := Median(xs); !almostEqual(v, 2.5) {
+		t.Fatalf("median = %v, want 2.5", v)
+	}
+}
+
+func TestPercentileOddMedian(t *testing.T) {
+	if v, _ := Median([]float64{5, 1, 3}); !almostEqual(v, 3) {
+		t.Fatalf("median = %v, want 3", v)
+	}
+}
+
+func TestPercentileClampAndBounds(t *testing.T) {
+	xs := []float64{10, 20, 30}
+	if v, _ := Percentile(xs, -1); !almostEqual(v, 10) {
+		t.Fatalf("p<0 = %v, want 10 (min)", v)
+	}
+	if v, _ := Percentile(xs, 2); !almostEqual(v, 30) {
+		t.Fatalf("p>1 = %v, want 30 (max)", v)
+	}
+}
+
+func TestPercentileDoesNotMutate(t *testing.T) {
+	xs := []float64{3, 1, 2}
+	_, _ = Median(xs)
+	if xs[0] != 3 || xs[1] != 1 || xs[2] != 2 {
+		t.Fatalf("input was mutated: %v", xs)
+	}
+}

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -186,7 +186,11 @@ type ParsedEvent struct {
 	TaskSnapshot *[]TaskSnapshotEntry
 
 	// Metadata extracted by the parser.
-	ModelName     string
+	ModelName string
+	// AgentVersion is the upstream agent CLI's version, if the transcript
+	// exposes it (claudecode header `version`, codex `session_meta.cli_version`,
+	// aider `> Aider vX.Y.Z`). Empty otherwise. See issue #374.
+	AgentVersion  string
 	ContextWindow int64
 	// Tokens is the latest-turn snapshot used for context-utilization display.
 	// It is NOT used for cost accumulation — use Contribution for that.
@@ -418,6 +422,11 @@ type LedgerState struct {
 	// model — codex token_count) still routes to the right pricing bucket
 	// after a daemon restart, before the next model-bearing event arrives.
 	ModelName string `json:"model_name,omitempty"`
+	// AgentVersion persists the upstream agent CLI version parsed from the
+	// transcript header so a daemon restart that resumes at LastOffset (zero
+	// new lines, header never re-read) keeps it for the cache-bloat detector's
+	// version attribution. See issue #374.
+	AgentVersion string `json:"agent_version,omitempty"`
 	// LastEventType persists the most recent substantive event type so a
 	// daemon restart that resumes at LastOffset (zero new lines) can still
 	// answer IsAgentDone. Without it, a session persisted as `working` whose

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -63,6 +63,7 @@ type SessionMetrics struct {
 	CumCacheCreationTokens int64   `json:"cum_cache_creation_tokens,omitempty"`
 	EstimatedCostUSD       float64 `json:"estimated_cost_usd,omitempty"`
 	ModelName              string  `json:"model_name,omitempty"`
+	AgentVersion           string  `json:"agent_version,omitempty"`
 	ContextWindow          int64   `json:"context_window,omitempty"`
 	ContextUtilization     float64 `json:"context_utilization_percentage,omitempty"`
 	PressureLevel          string  `json:"pressure_level,omitempty"` // "safe", "caution", "warning", "critical"
@@ -403,6 +404,7 @@ func (t *TranscriptTailer) GetLedgerState() LedgerState {
 		LastOffset:         t.lastOffset,
 		CumProviderCostUSD: t.cumProviderCostUSD,
 		ModelName:          t.metrics.ModelName,
+		AgentVersion:       t.metrics.AgentVersion,
 		LastEventType:      t.metrics.LastEventType,
 		LastAssistantText:  t.lastAssistantText,
 	}
@@ -464,6 +466,9 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 	t.cumProviderCostUSD = s.CumProviderCostUSD
 	if s.ModelName != "" {
 		t.metrics.ModelName = s.ModelName
+	}
+	if s.AgentVersion != "" {
+		t.metrics.AgentVersion = s.AgentVersion
 	}
 	// Restore the classification anchor: a resume-at-EOF pass processes no
 	// events, and IsAgentDone needs the pre-restart event type to recognise

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -112,6 +112,11 @@ func (t *TranscriptTailer) applyModelMetadata(parsed *ParsedEvent) {
 	if parsed.ContextWindow > 0 {
 		t.contextWindowOverride = parsed.ContextWindow
 	}
+	// AgentVersion is sticky: the transcript exposes it once (header line), so
+	// keep the first non-empty value rather than letting later events blank it.
+	if parsed.AgentVersion != "" && t.metrics.AgentVersion == "" {
+		t.metrics.AgentVersion = parsed.AgentVersion
+	}
 }
 
 // applyTokenSnapshot updates the latest-turn snapshot fields used for

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -341,6 +341,8 @@ struct SessionMetrics: Codable {
     let rateLimitForecastEta: Date?        // projected wall-clock time when the imminent window hits 100% (nil when unforecastable)
     let taskEstimate: TaskEstimateInfo?    // agent-authored task progress from the in-band marker (issue #558)
     let taskCompletionEta: Date?           // projected task completion (nil when no marker / no progress yet)
+    let cacheBloat: Bool?                  // cache-creation regression detected for this session (issue #374)
+    let cacheBloatTooltip: String?         // hover text naming the regressing version (empty when no attribution)
 
     enum CodingKeys: String, CodingKey {
         case elapsedSeconds = "elapsed_seconds"
@@ -357,6 +359,8 @@ struct SessionMetrics: Codable {
         case rateLimitForecastEta = "rate_limit_forecast_eta"
         case taskEstimate = "task_estimate"
         case taskCompletionEta = "task_completion_eta"
+        case cacheBloat = "cache_bloat"
+        case cacheBloatTooltip = "cache_bloat_tooltip"
     }
 
     init(from decoder: Decoder) throws {
@@ -387,6 +391,8 @@ struct SessionMetrics: Codable {
         } else {
             taskCompletionEta = nil
         }
+        cacheBloat = try c.decodeIfPresent(Bool.self, forKey: .cacheBloat)
+        cacheBloatTooltip = try c.decodeIfPresent(String.self, forKey: .cacheBloatTooltip)
     }
 
     /// Explicit memberwise initializer for SwiftUI previews and tests that
@@ -406,7 +412,9 @@ struct SessionMetrics: Codable {
         rateLimit: RateLimitInfo? = nil,
         rateLimitForecastEta: Date? = nil,
         taskEstimate: TaskEstimateInfo? = nil,
-        taskCompletionEta: Date? = nil
+        taskCompletionEta: Date? = nil,
+        cacheBloat: Bool? = nil,
+        cacheBloatTooltip: String? = nil
     ) {
         self.elapsedSeconds = elapsedSeconds
         self.totalTokens = totalTokens
@@ -422,6 +430,8 @@ struct SessionMetrics: Codable {
         self.rateLimitForecastEta = rateLimitForecastEta
         self.taskEstimate = taskEstimate
         self.taskCompletionEta = taskCompletionEta
+        self.cacheBloat = cacheBloat
+        self.cacheBloatTooltip = cacheBloatTooltip
     }
 
     func encode(to encoder: Encoder) throws {
@@ -440,6 +450,8 @@ struct SessionMetrics: Codable {
         try c.encodeIfPresent(rateLimitForecastEta.map { $0.timeIntervalSince1970 }, forKey: .rateLimitForecastEta)
         try c.encodeIfPresent(taskEstimate, forKey: .taskEstimate)
         try c.encodeIfPresent(taskCompletionEta.map { $0.timeIntervalSince1970 }, forKey: .taskCompletionEta)
+        try c.encodeIfPresent(cacheBloat, forKey: .cacheBloat)
+        try c.encodeIfPresent(cacheBloatTooltip, forKey: .cacheBloatTooltip)
     }
     
     // Computed properties for UI display

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1203,6 +1203,20 @@ struct SessionRowView: View {
                         .tooltip(offline ? "\(host) — offline" : host)
                 }
 
+                // Cache-creation regression glyph (#374) — an upward arrow marks
+                // a session whose median cache-creation per turn has regressed
+                // past the project baseline. The tooltip names the regressing
+                // upstream version when the daemon could attribute it.
+                if session.metrics?.cacheBloat == true {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 9))
+                        .foregroundColor(.orange)
+                        .frame(width: 14, alignment: .center)
+                        .tooltip(session.metrics?.cacheBloatTooltip?.isEmpty == false
+                            ? session.metrics!.cacheBloatTooltip!
+                            : "cache-creation regression")
+                }
+
                 // Active subagent count badge
                 if activeSubagentCount > 0 {
                     Text("\(activeSubagentCount)")

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -846,6 +846,14 @@
       color: var(--muted); opacity: 0.85;
     }
     .row-origin svg { display: block; }
+    /* Cache-creation regression glyph (#374) — an upward arrow tinted with the
+       warning color, surfaced when the daemon flags a cache-creation
+       regression for the session. */
+    .row-cache-bloat {
+      width: 14px; height: 14px; flex-shrink: 0;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--warning, #e0a000); font-weight: 700; cursor: default;
+    }
     /* Active tool indicator — hidden for now (the overlay doesn't surface it
        in the default row either). Keep the rule + JS update path so we can
        re-enable later, but force-hide via CSS. */

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -813,6 +813,7 @@ import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
         '<span class="row-sub-badge" style="display:none"></span>' +
         '<span class="row-role-badge" style="display:none"></span>' +
         '<span class="row-origin" style="display:none"></span>' +
+        '<span class="row-cache-bloat" style="display:none">↑</span>' +
         '<span class="row-branch"></span>' +
         '<span class="row-tool" style="display:none"></span>' +
         '<span class="row-ctx-bar"><span class="row-ctx-fill"></span><span class="row-ctx-label"></span></span>' +
@@ -930,6 +931,19 @@ import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
         originEl.title = daemonLabelFor(sourceIdOf(agent.session_id));
       } else if (originEl.style.display !== 'none') {
         originEl.style.display = 'none';
+      }
+
+      // Cache-creation regression glyph (#374) — an upward arrow marks a
+      // session whose median cache-creation per turn regressed past the project
+      // baseline. Tooltip names the regressing upstream version when attributed.
+      const cacheBloatEl = el.querySelector('.row-cache-bloat');
+      if (cacheBloatEl) {
+        if (metrics.cache_bloat) {
+          cacheBloatEl.style.display = '';
+          cacheBloatEl.title = metrics.cache_bloat_tooltip || 'cache-creation regression';
+        } else if (cacheBloatEl.style.display !== 'none') {
+          cacheBloatEl.style.display = 'none';
+        }
       }
 
       const subBadge = el.querySelector('.row-sub-badge');


### PR DESCRIPTION
Closes #374.

Ports codeburn's cache-bloat detector to run **live** in the daemon: flag a working session whose median cache-creation per turn exceeds the project's p25 baseline × threshold, attribute the regression to a specific upstream agent version when the project history spans two versions, and emit a structured event the moment it fires.

## What landed

**Detector** — `core/application/services/cache_bloat_detector.go`
- Per-project **p25 baseline** of cache-creation-per-turn over completed sessions of the same adapter in a trailing N-day window, sourced from `SessionRepository.ListAll()` (cost-tracker persistence untouched) behind a 60s snapshot cache.
- Live **rolling median** of per-turn cache-creation deltas; trips when `> baseline × threshold` (default 1.4). **Kill switch** at `threshold ≤ 0`; **variance guard** below 3 completed turns.
- **Version attribution**: groups window sessions by `AgentVersion`; names the regressing version when ≥2 versions differ by > 10K tokens, else empty tooltip (no false attribution).
- Emits `cache_bloat_detected` to **`events.log`** via the `Logger` (the `ir:agent-releases` consumer), once per `(project, regressing_version)` per process.

**Data capture**
- New `AgentVersion` on `SessionMetrics`, riding the existing `Model` enrichment seam (tailer → `TailerToDomain`) and persisted across restarts via the ledger.
- Captured from transcripts for **claudecode** (top-level `version`), **codex** (`session_meta.cli_version`), **aider** (`> Aider vX`). pi/opencode expose it only via process argv → **follow-up**; they fire the glyph without a version tooltip (the issue's required no-false-attribution behavior).
- New `CompletedTurns` counter + `CacheBloat`/`CacheBloatTooltip`, wired into `MergeMetrics` with carry-over guards.

**Config**: `IRRLICHT_CACHE_BLOAT_{BASELINE_DAYS,THRESHOLD,VERSION_DELTA,MIN_TURNS}`.

**UI**: `↑` glyph + tooltip on the macOS row (`SessionListView`) and the web row (`irrlicht.js`/`.css`), cloning the existing origin-glyph path; tooltip composed daemon-side.

## Deliberate deviations from the issue text
1. **Tests are Go service-level**, not transcript-replay — the replay harness asserts a single transcript's stream and can't express a per-project baseline over N sessions + config + version grouping. Covered: scenarios A–D, dedupe, baseline lookback/adapter filtering, the `events.log` sink, stats percentile/median, and per-adapter version capture.
2. **Event → `events.log` (`Logger`)**, not the lifecycle recorder (which only exists under `--record`) — that's what `ir:agent-releases` consumes.

## Verification
- `go test ./... -race` (green serially; the intermittent parallel `-race` flakes are pre-existing test-harness races in `session_detector_test.go`/`debounce_test.go`, neither in this diff), `go vet`, `go build ./...`.
- `tools/onboarding-factory/...` pass (new `SessionMetrics` fields don't perturb replay goldens — `cmd/replay/types.go` is a curated struct), `replay-fixtures.sh` ok, `of validate` ok, `build-dev.sh` builds.
- web `npm test` 93/93; macOS `swift build` + tests compile clean.

## Follow-up
- pi/opencode `AgentVersion` capture via process argv (the precursor the issue anticipates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)