### PR TITLE
feat(macos): show subscription quota in the menu bar status icon

### DIFF
--- a/platforms/macos/Irrlicht/App/MenuBarController.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarController.swift
@@ -139,6 +139,13 @@ final class MenuBarController: NSObject {
         // a real change — same shape as SessionManager.init's
         // sourcesSettingsChanged observer.
         let defaultsSignal = NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
+            // Unlike NotificationCenter.addObserver(forName:object:queue: .main)
+            // (what SessionManager's sourcesSettingsChanged observer actually
+            // uses), a plain Combine publisher delivers on whatever thread
+            // posted the notification. Hop to main before the compactMap
+            // below mutates lastMenuBarStyle/etc — those are plain, non-atomic
+            // properties read/written elsewhere on the main thread.
+            .receive(on: RunLoop.main)
             .compactMap { [weak self] _ -> Void? in
                 guard let self else { return nil }
                 let style = UserDefaults.standard.string(forKey: MenuBarStyle.storageKey) ?? ""

--- a/platforms/macos/Irrlicht/App/MenuBarController.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarController.swift
@@ -39,6 +39,14 @@ final class MenuBarController: NSObject {
     private var escapeMonitor: Any?
     private var resignObserver: NSObjectProtocol?
 
+    // Last-seen values for the menu-bar quota settings (issue #909), so the
+    // broad UserDefaults.didChangeNotification (fires for *any* default,
+    // mirroring the pattern SessionManager.init uses for sourcesSettingsChanged)
+    // only triggers a rebuild when one of these three actually changed.
+    private var lastMenuBarStyle = UserDefaults.standard.string(forKey: MenuBarStyle.storageKey) ?? ""
+    private var lastMenuBarQuotaProvider = UserDefaults.standard.string(forKey: MenuBarQuotaProvider.storageKey) ?? ""
+    private var lastMenuBarQuotaVisual = UserDefaults.standard.string(forKey: QuotaVisualStyle.storageKey) ?? ""
+
     private static let escapeKeyCode: UInt16 = 53
 
     init(
@@ -124,9 +132,41 @@ final class MenuBarController: NSObject {
         let gasTownSignal = gasTownProvider.objectWillChange
             .map { _ in () }
             .eraseToAnyPublisher()
+        // Settings picker changes (issue #909: menu bar style/provider/shape)
+        // must repaint the icon immediately, not wait for the next unrelated
+        // session event. didChangeNotification fires for *any* UserDefaults
+        // write, so diff against the last-seen values before treating it as
+        // a real change — same shape as SessionManager.init's
+        // sourcesSettingsChanged observer.
+        let defaultsSignal = NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
+            .compactMap { [weak self] _ -> Void? in
+                guard let self else { return nil }
+                let style = UserDefaults.standard.string(forKey: MenuBarStyle.storageKey) ?? ""
+                let provider = UserDefaults.standard.string(forKey: MenuBarQuotaProvider.storageKey) ?? ""
+                let visual = UserDefaults.standard.string(forKey: QuotaVisualStyle.storageKey) ?? ""
+                guard style != self.lastMenuBarStyle
+                    || provider != self.lastMenuBarQuotaProvider
+                    || visual != self.lastMenuBarQuotaVisual
+                else { return nil }
+                self.lastMenuBarStyle = style
+                self.lastMenuBarQuotaProvider = provider
+                self.lastMenuBarQuotaVisual = visual
+                return ()
+            }
+            .eraseToAnyPublisher()
+        // The quota icon's pace marker and reset-window cutoff are
+        // wall-clock-dependent — they need to move even when no session
+        // event fires (e.g. everything sits `ready` for an hour). 30s
+        // matches SessionManager's existing projectCostsRefreshInterval.
+        let tickSignal = Timer.publish(every: 30, on: .main, in: .common)
+            .autoconnect()
+            .map { _ in () }
+            .eraseToAnyPublisher()
 
         imageSubscription = sessionSignal
             .merge(with: gasTownSignal)
+            .merge(with: defaultsSignal)
+            .merge(with: tickSignal)
             .debounce(for: .milliseconds(50), scheduler: RunLoop.main)
             .sink { [weak self] _ in
                 MainActor.assumeIsolated {

--- a/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
@@ -79,9 +79,13 @@ enum MenuBarImageBuilder {
             sessions: nonGtSessions,
             projectGroupOrder: sessionManager.projectGroupOrder
         )
+        // Combined style shares its width budget with the dots, so the
+        // quota bars render in a narrower, label-less layout there — see
+        // QuotaMenuBarRenderer.buildSVG's `compact` handling.
         let quotaImage = style == .lights ? nil : QuotaMenuBarRenderer.imageForSelectedProvider(
             sessions: nonGtSessions,
-            providerKey: MenuBarQuotaProvider.current
+            providerKey: MenuBarQuotaProvider.current,
+            compact: style == .combined
         )
         // .usage style with sessions active but no renderable quota yet
         // (fresh daemon start, or the selected provider hasn't ticked a
@@ -95,8 +99,10 @@ enum MenuBarImageBuilder {
         ) ? computedDotsImage : nil
         // Dots first (left), quota bars last (right) — closest to the
         // system status icons (WiFi/battery/clock), matching issue #909's
-        // mockup ordering.
-        let baseImage = composeSideBySide(dotsImage, quotaImage)
+        // mockup ordering. Uses the same gap as between dot-groups
+        // themselves (MenuBarStatusRenderer.groupGap) so the dots-to-quota
+        // seam in Combined style reads as "one more group," not a wider gap.
+        let baseImage = composeSideBySide(dotsImage, quotaImage, gap: MenuBarStatusRenderer.groupGap)
 
         guard gasTownProvider.isDaemonRunning else { return baseImage }
 

--- a/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
@@ -47,12 +47,27 @@ enum MenuBarImageBuilder {
         let nonGtSessions = gasTownProvider.isDaemonRunning
             ? sessionManager.sessions.filter { !gasTownProvider.ownsSession($0) }
             : sessionManager.sessions
-        let dotsImage = MenuBarStatusRenderer.buildStatusImage(
+
+        // Issue #909: which content the icon shows is a user choice (default
+        // .lights = today's behavior, unchanged for existing users). Either
+        // half can come back nil (no sessions for .usage-only, or no
+        // rate_limit data yet for .usage/.combined) without collapsing the
+        // whole icon — composeSideBySide degrades to whichever half exists.
+        let style = MenuBarStyle.current
+        let dotsImage = style == .usage ? nil : MenuBarStatusRenderer.buildStatusImage(
             sessions: nonGtSessions,
             projectGroupOrder: sessionManager.projectGroupOrder
         )
+        let quotaImage = style == .lights ? nil : QuotaMenuBarRenderer.imageForSelectedProvider(
+            sessions: nonGtSessions,
+            providerKey: MenuBarQuotaProvider.current
+        )
+        // Dots first (left), quota bars last (right) — closest to the
+        // system status icons (WiFi/battery/clock), matching issue #909's
+        // mockup ordering.
+        let baseImage = composeSideBySide(dotsImage, quotaImage)
 
-        guard gasTownProvider.isDaemonRunning else { return dotsImage }
+        guard gasTownProvider.isDaemonRunning else { return baseImage }
 
         let rigCount = sessionManager.apiGroups.first { $0.isGasTown }?.groups?.count ?? 0
         let emoji = NSAttributedString(string: "\u{26FD}", attributes: [
@@ -65,26 +80,46 @@ enum MenuBarImageBuilder {
         let badge = NSMutableAttributedString()
         badge.append(emoji)
         badge.append(countStr)
-        let badgeSize = badge.size()
 
-        let gap: CGFloat = dotsImage != nil ? 4 : 0
-        let dotsWidth = dotsImage?.size.width ?? 0
-        let dotsHeight = dotsImage?.size.height ?? 0
-        let totalWidth = badgeSize.width + gap + dotsWidth
-        let totalHeight = max(badgeSize.height, dotsHeight)
+        return composeSideBySide(attributedStringImage(badge), baseImage)
+    }
 
-        let combined = NSImage(size: NSSize(width: totalWidth, height: totalHeight))
-        combined.lockFocus()
-        let badgeY = (totalHeight - badgeSize.height) / 2
-        badge.draw(at: NSPoint(x: 0, y: badgeY))
-        if let dotsImage {
-            let dotsY = (totalHeight - dotsHeight) / 2
-            dotsImage.draw(at: NSPoint(x: badgeSize.width + gap, y: dotsY),
-                           from: .zero, operation: .sourceOver, fraction: 1)
+    /// Horizontally concatenates two optional images with a fixed gap,
+    /// vertically centering each on the taller one's height. Either side
+    /// may be nil — the other renders alone with no artificial gap. Shared
+    /// by the quota+dots composition and the Gas Town badge+base
+    /// composition, which both used to hand-roll this same NSImage math.
+    static func composeSideBySide(_ left: NSImage?, _ right: NSImage?, gap: CGFloat = 4) -> NSImage? {
+        switch (left, right) {
+        case (nil, nil):
+            return nil
+        case (let l?, nil):
+            return l
+        case (nil, let r?):
+            return r
+        case (let l?, let r?):
+            let totalWidth = l.size.width + gap + r.size.width
+            let totalHeight = max(l.size.height, r.size.height)
+            let combined = NSImage(size: NSSize(width: totalWidth, height: totalHeight))
+            combined.lockFocus()
+            l.draw(at: NSPoint(x: 0, y: (totalHeight - l.size.height) / 2),
+                   from: .zero, operation: .sourceOver, fraction: 1)
+            r.draw(at: NSPoint(x: l.size.width + gap, y: (totalHeight - r.size.height) / 2),
+                   from: .zero, operation: .sourceOver, fraction: 1)
+            combined.unlockFocus()
+            combined.isTemplate = false
+            return combined
         }
-        combined.unlockFocus()
-        combined.isTemplate = false
-        return combined
+    }
+
+    private static func attributedStringImage(_ text: NSAttributedString) -> NSImage {
+        let size = text.size()
+        let image = NSImage(size: size)
+        image.lockFocus()
+        text.draw(at: .zero)
+        image.unlockFocus()
+        image.isTemplate = false
+        return image
     }
 
 }

--- a/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
@@ -20,15 +20,21 @@ enum MenuBarImageBuilder {
     }
 
     /// True when `.usage` style has nothing to show (no renderable quota
-    /// yet) but sessions are actually active — see the fallback comment at
-    /// its call site in `combinedImage`. Pure decision, extracted for
-    /// testability without a SessionManager, mirroring `iconState`.
+    /// yet) but the dots view is actually renderable — see the fallback
+    /// comment at its call site in `combinedImage`. Takes the already-built
+    /// dots image rather than a raw session count: a non-zero session count
+    /// doesn't guarantee `buildStatusImage` succeeds (e.g. sessions whose
+    /// parent was pruned out from under them still carry a non-nil
+    /// `parentSessionId` and get excluded from every project group), and
+    /// checking the actual image avoids re-deriving that success/failure a
+    /// second time. Pure decision, extracted for testability without a
+    /// SessionManager, mirroring `iconState`.
     static func shouldFallBackToDotsForUsageStyle(
         style: MenuBarStyle,
         quotaImage: NSImage?,
-        sessionCount: Int
+        dotsImage: NSImage?
     ) -> Bool {
-        style == .usage && quotaImage == nil && sessionCount > 0
+        style == .usage && quotaImage == nil && dotsImage != nil
     }
 
     static func build(
@@ -66,7 +72,10 @@ enum MenuBarImageBuilder {
         // rate_limit data yet for .usage/.combined) without collapsing the
         // whole icon — composeSideBySide degrades to whichever half exists.
         let style = MenuBarStyle.current
-        var dotsImage = style == .usage ? nil : MenuBarStatusRenderer.buildStatusImage(
+        // Computed once regardless of style so the .usage fallback below can
+        // check its actual success/failure instead of re-deriving it from a
+        // raw session count (see shouldFallBackToDotsForUsageStyle's doc).
+        let computedDotsImage = MenuBarStatusRenderer.buildStatusImage(
             sessions: nonGtSessions,
             projectGroupOrder: sessionManager.projectGroupOrder
         )
@@ -81,12 +90,9 @@ enum MenuBarImageBuilder {
         // OffFlameImage.menuBar, the "no sessions running" icon, while
         // sessions are in fact active. Fall back to dots so the icon stays
         // honest about "something is running" even without quota data.
-        if shouldFallBackToDotsForUsageStyle(style: style, quotaImage: quotaImage, sessionCount: nonGtSessions.count) {
-            dotsImage = MenuBarStatusRenderer.buildStatusImage(
-                sessions: nonGtSessions,
-                projectGroupOrder: sessionManager.projectGroupOrder
-            )
-        }
+        let dotsImage = style != .usage || shouldFallBackToDotsForUsageStyle(
+            style: style, quotaImage: quotaImage, dotsImage: computedDotsImage
+        ) ? computedDotsImage : nil
         // Dots first (left), quota bars last (right) — closest to the
         // system status icons (WiFi/battery/clock), matching issue #909's
         // mockup ordering.

--- a/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
@@ -19,6 +19,18 @@ enum MenuBarImageBuilder {
         return .off
     }
 
+    /// True when `.usage` style has nothing to show (no renderable quota
+    /// yet) but sessions are actually active — see the fallback comment at
+    /// its call site in `combinedImage`. Pure decision, extracted for
+    /// testability without a SessionManager, mirroring `iconState`.
+    static func shouldFallBackToDotsForUsageStyle(
+        style: MenuBarStyle,
+        quotaImage: NSImage?,
+        sessionCount: Int
+    ) -> Bool {
+        style == .usage && quotaImage == nil && sessionCount > 0
+    }
+
     static func build(
         sessionManager: SessionManager,
         gasTownProvider: GasTownProvider
@@ -54,7 +66,7 @@ enum MenuBarImageBuilder {
         // rate_limit data yet for .usage/.combined) without collapsing the
         // whole icon — composeSideBySide degrades to whichever half exists.
         let style = MenuBarStyle.current
-        let dotsImage = style == .usage ? nil : MenuBarStatusRenderer.buildStatusImage(
+        var dotsImage = style == .usage ? nil : MenuBarStatusRenderer.buildStatusImage(
             sessions: nonGtSessions,
             projectGroupOrder: sessionManager.projectGroupOrder
         )
@@ -62,6 +74,19 @@ enum MenuBarImageBuilder {
             sessions: nonGtSessions,
             providerKey: MenuBarQuotaProvider.current
         )
+        // .usage style with sessions active but no renderable quota yet
+        // (fresh daemon start, or the selected provider hasn't ticked a
+        // statusline sample) must not collapse to nothing here — with
+        // dotsImage nil and quotaImage nil, the caller falls through to
+        // OffFlameImage.menuBar, the "no sessions running" icon, while
+        // sessions are in fact active. Fall back to dots so the icon stays
+        // honest about "something is running" even without quota data.
+        if shouldFallBackToDotsForUsageStyle(style: style, quotaImage: quotaImage, sessionCount: nonGtSessions.count) {
+            dotsImage = MenuBarStatusRenderer.buildStatusImage(
+                sessions: nonGtSessions,
+                projectGroupOrder: sessionManager.projectGroupOrder
+            )
+        }
         // Dots first (left), quota bars last (right) — closest to the
         // system status icons (WiFi/battery/clock), matching issue #909's
         // mockup ordering.

--- a/platforms/macos/Irrlicht/Models/MenuBarStyle.swift
+++ b/platforms/macos/Irrlicht/Models/MenuBarStyle.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Which content the NSStatusItem icon renders (issue #909): the classic
+/// per-project session-state dots, the subscription quota mini-bars, or
+/// both side by side. Stored in @AppStorage("menuBarStyle"); defaults to
+/// `.lights` so existing users see no visual change until they opt in.
+enum MenuBarStyle: String, CaseIterable, Identifiable {
+    case lights
+    case usage
+    case combined
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .lights: return "Lights"
+        case .usage: return "Usage"
+        case .combined: return "Combined"
+        }
+    }
+
+    static let storageKey = "menuBarStyle"
+
+    /// Read the persisted style. Falls back to `.lights` for an unset or
+    /// unparseable value, matching ProviderModePreference's fallback shape.
+    static var current: MenuBarStyle {
+        let raw = UserDefaults.standard.string(forKey: storageKey) ?? ""
+        return MenuBarStyle(rawValue: raw) ?? .lights
+    }
+}
+
+/// Which subscription provider's quota renders in the Usage/Combined menu
+/// bar styles. A single fixed choice, not multi-provider — issue #909's
+/// maintainer flagged that showing every subscription at once would crowd
+/// an already-tight icon budget shared with the capped-at-5 dot groups.
+/// Stored under @AppStorage("menuBarQuotaProvider"); empty means "not yet
+/// chosen", and MenuBarImageBuilder falls back to the freshest provider
+/// it finds.
+enum MenuBarQuotaProvider {
+    static let storageKey = "menuBarQuotaProvider"
+
+    static var current: String? {
+        let raw = UserDefaults.standard.string(forKey: storageKey) ?? ""
+        return raw.isEmpty ? nil : raw
+    }
+}
+
+/// How the quota portion of the icon renders when MenuBarStyle is `.usage`
+/// or `.combined`: the stacked 5h/7d bars, or a single compact ring for the
+/// most-imminent window (mirrors Claude Usage Tracker's "Compact" icon
+/// style, requested alongside issue #909). Stored under
+/// @AppStorage("menuBarQuotaVisual"); defaults to `.bars`.
+enum QuotaVisualStyle: String, CaseIterable, Identifiable {
+    case bars
+    case circle
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .bars: return "Bars"
+        case .circle: return "Circle"
+        }
+    }
+
+    static let storageKey = "menuBarQuotaVisual"
+
+    static var current: QuotaVisualStyle {
+        let raw = UserDefaults.standard.string(forKey: storageKey) ?? ""
+        return QuotaVisualStyle(rawValue: raw) ?? .bars
+    }
+}

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -89,6 +89,15 @@ struct RateLimitWindowInfo: Codable, Hashable {
         case resetsAt = "resets_at"
     }
 
+    /// Explicit memberwise initializer for tests — `init(from:)` below
+    /// suppresses Swift's synthesized one, mirroring the pattern already
+    /// used on SessionMetrics for the same reason.
+    init(usedPercent: Double, windowMinutes: Int, resetsAt: Date) {
+        self.usedPercent = usedPercent
+        self.windowMinutes = windowMinutes
+        self.resetsAt = resetsAt
+    }
+
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         usedPercent = try c.decode(Double.self, forKey: .usedPercent)
@@ -200,6 +209,16 @@ struct RateLimitInfo: Codable, Hashable {
         case credits
         case reachedType = "reached_type"
         case sampledAt = "sampled_at"
+    }
+
+    /// Explicit memberwise initializer for tests — see RateLimitWindowInfo's
+    /// for why one isn't synthesized.
+    init(windows: [RateLimitWindowInfo], planType: String? = nil, credits: CreditsInfo? = nil, reachedType: String? = nil, sampledAt: Date) {
+        self.windows = windows
+        self.planType = planType
+        self.credits = credits
+        self.reachedType = reachedType
+        self.sampledAt = sampledAt
     }
 
     init(from decoder: Decoder) throws {

--- a/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
@@ -15,7 +15,12 @@ struct MenuBarStatusRenderer {
 
     private static let radius: CGFloat = 5
     private static let overlap: CGFloat = 4
-    private static let groupGap: CGFloat = 6
+    /// Gap between adjacent project dot-groups. Non-private so
+    /// MenuBarImageBuilder can reuse the exact same value for the gap
+    /// between the dots and the quota bars in Combined style — otherwise
+    /// that seam would visually read as a bigger gap than the ones between
+    /// dot-groups themselves.
+    static let groupGap: CGFloat = 6
     private static let height: CGFloat = 18
     private static let fontSize: CGFloat = 10
     private static let maxVisibleGroups = 5

--- a/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
@@ -1,0 +1,183 @@
+import AppKit
+import Foundation
+
+/// Renders the subscription-quota mini-bars ("5h" / "7d") for the menu bar
+/// status item — the Usage/Combined styles from issue #909. Shares
+/// MenuBarStatusRenderer's 18pt-tall coordinate system so the two pieces
+/// can sit side by side in MenuBarImageBuilder's composition.
+enum QuotaMenuBarRenderer {
+    private static let height: CGFloat = 18
+    private static let rowHeight: CGFloat = height / 2
+    private static let labelWidth: CGFloat = 15
+    private static let barWidth: CGFloat = 32
+    private static let barHeight: CGFloat = 5
+    private static let fontSize: CGFloat = 8
+    private static let gap: CGFloat = 3
+
+    /// Picks the freshest non-stale rate-limit snapshot for `providerKey`
+    /// across `sessions` and renders it. `providerKey` nil means "whatever
+    /// provider is freshest" — used until the user picks one in Settings.
+    static func imageForSelectedProvider(
+        sessions: [SessionState],
+        providerKey: String?
+    ) -> NSImage? {
+        guard let info = selectedSnapshot(sessions: sessions, providerKey: providerKey) else {
+            return nil
+        }
+        return buildImage(for: info)
+    }
+
+    /// Same freshest-wins / skip-stale rule SessionListView's quota-chip
+    /// bucketing uses (mergeIntoBuckets), simplified to a single provider
+    /// instead of one bucket per provider — the menu bar icon only ever
+    /// shows one subscription's numbers.
+    static func selectedSnapshot(
+        sessions: [SessionState],
+        providerKey: String?
+    ) -> RateLimitInfo? {
+        let now = Date()
+        let candidates: [(key: String, info: RateLimitInfo)] = sessions.compactMap { session in
+            guard let snap = session.metrics?.rateLimit else { return nil }
+            let isStale = snap.windows.contains { $0.resetsAt <= now }
+            guard !isStale else { return nil }
+            let key = snap.providerKey(adapter: session.adapter) ?? "unknown:\(session.adapter ?? "")"
+            return (key, snap)
+        }
+        let filtered = providerKey.map { key in candidates.filter { $0.key == key } } ?? candidates
+        return filtered.max { $0.info.sampledAt < $1.info.sampledAt }?.info
+    }
+
+    static func buildImage(for info: RateLimitInfo) -> NSImage? {
+        let built: (svg: String, width: CGFloat)?
+        switch QuotaVisualStyle.current {
+        case .bars: built = buildSVG(for: info)
+        case .circle: built = buildCircleSVG(for: info)
+        }
+        guard let (svg, width) = built else { return nil }
+        guard let data = svg.data(using: .utf8), let image = NSImage(data: data) else { return nil }
+        image.isTemplate = false
+        image.size = NSSize(width: width, height: height)
+        return image
+    }
+
+    static func buildSVG(for info: RateLimitInfo) -> (svg: String, width: CGFloat)? {
+        let fiveHour = info.windows.first { $0.canonicalWindowMinutes == 300 }
+        let sevenDay = info.windows.first { $0.canonicalWindowMinutes == 10080 }
+        guard fiveHour != nil || sevenDay != nil else { return nil }
+
+        let width = labelWidth + gap + barWidth
+        var svg = """
+        <svg xmlns="http://www.w3.org/2000/svg" width="\(Int(width))" height="\(Int(height))">
+        """
+        if let fiveHour {
+            svg += rowSVG(label: "5h", window: fiveHour, rowY: 0)
+        }
+        if let sevenDay {
+            svg += rowSVG(label: "7d", window: sevenDay, rowY: rowHeight)
+        }
+        svg += "</svg>"
+        return (svg, width)
+    }
+
+    /// Single compact ring for the 5h window specifically — deliberately
+    /// *not* RateLimitInfo.imminentWindow (which can jump to the 7d window
+    /// once that's more depleted than the 5h one): a glance-value should
+    /// stay pinned to one fixed window rather than silently swap which
+    /// number it's showing. Falls back to 7d only when 5h is absent (e.g.
+    /// a fresh snapshot that hasn't carried both windows yet).
+    static func buildCircleSVG(for info: RateLimitInfo) -> (svg: String, width: CGFloat)? {
+        let fiveHour = info.windows.first { $0.canonicalWindowMinutes == 300 }
+        let sevenDay = info.windows.first { $0.canonicalWindowMinutes == 10080 }
+        guard let window = fiveHour ?? sevenDay else { return nil }
+        let pct = min(max(window.usedPercent, 0), 100) / 100
+        let size = height // square, same 18pt row height as the bars/dots
+        let cx = size / 2
+        let cy = size / 2
+        let radius = size / 2 - 2.25
+        let strokeWidth: CGFloat = 2.5
+        let hex = colorHex(forPercent: window.usedPercent)
+
+        let circumference = 2 * Double.pi * Double(radius)
+        let dashOffset = circumference * (1 - pct)
+
+        var svg = """
+        <svg xmlns="http://www.w3.org/2000/svg" width="\(Int(size))" height="\(Int(size))">
+          <circle cx="\(svgNumber(cx))" cy="\(svgNumber(cy))" r="\(svgNumber(radius))" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="\(svgNumber(strokeWidth))"/>
+          <circle cx="\(svgNumber(cx))" cy="\(svgNumber(cy))" r="\(svgNumber(radius))" fill="none" stroke="#\(hex)" stroke-width="\(svgNumber(strokeWidth))" stroke-linecap="round" stroke-dasharray="\(String(format: "%.2f", circumference))" stroke-dashoffset="\(String(format: "%.2f", dashOffset))" transform="rotate(-90 \(svgNumber(cx)) \(svgNumber(cy)))"/>
+        """
+        if let pace = pacePercent(for: window) {
+            // Same origin as the fill arc (rotate(-90) = 12 o'clock at
+            // pace 0) so a full lap back to the top means the window's
+            // wall-clock time is up, independent of how much quota is
+            // actually used.
+            let angle = (-90.0 + 360.0 * (pace / 100.0)) * .pi / 180
+            let innerR = radius - strokeWidth / 2 - 0.75
+            let outerR = radius + strokeWidth / 2 + 0.75
+            let x1 = cx + innerR * CGFloat(cos(angle))
+            let y1 = cy + innerR * CGFloat(sin(angle))
+            let x2 = cx + outerR * CGFloat(cos(angle))
+            let y2 = cy + outerR * CGFloat(sin(angle))
+            svg += """
+            <line x1="\(svgNumber(x1))" y1="\(svgNumber(y1))" x2="\(svgNumber(x2))" y2="\(svgNumber(y2))" stroke="red" stroke-width="1"/>
+            """
+        }
+        svg += "</svg>"
+        return (svg, size)
+    }
+
+    private static func rowSVG(label: String, window: RateLimitWindowInfo, rowY: CGFloat) -> String {
+        let pct = min(max(window.usedPercent, 0), 100) / 100
+        let filledWidth = barWidth * pct
+        let barX = labelWidth + gap
+        let barY = rowY + (rowHeight - barHeight) / 2
+        let textY = rowY + rowHeight * 0.78
+        let hex = colorHex(forPercent: window.usedPercent)
+
+        var svg = """
+        <text x="0" y="\(svgNumber(textY))" font-family="Menlo,monospace" font-size="\(Int(fontSize))" fill="#9CA3AF">\(label)</text>
+        <rect x="\(svgNumber(barX))" y="\(svgNumber(barY))" width="\(svgNumber(barWidth))" height="\(svgNumber(barHeight))" rx="1.5" fill="rgba(255,255,255,0.18)"/>
+        <rect x="\(svgNumber(barX))" y="\(svgNumber(barY))" width="\(svgNumber(filledWidth))" height="\(svgNumber(barHeight))" rx="1.5" fill="#\(hex)"/>
+        """
+        // Pace marker (mirrors SessionListView.quotaPacePercent): reaching
+        // the bar's right edge means the window's wall-clock time is up,
+        // independent of the fill's used% value.
+        if let pace = pacePercent(for: window) {
+            let paceX = barX + barWidth * pace / 100
+            svg += """
+            <rect x="\(svgNumber(paceX - 0.5))" y="\(svgNumber(barY - 0.75))" width="1" height="\(svgNumber(barHeight + 1.5))" fill="red"/>
+            """
+        }
+        return svg
+    }
+
+    /// Mirrors SessionListView's quotaPacePercent exactly: "where you'd be
+    /// if usage had grown linearly since the window opened," expressed as
+    /// 0–100. A `resetsAt` already in the past clamps to 100 (marker pinned
+    /// at the far end) rather than throwing the snapshot away — same choice
+    /// the popover chip makes for a stale snapshot.
+    private static func pacePercent(for window: RateLimitWindowInfo) -> Double? {
+        guard window.windowMinutes > 0, window.resetsAt.timeIntervalSince1970 > 0 else { return nil }
+        let windowSeconds = Double(window.windowMinutes) * 60
+        let windowStart = window.resetsAt.addingTimeInterval(-windowSeconds)
+        let elapsed = Date().timeIntervalSince(windowStart)
+        return min(100, max(0, (elapsed / windowSeconds) * 100.0))
+    }
+
+    /// Reuses the pressure-level color ramp already established for
+    /// context-window pressure (Theme/Tokens.swift's IrrHex.pressure*)
+    /// instead of inventing new thresholds for quota.
+    private static func colorHex(forPercent percent: Double) -> String {
+        let hex: String
+        switch percent {
+        case ..<50: hex = IrrHex.pressureLow
+        case ..<80: hex = IrrHex.pressureMedium
+        case ..<95: hex = IrrHex.pressureHigh
+        default: hex = IrrHex.pressureCritical
+        }
+        return hex.replacingOccurrences(of: "#", with: "")
+    }
+
+    private static func svgNumber(_ value: CGFloat) -> String {
+        String(format: "%.2f", value)
+    }
+}

--- a/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
@@ -5,6 +5,7 @@ import Foundation
 /// status item — the Usage/Combined styles from issue #909. Shares
 /// MenuBarStatusRenderer's 18pt-tall coordinate system so the two pieces
 /// can sit side by side in MenuBarImageBuilder's composition.
+@MainActor
 enum QuotaMenuBarRenderer {
     private static let height: CGFloat = 18
     private static let rowHeight: CGFloat = height / 2
@@ -14,7 +15,7 @@ enum QuotaMenuBarRenderer {
     private static let fontSize: CGFloat = 8
     private static let gap: CGFloat = 3
 
-    /// Picks the freshest non-stale rate-limit snapshot for `providerKey`
+    /// Picks the freshest renderable rate-limit snapshot for `providerKey`
     /// across `sessions` and renders it. `providerKey` nil means "whatever
     /// provider is freshest" — used until the user picks one in Settings.
     static func imageForSelectedProvider(
@@ -27,19 +28,24 @@ enum QuotaMenuBarRenderer {
         return buildImage(for: info)
     }
 
-    /// Same freshest-wins / skip-stale rule SessionListView's quota-chip
-    /// bucketing uses (mergeIntoBuckets), simplified to a single provider
-    /// instead of one bucket per provider — the menu bar icon only ever
-    /// shows one subscription's numbers.
+    /// Freshest-`sampledAt`-wins across `sessions`, matching
+    /// SessionListView.mergeIntoBuckets' choice of representative snapshot
+    /// per provider. Unlike that bucketing, this does **not** drop stale
+    /// snapshots (any window past `resetsAt`): the popover keeps a stale
+    /// snapshot and dims the chip rather than blanking it, and the compact
+    /// icon has no room to dim — so it keeps showing the last-known reading
+    /// until the next statusline tick refreshes it, instead of disappearing
+    /// (which would otherwise make an active `.usage`-style icon look idle;
+    /// see MenuBarImageBuilder's fallback for the session-count side of that
+    /// same problem). What *is* filtered out is a snapshot with no windows
+    /// at all (the credits/usage-only path) — that can never render, so it
+    /// must not win over an older snapshot that actually has data.
     static func selectedSnapshot(
         sessions: [SessionState],
         providerKey: String?
     ) -> RateLimitInfo? {
-        let now = Date()
         let candidates: [(key: String, info: RateLimitInfo)] = sessions.compactMap { session in
-            guard let snap = session.metrics?.rateLimit else { return nil }
-            let isStale = snap.windows.contains { $0.resetsAt <= now }
-            guard !isStale else { return nil }
+            guard let snap = session.metrics?.rateLimit, !snap.windows.isEmpty else { return nil }
             let key = snap.providerKey(adapter: session.adapter) ?? "unknown:\(session.adapter ?? "")"
             return (key, snap)
         }
@@ -95,17 +101,18 @@ enum QuotaMenuBarRenderer {
         let cy = size / 2
         let radius = size / 2 - 2.25
         let strokeWidth: CGFloat = 2.5
-        let hex = colorHex(forPercent: window.usedPercent)
+        let pace = pacePercent(for: window)
+        let hex = colorHex(usedPercent: window.usedPercent, pacePercent: pace)
 
         let circumference = 2 * Double.pi * Double(radius)
         let dashOffset = circumference * (1 - pct)
 
         var svg = """
         <svg xmlns="http://www.w3.org/2000/svg" width="\(Int(size))" height="\(Int(size))">
-          <circle cx="\(svgNumber(cx))" cy="\(svgNumber(cy))" r="\(svgNumber(radius))" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="\(svgNumber(strokeWidth))"/>
+          <circle cx="\(svgNumber(cx))" cy="\(svgNumber(cy))" r="\(svgNumber(radius))" fill="none" stroke="\(trackColor)" stroke-width="\(svgNumber(strokeWidth))"/>
           <circle cx="\(svgNumber(cx))" cy="\(svgNumber(cy))" r="\(svgNumber(radius))" fill="none" stroke="#\(hex)" stroke-width="\(svgNumber(strokeWidth))" stroke-linecap="round" stroke-dasharray="\(String(format: "%.2f", circumference))" stroke-dashoffset="\(String(format: "%.2f", dashOffset))" transform="rotate(-90 \(svgNumber(cx)) \(svgNumber(cy)))"/>
         """
-        if let pace = pacePercent(for: window) {
+        if let pace {
             // Same origin as the fill arc (rotate(-90) = 12 o'clock at
             // pace 0) so a full lap back to the top means the window's
             // wall-clock time is up, independent of how much quota is
@@ -131,17 +138,18 @@ enum QuotaMenuBarRenderer {
         let barX = labelWidth + gap
         let barY = rowY + (rowHeight - barHeight) / 2
         let textY = rowY + rowHeight * 0.78
-        let hex = colorHex(forPercent: window.usedPercent)
+        let pace = pacePercent(for: window)
+        let hex = colorHex(usedPercent: window.usedPercent, pacePercent: pace)
 
         var svg = """
-        <text x="0" y="\(svgNumber(textY))" font-family="Menlo,monospace" font-size="\(Int(fontSize))" fill="#9CA3AF">\(label)</text>
-        <rect x="\(svgNumber(barX))" y="\(svgNumber(barY))" width="\(svgNumber(barWidth))" height="\(svgNumber(barHeight))" rx="1.5" fill="rgba(255,255,255,0.18)"/>
+        <text x="0" y="\(svgNumber(textY))" font-family="Menlo,monospace" font-size="\(Int(fontSize))" fill="\(labelColor)">\(label)</text>
+        <rect x="\(svgNumber(barX))" y="\(svgNumber(barY))" width="\(svgNumber(barWidth))" height="\(svgNumber(barHeight))" rx="1.5" fill="\(trackColor)"/>
         <rect x="\(svgNumber(barX))" y="\(svgNumber(barY))" width="\(svgNumber(filledWidth))" height="\(svgNumber(barHeight))" rx="1.5" fill="#\(hex)"/>
         """
         // Pace marker (mirrors SessionListView.quotaPacePercent): reaching
         // the bar's right edge means the window's wall-clock time is up,
         // independent of the fill's used% value.
-        if let pace = pacePercent(for: window) {
+        if let pace {
             let paceX = barX + barWidth * pace / 100
             svg += """
             <rect x="\(svgNumber(paceX - 0.5))" y="\(svgNumber(barY - 0.75))" width="1" height="\(svgNumber(barHeight + 1.5))" fill="red"/>
@@ -153,8 +161,9 @@ enum QuotaMenuBarRenderer {
     /// Mirrors SessionListView's quotaPacePercent exactly: "where you'd be
     /// if usage had grown linearly since the window opened," expressed as
     /// 0–100. A `resetsAt` already in the past clamps to 100 (marker pinned
-    /// at the far end) rather than throwing the snapshot away — same choice
-    /// the popover chip makes for a stale snapshot.
+    /// at the far end) rather than being treated as unpaceable — same
+    /// choice the popover chip makes for a stale snapshot, and reachable
+    /// here because `selectedSnapshot` no longer drops stale snapshots.
     private static func pacePercent(for window: RateLimitWindowInfo) -> Double? {
         guard window.windowMinutes > 0, window.resetsAt.timeIntervalSince1970 > 0 else { return nil }
         let windowSeconds = Double(window.windowMinutes) * 60
@@ -163,18 +172,57 @@ enum QuotaMenuBarRenderer {
         return min(100, max(0, (elapsed / windowSeconds) * 100.0))
     }
 
-    /// Reuses the pressure-level color ramp already established for
-    /// context-window pressure (Theme/Tokens.swift's IrrHex.pressure*)
-    /// instead of inventing new thresholds for quota.
-    private static func colorHex(forPercent percent: Double) -> String {
-        let hex: String
-        switch percent {
-        case ..<50: hex = IrrHex.pressureLow
-        case ..<80: hex = IrrHex.pressureMedium
-        case ..<95: hex = IrrHex.pressureHigh
-        default: hex = IrrHex.pressureCritical
+    /// Mirrors SessionListView.barColor's pace-aware ramp exactly (same
+    /// SessionListView.QuotaBarThreshold constants) rather than an
+    /// absolute-only ramp — otherwise the same window could read green in
+    /// the icon while the popover shows it orange for being ahead of pace,
+    /// which fails the "honest signals" bar. Returns a bare hex (no '#')
+    /// since callers splice it into SVG fill attributes; SessionListView's
+    /// version returns a SwiftUI Color instead, since it's used in a View.
+    private static func colorHex(usedPercent: Double, pacePercent: Double?) -> String {
+        if usedPercent >= SessionListView.QuotaBarThreshold.absoluteOrange { return systemOrangeHex }
+        guard let pace = pacePercent else {
+            switch usedPercent {
+            case SessionListView.QuotaBarThreshold.fallbackOrange...: return systemOrangeHex
+            case SessionListView.QuotaBarThreshold.fallbackYellow...: return systemYellowHex
+            default: return IrrSVG.ready
+            }
         }
-        return hex.replacingOccurrences(of: "#", with: "")
+        let delta = usedPercent - pace
+        if delta >= SessionListView.QuotaBarThreshold.paceDeltaOrange { return systemOrangeHex }
+        if delta >= SessionListView.QuotaBarThreshold.paceDeltaYellow { return systemYellowHex }
+        return IrrSVG.ready
+    }
+
+    // Bare hex for the two ramp colors SessionListView expresses as SwiftUI
+    // .orange / .yellow (system colors, not in IrrHex/IrrSVG). .orange
+    // already matches IrrHex.pressureMedium's value; kept as an explicit
+    // literal here since the naming ("pressureMedium") doesn't fit the
+    // pace-ramp vocabulary.
+    private static let systemOrangeHex = "FF9500"
+    private static let systemYellowHex = "FFCC00"
+
+    /// True when the app's effective appearance is dark — same signal
+    /// SessionState.adapterIcon already uses to pick a light/dark SVG
+    /// variant, kept consistent here rather than introducing a second way
+    /// to ask the same question. NSApp is nil in unit tests; default to
+    /// dark (today's only supported look before this fix) so tests don't
+    /// need an NSApplication instance.
+    private static var isDarkAppearance: Bool {
+        guard let app = NSApp else { return true }
+        return app.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+    }
+
+    /// Track (unfilled bar / ring) and label colors, appearance-aware: the
+    /// original translucent-white track and light-gray label were invisible
+    /// against a light menu bar (issue found in review — the dots renderer
+    /// avoids this by using only saturated fills, which this renderer can't
+    /// since the track must read as "empty" against the fill color).
+    private static var trackColor: String {
+        isDarkAppearance ? "rgba(255,255,255,0.18)" : "rgba(0,0,0,0.14)"
+    }
+    private static var labelColor: String {
+        isDarkAppearance ? "#9CA3AF" : "#6B7280"
     }
 
     private static func svgNumber(_ value: CGFloat) -> String {

--- a/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
@@ -158,40 +158,28 @@ enum QuotaMenuBarRenderer {
         return svg
     }
 
-    /// Mirrors SessionListView's quotaPacePercent exactly: "where you'd be
-    /// if usage had grown linearly since the window opened," expressed as
-    /// 0–100. A `resetsAt` already in the past clamps to 100 (marker pinned
-    /// at the far end) rather than being treated as unpaceable — same
-    /// choice the popover chip makes for a stale snapshot, and reachable
-    /// here because `selectedSnapshot` no longer drops stale snapshots.
+    /// Delegates to SessionListView.quotaPacePercent — same implementation
+    /// the popover chip uses, not a second copy — so "where you'd be if
+    /// usage had grown linearly since the window opened" can't drift between
+    /// the two. Reachable here because `selectedSnapshot` no longer drops
+    /// stale snapshots.
     private static func pacePercent(for window: RateLimitWindowInfo) -> Double? {
-        guard window.windowMinutes > 0, window.resetsAt.timeIntervalSince1970 > 0 else { return nil }
-        let windowSeconds = Double(window.windowMinutes) * 60
-        let windowStart = window.resetsAt.addingTimeInterval(-windowSeconds)
-        let elapsed = Date().timeIntervalSince(windowStart)
-        return min(100, max(0, (elapsed / windowSeconds) * 100.0))
+        SessionListView.quotaPacePercent(window)
     }
 
-    /// Mirrors SessionListView.barColor's pace-aware ramp exactly (same
-    /// SessionListView.QuotaBarThreshold constants) rather than an
-    /// absolute-only ramp — otherwise the same window could read green in
-    /// the icon while the popover shows it orange for being ahead of pace,
-    /// which fails the "honest signals" bar. Returns a bare hex (no '#')
-    /// since callers splice it into SVG fill attributes; SessionListView's
-    /// version returns a SwiftUI Color instead, since it's used in a View.
+    /// Delegates to SessionListView.quotaColorTier — the same pace-aware
+    /// ramp decision the popover chip's `barColor` uses, not a second
+    /// hand-synced copy — so the same window can't read green in the icon
+    /// while the popover shows it orange. Returns a bare hex (no '#') since
+    /// callers splice it into SVG fill attributes; SessionListView's
+    /// `barColor` maps the same tier to a SwiftUI `Color` instead, since
+    /// it's used in a View.
     private static func colorHex(usedPercent: Double, pacePercent: Double?) -> String {
-        if usedPercent >= SessionListView.QuotaBarThreshold.absoluteOrange { return systemOrangeHex }
-        guard let pace = pacePercent else {
-            switch usedPercent {
-            case SessionListView.QuotaBarThreshold.fallbackOrange...: return systemOrangeHex
-            case SessionListView.QuotaBarThreshold.fallbackYellow...: return systemYellowHex
-            default: return IrrSVG.ready
-            }
+        switch SessionListView.quotaColorTier(used: usedPercent, pace: pacePercent) {
+        case .green: return IrrSVG.ready
+        case .yellow: return systemYellowHex
+        case .orange: return systemOrangeHex
         }
-        let delta = usedPercent - pace
-        if delta >= SessionListView.QuotaBarThreshold.paceDeltaOrange { return systemOrangeHex }
-        if delta >= SessionListView.QuotaBarThreshold.paceDeltaYellow { return systemYellowHex }
-        return IrrSVG.ready
     }
 
     // Bare hex for the two ramp colors SessionListView expresses as SwiftUI
@@ -205,11 +193,12 @@ enum QuotaMenuBarRenderer {
     /// True when the app's effective appearance is dark — same signal
     /// SessionState.adapterIcon already uses to pick a light/dark SVG
     /// variant, kept consistent here rather than introducing a second way
-    /// to ask the same question. NSApp is nil in unit tests; default to
-    /// dark (today's only supported look before this fix) so tests don't
-    /// need an NSApplication instance.
+    /// to ask the same question — including its nil-fallback: NSApp is nil
+    /// in unit tests, and adapterIcon defaults to the light variant there
+    /// (the more common ambient appearance), so this matches rather than
+    /// disagreeing with it.
     private static var isDarkAppearance: Bool {
-        guard let app = NSApp else { return true }
+        guard let app = NSApp else { return false }
         return app.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
     }
 

--- a/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
@@ -14,18 +14,26 @@ enum QuotaMenuBarRenderer {
     private static let barHeight: CGFloat = 5
     private static let fontSize: CGFloat = 8
     private static let gap: CGFloat = 3
+    /// Bars style is narrowed by this factor (35% narrower) in Combined
+    /// style specifically, where the icon's width budget is shared with the
+    /// dots — see `rowSVG`'s `compact` handling.
+    private static let compactBarWidthFactor: CGFloat = 0.65
 
     /// Picks the freshest renderable rate-limit snapshot for `providerKey`
     /// across `sessions` and renders it. `providerKey` nil means "whatever
     /// provider is freshest" — used until the user picks one in Settings.
+    /// `compact` requests the narrower, label-less bars layout used in
+    /// Combined style (ignored by the Circle visual style, which has no
+    /// label to drop and is already compact).
     static func imageForSelectedProvider(
         sessions: [SessionState],
-        providerKey: String?
+        providerKey: String?,
+        compact: Bool = false
     ) -> NSImage? {
         guard let info = selectedSnapshot(sessions: sessions, providerKey: providerKey) else {
             return nil
         }
-        return buildImage(for: info)
+        return buildImage(for: info, compact: compact)
     }
 
     /// Freshest-`sampledAt`-wins across `sessions`, matching
@@ -53,10 +61,10 @@ enum QuotaMenuBarRenderer {
         return filtered.max { $0.info.sampledAt < $1.info.sampledAt }?.info
     }
 
-    static func buildImage(for info: RateLimitInfo) -> NSImage? {
+    static func buildImage(for info: RateLimitInfo, compact: Bool = false) -> NSImage? {
         let built: (svg: String, width: CGFloat)?
         switch QuotaVisualStyle.current {
-        case .bars: built = buildSVG(for: info)
+        case .bars: built = buildSVG(for: info, compact: compact)
         case .circle: built = buildCircleSVG(for: info)
         }
         guard let (svg, width) = built else { return nil }
@@ -66,20 +74,24 @@ enum QuotaMenuBarRenderer {
         return image
     }
 
-    static func buildSVG(for info: RateLimitInfo) -> (svg: String, width: CGFloat)? {
+    /// `compact` drops the "5h"/"7d" text label and narrows the bars —
+    /// used in Combined style, where the icon's width is shared with the
+    /// session-state dots. Defaults to `false` (today's Usage-style layout).
+    static func buildSVG(for info: RateLimitInfo, compact: Bool = false) -> (svg: String, width: CGFloat)? {
         let fiveHour = info.windows.first { $0.canonicalWindowMinutes == 300 }
         let sevenDay = info.windows.first { $0.canonicalWindowMinutes == 10080 }
         guard fiveHour != nil || sevenDay != nil else { return nil }
 
-        let width = labelWidth + gap + barWidth
+        let effectiveBarWidth = compact ? barWidth * compactBarWidthFactor : barWidth
+        let width = compact ? effectiveBarWidth : labelWidth + gap + barWidth
         var svg = """
         <svg xmlns="http://www.w3.org/2000/svg" width="\(Int(width))" height="\(Int(height))">
         """
         if let fiveHour {
-            svg += rowSVG(label: "5h", window: fiveHour, rowY: 0)
+            svg += rowSVG(label: "5h", window: fiveHour, rowY: 0, compact: compact)
         }
         if let sevenDay {
-            svg += rowSVG(label: "7d", window: sevenDay, rowY: rowHeight)
+            svg += rowSVG(label: "7d", window: sevenDay, rowY: rowHeight, compact: compact)
         }
         svg += "</svg>"
         return (svg, width)
@@ -132,25 +144,33 @@ enum QuotaMenuBarRenderer {
         return (svg, size)
     }
 
-    private static func rowSVG(label: String, window: RateLimitWindowInfo, rowY: CGFloat) -> String {
+    /// `compact` omits the leading "5h"/"7d" label and narrows the bar by
+    /// `compactBarWidthFactor` — see `buildSVG`'s doc.
+    private static func rowSVG(label: String, window: RateLimitWindowInfo, rowY: CGFloat, compact: Bool = false) -> String {
+        let effectiveBarWidth = compact ? barWidth * compactBarWidthFactor : barWidth
         let pct = min(max(window.usedPercent, 0), 100) / 100
-        let filledWidth = barWidth * pct
-        let barX = labelWidth + gap
+        let filledWidth = effectiveBarWidth * pct
+        let barX: CGFloat = compact ? 0 : labelWidth + gap
         let barY = rowY + (rowHeight - barHeight) / 2
         let textY = rowY + rowHeight * 0.78
         let pace = pacePercent(for: window)
         let hex = colorHex(usedPercent: window.usedPercent, pacePercent: pace)
 
-        var svg = """
-        <text x="0" y="\(svgNumber(textY))" font-family="Menlo,monospace" font-size="\(Int(fontSize))" fill="\(labelColor)">\(label)</text>
-        <rect x="\(svgNumber(barX))" y="\(svgNumber(barY))" width="\(svgNumber(barWidth))" height="\(svgNumber(barHeight))" rx="1.5" fill="\(trackColor)"/>
+        var svg = ""
+        if !compact {
+            svg += """
+            <text x="0" y="\(svgNumber(textY))" font-family="Menlo,monospace" font-size="\(Int(fontSize))" fill="\(labelColor)">\(label)</text>
+            """
+        }
+        svg += """
+        <rect x="\(svgNumber(barX))" y="\(svgNumber(barY))" width="\(svgNumber(effectiveBarWidth))" height="\(svgNumber(barHeight))" rx="1.5" fill="\(trackColor)"/>
         <rect x="\(svgNumber(barX))" y="\(svgNumber(barY))" width="\(svgNumber(filledWidth))" height="\(svgNumber(barHeight))" rx="1.5" fill="#\(hex)"/>
         """
         // Pace marker (mirrors SessionListView.quotaPacePercent): reaching
         // the bar's right edge means the window's wall-clock time is up,
         // independent of the fill's used% value.
         if let pace {
-            let paceX = barX + barWidth * pace / 100
+            let paceX = barX + effectiveBarWidth * pace / 100
             svg += """
             <rect x="\(svgNumber(paceX - 0.5))" y="\(svgNumber(barY - 0.75))" width="1" height="\(svgNumber(barHeight + 1.5))" fill="red"/>
             """

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -840,7 +840,7 @@ struct SessionListView: View {
         // Compute once per row — SwiftUI re-invokes view bodies on every
         // SessionManager publish, and calling quotaPacePercent twice
         // would also let two Date() captures disagree by microseconds.
-        let pace = quotaPacePercent(w)
+        let pace = Self.quotaPacePercent(w)
         HStack(spacing: 6) {
             Text(quotaWindowLabel(w.windowMinutes))
                 .font(.system(size: 9, weight: .medium, design: .monospaced))
@@ -883,7 +883,10 @@ struct SessionListView: View {
     /// `10079` instead of `10080`) is left as-is here — the
     /// ≤60-second drift in the implied window-start time is well
     /// below the resolution the marker conveys visually.
-    private func quotaPacePercent(_ w: RateLimitWindowInfo) -> Double? {
+    /// `static` + non-private (like `barColor`) so `QuotaMenuBarRenderer`'s
+    /// menu-bar icon can share this exact implementation instead of
+    /// re-deriving the same math in a second place.
+    static func quotaPacePercent(_ w: RateLimitWindowInfo) -> Double? {
         guard w.windowMinutes > 0 else { return nil }
         guard w.resetsAt.timeIntervalSince1970 > 0 else { return nil }
         let windowSeconds = Double(w.windowMinutes) * 60
@@ -949,7 +952,7 @@ struct SessionListView: View {
                 let label = quotaWindowLabel(w.windowMinutes)
                 let resets = formatTimeUntil(w.resetsAt)
                 var line = "\(label): \(used)% used · resets in \(resets)"
-                if let pace = quotaPacePercent(w) {
+                if let pace = Self.quotaPacePercent(w) {
                     let delta = used - Int(pace.rounded())
                     let verdict: String
                     if delta > 0 { verdict = "\(delta)pt over pace" }
@@ -1037,21 +1040,39 @@ struct SessionListView: View {
         static let fallbackYellow: Double = 50
     }
 
+    /// Three-way verdict the pace-aware ramp above resolves to, decoupled
+    /// from any particular color representation so both the SwiftUI chip
+    /// (`barColor`, a `Color`) and the menu-bar icon (`QuotaMenuBarRenderer`,
+    /// a bare hex string for SVG) can share the one branching implementation
+    /// instead of keeping two hand-synced copies of the same thresholds.
+    enum QuotaColorTier {
+        case green, yellow, orange
+    }
+
     /// `static` + non-private so XCTests can table-drive the threshold
-    /// boundaries without instantiating the view.
-    static func barColor(used: Double, pace: Double?) -> Color {
+    /// boundaries without instantiating the view, and so QuotaMenuBarRenderer
+    /// can call it directly.
+    static func quotaColorTier(used: Double, pace: Double?) -> QuotaColorTier {
         if used >= QuotaBarThreshold.absoluteOrange { return .orange }
         guard let pace = pace else {
             switch used {
             case QuotaBarThreshold.fallbackOrange...: return .orange
             case QuotaBarThreshold.fallbackYellow...: return .yellow
-            default: return IrrColors.pressureLow
+            default: return .green
             }
         }
         let delta = used - pace
         if delta >= QuotaBarThreshold.paceDeltaOrange { return .orange }
         if delta >= QuotaBarThreshold.paceDeltaYellow { return .yellow }
-        return IrrColors.pressureLow
+        return .green
+    }
+
+    static func barColor(used: Double, pace: Double?) -> Color {
+        switch quotaColorTier(used: used, pace: pace) {
+        case .green: return IrrColors.pressureLow
+        case .yellow: return .yellow
+        case .orange: return .orange
+        }
     }
 
     private func formatClockTime(_ date: Date) -> String {

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -612,14 +612,22 @@ struct SettingsView: View {
         }
     }
 
-    /// Provider keys with a live (non-stale) rate_limit snapshot right now,
-    /// for the Usage/Combined quota-provider picker. Not persisted anywhere
-    /// else — recomputed from whatever sessions happen to be visible when
-    /// Settings is open, same source SessionListView's quota chips read.
+    /// Provider keys with a rate_limit-carrying session right now, for the
+    /// Usage/Combined quota-provider picker. Not persisted anywhere else —
+    /// recomputed from whatever sessions happen to be visible when Settings
+    /// is open. Excludes Gas Town-owned sessions to match exactly what
+    /// MenuBarImageBuilder.combinedImage feeds into QuotaMenuBarRenderer —
+    /// offering a provider here that the icon can never actually render
+    /// (because its only carrying sessions are Gas Town's) would leave the
+    /// picker selection pointing at a permanently-empty quota display.
     private var knownQuotaProviderKeys: [String] {
+        let gasTownProvider = sessionManager.gasTownProvider
+        let eligibleSessions = gasTownProvider?.isDaemonRunning == true
+            ? sessionManager.sessions.filter { !(gasTownProvider?.ownsSession($0) ?? false) }
+            : sessionManager.sessions
         var keys = Set<String>()
-        for session in sessionManager.sessions {
-            guard let snap = session.metrics?.rateLimit else { continue }
+        for session in eligibleSessions {
+            guard let snap = session.metrics?.rateLimit, !snap.windows.isEmpty else { continue }
             keys.insert(snap.providerKey(adapter: session.adapter) ?? "unknown:\(session.adapter ?? "")")
         }
         return keys.sorted()

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -40,6 +40,11 @@ struct SettingsView: View {
     @AppStorage("advancedSettingsExpanded") private var advancedSettingsExpanded: Bool = false
     @AppStorage("providerMode_anthropic") private var providerModeAnthropic: String = ProviderModePreference.auto.rawValue
     @AppStorage("providerMode_openai") private var providerModeOpenAI: String = ProviderModePreference.auto.rawValue
+    // Menu bar icon content (issue #909): dots / quota bars / both. Default
+    // .lights keeps today's icon unchanged for existing users.
+    @AppStorage(MenuBarStyle.storageKey) private var menuBarStyle: String = MenuBarStyle.lights.rawValue
+    @AppStorage(MenuBarQuotaProvider.storageKey) private var menuBarQuotaProvider: String = ""
+    @AppStorage(QuotaVisualStyle.storageKey) private var menuBarQuotaVisual: String = QuotaVisualStyle.bars.rawValue
     @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = false
     @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = false
     @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = false
@@ -113,6 +118,55 @@ struct SettingsView: View {
                             }
                             providerModeRow(label: "Anthropic", selection: $providerModeAnthropic)
                             providerModeRow(label: "OpenAI", selection: $providerModeOpenAI)
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 6) {
+                            Text("Menu Bar Icon")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                                .foregroundColor(.secondary)
+                            InfoIcon(text: "Lights shows session-state dots (today's default). Usage replaces them with 5h/7d subscription quota bars. Combined shows both side by side.")
+                            Spacer()
+                        }
+                        Picker("", selection: $menuBarStyle) {
+                            ForEach(MenuBarStyle.allCases) { style in
+                                Text(style.label).tag(style.rawValue)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+
+                        if menuBarStyle != MenuBarStyle.lights.rawValue {
+                            HStack(spacing: 6) {
+                                Text("Quota provider")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                Spacer()
+                                Picker("", selection: $menuBarQuotaProvider) {
+                                    Text("Auto").tag("")
+                                    ForEach(knownQuotaProviderKeys, id: \.self) { key in
+                                        Text(quotaProviderLabel(key)).tag(key)
+                                    }
+                                }
+                                .labelsHidden()
+                                .frame(maxWidth: 140)
+                            }
+                            HStack(spacing: 6) {
+                                Text("Quota shape")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                Spacer()
+                                Picker("", selection: $menuBarQuotaVisual) {
+                                    ForEach(QuotaVisualStyle.allCases) { visual in
+                                        Text(visual.label).tag(visual.rawValue)
+                                    }
+                                }
+                                .pickerStyle(.segmented)
+                                .labelsHidden()
+                                .frame(maxWidth: 140)
+                            }
                         }
                     }
 
@@ -555,6 +609,27 @@ struct SettingsView: View {
             .labelsHidden()
             .fixedSize()
             Spacer()
+        }
+    }
+
+    /// Provider keys with a live (non-stale) rate_limit snapshot right now,
+    /// for the Usage/Combined quota-provider picker. Not persisted anywhere
+    /// else — recomputed from whatever sessions happen to be visible when
+    /// Settings is open, same source SessionListView's quota chips read.
+    private var knownQuotaProviderKeys: [String] {
+        var keys = Set<String>()
+        for session in sessionManager.sessions {
+            guard let snap = session.metrics?.rateLimit else { continue }
+            keys.insert(snap.providerKey(adapter: session.adapter) ?? "unknown:\(session.adapter ?? "")")
+        }
+        return keys.sorted()
+    }
+
+    private func quotaProviderLabel(_ key: String) -> String {
+        switch key {
+        case "anthropic": return "Claude"
+        case "openai": return "Codex"
+        default: return key
         }
     }
 

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -633,11 +633,21 @@ struct SettingsView: View {
         return keys.sorted()
     }
 
+    /// `providerKey(adapter:)` returns nil for plan types/adapters it
+    /// doesn't recognize (e.g. Team/Enterprise plans, or a wrapper adapter
+    /// like Pi/OpenCode whose inherited snapshot carries no plan type) —
+    /// `knownQuotaProviderKeys` then falls back to a raw `"unknown:<adapter>"`
+    /// bucket key. Surface the adapter name instead of that internal-looking
+    /// string so the picker still reads as a plausible option rather than
+    /// leaking implementation detail.
     private func quotaProviderLabel(_ key: String) -> String {
         switch key {
         case "anthropic": return "Claude"
         case "openai": return "Codex"
-        default: return key
+        default:
+            guard key.hasPrefix("unknown:") else { return key }
+            let adapter = key.dropFirst("unknown:".count)
+            return adapter.isEmpty ? "Other" : adapter.capitalized
         }
     }
 

--- a/platforms/macos/Tests/MenuBarImageBuilderTests.swift
+++ b/platforms/macos/Tests/MenuBarImageBuilderTests.swift
@@ -74,34 +74,41 @@ final class MenuBarImageBuilderTests: XCTestCase {
 
     // MARK: - shouldFallBackToDotsForUsageStyle (issue #909 review fix)
 
-    /// `.usage` style with active sessions but no renderable quota yet must
+    /// `.usage` style with a renderable dots image but no quota yet must
     /// not collapse to the "no sessions" icon — see the fallback comment in
     /// `combinedImage`.
-    func testFallsBackToDotsWhenUsageStyleHasNoQuotaButHasSessions() {
+    func testFallsBackToDotsWhenUsageStyleHasNoQuotaButDotsRendered() {
+        let dots = NSImage(size: NSSize(width: 10, height: 18))
         XCTAssertTrue(MenuBarImageBuilder.shouldFallBackToDotsForUsageStyle(
-            style: .usage, quotaImage: nil, sessionCount: 3
+            style: .usage, quotaImage: nil, dotsImage: dots
         ))
     }
 
     func testDoesNotFallBackWhenUsageStyleHasQuotaImage() {
         let quota = NSImage(size: NSSize(width: 10, height: 18))
+        let dots = NSImage(size: NSSize(width: 10, height: 18))
         XCTAssertFalse(MenuBarImageBuilder.shouldFallBackToDotsForUsageStyle(
-            style: .usage, quotaImage: quota, sessionCount: 3
+            style: .usage, quotaImage: quota, dotsImage: dots
         ))
     }
 
-    func testDoesNotFallBackWhenUsageStyleHasNoSessionsEither() {
+    /// Sessions can be active (non-zero count) while `buildStatusImage` still
+    /// returns nil (e.g. every session is a subagent whose parent was pruned
+    /// out from under it) — the fallback must key off the actual dots image,
+    /// not a raw session count that doesn't guarantee dots render.
+    func testDoesNotFallBackWhenUsageStyleHasNoRenderableDotsEither() {
         XCTAssertFalse(MenuBarImageBuilder.shouldFallBackToDotsForUsageStyle(
-            style: .usage, quotaImage: nil, sessionCount: 0
+            style: .usage, quotaImage: nil, dotsImage: nil
         ))
     }
 
     func testDoesNotFallBackForLightsOrCombinedStyles() {
+        let dots = NSImage(size: NSSize(width: 10, height: 18))
         XCTAssertFalse(MenuBarImageBuilder.shouldFallBackToDotsForUsageStyle(
-            style: .lights, quotaImage: nil, sessionCount: 3
+            style: .lights, quotaImage: nil, dotsImage: dots
         ))
         XCTAssertFalse(MenuBarImageBuilder.shouldFallBackToDotsForUsageStyle(
-            style: .combined, quotaImage: nil, sessionCount: 3
+            style: .combined, quotaImage: nil, dotsImage: dots
         ))
     }
 }

--- a/platforms/macos/Tests/MenuBarImageBuilderTests.swift
+++ b/platforms/macos/Tests/MenuBarImageBuilderTests.swift
@@ -71,4 +71,37 @@ final class MenuBarImageBuilderTests: XCTestCase {
         XCTAssertEqual(result?.size.width, 34) // 10 + 4 + 20
         XCTAssertEqual(result?.size.height, 18) // max(18, 12)
     }
+
+    // MARK: - shouldFallBackToDotsForUsageStyle (issue #909 review fix)
+
+    /// `.usage` style with active sessions but no renderable quota yet must
+    /// not collapse to the "no sessions" icon — see the fallback comment in
+    /// `combinedImage`.
+    func testFallsBackToDotsWhenUsageStyleHasNoQuotaButHasSessions() {
+        XCTAssertTrue(MenuBarImageBuilder.shouldFallBackToDotsForUsageStyle(
+            style: .usage, quotaImage: nil, sessionCount: 3
+        ))
+    }
+
+    func testDoesNotFallBackWhenUsageStyleHasQuotaImage() {
+        let quota = NSImage(size: NSSize(width: 10, height: 18))
+        XCTAssertFalse(MenuBarImageBuilder.shouldFallBackToDotsForUsageStyle(
+            style: .usage, quotaImage: quota, sessionCount: 3
+        ))
+    }
+
+    func testDoesNotFallBackWhenUsageStyleHasNoSessionsEither() {
+        XCTAssertFalse(MenuBarImageBuilder.shouldFallBackToDotsForUsageStyle(
+            style: .usage, quotaImage: nil, sessionCount: 0
+        ))
+    }
+
+    func testDoesNotFallBackForLightsOrCombinedStyles() {
+        XCTAssertFalse(MenuBarImageBuilder.shouldFallBackToDotsForUsageStyle(
+            style: .lights, quotaImage: nil, sessionCount: 3
+        ))
+        XCTAssertFalse(MenuBarImageBuilder.shouldFallBackToDotsForUsageStyle(
+            style: .combined, quotaImage: nil, sessionCount: 3
+        ))
+    }
 }

--- a/platforms/macos/Tests/MenuBarImageBuilderTests.swift
+++ b/platforms/macos/Tests/MenuBarImageBuilderTests.swift
@@ -45,4 +45,30 @@ final class MenuBarImageBuilderTests: XCTestCase {
             "Irrlicht — action required: permission pending"
         )
     }
+
+    // MARK: - composeSideBySide (issue #909: dots + quota composition)
+
+    func testComposeSideBySideReturnsNilWhenBothNil() {
+        XCTAssertNil(MenuBarImageBuilder.composeSideBySide(nil, nil))
+    }
+
+    func testComposeSideBySideReturnsLeftUnchangedWhenRightNil() {
+        let left = NSImage(size: NSSize(width: 10, height: 18))
+        let result = MenuBarImageBuilder.composeSideBySide(left, nil)
+        XCTAssertEqual(result?.size, NSSize(width: 10, height: 18))
+    }
+
+    func testComposeSideBySideReturnsRightUnchangedWhenLeftNil() {
+        let right = NSImage(size: NSSize(width: 12, height: 18))
+        let result = MenuBarImageBuilder.composeSideBySide(nil, right)
+        XCTAssertEqual(result?.size, NSSize(width: 12, height: 18))
+    }
+
+    func testComposeSideBySideSumsWidthAndTakesTallerHeightWhenBothPresent() {
+        let left = NSImage(size: NSSize(width: 10, height: 18))
+        let right = NSImage(size: NSSize(width: 20, height: 12))
+        let result = MenuBarImageBuilder.composeSideBySide(left, right, gap: 4)
+        XCTAssertEqual(result?.size.width, 34) // 10 + 4 + 20
+        XCTAssertEqual(result?.size.height, 18) // max(18, 12)
+    }
 }

--- a/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
+++ b/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
@@ -178,7 +178,11 @@ final class QuotaMenuBarRendererTests: XCTestCase {
     /// matches the popover's intent: show the last-known reading until the
     /// next statusline tick refreshes it.
     func testSelectedSnapshotKeepsStaleSnapshotsRatherThanDroppingThem() {
-        let stale = makeSession(id: "1", adapter: "claude-code", usedPercent: 10, sampledSecondsAgo: 5, resetsInPast: true)
+        let staleRateLimit = RateLimitInfo(
+            windows: [RateLimitWindowInfo(usedPercent: 10, windowMinutes: 300, resetsAt: Date().addingTimeInterval(-3600))],
+            sampledAt: Date().addingTimeInterval(-5)
+        )
+        let stale = sessionState(id: "1", adapter: "claude-code", rateLimit: staleRateLimit)
         let got = QuotaMenuBarRenderer.selectedSnapshot(sessions: [stale], providerKey: nil)
         XCTAssertEqual(got?.windows.first?.usedPercent, 10)
     }
@@ -187,16 +191,9 @@ final class QuotaMenuBarRendererTests: XCTestCase {
     /// render — it must not win the freshest-wins race over an older
     /// snapshot that actually has data.
     func testSelectedSnapshotSkipsSnapshotWithEmptyWindows() {
-        let unrenderable = SessionState(
-            id: "sess_unrenderable", state: .working, model: "claude-sonnet", cwd: "/tmp",
-            firstSeen: Date(), updatedAt: Date(),
-            metrics: SessionMetrics(
-                elapsedSeconds: 0, totalTokens: 0, modelName: "claude-sonnet",
-                contextWindow: nil, contextUtilization: 0, pressureLevel: "safe",
-                contextWindowUnknown: nil, estimatedCostUSD: nil, lastAssistantText: nil, tasks: nil,
-                rateLimit: RateLimitInfo(windows: [], sampledAt: Date()) // freshest, but empty
-            ),
-            adapter: "claude-code"
+        let unrenderable = sessionState(
+            id: "unrenderable", adapter: "claude-code",
+            rateLimit: RateLimitInfo(windows: [], sampledAt: Date()) // freshest, but empty
         )
         let renderable = makeSession(id: "2", adapter: "claude-code", usedPercent: 42, sampledSecondsAgo: 120)
         let got = QuotaMenuBarRenderer.selectedSnapshot(sessions: [unrenderable, renderable], providerKey: nil)
@@ -234,18 +231,25 @@ final class QuotaMenuBarRendererTests: XCTestCase {
         return RateLimitWindowInfo(usedPercent: usedPercent, windowMinutes: windowMinutes, resetsAt: resetsAt)
     }
 
+    /// Common case: a session with a fresh (future-resetting) rate-limit
+    /// window. Tests that need an already-expired window build a
+    /// RateLimitInfo directly and go through `sessionState` instead, so
+    /// this stays at 4 arguments rather than growing a resetsInPast flag
+    /// nobody but one test needed (CodeScene: excess function arguments).
     private func makeSession(
         id: String,
         adapter: String,
         usedPercent: Double,
-        sampledSecondsAgo: TimeInterval,
-        resetsInPast: Bool = false
+        sampledSecondsAgo: TimeInterval
     ) -> SessionState {
-        let resetsAt = resetsInPast ? Date().addingTimeInterval(-3600) : Date().addingTimeInterval(3600)
         let rateLimit = RateLimitInfo(
-            windows: [RateLimitWindowInfo(usedPercent: usedPercent, windowMinutes: 300, resetsAt: resetsAt)],
+            windows: [RateLimitWindowInfo(usedPercent: usedPercent, windowMinutes: 300, resetsAt: Date().addingTimeInterval(3600))],
             sampledAt: Date().addingTimeInterval(-sampledSecondsAgo)
         )
+        return sessionState(id: id, adapter: adapter, rateLimit: rateLimit)
+    }
+
+    private func sessionState(id: String, adapter: String, rateLimit: RateLimitInfo) -> SessionState {
         let metrics = SessionMetrics(
             elapsedSeconds: 0,
             totalTokens: 0,

--- a/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
+++ b/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
@@ -2,8 +2,10 @@ import XCTest
 @testable import Irrlicht
 
 /// Coverage for the menu-bar quota icon (issue #909): the stacked 5h/7d
-/// bars, the single-window compact ring, the pace marker both share, and
-/// the freshest-non-stale snapshot selection across live sessions.
+/// bars, the single-window compact ring, the pace marker both share, the
+/// pace-aware color ramp (must mirror SessionListView.barColor exactly —
+/// see QuotaChipBarColorTests for the popover-side pin of the same table),
+/// and the freshest-renderable snapshot selection across live sessions.
 @MainActor
 final class QuotaMenuBarRendererTests: XCTestCase {
 
@@ -33,17 +35,51 @@ final class QuotaMenuBarRendererTests: XCTestCase {
         XCTAssertTrue(result!.svg.contains(">7d<"))
     }
 
-    func testBuildSVGColorThresholds() {
-        // Mirrors QuotaChipBarColorTests' boundary pinning, for the bare-hex
-        // (no '#') ramp this renderer's SVG fill attributes use.
-        let cases: [(name: String, used: Double, wantHex: String)] = [
-            ("low",      30, "34C759"),
-            ("medium",   60, "FF9500"),
-            ("high",     85, "FF3B30"),
-            ("critical", 97, "D70015"),
+    /// Same ramp QuotaChipBarColorTests pins for SessionListView.barColor
+    /// — this renderer must reach the identical verdict (as a bare hex
+    /// instead of a SwiftUI Color) so the same window can't read green in
+    /// the icon while the popover shows it orange. Cases stay off the exact
+    /// threshold boundary on purpose: `windowWithPace` derives `pace` from
+    /// `Date()` at construction time and `buildSVG` re-evaluates it a moment
+    /// later, so an exact-boundary delta (e.g. precisely 5 or 15) can tip
+    /// either way on sub-millisecond wall-clock drift. Exact-boundary
+    /// pinning already lives in QuotaChipBarColorTests, which calls
+    /// `barColor(used:pace:)` directly with fixed Doubles and has none of
+    /// that drift.
+    func testBuildSVGColorThresholdsMirrorPopoverPaceRamp() {
+        let cases: [(name: String, used: Double, pace: Double, wantHex: String)] = [
+            ("on pace",                30, 30, "34C759"),
+            ("clearly still green",    33, 30, "34C759"),
+            ("clearly yellow",         36, 30, "FFCC00"),
+            ("clearly orange",         46, 30, "FF9500"),
+            ("far ahead",              70, 30, "FF9500"),
+            ("behind pace",            20, 40, "34C759"),
+            ("at cap (85%) overrides pace", 85, 50, "FF9500"),
         ]
         for c in cases {
-            let info = makeInfo(fiveHour: c.used, sevenDay: nil)
+            let window = windowWithPace(usedPercent: c.used, pace: c.pace)
+            let info = RateLimitInfo(windows: [window], sampledAt: Date())
+            let result = QuotaMenuBarRenderer.buildSVG(for: info)
+            XCTAssertTrue(
+                result?.svg.contains("#\(c.wantHex)") ?? false,
+                "\(c.name): expected #\(c.wantHex) in \(result?.svg ?? "nil")"
+            )
+        }
+    }
+
+    /// pace nil (no resetsAt) falls back to the absolute-only ramp, same as
+    /// SessionListView.barColor's nil-pace branch.
+    func testBuildSVGColorThresholdsFallBackToAbsoluteRampWhenUnpaceable() {
+        let cases: [(name: String, used: Double, wantHex: String)] = [
+            ("nil pace, low usage",    30, "34C759"),
+            ("nil pace, 50% — yellow", 50, "FFCC00"),
+            ("nil pace, 70% — orange", 70, "FF9500"),
+        ]
+        for c in cases {
+            let info = RateLimitInfo(
+                windows: [RateLimitWindowInfo(usedPercent: c.used, windowMinutes: 300, resetsAt: Date(timeIntervalSince1970: 0))],
+                sampledAt: Date()
+            )
             let result = QuotaMenuBarRenderer.buildSVG(for: info)
             XCTAssertTrue(
                 result?.svg.contains("#\(c.wantHex)") ?? false,
@@ -63,20 +99,24 @@ final class QuotaMenuBarRendererTests: XCTestCase {
     /// when the 7d window is more depleted — RateLimitInfo.imminentWindow
     /// would pick 7d here (80 > 20), which is deliberately *not* what the
     /// circle shows. A glance-value shouldn't silently swap which window
-    /// it's reading.
+    /// it's reading. Colors chosen so a wrong-window regression is
+    /// unambiguous: the 5h reading (20% used, 80% pace — well behind pace)
+    /// is green, while the 7d reading (80% used, ~57% pace — ahead of pace)
+    /// would be orange.
     func testBuildCircleSVGPrefersFiveHourOverSevenDayEvenWhenLessDepleted() {
-        let info = makeInfo(fiveHour: 20, sevenDay: 80)
+        let info = makeInfo(fiveHour: 20, sevenDay: 80, fiveHourResetsIn: 3600)
         let result = QuotaMenuBarRenderer.buildCircleSVG(for: info)
         XCTAssertNotNil(result)
-        XCTAssertTrue(result!.svg.contains("#34C759"), "should use the 5h window's low-usage green")
-        XCTAssertFalse(result!.svg.contains("#FF3B30"), "must not leak the 7d window's high-usage color")
+        XCTAssertTrue(result!.svg.contains("#34C759"), "should use the 5h window's green (behind pace)")
+        XCTAssertFalse(result!.svg.contains("#FF9500"), "must not leak the 7d window's orange (ahead of pace)")
     }
 
     func testBuildCircleSVGFallsBackToSevenDayWhenFiveHourAbsent() {
-        let info = RateLimitInfo(
-            windows: [RateLimitWindowInfo(usedPercent: 60, windowMinutes: 10080, resetsAt: Date().addingTimeInterval(3600))],
-            sampledAt: Date()
-        )
+        // Fresh 7d window (pace ≈ 0) so 60% used is unambiguously ahead of
+        // pace → orange, isolating "did it use the 7d window at all" from
+        // the color-ramp tests above.
+        let window = windowWithPace(usedPercent: 60, pace: 0, windowMinutes: 10080)
+        let info = RateLimitInfo(windows: [window], sampledAt: Date())
         let result = QuotaMenuBarRenderer.buildCircleSVG(for: info)
         XCTAssertNotNil(result)
         XCTAssertTrue(result!.svg.contains("#FF9500"))
@@ -116,7 +156,7 @@ final class QuotaMenuBarRendererTests: XCTestCase {
 
     // MARK: - selectedSnapshot
 
-    func testSelectedSnapshotPicksFreshestNonStaleAcrossSessions() {
+    func testSelectedSnapshotPicksFreshestAcrossSessions() {
         let older = makeSession(id: "1", adapter: "claude-code", usedPercent: 10, sampledSecondsAgo: 120)
         let newer = makeSession(id: "2", adapter: "claude-code", usedPercent: 90, sampledSecondsAgo: 5)
         let got = QuotaMenuBarRenderer.selectedSnapshot(sessions: [older, newer], providerKey: nil)
@@ -130,10 +170,37 @@ final class QuotaMenuBarRendererTests: XCTestCase {
         XCTAssertEqual(got?.windows.first?.usedPercent, 10)
     }
 
-    func testSelectedSnapshotSkipsStaleSnapshots() {
+    /// The popover (SessionListView.mergeIntoBuckets) keeps a stale
+    /// snapshot and dims the chip rather than dropping it — the icon has
+    /// no room to dim, but dropping entirely made an active session look
+    /// idle (it collapsed the whole quota display, which for `.usage`
+    /// style meant falling back to the "no sessions" icon). Keeping it
+    /// matches the popover's intent: show the last-known reading until the
+    /// next statusline tick refreshes it.
+    func testSelectedSnapshotKeepsStaleSnapshotsRatherThanDroppingThem() {
         let stale = makeSession(id: "1", adapter: "claude-code", usedPercent: 10, sampledSecondsAgo: 5, resetsInPast: true)
         let got = QuotaMenuBarRenderer.selectedSnapshot(sessions: [stale], providerKey: nil)
-        XCTAssertNil(got)
+        XCTAssertEqual(got?.windows.first?.usedPercent, 10)
+    }
+
+    /// A snapshot with no windows (the credits/usage-only path) can never
+    /// render — it must not win the freshest-wins race over an older
+    /// snapshot that actually has data.
+    func testSelectedSnapshotSkipsSnapshotWithEmptyWindows() {
+        let unrenderable = SessionState(
+            id: "sess_unrenderable", state: .working, model: "claude-sonnet", cwd: "/tmp",
+            firstSeen: Date(), updatedAt: Date(),
+            metrics: SessionMetrics(
+                elapsedSeconds: 0, totalTokens: 0, modelName: "claude-sonnet",
+                contextWindow: nil, contextUtilization: 0, pressureLevel: "safe",
+                contextWindowUnknown: nil, estimatedCostUSD: nil, lastAssistantText: nil, tasks: nil,
+                rateLimit: RateLimitInfo(windows: [], sampledAt: Date()) // freshest, but empty
+            ),
+            adapter: "claude-code"
+        )
+        let renderable = makeSession(id: "2", adapter: "claude-code", usedPercent: 42, sampledSecondsAgo: 120)
+        let got = QuotaMenuBarRenderer.selectedSnapshot(sessions: [unrenderable, renderable], providerKey: nil)
+        XCTAssertEqual(got?.windows.first?.usedPercent, 42)
     }
 
     func testSelectedSnapshotReturnsNilWhenNoSessionCarriesRateLimit() {
@@ -155,6 +222,16 @@ final class QuotaMenuBarRendererTests: XCTestCase {
             windows.append(RateLimitWindowInfo(usedPercent: sevenDay, windowMinutes: 10080, resetsAt: Date().addingTimeInterval(3 * 86400)))
         }
         return RateLimitInfo(windows: windows, sampledAt: Date())
+    }
+
+    /// Builds a window whose `resetsAt` implies exactly `pace` percent
+    /// elapsed, so color-ramp tests can target specific (used, pace) pairs
+    /// instead of whatever a fixed resetsAt happens to imply.
+    private func windowWithPace(usedPercent: Double, pace: Double, windowMinutes: Int = 300) -> RateLimitWindowInfo {
+        let windowSeconds = Double(windowMinutes) * 60
+        let elapsed = (pace / 100) * windowSeconds
+        let resetsAt = Date().addingTimeInterval(windowSeconds - elapsed)
+        return RateLimitWindowInfo(usedPercent: usedPercent, windowMinutes: windowMinutes, resetsAt: resetsAt)
     }
 
     private func makeSession(

--- a/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
+++ b/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
@@ -1,0 +1,196 @@
+import XCTest
+@testable import Irrlicht
+
+/// Coverage for the menu-bar quota icon (issue #909): the stacked 5h/7d
+/// bars, the single-window compact ring, the pace marker both share, and
+/// the freshest-non-stale snapshot selection across live sessions.
+@MainActor
+final class QuotaMenuBarRendererTests: XCTestCase {
+
+    // MARK: - buildSVG (bars)
+
+    func testBuildSVGReturnsNilWhenNoWindows() {
+        let info = RateLimitInfo(windows: [], sampledAt: Date())
+        XCTAssertNil(QuotaMenuBarRenderer.buildSVG(for: info))
+    }
+
+    func testBuildSVGIncludesBothRowsWhenBothWindowsPresent() {
+        let info = makeInfo(fiveHour: 20, sevenDay: 40)
+        let result = QuotaMenuBarRenderer.buildSVG(for: info)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.svg.contains(">5h<"))
+        XCTAssertTrue(result!.svg.contains(">7d<"))
+    }
+
+    func testBuildSVGOmitsMissingWindowRow() {
+        let info = RateLimitInfo(
+            windows: [RateLimitWindowInfo(usedPercent: 40, windowMinutes: 10080, resetsAt: Date().addingTimeInterval(3600))],
+            sampledAt: Date()
+        )
+        let result = QuotaMenuBarRenderer.buildSVG(for: info)
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result!.svg.contains(">5h<"))
+        XCTAssertTrue(result!.svg.contains(">7d<"))
+    }
+
+    func testBuildSVGColorThresholds() {
+        // Mirrors QuotaChipBarColorTests' boundary pinning, for the bare-hex
+        // (no '#') ramp this renderer's SVG fill attributes use.
+        let cases: [(name: String, used: Double, wantHex: String)] = [
+            ("low",      30, "34C759"),
+            ("medium",   60, "FF9500"),
+            ("high",     85, "FF3B30"),
+            ("critical", 97, "D70015"),
+        ]
+        for c in cases {
+            let info = makeInfo(fiveHour: c.used, sevenDay: nil)
+            let result = QuotaMenuBarRenderer.buildSVG(for: info)
+            XCTAssertTrue(
+                result?.svg.contains("#\(c.wantHex)") ?? false,
+                "\(c.name): expected #\(c.wantHex) in \(result?.svg ?? "nil")"
+            )
+        }
+    }
+
+    // MARK: - buildCircleSVG
+
+    func testBuildCircleSVGReturnsNilWhenNoWindows() {
+        let info = RateLimitInfo(windows: [], sampledAt: Date())
+        XCTAssertNil(QuotaMenuBarRenderer.buildCircleSVG(for: info))
+    }
+
+    /// Regression pin: the circle must stay pinned to the 5h window even
+    /// when the 7d window is more depleted — RateLimitInfo.imminentWindow
+    /// would pick 7d here (80 > 20), which is deliberately *not* what the
+    /// circle shows. A glance-value shouldn't silently swap which window
+    /// it's reading.
+    func testBuildCircleSVGPrefersFiveHourOverSevenDayEvenWhenLessDepleted() {
+        let info = makeInfo(fiveHour: 20, sevenDay: 80)
+        let result = QuotaMenuBarRenderer.buildCircleSVG(for: info)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.svg.contains("#34C759"), "should use the 5h window's low-usage green")
+        XCTAssertFalse(result!.svg.contains("#FF3B30"), "must not leak the 7d window's high-usage color")
+    }
+
+    func testBuildCircleSVGFallsBackToSevenDayWhenFiveHourAbsent() {
+        let info = RateLimitInfo(
+            windows: [RateLimitWindowInfo(usedPercent: 60, windowMinutes: 10080, resetsAt: Date().addingTimeInterval(3600))],
+            sampledAt: Date()
+        )
+        let result = QuotaMenuBarRenderer.buildCircleSVG(for: info)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.svg.contains("#FF9500"))
+    }
+
+    // MARK: - pace marker (mirrors SessionListView.quotaPacePercent)
+
+    func testPaceMarkerRenderedOnBarsWhenWindowHasFutureReset() {
+        let info = makeInfo(fiveHour: 20, sevenDay: nil, fiveHourResetsIn: 3600)
+        let result = QuotaMenuBarRenderer.buildSVG(for: info)
+        XCTAssertTrue(result!.svg.contains("fill=\"red\""))
+    }
+
+    func testPaceMarkerAbsentOnBarsWhenResetIsUnset() {
+        let info = RateLimitInfo(
+            windows: [RateLimitWindowInfo(usedPercent: 20, windowMinutes: 300, resetsAt: Date(timeIntervalSince1970: 0))],
+            sampledAt: Date()
+        )
+        let result = QuotaMenuBarRenderer.buildSVG(for: info)
+        XCTAssertFalse(result!.svg.contains("fill=\"red\""))
+    }
+
+    func testPaceMarkerStillRendersClampedWhenWindowAlreadyExpired() {
+        let info = RateLimitInfo(
+            windows: [RateLimitWindowInfo(usedPercent: 20, windowMinutes: 300, resetsAt: Date().addingTimeInterval(-60))],
+            sampledAt: Date()
+        )
+        let result = QuotaMenuBarRenderer.buildSVG(for: info)
+        XCTAssertTrue(result!.svg.contains("fill=\"red\""))
+    }
+
+    func testPaceMarkerRenderedOnCircleAsRedStroke() {
+        let info = makeInfo(fiveHour: 20, sevenDay: nil, fiveHourResetsIn: 3600)
+        let result = QuotaMenuBarRenderer.buildCircleSVG(for: info)
+        XCTAssertTrue(result!.svg.contains("stroke=\"red\""))
+    }
+
+    // MARK: - selectedSnapshot
+
+    func testSelectedSnapshotPicksFreshestNonStaleAcrossSessions() {
+        let older = makeSession(id: "1", adapter: "claude-code", usedPercent: 10, sampledSecondsAgo: 120)
+        let newer = makeSession(id: "2", adapter: "claude-code", usedPercent: 90, sampledSecondsAgo: 5)
+        let got = QuotaMenuBarRenderer.selectedSnapshot(sessions: [older, newer], providerKey: nil)
+        XCTAssertEqual(got?.windows.first?.usedPercent, 90)
+    }
+
+    func testSelectedSnapshotFiltersByProviderKey() {
+        let claude = makeSession(id: "1", adapter: "claude-code", usedPercent: 10, sampledSecondsAgo: 5)
+        let codex = makeSession(id: "2", adapter: "codex", usedPercent: 90, sampledSecondsAgo: 5)
+        let got = QuotaMenuBarRenderer.selectedSnapshot(sessions: [claude, codex], providerKey: "anthropic")
+        XCTAssertEqual(got?.windows.first?.usedPercent, 10)
+    }
+
+    func testSelectedSnapshotSkipsStaleSnapshots() {
+        let stale = makeSession(id: "1", adapter: "claude-code", usedPercent: 10, sampledSecondsAgo: 5, resetsInPast: true)
+        let got = QuotaMenuBarRenderer.selectedSnapshot(sessions: [stale], providerKey: nil)
+        XCTAssertNil(got)
+    }
+
+    func testSelectedSnapshotReturnsNilWhenNoSessionCarriesRateLimit() {
+        let plain = SessionState(
+            id: "sess_1", state: .working, model: "claude-sonnet", cwd: "/tmp",
+            firstSeen: Date(), updatedAt: Date()
+        )
+        XCTAssertNil(QuotaMenuBarRenderer.selectedSnapshot(sessions: [plain], providerKey: nil))
+    }
+
+    // MARK: - helpers
+
+    private func makeInfo(fiveHour: Double?, sevenDay: Double?, fiveHourResetsIn: TimeInterval = 3600) -> RateLimitInfo {
+        var windows: [RateLimitWindowInfo] = []
+        if let fiveHour {
+            windows.append(RateLimitWindowInfo(usedPercent: fiveHour, windowMinutes: 300, resetsAt: Date().addingTimeInterval(fiveHourResetsIn)))
+        }
+        if let sevenDay {
+            windows.append(RateLimitWindowInfo(usedPercent: sevenDay, windowMinutes: 10080, resetsAt: Date().addingTimeInterval(3 * 86400)))
+        }
+        return RateLimitInfo(windows: windows, sampledAt: Date())
+    }
+
+    private func makeSession(
+        id: String,
+        adapter: String,
+        usedPercent: Double,
+        sampledSecondsAgo: TimeInterval,
+        resetsInPast: Bool = false
+    ) -> SessionState {
+        let resetsAt = resetsInPast ? Date().addingTimeInterval(-3600) : Date().addingTimeInterval(3600)
+        let rateLimit = RateLimitInfo(
+            windows: [RateLimitWindowInfo(usedPercent: usedPercent, windowMinutes: 300, resetsAt: resetsAt)],
+            sampledAt: Date().addingTimeInterval(-sampledSecondsAgo)
+        )
+        let metrics = SessionMetrics(
+            elapsedSeconds: 0,
+            totalTokens: 0,
+            modelName: "claude-sonnet",
+            contextWindow: nil,
+            contextUtilization: 0,
+            pressureLevel: "safe",
+            contextWindowUnknown: nil,
+            estimatedCostUSD: nil,
+            lastAssistantText: nil,
+            tasks: nil,
+            rateLimit: rateLimit
+        )
+        return SessionState(
+            id: "sess_\(id)",
+            state: .working,
+            model: "claude-sonnet",
+            cwd: "/tmp",
+            firstSeen: Date(),
+            updatedAt: Date(),
+            metrics: metrics,
+            adapter: adapter
+        )
+    }
+}

--- a/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
+++ b/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
@@ -35,6 +35,38 @@ final class QuotaMenuBarRendererTests: XCTestCase {
         XCTAssertTrue(result!.svg.contains(">7d<"))
     }
 
+    // MARK: - buildSVG compact mode (Combined style: no labels, narrower bars)
+
+    func testBuildSVGCompactOmitsWindowLabels() {
+        let info = makeInfo(fiveHour: 20, sevenDay: 40)
+        let result = QuotaMenuBarRenderer.buildSVG(for: info, compact: true)
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result!.svg.contains(">5h<"))
+        XCTAssertFalse(result!.svg.contains(">7d<"))
+    }
+
+    func testBuildSVGCompactIsNarrowerThanDefault() {
+        let info = makeInfo(fiveHour: 20, sevenDay: 40)
+        let normal = QuotaMenuBarRenderer.buildSVG(for: info, compact: false)
+        let compact = QuotaMenuBarRenderer.buildSVG(for: info, compact: true)
+        XCTAssertNotNil(normal)
+        XCTAssertNotNil(compact)
+        XCTAssertLessThan(compact!.width, normal!.width)
+        // compact's total width IS the bar width (no label/gap column), so
+        // it can be compared directly against the known 32pt default bar
+        // width: the requested range is 30-40% narrower, i.e. 60-70% of 32.
+        XCTAssertGreaterThanOrEqual(compact!.width, 32 * 0.60)
+        XCTAssertLessThanOrEqual(compact!.width, 32 * 0.70)
+    }
+
+    func testBuildSVGCompactDefaultsToFalseWhenOmitted() {
+        let info = makeInfo(fiveHour: 20, sevenDay: 40)
+        let omitted = QuotaMenuBarRenderer.buildSVG(for: info)
+        let explicitFalse = QuotaMenuBarRenderer.buildSVG(for: info, compact: false)
+        XCTAssertEqual(omitted?.width, explicitFalse?.width)
+        XCTAssertTrue(omitted!.svg.contains(">5h<"))
+    }
+
     /// Same ramp QuotaChipBarColorTests pins for SessionListView.barColor
     /// — this renderer must reach the identical verdict (as a bare hex
     /// instead of a SwiftUI Color) so the same window can't read green in


### PR DESCRIPTION
## Summary

Implements #909: an opt-in Settings picker (**Lights / Usage / Combined**) so the menu-bar status icon can show the 5h/7d subscription-quota windows directly, instead of only inside the popover.

<img width="342" height="368" alt="image" src="https://github.com/user-attachments/assets/09056de0-64b5-46cc-b758-1ca45ab8d5a7" />

- **Lights** — today's behavior, unchanged (default, so existing users see no visual change).
- **Usage** — replaces the session-state dots with stacked 5h/7d quota bars (or a compact ring, see below).
- **Combined** — both side by side: dots left, quota right (closest to the system status icons), matching the mockup posted on the issue.

Additional controls, per your comment on the issue:
- **Quota shape**: Bars (5h/7d stacked) or a single compact ring pinned to the 5h window.
- **Quota provider**: a single-provider picker (not multi-provider) for accounts with more than one subscription (e.g. Claude + Codex) — deliberately not showing every provider at once, to stay within the icon's tight width budget alongside the existing capped-at-5 dot groups.
- **Pace marker**: both shapes carry a thin marker showing how much wall-clock time has elapsed in the window (mirrors `SessionListView.quotaPacePercent`), independent of usage%.

No new data collection — this is rendering-only. The 5h/7d windows were already flowing from the daemon's `statusLine` hook into `session.metrics.rateLimit`; this just adds a second consumer of that existing data.

### Two commits

1. `feat(macos): show subscription quota in the menu bar status icon` — the feature itself.
2. `fix(macos): correct quota-icon rebuild triggers, staleness, and appearance` — a set of real defects an independent second-pass review caught before this reached anyone else: the icon not repainting when the new settings changed, a stale-snapshot handling mismatch with the popover, an absolute-only color ramp that could disagree with the popover's pace-aware one, hardcoded colors invisible in light menu-bar appearance, and a couple of related edge cases. Left as a separate commit so the review trail is visible rather than squashed away.

### Scope note

I deliberately did **not** extract `SessionListView`'s fuller quota-chip bucketing (cost totals, stale-dimming, multi-provider chips) into a shared helper. `QuotaMenuBarRenderer`'s selection logic is intentionally leaner (single provider, no cost aggregation) — pulling popover-only concerns into the status-item icon felt like premature abstraction for what's currently a single consumer. Happy to revisit if you'd rather see that unified.

## Test plan

- 21 new/updated XCTest cases across `QuotaMenuBarRendererTests.swift` (bars/circle rendering, pace-aware color ramp mirroring `QuotaChipBarColorTests`, freshest-renderable snapshot selection) and `MenuBarImageBuilderTests.swift` (image composition geometry, `.usage`-style dots fallback).
- Full local suite (`swift test`, `go test ./core/... -race -count=1`, `tools/preflight.sh`) green, except one pre-existing environment-dependent Swift test failure (`SessionManagerTests.testTitleMatchScoreSkipsGenericTopsAndHomeBasename`) verified to also fail on a clean `main` checkout on this machine — unrelated to this change.
- Manually exercised all three styles + both quota shapes + the provider picker in a locally built dev instance (isolated daemon port, synthetic rate-limit data injected via the statusline endpoint) — confirmed the icon now repaints immediately on a settings change, and that bars/ring/labels are readable in both light and dark menu-bar appearance.
- No screenshots in this PR (local environment couldn't grant screen-recording permission to capture them) — happy to add if useful, or a maintainer/reviewer can pull the branch and check locally.

Closes #909.
