### PR TITLE
fix(tooling): scope install.sh daemon kill, retry smoke-test check, auto-create demo cwds

### DIFF
--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -763,7 +763,24 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
      fi
      exit 1
    fi
-   pgrep -f "$APP/Contents/MacOS/irrlichd" >/dev/null || { echo "FAIL: daemon not spawned"; }
+   # Daemon-spawn check — retry like the dashboard check below. A one-shot
+   # pgrep here raced during the v0.5.5 release (reported FAIL while the
+   # daemon was actually fine seconds later), which just produces ambiguity:
+   # a future run either has to manually re-verify a false alarm, or risks
+   # waving off a real failure as "probably that same race."
+   DAEMON_OK=0
+   for i in 1 2 3 4 5 6 7 8; do
+     if pgrep -f "$APP/Contents/MacOS/irrlichd" >/dev/null; then
+       DAEMON_OK=1; break
+     fi
+     sleep 1
+   done
+   if [ "$DAEMON_OK" -ne 1 ]; then
+     echo "FAIL: daemon not spawned — DO NOT SHIP"
+     pkill -f "$APP/Contents/MacOS/Irrlicht" 2>/dev/null
+     exit 1
+   fi
+   echo "OK daemon spawned"
 
    # Dashboard reachability — catches missing Resources/web/index.html
    # (v0.4.4 shipping defect). The grep on `<title>` is a stable marker in

--- a/site/install.sh
+++ b/site/install.sh
@@ -80,8 +80,27 @@ uninstall_previous() {
         pkill -f 'Irrlicht[^/]*\.app/Contents/MacOS/Irrlicht' 2>/dev/null || true
         removed_something=1
     fi
-    if pgrep -x irrlichd >/dev/null 2>&1; then
-        pkill -x irrlichd 2>/dev/null || true
+    # Stop any irrlichd bound to our port. Matching by process name alone
+    # (like the .app pkill above) would silently kill an unrelated irrlichd
+    # — a dev `--record` daemon on a different port, or another user's
+    # process. Scope the kill to whatever is actually listening on 7837;
+    # when we can't confirm that (no lsof), warn instead of guessing.
+    if command -v lsof >/dev/null 2>&1; then
+        daemon_pids=$(lsof -ti tcp:7837 -sTCP:LISTEN 2>/dev/null || true)
+        for pid in $daemon_pids; do
+            case "$(basename "$(ps -o comm= -p "$pid" 2>/dev/null)" 2>/dev/null)" in
+                irrlichd)
+                    kill "$pid" 2>/dev/null || true
+                    removed_something=1
+                    ;;
+            esac
+        done
+    elif pgrep -x irrlichd >/dev/null 2>&1; then
+        for pid in $(pgrep -x irrlichd); do
+            cmd=$(ps -o comm= -p "$pid" 2>/dev/null)
+            warn "Stopping irrlichd (pid $pid, $cmd) — no lsof available to confirm it's bound to port 7837"
+            kill "$pid" 2>/dev/null || true
+        done
         removed_something=1
     fi
 

--- a/tools/seed-demo-sessions/main.go
+++ b/tools/seed-demo-sessions/main.go
@@ -160,6 +160,9 @@ func runSeed(outDir, appPath string, clean, restart, force bool, scenario scenar
 	now := time.Now()
 	for _, src := range scenario.File.Sessions {
 		s := src.materialize(now)
+		if err := ensureSessionCWD(s.CWD); err != nil {
+			fmt.Printf("warning: could not create cwd %s for session %s (%v) — the daemon will reap this session as an orphan at startup unless the directory exists\n", s.CWD, s.SessionID, err)
+		}
 		path := filepath.Join(outDir, s.SessionID+".json")
 		data, err := json.MarshalIndent(s, "", "  ")
 		if err != nil {
@@ -419,6 +422,20 @@ func moveAllJSON(src, dst string) (int, error) {
 		moved++
 	}
 	return moved, nil
+}
+
+// ensureSessionCWD best-effort creates cwd so the daemon's orphan-at-seed
+// check (PIDManager.seedAlivePIDs, which deletes any seeded session whose
+// cwd doesn't exist) doesn't reap this session before it can be
+// screenshotted. Mirrors cwdMissing's own empty/relative-path skip.
+func ensureSessionCWD(cwd string) error {
+	if cwd == "" || !filepath.IsAbs(cwd) {
+		return nil
+	}
+	if _, err := os.Stat(cwd); err == nil {
+		return nil
+	}
+	return os.MkdirAll(cwd, 0o755)
 }
 
 func defaultInstancesDir() (string, error) {

--- a/tools/seed-demo-sessions/main_test.go
+++ b/tools/seed-demo-sessions/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureSessionCWD(t *testing.T) {
+	t.Run("creates missing absolute dir", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "projects", "demo-app")
+		if err := ensureSessionCWD(dir); err != nil {
+			t.Fatalf("ensureSessionCWD: %v", err)
+		}
+		if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+			t.Fatalf("expected %s to exist as a dir, err=%v", dir, err)
+		}
+	})
+
+	t.Run("leaves existing dir alone", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := ensureSessionCWD(dir); err != nil {
+			t.Fatalf("ensureSessionCWD: %v", err)
+		}
+	})
+
+	t.Run("skips empty path", func(t *testing.T) {
+		if err := ensureSessionCWD(""); err != nil {
+			t.Fatalf("ensureSessionCWD(\"\"): %v", err)
+		}
+	})
+
+	t.Run("skips relative path", func(t *testing.T) {
+		defer os.RemoveAll("relative")
+		if err := ensureSessionCWD("relative/path"); err != nil {
+			t.Fatalf("ensureSessionCWD(relative): %v", err)
+		}
+		if _, err := os.Stat("relative/path"); !os.IsNotExist(err) {
+			t.Fatalf("relative path should not have been created, err=%v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- `site/install.sh`'s uninstall step now scopes the daemon kill to whatever process is actually bound to port 7837 (via `lsof`), instead of an unscoped `pkill -x irrlichd` that could silently kill an unrelated irrlichd (e.g. a dev `--record` daemon on a different port). Falls back to a named PID/binary warning when `lsof` isn't available.
- `ir:release` skill's packaging smoke test wraps the daemon-liveness `pgrep` check in the same retry loop already used by the dashboard reachability check, fixing the race that produced a false `FAIL: daemon not spawned` during the v0.5.5 release.
- `tools/seed-demo-sessions` now best-effort creates each seeded session's `cwd` directory, so `PIDManager.seedAlivePIDs` doesn't silently reap the seeded session as an "orphan at seed" before it can be screenshotted — with a warning printed when creation isn't possible.

Fixes #871

## Test plan
- [x] `go build ./...` (workspace)
- [x] `go test ./core/... -race -count=1`
- [x] `go test ./tools/seed-demo-sessions/... -race -count=1` (new test for `ensureSessionCWD`)
- [x] `sh -n site/install.sh`
- [x] `tools/preflight.sh` (full local CI parity, pre-push hook) — all gates pass
- [x] `/code-review` at low effort — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)