### PR TITLE
refactor(core,swift): bundle constructor/helper params into options structs

### DIFF
--- a/core/adapters/inbound/agents/opencode/watcher_test.go
+++ b/core/adapters/inbound/agents/opencode/watcher_test.go
@@ -111,13 +111,23 @@ func insertMessage(t *testing.T, db *sql.DB, id, sessionID, role, modelID string
 	}
 }
 
+// partRow bundles the column values for one row inserted by insertPart.
+type partRow struct {
+	id        string
+	sessionID string
+	messageID string
+	partType  string
+	data      string
+	ts        int64
+}
+
 // insertPart inserts a part row.
-func insertPart(t *testing.T, db *sql.DB, id, sessionID, messageID, partType, data string, ts int64) {
+func insertPart(t *testing.T, db *sql.DB, row partRow) {
 	t.Helper()
 	_, err := db.Exec(
 		`INSERT INTO part (id, session_id, message_id, type, data, time_created, time_updated)
 		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		id, sessionID, messageID, partType, data, ts, ts,
+		row.id, row.sessionID, row.messageID, row.partType, row.data, row.ts, row.ts,
 	)
 	if err != nil {
 		t.Fatalf("insert part: %v", err)
@@ -149,7 +159,7 @@ func TestScanSessions_NewSession(t *testing.T) {
 	now := time.Now().UnixMilli()
 	insertSession(t, db, "ses_abc", "/home/user/project", now, "")
 	insertMessage(t, db, "msg_1", "ses_abc", "user", "claude-sonnet", now)
-	insertPart(t, db, "part_1", "ses_abc", "msg_1", "text", `{"text":"hello"}`, now)
+	insertPart(t, db, partRow{id: "part_1", sessionID: "ses_abc", messageID: "msg_1", partType: "text", data: `{"text":"hello"}`, ts: now})
 
 	w.scanSessions()
 
@@ -180,7 +190,7 @@ func TestScanSessions_Activity(t *testing.T) {
 	now := time.Now().UnixMilli()
 	insertSession(t, db, "ses_act", "/tmp", now, "")
 	insertMessage(t, db, "msg_a", "ses_act", "assistant", "gpt-4", now)
-	insertPart(t, db, "part_a", "ses_act", "msg_a", "text", `{"text":"first"}`, now)
+	insertPart(t, db, partRow{id: "part_a", sessionID: "ses_act", messageID: "msg_a", partType: "text", data: `{"text":"first"}`, ts: now})
 
 	// First scan: discover session.
 	w.scanSessions()
@@ -188,7 +198,7 @@ func TestScanSessions_Activity(t *testing.T) {
 
 	// Add a new part with later timestamp.
 	later := now + 1000
-	insertPart(t, db, "part_b", "ses_act", "msg_a", "text", `{"text":"second"}`, later)
+	insertPart(t, db, partRow{id: "part_b", sessionID: "ses_act", messageID: "msg_a", partType: "text", data: `{"text":"second"}`, ts: later})
 
 	w.scanSessions()
 
@@ -265,8 +275,8 @@ func TestScanSessions_CursorRace(t *testing.T) {
 	insertMessage(t, db, "msg_r2", "ses_race", "assistant", "gpt-4", now)
 
 	// Two parts with the SAME millisecond timestamp.
-	insertPart(t, db, "part_r1", "ses_race", "msg_r1", "text", `{"text":"a"}`, now)
-	insertPart(t, db, "part_r2", "ses_race", "msg_r2", "text", `{"text":"b"}`, now)
+	insertPart(t, db, partRow{id: "part_r1", sessionID: "ses_race", messageID: "msg_r1", partType: "text", data: `{"text":"a"}`, ts: now})
+	insertPart(t, db, partRow{id: "part_r2", sessionID: "ses_race", messageID: "msg_r2", partType: "text", data: `{"text":"b"}`, ts: now})
 
 	// First scan: discover both parts at once.
 	w.scanSessions()
@@ -286,7 +296,7 @@ func TestScanSessions_CursorRace(t *testing.T) {
 	}
 
 	// Add a third part with the SAME timestamp (same-ms race scenario).
-	insertPart(t, db, "part_r3", "ses_race", "msg_r1", "text", `{"text":"c"}`, now)
+	insertPart(t, db, partRow{id: "part_r3", sessionID: "ses_race", messageID: "msg_r1", partType: "text", data: `{"text":"c"}`, ts: now})
 
 	w.scanSessions()
 	events = collectEvents(ch, 500*time.Millisecond)
@@ -308,7 +318,7 @@ func TestScanSessions_NoDupOnSecondScan(t *testing.T) {
 	now := time.Now().UnixMilli()
 	insertSession(t, db, "ses_nodup", "/tmp", now, "")
 	insertMessage(t, db, "msg_nd", "ses_nodup", "user", "gpt-4", now)
-	insertPart(t, db, "part_nd", "ses_nodup", "msg_nd", "text", `{"text":"hi"}`, now)
+	insertPart(t, db, partRow{id: "part_nd", sessionID: "ses_nodup", messageID: "msg_nd", partType: "text", data: `{"text":"hi"}`, ts: now})
 
 	// Two scans without any new parts.
 	w.scanSessions()
@@ -484,7 +494,7 @@ func TestScanSessions_EmitsWhenProcessBecomesLive(t *testing.T) {
 	now := time.Now().UnixMilli()
 	insertSession(t, db, "ses_dormant", "/tmp/work", now, "")
 	insertMessage(t, db, "msg_d", "ses_dormant", "user", "gpt-4", now)
-	insertPart(t, db, "part_d1", "ses_dormant", "msg_d", "text", `{"text":"hello"}`, now)
+	insertPart(t, db, partRow{id: "part_d1", sessionID: "ses_dormant", messageID: "msg_d", partType: "text", data: `{"text":"hello"}`, ts: now})
 
 	// First scan: process not live → no emit.
 	w.scanSessions()
@@ -495,7 +505,7 @@ func TestScanSessions_EmitsWhenProcessBecomesLive(t *testing.T) {
 
 	// New activity arrives.
 	later := now + 1000
-	insertPart(t, db, "part_d2", "ses_dormant", "msg_d", "text", `{"text":"more"}`, later)
+	insertPart(t, db, partRow{id: "part_d2", sessionID: "ses_dormant", messageID: "msg_d", partType: "text", data: `{"text":"more"}`, ts: later})
 	if _, err := db.Exec(`UPDATE session SET time_updated = ? WHERE id = ?`, later, "ses_dormant"); err != nil {
 		t.Fatalf("bump time_updated: %v", err)
 	}
@@ -657,7 +667,7 @@ func TestScanSessions_ErrorMessageTerminal(t *testing.T) {
 	}
 	// A NON-terminal part (plain text), so the ONLY terminal signal is the
 	// message-level error — proving isErrorMessage is what flips Terminal.
-	insertPart(t, db, "part_err", "ses_err", "msg_err", "text", `{"text":"partial"}`, now)
+	insertPart(t, db, partRow{id: "part_err", sessionID: "ses_err", messageID: "msg_err", partType: "text", data: `{"text":"partial"}`, ts: now})
 
 	w.scanSessions()
 

--- a/core/adapters/outbound/relay/controller.go
+++ b/core/adapters/outbound/relay/controller.go
@@ -93,7 +93,14 @@ func (c *PublishController) Apply(enabled bool, url, token string) {
 	if c.cancel != nil {
 		c.cancel()
 	}
-	fwd := NewForwarder(url, c.identity, token, c.push, c.snapshot, c.control, c.controlEnabled, c.logger)
+	fwd := NewForwarder(url, c.identity, ForwarderDeps{
+		Token:          token,
+		Push:           c.push,
+		Snapshot:       c.snapshot,
+		Control:        c.control,
+		ControlEnabled: c.controlEnabled,
+		Logger:         c.logger,
+	})
 	ctx, cancel := context.WithCancel(c.parentCtx)
 	c.fwd = fwd
 	c.cancel = cancel

--- a/core/adapters/outbound/relay/forwarder.go
+++ b/core/adapters/outbound/relay/forwarder.go
@@ -129,22 +129,33 @@ type Forwarder struct {
 	lastErr string
 }
 
-// NewForwarder builds a Forwarder targeting relayURL. push and snapshot are
-// required; logger may be nil. token is sent in the hello for an auth-enabled
-// relay and may be empty (a no-auth relay ignores it). control + controlEnabled
-// gate inbound remote control (issue #724): a control frame is dispatched only
-// when controlEnabled() reports the relay-control toggle on; both may be nil to
-// disable remote control entirely.
-func NewForwarder(relayURL string, id Identity, token string, push outbound.PushBroadcaster, snapshot SnapshotFunc, control ControlHandler, controlEnabled func() bool, logger outbound.Logger) *Forwarder {
+// ForwarderDeps bundles NewForwarder's dependencies beyond the relay URL and
+// identity. Push and Snapshot are required; Logger may be nil. Token is sent
+// in the hello for an auth-enabled relay and may be empty (a no-auth relay
+// ignores it). Control + ControlEnabled gate inbound remote control (issue
+// #724): a control frame is dispatched only when ControlEnabled() reports
+// the relay-control toggle on; both may be nil to disable remote control
+// entirely.
+type ForwarderDeps struct {
+	Token          string
+	Push           outbound.PushBroadcaster
+	Snapshot       SnapshotFunc
+	Control        ControlHandler
+	ControlEnabled func() bool
+	Logger         outbound.Logger
+}
+
+// NewForwarder builds a Forwarder targeting relayURL.
+func NewForwarder(relayURL string, id Identity, deps ForwarderDeps) *Forwarder {
 	return &Forwarder{
 		url:            normalizeRelayURL(relayURL),
 		identity:       id,
-		token:          token,
-		push:           push,
-		snapshot:       snapshot,
-		control:        control,
-		controlEnabled: controlEnabled,
-		logger:         logger,
+		token:          deps.Token,
+		push:           deps.Push,
+		snapshot:       deps.Snapshot,
+		control:        deps.Control,
+		controlEnabled: deps.ControlEnabled,
+		logger:         deps.Logger,
 		dialer:         websocket.DefaultDialer,
 		minBackoff:     time.Second,
 		maxBackoff:     30 * time.Second,

--- a/core/adapters/outbound/relay/forwarder_test.go
+++ b/core/adapters/outbound/relay/forwarder_test.go
@@ -93,7 +93,7 @@ func TestForwarderHelloSnapshotAndPush(t *testing.T) {
 		return []*session.SessionState{{SessionID: "s1", State: "working"}},
 			[]AgentInfo{{Name: "claude-code", DisplayName: "Claude Code"}}
 	}
-	f := NewForwarder(tr.url, Identity{DaemonID: "d-123", DaemonLabel: "laptop"}, "", bc, snap, nil, nil, nil)
+	f := NewForwarder(tr.url, Identity{DaemonID: "d-123", DaemonLabel: "laptop"}, ForwarderDeps{Push: bc, Snapshot: snap})
 	go f.Run(t.Context())
 
 	var hello Hello
@@ -122,7 +122,7 @@ func TestForwarderHelloSnapshotAndPush(t *testing.T) {
 func TestForwarderFiltersFocusRequested(t *testing.T) {
 	tr := newTestRelay(t)
 	bc := newFakeBroadcaster()
-	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, "", bc, nil, nil, nil, nil)
+	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, ForwarderDeps{Push: bc})
 	go f.Run(t.Context())
 
 	tr.next(t) // hello
@@ -143,7 +143,7 @@ func TestForwarderFiltersFocusRequested(t *testing.T) {
 func TestForwarderReconnects(t *testing.T) {
 	tr := newTestRelay(t)
 	bc := newFakeBroadcaster()
-	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, "", bc, nil, nil, nil, nil)
+	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, ForwarderDeps{Push: bc})
 	f.minBackoff = 10 * time.Millisecond
 	f.maxBackoff = 20 * time.Millisecond
 	go f.Run(t.Context())
@@ -257,7 +257,7 @@ func TestForwarderSendsToken(t *testing.T) {
 	tr := newTestRelay(t)
 	bc := newFakeBroadcaster()
 	snap := func() ([]*session.SessionState, []AgentInfo) { return nil, nil }
-	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, "s3cr3t-token", bc, snap, nil, nil, nil)
+	f := NewForwarder(tr.url, Identity{DaemonID: "d1"}, ForwarderDeps{Token: "s3cr3t-token", Push: bc, Snapshot: snap})
 	go f.Run(t.Context())
 
 	var hello Hello
@@ -292,7 +292,7 @@ func TestForwarderStatusConnected(t *testing.T) {
 	tr := newTestRelay(t)
 	bc := newFakeBroadcaster()
 	snap := func() ([]*session.SessionState, []AgentInfo) { return nil, nil }
-	f := NewForwarder(tr.url, Identity{DaemonID: "d1", DaemonLabel: "lap"}, "", bc, snap, nil, nil, nil)
+	f := NewForwarder(tr.url, Identity{DaemonID: "d1", DaemonLabel: "lap"}, ForwarderDeps{Push: bc, Snapshot: snap})
 	go f.Run(t.Context())
 
 	tr.next(t) // hello
@@ -329,7 +329,7 @@ func TestForwarderStatusAuthFailed(t *testing.T) {
 	defer srv.Close()
 
 	bc := newFakeBroadcaster()
-	f := NewForwarder("ws"+strings.TrimPrefix(srv.URL, "http"), Identity{DaemonID: "d1"}, "bad-token", bc, nil, nil, nil, nil)
+	f := NewForwarder("ws"+strings.TrimPrefix(srv.URL, "http"), Identity{DaemonID: "d1"}, ForwarderDeps{Token: "bad-token", Push: bc})
 	f.minBackoff = 10 * time.Millisecond
 	f.maxBackoff = 20 * time.Millisecond
 	go f.Run(t.Context())

--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -227,11 +227,10 @@ func TestSessionDetector_ForceReadyToWorking_LogsTransition(t *testing.T) {
 	}
 
 	log := &mockLogger{}
-	det := services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		log, &mockGit{}, metrics, nil,
-		"test", 0, nil, nil, nil,
-	)
+	deps := defaultSessionDetectorDeps(pw, repo, nil)
+	deps.Log = log
+	deps.Metrics = metrics
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, deps)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)

--- a/core/application/services/diagnostics_service.go
+++ b/core/application/services/diagnostics_service.go
@@ -52,31 +52,32 @@ type DiagnosticsService struct {
 	paths          DiagnosticsPaths
 }
 
-// NewDiagnosticsService wires the service. isAlive is the per-PID liveness probe
-// (processlifecycle.IsAlive in production); agents supply both the process
-// matchers (for the full landscape) and the per-adapter infra-argv predicates
-// (for the ghost-session diagnosis). defaultAdapter is the adapter an
-// empty-Adapter session belongs to (claudecode.AdapterName), injected so the
-// application layer needn't import the inbound adapter.
-func NewDiagnosticsService(
-	repo outbound.SessionRepository,
-	obs outbound.ProcessObserver,
-	isAlive func(int) bool,
-	agents []agent.Agent,
-	defaultAdapter string,
-	cfg config.Config,
-	version string,
-	paths DiagnosticsPaths,
-) *DiagnosticsService {
+// DiagnosticsServiceDeps bundles NewDiagnosticsService's dependencies.
+type DiagnosticsServiceDeps struct {
+	Repo    outbound.SessionRepository
+	Obs     outbound.ProcessObserver
+	IsAlive func(int) bool // per-PID liveness probe (processlifecycle.IsAlive in production)
+	Agents  []agent.Agent  // supplies both process matchers (full landscape) and per-adapter infra-argv predicates (ghost-session diagnosis)
+	// DefaultAdapter is the adapter an empty-Adapter session belongs to
+	// (claudecode.AdapterName), injected so the application layer needn't
+	// import the inbound adapter.
+	DefaultAdapter string
+	Cfg            config.Config
+	Version        string
+	Paths          DiagnosticsPaths
+}
+
+// NewDiagnosticsService wires the service.
+func NewDiagnosticsService(deps DiagnosticsServiceDeps) *DiagnosticsService {
 	return &DiagnosticsService{
-		repo:           repo,
-		obs:            obs,
-		isAlive:        isAlive,
-		agents:         agents,
-		defaultAdapter: defaultAdapter,
-		cfg:            cfg,
-		version:        version,
-		paths:          paths,
+		repo:           deps.Repo,
+		obs:            deps.Obs,
+		isAlive:        deps.IsAlive,
+		agents:         deps.Agents,
+		defaultAdapter: deps.DefaultAdapter,
+		cfg:            deps.Cfg,
+		version:        deps.Version,
+		paths:          deps.Paths,
 	}
 }
 

--- a/core/application/services/diagnostics_service_test.go
+++ b/core/application/services/diagnostics_service_test.go
@@ -123,12 +123,21 @@ func buildTestService(t *testing.T) *DiagnosticsService {
 	}}
 	cfg := config.Config{MaxSessionAge: 5 * 24 * time.Hour, ReadySessionTTL: 30 * time.Minute, PermissionMode: "ask"}
 
-	return NewDiagnosticsService(&diagFakeRepo{sessions}, obs, isAlive, agents, "claude-code", cfg, "9.9.9+test", DiagnosticsPaths{
-		Home:            home,
-		InstancesDir:    instancesDir,
-		LedgerDir:       ledgerDir,
-		LogsDir:         logsDir,
-		PermissionsFile: permFile,
+	return NewDiagnosticsService(DiagnosticsServiceDeps{
+		Repo:           &diagFakeRepo{sessions},
+		Obs:            obs,
+		IsAlive:        isAlive,
+		Agents:         agents,
+		DefaultAdapter: "claude-code",
+		Cfg:            cfg,
+		Version:        "9.9.9+test",
+		Paths: DiagnosticsPaths{
+			Home:            home,
+			InstancesDir:    instancesDir,
+			LedgerDir:       ledgerDir,
+			LogsDir:         logsDir,
+			PermissionsFile: permFile,
+		},
 	})
 }
 

--- a/core/application/services/identity_guard_test.go
+++ b/core/application/services/identity_guard_test.go
@@ -32,10 +32,17 @@ func TestNewSessionDetector_PanicsOnZeroIdentity(t *testing.T) {
 	tw := newMockAgentWatcher()
 	tw.identity = agent.Identity{} // clear the default
 
-	services.NewSessionDetector(
-		[]inbound.Watcher{tw},
-		newMockProcessWatcher(), newMockRepo(),
-		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 0, nil, nil, nil,
-	)
+	services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           newMockProcessWatcher(),
+		Repo:         newMockRepo(),
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      &mockMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 }

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -136,33 +136,37 @@ func (s *PermissionService) SetDetectionPollIntervalForTest(d time.Duration) {
 	s.detectInterval = d
 }
 
+// PermissionServiceDeps bundles NewPermissionService's dependencies.
+// Factories may be nil (demo mode: no watchers ever start); HasLive may be
+// nil (no detection poller — nothing is ever "detected").
+type PermissionServiceDeps struct {
+	Agents    []agent.Agent
+	Store     outbound.PermissionStore
+	Push      outbound.PushBroadcaster
+	Log       outbound.Logger
+	Mode      string
+	Registrar watcherRegisterer
+	Factories map[string]WatcherFactory
+	HasLive   HasLiveProcessFunc
+}
+
 // NewPermissionService loads the persisted consent state and returns the
-// service. factories may be nil (demo mode: no watchers ever start);
-// hasLive may be nil (no detection poller — nothing is ever "detected").
-func NewPermissionService(
-	agents []agent.Agent,
-	store outbound.PermissionStore,
-	push outbound.PushBroadcaster,
-	log outbound.Logger,
-	mode string,
-	registrar watcherRegisterer,
-	factories map[string]WatcherFactory,
-	hasLive HasLiveProcessFunc,
-) *PermissionService {
-	set, err := store.Load()
+// service.
+func NewPermissionService(deps PermissionServiceDeps) *PermissionService {
+	set, err := deps.Store.Load()
 	if err != nil {
-		log.LogError("permissions", "", fmt.Sprintf("failed to load permission state (treating all as pending): %v", err))
+		deps.Log.LogError("permissions", "", fmt.Sprintf("failed to load permission state (treating all as pending): %v", err))
 		set = permission.Set{}
 	}
 	return &PermissionService{
-		agents:         agents,
-		store:          store,
-		push:           push,
-		log:            log,
-		mode:           mode,
-		registrar:      registrar,
-		factories:      factories,
-		hasLive:        hasLive,
+		agents:         deps.Agents,
+		store:          deps.Store,
+		push:           deps.Push,
+		log:            deps.Log,
+		mode:           deps.Mode,
+		registrar:      deps.Registrar,
+		factories:      deps.Factories,
+		hasLive:        deps.HasLive,
 		detectInterval: detectionPollInterval,
 		probes:         make(map[string]func() bool),
 		set:            set,

--- a/core/application/services/permission_service_test.go
+++ b/core/application/services/permission_service_test.go
@@ -177,10 +177,16 @@ func TestPermissionServiceFreshStateIsAllPendingAndInert(t *testing.T) {
 	c := &effectCounter{}
 	store := &mockPermStore{}
 	reg := &mockRegistrar{}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, store, &mockPush{}, &mockLogger{},
-		config.PermissionModeAsk, reg, nil, nil,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     store,
+		Push:      &mockPush{},
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: reg,
+		Factories: nil,
+		HasLive:   nil,
+	})
 	svc.Start(context.Background())
 
 	if svc.Granted("testagent", "config") || svc.Granted("testagent", "transcripts") {
@@ -210,10 +216,16 @@ func TestPermissionServiceGrantAppliesAndDenyRemoves(t *testing.T) {
 	c := &effectCounter{}
 	store := &mockPermStore{}
 	push := &mockPush{}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, store, push, &mockLogger{},
-		config.PermissionModeAsk, &mockRegistrar{}, nil, nil,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     store,
+		Push:      push,
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: &mockRegistrar{},
+		Factories: nil,
+		HasLive:   nil,
+	})
 	svc.Start(context.Background())
 
 	if err := svc.Answer([]services.PermissionAnswer{
@@ -252,10 +264,16 @@ func TestPermissionServiceReAnswerIsIdempotent(t *testing.T) {
 	c := &effectCounter{}
 	store := &mockPermStore{}
 	push := &mockPush{}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, store, push, &mockLogger{},
-		config.PermissionModeAsk, &mockRegistrar{}, nil, nil,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     store,
+		Push:      push,
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: &mockRegistrar{},
+		Factories: nil,
+		HasLive:   nil,
+	})
 	svc.Start(context.Background())
 
 	ans := []services.PermissionAnswer{{Agent: "testagent", Permission: "config", Grant: true}}
@@ -279,10 +297,16 @@ func TestPermissionServiceReAnswerIsIdempotent(t *testing.T) {
 
 func TestPermissionServiceUnknownPermissionRejectsWholeBatch(t *testing.T) {
 	c := &effectCounter{}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, &mockPush{}, &mockLogger{},
-		config.PermissionModeAsk, &mockRegistrar{}, nil, nil,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     &mockPermStore{},
+		Push:      &mockPush{},
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: &mockRegistrar{},
+		Factories: nil,
+		HasLive:   nil,
+	})
 	svc.Start(context.Background())
 
 	err := svc.Answer([]services.PermissionAnswer{
@@ -308,10 +332,16 @@ func TestPermissionServiceObserveGrantStartsAndDenyStopsWatchers(t *testing.T) {
 	factories := map[string]services.WatcherFactory{
 		"testagent": func() []inbound.Watcher { return []inbound.Watcher{w} },
 	}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, &mockPush{}, &mockLogger{},
-		config.PermissionModeAsk, reg, factories, nil,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     &mockPermStore{},
+		Push:      &mockPush{},
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: reg,
+		Factories: factories,
+		HasLive:   nil,
+	})
 	svc.Start(context.Background())
 
 	if err := svc.Answer([]services.PermissionAnswer{
@@ -353,10 +383,16 @@ func TestPermissionServiceGrantedStateResumesAtStart(t *testing.T) {
 	factories := map[string]services.WatcherFactory{
 		"testagent": func() []inbound.Watcher { return []inbound.Watcher{w} },
 	}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, store, &mockPush{}, &mockLogger{},
-		config.PermissionModeAsk, &mockRegistrar{}, factories, nil,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     store,
+		Push:      &mockPush{},
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: &mockRegistrar{},
+		Factories: factories,
+		HasLive:   nil,
+	})
 	svc.Start(context.Background())
 
 	// Persisted grants are exercised on boot: modify re-applied (hook
@@ -381,10 +417,16 @@ func TestPermissionServiceGrantAllMode(t *testing.T) {
 	factories := map[string]services.WatcherFactory{
 		"testagent": func() []inbound.Watcher { return []inbound.Watcher{w} },
 	}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, store, &mockPush{}, &mockLogger{},
-		config.PermissionModeGrantAll, &mockRegistrar{}, factories, nil,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     store,
+		Push:      &mockPush{},
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeGrantAll,
+		Registrar: &mockRegistrar{},
+		Factories: factories,
+		HasLive:   nil,
+	})
 	svc.Start(context.Background())
 
 	if !svc.Granted("testagent", "config") || !svc.Granted("testagent", "transcripts") {
@@ -418,10 +460,16 @@ func TestPermissionServiceDetectionFlagsAndBroadcasts(t *testing.T) {
 		defer mu.Unlock()
 		return live
 	}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, push, &mockLogger{},
-		config.PermissionModeAsk, &mockRegistrar{}, nil, hasLive,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     &mockPermStore{},
+		Push:      push,
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: &mockRegistrar{},
+		Factories: nil,
+		HasLive:   hasLive,
+	})
 	svc.SetDetectionPollIntervalForTest(10 * time.Millisecond)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -448,10 +496,16 @@ func TestPermissionServiceDetectionFlagsAndBroadcasts(t *testing.T) {
 func TestPermissionServiceGrantAllAnswerDoesNotPersist(t *testing.T) {
 	c := &effectCounter{}
 	store := &mockPermStore{}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, store, &mockPush{}, &mockLogger{},
-		config.PermissionModeGrantAll, &mockRegistrar{}, nil, nil,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     store,
+		Push:      &mockPush{},
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeGrantAll,
+		Registrar: &mockRegistrar{},
+		Factories: nil,
+		HasLive:   nil,
+	})
 	svc.Start(context.Background())
 
 	// A user answer on a grant-all daemon applies in memory but must not
@@ -472,10 +526,16 @@ func TestPermissionServiceGrantAllAnswerDoesNotPersist(t *testing.T) {
 
 func TestPermissionServiceObserveGranted(t *testing.T) {
 	c := &effectCounter{}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, &mockPush{}, &mockLogger{},
-		config.PermissionModeAsk, &mockRegistrar{}, nil, nil,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     &mockPermStore{},
+		Push:      &mockPush{},
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: &mockRegistrar{},
+		Factories: nil,
+		HasLive:   nil,
+	})
 	svc.Start(context.Background())
 
 	if svc.ObserveGranted("testagent") {
@@ -517,10 +577,16 @@ func TestPermissionServiceDetectionStopsWhenNothingPending(t *testing.T) {
 		calls++
 		return true
 	}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{set: set}, &mockPush{}, &mockLogger{},
-		config.PermissionModeAsk, &mockRegistrar{}, nil, hasLive,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     &mockPermStore{set: set},
+		Push:      &mockPush{},
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: &mockRegistrar{},
+		Factories: nil,
+		HasLive:   hasLive,
+	})
 	svc.SetDetectionPollIntervalForTest(5 * time.Millisecond)
 	svc.Start(context.Background())
 
@@ -536,11 +602,16 @@ func TestPermissionServiceDetectionStopsWhenNothingPending(t *testing.T) {
 func TestPermissionServiceDetectionProbeOverride(t *testing.T) {
 	c := &effectCounter{}
 	push := &mockPush{}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, push, &mockLogger{},
-		config.PermissionModeAsk, &mockRegistrar{}, nil,
-		func(agent.ProcessMatcher) bool { return false },
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     &mockPermStore{},
+		Push:      push,
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: &mockRegistrar{},
+		Factories: nil,
+		HasLive:   func(agent.ProcessMatcher) bool { return false },
+	})
 	svc.SetDetectionProbe("testagent", func() bool { return true })
 	svc.SetDetectionPollIntervalForTest(5 * time.Millisecond)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -563,10 +634,16 @@ func TestPermissionServiceDetectionProbeOverride(t *testing.T) {
 // recorded state.
 func TestPermissionServiceConflictingAnswersConverge(t *testing.T) {
 	c := &effectCounter{}
-	svc := services.NewPermissionService(
-		[]agent.Agent{testAgentDecl(c)}, &mockPermStore{}, &mockPush{}, &mockLogger{},
-		config.PermissionModeAsk, &mockRegistrar{}, nil, nil,
-	)
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{testAgentDecl(c)},
+		Store:     &mockPermStore{},
+		Push:      &mockPush{},
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: &mockRegistrar{},
+		Factories: nil,
+		HasLive:   nil,
+	})
 	svc.Start(context.Background())
 
 	for i := 0; i < 100; i++ {

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -130,31 +130,33 @@ type PIDManager struct {
 	recorderSeq *int64 // shared with SessionDetector for monotonic ordering
 }
 
+// PIDManagerDeps bundles NewPIDManager's dependencies. PW and Broadcaster may
+// be nil (optional). ProcessNames + LiveCWDs may both be nil — that disables
+// the DB-backed-orphan branch of the startup zombie sweep.
+type PIDManagerDeps struct {
+	PW               outbound.ProcessWatcher
+	Repo             outbound.SessionRepository
+	Log              outbound.Logger
+	Broadcaster      outbound.PushBroadcaster
+	ReadyTTL         time.Duration
+	PIDDiscovers     map[string]agent.PIDDiscoverFunc
+	ProcessNames     map[string]string
+	LiveCWDs         LiveCWDsFunc
+	OnSessionDeleted func(sessionID string)
+}
+
 // NewPIDManager creates a PIDManager with the given dependencies.
-// pw and broadcaster may be nil (optional). processNames + liveCWDs may
-// both be nil — that disables the DB-backed-orphan branch of the startup
-// zombie sweep.
-func NewPIDManager(
-	pw outbound.ProcessWatcher,
-	repo outbound.SessionRepository,
-	log outbound.Logger,
-	broadcaster outbound.PushBroadcaster,
-	readyTTL time.Duration,
-	pidDiscovers map[string]agent.PIDDiscoverFunc,
-	processNames map[string]string,
-	liveCWDs LiveCWDsFunc,
-	onSessionDeleted func(sessionID string),
-) *PIDManager {
+func NewPIDManager(deps PIDManagerDeps) *PIDManager {
 	return &PIDManager{
-		pw:               pw,
-		repo:             repo,
-		log:              log,
-		broadcaster:      broadcaster,
-		readyTTL:         readyTTL,
-		pidDiscovers:     pidDiscovers,
-		processNames:     processNames,
-		liveCWDs:         liveCWDs,
-		onSessionDeleted: onSessionDeleted,
+		pw:               deps.PW,
+		repo:             deps.Repo,
+		log:              deps.Log,
+		broadcaster:      deps.Broadcaster,
+		readyTTL:         deps.ReadyTTL,
+		pidDiscovers:     deps.PIDDiscovers,
+		processNames:     deps.ProcessNames,
+		liveCWDs:         deps.LiveCWDs,
+		onSessionDeleted: deps.OnSessionDeleted,
 		pendingPIDs:      make(map[string]int),
 	}
 }

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -31,34 +31,31 @@ func writeTranscript(t *testing.T, path string, mtime time.Time) {
 // mockLogger from testhelpers_test.go. readyTTL is set large so the normal
 // idle sweep doesn't interfere with the fast-delete path under test.
 func newPIDManagerForTest(repo *mockRepo) *services.PIDManager {
-	return services.NewPIDManager(
-		nil, // no ProcessWatcher
-		repo,
-		&mockLogger{},
-		nil, // no broadcaster
-		10*time.Minute,
-		nil, // no pid discovers
-		nil, // no process names
-		nil, // no live-CWDs lookup
-		func(string) {},
-	)
+	return services.NewPIDManager(services.PIDManagerDeps{
+		PW:               nil, // no ProcessWatcher
+		Repo:             repo,
+		Log:              &mockLogger{},
+		Broadcaster:      nil, // no broadcaster
+		ReadyTTL:         10 * time.Minute,
+		PIDDiscovers:     nil, // no pid discovers
+		ProcessNames:     nil, // no process names
+		LiveCWDs:         nil, // no live-CWDs lookup
+		OnSessionDeleted: func(string) {},
+	})
 }
 
 // newPIDManagerForTestWithLiveCWDs builds a PIDManager whose startup zombie
 // sweep can use the DB-backed-orphan branch — the sweep needs both an
 // adapter→process-name map and a live-CWDs lookup.
 func newPIDManagerForTestWithLiveCWDs(repo *mockRepo, processNames map[string]string, liveCWDs services.LiveCWDsFunc) *services.PIDManager {
-	return services.NewPIDManager(
-		nil,
-		repo,
-		&mockLogger{},
-		nil,
-		10*time.Minute,
-		nil,
-		processNames,
-		liveCWDs,
-		func(string) {},
-	)
+	return services.NewPIDManager(services.PIDManagerDeps{
+		Repo:             repo,
+		Log:              &mockLogger{},
+		ReadyTTL:         10 * time.Minute,
+		ProcessNames:     processNames,
+		LiveCWDs:         liveCWDs,
+		OnSessionDeleted: func(string) {},
+	})
 }
 
 // TestAllowsSession covers the #784 host-ancestry admission gate: an adapter
@@ -88,11 +85,13 @@ func TestAllowsSession(t *testing.T) {
 				discoverCalls++
 				return tc.discoverPID, tc.discoverErr
 			})
-			pm := services.NewPIDManager(
-				nil, repo, &mockLogger{}, nil, 10*time.Minute,
-				map[string]agent.PIDDiscoverFunc{"antigravity": discover},
-				nil, nil, func(string) {},
-			)
+			pm := services.NewPIDManager(services.PIDManagerDeps{
+				Repo:             repo,
+				Log:              &mockLogger{},
+				ReadyTTL:         10 * time.Minute,
+				PIDDiscovers:     map[string]agent.PIDDiscoverFunc{"antigravity": discover},
+				OnSessionDeleted: func(string) {},
+			})
 			requireKnownHost := map[string]bool{}
 			if tc.requireKnownHost {
 				requireKnownHost["antigravity"] = true
@@ -128,11 +127,13 @@ func TestAllowsSession_ClaimAwareDisambiguation(t *testing.T) {
 	discover := agent.PIDDiscoverFunc(func(cwd, transcriptPath string, disambiguate func([]int) int) (int, error) {
 		return disambiguate([]int{100, 200}), nil
 	})
-	pm := services.NewPIDManager(
-		nil, repo, &mockLogger{}, nil, 10*time.Minute,
-		map[string]agent.PIDDiscoverFunc{"antigravity": discover},
-		nil, nil, func(string) {},
-	)
+	pm := services.NewPIDManager(services.PIDManagerDeps{
+		Repo:             repo,
+		Log:              &mockLogger{},
+		ReadyTTL:         10 * time.Minute,
+		PIDDiscovers:     map[string]agent.PIDDiscoverFunc{"antigravity": discover},
+		OnSessionDeleted: func(string) {},
+	})
 	var checkedPID int
 	pm.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool {
 		checkedPID = pid
@@ -965,17 +966,14 @@ func TestTryDiscoverPID_ProcSession_BypassesDiscoverFn(t *testing.T) {
 		},
 	}
 
-	pm := services.NewPIDManager(
-		newMockProcessWatcher(),
-		repo,
-		&mockLogger{},
-		nil,
-		10*time.Minute,
-		discovers,
-		nil,
-		nil,
-		func(string) {},
-	)
+	pm := services.NewPIDManager(services.PIDManagerDeps{
+		PW:               newMockProcessWatcher(),
+		Repo:             repo,
+		Log:              &mockLogger{},
+		ReadyTTL:         10 * time.Minute,
+		PIDDiscovers:     discovers,
+		OnSessionDeleted: func(string) {},
+	})
 
 	if !pm.TryDiscoverPID("proc-12345", "/tmp/shared-cwd", "", "claude-code") {
 		t.Fatal("TryDiscoverPID returned false for proc-12345")
@@ -1001,17 +999,12 @@ func TestTryDiscoverPID_ProcSession_BypassesDiscoverFn(t *testing.T) {
 // detector's history/projectSessions eviction helper. Locks the #593 deletion
 // funnel: every PIDManager removal must fire it, or history rings leak.
 func newPIDManagerForTestWithDeleteSpy(repo *mockRepo, deleted *[]string) *services.PIDManager {
-	return services.NewPIDManager(
-		nil,
-		repo,
-		&mockLogger{},
-		nil,
-		10*time.Minute,
-		nil,
-		nil,
-		nil,
-		func(sid string) { *deleted = append(*deleted, sid) },
-	)
+	return services.NewPIDManager(services.PIDManagerDeps{
+		Repo:             repo,
+		Log:              &mockLogger{},
+		ReadyTTL:         10 * time.Minute,
+		OnSessionDeleted: func(sid string) { *deleted = append(*deleted, sid) },
+	})
 }
 
 // TestCheckPIDLiveness_ChildSweep_EvictsHistory: before #593 the liveness

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -234,28 +234,31 @@ type terminalUISignal struct {
 	ui        backchannel.UIKind
 }
 
+// SessionDetectorDeps bundles NewSessionDetector's dependencies beyond the
+// watcher list. PW and Broadcaster may be nil (optional).
+type SessionDetectorDeps struct {
+	PW           outbound.ProcessWatcher
+	Repo         outbound.SessionRepository
+	Log          outbound.Logger
+	Git          outbound.GitResolver
+	Metrics      outbound.MetricsCollector
+	Broadcaster  outbound.PushBroadcaster
+	Version      string
+	ReadyTTL     time.Duration
+	PIDDiscovers map[string]agent.PIDDiscoverFunc
+	ProcessNames map[string]string
+	LiveCWDs     LiveCWDsFunc
+}
+
 // NewSessionDetector creates a SessionDetector with all required
-// dependencies. pw and broadcaster may be nil (optional).
+// dependencies.
 //
 // Panics if any supplied watcher has a zero-value Identity. Every
 // downstream session created from that watcher's events would otherwise
 // have an empty Adapter field — a silent partial-failure mode (the
 // adapter-aware code paths fall back gracefully, but logs and the
 // /api/v1/agents endpoint surface "" instead of the real name).
-func NewSessionDetector(
-	watchers []inbound.Watcher,
-	pw outbound.ProcessWatcher,
-	repo outbound.SessionRepository,
-	log outbound.Logger,
-	git outbound.GitResolver,
-	metrics outbound.MetricsCollector,
-	broadcaster outbound.PushBroadcaster,
-	version string,
-	readyTTL time.Duration,
-	pidDiscovers map[string]agent.PIDDiscoverFunc,
-	processNames map[string]string,
-	liveCWDs LiveCWDsFunc,
-) *SessionDetector {
+func NewSessionDetector(watchers []inbound.Watcher, deps SessionDetectorDeps) *SessionDetector {
 	for i, w := range watchers {
 		if w.Identity() == (agent.Identity{}) {
 			panic(fmt.Sprintf("session_detector: watchers[%d] (%T) has no Identity — call .WithIdentity() before passing it to NewSessionDetector", i, w))
@@ -264,12 +267,12 @@ func NewSessionDetector(
 	det := &SessionDetector{
 		watchers:          watchers,
 		merged:            make(chan identifiedEvent, 16),
-		repo:              repo,
-		log:               log,
-		broadcaster:       broadcaster,
-		version:           version,
-		enricher:          newMetadataEnricher(git, metrics),
-		metrics:           metrics,
+		repo:              deps.Repo,
+		log:               deps.Log,
+		broadcaster:       deps.Broadcaster,
+		version:           deps.Version,
+		enricher:          newMetadataEnricher(deps.Git, deps.Metrics),
+		metrics:           deps.Metrics,
 		projectSessions:   make(map[string]string),
 		deletedSessions:   make(map[string]int64),
 		hostGateRejected:  make(map[string]struct{}),
@@ -285,10 +288,17 @@ func NewSessionDetector(
 		bgProbing:         make(map[string]bool),
 		uiSignals:         make(chan terminalUISignal, 64),
 	}
-	det.pidMgr = NewPIDManager(
-		pw, repo, log, broadcaster, readyTTL,
-		pidDiscovers, processNames, liveCWDs, det.removeFromProjectSessions,
-	)
+	det.pidMgr = NewPIDManager(PIDManagerDeps{
+		PW:               deps.PW,
+		Repo:             deps.Repo,
+		Log:              deps.Log,
+		Broadcaster:      deps.Broadcaster,
+		ReadyTTL:         deps.ReadyTTL,
+		PIDDiscovers:     deps.PIDDiscovers,
+		ProcessNames:     deps.ProcessNames,
+		LiveCWDs:         deps.LiveCWDs,
+		OnSessionDeleted: det.removeFromProjectSessions,
+	})
 	det.pidMgr.SetChildDeletedHandler(det.reevaluateParent)
 	return det
 }

--- a/core/application/services/session_detector_lifecycle_test.go
+++ b/core/application/services/session_detector_lifecycle_test.go
@@ -68,11 +68,19 @@ func TestSessionDetector_Removed_PrunesMetricsLedger(t *testing.T) {
 		UpdatedAt:      time.Now().Unix(),
 	}
 
-	det := services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &mockGit{}, mm, nil,
-		"test", 0, nil, nil, nil,
-	)
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      mm,
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)

--- a/core/application/services/session_detector_pid_test.go
+++ b/core/application/services/session_detector_pid_test.go
@@ -353,11 +353,19 @@ func TestSessionDetector_ClearWithStaleMetadata_DeletesOldSessionImmediately(t *
 	discovers := map[string]agent.PIDDiscoverFunc{
 		"claude-code": claudecode.DiscoverPID,
 	}
-	det := services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 0, discovers, nil, nil,
-	)
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      &mockMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: discovers,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)

--- a/core/application/services/session_detector_subagent_test.go
+++ b/core/application/services/session_detector_subagent_test.go
@@ -624,11 +624,19 @@ func TestSessionDetector_ParentReleasedToReady_WhenChildSweptByLiveness(t *testi
 	// The child-sweep path in PIDManager is gated on readyTTL > 0,
 	// so the default newDetector (readyTTL=0) would skip it entirely.
 	// Use a tiny TTL so the sweep actually runs its child-cleanup loop.
-	det := services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 1*time.Second, nil, nil, nil,
-	)
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      &mockMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     1 * time.Second,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -1222,11 +1230,19 @@ func TestSessionDetector_ParentBadgeCleared_WhenChildSweptWhileParentWaiting(t *
 	// The child-sweep path in PIDManager is gated on readyTTL > 0; wire a
 	// capturing broadcaster to assert the corrective parent push.
 	bc := &mockBroadcaster{}
-	det := services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &mockGit{}, &mockMetrics{}, bc,
-		"test", 1*time.Second, nil, nil, nil,
-	)
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      &mockMetrics{},
+		Broadcaster:  bc,
+		Version:      "test",
+		ReadyTTL:     1 * time.Second,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -152,11 +152,19 @@ func TestSessionDetector_NewSession_SkipsNonInteractiveHost(t *testing.T) {
 			return 62540, nil // real, live PID — just not launched by a terminal/IDE
 		},
 	}
-	det := services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 0, discovers, nil, nil,
-	)
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      &mockMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: discovers,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return false })
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -194,11 +202,19 @@ func TestSessionDetector_NewSession_AdmitsKnownHost(t *testing.T) {
 			return 4242, nil
 		},
 	}
-	det := services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 0, discovers, nil, nil,
-	)
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      &mockMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: discovers,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return true })
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -245,11 +261,19 @@ func TestSessionDetector_NewSession_HostGateResolvesCWDFromTranscript(t *testing
 			return 62540, nil
 		},
 	}
-	det := services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &cwdGit{cwd: wantCWD}, &mockMetrics{}, nil,
-		"test", 0, discovers, nil, nil,
-	)
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &cwdGit{cwd: wantCWD},
+		Metrics:      &mockMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: discovers,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return false })
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -297,11 +321,19 @@ func TestSessionDetector_NewSession_HostGateRejectionSurvivesIdentityLessRetry(t
 			return 62540, nil
 		},
 	}
-	det := services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &cwdGit{cwd: "/Users/ghost"}, &mockMetrics{}, nil,
-		"test", 0, discovers, nil, nil,
-	)
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &cwdGit{cwd: "/Users/ghost"},
+		Metrics:      &mockMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: discovers,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return false })
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/core/application/services/session_detector_test.go
+++ b/core/application/services/session_detector_test.go
@@ -152,19 +152,7 @@ func TestSessionDetector_NewSession_SkipsNonInteractiveHost(t *testing.T) {
 			return 62540, nil // real, live PID — just not launched by a terminal/IDE
 		},
 	}
-	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
-		PW:           pw,
-		Repo:         repo,
-		Log:          &mockLogger{},
-		Git:          &mockGit{},
-		Metrics:      &mockMetrics{},
-		Broadcaster:  nil,
-		Version:      "test",
-		ReadyTTL:     0,
-		PIDDiscovers: discovers,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, defaultSessionDetectorDeps(pw, repo, discovers))
 	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return false })
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -202,19 +190,7 @@ func TestSessionDetector_NewSession_AdmitsKnownHost(t *testing.T) {
 			return 4242, nil
 		},
 	}
-	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
-		PW:           pw,
-		Repo:         repo,
-		Log:          &mockLogger{},
-		Git:          &mockGit{},
-		Metrics:      &mockMetrics{},
-		Broadcaster:  nil,
-		Version:      "test",
-		ReadyTTL:     0,
-		PIDDiscovers: discovers,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, defaultSessionDetectorDeps(pw, repo, discovers))
 	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return true })
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -261,19 +237,9 @@ func TestSessionDetector_NewSession_HostGateResolvesCWDFromTranscript(t *testing
 			return 62540, nil
 		},
 	}
-	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
-		PW:           pw,
-		Repo:         repo,
-		Log:          &mockLogger{},
-		Git:          &cwdGit{cwd: wantCWD},
-		Metrics:      &mockMetrics{},
-		Broadcaster:  nil,
-		Version:      "test",
-		ReadyTTL:     0,
-		PIDDiscovers: discovers,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	deps := defaultSessionDetectorDeps(pw, repo, discovers)
+	deps.Git = &cwdGit{cwd: wantCWD}
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, deps)
 	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return false })
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -321,19 +287,9 @@ func TestSessionDetector_NewSession_HostGateRejectionSurvivesIdentityLessRetry(t
 			return 62540, nil
 		},
 	}
-	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
-		PW:           pw,
-		Repo:         repo,
-		Log:          &mockLogger{},
-		Git:          &cwdGit{cwd: "/Users/ghost"},
-		Metrics:      &mockMetrics{},
-		Broadcaster:  nil,
-		Version:      "test",
-		ReadyTTL:     0,
-		PIDDiscovers: discovers,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	deps := defaultSessionDetectorDeps(pw, repo, discovers)
+	deps.Git = &cwdGit{cwd: "/Users/ghost"}
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, deps)
 	det.SetHostGate(map[string]bool{"antigravity": true}, func(pid int) bool { return false })
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/core/application/services/terminal_observer_internal_test.go
+++ b/core/application/services/terminal_observer_internal_test.go
@@ -157,7 +157,19 @@ func TestObserverGates(t *testing.T) {
 // recorder. git/metrics/pw/broadcaster are nil — the handler never touches them.
 func newFusionDetector(repo outbound.SessionRepository) (*SessionDetector, *captureRecorder) {
 	rec := &captureRecorder{}
-	d := NewSessionDetector(nil, nil, repo, bcNopLog{}, nil, nil, nil, "", 0, nil, nil, nil)
+	d := NewSessionDetector(nil, SessionDetectorDeps{
+		PW:           nil,
+		Repo:         repo,
+		Log:          bcNopLog{},
+		Git:          nil,
+		Metrics:      nil,
+		Broadcaster:  nil,
+		Version:      "",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 	d.SetRecorder(rec)
 	return d, rec
 }

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -484,11 +484,19 @@ func newDetector(
 	pw *mockProcessWatcher,
 	repo *mockRepo,
 ) *services.SessionDetector {
-	return services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 0, nil, nil, nil,
-	)
+	return services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      &mockMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 }
 
 // newDetectorWithMetrics builds a SessionDetector using a caller-provided
@@ -499,11 +507,19 @@ func newDetectorWithMetrics(
 	repo *mockRepo,
 	metrics *funcMetrics,
 ) *services.SessionDetector {
-	return services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &mockGit{}, metrics, nil,
-		"test", 0, nil, nil, nil,
-	)
+	return services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      metrics,
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 }
 
 // newDetectorWithLiveCWDs builds a SessionDetector with a process-name map
@@ -521,11 +537,19 @@ func newDetectorWithLiveCWDs(
 	if git == nil {
 		git = &mockGit{}
 	}
-	return services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, git, &mockMetrics{}, nil,
-		"test", 0, nil, processNames, liveCWDs,
-	)
+	return services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          git,
+		Metrics:      &mockMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: processNames,
+		LiveCWDs:     liveCWDs,
+	})
 }
 
 // newDetectorWithCWDDiscovery builds a SessionDetector with a mock CWD-based
@@ -541,11 +565,19 @@ func newDetectorWithCWDDiscovery(
 			return cwdFn(cwd, disambiguate)
 		},
 	}
-	return services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &mockGit{}, &mockMetrics{}, nil,
-		"test", 0, discovers, nil, nil,
-	)
+	return services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      &mockMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: discovers,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 }
 
 // mockBroadcaster captures every Broadcast for assertions. Safe for
@@ -587,10 +619,18 @@ func newDetectorWithBroadcaster(
 	repo *mockRepo,
 ) (*services.SessionDetector, *mockBroadcaster) {
 	b := &mockBroadcaster{}
-	det := services.NewSessionDetector(
-		[]inbound.Watcher{tw}, pw, repo,
-		&mockLogger{}, &mockGit{}, &mockMetrics{}, b,
-		"test", 0, nil, nil, nil,
-	)
+	det := services.NewSessionDetector([]inbound.Watcher{tw}, services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      &mockMetrics{},
+		Broadcaster:  b,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 	return det, b
 }

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -251,6 +251,23 @@ type cwdGit struct {
 
 func (g *cwdGit) GetCWDFromTranscript(path string) string { return g.cwd }
 
+// defaultSessionDetectorDeps returns the SessionDetectorDeps most detector
+// tests in this file build identically (mockLogger/mockGit/mockMetrics, no
+// broadcaster, "test" version, zero ReadyTTL, no process-name map) — callers
+// set PW/Repo/PIDDiscovers and override Git when the scenario needs a
+// specific cwd.
+func defaultSessionDetectorDeps(pw outbound.ProcessWatcher, repo outbound.SessionRepository, discovers map[string]agent.PIDDiscoverFunc) services.SessionDetectorDeps {
+	return services.SessionDetectorDeps{
+		PW:           pw,
+		Repo:         repo,
+		Log:          &mockLogger{},
+		Git:          &mockGit{},
+		Metrics:      &mockMetrics{},
+		Version:      "test",
+		PIDDiscovers: discovers,
+	}
+}
+
 // mockMetrics records PruneEntry calls. Safe for concurrent use: PruneEntry
 // fires on the detector's Run goroutine while tests poll prunedSnapshot from
 // the test goroutine (issue #606 flaky-sibling fix replaced a fixed sleep with

--- a/core/cmd/irrlichd/backchannel_e2e_test.go
+++ b/core/cmd/irrlichd/backchannel_e2e_test.go
@@ -174,11 +174,13 @@ func TestBackchannelE2E_Remote(t *testing.T) {
 	fwd := relay.NewForwarder(
 		"ws"+strings.TrimPrefix(srv.URL, "http"),
 		relay.Identity{DaemonID: "d-e2e", DaemonLabel: "e2e"},
-		"", e2ePush{},
-		func() ([]*session.SessionState, []relay.AgentInfo) { return nil, nil },
-		in,                          // ControlHandler
-		func() bool { return true }, // relay-control toggle ON
-		e2eLog{},
+		relay.ForwarderDeps{
+			Push:           e2ePush{},
+			Snapshot:       func() ([]*session.SessionState, []relay.AgentInfo) { return nil, nil },
+			Control:        in,                          // ControlHandler
+			ControlEnabled: func() bool { return true }, // relay-control toggle ON
+			Logger:         e2eLog{},
+		},
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -248,7 +248,16 @@ func runDaemon() {
 	}
 
 	mux := http.NewServeMux()
-	registerCoreRoutes(mux, fsRepo, cachedRepo, historyTracker, push, allAgents, Version, rel.publishController, cfg)
+	registerCoreRoutes(mux, registerCoreRoutesDeps{
+		FSRepo:            fsRepo,
+		CachedRepo:        cachedRepo,
+		HistoryTracker:    historyTracker,
+		Push:              push,
+		AllAgents:         allAgents,
+		Version:           Version,
+		PublishController: rel.publishController,
+		Cfg:               cfg,
+	})
 
 	// Static web UI: served from disk so the dashboard ships as three files
 	// (index.html, irrlicht.css, irrlicht.js) under platforms/web/. API routes
@@ -278,15 +287,57 @@ func runDaemon() {
 	// resolved at request time via rel.inputService (published once
 	// setupBackchannel runs), so a session reports controllable only once
 	// that wiring completes.
-	registerSessionRoutes(mux, cachedRepo, orchMonitor, costTracker, &rel.inputService, sockPath, push, logger)
+	registerSessionRoutes(mux, registerSessionRoutesDeps{
+		CachedRepo:   cachedRepo,
+		OrchMonitor:  orchMonitor,
+		CostTracker:  costTracker,
+		InputService: &rel.inputService,
+		SockPath:     sockPath,
+		Push:         push,
+		Logger:       logger,
+	})
 
 	var watcherFactories map[string]services.WatcherFactory
-	detector, watcherFactories = buildDetector(demoMode, pwPort, cachedRepo, logger, gitResolver, metricsCollector, push, Version, cfg, allAgents, costTracker, historyTracker)
+	detector, watcherFactories = buildDetector(buildDetectorDeps{
+		DemoMode:         demoMode,
+		PWPort:           pwPort,
+		CachedRepo:       cachedRepo,
+		Logger:           logger,
+		GitResolver:      gitResolver,
+		MetricsCollector: metricsCollector,
+		Push:             push,
+		Version:          Version,
+		Cfg:              cfg,
+		AllAgents:        allAgents,
+		CostTracker:      costTracker,
+		HistoryTracker:   historyTracker,
+	})
 
 	home, _ := os.UserHomeDir()
-	permService := setupPermissionService(mux, detector, push, logger, cfg, allAgents, watcherFactories, demoMode, home, startGastown, stopGastown)
+	permService := setupPermissionService(mux, setupPermissionServiceDeps{
+		Detector:         detector,
+		Push:             push,
+		Logger:           logger,
+		Cfg:              cfg,
+		AllAgents:        allAgents,
+		WatcherFactories: watcherFactories,
+		DemoMode:         demoMode,
+		Home:             home,
+		StartGastown:     startGastown,
+		StopGastown:      stopGastown,
+	})
 
-	backchannelEngine, terminalObserver := setupBackchannel(mux, cachedRepo, push, permService, detector, logger, home, &rel.inputService, rel.controlStore, allAgents)
+	backchannelEngine, terminalObserver := setupBackchannel(mux, setupBackchannelDeps{
+		CachedRepo:        cachedRepo,
+		Push:              push,
+		PermService:       permService,
+		Detector:          detector,
+		Logger:            logger,
+		Home:              home,
+		InputService:      &rel.inputService,
+		RelayControlStore: rel.controlStore,
+		AllAgents:         allAgents,
+	})
 
 	registerHookRoutes(mux, detector, metricsCollector, permService, logger)
 
@@ -306,7 +357,17 @@ func runDaemon() {
 
 	sweepZombies(demoMode, detector, logger)
 
-	defer startBackgroundLoops(detector, backchannelEngine, cachedRepo, gitResolver, terminalObserver, permService, cfg, demoMode, logger)()
+	defer startBackgroundLoops(startBackgroundLoopsDeps{
+		Detector:          detector,
+		BackchannelEngine: backchannelEngine,
+		CachedRepo:        cachedRepo,
+		GitResolver:       gitResolver,
+		TerminalObserver:  terminalObserver,
+		PermService:       permService,
+		Cfg:               cfg,
+		DemoMode:          demoMode,
+		Logger:            logger,
+	})()
 
 	logger.LogInfo("startup", "", fmt.Sprintf("irrlichd %s listening on unix:%s and tcp:%s", Version, sockPath, resolvedAddr))
 

--- a/core/cmd/irrlichd/paths.go
+++ b/core/cmd/irrlichd/paths.go
@@ -89,22 +89,22 @@ func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Ag
 	home, _ := os.UserHomeDir()
 	ledgerDir, _ := metrics.LedgerDir()
 	logsDir, _ := logging.LogDir()
-	return services.NewDiagnosticsService(
-		fsRepo,
-		processlifecycle.Observer(),
-		processlifecycle.IsAlive,
-		allAgents,
-		claudecode.AdapterName,
-		cfg,
-		Version,
-		services.DiagnosticsPaths{
+	return services.NewDiagnosticsService(services.DiagnosticsServiceDeps{
+		Repo:           fsRepo,
+		Obs:            processlifecycle.Observer(),
+		IsAlive:        processlifecycle.IsAlive,
+		Agents:         allAgents,
+		DefaultAdapter: claudecode.AdapterName,
+		Cfg:            cfg,
+		Version:        Version,
+		Paths: services.DiagnosticsPaths{
 			Home:            home,
 			InstancesDir:    fsRepo.InstancesDir(),
 			LedgerDir:       ledgerDir,
 			LogsDir:         logsDir,
 			PermissionsFile: filepath.Join(dataDir(home), "permissions.json"),
 		},
-	)
+	})
 }
 
 // runDiagnose writes a diagnostics bundle to the current directory and exits.

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -368,31 +368,33 @@ func setupProcessWatcher(demoMode bool, detector **services.SessionDetector, log
 	}
 }
 
+// registerCoreRoutesDeps bundles registerCoreRoutes' dependencies.
+type registerCoreRoutesDeps struct {
+	FSRepo            *filesystem.SessionRepository
+	CachedRepo        outbound.SessionRepository
+	HistoryTracker    *services.HistoryTracker
+	Push              outbound.PushBroadcaster
+	AllAgents         []agent.Agent
+	Version           string
+	PublishController *relay.PublishController
+	Cfg               config.Config
+}
+
 // registerCoreRoutes wires the always-on API surface: session state, the
 // WebSocket stream, agent/version metadata, relay publish status, pprof, and
 // the diagnostics bundle. The sessions endpoint itself is registered
 // separately by registerSessionRoutes, once orchMonitor is available.
-func registerCoreRoutes(
-	mux *http.ServeMux,
-	fsRepo *filesystem.SessionRepository,
-	cachedRepo outbound.SessionRepository,
-	historyTracker *services.HistoryTracker,
-	push outbound.PushBroadcaster,
-	allAgents []agent.Agent,
-	version string,
-	publishController *relay.PublishController,
-	cfg config.Config,
-) {
-	mux.HandleFunc("GET /state", handleGetState(cachedRepo))
+func registerCoreRoutes(mux *http.ServeMux, deps registerCoreRoutesDeps) {
+	mux.HandleFunc("GET /state", handleGetState(deps.CachedRepo))
 
-	hub := wshub.NewHub(push, historySnapshotProvider(historyTracker))
+	hub := wshub.NewHub(deps.Push, historySnapshotProvider(deps.HistoryTracker))
 	mux.HandleFunc("GET /api/v1/sessions/stream", hub.ServeWS)
-	mux.HandleFunc("GET /api/v1/agents", handleGetAgents(allAgents))
-	mux.HandleFunc("GET /api/v1/version", handleGetVersion(version))
-	mux.HandleFunc("GET /api/v1/relay/publish", handleGetPublishStatus(publishController))
+	mux.HandleFunc("GET /api/v1/agents", handleGetAgents(deps.AllAgents))
+	mux.HandleFunc("GET /api/v1/version", handleGetVersion(deps.Version))
+	mux.HandleFunc("GET /api/v1/relay/publish", handleGetPublishStatus(deps.PublishController))
 	// PUT reconfigures publishing on the running daemon (issue #722). Loopback
 	// only: it mutates forwarder config and carries the relay token in its body.
-	mux.HandleFunc("PUT /api/v1/relay/publish", localhostOnly(handlePutPublishStatus(publishController)))
+	mux.HandleFunc("PUT /api/v1/relay/publish", localhostOnly(handlePutPublishStatus(deps.PublishController)))
 
 	// pprof debug endpoints for runtime profiling (localhost only).
 	mux.HandleFunc("GET /debug/pprof/", localhostOnly(pprof.Index))
@@ -405,7 +407,7 @@ func registerCoreRoutes(
 	// per-PID liveness, trimmed logs, and config for bug reports. Localhost
 	// only — it carries session paths and (pre-redaction) process argv. Reads
 	// fsRepo directly for a fresh, uncached snapshot.
-	diagSvc := buildDiagnostics(fsRepo, allAgents, cfg)
+	diagSvc := buildDiagnostics(deps.FSRepo, deps.AllAgents, deps.Cfg)
 	mux.HandleFunc("GET /debug/bundle", localhostOnly(handleDiagnosticsBundle(diagSvc)))
 }
 
@@ -556,23 +558,25 @@ func gastownEffects(orchCtx context.Context, orchMonitor *services.OrchestratorM
 	return start, stop
 }
 
+// registerSessionRoutesDeps bundles registerSessionRoutes' dependencies.
+type registerSessionRoutesDeps struct {
+	CachedRepo   outbound.SessionRepository
+	OrchMonitor  *services.OrchestratorMonitor
+	CostTracker  outbound.CostTracker
+	InputService *atomic.Pointer[services.InputService]
+	SockPath     string
+	Push         outbound.PushBroadcaster
+	Logger       outbound.Logger
+}
+
 // registerSessionRoutes wires the sessions/history/focus endpoints. Kept
 // separate from registerCoreRoutes because it needs orchMonitor and the
 // not-yet-published inputService: a session only reports controllable once
 // setupBackchannel has run.
-func registerSessionRoutes(
-	mux *http.ServeMux,
-	cachedRepo outbound.SessionRepository,
-	orchMonitor *services.OrchestratorMonitor,
-	costTracker outbound.CostTracker,
-	inputService *atomic.Pointer[services.InputService],
-	sockPath string,
-	push outbound.PushBroadcaster,
-	logger outbound.Logger,
-) {
-	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(cachedRepo, orchMonitor, costTracker,
+func registerSessionRoutes(mux *http.ServeMux, deps registerSessionRoutesDeps) {
+	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(deps.CachedRepo, deps.OrchMonitor, deps.CostTracker,
 		func(sessionID string) bool {
-			if s := inputService.Load(); s != nil {
+			if s := deps.InputService.Load(); s != nil {
 				return s.Controllable(sessionID)
 			}
 			return false
@@ -583,11 +587,27 @@ func registerSessionRoutes(
 	// chart=yield (per-project productive-vs-reverted spend over sessions). Phase
 	// 3 (#751) adds chart=agents, a concurrent-agents series reconstructed from
 	// the lifecycle recordings (read-only; empty unless --record has been used).
-	concurrencyTracker := filesystem.NewConcurrencyTrackerWithDir(resolveRecordingsDir(sockPath))
-	mux.HandleFunc("GET /api/v1/history", handleGetHistory(costTracker, cachedRepo, concurrencyTracker))
+	concurrencyTracker := filesystem.NewConcurrencyTrackerWithDir(resolveRecordingsDir(deps.SockPath))
+	mux.HandleFunc("GET /api/v1/history", handleGetHistory(deps.CostTracker, deps.CachedRepo, concurrencyTracker))
 
-	focusService := services.NewFocusService(cachedRepo, push, logger)
-	mux.HandleFunc("POST /api/v1/sessions/{id}/focus", sessionshandler.NewFocusHandler(focusService, logger))
+	focusService := services.NewFocusService(deps.CachedRepo, deps.Push, deps.Logger)
+	mux.HandleFunc("POST /api/v1/sessions/{id}/focus", sessionshandler.NewFocusHandler(focusService, deps.Logger))
+}
+
+// buildDetectorDeps bundles buildDetector's dependencies.
+type buildDetectorDeps struct {
+	DemoMode         bool
+	PWPort           outbound.ProcessWatcher
+	CachedRepo       outbound.SessionRepository
+	Logger           outbound.Logger
+	GitResolver      *git.Adapter
+	MetricsCollector outbound.MetricsCollector
+	Push             outbound.PushBroadcaster
+	Version          string
+	Cfg              config.Config
+	AllAgents        []agent.Agent
+	CostTracker      outbound.CostTracker
+	HistoryTracker   *services.HistoryTracker
 }
 
 // buildDetector constructs the SessionDetector (orchestrating Watchers +
@@ -598,26 +618,13 @@ func registerSessionRoutes(
 // factory that the PermissionService invokes only when the user grants that
 // agent's observe permission — and cancels on revoke. Skipped entirely
 // under demo mode, which serves only what's already on disk in instances/.
-func buildDetector(
-	demoMode bool,
-	pwPort outbound.ProcessWatcher,
-	cachedRepo outbound.SessionRepository,
-	logger outbound.Logger,
-	gitResolver *git.Adapter,
-	metricsCollector outbound.MetricsCollector,
-	push outbound.PushBroadcaster,
-	version string,
-	cfg config.Config,
-	allAgents []agent.Agent,
-	costTracker outbound.CostTracker,
-	historyTracker *services.HistoryTracker,
-) (*services.SessionDetector, map[string]services.WatcherFactory) {
+func buildDetector(deps buildDetectorDeps) (*services.SessionDetector, map[string]services.WatcherFactory) {
 	// Suppress ghost proc pre-sessions for live processes whose real session
 	// is already persisted. The PID discriminator in HasRealSessionForPID
 	// prevents historical sessions on disk (GH #113, within MaxSessionAge)
 	// from blocking new processes in the same project.
 	realSessionCheck := func(projectDir string, pid int) bool {
-		sessions, err := cachedRepo.ListAll()
+		sessions, err := deps.CachedRepo.ListAll()
 		if err != nil {
 			return false
 		}
@@ -625,41 +632,48 @@ func buildDetector(
 	}
 
 	var watcherFactories map[string]services.WatcherFactory
-	if !demoMode {
-		watcherFactories = make(map[string]services.WatcherFactory, len(allAgents))
-		for _, a := range allAgents {
+	if !deps.DemoMode {
+		watcherFactories = make(map[string]services.WatcherFactory, len(deps.AllAgents))
+		for _, a := range deps.AllAgents {
 			watcherFactories[a.Identity.Name] = func() []inbound.Watcher {
-				ws, _ := buildAgentWatchers(a, cfg.MaxSessionAge, realSessionCheck)
+				ws, _ := buildAgentWatchers(a, deps.Cfg.MaxSessionAge, realSessionCheck)
 				return ws
 			}
 		}
 	}
 
-	pidDiscovers := agents.PIDDiscoverers(allAgents)
-	processNames := agents.ProcessNames(allAgents)
+	pidDiscovers := agents.PIDDiscoverers(deps.AllAgents)
+	processNames := agents.ProcessNames(deps.AllAgents)
 
-	detector := services.NewSessionDetector(
-		nil, pwPort,
-		cachedRepo, logger, gitResolver, metricsCollector, push,
-		version, cfg.ReadySessionTTL,
-		pidDiscovers, processNames, processlifecycle.LiveCWDs,
-	)
-	if costTracker != nil {
-		detector.SetCostTracker(costTracker)
+	detector := services.NewSessionDetector(nil, services.SessionDetectorDeps{
+		PW:           deps.PWPort,
+		Repo:         deps.CachedRepo,
+		Log:          deps.Logger,
+		Git:          deps.GitResolver,
+		Metrics:      deps.MetricsCollector,
+		Broadcaster:  deps.Push,
+		Version:      deps.Version,
+		ReadyTTL:     deps.Cfg.ReadySessionTTL,
+		PIDDiscovers: pidDiscovers,
+		ProcessNames: processNames,
+		LiveCWDs:     processlifecycle.LiveCWDs,
+	})
+	if deps.CostTracker != nil {
+		detector.SetCostTracker(deps.CostTracker)
 	}
-	detector.SetHistoryTracker(historyTracker)
+	detector.SetHistoryTracker(deps.HistoryTracker)
 
 	// Cache-creation regression detector (#374): per-project baseline from the
 	// session repo; findings logged to events.log for the ir:agent-releases
 	// consumer. Self-disables when cacheBloatThreshold <= 0 (the kill switch).
 	detector.SetCacheBloatDetector(services.NewCacheBloatDetector(
-		cachedRepo,
-		services.NewLoggerCacheBloatSink(logger),
+		deps.CachedRepo,
+		services.NewLoggerCacheBloatSink(deps.Logger),
 		services.CacheBloatConfig{
-			BaselineDays:       cfg.CacheBloatBaselineDays,
-			Threshold:          cfg.CacheBloatThreshold,
-			VersionDeltaTokens: cfg.CacheBloatVersionDeltaTokens,
-			MinTurns:           cfg.CacheBloatMinTurns,
+			BaselineDays:       deps.Cfg.CacheBloatBaselineDays,
+			Threshold:          deps.Cfg.CacheBloatThreshold,
+			VersionDeltaTokens: deps.Cfg.CacheBloatVersionDeltaTokens,
+			MinTurns:           deps.Cfg.CacheBloatMinTurns,
 		},
 	))
 
@@ -673,26 +687,32 @@ func buildDetector(
 // that makes the wizard appear when a new agent shows up. Under demo mode
 // the factories and detection are nil — the daemon never monitors anything
 // live.
-func setupPermissionService(
-	mux *http.ServeMux,
-	detector *services.SessionDetector,
-	push outbound.PushBroadcaster,
-	logger outbound.Logger,
-	cfg config.Config,
-	allAgents []agent.Agent,
-	watcherFactories map[string]services.WatcherFactory,
-	demoMode bool,
-	home string,
-	startGastown, stopGastown func() error,
-) *services.PermissionService {
-	permStore := filesystem.NewPermissionStore(dataDir(home))
+// setupPermissionServiceDeps bundles setupPermissionService's dependencies.
+type setupPermissionServiceDeps struct {
+	Detector         *services.SessionDetector
+	Push             outbound.PushBroadcaster
+	Logger           outbound.Logger
+	Cfg              config.Config
+	AllAgents        []agent.Agent
+	WatcherFactories map[string]services.WatcherFactory
+	DemoMode         bool
+	Home             string
+	StartGastown     func() error
+	StopGastown      func() error
+}
+
+func setupPermissionService(mux *http.ServeMux, deps setupPermissionServiceDeps) *services.PermissionService {
+	detector := deps.Detector
+	logger := deps.Logger
+	allAgents := deps.AllAgents
+	permStore := filesystem.NewPermissionStore(dataDir(deps.Home))
 	// Fold the pre-wizard task-eta consent record (activation.json, issue
 	// #558) into the store before the service loads it (issue #577).
-	services.MigrateLegacyTaskEtaConsent(dataDir(home), permStore,
+	services.MigrateLegacyTaskEtaConsent(dataDir(deps.Home), permStore,
 		claudecode.AdapterName, claudecode.PermissionKeyInstructions, logger)
 
 	var hasLive services.HasLiveProcessFunc
-	if !demoMode {
+	if !deps.DemoMode {
 		hasLive = processlifecycle.HasLiveProcess
 	}
 	// The consent catalog is the agent adapters plus three daemon-wide
@@ -702,13 +722,19 @@ func setupPermissionService(
 	// remote-control config patch (writes kitty.conf for tab-precise
 	// click-to-focus, #425).
 	permissionAgents := append(append([]agent.Agent{}, allAgents...),
-		gastownadapter.PermissionDeclaration(startGastown, stopGastown),
+		gastownadapter.PermissionDeclaration(deps.StartGastown, deps.StopGastown),
 		processlifecycle.LauncherPermissionDeclaration(),
 		processlifecycle.KittyPermissionDeclaration())
-	permService := services.NewPermissionService(
-		permissionAgents, permStore, push, logger,
-		cfg.PermissionMode, detector, watcherFactories, hasLive,
-	)
+	permService := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    permissionAgents,
+		Store:     permStore,
+		Push:      deps.Push,
+		Log:       logger,
+		Mode:      deps.Cfg.PermissionMode,
+		Registrar: detector,
+		Factories: deps.WatcherFactories,
+		HasLive:   hasLive,
+	})
 	// Gas Town is detected by root-directory presence (stat-only), not by
 	// a live process matcher.
 	permService.SetDetectionProbe(gastownadapter.Name, gastownadapter.RootDetected)
@@ -758,7 +784,7 @@ func setupPermissionService(
 	// --bg-spare pool helper outlives every session, so a mis-bound session
 	// would otherwise never be reaped (#727). Demo mode never tracks live
 	// processes, so leave the reaper unwired there.
-	if !demoMode {
+	if !deps.DemoMode {
 		detector.SetInfraReaper(agents.ArgvExcluders(allAgents), processlifecycle.ReadArgv)
 		// Reject a candidate PID launched by something other than a known
 		// terminal or IDE before a session is ever created — e.g. CodexBar
@@ -791,6 +817,19 @@ func setupPermissionService(
 	return permService
 }
 
+// setupBackchannelDeps bundles setupBackchannel's dependencies.
+type setupBackchannelDeps struct {
+	CachedRepo        outbound.SessionRepository
+	Push              outbound.PushBroadcaster
+	PermService       *services.PermissionService
+	Detector          *services.SessionDetector
+	Logger            outbound.Logger
+	Home              string
+	InputService      *atomic.Pointer[services.InputService]
+	RelayControlStore *filesystem.RelayControlStore
+	AllAgents         []agent.Agent
+}
+
 // setupBackchannel wires control discovered agents by scripting their
 // terminal backend (issue #724). A default-OFF master toggle gates the whole
 // capability; the per-adapter "control" consent and a usable backend target
@@ -798,28 +837,18 @@ func setupPermissionService(
 // controllable) for both the manual HTTP path and the event→action rule
 // engine. Routes are localhostOnly + a Sec-Fetch-Site guard on the mutating
 // verbs, since injected input drives a live agent.
-func setupBackchannel(
-	mux *http.ServeMux,
-	cachedRepo outbound.SessionRepository,
-	push outbound.PushBroadcaster,
-	permService *services.PermissionService,
-	detector *services.SessionDetector,
-	logger outbound.Logger,
-	home string,
-	inputService *atomic.Pointer[services.InputService],
-	relayControlStore *filesystem.RelayControlStore,
-	allAgents []agent.Agent,
-) (*services.BackchannelEngine, *services.TerminalObserver) {
-	backchannelStore := filesystem.NewBackchannelStore(dataDir(home))
-	controlController := control.NewController(cachedRepo, push, logger)
-	in := services.NewInputService(cachedRepo, controlController, permService, backchannelStore.Enabled, logger)
-	inputService.Store(in) // publish to the HTTP/forwarder readers
+func setupBackchannel(mux *http.ServeMux, deps setupBackchannelDeps) (*services.BackchannelEngine, *services.TerminalObserver) {
+	logger := deps.Logger
+	backchannelStore := filesystem.NewBackchannelStore(dataDir(deps.Home))
+	controlController := control.NewController(deps.CachedRepo, deps.Push, logger)
+	in := services.NewInputService(deps.CachedRepo, controlController, deps.PermService, backchannelStore.Enabled, logger)
+	deps.InputService.Store(in) // publish to the HTTP/forwarder readers
 	mux.HandleFunc("/api/v1/activation/backchannel",
 		localhostOnly(activationhandler.NewBackchannelHandler(backchannelStore, logger)))
 	// Remote-control toggle (#724): default OFF; gates whether the relay
 	// forwarder acts on inbound control frames (the outer remote gate).
 	mux.HandleFunc("/api/v1/activation/relay-control",
-		localhostOnly(activationhandler.NewToggleHandler(relayControlStore, "relay_control_enabled", logger)))
+		localhostOnly(activationhandler.NewToggleHandler(deps.RelayControlStore, "relay_control_enabled", logger)))
 	mux.HandleFunc("POST /api/v1/sessions/{id}/input",
 		localhostOnly(sessionshandler.NewInputHandler(in, logger)))
 	mux.HandleFunc("POST /api/v1/sessions/{id}/interrupt",
@@ -829,8 +858,8 @@ func setupBackchannel(
 	// context_pressure → /compact). The engine consumes the push stream and
 	// fires through inputService, so the same toggle+consent+controllable
 	// gates apply. Started under detectorCtx by startBackgroundLoops.
-	backchannelRules := filesystem.NewBackchannelRulesStore(dataDir(home))
-	backchannelEngine := services.NewBackchannelEngine(backchannelRules, in, agents.ControlPresets(allAgents), push, backchannelStore.Enabled, logger)
+	backchannelRules := filesystem.NewBackchannelRulesStore(dataDir(deps.Home))
+	backchannelEngine := services.NewBackchannelEngine(backchannelRules, in, agents.ControlPresets(deps.AllAgents), deps.Push, backchannelStore.Enabled, logger)
 	mux.HandleFunc("/api/v1/backchannel/rules",
 		localhostOnly(backchannelhandler.NewRulesHandler(backchannelRules, logger)))
 
@@ -841,8 +870,8 @@ func setupBackchannel(
 	// inputService — master-toggle + per-adapter "control" consent — so a
 	// disabled backchannel reads nothing. Started under detectorCtx by
 	// startBackgroundLoops.
-	terminalReader := control.NewReader(cachedRepo, logger)
-	terminalObserver := services.NewTerminalObserver(cachedRepo, terminalReader, permService, backchannelStore.Enabled, detector, logger)
+	terminalReader := control.NewReader(deps.CachedRepo, logger)
+	terminalObserver := services.NewTerminalObserver(deps.CachedRepo, terminalReader, deps.PermService, backchannelStore.Enabled, deps.Detector, logger)
 
 	return backchannelEngine, terminalObserver
 }
@@ -919,45 +948,49 @@ func sweepZombies(demoMode bool, detector *services.SessionDetector, logger outb
 // launches the detection poller. Effects run synchronously so a grant-all
 // daemon (demo/record/test) is fully monitoring before startup proceeds.
 // Returns the cancel func for the shared context; the caller defers it.
-func startBackgroundLoops(
-	detector *services.SessionDetector,
-	backchannelEngine *services.BackchannelEngine,
-	cachedRepo outbound.SessionRepository,
-	gitResolver *git.Adapter,
-	terminalObserver *services.TerminalObserver,
-	permService *services.PermissionService,
-	cfg config.Config,
-	demoMode bool,
-	logger outbound.Logger,
-) context.CancelFunc {
+// startBackgroundLoopsDeps bundles startBackgroundLoops' dependencies.
+type startBackgroundLoopsDeps struct {
+	Detector          *services.SessionDetector
+	BackchannelEngine *services.BackchannelEngine
+	CachedRepo        outbound.SessionRepository
+	GitResolver       *git.Adapter
+	TerminalObserver  *services.TerminalObserver
+	PermService       *services.PermissionService
+	Cfg               config.Config
+	DemoMode          bool
+	Logger            outbound.Logger
+}
+
+func startBackgroundLoops(deps startBackgroundLoopsDeps) context.CancelFunc {
+	logger := deps.Logger
 	detectorCtx, detectorCancel := context.WithCancel(context.Background())
 	go func() {
-		if err := detector.Run(detectorCtx); err != nil && err != context.Canceled {
+		if err := deps.Detector.Run(detectorCtx); err != nil && err != context.Canceled {
 			logger.LogError("session-detector", "", fmt.Sprintf("detector error: %v", err))
 		}
 	}()
 
-	go backchannelEngine.Run(detectorCtx)
+	go deps.BackchannelEngine.Run(detectorCtx)
 
 	// Yield sweep (issue #373): periodically correlates `git revert` commits
 	// back to the sessions that authored the reverted work, flipping their
 	// YieldState to reverted. Read-mostly and fault-tolerant, so it runs in
 	// every mode.
-	go services.NewYieldSweeper(cachedRepo, gitResolver, logger, cfg.YieldSweepInterval).Run(detectorCtx)
+	go services.NewYieldSweeper(deps.CachedRepo, deps.GitResolver, logger, deps.Cfg.YieldSweepInterval).Run(detectorCtx)
 
 	go func() {
-		if err := terminalObserver.Run(detectorCtx); err != nil && err != context.Canceled {
+		if err := deps.TerminalObserver.Run(detectorCtx); err != nil && err != context.Canceled {
 			logger.LogError("terminal-observer", "", fmt.Sprintf("observer error: %v", err))
 		}
 	}()
 
-	if !demoMode {
-		permService.Start(detectorCtx)
+	if !deps.DemoMode {
+		deps.PermService.Start(detectorCtx)
 		// The installed hooks POST via curl; without it they silently no-op
 		// and tool-use permission prompts never surface as `waiting`. Warn
 		// loudly so this isn't an invisible failure (the transcript
 		// heuristic still covers held file-edit prompts). See #488.
-		if permService.Granted(claudecode.AdapterName, claudecode.PermissionKeyHooks) &&
+		if deps.PermService.Granted(claudecode.AdapterName, claudecode.PermissionKeyHooks) &&
 			!claudecode.HookDeliveryAvailable() {
 			logger.LogError("startup", "", "curl not found on PATH — Claude Code permission-prompt detection is degraded: hooks POST via curl, so without it permission prompts may not surface as 'waiting'. Install curl to restore full detection (#488).")
 		}

--- a/core/e2e/concurrent_test.go
+++ b/core/e2e/concurrent_test.go
@@ -26,19 +26,7 @@ func TestScanner_TracksTwoConcurrentProcessesWithSameAgentName(t *testing.T) {
 	scanner := processlifecycle.NewScanner(name, "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
-	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
-		PW:           nil,
-		Repo:         repo,
-		Log:          &nopLogger{},
-		Git:          &stubGit{},
-		Metrics:      &stubMetrics{},
-		Broadcaster:  nil,
-		Version:      "test",
-		ReadyTTL:     0,
-		PIDDiscovers: nil,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, defaultSessionDetectorDeps(repo))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/core/e2e/concurrent_test.go
+++ b/core/e2e/concurrent_test.go
@@ -26,11 +26,19 @@ func TestScanner_TracksTwoConcurrentProcessesWithSameAgentName(t *testing.T) {
 	scanner := processlifecycle.NewScanner(name, "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
-	detector := services.NewSessionDetector(
-		[]inbound.Watcher{scanner},
-		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil, nil, nil,
-	)
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
+		PW:           nil,
+		Repo:         repo,
+		Log:          &nopLogger{},
+		Git:          &stubGit{},
+		Metrics:      &stubMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/core/e2e/crash_test.go
+++ b/core/e2e/crash_test.go
@@ -27,11 +27,19 @@ func TestSession_NoCancelledState_OnSIGKILL(t *testing.T) {
 	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
-	detector := services.NewSessionDetector(
-		[]inbound.Watcher{scanner},
-		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil, nil, nil,
-	)
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
+		PW:           nil,
+		Repo:         repo,
+		Log:          &nopLogger{},
+		Git:          &stubGit{},
+		Metrics:      &stubMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/core/e2e/crash_test.go
+++ b/core/e2e/crash_test.go
@@ -27,19 +27,7 @@ func TestSession_NoCancelledState_OnSIGKILL(t *testing.T) {
 	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
-	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
-		PW:           nil,
-		Repo:         repo,
-		Log:          &nopLogger{},
-		Git:          &stubGit{},
-		Metrics:      &stubMetrics{},
-		Broadcaster:  nil,
-		Version:      "test",
-		ReadyTTL:     0,
-		PIDDiscovers: nil,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, defaultSessionDetectorDeps(repo))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/core/e2e/e2e_helpers_test.go
+++ b/core/e2e/e2e_helpers_test.go
@@ -13,9 +13,26 @@ import (
 	"time"
 
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
+	"irrlicht/core/application/services"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
 )
+
+// defaultSessionDetectorDeps returns the SessionDetectorDeps every e2e test in
+// this package builds identically (nopLogger/stubGit/stubMetrics, no
+// broadcaster, "test" version, zero ReadyTTL, no PID/process-name maps) —
+// callers overwrite only the field(s) their scenario needs.
+func defaultSessionDetectorDeps(repo outbound.SessionRepository) services.SessionDetectorDeps {
+	return services.SessionDetectorDeps{
+		Repo:     repo,
+		Log:      &nopLogger{},
+		Git:      &stubGit{},
+		Metrics:  &stubMetrics{},
+		Version:  "test",
+		ReadyTTL: 0,
+	}
+}
 
 // realTempDir returns a temp dir with macOS /var → /private/var symlinks resolved,
 // so paths match what lsof reports for process CWDs.

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -48,21 +48,7 @@ func TestPreSession_DetectedBeforeTranscript(t *testing.T) {
 	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
-	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
-		PW: nil,
-		Repo:// no ProcessWatcher needed
-		repo,
-		Log:         &nopLogger{},
-		Git:         &stubGit{},
-		Metrics:     &stubMetrics{},
-		Broadcaster: nil,
-		Version:// no broadcaster
-		"test",
-		ReadyTTL:     0,
-		PIDDiscovers: nil,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, defaultSessionDetectorDeps(repo))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -132,19 +118,7 @@ func TestPreSession_ReplacedByRealSession(t *testing.T) {
 		identity: testIdentity,
 	}
 
-	detector := services.NewSessionDetector([]inbound.Watcher{scanner, transcriptWatcher}, services.SessionDetectorDeps{
-		PW:           nil,
-		Repo:         repo,
-		Log:          &nopLogger{},
-		Git:          &stubGit{},
-		Metrics:      &stubMetrics{},
-		Broadcaster:  nil,
-		Version:      "test",
-		ReadyTTL:     0,
-		PIDDiscovers: nil,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner, transcriptWatcher}, defaultSessionDetectorDeps(repo))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -224,19 +198,7 @@ func TestPreSession_CreatedDespiteHistoricalSession(t *testing.T) {
 	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
-	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
-		PW:           nil,
-		Repo:         repo,
-		Log:          &nopLogger{},
-		Git:          &stubGit{},
-		Metrics:      &stubMetrics{},
-		Broadcaster:  nil,
-		Version:      "test",
-		ReadyTTL:     0,
-		PIDDiscovers: nil,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, defaultSessionDetectorDeps(repo))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -283,19 +245,7 @@ func TestPreSession_SurvivesNeighbourSessionActivity(t *testing.T) {
 	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
-	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
-		PW:           nil,
-		Repo:         repo,
-		Log:          &nopLogger{},
-		Git:          &stubGit{},
-		Metrics:      &stubMetrics{},
-		Broadcaster:  nil,
-		Version:      "test",
-		ReadyTTL:     0,
-		PIDDiscovers: nil,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, defaultSessionDetectorDeps(repo))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -341,19 +291,7 @@ func TestPreSession_RemovedOnProcessExit(t *testing.T) {
 	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
-	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
-		PW:           nil,
-		Repo:         repo,
-		Log:          &nopLogger{},
-		Git:          &stubGit{},
-		Metrics:      &stubMetrics{},
-		Broadcaster:  nil,
-		Version:      "test",
-		ReadyTTL:     0,
-		PIDDiscovers: nil,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, defaultSessionDetectorDeps(repo))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -434,19 +372,9 @@ func TestPreSession_DoesNotEvictNeighborSessionWithSharedCWD(t *testing.T) {
 	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
-	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
-		PW:           nil,
-		Repo:         repo,
-		Log:          &nopLogger{},
-		Git:          &stubGit{},
-		Metrics:      &stubMetrics{},
-		Broadcaster:  nil,
-		Version:      "test",
-		ReadyTTL:     0,
-		PIDDiscovers: discovers,
-		ProcessNames: nil,
-		LiveCWDs:     nil,
-	})
+	deps := defaultSessionDetectorDeps(repo)
+	deps.PIDDiscovers = discovers
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, deps)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/core/e2e/presession_test.go
+++ b/core/e2e/presession_test.go
@@ -48,16 +48,21 @@ func TestPreSession_DetectedBeforeTranscript(t *testing.T) {
 	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
-	detector := services.NewSessionDetector(
-		[]inbound.Watcher{scanner},
-		nil, // no ProcessWatcher needed
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
+		PW: nil,
+		Repo:// no ProcessWatcher needed
 		repo,
-		&nopLogger{},
-		&stubGit{},
-		&stubMetrics{},
-		nil, // no broadcaster
-		"test", 0, nil, nil, nil,
-	)
+		Log:         &nopLogger{},
+		Git:         &stubGit{},
+		Metrics:     &stubMetrics{},
+		Broadcaster: nil,
+		Version:// no broadcaster
+		"test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -127,11 +132,19 @@ func TestPreSession_ReplacedByRealSession(t *testing.T) {
 		identity: testIdentity,
 	}
 
-	detector := services.NewSessionDetector(
-		[]inbound.Watcher{scanner, transcriptWatcher},
-		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil, nil, nil,
-	)
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner, transcriptWatcher}, services.SessionDetectorDeps{
+		PW:           nil,
+		Repo:         repo,
+		Log:          &nopLogger{},
+		Git:          &stubGit{},
+		Metrics:      &stubMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -211,11 +224,19 @@ func TestPreSession_CreatedDespiteHistoricalSession(t *testing.T) {
 	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
-	detector := services.NewSessionDetector(
-		[]inbound.Watcher{scanner},
-		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil, nil, nil,
-	)
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
+		PW:           nil,
+		Repo:         repo,
+		Log:          &nopLogger{},
+		Git:          &stubGit{},
+		Metrics:      &stubMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -262,11 +283,19 @@ func TestPreSession_SurvivesNeighbourSessionActivity(t *testing.T) {
 	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
-	detector := services.NewSessionDetector(
-		[]inbound.Watcher{scanner},
-		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil, nil, nil,
-	)
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
+		PW:           nil,
+		Repo:         repo,
+		Log:          &nopLogger{},
+		Git:          &stubGit{},
+		Metrics:      &stubMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -312,11 +341,19 @@ func TestPreSession_RemovedOnProcessExit(t *testing.T) {
 	scanner := processlifecycle.NewScanner(processName, "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	repo := newMemRepo()
 
-	detector := services.NewSessionDetector(
-		[]inbound.Watcher{scanner},
-		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil, nil, nil,
-	)
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
+		PW:           nil,
+		Repo:         repo,
+		Log:          &nopLogger{},
+		Git:          &stubGit{},
+		Metrics:      &stubMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -397,11 +434,19 @@ func TestPreSession_DoesNotEvictNeighborSessionWithSharedCWD(t *testing.T) {
 	scanner := processlifecycle.NewScanner(fakeProcessName(), "test", 200*time.Millisecond).WithIdentity(testIdentity)
 	scanner.WithSessionChecker(realSessionCheckerFor(repo))
 
-	detector := services.NewSessionDetector(
-		[]inbound.Watcher{scanner},
-		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, discovers, nil, nil,
-	)
+	detector := services.NewSessionDetector([]inbound.Watcher{scanner}, services.SessionDetectorDeps{
+		PW:           nil,
+		Repo:         repo,
+		Log:          &nopLogger{},
+		Git:          &stubGit{},
+		Metrics:      &stubMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: discovers,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/core/e2e/startup_cleanup_test.go
+++ b/core/e2e/startup_cleanup_test.go
@@ -66,11 +66,19 @@ func TestStartupCleanup_DeletesZombieFromPriorDaemonRun(t *testing.T) {
 		t.Fatalf("seed living: %v", err)
 	}
 
-	detector := services.NewSessionDetector(
-		[]inbound.Watcher{},
-		nil, repo, &nopLogger{}, &stubGit{}, &stubMetrics{}, nil,
-		"test", 0, nil, nil, nil,
-	)
+	detector := services.NewSessionDetector([]inbound.Watcher{}, services.SessionDetectorDeps{
+		PW:           nil,
+		Repo:         repo,
+		Log:          &nopLogger{},
+		Git:          &stubGit{},
+		Metrics:      &stubMetrics{},
+		Broadcaster:  nil,
+		Version:      "test",
+		ReadyTTL:     0,
+		PIDDiscovers: nil,
+		ProcessNames: nil,
+		LiveCWDs:     nil,
+	})
 
 	deleted := detector.CleanupZombies()
 	if deleted != 1 {

--- a/platforms/macos/TestsHarness/LauncherHarnessTests.swift
+++ b/platforms/macos/TestsHarness/LauncherHarnessTests.swift
@@ -20,32 +20,38 @@ final class LauncherHarnessTests: XCTestCase {
 
     // MARK: - Helpers
 
+    /// Bundles makeSession's optional launcher-identity fields, beyond the
+    /// core termProgram/cwd pair every session needs.
+    private struct LauncherOverrides {
+        var itermSessionID: String? = nil
+        var tty: String? = nil
+        var kittyListenOn: String? = nil
+        var kittyWindowID: String? = nil
+        var kittyPID: Int? = nil
+        var tmuxPane: String? = nil
+        var tmuxSocket: String? = nil
+    }
+
     /// Constructs a minimal SessionState whose launcher is wired to the given
     /// termProgram, cwd, and optional extra fields.
     private func makeSession(
         id: String = UUID().uuidString,
         termProgram: String,
         cwd: String,
-        itermSessionID: String? = nil,
-        tty: String? = nil,
-        kittyListenOn: String? = nil,
-        kittyWindowID: String? = nil,
-        kittyPID: Int? = nil,
-        tmuxPane: String? = nil,
-        tmuxSocket: String? = nil
+        launcher overrides: LauncherOverrides = LauncherOverrides()
     ) throws -> SessionState {
         // Build the JSON we'd receive from the daemon so we rely on the actual
         // Codable path rather than synthesising via initializer.
         var launcherFields: [String: Any] = [
             "term_program": termProgram,
         ]
-        if let v = itermSessionID  { launcherFields["iterm_session_id"] = v }
-        if let v = tty             { launcherFields["tty"] = v }
-        if let v = kittyListenOn   { launcherFields["kitty_listen_on"] = v }
-        if let v = kittyWindowID   { launcherFields["kitty_window_id"] = v }
-        if let v = kittyPID        { launcherFields["kitty_pid"] = v }
-        if let v = tmuxPane        { launcherFields["tmux_pane"] = v }
-        if let v = tmuxSocket      { launcherFields["tmux_socket"] = v }
+        if let v = overrides.itermSessionID  { launcherFields["iterm_session_id"] = v }
+        if let v = overrides.tty             { launcherFields["tty"] = v }
+        if let v = overrides.kittyListenOn   { launcherFields["kitty_listen_on"] = v }
+        if let v = overrides.kittyWindowID   { launcherFields["kitty_window_id"] = v }
+        if let v = overrides.kittyPID        { launcherFields["kitty_pid"] = v }
+        if let v = overrides.tmuxPane        { launcherFields["tmux_pane"] = v }
+        if let v = overrides.tmuxSocket      { launcherFields["tmux_socket"] = v }
 
         let sessionDict: [String: Any] = [
             "session_id": id,
@@ -154,9 +160,11 @@ final class LauncherHarnessTests: XCTestCase {
         let session = try makeSession(
             termProgram: "kitty",
             cwd: "/tmp/kitty-decode-test",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
-            kittyListenOn: "unix:/tmp/kitty-12345",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
-            kittyWindowID: "2",
-            kittyPID: 12345
+            launcher: LauncherOverrides(
+                kittyListenOn: "unix:/tmp/kitty-12345",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+                kittyWindowID: "2",
+                kittyPID: 12345
+            )
         )
         XCTAssertEqual(session.launcher?.kittyPID, 12345)
         XCTAssertEqual(session.launcher?.kittyListenOn, "unix:/tmp/kitty-12345")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint


### PR DESCRIPTION
## Summary
- Fixes 13 SonarQube findings (`go:S107` ×12, `swift:S107` ×1 — backlog tracked in #901): functions exceeding the 7-parameter limit.
- 5 exported service constructors (`NewPIDManager`, `NewDiagnosticsService`, `NewForwarder`, `NewSessionDetector`, `NewPermissionService`) now take a doc-commented `XxxDeps` struct instead of a long positional list, following the existing `Options`-struct convention in `core/application/replayengine/engine.go`.
- 6 single-call-site `core/cmd/irrlichd/startup.go` wiring helpers get the same treatment (`registerCoreRoutes`, `registerSessionRoutes`, `buildDetector`, `setupPermissionService`, `setupBackchannel`, `startBackgroundLoops`).
- `insertPart` test helper in `opencode/watcher_test.go` bundles its 6 column args into a `partRow` struct.
- Swift's `LauncherHarnessTests.swift` `makeSession` bundles its 7 optional launcher-identity params into a `LauncherOverrides` struct.
- Pure signature refactor — no behavior change. All 61+ call sites (production wiring + tests) updated to named struct literals.

## Test plan
- [x] `gofmt -l core/` — clean
- [x] `go build ./core/...`, `go vet ./core/...` — clean
- [x] `go test ./core/... -count=1` — passes (two different tests flaked across separate full-suite runs — `TestSessionDetector_ParentReleasedToReady_WhenChildFinishes` and `TestDaemonStartupSmoke`/`TestDebounce_FirstEventFiresImmediately` — each confirmed to pass reliably in isolation; pre-existing timing/resource-contention flakiness under full-package load, unrelated to this pure signature change)
- [x] `swift build --build-tests` in `platforms/macos` — succeeds, including the edited `LauncherHarnessTests.swift`
- [x] `/code-review low` — no findings
- [x] `tools/preflight.sh` (pre-push hook) — passed