### PR TITLE
fix(security): close CodeQL alerts that persisted after #910

### DIFF
--- a/core/adapters/outbound/filesystem/repository.go
+++ b/core/adapters/outbound/filesystem/repository.go
@@ -41,7 +41,16 @@ func (r *SessionRepository) InstancesDir() string {
 
 // Load reads a session state from disk. Returns (nil, err) if the file does not exist.
 func (r *SessionRepository) Load(sessionID string) (*session.SessionState, error) {
-	data, err := os.ReadFile(r.statePath(sessionID))
+	path := r.statePath(sessionID)
+	// statePath already routes sessionID through sanitizeSessionID, so this is
+	// a no-op for any legitimate caller — but CodeQL's go/path-injection query
+	// doesn't credit a sanitizer applied inside a called function one hop back
+	// (see sanitizeSessionID's doc comment); checking the exact value reaching
+	// os.ReadFile, right here, is what it recognizes.
+	if strings.Contains(path, "..") {
+		return nil, fmt.Errorf("invalid session id %q", sessionID)
+	}
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -334,27 +334,38 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       rebuildTimelineHistory();
     }
 
+    // applyOneTickBucket folds one session's bucket update into dict,
+    // returning whether it actually changed anything. Extracted from
+    // applyHistoryTick so that function's own loop/dedup branching doesn't
+    // compound with this per-session bucket-shifting logic (CodeScene
+    // flagged applyHistoryTick as a declining hotspot once the
+    // isDangerousKey guard added a branch on top of an already-complex
+    // method).
+    function applyOneTickBucket(dict, sid, granularitySec, buckets, bucketGenerations) {
+      if (isDangerousKey(sid)) return false;
+      // Skip if this tick has already been folded into our snapshot.
+      if (bucketGenerations?.[sid] !== undefined) {
+        const gen = bucketGenerations[sid];
+        const last = lastTickGen[sid]?.[granularitySec] || 0;
+        if (last && gen <= last) return false;
+        if (!lastTickGen[sid]) lastTickGen[sid] = Object.create(null);
+        lastTickGen[sid][granularitySec] = gen;
+      }
+      let arr = dict[sid];
+      if (!arr) arr = new Array(60).fill('');
+      arr.shift();
+      arr.push(HISTORY_PRIORITY_TO_STATE[buckets[sid] & 0x3]);
+      while (arr.length < 60) arr.unshift('');
+      dict[sid] = arr;
+      return true;
+    }
+
     function applyHistoryTick(granularitySec, buckets, bucketGenerations) {
       if (![1, 10, 60].includes(granularitySec)) return;
       const dict = historyByGranularity[granularitySec];
       let changed = false;
       for (const sid of Object.keys(buckets)) {
-        if (isDangerousKey(sid)) continue;
-        // Skip if this tick has already been folded into our snapshot.
-        if (bucketGenerations?.[sid] !== undefined) {
-          const gen = bucketGenerations[sid];
-          const last = lastTickGen[sid]?.[granularitySec] || 0;
-          if (last && gen <= last) continue;
-          if (!lastTickGen[sid]) lastTickGen[sid] = Object.create(null);
-          lastTickGen[sid][granularitySec] = gen;
-        }
-        let arr = dict[sid];
-        if (!arr) arr = new Array(60).fill('');
-        arr.shift();
-        arr.push(HISTORY_PRIORITY_TO_STATE[buckets[sid] & 0x3]);
-        while (arr.length < 60) arr.unshift('');
-        dict[sid] = arr;
-        changed = true;
+        if (applyOneTickBucket(dict, sid, granularitySec, buckets, bucketGenerations)) changed = true;
       }
       if (changed && granularitySec === currentGranularity) rebuildTimelineHistory();
     }

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -251,6 +251,19 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     // a tick that's already reflected in our snapshot (closing the connect-time race).
     const lastTickGen = Object.create(null);
 
+    // isDangerousKey guards every historyByGranularity[gran][sessionID] /
+    // lastTickGen[sessionID] access below. Those dicts are already
+    // Object.create(null) (no prototype to hijack via a "__proto__" key),
+    // but CodeQL's prototype-pollution query doesn't credit that — it
+    // flags the later `arr[...] = value` write on the value pulled out by
+    // a server-controlled key, several lines downstream of where the dict
+    // itself was hardened. Rejecting the dangerous keys at the point of
+    // lookup makes the safety explicit right where CodeQL's dataflow
+    // expects to see it, on top of the null-prototype backstop.
+    function isDangerousKey(key) {
+      return key === '__proto__' || key === 'constructor' || key === 'prototype';
+    }
+
     const HISTORY_PRIORITY_TO_STATE = ['ready', 'working', 'waiting', ''];
     function historyPriorityForState(s) {
       switch (s) {
@@ -296,6 +309,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     }
 
     function applyHistorySnapshot(sessionID, history, generations) {
+      if (isDangerousKey(sessionID)) return;
       for (const granKey of Object.keys(history)) {
         const gran = Number.parseInt(granKey, 10);
         if (![1, 10, 60].includes(gran)) continue;
@@ -325,6 +339,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       const dict = historyByGranularity[granularitySec];
       let changed = false;
       for (const sid of Object.keys(buckets)) {
+        if (isDangerousKey(sid)) continue;
         // Skip if this tick has already been folded into our snapshot.
         if (bucketGenerations?.[sid] !== undefined) {
           const gen = bucketGenerations[sid];
@@ -345,6 +360,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     }
 
     function applyHistoryUpgrade(sessionID, priority) {
+      if (isDangerousKey(sessionID)) return;
       const newState = HISTORY_PRIORITY_TO_STATE[priority & 0x3];
       const newPrio = historyPriorityForState(newState);
       let changedActive = false;

--- a/tools/onboarding-factory/internal/viewer/playback.go
+++ b/tools/onboarding-factory/internal/viewer/playback.go
@@ -309,6 +309,15 @@ func (m *PlaybackManager) StartViewerInternal(agent, subtree, scenario string, s
 			return nil, fmt.Errorf("invalid recording name")
 		}
 		eventsDir = filepath.Join(scenarioDir, "recordings", recording)
+		// eventsDir is built from the already-Base()'d/validated recording
+		// above, so this is a no-op for any legitimate value — but CodeQL's
+		// go/path-injection query doesn't credit that validation across the
+		// intervening filepath.Join (see the store.underRoot doc comment for
+		// the same rationale); checking the exact value reaching os.Stat,
+		// right here, is what it recognizes.
+		if strings.Contains(eventsDir, "..") {
+			return nil, fmt.Errorf("invalid recording name")
+		}
 		if _, err := os.Stat(filepath.Join(eventsDir, "events.jsonl")); err != nil {
 			return nil, fmt.Errorf("recording %q has no events.jsonl", recording)
 		}


### PR DESCRIPTION
## Summary

A fresh CodeQL scan of `main` after #910 merged found **4 alerts still open**. Investigating each showed 3 were new dataflow paths to the same sink *lines* through a **different taint source** than what #910 addressed — not a re-flag of insufficiently-fixed code:

- **`repository.go`'s `Load`**: the alert's cited source is now the loopback control API's sessionID reached via `forwarder.go`, not the `input.go` handler #910 fixed. `statePath` already routes `sessionID` through `sanitizeSessionID`, but CodeQL doesn't credit a sanitizer applied inside a called function one hop back (same lesson as `shard.go`'s `LoadAgentCell` in #896, whose alert also survived `AgentCellDir`'s internal hardening). Added a direct `strings.Contains(path, "..")` check on the exact value reaching `os.ReadFile`.
- **`playback.go`'s `StartViewerInternal`**: `eventsDir` is built from the already-validated `recording`, but through an intervening `filepath.Join` CodeQL doesn't trace through to the `os.Stat` call. Added the same direct check on `eventsDir` right before the sink.
- **`irrlicht.js`'s `historyByGranularity`/`lastTickGen`**: these dicts are already `Object.create(null)` (from an earlier fix), which genuinely neutralizes prototype pollution — but CodeQL's query flags the downstream `arr[...] = value` write on the value pulled out by a server-controlled key, without crediting the null-prototype dict it came from. Added an explicit `isDangerousKey` guard at the three call sites that index by a WS-sourced session id.

**The 4th (`go/request-forgery` on the relay URL in `forwarder.go`) is left as documented risk.** CodeQL's own guidance for this query's sanitizer is "select from a fixed list of known values" — fundamentally incompatible with "connect to whatever relay server you configure," which is this feature's actual purpose. The URL already gets real structural validation (scheme/host/userinfo) before dialing (#910). Recommend dismissing this specific alert in the Security UI as an accepted, by-design risk rather than chasing a code shape that would either break the feature or duplicate validation logic for no verified benefit.

## Test plan

- [x] `go build ./... && go vet ./...` clean on both `core/` and `tools/onboarding-factory/`
- [x] `go test ./... -race -count=1` clean on both modules (one pre-existing, unrelated `-race` timing flake in `core/application/services` reproduced and confirmed clean with `-p 1`, not caused by this change)
- [x] `npm test` green on both `platforms/web` (133 tests) and the onboarding-factory viewer (80 tests)
- [x] `tools/preflight.sh` — all green
- [ ] Confirm the 3 fixed alerts close on the next code-scanning run against `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)