### PR TITLE
fix(macos): make SessionRowSnapshotTests hermetic against live daemon

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager+Hydration.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Hydration.swift
@@ -108,8 +108,10 @@ extension SessionManager {
 
     /// Starts periodic re-hydration so group-level cost values (which arrive
     /// as part of /api/v1/sessions and are not pushed via WebSocket deltas)
-    /// stay fresh. Idempotent.
+    /// stay fresh. Idempotent. No-op under XCTest (issue #832) — a real
+    /// daemon round-trip has no business running on a timer during unit tests.
     func startProjectCostsPolling() {
+        guard !isRunningUnitTests else { return }
         projectCostsTimer?.invalidate()
         projectCostsTimer = Timer.scheduledTimer(withTimeInterval: projectCostsRefreshInterval, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in

--- a/platforms/macos/Irrlicht/Managers/SessionManager+Relay.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Relay.swift
@@ -22,7 +22,13 @@ extension SessionManager {
 
     /// Diffs the current Sources config against the last applied one and
     /// reconnects only on change. Cheap to call on every UserDefaults change.
+    /// Under XCTest this is a no-op (issue #832) — every SessionManager()
+    /// built by a test would otherwise dial the real local daemon (both here
+    /// and via the `UserDefaults.didChangeNotification` observer any test's
+    /// `defaults.set(...)` fires), racing snapshot/state assertions against
+    /// whatever daemon happens to be reachable on the machine.
     func sourcesSettingsChanged() {
+        guard !isRunningUnitTests else { return }
         let cfg = "\(useLocalDaemon)|\(useRelayServer)|\(relayServerURL)"
         guard cfg != lastSourceConfig else { return }
         lastSourceConfig = cfg

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -204,6 +204,16 @@ class SessionManager: ObservableObject {
     /// system-suppressed banner. Injectable for tests.
     let focusMonitor: FocusStateProviding
 
+    /// True when running under XCTest. Detected by whether XCTest's runtime
+    /// class is loaded into this process — unlike `canUseUserNotifications`'s
+    /// `XCTestConfigurationFilePath` env var (only set by Xcode's own test
+    /// runner), this also holds for this project's actual test command,
+    /// `swift test`, which never sets that variable. Gates real daemon
+    /// network activity (WebSocket connect, REST hydration, periodic cost
+    /// polling) so unit tests never race against whatever daemon happens to
+    /// be reachable on the machine (issue #832).
+    let isRunningUnitTests = NSClassFromString("XCTestCase") != nil
+
     init(focusMonitor: FocusStateProviding = FocusMonitor()) {
         self.focusMonitor = focusMonitor
 

--- a/platforms/macos/Tests/SessionRowSnapshotTests.swift
+++ b/platforms/macos/Tests/SessionRowSnapshotTests.swift
@@ -13,9 +13,69 @@ final class SessionRowSnapshotTests: XCTestCase {
     private var originalThresholdUnit: Any?
     private var originalUserIntent: Any?
     private var originalSummariesCollapsed: Any?
+    private var savedAgentRegistry: [String: AgentBranding] = [:]
 
     override func setUp() async throws {
         try await super.setUp()
+        // SessionManager() no longer hydrates AgentRegistry from a live daemon
+        // under XCTest (issue #832) — seed the branding entries the fixtures
+        // below render (antigravity ghost rows, a claude-code working row) so
+        // they show the real brand icon deterministically instead of racing a
+        // network call. Mirrors the SVGs in
+        // core/adapters/inbound/agents/{antigravity,claudecode}/agent.go.
+        savedAgentRegistry = AgentRegistry.byName
+        AgentRegistry.byName["antigravity"] = AgentBranding(
+            name: "antigravity",
+            displayName: "Antigravity",
+            iconSVGLight: """
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 100 100">
+              <g fill="none" stroke-width="15" stroke-linecap="round">
+                <path d="M16 82 Q27.3 39.3 38.7 25.1" stroke="#4285F4"/>
+                <path d="M38.7 25.1 Q50 10.9 61.3 25.1" stroke="#EA4335"/>
+                <path d="M61.3 25.1 Q72.7 39.3 84 82" stroke="#34A853"/>
+              </g>
+            </svg>
+            """,
+            iconSVGDark: """
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 100 100">
+              <g fill="none" stroke-width="15" stroke-linecap="round">
+                <path d="M16 82 Q27.3 39.3 38.7 25.1" stroke="#8AB4F8"/>
+                <path d="M38.7 25.1 Q50 10.9 61.3 25.1" stroke="#F28B82"/>
+                <path d="M61.3 25.1 Q72.7 39.3 84 82" stroke="#81C995"/>
+              </g>
+            </svg>
+            """
+        )
+        AgentRegistry.byName["claude-code"] = AgentBranding(
+            name: "claude-code",
+            displayName: "Claude Code",
+            iconSVGLight: """
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 56 56">
+              <rect x="8" y="4" width="40" height="32" rx="4" fill="#D97757"/>
+              <rect x="4" y="16" width="8" height="12" rx="2" fill="#D97757"/>
+              <rect x="44" y="16" width="8" height="12" rx="2" fill="#D97757"/>
+              <rect x="18" y="12" width="8" height="8" rx="1" fill="#4A2820"/>
+              <rect x="30" y="12" width="8" height="8" rx="1" fill="#4A2820"/>
+              <rect x="12" y="36" width="6" height="14" rx="1" fill="#D97757"/>
+              <rect x="22" y="36" width="6" height="10" rx="1" fill="#D97757"/>
+              <rect x="32" y="36" width="6" height="10" rx="1" fill="#D97757"/>
+              <rect x="42" y="36" width="6" height="14" rx="1" fill="#D97757"/>
+            </svg>
+            """,
+            iconSVGDark: """
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 56 56">
+              <rect x="8" y="4" width="40" height="32" rx="4" fill="#D97757"/>
+              <rect x="4" y="16" width="8" height="12" rx="2" fill="#D97757"/>
+              <rect x="44" y="16" width="8" height="12" rx="2" fill="#D97757"/>
+              <rect x="18" y="12" width="8" height="8" rx="1" fill="#4A2820"/>
+              <rect x="30" y="12" width="8" height="8" rx="1" fill="#4A2820"/>
+              <rect x="12" y="36" width="6" height="14" rx="1" fill="#D97757"/>
+              <rect x="22" y="36" width="6" height="10" rx="1" fill="#D97757"/>
+              <rect x="32" y="36" width="6" height="10" rx="1" fill="#D97757"/>
+              <rect x="42" y="36" width="6" height="14" rx="1" fill="#D97757"/>
+            </svg>
+            """
+        )
         // SessionRowView reads several keys via @AppStorage (UserDefaults.standard).
         // Snapshot + restore so the developer's defaults survive the test run.
         let defaults = UserDefaults.standard
@@ -48,6 +108,7 @@ final class SessionRowSnapshotTests: XCTestCase {
         restore(key: ContextPressureThreshold.unitKey, value: originalThresholdUnit)
         restore(key: "userIntentDisplay", value: originalUserIntent)
         restore(key: "summariesCollapsed", value: originalSummariesCollapsed)
+        AgentRegistry.byName = savedAgentRegistry
         try await super.tearDown()
     }
 


### PR DESCRIPTION
## Summary

`SessionManager()` fired real HTTP hydration calls (and opened a real WebSocket) to the local daemon on construction, and again on every `UserDefaults` change via a `didChangeNotification` observer. Every test that builds a `SessionManager()` — not just `SessionRowSnapshotTests` — was racing its assertions against whatever daemon happened to be reachable on `127.0.0.1:7837` at the time.

For `testFixture_AntigravityGhost` / `testGhostRow_PID0_NilMetrics`, that race meant the adapter icon sometimes rendered from the live daemon's `/api/v1/agents` response (branded arc glyph) and sometimes from the pre-hydration generic fallback ("?"), depending on which finished first.

## Root cause confirmed

`AgentRegistry.byName` gets swapped out by `hydrateAgents()`, called from `connect()`, called from `reconcileSources()`, driven by `sourcesSettingsChanged()` — invoked once from `SessionManager.init()`'s startup `Task`, and again from a process-wide `UserDefaults.didChangeNotification` observer that fires on every `defaults.set(...)`, which nearly every `SessionRowSnapshotTests` case calls in `setUp()`/its body.

The existing XCTest-detection idiom in this codebase (`canUseUserNotifications`'s `ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"]`) turned out to be a dead check under this project's actual test command, `swift test` — that env var is only set by Xcode's own test runner, never by SwiftPM's. Verified empirically (dumped the test process's environment) before picking a check that's actually true under `swift test`: `NSClassFromString("XCTestCase") != nil`.

## Fix

- `SessionManager.isRunningUnitTests`: true whenever XCTest's runtime class is loaded into the process.
- `sourcesSettingsChanged()` (the single choke point both the init-time call and the notification observer funnel through) and `startProjectCostsPolling()` become no-ops under XCTest — no unit test dials a real daemon anymore.
- `SessionRowSnapshotTests.setUp()` seeds `AgentRegistry.byName` with the real antigravity/claude-code branding (copied from `core/adapters/inbound/agents/{antigravity,claudecode}/agent.go`) instead of relying on a network hydration race, and restores the registry in `tearDown()` (mirrors the existing pattern in `BackchannelRulesViewSnapshotTests`).

No snapshot PNGs needed re-recording — the seeded SVG data is byte-identical to what the live daemon serves, so rendering is unchanged.

## Verification

- `swift test --filter SessionRowSnapshotTests` — 21/21 pass, repeated 4x for determinism, zero "Hydrated"/"WebSocket connected" log lines during the run (previously present even when tests passed).
- Full `swift test` — 206 tests, 5 skipped, 0 failures.
- `tools/preflight.sh` — all gates green (go tests, onboarding-factory, replaydata validate, recording-rig smoke test, both web suites, ARS architecture gate).

Fixes #832

## Test plan
- [x] `swift test --filter SessionRowSnapshotTests` green, repeatably
- [x] Full `swift test` green (206 tests)
- [x] `tools/preflight.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)