### PR TITLE
fix(daemon): History Group=Model bucket everything under "unknown"

### DIFF
--- a/core/adapters/outbound/filesystem/cost_tracker.go
+++ b/core/adapters/outbound/filesystem/cost_tracker.go
@@ -29,7 +29,10 @@ const (
 	// JSONL with omitempty, so pre-v2 rows simply decode with empty branch and
 	// model (read back as "unknown" for those group axes) — no migration and
 	// no daemon-restart requirement. The constant is documentary; rows do not
-	// carry it.
+	// carry it. Note: rows written between #750 and #792's fix are also
+	// schema-v2 but have an empty model for a different reason (a dead source
+	// field, not a pre-v2 row) — no backfill for those either, they age out
+	// under normal retention.
 	costSchemaVersion = 2
 )
 
@@ -119,10 +122,23 @@ func (t *CostTracker) SetProviderResolver(fn func(*session.SessionState) string)
 	}
 }
 
-// RecordSnapshot appends a row for the session if cost or any cumulative
-// token count has changed since the last stored row, and at least
-// costWriteInterval has elapsed since that row. No-ops on sessions without
-// metrics or a project name — nothing useful to store.
+// modelForRow resolves a session's model name for a cost row: prefer the
+// live Metrics.ModelName (populated by the adapters/tailer as turns stream
+// in), falling back to the SessionState.Model field when ModelName is empty
+// or the "unknown" sentinel. Mirrors the equivalent resolution in the
+// session-list handler (handlers.go's /state endpoint) — shared here between
+// RecordSnapshot and RecordBaseline, the two callers within this file.
+func modelForRow(state *session.SessionState) string {
+	if state.Metrics.ModelName != "" && state.Metrics.ModelName != "unknown" {
+		return state.Metrics.ModelName
+	}
+	return state.Model
+}
+
+// RecordSnapshot appends a row for the session if cost, any cumulative token
+// count, or the resolved model has changed since the last stored row, and at
+// least costWriteInterval has elapsed since that row. No-ops on sessions
+// without metrics or a project name — nothing useful to store.
 func (t *CostTracker) RecordSnapshot(state *session.SessionState) error {
 	if state == nil || state.Metrics == nil {
 		return nil
@@ -132,17 +148,13 @@ func (t *CostTracker) RecordSnapshot(state *session.SessionState) error {
 		return nil
 	}
 	m := state.Metrics
-	model := state.Model
-	if m.ModelName != "" && m.ModelName != "unknown" {
-		model = m.ModelName
-	}
 
 	row := snapshotRow{
 		TS:        time.Now().Unix(),
 		Project:   state.ProjectName,
 		Branch:    state.GitBranch,
 		Provider:  t.providerOf(state),
-		Model:     model,
+		Model:     modelForRow(state),
 		Session:   state.SessionID,
 		Cost:      m.EstimatedCostUSD,
 		CumIn:     m.CumInputTokens,
@@ -158,7 +170,8 @@ func (t *CostTracker) RecordSnapshot(state *session.SessionState) error {
 			prev.CumIn == row.CumIn &&
 			prev.CumOut == row.CumOut &&
 			prev.CumRead == row.CumRead &&
-			prev.CumCreate == row.CumCreate
+			prev.CumCreate == row.CumCreate &&
+			prev.Model == row.Model
 		if unchanged {
 			t.mu.Unlock()
 			return nil
@@ -215,16 +228,12 @@ func (t *CostTracker) RecordBaseline(state *session.SessionState) error {
 	if ts == 0 {
 		ts = time.Now().Unix()
 	}
-	model := state.Model
-	if m.ModelName != "" && m.ModelName != "unknown" {
-		model = m.ModelName
-	}
 	row := snapshotRow{
 		TS:        ts,
 		Project:   state.ProjectName,
 		Branch:    state.GitBranch,
 		Provider:  t.providerOf(state),
-		Model:     model,
+		Model:     modelForRow(state),
 		Session:   state.SessionID,
 		Cost:      m.EstimatedCostUSD,
 		CumIn:     m.CumInputTokens,

--- a/core/adapters/outbound/filesystem/cost_tracker.go
+++ b/core/adapters/outbound/filesystem/cost_tracker.go
@@ -40,7 +40,7 @@ type snapshotRow struct {
 	Project   string  `json:"project,omitempty"`  // raw SessionState.ProjectName (filename is sanitized)
 	Branch    string  `json:"branch,omitempty"`   // SessionState.GitBranch ("" = detached/unknown); see #750
 	Provider  string  `json:"provider,omitempty"` // "anthropic", "openai", or "" (unknown); see providerForSession
-	Model     string  `json:"model,omitempty"`    // SessionState.Model ("" = unknown)
+	Model     string  `json:"model,omitempty"`    // Metrics.ModelName, falling back to SessionState.Model ("" = unknown)
 	Session   string  `json:"session"`
 	Cost      float64 `json:"cost"`
 	CumIn     int64   `json:"cum_in,omitempty"`
@@ -132,13 +132,17 @@ func (t *CostTracker) RecordSnapshot(state *session.SessionState) error {
 		return nil
 	}
 	m := state.Metrics
+	model := state.Model
+	if m.ModelName != "" && m.ModelName != "unknown" {
+		model = m.ModelName
+	}
 
 	row := snapshotRow{
 		TS:        time.Now().Unix(),
 		Project:   state.ProjectName,
 		Branch:    state.GitBranch,
 		Provider:  t.providerOf(state),
-		Model:     state.Model,
+		Model:     model,
 		Session:   state.SessionID,
 		Cost:      m.EstimatedCostUSD,
 		CumIn:     m.CumInputTokens,
@@ -211,12 +215,16 @@ func (t *CostTracker) RecordBaseline(state *session.SessionState) error {
 	if ts == 0 {
 		ts = time.Now().Unix()
 	}
+	model := state.Model
+	if m.ModelName != "" && m.ModelName != "unknown" {
+		model = m.ModelName
+	}
 	row := snapshotRow{
 		TS:        ts,
 		Project:   state.ProjectName,
 		Branch:    state.GitBranch,
 		Provider:  t.providerOf(state),
-		Model:     state.Model,
+		Model:     model,
 		Session:   state.SessionID,
 		Cost:      m.EstimatedCostUSD,
 		CumIn:     m.CumInputTokens,

--- a/core/adapters/outbound/filesystem/cost_tracker_test.go
+++ b/core/adapters/outbound/filesystem/cost_tracker_test.go
@@ -357,6 +357,27 @@ func TestRecordBaseline_WritesOncePerSession(t *testing.T) {
 	}
 }
 
+// TestRecordBaseline_ModelFromMetrics is RecordBaseline's twin of
+// TestRecordSnapshot_ModelFromMetrics — RecordBaseline resolves the model via
+// the same modelForRow helper, but has its own call site, so it needs its own
+// regression test rather than relying on RecordSnapshot's coverage.
+func TestRecordBaseline_ModelFromMetrics(t *testing.T) {
+	tr := newTestTracker(t)
+	state := &session.SessionState{
+		SessionID:   "s1",
+		ProjectName: "proj-a",
+		FirstSeen:   1_700_000_000,
+		Metrics:     &session.SessionMetrics{EstimatedCostUSD: 0.50, ModelName: "claude-sonnet-5"},
+	}
+	if err := tr.RecordBaseline(state); err != nil {
+		t.Fatal(err)
+	}
+	rows := readRows(t, tr.filePath("proj-a"))
+	if len(rows) != 1 || rows[0].Model != "claude-sonnet-5" {
+		t.Fatalf("want model from Metrics.ModelName, got %+v", rows)
+	}
+}
+
 func TestProjectKey_SanitisesUnsafeChars(t *testing.T) {
 	if k := projectKey("foo/bar"); k != "foo_bar" {
 		t.Fatalf("want foo_bar, got %s", k)
@@ -641,6 +662,41 @@ func TestRecordSnapshot_ModelUnknownSentinelFallsBackEmpty(t *testing.T) {
 	rows := readRows(t, tr.filePath("proj-a"))
 	if len(rows) != 1 || rows[0].Model != "" {
 		t.Fatalf("want empty model (SessionState.Model fallback) for the unknown sentinel, got %+v", rows)
+	}
+}
+
+// TestRecordSnapshot_ModelChangeAloneTriggersWrite: the dedup check that
+// gates each write compares Cost/CumIn/CumOut/CumRead/CumCreate — a model
+// resolving (or changing) with no coincident cost/token delta must still be
+// treated as a change, or the new model is silently dropped and the stale
+// value from the last written row persists indefinitely for idle sessions.
+func TestRecordSnapshot_ModelChangeAloneTriggersWrite(t *testing.T) {
+	tr := newTestTracker(t)
+	state := &session.SessionState{
+		SessionID:   "s1",
+		ProjectName: "proj-a",
+		Metrics:     &session.SessionMetrics{EstimatedCostUSD: 0.10, ModelName: "unknown"},
+	}
+	if err := tr.RecordSnapshot(state); err != nil {
+		t.Fatal(err)
+	}
+
+	// Forge an older lastWrite so the *interval* throttle doesn't also
+	// suppress the second write — isolating the model-only-change path.
+	tr.mu.Lock()
+	lw := tr.lastWrite["s1"]
+	lw.TS -= int64(costWriteInterval/time.Second) + 1
+	tr.lastWrite["s1"] = lw
+	tr.mu.Unlock()
+
+	// Model resolves; cost/tokens are unchanged.
+	state.Metrics.ModelName = "claude-opus-4-8"
+	if err := tr.RecordSnapshot(state); err != nil {
+		t.Fatal(err)
+	}
+	rows := readRows(t, tr.filePath("proj-a"))
+	if len(rows) != 2 || rows[1].Model != "claude-opus-4-8" {
+		t.Fatalf("want a second row capturing the resolved model, got %+v", rows)
 	}
 }
 

--- a/core/adapters/outbound/filesystem/cost_tracker_test.go
+++ b/core/adapters/outbound/filesystem/cost_tracker_test.go
@@ -601,6 +601,49 @@ func TestRecordSnapshot_StampsBranchAndModel(t *testing.T) {
 	}
 }
 
+// TestRecordSnapshot_ModelFromMetrics is the real-world shape (#792):
+// SessionState.Model is never set in production — the live model name lives
+// on Metrics.ModelName. A row must pick that up rather than always falling
+// back to the (empty) SessionState.Model, which previously bucketed every
+// session under "unknown" regardless of the model actually used.
+func TestRecordSnapshot_ModelFromMetrics(t *testing.T) {
+	tr := newTestTracker(t)
+	state := &session.SessionState{
+		SessionID:   "s1",
+		ProjectName: "proj-a",
+		Metrics:     &session.SessionMetrics{EstimatedCostUSD: 0.10, ModelName: "claude-opus-4-8"},
+	}
+	if err := tr.RecordSnapshot(state); err != nil {
+		t.Fatal(err)
+	}
+	rows := readRows(t, tr.filePath("proj-a"))
+	if len(rows) != 1 || rows[0].Model != "claude-opus-4-8" {
+		t.Fatalf("want model from Metrics.ModelName, got %+v", rows)
+	}
+}
+
+// TestRecordSnapshot_ModelUnknownSentinelFallsBackEmpty ensures the
+// Metrics.ModelName "unknown" sentinel (distinct from "") doesn't get
+// persisted verbatim — it should fall through to the empty/SessionState.Model
+// fallback like handlers.go's session-list resolution does, so it still
+// buckets under the aggregate unknown group rather than a literal "unknown"
+// model name.
+func TestRecordSnapshot_ModelUnknownSentinelFallsBackEmpty(t *testing.T) {
+	tr := newTestTracker(t)
+	state := &session.SessionState{
+		SessionID:   "s1",
+		ProjectName: "proj-a",
+		Metrics:     &session.SessionMetrics{EstimatedCostUSD: 0.10, ModelName: "unknown"},
+	}
+	if err := tr.RecordSnapshot(state); err != nil {
+		t.Fatal(err)
+	}
+	rows := readRows(t, tr.filePath("proj-a"))
+	if len(rows) != 1 || rows[0].Model != "" {
+		t.Fatalf("want empty model (SessionState.Model fallback) for the unknown sentinel, got %+v", rows)
+	}
+}
+
 // TestSnapshotSchema_PreV2RowsReadUnknown asserts the schema bump is backward
 // compatible: a row written without the branch/model columns decodes with both
 // empty and buckets under the unknown ("") key on those axes — no migration.


### PR DESCRIPTION
## Summary
- `RecordSnapshot`/`RecordBaseline` in `cost_tracker.go` stamped each cost row's `Model` field from `SessionState.Model`, a field that's never assigned anywhere in production code (only in a test fixture) — always `""`. Every row landed in the aggregate "unknown" bucket, so grouping History's Usage tab by Model always showed a single "unknown" entry no matter which models were actually used.
- Fall back to `Metrics.ModelName` (guarding empty and the `"unknown"` sentinel), mirroring the pattern already used correctly in the session-list handler (`handlers.go:1071-1073`).
- Introduced ~2026-06-27 in #750/#771 (branch/worktree + provider/model attribution) — the `Model` column was wired to the wrong source field from day one, not a regression and not a data-quality issue with pre-existing history.

Fixes #792

## Test plan
- [x] Added `TestRecordSnapshot_ModelFromMetrics` — confirmed it fails without the fix (`Model` empty) and passes with it
- [x] Added `TestRecordSnapshot_ModelUnknownSentinelFallsBackEmpty` — the `"unknown"` sentinel doesn't get persisted verbatim, keeps bucketing under the aggregate unknown group
- [x] `go test ./core/adapters/outbound/filesystem/... -v` — all pass, including the pre-existing `TestRecordSnapshot_StampsBranchAndModel` (still valid, exercises the `SessionState.Model` fallback path)
- [x] `go test ./core/... -race -count=1` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)