### PR TITLE
fix(session): arm background-liveness probe before ready→working force-bounce

### DIFF
--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -129,6 +129,78 @@ func TestSessionDetector_BackgroundProcess_HoldsWorkingThenReady(t *testing.T) {
 	<-done
 }
 
+// A session already `ready` (e.g. a prior background job just finished and
+// settled it) that then shows a *fresh* background spawn on the very next
+// activity event must be pulled back to working and held there while that new
+// process is alive — not skip the liveness probe because the pass started
+// from `ready`. Reproduces issue #937: a retried `git push -u
+// run_in_background:true` launched right after the session had settled ready
+// was silently invisible to the liveness gate, and the session bounced
+// ready→working→ready in the same pass despite the push still running.
+func TestSessionDetector_BackgroundProcess_FreshSpawnFromReady_HoldsWorking(t *testing.T) {
+	const sid = "bg3"
+	const path = "/home/.claude/projects/-Users-test/bg3.jsonl"
+
+	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		return &session.SessionMetrics{
+			LastEventType:            "turn_done",
+			BackgroundProcessCount:   1,
+			BackgroundProcessOutputs: []string{"/tmp/x/tasks/retry.output"},
+		}, nil
+	}}
+
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	repo.states[sid] = &session.SessionState{
+		SessionID:      sid,
+		State:          session.StateReady,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	rec := &mockRecorder{}
+	det.SetRecorder(rec)
+
+	var probeLive atomic.Bool
+	probeLive.Store(true)
+	det.SetBackgroundProbeForTest(func(paths []string) bool {
+		return probeLive.Load()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      sid,
+		ProjectDir:     "-Users-test",
+		TranscriptPath: path,
+		Terminal:       false,
+	}
+	time.Sleep(250 * time.Millisecond) // allow the async probe + any self-trigger to settle
+	if n := readyTransitions(rec, sid); n != 0 {
+		t.Fatalf("session flipped to ready %d time(s) while its freshly-spawned background process is alive", n)
+	}
+
+	// Background process exits — probe now reports it gone → session goes ready.
+	probeLive.Store(false)
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      sid,
+		ProjectDir:     "-Users-test",
+		TranscriptPath: path,
+		Terminal:       true,
+	}
+	waitForReadyTransition(t, rec, sid)
+
+	cancel()
+	<-done
+}
+
 // A dead probe verdict must also purge the processes from the tailer's open
 // set and ledger — they died without a transcript-observable termination, and
 // the persisted entries would otherwise resurrect as phantom open processes

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -515,6 +515,26 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 
 	transcriptGrew := d.observeTranscriptGrowth(state, ev)
 
+	// Short-circuit when this pass consumed transcript content but produced
+	// no state-relevant change — e.g. Claude Code's post-turn
+	// `system/away_summary` recap, which the parser marks Skip=true. The
+	// force-bounce below would otherwise see the stale LastEventType from
+	// the prior turn_done and flip a ready session back to working
+	// (issue #329).
+	skipClassification := state.Metrics != nil && state.Metrics.NoSubstantiveActivity
+
+	// Bounce a ready session back to working on fresh activity BEFORE the
+	// background-liveness probe below, which is gated on state==working
+	// (issue #445) and would otherwise see this pass's stale `ready` and
+	// clear/skip the probe — silently dropping the hold for a background
+	// process (e.g. a retried `git push`) launched right after the session
+	// had settled to ready. See issue #937. Skipped in lockstep with
+	// classifyAndTransition below so a no-substantive-activity pass still
+	// can't force the bounce (issue #329).
+	if !skipClassification {
+		d.forceReadyToWorkingIfActive(state, ev)
+	}
+
 	// Probe Bash background-process liveness (run_in_background). Must run
 	// after RefreshOnActivity (which recomputes metrics, clearing the flag)
 	// and before ClassifyState (whose IsAgentDone check reads it). Gated on
@@ -537,15 +557,9 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 
 	d.recordTaskDeltas(id, ev, state)
 
-	// Short-circuit when this pass consumed transcript content but produced
-	// no state-relevant change — e.g. Claude Code's post-turn
-	// `system/away_summary` recap, which the parser marks Skip=true. The
-	// force-bounce below would otherwise see the stale LastEventType from
-	// the prior turn_done and flip a ready session back to working
-	// (issue #329). Still record this as activity (LastEvent / EventCount /
-	// UpdatedAt / broadcast) so the UI's "last activity" stays fresh —
-	// just don't re-run the state machine.
-	skipClassification := state.Metrics != nil && state.Metrics.NoSubstantiveActivity
+	// Still record this pass as activity (LastEvent / EventCount / UpdatedAt /
+	// broadcast) below even when classification is skipped, so the UI's
+	// "last activity" stays fresh — just don't re-run the state machine.
 	if !skipClassification {
 		d.classifyAndTransition(state, ev)
 	}
@@ -699,12 +713,8 @@ func (d *SessionDetector) recordTaskDeltas(id agent.Identity, ev agent.Event, st
 // when this pass's metrics show substantive activity (see
 // processActivityLocked's skipClassification guard).
 func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev agent.Event) {
-	// Force ready→working when metrics show activity so ClassifyState can
-	// properly detect the working→ready transition. Without this, sessions
-	// that start as ready (initial state) and whose first activity event
-	// already shows IsAgentDone()=true would stay ready with no transition
-	// broadcast — the UI would never see the "agent finished" event.
-	d.forceReadyToWorkingIfActive(state, ev)
+	// Ready→working (if applicable) already ran in processActivityLocked,
+	// before applyBackgroundLiveness — see that call site.
 
 	// Overlay hook-based permission-pending signal onto metrics. Must happen
 	// after RefreshOnActivity (which recomputes metrics from the transcript)
@@ -747,8 +757,10 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 
 // forceReadyToWorkingIfActive bounces a ready session straight to working
 // when its freshly refreshed metrics show activity, so ClassifyState can
-// then detect a genuine working→ready transition on this same pass. See
-// classifyAndTransition's call site for why this matters.
+// then detect a genuine working→ready transition on this same pass, and so
+// the background-liveness probe (see processActivityLocked's call site)
+// evaluates against this pass's effective state rather than the prior
+// pass's stale `ready`.
 func (d *SessionDetector) forceReadyToWorkingIfActive(state *session.SessionState, ev agent.Event) {
 	if state.State != session.StateReady || state.Metrics == nil || state.Metrics.LastEventType == "" {
 		return


### PR DESCRIPTION
## Summary

Fixes #937. A session that had settled to `ready` (e.g. a prior backgrounded
process finished/failed) and then launches a *fresh* `run_in_background`
command on its very next activity event never got the liveness hold that
should keep it `working` until that new process exits.

## Root cause

`processActivityLocked` called `applyBackgroundLiveness` (the probe that
holds a session `working` while its Bash `run_in_background` process is
still alive — issue #445) *before* the ready→working force-bounce
(`forceReadyToWorkingIfActive`, which used to live inside
`classifyAndTransition`, called after the probe). `applyBackgroundLiveness`
is gated on `state.State == StateWorking` (deliberately, so it never
resurrects a session the user already cancelled). So when a background spawn
event arrived while the session was still `ready` from the previous pass,
the probe's gate saw the stale `ready`, skipped arming, and cleared
tracking — before the force-bounce ever flipped the session to `working`.
The session would bounce `ready → working → ready` within the same pass
despite the newly-launched background process still running.

This is exactly the failure mode that produced #937's evidence: a session
retried a `git push` in the background right after it had settled to ready
(the first push attempt had failed), and the daemon showed it as `ready`
while the push kept running for several more minutes.

## Fix

Hoist the ready→working force-bounce to run before the liveness probe,
gated in lockstep with `classifyAndTransition`'s existing
`NoSubstantiveActivity` skip (issue #329) so an `away_summary` recap still
can't trigger it.

## Test plan

- [x] New regression test `TestSessionDetector_BackgroundProcess_FreshSpawnFromReady_HoldsWorking` — verified it fails without the fix and passes with it.
- [x] `go test ./core/... -race -count=1 -p 1` passes (one flaky, known pre-existing test confirmed independently flaky, unrelated to this change).
- [x] `tools/preflight.sh`-equivalent pre-push gate passed on push.