### PR TITLE
chore: refresh agent landscape (2026-07-05)

### DIFF
--- a/.claude/skills/ir:agent-landscape/references/agent-data.json
+++ b/.claude/skills/ir:agent-landscape/references/agent-data.json
@@ -1,13 +1,13 @@
 {
-  "last_updated": "2026-05-31",
+  "last_updated": "2026-07-05",
   "agents": [
     {
       "name": "Claw Code",
       "github_repo": "ultraworkers/claw-code",
       "category": "agent",
       "website": "https://github.com/ultraworkers/claw-code",
-      "description": "Rust CLI agent harness that wraps Claude via the Anthropic API; star count inflated by viral self-promotion in the README (\"fastest repo to 100K stars\").",
-      "stars": 191505,
+      "description": "An agent-managed museum exhibit, built in Rust with Gajae-Code / LazyCodex — developed and maintained with no human intervention.",
+      "stars": 194570,
       "language": "Rust",
       "license": "MIT",
       "interface": "CLI",
@@ -16,6 +16,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 194570
+        },
         {
           "date": "2026-05-15",
           "stars": 191505
@@ -36,7 +40,7 @@
       "category": "agent",
       "website": "https://opencode.ai",
       "description": "The open source coding agent.",
-      "stars": 160573,
+      "stars": 182478,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "CLI",
@@ -45,6 +49,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 182478
+        },
         {
           "date": "2026-05-15",
           "stars": 160573
@@ -65,8 +73,8 @@
       "category": "agent",
       "website": "https://www.anthropic.com/claude-code",
       "description": "Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands.",
-      "stars": 123761,
-      "language": "Shell",
+      "stars": 136132,
+      "language": "Python",
       "license": null,
       "interface": "CLI",
       "pricing": "Paid (usage-based)",
@@ -74,6 +82,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 136132
+        },
         {
           "date": "2026-05-15",
           "stars": 123761
@@ -94,15 +106,19 @@
       "category": "agent",
       "website": "https://github.com/google-gemini/gemini-cli",
       "description": "An open-source AI agent that brings the power of Gemini directly into your terminal.",
-      "stars": 104022,
+      "stars": 105752,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "CLI",
       "pricing": "Free (open source)",
-      "irrlicht_support": "planned",
+      "irrlicht_support": "live",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 105752
+        },
         {
           "date": "2026-05-15",
           "stars": 104022
@@ -123,7 +139,7 @@
       "category": "agent",
       "website": "https://github.com/openai/codex",
       "description": "Lightweight coding agent that runs in your terminal",
-      "stars": 82811,
+      "stars": 95588,
       "language": "Rust",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -132,6 +148,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 95588
+        },
         {
           "date": "2026-05-15",
           "stars": 82811
@@ -152,7 +172,7 @@
       "category": "agent",
       "website": "https://github.com/OpenHands/OpenHands",
       "description": "🙌 OpenHands: AI-Driven Development",
-      "stars": 73613,
+      "stars": 79471,
       "language": "Python",
       "license": "NOASSERTION",
       "interface": "CLI / Web",
@@ -161,6 +181,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 79471
+        },
         {
           "date": "2026-05-15",
           "stars": 73613
@@ -176,12 +200,45 @@
       ]
     },
     {
+      "name": "Pi",
+      "github_repo": "earendil-works/pi",
+      "category": "agent",
+      "website": "https://github.com/earendil-works/pi",
+      "description": "AI agent toolkit: unified LLM API, agent loop, TUI, coding agent CLI",
+      "stars": 67727,
+      "language": "TypeScript",
+      "license": "MIT",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "live",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 67727
+        },
+        {
+          "date": "2026-05-15",
+          "stars": 49664
+        },
+        {
+          "date": "2026-04-24",
+          "stars": 39373
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 34689
+        }
+      ]
+    },
+    {
       "name": "Cline",
       "github_repo": "cline/cline",
       "category": "agent",
       "website": "https://cline.bot",
       "description": "Autonomous coding agent as an SDK, IDE extension, or CLI assistant.",
-      "stars": 61809,
+      "stars": 64294,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "IDE extension (VS Code)",
@@ -190,6 +247,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 64294
+        },
         {
           "date": "2026-05-15",
           "stars": 61809
@@ -210,7 +271,7 @@
       "category": "agent",
       "website": "https://www.warp.dev",
       "description": "Warp is an agentic development environment, born out of the terminal.",
-      "stars": 58530,
+      "stars": 62818,
       "language": "Rust",
       "license": "AGPL-3.0",
       "interface": "Desktop app (Terminal)",
@@ -219,6 +280,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 62818
+        },
         {
           "date": "2026-05-15",
           "stars": 58530
@@ -234,41 +299,12 @@
       ]
     },
     {
-      "name": "Pi",
-      "github_repo": "earendil-works/pi",
-      "category": "agent",
-      "website": "https://github.com/badlogic/pi-mono",
-      "description": "Mario Zechner's AI agent toolkit (CLI coding agent, unified LLM API, TUI/web libraries, Slack bot, vLLM pods); repo and `@earendil-works/*` packages moved to `earendil-works/pi` in v0.74.",
-      "stars": 49664,
-      "language": "TypeScript",
-      "license": "MIT",
-      "interface": "CLI",
-      "pricing": "Free (open source)",
-      "irrlicht_support": "live",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {
-          "date": "2026-05-15",
-          "stars": 49664
-        },
-        {
-          "date": "2026-04-24",
-          "stars": 39373
-        },
-        {
-          "date": "2026-04-12",
-          "stars": 34689
-        }
-      ]
-    },
-    {
       "name": "Goose",
       "github_repo": "aaif-goose/goose",
       "category": "agent",
       "website": "https://block.github.io/goose/",
-      "description": "Extensible open-source agent (install/execute/edit/test with any LLM); originated at Block before transfer to the `aaif-goose` org.",
-      "stars": 45230,
+      "description": "an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM",
+      "stars": 50663,
       "language": "Rust",
       "license": "Apache-2.0",
       "interface": "CLI / Desktop app",
@@ -277,6 +313,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 50663
+        },
         {
           "date": "2026-05-15",
           "stars": 45230
@@ -297,7 +337,7 @@
       "category": "agent",
       "website": "https://aider.chat",
       "description": "aider is AI pair programming in your terminal",
-      "stars": 44842,
+      "stars": 47065,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -306,6 +346,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 47065
+        },
         {
           "date": "2026-05-15",
           "stars": 44842
@@ -325,8 +369,8 @@
       "github_repo": "continuedev/continue",
       "category": "agent",
       "website": "https://continue.dev",
-      "description": "⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI",
-      "stars": 33196,
+      "description": "open-source coding agent",
+      "stars": 34690,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "IDE extension / CLI",
@@ -335,6 +379,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 34690
+        },
         {
           "date": "2026-05-15",
           "stars": 33196
@@ -355,7 +403,7 @@
       "category": "agent",
       "website": "https://cursor.com",
       "description": "Proprietary AI-first code editor (the GitHub repo hosts issues only; editor source is closed).",
-      "stars": 32875,
+      "stars": 33006,
       "language": null,
       "license": null,
       "interface": "Desktop app (IDE)",
@@ -364,6 +412,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 33006
+        },
         {
           "date": "2026-05-15",
           "stars": 32875
@@ -379,70 +431,12 @@
       ]
     },
     {
-      "name": "Void",
-      "github_repo": "voideditor/void",
-      "category": "agent",
-      "website": "https://voideditor.com",
-      "description": "Open-source AI code editor (VS Code fork).",
-      "stars": 28752,
-      "language": "TypeScript",
-      "license": "Apache-2.0",
-      "interface": "Desktop app (IDE)",
-      "pricing": "Free (open source)",
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {
-          "date": "2026-05-15",
-          "stars": 28752
-        },
-        {
-          "date": "2026-04-24",
-          "stars": 28644
-        },
-        {
-          "date": "2026-04-12",
-          "stars": 28553
-        }
-      ]
-    },
-    {
-      "name": "Qwen Code",
-      "github_repo": "QwenLM/qwen-code",
-      "category": "agent",
-      "website": "https://qwen.ai/qwencode",
-      "description": "An open-source AI agent that lives in your terminal.",
-      "stars": 24401,
-      "language": "TypeScript",
-      "license": "Apache-2.0",
-      "interface": "CLI",
-      "pricing": "Free (open source)",
-      "irrlicht_support": "planned",
-      "first_seen": "2026-04-10",
-      "alternative_metrics": null,
-      "stars_history": [
-        {
-          "date": "2026-05-15",
-          "stars": 24401
-        },
-        {
-          "date": "2026-04-24",
-          "stars": 23813
-        },
-        {
-          "date": "2026-04-12",
-          "stars": 22823
-        }
-      ]
-    },
-    {
       "name": "Crush",
       "github_repo": "charmbracelet/crush",
       "category": "agent",
       "website": "https://charm.land/crush",
       "description": "Glamourous agentic coding for all 💘",
-      "stars": 24298,
+      "stars": 26077,
       "language": "Go",
       "license": "NOASSERTION",
       "interface": "CLI",
@@ -451,6 +445,10 @@
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 26077
+        },
         {
           "date": "2026-05-15",
           "stars": 24298
@@ -466,31 +464,35 @@
       ]
     },
     {
-      "name": "Roo Code",
-      "github_repo": "RooCodeInc/Roo-Code",
+      "name": "Qwen Code",
+      "github_repo": "QwenLM/qwen-code",
       "category": "agent",
-      "website": "https://roocode.com",
-      "description": "Roo Code gives you a whole dev team of AI agents in your code editor.",
-      "stars": 24073,
+      "website": "https://qwen.ai/qwencode",
+      "description": "An open-source AI coding agent that lives in your terminal.",
+      "stars": 25787,
       "language": "TypeScript",
       "license": "Apache-2.0",
-      "interface": "IDE extension (VS Code)",
+      "interface": "CLI",
       "pricing": "Free (open source)",
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
+      "irrlicht_support": "planned",
+      "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
         {
+          "date": "2026-07-05",
+          "stars": 25787
+        },
+        {
           "date": "2026-05-15",
-          "stars": 24073
+          "stars": 24401
         },
         {
           "date": "2026-04-24",
-          "stars": 23345
+          "stars": 23813
         },
         {
           "date": "2026-04-12",
-          "stars": 23088
+          "stars": 22823
         }
       ]
     },
@@ -500,7 +502,7 @@
       "category": "agent",
       "website": "https://kilo.ai",
       "description": "Kilo is the all-in-one agentic engineering platform. Build, ship, and iterate faster with the most popular open source coding agent.",
-      "stars": 19304,
+      "stars": 25591,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "IDE extension / CLI",
@@ -509,6 +511,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 25591
+        },
         {
           "date": "2026-05-15",
           "stars": 19304
@@ -529,7 +535,7 @@
       "category": "agent",
       "website": "https://swe-agent.com",
       "description": "SWE-agent takes a GitHub issue and tries to automatically fix it, using your LM of choice. It can also be employed for offensive cybersecurity or competitive coding challenges. [NeurIPS 2024]",
-      "stars": 19225,
+      "stars": 19705,
       "language": "Python",
       "license": "MIT",
       "interface": "CLI",
@@ -538,6 +544,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 19705
+        },
         {
           "date": "2026-05-15",
           "stars": 19225
@@ -558,7 +568,7 @@
       "category": "agent",
       "website": "https://plandex.ai",
       "description": "Open source AI coding agent. Designed for large projects and real world tasks.",
-      "stars": 15365,
+      "stars": 15502,
       "language": "Go",
       "license": "MIT",
       "interface": "CLI",
@@ -567,6 +577,10 @@
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 15502
+        },
         {
           "date": "2026-05-15",
           "stars": 15365
@@ -587,7 +601,7 @@
       "category": "agent",
       "website": "https://github.com/langchain-ai/open-swe",
       "description": "An Open-Source Asynchronous Coding Agent",
-      "stars": 9802,
+      "stars": 10103,
       "language": "Python",
       "license": "MIT",
       "interface": "Web",
@@ -596,6 +610,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 10103
+        },
         {
           "date": "2026-05-15",
           "stars": 9802
@@ -616,7 +634,7 @@
       "category": "agent",
       "website": "https://sweep.dev",
       "description": "Sweep: AI coding assistant for JetBrains",
-      "stars": 7713,
+      "stars": 7700,
       "language": "Jupyter Notebook",
       "license": "NOASSERTION",
       "interface": "IDE extension (JetBrains)",
@@ -625,6 +643,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 7700
+        },
         {
           "date": "2026-05-15",
           "stars": 7713
@@ -645,7 +667,7 @@
       "category": "agent",
       "website": "https://forgecode.dev",
       "description": "AI enabled pair programmer for Claude, GPT, O Series, Grok, Deepseek, Gemini and 300+ models",
-      "stars": 7295,
+      "stars": 7445,
       "language": "Rust",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -654,6 +676,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 7445
+        },
         {
           "date": "2026-05-15",
           "stars": 7295
@@ -669,12 +695,33 @@
       ]
     },
     {
+      "name": "Kiro",
+      "github_repo": "kirodotdev/Kiro",
+      "category": "agent",
+      "website": "https://kiro.dev",
+      "description": "Kiro is an agentic IDE that works alongside you from prototype to production.",
+      "stars": 3965,
+      "language": "TypeScript",
+      "license": null,
+      "interface": "Desktop app (IDE) / CLI",
+      "pricing": "Freemium",
+      "irrlicht_support": "live",
+      "first_seen": "2026-04-10",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 3965
+        }
+      ]
+    },
+    {
       "name": "RA.Aid",
       "github_repo": "ai-christianson/RA.Aid",
       "category": "agent",
       "website": "https://www.ra-aid.ai",
       "description": "Develop software autonomously.",
-      "stars": 2224,
+      "stars": 2223,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -683,6 +730,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 2223
+        },
         {
           "date": "2026-05-15",
           "stars": 2224
@@ -703,7 +754,7 @@
       "category": "agent",
       "website": "https://www.factory.ai",
       "description": "Factory - Agent-Native Software Development",
-      "stars": 876,
+      "stars": 1007,
       "language": null,
       "license": null,
       "interface": "Web / CLI",
@@ -712,6 +763,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 1007
+        },
         {
           "date": "2026-05-15",
           "stars": 876
@@ -732,7 +787,7 @@
       "category": "agent",
       "website": "https://trypear.ai",
       "description": "PearAI: Open Source AI Code Editor (Fork of VSCode). The PearAI Submodule (https://github.com/trypear/pearai-submodule) is a fork of Continue.",
-      "stars": 689,
+      "stars": 703,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "Desktop app (IDE)",
@@ -741,6 +796,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 703
+        },
         {
           "date": "2026-05-15",
           "stars": 689
@@ -761,7 +820,7 @@
       "category": "agent",
       "website": "https://codegen.com",
       "description": "Python wrapper for the Codegen API - run code agents at scale",
-      "stars": 521,
+      "stars": 519,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "SDK / Web",
@@ -770,6 +829,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 519
+        },
         {
           "date": "2026-05-15",
           "stars": 521
@@ -785,30 +848,11 @@
       ]
     },
     {
-      "name": "Antigravity",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://antigravity.google/product/antigravity-cli",
-      "description": "Google's Go-based agent-first development platform with a terminal CLI; replaced Gemini CLI on 2026-05-19 (Gemini CLI requests stop 2026-06-18). Distributed as a closed binary via install script.",
-      "stars": null,
-      "language": null,
-      "license": null,
-      "interface": "Desktop app (IDE) / CLI",
-      "pricing": "Freemium",
-      "irrlicht_support": "none",
-      "first_seen": "2026-05-31",
-      "alternative_metrics": {
-        "source": "Google I/O 2026; Google Developers Blog 'Transitioning Gemini CLI to Antigravity CLI'; no independent funding/user data",
-        "measured_date": "2026-05-31"
-      },
-      "stars_history": []
-    },
-    {
       "name": "Amazon Q Developer",
       "github_repo": null,
       "category": "agent",
       "website": "https://aws.amazon.com/q/developer/",
-      "description": "AWS's AI coding assistant (completions, transformations, agentic refactors).",
+      "description": "AWS's AI coding assistant (completions, transformations, agentic refactors). AWS announced IDE plugins and paid subscriptions are being sunset (new signups blocked 2026-05-15, end of support 2027-04-30), superseded by Kiro.",
       "stars": null,
       "language": null,
       "license": null,
@@ -817,8 +861,8 @@
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "source": "AWS product; no independent user/funding disclosures",
-        "measured_date": "2026-04-24"
+        "source": "AWS DevOps Blog, 'Amazon Q Developer end-of-support announcement', 2026-04-30",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -836,8 +880,27 @@
       "irrlicht_support": "planned",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "source": "Amp spin-out announcement (Q1 2026); inherits Sourcegraph Cody lineage",
-        "measured_date": "2026-04-24"
+        "source": "Sourcegraph spins out Amp as standalone company (backed by Craft/Redpoint/Sequoia/Goldcrest/a16z); no new standalone round disclosed as of 2026-07-05",
+        "measured_date": "2026-07-05"
+      },
+      "stars_history": []
+    },
+    {
+      "name": "Antigravity",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://antigravity.google/product/antigravity-cli",
+      "description": "Google's Go-based agent-first development platform with a terminal CLI; replaced Gemini CLI on 2026-05-19 (Gemini CLI requests stop 2026-06-18). Distributed as a closed binary via install script.",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "Desktop app (IDE) / CLI",
+      "pricing": "Freemium",
+      "irrlicht_support": "live",
+      "first_seen": "2026-05-31",
+      "alternative_metrics": {
+        "source": "Google I/O 2026; Google Developers Blog 'Transitioning Gemini CLI to Antigravity CLI'; no independent funding/user data (checked 2026-07-05)",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -856,27 +919,8 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": {
         "funding_millions_usd": 252,
-        "source": "Crunchbase; TechCrunch Series B coverage",
-        "measured_date": "2026-04-24"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "CodeGPT",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://www.codegpt.co",
-      "description": "Full-stack AI agent platform with a codebase knowledge graph.",
-      "stars": null,
-      "language": null,
-      "license": null,
-      "interface": "IDE extension / Web",
-      "pricing": "Freemium",
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "source": "no public metrics found",
-        "measured_date": "2026-04-24"
+        "source": "Augment Inc. $227M Series B (~$977M post-money); TechCrunch/Augment blog coverage; no change since last check (checked 2026-07-05)",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -894,8 +938,28 @@
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "source": "no public metrics found",
-        "measured_date": "2026-04-24"
+        "funding_millions_usd": 1.5,
+        "source": "Crunchbase; YC F24 ~$500K seed, ~$1.5M total raised (checked 2026-07-05)",
+        "measured_date": "2026-07-05"
+      },
+      "stars_history": []
+    },
+    {
+      "name": "CodeGPT",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://www.codegpt.co",
+      "description": "Full-stack AI agent platform with a codebase knowledge graph.",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "IDE extension / Web",
+      "pricing": "Freemium",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": {
+        "source": "no public metrics found (checked 2026-07-05)",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -913,8 +977,9 @@
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "source": "no public funding/user data found",
-        "measured_date": "2026-04-24"
+        "funding_millions_usd": 8,
+        "source": "Cosine newsroom (cosine.sh/newsroom); ~$8M seed, ~Dec 2025 (checked 2026-07-05). Named as model partner in a UK 'Sovereign AI Coalition' (2026-06-08) but that's a partnership, not company funding.",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -923,7 +988,7 @@
       "github_repo": null,
       "category": "agent",
       "website": "https://devin.ai",
-      "description": "Cognition AI's autonomous software-engineer agent; parent company merged Windsurf (Cascade IDE) into its stack in 2025.",
+      "description": "Cognition AI's autonomous software-engineer agent; parent company also owns Windsurf (Cascade IDE, merged into its stack in 2025).",
       "stars": null,
       "language": null,
       "license": null,
@@ -932,10 +997,10 @@
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "funding_millions_usd": 696,
-        "valuation_billions_usd": 10.2,
-        "source": "Cognition's Sep 2025 $400M round (Founders Fund, Lux, 8VC); Wikipedia; CNBC",
-        "measured_date": "2026-04-24"
+        "funding_millions_usd": 1000,
+        "valuation_billions_usd": 26,
+        "source": "TechCrunch/Bloomberg: Cognition AI raised $1B+ at $25B pre-money (~$26B post-money) valuation, announced 2026-05-27; reported ARR grew from $37M (May 2025) to $492M. Figure is Cognition-parent-level, attributed to Devin as its flagship product.",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -953,28 +1018,9 @@
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "estimated_users": "20000000+",
-        "source": "GitHub Q4 2025 disclosures; exact figure varies by source",
-        "measured_date": "2026-04-24"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "Kiro",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://kiro.dev",
-      "description": "AWS-backed agentic IDE with spec-driven development and autonomous task execution.",
-      "stars": null,
-      "language": null,
-      "license": null,
-      "interface": "Desktop app (IDE)",
-      "pricing": "Freemium",
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-10",
-      "alternative_metrics": {
-        "source": "AWS-backed product; no independent funding data",
-        "measured_date": "2026-04-24"
+        "estimated_users": "4700000",
+        "source": "Microsoft Jan 28 2026 earnings call: ~4.7M paid GitHub Copilot subscribers. CORRECTION: prior '20000000+' figure conflated this with Microsoft 365 Copilot's ~20M paid seats (disclosed on Microsoft's Apr 29 2026 call) — a different product; do not merge again.",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -992,8 +1038,8 @@
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "source": "no public metrics found",
-        "measured_date": "2026-04-24"
+        "source": "no public metrics found (checked 2026-07-05). Caution: Crunchbase/Tracxn listings for 'Morph' often refer to an unrelated crypto/L2 blockchain company, not MorphLLM (YC S23 coding-agent infra).",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -1012,8 +1058,8 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": {
         "funding_millions_usd": 626,
-        "source": "Crunchbase; Nvidia strategic investment reports",
-        "measured_date": "2026-04-24"
+        "source": "Crunchbase; Nvidia strategic investment reports. Context: FT (via Techmeme, ~2026-04-02) reported a planned $2B Series C with an up-to-$1B Nvidia anchor collapsed after a CoreWeave data-center deal fell through; total raised remains ~$625-626M, unresolved as of 2026-07-05.",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -1032,8 +1078,8 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": {
         "funding_millions_usd": 120,
-        "source": "TechCrunch / Ctech Series B (Mar 2026)",
-        "measured_date": "2026-04-24"
+        "source": "TechCrunch, 'Qodo bets on code verification as AI coding scales, raises $70M' (2026-03-30) -> $120M total; no change since last check (checked 2026-07-05)",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -1053,8 +1099,8 @@
       "alternative_metrics": {
         "estimated_users": "1000000",
         "funding_millions_usd": 102,
-        "source": "Tabnine press releases; Crunchbase",
-        "measured_date": "2026-04-24"
+        "source": "Tabnine press releases; Tracxn company profile; no change since last check (checked 2026-07-05)",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -1074,8 +1120,8 @@
       "alternative_metrics": {
         "funding_millions_usd": null,
         "acquisition_price_millions_usd": 250,
-        "source": "Cognition AI press release (Dec 2025); TechCrunch coverage",
-        "measured_date": "2026-04-24"
+        "source": "Cognition AI acquired Windsurf/Codeium (Dec 2025, ~$250M). Cognition (parent) itself raised $1B+ at ~$26B post-money on 2026-05-27 (TechCrunch/Bloomberg) but no Windsurf-specific standalone figure exists post-fold-in.",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -1093,8 +1139,8 @@
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "source": "early-stage; no public metrics",
-        "measured_date": "2026-04-24"
+        "source": "no credible new disclosure (checked 2026-07-05). A low-quality aggregator (Signalbase) claim of a '$100K seed' (~Mar 2026, no named investors) was evaluated and rejected as not credible. Last verifiable figure: Scale Venture Partners-led ~$2.1M round (Sep 2025) — not independently reconfirmed this run, so left unset rather than carried forward unverified.",
+        "measured_date": "2026-07-05"
       },
       "stars_history": []
     },
@@ -1104,7 +1150,7 @@
       "category": "orchestrator",
       "website": "https://paperclip.ing",
       "description": "The open-source app everyone uses to manage agents at work",
-      "stars": 65560,
+      "stars": 72750,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "Web",
@@ -1113,6 +1159,10 @@
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 72750
+        },
         {
           "date": "2026-05-15",
           "stars": 65560
@@ -1132,8 +1182,8 @@
       "github_repo": "ruvnet/ruflo",
       "category": "orchestrator",
       "website": "https://github.com/ruvnet/ruflo",
-      "description": "Agent orchestration platform for Claude: multi-agent swarms, RAG integration, Claude Code / Codex integration.",
-      "stars": 51261,
+      "description": "🌊 The leading agent meta-harness. Deploy intelligent multi-player swarms, coordinate autonomous workflows, and build conversational AI systems. Features adaptive memory, self-learning intelligence, RAG integration, and native Claude Code / Codex / Hermes and many more Integrated",
+      "stars": 63063,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "CLI / SDK",
@@ -1142,6 +1192,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 63063
+        },
         {
           "date": "2026-05-15",
           "stars": 51261
@@ -1162,7 +1216,7 @@
       "category": "orchestrator",
       "website": "https://www.agno.com",
       "description": "Build, run, and manage agent platforms.",
-      "stars": 40134,
+      "stars": 40999,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "SDK / Web",
@@ -1171,6 +1225,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 40999
+        },
         {
           "date": "2026-05-15",
           "stars": 40134
@@ -1191,7 +1249,7 @@
       "category": "orchestrator",
       "website": "https://github.com/OpenBMB/ChatDev",
       "description": "ChatDev 2.0: Dev All through LLM-powered Multi-Agent Collaboration",
-      "stars": 33093,
+      "stars": 33658,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "CLI / Web",
@@ -1200,6 +1258,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 33658
+        },
         {
           "date": "2026-05-15",
           "stars": 33093
@@ -1219,8 +1281,8 @@
       "github_repo": "stitionai/devika",
       "category": "orchestrator",
       "website": "https://github.com/stitionai/devika",
-      "description": "Open-source agentic software engineer (originally an open alternative to Devin).",
-      "stars": 19507,
+      "description": "Devika is the first open-source implementation of an Agentic Software Engineer. Initially started as an open-source alternative to Devin.",
+      "stars": 19535,
       "language": "Python",
       "license": "MIT",
       "interface": "Web",
@@ -1229,6 +1291,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 19535
+        },
         {
           "date": "2026-05-15",
           "stars": 19507
@@ -1249,7 +1315,7 @@
       "category": "orchestrator",
       "website": "https://github.com/gastownhall/gastown",
       "description": "Gas Town - multi-agent workspace manager",
-      "stars": 15195,
+      "stars": 16235,
       "language": "Go",
       "license": "MIT",
       "interface": "CLI",
@@ -1258,6 +1324,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 16235
+        },
         {
           "date": "2026-05-15",
           "stars": 15195
@@ -1273,49 +1343,24 @@
       ]
     },
     {
-      "name": "Claude Squad",
-      "github_repo": "smtg-ai/claude-squad",
-      "category": "orchestrator",
-      "website": "https://github.com/smtg-ai/claude-squad",
-      "description": "Manage multiple AI terminal agents like Claude Code, Codex, OpenCode, and Amp.",
-      "stars": 7475,
-      "language": "Go",
-      "license": "AGPL-3.0",
-      "interface": "CLI (tmux)",
-      "pricing": "Free (open source)",
-      "irrlicht_support": "planned",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {
-          "date": "2026-05-15",
-          "stars": 7475
-        },
-        {
-          "date": "2026-04-24",
-          "stars": 7145
-        },
-        {
-          "date": "2026-04-12",
-          "stars": 6961
-        }
-      ]
-    },
-    {
       "name": "Composio",
-      "github_repo": "ComposioHQ/agent-orchestrator",
+      "github_repo": "AgentWrapper/agent-orchestrator",
       "category": "orchestrator",
       "website": "https://composio.dev",
       "description": "Agentic orchestrator for parallel coding agents — plans tasks, spawns agents, and autonomously handles CI fixes, merge conflicts, and code reviews.",
-      "stars": 7047,
-      "language": "TypeScript",
-      "license": "MIT",
+      "stars": 8053,
+      "language": "Go",
+      "license": "Apache-2.0",
       "interface": "CLI / Web",
       "pricing": "Freemium",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 8053
+        },
         {
           "date": "2026-05-15",
           "stars": 7047
@@ -1331,12 +1376,45 @@
       ]
     },
     {
+      "name": "Claude Squad",
+      "github_repo": "smtg-ai/claude-squad",
+      "category": "orchestrator",
+      "website": "https://github.com/smtg-ai/claude-squad",
+      "description": "Manage multiple AI terminal agents like Claude Code, Codex, OpenCode, and Amp.",
+      "stars": 8023,
+      "language": "Go",
+      "license": "AGPL-3.0",
+      "interface": "CLI (tmux)",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "planned",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 8023
+        },
+        {
+          "date": "2026-05-15",
+          "stars": 7475
+        },
+        {
+          "date": "2026-04-24",
+          "stars": 7145
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 6961
+        }
+      ]
+    },
+    {
       "name": "Emdash",
       "github_repo": "generalaction/emdash",
       "category": "orchestrator",
       "website": "https://github.com/generalaction/emdash",
-      "description": "Emdash is the Open-Source Agentic Development Environment (YC W26). Run multiple coding agents in parallel. Use any provider.",
-      "stars": 4710,
+      "description": "Emdash is the Open-Source Agentic Development Environment (🧡 YC W26). Run multiple coding agents in parallel. Use any provider.",
+      "stars": 5070,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "Desktop app (Electron)",
@@ -1345,6 +1423,10 @@
       "first_seen": "2026-05-31",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 5070
+        },
         {
           "date": "2026-05-31",
           "stars": 4710
@@ -1356,8 +1438,8 @@
       "github_repo": "darrenhinde/OpenAgentsControl",
       "category": "orchestrator",
       "website": "https://github.com/darrenhinde/OpenAgentsControl",
-      "description": "AI agent framework for plan-first development workflows with approval-based execution. Multi-language support (TypeScript, Python, Go, Rust) with automatic testing, code review, and validation built for OpenCode.",
-      "stars": 4187,
+      "description": "AI agent framework for plan-first development workflows with approval-based execution. Multi-language support (TypeScript, Python, Go, Rust) with automatic testing, code review, and validation built for OpenCode",
+      "stars": 4484,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "CLI / SDK",
@@ -1367,8 +1449,37 @@
       "alternative_metrics": null,
       "stars_history": [
         {
+          "date": "2026-07-05",
+          "stars": 4484
+        },
+        {
           "date": "2026-05-31",
           "stars": 4187
+        }
+      ]
+    },
+    {
+      "name": "Bernstein",
+      "github_repo": "sipyourdrink-ltd/bernstein",
+      "category": "orchestrator",
+      "website": "https://bernstein.run",
+      "description": "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, +40 more). HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on. https://bernstein.run",
+      "stars": 634,
+      "language": "Python",
+      "license": "Apache-2.0",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "none",
+      "first_seen": "2026-05-31",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 634
+        },
+        {
+          "date": "2026-05-31",
+          "stars": 530
         }
       ]
     },
@@ -1378,7 +1489,7 @@
       "category": "orchestrator",
       "website": "https://github.com/dlorenc/multiclaude",
       "description": "Parallel Claude Code instances in tmux with a Brownian-ratchet CI model.",
-      "stars": 548,
+      "stars": 555,
       "language": "Go",
       "license": null,
       "interface": "CLI (tmux)",
@@ -1387,6 +1498,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 555
+        },
         {
           "date": "2026-05-15",
           "stars": 548
@@ -1402,33 +1517,12 @@
       ]
     },
     {
-      "name": "Bernstein",
-      "github_repo": "sipyourdrink-ltd/bernstein",
-      "category": "orchestrator",
-      "website": "https://bernstein.run",
-      "description": "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, +40 more). HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy.",
-      "stars": 530,
-      "language": "Python",
-      "license": "Apache-2.0",
-      "interface": "CLI",
-      "pricing": "Free (open source)",
-      "irrlicht_support": "none",
-      "first_seen": "2026-05-31",
-      "alternative_metrics": null,
-      "stars_history": [
-        {
-          "date": "2026-05-31",
-          "stars": 530
-        }
-      ]
-    },
-    {
       "name": "Stoneforge",
       "github_repo": "stoneforge-ai/stoneforge",
       "category": "orchestrator",
       "website": "https://stoneforge.ai",
       "description": "A web dashboard and runtime for orchestrating AI coding agents",
-      "stars": 143,
+      "stars": 160,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "Web",
@@ -1437,6 +1531,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 160
+        },
         {
           "date": "2026-05-15",
           "stars": 143
@@ -1456,16 +1554,20 @@
       "github_repo": "nxtg-ai/forge-orchestrator",
       "category": "orchestrator",
       "website": "https://forge.nxtg.ai",
-      "description": "Rust-based multi-AI task orchestrator with file locking and drift detection.",
-      "stars": 116,
+      "description": "Forge Orchestrator: Multi-AI task orchestration. File locking, knowledge capture, drift detection. Rust.",
+      "stars": 128,
       "language": "Rust",
-      "license": "NOASSERTION",
+      "license": null,
       "interface": "CLI",
       "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-07-05",
+          "stars": 128
+        },
         {
           "date": "2026-05-15",
           "stars": 116
@@ -1479,6 +1581,68 @@
           "stars": 108
         }
       ]
+    }
+  ],
+  "archived": [
+    {
+      "name": "Roo Code",
+      "github_repo": "RooCodeInc/Roo-Code",
+      "category": "agent",
+      "website": "https://roocode.com",
+      "description": "Roo Code gives you a whole dev team of AI agents in your code editor.",
+      "stars": 24304,
+      "language": "TypeScript",
+      "license": "Apache-2.0",
+      "interface": "IDE extension (VS Code)",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 24073
+        },
+        {
+          "date": "2026-04-24",
+          "stars": 23345
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 23088
+        }
+      ],
+      "archived_reason": "Repo archived by owner 2026-05-15 after hitting 3M installs; original team is \"going all-in on Roomote\" per project changelog, and a community team is arranging an official handoff to keep the VS Code extension maintained."
+    },
+    {
+      "name": "Void",
+      "github_repo": "voideditor/void",
+      "category": "agent",
+      "website": "https://voideditor.com",
+      "description": "Open-source AI code editor (VS Code fork).",
+      "stars": 28822,
+      "language": "TypeScript",
+      "license": "Apache-2.0",
+      "interface": "Desktop app (IDE)",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-05-15",
+          "stars": 28752
+        },
+        {
+          "date": "2026-04-24",
+          "stars": 28644
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 28553
+        }
+      ],
+      "archived_reason": "Repo archived by owner 2026-06-02; team paused active development to \"explore novel coding ideas\" per GitHub issue #926 discussion. Not replaced by a named successor. Last release remains usable."
     }
   ]
 }

--- a/.claude/skills/ir:agent-landscape/skill.md
+++ b/.claude/skills/ir:agent-landscape/skill.md
@@ -65,6 +65,8 @@ Field definitions:
 - `category` — `"agent"` or `"orchestrator"`.
 - `first_seen` — ISO date when this entry was first added. Never change it once set.
 
+Top-level `archived` array (sibling to `agents`) holds entries moved out per rule 8. Same shape as an `agents` entry plus an `archived_reason` string (why it was archived, cited from the search that found it). The HTML generator only reads `data["agents"]`, so anything here is automatically excluded from both the ranked table and the "No public repo" group — no generator change needed. If a run finds the entry is no longer archived (`archived: false` again), move it back into `agents` and drop `archived_reason`.
+
 ### Snapshot strategy
 
 Snapshots accumulate over successive runs. No back-filling.
@@ -89,10 +91,10 @@ An agent is "NEW" only if both:
 
 ## Irrlicht support mapping
 
-The canonical source of truth is `core/adapters/inbound/agents/` + `core/adapters/inbound/orchestrators/`. As of this writing:
+The canonical source of truth is `core/adapters/inbound/agents/` (registered in `all.go`'s `All()`) + `core/adapters/inbound/orchestrators/`. As of this writing:
 
-- `live`: Claude Code (`anthropics/claude-code`), OpenAI Codex (`openai/codex`), Pi (`earendil-works/pi`, renamed from `badlogic/pi-mono` in v0.74), Gas Town (`gastownhall/gastown`), Aider (`Aider-AI/aider`), OpenCode (`anomalyco/opencode`).
-- `planned`: Gemini CLI, Cursor, Amp, Claude Squad, Qwen Code, Crush, Continue, Goose, Kilo Code, Paperclip, Ruflo, Multiclaude, SWE-agent.
+- `live`: Claude Code (`anthropics/claude-code`), OpenAI Codex (`openai/codex`), Pi (`earendil-works/pi`, renamed from `badlogic/pi-mono` in v0.74), Aider (`Aider-AI/aider`), OpenCode (`anomalyco/opencode`), Kiro (adapter targets Kiro CLI specifically, `AdapterName "kiro-cli"`; product repo `kirodotdev/Kiro`), Gemini CLI (`google-gemini/gemini-cli`), Antigravity (closed-source, no public repo), Gas Town (`gastownhall/gastown`).
+- `planned`: Cursor, Claude Squad, Qwen Code, Crush, Continue, Goose, Kilo Code, Paperclip, Ruflo, Multiclaude, SWE-agent.
 - Everything else: `none`.
 
 Before each run, `ls core/adapters/inbound/agents/` and `ls core/adapters/inbound/orchestrators/` to confirm the list is still correct. If the set of live adapters has changed, update this section and apply the change to `agent-data.json`.

--- a/site/landscape/compare/index.html
+++ b/site/landscape/compare/index.html
@@ -122,7 +122,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <a href="../" class="back-link">&larr; Back to Landscape</a>
   <div class="page-header">
     <h1>Agent Comparison</h1>
-    <div class="updated">Last updated: 2026-05-15</div>
+    <div class="updated">Last updated: 2026-07-05</div>
     <p class="intro">In-depth comparison of all tracked AI coding agents and orchestrators. Click any column header to sort. Growth figures are measured relative to today using snapshots taken at: today, ~1 month ago, and ~3 months ago.</p>
   </div>
 
@@ -144,22 +144,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 </tr></thead>
 <tbody>
 <tr>
-  <td class="name" data-sort="claw code"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="191505">191,505</td>
-  <td class="growth-3m"><span class="growth-up">+3,455 <span class="growth-pct">(+1.8%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>Rust</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="opencode"><a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="160573">160,573</td>
-  <td class="growth-3m"><span class="growth-up">+11,826 <span class="growth-pct">(+8.0%)</span></span></td>
+  <td class="mono" data-sort="182478">182,478</td>
+  <td class="growth-3m"><span class="growth-up">+21,905 <span class="growth-pct">(+13.6%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -170,32 +158,32 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="claude code"><a href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener">Claude Code</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="123761">123,761</td>
-  <td class="growth-3m"><span class="growth-up">+6,208 <span class="growth-pct">(+5.3%)</span></span></td>
+  <td class="mono" data-sort="136132">136,132</td>
+  <td class="growth-3m"><span class="growth-up">+12,371 <span class="growth-pct">(+10.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>—</td>
-  <td>Shell</td>
+  <td>Python</td>
   <td>CLI</td>
   <td>Paid (usage-based)</td>
   <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="gemini cli"><a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener">Gemini CLI</a></td>
+  <td class="name" data-sort="claw code"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="104022">104,022</td>
-  <td class="growth-3m"><span class="growth-up">+1,718 <span class="growth-pct">(+1.7%)</span></span></td>
+  <td class="mono" data-sort="194570">194,570</td>
+  <td class="growth-3m"><span class="growth-up">+3,065 <span class="growth-pct">(+1.6%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>TypeScript</td>
+  <td>MIT</td>
+  <td>Rust</td>
   <td>CLI</td>
   <td>Free (open source)</td>
-  <td><span class="badge badge-planned">planned</span></td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
   <td class="name" data-sort="openai codex"><a href="https://github.com/openai/codex" target="_blank" rel="noopener">OpenAI Codex</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="82811">82,811</td>
-  <td class="growth-3m"><span class="growth-up">+5,243 <span class="growth-pct">(+6.8%)</span></span></td>
+  <td class="mono" data-sort="95588">95,588</td>
+  <td class="growth-3m"><span class="growth-up">+12,777 <span class="growth-pct">(+15.4%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Rust</td>
@@ -204,10 +192,34 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="pi"><a href="https://github.com/earendil-works/pi" target="_blank" rel="noopener">Pi</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="67727">67,727</td>
+  <td class="growth-3m"><span class="growth-up">+18,063 <span class="growth-pct">(+36.4%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-live">live</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="ruflo"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="63063">63,063</td>
+  <td class="growth-3m"><span class="growth-up">+11,802 <span class="growth-pct">(+23.0%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>CLI / SDK</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="openhands"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">OpenHands</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="73613">73,613</td>
-  <td class="growth-3m"><span class="growth-up">+1,628 <span class="growth-pct">(+2.3%)</span></span></td>
+  <td class="mono" data-sort="79471">79,471</td>
+  <td class="growth-3m"><span class="growth-up">+5,858 <span class="growth-pct">(+8.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>NOASSERTION</td>
   <td>Python</td>
@@ -218,8 +230,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="paperclip"><a href="https://paperclip.ing" target="_blank" rel="noopener">Paperclip</a><sup class="badge badge-new">NEW</sup></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="65560">65,560</td>
-  <td class="growth-3m"><span class="growth-up">+7,177 <span class="growth-pct">(+12.3%)</span></span></td>
+  <td class="mono" data-sort="72750">72,750</td>
+  <td class="growth-3m"><span class="growth-up">+7,190 <span class="growth-pct">(+11.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -228,22 +240,22 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="cline"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
+  <td class="name" data-sort="gemini cli"><a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener">Gemini CLI</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="61809">61,809</td>
-  <td class="growth-3m"><span class="growth-up">+860 <span class="growth-pct">(+1.4%)</span></span></td>
+  <td class="mono" data-sort="105752">105,752</td>
+  <td class="growth-3m"><span class="growth-up">+1,730 <span class="growth-pct">(+1.7%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
-  <td>IDE extension (VS Code)</td>
-  <td>Freemium</td>
-  <td><span class="badge badge-none">not tracked</span></td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
   <td class="name" data-sort="warp"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="58530">58,530</td>
-  <td class="growth-3m"><span class="growth-up">+32,029 <span class="growth-pct">(+120.9%)</span></span></td>
+  <td class="mono" data-sort="62818">62,818</td>
+  <td class="growth-3m"><span class="growth-up">+4,288 <span class="growth-pct">(+7.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>AGPL-3.0</td>
   <td>Rust</td>
@@ -252,34 +264,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="ruflo"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
-  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="51261">51,261</td>
-  <td class="growth-3m"><span class="growth-up">+18,182 <span class="growth-pct">(+55.0%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>TypeScript</td>
-  <td>CLI / SDK</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-planned">planned</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="pi"><a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener">Pi</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="49664">49,664</td>
-  <td class="growth-3m"><span class="growth-up">+10,291 <span class="growth-pct">(+26.1%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>TypeScript</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-live">live</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="goose"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="45230">45,230</td>
-  <td class="growth-3m"><span class="growth-up">+2,091 <span class="growth-pct">(+4.8%)</span></span></td>
+  <td class="mono" data-sort="50663">50,663</td>
+  <td class="growth-3m"><span class="growth-up">+5,433 <span class="growth-pct">(+12.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Rust</td>
@@ -288,10 +276,22 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="cline"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="64294">64,294</td>
+  <td class="growth-3m"><span class="growth-up">+2,485 <span class="growth-pct">(+4.0%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>IDE extension (VS Code)</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="aider"><a href="https://aider.chat" target="_blank" rel="noopener">Aider</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="44842">44,842</td>
-  <td class="growth-3m"><span class="growth-up">+968 <span class="growth-pct">(+2.2%)</span></span></td>
+  <td class="mono" data-sort="47065">47,065</td>
+  <td class="growth-3m"><span class="growth-up">+2,223 <span class="growth-pct">(+5.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Python</td>
@@ -300,22 +300,22 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="agno"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
-  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="40134">40,134</td>
-  <td class="growth-3m"><span class="growth-up">+486 <span class="growth-pct">(+1.2%)</span></span></td>
+  <td class="name" data-sort="kilo code"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="25591">25,591</td>
+  <td class="growth-3m"><span class="growth-up">+6,287 <span class="growth-pct">(+32.6%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>Python</td>
-  <td>SDK / Web</td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>IDE extension / CLI</td>
   <td>Freemium</td>
-  <td><span class="badge badge-none">not tracked</span></td>
+  <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
   <td class="name" data-sort="continue"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="33196">33,196</td>
-  <td class="growth-3m"><span class="growth-up">+426 <span class="growth-pct">(+1.3%)</span></span></td>
+  <td class="mono" data-sort="34690">34,690</td>
+  <td class="growth-3m"><span class="growth-up">+1,494 <span class="growth-pct">(+4.5%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -324,10 +324,46 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="agno"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="40999">40,999</td>
+  <td class="growth-3m"><span class="growth-up">+865 <span class="growth-pct">(+2.2%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Python</td>
+  <td>SDK / Web</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="crush"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="26077">26,077</td>
+  <td class="growth-3m"><span class="growth-up">+1,779 <span class="growth-pct">(+7.3%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>NOASSERTION</td>
+  <td>Go</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="qwen code"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="25787">25,787</td>
+  <td class="growth-3m"><span class="growth-up">+1,386 <span class="growth-pct">(+5.7%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="chatdev"><a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener">ChatDev</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="33093">33,093</td>
-  <td class="growth-3m"><span class="growth-up">+246 <span class="growth-pct">(+0.7%)</span></span></td>
+  <td class="mono" data-sort="33658">33,658</td>
+  <td class="growth-3m"><span class="growth-up">+565 <span class="growth-pct">(+1.7%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Python</td>
@@ -338,116 +374,20 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="cursor"><a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="32875">32,875</td>
-  <td class="growth-3m"><span class="growth-up">+182 <span class="growth-pct">(+0.6%)</span></span></td>
+  <td class="mono" data-sort="33006">33,006</td>
+  <td class="growth-3m"><span class="growth-up">+131 <span class="growth-pct">(+0.4%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>—</td>
   <td>—</td>
   <td>Desktop app (IDE)</td>
   <td>Freemium</td>
   <td><span class="badge badge-planned">planned</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="void"><a href="https://voideditor.com" target="_blank" rel="noopener">Void</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="28752">28,752</td>
-  <td class="growth-3m"><span class="growth-up">+108 <span class="growth-pct">(+0.4%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>TypeScript</td>
-  <td>Desktop app (IDE)</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="qwen code"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a><sup class="badge badge-new">NEW</sup></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="24401">24,401</td>
-  <td class="growth-3m"><span class="growth-up">+588 <span class="growth-pct">(+2.5%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>TypeScript</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-planned">planned</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="crush"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a><sup class="badge badge-new">NEW</sup></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="24298">24,298</td>
-  <td class="growth-3m"><span class="growth-up">+880 <span class="growth-pct">(+3.8%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>NOASSERTION</td>
-  <td>Go</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-planned">planned</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="roo code"><a href="https://roocode.com" target="_blank" rel="noopener">Roo Code</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="24073">24,073</td>
-  <td class="growth-3m"><span class="growth-up">+728 <span class="growth-pct">(+3.1%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>TypeScript</td>
-  <td>IDE extension (VS Code)</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="devika"><a href="https://github.com/stitionai/devika" target="_blank" rel="noopener">Devika</a></td>
-  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="19507">19,507</td>
-  <td class="growth-3m"><span class="growth-up">+5 <span class="growth-pct">(+0.0%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>Python</td>
-  <td>Web</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="kilo code"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="19304">19,304</td>
-  <td class="growth-3m"><span class="growth-up">+799 <span class="growth-pct">(+4.3%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>TypeScript</td>
-  <td>IDE extension / CLI</td>
-  <td>Freemium</td>
-  <td><span class="badge badge-planned">planned</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="swe-agent"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="19225">19,225</td>
-  <td class="growth-3m"><span class="growth-up">+175 <span class="growth-pct">(+0.9%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>Python</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-planned">planned</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="plandex"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a><sup class="badge badge-new">NEW</sup></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="15365">15,365</td>
-  <td class="growth-3m"><span class="growth-up">+76 <span class="growth-pct">(+0.5%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>Go</td>
-  <td>CLI</td>
-  <td>Freemium</td>
-  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
   <td class="name" data-sort="gas town"><a href="https://github.com/gastownhall/gastown" target="_blank" rel="noopener">Gas Town</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="15195">15,195</td>
-  <td class="growth-3m"><span class="growth-up">+615 <span class="growth-pct">(+4.2%)</span></span></td>
+  <td class="mono" data-sort="16235">16,235</td>
+  <td class="growth-3m"><span class="growth-up">+1,040 <span class="growth-pct">(+6.8%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>Go</td>
@@ -456,10 +396,58 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="swe-agent"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="19705">19,705</td>
+  <td class="growth-3m"><span class="growth-up">+480 <span class="growth-pct">(+2.5%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Python</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="composio"><a href="https://composio.dev" target="_blank" rel="noopener">Composio</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="8053">8,053</td>
+  <td class="growth-3m"><span class="growth-up">+1,006 <span class="growth-pct">(+14.3%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Go</td>
+  <td>CLI / Web</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="plandex"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="15502">15,502</td>
+  <td class="growth-3m"><span class="growth-up">+137 <span class="growth-pct">(+0.9%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Go</td>
+  <td>CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="kiro"><a href="https://kiro.dev" target="_blank" rel="noopener">Kiro</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="3965">3,965</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>TypeScript</td>
+  <td>Desktop app (IDE) / CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-live">live</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="open swe"><a href="https://github.com/langchain-ai/open-swe" target="_blank" rel="noopener">Open SWE</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="9802">9,802</td>
-  <td class="growth-3m"><span class="growth-up">+160 <span class="growth-pct">(+1.7%)</span></span></td>
+  <td class="mono" data-sort="10103">10,103</td>
+  <td class="growth-3m"><span class="growth-up">+301 <span class="growth-pct">(+3.1%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>Python</td>
@@ -468,22 +456,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="sweep"><a href="https://sweep.dev" target="_blank" rel="noopener">Sweep</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="7713">7,713</td>
-  <td class="growth-3m"><span class="growth-up">+8 <span class="growth-pct">(+0.1%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>NOASSERTION</td>
-  <td>Jupyter Notebook</td>
-  <td>IDE extension (JetBrains)</td>
-  <td>Freemium</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="claude squad"><a href="https://github.com/smtg-ai/claude-squad" target="_blank" rel="noopener">Claude Squad</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="7475">7,475</td>
-  <td class="growth-3m"><span class="growth-up">+330 <span class="growth-pct">(+4.6%)</span></span></td>
+  <td class="mono" data-sort="8023">8,023</td>
+  <td class="growth-3m"><span class="growth-up">+548 <span class="growth-pct">(+7.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>AGPL-3.0</td>
   <td>Go</td>
@@ -492,10 +468,34 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="devika"><a href="https://github.com/stitionai/devika" target="_blank" rel="noopener">Devika</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="19535">19,535</td>
+  <td class="growth-3m"><span class="growth-up">+28 <span class="growth-pct">(+0.1%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Python</td>
+  <td>Web</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="emdash"><a href="https://github.com/generalaction/emdash" target="_blank" rel="noopener">Emdash</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="5070">5,070</td>
+  <td class="growth-3m"><span class="growth-up">+360 <span class="growth-pct">(+7.6%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>Desktop app (Electron)</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="forge code"><a href="https://forgecode.dev" target="_blank" rel="noopener">Forge Code</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="7295">7,295</td>
-  <td class="growth-3m"><span class="growth-up">+370 <span class="growth-pct">(+5.3%)</span></span></td>
+  <td class="mono" data-sort="7445">7,445</td>
+  <td class="growth-3m"><span class="growth-up">+150 <span class="growth-pct">(+2.1%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Rust</td>
@@ -504,34 +504,34 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="composio"><a href="https://composio.dev" target="_blank" rel="noopener">Composio</a></td>
+  <td class="name" data-sort="openagentscontrol"><a href="https://github.com/darrenhinde/OpenAgentsControl" target="_blank" rel="noopener">OpenAgentsControl</a><sup class="badge badge-new">NEW</sup></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="7047">7,047</td>
-  <td class="growth-3m"><span class="growth-up">+573 <span class="growth-pct">(+8.9%)</span></span></td>
+  <td class="mono" data-sort="4484">4,484</td>
+  <td class="growth-3m"><span class="growth-up">+297 <span class="growth-pct">(+7.1%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
-  <td>CLI / Web</td>
-  <td>Freemium</td>
+  <td>CLI / SDK</td>
+  <td>Free (open source)</td>
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="ra.aid"><a href="https://www.ra-aid.ai" target="_blank" rel="noopener">RA.Aid</a></td>
+  <td class="name" data-sort="sweep"><a href="https://sweep.dev" target="_blank" rel="noopener">Sweep</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="2224">2,224</td>
-  <td class="growth-3m"><span class="growth-up">+1 <span class="growth-pct">(+0.0%)</span></span></td>
+  <td class="mono" data-sort="7700">7,700</td>
+  <td class="growth-3m"><span class="growth-down">-13 <span class="growth-pct">(-0.2%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>Python</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
+  <td>NOASSERTION</td>
+  <td>Jupyter Notebook</td>
+  <td>IDE extension (JetBrains)</td>
+  <td>Freemium</td>
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
   <td class="name" data-sort="factory"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="876">876</td>
-  <td class="growth-3m"><span class="growth-up">+82 <span class="growth-pct">(+10.3%)</span></span></td>
+  <td class="mono" data-sort="1007">1,007</td>
+  <td class="growth-3m"><span class="growth-up">+131 <span class="growth-pct">(+15.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>—</td>
   <td>—</td>
@@ -540,10 +540,34 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="bernstein"><a href="https://bernstein.run" target="_blank" rel="noopener">Bernstein</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="634">634</td>
+  <td class="growth-3m"><span class="growth-up">+104 <span class="growth-pct">(+19.6%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Python</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="ra.aid"><a href="https://www.ra-aid.ai" target="_blank" rel="noopener">RA.Aid</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="2223">2,223</td>
+  <td class="growth-3m"><span class="growth-down">-1 <span class="growth-pct">(-0.0%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Python</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="pear ai"><a href="https://trypear.ai" target="_blank" rel="noopener">Pear AI</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="689">689</td>
-  <td class="growth-3m"><span class="growth-up">+13 <span class="growth-pct">(+1.9%)</span></span></td>
+  <td class="mono" data-sort="703">703</td>
+  <td class="growth-3m"><span class="growth-up">+14 <span class="growth-pct">(+2.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -554,8 +578,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="multiclaude"><a href="https://github.com/dlorenc/multiclaude" target="_blank" rel="noopener">Multiclaude</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="548">548</td>
-  <td class="growth-3m"><span class="growth-up">+9 <span class="growth-pct">(+1.7%)</span></span></td>
+  <td class="mono" data-sort="555">555</td>
+  <td class="growth-3m"><span class="growth-up">+7 <span class="growth-pct">(+1.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>—</td>
   <td>Go</td>
@@ -566,8 +590,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="codegen"><a href="https://codegen.com" target="_blank" rel="noopener">Codegen</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="521">521</td>
-  <td class="growth-3m"><span class="growth-flat">0 <span class="growth-pct">(0.0%)</span></span></td>
+  <td class="mono" data-sort="519">519</td>
+  <td class="growth-3m"><span class="growth-down">-2 <span class="growth-pct">(-0.4%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Python</td>
@@ -578,8 +602,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="stoneforge"><a href="https://stoneforge.ai" target="_blank" rel="noopener">Stoneforge</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="143">143</td>
-  <td class="growth-3m"><span class="growth-up">+13 <span class="growth-pct">(+10.0%)</span></span></td>
+  <td class="mono" data-sort="160">160</td>
+  <td class="growth-3m"><span class="growth-up">+17 <span class="growth-pct">(+11.9%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -590,10 +614,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="forge orchestrator"><a href="https://forge.nxtg.ai" target="_blank" rel="noopener">Forge Orchestrator</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="116">116</td>
-  <td class="growth-3m"><span class="growth-up">+7 <span class="growth-pct">(+6.4%)</span></span></td>
+  <td class="mono" data-sort="128">128</td>
+  <td class="growth-3m"><span class="growth-up">+12 <span class="growth-pct">(+10.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>NOASSERTION</td>
+  <td>—</td>
   <td>Rust</td>
   <td>CLI</td>
   <td>Free (open source)</td>
@@ -624,6 +648,18 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="antigravity"><a href="https://antigravity.google/product/antigravity-cli" target="_blank" rel="noopener">Antigravity</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="-1">—</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="0"><span class="badge-oss-no">No</span></td>
+  <td>—</td>
+  <td>—</td>
+  <td>Desktop app (IDE) / CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-live">live</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="augment code"><a href="https://www.augmentcode.com" target="_blank" rel="noopener">Augment Code</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
   <td class="mono" data-sort="-1">$252M raised</td>
@@ -638,7 +674,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="codebuff"><a href="https://codebuff.com" target="_blank" rel="noopener">Codebuff</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="-1">—</td>
+  <td class="mono" data-sort="-1">$1.5M raised</td>
   <td class="growth-3m"><span class="growth-na">—</span></td>
   <td data-sort="0"><span class="badge-oss-no">No</span></td>
   <td>—</td>
@@ -662,7 +698,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="cosine genie"><a href="https://cosine.sh" target="_blank" rel="noopener">Cosine Genie</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="-1">—</td>
+  <td class="mono" data-sort="-1">$8M raised</td>
   <td class="growth-3m"><span class="growth-na">—</span></td>
   <td data-sort="0"><span class="badge-oss-no">No</span></td>
   <td>—</td>
@@ -674,7 +710,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="devin"><a href="https://devin.ai" target="_blank" rel="noopener">Devin</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="-1">$696M raised</td>
+  <td class="mono" data-sort="-1">$1000M raised</td>
   <td class="growth-3m"><span class="growth-na">—</span></td>
   <td data-sort="0"><span class="badge-oss-no">No</span></td>
   <td>—</td>
@@ -686,25 +722,13 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="github copilot"><a href="https://github.com/features/copilot" target="_blank" rel="noopener">GitHub Copilot</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="-1">20.0M users</td>
+  <td class="mono" data-sort="-1">4.7M users</td>
   <td class="growth-3m"><span class="growth-na">—</span></td>
   <td data-sort="0"><span class="badge-oss-no">No</span></td>
   <td>—</td>
   <td>—</td>
   <td>IDE extension / Web</td>
   <td>Paid (from $10/mo)</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="kiro"><a href="https://kiro.dev" target="_blank" rel="noopener">Kiro</a><sup class="badge badge-new">NEW</sup></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="-1">—</td>
-  <td class="growth-3m"><span class="growth-na">—</span></td>
-  <td data-sort="0"><span class="badge-oss-no">No</span></td>
-  <td>—</td>
-  <td>—</td>
-  <td>Desktop app (IDE)</td>
-  <td>Freemium</td>
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>

--- a/site/landscape/index.html
+++ b/site/landscape/index.html
@@ -120,13 +120,13 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <div class="container">
   <div class="page-header">
     <h1>AI Coding Agent Landscape</h1>
-    <div class="updated">Last updated: 2026-05-15</div>
+    <div class="updated">Last updated: 2026-07-05</div>
     <p class="intro">A living ranking of AI coding agents and agent orchestrators, sorted by a blend of GitHub popularity and growth momentum. Agents that Irrlicht already monitors are marked <span class="badge badge-live">live</span>, upcoming integrations are <span class="badge badge-planned">planned</span>. Agents first tracked less than 3 months ago are marked <span class="badge badge-new">NEW</span>.</p>
     <a href="compare/" class="compare-link">See detailed comparison with all metrics &rarr;</a>
   </div>
 
   <h2 class="section-title">Coding Agents</h2>
-  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-05-15.</p>
+  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-07-05.</p>
   <table class="landscape-table">
 <thead><tr>
   <th class="rank">#</th><th>Name</th><th>Stars</th><th class="growth-3m">Recent growth</th><th>Irrlicht</th><th>Description</th>
@@ -135,217 +135,209 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 
   <tr>
     <td class="rank">#1</td>
-    <td class="name"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
-    <td class="stars">191,505</td>
-    <td class="growth growth-3m"><span class="growth-up">+3,455 <span class="growth-pct">(+1.8%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Rust CLI agent harness that wraps Claude via the Anthropic API; star count inflated by viral self-promotion in the README (&quot;fastest repo to 100K stars&quot;).</td>
-  </tr>
-  <tr>
-    <td class="rank">#2</td>
     <td class="name"><a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a></td>
-    <td class="stars">160,573</td>
-    <td class="growth growth-3m"><span class="growth-up">+11,826 <span class="growth-pct">(+8.0%)</span></span></td>
+    <td class="stars">182,478</td>
+    <td class="growth growth-3m"><span class="growth-up">+21,905 <span class="growth-pct">(+13.6%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
     <td class="desc">The open source coding agent.</td>
   </tr>
   <tr>
-    <td class="rank">#3</td>
+    <td class="rank">#2</td>
     <td class="name"><a href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener">Claude Code</a></td>
-    <td class="stars">123,761</td>
-    <td class="growth growth-3m"><span class="growth-up">+6,208 <span class="growth-pct">(+5.3%)</span></span></td>
+    <td class="stars">136,132</td>
+    <td class="growth growth-3m"><span class="growth-up">+12,371 <span class="growth-pct">(+10.0%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
     <td class="desc">Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands.</td>
   </tr>
   <tr>
-    <td class="rank">#4</td>
-    <td class="name"><a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener">Gemini CLI</a></td>
-    <td class="stars">104,022</td>
-    <td class="growth growth-3m"><span class="growth-up">+1,718 <span class="growth-pct">(+1.7%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">An open-source AI agent that brings the power of Gemini directly into your terminal.</td>
+    <td class="rank">#3</td>
+    <td class="name"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
+    <td class="stars">194,570</td>
+    <td class="growth growth-3m"><span class="growth-up">+3,065 <span class="growth-pct">(+1.6%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">An agent-managed museum exhibit, built in Rust with Gajae-Code / LazyCodex — developed and maintained with no human intervention.</td>
   </tr>
   <tr>
-    <td class="rank">#5</td>
+    <td class="rank">#4</td>
     <td class="name"><a href="https://github.com/openai/codex" target="_blank" rel="noopener">OpenAI Codex</a></td>
-    <td class="stars">82,811</td>
-    <td class="growth growth-3m"><span class="growth-up">+5,243 <span class="growth-pct">(+6.8%)</span></span></td>
+    <td class="stars">95,588</td>
+    <td class="growth growth-3m"><span class="growth-up">+12,777 <span class="growth-pct">(+15.4%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
     <td class="desc">Lightweight coding agent that runs in your terminal</td>
   </tr>
   <tr>
+    <td class="rank">#5</td>
+    <td class="name"><a href="https://github.com/earendil-works/pi" target="_blank" rel="noopener">Pi</a></td>
+    <td class="stars">67,727</td>
+    <td class="growth growth-3m"><span class="growth-up">+18,063 <span class="growth-pct">(+36.4%)</span></span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">AI agent toolkit: unified LLM API, agent loop, TUI, coding agent CLI</td>
+  </tr>
+  <tr>
     <td class="rank">#6</td>
     <td class="name"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">OpenHands</a></td>
-    <td class="stars">73,613</td>
-    <td class="growth growth-3m"><span class="growth-up">+1,628 <span class="growth-pct">(+2.3%)</span></span></td>
+    <td class="stars">79,471</td>
+    <td class="growth growth-3m"><span class="growth-up">+5,858 <span class="growth-pct">(+8.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">🙌 OpenHands: AI-Driven Development</td>
   </tr>
   <tr>
     <td class="rank">#7</td>
-    <td class="name"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
-    <td class="stars">61,809</td>
-    <td class="growth growth-3m"><span class="growth-up">+860 <span class="growth-pct">(+1.4%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Autonomous coding agent as an SDK, IDE extension, or CLI assistant.</td>
+    <td class="name"><a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener">Gemini CLI</a></td>
+    <td class="stars">105,752</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,730 <span class="growth-pct">(+1.7%)</span></span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">An open-source AI agent that brings the power of Gemini directly into your terminal.</td>
   </tr>
   <tr>
     <td class="rank">#8</td>
     <td class="name"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
-    <td class="stars">58,530</td>
-    <td class="growth growth-3m"><span class="growth-up">+32,029 <span class="growth-pct">(+120.9%)</span></span></td>
+    <td class="stars">62,818</td>
+    <td class="growth growth-3m"><span class="growth-up">+4,288 <span class="growth-pct">(+7.3%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Warp is an agentic development environment, born out of the terminal.</td>
   </tr>
   <tr>
     <td class="rank">#9</td>
-    <td class="name"><a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener">Pi</a></td>
-    <td class="stars">49,664</td>
-    <td class="growth growth-3m"><span class="growth-up">+10,291 <span class="growth-pct">(+26.1%)</span></span></td>
-    <td><span class="badge badge-live">live</span></td>
-    <td class="desc">Mario Zechner&#x27;s AI agent toolkit (CLI coding agent, unified LLM API, TUI/web libraries, Slack bot, vLLM pods); repo and `@earendil-works/*` packages moved to `earendil-works/pi` in v0.74.</td>
+    <td class="name"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
+    <td class="stars">50,663</td>
+    <td class="growth growth-3m"><span class="growth-up">+5,433 <span class="growth-pct">(+12.0%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM</td>
   </tr>
   <tr>
     <td class="rank">#10</td>
-    <td class="name"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
-    <td class="stars">45,230</td>
-    <td class="growth growth-3m"><span class="growth-up">+2,091 <span class="growth-pct">(+4.8%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Extensible open-source agent (install/execute/edit/test with any LLM); originated at Block before transfer to the `aaif-goose` org.</td>
+    <td class="name"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
+    <td class="stars">64,294</td>
+    <td class="growth growth-3m"><span class="growth-up">+2,485 <span class="growth-pct">(+4.0%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Autonomous coding agent as an SDK, IDE extension, or CLI assistant.</td>
   </tr>
   <tr>
     <td class="rank">#11</td>
     <td class="name"><a href="https://aider.chat" target="_blank" rel="noopener">Aider</a></td>
-    <td class="stars">44,842</td>
-    <td class="growth growth-3m"><span class="growth-up">+968 <span class="growth-pct">(+2.2%)</span></span></td>
+    <td class="stars">47,065</td>
+    <td class="growth growth-3m"><span class="growth-up">+2,223 <span class="growth-pct">(+5.0%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
     <td class="desc">aider is AI pair programming in your terminal</td>
   </tr>
   <tr>
     <td class="rank">#12</td>
-    <td class="name"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
-    <td class="stars">33,196</td>
-    <td class="growth growth-3m"><span class="growth-up">+426 <span class="growth-pct">(+1.3%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">⏩ Source-controlled AI checks, enforceable in CI. Powered by the open-source Continue CLI</td>
-  </tr>
-  <tr>
-    <td class="rank">#13</td>
-    <td class="name"><a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a></td>
-    <td class="stars">32,875</td>
-    <td class="growth growth-3m"><span class="growth-up">+182 <span class="growth-pct">(+0.6%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Proprietary AI-first code editor (the GitHub repo hosts issues only; editor source is closed).</td>
-  </tr>
-  <tr>
-    <td class="rank">#14</td>
-    <td class="name"><a href="https://voideditor.com" target="_blank" rel="noopener">Void</a></td>
-    <td class="stars">28,752</td>
-    <td class="growth growth-3m"><span class="growth-up">+108 <span class="growth-pct">(+0.4%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Open-source AI code editor (VS Code fork).</td>
-  </tr>
-  <tr>
-    <td class="rank">#15</td>
-    <td class="name"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">24,401</td>
-    <td class="growth growth-3m"><span class="growth-up">+588 <span class="growth-pct">(+2.5%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">An open-source AI agent that lives in your terminal.</td>
-  </tr>
-  <tr>
-    <td class="rank">#16</td>
-    <td class="name"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">24,298</td>
-    <td class="growth growth-3m"><span class="growth-up">+880 <span class="growth-pct">(+3.8%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Glamourous agentic coding for all 💘</td>
-  </tr>
-  <tr>
-    <td class="rank">#17</td>
-    <td class="name"><a href="https://roocode.com" target="_blank" rel="noopener">Roo Code</a></td>
-    <td class="stars">24,073</td>
-    <td class="growth growth-3m"><span class="growth-up">+728 <span class="growth-pct">(+3.1%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Roo Code gives you a whole dev team of AI agents in your code editor.</td>
-  </tr>
-  <tr>
-    <td class="rank">#18</td>
     <td class="name"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
-    <td class="stars">19,304</td>
-    <td class="growth growth-3m"><span class="growth-up">+799 <span class="growth-pct">(+4.3%)</span></span></td>
+    <td class="stars">25,591</td>
+    <td class="growth growth-3m"><span class="growth-up">+6,287 <span class="growth-pct">(+32.6%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">Kilo is the all-in-one agentic engineering platform. Build, ship, and iterate faster with the most popular open source coding agent.</td>
   </tr>
   <tr>
-    <td class="rank">#19</td>
+    <td class="rank">#13</td>
+    <td class="name"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
+    <td class="stars">34,690</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,494 <span class="growth-pct">(+4.5%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">open-source coding agent</td>
+  </tr>
+  <tr>
+    <td class="rank">#14</td>
+    <td class="name"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">26,077</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,779 <span class="growth-pct">(+7.3%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Glamourous agentic coding for all 💘</td>
+  </tr>
+  <tr>
+    <td class="rank">#15</td>
+    <td class="name"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">25,787</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,386 <span class="growth-pct">(+5.7%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">An open-source AI coding agent that lives in your terminal.</td>
+  </tr>
+  <tr>
+    <td class="rank">#16</td>
+    <td class="name"><a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a></td>
+    <td class="stars">33,006</td>
+    <td class="growth growth-3m"><span class="growth-up">+131 <span class="growth-pct">(+0.4%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">Proprietary AI-first code editor (the GitHub repo hosts issues only; editor source is closed).</td>
+  </tr>
+  <tr>
+    <td class="rank">#17</td>
     <td class="name"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
-    <td class="stars">19,225</td>
-    <td class="growth growth-3m"><span class="growth-up">+175 <span class="growth-pct">(+0.9%)</span></span></td>
+    <td class="stars">19,705</td>
+    <td class="growth growth-3m"><span class="growth-up">+480 <span class="growth-pct">(+2.5%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">SWE-agent takes a GitHub issue and tries to automatically fix it, using your LM of choice. It can also be employed for offensive cybersecurity or competitive coding challenges. [NeurIPS 2024]</td>
   </tr>
   <tr>
-    <td class="rank">#20</td>
+    <td class="rank">#18</td>
     <td class="name"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">15,365</td>
-    <td class="growth growth-3m"><span class="growth-up">+76 <span class="growth-pct">(+0.5%)</span></span></td>
+    <td class="stars">15,502</td>
+    <td class="growth growth-3m"><span class="growth-up">+137 <span class="growth-pct">(+0.9%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Open source AI coding agent. Designed for large projects and real world tasks.</td>
   </tr>
   <tr>
-    <td class="rank">#21</td>
+    <td class="rank">#19</td>
+    <td class="name"><a href="https://kiro.dev" target="_blank" rel="noopener">Kiro</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">3,965</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">Kiro is an agentic IDE that works alongside you from prototype to production.</td>
+  </tr>
+  <tr>
+    <td class="rank">#20</td>
     <td class="name"><a href="https://github.com/langchain-ai/open-swe" target="_blank" rel="noopener">Open SWE</a></td>
-    <td class="stars">9,802</td>
-    <td class="growth growth-3m"><span class="growth-up">+160 <span class="growth-pct">(+1.7%)</span></span></td>
+    <td class="stars">10,103</td>
+    <td class="growth growth-3m"><span class="growth-up">+301 <span class="growth-pct">(+3.1%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">An Open-Source Asynchronous Coding Agent</td>
   </tr>
   <tr>
+    <td class="rank">#21</td>
+    <td class="name"><a href="https://forgecode.dev" target="_blank" rel="noopener">Forge Code</a></td>
+    <td class="stars">7,445</td>
+    <td class="growth growth-3m"><span class="growth-up">+150 <span class="growth-pct">(+2.1%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">AI enabled pair programmer for Claude, GPT, O Series, Grok, Deepseek, Gemini and 300+ models</td>
+  </tr>
+  <tr>
     <td class="rank">#22</td>
     <td class="name"><a href="https://sweep.dev" target="_blank" rel="noopener">Sweep</a></td>
-    <td class="stars">7,713</td>
-    <td class="growth growth-3m"><span class="growth-up">+8 <span class="growth-pct">(+0.1%)</span></span></td>
+    <td class="stars">7,700</td>
+    <td class="growth growth-3m"><span class="growth-down">-13 <span class="growth-pct">(-0.2%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Sweep: AI coding assistant for JetBrains</td>
   </tr>
   <tr>
     <td class="rank">#23</td>
-    <td class="name"><a href="https://forgecode.dev" target="_blank" rel="noopener">Forge Code</a></td>
-    <td class="stars">7,295</td>
-    <td class="growth growth-3m"><span class="growth-up">+370 <span class="growth-pct">(+5.3%)</span></span></td>
+    <td class="name"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
+    <td class="stars">1,007</td>
+    <td class="growth growth-3m"><span class="growth-up">+131 <span class="growth-pct">(+15.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">AI enabled pair programmer for Claude, GPT, O Series, Grok, Deepseek, Gemini and 300+ models</td>
+    <td class="desc">Factory - Agent-Native Software Development</td>
   </tr>
   <tr>
     <td class="rank">#24</td>
     <td class="name"><a href="https://www.ra-aid.ai" target="_blank" rel="noopener">RA.Aid</a></td>
-    <td class="stars">2,224</td>
-    <td class="growth growth-3m"><span class="growth-up">+1 <span class="growth-pct">(+0.0%)</span></span></td>
+    <td class="stars">2,223</td>
+    <td class="growth growth-3m"><span class="growth-down">-1 <span class="growth-pct">(-0.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Develop software autonomously.</td>
   </tr>
   <tr>
     <td class="rank">#25</td>
-    <td class="name"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
-    <td class="stars">876</td>
-    <td class="growth growth-3m"><span class="growth-up">+82 <span class="growth-pct">(+10.3%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Factory - Agent-Native Software Development</td>
-  </tr>
-  <tr>
-    <td class="rank">#26</td>
     <td class="name"><a href="https://trypear.ai" target="_blank" rel="noopener">Pear AI</a></td>
-    <td class="stars">689</td>
-    <td class="growth growth-3m"><span class="growth-up">+13 <span class="growth-pct">(+1.9%)</span></span></td>
+    <td class="stars">703</td>
+    <td class="growth growth-3m"><span class="growth-up">+14 <span class="growth-pct">(+2.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">PearAI: Open Source AI Code Editor (Fork of VSCode). The PearAI Submodule (https://github.com/trypear/pearai-submodule) is a fork of Continue.</td>
   </tr>
   <tr>
-    <td class="rank">#27</td>
+    <td class="rank">#26</td>
     <td class="name"><a href="https://codegen.com" target="_blank" rel="noopener">Codegen</a></td>
-    <td class="stars">521</td>
-    <td class="growth growth-3m"><span class="growth-flat">0 <span class="growth-pct">(0.0%)</span></span></td>
+    <td class="stars">519</td>
+    <td class="growth growth-3m"><span class="growth-down">-2 <span class="growth-pct">(-0.4%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Python wrapper for the Codegen API - run code agents at scale</td>
   </tr>
@@ -356,7 +348,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
     <td class="alt-metric">—</td>
     <td class="growth growth-3m"><span class="growth-na">—</span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">AWS&#x27;s AI coding assistant (completions, transformations, agentic refactors).</td>
+    <td class="desc">AWS&#x27;s AI coding assistant (completions, transformations, agentic refactors). AWS announced IDE plugins and paid subscriptions are being sunset (new signups blocked 2026-05-15, end of support 2027-04-30), superseded by Kiro.</td>
   </tr>
   <tr>
     <td class="rank">—</td>
@@ -365,6 +357,14 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
     <td class="growth growth-3m"><span class="growth-na">—</span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">Agentic coding agent spinning out from Sourcegraph as a standalone company in 2026 (formerly Sourcegraph Cody); CLI + VS Code extension.</td>
+  </tr>
+  <tr>
+    <td class="rank">—</td>
+    <td class="name"><a href="https://antigravity.google/product/antigravity-cli" target="_blank" rel="noopener">Antigravity</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="alt-metric">—</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">Google&#x27;s Go-based agent-first development platform with a terminal CLI; replaced Gemini CLI on 2026-05-19 (Gemini CLI requests stop 2026-06-18). Distributed as a closed binary via install script.</td>
   </tr>
   <tr>
     <td class="rank">—</td>
@@ -377,7 +377,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <tr>
     <td class="rank">—</td>
     <td class="name"><a href="https://codebuff.com" target="_blank" rel="noopener">Codebuff</a></td>
-    <td class="alt-metric">—</td>
+    <td class="alt-metric">$1.5M raised</td>
     <td class="growth growth-3m"><span class="growth-na">—</span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">AI coding agent for the terminal.</td>
@@ -393,7 +393,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <tr>
     <td class="rank">—</td>
     <td class="name"><a href="https://cosine.sh" target="_blank" rel="noopener">Cosine Genie</a></td>
-    <td class="alt-metric">—</td>
+    <td class="alt-metric">$8M raised</td>
     <td class="growth growth-3m"><span class="growth-na">—</span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Fully autonomous AI software engineer using Cosine&#x27;s proprietary Genie model.</td>
@@ -401,26 +401,18 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <tr>
     <td class="rank">—</td>
     <td class="name"><a href="https://devin.ai" target="_blank" rel="noopener">Devin</a></td>
-    <td class="alt-metric">$696M raised</td>
+    <td class="alt-metric">$1000M raised</td>
     <td class="growth growth-3m"><span class="growth-na">—</span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Cognition AI&#x27;s autonomous software-engineer agent; parent company merged Windsurf (Cascade IDE) into its stack in 2025.</td>
+    <td class="desc">Cognition AI&#x27;s autonomous software-engineer agent; parent company also owns Windsurf (Cascade IDE, merged into its stack in 2025).</td>
   </tr>
   <tr>
     <td class="rank">—</td>
     <td class="name"><a href="https://github.com/features/copilot" target="_blank" rel="noopener">GitHub Copilot</a></td>
-    <td class="alt-metric">20.0M users</td>
+    <td class="alt-metric">4.7M users</td>
     <td class="growth growth-3m"><span class="growth-na">—</span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">GitHub&#x27;s AI pair programmer (completion + chat + coding agent).</td>
-  </tr>
-  <tr>
-    <td class="rank">—</td>
-    <td class="name"><a href="https://kiro.dev" target="_blank" rel="noopener">Kiro</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="alt-metric">—</td>
-    <td class="growth growth-3m"><span class="growth-na">—</span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">AWS-backed agentic IDE with spec-driven development and autonomous task execution.</td>
   </tr>
   <tr>
     <td class="rank">—</td>
@@ -473,7 +465,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 </tbody></table>
 
   <h2 class="section-title">Agent Orchestrators</h2>
-  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-05-15.</p>
+  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-07-05.</p>
   <table class="landscape-table">
 <thead><tr>
   <th class="rank">#</th><th>Name</th><th>Stars</th><th class="growth-3m">Recent growth</th><th>Irrlicht</th><th>Description</th>
@@ -482,91 +474,115 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 
   <tr>
     <td class="rank">#1</td>
+    <td class="name"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
+    <td class="stars">63,063</td>
+    <td class="growth growth-3m"><span class="growth-up">+11,802 <span class="growth-pct">(+23.0%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">🌊 The leading agent meta-harness. Deploy intelligent multi-player swarms, coordinate autonomous workflows, and build conversational AI systems. Features adaptive memory, self-learning intelligence, RAG integration, and native Claude Code / Codex / Hermes and many more Integrated</td>
+  </tr>
+  <tr>
+    <td class="rank">#2</td>
     <td class="name"><a href="https://paperclip.ing" target="_blank" rel="noopener">Paperclip</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">65,560</td>
-    <td class="growth growth-3m"><span class="growth-up">+7,177 <span class="growth-pct">(+12.3%)</span></span></td>
+    <td class="stars">72,750</td>
+    <td class="growth growth-3m"><span class="growth-up">+7,190 <span class="growth-pct">(+11.0%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">The open-source app everyone uses to manage agents at work</td>
   </tr>
   <tr>
-    <td class="rank">#2</td>
-    <td class="name"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
-    <td class="stars">51,261</td>
-    <td class="growth growth-3m"><span class="growth-up">+18,182 <span class="growth-pct">(+55.0%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Agent orchestration platform for Claude: multi-agent swarms, RAG integration, Claude Code / Codex integration.</td>
-  </tr>
-  <tr>
     <td class="rank">#3</td>
     <td class="name"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
-    <td class="stars">40,134</td>
-    <td class="growth growth-3m"><span class="growth-up">+486 <span class="growth-pct">(+1.2%)</span></span></td>
+    <td class="stars">40,999</td>
+    <td class="growth growth-3m"><span class="growth-up">+865 <span class="growth-pct">(+2.2%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Build, run, and manage agent platforms.</td>
   </tr>
   <tr>
     <td class="rank">#4</td>
     <td class="name"><a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener">ChatDev</a></td>
-    <td class="stars">33,093</td>
-    <td class="growth growth-3m"><span class="growth-up">+246 <span class="growth-pct">(+0.7%)</span></span></td>
+    <td class="stars">33,658</td>
+    <td class="growth growth-3m"><span class="growth-up">+565 <span class="growth-pct">(+1.7%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">ChatDev 2.0: Dev All through LLM-powered Multi-Agent Collaboration</td>
   </tr>
   <tr>
     <td class="rank">#5</td>
-    <td class="name"><a href="https://github.com/stitionai/devika" target="_blank" rel="noopener">Devika</a></td>
-    <td class="stars">19,507</td>
-    <td class="growth growth-3m"><span class="growth-up">+5 <span class="growth-pct">(+0.0%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Open-source agentic software engineer (originally an open alternative to Devin).</td>
-  </tr>
-  <tr>
-    <td class="rank">#6</td>
     <td class="name"><a href="https://github.com/gastownhall/gastown" target="_blank" rel="noopener">Gas Town</a></td>
-    <td class="stars">15,195</td>
-    <td class="growth growth-3m"><span class="growth-up">+615 <span class="growth-pct">(+4.2%)</span></span></td>
+    <td class="stars">16,235</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,040 <span class="growth-pct">(+6.8%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
     <td class="desc">Gas Town - multi-agent workspace manager</td>
   </tr>
   <tr>
+    <td class="rank">#6</td>
+    <td class="name"><a href="https://composio.dev" target="_blank" rel="noopener">Composio</a></td>
+    <td class="stars">8,053</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,006 <span class="growth-pct">(+14.3%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Agentic orchestrator for parallel coding agents — plans tasks, spawns agents, and autonomously handles CI fixes, merge conflicts, and code reviews.</td>
+  </tr>
+  <tr>
     <td class="rank">#7</td>
     <td class="name"><a href="https://github.com/smtg-ai/claude-squad" target="_blank" rel="noopener">Claude Squad</a></td>
-    <td class="stars">7,475</td>
-    <td class="growth growth-3m"><span class="growth-up">+330 <span class="growth-pct">(+4.6%)</span></span></td>
+    <td class="stars">8,023</td>
+    <td class="growth growth-3m"><span class="growth-up">+548 <span class="growth-pct">(+7.3%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">Manage multiple AI terminal agents like Claude Code, Codex, OpenCode, and Amp.</td>
   </tr>
   <tr>
     <td class="rank">#8</td>
-    <td class="name"><a href="https://composio.dev" target="_blank" rel="noopener">Composio</a></td>
-    <td class="stars">7,047</td>
-    <td class="growth growth-3m"><span class="growth-up">+573 <span class="growth-pct">(+8.9%)</span></span></td>
+    <td class="name"><a href="https://github.com/stitionai/devika" target="_blank" rel="noopener">Devika</a></td>
+    <td class="stars">19,535</td>
+    <td class="growth growth-3m"><span class="growth-up">+28 <span class="growth-pct">(+0.1%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Agentic orchestrator for parallel coding agents — plans tasks, spawns agents, and autonomously handles CI fixes, merge conflicts, and code reviews.</td>
+    <td class="desc">Devika is the first open-source implementation of an Agentic Software Engineer. Initially started as an open-source alternative to Devin.</td>
   </tr>
   <tr>
     <td class="rank">#9</td>
+    <td class="name"><a href="https://github.com/generalaction/emdash" target="_blank" rel="noopener">Emdash</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">5,070</td>
+    <td class="growth growth-3m"><span class="growth-up">+360 <span class="growth-pct">(+7.6%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Emdash is the Open-Source Agentic Development Environment (🧡 YC W26). Run multiple coding agents in parallel. Use any provider.</td>
+  </tr>
+  <tr>
+    <td class="rank">#10</td>
+    <td class="name"><a href="https://github.com/darrenhinde/OpenAgentsControl" target="_blank" rel="noopener">OpenAgentsControl</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">4,484</td>
+    <td class="growth growth-3m"><span class="growth-up">+297 <span class="growth-pct">(+7.1%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">AI agent framework for plan-first development workflows with approval-based execution. Multi-language support (TypeScript, Python, Go, Rust) with automatic testing, code review, and validation built for OpenCode</td>
+  </tr>
+  <tr>
+    <td class="rank">#11</td>
+    <td class="name"><a href="https://bernstein.run" target="_blank" rel="noopener">Bernstein</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">634</td>
+    <td class="growth growth-3m"><span class="growth-up">+104 <span class="growth-pct">(+19.6%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, +40 more). HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on. https://bernstein.run</td>
+  </tr>
+  <tr>
+    <td class="rank">#12</td>
     <td class="name"><a href="https://github.com/dlorenc/multiclaude" target="_blank" rel="noopener">Multiclaude</a></td>
-    <td class="stars">548</td>
-    <td class="growth growth-3m"><span class="growth-up">+9 <span class="growth-pct">(+1.7%)</span></span></td>
+    <td class="stars">555</td>
+    <td class="growth growth-3m"><span class="growth-up">+7 <span class="growth-pct">(+1.3%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">Parallel Claude Code instances in tmux with a Brownian-ratchet CI model.</td>
   </tr>
   <tr>
-    <td class="rank">#10</td>
+    <td class="rank">#13</td>
     <td class="name"><a href="https://stoneforge.ai" target="_blank" rel="noopener">Stoneforge</a></td>
-    <td class="stars">143</td>
-    <td class="growth growth-3m"><span class="growth-up">+13 <span class="growth-pct">(+10.0%)</span></span></td>
+    <td class="stars">160</td>
+    <td class="growth growth-3m"><span class="growth-up">+17 <span class="growth-pct">(+11.9%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">A web dashboard and runtime for orchestrating AI coding agents</td>
   </tr>
   <tr>
-    <td class="rank">#11</td>
+    <td class="rank">#14</td>
     <td class="name"><a href="https://forge.nxtg.ai" target="_blank" rel="noopener">Forge Orchestrator</a></td>
-    <td class="stars">116</td>
-    <td class="growth growth-3m"><span class="growth-up">+7 <span class="growth-pct">(+6.4%)</span></span></td>
+    <td class="stars">128</td>
+    <td class="growth growth-3m"><span class="growth-up">+12 <span class="growth-pct">(+10.3%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Rust-based multi-AI task orchestrator with file locking and drift detection.</td>
+    <td class="desc">Forge Orchestrator: Multi-AI task orchestration. File locking, knowledge capture, drift detection. Rust.</td>
   </tr>
 </tbody></table>
 </div>


### PR DESCRIPTION
## Summary
- Refreshed GitHub stars/language/license/description for all 40 tracked GitHub-backed agents and orchestrators, and funding/user metrics for the 15 closed-source entries.
- Marked Gemini CLI, Antigravity, and Kiro as `irrlicht_support: live` — `core/adapters/inbound/agents/all.go`'s `All()` already wires them into the daemon; the skill's mapping doc was stale.
- Archived Void and Roo Code (both repos marked `archived: true` upstream) into a new top-level `archived` array in `agent-data.json` so they drop out of the ranked tables without losing their history; updated `skill.md` to document that schema addition.
- Followed Composio's orchestrator repo transfer from `ComposioHQ/agent-orchestrator` to `AgentWrapper/agent-orchestrator` (flagging for follow-up: the product's own site still attributes it to Composio, but GitHub ownership says otherwise).
- Corrected a stale GitHub Copilot user-count figure that had conflated it with Microsoft 365 Copilot (~20M seats) — now sourced to GitHub Copilot's own ~4.7M paid-subscriber disclosure.
- Regenerated `site/landscape/index.html` and `site/landscape/compare/index.html`.

## Test plan
- [x] `tools/preflight.sh` ran automatically via the pre-push hook — gofmt, full Go test suite, onboarding-factory tests, replaydata validate, recording-rig smoke test, both web test suites, and the ARS architecture gate all passed.
- [x] Spot-checked generated HTML: archived agents excluded from ranked/no-repo tables, Kiro shows as `live` with a NEW badge, Composio's rename resolved correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)