### PR TITLE
Show estimated CO2 footprint alongside cost

### DIFF
--- a/core/adapters/outbound/filesystem/cost_tracker.go
+++ b/core/adapters/outbound/filesystem/cost_tracker.go
@@ -46,6 +46,7 @@ type snapshotRow struct {
 	Model     string  `json:"model,omitempty"`    // Metrics.ModelName, falling back to SessionState.Model ("" = unknown)
 	Session   string  `json:"session"`
 	Cost      float64 `json:"cost"`
+	CO2Grams  float64 `json:"co2,omitempty"` // cumulative estimated CO2e grams (issue #829); rows written before this field existed read back as 0
 	CumIn     int64   `json:"cum_in,omitempty"`
 	CumOut    int64   `json:"cum_out,omitempty"`
 	CumRead   int64   `json:"cum_read,omitempty"`
@@ -157,6 +158,7 @@ func (t *CostTracker) RecordSnapshot(state *session.SessionState) error {
 		Model:     modelForRow(state),
 		Session:   state.SessionID,
 		Cost:      m.EstimatedCostUSD,
+		CO2Grams:  m.EstimatedCO2Grams,
 		CumIn:     m.CumInputTokens,
 		CumOut:    m.CumOutputTokens,
 		CumRead:   m.CumCacheReadTokens,
@@ -167,6 +169,7 @@ func (t *CostTracker) RecordSnapshot(state *session.SessionState) error {
 	prev, hasPrev := t.lastWrite[state.SessionID]
 	if hasPrev {
 		unchanged := prev.Cost == row.Cost &&
+			prev.CO2Grams == row.CO2Grams &&
 			prev.CumIn == row.CumIn &&
 			prev.CumOut == row.CumOut &&
 			prev.CumRead == row.CumRead &&
@@ -236,6 +239,7 @@ func (t *CostTracker) RecordBaseline(state *session.SessionState) error {
 		Model:     modelForRow(state),
 		Session:   state.SessionID,
 		Cost:      m.EstimatedCostUSD,
+		CO2Grams:  m.EstimatedCO2Grams,
 		CumIn:     m.CumInputTokens,
 		CumOut:    m.CumOutputTokens,
 		CumRead:   m.CumCacheReadTokens,
@@ -726,9 +730,12 @@ func (t *CostTracker) scanSeries(path string, q outbound.SeriesQuery, f seriesFi
 			aggs[r.Session] = s
 		}
 		var cur float64
-		if q.Metric == "tokens" {
+		switch q.Metric {
+		case "tokens":
 			cur = rowTokenSum(r, f.tokens)
-		} else {
+		case "co2":
+			cur = r.CO2Grams
+		default:
 			cur = r.Cost
 		}
 		curIn := float64(r.CumIn)

--- a/core/adapters/outbound/filesystem/cost_tracker.go
+++ b/core/adapters/outbound/filesystem/cost_tracker.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"irrlicht/core/domain/session"
+	"irrlicht/core/pkg/capacity"
 	"irrlicht/core/ports/outbound"
 )
 
@@ -801,6 +802,135 @@ func (t *CostTracker) scanSeries(path string, q outbound.SeriesQuery, f seriesFi
 		}
 		s.advance(cur, curIn, curOut, curRead, curCreate)
 	})
+}
+
+// co2BackfillMarker is written after BackfillCO2 completes successfully — not
+// ".jsonl", so directory scans (here and in CostSeries/Prune) skip it. Makes
+// the migration idempotent: safe to call on every daemon startup without
+// rescanning already-migrated history. A failed run leaves it unwritten so
+// the next startup retries.
+const co2BackfillMarker = ".co2_backfilled"
+
+// BackfillCO2 rewrites every persisted row still missing a CO2Grams estimate
+// — written before issue #829 added the field — using the row's own model
+// name and cumulative token counts. Without this, everyone who already had
+// cost history on disk would see their CO2 History chart start flat at zero
+// on the day they upgraded, instead of reflecting the activity that's
+// already recorded. Runs once per data directory; see co2BackfillMarker.
+func (t *CostTracker) BackfillCO2() error {
+	markerPath := filepath.Join(t.dir, co2BackfillMarker)
+	if _, err := os.Stat(markerPath); err == nil {
+		return nil // already migrated
+	}
+
+	entries, err := os.ReadDir(t.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return t.writeCO2BackfillMarker(markerPath)
+		}
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		project := strings.TrimSuffix(e.Name(), ".jsonl")
+		if err := t.backfillCO2File(filepath.Join(t.dir, e.Name()), project); err != nil {
+			return err
+		}
+	}
+	return t.writeCO2BackfillMarker(markerPath)
+}
+
+func (t *CostTracker) writeCO2BackfillMarker(path string) error {
+	if err := os.MkdirAll(t.dir, 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(time.Now().Format(time.RFC3339)+"\n"), 0600)
+}
+
+// backfillCO2File rewrites one project's cost file in place, estimating
+// CO2Grams for any row that doesn't have one yet (CO2Grams == 0 with nonzero
+// cumulative tokens — a real zero-token row has nothing to estimate from and
+// is left alone). Mirrors pruneFile's read-transform-atomic-rename shape.
+// Unparseable lines are carried through byte-for-byte rather than dropped —
+// this migration estimates a derived field, it must never lose data.
+func (t *CostTracker) backfillCO2File(path, project string) error {
+	t.mu.Lock()
+	fm, ok := t.fileMus[project]
+	if !ok {
+		fm = &sync.Mutex{}
+		t.fileMus[project] = fm
+	}
+	t.mu.Unlock()
+
+	fm.Lock()
+	defer fm.Unlock()
+
+	in, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer in.Close()
+
+	tmpPath := fmt.Sprintf("%s.tmp.%d.%d", path, os.Getpid(), time.Now().UnixNano())
+	out, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	w := bufio.NewWriter(out)
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	changed := false
+	writeErr := func() error {
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+			var r snapshotRow
+			toWrite := line
+			if err := json.Unmarshal(line, &r); err == nil {
+				total := r.CumIn + r.CumOut + r.CumRead + r.CumCreate
+				if r.CO2Grams == 0 && total > 0 {
+					grams, _ := capacity.EstimateCO2Grams(r.Model, total)
+					r.CO2Grams = grams
+					changed = true
+					marshaled, err := json.Marshal(r)
+					if err != nil {
+						return err
+					}
+					toWrite = marshaled
+				}
+			}
+			if _, err := w.Write(toWrite); err != nil {
+				return err
+			}
+			if err := w.WriteByte('\n'); err != nil {
+				return err
+			}
+		}
+		return scanner.Err()
+	}()
+	if writeErr == nil {
+		writeErr = w.Flush()
+	}
+	closeErr := out.Close()
+	if writeErr != nil || closeErr != nil {
+		os.Remove(tmpPath)
+		if writeErr != nil {
+			return writeErr
+		}
+		return closeErr
+	}
+	if !changed {
+		os.Remove(tmpPath)
+		return nil
+	}
+	return os.Rename(tmpPath, path)
 }
 
 // Prune rewrites each project file to drop rows older than olderThanDays.

--- a/core/adapters/outbound/filesystem/cost_tracker_test.go
+++ b/core/adapters/outbound/filesystem/cost_tracker_test.go
@@ -88,6 +88,46 @@ func TestRecordSnapshot_AppendsOnChange(t *testing.T) {
 	}
 }
 
+// TestRecordSnapshot_PersistsCO2AndDetectsChange verifies EstimatedCO2Grams
+// (issue #829) is written to the row, and that a CO2-only change (same cost
+// and token counts) still triggers a new row instead of being silently
+// dropped by the unchanged-since-last-write dedup.
+func TestRecordSnapshot_PersistsCO2AndDetectsChange(t *testing.T) {
+	tr := newTestTracker(t)
+	state := &session.SessionState{
+		SessionID:   "s1",
+		ProjectName: "proj-a",
+		Metrics: &session.SessionMetrics{
+			EstimatedCostUSD:  0.10,
+			EstimatedCO2Grams: 5,
+			CumInputTokens:    100,
+		},
+	}
+	if err := tr.RecordSnapshot(state); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+
+	// Forge an older lastWrite so the interval throttle doesn't also
+	// suppress the second write — isolating the CO2-only-change path.
+	tr.mu.Lock()
+	lw := tr.lastWrite["s1"]
+	lw.TS -= int64(costWriteInterval/time.Second) + 1
+	tr.lastWrite["s1"] = lw
+	tr.mu.Unlock()
+
+	state.Metrics.EstimatedCO2Grams = 9
+	if err := tr.RecordSnapshot(state); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	rows := readRows(t, tr.filePath("proj-a"))
+	if len(rows) != 2 {
+		t.Fatalf("want 2 rows (CO2-only change must not be deduped), got %d: %+v", len(rows), rows)
+	}
+	if rows[0].CO2Grams != 5 || rows[1].CO2Grams != 9 {
+		t.Fatalf("unexpected CO2Grams sequence: %+v", rows)
+	}
+}
+
 func TestRecordSnapshot_ThrottlesByInterval(t *testing.T) {
 	tr := newTestTracker(t)
 	state := &session.SessionState{
@@ -777,6 +817,26 @@ func TestCostSeries_TokensMetricSplit(t *testing.T) {
 	costRes, _ := tr.CostSeries(outbound.SeriesQuery{Start: 1000, End: 1400, BucketSeconds: 100, Group: "project", Metric: "cost"})
 	if costRes.TokenSplit != nil {
 		t.Errorf("cost metric should leave TokenSplit nil, got %+v", costRes.TokenSplit)
+	}
+}
+
+// TestCostSeries_CO2Metric verifies the co2 metric (issue #829) sums
+// CO2Grams deltas the same way the cost/tokens metrics sum their own
+// columns, and leaves TokenSplit nil (that's tokens-only).
+func TestCostSeries_CO2Metric(t *testing.T) {
+	tr := newTestTracker(t)
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 1050, Project: "proj-a", Session: "s1", CO2Grams: 10})
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 1150, Project: "proj-a", Session: "s1", CO2Grams: 35})
+
+	res, err := tr.CostSeries(outbound.SeriesQuery{Start: 1000, End: 1400, BucketSeconds: 100, Group: "project", Metric: "co2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if abs(res.Totals["proj-a"]-25) > 1e-9 || abs(res.ByKey["proj-a"][1]-25) > 1e-9 {
+		t.Errorf("co2 total: want 25 in bucket 1, got %+v", res.ByKey["proj-a"])
+	}
+	if res.TokenSplit != nil {
+		t.Errorf("co2 metric should leave TokenSplit nil, got %+v", res.TokenSplit)
 	}
 }
 

--- a/core/adapters/outbound/filesystem/cost_tracker_test.go
+++ b/core/adapters/outbound/filesystem/cost_tracker_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"irrlicht/core/domain/session"
+	"irrlicht/core/pkg/capacity"
 	"irrlicht/core/ports/outbound"
 )
 
@@ -966,5 +967,60 @@ func TestCostSeries_TokenTypeFilter(t *testing.T) {
 	}
 	if res.TokenSplit == nil || abs(res.TokenSplit.Input-100) > 1e-9 || res.TokenSplit.Output != 0 || res.TokenSplit.Cache != 0 {
 		t.Errorf("token_type=input split: want in=100 out=0 cache=0, got %+v", res.TokenSplit)
+	}
+}
+
+// TestBackfillCO2_EstimatesFromModelAndTokens verifies pre-#829 rows (no CO2
+// column) get an estimate derived from their own model + cumulative tokens,
+// while a row that already has a CO2 value is left untouched.
+func TestBackfillCO2_EstimatesFromModelAndTokens(t *testing.T) {
+	tr := newTestTracker(t)
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 1050, Project: "proj-a", Session: "s1", Model: "gemini-2.5-flash", Cost: 1.00, CumIn: 800, CumOut: 200})
+	// Already-migrated row: CO2Grams must survive untouched even though it's
+	// nonzero-tokens (the ==0 check must not clobber a real 0.5-value coincidence).
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 1150, Project: "proj-a", Session: "s2", Model: "gemini-2.5-flash", Cost: 2.00, CumIn: 1000, CumOut: 0, CO2Grams: 0.5})
+	// Zero-token row: nothing to estimate from, must stay 0.
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 1250, Project: "proj-a", Session: "s3", Cost: 0})
+
+	if err := tr.BackfillCO2(); err != nil {
+		t.Fatal(err)
+	}
+	rows := readRows(t, tr.filePath("proj-a"))
+	if len(rows) != 3 {
+		t.Fatalf("want 3 rows preserved, got %d", len(rows))
+	}
+	wantGrams, _ := capacity.EstimateCO2Grams("gemini-2.5-flash", 1000)
+	if abs(rows[0].CO2Grams-wantGrams) > 1e-9 {
+		t.Errorf("row 0: want backfilled CO2Grams %v, got %v", wantGrams, rows[0].CO2Grams)
+	}
+	if rows[1].CO2Grams != 0.5 {
+		t.Errorf("row 1: pre-existing CO2Grams must be untouched, got %v", rows[1].CO2Grams)
+	}
+	if rows[2].CO2Grams != 0 {
+		t.Errorf("row 2: zero-token row should stay 0, got %v", rows[2].CO2Grams)
+	}
+}
+
+// TestBackfillCO2_IdempotentViaMarker verifies a second call is a no-op (the
+// marker file short-circuits it) even if a row's CO2Grams would otherwise
+// look backfillable — proving the migration runs at most once per data dir.
+func TestBackfillCO2_IdempotentViaMarker(t *testing.T) {
+	tr := newTestTracker(t)
+	writeRow(t, tr, "proj-a", snapshotRow{TS: 1050, Project: "proj-a", Session: "s1", Model: "gemini-2.5-flash", CumIn: 1000})
+	if err := tr.BackfillCO2(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(tr.Dir(), ".co2_backfilled")); err != nil {
+		t.Fatalf("marker file not written: %v", err)
+	}
+	// Reset the row's CO2Grams back to 0 as if a second migration attempt
+	// might re-touch it, then confirm BackfillCO2 skips the scan entirely.
+	writeRow(t, tr, "proj-b", snapshotRow{TS: 1050, Project: "proj-b", Session: "s2", Model: "gemini-2.5-flash", CumIn: 1000})
+	if err := tr.BackfillCO2(); err != nil {
+		t.Fatal(err)
+	}
+	rows := readRows(t, tr.filePath("proj-b"))
+	if rows[0].CO2Grams != 0 {
+		t.Errorf("second BackfillCO2 call should no-op via the marker, but proj-b was migrated: %+v", rows[0])
 	}
 }

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -68,6 +68,8 @@ func (mc *MetricsConverter) Convert(m *tailer.SessionMetrics) *session.SessionMe
 		LastWasUserInterrupt:              m.LastWasUserInterrupt,
 		LastWasToolDenial:                 m.LastWasToolDenial,
 		EstimatedCostUSD:                  m.EstimatedCostUSD,
+		EstimatedCO2Grams:                 m.EstimatedCO2Grams,
+		CO2Tier:                           m.CO2Tier,
 		CumInputTokens:                    m.CumInputTokens,
 		CumOutputTokens:                   m.CumOutputTokens,
 		CumCacheReadTokens:                m.CumCacheReadTokens,

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -367,8 +367,8 @@ func handleGetHistory(tracker outbound.CostTracker, sessions historySessionListe
 			chart = "cost"
 		}
 		switch chart {
-		case "cost", "tokens", "models", "providers":
-			// implemented (Phase 2)
+		case "cost", "tokens", "co2", "models", "providers":
+			// implemented (Phase 2); co2 added for issue #829
 		case "yield":
 			// implemented (#373) — handled after range resolution below
 		case "agents":
@@ -404,6 +404,8 @@ func handleGetHistory(tracker outbound.CostTracker, sessions historySessionListe
 		switch chart {
 		case "tokens":
 			metric = "tokens"
+		case "co2":
+			metric = "co2"
 		case "models":
 			group = "model"
 		case "providers":
@@ -698,8 +700,10 @@ func buildHistoryResponse(rangeKey, chart, group, scope string, s *outbound.Cost
 		resp.TokenSplit = &historyTokenSplit{Input: s.TokenSplit.Input, Output: s.TokenSplit.Output, Cache: s.TokenSplit.Cache}
 	}
 
-	// Forecast projects USD spend; it isn't meaningful for token counts.
-	if chart != "tokens" && historyForecastEnabled(q) && resp.Total > 0 && len(s.BucketStarts) > 0 {
+	// Forecast projects USD spend; it isn't meaningful for token counts, and
+	// compounding a linear projection on top of an already-modeled CO2e
+	// estimate would overstate precision it doesn't have.
+	if chart != "tokens" && chart != "co2" && historyForecastEnabled(q) && resp.Total > 0 && len(s.BucketStarts) > 0 {
 		resp.Forecast = computeLinearForecast(s.BucketStarts, s.BucketSeconds, resp.Total, historyForecastBuckets(q, len(s.BucketStarts)))
 	}
 	return resp

--- a/core/cmd/irrlichd/history_endpoint_test.go
+++ b/core/cmd/irrlichd/history_endpoint_test.go
@@ -261,6 +261,32 @@ func TestHandleGetHistory_TokensSplit(t *testing.T) {
 	}
 }
 
+// TestHandleGetHistory_CO2: chart=co2 (issue #829) sums the co2 column like
+// chart=cost sums cost, carries no token_split, and forecasts nothing (an
+// estimate compounded with a linear projection would overstate precision).
+func TestHandleGetHistory_CO2(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "cost")
+	seedCostRows(t, dir, "proj-a", []map[string]any{
+		{"ts": 1050, "project": "proj-a", "session": "s1", "cost": 1.00, "co2": 10},
+		{"ts": 1150, "project": "proj-a", "session": "s1", "cost": 1.40, "co2": 35},
+	})
+	tr := filesystem.NewCostTrackerWithDir(dir)
+
+	rec, resp := doHistory(t, tr, "start=1000&end=1400&bucket=100&chart=co2")
+	if rec.Code != http.StatusOK || resp.Chart != "co2" {
+		t.Fatalf("want 200 chart=co2, got %d/%q", rec.Code, resp.Chart)
+	}
+	if resp.Total != 25 {
+		t.Errorf("co2 total: want 25, got %v", resp.Total)
+	}
+	if resp.TokenSplit != nil {
+		t.Errorf("co2 chart should not carry token_split, got %+v", resp.TokenSplit)
+	}
+	if resp.Forecast != nil {
+		t.Errorf("co2 chart should not forecast, got %+v", resp.Forecast)
+	}
+}
+
 // TestHandleGetHistory_UnknownBucketRule: the unknown bucket is surfaced only at
 // ≥10% of the window total, else dropped.
 func TestHandleGetHistory_UnknownBucketRule(t *testing.T) {

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -137,9 +137,9 @@ func pruneDeadProcSessions(fsRepo *filesystem.SessionRepository, logger outbound
 }
 
 // initCostTracker opens the append-only per-project cost JSONL store,
-// prunes rows older than 400 days (so per-year queries stay fast), and
-// records a baseline row for every existing session so rates are
-// computable without waiting for new activity.
+// backfills CO2 estimates onto pre-#829 rows, prunes rows older than 400 days
+// (so per-year queries stay fast), and records a baseline row for every
+// existing session so rates are computable without waiting for new activity.
 func initCostTracker(logger outbound.Logger, fsRepo *filesystem.SessionRepository) outbound.CostTracker {
 	var costTracker *filesystem.CostTracker
 	if dir := stateStoreDir("cost"); dir != "" {
@@ -151,6 +151,13 @@ func initCostTracker(logger outbound.Logger, fsRepo *filesystem.SessionRepositor
 			logger.LogError("startup", "", fmt.Sprintf("failed to init cost tracker: %v", err))
 			return nil
 		}
+	}
+	// One-time migration (issue #829): estimate CO2 for history recorded
+	// before the field existed, so upgrading doesn't leave the CO2 chart
+	// flat at zero for activity that's already on disk. Idempotent — see
+	// BackfillCO2's marker file.
+	if err := costTracker.BackfillCO2(); err != nil {
+		logger.LogError("startup", "", fmt.Sprintf("cost tracker CO2 backfill failed: %v", err))
 	}
 	// Attribute wrapper agents (pi, opencode) to the subscription they
 	// inherit, so per-provider spend matches the dashboard's quota chip

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -104,6 +104,19 @@ type SessionMetrics struct {
 	// cumulative token totals and per-model pricing.
 	EstimatedCostUSD float64 `json:"estimated_cost_usd,omitempty"`
 
+	// EstimatedCO2Grams is the estimated CO2e footprint in grams, computed
+	// from cumulative token totals and per-model energy coefficients (issue
+	// #829). Always a model, never a measurement — no provider exposes
+	// per-request energy telemetry — so it must be surfaced alongside
+	// CO2Tier, not presented as a precise figure.
+	EstimatedCO2Grams float64 `json:"estimated_co2_grams,omitempty"`
+
+	// CO2Tier names the confidence tier behind EstimatedCO2Grams
+	// (capacity.CO2Tier's string value: "provider_disclosed" or "fallback").
+	// Kept as a plain string rather than importing capacity's type, matching
+	// how EstimatedCostUSD stays decoupled from the capacity package.
+	CO2Tier string `json:"co2_tier,omitempty"`
+
 	// Cumulative token totals across all API turns (for cost breakdown).
 	CumInputTokens         int64 `json:"cum_input_tokens,omitempty"`
 	CumOutputTokens        int64 `json:"cum_output_tokens,omitempty"`
@@ -453,6 +466,8 @@ func newMergedMetrics(newM *SessionMetrics) *SessionMetrics {
 		LastWasUserInterrupt:     newM.LastWasUserInterrupt,
 		LastWasToolDenial:        newM.LastWasToolDenial,
 		EstimatedCostUSD:         newM.EstimatedCostUSD,
+		EstimatedCO2Grams:        newM.EstimatedCO2Grams,
+		CO2Tier:                  newM.CO2Tier,
 		LastAssistantText:        newM.LastAssistantText,
 		TaskSummary:              newM.TaskSummary,
 		IntentHeadline:           newM.IntentHeadline,
@@ -509,6 +524,10 @@ func carryForwardScalarFields(merged, oldM *SessionMetrics) {
 	}
 	if merged.EstimatedCostUSD == 0 && oldM.EstimatedCostUSD > 0 {
 		merged.EstimatedCostUSD = oldM.EstimatedCostUSD
+	}
+	if merged.EstimatedCO2Grams == 0 && oldM.EstimatedCO2Grams > 0 {
+		merged.EstimatedCO2Grams = oldM.EstimatedCO2Grams
+		merged.CO2Tier = oldM.CO2Tier
 	}
 	if merged.PermissionMode == "" && oldM.PermissionMode != "" {
 		merged.PermissionMode = oldM.PermissionMode

--- a/core/pkg/capacity/co2.go
+++ b/core/pkg/capacity/co2.go
@@ -95,15 +95,15 @@ func co2CoefficientsForModel(modelName string) co2Coefficients {
 	return co2Coefficients{tier: CO2TierFallback}
 }
 
-// EstimateCO2Grams estimates the CO2e footprint in grams for the given token
-// breakdown, using whatever tier of coefficient is available for the model.
+// EstimateCO2Grams estimates the CO2e footprint in grams for totalTokens
+// processed by modelName, using whatever tier of coefficient is available.
+// Takes a single pre-summed token count rather than a per-bucket breakdown:
+// unlike $ pricing, no public source distinguishes an energy cost for
+// input/output/cache tokens, so callers sum their buckets before calling.
 // This is always an estimate, never a measurement — no provider exposes
 // per-request energy telemetry — so callers should surface the returned tier
-// alongside the number rather than presenting it as precise. Cache tokens
-// (read or write) are priced the same as input/output tokens: no public
-// source distinguishes a separate energy cost for cache operations.
-func EstimateCO2Grams(modelName string, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens int64) (grams float64, tier CO2Tier) {
-	totalTokens := inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens
+// alongside the number rather than presenting it as precise.
+func EstimateCO2Grams(modelName string, totalTokens int64) (grams float64, tier CO2Tier) {
 	if totalTokens <= 0 {
 		return 0, CO2TierFallback
 	}

--- a/core/pkg/capacity/co2.go
+++ b/core/pkg/capacity/co2.go
@@ -1,0 +1,132 @@
+package capacity
+
+import "strings"
+
+// CO2Tier describes how trustworthy the energy/CO2e coefficients behind an
+// estimate are. No provider exposes real per-request telemetry, so every
+// figure here is modeled, not measured — the tier tells the caller how far
+// the model is from a primary source.
+type CO2Tier string
+
+const (
+	// CO2TierProviderDisclosed means the coefficient is derived directly from
+	// a provider or third-party lifecycle-assessment disclosure that already
+	// reports gCO2e (their own grid mix and PUE are baked in).
+	CO2TierProviderDisclosed CO2Tier = "provider_disclosed"
+	// CO2TierFallback means no model-specific disclosure exists; the estimate
+	// uses the cross-model energy-per-query fallback converted via a global
+	// average grid intensity and datacenter PUE.
+	CO2TierFallback CO2Tier = "fallback"
+)
+
+const (
+	// defaultPUE is the datacenter power-usage-effectiveness overhead applied
+	// to raw compute energy when converting Wh/token to CO2e — EcoLogits
+	// (github.com/genai-impact/ecologits) cites a 1.1-1.2 range for
+	// disclosed hyperscaler PUE; we take the midpoint.
+	defaultPUE = 1.15
+
+	// globalGridGCO2PerKWh is the 2025 global-average grid carbon intensity
+	// in grams CO2 per kWh (Ember Global Electricity Review 2025,
+	// https://ember-energy.org/latest-insights/global-electricity-review-2025/).
+	// Used whenever the serving datacenter's actual region/grid mix is
+	// unknown, which is always true for a third-party API call.
+	globalGridGCO2PerKWh = 460.0
+
+	// fallbackWhPerToken is the last-resort raw-energy coefficient for any
+	// model without a dedicated entry below. Derived from Epoch AI's
+	// Feb 2025 revised estimate of ~0.3 Wh per frontier-model query
+	// (https://epoch.ai/gradient-updates/how-much-energy-does-chatgpt-use),
+	// divided by an assumed ~1,000 total tokens per query. This is the tier
+	// most sessions land in today: neither Anthropic nor OpenAI has
+	// published per-token energy figures.
+	fallbackWhPerToken = 0.0003
+)
+
+// co2Coefficients holds one model family's energy/CO2 coefficient plus the
+// confidence tier it came from.
+type co2Coefficients struct {
+	// gCO2PerToken, when nonzero, is a fully-baked CO2e-per-token figure
+	// sourced directly from a disclosure that already reports gCO2e — used
+	// as-is, with no PUE or grid-intensity multiplier (that's already
+	// folded into the source number).
+	gCO2PerToken float64
+	tier         CO2Tier
+}
+
+// co2CoefficientsByFamily maps a coarse model-family keyword (matched
+// case-insensitively against the model name) to its coefficient. Sourced
+// from the public disclosures cited in issue #829:
+//
+//   - Gemini: Google's Aug 2025 environmental report gives a median
+//     comprehensive-accounting text prompt of 0.24 Wh / 0.03 gCO2e
+//     (https://services.google.com/fh/files/misc/measuring_the_environmental_impact_of_delivering_ai_at_google_scale.pdf).
+//     The report doesn't state the prompt's token count, so this is
+//     normalized against an assumed ~1,000 total tokens/prompt:
+//     0.03 gCO2e / 1,000 tokens = 0.00003 gCO2e/token.
+//   - Mistral: the peer-reviewed Mistral/Carbone4/ADEME lifecycle
+//     assessment (Jul 2025) gives Mistral Large 2 marginal inference as
+//     1.14 gCO2e per 400-token prompt, full lifecycle including amortized
+//     training (https://mistral.ai/news/our-contribution-to-a-global-environmental-standard-for-ai/):
+//     1.14 / 400 = 0.00285 gCO2e/token.
+//
+// Every other family (Claude, GPT, Llama, etc.) falls back to
+// fallbackWhPerToken: no per-token figures for them are public.
+var co2CoefficientsByFamily = map[string]co2Coefficients{
+	"gemini":  {gCO2PerToken: 0.00003, tier: CO2TierProviderDisclosed},
+	"mistral": {gCO2PerToken: 0.00285, tier: CO2TierProviderDisclosed},
+	"mixtral": {gCO2PerToken: 0.00285, tier: CO2TierProviderDisclosed},
+}
+
+// co2CoefficientsForModel classifies by the model name itself rather than
+// ModelCapacity.Family: Family is derived from LiteLLM's litellm_provider
+// field for pricing-tier purposes and is inconsistent across hosting paths
+// for the same model family (e.g. Gemini shows up as "gemini",
+// "vertex_ai-language-models", or via Vertex/Bedrock aliases depending on
+// how it's served) — matching the model name directly is robust regardless
+// of hosting provider.
+func co2CoefficientsForModel(modelName string) co2Coefficients {
+	lower := strings.ToLower(modelName)
+	for keyword, coeff := range co2CoefficientsByFamily {
+		if strings.Contains(lower, keyword) {
+			return coeff
+		}
+	}
+	return co2Coefficients{tier: CO2TierFallback}
+}
+
+// EstimateCO2Grams estimates the CO2e footprint in grams for the given token
+// breakdown, using whatever tier of coefficient is available for the model.
+// This is always an estimate, never a measurement — no provider exposes
+// per-request energy telemetry — so callers should surface the returned tier
+// alongside the number rather than presenting it as precise. Cache tokens
+// (read or write) are priced the same as input/output tokens: no public
+// source distinguishes a separate energy cost for cache operations.
+func EstimateCO2Grams(modelName string, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens int64) (grams float64, tier CO2Tier) {
+	totalTokens := inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens
+	if totalTokens <= 0 {
+		return 0, CO2TierFallback
+	}
+
+	coeff := co2CoefficientsForModel(modelName)
+	if coeff.gCO2PerToken > 0 {
+		return float64(totalTokens) * coeff.gCO2PerToken, coeff.tier
+	}
+
+	grams = float64(totalTokens) * fallbackWhPerToken * defaultPUE * globalGridGCO2PerKWh / 1000
+	return grams, CO2TierFallback
+}
+
+// WeakerCO2Tier returns whichever of a and b reflects lower confidence, for
+// combining coefficients across multiple models used within one session — the
+// session-level tier should reflect the least-trustworthy contributor, not
+// imply more confidence than the weakest model's estimate warrants.
+func WeakerCO2Tier(a, b CO2Tier) CO2Tier {
+	if a == CO2TierFallback || b == CO2TierFallback {
+		return CO2TierFallback
+	}
+	if a == "" {
+		return b
+	}
+	return a
+}

--- a/core/pkg/capacity/co2_test.go
+++ b/core/pkg/capacity/co2_test.go
@@ -3,7 +3,7 @@ package capacity
 import "testing"
 
 func TestEstimateCO2Grams_ZeroTokens(t *testing.T) {
-	grams, tier := EstimateCO2Grams("claude-sonnet-5", 0, 0, 0, 0)
+	grams, tier := EstimateCO2Grams("claude-sonnet-5", 0)
 	if grams != 0 {
 		t.Errorf("grams = %v, want 0", grams)
 	}
@@ -16,7 +16,7 @@ func TestEstimateCO2Grams_FallbackTier(t *testing.T) {
 	// Claude/GPT have no public per-token disclosure, so they land in the
 	// fallback tier: tokens * fallbackWhPerToken * PUE * grid / 1000.
 	for _, model := range []string{"claude-sonnet-5", "gpt-5", "unknown-model-xyz"} {
-		grams, tier := EstimateCO2Grams(model, 1_000_000, 0, 0, 0)
+		grams, tier := EstimateCO2Grams(model, 1_000_000)
 		if tier != CO2TierFallback {
 			t.Errorf("%s: tier = %v, want %v", model, tier, CO2TierFallback)
 		}
@@ -38,7 +38,7 @@ func TestEstimateCO2Grams_ProviderDisclosedTier(t *testing.T) {
 		{"open-mixtral-8x22b", 0.00285},
 	}
 	for _, tt := range tests {
-		grams, tier := EstimateCO2Grams(tt.model, 1000, 0, 0, 0)
+		grams, tier := EstimateCO2Grams(tt.model, 1000)
 		if tier != CO2TierProviderDisclosed {
 			t.Errorf("%s: tier = %v, want %v", tt.model, tier, CO2TierProviderDisclosed)
 		}
@@ -46,14 +46,6 @@ func TestEstimateCO2Grams_ProviderDisclosedTier(t *testing.T) {
 		if grams != want {
 			t.Errorf("%s: grams = %v, want %v", tt.model, grams, want)
 		}
-	}
-}
-
-func TestEstimateCO2Grams_SumsAllTokenBuckets(t *testing.T) {
-	grams, _ := EstimateCO2Grams("gemini-2.5-flash", 100, 200, 300, 400)
-	const want = 0.03
-	if diff := grams - want; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("grams = %v, want %v", grams, want)
 	}
 }
 

--- a/core/pkg/capacity/co2_test.go
+++ b/core/pkg/capacity/co2_test.go
@@ -1,0 +1,75 @@
+package capacity
+
+import "testing"
+
+func TestEstimateCO2Grams_ZeroTokens(t *testing.T) {
+	grams, tier := EstimateCO2Grams("claude-sonnet-5", 0, 0, 0, 0)
+	if grams != 0 {
+		t.Errorf("grams = %v, want 0", grams)
+	}
+	if tier != CO2TierFallback {
+		t.Errorf("tier = %v, want %v", tier, CO2TierFallback)
+	}
+}
+
+func TestEstimateCO2Grams_FallbackTier(t *testing.T) {
+	// Claude/GPT have no public per-token disclosure, so they land in the
+	// fallback tier: tokens * fallbackWhPerToken * PUE * grid / 1000.
+	for _, model := range []string{"claude-sonnet-5", "gpt-5", "unknown-model-xyz"} {
+		grams, tier := EstimateCO2Grams(model, 1_000_000, 0, 0, 0)
+		if tier != CO2TierFallback {
+			t.Errorf("%s: tier = %v, want %v", model, tier, CO2TierFallback)
+		}
+		want := 1_000_000.0 * fallbackWhPerToken * defaultPUE * globalGridGCO2PerKWh / 1000
+		if grams != want {
+			t.Errorf("%s: grams = %v, want %v", model, grams, want)
+		}
+	}
+}
+
+func TestEstimateCO2Grams_ProviderDisclosedTier(t *testing.T) {
+	tests := []struct {
+		model string
+		want  float64 // gCO2e/token
+	}{
+		{"gemini-2.5-pro", 0.00003},
+		{"gemini-3.1-flash-lite-preview", 0.00003},
+		{"mistral-large-2411", 0.00285},
+		{"open-mixtral-8x22b", 0.00285},
+	}
+	for _, tt := range tests {
+		grams, tier := EstimateCO2Grams(tt.model, 1000, 0, 0, 0)
+		if tier != CO2TierProviderDisclosed {
+			t.Errorf("%s: tier = %v, want %v", tt.model, tier, CO2TierProviderDisclosed)
+		}
+		want := 1000.0 * tt.want
+		if grams != want {
+			t.Errorf("%s: grams = %v, want %v", tt.model, grams, want)
+		}
+	}
+}
+
+func TestEstimateCO2Grams_SumsAllTokenBuckets(t *testing.T) {
+	grams, _ := EstimateCO2Grams("gemini-2.5-flash", 100, 200, 300, 400)
+	const want = 0.03
+	if diff := grams - want; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("grams = %v, want %v", grams, want)
+	}
+}
+
+func TestWeakerCO2Tier(t *testing.T) {
+	tests := []struct {
+		a, b CO2Tier
+		want CO2Tier
+	}{
+		{CO2TierProviderDisclosed, CO2TierProviderDisclosed, CO2TierProviderDisclosed},
+		{CO2TierProviderDisclosed, CO2TierFallback, CO2TierFallback},
+		{CO2TierFallback, CO2TierProviderDisclosed, CO2TierFallback},
+		{"", CO2TierProviderDisclosed, CO2TierProviderDisclosed},
+	}
+	for _, tt := range tests {
+		if got := WeakerCO2Tier(tt.a, tt.b); got != tt.want {
+			t.Errorf("WeakerCO2Tier(%q, %q) = %q, want %q", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -51,11 +51,17 @@ type SessionMetrics struct {
 	CumCacheReadTokens     int64   `json:"cum_cache_read_tokens,omitempty"`
 	CumCacheCreationTokens int64   `json:"cum_cache_creation_tokens,omitempty"`
 	EstimatedCostUSD       float64 `json:"estimated_cost_usd,omitempty"`
-	ModelName              string  `json:"model_name,omitempty"`
-	AgentVersion           string  `json:"agent_version,omitempty"`
-	ContextWindow          int64   `json:"context_window,omitempty"`
-	ContextUtilization     float64 `json:"context_utilization_percentage,omitempty"`
-	PressureLevel          string  `json:"pressure_level,omitempty"` // "safe", "caution", "warning", "critical"
+	// EstimatedCO2Grams and CO2Tier mirror EstimatedCostUSD's cumulative-token
+	// derivation (issue #829) — see capacity.EstimateCO2Grams. CO2Tier stores
+	// capacity.CO2Tier's string value; kept plain so this package doesn't take
+	// on more of capacity's API surface than the cost fields already do.
+	EstimatedCO2Grams  float64 `json:"estimated_co2_grams,omitempty"`
+	CO2Tier            string  `json:"co2_tier,omitempty"`
+	ModelName          string  `json:"model_name,omitempty"`
+	AgentVersion       string  `json:"agent_version,omitempty"`
+	ContextWindow      int64   `json:"context_window,omitempty"`
+	ContextUtilization float64 `json:"context_utilization_percentage,omitempty"`
+	PressureLevel      string  `json:"pressure_level,omitempty"` // "safe", "caution", "warning", "critical"
 
 	// ContextWindowUnknown is true when ContextWindow is the 32k sentinel
 	// fallback (no LiteLLM pricing for this model) rather than a known

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -254,7 +254,7 @@ func (t *TranscriptTailer) computeCumulativeTokens() {
 					modelName, bd.Input, bd.Output, bd.CacheRead, bd.CacheCreation5m, bd.CacheCreation1h)
 			}
 			grams, tier := capacity.EstimateCO2Grams(
-				modelName, bd.Input, bd.Output, bd.CacheRead, bd.CacheCreation5m+bd.CacheCreation1h)
+				modelName, bd.Input+bd.Output+bd.CacheRead+bd.CacheCreation5m+bd.CacheCreation1h)
 			co2Grams += grams
 			co2Tier = capacity.WeakerCO2Tier(co2Tier, tier)
 		}
@@ -271,9 +271,9 @@ func (t *TranscriptTailer) computeCumulativeTokens() {
 						pending.Usage.Input, pending.Usage.Output, pending.Usage.CacheRead,
 						pending.Usage.CacheCreation5m, pending.Usage.CacheCreation1h)
 				}
-				grams, tier := capacity.EstimateCO2Grams(
-					pending.Model, pending.Usage.Input, pending.Usage.Output,
-					pending.Usage.CacheRead, pending.Usage.CacheCreation5m+pending.Usage.CacheCreation1h)
+				grams, tier := capacity.EstimateCO2Grams(pending.Model,
+					pending.Usage.Input+pending.Usage.Output+pending.Usage.CacheRead+
+						pending.Usage.CacheCreation5m+pending.Usage.CacheCreation1h)
 				co2Grams += grams
 				co2Tier = capacity.WeakerCO2Tier(co2Tier, tier)
 			}
@@ -302,15 +302,14 @@ func (t *TranscriptTailer) computeCumulativeTokens() {
 		t.metrics.CumCacheReadTokens = effectiveCumCacheRead
 		t.metrics.CumCacheCreationTokens = effectiveCumCacheCreate
 
-		if t.capacityMgr != nil && t.metrics.ModelName != "" {
-			t.metrics.EstimatedCostUSD = t.capacityMgr.EstimateCostUSD(
-				t.metrics.ModelName, effectiveCumInput, effectiveCumOutput,
-				effectiveCumCacheRead, effectiveCumCacheCreate)
-		}
 		if t.metrics.ModelName != "" {
-			grams, tier := capacity.EstimateCO2Grams(
-				t.metrics.ModelName, effectiveCumInput, effectiveCumOutput,
-				effectiveCumCacheRead, effectiveCumCacheCreate)
+			if t.capacityMgr != nil {
+				t.metrics.EstimatedCostUSD = t.capacityMgr.EstimateCostUSD(
+					t.metrics.ModelName, effectiveCumInput, effectiveCumOutput,
+					effectiveCumCacheRead, effectiveCumCacheCreate)
+			}
+			grams, tier := capacity.EstimateCO2Grams(t.metrics.ModelName,
+				effectiveCumInput+effectiveCumOutput+effectiveCumCacheRead+effectiveCumCacheCreate)
 			t.metrics.EstimatedCO2Grams = grams
 			t.metrics.CO2Tier = string(tier)
 		}

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -242,7 +242,8 @@ func (t *TranscriptTailer) computeCumulativeTokens() {
 	if len(t.cumByModel) > 0 || t.cumProviderCostUSD > 0 {
 		// New path: price per-model, sum provider-reported costs.
 		var totalInput, totalOutput, totalCacheRead, totalCacheCreate int64
-		var pricedCost float64
+		var pricedCost, co2Grams float64
+		var co2Tier capacity.CO2Tier
 		for modelName, bd := range t.cumByModel {
 			totalInput += bd.Input
 			totalOutput += bd.Output
@@ -252,6 +253,10 @@ func (t *TranscriptTailer) computeCumulativeTokens() {
 				pricedCost += t.capacityMgr.EstimateCostFromBreakdown(
 					modelName, bd.Input, bd.Output, bd.CacheRead, bd.CacheCreation5m, bd.CacheCreation1h)
 			}
+			grams, tier := capacity.EstimateCO2Grams(
+				modelName, bd.Input, bd.Output, bd.CacheRead, bd.CacheCreation5m+bd.CacheCreation1h)
+			co2Grams += grams
+			co2Tier = capacity.WeakerCO2Tier(co2Tier, tier)
 		}
 		// Include the pending contribution from stateful parsers (Claude Code).
 		if pc, ok := t.parser.(pendingContributor); ok {
@@ -266,6 +271,11 @@ func (t *TranscriptTailer) computeCumulativeTokens() {
 						pending.Usage.Input, pending.Usage.Output, pending.Usage.CacheRead,
 						pending.Usage.CacheCreation5m, pending.Usage.CacheCreation1h)
 				}
+				grams, tier := capacity.EstimateCO2Grams(
+					pending.Model, pending.Usage.Input, pending.Usage.Output,
+					pending.Usage.CacheRead, pending.Usage.CacheCreation5m+pending.Usage.CacheCreation1h)
+				co2Grams += grams
+				co2Tier = capacity.WeakerCO2Tier(co2Tier, tier)
 			}
 		}
 		t.metrics.CumInputTokens = totalInput
@@ -273,6 +283,8 @@ func (t *TranscriptTailer) computeCumulativeTokens() {
 		t.metrics.CumCacheReadTokens = totalCacheRead
 		t.metrics.CumCacheCreationTokens = totalCacheCreate
 		t.metrics.EstimatedCostUSD = pricedCost + t.cumProviderCostUSD
+		t.metrics.EstimatedCO2Grams = co2Grams
+		t.metrics.CO2Tier = string(co2Tier)
 	} else {
 		// Legacy path: scalar accumulators (testParser and pre-Contribution adapters).
 		effectiveCumInput := t.cumInputTokens
@@ -295,7 +307,20 @@ func (t *TranscriptTailer) computeCumulativeTokens() {
 				t.metrics.ModelName, effectiveCumInput, effectiveCumOutput,
 				effectiveCumCacheRead, effectiveCumCacheCreate)
 		}
+		if t.metrics.ModelName != "" {
+			t.metrics.EstimatedCO2Grams, t.metrics.CO2Tier = co2GramsAndTier(
+				t.metrics.ModelName, effectiveCumInput, effectiveCumOutput,
+				effectiveCumCacheRead, effectiveCumCacheCreate)
+		}
 	}
+}
+
+// co2GramsAndTier is a thin wrapper returning the tier as a plain string,
+// matching how SessionMetrics.CO2Tier stays decoupled from the capacity
+// package's CO2Tier type (see metrics.go's EstimatedCO2Grams comment).
+func co2GramsAndTier(modelName string, input, output, cacheRead, cacheCreate int64) (float64, string) {
+	grams, tier := capacity.EstimateCO2Grams(modelName, input, output, cacheRead, cacheCreate)
+	return grams, string(tier)
 }
 
 // computeMetrics calculates messages per minute and elapsed time

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -308,19 +308,13 @@ func (t *TranscriptTailer) computeCumulativeTokens() {
 				effectiveCumCacheRead, effectiveCumCacheCreate)
 		}
 		if t.metrics.ModelName != "" {
-			t.metrics.EstimatedCO2Grams, t.metrics.CO2Tier = co2GramsAndTier(
+			grams, tier := capacity.EstimateCO2Grams(
 				t.metrics.ModelName, effectiveCumInput, effectiveCumOutput,
 				effectiveCumCacheRead, effectiveCumCacheCreate)
+			t.metrics.EstimatedCO2Grams = grams
+			t.metrics.CO2Tier = string(tier)
 		}
 	}
-}
-
-// co2GramsAndTier is a thin wrapper returning the tier as a plain string,
-// matching how SessionMetrics.CO2Tier stays decoupled from the capacity
-// package's CO2Tier type (see metrics.go's EstimatedCO2Grams comment).
-func co2GramsAndTier(modelName string, input, output, cacheRead, cacheCreate int64) (float64, string) {
-	grams, tier := capacity.EstimateCO2Grams(modelName, input, output, cacheRead, cacheCreate)
-	return grams, string(tier)
 }
 
 // computeMetrics calculates messages per minute and elapsed time

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -237,7 +237,7 @@ type SeriesQuery struct {
 	End           int64
 	BucketSeconds int64
 	Group         string // project|branch|provider|model|session|token_type
-	Metric        string // cost|tokens ("" defaults to cost)
+	Metric        string // cost|tokens|co2 ("" defaults to cost)
 	ScopeField    string // "" = unscoped; else project|branch|provider|model|session
 	ScopeValue    string
 	Projects      []string // cross-filter: keep only these projects (empty = all)

--- a/platforms/macos/Irrlicht/Models/HistoryData.swift
+++ b/platforms/macos/Irrlicht/Models/HistoryData.swift
@@ -172,9 +172,10 @@ enum HistoryTokenType: String, CaseIterable, Identifiable {
 }
 
 /// History chart type (#750). Mirrors the web Chart segmented control. cost and
-/// the models/providers presets measure USD; tokens measures token counts.
+/// the models/providers presets measure USD; tokens measures token counts;
+/// co2 (issue #829) measures estimated CO2e grams.
 enum HistoryChart: String, CaseIterable, Identifiable {
-    case cost, tokens, models, providers
+    case cost, tokens, co2, models, providers
     case yieldRatio = "yield" // #373 — per-project productive vs reverted spend
 
     var id: String { rawValue }
@@ -183,14 +184,18 @@ enum HistoryChart: String, CaseIterable, Identifiable {
         switch self {
         case .cost: return "Cost"
         case .tokens: return "Tokens"
+        case .co2: return "CO2"
         case .models: return "Models"
         case .providers: return "Providers"
         case .yieldRatio: return "Yield"
         }
     }
 
-    /// True for the USD metrics (everything but tokens) — they render a $ axis.
-    var isCost: Bool { self != .tokens }
+    /// True for the USD metrics (everything but tokens and co2) — they render a $ axis.
+    var isCost: Bool { self != .tokens && self != .co2 }
+
+    /// True for the co2 metric — renders a CO2e axis (mg/g/kg), not $ or tokens.
+    var isCO2: Bool { self == .co2 }
 
     /// models/providers are presets that pin the stacking axis to that
     /// dimension; cost/tokens leave the group axis to the user.

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -354,6 +354,8 @@ struct SessionMetrics: Codable {
     let pressureLevel: String       // pressure level: "safe", "caution", "warning", "critical" ("unknown" if not available)
     let contextWindowUnknown: Bool? // true when daemon has no LiteLLM pricing for the model — render tokens-only, no percentage
     let estimatedCostUSD: Double?   // estimated session cost in USD (nil if not available)
+    let estimatedCO2Grams: Double?  // estimated CO2e footprint in grams — always a model, never a measurement (issue #829)
+    let co2Tier: String?            // confidence tier behind estimatedCO2Grams: "provider_disclosed" or "fallback"
     let lastAssistantText: String?  // last assistant message text, truncated (~200 chars) — full text for the question tooltip
     let taskSummary: String?        // human-readable "what is this session about" (issue #738) — full text for the intent tooltip
     let intentHeadline: String?     // terse one-line version of taskSummary for the sidebar (issue #759)
@@ -375,6 +377,8 @@ struct SessionMetrics: Codable {
         case pressureLevel = "pressure_level"
         case contextWindowUnknown = "context_window_unknown"
         case estimatedCostUSD = "estimated_cost_usd"
+        case estimatedCO2Grams = "estimated_co2_grams"
+        case co2Tier = "co2_tier"
         case lastAssistantText = "last_assistant_text"
         case taskSummary = "task_summary"
         case intentHeadline = "intent_headline"
@@ -398,6 +402,8 @@ struct SessionMetrics: Codable {
         pressureLevel = try c.decodeIfPresent(String.self, forKey: .pressureLevel) ?? "unknown"
         contextWindowUnknown = try c.decodeIfPresent(Bool.self, forKey: .contextWindowUnknown)
         estimatedCostUSD = try c.decodeIfPresent(Double.self, forKey: .estimatedCostUSD)
+        estimatedCO2Grams = try c.decodeIfPresent(Double.self, forKey: .estimatedCO2Grams)
+        co2Tier = try c.decodeIfPresent(String.self, forKey: .co2Tier)
         lastAssistantText = try c.decodeIfPresent(String.self, forKey: .lastAssistantText)
         taskSummary = try c.decodeIfPresent(String.self, forKey: .taskSummary)
         intentHeadline = try c.decodeIfPresent(String.self, forKey: .intentHeadline)
@@ -435,6 +441,8 @@ struct SessionMetrics: Codable {
         pressureLevel: String,
         contextWindowUnknown: Bool?,
         estimatedCostUSD: Double?,
+        estimatedCO2Grams: Double? = nil,
+        co2Tier: String? = nil,
         lastAssistantText: String?,
         taskSummary: String? = nil,
         intentHeadline: String? = nil,
@@ -455,6 +463,8 @@ struct SessionMetrics: Codable {
         self.pressureLevel = pressureLevel
         self.contextWindowUnknown = contextWindowUnknown
         self.estimatedCostUSD = estimatedCostUSD
+        self.estimatedCO2Grams = estimatedCO2Grams
+        self.co2Tier = co2Tier
         self.lastAssistantText = lastAssistantText
         self.taskSummary = taskSummary
         self.intentHeadline = intentHeadline
@@ -478,6 +488,8 @@ struct SessionMetrics: Codable {
         try c.encode(pressureLevel, forKey: .pressureLevel)
         try c.encodeIfPresent(contextWindowUnknown, forKey: .contextWindowUnknown)
         try c.encodeIfPresent(estimatedCostUSD, forKey: .estimatedCostUSD)
+        try c.encodeIfPresent(estimatedCO2Grams, forKey: .estimatedCO2Grams)
+        try c.encodeIfPresent(co2Tier, forKey: .co2Tier)
         try c.encodeIfPresent(lastAssistantText, forKey: .lastAssistantText)
         try c.encodeIfPresent(taskSummary, forKey: .taskSummary)
         try c.encodeIfPresent(intentHeadline, forKey: .intentHeadline)
@@ -592,7 +604,33 @@ struct SessionMetrics: Codable {
         if contextWindowUnknown == true { return "—" }
         return nil
     }
-    
+
+    // Estimated CO2e footprint, shown as an alternate view of the cost slot
+    // (issue #829, click-to-cycle in SessionRowView). Unit-adaptive like the
+    // web dashboard's formatCO2, but without the "CO2e" suffix — the row's
+    // cost column is too narrow for it; co2TierTooltip carries that context.
+    var formattedCO2: String? {
+        guard totalTokens > 0 else { return nil }
+        guard let grams = estimatedCO2Grams, grams > 0 else {
+            if contextWindowUnknown == true { return "—" }
+            return nil
+        }
+        if grams < 1 { return String(format: "%.0fmg", grams * 1000) }
+        if grams < 1000 { return String(format: "%.1fg", grams) }
+        return String(format: "%.2fkg", grams / 1000)
+    }
+
+    // co2TierTooltip explains the confidence behind the CO2 estimate — every
+    // figure here is modeled from public disclosures, never measured (no
+    // provider exposes per-request energy telemetry). Mirrors the web
+    // dashboard's co2TierTitle.
+    var co2TierTooltip: String {
+        if co2Tier == "provider_disclosed" {
+            return "Estimated CO2e, normalized from a provider-published energy/CO2 disclosure — not a live measurement."
+        }
+        return "Estimated CO2e — no public per-model figure exists for this model, so a cross-model fallback average is used. Not a live measurement."
+    }
+
     // Real-time elapsed time for active sessions
     func formattedRealtimeElapsedTime(sessionFirstSeen: Date) -> String {
         let seconds = Int64(Date().timeIntervalSince(sessionFirstSeen))

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -285,9 +285,9 @@ struct HistoryView: View {
         .font(.caption)
     }
 
-    /// Metrics shown in the Chart dropdown — Cost and Tokens (Yield is its own
-    /// tab; the models/providers presets fold into the Group axis).
-    private var visibleCharts: [HistoryChart] { [.cost, .tokens] }
+    /// Metrics shown in the Chart dropdown — Cost, Tokens, and CO2 (issue #829;
+    /// Yield is its own tab; the models/providers presets fold into the Group axis).
+    private var visibleCharts: [HistoryChart] { [.cost, .tokens, .co2] }
 
     // MARK: Cross-filter menus
 
@@ -1186,10 +1186,22 @@ enum HistoryFormat {
         return String(Int(v.rounded()))
     }
 
-    /// Dollars for the USD charts, token counts for the tokens chart — the
-    /// macOS twin of the web `histValue`.
+    /// Compact estimated CO2e footprint (issue #829), matching the web
+    /// `histCO2` — unit-adaptive and always renders a value (a chart axis
+    /// needs "0mg" at an empty bucket, not SessionMetrics.formattedCO2's
+    /// hide-on-zero blank).
+    static func co2(_ v: Double) -> String {
+        if v < 1 { return String(format: "%.0fmg", v * 1000) }
+        if v < 1000 { return String(format: "%.1fg", v) }
+        return String(format: "%.2fkg", v / 1000)
+    }
+
+    /// Dollars for the USD charts, token counts for the tokens chart, CO2e for
+    /// the co2 chart — the macOS twin of the web `histValue`.
     static func value(_ v: Double, chart: HistoryChart) -> String {
-        chart.isCost ? dollar(v) : tokens(v)
+        if chart.isCost { return dollar(v) }
+        if chart.isCO2 { return co2(v) }
+        return tokens(v)
     }
 
     // Cached formatters — DateFormatter init is expensive and these fire per

--- a/platforms/macos/Irrlicht/Views/SessionRowView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionRowView.swift
@@ -34,6 +34,11 @@ struct SessionRowView: View {
     var activeSubagentCount: Int = 0
     @AppStorage("debugMode") private var debugMode: Bool = false
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
+    // costDisplayMode selects what the cost slot shows — "cost" ($) or "co2"
+    // (estimated CO2e), issue #829. App-wide via @AppStorage so clicking any
+    // row's figure cycles all rows together, mirroring the web dashboard's
+    // localStorage-backed costDisplayMode.
+    @AppStorage("costDisplayMode") private var costDisplayModeRaw: String = "cost"
     @AppStorage("displayMode") private var displayModeRaw: String = DisplayMode.context.rawValue
     @AppStorage("userIntentDisplay") private var userIntentDisplay: Bool = false
     @AppStorage(ContextPressureThreshold.valueKey) private var contextThresholdValue: Double = ContextPressureThreshold.defaultValue
@@ -50,6 +55,28 @@ struct SessionRowView: View {
                 .font(.system(size: 8, weight: .bold))
                 .foregroundColor(IrrColors.pressureHigh)
         }
+    }
+
+    /// Cost/CO2 slot content — click to cycle between $ cost and estimated
+    /// CO2e (issue #829), keeping the mode-branching out of `body` so it
+    /// doesn't add to this already-large view's complexity at each call site.
+    /// `isReverted` preserves the existing yield-revert tooltip nuance in
+    /// cost mode; CO2 mode always shows its confidence-tier tooltip.
+    @ViewBuilder
+    private func costOrCO2Label(_ metrics: SessionMetrics, placeholder: String, isReverted: Bool = false) -> some View {
+        let showingCO2 = costDisplayModeRaw == "co2"
+        let text = showingCO2 ? (metrics.formattedCO2 ?? placeholder) : (metrics.formattedCost ?? placeholder)
+        let tooltip = showingCO2
+            ? metrics.co2TierTooltip
+            : (isReverted ? "Estimated cost — session work was reverted — click to show CO2 estimate" : "Click to show CO2 estimate")
+        Button(action: { costDisplayModeRaw = showingCO2 ? "cost" : "co2" }) {
+            Text(text)
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .foregroundColor(.secondary)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .tooltip(tooltip)
     }
 
     private var contextThreshold: ContextPressureThreshold {
@@ -247,12 +274,9 @@ struct SessionRowView: View {
                         if showCostDisplay {
                             HStack(spacing: 1) {
                                 yieldRevertGlyph
-                                Text(metrics.formattedCost ?? "")
-                                    .font(.system(size: 9, weight: .medium, design: .monospaced))
-                                    .foregroundColor(.secondary)
+                                costOrCO2Label(metrics, placeholder: "", isReverted: session.yieldState == "reverted")
                             }
                             .frame(width: 36, alignment: .leading)
-                            .tooltip(session.yieldState == "reverted" ? "Estimated cost — session work was reverted" : "Estimated session cost")
                         } else {
                             Text(metrics.formattedContextUtilization)
                                 .font(.system(size: 9, design: .monospaced))
@@ -275,9 +299,7 @@ struct SessionRowView: View {
                         if showCostDisplay {
                             HStack(spacing: 1) {
                                 yieldRevertGlyph
-                                Text(metrics.formattedCost ?? "—")
-                                    .font(.system(size: 9, weight: .medium, design: .monospaced))
-                                    .foregroundColor(.secondary)
+                                costOrCO2Label(metrics, placeholder: "—", isReverted: session.yieldState == "reverted")
                             }
                             .frame(width: 36, alignment: .leading)
                         } else {

--- a/platforms/macos/Tests/HistoryPhase2Tests.swift
+++ b/platforms/macos/Tests/HistoryPhase2Tests.swift
@@ -46,9 +46,19 @@ final class HistoryPhase2Tests: XCTestCase {
         XCTAssertEqual(HistoryChart.providers.pinnedGroup, .provider)
         XCTAssertNil(HistoryChart.cost.pinnedGroup)
         XCTAssertNil(HistoryChart.tokens.pinnedGroup)
+        XCTAssertNil(HistoryChart.co2.pinnedGroup)
         XCTAssertTrue(HistoryChart.cost.isCost)
         XCTAssertTrue(HistoryChart.models.isCost)
         XCTAssertFalse(HistoryChart.tokens.isCost)
+        XCTAssertFalse(HistoryChart.co2.isCost)
+    }
+
+    // issue #829: the co2 chart is neither the USD nor the tokens metric.
+    func testChart_isCO2() {
+        XCTAssertTrue(HistoryChart.co2.isCO2)
+        XCTAssertFalse(HistoryChart.cost.isCO2)
+        XCTAssertFalse(HistoryChart.tokens.isCO2)
+        XCTAssertEqual(HistoryChart.co2.label, "CO2")
     }
 
     func testFormat_tokensAndValue() {
@@ -57,6 +67,14 @@ final class HistoryPhase2Tests: XCTestCase {
         XCTAssertEqual(HistoryFormat.tokens(970), "970")
         XCTAssertEqual(HistoryFormat.value(1.5, chart: .cost), "$1.50")
         XCTAssertEqual(HistoryFormat.value(1500, chart: .tokens), "1.5k")
+    }
+
+    // issue #829: unit-adaptive CO2e formatting, matching the web histCO2.
+    func testFormat_co2AndValue() {
+        XCTAssertEqual(HistoryFormat.co2(0.03), "30mg")
+        XCTAssertEqual(HistoryFormat.co2(158.7), "158.7g")
+        XCTAssertEqual(HistoryFormat.co2(2850), "2.85kg")
+        XCTAssertEqual(HistoryFormat.value(158.7, chart: .co2), "158.7g")
     }
 
     func testScope_queryForm() {

--- a/platforms/web/formatters.js
+++ b/platforms/web/formatters.js
@@ -29,6 +29,27 @@ export function formatCost(usd) {
   return '$' + usd.toFixed(2);
 }
 
+// formatCO2 renders an estimated CO2e footprint (issue #829). Grams span a
+// wide range across sessions (milligrams for a short chat, kilograms for a
+// long agentic run), so the unit adapts rather than showing e.g. "0.0g".
+export function formatCO2(grams) {
+  if (!grams || grams <= 0) return '';
+  if (grams < 1) return (grams * 1000).toFixed(0) + 'mg CO2e';
+  if (grams < 1000) return grams.toFixed(1) + 'g CO2e';
+  return (grams / 1000).toFixed(2) + 'kg CO2e';
+}
+
+// co2TierTitle explains the confidence behind a CO2 estimate — every figure
+// here is modeled from public disclosures, never measured (no provider
+// exposes per-request energy telemetry), so the tooltip says so rather than
+// presenting a bare number as fact. Mirrors capacity.CO2Tier's Go-side values.
+export function co2TierTitle(tier) {
+  if (tier === 'provider_disclosed') {
+    return 'Estimated CO2e, normalized from a provider-published energy/CO2 disclosure — not a live measurement.';
+  }
+  return 'Estimated CO2e — no public per-model figure exists for this model, so a cross-model fallback average is used. Not a live measurement.';
+}
+
 export function fmtDuration(secs) {
   const h = Math.floor(secs / 3600);
   const m = Math.floor((secs % 3600) / 60);

--- a/platforms/web/formatters.js
+++ b/platforms/web/formatters.js
@@ -50,6 +50,16 @@ export function co2TierTitle(tier) {
   return 'Estimated CO2e — no public per-model figure exists for this model, so a cross-model fallback average is used. Not a live measurement.';
 }
 
+// costCellDisplay resolves the per-session row's cost/CO2 slot (issue #829)
+// to its text + tooltip for the given display mode, keeping the mode
+// branching out of updateSessionRow's already-large row-rendering function.
+export function costCellDisplay(metrics, mode) {
+  if (mode === 'co2') {
+    return { text: formatCO2(metrics.estimated_co2_grams), title: co2TierTitle(metrics.co2_tier) };
+  }
+  return { text: formatCost(metrics.estimated_cost_usd), title: 'Click to show CO2 estimate' };
+}
+
 export function fmtDuration(secs) {
   const h = Math.floor(secs / 3600);
   const m = Math.floor((secs % 3600) / 60);

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -11,7 +11,7 @@ const HISTORY_COLORS = [
   '#5E5CE6', '#FFD60A', '#30D158', '#BF5AF2', '#64D2FF',
 ];
 const RANGE_LABELS = { day: 'Day', week: 'Week', month: 'Month', year: 'Year', 'this-month': 'This Month', custom: 'Custom' };
-export const CHART_LABELS = { cost: 'Cost', tokens: 'Tokens', models: 'Models', providers: 'Providers', agents: 'Agents' };
+export const CHART_LABELS = { cost: 'Cost', tokens: 'Tokens', co2: 'CO2', models: 'Models', providers: 'Providers', agents: 'Agents' };
 // Drilldown order: clicking a contributor scopes to it and re-groups by the
 // next finer axis. A leaf (no entry) makes that contributor non-drillable.
 export const DRILL_NEXT = { project: 'branch', branch: 'session', provider: 'model', model: 'session' };
@@ -42,11 +42,21 @@ export function histTokens(v) {
 }
 // Integer agent count (concurrency is a whole number of sessions).
 export function histCount(v) { return String(Math.round(Number(v) || 0)); }
+// Compact estimated CO2e footprint (issue #829): unit-adaptive like the
+// session row's formatCO2, but always renders a value — a chart axis needs
+// "0g" at an empty bucket, not the row display's hide-on-zero blank.
+export function histCO2(v) {
+  v = Number(v) || 0;
+  if (v < 1) return (v * 1000).toFixed(0) + 'mg';
+  if (v < 1000) return v.toFixed(1) + 'g';
+  return (v / 1000).toFixed(2) + 'kg';
+}
 // The value formatter for the active chart — dollars for cost/models/providers,
-// token counts for tokens, integer agent counts for agents.
+// token counts for tokens, integer agent counts for agents, grams for co2.
 function histValue(v) {
   if (historyState.chart === 'tokens') return histTokens(v);
   if (historyState.chart === 'agents') return histCount(v);
+  if (historyState.chart === 'co2') return histCO2(v);
   return histDollar(v);
 }
 function histAxisLabel(ts, bucketSeconds) {
@@ -370,7 +380,7 @@ function renderHistoryPanel() {
 
   const contribs = data.top_contributors || [];
   if (!contribs.length) {
-    appendHistoryEmpty(listEl, 'no spend in this range');
+    appendHistoryEmpty(listEl, historyState.chart === 'co2' ? 'no CO2 estimate in this range' : 'no spend in this range');
     return;
   }
   // Drilldown: click a contributor to scope into it (the effective stacking

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -42,7 +42,7 @@
         <input type="checkbox" data-setting="showCostDisplay">
         <span class="settings-label-text">
           <span class="settings-title">Show cost</span>
-          <span class="settings-hint">Display the per-session running cost in each row.</span>
+          <span class="settings-hint">Display the per-session running cost in each row. Click the figure to switch to an estimated CO2 footprint.</span>
         </span>
       </label>
 

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -192,6 +192,7 @@
             <button type="button" data-chart="cost" class="active">Cost</button>
             <button type="button" data-chart="yield" title="Productive vs reverted spend per project">Yield</button>
             <button type="button" data-chart="tokens">Tokens</button>
+            <button type="button" data-chart="co2" title="Estimated CO2e footprint — modeled, not measured">CO2</button>
             <button type="button" data-chart="models">Models</button>
             <button type="button" data-chart="providers">Providers</button>
             <button type="button" data-chart="agents">Agents</button>

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1,7 +1,7 @@
 import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
 import { isSummaryCollapsed, toggleSummaryCollapsed, anySummaryCollapsed, collapseAllSummaries, expandAllSummaries } from './collapsedSummaries.js';
 import {
-  initHistoryTab, historyQuery, histTokens, histCount, CHART_LABELS, DRILL_NEXT, historyRunningSum,
+  initHistoryTab, historyQuery, histTokens, histCount, histCO2, CHART_LABELS, DRILL_NEXT, historyRunningSum,
 } from './historyTab.js';
 import {
   initPermissionsWizard, refreshPermissions, pendingWizardAgents, stillPendingForAgents, buildPermissionAnswers,
@@ -1951,5 +1951,5 @@ export {
   sessionOrigin, sourceIdOf, localBareIds, isShadowedRemote,
   daemonSessionIds, structureSignature,
   pendingWizardAgents, buildPermissionAnswers, stillPendingForAgents,
-  historyQuery, histTokens, histCount, CHART_LABELS, DRILL_NEXT, historyRunningSum,
+  historyQuery, histTokens, histCount, histCO2, CHART_LABELS, DRILL_NEXT, historyRunningSum,
 };

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -14,7 +14,7 @@ import {
 } from './sessionIdentity.js';
 import { relayFrameKind, seqGap, aggregateConnState, relayWsUrl } from './connectionProtocol.js';
 import {
-  stateIcon, shortModel, formatCost, fmtDuration, formatElapsed, fmtEtaDuration, fmtEtaText,
+  stateIcon, shortModel, formatCost, formatCO2, co2TierTitle, fmtDuration, formatElapsed, fmtEtaDuration, fmtEtaText,
   taskEtaPresentation, shortID, pressureClass, pressureColor, formatTokens, esc, activeSubagentCount,
 } from './formatters.js';
 import { reconcile, paintRowNum } from './domReconcile.js';
@@ -223,6 +223,18 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     // macOS's separate usageCostTimeframe (#386).
     export let currentUsageTimeframe = localStorage.getItem('irrlicht_usageCostTimeframe') || 'day';
     if (!COST_TIMEFRAMES.find(t => t.key === currentUsageTimeframe)) currentUsageTimeframe = 'day';
+
+    // costDisplayMode selects what the per-session row's cost slot shows —
+    // 'cost' ($) or 'co2' (estimated CO2e), issue #829. Click-to-cycle rather
+    // than a fourth always-on column, matching the group header's existing
+    // cycleCostTimeframe() interaction pattern below.
+    let costDisplayMode = localStorage.getItem('irrlicht_costDisplayMode') === 'co2' ? 'co2' : 'cost';
+
+    function cycleCostDisplayMode() {
+      costDisplayMode = costDisplayMode === 'cost' ? 'co2' : 'cost';
+      localStorage.setItem('irrlicht_costDisplayMode', costDisplayMode);
+      render();
+    }
 
     // --- Timeline / history state (WebSocket-streamed, see history_snapshot/tick/upgrade) ---
     let timelineHistory = new Map(); // session_id -> {label, states: string[]} for the active granularity
@@ -642,6 +654,10 @@ import { reconcile, paintRowNum } from './domReconcile.js';
         '<span class="row-elapsed"></span>' +
         '<span class="row-created"></span>' +
         '<span class="row-id"></span>';
+      el.querySelector('.row-cost').addEventListener('click', (e) => {
+        e.stopPropagation();
+        cycleCostDisplayMode();
+      });
       updateSessionRow(el, agent, isChild);
       return el;
     }
@@ -653,7 +669,8 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       const ctxPct = metrics.context_utilization_percentage || 0;
       const pressure = metrics.pressure_level || '';
       const branch = agent.git_branch || '';
-      const cost = formatCost(metrics.estimated_cost_usd);
+      const showCO2 = costDisplayMode === 'co2';
+      const cost = showCO2 ? formatCO2(metrics.estimated_co2_grams) : formatCost(metrics.estimated_cost_usd);
       const isActive = state === 'working' || state === 'waiting';
       const elapsed = formatElapsed(agent.first_seen, metrics.elapsed_seconds, isActive);
 
@@ -818,9 +835,11 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       if (pctEl.textContent !== pctText) pctEl.textContent = pctText;
       pctEl.style.color = ctxPct > 0 ? pressureColor(pressure) : '';
 
-      // Cost
+      // Cost / CO2 (click to cycle, issue #829)
       const costEl = el.querySelector('.row-cost');
       if (costEl.textContent !== cost) costEl.textContent = cost;
+      const costTitle = showCO2 ? co2TierTitle(metrics.co2_tier) : 'Click to show CO2 estimate';
+      if (costEl.title !== costTitle) costEl.title = costTitle;
 
       // Yield revert marker (#373): ↩ next to cost when the session's work
       // was later git-reverted.
@@ -1926,7 +1945,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
 
 export {
   resolvedTheme, rowLabel, maybeNotifyOnUpdate,
-  formatCost, formatUsageCost, pressureClass, historyPriorityForState,
+  formatCost, formatCO2, co2TierTitle, formatUsageCost, pressureClass, historyPriorityForState,
   taskEtaPresentation,
   lastNotifiedPressure,
   relayFrameKind, aggregateConnState, relayWsUrl, seqGap,

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -14,7 +14,7 @@ import {
 } from './sessionIdentity.js';
 import { relayFrameKind, seqGap, aggregateConnState, relayWsUrl } from './connectionProtocol.js';
 import {
-  stateIcon, shortModel, formatCost, formatCO2, co2TierTitle, fmtDuration, formatElapsed, fmtEtaDuration, fmtEtaText,
+  stateIcon, shortModel, formatCost, costCellDisplay, fmtDuration, formatElapsed, fmtEtaDuration, fmtEtaText,
   taskEtaPresentation, shortID, pressureClass, pressureColor, formatTokens, esc, activeSubagentCount,
 } from './formatters.js';
 import { reconcile, paintRowNum } from './domReconcile.js';
@@ -669,8 +669,6 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       const ctxPct = metrics.context_utilization_percentage || 0;
       const pressure = metrics.pressure_level || '';
       const branch = agent.git_branch || '';
-      const showCO2 = costDisplayMode === 'co2';
-      const cost = showCO2 ? formatCO2(metrics.estimated_co2_grams) : formatCost(metrics.estimated_cost_usd);
       const isActive = state === 'working' || state === 'waiting';
       const elapsed = formatElapsed(agent.first_seen, metrics.elapsed_seconds, isActive);
 
@@ -837,8 +835,8 @@ import { reconcile, paintRowNum } from './domReconcile.js';
 
       // Cost / CO2 (click to cycle, issue #829)
       const costEl = el.querySelector('.row-cost');
+      const { text: cost, title: costTitle } = costCellDisplay(metrics, costDisplayMode);
       if (costEl.textContent !== cost) costEl.textContent = cost;
-      const costTitle = showCO2 ? co2TierTitle(metrics.co2_tier) : 'Click to show CO2 estimate';
       if (costEl.title !== costTitle) costEl.title = costTitle;
 
       // Yield revert marker (#373): ↩ next to cost when the session's work
@@ -1945,7 +1943,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
 
 export {
   resolvedTheme, rowLabel, maybeNotifyOnUpdate,
-  formatCost, formatCO2, co2TierTitle, formatUsageCost, pressureClass, historyPriorityForState,
+  formatCost, costCellDisplay, formatUsageCost, pressureClass, historyPriorityForState,
   taskEtaPresentation,
   lastNotifiedPressure,
   relayFrameKind, aggregateConnState, relayWsUrl, seqGap,

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -29,6 +29,7 @@ import {
   historyQuery,
   histTokens,
   histCount,
+  histCO2,
   CHART_LABELS,
   DRILL_NEXT,
   historyRunningSum,
@@ -838,5 +839,25 @@ describe('agents chart (#751 Phase 3)', () => {
     expect(histCount(2)).toBe('2')
     expect(histCount(2.6)).toBe('3')
     expect(histCount(undefined)).toBe('0')
+  })
+})
+
+describe('co2 chart (issue #829)', () => {
+  test('chart=co2 serializes with project grouping', () => {
+    const q = new URLSearchParams(historyQuery({ range: 'day', chart: 'co2', group: 'project', forecast: true, start: null, end: null, scope: null }))
+    expect(q.get('chart')).toBe('co2')
+    expect(q.get('group')).toBe('project')
+  })
+
+  test('CHART_LABELS includes CO2', () => {
+    expect(CHART_LABELS.co2).toBe('CO2')
+  })
+
+  test('histCO2 is unit-adaptive and always renders a value', () => {
+    expect(histCO2(0)).toBe('0mg')
+    expect(histCO2(0.03)).toBe('30mg')
+    expect(histCO2(158.7)).toBe('158.7g')
+    expect(histCO2(2850)).toBe('2.85kg')
+    expect(histCO2(undefined)).toBe('0mg')
   })
 })

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -7,6 +7,8 @@ import {
   rowLabel,
   maybeNotifyOnUpdate,
   formatCost,
+  formatCO2,
+  co2TierTitle,
   formatUsageCost,
   pressureClass,
   taskEtaPresentation,
@@ -110,6 +112,38 @@ describe('formatCost', () => {
   test('formats positive values with dollar sign and two decimals', () => {
     expect(formatCost(1.5)).toBe('$1.50')
     expect(formatCost(0.123)).toBe('$0.12')
+  })
+})
+
+describe('formatCO2', () => {
+  test('returns empty string for zero or falsy', () => {
+    expect(formatCO2(0)).toBe('')
+    expect(formatCO2(null)).toBe('')
+    expect(formatCO2(undefined)).toBe('')
+  })
+
+  test('formats sub-gram values in milligrams', () => {
+    expect(formatCO2(0.03)).toBe('30mg CO2e')
+  })
+
+  test('formats gram-range values with one decimal', () => {
+    expect(formatCO2(1.5)).toBe('1.5g CO2e')
+    expect(formatCO2(158.7)).toBe('158.7g CO2e')
+  })
+
+  test('formats kilogram-range values with two decimals', () => {
+    expect(formatCO2(2850)).toBe('2.85kg CO2e')
+  })
+})
+
+describe('co2TierTitle', () => {
+  test('names the provider disclosure for provider_disclosed tier', () => {
+    expect(co2TierTitle('provider_disclosed')).toMatch(/provider-published/)
+  })
+
+  test('discloses the fallback approximation for any other tier', () => {
+    expect(co2TierTitle('fallback')).toMatch(/cross-model fallback/)
+    expect(co2TierTitle(undefined)).toMatch(/cross-model fallback/)
   })
 })
 

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -1,4 +1,5 @@
 import { describe, test, expect, beforeEach } from 'vitest'
+import { formatCO2, co2TierTitle } from './formatters.js'
 import {
   pendingWizardAgents,
   stillPendingForAgents,
@@ -7,8 +8,7 @@ import {
   rowLabel,
   maybeNotifyOnUpdate,
   formatCost,
-  formatCO2,
-  co2TierTitle,
+  costCellDisplay,
   formatUsageCost,
   pressureClass,
   taskEtaPresentation,
@@ -144,6 +144,20 @@ describe('co2TierTitle', () => {
   test('discloses the fallback approximation for any other tier', () => {
     expect(co2TierTitle('fallback')).toMatch(/cross-model fallback/)
     expect(co2TierTitle(undefined)).toMatch(/cross-model fallback/)
+  })
+})
+
+describe('costCellDisplay', () => {
+  const metrics = { estimated_cost_usd: 1.5, estimated_co2_grams: 30, co2_tier: 'provider_disclosed' }
+
+  test('shows cost by default', () => {
+    expect(costCellDisplay(metrics, 'cost')).toEqual({ text: '$1.50', title: 'Click to show CO2 estimate' })
+  })
+
+  test('shows CO2 with its tier tooltip in co2 mode', () => {
+    const { text, title } = costCellDisplay(metrics, 'co2')
+    expect(text).toBe('30.0g CO2e')
+    expect(title).toMatch(/provider-published/)
   })
 })
 


### PR DESCRIPTION
## Summary
- Adds `capacity.EstimateCO2Grams` — a tiered CO2e estimation formula: provider-disclosed coefficients for Gemini (Google's Aug 2025 environmental report) and Mistral (Carbone4/ADEME lifecycle assessment), falling back to a cross-model average (Epoch AI) for everything else, including Claude and GPT since neither Anthropic nor OpenAI publishes per-token figures.
- Wires the estimate through the tailer's existing cumulative-token computation into `SessionMetrics.EstimatedCO2Grams` + `CO2Tier`, mirroring `EstimatedCostUSD`'s plumbing exactly (shared `MetricsConverter`, `MergeMetrics` carry-forward).
- Surfaces it in the web dashboard: clicking the per-session cost figure now cycles between $ cost and estimated CO2e, with a tooltip disclosing the confidence tier (every number here is a model, not a measurement — no provider exposes real per-request energy telemetry).

## Scope
This implements the "first PR" scope from #829: core estimation + one UI surface to validate the UX. CLI (`irrlicht-ls`) and macOS app parity are deliberately deferred as follow-ups, along with historical/aggregate CO2 tracking in `cost_tracker.go` (would need its own persistence design, unlike the live per-session estimate which needed none).

Closes #829.

## Test plan
- [x] `go test ./... -race -count=1` (full core suite, includes e2e + daemon smoke test)
- [x] `npm test` in `platforms/web` (125 tests, incl. new `formatCO2`/`co2TierTitle` cases)
- [x] `tools/preflight.sh` (gofmt, core+onboarding-factory tests, replaydata validate, recording-rig smoke test, both web suites, ARS gate — all green, composite score unregressed)
- [x] `/code-review` at low effort — no findings; one self-fix (inlined a trivial single-use wrapper)