### PR TITLE
fix(macos): recycle relay URLSession on wedged reconnect (#846)

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager+Relay.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Relay.swift
@@ -78,8 +78,16 @@ extension SessionManager {
     func startRelay() {
         guard relayConnectionState == .disconnected else { return }
         relayConnectionState = .connecting
-        relayReconnectDelay = 1.0
+        resetRelayConnectBackoff()
         scheduleRelayConnect(after: 0)
+    }
+
+    /// Clears backoff/failure state for a fresh relay connect cycle. Mirrors
+    /// `resetLocalConnectBackoff()` (#846).
+    func resetRelayConnectBackoff() {
+        relayReconnectDelay = 1.0
+        consecutiveRelayConnectFailures = 0
+        relayConnectionStalled = false
     }
 
     func stopRelay() {
@@ -88,6 +96,7 @@ extension SessionManager {
         relayWebSocketTask?.cancel(with: .normalClosure, reason: nil)
         relayWebSocketTask = nil
         relayConnectionState = .disconnected
+        relayConnectionStalled = false
         relayDaemons.removeAll()
         if !relaySessionMap.isEmpty {
             relaySessionMap.removeAll()
@@ -112,7 +121,7 @@ extension SessionManager {
             relayConnectionState = .disconnected
             return
         }
-        let task = URLSession.shared.webSocketTask(with: url)
+        let task = relayURLSession.webSocketTask(with: url)
         relayWebSocketTask = task
         task.resume()
         relayConnectionState = .connected
@@ -128,8 +137,8 @@ extension SessionManager {
             try? await task.send(.string(helloStr))
         }
 
+        var confirmed = false
         do {
-            var confirmed = false
             while !Task.isCancelled {
                 let message = try await task.receive()
                 // Reset the backoff only once the relay actually delivers a
@@ -138,7 +147,7 @@ extension SessionManager {
                 // reconnect loop against an unreachable relay.
                 if !confirmed {
                     confirmed = true
-                    relayReconnectDelay = 1.0
+                    recordConfirmedRelayConnect()
                 }
                 switch message {
                 case .string(let text):
@@ -151,6 +160,19 @@ extension SessionManager {
             }
         } catch {
             print("🔌 Relay disconnected: \(error.localizedDescription)")
+        }
+
+        // The cycle closed without ever confirming a frame — the same
+        // stuck-URLSession failure mode #843 fixed for the local daemon can
+        // strand the relay link the same way if `irrlichtrelay` restarts on
+        // the same host:port while a client is connected. Recycle
+        // `relayURLSession` once failures pile up rather than waiting on an
+        // app relaunch (#846). A 4401 (rejected token, handled below) isn't a
+        // wedged connection, so it doesn't count toward the streak.
+        if !confirmed && task.closeCode.rawValue != 4401 {
+            if recordFailedRelayConnectAttempt() {
+                print("🔌 Relay unreachable after repeated attempts — recreating URLSession")
+            }
         }
 
         // The link is down, so we no longer know the remote state: drop the
@@ -181,6 +203,32 @@ extension SessionManager {
         relayConnectionState = .reconnecting
         relayReconnectDelay = min(relayReconnectDelay * 2, maxReconnectDelay)
         scheduleRelayConnect(after: delay)
+    }
+
+    /// Applied once a relay reconnect attempt's WebSocket is confirmed alive
+    /// by an arrived frame. Mirrors `recordConfirmedLocalConnect()` for the
+    /// relay path (#846).
+    func recordConfirmedRelayConnect() {
+        relayReconnectDelay = 1.0
+        consecutiveRelayConnectFailures = 0
+        relayConnectionStalled = false
+    }
+
+    /// Applied once a relay reconnect attempt's cycle closes without ever
+    /// confirming a frame. Bumps the failure streak and, once it crosses
+    /// `relayConnectFailuresBeforeSessionRecycle`, recycles `relayURLSession`
+    /// and flags the connection as stalled. Returns whether it recycled, for
+    /// logging. Mirrors `recordFailedLocalConnectAttempt()` (#843) for the
+    /// relay path (#846).
+    @discardableResult
+    func recordFailedRelayConnectAttempt() -> Bool {
+        consecutiveRelayConnectFailures += 1
+        guard consecutiveRelayConnectFailures >= relayConnectFailuresBeforeSessionRecycle else { return false }
+        relayURLSession.invalidateAndCancel()
+        relayURLSession = URLSession(configuration: .ephemeral)
+        consecutiveRelayConnectFailures = 0
+        relayConnectionStalled = true
+        return true
     }
 
     /// Normalizes a user-entered relay address into a ws(s):// stream URL.
@@ -344,7 +392,8 @@ extension SessionManager {
                     lines.append("\(label) — connected")
                 }
             } else {
-                lines.append("\(relayServerURL) — \(relayConnectionState.shortLabel)")
+                let stalledSuffix = relayConnectionStalled ? " (relay unreachable — retrying)" : ""
+                lines.append("\(relayServerURL) — \(relayConnectionState.shortLabel)\(stalledSuffix)")
             }
         }
         return lines.isEmpty ? connectionState.tooltip : lines.joined(separator: "\n")

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -173,6 +173,23 @@ class SessionManager: ObservableObject {
     var relayConnectTask: Task<Void, Never>?
     var relayReconnectDelay: TimeInterval = 1.0
     @Published var relayConnectionState: ConnectionState = .disconnected
+    /// Dedicated session for relay traffic, mirroring `localURLSession`: a
+    /// standalone `irrlichtrelay` restarting on the same port can wedge
+    /// `URLSession.shared` the same way a restarted local daemon could (#843),
+    /// so the relay path gets its own recyclable instance too (#846).
+    /// `URLSession.shared` stays in use elsewhere (ActivationClient,
+    /// BackchannelRulesClient, PublishClient, HistoryView) for one-off calls
+    /// unrelated to this reconnect loop.
+    var relayURLSession = URLSession(configuration: .ephemeral)
+    /// Consecutive relay-connect cycles that never got a single frame back
+    /// from the relay. Reset on any confirmed message.
+    var consecutiveRelayConnectFailures = 0
+    /// After this many consecutive failures, recycle `relayURLSession` (#846).
+    let relayConnectFailuresBeforeSessionRecycle = 3
+    /// True once a `relayURLSession` recycle hasn't yet been followed by a
+    /// confirmed reconnect — surfaces alongside `localConnectionStalled` in
+    /// the connection tooltip (#846).
+    @Published var relayConnectionStalled = false
     /// Relay-sourced sessions, keyed by session id.
     var relaySessionMap: [String: SessionState] = [:]
     /// Daemons the relay reports connected: daemon_id → label, for the tooltip.

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1124,15 +1124,20 @@ struct SessionListView: View {
 
     private var statusColor: Color {
         let aggregate = sessionManager.aggregateConnectionState
-        // A stalled local reconnect (#843) is a more severe signal than an
-        // ordinary transient "reconnecting" blip — flag it red rather than
-        // yellow even though the auto-retry loop is still quietly running.
-        // Only when it isn't masked by another healthy source, though — a
-        // relay connection can be carrying the session list just fine while
-        // the local daemon link is stuck, and the aggregate already reports
-        // that (`.connected` wins in `aggregateConnectionState`).
-        if aggregate != .connected && sessionManager.useLocalDaemon && sessionManager.localConnectionStalled {
-            return IrrColors.wsDisconnected
+        // A stalled reconnect — local (#843) or relay (#846) — is a more
+        // severe signal than an ordinary transient "reconnecting" blip —
+        // flag it red rather than yellow even though the auto-retry loop is
+        // still quietly running. Only when it isn't masked by another
+        // healthy source, though — the other connection can be carrying the
+        // session list just fine while this one is stuck, and the aggregate
+        // already reports that (`.connected` wins in `aggregateConnectionState`).
+        if aggregate != .connected {
+            if sessionManager.useLocalDaemon && sessionManager.localConnectionStalled {
+                return IrrColors.wsDisconnected
+            }
+            if sessionManager.useRelayServer && !sessionManager.relayServerURL.isEmpty && sessionManager.relayConnectionStalled {
+                return IrrColors.wsDisconnected
+            }
         }
         switch aggregate {
         case .connected: return IrrColors.wsConnected

--- a/platforms/macos/Tests/SessionManagerRelayReconnectTests.swift
+++ b/platforms/macos/Tests/SessionManagerRelayReconnectTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import Irrlicht
+import Foundation
+
+/// Regression coverage for #846: the relay reconnect loop dialed out on the
+/// never-recycled `URLSession.shared`, so a standalone `irrlichtrelay`
+/// restarting on the same host:port could wedge the connection the same way
+/// a restarted local daemon did before #843 — see
+/// `SessionManagerReconnectTests` for that story. This mirrors those tests
+/// for the relay path's own dedicated `relayURLSession`.
+@MainActor
+final class SessionManagerRelayReconnectTests: XCTestCase {
+    private var sut: SessionManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        sut = SessionManager()
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        try await super.tearDown()
+    }
+
+    func testRecordConfirmedRelayConnect_resetsBackoffAndFailureState() {
+        sut.relayReconnectDelay = 16.0
+        sut.consecutiveRelayConnectFailures = 2
+        sut.relayConnectionStalled = true
+
+        sut.recordConfirmedRelayConnect()
+
+        XCTAssertEqual(sut.relayReconnectDelay, 1.0,
+                       "a confirmed connect must reset the backoff for the next disconnect")
+        XCTAssertEqual(sut.consecutiveRelayConnectFailures, 0)
+        XCTAssertFalse(sut.relayConnectionStalled)
+    }
+
+    func testRecordFailedRelayConnectAttempt_doesNotRecycleBeforeThreshold() {
+        let originalSession = sut.relayURLSession
+
+        for _ in 0..<(sut.relayConnectFailuresBeforeSessionRecycle - 1) {
+            XCTAssertFalse(sut.recordFailedRelayConnectAttempt())
+        }
+
+        XCTAssertFalse(sut.relayConnectionStalled, "must not surface stalled before the threshold")
+        XCTAssertTrue(sut.relayURLSession === originalSession, "session must survive isolated blips")
+    }
+
+    func testRecordFailedRelayConnectAttempt_recyclesSessionAtThreshold() {
+        let originalSession = sut.relayURLSession
+
+        for _ in 0..<(sut.relayConnectFailuresBeforeSessionRecycle - 1) {
+            sut.recordFailedRelayConnectAttempt()
+        }
+        let recycled = sut.recordFailedRelayConnectAttempt()
+
+        XCTAssertTrue(recycled, "the Nth consecutive failure must trigger a recycle")
+        XCTAssertTrue(sut.relayConnectionStalled, "a recycle surfaces as stalled for the UI")
+        XCTAssertFalse(sut.relayURLSession === originalSession,
+                       "a stuck relay URLSession must be discarded, not reused (#846)")
+        XCTAssertEqual(sut.consecutiveRelayConnectFailures, 0, "the streak resets after recycling")
+    }
+
+    func testResetRelayConnectBackoff_clearsStaleFailureState() {
+        sut.relayReconnectDelay = 8.0
+        sut.consecutiveRelayConnectFailures = sut.relayConnectFailuresBeforeSessionRecycle
+        sut.relayConnectionStalled = true
+
+        sut.resetRelayConnectBackoff()
+
+        XCTAssertEqual(sut.relayReconnectDelay, 1.0)
+        XCTAssertEqual(sut.consecutiveRelayConnectFailures, 0)
+        XCTAssertFalse(sut.relayConnectionStalled)
+    }
+
+    func testStopRelay_clearsStalledFlag() {
+        sut.relayConnectionStalled = true
+
+        sut.stopRelay()
+
+        XCTAssertFalse(sut.relayConnectionStalled)
+    }
+}


### PR DESCRIPTION
## Summary
- `relayConnect()` dialed the relay's WebSocket on the never-recycled `URLSession.shared`, so a standalone `irrlichtrelay` restarting on the same host:port could wedge the connection the same way a restarted local daemon did before #843.
- Gives the relay path its own dedicated `relayURLSession`, recycled after `relayConnectFailuresBeforeSessionRecycle` (3) consecutive failed connect cycles — mirrors `recordFailedLocalConnectAttempt()`/`recordConfirmedLocalConnect()` from #843.
- Surfaces a stalled relay recycle in the connection tooltip and the header status dot, mirroring the existing `localConnectionStalled` treatment.

Closes #846.

## Test plan
- [x] `swift test` — 217 tests pass, including new `SessionManagerRelayReconnectTests` (confirm/fail/backoff-reset/stop mirrors of the existing local-daemon reconnect tests)
- [x] `tools/preflight.sh` (via pre-push hook) — all gates pass