### PR TITLE
fix(daemon): hold parent working while a background child is active during turn-done waiting

### DIFF
--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -626,27 +626,24 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 		// cleanupChildren either way (finishOrphanedChildren's quiet-window
 		// and open-tool guards already leave a truly running child alone).
 		parentHeldWorking := false
+		holdWorkingIfChildrenActive := func(logMsg string) {
+			if !d.holdIfChildrenActive(state.SessionID) {
+				return
+			}
+			d.log.LogInfo(logComponentSessionDetector, ev.SessionID, logMsg)
+			newState = session.StateWorking
+			reason = ""
+			parentHeldWorking = true
+		}
 		if state.ParentSessionID == "" {
 			switch {
 			case newState == session.StateReady:
-				if d.holdIfChildrenActive(state.SessionID) {
-					d.log.LogInfo(logComponentSessionDetector, ev.SessionID,
-						"holding parent working — active children still running")
-					newState = session.StateWorking
-					reason = ""
-					parentHeldWorking = true
-				}
+				holdWorkingIfChildrenActive("holding parent working — active children still running")
 			case newState == session.StateWaiting && state.Metrics != nil && state.Metrics.IsAgentDone():
 				// Turn-done waiting (question/cue). Permission-prompt
 				// waiting never reaches here: its open tool call makes
 				// IsAgentDone return false.
-				if d.holdIfChildrenActive(state.SessionID) {
-					d.log.LogInfo(logComponentSessionDetector, ev.SessionID,
-						"holding parent working — active children still running (turn ended in waiting cue)")
-					newState = session.StateWorking
-					reason = ""
-					parentHeldWorking = true
-				}
+				holdWorkingIfChildrenActive("holding parent working — active children still running (turn ended in waiting cue)")
 			}
 		}
 

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -612,17 +612,24 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 		// question/cue (#593) — IsAgentDone gates it, so permission-prompt
 		// waiting (open tool call) is excluded. Without this, a parent whose
 		// overnight run ends by asking a question leaves its finished
-		// children stuck in working until the liveness sweep. The waiting
-		// branch only fast-forwards: no hold (the parent legitimately waits
-		// on the user) and no cleanupChildren (background children may still
-		// be running; finishOrphanedChildren's quiet-window and open-tool
-		// guards leave those alone).
+		// children stuck in working until the liveness sweep.
+		//
+		// The waiting branch also holds the parent working when a genuinely
+		// active child remains (#897) — mirroring the ready branch below.
+		// A turn-ending cue like "I'll wait for its completion notification"
+		// can read as a question/cue to the classifier while actually
+		// describing a wait on the parent's own background subagent, not
+		// the user; surfacing "waiting" in that case reads as "nothing
+		// happening" on the dashboard when a subagent is still working.
+		// finishOrphanedChildren runs first so a child that's merely stale
+		// (not genuinely active) doesn't hold the parent forever; no
+		// cleanupChildren either way (finishOrphanedChildren's quiet-window
+		// and open-tool guards already leave a truly running child alone).
 		parentHeldWorking := false
 		if state.ParentSessionID == "" {
 			switch {
 			case newState == session.StateReady:
-				d.finishOrphanedChildren(state.SessionID)
-				if d.hasActiveChildren(state.SessionID) {
+				if d.holdIfChildrenActive(state.SessionID) {
 					d.log.LogInfo(logComponentSessionDetector, ev.SessionID,
 						"holding parent working — active children still running")
 					newState = session.StateWorking
@@ -630,10 +637,16 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 					parentHeldWorking = true
 				}
 			case newState == session.StateWaiting && state.Metrics != nil && state.Metrics.IsAgentDone():
-				// Turn-done waiting (question/cue) — fast-forward only.
-				// Permission-prompt waiting never reaches here: its open
-				// tool call makes IsAgentDone return false.
-				d.finishOrphanedChildren(state.SessionID)
+				// Turn-done waiting (question/cue). Permission-prompt
+				// waiting never reaches here: its open tool call makes
+				// IsAgentDone return false.
+				if d.holdIfChildrenActive(state.SessionID) {
+					d.log.LogInfo(logComponentSessionDetector, ev.SessionID,
+						"holding parent working — active children still running (turn ended in waiting cue)")
+					newState = session.StateWorking
+					reason = ""
+					parentHeldWorking = true
+				}
 			}
 		}
 

--- a/core/application/services/session_detector_subagent.go
+++ b/core/application/services/session_detector_subagent.go
@@ -164,6 +164,17 @@ func (d *SessionDetector) hasActiveChildren(parentID string) bool {
 	return false
 }
 
+// holdIfChildrenActive fast-forwards any orphaned children of sessionID
+// (see finishOrphanedChildren) and reports whether a genuinely active one
+// remains. Shared by processActivity's ready and turn-done-waiting branches,
+// which both hold the parent working identically when it does (#897) — a
+// single call site keeps that hold logic from drifting out of sync between
+// the two.
+func (d *SessionDetector) holdIfChildrenActive(sessionID string) bool {
+	d.finishOrphanedChildren(sessionID)
+	return d.hasActiveChildren(sessionID)
+}
+
 // holdParentWorkingForNewChild forces a parent session that is sitting at
 // ready back to working the moment a new child of it is discovered.
 //

--- a/core/application/services/session_detector_subagent_test.go
+++ b/core/application/services/session_detector_subagent_test.go
@@ -1011,10 +1011,15 @@ func TestSessionDetector_PermissionWaitingDoesNotFastForwardChildren(t *testing.
 	<-done
 }
 
-// TestSessionDetector_WaitingParent_DoesNotCleanupBackgroundChildren: a
-// background child still writing its transcript (within SubagentQuietWindow)
-// survives the parent's turn-done-waiting transition untouched (#593).
-func TestSessionDetector_WaitingParent_DoesNotCleanupBackgroundChildren(t *testing.T) {
+// TestSessionDetector_WaitingParent_HeldWorking_WhenBackgroundChildActive
+// covers #897: a parent whose turn ends in a waiting cue ("Want a summary
+// when it lands?") is held working — not waiting — while a background child
+// is still genuinely active (transcript freshly written, within
+// SubagentQuietWindow). Surfacing "waiting" here would read as "nothing
+// happening" on the dashboard even though the child is still running. The
+// child itself is left untouched either way (#593) — this only changes the
+// parent's own state.
+func TestSessionDetector_WaitingParent_HeldWorking_WhenBackgroundChildActive(t *testing.T) {
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()
 	repo := newMockRepo()
@@ -1082,8 +1087,8 @@ func TestSessionDetector_WaitingParent_DoesNotCleanupBackgroundChildren(t *testi
 	if parent == nil {
 		t.Fatal("parent session should still exist")
 	}
-	if parent.State != session.StateWaiting {
-		t.Errorf("parent state: got %q, want waiting", parent.State)
+	if parent.State != session.StateWorking {
+		t.Errorf("parent state: got %q, want working — held by the active background child (#897)", parent.State)
 	}
 
 	child, _ := repo.Load("child-bg")

--- a/core/domain/session/waiting_cue.go
+++ b/core/domain/session/waiting_cue.go
@@ -128,6 +128,27 @@ var waitingCuePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)\bis (?:that|this) (?:right|correct|ok|okay|fine|good|what you wanted)\b`),
 }
 
+// waitingCueExclusions veto an otherwise-matched cue when the sentence names
+// an explicitly non-human wait target. "its"/"their"/"it" as the object of
+// wait/waiting unambiguously refer to something already named elsewhere in
+// the text (an agent, a job, a process) — never to the user being addressed
+// directly, unlike "for you"/"for your". Scoped narrowly to "wait(ing)
+// for/on <pronoun>" so it can't accidentally veto an unrelated cue earlier
+// in the same sentence. See #897: "I'll wait for its completion
+// notification" must not register as waiting on the user.
+var waitingCueExclusions = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\bwait(?:ing)?\s+(?:for|on)\s+(?:its|their|it)\b`),
+}
+
+func isSelfReferentialWait(s string) bool {
+	for _, re := range waitingCueExclusions {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
 // ExtractWaitingCue returns the trailing sentence that carries an imperative
 // or implicit waiting cue, or "" when none is present. Unlike
 // ExtractQuestionSnippet it does not require a literal '?'; it matches the
@@ -146,6 +167,9 @@ func ExtractWaitingCue(text string) string {
 		s := tail[i]
 		stripped := strings.TrimLeft(strings.TrimRight(s, trailingMarkdownNoise), markdownWrapper)
 		if stripped == "" {
+			continue
+		}
+		if isSelfReferentialWait(stripped) {
 			continue
 		}
 		for _, re := range waitingCuePatterns {

--- a/core/domain/session/waiting_cue_test.go
+++ b/core/domain/session/waiting_cue_test.go
@@ -114,6 +114,8 @@ func TestExtractWaitingCue(t *testing.T) {
 		{"19 drop the API key", "Drop the API key in .env and I'll re-run.", true},
 		{"20 once you've reviewed", "Once you've reviewed, ship it.", true},
 		{"21 I'll wait", "I'll wait for your green light before pushing.", true},
+		{"21b I'll wait until you're free", "I'll wait until you're free to look at this.", true},
+		{"21c I'll wait on your input", "I'll wait on your input before proceeding.", true},
 		{"23 lmk", "Lmk if you'd rather I split the PR.", true},
 		{"24 tell me", "Tell me which approach you prefer.", true},
 		{"25 please review", "Please review the diff.", true},
@@ -134,6 +136,14 @@ func TestExtractWaitingCue(t *testing.T) {
 		{"neg test failures substring", "Use a fixture, e.g. small.json. The tests pass.", false},
 		{"neg empty", "", false},
 		{"neg statement", "I am done.", false},
+		// #897: "I'll wait" on a background subagent's own completion is not
+		// a wait on the user — vetoed by waitingCueExclusions ("its"/"their"/
+		// "it" as the wait object), not by narrowing the inclusion pattern
+		// (that regressed recall for genuine human-directed waits lacking a
+		// literal "for you"/"for your", per code review on this fix).
+		{"neg wait for background agent (its)", "The Go agent is doing significant interface-renaming work — I'll wait for its completion notification before touching any Go/JS files myself.", false},
+		{"neg wait for background agents (their)", "The Go and JS agents are still running — I'll wait for their completion before merging.", false},
+		{"neg wait for it", "The background job is almost done — I'll wait for it to finish before continuing.", false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- A parent session whose turn ends in a waiting cue (e.g. *"I'll wait for its completion notification..."*) collapsed straight to `waiting` even when a background `Agent`-tool child it had kicked off was still genuinely running — the waiting branch in `processActivity` never checked `hasActiveChildren`, unlike the ready-transition branch just above it. Fixed by sharing a new `holdIfChildrenActive` helper (`session_detector_subagent.go`) between both branches, so the waiting path now holds the parent `working` when a child is genuinely still active, mirroring the existing ready-path behavior.
- The `I'll wait` waiting-cue regex (`waiting_cue.go`) is tightened via a new exclusion list (`its`/`their`/`it` as the wait object) instead of narrowing the inclusion pattern — narrowing it to require a literal `for you`/`for your` would have dropped detection of genuine human-directed waits phrased without that exact object (caught by an xhigh code-review pass on the first draft of this fix).

Closes #897.

## Test plan

- [x] `go test ./core/domain/session/... -race -count=1` — new/updated `TestExtractWaitingCue` / `TestIsWaitingForUserInput_ImperativeCues` cases pass, including the `#897` false-positive and the exclusion-list regression cases.
- [x] `go test ./core/application/services/... -race -count=1` — updated `TestSessionDetector_WaitingParent_HeldWorking_WhenBackgroundChildActive` plus the full `TestSessionDetector_*` suite pass; the two adjacent tests (orphaned children, permission-prompt waiting) are unaffected as expected.
- [x] `go test ./core/... -race -count=1` — full suite green (one pre-existing `-race` timing flake in `TestDebounce_*`, confirmed unrelated: passes reliably in isolation/serially and touches no file in this diff).
- [x] `tools/preflight.sh` (via the pre-push hook) — gofmt, core tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, both web suites, ARS architecture gate, and the security scan all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)