### PR TITLE
fix(macos): unify Settings/History panel chrome — header, toggle, spacing, width

### DIFF
--- a/platforms/macos/Irrlicht/Models/HistoryData.swift
+++ b/platforms/macos/Irrlicht/Models/HistoryData.swift
@@ -123,10 +123,7 @@ enum HistoryRange: String, CaseIterable, Identifiable {
 
     /// Query items for `GET /api/v1/history`, mirroring the web `historyQuery()`:
     /// presets send `range`; `.custom` sends explicit `start`/`end` unix seconds.
-    /// `filters` carries the orthogonal cross-filters keyed by dimension; the
-    /// dimension being grouped on is dropped (never both axis and filter), and
-    /// token_type is omitted outside the tokens metric.
-    func queryItems(chart: HistoryChart, group: HistoryGroup, scope: HistoryScope?, filters: [HistoryGroup: [String]], forecast: Bool, customStart: Int64?, customEnd: Int64?) -> [URLQueryItem] {
+    func queryItems(chart: HistoryChart, group: HistoryGroup, scope: HistoryScope?, forecast: Bool, customStart: Int64?, customEnd: Int64?) -> [URLQueryItem] {
         var items = [
             URLQueryItem(name: "chart", value: chart.rawValue),
             URLQueryItem(name: "group", value: group.rawValue),
@@ -134,13 +131,6 @@ enum HistoryRange: String, CaseIterable, Identifiable {
         ]
         if let scope {
             items.append(URLQueryItem(name: "scope", value: scope.query))
-        }
-        for dim in [HistoryGroup.provider, .tokenType, .project] {
-            if dim == group { continue }
-            if dim == .tokenType && chart != .tokens { continue }
-            if let vals = filters[dim], !vals.isEmpty {
-                items.append(URLQueryItem(name: dim.rawValue, value: vals.sorted().joined(separator: ",")))
-            }
         }
         if self == .custom, let customStart, let customEnd {
             items.append(URLQueryItem(name: "start", value: String(customStart)))
@@ -152,8 +142,9 @@ enum HistoryRange: String, CaseIterable, Identifiable {
     }
 }
 
-/// Token kind for the `token_type` group axis and the token_type cross-filter
-/// (#750). Raw values match the daemon's `outbound.TokenTypeKeys`.
+/// Token kind for the `token_type` group axis and its band labels in the
+/// content-view legend (#750). Raw values match the daemon's
+/// `outbound.TokenTypeKeys`.
 enum HistoryTokenType: String, CaseIterable, Identifiable {
     case input, output
     case cacheRead = "cache_read"

--- a/platforms/macos/Irrlicht/Views/EqualWidthSegmentedControl.swift
+++ b/platforms/macos/Irrlicht/Views/EqualWidthSegmentedControl.swift
@@ -1,0 +1,63 @@
+import AppKit
+import SwiftUI
+
+/// A segmented control whose segments always split the available width
+/// evenly, edge to edge (issue #940).
+///
+/// SwiftUI's `Picker(pickerStyle: .segmented)` only centers within extra
+/// space `.frame(maxWidth: .infinity)` offers — it never stretches into it,
+/// because the underlying `NSSegmentedControl` sizes to fit its content and
+/// ignores externally imposed width. Bridging to `NSSegmentedControl`
+/// directly and setting `segmentDistribution = .fillEqually` is the native
+/// fix, mirroring `IrrlichtSwitchToggleStyle`'s precedent of dropping to
+/// AppKit when SwiftUI's stock control can't be styled the way the app
+/// needs.
+struct EqualWidthSegmentedControl: NSViewRepresentable {
+    let labels: [String]
+    let values: [String]
+    @Binding var selection: String
+    var tint: Color?
+
+    func makeNSView(context: Context) -> NSSegmentedControl {
+        let control = NSSegmentedControl(
+            labels: labels,
+            trackingMode: .selectOne,
+            target: context.coordinator,
+            action: #selector(Coordinator.changed(_:))
+        )
+        control.segmentDistribution = .fillEqually
+        return control
+    }
+
+    func updateNSView(_ nsView: NSSegmentedControl, context: Context) {
+        context.coordinator.parent = self
+        if let idx = values.firstIndex(of: selection), nsView.selectedSegment != idx {
+            nsView.selectedSegment = idx
+        }
+        if let tint {
+            nsView.selectedSegmentBezelColor = NSColor(tint)
+        }
+    }
+
+    // Without this, SwiftUI falls back to the NSView's intrinsicContentSize
+    // for width — the same "hug content" sizing that makes the native
+    // Picker(pickerStyle: .segmented) refuse to stretch. Honoring the
+    // proposed width here (paired with `.frame(maxWidth: .infinity)` at the
+    // call site) is what actually makes this control fill the row.
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSSegmentedControl, context: Context) -> CGSize? {
+        let fitting = nsView.fittingSize
+        return CGSize(width: proposal.width ?? fitting.width, height: fitting.height)
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject {
+        var parent: EqualWidthSegmentedControl
+        init(_ parent: EqualWidthSegmentedControl) { self.parent = parent }
+
+        @objc func changed(_ sender: NSSegmentedControl) {
+            guard parent.values.indices.contains(sender.selectedSegment) else { return }
+            parent.selection = parent.values[sender.selectedSegment]
+        }
+    }
+}

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -47,15 +47,6 @@ struct HistoryView: View {
     @State private var appliedCustomStart: Int64?
     @State private var appliedCustomEnd: Int64?
 
-    // Orthogonal cross-filters (#750): each narrows the others; the grouped
-    // dimension's filter is hidden. knownProviders/knownProjects accumulate the
-    // option lists seen across responses (token types are a fixed set).
-    @State private var filterProvider: Set<String> = []
-    @State private var filterTokenType: Set<HistoryTokenType> = []
-    @State private var filterProject: Set<String> = []
-    @State private var knownProviders: [String] = []
-    @State private var knownProjects: [String] = []
-
     @State private var response: HistoryResponse?
     @State private var yieldResponse: HistoryYieldResponse?
     @State private var loadFailed = false
@@ -65,19 +56,11 @@ struct HistoryView: View {
         self._tab = State(initialValue: initialTab)
     }
 
-    /// The cross-filters keyed by dimension, for `queryItems` and the query key.
-    private var filtersDict: [HistoryGroup: [String]] {
-        [.provider: Array(filterProvider),
-         .tokenType: filterTokenType.map(\.rawValue),
-         .project: Array(filterProject)]
-    }
-
     /// Re-runs the fetch via `.task(id:)` whenever the effective query changes.
     /// This is the macOS equivalent of the web's manual `historyFetchSeq`
     /// dedup — `.task(id:)` cancels the in-flight request when the key changes.
     private var queryKey: String {
-        let flt = "\(filterProvider.sorted().joined(separator: ","))|\(filterTokenType.map(\.rawValue).sorted().joined(separator: ","))|\(filterProject.sorted().joined(separator: ","))"
-        let dims = "\(tab.rawValue)-\(fetchChart.rawValue)-\(effectiveGroup.rawValue)-\(scope?.query ?? "")-\(flt)"
+        let dims = "\(tab.rawValue)-\(fetchChart.rawValue)-\(effectiveGroup.rawValue)-\(scope?.query ?? "")"
         if range == .custom {
             return "custom-\(appliedCustomStart ?? 0)-\(appliedCustomEnd ?? 0)-\(dims)"
         }
@@ -133,7 +116,6 @@ struct HistoryView: View {
         // token concept); keep them consistent however either is changed.
         .onChange(of: group) { newGroup in
             if newGroup == .tokenType && chart != .tokens { chart = .tokens }
-            clearFilter(for: newGroup) // a dimension is never both axis and filter
         }
         .onChange(of: chart) { newChart in
             if newChart != .tokens && group == .tokenType { group = .project }
@@ -143,16 +125,6 @@ struct HistoryView: View {
         .onChange(of: tab) { newTab in
             scope = nil
             if newTab == .usage, chart == .yieldRatio { chart = .cost }
-        }
-    }
-
-    /// Clears the filter on whichever dimension just became the stacking axis.
-    private func clearFilter(for group: HistoryGroup) {
-        switch group {
-        case .provider: filterProvider = []
-        case .tokenType: filterTokenType = []
-        case .project: filterProject = []
-        default: break
         }
     }
 
@@ -196,9 +168,8 @@ struct HistoryView: View {
         .padding(.vertical, IrrSpacing.sp3)
     }
 
-    /// Range picker, shared by the Usage and Yield tabs. Labels are hidden —
-    /// with the row down to Range/Chart/Group/Filters, the value alone
-    /// ("Day", "Cost", "Proj") reads fine and keeps everything on one line.
+    /// Range picker for the Yield tab (Usage builds its own Range/Chart/Group
+    /// row where all three share the width evenly, so it doesn't reuse this).
     @ViewBuilder private var rangePicker: some View {
         Picker("Range", selection: $range) {
             ForEach(HistoryRange.allCases) { Text($0.label).tag($0) }
@@ -207,13 +178,20 @@ struct HistoryView: View {
         .fixedSize()
     }
 
-    /// Usage tab: cost/token time series. Range, Chart, Group, and the
-    /// cross-filters (as one "Filters" dropdown) all fit on a single row —
-    /// the models/providers presets are gone, they're just Cost grouped by
-    /// model/provider, which the Group axis already offers.
+    /// Usage tab: cost/token time series. Range, Chart, and Group share the
+    /// row evenly, each a third of the width (issue #940 — the "Filters"
+    /// cross-filter dropdown was dropped: narrowing to one project/branch/
+    /// model already works via drilldown, and the extra dimension wasn't
+    /// earning its row space) — the models/providers presets are gone too,
+    /// they're just Cost grouped by model/provider, which the Group axis
+    /// already offers.
     @ViewBuilder private var usageControls: some View {
         HStack(spacing: IrrSpacing.sp3) {
-            rangePicker
+            Picker("Range", selection: $range) {
+                ForEach(HistoryRange.allCases) { Text($0.label).tag($0) }
+            }
+            .labelsHidden()
+            .frame(maxWidth: .infinity)
             Picker("Chart", selection: Binding(
                 get: { chart },
                 set: { chart = $0; scope = nil } // a new metric resets any drilldown
@@ -221,7 +199,7 @@ struct HistoryView: View {
                 ForEach(visibleCharts) { Text($0.label).tag($0) }
             }
             .labelsHidden()
-            .fixedSize()
+            .frame(maxWidth: .infinity)
             Picker("Group", selection: Binding(
                 get: { effectiveGroup },
                 set: { newGroup in
@@ -233,13 +211,7 @@ struct HistoryView: View {
                 ForEach(HistoryGroup.allCases) { Text($0.shortLabel).tag($0) }
             }
             .labelsHidden()
-            .fixedSize()
-            // Cross-filters (#750) as one dropdown (#750's three separate menus
-            // didn't fit the row); the daemon query still drops the grouped
-            // dimension and the token_type filter outside the tokens metric,
-            // so those act as no-ops rather than vanishing from the UI.
-            filtersMenu
-            Spacer(minLength: 0)
+            .frame(maxWidth: .infinity)
         }
         .pickerStyle(.menu)
         .controlSize(.small)
@@ -277,63 +249,6 @@ struct HistoryView: View {
     /// Metrics shown in the Chart dropdown — Cost, Tokens, and CO2 (issue #829;
     /// Yield is its own tab; the models/providers presets fold into the Group axis).
     private var visibleCharts: [HistoryChart] { [.cost, .tokens, .co2] }
-
-    // MARK: Cross-filter menus
-
-    private func filterLabel(_ name: String, count: Int) -> String {
-        count > 0 ? "\(name) (\(count))" : name
-    }
-
-    private func setBinding(_ set: Binding<Set<String>>, _ value: String) -> Binding<Bool> {
-        Binding(
-            get: { set.wrappedValue.contains(value) },
-            set: { on in if on { set.wrappedValue.insert(value) } else { set.wrappedValue.remove(value) } }
-        )
-    }
-
-    private func tokenBinding(_ tt: HistoryTokenType) -> Binding<Bool> {
-        Binding(
-            get: { filterTokenType.contains(tt) },
-            set: { on in if on { filterTokenType.insert(tt) } else { filterTokenType.remove(tt) } }
-        )
-    }
-
-    /// Total selections across all three filter dimensions, shown as the
-    /// "Filters" dropdown's badge count.
-    private var activeFilterCount: Int {
-        filterProvider.count + filterTokenType.count + filterProject.count
-    }
-
-    /// One dropdown holding all three cross-filters as submenus — Provider,
-    /// Type, and Project no longer need a row slot each.
-    @ViewBuilder private var filtersMenu: some View {
-        Menu(filterLabel("Filters", count: activeFilterCount)) {
-            Menu(filterLabel("Provider", count: filterProvider.count)) {
-                if knownProviders.isEmpty {
-                    Text("none seen yet")
-                } else {
-                    ForEach(knownProviders, id: \.self) { p in
-                        Toggle(p, isOn: setBinding($filterProvider, p))
-                    }
-                }
-            }
-            Menu(filterLabel("Type", count: filterTokenType.count)) {
-                ForEach(HistoryTokenType.allCases) { tt in
-                    Toggle(tt.label, isOn: tokenBinding(tt))
-                }
-            }
-            Menu(filterLabel("Project", count: filterProject.count)) {
-                if knownProjects.isEmpty {
-                    Text("none seen yet")
-                } else {
-                    ForEach(knownProjects, id: \.self) { p in
-                        Toggle(p, isOn: setBinding($filterProject, p))
-                    }
-                }
-            }
-        }
-        .fixedSize()
-    }
 
     // MARK: Content
 
@@ -429,7 +344,7 @@ struct HistoryView: View {
         loadFailed = false
         var comps = URLComponents(string: "\(DaemonEndpoint.httpBase)/api/v1/history")
         // queryItems ignores the custom bounds unless range == .custom.
-        comps?.queryItems = range.queryItems(chart: fetchChart, group: effectiveGroup, scope: scope, filters: filtersDict, forecast: false, customStart: appliedCustomStart, customEnd: appliedCustomEnd)
+        comps?.queryItems = range.queryItems(chart: fetchChart, group: effectiveGroup, scope: scope, forecast: false, customStart: appliedCustomStart, customEnd: appliedCustomEnd)
         guard let url = comps?.url else { return }
         do {
             let (data, resp) = try await URLSession.shared.data(from: url)
@@ -446,25 +361,10 @@ struct HistoryView: View {
                 let decoded = try JSONDecoder().decode(HistoryResponse.self, from: data)
                 if Task.isCancelled { return }
                 response = decoded
-                // Grow the provider/project filter vocabularies from any
-                // response grouped on that axis (token types are a fixed set).
-                if decoded.group == "provider" {
-                    knownProviders = mergeKnown(knownProviders, decoded.topContributors)
-                } else if decoded.group == "project" {
-                    knownProjects = mergeKnown(knownProjects, decoded.topContributors)
-                }
             }
         } catch {
             if !Task.isCancelled { loadFailed = true }
         }
-    }
-
-    /// Merges a response's contributor labels into an accumulated option list,
-    /// dropping the synthetic "unknown" bucket and keeping it sorted.
-    private func mergeKnown(_ existing: [String], _ contribs: [HistoryContributor]) -> [String] {
-        var set = Set(existing)
-        for c in contribs where !c.label.isEmpty && c.label != "unknown" { set.insert(c.label) }
-        return set.sorted()
     }
 
     private func save(ext: String, text: String) {
@@ -483,7 +383,7 @@ struct HistoryView: View {
 // only part of History that needs `sessionManager`, which publishes on every
 // live session tick (as often as every ~100ms during active sessions). If
 // HistoryView itself subscribed, that churn would re-evaluate the whole body
-// — including the Usage tab's Filters menu — dismissing any open submenu.
+// — including the Usage tab's Chart/Group menus — dismissing any open one.
 
 private struct HistoryQuotaTabContent: View {
     @EnvironmentObject var sessionManager: SessionManager

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -110,7 +110,9 @@ struct HistoryView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            header
+            PanelHeader(title: "History", onBack: onClose)
+            Divider()
+            tabSwitcher
             Divider()
             // Quota has no controls (topControls renders EmptyView for it) —
             // skip the row entirely rather than showing a blank padded gap
@@ -156,45 +158,32 @@ struct HistoryView: View {
 
     // MARK: Header
 
-    private var header: some View {
-        // A leading Back button, a centered tab switcher, and an invisible
-        // mirror of the Back button on the trailing side to balance the
-        // centering — the two Spacers guarantee a minimum gap on both sides
-        // of the switcher regardless of how wide Dynamic Type/accessibility
-        // text sizing makes the Back button, so it can never overlap it.
+    /// Tab switcher row, below the shared `PanelHeader` (issue #940 — the
+    /// header itself is now identical across every sub-panel; view-specific
+    /// controls live in their own row underneath it).
+    private var tabSwitcher: some View {
         HStack {
-            backButton
-            Spacer(minLength: IrrSpacing.sp2)
+            Spacer(minLength: 0)
             Picker("", selection: $tab) {
                 ForEach(HistoryTab.allCases) { Text($0.label).tag($0) }
             }
             .pickerStyle(.segmented)
             .labelsHidden()
             .fixedSize()
-            Spacer(minLength: IrrSpacing.sp2)
-            backButton.opacity(0).allowsHitTesting(false).accessibilityHidden(true)
+            // App accent instead of system blue, matching Settings' Menu Bar
+            // Icon control and every session-state color (issue #940).
+            .tint(IrrColors.working)
+            Spacer(minLength: 0)
         }
         .padding(.horizontal, IrrSpacing.sp4)
         .padding(.vertical, IrrSpacing.sp3)
-    }
-
-    private var backButton: some View {
-        Button(action: onClose) {
-            HStack(spacing: 2) {
-                Image(systemName: "chevron.left")
-                Text("Back")
-            }
-            .foregroundColor(.secondary)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 
     // MARK: Controls
 
     /// Only the controls that apply to the active tab — Quota needs none,
     /// Yield needs just a range, Usage gets the full set (the tab selector
-    /// itself now lives in the header).
+    /// itself lives in `tabSwitcher`, above).
     private var topControls: some View {
         VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
             switch tab {

--- a/platforms/macos/Irrlicht/Views/PanelHeader.swift
+++ b/platforms/macos/Irrlicht/Views/PanelHeader.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Shared header for every full-panel swap inside the menu-bar popover
+/// (History, Settings, and future sub-panels — issue #940). A leading "‹
+/// Back" affordance, a centered title, and an invisible mirror of Back on
+/// the trailing side so the title stays centered regardless of how wide
+/// Dynamic Type/accessibility text sizing makes the Back button — the two
+/// Spacers guarantee a minimum gap on both sides.
+struct PanelHeader: View {
+    let title: String
+    let onBack: () -> Void
+
+    var body: some View {
+        HStack {
+            backButton
+            Spacer(minLength: IrrSpacing.sp2)
+            Text(title)
+                .font(.headline)
+            Spacer(minLength: IrrSpacing.sp2)
+            backButton.opacity(0).allowsHitTesting(false).accessibilityHidden(true)
+        }
+        .padding(.horizontal, IrrSpacing.sp4)
+        .padding(.vertical, IrrSpacing.sp3)
+    }
+
+    private var backButton: some View {
+        Button(action: onBack) {
+            HStack(spacing: 2) {
+                Image(systemName: "chevron.left")
+                Text("Back")
+            }
+            .foregroundColor(.secondary)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/platforms/macos/Irrlicht/Views/PermissionWizardView.swift
+++ b/platforms/macos/Irrlicht/Views/PermissionWizardView.swift
@@ -105,7 +105,10 @@ struct PermissionWizardView: View {
             .padding(.top, 12)
             .padding(.bottom, 20)
         }
-        .frame(width: 360)
+        // Matches SettingsView's panel width (issue #940) — review mode swaps
+        // this view in as Settings' panel body in the same NSPanel, so a
+        // mismatched width would reintroduce the resize jump that issue fixed.
+        .frame(width: SessionListView.panelWidth)
         .background(Color(NSColor.windowBackgroundColor))
         .toggleStyle(IrrlichtSwitchToggleStyle())
     }

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -133,17 +133,19 @@ struct SettingsView: View {
                             InfoIcon(text: "Lights shows session-state dots (today's default). Usage replaces them with 5h/7d subscription quota bars. Combined shows both side by side.")
                             Spacer()
                         }
-                        Picker("", selection: $menuBarStyle) {
-                            ForEach(MenuBarStyle.allCases) { style in
-                                Text(style.label).tag(style.rawValue)
-                            }
-                        }
-                        .pickerStyle(.segmented)
-                        .labelsHidden()
-                        // Tint with the app's accent instead of the system default
-                        // blue, matching every other session-state color in the
-                        // app (issue #940).
-                        .tint(IrrColors.working)
+                        // A real Picker(pickerStyle: .segmented) only centers
+                        // within extra width instead of stretching into it —
+                        // EqualWidthSegmentedControl bridges to NSSegmentedControl
+                        // so the three segments split the full row edge to edge
+                        // (issue #940), tinted with the app's accent instead of
+                        // the system default blue.
+                        EqualWidthSegmentedControl(
+                            labels: MenuBarStyle.allCases.map(\.label),
+                            values: MenuBarStyle.allCases.map(\.rawValue),
+                            selection: $menuBarStyle,
+                            tint: IrrColors.working
+                        )
+                        .frame(maxWidth: .infinity, minHeight: 22)
 
                         if menuBarStyle != MenuBarStyle.lights.rawValue {
                             HStack(spacing: 6) {

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -74,33 +74,29 @@ struct SettingsView: View {
 
     var body: some View {
         // Header and footer are pinned; only the settings sections scroll.
-        // This keeps the "Done" button visible no matter how many sections
-        // expand — the old fixed `height: 860` frame overflowed the menu-bar
-        // popover and clipped the footer. The scroll area is capped the same
-        // way SessionListView caps its list (see `groupListMaxHeight`).
-        // Horizontal insets live on the header, footer, scroll *content*, and
-        // dividers — NOT on the outer container — so the ScrollView spans the
-        // full panel width and its scroll track sits flush against the right
-        // edge, while the text stays inset.
+        // This keeps the footer visible no matter how many sections expand —
+        // the old fixed `height: 860` frame overflowed the menu-bar popover
+        // and clipped it. The scroll area is capped the same way
+        // SessionListView caps its list (see `groupListMaxHeight`).
+        // Horizontal insets live on the scroll *content* only — NOT on the
+        // outer container or the dividers (issue #940: dividers run full-bleed
+        // everywhere, matching History) — so the ScrollView spans the full
+        // panel width and its scroll track sits flush against the right edge,
+        // while the text stays inset.
         VStack(alignment: .leading, spacing: 0) {
-            Text("Settings")
-                .font(.headline)
-                .padding(.horizontal, 20)
-                .padding(.top, 20)
-                .padding(.bottom, 12)
+            PanelHeader(title: "Settings", onBack: { isPresented = false })
 
             Divider()
-                .padding(.horizontal, 20)
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: IrrSpacing.sp4) {
                     LeadingToggle(
                         isOn: $showCostDisplay,
                         label: "Show Estimated Cost",
                         info: "Display estimated USD cost per session and per project group. Cost estimates are approximate."
                     )
 
-                    VStack(alignment: .leading, spacing: 8) {
+                    VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
                         LeadingToggle(
                             isOn: $showQuotaForecast,
                             label: "Show Quota Forecast",
@@ -121,7 +117,7 @@ struct SettingsView: View {
                         }
                     }
 
-                    VStack(alignment: .leading, spacing: 8) {
+                    VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
                         HStack(spacing: 6) {
                             Text("Menu Bar Icon")
                                 .font(.caption)
@@ -137,6 +133,10 @@ struct SettingsView: View {
                         }
                         .pickerStyle(.segmented)
                         .labelsHidden()
+                        // Tint with the app's accent instead of the system default
+                        // blue, matching every other session-state color in the
+                        // app (issue #940).
+                        .tint(IrrColors.working)
 
                         if menuBarStyle != MenuBarStyle.lights.rawValue {
                             HStack(spacing: 6) {
@@ -166,11 +166,12 @@ struct SettingsView: View {
                                 .pickerStyle(.segmented)
                                 .labelsHidden()
                                 .frame(maxWidth: 140)
+                                .tint(IrrColors.working)
                             }
                         }
                     }
 
-                    VStack(alignment: .leading, spacing: 8) {
+                    VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
                         LeadingToggle(
                             isOn: $launchAtLogin,
                             label: "Open at Login",
@@ -205,7 +206,7 @@ struct SettingsView: View {
 
                     Divider()
 
-                    VStack(alignment: .leading, spacing: 8) {
+                    VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
                         HStack(spacing: 6) {
                             Text("Permissions")
                                 .font(.subheadline)
@@ -223,7 +224,7 @@ struct SettingsView: View {
 
                     Divider()
 
-                    VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: IrrSpacing.sp3) {
                         HStack(spacing: 6) {
                             Text("Notifications")
                                 .font(.subheadline)
@@ -251,7 +252,7 @@ struct SettingsView: View {
                             onImportError: { customImportError = $0 }
                         )
                         ContextThresholdRow(enabled: notifyOnContextPressure)
-                            .padding(.leading, 18)
+                            .padding(.leading, IrrSpacing.sp4)
 
                         if let error = customImportError {
                             Text(error)
@@ -287,7 +288,7 @@ struct SettingsView: View {
 
                     Divider()
 
-                    VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: IrrSpacing.sp3) {
                         Text("Updates")
                             .font(.subheadline)
                             .fontWeight(.medium)
@@ -330,7 +331,7 @@ struct SettingsView: View {
                     // Advanced Settings (#694): power-user and still-maturing
                     // controls, collapsed by default. Disclosure state persists
                     // via @AppStorage("advancedSettingsExpanded").
-                    VStack(alignment: .leading, spacing: 12) {
+                    VStack(alignment: .leading, spacing: IrrSpacing.sp3) {
                         Button {
                             withAnimation(IrrMotion.easeOut(duration: IrrMotion.fast)) {
                                 advancedSettingsExpanded.toggle()
@@ -438,10 +439,10 @@ struct SettingsView: View {
 
                             if backchannelActivation {
                                 BackchannelRulesView()
-                                    .padding(.leading, 16)
+                                    .padding(.leading, IrrSpacing.sp4)
                             }
 
-                            VStack(alignment: .leading, spacing: 8) {
+                            VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
                                 HStack(spacing: 6) {
                                     Text("Sources")
                                         .font(.subheadline)
@@ -549,28 +550,29 @@ struct SettingsView: View {
                         }
                     }
                 }
-                .padding(.horizontal, 20)
-                .padding(.vertical, 16)
+                .padding(.horizontal, IrrSpacing.sp4)
+                .padding(.vertical, IrrSpacing.sp4)
             }
             .frame(maxHeight: 520)
             .fixedSize(horizontal: false, vertical: true)
 
             Divider()
-                .padding(.horizontal, 20)
 
+            // "Back" in the header above is the only way to close this panel
+            // now (issue #940 — no separate footer "Done" button), so the
+            // footer is just the version string, matching History's footer-less
+            // pattern as closely as Settings' still-useful version display allows.
             HStack {
                 Text("Irrlicht v\(appVersion)")
                     .font(.caption)
                     .foregroundColor(.secondary)
                 Spacer()
-                Button("Done") { isPresented = false }
-                    .keyboardShortcut(.defaultAction)
             }
-            .padding(.horizontal, 20)
-            .padding(.top, 12)
-            .padding(.bottom, 20)
+            .padding(.horizontal, IrrSpacing.sp4)
+            .padding(.top, IrrSpacing.sp3)
+            .padding(.bottom, IrrSpacing.sp4)
         }
-        .frame(width: 360)
+        .frame(width: SessionListView.panelWidth)
         .background(Color(NSColor.windowBackgroundColor))
         .toggleStyle(IrrlichtSwitchToggleStyle())
         .background(
@@ -598,7 +600,7 @@ struct SettingsView: View {
                 .font(.callout)
                 .frame(width: 80, alignment: .leading)
             // A .menu (not .segmented) picker: the "Subscription" option makes a
-            // segmented control ~315pt wide, which overflows the 360pt panel and
+            // segmented control ~315pt wide, which overflows the panel and
             // clips the whole settings stack. The dropdown stays compact.
             Picker("", selection: selection) {
                 ForEach(ProviderModePreference.allCases) { mode in
@@ -713,7 +715,7 @@ private struct CLIToolSection: View {
     @State private var errorMessage: String?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: IrrSpacing.sp3) {
             Text("Command-Line Tool")
                 .font(.subheadline)
                 .fontWeight(.medium)
@@ -798,7 +800,7 @@ private struct ContextThresholdRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: IrrSpacing.sp2) {
             Text("Alert at")
                 .font(.caption)
                 .foregroundColor(.secondary)
@@ -865,7 +867,7 @@ private struct NotificationEventRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             LeadingToggle(isOn: $enabled, label: event.displayName)
-            HStack(spacing: 8) {
+            HStack(spacing: IrrSpacing.sp2) {
                 Picker("", selection: $selection) {
                     ForEach(SoundChoice.builtIns, id: \.self) { choice in
                         Text(choice.displayName).tag(choice)
@@ -1033,10 +1035,18 @@ struct InfoIcon: View {
 /// Internal (not private): PermissionWizardView applies it too.
 struct IrrlichtSwitchToggleStyle: ToggleStyle {
     func makeBody(configuration: Configuration) -> some View {
-        HStack(spacing: 8) {
+        HStack(spacing: IrrSpacing.sp2) {
             ZStack(alignment: configuration.isOn ? .trailing : .leading) {
                 Capsule()
-                    .fill(configuration.isOn ? IrrColors.ready : IrrColors.cancelled.opacity(0.4))
+                    // Off state needs its own visible fill + stroke, not just a
+                    // dim tint of the on-color — at 0.4 opacity the old fill
+                    // read as almost invisible against the dark background,
+                    // leaving off switches looking like a bare floating knob
+                    // rather than a switch (issue #940).
+                    .fill(configuration.isOn ? IrrColors.ready : Color.primary.opacity(0.14))
+                    .overlay(
+                        Capsule().strokeBorder(Color.primary.opacity(configuration.isOn ? 0 : 0.20), lineWidth: 1)
+                    )
                 Circle()
                     .fill(Color.white)
                     .shadow(color: Color.black.opacity(0.18), radius: 1, x: 0, y: 0.5)

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -45,6 +45,13 @@ struct SettingsView: View {
     @AppStorage(MenuBarStyle.storageKey) private var menuBarStyle: String = MenuBarStyle.lights.rawValue
     @AppStorage(MenuBarQuotaProvider.storageKey) private var menuBarQuotaProvider: String = ""
     @AppStorage(QuotaVisualStyle.storageKey) private var menuBarQuotaVisual: String = QuotaVisualStyle.bars.rawValue
+    // Master gate (issue #940): collapses the whole Notifications section
+    // when off, instead of showing three always-visible event rows to users
+    // who don't want any of it. A brand-new key defaults to false, but
+    // `reconcileNotificationsMasterDefault()` flips it true once on first
+    // appearance for anyone upgrading with an event already enabled, so
+    // existing notification setups don't silently vanish.
+    @AppStorage("notificationsEnabled") private var notificationsEnabled: Bool = false
     @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = false
     @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = false
     @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = false
@@ -224,7 +231,7 @@ struct SettingsView: View {
 
                     Divider()
 
-                    VStack(alignment: .leading, spacing: IrrSpacing.sp3) {
+                    VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
                         HStack(spacing: 6) {
                             Text("Notifications")
                                 .font(.subheadline)
@@ -233,55 +240,65 @@ struct SettingsView: View {
                             Spacer()
                         }
 
-                        NotificationEventRow(
-                            event: .ready,
-                            enabled: $notifyOnReady,
-                            sampleText: "Agent ready",
-                            onImportError: { customImportError = $0 }
-                        )
-                        NotificationEventRow(
-                            event: .waiting,
-                            enabled: $notifyOnWaiting,
-                            sampleText: "Agent waiting for input",
-                            onImportError: { customImportError = $0 }
-                        )
-                        NotificationEventRow(
-                            event: .contextPressure,
-                            enabled: $notifyOnContextPressure,
-                            sampleText: "Context pressure: 80% threshold reached",
-                            onImportError: { customImportError = $0 }
-                        )
-                        ContextThresholdRow(enabled: notifyOnContextPressure)
-                            .padding(.leading, IrrSpacing.sp4)
+                        LeadingToggle(isOn: $notificationsEnabled, label: "Enable notifications")
 
-                        if let error = customImportError {
-                            Text(error)
-                                .font(.caption)
-                                .foregroundColor(.orange)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
+                        if notificationsEnabled {
+                            VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
+                                NotificationEventRow(
+                                    event: .ready,
+                                    enabled: $notifyOnReady,
+                                    sampleText: "Agent ready",
+                                    onImportError: { customImportError = $0 }
+                                )
+                                NotificationEventRow(
+                                    event: .waiting,
+                                    enabled: $notifyOnWaiting,
+                                    sampleText: "Agent waiting for input",
+                                    onImportError: { customImportError = $0 }
+                                )
+                                NotificationEventRow(
+                                    event: .contextPressure,
+                                    enabled: $notifyOnContextPressure,
+                                    sampleText: "Context pressure: 80% threshold reached",
+                                    onImportError: { customImportError = $0 }
+                                )
+                                ContextThresholdRow(enabled: notifyOnContextPressure)
+                                    .padding(.leading, IrrSpacing.sp4)
+                            }
 
-                        if notificationsDenied && (notifyOnReady || notifyOnWaiting || notifyOnContextPressure) {
-                            HStack(spacing: 4) {
-                                Image(systemName: "exclamationmark.triangle.fill")
-                                    .foregroundColor(.orange)
-                                    .font(.caption)
-                                    .tooltip("Notifications blocked in System Settings")
-                                Text("Notifications are blocked.")
+                            if let error = customImportError {
+                                Text(error)
                                     .font(.caption)
                                     .foregroundColor(.orange)
-                                Button("Open Settings") {
-                                    if let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings") {
-                                        NSWorkspace.shared.open(url)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+
+                            if notificationsDenied && (notifyOnReady || notifyOnWaiting || notifyOnContextPressure) {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "exclamationmark.triangle.fill")
+                                        .foregroundColor(.orange)
+                                        .font(.caption)
+                                        .tooltip("Notifications blocked in System Settings")
+                                    Text("Notifications are blocked.")
+                                        .font(.caption)
+                                        .foregroundColor(.orange)
+                                    Button("Open Settings") {
+                                        if let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings") {
+                                            NSWorkspace.shared.open(url)
+                                        }
                                     }
+                                    .font(.caption)
+                                    .buttonStyle(.link)
+                                    .tooltip("Open System Settings → Notifications")
                                 }
-                                .font(.caption)
-                                .buttonStyle(.link)
-                                .tooltip("Open System Settings → Notifications")
                             }
                         }
                     }
-                    .onAppear { checkNotificationAuth() }
+                    .onAppear {
+                        reconcileNotificationsMasterDefault()
+                        checkNotificationAuth()
+                    }
+                    .onChange(of: notificationsEnabled) { _ in checkNotificationAuth() }
                     .onChange(of: notifyOnReady) { _ in checkNotificationAuth() }
                     .onChange(of: notifyOnWaiting) { _ in checkNotificationAuth() }
                     .onChange(of: notifyOnContextPressure) { _ in checkNotificationAuth() }
@@ -666,6 +683,17 @@ struct SettingsView: View {
         }
     }
 
+    /// One-time migration for the new master "Enable notifications" toggle
+    /// (issue #940): a brand-new `@AppStorage` key defaults to `false`, which
+    /// would hide an existing user's already-configured per-event toggles
+    /// behind a collapsed, seemingly-off section. Runs only while the key is
+    /// still absent from `UserDefaults` — once set (by this reconcile or by
+    /// the user), it's never overridden again.
+    private func reconcileNotificationsMasterDefault() {
+        guard UserDefaults.standard.object(forKey: "notificationsEnabled") == nil else { return }
+        notificationsEnabled = notifyOnReady || notifyOnWaiting || notifyOnContextPressure
+    }
+
     private func checkNotificationAuth() {
         guard Bundle.main.bundleIdentifier != nil,
               Bundle.main.bundleURL.pathExtension == "app" else { return }
@@ -865,9 +893,14 @@ private struct NotificationEventRow: View {
     @State private var selection: SoundChoice = .default
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            LeadingToggle(isOn: $enabled, label: event.displayName)
+        // One row (issue #940): toggle + label + sound picker + preview all
+        // share a line — LeadingToggle's trailing Spacer absorbs the gap
+        // between the label and the fixed-width picker/button, so this
+        // stays a single line regardless of how long `event.displayName` is.
+        VStack(alignment: .leading, spacing: IrrSpacing.sp1) {
             HStack(spacing: IrrSpacing.sp2) {
+                LeadingToggle(isOn: $enabled, label: event.displayName)
+
                 Picker("", selection: $selection) {
                     ForEach(SoundChoice.builtIns, id: \.self) { choice in
                         Text(choice.displayName).tag(choice)
@@ -885,7 +918,8 @@ private struct NotificationEventRow: View {
                 }
                 .labelsHidden()
                 .disabled(!enabled)
-                .frame(maxWidth: .infinity)
+                .frame(width: 112)
+                .tooltip(selection.displayName)
                 .onChange(of: selection) { newValue in
                     handle(newValue)
                 }
@@ -894,9 +928,10 @@ private struct NotificationEventRow: View {
                     SoundPlayer.preview(selection, sampleText: sampleText)
                 } label: {
                     Image(systemName: "play.fill")
-                        .frame(width: 14, height: 14)
+                        .frame(width: 10, height: 10)
                 }
                 .buttonStyle(.bordered)
+                .controlSize(.small)
                 .disabled(!enabled || selection == .none)
                 .tooltip("Preview")
             }
@@ -914,7 +949,7 @@ private struct NotificationEventRow: View {
                         Image(systemName: "arrow.down.circle")
                         Text("Manage \(voice.displayName) in System Settings")
                     }
-                    .font(.caption)
+                    .font(.caption2)
                 }
                 .buttonStyle(.link)
                 .tooltip("Open System Settings → Accessibility → Spoken Content")

--- a/platforms/macos/Tests/HistoryPhase2Tests.swift
+++ b/platforms/macos/Tests/HistoryPhase2Tests.swift
@@ -13,7 +13,6 @@ final class HistoryPhase2Tests: XCTestCase {
         let p = params(HistoryRange.day.queryItems(
             chart: .tokens, group: .branch,
             scope: HistoryScope(field: .project, value: "irrlicht"),
-            filters: [:],
             forecast: true, customStart: nil, customEnd: nil))
         XCTAssertEqual(p["chart"], "tokens")
         XCTAssertEqual(p["group"], "branch")
@@ -25,7 +24,6 @@ final class HistoryPhase2Tests: XCTestCase {
     func testQueryItemsCustomRangeSendsStartEndNotRange() {
         let p = params(HistoryRange.custom.queryItems(
             chart: .cost, group: .project, scope: nil,
-            filters: [:],
             forecast: false, customStart: 900, customEnd: 2000))
         XCTAssertEqual(p["start"], "900")
         XCTAssertEqual(p["end"], "2000")
@@ -79,34 +77,6 @@ final class HistoryPhase2Tests: XCTestCase {
 
     func testScopeQueryForm() {
         XCTAssertEqual(HistoryScope(field: .branch, value: "main").query, "branch:main")
-    }
-
-    func testQueryItemsEmitsNonGroupedFiltersAndDropsGroupedDimension() {
-        let p = params(HistoryRange.day.queryItems(
-            chart: .tokens, group: .project, scope: nil,
-            filters: [.provider: ["anthropic"], .tokenType: ["input", "output"], .project: ["x"]],
-            forecast: true, customStart: nil, customEnd: nil))
-        XCTAssertEqual(p["provider"], "anthropic")
-        XCTAssertEqual(p["token_type"], "input,output")
-        XCTAssertNil(p["project"]) // project is the active group
-    }
-
-    func testQueryItemsTokenTypeFilterOmittedUnlessTokensMetric() {
-        let p = params(HistoryRange.day.queryItems(
-            chart: .cost, group: .project, scope: nil,
-            filters: [.tokenType: ["input"], .provider: ["anthropic"]],
-            forecast: true, customStart: nil, customEnd: nil))
-        XCTAssertNil(p["token_type"])
-        XCTAssertEqual(p["provider"], "anthropic")
-    }
-
-    func testQueryItemsEmptyFiltersEmitNothing() {
-        let p = params(HistoryRange.day.queryItems(
-            chart: .tokens, group: .project, scope: nil,
-            filters: [.provider: [], .tokenType: []],
-            forecast: true, customStart: nil, customEnd: nil))
-        XCTAssertNil(p["provider"])
-        XCTAssertNil(p["token_type"])
     }
 
     func testTokenTypeGroupIsLeafWithLabel() {

--- a/platforms/macos/Tests/SettingsViewTests.swift
+++ b/platforms/macos/Tests/SettingsViewTests.swift
@@ -28,8 +28,9 @@ final class SettingsViewTests: XCTestCase {
         // deterministically — the test verifies opacity, not hue, but
         // appearance-pinning keeps the render stable across themes.
         hosting.appearance = NSAppearance(named: .darkAqua)
-        // SettingsView hard-codes its own 360×520 frame.
-        hosting.frame = CGRect(x: 0, y: 0, width: 360, height: 520)
+        // SettingsView pins its width to SessionListView.panelWidth (issue
+        // #940 — shared with History/the session list) and its own 520 height.
+        hosting.frame = CGRect(x: 0, y: 0, width: SessionListView.panelWidth, height: 520)
         hosting.layoutSubtreeIfNeeded()
 
         guard let bitmap = hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds) else {


### PR DESCRIPTION
Closes #940.

## Summary

Implements the end-state proposed in #940: a shared component set for
every menu-bar sub-panel, applied to History and Settings, instead of each
panel drifting independently.

- **New `PanelHeader`** (back-chevron + centered title + balanced trailing
  spacer), used by both `HistoryView` and `SettingsView`. History's
  Usage/Yield/Quota tab switcher moves out of the header into its own
  `tabSwitcher` row below it, so the header itself is now identical in both
  panels.
- **Toggle track fixed**: `IrrlichtSwitchToggleStyle`'s off-state used
  `IrrColors.cancelled.opacity(0.4)`, which read as an almost-invisible
  track on the dark background — off switches looked like a bare floating
  knob rather than a switch. Now uses a visible `Color.primary.opacity(0.14)`
  fill with a `0.20`-opacity stroke border.
- **Panel width unified**: Settings dropped its hardcoded `360pt` frame for
  the shared `SessionListView.panelWidth` (380pt) that History and the
  session list already use — no more popover resize when switching panels.
  `PermissionWizardView` (which swaps into the same NSPanel as Settings in
  review mode) gets the same width for the same reason.
- **Spacing migrated onto `IrrSpacing`**: every raw padding/spacing number
  in `SettingsView` now uses the shared token scale (4/8/12/16/24/32). This
  also fixes the two nested-row indents that had drifted to different
  values (18pt vs 16pt) — both are now `IrrSpacing.sp4`.
- **Dividers now full-bleed** in Settings, matching History, instead of
  being inset by 20pt.
- **Accent color**: Settings' Menu Bar Icon and Quota Shape segmented
  controls, and History's tab switcher, are tinted with the app's purple
  (`IrrColors.working`) instead of system blue.
- Settings' footer "Done" button is removed — "Back" in the new header is
  now the only way to close the panel, same as History. The footer keeps
  just the version string.

## Also in this PR: Notifications refactor

- Added a single master **"Enable notifications"** toggle that gates the
  whole section — the three per-event rows and the context-pressure
  threshold row only render when it's on, instead of always showing three
  rows of controls to users who don't want any of it.
- A one-time migration (`reconcileNotificationsMasterDefault`) defaults the
  new toggle to on for anyone upgrading with an event already enabled, so
  existing notification setups don't silently disappear.
- Each event row is now a **single compact line** (toggle + label + sound
  picker + preview button) instead of two-to-three lines — `LeadingToggle`'s
  trailing `Spacer` absorbs the gap to the fixed-width picker.

## Also in this PR: History Filters removal

- Removed the Usage tab's "Filters" cross-filter dropdown (provider /
  token-type / project) along with all its backing state, query wiring,
  and the known-providers/projects vocabulary tracking that only fed it —
  narrowing to one project/branch/model already works via drilldown, so
  the extra dimension wasn't earning its row space.
- With the row down to Range/Chart/Group, each picker now takes
  `.frame(maxWidth: .infinity)` instead of `.fixedSize()`, so the three
  split the row width evenly (33% each) instead of leaving blank space
  where Filters used to sit.

## Design reference

- Original findings + screenshots: #940
- Proposed end state (HTML/CSS mockup, 1:1 scale): https://claude.ai/code/artifact/2ae76927-85c2-4073-886b-c4e433c1ec08

## Out of scope

`PermissionWizardView`'s own header/footer (title + description + Apply/
Decide Later buttons) is a different interaction pattern (a consent flow,
not simple navigation) and wasn't restructured — only its width was
brought in line so it doesn't reintroduce a resize jump when swapped in
as Settings' panel body. Unifying its header is left for a follow-up if
desired.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` (macOS package) — 242 tests, 0 failures, including
      unmodified `HistoryViewSnapshotTests` goldens (they render
      `HistoryContentView` directly, not the header, so they were
      unaffected by the header refactor) and `SettingsViewTests`
      (updated to the new panel width)
- [x] `go test ./core/... -race -count=1` — pass (unrelated to this
      Swift-only change, run for completeness)
- [x] `tools/preflight.sh` (full local CI parity via the pre-push hook) —
      all gates PASS on every push: gofmt, core module tests,
      onboarding-factory tests, replaydata validate, recording-rig smoke
      test, starhistory tests, both web suites, ARS architecture gate,
      security scan
- [x] `/code-review low` — no findings (run once per commit)
- [x] Verified visually by rendering the views to PNG via
      `NSHostingView` + `bitmapImageRepForCachingDisplay` (same technique
      already used by `SettingsViewTests`) before and after each change —
      including the Notifications collapsed/expanded states and the
      built-in-sound vs. spoken-voice row variants
