### PR TITLE
fix(services): tighten session_detector test-file organization from #814 review

### DIFF
--- a/core/application/services/session_detector_activity_test.go
+++ b/core/application/services/session_detector_activity_test.go
@@ -498,6 +498,37 @@ func TestSessionDetector_Activity_NormalToolCompletion_StaysWorking(t *testing.T
 	}
 }
 
+func TestSessionDetector_Activity_UnknownSession_TreatedAsNew(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "unknown1",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: "/home/.claude/projects/-Users-test/unknown1.jsonl",
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	state, err := repo.Load("unknown1")
+	if err != nil {
+		t.Fatalf("session should have been created: %v", err)
+	}
+	if state.State != session.StateReady {
+		t.Errorf("state: got %q, want ready", state.State)
+	}
+}
+
 func TestNeedsUserAttention(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/core/application/services/session_detector_lifecycle_test.go
+++ b/core/application/services/session_detector_lifecycle_test.go
@@ -188,37 +188,6 @@ func TestSessionDetector_ContextCancel_StopsGracefully(t *testing.T) {
 	}
 }
 
-func TestSessionDetector_Activity_UnknownSession_TreatedAsNew(t *testing.T) {
-	tw := newMockAgentWatcher()
-	pw := newMockProcessWatcher()
-	repo := newMockRepo()
-
-	det := newDetector(tw, pw, repo)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- det.Run(ctx) }()
-
-	tw.ch <- agent.Event{
-		Type:           agent.EventActivity,
-		SessionID:      "unknown1",
-		ProjectDir:     "-Users-test",
-		TranscriptPath: "/home/.claude/projects/-Users-test/unknown1.jsonl",
-	}
-
-	time.Sleep(50 * time.Millisecond)
-	cancel()
-	<-done
-
-	state, err := repo.Load("unknown1")
-	if err != nil {
-		t.Fatalf("session should have been created: %v", err)
-	}
-	if state.State != session.StateReady {
-		t.Errorf("state: got %q, want ready", state.State)
-	}
-}
-
 func TestSessionDetector_HandleProcessExit_DeletesSession(t *testing.T) {
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()

--- a/core/application/services/session_detector_pid_test.go
+++ b/core/application/services/session_detector_pid_test.go
@@ -1,3 +1,10 @@
+// session_detector_pid_test.go covers PID-assignment scenarios:
+// SessionDetector.HandlePIDAssigned (defined in session_detector_lifecycle.go
+// — there is no standalone session_detector_pid.go production file) plus the
+// /clear same-PID reuse cleanup path. Grouped by scenario (binding a
+// discovered PID to a session), not by production file, so a new
+// PID-assignment test belongs here even though the code under test lives in
+// the lifecycle file.
 package services_test
 
 import (


### PR DESCRIPTION
## Summary
Two low-severity nits surfaced by an `/review` of #814 (the `session_detector_test.go` scenario-group split), both pure test-organization fixes with zero behavior change:

- `TestSessionDetector_Activity_UnknownSession_TreatedAsNew` moved from `session_detector_lifecycle_test.go` into `session_detector_activity_test.go` — it was the only `Activity_`-prefixed test living outside the file all 10 other `Activity_` tests are in, and thematically it tests activity-driven state transition (new session reaches `ready`), not removal/process-exit/seed-from-disk.
- Added a short header comment to `session_detector_pid_test.go` clarifying that its "pid" grouping has no `session_detector_pid.go` production-code counterpart — `HandlePIDAssigned` actually lives in `session_detector_lifecycle.go` — so a future contributor isn't misled by the split's otherwise 1:1 mirror of production file boundaries into placing a new PID-assignment test in the lifecycle file instead.

## Test plan
- [x] `go build ./core/...`, `go vet ./core/application/services/...` clean
- [x] `gofmt -l` clean on touched files
- [x] `go test ./core/application/services/... -race -count=1` green
- [x] `tools/preflight.sh` (full local CI parity via pre-push hook) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)