### PR TITLE
fix(web): close history-seg fieldsets with </fieldset>, not </div>

### DIFF
--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -174,7 +174,7 @@
             <button type="button" data-range="year">Year</button>
             <button type="button" data-range="this-month">This Month</button>
             <button type="button" data-range="custom">Custom…</button>
-          </div>
+          </fieldset>
           <div class="history-custom" id="history-custom" hidden>
             <input type="date" id="history-start" aria-label="Start date">
             <span class="history-custom-sep">→</span>
@@ -216,7 +216,7 @@
             <button type="button" data-group="model">Model</button>
             <button type="button" data-group="session">Session</button>
             <button type="button" data-group="token_type" title="Stack by token kind (tokens metric)">Token type</button>
-          </div>
+          </fieldset>
         </div>
         <div class="history-ctl-row" id="history-filter-row">
           <span class="history-ctl-label">Filter</span>


### PR DESCRIPTION
## Summary

- The Range and Group rows in the History tab's `.history-controls` block closed their `<fieldset class="history-seg">` with a stray `</div>` instead of `</fieldset>`. Per HTML5 tree construction, a mismatched end tag against a "special" element like `<fieldset>` is ignored, so later siblings (e.g. the Forecast toggle) ended up nested inside the still-open fieldset instead of their intended `.history-ctl-row`.
- Fix is mechanical: swap the two stray `</div>` for `</fieldset>` (the Chart row's two fieldsets were already correct).

Fixes #958

## Test plan

- [x] Verified via jsdom (same approach the issue used to detect the bug): forecast checkbox now nests under `.history-ctl-row` as intended, and all 4 `fieldset.history-seg` elements close correctly with the right parent/children.
- [x] `npm test` in `platforms/web` — 150/150 passing.
- [x] `/code-review` (low effort) — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)