### PR TITLE
fix(daemon): reap subagents whose transcript was deleted out from under them

### DIFF
--- a/core/application/services/helpers.go
+++ b/core/application/services/helpers.go
@@ -28,6 +28,13 @@ func isDBBackedTranscriptPath(path string) bool {
 // isStaleTranscript reports whether the transcript file at path has not been
 // modified within orphanTranscriptAge. Returns false for empty paths, stat
 // errors, or DB-backed paths (whose staleness is managed by the adapter).
+//
+// A missing file deliberately returns false here rather than true: plenty of
+// legitimate sessions (freshly created, or ones built directly as test
+// fixtures) reference a transcript path that doesn't exist on disk yet, and
+// treating that the same as "definitely gone" would delete them on sight. See
+// isDeletedTranscript for the narrower, age-gated check that does treat a
+// missing file as an orphan signal.
 func isStaleTranscript(path string) bool {
 	if path == "" || isDBBackedTranscriptPath(path) {
 		return false
@@ -37,6 +44,21 @@ func isStaleTranscript(path string) bool {
 		return false
 	}
 	return time.Since(info.ModTime()) > orphanTranscriptAge
+}
+
+// isDeletedTranscript reports whether the transcript file at path is
+// confirmed gone (os.IsNotExist) rather than merely old or never-yet-written.
+// Distinct from isStaleTranscript's mtime check: a file that once existed and
+// has now been deleted outright (e.g. its worktree was torn down) is a
+// stronger, unambiguous orphan signal — but on its own it can't distinguish
+// "deleted" from "not created yet", so callers must additionally gate on the
+// session's own age (see reapStaleChild) before treating it as fatal.
+func isDeletedTranscript(path string) bool {
+	if path == "" || isDBBackedTranscriptPath(path) {
+		return false
+	}
+	_, err := os.Stat(path)
+	return os.IsNotExist(err)
 }
 
 // isNewestTranscriptInDir reports whether the transcript at path has the

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -956,17 +956,28 @@ func (pm *PIDManager) sweepStaleSnapshot(snap livenessSnapshot) {
 }
 
 // reapStaleChild deletes snap when it's a finished or zombie subagent (ready,
-// or its transcript stopped updating) and notifies onChildDeleted so the
-// parent — which may have been held in `working` solely because of this
-// child — gets re-evaluated. Without that nudge the parent stays stuck until
-// its own next transcript event, which may never come for a finished
-// session. DB-backed adapters are exempt: they manage their own subagent
-// lifetime via maxAge.
+// its transcript stopped updating, or its transcript is confirmed deleted)
+// and notifies onChildDeleted so the parent — which may have been held in
+// `working` solely because of this child — gets re-evaluated. Without that
+// nudge the parent stays stuck until its own next transcript event, which may
+// never come for a finished session. DB-backed adapters are exempt: they
+// manage their own subagent lifetime via maxAge.
 func (pm *PIDManager) reapStaleChild(snap livenessSnapshot) {
 	if strings.Contains(snap.transcriptPath, "?session=") {
 		return
 	}
-	if snap.sessionState != session.StateReady && !isStaleTranscript(snap.transcriptPath) {
+	// A subagent whose transcript has been deleted outright (its worktree
+	// was torn down mid-run, or similar) is orphaned regardless of its own
+	// State or inherited PID — subagents share their parent's PID rather than
+	// owning one, so a live PID proves nothing about this specific child, and
+	// the sweep is its only backstop (see the comment on isStartupZombie).
+	// isDeletedTranscript can't tell "deleted" apart from "not written yet",
+	// so it's only trusted once the child has existed for orphanTranscriptAge
+	// — long past any normal spawn-to-first-write race.
+	transcriptGone := isStaleTranscript(snap.transcriptPath) ||
+		(isDeletedTranscript(snap.transcriptPath) &&
+			time.Since(time.Unix(snap.state.FirstSeen, 0)) > orphanTranscriptAge)
+	if snap.sessionState != session.StateReady && !transcriptGone {
 		return
 	}
 	reason := "child ready — liveness sweep"

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -198,6 +198,74 @@ func TestCheckPIDLiveness_StaleTranscript_Deleted(t *testing.T) {
 	}
 }
 
+// TestCheckPIDLiveness_ChildTranscriptDeleted_Reaped guards against a ghost
+// subagent surviving forever once its backing transcript file has been
+// deleted outright (e.g. its worktree was torn down mid-run), rather than
+// merely gone stale. Before this fix, reapStaleChild only checked
+// isStaleTranscript, which passes a missing file straight through as "not
+// stale" (os.Stat's error is indistinguishable from "not old enough yet"), so
+// a working child whose transcript no longer exists at all was never reaped —
+// it isn't Ready, and isStaleTranscript never returned true for it. The
+// child's own PID is alive (subagents inherit their parent's PID rather than
+// owning one — see the comment on isStartupZombie), so seed-time PID-liveness
+// checks can't catch it either; this periodic sweep is the only backstop, and
+// its parent ("long-gone-parent") is already gone from the repo, matching the
+// observed production case. FirstSeen is set well beyond orphanTranscriptAge
+// so the fresh-session grace period (see the sibling NotYetWritten test)
+// doesn't shield it.
+func TestCheckPIDLiveness_ChildTranscriptDeleted_Reaped(t *testing.T) {
+	tmp := t.TempDir()
+	deletedTranscript := filepath.Join(tmp, "never-created", "agent-orphan.jsonl")
+
+	repo := newMockRepo()
+	repo.states["agent-orphan"] = &session.SessionState{
+		SessionID:       "agent-orphan",
+		Adapter:         "claude-code",
+		State:           session.StateWorking,
+		ParentSessionID: "long-gone-parent",
+		PID:             os.Getpid(), // alive, but inherited — not its own process
+		TranscriptPath:  deletedTranscript,
+		FirstSeen:       time.Now().Add(-10 * time.Minute).Unix(),
+		UpdatedAt:       time.Now().Unix(),
+	}
+
+	newPIDManagerForTest(repo).CheckPIDLiveness()
+
+	if repo.states["agent-orphan"] != nil {
+		t.Fatal("child session whose transcript file no longer exists at all should be reaped, not kept forever")
+	}
+}
+
+// TestCheckPIDLiveness_ChildTranscriptNotYetWritten_Kept is the safety
+// counterpart: a child created moments ago, whose transcript file hasn't been
+// written yet, must NOT be reaped just because the path doesn't exist —
+// isDeletedTranscript can't tell "deleted" apart from "not created yet", so
+// reapStaleChild only trusts it once the child is older than
+// orphanTranscriptAge. Without this guard a normal spawn-to-first-write race
+// would delete brand-new subagents.
+func TestCheckPIDLiveness_ChildTranscriptNotYetWritten_Kept(t *testing.T) {
+	tmp := t.TempDir()
+	notYetWritten := filepath.Join(tmp, "not-yet-written", "agent-fresh.jsonl")
+
+	repo := newMockRepo()
+	repo.states["agent-fresh"] = &session.SessionState{
+		SessionID:       "agent-fresh",
+		Adapter:         "claude-code",
+		State:           session.StateWorking,
+		ParentSessionID: "parent",
+		PID:             os.Getpid(),
+		TranscriptPath:  notYetWritten,
+		FirstSeen:       time.Now().Unix(),
+		UpdatedAt:       time.Now().Unix(),
+	}
+
+	newPIDManagerForTest(repo).CheckPIDLiveness()
+
+	if repo.states["agent-fresh"] == nil {
+		t.Fatal("freshly created child whose transcript hasn't been written yet must not be reaped")
+	}
+}
+
 // TestCheckPIDLiveness_DeadProcessWorking_Reaped guards the end-state the #667
 // fix relies on: once UpdatedAt is allowed to age (the activity bump no longer
 // refreshes it on no-op refresh passes), a working session with pid=0 whose

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -266,6 +266,68 @@ func TestCheckPIDLiveness_ChildTranscriptNotYetWritten_Kept(t *testing.T) {
 	}
 }
 
+// orphanTranscriptAgeForTest mirrors the unexported orphanTranscriptAge
+// constant (core/application/services/session_detector.go) so the boundary
+// tests below track it instead of hardcoding a value that could silently
+// drift out of sync with the real threshold.
+const orphanTranscriptAgeForTest = 2 * time.Minute
+
+// TestCheckPIDLiveness_ChildTranscriptDeleted_JustUnderGracePeriod_Kept pins
+// down the shield's edge from the "still protected" side: a child just
+// *inside* the grace period, with its transcript already gone, must still be
+// kept — isDeletedTranscript alone can't distinguish "deleted" from "not
+// created yet", so the FirstSeen age gate is the only thing standing between
+// this case and TestCheckPIDLiveness_ChildTranscriptNotYetWritten_Kept's.
+func TestCheckPIDLiveness_ChildTranscriptDeleted_JustUnderGracePeriod_Kept(t *testing.T) {
+	tmp := t.TempDir()
+	deletedTranscript := filepath.Join(tmp, "never-created", "agent-borderline.jsonl")
+
+	repo := newMockRepo()
+	repo.states["agent-borderline"] = &session.SessionState{
+		SessionID:       "agent-borderline",
+		Adapter:         "claude-code",
+		State:           session.StateWorking,
+		ParentSessionID: "parent",
+		PID:             os.Getpid(),
+		TranscriptPath:  deletedTranscript,
+		FirstSeen:       time.Now().Add(-orphanTranscriptAgeForTest + 10*time.Second).Unix(),
+		UpdatedAt:       time.Now().Unix(),
+	}
+
+	newPIDManagerForTest(repo).CheckPIDLiveness()
+
+	if repo.states["agent-borderline"] == nil {
+		t.Fatal("child just inside the grace period should still be shielded, even with a missing transcript")
+	}
+}
+
+// TestCheckPIDLiveness_ChildTranscriptDeleted_JustOverGracePeriod_Reaped is
+// the other edge: once the child ages past the grace period, a missing
+// transcript stops being ambiguous and the shield must release it on the
+// very next sweep tick.
+func TestCheckPIDLiveness_ChildTranscriptDeleted_JustOverGracePeriod_Reaped(t *testing.T) {
+	tmp := t.TempDir()
+	deletedTranscript := filepath.Join(tmp, "never-created", "agent-expired.jsonl")
+
+	repo := newMockRepo()
+	repo.states["agent-expired"] = &session.SessionState{
+		SessionID:       "agent-expired",
+		Adapter:         "claude-code",
+		State:           session.StateWorking,
+		ParentSessionID: "parent",
+		PID:             os.Getpid(),
+		TranscriptPath:  deletedTranscript,
+		FirstSeen:       time.Now().Add(-orphanTranscriptAgeForTest - 10*time.Second).Unix(),
+		UpdatedAt:       time.Now().Unix(),
+	}
+
+	newPIDManagerForTest(repo).CheckPIDLiveness()
+
+	if repo.states["agent-expired"] != nil {
+		t.Fatal("child just past the grace period with a missing transcript should be reaped")
+	}
+}
+
 // TestCheckPIDLiveness_DeadProcessWorking_Reaped guards the end-state the #667
 // fix relies on: once UpdatedAt is allowed to age (the activity bump no longer
 // refreshes it on no-op refresh passes), a working session with pid=0 whose


### PR DESCRIPTION
## Summary
- A subagent's PID is inherited from its parent process rather than its own (subagents run inside the parent, not as a separate process) — so once the parent exits and that PID gets reused by an unrelated process, PID-liveness checks can never tell the orphaned subagent is dead.
- The periodic sweep's only other backstop, `reapStaleChild`, checked `isStaleTranscript`, which treats a transcript file that's been deleted outright the same as "hasn't gone stale yet" (an `os.Stat` error was silently passed through as `false`). Combined with the PID issue above, a subagent whose worktree was torn down mid-run could survive forever, showing up as a phantom top-level session once its parent also dropped out of the tracked set.
- Adds `isDeletedTranscript` (confirmed-gone via `os.IsNotExist`, distinct from "not written yet") and wires it into `reapStaleChild`, gated on the child being older than `orphanTranscriptAge` via `FirstSeen` so a freshly-spawned subagent isn't mistaken for an orphan before its transcript exists.

## Test plan
- [x] `TestCheckPIDLiveness_ChildTranscriptDeleted_Reaped` — reproduces the production case; fails without the fix, passes with it
- [x] `TestCheckPIDLiveness_ChildTranscriptNotYetWritten_Kept` — safety counterpart guarding the fresh-session grace period
- [x] `go test ./core/... -race -count=1` — full suite green (re-ran multiple times; the services package has a pre-existing `-race` timing flake unrelated to this change, reproduced identically on `main`)
- [x] `go vet`, `gofmt` clean; architecture gate (`TestArchitecture`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)