### PR TITLE
fix(security): resolve remaining SonarQube security/reliability findings (#901)

### DIFF
--- a/platforms/macos/Irrlicht/Managers/KeychainStore.swift
+++ b/platforms/macos/Irrlicht/Managers/KeychainStore.swift
@@ -38,7 +38,7 @@ enum KeychainStore {
         // doesn't block a headless read afterward. ThisDeviceOnly formalizes
         // that this never leaves the device (matches kSecAttrSynchronizable's
         // default of false, now explicit rather than incidental).
-        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        attrs[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly // NOSONAR (swift:S6288) — see comment above
         return SecItemAdd(attrs as CFDictionary, nil) == errSecSuccess
     }
 

--- a/platforms/web/connectionProtocol.js
+++ b/platforms/web/connectionProtocol.js
@@ -50,7 +50,7 @@ export function relayWsUrl(raw) {
   // operator adds themselves (see examples/relay/Dockerfile) — a caller who
   // wants TLS types `https://`/`wss://` and the mapping above already
   // honors that.
-  if (!/^wss?:\/\//i.test(u)) u = 'ws://' + u;
+  if (!/^wss?:\/\//i.test(u)) u = 'ws://' + u; // NOSONAR (javascript:S5332) — see comment above
   while (u.endsWith('/')) u = u.slice(0, -1);
   if (!/\/api\/v1\/sessions\/stream$/.test(u)) u += '/api/v1/sessions/stream';
   return u;

--- a/tools/linux-replay-entrypoint.sh
+++ b/tools/linux-replay-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Default command for the tools/linux-replay.Dockerfile image, extracted
+# into a script and invoked in exec form (docker:S7019) rather than as an
+# inline shell-form CMD. Still the image's CMD (not a RUN) so `docker run`
+# re-executes it against the built layers with a fresh process table for
+# the conformance test.
+#
+# -race matches the linux.yml CI job — the conformance test exists to catch
+# pidfd/poll concurrency bugs, so this harness must exercise the detector
+# too, or a race could pass here and fail CI.
+set -eux
+cd /src/tools/onboarding-factory
+go test ./cmd/replay/... -race -count=1
+cd /src/core
+go test ./adapters/inbound/agents/processlifecycle/... -race -count=1
+cd /src
+tools/replay-fixtures.sh

--- a/tools/linux-replay.Dockerfile
+++ b/tools/linux-replay.Dockerfile
@@ -49,14 +49,6 @@ RUN cd core && go build ./...
 
 # Run the cross-platform gate. Kept as the image's default command (not a
 # RUN) so `docker run` re-executes it against the built layers and a fresh
-# process table for the conformance test.
-# -race matches the linux.yml CI job — the conformance test exists to catch
-# pidfd/poll concurrency bugs, so the local harness must exercise the detector
-# too, or a race could pass here and fail CI.
-CMD set -eux; \
-    cd /src/tools/onboarding-factory; \
-    go test ./cmd/replay/... -race -count=1; \
-    cd /src/core; \
-    go test ./adapters/inbound/agents/processlifecycle/... -race -count=1; \
-    cd /src; \
-    tools/replay-fixtures.sh
+# process table for the conformance test. Extracted into a script + exec
+# form (docker:S7019) rather than an inline shell-form CMD.
+CMD ["tools/linux-replay-entrypoint.sh"]


### PR DESCRIPTION
## Summary
Resolves the last 4 open SECURITY/RELIABILITY issues from #901 (the MAINTAINABILITY backlog is tracked separately, still open):

- **`text:S8566`** (SECURITY, MEDIUM) — `tools/starhistory/go.mod` had no `go.sum`. The module has zero external dependencies (stdlib + one local subpackage only), so `go mod tidy` produces nothing to checksum — added an empty `go.sum` so the lock file exists, satisfying the rule without any behavioral change. Verified `go build`/`go vet`/`go mod verify`/`go test` all pass.
- **`javascript:S5332`** (SECURITY, LOW) — `platforms/web/connectionProtocol.js:53`'s `ws://` default already has a rationale comment from a prior PR (#908) explaining it's an intentional trusted-LAN default with TLS as an opt-in. A comment alone doesn't clear a SonarQube finding — added `// NOSONAR` to formally suppress it.
- **`swift:S6288`** (SECURITY, MEDIUM) — same pattern: `KeychainStore.swift`'s no-biometric-gate accessibility already has a rationale comment (irrlichd needs unattended headless reads to auto-reconnect to the relay). Added `// NOSONAR`.
- **`docker:S7019`** (RELIABILITY + MAINTAINABILITY, MEDIUM) — `tools/linux-replay.Dockerfile`'s `CMD` was a multi-statement inline shell script. Extracted it into `tools/linux-replay-entrypoint.sh` and switched `CMD` to exec form, preserving the "CMD not RUN" semantics (still re-executed by `docker run` against a fresh process table) and `set -eux` fail-fast behavior.

## Test plan
- [x] `go build`/`go vet`/`go mod verify`/`go test` in `tools/starhistory` — clean
- [x] `npm test` in `platforms/web` — 133/133 pass
- [x] `swift build` in `platforms/macos` — clean
- [x] `docker build -f tools/linux-replay.Dockerfile .` then `docker run` the image end-to-end — exits 0, full replay-fixtures + conformance gate passes with the new exec-form CMD
- [x] `/code-review low` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)