### PR TITLE
feat(skill): ir:exec end-to-end loop — worktree → visual HTML plan → impl → PR → /review → /simplify (#756)

### DIFF
--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -55,15 +55,18 @@ typed. If none is resolvable, ask for an issue number before continuing.
      file or function names here (those belong to the technical Approach below).
    - **Visual** — pick exactly one archetype (see next bullet), or delete all three.
    - **Approach & Design (technical)** — the file/function-level direction (`REPEAT:approach`).
-   - **Steps** — `REPEAT:step`; card = title + one-line summary + file chips; the deep
-     rationale/edge-cases go in the step's `<template>` (click-to-reveal).
+   - **Steps** — `REPEAT:step`; card = title + one-line summary + one or more `chip`
+     spans for the file(s) it touches; the deep rationale/edge-cases go in the step's
+     `<template>` (click-to-reveal).
    - **Files Touched** — `REPEAT:file`, `badge` class `new`|`mod`|`del`; per-file "what
      changes and why" in its `<template>`.
    - **Risks & Unknowns** — `REPEAT:risk` (native `<details>`).
 
    **Fill primitives:** replace every `{{TOKEN}}`; duplicate each
    `REPEAT:x`…`/REPEAT:x` region per item and delete the leftover example; delete any
-   unused `OPTIONAL:x` region whole.
+   unused `OPTIONAL:x` region whole. Then **strip every `REPEAT:`/`OPTIONAL:` marker
+   comment** from the file — they are scaffolding, not output (a kept marker is
+   harmless but clutters the source).
 
    **Pick ONE visual archetype** matching the dominant kind of work (delete the others;
    delete all three if no visual adds signal — don't ship an empty box):
@@ -73,15 +76,22 @@ typed. If none is resolvable, ask for an issue number before continuing.
    | Data processing | `OPTIONAL:dataflow` | node-and-arrow flow; each node `data-detail` reveals its transform |
    | Vertical slice / many components | `OPTIONAL:components` | impact-map nodes, `data-impact` = `changed`\|`adjacent`\|`untouched` — show the blast radius AND what's left alone |
 
-   **UI screenshot policy** (the `ui` archetype embeds the *real* current UI):
-   - **Web UI (a URL exists):** use the `claude-in-chrome` tools to open the running UI,
-     screenshot the relevant viewport (not a giant full-page capture — keep the data-URI
-     reasonable), and embed it as the "Today" `<img src="data:image/png;base64,…">`.
-   - **Non-URL UI (macOS app, CLI):** there's no reliable capture at plan time — **ask
-     the user for a screenshot**, or hand-model the current screen as SVG from code/asset
-     inspection. **Never invent a UI you haven't seen.**
+   **UI screenshot policy** (the `ui` archetype embeds the *real* current UI). Obtain the
+   capture **before** rendering — never ship the page with an unfilled
+   `{{UI_SCREENSHOT_DATA_URI}}`:
+   - **Web UI (a URL exists):** use the `claude-in-chrome` tools to open the running UI
+     and screenshot the relevant viewport (not a giant full-page capture). The capture
+     comes back as a file path — **base64-encode it** and embed as the "Today"
+     `<img src="data:image/png;base64,…">`. Never put a `file://`, `http(s)://`, or raw
+     path in `src` (that is an external/broken reference, not self-contained).
+   - **Non-URL UI (macOS app, CLI) or no clean capture:** there's no reliable capture at
+     plan time — either **ask the user for a screenshot** (and wait for it before
+     rendering), **hand-model the current screen as SVG** in place of the `<img>`, or
+     **delete the `OPTIONAL:ui` block**. **Never invent a UI you haven't seen**, and never
+     render with the image token still unfilled.
 
-   **Interactivity:** to make anything click-to-reveal, give it `data-detail="<id>"` and
+   **Interactivity:** to make anything click-to-reveal, give it `data-detail="<id>"`
+   (the id must be **unique within the page**) and
    put the detail in a sibling `<template data-detail-body="<id>">`. **Do not write event
    handlers** — the template's inline engine handles it.
 
@@ -92,13 +102,15 @@ typed. If none is resolvable, ask for an issue number before continuing.
      are fine.
    - Never write a comment-close sequence inside a comment's text, and never write a
      closing `</template>` or `</script>` inside a detail body.
-   - Before presenting, verify **no `{{` and no `REPEAT:`/`OPTIONAL:` markers are left
-     behind** (the page also shows a warning banner at load time if any slip through).
+   - Before presenting, verify **no `{{TOKEN}}` is left behind** (the page also shows a
+     warning banner at load time if any slip through).
    - One visual archetype max; Steps ≤ 8–10.
-7. **Present the link and stop.** Give the user the `file:///tmp/ir-exec-plan-<N>.html`
-   link plus a 2–3 line summary, then **wait**. Do not edit a single file until the
-   user replies with approval. If they request changes, revise the plan + HTML and
-   re-present.
+7. **Present the link, then end your turn.** Give the user the
+   `file:///tmp/ir-exec-plan-<N>.html` link plus a 2–3 line summary, and **stop the
+   response there** — do not present the link and keep working in the same turn. The
+   next user message is the gate: treat only an explicit approval as go. An ambiguous or
+   partial reply ("looks good, but…") is a change request — revise the plan + HTML and
+   re-present. Do not edit a single implementation file until the user approves.
 
 ## Phase 4 — Implement (only after approval)
 

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -1,35 +1,112 @@
 ---
 name: ir:exec
-description: Investigate a GitHub issue and produce an implementation plan. Use at the start of a new task in a fresh worktree. Triggers on "/ir:exec", "plan issue", "plan this issue", "investigate issue", or when the user provides an issue number/URL and asks for a plan.
+description: End-to-end execution of a GitHub issue — open a worktree, investigate, present a visual HTML plan for approval, then (on accept) implement, open a PR, review it with /review, fix findings, simplify, and hand back the PR link with a test-or-merge recommendation. Triggers on "/ir:exec", "exec issue", "implement issue", "plan issue", or when the user gives an issue number/URL and asks to plan or implement it.
 ---
 
-# Plan a GitHub Issue
+# Execute a GitHub Issue, End to End
 
-Goal: read the issue, understand the affected code, then propose an implementation plan and enter plan mode.
+Take an issue from a number to a review-clean PR. The flow has a hard gate in the
+middle: **plan → user approves → implement**. Nothing is edited before approval.
+
+```
+worktree → investigate → HTML plan (/tmp) → ⛔ APPROVAL → implement → PR → /review → fix → /simplify → PR link + recommendation
+```
 
 ## Inputs
 
-Issue numer is provided from the git branch and/or worktree name. 
-If there is no branch or worktree ask the user for a ticket.
+The issue number comes from the branch or worktree name, or from what the user
+typed. If none is resolvable, ask for an issue number before continuing.
 
-## Workflow
+## Phase 1 — Worktree
 
-1. **Confirm the worktree.** Run `pwd` and `git status -sb`. If not in a clean worktree, point it out — don't block.
-2. **Fetch the issue** (and its comments — they often contain the real spec):
+1. **Resolve the issue number** and a short kebab slug from its title.
+2. **Open a dedicated worktree** off the latest `main` (skip if already in a clean,
+   issue-matching worktree — run `pwd` + `git status -sb` to check):
    ```bash
-   gh issue view <N> --comments
+   git -C <main-repo> fetch origin main
+   git -C <main-repo> worktree add -b feat/<N>-<slug> .claude/worktrees/<N>-<slug> origin/main
    ```
-   For cross-repo: `gh issue view <N> --repo <owner/repo> --comments`.
-3. **Investigate the code.** Delegate to one or more `Explore` subagents with thoroughness "medium" — one prompt that names the issue's key terms (file names, symbols, error strings, feature names) and asks: where does this live, what touches it, what's the current behavior. Don't grep manually first; the subagent handles it and protects the main context.
-4. **Synthesize a plan.** Distill into:
-   - **Problem** — one sentence, what's broken or missing.
-   - **Approach** — the chosen direction in 2–4 bullets, naming files/functions you'll touch.
-   - **Steps** — ordered, concrete edits. Each step is one logical change.
-   - **Risks / unknowns** — anything you'd want the user to weigh in on before coding.
-5. **Present the plan for approval** by calling `ExitPlanMode`. Do not start editing until approved.
+   `.claude/worktrees/` is gitignored. **Do all work via the worktree path** — editing
+   the main checkout's files by absolute path touches the wrong tree.
+
+## Phase 2 — Investigate & plan
+
+3. **Fetch the issue and its comments** (comments often hold the real spec):
+   ```bash
+   gh issue view <N> --comments        # add --repo <owner/repo> for cross-repo
+   ```
+4. **Investigate the code.** Delegate to one or more `Explore` subagents (thoroughness
+   "medium") with a prompt naming the issue's key terms — file names, symbols, error
+   strings, feature names — asking where it lives, what touches it, current behavior.
+   Don't grep manually first; the subagent protects the main context.
+5. **Synthesize the plan**: Problem (one sentence), Approach/Design (the chosen
+   direction, naming files/functions), Steps (ordered, concrete, one logical change
+   each), Files touched (new/mod/del), Risks/unknowns.
+
+## Phase 3 — Visual HTML plan + approval gate
+
+6. **Render the plan to HTML.** Read `templates/plan.html` (next to this file). Copy it
+   to `/tmp/ir-exec-plan-<N>.html` and fill it in:
+   - Replace every `{{TOKEN}}`. Keep the `<style>` block byte-for-byte — it is the
+     design system, not content.
+   - For each `<!-- REPEAT:x -->…<!-- /REPEAT:x -->` region, duplicate the inner block
+     once per item (steps, files, approach bullets, risks) and remove the leftover
+     example. File `badge` class is `new` | `mod` | `del`.
+   - Use the `<!-- OPTIONAL:diagram -->` flow region to visualize the design when it
+     helps (data flow, component seams, before/after). Delete it whole if a diagram
+     adds nothing — don't ship an empty box.
+   - Keep it self-contained: no external URLs, scripts, or fonts.
+7. **Present the link and stop.** Give the user the `file:///tmp/ir-exec-plan-<N>.html`
+   link plus a 2–3 line summary, then **wait**. Do not edit a single file until the
+   user replies with approval. If they request changes, revise the plan + HTML and
+   re-present.
+
+## Phase 4 — Implement (only after approval)
+
+8. **Push through the implementation** in the worktree.
+   - If the work is complex/multi-part, break it into tasks with `TaskCreate` and work
+     them in order (as you naturally would). For a small change, just implement it.
+   - Follow the repo's conventions (AGENTS.md): surgical changes, match surrounding
+     style, three-state model, hexagonal layering, etc.
+9. **Verify** before declaring done: run the test suites relevant to what you touched
+   (per AGENTS.md — `go test ./core/... -race -count=1`, the factory/web suites, replay
+   fixtures, `swift build`/`swift test`, as applicable). Fix what you broke.
+
+## Phase 5 — PR, review, simplify
+
+10. **Open the PR** against `main`:
+    ```bash
+    git push -u origin feat/<N>-<slug>
+    gh pr create --base main --fill   # or a written title/body; reference "Closes #<N>"
+    ```
+    End the PR body with the `🤖 Generated with [Claude Code]` line.
+11. **Review with the `/review` skill on the PR.** Then fix every issue it surfaces, in
+    the worktree, and push the fixes.
+    - **IMPORTANT: do NOT use the Workflow tool / multi-agent orchestration for the
+      review — it is too expensive.** Invoke the `/review` skill directly (use
+      `/code-review` on the local diff if you prefer not to round-trip the PR). A single
+      review pass, not a fan-out.
+12. **Run the `/simplify` skill** on the change to clean up reuse/complexity, then push.
+
+## Phase 6 — Hand back
+
+13. **Present the final PR link** and ask whether the user wants to **test** or **merge**.
+    Make a recommendation, and let your **confidence** decide which you lead with:
+    - **Lean merge** when: `/review` came back clean (no unresolved findings), all
+      relevant suites are green, and the diff is small/low-risk and fully covered by
+      tests. Suggested: `gh pr merge --squash` (keep the branch — don't pass
+      `--delete-branch`).
+    - **Lean test-first** when: review raised non-trivial findings, tests are
+      failing/flaky/absent for the behavior, the diff is large or risky, or the change
+      is user-visible and only confirmable by running it. Point at `/verify`, or
+      `/ir:test-mac` for macOS-app changes.
+    State the recommendation in one line with the reason; the merge decision is the
+    user's.
 
 ## Notes
 
-- Keep the plan tight. If it's longer than ~30 lines, you're over-planning — collapse steps.
-- If the issue is ambiguous or under-specified, surface that in **Risks / unknowns** rather than guessing silently.
-- Skip steps only when clearly redundant (e.g. user already pasted the issue body).
+- The approval gate (Phase 3) is real — never start editing before the user accepts.
+- Keep the plan tight: if Steps run past ~8–10 entries, you're over-planning; collapse.
+- If the issue is ambiguous, surface it under Risks/unknowns in the plan rather than
+  guessing — that's what the approval gate is for.
+- One worktree + one branch + one PR per issue.

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -46,16 +46,55 @@ typed. If none is resolvable, ask for an issue number before continuing.
 ## Phase 3 — Visual HTML plan + approval gate
 
 6. **Render the plan to HTML.** Read `templates/plan.html` (next to this file). Copy it
-   to `/tmp/ir-exec-plan-<N>.html` and fill it in:
-   - Replace every `{{TOKEN}}`. Keep the `<style>` block byte-for-byte — it is the
-     design system, not content.
-   - For each `<!-- REPEAT:x -->…<!-- /REPEAT:x -->` region, duplicate the inner block
-     once per item (steps, files, approach bullets, risks) and remove the leftover
-     example. File `badge` class is `new` | `mod` | `del`.
-   - Use the `<!-- OPTIONAL:diagram -->` flow region to visualize the design when it
-     helps (data flow, component seams, before/after). Delete it whole if a diagram
-     adds nothing — don't ship an empty box.
-   - Keep it self-contained: no external URLs, scripts, or fonts.
+   to `/tmp/ir-exec-plan-<N>.html` and fill it in. The page reads outside-in — a
+   stranger to the codebase should understand the top half:
+
+   **Section roster (order in the template):**
+   - **TL;DR** — `{{TLDR}}`, 2–3 sentences: the problem + the intent. The most-read line.
+   - **High-level design** — `{{HLD_INTRO}}` + `REPEAT:hld` bullets. **Code-free**: no
+     file or function names here (those belong to the technical Approach below).
+   - **Visual** — pick exactly one archetype (see next bullet), or delete all three.
+   - **Approach & Design (technical)** — the file/function-level direction (`REPEAT:approach`).
+   - **Steps** — `REPEAT:step`; card = title + one-line summary + file chips; the deep
+     rationale/edge-cases go in the step's `<template>` (click-to-reveal).
+   - **Files Touched** — `REPEAT:file`, `badge` class `new`|`mod`|`del`; per-file "what
+     changes and why" in its `<template>`.
+   - **Risks & Unknowns** — `REPEAT:risk` (native `<details>`).
+
+   **Fill primitives:** replace every `{{TOKEN}}`; duplicate each
+   `REPEAT:x`…`/REPEAT:x` region per item and delete the leftover example; delete any
+   unused `OPTIONAL:x` region whole.
+
+   **Pick ONE visual archetype** matching the dominant kind of work (delete the others;
+   delete all three if no visual adds signal — don't ship an empty box):
+   | Issue kind | Keep block | What to author |
+   |---|---|---|
+   | Frontend / UI | `OPTIONAL:ui` | a real screenshot ("Today") + a hand-authored SVG wireframe ("Proposed"); mark each new region `<g data-detail="ui-N">` |
+   | Data processing | `OPTIONAL:dataflow` | node-and-arrow flow; each node `data-detail` reveals its transform |
+   | Vertical slice / many components | `OPTIONAL:components` | impact-map nodes, `data-impact` = `changed`\|`adjacent`\|`untouched` — show the blast radius AND what's left alone |
+
+   **UI screenshot policy** (the `ui` archetype embeds the *real* current UI):
+   - **Web UI (a URL exists):** use the `claude-in-chrome` tools to open the running UI,
+     screenshot the relevant viewport (not a giant full-page capture — keep the data-URI
+     reasonable), and embed it as the "Today" `<img src="data:image/png;base64,…">`.
+   - **Non-URL UI (macOS app, CLI):** there's no reliable capture at plan time — **ask
+     the user for a screenshot**, or hand-model the current screen as SVG from code/asset
+     inspection. **Never invent a UI you haven't seen.**
+
+   **Interactivity:** to make anything click-to-reveal, give it `data-detail="<id>"` and
+   put the detail in a sibling `<template data-detail-body="<id>">`. **Do not write event
+   handlers** — the template's inline engine handles it.
+
+   **Self-containment & hazards:**
+   - Self-contained = **no EXTERNAL resources** (no URLs, CDN scripts, or web fonts).
+     The inline `<style>` block and the inline `<script>` engine are part of the
+     template — **keep both byte-for-byte**, add no others. `data:` URIs (the screenshot)
+     are fine.
+   - Never write a comment-close sequence inside a comment's text, and never write a
+     closing `</template>` or `</script>` inside a detail body.
+   - Before presenting, verify **no `{{` and no `REPEAT:`/`OPTIONAL:` markers are left
+     behind** (the page also shows a warning banner at load time if any slip through).
+   - One visual archetype max; Steps ≤ 8–10.
 7. **Present the link and stop.** Give the user the `file:///tmp/ir-exec-plan-<N>.html`
    link plus a 2–3 line summary, then **wait**. Do not edit a single file until the
    user replies with approval. If they request changes, revise the plan + HTML and

--- a/.claude/skills/ir:exec/templates/plan.html
+++ b/.claude/skills/ir:exec/templates/plan.html
@@ -1,19 +1,31 @@
 <!doctype html>
 <!--
-  ir:exec plan template — self-contained, no external resources.
+  ir:exec plan template — self-contained (no EXTERNAL resources: no URLs, CDN
+  scripts, or web fonts). The inline style block AND the inline interaction-engine
+  script are part of the template — keep both byte-for-byte; do not add others.
+  data: URIs (e.g. an embedded screenshot) are allowed — they are not external.
 
   HOW TO USE (see ../SKILL.md). NOTE: this how-to avoids writing literal
-  comment-close sequences so it never terminates early; the body holds the
-  real "REPEAT:x" / "OPTIONAL:x" marker comments.
+  comment-close sequences so it never terminates early; the body holds the real
+  REPEAT:x and OPTIONAL:x marker comments.
     1. Copy this file to /tmp/ir-exec-plan-<issue>.html
     2. Replace every {{TOKEN}} with real content.
-    3. For each REPEAT:x marker-comment region in the body, duplicate the inner
-       block once per item, then delete the leftover example block.
-    4. NEVER edit the style block — it is the design system; keep it byte-for-byte.
-    5. OPTIONAL:x marker-comment regions may be deleted whole if unused.
+    3. For each REPEAT:x marker-comment region, duplicate the inner block once per
+       item, then delete the leftover example block.
+    4. OPTIONAL:x marker-comment regions may be deleted whole if unused. The visual
+       section ships THREE archetypes (ui / dataflow / components): keep the ONE that
+       fits the issue, delete the other two; delete all three if no visual helps.
+    5. To make anything click-to-reveal, give it data-detail="<id>" and put the detail
+       in a sibling <template data-detail-body="<id>">. Do NOT write event handlers —
+       the inline engine handles it.
+    6. NEVER edit the style block or the script engine — they are the design system.
+    7. Never write a comment-close sequence inside a comment's text, and never write a
+       closing template or script tag inside a detail body. Leave no {{ or REPEAT:/
+       OPTIONAL: markers behind (a load-time banner warns if you do).
 
-  The plan page is PRE-implementation: Problem, Approach/Design, Steps, Files, Risks.
-  Confidence / test-vs-merge is a later conversational step, not part of this page.
+  Section order: header -> TL;DR -> High-level design -> Adaptive visual ->
+  Approach (deep) -> Steps -> Files -> Risks -> Approval. The plan is
+  PRE-implementation; confidence / test-vs-merge is a later conversational step.
 -->
 <html lang="en">
 <head>
@@ -22,117 +34,146 @@
 <title>Plan · #{{ISSUE_NUMBER}} {{ISSUE_TITLE}}</title>
 <style>
   :root {
-    --bg: #0f1115;
-    --surface: #171a21;
-    --surface-2: #1e222b;
-    --border: #2a2f3a;
-    --text: #e6e9ef;
-    --muted: #9aa3b2;
-    --faint: #6b7280;
-    --accent: #7c9cff;
-    --accent-soft: #1f2740;
-    --new: #4ade80;
-    --mod: #fbbf24;
-    --del: #f87171;
-    --risk: #fb923c;
+    /* Irrlicht brand — copied inline (no font @import); system fonts only. */
+    --bg: #050a14;
+    --surface: #0c1426;
+    --surface-2: #111b30;
+    --border: rgba(138, 132, 246, 0.14);
+    --border-soft: rgba(138, 132, 246, 0.08);
+    --text: #c8cdd8;
+    --text-bright: #e8ecf4;
+    --muted: #8a93a8;
+    --faint: #5a6378;
+    --working: #8b5cf6;   /* purple — primary accent / changed */
+    --waiting: #ff9500;   /* orange — adjacent / at-risk / risk */
+    --ready:   #34c759;   /* green  — new / added */
+    --del:     #f87171;   /* red    — removed */
+    --working-soft: rgba(139, 92, 246, 0.13);
+    --waiting-soft: rgba(255, 149, 0, 0.13);
+    --ready-soft:   rgba(52, 199, 89, 0.13);
+    --del-soft:     rgba(248, 113, 113, 0.13);
+    --accent: var(--working);
     --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
     --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   }
   * { box-sizing: border-box; }
   html { -webkit-text-size-adjust: 100%; }
   body {
-    margin: 0;
-    background: var(--bg);
-    color: var(--text);
-    font-family: var(--sans);
-    font-size: 15px;
-    line-height: 1.6;
+    margin: 0; background: var(--bg); color: var(--text);
+    font-family: var(--sans); font-size: 15px; line-height: 1.6;
   }
-  .wrap { max-width: 860px; margin: 0 auto; padding: 40px 24px 96px; }
+  .wrap { max-width: 880px; margin: 0 auto; padding: 40px 24px 96px; }
 
   /* Header */
-  header { border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 36px; }
-  .eyebrow { font-family: var(--mono); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; color: var(--accent); margin: 0 0 8px; }
-  h1 { font-size: 26px; line-height: 1.25; margin: 0 0 16px; font-weight: 650; }
+  header { border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 32px; }
+  .eyebrow { font-family: var(--mono); font-size: 12px; letter-spacing: .1em; text-transform: uppercase; color: var(--working); margin: 0 0 8px; }
+  h1 { font-size: 26px; line-height: 1.25; margin: 0 0 16px; font-weight: 650; color: var(--text-bright); }
   .meta { display: flex; flex-wrap: wrap; gap: 8px 16px; font-family: var(--mono); font-size: 12.5px; color: var(--muted); }
-  .meta a { color: var(--accent); text-decoration: none; }
+  .meta a { color: var(--working); text-decoration: none; }
   .meta a:hover { text-decoration: underline; }
-  .meta span b { color: var(--text); font-weight: 600; }
+  .meta span b { color: var(--text-bright); font-weight: 600; }
 
   /* Sections */
-  section { margin: 0 0 40px; }
+  section { margin: 0 0 38px; }
   h2 {
     font-size: 13px; letter-spacing: .08em; text-transform: uppercase;
-    color: var(--faint); margin: 0 0 16px; font-weight: 600;
+    color: var(--faint); margin: 0 0 14px; font-weight: 600;
     display: flex; align-items: center; gap: 10px;
   }
-  h2::before { content: ""; width: 14px; height: 2px; background: var(--accent); border-radius: 2px; }
-
-  .lede { font-size: 16px; color: var(--text); margin: 0 0 12px; }
+  h2::before { content: ""; width: 14px; height: 2px; background: var(--working); border-radius: 2px; }
+  .lede { font-size: 16px; color: var(--text-bright); margin: 0 0 12px; }
   p { margin: 0 0 12px; }
-  .muted { color: var(--muted); }
-  code { font-family: var(--mono); font-size: .88em; background: var(--surface-2); padding: 1px 6px; border-radius: 5px; color: #cdd6f4; }
+  code { font-family: var(--mono); font-size: .88em; background: var(--surface-2); padding: 1px 6px; border-radius: 5px; color: #d6cffb; }
 
-  /* Approach bullets */
+  /* TL;DR — the most-read block */
+  .tldr { background: linear-gradient(180deg, var(--working-soft), transparent); border: 1px solid var(--border); border-left: 3px solid var(--working); border-radius: 12px; padding: 18px 22px; }
+  .tldr h2 { margin-bottom: 8px; color: var(--working); }
+  .tldr h2::before { background: var(--working); }
+  .tldr .lede { margin: 0; font-size: 16.5px; line-height: 1.55; }
+
+  /* High-level design bullets */
   ul.approach { list-style: none; margin: 0; padding: 0; }
   ul.approach li { position: relative; padding: 0 0 10px 22px; }
-  ul.approach li::before { content: "→"; position: absolute; left: 0; color: var(--accent); font-family: var(--mono); }
+  ul.approach li::before { content: "\2192"; position: absolute; left: 0; color: var(--working); font-family: var(--mono); }
 
-  /* Diagram */
-  .diagram {
-    background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
-    padding: 24px; margin: 12px 0 4px; overflow-x: auto;
-  }
+  /* Click-to-reveal affordance + detail panels */
+  [data-detail] { cursor: pointer; }
+  .detail-panel { margin-top: 12px; background: var(--bg); border: 1px solid var(--border); border-radius: 9px; padding: 12px 14px; font-size: 14px; color: var(--text); animation: fade .12s ease-out; }
+  .detail-panel p { margin: 0 0 8px; } .detail-panel p:last-child { margin: 0; }
+  @keyframes fade { from { opacity: 0; transform: translateY(-3px); } to { opacity: 1; transform: none; } }
+  .visual-detail-dock:empty { display: none; }
+  .visual-detail-dock { margin-top: 12px; }
+
+  /* Adaptive visual — UI before/after */
+  .ui-ba { display: flex; flex-wrap: wrap; gap: 16px; }
+  .ui-panel { flex: 1 1 280px; margin: 0; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 12px; }
+  .ui-panel figcaption { font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: var(--faint); margin: 0 0 8px; }
+  .ui-shot { display: block; max-width: 100%; height: auto; border-radius: 7px; border: 1px solid var(--border-soft); }
+  .ui-mock { display: block; width: 100%; height: auto; background: var(--bg); border-radius: 7px; }
+  .ui-mock rect, .ui-mock line { vector-effect: non-scaling-stroke; }
+  .ui-region-new { } .ui-region-new rect { fill: var(--ready-soft); stroke: var(--ready); stroke-width: 1.5; }
+  .ui-region-new text { fill: var(--ready); font: 600 9px var(--mono); }
+  [data-detail].detail-open { outline: 2px solid var(--working); outline-offset: 1px; }
+
+  /* Adaptive visual — data-flow (reuses .diagram/.flow) */
+  .diagram { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 22px; margin: 4px 0; overflow-x: auto; }
   .flow { display: flex; align-items: center; gap: 12px; min-width: max-content; }
-  .node {
-    background: var(--surface-2); border: 1px solid var(--border); border-radius: 9px;
-    padding: 10px 14px; font-family: var(--mono); font-size: 12.5px; white-space: nowrap;
-  }
-  .node.accent { border-color: var(--accent); background: var(--accent-soft); color: #cdd6ff; }
+  .node { background: var(--surface-2); border: 1px solid var(--border); border-radius: 9px; padding: 10px 14px; font-family: var(--mono); font-size: 12.5px; white-space: nowrap; }
+  .node.accent { border-color: var(--working); background: var(--working-soft); color: #d6cffb; }
   .arrow { color: var(--faint); font-family: var(--mono); }
+
+  /* Adaptive visual — component-impact map */
+  .impact-map { display: flex; flex-wrap: wrap; gap: 8px; }
+  .cnode { font-family: var(--mono); font-size: 12.5px; padding: 7px 12px; border-radius: 8px; border: 1px solid var(--border); background: var(--surface-2); color: var(--text); }
+  .cnode[data-impact="changed"]   { border-color: var(--working); background: var(--working-soft); color: #d6cffb; }
+  .cnode[data-impact="adjacent"]  { border-color: var(--waiting); background: var(--waiting-soft); color: #ffd9a8; }
+  .cnode[data-impact="untouched"] { color: var(--faint); opacity: .7; }
+  .impact-legend { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 12px; font-family: var(--mono); font-size: 11.5px; color: var(--muted); }
+  .impact-legend i { display: inline-block; width: 9px; height: 9px; border-radius: 3px; margin-right: 5px; vertical-align: middle; }
+  .lg-changed { background: var(--working); } .lg-adjacent { background: var(--waiting); } .lg-untouched { background: var(--faint); }
 
   /* Steps */
   ol.steps { list-style: none; counter-reset: step; margin: 0; padding: 0; }
-  ol.steps > li {
-    position: relative; counter-increment: step;
-    background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
-    padding: 18px 20px 18px 60px; margin: 0 0 14px;
-  }
-  ol.steps > li::before {
-    content: counter(step); position: absolute; left: 16px; top: 17px;
-    width: 28px; height: 28px; border-radius: 50%;
-    background: var(--accent-soft); color: var(--accent); border: 1px solid var(--accent);
-    font-family: var(--mono); font-size: 13px; font-weight: 600;
-    display: flex; align-items: center; justify-content: center;
-  }
-  .step-title { font-weight: 600; font-size: 15.5px; margin: 0 0 6px; }
-  .step-body { color: var(--muted); margin: 0 0 10px; font-size: 14.5px; }
-  .step-body:last-child { margin-bottom: 0; }
+  ol.steps > li { position: relative; counter-increment: step; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 16px 40px 16px 56px; margin: 0 0 12px; }
+  ol.steps > li::before { content: counter(step); position: absolute; left: 14px; top: 15px; width: 26px; height: 26px; border-radius: 50%; background: var(--working-soft); color: var(--working); border: 1px solid var(--working); font-family: var(--mono); font-size: 12.5px; font-weight: 600; display: flex; align-items: center; justify-content: center; }
+  ol.steps > li[data-detail]::after { content: "\203A"; position: absolute; right: 16px; top: 15px; color: var(--faint); font-size: 18px; transition: transform .15s; }
+  ol.steps > li[data-detail].detail-open::after { transform: rotate(90deg); color: var(--working); }
+  ol.steps > li[data-detail].detail-open { outline: none; }
+  .step-title { font-weight: 600; font-size: 15px; margin: 0 0 5px; color: var(--text-bright); }
+  .step-body { color: var(--muted); margin: 0 0 9px; font-size: 14px; } .step-body:last-child { margin-bottom: 0; }
   .step-files { display: flex; flex-wrap: wrap; gap: 6px; }
   .chip { font-family: var(--mono); font-size: 11.5px; background: var(--surface-2); border: 1px solid var(--border); color: var(--muted); padding: 2px 8px; border-radius: 6px; }
 
-  /* Files table */
+  /* Files touched */
   .files { display: flex; flex-direction: column; gap: 6px; }
-  .file-row { display: flex; align-items: center; gap: 12px; font-family: var(--mono); font-size: 13px; padding: 8px 12px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; }
+  .file-row { position: relative; display: flex; align-items: center; gap: 12px; font-family: var(--mono); font-size: 13px; padding: 8px 34px 8px 12px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; }
+  .file-row[data-detail]::after { content: "\203A"; position: absolute; right: 14px; color: var(--faint); font-size: 16px; transition: transform .15s; }
+  .file-row[data-detail].detail-open::after { transform: rotate(90deg); color: var(--working); }
+  .file-row[data-detail].detail-open { outline: none; }
   .badge { font-size: 10.5px; font-weight: 700; letter-spacing: .04em; padding: 2px 7px; border-radius: 5px; flex-shrink: 0; min-width: 46px; text-align: center; }
-  .badge.new { background: rgba(74,222,128,.12); color: var(--new); border: 1px solid rgba(74,222,128,.3); }
-  .badge.mod { background: rgba(251,191,36,.12); color: var(--mod); border: 1px solid rgba(251,191,36,.3); }
-  .badge.del { background: rgba(248,113,113,.12); color: var(--del); border: 1px solid rgba(248,113,113,.3); }
-  .file-row .path { color: var(--text); word-break: break-all; }
+  .badge.new { background: var(--ready-soft); color: var(--ready); border: 1px solid rgba(52,199,89,.3); }
+  .badge.mod { background: var(--waiting-soft); color: var(--waiting); border: 1px solid rgba(255,149,0,.3); }
+  .badge.del { background: var(--del-soft); color: var(--del); border: 1px solid rgba(248,113,113,.3); }
+  .file-row .path { color: var(--text-bright); word-break: break-all; }
   .file-row .note { color: var(--faint); margin-left: auto; font-size: 12px; white-space: nowrap; }
 
-  /* Risks */
-  .risk-card { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--risk); border-radius: 10px; padding: 14px 18px; margin: 0 0 12px; }
-  .risk-card .rt { font-weight: 600; margin: 0 0 4px; color: #ffd9b3; }
-  .risk-card .rb { color: var(--muted); margin: 0; font-size: 14.5px; }
+  /* Risks — native details */
+  .risk-card { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--waiting); border-radius: 10px; padding: 12px 16px; margin: 0 0 10px; }
+  .risk-card > summary { font-weight: 600; color: #ffd9a8; cursor: pointer; list-style: none; }
+  .risk-card > summary::-webkit-details-marker { display: none; }
+  .risk-card > summary::before { content: "\203A "; color: var(--waiting); }
+  .risk-card[open] > summary::before { content: "\2304 "; }
+  .risk-card .rb { color: var(--muted); margin: 8px 0 0; font-size: 14px; }
 
   /* Approval footer */
-  .approval { background: var(--accent-soft); border: 1px solid var(--accent); border-radius: 12px; padding: 20px 22px; margin-top: 8px; }
-  .approval h2 { color: var(--accent); margin-bottom: 8px; }
-  .approval h2::before { background: var(--accent); }
-  .approval p { color: #cdd6ff; margin: 0; }
+  .approval { background: var(--working-soft); border: 1px solid var(--working); border-radius: 12px; padding: 18px 22px; }
+  .approval h2 { color: var(--working); margin-bottom: 8px; } .approval h2::before { background: var(--working); }
+  .approval p { color: #d6cffb; margin: 0; }
 
-  footer { margin-top: 48px; padding-top: 20px; border-top: 1px solid var(--border); font-family: var(--mono); font-size: 11.5px; color: var(--faint); text-align: center; }
+  /* Unfilled-template warning banner (shown only by the engine guardrail) */
+  .fill-warning { position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: var(--waiting); color: #1a1205; font-family: var(--mono); font-size: 12.5px; text-align: center; padding: 7px 12px; font-weight: 600; }
+
+  footer { margin-top: 44px; padding-top: 18px; border-top: 1px solid var(--border); font-family: var(--mono); font-size: 11.5px; color: var(--faint); text-align: center; }
 </style>
 </head>
 <body>
@@ -149,44 +190,102 @@
     </div>
   </header>
 
-  <section>
-    <h2>Problem</h2>
-    <p class="lede">{{PROBLEM}}</p>
+  <section class="tldr">
+    <h2>TL;DR</h2>
+    <p class="lede">{{TLDR}}</p>
   </section>
 
   <section>
-    <h2>Approach &amp; Design</h2>
+    <h2>How it works (high level)</h2>
+    <p>{{HLD_INTRO}}</p>
+    <ul class="approach">
+      <!-- REPEAT:hld -->
+      <li>{{HLD_POINT}}</li>
+      <!-- /REPEAT:hld -->
+    </ul>
+  </section>
+
+  <section>
+    <h2>Visual</h2>
+
+    <!-- OPTIONAL:ui — Frontend/UI tickets. Embed the REAL current screenshot as a
+         data: URI ("Today"), hand-author the SVG wireframe ("Proposed"); mark each
+         new region <g data-detail="ui-N"> and give it a matching template. -->
+    <div class="ui-ba">
+      <figure class="ui-panel">
+        <figcaption>Today</figcaption>
+        <img class="ui-shot" src="{{UI_SCREENSHOT_DATA_URI}}" alt="current UI">
+      </figure>
+      <figure class="ui-panel">
+        <figcaption>Proposed</figcaption>
+        <svg class="ui-mock" viewBox="0 0 320 200" role="img" aria-label="proposed UI">
+          <rect x="6" y="6" width="308" height="188" rx="6" fill="none" stroke="var(--border)"/>
+          <g data-detail="ui-1" class="ui-region-new">
+            <rect x="16" y="60" width="288" height="120" rx="5"/>
+            <text x="26" y="80">{{UI_NEW_LABEL}}</text>
+          </g>
+        </svg>
+      </figure>
+    </div>
+    <div class="visual-detail-dock" data-detail-dock></div>
+    <template data-detail-body="ui-1"><p>{{UI_NEW_DETAIL}}</p></template>
+    <!-- /OPTIONAL:ui -->
+
+    <!-- OPTIONAL:dataflow — Data-processing tickets. Node-and-arrow flow; each node
+         may be data-detail clickable to reveal its transform. -->
+    <div class="diagram">
+      <div class="flow">
+        <div class="node" data-detail="df-1">{{DF_NODE}}</div>
+        <span class="arrow">&rarr;</span>
+        <div class="node accent" data-detail="df-2">{{DF_NODE}}</div>
+        <span class="arrow">&rarr;</span>
+        <div class="node" data-detail="df-3">{{DF_NODE}}</div>
+      </div>
+    </div>
+    <template data-detail-body="df-1"><p>{{DF_DETAIL}}</p></template>
+    <template data-detail-body="df-2"><p>{{DF_DETAIL}}</p></template>
+    <template data-detail-body="df-3"><p>{{DF_DETAIL}}</p></template>
+    <!-- /OPTIONAL:dataflow -->
+
+    <!-- OPTIONAL:components — Vertical slice across many components. data-impact is one
+         of changed|adjacent|untouched; show the blast radius AND what's left alone. -->
+    <div class="impact-map">
+      <!-- REPEAT:cnode -->
+      <span class="cnode" data-impact="{{IMPACT}}" data-detail="c-{{CID}}">{{COMPONENT}}</span>
+      <!-- /REPEAT:cnode -->
+    </div>
+    <div class="impact-legend">
+      <span><i class="lg-changed"></i>changed</span>
+      <span><i class="lg-adjacent"></i>adjacent / at-risk</span>
+      <span><i class="lg-untouched"></i>untouched</span>
+    </div>
+    <div class="visual-detail-dock" data-detail-dock></div>
+    <!-- REPEAT:cdetail -->
+    <template data-detail-body="c-{{CID}}"><p>{{COMPONENT_DETAIL}}</p></template>
+    <!-- /REPEAT:cdetail -->
+    <!-- /OPTIONAL:components -->
+
+  </section>
+
+  <section>
+    <h2>Approach &amp; Design (technical)</h2>
     <p>{{APPROACH_INTRO}}</p>
     <ul class="approach">
       <!-- REPEAT:approach -->
       <li>{{APPROACH_BULLET}}</li>
       <!-- /REPEAT:approach -->
     </ul>
-
-    <!-- OPTIONAL:diagram — a clean flow/box visual of the design. Edit the nodes;
-         add more .flow rows for layered diagrams. Delete this whole block if not useful. -->
-    <div class="diagram">
-      <div class="flow">
-        <div class="node">{{DIAGRAM_NODE}}</div>
-        <span class="arrow">→</span>
-        <div class="node accent">{{DIAGRAM_NODE}}</div>
-        <span class="arrow">→</span>
-        <div class="node">{{DIAGRAM_NODE}}</div>
-      </div>
-    </div>
-    <!-- /OPTIONAL:diagram -->
   </section>
 
   <section>
     <h2>Steps</h2>
     <ol class="steps">
       <!-- REPEAT:step -->
-      <li>
+      <li data-detail="step-{{STEP_ID}}">
         <p class="step-title">{{STEP_TITLE}}</p>
-        <p class="step-body">{{STEP_BODY}}</p>
-        <div class="step-files">
-          <span class="chip">{{STEP_FILE}}</span>
-        </div>
+        <p class="step-body">{{STEP_SUMMARY}}</p>
+        <div class="step-files"><span class="chip">{{STEP_FILE}}</span></div>
+        <template data-detail-body="step-{{STEP_ID}}"><p>{{STEP_DETAIL}}</p></template>
       </li>
       <!-- /REPEAT:step -->
     </ol>
@@ -196,10 +295,11 @@
     <h2>Files Touched</h2>
     <div class="files">
       <!-- REPEAT:file — badge class is one of: new | mod | del -->
-      <div class="file-row">
+      <div class="file-row" data-detail="file-{{FILE_ID}}">
         <span class="badge mod">{{FILE_STATUS}}</span>
         <span class="path">{{FILE_PATH}}</span>
         <span class="note">{{FILE_NOTE}}</span>
+        <template data-detail-body="file-{{FILE_ID}}"><p>{{FILE_DETAIL}}</p></template>
       </div>
       <!-- /REPEAT:file -->
     </div>
@@ -208,10 +308,10 @@
   <section>
     <h2>Risks &amp; Unknowns</h2>
     <!-- REPEAT:risk -->
-    <div class="risk-card">
-      <p class="rt">{{RISK_TITLE}}</p>
+    <details class="risk-card">
+      <summary>{{RISK_TITLE}}</summary>
       <p class="rb">{{RISK_BODY}}</p>
-    </div>
+    </details>
     <!-- /REPEAT:risk -->
   </section>
 
@@ -223,5 +323,60 @@
   <footer>ir:exec · plan for #{{ISSUE_NUMBER}} · {{GENERATED}}</footer>
 
 </div>
+
+<script>
+/* ir:exec interaction-engine — design-system content, keep byte-for-byte.
+   Generic click-to-reveal: any [data-detail] element toggles the sibling
+   <template data-detail-body="<id>">. No per-issue JS. Also warns (never blocks)
+   if the template shipped with unfilled placeholders. */
+(function () {
+  "use strict";
+  try {
+    var main = document.querySelector(".wrap");           // scan content only, not this script
+    var raw = main ? main.innerHTML : "";
+    if (/\{\{[A-Z_]+\}\}|REPEAT:|OPTIONAL:/.test(raw)) {
+      var warn = document.createElement("div");
+      warn.className = "fill-warning";
+      warn.textContent = "⚠ template not fully filled — a placeholder or marker was left behind";
+      document.body.appendChild(warn);
+    }
+    var open = null;
+    function close() {
+      if (!open) return;
+      if (open.panel && open.panel.parentNode) open.panel.parentNode.removeChild(open.panel);
+      open.trigger.classList.remove("detail-open");
+      open.trigger.setAttribute("aria-expanded", "false");
+      open = null;
+    }
+    document.addEventListener("click", function (e) {
+      var t = e.target;
+      if (t.closest && t.closest(".detail-panel")) return;          // clicks inside a panel never toggle
+      var trigger = t.closest ? t.closest("[data-detail]") : null;  // works for HTML and SVG elements
+      if (!trigger) return;
+      var id = trigger.getAttribute("data-detail");
+      var tpl = document.querySelector('template[data-detail-body="' + id + '"]');
+      if (!tpl) return;
+      var wasOpen = open && open.trigger === trigger;
+      close();
+      if (wasOpen) return;                                          // second click closes
+      var panel = document.createElement("div");
+      panel.className = "detail-panel";
+      panel.appendChild(tpl.content.cloneNode(true));
+      var isSvg = !!trigger.ownerSVGElement;
+      if (isSvg) {
+        var dock = null, n = trigger;
+        while (n && n.parentNode) { n = n.parentNode; if (n.querySelector) { dock = n.querySelector("[data-detail-dock]"); if (dock) break; } }
+        (dock || document.body).appendChild(panel);
+      } else {
+        trigger.appendChild(panel);
+      }
+      trigger.classList.add("detail-open");
+      trigger.setAttribute("aria-expanded", "true");
+      open = { trigger: trigger, panel: panel };
+    });
+    document.addEventListener("keydown", function (e) { if (e.key === "Escape") close(); });
+  } catch (err) { /* a partial fill must never break the page */ }
+})();
+</script>
 </body>
 </html>

--- a/.claude/skills/ir:exec/templates/plan.html
+++ b/.claude/skills/ir:exec/templates/plan.html
@@ -15,13 +15,16 @@
     4. OPTIONAL:x marker-comment regions may be deleted whole if unused. The visual
        section ships THREE archetypes (ui / dataflow / components): keep the ONE that
        fits the issue, delete the other two; delete all three if no visual helps.
-    5. To make anything click-to-reveal, give it data-detail="<id>" and put the detail
-       in a sibling <template data-detail-body="<id>">. Do NOT write event handlers —
-       the inline engine handles it.
-    6. NEVER edit the style block or the script engine — they are the design system.
+    5. To make anything click-to-reveal, give it data-detail="<id>" (the id must be
+       UNIQUE in the page) and put the detail in a sibling
+       <template data-detail-body="<id>">. Do NOT write event handlers — the inline
+       engine handles it.
+    6. STRIP every REPEAT:x / OPTIONAL:x marker comment from the final file — they are
+       scaffolding, not output. NEVER edit the style block or the script engine — they
+       are the design system.
     7. Never write a comment-close sequence inside a comment's text, and never write a
-       closing template or script tag inside a detail body. Leave no {{ or REPEAT:/
-       OPTIONAL: markers behind (a load-time banner warns if you do).
+       closing template or script tag inside a detail body. Leave no {{TOKEN}} behind
+       (a load-time banner warns if you do).
 
   Section order: header -> TL;DR -> High-level design -> Adaptive visual ->
   Approach (deep) -> Steps -> Files -> Risks -> Approval. The plan is
@@ -52,7 +55,7 @@
     --waiting-soft: rgba(255, 149, 0, 0.13);
     --ready-soft:   rgba(52, 199, 89, 0.13);
     --del-soft:     rgba(248, 113, 113, 0.13);
-    --accent: var(--working);
+    --accent-text: #d6cffb;   /* readable purple text on --working-soft fills */
     --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
     --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   }
@@ -81,15 +84,14 @@
     display: flex; align-items: center; gap: 10px;
   }
   h2::before { content: ""; width: 14px; height: 2px; background: var(--working); border-radius: 2px; }
-  .lede { font-size: 16px; color: var(--text-bright); margin: 0 0 12px; }
   p { margin: 0 0 12px; }
-  code { font-family: var(--mono); font-size: .88em; background: var(--surface-2); padding: 1px 6px; border-radius: 5px; color: #d6cffb; }
+  code { font-family: var(--mono); font-size: .88em; background: var(--surface-2); padding: 1px 6px; border-radius: 5px; color: var(--accent-text); }
 
   /* TL;DR — the most-read block */
   .tldr { background: linear-gradient(180deg, var(--working-soft), transparent); border: 1px solid var(--border); border-left: 3px solid var(--working); border-radius: 12px; padding: 18px 22px; }
   .tldr h2 { margin-bottom: 8px; color: var(--working); }
   .tldr h2::before { background: var(--working); }
-  .tldr .lede { margin: 0; font-size: 16.5px; line-height: 1.55; }
+  .tldr .lede { margin: 0; font-size: 16.5px; line-height: 1.55; color: var(--text-bright); }
 
   /* High-level design bullets */
   ul.approach { list-style: none; margin: 0; padding: 0; }
@@ -101,8 +103,8 @@
   .detail-panel { margin-top: 12px; background: var(--bg); border: 1px solid var(--border); border-radius: 9px; padding: 12px 14px; font-size: 14px; color: var(--text); animation: fade .12s ease-out; }
   .detail-panel p { margin: 0 0 8px; } .detail-panel p:last-child { margin: 0; }
   @keyframes fade { from { opacity: 0; transform: translateY(-3px); } to { opacity: 1; transform: none; } }
-  .visual-detail-dock:empty { display: none; }
   .visual-detail-dock { margin-top: 12px; }
+  .visual-detail-dock:empty { display: none; }
 
   /* Adaptive visual — UI before/after */
   .ui-ba { display: flex; flex-wrap: wrap; gap: 16px; }
@@ -110,8 +112,9 @@
   .ui-panel figcaption { font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: var(--faint); margin: 0 0 8px; }
   .ui-shot { display: block; max-width: 100%; height: auto; border-radius: 7px; border: 1px solid var(--border-soft); }
   .ui-mock { display: block; width: 100%; height: auto; background: var(--bg); border-radius: 7px; }
-  .ui-mock rect, .ui-mock line { vector-effect: non-scaling-stroke; }
-  .ui-region-new { } .ui-region-new rect { fill: var(--ready-soft); stroke: var(--ready); stroke-width: 1.5; }
+  .ui-mock rect { vector-effect: non-scaling-stroke; }
+  .ui-frame { fill: none; stroke: var(--border); }   /* var() resolves in CSS, not in an SVG presentation attr */
+  .ui-region-new rect { fill: var(--ready-soft); stroke: var(--ready); stroke-width: 1.5; }
   .ui-region-new text { fill: var(--ready); font: 600 9px var(--mono); }
   [data-detail].detail-open { outline: 2px solid var(--working); outline-offset: 1px; }
 
@@ -119,13 +122,13 @@
   .diagram { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 22px; margin: 4px 0; overflow-x: auto; }
   .flow { display: flex; align-items: center; gap: 12px; min-width: max-content; }
   .node { background: var(--surface-2); border: 1px solid var(--border); border-radius: 9px; padding: 10px 14px; font-family: var(--mono); font-size: 12.5px; white-space: nowrap; }
-  .node.accent { border-color: var(--working); background: var(--working-soft); color: #d6cffb; }
+  .node.accent { border-color: var(--working); background: var(--working-soft); color: var(--accent-text); }
   .arrow { color: var(--faint); font-family: var(--mono); }
 
   /* Adaptive visual — component-impact map */
   .impact-map { display: flex; flex-wrap: wrap; gap: 8px; }
   .cnode { font-family: var(--mono); font-size: 12.5px; padding: 7px 12px; border-radius: 8px; border: 1px solid var(--border); background: var(--surface-2); color: var(--text); }
-  .cnode[data-impact="changed"]   { border-color: var(--working); background: var(--working-soft); color: #d6cffb; }
+  .cnode[data-impact="changed"]   { border-color: var(--working); background: var(--working-soft); color: var(--accent-text); }
   .cnode[data-impact="adjacent"]  { border-color: var(--waiting); background: var(--waiting-soft); color: #ffd9a8; }
   .cnode[data-impact="untouched"] { color: var(--faint); opacity: .7; }
   .impact-legend { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 12px; font-family: var(--mono); font-size: 11.5px; color: var(--muted); }
@@ -168,7 +171,7 @@
   /* Approval footer */
   .approval { background: var(--working-soft); border: 1px solid var(--working); border-radius: 12px; padding: 18px 22px; }
   .approval h2 { color: var(--working); margin-bottom: 8px; } .approval h2::before { background: var(--working); }
-  .approval p { color: #d6cffb; margin: 0; }
+  .approval p { color: var(--accent-text); margin: 0; }
 
   /* Unfilled-template warning banner (shown only by the engine guardrail) */
   .fill-warning { position: fixed; top: 0; left: 0; right: 0; z-index: 9999; background: var(--waiting); color: #1a1205; font-family: var(--mono); font-size: 12.5px; text-align: center; padding: 7px 12px; font-weight: 600; }
@@ -219,7 +222,7 @@
       <figure class="ui-panel">
         <figcaption>Proposed</figcaption>
         <svg class="ui-mock" viewBox="0 0 320 200" role="img" aria-label="proposed UI">
-          <rect x="6" y="6" width="308" height="188" rx="6" fill="none" stroke="var(--border)"/>
+          <rect class="ui-frame" x="6" y="6" width="308" height="188" rx="6"/>
           <g data-detail="ui-1" class="ui-region-new">
             <rect x="16" y="60" width="288" height="120" rx="5"/>
             <text x="26" y="80">{{UI_NEW_LABEL}}</text>
@@ -227,7 +230,6 @@
         </svg>
       </figure>
     </div>
-    <div class="visual-detail-dock" data-detail-dock></div>
     <template data-detail-body="ui-1"><p>{{UI_NEW_DETAIL}}</p></template>
     <!-- /OPTIONAL:ui -->
 
@@ -250,8 +252,8 @@
     <!-- OPTIONAL:components — Vertical slice across many components. data-impact is one
          of changed|adjacent|untouched; show the blast radius AND what's left alone. -->
     <div class="impact-map">
-      <!-- REPEAT:cnode -->
-      <span class="cnode" data-impact="{{IMPACT}}" data-detail="c-{{CID}}">{{COMPONENT}}</span>
+      <!-- REPEAT:cnode — id and detail authored together so the CID can't drift -->
+      <span class="cnode" data-impact="{{IMPACT}}" data-detail="c-{{CID}}">{{COMPONENT}}<template data-detail-body="c-{{CID}}"><p>{{COMPONENT_DETAIL}}</p></template></span>
       <!-- /REPEAT:cnode -->
     </div>
     <div class="impact-legend">
@@ -259,12 +261,11 @@
       <span><i class="lg-adjacent"></i>adjacent / at-risk</span>
       <span><i class="lg-untouched"></i>untouched</span>
     </div>
-    <div class="visual-detail-dock" data-detail-dock></div>
-    <!-- REPEAT:cdetail -->
-    <template data-detail-body="c-{{CID}}"><p>{{COMPONENT_DETAIL}}</p></template>
-    <!-- /REPEAT:cdetail -->
     <!-- /OPTIONAL:components -->
 
+    <!-- shared dock for click-to-reveal detail of any visual region (kept whichever
+         archetype survives) -->
+    <div class="visual-detail-dock" data-detail-dock></div>
   </section>
 
   <section>
@@ -334,10 +335,10 @@
   try {
     var main = document.querySelector(".wrap");           // scan content only, not this script
     var raw = main ? main.innerHTML : "";
-    if (/\{\{[A-Z_]+\}\}|REPEAT:|OPTIONAL:/.test(raw)) {
+    if (/\{\{[A-Z_]+\}\}/.test(raw)) {                     // leftover token; markers are stripped during fill
       var warn = document.createElement("div");
       warn.className = "fill-warning";
-      warn.textContent = "⚠ template not fully filled — a placeholder or marker was left behind";
+      warn.textContent = "⚠ template not fully filled — a placeholder was left behind";
       document.body.appendChild(warn);
     }
     var open = null;
@@ -349,30 +350,30 @@
       open = null;
     }
     document.addEventListener("click", function (e) {
-      var t = e.target;
-      if (t.closest && t.closest(".detail-panel")) return;          // clicks inside a panel never toggle
-      var trigger = t.closest ? t.closest("[data-detail]") : null;  // works for HTML and SVG elements
-      if (!trigger) return;
-      var id = trigger.getAttribute("data-detail");
-      var tpl = document.querySelector('template[data-detail-body="' + id + '"]');
-      if (!tpl) return;
-      var wasOpen = open && open.trigger === trigger;
-      close();
-      if (wasOpen) return;                                          // second click closes
-      var panel = document.createElement("div");
-      panel.className = "detail-panel";
-      panel.appendChild(tpl.content.cloneNode(true));
-      var isSvg = !!trigger.ownerSVGElement;
-      if (isSvg) {
-        var dock = null, n = trigger;
-        while (n && n.parentNode) { n = n.parentNode; if (n.querySelector) { dock = n.querySelector("[data-detail-dock]"); if (dock) break; } }
-        (dock || document.body).appendChild(panel);
-      } else {
-        trigger.appendChild(panel);
-      }
-      trigger.classList.add("detail-open");
-      trigger.setAttribute("aria-expanded", "true");
-      open = { trigger: trigger, panel: panel };
+      try {                                                         // runs after setup — guard so a bad fill can't break clicks
+        var t = e.target;
+        if (t.closest(".detail-panel")) return;                     // clicks inside a panel never toggle
+        var trigger = t.closest("[data-detail]");                   // closest works on HTML and SVG elements
+        if (!trigger) return;
+        var id = trigger.getAttribute("data-detail"), tpl = null;
+        var tpls = document.querySelectorAll("template[data-detail-body]"); // match by value — no selector injection
+        for (var i = 0; i < tpls.length; i++) { if (tpls[i].getAttribute("data-detail-body") === id) { tpl = tpls[i]; break; } }
+        if (!tpl) return;
+        var wasOpen = open && open.trigger === trigger;
+        close();
+        if (wasOpen) return;                                        // second click closes
+        var panel = document.createElement("div");
+        panel.className = "detail-panel";
+        panel.appendChild(tpl.content.cloneNode(true));
+        // Render in the trigger's OWN <section> dock if it has one (the visual archetypes);
+        // otherwise expand inline inside the trigger (steps, file rows). SVG with no dock → body.
+        var sec = trigger.closest("section");
+        var dock = sec ? sec.querySelector("[data-detail-dock]") : null;
+        (dock || (trigger.ownerSVGElement ? document.body : trigger)).appendChild(panel);
+        trigger.classList.add("detail-open");
+        trigger.setAttribute("aria-expanded", "true");
+        open = { trigger: trigger, panel: panel };
+      } catch (err) { /* a malformed id or unexpected DOM must never break the page */ }
     });
     document.addEventListener("keydown", function (e) { if (e.key === "Escape") close(); });
   } catch (err) { /* a partial fill must never break the page */ }

--- a/.claude/skills/ir:exec/templates/plan.html
+++ b/.claude/skills/ir:exec/templates/plan.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<!--
+  ir:exec plan template — self-contained, no external resources.
+
+  HOW TO USE (see ../SKILL.md). NOTE: this how-to avoids writing literal
+  comment-close sequences so it never terminates early; the body holds the
+  real "REPEAT:x" / "OPTIONAL:x" marker comments.
+    1. Copy this file to /tmp/ir-exec-plan-<issue>.html
+    2. Replace every {{TOKEN}} with real content.
+    3. For each REPEAT:x marker-comment region in the body, duplicate the inner
+       block once per item, then delete the leftover example block.
+    4. NEVER edit the style block — it is the design system; keep it byte-for-byte.
+    5. OPTIONAL:x marker-comment regions may be deleted whole if unused.
+
+  The plan page is PRE-implementation: Problem, Approach/Design, Steps, Files, Risks.
+  Confidence / test-vs-merge is a later conversational step, not part of this page.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Plan · #{{ISSUE_NUMBER}} {{ISSUE_TITLE}}</title>
+<style>
+  :root {
+    --bg: #0f1115;
+    --surface: #171a21;
+    --surface-2: #1e222b;
+    --border: #2a2f3a;
+    --text: #e6e9ef;
+    --muted: #9aa3b2;
+    --faint: #6b7280;
+    --accent: #7c9cff;
+    --accent-soft: #1f2740;
+    --new: #4ade80;
+    --mod: #fbbf24;
+    --del: #f87171;
+    --risk: #fb923c;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.6;
+  }
+  .wrap { max-width: 860px; margin: 0 auto; padding: 40px 24px 96px; }
+
+  /* Header */
+  header { border-bottom: 1px solid var(--border); padding-bottom: 24px; margin-bottom: 36px; }
+  .eyebrow { font-family: var(--mono); font-size: 12px; letter-spacing: .08em; text-transform: uppercase; color: var(--accent); margin: 0 0 8px; }
+  h1 { font-size: 26px; line-height: 1.25; margin: 0 0 16px; font-weight: 650; }
+  .meta { display: flex; flex-wrap: wrap; gap: 8px 16px; font-family: var(--mono); font-size: 12.5px; color: var(--muted); }
+  .meta a { color: var(--accent); text-decoration: none; }
+  .meta a:hover { text-decoration: underline; }
+  .meta span b { color: var(--text); font-weight: 600; }
+
+  /* Sections */
+  section { margin: 0 0 40px; }
+  h2 {
+    font-size: 13px; letter-spacing: .08em; text-transform: uppercase;
+    color: var(--faint); margin: 0 0 16px; font-weight: 600;
+    display: flex; align-items: center; gap: 10px;
+  }
+  h2::before { content: ""; width: 14px; height: 2px; background: var(--accent); border-radius: 2px; }
+
+  .lede { font-size: 16px; color: var(--text); margin: 0 0 12px; }
+  p { margin: 0 0 12px; }
+  .muted { color: var(--muted); }
+  code { font-family: var(--mono); font-size: .88em; background: var(--surface-2); padding: 1px 6px; border-radius: 5px; color: #cdd6f4; }
+
+  /* Approach bullets */
+  ul.approach { list-style: none; margin: 0; padding: 0; }
+  ul.approach li { position: relative; padding: 0 0 10px 22px; }
+  ul.approach li::before { content: "→"; position: absolute; left: 0; color: var(--accent); font-family: var(--mono); }
+
+  /* Diagram */
+  .diagram {
+    background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+    padding: 24px; margin: 12px 0 4px; overflow-x: auto;
+  }
+  .flow { display: flex; align-items: center; gap: 12px; min-width: max-content; }
+  .node {
+    background: var(--surface-2); border: 1px solid var(--border); border-radius: 9px;
+    padding: 10px 14px; font-family: var(--mono); font-size: 12.5px; white-space: nowrap;
+  }
+  .node.accent { border-color: var(--accent); background: var(--accent-soft); color: #cdd6ff; }
+  .arrow { color: var(--faint); font-family: var(--mono); }
+
+  /* Steps */
+  ol.steps { list-style: none; counter-reset: step; margin: 0; padding: 0; }
+  ol.steps > li {
+    position: relative; counter-increment: step;
+    background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+    padding: 18px 20px 18px 60px; margin: 0 0 14px;
+  }
+  ol.steps > li::before {
+    content: counter(step); position: absolute; left: 16px; top: 17px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--accent-soft); color: var(--accent); border: 1px solid var(--accent);
+    font-family: var(--mono); font-size: 13px; font-weight: 600;
+    display: flex; align-items: center; justify-content: center;
+  }
+  .step-title { font-weight: 600; font-size: 15.5px; margin: 0 0 6px; }
+  .step-body { color: var(--muted); margin: 0 0 10px; font-size: 14.5px; }
+  .step-body:last-child { margin-bottom: 0; }
+  .step-files { display: flex; flex-wrap: wrap; gap: 6px; }
+  .chip { font-family: var(--mono); font-size: 11.5px; background: var(--surface-2); border: 1px solid var(--border); color: var(--muted); padding: 2px 8px; border-radius: 6px; }
+
+  /* Files table */
+  .files { display: flex; flex-direction: column; gap: 6px; }
+  .file-row { display: flex; align-items: center; gap: 12px; font-family: var(--mono); font-size: 13px; padding: 8px 12px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; }
+  .badge { font-size: 10.5px; font-weight: 700; letter-spacing: .04em; padding: 2px 7px; border-radius: 5px; flex-shrink: 0; min-width: 46px; text-align: center; }
+  .badge.new { background: rgba(74,222,128,.12); color: var(--new); border: 1px solid rgba(74,222,128,.3); }
+  .badge.mod { background: rgba(251,191,36,.12); color: var(--mod); border: 1px solid rgba(251,191,36,.3); }
+  .badge.del { background: rgba(248,113,113,.12); color: var(--del); border: 1px solid rgba(248,113,113,.3); }
+  .file-row .path { color: var(--text); word-break: break-all; }
+  .file-row .note { color: var(--faint); margin-left: auto; font-size: 12px; white-space: nowrap; }
+
+  /* Risks */
+  .risk-card { background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--risk); border-radius: 10px; padding: 14px 18px; margin: 0 0 12px; }
+  .risk-card .rt { font-weight: 600; margin: 0 0 4px; color: #ffd9b3; }
+  .risk-card .rb { color: var(--muted); margin: 0; font-size: 14.5px; }
+
+  /* Approval footer */
+  .approval { background: var(--accent-soft); border: 1px solid var(--accent); border-radius: 12px; padding: 20px 22px; margin-top: 8px; }
+  .approval h2 { color: var(--accent); margin-bottom: 8px; }
+  .approval h2::before { background: var(--accent); }
+  .approval p { color: #cdd6ff; margin: 0; }
+
+  footer { margin-top: 48px; padding-top: 20px; border-top: 1px solid var(--border); font-family: var(--mono); font-size: 11.5px; color: var(--faint); text-align: center; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header>
+    <p class="eyebrow">Implementation Plan</p>
+    <h1>{{ISSUE_TITLE}}</h1>
+    <div class="meta">
+      <span>Issue <a href="{{ISSUE_URL}}">#{{ISSUE_NUMBER}}</a></span>
+      <span>Branch <b>{{BRANCH}}</b></span>
+      <span>Worktree <b>{{WORKTREE}}</b></span>
+      <span>Generated {{GENERATED}}</span>
+    </div>
+  </header>
+
+  <section>
+    <h2>Problem</h2>
+    <p class="lede">{{PROBLEM}}</p>
+  </section>
+
+  <section>
+    <h2>Approach &amp; Design</h2>
+    <p>{{APPROACH_INTRO}}</p>
+    <ul class="approach">
+      <!-- REPEAT:approach -->
+      <li>{{APPROACH_BULLET}}</li>
+      <!-- /REPEAT:approach -->
+    </ul>
+
+    <!-- OPTIONAL:diagram — a clean flow/box visual of the design. Edit the nodes;
+         add more .flow rows for layered diagrams. Delete this whole block if not useful. -->
+    <div class="diagram">
+      <div class="flow">
+        <div class="node">{{DIAGRAM_NODE}}</div>
+        <span class="arrow">→</span>
+        <div class="node accent">{{DIAGRAM_NODE}}</div>
+        <span class="arrow">→</span>
+        <div class="node">{{DIAGRAM_NODE}}</div>
+      </div>
+    </div>
+    <!-- /OPTIONAL:diagram -->
+  </section>
+
+  <section>
+    <h2>Steps</h2>
+    <ol class="steps">
+      <!-- REPEAT:step -->
+      <li>
+        <p class="step-title">{{STEP_TITLE}}</p>
+        <p class="step-body">{{STEP_BODY}}</p>
+        <div class="step-files">
+          <span class="chip">{{STEP_FILE}}</span>
+        </div>
+      </li>
+      <!-- /REPEAT:step -->
+    </ol>
+  </section>
+
+  <section>
+    <h2>Files Touched</h2>
+    <div class="files">
+      <!-- REPEAT:file — badge class is one of: new | mod | del -->
+      <div class="file-row">
+        <span class="badge mod">{{FILE_STATUS}}</span>
+        <span class="path">{{FILE_PATH}}</span>
+        <span class="note">{{FILE_NOTE}}</span>
+      </div>
+      <!-- /REPEAT:file -->
+    </div>
+  </section>
+
+  <section>
+    <h2>Risks &amp; Unknowns</h2>
+    <!-- REPEAT:risk -->
+    <div class="risk-card">
+      <p class="rt">{{RISK_TITLE}}</p>
+      <p class="rb">{{RISK_BODY}}</p>
+    </div>
+    <!-- /REPEAT:risk -->
+  </section>
+
+  <section class="approval">
+    <h2>Approval</h2>
+    <p>Review this plan, then reply in the session to approve (or request changes). Implementation does not begin until you accept.</p>
+  </section>
+
+  <footer>ir:exec · plan for #{{ISSUE_NUMBER}} · {{GENERATED}}</footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
Closes #756.

Evolves `ir:exec` from a plan-only skill (it ended at `ExitPlanMode`) into a **six-phase end-to-end issue executor** with one hard human gate between planning and code:

```
worktree → investigate → HTML plan (/tmp) → ⛔ APPROVAL → implement → PR → /review → fix → /simplify → PR link + test-or-merge recommendation
```

### What changed
- **`SKILL.md`** rewritten into the six phases. Resolves the open questions from the issue:
  - **Worktree**: `git worktree add -b feat/<N>-<slug> .claude/worktrees/<N>-<slug> origin/main` (gitignored path, matches existing convention).
  - **Approval gate**: present the `file:///tmp/...` link + summary, then *stop and wait* — a plain reply-to-approve gate, not `ExitPlanMode`.
  - **Review**: `/review` on the PR. **Pinned: never the Workflow / multi-agent tool — too expensive.** Single pass, then fix findings.
  - **Confidence rubric**: concrete signals (clean review + green suites + small/low-risk diff → lean merge; findings / flaky-or-absent tests / large-risky / user-visible → lean test-first).
- **`templates/plan.html`** (new): a self-contained HTML plan template — no external URLs/scripts/fonts. Dark, card-based: header, Problem, Approach/Design + optional flow diagram, numbered Steps, Files-touched with new/mod/del badges, Risks callouts, approval footer. Uses `{{TOKEN}}` placeholders + `REPEAT`/`OPTIONAL` marker regions; the agent keeps the `<style>` block verbatim and only swaps body content. Visual style inspired by mattpocock's `improve-codebase-architecture` skill.

### Verification
This is a skill definition (agent instructions + an HTML asset), so verification is structural rather than a unit test:
- Template is self-contained (no external resources) and parses with balanced tags (Python `html.parser`).
- Fixed a real bug found in review-of-self: the leading how-to comment quoted `<!-- REPEAT -->` markers, whose inner `-->` prematurely terminated the comment (browsers do the same) — reworded to avoid literal comment-close sequences.
- Dogfooded: a filled instance for this very issue renders from the template at `/tmp/ir-exec-plan-756.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update — richer, interactive plan page (commit `fef2faa7`)

Per follow-up feedback, the plan page is no longer flat text:
- **TL;DR** + a code-free **"How it works"** section above the technical Approach.
- **Adaptive visual** — pick one of three `OPTIONAL` archetypes: **UI before/after** (real screenshot as a `data:` URI beside a hand-authored SVG wireframe), **data-flow**, or a **component-impact map** (changed/adjacent/untouched) — or none.
- **Interactivity** via one generic inline engine: any `[data-detail]` element toggles its sibling `<template data-detail-body>`. It **clones nodes** (no `innerHTML` string-building, no JSON parse), so a partial fill never blanks the page; Esc closes; a load-time guardrail banner warns (never blocks) on leftover `{{tokens}}`. (Rejected a `window.__PLAN__` JSON-blob renderer precisely because one bad quote would blank the whole page at the approval gate.)
- Retuned to the **Irrlicht brand** palette, copied inline — deliberately **not** `@import`-ing the design-system sheet (it pulls Google Fonts, which would break self-containment).
- Self-containment rule reversed: no **external** resources, but the inline `<style>` + `<script>` are part of the template (kept byte-for-byte); `data:` URIs allowed.

Verified: template + a filled #755 dogfood parse clean; exact `data-detail`↔`template` parity; guardrail fires on the skeleton, quiet on the filled page; engine passes `node --check`.
