### PR TITLE
feat(onboarding): capture & serve antigravity's conversations/<id>.db in replay (#766)

### DIFF
--- a/core/adapters/inbound/agents/antigravity/replaystore.go
+++ b/core/adapters/inbound/agents/antigravity/replaystore.go
@@ -1,0 +1,89 @@
+package antigravity
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// StageReplayStore implements tailer.ReplayStoreStager (issue #766). Live, the
+// parser locates the conversation usage store by climbing
+// brain/<conv>/.system_generated/logs/ to <root> and reading
+// <root>/conversations/<conv>.db (see storePathForTranscript in dbmetrics.go).
+// During replay the recorded transcript is materialized in a flat scratch dir,
+// so the recording rig captures the store under
+// recordingDir/store/conversations/<conv>.db and this hook rebuilds the live
+// layout under tmpDir: it copies the store to tmpDir/conversations/ and returns
+// a transcript path nested under tmpDir/brain/<conv>/.system_generated/logs/, so
+// the unchanged storePathForTranscript resolves the staged store exactly as it
+// does live.
+//
+// When no store was captured (every recording made before #766, and every
+// non-Antigravity adapter) it returns "" so the replay engine falls back to the
+// flat transcript path — reproducing a pre-#719 storeless session byte-for-byte.
+func (p *Parser) StageReplayStore(tmpDir, recordingDir string) (string, error) {
+	srcDir := filepath.Join(recordingDir, "store", "conversations")
+	dbs, _ := filepath.Glob(filepath.Join(srcDir, "*.db"))
+	if len(dbs) == 0 {
+		return "", nil
+	}
+	// The conv-id is the join key shared by the brain transcript dir and the
+	// store filename, so reuse the captured store's <conv>.db name for both.
+	conv := strings.TrimSuffix(filepath.Base(dbs[0]), ".db")
+
+	// Mirror the live store location: tmpDir/conversations/<conv>.db plus any
+	// -wal/-shm. Copy every file in the captured store dir verbatim so the
+	// WAL-aware reader sees the same bytes it would live.
+	if err := copyDirFiles(srcDir, filepath.Join(tmpDir, "conversations")); err != nil {
+		return "", err
+	}
+
+	// Recreate the brain transcript tree so sessionIDFromPath/storePathForTranscript
+	// climb back to tmpDir and find conversations/<conv>.db. The engine opens the
+	// returned path to write the transcript bytes, so we make only its parent.
+	logsDir := filepath.Join(tmpDir, "brain", conv, ".system_generated", "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		return "", err
+	}
+	return filepath.Join(logsDir, transcriptFilename), nil
+}
+
+// copyDirFiles copies every regular file directly under src into dst (created
+// if needed). Non-recursive: the conversation store dir holds only the .db and
+// its -wal/-shm siblings.
+func copyDirFiles(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if err := copyFile(filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/core/adapters/inbound/agents/antigravity/replaystore_test.go
+++ b/core/adapters/inbound/agents/antigravity/replaystore_test.go
@@ -1,0 +1,158 @@
+package antigravity
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/application/replayengine"
+	"irrlicht/core/pkg/tailer"
+)
+
+// Compile-time proof the parser opts into replay store staging — the seam that
+// lets replay resolve the sibling conversation store the daemon reads live (#766).
+var _ tailer.ReplayStoreStager = (*Parser)(nil)
+
+// turnLines is one trivial turn — prompt, a working tool step, then a terminal
+// line that settles to turn_done (where the store is read). Shared by the
+// staging and replay tests.
+func turnLines() []map[string]any {
+	return []map[string]any{
+		line("USER_EXPLICIT", "USER_INPUT", 0,
+			"<USER_REQUEST>\nhi\n</USER_REQUEST>\n<USER_SETTINGS_CHANGE>\nThe user changed setting `Model Selection` from None to Gemini 3.1 Pro (Low).\n</USER_SETTINGS_CHANGE>", nil),
+		line("MODEL", "PLANNER_RESPONSE", 1, "I will run it.", runCommand("/repo")),
+		line("MODEL", "PLANNER_RESPONSE", 2, "", nil),
+	}
+}
+
+// writeRecording lays out a recording dir the way promote-recording.sh does: a
+// flat transcript.jsonl plus, when rows != nil, the captured store under
+// store/conversations/<conv>.db (the #766 capture). Returns the recording dir.
+func writeRecording(t *testing.T, conv string, lines []map[string]any, rows map[int][]byte) string {
+	t.Helper()
+	recDir := t.TempDir()
+	var buf []byte
+	for _, l := range lines {
+		b, err := json.Marshal(l)
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf = append(append(buf, b...), '\n')
+	}
+	if err := os.WriteFile(filepath.Join(recDir, transcriptFilename), buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if rows != nil {
+		// writeStore creates <root>/conversations/<conv>.db; rooting it at
+		// recDir/store reproduces the rig's store/conversations/<conv>.db layout.
+		writeStore(t, filepath.Join(recDir, "store"), conv, rows)
+	}
+	return recDir
+}
+
+// TestStageReplayStore proves the staging rebuilds the live layout so the
+// unchanged storePathForTranscript resolves the captured store, and that the
+// WAL sibling rides along.
+func TestStageReplayStore(t *testing.T) {
+	conv := "abc-123"
+	recDir := writeRecording(t, conv, turnLines(), map[int][]byte{0: genBlob(16353, "gemini-3.1-pro-low")})
+	// A -wal sibling must survive the round-trip (the reader is WAL-aware).
+	walSrc := filepath.Join(recDir, "store", "conversations", conv+".db-wal")
+	if err := os.WriteFile(walSrc, []byte("wal"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tmpDir := t.TempDir()
+	got, err := (&Parser{}).StageReplayStore(tmpDir, recDir)
+	if err != nil {
+		t.Fatalf("StageReplayStore: %v", err)
+	}
+
+	want := filepath.Join(tmpDir, "brain", conv, ".system_generated", "logs", transcriptFilename)
+	if got != want {
+		t.Fatalf("transcript path = %q, want %q", got, want)
+	}
+	// Round-trip guard: the path the daemon's UNCHANGED resolver derives from the
+	// reconstructed transcript must land on the staged store. If the brain layout
+	// here and sessionIDFromPath/storePathForTranscript ever drift apart, this fails.
+	stored := storePathForTranscript(got)
+	if want := filepath.Join(tmpDir, "conversations", conv+".db"); stored != want {
+		t.Fatalf("storePathForTranscript(%q) = %q, want %q", got, stored, want)
+	}
+	if _, err := os.Stat(stored); err != nil {
+		t.Fatalf("staged db not found at %s: %v", stored, err)
+	}
+	if _, err := os.Stat(stored + "-wal"); err != nil {
+		t.Errorf("WAL sibling not staged alongside the db: %v", err)
+	}
+}
+
+// TestStageReplayStoreNoStore proves a recording without a captured store
+// (every pre-#766 recording) makes the stager a no-op so replay falls back to
+// the flat transcript path.
+func TestStageReplayStoreNoStore(t *testing.T) {
+	recDir := writeRecording(t, "abc-123", turnLines(), nil)
+	got, err := (&Parser{}).StageReplayStore(t.TempDir(), recDir)
+	if err != nil {
+		t.Fatalf("StageReplayStore: %v", err)
+	}
+	if got != "" {
+		t.Errorf("no captured store: want %q (flat-path fallback), got %q", "", got)
+	}
+}
+
+// TestReplayResolvesStagedStore is the end-to-end proof: a recording carrying a
+// captured store replays through the production engine with context tokens and
+// a resolved context window — the signals #719 reads live, now observable from
+// the recording alone.
+func TestReplayResolvesStagedStore(t *testing.T) {
+	recDir := writeRecording(t, "abc-123", turnLines(), map[int][]byte{0: genBlob(16353, "gemini-3.1-pro-low")})
+
+	res, err := replayengine.ReplayTranscript(filepath.Join(recDir, transcriptFilename), replayengine.Options{
+		Adapter:                    AdapterName,
+		Parser:                     &Parser{},
+		DebounceWindow:             2 * time.Second,
+		DisableModelConfigFallback: true,
+	})
+	if err != nil {
+		t.Fatalf("ReplayTranscript: %v", err)
+	}
+	m := res.LastMetrics
+	if m == nil {
+		t.Fatal("replay produced no LastMetrics")
+	}
+	if m.TotalTokens != 16353 {
+		t.Errorf("TotalTokens = %d, want 16353 from the staged store", m.TotalTokens)
+	}
+	if m.ContextWindow <= 0 {
+		t.Errorf("ContextWindow = %d, want > 0 (resolved via the staged store + capacity map)", m.ContextWindow)
+	}
+	if m.ContextUtilization <= 0 {
+		t.Errorf("ContextUtilization = %.3f%%, want > 0", m.ContextUtilization)
+	}
+}
+
+// TestReplayWithoutStoreIsStoreless is the negative control: the IDENTICAL
+// transcript with no captured store replays storeless, proving the staging —
+// not the transcript — is what surfaces the db-backed metrics.
+func TestReplayWithoutStoreIsStoreless(t *testing.T) {
+	recDir := writeRecording(t, "abc-123", turnLines(), nil)
+
+	res, err := replayengine.ReplayTranscript(filepath.Join(recDir, transcriptFilename), replayengine.Options{
+		Adapter:                    AdapterName,
+		Parser:                     &Parser{},
+		DebounceWindow:             2 * time.Second,
+		DisableModelConfigFallback: true,
+	})
+	if err != nil {
+		t.Fatalf("ReplayTranscript: %v", err)
+	}
+	if res.LastMetrics.TotalTokens != 0 {
+		t.Errorf("TotalTokens = %d, want 0 without a captured store", res.LastMetrics.TotalTokens)
+	}
+	if res.LastMetrics.ContextWindow != 0 {
+		t.Errorf("ContextWindow = %d, want 0 without a captured store", res.LastMetrics.ContextWindow)
+	}
+}

--- a/core/application/replayengine/engine.go
+++ b/core/application/replayengine/engine.go
@@ -163,6 +163,17 @@ func newReplayer(src string, opts Options, events []rawEvent) (*replayer, func()
 		return nil, nil, err
 	}
 	tmpPath := filepath.Join(tmpDir, "transcript.jsonl")
+	// A parser whose live store sits outside the transcript tree (Antigravity's
+	// conversations/<conv>.db, #766) rebuilds its expected layout under tmpDir
+	// from a store captured next to the recorded transcript, and returns where
+	// the transcript must live so its unchanged path-resolution finds the store.
+	// Best-effort, like the sidecar staging below: any failure falls back to the
+	// flat path, replaying storeless (the pre-#719 state).
+	if st, ok := opts.Parser.(tailer.ReplayStoreStager); ok {
+		if relocated, err := st.StageReplayStore(tmpDir, filepath.Dir(src)); err == nil && relocated != "" {
+			tmpPath = relocated
+		}
+	}
 	tmp, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		os.RemoveAll(tmpDir)

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -415,6 +415,21 @@ type TranscriptPathAware interface {
 	SetTranscriptPath(path string)
 }
 
+// ReplayStoreStager is an optional interface for parsers whose live
+// path-resolution reads a store that is NOT a transcript sibling — e.g.
+// Antigravity's conversations/<conv>.db, which the parser finds by climbing the
+// brain/<conv>/.system_generated/logs/ tree (issue #766). During replay the
+// recorded transcript is materialized in a flat scratch dir, so that climb
+// would miss the captured store. The replay engine gives such a parser a chance
+// to rebuild its expected directory layout under tmpDir from a store captured
+// next to the recorded transcript (recordingDir/store/…), and to return the
+// transcript path the tailer should open instead of the flat default.
+// Returning "" (or any error) means "no relocation — use the flat path", so a
+// recording without a captured store replays exactly as before.
+type ReplayStoreStager interface {
+	StageReplayStore(tmpDir, recordingDir string) (transcriptPath string, err error)
+}
+
 // LedgerSchemaVersion is the current ledger schema. A persisted ledger with a
 // different version is discarded on load, forcing a full transcript re-scan
 // under the current parser. Bump it whenever a LedgerState change (or a parser

--- a/tools/curate-lifecycle-fixture.sh
+++ b/tools/curate-lifecycle-fixture.sh
@@ -177,6 +177,26 @@ if [[ "$TRANSCRIPT" == *.jsonl && -f "$SIDECAR_SRC" ]]; then
   echo "wrote $SCENARIO_DIR/transcript.json (metadata sidecar)"
 fi
 
+# Antigravity conversation store: token usage and the canonical model id live in
+# a per-conversation SQLite store BESIDE the transcript tree (not a sibling), at
+# <root>/conversations/<conv>.db — where <root> is five levels above
+# <root>/brain/<conv>/.system_generated/logs/transcript.jsonl (dbmetrics.go's
+# storePathForTranscript). The live daemon reads it (#719) but the transcript
+# carries no tokens, so capture it (with any -wal/-shm) under store/conversations/
+# so replay can rebuild the layout and resolve the same metrics it does live (#766).
+if [[ "$ADAPTER" == "antigravity" && -f "$TRANSCRIPT" ]]; then
+  CONV="$(basename "$(dirname "$(dirname "$(dirname "$TRANSCRIPT")")")")"
+  ROOT="$(cd "$(dirname "$TRANSCRIPT")/../../../.." && pwd)"
+  DB="$ROOT/conversations/$CONV.db"
+  if [[ -f "$DB" ]]; then
+    mkdir -p "$SCENARIO_DIR/store/conversations"
+    for ext in "" "-wal" "-shm"; do
+      [[ -f "$DB$ext" ]] && cp "$DB$ext" "$SCENARIO_DIR/store/conversations/"
+    done
+    echo "wrote $SCENARIO_DIR/store/conversations/$CONV.db (antigravity usage store)"
+  fi
+fi
+
 # Copy all subagent transcripts, if any. The real-world layout is
 # <project-dir>/<parent-id>/subagents/<agent-id>.jsonl (Claude Code's
 # subagent convention) — we mirror that flat in the fixture sibling dir.

--- a/tools/promote-recording.sh
+++ b/tools/promote-recording.sh
@@ -110,6 +110,14 @@ for f in events.jsonl transcript.jsonl transcript.md transcript.json; do
     cp "$STAGED_DIR/$f" "$REC_DIR/$f"
   fi
 done
+# Antigravity usage store (#766): curate captured the sibling SQLite store under
+# store/conversations/; carry the whole subtree so replay can rebuild the live
+# layout and resolve tokens + the canonical model. RecordingComplete checks only
+# required-file presence, so this extra subtree keeps `of validate` green.
+if [[ -d "$STAGED_DIR/store" ]]; then
+  cp -R "$STAGED_DIR/store" "$REC_DIR/store"
+  echo "wrote $REC_DIR/store (antigravity usage store)" >&2
+fi
 echo "wrote recording $REC_DIR" >&2
 
 # 3. Validate this recording against the cell's expected.jsonl, capturing the


### PR DESCRIPTION
## What

Antigravity keeps token usage and the canonical model id in a per-conversation SQLite store **beside** the transcript — `conversations/<conv>.db` — not in the transcript JSONL. The live daemon reads it (#719) to light up the context bar, but the onboarding recording rig only ever snapshots the transcript, so the replay matrix was structurally blind to every db-derived signal.

This PR makes the rig **capture** that store into each antigravity recording and **serve** it at replay time by rebuilding the live directory layout in the replay scratch dir — so the daemon's existing `storePathForTranscript` resolves it identically, with **zero change to the resolution logic**.

## How

- **Capture** (`tools/curate-lifecycle-fixture.sh`): an `antigravity`-gated block (mirroring the kiro `transcript.json` sidecar block, #599) climbs from the captured transcript to `<root>` and copies `<root>/conversations/<conv>.db` (+ any `-wal`/`-shm`) into the staged cell under `store/conversations/`.
- **Promote** (`tools/promote-recording.sh`): carries the `store/` subtree into the committed `recordings/<name>/`. `RecordingComplete` is presence-only, so `of validate` stays green.
- **Serve** (`core/application/replayengine/engine.go` `newReplayer`): a new optional `tailer.ReplayStoreStager` lets the antigravity parser rebuild `brain/<conv>/.system_generated/logs/transcript.jsonl` + `conversations/<conv>.db` under the replay scratch dir from a captured store, and return the relocated transcript path. `SetTranscriptPath` → `storePathForTranscript` (both unchanged) then resolve the store exactly as live. The path geometry stays in the adapter (`core/adapters/inbound/agents/antigravity/replaystore.go`); the engine learns nothing antigravity-specific, and recordings without a captured store replay byte-identically.

## Tests

`core/adapters/inbound/agents/antigravity/replaystore_test.go`:
- **End-to-end**: a synthetic recording (transcript + `store/conversations/<conv>.db`) replays through `replayengine.ReplayTranscript` with `context_window > 0` and `context_utilization_percentage > 0`.
- **Negative control**: the identical transcript *without* a captured store replays storeless — proving the staging, not the transcript, surfaces the metrics.
- **Round-trip guard**: the reconstructed transcript path round-trips through `sessionIDFromPath`/`storePathForTranscript` back to the staged db, so the duplicated brain-layout geometry can't silently drift.

All suites green: `go test ./core/... -race`, `go test ./tools/onboarding-factory/... -race`, byte-identity replay goldens (**unchanged**), `of validate`, `replay-fixtures.sh`, rig `smoke-test.sh`.

## Scope note — this delivers capture+serve; the 1.8/5.1 *flip* needs two follow-ons

The issue's scope item 3 ("re-record 1.8 / 5.1 and confirm they flip to `observed`") is **not** in this PR, and investigation showed a re-record alone is **not sufficient**:

1. **A live `agy` re-record is required** to produce a recording that actually contains a `.db` (existing recordings have none; we must not fabricate one into a committed recording — recordings are the single source of truth).
2. **The golden summary doesn't yet carry the db-backed fields.** `of verify` reads the golden `summary` block, where `finalizeSummary`/`reportSummary` serialize only `cum_*` tokens / cost / model — **not** `context_window`, `context_utilization_percentage`, or `total_tokens`. And the `tokens` observation asserts `cum_input + cum_output`, which the store (set as `TotalTokens` only) never populates. So even after a re-record, `of verify` couldn't assert 1.8/5.1 without **also** surfacing those fields in `reportSummary` + `finalizeSummary` + the `replaySummary` validator. That's a cross-cutting change (it would regenerate goldens across adapters) and is intentionally left out here.

This PR is the necessary, surgical foundation (capture + serve, proven end-to-end). Recommend a follow-up issue for the golden-summary surfacing + the live re-record to actually flip the cells.

Refs #716, #719. Closes none — see scope note (#766 remains open for the flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)