### PR TITLE
Fix SonarQube security/reliability findings, phase 1 of #901

### DIFF
--- a/platforms/macos/Irrlicht/Managers/KeychainStore.swift
+++ b/platforms/macos/Irrlicht/Managers/KeychainStore.swift
@@ -34,10 +34,11 @@ enum KeychainStore {
         // swift:S6288): irrlichd reads this token unattended to auto-reconnect
         // to the relay, including right after login before the user has
         // touched the app. AfterFirstUnlock is the standard non-interactive
-        // tier — item is unavailable before the device's first unlock (and
-        // never leaves this device, see kSecAttrSynchronizable default of
-        // false), but doesn't block a headless read afterward.
-        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        // tier — item is unavailable before the device's first unlock, but
+        // doesn't block a headless read afterward. ThisDeviceOnly formalizes
+        // that this never leaves the device (matches kSecAttrSynchronizable's
+        // default of false, now explicit rather than incidental).
+        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         return SecItemAdd(attrs as CFDictionary, nil) == errSecSuccess
     }
 

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -263,7 +263,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       if (raw.length !== 15) return null;
       const out = new Array(60);
       for (let i = 0; i < 15; i++) {
-        const byte = raw.charCodeAt(i);
+        const byte = raw.codePointAt(i);
         out[i * 4 + 0] = HISTORY_PRIORITY_TO_STATE[(byte >> 6) & 0x3];
         out[i * 4 + 1] = HISTORY_PRIORITY_TO_STATE[(byte >> 4) & 0x3];
         out[i * 4 + 2] = HISTORY_PRIORITY_TO_STATE[(byte >> 2) & 0x3];

--- a/site/landscape/compare/index.html
+++ b/site/landscape/compare/index.html
@@ -839,8 +839,8 @@ document.addEventListener('DOMContentLoaded', function() {
         var cellA = a.children[idx], cellB = b.children[idx];
         var valA = (cellA.getAttribute('data-sort') || cellA.textContent).trim();
         var valB = (cellB.getAttribute('data-sort') || cellB.textContent).trim();
-        var numA = parseFloat(valA), numB = parseFloat(valB);
-        if (!isNaN(numA) && !isNaN(numB)) {
+        var numA = Number.parseFloat(valA), numB = Number.parseFloat(valB);
+        if (!Number.isNaN(numA) && !Number.isNaN(numB)) {
           return sortAsc ? numA - numB : numB - numA;
         }
         if (valA === '\u2014' || valA === '') return 1;

--- a/tools/onboarding-factory/internal/viewer/web/viewer.js
+++ b/tools/onboarding-factory/internal/viewer/web/viewer.js
@@ -20,6 +20,15 @@ const SPEED_PRESETS = [1, 2, 5, 10, 25, 100];
 // lowercase-alnum-dash-underscore slugs, never containing "/", "?", or "#".
 const RECORDING_SLUG_RE = /^[a-z0-9][a-z0-9_-]*$/;
 
+// Strip control characters and cap length before logging a server-provided
+// string (SonarQube jssecurity:S5145 — fetch response fields are tainted
+// regardless of same-origin trust). Uses String(), not `value || ""`, so
+// null/undefined/empty/garbage stay distinguishable in the log instead of
+// all collapsing to the same blank output.
+function sanitizeForLog(value) {
+  return String(value).replace(/[\r\n]+/g, " ").slice(0, 300);
+}
+
 // inferDriverLabel returns "Interactive (tmux REPL)" when the adapter
 // entry has a non-empty script array, "Headless one-shot" otherwise.
 // Pure function — exported for unit tests.
@@ -2589,11 +2598,7 @@ function renderPlayback(s, detailData, archiveName) {
       // Never pop a blocking modal — a scenario with no events.jsonl/usable
       // transcript (e.g. an un-recorded cell opened via a deep link) just has
       // nothing to play. Log non-blocking for debugging and bail quietly.
-      // Strip control characters and cap length before logging the server's
-      // error text (SonarQube jssecurity:S5145 — res.error is a fetch
-      // response body, tainted regardless of same-origin trust).
-      const safeError = String(res.error || "").replace(/[\r\n]+/g, " ").slice(0, 300);
-      console.warn("replay start failed:", res.status, safeError);
+      console.warn("replay start failed:", res.status, sanitizeForLog(res.error));
       return;
     }
     const body = res.body;
@@ -2619,7 +2624,7 @@ function renderPlayback(s, detailData, archiveName) {
         (totalMs ? ` — total ${(totalMs/1000).toFixed(1)}s` : "") +
         (events.length ? ` — ${events.length} events` : "");
     } else {
-      console.warn(`replay start: rejected unsafe dashboard_url ${JSON.stringify(body.dashboard_url)}`);
+      console.warn(`replay start: rejected unsafe dashboard_url ${sanitizeForLog(body.dashboard_url)}`);
       iframe.src = "about:blank";
       iframeWrap.style.display = "none";
     }


### PR DESCRIPTION
## Summary

Phase 1 of #901 (467 open SonarQube Cloud issues) — the Security (15) + Reliability (11) bucket. Every flagged location was read directly before deciding fix vs. dismiss, not just Sonar's one-line message.

**Real code fixes (4):**
- `viewer.js`: sanitize `dashboard_url`/`res.error` before logging via a shared `sanitizeForLog()` helper (`jssecurity:S5145`) — uses `String(value)` rather than `value || ""` so null/undefined/empty/garbage stay distinguishable in the log
- `KeychainStore.swift`: tighten keychain item to `AfterFirstUnlockThisDeviceOnly` (`swift:S6288`, partial — the biometric-gate ask is a product trade-off that would break `irrlichd`'s unattended relay reconnect, left open)
- `irrlicht.js`: `charCodeAt` → `codePointAt` on `atob()` byte output (`javascript:S7758`)
- `compare/index.html`: `Number.parseFloat`/`Number.isNaN` (`javascript:S7773`)

**Dismissed in SonarQube directly (17, no code change)** — confirmed false-positive or intentional-design on direct code read, each with a justification comment linking back to #901:
- 3× `jssecurity:S8476` (viewer.js) — already allowlist-validated + `encodeURIComponent`-encoded; Sonar's taint tracker doesn't see through the regex-validate-then-early-return pattern
- `swift:S1523` — fixed AppleScript templates, only pre-escaped values interpolated
- `go:S2245` + 7× `javascript:S2245` — non-security `math/rand`/`Math.random()` uses (reconnect jitter, decorative canvas animation)
- 4× `godre:S8188` — `cancel()` genuinely called in every case, just deferred at a different (correct, documented) scope
- `javascript:S6861` — an intentional ES-module live-binding export, genuinely reassigned elsewhere (wontfix, not falsepositive — the pattern is real, just deliberate)

**Left open, needs a product decision, not a patch:**
- `javascript:S5332` (`ws://` default) — deliberate trusted-LAN deployment trade-off
- `swift:S6288`'s full ask (biometric gate) — would break unattended daemon reconnect

The remaining 441 Maintainability issues stay tracked in #901 for later phases.

## Test plan

- [x] `go build ./... && go vet ./...` — clean
- [x] Swift macOS app builds (`swift build`) — confirms `KeychainStore.swift` compiles
- [x] `platforms/web` vitest suite — 133/133 passing
- [x] Full `tools/preflight.sh` (pre-push hook) — gofmt, core+onboarding-factory Go tests, replaydata validate, recording-rig smoke test, web tests, ARS architecture gate, security scan (govulncheck/gosec/npm audit) — all PASS
- [x] Workflow-backed `/code-review` (xhigh) — 2 findings, both fixed (null/undefined log collapse, duplicated sanitization logic factored into `sanitizeForLog()`)
- [ ] Confirm on SonarCloud after next automatic analysis that the 15+11 issues in this bucket are resolved (async, can't verify immediately post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)