### PR TITLE
fix(services): stop racy direct mockRepo reads in 2 more flaky tests

### DIFF
--- a/core/application/services/debounce_test.go
+++ b/core/application/services/debounce_test.go
@@ -34,7 +34,7 @@ func TestDebounce_FirstEventFiresImmediately(t *testing.T) {
 		EventCount:     1,
 	})
 
-	savesBefore := repo.saves
+	savesBefore := repo.savesCount()
 
 	// Send a single activity event.
 	tw.ch <- agent.Event{
@@ -44,16 +44,14 @@ func TestDebounce_FirstEventFiresImmediately(t *testing.T) {
 		TranscriptPath: "/home/.claude/projects/-Users-test/deb1.jsonl",
 	}
 
-	// The leading-edge fires immediately — check within 50ms (well before the
-	// 2-second debounce window).
-	time.Sleep(50 * time.Millisecond)
+	// The leading-edge fires immediately — poll well before the 2-second
+	// debounce window so a slow scheduler under load doesn't false-fail a
+	// fixed sleep.
+	waitForCondition(func() bool { return repo.savesCount() > savesBefore }, 500*time.Millisecond)
 
-	repo.mu.Lock()
-	savesAfter := repo.saves
-	repo.mu.Unlock()
-
+	savesAfter := repo.savesCount()
 	if savesAfter <= savesBefore {
-		t.Errorf("expected at least one save within 50ms (leading-edge), got saves before=%d after=%d", savesBefore, savesAfter)
+		t.Errorf("expected at least one save within 500ms (leading-edge), got saves before=%d after=%d", savesBefore, savesAfter)
 	}
 
 	cancel()
@@ -208,17 +206,16 @@ func TestDebounce_TerminalEventShortCircuits(t *testing.T) {
 	})
 
 	// First non-terminal event — fires immediately (leading edge) and starts the 2s timer.
+	savesBeforeFirst := repo.savesCount()
 	tw.ch <- agent.Event{
 		Type:           agent.EventActivity,
 		SessionID:      "term1",
 		ProjectDir:     "-Users-test",
 		TranscriptPath: "/home/.claude/projects/-Users-test/term1.jsonl",
 	}
-	time.Sleep(50 * time.Millisecond)
+	waitForCondition(func() bool { return repo.savesCount() > savesBeforeFirst }, 500*time.Millisecond)
 
-	repo.mu.Lock()
-	savesAfterFirst := repo.saves
-	repo.mu.Unlock()
+	savesAfterFirst := repo.savesCount()
 
 	// Terminal event mid-window — should fire immediately, not after 2s.
 	tw.ch <- agent.Event{
@@ -229,13 +226,10 @@ func TestDebounce_TerminalEventShortCircuits(t *testing.T) {
 		Terminal:       true,
 	}
 
-	// Wait well under the 2s debounce window.
-	time.Sleep(100 * time.Millisecond)
+	// Poll well under the 2s debounce window.
+	waitForCondition(func() bool { return repo.savesCount() > savesAfterFirst }, 500*time.Millisecond)
 
-	repo.mu.Lock()
-	savesAfterTerminal := repo.saves
-	repo.mu.Unlock()
-
+	savesAfterTerminal := repo.savesCount()
 	if savesAfterTerminal <= savesAfterFirst {
 		t.Errorf("terminal event should trigger processActivity immediately: saves before=%d after=%d", savesAfterFirst, savesAfterTerminal)
 	}
@@ -267,7 +261,7 @@ func TestDebounce_FirstEventTerminalFiresImmediately(t *testing.T) {
 		EventCount:     1,
 	})
 
-	savesBefore := repo.saves
+	savesBefore := repo.savesCount()
 
 	// First event for the session is already terminal — should fire immediately
 	// via the leading-edge path (no prior debounce entry).
@@ -279,12 +273,9 @@ func TestDebounce_FirstEventTerminalFiresImmediately(t *testing.T) {
 		Terminal:       true,
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	waitForCondition(func() bool { return repo.savesCount() > savesBefore }, 500*time.Millisecond)
 
-	repo.mu.Lock()
-	savesAfter := repo.saves
-	repo.mu.Unlock()
-
+	savesAfter := repo.savesCount()
 	if savesAfter <= savesBefore {
 		t.Errorf("first terminal event should fire immediately: saves before=%d after=%d", savesBefore, savesAfter)
 	}

--- a/core/application/services/session_detector_subagent_test.go
+++ b/core/application/services/session_detector_subagent_test.go
@@ -300,14 +300,13 @@ func TestSessionDetector_ParentReleasedToReady_WhenChildFinishes(t *testing.T) {
 		TranscriptPath: "/home/.claude/projects/-Users-test/parent2/subagents/child2.jsonl",
 	}
 
-	time.Sleep(50 * time.Millisecond)
+	waitForSessionState(repo, "parent2", session.StateReady, 500*time.Millisecond)
 
-	parent, _ := repo.Load("parent2")
-	if parent == nil {
-		t.Fatal("parent session should still exist")
-	}
-	if parent.State != session.StateReady {
-		t.Errorf("parent state: got %q, want ready (child finished, parent turn was done)", parent.State)
+	repo.mu.Lock()
+	got := repo.lastSavedState["parent2"]
+	repo.mu.Unlock()
+	if got != session.StateReady {
+		t.Errorf("parent state: got %q, want ready (child finished, parent turn was done)", got)
 	}
 
 	cancel()


### PR DESCRIPTION
## Summary
- `TestDebounce_FirstEventFiresImmediately` read `repo.saves` directly (unlocked) while the detector's own goroutine concurrently wrote it via `Save()`; switched to the existing race-free `savesCount()` accessor.
- `TestSessionDetector_ParentReleasedToReady_WhenChildFinishes` read `parent.State` off the shared `*SessionState` pointer returned by `Load()`, racing `applyStateTransition()`'s concurrent write; switched to `waitForSessionState` + the repo's `lastSavedState` snapshot, matching the #942/#944 fix for the sibling test.
- Also hardened two more `debounce_test.go` "fires immediately" assertions (`TestDebounce_FirstEventTerminalFiresImmediately`, `TestDebounce_TerminalEventShortCircuits`) that used the same unlocked `repo.saves` read plus a fixed 50-100ms sleep — the sleep alone proved timing-flaky under load even after the race-safe read, so both now poll `savesCount()` with headroom well under the 2s debounce window instead of sleeping a fixed duration.

Fixes #956.

## Test plan
- [x] `go test ./core/application/services/... -race -count=5` — clean
- [x] Stress-tested the 4 touched tests with `-race -count=15` — no races, no flakes
- [x] `go test ./core/... -race -count=1` — clean except two pre-existing, unrelated flakes reproduced independently of this diff (`TestSessionDetector_HandlePermissionHook_PreToolUseTransitionsToWaiting` in a file untouched by this PR, and `TestDaemonStartupSmoke`'s daemon-boot timing test) — both pass in isolation and are unrelated to the mockRepo read pattern this issue addresses
- [x] `tools/preflight.sh` (via pre-push hook) — all gates pass
- [x] `/code-review` at low effort — diff is test-only, no findings in scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)