### PR TITLE
fix(sonar): resolve mechanical SonarQube maintainability findings (#901)

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/monitor_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/monitor_other.go
@@ -20,7 +20,9 @@ func NewMonitor(handler exitHandler) (*pidMonitor, error) {
 
 func (m *pidMonitor) Watch(pid int, sessionID string) error { return nil }
 
-func (m *pidMonitor) Unwatch(pid int) {}
+func (m *pidMonitor) Unwatch(pid int) {
+	// no-op — this platform has no exit-signal primitive to unregister
+}
 
 // Run blocks until ctx is cancelled, matching the other implementations.
 func (m *pidMonitor) Run(ctx context.Context) error {

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -889,7 +889,9 @@ func setupRecording(detector *services.SessionDetector, sockPath string, logger 
 	rec, err := recorder.NewJSONLRecorder(recordingsDir)
 	if err != nil {
 		logger.LogError("startup", "", fmt.Sprintf("failed to init lifecycle recorder: %v", err))
-		return func() {}
+		return func() {
+			// no-op cleanup — recorder never initialized
+		}
 	}
 	detector.SetRecorder(rec)
 	logger.LogInfo("startup", "", fmt.Sprintf("lifecycle recording enabled: %s", rec.Path()))

--- a/core/domain/agent/file_parser.go
+++ b/core/domain/agent/file_parser.go
@@ -23,7 +23,9 @@ type JSONLineParser struct {
 	NewParser func() LineParser
 }
 
-func (JSONLineParser) isFileParser() {}
+func (JSONLineParser) isFileParser() {
+	// sealing marker — deliberately empty
+}
 
 // RawLineParser is used by adapters whose source format is not JSONL
 // (aider's .aider.chat.history.md is markdown). NewParser returns a
@@ -43,7 +45,9 @@ type RawLineParser struct {
 	NewParser func() RawParser
 }
 
-func (RawLineParser) isFileParser() {}
+func (RawLineParser) isFileParser() {
+	// sealing marker — deliberately empty
+}
 
 // LineParser parses a single JSONL line into a normalized ParsedEvent.
 // Adapter packages provide stateful implementations (Claude Code tracks

--- a/core/domain/agent/process_matcher.go
+++ b/core/domain/agent/process_matcher.go
@@ -14,7 +14,9 @@ type ExactName struct {
 	Name string
 }
 
-func (ExactName) isProcessMatcher() {}
+func (ExactName) isProcessMatcher() {
+	// sealing marker — deliberately empty
+}
 
 // CommandPattern matches via `pgrep -f Regex` — the full command line is
 // matched, not just argv[0]. Use when the OS process name does not match
@@ -25,4 +27,6 @@ type CommandPattern struct {
 	Regex *regexp.Regexp
 }
 
-func (CommandPattern) isProcessMatcher() {}
+func (CommandPattern) isProcessMatcher() {
+	// sealing marker — deliberately empty
+}

--- a/core/domain/agent/source.go
+++ b/core/domain/agent/source.go
@@ -52,7 +52,9 @@ type FilesUnderRoot struct {
 	SessionIDFromPath func(path string) string
 }
 
-func (FilesUnderRoot) isSource() {}
+func (FilesUnderRoot) isSource() {
+	// sealing marker — deliberately empty
+}
 
 // RootDirFor returns the directory the runtime should watch for this source
 // on the given OS (pass runtime.GOOS): the DirByOS override when one is set
@@ -82,7 +84,9 @@ type FilesUnderCWD struct {
 	Parser   RawLineParser
 }
 
-func (FilesUnderCWD) isSource() {}
+func (FilesUnderCWD) isSource() {
+	// sealing marker — deliberately empty
+}
 
 // ProcessOwnedStore — session state lives in a structured store (SQLite,
 // typically) whose path is derivable from the process PID or a stable
@@ -95,4 +99,6 @@ type ProcessOwnedStore struct {
 	Reader     MetricsReader
 }
 
-func (ProcessOwnedStore) isSource() {}
+func (ProcessOwnedStore) isSource() {
+	// sealing marker — deliberately empty
+}

--- a/examples/coding-factory/agent.Dockerfile
+++ b/examples/coding-factory/agent.Dockerfile
@@ -28,12 +28,12 @@ FROM node:${NODE_VERSION}-bookworm-slim AS runtime
 # for `task_complete` with jq. curl: REQUIRED — the daemon's auto-installed hook
 # POSTs via `curl … || true`; without it the hook silently no-ops and tool-use
 # permission prompts never surface as `waiting` (#488).
+# OpenAI Codex CLI (the real agent this testbed observes).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates git tini procps curl tmux jq \
-    && rm -rf /var/lib/apt/lists/*
-# OpenAI Codex CLI (the real agent this testbed observes).
-RUN npm install -g @openai/codex
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g @openai/codex
 
 # Non-root `agent` — both codex and irrlichd run as this user, sharing $HOME so
 # the daemon can read codex's transcripts under ~/.codex/sessions.

--- a/examples/roundtrip/agent.Dockerfile
+++ b/examples/roundtrip/agent.Dockerfile
@@ -32,11 +32,11 @@ FROM node:${NODE_VERSION}-bookworm-slim AS runtime
 # `curl … || true`; without curl the hook silently no-ops (the `|| true`
 # swallows "command not found"), so PermissionRequest never reaches the
 # daemon and tool-use permission prompts never surface as `waiting` (#488).
+# Claude Code CLI (the real agent this testbed observes).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates git tini procps curl \
-    && rm -rf /var/lib/apt/lists/*
-# Claude Code CLI (the real agent this testbed observes).
-RUN npm install -g @anthropic-ai/claude-code
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g @anthropic-ai/claude-code
 
 # Non-root `agent` — avoids claude's run-as-root friction; both claude and
 # irrlichd run as this user.

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/KittyActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/KittyActivator.swift
@@ -42,7 +42,7 @@ struct KittyActivator: HostActivator {
             // `activated` already carries the synchronous result; the async
             // `then` completion (fires once a cold-launched app finishes
             // opening) isn't needed here.
-            activated = AppActivator.activate(bundleID: bundleID) { _ in }
+            activated = AppActivator.activate(bundleID: bundleID) { _ in /* completion not needed here */ }
         }
 
         // 2. Switch to the right tab via kitty's remote control if the user

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -591,8 +591,8 @@ struct HistoryContentView: View {
     var scope: HistoryScope?
     // No-op defaults so previews/snapshot tests can host this view without
     // wiring drill-down interaction.
-    var onDrill: (HistoryGroup, String) -> Void = { _, _ in }
-    var onClearDrill: () -> Void = {}
+    var onDrill: (HistoryGroup, String) -> Void = { _, _ in /* no-op default */ }
+    var onClearDrill: () -> Void = { /* no-op default */ }
     let onExportCSV: () -> Void
     let onExportJSON: () -> Void
 

--- a/platforms/macos/Tests/HistoryViewSnapshotTests.swift
+++ b/platforms/macos/Tests/HistoryViewSnapshotTests.swift
@@ -123,8 +123,8 @@ final class HistoryViewSnapshotTests: XCTestCase {
         let view = HistoryContentView(
             data: populated(),
             range: .month,
-            onExportCSV: {},
-            onExportJSON: {}
+            onExportCSV: { /* unused in this snapshot */ },
+            onExportJSON: { /* unused in this snapshot */ }
         )
         assertSnapshot(of: host(view, height: 460), as: .image)
     }
@@ -136,8 +136,8 @@ final class HistoryViewSnapshotTests: XCTestCase {
             chart: .tokens,
             group: .branch,
             scope: nil,
-            onExportCSV: {},
-            onExportJSON: {}
+            onExportCSV: { /* unused in this snapshot */ },
+            onExportJSON: { /* unused in this snapshot */ }
         )
         assertSnapshot(of: host(view, height: 460), as: .image)
     }
@@ -149,8 +149,8 @@ final class HistoryViewSnapshotTests: XCTestCase {
             chart: .cost,
             group: .branch,
             scope: HistoryScope(field: .project, value: "irrlicht"),
-            onExportCSV: {},
-            onExportJSON: {}
+            onExportCSV: { /* unused in this snapshot */ },
+            onExportJSON: { /* unused in this snapshot */ }
         )
         assertSnapshot(of: host(view, height: 500), as: .image)
     }
@@ -159,8 +159,8 @@ final class HistoryViewSnapshotTests: XCTestCase {
         let view = HistoryContentView(
             data: empty(),
             range: .day,
-            onExportCSV: {},
-            onExportJSON: {}
+            onExportCSV: { /* unused in this snapshot */ },
+            onExportJSON: { /* unused in this snapshot */ }
         )
         assertSnapshot(of: host(view, height: 320), as: .image)
     }

--- a/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
+++ b/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
@@ -234,7 +234,7 @@ final class QuotaMenuBarRendererTests: XCTestCase {
 
     func testSelectedSnapshotReturnsNilWhenNoSessionCarriesRateLimit() {
         let plain = SessionState(
-            id: "sess_1", state: .working, model: "claude-sonnet", cwd: "/tmp",
+            id: "sess_1", state: .working, model: "claude-sonnet", cwd: "/tmp",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             firstSeen: Date(), updatedAt: Date()
         )
         XCTAssertNil(QuotaMenuBarRenderer.selectedSnapshot(sessions: [plain], providerKey: nil))
@@ -299,7 +299,7 @@ final class QuotaMenuBarRendererTests: XCTestCase {
             id: "sess_\(id)",
             state: .working,
             model: "claude-sonnet",
-            cwd: "/tmp",
+            cwd: "/tmp",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             firstSeen: Date(),
             updatedAt: Date(),
             metrics: metrics,

--- a/platforms/web/connectionProtocol.js
+++ b/platforms/web/connectionProtocol.js
@@ -52,6 +52,6 @@ export function relayWsUrl(raw) {
   // honors that.
   if (!/^wss?:\/\//i.test(u)) u = 'ws://' + u; // NOSONAR (javascript:S5332) — see comment above
   while (u.endsWith('/')) u = u.slice(0, -1);
-  if (!/\/api\/v1\/sessions\/stream$/.test(u)) u += '/api/v1/sessions/stream';
+  if (!u.endsWith('/api/v1/sessions/stream')) u += '/api/v1/sessions/stream';
   return u;
 }

--- a/platforms/web/domReconcile.js
+++ b/platforms/web/domReconcile.js
@@ -52,7 +52,7 @@ export function reconcile(parent, items, keyFn, createFn, updateFn) {
   // Remove orphans
   for (const [key, el] of existingByKey) {
     if (!desiredKeys.has(key)) {
-      parent.removeChild(el);
+      el.remove();
     }
   }
 }

--- a/platforms/web/formatters.js
+++ b/platforms/web/formatters.js
@@ -191,8 +191,9 @@ export function taskEtaPresentation(metrics, state, nowSec) {
   const est = metrics?.task_estimate;
   const eta = metrics?.task_completion_eta;
   if (state !== 'working' || !est) return null;
-  const sourceLabel = est.source === 'tasks' ? 'from task list'
-    : est.source === 'subagents' ? 'from subagents' : 'agent-reported';
+  let sourceLabel = 'agent-reported';
+  if (est.source === 'tasks') sourceLabel = 'from task list';
+  else if (est.source === 'subagents') sourceLabel = 'from subagents';
   // Explicit null/undefined check before the <= comparison (SonarQube
   // javascript:S1940 wants <= over !(... > ...), but `undefined <= 0` is
   // false while `!(undefined > 0)` is true — a missing completed_rounds

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -138,10 +138,12 @@ function renderHistory() {
   // Yield counts completed sessions; agents are reconstructed from opt-in
   // recordings — each gets its own empty caption.
   const emptyEl = document.getElementById('history-chart-empty');
-  if (emptyEl) emptyEl.textContent =
-    isYield ? 'no completed sessions in this range yet'
-      : historyState.chart === 'agents' ? 'no recordings in this range yet'
-        : 'no cost data in this range yet';
+  if (emptyEl) {
+    let emptyText = 'no cost data in this range yet';
+    if (isYield) emptyText = 'no completed sessions in this range yet';
+    else if (historyState.chart === 'agents') emptyText = 'no recordings in this range yet';
+    emptyEl.textContent = emptyText;
+  }
   if (!historyState.data) {
     const wrap = document.getElementById('history-chart-wrap');
     if (wrap) wrap.classList.add('empty');
@@ -317,7 +319,7 @@ function paintHistoryChart() {
   // Grand cumulative total = the stack's right-edge height; it anchors the
   // forecast when cumulative.
   let grandTotal = 0;
-  for (let r = 0; r < matrix.length; r++) grandTotal += matrix[r][B - 1] || 0;
+  for (const row of matrix) grandTotal += row[B - 1] || 0;
   const { H, fcY } = historyForecastSeries(data, cumulative, grandTotal);
 
   // Y scale = the tallest stacked column (sum across bands per bucket), also

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -28,10 +28,10 @@
               title="Toggle light/dark theme" aria-label="Toggle theme">☾</button>
       <button class="theme-toggle" id="settings-toggle" type="button"
               title="Settings" aria-label="Settings">⚙</button>
-      <div class="ws-status" role="status" aria-live="polite">
-        <div class="ws-dot connecting" id="ws-dot"></div>
+      <output class="ws-status" aria-live="polite">
+        <span class="ws-dot connecting" id="ws-dot"></span>
         <span id="ws-label">connecting</span>
-      </div>
+      </output>
     </div>
   </header>
 
@@ -167,7 +167,7 @@
       <div class="history-controls">
         <div class="history-ctl-row">
           <span class="history-ctl-label">Range</span>
-          <div class="history-seg" id="history-range" role="group" aria-label="Range">
+          <fieldset class="history-seg" id="history-range" aria-label="Range">
             <button type="button" data-range="day" class="active">Day</button>
             <button type="button" data-range="week">Week</button>
             <button type="button" data-range="month">Month</button>
@@ -188,7 +188,7 @@
         </div>
         <div class="history-ctl-row">
           <span class="history-ctl-label">Chart</span>
-          <div class="history-seg" id="history-chart-sel" role="group" aria-label="Chart type">
+          <fieldset class="history-seg" id="history-chart-sel" aria-label="Chart type">
             <button type="button" data-chart="cost" class="active">Cost</button>
             <button type="button" data-chart="yield" title="Productive vs reverted spend per project">Yield</button>
             <button type="button" data-chart="tokens">Tokens</button>
@@ -200,7 +200,7 @@
         </div>
         <div class="history-ctl-row">
           <span class="history-ctl-label">Group</span>
-          <div class="history-seg" id="history-group-sel" role="group" aria-label="Group by">
+          <fieldset class="history-seg" id="history-group-sel" aria-label="Group by">
             <button type="button" data-group="project" class="active">Project</button>
             <button type="button" data-group="branch">Branch</button>
             <button type="button" data-group="provider">Provider</button>

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1218,7 +1218,7 @@
       border: 1px solid var(--border-subtle);
       border-radius: 4px;
       line-height: 1.5;
-      word-break: break-word;
+      overflow-wrap: break-word;
     }
     .settings-modal .settings-modal-close {
       background: none;
@@ -1299,6 +1299,7 @@
     .history-seg {
       display: inline-flex; border: 1px solid var(--border);
       border-radius: 5px; overflow: hidden;
+      margin: 0; padding: 0; min-width: 0;
     }
     .history-seg button {
       background: none; border: none; border-right: 1px solid var(--border);

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -76,8 +76,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       const onChange = () => {
         if (!storedTheme()) { updateThemeToggleGlyph(); render(); }
       };
-      if (mq.addEventListener) mq.addEventListener('change', onChange);
-      else if (mq.addListener) mq.addListener(onChange);
+      mq.addEventListener('change', onChange);
     }
 
     // --- Display mode (Context / 1 Min / 10 Min / 60 Min) ---
@@ -1366,11 +1365,9 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       const host = document.getElementById('app-state-icons');
       if (!host) return;
       const list = topLevel || [];
-      const sig = list.length === 0
-        ? 'empty'
-        : list.length <= 3
-          ? 'icons:' + list.map(s => s.state || 'ready').join(',')
-          : 'count:' + list.length;
+      let sig = 'count:' + list.length;
+      if (list.length === 0) sig = 'empty';
+      else if (list.length <= 3) sig = 'icons:' + list.map(s => s.state || 'ready').join(',');
       if (host.dataset.sig === sig) return;
       host.dataset.sig = sig;
       if (list.length === 0) {
@@ -1713,7 +1710,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     function rebuildSources() {
       const desired = desiredSources();
       const desiredById = new Map(desired.map(s => [s.id, s]));
-      for (const [id, src] of [...sources]) {
+      for (const [id, src] of sources) {
         const want = desiredById.get(id);
         // Drop a source that's no longer desired, OR a relay source whose token
         // changed / is parked in 'unauthorized'. The source id is keyed by URL

--- a/platforms/web/quotaChips.js
+++ b/platforms/web/quotaChips.js
@@ -19,8 +19,7 @@ const QUOTA_FORECAST_KEY = 'showQuotaForecast';
 export function showQuotaForecast() {
   // Default ON, mirroring macOS @AppStorage("showQuotaForecast") default.
   const v = localStorage.getItem(QUOTA_FORECAST_KEY);
-  if (v === '0' || v === 'false') return false;
-  return true;
+  return v !== '0' && v !== 'false';
 }
 export function setShowQuotaForecast(on) {
   // Safari Private mode and storage-disabled contexts throw on
@@ -225,9 +224,7 @@ function bucketChips(sessions, nowMs) {
     mergeChipIntoBucket(existing, snap, s, mode, imm, stale);
     existing.totalCostUSD += cost;
   }
-  return Array.from(buckets.values()).sort((a, b) =>
-    a.key < b.key ? -1 : a.key > b.key ? 1 : 0
-  );
+  return Array.from(buckets.values()).sort((a, b) => a.key.localeCompare(b.key));
 }
 
 // subscriptionWindowLine renders one quota window's tooltip line: percent
@@ -239,9 +236,9 @@ function subscriptionWindowLine(w, nowMs) {
   let line = label + ': ' + used + '% used';
   if (pace != null) {
     const delta = used - Math.round(pace);
-    const verdict = delta > 0 ? (delta + 'pt over pace')
-                  : delta < 0 ? ((-delta) + 'pt under pace')
-                  : 'on pace';
+    let verdict = 'on pace';
+    if (delta > 0) verdict = delta + 'pt over pace';
+    else if (delta < 0) verdict = (-delta) + 'pt under pace';
     line += ' · ' + verdict;
   }
   if (w.resets_at) line += ' · resets in ' + formatTimeUntil(w.resets_at);

--- a/platforms/web/vitest.setup.js
+++ b/platforms/web/vitest.setup.js
@@ -88,5 +88,4 @@ global.fetch = () => Promise.reject(new Error('no server'));
 global.Notification = class {
   static permission = 'default';
   static requestPermission() { return Promise.resolve('default'); }
-  constructor() {}
 };

--- a/site/landscape/compare/index.html
+++ b/site/landscape/compare/index.html
@@ -837,8 +837,8 @@ document.addEventListener('DOMContentLoaded', function() {
       var rows = Array.from(tbody.querySelectorAll('tr'));
       rows.sort(function(a, b) {
         var cellA = a.children[idx], cellB = b.children[idx];
-        var valA = (cellA.getAttribute('data-sort') || cellA.textContent).trim();
-        var valB = (cellB.getAttribute('data-sort') || cellB.textContent).trim();
+        var valA = (cellA.dataset.sort || cellA.textContent).trim();
+        var valB = (cellB.dataset.sort || cellB.textContent).trim();
         var numA = Number.parseFloat(valA), numB = Number.parseFloat(valB);
         if (!Number.isNaN(numA) && !Number.isNaN(numB)) {
           return sortAsc ? numA - numB : numB - numA;

--- a/tools/irrlicht-design-system/ui_kits/dashboard/GasTown.jsx
+++ b/tools/irrlicht-design-system/ui_kits/dashboard/GasTown.jsx
@@ -15,7 +15,7 @@ function dotBar(total, done) {
 }
 
 window.GasTown = function GasTown({ orchestrator }) {
-  if (!orchestrator || !orchestrator.running) return null;
+  if (!orchestrator?.running) return null;
   const convoys = (orchestrator.work_units || []).filter(w => w.type === 'convoy');
   return (
     <div className="gt-section">
@@ -26,7 +26,7 @@ window.GasTown = function GasTown({ orchestrator }) {
       {orchestrator.global_agents?.length > 0 && (
         <div className="gt-agents-row">
           {orchestrator.global_agents.map((ga, i) => (
-            <div key={i} className="gt-agent-chip" title={ga.description || ga.role}>
+            <div key={ga.session_id || ga.role || i} className="gt-agent-chip" title={ga.description || ga.role}>
               <span>{ga.icon && ga.icon + ' '}{ga.role}</span>
               <span className="gt-chip-dot" style={{background: stateColor(ga.state)}}/>
               <span className="gt-chip-id">{ga.session_id ? ga.session_id.slice(0,6) : 'idle'}</span>
@@ -38,11 +38,11 @@ window.GasTown = function GasTown({ orchestrator }) {
         const workers = (cb.worktrees || []).flatMap(wt => wt.workers || []);
         if (!workers.length) return null;
         return (
-          <div key={ci} className="gt-rig-block">
+          <div key={cb.name || ci} className="gt-rig-block">
             <div className="gt-rig-name">rig: {cb.name}</div>
             <div className="gt-workers">
               {workers.map((w, wi) => (
-                <div key={wi} className="gt-agent-chip" title={w.description || w.role}>
+                <div key={w.id || wi} className="gt-agent-chip" title={w.description || w.role}>
                   <span>{w.icon && w.icon + ' '}{w.role}{w.name && <span style={{color:'var(--text)'}}> {w.name}</span>}</span>
                   <span className="gt-chip-dot" style={{background: stateColor(w.state)}}/>
                   {w.id && <span className="gt-chip-id">{w.id.slice(0,8)}</span>}
@@ -58,7 +58,7 @@ window.GasTown = function GasTown({ orchestrator }) {
           {convoys.map((c, i) => {
             const done = c.done >= c.total;
             return (
-              <div key={i} className="gt-convoy-row">
+              <div key={c.name || i} className="gt-convoy-row">
                 <span className={'gt-convoy-name' + (done ? ' done' : '')}>{c.name}</span>
                 <span className="gt-dotbar" style={{color: done ? 'var(--ready)' : 'var(--working)'}}>{dotBar(c.total, c.done)}</span>
                 <span className="gt-convoy-fraction">{c.done} / {c.total}</span>

--- a/tools/irrlicht-design-system/ui_kits/dashboard/GroupHeader.jsx
+++ b/tools/irrlicht-design-system/ui_kits/dashboard/GroupHeader.jsx
@@ -2,9 +2,12 @@
 window.GroupHeader = function GroupHeader({ group, collapsed, onToggle, timeframe, onCycleTimeframe }) {
   const total = group.agents.length + group.agents.reduce((n,a) => n + (a.children?.length || 0), 0);
   const maxCtx = Math.max(0, ...group.agents.map(a => (a.metrics?.context_utilization_percentage) || 0));
-  const dotColor = maxCtx > 90 ? 'var(--pressure-high)' : maxCtx > 75 ? 'var(--pressure-medium)' : maxCtx > 50 ? 'var(--waiting)' : 'var(--ready)';
+  let dotColor = 'var(--ready)';
+  if (maxCtx > 90) dotColor = 'var(--pressure-high)';
+  else if (maxCtx > 75) dotColor = 'var(--pressure-medium)';
+  else if (maxCtx > 50) dotColor = 'var(--waiting)';
   const tfSuffix = {day:'/d', week:'/w', month:'/mo', year:'/yr'}[timeframe] || '/d';
-  const cost = group.costs && group.costs[timeframe];
+  const cost = group.costs?.[timeframe];
   return (
     <div className="group-hdr">
       <button type="button" className="group-toggle" onClick={onToggle} aria-expanded={!collapsed}>

--- a/tools/irrlicht-design-system/ui_kits/dashboard/SessionRow.jsx
+++ b/tools/irrlicht-design-system/ui_kits/dashboard/SessionRow.jsx
@@ -21,7 +21,7 @@ window.SessionRow = function SessionRow({ agent, num, isChild }) {
   const pCls = pressureClass(m.pressure_level);
   const subCount = (agent.children || []).filter(c => c.state === 'working' || c.state === 'waiting').length;
   const toolLbl = { Edit:'Edit', Read:'Read', Bash:'Bash', AskUserQuestion:'Ask User', ExitPlanMode:'Plan Mode', Grep:'Grep', Write:'Write' };
-  const tool = m.has_open_tool_call && m.last_open_tool_names && m.last_open_tool_names[0];
+  const tool = m.has_open_tool_call && m.last_open_tool_names?.[0];
   const toolIsUser = tool === 'AskUserQuestion' || tool === 'ExitPlanMode';
 
   return (

--- a/tools/irrlicht-design-system/ui_kits/landing/InstallBlock.jsx
+++ b/tools/irrlicht-design-system/ui_kits/landing/InstallBlock.jsx
@@ -29,7 +29,7 @@ window.FeatureTrio = function FeatureTrio() {
   return (
     <section className="features" id="features">
       {features.map((f, i) => (
-        <div key={i} className="feature">
+        <div key={f.title || i} className="feature">
           <div className="feature-dot" style={{background: f.dot, boxShadow: `0 0 14px ${f.dot}`}}/>
           <h3 className="feature-title">{f.title}</h3>
           <p className="feature-body">{f.body}</p>

--- a/tools/onboarding-factory/internal/viewer/web/viewer.js
+++ b/tools/onboarding-factory/internal/viewer/web/viewer.js
@@ -1224,9 +1224,10 @@ function _appendPipelineTailSegments(wrap, blocked, pipe, meas, jump) {
         "Spec — not authored yet"));
   // Recordings count (latest counts as 1; archive_count is additional)
   const totalRecs = (rcs.latest ? 1 : 0) + (rcs.archive_count || 0);
+  const recsSuffix = totalRecs === 1 ? "" : "s";
   wrap.appendChild(totalRecs > 0
     ? _pipeBtn(String(totalRecs), "#d6f0d4", "#1f5a1d", jump("recordings"), false,
-        `${totalRecs} recording${totalRecs === 1 ? "" : "s"}`)
+        `${totalRecs} recording${recsSuffix}`)
     : _pipeBtn("·", "transparent", "#bbb", jump("recordings"), false,
         "No recordings yet"));
   // Validation
@@ -1586,13 +1587,12 @@ async function loadScenario(s, initialArchive, focus) {
     return;
   }
   const recordingPath = `${encodeURIComponent(s.agent)}/${encodeURIComponent(s.subtree)}/${encodeURIComponent(s.id)}`;
-  const [data, archives, recipes, catalog] = await Promise.all([
+  // Recipe lookup uses recipesByCoverageId (populated once at init from
+  // /api/recipes — see comment above), so no per-recording recipes fetch
+  // is needed here.
+  const [data, archives, catalog] = await Promise.all([
     fetch(`/api/scenarios/${recordingPath}`).then(r => r.json()),
     fetch(`/api/scenarios/${recordingPath}/recordings`).then(r => r.ok ? r.json() : []).catch(() => []),
-    // Recipes for the new Recipe panel target on this page (anchor:
-    // recipe). Same payload the coverage page uses. Look up the
-    // by_adapter entry under the scenario name and agent slug.
-    fetch(`/api/recipes`).then(r => r.ok ? r.json() : null).catch(() => null),
     // Coverage catalog: lets us render a stub Assessment panel from
     // the matrix verdict + notes when no assessment.json exists.
     // Without this fallback the ⚙ / ◉ pipeline-strip jumps would
@@ -2066,9 +2066,8 @@ function _buildExpectedRow(ph, def, specOnly) {
   // delta_ms may be 0 (phase matched exactly at its anchor) — treat
   // anything numeric as renderable, only fall back to "—" when the
   // phase never matched at all.
-  const delta = ph.matched_ts
-    ? `+${Number.isFinite(ph.delta_ms) ? ph.delta_ms : 0} ms`
-    : "—";
+  const deltaMs = Number.isFinite(ph.delta_ms) ? ph.delta_ms : 0;
+  const delta = ph.matched_ts ? `+${deltaMs} ms` : "—";
   tr.innerHTML = `
         <td><code>${escapeHtml(ph.phase)}</code></td>
         <td style="font-size: 11px;">${target}</td>
@@ -2179,6 +2178,16 @@ export function renderManifestFields(m, passRateLabel, alwaysEllipsis) {
 //   other <name>   → an older recording: fetched via the recordings endpoint;
 //                    Playback retargets to its events via /api/replay/start's
 //                    recording field.
+// Label: recording_started_at, daemon version, fresh pass rate. Uses
+// recording_started_at (not promoted_at) so the timestamps describe WHEN
+// the recording was captured.
+function fmtLabel(startedAt, daemonVer, passRate) {
+  const ts = startedAt || "(no timestamp)";
+  const ver = daemonVer ? ` · daemon ${daemonVer}` : "";
+  const pass = passRate ? ` · ${passRate}` : "";
+  return `${ts}${ver}${pass}`;
+}
+
 function renderRecordingHistory(s, latestData, archives, initialArchive, recipeEntry, coverageEntry) {
   const wrap = document.createElement("div");
 
@@ -2188,9 +2197,10 @@ function renderRecordingHistory(s, latestData, archives, initialArchive, recipeE
   const intro = document.createElement("div");
   intro.style.cssText = "margin-bottom: 8px; font-size: 12px; color: #555;";
   const recCount = (archives || []).length;
+  const recCountSuffix = recCount === 1 ? "" : "s";
   intro.innerHTML = `Select which recording to inspect — all live under <code>recordings/</code>, newest first. <b>expected.jsonl</b> is the constant benchmark across all of them; picking an older recording re-evaluates the current spec against its events (drift signal).` +
     (recCount > 0
-      ? ` <b>${recCount}</b> recording${recCount === 1 ? "" : "s"} available.`
+      ? ` <b>${recCount}</b> recording${recCountSuffix} available.`
       : ` No recordings yet.`);
   selPanel.appendChild(intro);
 
@@ -2200,17 +2210,6 @@ function renderRecordingHistory(s, latestData, archives, initialArchive, recipeE
   noneOpt.value = "__none__";
   noneOpt.textContent = "— No recording (spec only) —";
   select.appendChild(noneOpt);
-
-  // Label: recording_started_at, daemon version, fresh pass rate. Uses
-  // recording_started_at (not promoted_at) so the timestamps describe WHEN
-  // the recording was captured.
-  function fmtLabel(startedAt, daemonVer, passRate) {
-    const ts = startedAt || "(no timestamp)";
-    const ver = daemonVer ? ` · daemon ${daemonVer}` : "";
-    const pass = passRate ? ` · ${passRate}` : "";
-    return `${ts}${ver}${pass}`;
-  }
-
 
   // Every recording lives under recordings/<name>/ — there is no separate
   // "Latest" entry. The list is newest-first by name; the newest (the one the


### PR DESCRIPTION
## Summary
- Resolves the mechanical, no-judgment-call slice of #901's remaining backlog (223 open issues when this started).
- **swift:S1186 / go:S1186 (20)**: add explanatory nested comments to intentionally-empty sealed-interface markers, no-op stubs, and unused test-fixture closures instead of implementing bodies that would never run.
- **javascript:S3358 (10)**: extract nested ternaries into if/else chains or intermediate variables across `irrlicht.js`, the onboarding-factory viewer, and the design-system JSX kit.
- **Web:S6819 (4 of 6)**: swap `div[role=status]` for `<output>`, and three `div[role=group]` segmented controls for `<fieldset>` (with a UA-style reset in `irrlicht.css`). The 2 `div[role=dialog]` findings (Settings/Permissions modals) are **deferred** — converting to native `<dialog>` is a real behavioral change (`showModal`/`close`, `::backdrop` semantics, focus trapping), not a mechanical swap, and risks regressing core UI.
- **~28 long-tail rules** (1-5 issues each): unused vars, useless constructor, index-as-React-key, optional chaining, deprecated APIs (`addListener`, `word-break: break-word`), `.dataset` over `getAttribute`, `for-of` over indexed loops, merged consecutive Dockerfile `RUN` instructions, and a dead redundant fetch in the onboarding-factory viewer.

## Also: closed 79 zombie swift:S1075 findings via the SonarQube API
PR #914 suppressed all `swift:S1075` findings in code with `// NOSONAR` back in July, but this project's automatic analysis (no CI-based scanner configured) never actually closes issues suppressed that way — it just carries them forward scan after scan indefinitely. Confirmed by comparing issue `updateDate` timestamps: they stalled at 2026-07-05, before #914 even merged, while genuine code fixes (e.g. #916's complexity refactor) were picked up cleanly. Dismissed all 79 as false-positive via the SonarQube API (same mechanism phase 1 used successfully for 17 issues) — 2 of them were new (introduced by #917's `QuotaMenuBarRendererTests.swift`), so those got the in-code NOSONAR annotation first, then the same API dismissal.

## Deliberately left alone (real refactors or already-documented false positives, not mechanical)
`godre:S8242` (context-field removal), `go:S1871` (duplicate-branch consolidation), `swift:S4144`/`go:S4144` (duplicate-implementation consolidation), `go:S3776` (cognitive complexity), `swift:S107` (10-param refactor), `javascript:S7785` (top-level-await conversion), `css:S7924` (contrast — design decision), `swift:S2094`, `swift:S2961` (cross-file rename), `swift:S3661` (`try!` relaxation), `css:S4666` (selector merge), `swift:S117` and the remaining `godre:S8196` (already-documented false positives: SwiftUI `$binding` syntax and an established alternate Go interface-naming idiom, respectively), and `shelldre:S7682` / two `shelldre:S1481` (a genuine rule conflict — an explicit `return` here would trigger shellcheck SC2317 unreachable-code on a function where every branch calls `exit`, already documented in the source).

## Test plan
- [x] `go build ./core/... ./tools/onboarding-factory/...` — clean
- [x] `go test ./core/... -race -count=1` — all green (one isolated re-run of `TestSessionDetector_ParentNotAffected_WhenNoChildren` after a full-suite race flake — confirmed pre-existing and unrelated: the diff touches neither `session_detector_activity.go`, `session_detector_subagent_test.go`, nor `pid_manager.go`)
- [x] `go test ./tools/onboarding-factory/... -race -count=1` — all green
- [x] `tools/replay-fixtures.sh` — byte-identical goldens
- [x] `go run ./tools/onboarding-factory/cmd/of validate` — OK
- [x] `npm test` in `platforms/web` (133/133) and the onboarding-factory viewer (80/80)
- [x] `swift build --build-tests && swift test --filter IrrlichtTests` — builds clean; 2 pre-existing snapshot flakes (`testGhostRowPID0NilMetrics`, `testFixtureAntigravityGhost` — fixed-epoch "time ago" drift, already called out in #914's own test plan), unrelated to this diff
- [x] `tools/preflight.sh`-equivalent pre-push hook — passed on retry (same known-flaky pair passed clean the second run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)