### PR TITLE
fix(services): stop racy direct SessionState read in flaky test

### DIFF
--- a/core/application/services/session_detector_subagent_test.go
+++ b/core/application/services/session_detector_subagent_test.go
@@ -738,11 +738,13 @@ func TestSessionDetector_ParentNotAffected_WhenNoChildren(t *testing.T) {
 		TranscriptPath: "/home/.claude/projects/-Users-test/solo1.jsonl",
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	waitForSessionState(repo, "solo1", session.StateReady, 500*time.Millisecond)
 
-	state, _ := repo.Load("solo1")
-	if state.State != session.StateReady {
-		t.Errorf("state: got %q, want ready (no children, turn done)", state.State)
+	repo.mu.Lock()
+	got := repo.lastSavedState["solo1"]
+	repo.mu.Unlock()
+	if got != session.StateReady {
+		t.Errorf("state: got %q, want ready (no children, turn done)", got)
 	}
 
 	cancel()


### PR DESCRIPTION
## Summary
- Fixes #942: `TestSessionDetector_ParentNotAffected_WhenNoChildren` read `state.State` directly off the shared `*session.SessionState` pointer returned by `mockRepo.Load()` right after a fixed 50ms sleep, racing the detector's own goroutine mid-transition in `applyStateTransition`.
- Switches to `waitForSessionState` + the repo's lock-protected `lastSavedState` snapshot (the pattern already used by every other test in this package that needs to observe async detector state), instead of a racy direct field read.
- Test-only change — no production code touched.

## Test plan
- [x] `go test ./application/services/... -run TestSessionDetector_ParentNotAffected_WhenNoChildren -race -count=20` — all pass, no more data race
- [x] `go test ./application/services/... -race -count=3` — full package clean
- [x] `tools/preflight.sh` (via pre-push hook) — all gates pass, including the full `-race` suite that previously flaked on this exact test

🤖 Generated with [Claude Code](https://claude.com/claude-code)