### PR TITLE
feat(web): agent-legible HTML snapshot artifacts for the session list (#757 Phase 3)

### DIFF
--- a/platforms/web/.gitignore
+++ b/platforms/web/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+snapshots/out/

--- a/platforms/web/package.json
+++ b/platforms/web/package.json
@@ -2,7 +2,9 @@
   "name": "irrlicht-web",
   "type": "module",
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "snapshot": "vitest run snapshots/render-html.test.js",
+    "snapshot:png": "node snapshots/snapshot.png.mjs"
   },
   "devDependencies": {
     "vitest": "^4.1.7",

--- a/platforms/web/snapshots/fixtures.js
+++ b/platforms/web/snapshots/fixtures.js
@@ -1,0 +1,204 @@
+// Scenes for the web dashboard HTML snapshot artifacts (issue #757). Each scene
+// is an initial /api/v1/sessions payload (the wrapped {groups:[...]} shape) plus
+// optional websocket deltas (session_update / session_deleted messages, the same
+// envelopes irrlicht.js consumes). render-html.test.js drives each scene through
+// the real app in jsdom and serializes #session-list to a self-contained HTML.
+//
+// The render test pins the wall clock to FIXED_NOW_SEC, so first_seen offsets
+// below produce deterministic elapsed labels (active sessions render
+// Date.now()-first_seen).
+
+export const FIXED_NOW_SEC = 1764800120
+const t = (agoSec) => FIXED_NOW_SEC - agoSec
+
+const group = (name, agents, costs = {}) => ({ name, agents, costs })
+const sessions = (...groups) => ({ groups, provider_costs: {} })
+
+export const scenes = [
+  {
+    name: '01-mixed-states',
+    theme: 'dark',
+    expectedRows: 3,
+    sessions: sessions(
+      group('irrlicht', [
+        {
+          session_id: 'proc-1', state: 'working', project_name: 'irrlicht',
+          git_branch: 'main', adapter: 'claude-code', first_seen: t(125),
+          metrics: {
+            model_name: 'claude-opus-4-8', estimated_cost_usd: 0.42,
+            context_utilization_percentage: 45, pressure_level: 'low',
+            total_tokens: 48000, elapsed_seconds: 125,
+          },
+        },
+        {
+          session_id: 'proc-2', state: 'waiting', project_name: 'irrlicht',
+          git_branch: 'feat/x', adapter: 'claude-code', first_seen: t(60),
+          metrics: {
+            model_name: 'claude-sonnet-4-6', context_utilization_percentage: 20,
+            pressure_level: 'low', total_tokens: 12000,
+          },
+        },
+        {
+          session_id: 'proc-3', state: 'ready', project_name: 'irrlicht',
+          git_branch: 'main', adapter: 'claude-code', first_seen: t(900),
+          metrics: {
+            model_name: 'claude-opus-4-8', estimated_cost_usd: 1.10,
+            elapsed_seconds: 900,
+          },
+        },
+      ], { day: 1.52 }),
+    ),
+    deltas: [],
+  },
+
+  {
+    name: '02-antigravity-ghost',
+    theme: 'dark',
+    // One real session, then a transient antigravity PID=0 ghost arrives over
+    // the wire beside it — the row Phase 1's daemon trace explains.
+    expectedRows: 2,
+    sessions: sessions(
+      group('app', [
+        {
+          session_id: 'sess-real', state: 'working', project_name: 'app',
+          git_branch: 'main', adapter: 'claude-code', first_seen: t(200),
+          metrics: {
+            model_name: 'claude-opus-4-8', estimated_cost_usd: 0.18,
+            context_utilization_percentage: 30, pressure_level: 'low',
+            total_tokens: 21000, elapsed_seconds: 200,
+          },
+        },
+      ]),
+    ),
+    deltas: [
+      {
+        type: 'session_update',
+        session: {
+          session_id: 'proc-0', state: 'ready', project_name: 'app',
+          git_branch: 'main', adapter: 'antigravity', first_seen: t(33),
+          metrics: { model_name: 'gemini-3-pro', elapsed_seconds: 33 },
+        },
+      },
+    ],
+  },
+
+  {
+    name: '03-context-pressure',
+    theme: 'dark',
+    expectedRows: 2,
+    sessions: sessions(
+      group('irrlicht', [
+        {
+          session_id: 'proc-hot', state: 'working', project_name: 'irrlicht',
+          git_branch: 'main', adapter: 'claude-code', first_seen: t(1800),
+          metrics: {
+            model_name: 'claude-opus-4-8', estimated_cost_usd: 4.20,
+            context_utilization_percentage: 92, pressure_level: 'critical',
+            total_tokens: 184000, elapsed_seconds: 1800,
+          },
+        },
+        {
+          session_id: 'proc-warm', state: 'working', project_name: 'irrlicht',
+          git_branch: 'feat/y', adapter: 'claude-code', first_seen: t(300),
+          metrics: {
+            model_name: 'claude-sonnet-4-6', estimated_cost_usd: 0.65,
+            context_utilization_percentage: 70, pressure_level: 'warning',
+            total_tokens: 140000, elapsed_seconds: 300,
+          },
+        },
+      ], { day: 4.85 }),
+    ),
+    deltas: [],
+  },
+
+  {
+    name: '04-background-agents',
+    theme: 'dark',
+    // Mirrors irrlicht.bgbadge.test.js: a detached bg agent, an attached one,
+    // and an ordinary session (no badge).
+    expectedRows: 3,
+    sessions: sessions(
+      group('irrlicht', [
+        {
+          session_id: 'bg-detached', state: 'ready', project_name: 'irrlicht',
+          adapter: 'claude-code', first_seen: t(600),
+          metrics: { model_name: 'claude-opus-4-8', elapsed_seconds: 600 },
+          background: { name: 'Add guiding colors to quest cards', detached: true },
+        },
+        {
+          session_id: 'bg-attached', state: 'working', project_name: 'irrlicht',
+          adapter: 'claude-code', first_seen: t(90),
+          metrics: { model_name: 'claude-opus-4-8', total_tokens: 8000, elapsed_seconds: 90 },
+          background: { name: 'Tidy imports' },
+        },
+        {
+          session_id: 'normal', state: 'ready', project_name: 'irrlicht',
+          adapter: 'claude-code', first_seen: t(1200),
+          metrics: { model_name: 'claude-sonnet-4-6', elapsed_seconds: 1200 },
+        },
+      ]),
+    ),
+    deltas: [],
+  },
+
+  {
+    name: '05-multi-group',
+    theme: 'dark',
+    // Two projects → group headers render.
+    expectedRows: 3,
+    sessions: sessions(
+      group('irrlicht', [
+        {
+          session_id: 'irr-1', state: 'working', project_name: 'irrlicht',
+          git_branch: 'main', adapter: 'claude-code', first_seen: t(140),
+          metrics: {
+            model_name: 'claude-opus-4-8', estimated_cost_usd: 0.31,
+            context_utilization_percentage: 38, pressure_level: 'low',
+            total_tokens: 30000, elapsed_seconds: 140,
+          },
+        },
+        {
+          session_id: 'irr-2', state: 'ready', project_name: 'irrlicht',
+          git_branch: 'main', adapter: 'claude-code', first_seen: t(700),
+          metrics: { model_name: 'claude-opus-4-8', elapsed_seconds: 700 },
+        },
+      ], { day: 0.9 }),
+      group('webapp', [
+        {
+          session_id: 'web-1', state: 'waiting', project_name: 'webapp',
+          git_branch: 'feat/login', adapter: 'codex', first_seen: t(45),
+          metrics: {
+            model_name: 'gpt-5-codex', context_utilization_percentage: 15,
+            pressure_level: 'low', total_tokens: 9000,
+          },
+        },
+      ], { day: 0.2 }),
+    ),
+    deltas: [],
+  },
+
+  {
+    name: '06-light-theme',
+    theme: 'light',
+    expectedRows: 2,
+    sessions: sessions(
+      group('irrlicht', [
+        {
+          session_id: 'lt-1', state: 'working', project_name: 'irrlicht',
+          git_branch: 'main', adapter: 'claude-code', first_seen: t(125),
+          metrics: {
+            model_name: 'claude-opus-4-8', estimated_cost_usd: 0.42,
+            context_utilization_percentage: 45, pressure_level: 'low',
+            total_tokens: 48000, elapsed_seconds: 125,
+          },
+        },
+        {
+          session_id: 'lt-2', state: 'ready', project_name: 'irrlicht',
+          git_branch: 'main', adapter: 'claude-code', first_seen: t(900),
+          metrics: { model_name: 'claude-opus-4-8', estimated_cost_usd: 1.10, elapsed_seconds: 900 },
+        },
+      ], { day: 1.52 }),
+    ),
+    deltas: [],
+  },
+]

--- a/platforms/web/snapshots/render-html.test.js
+++ b/platforms/web/snapshots/render-html.test.js
@@ -1,0 +1,110 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { scenes, FIXED_NOW_SEC } from './fixtures.js'
+import { serializeSessionList } from './serialize.js'
+
+// Tier 1 of the web visual artifact (issue #757): drive each scene through the
+// REAL irrlicht.js in jsdom, assert the rows render (so a broken render fails
+// `npm test` — this is the CI gate), and emit a self-contained HTML per scene
+// under snapshots/out/ for an agent to read via the Artifact tool / WebFetch.
+//
+// jsdom can't paint pixels, so this is structural HTML + inlined CSS, not a PNG;
+// the true-PNG path is the opt-in snapshot.png.mjs (Tier 2).
+
+const here = dirname(fileURLToPath(import.meta.url))
+const outDir = join(here, 'out')
+
+// The DOM scaffold irrlicht.js queries at module load (mirrors vitest.setup.js).
+// Re-applied per scene so each fresh import renders into a clean #session-list.
+const SETUP_BODY = `
+  <header></header>
+  <button id="theme-toggle"></button>
+  <button id="view-mode-cycle">Context</button>
+  <button id="summary-collapse-all"></button>
+  <button id="settings-toggle"></button>
+  <button id="settings-close"></button>
+  <div id="settings-backdrop"></div>
+  <div id="settings-providers"></div>
+  <div id="session-list"></div>
+  <div id="app-version"></div>
+  <div id="empty-state"></div>
+  <div id="ws-dot" class="ws-dot"></div>
+  <span id="ws-label"></span>
+  <div id="quota-chips"></div>
+  <div id="app-state-icons"></div>
+  <div id="gt-container" style="display:none"></div>
+  <div id="connection-banner"></div>
+  <div id="settings-perm-note"></div>
+  <button id="settings-review-permissions"></button>
+  <div id="permissions-backdrop">
+    <h2 id="permissions-title"></h2>
+    <p id="permissions-intro"></p>
+    <div id="permissions-body"></div>
+    <button id="permissions-apply"></button>
+  </div>
+`
+
+function makeFetch(sessionsPayload) {
+  return (url) => {
+    const u = String(url)
+    if (u.includes('/api/v1/sessions')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(sessionsPayload) })
+    }
+    if (u.includes('/api/v1/agents')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve(null) })
+  }
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0))
+
+beforeEach(() => {
+  vi.resetModules()
+  document.body.innerHTML = SETUP_BODY
+  localStorage.clear()
+  // Freeze ONLY Date: active-session elapsed and the ETA chip read Date.now(),
+  // so a fixed clock makes the artifact deterministic. setTimeout stays real so
+  // the post-import flush tick still fires (faking all timers would deadlock on
+  // irrlicht.js's reconnect/elapsed setInterval loops).
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(FIXED_NOW_SEC * 1000)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+mkdirSync(outDir, { recursive: true })
+
+describe('web session-list HTML snapshot artifacts (#757)', () => {
+  for (const scene of scenes) {
+    test(scene.name, async () => {
+      localStorage.setItem('irrlicht_theme', scene.theme)
+      global.fetch = makeFetch(scene.sessions)
+
+      await import('../irrlicht.js')
+      await tick() // let the initial Promise.all(fetch…).then(render) settle
+
+      const ws = global.lastMockWebSocket
+      if (ws) {
+        ws.simulateOpen()
+        for (const delta of scene.deltas) ws.simulateMessage(delta)
+      }
+      await tick()
+
+      // CI gate: a broken render (no rows) fails `npm test`.
+      const rows = document.querySelectorAll('#session-list .session-row')
+      expect(rows.length).toBe(scene.expectedRows)
+
+      const html = serializeSessionList(document, {
+        theme: scene.theme,
+        title: `irrlicht — ${scene.name}`,
+      })
+      expect(html).toContain('session-row')
+      writeFileSync(join(outDir, `${scene.name}.html`), html)
+    })
+  }
+})

--- a/platforms/web/snapshots/render-html.test.js
+++ b/platforms/web/snapshots/render-html.test.js
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { scenes, FIXED_NOW_SEC } from './fixtures.js'
 import { serializeSessionList } from './serialize.js'
+import { SETUP_BODY } from '../vitest.setup.js'
 
 // Tier 1 of the web visual artifact (issue #757): drive each scene through the
 // REAL irrlicht.js in jsdom, assert the rows render (so a broken render fails
@@ -16,35 +17,9 @@ import { serializeSessionList } from './serialize.js'
 const here = dirname(fileURLToPath(import.meta.url))
 const outDir = join(here, 'out')
 
-// The DOM scaffold irrlicht.js queries at module load (mirrors vitest.setup.js).
-// Re-applied per scene so each fresh import renders into a clean #session-list.
-const SETUP_BODY = `
-  <header></header>
-  <button id="theme-toggle"></button>
-  <button id="view-mode-cycle">Context</button>
-  <button id="summary-collapse-all"></button>
-  <button id="settings-toggle"></button>
-  <button id="settings-close"></button>
-  <div id="settings-backdrop"></div>
-  <div id="settings-providers"></div>
-  <div id="session-list"></div>
-  <div id="app-version"></div>
-  <div id="empty-state"></div>
-  <div id="ws-dot" class="ws-dot"></div>
-  <span id="ws-label"></span>
-  <div id="quota-chips"></div>
-  <div id="app-state-icons"></div>
-  <div id="gt-container" style="display:none"></div>
-  <div id="connection-banner"></div>
-  <div id="settings-perm-note"></div>
-  <button id="settings-review-permissions"></button>
-  <div id="permissions-backdrop">
-    <h2 id="permissions-title"></h2>
-    <p id="permissions-intro"></p>
-    <div id="permissions-body"></div>
-    <button id="permissions-apply"></button>
-  </div>
-`
+// SETUP_BODY (the DOM scaffold irrlicht.js queries at module load) is imported
+// from vitest.setup.js — the single source of truth — and re-applied per scene
+// so each fresh import renders into a clean #session-list.
 
 function makeFetch(sessionsPayload) {
   return (url) => {

--- a/platforms/web/snapshots/serialize.js
+++ b/platforms/web/snapshots/serialize.js
@@ -1,0 +1,59 @@
+// Serializes the live-rendered #session-list subtree into a single
+// self-contained HTML document with irrlicht.css inlined (issue #757). The
+// output has no external references — no CDN, no fonts, no scripts — so it is
+// safe to view via the Artifact tool's strict CSP or over WebFetch.
+
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const cssPath = join(here, '..', 'irrlicht.css')
+
+/** The dashboard's stylesheet, read from disk so the artifact tracks the real CSS. */
+export function readCss() {
+  return readFileSync(cssPath, 'utf8')
+}
+
+/**
+ * Build a self-contained HTML page from the current #session-list DOM.
+ * @param {Document} document - the jsdom document after a render
+ * @param {{theme?: string, title?: string}} opts
+ */
+export function serializeSessionList(document, { theme = 'dark', title = 'irrlicht session list' } = {}) {
+  const list = document.getElementById('session-list')
+  const body = list ? list.outerHTML : '<p>(no #session-list rendered)</p>'
+  const themeAttr = theme ? ` data-theme="${theme}"` : ''
+  const css = readCss()
+  return `<!doctype html>
+<html lang="en"${themeAttr}>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<style>
+${css}
+/* Snapshot determinism: this is a captured still frame. Complete every
+   animation INSTANTLY (duration 0s) rather than disabling it — disabling would
+   strand intro animations at their first frame, and .session-row starts at
+   opacity:0 and reveals via @keyframes row-reveal, so it would vanish. Kill
+   transitions outright. */
+*, *::before, *::after {
+  animation-duration: 0s !important;
+  animation-delay: 0s !important;
+  transition: none !important;
+}
+/* Belt-and-suspenders: pin the row to its revealed state regardless of how the
+   reveal keyframe is honored. */
+.session-row { opacity: 1 !important; }
+html, body { margin: 0; }
+body { padding: 16px; }
+#session-list { max-width: 760px; }
+</style>
+</head>
+<body>
+${body}
+</body>
+</html>
+`
+}

--- a/platforms/web/snapshots/snapshot.png.mjs
+++ b/platforms/web/snapshots/snapshot.png.mjs
@@ -1,0 +1,55 @@
+// Tier 2 (opt-in): render each Tier-1 HTML artifact in headless Chromium and
+// screenshot it to a true PNG (issue #757). jsdom can't paint pixels, so this is
+// the only path to a real image — but it needs a browser, which `npm test`/CI
+// must never pull. So playwright is deliberately NOT a package.json dependency
+// (its postinstall would download browser binaries on every CI install); it is
+// imported dynamically here and only when you opt in:
+//
+//   npm run snapshot                       # regenerate out/*.html (Tier 1)
+//   npm i -D playwright                     # one-time, local only
+//   npx playwright install chromium         # one-time, fetch the browser
+//   npm run snapshot:png                    # this script
+//
+// Reads snapshots/out/*.html, writes snapshots/out/png/*.png.
+
+import { readdirSync, mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const htmlDir = join(here, 'out')
+const pngDir = join(htmlDir, 'png')
+
+let chromium
+try {
+  ({ chromium } = await import('playwright'))
+} catch {
+  console.error(
+    'playwright is not installed (it is intentionally not a dependency).\n' +
+    'Install it locally, then retry:\n' +
+    '  npm i -D playwright && npx playwright install chromium && npm run snapshot:png',
+  )
+  process.exit(1)
+}
+
+let files
+try {
+  files = readdirSync(htmlDir).filter((f) => f.endsWith('.html'))
+} catch {
+  files = []
+}
+if (files.length === 0) {
+  console.error('No HTML artifacts in snapshots/out/. Run `npm run snapshot` first.')
+  process.exit(1)
+}
+
+mkdirSync(pngDir, { recursive: true })
+const browser = await chromium.launch()
+const page = await browser.newPage({ viewport: { width: 800, height: 600 }, deviceScaleFactor: 2 })
+for (const f of files.sort()) {
+  await page.goto(pathToFileURL(join(htmlDir, f)).href)
+  const out = join(pngDir, f.replace(/\.html$/, '.png'))
+  await page.screenshot({ path: out, fullPage: true })
+  console.log('wrote', out)
+}
+await browser.close()

--- a/platforms/web/vitest.setup.js
+++ b/platforms/web/vitest.setup.js
@@ -1,5 +1,7 @@
-// Minimum DOM required for irrlicht.js top-level wiring
-document.body.innerHTML = `
+// Minimum DOM required for irrlicht.js top-level wiring. Exported so the
+// snapshots/ render test re-applies the same scaffold per scene instead of
+// keeping a divergent copy that silently goes stale (issue #757).
+export const SETUP_BODY = `
   <header></header>
   <button id="theme-toggle"></button>
   <button id="view-mode-cycle">Context</button>
@@ -26,6 +28,7 @@ document.body.innerHTML = `
     <button id="permissions-apply"></button>
   </div>
 `;
+document.body.innerHTML = SETUP_BODY;
 
 // jsdom has no canvas — give paintRowHistory the minimal 2D context it uses
 // so tests that render session rows don't trip an unhandled rejection.


### PR DESCRIPTION
Phase 3 of #757 (agent-legible observability). Mirrors the macOS snapshot harness for the **web dashboard**, which today produces no visual artifact at all: an agent can now drive a dashboard state and *see* what it renders.

Two-tier hybrid, all under `platforms/web/snapshots/`:

## Tier 1 — self-contained HTML (default, ships in `npm test`)
`render-html.test.js` drives **6 scenes** through the real `irrlicht.js` in jsdom (reusing the existing fetch-override + `MockWebSocket` pattern), asserts the expected `.session-row` count (so a broken render fails CI), and serializes `#session-list` into one self-contained `.html` per scene with `irrlicht.css` inlined (`serialize.js`). No external references → safe to view via the **Artifact** tool's strict CSP or **WebFetch**.

Scenes (`fixtures.js`): mixed working/waiting/ready states · an **antigravity PID=0 ghost** arriving over the wire beside a real row (the row Phase 1's trace explains) · context-pressure (critical/warning bars + alert) · background agents (detached/attached badges) · multi-group (headers + per-group costs) · a light-theme variant.

## Tier 2 — true PNG (opt-in)
`snapshot.png.mjs` screenshots each Tier-1 HTML in headless Chromium. **playwright is deliberately *not* a package.json dependency** — its postinstall downloads browser binaries on every CI `npm install`, which is exactly what the issue says to avoid. It's imported dynamically with install instructions; CI never pulls a browser. Run locally:
```
npm run snapshot                              # regenerate out/*.html
npm i -D playwright && npx playwright install chromium
npm run snapshot:png                          # out/png/*.png
```

## Determinism
`render-html.test.js` fakes **only `Date`** (`vi.useFakeTimers({toFake:['Date']})` + `setSystemTime`) so active-session elapsed and the ETA chip are clock-independent, while `setTimeout` stays real for the post-import flush tick (faking all timers would deadlock on irrlicht.js's reconnect/elapsed `setInterval`s). The serialized CSS **completes animations instantly** (`animation-duration:0s`) rather than disabling them.

### A real bug the visual pass caught
Disabling animations (`animation:none`) stranded `.session-row` at its `opacity:0` reveal frame — every row invisible. The DOM-assertion tests pass regardless (the elements exist), so this only surfaced when I rendered the Tier-2 PNGs and looked. Fixed by completing the reveal instead of disabling it; this is the whole argument for the artifact.

## Decisions
- **No pixel-diff baseline for web** — system-font stacks differ macOS vs Linux → flaky. The existing DOM-assertion tests remain the correctness gate; the artifact is *read*, not gated.
- `snapshots/out/` is gitignored. `package-lock.json` untouched.

## Verification
- `npm test` → **104 tests / 7 files pass** (includes the 6 new scenes).
- `npm run snapshot` emits 6 HTML; rendered all 6 to PNG and inspected each — rows, ctx bars, costs, pressure alerts, bg badges, group headers, the ghost row, and the light theme all render correctly.

Independent of #760 (Phase 1) and #762 (Phase 2); same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)