### PR TITLE
fix(daemon): count a session's sole still-active transition in concurrency series

### DIFF
--- a/core/adapters/outbound/filesystem/concurrency_tracker.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker.go
@@ -388,6 +388,16 @@ type stateInterval struct {
 // a synthetic sentinel, not a real transition — it must be read for
 // interval-closing but excluded from readyAt, or every session still active
 // "now" would spuriously count as having gone ready this instant.
+//
+// When lastEventTS == last.ts — the transition is itself the session's last
+// recorded event, with no later heartbeat to push the bound forward — the
+// synthetic bound is nudged one second past it instead of landing exactly on
+// it. Without the nudge the closing interval is zero-width and the loop below
+// (which requires next.ts > cur.ts) drops it entirely: a session whose only
+// event is a single still-active transition would vanish from both
+// AgentsSeries and StateSeries despite clearly having been active at that
+// instant (issue #983). A one-second floor is the same granularity every
+// timestamp here already uses (ev.Timestamp.Unix()).
 func (tl *sessionTimeline) stateReconstruction() (ivs []stateInterval, readyAt []int64) {
 	if len(tl.transitions) == 0 {
 		return nil, nil
@@ -402,7 +412,7 @@ func (tl *sessionTimeline) stateReconstruction() (ivs []stateInterval, readyAt [
 	}
 
 	if last := tr[len(tr)-1]; concurrencyActive(last.state) {
-		tr = append(tr, stateChange{tl.lastEventTS, session.StateReady})
+		tr = append(tr, stateChange{max(tl.lastEventTS, last.ts+1), session.StateReady})
 	}
 	for i := 0; i < len(tr)-1; i++ {
 		cur, next := tr[i], tr[i+1]

--- a/core/adapters/outbound/filesystem/concurrency_tracker_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_test.go
@@ -273,6 +273,33 @@ func TestAgentsSeries_Empty(t *testing.T) {
 	}
 }
 
+// TestAgentsSeries_SoleTransitionStillCounts: a session whose only transition
+// is its (still-active) working transition — with no later heartbeat, so
+// lastEventTS lands exactly on that transition's own timestamp — must still
+// contribute an interval instead of vanishing. Regression for #983: the
+// synthetic "last known alive" bound used to collapse to a zero-width
+// interval in exactly this case, and the loop building intervals silently
+// dropped it.
+func TestAgentsSeries_SoleTransitionStillCounts(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projY"),
+		transition(2, 100, "s1", session.StateWorking), // last event; no later activity
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.AgentsSeries(outbound.SeriesQuery{Start: 0, End: 300, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	if res.Peak != 1 {
+		t.Errorf("peak: want 1, got %v", res.Peak)
+	}
+	if res.PeakByKey["projY"] != 1 {
+		t.Errorf("peakByKey[projY]: want 1, got %v", res.PeakByKey["projY"])
+	}
+}
+
 // TestAgentsSeries_ScopeProject: a project scope filters to that project's
 // sessions only.
 func TestAgentsSeries_ScopeProject(t *testing.T) {
@@ -468,6 +495,30 @@ func TestStateSeries_Empty(t *testing.T) {
 	}
 	if res.BucketStarts == nil {
 		t.Error("bucket_starts should be a non-nil slice")
+	}
+}
+
+// TestStateSeries_SoleTransitionStillCounts: StateSeries' counterpart of
+// TestAgentsSeries_SoleTransitionStillCounts — a session with exactly one
+// recorded transition and no later event must still show up in the working
+// series instead of vanishing entirely (#983).
+func TestStateSeries_SoleTransitionStillCounts(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projY"),
+		transition(2, 100, "s1", session.StateWorking), // last event; no later activity
+	})
+	tr := NewConcurrencyTrackerWithDir(dir)
+
+	res, err := tr.StateSeries(outbound.SeriesQuery{Start: 0, End: 300, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("StateSeries: %v", err)
+	}
+	if peak := maxOf(res.ByState[session.StateWorking]["projY"]); peak != 1 {
+		t.Errorf("working[projY] peak: want 1, got %v", peak)
+	}
+	if res.Peak != 1 {
+		t.Errorf("peak: want 1, got %v", res.Peak)
 	}
 }
 


### PR DESCRIPTION
## Summary
- A session whose only recorded event is a still-active state transition (no later `transcript_activity` heartbeat) had `lastEventTS` collapse exactly onto that transition's own timestamp. The synthetic "last known alive" bound in `stateReconstruction` then produced a zero-width interval `[ts, ts)`, which the interval-building loop silently drops — the session vanished entirely from both `AgentsSeries` and `StateSeries` despite being active at that instant.
- Fix: nudge the synthetic bound to `max(lastEventTS, last.ts+1)` in `core/adapters/outbound/filesystem/concurrency_tracker.go`, so the closing interval is never zero-width. Since `AgentsSeries` and `StateSeries` both build on the same `stateReconstruction`, both series are fixed by one change.
- Added regression tests (`TestAgentsSeries_SoleTransitionStillCounts`, `TestStateSeries_SoleTransitionStillCounts`) that fail on the pre-fix code and pass after.

## Test plan
- [x] `go test ./core/... -race -count=1` — full suite passes
- [x] Verified the two new regression tests fail against the pre-fix code (reverted the source change, reran — both failed with peak 0) and pass with the fix
- [x] `tools/preflight.sh` (pre-push hook) — all gates pass (gofmt, core tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, starhistory tests, both web suites, ARS gate, security scan)

Fixes #983.

🤖 Generated with [Claude Code](https://claude.com/claude-code)