### PR TITLE
fix(ci): make antigravity replay context-window test hermetic

### DIFF
--- a/core/adapters/inbound/agents/antigravity/testdata/model-capacity-cache.json
+++ b/core/adapters/inbound/agents/antigravity/testdata/model-capacity-cache.json
@@ -1,0 +1,33 @@
+{
+  "fetched_at": "2026-06-28T00:00:00Z",
+  "config": {
+    "version": "remote-v2",
+    "last_updated": "2026-06-28",
+    "models": {
+      "gemini-3.1-pro-preview": {
+        "context_window": 1048576,
+        "max_output": 65536,
+        "family": "vertex_ai-language-models",
+        "display_name": "gemini-3.1-pro-preview",
+        "pricing": {
+          "input_per_mtok": 2,
+          "output_per_mtok": 12,
+          "cache_read_per_mtok": 0.2,
+          "cache_creation_per_mtok": 0
+        }
+      },
+      "gemini-3-flash-preview": {
+        "context_window": 1048576,
+        "max_output": 65535,
+        "family": "vertex_ai-language-models",
+        "display_name": "gemini-3-flash-preview",
+        "pricing": {
+          "input_per_mtok": 0.5,
+          "output_per_mtok": 3,
+          "cache_read_per_mtok": 0.05,
+          "cache_creation_per_mtok": 0
+        }
+      }
+    }
+  }
+}

--- a/core/adapters/inbound/agents/antigravity/testmain_test.go
+++ b/core/adapters/inbound/agents/antigravity/testmain_test.go
@@ -1,0 +1,24 @@
+package antigravity
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMain pins the model-capacity (LiteLLM) cache to a committed snapshot
+// (testdata/model-capacity-cache.json) so the replay test that resolves a
+// context window is hermetic. Without it, GetModelCapacity reads whatever
+// LiteLLM data happens to be cached at ~/.local/share/irrlicht on the dev
+// machine or CI runner — which passes on a warm cache but resolves a zero
+// context window on a cold one (a fresh CI runner has no cache), making
+// TestReplayResolvesStagedStore fail with ContextWindow=0. The env var is the
+// same escape hatch cachePath() honors in production, so setting it here
+// changes nothing about how the daemon ships (mirrors the onboarding-factory
+// replay TestMain).
+func TestMain(m *testing.M) {
+	if abs, err := filepath.Abs(filepath.Join("testdata", "model-capacity-cache.json")); err == nil {
+		_ = os.Setenv("IRRLICHT_MODEL_CAPACITY_CACHE", abs)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## What

`go test ./core/... -race` fails on a clean CI runner in the antigravity adapter:

```
--- FAIL: TestReplayResolvesStagedStore
    replaystore_test.go:130: ContextWindow = 0, want > 0 (resolved via the staged store + capacity map)
    replaystore_test.go:133: ContextUtilization = 0.000%, want > 0
```

(e.g. [run 28303394784](https://github.com/ingo-eichhorst/Irrlicht/actions/runs/28303394784))

## Root cause

`TestReplayResolvesStagedStore` (added in #775 for #766) replays a recording, reads the captured store for `TotalTokens`, then resolves the **context window** by looking the store's canonical model id (`gemini-3.1-pro-low` → alias → `gemini-3.1-pro-preview`) up in the capacity map.

That map is served purely from the on-disk LiteLLM cache at `~/.local/share/irrlicht/model-capacity-cache.json` — there is no embedded default (`GetModelCapacity` returns a zero value when the cache is absent). So:

- **Dev machine** — warm cache holds `gemini-3.1-pro-preview → 1048576`, the window resolves, test passes.
- **Fresh CI runner** — no cache file → empty model map → `ContextWindow = 0`, `ContextUtilization = 0` → fail.

The CI log confirms it: `TotalTokens == 16353` passed (store read fine); only the capacity-map-derived fields were zero. Reproduced locally with `IRRLICHT_MODEL_CAPACITY_CACHE=/nonexistent go test ...` — identical two failures.

## Fix

Add a `TestMain` that pins `IRRLICHT_MODEL_CAPACITY_CACHE` to a committed `testdata/model-capacity-cache.json` snapshot — exactly the pattern the onboarding-factory replay tests already use (`tools/onboarding-factory/cmd/replay/testmain_test.go`). The env var is the same production escape hatch `cachePath()` honors, so nothing about the shipped daemon changes. The snapshot is minimal: just the gemini-3.x preview entries the adapter's fixtures resolve through.

## Verification

- `HOME=<empty> go test ./core/adapters/inbound/agents/antigravity/ -run TestReplay -count=1` — now **PASS** (was FAIL).
- `go test ./core/adapters/inbound/agents/antigravity/ -race -count=1` — **ok**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)