### PR TITLE
fix(daemon): don't flip a session to ready when its transcript moves into a worktree (#877)

### DIFF
--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"irrlicht/core/domain/agent"
@@ -11,6 +12,18 @@ import (
 )
 
 func (d *SessionDetector) onRemoved(ev agent.Event) {
+	// A .jsonl "removal" is often a *relocation*, not a deletion. Claude Code
+	// derives a session's project-dir slug from its cwd, so when a session cd's
+	// into a git worktree it moves its transcript to a new slug (same session
+	// id, new path). fsnotify reports the old path's rename as a deletion
+	// (fswatcher collapses Rename→Removed), but the session is alive and still
+	// working. Re-point tracking at the surviving copy instead of forcing the
+	// session to ready (issue #877).
+	if newPath := relocatedTranscript(ev.TranscriptPath); newPath != "" {
+		d.onRelocated(ev, newPath)
+		return
+	}
+
 	d.log.LogInfo("session-detector", ev.SessionID, "session removed")
 
 	// Cancel any pending debounce timer for this session.
@@ -47,6 +60,77 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	d.pidMgr.WithSessionStateLock(func() {
 		d.onRemovedLocked(state, ev)
 	})
+}
+
+// onRelocated handles a transcript that moved to a new project-dir slug rather
+// than being deleted (see relocatedTranscript). The session is alive and keeps
+// its current state — the fix for a session spuriously flipping to ready when
+// it cd's into a git worktree (issue #877). Tracking is re-pointed at the
+// surviving file so subsequent activity events and metric refreshes follow it.
+func (d *SessionDetector) onRelocated(ev agent.Event, newPath string) {
+	newProjectDir := filepath.Base(filepath.Dir(newPath))
+	d.log.LogInfo("session-detector", ev.SessionID,
+		fmt.Sprintf("transcript relocated to %s — session still alive, not marking ready", newProjectDir))
+
+	// Keep the project-dir tracking current for parent derivation.
+	d.mu.Lock()
+	d.projectSessions[ev.SessionID] = newProjectDir
+	d.mu.Unlock()
+
+	state, err := d.repo.Load(ev.SessionID)
+	if err != nil || state == nil {
+		return
+	}
+
+	// Re-point the session (and the metrics tailer) at the surviving file. Under
+	// the PIDManager's state lock — a PID-discovery goroutine may still be in
+	// flight for this session, writing state.PID/UpdatedAt on this same pointer
+	// (issue #606).
+	d.pidMgr.WithSessionStateLock(func() {
+		if state.TranscriptPath == newPath {
+			return // an activity event already followed the move
+		}
+		// Drop the tailer cache for the now-gone path. The new-path tailer
+		// re-reads the full (moved) file on the next activity event, so
+		// cumulative metrics are rebuilt intact.
+		d.enricher.PruneMetrics(state.TranscriptPath)
+		state.TranscriptPath = newPath
+		state.UpdatedAt = time.Now().Unix()
+		if err := d.repo.Save(state); err != nil {
+			d.log.LogError("session-detector", ev.SessionID,
+				fmt.Sprintf("failed to save relocated transcript path: %v", err))
+			return
+		}
+		d.broadcast(outbound.PushTypeUpdated, state)
+	})
+}
+
+// relocatedTranscript reports whether a transcript that fsnotify flagged as
+// removed actually still exists under a *different* project-dir slug — i.e. it
+// was moved, not deleted. Returns the surviving path, or "" for a genuine
+// removal.
+//
+// The scan is scoped to the sibling project dirs of the removed path
+// (<projectsRoot>/*/<file>), so it stays adapter-agnostic: layouts that don't
+// place transcripts exactly one level under a shared root simply find no match
+// and fall through to the normal removal path. filepath.Glob only returns paths
+// that exist, and the removed path no longer does, so any other match is a live
+// relocated copy.
+func relocatedTranscript(removedPath string) string {
+	if removedPath == "" {
+		return ""
+	}
+	projectsRoot := filepath.Dir(filepath.Dir(removedPath))
+	matches, err := filepath.Glob(filepath.Join(projectsRoot, "*", filepath.Base(removedPath)))
+	if err != nil {
+		return ""
+	}
+	for _, m := range matches {
+		if m != removedPath {
+			return m
+		}
+	}
+	return ""
 }
 
 // onRemovedLocked finishes removal handling for an already-loaded session. It

--- a/core/application/services/session_detector_lifecycle_test.go
+++ b/core/application/services/session_detector_lifecycle_test.go
@@ -134,6 +134,70 @@ func TestSessionDetector_Removed_SkipsTerminalState(t *testing.T) {
 	}
 }
 
+// A transcript "removal" that is really a relocation to a new project-dir slug
+// (the same session cd'ing into a git worktree) must NOT flip the live session
+// to ready — it should re-point tracking at the moved file. Regression test for
+// issue #877.
+func TestSessionDetector_Removed_TranscriptRelocation_StaysAlive(t *testing.T) {
+	root := t.TempDir()
+	oldDir := filepath.Join(root, "-Users-test")
+	newDir := filepath.Join(root, "-Users-test--claude-worktrees-877")
+	if err := os.MkdirAll(newDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The old path is intentionally absent (moved away); only the new copy
+	// exists on disk — exactly what Claude Code leaves after a worktree cd.
+	oldPath := filepath.Join(oldDir, "reloc1.jsonl")
+	newPath := filepath.Join(newDir, "reloc1.jsonl")
+	if err := os.WriteFile(newPath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	repo.states["reloc1"] = &session.SessionState{
+		SessionID:      "reloc1",
+		State:          session.StateWorking,
+		TranscriptPath: oldPath,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventRemoved,
+		SessionID:      "reloc1",
+		TranscriptPath: oldPath,
+	}
+
+	// Poll for the transcript-path follow via the race-free probe rather than a
+	// fixed sleep (issue #606 flaky sibling) — background goroutines mutate the
+	// shared *SessionState pointer, so a bare Load().TranscriptPath read races.
+	waitForCondition(func() bool {
+		return repo.transcriptPathOf("reloc1") == newPath
+	}, time.Second)
+	cancel()
+	<-done
+
+	if got := repo.transcriptPathOf("reloc1"); got != newPath {
+		t.Errorf("transcript_path: got %q, want %q (must follow the moved file)", got, newPath)
+	}
+	// The session must never have been flipped to ready.
+	repo.mu.Lock()
+	gotState := repo.lastSavedState["reloc1"]
+	repo.mu.Unlock()
+	if gotState == session.StateReady {
+		t.Errorf("state: got %q, want working (a relocation must not force ready)", gotState)
+	}
+}
+
 func TestSessionDetector_ExistingSession_UpdatesTranscriptPath(t *testing.T) {
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()

--- a/core/application/services/session_detector_lifecycle_test.go
+++ b/core/application/services/session_detector_lifecycle_test.go
@@ -134,67 +134,86 @@ func TestSessionDetector_Removed_SkipsTerminalState(t *testing.T) {
 	}
 }
 
-// A transcript "removal" that is really a relocation to a new project-dir slug
-// (the same session cd'ing into a git worktree) must NOT flip the live session
-// to ready — it should re-point tracking at the moved file. Regression test for
-// issue #877.
+// A transcript "removal" that is really a relocation to a sibling project-dir
+// slug (the same session cd'ing between the main repo and a git worktree) must
+// NOT flip the live session to ready — it should re-point tracking at the moved
+// file. The detection is direction-agnostic, so both entering a worktree
+// (main→worktree slug) and closing one (worktree→main slug) are covered.
+// Regression test for issue #877.
 func TestSessionDetector_Removed_TranscriptRelocation_StaysAlive(t *testing.T) {
-	root := t.TempDir()
-	oldDir := filepath.Join(root, "-Users-test")
-	newDir := filepath.Join(root, "-Users-test--claude-worktrees-877")
-	if err := os.MkdirAll(newDir, 0o755); err != nil {
-		t.Fatal(err)
+	const (
+		mainSlug = "-Users-test"
+		wtSlug   = "-Users-test--claude-worktrees-877"
+	)
+	tests := []struct {
+		name     string
+		fromSlug string // slug the transcript is renamed away from (the "removed" path)
+		toSlug   string // slug it moved to (the surviving path)
+	}{
+		{name: "enter worktree", fromSlug: mainSlug, toSlug: wtSlug},
+		{name: "close worktree", fromSlug: wtSlug, toSlug: mainSlug},
 	}
-	// The old path is intentionally absent (moved away); only the new copy
-	// exists on disk — exactly what Claude Code leaves after a worktree cd.
-	oldPath := filepath.Join(oldDir, "reloc1.jsonl")
-	newPath := filepath.Join(newDir, "reloc1.jsonl")
-	if err := os.WriteFile(newPath, []byte("{}\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			toDir := filepath.Join(root, tc.toSlug)
+			if err := os.MkdirAll(toDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			// The "from" path is intentionally absent (renamed away); only the
+			// destination copy exists on disk — exactly what Claude Code leaves
+			// after a cwd change.
+			fromPath := filepath.Join(root, tc.fromSlug, "reloc1.jsonl")
+			toPath := filepath.Join(toDir, "reloc1.jsonl")
+			if err := os.WriteFile(toPath, []byte("{}\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
 
-	tw := newMockAgentWatcher()
-	pw := newMockProcessWatcher()
-	repo := newMockRepo()
+			tw := newMockAgentWatcher()
+			pw := newMockProcessWatcher()
+			repo := newMockRepo()
 
-	repo.states["reloc1"] = &session.SessionState{
-		SessionID:      "reloc1",
-		State:          session.StateWorking,
-		TranscriptPath: oldPath,
-		FirstSeen:      time.Now().Unix(),
-		UpdatedAt:      time.Now().Unix(),
-	}
+			repo.states["reloc1"] = &session.SessionState{
+				SessionID:      "reloc1",
+				State:          session.StateWorking,
+				TranscriptPath: fromPath,
+				FirstSeen:      time.Now().Unix(),
+				UpdatedAt:      time.Now().Unix(),
+			}
 
-	det := newDetector(tw, pw, repo)
+			det := newDetector(tw, pw, repo)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- det.Run(ctx) }()
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- det.Run(ctx) }()
 
-	tw.ch <- agent.Event{
-		Type:           agent.EventRemoved,
-		SessionID:      "reloc1",
-		TranscriptPath: oldPath,
-	}
+			tw.ch <- agent.Event{
+				Type:           agent.EventRemoved,
+				SessionID:      "reloc1",
+				TranscriptPath: fromPath,
+			}
 
-	// Poll for the transcript-path follow via the race-free probe rather than a
-	// fixed sleep (issue #606 flaky sibling) — background goroutines mutate the
-	// shared *SessionState pointer, so a bare Load().TranscriptPath read races.
-	waitForCondition(func() bool {
-		return repo.transcriptPathOf("reloc1") == newPath
-	}, time.Second)
-	cancel()
-	<-done
+			// Poll for the transcript-path follow via the race-free probe rather
+			// than a fixed sleep (issue #606 flaky sibling) — background
+			// goroutines mutate the shared *SessionState pointer, so a bare
+			// Load().TranscriptPath read races.
+			waitForCondition(func() bool {
+				return repo.transcriptPathOf("reloc1") == toPath
+			}, time.Second)
+			cancel()
+			<-done
 
-	if got := repo.transcriptPathOf("reloc1"); got != newPath {
-		t.Errorf("transcript_path: got %q, want %q (must follow the moved file)", got, newPath)
-	}
-	// The session must never have been flipped to ready.
-	repo.mu.Lock()
-	gotState := repo.lastSavedState["reloc1"]
-	repo.mu.Unlock()
-	if gotState == session.StateReady {
-		t.Errorf("state: got %q, want working (a relocation must not force ready)", gotState)
+			if got := repo.transcriptPathOf("reloc1"); got != toPath {
+				t.Errorf("transcript_path: got %q, want %q (must follow the moved file)", got, toPath)
+			}
+			// The session must never have been flipped to ready.
+			repo.mu.Lock()
+			gotState := repo.lastSavedState["reloc1"]
+			repo.mu.Unlock()
+			if gotState == session.StateReady {
+				t.Errorf("state: got %q, want working (a relocation must not force ready)", gotState)
+			}
+		})
 	}
 }
 

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -134,6 +134,17 @@ func (r *mockRepo) updatedAtOf(sessionID string) int64 {
 	return 0
 }
 
+// transcriptPathOf reads a session's TranscriptPath under r.mu (race-free;
+// background goroutines mutate the shared *SessionState — issue #606).
+func (r *mockRepo) transcriptPathOf(sessionID string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s, ok := r.states[sessionID]; ok {
+		return s.TranscriptPath
+	}
+	return ""
+}
+
 // waitForCondition polls fn until it returns true or the timeout elapses. The
 // generic poll-for-condition replacement for fixed sleeps in tests whose
 // completion signal isn't a saved State value (issue #606).


### PR DESCRIPTION
Fixes #877.

## Problem

A live Claude Code session could spuriously flip to **`ready`** the moment it `cd`'d into a git worktree, even though the agent was still working. Verified on session `0cd07c64` (issue #872's worktree): the daemon logged `new session detected in …worktrees-872…` immediately followed by `session removed` (0.7ms later) while the agent process was still alive.

## Root cause

Claude Code derives a session's transcript project-dir slug from its **cwd**, so entering `.claude/worktrees/<branch>` relocates the `.jsonl` to a new slug (same session id, new path). The fswatcher collapses `fsnotify.Rename` into `EventRemoved` (`fswatcher/watcher.go:277`), so the old path's rename reads as a deletion, and `onRemovedLocked` unconditionally forced the session to `ready` (reason `"transcript removed"`) — loading by id only, never checking whether the removed path was still the session's live transcript. It's a race against the new-path `Create`/`Activity` events, which is why only *some* worktree entries were hit.

Secondary: the "already exists" re-detection branch only backfills `TranscriptPath` when it's empty, so the session was left pointing at a now-nonexistent path.

## Fix

`onRemoved` now detects relocation: if a transcript for the same filename still exists under a *sibling* project-dir slug, treat it as a move, not a removal — re-point `projectSessions` + `state.TranscriptPath` at the surviving file and keep the session's current state. The scan (`<projectsRoot>/*/<file>`) is adapter-agnostic; layouts that don't nest transcripts one level under a shared root find no match and fall through to the normal removal path. Metrics survive intact — the new-path tailer re-reads the full moved file.

## Tests

- New regression test `TestSessionDetector_Removed_TranscriptRelocation_StaysAlive`: a relocated transcript keeps the session `working` and follows the moved file. Confirmed it fails without the fix (`state: got "ready"`, path stuck at old slug) and passes with it.
- Existing genuine-removal → `ready` tests still pass (their paths don't exist on disk, so the relocation scan correctly finds nothing).
- Full `go test ./core/... -race -count=1` green; `tools/preflight.sh` gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)