### PR TITLE
fix(macos): collapse relay-echoed sessions in the flat sessions array too

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager+WebSocket.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+WebSocket.swift
@@ -297,10 +297,19 @@ extension SessionManager {
         // menu-bar counts include other machines' sessions. Local wins on id
         // collision — the same daemon reached via both sources shows once.
         let localIDs = Set(sessionMap.keys)
+        // Local-wins name-collapse (#746, #828): a project the local daemon
+        // publishes and also subscribes back to via the relay echoes with a
+        // drifted session_id that escapes the id-only filter below. Mirrors
+        // recomposeApiGroups()/relayGroups()'s collapse so the flat `sessions`
+        // array (menu bar, cycling) agrees with `apiGroups` (list view) instead
+        // of double-counting the echo.
+        let localProjectNames = Set(localApiGroups.map(\.name))
         // Two different relay daemons sharing a session_id stay distinct (keyed
         // by compound rowID), so build a flat array rather than a bare-id dict
         // — a dict would collide them back into one row (#537).
-        let relayOnly = relaySessionMap.values.filter { !localIDs.contains($0.id) }
+        let relayOnly = relaySessionMap.values.filter {
+            !localIDs.contains($0.id) && !localProjectNames.contains($0.projectName ?? "")
+        }
         let all = Array(sessionMap.values) + relayOnly
 
         // Exclude child sessions (subagents) from the main session list so they

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -393,6 +393,21 @@ final class SessionManagerApiGroupsTests: XCTestCase {
         )
     }
 
+    /// The same relay echo must also collapse in the flat `sessions` array
+    /// (#828) — not just in `apiGroups`. Before the fix, `rebuildSessionsFromMap`
+    /// only deduped relay sessions by id, so the drifted-id echo survived and
+    /// the menu bar (which reads `sessions`) double-counted the project while
+    /// the list view (which reads `apiGroups`) already showed the correct total.
+    func testRelayEcho_sameProjectName_driftedId_collapsesToLocal_inFlatSessions() {
+        sut.sessionMap["local-1"] = makeSession(id: "local-1", projectName: "irrlicht")
+        sut.seedLocalApiGroups([AgentGroup(name: "irrlicht", agents: [makeSession(id: "local-1", projectName: "irrlicht")])])
+        sut.handleRelayMessage(relayPush(source: "ghostDaemon", sessionId: "drifted-9", project: "irrlicht"))
+
+        let irrlicht = sut.sessions.filter { $0.projectName == "irrlicht" }
+        XCTAssertEqual(irrlicht.count, 1, "the menu bar's flat session list must also collapse the relay echo")
+        XCTAssertNil(irrlicht.first?.daemonID, "the surviving row is the local one")
+    }
+
     /// A relay-only project with no local equivalent still appears — the
     /// name-collapse only suppresses collisions, not genuine remote projects.
     func testRelayOnly_differentProject_stillAppears() {
@@ -478,13 +493,15 @@ final class SessionManagerApiGroupsTests: XCTestCase {
     private func makeSession(
         id: String,
         cost: Double = 0,
-        children: [SessionState]? = nil
+        children: [SessionState]? = nil,
+        projectName: String? = nil
     ) -> SessionState {
         SessionState(
             id: id,
             state: .working,
             model: "test-model",
             cwd: "/tmp",
+            projectName: projectName,
             firstSeen: Date(timeIntervalSince1970: 0),
             updatedAt: Date(timeIntervalSince1970: 0),
             metrics: SessionMetrics(


### PR DESCRIPTION
## Summary
- Fixes #828: the menu bar overcounted sessions for a project vs. the correct count in the list view, when Local + Relay sources are both enabled and the local daemon publishes its own sessions to the relay it subscribes to.
- PR #746/#748 already fixed this relay-echo scenario for `apiGroups` (the list view) with a name-based collapse in `recomposeApiGroups()`, but the flat `sessions` array (menu bar dots/badge, session cycling) only deduped relay sessions by id — and the echoed session carries a drifted id that escapes that filter. This mirrors the same name-based collapse into `rebuildSessionsFromMap()`.

## Test plan
- [x] Added `testRelayEcho_sameProjectName_driftedId_collapsesToLocal_inFlatSessions` — verified it fails (`2 != 1`) without the fix and passes with it.
- [x] `swift test` — full macOS suite green (all suites, including snapshots).
- [x] `tools/preflight.sh` — all local CI-parity gates pass (go tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, both web suites, ARS gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)