### PR TITLE
feat(core): enforce hexagonal layering + architecture-score regression gate

### DIFF
--- a/.github/workflows/ars-gate.yml
+++ b/.github/workflows/ars-gate.yml
@@ -1,0 +1,27 @@
+name: ARS Architecture Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ars-gate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: false
+
+      - name: Run ARS architecture gate
+        run: tools/ars-gate.sh core

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,12 +47,15 @@ Before marking a ticket done, run the full suite — every layer must pass:
   from Key Conventions — `domain/` and `ports/` packages may not import
   outward into `adapters/` or `application/`, and `application/services/`
   may only reach `adapters/inbound/` through `ports/`.
-- Architecture score: `tools/ars-gate.sh` fails if the Agent Readiness Score
-  (composite or any category) regresses vs `origin/main` — enforced as a
-  required PR check (`.github/workflows/ars-gate.yml`) and mirrored locally
-  by `tools/preflight.sh`'s `arch` gate (see "Local CI parity" below).
-  Deterministic and workflow-agnostic: it fires on any push, not tied to a
-  specific agent skill.
+- Architecture score: `tools/ars-gate.sh` flags it when the Agent Readiness
+  Score (composite or any category) regresses vs `origin/main` — advisory,
+  not a merge gate: it runs as a PR check (`.github/workflows/ars-gate.yml`,
+  not required by branch protection) and is mirrored locally by
+  `tools/preflight.sh`'s `arch` gate (see "Local CI parity" below). A
+  red result is a prompt to look closer, not a block — use judgment on
+  whether the regression is worth addressing before merging. Deterministic
+  and workflow-agnostic: it fires on any push, not tied to a specific agent
+  skill.
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh`
 - Replay goldens (when a recording or replay-output change is in play):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,17 @@ Before marking a ticket done, run the full suite — every layer must pass:
 - Unit + e2e: `go test ./core/... -race -count=1` (includes the headless
   daemon startup smoke test — boots a real `irrlichd` on an ephemeral port
   under `t.TempDir()`, so it never touches the production daemon).
+- Architecture: `core/architecture_test.go` (runs automatically as part of
+  `go test ./core/...`) statically enforces the hexagonal import direction
+  from Key Conventions — `domain/` and `ports/` packages may not import
+  outward into `adapters/` or `application/`, and `application/services/`
+  may only reach `adapters/inbound/` through `ports/`.
+- Architecture score: `tools/ars-gate.sh` fails if the Agent Readiness Score
+  (composite or any category) regresses vs `origin/main` — enforced as a
+  required PR check (`.github/workflows/ars-gate.yml`) and mirrored locally
+  by `tools/preflight.sh`'s `arch` gate (see "Local CI parity" below).
+  Deterministic and workflow-agnostic: it fires on any push, not tied to a
+  specific agent skill.
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh`
 - Replay goldens (when a recording or replay-output change is in play):
@@ -63,16 +74,17 @@ Before marking a ticket done, run the full suite — every layer must pass:
 
 ### Local CI parity — catch failures before pushing
 
-`tools/preflight.sh` runs every PR-gating check (test.yml + web-test.yml,
-plus the full Linux build+test+replay-fixtures gate via Docker under
-`--linux`) locally, in CI's order, and prints a pass/fail summary instead of
-stopping at the first failure — so before opening a PR, run it once instead
-of round-tripping through GitHub Actions per fix:
+`tools/preflight.sh` runs every PR-gating check (test.yml + web-test.yml +
+ars-gate.yml, plus the full Linux build+test+replay-fixtures gate via Docker
+under `--linux`) locally, in CI's order, and prints a pass/fail summary
+instead of stopping at the first failure — so before opening a PR, run it
+once instead of round-tripping through GitHub Actions per fix:
 
 ```
 tools/preflight.sh                # everything except the Linux Docker gate
 tools/preflight.sh --linux        # + full Linux parity (slow: needs Docker)
 tools/preflight.sh --only go      # just the go-test.yml-equivalent gates
+tools/preflight.sh --only arch    # just the ARS architecture gate
 ```
 
 `tools/install-git-hooks.sh` (run once per clone; worktrees share the parent

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,9 @@ expected to follow.
 3. Add tests for new behavior; prefer table-driven tests in Go.
 4. Run the full test suite locally (see [AGENTS.md](AGENTS.md#testing)).
 5. Push and open a PR. Fill in the PR template (summary, test plan, screenshots for UI work).
-   A PR's architecture-health score (`core/`) may not regress vs `main` — the
-   `ARS Architecture Gate` CI check enforces this (see [AGENTS.md](AGENTS.md#testing)
+   The `ARS Architecture Gate` CI check flags an architecture-health
+   (`core/`) regression vs `main` — advisory, not required to merge; treat a
+   red result as a prompt to look closer (see [AGENTS.md](AGENTS.md#testing)
    for the local `tools/preflight.sh` equivalent).
 6. Expect review feedback. Small PRs merge faster.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ git clone https://github.com/ingo-eichhorst/Irrlicht.git
 cd Irrlicht
 ./tools/build-release.sh       # build daemon + macOS app
 go test ./core/... -race -count=1   # run the Go suite (see AGENTS.md for the full list)
+tools/install-git-hooks.sh     # one-time: wire the pre-push preflight check
 ```
 
 The full suite — Go unit + e2e, the onboarding-factory, replay fixtures, and the
@@ -52,6 +53,9 @@ expected to follow.
 3. Add tests for new behavior; prefer table-driven tests in Go.
 4. Run the full test suite locally (see [AGENTS.md](AGENTS.md#testing)).
 5. Push and open a PR. Fill in the PR template (summary, test plan, screenshots for UI work).
+   A PR's architecture-health score (`core/`) may not regress vs `main` — the
+   `ARS Architecture Gate` CI check enforces this (see [AGENTS.md](AGENTS.md#testing)
+   for the local `tools/preflight.sh` equivalent).
 6. Expect review feedback. Small PRs merge faster.
 
 Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/):

--- a/core/architecture_test.go
+++ b/core/architecture_test.go
@@ -1,0 +1,66 @@
+// architecture_test.go lives at the module root, not in a subpackage, so
+// packages.Load's "./..." pattern can see every package in the module from
+// a single load.
+package core_test
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+func TestArchitectureLayerImportDirection(t *testing.T) {
+	cfg := &packages.Config{Mode: packages.NeedName | packages.NeedImports, Dir: "."}
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatalf("packages.Load: %v", err)
+	}
+	if n := packages.PrintErrors(pkgs); n > 0 {
+		t.Fatalf("packages.Load reported %d package error(s); build is broken", n)
+	}
+	if len(pkgs) == 0 {
+		t.Fatalf("packages.Load returned no packages for pattern \"./...\"")
+	}
+
+	rules := []struct {
+		name              string
+		sourcePrefix      string
+		forbiddenPrefixes []string
+	}{
+		{
+			name:              "domain must not import ports, adapters, or application",
+			sourcePrefix:      "irrlicht/core/domain/",
+			forbiddenPrefixes: []string{"irrlicht/core/ports/", "irrlicht/core/adapters/", "irrlicht/core/application/"},
+		},
+		{
+			name:              "ports must not import adapters",
+			sourcePrefix:      "irrlicht/core/ports/",
+			forbiddenPrefixes: []string{"irrlicht/core/adapters/"},
+		},
+		{
+			name:              "application/services must reach adapters through ports, not directly into adapters/inbound",
+			sourcePrefix:      "irrlicht/core/application/services/",
+			forbiddenPrefixes: []string{"irrlicht/core/adapters/inbound/"},
+		},
+	}
+
+	for _, pkg := range pkgs {
+		for _, rule := range rules {
+			if !hasLayerPrefix(pkg.PkgPath, rule.sourcePrefix) {
+				continue
+			}
+			for importPath := range pkg.Imports { // map key is the direct import path
+				for _, forbidden := range rule.forbiddenPrefixes {
+					if hasLayerPrefix(importPath, forbidden) {
+						t.Errorf("layering violation (%s): %q imports %q", rule.name, pkg.PkgPath, importPath)
+					}
+				}
+			}
+		}
+	}
+}
+
+func hasLayerPrefix(path, prefix string) bool {
+	return path == strings.TrimSuffix(prefix, "/") || strings.HasPrefix(path, prefix)
+}

--- a/core/go.mod
+++ b/core/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/grandcat/zeroconf v1.0.0
 	golang.org/x/sys v0.45.0
+	golang.org/x/tools v0.42.0
 	modernc.org/sqlite v1.50.0
 )
 
@@ -22,7 +23,6 @@ require (
 	golang.org/x/mod v0.33.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/tools v0.42.0 // indirect
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/tools/ars-gate.sh
+++ b/tools/ars-gate.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# ars-gate.sh — deterministic architecture-regression gate.
+#
+# Scans the given directory (default: core) with ARS (Agent Readiness Score,
+# github.com/ingo-eichhorst/agent-readyness) and fails if the composite score,
+# or any individual category score, has regressed vs a fresh origin/main scan.
+#
+# Shared by .githooks/pre-push and .github/workflows/ars-gate.yml so both
+# enforcement points use identical comparison logic — never duplicate the
+# diff logic in the hook or the workflow, call this script from both.
+#
+# Usage: tools/ars-gate.sh [<dir>]   # <dir> is relative to the repo root, default "core"
+set -euo pipefail
+
+DIR="${1:-core}"
+TOLERANCE="0.05"
+ARS_VERSION="v0.0.9" # keep in sync with .github/workflows/ars.yml
+
+command -v ars >/dev/null 2>&1 || go install "github.com/ingo-eichhorst/agent-readyness/cmd/ars@${ARS_VERSION}"
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+AFTER_JSON=$(mktemp)
+BEFORE_JSON=$(mktemp)
+BASE_WORKTREE=$(mktemp -d)
+cleanup() {
+  git worktree remove "$BASE_WORKTREE" --force >/dev/null 2>&1 || true
+  rm -f "$AFTER_JSON" "$BEFORE_JSON"
+}
+trap cleanup EXIT
+
+# `ars scan --json` prints a diagnostic line ("LLM features disabled...")
+# to stdout before the JSON payload; strip anything before the first "{".
+echo "ars-gate: scanning current tree ($DIR)..." >&2
+ars scan "$DIR" --no-llm --json | sed -n '/^{/,$p' >"$AFTER_JSON"
+
+echo "ars-gate: fetching origin/main and scanning baseline..." >&2
+git fetch --quiet origin main
+git worktree add --quiet --detach "$BASE_WORKTREE" origin/main
+ars scan "$BASE_WORKTREE/$DIR" --no-llm --json | sed -n '/^{/,$p' >"$BEFORE_JSON"
+
+RESULT=$(jq -n \
+  --slurpfile before "$BEFORE_JSON" \
+  --slurpfile after "$AFTER_JSON" \
+  --argjson tol "$TOLERANCE" \
+  '
+  ($before[0]) as $b | ($after[0]) as $a |
+  (($b.categories // []) | map({(.name): .score}) | add // {}) as $bc |
+  (($a.categories // []) | map({(.name): .score}) | add // {}) as $ac |
+  {
+    composite_before: $b.composite_score,
+    composite_after: $a.composite_score,
+    composite_regressed: (($b.composite_score - $a.composite_score) > $tol),
+    category_regressions: [
+      $bc | keys[] | . as $k
+      | select($ac[$k] != null and ($bc[$k] - $ac[$k]) > $tol)
+      | {name: $k, before: $bc[$k], after: $ac[$k], delta: ($ac[$k] - $bc[$k])}
+    ]
+  }
+  ')
+
+echo "$RESULT" | jq .
+
+COMPOSITE_REGRESSED=$(echo "$RESULT" | jq -r '.composite_regressed')
+CATEGORY_REGRESSION_COUNT=$(echo "$RESULT" | jq '.category_regressions | length')
+
+if [ "$COMPOSITE_REGRESSED" = "true" ] || [ "$CATEGORY_REGRESSION_COUNT" -gt 0 ]; then
+  echo "ars-gate: FAILED — architecture health regressed vs origin/main" >&2
+  echo "$RESULT" | jq '.category_regressions' >&2
+  exit 1
+fi
+
+echo "ars-gate: passed (composite $(echo "$RESULT" | jq -r '.composite_before') -> $(echo "$RESULT" | jq -r '.composite_after'))" >&2

--- a/tools/ars-gate.sh
+++ b/tools/ars-gate.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-# ars-gate.sh — deterministic architecture-regression gate.
+# ars-gate.sh — deterministic architecture-regression check (advisory, not a
+# merge gate: flags a regression for review, doesn't block a PR on its own).
 #
 # Scans the given directory (default: core) with ARS (Agent Readiness Score,
 # github.com/ingo-eichhorst/agent-readyness) and fails if the composite score,
 # or any individual category score, has regressed vs a fresh origin/main scan.
 #
-# Shared by .githooks/pre-push and .github/workflows/ars-gate.yml so both
-# enforcement points use identical comparison logic — never duplicate the
-# diff logic in the hook or the workflow, call this script from both.
+# Shared by tools/preflight.sh's `arch` gate and .github/workflows/ars-gate.yml
+# so both surfaces use identical comparison logic — never duplicate the diff
+# logic in preflight.sh or the workflow, call this script from both.
 #
 # Usage: tools/ars-gate.sh [<dir>]   # <dir> is relative to the repo root, default "core"
 set -euo pipefail

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -10,6 +10,8 @@
 #   .github/workflows/test.yml      — gofmt, core + onboarding-factory tests,
 #                                      of validate, recording-rig smoke test
 #   .github/workflows/web-test.yml  — npm test in both web trees
+#   .github/workflows/ars-gate.yml  — ARS architecture-regression gate
+#                                      (composite/category score vs origin/main)
 #   .github/workflows/linux.yml     — build + full test suite (-race) +
 #                                      replay-fixtures under Linux, via the
 #                                      linux-replay Docker image (opt-in:
@@ -20,6 +22,7 @@
 #   tools/preflight.sh --linux         # + full Linux parity via Docker
 #   tools/preflight.sh --only go       # just the go-test.yml-equivalent gates
 #   tools/preflight.sh --only web      # just the two npm test trees
+#   tools/preflight.sh --only arch     # just the ARS architecture gate
 #   tools/preflight.sh --only linux    # just the Linux Docker gate
 #
 # PLATFORMS overrides the Linux gate's docker --platform (default: linux/amd64,
@@ -88,6 +91,11 @@ web_tree() { ( cd "$1" && npm ci && npm test ); }
 if want web; then
   run_gate "web: platforms/web"             web_tree platforms/web
   run_gate "web: onboarding-factory viewer" web_tree tools/onboarding-factory/internal/viewer/web
+fi
+
+# ---- arch group (mirrors ars-gate.yml) -----------------------------------
+if want arch; then
+  run_gate "ARS architecture gate" tools/ars-gate.sh
 fi
 
 # ---- linux group (mirrors linux.yml, opt-in: --linux or --only linux) ---


### PR DESCRIPTION
## Summary
- `core/architecture_test.go` statically enforces the hexagonal import direction from AGENTS.md's Key Conventions, via `go/packages` direct-import checks: `domain/` and `ports/` may not import outward into `adapters/`/`application/`, and `application/services/` may only reach `adapters/inbound/` through `ports/`. This one's a real test — part of `go test ./core/...`, does fail the suite on a violation.
- `tools/ars-gate.sh` flags it when the Agent Readiness Score (composite or any category) regresses vs a fresh `origin/main` scan. **Advisory, not a merge gate** — runs as a PR check (`.github/workflows/ars-gate.yml`) and is mirrored locally via `tools/preflight.sh --only arch`, but branch protection does not require it to pass. A red result is a prompt to look closer, not a block.
- Deliberately git/CI-based rather than tied to any specific agent skill (e.g. `/ir:exec`), so the signal fires on any push regardless of what opened the PR.

Closes #796.

## Test plan
- [x] `core/architecture_test.go` verified to fail on an injected violation (both a same-layer `t.Errorf` case and a cross-layer import-cycle case), then reverted.
- [x] `tools/ars-gate.sh` verified against real data (this PR's actual diff: composite score improves slightly, 7.937 → 7.941) and against a synthetic regression (correctly flags the exact category/delta).
- [x] `tools/preflight.sh --only arch` runs the same check locally.
- [x] `ars-gate` confirmed to self-register and report on this very PR.
- [x] Branch protection confirmed to have no required status checks (ars-gate and CodeScene are both advisory-only, not merge gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)