### PR TITLE
feat(history): Phase 3 — concurrent-agents chart from recordings (#751)

### DIFF
--- a/core/adapters/outbound/filesystem/concurrency_tracker.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker.go
@@ -1,0 +1,378 @@
+package filesystem
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// concurrencyUnknownProject labels sessions whose recordings carry no working
+// directory (so no project can be derived). Matches the handler's "unknown"
+// contributor label for cost.
+const concurrencyUnknownProject = "unknown"
+
+// ConcurrencyTracker reconstructs concurrent-agent counts over time from the
+// lifecycle recordings irrlichd writes under <dataDir>/recordings when started
+// with --record (issue #751, History tab Phase 3). It is read-only — it never
+// writes the recordings dir — and is the recordings analog of CostTracker's
+// CostSeries over the cost dir.
+type ConcurrencyTracker struct {
+	dir string
+}
+
+// NewConcurrencyTrackerWithDir returns a reader rooted at the given recordings
+// directory. The daemon passes the same dir the recorder writes to (see
+// resolveRecordingsDir), so reads and writes can't drift.
+func NewConcurrencyTrackerWithDir(dir string) *ConcurrencyTracker {
+	return &ConcurrencyTracker{dir: dir}
+}
+
+// Dir returns the recordings directory this reader scans.
+func (t *ConcurrencyTracker) Dir() string { return t.dir }
+
+// stateChange is one (timestamp, state) point in a session's reconstructed
+// state timeline.
+type stateChange struct {
+	ts    int64
+	state string // working|waiting|ready
+}
+
+// sessionTimeline accumulates one session's state transitions and project label
+// while recordings are scanned. transitions are appended in scan order and
+// sorted by ts before use; lastEventTS bounds a session that is still active at
+// the end of the recording (no process_exited / transcript_removed) so it isn't
+// counted as alive forever.
+type sessionTimeline struct {
+	project     string
+	lastEventTS int64
+	transitions []stateChange
+}
+
+// interval is a half-open [enter, exit) span during which a session is active
+// (working or waiting). A session contributes +1 to concurrency over it.
+type interval struct {
+	enter int64
+	exit  int64
+}
+
+// concurrencyActive reports whether a state counts toward concurrency: an agent
+// is "concurrent" while working or waiting, and stops once it goes ready
+// (process exited / cancelled / transcript removed) — the three-state model
+// read literally (#751).
+func concurrencyActive(state string) bool {
+	return state == session.StateWorking || state == session.StateWaiting
+}
+
+// concurrencyProject derives a project label for an event from its working
+// directory (basename), matching how the cost chart keys projects. State and
+// process events carry no CWD, so the label is sourced from the session's
+// transcript events (which do) via "last non-empty wins" in loadTimelines.
+func concurrencyProject(ev lifecycle.Event) string {
+	if ev.CWD != "" {
+		return filepath.Base(ev.CWD)
+	}
+	return ""
+}
+
+// AgentsSeries reconstructs a per-project concurrent-agents time series over
+// [Start, End) bucketed into BucketSeconds-wide buckets, plus the exact
+// peak/average/current total concurrency. One pass over every recording file.
+// A missing recordings dir (the common case — --record is opt-in) yields an
+// empty result, never an error.
+func (t *ConcurrencyTracker) AgentsSeries(q outbound.SeriesQuery) (*outbound.ConcurrencyResult, error) {
+	start, end, bucketSeconds := q.Start, q.End, q.BucketSeconds
+	if bucketSeconds <= 0 || end <= start {
+		return emptyConcurrencyResult(start, end, bucketSeconds), nil
+	}
+	// Coarsen the bucket if the span would otherwise blow past the ceiling,
+	// keeping the allocation and payload bounded — same rule as CostSeries.
+	if span := end - start; span/bucketSeconds+1 > maxSeriesBuckets {
+		bucketSeconds = (span + maxSeriesBuckets - 1) / maxSeriesBuckets
+	}
+	n := int((end - start + bucketSeconds - 1) / bucketSeconds)
+	out := &outbound.ConcurrencyResult{
+		Start:         start,
+		End:           end,
+		BucketSeconds: bucketSeconds,
+		BucketStarts:  make([]int64, n),
+		ByKey:         map[string][]float64{},
+		PeakByKey:     map[string]float64{},
+	}
+	for i := range out.BucketStarts {
+		out.BucketStarts[i] = start + int64(i)*bucketSeconds
+	}
+
+	timelines, err := t.loadTimelines()
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect each session's active intervals, clamped to the window. Group by
+	// project for the per-bucket peak series, and keep a flat list for the exact
+	// total peak/average. Current counts sessions active strictly across End
+	// (their real, pre-clamp interval spans "now").
+	byProject := map[string][]interval{}
+	var all []interval
+	for sid, tl := range timelines {
+		if !concurrencyScopeMatches(q, sid, tl.project) {
+			continue
+		}
+		project := tl.project
+		if project == "" {
+			project = concurrencyUnknownProject
+		}
+		for _, iv := range tl.activeIntervals() {
+			if iv.enter < end && iv.exit > end {
+				out.Current++ // spans the window end → still active "now"
+			}
+			a, b := iv.enter, iv.exit
+			if a < start {
+				a = start
+			}
+			if b > end {
+				b = end
+			}
+			if b <= a {
+				continue
+			}
+			cl := interval{a, b}
+			byProject[project] = append(byProject[project], cl)
+			all = append(all, cl)
+		}
+	}
+
+	// Per-project per-bucket peak concurrency.
+	for project, ivs := range byProject {
+		dst := make([]float64, n)
+		peak := 0.0
+		sweepIntervals(ivs, func(t0, t1 int64, v float64) {
+			if v > peak {
+				peak = v
+			}
+			lo := int((t0 - start) / bucketSeconds)
+			hi := int((t1 - 1 - start) / bucketSeconds)
+			if lo < 0 {
+				lo = 0
+			}
+			if hi >= n {
+				hi = n - 1
+			}
+			for i := lo; i <= hi; i++ {
+				if v > dst[i] {
+					dst[i] = v
+				}
+			}
+		})
+		out.ByKey[project] = dst
+		out.PeakByKey[project] = peak
+	}
+
+	// Exact total peak (max simultaneous across all projects) and time-weighted
+	// average over [start, end).
+	integral := 0.0
+	sweepIntervals(all, func(t0, t1 int64, v float64) {
+		if v > out.Peak {
+			out.Peak = v
+		}
+		integral += v * float64(t1-t0)
+	})
+	if end > start {
+		out.Average = integral / float64(end-start)
+	}
+	return out, nil
+}
+
+// emptyConcurrencyResult returns a valid zero-data result so the dashboard
+// renders a clean empty state instead of erroring.
+func emptyConcurrencyResult(start, end, bucketSeconds int64) *outbound.ConcurrencyResult {
+	return &outbound.ConcurrencyResult{
+		Start:         start,
+		End:           end,
+		BucketSeconds: bucketSeconds,
+		BucketStarts:  []int64{},
+		ByKey:         map[string][]float64{},
+		PeakByKey:     map[string]float64{},
+	}
+}
+
+// concurrencyScopeMatches applies a drilldown scope to a session. Recordings
+// carry only project and session id, so a scope on project/session filters
+// directly; a scope on an axis recordings don't carry (branch/provider/model)
+// matches nothing rather than silently returning everything.
+func concurrencyScopeMatches(q outbound.SeriesQuery, sessionID, project string) bool {
+	switch q.ScopeField {
+	case "":
+		return true
+	case "project":
+		return project == q.ScopeValue
+	case "session":
+		return sessionID == q.ScopeValue
+	default:
+		return false
+	}
+}
+
+// activeIntervals reconstructs a session's [enter, exit) active spans from its
+// state timeline. A session is active while working or waiting and inactive
+// while ready. A session still active at its last recorded event (no terminator)
+// is bounded at that last event — "last known alive" — so a daemon that died
+// mid-session doesn't leave a session counted as alive forever. The bound is
+// needed for the common idle case too: a session waiting for input emits no
+// further events, so without it that session's whole bounded span would drop.
+// (lastEventTS >= last.ts always, since every transition is itself an event.)
+func (tl *sessionTimeline) activeIntervals() []interval {
+	if len(tl.transitions) == 0 {
+		return nil
+	}
+	tr := append([]stateChange(nil), tl.transitions...)
+	sort.SliceStable(tr, func(i, j int) bool { return tr[i].ts < tr[j].ts })
+	if last := tr[len(tr)-1]; concurrencyActive(last.state) {
+		tr = append(tr, stateChange{tl.lastEventTS, session.StateReady})
+	}
+
+	var ivs []interval
+	activeStart := int64(-1)
+	for _, c := range tr {
+		if concurrencyActive(c.state) {
+			if activeStart < 0 {
+				activeStart = c.ts
+			}
+			continue
+		}
+		if activeStart >= 0 {
+			if c.ts > activeStart {
+				ivs = append(ivs, interval{activeStart, c.ts})
+			}
+			activeStart = -1
+		}
+	}
+	return ivs
+}
+
+// sweepIntervals walks a set of half-open intervals in time order and calls fn
+// for each maximal [t0, t1) segment with the overlap count active during it.
+// Zero-overlap gaps are skipped. At a shared timestamp, exits (-1) are applied
+// before entries (+1) so abutting intervals ([a,T) then [T,b)) don't read as
+// overlapping.
+func sweepIntervals(ivs []interval, fn func(t0, t1 int64, value float64)) {
+	type ev struct {
+		ts int64
+		d  int
+	}
+	evs := make([]ev, 0, len(ivs)*2)
+	for _, iv := range ivs {
+		if iv.exit <= iv.enter {
+			continue
+		}
+		evs = append(evs, ev{iv.enter, +1}, ev{iv.exit, -1})
+	}
+	if len(evs) == 0 {
+		return
+	}
+	sort.Slice(evs, func(i, j int) bool {
+		if evs[i].ts != evs[j].ts {
+			return evs[i].ts < evs[j].ts
+		}
+		return evs[i].d < evs[j].d // -1 before +1 at equal ts
+	})
+	cur := 0
+	prev := evs[0].ts
+	for _, e := range evs {
+		if e.ts > prev {
+			if cur > 0 {
+				fn(prev, e.ts, float64(cur))
+			}
+			prev = e.ts
+		}
+		cur += e.d
+	}
+}
+
+// loadTimelines scans every recording file once and groups events by session
+// into reconstructed state timelines. The project label is sourced from
+// whichever of a session's events carry a CWD ("last non-empty wins").
+func (t *ConcurrencyTracker) loadTimelines() (map[string]*sessionTimeline, error) {
+	timelines := map[string]*sessionTimeline{}
+	entries, err := os.ReadDir(t.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return timelines, nil
+		}
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		if err := scanRecordingFile(filepath.Join(t.dir, e.Name()), func(ev lifecycle.Event) {
+			tl := timelines[ev.SessionID]
+			if tl == nil {
+				tl = &sessionTimeline{}
+				timelines[ev.SessionID] = tl
+			}
+			ts := ev.Timestamp.Unix()
+			if ts > tl.lastEventTS {
+				tl.lastEventTS = ts
+			}
+			if p := concurrencyProject(ev); p != "" {
+				tl.project = p
+			}
+			switch ev.Kind {
+			case lifecycle.KindStateTransition:
+				if session.IsCanonicalState(ev.NewState) {
+					tl.transitions = append(tl.transitions, stateChange{ts, ev.NewState})
+				}
+			case lifecycle.KindProcessExited, lifecycle.KindTranscriptRemoved:
+				// A terminated session is ready, even if no state_transition
+				// to ready was recorded for it.
+				tl.transitions = append(tl.transitions, stateChange{ts, session.StateReady})
+			}
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return timelines, nil
+}
+
+// scanRecordingFile streams one recording file, invoking perEvent for each
+// parsed lifecycle event. A missing file and malformed lines are skipped — a
+// partial file shouldn't fail the whole query. Same skip policy as scanCostFile,
+// but with an 8 MB max line like the replay reader (loadAllLifecycleEvents):
+// recordings interleave every session, so lines and files run larger than the
+// per-project cost files.
+func scanRecordingFile(path string, perEvent func(lifecycle.Event)) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev lifecycle.Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			continue
+		}
+		perEvent(ev)
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+}

--- a/core/adapters/outbound/filesystem/concurrency_tracker_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_test.go
@@ -1,0 +1,303 @@
+package filesystem
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// seedRecording writes lifecycle events to <dir>/<name> in the JSONL shape the
+// recorder produces, so AgentsSeries reads them back the same way it reads a
+// real recording.
+func seedRecording(t *testing.T, dir, name string, events []lifecycle.Event) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	f, err := os.Create(filepath.Join(dir, name))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, ev := range events {
+		if err := enc.Encode(ev); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}
+}
+
+// transcriptNew is a session-appearance event carrying the CWD (the source of
+// the project label).
+func transcriptNew(seq, ts int64, sid, cwd string) lifecycle.Event {
+	return lifecycle.Event{Seq: seq, Timestamp: time.Unix(ts, 0), Kind: lifecycle.KindTranscriptNew, SessionID: sid, CWD: cwd}
+}
+
+// activity is a transcript-activity event (no state change), used to push a
+// session's last-event timestamp forward.
+func activity(seq, ts int64, sid, cwd string) lifecycle.Event {
+	return lifecycle.Event{Seq: seq, Timestamp: time.Unix(ts, 0), Kind: lifecycle.KindTranscriptActivity, SessionID: sid, CWD: cwd}
+}
+
+func transition(seq, ts int64, sid, newState string) lifecycle.Event {
+	return lifecycle.Event{Seq: seq, Timestamp: time.Unix(ts, 0), Kind: lifecycle.KindStateTransition, SessionID: sid, NewState: newState}
+}
+
+func processExited(seq, ts int64, sid string) lifecycle.Event {
+	return lifecycle.Event{Seq: seq, Timestamp: time.Unix(ts, 0), Kind: lifecycle.KindProcessExited, SessionID: sid}
+}
+
+func approxEq(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+// TestAgentsSeries_SingleSession: one session active [100,200) in a 300-wide
+// window bucketed at 60s lands its peak (1) in the buckets it overlaps, with an
+// exact time-weighted average and no lingering "current".
+func TestAgentsSeries_SingleSession(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projX"),
+		transition(2, 100, "s1", session.StateWorking),
+		transition(3, 200, "s1", session.StateReady),
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.AgentsSeries(outbound.SeriesQuery{Start: 0, End: 300, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	if res.Peak != 1 {
+		t.Errorf("peak: want 1, got %v", res.Peak)
+	}
+	if res.Current != 0 {
+		t.Errorf("current: want 0 (ended before window end), got %v", res.Current)
+	}
+	if !approxEq(res.Average, 100.0/300.0) {
+		t.Errorf("average: want %.6f, got %v", 100.0/300.0, res.Average)
+	}
+	// Buckets: 0=[0,60) 1=[60,120) 2=[120,180) 3=[180,240) 4=[240,300).
+	// Interval [100,200) covers buckets 1,2,3.
+	want := []float64{0, 1, 1, 1, 0}
+	got := res.ByKey["projX"]
+	if len(got) != len(want) {
+		t.Fatalf("byKey[projX]: want len %d, got %v", len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("byKey[projX][%d]: want %v, got %v", i, want[i], got[i])
+		}
+	}
+	if res.PeakByKey["projX"] != 1 {
+		t.Errorf("peakByKey[projX]: want 1, got %v", res.PeakByKey["projX"])
+	}
+}
+
+// TestAgentsSeries_OverlapSameProject: two sessions in the same project that
+// overlap drive the total peak to 2.
+func TestAgentsSeries_OverlapSameProject(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projX"),
+		transition(2, 100, "s1", session.StateWorking),
+		transition(3, 250, "s1", session.StateReady),
+		transcriptNew(4, 140, "s2", "/home/me/projX"),
+		transition(5, 150, "s2", session.StateWorking),
+		transition(6, 300, "s2", session.StateReady),
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.AgentsSeries(outbound.SeriesQuery{Start: 0, End: 360, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	if res.Peak != 2 {
+		t.Errorf("peak: want 2 (overlap [150,250)), got %v", res.Peak)
+	}
+	if res.PeakByKey["projX"] != 2 {
+		t.Errorf("peakByKey[projX]: want 2, got %v", res.PeakByKey["projX"])
+	}
+}
+
+// TestAgentsSeries_IdleWaitingCounts: a session that finished its turn and is
+// idling in waiting — its last recorded event being the waiting transition, with
+// no later activity — still contributes its bounded active span. Regression for
+// the dangling-bound guard dropping the whole span when the trailing state is
+// active.
+func TestAgentsSeries_IdleWaitingCounts(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projX"),
+		transition(2, 100, "s1", session.StateWorking),
+		transition(3, 200, "s1", session.StateWaiting), // last event; idle thereafter
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.AgentsSeries(outbound.SeriesQuery{Start: 0, End: 300, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	if res.Peak != 1 {
+		t.Errorf("peak: want 1 (active [100,200) bounded at last event), got %v", res.Peak)
+	}
+	if res.PeakByKey["projX"] != 1 {
+		t.Errorf("peakByKey[projX]: want 1, got %v", res.PeakByKey["projX"])
+	}
+	// Last known alive at 200 < window end 300 → not counted as current.
+	if res.Current != 0 {
+		t.Errorf("current: want 0, got %v", res.Current)
+	}
+}
+
+// TestAgentsSeries_ExitAtEndNotCurrent: a session that goes ready exactly at the
+// window end is not "current" — it terminated, it isn't active now.
+func TestAgentsSeries_ExitAtEndNotCurrent(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projX"),
+		transition(2, 100, "s1", session.StateWorking),
+		transition(3, 300, "s1", session.StateReady), // ready exactly at End
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.AgentsSeries(outbound.SeriesQuery{Start: 0, End: 300, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	if res.Current != 0 {
+		t.Errorf("current: want 0 (terminated at End), got %v", res.Current)
+	}
+	if res.Peak != 1 {
+		t.Errorf("peak: want 1, got %v", res.Peak)
+	}
+}
+
+// TestAgentsSeries_TwoProjects: overlapping sessions in different projects sum
+// to a total peak of 2 while each project's own peak stays 1.
+func TestAgentsSeries_TwoProjects(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projA"),
+		transition(2, 100, "s1", session.StateWorking),
+		transition(3, 250, "s1", session.StateReady),
+		transcriptNew(4, 140, "s2", "/home/me/projB"),
+		transition(5, 150, "s2", session.StateWorking),
+		transition(6, 300, "s2", session.StateReady),
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.AgentsSeries(outbound.SeriesQuery{Start: 0, End: 360, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	if res.Peak != 2 {
+		t.Errorf("total peak: want 2, got %v", res.Peak)
+	}
+	if res.PeakByKey["projA"] != 1 || res.PeakByKey["projB"] != 1 {
+		t.Errorf("per-project peaks: want 1/1, got %v/%v", res.PeakByKey["projA"], res.PeakByKey["projB"])
+	}
+}
+
+// TestAgentsSeries_CurrentReachesEnd: a session still active at the window's end
+// (no exit recorded, but later activity) is bounded at its last event and, when
+// that reaches the window end, counts toward "current".
+func TestAgentsSeries_CurrentReachesEnd(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 240, "s1", "/home/me/projX"),
+		transition(2, 250, "s1", session.StateWorking),
+		activity(3, 350, "s1", "/home/me/projX"), // last event after window end
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.AgentsSeries(outbound.SeriesQuery{Start: 0, End: 300, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	if res.Peak != 1 {
+		t.Errorf("peak: want 1, got %v", res.Peak)
+	}
+	if res.Current != 1 {
+		t.Errorf("current: want 1 (active at window end), got %v", res.Current)
+	}
+}
+
+// TestAgentsSeries_ProcessExitEndsConcurrency: a process_exited event ends the
+// active interval even with no explicit state_transition to ready.
+func TestAgentsSeries_ProcessExitEndsConcurrency(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projX"),
+		transition(2, 100, "s1", session.StateWorking),
+		processExited(3, 160, "s1"),
+		activity(4, 400, "s1", "/home/me/projX"), // stray late event must not revive it
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.AgentsSeries(outbound.SeriesQuery{Start: 0, End: 480, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	if res.Peak != 1 {
+		t.Errorf("peak: want 1, got %v", res.Peak)
+	}
+	if res.Current != 0 {
+		t.Errorf("current: want 0 (exited at 160), got %v", res.Current)
+	}
+	if !approxEq(res.Average, 60.0/480.0) {
+		t.Errorf("average: want %.6f (active [100,160)), got %v", 60.0/480.0, res.Average)
+	}
+}
+
+// TestAgentsSeries_Empty: a missing recordings dir yields a valid empty result,
+// not an error (the common case — --record is opt-in).
+func TestAgentsSeries_Empty(t *testing.T) {
+	tr := NewConcurrencyTrackerWithDir(filepath.Join(t.TempDir(), "recordings"))
+	res, err := tr.AgentsSeries(outbound.SeriesQuery{Start: 0, End: 300, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	if res.Peak != 0 || res.Average != 0 || res.Current != 0 {
+		t.Errorf("want zero summary, got peak=%v avg=%v current=%v", res.Peak, res.Average, res.Current)
+	}
+	if len(res.ByKey) != 0 || len(res.PeakByKey) != 0 {
+		t.Errorf("want empty maps, got byKey=%v peakByKey=%v", res.ByKey, res.PeakByKey)
+	}
+	if res.BucketStarts == nil {
+		t.Error("bucket_starts should be a non-nil slice")
+	}
+}
+
+// TestAgentsSeries_ScopeProject: a project scope filters to that project's
+// sessions only.
+func TestAgentsSeries_ScopeProject(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projA"),
+		transition(2, 100, "s1", session.StateWorking),
+		transition(3, 250, "s1", session.StateReady),
+		transcriptNew(4, 90, "s2", "/home/me/projB"),
+		transition(5, 100, "s2", session.StateWorking),
+		transition(6, 250, "s2", session.StateReady),
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.AgentsSeries(outbound.SeriesQuery{Start: 0, End: 360, BucketSeconds: 60, ScopeField: "project", ScopeValue: "projA"})
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	if res.Peak != 1 {
+		t.Errorf("scoped peak: want 1, got %v", res.Peak)
+	}
+	if _, ok := res.PeakByKey["projB"]; ok {
+		t.Errorf("projB should be filtered out, got %v", res.PeakByKey)
+	}
+	if res.PeakByKey["projA"] != 1 {
+		t.Errorf("peakByKey[projA]: want 1, got %v", res.PeakByKey["projA"])
+	}
+}

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -236,8 +236,9 @@ func providerCostsByProvider(byTf map[string]map[string]float64) map[string]map[
 // History tab (issues #369 / #750). Phase 1 served chart=cost grouped by
 // project; Phase 2 adds the tokens/models/providers chart types and the
 // branch/provider/model/session group axes plus drilldown scoping, all computed
-// from the cost snapshot files via CostTracker.CostSeries. chart=agents remains
-// a Phase 3 (#751) 501 stub.
+// from the cost snapshot files via CostTracker.CostSeries. Phase 3 (#751) adds
+// chart=agents, a concurrent-agents series reconstructed from the lifecycle
+// recordings via ConcurrencyReader.AgentsSeries; chart=state stays a 501 stub.
 
 type historyPoint struct {
 	TS int64 `json:"ts"`
@@ -260,6 +261,16 @@ type historyTokenSplit struct {
 	Input  float64 `json:"input"`
 	Output float64 `json:"output"`
 	Cache  float64 `json:"cache"`
+}
+
+// historyConcurrency is the concurrent-agents summary, present only for
+// chart=agents (#751). Peak is the window's max simultaneous agents, Average the
+// time-weighted mean, Current the count still active at the window's end edge.
+// Drives the agents side panel.
+type historyConcurrency struct {
+	Peak    float64 `json:"peak"`
+	Average float64 `json:"average"`
+	Current float64 `json:"current"`
 }
 
 type historyForecastPoint struct {
@@ -287,6 +298,7 @@ type historyResponse struct {
 	TopContributors []historyContributor `json:"top_contributors"`
 	Forecast        *historyForecast     `json:"forecast,omitempty"`
 	TokenSplit      *historyTokenSplit   `json:"token_split,omitempty"` // chart=tokens only
+	Concurrency     *historyConcurrency  `json:"concurrency,omitempty"` // chart=agents only
 	Scope           string               `json:"scope,omitempty"`       // active drilldown filter "field:value"
 }
 
@@ -330,7 +342,7 @@ type historySessionLister interface {
 // &bucket=&forecast=&forecast_buckets=. Range is a trailing window
 // (day|week|month|year), a calendar shorthand (this-month), or an explicit
 // start&end (unix seconds). Bucket granularity is downsampled at read time.
-func handleGetHistory(tracker outbound.CostTracker, sessions historySessionLister) http.HandlerFunc {
+func handleGetHistory(tracker outbound.CostTracker, sessions historySessionLister, concurrency outbound.ConcurrencyReader) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 
@@ -344,6 +356,10 @@ func handleGetHistory(tracker outbound.CostTracker, sessions historySessionListe
 		case "yield":
 			// implemented (#373) — handled after range resolution below
 		case "agents":
+			// implemented (Phase 3) — handled after range resolution below
+		case "state":
+			// time-in-state is the issue's optional second half (#751); the
+			// reconstruction exists but no chart is wired yet.
 			writeHistoryNotImplemented(w, "chart="+chart, 3)
 			return
 		default:
@@ -365,6 +381,7 @@ func handleGetHistory(tracker outbound.CostTracker, sessions historySessionListe
 
 		// chart picks the measured metric; models/providers are presets that
 		// pin the stacking axis to that dimension (one-click "cost by X").
+		// agents is reconstructed per project only.
 		metric := "cost"
 		switch chart {
 		case "tokens":
@@ -373,6 +390,8 @@ func handleGetHistory(tracker outbound.CostTracker, sessions historySessionListe
 			group = "model"
 		case "providers":
 			group = "provider"
+		case "agents":
+			group = "project"
 		}
 
 		scopeField, scopeValue := parseHistoryScope(q.Get("scope"))
@@ -396,6 +415,33 @@ func handleGetHistory(tracker outbound.CostTracker, sessions historySessionListe
 		}
 
 		bucketSeconds := historyBucketSeconds(q, end-start)
+
+		if chart == "agents" {
+			var cr *outbound.ConcurrencyResult
+			if concurrency != nil {
+				c, err := concurrency.AgentsSeries(outbound.SeriesQuery{
+					Start:         start,
+					End:           end,
+					BucketSeconds: bucketSeconds,
+					Group:         group,
+					ScopeField:    scopeField,
+					ScopeValue:    scopeValue,
+				})
+				if err != nil {
+					http.Error(w, "internal error", http.StatusInternalServerError)
+					return
+				}
+				cr = c
+			}
+			if cr == nil {
+				// No reader (recordings dir unresolved): empty-but-valid payload.
+				cr = &outbound.ConcurrencyResult{Start: start, End: end, BucketSeconds: bucketSeconds, BucketStarts: []int64{}, ByKey: map[string][]float64{}, PeakByKey: map[string]float64{}}
+			}
+			resp := buildAgentsResponse(rangeKey, scopeEcho, cr)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
 
 		var series *outbound.CostSeriesResult
 		if tracker != nil {
@@ -569,6 +615,60 @@ func buildHistoryResponse(rangeKey, chart, group, scope string, s *outbound.Cost
 	// Forecast projects USD spend; it isn't meaningful for token counts.
 	if chart != "tokens" && historyForecastEnabled(q) && resp.Total > 0 && len(s.BucketStarts) > 0 {
 		resp.Forecast = computeLinearForecast(s.BucketStarts, s.BucketSeconds, resp.Total, historyForecastBuckets(q, len(s.BucketStarts)))
+	}
+	return resp
+}
+
+// buildAgentsResponse flattens a concurrency reconstruction into the history
+// envelope (#751). It reuses the same sparse [{ts,project,value}] series +
+// bucket_starts the cost chart's canvas renderer consumes (so the frontend
+// renderer is shared untouched), ranks top contributors by each project's peak
+// concurrency, and attaches the peak/average/current summary the agents side
+// panel shows. Total carries the exact whole-window peak (the side panel's
+// headline). No forecast or token split — neither is meaningful for a count.
+func buildAgentsResponse(rangeKey, scope string, c *outbound.ConcurrencyResult) historyResponse {
+	resp := historyResponse{
+		Range:           rangeKey,
+		Chart:           "agents",
+		Group:           "project",
+		Start:           c.Start,
+		End:             c.End,
+		BucketSeconds:   c.BucketSeconds,
+		BucketStarts:    c.BucketStarts,
+		Total:           c.Peak,
+		Series:          []historyPoint{},
+		TopContributors: []historyContributor{},
+		Concurrency:     &historyConcurrency{Peak: c.Peak, Average: c.Average, Current: c.Current},
+		Scope:           scope,
+	}
+
+	// Deterministic key order: peak desc, then name.
+	keys := make([]string, 0, len(c.PeakByKey))
+	for k := range c.PeakByKey {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if c.PeakByKey[keys[i]] != c.PeakByKey[keys[j]] {
+			return c.PeakByKey[keys[i]] > c.PeakByKey[keys[j]]
+		}
+		return keys[i] < keys[j]
+	})
+
+	for _, k := range keys {
+		for i, v := range c.ByKey[k] {
+			if i >= len(c.BucketStarts) {
+				break
+			}
+			if v != 0 {
+				resp.Series = append(resp.Series, historyPoint{TS: c.BucketStarts[i], Project: k, Value: v})
+			}
+		}
+	}
+	for i, k := range keys {
+		if i >= 5 {
+			break
+		}
+		resp.TopContributors = append(resp.TopContributors, historyContributor{Label: k, Value: c.PeakByKey[k]})
 	}
 	return resp
 }

--- a/core/cmd/irrlichd/history_endpoint_test.go
+++ b/core/cmd/irrlichd/history_endpoint_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"irrlicht/core/adapters/outbound/filesystem"
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
 )
 
 // seedCostRows appends raw snapshot rows to <dir>/<project>.jsonl in the
@@ -36,7 +38,7 @@ func doHistory(t *testing.T, tracker *filesystem.CostTracker, query string) (*ht
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?"+query, nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(tracker, nil)(rec, req)
+	handleGetHistory(tracker, nil, nil)(rec, req)
 	var resp historyResponse
 	if rec.Code == http.StatusOK {
 		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
@@ -111,21 +113,87 @@ func TestHandleGetHistory_CustomRange(t *testing.T) {
 	}
 }
 
-// TestHandleGetHistory_AgentsStub: chart=agents is still Phase 3 (#751).
-func TestHandleGetHistory_AgentsStub(t *testing.T) {
-	tr := filesystem.NewCostTrackerWithDir(filepath.Join(t.TempDir(), "cost"))
+// seedRecording writes lifecycle events to <dir>/<name> in the recorder's JSONL
+// shape, so the concurrency reader reconstructs concurrency from them.
+func seedRecording(t *testing.T, dir, name string, events []lifecycle.Event) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	f, err := os.Create(filepath.Join(dir, name))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, ev := range events {
+		if err := enc.Encode(ev); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}
+}
+
+// TestHandleGetHistory_AgentsConcurrency: chart=agents now reconstructs a
+// concurrent-agents series from recordings (no more 501), with the peak/average/
+// current summary and top concurrent projects in the side panel.
+func TestHandleGetHistory_AgentsConcurrency(t *testing.T) {
+	recDir := filepath.Join(t.TempDir(), "recordings")
+	now := time.Now().Unix()
+	at := func(sec int64) time.Time { return time.Unix(now-sec, 0) }
+	seedRecording(t, recDir, "run.jsonl", []lifecycle.Event{
+		{Seq: 1, Timestamp: at(3600), Kind: lifecycle.KindTranscriptNew, SessionID: "s1", CWD: "/home/me/projX"},
+		{Seq: 2, Timestamp: at(3500), Kind: lifecycle.KindStateTransition, SessionID: "s1", NewState: session.StateWorking},
+		{Seq: 3, Timestamp: at(1800), Kind: lifecycle.KindStateTransition, SessionID: "s1", NewState: session.StateReady},
+	})
+	cost := filesystem.NewCostTrackerWithDir(filepath.Join(t.TempDir(), "cost"))
+	conc := filesystem.NewConcurrencyTrackerWithDir(recDir)
+
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?range=day&chart=agents", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(tr, nil)(rec, req)
-	if rec.Code != http.StatusNotImplemented {
-		t.Fatalf("chart=agents: want 501, got %d", rec.Code)
+	handleGetHistory(cost, nil, conc)(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("chart=agents: want 200, got %d (%s)", rec.Code, rec.Body.String())
 	}
-	var body map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+	var resp historyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if body["phase"] != float64(3) {
-		t.Errorf("want phase 3, got %v", body["phase"])
+	if resp.Chart != "agents" || resp.Group != "project" {
+		t.Errorf("envelope: chart=%q group=%q", resp.Chart, resp.Group)
+	}
+	if resp.Concurrency == nil || resp.Concurrency.Peak != 1 {
+		t.Errorf("concurrency summary: want peak 1, got %+v", resp.Concurrency)
+	}
+	if len(resp.TopContributors) != 1 || resp.TopContributors[0].Label != "projX" {
+		t.Errorf("top concurrent projects: want [projX], got %+v", resp.TopContributors)
+	}
+	if resp.Forecast != nil || resp.TokenSplit != nil {
+		t.Errorf("agents chart should carry neither forecast nor token_split, got %+v / %+v", resp.Forecast, resp.TokenSplit)
+	}
+	if len(resp.Series) == 0 {
+		t.Error("want a non-empty concurrency series")
+	}
+}
+
+// TestHandleGetHistory_AgentsEmpty: no recordings (the common case — --record is
+// opt-in) returns a clean empty payload, not an error.
+func TestHandleGetHistory_AgentsEmpty(t *testing.T) {
+	conc := filesystem.NewConcurrencyTrackerWithDir(filepath.Join(t.TempDir(), "recordings"))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?range=day&chart=agents", nil)
+	rec := httptest.NewRecorder()
+	handleGetHistory(nil, nil, conc)(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty agents: want 200, got %d", rec.Code)
+	}
+	var resp historyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Concurrency == nil || resp.Concurrency.Peak != 0 {
+		t.Errorf("want zero concurrency summary, got %+v", resp.Concurrency)
+	}
+	if len(resp.Series) != 0 || resp.Series == nil {
+		t.Errorf("want non-nil empty series, got %+v", resp.Series)
 	}
 }
 
@@ -275,7 +343,7 @@ func TestHandleGetHistory_BadRequests(t *testing.T) {
 	for _, q := range []string{"chart=bogus", "group=bogus", "range=bogus", "start=abc&end=def", "start=2000&end=1000"} {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/history?"+q, nil)
 		rec := httptest.NewRecorder()
-		handleGetHistory(tr, nil)(rec, req)
+		handleGetHistory(tr, nil, nil)(rec, req)
 		if rec.Code != http.StatusBadRequest {
 			t.Errorf("%q: want 400, got %d", q, rec.Code)
 		}
@@ -285,7 +353,7 @@ func TestHandleGetHistory_BadRequests(t *testing.T) {
 func TestHandleGetHistory_NilTrackerEmpty(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?range=week", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, nil)(rec, req)
+	handleGetHistory(nil, nil, nil)(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("nil tracker: want 200, got %d", rec.Code)
 	}

--- a/core/cmd/irrlichd/history_yield_endpoint_test.go
+++ b/core/cmd/irrlichd/history_yield_endpoint_test.go
@@ -82,7 +82,7 @@ func TestHandleGetHistory_YieldEndpoint(t *testing.T) {
 	}}
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=yield&range=day", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, lister)(rec, req)
+	handleGetHistory(nil, lister, nil)(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -497,8 +497,12 @@ func main() {
 		}))
 
 	// History tab analytics (issue #369): trailing/calendar/custom-range cost
-	// series + linear forecast, computed from the cost snapshot files.
-	mux.HandleFunc("GET /api/v1/history", handleGetHistory(costTracker, cachedRepo))
+	// series + linear forecast, computed from the cost snapshot files. #373 adds
+	// chart=yield (per-project productive-vs-reverted spend over sessions). Phase
+	// 3 (#751) adds chart=agents, a concurrent-agents series reconstructed from
+	// the lifecycle recordings (read-only; empty unless --record has been used).
+	concurrencyTracker := filesystem.NewConcurrencyTrackerWithDir(resolveRecordingsDir(sockPath))
+	mux.HandleFunc("GET /api/v1/history", handleGetHistory(costTracker, cachedRepo, concurrencyTracker))
 
 	focusService := services.NewFocusService(cachedRepo, push, logger)
 	mux.HandleFunc("POST /api/v1/sessions/{id}/focus", sessionshandler.NewFocusHandler(focusService, logger))
@@ -726,10 +730,7 @@ func main() {
 	// wins even when IRRLICHT_HOME is set, so test harnesses (e.g. the
 	// onboarding factory's record path) can pin recordings somewhere specific.
 	if recordEnabled {
-		recordingsDir := os.Getenv("IRRLICHT_RECORDINGS_DIR")
-		if recordingsDir == "" {
-			recordingsDir = filepath.Join(filepath.Dir(sockPath), "recordings")
-		}
+		recordingsDir := resolveRecordingsDir(sockPath)
 		rec, err := recorder.NewJSONLRecorder(recordingsDir)
 		if err != nil {
 			logger.LogError("startup", "", fmt.Sprintf("failed to init lifecycle recorder: %v", err))
@@ -897,6 +898,17 @@ func stateStoreDir(sub string) string {
 		return filepath.Join(v, sub)
 	}
 	return ""
+}
+
+// resolveRecordingsDir returns where lifecycle recordings live: the
+// IRRLICHT_RECORDINGS_DIR override when set, else <dir-of-socket>/recordings
+// (IRRLICHT_HOME-relative via sockPath). Shared by the recorder writer and the
+// History tab's read-side concurrency reader (#751) so the two never drift.
+func resolveRecordingsDir(sockPath string) string {
+	if d := os.Getenv("IRRLICHT_RECORDINGS_DIR"); d != "" {
+		return d
+	}
+	return filepath.Join(filepath.Dir(sockPath), "recordings")
 }
 
 // resolveSessionRepo resolves the on-disk session store, honoring IRRLICHT_HOME

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -254,6 +254,38 @@ type CostSeriesResult struct {
 	TokenSplit    *TokenSplit          `json:"token_split,omitempty"`
 }
 
+// ConcurrencyResult is the reconstruction of concurrent-agent counts over time
+// from lifecycle recordings, returned by ConcurrencyReader.AgentsSeries (issue
+// #751, History tab Phase 3). It parallels CostSeriesResult: BucketStarts holds
+// each bucket's start (unix seconds) and ByKey maps a project to its per-bucket
+// peak concurrency (each slice has len == len(BucketStarts)). PeakByKey is each
+// project's peak concurrency over the whole window (drives the top-projects
+// list). Peak/Average/Current summarize the exact total concurrency across all
+// projects: the window maximum, the time-weighted mean, and the count of
+// sessions still active at End ("now").
+type ConcurrencyResult struct {
+	Start         int64                `json:"start"`
+	End           int64                `json:"end"`
+	BucketSeconds int64                `json:"bucket_seconds"`
+	BucketStarts  []int64              `json:"bucket_starts"`
+	ByKey         map[string][]float64 `json:"by_key"`
+	PeakByKey     map[string]float64   `json:"peak_by_key"`
+	Peak          float64              `json:"peak"`
+	Average       float64              `json:"average"`
+	Current       float64              `json:"current"`
+}
+
+// ConcurrencyReader reconstructs a concurrent-agents time series from the
+// lifecycle recordings irrlichd writes under <dataDir>/recordings when started
+// with --record (issue #751). It is the read-side counterpart to EventRecorder
+// and the recordings analog of CostTracker.CostSeries. Implementations must be
+// safe for concurrent use. AgentsSeries honors SeriesQuery's window, bucket
+// width, and scope filter; the group axis is always project (the only axis
+// recordings carry), so Group is ignored.
+type ConcurrencyReader interface {
+	AgentsSeries(q SeriesQuery) (*ConcurrencyResult, error)
+}
+
 // CostTracker persists per-session cost/token snapshots so clients can query
 // project-level cost totals over a trailing time window (last day/week/…).
 // Implementations must be safe for concurrent use.

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -194,7 +194,7 @@
             <button type="button" data-chart="tokens">Tokens</button>
             <button type="button" data-chart="models">Models</button>
             <button type="button" data-chart="providers">Providers</button>
-            <button type="button" data-chart="agents" disabled title="Available in Phase 3">Agents</button>
+            <button type="button" data-chart="agents">Agents</button>
           </div>
         </div>
         <div class="history-ctl-row">

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -2956,7 +2956,7 @@ import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collap
       '#5E5CE6', '#FFD60A', '#30D158', '#BF5AF2', '#64D2FF',
     ];
     const RANGE_LABELS = { day: 'Day', week: 'Week', month: 'Month', year: 'Year', 'this-month': 'This Month', custom: 'Custom' };
-    const CHART_LABELS = { cost: 'Cost', tokens: 'Tokens', models: 'Models', providers: 'Providers' };
+    const CHART_LABELS = { cost: 'Cost', tokens: 'Tokens', models: 'Models', providers: 'Providers', agents: 'Agents' };
     // Drilldown order: clicking a contributor scopes to it and re-groups by the
     // next finer axis. A leaf (no entry) makes that contributor non-drillable.
     const DRILL_NEXT = { project: 'branch', branch: 'session', provider: 'model', model: 'session' };
@@ -2974,9 +2974,15 @@ import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collap
       if (v >= 1e3) return (v / 1e3).toFixed(1) + 'k';
       return String(Math.round(v));
     }
+    // Integer agent count (concurrency is a whole number of sessions).
+    function histCount(v) { return String(Math.round(Number(v) || 0)); }
     // The value formatter for the active chart — dollars for cost/models/providers,
-    // token counts for tokens.
-    function histValue(v) { return historyState.chart === 'tokens' ? histTokens(v) : histDollar(v); }
+    // token counts for tokens, integer agent counts for agents.
+    function histValue(v) {
+      if (historyState.chart === 'tokens') return histTokens(v);
+      if (historyState.chart === 'agents') return histCount(v);
+      return histDollar(v);
+    }
     function histAxisLabel(ts, bucketSeconds) {
       const d = new Date(ts * 1000);
       if (bucketSeconds < 86400) {
@@ -3028,8 +3034,13 @@ import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collap
     function renderHistory() {
       renderHistoryBreadcrumb();
       const isYield = historyState.chart === 'yield';
+      // Yield counts completed sessions; agents are reconstructed from opt-in
+      // recordings — each gets its own empty caption.
       const emptyEl = document.getElementById('history-chart-empty');
-      if (emptyEl) emptyEl.textContent = isYield ? 'no completed sessions in this range yet' : 'no cost data in this range yet';
+      if (emptyEl) emptyEl.textContent =
+        isYield ? 'no completed sessions in this range yet'
+          : historyState.chart === 'agents' ? 'no recordings in this range yet'
+            : 'no cost data in this range yet';
       if (!historyState.data) {
         const wrap = document.getElementById('history-chart-wrap');
         if (wrap) wrap.classList.add('empty');
@@ -3179,6 +3190,32 @@ import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collap
       const listEl = document.getElementById('history-contrib');
       const chartLabel = CHART_LABELS[historyState.chart] || 'Total';
       if (titleEl) titleEl.textContent = chartLabel + ' · ' + (RANGE_LABELS[historyState.range] || historyState.range);
+
+      // Agents: the panel summarizes concurrency (peak headline, avg/current
+      // sub-line) and ranks the projects that ran the most agents at once. No
+      // forecast or drilldown — concurrency is reconstructed per project only.
+      if (historyState.chart === 'agents') {
+        const conc = data.concurrency || { peak: 0, average: 0, current: 0 };
+        if (totalEl) totalEl.textContent = histCount(conc.peak) + ' peak';
+        if (fcEl) fcEl.textContent = 'avg ' + (Number(conc.average) || 0).toFixed(1) + ' · now ' + histCount(conc.current);
+        if (!listEl) return;
+        listEl.innerHTML = '';
+        const projects = data.top_contributors || [];
+        if (!projects.length) {
+          appendHistoryEmpty(listEl, 'no agents in this range');
+          return;
+        }
+        projects.forEach((c, i) => {
+          const li = document.createElement('li');
+          const dot = document.createElement('span'); dot.className = 'dot'; dot.style.background = historyColorFor(i);
+          const label = document.createElement('span'); label.className = 'label'; label.textContent = c.label;
+          const val = document.createElement('span'); val.className = 'val'; val.textContent = histCount(c.value);
+          li.append(dot, label, val);
+          listEl.appendChild(li);
+        });
+        return;
+      }
+
       if (totalEl) totalEl.textContent = histValue(data.total);
       if (fcEl) {
         // Forecast is USD-only; the daemon omits it for the tokens chart.
@@ -3486,9 +3523,11 @@ import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collap
       if (!b || b.disabled) return;
       const c = b.dataset.chart;
       historyState.chart = c;
-      // models/providers are presets that pin the stacking axis.
+      // models/providers are presets that pin the stacking axis; agents is
+      // reconstructed per project only.
       if (c === 'models') historyState.group = 'model';
       else if (c === 'providers') historyState.group = 'provider';
+      else if (c === 'agents') historyState.group = 'project';
       historyState.scope = null; // a new metric resets any drilldown
       syncHistorySelectors();
       fetchHistory();
@@ -3499,9 +3538,9 @@ import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collap
       const b = e.target.closest('button[data-group]');
       if (!b || b.disabled) return;
       historyState.group = b.dataset.group;
-      // Choosing a group explicitly leaves the metric-preset charts so the
-      // chosen axis sticks.
-      if (historyState.chart === 'models' || historyState.chart === 'providers') historyState.chart = 'cost';
+      // Choosing a group explicitly leaves the metric-preset charts (and agents,
+      // which is project-only) so the chosen axis sticks on a cost breakdown.
+      if (historyState.chart === 'models' || historyState.chart === 'providers' || historyState.chart === 'agents') historyState.chart = 'cost';
       historyState.scope = null;
       syncHistorySelectors();
       fetchHistory();
@@ -3537,5 +3576,5 @@ export {
   sessionOrigin, sourceIdOf, localBareIds, isShadowedRemote,
   daemonSessionIds, structureSignature,
   pendingWizardAgents, buildPermissionAnswers, stillPendingForAgents,
-  historyQuery, histTokens, DRILL_NEXT,
+  historyQuery, histTokens, histCount, CHART_LABELS, DRILL_NEXT,
 };

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -26,6 +26,8 @@ import {
   structureSignature,
   historyQuery,
   histTokens,
+  histCount,
+  CHART_LABELS,
   DRILL_NEXT,
 } from './irrlicht.js'
 
@@ -726,5 +728,24 @@ describe('DRILL_NEXT (drilldown axis order)', () => {
     expect(DRILL_NEXT.provider).toBe('model')
     expect(DRILL_NEXT.model).toBe('session')
     expect(DRILL_NEXT.session).toBeUndefined()
+  })
+})
+
+describe('agents chart (#751 Phase 3)', () => {
+  test('chart=agents serializes with project grouping', () => {
+    const q = new URLSearchParams(historyQuery({ range: 'day', chart: 'agents', group: 'project', forecast: true, start: null, end: null, scope: null }))
+    expect(q.get('chart')).toBe('agents')
+    expect(q.get('group')).toBe('project')
+  })
+
+  test('CHART_LABELS includes Agents', () => {
+    expect(CHART_LABELS.agents).toBe('Agents')
+  })
+
+  test('histCount renders an integer agent count', () => {
+    expect(histCount(0)).toBe('0')
+    expect(histCount(2)).toBe('2')
+    expect(histCount(2.6)).toBe('3')
+    expect(histCount(undefined)).toBe('0')
   })
 })


### PR DESCRIPTION
## What

History tab **Phase 3** (#751, follow-up to #369 / #750): lights up the previously-disabled **Agents** chart by reconstructing a **concurrent-agents count over time** from the lifecycle recordings irrlichd already writes under `<dataDir>/recordings` (opt-in `--record`). No new on-disk format — Phase 3 is a pure read-side consumer.

The hard design constraint holds: **one chart + one side panel, ever** — `agents` is just another chart-type toggle.

## How

Mirrors the Phase 1/2 cost path (port → filesystem adapter → handler case → frontend branch), pointed at the recordings dir instead of the cost dir:

- **Port** `outbound.ConcurrencyReader` + `ConcurrencyResult` (parallel to `CostTracker.CostSeries` / `CostSeriesResult`), reusing the existing `SeriesQuery`.
- **Adapter** `filesystem.ConcurrencyTracker`: loads every `recordings/*.jsonl` into the existing `lifecycle.Event`, rebuilds each session's `working`/`waiting`/`ready` timeline, and computes:
  - per-project, per-bucket **peak** concurrency (the stacked area), and
  - exact total **peak / time-weighted average / current** via an interval sweep.
  - "Concurrent" = a session that is **working or waiting** (ready = process exited / cancelled — stops counting), straight from the three-state model. A session still active at its last recorded event is bounded there, so a daemon that died mid-session isn't counted as alive forever.
- **Handler**: `handleGetHistory` gains the `chart=agents` case (was a `501 {phase:3}` stub), reusing the sparse `series` + `bucket_starts` shape so the canvas renderer is untouched, plus a new `concurrency` summary block. `chart=state` (time-in-state) stays an explicit deferred 501. `main.go` adds a shared `resolveRecordingsDir` helper so the reader and recorder writer can't drift.
- **Frontend**: enable the Agents button; render the concurrency area chart and an adapted side panel (peak headline, `avg · now` sub-line, top concurrent projects); integer Y-axis formatting; chart-aware empty caption. Recordings are opt-in, so empty installs get a clean "no recordings in this range yet" state.

## Acceptance criteria

- [x] `chart=agents` returns a per-bucket concurrent-agent count series from `recordings/*.jsonl` (no more 501).
- [x] Side panel shows peak / average / current + top concurrent projects.
- [x] No recordings → clean empty state, no errors.
- [x] Respects the three-state model; no new on-disk schema.
- [x] Still exactly one chart + one side panel.
- [x] `go test ./core/... -race`, `npm test` (platforms/web), and `tools/replay-fixtures.sh` all pass.

## Out of scope / deferred

- `chart=state` (time-in-state) — the issue's explicitly-**optional** second half. The reconstruction already produces per-state durations, so it's a cheap fast-follow; left as an honest 501 with no frontend button.

## Test plan

- New `concurrency_tracker_test.go`: single session, same-project overlap → peak 2, two projects, current-at-end, process-exit ends concurrency, empty dir, project scope.
- `history_endpoint_test.go`: agents stub test flipped from 501 → 200 (series + summary + top projects), plus a no-recordings empty test.
- New vitest cases: `chart=agents` query/group, `CHART_LABELS.agents`, `histCount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)