### PR TITLE
feat(tools): add DORA Change Failure Rate + MTTR (Phase 2)

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/monitor_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/monitor_other.go
@@ -20,7 +20,9 @@ func NewMonitor(handler exitHandler) (*pidMonitor, error) {
 
 func (m *pidMonitor) Watch(pid int, sessionID string) error { return nil }
 
-func (m *pidMonitor) Unwatch(pid int) {}
+func (m *pidMonitor) Unwatch(pid int) {
+	// no-op — this platform has no exit-signal primitive to unregister
+}
 
 // Run blocks until ctx is cancelled, matching the other implementations.
 func (m *pidMonitor) Run(ctx context.Context) error {

--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -129,6 +129,78 @@ func TestSessionDetector_BackgroundProcess_HoldsWorkingThenReady(t *testing.T) {
 	<-done
 }
 
+// A session already `ready` (e.g. a prior background job just finished and
+// settled it) that then shows a *fresh* background spawn on the very next
+// activity event must be pulled back to working and held there while that new
+// process is alive — not skip the liveness probe because the pass started
+// from `ready`. Reproduces issue #937: a retried `git push -u
+// run_in_background:true` launched right after the session had settled ready
+// was silently invisible to the liveness gate, and the session bounced
+// ready→working→ready in the same pass despite the push still running.
+func TestSessionDetector_BackgroundProcess_FreshSpawnFromReady_HoldsWorking(t *testing.T) {
+	const sid = "bg3"
+	const path = "/home/.claude/projects/-Users-test/bg3.jsonl"
+
+	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		return &session.SessionMetrics{
+			LastEventType:            "turn_done",
+			BackgroundProcessCount:   1,
+			BackgroundProcessOutputs: []string{"/tmp/x/tasks/retry.output"},
+		}, nil
+	}}
+
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	repo.states[sid] = &session.SessionState{
+		SessionID:      sid,
+		State:          session.StateReady,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	rec := &mockRecorder{}
+	det.SetRecorder(rec)
+
+	var probeLive atomic.Bool
+	probeLive.Store(true)
+	det.SetBackgroundProbeForTest(func(paths []string) bool {
+		return probeLive.Load()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      sid,
+		ProjectDir:     "-Users-test",
+		TranscriptPath: path,
+		Terminal:       false,
+	}
+	time.Sleep(250 * time.Millisecond) // allow the async probe + any self-trigger to settle
+	if n := readyTransitions(rec, sid); n != 0 {
+		t.Fatalf("session flipped to ready %d time(s) while its freshly-spawned background process is alive", n)
+	}
+
+	// Background process exits — probe now reports it gone → session goes ready.
+	probeLive.Store(false)
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      sid,
+		ProjectDir:     "-Users-test",
+		TranscriptPath: path,
+		Terminal:       true,
+	}
+	waitForReadyTransition(t, rec, sid)
+
+	cancel()
+	<-done
+}
+
 // A dead probe verdict must also purge the processes from the tailer's open
 // set and ledger — they died without a transcript-observable termination, and
 // the persisted entries would otherwise resurrect as phantom open processes

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -515,6 +515,26 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 
 	transcriptGrew := d.observeTranscriptGrowth(state, ev)
 
+	// Short-circuit when this pass consumed transcript content but produced
+	// no state-relevant change — e.g. Claude Code's post-turn
+	// `system/away_summary` recap, which the parser marks Skip=true. The
+	// force-bounce below would otherwise see the stale LastEventType from
+	// the prior turn_done and flip a ready session back to working
+	// (issue #329).
+	skipClassification := state.Metrics != nil && state.Metrics.NoSubstantiveActivity
+
+	// Bounce a ready session back to working on fresh activity BEFORE the
+	// background-liveness probe below, which is gated on state==working
+	// (issue #445) and would otherwise see this pass's stale `ready` and
+	// clear/skip the probe — silently dropping the hold for a background
+	// process (e.g. a retried `git push`) launched right after the session
+	// had settled to ready. See issue #937. Skipped in lockstep with
+	// classifyAndTransition below so a no-substantive-activity pass still
+	// can't force the bounce (issue #329).
+	if !skipClassification {
+		d.forceReadyToWorkingIfActive(state, ev)
+	}
+
 	// Probe Bash background-process liveness (run_in_background). Must run
 	// after RefreshOnActivity (which recomputes metrics, clearing the flag)
 	// and before ClassifyState (whose IsAgentDone check reads it). Gated on
@@ -537,15 +557,9 @@ func (d *SessionDetector) processActivityLocked(id agent.Identity, state *sessio
 
 	d.recordTaskDeltas(id, ev, state)
 
-	// Short-circuit when this pass consumed transcript content but produced
-	// no state-relevant change — e.g. Claude Code's post-turn
-	// `system/away_summary` recap, which the parser marks Skip=true. The
-	// force-bounce below would otherwise see the stale LastEventType from
-	// the prior turn_done and flip a ready session back to working
-	// (issue #329). Still record this as activity (LastEvent / EventCount /
-	// UpdatedAt / broadcast) so the UI's "last activity" stays fresh —
-	// just don't re-run the state machine.
-	skipClassification := state.Metrics != nil && state.Metrics.NoSubstantiveActivity
+	// Still record this pass as activity (LastEvent / EventCount / UpdatedAt /
+	// broadcast) below even when classification is skipped, so the UI's
+	// "last activity" stays fresh — just don't re-run the state machine.
 	if !skipClassification {
 		d.classifyAndTransition(state, ev)
 	}
@@ -699,12 +713,8 @@ func (d *SessionDetector) recordTaskDeltas(id agent.Identity, ev agent.Event, st
 // when this pass's metrics show substantive activity (see
 // processActivityLocked's skipClassification guard).
 func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev agent.Event) {
-	// Force ready→working when metrics show activity so ClassifyState can
-	// properly detect the working→ready transition. Without this, sessions
-	// that start as ready (initial state) and whose first activity event
-	// already shows IsAgentDone()=true would stay ready with no transition
-	// broadcast — the UI would never see the "agent finished" event.
-	d.forceReadyToWorkingIfActive(state, ev)
+	// Ready→working (if applicable) already ran in processActivityLocked,
+	// before applyBackgroundLiveness — see that call site.
 
 	// Overlay hook-based permission-pending signal onto metrics. Must happen
 	// after RefreshOnActivity (which recomputes metrics from the transcript)
@@ -747,8 +757,10 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 
 // forceReadyToWorkingIfActive bounces a ready session straight to working
 // when its freshly refreshed metrics show activity, so ClassifyState can
-// then detect a genuine working→ready transition on this same pass. See
-// classifyAndTransition's call site for why this matters.
+// then detect a genuine working→ready transition on this same pass, and so
+// the background-liveness probe (see processActivityLocked's call site)
+// evaluates against this pass's effective state rather than the prior
+// pass's stale `ready`.
 func (d *SessionDetector) forceReadyToWorkingIfActive(state *session.SessionState, ev agent.Event) {
 	if state.State != session.StateReady || state.Metrics == nil || state.Metrics.LastEventType == "" {
 		return

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -889,7 +889,9 @@ func setupRecording(detector *services.SessionDetector, sockPath string, logger 
 	rec, err := recorder.NewJSONLRecorder(recordingsDir)
 	if err != nil {
 		logger.LogError("startup", "", fmt.Sprintf("failed to init lifecycle recorder: %v", err))
-		return func() {}
+		return func() {
+			// no-op cleanup — recorder never initialized
+		}
 	}
 	detector.SetRecorder(rec)
 	logger.LogInfo("startup", "", fmt.Sprintf("lifecycle recording enabled: %s", rec.Path()))

--- a/core/domain/agent/file_parser.go
+++ b/core/domain/agent/file_parser.go
@@ -23,7 +23,9 @@ type JSONLineParser struct {
 	NewParser func() LineParser
 }
 
-func (JSONLineParser) isFileParser() {}
+func (JSONLineParser) isFileParser() {
+	// sealing marker — deliberately empty
+}
 
 // RawLineParser is used by adapters whose source format is not JSONL
 // (aider's .aider.chat.history.md is markdown). NewParser returns a
@@ -43,7 +45,9 @@ type RawLineParser struct {
 	NewParser func() RawParser
 }
 
-func (RawLineParser) isFileParser() {}
+func (RawLineParser) isFileParser() {
+	// sealing marker — deliberately empty
+}
 
 // LineParser parses a single JSONL line into a normalized ParsedEvent.
 // Adapter packages provide stateful implementations (Claude Code tracks

--- a/core/domain/agent/process_matcher.go
+++ b/core/domain/agent/process_matcher.go
@@ -14,7 +14,9 @@ type ExactName struct {
 	Name string
 }
 
-func (ExactName) isProcessMatcher() {}
+func (ExactName) isProcessMatcher() {
+	// sealing marker — deliberately empty
+}
 
 // CommandPattern matches via `pgrep -f Regex` — the full command line is
 // matched, not just argv[0]. Use when the OS process name does not match
@@ -25,4 +27,6 @@ type CommandPattern struct {
 	Regex *regexp.Regexp
 }
 
-func (CommandPattern) isProcessMatcher() {}
+func (CommandPattern) isProcessMatcher() {
+	// sealing marker — deliberately empty
+}

--- a/core/domain/agent/source.go
+++ b/core/domain/agent/source.go
@@ -52,7 +52,9 @@ type FilesUnderRoot struct {
 	SessionIDFromPath func(path string) string
 }
 
-func (FilesUnderRoot) isSource() {}
+func (FilesUnderRoot) isSource() {
+	// sealing marker — deliberately empty
+}
 
 // RootDirFor returns the directory the runtime should watch for this source
 // on the given OS (pass runtime.GOOS): the DirByOS override when one is set
@@ -82,7 +84,9 @@ type FilesUnderCWD struct {
 	Parser   RawLineParser
 }
 
-func (FilesUnderCWD) isSource() {}
+func (FilesUnderCWD) isSource() {
+	// sealing marker — deliberately empty
+}
 
 // ProcessOwnedStore — session state lives in a structured store (SQLite,
 // typically) whose path is derivable from the process PID or a stable
@@ -95,4 +99,6 @@ type ProcessOwnedStore struct {
 	Reader     MetricsReader
 }
 
-func (ProcessOwnedStore) isSource() {}
+func (ProcessOwnedStore) isSource() {
+	// sealing marker — deliberately empty
+}

--- a/examples/coding-factory/agent.Dockerfile
+++ b/examples/coding-factory/agent.Dockerfile
@@ -28,12 +28,12 @@ FROM node:${NODE_VERSION}-bookworm-slim AS runtime
 # for `task_complete` with jq. curl: REQUIRED — the daemon's auto-installed hook
 # POSTs via `curl … || true`; without it the hook silently no-ops and tool-use
 # permission prompts never surface as `waiting` (#488).
+# OpenAI Codex CLI (the real agent this testbed observes).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates git tini procps curl tmux jq \
-    && rm -rf /var/lib/apt/lists/*
-# OpenAI Codex CLI (the real agent this testbed observes).
-RUN npm install -g @openai/codex
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g @openai/codex
 
 # Non-root `agent` — both codex and irrlichd run as this user, sharing $HOME so
 # the daemon can read codex's transcripts under ~/.codex/sessions.

--- a/examples/roundtrip/agent.Dockerfile
+++ b/examples/roundtrip/agent.Dockerfile
@@ -32,11 +32,11 @@ FROM node:${NODE_VERSION}-bookworm-slim AS runtime
 # `curl … || true`; without curl the hook silently no-ops (the `|| true`
 # swallows "command not found"), so PermissionRequest never reaches the
 # daemon and tool-use permission prompts never surface as `waiting` (#488).
+# Claude Code CLI (the real agent this testbed observes).
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates git tini procps curl \
-    && rm -rf /var/lib/apt/lists/*
-# Claude Code CLI (the real agent this testbed observes).
-RUN npm install -g @anthropic-ai/claude-code
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g @anthropic-ai/claude-code
 
 # Non-root `agent` — avoids claude's run-as-root friction; both claude and
 # irrlichd run as this user.

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/KittyActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/KittyActivator.swift
@@ -42,7 +42,7 @@ struct KittyActivator: HostActivator {
             // `activated` already carries the synchronous result; the async
             // `then` completion (fires once a cold-launched app finishes
             // opening) isn't needed here.
-            activated = AppActivator.activate(bundleID: bundleID) { _ in }
+            activated = AppActivator.activate(bundleID: bundleID) { _ in /* completion not needed here */ }
         }
 
         // 2. Switch to the right tab via kitty's remote control if the user

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -591,8 +591,8 @@ struct HistoryContentView: View {
     var scope: HistoryScope?
     // No-op defaults so previews/snapshot tests can host this view without
     // wiring drill-down interaction.
-    var onDrill: (HistoryGroup, String) -> Void = { _, _ in }
-    var onClearDrill: () -> Void = {}
+    var onDrill: (HistoryGroup, String) -> Void = { _, _ in /* no-op default */ }
+    var onClearDrill: () -> Void = { /* no-op default */ }
     let onExportCSV: () -> Void
     let onExportJSON: () -> Void
 

--- a/platforms/macos/Tests/HistoryViewSnapshotTests.swift
+++ b/platforms/macos/Tests/HistoryViewSnapshotTests.swift
@@ -123,8 +123,8 @@ final class HistoryViewSnapshotTests: XCTestCase {
         let view = HistoryContentView(
             data: populated(),
             range: .month,
-            onExportCSV: {},
-            onExportJSON: {}
+            onExportCSV: { /* unused in this snapshot */ },
+            onExportJSON: { /* unused in this snapshot */ }
         )
         assertSnapshot(of: host(view, height: 460), as: .image)
     }
@@ -136,8 +136,8 @@ final class HistoryViewSnapshotTests: XCTestCase {
             chart: .tokens,
             group: .branch,
             scope: nil,
-            onExportCSV: {},
-            onExportJSON: {}
+            onExportCSV: { /* unused in this snapshot */ },
+            onExportJSON: { /* unused in this snapshot */ }
         )
         assertSnapshot(of: host(view, height: 460), as: .image)
     }
@@ -149,8 +149,8 @@ final class HistoryViewSnapshotTests: XCTestCase {
             chart: .cost,
             group: .branch,
             scope: HistoryScope(field: .project, value: "irrlicht"),
-            onExportCSV: {},
-            onExportJSON: {}
+            onExportCSV: { /* unused in this snapshot */ },
+            onExportJSON: { /* unused in this snapshot */ }
         )
         assertSnapshot(of: host(view, height: 500), as: .image)
     }
@@ -159,8 +159,8 @@ final class HistoryViewSnapshotTests: XCTestCase {
         let view = HistoryContentView(
             data: empty(),
             range: .day,
-            onExportCSV: {},
-            onExportJSON: {}
+            onExportCSV: { /* unused in this snapshot */ },
+            onExportJSON: { /* unused in this snapshot */ }
         )
         assertSnapshot(of: host(view, height: 320), as: .image)
     }

--- a/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
+++ b/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
@@ -234,7 +234,7 @@ final class QuotaMenuBarRendererTests: XCTestCase {
 
     func testSelectedSnapshotReturnsNilWhenNoSessionCarriesRateLimit() {
         let plain = SessionState(
-            id: "sess_1", state: .working, model: "claude-sonnet", cwd: "/tmp",
+            id: "sess_1", state: .working, model: "claude-sonnet", cwd: "/tmp",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             firstSeen: Date(), updatedAt: Date()
         )
         XCTAssertNil(QuotaMenuBarRenderer.selectedSnapshot(sessions: [plain], providerKey: nil))
@@ -299,7 +299,7 @@ final class QuotaMenuBarRendererTests: XCTestCase {
             id: "sess_\(id)",
             state: .working,
             model: "claude-sonnet",
-            cwd: "/tmp",
+            cwd: "/tmp",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
             firstSeen: Date(),
             updatedAt: Date(),
             metrics: metrics,

--- a/platforms/web/connectionProtocol.js
+++ b/platforms/web/connectionProtocol.js
@@ -52,6 +52,6 @@ export function relayWsUrl(raw) {
   // honors that.
   if (!/^wss?:\/\//i.test(u)) u = 'ws://' + u; // NOSONAR (javascript:S5332) — see comment above
   while (u.endsWith('/')) u = u.slice(0, -1);
-  if (!/\/api\/v1\/sessions\/stream$/.test(u)) u += '/api/v1/sessions/stream';
+  if (!u.endsWith('/api/v1/sessions/stream')) u += '/api/v1/sessions/stream';
   return u;
 }

--- a/platforms/web/domReconcile.js
+++ b/platforms/web/domReconcile.js
@@ -52,7 +52,7 @@ export function reconcile(parent, items, keyFn, createFn, updateFn) {
   // Remove orphans
   for (const [key, el] of existingByKey) {
     if (!desiredKeys.has(key)) {
-      parent.removeChild(el);
+      el.remove();
     }
   }
 }

--- a/platforms/web/formatters.js
+++ b/platforms/web/formatters.js
@@ -191,8 +191,9 @@ export function taskEtaPresentation(metrics, state, nowSec) {
   const est = metrics?.task_estimate;
   const eta = metrics?.task_completion_eta;
   if (state !== 'working' || !est) return null;
-  const sourceLabel = est.source === 'tasks' ? 'from task list'
-    : est.source === 'subagents' ? 'from subagents' : 'agent-reported';
+  let sourceLabel = 'agent-reported';
+  if (est.source === 'tasks') sourceLabel = 'from task list';
+  else if (est.source === 'subagents') sourceLabel = 'from subagents';
   // Explicit null/undefined check before the <= comparison (SonarQube
   // javascript:S1940 wants <= over !(... > ...), but `undefined <= 0` is
   // false while `!(undefined > 0)` is true — a missing completed_rounds

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -138,10 +138,12 @@ function renderHistory() {
   // Yield counts completed sessions; agents are reconstructed from opt-in
   // recordings — each gets its own empty caption.
   const emptyEl = document.getElementById('history-chart-empty');
-  if (emptyEl) emptyEl.textContent =
-    isYield ? 'no completed sessions in this range yet'
-      : historyState.chart === 'agents' ? 'no recordings in this range yet'
-        : 'no cost data in this range yet';
+  if (emptyEl) {
+    let emptyText = 'no cost data in this range yet';
+    if (isYield) emptyText = 'no completed sessions in this range yet';
+    else if (historyState.chart === 'agents') emptyText = 'no recordings in this range yet';
+    emptyEl.textContent = emptyText;
+  }
   if (!historyState.data) {
     const wrap = document.getElementById('history-chart-wrap');
     if (wrap) wrap.classList.add('empty');
@@ -317,7 +319,7 @@ function paintHistoryChart() {
   // Grand cumulative total = the stack's right-edge height; it anchors the
   // forecast when cumulative.
   let grandTotal = 0;
-  for (let r = 0; r < matrix.length; r++) grandTotal += matrix[r][B - 1] || 0;
+  for (const row of matrix) grandTotal += row[B - 1] || 0;
   const { H, fcY } = historyForecastSeries(data, cumulative, grandTotal);
 
   // Y scale = the tallest stacked column (sum across bands per bucket), also

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -28,10 +28,10 @@
               title="Toggle light/dark theme" aria-label="Toggle theme">☾</button>
       <button class="theme-toggle" id="settings-toggle" type="button"
               title="Settings" aria-label="Settings">⚙</button>
-      <div class="ws-status" role="status" aria-live="polite">
-        <div class="ws-dot connecting" id="ws-dot"></div>
+      <output class="ws-status" aria-live="polite">
+        <span class="ws-dot connecting" id="ws-dot"></span>
         <span id="ws-label">connecting</span>
-      </div>
+      </output>
     </div>
   </header>
 
@@ -167,7 +167,7 @@
       <div class="history-controls">
         <div class="history-ctl-row">
           <span class="history-ctl-label">Range</span>
-          <div class="history-seg" id="history-range" role="group" aria-label="Range">
+          <fieldset class="history-seg" id="history-range" aria-label="Range">
             <button type="button" data-range="day" class="active">Day</button>
             <button type="button" data-range="week">Week</button>
             <button type="button" data-range="month">Month</button>
@@ -188,7 +188,7 @@
         </div>
         <div class="history-ctl-row">
           <span class="history-ctl-label">Chart</span>
-          <div class="history-seg" id="history-chart-sel" role="group" aria-label="Chart type">
+          <fieldset class="history-seg" id="history-chart-sel" aria-label="Chart type">
             <button type="button" data-chart="cost" class="active">Cost</button>
             <button type="button" data-chart="yield" title="Productive vs reverted spend per project">Yield</button>
             <button type="button" data-chart="tokens">Tokens</button>
@@ -200,7 +200,7 @@
         </div>
         <div class="history-ctl-row">
           <span class="history-ctl-label">Group</span>
-          <div class="history-seg" id="history-group-sel" role="group" aria-label="Group by">
+          <fieldset class="history-seg" id="history-group-sel" aria-label="Group by">
             <button type="button" data-group="project" class="active">Project</button>
             <button type="button" data-group="branch">Branch</button>
             <button type="button" data-group="provider">Provider</button>

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1218,7 +1218,7 @@
       border: 1px solid var(--border-subtle);
       border-radius: 4px;
       line-height: 1.5;
-      word-break: break-word;
+      overflow-wrap: break-word;
     }
     .settings-modal .settings-modal-close {
       background: none;
@@ -1299,6 +1299,7 @@
     .history-seg {
       display: inline-flex; border: 1px solid var(--border);
       border-radius: 5px; overflow: hidden;
+      margin: 0; padding: 0; min-width: 0;
     }
     .history-seg button {
       background: none; border: none; border-right: 1px solid var(--border);

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -76,8 +76,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       const onChange = () => {
         if (!storedTheme()) { updateThemeToggleGlyph(); render(); }
       };
-      if (mq.addEventListener) mq.addEventListener('change', onChange);
-      else if (mq.addListener) mq.addListener(onChange);
+      mq.addEventListener('change', onChange);
     }
 
     // --- Display mode (Context / 1 Min / 10 Min / 60 Min) ---
@@ -1366,11 +1365,9 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       const host = document.getElementById('app-state-icons');
       if (!host) return;
       const list = topLevel || [];
-      const sig = list.length === 0
-        ? 'empty'
-        : list.length <= 3
-          ? 'icons:' + list.map(s => s.state || 'ready').join(',')
-          : 'count:' + list.length;
+      let sig = 'count:' + list.length;
+      if (list.length === 0) sig = 'empty';
+      else if (list.length <= 3) sig = 'icons:' + list.map(s => s.state || 'ready').join(',');
       if (host.dataset.sig === sig) return;
       host.dataset.sig = sig;
       if (list.length === 0) {
@@ -1713,7 +1710,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     function rebuildSources() {
       const desired = desiredSources();
       const desiredById = new Map(desired.map(s => [s.id, s]));
-      for (const [id, src] of [...sources]) {
+      for (const [id, src] of sources) {
         const want = desiredById.get(id);
         // Drop a source that's no longer desired, OR a relay source whose token
         // changed / is parked in 'unauthorized'. The source id is keyed by URL

--- a/platforms/web/quotaChips.js
+++ b/platforms/web/quotaChips.js
@@ -19,8 +19,7 @@ const QUOTA_FORECAST_KEY = 'showQuotaForecast';
 export function showQuotaForecast() {
   // Default ON, mirroring macOS @AppStorage("showQuotaForecast") default.
   const v = localStorage.getItem(QUOTA_FORECAST_KEY);
-  if (v === '0' || v === 'false') return false;
-  return true;
+  return v !== '0' && v !== 'false';
 }
 export function setShowQuotaForecast(on) {
   // Safari Private mode and storage-disabled contexts throw on
@@ -225,9 +224,7 @@ function bucketChips(sessions, nowMs) {
     mergeChipIntoBucket(existing, snap, s, mode, imm, stale);
     existing.totalCostUSD += cost;
   }
-  return Array.from(buckets.values()).sort((a, b) =>
-    a.key < b.key ? -1 : a.key > b.key ? 1 : 0
-  );
+  return Array.from(buckets.values()).sort((a, b) => a.key.localeCompare(b.key));
 }
 
 // subscriptionWindowLine renders one quota window's tooltip line: percent
@@ -239,9 +236,9 @@ function subscriptionWindowLine(w, nowMs) {
   let line = label + ': ' + used + '% used';
   if (pace != null) {
     const delta = used - Math.round(pace);
-    const verdict = delta > 0 ? (delta + 'pt over pace')
-                  : delta < 0 ? ((-delta) + 'pt under pace')
-                  : 'on pace';
+    let verdict = 'on pace';
+    if (delta > 0) verdict = delta + 'pt over pace';
+    else if (delta < 0) verdict = (-delta) + 'pt under pace';
     line += ' · ' + verdict;
   }
   if (w.resets_at) line += ' · resets in ' + formatTimeUntil(w.resets_at);

--- a/platforms/web/vitest.setup.js
+++ b/platforms/web/vitest.setup.js
@@ -88,5 +88,4 @@ global.fetch = () => Promise.reject(new Error('no server'));
 global.Notification = class {
   static permission = 'default';
   static requestPermission() { return Promise.resolve('default'); }
-  constructor() {}
 };

--- a/site/landscape/compare/index.html
+++ b/site/landscape/compare/index.html
@@ -837,8 +837,8 @@ document.addEventListener('DOMContentLoaded', function() {
       var rows = Array.from(tbody.querySelectorAll('tr'));
       rows.sort(function(a, b) {
         var cellA = a.children[idx], cellB = b.children[idx];
-        var valA = (cellA.getAttribute('data-sort') || cellA.textContent).trim();
-        var valB = (cellB.getAttribute('data-sort') || cellB.textContent).trim();
+        var valA = (cellA.dataset.sort || cellA.textContent).trim();
+        var valB = (cellB.dataset.sort || cellB.textContent).trim();
         var numA = Number.parseFloat(valA), numB = Number.parseFloat(valB);
         if (!Number.isNaN(numA) && !Number.isNaN(numB)) {
           return sortAsc ? numA - numB : numB - numA;

--- a/tools/dora-metrics.sh
+++ b/tools/dora-metrics.sh
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
-# dora-metrics.sh — directional DORA metrics (Deployment Frequency, Lead
-# Time for Changes) computed entirely from local git tags/history, plus
-# gh release list as an optional enrichment for release-published
-# timestamps. No dashboard, no persistence — just a plain-text summary.
+# dora-metrics.sh — directional DORA metrics computed entirely from local
+# git tags/history, plus gh release list / gh issue list as optional
+# enrichment. No dashboard, no persistence — just a plain-text summary.
 #
-# Change Failure Rate and Time to Restore Service (MTTR) are NOT computed
-# here — see #936 for that phase; it needs a decision on what counts as a
-# "failure" (hotfix within N hours? revert commit? bug-labeled issue linked
-# to a release?) before it can be built.
+#   - Deployment Frequency, Lead Time for Changes: from git tags + commit
+#     history alone.
+#   - Change Failure Rate, Mean Time to Restore (#936): a release in range
+#     is a "failure" if ANY of three signals fire —
+#       1. hotfix: it landed within --hotfix-window-hours of the prior
+#          release.
+#       2. revert: it ships a commit whose subject matches ^Revert and
+#          whose "This reverts commit <hash>." trailer resolves to a
+#          commit shipped in an earlier release.
+#       3. bug-issue: it ships a commit referencing "Fixes/Closes/Resolves
+#          #NNN" for an issue labeled "bug" (requires gh).
+#     MTTR is measured per flagged instance (failure shipped -> fix
+#     shipped), not per unique release, so it can exceed the deduped CFR
+#     count.
 #
 # Assumes release tags are named v<major>.<minor>.<patch> (matches
 # version.json's "version" field) and are created on main's ancestry — no
@@ -21,6 +30,7 @@
 #   tools/dora-metrics.sh                              # last 90 days
 #   tools/dora-metrics.sh --since "30 days ago"
 #   tools/dora-metrics.sh --since 2026-01-01 --until 2026-04-01
+#   tools/dora-metrics.sh --hotfix-window-hours 12
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -28,12 +38,14 @@ cd "$REPO_ROOT"
 
 SINCE="90 days ago"
 UNTIL="now"
+HOTFIX_WINDOW_HOURS=24
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --since) SINCE="$2"; shift 2 ;;
     --until) UNTIL="$2"; shift 2 ;;
-    -h|--help) sed -n '2,22p' "$0"; exit 0 ;;
+    --hotfix-window-hours) HOTFIX_WINDOW_HOURS="$2"; shift 2 ;;
+    -h|--help) sed -n '2,33p' "$0"; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -87,12 +99,39 @@ if [[ ${#TAG_NAMES[@]} -eq 0 ]]; then
   exit 1
 fi
 
-# Optional enrichment: gh release list for published-at timestamps. Failure
-# is non-fatal — local tag creatordate already covers what we need.
+# ISO-8601 (GitHub API timestamp shape, e.g. 2026-07-11T08:36:42Z) → epoch.
+# Separate from to_epoch() above, which is tuned for user-supplied
+# free-form/date-only --since/--until specs, not API timestamps.
+iso_to_epoch() {
+  local spec="$1"
+  if date -d "$spec" +%s 2>/dev/null; then
+    return 0
+  fi
+  date -j -f "%Y-%m-%dT%H:%M:%SZ" "$spec" +%s 2>/dev/null
+}
+
+# Optional enrichment: gh release list for published-at timestamps, and gh
+# issue list for the bug-issue Change Failure Rate signal. Failure is
+# non-fatal — local tag creatordate already covers Deployment
+# Frequency/Lead Time, and the bug-issue signal simply drops out below.
 GH_NOTE="local git tags"
+BUG_ISSUE_NUMS=()
+BUG_ISSUE_CREATED_EPOCH=()
 if command -v gh >/dev/null 2>&1; then
   if gh release list --limit 1 >/dev/null 2>&1; then
     GH_NOTE="git tags + gh release list"
+    REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+    if [[ -n "$REPO_NWO" ]] && bug_json=$(gh issue list --repo "$REPO_NWO" --label bug --state all --json number,createdAt --limit 1000 2>/dev/null); then
+      while IFS=$'\t' read -r num created; do
+        [[ -z "$num" ]] && continue
+        epoch=$(iso_to_epoch "$created") || continue
+        BUG_ISSUE_NUMS+=("$num")
+        BUG_ISSUE_CREATED_EPOCH+=("$epoch")
+      done < <(echo "$bug_json" | jq -r '.[] | "\(.number)\t\(.createdAt)"' 2>/dev/null)
+      GH_NOTE="git tags + gh release list + gh issue list (bug label)"
+    else
+      echo "WARN: gh issue list (bug label) failed — bug-issue CFR/MTTR signal disabled" >&2
+    fi
   else
     echo "WARN: gh unavailable/unauthenticated — using local git tags only; run \`gh auth login\` for richer data" >&2
   fi
@@ -114,6 +153,44 @@ done
 
 fmt_date() {
   date -d "@$1" +%Y-%m-%d 2>/dev/null || date -r "$1" +%Y-%m-%d
+}
+
+format_hours() {
+  local hours="$1"
+  if [[ "$hours" -ge 24 ]]; then
+    awk -v h="$hours" 'BEGIN { printf "%.1f days", h / 24 }'
+  else
+    echo "${hours} hours"
+  fi
+}
+
+median_of() {
+  local sorted=() h count mid
+  while IFS= read -r h; do sorted+=("$h"); done < <(printf '%s\n' "$@" | sort -n)
+  count=${#sorted[@]}
+  mid=$((count / 2))
+  if [[ $((count % 2)) -eq 1 ]]; then
+    echo "${sorted[$mid]}"
+  else
+    echo $(( (sorted[$((mid-1))] + sorted[$mid]) / 2 ))
+  fi
+}
+
+mean_of() {
+  printf '%s\n' "$@" | awk '{ sum += $1; n++ } END { printf "%d", sum / n }'
+}
+
+# Linear-scan membership check against a small index set, passed as extra
+# positional args (bash 3.2 has no namerefs, so this is the portable way to
+# share one helper across different candidate-index arrays — e.g.
+# TARGET_IDX for Lead Time, IN_RANGE_IDX for Change Failure Rate).
+idx_in_set() {
+  local needle="$1" t
+  shift
+  for t in "$@"; do
+    [[ "$t" == "$needle" ]] && return 0
+  done
+  return 1
 }
 
 since_display=$(fmt_date "$SINCE_EPOCH")
@@ -182,19 +259,11 @@ if [[ "$n" -eq 0 ]]; then
   TARGET_IDX=("$next_idx")
 fi
 
-is_target() {
-  local idx="$1" t
-  for t in "${TARGET_IDX[@]}"; do
-    [[ "$t" == "$idx" ]] && return 0
-  done
-  return 1
-}
-
 LEAD_HOURS=()
 commits_analyzed=0
 i=0
 while [[ $i -lt ${#TAG_NAMES[@]} ]]; do
-  if ! is_target "$i"; then
+  if ! idx_in_set "$i" ${TARGET_IDX[@]+"${TARGET_IDX[@]}"}; then
     i=$((i + 1))
     continue
   fi
@@ -214,41 +283,180 @@ while [[ $i -lt ${#TAG_NAMES[@]} ]]; do
       LEAD_HOURS+=("$lead_hours")
       commits_analyzed=$((commits_analyzed + 1))
     fi
-  done < <(git log --pretty=format:'%H %at' "$range_spec" 2>/dev/null || true)
+  done < <( { git log --pretty=format:'%H %at' "$range_spec" 2>/dev/null || true; echo; } )
 
   i=$((i + 1))
 done
 
 printf "  %-28s%s\n" "Commits analyzed:" "$commits_analyzed"
 
-format_hours() {
-  local hours="$1"
-  if [[ "$hours" -ge 24 ]]; then
-    awk -v h="$hours" 'BEGIN { printf "%.1f days", h / 24 }'
-  else
-    echo "${hours} hours"
-  fi
-}
-
 if [[ "$commits_analyzed" -eq 0 ]]; then
   printf "  %-28s%s\n" "Median lead time:" "n/a"
   printf "  %-28s%s\n" "Mean lead time:" "n/a"
 else
-  sorted=()
-  while IFS= read -r h; do
-    sorted+=("$h")
-  done < <(printf '%s\n' "${LEAD_HOURS[@]}" | sort -n)
-  count=${#sorted[@]}
-  mid=$((count / 2))
-  if [[ $((count % 2)) -eq 1 ]]; then
-    median=${sorted[$mid]}
-  else
-    median=$(( (sorted[$((mid-1))] + sorted[$mid]) / 2 ))
-  fi
-  mean=$(printf '%s\n' "${LEAD_HOURS[@]}" | awk '{ sum += $1; n++ } END { printf "%d", sum / n }')
+  printf "  %-28s%s\n" "Median lead time:" "$(format_hours "$(median_of "${LEAD_HOURS[@]}")")"
+  printf "  %-28s%s\n" "Mean lead time:" "$(format_hours "$(mean_of "${LEAD_HOURS[@]}")")"
+fi
 
-  printf "  %-28s%s\n" "Median lead time:" "$(format_hours "$median")"
-  printf "  %-28s%s\n" "Mean lead time:" "$(format_hours "$mean")"
+echo
+
+# ---- Change Failure Rate + Mean Time to Restore ----------------------------
+
+tag_epoch_of() {
+  local name="$1" j=0
+  while [[ $j -lt ${#TAG_NAMES[@]} ]]; do
+    if [[ "${TAG_NAMES[$j]}" == "$name" ]]; then
+      echo "${TAG_EPOCHS[$j]}"
+      return 0
+    fi
+    j=$((j + 1))
+  done
+  return 1
+}
+
+bug_issue_created_epoch() {
+  local num="$1" j=0
+  while [[ $j -lt ${#BUG_ISSUE_NUMS[@]} ]]; do
+    if [[ "${BUG_ISSUE_NUMS[$j]}" == "$num" ]]; then
+      echo "${BUG_ISSUE_CREATED_EPOCH[$j]}"
+      return 0
+    fi
+    j=$((j + 1))
+  done
+  return 1
+}
+
+hotfix_window_seconds=$((HOTFIX_WINDOW_HOURS * 3600))
+
+HOTFIX_FAILED_IDX=()
+HOTFIX_MTTR_HOURS=()
+REVERT_FAILED_IDX=()
+REVERT_MTTR_HOURS=()
+REVERT_UNRESOLVED=0
+BUG_FAILED_IDX=()
+BUG_MTTR_HOURS=()
+
+i=0
+while [[ $i -lt ${#TAG_NAMES[@]} ]]; do
+  if ! idx_in_set "$i" ${IN_RANGE_IDX[@]+"${IN_RANGE_IDX[@]}"}; then
+    i=$((i + 1))
+    continue
+  fi
+
+  tag_name="${TAG_NAMES[$i]}"
+  tag_epoch="${TAG_EPOCHS[$i]}"
+
+  if [[ "$i" -gt 0 ]]; then
+    prev_epoch="${TAG_EPOCHS[$((i-1))]}"
+    delta=$((tag_epoch - prev_epoch))
+    if [[ "$delta" -lt "$hotfix_window_seconds" ]]; then
+      HOTFIX_FAILED_IDX+=("$i")
+      HOTFIX_MTTR_HOURS+=("$((delta / 3600))")
+    fi
+    range_spec="${TAG_NAMES[$((i-1))]}..${tag_name}"
+  else
+    range_spec="$tag_name"
+  fi
+
+  # Walk this release's shipped commits once for both the revert and
+  # bug-issue signals. %x1e/%x1f are ASCII record/unit separators — control
+  # bytes that won't collide with real commit message content — so a
+  # multi-line %B body can be parsed without spawning a process per commit.
+  while IFS= read -r -d $'\x1e' record; do
+    [[ -z "$record" ]] && continue
+    commit_hash="${record%%$'\x1f'*}"
+    body="${record#*$'\x1f'}"
+    subject="${body%%$'\n'*}"
+
+    if [[ "$subject" =~ ^[Rr]evert ]]; then
+      if [[ "$body" =~ This\ reverts\ commit\ ([0-9a-f]+) ]]; then
+        orig_hash="${BASH_REMATCH[1]}"
+        orig_tag=$(git tag --contains "$orig_hash" --sort=creatordate 2>/dev/null | grep -E "$TAG_PATTERN" | head -1 || true)
+        if [[ -n "$orig_tag" && "$orig_tag" != "$tag_name" ]] && orig_epoch=$(tag_epoch_of "$orig_tag"); then
+          REVERT_FAILED_IDX+=("$i")
+          REVERT_MTTR_HOURS+=("$(( (tag_epoch - orig_epoch) / 3600 ))")
+        fi
+      else
+        REVERT_UNRESOLVED=$((REVERT_UNRESOLVED + 1))
+      fi
+    fi
+
+    if [[ ${#BUG_ISSUE_NUMS[@]} -gt 0 ]]; then
+      while IFS= read -r issue_num; do
+        [[ -z "$issue_num" ]] && continue
+        if created_epoch=$(bug_issue_created_epoch "$issue_num"); then
+          BUG_FAILED_IDX+=("$i")
+          BUG_MTTR_HOURS+=("$(( (tag_epoch - created_epoch) / 3600 ))")
+        fi
+      done < <(echo "$body" | grep -ioE '(fixe?s?|closes?|resolves?)[[:space:]]+#[0-9]+' | grep -oE '[0-9]+' || true)
+    fi
+  done < <( { git log --pretty=format:'%x1e%H%x1f%B' "$range_spec" 2>/dev/null || true; printf '\x1e'; } )
+
+  i=$((i + 1))
+done
+
+ALL_FAILED_IDX=()
+ALL_FAILED_IDX+=(${HOTFIX_FAILED_IDX[@]+"${HOTFIX_FAILED_IDX[@]}"})
+ALL_FAILED_IDX+=(${REVERT_FAILED_IDX[@]+"${REVERT_FAILED_IDX[@]}"})
+ALL_FAILED_IDX+=(${BUG_FAILED_IDX[@]+"${BUG_FAILED_IDX[@]}"})
+
+UNIQUE_FAILED_IDX=()
+for idx in ${ALL_FAILED_IDX[@]+"${ALL_FAILED_IDX[@]}"}; do
+  dup=0
+  for u in ${UNIQUE_FAILED_IDX[@]+"${UNIQUE_FAILED_IDX[@]}"}; do
+    [[ "$u" == "$idx" ]] && { dup=1; break; }
+  done
+  [[ "$dup" -eq 0 ]] && UNIQUE_FAILED_IDX+=("$idx")
+done
+
+echo "Change Failure Rate  (deploy causing a hotfix / revert / bug-fix within range)"
+printf "  %-30s%s\n" "Failures (hotfix signal):" "${#HOTFIX_FAILED_IDX[@]}"
+if [[ "$REVERT_UNRESOLVED" -gt 0 ]]; then
+  printf "  %-30s%s\n" "Failures (revert signal):" "${#REVERT_FAILED_IDX[@]} (${REVERT_UNRESOLVED} unresolved, non-standard revert)"
+else
+  printf "  %-30s%s\n" "Failures (revert signal):" "${#REVERT_FAILED_IDX[@]}"
+fi
+if [[ ${#BUG_ISSUE_NUMS[@]} -eq 0 ]]; then
+  printf "  %-30s%s\n" "Failures (bug-issue signal):" "n/a — gh unavailable/unauthenticated"
+else
+  printf "  %-30s%s\n" "Failures (bug-issue signal):" "${#BUG_FAILED_IDX[@]}"
+fi
+if [[ "$n" -eq 0 ]]; then
+  printf "  %-30s%s\n" "Failures (union, deduped):" "n/a — no release in range"
+else
+  cfr_pct=$(awk -v f="${#UNIQUE_FAILED_IDX[@]}" -v n="$n" 'BEGIN { printf "%.1f", (f / n) * 100 }')
+  printf "  %-30s%s\n" "Failures (union, deduped):" "${#UNIQUE_FAILED_IDX[@]} / ${n}  (${cfr_pct}%)"
+fi
+echo
+
+echo "Mean Time to Restore  (failure shipped -> fix shipped, per flagged instance)"
+
+ALL_MTTR_HOURS=()
+ALL_MTTR_HOURS+=(${HOTFIX_MTTR_HOURS[@]+"${HOTFIX_MTTR_HOURS[@]}"})
+ALL_MTTR_HOURS+=(${REVERT_MTTR_HOURS[@]+"${REVERT_MTTR_HOURS[@]}"})
+ALL_MTTR_HOURS+=(${BUG_MTTR_HOURS[@]+"${BUG_MTTR_HOURS[@]}"})
+
+if [[ ${#HOTFIX_MTTR_HOURS[@]} -eq 0 ]]; then
+  printf "  %-30s%s\n" "MTTR median (hotfix):" "n/a"
+else
+  printf "  %-30s%s\n" "MTTR median (hotfix):" "$(format_hours "$(median_of "${HOTFIX_MTTR_HOURS[@]}")")"
+fi
+if [[ ${#REVERT_MTTR_HOURS[@]} -eq 0 ]]; then
+  printf "  %-30s%s\n" "MTTR median (revert):" "n/a"
+else
+  printf "  %-30s%s\n" "MTTR median (revert):" "$(format_hours "$(median_of "${REVERT_MTTR_HOURS[@]}")")"
+fi
+if [[ ${#BUG_MTTR_HOURS[@]} -eq 0 ]]; then
+  printf "  %-30s%s\n" "MTTR median (bug-issue):" "n/a"
+else
+  printf "  %-30s%s\n" "MTTR median (bug-issue):" "$(format_hours "$(median_of "${BUG_MTTR_HOURS[@]}")")"
+fi
+if [[ ${#ALL_MTTR_HOURS[@]} -eq 0 ]]; then
+  printf "  %-30s%s\n" "MTTR median (combined):" "n/a"
+  printf "  %-30s%s\n" "MTTR mean (combined):" "n/a"
+else
+  printf "  %-30s%s\n" "MTTR median (combined):" "$(format_hours "$(median_of "${ALL_MTTR_HOURS[@]}")")"
+  printf "  %-30s%s\n" "MTTR mean (combined):" "$(format_hours "$(mean_of "${ALL_MTTR_HOURS[@]}")")"
 fi
 
 echo

--- a/tools/irrlicht-design-system/ui_kits/dashboard/GasTown.jsx
+++ b/tools/irrlicht-design-system/ui_kits/dashboard/GasTown.jsx
@@ -15,7 +15,7 @@ function dotBar(total, done) {
 }
 
 window.GasTown = function GasTown({ orchestrator }) {
-  if (!orchestrator || !orchestrator.running) return null;
+  if (!orchestrator?.running) return null;
   const convoys = (orchestrator.work_units || []).filter(w => w.type === 'convoy');
   return (
     <div className="gt-section">
@@ -26,7 +26,7 @@ window.GasTown = function GasTown({ orchestrator }) {
       {orchestrator.global_agents?.length > 0 && (
         <div className="gt-agents-row">
           {orchestrator.global_agents.map((ga, i) => (
-            <div key={i} className="gt-agent-chip" title={ga.description || ga.role}>
+            <div key={ga.session_id || ga.role || i} className="gt-agent-chip" title={ga.description || ga.role}>
               <span>{ga.icon && ga.icon + ' '}{ga.role}</span>
               <span className="gt-chip-dot" style={{background: stateColor(ga.state)}}/>
               <span className="gt-chip-id">{ga.session_id ? ga.session_id.slice(0,6) : 'idle'}</span>
@@ -38,11 +38,11 @@ window.GasTown = function GasTown({ orchestrator }) {
         const workers = (cb.worktrees || []).flatMap(wt => wt.workers || []);
         if (!workers.length) return null;
         return (
-          <div key={ci} className="gt-rig-block">
+          <div key={cb.name || ci} className="gt-rig-block">
             <div className="gt-rig-name">rig: {cb.name}</div>
             <div className="gt-workers">
               {workers.map((w, wi) => (
-                <div key={wi} className="gt-agent-chip" title={w.description || w.role}>
+                <div key={w.id || wi} className="gt-agent-chip" title={w.description || w.role}>
                   <span>{w.icon && w.icon + ' '}{w.role}{w.name && <span style={{color:'var(--text)'}}> {w.name}</span>}</span>
                   <span className="gt-chip-dot" style={{background: stateColor(w.state)}}/>
                   {w.id && <span className="gt-chip-id">{w.id.slice(0,8)}</span>}
@@ -58,7 +58,7 @@ window.GasTown = function GasTown({ orchestrator }) {
           {convoys.map((c, i) => {
             const done = c.done >= c.total;
             return (
-              <div key={i} className="gt-convoy-row">
+              <div key={c.name || i} className="gt-convoy-row">
                 <span className={'gt-convoy-name' + (done ? ' done' : '')}>{c.name}</span>
                 <span className="gt-dotbar" style={{color: done ? 'var(--ready)' : 'var(--working)'}}>{dotBar(c.total, c.done)}</span>
                 <span className="gt-convoy-fraction">{c.done} / {c.total}</span>

--- a/tools/irrlicht-design-system/ui_kits/dashboard/GroupHeader.jsx
+++ b/tools/irrlicht-design-system/ui_kits/dashboard/GroupHeader.jsx
@@ -2,9 +2,12 @@
 window.GroupHeader = function GroupHeader({ group, collapsed, onToggle, timeframe, onCycleTimeframe }) {
   const total = group.agents.length + group.agents.reduce((n,a) => n + (a.children?.length || 0), 0);
   const maxCtx = Math.max(0, ...group.agents.map(a => (a.metrics?.context_utilization_percentage) || 0));
-  const dotColor = maxCtx > 90 ? 'var(--pressure-high)' : maxCtx > 75 ? 'var(--pressure-medium)' : maxCtx > 50 ? 'var(--waiting)' : 'var(--ready)';
+  let dotColor = 'var(--ready)';
+  if (maxCtx > 90) dotColor = 'var(--pressure-high)';
+  else if (maxCtx > 75) dotColor = 'var(--pressure-medium)';
+  else if (maxCtx > 50) dotColor = 'var(--waiting)';
   const tfSuffix = {day:'/d', week:'/w', month:'/mo', year:'/yr'}[timeframe] || '/d';
-  const cost = group.costs && group.costs[timeframe];
+  const cost = group.costs?.[timeframe];
   return (
     <div className="group-hdr">
       <button type="button" className="group-toggle" onClick={onToggle} aria-expanded={!collapsed}>

--- a/tools/irrlicht-design-system/ui_kits/dashboard/SessionRow.jsx
+++ b/tools/irrlicht-design-system/ui_kits/dashboard/SessionRow.jsx
@@ -21,7 +21,7 @@ window.SessionRow = function SessionRow({ agent, num, isChild }) {
   const pCls = pressureClass(m.pressure_level);
   const subCount = (agent.children || []).filter(c => c.state === 'working' || c.state === 'waiting').length;
   const toolLbl = { Edit:'Edit', Read:'Read', Bash:'Bash', AskUserQuestion:'Ask User', ExitPlanMode:'Plan Mode', Grep:'Grep', Write:'Write' };
-  const tool = m.has_open_tool_call && m.last_open_tool_names && m.last_open_tool_names[0];
+  const tool = m.has_open_tool_call && m.last_open_tool_names?.[0];
   const toolIsUser = tool === 'AskUserQuestion' || tool === 'ExitPlanMode';
 
   return (

--- a/tools/irrlicht-design-system/ui_kits/landing/InstallBlock.jsx
+++ b/tools/irrlicht-design-system/ui_kits/landing/InstallBlock.jsx
@@ -29,7 +29,7 @@ window.FeatureTrio = function FeatureTrio() {
   return (
     <section className="features" id="features">
       {features.map((f, i) => (
-        <div key={i} className="feature">
+        <div key={f.title || i} className="feature">
           <div className="feature-dot" style={{background: f.dot, boxShadow: `0 0 14px ${f.dot}`}}/>
           <h3 className="feature-title">{f.title}</h3>
           <p className="feature-body">{f.body}</p>

--- a/tools/onboarding-factory/internal/viewer/web/viewer.js
+++ b/tools/onboarding-factory/internal/viewer/web/viewer.js
@@ -1224,9 +1224,10 @@ function _appendPipelineTailSegments(wrap, blocked, pipe, meas, jump) {
         "Spec — not authored yet"));
   // Recordings count (latest counts as 1; archive_count is additional)
   const totalRecs = (rcs.latest ? 1 : 0) + (rcs.archive_count || 0);
+  const recsSuffix = totalRecs === 1 ? "" : "s";
   wrap.appendChild(totalRecs > 0
     ? _pipeBtn(String(totalRecs), "#d6f0d4", "#1f5a1d", jump("recordings"), false,
-        `${totalRecs} recording${totalRecs === 1 ? "" : "s"}`)
+        `${totalRecs} recording${recsSuffix}`)
     : _pipeBtn("·", "transparent", "#bbb", jump("recordings"), false,
         "No recordings yet"));
   // Validation
@@ -1586,13 +1587,12 @@ async function loadScenario(s, initialArchive, focus) {
     return;
   }
   const recordingPath = `${encodeURIComponent(s.agent)}/${encodeURIComponent(s.subtree)}/${encodeURIComponent(s.id)}`;
-  const [data, archives, recipes, catalog] = await Promise.all([
+  // Recipe lookup uses recipesByCoverageId (populated once at init from
+  // /api/recipes — see comment above), so no per-recording recipes fetch
+  // is needed here.
+  const [data, archives, catalog] = await Promise.all([
     fetch(`/api/scenarios/${recordingPath}`).then(r => r.json()),
     fetch(`/api/scenarios/${recordingPath}/recordings`).then(r => r.ok ? r.json() : []).catch(() => []),
-    // Recipes for the new Recipe panel target on this page (anchor:
-    // recipe). Same payload the coverage page uses. Look up the
-    // by_adapter entry under the scenario name and agent slug.
-    fetch(`/api/recipes`).then(r => r.ok ? r.json() : null).catch(() => null),
     // Coverage catalog: lets us render a stub Assessment panel from
     // the matrix verdict + notes when no assessment.json exists.
     // Without this fallback the ⚙ / ◉ pipeline-strip jumps would
@@ -2066,9 +2066,8 @@ function _buildExpectedRow(ph, def, specOnly) {
   // delta_ms may be 0 (phase matched exactly at its anchor) — treat
   // anything numeric as renderable, only fall back to "—" when the
   // phase never matched at all.
-  const delta = ph.matched_ts
-    ? `+${Number.isFinite(ph.delta_ms) ? ph.delta_ms : 0} ms`
-    : "—";
+  const deltaMs = Number.isFinite(ph.delta_ms) ? ph.delta_ms : 0;
+  const delta = ph.matched_ts ? `+${deltaMs} ms` : "—";
   tr.innerHTML = `
         <td><code>${escapeHtml(ph.phase)}</code></td>
         <td style="font-size: 11px;">${target}</td>
@@ -2179,6 +2178,16 @@ export function renderManifestFields(m, passRateLabel, alwaysEllipsis) {
 //   other <name>   → an older recording: fetched via the recordings endpoint;
 //                    Playback retargets to its events via /api/replay/start's
 //                    recording field.
+// Label: recording_started_at, daemon version, fresh pass rate. Uses
+// recording_started_at (not promoted_at) so the timestamps describe WHEN
+// the recording was captured.
+function fmtLabel(startedAt, daemonVer, passRate) {
+  const ts = startedAt || "(no timestamp)";
+  const ver = daemonVer ? ` · daemon ${daemonVer}` : "";
+  const pass = passRate ? ` · ${passRate}` : "";
+  return `${ts}${ver}${pass}`;
+}
+
 function renderRecordingHistory(s, latestData, archives, initialArchive, recipeEntry, coverageEntry) {
   const wrap = document.createElement("div");
 
@@ -2188,9 +2197,10 @@ function renderRecordingHistory(s, latestData, archives, initialArchive, recipeE
   const intro = document.createElement("div");
   intro.style.cssText = "margin-bottom: 8px; font-size: 12px; color: #555;";
   const recCount = (archives || []).length;
+  const recCountSuffix = recCount === 1 ? "" : "s";
   intro.innerHTML = `Select which recording to inspect — all live under <code>recordings/</code>, newest first. <b>expected.jsonl</b> is the constant benchmark across all of them; picking an older recording re-evaluates the current spec against its events (drift signal).` +
     (recCount > 0
-      ? ` <b>${recCount}</b> recording${recCount === 1 ? "" : "s"} available.`
+      ? ` <b>${recCount}</b> recording${recCountSuffix} available.`
       : ` No recordings yet.`);
   selPanel.appendChild(intro);
 
@@ -2200,17 +2210,6 @@ function renderRecordingHistory(s, latestData, archives, initialArchive, recipeE
   noneOpt.value = "__none__";
   noneOpt.textContent = "— No recording (spec only) —";
   select.appendChild(noneOpt);
-
-  // Label: recording_started_at, daemon version, fresh pass rate. Uses
-  // recording_started_at (not promoted_at) so the timestamps describe WHEN
-  // the recording was captured.
-  function fmtLabel(startedAt, daemonVer, passRate) {
-    const ts = startedAt || "(no timestamp)";
-    const ver = daemonVer ? ` · daemon ${daemonVer}` : "";
-    const pass = passRate ? ` · ${passRate}` : "";
-    return `${ts}${ver}${pass}`;
-  }
-
 
   // Every recording lives under recordings/<name>/ — there is no separate
   // "Latest" entry. The list is newest-first by name; the newest (the one the


### PR DESCRIPTION
## Summary
- Fixes #936: extends `tools/dora-metrics.sh` with Change Failure Rate and MTTR, combining the three candidate failure signals from #936's discussion (per the user's decision to combine rather than pick one):
  1. **Hotfix window** — release landed within `--hotfix-window-hours` (default 24) of the prior release.
  2. **Revert commit** — release ships a commit matching `^Revert` whose `This reverts commit <hash>.` trailer resolves to a commit shipped in an earlier release. A non-standard `revert:`-style commit with no trailer is tallied separately as "unresolved" rather than silently dropped or guessed at.
  3. **Bug-labeled issue** — release ships a commit referencing `Fixes/Closes/Resolves #NNN` for a `gh issue list --label bug` issue. Degrades gracefully (signal line shows `n/a`) when `gh` is unavailable/unauthenticated, matching Phase 1's existing convention.
- CFR = deduped union of flagged releases / releases in range. MTTR reported per-signal and combined, one sample per flagged instance (not deduped) since each is a distinct restore event.
- **Also fixes a pre-existing Phase 1 bug** found while extending the file: the Lead Time commit walk silently dropped the *last* commit of every per-tag range, because `git log`'s final line has no trailing newline and `while read` treats that as a failed read (classic missing-final-newline bug). Confirmed via a synthetic single-commit-per-tag repo (previously reported 0 commits; now reports correctly) and cross-checked against the real repo (901 → 935 commits over the same 180-day window, +34 ≈ 1 per tag walked).
- Refactored to dedupe: hoisted `median_of`/`mean_of`/`format_hours` and a shared `idx_in_set` membership helper so Lead Time and the new CFR/MTTR section share logic instead of each reimplementing it (caught in low-effort code review on this PR).

Branches on top of #943 (Phase 1, not yet merged) since this extends that file directly — base branch here is `worktree-issue-919-dora-metrics`, not `main`. Merge #943 first, or merge this into it.

## Test plan
- [x] `bash -n tools/dora-metrics.sh`
- [x] Ran against real repo history at multiple ranges (14/90/180 days), zero-release range, single-release range, `gh`-unavailable (restricted `PATH`)
- [x] Manually cross-checked one instance per signal against real data: a real bug-fix commit (`Fixes #920`, issue labeled "bug", shipped in v0.5.6) correctly flagged; the repo's one non-standard `revert:` commit (no trailer) correctly tallied as "unresolved" rather than silently dropped
- [x] Built a synthetic throwaway git repo to exercise the *resolved*-revert code path end to end (no real example exists in this repo's main history) — confirmed correct MTTR computation
- [x] Code-reviewed at low effort; fixed both findings (duplicate median/mean logic, duplicate membership-check helper) by hoisting shared helpers
- [x] `tools/preflight.sh` (via pre-push hook) — all gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)