### PR TITLE
feat(history): add Activity Matrix chart (chart=state)

### DIFF
--- a/core/adapters/outbound/filesystem/concurrency_tracker.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker.go
@@ -160,6 +160,124 @@ func collectScopedIntervals(timelines map[string]*sessionTimeline, q outbound.Se
 	return byProject, all, current
 }
 
+// StateSeries is AgentsSeries' per-state counterpart (issue #981): it keeps
+// working/waiting separate instead of merging them into one "active" count,
+// and adds ready as a per-bucket transition histogram. Same coarsening-by-span
+// and empty-result conventions as AgentsSeries; one additional pass over the
+// already-loaded timelines, no extra file I/O.
+func (t *ConcurrencyTracker) StateSeries(q outbound.SeriesQuery) (*outbound.StateSeriesResult, error) {
+	start, end, bucketSeconds := q.Start, q.End, q.BucketSeconds
+	if bucketSeconds <= 0 || end <= start {
+		return emptyStateSeriesResult(start, end, bucketSeconds), nil
+	}
+	if span := end - start; span/bucketSeconds+1 > maxSeriesBuckets {
+		bucketSeconds = (span + maxSeriesBuckets - 1) / maxSeriesBuckets
+	}
+	n := int((end - start + bucketSeconds - 1) / bucketSeconds)
+	out := &outbound.StateSeriesResult{
+		Start:         start,
+		End:           end,
+		BucketSeconds: bucketSeconds,
+		BucketStarts:  make([]int64, n),
+		ByState: map[string]map[string][]float64{
+			session.StateWorking: {},
+			session.StateWaiting: {},
+			session.StateReady:   {},
+		},
+	}
+	for i := range out.BucketStarts {
+		out.BucketStarts[i] = start + int64(i)*bucketSeconds
+	}
+
+	timelines, err := t.loadTimelines()
+	if err != nil {
+		return nil, err
+	}
+
+	byState, readyByProject, current := collectScopedStateIntervals(timelines, q, start, end)
+	out.Current = current
+
+	var allActive []interval
+	for state, byProject := range byState {
+		for project, ivs := range byProject {
+			dst, _ := bucketPeakSeries(ivs, start, bucketSeconds, n)
+			out.ByState[state][project] = dst
+			allActive = append(allActive, ivs...)
+		}
+	}
+	out.Peak, out.Average = totalPeakAndAverage(allActive, start, end)
+
+	for project, events := range readyByProject {
+		dst := make([]float64, n)
+		for _, ts := range events {
+			idx := int((ts - start) / bucketSeconds)
+			if idx >= 0 && idx < n {
+				dst[idx]++
+			}
+		}
+		out.ByState[session.StateReady][project] = dst
+	}
+
+	return out, nil
+}
+
+// collectScopedStateIntervals is collectScopedIntervals' per-state
+// counterpart: it gathers each in-scope session's working/waiting intervals,
+// clamped to [start, end) and grouped by state then project, plus every ready
+// transition timestamp landing in [start, end), grouped by project. current
+// counts sessions active (in either state) strictly across end, matching
+// collectScopedIntervals' "still active now" semantics exactly.
+func collectScopedStateIntervals(timelines map[string]*sessionTimeline, q outbound.SeriesQuery, start, end int64) (byState map[string]map[string][]interval, readyByProject map[string][]int64, current float64) {
+	byState = map[string]map[string][]interval{
+		session.StateWorking: {},
+		session.StateWaiting: {},
+	}
+	readyByProject = map[string][]int64{}
+	for sid, tl := range timelines {
+		if !concurrencyScopeMatches(q, sid, tl.project) {
+			continue
+		}
+		project := tl.project
+		if project == "" {
+			project = concurrencyUnknownProject
+		}
+		ivs, readyAt := tl.stateReconstruction()
+		for _, iv := range ivs {
+			if iv.enter < end && iv.exit > end {
+				current++ // spans the window end → still active "now"
+			}
+			cl, ok := clampInterval(interval{iv.enter, iv.exit}, start, end)
+			if !ok {
+				continue
+			}
+			byState[iv.state][project] = append(byState[iv.state][project], cl)
+		}
+		for _, ts := range readyAt {
+			if ts < start || ts >= end {
+				continue
+			}
+			readyByProject[project] = append(readyByProject[project], ts)
+		}
+	}
+	return byState, readyByProject, current
+}
+
+// emptyStateSeriesResult returns a valid zero-data result so the dashboard
+// renders a clean empty state instead of erroring.
+func emptyStateSeriesResult(start, end, bucketSeconds int64) *outbound.StateSeriesResult {
+	return &outbound.StateSeriesResult{
+		Start:         start,
+		End:           end,
+		BucketSeconds: bucketSeconds,
+		BucketStarts:  []int64{},
+		ByState: map[string]map[string][]float64{
+			session.StateWorking: {},
+			session.StateWaiting: {},
+			session.StateReady:   {},
+		},
+	}
+}
+
 // clampInterval clips iv to [start, end), reporting ok=false when the
 // clamped span is empty.
 func clampInterval(iv interval, start, end int64) (interval, bool) {
@@ -249,41 +367,70 @@ func concurrencyScopeMatches(q outbound.SeriesQuery, sessionID, project string) 
 	}
 }
 
-// activeIntervals reconstructs a session's [enter, exit) active spans from its
-// state timeline. A session is active while working or waiting and inactive
-// while ready. A session still active at its last recorded event (no terminator)
-// is bounded at that last event — "last known alive" — so a daemon that died
-// mid-session doesn't leave a session counted as alive forever. The bound is
-// needed for the common idle case too: a session waiting for input emits no
-// further events, so without it that session's whole bounded span would drop.
-// (lastEventTS >= last.ts always, since every transition is itself an event.)
-func (tl *sessionTimeline) activeIntervals() []interval {
+// stateInterval is a half-open [enter, exit) span together with the specific
+// working/waiting state active during it — the per-state generalization of
+// interval, which only tracks "active" (working or waiting, merged).
+type stateInterval struct {
+	enter, exit int64
+	state       string // session.StateWorking | session.StateWaiting
+}
+
+// stateReconstruction rebuilds a session's full timeline: working/waiting
+// spans as durations (stateInterval, tagged by which of the two states was
+// active) and every transition into ready as an instantaneous timestamp —
+// ready is session.go's terminal state, with no duration to be concurrent in,
+// so "how many agents went ready in bucket X" (issue #981) is a transition
+// count, not a concurrency count. A session still working/waiting at its last
+// recorded event (no terminator) is bounded at that last event — "last known
+// alive" — so a daemon that died mid-session doesn't leave it counted as alive
+// forever; same rule the merged reconstruction below always used. (lastEventTS
+// >= last.ts always, since every transition is itself an event.) That bound is
+// a synthetic sentinel, not a real transition — it must be read for
+// interval-closing but excluded from readyAt, or every session still active
+// "now" would spuriously count as having gone ready this instant.
+func (tl *sessionTimeline) stateReconstruction() (ivs []stateInterval, readyAt []int64) {
 	if len(tl.transitions) == 0 {
-		return nil
+		return nil, nil
 	}
 	tr := append([]stateChange(nil), tl.transitions...)
 	sort.SliceStable(tr, func(i, j int) bool { return tr[i].ts < tr[j].ts })
+
+	for _, c := range tr {
+		if c.state == session.StateReady {
+			readyAt = append(readyAt, c.ts)
+		}
+	}
+
 	if last := tr[len(tr)-1]; concurrencyActive(last.state) {
 		tr = append(tr, stateChange{tl.lastEventTS, session.StateReady})
 	}
-
-	var ivs []interval
-	activeStart := int64(-1)
-	for _, c := range tr {
-		if concurrencyActive(c.state) {
-			if activeStart < 0 {
-				activeStart = c.ts
-			}
+	for i := 0; i < len(tr)-1; i++ {
+		cur, next := tr[i], tr[i+1]
+		if !concurrencyActive(cur.state) {
 			continue
 		}
-		if activeStart >= 0 {
-			if c.ts > activeStart {
-				ivs = append(ivs, interval{activeStart, c.ts})
-			}
-			activeStart = -1
+		if next.ts > cur.ts {
+			ivs = append(ivs, stateInterval{cur.ts, next.ts, cur.state})
 		}
 	}
-	return ivs
+	return ivs, readyAt
+}
+
+// activeIntervals reports the merged working-or-waiting spans a session was
+// concurrently "active" for — the view AgentsSeries needs, which doesn't
+// distinguish which of the two states was active. Built on
+// stateReconstruction so the merged and per-state views can never drift
+// apart: sweepIntervals already treats abutting intervals (one state's exit
+// landing exactly on the next state's enter) as continuous rather than a gap
+// (see its doc comment), so splitting the merged span into per-state
+// sub-intervals here doesn't change AgentsSeries' peak/average/bucket output.
+func (tl *sessionTimeline) activeIntervals() []interval {
+	ivs, _ := tl.stateReconstruction()
+	out := make([]interval, 0, len(ivs))
+	for _, iv := range ivs {
+		out = append(out, interval{iv.enter, iv.exit})
+	}
+	return out
 }
 
 // sweepIntervals walks a set of half-open intervals in time order and calls fn

--- a/core/adapters/outbound/filesystem/concurrency_tracker_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_test.go
@@ -301,3 +301,236 @@ func TestAgentsSeries_ScopeProject(t *testing.T) {
 		t.Errorf("peakByKey[projA]: want 1, got %v", res.PeakByKey["projA"])
 	}
 }
+
+// TestStateSeries_ActiveAtEndIsNotReady: a session still working at the
+// window end (no ready transition recorded) must not count toward the ready
+// histogram — the "last known alive" bound that closes its working interval
+// is a synthetic sentinel, not a real transition. Regression: an earlier
+// version leaked that sentinel into readyAt, so every still-active session
+// spuriously showed a ready count in whatever bucket contained "now".
+func TestStateSeries_ActiveAtEndIsNotReady(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projX"),
+		transition(2, 100, "s1", session.StateWorking),
+		activity(3, 280, "s1", "/home/me/projX"), // last event; still working, no exit
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.StateSeries(outbound.SeriesQuery{Start: 0, End: 300, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("StateSeries: %v", err)
+	}
+	if got := res.ByState[session.StateReady]["projX"]; got != nil {
+		t.Errorf("ready[projX]: want no ready series (session never went ready), got %v", got)
+	}
+	if peak := maxOf(res.ByState[session.StateWorking]["projX"]); peak != 1 {
+		t.Errorf("working[projX] peak: want 1, got %v", peak)
+	}
+}
+
+// TestStateSeries_WorkingThenWaiting: a session works [100,150) then idles
+// waiting [150,220) before going ready — the per-state split AgentsSeries
+// can't make. Working and waiting must land in their own buckets, and ready
+// must count once in the bucket containing the ready transition (220).
+func TestStateSeries_WorkingThenWaiting(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projX"),
+		transition(2, 100, "s1", session.StateWorking),
+		transition(3, 150, "s1", session.StateWaiting),
+		transition(4, 220, "s1", session.StateReady),
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.StateSeries(outbound.SeriesQuery{Start: 0, End: 300, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("StateSeries: %v", err)
+	}
+	// Buckets: 0=[0,60) 1=[60,120) 2=[120,180) 3=[180,240) 4=[240,300).
+	// Working [100,150) covers buckets 1,2. Waiting [150,220) covers buckets 2,3.
+	wantWorking := []float64{0, 1, 1, 0, 0}
+	wantWaiting := []float64{0, 0, 1, 1, 0}
+	if got := res.ByState[session.StateWorking]["projX"]; !floatsEq(got, wantWorking) {
+		t.Errorf("working[projX]: want %v, got %v", wantWorking, got)
+	}
+	if got := res.ByState[session.StateWaiting]["projX"]; !floatsEq(got, wantWaiting) {
+		t.Errorf("waiting[projX]: want %v, got %v", wantWaiting, got)
+	}
+	// Ready transition at ts=220 falls in bucket 3 ([180,240)).
+	wantReady := []float64{0, 0, 0, 1, 0}
+	if got := res.ByState[session.StateReady]["projX"]; !floatsEq(got, wantReady) {
+		t.Errorf("ready[projX]: want %v, got %v", wantReady, got)
+	}
+}
+
+// TestStateSeries_ReadyIsTransitionCount: two sessions going ready in the same
+// bucket both count, distinguishing the ready histogram from a concurrency
+// count (which would never exceed however many sessions exist at once, but
+// specifically confirms multiple transitions accumulate rather than the last
+// one winning).
+func TestStateSeries_ReadyIsTransitionCount(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projX"),
+		transition(2, 100, "s1", session.StateWorking),
+		transition(3, 130, "s1", session.StateReady),
+		transcriptNew(4, 90, "s2", "/home/me/projX"),
+		transition(5, 95, "s2", session.StateWorking),
+		transition(6, 140, "s2", session.StateReady),
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.StateSeries(outbound.SeriesQuery{Start: 0, End: 180, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("StateSeries: %v", err)
+	}
+	// Both ready transitions (130, 140) land in bucket 2 ([120,180)).
+	want := []float64{0, 0, 2}
+	if got := res.ByState[session.StateReady]["projX"]; !floatsEq(got, want) {
+		t.Errorf("ready[projX]: want %v, got %v", want, got)
+	}
+}
+
+// TestStateSeries_TwoProjectsIsolated: each project's per-state series stays
+// keyed to its own project — no cross-contamination.
+func TestStateSeries_TwoProjectsIsolated(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projA"),
+		transition(2, 100, "s1", session.StateWorking),
+		transition(3, 250, "s1", session.StateReady),
+		transcriptNew(4, 90, "s2", "/home/me/projB"),
+		transition(5, 100, "s2", session.StateWaiting),
+		transition(6, 250, "s2", session.StateReady),
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.StateSeries(outbound.SeriesQuery{Start: 0, End: 360, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("StateSeries: %v", err)
+	}
+	if v := res.ByState[session.StateWorking]["projB"]; v != nil {
+		t.Errorf("projB should have no working series, got %v", v)
+	}
+	if v := res.ByState[session.StateWaiting]["projA"]; v != nil {
+		t.Errorf("projA should have no waiting series, got %v", v)
+	}
+	if peak := maxOf(res.ByState[session.StateWorking]["projA"]); peak != 1 {
+		t.Errorf("projA working peak: want 1, got %v", peak)
+	}
+	if peak := maxOf(res.ByState[session.StateWaiting]["projB"]); peak != 1 {
+		t.Errorf("projB waiting peak: want 1, got %v", peak)
+	}
+}
+
+// TestStateSeries_ScopeProject: a project scope filters to that project's
+// sessions only, matching AgentsSeries' scoping convention.
+func TestStateSeries_ScopeProject(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projA"),
+		transition(2, 100, "s1", session.StateWorking),
+		transition(3, 250, "s1", session.StateReady),
+		transcriptNew(4, 90, "s2", "/home/me/projB"),
+		transition(5, 100, "s2", session.StateWorking),
+		transition(6, 250, "s2", session.StateReady),
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.StateSeries(outbound.SeriesQuery{Start: 0, End: 360, BucketSeconds: 60, ScopeField: "project", ScopeValue: "projA"})
+	if err != nil {
+		t.Fatalf("StateSeries: %v", err)
+	}
+	if _, ok := res.ByState[session.StateWorking]["projB"]; ok {
+		t.Errorf("projB should be filtered out, got %v", res.ByState[session.StateWorking])
+	}
+	if peak := maxOf(res.ByState[session.StateWorking]["projA"]); peak != 1 {
+		t.Errorf("projA working peak: want 1, got %v", peak)
+	}
+}
+
+// TestStateSeries_Empty: a missing recordings dir yields a valid empty
+// result, not an error — same convention as AgentsSeries.
+func TestStateSeries_Empty(t *testing.T) {
+	tr := NewConcurrencyTrackerWithDir(filepath.Join(t.TempDir(), "recordings"))
+	res, err := tr.StateSeries(outbound.SeriesQuery{Start: 0, End: 300, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("StateSeries: %v", err)
+	}
+	if res.Peak != 0 || res.Average != 0 || res.Current != 0 {
+		t.Errorf("want zero summary, got peak=%v avg=%v current=%v", res.Peak, res.Average, res.Current)
+	}
+	for _, state := range []string{session.StateWorking, session.StateWaiting, session.StateReady} {
+		if len(res.ByState[state]) != 0 {
+			t.Errorf("by_state[%s] should be empty, got %v", state, res.ByState[state])
+		}
+	}
+	if res.BucketStarts == nil {
+		t.Error("bucket_starts should be a non-nil slice")
+	}
+}
+
+// TestStateSeries_SummaryMatchesAgentsSeries: StateSeries' Peak/Average/Current
+// summary (computed over its own per-state interval reconstruction) must
+// agree exactly with AgentsSeries' merged-state summary for the same query —
+// both are built from the same underlying transitions, just split
+// differently, and sweepIntervals treats abutting per-state sub-intervals as
+// continuous (see stateReconstruction / activeIntervals), so they must not
+// diverge.
+func TestStateSeries_SummaryMatchesAgentsSeries(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projA"),
+		transition(2, 100, "s1", session.StateWorking),
+		transition(3, 150, "s1", session.StateWaiting), // mid-session state flip
+		transition(4, 250, "s1", session.StateReady),
+		transcriptNew(5, 140, "s2", "/home/me/projA"),
+		transition(6, 145, "s2", session.StateWorking),
+		activity(7, 280, "s2", "/home/me/projA"), // still active at window end
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+	q := outbound.SeriesQuery{Start: 0, End: 300, BucketSeconds: 60}
+
+	agents, err := tr.AgentsSeries(q)
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	states, err := tr.StateSeries(q)
+	if err != nil {
+		t.Fatalf("StateSeries: %v", err)
+	}
+	if !approxEq(agents.Peak, states.Peak) {
+		t.Errorf("peak mismatch: agents=%v states=%v", agents.Peak, states.Peak)
+	}
+	if !approxEq(agents.Average, states.Average) {
+		t.Errorf("average mismatch: agents=%v states=%v", agents.Average, states.Average)
+	}
+	if agents.Current != states.Current {
+		t.Errorf("current mismatch: agents=%v states=%v", agents.Current, states.Current)
+	}
+}
+
+// floatsEq compares two float64 slices for exact equality (the values under
+// test here are all small integer counts, so no tolerance is needed).
+func floatsEq(got, want []float64) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func maxOf(vs []float64) float64 {
+	m := 0.0
+	for _, v := range vs {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -319,6 +319,29 @@ type historyConcurrency struct {
 	Current float64 `json:"current"`
 }
 
+// historyStateResponse is the chart=state payload (#981, the Activity
+// Matrix): a per-project, per-state agent-count grid, unlike every other
+// chart's single-value-per-point series. Projects is row order (busiest
+// first, by total activity across every state and bucket); ByState mirrors
+// outbound.StateSeriesResult.ByState directly (state -> project -> per-bucket
+// counts, each slice aligned to BucketStarts) — the matrix is dense, not the
+// sparse [{ts,project,value}] shape the canvas time-series charts use, since
+// every cell needs a value to render a grid. Concurrency reuses the agents
+// side panel's peak/average/current shape (working+waiting combined).
+type historyStateResponse struct {
+	Range         string                          `json:"range"`
+	Chart         string                          `json:"chart"`
+	Group         string                          `json:"group"`
+	Start         int64                           `json:"start"`
+	End           int64                           `json:"end"`
+	BucketSeconds int64                           `json:"bucket_seconds"`
+	BucketStarts  []int64                         `json:"bucket_starts"`
+	Projects      []string                        `json:"projects"`
+	ByState       map[string]map[string][]float64 `json:"by_state"`
+	Concurrency   *historyConcurrency             `json:"concurrency,omitempty"`
+	Scope         string                          `json:"scope,omitempty"`
+}
+
 type historyForecastPoint struct {
 	TS    int64   `json:"ts"`
 	Value float64 `json:"value"`
@@ -464,10 +487,9 @@ func serveHistoryDoraChart(w http.ResponseWriter, git historyGitReader, sessions
 }
 
 // historyChartKnown validates the requested ?chart= value. Charts implemented
-// in Phase 1-3 pass through; chart=state is scaffolded in the UI but not wired
-// yet (writes a 501); anything else is a client error (writes a 400). Returns
-// false once it has already written the response, in which case the caller
-// must return immediately.
+// in Phase 1-3 pass through; anything else is a client error (writes a 400).
+// Returns false once it has already written the response, in which case the
+// caller must return immediately.
 func historyChartKnown(w http.ResponseWriter, chart string) bool {
 	switch chart {
 	case "cost", "tokens", "co2", "models", "providers":
@@ -479,10 +501,8 @@ func historyChartKnown(w http.ResponseWriter, chart string) bool {
 	case "agents":
 		// implemented (Phase 3) — handled after range resolution below
 	case "state":
-		// time-in-state is the issue's optional second half (#751); the
-		// reconstruction exists but no chart is wired yet.
-		writeHistoryNotImplemented(w, "chart="+chart, 3)
-		return false
+		// implemented (#981, the "Activity Matrix" — time-in-state, the
+		// optional second half of #751) — handled after range resolution below
 	default:
 		http.Error(w, "unknown chart: "+chart, http.StatusBadRequest)
 		return false
@@ -521,6 +541,11 @@ func historyMetricAndGroup(chart, group string) (metric, effectiveGroup string) 
 	case "providers":
 		return "cost", "provider"
 	case "agents":
+		return "cost", "project"
+	case "state":
+		// Same project-only limitation as agents: recordings carry no
+		// branch/provider/model axis. Metric is unused for chart=state (it
+		// never touches CostTracker), "cost" is just a harmless placeholder.
 		return "cost", "project"
 	default:
 		return "cost", group
@@ -568,6 +593,34 @@ func serveHistoryAgentsChart(w http.ResponseWriter, concurrency outbound.Concurr
 		cr = &outbound.ConcurrencyResult{Start: query.Start, End: query.End, BucketSeconds: query.BucketSeconds, BucketStarts: []int64{}, ByKey: map[string][]float64{}, PeakByKey: map[string]float64{}}
 	}
 	writeHistoryJSON(w, buildAgentsResponse(rangeKey, scopeEcho, cr))
+}
+
+// serveHistoryStateChart serves chart=state (#981): a per-project,
+// per-state (working/waiting/ready) series reconstructed from lifecycle
+// recordings via ConcurrencyReader.StateSeries — AgentsSeries' per-state
+// counterpart. A nil reader or an unresolved recordings dir yields an
+// empty-but-valid payload rather than an error, mirroring
+// serveHistoryAgentsChart.
+func serveHistoryStateChart(w http.ResponseWriter, concurrency outbound.ConcurrencyReader, rangeKey, scopeEcho string, query outbound.SeriesQuery) {
+	var sr *outbound.StateSeriesResult
+	if concurrency != nil {
+		s, err := concurrency.StateSeries(query)
+		if err != nil {
+			http.Error(w, errInternalErrorMsg, http.StatusInternalServerError)
+			return
+		}
+		sr = s
+	}
+	if sr == nil {
+		sr = &outbound.StateSeriesResult{
+			Start: query.Start, End: query.End, BucketSeconds: query.BucketSeconds,
+			BucketStarts: []int64{},
+			ByState: map[string]map[string][]float64{
+				session.StateWorking: {}, session.StateWaiting: {}, session.StateReady: {},
+			},
+		}
+	}
+	writeHistoryJSON(w, buildStateResponse(rangeKey, scopeEcho, sr))
 }
 
 // historyCrossFilters resolves the orthogonal ?project=/?provider=/?token_type=
@@ -655,16 +708,36 @@ func resolveHistoryQuery(w http.ResponseWriter, q url.Values) (historyQuery, boo
 	scopeField, scopeValue := parseHistoryScope(q.Get("scope"))
 	scopeEcho := historyScopeEcho(scopeField, scopeValue)
 
-	rangeKey, start, end, ok := resolveHistoryRange(q)
-	if !ok {
-		http.Error(w, "invalid range: use range=day|week|month|year|this-month or start&end (unix seconds)", http.StatusBadRequest)
-		return historyQuery{}, false
+	// chart=state (#981) resolves its window from a named ?granularity=
+	// zoom-level instead of the usual ?range=/?bucket= pair — the granularity
+	// picks both the bucket width and the trailing window at once.
+	var rangeKey string
+	var start, end, bucketSeconds int64
+	if chart == "state" {
+		granularity := q.Get("granularity")
+		if granularity == "" {
+			granularity = "24h"
+		}
+		bs, s, e, gok := resolveHistoryGranularity(granularity)
+		if !gok {
+			http.Error(w, "invalid granularity: use 1m|10m|60m|8h|24h|7d|1mo|6mo|1y", http.StatusBadRequest)
+			return historyQuery{}, false
+		}
+		rangeKey, start, end, bucketSeconds = granularity, s, e, bs
+	} else {
+		rk, s, e, ok := resolveHistoryRange(q)
+		if !ok {
+			http.Error(w, "invalid range: use range=day|week|month|year|this-month or start&end (unix seconds)", http.StatusBadRequest)
+			return historyQuery{}, false
+		}
+		rangeKey, start, end = rk, s, e
+		bucketSeconds = historyBucketSeconds(q, end-start)
 	}
 
 	seriesQuery := outbound.SeriesQuery{
 		Start:         start,
 		End:           end,
-		BucketSeconds: historyBucketSeconds(q, end-start),
+		BucketSeconds: bucketSeconds,
 		Group:         group,
 		ScopeField:    scopeField,
 		ScopeValue:    scopeValue,
@@ -707,6 +780,11 @@ func handleGetHistory(tracker outbound.CostTracker, sessions historySessionListe
 
 		if hq.chart == "agents" {
 			serveHistoryAgentsChart(w, concurrency, hq.rangeKey, hq.scopeEcho, hq.seriesQuery)
+			return
+		}
+
+		if hq.chart == "state" {
+			serveHistoryStateChart(w, concurrency, hq.rangeKey, hq.scopeEcho, hq.seriesQuery)
 			return
 		}
 
@@ -785,17 +863,6 @@ func parseTokenTypeFilter(s string) ([]string, bool) {
 	return raw, true
 }
 
-// writeHistoryNotImplemented emits a 501 with a phase hint for chart types and
-// groups scaffolded in the UI but not yet wired (Phase 2/3).
-func writeHistoryNotImplemented(w http.ResponseWriter, what string, phase int) {
-	w.Header().Set(headerContentType, contentTypeJSON)
-	w.WriteHeader(http.StatusNotImplemented)
-	json.NewEncoder(w).Encode(map[string]any{
-		"error": what + " is not implemented in Phase 1",
-		"phase": phase,
-	})
-}
-
 // resolveHistoryRange resolves the requested window to [start, end) unix
 // seconds. Precedence: explicit start&end → calendar shorthand / trailing
 // window via range. Missing range defaults to "day". Returns ok=false on a
@@ -842,6 +909,51 @@ func historyBucketSeconds(q url.Values, span int64) int64 {
 	default:
 		return 86400
 	}
+}
+
+// historyGranularitySpec pairs a named granularity's bucket width with the
+// number of buckets its default window shows — the "zoom level" for
+// chart=state's activity matrix (#981): picking a granularity changes both
+// the bucket width and the visible span at once (e.g. "1 min" buckets show
+// the last 45 minutes, "1 year" buckets show the last 8 years).
+type historyGranularitySpec struct {
+	bucketSeconds int64
+	buckets       int64
+}
+
+// historyGranularitySpecs is chart=state's only bucket-width source — unlike
+// every other chart (downsampled by span via historyBucketSeconds), the
+// activity matrix always resolves both bucket width and window from a single
+// named step. The month/6-month/year entries use an averaged bucket width
+// (30/182/365 days) rather than true calendar boundaries: the shared series
+// pipeline assumes a uniform bucket stride (BucketStarts is a fixed-step
+// loop — see StateSeries/AgentsSeries/CostSeries), and switching that to
+// variable-width calendar buckets would be a cross-cutting change touching
+// every chart, not just this one. Tracked as a known approximation — see the
+// feature issue's open questions.
+var historyGranularitySpecs = map[string]historyGranularitySpec{
+	"1m":  {60, 45},
+	"10m": {600, 48},
+	"60m": {3600, 24},
+	"8h":  {8 * 3600, 21},
+	"24h": {86400, 30},
+	"7d":  {7 * 86400, 20},
+	"1mo": {30 * 86400, 18},
+	"6mo": {182 * 86400, 10},
+	"1y":  {365 * 86400, 8},
+}
+
+// resolveHistoryGranularity resolves a chart=state ?granularity= value into a
+// bucket width and a trailing [start, now] window — the default window for
+// that granularity's zoom level. ok is false for an unrecognized granularity.
+func resolveHistoryGranularity(granularity string) (bucketSeconds, start, end int64, ok bool) {
+	spec, known := historyGranularitySpecs[granularity]
+	if !known {
+		return 0, 0, 0, false
+	}
+	end = time.Now().Unix()
+	start = end - spec.bucketSeconds*spec.buckets
+	return spec.bucketSeconds, start, end, true
 }
 
 // historyUnknownLabel / historyUnknownMinShare govern the "unknown" group
@@ -974,6 +1086,35 @@ func buildAgentsResponse(rangeKey, scope string, c *outbound.ConcurrencyResult) 
 	resp.Series = appendSparsePoints(resp.Series, keys, c.ByKey, c.BucketStarts)
 	resp.TopContributors = topHistoryContributors(keys, c.PeakByKey, 5)
 	return resp
+}
+
+// buildStateResponse flattens a per-state concurrency reconstruction into the
+// activity-matrix envelope (#981). Project row order is busiest-first, by
+// each project's total count summed across every state and bucket — the same
+// "rank by what the reader cares about" convention sortKeysByValueDesc gives
+// every other chart's top-contributors list.
+func buildStateResponse(rangeKey, scope string, s *outbound.StateSeriesResult) historyStateResponse {
+	totals := map[string]float64{}
+	for _, byProject := range s.ByState {
+		for project, vals := range byProject {
+			for _, v := range vals {
+				totals[project] += v
+			}
+		}
+	}
+	return historyStateResponse{
+		Range:         rangeKey,
+		Chart:         "state",
+		Group:         "project",
+		Start:         s.Start,
+		End:           s.End,
+		BucketSeconds: s.BucketSeconds,
+		BucketStarts:  s.BucketStarts,
+		Projects:      sortKeysByValueDesc(totals),
+		ByState:       s.ByState,
+		Concurrency:   &historyConcurrency{Peak: s.Peak, Average: s.Average, Current: s.Current},
+		Scope:         scope,
+	}
 }
 
 // resolveUnknownBucket relabels or drops the "" key that CostSeries emits for

--- a/core/cmd/irrlichd/history_state_endpoint_test.go
+++ b/core/cmd/irrlichd/history_state_endpoint_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/adapters/outbound/filesystem"
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+)
+
+// TestHandleGetHistory_StateChart: chart=state (#981) returns a per-project,
+// per-state grid reconstructed from recordings — working/waiting/ready kept
+// separate, unlike chart=agents' merged "active" count.
+func TestHandleGetHistory_StateChart(t *testing.T) {
+	recDir := filepath.Join(t.TempDir(), "recordings")
+	now := time.Now().Unix()
+	at := func(sec int64) time.Time { return time.Unix(now-sec, 0) }
+	seedRecording(t, recDir, "run.jsonl", []lifecycle.Event{
+		{Seq: 1, Timestamp: at(3600), Kind: lifecycle.KindTranscriptNew, SessionID: "s1", CWD: "/home/me/projX"},
+		{Seq: 2, Timestamp: at(3500), Kind: lifecycle.KindStateTransition, SessionID: "s1", NewState: session.StateWorking},
+		{Seq: 3, Timestamp: at(3400), Kind: lifecycle.KindStateTransition, SessionID: "s1", NewState: session.StateWaiting},
+		{Seq: 4, Timestamp: at(1800), Kind: lifecycle.KindStateTransition, SessionID: "s1", NewState: session.StateReady},
+	})
+	conc := filesystem.NewConcurrencyTrackerWithDir(recDir)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=state&granularity=24h", nil)
+	rec := httptest.NewRecorder()
+	handleGetHistory(nil, nil, conc, nil)(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("chart=state: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	var resp historyStateResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Chart != "state" || resp.Group != "project" || resp.Range != "24h" {
+		t.Errorf("envelope: %+v", resp)
+	}
+	if resp.BucketSeconds != 86400 {
+		t.Errorf("24h granularity should bucket at 86400s, got %d", resp.BucketSeconds)
+	}
+	if len(resp.Projects) != 1 || resp.Projects[0] != "projX" {
+		t.Errorf("projects: want [projX], got %+v", resp.Projects)
+	}
+	if resp.ByState == nil || resp.ByState[session.StateWorking] == nil || resp.ByState[session.StateWaiting] == nil || resp.ByState[session.StateReady] == nil {
+		t.Fatalf("by_state must carry all three canonical states, got %+v", resp.ByState)
+	}
+	if v := sum(resp.ByState[session.StateWorking]["projX"]); v <= 0 {
+		t.Errorf("working[projX] should have positive activity, got series %v", resp.ByState[session.StateWorking]["projX"])
+	}
+	if v := sum(resp.ByState[session.StateWaiting]["projX"]); v <= 0 {
+		t.Errorf("waiting[projX] should have positive activity, got series %v", resp.ByState[session.StateWaiting]["projX"])
+	}
+	if v := sum(resp.ByState[session.StateReady]["projX"]); v != 1 {
+		t.Errorf("ready[projX] should count exactly one transition, got %v (series %v)", v, resp.ByState[session.StateReady]["projX"])
+	}
+	if resp.Concurrency == nil || resp.Concurrency.Peak != 1 {
+		t.Errorf("concurrency summary: want peak 1, got %+v", resp.Concurrency)
+	}
+}
+
+// TestHandleGetHistory_StateChartEmpty: no recordings (the common case —
+// --record is opt-in) returns a clean empty payload, not an error.
+func TestHandleGetHistory_StateChartEmpty(t *testing.T) {
+	conc := filesystem.NewConcurrencyTrackerWithDir(filepath.Join(t.TempDir(), "recordings"))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=state", nil)
+	rec := httptest.NewRecorder()
+	handleGetHistory(nil, nil, conc, nil)(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty state chart: want 200, got %d", rec.Code)
+	}
+	var resp historyStateResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Range != "24h" {
+		t.Errorf("default granularity: want 24h, got %q", resp.Range)
+	}
+	if len(resp.Projects) != 0 {
+		t.Errorf("want no projects, got %+v", resp.Projects)
+	}
+	if resp.Concurrency == nil || resp.Concurrency.Peak != 0 {
+		t.Errorf("want zero concurrency summary, got %+v", resp.Concurrency)
+	}
+}
+
+// TestHandleGetHistory_StateChartBadGranularity: an unrecognized ?granularity=
+// is a client error, matching every other malformed history query param.
+func TestHandleGetHistory_StateChartBadGranularity(t *testing.T) {
+	conc := filesystem.NewConcurrencyTrackerWithDir(filepath.Join(t.TempDir(), "recordings"))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=state&granularity=fortnight", nil)
+	rec := httptest.NewRecorder()
+	handleGetHistory(nil, nil, conc, nil)(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("bad granularity: want 400, got %d", rec.Code)
+	}
+}
+
+// TestHandleGetHistory_StateChartGranularitySteps: every one of the nine named
+// granularities resolves to its own fixed bucket width.
+func TestHandleGetHistory_StateChartGranularitySteps(t *testing.T) {
+	conc := filesystem.NewConcurrencyTrackerWithDir(filepath.Join(t.TempDir(), "recordings"))
+	want := map[string]int64{
+		"1m": 60, "10m": 600, "60m": 3600, "8h": 8 * 3600, "24h": 86400,
+		"7d": 7 * 86400, "1mo": 30 * 86400, "6mo": 182 * 86400, "1y": 365 * 86400,
+	}
+	for granularity, bucketSeconds := range want {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=state&granularity="+granularity, nil)
+		rec := httptest.NewRecorder()
+		handleGetHistory(nil, nil, conc, nil)(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("granularity=%s: want 200, got %d", granularity, rec.Code)
+		}
+		var resp historyStateResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("granularity=%s: decode: %v", granularity, err)
+		}
+		if resp.BucketSeconds != bucketSeconds {
+			t.Errorf("granularity=%s: want bucket_seconds=%d, got %d", granularity, bucketSeconds, resp.BucketSeconds)
+		}
+	}
+}
+
+func sum(vs []float64) float64 {
+	var s float64
+	for _, v := range vs {
+		s += v
+	}
+	return s
+}

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -292,15 +292,45 @@ type ConcurrencyResult struct {
 	Current       float64              `json:"current"`
 }
 
+// StateSeriesResult is the reconstruction of per-project, per-state agent
+// counts over time, returned by ConcurrencyReader.StateSeries (issue #981,
+// the optional "time-in-state" second half of #751). It parallels
+// ConcurrencyResult: BucketStarts holds each bucket's start (unix seconds).
+// ByState maps each canonical state (session.StateWorking/StateWaiting/
+// StateReady) to a project -> per-bucket slice (each slice has len ==
+// len(BucketStarts)). Working/waiting counts are per-bucket peak concurrency
+// in that specific state — the same semantics as ConcurrencyResult.ByKey,
+// just split by state instead of merged into one "active" count. Ready
+// counts are the number of sessions that transitioned to ready within the
+// bucket: ready is session.go's terminal state, with no duration to be
+// concurrent in, so it's a transition histogram rather than a concurrency
+// count. Peak/Average/Current mirror ConcurrencyResult's working+waiting
+// summary (the "how busy" headline), computed over the same reconstructed
+// intervals.
+type StateSeriesResult struct {
+	Start         int64                           `json:"start"`
+	End           int64                           `json:"end"`
+	BucketSeconds int64                           `json:"bucket_seconds"`
+	BucketStarts  []int64                         `json:"bucket_starts"`
+	ByState       map[string]map[string][]float64 `json:"by_state"`
+	Peak          float64                         `json:"peak"`
+	Average       float64                         `json:"average"`
+	Current       float64                         `json:"current"`
+}
+
 // ConcurrencyReader reconstructs a concurrent-agents time series from the
 // lifecycle recordings irrlichd writes under <dataDir>/recordings when started
 // with --record (issue #751). It is the read-side counterpart to EventRecorder
 // and the recordings analog of CostTracker.CostSeries. Implementations must be
-// safe for concurrent use. AgentsSeries honors SeriesQuery's window, bucket
-// width, and scope filter; the group axis is always project (the only axis
-// recordings carry), so Group is ignored.
+// safe for concurrent use. AgentsSeries/StateSeries honor SeriesQuery's window,
+// bucket width, and scope filter; the group axis is always project (the only
+// axis recordings carry), so Group is ignored.
 type ConcurrencyReader interface {
 	AgentsSeries(q SeriesQuery) (*ConcurrencyResult, error)
+	// StateSeries is AgentsSeries' per-state counterpart (issue #981): where
+	// AgentsSeries merges working+waiting into one "active" count, StateSeries
+	// keeps the three states separate — see StateSeriesResult.
+	StateSeries(q SeriesQuery) (*StateSeriesResult, error)
 }
 
 // CostTracker persists per-session cost/token snapshots so clients can query

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -11,7 +11,14 @@ const HISTORY_COLORS = [
   '#5E5CE6', '#FFD60A', '#30D158', '#BF5AF2', '#64D2FF',
 ];
 const RANGE_LABELS = { day: 'Day', week: 'Week', month: 'Month', year: 'Year', 'this-month': 'This Month', custom: 'Custom' };
-export const CHART_LABELS = { cost: 'Cost', tokens: 'Tokens', co2: 'CO2', models: 'Models', providers: 'Providers', agents: 'Agents', yield: 'Yield', dora: 'DORA' };
+export const CHART_LABELS = { cost: 'Cost', tokens: 'Tokens', co2: 'CO2', models: 'Models', providers: 'Providers', agents: 'Agents', state: 'Activity', yield: 'Yield', dora: 'DORA' };
+// Granularity steps for chart=state's activity matrix (issue #981) — each
+// picks both the server's bucket width and the matrix's visible column
+// count at once (see historyGranularitySpecs on the daemon side).
+const GRANULARITY_LABELS = { '1m': '1 min', '10m': '10 min', '60m': '60 min', '8h': '8 hr', '24h': '24 hr', '7d': '7 day', '1mo': '1 mo', '6mo': '6 mo', '1y': '1 yr' };
+// Fixed stack order for the activity matrix's per-cell mini bar, bottom to
+// top — mirrors the canonical state order in core/domain/session/session.go.
+const STATE_STACK_ORDER = ['working', 'waiting', 'ready'];
 // Drilldown order: clicking a contributor scopes to it and re-groups by the
 // next finer axis. A leaf (no entry) makes that contributor non-drillable.
 export const DRILL_NEXT = { project: 'branch', branch: 'session', provider: 'model', model: 'session' };
@@ -25,6 +32,9 @@ const TOKEN_TYPE_LABEL = { input: 'Input', output: 'Output', cache_read: 'Cache 
 // provider/project option lists seen across responses (token_type is fixed).
 const historyState = {
   range: 'day', chart: 'cost', group: 'project', forecast: true, start: null, end: null, scope: null, data: null,
+  // granularity is chart=state's own zoom-level axis (#981) — independent of
+  // range, which every other chart uses instead.
+  granularity: '24h',
   filters: { provider: [], token_type: [], project: [] },
   known: { provider: [], project: [] },
   // DORA (#951) is inherently repo-scoped — needs exactly one project,
@@ -178,7 +188,11 @@ export function historyQuery(state = historyState) {
   p.set('group', state.group);
   p.set('forecast', state.forecast ? 'true' : 'false');
   if (state.scope) p.set('scope', state.scope.field + ':' + state.scope.value);
-  if (state.range === 'custom' && state.start != null && state.end != null) {
+  if (state.chart === 'state') {
+    // The activity matrix resolves its window from a granularity zoom-level
+    // instead of range/start/end — see historyGranularitySpecs on the daemon.
+    p.set('granularity', state.granularity);
+  } else if (state.range === 'custom' && state.start != null && state.end != null) {
     p.set('start', String(state.start));
     p.set('end', String(state.end));
   } else {
@@ -239,19 +253,25 @@ function renderHistory() {
   renderHistoryBreadcrumb();
   renderHistoryFilters();
   syncDoraProjectRow();
+  syncGranularityRow();
+  syncHistoryRangeRow();
   syncHistoryCO2Info();
   const isYield = historyState.chart === 'yield';
   const isDora = historyState.chart === 'dora';
-  // Yield counts completed sessions; agents are reconstructed from opt-in
-  // recordings — each gets its own empty caption. DORA never paints the
-  // canvas at all (it's a period summary, not a time series) — its content
-  // lives entirely in the side panel (see renderDoraPanel).
+  const isState = historyState.chart === 'state';
+  // The activity matrix is a grid, not a time-series line — it replaces the
+  // shared canvas with its own scrollable DOM grid (see history-matrix-scroll).
+  syncHistoryMatrixVisibility(isState);
+  // Yield counts completed sessions; agents/state are reconstructed from
+  // opt-in recordings — each gets its own empty caption. DORA never paints
+  // the canvas at all (it's a period summary, not a time series) — its
+  // content lives entirely in the side panel (see renderDoraPanel).
   const emptyEl = document.getElementById('history-chart-empty');
   if (emptyEl) {
     let emptyText = 'no cost data in this range yet';
     if (isYield) emptyText = 'no completed sessions in this range yet';
     else if (isDora) emptyText = historyState.doraProject ? 'DORA metrics — see panel' : 'select a project to see DORA metrics';
-    else if (historyState.chart === 'agents') emptyText = 'no recordings in this range yet';
+    else if (historyState.chart === 'agents' || isState) emptyText = 'no recordings in this range yet';
     emptyEl.textContent = emptyText;
   }
   if (!historyState.data) {
@@ -267,10 +287,38 @@ function renderHistory() {
   } else if (isYield) {
     paintYieldChart();
     renderYieldPanel();
+  } else if (isState) {
+    renderStateMatrix();
+    renderStatePanel();
   } else {
     paintHistoryChart();
     renderHistoryPanel();
   }
+}
+
+// syncHistoryMatrixVisibility toggles between the shared canvas (every
+// time-series chart) and the activity matrix's own DOM grid (chart=state
+// only) — the matrix doesn't fit the canvas's continuous-time painter.
+function syncHistoryMatrixVisibility(isState) {
+  const canvas = document.getElementById('history-chart');
+  const matrixScroll = document.getElementById('history-matrix-scroll');
+  if (canvas) canvas.hidden = isState;
+  if (matrixScroll) matrixScroll.hidden = !isState;
+}
+
+// syncHistoryRangeRow hides the Day/Week/Month/… range selector for
+// chart=state: the activity matrix resolves its window from ?granularity=
+// instead, so the range buttons would be visible but silently inert.
+function syncHistoryRangeRow() {
+  const row = document.getElementById('history-range-row');
+  if (row) row.hidden = historyState.chart === 'state';
+}
+
+// syncGranularityRow shows the granularity zoom-level control only while
+// chart=state is active, mirroring syncDoraProjectRow's per-chart row toggle.
+function syncGranularityRow() {
+  const row = document.getElementById('history-granularity-row');
+  if (row) row.hidden = historyState.chart !== 'state';
 }
 
 // setupHistoryCanvas sizes the canvas for the current DPR/layout, clears
@@ -500,6 +548,230 @@ function paintHistoryChart() {
 
   // X axis time labels.
   drawHistoryXAxisLabels(geo, { buckets, B, bucketSeconds: data.bucket_seconds, muted, h, padB });
+}
+
+// --- Activity matrix (chart=state, issue #981) ---
+// A grid — projects as rows, time buckets as columns — replacing the shared
+// canvas's single continuous-time painter with its own scrollable DOM grid,
+// since a matrix doesn't fit that shape (see renderStateMatrix). "No data
+// recorded" vs. "zero activity" isn't distinguished per cell: the daemon has
+// no persisted record of when --record was toggled per project, only the
+// recordings it did capture, so that distinction isn't reliably derivable
+// today — a zero-activity cell and a before-recording-started cell render
+// identically (flat, no bar). Every cell's exact values stay reachable via
+// the panel's peak/average/current summary, the per-cell tooltip/aria-label,
+// and the existing CSV/JSON export buttons (chart-agnostic already).
+
+const STATE_CELL_INNER_H = 26; // px — must match the bar's available height in irrlicht.css (.hsm-cell's grid row height minus .hsm-bar's bottom margin)
+
+// stateCellCounts returns one (project, bucket-index) cell's
+// {working, waiting, ready} counts, defaulting missing entries to 0.
+export function stateCellCounts(data, project, i) {
+  const by = data?.by_state || {};
+  const out = {};
+  for (const state of STATE_STACK_ORDER) out[state] = (by[state]?.[project]?.[i]) || 0;
+  return out;
+}
+
+// stateCellTotal sums one cell's working+waiting+ready counts.
+export function stateCellTotal(data, project, i) {
+  const counts = stateCellCounts(data, project, i);
+  return counts.working + counts.waiting + counts.ready;
+}
+
+// stateMatrixMaxTotal finds the busiest single cell across the whole visible
+// grid. The matrix's bar-height scale is global (comparable busyness across
+// projects), not normalized per row.
+export function stateMatrixMaxTotal(data) {
+  const projects = data?.projects || [];
+  const buckets = data?.bucket_starts || [];
+  let max = 0;
+  for (const project of projects) {
+    for (let i = 0; i < buckets.length; i++) {
+      const t = stateCellTotal(data, project, i);
+      if (t > max) max = t;
+    }
+  }
+  return max;
+}
+
+// stateBucketLabel formats one column header, coarsening the format as the
+// granularity widens — a "60m" column needs a time-of-day, a "1y" column
+// just needs the year.
+export function stateBucketLabel(ts, granularity) {
+  const d = new Date(ts * 1000);
+  if (granularity === '1y') return String(d.getFullYear());
+  if (granularity === '1mo' || granularity === '6mo') return d.toLocaleDateString(undefined, { month: 'short', year: '2-digit' });
+  if (granularity === '7d' || granularity === '24h' || granularity === '8h') return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+function buildStateCornerCell() {
+  const el = document.createElement('div');
+  el.className = 'hsm-corner';
+  return el;
+}
+
+function buildStateColLabel(text) {
+  const el = document.createElement('div');
+  el.className = 'hsm-col-label';
+  el.textContent = text;
+  return el;
+}
+
+function buildStateRowLabel(project) {
+  const el = document.createElement('div');
+  el.className = 'hsm-row-label';
+  el.textContent = project;
+  el.title = project;
+  return el;
+}
+
+// buildStateCell renders one grid cell: a bottom-anchored stacked mini bar
+// (working/waiting/ready, fixed stack order — see STATE_STACK_ORDER) sized
+// against maxTotal, with a hover/focus tooltip and an aria-label carrying the
+// exact counts for anyone not using the tooltip.
+function buildStateCell(project, ts, counts, maxTotal) {
+  const cell = document.createElement('div');
+  cell.className = 'hsm-cell';
+  cell.tabIndex = 0;
+  cell.setAttribute('role', 'img');
+  cell.setAttribute('aria-label', project + ', ' + new Date(ts * 1000).toLocaleString() + ': ' +
+    counts.working + ' working, ' + counts.waiting + ' waiting, ' + counts.ready + ' ready');
+
+  const bar = document.createElement('div');
+  bar.className = 'hsm-bar';
+  const total = counts.working + counts.waiting + counts.ready;
+  if (total > 0) {
+    bar.style.height = Math.max(3, Math.round((total / maxTotal) * STATE_CELL_INNER_H)) + 'px';
+    let lastNonZero = null;
+    for (const state of STATE_STACK_ORDER) if (counts[state] > 0) lastNonZero = state;
+    for (const state of STATE_STACK_ORDER) {
+      if (counts[state] <= 0) continue;
+      const seg = document.createElement('div');
+      seg.className = 'hsm-seg hsm-seg-' + state + (state === lastNonZero ? ' hsm-seg-cap' : '');
+      seg.style.flexGrow = String(counts[state]);
+      bar.appendChild(seg);
+    }
+  }
+  cell.appendChild(bar);
+
+  cell.addEventListener('pointerenter', () => showStateTooltip(cell, project, ts, counts));
+  cell.addEventListener('focus', () => showStateTooltip(cell, project, ts, counts));
+  cell.addEventListener('pointerleave', hideStateTooltip);
+  cell.addEventListener('blur', hideStateTooltip);
+  return cell;
+}
+
+// renderStateMatrix (re)builds the whole grid on every render — matrix sizes
+// here (a handful of projects × tens of buckets) are small enough that a
+// diffing update isn't worth the complexity every other History chart avoids
+// too (paintHistoryChart also redraws from scratch each time).
+function renderStateMatrix() {
+  const data = historyState.data;
+  const mount = document.getElementById('history-matrix');
+  const scroll = document.getElementById('history-matrix-scroll');
+  const wrap = document.getElementById('history-chart-wrap');
+  if (!mount) return;
+  const projects = data?.projects || [];
+  const buckets = data?.bucket_starts || [];
+  const hasData = projects.length > 0 && buckets.length > 0;
+  if (wrap) wrap.classList.toggle('empty', !hasData);
+  if (scroll) scroll.hidden = !hasData;
+  mount.innerHTML = '';
+  if (!hasData) return;
+
+  mount.style.gridTemplateColumns = 'var(--hsm-row-label-w) repeat(' + buckets.length + ', var(--hsm-cell-w))';
+
+  const maxTotal = stateMatrixMaxTotal(data) || 1;
+  mount.appendChild(buildStateCornerCell());
+  for (const ts of buckets) mount.appendChild(buildStateColLabel(stateBucketLabel(ts, historyState.granularity)));
+  for (const project of projects) {
+    mount.appendChild(buildStateRowLabel(project));
+    buckets.forEach((ts, i) => mount.appendChild(buildStateCell(project, ts, stateCellCounts(data, project, i), maxTotal)));
+  }
+}
+
+// renderStatePanel fills the side panel for the activity matrix: the same
+// peak/avg/current summary shape the agents chart uses (working+waiting
+// combined), plus a legend for the three-color stacked bar — the matrix has
+// no separate contributor list since its rows already are the projects.
+function renderStatePanel() {
+  const data = historyState.data;
+  const titleEl = document.getElementById('history-panel-title');
+  const totalEl = document.getElementById('history-total');
+  const fcEl = document.getElementById('history-forecast-line');
+  const listEl = document.getElementById('history-contrib');
+  if (titleEl) titleEl.textContent = 'Activity · ' + (GRANULARITY_LABELS[historyState.granularity] || historyState.granularity);
+  const conc = data?.concurrency || { peak: 0, average: 0, current: 0 };
+  if (totalEl) totalEl.textContent = histCount(conc.peak) + ' peak';
+  if (fcEl) fcEl.textContent = 'avg ' + (Number(conc.average) || 0).toFixed(1) + ' · now ' + histCount(conc.current);
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  if (!(data?.projects || []).length) {
+    appendHistoryEmpty(listEl, 'no agents in this range');
+    return;
+  }
+  for (const [state, label] of [['working', 'Working'], ['waiting', 'Waiting'], ['ready', 'Ready']]) {
+    const li = document.createElement('li');
+    const dot = document.createElement('span'); dot.className = 'dot hsm-seg-' + state;
+    const lab = document.createElement('span'); lab.className = 'label'; lab.textContent = label;
+    li.append(dot, lab);
+    listEl.appendChild(li);
+  }
+}
+
+function stateTooltipEl() {
+  let el = document.getElementById('history-matrix-tooltip');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'history-matrix-tooltip';
+    el.className = 'hsm-tooltip';
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
+// showStateTooltip shows the same detail on keyboard focus as on hover
+// (per the interaction spec every hoverable chart mark should follow),
+// anchored to the cell's own rect rather than pointer coordinates so focus
+// (which carries no pointer position) positions identically to hover.
+function showStateTooltip(cell, project, ts, counts) {
+  const el = stateTooltipEl();
+  el.innerHTML = '';
+  const title = document.createElement('div'); title.className = 'hsm-tooltip-title'; title.textContent = project;
+  const range = document.createElement('div'); range.className = 'hsm-tooltip-range'; range.textContent = new Date(ts * 1000).toLocaleString();
+  el.append(title, range);
+  for (const [state, label] of [['working', 'Working'], ['waiting', 'Waiting'], ['ready', 'Ready']]) {
+    const row = document.createElement('div'); row.className = 'hsm-tooltip-row';
+    const key = document.createElement('span'); key.className = 'hsm-tooltip-key';
+    const dot = document.createElement('i'); dot.className = 'hsm-tooltip-dot hsm-seg-' + state;
+    key.appendChild(dot);
+    key.appendChild(document.createTextNode(label));
+    const val = document.createElement('span'); val.className = 'hsm-tooltip-val'; val.textContent = String(counts[state]);
+    row.append(key, val);
+    el.appendChild(row);
+  }
+  el.classList.add('show');
+  positionStateTooltip(cell);
+}
+
+function positionStateTooltip(cell) {
+  const el = document.getElementById('history-matrix-tooltip');
+  if (!el || !el.classList.contains('show') || !cell) return;
+  const rect = cell.getBoundingClientRect();
+  const r = el.getBoundingClientRect();
+  const pad = 6;
+  let x = rect.right + pad, y = rect.top;
+  if (x + r.width > window.innerWidth - 10) x = rect.left - r.width - pad;
+  if (y + r.height > window.innerHeight - 10) y = window.innerHeight - r.height - 10;
+  el.style.left = x + 'px';
+  el.style.top = y + 'px';
+}
+
+function hideStateTooltip() {
+  const el = document.getElementById('history-matrix-tooltip');
+  if (el) el.classList.remove('show');
 }
 
 // buildHistoryStatRow builds one contributor list-item: colored dot, label,
@@ -944,6 +1216,17 @@ function exportHistoryCSV() {
         (p.yield || 0).toFixed(6), String(p.reverted_count || 0),
       ].join(','));
     }
+  } else if (historyState.chart === 'state') {
+    lines = ['bucket_start,project,working,waiting,ready'];
+    const by = d.by_state || {};
+    for (const project of (d.projects || [])) {
+      (d.bucket_starts || []).forEach((ts, i) => {
+        const w = by.working?.[project]?.[i] || 0;
+        const wt = by.waiting?.[project]?.[i] || 0;
+        const r = by.ready?.[project]?.[i] || 0;
+        lines.push([new Date(ts * 1000).toISOString(), historyCsvCell(project), w, wt, r].join(','));
+      });
+    }
   } else if (historyState.chart === 'dora') {
     lines = ['metric,value,unit,sample_size,available,message'];
     const rows = [
@@ -1022,7 +1305,7 @@ export function initHistoryTab() {
     // reconstructed per project only.
     if (c === 'models') historyState.group = 'model';
     else if (c === 'providers') historyState.group = 'provider';
-    else if (c === 'agents') historyState.group = 'project';
+    else if (c === 'agents' || c === 'state') historyState.group = 'project'; // recordings carry no other axis
     else if (c !== 'tokens' && historyState.group === 'token_type') historyState.group = 'project'; // token_type needs the tokens metric
     historyState.scope = null; // a new metric resets any drilldown
     syncHistorySelectors();
@@ -1039,6 +1322,15 @@ export function initHistoryTab() {
     fetchHistory();
   });
 
+  const histGranularitySeg = document.getElementById('history-granularity-sel');
+  if (histGranularitySeg) histGranularitySeg.addEventListener('click', (e) => {
+    const b = e.target.closest('button[data-granularity]');
+    if (!b) return;
+    for (const x of histGranularitySeg.querySelectorAll('button')) x.classList.toggle('active', x === b);
+    historyState.granularity = b.dataset.granularity;
+    fetchHistory();
+  });
+
   const histGroupSeg = document.getElementById('history-group-sel');
   if (histGroupSeg) histGroupSeg.addEventListener('click', (e) => {
     const b = e.target.closest('button[data-group]');
@@ -1046,10 +1338,10 @@ export function initHistoryTab() {
     historyState.group = b.dataset.group;
     if (historyState.group === 'token_type') {
       historyState.chart = 'tokens'; // token bands require the tokens metric
-    } else if (historyState.chart === 'models' || historyState.chart === 'providers' || historyState.chart === 'agents') {
+    } else if (historyState.chart === 'models' || historyState.chart === 'providers' || historyState.chart === 'agents' || historyState.chart === 'state') {
       // Choosing a group explicitly leaves the metric-preset charts (and
-      // agents, which is project-only) so the chosen axis sticks on a cost
-      // breakdown.
+      // agents/state, which are project-only) so the chosen axis sticks on a
+      // cost breakdown.
       historyState.chart = 'cost';
     }
     // A dimension is never both the stacking axis and a filter.

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -165,7 +165,7 @@
 
     <section id="view-history" aria-label="Historical cost analytics">
       <div class="history-controls">
-        <div class="history-ctl-row">
+        <div class="history-ctl-row" id="history-range-row">
           <span class="history-ctl-label">Range</span>
           <fieldset class="history-seg" id="history-range" aria-label="Range">
             <button type="button" data-range="day" class="active">Day</button>
@@ -195,6 +195,7 @@
             <button type="button" data-chart="models">Models</button>
             <button type="button" data-chart="providers">Providers</button>
             <button type="button" data-chart="agents">Agents</button>
+            <button type="button" data-chart="state" title="Working/waiting/ready mix per project over time">Activity</button>
           </fieldset>
           <fieldset class="history-seg" id="history-metrics-sel" aria-label="Metrics">
             <button type="button" data-chart="yield" title="Metrics: productive vs reverted spend per project">Yield</button>
@@ -206,6 +207,20 @@
           <select id="history-dora-project" aria-label="DORA project">
             <option value="">Select a project…</option>
           </select>
+        </div>
+        <div class="history-ctl-row" id="history-granularity-row" hidden>
+          <span class="history-ctl-label">Granularity</span>
+          <fieldset class="history-seg" id="history-granularity-sel" aria-label="Time bucket granularity">
+            <button type="button" data-granularity="1m">1 min</button>
+            <button type="button" data-granularity="10m">10 min</button>
+            <button type="button" data-granularity="60m">60 min</button>
+            <button type="button" data-granularity="8h">8 hr</button>
+            <button type="button" data-granularity="24h" class="active">24 hr</button>
+            <button type="button" data-granularity="7d">7 day</button>
+            <button type="button" data-granularity="1mo">1 mo</button>
+            <button type="button" data-granularity="6mo">6 mo</button>
+            <button type="button" data-granularity="1y">1 yr</button>
+          </fieldset>
         </div>
         <div class="history-ctl-row">
           <span class="history-ctl-label">Group</span>
@@ -240,6 +255,9 @@
       <div class="history-layout">
         <div class="history-chart-wrap" id="history-chart-wrap">
           <canvas id="history-chart"></canvas>
+          <div class="history-matrix-scroll" id="history-matrix-scroll" hidden>
+            <div class="history-matrix" id="history-matrix"></div>
+          </div>
           <div class="history-chart-empty" id="history-chart-empty">no cost data in this range yet</div>
           <a id="history-co2-info" class="history-co2-info" href="https://irrlicht.io/docs/co2-methodology.html" target="_blank" rel="noopener" title="How the CO2e estimate and its equivalents are calculated" hidden>ⓘ methodology</a>
         </div>

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1413,6 +1413,72 @@
     .history-co2-info:hover { color: var(--text-bright); border-color: var(--pressure-high); }
     .history-co2-info[hidden] { display: none; }
 
+    /* Activity matrix (chart=state, issue #981): projects × time buckets,
+       each cell a stacked working/waiting/ready mini bar. Replaces the
+       canvas inside the same .history-chart-wrap card (see
+       syncHistoryMatrixVisibility). */
+    .history-matrix-scroll { position: absolute; inset: 10px; overflow: auto; }
+    .history-matrix-scroll[hidden] { display: none; }
+    .history-matrix {
+      display: grid;
+      --hsm-row-label-w: 130px;
+      --hsm-cell-w: 28px;
+      grid-auto-rows: 34px;
+    }
+    .hsm-corner, .hsm-col-label, .hsm-row-label {
+      position: sticky; background: var(--surface);
+    }
+    .hsm-corner { top: 0; left: 0; z-index: 2; }
+    .hsm-col-label {
+      top: 0; z-index: 1;
+      display: flex; align-items: center; justify-content: center;
+      font-family: var(--font-mono); font-size: 10px; color: var(--muted);
+      border-bottom: 1px solid var(--border-subtle);
+      white-space: nowrap;
+    }
+    .hsm-row-label {
+      left: 0; z-index: 1;
+      display: flex; align-items: center;
+      padding-right: 10px;
+      font-size: 12px; color: var(--text);
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+      border-right: 1px solid var(--border-subtle);
+    }
+    .hsm-cell {
+      position: relative;
+      display: flex; align-items: flex-end; justify-content: center;
+      border-bottom: 1px solid var(--border-subtle);
+      cursor: pointer; outline: none;
+    }
+    .hsm-cell:focus-visible { box-shadow: inset 0 0 0 1.5px var(--working); border-radius: 3px; }
+    .hsm-bar {
+      width: 20px; margin-bottom: 4px;
+      display: flex; flex-direction: column-reverse; gap: 1px;
+    }
+    .hsm-seg { width: 100%; }
+    .hsm-seg-working { background: var(--working); }
+    .hsm-seg-waiting { background: var(--waiting); }
+    .hsm-seg-ready { background: var(--ready); }
+    .hsm-seg-cap { border-radius: 3px 3px 0 0; }
+
+    .hsm-tooltip {
+      position: fixed; z-index: 1000;
+      background: var(--surface-hover); border: 1px solid var(--border);
+      border-radius: 8px; padding: 8px 10px;
+      font-family: var(--font-mono); font-size: 11px; color: var(--text);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+      opacity: 0; pointer-events: none; transform: translateY(2px);
+      transition: opacity 0.1s, transform 0.1s;
+      min-width: 160px;
+    }
+    .hsm-tooltip.show { opacity: 1; transform: translateY(0); }
+    .hsm-tooltip-title { font-weight: 600; color: var(--text-bright); font-family: var(--font-sans); font-size: 12px; margin-bottom: 2px; }
+    .hsm-tooltip-range { color: var(--muted); margin-bottom: 6px; }
+    .hsm-tooltip-row { display: flex; justify-content: space-between; gap: 14px; padding: 1px 0; }
+    .hsm-tooltip-key { display: flex; align-items: center; gap: 6px; color: var(--muted); }
+    .hsm-tooltip-dot { width: 7px; height: 7px; border-radius: 2px; display: inline-block; }
+    .hsm-tooltip-val { color: var(--text-bright); font-weight: 600; }
+
     .history-panel {
       flex: 0 0 260px; display: flex; flex-direction: column;
       background: var(--surface); border: 1px solid var(--border);

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -2151,4 +2151,5 @@ export {
   historyQuery, histTokens, histCount, histCO2, CHART_LABELS, DRILL_NEXT, historyRunningSum,
   histDoraPerWeek, histDoraPercent, histDoraHours,
   CO2_EQUIVALENTS, pickCO2Equivalents,
+  stateCellCounts, stateCellTotal, stateMatrixMaxTotal, stateBucketLabel,
 } from './historyTab.js';

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -38,6 +38,10 @@ import {
   historyRunningSum,
   CO2_EQUIVALENTS,
   pickCO2Equivalents,
+  stateCellCounts,
+  stateCellTotal,
+  stateMatrixMaxTotal,
+  stateBucketLabel,
 } from './irrlicht.js'
 
 describe('resolvedTheme', () => {
@@ -880,6 +884,60 @@ describe('agents chart (#751 Phase 3)', () => {
     expect(histCount(2)).toBe('2')
     expect(histCount(2.6)).toBe('3')
     expect(histCount(undefined)).toBe('0')
+  })
+})
+
+describe('activity matrix (chart=state, #981)', () => {
+  test('chart=state serializes with project grouping and a granularity param, not range', () => {
+    const q = new URLSearchParams(historyQuery({ chart: 'state', group: 'project', granularity: '8h', forecast: true, scope: null, filters: {} }))
+    expect(q.get('chart')).toBe('state')
+    expect(q.get('group')).toBe('project')
+    expect(q.get('granularity')).toBe('8h')
+    expect(q.get('range')).toBeNull()
+  })
+
+  test('CHART_LABELS includes Activity', () => {
+    expect(CHART_LABELS.state).toBe('Activity')
+  })
+
+  const sampleData = {
+    projects: ['projA', 'projB'],
+    bucket_starts: [1000, 2000, 3000],
+    by_state: {
+      working: { projA: [1, 2, 0] },
+      waiting: { projA: [0, 1, 1], projB: [3, 0, 0] },
+      ready: { projA: [0, 0, 1] },
+    },
+  }
+
+  test('stateCellCounts defaults missing states/projects to 0', () => {
+    expect(stateCellCounts(sampleData, 'projA', 1)).toEqual({ working: 2, waiting: 1, ready: 0 })
+    expect(stateCellCounts(sampleData, 'projB', 0)).toEqual({ working: 0, waiting: 3, ready: 0 })
+    expect(stateCellCounts(sampleData, 'unknownProject', 0)).toEqual({ working: 0, waiting: 0, ready: 0 })
+  })
+
+  test('stateCellTotal sums working+waiting+ready for one cell', () => {
+    expect(stateCellTotal(sampleData, 'projA', 1)).toBe(3)
+    expect(stateCellTotal(sampleData, 'projA', 2)).toBe(2)
+  })
+
+  test('stateMatrixMaxTotal finds the busiest cell across the whole grid', () => {
+    // projA totals: 1, 3, 2 — projB totals: 3, 0, 0. Busiest is 3.
+    expect(stateMatrixMaxTotal(sampleData)).toBe(3)
+  })
+
+  test('stateMatrixMaxTotal is 0 for an empty grid', () => {
+    expect(stateMatrixMaxTotal({ projects: [], bucket_starts: [], by_state: {} })).toBe(0)
+    expect(stateMatrixMaxTotal(null)).toBe(0)
+  })
+
+  test('stateBucketLabel coarsens format as granularity widens', () => {
+    const ts = Math.floor(new Date('2026-03-15T14:30:00Z').getTime() / 1000)
+    expect(stateBucketLabel(ts, '1y')).toBe('2026')
+    expect(stateBucketLabel(ts, '1mo')).toMatch(/Mar.*26/)
+    expect(stateBucketLabel(ts, '24h')).toMatch(/Mar/)
+    // Fine granularities (minutes/hours) render a time-of-day, not a date.
+    expect(stateBucketLabel(ts, '60m')).not.toMatch(/Mar|2026/)
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #981 — completes the "time-in-state" second half of #751 (previously a `501` stub).

Adds a new **Activity** chart to the History tab: a projects × time-buckets grid showing working/waiting/ready agent counts, zoomable across nine named granularities (1 min → 1 year). Rows are projects (busiest first), each cell a stacked mini bar; hover/focus for exact counts.

Full spec + interactive HTML/SVG mockup: https://claude.ai/code/artifact/564c61e4-ea99-48ab-8f07-40f0473f406d

## Backend

- `ConcurrencyReader.StateSeries` reconstructs per-project, per-state bucketed counts from lifecycle recordings — working/waiting are peak-concurrency-per-bucket (same semantics as the existing `agents` chart, just split by state instead of merged); `ready` is a per-bucket transition histogram, since ready is the terminal state with no duration to be concurrent in.
- `sessionTimeline.activeIntervals` is refactored onto a shared `stateReconstruction`, so the merged (`agents`) and per-state (`state`) views can never drift apart — verified behavior-identical against the existing `AgentsSeries` test suite (all pre-existing tests pass unmodified).
- `chart=state` replaces its old `501` stub and resolves its window from a named `?granularity=` step instead of `?range=`/`?bucket=`.
- Month/6-month/year granularities use an averaged bucket width rather than true calendar boundaries — a deliberate, documented approximation. The shared series pipeline (`BucketStarts`) assumes a uniform bucket stride; switching that to variable-width calendar buckets is a cross-cutting change affecting every chart, not just this one, and belongs in its own PR.

## Frontend

- New "Activity" chart button + a granularity segmented control (mirrors the existing chart/group segmented-control pattern).
- A scrollable DOM grid (not canvas) replaces the shared time-series painter for this chart only — the matrix's discrete grid + per-cell hover doesn't fit the canvas's continuous-time model, matching the precedent DORA/Yield already set for chart-specific rendering.
- Hover/focus tooltip with exact working/waiting/ready counts, `aria-label`s on every cell, and CSV export support.
- No separate "no data recorded" vs. "zero activity" cell state: the daemon has no persisted record of when `--record` was toggled per project, so that distinction isn't reliably derivable today (flagged as an open question in the original spec).

## Bugs found while building this

- **Fixed, with a regression test:** a session still active (working/waiting) at the query window's end was spuriously counted as having gone "ready" — the synthetic "last known alive" bound used to close its interval was leaking into the ready-transition histogram. Found via live smoke-testing against a real daemon (not caught by unit tests until I added one matching the scenario).
- **Filed separately as #983** (pre-existing, out of scope here): a session with exactly one recorded transition and no later event vanishes entirely from both `AgentsSeries` and `StateSeries` — a zero-duration edge case in the shared interval-bounding logic that predates this change and affects the already-shipped `agents` chart too.

## Test plan

- [x] `go test ./core/... -race -count=1` — all packages pass
- [x] `go test ./tools/onboarding-factory/... -race -count=1` — pass
- [x] `npm test` in both `platforms/web/` and the onboarding-factory viewer — pass (157 + 80 tests)
- [x] `tools/architecture_test.go` (hexagonal import direction) — pass
- [x] `tools/ars-gate.sh` — no regression (composite 7.986 → 7.972, within noise)
- [x] `tools/preflight.sh` (gofmt, go tests, onboarding-factory, replaydata validate, recording-rig smoke test, both web suites, ARS gate, security scan) — all green, and re-verified by the pre-push hook
- [x] Live smoke test: built the daemon from this branch, seeded synthetic recordings, hit `GET /api/v1/history?chart=state` on a real running instance, confirmed the JSON shape and served web assets — this is what surfaced the ready-transition bug above
- [ ] Not done: a literal browser render/click-through of the new UI (no visual browser available in this environment) — the live API + served JS/HTML were verified via curl, and the vitest suite covers every exported pure helper (`stateCellCounts`, `stateMatrixMaxTotal`, `stateBucketLabel`, `historyQuery`'s granularity branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)