### PR TITLE
feat(daemon): enrich opt-in lifecycle trace so ghosts are reconstructable (#757 Phase 1)

### DIFF
--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -234,9 +234,12 @@ func (pm *PIDManager) record(ev lifecycle.Event) {
 	pm.recorder.Record(ev)
 }
 
-// HandleProcessExit deletes a session when its process exits.
-func (pm *PIDManager) HandleProcessExit(pid int, sessionID string) {
-	pm.record(lifecycle.Event{Kind: lifecycle.KindProcessExited, SessionID: sessionID, PID: pid})
+// HandleProcessExit deletes a session when its process exits. reason describes
+// the triggering edge (e.g. "pid exited (ESRCH)") and is recorded on both the
+// KindProcessExited event and the resulting deletion, so a trace explains why
+// the session went away (issue #757).
+func (pm *PIDManager) HandleProcessExit(pid int, sessionID, reason string) {
+	pm.record(lifecycle.Event{Kind: lifecycle.KindProcessExited, SessionID: sessionID, PID: pid, Reason: reason})
 
 	if pm.onSessionDeleted != nil {
 		pm.onSessionDeleted(sessionID)
@@ -252,7 +255,7 @@ func (pm *PIDManager) HandleProcessExit(pid int, sessionID string) {
 	pm.log.LogInfo("process-exit", sessionID,
 		fmt.Sprintf("pid %d exited, deleting session (was %s)", pid, state.State))
 
-	pm.deleteWithChildren(state)
+	pm.deleteWithChildren(state, reason)
 }
 
 // CleanupZombies is a one-shot synchronous startup sweep that deletes any
@@ -306,7 +309,7 @@ func (pm *PIDManager) CleanupZombies() int {
 		}
 		pm.log.LogInfo("startup-cleanup", state.SessionID,
 			fmt.Sprintf("zombie session (pid=%d, state=%s, adapter=%s) — deleting", state.PID, state.State, state.Adapter))
-		pm.deleteWithChildren(state)
+		pm.deleteWithChildren(state, fmt.Sprintf("startup zombie sweep: pid=%d state=%s", state.PID, state.State))
 		deleted++
 	}
 	return deleted
@@ -422,7 +425,9 @@ func (pm *PIDManager) deleteSession(s *session.SessionState, reason string) {
 }
 
 // deleteWithChildren removes a session and all its child sessions (subagents).
-func (pm *PIDManager) deleteWithChildren(state *session.SessionState) {
+// reason is recorded on the parent's deletion event so the trace explains why
+// it was reaped; children carry "parent deleted" (issue #757).
+func (pm *PIDManager) deleteWithChildren(state *session.SessionState, reason string) {
 	if states, err := pm.repo.ListAll(); err == nil {
 		for _, s := range states {
 			if s.ParentSessionID == state.SessionID {
@@ -430,7 +435,7 @@ func (pm *PIDManager) deleteWithChildren(state *session.SessionState) {
 			}
 		}
 	}
-	pm.deleteSession(state, "session deleted")
+	pm.deleteSession(state, reason)
 }
 
 // cleanupChildren removes all child sessions of the given parent.
@@ -787,7 +792,7 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 	for _, snap := range snaps {
 		if snap.pid > 0 {
 			if err := syscall.Kill(snap.pid, 0); err == syscall.ESRCH {
-				pm.HandleProcessExit(snap.pid, snap.state.SessionID)
+				pm.HandleProcessExit(snap.pid, snap.state.SessionID, "pid exited (ESRCH)")
 				foundDead = true
 				continue
 			}
@@ -799,7 +804,8 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 				pm.log.LogInfo("session-detector", snap.state.SessionID,
 					fmt.Sprintf("pid %d is %s background infra, not the session — reaping ghost",
 						snap.pid, snap.adapter))
-				pm.HandleProcessExit(snap.pid, snap.state.SessionID)
+				pm.HandleProcessExit(snap.pid, snap.state.SessionID,
+					fmt.Sprintf("infra-bound ghost: pid %d is %s background infra, not the session", snap.pid, snap.adapter))
 				foundDead = true
 			}
 		}
@@ -851,7 +857,8 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 				isStaleTranscript(snap.transcriptPath) {
 				pm.log.LogInfo("session-detector", snap.state.SessionID,
 					"ready session with no PID and stale transcript for >30s, deleting")
-				pm.deleteWithChildren(snap.state)
+				pm.deleteWithChildren(snap.state,
+					"ghost reaped: PID=0, ready, stale transcript >30s — pre-session never bound a process")
 				continue
 			}
 
@@ -868,7 +875,8 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 				pm.log.LogInfo("session-detector", snap.state.SessionID,
 					fmt.Sprintf("%s session (pid=%d) idle for >%v, deleting",
 						snap.sessionState, snap.pid, pm.readyTTL))
-				pm.deleteWithChildren(snap.state)
+				pm.deleteWithChildren(snap.state,
+					fmt.Sprintf("%s session (pid=%d) idle >%v — liveness sweep", snap.sessionState, snap.pid, pm.readyTTL))
 			}
 		}
 	}
@@ -948,7 +956,7 @@ func (pm *PIDManager) seedAlivePIDs(states []*session.SessionState) map[int]*ses
 			// cwdMissing also catches zombies re-touched by `claude --resume`
 			// after the worktree was deleted (#321).
 			pm.log.LogInfo("session-detector-seed", state.SessionID, "deleting orphan session")
-			pm.deleteWithChildren(state)
+			pm.deleteWithChildren(state, "orphan session at seed — PID discovery never succeeded")
 		}
 	}
 	return newestByPID
@@ -961,7 +969,7 @@ func (pm *PIDManager) handleAlivePIDState(state *session.SessionState) bool {
 	if err := syscall.Kill(state.PID, 0); err == syscall.ESRCH {
 		pm.log.LogInfo("session-detector-seed", state.SessionID,
 			fmt.Sprintf("pid %d dead, deleting session", state.PID))
-		pm.deleteWithChildren(state)
+		pm.deleteWithChildren(state, fmt.Sprintf("pid %d dead at seed (ESRCH)", state.PID))
 		return false
 	}
 	if pm.pw != nil {

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -859,7 +859,7 @@ func TestHandleProcessExit_EvictsChildrenViaFunnel(t *testing.T) {
 	}
 
 	var deleted []string
-	newPIDManagerForTestWithDeleteSpy(repo, &deleted).HandleProcessExit(4242, "parent")
+	newPIDManagerForTestWithDeleteSpy(repo, &deleted).HandleProcessExit(4242, "parent", "test: pid exited")
 
 	if len(repo.states) != 0 {
 		t.Fatalf("parent and child should both be gone, repo has %d sessions", len(repo.states))

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -390,6 +390,30 @@ func (d *SessionDetector) record(ev lifecycle.Event) {
 	d.recorder.Record(ev)
 }
 
+// classifierInputs snapshots the transient SessionMetrics signals that drive
+// ClassifyState into a lifecycle.ClassifierInputs for attaching to recorded
+// state-transition events (issue #757). Returns nil when metrics is nil so the
+// event's omitempty Inputs field stays absent.
+func classifierInputs(m *session.SessionMetrics) *lifecycle.ClassifierInputs {
+	if m == nil {
+		return nil
+	}
+	return &lifecycle.ClassifierInputs{
+		HasLiveBackgroundProcess:          m.HasLiveBackgroundProcess,
+		PermissionPending:                 m.PermissionPending,
+		CompactInProgress:                 m.CompactInProgress,
+		OpenToolStalled:                   m.OpenToolStalled,
+		SawUserBlockingToolClosedThisPass: m.SawUserBlockingToolClosedThisPass,
+		SawManualCompactBoundary:          m.SawManualCompactBoundary,
+		NoSubstantiveActivity:             m.NoSubstantiveActivity,
+		HasOpenToolCall:                   m.HasOpenToolCall,
+		LastOpenToolNames:                 m.LastOpenToolNames,
+		LastEventType:                     m.LastEventType,
+		LastWasUserInterrupt:              m.LastWasUserInterrupt,
+		LastWasToolDenial:                 m.LastWasToolDenial,
+	}
+}
+
 // AddWatcher registers a watcher with the running (or not-yet-running)
 // detector: a drain goroutine subscribes to the watcher's events and fans
 // them into the merged channel until ctx is cancelled. The caller owns the

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -597,6 +597,7 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 				PrevState: session.StateWorking,
 				NewState:  session.StateWaiting,
 				Reason:    SyntheticWaitingReason,
+				Inputs:    classifierInputs(state.Metrics),
 			})
 			state.State = session.StateWaiting
 			newState, reason = ClassifyState(state.State, state.Metrics)

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -606,7 +606,7 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 			if reason != "" {
 				d.log.LogInfo("session-detector", ev.SessionID, reason)
 			}
-			d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: ev.SessionID, PrevState: state.State, NewState: newState, Reason: reason})
+			d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: ev.SessionID, PrevState: state.State, NewState: newState, Reason: reason, Inputs: classifierInputs(state.Metrics)})
 			state.State = newState
 			state.UpdatedAt = now
 

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -100,7 +100,7 @@ func (d *SessionDetector) cleanupPreSessionsForProject(projectDir, realCWD, adap
 			adapterName = state.Adapter
 			d.broadcast(outbound.PushTypeDeleted, state)
 		}
-		d.record(lifecycle.Event{Kind: lifecycle.KindPreSessionRemoved, SessionID: sid, Adapter: adapterName})
+		d.record(lifecycle.Event{Kind: lifecycle.KindPreSessionRemoved, SessionID: sid, Adapter: adapterName, Reason: "superseded by real session for project"})
 		d.log.LogInfo("session-detector", sid,
 			fmt.Sprintf("removed pre-session — real session arrived in %s", projectDir))
 	}

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -92,9 +92,10 @@ func (d *SessionDetector) onRemovedLocked(state *session.SessionState, ev agent.
 	d.enricher.PruneMetrics(state.TranscriptPath)
 }
 
-// HandleProcessExit deletes a session when its process exits.
-func (d *SessionDetector) HandleProcessExit(pid int, sessionID string) {
-	d.pidMgr.HandleProcessExit(pid, sessionID)
+// HandleProcessExit deletes a session when its process exits. reason describes
+// the triggering edge for the recorded lifecycle trace (issue #757).
+func (d *SessionDetector) HandleProcessExit(pid int, sessionID, reason string) {
+	d.pidMgr.HandleProcessExit(pid, sessionID, reason)
 }
 
 // HandlePIDAssigned records a newly-discovered PID for a session.

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -1083,7 +1083,7 @@ func TestSessionDetector_HandleProcessExit_DeletesSession(t *testing.T) {
 
 	det := newDetector(tw, pw, repo)
 
-	det.HandleProcessExit(12345, "exit1")
+	det.HandleProcessExit(12345, "exit1", "test: pid exited")
 
 	state, _ := repo.Load("exit1")
 	if state != nil {
@@ -1106,7 +1106,7 @@ func TestSessionDetector_HandleProcessExit_DeletesReadySession(t *testing.T) {
 
 	det := newDetector(tw, pw, repo)
 
-	det.HandleProcessExit(12345, "exit2")
+	det.HandleProcessExit(12345, "exit2", "test: pid exited")
 
 	state, _ := repo.Load("exit2")
 	if state != nil {
@@ -1135,7 +1135,7 @@ func TestSessionDetector_ContinueSession_RecreatableAfterProcessExit(t *testing.
 	det.SetDeletedCooldown(0) // allow immediate re-creation
 
 	// Process exits — session is deleted and added to deletedSessions.
-	det.HandleProcessExit(12345, "cont1")
+	det.HandleProcessExit(12345, "cont1", "test: pid exited")
 
 	state, _ := repo.Load("cont1")
 	if state != nil {
@@ -1198,7 +1198,7 @@ func TestSessionDetector_LateWriteAfterQuit_NoGhostSession(t *testing.T) {
 	// Keep default 10s cooldown — late writes happen within milliseconds.
 
 	// Process exits — session deleted.
-	det.HandleProcessExit(12345, "ghost1")
+	det.HandleProcessExit(12345, "ghost1", "test: pid exited")
 
 	state, _ := repo.Load("ghost1")
 	if state != nil {
@@ -1244,7 +1244,7 @@ func TestSessionDetector_HandleProcessExit_UnknownSession(t *testing.T) {
 	det := newDetector(tw, pw, repo)
 
 	// Should not panic for unknown session.
-	det.HandleProcessExit(99999, "nonexistent")
+	det.HandleProcessExit(99999, "nonexistent", "test: pid exited")
 }
 
 // TestSessionDetector_SeedFromDisk_PersistsRefreshedMetrics is a regression

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -297,7 +297,7 @@ func main() {
 	var pwPort outbound.ProcessWatcher
 	if !demoMode {
 		pw, err := processlifecycle.NewMonitor(func(pid int, sessionID string) {
-			detector.HandleProcessExit(pid, sessionID)
+			detector.HandleProcessExit(pid, sessionID, "process watcher: pid exited (NOTE_EXIT)")
 		})
 		if err != nil {
 			logger.LogError("startup", "", fmt.Sprintf("ProcessWatcher init failed (non-fatal): %v", err))

--- a/core/domain/lifecycle/event.go
+++ b/core/domain/lifecycle/event.go
@@ -91,6 +91,12 @@ type Event struct {
 	NewState  string `json:"new_state,omitempty"`
 	Reason    string `json:"reason,omitempty"`
 
+	// Inputs is the classifier-input snapshot that drove this transition
+	// (KindStateTransition only). Pointer + omitempty: absent on every event
+	// that isn't a transition, so existing sidecars stay compact. Lets an
+	// agent reconstruct *why* the classifier chose NewState (issue #757).
+	Inputs *ClassifierInputs `json:"inputs,omitempty"`
+
 	// Parent-child.
 	ParentSessionID string `json:"parent_session_id,omitempty"`
 
@@ -122,4 +128,27 @@ type Event struct {
 	DeltaTokens       int64   `json:"delta_tokens,omitempty"`
 	BaselineMedian    float64 `json:"baseline_median,omitempty"`
 	CurrentMedian     float64 `json:"current_median,omitempty"`
+}
+
+// ClassifierInputs is a snapshot of the transient SessionMetrics signals that
+// feed ClassifyState, attached to KindStateTransition events so a recorded
+// trace explains its own classification decisions at replay time (issue #757).
+// Every field is omitempty and mirrors the same-named SessionMetrics field;
+// the values are copied, never re-derived here. Captured on the transition edge
+// only (not on every activity event) since these are the inputs that decided
+// the new state — the headline use is reconstructing why an antigravity PID=0
+// ghost was classified ready before it was reaped.
+type ClassifierInputs struct {
+	HasLiveBackgroundProcess          bool     `json:"has_live_background_process,omitempty"`
+	PermissionPending                 bool     `json:"permission_pending,omitempty"`
+	CompactInProgress                 bool     `json:"compact_in_progress,omitempty"`
+	OpenToolStalled                   bool     `json:"open_tool_stalled,omitempty"`
+	SawUserBlockingToolClosedThisPass bool     `json:"saw_user_blocking_tool_closed_this_pass,omitempty"`
+	SawManualCompactBoundary          bool     `json:"saw_manual_compact_boundary,omitempty"`
+	NoSubstantiveActivity             bool     `json:"no_substantive_activity,omitempty"`
+	HasOpenToolCall                   bool     `json:"has_open_tool_call,omitempty"`
+	LastOpenToolNames                 []string `json:"last_open_tool_names,omitempty"`
+	LastEventType                     string   `json:"last_event_type,omitempty"`
+	LastWasUserInterrupt              bool     `json:"last_was_user_interrupt,omitempty"`
+	LastWasToolDenial                 bool     `json:"last_was_tool_denial,omitempty"`
 }

--- a/tools/onboarding-factory/cmd/replay/ghosts.go
+++ b/tools/onboarding-factory/cmd/replay/ghosts.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -49,9 +48,14 @@ func buildGhostTimelines(events []lifecycle.Event) []sessionTimeline {
 				g.finalReason = ev.Reason
 			}
 		case lifecycle.KindTranscriptRemoved, lifecycle.KindProcessExited, lifecycle.KindPreSessionRemoved:
-			g.removed = true
-			g.removedAt = ev.Timestamp
-			g.removalReason = ev.Reason
+			// Keep the FIRST removal edge: a HandleProcessExit reap records
+			// KindProcessExited and then KindTranscriptRemoved for the same
+			// session, and the process-exit edge is the true (earlier) one.
+			if !g.removed {
+				g.removed = true
+				g.removedAt = ev.Timestamp
+				g.removalReason = ev.Reason
+			}
 		}
 	}
 
@@ -70,7 +74,11 @@ func buildGhostTimelines(events []lifecycle.Event) []sessionTimeline {
 				base[i].LifetimeMs = at.Sub(base[i].FirstSeen).Milliseconds()
 			}
 		}
-		base[i].IsGhost = !g.substantive
+		// Children (subagents) are not ghosts in the antigravity PID=0 sense: a
+		// subagent reaped via "parent deleted" can lack both a PID and a
+		// working/waiting transition of its own, yet it did real work. Exclude
+		// them so the conservative predicate doesn't false-positive.
+		base[i].IsGhost = !g.substantive && base[i].ParentSessionID == ""
 	}
 	return base
 }
@@ -217,12 +225,9 @@ func runGhostDump(sidecarPath string) error {
 	if err != nil {
 		return fmt.Errorf("load sidecar %s: %w", sidecarPath, err)
 	}
+	// buildGhostTimelines already returns timelines sorted by FirstSeen
+	// (buildSessionTimelines sorts; the ghost-layering pass preserves order).
 	timelines := buildGhostTimelines(events)
-	// Stable, time-independent ordering already applied by buildSessionTimelines
-	// (sorted by FirstSeen); keep ghosts grouped within that order.
-	sort.SliceStable(timelines, func(i, j int) bool {
-		return timelines[i].FirstSeen.Before(timelines[j].FirstSeen)
-	})
 	fmt.Print(renderGhostTimeline(sidecarPath, timelines, lastTransitionInputs(events)))
 	return nil
 }

--- a/tools/onboarding-factory/cmd/replay/ghosts.go
+++ b/tools/onboarding-factory/cmd/replay/ghosts.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+)
+
+// ghostAgg accumulates the per-session signals that decide whether a session
+// was a "ghost" — minted, never did substantive work, then reaped. Computed in
+// a second pass over the sidecar events so the JSON report path stays untouched
+// (issue #757).
+type ghostAgg struct {
+	substantive   bool
+	removed       bool
+	removedAt     time.Time
+	removalReason string
+	finalReason   string
+}
+
+// buildGhostTimelines reuses the standard per-session aggregation and layers
+// ghost-detection signals on top for the --ghosts text view. A session is a
+// ghost when it was removed yet never showed substantive activity — it never
+// bound a PID and never entered working/waiting. The predicate is conservative
+// (prefers false negatives): anything that ever got a PID or actively worked is
+// not a ghost, even if it is later reaped.
+func buildGhostTimelines(events []lifecycle.Event) []sessionTimeline {
+	base := buildSessionTimelines(events)
+
+	agg := make(map[string]*ghostAgg, len(base))
+	for _, ev := range events {
+		g := agg[ev.SessionID]
+		if g == nil {
+			g = &ghostAgg{}
+			agg[ev.SessionID] = g
+		}
+		switch ev.Kind {
+		case lifecycle.KindPIDDiscovered:
+			g.substantive = true
+		case lifecycle.KindStateTransition:
+			if ev.NewState == session.StateWorking || ev.NewState == session.StateWaiting {
+				g.substantive = true
+			}
+			if ev.Reason != "" {
+				g.finalReason = ev.Reason
+			}
+		case lifecycle.KindTranscriptRemoved, lifecycle.KindProcessExited, lifecycle.KindPreSessionRemoved:
+			g.removed = true
+			g.removedAt = ev.Timestamp
+			g.removalReason = ev.Reason
+		}
+	}
+
+	for i := range base {
+		g := agg[base[i].SessionID]
+		if g == nil || !g.removed {
+			continue
+		}
+		base[i].HadSubstantive = g.substantive
+		base[i].RemovalReason = g.removalReason
+		base[i].FinalReason = g.finalReason
+		if !g.removedAt.IsZero() {
+			at := g.removedAt
+			base[i].RemovedAt = &at
+			if !base[i].FirstSeen.IsZero() {
+				base[i].LifetimeMs = at.Sub(base[i].FirstSeen).Milliseconds()
+			}
+		}
+		base[i].IsGhost = !g.substantive
+	}
+	return base
+}
+
+// lastTransitionInputs maps each session to the classifier-input snapshot from
+// its most recent state transition, so the ghost view can explain *why* the
+// classifier reached the session's final state (the Inputs captured in 1a).
+func lastTransitionInputs(events []lifecycle.Event) map[string]*lifecycle.ClassifierInputs {
+	out := make(map[string]*lifecycle.ClassifierInputs)
+	for _, ev := range events {
+		if ev.Kind == lifecycle.KindStateTransition && ev.Inputs != nil {
+			out[ev.SessionID] = ev.Inputs
+		}
+	}
+	return out
+}
+
+// formatClassifierInputs renders the set (non-zero) classifier-input fields as a
+// compact comma-separated list. Returns "(none recorded)" when nil — sidecars
+// recorded before issue #757 carry no Inputs.
+func formatClassifierInputs(in *lifecycle.ClassifierInputs) string {
+	if in == nil {
+		return "(none recorded)"
+	}
+	var parts []string
+	add := func(name string, set bool) {
+		if set {
+			parts = append(parts, name)
+		}
+	}
+	add("has_live_background_process", in.HasLiveBackgroundProcess)
+	add("permission_pending", in.PermissionPending)
+	add("compact_in_progress", in.CompactInProgress)
+	add("open_tool_stalled", in.OpenToolStalled)
+	add("saw_user_blocking_tool_closed", in.SawUserBlockingToolClosedThisPass)
+	add("saw_manual_compact_boundary", in.SawManualCompactBoundary)
+	add("no_substantive_activity", in.NoSubstantiveActivity)
+	add("has_open_tool_call", in.HasOpenToolCall)
+	add("last_was_user_interrupt", in.LastWasUserInterrupt)
+	add("last_was_tool_denial", in.LastWasToolDenial)
+	if in.LastEventType != "" {
+		parts = append(parts, "last_event_type="+in.LastEventType)
+	}
+	if len(in.LastOpenToolNames) > 0 {
+		parts = append(parts, "open_tools=["+strings.Join(in.LastOpenToolNames, ",")+"]")
+	}
+	if len(parts) == 0 {
+		return "(all defaults)"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// renderGhostTimeline produces a human-first text report of the sidecar's
+// sessions, ghosts first with full lifecycle detail, then a one-line summary of
+// the substantive sessions. This view is intentionally kept off the JSON/golden
+// path — it exists for an agent reconstructing why a transient session (e.g. an
+// antigravity PID=0 ghost) appeared and was reaped.
+func renderGhostTimeline(sidecarPath string, timelines []sessionTimeline, inputs map[string]*lifecycle.ClassifierInputs) string {
+	var ghosts, others []sessionTimeline
+	for _, t := range timelines {
+		if t.IsGhost {
+			ghosts = append(ghosts, t)
+		} else {
+			others = append(others, t)
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "ghost timeline — %s\n", sidecarPath)
+	fmt.Fprintf(&b, "%d session(s), %d ghost(s)\n\n", len(timelines), len(ghosts))
+
+	if len(ghosts) == 0 {
+		b.WriteString("GHOSTS\n  (none)\n\n")
+	} else {
+		b.WriteString("GHOSTS\n")
+		for _, t := range ghosts {
+			adapter := t.Adapter
+			if adapter == "" {
+				adapter = "?"
+			}
+			fmt.Fprintf(&b, "  %s  [%s]  GHOST\n", t.SessionID, adapter)
+			fmt.Fprintf(&b, "    minted    %s\n", fmtTime(t.FirstSeen))
+			fmt.Fprintf(&b, "    lifetime  %s\n", fmtLifetime(t.LifetimeMs))
+			final := t.FinalState
+			if final == "" {
+				final = "(no transition)"
+			}
+			fmt.Fprintf(&b, "    final     %s%s\n", final, fmtReason(t.FinalReason))
+			fmt.Fprintf(&b, "    inputs    %s\n", formatClassifierInputs(inputs[t.SessionID]))
+			fmt.Fprintf(&b, "    reaped    %s%s\n", fmtTimePtr(t.RemovedAt), fmtReason(t.RemovalReason))
+			b.WriteString("    substantive activity: none\n")
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("OTHER SESSIONS\n")
+	if len(others) == 0 {
+		b.WriteString("  (none)\n")
+	}
+	for _, t := range others {
+		adapter := t.Adapter
+		if adapter == "" {
+			adapter = "?"
+		}
+		final := t.FinalState
+		if final == "" {
+			final = "-"
+		}
+		fmt.Fprintf(&b, "  %s  [%s]  %s  pid=%d  events=%d  duration=%s\n",
+			t.SessionID, adapter, final, t.PID, t.EventCount, fmtLifetime(t.DurationMs))
+	}
+	return b.String()
+}
+
+func fmtTime(t time.Time) string {
+	if t.IsZero() {
+		return "(unknown)"
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func fmtTimePtr(t *time.Time) string {
+	if t == nil {
+		return "(not reaped)"
+	}
+	return fmtTime(*t)
+}
+
+func fmtLifetime(ms int64) string {
+	return (time.Duration(ms) * time.Millisecond).String()
+}
+
+func fmtReason(reason string) string {
+	if reason == "" {
+		return ""
+	}
+	return fmt.Sprintf(" — %q", reason)
+}
+
+// runGhostDump loads a lifecycle sidecar and prints its ghost timeline to
+// stdout. Backs the --ghosts flag.
+func runGhostDump(sidecarPath string) error {
+	events, err := loadAllLifecycleEvents(sidecarPath)
+	if err != nil {
+		return fmt.Errorf("load sidecar %s: %w", sidecarPath, err)
+	}
+	timelines := buildGhostTimelines(events)
+	// Stable, time-independent ordering already applied by buildSessionTimelines
+	// (sorted by FirstSeen); keep ghosts grouped within that order.
+	sort.SliceStable(timelines, func(i, j int) bool {
+		return timelines[i].FirstSeen.Before(timelines[j].FirstSeen)
+	})
+	fmt.Print(renderGhostTimeline(sidecarPath, timelines, lastTransitionInputs(events)))
+	return nil
+}

--- a/tools/onboarding-factory/cmd/replay/ghosts_test.go
+++ b/tools/onboarding-factory/cmd/replay/ghosts_test.go
@@ -106,3 +106,23 @@ func TestBuildGhostTimelines_NoGhostsLeaveReportFieldsZero(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildGhostTimelines_SubagentNotGhost guards the child exclusion: a
+// completed subagent (ParentSessionID set) reaped via "parent deleted" — no PID
+// and no working/waiting transition of its own — must NOT be flagged a ghost,
+// even though it has the same removed && !substantive shape as a real ghost.
+func TestBuildGhostTimelines_SubagentNotGhost(t *testing.T) {
+	base := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	events := []lifecycle.Event{
+		{Seq: 1, Timestamp: base, Kind: lifecycle.KindTranscriptNew, SessionID: "child", Adapter: "claude-code"},
+		{Seq: 2, Timestamp: base.Add(time.Second), Kind: lifecycle.KindParentLinked, SessionID: "child", ParentSessionID: "parent"},
+		{Seq: 3, Timestamp: base.Add(2 * time.Second), Kind: lifecycle.KindStateTransition, SessionID: "child",
+			PrevState: session.StateWorking, NewState: session.StateReady, Reason: "subagent completed (parent task-notification)"},
+		{Seq: 4, Timestamp: base.Add(3 * time.Second), Kind: lifecycle.KindTranscriptRemoved, SessionID: "child", Reason: "parent deleted"},
+	}
+	for _, tl := range buildGhostTimelines(events) {
+		if tl.SessionID == "child" && tl.IsGhost {
+			t.Errorf("completed subagent (ParentSessionID set) must not be flagged IsGhost")
+		}
+	}
+}

--- a/tools/onboarding-factory/cmd/replay/ghosts_test.go
+++ b/tools/onboarding-factory/cmd/replay/ghosts_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+)
+
+// TestBuildGhostTimelines_DetectsPID0Ghost is the CI-grade proof for the
+// antigravity headline case (issue #757): a PID=0 session that is classified
+// ready, never does substantive work, and is reaped on the stale-transcript
+// path must be flagged IsGhost with its removal reason and lifetime, while a
+// substantive sibling that bound a PID and worked must not.
+func TestBuildGhostTimelines_DetectsPID0Ghost(t *testing.T) {
+	base := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	const ghostReason = "ghost reaped: PID=0, ready, stale transcript >30s — pre-session never bound a process"
+
+	events := []lifecycle.Event{
+		// Ghost: minted, classified ready, never worked, reaped 33s later.
+		{Seq: 1, Timestamp: base, Kind: lifecycle.KindTranscriptNew, SessionID: "proc-0", Adapter: "antigravity"},
+		{Seq: 2, Timestamp: base.Add(1 * time.Second), Kind: lifecycle.KindStateTransition, SessionID: "proc-0",
+			PrevState: session.StateWorking, NewState: session.StateReady, Reason: "agent turn complete",
+			Inputs: &lifecycle.ClassifierInputs{NoSubstantiveActivity: true, LastEventType: "assistant"}},
+		{Seq: 3, Timestamp: base.Add(33 * time.Second), Kind: lifecycle.KindTranscriptRemoved, SessionID: "proc-0",
+			Adapter: "antigravity", Reason: ghostReason},
+
+		// Substantive sibling: bound a PID, worked, exited cleanly.
+		{Seq: 4, Timestamp: base.Add(10 * time.Second), Kind: lifecycle.KindTranscriptNew, SessionID: "sess-real", Adapter: "antigravity"},
+		{Seq: 5, Timestamp: base.Add(11 * time.Second), Kind: lifecycle.KindPIDDiscovered, SessionID: "sess-real", PID: 4242},
+		{Seq: 6, Timestamp: base.Add(12 * time.Second), Kind: lifecycle.KindStateTransition, SessionID: "sess-real",
+			PrevState: session.StateReady, NewState: session.StateWorking, Reason: "transcript activity"},
+		{Seq: 7, Timestamp: base.Add(40 * time.Second), Kind: lifecycle.KindStateTransition, SessionID: "sess-real",
+			PrevState: session.StateWorking, NewState: session.StateReady, Reason: "agent turn complete"},
+		{Seq: 8, Timestamp: base.Add(45 * time.Second), Kind: lifecycle.KindProcessExited, SessionID: "sess-real",
+			PID: 4242, Reason: "pid exited (ESRCH)"},
+	}
+
+	timelines := buildGhostTimelines(events)
+	byID := make(map[string]sessionTimeline, len(timelines))
+	for _, tl := range timelines {
+		byID[tl.SessionID] = tl
+	}
+
+	ghost, ok := byID["proc-0"]
+	if !ok {
+		t.Fatalf("no timeline for ghost session")
+	}
+	if !ghost.IsGhost {
+		t.Errorf("proc-0 should be flagged IsGhost")
+	}
+	if ghost.HadSubstantive {
+		t.Errorf("proc-0 should have HadSubstantive=false")
+	}
+	if ghost.RemovalReason != ghostReason {
+		t.Errorf("proc-0 RemovalReason = %q, want %q", ghost.RemovalReason, ghostReason)
+	}
+	if ghost.FinalReason != "agent turn complete" {
+		t.Errorf("proc-0 FinalReason = %q, want %q", ghost.FinalReason, "agent turn complete")
+	}
+	if ghost.RemovedAt == nil {
+		t.Fatalf("proc-0 RemovedAt should be set")
+	}
+	if ghost.LifetimeMs != 33_000 {
+		t.Errorf("proc-0 LifetimeMs = %d, want 33000", ghost.LifetimeMs)
+	}
+
+	real, ok := byID["sess-real"]
+	if !ok {
+		t.Fatalf("no timeline for substantive session")
+	}
+	if real.IsGhost {
+		t.Errorf("sess-real should NOT be flagged IsGhost (bound a PID and worked)")
+	}
+	if !real.HadSubstantive {
+		t.Errorf("sess-real should have HadSubstantive=true")
+	}
+
+	// The text view must name the ghost, its reason, its lifetime, and the
+	// classifier inputs that drove the final classification.
+	out := renderGhostTimeline("test.events.jsonl", timelines, lastTransitionInputs(events))
+	for _, want := range []string{"1 ghost(s)", "proc-0", "GHOST", ghostReason, "33s", "no_substantive_activity", "sess-real"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ghost timeline output missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+// TestBuildGhostTimelines_NoGhostsLeaveReportFieldsZero guards byte-identity:
+// for a fully substantive session the ghost fields must stay zero so the JSON
+// report path (which never calls buildGhostTimelines) cannot drift.
+func TestBuildGhostTimelines_NoGhostsLeaveReportFieldsZero(t *testing.T) {
+	base := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	events := []lifecycle.Event{
+		{Seq: 1, Timestamp: base, Kind: lifecycle.KindTranscriptNew, SessionID: "s", Adapter: "claude-code"},
+		{Seq: 2, Timestamp: base.Add(time.Second), Kind: lifecycle.KindPIDDiscovered, SessionID: "s", PID: 99},
+		{Seq: 3, Timestamp: base.Add(2 * time.Second), Kind: lifecycle.KindStateTransition, SessionID: "s",
+			PrevState: session.StateReady, NewState: session.StateWorking, Reason: "transcript activity"},
+	}
+	// Standard (report) path must never set ghost fields.
+	for _, tl := range buildSessionTimelines(events) {
+		if tl.IsGhost || tl.RemovalReason != "" || tl.RemovedAt != nil || tl.LifetimeMs != 0 || tl.FinalReason != "" || tl.HadSubstantive {
+			t.Errorf("report-path timeline carries ghost fields: %+v", tl)
+		}
+	}
+}

--- a/tools/onboarding-factory/cmd/replay/main.go
+++ b/tools/onboarding-factory/cmd/replay/main.go
@@ -27,6 +27,8 @@
 //	--debounce DURATION     Simulated activity debounce window. Default 2s.
 //	--flicker-max DURATION  Episodes shorter than this are counted as flickers. Default 10s.
 //	--quiet                 Suppress per-event progress on stderr.
+//	--ghosts SIDECAR        Print a human-readable ghost lifecycle timeline from a
+//	                        lifecycle sidecar (.events.jsonl) and exit.
 //
 // The report is a JSON object containing every state transition (with reason,
 // virtual timestamp, event index, and a metric snapshot) plus a flicker
@@ -138,11 +140,19 @@ type cliOptions struct {
 	debounceFlag time.Duration
 	flickerMax   time.Duration
 	quiet        bool
+	ghostsPath   string
 	src          string
 }
 
 func main() {
 	opts := parseFlags()
+	if opts.ghostsPath != "" {
+		if err := runGhostDump(opts.ghostsPath); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
 	transcriptPath, sidecarPath, useSidecar := resolveInputPaths(opts.src)
 	if !useSidecar && opts.sessionFlag != "" {
 		fmt.Fprintln(os.Stderr, "--session requires a sidecar (.events.jsonl); no sidecar found")
@@ -172,7 +182,13 @@ func parseFlags() cliOptions {
 	flag.DurationVar(&opts.debounceFlag, "debounce", 2*time.Second, "simulated activity debounce window")
 	flag.DurationVar(&opts.flickerMax, "flicker-max", 10*time.Second, "episodes shorter than this are counted as flickers (automated agent loops cycle turns in ~25s, so 30s overcounts)")
 	flag.BoolVar(&opts.quiet, "quiet", false, "suppress per-event progress on stderr")
+	flag.StringVar(&opts.ghostsPath, "ghosts", "", "print a human-readable ghost lifecycle timeline from a lifecycle sidecar (.events.jsonl) and exit")
 	flag.Parse()
+	// --ghosts is a self-contained text mode driven by its own sidecar path; it
+	// takes no positional transcript argument.
+	if opts.ghostsPath != "" {
+		return opts
+	}
 	if flag.NArg() != 1 {
 		fmt.Fprintln(os.Stderr, "usage: replay [flags] INPUT.jsonl")
 		flag.PrintDefaults()

--- a/tools/onboarding-factory/cmd/replay/types.go
+++ b/tools/onboarding-factory/cmd/replay/types.go
@@ -74,6 +74,18 @@ type sessionTimeline struct {
 	PIDDiscoveryMs  int64            `json:"pid_discovery_lag_ms,omitempty"`
 	DebounceEvents  int              `json:"debounce_coalesced_events"`
 	StateDurations  map[string]int64 `json:"state_durations_ms"`
+
+	// Ghost-detection signals (issue #757) populated ONLY by buildGhostTimelines
+	// for the --ghosts text view — never by the JSON report path
+	// (finalizeSessionTracker), so committed replay goldens stay byte-identical.
+	// RemovedAt is a pointer because time.Time's zero value is not suppressed by
+	// omitempty; nil keeps it out of any serialized timeline.
+	IsGhost        bool       `json:"is_ghost,omitempty"`
+	HadSubstantive bool       `json:"had_substantive,omitempty"`
+	RemovalReason  string     `json:"removal_reason,omitempty"`
+	RemovedAt      *time.Time `json:"removed_at,omitempty"`
+	LifetimeMs     int64      `json:"lifetime_ms,omitempty"`
+	FinalReason    string     `json:"final_reason,omitempty"`
 }
 
 // extendedCheck compares the replayed state transitions against a committed


### PR DESCRIPTION
Phase 1 of #757 (agent-legible observability). Independent and highest-leverage — directly closes the antigravity PID=0 "ghost session" gap: today such a session appears briefly then is reaped with a single log line and a generic `"session deleted"` reason, leaving no replayable trace of *why*.

## What changed (all additive, opt-in `--record` only)

**1a. Capture classifier inputs on state transitions.** `lifecycle.Event` gains an optional `Inputs *ClassifierInputs` (pointer + `omitempty`, so it's absent on the ~95% of events that aren't transitions). It snapshots the transient `SessionMetrics` signals that drive `ClassifyState` (`NoSubstantiveActivity`, `PermissionPending`, `HasLiveBackgroundProcess`, …) so a trace explains *why* the classifier chose a state. No new `SessionMetrics` fields.

**1b. Make reaping edges carry *why*.** `HandleProcessExit` and `deleteWithChildren` now take a `reason` that lands on the recorded `KindProcessExited` / `KindTranscriptRemoved` events. Every reap path records a descriptive reason instead of the generic `"session deleted"`:
- ESRCH: `"pid exited (ESRCH)"`
- infra-bound ghost (#727): `"infra-bound ghost: pid N is <adapter> background infra, not the session"`
- **PID=0 stale-transcript reap (the headline):** `"ghost reaped: PID=0, ready, stale transcript >30s — pre-session never bound a process"`
- startup/seed zombie sweeps, idle TTL, and the superseded pre-session sweep each get a real reason too.

**1c. `replay --ghosts <sidecar.jsonl>`.** A human-first text timeline (ghosts first) — *"minted at T → no substantive activity → reaped at T+33s because `<reason>`"* — plus the classifier inputs from the final transition. Example:

```
GHOSTS
  proc-0  [antigravity]  GHOST
    minted    2026-06-27T12:00:00Z
    lifetime  33s
    final     ready — "agent turn complete"
    inputs    no_substantive_activity, last_event_type=assistant
    reaped    2026-06-27T12:00:33Z — "ghost reaped: PID=0, ready, stale transcript >30s — pre-session never bound a process"
    substantive activity: none
```

## Byte-identity note

The ghost signals on `sessionTimeline` are computed in a **separate `buildGhostTimelines` pass used only by `--ghosts`** — the JSON report path (`finalizeSessionTracker`) is untouched, and `RemovedAt` is a `*time.Time` so its zero value can't leak into serialized timelines. Result: **committed replay goldens are byte-identical with no regeneration** (the `TestFixtureReplayByteIdentity` suite passes unchanged). This is a deliberate refinement of the issue's "fold into finalize" wording: the issue's own constraint is byte-identity, and there are 144 `presession_removed` / 527 `transcript_removed` events across 294 committed sidecars that folding into the report path would have churned.

## Verification
- `go test ./core/... -race -count=1` ✅
- `go test ./tools/onboarding-factory/... -race -count=1` ✅
- `tools/replay-fixtures.sh` ✅ · `of validate` ✅
- New ghost-detection unit tests (`ghosts_test.go`) ✅
- Replay byte-identity goldens: pass, **no regen** ✅

## Follow-ups (separate PRs, per the issue's phasing)
- Phase 2 — macOS snapshot harness for the unobservable states.
- Phase 3 — web dashboard HTML snapshot artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)