### PR TITLE
chore(ci): add manual CodeScene report fetcher

### DIFF
--- a/.github/workflows/codescene-report.yml
+++ b/.github/workflows/codescene-report.yml
@@ -1,0 +1,25 @@
+name: CodeScene Report (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      endpoint:
+        description: "API path under /v2/projects/<id>/ (default: analyses/latest)"
+        required: false
+        default: "analyses/latest"
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Fetch CodeScene report
+        env:
+          CODESCENE_API_TOKEN: ${{ secrets.CODESCENE_API_TOKEN }}
+          CODESCENE_PROJECT_ID: "82148"
+        run: tools/codescene-report.sh "${{ inputs.endpoint }}"

--- a/tools/codescene-report.sh
+++ b/tools/codescene-report.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# codescene-report.sh — fetch a CodeScene cloud analysis report for this
+# repo's connected project (api.codescene.io/v2), for agents/scripts to read.
+#
+# Requires:
+#   CODESCENE_API_TOKEN    Bearer token from the CodeScene dashboard's API
+#                          tokens page (repo secret in CI; never commit it).
+#   CODESCENE_PROJECT_ID   This repo's CodeScene project id (82148 for
+#                          ingo-eichhorst/Irrlicht).
+#
+# Usage:
+#   tools/codescene-report.sh                        # latest analysis overview
+#   tools/codescene-report.sh analyses/123/components # any endpoint under
+#                                                      # /v2/projects/<id>/
+set -euo pipefail
+
+: "${CODESCENE_API_TOKEN:?CODESCENE_API_TOKEN env var required}"
+: "${CODESCENE_PROJECT_ID:?CODESCENE_PROJECT_ID env var required}"
+
+ENDPOINT="${1:-analyses/latest}"
+API_BASE="https://api.codescene.io/v2/projects/${CODESCENE_PROJECT_ID}"
+
+curl -sf -H "Authorization: Bearer ${CODESCENE_API_TOKEN}" "${API_BASE}/${ENDPOINT}" | jq .


### PR DESCRIPTION
## Summary
- Adds `tools/codescene-report.sh` + a `workflow_dispatch` job so an agent (or human) can pull a live CodeScene cloud analysis report (Code Health, hotspots, architectural component health) on demand, via the repo's connected CodeScene project (id 82148).
- Read-only reporting only — no gating, no changes to `core/` or any application behavior.

## Test plan
- [x] Script syntax validated (`bash -n`), YAML validated.
- [ ] Trigger `workflow_dispatch` after merge and confirm it prints a report using the `CODESCENE_API_TOKEN` repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)