### PR TITLE
feat(ci): auto-refresh CodeScene badge, add on-demand report skill

### DIFF
--- a/.claude/skills/ir:codescene-report/skill.md
+++ b/.claude/skills/ir:codescene-report/skill.md
@@ -1,0 +1,103 @@
+---
+name: "ir:codescene-report"
+description: "Trigger an on-demand CodeScene code-health report and summarize it — overall score, trend, and the worst refactoring-target hotspots. Wraps the manual codescene-report.yml workflow so you don't have to drive the GitHub Actions UI by hand. Use when the user says '/ir:codescene-report', 'run a codescene report', 'check code health', 'codescene improvement run', or wants an up-to-date look at code health outside the automatic per-PR check."
+---
+
+# CodeScene Report (on demand)
+
+Irrlicht's per-PR "CodeScene Code Health Review" check (via the CodeScene
+GitHub App, project 82148) is advisory-only — see AGENTS.md's Testing
+section. It is *not* the mechanism for periodic improvement work. This
+skill is: fetch the current report, on demand, and hand back a short,
+readable summary — no PR, no waiting on Actions UI.
+
+The README's CodeScene badge already shows the live overall score
+(refreshed on every push to `main` by `codescene-badge.yml`) — this skill
+is for going deeper: trend plus the actual hotspot files.
+
+## Workflow
+
+### 1. Trigger the overview
+
+```bash
+gh workflow run codescene-report.yml -R ingo-eichhorst/Irrlicht
+```
+
+The workflow defaults to the `analyses/latest` endpoint (project-wide
+summary + current/month/year code health score).
+
+### 2. Find the run
+
+`workflow_dispatch` doesn't return a run ID, so poll for it:
+
+```bash
+sleep 4
+gh run list -R ingo-eichhorst/Irrlicht --workflow=codescene-report.yml \
+  --limit 1 --json databaseId,status,createdAt
+```
+
+If `status` isn't yet `completed`, wait and check again (a couple of
+retries is normal — the job itself takes well under a minute).
+
+### 3. Wait for completion and pull the JSON
+
+```bash
+gh run watch <databaseId> -R ingo-eichhorst/Irrlicht --exit-status
+gh run view <databaseId> -R ingo-eichhorst/Irrlicht --log | grep "Fetch CodeScene report"
+```
+
+Strip the `report\tFetch CodeScene report\t<timestamp>` prefix (and the
+ANSI-colored command-echo line) from each line to recover the raw JSON
+body. From the `analyses/latest` shape, pull out:
+
+- `id` — the analysis id, needed for step 4
+- `high_level_metrics.current_score` / `month_score` / `year_score`
+- `summary` — commits, files, authors_count, issues_classed_as_defects
+
+### 4. Trigger the hotspot list
+
+Using the `id` from step 3:
+
+```bash
+gh workflow run codescene-report.yml -R ingo-eichhorst/Irrlicht \
+  -f endpoint="analyses/<id>/technical-debt?refactoring_targets=true"
+```
+
+Repeat steps 2–3 to fetch this run's output. It returns a `result` array
+of files with `refactoring_target`, `code_health_score`, `friction`,
+`friction_last_month`, `loc`, and `revisions`.
+
+### 5. Summarize
+
+Report back concisely:
+
+```
+CodeScene report — <repo> @ <analysis timestamp>
+Code health: <current_score>/10  (month: <month_score>, year: <year_score>)
+<commits> commits · <files> files · <issues_classed_as_defects> defects flagged
+
+Top refactoring targets (lowest health first):
+  <score>/10  <file>            friction <friction> (last month <friction_last_month>), <loc> loc, <revisions> revisions
+  ...
+```
+
+Sort hotspots by `code_health_score` ascending and show at most 8 — this
+is meant to be a quick read, not the full dump. If the user wants deeper
+detail on one file, re-run step 4 pointed at a narrower endpoint (see
+CodeScene's `/v2/projects/<id>/` API) or hand them the
+`https://codescene.io/projects/82148/...` link from the check run instead
+of reproducing it here.
+
+## Constraints
+
+- **Don't file issues or open PRs from this skill.** This is a read-only,
+  on-demand look — the automatic per-PR check and the README badge already
+  give continuous coverage, and all three are informational, not action
+  items to auto-execute. If the user wants a hotspot turned into follow-up
+  work, that's a separate, explicit ask.
+- **Don't add scheduling.** "From time to time" means the maintainer
+  invokes this manually when curious — no cron, no CronCreate. If that
+  changes, it's a distinct decision to make explicitly.
+- The CODESCENE_API_TOKEN this relies on lives only as a GitHub Actions
+  secret — there is no local/offline path. Every invocation goes through
+  the `codescene-report.yml` workflow.

--- a/.github/workflows/codescene-badge.yml
+++ b/.github/workflows/codescene-badge.yml
@@ -1,0 +1,77 @@
+name: Update CodeScene Badge
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  badge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Fetch current code health score
+        env:
+          CODESCENE_API_TOKEN: ${{ secrets.CODESCENE_API_TOKEN }}
+          CODESCENE_PROJECT_ID: "82148"
+        run: |
+          SCORE=$(tools/codescene-report.sh "analyses/latest" | jq -r '.high_level_metrics.current_score')
+          if [ -z "$SCORE" ] || [ "$SCORE" = "null" ]; then
+            echo "::error::could not read high_level_metrics.current_score from analyses/latest"
+            exit 1
+          fi
+          echo "SCORE=$SCORE" >> "$GITHUB_ENV"
+          echo "Code health: ${SCORE}/10"
+
+      - name: Determine badge color
+        run: |
+          # CodeScene's own bands: 8-10 healthy, 4-7.99 warning, 0-3.99 alert.
+          whole="${SCORE%.*}"
+          if [ "$whole" -ge 8 ]; then
+            COLOR="brightgreen"
+          elif [ "$whole" -ge 4 ]; then
+            COLOR="yellow"
+          else
+            COLOR="red"
+          fi
+          echo "COLOR=$COLOR" >> "$GITHUB_ENV"
+
+      - name: Update Gist with code health score
+        env:
+          GIST_SECRET: ${{ secrets.GIST_SECRET }}
+          # Reuses the same badges gist as coverage.yml (adds a second file to it).
+          COVERAGE_GIST_ID: ${{ secrets.COVERAGE_GIST_ID }}
+        run: |
+          if [ -z "$GIST_SECRET" ]; then
+            echo "::error::GIST_SECRET is not set in repository secrets"
+            exit 1
+          fi
+          if [ -z "$COVERAGE_GIST_ID" ]; then
+            echo "::error::COVERAGE_GIST_ID is not set in repository secrets"
+            exit 1
+          fi
+          MESSAGE=$(printf '%.1f/10' "$SCORE")
+          BADGE_JSON="{\"schemaVersion\":1,\"label\":\"code health\",\"message\":\"${MESSAGE}\",\"color\":\"${COLOR}\"}"
+          jq -n --arg content "$BADGE_JSON" '{"files":{"codescene.json":{"content":$content}}}' > /tmp/gist-payload.json
+          # curl writes "000" to %{http_code} when no response was received (DNS/TLS/connect failure).
+          http_code=$(curl -sS -o /tmp/gist-response.json -w '%{http_code}' \
+            --connect-timeout 10 --max-time 30 \
+            --retry 3 --retry-delay 2 --retry-all-errors \
+            -X PATCH \
+            -H "Authorization: token $GIST_SECRET" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/gist-payload.json \
+            "https://api.github.com/gists/$COVERAGE_GIST_ID")
+          echo "HTTP $http_code"
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::error::Gist update failed (HTTP $http_code)"
+            if [ -s /tmp/gist-response.json ]; then
+              cat /tmp/gist-response.json
+            else
+              echo "(no response body — likely transport failure)"
+            fi
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,17 @@ Before marking a ticket done, run the full suite — every layer must pass:
   whether the regression is worth addressing before merging. Deterministic
   and workflow-agnostic: it fires on any push, not tied to a specific agent
   skill.
+- Code health: CodeScene posts a "CodeScene Code Health Review" check on every
+  PR automatically (via the CodeScene GitHub App, configured on codescene.io
+  project 82148 — not a workflow in this repo). Like the ARS score, it's
+  advisory, not a merge gate: neither branch protection nor the "Protect
+  Main" ruleset requires it to pass. A red result is a prompt to look
+  closer, not something to chase to green before merging or releasing. The
+  README's CodeScene badge shows the live score, auto-refreshed on every
+  push to `main` by `.github/workflows/codescene-badge.yml`. For a deeper
+  on-demand look (hotspots, trend) with no PR needed, run
+  `/ir:codescene-report`, which wraps the manual `codescene-report.yml`
+  workflow.
 - Permission gating: `contracttesting.AssertPermissionGated` (`core/internal/contracttesting/permission_gate.go`)
   is the behavioral counterpart to the architecture test — it can't be checked
   statically because gating happens at runtime, by an adapter (or the shared

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![UI Features](assets/explainer.png)
 
 [![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fingo-eichhorst%2F9f14c8e5f25c1ccf5d6500c1685fd9fb%2Fraw%2Fcoverage.json&color=%238B5CF6)](https://github.com/ingo-eichhorst/Irrlicht/actions/workflows/coverage.yml)
-[![CodeScene](https://img.shields.io/badge/CodeScene-Report-6c5ce7)](https://github.com/ingo-eichhorst/Irrlicht/actions/workflows/codescene-report.yml)
+[![CodeScene](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fingo-eichhorst%2F9f14c8e5f25c1ccf5d6500c1685fd9fb%2Fraw%2Fcodescene.json)](https://github.com/ingo-eichhorst/Irrlicht/actions/workflows/codescene-report.yml)
 [![License](https://img.shields.io/badge/license-MIT-orange?color=%23FF9500)](LICENSE)
 [![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fingo-eichhorst%2FIrrlicht%2Fmain%2Fversion.json&query=%24.version&label=version&color=%2334C759)](version.json)
 [![ARS](https://img.shields.io/badge/ARS-Agent--Ready%208.1%2F10-green)](https://github.com/ingo-eichhorst/agent-readyness)


### PR DESCRIPTION
## Summary
- Replaces the static "CodeScene: Report" README badge with a live score badge (e.g. `code health: 8.3/10`), auto-refreshed on every push to `main` via `codescene-badge.yml` (reuses the same badges gist + secrets as `coverage.yml`).
- Documents the CodeScene per-PR check as advisory-only in AGENTS.md, mirroring the existing ARS-gate note — it's not required by branch protection or the "Protect Main" ruleset, so it shouldn't be treated as something to chase to green before merging/releasing.
- Adds `/ir:codescene-report`, a skill that wraps the existing manual `codescene-report.yml` workflow so pulling a deeper on-demand report (trend + hotspot files) is a one-liner instead of driving the Actions UI by hand. Read-only — doesn't file issues or schedule anything.

## Test plan
- [x] `tools/preflight.sh` passed locally (pre-push hook ran it)
- [x] Manually verified the `codescene-report.yml` workflow's `analyses/latest` and `analyses/<id>/technical-debt?refactoring_targets=true` endpoints against the live API to confirm field names (`high_level_metrics.current_score`, not a guessed name)
- [ ] After merge, confirm `codescene-badge.yml` runs on the push-to-main trigger and the gist's `codescene.json` file updates
- [ ] Confirm the README badge renders the live score (may take a minute for shields.io's cache)