### PR TITLE
fix(daemon): synthesize swallowed first-turn transition on late session discovery

### DIFF
--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -293,8 +293,38 @@ func (d *SessionDetector) finalizeNewSession(id agent.Identity, ev agent.Event, 
 		d.record(lifecycle.Event{Kind: lifecycle.KindPreSessionCreated, SessionID: ev.SessionID, Adapter: id.Name, ProjectDir: ev.ProjectDir, CWD: ev.CWD})
 	}
 
-	// Record initial state transition.
-	d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: ev.SessionID, NewState: state.State, Reason: "new session created"})
+	// When a real transcript session arrives, remove any pre-sessions for the
+	// same project. Match by projectDir first (Claude Code layout), then
+	// fall back to CWD (Codex/Pi have different transcript layouts). Runs
+	// *before* the initial transition below (moved up from its previous
+	// position after that record) so its return value — whether this session
+	// is superseding a pre-session the daemon was already live-tracking — is
+	// available to ShouldSynthesizeCatchUpTurn (issue #996).
+	supersedingLivePreSession := false
+	if ev.TranscriptPath != "" {
+		supersedingLivePreSession = d.cleanupPreSessionsForProject(ev.ProjectDir, state.CWD, id.Name)
+	}
+
+	// Record initial state transition(s). Ordinarily a single flat "new
+	// session created" record — but if this session's very first observation
+	// already shows a completed turn AND it's superseding a pre-session the
+	// daemon was already live-tracking, the real working->ready cycle for
+	// that turn happened before discovery and would otherwise be silently
+	// swallowed (issue #996): synthesize it instead, mirroring
+	// synthesizeCollapsedTurnBoundaryIfNeeded's existing pattern (issue #988)
+	// for a different collapsed-boundary shape. Scoped to top-level sessions
+	// only — pre-sessions are minted from a matched top-level OS process, so
+	// a child/subagent session is never the one superseding one in practice;
+	// the explicit ParentSessionID guard keeps that scope intentional rather
+	// than incidental, and children keep today's behavior (correct final
+	// state via the ClassifyState re-run in buildNewSessionState, but no
+	// synthesized intermediate transition) as a deliberately separate,
+	// unfixed gap.
+	if state.ParentSessionID == "" && ShouldSynthesizeCatchUpTurn(supersedingLivePreSession, state.Metrics) {
+		d.recordCatchUpTurn(ev.SessionID, state)
+	} else {
+		d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: ev.SessionID, NewState: state.State, Reason: "new session created"})
+	}
 
 	d.broadcast(outbound.PushTypeCreated, state)
 
@@ -307,13 +337,30 @@ func (d *SessionDetector) finalizeNewSession(id agent.Identity, ev agent.Event, 
 		d.holdParentWorkingForNewChild(state.ParentSessionID)
 	}
 
-	// When a real transcript session arrives, remove any pre-sessions for the
-	// same project. Match by projectDir first (Claude Code layout), then
-	// fall back to CWD (Codex/Pi have different transcript layouts).
-	if ev.TranscriptPath != "" {
-		d.cleanupPreSessionsForProject(ev.ProjectDir, state.CWD, id.Name)
-	}
 	return true
+}
+
+// recordCatchUpTurn emits the synthetic ready->working->ready pair
+// representing a turn that had already completed by the time this session
+// was first discovered (issue #996) — see ShouldSynthesizeCatchUpTurn.
+// state.State is left as already classified (Ready); only the recorded
+// lifecycle history changes.
+func (d *SessionDetector) recordCatchUpTurn(sessionID string, state *session.SessionState) {
+	d.record(lifecycle.Event{
+		Kind:      lifecycle.KindStateTransition,
+		SessionID: sessionID,
+		NewState:  session.StateWorking,
+		Reason:    SyntheticCatchUpTurnStartReason,
+		Inputs:    classifierInputs(state.Metrics),
+	})
+	d.record(lifecycle.Event{
+		Kind:      lifecycle.KindStateTransition,
+		SessionID: sessionID,
+		PrevState: session.StateWorking,
+		NewState:  session.StateReady,
+		Reason:    SyntheticCatchUpTurnDoneReason,
+		Inputs:    classifierInputs(state.Metrics),
+	})
 }
 
 // backfillExistingSession fills in TranscriptPath/Adapter on an

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -295,31 +295,23 @@ func (d *SessionDetector) finalizeNewSession(id agent.Identity, ev agent.Event, 
 
 	// When a real transcript session arrives, remove any pre-sessions for the
 	// same project. Match by projectDir first (Claude Code layout), then
-	// fall back to CWD (Codex/Pi have different transcript layouts). Runs
-	// *before* the initial transition below (moved up from its previous
-	// position after that record) so its return value — whether this session
-	// is superseding a pre-session the daemon was already live-tracking — is
-	// available to ShouldSynthesizeCatchUpTurn (issue #996).
+	// fall back to CWD (Codex/Pi have different transcript layouts). Moved
+	// ahead of the transition record below so ShouldSynthesizeCatchUpTurn
+	// (issue #996) can see its return value.
 	supersedingLivePreSession := false
 	if ev.TranscriptPath != "" {
 		supersedingLivePreSession = d.cleanupPreSessionsForProject(ev.ProjectDir, state.CWD, id.Name)
 	}
 
-	// Record initial state transition(s). Ordinarily a single flat "new
-	// session created" record — but if this session's very first observation
-	// already shows a completed turn AND it's superseding a pre-session the
-	// daemon was already live-tracking, the real working->ready cycle for
-	// that turn happened before discovery and would otherwise be silently
-	// swallowed (issue #996): synthesize it instead, mirroring
-	// synthesizeCollapsedTurnBoundaryIfNeeded's existing pattern (issue #988)
-	// for a different collapsed-boundary shape. Scoped to top-level sessions
-	// only — pre-sessions are minted from a matched top-level OS process, so
-	// a child/subagent session is never the one superseding one in practice;
-	// the explicit ParentSessionID guard keeps that scope intentional rather
-	// than incidental, and children keep today's behavior (correct final
-	// state via the ClassifyState re-run in buildNewSessionState, but no
-	// synthesized intermediate transition) as a deliberately separate,
-	// unfixed gap.
+	// Record initial state transition(s): the ordinary flat "new session
+	// created" record, or — if catching up on a swallowed first turn
+	// (issue #996) — a synthetic ready->working->ready pair instead, mirroring
+	// synthesizeCollapsedTurnBoundaryIfNeeded's pattern (issue #988) for a
+	// different collapsed-boundary shape. Scoped to top-level sessions:
+	// pre-sessions are only ever minted for a top-level OS process, so a
+	// child/subagent session can't be the one superseding one — children
+	// keep today's behavior (correct final state, no synthesized transition)
+	// as a separate, deliberately unfixed gap (issue #999).
 	if state.ParentSessionID == "" && ShouldSynthesizeCatchUpTurn(supersedingLivePreSession, state.Metrics) {
 		d.recordCatchUpTurn(ev.SessionID, state)
 	} else {
@@ -346,12 +338,14 @@ func (d *SessionDetector) finalizeNewSession(id agent.Identity, ev agent.Event, 
 // state.State is left as already classified (Ready); only the recorded
 // lifecycle history changes.
 func (d *SessionDetector) recordCatchUpTurn(sessionID string, state *session.SessionState) {
+	d.log.LogInfo(logComponentSessionDetector, sessionID, SyntheticCatchUpTurnDoneReason)
+	inputs := classifierInputs(state.Metrics)
 	d.record(lifecycle.Event{
 		Kind:      lifecycle.KindStateTransition,
 		SessionID: sessionID,
 		NewState:  session.StateWorking,
 		Reason:    SyntheticCatchUpTurnStartReason,
-		Inputs:    classifierInputs(state.Metrics),
+		Inputs:    inputs,
 	})
 	d.record(lifecycle.Event{
 		Kind:      lifecycle.KindStateTransition,
@@ -359,7 +353,7 @@ func (d *SessionDetector) recordCatchUpTurn(sessionID string, state *session.Ses
 		PrevState: session.StateWorking,
 		NewState:  session.StateReady,
 		Reason:    SyntheticCatchUpTurnDoneReason,
-		Inputs:    classifierInputs(state.Metrics),
+		Inputs:    inputs,
 	})
 }
 

--- a/core/application/services/session_detector_catchup_test.go
+++ b/core/application/services/session_detector_catchup_test.go
@@ -1,0 +1,203 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+)
+
+// transitionsFor returns the KindStateTransition events recorded for
+// sessionID, in emission order.
+func transitionsFor(rec *mockRecorder, sessionID string) []lifecycle.Event {
+	var out []lifecycle.Event
+	for _, ev := range rec.snapshot() {
+		if ev.Kind == lifecycle.KindStateTransition && ev.SessionID == sessionID {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// TestSessionDetector_CatchUpTurn_SynthesizesWhenSupersedingLivePreSession is
+// the regression test for issue #996: a mistral-vibe-shaped race where the
+// daemon binds a pre-session (proc-<pid>) to the running process almost
+// instantly, but the real transcript is discovered late enough that its
+// first turn has already fully completed. Because this real session is
+// superseding a pre-session the daemon was already live-tracking, the
+// missing working→ready cycle for that turn must be synthesized rather than
+// silently swallowed.
+func TestSessionDetector_CatchUpTurn_SynthesizesWhenSupersedingLivePreSession(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	rec := &mockRecorder{}
+
+	// Simulates a transcript whose full content is already parsed as a
+	// completed turn by the time the daemon first looks — mirrors
+	// mistral-vibe's 534-byte messages.jsonl in the recorded fixture.
+	metrics := &funcMetrics{fn: func(path, adapter string) (*session.SessionMetrics, error) {
+		if path == "" {
+			return nil, nil
+		}
+		return &session.SessionMetrics{LastEventType: "turn_done"}, nil
+	}}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	det.SetRecorder(rec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	// Pre-session: the process scanner spots the running agent before any
+	// transcript exists (mirrors processlifecycle.Scanner minting proc-<pid>).
+	tw.ch <- agent.Event{
+		Type:       agent.EventNewSession,
+		SessionID:  "proc-996",
+		ProjectDir: "vibe-project",
+	}
+	waitForCondition(func() bool { s, _ := repo.Load("proc-996"); return s != nil }, time.Second)
+
+	// The real transcript appears late, already showing a completed turn.
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "session_real_1",
+		ProjectDir:     "vibe-project",
+		TranscriptPath: "/home/.vibe/logs/session/session_real_1/messages.jsonl",
+	}
+	waitForCondition(func() bool { s, _ := repo.Load("session_real_1"); return s != nil }, time.Second)
+	// cleanupPreSessionsForProject runs synchronously within the same
+	// finalizeNewSession call — wait for its actual effect (the pre-session
+	// gone) rather than a fixed sleep.
+	waitForCondition(func() bool { s, _ := repo.Load("proc-996"); return s == nil }, time.Second)
+	cancel()
+	<-done
+
+	transitions := transitionsFor(rec, "session_real_1")
+	if len(transitions) != 2 {
+		t.Fatalf("expected 2 synthesized state transitions for session_real_1, got %d: %+v", len(transitions), transitions)
+	}
+	if transitions[0].NewState != session.StateWorking || transitions[0].Reason != services.SyntheticCatchUpTurnStartReason {
+		t.Errorf("first transition = %+v, want new_state=working reason=%q", transitions[0], services.SyntheticCatchUpTurnStartReason)
+	}
+	if transitions[1].PrevState != session.StateWorking || transitions[1].NewState != session.StateReady ||
+		transitions[1].Reason != services.SyntheticCatchUpTurnDoneReason {
+		t.Errorf("second transition = %+v, want working->ready reason=%q", transitions[1], services.SyntheticCatchUpTurnDoneReason)
+	}
+
+	state, err := repo.Load("session_real_1")
+	if err != nil || state == nil {
+		t.Fatalf("session_real_1 not created: %v", err)
+	}
+	if state.State != session.StateReady {
+		t.Errorf("persisted state: got %q, want ready (synthesis only changes recorded history, not the settled state)", state.State)
+	}
+}
+
+// TestSessionDetector_CatchUpTurn_NoSynthesisWithoutLivePreSession is the
+// critical regression guard for issue #996's design decision: a cold-started
+// daemon rediscovering an already-finished, historical session (no live
+// pre-session was ever tracked for it — nobody is watching this process)
+// must NOT get a synthetic bounce. Firing unconditionally on
+// metrics.IsAgentDone() alone would flood the lifecycle stream every time a
+// daemon with a large backlog starts up, which is exactly the scenario that
+// exposed this issue's own multi-second discovery delay.
+func TestSessionDetector_CatchUpTurn_NoSynthesisWithoutLivePreSession(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	rec := &mockRecorder{}
+
+	metrics := &funcMetrics{fn: func(path, adapter string) (*session.SessionMetrics, error) {
+		if path == "" {
+			return nil, nil
+		}
+		return &session.SessionMetrics{LastEventType: "turn_done"}, nil
+	}}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	det.SetRecorder(rec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	// No pre-session event at all — this transcript is discovered cold,
+	// with no evidence the daemon was ever live-tracking its process.
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "session_old_1",
+		ProjectDir:     "old-project",
+		TranscriptPath: "/home/.vibe/logs/session/session_old_1/messages.jsonl",
+	}
+	waitForCondition(func() bool { s, _ := repo.Load("session_old_1"); return s != nil }, time.Second)
+	time.Sleep(30 * time.Millisecond) // let any (undesired) second transition land before asserting
+	cancel()
+	<-done
+
+	transitions := transitionsFor(rec, "session_old_1")
+	if len(transitions) != 1 {
+		t.Fatalf("expected 1 (unchanged) state transition for session_old_1, got %d: %+v", len(transitions), transitions)
+	}
+	if transitions[0].NewState != session.StateReady || transitions[0].Reason != "new session created" {
+		t.Errorf("transition = %+v, want the ordinary flat new_state=ready reason=\"new session created\"", transitions[0])
+	}
+}
+
+// TestSessionDetector_CatchUpTurn_NoSynthesisWhenTurnNotYetDone is the
+// other regression guard: the ordinary, non-buggy fast-discovery path (a
+// pre-session superseded by a real session whose transcript does NOT yet
+// show a completed turn) must also stay unchanged — synthesis only applies
+// when a turn was actually swallowed.
+func TestSessionDetector_CatchUpTurn_NoSynthesisWhenTurnNotYetDone(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	rec := &mockRecorder{}
+
+	metrics := &funcMetrics{fn: func(path, adapter string) (*session.SessionMetrics, error) {
+		if path == "" {
+			return nil, nil
+		}
+		// Turn is still in flight — no turn_done yet.
+		return &session.SessionMetrics{LastEventType: "user"}, nil
+	}}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	det.SetRecorder(rec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:       agent.EventNewSession,
+		SessionID:  "proc-997",
+		ProjectDir: "cc-project",
+	}
+	waitForCondition(func() bool { s, _ := repo.Load("proc-997"); return s != nil }, time.Second)
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      "session_real_2",
+		ProjectDir:     "cc-project",
+		TranscriptPath: "/home/.claude/projects/cc-project/session_real_2.jsonl",
+	}
+	waitForCondition(func() bool { s, _ := repo.Load("session_real_2"); return s != nil }, time.Second)
+	waitForCondition(func() bool { s, _ := repo.Load("proc-997"); return s == nil }, time.Second)
+	cancel()
+	<-done
+
+	transitions := transitionsFor(rec, "session_real_2")
+	if len(transitions) != 1 {
+		t.Fatalf("expected 1 (unchanged) state transition for session_real_2, got %d: %+v", len(transitions), transitions)
+	}
+	if transitions[0].NewState != session.StateReady || transitions[0].Reason != "new session created" {
+		t.Errorf("transition = %+v, want the ordinary flat new_state=ready reason=\"new session created\"", transitions[0])
+	}
+}

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -63,11 +63,8 @@ func (d *SessionDetector) broadcast(msgType string, state *session.SessionState)
 // cleanupPreSessionsForProject retires any pre-session(s) (proc-<pid>) for
 // the same project/cwd now that a real transcript-backed session has
 // arrived. Returns whether at least one pre-session was actually retired —
-// callers use this as the "this daemon was already live-tracking the
-// underlying process before the transcript existed" signal that
-// ShouldSynthesizeCatchUpTurn (issue #996) needs to distinguish a genuine
-// live-launch race from an ordinary cold-start rediscovery of an old,
-// already-finished session.
+// callers feed this into ShouldSynthesizeCatchUpTurn (state_classifier.go)
+// as its "was this daemon already live-tracking the process" signal.
 func (d *SessionDetector) cleanupPreSessionsForProject(projectDir, realCWD, adapter string) bool {
 	// Collect candidates under the lock; defer I/O (repo.Load) to outside.
 	d.mu.Lock()

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -60,7 +60,15 @@ func (d *SessionDetector) broadcast(msgType string, state *session.SessionState)
 	d.broadcaster.Broadcast(outbound.PushMessage{Type: outbound.PushTypeUpdated, Session: parent})
 }
 
-func (d *SessionDetector) cleanupPreSessionsForProject(projectDir, realCWD, adapter string) {
+// cleanupPreSessionsForProject retires any pre-session(s) (proc-<pid>) for
+// the same project/cwd now that a real transcript-backed session has
+// arrived. Returns whether at least one pre-session was actually retired —
+// callers use this as the "this daemon was already live-tracking the
+// underlying process before the transcript existed" signal that
+// ShouldSynthesizeCatchUpTurn (issue #996) needs to distinguish a genuine
+// live-launch race from an ordinary cold-start rediscovery of an old,
+// already-finished session.
+func (d *SessionDetector) cleanupPreSessionsForProject(projectDir, realCWD, adapter string) bool {
 	// Collect candidates under the lock; defer I/O (repo.Load) to outside.
 	d.mu.Lock()
 	var ids []string
@@ -104,4 +112,5 @@ func (d *SessionDetector) cleanupPreSessionsForProject(projectDir, realCWD, adap
 		d.log.LogInfo(logComponentSessionDetector, sid,
 			fmt.Sprintf("removed pre-session — real session arrived in %s", projectDir))
 	}
+	return len(ids) > 0
 }

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -224,38 +224,18 @@ const SyntheticCatchUpTurnDoneReason = "turn already complete at first discovery
 
 // ShouldSynthesizeCatchUpTurn reports whether a brand-new session's initial
 // lifecycle record should be a synthetic ready→working→ready pair instead of
-// a single flat "new session created" transition (issue #996).
+// a single flat "new session created" transition — for when discovery was
+// delayed long enough that the first turn already completed (metrics.IsAgentDone())
+// before the daemon ever looked, which would otherwise silently swallow it
+// and mislead downstream turn-boundary consumers about which turn was first
+// (issue #996).
 //
-// A session's discovery is normally near-instant, so the daemon observes
-// every turn's own working→ready cycle as it happens. But when discovery is
-// delayed — e.g. a cold-started daemon has to scan a large backlog of older
-// session directories before it notices a brand-new one — an entire first
-// turn can complete before the daemon ever looks at the transcript. Without
-// this synthesis, that turn is silently swallowed: the session is created
-// directly in its final classified state (typically ready) with no record
-// that a turn ever happened, and the *next* turn is misread downstream as
-// the first one.
-//
-// Fires only when BOTH hold:
-//  1. metrics.IsAgentDone() — the transcript already shows a completed turn
-//     as of this first observation.
-//  2. supersedingLivePreSession — this real session is superseding a
-//     pre-session (proc-<pid>) the daemon was already live-tracking for the
-//     same project/cwd.
-//
-// The second condition is deliberate and load-bearing, not incidental: it is
-// what stops this from also firing every time a daemon (especially a fresh,
-// state-less one — e.g. an isolated recording daemon) cold-starts and
-// rediscovers a large backlog of old, already-finished sessions nobody is
-// live-tracking. Without it, every one of those would get a spurious
-// synthetic bounce, flooding the lifecycle stream — the same class of
-// backlog that produced this issue's own multi-second discovery delay in
-// the first place. A superseded pre-session proves the daemon witnessed
-// this exact process live from near-birth, so the missing turn is a genuine
-// observability gap rather than a stale historical session.
+// supersedingLivePreSession is the load-bearing half of the gate: it's only
+// true when this session is superseding a pre-session (proc-<pid>) the
+// daemon was already live-tracking for the same project/cwd — proof this is
+// a genuine live-launch race, not an ordinary cold-start rediscovery of a
+// large backlog of old, already-finished sessions (which must never get a
+// spurious bounce; see cleanupPreSessionsForProject's doc comment).
 func ShouldSynthesizeCatchUpTurn(supersedingLivePreSession bool, metrics *session.SessionMetrics) bool {
-	if !supersedingLivePreSession || metrics == nil {
-		return false
-	}
-	return metrics.IsAgentDone()
+	return supersedingLivePreSession && metrics.IsAgentDone()
 }

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -209,3 +209,53 @@ func ShouldSynthesizeCollapsedTurnBoundary(currentState string, metrics *session
 	}
 	return metrics.SawMidPassTurnBoundary
 }
+
+// SyntheticCatchUpTurnStartReason is the reason string for the synthetic
+// ready→working transition emitted when a brand-new session's very first
+// observation already shows a completed turn — discovery was delayed long
+// enough that the turn finished before the daemon ever looked (issue #996).
+// Paired with SyntheticCatchUpTurnDoneReason; see ShouldSynthesizeCatchUpTurn
+// for when this fires.
+const SyntheticCatchUpTurnStartReason = "new session created (turn already in progress at first discovery)"
+
+// SyntheticCatchUpTurnDoneReason is the reason string for the working→ready
+// half of the same synthetic pair (see SyntheticCatchUpTurnStartReason).
+const SyntheticCatchUpTurnDoneReason = "turn already complete at first discovery → synthetic catch-up"
+
+// ShouldSynthesizeCatchUpTurn reports whether a brand-new session's initial
+// lifecycle record should be a synthetic ready→working→ready pair instead of
+// a single flat "new session created" transition (issue #996).
+//
+// A session's discovery is normally near-instant, so the daemon observes
+// every turn's own working→ready cycle as it happens. But when discovery is
+// delayed — e.g. a cold-started daemon has to scan a large backlog of older
+// session directories before it notices a brand-new one — an entire first
+// turn can complete before the daemon ever looks at the transcript. Without
+// this synthesis, that turn is silently swallowed: the session is created
+// directly in its final classified state (typically ready) with no record
+// that a turn ever happened, and the *next* turn is misread downstream as
+// the first one.
+//
+// Fires only when BOTH hold:
+//  1. metrics.IsAgentDone() — the transcript already shows a completed turn
+//     as of this first observation.
+//  2. supersedingLivePreSession — this real session is superseding a
+//     pre-session (proc-<pid>) the daemon was already live-tracking for the
+//     same project/cwd.
+//
+// The second condition is deliberate and load-bearing, not incidental: it is
+// what stops this from also firing every time a daemon (especially a fresh,
+// state-less one — e.g. an isolated recording daemon) cold-starts and
+// rediscovers a large backlog of old, already-finished sessions nobody is
+// live-tracking. Without it, every one of those would get a spurious
+// synthetic bounce, flooding the lifecycle stream — the same class of
+// backlog that produced this issue's own multi-second discovery delay in
+// the first place. A superseded pre-session proves the daemon witnessed
+// this exact process live from near-birth, so the missing turn is a genuine
+// observability gap rather than a stale historical session.
+func ShouldSynthesizeCatchUpTurn(supersedingLivePreSession bool, metrics *session.SessionMetrics) bool {
+	if !supersedingLivePreSession || metrics == nil {
+		return false
+	}
+	return metrics.IsAgentDone()
+}


### PR DESCRIPTION
## Summary

When a session's real transcript is discovered late enough that its first turn already completed — e.g. a cold-started daemon has to scan a large backlog of older session directories before noticing a brand-new one — the daemon today snapshots the session straight into its final classified state and never records a `working` transition for that turn. The *next* turn is then misread downstream as the first one.

This surfaced as mistral-vibe's `1-3_long-idle-live-session` onboarding-factory scenario going `known_failing` after #988 fixed a *different* mechanism (a spurious force-bounce flicker) for the same scenario: the presession `proc-<pid>` bound `ready` at +118ms, but the real `session_<ts>_<hash>` transcript wasn't discovered until +17.3s — by which point turn 1 (534 bytes, user+assistant) had already fully flushed. The daemon settled straight into `ready` with a flat "new session created" record; the only observed `working→ready` cycle turned out to be turn 2's, misattributed as `first_turn_start`/`first_turn_end`.

## Fix

Synthesize the missing `ready→working→ready` pair — but **only** when the new session is superseding a pre-session (`proc-<pid>`) the daemon was already live-tracking for the same project/cwd. That gate is deliberate: firing on `IsAgentDone()` alone would also trigger every time a daemon (especially a fresh, state-less one, e.g. an isolated onboarding-factory recording daemon) cold-starts and rediscovers a large backlog of old, already-finished sessions nobody is live-tracking — flooding the lifecycle stream with spurious bounces, which is exactly the class of backlog that produced this issue's own 17s discovery delay in the first place. A superseded pre-session proves the daemon witnessed this exact process live from near-birth, so the missing turn is a genuine observability gap rather than a stale historical session.

- `core/application/services/state_classifier.go` — new `ShouldSynthesizeCatchUpTurn` predicate + `SyntheticCatchUpTurnStartReason`/`SyntheticCatchUpTurnDoneReason` constants, mirroring issue #988's `ShouldSynthesizeCollapsedTurnBoundary` pattern.
- `core/application/services/session_detector_helpers.go` — `cleanupPreSessionsForProject` now returns whether it retired a live pre-session.
- `core/application/services/session_detector_activity.go` — `finalizeNewSession` reorders that cleanup ahead of the initial transition record and branches into the synthetic pair when both signals hold. Scoped to top-level sessions (`state.ParentSessionID == ""`).

Adapter-agnostic: mistral-vibe has no discovery code of its own — it uses the same generic `fswatcher`/`FilesUnderRoot` wiring as every other adapter — so the same race (and fix) applies to any adapter whose discovery is delayed past one full turn.

## Explicitly out of scope (filed as follow-ups)

- **#998** — the ~17.3s cold-scan latency itself (`fswatcher`'s synchronous, lexically-ordered `addExistingDirs` walk before arming the live watch). Fixing it wouldn't fully eliminate the race this PR addresses (a busy machine or a restart mid-turn can always reproduce a nonzero delay), and it widens blast radius to every adapter's cold-start behavior — deserves its own review.
- **#999** — child/subagent sessions have a narrower version of the same swallowed-turn gap (they get correctly classified *final* state via the existing `ParentSessionID != ""` reclassify branch, but never a synthesized intermediate transition). No observed failure covers this shape yet, so left unfixed here.
- The mistral-vibe `1-3_long-idle-live-session` scenario's `known_failing` badge is **not** flipped by this PR. This repo's convention treats recordings as the single source of truth, so that needs a live re-recording — and per the scenario's own notes, a warm-daemon `--attach` recording would likely not even reproduce the race (the latency is tied to a fresh/isolated daemon's cold-start backlog scan), making a re-record attempt a plausible wasted/misleading step right now. The scenario stays `known_failing` pending a recording that happens to reproduce the latency.

## Verification

- New regression tests in `core/application/services/session_detector_catchup_test.go`: the race synthesizes the bounce; two guards confirm ordinary cold-start backlog rediscovery (no pre-session) and the normal fast-discovery path (turn not yet done) are both byte-for-byte unchanged.
- `go test ./core/... -race -count=1` — full suite green.
- `go test ./tools/onboarding-factory/... -race -count=1` and `tools/replay-fixtures.sh` — green; the mistral-vibe `1-3_long-idle-live-session` replay golden is unaffected (the replay engine has no pre-session concept, as predicted), and `known_failing` is still correctly asserted as expected there.
- `tools/preflight.sh --only go` and `--only arch` — both pass (ARS composite ticked up slightly, no regressions).

Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)