### PR TITLE
fix(ci): CodeScene badge was reading the hotspots-only score, not the project score

### DIFF
--- a/.github/workflows/codescene-badge.yml
+++ b/.github/workflows/codescene-badge.yml
@@ -13,26 +13,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: DEBUG dump raw API responses
-        env:
-          CODESCENE_API_TOKEN: ${{ secrets.CODESCENE_API_TOKEN }}
-          CODESCENE_PROJECT_ID: "82148"
-        run: |
-          echo "=== analyses/latest ==="
-          tools/codescene-report.sh "analyses/latest"
-          echo "=== analyses (list, if it exists) ==="
-          tools/codescene-report.sh "analyses" || echo "(no such endpoint)"
-          echo "=== repository (project overview, if it exists) ==="
-          tools/codescene-report.sh "" || echo "(no such endpoint)"
-
       - name: Fetch current code health score
         env:
           CODESCENE_API_TOKEN: ${{ secrets.CODESCENE_API_TOKEN }}
           CODESCENE_PROJECT_ID: "82148"
         run: |
-          SCORE=$(tools/codescene-report.sh "analyses/latest" | jq -r '.high_level_metrics.current_score')
+          # high_level_metrics.current_score is an alias for
+          # hotspots_code_health_now_weighted_average (hotspot files only,
+          # i.e. the most-frequently-changed ones) — NOT the whole-codebase
+          # score shown on the CodeScene dashboard. That's
+          # code_health_weighted_average_current. The two normally track
+          # closely, but diverge sharply after a PR that concentrates its
+          # changes in hotspot files (see #901's cognitive-complexity pass,
+          # which showed a false ~1-point badge drop while the dashboard's
+          # real score improved).
+          SCORE=$(tools/codescene-report.sh "analyses/latest" | jq -r '.high_level_metrics.code_health_weighted_average_current')
           if [ -z "$SCORE" ] || [ "$SCORE" = "null" ]; then
-            echo "::error::could not read high_level_metrics.current_score from analyses/latest"
+            echo "::error::could not read high_level_metrics.code_health_weighted_average_current from analyses/latest"
             exit 1
           fi
           echo "SCORE=$SCORE" >> "$GITHUB_ENV"

--- a/.github/workflows/codescene-badge.yml
+++ b/.github/workflows/codescene-badge.yml
@@ -13,6 +13,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: DEBUG dump raw API responses
+        env:
+          CODESCENE_API_TOKEN: ${{ secrets.CODESCENE_API_TOKEN }}
+          CODESCENE_PROJECT_ID: "82148"
+        run: |
+          echo "=== analyses/latest ==="
+          tools/codescene-report.sh "analyses/latest"
+          echo "=== analyses (list, if it exists) ==="
+          tools/codescene-report.sh "analyses" || echo "(no such endpoint)"
+          echo "=== repository (project overview, if it exists) ==="
+          tools/codescene-report.sh "" || echo "(no such endpoint)"
+
       - name: Fetch current code health score
         env:
           CODESCENE_API_TOKEN: ${{ secrets.CODESCENE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- After #916 (the go:S3776 cognitive-complexity refactor) merged, the README's CodeScene badge dropped from 8.38 to 7.25, which looked like a real regression — but the CodeScene dashboard itself showed **8.63, improving**.
- Root cause: `high_level_metrics.current_score` (what the badge workflow reads from `analyses/latest`) is an alias for `hotspots_code_health_now_weighted_average` — the code health average of only the most-frequently-changed files — not the whole-codebase score shown on the dashboard (`code_health_weighted_average_current`). Confirmed via a throwaway debug branch that dumped the raw API response.
- The two numbers normally track closely, so this went unnoticed until a PR that concentrates its changes in hotspot files (session_detector*.go, irrlicht.js, handlers.go — all frequently-changed) pulled the hotspots-only number down while the real project-wide score genuinely improved.
- Fix: read `code_health_weighted_average_current` instead, with a comment explaining the distinction so this doesn't get silently reverted later.

## Test plan
- [x] Verified via `workflow_dispatch` on a debug branch that the corrected field returns 8.63, matching the CodeScene dashboard exactly
- [x] `tools/preflight.sh` — all gates pass (workflow-YAML-only change, no application code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)