### PR TITLE
feat(core): shared contract test for consent-gated adapter call sites (#797)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,17 @@ Before marking a ticket done, run the full suite — every layer must pass:
   whether the regression is worth addressing before merging. Deterministic
   and workflow-agnostic: it fires on any push, not tied to a specific agent
   skill.
+- Permission gating: `contracttesting.AssertPermissionGated` (`core/internal/contracttesting/permission_gate.go`)
+  is the behavioral counterpart to the architecture test — it can't be checked
+  statically because gating happens at runtime, by an adapter (or the shared
+  services layer) choosing to call `PermissionService.Granted`/`ObserveGranted`
+  before a read/write, or by wiring a permission's `Apply`/`Remove` closures.
+  New adapters should wire it into their test suite for every `modify`-kind
+  permission they declare — see `claudecode`'s hooks/statusline (a live
+  per-request `ConsentGate`), `claudecode`'s instructions and `processlifecycle`'s
+  kitty remote-control (install-type `Apply`/`Remove`), and `InputService`'s
+  backchannel forwarding (the shared "control" gate) for the three call-site
+  shapes it covers.
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh`
 - Replay goldens (when a recording or replay-output change is in play):

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -8,7 +8,9 @@ import (
 	"sync"
 	"testing"
 
+	"irrlicht/core/domain/permission"
 	"irrlicht/core/domain/session"
+	"irrlicht/core/internal/contracttesting"
 )
 
 // mockTarget records calls to HandlePermissionHook and HandleCompactHook for
@@ -43,6 +45,13 @@ func (m *mockTarget) getCalls() []hookCall {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return append([]hookCall{}, m.calls...)
+}
+
+func (m *mockTarget) reset() {
+	m.mu.Lock()
+	m.calls = nil
+	m.compactCalls = nil
+	m.mu.Unlock()
 }
 
 func (m *mockTarget) getCompactCalls() []compactCall {
@@ -352,6 +361,26 @@ type fakeGate bool
 
 func (g fakeGate) Granted(_, _ string) bool { return bool(g) }
 
+// mutableGate is a ConsentGate whose answer can change between calls —
+// needed to drive a single handler instance through all three consent
+// states for contracttesting.AssertPermissionGated.
+type mutableGate struct {
+	mu      sync.Mutex
+	granted bool
+}
+
+func (g *mutableGate) Granted(_, _ string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.granted
+}
+
+func (g *mutableGate) setGranted(v bool) {
+	g.mu.Lock()
+	g.granted = v
+	g.mu.Unlock()
+}
+
 func TestHookHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 	target := &mockTarget{}
 	handler := NewHookHandler(target, nil, fakeGate(false), mockLogger{})
@@ -564,4 +593,31 @@ func TestHookHandler_PreToolUse_UserInputToolStillDispatchesWithMarkerScan(t *te
 	if got := markers.getCalls(); len(got) != 1 || got[0].est.CompletedRounds != 2 {
 		t.Errorf("IngestTaskEstimate calls = %+v, want one 2/4 ingest (nested input walk)", got)
 	}
+}
+
+// TestHookHandler_PermissionGateContract wires the hooks permission's live
+// per-request ConsentGate check into the shared issue #797 contract: while
+// PermissionKeyHooks is pending or denied, an inbound hook payload must
+// dispatch to nothing; granted, it must dispatch; revoked, dispatch must
+// stop again. TestHookHandler_ConsentGateDropsWhenNotGranted /
+// ConsentGatePassesWhenGranted above cover the same call site by hand —
+// this is the generalized, three-state version.
+func TestHookHandler_PermissionGateContract(t *testing.T) {
+	target := &mockTarget{}
+	gate := &mutableGate{}
+	handler := NewHookHandler(target, nil, gate, mockLogger{})
+	payload := hookPayload{
+		TranscriptPath: "/Users/u/.claude/projects/p/sess-gate.jsonl",
+		HookEventName:  "PermissionRequest",
+		ToolName:       "Bash",
+	}
+
+	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+		SetState: func(state permission.State) { gate.setGranted(state == permission.StateGranted) },
+		Exercise: func() {
+			target.reset()
+			postHook(t, handler, payload)
+		},
+		Observe: func() bool { return len(target.getCalls()) > 0 },
+	})
 }

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -5,6 +5,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/internal/contracttesting"
 )
 
 // memoryPathFor returns the CLAUDE.md path inside the temp HOME.
@@ -468,4 +472,55 @@ func TestRemoveInstructionBlocks_RoundTripsToOriginal(t *testing.T) {
 	if got := readFileString(t, path); got != original {
 		t.Errorf("round-trip changed content:\n%q\nwant\n%q", got, original)
 	}
+}
+
+// findPermission returns the declared permission matching key, failing the
+// test if the adapter dropped or renamed it.
+func findPermission(t *testing.T, a agent.Agent, key string) agent.Permission {
+	t.Helper()
+	for _, p := range a.Permissions {
+		if p.Key == key {
+			return p
+		}
+	}
+	t.Fatalf("no permission %q declared by %s", key, a.Identity.Name)
+	return agent.Permission{}
+}
+
+// TestInstructionsPermission_GateContract drives the real Apply/Remove
+// closures behind the declared "instructions" permission through the
+// shared issue #797 contract. Unlike hooks/statusline (a live per-request
+// ConsentGate), this permission has no in-code check of its own — its
+// consent gate is entirely PermissionService's generic effect dispatch, so
+// this test proves that dispatch is wired to the real closures Agent()
+// exports, not a stand-in.
+func TestInstructionsPermission_GateContract(t *testing.T) {
+	home := withTempHome(t)
+	path := memoryPathFor(home)
+	decl := findPermission(t, Agent(), PermissionKeyInstructions)
+
+	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+		SetState: func(state permission.State) {
+			switch state {
+			case permission.StateGranted:
+				if err := decl.Apply(); err != nil {
+					t.Fatalf("Apply: %v", err)
+				}
+			case permission.StateDenied:
+				if err := decl.Remove(); err != nil {
+					t.Fatalf("Remove: %v", err)
+				}
+			}
+			// Pending: PermissionService never invokes Apply/Remove until
+			// the user answers, so there is nothing to do here.
+		},
+		Exercise: func() {}, // the effect IS the Apply/Remove call above
+		Observe: func() bool {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return false
+			}
+			return strings.Contains(string(data), taskEtaBeginSentinel)
+		},
+	})
 }

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"irrlicht/core/domain/permission"
 	"irrlicht/core/domain/session"
+	"irrlicht/core/internal/contracttesting"
 )
 
 type fakeRateLimitTarget struct {
@@ -23,6 +25,10 @@ type rateLimitCall struct {
 
 func (f *fakeRateLimitTarget) IngestRateLimit(path string, snap *session.RateLimitSnapshot) {
 	f.calls = append(f.calls, rateLimitCall{path: path, snap: snap})
+}
+
+func (f *fakeRateLimitTarget) reset() {
+	f.calls = nil
 }
 
 type silentLogger struct{}
@@ -280,4 +286,36 @@ func TestStatuslineHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 	if len(target.calls) != 0 {
 		t.Fatalf("ingested %d snapshots while permission not granted", len(target.calls))
 	}
+}
+
+// TestStatuslineHandler_PermissionGateContract generalizes
+// ConsentGateDropsWhenNotGranted into the shared issue #797 contract: an
+// inbound statusline POST must be dropped while PermissionKeyStatusline is
+// pending or denied, ingested once granted, and dropped again once
+// revoked.
+func TestStatuslineHandler_PermissionGateContract(t *testing.T) {
+	target := &fakeRateLimitTarget{}
+	gate := &mutableGate{}
+	h := NewStatuslineHandler(target, gate, silentLogger{})
+	body := `{
+		"session_id": "abc",
+		"transcript_path": "/tmp/sessions/abc.jsonl",
+		"rate_limits": {
+			"five_hour": {"used_percentage": 47, "resets_at": 1778761800}
+		}
+	}`
+
+	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+		SetState: func(state permission.State) { gate.setGranted(state == permission.StateGranted) },
+		Exercise: func() {
+			target.reset()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode/statusline", strings.NewReader(body))
+			rec := httptest.NewRecorder()
+			h(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+		},
+		Observe: func() bool { return len(target.calls) > 0 },
+	})
 }

--- a/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
@@ -5,6 +5,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/internal/contracttesting"
 )
 
 // withTempKittyConfig points kitty config resolution at a temp dir via
@@ -280,4 +284,51 @@ func TestKittyPermissionDeclarationShape(t *testing.T) {
 	if p.Apply == nil || p.Remove == nil {
 		t.Error("modify-kind permission must carry Apply and Remove closures")
 	}
+}
+
+// TestKittyPermission_GateContract drives the real Apply/Remove closures
+// behind the declared "remote-control" permission through the shared issue
+// #797 contract: like the claudecode instructions permission, this
+// permission has no in-code live check of its own — its gate is
+// PermissionService's generic effect dispatch — so this proves that
+// dispatch reaches the real closures KittyPermissionDeclaration exports.
+func TestKittyPermission_GateContract(t *testing.T) {
+	path := withTempKittyConfig(t)
+	decl := findKittyPermission(t, PermissionKeyKittyConfig)
+
+	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+		SetState: func(state permission.State) {
+			switch state {
+			case permission.StateGranted:
+				if err := decl.Apply(); err != nil {
+					t.Fatalf("Apply: %v", err)
+				}
+			case permission.StateDenied:
+				if err := decl.Remove(); err != nil {
+					t.Fatalf("Remove: %v", err)
+				}
+			}
+		},
+		Exercise: func() {}, // the effect IS the Apply/Remove call above
+		Observe: func() bool {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return false
+			}
+			return strings.Contains(string(data), kittyBlockStart)
+		},
+	})
+}
+
+// findKittyPermission returns the declared permission matching key, failing
+// the test if the declaration dropped or renamed it.
+func findKittyPermission(t *testing.T, key string) agent.Permission {
+	t.Helper()
+	for _, p := range KittyPermissionDeclaration().Permissions {
+		if p.Key == key {
+			return p
+		}
+	}
+	t.Fatalf("no permission %q declared", key)
+	return agent.Permission{}
 }

--- a/core/application/services/input_service_test.go
+++ b/core/application/services/input_service_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"irrlicht/core/application/services"
+	"irrlicht/core/domain/permission"
 	"irrlicht/core/domain/session"
+	"irrlicht/core/internal/contracttesting"
 )
 
 // fakeController records what InputService delegates to the AgentController.
@@ -31,6 +33,13 @@ func (f *fakeController) Controllable(_ string) bool { return f.controllable }
 type fakeConsent struct{ granted bool }
 
 func (f fakeConsent) Granted(_, _ string) bool { return f.granted }
+
+// mutableConsent is a consentGate whose answer can change between calls —
+// needed to drive a single InputService instance through all three
+// consent states for contracttesting.AssertPermissionGated.
+type mutableConsent struct{ granted bool }
+
+func (c *mutableConsent) Granted(_, _ string) bool { return c.granted }
 
 func controllableSession() *session.SessionState {
 	return &session.SessionState{SessionID: "abc", Adapter: "claude-code"}
@@ -120,4 +129,25 @@ func TestControllable_ReflectsGate(t *testing.T) {
 	if !newInput(true, true, true, nil).Controllable("abc") {
 		t.Error("all gates open: want controllable")
 	}
+}
+
+// TestSendInput_PermissionGateContract wires the backchannel's live
+// per-call ConsentGate check (input_service.go's resolve, the exact
+// "backchannel write path" issue #797 was filed to guard) into the shared
+// three-state contract: forwarding must be a no-op while the "control"
+// permission is pending or denied, must delegate to the controller once
+// granted, and must stop again once revoked.
+func TestSendInput_PermissionGateContract(t *testing.T) {
+	consent := &mutableConsent{}
+	ctrl := &fakeController{controllable: true}
+	svc := services.NewInputService(&stubRepo{state: controllableSession()}, ctrl, consent, func() bool { return true }, stubLog{})
+
+	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+		SetState: func(state permission.State) { consent.granted = state == permission.StateGranted },
+		Exercise: func() {
+			ctrl.sentData = nil
+			_ = svc.SendInput("abc", []byte("x"))
+		},
+		Observe: func() bool { return ctrl.sentData != nil },
+	})
 }

--- a/core/internal/contracttesting/permission_gate.go
+++ b/core/internal/contracttesting/permission_gate.go
@@ -1,0 +1,53 @@
+package contracttesting
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/permission"
+)
+
+// PermissionGate wires one declared permission's consent-gated call site
+// into AssertPermissionGated. SetState drives the permission to the given
+// state through whatever mechanism the call site actually checks — a
+// mutable fake ConsentGate for a live per-request check (an HTTP handler,
+// input forwarding), or the permission's real Apply/Remove closures for an
+// install-type permission (a hook file, a config block). Exercise performs
+// the action the permission is supposed to gate. Observe reports whether
+// the gated effect is currently present.
+type PermissionGate struct {
+	SetState func(state permission.State)
+	Exercise func()
+	Observe  func() bool
+}
+
+// AssertPermissionGated runs the issue #797 contract against g: no
+// observable effect while the permission is pending, the effect observable
+// once granted, and the effect undone after a subsequent revoke. Each
+// state transition is followed by an Exercise + Observe pair, so a call
+// site that forgot to check consent is caught even when the underlying
+// resource (a hook entry, a config block) was left behind by an earlier
+// grant.
+func AssertPermissionGated(t *testing.T, g PermissionGate) {
+	t.Helper()
+	t.Run("pending_no_effect", func(t *testing.T) {
+		g.SetState(permission.StatePending)
+		g.Exercise()
+		if g.Observe() {
+			t.Error("effect observed while permission is pending — call site is not consent-gated")
+		}
+	})
+	t.Run("granted_effect_observable", func(t *testing.T) {
+		g.SetState(permission.StateGranted)
+		g.Exercise()
+		if !g.Observe() {
+			t.Error("effect not observed after granting permission")
+		}
+	})
+	t.Run("revoked_effect_undone", func(t *testing.T) {
+		g.SetState(permission.StateDenied)
+		g.Exercise()
+		if g.Observe() {
+			t.Error("effect still observed after revoking a previously granted permission")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `contracttesting.AssertPermissionGated` (`core/internal/contracttesting/permission_gate.go`): a shared three-state (pending/granted/revoked) assertion that drives one declared permission's real gate and checks no effect leaks while pending, the effect appears once granted, and it's undone on revoke.
- Wires it into `claudecode`'s four `modify`-kind permissions (hooks/statusline via their live per-request `ConsentGate`, instructions via the real `Apply`/`Remove` closures), `processlifecycle`'s kitty remote-control permission (install-type `Apply`/`Remove`), and `InputService`'s backchannel forwarding gate — the exact "new backchannel write path that skips the gate" risk the issue calls out.
- Documents the pattern in `AGENTS.md`'s Testing section, alongside the architecture test it complements (that one is static; this one is the runtime/behavioral counterpart).

Closes #797.

## Test plan
- [x] `go test ./core/... -race -count=1` (green; two unrelated timing-sensitive tests — `TestDebounce_FirstEventTerminalFiresImmediately`, `TestDaemonStartupSmoke`, `TestAnyLiveOutputWriter_RealProcess` — are pre-existing load-sensitive flakes, confirmed passing in isolation and reproducible on unmodified `main`)
- [x] `tools/preflight.sh` (full local CI parity, including web suites and the ARS architecture gate) — all green, ran automatically via the pre-push hook
- [x] New tests verified individually with `-race`: `TestHookHandler_PermissionGateContract`, `TestStatuslineHandler_PermissionGateContract`, `TestInstructionsPermission_GateContract`, `TestKittyPermission_GateContract`, `TestSendInput_PermissionGateContract`

🤖 Generated with [Claude Code](https://claude.com/claude-code)