### PR TITLE
feat(web): History tab — Phase 1 cost analytics (#369)

### DIFF
--- a/core/adapters/outbound/filesystem/cost_tracker.go
+++ b/core/adapters/outbound/filesystem/cost_tracker.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
 )
 
 const (
@@ -441,6 +442,147 @@ func addContributions(s *sessionWindows, key string, out map[string]map[string]f
 		}
 		out[tf][key] += d
 	}
+}
+
+// seriesAgg accumulates one session's per-bucket incremental cost while a cost
+// file is scanned. prevCost carries the running cumulative cost so the next
+// in-range row's delta can be computed; project is the bucket key (constant
+// across a session's rows, matching scanWindows).
+type seriesAgg struct {
+	project  string
+	prevCost float64
+	hasPrev  bool
+	buckets  []float64
+}
+
+// CostSeries returns a per-project incremental-cost time series bucketed into
+// fixed bucketSeconds-wide buckets spanning [start, end) (unix seconds), plus
+// each project's total over the range. A session's spend in a bucket is the
+// increase in its cumulative cost across the rows that fall in that bucket; the
+// last row before start (or, failing that, the first in-range row) seeds the
+// baseline so pre-range cost is never attributed to the first bucket. Because
+// snapshot cost is monotonic, summing a project's buckets yields the same
+// (max − baseline) total CostsInWindows computes for the matching trailing
+// window. One pass over every cost file.
+func (t *CostTracker) CostSeries(start, end, bucketSeconds int64) (*outbound.CostSeriesResult, error) {
+	out := &outbound.CostSeriesResult{
+		Start:         start,
+		End:           end,
+		BucketSeconds: bucketSeconds,
+		BucketStarts:  []int64{},
+		ByProject:     map[string][]float64{},
+		Totals:        map[string]float64{},
+	}
+	if bucketSeconds <= 0 || end <= start {
+		return out, nil
+	}
+	n := int((end - start + bucketSeconds - 1) / bucketSeconds)
+	out.BucketStarts = make([]int64, n)
+	for i := range out.BucketStarts {
+		out.BucketStarts[i] = start + int64(i)*bucketSeconds
+	}
+
+	entries, err := os.ReadDir(t.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return out, nil
+		}
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		fallback := strings.TrimSuffix(e.Name(), ".jsonl")
+		if err := t.scanSeries(filepath.Join(t.dir, e.Name()), start, end, bucketSeconds, n, fallback, out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// scanSeries streams one cost file once and folds its sessions' per-bucket
+// deltas into out. A session whose rows carry no project is keyed under
+// fallback (the filename), mirroring CostsInWindows.
+func (t *CostTracker) scanSeries(path string, start, end, bucketSeconds int64, n int, fallback string, out *outbound.CostSeriesResult) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	aggs := make(map[string]*seriesAgg)
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var r snapshotRow
+		if err := json.Unmarshal(line, &r); err != nil {
+			continue
+		}
+		s := aggs[r.Session]
+		if s == nil {
+			s = &seriesAgg{buckets: make([]float64, n)}
+			aggs[r.Session] = s
+		}
+		if r.Project != "" {
+			s.project = r.Project
+		}
+		if r.TS < start {
+			// Pre-range row: keep advancing the baseline so the first
+			// in-range delta measures spend since the last snapshot.
+			s.prevCost = r.Cost
+			s.hasPrev = true
+			continue
+		}
+		if r.TS >= end {
+			continue
+		}
+		if !s.hasPrev {
+			// First observation of this session, with no pre-range baseline:
+			// seed the baseline, contributing nothing for this row.
+			s.prevCost = r.Cost
+			s.hasPrev = true
+			continue
+		}
+		if d := r.Cost - s.prevCost; d > 0 {
+			idx := int((r.TS - start) / bucketSeconds)
+			if idx < 0 {
+				idx = 0
+			} else if idx >= n {
+				idx = n - 1
+			}
+			s.buckets[idx] += d
+		}
+		s.prevCost = r.Cost
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return err
+	}
+	for _, s := range aggs {
+		key := s.project
+		if key == "" {
+			key = fallback
+		}
+		dst := out.ByProject[key]
+		if dst == nil {
+			dst = make([]float64, n)
+			out.ByProject[key] = dst
+		}
+		for i, v := range s.buckets {
+			if v != 0 {
+				dst[i] += v
+				out.Totals[key] += v
+			}
+		}
+	}
+	return nil
 }
 
 // Prune rewrites each project file to drop rows older than olderThanDays.

--- a/core/adapters/outbound/filesystem/cost_tracker.go
+++ b/core/adapters/outbound/filesystem/cost_tracker.go
@@ -368,27 +368,8 @@ type sessionWindows struct {
 //     the minimum cost observed inside the window.
 //   - contribution = max(0, MAX(cost) − baseline).
 func (t *CostTracker) scanWindows(path string, cutoffs map[string]int64) (map[string]*sessionWindows, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	defer f.Close()
-
 	agg := make(map[string]*sessionWindows)
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-		var r snapshotRow
-		if err := json.Unmarshal(line, &r); err != nil {
-			continue
-		}
+	err := scanCostFile(path, func(r snapshotRow) {
 		s := agg[r.Session]
 		if s == nil {
 			s = &sessionWindows{windows: make(map[string]*windowAgg, len(cutoffs))}
@@ -423,11 +404,46 @@ func (t *CostTracker) scanWindows(path string, cutoffs map[string]int64) (map[st
 				w.hasMax = true
 			}
 		}
-	}
-	if err := scanner.Err(); err != nil && err != io.EOF {
+	})
+	if err != nil {
 		return nil, err
 	}
 	return agg, nil
+}
+
+// scanCostFile streams one cost file, invoking perRow for each parsed snapshot
+// row. A missing file and malformed lines are skipped. Shared by scanWindows
+// (trailing-window baseline/max) and scanSeries (per-bucket deltas) so the
+// on-disk format, line-buffer sizing, and skip policy live in one place — the
+// two row folds must stay in lockstep for a series' sum to match its window
+// total.
+func scanCostFile(path string, perRow func(snapshotRow)) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var r snapshotRow
+		if err := json.Unmarshal(line, &r); err != nil {
+			continue
+		}
+		perRow(r)
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return err
+	}
+	return nil
 }
 
 // addContributions folds one session's per-window deltas into out under key.
@@ -455,6 +471,13 @@ type seriesAgg struct {
 	buckets  []float64
 }
 
+// maxSeriesBuckets caps how many buckets CostSeries will allocate, so a wide
+// span paired with a tiny bucket (e.g. a custom range with ?bucket=1) can't
+// force a multi-gigabyte allocation. When the requested granularity would
+// exceed it, the bucket is coarsened to keep [start, end) covered within the
+// ceiling; the result reports the BucketSeconds actually used.
+const maxSeriesBuckets = 10000
+
 // CostSeries returns a per-project incremental-cost time series bucketed into
 // fixed bucketSeconds-wide buckets spanning [start, end) (unix seconds), plus
 // each project's total over the range. A session's spend in a bucket is the
@@ -465,19 +488,31 @@ type seriesAgg struct {
 // (max − baseline) total CostsInWindows computes for the matching trailing
 // window. One pass over every cost file.
 func (t *CostTracker) CostSeries(start, end, bucketSeconds int64) (*outbound.CostSeriesResult, error) {
+	if bucketSeconds <= 0 || end <= start {
+		return &outbound.CostSeriesResult{
+			Start:         start,
+			End:           end,
+			BucketSeconds: bucketSeconds,
+			BucketStarts:  []int64{},
+			ByProject:     map[string][]float64{},
+			Totals:        map[string]float64{},
+		}, nil
+	}
+	// Bound the bucket count: coarsen the bucket if the span would otherwise
+	// blow past the ceiling, keeping the allocation (and JSON payload) bounded
+	// regardless of caller-supplied start/end/bucket.
+	if span := end - start; span/bucketSeconds+1 > maxSeriesBuckets {
+		bucketSeconds = (span + maxSeriesBuckets - 1) / maxSeriesBuckets
+	}
+	n := int((end - start + bucketSeconds - 1) / bucketSeconds)
 	out := &outbound.CostSeriesResult{
 		Start:         start,
 		End:           end,
 		BucketSeconds: bucketSeconds,
-		BucketStarts:  []int64{},
+		BucketStarts:  make([]int64, n),
 		ByProject:     map[string][]float64{},
 		Totals:        map[string]float64{},
 	}
-	if bucketSeconds <= 0 || end <= start {
-		return out, nil
-	}
-	n := int((end - start + bucketSeconds - 1) / bucketSeconds)
-	out.BucketStarts = make([]int64, n)
 	for i := range out.BucketStarts {
 		out.BucketStarts[i] = start + int64(i)*bucketSeconds
 	}
@@ -505,27 +540,8 @@ func (t *CostTracker) CostSeries(start, end, bucketSeconds int64) (*outbound.Cos
 // deltas into out. A session whose rows carry no project is keyed under
 // fallback (the filename), mirroring CostsInWindows.
 func (t *CostTracker) scanSeries(path string, start, end, bucketSeconds int64, n int, fallback string, out *outbound.CostSeriesResult) error {
-	f, err := os.Open(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	defer f.Close()
-
 	aggs := make(map[string]*seriesAgg)
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-		var r snapshotRow
-		if err := json.Unmarshal(line, &r); err != nil {
-			continue
-		}
+	err := scanCostFile(path, func(r snapshotRow) {
 		s := aggs[r.Session]
 		if s == nil {
 			s = &seriesAgg{buckets: make([]float64, n)}
@@ -539,30 +555,26 @@ func (t *CostTracker) scanSeries(path string, start, end, bucketSeconds int64, n
 			// in-range delta measures spend since the last snapshot.
 			s.prevCost = r.Cost
 			s.hasPrev = true
-			continue
+			return
 		}
 		if r.TS >= end {
-			continue
+			return
 		}
 		if !s.hasPrev {
 			// First observation of this session, with no pre-range baseline:
 			// seed the baseline, contributing nothing for this row.
 			s.prevCost = r.Cost
 			s.hasPrev = true
-			continue
+			return
 		}
 		if d := r.Cost - s.prevCost; d > 0 {
-			idx := int((r.TS - start) / bucketSeconds)
-			if idx < 0 {
-				idx = 0
-			} else if idx >= n {
-				idx = n - 1
-			}
-			s.buckets[idx] += d
+			// The guards above filter rows to [start, end), so the index is
+			// always within [0, n-1] — no clamp needed.
+			s.buckets[int((r.TS-start)/bucketSeconds)] += d
 		}
 		s.prevCost = r.Cost
-	}
-	if err := scanner.Err(); err != nil && err != io.EOF {
+	})
+	if err != nil {
 		return err
 	}
 	for _, s := range aggs {

--- a/core/adapters/outbound/filesystem/cost_tracker_test.go
+++ b/core/adapters/outbound/filesystem/cost_tracker_test.go
@@ -455,6 +455,28 @@ func TestCostSeries_SumMatchesWindowTotal(t *testing.T) {
 	}
 }
 
+// TestCostSeries_CapsBucketCount guards against a wide span + tiny bucket
+// forcing an unbounded allocation: the bucket is coarsened so the count stays
+// within maxSeriesBuckets while still covering [start, end).
+func TestCostSeries_CapsBucketCount(t *testing.T) {
+	tr := newTestTracker(t)
+	res, err := tr.CostSeries(0, 2_000_000_000, 1) // naive n would be ~2e9
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.BucketStarts) > maxSeriesBuckets {
+		t.Fatalf("bucket count %d exceeds cap %d", len(res.BucketStarts), maxSeriesBuckets)
+	}
+	if res.BucketSeconds <= 1 {
+		t.Fatalf("bucket should have been coarsened above 1s, got %d", res.BucketSeconds)
+	}
+	// Buckets must still span the whole range.
+	last := res.BucketStarts[len(res.BucketStarts)-1]
+	if last+res.BucketSeconds < 2_000_000_000 {
+		t.Fatalf("buckets do not cover the range: last=%d bucket=%d", last, res.BucketSeconds)
+	}
+}
+
 func TestCostSeries_EmptyAndInvalid(t *testing.T) {
 	tr := newTestTracker(t) // dir does not exist yet
 	res, err := tr.CostSeries(1000, 2000, 100)

--- a/core/adapters/outbound/filesystem/cost_tracker_test.go
+++ b/core/adapters/outbound/filesystem/cost_tracker_test.go
@@ -369,6 +369,116 @@ func abs(f float64) float64 {
 	return f
 }
 
+func sumF(s []float64) float64 {
+	var sum float64
+	for _, v := range s {
+		sum += v
+	}
+	return sum
+}
+
+// TestCostSeries_BucketsDeltas covers the core bucketing rules across two
+// projects in separate files: deltas land in the bucket of the later row;
+// a pre-range row seeds the baseline so the first in-range delta measures
+// spend since the last snapshot; and a session whose first row is in-range
+// contributes nothing for that row (no pre-range baseline).
+func TestCostSeries_BucketsDeltas(t *testing.T) {
+	tr := newTestTracker(t)
+	const start, bucket int64 = 1000, 100
+	const end = start + 4*bucket // 4 buckets: [1000,1100,1200,1300]
+
+	// proj-a / s1: baseline before start, then deltas into buckets 0, 1, 3.
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 950, Project: "proj-a", Session: "s1", Cost: 1.00})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 1050, Project: "proj-a", Session: "s1", Cost: 1.30})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 1150, Project: "proj-a", Session: "s1", Cost: 1.50})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 1350, Project: "proj-a", Session: "s1", Cost: 2.00})
+	// proj-a / s2: first row is in-range → seeds baseline (no delta), one delta into bucket 2.
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 1050, Project: "proj-a", Session: "s2", Cost: 0.50})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 1250, Project: "proj-a", Session: "s2", Cost: 0.90})
+	// proj-b / s3: separate file, single delta into bucket 0.
+	writeRow(t, tr, "proj-b", snapshotRow{TS: 980, Project: "proj-b", Session: "s3", Cost: 5.00})
+	writeRow(t, tr, "proj-b", snapshotRow{TS: 1010, Project: "proj-b", Session: "s3", Cost: 5.20})
+
+	res, err := tr.CostSeries(start, end, bucket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.BucketStarts) != 4 || res.BucketStarts[0] != 1000 || res.BucketStarts[3] != 1300 {
+		t.Fatalf("bucket starts: %v", res.BucketStarts)
+	}
+	wantA := []float64{0.30, 0.20, 0.40, 0.50} // s1 → 0,1,3 ; s2 → 2
+	for i, want := range wantA {
+		if abs(res.ByProject["proj-a"][i]-want) > 1e-9 {
+			t.Errorf("proj-a bucket %d: want %v, got %v", i, want, res.ByProject["proj-a"][i])
+		}
+	}
+	if abs(res.Totals["proj-a"]-1.40) > 1e-9 {
+		t.Errorf("proj-a total: want 1.40, got %v", res.Totals["proj-a"])
+	}
+	wantB := []float64{0.20, 0, 0, 0}
+	for i, want := range wantB {
+		if abs(res.ByProject["proj-b"][i]-want) > 1e-9 {
+			t.Errorf("proj-b bucket %d: want %v, got %v", i, want, res.ByProject["proj-b"][i])
+		}
+	}
+	if abs(res.Totals["proj-b"]-0.20) > 1e-9 {
+		t.Errorf("proj-b total: want 0.20, got %v", res.Totals["proj-b"])
+	}
+}
+
+// TestCostSeries_SumMatchesWindowTotal verifies a series' per-project sum over
+// a trailing window equals the total ProjectCostsInWindows computes for the
+// same window — they share the baseline/delta model.
+func TestCostSeries_SumMatchesWindowTotal(t *testing.T) {
+	tr := newTestTracker(t)
+	now := time.Now().Unix()
+	writeRow(t, tr, "proj-a", snapshotRow{TS: now - 12*3600, Project: "proj-a", Session: "s1", Cost: 1.00})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: now - 1*3600, Project: "proj-a", Session: "s1", Cost: 1.50})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: now - 200*3600, Project: "proj-a", Session: "s2", Cost: 3.00})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: now - 3*24*3600, Project: "proj-a", Session: "s2", Cost: 4.00})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: now - 2*3600, Project: "proj-a", Session: "s2", Cost: 4.75})
+
+	const day int64 = 24 * 3600
+	window, err := tr.ProjectCostsInWindows(map[string]int64{"day": day})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := tr.CostSeries(now-day, now, 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if abs(sumF(res.ByProject["proj-a"])-window["day"]["proj-a"]) > 1e-9 {
+		t.Fatalf("series sum %v != window total %v", sumF(res.ByProject["proj-a"]), window["day"]["proj-a"])
+	}
+	if abs(res.Totals["proj-a"]-window["day"]["proj-a"]) > 1e-9 {
+		t.Fatalf("totals %v != window total %v", res.Totals["proj-a"], window["day"]["proj-a"])
+	}
+}
+
+func TestCostSeries_EmptyAndInvalid(t *testing.T) {
+	tr := newTestTracker(t) // dir does not exist yet
+	res, err := tr.CostSeries(1000, 2000, 100)
+	if err != nil {
+		t.Fatalf("empty dir should not error: %v", err)
+	}
+	if len(res.ByProject) != 0 || len(res.Totals) != 0 {
+		t.Fatalf("want empty maps, got %+v", res)
+	}
+	if len(res.BucketStarts) != 10 {
+		t.Fatalf("want 10 buckets, got %d", len(res.BucketStarts))
+	}
+	// Degenerate args return an empty result, not an error.
+	for _, bad := range [][3]int64{{1000, 2000, 0}, {2000, 1000, 100}} {
+		r, err := tr.CostSeries(bad[0], bad[1], bad[2])
+		if err != nil {
+			t.Fatalf("args %v: unexpected error %v", bad, err)
+		}
+		if len(r.BucketStarts) != 0 {
+			t.Fatalf("args %v: want no buckets, got %d", bad, len(r.BucketStarts))
+		}
+	}
+}
+
 func TestRecordSnapshot_StampsProvider(t *testing.T) {
 	tr := newTestTracker(t)
 	state := &session.SessionState{

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -418,9 +418,6 @@ func buildHistoryResponse(rangeKey, chart, group string, s *outbound.CostSeriesR
 		Series:          []historyPoint{},
 		TopContributors: []historyContributor{},
 	}
-	if resp.BucketStarts == nil {
-		resp.BucketStarts = []int64{}
-	}
 
 	// Deterministic project order: total desc, then name.
 	projects := make([]string, 0, len(s.Totals))
@@ -434,14 +431,12 @@ func buildHistoryResponse(rangeKey, chart, group string, s *outbound.CostSeriesR
 		return projects[i] < projects[j]
 	})
 
-	grand := make([]float64, len(s.BucketStarts))
 	for _, p := range projects {
 		resp.Total += s.Totals[p]
 		for i, v := range s.ByProject[p] {
 			if i >= len(s.BucketStarts) {
 				break
 			}
-			grand[i] += v
 			if v != 0 {
 				resp.Series = append(resp.Series, historyPoint{TS: s.BucketStarts[i], Project: p, Value: v})
 			}
@@ -454,8 +449,8 @@ func buildHistoryResponse(rangeKey, chart, group string, s *outbound.CostSeriesR
 		resp.TopContributors = append(resp.TopContributors, historyContributor{Label: p, Value: s.Totals[p]})
 	}
 
-	if historyForecastEnabled(q) && resp.Total > 0 && len(grand) > 0 {
-		resp.Forecast = computeLinearForecast(grand, s.BucketStarts, s.BucketSeconds, resp.Total, historyForecastBuckets(q, len(grand)))
+	if historyForecastEnabled(q) && resp.Total > 0 && len(s.BucketStarts) > 0 {
+		resp.Forecast = computeLinearForecast(s.BucketStarts, s.BucketSeconds, resp.Total, historyForecastBuckets(q, len(s.BucketStarts)))
 	}
 	return resp
 }
@@ -488,47 +483,28 @@ func historyForecastBuckets(q url.Values, n int) int {
 	return h
 }
 
-// computeLinearForecast fits y = a + b·x (least squares) over the per-bucket
-// grand-total series and projects `horizon` future buckets. Projected is the
-// current total plus the (non-negative) projected future spend; basis is
-// "linear" so the UI can label it an estimate.
-func computeLinearForecast(grand []float64, bucketStarts []int64, bucketSeconds int64, currentTotal float64, horizon int) *historyForecast {
-	n := len(grand)
-	var sx, sy, sxx, sxy float64
-	for i, y := range grand {
-		x := float64(i)
-		sx += x
-		sy += y
-		sxx += x * x
-		sxy += x * y
-	}
-	fn := float64(n)
-	var a, b float64
-	if denom := fn*sxx - sx*sx; denom != 0 {
-		b = (fn*sxy - sx*sy) / denom
-		a = (sy - b*sx) / fn
-	} else if fn > 0 {
-		a = sy / fn
-	}
-
+// computeLinearForecast projects future spend by extrapolating the window's
+// mean per-bucket rate (total ÷ bucket count) forward over `horizon` buckets —
+// a linear extrapolation of cumulative spend. It depends only on the total and
+// the elapsed bucket count, not on where in the window the spend landed: the
+// same total yields the same projection whether spend was bursty-early or
+// bursty-late. (A least-squares fit over the sparse, mostly-zero per-bucket
+// deltas does depend on burst position, which made the headline projection
+// swing widely for identical totals.) basis is "linear" so the UI labels it an
+// estimate.
+func computeLinearForecast(bucketStarts []int64, bucketSeconds int64, currentTotal float64, horizon int) *historyForecast {
+	n := len(bucketStarts)
 	fc := &historyForecast{Basis: "linear", HorizonBuckets: horizon, Series: []historyForecastPoint{}}
-	var lastTS int64
-	if n > 0 {
-		lastTS = bucketStarts[n-1]
-	}
-	var future float64
-	for k := 1; k <= horizon; k++ {
-		y := a + b*float64(n-1+k)
-		if y < 0 {
-			y = 0
-		}
-		fc.Series = append(fc.Series, historyForecastPoint{TS: lastTS + int64(k)*bucketSeconds, Value: y})
-		future += y
-	}
-	fc.Projected = currentTotal + future
-	if fc.Projected < currentTotal {
+	if n == 0 {
 		fc.Projected = currentTotal
+		return fc
 	}
+	rate := currentTotal / float64(n) // mean USD per bucket over the window
+	lastTS := bucketStarts[n-1]
+	for k := 1; k <= horizon; k++ {
+		fc.Series = append(fc.Series, historyForecastPoint{TS: lastTS + int64(k)*bucketSeconds, Value: rate})
+	}
+	fc.Projected = currentTotal + rate*float64(horizon)
 	return fc
 }
 

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -373,12 +373,13 @@ func resolveHistoryRange(q url.Values) (rangeKey string, start, end int64, ok bo
 		rk = "day"
 	}
 	now := time.Now()
+	nowUnix := now.Unix()
 	switch rk {
 	case "day", "week", "month", "year":
-		return rk, now.Unix() - costTimeframeSeconds[rk], now.Unix(), true
+		return rk, nowUnix - costTimeframeSeconds[rk], nowUnix, true
 	case "this-month":
 		first := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
-		return rk, first.Unix(), now.Unix(), true
+		return rk, first.Unix(), nowUnix, true
 	default:
 		return "", 0, 0, false
 	}

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -229,6 +231,305 @@ func providerCostsByProvider(byTf map[string]map[string]float64) map[string]map[
 		return nil
 	}
 	return out
+}
+
+// History tab (issue #369). Phase 1 serves chart=cost grouped by project only,
+// computed from the cost snapshot files via CostTracker.CostSeries. The other
+// chart types and groups are scaffolded in the UI but return 501 here with a
+// phase hint so the frontend can disable them honestly.
+
+type historyPoint struct {
+	TS      int64   `json:"ts"`
+	Project string  `json:"project"`
+	Value   float64 `json:"value"`
+}
+
+type historyContributor struct {
+	Label string  `json:"label"`
+	Value float64 `json:"value"`
+}
+
+type historyForecastPoint struct {
+	TS    int64   `json:"ts"`
+	Value float64 `json:"value"`
+}
+
+type historyForecast struct {
+	Projected      float64                `json:"projected"`
+	Basis          string                 `json:"basis"`
+	HorizonBuckets int                    `json:"horizon_buckets"`
+	Series         []historyForecastPoint `json:"series"`
+}
+
+type historyResponse struct {
+	Range           string               `json:"range"`
+	Chart           string               `json:"chart"`
+	Group           string               `json:"group"`
+	Start           int64                `json:"start"`
+	End             int64                `json:"end"`
+	BucketSeconds   int64                `json:"bucket_seconds"`
+	BucketStarts    []int64              `json:"bucket_starts"`
+	Total           float64              `json:"total"`
+	Series          []historyPoint       `json:"series"`
+	TopContributors []historyContributor `json:"top_contributors"`
+	Forecast        *historyForecast     `json:"forecast,omitempty"`
+}
+
+// handleGetHistory serves GET /api/v1/history?range=&chart=&group=&start=&end=
+// &bucket=&forecast=&forecast_buckets=. Range is a trailing window
+// (day|week|month|year), a calendar shorthand (this-month), or an explicit
+// start&end (unix seconds). Bucket granularity is downsampled at read time.
+func handleGetHistory(tracker outbound.CostTracker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+
+		chart := q.Get("chart")
+		if chart == "" {
+			chart = "cost"
+		}
+		switch chart {
+		case "cost":
+			// implemented
+		case "tokens", "models", "providers":
+			writeHistoryNotImplemented(w, "chart="+chart, 2)
+			return
+		case "agents":
+			writeHistoryNotImplemented(w, "chart="+chart, 3)
+			return
+		default:
+			http.Error(w, "unknown chart: "+chart, http.StatusBadRequest)
+			return
+		}
+
+		group := q.Get("group")
+		if group == "" {
+			group = "project"
+		}
+		switch group {
+		case "project":
+			// implemented
+		case "branch", "provider", "model", "session":
+			writeHistoryNotImplemented(w, "group="+group, 2)
+			return
+		default:
+			http.Error(w, "unknown group: "+group, http.StatusBadRequest)
+			return
+		}
+
+		rangeKey, start, end, ok := resolveHistoryRange(q)
+		if !ok {
+			http.Error(w, "invalid range: use range=day|week|month|year|this-month or start&end (unix seconds)", http.StatusBadRequest)
+			return
+		}
+		bucketSeconds := historyBucketSeconds(q, end-start)
+
+		var series *outbound.CostSeriesResult
+		if tracker != nil {
+			s, err := tracker.CostSeries(start, end, bucketSeconds)
+			if err != nil {
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
+			series = s
+		}
+		if series == nil {
+			// No tracker (init failed): respond with an empty-but-valid payload
+			// so the dashboard renders cleanly instead of erroring.
+			series = &outbound.CostSeriesResult{Start: start, End: end, BucketSeconds: bucketSeconds, BucketStarts: []int64{}, ByProject: map[string][]float64{}, Totals: map[string]float64{}}
+		}
+
+		resp := buildHistoryResponse(rangeKey, chart, group, series, q)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// writeHistoryNotImplemented emits a 501 with a phase hint for chart types and
+// groups scaffolded in the UI but not yet wired (Phase 2/3).
+func writeHistoryNotImplemented(w http.ResponseWriter, what string, phase int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotImplemented)
+	json.NewEncoder(w).Encode(map[string]any{
+		"error": what + " is not implemented in Phase 1",
+		"phase": phase,
+	})
+}
+
+// resolveHistoryRange resolves the requested window to [start, end) unix
+// seconds. Precedence: explicit start&end → calendar shorthand / trailing
+// window via range. Missing range defaults to "day". Returns ok=false on a
+// malformed explicit range or an unknown range key.
+func resolveHistoryRange(q url.Values) (rangeKey string, start, end int64, ok bool) {
+	if s := q.Get("start"); s != "" {
+		startN, err1 := strconv.ParseInt(s, 10, 64)
+		endN, err2 := strconv.ParseInt(q.Get("end"), 10, 64)
+		if err1 != nil || err2 != nil || endN <= startN {
+			return "", 0, 0, false
+		}
+		return "custom", startN, endN, true
+	}
+	rk := q.Get("range")
+	if rk == "" {
+		rk = "day"
+	}
+	now := time.Now()
+	switch rk {
+	case "day", "week", "month", "year":
+		return rk, now.Unix() - costTimeframeSeconds[rk], now.Unix(), true
+	case "this-month":
+		first := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+		return rk, first.Unix(), now.Unix(), true
+	default:
+		return "", 0, 0, false
+	}
+}
+
+// historyBucketSeconds picks a bucket width: an explicit positive ?bucket=
+// override, else downsampled by span — 1 m for ≤2 d, 1 h for ≤14 d, else 1 d.
+func historyBucketSeconds(q url.Values, span int64) int64 {
+	if b := q.Get("bucket"); b != "" {
+		if v, err := strconv.ParseInt(b, 10, 64); err == nil && v > 0 {
+			return v
+		}
+	}
+	switch {
+	case span <= 2*24*3600:
+		return 60
+	case span <= 14*24*3600:
+		return 3600
+	default:
+		return 86400
+	}
+}
+
+// buildHistoryResponse flattens the per-project series into the response
+// envelope: a sparse [{ts,project,value}] series (zero buckets omitted),
+// per-project top contributors, and an optional linear forecast over the
+// grand (all-project) per-bucket total.
+func buildHistoryResponse(rangeKey, chart, group string, s *outbound.CostSeriesResult, q url.Values) historyResponse {
+	resp := historyResponse{
+		Range:           rangeKey,
+		Chart:           chart,
+		Group:           group,
+		Start:           s.Start,
+		End:             s.End,
+		BucketSeconds:   s.BucketSeconds,
+		BucketStarts:    s.BucketStarts,
+		Series:          []historyPoint{},
+		TopContributors: []historyContributor{},
+	}
+	if resp.BucketStarts == nil {
+		resp.BucketStarts = []int64{}
+	}
+
+	// Deterministic project order: total desc, then name.
+	projects := make([]string, 0, len(s.Totals))
+	for p := range s.Totals {
+		projects = append(projects, p)
+	}
+	sort.Slice(projects, func(i, j int) bool {
+		if s.Totals[projects[i]] != s.Totals[projects[j]] {
+			return s.Totals[projects[i]] > s.Totals[projects[j]]
+		}
+		return projects[i] < projects[j]
+	})
+
+	grand := make([]float64, len(s.BucketStarts))
+	for _, p := range projects {
+		resp.Total += s.Totals[p]
+		for i, v := range s.ByProject[p] {
+			if i >= len(s.BucketStarts) {
+				break
+			}
+			grand[i] += v
+			if v != 0 {
+				resp.Series = append(resp.Series, historyPoint{TS: s.BucketStarts[i], Project: p, Value: v})
+			}
+		}
+	}
+	for i, p := range projects {
+		if i >= 5 {
+			break
+		}
+		resp.TopContributors = append(resp.TopContributors, historyContributor{Label: p, Value: s.Totals[p]})
+	}
+
+	if historyForecastEnabled(q) && resp.Total > 0 && len(grand) > 0 {
+		resp.Forecast = computeLinearForecast(grand, s.BucketStarts, s.BucketSeconds, resp.Total, historyForecastBuckets(q, len(grand)))
+	}
+	return resp
+}
+
+// historyForecastEnabled defaults to on; ?forecast=false|0 disables it.
+func historyForecastEnabled(q url.Values) bool {
+	switch q.Get("forecast") {
+	case "false", "0":
+		return false
+	default:
+		return true
+	}
+}
+
+// historyForecastBuckets returns the projection horizon: an explicit positive
+// ?forecast_buckets= override, else ~20% of the visible buckets (min 1, cap 60).
+func historyForecastBuckets(q url.Values, n int) int {
+	if b := q.Get("forecast_buckets"); b != "" {
+		if v, err := strconv.Atoi(b); err == nil && v > 0 {
+			return v
+		}
+	}
+	h := n / 5
+	if h < 1 {
+		h = 1
+	}
+	if h > 60 {
+		h = 60
+	}
+	return h
+}
+
+// computeLinearForecast fits y = a + b·x (least squares) over the per-bucket
+// grand-total series and projects `horizon` future buckets. Projected is the
+// current total plus the (non-negative) projected future spend; basis is
+// "linear" so the UI can label it an estimate.
+func computeLinearForecast(grand []float64, bucketStarts []int64, bucketSeconds int64, currentTotal float64, horizon int) *historyForecast {
+	n := len(grand)
+	var sx, sy, sxx, sxy float64
+	for i, y := range grand {
+		x := float64(i)
+		sx += x
+		sy += y
+		sxx += x * x
+		sxy += x * y
+	}
+	fn := float64(n)
+	var a, b float64
+	if denom := fn*sxx - sx*sx; denom != 0 {
+		b = (fn*sxy - sx*sy) / denom
+		a = (sy - b*sx) / fn
+	} else if fn > 0 {
+		a = sy / fn
+	}
+
+	fc := &historyForecast{Basis: "linear", HorizonBuckets: horizon, Series: []historyForecastPoint{}}
+	var lastTS int64
+	if n > 0 {
+		lastTS = bucketStarts[n-1]
+	}
+	var future float64
+	for k := 1; k <= horizon; k++ {
+		y := a + b*float64(n-1+k)
+		if y < 0 {
+			y = 0
+		}
+		fc.Series = append(fc.Series, historyForecastPoint{TS: lastTS + int64(k)*bucketSeconds, Value: y})
+		future += y
+	}
+	fc.Projected = currentTotal + future
+	if fc.Projected < currentTotal {
+		fc.Projected = currentTotal
+	}
+	return fc
 }
 
 // handleGetVersion serves the daemon's build version. Frontends use it to

--- a/core/cmd/irrlichd/history_endpoint_test.go
+++ b/core/cmd/irrlichd/history_endpoint_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/adapters/outbound/filesystem"
+)
+
+// seedCostRows appends raw snapshot rows to <dir>/<project>.jsonl in the
+// on-disk JSONL shape the cost tracker reads.
+func seedCostRows(t *testing.T, dir, project string, rows []map[string]any) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	f, err := os.OpenFile(filepath.Join(dir, project+".jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	for _, r := range rows {
+		b, _ := json.Marshal(r)
+		if _, err := f.Write(append(b, '\n')); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+}
+
+func doHistory(t *testing.T, tracker *filesystem.CostTracker, query string) (*httptest.ResponseRecorder, historyResponse) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?"+query, nil)
+	rec := httptest.NewRecorder()
+	handleGetHistory(tracker)(rec, req)
+	var resp historyResponse
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode body %q: %v", rec.Body.String(), err)
+		}
+	}
+	return rec, resp
+}
+
+func TestHandleGetHistory_CostByProject(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "cost")
+	now := time.Now().Unix()
+	// proj-a: both rows in-window → first seeds baseline, second is a 0.50 delta.
+	seedCostRows(t, dir, "proj-a", []map[string]any{
+		{"ts": now - 12*3600, "project": "proj-a", "session": "s1", "cost": 1.00},
+		{"ts": now - 1*3600, "project": "proj-a", "session": "s1", "cost": 1.50},
+	})
+	// proj-b: 0.20 delta.
+	seedCostRows(t, dir, "proj-b", []map[string]any{
+		{"ts": now - 2*3600, "project": "proj-b", "session": "s2", "cost": 0.20},
+		{"ts": now - 1*3600, "project": "proj-b", "session": "s2", "cost": 0.40},
+	})
+	tr := filesystem.NewCostTrackerWithDir(dir)
+
+	rec, resp := doHistory(t, tr, "range=day&chart=cost")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if resp.Range != "day" || resp.Chart != "cost" || resp.Group != "project" {
+		t.Errorf("envelope: %+v", resp)
+	}
+	if resp.BucketSeconds != 60 {
+		t.Errorf("day should bucket at 60s, got %d", resp.BucketSeconds)
+	}
+	if d := resp.Total - 0.70; d > 1e-9 || d < -1e-9 {
+		t.Errorf("total: want 0.70, got %v", resp.Total)
+	}
+	if len(resp.TopContributors) != 2 || resp.TopContributors[0].Label != "proj-a" {
+		t.Errorf("top contributors: %+v", resp.TopContributors)
+	}
+	if len(resp.Series) != 2 {
+		t.Errorf("want 2 sparse series points, got %d: %+v", len(resp.Series), resp.Series)
+	}
+	if resp.Forecast == nil || resp.Forecast.Basis != "linear" {
+		t.Errorf("forecast: %+v", resp.Forecast)
+	}
+	if resp.Forecast != nil && resp.Forecast.Projected < resp.Total {
+		t.Errorf("projected %v must be >= total %v", resp.Forecast.Projected, resp.Total)
+	}
+}
+
+func TestHandleGetHistory_CustomRange(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "cost")
+	seedCostRows(t, dir, "proj-a", []map[string]any{
+		{"ts": 1000, "project": "proj-a", "session": "s1", "cost": 1.00},
+		{"ts": 1500, "project": "proj-a", "session": "s1", "cost": 1.25},
+	})
+	tr := filesystem.NewCostTrackerWithDir(dir)
+
+	rec, resp := doHistory(t, tr, "start=900&end=2000&bucket=100&forecast=false")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", rec.Code)
+	}
+	if resp.Range != "custom" || resp.Start != 900 || resp.End != 2000 || resp.BucketSeconds != 100 {
+		t.Errorf("custom envelope: %+v", resp)
+	}
+	if d := resp.Total - 0.25; d > 1e-9 || d < -1e-9 {
+		t.Errorf("total: want 0.25, got %v", resp.Total)
+	}
+	if resp.Forecast != nil {
+		t.Errorf("forecast=false should omit forecast, got %+v", resp.Forecast)
+	}
+}
+
+func TestHandleGetHistory_PhaseStubs(t *testing.T) {
+	tr := filesystem.NewCostTrackerWithDir(filepath.Join(t.TempDir(), "cost"))
+	cases := []struct {
+		query string
+		phase float64
+	}{
+		{"chart=tokens", 2},
+		{"chart=models", 2},
+		{"chart=providers", 2},
+		{"chart=agents", 3},
+		{"group=branch", 2},
+		{"group=session", 2},
+	}
+	for _, c := range cases {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/history?range=day&"+c.query, nil)
+		rec := httptest.NewRecorder()
+		handleGetHistory(tr)(rec, req)
+		if rec.Code != http.StatusNotImplemented {
+			t.Errorf("%s: want 501, got %d", c.query, rec.Code)
+			continue
+		}
+		var body map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Errorf("%s: decode: %v", c.query, err)
+			continue
+		}
+		if body["phase"] != c.phase {
+			t.Errorf("%s: want phase %v, got %v", c.query, c.phase, body["phase"])
+		}
+	}
+}
+
+func TestHandleGetHistory_BadRequests(t *testing.T) {
+	tr := filesystem.NewCostTrackerWithDir(filepath.Join(t.TempDir(), "cost"))
+	for _, q := range []string{"chart=bogus", "group=bogus", "range=bogus", "start=abc&end=def", "start=2000&end=1000"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/history?"+q, nil)
+		rec := httptest.NewRecorder()
+		handleGetHistory(tr)(rec, req)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%q: want 400, got %d", q, rec.Code)
+		}
+	}
+}
+
+func TestHandleGetHistory_NilTrackerEmpty(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?range=week", nil)
+	rec := httptest.NewRecorder()
+	handleGetHistory(nil)(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("nil tracker: want 200, got %d", rec.Code)
+	}
+	var resp historyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 0 || len(resp.Series) != 0 {
+		t.Errorf("want empty payload, got %+v", resp)
+	}
+	// Empty payload must still serialize series as [] (not null) so the chart
+	// renders cleanly on a fresh install.
+	if resp.Series == nil {
+		t.Error("series should be a non-nil empty slice")
+	}
+}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -492,6 +492,10 @@ func main() {
 			return false
 		}))
 
+	// History tab analytics (issue #369): trailing/calendar/custom-range cost
+	// series + linear forecast, computed from the cost snapshot files.
+	mux.HandleFunc("GET /api/v1/history", handleGetHistory(costTracker))
+
 	focusService := services.NewFocusService(cachedRepo, push, logger)
 	mux.HandleFunc("POST /api/v1/sessions/{id}/focus", sessionshandler.NewFocusHandler(focusService, logger))
 

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -201,6 +201,20 @@ type EventRecorder interface {
 	Close() error
 }
 
+// CostSeriesResult is the downsampled per-project incremental-cost time series
+// returned by CostTracker.CostSeries. BucketStarts holds each bucket's start
+// timestamp (unix seconds); ByProject maps a project to its per-bucket
+// incremental USD (each slice has len == len(BucketStarts)); Totals is each
+// project's sum over [Start, End).
+type CostSeriesResult struct {
+	Start         int64                `json:"start"`
+	End           int64                `json:"end"`
+	BucketSeconds int64                `json:"bucket_seconds"`
+	BucketStarts  []int64              `json:"bucket_starts"`
+	ByProject     map[string][]float64 `json:"by_project"`
+	Totals        map[string]float64   `json:"totals"`
+}
+
 // CostTracker persists per-session cost/token snapshots so clients can query
 // project-level cost totals over a trailing time window (last day/week/…).
 // Implementations must be safe for concurrent use.
@@ -218,6 +232,13 @@ type CostTracker interface {
 	// byProvider keys by billing provider ("anthropic"/"openai"), excluding
 	// rows with no known provider. Both axes come from one scan.
 	CostsInWindows(windowSeconds map[string]int64) (byProject, byProvider map[string]map[string]float64, err error)
+
+	// CostSeries returns a downsampled per-project incremental-cost time series
+	// over [start, end) (unix seconds), bucketed into bucketSeconds-wide
+	// buckets, plus per-project totals. One pass over every cost file, reusing
+	// the same baseline/delta model as CostsInWindows so a series' sum matches
+	// the corresponding trailing-window total.
+	CostSeries(start, end, bucketSeconds int64) (*CostSeriesResult, error)
 
 	// Prune drops snapshot rows older than the given number of days.
 	// Safe to call periodically (e.g. daemon startup).

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -18,6 +18,8 @@
       <div class="app-state-icons" id="app-state-icons" aria-label="Active sessions"></div>
     </div>
     <div class="header-right">
+      <button class="view-mode-cycle" id="history-tab-toggle" type="button"
+              title="Show historical cost analytics">History</button>
       <button class="view-mode-cycle" id="view-mode-cycle" type="button"
               title="Cycle Context / 1 Min / 10 Min / 60 Min">Context</button>
       <button class="theme-toggle" id="theme-toggle" type="button"
@@ -150,11 +152,77 @@
 
   <main>
     <div id="connection-banner" role="alert" aria-live="polite"></div>
-    <div id="empty-state">
-      <div class="empty-dot"></div>
-      <p>awaiting sessions</p>
+
+    <div id="view-live">
+      <div id="empty-state">
+        <div class="empty-dot"></div>
+        <p>awaiting sessions</p>
+      </div>
+      <div class="session-list" id="session-list" aria-live="polite"></div>
     </div>
-    <div class="session-list" id="session-list" aria-live="polite"></div>
+
+    <section id="view-history" aria-label="Historical cost analytics">
+      <div class="history-controls">
+        <div class="history-ctl-row">
+          <span class="history-ctl-label">Range</span>
+          <div class="history-seg" id="history-range" role="group" aria-label="Range">
+            <button type="button" data-range="day" class="active">Day</button>
+            <button type="button" data-range="week">Week</button>
+            <button type="button" data-range="month">Month</button>
+            <button type="button" data-range="year">Year</button>
+            <button type="button" data-range="this-month">This Month</button>
+            <button type="button" data-range="custom">Custom…</button>
+          </div>
+          <div class="history-custom" id="history-custom" hidden>
+            <input type="date" id="history-start" aria-label="Start date">
+            <span class="history-custom-sep">→</span>
+            <input type="date" id="history-end" aria-label="End date">
+            <button type="button" id="history-custom-apply">Apply</button>
+          </div>
+          <label class="history-forecast-toggle">
+            <input type="checkbox" id="history-forecast" checked>
+            <span>Forecast</span>
+          </label>
+        </div>
+        <div class="history-ctl-row">
+          <span class="history-ctl-label">Chart</span>
+          <div class="history-seg" id="history-chart-sel" role="group" aria-label="Chart type">
+            <button type="button" data-chart="cost" class="active">Cost</button>
+            <button type="button" data-chart="tokens" disabled title="Available in Phase 2">Tokens</button>
+            <button type="button" data-chart="models" disabled title="Available in Phase 2">Models</button>
+            <button type="button" data-chart="providers" disabled title="Available in Phase 2">Providers</button>
+            <button type="button" data-chart="agents" disabled title="Available in Phase 3">Agents</button>
+          </div>
+        </div>
+        <div class="history-ctl-row">
+          <span class="history-ctl-label">Group</span>
+          <div class="history-seg" id="history-group-sel" role="group" aria-label="Group by">
+            <button type="button" data-group="project" class="active">Project</button>
+            <button type="button" data-group="branch" disabled title="Available in Phase 2">Branch</button>
+            <button type="button" data-group="provider" disabled title="Available in Phase 2">Provider</button>
+            <button type="button" data-group="model" disabled title="Available in Phase 2">Model</button>
+            <button type="button" data-group="session" disabled title="Available in Phase 2">Session</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="history-layout">
+        <div class="history-chart-wrap" id="history-chart-wrap">
+          <canvas id="history-chart"></canvas>
+          <div class="history-chart-empty" id="history-chart-empty">no cost data in this range yet</div>
+        </div>
+        <aside class="history-panel" id="history-panel">
+          <div class="history-panel-title" id="history-panel-title">Total · Day</div>
+          <div class="history-total" id="history-total">$0.00</div>
+          <div class="history-forecast-line" id="history-forecast-line"></div>
+          <ul class="history-contrib" id="history-contrib"></ul>
+          <div class="history-panel-footer">
+            <button type="button" id="history-export-csv">CSV</button>
+            <button type="button" id="history-export-json">JSON</button>
+          </div>
+        </aside>
+      </div>
+    </section>
   </main>
 
   <script type="module" src="irrlicht.js"></script>

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1186,3 +1186,110 @@
       color: var(--muted);
       padding: 4px 4px 0;
     }
+
+    /* --- History tab (issue #369) ---
+       A top-level view toggled by #history-tab-toggle. Mutually exclusive with
+       the live session list; one chart + one side panel, per the issue's hard
+       constraint. The Context/1m/10m/60m cycle only applies to the live list,
+       so it's hidden while the History tab is active. */
+    #view-history { display: none; }
+    body.tab-history #view-live { display: none; }
+    body.tab-history #view-history { display: block; }
+    body.tab-history #view-mode-cycle { display: none; }
+    #history-tab-toggle.active {
+      border-color: var(--working);
+      color: var(--working);
+      background: var(--working-dim);
+    }
+
+    .history-controls { display: flex; flex-direction: column; gap: 8px; margin-bottom: 14px; }
+    .history-ctl-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+    .history-ctl-label {
+      font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em;
+      text-transform: uppercase; color: var(--muted); width: 52px; flex-shrink: 0;
+    }
+    .history-seg {
+      display: inline-flex; border: 1px solid var(--border);
+      border-radius: 5px; overflow: hidden;
+    }
+    .history-seg button {
+      background: none; border: none; border-right: 1px solid var(--border);
+      color: var(--text); font-family: var(--font-mono); font-size: 10px;
+      letter-spacing: 0.03em; padding: 4px 10px; cursor: pointer;
+      transition: background 0.15s, color 0.15s;
+    }
+    .history-seg button:last-child { border-right: none; }
+    .history-seg button:hover:not(:disabled):not(.active) {
+      background: var(--surface-hover); color: var(--text-bright);
+    }
+    .history-seg button.active { background: var(--working-dim); color: var(--working); }
+    .history-seg button:disabled { color: var(--muted); opacity: 0.4; cursor: not-allowed; }
+
+    .history-custom { display: inline-flex; align-items: center; gap: 6px; }
+    .history-custom[hidden] { display: none; }
+    .history-custom input[type="date"] {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 4px;
+      color: var(--text); font-family: var(--font-mono); font-size: 10px; padding: 3px 6px;
+    }
+    .history-custom-sep { color: var(--muted); }
+    .history-custom button, .history-panel-footer button {
+      background: none; border: 1px solid var(--border); border-radius: 4px;
+      color: var(--text); font-family: var(--font-mono); font-size: 10px;
+      padding: 3px 10px; cursor: pointer; transition: border-color 0.15s, color 0.15s;
+    }
+    .history-custom button:hover, .history-panel-footer button:hover {
+      border-color: var(--working); color: var(--text-bright);
+    }
+
+    .history-forecast-toggle {
+      display: inline-flex; align-items: center; gap: 5px; margin-left: auto;
+      font-family: var(--font-mono); font-size: 10px; color: var(--muted); cursor: pointer;
+    }
+
+    .history-layout { display: flex; gap: 18px; align-items: stretch; }
+    .history-chart-wrap {
+      position: relative; flex: 1 1 auto; min-width: 0; height: 360px;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 10px;
+    }
+    #history-chart { width: 100%; height: 100%; display: block; }
+    .history-chart-empty {
+      position: absolute; inset: 0; display: none; align-items: center; justify-content: center;
+      font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.1em;
+      text-transform: uppercase; color: var(--muted);
+    }
+    .history-chart-wrap.empty .history-chart-empty { display: flex; }
+
+    .history-panel {
+      flex: 0 0 260px; display: flex; flex-direction: column;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 8px; padding: 16px;
+    }
+    .history-panel-title {
+      font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em;
+      text-transform: uppercase; color: var(--muted); margin-bottom: 8px;
+    }
+    .history-total { font-family: var(--font-mono); font-size: 30px; font-weight: 600; color: var(--text-bright); }
+    .history-forecast-line {
+      font-family: var(--font-mono); font-size: 11px; color: var(--waiting);
+      margin-top: 4px; min-height: 14px;
+    }
+    .history-contrib {
+      list-style: none; margin: 16px 0 0; padding: 0;
+      display: flex; flex-direction: column; gap: 8px; flex: 1 1 auto;
+    }
+    .history-contrib li { display: flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 12px; }
+    .history-contrib .dot { width: 9px; height: 9px; border-radius: 2px; flex-shrink: 0; }
+    .history-contrib .label { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .history-contrib .val { margin-left: auto; color: var(--text-bright); }
+    .history-empty-contrib { color: var(--muted); font-family: var(--font-mono); font-size: 11px; }
+    .history-panel-footer {
+      display: flex; gap: 8px; justify-content: flex-end;
+      margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--border);
+    }
+
+    @media (max-width: 720px) {
+      .history-layout { flex-direction: column; }
+      .history-panel { flex-basis: auto; }
+      .history-chart-wrap { height: 280px; }
+    }

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -2833,7 +2833,7 @@ import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
     // chart/group buttons are disabled stubs. The stacked-area chart is
     // hand-rolled on a canvas (no external lib), mirroring paintRowHistory's
     // DPI handling.
-    const HISTORY_TAB_KEY = 'irrlicht_activeTab';
+    const ACTIVE_TAB_KEY = 'irrlicht_activeTab';
     const HISTORY_COLORS = [
       '#8B5CF6', '#34C759', '#FF9500', '#0A84FF', '#FF375F',
       '#5E5CE6', '#FFD60A', '#30D158', '#BF5AF2', '#64D2FF',
@@ -2862,7 +2862,7 @@ import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
         btn.textContent = on ? 'Live' : 'History';
         btn.title = on ? 'Back to live sessions' : 'Show historical cost analytics';
       }
-      localStorage.setItem(HISTORY_TAB_KEY, on ? 'history' : 'live');
+      localStorage.setItem(ACTIVE_TAB_KEY, on ? 'history' : 'live');
       if (on) fetchHistory();
     }
 
@@ -2945,18 +2945,17 @@ import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
         const r = idx.get(pt.project), c = tsIdx.get(pt.ts);
         if (r != null && c != null) matrix[r][c] += pt.value;
       }
-      const grand = new Array(B).fill(0);
-      for (let c = 0; c < B; c++) {
-        let s = 0;
-        for (let r = 0; r < projects.length; r++) s += matrix[r][c];
-        grand[c] = s;
-      }
-
       const fc = (historyState.forecast && data.forecast && Array.isArray(data.forecast.series)) ? data.forecast.series : [];
       const H = fc.length;
 
+      // Y scale = the tallest stacked column (sum across projects per bucket),
+      // also accounting for the forecast points.
       let maxY = 0;
-      for (const v of grand) if (v > maxY) maxY = v;
+      for (let c = 0; c < B; c++) {
+        let s = 0;
+        for (let r = 0; r < projects.length; r++) s += matrix[r][c];
+        if (s > maxY) maxY = s;
+      }
       for (const p of fc) if (p.value > maxY) maxY = p.value;
       if (maxY <= 0) maxY = 1;
       maxY *= 1.12;
@@ -2983,7 +2982,7 @@ import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
         ctx.lineTo(w - padR, y);
         ctx.stroke();
         ctx.fillStyle = muted;
-        ctx.fillText('$' + v.toFixed(2), padL - 6, y);
+        ctx.fillText(histDollar(v), padL - 6, y);
       }
 
       // Stacked areas, bottom-up.
@@ -3152,7 +3151,7 @@ import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
     });
 
     // Restore the History tab if it was active last session.
-    if (localStorage.getItem(HISTORY_TAB_KEY) === 'history') setHistoryTab(true);
+    if (localStorage.getItem(ACTIVE_TAB_KEY) === 'history') setHistoryTab(true);
 
 export {
   resolvedTheme, rowLabel, maybeNotifyOnUpdate,

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -3001,14 +3001,18 @@ import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
         for (let c = 0; c < B; c++) baseline[c] += matrix[r][c];
       }
 
-      // Forecast: dashed continuation of the grand-total top edge.
+      // Forecast: a dashed flat line at the projected per-bucket rate, drawn
+      // from the right edge of the data into the future. Anchored at the
+      // forecast's own first value (not grand[B-1]) so an empty trailing bucket
+      // — common for the in-progress current minute — doesn't draw a spurious
+      // dip-and-spike down to the axis.
       if (H > 0) {
         ctx.save();
         ctx.setLineDash([4, 3]);
         ctx.strokeStyle = waiting;
         ctx.lineWidth = 1.5;
         ctx.beginPath();
-        ctx.moveTo(xAt(B - 1), yAt(grand[B - 1] || 0));
+        ctx.moveTo(xAt(B - 1), yAt(fc[0].value));
         for (let k = 0; k < H; k++) ctx.lineTo(xAt(B + k), yAt(fc[k].value));
         ctx.stroke();
         ctx.restore();

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -2826,6 +2826,330 @@ import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
 
     refreshPermissions();
 
+    // --- History tab (issue #369) ---
+    // A top-level view (toggled by #history-tab-toggle) that charts historical
+    // USD cost from GET /api/v1/history. Hard constraint: exactly one chart +
+    // one side panel. Phase 1 wires chart=cost grouped by project; the other
+    // chart/group buttons are disabled stubs. The stacked-area chart is
+    // hand-rolled on a canvas (no external lib), mirroring paintRowHistory's
+    // DPI handling.
+    const HISTORY_TAB_KEY = 'irrlicht_activeTab';
+    const HISTORY_COLORS = [
+      '#8B5CF6', '#34C759', '#FF9500', '#0A84FF', '#FF375F',
+      '#5E5CE6', '#FFD60A', '#30D158', '#BF5AF2', '#64D2FF',
+    ];
+    const RANGE_LABELS = { day: 'Day', week: 'Week', month: 'Month', year: 'Year', 'this-month': 'This Month', custom: 'Custom' };
+    const historyState = { range: 'day', chart: 'cost', group: 'project', forecast: true, start: null, end: null, data: null };
+    let historyFetchSeq = 0;
+    let historyResizeRAF = 0;
+
+    function historyColorFor(i) { return HISTORY_COLORS[i % HISTORY_COLORS.length]; }
+    function histDollar(v) { return '$' + (Number(v) || 0).toFixed(2); }
+    function histAxisLabel(ts, bucketSeconds) {
+      const d = new Date(ts * 1000);
+      if (bucketSeconds < 86400) {
+        return String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
+      }
+      return (d.getMonth() + 1) + '/' + d.getDate();
+    }
+
+    function historyTabOn() { return document.body.classList.contains('tab-history'); }
+    function setHistoryTab(on) {
+      document.body.classList.toggle('tab-history', on);
+      const btn = document.getElementById('history-tab-toggle');
+      if (btn) {
+        btn.classList.toggle('active', on);
+        btn.textContent = on ? 'Live' : 'History';
+        btn.title = on ? 'Back to live sessions' : 'Show historical cost analytics';
+      }
+      localStorage.setItem(HISTORY_TAB_KEY, on ? 'history' : 'live');
+      if (on) fetchHistory();
+    }
+
+    function historyQuery() {
+      const p = new URLSearchParams();
+      p.set('chart', historyState.chart);
+      p.set('group', historyState.group);
+      p.set('forecast', historyState.forecast ? 'true' : 'false');
+      if (historyState.range === 'custom' && historyState.start != null && historyState.end != null) {
+        p.set('start', String(historyState.start));
+        p.set('end', String(historyState.end));
+      } else {
+        p.set('range', historyState.range);
+      }
+      return p.toString();
+    }
+
+    function fetchHistory() {
+      const seq = ++historyFetchSeq;
+      return fetch('/api/v1/history?' + historyQuery())
+        .then(r => (r.ok ? r.json() : null))
+        .catch(() => null)
+        .then(data => {
+          if (seq !== historyFetchSeq) return; // superseded by a newer request
+          historyState.data = data || null;
+          renderHistory();
+        });
+    }
+
+    function renderHistory() {
+      if (!historyState.data) {
+        const wrap = document.getElementById('history-chart-wrap');
+        if (wrap) wrap.classList.add('empty');
+        return;
+      }
+      paintHistoryChart();
+      renderHistoryPanel();
+    }
+
+    function paintHistoryChart() {
+      const canvas = document.getElementById('history-chart');
+      const wrap = document.getElementById('history-chart-wrap');
+      if (!canvas || !wrap) return;
+      const data = historyState.data;
+      const dpr = window.devicePixelRatio || 1;
+      const w = canvas.offsetWidth || wrap.clientWidth || 600;
+      const h = canvas.offsetHeight || 340;
+      const pxW = Math.round(w * dpr), pxH = Math.round(h * dpr);
+      if (canvas.width !== pxW || canvas.height !== pxH) { canvas.width = pxW; canvas.height = pxH; }
+      const ctx = canvas.getContext('2d');
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, w, h);
+
+      const buckets = (data && data.bucket_starts) || [];
+      const B = buckets.length;
+      const hasData = !!(data && data.total > 0 && B > 0);
+      wrap.classList.toggle('empty', !hasData);
+      if (!hasData) return;
+
+      const cs = getComputedStyle(document.documentElement);
+      const muted = (cs.getPropertyValue('--muted') || '#888').trim();
+      const waiting = (cs.getPropertyValue('--waiting') || '#FF9500').trim();
+      const gridColor = 'rgba(128,140,170,0.18)';
+
+      // Per-project matrix aligned to buckets. Project order follows
+      // top_contributors (so side-panel dots match chart colors), then any
+      // extra projects from the series.
+      const projects = [];
+      const idx = new Map();
+      for (const c of (data.top_contributors || [])) {
+        if (!idx.has(c.label)) { idx.set(c.label, projects.length); projects.push(c.label); }
+      }
+      for (const pt of (data.series || [])) {
+        if (!idx.has(pt.project)) { idx.set(pt.project, projects.length); projects.push(pt.project); }
+      }
+      const matrix = projects.map(() => new Array(B).fill(0));
+      const tsIdx = new Map();
+      buckets.forEach((t, i) => tsIdx.set(t, i));
+      for (const pt of (data.series || [])) {
+        const r = idx.get(pt.project), c = tsIdx.get(pt.ts);
+        if (r != null && c != null) matrix[r][c] += pt.value;
+      }
+      const grand = new Array(B).fill(0);
+      for (let c = 0; c < B; c++) {
+        let s = 0;
+        for (let r = 0; r < projects.length; r++) s += matrix[r][c];
+        grand[c] = s;
+      }
+
+      const fc = (historyState.forecast && data.forecast && Array.isArray(data.forecast.series)) ? data.forecast.series : [];
+      const H = fc.length;
+
+      let maxY = 0;
+      for (const v of grand) if (v > maxY) maxY = v;
+      for (const p of fc) if (p.value > maxY) maxY = p.value;
+      if (maxY <= 0) maxY = 1;
+      maxY *= 1.12;
+
+      const padL = 46, padR = 12, padT = 12, padB = 22;
+      const plotW = Math.max(1, w - padL - padR);
+      const plotH = Math.max(1, h - padT - padB);
+      const N = B + H;
+      const xAt = (i) => (N <= 1 ? padL : padL + plotW * (i / (N - 1)));
+      const yAt = (v) => padT + plotH * (1 - v / maxY);
+
+      // Y gridlines + dollar labels (drawn first, behind the areas).
+      ctx.font = '10px ui-monospace, monospace';
+      ctx.textBaseline = 'middle';
+      ctx.textAlign = 'right';
+      const ticks = 4;
+      for (let t = 0; t <= ticks; t++) {
+        const v = maxY * t / ticks;
+        const y = yAt(v);
+        ctx.strokeStyle = gridColor;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(padL, y);
+        ctx.lineTo(w - padR, y);
+        ctx.stroke();
+        ctx.fillStyle = muted;
+        ctx.fillText('$' + v.toFixed(2), padL - 6, y);
+      }
+
+      // Stacked areas, bottom-up.
+      const baseline = new Array(B).fill(0);
+      for (let r = 0; r < projects.length; r++) {
+        ctx.beginPath();
+        for (let c = 0; c < B; c++) {
+          const x = xAt(c), y = yAt(baseline[c] + matrix[r][c]);
+          if (c === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+        }
+        for (let c = B - 1; c >= 0; c--) ctx.lineTo(xAt(c), yAt(baseline[c]));
+        ctx.closePath();
+        ctx.fillStyle = historyColorFor(r);
+        ctx.fill();
+        for (let c = 0; c < B; c++) baseline[c] += matrix[r][c];
+      }
+
+      // Forecast: dashed continuation of the grand-total top edge.
+      if (H > 0) {
+        ctx.save();
+        ctx.setLineDash([4, 3]);
+        ctx.strokeStyle = waiting;
+        ctx.lineWidth = 1.5;
+        ctx.beginPath();
+        ctx.moveTo(xAt(B - 1), yAt(grand[B - 1] || 0));
+        for (let k = 0; k < H; k++) ctx.lineTo(xAt(B + k), yAt(fc[k].value));
+        ctx.stroke();
+        ctx.restore();
+      }
+
+      // X axis time labels.
+      ctx.fillStyle = muted;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      const labelCount = Math.min(6, B);
+      for (let i = 0; i < labelCount; i++) {
+        const c = Math.round(i * (B - 1) / Math.max(1, labelCount - 1));
+        ctx.fillText(histAxisLabel(buckets[c], data.bucket_seconds), xAt(c), h - padB + 5);
+      }
+    }
+
+    function renderHistoryPanel() {
+      const data = historyState.data;
+      if (!data) return;
+      const titleEl = document.getElementById('history-panel-title');
+      const totalEl = document.getElementById('history-total');
+      const fcEl = document.getElementById('history-forecast-line');
+      const listEl = document.getElementById('history-contrib');
+      if (titleEl) titleEl.textContent = 'Total · ' + (RANGE_LABELS[historyState.range] || historyState.range);
+      if (totalEl) totalEl.textContent = histDollar(data.total);
+      if (fcEl) {
+        fcEl.textContent = (historyState.forecast && data.forecast)
+          ? '▲ projected ' + histDollar(data.forecast.projected) + ' (' + (data.forecast.basis || 'linear') + ')'
+          : '';
+      }
+      if (!listEl) return;
+      listEl.innerHTML = '';
+      const contribs = data.top_contributors || [];
+      if (!contribs.length) {
+        const li = document.createElement('li');
+        li.className = 'history-empty-contrib';
+        li.textContent = 'no spend in this range';
+        listEl.appendChild(li);
+        return;
+      }
+      contribs.forEach((c, i) => {
+        const li = document.createElement('li');
+        const dot = document.createElement('span');
+        dot.className = 'dot';
+        dot.style.background = historyColorFor(i);
+        const label = document.createElement('span');
+        label.className = 'label';
+        label.textContent = c.label;
+        const val = document.createElement('span');
+        val.className = 'val';
+        val.textContent = histDollar(c.value);
+        li.appendChild(dot);
+        li.appendChild(label);
+        li.appendChild(val);
+        listEl.appendChild(li);
+      });
+    }
+
+    function historyDownload(filename, mime, text) {
+      const blob = new Blob([text], { type: mime });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+    function historyCsvCell(s) {
+      s = String(s);
+      return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
+    }
+    function exportHistoryCSV() {
+      const d = historyState.data;
+      if (!d) return;
+      const lines = ['bucket_start,project,value'];
+      for (const pt of (d.series || [])) {
+        lines.push([new Date(pt.ts * 1000).toISOString(), historyCsvCell(pt.project), pt.value.toFixed(6)].join(','));
+      }
+      historyDownload('irrlicht-history-' + historyState.range + '-' + historyState.chart + '.csv', 'text/csv;charset=utf-8', lines.join('\n') + '\n');
+    }
+    function exportHistoryJSON() {
+      const d = historyState.data;
+      if (!d) return;
+      historyDownload('irrlicht-history-' + historyState.range + '-' + historyState.chart + '.json', 'application/json', JSON.stringify(d, null, 2));
+    }
+
+    // Wiring.
+    const histToggleBtn = document.getElementById('history-tab-toggle');
+    if (histToggleBtn) histToggleBtn.addEventListener('click', () => setHistoryTab(!historyTabOn()));
+
+    const histRangeSeg = document.getElementById('history-range');
+    if (histRangeSeg) histRangeSeg.addEventListener('click', (e) => {
+      const b = e.target.closest('button[data-range]');
+      if (!b) return;
+      for (const x of histRangeSeg.querySelectorAll('button')) x.classList.toggle('active', x === b);
+      const r = b.dataset.range;
+      const custom = document.getElementById('history-custom');
+      if (r === 'custom') { if (custom) custom.hidden = false; return; } // wait for Apply
+      if (custom) custom.hidden = true;
+      historyState.range = r;
+      historyState.start = null;
+      historyState.end = null;
+      fetchHistory();
+    });
+
+    const histApplyBtn = document.getElementById('history-custom-apply');
+    if (histApplyBtn) histApplyBtn.addEventListener('click', () => {
+      const sv = document.getElementById('history-start').value;
+      const ev = document.getElementById('history-end').value;
+      if (!sv || !ev) return;
+      const start = Math.floor(new Date(sv + 'T00:00:00').getTime() / 1000);
+      const end = Math.floor(new Date(ev + 'T00:00:00').getTime() / 1000) + 86400; // include the end day
+      if (!(end > start)) return;
+      historyState.range = 'custom';
+      historyState.start = start;
+      historyState.end = end;
+      fetchHistory();
+    });
+
+    const histForecastChk = document.getElementById('history-forecast');
+    if (histForecastChk) histForecastChk.addEventListener('change', () => {
+      historyState.forecast = histForecastChk.checked;
+      fetchHistory();
+    });
+
+    const histCsvBtn = document.getElementById('history-export-csv');
+    if (histCsvBtn) histCsvBtn.addEventListener('click', exportHistoryCSV);
+    const histJsonBtn = document.getElementById('history-export-json');
+    if (histJsonBtn) histJsonBtn.addEventListener('click', exportHistoryJSON);
+
+    window.addEventListener('resize', () => {
+      if (!historyTabOn() || !historyState.data) return;
+      if (historyResizeRAF) cancelAnimationFrame(historyResizeRAF);
+      historyResizeRAF = requestAnimationFrame(paintHistoryChart);
+    });
+
+    // Restore the History tab if it was active last session.
+    if (localStorage.getItem(HISTORY_TAB_KEY) === 'history') setHistoryTab(true);
+
 export {
   resolvedTheme, rowLabel, maybeNotifyOnUpdate,
   formatCost, formatUsageCost, pressureClass, historyPriorityForState,


### PR DESCRIPTION
Closes #369 (Phase 1). Phase 2 → #750, Phase 3 → #751.

## What

Adds a **History tab** to the web dashboard surfacing historical USD cost analytics, computed from the cost snapshot files irrlichd already writes (`~/.local/share/irrlicht/cost/*.jsonl`) — **no new on-disk schema, no migration**.

### Backend
- `CostTracker.CostSeries(start, end, bucketSeconds)` (+ `CostSeriesResult` port DTO) — a downsampled per-project incremental-cost time series. Reuses the existing `snapshotRow` scanner, `projectKey`, and the same baseline/delta model as `CostsInWindows`, so a series' sum equals the trailing-window total. One pass over all cost files.
- `GET /api/v1/history?range=&chart=&group=&start=&end=&bucket=&forecast=` — trailing windows (`day|week|month|year`), a calendar shorthand (`this-month`), and explicit custom `start&end` (unix seconds); read-time downsampling (1m / 1h / 1d); a linear least-squares forecast over the grand-total series (`basis:"linear"`). Scaffolded chart types (`tokens|models|providers`) and groups (`branch|provider|model|session`) return **501** with a `phase` hint; `agents` → 501 phase 3.

### Frontend (`platforms/web/` — three files: `index.html`, `irrlicht.js`, `irrlicht.css`)
- Header **History** toggle; a top-level view independent of the live session list.
- **One** hand-rolled stacked-area canvas chart (no external lib) + **one** side panel (total, `▲ projected $X (linear)`, top contributors with color-matched dots). Range/Chart/Group selectors render all options; only **Cost × Project** is wired — the rest are disabled with a "Phase 2/3" hint. Forecast toggle, custom date pickers, CSV/JSON export.

## Design constraint
**One chart + one side panel, ever** (per #369). Chart-type/Group are in-place toggles, not stacked panels.

## Notes / deviations from the issue text
- The issue says "single file `index.html`" — that's stale; the dashboard is three files now, so changes span all three.
- Per maintainer direction, the range model is richer than the issue's fixed four: trailing windows **+** `this-month` **+** custom start/end, with forecast as an optional toggle.

## Testing
- `go test ./core/... -race -count=1` ✅ (new `CostSeries` unit tests + `/api/v1/history` handler tests), `go vet ./core/...` clean.
- `tools/replay-fixtures.sh` ✅; `npm test` in `platforms/web` ✅ (93 tests).
- Manual end-to-end against an isolated dev daemon (port 7838): tab toggle, Day/Month/custom ranges, dashed forecast, contributor dots, empty-state overlay, CSV/JSON builders, and the 501/400 paths — all correct, **no console errors**, live dashboard unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)