### PR TITLE
fix(daemon): hold a ready parent working when a new Workflow-tool child appears

### DIFF
--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -308,6 +308,14 @@ func (d *SessionDetector) RunPIDLivenessSweepForTest() {
 	d.pidMgr.CheckPIDLiveness()
 }
 
+// RunStaleSessionRefreshForTest runs one iteration of the stale-working
+// refresh synchronously. Intended for tests that need to exercise the
+// periodic re-classification pass without waiting for the real
+// staleWorkingRefreshInterval ticker.
+func (d *SessionDetector) RunStaleSessionRefreshForTest() {
+	d.refreshStaleSessions()
+}
+
 // CleanupZombies runs a one-shot startup sweep that deletes persisted
 // sessions whose process is provably gone. Call before the daemon starts
 // serving requests so the API never returns stale records inherited from a

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -179,6 +179,22 @@ func (d *SessionDetector) onNewSession(id agent.Identity, ev agent.Event) {
 		// Resolve git metadata and compute initial metrics.
 		d.enricher.EnrichNewSession(state, ev)
 
+		// A child's own first activity event may not arrive for a while — the
+		// same background-workflow discovery lag that leaves its parent
+		// needing holdParentWorkingForNewChild below. Classify it against its
+		// own freshly-computed metrics now instead of leaving it at the
+		// generic "ready until proven otherwise" bootstrap: a child stuck at
+		// ready doesn't count as active in hasActiveChildren, so the parent's
+		// hold below can't survive past the child's own next activity pass —
+		// e.g. the periodic stale-session sweep would see the parent's own
+		// turn-done metrics unchanged, find no active children, and flip it
+		// straight back to ready (issue #889).
+		if state.ParentSessionID != "" {
+			if newState, _ := ClassifyState(state.State, state.Metrics); newState != state.State {
+				state.State = newState
+			}
+		}
+
 		if err := d.repo.Save(state); err != nil {
 			d.log.LogError("session-detector", ev.SessionID,
 				fmt.Sprintf("failed to save new session: %v", err))
@@ -193,9 +209,18 @@ func (d *SessionDetector) onNewSession(id agent.Identity, ev agent.Event) {
 		}
 
 		// Record initial state transition.
-		d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: ev.SessionID, NewState: session.StateReady, Reason: "new session created"})
+		d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: ev.SessionID, NewState: state.State, Reason: "new session created"})
 
 		d.broadcast(outbound.PushTypeCreated, state)
+
+		// This child's parent may have already flipped to ready before this
+		// child was discovered (e.g. a background Workflow-tool run whose
+		// turn-done fired while it had no active children yet). Hold it
+		// working now instead of waiting for the parent's own next
+		// transcript/hook event to catch it (issue #889).
+		if state.ParentSessionID != "" {
+			d.holdParentWorkingForNewChild(state.ParentSessionID)
+		}
 
 		// When a real transcript session arrives, remove any pre-sessions for
 		// the same project. Match by projectDir first (Claude Code layout),

--- a/core/application/services/session_detector_subagent.go
+++ b/core/application/services/session_detector_subagent.go
@@ -164,6 +164,50 @@ func (d *SessionDetector) hasActiveChildren(parentID string) bool {
 	return false
 }
 
+// holdParentWorkingForNewChild forces a parent session that is sitting at
+// ready back to working the moment a new child of it is discovered.
+//
+// A background Workflow-tool run can legitimately have zero active children
+// for a stretch: before its first subagent's transcript appears, or between
+// pipeline stages (a stage's children finish and are cleaned up before the
+// next stage's children are discovered). If the parent's own turn-done fires
+// during one of those windows, hasActiveChildren finds nothing and the
+// classifier flips the parent to ready — even though the child just
+// discovered here proves the background job is still running. The child
+// itself starts in the generic "ready until content proves otherwise" state
+// too, so waiting for it to be classified as working is too slow; its mere
+// existence as this parent's child is already sufficient evidence.
+//
+// This is the mirror image of reevaluateParent, which only ever pulls a
+// held-working parent down to ready — it never pushes a wrongly-ready parent
+// back up. See issue #889.
+//
+// Runs under WithSessionStateLock, matching every other load-modify-save of
+// an already-existing SessionState in this package: the parent may have its
+// own PID-discovery goroutine in flight (assignPIDLocked writes state.PID/
+// UpdatedAt on the same shared pointer), and without the lock this would
+// race it (issue #606).
+func (d *SessionDetector) holdParentWorkingForNewChild(parentID string) {
+	d.pidMgr.WithSessionStateLock(func() {
+		parent, err := d.repo.Load(parentID)
+		if err != nil || parent == nil || parent.State != session.StateReady {
+			return
+		}
+		d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: parentID, PrevState: parent.State, NewState: session.StateWorking, Reason: "new child discovered while ready — holding working"})
+		parent.State = session.StateWorking
+		parent.UpdatedAt = time.Now().Unix()
+		d.refreshSubagentSummary(parent)
+		if err := d.repo.Save(parent); err != nil {
+			d.log.LogError("session-detector", parentID,
+				fmt.Sprintf("failed to hold parent working for new child: %v", err))
+			return
+		}
+		d.log.LogInfo("session-detector", parentID,
+			"holding parent working — new child discovered while ready")
+		d.broadcast(outbound.PushTypeUpdated, parent)
+	})
+}
+
 // reevaluateParent checks whether a parent session should transition now that
 // a child's state has changed. If the parent's own turn is done (IsAgentDone)
 // and no more active children remain, the parent transitions to ready (or

--- a/core/application/services/session_detector_subagent_test.go
+++ b/core/application/services/session_detector_subagent_test.go
@@ -35,6 +35,61 @@ func workflowChildMetrics() *funcMetrics {
 	}}
 }
 
+// setupWorkflowChildDiscovery reproduces the #889 bug precondition: a parent
+// whose turn is already done and sitting at ready (no children discovered
+// yet), then fires a new Workflow-tool child transcript for it — path shape
+// matching the fan-out layout from issue #565,
+// .../<parent>/subagents/workflows/<runID>/<childSessionID>.jsonl — and waits
+// for the parent to be held working. Returns the running detector so callers
+// can either assert immediately or drive further scenarios (e.g. the
+// stale-session sweep) before calling cancel/done themselves.
+func setupWorkflowChildDiscovery(t *testing.T, parentID, childSessionID, runID string) (repo *mockRepo, det *services.SessionDetector, cancel context.CancelFunc, done chan error) {
+	t.Helper()
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo = newMockRepo()
+
+	det = newDetectorWithMetrics(tw, pw, repo, workflowChildMetrics())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done = make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	repo.Save(&session.SessionState{
+		SessionID:      parentID,
+		State:          session.StateReady,
+		TranscriptPath: "/home/.claude/projects/-Users-test/" + parentID + ".jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:     "turn_done",
+			HasOpenToolCall:   false,
+			LastAssistantText: "The background workflow is running. I'll be notified when it completes.",
+		},
+	})
+
+	runDir := filepath.Join(t.TempDir(), parentID, "subagents", "workflows", runID)
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	childPath := filepath.Join(runDir, childSessionID+".jsonl")
+	writeOldTranscript(t, childPath, 0)
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      childSessionID,
+		ProjectDir:     runID,
+		TranscriptPath: childPath,
+	}
+
+	waitForSessionState(repo, parentID, session.StateWorking, time.Second)
+	return repo, det, cancel, done
+}
+
 // --- parent-child state propagation tests ------------------------------------
 
 func TestSessionDetector_ParentHeldWorking_WhenChildrenActive(t *testing.T) {
@@ -121,55 +176,7 @@ func TestSessionDetector_ParentHeldWorking_WhenChildrenActive(t *testing.T) {
 // waiting for either the child's own next activity pass or an incidental
 // hook event on the parent to catch it.
 func TestSessionDetector_ParentHeldWorking_WhenNewChildDiscoveredWhileReady(t *testing.T) {
-	tw := newMockAgentWatcher()
-	pw := newMockProcessWatcher()
-	repo := newMockRepo()
-
-	det := newDetectorWithMetrics(tw, pw, repo, workflowChildMetrics())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- det.Run(ctx) }()
-
-	time.Sleep(20 * time.Millisecond)
-
-	now := time.Now().Unix()
-
-	// Parent: already flipped to ready — its turn ended before any
-	// subagent of the just-dispatched background workflow was discovered.
-	repo.Save(&session.SessionState{
-		SessionID:      "parent-wf-889",
-		State:          session.StateReady,
-		TranscriptPath: "/home/.claude/projects/-Users-test/parent-wf-889.jsonl",
-		FirstSeen:      now,
-		UpdatedAt:      now,
-		EventCount:     5,
-		Metrics: &session.SessionMetrics{
-			LastEventType:     "turn_done",
-			HasOpenToolCall:   false,
-			LastAssistantText: "The background workflow is running. I'll be notified when it completes.",
-		},
-	})
-
-	// The workflow's first subagent transcript appears. Path shape matches
-	// the Workflow-tool fan-out layout (issue #565):
-	// .../<parent>/subagents/workflows/<run-id>/agent-<id>.jsonl
-	tmpDir := t.TempDir()
-	runDir := filepath.Join(tmpDir, "parent-wf-889", "subagents", "workflows", "wf_a1b2c3")
-	if err := os.MkdirAll(runDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	childPath := filepath.Join(runDir, "agent-review1.jsonl")
-	writeOldTranscript(t, childPath, 0)
-
-	tw.ch <- agent.Event{
-		Type:           agent.EventNewSession,
-		SessionID:      "agent-review1",
-		ProjectDir:     "wf_a1b2c3",
-		TranscriptPath: childPath,
-	}
-
-	waitForSessionState(repo, "parent-wf-889", session.StateWorking, time.Second)
+	repo, _, cancel, done := setupWorkflowChildDiscovery(t, "parent-wf-889", "agent-review1", "wf_a1b2c3")
 	cancel()
 	<-done
 
@@ -205,50 +212,7 @@ func TestSessionDetector_ParentHeldWorking_WhenNewChildDiscoveredWhileReady(t *t
 // at creation (in onNewSession) closes this: the child persists as working,
 // so hasActiveChildren keeps holding the parent on every subsequent sweep.
 func TestSessionDetector_ParentHeldWorking_SurvivesStaleSessionRefresh(t *testing.T) {
-	tw := newMockAgentWatcher()
-	pw := newMockProcessWatcher()
-	repo := newMockRepo()
-
-	det := newDetectorWithMetrics(tw, pw, repo, workflowChildMetrics())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- det.Run(ctx) }()
-
-	time.Sleep(20 * time.Millisecond)
-
-	now := time.Now().Unix()
-
-	repo.Save(&session.SessionState{
-		SessionID:      "parent-wf-sweep",
-		State:          session.StateReady,
-		TranscriptPath: "/home/.claude/projects/-Users-test/parent-wf-sweep.jsonl",
-		FirstSeen:      now,
-		UpdatedAt:      now,
-		EventCount:     5,
-		Metrics: &session.SessionMetrics{
-			LastEventType:     "turn_done",
-			HasOpenToolCall:   false,
-			LastAssistantText: "The background workflow is running. I'll be notified when it completes.",
-		},
-	})
-
-	tmpDir := t.TempDir()
-	runDir := filepath.Join(tmpDir, "parent-wf-sweep", "subagents", "workflows", "wf_d4e5f6")
-	if err := os.MkdirAll(runDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	childPath := filepath.Join(runDir, "agent-review2.jsonl")
-	writeOldTranscript(t, childPath, 0)
-
-	tw.ch <- agent.Event{
-		Type:           agent.EventNewSession,
-		SessionID:      "agent-review2",
-		ProjectDir:     "wf_d4e5f6",
-		TranscriptPath: childPath,
-	}
-
-	waitForSessionState(repo, "parent-wf-sweep", session.StateWorking, time.Second)
+	repo, det, cancel, done := setupWorkflowChildDiscovery(t, "parent-wf-sweep", "agent-review2", "wf_d4e5f6")
 
 	// Age both parent and child well past staleWorkingRefreshInterval (5s) so
 	// the sweep's staleness gate doesn't skip them, then run it directly

--- a/core/application/services/session_detector_subagent_test.go
+++ b/core/application/services/session_detector_subagent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +15,25 @@ import (
 	"irrlicht/core/ports/inbound"
 	"irrlicht/core/ports/outbound"
 )
+
+// workflowChildMetrics returns a funcMetrics that reports a live, mid-tool-call
+// subagent for any Workflow-tool fan-out path (.../subagents/workflows/...)
+// and falls back to nil (no-op merge) for everything else — the parent's own
+// fake, non-backed transcript path included. Used by the #889 regression
+// tests below to give freshly-discovered children real metrics, since
+// mockMetrics.ComputeMetrics always returns nil.
+func workflowChildMetrics() *funcMetrics {
+	return &funcMetrics{fn: func(path, adapter string) (*session.SessionMetrics, error) {
+		if !strings.Contains(path, "subagents/workflows") {
+			return nil, nil
+		}
+		return &session.SessionMetrics{
+			LastEventType:     "tool_use",
+			HasOpenToolCall:   true,
+			LastOpenToolNames: []string{"Bash"},
+		}, nil
+	}}
+}
 
 // --- parent-child state propagation tests ------------------------------------
 
@@ -81,6 +101,185 @@ func TestSessionDetector_ParentHeldWorking_WhenChildrenActive(t *testing.T) {
 
 	cancel()
 	<-done
+}
+
+// TestSessionDetector_ParentHeldWorking_WhenNewChildDiscoveredWhileReady
+// reproduces issue #889: a parent running a background Workflow-tool call can
+// have its own turn-done fire while it has zero active children — either
+// because the workflow's first subagent hasn't been discovered yet, or
+// because a pipeline stage boundary left it with none for a moment. With no
+// active children, hasActiveChildren finds nothing and the classifier flips
+// the parent to ready. Moments later the next stage's subagent transcript
+// appears — proof the background job is still running — but before this fix
+// nothing re-evaluated the parent at that point: the new child itself starts
+// in the generic "ready until proven otherwise" state too, so waiting for its
+// own content-based classification left the parent showing ready for as long
+// as tens of seconds in production.
+//
+// holdParentWorkingForNewChild closes this by forcing an already-ready parent
+// back to working the instant a new child of it is discovered, rather than
+// waiting for either the child's own next activity pass or an incidental
+// hook event on the parent to catch it.
+func TestSessionDetector_ParentHeldWorking_WhenNewChildDiscoveredWhileReady(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetectorWithMetrics(tw, pw, repo, workflowChildMetrics())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+
+	// Parent: already flipped to ready — its turn ended before any
+	// subagent of the just-dispatched background workflow was discovered.
+	repo.Save(&session.SessionState{
+		SessionID:      "parent-wf-889",
+		State:          session.StateReady,
+		TranscriptPath: "/home/.claude/projects/-Users-test/parent-wf-889.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:     "turn_done",
+			HasOpenToolCall:   false,
+			LastAssistantText: "The background workflow is running. I'll be notified when it completes.",
+		},
+	})
+
+	// The workflow's first subagent transcript appears. Path shape matches
+	// the Workflow-tool fan-out layout (issue #565):
+	// .../<parent>/subagents/workflows/<run-id>/agent-<id>.jsonl
+	tmpDir := t.TempDir()
+	runDir := filepath.Join(tmpDir, "parent-wf-889", "subagents", "workflows", "wf_a1b2c3")
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	childPath := filepath.Join(runDir, "agent-review1.jsonl")
+	writeOldTranscript(t, childPath, 0)
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "agent-review1",
+		ProjectDir:     "wf_a1b2c3",
+		TranscriptPath: childPath,
+	}
+
+	waitForSessionState(repo, "parent-wf-889", session.StateWorking, time.Second)
+	cancel()
+	<-done
+
+	parent, _ := repo.Load("parent-wf-889")
+	if parent == nil {
+		t.Fatal("parent session should still exist")
+	}
+	if parent.State != session.StateWorking {
+		t.Errorf("parent state: got %q, want working — new child discovered while ready must hold it", parent.State)
+	}
+
+	child, _ := repo.Load("agent-review1")
+	if child == nil {
+		t.Fatal("child session should have been created")
+	}
+	if child.ParentSessionID != "parent-wf-889" {
+		t.Errorf("child ParentSessionID: got %q, want %q", child.ParentSessionID, "parent-wf-889")
+	}
+	if child.State != session.StateWorking {
+		t.Errorf("child state: got %q, want working — classified against its own metrics at creation, not left at the generic ready bootstrap", child.State)
+	}
+}
+
+// TestSessionDetector_ParentHeldWorking_SurvivesStaleSessionRefresh guards
+// the other half of issue #889's fix: holdParentWorkingForNewChild alone only
+// flips the parent's State in memory for one instant. If the newly-discovered
+// child were left at its generic bootstrap ready state, hasActiveChildren
+// would not count it as active, and the periodic stale-session refresh
+// (staleWorkingRefreshInterval, 5s) would re-run the classifier against the
+// parent's unchanged turn-done metrics, find no active children, and silently
+// flip the parent straight back to ready — reproducing #889 a few seconds
+// later instead of fixing it. Classifying the child against its own metrics
+// at creation (in onNewSession) closes this: the child persists as working,
+// so hasActiveChildren keeps holding the parent on every subsequent sweep.
+func TestSessionDetector_ParentHeldWorking_SurvivesStaleSessionRefresh(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetectorWithMetrics(tw, pw, repo, workflowChildMetrics())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+
+	repo.Save(&session.SessionState{
+		SessionID:      "parent-wf-sweep",
+		State:          session.StateReady,
+		TranscriptPath: "/home/.claude/projects/-Users-test/parent-wf-sweep.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:     "turn_done",
+			HasOpenToolCall:   false,
+			LastAssistantText: "The background workflow is running. I'll be notified when it completes.",
+		},
+	})
+
+	tmpDir := t.TempDir()
+	runDir := filepath.Join(tmpDir, "parent-wf-sweep", "subagents", "workflows", "wf_d4e5f6")
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	childPath := filepath.Join(runDir, "agent-review2.jsonl")
+	writeOldTranscript(t, childPath, 0)
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "agent-review2",
+		ProjectDir:     "wf_d4e5f6",
+		TranscriptPath: childPath,
+	}
+
+	waitForSessionState(repo, "parent-wf-sweep", session.StateWorking, time.Second)
+
+	// Age both parent and child well past staleWorkingRefreshInterval (5s) so
+	// the sweep's staleness gate doesn't skip them, then run it directly
+	// instead of waiting on the real ticker.
+	stale := time.Now().Add(-10 * time.Minute).Unix()
+	parent, _ := repo.Load("parent-wf-sweep")
+	parent.UpdatedAt = stale
+	repo.Save(parent)
+	child, _ := repo.Load("agent-review2")
+	child.UpdatedAt = stale
+	repo.Save(child)
+
+	det.RunStaleSessionRefreshForTest()
+
+	// Poll instead of a fixed sleep: the sweep dispatches through the same
+	// async event-loop path as a real transcript event.
+	waitForCondition(func() bool {
+		p, _ := repo.Load("parent-wf-sweep")
+		return p != nil && p.State == session.StateWorking
+	}, time.Second)
+
+	cancel()
+	<-done
+
+	parent, _ = repo.Load("parent-wf-sweep")
+	if parent == nil {
+		t.Fatal("parent session should still exist")
+	}
+	if parent.State != session.StateWorking {
+		t.Errorf("parent state after stale-session refresh: got %q, want working — the child must still count as active", parent.State)
+	}
 }
 
 func TestSessionDetector_ParentReleasedToReady_WhenChildFinishes(t *testing.T) {


### PR DESCRIPTION
## Summary

- A parent session running a background `Workflow` tool call can have its own turn-done fire while it has zero active children — before the first subagent's transcript appears, or between pipeline stages. `hasActiveChildren` finds nothing at that instant and the classifier flips the parent to `ready`, even though the background job is still running (reproduced twice in one live session, see #889).
- `holdParentWorkingForNewChild` forces an already-`ready` parent back to `working` the moment a new child of it is discovered, instead of waiting for the parent's own next transcript/hook event to catch it.
- `onNewSession` now classifies a newly-discovered child against its own freshly-computed metrics immediately, rather than leaving it at the generic "ready until proven otherwise" bootstrap — otherwise the child stays uncounted by `hasActiveChildren` and the periodic stale-session refresh (5s ticker) silently undoes the hold a few seconds later, reproducing #889 anyway.
- The parent-side write is now wrapped in `WithSessionStateLock`, matching every other load-modify-save of an existing `SessionState` in this file, since the parent may have its own PID-discovery goroutine in flight (#606).

Fixes #889.

## Test plan

- [x] New regression test: `TestSessionDetector_ParentHeldWorking_WhenNewChildDiscoveredWhileReady` — fails without the fix (parent stays `ready`), passes with it.
- [x] New regression test: `TestSessionDetector_ParentHeldWorking_SurvivesStaleSessionRefresh` — locks in that the hold survives the periodic stale-session sweep; fails without the child-classification fix (parent flips back to `ready` after the sweep), passes with it.
- [x] `go test ./core/... -race -count=1` — full suite green, including the architecture test.
- [x] `tools/preflight.sh` (go + web + ARS gate) — all green; ARS composite ticks up slightly (7.9639 → 7.9644), no regression.
- [x] Workflow-backed `/code-review` at `xhigh` effort — found 2 real defects in the first draft of this fix (child left uncounted by `hasActiveChildren`, missing `WithSessionStateLock`), both fixed and verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)