### PR TITLE
fix(backchannel): route Custom actions through SendCommand for submit

### DIFF
--- a/core/application/services/backchannel_service.go
+++ b/core/application/services/backchannel_service.go
@@ -254,7 +254,7 @@ func (e *BackchannelEngine) runActions(r backchannel.Rule, sid, adapter string) 
 				}
 				err = e.input.SendCommand(sid, cmd)
 			} else {
-				err = e.input.SendInput(sid, []byte(a.Data))
+				err = e.input.SendCommand(sid, a.Data)
 			}
 		case backchannel.ActionInterrupt:
 			err = e.input.Interrupt(sid)

--- a/core/application/services/backchannel_service_test.go
+++ b/core/application/services/backchannel_service_test.go
@@ -94,18 +94,18 @@ func TestRunActions_UnsupportedPresetDoesNotFire(t *testing.T) {
 	}
 }
 
-func TestRunActions_CustomSendsRawVerbatim(t *testing.T) {
+func TestRunActions_CustomSubmitsViaSendCommand(t *testing.T) {
 	on := true
 	fw := &fakeForwarder{}
 	e := NewBackchannelEngine(stubRules{}, fw, claudeCompactPresets(), nil, func() bool { return on }, bcNopLog{})
 	r := backchannel.Rule{ID: "r", Enabled: true,
-		Actions: []backchannel.Action{{Kind: backchannel.ActionInput, Data: "/foo\r"}}}
+		Actions: []backchannel.Action{{Kind: backchannel.ActionInput, Data: "/foo"}}}
 	e.runActions(r, "s1", "claude-code")
-	if string(fw.sentInput) != "/foo\r" {
-		t.Errorf("SendInput = %q, want %q", fw.sentInput, "/foo\r")
+	if fw.sentCommand != "/foo" {
+		t.Errorf("SendCommand = %q, want %q", fw.sentCommand, "/foo")
 	}
-	if fw.commandSet {
-		t.Errorf("SendCommand must not be used for Custom, got %q", fw.sentCommand)
+	if fw.sentInput != nil {
+		t.Errorf("SendInput must not be used for Custom, got %q", fw.sentInput)
 	}
 }
 

--- a/core/domain/backchannel/rule.go
+++ b/core/domain/backchannel/rule.go
@@ -61,9 +61,10 @@ type Action struct {
 	// daemon translates per the session's agent + terminal backend (issue
 	// #754). One of the Preset* ids. When empty, Data is sent verbatim (Custom).
 	Preset string `json:"preset,omitempty"`
-	// Data is the raw text injected for a Custom ActionInput (Preset empty),
-	// sent byte-for-byte including any submit sequence the user typed. Ignored
-	// when Preset is set.
+	// Data is the command text injected for a Custom ActionInput (Preset
+	// empty); the backend appends whatever submit sequence it needs (issue
+	// #963), so Data should not include a trailing CR itself. Ignored when
+	// Preset is set.
 	Data string `json:"data,omitempty"`
 }
 

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -411,7 +411,7 @@ type AgentController interface {
 	// SendCommand injects a command and submits it. Unlike SendInput, the
 	// submit sequence is owned by the backend: tmux/kitty get a trailing CR
 	// appended; AppleScript hosts auto-submit the bare command. Used for
-	// preset actions whose command text is agent-declared (issue #754).
+	// backchannel actions — both preset (issue #754) and custom.
 	SendCommand(sessionID, command string) error
 	// Interrupt delivers an interrupt (e.g. Ctrl-C) to the session.
 	Interrupt(sessionID string) error


### PR DESCRIPTION
## Summary
- Custom backchannel input actions (e.g. a rule sending `/compact`) went through `SendInput`, which types the string verbatim with no submit sequence appended — so the command never actually submits, even on already-controllable terminals (tmux/kitty/AppleScript).
- `SendCommand` already owns the correct per-backend submit logic and is what preset actions use; route Custom actions the same way.
- Updated the stale doc comments that assumed the user would type a literal `\r` into the rule's Data field (there's no way to do that from the Settings text field UI).

Fixes #963.

## Test plan
- [x] `go test ./core/application/services/... ./core/adapters/outbound/control/... ./core/domain/backchannel/...` — updated `TestRunActions_CustomSendsRawVerbatim` → `TestRunActions_CustomSubmitsViaSendCommand`, asserts Custom now goes through `SendCommand` with bare data (no manual CR)
- [x] `tools/preflight.sh` — all gates pass (one unrelated pre-existing `-race` timing flake in `TestDebounce_*` reproduced once, did not reproduce on retry)
- [x] `/code-review low` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)