### PR TITLE
fix(test): sync client registration before daemon dial in relay control test

### DIFF
--- a/core/cmd/irrlichtrelay/control_test.go
+++ b/core/cmd/irrlichtrelay/control_test.go
@@ -69,6 +69,13 @@ func TestRelayRoutesControlToDaemon(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	// Wait for the client's initial snapshot before dialing the daemon: dial()
+	// returning only means the TCP/HTTP handshake finished, not that the
+	// server has processed the hello and registered the client yet. Without
+	// this sync point the daemon's hello can race ahead and register+broadcast
+	// daemon_status before the client is in h.clients, so fanout drops the
+	// frame and the readUntil below times out (flaked in #913's CI run).
+	readUntil(t, client, relay.MsgSnapshot)
 
 	daemon := dial(t, wsURL)
 	if err := daemon.WriteJSON(relay.Hello{


### PR DESCRIPTION
## Summary
- `TestRelayRoutesControlToDaemon` dialed the daemon right after writing the client's hello, but `dial()` returning only means the TCP/HTTP handshake finished — not that the server has processed the hello and registered the client.
- Under scheduler contention (heavier `-race` load, constrained CI runners), the daemon's hello could register + broadcast `daemon_status` before the client finished registering, so `fanout` dropped the frame and the test's `readUntil` timed out waiting for it forever.
- This flaked CI on `main` twice: 2026-07-03 (run 28684388606) and 2026-07-07 (run [28902108011](https://github.com/ingo-eichhorst/Irrlicht/actions/runs/28902108011/job/85741054776), the current `main` HEAD, unrelated to that commit's actual content).
- Fix mirrors the already-correct `TestRelayRoundTrip` in the same file: read the client's initial `MsgSnapshot` frame (which can only be sent after registration) before dialing the daemon, establishing a real happens-before instead of relying on wall-clock ordering.

## Test plan
- [x] `go test ./core/cmd/irrlichtrelay/... -race -count=50 -run TestRelayRoutesControlToDaemon` — 50/50 pass (previously reproduced the timeout under load)
- [x] `go test ./core/cmd/irrlichtrelay/... -race -count=1 -v` — full package passes
- [x] `go test ./core/... -race -count=1` — full suite passes
- [x] `tools/preflight.sh` (via pre-push hook) — all gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)