### PR TITLE
fix(onboarding-factory): structurally prevent archive-name path traversal and manifest HTML injection

### DIFF
--- a/tools/onboarding-factory/internal/viewer/recordings.go
+++ b/tools/onboarding-factory/internal/viewer/recordings.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"irrlicht/tools/onboarding-factory/internal/validate"
 )
@@ -38,36 +37,39 @@ func (s *Server) handleRecordingsList(w http.ResponseWriter, scenarioDir string)
 // for one archived recording. Mirrors the main scenario-detail shape but
 // pulls from recordings/<name>/ and re-validates against the CURRENT
 // top-level expected.jsonl (the drift signal).
-func (s *Server) handleArchivedRecording(w http.ResponseWriter, scenarioDir, name string) {
+func (s *Server) handleArchivedRecording(w http.ResponseWriter, scenarioDir, rawName string) {
 	// Defense in depth — the URL slug regex constrained agent + id, not the
-	// archive name. Disallow path traversal here.
-	if strings.Contains(name, "..") || strings.ContainsRune(name, filepath.Separator) {
+	// archive name. NewSafeArchiveName disallows path traversal, and every
+	// path built below is only reachable through the SafeArchiveName it
+	// returns, so a future call site can't bypass the check.
+	name, err := NewSafeArchiveName(rawName)
+	if err != nil {
 		http.Error(w, "invalid archive name", http.StatusBadRequest)
 		return
 	}
 	store := s.store()
-	archiveDir := filepath.Join(scenarioDir, "recordings", name)
+	archiveDir := store.archiveFilePath(scenarioDir, name, "")
 	if !store.exists(archiveDir) {
 		http.Error(w, "archive not found", http.StatusNotFound)
 		return
 	}
-	d := ArchivedRecordingDetail{Name: name}
-	if b, ok := store.readFile(filepath.Join(archiveDir, "manifest.json")); ok {
+	d := ArchivedRecordingDetail{Name: string(name)}
+	if b, ok := store.readFile(store.archiveFilePath(scenarioDir, name, "manifest.json")); ok {
 		if err := json.Unmarshal(b, &d.Manifest); err != nil {
 			logViewerError("handleArchivedRecording: malformed manifest.json in archive %q: %v", name, err)
 		}
-		d.Manifest.Name = name
+		d.Manifest.Name = string(name)
 	}
-	d.Transitions = readTransitionsRaw(filepath.Join(archiveDir, "events.jsonl"))
+	d.Transitions = readTransitionsRaw(store.archiveFilePath(scenarioDir, name, "events.jsonl"))
 	// Re-evaluate the archive against the CURRENT top-level expected.jsonl.
 	// Drift signal: archive may have passed at promote-time but fail today
 	// because the spec moved.
 	if rep, err := validate.ValidateExpectedAgainst(
 		filepath.Join(scenarioDir, "expected.jsonl"),
-		filepath.Join(archiveDir, "events.jsonl"),
+		store.archiveFilePath(scenarioDir, name, "events.jsonl"),
 	); err == nil && rep != nil {
 		d.Expected = rep
 	}
-	d.Tools = extractToolCalls(filepath.Join(archiveDir, "transcript.jsonl"))
+	d.Tools = extractToolCalls(store.archiveFilePath(scenarioDir, name, "transcript.jsonl"))
 	writeJSON(w, d)
 }

--- a/tools/onboarding-factory/internal/viewer/store.go
+++ b/tools/onboarding-factory/internal/viewer/store.go
@@ -1,9 +1,11 @@
 package viewer
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // RecordingStore is the filesystem repository for the replaydata tree. It
@@ -44,6 +46,31 @@ func (st RecordingStore) readFile(path string) ([]byte, bool) {
 func (st RecordingStore) exists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// SafeArchiveName is a recording-archive directory name that has already
+// been checked against path traversal (no ".." segment, no path
+// separator). The zero value is invalid — construct via NewSafeArchiveName.
+// archiveFilePath is the only thing that accepts this type, so a future
+// call site building a path under an archive dir can't skip the check by
+// passing a raw string instead.
+type SafeArchiveName string
+
+// NewSafeArchiveName validates name and returns it as a SafeArchiveName. An
+// archive name is joined one path segment below <scenarioDir>/recordings/,
+// so a ".." segment or an embedded separator would let it escape that
+// directory.
+func NewSafeArchiveName(name string) (SafeArchiveName, error) {
+	if name == "" || strings.Contains(name, "..") || strings.ContainsRune(name, filepath.Separator) {
+		return "", fmt.Errorf("invalid archive name %q", name)
+	}
+	return SafeArchiveName(name), nil
+}
+
+// archiveFilePath resolves relPath under scenarioDir/recordings/<name>.
+// relPath may be "" to get the archive directory itself.
+func (st RecordingStore) archiveFilePath(scenarioDir string, name SafeArchiveName, relPath string) string {
+	return filepath.Join(scenarioDir, "recordings", string(name), relPath)
 }
 
 // listScenarios walks replaydata/agents/<agent>/{scenarios,regressions}/<id>

--- a/tools/onboarding-factory/internal/viewer/store_test.go
+++ b/tools/onboarding-factory/internal/viewer/store_test.go
@@ -1,0 +1,37 @@
+package viewer
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNewSafeArchiveName(t *testing.T) {
+	for _, bad := range []string{"", "..", "../../etc/passwd", "sub/dir", "sub" + string(filepath.Separator) + "dir"} {
+		if _, err := NewSafeArchiveName(bad); err == nil {
+			t.Errorf("NewSafeArchiveName(%q) = nil error; want rejection", bad)
+		}
+	}
+	name, err := NewSafeArchiveName("2026-05-01_run")
+	if err != nil {
+		t.Fatalf("NewSafeArchiveName(valid) = %v; want nil error", err)
+	}
+	if string(name) != "2026-05-01_run" {
+		t.Errorf("name = %q; want %q", name, "2026-05-01_run")
+	}
+}
+
+func TestArchiveFilePath(t *testing.T) {
+	var st RecordingStore
+	name, err := NewSafeArchiveName("2026-05-01_run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := st.archiveFilePath("/scenario", name, "manifest.json")
+	want := filepath.Join("/scenario", "recordings", "2026-05-01_run", "manifest.json")
+	if got != want {
+		t.Errorf("archiveFilePath() = %q; want %q", got, want)
+	}
+	if dir := st.archiveFilePath("/scenario", name, ""); dir != filepath.Join("/scenario", "recordings", "2026-05-01_run") {
+		t.Errorf("archiveFilePath(relPath=\"\") = %q; want the archive dir itself", dir)
+	}
+}

--- a/tools/onboarding-factory/internal/viewer/web/viewer.js
+++ b/tools/onboarding-factory/internal/viewer/web/viewer.js
@@ -1797,6 +1797,32 @@ function truncate(s, n) {
   return s.slice(0, n - 1) + "…";
 }
 
+// Renders the manifestBox field list (promoted_at, daemon_version, ...) via
+// DOM construction rather than an innerHTML template literal, so a manifest
+// value can never be interpreted as markup regardless of what a recording's
+// manifest.json contains. alwaysEllipsis matches the archive case, which
+// appends "…" after recipe_hash unconditionally; the newest-recording case
+// only appends it when a hash is present.
+export function renderManifestFields(m, passRateLabel, alwaysEllipsis) {
+  const frag = document.createDocumentFragment();
+  const row = (label, ...valueParts) => {
+    const b = document.createElement("b");
+    b.textContent = `${label}:`;
+    frag.append(b, " ", ...valueParts, document.createElement("br"));
+  };
+  row("promoted_at", m.promoted_at || "");
+  row("daemon_version", m.daemon_version || "");
+  row("agent_cli_version", m.agent_cli_version || "");
+  const code = document.createElement("code");
+  code.textContent = (m.recipe_hash || "").slice(0, 16);
+  row("recipe_hash", code, (alwaysEllipsis || m.recipe_hash) ? "…" : "");
+  row(passRateLabel, m.expected_pass_rate || "—");
+  const last = document.createElement("b");
+  last.textContent = "recording_started_at:";
+  frag.append(last, " ", m.recording_started_at || "");
+  return frag;
+}
+
 // renderRecordingHistory is the TOP-LEVEL controller for the scenario detail
 // page. It owns:
 //   - a selector with options [(none), ...recordings newest-first]. Every
@@ -1847,6 +1873,7 @@ function renderRecordingHistory(s, latestData, archives, initialArchive, recipeE
     return `${ts}${ver}${pass}`;
   }
 
+
   // Every recording lives under recordings/<name>/ — there is no separate
   // "Latest" entry. The list is newest-first by name; the newest (the one the
   // ScenarioDetail's recording-derived fields describe) is latestData.latest_recording.
@@ -1888,7 +1915,7 @@ function renderRecordingHistory(s, latestData, archives, initialArchive, recipeE
     // Reset the spec panel and the below-container before deciding
     // what to render. The Spec expectations panel always re-renders;
     // below-container is conditionally populated.
-    manifestBox.innerHTML = "";
+    manifestBox.replaceChildren();
     below.innerHTML = "";
 
     if (value === "__none__") {
@@ -1896,7 +1923,9 @@ function renderRecordingHistory(s, latestData, archives, initialArchive, recipeE
       // result/delta columns, or the summary chip. The point is "here's
       // the spec" — there's no recording to validate against.
       expHost.replaceChildren(renderExpected(latestData, "spec"));
-      manifestBox.innerHTML = `<i>No recording selected — only Spec expectations rendered. Pick a recording to see captured behavior.</i>`;
+      const i = document.createElement("i");
+      i.textContent = "No recording selected — only Spec expectations rendered. Pick a recording to see captured behavior.";
+      manifestBox.appendChild(i);
       return;
     }
 
@@ -1906,16 +1935,13 @@ function renderRecordingHistory(s, latestData, archives, initialArchive, recipeE
       expHost.replaceChildren(renderExpected(latestData));
       const lm = latestData.latest_manifest;
       if (lm) {
-        manifestBox.innerHTML = `
-          <b>promoted_at:</b> ${escapeHtml(lm.promoted_at || "")}<br>
-          <b>daemon_version:</b> ${escapeHtml(lm.daemon_version || "")}<br>
-          <b>agent_cli_version:</b> ${escapeHtml(lm.agent_cli_version || "")}<br>
-          <b>recipe_hash:</b> <code>${escapeHtml((lm.recipe_hash || "").slice(0, 16))}${lm.recipe_hash ? "…" : ""}</code><br>
-          <b>expected_pass_rate:</b> ${escapeHtml(lm.expected_pass_rate || "—")}<br>
-          <b>recording_started_at:</b> ${escapeHtml(lm.recording_started_at || "")}
-        `;
+        manifestBox.append(renderManifestFields(lm, "expected_pass_rate", /*alwaysEllipsis=*/false));
       } else {
-        manifestBox.innerHTML = `<i>Showing the newest recording (<code>recordings/${escapeHtml(newestName)}/</code>).</i>`;
+        const i = document.createElement("i");
+        const code = document.createElement("code");
+        code.textContent = `recordings/${newestName}/`;
+        i.append("Showing the newest recording (", code, ").");
+        manifestBox.appendChild(i);
       }
       renderRecordingPanels(latestData, /*recordingName=*/newestName);
       return;
@@ -1924,14 +1950,7 @@ function renderRecordingHistory(s, latestData, archives, initialArchive, recipeE
     // An older recording selected.
     const arch = (archives || []).find(a => a.name === value);
     if (arch) {
-      manifestBox.innerHTML = `
-        <b>promoted_at:</b> ${escapeHtml(arch.promoted_at || "")}<br>
-        <b>daemon_version:</b> ${escapeHtml(arch.daemon_version || "")}<br>
-        <b>agent_cli_version:</b> ${escapeHtml(arch.agent_cli_version || "")}<br>
-        <b>recipe_hash:</b> <code>${escapeHtml((arch.recipe_hash || "").slice(0, 16))}…</code><br>
-        <b>expected_pass_rate (at promote):</b> ${escapeHtml(arch.expected_pass_rate || "—")}<br>
-        <b>recording_started_at:</b> ${escapeHtml(arch.recording_started_at || "")}
-      `;
+      manifestBox.append(renderManifestFields(arch, "expected_pass_rate (at promote)", /*alwaysEllipsis=*/true));
     }
     const archDetail = await fetch(
       `/api/scenarios/${s.agent}/${s.subtree}/${s.id}/recordings/${encodeURIComponent(value)}`
@@ -1952,11 +1971,19 @@ function renderRecordingHistory(s, latestData, archives, initialArchive, recipeE
       if (frozenRate === freshRate) {
         driftNote.style.background = "#fafaf2";
         driftNote.style.color = "#555";
-        driftNote.innerHTML = `<b>No drift:</b> archive's frozen pass rate (${escapeHtml(frozenRate)}) matches a fresh evaluation against today's spec.`;
+        const b = document.createElement("b");
+        b.textContent = "No drift:";
+        driftNote.append(b, ` archive's frozen pass rate (${frozenRate}) matches a fresh evaluation against today's spec.`);
       } else {
         driftNote.style.background = "#fff7d6";
         driftNote.style.color = "#8a4500";
-        driftNote.innerHTML = `<b>Drift detected:</b> at promote time the archive showed <code>${escapeHtml(frozenRate)}</code>; today's spec rates the same archive as <code>${escapeHtml(freshRate)}</code>.`;
+        const b = document.createElement("b");
+        b.textContent = "Drift detected:";
+        const codeFrozen = document.createElement("code");
+        codeFrozen.textContent = frozenRate;
+        const codeFresh = document.createElement("code");
+        codeFresh.textContent = freshRate;
+        driftNote.append(b, " at promote time the archive showed ", codeFrozen, "; today's spec rates the same archive as ", codeFresh, ".");
       }
       manifestBox.appendChild(driftNote);
     }

--- a/tools/onboarding-factory/internal/viewer/web/viewer.test.js
+++ b/tools/onboarding-factory/internal/viewer/web/viewer.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { agentsPerPage, inferDriverLabel, paginateAgents, renderMarkdown } from './viewer.js'
+import { agentsPerPage, inferDriverLabel, paginateAgents, renderMarkdown, renderManifestFields } from './viewer.js'
 
 describe('renderMarkdown', () => {
   test('## / ### headings → h4 / h5', () => {
@@ -143,5 +143,49 @@ describe('paginateAgents', () => {
       visible: ['opencode', 'kiro-cli'],
       page: 2, pages: 3, start: 4, end: 6,
     })
+  })
+})
+
+describe('renderManifestFields', () => {
+  function fieldsToText(m, passRateLabel, alwaysEllipsis) {
+    const box = document.createElement('div')
+    box.append(renderManifestFields(m, passRateLabel, alwaysEllipsis))
+    return box
+  }
+
+  test('field values render as text, never as markup (no innerHTML injection)', () => {
+    const box = fieldsToText({
+      promoted_at: '<img src=x onerror=alert(1)>',
+      daemon_version: '0.3.0',
+      agent_cli_version: '1.0',
+      recipe_hash: 'abcd1234',
+      expected_pass_rate: '10/10',
+      recording_started_at: '2026-05-01T10:00:00Z',
+    }, 'expected_pass_rate', false)
+    expect(box.querySelector('img')).toBeNull()
+    expect(box.textContent).toContain('<img src=x onerror=alert(1)>')
+  })
+
+  test('recipe_hash is truncated to 16 chars and wrapped in <code>', () => {
+    const box = fieldsToText({ recipe_hash: 'a'.repeat(40) }, 'expected_pass_rate', false)
+    const code = box.querySelector('code')
+    expect(code.textContent).toBe('a'.repeat(16))
+  })
+
+  test('alwaysEllipsis=false omits the ellipsis when recipe_hash is empty', () => {
+    const box = fieldsToText({}, 'expected_pass_rate', false)
+    expect(box.textContent).not.toContain('…')
+  })
+
+  test('alwaysEllipsis=true appends the ellipsis even when recipe_hash is empty', () => {
+    const box = fieldsToText({}, 'expected_pass_rate (at promote)', true)
+    expect(box.textContent).toContain('…')
+    expect(box.textContent).toContain('expected_pass_rate (at promote):')
+  })
+
+  test('missing fields fall back to placeholders, not "undefined"', () => {
+    const box = fieldsToText({}, 'expected_pass_rate', false)
+    expect(box.textContent).toContain('expected_pass_rate: —')
+    expect(box.textContent).not.toContain('undefined')
   })
 })


### PR DESCRIPTION
## Summary
- Replaces the ad-hoc guard-then-join for archive names with a `SafeArchiveName` type — `archiveFilePath` is the only way to build a path under `recordings/<name>/`, so validation can't be skipped by a future call site.
- Replaces the `manifestBox`/`driftNote` `innerHTML` template literals (viewer.js) with DOM construction (`renderManifestFields`), so manifest field values render as text and can't be interpreted as markup regardless of content.
- Adds unit tests for both: Go path-traversal rejection + path building, and JS field rendering (including an explicit "no `<img>` injection" assertion).

Fixes #892 (which itself superseded #887 — marking these findings false-positive rather than fixing the pattern).

## Test plan
- [x] `go test ./tools/onboarding-factory/... -race -count=1` — all pass, including the existing path-traversal guard test
- [x] `npm test` in `tools/onboarding-factory/internal/viewer/web` — 80/80 pass (5 new)
- [x] `tools/preflight.sh` (full local CI parity, incl. security scan) — pass
- [x] `/code-review` at low effort — no findings