### PR TITLE
fix(antigravity): reject sessions bound to a non-interactive host

### DIFF
--- a/core/adapters/inbound/agents/antigravity/agent.go
+++ b/core/adapters/inbound/agents/antigravity/agent.go
@@ -47,8 +47,9 @@ func Agent() agent.Agent {
 			IconSVGDark:  iconSVGDark,
 		},
 		Process: agent.Process{
-			Match:         agent.ExactName{Name: ProcessName},
-			PIDForSession: DiscoverPID,
+			Match:            agent.ExactName{Name: ProcessName},
+			PIDForSession:    DiscoverPID,
+			RequireKnownHost: true,
 		},
 		Source: agent.FilesUnderRoot{
 			Dir:               cliBrainDir,

--- a/core/adapters/inbound/agents/maps.go
+++ b/core/adapters/inbound/agents/maps.go
@@ -100,6 +100,21 @@ func ArgvExcluders(agents []agent.Agent) map[string]func([]string) bool {
 	return m
 }
 
+// RequireKnownHost produces the adapter-name → Process.RequireKnownHost map
+// consumed by session admission's host-ancestry gate: a candidate PID
+// launched by something other than a known terminal or IDE is rejected before
+// a session is ever created (#784). Only adapters that opt in (today:
+// antigravity) appear; the rest get no entry, so admission is unaffected.
+func RequireKnownHost(agents []agent.Agent) map[string]bool {
+	m := make(map[string]bool)
+	for _, a := range agents {
+		if a.Process.RequireKnownHost {
+			m[a.Identity.Name] = true
+		}
+	}
+	return m
+}
+
 // ControlPresets produces the adapter-name → (preset id → command text) map
 // consumed by the BackchannelEngine to translate a rule's agent-agnostic preset
 // into the concrete command for the session's agent (issue #754). Only adapters

--- a/core/adapters/inbound/agents/processlifecycle/hosts_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/hosts_darwin.go
@@ -64,6 +64,18 @@ func termProgramForAppPath(cmdPath string) string {
 	return termProgramByAppName[appName]
 }
 
+// knownEmbeddedHostBundleIDs supplements termProgramByAppName for hosts that
+// embed a real terminal but aren't in the curated activation map — no Swift
+// activator is needed here since this list backs a session-identity check
+// (IsKnownInteractiveHost), not focus routing. Obsidian's community terminal
+// plugins (e.g. ghostty-terminal) run a real shell as a child of Obsidian.app,
+// so a coding-agent CLI launched there has a legitimate interactive lineage —
+// see issue #728 (which resolves Obsidian generically for click-to-focus) and
+// issue #784 (which needs an explicit allow-list, not "any top-level app").
+var knownEmbeddedHostBundleIDs = map[string]bool{
+	"md.obsidian": true,
+}
+
 // topLevelAppPath returns the path of the top-level application bundle whose
 // main executable is cmdPath, or "" when cmdPath is not the main executable of
 // a real top-level `.app`. It backs the generic host fallback (for embedded

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -159,7 +159,14 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int) {
 // but isn't a curated terminal/IDE and isn't in knownEmbeddedHostBundleIDs
 // returns false — which is exactly what excludes CodexBar.
 func IsKnownInteractiveHost(pid int) bool {
+	// Short-circuit before the second ancestry walk: resolveHostFromAncestry
+	// and resolveHostBundleIDFromAncestry each independently re-walk the same
+	// parent chain via their own ps shellouts, so skip the bundle-ID walk
+	// entirely once the curated map already matched.
 	term, _ := resolveHostFromAncestry(pid)
+	if term != "" {
+		return true
+	}
 	bundleID, _ := resolveHostBundleIDFromAncestry(pid)
 	return isKnownInteractiveHostFrom(term, bundleID)
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -144,6 +144,33 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int) {
 	return "", 0
 }
 
+// IsKnownInteractiveHost reports whether pid's process ancestry traces back to
+// a recognized terminal emulator or IDE (the curated termProgramByAppName map,
+// via resolveHostFromAncestry), or to another host known to embed a real
+// terminal (knownEmbeddedHostBundleIDs, e.g. Obsidian). It gates session
+// admission for adapters whose process can be spawned non-interactively by
+// unrelated tooling — issue #784, where a third-party menu-bar app (CodexBar)
+// kept an Antigravity `agy` CLI process running in the background for quota
+// polling, with no distinguishing argv or cwd.
+//
+// Unlike resolveHostBundleIDFromAncestry (which accepts ANY top-level app, for
+// click-to-focus purposes where bringing an unrecognized host forward is still
+// useful), this is a real allow-list: an ancestor that is a legitimate `.app`
+// but isn't a curated terminal/IDE and isn't in knownEmbeddedHostBundleIDs
+// returns false — which is exactly what excludes CodexBar.
+func IsKnownInteractiveHost(pid int) bool {
+	term, _ := resolveHostFromAncestry(pid)
+	bundleID, _ := resolveHostBundleIDFromAncestry(pid)
+	return isKnownInteractiveHostFrom(term, bundleID)
+}
+
+// isKnownInteractiveHostFrom is the pure decision behind IsKnownInteractiveHost,
+// split out so the allow-list logic can be tested with synthetic ancestry
+// results instead of depending on whatever launched the test binary.
+func isKnownInteractiveHostFrom(termProgram, bundleID string) bool {
+	return termProgram != "" || knownEmbeddedHostBundleIDs[bundleID]
+}
+
 // resolveTermProgramFromAncestry is a thin wrapper that discards the host
 // PID. Kept for the existing call site that only cares whether kitty (or any
 // other host) appears in the chain; callers that also need the host PID

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -314,6 +314,38 @@ func TestResolveTermProgramFromAncestry_Self(t *testing.T) {
 	}
 }
 
+// TestIsKnownInteractiveHostFrom exercises the allow-list decision with
+// synthetic ancestry results — no live process chain needed — so the CodexBar
+// exclusion (#784) and the Obsidian carve-out (#728) are both deterministic,
+// not dependent on whatever happens to have launched `go test`.
+func TestIsKnownInteractiveHostFrom(t *testing.T) {
+	tests := []struct {
+		name                 string
+		termProgram          string
+		bundleID             string
+		wantKnownInteractive bool
+	}{
+		{"curated terminal", "iTerm.app", "", true},
+		{"curated IDE", "vscode", "", true},
+		{"obsidian via generic top-level-app fallback", "", "md.obsidian", true},
+		{"codexbar is a real .app but not allow-listed", "", "com.steipete.codexbar", false},
+		{"no ancestry resolved at all", "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isKnownInteractiveHostFrom(tc.termProgram, tc.bundleID); got != tc.wantKnownInteractive {
+				t.Errorf("isKnownInteractiveHostFrom(%q, %q) = %v, want %v", tc.termProgram, tc.bundleID, got, tc.wantKnownInteractive)
+			}
+		})
+	}
+}
+
+// TestIsKnownInteractiveHost_Self mirrors the other "_Self" ancestry tests:
+// we don't know what launched `go test`, so only assert it returns cleanly.
+func TestIsKnownInteractiveHost_Self(t *testing.T) {
+	_ = IsKnownInteractiveHost(os.Getpid())
+}
+
 func reverseLookup(termProgram string) string {
 	for k, v := range termProgramByAppName {
 		if v == termProgram {

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -47,3 +47,9 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int) { retu
 func kittyAncestryPID(pid int) int                             { return 0 }
 func kittyListenOnFor(kittyPID int) string                     { return "" }
 func kittyWindowIDForPID(socket string, sessionPID int) string { return "" }
+
+// IsKnownInteractiveHost is darwin-only (ancestry walking); other platforms
+// fail open. The exclusion signal it backs (CodexBar's non-interactive `agy`
+// process, issue #784) only exists on macOS, so failing closed here would
+// reject every antigravity CLI session on this platform instead.
+func IsKnownInteractiveHost(pid int) bool { return true }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -21,3 +21,9 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int) { retu
 func kittyAncestryPID(pid int) int                             { return 0 }
 func kittyListenOnFor(kittyPID int) string                     { return "" }
 func kittyWindowIDForPID(socket string, sessionPID int) string { return "" }
+
+// IsKnownInteractiveHost is darwin-only (ancestry walking); other platforms
+// fail open. The exclusion signal it backs (CodexBar's non-interactive `agy`
+// process, issue #784) only exists on macOS, so failing closed here would
+// reject every antigravity CLI session on this platform instead.
+func IsKnownInteractiveHost(pid int) bool { return true }

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -84,6 +84,16 @@ type PIDManager struct {
 	argvExcluders map[string]func([]string) bool
 	readArgv      func(pid int) []string
 
+	// requireKnownHost maps adapter name → whether Process.RequireKnownHost is
+	// set, and isKnownHost checks a PID's process ancestry against known
+	// terminals/IDEs. Together they let session admission reject a candidate
+	// PID that is real and alive but was launched by something other than an
+	// interactive terminal or IDE (e.g. CodexBar keeping an Antigravity `agy`
+	// process running for quota polling — issue #784). Both nil disables the
+	// check; installed once at startup via SetHostGate.
+	requireKnownHost map[string]bool
+	isKnownHost      func(pid int) bool
+
 	// onSessionDeleted is called when a session is deleted so the caller can
 	// clean up its own tracking structures (e.g. projectSessions map).
 	onSessionDeleted func(sessionID string)
@@ -187,6 +197,45 @@ func (pm *PIDManager) SetBackgroundReader(fn BackgroundReader) {
 func (pm *PIDManager) SetInfraReaper(excluders map[string]func([]string) bool, readArgv func(pid int) []string) {
 	pm.argvExcluders = excluders
 	pm.readArgv = readArgv
+}
+
+// SetHostGate installs the seam session admission uses to reject a candidate
+// PID launched by something other than a known terminal or IDE (issue #784).
+// requireKnownHost maps adapter name → Process.RequireKnownHost; isKnownHost
+// resolves a PID's process ancestry. Both nil (the default, and what
+// tests/demo mode leave) disables the check. Called once at startup.
+func (pm *PIDManager) SetHostGate(requireKnownHost map[string]bool, isKnownHost func(pid int) bool) {
+	pm.requireKnownHost = requireKnownHost
+	pm.isKnownHost = isKnownHost
+}
+
+// AllowsSession reports whether a new session should be admitted for adapter,
+// given the candidate PID (if any) a synchronous one-shot discovery attempt
+// finds at cwd. Adapters that don't opt into RequireKnownHost always return
+// true — this check is additive and inert everywhere except antigravity.
+//
+// When the adapter opts in: a PID discovered now but whose ancestry doesn't
+// resolve to a known terminal/IDE rejects admission outright, so no
+// SessionState (and no menu-bar circle) is ever created for it. No PID found
+// yet fails open — discovery is best-effort and a real session's process is
+// virtually always already running by the time its transcript file appears,
+// but a rare timing race must not block a legitimate session forever.
+func (pm *PIDManager) AllowsSession(adapter, cwd, transcriptPath string) bool {
+	if !pm.requireKnownHost[adapter] {
+		return true
+	}
+	discover := pm.pidDiscovers[adapter]
+	if discover == nil {
+		return true
+	}
+	pid, err := discover(cwd, transcriptPath, nil)
+	if err != nil || pid <= 0 {
+		return true
+	}
+	if pm.isKnownHost == nil {
+		return true
+	}
+	return pm.isKnownHost(pid)
 }
 
 // captureLauncher invokes the launcher-env reader if one is installed and

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -209,6 +209,13 @@ func (pm *PIDManager) SetHostGate(requireKnownHost map[string]bool, isKnownHost 
 	pm.isKnownHost = isKnownHost
 }
 
+// RequiresKnownHost reports whether adapter has opted into the host-ancestry
+// admission gate (Process.RequireKnownHost), so callers can decide whether
+// it's worth resolving a cwd before calling AllowsSession.
+func (pm *PIDManager) RequiresKnownHost(adapter string) bool {
+	return pm.requireKnownHost[adapter]
+}
+
 // AllowsSession reports whether a new session should be admitted for adapter,
 // given the candidate PID (if any) a synchronous one-shot discovery attempt
 // finds at cwd. Adapters that don't opt into RequireKnownHost always return
@@ -220,7 +227,13 @@ func (pm *PIDManager) SetHostGate(requireKnownHost map[string]bool, isKnownHost 
 // yet fails open — discovery is best-effort and a real session's process is
 // virtually always already running by the time its transcript file appears,
 // but a rare timing race must not block a legitimate session forever.
-func (pm *PIDManager) AllowsSession(adapter, cwd, transcriptPath string) bool {
+//
+// Uses the same claim-aware disambiguator as TryDiscoverPID (via sessionID)
+// so this check and the real PID binding that follows always agree on which
+// PID they're looking at — a mismatch would let the gate ancestry-check a
+// stale/unrelated PID sharing the same cwd instead of the one that's actually
+// about to be bound.
+func (pm *PIDManager) AllowsSession(sessionID, adapter, cwd, transcriptPath string) bool {
 	if !pm.requireKnownHost[adapter] {
 		return true
 	}
@@ -228,7 +241,7 @@ func (pm *PIDManager) AllowsSession(adapter, cwd, transcriptPath string) bool {
 	if discover == nil {
 		return true
 	}
-	pid, err := discover(cwd, transcriptPath, nil)
+	pid, err := discover(cwd, transcriptPath, pm.claimAwareDisambiguate(sessionID))
 	if err != nil || pid <= 0 {
 		return true
 	}
@@ -690,10 +703,26 @@ func (pm *PIDManager) TryDiscoverPID(sessionID, cwd, transcriptPath, adapter str
 		return false
 	}
 
-	// Prefer unclaimed PIDs (multiple instances in same dir), but allow
-	// claimed PIDs when all candidates are claimed (/clear scenario).
+	if pid, err := discoverFn(cwd, transcriptPath, pm.claimAwareDisambiguate(sessionID)); err == nil && pid > 0 {
+		pm.log.LogInfo("session-detector", sessionID,
+			fmt.Sprintf("discovered pid %d for %s session", pid, adapter))
+		pm.HandlePIDAssigned(pid, sessionID)
+		return true
+	}
+	return false
+}
+
+// claimAwareDisambiguate builds a disambiguator that prefers the highest
+// unclaimed PID among candidates sharing a cwd, falling back to the highest
+// claimed PID when every candidate is already claimed by another session
+// (the /clear scenario). Shared by TryDiscoverPID and AllowsSession so both
+// pick the same PID for the same session — they used to disagree (AllowsSession
+// passed a nil disambiguate, which falls back to each adapter's own default,
+// e.g. antigravity's lowestPID), letting the admission gate ancestry-check a
+// different, possibly stale, PID than the one that would actually get bound.
+func (pm *PIDManager) claimAwareDisambiguate(sessionID string) func([]int) int {
 	claimed := pm.claimedPIDs(sessionID)
-	disambiguate := func(pids []int) int {
+	return func(pids []int) int {
 		bestUnclaimed, bestAny := 0, 0
 		for _, p := range pids {
 			if p > bestAny {
@@ -708,14 +737,6 @@ func (pm *PIDManager) TryDiscoverPID(sessionID, cwd, transcriptPath, adapter str
 		}
 		return bestAny
 	}
-
-	if pid, err := discoverFn(cwd, transcriptPath, disambiguate); err == nil && pid > 0 {
-		pm.log.LogInfo("session-detector", sessionID,
-			fmt.Sprintf("discovered pid %d for %s session", pid, adapter))
-		pm.HandlePIDAssigned(pid, sessionID)
-		return true
-	}
-	return false
 }
 
 // DiscoverPIDWithRetry tries to discover a PID immediately, then retries at

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -99,13 +99,50 @@ func TestAllowsSession(t *testing.T) {
 			}
 			pm.SetHostGate(requireKnownHost, func(pid int) bool { return tc.isKnownHost })
 
-			if got := pm.AllowsSession("antigravity", "/some/cwd", "/some/transcript.jsonl"); got != tc.want {
+			if got := pm.AllowsSession("sess1", "antigravity", "/some/cwd", "/some/transcript.jsonl"); got != tc.want {
 				t.Errorf("AllowsSession() = %v, want %v", got, tc.want)
 			}
 			if tc.requireKnownHost && discoverCalls != 1 {
 				t.Errorf("expected discover to be called once, got %d", discoverCalls)
 			}
 		})
+	}
+}
+
+// TestAllowsSession_ClaimAwareDisambiguation is the regression test for the
+// #791 review finding: AllowsSession used to pass a nil disambiguate to the
+// discover func, which for antigravity falls back to the lowest matching PID
+// — diverging from TryDiscoverPID's claim-aware "highest unclaimed" policy.
+// If a stale PID (already claimed by another session) shares a cwd with a
+// brand-new, legitimate process, the two paths must agree on which PID they're
+// looking at, or the gate can ancestry-check the wrong one and reject a real
+// session.
+func TestAllowsSession_ClaimAwareDisambiguation(t *testing.T) {
+	repo := newMockRepo()
+	// PID 100 is already claimed by another session (a stale/ghost binding);
+	// PID 200 is the new, unclaimed, legitimate process. A claim-aware
+	// disambiguator must prefer 200 despite it being numerically higher than
+	// (not lower than, the naive "lowest PID" default) 100.
+	repo.states["other-session"] = &session.SessionState{SessionID: "other-session", PID: 100}
+
+	discover := agent.PIDDiscoverFunc(func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
+		return disambiguate([]int{100, 200}), nil
+	})
+	pm := services.NewPIDManager(
+		nil, repo, &mockLogger{}, nil, 10*time.Minute,
+		map[string]agent.PIDDiscoverFunc{"antigravity": discover},
+		nil, nil, func(string) {},
+	)
+	var checkedPID int
+	pm.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool {
+		checkedPID = pid
+		return true
+	})
+
+	pm.AllowsSession("new-session", "antigravity", "/some/cwd", "/some/transcript.jsonl")
+
+	if checkedPID != 200 {
+		t.Errorf("AllowsSession ancestry-checked PID %d, want 200 (the unclaimed candidate — PID 100 is already claimed by another session)", checkedPID)
 	}
 }
 

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -61,6 +61,54 @@ func newPIDManagerForTestWithLiveCWDs(repo *mockRepo, processNames map[string]st
 	)
 }
 
+// TestAllowsSession covers the #784 host-ancestry admission gate: an adapter
+// that opts into RequireKnownHost rejects a candidate PID whose ancestry
+// isn't a known terminal/IDE, but only once a PID actually resolves — a
+// same-tick "no PID yet" must fail open, and adapters that never opt in must
+// be entirely unaffected.
+func TestAllowsSession(t *testing.T) {
+	tests := []struct {
+		name             string
+		requireKnownHost bool
+		discoverPID      int
+		discoverErr      error
+		isKnownHost      bool
+		want             bool
+	}{
+		{"adapter doesn't opt in: always allowed regardless of host", false, 12345, nil, false, true},
+		{"opts in, no PID discoverable yet: fails open", true, 0, errors.New("not found"), false, true},
+		{"opts in, PID found, known host: allowed", true, 12345, nil, true, true},
+		{"opts in, PID found, unknown host (e.g. CodexBar): rejected", true, 12345, nil, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newMockRepo()
+			discoverCalls := 0
+			discover := agent.PIDDiscoverFunc(func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
+				discoverCalls++
+				return tc.discoverPID, tc.discoverErr
+			})
+			pm := services.NewPIDManager(
+				nil, repo, &mockLogger{}, nil, 10*time.Minute,
+				map[string]agent.PIDDiscoverFunc{"antigravity": discover},
+				nil, nil, func(string) {},
+			)
+			requireKnownHost := map[string]bool{}
+			if tc.requireKnownHost {
+				requireKnownHost["antigravity"] = true
+			}
+			pm.SetHostGate(requireKnownHost, func(pid int) bool { return tc.isKnownHost })
+
+			if got := pm.AllowsSession("antigravity", "/some/cwd", "/some/transcript.jsonl"); got != tc.want {
+				t.Errorf("AllowsSession() = %v, want %v", got, tc.want)
+			}
+			if tc.requireKnownHost && discoverCalls != 1 {
+				t.Errorf("expected discover to be called once, got %d", discoverCalls)
+			}
+		})
+	}
+}
+
 // TestCheckPIDLiveness_FreshTranscript_NotDeleted verifies the Layer 2 fix for
 // issue #109: a ready session with PID=0 and a freshly-written transcript must
 // NOT be fast-deleted after 30s. PID discovery may still be catching up (e.g.

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -347,6 +347,13 @@ func (d *SessionDetector) SetInfraReaper(excluders map[string]func([]string) boo
 	d.pidMgr.SetInfraReaper(excluders, readArgv)
 }
 
+// SetHostGate installs the session-admission seam that rejects a candidate PID
+// launched by something other than a known terminal or IDE (#784). Both args
+// nil disables the check. Call before Run.
+func (d *SessionDetector) SetHostGate(requireKnownHost map[string]bool, isKnownHost func(pid int) bool) {
+	d.pidMgr.SetHostGate(requireKnownHost, isKnownHost)
+}
+
 // SetConsentGate installs the per-adapter observe-consent check (#570).
 // Call before Run. Production wires PermissionService.ObserveGranted; nil
 // (the default) allows everything.

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -118,6 +118,16 @@ type SessionDetector struct {
 	// --continue, not ghost events from a dying process.
 	deletedSessions map[string]int64
 
+	// hostGateRejected tracks session IDs the host-ancestry admission gate
+	// (issue #784) has already rejected. No cooldown/expiry, unlike
+	// deletedSessions — a rejected PID's process ancestry (e.g. CodexBar,
+	// not a terminal) won't change for the life of that process, so there's
+	// no legitimate retry case to allow. Exists specifically to close a gap
+	// where the debounce-coalesce path re-enters onNewSession with an empty
+	// Identity, which would otherwise bypass the gate on a same-window retry
+	// (see the PID-manager AllowsSession call site in onNewSession).
+	hostGateRejected map[string]struct{}
+
 	// debounce coalesces rapid transcript activity events per session.
 	debounceMu sync.Mutex
 	debounce   map[string]*debounceEntry
@@ -243,6 +253,7 @@ func NewSessionDetector(
 		metrics:           metrics,
 		projectSessions:   make(map[string]string),
 		deletedSessions:   make(map[string]int64),
+		hostGateRejected:  make(map[string]struct{}),
 		debounce:          make(map[string]*debounceEntry),
 		debouncedEvents:   make(chan agent.Event, 64),
 		deletedCooldown:   10 * time.Second,

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -114,6 +114,18 @@ func (d *SessionDetector) onNewSession(id agent.Identity, ev agent.Event) {
 			return
 		}
 
+		// Skip sessions whose adapter requires a known interactive host
+		// (currently antigravity only) when the process behind them was
+		// launched by something other than a recognized terminal or IDE — a
+		// synchronous, one-shot check so a non-interactive process never
+		// becomes a visible session in the first place, rather than appearing
+		// and being reaped later (issue #784).
+		if !d.pidMgr.AllowsSession(id.Name, ev.CWD, ev.TranscriptPath) {
+			d.log.LogInfo("session-detector", ev.SessionID,
+				"skipping session bound to a non-interactive host")
+			return
+		}
+
 		// All new sessions start as ready. Content-based detection on
 		// subsequent activity events will transition to working/waiting.
 		parentID := ev.ParentSessionID

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -114,16 +114,39 @@ func (d *SessionDetector) onNewSession(id agent.Identity, ev agent.Event) {
 			return
 		}
 
+		// Skip sessions previously rejected by the host-ancestry gate below.
+		// Checked unconditionally (before looking at id.Name) because the
+		// debounce-coalesce path re-enters onNewSession with an empty
+		// Identity (see processActivityWithoutIdentity) — without this cache,
+		// AllowsSession("", ...) would no-op on the unrecognized adapter name
+		// and let an already-rejected non-interactive session slip through on
+		// a same-window retry.
+		d.mu.Lock()
+		_, hostRejected := d.hostGateRejected[ev.SessionID]
+		d.mu.Unlock()
+		if hostRejected {
+			return
+		}
+
 		// Skip sessions whose adapter requires a known interactive host
 		// (currently antigravity only) when the process behind them was
 		// launched by something other than a recognized terminal or IDE — a
 		// synchronous, one-shot check so a non-interactive process never
 		// becomes a visible session in the first place, rather than appearing
 		// and being reaped later (issue #784).
-		if !d.pidMgr.AllowsSession(id.Name, ev.CWD, ev.TranscriptPath) {
-			d.log.LogInfo("session-detector", ev.SessionID,
-				"skipping session bound to a non-interactive host")
-			return
+		if d.pidMgr.RequiresKnownHost(id.Name) {
+			cwd := ev.CWD
+			if cwd == "" {
+				cwd = d.enricher.git.GetCWDFromTranscript(ev.TranscriptPath)
+			}
+			if !d.pidMgr.AllowsSession(ev.SessionID, id.Name, cwd, ev.TranscriptPath) {
+				d.mu.Lock()
+				d.hostGateRejected[ev.SessionID] = struct{}{}
+				d.mu.Unlock()
+				d.log.LogInfo("session-detector", ev.SessionID,
+					"skipping session bound to a non-interactive host")
+				return
+			}
 		}
 
 		// All new sessions start as ready. Content-based detection on

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -226,6 +226,137 @@ func TestSessionDetector_NewSession_AdmitsKnownHost(t *testing.T) {
 	}
 }
 
+// TestSessionDetector_NewSession_HostGateResolvesCWDFromTranscript is the
+// regression test for the #791 review finding that the host-ancestry gate was
+// a structural no-op for antigravity's normal transcript-driven path: fswatcher
+// never sets Event.CWD, so DiscoverPID's cwd-based lookup would always
+// short-circuit to (0, nil) and AllowsSession would fail open before ever
+// attempting an ancestry check. The gate must fall back to the transcript-
+// derived cwd (mirroring the existing #576 stale-rescue pattern) so discovery
+// actually gets a usable cwd.
+func TestSessionDetector_NewSession_HostGateResolvesCWDFromTranscript(t *testing.T) {
+	tw := newMockAgentWatcher().withIdentity(agent.Identity{Name: "antigravity"})
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	const wantCWD = "/Users/ghost/.gemini/antigravity-cli"
+	discoverCalls := 0
+	discovers := map[string]agent.PIDDiscoverFunc{
+		"antigravity": func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
+			discoverCalls++
+			if cwd != wantCWD {
+				t.Errorf("discover called with cwd %q, want %q (transcript-derived fallback cwd wasn't threaded through)", cwd, wantCWD)
+			}
+			return 62540, nil
+		},
+	}
+	det := services.NewSessionDetector(
+		[]inbound.Watcher{tw}, pw, repo,
+		&mockLogger{}, &cwdGit{cwd: wantCWD}, &mockMetrics{}, nil,
+		"test", 0, discovers, nil, nil,
+	)
+	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return false })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "ghost-empty-cwd",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: "/home/.gemini/antigravity-cli/brain/conv/transcript.jsonl",
+		// CWD deliberately left empty — matches production fswatcher events.
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if discoverCalls == 0 {
+		t.Fatal("discover was never called — the host gate never attempted PID discovery at all")
+	}
+	if state, _ := repo.Load("ghost-empty-cwd"); state != nil {
+		t.Errorf("session should have been rejected once discovered via the transcript-derived cwd, got state %q", state.State)
+	}
+}
+
+// TestSessionDetector_NewSession_HostGateRejectionSurvivesIdentityLessRetry is
+// the regression test for the #791 review finding that a session rejected by
+// the host gate could still be created via the debounce-coalesce path: a
+// second activity event within the 2s debounce window is coalesced and
+// re-dispatched through processActivityWithoutIdentity, which calls
+// onNewSession with an empty Identity — without the hostGateRejected cache,
+// AllowsSession("", ...) would no-op on the unrecognized adapter name and
+// admit the retry. Drives the real debounce timer (NewSessionDetector panics
+// if a watcher itself has no Identity, so there's no way to synthesize this
+// via a second watcher — the empty identity only ever arises internally, via
+// processActivityWithoutIdentity) rather than a synthetic shortcut.
+func TestSessionDetector_NewSession_HostGateRejectionSurvivesIdentityLessRetry(t *testing.T) {
+	tw := newMockAgentWatcher().withIdentity(agent.Identity{Name: "antigravity"})
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	discovers := map[string]agent.PIDDiscoverFunc{
+		"antigravity": func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
+			return 62540, nil
+		},
+	}
+	det := services.NewSessionDetector(
+		[]inbound.Watcher{tw}, pw, repo,
+		&mockLogger{}, &cwdGit{cwd: "/Users/ghost"}, &mockMetrics{}, nil,
+		"test", 0, discovers, nil, nil,
+	)
+	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return false })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	transcriptPath := "/home/.gemini/antigravity-cli/brain/conv/transcript.jsonl"
+
+	// First event: proper identity, rejected by the host gate.
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "ghost-retry",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: transcriptPath,
+	}
+	time.Sleep(30 * time.Millisecond)
+
+	// First EventActivity for this session ID: onActivity fires it
+	// immediately (with proper identity) and starts the debounce window —
+	// state is still nil, so this re-enters onNewSession and is rejected
+	// again, this time via the hostGateRejected cache.
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "ghost-retry",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: transcriptPath,
+	}
+	time.Sleep(30 * time.Millisecond)
+
+	// Second EventActivity within the debounce window: coalesced, and
+	// re-dispatched after activityDebounceWindow via
+	// processActivityWithoutIdentity — the empty-identity call this test
+	// targets.
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "ghost-retry",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: transcriptPath,
+	}
+	// activityDebounceWindow (session_detector.go) is 2s and unexported;
+	// this external test package can't reference it directly.
+	time.Sleep(2*time.Second + 200*time.Millisecond)
+	cancel()
+	<-done
+
+	if state, _ := repo.Load("ghost-retry"); state != nil {
+		t.Errorf("session rejected by the host gate should stay rejected on a coalesced, identity-less retry, got state %q", state.State)
+	}
+}
+
 // --- stale-transcript rescue (issue #576) -------------------------------------
 //
 // When observe consent is granted after agent sessions are already running,

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -141,6 +141,91 @@ func TestSessionDetector_NewSession_SkipsWhenCWDDeleted(t *testing.T) {
 	}
 }
 
+// TestSessionDetector_NewSession_SkipsNonInteractiveHost is the regression
+// test for issue #784: an adapter that opts into RequireKnownHost (currently
+// only antigravity) must never create a session for a process whose ancestry
+// doesn't resolve to a known terminal or IDE — e.g. a third-party tool like
+// CodexBar keeping the agent's CLI running in the background for quota
+// polling, with a real, live, but non-interactive PID.
+func TestSessionDetector_NewSession_SkipsNonInteractiveHost(t *testing.T) {
+	tw := newMockAgentWatcher().withIdentity(agent.Identity{Name: "antigravity"})
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	discovers := map[string]agent.PIDDiscoverFunc{
+		"antigravity": func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
+			return 62540, nil // real, live PID — just not launched by a terminal/IDE
+		},
+	}
+	det := services.NewSessionDetector(
+		[]inbound.Watcher{tw}, pw, repo,
+		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
+		"test", 0, discovers, nil, nil,
+	)
+	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return false })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "ghost1",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: "/home/.gemini/antigravity-cli/brain/conv/transcript.jsonl",
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if state, _ := repo.Load("ghost1"); state != nil {
+		t.Errorf("session bound to a non-interactive host should not be created, got state %q", state.State)
+	}
+}
+
+// TestSessionDetector_NewSession_AdmitsKnownHost is the companion to
+// TestSessionDetector_NewSession_SkipsNonInteractiveHost: a real session
+// whose process ancestry resolves to a known terminal/IDE must be admitted
+// exactly as before — the #784 gate must not delay or block legitimate
+// sessions.
+func TestSessionDetector_NewSession_AdmitsKnownHost(t *testing.T) {
+	tw := newMockAgentWatcher().withIdentity(agent.Identity{Name: "antigravity"})
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	discovers := map[string]agent.PIDDiscoverFunc{
+		"antigravity": func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
+			return 4242, nil
+		},
+	}
+	det := services.NewSessionDetector(
+		[]inbound.Watcher{tw}, pw, repo,
+		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
+		"test", 0, discovers, nil, nil,
+	)
+	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return true })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "real1",
+		ProjectDir:     "-Users-test-project",
+		TranscriptPath: "/home/.gemini/antigravity-cli/brain/conv/transcript.jsonl",
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if state, err := repo.Load("real1"); err != nil || state == nil {
+		t.Fatalf("session bound to a known host should be created: err=%v state=%v", err, state)
+	}
+}
+
 // --- stale-transcript rescue (issue #576) -------------------------------------
 //
 // When observe consent is granted after agent sessions are already running,

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -649,6 +649,14 @@ func main() {
 	if !demoMode {
 		detector.SetInfraReaper(agents.ArgvExcluders(allAgents), processlifecycle.ReadArgv)
 	}
+	// Reject a candidate PID launched by something other than a known
+	// terminal or IDE before a session is ever created — e.g. CodexBar
+	// keeping an Antigravity `agy` process running in the background for
+	// quota polling, with no distinguishing argv or cwd (#784). Demo mode
+	// never tracks live processes, so leave the gate unwired there.
+	if !demoMode {
+		detector.SetHostGate(agents.RequireKnownHost(allAgents), processlifecycle.IsKnownInteractiveHost)
+	}
 	// Consent gate for the detector's own transcript reads (startup seed +
 	// stale-working refresh of PERSISTED sessions) — the watcher pipeline
 	// is gated by construction, but these two paths read repo-listed

--- a/core/domain/agent/declaration.go
+++ b/core/domain/agent/declaration.go
@@ -125,4 +125,15 @@ type Process struct {
 	// (unreadable, e.g. hardened-runtime) is passed through, so an adapter's
 	// predicate must default to *not* excluding when it can't tell.
 	ExcludeArgv func(argv []string) bool
+
+	// RequireKnownHost, when true, gates session admission on the bound
+	// process's OS-level ancestry: a candidate PID whose parent chain doesn't
+	// resolve to a recognized terminal emulator or IDE is rejected, and no
+	// session is created for it. Unlike ExcludeArgv (adapter-specific argv
+	// shapes), the ancestry check itself is generic and shared — this is a
+	// plain opt-in flag, not a predicate. Added for issue #784: a third-party
+	// menu-bar app (CodexBar) kept an Antigravity `agy` CLI process running in
+	// the background for quota polling, with no distinguishing argv or cwd
+	// signal, so identity has to come from who launched the process instead.
+	RequireKnownHost bool
 }


### PR DESCRIPTION
## Summary

CodexBar (a third-party menu-bar app, github.com/steipete/CodexBar) deliberately keeps an Antigravity `agy` CLI process running in the background to poll quota data — confirmed in its own docs/source (PTY-launched, bare argv, cwd forced to `$HOME`, never sent any input). Irrlicht had no way to recognize this as non-interactive infra, so it surfaced a permanent phantom menu-bar circle for it; restarting Irrlicht didn't help since the app just reconnects to the already-running daemon.

A TTL/staleness-based fix was considered and rejected: Antigravity's `NoSubstantiveActivity` signal resets on any parseable line, so a periodically-active CodexBar poll would make a reaped ghost look freshly alive again minutes later — a worse, flickering UX than the original bug.

- Add `Process.RequireKnownHost` (mirrors the existing `ExcludeArgv` opt-in pattern) — antigravity is the only adapter that sets it.
- `PIDManager.AllowsSession` does a synchronous, one-shot ancestry check the moment a candidate PID is discovered, wired into `onNewSession` alongside the existing admission vetoes. A process whose ancestry doesn't resolve to a known terminal/IDE never becomes a session in the first place — no delay for real sessions, no reappearing ghost for CodexBar's.
- Reuses the ancestry-walking machinery built for #728 (Obsidian click-to-focus), extended with an explicit `knownEmbeddedHostBundleIDs` allow-list (starting with Obsidian's bundle ID) — the existing generic "any top-level `.app`" fallback can't be reused as-is since it would also match CodexBar.
- Fails open on non-macOS platforms (ancestry resolution is darwin-only, and CodexBar itself only exists on macOS).

Closes #784

## Test plan

- [x] `go test ./core/... -race -count=1` — full suite green (two unrelated pre-existing `-race` flakes in `core/application/services` reproduced identically on unmodified `main`, confirmed not caused by this change)
- [x] `go vet ./...` and `gofmt -l` clean
- [x] New unit tests: `TestIsKnownInteractiveHostFrom` (deterministic allow-list decisions), `TestAllowsSession` (fail-open on no-PID, reject on unknown host, no-op for non-opted-in adapters), `TestSessionDetector_NewSession_{Skips,Admits}...` (integration-level: a CodexBar-shaped ghost never gets a `SessionState`; a real-host session is admitted immediately)
- [ ] Manual confirmation against the reporter's machine once they reply with an `irrlichd --diagnose` bundle (requested on #784)

🤖 Generated with [Claude Code](https://claude.com/claude-code)