### PR TITLE
fix(macos): persist Expand All Task Summaries toggle across restarts

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -84,8 +84,11 @@ class SessionManager: ObservableObject {
     /// Global collapse state for every session's task-summary/question block
     /// (issue #738). A single bool — not a per-id set — so sessions that appear
     /// after a "collapse all" still honor it (a snapshot set would leave new
-    /// rows expanded). Default expanded; in-memory only.
-    @Published var summariesCollapsed: Bool = false
+    /// rows expanded). Default expanded. Persisted in UserDefaults (#799) so
+    /// the choice survives app restarts.
+    @Published var summariesCollapsed: Bool = UserDefaults.standard.bool(forKey: "summariesCollapsed") {
+        didSet { UserDefaults.standard.set(summariesCollapsed, forKey: "summariesCollapsed") }
+    }
 
     /// Timer that periodically re-hydrates sessions so group-level cost
     /// values (which only ride the /api/v1/sessions response) stay fresh —

--- a/platforms/macos/Tests/SessionRowSnapshotTests.swift
+++ b/platforms/macos/Tests/SessionRowSnapshotTests.swift
@@ -12,6 +12,7 @@ final class SessionRowSnapshotTests: XCTestCase {
     private var originalThresholdValue: Any?
     private var originalThresholdUnit: Any?
     private var originalUserIntent: Any?
+    private var originalSummariesCollapsed: Any?
 
     override func setUp() async throws {
         try await super.setUp()
@@ -24,6 +25,7 @@ final class SessionRowSnapshotTests: XCTestCase {
         originalThresholdValue = defaults.object(forKey: ContextPressureThreshold.valueKey)
         originalThresholdUnit = defaults.object(forKey: ContextPressureThreshold.unitKey)
         originalUserIntent = defaults.object(forKey: "userIntentDisplay")
+        originalSummariesCollapsed = defaults.object(forKey: "summariesCollapsed")
         defaults.set("context", forKey: "displayMode")
         defaults.set(false, forKey: "debugMode")
         defaults.set(false, forKey: "showCostDisplay")
@@ -32,6 +34,9 @@ final class SessionRowSnapshotTests: XCTestCase {
         // of the developer's Settings (issue #689 made it configurable).
         defaults.set(80, forKey: ContextPressureThreshold.valueKey)
         defaults.set(ContextPressureThreshold.Unit.percent.rawValue, forKey: ContextPressureThreshold.unitKey)
+        // summariesCollapsed now persists (#799) — pin it so SessionManager's
+        // init value doesn't depend on the developer's real toggle state.
+        defaults.set(false, forKey: "summariesCollapsed")
         sessionManager = SessionManager()
     }
 
@@ -42,6 +47,7 @@ final class SessionRowSnapshotTests: XCTestCase {
         restore(key: ContextPressureThreshold.valueKey, value: originalThresholdValue)
         restore(key: ContextPressureThreshold.unitKey, value: originalThresholdUnit)
         restore(key: "userIntentDisplay", value: originalUserIntent)
+        restore(key: "summariesCollapsed", value: originalSummariesCollapsed)
         try await super.tearDown()
     }
 


### PR DESCRIPTION
## Summary
- `summariesCollapsed` (the global "Expand all task summaries" / "Collapse all task summaries" toggle) was in-memory only, so it reset to expanded on every app launch.
- Persists the value in `UserDefaults` via a `didSet` on the `@Published` property, initialized from the stored value (defaults to expanded/`false` when absent, matching today's first-launch behavior).
- Pinned the new `summariesCollapsed` UserDefaults key in `SessionRowSnapshotTests`'s setUp/tearDown (mirroring the file's existing guards for `displayMode`, `userIntentDisplay`, etc.) so the snapshot test doesn't leak state into, or depend on, the developer's real preference.

Fixes #799

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` — all 202 tests pass (0 failures), including `testCollapsed_HidesSummaryBlocks`
- [x] Verified via `defaults read` that no test run leaks `summariesCollapsed` into the real `UserDefaults` domain
- [x] `/code-review` (low effort) — no findings
- [x] `/simplify` — diff is minimal (3-line property change), already in the idiomatic form used elsewhere in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)