### PR TITLE
feat(cache-bloat): show percentage above baseline in badge

### DIFF
--- a/core/application/services/cache_bloat_detector.go
+++ b/core/application/services/cache_bloat_detector.go
@@ -3,6 +3,7 @@ package services
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"time"
 
 	"irrlicht/core/domain/lifecycle"
@@ -130,6 +131,7 @@ func (c *CacheBloatDetector) OnActivity(state *session.SessionState) {
 	if currentMedian <= baseline*c.cfg.Threshold {
 		// Below threshold — clear any prior verdict (re-evaluated each turn).
 		state.Metrics.CacheBloat = false
+		state.Metrics.CacheBloatPercent = 0
 		state.Metrics.CacheBloatTooltip = ""
 		state.Metrics.CacheBloatExplanation = ""
 		return
@@ -137,6 +139,7 @@ func (c *CacheBloatDetector) OnActivity(state *session.SessionState) {
 
 	// Regression tripped. Set the glyph and (when possible) name the version.
 	state.Metrics.CacheBloat = true
+	state.Metrics.CacheBloatPercent = int(math.Round((currentMedian/baseline - 1) * 100))
 	tooltip, regressing, prior, deltaTokens := c.attributeVersion(state, currentMedian)
 	state.Metrics.CacheBloatTooltip = tooltip
 	state.Metrics.CacheBloatExplanation = cacheBloatExplanation(tooltip)

--- a/core/application/services/cache_bloat_detector_test.go
+++ b/core/application/services/cache_bloat_detector_test.go
@@ -84,6 +84,9 @@ func TestCacheBloat_ScenarioA_VersionAttribution(t *testing.T) {
 	if !live.Metrics.CacheBloat {
 		t.Fatal("expected CacheBloat glyph to fire")
 	}
+	if live.Metrics.CacheBloatPercent <= 0 {
+		t.Errorf("expected CacheBloatPercent > 0, got %d", live.Metrics.CacheBloatPercent)
+	}
 	tip := live.Metrics.CacheBloatTooltip
 	if !strings.Contains(tip, "2.0.0") || !strings.Contains(tip, "1.0.0") || !strings.Contains(tip, "claude-code") {
 		t.Errorf("tooltip should name both versions and adapter, got %q", tip)
@@ -129,6 +132,9 @@ func TestCacheBloat_ScenarioB_NoFalseAttribution(t *testing.T) {
 
 	if !live.Metrics.CacheBloat {
 		t.Fatal("expected CacheBloat glyph to fire")
+	}
+	if want := 100; live.Metrics.CacheBloatPercent != want {
+		t.Errorf("CacheBloatPercent = %d, want %d (baseline 5000, median 10000)", live.Metrics.CacheBloatPercent, want)
 	}
 	if live.Metrics.CacheBloatTooltip != "" {
 		t.Errorf("tooltip must be empty (no attribution), got %q", live.Metrics.CacheBloatTooltip)
@@ -255,6 +261,9 @@ func TestCacheBloat_ClearsWhenMedianDropsBack(t *testing.T) {
 	driveTurns(d, live, 1000, 4) // median falls to 1000 → below 5000×1.4
 	if live.Metrics.CacheBloat {
 		t.Error("glyph should clear once median drops back under threshold")
+	}
+	if live.Metrics.CacheBloatPercent != 0 {
+		t.Errorf("percent should clear too, got %d", live.Metrics.CacheBloatPercent)
 	}
 	if live.Metrics.CacheBloatTooltip != "" {
 		t.Errorf("tooltip should clear too, got %q", live.Metrics.CacheBloatTooltip)

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -140,6 +140,14 @@ type SessionMetrics struct {
 	// transcript.
 	CacheBloat bool `json:"cache_bloat,omitempty"`
 
+	// CacheBloatPercent is how far the session's current median cache-creation
+	// per turn sits above the project's p25 baseline, as a rounded percentage
+	// (e.g. 340 means 340% above baseline). Set alongside CacheBloat by the
+	// detector; both UIs append it to the badge so the glyph carries a
+	// magnitude, not just an up-arrow (issue #946). Zero when CacheBloat is
+	// false.
+	CacheBloatPercent int `json:"cache_bloat_percent,omitempty"`
+
 	// CacheBloatTooltip is the human-readable hover text for the CacheBloat
 	// glyph, composed daemon-side so both UIs stay dumb. When the project's
 	// lookback window contains ≥2 distinct agent versions with a large enough

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -385,6 +385,7 @@ struct SessionMetrics: Codable {
     let taskEstimate: TaskEstimateInfo?    // agent-authored task progress from the in-band marker (issue #558)
     let taskCompletionEta: Date?           // projected task completion (nil when no marker / no progress yet)
     let cacheBloat: Bool?                  // cache-creation regression detected for this session (issue #374)
+    let cacheBloatPercent: Int?            // how far above the project baseline, as a rounded percent (issue #946)
     let cacheBloatTooltip: String?         // hover text naming the regressing version (empty when no attribution)
     let cacheBloatExplanation: String?     // longer plain-language hover text, composed daemon-side (issue #827)
 
@@ -409,6 +410,7 @@ struct SessionMetrics: Codable {
         case taskEstimate = "task_estimate"
         case taskCompletionEta = "task_completion_eta"
         case cacheBloat = "cache_bloat"
+        case cacheBloatPercent = "cache_bloat_percent"
         case cacheBloatTooltip = "cache_bloat_tooltip"
         case cacheBloatExplanation = "cache_bloat_explanation"
     }
@@ -447,6 +449,7 @@ struct SessionMetrics: Codable {
             taskCompletionEta = nil
         }
         cacheBloat = try c.decodeIfPresent(Bool.self, forKey: .cacheBloat)
+        cacheBloatPercent = try c.decodeIfPresent(Int.self, forKey: .cacheBloatPercent)
         cacheBloatTooltip = try c.decodeIfPresent(String.self, forKey: .cacheBloatTooltip)
         cacheBloatExplanation = try c.decodeIfPresent(String.self, forKey: .cacheBloatExplanation)
     }
@@ -475,6 +478,7 @@ struct SessionMetrics: Codable {
         taskEstimate: TaskEstimateInfo? = nil,
         taskCompletionEta: Date? = nil,
         cacheBloat: Bool? = nil,
+        cacheBloatPercent: Int? = nil,
         cacheBloatTooltip: String? = nil,
         cacheBloatExplanation: String? = nil
     ) {
@@ -498,6 +502,7 @@ struct SessionMetrics: Codable {
         self.taskEstimate = taskEstimate
         self.taskCompletionEta = taskCompletionEta
         self.cacheBloat = cacheBloat
+        self.cacheBloatPercent = cacheBloatPercent
         self.cacheBloatTooltip = cacheBloatTooltip
         self.cacheBloatExplanation = cacheBloatExplanation
     }
@@ -524,6 +529,7 @@ struct SessionMetrics: Codable {
         try c.encodeIfPresent(taskEstimate, forKey: .taskEstimate)
         try c.encodeIfPresent(taskCompletionEta.map { $0.timeIntervalSince1970 }, forKey: .taskCompletionEta)
         try c.encodeIfPresent(cacheBloat, forKey: .cacheBloat)
+        try c.encodeIfPresent(cacheBloatPercent, forKey: .cacheBloatPercent)
         try c.encodeIfPresent(cacheBloatTooltip, forKey: .cacheBloatTooltip)
         try c.encodeIfPresent(cacheBloatExplanation, forKey: .cacheBloatExplanation)
     }

--- a/platforms/macos/Irrlicht/Views/SessionRowView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionRowView.swift
@@ -174,7 +174,9 @@ struct SessionRowView: View {
     private var cacheBloatBlock: some View {
         if session.metrics?.cacheBloat == true {
             let tooltip = session.metrics?.cacheBloatTooltip
-            let badgeText = (tooltip?.isEmpty == false) ? tooltip! : "cache \u{2191}"
+            let base = (tooltip?.isEmpty == false) ? tooltip! : "cache \u{2191}"
+            let percent = session.metrics?.cacheBloatPercent ?? 0
+            let badgeText = percent > 0 ? "\(base) +\(percent)%" : base
             Text(badgeText)
                 .pill(color: IrrColors.pressureHigh, font: .system(size: 9, weight: .semibold, design: .monospaced))
                 .padding(.top, 2)

--- a/platforms/macos/Tests/SessionRowSnapshotTests.swift
+++ b/platforms/macos/Tests/SessionRowSnapshotTests.swift
@@ -136,6 +136,7 @@ final class SessionRowSnapshotTests: XCTestCase {
         taskEstimate: TaskEstimateInfo? = nil,
         taskCompletionEta: Date? = nil,
         cacheBloat: Bool? = nil,
+        cacheBloatPercent: Int? = nil,
         cacheBloatTooltip: String? = nil,
         cacheBloatExplanation: String? = nil
     ) -> SessionMetrics {
@@ -154,6 +155,7 @@ final class SessionRowSnapshotTests: XCTestCase {
             taskEstimate: taskEstimate,
             taskCompletionEta: taskCompletionEta,
             cacheBloat: cacheBloat,
+            cacheBloatPercent: cacheBloatPercent,
             cacheBloatTooltip: cacheBloatTooltip,
             cacheBloatExplanation: cacheBloatExplanation
         )

--- a/platforms/web/formatters.js
+++ b/platforms/web/formatters.js
@@ -238,10 +238,14 @@ export function activeSubagentCount(a) {
 
 // Cache-creation regression badge (#813) — short visible text. `tooltip` is
 // the daemon's cache_bloat_tooltip: the version-attribution string when it
-// could name the regressing upstream version, else '' (no attribution). The
-// longer hover explanation is composed daemon-side (cache_bloat_explanation,
-// issue #827) and rendered verbatim — see updateCacheBloatRow in irrlicht.js.
-export function cacheBloatBadgeText(tooltip) {
-  return tooltip || 'cache ↑';
+// could name the regressing upstream version, else '' (no attribution).
+// `percent` is cache_bloat_percent — how far the session's median
+// cache-creation per turn sits above the project baseline, appended so the
+// badge carries a magnitude, not just an up-arrow (issue #946). The longer
+// hover explanation is composed daemon-side (cache_bloat_explanation, issue
+// #827) and rendered verbatim — see updateCacheBloatRow in irrlicht.js.
+export function cacheBloatBadgeText(tooltip, percent) {
+  const base = tooltip || 'cache ↑';
+  return percent > 0 ? `${base} +${percent}%` : base;
 }
 

--- a/platforms/web/irrlicht.cachebloat.test.js
+++ b/platforms/web/irrlicht.cachebloat.test.js
@@ -38,6 +38,7 @@ const sessionsPayload = {
           first_seen: 1764800000,
           metrics: {
             cache_bloat: true,
+            cache_bloat_percent: 340,
             cache_bloat_tooltip: 'claude-code 2.1.143 +14K cache tokens vs 2.1.98',
             cache_bloat_explanation: attributedExplanation,
           },
@@ -48,7 +49,12 @@ const sessionsPayload = {
           project_name: 'irrlicht',
           adapter: 'claude-code',
           first_seen: 1764800100,
-          metrics: { cache_bloat: true, cache_bloat_tooltip: '', cache_bloat_explanation: unattributedExplanation },
+          metrics: {
+            cache_bloat: true,
+            cache_bloat_percent: 210,
+            cache_bloat_tooltip: '',
+            cache_bloat_explanation: unattributedExplanation,
+          },
         },
         {
           session_id: 'normal',
@@ -97,13 +103,14 @@ describe('cache-creation regression badge (#813)', () => {
     // rendered verbatim (issue #827 — no client-side re-derivation).
     const attributed = cacheBloatBadge('attributed')
     expect(attributed).not.toBeNull()
-    expect(attributed.textContent).toBe('claude-code 2.1.143 +14K cache tokens vs 2.1.98')
+    expect(attributed.textContent).toBe('claude-code 2.1.143 +14K cache tokens vs 2.1.98 +340%')
     expect(attributed.title).toBe(attributedExplanation)
 
-    // Unattributed: compact fallback label, not the old generic sentence.
+    // Unattributed: compact fallback label, not the old generic sentence,
+    // plus the percentage-above-baseline suffix (issue #946).
     const unattributed = cacheBloatBadge('unattributed')
     expect(unattributed).not.toBeNull()
-    expect(unattributed.textContent).toBe('cache ↑')
+    expect(unattributed.textContent).toBe('cache ↑ +210%')
     expect(unattributed.title).toBe(unattributedExplanation)
     expect(unattributed.title).not.toContain('Likely tied to')
 

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1252,7 +1252,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
 
     function updateCacheBloatRow(el, agent) {
       const metrics = agent.metrics || {};
-      const badgeText = cacheBloatBadgeText(metrics.cache_bloat_tooltip);
+      const badgeText = cacheBloatBadgeText(metrics.cache_bloat_tooltip, metrics.cache_bloat_percent);
       if (el.dataset.badge !== badgeText) {
         el.dataset.badge = badgeText;
         el.innerHTML = '<span class="row-cache-bloat">' + esc(badgeText) + '</span>';


### PR DESCRIPTION
## Summary
- The cache-bloat badge only showed a bare "cache ↑" (or a version-attribution string) with no magnitude — users couldn't tell if the regression was minor or severe without hovering.
- Adds `CacheBloatPercent` (`cache_bloat_percent`), computed daemon-side as how far the session's current median cache-creation per turn sits above the project's p25 baseline, rounded to a percentage.
- Both macOS (`SessionRowView.swift`) and web (`formatters.js`/`irrlicht.js`) badges now append `+N%` to the existing text, e.g. `cache ↑ +340%` or `claude-code 2.1.143 +14K cache tokens vs 2.1.98 +340%`.

Fixes #946

## Test plan
- [x] `go test ./core/application/services/... -run CacheBloat -v` — new percent assertions pass (trip, clear, version-attributed)
- [x] `swift build` + `swift test` in `platforms/macos` — 245 tests pass, including all `SessionRowSnapshotTests` snapshots (unaffected since percent defaults to nil/0)
- [x] `npm test` in `platforms/web` — 133 tests pass, including updated `irrlicht.cachebloat.test.js` assertions
- [x] `tools/preflight.sh` (pre-push hook) — green, aside from a known pre-existing flaky `TestDebounce_FirstEventFiresImmediately` timing test unrelated to this change (passed on retry)
- [x] `/code-review low` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)