### PR TITLE
fix(macos): cap DORA project picker width so it can't overflow the History panel

### DIFF
--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -277,7 +277,10 @@ struct HistoryView: View {
 
     /// DORA's project picker (#951), sourced from knownProjects — already
     /// populated from cost fetches grouped by project, so no separate
-    /// project-discovery fetch is needed.
+    /// project-discovery fetch is needed. Capped with maxWidth (not
+    /// `.fixedSize()`, unlike its Section/Range siblings) because project
+    /// names are unbounded-length user data; without a ceiling a long name
+    /// pushes the row past the panel's fixed width (#962).
     @ViewBuilder private var doraProjectPicker: some View {
         Picker("Project", selection: Binding(
             get: { doraProject ?? "" },
@@ -287,7 +290,7 @@ struct HistoryView: View {
             ForEach(knownProjects, id: \.self) { Text($0).tag($0) }
         }
         .labelsHidden()
-        .fixedSize()
+        .frame(maxWidth: 140)
     }
 
     /// Custom-range date pickers, shared by the Usage and Metrics tabs.


### PR DESCRIPTION
## Summary
- The DORA project picker in the History tab's Metrics section used `.fixedSize()`, so its width tracked the selected project name with no upper bound.
- The History panel is pinned to a fixed 380pt width; a long project name (combined with the Section/Range pickers alongside it) could push the row — and everything below it — out of frame.
- Caps the picker with `.frame(maxWidth: 140)` instead, so it can never exceed the available width regardless of project name length.

Fixes #962

## Test plan
- [x] `swift build` succeeds
- [x] `swift test --filter HistoryViewSnapshotTests` — all 9 pass (none exercise the picker row directly, so no goldens needed updating)
- [x] `/code-review` (low effort) on the diff — no findings
- [x] `tools/preflight.sh`-equivalent gates all pass via the pre-push hook