### PR TITLE
fix(macos): suppress false-positive swift:S1075 findings (#901)

### DIFF
--- a/platforms/macos/Irrlicht/Managers/CLIToolInstaller.swift
+++ b/platforms/macos/Irrlicht/Managers/CLIToolInstaller.swift
@@ -8,7 +8,7 @@ enum CLIToolInstaller {
     /// Candidate bin directories, in preference order. `/usr/local/bin` is on
     /// the default PATH but usually root-owned; `/opt/homebrew/bin` is
     /// user-writable on Apple Silicon Homebrew setups.
-    static let defaultCandidates = ["/usr/local/bin", "/opt/homebrew/bin"]
+    static let defaultCandidates = ["/usr/local/bin", "/opt/homebrew/bin"]  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
 
     enum Status: Equatable {
         case unavailable          // binary not in this bundle (dev builds)
@@ -36,7 +36,7 @@ enum CLIToolInstaller {
         guard let source = bundledLs else { return .unavailable }
         let fm = FileManager.default
         for dir in candidates {
-            let link = dir + "/irrlicht-ls"
+            let link = dir + "/irrlicht-ls"  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
             if let dest = try? fm.destinationOfSymbolicLink(atPath: link),
                URL(fileURLWithPath: dest).standardizedFileURL == source.standardizedFileURL {
                 return .installed(path: link)
@@ -87,7 +87,7 @@ enum CLIToolInstaller {
         guard let dir = chooseTarget(candidates: candidates) else {
             return .failed(message: "No writable bin directory found. Run: sudo ln -sf \"\(source.path)\" /usr/local/bin/irrlicht-ls")
         }
-        let link = dir + "/irrlicht-ls"
+        let link = dir + "/irrlicht-ls"  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
         if let message = clearLinkSite(link) {
             return .failed(message: message)
         }

--- a/platforms/macos/Irrlicht/Managers/DaemonManager.swift
+++ b/platforms/macos/Irrlicht/Managers/DaemonManager.swift
@@ -150,7 +150,7 @@ final class DaemonManager: ObservableObject {
             return
         }
         let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
         task.arguments = ["-x", "irrlichd"]
         task.standardOutput = FileHandle.nullDevice
         task.standardError = FileHandle.nullDevice

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/KittyActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/KittyActivator.swift
@@ -79,10 +79,10 @@ struct KittyActivator: HostActivator {
     private static let kittenPath: String? = {
         let home = ProcessInfo.processInfo.environment["HOME"] ?? ""
         let candidates = [
-            "/Applications/kitty.app/Contents/MacOS/kitten",
-            "/usr/local/bin/kitten",
-            "/opt/homebrew/bin/kitten",
-            home + "/.local/bin/kitten",
+            "/Applications/kitty.app/Contents/MacOS/kitten",  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
+            "/usr/local/bin/kitten",  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
+            "/opt/homebrew/bin/kitten",  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
+            home + "/.local/bin/kitten",  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
         ]
         return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
     }()

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/TmuxActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/TmuxActivator.swift
@@ -34,7 +34,7 @@ struct TmuxActivator: HostActivator {
             // Select the pane first so it's active when the host terminal
             // window comes to the foreground.
             let result = ProcessRunner.run(
-                "/usr/bin/env",
+                "/usr/bin/env",  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
                 args: ["tmux", "-S", socket, "select-pane", "-t", pane],
                 timeout: 2.0
             )

--- a/platforms/macos/Irrlicht/Managers/PublishClient.swift
+++ b/platforms/macos/Irrlicht/Managers/PublishClient.swift
@@ -7,7 +7,7 @@ import Foundation
 /// tells it the desired `{enabled, url, token}`, which works whether the app
 /// spawned the daemon or adopted an already-running one.
 enum PublishClient {
-    static let path = "/api/v1/relay/publish"
+    static let path = "/api/v1/relay/publish"  // NOSONAR (swift:S1075) — fixed route on the daemon's own loopback API, not an external URI
 
     /// Wire shape of the PUT body. The relay token travels in this loopback
     /// body rather than a spawn-time env var (issue #722); the daemon binds

--- a/platforms/macos/Irrlicht/Managers/SessionManager+Relay.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Relay.swift
@@ -239,7 +239,7 @@ extension SessionManager {
         else if s.hasPrefix("https://") { s = "wss://" + s.dropFirst("https://".count) }
         if !s.hasPrefix("ws://") && !s.hasPrefix("wss://") { s = "ws://" + s }
         while s.hasSuffix("/") { s.removeLast() }
-        if !s.hasSuffix("/api/v1/sessions/stream") { s += "/api/v1/sessions/stream" }
+        if !s.hasSuffix("/api/v1/sessions/stream") { s += "/api/v1/sessions/stream" }  // NOSONAR (swift:S1075) — fixed route on the daemon's own loopback API, not an external URI
         return URL(string: s)
     }
 

--- a/platforms/macos/Irrlicht/Views/BackchannelRulesView.swift
+++ b/platforms/macos/Irrlicht/Views/BackchannelRulesView.swift
@@ -229,7 +229,7 @@ struct BackchannelRulesView: View {
                     .fixedSize()
 
                     if action.wrappedValue.preset == nil {
-                        TextField("/compact", text: Binding(
+                        TextField("/compact", text: Binding(  // NOSONAR (swift:S1075) — slash-command placeholder text, not a URI
                             get: { action.wrappedValue.data ?? "" },
                             set: { action.wrappedValue.data = $0 }
                         ))

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1181,7 +1181,7 @@ struct SessionListView_Previews: PreviewProvider {
                         id: "sess_abc123def456",
                         state: .working,
                         model: "claude-sonnet-4-6",
-                        cwd: "/Users/user/projects/multi-cc-bar",
+                        cwd: "/Users/user/projects/multi-cc-bar",  // NOSONAR (swift:S1075) — SwiftUI preview fixture, never runs in production
                         gitBranch: "main",
                         projectName: "multi-cc-bar",
                         firstSeen: Date().addingTimeInterval(-180),

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -8,7 +8,7 @@ struct SettingsView: View {
     /// (SonarQube swift:S1075 flags the literal; this is intentionally fixed
     /// — it's an example value, not something worth threading through as a
     /// parameter for its three call sites here).
-    private static let defaultRelayURLPlaceholder = "ws://localhost:7839"
+    private static let defaultRelayURLPlaceholder = "ws://localhost:7839"  // NOSONAR (swift:S1075) — see doc comment above
 
     @Binding var isPresented: Bool
     /// Swaps the panel body to the permission wizard in review mode (issue #570).

--- a/platforms/macos/Tests/CLIToolInstallerTests.swift
+++ b/platforms/macos/Tests/CLIToolInstallerTests.swift
@@ -4,24 +4,24 @@ import XCTest
 final class CLIToolInstallerTests: XCTestCase {
     func testChooseTargetPicksFirstWritableCandidate() {
         let target = CLIToolInstaller.chooseTarget(
-            candidates: ["/nope/a", "/yes/b", "/yes/c"],
-            isWritableDir: { $0.hasPrefix("/yes") }
+            candidates: ["/nope/a", "/yes/b", "/yes/c"],  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            isWritableDir: { $0.hasPrefix("/yes") }  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         )
-        XCTAssertEqual(target, "/yes/b")
+        XCTAssertEqual(target, "/yes/b")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
     }
 
     func testChooseTargetFallsBackToSecondCandidate() {
         // The /usr/local/bin → /opt/homebrew/bin ladder: first not writable.
         let target = CLIToolInstaller.chooseTarget(
-            candidates: ["/usr/local/bin", "/opt/homebrew/bin"],
-            isWritableDir: { $0 == "/opt/homebrew/bin" }
+            candidates: ["/usr/local/bin", "/opt/homebrew/bin"],  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            isWritableDir: { $0 == "/opt/homebrew/bin" }  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         )
-        XCTAssertEqual(target, "/opt/homebrew/bin")
+        XCTAssertEqual(target, "/opt/homebrew/bin")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
     }
 
     func testChooseTargetReturnsNilWhenNothingWritable() {
         XCTAssertNil(CLIToolInstaller.chooseTarget(
-            candidates: ["/a", "/b"],
+            candidates: ["/a", "/b"],  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             isWritableDir: { _ in false }
         ))
     }
@@ -33,7 +33,7 @@ final class CLIToolInstallerTests: XCTestCase {
         // no embedded binary the failure is "not embedded".
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(atPath: dir) }
-        FileManager.default.createFile(atPath: dir + "/irrlicht-ls", contents: Data("real".utf8))
+        FileManager.default.createFile(atPath: dir + "/irrlicht-ls", contents: Data("real".utf8))  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
 
         let result = CLIToolInstaller.install(candidates: [dir])
         guard case .failed(let message) = result else {
@@ -44,7 +44,7 @@ final class CLIToolInstallerTests: XCTestCase {
         XCTAssertTrue(message.contains("not embedded"), "unexpected failure: \(message)")
         // The squatting file is untouched either way.
         XCTAssertEqual(
-            try String(contentsOfFile: dir + "/irrlicht-ls", encoding: .utf8), "real"
+            try String(contentsOfFile: dir + "/irrlicht-ls", encoding: .utf8), "real"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         )
     }
 
@@ -61,9 +61,9 @@ final class CLIToolInstallerTests: XCTestCase {
         // check and createSymbolicLink failed with "file exists".
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(atPath: dir) }
-        let link = dir + "/irrlicht-ls"
+        let link = dir + "/irrlicht-ls"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         try FileManager.default.createSymbolicLink(
-            atPath: link, withDestinationPath: dir + "/gone-bundle/irrlicht-ls"
+            atPath: link, withDestinationPath: dir + "/gone-bundle/irrlicht-ls"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         )
 
         XCTAssertNil(CLIToolInstaller.clearLinkSite(link), "dangling symlink must be cleared, not reported")
@@ -73,9 +73,9 @@ final class CLIToolInstallerTests: XCTestCase {
     func testClearLinkSiteRemovesValidSymlink() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(atPath: dir) }
-        let target = dir + "/target"
+        let target = dir + "/target"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         FileManager.default.createFile(atPath: target, contents: Data("bin".utf8))
-        let link = dir + "/irrlicht-ls"
+        let link = dir + "/irrlicht-ls"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         try FileManager.default.createSymbolicLink(atPath: link, withDestinationPath: target)
 
         XCTAssertNil(CLIToolInstaller.clearLinkSite(link))
@@ -87,7 +87,7 @@ final class CLIToolInstallerTests: XCTestCase {
     func testClearLinkSiteRefusesRegularFile() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(atPath: dir) }
-        let link = dir + "/irrlicht-ls"
+        let link = dir + "/irrlicht-ls"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         FileManager.default.createFile(atPath: link, contents: Data("real".utf8))
 
         let message = CLIToolInstaller.clearLinkSite(link)

--- a/platforms/macos/Tests/DaemonManagerTests.swift
+++ b/platforms/macos/Tests/DaemonManagerTests.swift
@@ -42,11 +42,11 @@ final class DaemonManagerTests: XCTestCase {
 
     func testBuildDaemonEnvSetsBindAddrAndPreservesBase() {
         let env = DaemonManager.buildDaemonEnv(
-            base: ["PATH": "/usr/bin"],
+            base: ["PATH": "/usr/bin"],  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             bindAddr: "127.0.0.1:7838"
         )
         XCTAssertEqual(env["IRRLICHT_BIND_ADDR"], "127.0.0.1:7838")
-        XCTAssertEqual(env["PATH"], "/usr/bin", "base environment must be preserved")
+        XCTAssertEqual(env["PATH"], "/usr/bin", "base environment must be preserved")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
     }
 
     func testBuildDaemonEnvStripsInheritedRelayVars() {
@@ -57,13 +57,13 @@ final class DaemonManagerTests: XCTestCase {
         // daemon would publish to a stale relay the user never configured until
         // the app's corrective PUT landed.
         let env = DaemonManager.buildDaemonEnv(
-            base: ["IRRLICHT_RELAY_URL": "wss://stale", "IRRLICHT_RELAY_TOKEN": "stale", "PATH": "/usr/bin"],
+            base: ["IRRLICHT_RELAY_URL": "wss://stale", "IRRLICHT_RELAY_TOKEN": "stale", "PATH": "/usr/bin"],  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             bindAddr: "127.0.0.1:7837"
         )
         XCTAssertNil(env["IRRLICHT_RELAY_URL"], "inherited relay URL must be stripped")
         XCTAssertNil(env["IRRLICHT_RELAY_TOKEN"], "inherited relay token must be stripped")
         XCTAssertEqual(env["IRRLICHT_BIND_ADDR"], "127.0.0.1:7837")
-        XCTAssertEqual(env["PATH"], "/usr/bin", "unrelated base vars must be preserved")
+        XCTAssertEqual(env["PATH"], "/usr/bin", "unrelated base vars must be preserved")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
     }
 
     func testPublishSettingsDidChangeDoesNotRelaunchDaemon() {

--- a/platforms/macos/Tests/GroupViewSnapshotTests.swift
+++ b/platforms/macos/Tests/GroupViewSnapshotTests.swift
@@ -40,7 +40,7 @@ final class GroupViewSnapshotTests: XCTestCase {
             id: id,
             state: .working,
             model: "claude-opus-4-7",
-            cwd: "/Users/test/projects/app",
+            cwd: "/Users/test/projects/app",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             transcriptPath: nil,
             gitBranch: "main",
             projectName: "app",
@@ -119,7 +119,7 @@ final class GroupViewSnapshotTests: XCTestCase {
             id: "proc-0",
             state: .ready,
             model: "gemini-3-pro",
-            cwd: "/Users/test/projects/app",
+            cwd: "/Users/test/projects/app",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             transcriptPath: nil,
             gitBranch: "main",
             projectName: "app",

--- a/platforms/macos/Tests/PublishClientTests.swift
+++ b/platforms/macos/Tests/PublishClientTests.swift
@@ -6,7 +6,7 @@ final class PublishClientTests: XCTestCase {
 
     func testMakeRequestEncodesConfigAsPutJSON() throws {
         let req = try XCTUnwrap(PublishClient.makeRequest(
-            enabled: true, url: "ws://localhost:7839", token: "tok"))
+            enabled: true, url: "ws://localhost:7839", token: "tok"))  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
 
         XCTAssertEqual(req.httpMethod, "PUT")
         XCTAssertEqual(req.url?.path, PublishClient.path)
@@ -14,7 +14,7 @@ final class PublishClientTests: XCTestCase {
 
         let body = try XCTUnwrap(req.httpBody)
         let decoded = try JSONDecoder().decode(PublishClient.Config.self, from: body)
-        XCTAssertEqual(decoded, PublishClient.Config(enabled: true, url: "ws://localhost:7839", token: "tok"))
+        XCTAssertEqual(decoded, PublishClient.Config(enabled: true, url: "ws://localhost:7839", token: "tok"))  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
     }
 
     func testMakeRequestCarriesDisableAndEmptyToken() throws {

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -283,7 +283,7 @@ final class SessionManagerApiGroupsTests: XCTestCase {
         let id = UUID().uuidString
         let child = makeSession(id: "\(id)-child")
         let working = SessionState(
-            id: id, state: .working, model: "test-model", cwd: "/tmp",
+            id: id, state: .working, model: "test-model", cwd: "/tmp",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             firstSeen: Date(timeIntervalSince1970: 0),
             updatedAt: Date(timeIntervalSince1970: 0),
             role: "test-role", children: [child]
@@ -500,7 +500,7 @@ final class SessionManagerApiGroupsTests: XCTestCase {
             id: id,
             state: .working,
             model: "test-model",
-            cwd: "/tmp",
+            cwd: "/tmp",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             projectName: projectName,
             firstSeen: Date(timeIntervalSince1970: 0),
             updatedAt: Date(timeIntervalSince1970: 0),

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -56,8 +56,8 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertEqual(session.id, "sess_test123")
         XCTAssertEqual(session.state, .working)
         XCTAssertEqual(session.model, "claude-3.7-sonnet")
-        XCTAssertEqual(session.cwd, "/Users/test/projects/app")
-        XCTAssertEqual(session.transcriptPath, "/Users/test/.claude/projects/app/transcript.jsonl")
+        XCTAssertEqual(session.cwd, "/Users/test/projects/app")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+        XCTAssertEqual(session.transcriptPath, "/Users/test/.claude/projects/app/transcript.jsonl")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         XCTAssertEqual(session.eventCount, 5)
         XCTAssertEqual(session.lastEvent, "UserPromptSubmit")
     }
@@ -171,8 +171,8 @@ final class SessionManagerTests: XCTestCase {
             id: "sess_abc123def456ghi789",
             state: .working,
             model: "claude-3.7-sonnet",
-            cwd: "/test",
-            transcriptPath: "/test/transcript.jsonl",
+            cwd: "/test",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            transcriptPath: "/test/transcript.jsonl",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             firstSeen: Date(),
             updatedAt: Date(),
             eventCount: 1,
@@ -188,8 +188,8 @@ final class SessionManagerTests: XCTestCase {
             id: "sess_test",
             state: .working,
             model: "claude-3.7-sonnet",
-            cwd: "/test",
-            transcriptPath: "/test/transcript.jsonl",
+            cwd: "/test",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            transcriptPath: "/test/transcript.jsonl",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             firstSeen: oneMinuteAgo,
             updatedAt: oneMinuteAgo,
             eventCount: 1,
@@ -302,8 +302,8 @@ final class SessionManagerTests: XCTestCase {
             id: "sess_\(id)",
             state: state,
             model: "claude-3.7-sonnet",
-            cwd: "/Users/test/projects/test",
-            transcriptPath: "/Users/test/.claude/projects/test/transcript.jsonl",
+            cwd: "/Users/test/projects/test",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            transcriptPath: "/Users/test/.claude/projects/test/transcript.jsonl",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             firstSeen: Date(),
             updatedAt: Date(),
             eventCount: 1,
@@ -424,7 +424,7 @@ final class SessionManagerTests: XCTestCase {
     func testTitleMatchScoreFullCwdDominates() {
         // Full cwd in title (iTerm2/Terminal tab title style) dominates any
         // ancestor match.
-        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
+        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         XCTAssertEqual(
             AXTitleMatchActivator.titleMatchScore(
                 title: "ingo@mac: /Users/ingo/projects/irrlicht/.claude/worktrees/170 — zsh",
@@ -436,7 +436,7 @@ final class SessionManagerTests: XCTestCase {
         // cwd is several levels below the VS Code workspace root.
         // VS Code's window title shows only the workspace folder name
         // ("irrlicht"). The matcher must still find that as an ancestor.
-        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
+        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
 
         // parts index: Users(0) ingo(1) projects(2) irrlicht(3) .claude(4) worktrees(5) 170(6)
         //   Basename "170" — score 7.
@@ -458,7 +458,7 @@ final class SessionManagerTests: XCTestCase {
     func testTitleMatchScoreSkipsGenericTopsAndHomeBasename() {
         // "Users" and the user's home basename must never match alone —
         // otherwise every title string containing "ingo" would win.
-        let cwd = "/Users/ingo/projects/irrlicht"
+        let cwd = "/Users/ingo/projects/irrlicht"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         // Title matches "ingo" only — must score 0 (skipped).
         XCTAssertEqual(
             AXTitleMatchActivator.titleMatchScore(title: "ingo@mac: ~ — zsh", cwd: cwd),
@@ -470,7 +470,7 @@ final class SessionManagerTests: XCTestCase {
     }
 
     func testTitleMatchScoreEmptyInputs() {
-        let cwd = "/Users/ingo/projects/irrlicht"
+        let cwd = "/Users/ingo/projects/irrlicht"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         XCTAssertEqual(AXTitleMatchActivator.titleMatchScore(title: "", cwd: cwd), 0)
         XCTAssertEqual(AXTitleMatchActivator.titleMatchScore(title: "anything", cwd: ""), 0)
     }
@@ -479,7 +479,7 @@ final class SessionManagerTests: XCTestCase {
         // Worktree session, three VS Code windows open. Only one window
         // (the main repo) is an ancestor of the cwd — that one wins, even
         // though the cwd basename itself doesn't appear anywhere.
-        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
+        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         let titles = [
             "2.1.114 — irrlicht",                // 0: main repo, ancestor depth 3 → score 4
             "index.html — opencode-test",        // 1: unrelated
@@ -491,7 +491,7 @@ final class SessionManagerTests: XCTestCase {
     func testBestMatchIndexPrefersDeeperMatchWhenBothPresent() {
         // If both a deeper subfolder window ("core") and the repo root ("irrlicht")
         // are open, a cwd inside core should pick the core window.
-        let cwd = "/Users/ingo/projects/irrlicht/core"
+        let cwd = "/Users/ingo/projects/irrlicht/core"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         let titles = [
             "README.md — irrlicht",     // ancestor at depth 3 → score 4
             "main.go — core",           // basename at depth 4 → score 5 (wins)
@@ -500,7 +500,7 @@ final class SessionManagerTests: XCTestCase {
     }
 
     func testBestMatchIndexReturnsNilWhenNoMatch() {
-        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"
+        let cwd = "/Users/ingo/projects/irrlicht/.claude/worktrees/170"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         let titles = ["README.md — some-other-project", "", "main.swift — another"]
         XCTAssertNil(AXTitleMatchActivator.bestMatchIndex(titles: titles, cwd: cwd))
     }
@@ -509,7 +509,7 @@ final class SessionManagerTests: XCTestCase {
         // Two windows whose titles both contain "irrlicht" (same leaf depth = tie
         // on primary score). The second window also contains "a", the grandparent
         // segment of the actual cwd, so it should win the tie-break.
-        let cwd = "/Users/ingo/a/irrlicht"
+        let cwd = "/Users/ingo/a/irrlicht"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         let titles = [
             "README.md — irrlicht",   // 0: leaf match, prefix count 1 (irrlicht)
             "main.go — irrlicht — a", // 1: leaf match, prefix count 2 (irrlicht + a)
@@ -520,7 +520,7 @@ final class SessionManagerTests: XCTestCase {
     func testBestMatchIndexTmuxStyleTitleParsed() {
         // tmux window titles often embed full paths like "[0] 1:zsh /Users/.../irrlicht".
         // The Tier A score (1000) fires because the full cwd substring is present.
-        let cwd = "/Users/ingo/projects/irrlicht"
+        let cwd = "/Users/ingo/projects/irrlicht"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         let titles = [
             "README.md — other-project",
             "[0] 1:zsh /Users/ingo/projects/irrlicht",  // full cwd → Tier A
@@ -529,7 +529,7 @@ final class SessionManagerTests: XCTestCase {
     }
 
     func testCWDSegmentMatchCountBasic() {
-        let cwd = "/Users/ingo/a/irrlicht"
+        let cwd = "/Users/ingo/a/irrlicht"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         // Title contains both "irrlicht" and "a"
         XCTAssertEqual(
             AXTitleMatchActivator.cwdSegmentMatchCount(title: "main.go — irrlicht — a", cwd: cwd),
@@ -546,7 +546,7 @@ final class SessionManagerTests: XCTestCase {
 
     func testCWDSegmentMatchCountSkipsGenericSegments() {
         // "Users" and "home" are generic and must not inflate the count.
-        let cwd = "/Users/ingo/irrlicht"
+        let cwd = "/Users/ingo/irrlicht"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         XCTAssertEqual(
             AXTitleMatchActivator.cwdSegmentMatchCount(title: "Users — home — irrlicht", cwd: cwd),
             1) // only "irrlicht" counts; Users/ingo filtered out

--- a/platforms/macos/Tests/SessionRowSnapshotTests.swift
+++ b/platforms/macos/Tests/SessionRowSnapshotTests.swift
@@ -176,7 +176,7 @@ final class SessionRowSnapshotTests: XCTestCase {
             id: "sess_row_test",
             state: state,
             model: "claude-opus-4-7",
-            cwd: "/Users/test/projects/app",
+            cwd: "/Users/test/projects/app",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             transcriptPath: nil,
             gitBranch: "main",
             projectName: "app",

--- a/platforms/macos/Tests/SoundChoiceTests.swift
+++ b/platforms/macos/Tests/SoundChoiceTests.swift
@@ -18,7 +18,7 @@ final class SoundChoiceTests: XCTestCase {
     }
 
     func testCustomRoundTrip() {
-        let original = SoundChoice.custom(installedFilename: "IrrlichtCustom-ready.caf", displayPath: "/Users/x/Music/alert.mp3")
+        let original = SoundChoice.custom(installedFilename: "IrrlichtCustom-ready.caf", displayPath: "/Users/x/Music/alert.mp3")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         let decoded = SoundChoice(rawValue: original.rawValue)
         XCTAssertEqual(decoded, original)
     }
@@ -26,7 +26,7 @@ final class SoundChoiceTests: XCTestCase {
     func testCustomWithPipeInPathRoundTrips() {
         // The grammar splits on the first `|`, so a display path that itself
         // contains `|` after the separator must survive intact.
-        let original = SoundChoice.custom(installedFilename: "IrrlichtCustom-waiting.caf", displayPath: "/tmp/weird|name.wav")
+        let original = SoundChoice.custom(installedFilename: "IrrlichtCustom-waiting.caf", displayPath: "/tmp/weird|name.wav")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         let decoded = SoundChoice(rawValue: original.rawValue)
         XCTAssertEqual(decoded, original)
     }
@@ -53,7 +53,7 @@ final class SoundChoiceTests: XCTestCase {
     }
 
     func testCustomNotificationSoundUsesInstalledFilename() {
-        let choice = SoundChoice.custom(installedFilename: "IrrlichtCustom-ready.caf", displayPath: "/x.mp3")
+        let choice = SoundChoice.custom(installedFilename: "IrrlichtCustom-ready.caf", displayPath: "/x.mp3")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         XCTAssertEqual(choice.notificationSoundName, "IrrlichtCustom-ready.caf")
     }
 }

--- a/platforms/macos/Tests/SoundPlayerTests.swift
+++ b/platforms/macos/Tests/SoundPlayerTests.swift
@@ -69,7 +69,7 @@ final class SoundPlayerTests: XCTestCase {
     func testResolveMissingCustomFallsBackToPing() {
         let defaults = UserDefaults.standard
         let event = NotificationEvent.contextPressure
-        let missing = SoundChoice.custom(installedFilename: "IrrlichtCustom-doesnotexist.caf", displayPath: "/tmp/x.mp3")
+        let missing = SoundChoice.custom(installedFilename: "IrrlichtCustom-doesnotexist.caf", displayPath: "/tmp/x.mp3")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         defaults.set(missing.rawValue, forKey: event.soundKey)
         defer { defaults.removeObject(forKey: event.soundKey) }
 
@@ -84,7 +84,7 @@ final class SoundPlayerTests: XCTestCase {
     // MARK: - installCustom
 
     func testInstallCustomPassthroughCopiesAiff() throws {
-        let src = URL(fileURLWithPath: "/System/Library/Sounds/Glass.aiff")
+        let src = URL(fileURLWithPath: "/System/Library/Sounds/Glass.aiff")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         try XCTSkipUnless(FileManager.default.fileExists(atPath: src.path), "system Glass.aiff missing")
 
         let installed = try waitInstall(src: src, event: .ready)
@@ -172,7 +172,7 @@ final class SoundPlayerTests: XCTestCase {
     func testInstallCustomReplacesStaleVariant() throws {
         // First install a .aiff, then install a .wav for the same event and
         // confirm the .aiff is gone.
-        let aiffSrc = URL(fileURLWithPath: "/System/Library/Sounds/Pop.aiff")
+        let aiffSrc = URL(fileURLWithPath: "/System/Library/Sounds/Pop.aiff")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         try XCTSkipUnless(FileManager.default.fileExists(atPath: aiffSrc.path), "system Pop.aiff missing")
 
         let installedA = try waitInstall(src: aiffSrc, event: .waiting)

--- a/platforms/macos/TestsHarness/LauncherHarnessTests.swift
+++ b/platforms/macos/TestsHarness/LauncherHarnessTests.swift
@@ -108,7 +108,7 @@ final class LauncherHarnessTests: XCTestCase {
         // Must not crash or throw — just silently return.
         AXTitleMatchActivator.raiseMatchingWindow(
             bundleID: "com.nonexistent.app.harness",
-            cwd: "/Users/test/myproject"
+            cwd: "/Users/test/myproject"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         )
     }
 
@@ -128,7 +128,7 @@ final class LauncherHarnessTests: XCTestCase {
 
     func testProcessRunnerTimesOut() throws {
         try XCTSkipUnless(Self.harnessEnabled, "requires TEST_HARNESS=1")
-        let result = ProcessRunner.run("/bin/sleep", args: ["10"], timeout: 0.2)
+        let result = ProcessRunner.run("/bin/sleep", args: ["10"], timeout: 0.2)  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         XCTAssertEqual(result.status, -1, "Timed-out process should return status -1")
         XCTAssertEqual(result.stderr, "timeout")
     }
@@ -137,7 +137,7 @@ final class LauncherHarnessTests: XCTestCase {
         try XCTSkipUnless(Self.harnessEnabled, "requires TEST_HARNESS=1")
         // Session with no KITTY_LISTEN_ON — should fall back to app-level
         // activation without crashing, and return false when kitty isn't installed.
-        let session = try makeSession(termProgram: "kitty", cwd: "/tmp/kitty-harness-test")
+        let session = try makeSession(termProgram: "kitty", cwd: "/tmp/kitty-harness-test")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         let activated = KittyActivator().activate(session)
         // We can only assert no crash; activated may be true or false depending
         // on whether kitty is installed on the developer's machine.
@@ -153,13 +153,13 @@ final class LauncherHarnessTests: XCTestCase {
     func testKittyLauncherDecodesKittyPID() throws {
         let session = try makeSession(
             termProgram: "kitty",
-            cwd: "/tmp/kitty-decode-test",
-            kittyListenOn: "unix:/tmp/kitty-12345",
+            cwd: "/tmp/kitty-decode-test",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            kittyListenOn: "unix:/tmp/kitty-12345",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             kittyWindowID: "2",
             kittyPID: 12345
         )
         XCTAssertEqual(session.launcher?.kittyPID, 12345)
-        XCTAssertEqual(session.launcher?.kittyListenOn, "unix:/tmp/kitty-12345")
+        XCTAssertEqual(session.launcher?.kittyListenOn, "unix:/tmp/kitty-12345")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         XCTAssertEqual(session.launcher?.kittyWindowID, "2")
     }
 }


### PR DESCRIPTION
## Summary
- SonarQube's `swift:S1075` rule ("Refactor your code to get this URI from a customizable parameter") fires on any string literal that merely looks URI/path-shaped (starts with `/`, or contains `://`), with no regard for whether it's actually an externally-configurable network endpoint.
- Reviewed all 70 open `swift:S1075` findings in `platforms/macos/` by hand; every one is a false positive, falling into one of:
  - a local filesystem/binary path (candidate bin dirs, `/usr/bin/pkill`, `/usr/bin/env`, embedded symlink targets)
  - a fixed REST route on the daemon's own loopback API (never external)
  - a SwiftUI placeholder/preview literal
  - a test-fixture string (opaque `cwd`/path/URL values used only as test input)
- Suppressed each in place with `// NOSONAR (swift:S1075) — <reason>`, following the established convention from `KeychainStore.swift:41` and `connectionProtocol.js:53` (merged in #911/#912). No code behavior changed — comment-only diff.
- This resolves the `swift:S1075` slice of #901; other slices of that umbrella issue remain open.

## Test plan
- [x] `swift build --build-tests` — build succeeds
- [x] `swift test --filter IrrlichtTests` — 211 tests executed, 209 pass / 2 pre-existing snapshot failures (`SessionRowSnapshotTests.testGhostRowPID0NilMetrics`, `testFixtureAntigravityGhost`) confirmed to reproduce identically on unmodified `origin/main` (wall-clock drift in fixed-epoch "time ago" snapshot fixtures, unrelated to this change)
- [x] `/code-review low` — no findings (diff is comment-only)
- [x] `git diff --stat` skimmed — 70 insertions/70 deletions across 19 files, every changed line only gained a trailing NOSONAR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)