### PR TITLE
onboarding-factory: implement 'interrupt' driver action for antigravity + kiro-cli

### DIFF
--- a/replaydata/agents/antigravity/driver-interactive.sh
+++ b/replaydata/agents/antigravity/driver-interactive.sh
@@ -110,7 +110,7 @@ SES_MARKER=(); SES_CWD=(); SES_ALIVE=()
 # recipe-lint flags a recipe needing it as a semantic_gap before recording. Set
 # DRIVE_SLASH_REQUIRES_STEP_TYPE=true if antigravity is headless-first (a bare
 # send "/cmd" stores literal text instead of reaching the REPL).
-DRIVE_ELICITS="send slash wait_turn keys sleep exit_clean restart resume sigkill start_session session"
+DRIVE_ELICITS="send slash wait_turn keys sleep interrupt exit_clean restart resume sigkill start_session session"
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 RUN_CWD="${IRRLICHT_ONBOARD_CWD:-$STAGING/cwd}"
 mkdir -p "$RUN_CWD"
@@ -350,6 +350,27 @@ step_keys() { # <keys>
   sleep 0.3
 }
 
+# --- AGENT-SPECIFIC SEAM: interrupt — cancel the in-flight turn (Escape) -----
+# agy's TUI binds Escape to cancel the in-flight turn (footer reads
+# "esc to cancel" while generating). Live-verified (#934): sending Escape
+# mid-turn shows "Interrupted · What should Antigravity CLI do instead?" and
+# ends the generation. The cancelled turn DOES land a terminal marker: a
+# MODEL/PLANNER_RESPONSE with status "DONE" and no tool_calls — same shape as
+# a normal completed turn, just with content omitted rather than the model's
+# text (this matches parser.go's own comment: a no-tool-calls PLANNER_RESPONSE
+# is "often empty content" and still settles the session). So turn_count sees
+# it exactly like any other completed turn. No EXPECTED_TURNS bookkeeping is
+# needed here regardless: unlike claudecode/codex/pi (which bump
+# EXPECTED_TURNS at send time and so must decrement it on interrupt), this
+# driver bumps EXPECTED_TURNS inside wait_turn() itself (SEAM 2) — an
+# interrupt that is never followed by its own wait_turn call never touches
+# the counter.
+step_interrupt() {
+  tmux send-keys -t "$SESSION" Escape
+  echo "[driver] interrupt[s$ACTIVE]: sent Escape" >&2
+  sleep 1
+}
+
 # --- AGENT-SPECIFIC SEAM: find the agy PID the daemon binds ------------------
 # Mirror core/adapters/inbound/agents/antigravity/pid.go: a plain process-name
 # (agy) + cwd match, lowest PID — agy is a single native process per
@@ -497,7 +518,7 @@ while IFS= read -r step; do
     send|slash)      send_text "$(jq -r '.text' <<<"$step")" ;;
     wait_turn)       wait_turn || break ;;
     sleep)           sleep "$(jq -r '.seconds // 1' <<<"$step")" ;;
-    interrupt)       not_implemented interrupt || break ;;       # TODO(antigravity): Escape/Ctrl-C the in-flight turn
+    interrupt)       step_interrupt ;;
     keys)            step_keys "$(jq -r '.keys' <<<"$step")" ;;
     reset_session)   not_implemented reset_session || break ;;   # TODO(antigravity): in-REPL /clear|/new → new id, SAME slot; re-resolve SES_TRANSCRIPT[$ACTIVE] (SEAM 3)
     restart)         step_restart ;;

--- a/replaydata/agents/kiro-cli/driver-interactive.sh
+++ b/replaydata/agents/kiro-cli/driver-interactive.sh
@@ -17,8 +17,9 @@
 # concurrent multi-slot primitives) are ALSO ported from
 # drive-codex-interactive.sh — kiro's per-slot MARKER + transcript_claimed model
 # is byte-identical to codex's, so two concurrent same-cwd sessions each resolve
-# to a distinct <uuid>.jsonl. The remaining signal primitives (interrupt,
-# reset_session) stay stubbed — `record` ports each when a recipe first needs it.
+# to a distinct <uuid>.jsonl. interrupt is ALSO ported (#934, live-verified):
+# kiro's TUI binds Escape to cancel the in-flight turn. reset_session stays
+# stubbed — `record` ports it when a recipe first needs it.
 #
 # IMPORTANT — how a stubbed arm is caught: every standard arm is PRESENT here
 # (so recipe-lint's GRAMMAR check treats it as handled and will NOT report a
@@ -172,7 +173,7 @@ source "$_DRIVE_LIB/contracts.sh"
 # it is invisible to the daemon and MUST NOT be used for recording (FINDINGS.md
 # §7). slash commands reach the live TUI directly (a bare send "/cmd" is NOT
 # stored as literal text), so DRIVE_SLASH_REQUIRES_STEP_TYPE stays false.
-DRIVE_ELICITS="send slash wait_turn sleep keys restart resume sigkill exit_clean start_session session"
+DRIVE_ELICITS="send slash wait_turn sleep keys interrupt restart resume sigkill exit_clean start_session session"
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 
 remaining_seconds() { local now; now=$(date +%s); (( now >= DEADLINE )) && echo 0 || echo $((DEADLINE - now)); }
@@ -375,6 +376,24 @@ send_keys() { # <key-token-list>
   tmux send-keys -t "$SESSION" $keys
   echo "[driver] keys[s$ACTIVE]: $keys (no turn expected)" >&2
   sleep 0.3
+}
+
+# --- AGENT-SPECIFIC SEAM: interrupt — cancel the in-flight turn (Escape) -----
+# kiro-cli's TUI binds Escape to "cancel the in-flight turn" (its footer reads
+# "Thinking... (esc to cancel)" while a turn is running). Live-verified
+# (#934): sending Escape mid-turn — whether still in the pre-stream "Thinking"
+# phase or after tokens have started streaming — always lands a SYNTHETIC
+# text-only AssistantMessage whose content is literally "Response was
+# interrupted by the user", with no toolUse block. turn_count's filter
+# (mirrors kirocli/parser.go's turn_done rule: text-only AssistantMessage)
+# counts this exactly like a normal completed turn. So — unlike
+# claudecode/codex/pi, whose cancelled turn leaves no matching terminal
+# marker — EXPECTED_TURNS is NOT decremented here: the interrupt itself
+# satisfies the turn the preceding send was expecting.
+step_interrupt() {
+  tmux send-keys -t "$SESSION" Escape
+  echo "[driver] interrupt[s$ACTIVE]: sent Escape (still expecting turn $EXPECTED_TURNS)" >&2
+  sleep 1
 }
 
 # --- TEARDOWN SEAM A: exit_clean ---------------------------------------------
@@ -584,7 +603,7 @@ while IFS= read -r step; do
     slash)           send_slash "$(jq -r '.text' <<<"$step")" ;;
     wait_turn)       wait_turn || STEP_OK=false ;;
     sleep)           sleep "$(jq -r '.seconds // 1' <<<"$step")" ;;
-    interrupt)       not_implemented interrupt || STEP_OK=false ;;     # TODO(kiro-cli): Escape/Ctrl-C the in-flight turn
+    interrupt)       step_interrupt ;;
     keys)            send_keys "$(jq -r '.keys' <<<"$step")" ;;
     reset_session)   not_implemented reset_session || STEP_OK=false ;; # TODO(kiro-cli): in-REPL /clear|/new → new session id
     restart)         step_restart ;;


### PR DESCRIPTION
## Summary

- Ports the `interrupt` step (Escape sent to the live tmux TUI) into both drivers, replacing the `not_implemented` stubs flagged by SonarQube's TODO-comment rule (`shelldre:S1135`) during #901's backlog triage.
- Live-verified against real authenticated sessions (not just code inspection): both CLIs bind Escape to cancel the in-flight turn.
  - **kiro-cli**: cancellation lands a synthetic text-only `AssistantMessage` ("Response was interrupted by the user") that the existing `turn_count` filter already counts like a normal completed turn — no `EXPECTED_TURNS` adjustment needed.
  - **antigravity**: cancellation lands an empty-content `PLANNER_RESPONSE` with no `tool_calls` — the same shape `turn_count` already recognizes as a completed turn. This driver bumps `EXPECTED_TURNS` inside `wait_turn()` rather than at send time, so no counter bookkeeping is needed there either.
- Both `DRIVE_ELICITS` lists now include `interrupt`, and `recipe-lint` confirms it's a handled, elicited step type for both adapters.

## Side finding (not acted on in this PR)

Both adapters' `2-20_user-esc-interrupt` scenario assessments currently say `daemon_capability: incapable` (frozen), reasoned from static code inspection that an interrupted turn leaves no terminal marker the daemon's parser would recognize. Live testing here shows the opposite for both: kiro-cli's synthetic "interrupted" message and antigravity's empty-content `PLANNER_RESPONSE` both match the parsers' existing turn-done rules. This suggests those two scenarios may actually be daemon-capable and worth re-assessing in a follow-up `/ir:onboarding-factory` pass — out of scope for this issue, which is driver-only.

Fixes #934

## Test plan

- [x] Live-verified `step_interrupt` against a real `kiro-cli` session (manual tmux test + full driver end-to-end run) — confirmed Escape cancels the turn and the driver's `wait_turn` correctly settles afterward.
- [x] Live-verified `step_interrupt` against a real `agy` (antigravity) session (manual tmux test + full driver end-to-end run) — confirmed Escape cancels the turn.
- [x] `bash tools/onboarding-factory/scripts/lib/recipe-lint_test.sh` — all pass.
- [x] `bash tools/onboarding-factory/scripts/smoke-test.sh` — all pass.
- [x] `go run ./tools/onboarding-factory/cmd/of validate` — OK.
- [x] `go test ./core/... -race -count=1` — all pass except a pre-existing, unrelated flaky test (`TestDebounce_FirstEventTerminalFiresImmediately`, ~1/5 runs, no Go code touched by this PR).
- [x] `tools/preflight.sh` — all green (re-confirmed by the pre-push hook).
- [x] `/code-review` at low effort — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)