### PR TITLE
fix(macos): recover from a stuck local-daemon reconnect

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager+Hydration.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Hydration.swift
@@ -25,7 +25,7 @@ extension SessionManager {
     func hydrateAgents() async {
         guard let url = URL(string: "\(DaemonEndpoint.httpBase)/api/v1/agents") else { return }
         do {
-            let (data, response) = try await URLSession.shared.data(from: url)
+            let (data, response) = try await localURLSession.data(from: url)
             guard (response as? HTTPURLResponse)?.statusCode == 200 else { return }
             let entries = try JSONDecoder().decode([AgentBranding].self, from: data)
             AgentRegistry.byName = Dictionary(uniqueKeysWithValues: entries.map { ($0.name, $0) })
@@ -41,7 +41,7 @@ extension SessionManager {
     func refreshPermissions() async {
         guard let url = URL(string: "\(DaemonEndpoint.httpBase)/api/v1/permissions") else { return }
         do {
-            let (data, response) = try await URLSession.shared.data(from: url)
+            let (data, response) = try await localURLSession.data(from: url)
             guard (response as? HTTPURLResponse)?.statusCode == 200 else { return }
             permissionsSnapshot = try JSONDecoder().decode(PermissionsSnapshot.self, from: data)
         } catch {
@@ -65,7 +65,7 @@ extension SessionManager {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         do {
             request.httpBody = try JSONEncoder().encode(["answers": answers])
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await localURLSession.data(for: request)
             guard (response as? HTTPURLResponse)?.statusCode == 200 else { return false }
             permissionsSnapshot = try JSONDecoder().decode(PermissionsSnapshot.self, from: data)
             return true
@@ -84,7 +84,7 @@ extension SessionManager {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         do {
             request.httpBody = try JSONEncoder().encode(["data": text])
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await localURLSession.data(for: request)
             return (response as? HTTPURLResponse)?.statusCode == 200
         } catch {
             print("⌨️ sendInput failed: \(error.localizedDescription)")
@@ -98,7 +98,7 @@ extension SessionManager {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         do {
-            let (_, response) = try await URLSession.shared.data(for: request)
+            let (_, response) = try await localURLSession.data(for: request)
             return (response as? HTTPURLResponse)?.statusCode == 200
         } catch {
             print("⌨️ interrupt failed: \(error.localizedDescription)")
@@ -128,7 +128,7 @@ extension SessionManager {
         guard useLocalDaemon else { return }
         guard let url = URL(string: "\(DaemonEndpoint.httpBase)/api/v1/sessions") else { return }
         do {
-            let (data, response) = try await URLSession.shared.data(from: url)
+            let (data, response) = try await localURLSession.data(from: url)
             guard (response as? HTTPURLResponse)?.statusCode == 200 else { return }
             let decoder = JSONDecoder()
             let payload = try decoder.decode(SessionsResponse.self, from: data)

--- a/platforms/macos/Irrlicht/Managers/SessionManager+Relay.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Relay.swift
@@ -335,7 +335,8 @@ extension SessionManager {
     var connectionTooltip: String {
         var lines: [String] = []
         if useLocalDaemon {
-            lines.append("Local — \(connectionState.shortLabel)")
+            let stalledSuffix = localConnectionStalled ? " (daemon unreachable — retrying)" : ""
+            lines.append("Local — \(connectionState.shortLabel)\(stalledSuffix)")
         }
         if useRelayServer && !relayServerURL.isEmpty {
             if relayConnectionState == .connected && !relayDaemons.isEmpty {

--- a/platforms/macos/Irrlicht/Managers/SessionManager+WebSocket.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+WebSocket.swift
@@ -14,6 +14,8 @@ extension SessionManager {
         guard connectionState == .disconnected else { return }
         connectionState = .connecting
         reconnectDelay = 1.0
+        consecutiveLocalConnectFailures = 0
+        localConnectionStalled = false
         scheduleConnect(after: 0)
     }
 
@@ -27,6 +29,7 @@ extension SessionManager {
         rehydrationTask?.cancel()
         rehydrationTask = nil
         connectionState = .disconnected
+        localConnectionStalled = false
     }
 
     func scheduleConnect(after delay: TimeInterval) {
@@ -46,18 +49,28 @@ extension SessionManager {
         await refreshPermissions()
 
         guard let url = URL(string: "\(DaemonEndpoint.wsBase)/api/v1/sessions/stream") else { return }
-        let task = URLSession.shared.webSocketTask(with: url)
+        let task = localURLSession.webSocketTask(with: url)
         webSocketTask = task
         task.resume()
 
         lastPushSeq = 0 // fresh stream, fresh seq cursor (#600)
-        reconnectDelay = 1.0
-        connectionState = .connected
-        print("🔌 WebSocket connected to irrlichd")
 
+        // `resume()` returns before the WebSocket handshake is known good —
+        // the HTTP upgrade itself can still fail — so `confirmed` only flips
+        // once a message actually arrives. Resetting the backoff/failure
+        // streak (and declaring "connected") any earlier defeated the
+        // exponential backoff entirely: every attempt reset `reconnectDelay`
+        // to 1.0 before failing, so a dead daemon got hammered every ~1.1s
+        // forever instead of backing off (#843).
+        var confirmed = false
         do {
             while !Task.isCancelled {
                 let message = try await task.receive()
+                if !confirmed {
+                    confirmed = true
+                    recordConfirmedLocalConnect()
+                    print("🔌 WebSocket connected to irrlichd")
+                }
                 switch message {
                 case .string(let text):
                     handleWsMessage(text)
@@ -75,6 +88,19 @@ extension SessionManager {
 
         guard connectionState != .disconnected && !Task.isCancelled else { return }
 
+        if !confirmed {
+            // Hydration and the socket both came back empty, even though
+            // `resume()` said the attempt started fine. A stuck OS-level
+            // connection cache pinned to this URLSession instance can cause
+            // exactly that — failing forever against a healthy daemon that
+            // restarted on the same port — until something discards it
+            // (previously only an app relaunch; #843). Recycle it ourselves
+            // once failures pile up rather than waiting on that.
+            if recordFailedLocalConnectAttempt() {
+                print("🔌 Local daemon unreachable after repeated attempts — recreating URLSession")
+            }
+        }
+
         let jitter = Double.random(in: 0...(reconnectDelay * 0.2))
         let delay = reconnectDelay + jitter
         connectionState = .reconnecting
@@ -82,6 +108,35 @@ extension SessionManager {
 
         reconnectDelay = min(reconnectDelay * 2, maxReconnectDelay)
         scheduleConnect(after: delay)
+    }
+
+    /// Applied once a reconnect attempt's WebSocket delivers its first
+    /// message — the only reliable proof the daemon on the other end is
+    /// actually the one answering, since `resume()` returns before the
+    /// upgrade is confirmed. Split out of `connect()` so the state
+    /// transition is unit-testable without a live socket (#843).
+    func recordConfirmedLocalConnect() {
+        reconnectDelay = 1.0
+        consecutiveLocalConnectFailures = 0
+        localConnectionStalled = false
+        connectionState = .connected
+    }
+
+    /// Applied once a reconnect attempt's hydration + WebSocket both come
+    /// back empty. Bumps the failure streak and, once it crosses
+    /// `localConnectFailuresBeforeSessionRecycle`, recycles `localURLSession`
+    /// and flags the connection as stalled so the UI can show something
+    /// stronger than "reconnecting" (#843). Returns whether it recycled, for
+    /// logging. Split out of `connect()` for unit testability.
+    @discardableResult
+    func recordFailedLocalConnectAttempt() -> Bool {
+        consecutiveLocalConnectFailures += 1
+        guard consecutiveLocalConnectFailures >= localConnectFailuresBeforeSessionRecycle else { return false }
+        localURLSession.invalidateAndCancel()
+        localURLSession = URLSession(configuration: .ephemeral)
+        consecutiveLocalConnectFailures = 0
+        localConnectionStalled = true
+        return true
     }
 
     // MARK: - Inbound message decoding

--- a/platforms/macos/Irrlicht/Managers/SessionManager+WebSocket.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+WebSocket.swift
@@ -13,10 +13,17 @@ extension SessionManager {
     func startWebSocket() {
         guard connectionState == .disconnected else { return }
         connectionState = .connecting
+        resetLocalConnectBackoff()
+        scheduleConnect(after: 0)
+    }
+
+    /// Clears backoff/failure state for a fresh connect cycle. Split out of
+    /// `startWebSocket()` so it's unit-testable without also triggering a
+    /// live `scheduleConnect()` dial (#843).
+    func resetLocalConnectBackoff() {
         reconnectDelay = 1.0
         consecutiveLocalConnectFailures = 0
         localConnectionStalled = false
-        scheduleConnect(after: 0)
     }
 
     func stopWebSocket() {
@@ -56,21 +63,30 @@ extension SessionManager {
         lastPushSeq = 0 // fresh stream, fresh seq cursor (#600)
 
         // `resume()` returns before the WebSocket handshake is known good —
-        // the HTTP upgrade itself can still fail — so `confirmed` only flips
-        // once a message actually arrives. Resetting the backoff/failure
-        // streak (and declaring "connected") any earlier defeated the
-        // exponential backoff entirely: every attempt reset `reconnectDelay`
-        // to 1.0 before failing, so a dead daemon got hammered every ~1.1s
-        // forever instead of backing off (#843).
-        var confirmed = false
+        // the HTTP upgrade itself can still fail — so declaring "connected"
+        // (and resetting the backoff/failure streak) any earlier defeated
+        // the exponential backoff entirely: every attempt reset
+        // `reconnectDelay` to 1.0 before failing, so a dead daemon got
+        // hammered every ~1.1s forever instead of backing off (#843).
+        //
+        // A daemon with no tracked sessions can go the entire cycle without
+        // pushing a single application message, so waiting on `receive()`
+        // alone would never confirm a perfectly healthy idle connection —
+        // send a protocol-level ping right away too. Whichever signal wins
+        // the race calls `recordConfirmedLocalConnect()`, which is
+        // idempotent (`connectionState` gates it) so there's no double-fire.
+        task.sendPing { [weak self] error in
+            guard error == nil else { return }
+            Task { @MainActor [weak self] in
+                guard let self, self.webSocketTask === task else { return }
+                self.recordConfirmedLocalConnect()
+            }
+        }
+
         do {
             while !Task.isCancelled {
                 let message = try await task.receive()
-                if !confirmed {
-                    confirmed = true
-                    recordConfirmedLocalConnect()
-                    print("🔌 WebSocket connected to irrlichd")
-                }
+                recordConfirmedLocalConnect()
                 switch message {
                 case .string(let text):
                     handleWsMessage(text)
@@ -88,14 +104,15 @@ extension SessionManager {
 
         guard connectionState != .disconnected && !Task.isCancelled else { return }
 
-        if !confirmed {
-            // Hydration and the socket both came back empty, even though
-            // `resume()` said the attempt started fine. A stuck OS-level
-            // connection cache pinned to this URLSession instance can cause
-            // exactly that — failing forever against a healthy daemon that
-            // restarted on the same port — until something discards it
-            // (previously only an app relaunch; #843). Recycle it ourselves
-            // once failures pile up rather than waiting on that.
+        if connectionState != .connected {
+            // Neither the ping nor hydration nor the socket ever confirmed
+            // anything, even though `resume()` said the attempt started
+            // fine. A stuck OS-level connection cache pinned to this
+            // URLSession instance can cause exactly that — failing forever
+            // against a healthy daemon that restarted on the same port —
+            // until something discards it (previously only an app relaunch;
+            // #843). Recycle it ourselves once failures pile up rather than
+            // waiting on that.
             if recordFailedLocalConnectAttempt() {
                 print("🔌 Local daemon unreachable after repeated attempts — recreating URLSession")
             }
@@ -110,16 +127,18 @@ extension SessionManager {
         scheduleConnect(after: delay)
     }
 
-    /// Applied once a reconnect attempt's WebSocket delivers its first
-    /// message — the only reliable proof the daemon on the other end is
-    /// actually the one answering, since `resume()` returns before the
-    /// upgrade is confirmed. Split out of `connect()` so the state
-    /// transition is unit-testable without a live socket (#843).
+    /// Applied once a reconnect attempt's WebSocket is confirmed alive — a
+    /// successful ping/pong or an arrived message, whichever comes first.
+    /// Idempotent (gated on `connectionState`) since both signals race for
+    /// the same cycle. Split out of `connect()` so the state transition is
+    /// unit-testable without a live socket (#843).
     func recordConfirmedLocalConnect() {
+        guard connectionState != .connected else { return }
         reconnectDelay = 1.0
         consecutiveLocalConnectFailures = 0
         localConnectionStalled = false
         connectionState = .connected
+        print("🔌 WebSocket connected to irrlichd")
     }
 
     /// Applied once a reconnect attempt's hydration + WebSocket both come

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -125,6 +125,22 @@ class SessionManager: ObservableObject {
     var connectTask: Task<Void, Never>?
     var reconnectDelay: TimeInterval = 1.0
     let maxReconnectDelay: TimeInterval = 30.0
+    /// Dedicated session for all local-daemon traffic (WebSocket + REST
+    /// hydration) instead of `URLSession.shared`. An OS-level connection
+    /// cache pinned to one URLSession instance can get stuck against a host
+    /// that restarted on the same port, failing forever even once the new
+    /// process is healthy (#843) — recreating the instance (see `connect()`)
+    /// discards whatever cached state caused that.
+    var localURLSession = URLSession(configuration: .ephemeral)
+    /// Consecutive local-connect cycles that never got a single byte back
+    /// from the daemon. Reset on any confirmed message.
+    var consecutiveLocalConnectFailures = 0
+    /// After this many consecutive failures, recycle `localURLSession` (#843).
+    let localConnectFailuresBeforeSessionRecycle = 3
+    /// True once a `localURLSession` recycle hasn't yet been followed by a
+    /// confirmed reconnect — surfaces the "this isn't a normal transient
+    /// blip anymore" state in the connection tooltip/dot (#843).
+    @Published var localConnectionStalled = false
     var sessionMap: [String: SessionState] = [:]
     /// Last stamped push `seq` received on the stream. 0 = fresh cursor
     /// (reset on every (re)connect). See #600.

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1123,6 +1123,12 @@ struct SessionListView: View {
     }
 
     private var statusColor: Color {
+        // A stalled local reconnect (#843) is a more severe signal than an
+        // ordinary transient "reconnecting" blip — flag it red rather than
+        // yellow even though the auto-retry loop is still quietly running.
+        if sessionManager.useLocalDaemon && sessionManager.localConnectionStalled {
+            return IrrColors.wsDisconnected
+        }
         switch sessionManager.aggregateConnectionState {
         case .connected: return IrrColors.wsConnected
         case .connecting, .reconnecting: return IrrColors.wsConnecting

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1123,13 +1123,18 @@ struct SessionListView: View {
     }
 
     private var statusColor: Color {
+        let aggregate = sessionManager.aggregateConnectionState
         // A stalled local reconnect (#843) is a more severe signal than an
         // ordinary transient "reconnecting" blip — flag it red rather than
         // yellow even though the auto-retry loop is still quietly running.
-        if sessionManager.useLocalDaemon && sessionManager.localConnectionStalled {
+        // Only when it isn't masked by another healthy source, though — a
+        // relay connection can be carrying the session list just fine while
+        // the local daemon link is stuck, and the aggregate already reports
+        // that (`.connected` wins in `aggregateConnectionState`).
+        if aggregate != .connected && sessionManager.useLocalDaemon && sessionManager.localConnectionStalled {
             return IrrColors.wsDisconnected
         }
-        switch sessionManager.aggregateConnectionState {
+        switch aggregate {
         case .connected: return IrrColors.wsConnected
         case .connecting, .reconnecting: return IrrColors.wsConnecting
         case .disconnected: return IrrColors.wsDisconnected

--- a/platforms/macos/Tests/SessionManagerReconnectTests.swift
+++ b/platforms/macos/Tests/SessionManagerReconnectTests.swift
@@ -13,9 +13,16 @@ import Foundation
 /// forever even once a healthy daemon was listening again; only an app
 /// relaunch (a fresh process, and so a fresh URLSession) recovered.
 ///
+/// The fix's first cut confirmed a connection only once an application
+/// message arrived — which a daemon with zero tracked sessions may never
+/// send, permanently stranding the UI on "Connecting…" and eventually
+/// mis-flagging a perfectly healthy idle connection as stalled. `connect()`
+/// now also confirms via a protocol-level ping/pong, so an idle-but-healthy
+/// connection is recognized without waiting on app traffic.
+///
 /// `connect()` itself does real networking and isn't exercised here (see
 /// SessionManagerTests's issue #832 note on why tests never dial the real
-/// daemon); these tests pin the two state transitions it delegates to.
+/// daemon); these tests pin the state transitions it delegates to.
 @MainActor
 final class SessionManagerReconnectTests: XCTestCase {
     private var sut: SessionManager!
@@ -46,6 +53,22 @@ final class SessionManagerReconnectTests: XCTestCase {
         XCTAssertEqual(sut.connectionState, .connected)
     }
 
+    /// `connect()` confirms via whichever signal arrives first — a ping/pong
+    /// (needed because a daemon with zero tracked sessions may never push a
+    /// single application message) or a received message. Both must land on
+    /// the same idempotent call, so a second confirmation after the state is
+    /// already `.connected` is a no-op rather than re-arming the counters.
+    func testRecordConfirmedLocalConnect_isIdempotent() {
+        sut.recordConfirmedLocalConnect()
+        XCTAssertEqual(sut.connectionState, .connected)
+
+        sut.consecutiveLocalConnectFailures = 2 // as if a failure was mid-flight
+        sut.recordConfirmedLocalConnect()
+
+        XCTAssertEqual(sut.consecutiveLocalConnectFailures, 2,
+                       "a second confirmation on an already-connected cycle must not touch state again")
+    }
+
     func testRecordFailedLocalConnectAttempt_doesNotRecycleBeforeThreshold() {
         let originalSession = sut.localURLSession
 
@@ -72,15 +95,18 @@ final class SessionManagerReconnectTests: XCTestCase {
         XCTAssertEqual(sut.consecutiveLocalConnectFailures, 0, "the streak resets after recycling")
     }
 
-    func testStartWebSocket_clearsStaleFailureState() {
+    func testResetLocalConnectBackoff_clearsStaleFailureState() {
+        // Exercises the reset helper directly rather than `startWebSocket()`
+        // itself, which would also schedule a live `connect()` dial (#843).
+        sut.reconnectDelay = 8.0
         sut.consecutiveLocalConnectFailures = sut.localConnectFailuresBeforeSessionRecycle
         sut.localConnectionStalled = true
 
-        sut.startWebSocket()
+        sut.resetLocalConnectBackoff()
 
+        XCTAssertEqual(sut.reconnectDelay, 1.0)
         XCTAssertEqual(sut.consecutiveLocalConnectFailures, 0)
         XCTAssertFalse(sut.localConnectionStalled)
-        sut.stopWebSocket() // cancel the scheduled connect before it can dial out
     }
 
     func testStopWebSocket_clearsStalledFlag() {

--- a/platforms/macos/Tests/SessionManagerReconnectTests.swift
+++ b/platforms/macos/Tests/SessionManagerReconnectTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import Irrlicht
+import Foundation
+
+/// Regression coverage for #843: the macOS app never recovered when the
+/// daemon it was connected to died and a new one started on the same port.
+///
+/// Two bugs combined to cause that. First, `connect()` reset `reconnectDelay`
+/// back to 1.0 on every attempt — including failed ones — before the
+/// exponential backoff could ever take effect, so a dead daemon got hammered
+/// every ~1.1s forever instead of backing off. Second, `URLSession.shared`
+/// could get stuck against a host:port that restarted under it, failing
+/// forever even once a healthy daemon was listening again; only an app
+/// relaunch (a fresh process, and so a fresh URLSession) recovered.
+///
+/// `connect()` itself does real networking and isn't exercised here (see
+/// SessionManagerTests's issue #832 note on why tests never dial the real
+/// daemon); these tests pin the two state transitions it delegates to.
+@MainActor
+final class SessionManagerReconnectTests: XCTestCase {
+    private var sut: SessionManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        sut = SessionManager()
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        try await super.tearDown()
+    }
+
+    func testRecordConfirmedLocalConnect_resetsBackoffAndFailureState() {
+        // Simulate having backed off after several failed attempts.
+        sut.reconnectDelay = 16.0
+        sut.consecutiveLocalConnectFailures = 2
+        sut.localConnectionStalled = true
+        sut.connectionState = .reconnecting
+
+        sut.recordConfirmedLocalConnect()
+
+        XCTAssertEqual(sut.reconnectDelay, 1.0,
+                       "a confirmed connect must reset the backoff for the next disconnect")
+        XCTAssertEqual(sut.consecutiveLocalConnectFailures, 0)
+        XCTAssertFalse(sut.localConnectionStalled)
+        XCTAssertEqual(sut.connectionState, .connected)
+    }
+
+    func testRecordFailedLocalConnectAttempt_doesNotRecycleBeforeThreshold() {
+        let originalSession = sut.localURLSession
+
+        for _ in 0..<(sut.localConnectFailuresBeforeSessionRecycle - 1) {
+            XCTAssertFalse(sut.recordFailedLocalConnectAttempt())
+        }
+
+        XCTAssertFalse(sut.localConnectionStalled, "must not surface stalled before the threshold")
+        XCTAssertTrue(sut.localURLSession === originalSession, "session must survive isolated blips")
+    }
+
+    func testRecordFailedLocalConnectAttempt_recyclesSessionAtThreshold() {
+        let originalSession = sut.localURLSession
+
+        for _ in 0..<(sut.localConnectFailuresBeforeSessionRecycle - 1) {
+            sut.recordFailedLocalConnectAttempt()
+        }
+        let recycled = sut.recordFailedLocalConnectAttempt()
+
+        XCTAssertTrue(recycled, "the Nth consecutive failure must trigger a recycle")
+        XCTAssertTrue(sut.localConnectionStalled, "a recycle surfaces as stalled for the UI")
+        XCTAssertFalse(sut.localURLSession === originalSession,
+                       "a stuck URLSession must be discarded, not reused (#843)")
+        XCTAssertEqual(sut.consecutiveLocalConnectFailures, 0, "the streak resets after recycling")
+    }
+
+    func testStartWebSocket_clearsStaleFailureState() {
+        sut.consecutiveLocalConnectFailures = sut.localConnectFailuresBeforeSessionRecycle
+        sut.localConnectionStalled = true
+
+        sut.startWebSocket()
+
+        XCTAssertEqual(sut.consecutiveLocalConnectFailures, 0)
+        XCTAssertFalse(sut.localConnectionStalled)
+        sut.stopWebSocket() // cancel the scheduled connect before it can dial out
+    }
+
+    func testStopWebSocket_clearsStalledFlag() {
+        sut.localConnectionStalled = true
+
+        sut.stopWebSocket()
+
+        XCTAssertFalse(sut.localConnectionStalled)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #843: the menu bar app never recovered when the daemon it was connected to died and a new one started on the same port — only killing and relaunching the app itself worked.
- Root cause was two compounding bugs in `SessionManager+WebSocket.swift`'s `connect()`: (1) `reconnectDelay` was reset to 1.0 on every attempt — including failed ones — before the exponential backoff could ever take effect, so a dead daemon got hammered every ~1.1s forever instead of backing off; (2) all local-daemon traffic rode `URLSession.shared`, which can wedge against a host:port that restarted under it and then fail forever even once a healthy daemon is listening again.
- Fix: move all local-daemon HTTP + WebSocket traffic onto a dedicated `URLSession` that gets recreated after 3 consecutive silent-failure cycles, only reset the backoff/failure streak once a message actually confirms the connection (mirrors the existing `relayConnect()` pattern), and surface a "daemon unreachable — retrying" state in the connection tooltip/dot instead of quietly retrying forever with no visible indication.

## Test plan
- [x] `swift build` — compiles clean
- [x] `swift test` — full suite passes, including new `SessionManagerReconnectTests` pinning the backoff-reset and session-recycle state transitions
- [x] `tools/preflight.sh` — full local CI parity (go tests, onboarding-factory, replaydata validate, web suites, ARS gate) — all green
- [ ] Manual: not verified live against a real daemon-restart scenario (no GUI session available in this environment) — the fix is scoped to the state-machine logic described in the issue, unit-tested in isolation since `connect()` itself does real networking (existing tests never dial the real daemon, see #832)

🤖 Generated with [Claude Code](https://claude.com/claude-code)