### PR TITLE
fix: remove fragile SwiftPM resource-bundle dependency

### DIFF
--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -345,13 +345,13 @@ All tests must pass before proceeding.
 > in the bundle; the PKG postinstall symlinks `irrlicht-ls` into
 > `/usr/local/bin` — #608), the Linux tarballs, assembles + DevID-signs the
 > bundle, DevID-signs the DMG file itself (since #652; see the DMG-signature
-> note in step 7 below), notarizes + staples the DMG, builds the
+> note in step 6 below), notarizes + staples the DMG, builds the
 > PKG, and writes `.build/checksums.sha256`. It does **NOT** do four things —
 > do them by hand afterward:
 > 1. **ZIP**: `ditto -c -k --sequesterRsrc --keepParent .build/Irrlicht.app .build/Irrlicht-$NEW_VERSION.zip`
 > 2. **Re-checksum to include the zip**: regenerate `.build/checksums.sha256` over the dmg, pkg, zip, and the three tarballs.
-> 3. **Sparkle-sign the DMG** + add the `site/appcast.xml` `<item>` (Step 6 step 7's Sparkle block).
-> 4. **Smoke-test** the bundle (Step 6 step 8) — but see the port hazard below.
+> 3. **Sparkle-sign the DMG** + add the `site/appcast.xml` `<item>` (Step 6 step 6's Sparkle block).
+> 4. **Smoke-test** the bundle (Step 6 step 7) — but see the port hazard below.
 >
 > **The `focus-status` entitlement is gone (don't re-add a FOCUS_TRUE check).**
 > v0.4.7 STRIPPED `com.apple.developer.focus-status` (AMFI POSIX 153 killed
@@ -511,17 +511,7 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
 1. Copy Swift binary → `$APP_STAGING/Contents/MacOS/Irrlicht` (from path above).
 2. Copy universal daemon → `$APP_STAGING/Contents/MacOS/irrlichd`.
 3. Copy `AppIcon.icns` → `$APP_STAGING/Contents/Resources/AppIcon.icns`.
-4. **Copy the SwiftPM resource bundle** `Irrlicht_Irrlicht.bundle` →
-   `$APP_STAGING/Contents/Resources/Irrlicht_Irrlicht.bundle`. The Swift code uses
-   `Bundle.module.url(...)` which aborts during its own initialization if
-   the bundle isn't present — the `?? Bundle.main...` fallback never runs.
-   Missing this bundle shipped a broken v0.3.4 that crashed at launch
-   (`EXC_BREAKPOINT` in `resource_bundle_accessor.swift`).
-   ```bash
-   cp -R /Users/ingo/projects/irrlicht/platforms/macos/.build/apple/Products/Release/Irrlicht_Irrlicht.bundle \
-         "$APP_STAGING/Contents/Resources/Irrlicht_Irrlicht.bundle"
-   ```
-5. **Copy the dashboard UI** → `$APP_STAGING/Contents/Resources/web/index.html`.
+4. **Copy the dashboard UI** → `$APP_STAGING/Contents/Resources/web/index.html`.
    The daemon resolves it at runtime via `<exe>/../Resources/web/`
    (`resolveUIDir` in `core/cmd/irrlichd/main.go`). Without this copy,
    `GET /` returns the 503 "Dashboard UI not found" fallback — every
@@ -533,7 +523,7 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
    cp /Users/ingo/projects/irrlicht/platforms/web/index.html \
       "$APP_STAGING/Contents/Resources/web/index.html"
    ```
-6. **Write a resolved `Info.plist`** to `$APP_STAGING/Contents/Info.plist`.
+5. **Write a resolved `Info.plist`** to `$APP_STAGING/Contents/Info.plist`.
    This is a hand-written file, *not* a copy of `platforms/macos/Irrlicht/Resources/Info.plist`
    (which contains unresolved Xcode variables like `$(PRODUCT_NAME)`). Use
    the full template below verbatim, substituting only `$NEW_VERSION` and
@@ -600,7 +590,7 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
    </plist>
    ```
 
-7. **Sign with Developer ID, then notarize and staple the DMG.**
+6. **Sign with Developer ID, then notarize and staple the DMG.**
 
    One-time credential setup (skip if already done):
    ```bash
@@ -720,7 +710,7 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
    commit in step 10 must include `site/appcast.xml` — GitHub Pages serves
    it from `https://irrlicht.io/appcast.xml` so existing installs see the
    new entry.
-8. **Smoke test before packaging** — launch the built app, wait ~2s, confirm
+7. **Smoke test before packaging** — launch the built app, wait ~2s, confirm
    the process is still alive, has spawned `irrlichd`, and that the daemon
    serves the dashboard at `127.0.0.1:7837/`.
 

--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -229,10 +229,9 @@ independent axes:
          cp "$DEBUG_BIN" "$APP_TARGET/Contents/MacOS/Irrlicht"
          rm -rf "$APP_TARGET/Contents/Frameworks/Sparkle.framework"
          cp -R "$DEBUG_SPARKLE" "$APP_TARGET/Contents/Frameworks/Sparkle.framework"
-         # Refresh the SwiftPM resource bundle + icon too, so a developer
-         # iterating on Resources/ assets sees the same result in replace
-         # mode as in separate mode instead of a stale production copy.
-         cp -R "$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht_Irrlicht.bundle" "$APP_TARGET/Contents/Resources/Irrlicht_Irrlicht.bundle" 2>/dev/null || true
+         # Refresh the icon too, so a developer iterating on Resources/ assets
+         # sees the same result in replace mode as in separate mode instead of
+         # a stale production copy.
          cp "$REPO_ROOT/platforms/macos/Irrlicht/Resources/AppIcon.icns" "$APP_TARGET/Contents/Resources/AppIcon.icns"
          # The SwiftPM debug binary links Sparkle as @rpath/Sparkle.framework but only
          # carries an @loader_path rpath (= Contents/MacOS) — it lacks the bundle-layout
@@ -252,8 +251,6 @@ independent axes:
          mkdir -p "$APP_TARGET/Contents/MacOS" "$APP_TARGET/Contents/Resources"
          cp "$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht" "$APP_TARGET/Contents/MacOS/Irrlicht"
          cp "$REPO_ROOT/platforms/macos/Irrlicht/Resources/AppIcon.icns" "$APP_TARGET/Contents/Resources/AppIcon.icns"
-         # Copy the SwiftPM resource bundle so Bundle.module works at runtime
-         cp -R "$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht_Irrlicht.bundle" "$APP_TARGET/Contents/Resources/Irrlicht_Irrlicht.bundle" 2>/dev/null || true
          # Embed Sparkle.framework (required since v0.4.7 auto-update integration)
          mkdir -p "$APP_TARGET/Contents/Frameworks"
          cp -R "$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug/Sparkle.framework" "$APP_TARGET/Contents/Frameworks/"

--- a/platforms/macos/Irrlicht/IrrlichtApp.swift
+++ b/platforms/macos/Irrlicht/IrrlichtApp.swift
@@ -44,9 +44,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         mainMenu.addItem(editItem)
         NSApp.mainMenu = mainMenu
 
-        // Try Bundle.module (SwiftPM resource bundle) first, then Bundle.main (.app bundle)
-        let iconURL = Bundle.module.url(forResource: "AppIcon", withExtension: "icns", subdirectory: "Resources")
-            ?? Bundle.main.url(forResource: "AppIcon", withExtension: "icns")
+        let iconURL = Bundle.main.url(forResource: "AppIcon", withExtension: "icns")
         if let iconURL, let icon = NSImage(contentsOf: iconURL) {
             NSApp.applicationIconImage = icon
         }

--- a/platforms/macos/Package.swift
+++ b/platforms/macos/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
                 .product(name: "Sparkle", package: "Sparkle"),
             ],
             path: "Irrlicht",
-            resources: [.copy("Resources")]
+            exclude: ["Resources"]
         ),
         .testTarget(
             name: "IrrlichtTests",

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -126,19 +126,6 @@ cp platforms/web/index.html platforms/web/irrlicht.css platforms/web/irrlicht.js
 # AppIcon — required for menu bar / Finder display.
 cp platforms/macos/Irrlicht/Resources/AppIcon.icns "$APP_CONTENTS/Resources/AppIcon.icns"
 
-# SwiftPM resource bundle — Bundle.module.url(...) aborts during its own
-# initialization if this bundle isn't present (the ?? fallback never runs).
-# Missing this bundle shipped a broken v0.3.4 that crashed at launch.
-SWIFTPM_RESOURCES="platforms/macos/.build/apple/Products/Release/Irrlicht_Irrlicht.bundle"
-if [ ! -d "$SWIFTPM_RESOURCES" ]; then
-    SWIFTPM_RESOURCES=$(find platforms/macos/.build -name "Irrlicht_Irrlicht.bundle" -type d -not -path "*debug*" | head -1)
-fi
-if [ -z "$SWIFTPM_RESOURCES" ] || [ ! -d "$SWIFTPM_RESOURCES" ]; then
-    echo "ERROR: Could not find Irrlicht_Irrlicht.bundle in SwiftPM build output"
-    exit 1
-fi
-cp -R "$SWIFTPM_RESOURCES" "$APP_CONTENTS/Resources/Irrlicht_Irrlicht.bundle"
-
 # Embed daemon and CLI tools inside the app bundle (single-artifact distribution)
 cp "$BUILD_DIR/${DAEMON_NAME}-darwin-universal" "$APP_CONTENTS/MacOS/${DAEMON_NAME}"
 chmod 755 "$APP_CONTENTS/MacOS/${DAEMON_NAME}"
@@ -266,10 +253,6 @@ if [ -n "${DEVELOPER_ID:-}" ]; then
     echo "Signing app bundle with Developer ID..."
     SIGN_IDENTITY="Developer ID Application: ${DEVELOPER_ID}"
     sign_sparkle --sign "$SIGN_IDENTITY" --options runtime --timestamp
-    # Sign the SwiftPM resource bundle — Sequoia AMFI POSIX 153-kills the app
-    # at launch if any nested bundle under Contents/Resources is unsigned.
-    codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
-        "$APP_CONTENTS/Resources/Irrlicht_Irrlicht.bundle"
     codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
         "$APP_CONTENTS/MacOS/${DAEMON_NAME}"
     codesign --force --sign "$SIGN_IDENTITY" --options runtime --timestamp \
@@ -291,7 +274,6 @@ if [ -n "${DEVELOPER_ID:-}" ]; then
 else
     echo "Signing app bundle (ad-hoc — set DEVELOPER_ID to use Developer ID cert)..."
     sign_sparkle --sign -
-    codesign --force --sign - "$APP_CONTENTS/Resources/Irrlicht_Irrlicht.bundle"
     codesign --force --sign - "$APP_CONTENTS/MacOS/${DAEMON_NAME}"
     codesign --force --sign - "$APP_CONTENTS/MacOS/irrlicht-focus"
     codesign --force --sign - "$APP_CONTENTS/MacOS/irrlicht-ls"


### PR DESCRIPTION
## Summary
- `Bundle.module`'s SwiftPM-generated accessor only ever resolves via its compile-time absolute `buildPath` fallback — `mainPath` (`Bundle.main.bundleURL`, the app-bundle root) never matches where every build script actually copies `Irrlicht_Irrlicht.bundle` (`Contents/Resources/`). For `ir:test-mac`'s dev app this crashes the moment the worktree that built it is deleted (`buildPath` points inside that worktree's `.build/`) — reported as #844.
- The only use of `Bundle.module` in the whole app is looking up `AppIcon.icns`, which every build script already copies straight into `Contents/Resources/AppIcon.icns` independently — `Bundle.main` already finds it directly. So the SwiftPM resource-bundle mechanism is removable entirely rather than just relocating where the dev script copies it.
- Removed `resources: [.copy("Resources")]` from `Package.swift` (now `exclude: ["Resources"]` to silence SwiftPM's "unhandled files" warning), dropped the `Bundle.module` fallback in `IrrlichtApp.swift`, and deleted the now-dead `Irrlicht_Irrlicht.bundle` copy/codesign steps from `build-release.sh` and both `ir:test-mac`/`ir:release` skill docs (renumbering the release skill's manual-fallback steps to match).

## Test plan
- [x] `swift build` — succeeds, no `resource_bundle_accessor.swift` generated, no warnings
- [x] `swift test` — 206/206 tests pass (5 skipped, require `TEST_HARNESS=1`)
- [x] Manually assembled a `.app` bundle with **no** `Irrlicht_Irrlicht.bundle` at all and launched it — stays alive, no fatal error, no crash report (previously this exact scenario hard-crashed with `could not load resource bundle`)
- [x] `go build ./...` in `core/` — unaffected, still builds
- [x] `tools/preflight.sh` — all green except a pre-existing, unrelated flaky test (`TestDebounce_FirstEventFiresImmediately`, a timing test in `core/application/services`; confirmed unrelated by touching zero `.go` files and re-running it 5x in isolation, all passing)

Closes #844