### PR TITLE
feat(session): detect questions/waiting cues in non-English text

### DIFF
--- a/core/domain/session/waiting_cue.go
+++ b/core/domain/session/waiting_cue.go
@@ -64,6 +64,7 @@ func ExtractQuestionSnippet(text string) string {
 	if text == "" {
 		return ""
 	}
+	text = foldCombiningDiacritics(text)
 	sentences := splitSentences(text)
 	for i, s := range sentences {
 		trimmed := strings.TrimSpace(s)
@@ -160,6 +161,7 @@ func ExtractWaitingCue(text string) string {
 	if text == "" {
 		return ""
 	}
+	text = foldCombiningDiacritics(text)
 	// Walk the tail newest-first so when both the last and second-to-last
 	// sentence match a cue, the more recent (and usually more natural for
 	// display) sentence is returned.

--- a/core/domain/session/waiting_cue.go
+++ b/core/domain/session/waiting_cue.go
@@ -9,6 +9,7 @@ package session
 import (
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 // trailingMarkdownNoise are characters that commonly appear AFTER a
@@ -73,7 +74,7 @@ func ExtractQuestionSnippet(text string) string {
 		if stripped == "" {
 			continue
 		}
-		if stripped[len(stripped)-1] != '?' {
+		if !endsWithQuestionMark(stripped) {
 			continue
 		}
 		if isRhetorical(sentences, i) {
@@ -172,7 +173,7 @@ func ExtractWaitingCue(text string) string {
 		if isSelfReferentialWait(stripped) {
 			continue
 		}
-		for _, re := range waitingCuePatterns {
+		for _, re := range allWaitingCuePatterns {
 			if re.MatchString(stripped) {
 				return s
 			}
@@ -235,34 +236,66 @@ func looksLikeAnswer(s string) bool {
 			return true
 		}
 	}
+	for _, p := range i18nAnswerPrefixes {
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
 	return false
 }
 
-// splitSentences splits text on sentence terminators (`.`, `!`, `?`) and
-// newlines. A terminator only ends a sentence when followed by whitespace,
-// end-of-string, or markdown wrappers leading to either — so URL `?` and
-// abbreviations like `e.g.` don't split. Each returned sentence retains its
-// terminator and any wrapper characters.
+// questionTerminators are the runes that end a question sentence across
+// scripts: ASCII `?`, full-width `？` (CJK), `؟` (Arabic), and `;`
+// (Greek question mark — NOT the ASCII semicolon it visually resembles).
+// See issue #933: question detection was ASCII-`?`-only, missing every
+// non-Latin question mark.
+const questionTerminators = "?？؟;"
+
+// cjkSentenceTerminators additionally end a *sentence* (for splitSentences)
+// without requiring a following whitespace/EOS — CJK text is typically
+// written without spaces between sentences, unlike Latin/Arabic/Greek.
+const cjkSentenceTerminators = "？！。"
+
+func endsWithQuestionMark(s string) bool {
+	r, _ := utf8.DecodeLastRuneInString(s)
+	return strings.ContainsRune(questionTerminators, r)
+}
+
+func isCJKSentenceTerminator(r rune) bool {
+	return strings.ContainsRune(cjkSentenceTerminators, r)
+}
+
+// splitSentences splits text on sentence terminators (`.`, `!`, `?`, and
+// their CJK/Arabic/Greek counterparts) and newlines. A Latin/Arabic/Greek
+// terminator only ends a sentence when followed by whitespace, end-of-string,
+// or markdown wrappers leading to either — so URL `?` and abbreviations like
+// `e.g.` don't split. CJK terminators (`？！。`) end a sentence unconditionally
+// since CJK text is conventionally written without inter-sentence spaces.
+// Each returned sentence retains its terminator and any wrapper characters.
 func splitSentences(text string) []string {
 	var sentences []string
 	start := 0
-	for i := 0; i < len(text); i++ {
-		c := text[i]
-		switch c {
-		case '.', '!', '?':
-			j := i + 1
+	for i := 0; i < len(text); {
+		r, size := utf8.DecodeRuneInString(text[i:])
+		switch {
+		case r == '\n':
+			sentences = append(sentences, text[start:i])
+			start = i + size
+			i += size
+			continue
+		case r == '.' || r == '!' || r == '?' || isCJKSentenceTerminator(r) || r == '؟' || r == ';':
+			j := i + size
 			for j < len(text) && strings.IndexByte(markdownWrapper, text[j]) >= 0 {
 				j++
 			}
-			if j == len(text) || isSentenceBreak(text[j]) {
+			if isCJKSentenceTerminator(r) || j == len(text) || isSentenceBreak(text[j]) {
 				sentences = append(sentences, text[start:j])
 				start = j
-				i = j - 1
+				i = j
+				continue
 			}
-		case '\n':
-			sentences = append(sentences, text[start:i])
-			start = i + 1
 		}
+		i += size
 	}
 	if start < len(text) {
 		sentences = append(sentences, text[start:])

--- a/core/domain/session/waiting_cue.go
+++ b/core/domain/session/waiting_cue.go
@@ -233,12 +233,7 @@ func looksLikeAnswer(s string) bool {
 		return false
 	}
 	lower := strings.ToLower(s)
-	for _, p := range answerPrefixes {
-		if strings.HasPrefix(lower, p) {
-			return true
-		}
-	}
-	for _, p := range i18nAnswerPrefixes {
+	for _, p := range allAnswerPrefixes {
 		if strings.HasPrefix(lower, p) {
 			return true
 		}
@@ -267,6 +262,31 @@ func isCJKSentenceTerminator(r rune) bool {
 	return strings.ContainsRune(cjkSentenceTerminators, r)
 }
 
+// isSentenceTerminatorRune reports whether r ends a sentence in any of the
+// scripts splitSentences handles: ASCII `.`/`!`/`?`, Arabic `؟`, the Greek
+// question mark, or a CJK terminator.
+func isSentenceTerminatorRune(r rune) bool {
+	return r == '.' || r == '!' || r == '?' || r == '؟' || r == ';' || isCJKSentenceTerminator(r)
+}
+
+// skipMarkdownWrapper advances j past any run of markdown-wrapper characters
+// (e.g. the `**` in `?**`) starting at j, without crossing whitespace.
+func skipMarkdownWrapper(text string, j int) int {
+	for j < len(text) && strings.IndexByte(markdownWrapper, text[j]) >= 0 {
+		j++
+	}
+	return j
+}
+
+// sentenceEndsAt reports whether a terminator rune r, having consumed any
+// trailing markdown wrapper up to index j, actually ends the sentence there.
+// CJK terminators always do (no inter-sentence spacing convention); Latin/
+// Arabic/Greek terminators only do at end-of-string or before whitespace —
+// otherwise it's an abbreviation (`e.g.`) or URL fragment, not a boundary.
+func sentenceEndsAt(r rune, text string, j int) bool {
+	return isCJKSentenceTerminator(r) || j == len(text) || isSentenceBreak(text[j])
+}
+
 // splitSentences splits text on sentence terminators (`.`, `!`, `?`, and
 // their CJK/Arabic/Greek counterparts) and newlines. A Latin/Arabic/Greek
 // terminator only ends a sentence when followed by whitespace, end-of-string,
@@ -279,18 +299,15 @@ func splitSentences(text string) []string {
 	start := 0
 	for i := 0; i < len(text); {
 		r, size := utf8.DecodeRuneInString(text[i:])
-		switch {
-		case r == '\n':
+		if r == '\n' {
 			sentences = append(sentences, text[start:i])
 			start = i + size
 			i += size
 			continue
-		case r == '.' || r == '!' || r == '?' || isCJKSentenceTerminator(r) || r == '؟' || r == ';':
-			j := i + size
-			for j < len(text) && strings.IndexByte(markdownWrapper, text[j]) >= 0 {
-				j++
-			}
-			if isCJKSentenceTerminator(r) || j == len(text) || isSentenceBreak(text[j]) {
+		}
+		if isSentenceTerminatorRune(r) {
+			j := skipMarkdownWrapper(text, i+size)
+			if sentenceEndsAt(r, text, j) {
 				sentences = append(sentences, text[start:j])
 				start = j
 				i = j

--- a/core/domain/session/waiting_cue.go
+++ b/core/domain/session/waiting_cue.go
@@ -278,43 +278,44 @@ func skipMarkdownWrapper(text string, j int) int {
 	return j
 }
 
-// sentenceEndsAt reports whether a terminator rune r, having consumed any
-// trailing markdown wrapper up to index j, actually ends the sentence there.
-// CJK terminators always do (no inter-sentence spacing convention); Latin/
-// Arabic/Greek terminators only do at end-of-string or before whitespace —
-// otherwise it's an abbreviation (`e.g.`) or URL fragment, not a boundary.
-func sentenceEndsAt(r rune, text string, j int) bool {
-	return isCJKSentenceTerminator(r) || j == len(text) || isSentenceBreak(text[j])
+// sentenceBoundaryAfter decodes the rune at i and reports where to resume
+// scanning next, plus whether that position is a sentence boundary. next is
+// always a valid resume point (whether or not boundary is true), so the
+// caller never needs to re-decode. A position is a boundary when the rune
+// is a newline, or a terminator (`.`/`!`/`?`/Arabic/Greek/CJK) that actually
+// ends the sentence there — for Latin/Arabic/Greek terminators, only at
+// end-of-string or before whitespace, so `e.g.` and URL fragments don't
+// split; CJK terminators (`？！。`) always end the sentence, since CJK text
+// is conventionally written without inter-sentence spaces.
+func sentenceBoundaryAfter(text string, i int) (next int, boundary bool) {
+	r, size := utf8.DecodeRuneInString(text[i:])
+	if r == '\n' {
+		return i + size, true
+	}
+	if !isSentenceTerminatorRune(r) {
+		return i + size, false
+	}
+	j := skipMarkdownWrapper(text, i+size)
+	if isCJKSentenceTerminator(r) || j == len(text) || isSentenceBreak(text[j]) {
+		return j, true
+	}
+	return i + size, false
 }
 
 // splitSentences splits text on sentence terminators (`.`, `!`, `?`, and
-// their CJK/Arabic/Greek counterparts) and newlines. A Latin/Arabic/Greek
-// terminator only ends a sentence when followed by whitespace, end-of-string,
-// or markdown wrappers leading to either — so URL `?` and abbreviations like
-// `e.g.` don't split. CJK terminators (`？！。`) end a sentence unconditionally
-// since CJK text is conventionally written without inter-sentence spaces.
+// their CJK/Arabic/Greek counterparts) and newlines, via sentenceBoundaryAfter.
 // Each returned sentence retains its terminator and any wrapper characters.
 func splitSentences(text string) []string {
 	var sentences []string
 	start := 0
 	for i := 0; i < len(text); {
-		r, size := utf8.DecodeRuneInString(text[i:])
-		if r == '\n' {
-			sentences = append(sentences, text[start:i])
-			start = i + size
-			i += size
+		next, boundary := sentenceBoundaryAfter(text, i)
+		if !boundary {
+			i = next
 			continue
 		}
-		if isSentenceTerminatorRune(r) {
-			j := skipMarkdownWrapper(text, i+size)
-			if sentenceEndsAt(r, text, j) {
-				sentences = append(sentences, text[start:j])
-				start = j
-				i = j
-				continue
-			}
-		}
-		i += size
+		sentences = append(sentences, text[start:next])
+		start, i = next, next
 	}
 	if start < len(text) {
 		sentences = append(sentences, text[start:])

--- a/core/domain/session/waiting_cue_i18n.go
+++ b/core/domain/session/waiting_cue_i18n.go
@@ -171,3 +171,8 @@ var i18nAnswerPrefixes = []string{
 	// Chinese
 	"因为",
 }
+
+// allAnswerPrefixes is the full set looksLikeAnswer scans against — the
+// English set (answerPrefixes, issue #236) plus i18nAnswerPrefixes above
+// (issue #933), merged once so the hot-path check is a single loop.
+var allAnswerPrefixes = append(append([]string{}, answerPrefixes...), i18nAnswerPrefixes...)

--- a/core/domain/session/waiting_cue_i18n.go
+++ b/core/domain/session/waiting_cue_i18n.go
@@ -50,7 +50,10 @@ var (
 
 	waitingCuePatternsES = []*regexp.Regexp{
 		regexp.MustCompile(`(?i)\b(?:avísame|avíseme)\b`),
-		regexp.MustCompile(`(?i)\b(?:dime|dígame)\b`),
+		// "dime" is excluded — it's also the English coin ("costs a dime",
+		// "turn on a dime"), same collision class as the German "da"/French
+		// "car" fix above. "dígame" (formal, no English collision) is kept.
+		regexp.MustCompile(`(?i)\bdígame\b`),
 		regexp.MustCompile(`(?i)¿?\b(?:podrías|podría)\b`),
 		// "su" (his/her/their/formal-your) is excluded — see the German
 		// "ihr"/"ihre" comment above for why the ambiguous form is dropped.
@@ -93,7 +96,10 @@ var (
 		regexp.MustCompile(`(?i)\bantes de eu\b`),
 		regexp.MustCompile(`(?i)\bassim que você\b`),
 		regexp.MustCompile(`(?i)\bpor favor\s+\w+\b`),
-		regexp.MustCompile(`(?i)\b(?:confirme|verifique|revise|teste)\s+\w+\b`),
+		// "revise" is excluded — it's an actual English verb with the same
+		// meaning ("I'll revise my approach"), not just a lookalike; same
+		// collision class as "dime"/"da"/"car" above.
+		regexp.MustCompile(`(?i)\b(?:confirme|verifique|teste)\s+\w+\b`),
 		regexp.MustCompile(`(?i)\bo que você acha\b`),
 	}
 

--- a/core/domain/session/waiting_cue_i18n.go
+++ b/core/domain/session/waiting_cue_i18n.go
@@ -21,7 +21,7 @@ var (
 		// A. Direct ask
 		regexp.MustCompile(`(?i)\b(?:sag|sagt|sagen sie)\s+(?:mir|uns)\s+bescheid\b`),
 		regexp.MustCompile(`(?i)\blass(?:en sie)?\s+(?:mich|uns)\s+wissen\b`),
-		regexp.MustCompile(`(?i)\bkannst du|könnten sie\b`),
+		regexp.MustCompile(`(?i)\b(?:kannst du|könnten sie)\b`),
 		// B. Approval / review framings. "ihr"/"ihre" (her/their/formal-your)
 		// is deliberately excluded — unlike English "its"/"their" it isn't
 		// lexically distinguishable from formal-address "your" here, so
@@ -39,7 +39,7 @@ var (
 		// comment above), so the scoped "warte auf dein/deine" pattern above
 		// is the only supported form.
 		regexp.MustCompile(`(?i)\bbevor ich\b`),
-		regexp.MustCompile(`(?i)\bsobald du\b|\bsobald sie\b`),
+		regexp.MustCompile(`(?i)\bsobald (?:du|sie)\b`),
 		// D. Curated imperatives
 		regexp.MustCompile(`(?i)\bbitte\s+\w+\b`),
 		regexp.MustCompile(`(?i)\b(?:prüfe|überprüfe|bestätige|teste|schau dir)\s+\w+\b`),
@@ -49,9 +49,9 @@ var (
 	}
 
 	waitingCuePatternsES = []*regexp.Regexp{
-		regexp.MustCompile(`(?i)\bavísame|avíseme\b`),
-		regexp.MustCompile(`(?i)\bdime|dígame\b`),
-		regexp.MustCompile(`(?i)\b¿?podrías|¿?podría\b`),
+		regexp.MustCompile(`(?i)\b(?:avísame|avíseme)\b`),
+		regexp.MustCompile(`(?i)\b(?:dime|dígame)\b`),
+		regexp.MustCompile(`(?i)¿?\b(?:podrías|podría)\b`),
 		// "su" (his/her/their/formal-your) is excluded — see the German
 		// "ihr"/"ihre" comment above for why the ambiguous form is dropped.
 		regexp.MustCompile(`(?i)\besperando tu\b`),
@@ -67,22 +67,22 @@ var (
 	}
 
 	waitingCuePatternsFR = []*regexp.Regexp{
-		regexp.MustCompile(`(?i)\bdis-moi|dites-moi\b`),
-		regexp.MustCompile(`(?i)\bfais-moi savoir|faites-le-moi savoir\b`),
-		regexp.MustCompile(`(?i)\bpourrais-tu|pourriez-vous\b`),
-		regexp.MustCompile(`(?i)\bj'attends ta|j'attends votre\b`),
-		regexp.MustCompile(`(?i)\bprêt pour ta|prêt pour votre\b`),
+		regexp.MustCompile(`(?i)\b(?:dis-moi|dites-moi)\b`),
+		regexp.MustCompile(`(?i)\b(?:fais-moi savoir|faites-le-moi savoir)\b`),
+		regexp.MustCompile(`(?i)\b(?:pourrais-tu|pourriez-vous)\b`),
+		regexp.MustCompile(`(?i)\b(?:j'attends ta|j'attends votre)\b`),
+		regexp.MustCompile(`(?i)\bprêt pour (?:ta|votre)\b`),
 		regexp.MustCompile(`(?i)\bavant que je\b`),
-		regexp.MustCompile(`(?i)\bdès que tu\b|\bdès que vous\b`),
-		regexp.MustCompile(`(?i)\bs'il te plaît|s'il vous plaît\b`),
+		regexp.MustCompile(`(?i)\bdès que (?:tu|vous)\b`),
+		regexp.MustCompile(`(?i)\bs'il (?:te|vous) plaît\b`),
 		regexp.MustCompile(`(?i)\b(?:confirme|vérifie|teste|relis)\s+\w+\b`),
 		regexp.MustCompile(`(?i)\bqu'en penses-tu\b`),
 	}
 
 	waitingCuePatternsPT = []*regexp.Regexp{
-		regexp.MustCompile(`(?i)\bme avise|avisa-me\b`),
-		regexp.MustCompile(`(?i)\bme diga|diga-me\b`),
-		regexp.MustCompile(`(?i)\bpoderia você|você poderia\b`),
+		regexp.MustCompile(`(?i)\b(?:me avise|avisa-me)\b`),
+		regexp.MustCompile(`(?i)\b(?:me diga|diga-me)\b`),
+		regexp.MustCompile(`(?i)\b(?:poderia você|você poderia)\b`),
 		// "sua"/"seu" (his/her/their/formal-your) is excluded here — same
 		// reasoning as the German/Spanish comments above — but kept in the
 		// pattern below, where the trailing "revisão"/"aprovação" (review/

--- a/core/domain/session/waiting_cue_i18n.go
+++ b/core/domain/session/waiting_cue_i18n.go
@@ -1,0 +1,138 @@
+package session
+
+import "regexp"
+
+// Non-English waiting-cue patterns, mirroring the same A–E coverage buckets
+// as waitingCuePatterns (issue #381) for the languages LLM responses are
+// most commonly observed in. See issue #933: the cue detector was English-
+// only, so a turn ending on e.g. "Sag mir Bescheid, bevor ich fortfahre"
+// never registered as waiting.
+//
+// No language detection: all buckets are OR'd together regardless of the
+// text's language, same as the English set. The false-positive surface of a
+// foreign-language phrase appearing inside otherwise-English text (or vice
+// versa) is negligible, and recall matters more than precision here (#381).
+//
+// Coverage is intentionally partial — these are the highest-value phrases
+// per language, not an exhaustive translation of every English pattern.
+// Extend per-language buckets as new false negatives are reported.
+var (
+	waitingCuePatternsDE = []*regexp.Regexp{
+		// A. Direct ask
+		regexp.MustCompile(`(?i)\b(?:sag|sagt|sagen sie)\s+(?:mir|uns)\s+bescheid\b`),
+		regexp.MustCompile(`(?i)\blass(?:en sie)?\s+(?:mich|uns)\s+wissen\b`),
+		regexp.MustCompile(`(?i)\bkannst du|könnten sie\b`),
+		// B. Approval / review framings
+		regexp.MustCompile(`(?i)\bwarte(?:n sie)? auf (?:dein|deine|ihr|ihre)\b`),
+		regexp.MustCompile(`(?i)\bbereit für (?:dein|deine|ihr|ihre) (?:feedback|freigabe|review)\b`),
+		// C. Action gates
+		regexp.MustCompile(`(?i)\bbevor ich\b`),
+		regexp.MustCompile(`(?i)\bsobald du\b|\bsobald sie\b`),
+		regexp.MustCompile(`(?i)\bich warte\b`),
+		// D. Curated imperatives
+		regexp.MustCompile(`(?i)\bbitte\s+\w+\b`),
+		regexp.MustCompile(`(?i)\b(?:prüfe|überprüfe|bestätige|teste|schau dir)\s+\w+\b`),
+		// E. Trailing soft asks
+		regexp.MustCompile(`(?i)\bwas denkst du\b`),
+		regexp.MustCompile(`(?i)\bfeedback\b\s*$`),
+	}
+
+	waitingCuePatternsES = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)\bavísame|avíseme\b`),
+		regexp.MustCompile(`(?i)\bdime|dígame\b`),
+		regexp.MustCompile(`(?i)\b¿?podrías|¿?podría\b`),
+		regexp.MustCompile(`(?i)\besperando tu|esperando su\b`),
+		regexp.MustCompile(`(?i)\blisto para tu|listo para su\b`),
+		regexp.MustCompile(`(?i)\bantes de que (?:yo|nosotros)\b`),
+		regexp.MustCompile(`(?i)\ben cuanto (?:tú|usted)\b`),
+		regexp.MustCompile(`(?i)\bespero tu|espero su\b`),
+		regexp.MustCompile(`(?i)\bpor favor\s+\w+\b`),
+		regexp.MustCompile(`(?i)\b(?:confirma|verifica|revisa|comprueba)\s+\w+\b`),
+		regexp.MustCompile(`(?i)\bqué (?:opinas|piensas)\b`),
+	}
+
+	waitingCuePatternsFR = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)\bdis-moi|dites-moi\b`),
+		regexp.MustCompile(`(?i)\bfais-moi savoir|faites-le-moi savoir\b`),
+		regexp.MustCompile(`(?i)\bpourrais-tu|pourriez-vous\b`),
+		regexp.MustCompile(`(?i)\bj'attends ta|j'attends votre\b`),
+		regexp.MustCompile(`(?i)\bprêt pour ta|prêt pour votre\b`),
+		regexp.MustCompile(`(?i)\bavant que je\b`),
+		regexp.MustCompile(`(?i)\bdès que tu\b|\bdès que vous\b`),
+		regexp.MustCompile(`(?i)\bs'il te plaît|s'il vous plaît\b`),
+		regexp.MustCompile(`(?i)\b(?:confirme|vérifie|teste|relis)\s+\w+\b`),
+		regexp.MustCompile(`(?i)\bqu'en penses-tu\b`),
+	}
+
+	waitingCuePatternsPT = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)\bme avise|avisa-me\b`),
+		regexp.MustCompile(`(?i)\bme diga|diga-me\b`),
+		regexp.MustCompile(`(?i)\bpoderia você|você poderia\b`),
+		regexp.MustCompile(`(?i)\baguardo (?:sua|seu|teu|tua)\b`),
+		regexp.MustCompile(`(?i)\bpronto para (?:sua|seu|teu|tua) (?:revisão|aprovação)\b`),
+		regexp.MustCompile(`(?i)\bantes de eu\b`),
+		regexp.MustCompile(`(?i)\bassim que você\b`),
+		regexp.MustCompile(`(?i)\bpor favor\s+\w+\b`),
+		regexp.MustCompile(`(?i)\b(?:confirme|verifique|revise|teste)\s+\w+\b`),
+		regexp.MustCompile(`(?i)\bo que você acha\b`),
+	}
+
+	// Japanese and Chinese patterns skip the `(?i)` flag (no case folding)
+	// and word boundaries `\b` (CJK scripts have no whitespace-delimited
+	// word boundaries for Go's regexp engine to anchor on).
+	waitingCuePatternsJA = []*regexp.Regexp{
+		regexp.MustCompile(`教えてください`),
+		regexp.MustCompile(`知らせてください|お知らせください`),
+		regexp.MustCompile(`確認してください`),
+		regexp.MustCompile(`確認をお願いします`),
+		regexp.MustCompile(`(?:承認|レビュー)をお願いします`),
+		regexp.MustCompile(`よろしいですか`),
+		regexp.MustCompile(`どう思いますか`),
+	}
+
+	waitingCuePatternsZH = []*regexp.Regexp{
+		regexp.MustCompile(`请告诉我`),
+		regexp.MustCompile(`请(?:确认|检查|核实)`),
+		regexp.MustCompile(`请(?:审核|批准|审阅)`),
+		regexp.MustCompile(`等待(?:您|你)的(?:回复|确认|批准)`),
+		regexp.MustCompile(`你觉得怎么样|您觉得如何`),
+	}
+)
+
+// allWaitingCuePatterns is the full multilingual set ExtractWaitingCue
+// scans against — the English set (waitingCuePatterns, issue #381) plus the
+// per-language buckets above (issue #933).
+var allWaitingCuePatterns = concatWaitingCuePatterns()
+
+func concatWaitingCuePatterns() []*regexp.Regexp {
+	all := make([]*regexp.Regexp, 0,
+		len(waitingCuePatterns)+
+			len(waitingCuePatternsDE)+len(waitingCuePatternsES)+
+			len(waitingCuePatternsFR)+len(waitingCuePatternsPT)+
+			len(waitingCuePatternsJA)+len(waitingCuePatternsZH))
+	all = append(all, waitingCuePatterns...)
+	all = append(all, waitingCuePatternsDE...)
+	all = append(all, waitingCuePatternsES...)
+	all = append(all, waitingCuePatternsFR...)
+	all = append(all, waitingCuePatternsPT...)
+	all = append(all, waitingCuePatternsJA...)
+	all = append(all, waitingCuePatternsZH...)
+	return all
+}
+
+// i18nAnswerPrefixes extend answerPrefixes (the rhetorical-question veto,
+// issue #236) with the top languages' "because/since" equivalents, so a
+// rhetorical Q&A pair in those languages is also correctly skipped rather
+// than misread as a real waiting question.
+var i18nAnswerPrefixes = []string{
+	// German
+	"weil ", "weil,", "da ",
+	// Spanish / Portuguese share "porque"
+	"porque ", "porque,",
+	// French
+	"parce que ", "car ", "car,",
+	// Japanese
+	"なぜなら",
+	// Chinese
+	"因为",
+}

--- a/core/domain/session/waiting_cue_i18n.go
+++ b/core/domain/session/waiting_cue_i18n.go
@@ -22,13 +22,24 @@ var (
 		regexp.MustCompile(`(?i)\b(?:sag|sagt|sagen sie)\s+(?:mir|uns)\s+bescheid\b`),
 		regexp.MustCompile(`(?i)\blass(?:en sie)?\s+(?:mich|uns)\s+wissen\b`),
 		regexp.MustCompile(`(?i)\bkannst du|könnten sie\b`),
-		// B. Approval / review framings
-		regexp.MustCompile(`(?i)\bwarte(?:n sie)? auf (?:dein|deine|ihr|ihre)\b`),
+		// B. Approval / review framings. "ihr"/"ihre" (her/their/formal-your)
+		// is deliberately excluded — unlike English "its"/"their" it isn't
+		// lexically distinguishable from formal-address "your" here, so
+		// including it would reproduce the false-positive class #897 fixed
+		// for English ("Ich warte auf ihre Fertigstellung" about a
+		// background job would otherwise misregister as waiting-on-user).
+		regexp.MustCompile(`(?i)\bwarte(?:n sie)? auf (?:dein|deine)\b`),
 		regexp.MustCompile(`(?i)\bbereit für (?:dein|deine|ihr|ihre) (?:feedback|freigabe|review)\b`),
-		// C. Action gates
+		// C. Action gates. A bare "ich warte" (I'm waiting) catch-all is
+		// deliberately omitted — with no disambiguating object, it would be
+		// as context-free as English's `\bI'?ll wait\b`, which is only safe
+		// there because the exclusion veto (waitingCueExclusions) can
+		// distinguish "its"/"their" from "your"; German has no equivalent
+		// unambiguous non-human pronoun to veto on (see the "ihr"/"ihre"
+		// comment above), so the scoped "warte auf dein/deine" pattern above
+		// is the only supported form.
 		regexp.MustCompile(`(?i)\bbevor ich\b`),
 		regexp.MustCompile(`(?i)\bsobald du\b|\bsobald sie\b`),
-		regexp.MustCompile(`(?i)\bich warte\b`),
 		// D. Curated imperatives
 		regexp.MustCompile(`(?i)\bbitte\s+\w+\b`),
 		regexp.MustCompile(`(?i)\b(?:prüfe|überprüfe|bestätige|teste|schau dir)\s+\w+\b`),
@@ -41,11 +52,15 @@ var (
 		regexp.MustCompile(`(?i)\bavísame|avíseme\b`),
 		regexp.MustCompile(`(?i)\bdime|dígame\b`),
 		regexp.MustCompile(`(?i)\b¿?podrías|¿?podría\b`),
-		regexp.MustCompile(`(?i)\besperando tu|esperando su\b`),
-		regexp.MustCompile(`(?i)\blisto para tu|listo para su\b`),
+		// "su" (his/her/their/formal-your) is excluded — see the German
+		// "ihr"/"ihre" comment above for why the ambiguous form is dropped.
+		regexp.MustCompile(`(?i)\besperando tu\b`),
+		// "su" is excluded from the two patterns below for the same reason
+		// as "esperando su" above.
+		regexp.MustCompile(`(?i)\blisto para tu\b`),
 		regexp.MustCompile(`(?i)\bantes de que (?:yo|nosotros)\b`),
 		regexp.MustCompile(`(?i)\ben cuanto (?:tú|usted)\b`),
-		regexp.MustCompile(`(?i)\bespero tu|espero su\b`),
+		regexp.MustCompile(`(?i)\bespero tu\b`),
 		regexp.MustCompile(`(?i)\bpor favor\s+\w+\b`),
 		regexp.MustCompile(`(?i)\b(?:confirma|verifica|revisa|comprueba)\s+\w+\b`),
 		regexp.MustCompile(`(?i)\bqué (?:opinas|piensas)\b`),
@@ -68,7 +83,12 @@ var (
 		regexp.MustCompile(`(?i)\bme avise|avisa-me\b`),
 		regexp.MustCompile(`(?i)\bme diga|diga-me\b`),
 		regexp.MustCompile(`(?i)\bpoderia você|você poderia\b`),
-		regexp.MustCompile(`(?i)\baguardo (?:sua|seu|teu|tua)\b`),
+		// "sua"/"seu" (his/her/their/formal-your) is excluded here — same
+		// reasoning as the German/Spanish comments above — but kept in the
+		// pattern below, where the trailing "revisão"/"aprovação" (review/
+		// approval) disambiguates: those are user-facing actions a
+		// background job wouldn't plausibly be described as awaiting.
+		regexp.MustCompile(`(?i)\baguardo (?:teu|tua)\b`),
 		regexp.MustCompile(`(?i)\bpronto para (?:sua|seu|teu|tua) (?:revisão|aprovação)\b`),
 		regexp.MustCompile(`(?i)\bantes de eu\b`),
 		regexp.MustCompile(`(?i)\bassim que você\b`),

--- a/core/domain/session/waiting_cue_i18n.go
+++ b/core/domain/session/waiting_cue_i18n.go
@@ -144,13 +144,22 @@ func concatWaitingCuePatterns() []*regexp.Regexp {
 // issue #236) with the top languages' "because/since" equivalents, so a
 // rhetorical Q&A pair in those languages is also correctly skipped rather
 // than misread as a real waiting question.
+//
+// German "da" ("since") and French "car" ("because") are deliberately
+// excluded — both are also common English words/names ("Da Vinci", "Car
+// trouble aside, ..."), and looksLikeAnswer lowercases before the prefix
+// check, so case can't disambiguate them. Unlike the ambiguous possessives
+// in waitingCuePatterns*, there's no unambiguous fallback token that keeps
+// German/French recall for the single-word form, so those two are dropped
+// entirely; "weil"/"parce que" (unambiguous, no English collision) still
+// cover the common case.
 var i18nAnswerPrefixes = []string{
 	// German
-	"weil ", "weil,", "da ",
+	"weil ", "weil,",
 	// Spanish / Portuguese share "porque"
 	"porque ", "porque,",
 	// French
-	"parce que ", "car ", "car,",
+	"parce que ",
 	// Japanese
 	"なぜなら",
 	// Chinese

--- a/core/domain/session/waiting_cue_normalize.go
+++ b/core/domain/session/waiting_cue_normalize.go
@@ -31,6 +31,18 @@ var combiningDiacriticMarks = map[rune]map[rune]rune{
 // for the cheap strings.ContainsAny prefilter in foldCombiningDiacritics.
 const combiningDiacriticMarksCutset = "̧̀́̂̃̈"
 
+// composeDiacritic looks up the precomposed rune for a base letter followed
+// by a combining mark, flattening the two-level map lookup into a single
+// ok check for foldCombiningDiacritics.
+func composeDiacritic(base, mark rune) (rune, bool) {
+	marks, ok := combiningDiacriticMarks[mark]
+	if !ok {
+		return 0, false
+	}
+	composed, ok := marks[base]
+	return composed, ok
+}
+
 // foldCombiningDiacritics composes NFD base-letter+combining-mark pairs
 // found in combiningDiacriticMarks into their precomposed rune, leaving
 // everything else (including base+mark combinations not in the table)
@@ -42,17 +54,14 @@ func foldCombiningDiacritics(s string) string {
 	runes := []rune(s)
 	out := make([]rune, 0, len(runes))
 	for i := 0; i < len(runes); i++ {
-		r := runes[i]
 		if i+1 < len(runes) {
-			if marks, ok := combiningDiacriticMarks[runes[i+1]]; ok {
-				if composed, ok := marks[r]; ok {
-					out = append(out, composed)
-					i++
-					continue
-				}
+			if composed, ok := composeDiacritic(runes[i], runes[i+1]); ok {
+				out = append(out, composed)
+				i++
+				continue
 			}
 		}
-		out = append(out, r)
+		out = append(out, runes[i])
 	}
 	return string(out)
 }

--- a/core/domain/session/waiting_cue_normalize.go
+++ b/core/domain/session/waiting_cue_normalize.go
@@ -1,0 +1,58 @@
+package session
+
+import "strings"
+
+// combiningDiacriticMarks are the Unicode "combining diacritical marks"
+// (NFD) this package composes back onto their preceding base letter before
+// pattern matching. See issue #933 code review: the i18n cue/answer-prefix
+// patterns are written with precomposed (NFC) accented characters (é, ç, ã,
+// ...); Go's regexp package does no Unicode normalization, so if a
+// transcript source ever emitted NFD text — "e" + U+0301 COMBINING ACUTE
+// ACCENT instead of the single precomposed rune "é" — every accented
+// pattern would silently fail to match.
+//
+// This composes only the specific base+mark combinations the es/fr/pt
+// patterns actually use, rather than pulling in golang.org/x/text/unicode/norm
+// for full NFC normalization: that package would ratchet several unrelated
+// transitive dependency versions across the whole workspace (go.work.sum is
+// shared by every module in this repo) just to defend against an edge case
+// that hasn't been observed in practice — LLM output is effectively always
+// NFC already.
+var combiningDiacriticMarks = map[rune]map[rune]rune{
+	0x0300: {'a': 'à', 'e': 'è', 'i': 'ì', 'o': 'ò', 'u': 'ù', 'A': 'À', 'E': 'È', 'I': 'Ì', 'O': 'Ò', 'U': 'Ù'},
+	0x0301: {'a': 'á', 'e': 'é', 'i': 'í', 'o': 'ó', 'u': 'ú', 'A': 'Á', 'E': 'É', 'I': 'Í', 'O': 'Ó', 'U': 'Ú'},
+	0x0302: {'a': 'â', 'e': 'ê', 'i': 'î', 'o': 'ô', 'u': 'û', 'A': 'Â', 'E': 'Ê', 'I': 'Î', 'O': 'Ô', 'U': 'Û'},
+	0x0303: {'a': 'ã', 'n': 'ñ', 'o': 'õ', 'A': 'Ã', 'N': 'Ñ', 'O': 'Õ'},
+	0x0308: {'a': 'ä', 'e': 'ë', 'i': 'ï', 'o': 'ö', 'u': 'ü', 'A': 'Ä', 'E': 'Ë', 'I': 'Ï', 'O': 'Ö', 'U': 'Ü'},
+	0x0327: {'c': 'ç', 'C': 'Ç'},
+}
+
+// combiningDiacriticMarksCutset is combiningDiacriticMarks' keys as a string,
+// for the cheap strings.ContainsAny prefilter in foldCombiningDiacritics.
+const combiningDiacriticMarksCutset = "̧̀́̂̃̈"
+
+// foldCombiningDiacritics composes NFD base-letter+combining-mark pairs
+// found in combiningDiacriticMarks into their precomposed rune, leaving
+// everything else (including base+mark combinations not in the table)
+// untouched.
+func foldCombiningDiacritics(s string) string {
+	if !strings.ContainsAny(s, combiningDiacriticMarksCutset) {
+		return s
+	}
+	runes := []rune(s)
+	out := make([]rune, 0, len(runes))
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		if i+1 < len(runes) {
+			if marks, ok := combiningDiacriticMarks[runes[i+1]]; ok {
+				if composed, ok := marks[r]; ok {
+					out = append(out, composed)
+					i++
+					continue
+				}
+			}
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}

--- a/core/domain/session/waiting_cue_test.go
+++ b/core/domain/session/waiting_cue_test.go
@@ -2,15 +2,36 @@ package session
 
 import "testing"
 
+// boolCueCase is the shared table shape for the four suites in this file
+// that assert a text-to-bool classification; runBoolCueCases is their
+// shared harness, so each suite only declares its case table and the
+// function under test.
+type boolCueCase struct {
+	name string
+	text string
+	want bool
+}
+
+func runBoolCueCases(t *testing.T, cases []boolCueCase, detect func(string) bool) {
+	t.Helper()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := detect(c.text); got != c.want {
+				t.Errorf("text=%q: got %v, want %v", c.text, got, c.want)
+			}
+		})
+	}
+}
+
+func isWaitingForUserInput(text string) bool {
+	return (&SessionMetrics{LastAssistantText: text}).IsWaitingForUserInput()
+}
+
 func TestIsWaitingForUserInput_TrailingMarkdown(t *testing.T) {
 	// Models routinely wrap questions in markdown; the literal last
 	// byte is often a delimiter, not '?'. Pin that the classifier
 	// strips trailing markdown noise before the check.
-	cases := []struct {
-		name string
-		text string
-		want bool
-	}{
+	cases := []boolCueCase{
 		{"plain", "What now?", true},
 		{"trailing whitespace", "What now?   \n", true},
 		{"bold", "**What now?**", true},
@@ -44,14 +65,7 @@ func TestIsWaitingForUserInput_TrailingMarkdown(t *testing.T) {
 		{"Arabic question mark", "هل تريد أن أتابع؟", true},
 		{"Greek question mark", "Θέλετε να συνεχίσω;", true},
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			m := &SessionMetrics{LastAssistantText: c.text}
-			if got := m.IsWaitingForUserInput(); got != c.want {
-				t.Errorf("text=%q: got %v, want %v", c.text, got, c.want)
-			}
-		})
-	}
+	runBoolCueCases(t, cases, isWaitingForUserInput)
 }
 
 func TestExtractQuestionSnippet(t *testing.T) {
@@ -108,11 +122,7 @@ func TestExtractWaitingCue(t *testing.T) {
 	// Issue #381: agents often end a turn with an imperative or implicit
 	// cue rather than a literal `?`. ExtractWaitingCue covers that gap.
 	// Each case mirrors a row in the coverage matrix.
-	cases := []struct {
-		name string
-		text string
-		want bool // true = a cue is detected
-	}{
+	cases := []boolCueCase{
 		// 24 of the 30 matrix rows from issue #381; the remaining 6 are
 		// `?`-bearing and stay the responsibility of ExtractQuestionSnippet
 		// (covered by TestExtractQuestionSnippet).
@@ -201,14 +211,7 @@ func TestExtractWaitingCue(t *testing.T) {
 		{"neg en: 'turn on a dime' does not trigger Spanish dime-cue", "It could turn on a dime.", false},
 		{"neg en: 'I'll revise' does not trigger Portuguese revise-cue", "I'll revise my approach and continue.", false},
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := ExtractWaitingCue(c.text) != ""
-			if got != c.want {
-				t.Errorf("ExtractWaitingCue(%q) detected=%v, want %v (snippet=%q)", c.text, got, c.want, ExtractWaitingCue(c.text))
-			}
-		})
-	}
+	runBoolCueCases(t, cases, func(text string) bool { return ExtractWaitingCue(text) != "" })
 }
 
 func TestIsWaitingForUserInput_ImperativeCues(t *testing.T) {
@@ -216,11 +219,7 @@ func TestIsWaitingForUserInput_ImperativeCues(t *testing.T) {
 	// detector, turns that end with an imperative gate now register as
 	// waiting. Sample the most representative shapes from issue #381 so a
 	// future regression at either layer surfaces here too.
-	cases := []struct {
-		name string
-		text string
-		want bool
-	}{
+	cases := []boolCueCase{
 		{"take a look + let me know", "Take a look at the icon and let me know if it's right.", true},
 		{"ready for your review", "Pushed PR #379 as draft. Ready for your review.", true},
 		{"your call", "Two options — A) revert, B) re-roll. Your call.", true},
@@ -234,12 +233,5 @@ func TestIsWaitingForUserInput_ImperativeCues(t *testing.T) {
 		{"all green pushed stays ready", "All green. Pushed to main.", false},
 		{"confirmed past tense stays ready", "Confirmed: the migration ran cleanly.", false},
 	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			m := &SessionMetrics{LastAssistantText: c.text}
-			if got := m.IsWaitingForUserInput(); got != c.want {
-				t.Errorf("text=%q: got %v, want %v", c.text, got, c.want)
-			}
-		})
-	}
+	runBoolCueCases(t, cases, isWaitingForUserInput)
 }

--- a/core/domain/session/waiting_cue_test.go
+++ b/core/domain/session/waiting_cue_test.go
@@ -39,6 +39,10 @@ func TestIsWaitingForUserInput_TrailingMarkdown(t *testing.T) {
 		{"joke with Because answer across newline", "Why do programmers prefer dark mode?\nBecause light attracts bugs.", false},
 		{"Since-prefixed answer is rhetorical", "Why bother? Since the cache already has it, we skip.", false},
 		{"rhetorical Q followed by real Q", "Why? Because reasons. Should I proceed?", true},
+		// Non-Latin question marks — issue #933.
+		{"CJK full-width question mark", "続けますか？", true},
+		{"Arabic question mark", "هل تريد أن أتابع؟", true},
+		{"Greek question mark", "Θέλετε να συνεχίσω;", true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -74,6 +78,15 @@ func TestExtractQuestionSnippet(t *testing.T) {
 		{"joke with Because across newline returns empty", "Why do programmers prefer dark mode?\nBecause light attracts bugs.", ""},
 		{"rhetorical Q followed by real Q returns the real one", "Why? Because reasons. Should I proceed?", "Should I proceed?"},
 		{"non-answer continuation is not rhetorical", "What would you like? In the meantime I'll move on.", "What would you like?"},
+		// Non-Latin question marks — issue #933.
+		{"CJK full-width question mark", "続けますか？", "続けますか？"},
+		{"CJK question with trailing status, no space (no inter-sentence spaces)", "続けますか？念のため確認します。", "続けますか？"},
+		{"Arabic question mark", "هل تريد أن أتابع؟", "هل تريد أن أتابع؟"},
+		{"Greek question mark", "Θέλετε να συνεχίσω;", "Θέλετε να συνεχίσω;"},
+		{"CJK question wrapped in bold markdown", "**続けますか？**", "**続けますか？**"},
+		// Rhetorical Q&A veto in other languages — issue #933.
+		{"de: rhetorical weil-answer returns empty", "Warum? Weil der Cache das schon hat.", ""},
+		{"es: rhetorical porque-answer returns empty", "¿Por qué? Porque el caché ya lo tiene.", ""},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -144,6 +157,21 @@ func TestExtractWaitingCue(t *testing.T) {
 		{"neg wait for background agent (its)", "The Go agent is doing significant interface-renaming work — I'll wait for its completion notification before touching any Go/JS files myself.", false},
 		{"neg wait for background agents (their)", "The Go and JS agents are still running — I'll wait for their completion before merging.", false},
 		{"neg wait for it", "The background job is almost done — I'll wait for it to finish before continuing.", false},
+
+		// Non-English cue patterns — issue #933.
+		{"de: sag mir bescheid", "Sag mir Bescheid, bevor ich fortfahre.", true},
+		{"de: bitte + verb", "Bitte prüfe die Änderungen.", true},
+		{"es: avísame", "Avísame si quieres que continúe.", true},
+		{"es: por favor + verb", "Por favor confirma el despliegue.", true},
+		{"fr: dis-moi", "Dis-moi si tu veux que je continue.", true},
+		{"fr: s'il te plaît + verb", "S'il te plaît vérifie le diff.", true},
+		{"pt: me avise", "Me avise se quiser que eu continue.", true},
+		{"pt: por favor + verb", "Por favor confirme o deploy.", true},
+		{"ja: kakunin shite kudasai", "変更を確認してください。", true},
+		{"zh: qing quren", "请确认部署是否正确。", true},
+		// Non-English negatives — plain statements must not trigger.
+		{"neg de: statement", "Ich habe die Änderungen vorgenommen.", false},
+		{"neg fr: statement", "J'ai terminé les modifications.", false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/core/domain/session/waiting_cue_test.go
+++ b/core/domain/session/waiting_cue_test.go
@@ -176,6 +176,12 @@ func TestExtractWaitingCue(t *testing.T) {
 		{"pt: por favor + verb", "Por favor confirme o deploy.", true},
 		{"ja: kakunin shite kudasai", "変更を確認してください。", true},
 		{"zh: qing quren", "请确认部署是否正确。", true},
+		// NFD-decomposed (combining-mark) input — issue #933 code review.
+		// The i18n patterns use precomposed (NFC) accented runes; a
+		// transcript source emitting NFD text (base letter + combining
+		// mark as separate runes) must still match after foldCombiningDiacritics.
+		{"es: NFD-decomposed avísame still matches", "Avísame si quieres que continúe.", true},
+		{"fr: NFD-decomposed plaît still matches", "S'il te plaît vérifie le diff.", true},
 		// Non-English negatives — plain statements must not trigger.
 		{"neg de: statement", "Ich habe die Änderungen vorgenommen.", false},
 		{"neg fr: statement", "J'ai terminé les modifications.", false},

--- a/core/domain/session/waiting_cue_test.go
+++ b/core/domain/session/waiting_cue_test.go
@@ -87,6 +87,13 @@ func TestExtractQuestionSnippet(t *testing.T) {
 		// Rhetorical Q&A veto in other languages — issue #933.
 		{"de: rhetorical weil-answer returns empty", "Warum? Weil der Cache das schon hat.", ""},
 		{"es: rhetorical porque-answer returns empty", "¿Por qué? Porque el caché ya lo tiene.", ""},
+		// Cross-language word collisions in the rhetorical veto — issue #933
+		// code review. German "da" ("since") and French "car" ("because")
+		// are also common English words/names; a bare-prefix veto on them
+		// would wrongly suppress a real English question followed by an
+		// unrelated sentence that happens to start with the same word.
+		{"en: 'Da Vinci' does not trigger German da-veto", "Should we proceed? Da Vinci's sketches are relevant background.", "Should we proceed?"},
+		{"en: 'Car trouble' does not trigger French car-veto", "What broke the build? Car analogies aside, let's debug.", "What broke the build?"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/core/domain/session/waiting_cue_test.go
+++ b/core/domain/session/waiting_cue_test.go
@@ -172,6 +172,14 @@ func TestExtractWaitingCue(t *testing.T) {
 		// Non-English negatives — plain statements must not trigger.
 		{"neg de: statement", "Ich habe die Änderungen vorgenommen.", false},
 		{"neg fr: statement", "J'ai terminé les modifications.", false},
+		// Ambiguous formal-possessive false positives — issue #933 code
+		// review. "ihre"/"su"/"sua" mean her/their/formal-your all at once
+		// in these languages (unlike English "its"/"their"), so a background
+		// job's completion described with the formal possessive must not be
+		// misread as addressed to the user, mirroring #897 for English.
+		{"neg de: warte auf ihre (ambiguous, background job)", "Der andere Agent arbeitet noch. Ich warte auf ihre Fertigstellung.", false},
+		{"neg es: esperando su (ambiguous, background job)", "El otro agente sigue trabajando — estoy esperando su finalización.", false},
+		{"neg pt: aguardo sua (ambiguous, background job)", "O outro agente ainda está rodando — aguardo sua finalização.", false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/core/domain/session/waiting_cue_test.go
+++ b/core/domain/session/waiting_cue_test.go
@@ -193,6 +193,13 @@ func TestExtractWaitingCue(t *testing.T) {
 		{"neg de: warte auf ihre (ambiguous, background job)", "Der andere Agent arbeitet noch. Ich warte auf ihre Fertigstellung.", false},
 		{"neg es: esperando su (ambiguous, background job)", "El otro agente sigue trabajando — estoy esperando su finalización.", false},
 		{"neg pt: aguardo sua (ambiguous, background job)", "O outro agente ainda está rodando — aguardo sua finalização.", false},
+		// Further cross-language word collisions — issue #933, found by an
+		// independent Opus review pass. Spanish "dime" (tell me) is also the
+		// English coin; Portuguese "revise" is literally an English verb
+		// with the same meaning, not just a lookalike.
+		{"neg en: 'a dime' does not trigger Spanish dime-cue", "The fix costs a dime.", false},
+		{"neg en: 'turn on a dime' does not trigger Spanish dime-cue", "It could turn on a dime.", false},
+		{"neg en: 'I'll revise' does not trigger Portuguese revise-cue", "I'll revise my approach and continue.", false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `ExtractQuestionSnippet` and `splitSentences` only recognized the ASCII `?` byte — full-width `？` (CJK), `؟` (Arabic), and the Greek question mark `;` (U+037E) never registered as a question terminator. Both are now rune-based and recognize all four.
- `ExtractWaitingCue`'s imperative/implicit waiting-cue patterns were English-only. Added per-language pattern buckets (de/es/fr/pt/ja/zh) in a new `waiting_cue_i18n.go`, OR'd into the existing English set with the same recall-over-precision stance as #381.
- Extended the rhetorical-Q&A veto's `answerPrefixes` with de/es/fr/ja/zh equivalents of "because/since" so the false-positive suppression from #236 also works cross-language.

Fixes #933.

## Test plan
- [x] `go test ./core/domain/session/... -v` — all existing + new i18n fixtures pass (CJK/Arabic/Greek question marks, non-English cue patterns, non-English rhetorical veto)
- [x] `go test ./core/... -race -count=1` — full suite green
- [x] `tools/preflight.sh` — all gates pass (gofmt, core tests, web suites, ARS, security scan)