### PR TITLE
feat(skills): ir:doc-review fixes findings directly, files issues only as fallback

### DIFF
--- a/.claude/skills/ir:agent-releases/skill.md
+++ b/.claude/skills/ir:agent-releases/skill.md
@@ -1,6 +1,6 @@
 ---
 name: "ir:agent-releases"
-description: "Check latest releases of coding agents monitored by irrlicht (Claude Code, OpenAI Codex, Pi, Gas Town) and report new features that impact session monitoring. Use when user says 'agent releases', 'check releases', 'agent updates', '/ir:agent-releases', or wants to know if upstream agent changes affect irrlicht."
+description: "Check latest releases of coding agents monitored by irrlicht (Claude Code, OpenAI Codex, Pi, Gas Town, Aider, OpenCode, Gemini CLI, Kiro CLI, Antigravity) and report new features that impact session monitoring. Use when user says 'agent releases', 'check releases', 'agent updates', '/ir:agent-releases', or wants to know if upstream agent changes affect irrlicht."
 ---
 
 # Agent Release Monitor for Irrlicht
@@ -36,6 +36,30 @@ Use WebSearch and WebFetch to find recent releases for each agent. Search in thi
 #### Gas Town
 - Search: `"Gas Town" orchestrator OR "gastown" coding agent release`
 - Note: Gas Town may be internal/limited. If no results found, note "no public releases found" and move on.
+
+#### Aider
+- Search: `"aider" changelog OR release notes site:aider.chat OR site:github.com/Aider-AI`
+- Also check: `https://github.com/Aider-AI/aider/blob/main/HISTORY.md`
+- Focus on: chat history file format (`.aider.chat.history.md`), CLI process naming, config file changes
+
+#### OpenCode
+- Search: `"opencode" changelog OR release notes site:github.com/anomalyco`
+- Also check: `https://github.com/anomalyco/opencode/releases`
+- Focus on: session database schema (`~/.local/share/opencode/opencode.db`), process name, config file changes
+
+#### Gemini CLI
+- Search: `"Gemini CLI" changelog OR release notes site:github.com/google-gemini`
+- Also check: `https://github.com/google-gemini/gemini-cli/releases`
+- Focus on: session transcript format under `~/.gemini/tmp/`, process naming (`bin/gemini`), heap-bump worker re-exec behavior
+
+#### Kiro CLI
+- Search: `"Kiro CLI" OR "AWS Kiro" changelog OR release notes site:github.com/kirodotdev`
+- Also check: `https://github.com/kirodotdev/Kiro/releases`
+- Focus on: session transcript format under `~/.kiro/sessions/cli/`, sidecar metadata schema, process naming
+
+#### Antigravity
+- Search: `"Google Antigravity" IDE changelog OR release notes`
+- Note: Antigravity is closed-source with no public GitHub repo; check the official product site/blog. If no results found, note "no public releases found" and move on.
 
 ### 3. Analyze Impact
 

--- a/.claude/skills/ir:doc-review/SKILL.md
+++ b/.claude/skills/ir:doc-review/SKILL.md
@@ -30,9 +30,8 @@ literally** — never invent criteria, never grade on subjective grounds (tone, 
   file nothing. Use this first, and for the convergence check.
 - An optional path or glob — limit the audit to matching surfaces (default: all in-scope).
 
-Without `--report-only`, every run fixes what it finds. This is what `ir:release` Step 4b runs
-on every release (#834, #837), so drift can't silently accumulate the way the stale "no hooks"
-claim once did.
+`ir:release` Step 4b runs this fix-by-default workflow on every release (#834, #837), so drift
+can't silently accumulate the way the stale "no hooks" claim once did.
 
 ## Workflow
 
@@ -92,13 +91,18 @@ reuses it verbatim for whatever remains unresolved):
 - **Exact fix** — the specific replacement text / precise addition / reference to correct.
   Agent-ready imperative, no "consider" or "maybe". For C1/C3/C4 (missing content) this means
   actually drafting the missing section/example/mention, grounded in the authoritative
-  code-derived source — not just describing that something is missing.
+  code-derived source — not just describing that something is missing. When the authoritative
+  source is a comment claiming something is "reserved", "not yet implemented", or "future work",
+  verify that against actual call sites/behavior (grep for where the constant/function is really
+  used) before repeating the comment as fact — comments go stale faster than code, and a drafted
+  fix that just echoes a stale comment is itself a new validity defect.
 - **Verification** — the concrete re-check (e.g. "the path resolves", "the grid lists all 7
   adapters", "the count matches `All()`").
 
 ### 6b. Apply every determinable fix directly
-Skip this step entirely if `--report-only` was passed — every finding then falls straight
-through to step 7 unchanged, and nothing is edited.
+Skip this step entirely if `--report-only` was passed — every finding then stays unresolved and
+flows straight to step 8's report. Step 7 (which files/closes issues) is also skipped under
+`--report-only`, so nothing is edited and no GitHub issue is touched either.
 
 Otherwise, for each finding: re-locate the anchor by its verbatim quote (don't trust the
 original line number — an earlier edit in the same file may have shifted it), apply the "Exact
@@ -122,7 +126,14 @@ fix" text from step 6, then immediately run that finding's own "Verification" ch
 Record every successfully applied fix (surface + finding-ID) for the step 8 summary.
 
 ### 7. File or close issues only for what's left unresolved (skip entirely if --report-only)
-This should be the rare exception, not the common case — most runs file nothing.
+
+First, fetch every currently-open doc-review issue **once**, up front — this single list drives
+both the create-or-update loop and the close-stale-issues step below, so a surface with zero
+unresolved findings this run (nothing to loop over otherwise) can still be checked for a stale
+issue to close:
+`gh issue list --repo ingo-eichhorst/Irrlicht --state open --search "in:title docs(" --json number,title,body`
+Extract each returned issue's surface from its title (`docs(<surface>): …`) into a
+surface→issue-number map.
 
 For each surface with ≥1 **unresolved** finding after step 6b:
 - **Title:** `docs(<surface>): <N> findings — <c> Critical / <m> Major / <n> Minor / <k> Nit`
@@ -135,15 +146,15 @@ For each surface with ≥1 **unresolved** finding after step 6b:
     verification check failed).
   - Last line — the hidden reconciliation marker (one line, exactly):
     `<!-- ir:doc-review surface=<path> findings=<id1,id2,...> -->`
-- `gh issue list --repo ingo-eichhorst/Irrlicht --state open --search "in:title docs(<surface>)" --json number,body,title`.
-  - **No match →** `gh issue create` with the title/body above and labels: `documentation`, the
-    matching `scope:*` (mapping below), and `needs-triage`.
-  - **Match →** read the existing body's marker and compare its finding-ID set to the new one.
-    If the sets differ, rebuild title+body and `gh issue edit <N> --body-file … --title …` in a
-    single call. If identical, leave the issue untouched.
+- **No entry for this surface in the map →** `gh issue create` with the title/body above and
+  labels: `documentation`, the matching `scope:*` (mapping below), and `needs-triage`.
+- **Entry found →** read the existing body's marker and compare its finding-ID set to the new
+  one. If the sets differ, rebuild title+body and `gh issue edit <N> --body-file … --title …` in
+  a single call. If identical, leave the issue untouched.
 
-For each surface that has an existing **open** `docs(<surface>): …` issue but zero unresolved
-findings this run (everything got fixed directly, or the prior findings no longer reproduce):
+For each surface **in the map** (has an existing open issue) that does **not** appear in the
+≥1-unresolved-finding loop above — everything got fixed directly, or the prior findings no
+longer reproduce:
 `gh issue close <N> --comment "All findings resolved directly by ir:doc-review — see the fixes to <surface>."`
 
 Never open a second issue for a surface that already has one. Leave priority and

--- a/.claude/skills/ir:doc-review/SKILL.md
+++ b/.claude/skills/ir:doc-review/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: ir:doc-review
-description: Audit all project documentation for understandability, completeness, and validity using objective, binary criteria, then file one GitHub issue per documentation surface with exact, agent-ready fixes. Every finding is anchored to a quoted location and stamped with a stable ID so independent runs converge. Triggers on "/ir:doc-review", "audit docs", "review documentation", "check the docs", "doc audit". Supports a --report-only dry run and a --fix mode that applies high-confidence corrections directly instead of filing an issue for them.
+description: Audit all project documentation for understandability, completeness, and validity using objective, binary criteria, then fix every finding directly in place. Filing a GitHub issue is the rare fallback — only for a finding whose fix is genuinely ambiguous or that fails verification after being applied. Every finding is anchored to a quoted location and stamped with a stable ID so independent runs converge. Triggers on "/ir:doc-review", "audit docs", "review documentation", "check the docs", "doc audit". Supports a --report-only dry run that changes nothing and files nothing.
 ---
 
 # ir:doc-review — Objective Documentation Audit
 
 Goal: audit **every** in-scope documentation surface against three axes —
-**understandability (U)**, **completeness (C)**, **validity (V)** — and emit **one GitHub
-issue per surface** containing exact, agent-ready fixes.
+**understandability (U)**, **completeness (C)**, **validity (V)** — and **fix every finding
+directly, in place**. Filing a GitHub issue is the fallback for the rare finding that can't be
+safely applied (see step 7) — it is not the default outcome of a finding.
 
 The audit must be **reproducible**: every finding is binary (a named criterion failed),
 anchored to a verbatim quote at a location, scored by a fixed severity rubric, and stamped with
@@ -25,16 +26,13 @@ literally** — never invent criteria, never grade on subjective grounds (tone, 
 
 ## Inputs
 
-- `--report-only` — run the full audit and print per-surface findings, but file nothing. Use
-  this first, and for the convergence check.
-- `--fix` — after scoring (step 5), apply direct edits for the auto-fix-eligible findings
-  defined in step 6b instead of filing an issue for them; every other finding still gets filed
-  as an issue in step 7. This is what `ir:release` Step 4b runs on every release (#834), so
-  drift can't silently accumulate the way the stale "no hooks" claim did — that claim's fix
-  (correcting existing prose to match a code-derived fact, no new content authored) is exactly
-  the auto-fix-eligible shape. Combine with `--report-only` to preview which findings would be
-  auto-fixed vs. filed, without touching any file or opening any issue.
+- `--report-only` — run the full audit and print per-surface findings, but change nothing and
+  file nothing. Use this first, and for the convergence check.
 - An optional path or glob — limit the audit to matching surfaces (default: all in-scope).
+
+Without `--report-only`, every run fixes what it finds. This is what `ir:release` Step 4b runs
+on every release (#834, #837), so drift can't silently accumulate the way the stale "no hooks"
+claim once did.
 
 ## Workflow
 
@@ -86,61 +84,67 @@ in the rubric, fan-out must not change the result.
 - Compute the stable finding-ID exactly as `references/rubric.md` specifies. Same input → same
   ID across runs.
 
-### 6. Build one issue body per surface
-For each surface with ≥1 finding:
+### 6. Draft the fix for each finding
+For every finding, write out (this is scratch working state, not an issue body yet — step 7
+reuses it verbatim for whatever remains unresolved):
+- **Location** — `file:line` (or HTML anchor) + a verbatim quote of the offending text.
+- **What's wrong** — one sentence, tied to the named criterion.
+- **Exact fix** — the specific replacement text / precise addition / reference to correct.
+  Agent-ready imperative, no "consider" or "maybe". For C1/C3/C4 (missing content) this means
+  actually drafting the missing section/example/mention, grounded in the authoritative
+  code-derived source — not just describing that something is missing.
+- **Verification** — the concrete re-check (e.g. "the path resolves", "the grid lists all 7
+  adapters", "the count matches `All()`").
+
+### 6b. Apply every determinable fix directly
+Skip this step entirely if `--report-only` was passed — every finding then falls straight
+through to step 7 unchanged, and nothing is edited.
+
+Otherwise, for each finding: re-locate the anchor by its verbatim quote (don't trust the
+original line number — an earlier edit in the same file may have shifted it), apply the "Exact
+fix" text from step 6, then immediately run that finding's own "Verification" check.
+
+- If the quote no longer matches the live file, or verification fails after the edit, **revert
+  the edit** and mark the finding **unresolved** — never leave a half-applied or unverified edit
+  in a doc, and never fuzzy-match a quote that's moved.
+- Skip applying (mark **unresolved**) only when the "Exact fix" is genuinely ambiguous — the
+  finding itself supports two materially different valid corrections and picking one is a real
+  judgment call, not just an authoring effort. This is a per-finding judgment, not a blanket
+  exemption for a whole criterion or axis — most C1/C3/C4/U-axis findings have one obviously
+  correct fix (add the missing mention, name the missing surface, state the missing example)
+  and should be applied like any other.
+- External-link liveness (V3, external links only) is never a fix target and never becomes an
+  unresolved finding either — it's owner-side and reported informationally in step 8, nothing
+  more.
+- When a surface has more than one finding, apply them bottom-of-file-upward so an earlier edit
+  can't shift a later finding's anchor off target.
+
+Record every successfully applied fix (surface + finding-ID) for the step 8 summary.
+
+### 7. File or close issues only for what's left unresolved (skip entirely if --report-only)
+This should be the rare exception, not the common case — most runs file nothing.
+
+For each surface with ≥1 **unresolved** finding after step 6b:
 - **Title:** `docs(<surface>): <N> findings — <c> Critical / <m> Major / <n> Minor / <k> Nit`
   (omit zero buckets). `<surface>` is the repo-relative path.
 - **Body:**
   - First line: `> *Generated by AI (ir:doc-review). Verify before acting.*`
   - A findings table with columns: ID · Axis+Criterion · Severity · Location.
-  - Then one `###` section per finding, in this exact order:
-    - **Location** — `file:line` (or HTML anchor) + a verbatim quote of the offending text.
-    - **What's wrong** — one sentence, tied to the named criterion.
-    - **Exact fix** — the specific replacement text / precise addition / reference to correct.
-      Agent-ready imperative, no "consider" or "maybe".
-    - **Verification** — the concrete re-check (e.g. "the path resolves", "the grid lists all 7
-      adapters", "the count matches `All()`").
+  - Then one `###` section per finding (Location / What's wrong / Exact fix / Verification, as
+    drafted in step 6), plus a line stating *why* it's unresolved (ambiguous fix, or which
+    verification check failed).
   - Last line — the hidden reconciliation marker (one line, exactly):
     `<!-- ir:doc-review surface=<path> findings=<id1,id2,...> -->`
+- `gh issue list --repo ingo-eichhorst/Irrlicht --state open --search "in:title docs(<surface>)" --json number,body,title`.
+  - **No match →** `gh issue create` with the title/body above and labels: `documentation`, the
+    matching `scope:*` (mapping below), and `needs-triage`.
+  - **Match →** read the existing body's marker and compare its finding-ID set to the new one.
+    If the sets differ, rebuild title+body and `gh issue edit <N> --body-file … --title …` in a
+    single call. If identical, leave the issue untouched.
 
-### 6b. Apply auto-fix-eligible findings directly (only with `--fix`)
-Skip this step entirely unless `--fix` was passed — without it, every finding built in step 6
-falls straight through to step 7 unchanged.
-
-For each finding, decide whether it is **auto-fix eligible** before step 7 runs:
-
-- **Eligible criteria:** V1, V2, V4, V5, V6, C2. These are exactly the findings where an
-  existing claim is directly contradicted by a code-derived inventory/fact
-  (`inventory-sources.md`), and step 6's own "Exact fix" text is a direct in-place correction or
-  removal — no new section, paragraph, or example needs authoring.
-- **Never eligible — always falls through to step 7:** U1–U6 (wording/ordering/audience are
-  judgment calls), C1/C3/C4 (missing mention, missing surface, missing example — these need new
-  content authored, not a correction), and V3 (link/anchor liveness — never blocking per the
-  severity rubric anyway).
-- Even within an eligible criterion, if the "Exact fix" isn't unambiguous from the inventory
-  alone — the claim could be resolved two different ways and picking one is a judgment call —
-  file it in step 7 instead of guessing.
-
-For each eligible finding: re-locate the anchor by its verbatim quote (don't trust the original
-line number — an earlier edit in the same file may have shifted it), apply the "Exact fix" text
-from step 6 verbatim, then immediately run that finding's own "Verification" check. If the quote
-no longer matches the live file, or verification fails after the edit, **revert the edit** and
-leave the finding in the surface's draft issue body for step 7 — never leave a half-applied or
-unverified edit in a doc, and never fuzzy-match a quote that's moved. When a surface has more
-than one eligible finding, apply them bottom-of-file-upward so an earlier edit can't shift a
-later finding's anchor off target.
-
-Remove every successfully auto-fixed finding from its surface's draft issue body (built in step
-6) before step 7 runs, and record it (surface + finding-ID) for the step 8 summary.
-
-### 7. Dedupe and file (skip entirely if --report-only)
-For each surface with findings remaining after step 6b (all findings, if `--fix` was not passed):
-1. `gh issue list --repo ingo-eichhorst/Irrlicht --state open --search "in:title docs(<surface>)" --json number,body,title`.
-2. **No match →** `gh issue create` with the title/body above and labels: `documentation`, the
-   matching `scope:*` (mapping below), and `needs-triage`.
-3. **Match →** read the existing body's marker and compare its finding-ID set to the new one.
-   If the sets differ, rebuild title+body and `gh issue edit <N> --body-file … --title …` in a
-   single call. If identical, leave the issue untouched.
+For each surface that has an existing **open** `docs(<surface>): …` issue but zero unresolved
+findings this run (everything got fixed directly, or the prior findings no longer reproduce):
+`gh issue close <N> --comment "All findings resolved directly by ir:doc-review — see the fixes to <surface>."`
 
 Never open a second issue for a surface that already has one. Leave priority and
 `ready-for-agent` to `ir:triage`. Create no new labels.
@@ -152,21 +156,21 @@ Scope-label mapping:
 - anything else (`README.md`, `CONTRIBUTING.md`, …) → no scope label
 
 ### 8. Print the run summary
-Always print: surfaces scanned, a findings-by-axis-and-severity table, and — unless
-`--report-only` — the issues created / updated / unchanged with their URLs. When `--fix` was
-set, also print the findings auto-fixed directly (surface + finding-ID, from step 6b) separately
-from the findings that still got filed as issues.
+Always print: surfaces scanned, a findings-by-axis-and-severity table, and the findings fixed
+directly (surface + finding-ID, from step 6b). Unless `--report-only`, also print any issues
+created / updated / closed with their URLs, and any findings still unresolved (with the reason)
+— this list should normally be empty or very short.
 
 ## Conventions
 
 - `gh` always targets `ingo-eichhorst/Irrlicht`.
 - Reuse existing labels only; never create new labels.
-- Without `--fix`, the skill **only reports** — it never edits documentation. With `--fix`, it
-  edits documentation directly, but only for the auto-fix-eligible findings defined in step 6b;
-  everything else still only gets filed as an issue, same as without the flag.
-- `--fix` never commits or opens a PR itself — it leaves auto-fixed files as uncommitted
-  working-tree changes for whatever invoked it (a release commit via `ir:release` Step 4b, or
-  the user's own review when run standalone) to pick up.
-- External-link liveness is reported but never blocks (see V3).
+- `--report-only` is the only mode that doesn't edit documentation. Every other run fixes
+  every determinable finding directly and files (or closes) an issue only for what's left
+  unresolved per step 6b/7.
+- Direct fixes never get committed or turned into a PR by this skill itself — it leaves them as
+  uncommitted working-tree changes for whatever invoked it (a release commit via `ir:release`
+  Step 4b, or the user's own review when run standalone) to pick up.
+- External-link liveness is reported but never blocks and never gets filed (see V3).
 - When uncertain whether something is a finding, re-read the criterion: if it isn't a binary
   failure you can quote, drop it. A false positive costs more than a missed nit.

--- a/.claude/skills/ir:doc-review/references/inventory-sources.md
+++ b/.claude/skills/ir:doc-review/references/inventory-sources.md
@@ -69,11 +69,16 @@ grep -rhoE 'os\.Getenv\("[A-Z_]+"\)' core --include='*.go' \
 
 The **config inventory** that completeness checks against is the user-facing subset only:
 
-- **Include:** every var matching `^IRRLICHT_`, plus the documented externals `NO_COLOR`,
-  `GT_BIN`, `GT_ROOT` (Gas Town orchestrator config).
+- **Include:** every var matching `^IRRLICHT_` that the grep recipe below can actually see — i.e.
+  passed to a Go `os.Getenv("...")` call as a string literal under `core/` — plus the documented
+  externals `NO_COLOR`, `GT_BIN`, `GT_ROOT` (Gas Town orchestrator config).
 - **Exclude (not user config):** `HOME`, `XDG_CONFIG_HOME` (standard OS env); and all
   test/build/helper vars — `GO_WANT_*`, `OBSERVER_HELPER_*`, `GASTOWN_FIXTURES_DIR`, and
   anything only read under `_test.go`.
+- **Out of the recipe's reach (verify by hand):** vars read via a named Go constant rather than a
+  string literal — e.g. `IRRLICHT_UI_DIR`, read as `os.Getenv(envUIDir)` in
+  `core/cmd/irrlichd/main.go` / `paths.go` — and vars read from Swift rather than Go, e.g.
+  `IRRLICHT_DAEMON_PORT` in `platforms/macos/Irrlicht/Managers/DaemonEndpoint.swift`.
 
 ```bash
 grep -rhoE 'os\.Getenv\("(IRRLICHT_[A-Z_]+|NO_COLOR|GT_BIN|GT_ROOT)"\)' core --include='*.go' \

--- a/.claude/skills/ir:onboarding-factory/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/SKILL.md
@@ -46,8 +46,8 @@ unattended / scheduled run. The goal is **a valid report and a reviewable PR by
 morning, with every cell that *can* be observed actually observed** — not just
 the easy ones. Run **fully autonomously**: never call `AskUserQuestion` /
 `ExitPlanMode` / block on a prompt mid-run — make the sensible call, document it,
-and keep going. Emit a one-line status at each stage boundary (see
-[[feedback_overnight_pushthrough]]); the final PR body *is* the morning report.
+and keep going. Emit a one-line status at each stage boundary; the final PR
+body *is* the morning report.
 
 This is more than the standard sweep. Work three passes until the matrix stops
 moving:

--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -283,7 +283,7 @@ For **patch releases**, skip Step D — the future section stays unchanged. The 
 
 ### 4b. Doc + README sweep (mandatory)
 
-Run the `/ir:doc-review --fix` workflow inline — see
+Run the `/ir:doc-review` workflow inline — see
 `.claude/skills/ir:doc-review/SKILL.md` for the full audit (this is that
 skill's "release-inline" use, same pattern as Step 1.5's
 `/ir:refresh-aliases`). Check every in-scope surface against **current
@@ -299,20 +299,18 @@ code-derived truth**, not just this release's diff:
    since. That gap is exactly what let README.md and `site/index.html` both
    keep claiming "no hooks" for several releases after the `claudecode`
    hooks feature shipped (#834).
-2. Apply the rubric per surface (steps 4–6) and auto-fix every
-   high-confidence finding directly (step 6b) — an existing claim directly
-   contradicted by a code fact, corrected in place with no new content
-   authored. The stale "no hooks" claim above is exactly this shape.
-3. File a GitHub issue (step 7) for anything left — findings that need new
-   content authored or a judgment call (missing docs, unclear sections, new
-   examples).
+2. Apply the rubric per surface (steps 4–6) and fix every finding directly
+   in place (step 6b) — including drafting missing content, not just
+   correcting claims that contradict a code fact. The stale "no hooks"
+   claim above is exactly the simplest case of this shape.
+3. File a GitHub issue (step 7) only for the rare finding left unresolved —
+   a genuinely ambiguous fix, or one that failed its own verification check.
 
 Then:
-- Review every auto-fixed surface yourself — confirm the edit reads
-  correctly in context before it ships, don't just trust that a diff
-  exists.
-- Leave the auto-fixed edits uncommitted; Step 7a's `git add` picks them up
-  alongside the other release artefacts.
+- Review every fixed surface yourself — confirm the edit reads correctly
+  in context before it ships, don't just trust that a diff exists.
+- Leave the fixes uncommitted; Step 7a's `git add` picks them up alongside
+  the other release artefacts.
 - Treat any newly filed/updated issue as a separate follow-up, not a
   release blocker — don't let it stall this release.
 
@@ -529,18 +527,19 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
    the full template below verbatim, substituting only `$NEW_VERSION` and
    the build number.
 
-   **Coupling rule:** the build now uses Developer ID signing with the
-   entitlements file, so `com.apple.developer.focus-status` is properly
-   claimed. `FocusMonitor.swift` detects the Developer ID signature at
-   runtime and loads `INFocusStatusCenter` via `NSClassFromString` —
-   no static `Intents.framework` link. (#357 tracks the eventual cleanup
-   to static `import Intents` once we confirm the dynamic gate is no
-   longer needed.)
+   **Coupling rule:** the entitlement is **not** currently claimed.
+   `com.apple.developer.focus-status` was stripped in v0.4.7 (AMFI POSIX
+   153 killed launches); `Irrlicht.entitlements` is an empty `<dict/>`
+   until #357 restores it with a provisioning profile. `FocusMonitor.swift`
+   still detects the Developer ID signature at runtime and loads
+   `INFocusStatusCenter` via `NSClassFromString` — no static
+   `Intents.framework` link — so Focus-status support degrades gracefully
+   without the entitlement.
 
    | Key | Include for ad-hoc? | Include for DevID (current)? |
    |---|---|---|
    | `NSAppleEventsUsageDescription` | Yes | Yes |
-   | `NSFocusStatusUsageDescription` | **No** — the runtime gate keeps Intents.framework unloaded on ad-hoc builds; the key + a statically linked Intents causes a TCC SIGABRT (v0.4.3). | **Yes** — DevID is in place (#233/#357). The entitlement is authorized and the key is included in the template. |
+   | `NSFocusStatusUsageDescription` | **No** — the runtime gate keeps Intents.framework unloaded on ad-hoc builds; the key + a statically linked Intents causes a TCC SIGABRT (v0.4.3). | **Yes (key only)** — the Info.plist key is harmless without the entitlement; `com.apple.developer.focus-status` itself is not currently claimed (stripped in v0.4.7, tracked by #357). |
    | Anything new | Audit the source. If the relevant Swift code uses `import <Framework>` directly, the binary will link the framework, and TCC may preflight at startup. Either gate the source (FocusMonitor pattern) or skip the usage description until DevID. |
 
    ```xml
@@ -799,10 +798,13 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
       symbol just before `__TCC_CRASHING_DUE_TO_PRIVACY_VIOLATION__` is
       the API or framework the preflight checked.
    3. Compare `codesign -d --entitlements -` output against the prior
-      release. The DevID-signed binary should carry exactly
-      `com.apple.developer.focus-status`. Extra or missing entitlements
-      vs. `Irrlicht.entitlements` indicate a codesign step error — fix
-      and re-sign before shipping (v0.4.3 mode: AMFI kills mismatched
+      release. `Irrlicht.entitlements` is an empty `<dict/>` (the
+      `com.apple.developer.focus-status` entitlement was stripped in
+      v0.4.7 and stays out until #357 restores it with a provisioning
+      profile), so the DevID-signed binary should carry no extra
+      entitlements beyond that empty dict. Extra entitlements vs.
+      `Irrlicht.entitlements` indicate a codesign step error — fix and
+      re-sign before shipping (v0.4.3 mode: AMFI kills mismatched
       entitlements with POSIX 153, fixed in #356).
    4. If steps 1–3 all clear, copy the bundle to `/Applications/` (kill
       the prior install first) and retry. A real shipping defect will
@@ -893,7 +895,7 @@ on `main`.
 
 ```bash
 # Core release artefacts plus any doc surface the Step 4b sweep
-# (`/ir:doc-review --fix`) may have auto-fixed. The `git add -- ...` form is
+# (`/ir:doc-review`) may have fixed. The `git add -- ...` form is
 # safe for missing files/globs.
 git add version.json CHANGELOG.md site/ docs/ \
         platforms/macos/Irrlicht/Resources/Info.plist \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 </div>
 
-> 🟣 working · 🟠 waiting · 🟢 ready — one ambient dot per session, multi-agent, zero manual setup.
+> 🟣 working · 🟠 waiting · 🟢 ready — one ambient dot per session, multi-agent, one-click setup.
 
 ## Install
 
@@ -65,7 +65,7 @@ Stages: `stable` production-ready · `beta` feature-complete, edge cases remain 
 | Cursor Agent   | planned |
 | Amp            | planned |
 
-**Orchestrators**
+**Orchestrators** (tools that coordinate multiple agent sessions/rigs, rather than being a single coding agent)
 
 | Orchestrator          | Stage   |
 | --------------------- | ------- |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,9 @@
 
 ## Supported versions
 
-Irrlicht is a single-artifact macOS app and ships as rolling releases. Only
-the **latest release** published on
+Irrlicht ships as rolling releases: a single-artifact macOS app, plus a
+daemon-only Linux build (no menu-bar UI). Only the **latest release**
+published on
 [GitHub Releases](https://github.com/ingo-eichhorst/Irrlicht/releases/latest)
 receives security fixes. If you're on an older version, please update before
 reporting.

--- a/docs/relay-protocol.md
+++ b/docs/relay-protocol.md
@@ -20,9 +20,10 @@ irrlichd ──(daemon role)──▶ irrlichtrelay ◀──(client role)──
 - A client may connect to the local daemon **and/or** a relay at once and merges
   the sessions into one list. The daemon speaks **raw** `PushMessage` frames (no
   handshake); the relay speaks the **envelope** below.
-- v0 is deliberately thin: **no auth, no TLS, no persistence, single node, one
-  relay per daemon.** Relay state is in-memory and rebuilt from each daemon's
-  reconnect `daemon_snapshot`.
+- v0 is deliberately thin: **no persistence, single node, one relay per
+  daemon.** Auth and TLS are supported but off by default (see
+  [Auth, TLS, and origins](#auth-tls-and-origins)). Relay state is in-memory
+  and rebuilt from each daemon's reconnect `daemon_snapshot`.
 
 ## Versioning
 
@@ -65,7 +66,7 @@ set headers on a WebSocket — one channel serves daemon, macOS, and web alike.
 ```jsonc
 { "type": "daemon_snapshot",
   "sessions": [ <SessionState>, ... ],   // the daemon's current sessions
-  "agents":   [ <AgentInfo>, ... ] }     // its adapter registry (/api/v1/agents shape)
+  "agents":   [ <AgentInfo>, ... ] }     // its **adapter** registry (the daemon's per-agent-type integrations; /api/v1/agents shape)
 ```
 
 Sent once per (re)connect to reconcile the relay's cache. The relay replaces
@@ -104,6 +105,21 @@ trust the daemon's stamp) and re-emits to every client. **Clients read `.msg`
 and process it exactly as a raw daemon frame.** `focus_requested` is filtered at
 the forwarder (host-local; meaningless cross-host, wiki §5.4).
 
+### `control` (client → relay → daemon, upstream)
+
+```jsonc
+{ "type": "control", "target_daemon": "uuid", "session_id": "proc-1234",
+  "action": "input" | "interrupt", "data": "…" }                    // input only
+```
+
+The first client→relay→daemon frame in an otherwise one-way protocol (issue
+#724): a client asks a specific daemon to inject input or an interrupt into
+one of its sessions. The relay routes the frame to the addressed daemon
+within the client's own token-derived workspace, then drops
+`target_daemon`; the daemon re-gates it through the same consent path
+(backchannel toggle, per-agent consent, controllability) as a local request
+before forwarding to its `InputService`.
+
 ## Client behavior
 
 A single client handler covers both source kinds: it always sends a client
@@ -130,7 +146,7 @@ without an empty first paint, and serves the `platforms/web/` dashboard:
 
 | Endpoint              | Body                                                            |
 | --------------------- | -------------------------------------------------------------- |
-| `GET /api/v1/sessions` | `{ "groups": [...] }` — `BuildDashboard` over the cached sessions (grouped by project; no orchestrator state in v0). |
+| `GET /api/v1/sessions` | `{ "groups": [...] }` — `BuildDashboard` over the cached sessions (grouped by project; no **orchestrator** (Gas Town) state in v0). |
 | `GET /api/v1/agents`   | union of every connected daemon's registry, deduped by `name`. |
 | `GET /api/v1/version`  | the relay's own build version.                                 |
 | `GET /` (+ assets)     | the dashboard, served from disk (`IRRLICHT_UI_DIR` override, else dev/bundle lookup). |

--- a/events.md
+++ b/events.md
@@ -139,7 +139,7 @@ Subagent sessions run independent state machines with the same 3 states.
 | Axis | Values |
 |------|--------|
 | **CompactionState** | `not_compacting` / `compacting` / `post_compact` -- overlaid on `working` |
-| **Adapter** | `claude-code` / `codex` / future -- identifies source agent |
+| **Adapter** | `claude-code` / `codex` / `pi` / `aider` / `opencode` / `kiro-cli` / `gemini-cli` / `antigravity` -- identifies source agent |
 | **PressureLevel** | `safe` / `caution` / `warning` / `critical` -- context window utilization |
 
 ---
@@ -149,7 +149,7 @@ Subagent sessions run independent state machines with the same 3 states.
 Session files: `~/Library/Application Support/Irrlicht/instances/<sessionID>.json`
 Atomic writes via temp file + rename. Real-time updates fan out via WebSocket (`session_created`, `session_updated`, `session_deleted`).
 
-Memory store merges disk on `ListAll` to pick up sessions created externally (e.g. by `irrlicht-hook`).
+Memory store merges disk on `ListAll` to pick up sessions created externally (e.g. by the claudecode hooks receiver, `POST /api/v1/hooks/claudecode`).
 
 ## Session Discovery Paths
 
@@ -157,3 +157,9 @@ Memory store merges disk on `ListAll` to pick up sessions created externally (e.
 |-----------|-------------------|
 | Claude Code | `~/.claude/projects/**/*.jsonl` |
 | OpenAI Codex | `~/.codex/**/*.jsonl` |
+| Pi | `~/.pi/agent/sessions/**/*.jsonl` |
+| Aider | `<project-cwd>/.aider.chat.history.md` |
+| OpenCode | `~/.local/share/opencode/opencode.db` (SQLite, polled — not a JSONL glob) |
+| Kiro CLI | `~/.kiro/sessions/cli/*.jsonl` |
+| Gemini CLI | `~/.gemini/tmp/**/chats/*.jsonl` |
+| Antigravity | `~/.gemini/antigravity-cli/brain/**/transcript.jsonl` (CLI) and `~/.gemini/antigravity/brain/**/transcript.jsonl` (IDE) |

--- a/site/docs/adapters.html
+++ b/site/docs/adapters.html
@@ -229,11 +229,13 @@
 
       <p>Defined as a sealed-sum across three orthogonal axes in <code>core/domain/agent/</code>: <code>Identity</code> (name + branding), <code>Process</code> (how to find the OS process), and <code>Source</code> (where the conversation lives).</p>
 
-<pre><code>// Top-level declaration — Identity × Process × Source.
+<pre><code>// Top-level declaration — Identity × Process × Source × Control × Permissions.
 type Agent struct {
-    Identity Identity
-    Process  Process
-    Source   Source
+    Identity    Identity
+    Process     Process
+    Source      Source
+    Control     Control     // backchannel write-back capability (issue #724); zero value = not controllable
+    Permissions []Permission // consent-gated capabilities the daemon may exercise
 }
 
 type Identity struct {
@@ -247,8 +249,10 @@ type Identity struct {
 // PIDForSession lives here rather than on Source so every variant gets
 // it uniformly.
 type Process struct {
-    Match         ProcessMatcher
-    PIDForSession PIDDiscoverFunc
+    Match            ProcessMatcher
+    PIDForSession    PIDDiscoverFunc
+    ExcludeArgv      func(argv []string) bool // reject a matched PID by argv shape; nil = never exclude
+    RequireKnownHost bool                     // gate admission on OS-level process ancestry (issue #784)
 }
 
 type PIDDiscoverFunc func(
@@ -274,8 +278,11 @@ type Source interface{ isSource() }
 // JSONL transcripts under a fixed $HOME-relative directory tree
 // (Claude Code, Codex, Pi).
 type FilesUnderRoot struct {
-    Dir    string     // path relative to $HOME, e.g. ".claude/projects"
-    Parser FileParser // JSONLineParser or RawLineParser
+    Dir               string                    // path relative to $HOME, e.g. ".claude/projects"
+    Parser            FileParser                // JSONLineParser or RawLineParser
+    DirByOS           map[string]string         // per-GOOS override of Dir, e.g. Windows %APPDATA%
+    ExtraDirs         []string                  // additional roots watched alongside Dir
+    SessionIDFromPath func(path string) string  // override: derive session ID from path, not filename stem
 }
 
 // One transcript per running process inside its CWD (aider).
@@ -296,6 +303,28 @@ type FileParser interface{ isFileParser() }
 
 type JSONLineParser struct { NewParser func() LineParser }
 type RawLineParser  struct { NewParser func() RawParser }
+
+// Control declares whether and how the daemon may write input back into a
+// discovered session's terminal backend (issue #724, the "backchannel").
+type Control struct {
+    SupportsInput bool              // true for interactive TUI/REPL agents (false for headless stores)
+    Interrupt     InterruptMethod   // how an interrupt is delivered (none / Ctrl-C / signal)
+    Presets       map[string]string // backchannel preset id → this agent's literal command text
+}
+
+// Permission declares one consent-gated capability: what it touches, what
+// feature it unlocks, and (for modify-kind entries) how to apply/undo it.
+// Nothing is exercised until the user grants it (issue #570).
+type Permission struct {
+    Key             string          // stable identifier, e.g. "hooks", "transcripts"
+    Kind            permission.Kind // modify (writes a file) or observe (reads only)
+    Title           string          // short label for the wizard row
+    FeatureUnlocked string          // what granting enables
+    Touches         string          // what the daemon reads/writes when granted
+    Detail          string          // expanded (i) text: exact paths/commands, how to undo
+    Apply           func() error    // performs the modification on grant (nil for observe-kind)
+    Remove          func() error    // undoes it on revoke (nil for observe-kind)
+}
 </code></pre>
 
       <p>Which canonical scenarios apply to an adapter is no longer a static per-adapter declaration. It is judged per (scenario, adapter) cell by the <code>assess</code> verb of the <code>/ir:onboarding-factory</code> skill across three pillars (agent capability / daemon sensor capture / driver capability), recorded in each cell's <code>replaydata/agents/&lt;name&gt;/scenarios/&lt;cell&gt;/metadata.json</code>. None of it is read by Go daemon code.</p>
@@ -374,6 +403,7 @@ type Event struct {
     Size            int64
     CWD             string // working directory of the agent process
     ParentSessionID string // empty unless this is a subagent
+    Terminal        bool   // true when this activity event ends the agent's turn (fast-path debounce)
 }
 
 // The port the daemon consumes. Each per-watcher drain goroutine in
@@ -479,7 +509,7 @@ type Watcher interface {
         <li>Exports an <code>agent.Agent</code> from <code>Agent()</code> with the right <code>Source</code> variant (<code>FilesUnderRoot</code> / <code>FilesUnderCWD</code> / <code>ProcessOwnedStore</code>), parser, and PID-discovery hook</li>
         <li>Registered in the <code>allAgents</code> slice in <code>core/cmd/irrlichd/main.go</code></li>
         <li>Emits all three lifecycle states: <code>working</code>, <code>waiting</code>, <code>ready</code></li>
-        <li><code>replaydata/agents/&lt;name&gt;/capabilities.json</code> populated against <code>replaydata/agents/features.json</code></li>
+        <li>Scenario cells assessed via the <code>assess</code> verb of <code>/ir:onboarding-factory</code>, recorded in <code>replaydata/agents/&lt;name&gt;/scenarios/&lt;cell&gt;/metadata.json</code></li>
         <li><code>baseline-hello</code> and <code>full-lifecycle-toolcall</code> fixtures committed and replay green via <code>tools/replay-fixtures.sh</code></li>
       </ul>
 
@@ -501,7 +531,7 @@ type Watcher interface {
 
       <p><strong>For adapters, additionally:</strong></p>
       <ul class="checklist">
-        <li><strong>All</strong> scenarios in <code>replaydata/agents/scenarios.json</code> whose <code>requires</code> is covered by the adapter's capabilities replay green</li>
+        <li><strong>All</strong> scenario cells assessed <code>agent_supports: yes</code> (or <code>partial</code>) replay green &mdash; verdict recorded per cell in <code>replaydata/agents/&lt;name&gt;/scenarios/&lt;cell&gt;/metadata.json</code></li>
         <li>Model + cost extraction wired through <code>core/adapters/outbound/metrics/</code></li>
         <li>Subagent / parent-child linkage emits <code>ParentSessionID</code> where the agent supports subagents</li>
       </ul>

--- a/site/docs/api-reference.html
+++ b/site/docs/api-reference.html
@@ -319,6 +319,10 @@ curl -X POST http://127.0.0.1:7837/api/v1/sessions/52d087d1-.../input \
 
       <p>Default-OFF toggle gating whether the relay forwarder acts on inbound control frames (the outer remote-control gate, for driving sessions from a relay-served client). Same verbs and loopback/cross-origin rules; replies <code>{"relay_control_enabled": bool}</code>. A standalone/headless daemon can instead enable it at startup via <code>IRRLICHT_RELAY_CONTROL=on</code>.</p>
 
+      <h3>GET / POST / DELETE /api/v1/activation/task-eta</h3>
+
+      <p>Legacy alias (issue #558) over the <code>claude-code</code> adapter&rsquo;s <code>instructions</code> permission (issue #577), kept so the macOS Settings toggle&rsquo;s wire shape stays stable. <code>GET</code> reads the state, <code>POST</code> grants, <code>DELETE</code> revokes, each replying <code>{"task_eta_enabled": bool}</code>. <strong>Loopback only</strong>; the mutating verbs reject cross-origin browser requests, since the granted effect rewrites <code>~/.claude/CLAUDE.md</code>.</p>
+
       <h3>GET / PUT /api/v1/backchannel/rules</h3>
 
       <p>The event&rarr;action rule set (e.g. context pressure &rarr; <code>/compact</code>). <code>GET</code> returns the current rules; <code>PUT</code> replaces the set with <code>{"rules": [&hellip;]}</code>. The rule engine fires through the same backchannel write path, so the same master-toggle + per-adapter <code>control</code> gates apply. <strong>Loopback only</strong>; <code>PUT</code> rejects cross-origin browser requests.</p>

--- a/site/docs/cli-tools.html
+++ b/site/docs/cli-tools.html
@@ -100,12 +100,15 @@
       <ul>
         <li><code>--version</code>, <code>-v</code> &mdash; Print version and exit</li>
         <li><code>--diagnose</code> &mdash; Write a redacted diagnostics bundle (<code>irrlicht-diag.tar.gz</code>) to the current directory and exit, without starting the daemon. For headless installs that can't reach the <code>GET /debug/bundle</code> endpoint. Honors <code>IRRLICHT_HOME</code></li>
+        <li><code>--uninstall-hooks</code> &mdash; Remove irrlicht's Claude Code hooks from <code>~/.claude/settings.json</code>, record the hooks permission as denied if it was previously granted (so it isn't silently re-installed on next start), and exit without starting the daemon</li>
+        <li><code>--uninstall-task-eta</code> &mdash; Remove irrlicht's managed task-eta and task-summary blocks from <code>~/.claude/CLAUDE.md</code> and exit without starting the daemon</li>
+        <li><code>--record</code> &mdash; Enable lifecycle recording of session events to <code>&lt;dataDir&gt;/recordings</code> (equivalent to <code>IRRLICHT_RECORD=1</code>); the daemon starts normally otherwise</li>
       </ul>
 
       <h3>What It Does</h3>
 
       <ul>
-        <li>Watches Claude Code, Codex, Pi, Aider, Kiro CLI, and Antigravity transcripts; OpenCode's SQLite WAL; Gemini CLI's transcripts; plus the Gas Town orchestrator</li>
+        <li>Watches Claude Code, Codex, Pi, Aider, Kiro CLI, and Antigravity transcripts; OpenCode's SQLite WAL; Gemini CLI's transcripts; plus the Gas Town orchestrator (a multi-agent coordinator layer distinct from the per-agent <a href="adapters.html">adapters</a> above)</li>
         <li>Tracks session state via deterministic state machine</li>
         <li>Serves HTTP API on <code>localhost:7837</code></li>
         <li>Serves WebSocket stream for real-time updates</li>
@@ -139,7 +142,7 @@
         <li><code>--id &lt;prefix&gt;</code> &mdash; Filter by session ID prefix (case-insensitive)</li>
         <li><code>--state working|waiting|ready</code> &mdash; Filter by session state</li>
         <li><code>--project &lt;substring&gt;</code> &mdash; Filter by project name (case-insensitive substring)</li>
-        <li><code>--adapter &lt;name&gt;</code> &mdash; Filter by agent adapter (e.g. <code>claude-code</code>, <code>codex</code>)</li>
+        <li><code>--adapter &lt;name&gt;</code> &mdash; Filter by <a href="adapters.html">agent adapter</a> (the per-agent integration, e.g. <code>claude-code</code>, <code>codex</code>)</li>
       </ul>
 
       <h3>Output Format</h3>
@@ -176,6 +179,12 @@ ready    api-server   e5f6g7h8 gpt-5 3% 400k codex  (1m ago)</code></pre>
       <h3>Usage</h3>
 
       <pre><code>irrlicht-focus &lt;sessionID&gt;</code></pre>
+
+      <h3>Example</h3>
+
+      <pre><code>irrlicht-focus 52d087d1</code></pre>
+
+      <p>Brings the terminal/IDE window for session <code>52d087d1</code> (see <code>irrlicht-ls</code> above for session IDs) to the foreground; exits <code>0</code> on success.</p>
 
       <h3>Arguments</h3>
 
@@ -225,6 +234,19 @@ irrlichtrelay --version</code></pre>
         <li><code>--max-conns-per-ip</code> &mdash; Max concurrent connections per remote IP; <code>0</code> disables (meaningless behind a proxy/NAT &mdash; see <code>--max-conns</code>) (default <code>32</code>)</li>
         <li><code>--version</code>, <code>-v</code> &mdash; Print version and exit</li>
       </ul>
+
+      <h3>token Flags</h3>
+
+      <ul>
+        <li><code>--tokens-file</code> &mdash; Path to the tokens file (default empty &rarr; <code>&lt;data-dir&gt;/tokens.json</code>)</li>
+        <li><code>--data-dir</code> &mdash; State directory for the tokens file (default empty &rarr; <code>$IRRLICHT_HOME</code> or <code>~/.local/share/irrlicht</code>)</li>
+        <li><code>--label</code> &mdash; Human label for the issued token (<code>issue</code> only)</li>
+        <li><code>--workspace</code> &mdash; Tenant workspace the issued token is scoped to (<code>issue</code> only; empty means the default single-tenant workspace)</li>
+      </ul>
+
+      <p>Example:</p>
+
+      <pre><code>irrlichtrelay token issue --label "laptop" --workspace default</code></pre>
 
       <h3>Security Note</h3>
 

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -388,7 +388,7 @@ test: add table-driven tests for state machine</code></pre>
 
       <div class="callout callout-warning">
         <strong>Non-negotiable</strong>
-        Both the Go test suite and the replay-fixture suite must exit 0. If either fails, the work is not done -- regardless of whether the code compiles or individual tests pass in isolation. These are the two most common local checks; the full required suite (Go unit+e2e, onboarding-factory, replay fixtures, and web suites) is listed in <code>AGENTS.md#testing</code> -- a change is only done when every layer passes.
+        Both the Go test suite and the replay-fixture suite must exit 0. If either fails, the work is not done -- regardless of whether the code compiles or individual tests pass in isolation. See the Testing section above for the full required suite.
       </div>
 
       <!-- ─── Code Review ─── -->

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -198,7 +198,7 @@
 
       <h3>Testing</h3>
 
-      <p>Before marking a change done, run all three layers and confirm they pass:</p>
+      <p>Before marking a change done, run both commands and confirm they pass:</p>
 
       <pre><code># Unit + e2e tests (race detector on, no cache)
 go test ./core/... -race -count=1
@@ -208,7 +208,7 @@ go test ./core/... -race -count=1
 
       <div class="callout callout-warning">
         <strong>Important</strong>
-        A change is only done when both commands exit 0. No exceptions.
+        A change is only done when both commands exit 0. No exceptions. These are the two most common local checks; the full required suite (Go unit+e2e, onboarding-factory, replay fixtures, and web suites) is listed in <code>AGENTS.md#testing</code> -- a change is only done when every layer passes.
       </div>
 
       <p>To run tests for individual components during development:</p>
@@ -245,7 +245,7 @@ test: add table-driven tests for state machine</code></pre>
         </li>
         <li>
           <strong>Push your branch</strong>
-          <pre><code>git push origin feature/my-feature</code></pre>
+          <pre><code>git push origin feat/my-feature</code></pre>
         </li>
         <li>
           <strong>Open a PR against <code>main</code></strong><br>
@@ -388,7 +388,7 @@ test: add table-driven tests for state machine</code></pre>
 
       <div class="callout callout-warning">
         <strong>Non-negotiable</strong>
-        Both the Go test suite and the replay-fixture suite must exit 0. If either fails, the work is not done -- regardless of whether the code compiles or individual tests pass in isolation.
+        Both the Go test suite and the replay-fixture suite must exit 0. If either fails, the work is not done -- regardless of whether the code compiles or individual tests pass in isolation. These are the two most common local checks; the full required suite (Go unit+e2e, onboarding-factory, replay fixtures, and web suites) is listed in <code>AGENTS.md#testing</code> -- a change is only done when every layer passes.
       </div>
 
       <!-- ─── Code Review ─── -->

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -103,7 +103,7 @@
         <li>
           <strong>Launch the app</strong><br>
           <pre><code>open /Applications/Irrlicht.app</code></pre>
-          <p>The embedded daemon starts automatically &mdash; no separate services to manage.</p>
+          <p>The embedded daemon (irrlichd, the background process that watches your sessions) starts automatically &mdash; no separate services to manage.</p>
         </li>
         <li>
           <strong>Look for the flame icon</strong><br>

--- a/site/docs/session-detection.html
+++ b/site/docs/session-detection.html
@@ -194,6 +194,17 @@
         <li><strong>Adapter name:</strong> <code>gemini-cli</code></li>
       </ul>
 
+      <h3>Antigravity</h3>
+
+      <ul>
+        <li><strong>Transcript location:</strong> <code>transcript.jsonl</code> under <code>~/.gemini/antigravity-cli/brain/&lt;conversation&gt;/.system_generated/logs/</code> (CLI) and <code>~/.gemini/antigravity/brain/&lt;conversation&gt;/.system_generated/logs/</code> (IDE)</li>
+        <li>One adapter covers both the <code>agy</code> CLI and the Antigravity IDE &mdash; they write byte-compatible transcripts to sibling brain stores</li>
+        <li>Discovery is transcript-first: the IDE hosts many conversations in one Electron process with no per-conversation PID, so PID-less sessions are first-class; the <code>agy</code> CLI is a standalone native binary matched by exact name</li>
+        <li>Since the transcript filename is the constant <code>transcript.jsonl</code>, the session id is derived from the conversation directory path</li>
+        <li>Tokens and the canonical model are read from the sibling conversation store <code>~/.gemini/antigravity{,-cli}/conversations/&lt;conversation&gt;.db</code> (not the transcript) so the context bar renders</li>
+        <li><strong>Adapter name:</strong> <code>antigravity</code></li>
+      </ul>
+
       <h2>PID Discovery</h2>
 
       <table>

--- a/site/docs/state-machine.html
+++ b/site/docs/state-machine.html
@@ -442,7 +442,7 @@
           <tr>
             <td><code>hook_received</code></td>
             <td>Agent hooks</td>
-            <td>Reserved for agent hook delivery (<code>HookName</code>/<code>HookData</code>); future work tracked by issue #108, not yet emitted.</td>
+            <td>Emitted by <code>dispatchHookActivity</code> whenever a claudecode permission hook (<code>PreToolUse</code>/<code>PostToolUse</code>/etc.) or a manual <code>/compact</code> (<code>PreCompact</code>) fires; carries the hook name in <code>HookName</code>. The sibling <code>HookData</code> field exists but is currently always empty.</td>
           </tr>
           <tr>
             <td><code>presession_created</code></td>

--- a/site/docs/state-machine.html
+++ b/site/docs/state-machine.html
@@ -371,6 +371,112 @@
       </ul>
       <p>This is a deliberate design choice. From the user's perspective, a cancelled turn is equivalent to a completed turn &mdash; the agent is idle and waiting for the next message. The three-state model (<span class="badge badge-working">working</span> / <span class="badge badge-waiting">waiting</span> / <span class="badge badge-ready">ready</span>) remains clean and unambiguous.</p>
 
+      <!-- ─── Lifecycle Event Kinds ─── -->
+      <h2>Lifecycle Event Kinds</h2>
+      <p>Underneath the three-state model, the daemon records a lower-level stream of typed events for session recording and replay &mdash; not just transcript-derived state transitions but also process lifecycle, filesystem, debounce, and parent-child signals. Each event carries a <code>Kind</code> discriminant (<code>core/domain/lifecycle/event.go</code>); this table enumerates all 18 constants, grouped as the source file itself groups them.</p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Kind</th>
+            <th>Category</th>
+            <th>When it fires</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>transcript_new</code></td>
+            <td>Transcript events</td>
+            <td>fswatcher/AgentWatcher detects a session's <code>.jsonl</code> transcript file appearing for the first time.</td>
+          </tr>
+          <tr>
+            <td><code>transcript_activity</code></td>
+            <td>Transcript events</td>
+            <td>fswatcher/AgentWatcher observes further writes to an already-known transcript file.</td>
+          </tr>
+          <tr>
+            <td><code>transcript_removed</code></td>
+            <td>Transcript events</td>
+            <td>fswatcher/AgentWatcher sees a tracked transcript file deleted.</td>
+          </tr>
+          <tr>
+            <td><code>pid_discovered</code></td>
+            <td>Process lifecycle</td>
+            <td>The process scanner (e.g. <code>pgrep -x claude</code>) finds a new agent PID that isn't already tracked.</td>
+          </tr>
+          <tr>
+            <td><code>process_spawned</code></td>
+            <td>Process lifecycle</td>
+            <td>A new agent process is observed starting.</td>
+          </tr>
+          <tr>
+            <td><code>process_exited</code></td>
+            <td>Process lifecycle</td>
+            <td>A tracked agent process exits (kqueue <code>NOTE_EXIT</code>).</td>
+          </tr>
+          <tr>
+            <td><code>file_event</code></td>
+            <td>Filesystem</td>
+            <td>Reserved for debounced create/write/remove/rename events on the agent's working directory (per <code>.specs/onboard-agent/07-10-recorder-fidelity.md</code>, WS08); the type is defined but emission is wired by a follow-up PR, not yet live.</td>
+          </tr>
+          <tr>
+            <td><code>state_transition</code></td>
+            <td>State machine</td>
+            <td>Emitted as the output of <code>ClassifyState</code> whenever a session's state changes; carries <code>PrevState</code>/<code>NewState</code>/<code>Reason</code> plus a <code>ClassifierInputs</code> snapshot explaining why.</td>
+          </tr>
+          <tr>
+            <td><code>parent_linked</code></td>
+            <td>Parent-child linkage</td>
+            <td>A subagent (child) session is linked to its parent session via <code>ParentSessionID</code>.</td>
+          </tr>
+          <tr>
+            <td><code>debounce_coalesced</code></td>
+            <td>Debounce</td>
+            <td>Multiple rapid events within the debounce window are coalesced into one; <code>CoalescedCount</code> records how many, for faithful replay.</td>
+          </tr>
+          <tr>
+            <td><code>debounce_terminal</code></td>
+            <td>Debounce</td>
+            <td>A terminal event bypasses the debounce window entirely and is recorded immediately rather than coalesced.</td>
+          </tr>
+          <tr>
+            <td><code>hook_received</code></td>
+            <td>Agent hooks</td>
+            <td>Reserved for agent hook delivery (<code>HookName</code>/<code>HookData</code>); future work tracked by issue #108, not yet emitted.</td>
+          </tr>
+          <tr>
+            <td><code>presession_created</code></td>
+            <td>Pre-sessions</td>
+            <td>The process scanner creates a synthetic pre-session (<code>proc-&lt;pid&gt;</code>) for a detected process that has no transcript yet.</td>
+          </tr>
+          <tr>
+            <td><code>presession_removed</code></td>
+            <td>Pre-sessions</td>
+            <td>A pre-session is cleaned up &mdash; either superseded once its real transcript appears, or discarded because the process exited before any transcript showed up.</td>
+          </tr>
+          <tr>
+            <td><code>task_delta</code></td>
+            <td>Tasks</td>
+            <td>Emitted once per <code>TaskDelta</code> the tailer folds into a session's task list (create / update / assign_id), carrying <code>TaskOp</code>, <code>TaskID</code>, <code>TaskSubject</code>, and <code>TaskStatus</code>.</td>
+          </tr>
+          <tr>
+            <td><code>ui_detected</code></td>
+            <td>Terminal / UI</td>
+            <td>A terminal-backend read-back finds a transcript-invisible UI state on the rendered terminal screen (today: the trust/permission dialog); <code>UIKind</code> is empty on the clearing edge.</td>
+          </tr>
+          <tr>
+            <td><code>terminal_frame</code></td>
+            <td>Terminal / UI</td>
+            <td>Reserved for raw terminal frame capture (pipe-pane plus a screen-buffer parser); defined but not emitted yet.</td>
+          </tr>
+          <tr>
+            <td><code>cache_bloat_detected</code></td>
+            <td>Cache-creation regression</td>
+            <td>Emitted once per (project, regressing version) pair within a daemon process lifetime, the first time a working session's median cache-creation per turn exceeds the project's p25 baseline &times; threshold (issue #374); consumed by the <code>ir:agent-releases</code> workflow.</td>
+          </tr>
+        </tbody>
+      </table>
+
       <!-- ─── Bottom nav ─── -->
       <div class="docs-nav-bottom">
         <a href="light-system.html">

--- a/site/docs/story.html
+++ b/site/docs/story.html
@@ -134,7 +134,7 @@
       <!-- ─── From three lights to a city ─── -->
       <h2>From three lights to a city</h2>
 
-      <p>It didn't stay simple. The menu bar ran out of room. Different vendors meant different rate limits and different transcript formats. Then orchestrators arrived &mdash; Gas Town with eighteen agents on a single run, a small coding factory humming away in the background. Eighteen agents without monitoring is not parallelism; it is chaos with extra steps.</p>
+      <p>It didn't stay simple. The menu bar ran out of room. Different vendors meant different rate limits and different transcript formats. Then orchestrators &mdash; tools like Gas Town that supervise many agent subprocesses under one run &mdash; arrived: eighteen agents on a single run, a small coding factory humming away in the background. Eighteen agents without monitoring is not parallelism; it is chaos with extra steps.</p>
 
       <figure class="story-figure">
         <img src="../assets/mascot/manufaktur-hall.webp"

--- a/site/index.html
+++ b/site/index.html
@@ -1765,7 +1765,7 @@ footer {
         </div>
         <div class="supported-item">
           <div class="si-dot"></div>
-          <span class="si-name">Linux (daemon-only)</span>
+          <span class="si-name">Linux (daemon-only — no menu-bar app, background service only)</span>
           <span class="si-tag tag-alpha">alpha</span>
         </div>
         <div class="supported-item">
@@ -1791,7 +1791,7 @@ footer {
       <p class="section-label">Capabilities</p>
       <h2 class="section-title">Everything you need,<br>nothing you don't</h2>
       <p class="section-desc">Zero configuration. Install, run, and Irrlicht discovers your sessions automatically.</p>
-      <p class="section-aside">Not a token counter. Not an observability stack. No SDK wrappers, no collectors, no dashboard tab to keep open &mdash; just the files your agents already write.</p>
+      <p class="section-aside">Not a token counter. Not an observability stack. No SDK wrappers, no collectors, no dashboard tab to keep open &mdash; mostly just the files your agents already write (plus a lightweight, auto-installed status hook for a couple of agents).</p>
     </div>
     <div class="features-grid reveal">
       <div class="feature-card">
@@ -1834,7 +1834,7 @@ footer {
           <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M10 2a8 8 0 110 16 8 8 0 010-16z"/><path d="M10 6v4l3 2"/></svg>
         </div>
         <h3>Zero Configuration</h3>
-        <p>No manual setup. Install the daemon and the app — it discovers sessions automatically, wiring up hooks itself where needed.</p>
+        <p>One-click setup. Install the daemon and the app — it detects your agents and shows exactly what it wants to read or install; approve once and it wires itself up.</p>
       </div>
     </div>
   </div>

--- a/tools/irrlicht-design-system/README.md
+++ b/tools/irrlicht-design-system/README.md
@@ -2,7 +2,7 @@
 
 > *In Goethe's Faust, an Irrlicht guides the way through the night. This one guides you through your agents — who's working, who's waiting, and where you're needed next.*
 
-**Irrlicht** (German: *will-o'-the-wisp*; IPA /eer-likht/) is an open-source macOS menu-bar telemetry app that monitors AI coding agents — Claude Code, OpenAI Codex, Pi, and the Gas Town orchestrator — in real time. Each session is a single colored light:
+**Irrlicht** (German: *will-o'-the-wisp*; IPA /eer-likht/) is an open-source macOS menu-bar telemetry app that monitors AI coding agents — Claude Code, OpenAI Codex, Pi, and the Gas Town orchestrator (a coordinator process that dispatches and supervises work across multiple agent workers) — in real time. Each session is a single colored light:
 
 - 🟣 **working** — the agent is thinking, building, streaming
 - 🟠 **waiting** — it needs you; the story pauses for your judgment


### PR DESCRIPTION
## Summary
- `ir:doc-review` used to auto-fix only narrow claim-vs-code-fact corrections (V1/V2/V4/V5/V6/C2) and file a GitHub issue for everything else — every missing-content or wording finding (C1/C3/C4/U1-U6). A single release run just filed 19 issues (#851-#869), several with a dozen+ findings, even though the skill already drafts an agent-ready "Exact fix" for every finding regardless of axis.
- Removes the axis-based eligibility restriction: every determinable finding is now fixed in place. Filing (or closing) an issue is now the fallback only for a finding whose fix is genuinely ambiguous or that fails its own verification check. Updated `ir:release` Step 4b to match — the `--fix` flag is gone since fixing is now the default.
- Retroactively applies the new behavior: fixed every finding directly in the 19 flagged docs/skills and closed all 19 issues (#851-#869).

## Test plan
- [x] `tools/preflight.sh` passed (go tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, both web suites, ARS gate)
- [x] All 19 `docs(...)` issues confirmed closed (`gh issue list --label documentation --state open` → empty)
- [ ] Spot-check a few of the fixed docs (state-machine.html's new Lifecycle Event Kinds section, session-detection.html's new Antigravity section) render correctly on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)