### PR TITLE
fix(git-hooks): unset GIT_DIR/GIT_WORK_TREE before running preflight in pre-push

### DIFF
--- a/tools/git-hooks/pre-push
+++ b/tools/git-hooks/pre-push
@@ -17,5 +17,15 @@
 # `rm $(git rev-parse --git-common-dir)/hooks/pre-push`.
 set -uo pipefail
 
+# Git invokes hooks with GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE set in the
+# environment so the hook's own git commands target the right repo. That
+# leaks into preflight's `go test` subprocess and from there into any test
+# that shells out to `git` expecting isolation via an explicit working
+# directory (e.g. a fresh t.TempDir() repo) — the env override wins over
+# that directory, so the test's git commands silently operate on THIS repo
+# instead, capable of writing real commits onto the branch being pushed.
+# Unset them so preflight's git-touching tests see a clean environment.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 echo "pre-push: running tools/preflight.sh (skip with --no-verify)"
 ./tools/preflight.sh


### PR DESCRIPTION
## Summary
- Git invokes hooks with `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` set in the environment so the hook's own git commands target the right repo.
- That env leaks into `tools/preflight.sh`'s `go test` subprocess, and from there into any test that shells out to `git` expecting isolation via an explicit working directory (e.g. a fresh `t.TempDir()` repo in `core/adapters/outbound/git/adapter_test.go` or `core/application/services/yield_sweeper_test.go`). The env override wins over the test's own working directory, so the git operations silently land on the real repo being pushed instead of the isolated fixture.
- Observed live: pushing an unrelated feature branch through the `pre-push` hook produced real `add a.txt` / `add b.txt` commits on that branch from `TestYieldSweeper_RevertCorrelates`/`TestYieldSweeper_RevertOnUnmergedBranch`, plus `GetGitRoot`/`GetProjectName`/`GetHeadCommit` tests failing because they resolved to the real repo root instead of their temp fixture.
- Fix: `unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE` at the top of `tools/git-hooks/pre-push`, before `preflight.sh` runs.

## Test plan
- [x] Reproduced the leak conceptually and confirmed the affected tests (`TestGetGitRoot_DeletedSubdir`, `TestGetGitRoot_NotARepo`, `TestGetProjectName_DeletedWorktree`, `TestGetHeadCommit`, `TestYieldSweeper_RevertCorrelates`, `TestYieldSweeper_RevertOnUnmergedBranch`) pass cleanly in a normal (non-hook) environment
- [x] With the fix applied, pushed this branch through the real `pre-push` hook — `tools/preflight.sh` passed clean (gofmt, core module tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, both web suites)
- [x] Confirmed the pushing branch/worktree stayed clean (no stray commits or files) after the hook ran

🤖 Generated with [Claude Code](https://claude.com/claude-code)