### PR TITLE
fix(session): log the ready→working force-bounce

### DIFF
--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/lifecycle"
 	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/inbound"
 )
 
 // readyTransitions counts recorded working/waiting→ready transitions for sid.
@@ -199,6 +201,61 @@ func TestSessionDetector_BackgroundProcess_FreshSpawnFromReady_HoldsWorking(t *t
 
 	cancel()
 	<-done
+}
+
+// The ready→working force-bounce (see forceReadyToWorkingIfActive) must be
+// logged via LogInfo, not just recorded to the lifecycle trace — otherwise it
+// changes session state with zero trace in the daemon's human-readable log.
+// See issue #953.
+func TestSessionDetector_ForceReadyToWorking_LogsTransition(t *testing.T) {
+	const sid = "force-log"
+	const path = "/home/.claude/projects/-Users-test/force-log.jsonl"
+
+	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		return &session.SessionMetrics{LastEventType: "turn_done"}, nil
+	}}
+
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	repo.states[sid] = &session.SessionState{
+		SessionID:      sid,
+		State:          session.StateReady,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	log := &mockLogger{}
+	det := services.NewSessionDetector(
+		[]inbound.Watcher{tw}, pw, repo,
+		log, &mockGit{}, metrics, nil,
+		"test", 0, nil, nil, nil,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	defer func() {
+		cancel()
+		<-done
+	}()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      sid,
+		ProjectDir:     "-Users-test",
+		TranscriptPath: path,
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if slices.Contains(log.infoSnapshot(), services.ForceReadyToWorkingReason) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("session %s: force ready→working bounce was never logged via LogInfo", sid)
 }
 
 // A dead probe verdict must also purge the processes from the tailer's open

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -765,6 +765,7 @@ func (d *SessionDetector) forceReadyToWorkingIfActive(state *session.SessionStat
 	if state.State != session.StateReady || state.Metrics == nil || state.Metrics.LastEventType == "" {
 		return
 	}
+	d.log.LogInfo(logComponentSessionDetector, ev.SessionID, ForceReadyToWorkingReason)
 	d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: ev.SessionID, PrevState: session.StateReady, NewState: session.StateWorking, Reason: ForceReadyToWorkingReason})
 	state.State = session.StateWorking
 }

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -227,6 +227,14 @@ func (l *mockLogger) LogError(_, _, msg string) {
 func (l *mockLogger) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
 func (l *mockLogger) Close() error                                            { return nil }
 
+func (l *mockLogger) infoSnapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.infos))
+	copy(out, l.infos)
+	return out
+}
+
 type mockGit struct{}
 
 func (g *mockGit) GetBranch(dir string) string { return "main" }


### PR DESCRIPTION
## Summary
- `forceReadyToWorkingIfActive` bounced a `ready` session back to `working` but only recorded a `lifecycle.Event` (visible in the `--record` JSONL trace) — never `d.log.LogInfo`, unlike every sibling transition function (`applyStateTransition`, `holdParentWorkingForNewChild`). The bounce was invisible in the human-readable `events.log`.
- Adds the missing `d.log.LogInfo(logComponentSessionDetector, ev.SessionID, ForceReadyToWorkingReason)` call, mirroring `applyStateTransition`'s log-then-record ordering.
- Adds `TestSessionDetector_ForceReadyToWorking_LogsTransition` to lock this in.

Fixes #953.

## Test plan
- [x] `go build ./core/...`
- [x] `go vet ./core/...`
- [x] New test passes: `go test ./core/application/services/... -race -count=1 -run TestSessionDetector_ForceReadyToWorking_LogsTransition -v`
- [x] `tools/preflight.sh` (via pre-push hook) — all gates green: gofmt, core module tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, starhistory tests, both web suites, ARS architecture gate, security scan
- [x] `/code-review` at low effort — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)