### PR TITLE
docs(readme): replace SonarCloud quality gate badge with rating badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 
 [![CodeScene](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fingo-eichhorst%2F9f14c8e5f25c1ccf5d6500c1685fd9fb%2Fraw%2Fcodescene.json)](https://github.com/ingo-eichhorst/Irrlicht/actions/workflows/codescene-badge.yml)
 [![ARS](https://img.shields.io/badge/ARS-Agent--Ready%208.1%2F10-green)](https://github.com/ingo-eichhorst/agent-readyness)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ingo-eichhorst_Irrlicht&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ingo-eichhorst_Irrlicht)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ingo-eichhorst_Irrlicht&metric=security_rating)](https://sonarcloud.io/summary/overall?id=ingo-eichhorst_Irrlicht)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ingo-eichhorst_Irrlicht&metric=reliability_rating)](https://sonarcloud.io/summary/overall?id=ingo-eichhorst_Irrlicht)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ingo-eichhorst_Irrlicht&metric=sqale_rating)](https://sonarcloud.io/summary/overall?id=ingo-eichhorst_Irrlicht)
 
 [🌐 Landing Page](https://ingo-eichhorst.github.io/Irrlicht/) · [📖 Documentation](https://ingo-eichhorst.github.io/Irrlicht/docs/quickstart.html) · [📦 Latest Release](https://github.com/ingo-eichhorst/Irrlicht/releases/latest)
 


### PR DESCRIPTION
## Summary
- Replace the single Quality Gate Status badge (which tracks the new-code leak period and can read "failed" even when the project is healthy) with the three native SonarCloud rating badges: Security, Reliability, Maintainability.
- These reflect the main branch's overall measures directly from SonarCloud's public badge endpoint — no CI secret or workflow required.

## Test plan
- [x] Verified each badge URL renders the expected letter grade (D/A/A) via curl against the SonarCloud API
- [x] Confirmed links point to the overall summary view, not the new-code view

🤖 Generated with [Claude Code](https://claude.com/claude-code)