### PR TITLE
fix(macos): stop CO2 unit wrapping to a second line in the session list

### DIFF
--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -623,7 +623,7 @@ struct SessionMetrics: Codable {
         }
         if grams < 1 { return String(format: "%.0fmg", grams * 1000) }
         if grams < 1000 { return String(format: "%.1fg", grams) }
-        return String(format: "%.2fkg", grams / 1000)
+        return String(format: "%.1fkg", grams / 1000)
     }
 
     // co2TierTooltip explains the confidence behind the CO2 estimate — every

--- a/platforms/macos/Irrlicht/Views/SessionRowView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionRowView.swift
@@ -101,6 +101,7 @@ struct SessionRowView: View {
             Text(text)
                 .font(.system(size: 9, weight: .medium, design: .monospaced))
                 .foregroundColor(.secondary)
+                .lineLimit(1)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- `formattedCO2`'s kg branch used two decimal digits while the sibling g/mg branches use 0-1, producing strings like `16.15kg` that overflow the session row's fixed 36pt cost/CO2 column and wrap onto a second line.
- Match the g branch's one-decimal precision (`16.2kg`) and add `.lineLimit(1)` to the cost/CO2 label as defense-in-depth.

Fixes #920

## Test plan
- [x] `swift build` succeeds
- [x] `tools/preflight.sh`-driven pre-push checks passed (go tests, gosec, web suites)
- [ ] Manual: toggle to CO2 mode in the macOS app list view and confirm large kg values render on one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)