### PR TITLE
fix: compose cache-bloat hover explanation daemon-side

### DIFF
--- a/core/application/services/cache_bloat_detector.go
+++ b/core/application/services/cache_bloat_detector.go
@@ -131,6 +131,7 @@ func (c *CacheBloatDetector) OnActivity(state *session.SessionState) {
 		// Below threshold — clear any prior verdict (re-evaluated each turn).
 		state.Metrics.CacheBloat = false
 		state.Metrics.CacheBloatTooltip = ""
+		state.Metrics.CacheBloatExplanation = ""
 		return
 	}
 
@@ -138,6 +139,7 @@ func (c *CacheBloatDetector) OnActivity(state *session.SessionState) {
 	state.Metrics.CacheBloat = true
 	tooltip, regressing, prior, deltaTokens := c.attributeVersion(state, currentMedian)
 	state.Metrics.CacheBloatTooltip = tooltip
+	state.Metrics.CacheBloatExplanation = cacheBloatExplanation(tooltip)
 
 	// Emit the structured event once per (project, regressing_version) pair
 	// within this process. regressing is "" when no attribution is possible,
@@ -274,6 +276,21 @@ func (c *CacheBloatDetector) attributeVersion(state *session.SessionState, curre
 	deltaTokens = int64(delta)
 	tooltip = fmt.Sprintf("%s %s +%dK cache tokens vs %s", state.Adapter, newest, deltaTokens/1000, prior)
 	return tooltip, newest, prior, deltaTokens
+}
+
+// cacheBloatExplanation composes the CacheBloat badge's longer plain-language
+// hover text from its short tooltip (issue #827). Both UIs used to derive
+// this string independently from cache_bloat_tooltip; composing it once here
+// and shipping it verbatim as CacheBloatExplanation keeps future wording
+// tweaks from silently diverging between platforms.
+func cacheBloatExplanation(tooltip string) string {
+	base := "This session is creating prompt-cache tokens well above normal for this project — it's getting less benefit from caching and costing more per turn."
+	attribution := ""
+	if tooltip != "" {
+		attribution = fmt.Sprintf(" Likely tied to %s.", tooltip)
+	}
+	causes := " Common causes: an agent update that changed context construction, large or varying pasted content each turn, or frequent context resets (e.g. /clear)."
+	return base + attribution + causes
 }
 
 // eligible reports whether a stored session counts toward the project's

--- a/core/application/services/cache_bloat_detector_test.go
+++ b/core/application/services/cache_bloat_detector_test.go
@@ -88,6 +88,13 @@ func TestCacheBloat_ScenarioA_VersionAttribution(t *testing.T) {
 	if !strings.Contains(tip, "2.0.0") || !strings.Contains(tip, "1.0.0") || !strings.Contains(tip, "claude-code") {
 		t.Errorf("tooltip should name both versions and adapter, got %q", tip)
 	}
+	explanation := live.Metrics.CacheBloatExplanation
+	if !strings.Contains(explanation, tip) {
+		t.Errorf("explanation should fold in the tooltip verbatim, got %q", explanation)
+	}
+	if !strings.Contains(explanation, "prompt-cache tokens well above normal") {
+		t.Errorf("explanation missing the plain-language base sentence, got %q", explanation)
+	}
 	if len(rec.events) != 1 {
 		t.Fatalf("expected exactly 1 event, got %d", len(rec.events))
 	}
@@ -125,6 +132,12 @@ func TestCacheBloat_ScenarioB_NoFalseAttribution(t *testing.T) {
 	}
 	if live.Metrics.CacheBloatTooltip != "" {
 		t.Errorf("tooltip must be empty (no attribution), got %q", live.Metrics.CacheBloatTooltip)
+	}
+	if strings.Contains(live.Metrics.CacheBloatExplanation, "Likely tied to") {
+		t.Errorf("explanation must not fabricate an attribution, got %q", live.Metrics.CacheBloatExplanation)
+	}
+	if live.Metrics.CacheBloatExplanation == "" {
+		t.Error("explanation should still be set when the glyph fires, even without attribution")
 	}
 	if len(rec.events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(rec.events))
@@ -245,6 +258,9 @@ func TestCacheBloat_ClearsWhenMedianDropsBack(t *testing.T) {
 	}
 	if live.Metrics.CacheBloatTooltip != "" {
 		t.Errorf("tooltip should clear too, got %q", live.Metrics.CacheBloatTooltip)
+	}
+	if live.Metrics.CacheBloatExplanation != "" {
+		t.Errorf("explanation should clear too, got %q", live.Metrics.CacheBloatExplanation)
 	}
 }
 

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -148,6 +148,13 @@ type SessionMetrics struct {
 	// attribution is possible (no false attribution).
 	CacheBloatTooltip string `json:"cache_bloat_tooltip,omitempty"`
 
+	// CacheBloatExplanation is the longer plain-language hover text for the
+	// CacheBloat badge, composed daemon-side (issue #827) from
+	// CacheBloatTooltip so both UIs render the identical string verbatim
+	// instead of each re-deriving it from the tooltip. Empty when CacheBloat
+	// is false.
+	CacheBloatExplanation string `json:"cache_bloat_explanation,omitempty"`
+
 	// LastCWD is the most recent working directory extracted from the
 	// transcript during metrics parsing. Used to avoid a separate file read.
 	LastCWD string `json:"-"` // transient — not persisted in session JSON
@@ -482,6 +489,7 @@ func newMergedMetrics(newM *SessionMetrics) *SessionMetrics {
 		CompletedTurns:           newM.CompletedTurns,
 		CacheBloat:               newM.CacheBloat,
 		CacheBloatTooltip:        newM.CacheBloatTooltip,
+		CacheBloatExplanation:    newM.CacheBloatExplanation,
 		Tasks:                    newM.Tasks,
 		NoSubstantiveActivity:    newM.NoSubstantiveActivity,
 		SawManualCompactBoundary: newM.SawManualCompactBoundary,
@@ -568,13 +576,14 @@ func carryForwardCumulativeCounters(merged, oldM *SessionMetrics) {
 // passes that didn't recompute them. TaskEstimate/TaskCompletionEta are
 // deliberately excluded: see the comment at their use site below.
 func carryForwardOverlayState(merged, oldM *SessionMetrics) {
-	// CacheBloat / CacheBloatTooltip are overlay flags set by the detector on
-	// turn boundaries (newM never carries them). Keep the last verdict sticky
-	// across mid-turn passes so the glyph doesn't flicker; the detector
-	// overwrites it on the next turn boundary.
+	// CacheBloat / CacheBloatTooltip / CacheBloatExplanation are overlay flags
+	// set by the detector on turn boundaries (newM never carries them). Keep
+	// the last verdict sticky across mid-turn passes so the glyph doesn't
+	// flicker; the detector overwrites it on the next turn boundary.
 	if !merged.CacheBloat && oldM.CacheBloat {
 		merged.CacheBloat = oldM.CacheBloat
 		merged.CacheBloatTooltip = oldM.CacheBloatTooltip
+		merged.CacheBloatExplanation = oldM.CacheBloatExplanation
 	}
 	// nil Tasks = "no data yet"; non-nil empty slice = "no tasks" — overwrite only for the latter.
 	if merged.Tasks == nil && oldM.Tasks != nil {

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -367,6 +367,7 @@ struct SessionMetrics: Codable {
     let taskCompletionEta: Date?           // projected task completion (nil when no marker / no progress yet)
     let cacheBloat: Bool?                  // cache-creation regression detected for this session (issue #374)
     let cacheBloatTooltip: String?         // hover text naming the regressing version (empty when no attribution)
+    let cacheBloatExplanation: String?     // longer plain-language hover text, composed daemon-side (issue #827)
 
     enum CodingKeys: String, CodingKey {
         case elapsedSeconds = "elapsed_seconds"
@@ -390,6 +391,7 @@ struct SessionMetrics: Codable {
         case taskCompletionEta = "task_completion_eta"
         case cacheBloat = "cache_bloat"
         case cacheBloatTooltip = "cache_bloat_tooltip"
+        case cacheBloatExplanation = "cache_bloat_explanation"
     }
 
     init(from decoder: Decoder) throws {
@@ -427,6 +429,7 @@ struct SessionMetrics: Codable {
         }
         cacheBloat = try c.decodeIfPresent(Bool.self, forKey: .cacheBloat)
         cacheBloatTooltip = try c.decodeIfPresent(String.self, forKey: .cacheBloatTooltip)
+        cacheBloatExplanation = try c.decodeIfPresent(String.self, forKey: .cacheBloatExplanation)
     }
 
     /// Explicit memberwise initializer for SwiftUI previews and tests that
@@ -453,7 +456,8 @@ struct SessionMetrics: Codable {
         taskEstimate: TaskEstimateInfo? = nil,
         taskCompletionEta: Date? = nil,
         cacheBloat: Bool? = nil,
-        cacheBloatTooltip: String? = nil
+        cacheBloatTooltip: String? = nil,
+        cacheBloatExplanation: String? = nil
     ) {
         self.elapsedSeconds = elapsedSeconds
         self.totalTokens = totalTokens
@@ -476,6 +480,7 @@ struct SessionMetrics: Codable {
         self.taskCompletionEta = taskCompletionEta
         self.cacheBloat = cacheBloat
         self.cacheBloatTooltip = cacheBloatTooltip
+        self.cacheBloatExplanation = cacheBloatExplanation
     }
 
     func encode(to encoder: Encoder) throws {
@@ -501,6 +506,7 @@ struct SessionMetrics: Codable {
         try c.encodeIfPresent(taskCompletionEta.map { $0.timeIntervalSince1970 }, forKey: .taskCompletionEta)
         try c.encodeIfPresent(cacheBloat, forKey: .cacheBloat)
         try c.encodeIfPresent(cacheBloatTooltip, forKey: .cacheBloatTooltip)
+        try c.encodeIfPresent(cacheBloatExplanation, forKey: .cacheBloatExplanation)
     }
     
     // Computed properties for UI display

--- a/platforms/macos/Irrlicht/Views/SessionRowView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionRowView.swift
@@ -3,18 +3,6 @@ import SwiftUI
 
 // MARK: - Session Row View
 
-/// Longer plain-language hover text for the cache-creation regression badge
-/// (#813). `tooltip` is the daemon's cacheBloatTooltip: the version-attribution
-/// string when it could name the regressing upstream version, else nil/empty.
-/// Hand-duplicated in web's formatters.js — #827 tracks moving this to the
-/// daemon so both clients render the same server-composed string.
-private func cacheBloatExplanation(_ tooltip: String?) -> String {
-    let base = "This session is creating prompt-cache tokens well above normal for this project — it's getting less benefit from caching and costing more per turn."
-    let attribution = (tooltip?.isEmpty == false) ? " Likely tied to \(tooltip!)." : ""
-    let causes = " Common causes: an agent update that changed context construction, large or varying pasted content each turn, or frequent context resets (e.g. /clear)."
-    return base + attribution + causes
-}
-
 /// Shared shape for the row's single-line notice pills (user-intent, pending
 /// question, cache-bloat badge): tinted text on a dim background, full-width,
 /// truncating rather than wrapping.
@@ -177,8 +165,9 @@ struct SessionRowView: View {
     /// row (like summaryBlock) rather than inline among the icon-row badges,
     /// since the short label can be a full version-attribution sentence far
     /// wider than the fixed-width icon slots that row allots each glyph.
-    /// Hover still reveals the longer plain-language explanation, folding in
-    /// the attribution when the daemon could name the regressing version.
+    /// Hover still reveals the longer plain-language explanation
+    /// (cacheBloatExplanation), composed daemon-side (issue #827) and
+    /// rendered verbatim so it can't silently diverge from web's copy.
     @ViewBuilder
     private var cacheBloatBlock: some View {
         if session.metrics?.cacheBloat == true {
@@ -187,7 +176,7 @@ struct SessionRowView: View {
             Text(badgeText)
                 .pill(color: IrrColors.pressureHigh, font: .system(size: 9, weight: .semibold, design: .monospaced))
                 .padding(.top, 2)
-                .tooltip(cacheBloatExplanation(tooltip))
+                .tooltip(session.metrics?.cacheBloatExplanation ?? "")
         }
     }
 

--- a/platforms/macos/Tests/SessionRowSnapshotTests.swift
+++ b/platforms/macos/Tests/SessionRowSnapshotTests.swift
@@ -75,7 +75,8 @@ final class SessionRowSnapshotTests: XCTestCase {
         taskEstimate: TaskEstimateInfo? = nil,
         taskCompletionEta: Date? = nil,
         cacheBloat: Bool? = nil,
-        cacheBloatTooltip: String? = nil
+        cacheBloatTooltip: String? = nil,
+        cacheBloatExplanation: String? = nil
     ) -> SessionMetrics {
         SessionMetrics(
             elapsedSeconds: 0,
@@ -92,7 +93,8 @@ final class SessionRowSnapshotTests: XCTestCase {
             taskEstimate: taskEstimate,
             taskCompletionEta: taskCompletionEta,
             cacheBloat: cacheBloat,
-            cacheBloatTooltip: cacheBloatTooltip
+            cacheBloatTooltip: cacheBloatTooltip,
+            cacheBloatExplanation: cacheBloatExplanation
         )
     }
 
@@ -315,7 +317,8 @@ final class SessionRowSnapshotTests: XCTestCase {
             state: .working,
             metrics: makeMetrics(
                 cacheBloat: true,
-                cacheBloatTooltip: "claude-code 2.1.143 +14K cache tokens vs 2.1.98"
+                cacheBloatTooltip: "claude-code 2.1.143 +14K cache tokens vs 2.1.98",
+                cacheBloatExplanation: "This session is creating prompt-cache tokens well above normal for this project — it's getting less benefit from caching and costing more per turn. Likely tied to claude-code 2.1.143 +14K cache tokens vs 2.1.98. Common causes: an agent update that changed context construction, large or varying pasted content each turn, or frequent context resets (e.g. /clear)."
             )
         )
         assertSnapshot(of: host(session, height: 72), as: .image)
@@ -326,7 +329,11 @@ final class SessionRowSnapshotTests: XCTestCase {
     func testCacheBloatBadge_Fallback() {
         let session = makeSession(
             state: .working,
-            metrics: makeMetrics(cacheBloat: true, cacheBloatTooltip: nil)
+            metrics: makeMetrics(
+                cacheBloat: true,
+                cacheBloatTooltip: nil,
+                cacheBloatExplanation: "This session is creating prompt-cache tokens well above normal for this project — it's getting less benefit from caching and costing more per turn. Common causes: an agent update that changed context construction, large or varying pasted content each turn, or frequent context resets (e.g. /clear)."
+            )
         )
         assertSnapshot(of: host(session, height: 72), as: .image)
     }

--- a/platforms/web/formatters.js
+++ b/platforms/web/formatters.js
@@ -217,20 +217,12 @@ export function activeSubagentCount(a) {
   return a.children.filter(c => c.state === 'working' || c.state === 'waiting').length;
 }
 
-// Cache-creation regression badge (#813) — short visible text plus a longer
-// hover explanation. `tooltip` is the daemon's cache_bloat_tooltip: the
-// version-attribution string when it could name the regressing upstream
-// version, else '' (no attribution).
+// Cache-creation regression badge (#813) — short visible text. `tooltip` is
+// the daemon's cache_bloat_tooltip: the version-attribution string when it
+// could name the regressing upstream version, else '' (no attribution). The
+// longer hover explanation is composed daemon-side (cache_bloat_explanation,
+// issue #827) and rendered verbatim — see updateCacheBloatRow in irrlicht.js.
 export function cacheBloatBadgeText(tooltip) {
   return tooltip || 'cache ↑';
-}
-
-// Hand-duplicated in macOS's SessionRowView.swift — #827 tracks moving this
-// to the daemon so both clients render the same server-composed string.
-export function cacheBloatExplanation(tooltip) {
-  const base = "This session is creating prompt-cache tokens well above normal for this project — it's getting less benefit from caching and costing more per turn.";
-  const attribution = tooltip ? ` Likely tied to ${tooltip}.` : '';
-  const causes = ' Common causes: an agent update that changed context construction, large or varying pasted content each turn, or frequent context resets (e.g. /clear).';
-  return base + attribution + causes;
 }
 

--- a/platforms/web/irrlicht.cachebloat.test.js
+++ b/platforms/web/irrlicht.cachebloat.test.js
@@ -9,8 +9,21 @@ import { describe, test, expect } from 'vitest'
 // fixed-width icon slots) since the attribution string can be a full
 // sentence — inline would squeeze .row-branch/.row-model on that row only.
 //
+// #827: the hover explanation is composed daemon-side (cache_bloat_explanation)
+// and rendered verbatim, so the fixture supplies it exactly as the detector
+// would rather than letting the client re-derive it from the tooltip.
+//
 // Own file so irrlicht.js loads fresh (per-file module isolation) against a
 // payload crafted for this case.
+
+const attributedExplanation =
+  "This session is creating prompt-cache tokens well above normal for this project — it's getting less benefit from caching and costing more per turn." +
+  ' Likely tied to claude-code 2.1.143 +14K cache tokens vs 2.1.98.' +
+  ' Common causes: an agent update that changed context construction, large or varying pasted content each turn, or frequent context resets (e.g. /clear).'
+
+const unattributedExplanation =
+  "This session is creating prompt-cache tokens well above normal for this project — it's getting less benefit from caching and costing more per turn." +
+  ' Common causes: an agent update that changed context construction, large or varying pasted content each turn, or frequent context resets (e.g. /clear).'
 
 const sessionsPayload = {
   groups: [
@@ -23,7 +36,11 @@ const sessionsPayload = {
           project_name: 'irrlicht',
           adapter: 'claude-code',
           first_seen: 1764800000,
-          metrics: { cache_bloat: true, cache_bloat_tooltip: 'claude-code 2.1.143 +14K cache tokens vs 2.1.98' },
+          metrics: {
+            cache_bloat: true,
+            cache_bloat_tooltip: 'claude-code 2.1.143 +14K cache tokens vs 2.1.98',
+            cache_bloat_explanation: attributedExplanation,
+          },
         },
         {
           session_id: 'unattributed',
@@ -31,7 +48,7 @@ const sessionsPayload = {
           project_name: 'irrlicht',
           adapter: 'claude-code',
           first_seen: 1764800100,
-          metrics: { cache_bloat: true, cache_bloat_tooltip: '' },
+          metrics: { cache_bloat: true, cache_bloat_tooltip: '', cache_bloat_explanation: unattributedExplanation },
         },
         {
           session_id: 'normal',
@@ -76,19 +93,19 @@ describe('cache-creation regression badge (#813)', () => {
     expect(document.querySelectorAll('#session-list .session-row').length).toBe(3)
 
     // Attributed: visible text is the daemon's version-attribution string,
-    // not just an icon; hover explanation folds the attribution in.
+    // not just an icon; hover explanation is the daemon-composed string,
+    // rendered verbatim (issue #827 — no client-side re-derivation).
     const attributed = cacheBloatBadge('attributed')
     expect(attributed).not.toBeNull()
     expect(attributed.textContent).toBe('claude-code 2.1.143 +14K cache tokens vs 2.1.98')
-    expect(attributed.title).toContain('claude-code 2.1.143 +14K cache tokens vs 2.1.98')
-    expect(attributed.title).toContain('creating prompt-cache tokens well above normal')
+    expect(attributed.title).toBe(attributedExplanation)
 
     // Unattributed: compact fallback label, not the old generic sentence.
     const unattributed = cacheBloatBadge('unattributed')
     expect(unattributed).not.toBeNull()
     expect(unattributed.textContent).toBe('cache ↑')
+    expect(unattributed.title).toBe(unattributedExplanation)
     expect(unattributed.title).not.toContain('Likely tied to')
-    expect(unattributed.title).toContain('creating prompt-cache tokens well above normal')
 
     // Ordinary session: no badge row at all.
     expect(cacheBloatRow('normal')).toBeUndefined()

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -16,7 +16,7 @@ import { relayFrameKind, seqGap, aggregateConnState, relayWsUrl } from './connec
 import {
   stateIcon, shortModel, formatCost, costCellDisplay, fmtDuration, formatElapsed, fmtEtaDuration, fmtEtaText,
   taskEtaPresentation, shortID, pressureClass, pressureColor, formatTokens, esc, activeSubagentCount,
-  cacheBloatBadgeText, cacheBloatExplanation,
+  cacheBloatBadgeText,
 } from './formatters.js';
 import { reconcile, paintRowNum } from './domReconcile.js';
 
@@ -1117,7 +1117,10 @@ import { reconcile, paintRowNum } from './domReconcile.js';
         el.dataset.badge = badgeText;
         el.innerHTML = '<span class="row-cache-bloat">' + esc(badgeText) + '</span>';
       }
-      el.querySelector('.row-cache-bloat').title = cacheBloatExplanation(metrics.cache_bloat_tooltip);
+      // The longer hover explanation is composed daemon-side (issue #827) and
+      // rendered verbatim so both UIs never re-derive (and silently diverge
+      // on) the wording.
+      el.querySelector('.row-cache-bloat').title = metrics.cache_bloat_explanation || '';
     }
 
     // Shared factory for trailing-row variants rendered beneath the parent


### PR DESCRIPTION
## Summary
- Adds `cache_bloat_explanation` to `session.metrics`, composed once by `CacheBloatDetector` from the existing `cache_bloat_tooltip`, instead of each client re-deriving the copy independently.
- macOS (`SessionRowView.swift`) and web (`irrlicht.js`) now render this field verbatim in the badge's hover text; the hand-duplicated composing functions on both platforms are removed.
- Closes #827.

## Test plan
- [x] `go test ./core/application/services/... -run CacheBloat -v` — extended with assertions that the explanation is set/cleared alongside the tooltip
- [x] `go test ./core/... -race -count=1`
- [x] `npm test` in `platforms/web` (includes updated `irrlicht.cachebloat.test.js` asserting exact verbatim hover text)
- [x] `swift test --enable-xctest` (all `SessionRowSnapshotTests`, including the two cache-bloat badge snapshots, pass)
- [x] `tools/preflight.sh` — all gates green, ARS composite unchanged/slightly improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)