### PR TITLE
security: add a security scan gate to ir:release + preflight

### DIFF
--- a/.claude/skills/ir:release/skill.md
+++ b/.claude/skills/ir:release/skill.md
@@ -325,6 +325,40 @@ cd /Users/ingo/projects/irrlicht/core && go test ./... -count=1
 
 All tests must pass before proceeding.
 
+## Step 5.5: Security Scan Gate
+
+Run before Step 6's ~5 minute Swift+DMG build, same fail-fast principle as
+the Step 7b race-guard check and the Step 6 smoke test.
+
+```bash
+tools/security-scan.sh
+```
+
+This checks, across every module in `go.work` and both web trees:
+
+- Open GitHub Dependabot alerts (Critical/High severity)
+- Open GitHub CodeQL code-scanning alerts (Critical/High severity)
+- `govulncheck` — any finding whose vulnerable symbol lives in a called
+  third-party dependency is blocking; a finding confined to `stdlib` (a Go
+  toolchain patch-level issue, not an application code fix) is logged but
+  doesn't block
+- `gosec` — High-severity + High-confidence findings are blocking; lower
+  severity/confidence findings are logged for visibility
+- `npm audit --audit-level=high` in `platforms/web` and
+  `tools/onboarding-factory/internal/viewer/web`
+
+**Abort the release on any non-zero exit.** The script names the failing
+tool, the specific finding (alert URL, OSV/CVE id, or gosec rule), and a
+fix-or-suppress path in its output — read that before deciding how to
+proceed. Do not re-run with `--local` to skip the GitHub alert checks; that
+flag exists only for `tools/preflight.sh`'s pre-push gate, which doesn't
+have (and shouldn't need) a `gh` call on every push.
+
+A check that can't run at all — missing tool, `gh` auth/scope failure — is
+a hard failure, not a skip. If the Dependabot/CodeQL checks fail with a 404
+from `gh api`, the token is missing the `security_events` scope:
+`gh auth refresh -s security_events`.
+
 ## Step 6: Build Artifacts
 
 > **⚠️ AUTHORITATIVE BUILD PATH — read before running the manual commands below.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,17 @@ Include as much of the following as you can:
 Please give us a reasonable window to ship a fix before any public disclosure.
 We'll coordinate timing with you.
 
+## Proactive scanning
+
+Beyond the reactive process above, every release runs a security gate
+(`tools/security-scan.sh`, invoked from `.claude/skills/ir:release/skill.md`)
+before artifacts are built: open GitHub Dependabot and CodeQL alerts,
+`govulncheck`, `gosec`, and `npm audit` across every Go module and web
+tree. Critical/High findings abort the release. The same local checks
+(without the GitHub alert queries) run via `tools/preflight.sh --only
+security` as part of the pre-push gate. GitHub CodeQL default setup covers
+Go and JavaScript/TypeScript continuously, independent of releases.
+
 ## Scope
 
 In scope:

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -17,12 +17,20 @@
 #                                      linux-replay Docker image (opt-in:
 #                                      needs Docker, by far the slowest gate)
 #
+# The `security` group has no matching workflow — GitHub Actions doesn't run
+# it yet (see .claude/skills/ir:release/skill.md's Step 5.5, which runs the
+# same tools/security-scan.sh at release time). It's local-only for now
+# because govulncheck/gosec/npm audit cost real time (~1 minute) and are
+# more valuable as a pre-push gate than on every PR push; a GH Actions
+# equivalent can be added later without changing tools/security-scan.sh.
+#
 # Usage:
 #   tools/preflight.sh                 # everything except the Linux gate
 #   tools/preflight.sh --linux         # + full Linux parity via Docker
 #   tools/preflight.sh --only go       # just the go-test.yml-equivalent gates
 #   tools/preflight.sh --only web      # just the two npm test trees
 #   tools/preflight.sh --only arch     # just the ARS architecture gate
+#   tools/preflight.sh --only security # just govulncheck + gosec + npm audit
 #   tools/preflight.sh --only linux    # just the Linux Docker gate
 #
 # PLATFORMS overrides the Linux gate's docker --platform (default: linux/amd64,
@@ -96,6 +104,13 @@ fi
 # ---- arch group (mirrors ars-gate.yml) -----------------------------------
 if want arch; then
   run_gate "ARS architecture gate" tools/ars-gate.sh
+fi
+
+# ---- security group (mirrors tools/security-scan.sh's local mode; the same
+# script's full mode, with GitHub Dependabot/CodeQL alert checks, runs at
+# release time from ir:release's Step 5.5, not here) ------------------------
+if want security; then
+  run_gate "security scan (govulncheck + gosec + npm audit)" tools/security-scan.sh --local
 fi
 
 # ---- linux group (mirrors linux.yml, opt-in: --linux or --only linux) ---

--- a/tools/security-scan.sh
+++ b/tools/security-scan.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# security-scan.sh — vulnerability scan + SAST gate, shared by
+# tools/preflight.sh's `security` group and .claude/skills/ir:release/skill.md's
+# pre-build gate (Step 5.5), so both surfaces run identical checks.
+#
+# Full mode (default, used by /ir:release):
+#   - open GitHub Dependabot alerts (Critical/High)
+#   - open GitHub CodeQL code-scanning alerts (Critical/High)
+#   - govulncheck ./...   (every module in go.work)
+#   - gosec ./...         (every module in go.work)
+#   - npm audit --audit-level=high (both web trees)
+#
+# Local mode (--local, used by preflight.sh's pre-push gate): skips the two
+# GitHub API calls — no repo/network dependency, and Dependabot/CodeQL alerts
+# aren't meaningfully different push-to-push — and runs govulncheck + gosec +
+# npm audit only.
+#
+# Severity semantics:
+#   - Dependabot / CodeQL: Critical or High severity alerts fail the gate.
+#     Medium/Low are logged, not blocking.
+#   - govulncheck has no per-finding severity field. A finding whose call
+#     trace bottoms out in a third-party module is treated as blocking (it
+#     means shipped code actually calls a known-vulnerable function — the
+#     same class of thing Dependabot alerts on). A finding confined to
+#     `stdlib` is a Go-toolchain patch-level issue, not a code change here —
+#     logged prominently as an upgrade recommendation, not blocking.
+#   - gosec: High-severity + High-confidence findings fail the gate.
+#     Everything else is logged for visibility, not blocking.
+#   - npm audit --audit-level=high already implements this split natively
+#     (fails only on high/critical advisories).
+#
+# A check that can't run at all — missing tool, `gh` auth/scope failure — is
+# a hard failure, not a skip. A silently-skipped scan is indistinguishable
+# from a clean one, which defeats the point of a gate.
+#
+# Usage: tools/security-scan.sh [--local]
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+LOCAL_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --local) LOCAL_ONLY=1 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# Every module in go.work — govulncheck/gosec run per module, matching how
+# go.work itself scopes builds (see tools/preflight.sh's `go` group for the
+# narrower go-test set: only core + onboarding-factory have test suites
+# today, but a vuln/SAST scan doesn't need tests to pass, so all five run).
+GO_MODULES=(core tools/onboarding-factory tools/wsload tools/seed-demo-sessions tools/eta-research)
+WEB_TREES=(platforms/web tools/onboarding-factory/internal/viewer/web)
+
+FAILED=0
+fail() { echo "FAIL: $1" >&2; FAILED=1; }
+warn() { echo "WARN: $1" >&2; }
+ok()   { echo "OK: $1"; }
+
+# ---- GitHub-native alerts (full mode only) --------------------------------
+
+gh_alert_gate() {
+  local label="$1" endpoint="$2" severity_filter="$3"
+  local raw rc
+  raw=$(gh api --paginate "$endpoint" -f state=open --jq '.[]' 2>&1)
+  rc=$?
+  if [[ $rc -ne 0 ]]; then
+    fail "$label: \`gh api $endpoint\` failed — auth or missing scope? output: $raw"
+    fail "$label: fix with: gh auth refresh -s security_events"
+    return
+  fi
+  local hits count
+  if [[ -z "$raw" ]]; then
+    hits='[]'
+  else
+    hits=$(echo "$raw" | jq -s "[.[] | select($severity_filter)]")
+  fi
+  count=$(echo "$hits" | jq 'length')
+  if [[ "$count" -gt 0 ]]; then
+    fail "$label: $count open Critical/High alert(s)"
+    echo "$hits" | jq -r '.[] | "  - " + (.html_url // (.number|tostring)) + " — " + (.security_advisory.summary // .rule.description // "no summary")' >&2
+  else
+    ok "$label: no open Critical/High alerts"
+  fi
+}
+
+if [[ "$LOCAL_ONLY" -eq 0 ]]; then
+  REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+  echo "-- Dependabot alerts ($REPO_NWO) --"
+  gh_alert_gate "dependabot" "repos/$REPO_NWO/dependabot/alerts" \
+    '(.security_advisory.severity=="critical" or .security_advisory.severity=="high")'
+
+  echo "-- CodeQL code-scanning alerts ($REPO_NWO) --"
+  gh_alert_gate "codeql" "repos/$REPO_NWO/code-scanning/alerts" \
+    '((.rule.security_severity_level=="critical" or .rule.security_severity_level=="high") or (.rule.security_severity_level==null and .rule.severity=="error"))'
+fi
+
+# ---- govulncheck (all modes) ----------------------------------------------
+
+command -v govulncheck >/dev/null 2>&1 || go install golang.org/x/vuln/cmd/govulncheck@latest
+
+for mod in "${GO_MODULES[@]}"; do
+  echo "-- govulncheck: $mod --"
+  gv_json=$(mktemp)
+  gv_err=$(mktemp)
+  if ! ( cd "$mod" && govulncheck -format json ./... ) >"$gv_json" 2>"$gv_err"; then
+    # govulncheck exits non-zero both when it finds vulnerabilities and when
+    # it hits a real scan error (e.g. build failure) — the JSON body tells
+    # them apart: a scan error has no "finding" entries at all.
+    finding_count=$(jq -s '[.[] | select(has("finding"))] | length' "$gv_json" 2>/dev/null || echo 0)
+    if [[ "$finding_count" -eq 0 ]]; then
+      fail "govulncheck: $mod — scan itself failed (not a vulnerability finding): $(cat "$gv_err")"
+      rm -f "$gv_json" "$gv_err"
+      continue
+    fi
+  fi
+  rm -f "$gv_err"
+  # Trace[0] is the vulnerable symbol's own module. A missing/empty trace is
+  # treated as non-stdlib (blocking) — fail safe rather than silently pass.
+  third_party=$(jq -s '[.[] | select(has("finding")) | select((.finding.trace[0].module // "unknown") != "stdlib") | .finding.osv] | unique' "$gv_json")
+  stdlib_only=$(jq -s '[.[] | select(has("finding")) | select((.finding.trace[0].module // "unknown") == "stdlib") | .finding.osv] | unique' "$gv_json")
+  tp_count=$(echo "$third_party" | jq 'length')
+  std_count=$(echo "$stdlib_only" | jq 'length')
+  if [[ "$tp_count" -gt 0 ]]; then
+    fail "govulncheck: $mod — $tp_count vulnerability/ies in called third-party code: $(echo "$third_party" | jq -c .)"
+  fi
+  if [[ "$std_count" -gt 0 ]]; then
+    warn "govulncheck: $mod — $std_count Go-toolchain (stdlib) vulnerability/ies: $(echo "$stdlib_only" | jq -c .) — not blocking; fix by bumping the Go toolchain, not application code"
+  fi
+  if [[ "$tp_count" -eq 0 && "$std_count" -eq 0 ]]; then
+    ok "govulncheck: $mod — clean"
+  fi
+  rm -f "$gv_json"
+done
+
+# ---- gosec (all modes) -----------------------------------------------------
+
+command -v gosec >/dev/null 2>&1 || fail "gosec not found — install: go install github.com/securego/gosec/v2/cmd/gosec@latest"
+
+if command -v gosec >/dev/null 2>&1; then
+  for mod in "${GO_MODULES[@]}"; do
+    echo "-- gosec: $mod (informational, all severities) --"
+    ( cd "$mod" && gosec -no-fail -quiet ./... ) || true
+
+    echo "-- gosec: $mod (gate: High severity + High confidence) --"
+    if ( cd "$mod" && gosec -quiet -severity high -confidence high ./... ); then
+      ok "gosec: $mod — no High/High findings"
+    else
+      fail "gosec: $mod — High-severity/High-confidence finding(s) — see output above"
+    fi
+  done
+fi
+
+# ---- npm audit (all modes) -------------------------------------------------
+
+for tree in "${WEB_TREES[@]}"; do
+  echo "-- npm audit: $tree --"
+  command -v npm >/dev/null 2>&1 || { fail "npm audit: $tree — npm not found"; continue; }
+  if ( cd "$tree" && npm audit --audit-level=high ); then
+    ok "npm audit: $tree — no High/Critical advisories"
+  else
+    fail "npm audit: $tree — High/Critical advisory/ies found (see above); fix with npm audit fix, or document a suppression"
+  fi
+done
+
+echo
+if [[ "$FAILED" -eq 1 ]]; then
+  echo "security-scan: FAILED — resolve the Critical/High finding(s) above before shipping." >&2
+  exit 1
+fi
+echo "security-scan: passed"


### PR DESCRIPTION
## Summary
- New `tools/security-scan.sh`: open Dependabot + CodeQL alerts (Critical/High blocks), `govulncheck`, `gosec`, and `npm audit --audit-level=high` across every `go.work` module and both web trees.
- Wired into `.claude/skills/ir:release/skill.md` as Step 5.5 (full mode, runs before the ~5 min Swift+DMG build) and `tools/preflight.sh --only security` (`--local` mode — no `gh` API dependency for the pre-push gate).
- Re-enabled GitHub CodeQL default setup for `go` + `javascript-typescript` (was silently `not-configured` — no workflow file or removal commit explains the lapse).
- `SECURITY.md` now documents the proactive gate alongside the existing reactive-disclosure process.

## Design notes
- `govulncheck` has no per-finding severity field. A finding whose vulnerable symbol traces to a called **third-party** module blocks the gate (same class of thing Dependabot alerts on). A finding confined to `stdlib` is a Go-toolchain patch-level issue, not an application fix — logged as a warning, not blocking. Verified empirically: today all 5 modules' only findings are stdlib-only (two Moderate Go 1.25.1 CVEs, fixed in 1.25.2/1.25.3), so the gate is green.
- `gosec` gates on High-severity + High-confidence only; everything else is logged for visibility (`-no-fail` informational pass first, then the blocking `-severity high -confidence high` pass).
- A check that can't run at all (missing tool, `gh` auth/scope failure) fails loudly rather than being silently skipped, per the issue's explicit acceptance criterion. Confirmed live: this repo's `gh` token currently lacks `security_events` scope, so a full-mode run correctly fails today with a `gh auth refresh -s security_events` fix pointer — a maintainer needs to run that once before `/ir:release`'s Step 5.5 can pass its Dependabot/CodeQL checks.
- Scoped govulncheck/gosec to all 5 `go.work` modules (not just the 2 with `go test` coverage) since a vuln/SAST scan only needs the code to build, not tests to pass.
- Did not add `dependabot.yml` — the issue's implementation notes flagged it as "worth adding alongside this work" but it's not in the acceptance criteria; kept this PR scoped to the gate itself.

## Test plan
- [x] `go test ./core/... -race -count=1` — pass
- [x] `go test ./tools/onboarding-factory/... -count=1` — pass
- [x] `tools/preflight.sh` (full, via the pre-push hook) — all 9 gates pass, including the new `security` gate
- [x] `tools/security-scan.sh --local` and `tools/security-scan.sh` (full) run manually — correct pass/fail/warn behavior verified for the GH-alert-auth-failure path and the stdlib-vs-third-party govulncheck split
- [x] `code-review` skill (low effort) on the diff — no findings
- [x] CodeQL default setup verified live: `state: "configured"` for `go` + `javascript-typescript`, first scan run kicked off

Fixes #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)