### PR TITLE
fix(daemon): raise SubagentQuietWindow to 90s to cover long background-research gaps

### DIFF
--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -58,11 +58,18 @@ const compactHoldTimeout = 5 * time.Minute
 // writes for an actively-running subagent. Background Task agents routinely
 // sit with no writes for 5-15 seconds while waiting on API responses —
 // session b27fdaef-6de4-403a-b277-790fe8d803bb showed a 9-second gap that
-// falsely tripped a 2-second window and re-created the child session on
-// the very next write. 30 seconds comfortably covers normal API latency
-// while still being 4× faster than the 2-minute stale-transcript sweep,
-// which is the fallback cleanup path for anything this function misses.
-const SubagentQuietWindow = 30 * time.Second
+// falsely tripped a 2-second window (bumped to 30s to fix). A background
+// research subagent making several WebSearch/WebFetch calls sits on a
+// coarser latency budget than a single API round-trip: session
+// d491a5f9-fc21-4fd1-a1df-f9dfcdc91fec (issue #881) showed a genuine
+// 61-second gap between transcript writes mid-run, which the 30-second
+// window falsely tripped — the child was promoted and deleted, and the
+// parent surfaced "ready" for 67 seconds before the subagent's real
+// completion landed. 90 seconds keeps comfortable headroom over that
+// observed worst case while staying well short of the 2-minute
+// stale-transcript sweep, which is the fallback cleanup path for anything
+// this function misses.
+const SubagentQuietWindow = 90 * time.Second
 
 // debounceEntry holds debounce state for a single session.
 type debounceEntry struct {

--- a/core/application/services/session_detector_subagent_test.go
+++ b/core/application/services/session_detector_subagent_test.go
@@ -200,10 +200,10 @@ func TestSessionDetector_OrphanedSubagentsFinishWhenParentTurnDone(t *testing.T)
 		},
 	})
 
-	// Two orphaned children: real stale transcript files (mtime 60s ago)
-	// so finishOrphanedChildren's quiet-window check (30s) treats them as
+	// Two orphaned children: real stale transcript files (mtime 100s ago)
+	// so finishOrphanedChildren's quiet-window check (90s) treats them as
 	// silent and promotes them.
-	staleMtime := time.Now().Add(-60 * time.Second)
+	staleMtime := time.Now().Add(-100 * time.Second)
 	for _, childID := range []string{"child-orphan-a", "child-orphan-b"} {
 		childPath := filepath.Join(tmpDir, childID+".jsonl")
 		if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
@@ -702,10 +702,10 @@ func TestSessionDetector_OrphanedChildrenFinish_WhenParentEndsWaitingWithQuestio
 		},
 	})
 
-	// Orphaned child: stale transcript (60s > SubagentQuietWindow), no open
+	// Orphaned child: stale transcript (100s > SubagentQuietWindow), no open
 	// tools — its work is done, only the stop_reason:null quirk keeps it
 	// classified as working.
-	staleMtime := time.Now().Add(-60 * time.Second)
+	staleMtime := time.Now().Add(-100 * time.Second)
 	childPath := filepath.Join(tmpDir, "child-of-asker.jsonl")
 	if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
 		t.Fatal(err)
@@ -797,7 +797,7 @@ func TestSessionDetector_PermissionWaitingDoesNotFastForwardChildren(t *testing.
 		},
 	})
 
-	staleMtime := time.Now().Add(-60 * time.Second)
+	staleMtime := time.Now().Add(-100 * time.Second)
 	childPath := filepath.Join(tmpDir, "child-of-perm.jsonl")
 	if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
 		t.Fatal(err)
@@ -975,7 +975,7 @@ func TestSessionDetector_ParentBadgeCleared_AfterReadyCleanup(t *testing.T) {
 		},
 	})
 
-	staleMtime := time.Now().Add(-60 * time.Second)
+	staleMtime := time.Now().Add(-100 * time.Second)
 	childPath := filepath.Join(tmpDir, "child-cleared.jsonl")
 	if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
 		t.Fatal(err)
@@ -1288,7 +1288,7 @@ func TestSessionDetector_ChildDeletionIsRecorded(t *testing.T) {
 		},
 	})
 
-	staleMtime := time.Now().Add(-60 * time.Second)
+	staleMtime := time.Now().Add(-100 * time.Second)
 	childPath := filepath.Join(tmpDir, "child-recorded.jsonl")
 	if err := os.WriteFile(childPath, []byte(""), 0644); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- `SubagentQuietWindow` (30s) falsely tripped on a genuine 61-second inter-write gap from a `WebSearch`/`WebFetch`-heavy background subagent, causing `finishOrphanedChildren` to promote and delete the still-running child and the parent to surface `ready` for 67 seconds while the subagent was still genuinely working.
- Raises the window to 90s, with the comment updated to record this second real-world incident alongside the original one from commit `66f59812`.
- Updates the 5 test call sites that hardcoded a 60s stale-mtime (previously > the 30s window, now inside the 90s window) to 100s so they keep exercising the orphan-promotion path they were written for.

## Root cause
Session `d491a5f9-fc21-4fd1-a1df-f9dfcdc91fec` (issue #881) dispatched a background research subagent via the `Agent`/`Task` tool with `run_in_background: true`. `finishOrphanedChildren` (`core/application/services/session_detector_subagent.go:42-94`) fast-forwards a child subagent to `ready` if its transcript hasn't been written to in `SubagentQuietWindow` — a heuristic needed because in-process subagent transcripts never emit a clean `end_turn`. A multi-minute, tool-heavy background subagent has longer natural quiet gaps than the 9-second case the prior 2s→30s fix (commit `66f59812`) accounted for.

Fixes #881

## Test plan
- [x] `go test ./core/application/services/... -race -count=1 -run "Subagent|Orphan|QuietWindow"` — all pass
- [x] `go test ./core/... -race -count=1` — all pass
- [x] `tools/preflight.sh` (ran automatically via pre-push hook) — gofmt, core tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, both web suites, ARS gate — all PASS