### PR TITLE
feat(headlines): concise intent + waiting headlines (markers + pluggable compaction) (#759)

### DIFF
--- a/core/adapters/inbound/agents/agentwiring/collector.go
+++ b/core/adapters/inbound/agents/agentwiring/collector.go
@@ -14,6 +14,7 @@ import (
 	"irrlicht/core/adapters/inbound/agents/aider"
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/adapters/inbound/agents/opencode"
+	"irrlicht/core/adapters/outbound/compaction"
 	"irrlicht/core/adapters/outbound/metrics"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/pkg/tailer"
@@ -48,5 +49,8 @@ func BuildMetricsCollector(adapters []agent.Agent) outbound.MetricsCollector {
 		SubagentCounters: agents.SubagentCounters(adapters),
 		MetricsProviders: agents.MetricsProviders(adapters),
 		FallbackName:     claudecode.AdapterName,
+		// Default headline compaction (issue #759). A future setting or LLM
+		// adapter swaps this one line.
+		Compactor: compaction.DeterministicCompactor{},
 	})
 }

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -87,9 +87,9 @@ type MarkerTarget interface {
 // body would not unmarshal. Tool inputs are small, shallow objects — the walk
 // recurses into nested objects/arrays for completeness. Latest valid of each
 // wins, matching the transcript scan.
-func scanToolInput(raw json.RawMessage, observedAt time.Time) (*tailer.TaskEstimate, *tailer.TaskSummary) {
+func scanToolInput(raw json.RawMessage, observedAt time.Time) (*tailer.TaskEstimate, *tailer.TaskSummary, *tailer.TaskQuestion) {
 	if len(raw) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	// Fast reject before decoding. The comment opener survives JSON string
 	// escaping (a backslash-quote doesn't touch "<!--"), but HTML-escaping
@@ -98,24 +98,25 @@ func scanToolInput(raw json.RawMessage, observedAt time.Time) (*tailer.TaskEstim
 	// raw-string needle below is the escaped opener byte-for-byte.
 	htmlEscapedOpener := `\u003c!--`
 	if s := string(raw); !strings.Contains(s, "<!--") && !strings.Contains(s, htmlEscapedOpener) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	var decoded interface{}
 	if err := json.Unmarshal(raw, &decoded); err != nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	return scanValueForMarkers(decoded, observedAt)
 }
 
 // scanValueForMarkers walks a decoded JSON value, scanning every string for
-// task-estimate and task-summary markers; latest valid of each wins. Shared by
-// the PostToolUse hook (scanToolInput) and the transcript parser so a marker
-// emitted inside a tool input — e.g. the Bash `description` carrier (#617) — is
-// found by both the live hook and the transcript/replay path. The per-string
-// fast-reject lives inside the Scan* functions.
-func scanValueForMarkers(v interface{}, observedAt time.Time) (*tailer.TaskEstimate, *tailer.TaskSummary) {
+// task-estimate, task-summary and task-question markers; latest valid of each
+// wins. Shared by the PostToolUse hook (scanToolInput) and the transcript
+// parser so a marker emitted inside a tool input — e.g. the Bash `description`
+// carrier (#617) — is found by both the live hook and the transcript/replay
+// path. The per-string fast-reject lives inside the Scan* functions.
+func scanValueForMarkers(v interface{}, observedAt time.Time) (*tailer.TaskEstimate, *tailer.TaskSummary, *tailer.TaskQuestion) {
 	var est *tailer.TaskEstimate
 	var sum *tailer.TaskSummary
+	var q *tailer.TaskQuestion
 	var walk func(v interface{})
 	walk = func(v interface{}) {
 		switch val := v.(type) {
@@ -125,6 +126,9 @@ func scanValueForMarkers(v interface{}, observedAt time.Time) (*tailer.TaskEstim
 			}
 			if found := tailer.ScanTaskSummary(val, observedAt); found != nil {
 				sum = found
+			}
+			if found := tailer.ScanTaskQuestion(val, observedAt); found != nil {
+				q = found
 			}
 		case map[string]interface{}:
 			for _, child := range val {
@@ -137,7 +141,7 @@ func scanValueForMarkers(v interface{}, observedAt time.Time) (*tailer.TaskEstim
 		}
 	}
 	walk(v)
-	return est, sum
+	return est, sum, q
 }
 
 // ConsentGate reports whether the user has granted a permission (issue
@@ -232,7 +236,11 @@ func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGate, l
 			// Bash description), and the payload reaches the daemon even
 			// when the transcript drops the surrounding prose.
 			if markers != nil {
-				est, sum := scanToolInput(payload.ToolInput, time.Now())
+				// The question marker rides end-of-turn assistant prose, not a
+				// tool-input carrier, so the hook path (tool inputs only) drops it
+				// (#759): the transcript text-block scan delivers it, and the
+				// deterministic compactor covers the no-marker case regardless.
+				est, sum, _ := scanToolInput(payload.ToolInput, time.Now())
 				if est != nil {
 					log.LogInfo("hook-receiver", sessionID,
 						fmt.Sprintf("task-estimate marker via %s tool input: %d/%d", payload.ToolName, est.CompletedRounds, est.TotalRounds))

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -1,9 +1,9 @@
 // instructioninstaller.go manages the Irrlicht-managed emission rules in the
 // user-level Claude Code instruction file ~/.claude/CLAUDE.md: the task-eta
-// progress marker (issue #558) and the task-summary marker (issue #738), each
-// in its own BEGIN/END-delimited block. The blocks instruct the agent to emit
-// in-band markers; with them in the user-level file every project inherits the
-// rules without per-repo opt-in.
+// progress marker (issue #558), the task-summary marker (issue #738) and the
+// task-question marker (issue #759), each in its own BEGIN/END-delimited block.
+// The blocks instruct the agent to emit in-band markers; with them in the
+// user-level file every project inherits the rules without per-repo opt-in.
 //
 // Like the hook/statusline installers, consent lives in the permission
 // wizard (issue #577): install/uninstall run as the claude-code/instructions
@@ -113,8 +113,42 @@ summary of the overall task as a hidden marker, early in the task:
 
 Emit it once near the start by appending it to the ` + "`description`" + ` of an
 early Bash call (never to the command itself). Re-emit only if the task
-fundamentally changes. Keep it under ~120 characters, plain prose, no secrets.
+fundamentally changes. Keep it a short one-liner — under ~70 characters, plain
+prose, no secrets.
 ` + taskSummaryEndSentinel
+
+// Sentinels delimiting the task-question managed block (issue #759). Distinct
+// from the eta/summary pairs so all three blocks coexist and are patched or
+// removed independently.
+const (
+	taskQuestionBeginSentinel = "<!-- BEGIN IRRLICHT MANAGED BLOCK (task-question) -->"
+	taskQuestionEndSentinel   = "<!-- END IRRLICHT MANAGED BLOCK (task-question) -->"
+)
+
+// managedTaskQuestionBlock instructs the agent to emit a terse one-line version
+// of the question it is blocked on when it ends a turn waiting on the user
+// (issue #759) — the preferred source for the surfaced waiting-state headline.
+// Unlike the eta/summary markers, a pending question has no following Bash call
+// to carry it, so the marker rides the end-of-turn response text — the one shape
+// that survives the claude ≥2.1.162 transcript text-drop (end-of-turn text is
+// not dropped; only mid-task pre-tool-call prose is). The example marker MUST
+// sit inside a fenced code block for the same reason as the other blocks —
+// Claude Code strips bare HTML comments from CLAUDE.md at injection time. The
+// daemon always falls back to compacting the raw last-assistant text, so the
+// marker is a refinement, not a requirement.
+const managedTaskQuestionBlock = taskQuestionBeginSentinel + `
+## Pending-question marker (managed by Irrlicht)
+
+When you end your turn by asking the user a question, also emit a hidden
+one-line version of that question so tools can show a terse headline:
+
+` + "```" + `
+<!-- {"marker":"irrlicht-question","question":"<the question, ~70 chars>"} -->
+` + "```" + `
+
+Emit it on its own line at the very end of your response, only when you are
+actually waiting on the user. Keep it under ~70 characters, plain prose.
+` + taskQuestionEndSentinel
 
 // claudeMemoryPath returns the user-level Claude Code instruction file path.
 func claudeMemoryPath() (string, error) {
@@ -188,6 +222,18 @@ func UninstallTaskSummaryBlock() (bool, error) {
 	return uninstallBlock(taskSummaryBeginSentinel, taskSummaryEndSentinel)
 }
 
+// EnsureTaskQuestionBlockInstalled writes-or-patches the task-question managed
+// block (issue #759) — installed alongside the eta/summary blocks under the
+// same instructions permission.
+func EnsureTaskQuestionBlockInstalled() (bool, error) {
+	return ensureBlockInstalled(taskQuestionBeginSentinel, taskQuestionEndSentinel, managedTaskQuestionBlock)
+}
+
+// UninstallTaskQuestionBlock removes only the task-question managed block.
+func UninstallTaskQuestionBlock() (bool, error) {
+	return uninstallBlock(taskQuestionBeginSentinel, taskQuestionEndSentinel)
+}
+
 // applyInstructionBlocks installs both managed blocks — the grant effect of
 // the instructions permission. Both are installed together so a single toggle
 // governs all irrlicht-managed instruction text. Returns on the first error.
@@ -195,17 +241,23 @@ func applyInstructionBlocks() error {
 	if _, err := EnsureTaskEtaBlockInstalled(); err != nil {
 		return err
 	}
-	_, err := EnsureTaskSummaryBlockInstalled()
+	if _, err := EnsureTaskSummaryBlockInstalled(); err != nil {
+		return err
+	}
+	_, err := EnsureTaskQuestionBlockInstalled()
 	return err
 }
 
-// removeInstructionBlocks removes both managed blocks — the revoke effect of
+// removeInstructionBlocks removes all managed blocks — the revoke effect of
 // the instructions permission.
 func removeInstructionBlocks() error {
 	if _, err := UninstallTaskEtaBlock(); err != nil {
 		return err
 	}
-	_, err := UninstallTaskSummaryBlock()
+	if _, err := UninstallTaskSummaryBlock(); err != nil {
+		return err
+	}
+	_, err := UninstallTaskQuestionBlock()
 	return err
 }
 

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -408,7 +408,24 @@ func TestEnsureTaskSummaryBlock_CreatesFileIfAbsent(t *testing.T) {
 	}
 }
 
-func TestApplyInstructionBlocks_InstallsBothAndCoexist(t *testing.T) {
+func TestEnsureTaskQuestionBlock_CreatesFileIfAbsent(t *testing.T) {
+	home := withTempHome(t)
+	modified, err := EnsureTaskQuestionBlockInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true on first install")
+	}
+	content := readFileString(t, memoryPathFor(home))
+	for _, want := range []string{taskQuestionBeginSentinel, taskQuestionEndSentinel, `"marker":"irrlicht-question"`} {
+		if !strings.Contains(content, want) {
+			t.Errorf("installed file missing %q", want)
+		}
+	}
+}
+
+func TestApplyInstructionBlocks_InstallsAllAndCoexist(t *testing.T) {
 	home := withTempHome(t)
 	if err := applyInstructionBlocks(); err != nil {
 		t.Fatal(err)
@@ -417,6 +434,7 @@ func TestApplyInstructionBlocks_InstallsBothAndCoexist(t *testing.T) {
 	for _, want := range []string{
 		taskEtaBeginSentinel, taskEtaEndSentinel, `"marker":"irrlicht-eta"`,
 		taskSummaryBeginSentinel, taskSummaryEndSentinel, `"marker":"irrlicht-summary"`,
+		taskQuestionBeginSentinel, taskQuestionEndSentinel, `"marker":"irrlicht-question"`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("file missing %q after applyInstructionBlocks", want)

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -417,8 +417,13 @@ func scanMessageContent(raw map[string]interface{}, ev *tailer.ParsedEvent) stri
 			// must not feed it). ETA stays prose/hook-only, so apply only the
 			// summary.
 			if isAssistantEventType(ev.EventType) {
-				if _, s := scanValueForMarkers(block["input"], ev.Timestamp); s != nil {
-					ev.TaskSummary = s
+				if _, s, q := scanValueForMarkers(block["input"], ev.Timestamp); s != nil || q != nil {
+					if s != nil {
+						ev.TaskSummary = s
+					}
+					if q != nil {
+						ev.TaskQuestion = q
+					}
 				}
 			}
 		case "tool_result":
@@ -437,6 +442,12 @@ func scanMessageContent(raw map[string]interface{}, ev *tailer.ParsedEvent) stri
 				}
 				if s := tailer.ScanTaskSummary(text, ev.Timestamp); s != nil {
 					ev.TaskSummary = s
+				}
+				// The question marker rides end-of-turn prose (the agent's final
+				// line when it asks the user something), which survives the
+				// text-drop, so the text-block scan is its primary path (#759).
+				if q := tailer.ScanTaskQuestion(text, ev.Timestamp); q != nil {
+					ev.TaskQuestion = q
 				}
 			}
 		}

--- a/core/adapters/outbound/compaction/compaction_test.go
+++ b/core/adapters/outbound/compaction/compaction_test.go
@@ -1,0 +1,95 @@
+package compaction
+
+import (
+	"strings"
+	"testing"
+
+	"irrlicht/core/ports/outbound"
+)
+
+func TestNoopCompactor_Identity(t *testing.T) {
+	in := "## Heading\n\nsome **bold** text with a `code` span and a question?"
+	for _, kind := range []outbound.CompactKind{outbound.CompactIntent, outbound.CompactQuestion} {
+		if got := (NoopCompactor{}).Compact(in, kind); got != in {
+			t.Errorf("kind %d: Compact = %q, want identity", kind, got)
+		}
+	}
+}
+
+func TestDeterministic_Empty(t *testing.T) {
+	for _, kind := range []outbound.CompactKind{outbound.CompactIntent, outbound.CompactQuestion} {
+		if got := (DeterministicCompactor{}).Compact("", kind); got != "" {
+			t.Errorf("kind %d: Compact(\"\") = %q, want empty", kind, got)
+		}
+		if got := (DeterministicCompactor{}).Compact("   \n\t  ", kind); got != "" {
+			t.Errorf("kind %d: Compact(whitespace) = %q, want empty", kind, got)
+		}
+	}
+}
+
+func TestDeterministic_Intent_FirstSentence(t *testing.T) {
+	in := "Add a logout button to the navbar. Then wire it to the auth service. And test it."
+	got := (DeterministicCompactor{}).Compact(in, outbound.CompactIntent)
+	if got != "Add a logout button to the navbar." {
+		t.Errorf("Compact = %q, want first sentence only", got)
+	}
+}
+
+func TestDeterministic_Question_UsesQuestionSnippet(t *testing.T) {
+	in := "Here's the plan with lots of detail. Should I run the migration now? I can also wait."
+	got := (DeterministicCompactor{}).Compact(in, outbound.CompactQuestion)
+	if got != "Should I run the migration now?" {
+		t.Errorf("Compact = %q, want the question sentence", got)
+	}
+}
+
+func TestDeterministic_Question_FallsBackToFirstLine(t *testing.T) {
+	in := "Let me know how you want to proceed.\nSecond line should be ignored."
+	got := (DeterministicCompactor{}).Compact(in, outbound.CompactQuestion)
+	if got != "Let me know how you want to proceed." {
+		t.Errorf("Compact = %q, want first non-empty line when no literal question", got)
+	}
+}
+
+func TestDeterministic_StripsCodeCommentsAndReminders(t *testing.T) {
+	in := "Refactor the parser.\n" +
+		"```go\nfunc x() {}\n```\n" +
+		"<!-- {\"marker\":\"irrlicht-summary\",\"summary\":\"noise\"} -->\n" +
+		"<system-reminder>do not surface this</system-reminder>"
+	got := (DeterministicCompactor{}).Compact(in, outbound.CompactIntent)
+	if got != "Refactor the parser." {
+		t.Errorf("Compact = %q, want noise stripped", got)
+	}
+	if strings.Contains(got, "marker") || strings.Contains(got, "system-reminder") || strings.Contains(got, "func x") {
+		t.Errorf("Compact = %q, leaked stripped noise", got)
+	}
+}
+
+func TestDeterministic_StripsInlineMarkdown(t *testing.T) {
+	in := "Fix the **flaky** `TestThing` and see [the docs](https://example.com)?"
+	got := (DeterministicCompactor{}).Compact(in, outbound.CompactQuestion)
+	want := "Fix the flaky TestThing and see the docs?"
+	if got != want {
+		t.Errorf("Compact = %q, want %q", got, want)
+	}
+}
+
+func TestDeterministic_CapsToMaxRunesWithEllipsis(t *testing.T) {
+	long := "Implement " + strings.Repeat("a very long intent ", 20) // no sentence terminator
+	got := (DeterministicCompactor{}).Compact(long, outbound.CompactIntent)
+	runes := []rune(got)
+	if len(runes) > maxHeadlineRunes {
+		t.Errorf("len = %d runes, want <= %d", len(runes), maxHeadlineRunes)
+	}
+	if runes[len(runes)-1] != '…' {
+		t.Errorf("Compact = %q, want trailing ellipsis", got)
+	}
+}
+
+func TestDeterministic_CollapsesWhitespace(t *testing.T) {
+	in := "Add   the\tbutton now."
+	got := (DeterministicCompactor{}).Compact(in, outbound.CompactIntent)
+	if got != "Add the button now." {
+		t.Errorf("Compact = %q, want collapsed whitespace", got)
+	}
+}

--- a/core/adapters/outbound/compaction/deterministic.go
+++ b/core/adapters/outbound/compaction/deterministic.go
@@ -1,0 +1,122 @@
+package compaction
+
+import (
+	"regexp"
+	"strings"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// maxHeadlineRunes caps the surfaced one-line headline. The instruction asks
+// the agent for ~70 chars; the cap is the hard ceiling for the raw-text
+// fallback so a paragraph never bloats the sidebar row.
+const maxHeadlineRunes = 70
+
+// Noise-stripping regexes, applied before headline selection. Each is
+// non-greedy and (?s) so a block spanning lines still matches.
+var (
+	fencedCodeRe     = regexp.MustCompile("(?s)```.*?```")
+	htmlCommentRe    = regexp.MustCompile(`(?s)<!--.*?-->`)
+	systemReminderRe = regexp.MustCompile(`(?s)<system-reminder>.*?</system-reminder>`)
+	markdownLinkRe   = regexp.MustCompile(`\[([^\]]*)\]\([^)]*\)`)
+	inlineMarkupRe   = regexp.MustCompile("[`*]+")
+)
+
+// DeterministicCompactor is the default pure-heuristic strategy: it strips
+// fenced code, HTML-comment markers and system-reminder tags, picks the most
+// headline-worthy fragment per kind (the question sentence, or the first
+// sentence of an intent), strips inline markdown, collapses whitespace and caps
+// the result to ~70 runes with an ellipsis on a rune boundary. Empty in → empty
+// out. It never errors. See issue #759.
+type DeterministicCompactor struct{}
+
+var _ outbound.TextCompactor = DeterministicCompactor{}
+
+// Compact reduces text to a one-line headline of the given kind.
+func (DeterministicCompactor) Compact(text string, kind outbound.CompactKind) string {
+	cleaned := stripNoise(text)
+	if cleaned == "" {
+		return ""
+	}
+
+	var headline string
+	switch kind {
+	case outbound.CompactQuestion:
+		// The same extractor the waiting-state classifier uses, so the headline
+		// matches the question that put the session into `waiting`. Fall back to
+		// the first non-empty line when there is no literal question.
+		if snippet := session.ExtractQuestionSnippet(cleaned); snippet != "" {
+			headline = snippet
+		} else {
+			headline = firstNonEmptyLine(cleaned)
+		}
+	default: // CompactIntent
+		headline = firstSentence(cleaned)
+	}
+
+	headline = stripInlineMarkdown(headline)
+	headline = strings.Join(strings.Fields(headline), " ")
+	return capRunes(headline, maxHeadlineRunes)
+}
+
+// stripNoise removes fenced code, HTML comments and system-reminder blocks —
+// the structural noise that would otherwise dominate a headline.
+func stripNoise(s string) string {
+	s = fencedCodeRe.ReplaceAllString(s, " ")
+	s = htmlCommentRe.ReplaceAllString(s, " ")
+	s = systemReminderRe.ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+// stripInlineMarkdown unwraps markdown links to their text and removes inline
+// emphasis/code markers. Underscores are left alone so snake_case identifiers
+// in a headline aren't mangled.
+func stripInlineMarkdown(s string) string {
+	s = markdownLinkRe.ReplaceAllString(s, "$1")
+	s = inlineMarkupRe.ReplaceAllString(s, "")
+	s = strings.TrimLeft(s, "#> ")
+	return strings.TrimSpace(s)
+}
+
+// firstNonEmptyLine returns the first line with non-whitespace content.
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// firstSentence returns the leading sentence of s — text up to the first
+// sentence-terminator (. ! ?) followed by whitespace or end-of-string, or up to
+// the first newline, whichever comes first. Heuristic: an abbreviation's period
+// followed by a space can split early; for a one-line headline that is an
+// acceptable trade and the cap still bounds the result.
+func firstSentence(s string) string {
+	runes := []rune(s)
+	for i, r := range runes {
+		if r == '\n' {
+			return strings.TrimSpace(string(runes[:i]))
+		}
+		if r == '.' || r == '!' || r == '?' {
+			next := i + 1
+			if next >= len(runes) || runes[next] == ' ' || runes[next] == '\n' || runes[next] == '\t' {
+				return strings.TrimSpace(string(runes[:next]))
+			}
+		}
+	}
+	return strings.TrimSpace(s)
+}
+
+// capRunes truncates s to at most max runes, replacing the last kept rune with
+// an ellipsis when it has to drop text (so the total never exceeds max).
+func capRunes(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	truncated := strings.TrimRight(string(runes[:max-1]), " ")
+	return truncated + "…"
+}

--- a/core/adapters/outbound/compaction/noop.go
+++ b/core/adapters/outbound/compaction/noop.go
@@ -1,0 +1,20 @@
+// Package compaction implements the outbound.TextCompactor strategy seam
+// (issue #759): turning bloated session text into a terse one-line sidebar
+// headline. NoopCompactor is the identity (no compaction); DeterministicCompactor
+// is the default pure-heuristic strategy. A future LLMCompactor can join here
+// without touching callers.
+package compaction
+
+import "irrlicht/core/ports/outbound"
+
+// NoopCompactor returns the text unchanged. It is the explicit identity used
+// where compaction is disabled, and the behaviour a nil compactor falls back to
+// in the converter seam.
+type NoopCompactor struct{}
+
+var _ outbound.TextCompactor = NoopCompactor{}
+
+// Compact returns text unchanged regardless of kind.
+func (NoopCompactor) Compact(text string, _ outbound.CompactKind) string {
+	return text
+}

--- a/core/adapters/outbound/metrics/adapter.go
+++ b/core/adapters/outbound/metrics/adapter.go
@@ -9,6 +9,7 @@ import (
 	"irrlicht/core/application/replayengine"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
+	"irrlicht/core/ports/outbound"
 )
 
 // lockedTailer wraps a TranscriptTailer with its own mutex so that
@@ -33,6 +34,10 @@ type Adapter struct {
 	subagents        map[string]agents.SubagentCounter
 	metricsProviders map[string]agents.MetricsProvider
 	fallbackName     string // adapter name to use when the requested name is unknown
+	// converter performs the tailer→domain conversion, including the one-line
+	// intent/question headline compaction (issue #759). Built once from the
+	// Registry's compactor; nil compactor → identity headlines.
+	converter *replayengine.MetricsConverter
 }
 
 // Registry holds the per-adapter behaviour the metrics adapter dispatches
@@ -49,6 +54,10 @@ type Registry struct {
 	// fallback factory, and zero ambiguity if Parsers["claude-code"] is
 	// ever swapped.
 	FallbackName string
+	// Compactor produces the one-line intent/question headlines (issue #759).
+	// Nil means identity (headlines carry the full text) — what existing tests
+	// that build a bare Registry get.
+	Compactor outbound.TextCompactor
 }
 
 // New returns a metrics Adapter configured from the given Registry.
@@ -59,6 +68,7 @@ func New(r Registry) *Adapter {
 		subagents:        r.SubagentCounters,
 		metricsProviders: r.MetricsProviders,
 		fallbackName:     r.FallbackName,
+		converter:        replayengine.NewMetricsConverter(r.Compactor),
 	}
 }
 
@@ -126,10 +136,10 @@ func (a *Adapter) ComputeMetrics(transcriptPath, adapter string) (*session.Sessi
 	if err != nil || m == nil {
 		return nil, nil //nolint:nilerr — absent transcript is not an error
 	}
-	// Plain field copies live in replayengine.TailerToDomain — the single
-	// tailer→domain conversion shared with the replay paths. Everything
-	// below is a live-only enrichment.
-	result := replayengine.TailerToDomain(m)
+	// Plain field copies + headline compaction live in the shared
+	// MetricsConverter — the single tailer→domain conversion shared with the
+	// replay paths. Everything below is a live-only enrichment.
+	result := a.converter.Convert(m)
 	result.OpenSubagents = a.countOpenSubagents(adapter, m)
 	if m.RateLimit != nil {
 		result.RateLimit = tailerRateLimitToDomain(m.RateLimit)

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -3,16 +3,49 @@ package replayengine
 import (
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
+	"irrlicht/core/ports/outbound"
 )
 
-// TailerToDomain converts the tailer's metrics struct into the domain type
-// consumed by services.ClassifyState. THE single tailer→domain plain-copy:
-// shared by the replay CLI (both its transcript and sidecar paths), this
-// engine, and the live metrics adapter — which layers its live-only
-// enrichments (subagent counter, rate-limit + ETA forecasts, presentation
-// defaults) on top. Plain field copies belong here so the live and replay
-// paths can't drift (#604 review).
+// MetricsConverter performs THE single tailer→domain conversion, shared by the
+// replay CLI (both its transcript and sidecar paths), this engine, and the live
+// metrics adapter — which layers its live-only enrichments (subagent counter,
+// rate-limit + ETA forecasts, presentation defaults) on top. Plain field copies
+// belong here so the live and replay paths can't drift (#604 review).
+//
+// It holds a TextCompactor (issue #759) used to derive the one-line
+// intent/question headlines. A nil compactor (or the nil-receiver free function
+// below) means identity compaction — the headlines carry the full text, which
+// is what the replay paths and tests use.
+type MetricsConverter struct {
+	compactor outbound.TextCompactor
+}
+
+// NewMetricsConverter returns a converter that compacts headlines via c. Pass
+// nil for identity (no compaction).
+func NewMetricsConverter(c outbound.TextCompactor) *MetricsConverter {
+	return &MetricsConverter{compactor: c}
+}
+
+// TailerToDomain is the identity-compaction convenience wrapper kept so replay
+// call sites that don't compact headlines (engine, replay CLI, tests) compile
+// unchanged. The live metrics adapter uses a NewMetricsConverter with the
+// deterministic compactor instead.
 func TailerToDomain(m *tailer.SessionMetrics) *session.SessionMetrics {
+	return (&MetricsConverter{}).Convert(m)
+}
+
+// compact applies the converter's compactor, falling back to identity when the
+// converter or its compactor is nil.
+func (mc *MetricsConverter) compact(text string, kind outbound.CompactKind) string {
+	if mc == nil || mc.compactor == nil {
+		return text
+	}
+	return mc.compactor.Compact(text, kind)
+}
+
+// Convert maps the tailer's metrics struct into the domain type consumed by
+// services.ClassifyState.
+func (mc *MetricsConverter) Convert(m *tailer.SessionMetrics) *session.SessionMetrics {
 	if m == nil {
 		return nil
 	}
@@ -80,18 +113,27 @@ func TailerToDomain(m *tailer.SessionMetrics) *session.SessionMetrics {
 			}
 		}
 	}
-	if snippet := session.ExtractQuestionSnippet(result.LastAssistantText); snippet != "" {
-		result.LastAssistantText = snippet
-	}
 	// Task summary (issue #738): the agent's in-band marker wins; the first
 	// user message is the heuristic fallback for agents that emit none. Both
 	// are wall-clock independent, so the selection lives in this shared
-	// plain-copy and surfaces identically in live and replay paths.
+	// plain-copy and surfaces identically in live and replay paths. Kept as the
+	// full text (the sidebar tooltip); IntentHeadline is its compacted form.
 	if m.TaskSummary != nil && m.TaskSummary.Text != "" {
 		result.TaskSummary = m.TaskSummary.Text
 	} else {
 		result.TaskSummary = m.FirstUserText
 	}
+
+	// Headlines (issue #759): the terse one-line sidebar text. The full
+	// TaskSummary / LastAssistantText are kept above for the hover tooltips —
+	// this no longer overwrites LastAssistantText with the question snippet, so
+	// the waiting-state classifier and tooltips see the complete text.
+	result.IntentHeadline = mc.compact(result.TaskSummary, outbound.CompactIntent)
+	questionSource := result.LastAssistantText
+	if m.TaskQuestion != nil && m.TaskQuestion.Text != "" {
+		questionSource = m.TaskQuestion.Text
+	}
+	result.QuestionHeadline = mc.compact(questionSource, outbound.CompactQuestion)
 	return result
 }
 

--- a/core/application/replayengine/metrics_test.go
+++ b/core/application/replayengine/metrics_test.go
@@ -4,7 +4,23 @@ import (
 	"testing"
 
 	"irrlicht/core/pkg/tailer"
+	"irrlicht/core/ports/outbound"
 )
+
+// fakeCompactor tags its output with the requested kind so tests can assert the
+// converter routes each source to the right CompactKind.
+type fakeCompactor struct{}
+
+func (fakeCompactor) Compact(text string, kind outbound.CompactKind) string {
+	switch kind {
+	case outbound.CompactIntent:
+		return "intent:" + text
+	case outbound.CompactQuestion:
+		return "question:" + text
+	default:
+		return text
+	}
+}
 
 func TestTailerToDomain_TaskSummary_MarkerWins(t *testing.T) {
 	m := &tailer.SessionMetrics{
@@ -31,5 +47,63 @@ func TestTailerToDomain_TaskSummary_EmptyWhenNeither(t *testing.T) {
 	got := TailerToDomain(&tailer.SessionMetrics{})
 	if got.TaskSummary != "" {
 		t.Errorf("TaskSummary = %q, want empty", got.TaskSummary)
+	}
+}
+
+func TestConvert_IntentHeadline_CompactsTaskSummary(t *testing.T) {
+	m := &tailer.SessionMetrics{
+		TaskSummary: &tailer.TaskSummary{Text: "add the logout button", ObservedAt: 100},
+	}
+	got := NewMetricsConverter(fakeCompactor{}).Convert(m)
+	if got.IntentHeadline != "intent:add the logout button" {
+		t.Errorf("IntentHeadline = %q, want it compacted from the summary", got.IntentHeadline)
+	}
+	// The full summary is preserved for the tooltip.
+	if got.TaskSummary != "add the logout button" {
+		t.Errorf("TaskSummary = %q, want the full text preserved", got.TaskSummary)
+	}
+}
+
+func TestConvert_QuestionHeadline_MarkerWinsOverLastAssistantText(t *testing.T) {
+	m := &tailer.SessionMetrics{
+		LastAssistantText: "a long rambling message ending in a question?",
+		TaskQuestion:      &tailer.TaskQuestion{Text: "run the migration?", ObservedAt: 100},
+	}
+	got := NewMetricsConverter(fakeCompactor{}).Convert(m)
+	if got.QuestionHeadline != "question:run the migration?" {
+		t.Errorf("QuestionHeadline = %q, want the marker to win", got.QuestionHeadline)
+	}
+	// The full last-assistant text is preserved for the tooltip + classifier.
+	if got.LastAssistantText != "a long rambling message ending in a question?" {
+		t.Errorf("LastAssistantText = %q, want the full text preserved (not overwritten)", got.LastAssistantText)
+	}
+}
+
+func TestConvert_QuestionHeadline_FallsBackToLastAssistantText(t *testing.T) {
+	m := &tailer.SessionMetrics{
+		LastAssistantText: "should I proceed?",
+	}
+	got := NewMetricsConverter(fakeCompactor{}).Convert(m)
+	if got.QuestionHeadline != "question:should I proceed?" {
+		t.Errorf("QuestionHeadline = %q, want fallback to last-assistant text", got.QuestionHeadline)
+	}
+}
+
+func TestTailerToDomain_NilCompactor_HeadlinesAreIdentity(t *testing.T) {
+	m := &tailer.SessionMetrics{
+		TaskSummary:       &tailer.TaskSummary{Text: "add the logout button", ObservedAt: 100},
+		LastAssistantText: "should I proceed?",
+	}
+	got := TailerToDomain(m)
+	// The free wrapper uses identity compaction — headlines carry the full text,
+	// and LastAssistantText is no longer overwritten with the question snippet.
+	if got.IntentHeadline != "add the logout button" {
+		t.Errorf("IntentHeadline = %q, want identity (full text)", got.IntentHeadline)
+	}
+	if got.QuestionHeadline != "should I proceed?" {
+		t.Errorf("QuestionHeadline = %q, want identity (full text)", got.QuestionHeadline)
+	}
+	if got.LastAssistantText != "should I proceed?" {
+		t.Errorf("LastAssistantText = %q, want full text preserved", got.LastAssistantText)
 	}
 }

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -169,7 +169,22 @@ type SessionMetrics struct {
 	// in-band irrlicht-summary marker when present, else a daemon-side
 	// heuristic (the first user message). Surfaced in both the waiting and
 	// ready states so a human can tell what a session was about at a glance.
+	// Kept as the full text; the sidebar shows IntentHeadline and uses this as
+	// the hover tooltip.
 	TaskSummary string `json:"task_summary,omitempty"`
+
+	// IntentHeadline is the terse ~70-char one-line version of TaskSummary,
+	// produced by the compaction seam (issue #759). The sidebar renders this in
+	// the purple "intent" block; the full TaskSummary is the tooltip. Empty
+	// when there is no summary source.
+	IntentHeadline string `json:"intent_headline,omitempty"`
+
+	// QuestionHeadline is the terse ~70-char one-line version of the pending
+	// question, produced by the compaction seam from the agent's in-band
+	// irrlicht-question marker when present, else from LastAssistantText (issue
+	// #759). The sidebar renders this in the orange "waiting" block; the full
+	// LastAssistantText is the tooltip. Empty when there is no question source.
+	QuestionHeadline string `json:"question_headline,omitempty"`
 
 	// PermissionMode is the session's permission mode from the JSONL
 	// (e.g. "default", "plan", "bypassPermissions"). Surfaced by the tailer
@@ -814,6 +829,8 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 		EstimatedCostUSD:         newM.EstimatedCostUSD,
 		LastAssistantText:        newM.LastAssistantText,
 		TaskSummary:              newM.TaskSummary,
+		IntentHeadline:           newM.IntentHeadline,
+		QuestionHeadline:         newM.QuestionHeadline,
 		PermissionMode:           newM.PermissionMode,
 		SubagentCompletions:      newM.SubagentCompletions,
 		AppliedTaskDeltas:        newM.AppliedTaskDeltas,

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -226,6 +226,12 @@ type ParsedEvent struct {
 	// recent one across passes.
 	TaskSummary *TaskSummary
 
+	// TaskQuestion, when non-nil, is the agent's terse one-line version of the
+	// question it is currently blocked on, parsed from an in-band HTML-comment
+	// marker (issue #759). Latest non-empty marker wins; the tailer keeps the
+	// most recent one across passes and clears it on a real user message.
+	TaskQuestion *TaskQuestion
+
 	// UserText is the prose of a genuine user prompt on this event (not a
 	// tool result). The tailer captures the FIRST non-empty one as the
 	// heuristic-fallback task summary (issue #738). Adapters that don't set
@@ -287,6 +293,21 @@ type TaskEstimate struct {
 // "what is this session about" that the UI surfaces in both the waiting and
 // ready states. Wall-clock independent, so it survives replay.
 type TaskSummary struct {
+	Text string
+	// ObservedAt is the unix-seconds timestamp of the transcript event the
+	// marker appeared in (replay-deterministic), used for latest-wins.
+	ObservedAt int64
+}
+
+// TaskQuestion mirrors the agent's terse one-line question parsed from an
+// in-band marker like
+//
+//	<!-- {"marker":"irrlicht-question","question":"Run the migration now?"} -->
+//
+// It is the question-state companion to TaskSummary (issue #759): the preferred
+// source for the surfaced waiting-state headline when the agent supplies one.
+// Wall-clock independent, so it survives replay.
+type TaskQuestion struct {
 	Text string
 	// ObservedAt is the unix-seconds timestamp of the transcript event the
 	// marker appeared in (replay-deterministic), used for latest-wins.
@@ -450,6 +471,10 @@ type LedgerState struct {
 	// before the next marker/message arrives. A reset stores a nil summary.
 	LastTaskSummary *TaskSummary `json:"last_task_summary,omitempty"`
 	FirstUserText   string       `json:"first_user_text,omitempty"`
+	// LastTaskQuestion persists the agent's task-question marker (issue #759)
+	// so a daemon restart keeps surfacing the waiting headline before the next
+	// marker/message arrives. A reset stores nil.
+	LastTaskQuestion *TaskQuestion `json:"last_task_question,omitempty"`
 	// ModelName is the last observed model for the session. Persisted so that
 	// applyContribution's fallback (used when a contribution event carries no
 	// model — codex token_count) still routes to the right pricing bucket

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -225,6 +225,14 @@ type SessionMetrics struct {
 	// as a daemon-side heuristic fallback for the surfaced task summary when
 	// no marker is present (issue #738) — e.g. agents that don't emit one.
 	FirstUserText string `json:"first_user_text,omitempty"`
+
+	// TaskQuestion is the most recent agent-emitted task-question marker
+	// (issue #759) — the terse one-line version of the question the agent is
+	// blocked on. Sporadic like TaskSummary; the last one seen persists across
+	// passes and is cleared on a real user message. Nil when the session never
+	// emitted a question marker; the surfaced waiting headline then falls back
+	// to compacting the raw last-assistant text.
+	TaskQuestion *TaskQuestion `json:"task_question,omitempty"`
 }
 
 // TranscriptTailer monitors transcript files and computes metrics.
@@ -335,6 +343,11 @@ type TranscriptTailer struct {
 	// once and never overwritten — the heuristic fallback for the surfaced
 	// task summary when no marker is present (issue #738).
 	firstUserText string
+
+	// lastTaskQuestion holds the most recent agent-emitted task-question marker
+	// (issue #759). Sporadic like lastTaskSummary — the last one seen persists
+	// across markerless passes; cleared on a real user message.
+	lastTaskQuestion *TaskQuestion
 
 	// tasks accumulates the session's task list from TaskCreate / TaskUpdate
 	// tool_use events parsed by the Claude Code adapter.
@@ -465,6 +478,7 @@ func (t *TranscriptTailer) GetLedgerState() LedgerState {
 	s.FirstTaskEstimate = t.firstTaskEstimate
 	s.LastTaskSummary = t.lastTaskSummary
 	s.FirstUserText = t.firstUserText
+	s.LastTaskQuestion = t.lastTaskQuestion
 	return s
 }
 
@@ -540,6 +554,7 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 	t.firstTaskEstimate = s.FirstTaskEstimate
 	t.lastTaskSummary = s.LastTaskSummary
 	t.firstUserText = s.FirstUserText
+	t.lastTaskQuestion = s.LastTaskQuestion
 }
 
 // TailAndProcess reads new transcript content from the last offset (or from the
@@ -1102,6 +1117,9 @@ func (t *TranscriptTailer) processParsedEvent(parsed *ParsedEvent, sawUserBlocki
 	if parsed.TaskSummary != nil {
 		t.applyTaskSummary(parsed.TaskSummary)
 	}
+	if parsed.TaskQuestion != nil {
+		t.applyTaskQuestion(parsed.TaskQuestion)
+	}
 	// Capture the first user prompt once as the heuristic-fallback summary
 	// (issue #738) — never overwritten, so it describes what the session was
 	// originally about even after many turns.
@@ -1121,6 +1139,9 @@ func (t *TranscriptTailer) processParsedEvent(parsed *ParsedEvent, sawUserBlocki
 		// The summary describes the now-superseded task; clear it so the next
 		// task re-anchors (the agent re-emits, or the heuristic takes over).
 		t.lastTaskSummary = nil
+		// The question was answered by this very user message — clear it so the
+		// next waiting turn re-derives from the new last-assistant text.
+		t.lastTaskQuestion = nil
 	}
 
 	t.addMessageEvent(MessageEvent{
@@ -1183,6 +1204,20 @@ func (t *TranscriptTailer) applyTaskSummary(s *TaskSummary) {
 // text blocks on claude ≥2.1.162. Caller holds the per-tailer lock.
 func (t *TranscriptTailer) IngestTaskSummary(s *TaskSummary) {
 	t.applyTaskSummary(s)
+}
+
+// applyTaskQuestion keeps the latest task-question marker (issue #759). A
+// question observed BEFORE the current latest is dropped so an out-of-order
+// delivery can't regress a fresher marker. The user-message reset stays in
+// processParsedEvent: it is transcript-line-driven.
+func (t *TranscriptTailer) applyTaskQuestion(q *TaskQuestion) {
+	if q == nil || q.Text == "" {
+		return
+	}
+	if t.lastTaskQuestion != nil && q.ObservedAt < t.lastTaskQuestion.ObservedAt {
+		return
+	}
+	t.lastTaskQuestion = q
 }
 
 // PurgeBackgroundProcs drops the tracked background processes whose output

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -331,6 +331,10 @@ func (t *TranscriptTailer) computeMetrics() {
 	t.metrics.TaskSummary = t.lastTaskSummary
 	t.metrics.FirstUserText = t.firstUserText
 
+	// The task-question marker is surfaced the same way (issue #759) — last-seen
+	// one persists across empty/resume passes, cleared on a user message.
+	t.metrics.TaskQuestion = t.lastTaskQuestion
+
 	// Background-process count + output paths share the rate-limit block's
 	// "must run even on an empty pass" property: the open set can be
 	// rehydrated from the ledger after a daemon restart and must surface

--- a/core/pkg/tailer/taskquestion_scan.go
+++ b/core/pkg/tailer/taskquestion_scan.go
@@ -1,0 +1,70 @@
+// taskquestion_scan.go parses the agent-emitted task-question marker from
+// assistant text (issue #759). When the agent ends a turn by asking the user
+// something, it may author a terse one-line version of that question and emit
+// it in-band as a hidden HTML comment, e.g.
+//
+//	<!-- {"marker":"irrlicht-question","question":"Run the migration now?"} -->
+//
+// irrlicht only parses it (read-only). It is the question-state companion to
+// the irrlicht-summary marker (tasksummary_scan.go): the summary describes the
+// task, the question describes what the agent is currently blocked on. It is
+// the preferred source for the surfaced waiting-state headline; when absent the
+// daemon falls back to compacting the raw last-assistant text. Parsing is
+// tolerant by design — the model rewrites markers — so we accept key drift and
+// ignore anything malformed rather than erroring. Latest non-empty marker wins.
+package tailer
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// taskQuestionMarkerKeyRe accepts the marker-key spellings the model emits
+// ("irrlicht-question", "irrlicht_question").
+var taskQuestionMarkerKeyRe = regexp.MustCompile(`^irrlicht[-_]question$`)
+
+// ScanTaskQuestion scans the full text of an assistant text block for
+// task-question markers and returns the last valid one, stamped with the event
+// timestamp. Returns nil when no valid marker is present. Like ScanTaskSummary
+// it must be fed the complete block text — ParsedEvent's truncated
+// AssistantText would lose markers in long messages.
+func ScanTaskQuestion(text string, observedAt time.Time) *TaskQuestion {
+	// Fast-reject the common no-marker case before running the regex engine —
+	// shares the hot path with ScanTaskEstimate / ScanTaskSummary.
+	if !strings.Contains(text, "<!--") {
+		return nil
+	}
+	var latest *TaskQuestion
+	for _, m := range taskEstimateCommentRe.FindAllStringSubmatch(text, -1) {
+		payload := m[1]
+		if len(payload) > maxTaskEstimateCommentLen {
+			continue
+		}
+		if q := parseTaskQuestionPayload(payload); q != nil {
+			q.ObservedAt = observedAt.Unix()
+			latest = q
+		}
+	}
+	return latest
+}
+
+// parseTaskQuestionPayload decodes one candidate JSON payload into a
+// TaskQuestion. Acceptance gate: the marker key matches irrlicht[-_]question
+// and a non-empty question string is present (tolerating the "text" key drift).
+// Returns nil for anything malformed or empty. Never errors.
+func parseTaskQuestionPayload(payload string) *TaskQuestion {
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(payload), &obj); err != nil {
+		return nil
+	}
+	if marker, _ := obj["marker"].(string); !taskQuestionMarkerKeyRe.MatchString(marker) {
+		return nil
+	}
+	text := cleanSummaryText(strField(obj, "question", "text"))
+	if text == "" {
+		return nil
+	}
+	return &TaskQuestion{Text: text}
+}

--- a/core/pkg/tailer/taskquestion_scan_test.go
+++ b/core/pkg/tailer/taskquestion_scan_test.go
@@ -1,0 +1,103 @@
+package tailer
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+var questionObservedAt = time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+
+func TestScanTaskQuestion_HappyPath(t *testing.T) {
+	text := `Done. <!-- {"marker":"irrlicht-question","question":"Run the migration now?"} --> Waiting.`
+	q := ScanTaskQuestion(text, questionObservedAt)
+	if q == nil {
+		t.Fatal("expected question, got nil")
+	}
+	if q.Text != "Run the migration now?" {
+		t.Errorf("Text = %q", q.Text)
+	}
+	if q.ObservedAt != questionObservedAt.Unix() {
+		t.Errorf("ObservedAt = %d, want %d", q.ObservedAt, questionObservedAt.Unix())
+	}
+}
+
+func TestScanTaskQuestion_MarkerKeyVariants(t *testing.T) {
+	for _, marker := range []string{"irrlicht-question", "irrlicht_question"} {
+		text := `<!-- {"marker":"` + marker + `","question":"proceed?"} -->`
+		if ScanTaskQuestion(text, questionObservedAt) == nil {
+			t.Errorf("marker key %q should be accepted", marker)
+		}
+	}
+}
+
+func TestScanTaskQuestion_TextKeyDrift(t *testing.T) {
+	for _, key := range []string{"question", "text"} {
+		text := `<!-- {"marker":"irrlicht-question","` + key + `":"which option?"} -->`
+		q := ScanTaskQuestion(text, questionObservedAt)
+		if q == nil || q.Text != "which option?" {
+			t.Errorf("alias %q: q = %+v", key, q)
+		}
+	}
+}
+
+func TestScanTaskQuestion_MalformedIgnored(t *testing.T) {
+	for name, text := range map[string]string{
+		"truncated json":  `<!-- {"marker":"irrlicht-question","question": -->`,
+		"not json":        `<!-- hello world -->`,
+		"no question key": `<!-- {"marker":"irrlicht-question"} -->`,
+		"empty question":  `<!-- {"marker":"irrlicht-question","question":""} -->`,
+		"foreign marker":  `<!-- {"marker":"irrlicht-summary","question":"x"} -->`,
+		"missing marker":  `<!-- {"question":"no marker key here"} -->`,
+		"non-string text": `<!-- {"marker":"irrlicht-question","question":42} -->`,
+	} {
+		if q := ScanTaskQuestion(text, questionObservedAt); q != nil {
+			t.Errorf("%s: expected nil, got %+v", name, q)
+		}
+	}
+}
+
+func TestScanTaskQuestion_CleansWhitespaceAndControlChars(t *testing.T) {
+	text := "<!-- {\"marker\":\"irrlicht-question\",\"question\":\"  run\\nthe\\t migration?  \"} -->"
+	q := ScanTaskQuestion(text, questionObservedAt)
+	if q == nil || q.Text != "run the migration?" {
+		t.Fatalf("q = %+v, want collapsed single line", q)
+	}
+}
+
+func TestScanTaskQuestion_CapsLength(t *testing.T) {
+	long := strings.Repeat("a", maxTaskSummaryRunes+50)
+	text := `<!-- {"marker":"irrlicht-question","question":"` + long + `"} -->`
+	q := ScanTaskQuestion(text, questionObservedAt)
+	if q == nil {
+		t.Fatal("expected question, got nil")
+	}
+	if got := len([]rune(q.Text)); got > maxTaskSummaryRunes {
+		t.Errorf("length = %d runes, want <= %d", got, maxTaskSummaryRunes)
+	}
+}
+
+func TestScanTaskQuestion_LatestWins(t *testing.T) {
+	text := `<!-- {"marker":"irrlicht-question","question":"first?"} -->
+prose
+<!-- {"marker":"irrlicht-question","question":"second?"} -->`
+	q := ScanTaskQuestion(text, questionObservedAt)
+	if q == nil || q.Text != "second?" {
+		t.Fatalf("q = %+v, want latest marker", q)
+	}
+}
+
+func TestScanTaskQuestion_LatestInvalidDoesNotShadowEarlierValid(t *testing.T) {
+	text := `<!-- {"marker":"irrlicht-question","question":"real?"} -->
+<!-- {"marker":"irrlicht-question","question":""} -->`
+	q := ScanTaskQuestion(text, questionObservedAt)
+	if q == nil || q.Text != "real?" {
+		t.Fatalf("q = %+v, want earlier valid marker", q)
+	}
+}
+
+func TestScanTaskQuestion_NoMarker(t *testing.T) {
+	if q := ScanTaskQuestion("plain prose, no comments at all", questionObservedAt); q != nil {
+		t.Fatalf("expected nil, got %+v", q)
+	}
+}

--- a/core/ports/outbound/compaction.go
+++ b/core/ports/outbound/compaction.go
@@ -1,0 +1,27 @@
+package outbound
+
+// CompactKind selects the compaction strategy for a piece of session text.
+// The two kinds carry different intent, so an adapter can shape the headline
+// differently per kind (e.g. a question keeps its trailing "?", an intent reads
+// as a statement). See issue #759.
+type CompactKind int
+
+const (
+	// CompactIntent compacts the session's "what is this about" text (the
+	// task-summary marker or the first user prompt) into a one-line headline.
+	CompactIntent CompactKind = iota
+	// CompactQuestion compacts the agent's pending question (the task-question
+	// marker or the raw last-assistant text) into a one-line headline.
+	CompactQuestion
+)
+
+// TextCompactor turns a possibly-bloated piece of session text into a terse
+// one-line headline suitable for the sidebar, with the full text kept elsewhere
+// for tooltips. It is a strategy seam (issue #759): the default deterministic
+// adapter is a pure heuristic; a future LLM adapter can swap in without touching
+// callers. There is deliberately no error return — a compactor that can't
+// improve the text (or whose backend fails) returns the input unchanged (and
+// logs via Logger), so the headline degrades gracefully rather than vanishing.
+type TextCompactor interface {
+	Compact(text string, kind CompactKind) string
+}

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -346,8 +346,10 @@ struct SessionMetrics: Codable {
     let pressureLevel: String       // pressure level: "safe", "caution", "warning", "critical" ("unknown" if not available)
     let contextWindowUnknown: Bool? // true when daemon has no LiteLLM pricing for the model — render tokens-only, no percentage
     let estimatedCostUSD: Double?   // estimated session cost in USD (nil if not available)
-    let lastAssistantText: String?  // last assistant message text, truncated (~200 chars)
-    let taskSummary: String?        // human-readable "what is this session about" (issue #738)
+    let lastAssistantText: String?  // last assistant message text, truncated (~200 chars) — full text for the question tooltip
+    let taskSummary: String?        // human-readable "what is this session about" (issue #738) — full text for the intent tooltip
+    let intentHeadline: String?     // terse one-line version of taskSummary for the sidebar (issue #759)
+    let questionHeadline: String?   // terse one-line version of the pending question for the sidebar (issue #759)
     let tasks: [SessionTask]?              // Claude Code task list (nil when TaskCreate never called)
     let rateLimit: RateLimitInfo?          // subscription-quota snapshot (nil for API-key / Bedrock / Vertex)
     let rateLimitForecastEta: Date?        // projected wall-clock time when the imminent window hits 100% (nil when unforecastable)
@@ -367,6 +369,8 @@ struct SessionMetrics: Codable {
         case estimatedCostUSD = "estimated_cost_usd"
         case lastAssistantText = "last_assistant_text"
         case taskSummary = "task_summary"
+        case intentHeadline = "intent_headline"
+        case questionHeadline = "question_headline"
         case tasks
         case rateLimit = "rate_limit"
         case rateLimitForecastEta = "rate_limit_forecast_eta"
@@ -388,6 +392,8 @@ struct SessionMetrics: Codable {
         estimatedCostUSD = try c.decodeIfPresent(Double.self, forKey: .estimatedCostUSD)
         lastAssistantText = try c.decodeIfPresent(String.self, forKey: .lastAssistantText)
         taskSummary = try c.decodeIfPresent(String.self, forKey: .taskSummary)
+        intentHeadline = try c.decodeIfPresent(String.self, forKey: .intentHeadline)
+        questionHeadline = try c.decodeIfPresent(String.self, forKey: .questionHeadline)
         tasks = try c.decodeIfPresent([SessionTask].self, forKey: .tasks)
         rateLimit = try c.decodeIfPresent(RateLimitInfo.self, forKey: .rateLimit)
         if let epoch = try c.decodeIfPresent(Double.self, forKey: .rateLimitForecastEta) {
@@ -423,6 +429,8 @@ struct SessionMetrics: Codable {
         estimatedCostUSD: Double?,
         lastAssistantText: String?,
         taskSummary: String? = nil,
+        intentHeadline: String? = nil,
+        questionHeadline: String? = nil,
         tasks: [SessionTask]?,
         rateLimit: RateLimitInfo? = nil,
         rateLimitForecastEta: Date? = nil,
@@ -441,6 +449,8 @@ struct SessionMetrics: Codable {
         self.estimatedCostUSD = estimatedCostUSD
         self.lastAssistantText = lastAssistantText
         self.taskSummary = taskSummary
+        self.intentHeadline = intentHeadline
+        self.questionHeadline = questionHeadline
         self.tasks = tasks
         self.rateLimit = rateLimit
         self.rateLimitForecastEta = rateLimitForecastEta
@@ -462,6 +472,8 @@ struct SessionMetrics: Codable {
         try c.encodeIfPresent(estimatedCostUSD, forKey: .estimatedCostUSD)
         try c.encodeIfPresent(lastAssistantText, forKey: .lastAssistantText)
         try c.encodeIfPresent(taskSummary, forKey: .taskSummary)
+        try c.encodeIfPresent(intentHeadline, forKey: .intentHeadline)
+        try c.encodeIfPresent(questionHeadline, forKey: .questionHeadline)
         try c.encodeIfPresent(tasks, forKey: .tasks)
         try c.encodeIfPresent(rateLimit, forKey: .rateLimit)
         try c.encodeIfPresent(rateLimitForecastEta.map { $0.timeIntervalSince1970 }, forKey: .rateLimitForecastEta)

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1198,42 +1198,49 @@ struct SessionRowView: View {
     /// control; there is no per-row toggle.
     @ViewBuilder
     private var summaryBlock: some View {
-        let summary = session.metrics?.taskSummary
-        let question = session.state == .waiting ? session.metrics?.lastAssistantText : nil
+        // Block text is the terse one-line headline (issue #759); the tooltip
+        // keeps the full text. Fall back to the full field when the daemon hasn't
+        // supplied a headline (older daemon, or pre-headline state).
+        let summaryFull = session.metrics?.taskSummary
+        let summaryLine = session.metrics?.intentHeadline ?? summaryFull
+        let questionFull = session.state == .waiting ? session.metrics?.lastAssistantText : nil
+        let questionLine = session.state == .waiting
+            ? (session.metrics?.questionHeadline ?? questionFull)
+            : nil
         let collapsed = summaryCollapsed
-        let showIntent = userIntentDisplay && (summary?.isEmpty == false) && !collapsed
-        let showQuestion = (question?.isEmpty == false) && !collapsed
+        let showIntent = userIntentDisplay && (summaryLine?.isEmpty == false) && !collapsed
+        let showQuestion = (questionLine?.isEmpty == false) && !collapsed
         if showIntent || showQuestion {
             VStack(alignment: .leading, spacing: 2) {
                 // User intent (beta): what the user asked for.
-                if showIntent, let s = summary {
+                if showIntent, let s = summaryLine {
                     Text(s)
                         .font(.system(size: 9))
                         .foregroundColor(IrrColors.intent)
-                        .lineLimit(3)
+                        .lineLimit(1)
                         .truncationMode(.tail)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 5)
                         .padding(.vertical, 3)
                         .background(IrrColors.intentDim)
                         .cornerRadius(IrrRadius.sm)
-                        .tooltip(s)
+                        .tooltip(summaryFull ?? s)
                 }
 
                 // Pending question: what the agent is asking.
-                if showQuestion, let q = question {
+                if showQuestion, let q = questionLine {
                     Text(q)
                         .font(.system(size: 9))
                         .foregroundColor(IrrColors.waiting)
-                        .lineLimit(3)
-                        .truncationMode(.head)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.horizontal, 5)
                         .padding(.vertical, 3)
                         .background(IrrColors.waitingDim)
                         .cornerRadius(IrrRadius.sm)
-                        // Surface the full prompt — head-truncation hides the start.
-                        .tooltip(q)
+                        // Surface the full prompt on hover.
+                        .tooltip(questionFull ?? q)
                 }
             }
             .padding(.top, 2)

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1335,7 +1335,10 @@ import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collap
     }
     function updateSummaryRow(el, agent) {
       const summary = (agent.metrics && agent.metrics.task_summary) || '';
-      const question = (agent.state === 'waiting' && agent.metrics && agent.metrics.last_assistant_text) || '';
+      // Prefer the terse one-line headline (issue #759); fall back to the full
+      // last-assistant text for older daemons. The full text is kept for hover.
+      const questionFull = (agent.state === 'waiting' && agent.metrics && agent.metrics.last_assistant_text) || '';
+      const question = (agent.state === 'waiting' && agent.metrics && (agent.metrics.question_headline || agent.metrics.last_assistant_text)) || '';
       if (!summary && !question) { el.style.display = 'none'; return; }
       el.style.display = '';
       el._sessionId = agent.session_id;
@@ -1355,7 +1358,7 @@ import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collap
         qEl.style.display = '';
         if (qEl.dataset.full !== question) {
           qEl.textContent = question;
-          qEl.title = question;
+          qEl.title = questionFull || question;
           qEl.dataset.full = question;
         }
       } else {

--- a/replaydata/agents/claudecode/regressions/06-cost-calculation-07f5cca9/recordings/2026-04-07-19-57-20_irrlichd-unknown/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/regressions/06-cost-calculation-07f5cca9/recordings/2026-04-07-19-57-20_irrlichd-unknown/transcript.jsonl.replay.json.golden
@@ -191,7 +191,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "- (d) build a small redactor that strips paths + suspicious strings before commi…"
+      "last_assistant_text_head": "… as-is,\n- (b) commit only 02/03/04 and drop the 60 MB one,\n- (c) run a secret…"
     },
     {
       "index": 11,
@@ -220,7 +220,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "Want me to start with the Bug B fix (small, self-contained, immediately visible …"
+      "last_assistant_text_head": "… to land for the regression numbers to drop.\n\nWant me to start with the Bug B…"
     },
     {
       "index": 13,
@@ -249,7 +249,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "Want me to ship both fixes as two separate commits?"
+      "last_assistant_text_head": "… | 4               | 2           | **0**           |\n\nWant me to ship both fi…"
     },
     {
       "index": 15,
@@ -307,7 +307,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "…e scoreboard, then move through the fixes one by one?"
+      "last_assistant_text_head": "…e scoreboard, then move through the fixes one by one? Or would you prefer I d…"
     },
     {
       "index": 19,

--- a/replaydata/agents/claudecode/regressions/08-issue-114-stuck-working-a/recordings/2026-04-09-20-49-38_irrlichd-unknown/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/regressions/08-issue-114-stuck-working-a/recordings/2026-04-09-20-49-38_irrlichd-unknown/transcript.jsonl.replay.json.golden
@@ -464,7 +464,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "Want me to restart the Swift app, or should I look at the app log to see what it…"
+      "last_assistant_text_head": "…menu bar may be collapsed — `proc-21130` should appear under the `irrlicht`…"
     },
     {
       "index": 30,
@@ -479,7 +479,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "Want me to restart the Swift app, or should I look at the app log to see what it…"
+      "last_assistant_text_head": "…menu bar may be collapsed — `proc-21130` should appear under the `irrlicht`…"
     },
     {
       "index": 31,

--- a/replaydata/agents/claudecode/regressions/10-full-lifecycle-839f0678/recordings/2026-04-11-11-52-09_irrlichd-unknown/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/regressions/10-full-lifecycle-839f0678/recordings/2026-04-11-11-52-09_irrlichd-unknown/transcript.jsonl.replay.json.golden
@@ -140,7 +140,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "What's on your mind?"
+      "last_assistant_text_head": "Got it — just chatting. What's on your mind?"
     },
     {
       "index": 7,

--- a/replaydata/agents/claudecode/regressions/16-ask-user-question-issue-150/recordings/2026-04-12-18-52-20_irrlichd-unknown/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/regressions/16-ask-user-question-issue-150/recordings/2026-04-12-18-52-20_irrlichd-unknown/transcript.jsonl.replay.json.golden
@@ -264,7 +264,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "What can I help you with?"
+      "last_assistant_text_head": "Hi! What can I help you with?"
     },
     {
       "index": 15,
@@ -279,7 +279,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "What can I help you with?"
+      "last_assistant_text_head": "Hi! What can I help you with?"
     },
     {
       "index": 16,
@@ -308,7 +308,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "What would you like to work on?"
+      "last_assistant_text_head": "Hey! What would you like to work on?"
     },
     {
       "index": 18,
@@ -382,7 +382,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "…at would you like me to test?"
+      "last_assistant_text_head": "…at would you like me to test? For example:\n\n- Run the Go test suite (`go test…"
     },
     {
       "index": 23,
@@ -411,7 +411,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "What are you looking to test?"
+      "last_assistant_text_head": "What are you looking to test? Give me a bit more context and I'll jump in."
     },
     {
       "index": 25,

--- a/replaydata/agents/pi/regressions/01-example-session/recordings/2026-04-06-16-22-10_irrlichd-unknown/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/pi/regressions/01-example-session/recordings/2026-04-06-16-22-10_irrlichd-unknown/transcript.jsonl.replay.json.golden
@@ -1033,7 +1033,7 @@
       "is_agent_done": true,
       "needs_user_attention": false,
       "waiting_for_user_input": true,
-      "last_assistant_text_head": "Yep — what do you want to do with **pi**?"
+      "last_assistant_text_head": "Yep — what do you want to do with **pi**?\n\nI can help with setup, config, skil…"
     },
     {
       "index": 69,


### PR DESCRIPTION
## What & why

The macOS sidebar's purple **Intent** and orange **Waiting** blocks were often paragraph-long and unreadable at a glance. Both now render as a terse **~70-char one-line headline**, with the full text preserved on hover. Closes #759.

## How it works

Per block: `source = agent marker if present else raw text` → `headline = compactor.Compact(source, kind)`. The full text stays in the domain fields for the tooltip.

- **Compaction port + adapters** — `ports/outbound/compaction.go` (`CompactKind` + `TextCompactor`); `adapters/outbound/compaction/` ships `NoopCompactor` (identity) and the default `DeterministicCompactor` (strip code fences / HTML-comment markers / `<system-reminder>` tags → question sentence or first intent sentence → strip inline markdown → collapse whitespace → cap ~70 runes with `…`). A future LLM adapter swaps in with no caller changes.
- **`irrlicht-question` marker** — mirrors `irrlicht-summary`: new `taskquestion_scan.go`, scanned in the claudecode parser's text-block **and** tool_use paths, accumulated latest-wins in the tailer, persisted in the ledger, surfaced on `SessionMetrics`. Its managed instruction block installs under the same instructions consent toggle; the summary block was tightened to a "short one-liner" target.
- **Converter seam** — the shared tailer→domain conversion is now `MetricsConverter{compactor}`. The live metrics adapter injects `DeterministicCompactor`; replay/engine keep the Noop-backed free `TailerToDomain` wrapper so those call sites are unchanged. It **no longer overwrites `LastAssistantText`** with the question snippet — the full text is kept for the tooltip and the waiting classifier (verdict unchanged: the snippet was idempotent under `ExtractQuestionSnippet`), and the snippet logic moved into `QuestionHeadline`.
- **Surfaced fields + UI** — domain gains `IntentHeadline`/`QuestionHeadline` (threaded through `MergeMetrics`); macOS `SessionState`/`SessionListView` render the headlines (`lineLimit(1)`, tail truncation) with the full text as the `.tooltip`. Web prefers `question_headline`.

## Notable decisions / deviations from the issue plan

- **Replay goldens were *not* unaffected** (the issue assumed they were). The curated replay struct includes `last_assistant_text_head`, so dropping the snippet-overwrite changes it from the question snippet to the more-correct full-text head. Regenerated 5 regression goldens (claudecode + pi); the diff is **only** that field.
- **Web** (`platforms/web/irrlicht.js`) — the issue scoped web out, but its waiting block uses `-webkit-line-clamp` which clips the *tail*; with `last_assistant_text` now the full tail, the question (at the end) would be clipped off. A 2-line change makes web prefer `question_headline` (full text kept on hover), preventing a regression this change would otherwise introduce.
- **Question-marker hook delivery is intentionally dropped** — the question rides end-of-turn assistant prose, not a tool-input carrier, so the PreToolUse hook path doesn't ingest it; the transcript text-block scan delivers it and the deterministic fallback covers the no-marker case.
- **No macOS snapshot regeneration needed** — for the existing short fixtures the new render (`lineLimit 3→1`, tail truncation, `headline ?? full` binding) is byte-identical, so the committed reference PNGs still pass (verified). Two unrelated snapshot tests (`testFixture_AntigravityGhost`, `testGhostRow_PID0_NilMetrics`) fail on this macOS 26 environment; they render ghost rows with `nil`/ready metrics that never touch the changed `summaryBlock`, so the mismatch is pre-existing/environmental.

## Open risk to confirm before/at merge

The `irrlicht-question` instruction block asks the agent to emit the marker on its **final response line** (no Bash call follows a question). This needs a live check that the HTML comment renders invisibly in the Claude Code terminal — the eta block already relies on response-text comments as a fallback, so precedent is good, and the feature degrades gracefully (the deterministic fallback works with no marker at all). If it's visible, dropping the block is a one-line revert.

## Verification

- `go build ./core/...`; `go test ./core/... -race` (services with `-p 1` for the documented pre-existing flake) — green
- factory tests, `of validate`, `tools/replay-fixtures.sh`, replay goldens — green
- `platforms/web` `npm test` — 105 passing
- `swift build --arch arm64`; `swift test --arch arm64` — 180/182 (2 pre-existing ghost-row snapshot mismatches, unrelated)
- New unit tests: question scanner (9 cases), deterministic + noop compactor, converter marker-preference / headline-vs-full separation, question instruction block

🤖 Generated with [Claude Code](https://claude.com/claude-code)