### PR TITLE
docs(agents): note git stash is not isolated per worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,11 @@
 - "wt+full" = create a worktree for the following issue. move into the worktree, plan, directly execute and start the code-review skill on low, then fix all issues and open a PR.
 - "wt+close" = make sure all contents of the worktree are pushed to a pr. Then close the worktree, move back to main and delete the worktree
 
+Worktrees share the parent repo's `.git` dir, so **`git stash` is not
+isolated per worktree** — it's a single shared stack. Concurrent agents
+stashing in different worktrees can pop each other's WIP. Use a local
+commit as a checkpoint instead (`git commit -m wip`, amend/reset later).
+
 ## Build Artifacts
 
 Use `./.build` for build artifacts.


### PR DESCRIPTION
## Summary
- Concurrent CodeScene-refactor agents (#804-#811, each in its own worktree) briefly popped each other's WIP via `git stash`, because the stash stack lives in the shared `.git` dir and is not isolated per worktree.
- Documents the gotcha in AGENTS.md's Short Cuts section (where worktree usage is introduced) so future agents use a local commit as a checkpoint instead.

## Test plan
- [x] `tools/preflight.sh` (full local gate via pre-push hook) — all green.