### PR TITLE
fix(onboarding-factory): validate dashboard_url before assigning to iframe.src

### DIFF
--- a/tools/onboarding-factory/internal/viewer/web/playbackTimeline.js
+++ b/tools/onboarding-factory/internal/viewer/web/playbackTimeline.js
@@ -307,3 +307,24 @@ export function findOffsetAfter(sorted, cur) {
   }
   return null;
 }
+
+// resolveDashboardIframeUrl validates a server-provided dashboard_url before
+// it's assigned to an iframe's src. Rejects anything that isn't an http(s)
+// URL on the viewer's own origin (e.g. a `javascript:` scheme, or a URL
+// pointing at a third-party host) by returning null. On success, appends
+// `pb=<playbackId>` as a cache-buster so re-clicking Play reloads the
+// dashboard even though setting iframe.src to an unchanged URL is normally
+// a no-op. Pure.
+export function resolveDashboardIframeUrl(dashboardUrl, playbackId, origin) {
+  if (typeof dashboardUrl !== "string" || dashboardUrl.trim() === "") return null;
+  let parsed;
+  try {
+    parsed = new URL(dashboardUrl, origin);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  if (parsed.origin !== origin) return null;
+  parsed.searchParams.set("pb", playbackId);
+  return parsed.toString();
+}

--- a/tools/onboarding-factory/internal/viewer/web/playbackTimeline.test.js
+++ b/tools/onboarding-factory/internal/viewer/web/playbackTimeline.test.js
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'vitest'
 import {
   isPresession, eventStyle, computeStateBand, computeEventDots, computeTurns,
   computeExpectedLane, deriveEventOffsets, findOffsetBefore, findOffsetAfter,
+  resolveDashboardIframeUrl,
 } from './playbackTimeline.js'
 
 describe('isPresession', () => {
@@ -201,5 +202,40 @@ describe('findOffsetBefore / findOffsetAfter', () => {
     expect(findOffsetAfter(sorted, -1)).toBe(100)
     expect(findOffsetAfter(sorted, 300)).toBeNull()
     expect(findOffsetAfter([], 50)).toBeNull()
+  })
+})
+
+describe('resolveDashboardIframeUrl', () => {
+  const origin = 'http://localhost:5173'
+  test('relative same-origin path resolves and gets a pb cache-buster', () => {
+    expect(resolveDashboardIframeUrl('/dashboard', 'pb-1', origin))
+      .toBe('http://localhost:5173/dashboard?pb=pb-1')
+  })
+  test('absolute same-origin URL with an existing query string keeps it and adds pb', () => {
+    expect(resolveDashboardIframeUrl('http://localhost:5173/dashboard?foo=bar', 'pb-2', origin))
+      .toBe('http://localhost:5173/dashboard?foo=bar&pb=pb-2')
+  })
+  test('javascript: scheme is rejected', () => {
+    expect(resolveDashboardIframeUrl('javascript:alert(1)', 'pb-3', origin)).toBeNull()
+  })
+  test('data: scheme is rejected', () => {
+    expect(resolveDashboardIframeUrl('data:text/html,<script>alert(1)</script>', 'pb-4', origin)).toBeNull()
+  })
+  test('cross-origin http(s) URL is rejected', () => {
+    expect(resolveDashboardIframeUrl('https://evil.example/dashboard', 'pb-5', origin)).toBeNull()
+  })
+  test('protocol-relative URL pointing off-origin is rejected', () => {
+    expect(resolveDashboardIframeUrl('//evil.example/dashboard', 'pb-6', origin)).toBeNull()
+  })
+  test('unparseable URL is rejected', () => {
+    expect(resolveDashboardIframeUrl('http://', 'pb-7', origin)).toBeNull()
+  })
+  test('nullish or empty dashboard_url is rejected', () => {
+    expect(resolveDashboardIframeUrl(null, 'pb-8', origin)).toBeNull()
+    expect(resolveDashboardIframeUrl(undefined, 'pb-8', origin)).toBeNull()
+    expect(resolveDashboardIframeUrl('', 'pb-8', origin)).toBeNull()
+  })
+  test('whitespace-only dashboard_url is rejected, not silently resolved to the origin root', () => {
+    expect(resolveDashboardIframeUrl('   ', 'pb-9', origin)).toBeNull()
   })
 })

--- a/tools/onboarding-factory/internal/viewer/web/viewer.js
+++ b/tools/onboarding-factory/internal/viewer/web/viewer.js
@@ -4,7 +4,7 @@
 // reason panel showing rule_id + signal_ref + evidence.
 
 import {
-  deriveEventOffsets, findOffsetBefore, findOffsetAfter,
+  deriveEventOffsets, findOffsetBefore, findOffsetAfter, resolveDashboardIframeUrl,
 } from './playbackTimeline.js';
 import {
   paintStateBand, paintEventDots, paintTurns, paintExpectedLane,
@@ -2417,17 +2417,26 @@ function renderPlayback(s, detailData, archiveName) {
     // Deduplicate offsets so a cluster of same-instant events doesn't
     // ping the prev/next buttons multiple times in one click.
     eventOffsets = deriveEventOffsets(events);
-    // Append a cache-buster so re-clicking Play actually reloads the
-    // dashboard inside the iframe (setting iframe.src to the same URL is
-    // a no-op in browsers — the WebSocket inside stays open with stale
-    // state). The query param is harmless to the dashboard's relative
-    // fetches.
-    const url = body.dashboard_url;
-    iframe.src = url + (url.includes("?") ? "&" : "?") + "pb=" + body.playback_id;
-    iframeWrap.style.display = "block";
-    iframeLabel.textContent = `${body.dashboard_url}` +
-      (totalMs ? ` — total ${(totalMs/1000).toFixed(1)}s` : "") +
-      (events.length ? ` — ${events.length} events` : "");
+    // resolveDashboardIframeUrl rejects anything but an http(s), same-origin
+    // URL (dashboard_url is server-provided) and appends a cache-buster so
+    // re-clicking Play actually reloads the dashboard inside the iframe
+    // (setting iframe.src to the same URL is normally a no-op in browsers —
+    // the WebSocket inside stays open with stale state). The replay itself
+    // is already running server-side by this point, so a rejected URL only
+    // blanks the iframe — it doesn't stop the rest of the timeline (scrubber,
+    // event markers, status polling) from wiring up below.
+    const safeUrl = resolveDashboardIframeUrl(body.dashboard_url, body.playback_id, window.location.origin);
+    if (safeUrl) {
+      iframe.src = safeUrl;
+      iframeWrap.style.display = "block";
+      iframeLabel.textContent = `${body.dashboard_url}` +
+        (totalMs ? ` — total ${(totalMs/1000).toFixed(1)}s` : "") +
+        (events.length ? ` — ${events.length} events` : "");
+    } else {
+      console.warn(`replay start: rejected unsafe dashboard_url ${JSON.stringify(body.dashboard_url)}`);
+      iframe.src = "about:blank";
+      iframeWrap.style.display = "none";
+    }
     btnPlay.disabled = true;
     btnPause.disabled = false;
     btnStop.disabled = false;


### PR DESCRIPTION
## Summary
- `viewer.js` assigned server-provided `body.dashboard_url` directly to `iframe.src` with no validation — flagged by SonarQube Cloud as `jssecurity:S5696` (BLOCKER).
- Add `resolveDashboardIframeUrl` (`playbackTimeline.js`), which rejects anything that isn't an http(s), same-origin URL (e.g. a `javascript:`/`data:` scheme, a cross-origin or protocol-relative URL, or a blank/whitespace-only string) and returns `null` in that case.
- When rejected, `startPlayback()` now falls back safely — it blanks the iframe and logs a warning — instead of bailing out of the whole function, so the rest of the playback UI (scrubber, event markers, status polling) still wires up even though the server-side replay has already started by that point.

## Test plan
- [x] `npm test` in `tools/onboarding-factory/internal/viewer/web` — 75 tests pass, including new cases for `javascript:`/`data:` schemes, cross-origin and protocol-relative URLs, unparseable URLs, and whitespace-only input.
- [x] `tools/preflight.sh` — full local CI parity (go tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, both web suites, ARS gate) — all green.

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)