### PR TITLE
fix(services,e2e,daemon): close out flaky-test-family follow-ups (#965, #967, #975)

### DIFF
--- a/core/application/services/mockrepo_fidelity_test.go
+++ b/core/application/services/mockrepo_fidelity_test.go
@@ -1,0 +1,93 @@
+package services_test
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestMockRepo_LoadReturnsIndependentCopy guards the #973 fix: Load must
+// never hand back the same pointer (or the same nested Metrics pointer)
+// twice, or a future edit that "simplifies" mockRepo back to returning the
+// stored pointer would silently reintroduce the aliasing race that made
+// core/application/services tests flake under -race for weeks (#578,
+// #606, #942/#944, #956/#964) before #973 closed it at the source.
+func TestMockRepo_LoadReturnsIndependentCopy(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["x"] = &session.SessionState{
+		SessionID: "x",
+		State:     session.StateWorking,
+		Metrics:   &session.SessionMetrics{TotalTokens: 10},
+	}
+
+	a, err := repo.Load("x")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	b, err := repo.Load("x")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if a == b {
+		t.Fatal("Load returned the same *SessionState pointer twice — mockRepo is aliasing again")
+	}
+	if a.Metrics == b.Metrics {
+		t.Fatal("Load returned the same *SessionMetrics pointer twice — nested field aliasing")
+	}
+
+	a.State = session.StateReady
+	a.Metrics.TotalTokens = 999
+
+	if b.State != session.StateWorking {
+		t.Errorf("mutating one Load() result changed another's State: got %q, want %q", b.State, session.StateWorking)
+	}
+	if b.Metrics.TotalTokens != 10 {
+		t.Errorf("mutating one Load() result's Metrics changed another's: got %d, want 10", b.Metrics.TotalTokens)
+	}
+}
+
+// TestMockRepo_SaveStoresIndependentCopy guards the other half of #973:
+// Save must copy the caller's struct in, so a caller that keeps mutating its
+// own pointer after Save() (as processActivityLocked's helpers do across a
+// single locked pass) can't reach back into what's stored.
+func TestMockRepo_SaveStoresIndependentCopy(t *testing.T) {
+	repo := newMockRepo()
+	s := &session.SessionState{SessionID: "y", State: session.StateWorking}
+
+	if err := repo.Save(s); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	s.State = session.StateReady // mutate the caller's copy after Save
+
+	got, err := repo.Load("y")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.State != session.StateWorking {
+		t.Errorf("Save aliased the caller's pointer: stored state changed to %q after the caller mutated its own copy", got.State)
+	}
+}
+
+// TestMockRepo_ListAllReturnsIndependentCopies guards ListAll the same way.
+func TestMockRepo_ListAllReturnsIndependentCopies(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["z"] = &session.SessionState{SessionID: "z", State: session.StateWorking}
+
+	all, err := repo.ListAll()
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(all))
+	}
+	all[0].State = session.StateReady
+
+	got, err := repo.Load("z")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.State != session.StateWorking {
+		t.Errorf("ListAll aliased stored state: mutating the returned slice's element changed Load's result to %q", got.State)
+	}
+}

--- a/core/application/services/session_detector_lifecycle_test.go
+++ b/core/application/services/session_detector_lifecycle_test.go
@@ -666,12 +666,16 @@ func TestSessionDetector_HandlePermissionHook_PreToolUseTransitionsToWaiting(t *
 	done := make(chan error, 1)
 	go func() { done <- det.Run(ctx) }()
 
-	// Let Run() start so the event loop is reading debouncedEvents.
-	time.Sleep(20 * time.Millisecond)
-
+	// dispatchHookActivity enqueues onto a 64-buffered debouncedEvents
+	// channel, so this can safely fire before Run()'s event loop starts
+	// without dropping the event — no need to wait for the loop first.
 	det.HandlePermissionHook(sessID, transcript, claudecode.HookPreToolUse)
 
-	time.Sleep(50 * time.Millisecond)
+	// Poll instead of a fixed sleep: under scheduler contention the event
+	// loop can take longer than any fixed window to process the
+	// hook-triggered activity event (issue #965).
+	waitForSessionState(repo, sessID, session.StateWaiting, 2*time.Second)
+
 	cancel()
 	<-done
 

--- a/core/cmd/irrlichd/daemon_smoke_test.go
+++ b/core/cmd/irrlichd/daemon_smoke_test.go
@@ -128,9 +128,13 @@ func bootSmokeDaemon(t *testing.T, bin string, extraEnv ...string) *smokeDaemon 
 	})
 	dumpLogsOnFail(t, d.homeDir)
 
-	// The daemon writes its resolved address here once listening.
+	// The daemon writes its resolved address here once listening. 15s (not
+	// 5s) gives waitForAddr's poll enough headroom on a heavily loaded
+	// machine — this is already poll-based (20ms interval), so widening the
+	// ceiling doesn't slow down the common case, only how long a genuinely
+	// contended run gets before failing (issue #967).
 	d.addrPath = filepath.Join(d.stateDir, "irrlichd.addr")
-	d.addr = waitForAddr(t, d.addrPath, 5*time.Second)
+	d.addr = waitForAddr(t, d.addrPath, 15*time.Second)
 	return d
 }
 

--- a/core/e2e/e2e_helpers_test.go
+++ b/core/e2e/e2e_helpers_test.go
@@ -132,6 +132,16 @@ func newMemRepo() *memRepo {
 	return &memRepo{states: make(map[string]*session.SessionState)}
 }
 
+// Load returns an independent deep copy of the stored state, matching the
+// real filesystem.SessionRepository (a fresh disk read every call). Before
+// this fix, Load handed back the same pointer stored in r.states, so a
+// concurrent, unlocked read (e.g. a background PID-discovery goroutine, or
+// this package's own assertions) raced the real SessionDetector/PIDManager
+// mutating that struct in place under PIDManager.WithSessionStateLock — a
+// lock this map's r.mu knows nothing about. Same bug as
+// core/application/services' mockRepo (issue #942/#956/#973); #975 tracks
+// this instance specifically because concurrent_test.go and crash_test.go
+// run the real detector in a goroutine against this repo.
 func (r *memRepo) Load(id string) (*session.SessionState, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -139,13 +149,16 @@ func (r *memRepo) Load(id string) (*session.SessionState, error) {
 	if !ok {
 		return nil, errors.New("not found")
 	}
-	return s, nil
+	return deepCopySessionState(s), nil
 }
 
+// Save stores an independent copy of s, not the caller's pointer — see
+// Load's doc comment.
 func (r *memRepo) Save(s *session.SessionState) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.states[s.SessionID] = s
+	cp := deepCopySessionState(s)
+	r.states[cp.SessionID] = cp
 	return nil
 }
 
@@ -156,14 +169,50 @@ func (r *memRepo) Delete(id string) error {
 	return nil
 }
 
+// ListAll returns independent deep copies for the same reason Load does.
 func (r *memRepo) ListAll() ([]*session.SessionState, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	out := make([]*session.SessionState, 0, len(r.states))
 	for _, s := range r.states {
-		out = append(out, s)
+		out = append(out, deepCopySessionState(s))
 	}
 	return out, nil
+}
+
+// deepCopySessionState returns an independent copy of s, one level deep: the
+// top-level struct plus a fresh copy of every pointer-typed field (Metrics,
+// Launcher, Background, Subagents, WaitingStartTime) so none of them is still
+// reachable from two goroutines at once. Deliberately not a JSON round-trip
+// (unlike cached_repository.go's deepCopySessions): several SessionMetrics
+// fields are json:"-" by design (NoSubstantiveActivity, PermissionPending,
+// ...) — per-pass, in-memory-only signals a live tailer/hook-receiver
+// computes and the same processActivityLocked call reads back moments
+// later — and a JSON copy would silently drop them. Mirrors
+// core/application/services/testhelpers_test.go's identically-named helper.
+func deepCopySessionState(s *session.SessionState) *session.SessionState {
+	cp := *s
+	if s.Launcher != nil {
+		l := *s.Launcher
+		cp.Launcher = &l
+	}
+	if s.Background != nil {
+		b := *s.Background
+		cp.Background = &b
+	}
+	if s.Subagents != nil {
+		sub := *s.Subagents
+		cp.Subagents = &sub
+	}
+	if s.WaitingStartTime != nil {
+		w := *s.WaitingStartTime
+		cp.WaitingStartTime = &w
+	}
+	if s.Metrics != nil {
+		m := *s.Metrics
+		cp.Metrics = &m
+	}
+	return &cp
 }
 
 type nopLogger struct{}

--- a/core/e2e/memrepo_fidelity_test.go
+++ b/core/e2e/memrepo_fidelity_test.go
@@ -1,0 +1,94 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestMemRepo_LoadReturnsIndependentCopy guards the #975 fix: Load must
+// never hand back the same pointer (or the same nested Metrics pointer)
+// twice. concurrent_test.go and crash_test.go run the real
+// SessionDetector.Run() in a goroutine against this repo, so an aliased
+// Load() result would race the detector's own in-place mutations under
+// PIDManager.WithSessionStateLock — the same bug core/application/services'
+// mockRepo had before #973. A future edit that "simplifies" memRepo back to
+// returning the stored pointer would silently reintroduce it.
+func TestMemRepo_LoadReturnsIndependentCopy(t *testing.T) {
+	repo := newMemRepo()
+	repo.states["x"] = &session.SessionState{
+		SessionID: "x",
+		State:     session.StateWorking,
+		Metrics:   &session.SessionMetrics{TotalTokens: 10},
+	}
+
+	a, err := repo.Load("x")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	b, err := repo.Load("x")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if a == b {
+		t.Fatal("Load returned the same *SessionState pointer twice — memRepo is aliasing again")
+	}
+	if a.Metrics == b.Metrics {
+		t.Fatal("Load returned the same *SessionMetrics pointer twice — nested field aliasing")
+	}
+
+	a.State = session.StateReady
+	a.Metrics.TotalTokens = 999
+
+	if b.State != session.StateWorking {
+		t.Errorf("mutating one Load() result changed another's State: got %q, want %q", b.State, session.StateWorking)
+	}
+	if b.Metrics.TotalTokens != 10 {
+		t.Errorf("mutating one Load() result's Metrics changed another's: got %d, want 10", b.Metrics.TotalTokens)
+	}
+}
+
+// TestMemRepo_SaveStoresIndependentCopy guards the other half of #975: Save
+// must copy the caller's struct in, so a caller that keeps mutating its own
+// pointer after Save() can't reach back into what's stored.
+func TestMemRepo_SaveStoresIndependentCopy(t *testing.T) {
+	repo := newMemRepo()
+	s := &session.SessionState{SessionID: "y", State: session.StateWorking}
+
+	if err := repo.Save(s); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	s.State = session.StateReady // mutate the caller's copy after Save
+
+	got, err := repo.Load("y")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.State != session.StateWorking {
+		t.Errorf("Save aliased the caller's pointer: stored state changed to %q after the caller mutated its own copy", got.State)
+	}
+}
+
+// TestMemRepo_ListAllReturnsIndependentCopies guards ListAll the same way.
+func TestMemRepo_ListAllReturnsIndependentCopies(t *testing.T) {
+	repo := newMemRepo()
+	repo.states["z"] = &session.SessionState{SessionID: "z", State: session.StateWorking}
+
+	all, err := repo.ListAll()
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(all))
+	}
+	all[0].State = session.StateReady
+
+	got, err := repo.Load("z")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.State != session.StateWorking {
+		t.Errorf("ListAll aliased stored state: mutating the returned slice's element changed Load's result to %q", got.State)
+	}
+}


### PR DESCRIPTION
## Summary
- **#975** — `core/e2e`'s `memRepo` had the identical `Load()`-aliasing bug #973 fixed in `core/application/services`' `mockRepo`: `Load`/`ListAll` returned the live stored pointer, and `Save` stored the caller's pointer directly. `concurrent_test.go` and `crash_test.go` run the real `SessionDetector.Run()` in a goroutine against it, so this was a live, exploitable risk — not dormant. Fixed with the same `deepCopySessionState`-style one-level-deep copy. Also adds regression-guard tests (`TestMockRepo_*` / `TestMemRepo_*`) that assert `Load`/`Save`/`ListAll` never alias, for both repos — nothing previously protected that invariant, so a future "simplification" could have silently reintroduced either bug.
- **#965** — `TestSessionDetector_HandlePermissionHook_PreToolUseTransitionsToWaiting` used two fixed sleeps (20ms to let `Run()` start, 50ms for the hook's effect to land) before reading state directly. The first sleep was unnecessary (`dispatchHookActivity` enqueues onto a 64-buffered channel, so it can't drop the event regardless of whether `Run()`'s loop has started); the second is replaced with `waitForSessionState`, matching the established pattern elsewhere in this file family.
- **#967** — `TestDebounce_FirstEvent*` was already fixed by #964 (poll-based, merged before #967 was filed) — verified still poll-based, no change needed. `TestDaemonStartupSmoke`'s addr-file wait was already poll-based every 20ms, just with too tight a 5s ceiling for a heavily loaded machine — widened to 15s.

## Test plan
- [x] `go test ./core/application/services/... -race -count=3 -p 1` — clean
- [x] `go test ./core/e2e/... -race -count=3` — clean
- [x] `go test ./core/cmd/irrlichd/... -race -count=1` — clean
- [x] `go test ./core/... -race -count=1` — full suite clean
- [x] `tools/preflight.sh` (via pre-push hook) — all gates passed
- [x] New regression-guard tests (`TestMockRepo_LoadReturnsIndependentCopy` etc.) pass and correctly fail if the copy is removed (verified locally before adding the fix)

Closes #965, closes #967, closes #975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)