### PR TITLE
fix: last 3 SonarQube findings from issue #901's backlog

### DIFF
--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -235,10 +235,8 @@ func TestSessionDetector_ForceReadyToWorking_LogsTransition(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- det.Run(ctx) }()
-	defer func() {
-		cancel()
-		<-done
-	}()
+	defer func() { <-done }()
+	defer cancel()
 
 	tw.ch <- agent.Event{
 		Type:           agent.EventActivity,

--- a/platforms/macos/Irrlicht/Views/EqualWidthSegmentedControl.swift
+++ b/platforms/macos/Irrlicht/Views/EqualWidthSegmentedControl.swift
@@ -44,7 +44,7 @@ struct EqualWidthSegmentedControl: NSViewRepresentable {
     // Picker(pickerStyle: .segmented) refuse to stretch. Honoring the
     // proposed width here (paired with `.frame(maxWidth: .infinity)` at the
     // call site) is what actually makes this control fill the row.
-    func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSSegmentedControl, context: Context) -> CGSize? {
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSSegmentedControl, context _: Context) -> CGSize? {
         let fitting = nsView.fittingSize
         return CGSize(width: proposal.width ?? fitting.width, height: fitting.height)
     }

--- a/tools/irrlicht-design-system/preview/comp-badges.html
+++ b/tools/irrlicht-design-system/preview/comp-badges.html
@@ -8,7 +8,7 @@ body{background:#080c16}
 .agent-orange{background:rgba(77,45,0,0.12);color:#FF9500}
 .alert{display:inline-flex;align-items:center;gap:6px;padding:3px 8px;border-radius:3px;font-size:9px;line-height:1}
 .alert-h{background:rgba(38,9,7,0.1);color:#FF3B30}
-.alert-c{background:rgba(215,0,21,0.12);color:#fb0018}
+.alert-c{background:rgba(215,0,21,0.12);color:#ff5868}
 .wschip{display:inline-flex;align-items:center;gap:7px;font-size:10px;color:#5a6480;letter-spacing:0.03em}
 .wsring{width:8px;height:8px;border-radius:50%;border:2px solid}
 .connected{border-color:#34C759;background:rgba(52,199,89,0.3)}


### PR DESCRIPTION
## Summary

Closes out the SonarQube backlog tracked in #901 down to just the 4 genuine feature gaps already tracked in #934/#935 (unimplemented `interrupt`/`reset_session` driver actions for antigravity/kiro-cli recordings — real work, not mechanical fixes).

- `css:S7924`: `comp-badges.html`'s `.alert-c` text was still failing contrast after an earlier fix (4.55:1, just barely over the 4.5 threshold by my own calculation — Sonar's algorithm apparently disagreed). Picked a color with real margin (6+:1 against both the page background and the composited translucent swatch background).
- `swift:S1172`: `EqualWidthSegmentedControl.swift`'s `sizeThatFits(context:)` is an `NSViewRepresentable` protocol requirement — renamed the unused *internal* parameter name to `context _: Context` (the external label SwiftUI's runtime calls with is untouched).
- `godre:S8188`: `background_process_test.go`'s context/cancel was already deferred, just bundled inside a closure together with the goroutine-done wait, which the rule's pattern-matcher doesn't recognize as "deferred cancel". Split into two separately-ordered `defer`s (cancel still fires before the wait — verified with `-race` that the synchronization order is unchanged, and caught+fixed a LIFO defer-ordering slip of my own before it shipped).

## Test plan
- [x] `go build ./core/...`, `go vet ./core/...` — clean
- [x] `go test ./core/... -count=1` — passes, including 3x `-race` reruns of the specific test touched
- [x] `swift build` — clean
- [x] `tools/preflight.sh` (pre-push hook) — passed