### PR TITLE
feat(skills): add --fix mode to ir:doc-review, wire it into release Step 4b

### DIFF
--- a/.claude/skills/ir:doc-review/SKILL.md
+++ b/.claude/skills/ir:doc-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ir:doc-review
-description: Audit all project documentation for understandability, completeness, and validity using objective, binary criteria, then file one GitHub issue per documentation surface with exact, agent-ready fixes. Every finding is anchored to a quoted location and stamped with a stable ID so independent runs converge. Triggers on "/ir:doc-review", "audit docs", "review documentation", "check the docs", "doc audit". Supports a --report-only dry run.
+description: Audit all project documentation for understandability, completeness, and validity using objective, binary criteria, then file one GitHub issue per documentation surface with exact, agent-ready fixes. Every finding is anchored to a quoted location and stamped with a stable ID so independent runs converge. Triggers on "/ir:doc-review", "audit docs", "review documentation", "check the docs", "doc audit". Supports a --report-only dry run and a --fix mode that applies high-confidence corrections directly instead of filing an issue for them.
 ---
 
 # ir:doc-review — Objective Documentation Audit
@@ -27,6 +27,13 @@ literally** — never invent criteria, never grade on subjective grounds (tone, 
 
 - `--report-only` — run the full audit and print per-surface findings, but file nothing. Use
   this first, and for the convergence check.
+- `--fix` — after scoring (step 5), apply direct edits for the auto-fix-eligible findings
+  defined in step 6b instead of filing an issue for them; every other finding still gets filed
+  as an issue in step 7. This is what `ir:release` Step 4b runs on every release (#834), so
+  drift can't silently accumulate the way the stale "no hooks" claim did — that claim's fix
+  (correcting existing prose to match a code-derived fact, no new content authored) is exactly
+  the auto-fix-eligible shape. Combine with `--report-only` to preview which findings would be
+  auto-fixed vs. filed, without touching any file or opening any issue.
 - An optional path or glob — limit the audit to matching surfaces (default: all in-scope).
 
 ## Workflow
@@ -96,8 +103,38 @@ For each surface with ≥1 finding:
   - Last line — the hidden reconciliation marker (one line, exactly):
     `<!-- ir:doc-review surface=<path> findings=<id1,id2,...> -->`
 
+### 6b. Apply auto-fix-eligible findings directly (only with `--fix`)
+Skip this step entirely unless `--fix` was passed — without it, every finding built in step 6
+falls straight through to step 7 unchanged.
+
+For each finding, decide whether it is **auto-fix eligible** before step 7 runs:
+
+- **Eligible criteria:** V1, V2, V4, V5, V6, C2. These are exactly the findings where an
+  existing claim is directly contradicted by a code-derived inventory/fact
+  (`inventory-sources.md`), and step 6's own "Exact fix" text is a direct in-place correction or
+  removal — no new section, paragraph, or example needs authoring.
+- **Never eligible — always falls through to step 7:** U1–U6 (wording/ordering/audience are
+  judgment calls), C1/C3/C4 (missing mention, missing surface, missing example — these need new
+  content authored, not a correction), and V3 (link/anchor liveness — never blocking per the
+  severity rubric anyway).
+- Even within an eligible criterion, if the "Exact fix" isn't unambiguous from the inventory
+  alone — the claim could be resolved two different ways and picking one is a judgment call —
+  file it in step 7 instead of guessing.
+
+For each eligible finding: re-locate the anchor by its verbatim quote (don't trust the original
+line number — an earlier edit in the same file may have shifted it), apply the "Exact fix" text
+from step 6 verbatim, then immediately run that finding's own "Verification" check. If the quote
+no longer matches the live file, or verification fails after the edit, **revert the edit** and
+leave the finding in the surface's draft issue body for step 7 — never leave a half-applied or
+unverified edit in a doc, and never fuzzy-match a quote that's moved. When a surface has more
+than one eligible finding, apply them bottom-of-file-upward so an earlier edit can't shift a
+later finding's anchor off target.
+
+Remove every successfully auto-fixed finding from its surface's draft issue body (built in step
+6) before step 7 runs, and record it (surface + finding-ID) for the step 8 summary.
+
 ### 7. Dedupe and file (skip entirely if --report-only)
-For each surface with findings:
+For each surface with findings remaining after step 6b (all findings, if `--fix` was not passed):
 1. `gh issue list --repo ingo-eichhorst/Irrlicht --state open --search "in:title docs(<surface>)" --json number,body,title`.
 2. **No match →** `gh issue create` with the title/body above and labels: `documentation`, the
    matching `scope:*` (mapping below), and `needs-triage`.
@@ -116,13 +153,20 @@ Scope-label mapping:
 
 ### 8. Print the run summary
 Always print: surfaces scanned, a findings-by-axis-and-severity table, and — unless
-`--report-only` — the issues created / updated / unchanged with their URLs.
+`--report-only` — the issues created / updated / unchanged with their URLs. When `--fix` was
+set, also print the findings auto-fixed directly (surface + finding-ID, from step 6b) separately
+from the findings that still got filed as issues.
 
 ## Conventions
 
 - `gh` always targets `ingo-eichhorst/Irrlicht`.
 - Reuse existing labels only; never create new labels.
-- The skill **only reports** — it never edits documentation. Auto-fixing is out of scope.
+- Without `--fix`, the skill **only reports** — it never edits documentation. With `--fix`, it
+  edits documentation directly, but only for the auto-fix-eligible findings defined in step 6b;
+  everything else still only gets filed as an issue, same as without the flag.
+- `--fix` never commits or opens a PR itself — it leaves auto-fixed files as uncommitted
+  working-tree changes for whatever invoked it (a release commit via `ir:release` Step 4b, or
+  the user's own review when run standalone) to pick up.
 - External-link liveness is reported but never blocks (see V3).
 - When uncertain whether something is a finding, re-read the criterion: if it isn't a binary
   failure you can quote, drop it. A false positive costs more than a missed nit.

--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -283,47 +283,41 @@ For **patch releases**, skip Step D — the future section stays unchanged. The 
 
 ### 4b. Doc + README sweep (mandatory)
 
-Walk **every** docs page and every top-level README, check each against the
-release's diff, and update any content that this release made stale. Don't
-rely on a hardcoded list — enumerate the targets dynamically so new pages
-can't be silently missed:
+Run the `/ir:doc-review --fix` workflow inline — see
+`.claude/skills/ir:doc-review/SKILL.md` for the full audit (this is that
+skill's "release-inline" use, same pattern as Step 1.5's
+`/ir:refresh-aliases`). Check every in-scope surface against **current
+code-derived truth**, not just this release's diff:
 
-```bash
-# Files in scope for the sweep — top-level site/*.html (the landing page
-# carries its own compatibility grid, separate from site/docs/), the docs
-# pages, and every top-level README.
-ls site/*.html site/docs/*.html
-echo README.md AGENTS.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md
+1. Build the code-derived inventories (`ir:doc-review` step 2) and enumerate
+   every in-scope surface (step 3) — README/AGENTS/CONTRIBUTING/SECURITY/
+   CODE_OF_CONDUCT, `docs/**/*.md`, `tools/*/README.md` + `SKILL.md`,
+   `.claude/skills/*/SKILL.md`, and the published site. Don't narrow this to
+   `git diff --name-only $(git describe --tags --abbrev=0)..HEAD` — a
+   diff-only check only catches drift *this* release introduced, and misses
+   drift that went stale in an *earlier* release and was never touched
+   since. That gap is exactly what let README.md and `site/index.html` both
+   keep claiming "no hooks" for several releases after the `claudecode`
+   hooks feature shipped (#834).
+2. Apply the rubric per surface (steps 4–6) and auto-fix every
+   high-confidence finding directly (step 6b) — an existing claim directly
+   contradicted by a code fact, corrected in place with no new content
+   authored. The stale "no hooks" claim above is exactly this shape.
+3. File a GitHub issue (step 7) for anything left — findings that need new
+   content authored or a judgment call (missing docs, unclear sections, new
+   examples).
 
-# What changed in this release — drives which pages are likely affected
-git diff --name-only $(git describe --tags --abbrev=0)..HEAD
-```
+Then:
+- Review every auto-fixed surface yourself — confirm the edit reads
+  correctly in context before it ships, don't just trust that a diff
+  exists.
+- Leave the auto-fixed edits uncommitted; Step 7a's `git add` picks them up
+  alongside the other release artefacts.
+- Treat any newly filed/updated issue as a separate follow-up, not a
+  release blocker — don't let it stall this release.
 
-For each file in scope, read it and ask: *does this release's diff
-invalidate anything written here?* Common triggers, with the doc page that
-typically owns the surface:
-
-| Diff touches… | Likely-affected docs |
-|---|---|
-| `core/adapters/inbound/agents/**` | `site/docs/adapters.html`, README compatibility grid, `AGENTS.md` "Adding a new agent adapter" section |
-| `core/ports/**`, `core/domain/**` | `site/docs/architecture.html`, `site/docs/adapters.html`, `AGENTS.md` if the adapter contract shape changes |
-| `core/cmd/irrlichd/main.go` slice/wiring rename (e.g. `agentCfgs` → `allAgents`) | `site/docs/api-reference.html` (the `GET /api/v1/agents` blurb references the slice name), `site/docs/contributing.html` adapter-PR checklist, `AGENTS.md` |
-| `core/cmd/irrlichd/handlers.go` (HTTP routes / payloads) | `site/docs/api-reference.html` |
-| `core/cmd/irrlicht-ls`, `core/cmd/irrlicht-focus` | `site/docs/cli-tools.html` |
-| `core/application/services/**`, `core/domain/session/**` | `site/docs/state-machine.html`, `site/docs/session-detection.html` |
-| `site/install.sh`, `tools/homebrew-tap/**`, install flow | `site/docs/installation.html`, `site/docs/quickstart.html`, `README.md` install section |
-| Config schema / settings files | `site/docs/configuration.html` |
-| New agent adapter shipped | README compatibility grid + `site/index.html` "Supported Agents & Platforms" grid (search for `tag-planned` / `tag-alpha`) + `site/docs/adapters.html` per-adapter row |
-| Adapter maturity-stage change | Same three places as "new adapter shipped" — README, landing page grid, adapters doc |
-| New platform shipped | README + `site/index.html` "Supported Agents & Platforms" grid (Platforms column) + `site/docs/index.html` overview |
-
-Update only where content is actually outdated — do **not** paraphrase
-correct content for the sake of touching the file. If a doc is fine, leave
-it untouched. When in doubt, prefer to update over leaving stale: a
-half-true doc is worse than a slightly chatty one.
-
-When this sweep finishes, every line you read should either be (a) still
-true on `main` after the release, or (b) edited to be true.
+Do not substitute a narrower, diff-only check for this step — closing that
+gap for good is the point.
 
 ## Step 5: Run Tests
 
@@ -908,12 +902,18 @@ on `main`.
 ### 7a. Stage and commit on a release branch
 
 ```bash
-# Core release artefacts plus any top-level README/doc files the Step 4b
-# sweep edited. The `git add -- ...` form is safe for missing files.
-git add version.json CHANGELOG.md site/ \
+# Core release artefacts plus any doc surface the Step 4b sweep
+# (`/ir:doc-review --fix`) may have auto-fixed. The `git add -- ...` form is
+# safe for missing files/globs.
+git add version.json CHANGELOG.md site/ docs/ \
         platforms/macos/Irrlicht/Resources/Info.plist \
         tools/homebrew-tap/Casks/irrlicht.rb
 git add -- README.md AGENTS.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md 2>/dev/null || true
+# ir:doc-review's fuller surface — tool/skill docs the sweep can also touch.
+git add -- tools/*/README.md tools/*/SKILL.md \
+        .claude/skills/*/SKILL.md .claude/skills/*/skill.md \
+        tools/irrlicht-design-system/README.md \
+        tools/irrlicht-design-system/ui_kits/*/README.md 2>/dev/null || true
 
 # Confirm nothing the sweep edited is left unstaged before committing.
 git status --short


### PR DESCRIPTION
## Summary
- `ir:doc-review` gains a `--fix` mode: for findings where an existing claim is directly contradicted by a code-derived fact (V1/V2/V4/V5/V6/C2), it applies the correction in place; everything else (missing content, judgment calls: U-axis, C1/C3/C4, V3) still falls back to filing a GitHub issue as before.
- `ir:release` Step 4b now runs `/ir:doc-review --fix` (the full inventory-backed audit) instead of a diff-only sweep — a diff against the last release tag can never catch drift that went stale in an *earlier* release, which is exactly the gap that let README.md and site/index.html both claim "no hooks" for several releases after the `claudecode` hooks feature shipped.
- Widened Step 7a's `git add` to also cover the doc surfaces `ir:doc-review --fix` can touch (`docs/`, `tools/*/README.md`+`SKILL.md`, `.claude/skills/*/SKILL.md`, design-system READMEs) so an auto-fix there actually lands in the release commit.

Closes #834.

## Test plan
- [x] `tools/preflight.sh` (via pre-push hook) — gofmt, full Go test suite, onboarding-factory tests, replaydata validate, recording-rig smoke test, both web suites, ARS gate — all PASS.
- [x] `/code-review` at low effort — no findings (docs/skill-file-only change, no runtime code path).
- This is a skill/workflow-prose change with no code paths to unit-test; correctness is a documentation-review concern, verified by re-reading the edited skill files end-to-end for internal consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)