### PR TITLE
fix(backchannel): re-key terminal-observer/session state across presession reconciliation

### DIFF
--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -105,6 +105,17 @@ type PIDManager struct {
 	// child (see hasActiveChildren in session_detector.go).
 	onChildDeleted func(parentID string)
 
+	// onSessionSuperseded is called when a presession is retired because a
+	// real session was reconciled onto the same identity (same PID, or same
+	// adapter+project/CWD). Unlike onSessionDeleted, it carries BOTH ids, so
+	// a subsystem that keeps its own per-session state (e.g. TerminalObserver's
+	// dialog-edge cache, or a Waiting state SessionDetector already persisted
+	// onto the presession's own row via a live terminal-observer signal) can
+	// carry that state forward onto the new id instead of losing it — the
+	// presession row is about to be deleted outright, unlike onSessionDeleted's
+	// other callers which only need to forget the old id (issue #997).
+	onSessionSuperseded func(oldID, newID string)
+
 	// pendingPIDs stores PIDs discovered by background goroutines, to be
 	// applied by processActivity on its next run. This avoids a race where
 	// HandlePIDAssigned's load-modify-save overwrites a state transition
@@ -175,6 +186,16 @@ func (pm *PIDManager) SetRecorder(r outbound.EventRecorder, seq *int64) {
 // `working` solely because of that child.
 func (pm *PIDManager) SetChildDeletedHandler(fn func(parentID string)) {
 	pm.onChildDeleted = fn
+}
+
+// SetSessionSupersededHandler registers a callback invoked whenever a
+// presession is retired in favor of a reconciled real session — from every
+// PIDManager-owned path that performs that reconciliation (same-PID match at
+// PID-assignment time, and both the seed-time and periodic pre-session
+// sweeps). Both ids are passed so the caller can re-key any per-session state
+// it owns onto the new id before the presession row is deleted (issue #997).
+func (pm *PIDManager) SetSessionSupersededHandler(fn func(oldID, newID string)) {
+	pm.onSessionSuperseded = fn
 }
 
 // SetLauncherEnvReader installs a reader that captures launcher identity
@@ -577,6 +598,11 @@ func (pm *PIDManager) cleanupStalePIDHolders(stale []*session.SessionState, sess
 			TranscriptPath: old.TranscriptPath,
 		})
 
+		// Fire before the delete so a re-key handler's own Load(old.SessionID)
+		// is guaranteed to still succeed (issue #997).
+		if pm.onSessionSuperseded != nil {
+			pm.onSessionSuperseded(old.SessionID, sessionID)
+		}
 		if pm.onSessionDeleted != nil {
 			pm.onSessionDeleted(old.SessionID)
 		}
@@ -1235,21 +1261,27 @@ func (pm *PIDManager) dedupeByPID(states []*session.SessionState, newestByPID ma
 				continue
 			}
 			pm.removeSessionUntracked(logComponentSessionDetectorSeed, state,
-				fmt.Sprintf("duplicate pid %d (keeping %s) — deleting", pid, newest.SessionID))
+				fmt.Sprintf("duplicate pid %d (keeping %s) — deleting", pid, newest.SessionID), "")
 		}
 	}
 }
 
-// removeSessionUntracked deletes s via the same log→onSessionDeleted→repo
-// .Delete→broadcast sequence used by the reconciliation sweeps (dedup and
-// pre-session supersession). Unlike deleteSession/deleteWithChildren, it does
-// NOT emit a lifecycle recorder event — these paths reconcile bookkeeping
-// artifacts (a duplicate PID row, a superseded proc-* placeholder) rather
-// than tearing down a session whose disappearance belongs in the offline
-// replay trace. tag and msg are the caller's log identity and message, kept
-// verbatim so log output is unchanged by this extraction.
-func (pm *PIDManager) removeSessionUntracked(tag string, s *session.SessionState, msg string) {
+// removeSessionUntracked deletes s via the same log→onSessionSuperseded→
+// onSessionDeleted→repo.Delete→broadcast sequence used by the reconciliation
+// sweeps (dedup and pre-session supersession). Unlike deleteSession/
+// deleteWithChildren, it does NOT emit a lifecycle recorder event — these
+// paths reconcile bookkeeping artifacts (a duplicate PID row, a superseded
+// proc-* placeholder) rather than tearing down a session whose disappearance
+// belongs in the offline replay trace. tag and msg are the caller's log
+// identity and message, kept verbatim so log output is unchanged by this
+// extraction. supersededBy is the reconciled session's id s is being retired
+// in favor of (empty for a plain same-PID dedup, which has no single
+// superseding identity to re-key state onto — issue #997).
+func (pm *PIDManager) removeSessionUntracked(tag string, s *session.SessionState, msg string, supersededBy string) {
 	pm.log.LogInfo(tag, s.SessionID, msg)
+	if supersededBy != "" && pm.onSessionSuperseded != nil {
+		pm.onSessionSuperseded(s.SessionID, supersededBy)
+	}
 	if pm.onSessionDeleted != nil {
 		pm.onSessionDeleted(s.SessionID)
 	}
@@ -1304,7 +1336,7 @@ func (pm *PIDManager) sweepSupersededPreSessions(states []*session.SessionState)
 		}
 		if candidate, _ := findSupersedingSession(proc, states); candidate != nil {
 			pm.removeSessionUntracked(logComponentSessionDetectorSeed, proc,
-				fmt.Sprintf("pre-session superseded by %s — deleting", candidate.SessionID))
+				fmt.Sprintf("pre-session superseded by %s — deleting", candidate.SessionID), candidate.SessionID)
 		}
 	}
 }
@@ -1362,7 +1394,7 @@ func (pm *PIDManager) sweepSupersededPreSessionsPeriodic() {
 			continue
 		}
 		pm.removeSessionUntracked(logComponentSessionDetector, v.state,
-			fmt.Sprintf("pre-session superseded by %s (PID-bound to a sibling) — deleting", v.candidate))
+			fmt.Sprintf("pre-session superseded by %s (PID-bound to a sibling) — deleting", v.candidate), v.candidate)
 	}
 }
 

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -1230,3 +1230,177 @@ func TestCheckPIDLiveness_PIDMatchPreSession_SweptImmediately(t *testing.T) {
 		t.Fatal("real session must survive")
 	}
 }
+
+// --- onSessionSuperseded (presession→real-session re-key hook, issue #997) ---
+
+// supersededPair records one onSessionSuperseded invocation for assertions.
+type supersededPair struct{ oldID, newID string }
+
+// newPIDManagerForTestWithSupersededSpy builds a PIDManager whose
+// onSessionSuperseded callback records every (oldID, newID) pair — the
+// presession re-key seam issue #997 introduced alongside the existing
+// onSessionDeleted funnel (see newPIDManagerForTestWithDeleteSpy).
+func newPIDManagerForTestWithSupersededSpy(repo *mockRepo, superseded *[]supersededPair) *services.PIDManager {
+	pm := services.NewPIDManager(services.PIDManagerDeps{
+		Repo:             repo,
+		Log:              &mockLogger{},
+		ReadyTTL:         10 * time.Minute,
+		OnSessionDeleted: func(string) {},
+	})
+	pm.SetSessionSupersededHandler(func(oldID, newID string) {
+		*superseded = append(*superseded, supersededPair{oldID: oldID, newID: newID})
+	})
+	return pm
+}
+
+// TestHandlePIDAssigned_FiresSupersededHook: cleanupStalePIDHolders (the
+// same-PID reconciliation path — the one that actually fired in the #997
+// mistral-vibe recording) must fire the re-key hook with (old, new) before
+// deleting the old row, so a subsystem carrying its own per-session state
+// (e.g. TerminalObserver's dialog cache) can move it onto the new id first.
+func TestHandlePIDAssigned_FiresSupersededHook(t *testing.T) {
+	repo := newMockRepo()
+	now := time.Now().Unix()
+	repo.states["old"] = &session.SessionState{
+		SessionID:      "old",
+		State:          session.StateReady,
+		PID:            42,
+		TranscriptPath: "/tmp/old.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	}
+	repo.states["new"] = &session.SessionState{
+		SessionID:      "new",
+		State:          session.StateReady,
+		TranscriptPath: "/tmp/new.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	}
+
+	var superseded []supersededPair
+	newPIDManagerForTestWithSupersededSpy(repo, &superseded).HandlePIDAssigned(42, "new")
+
+	if len(superseded) != 1 || superseded[0] != (supersededPair{oldID: "old", newID: "new"}) {
+		t.Fatalf("onSessionSuperseded pairs = %v, want [{old new}]", superseded)
+	}
+	if repo.states["old"] != nil {
+		t.Fatal("old session should still be deleted after the hook fires")
+	}
+}
+
+// TestSeedPIDs_FiresSupersededHookForPreSessionSweep: the seed-time
+// reconciliation sweep (sweepSupersededPreSessions) is a second, independent
+// path that retires presessions — it must fire the same hook.
+func TestSeedPIDs_FiresSupersededHookForPreSessionSweep(t *testing.T) {
+	pid := os.Getpid() // alive, so seedAlivePIDs' liveness check doesn't reap it first
+	repo := newMockRepo()
+	now := time.Now().Unix()
+	repo.states["real"] = &session.SessionState{
+		SessionID:      "real",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		PID:            pid,
+		TranscriptPath: "/tmp/real.jsonl",
+		UpdatedAt:      now,
+	}
+	repo.states["proc-live"] = &session.SessionState{
+		SessionID: "proc-live",
+		Adapter:   "claude-code",
+		State:     session.StateReady,
+		PID:       pid,
+		UpdatedAt: now,
+	}
+	states := []*session.SessionState{repo.states["real"], repo.states["proc-live"]}
+
+	var superseded []supersededPair
+	newPIDManagerForTestWithSupersededSpy(repo, &superseded).SeedPIDs(states)
+
+	if len(superseded) != 1 || superseded[0] != (supersededPair{oldID: "proc-live", newID: "real"}) {
+		t.Fatalf("onSessionSuperseded pairs = %v, want [{proc-live real}]", superseded)
+	}
+	if repo.states["proc-live"] != nil {
+		t.Fatal("pre-session should be swept by the seed-time reconciliation sweep")
+	}
+}
+
+// TestSeedPIDs_DedupDoesNotFireSupersededHook: dedupeByPID retires a genuine
+// duplicate real session (e.g. an orphan left by /clear), not a presession
+// reconciliation — there is no single "superseded by" identity to re-key
+// state onto, so the hook must stay silent for this path (issue #997 scoped
+// the hook to presession→real-session reconciliation specifically).
+func TestSeedPIDs_DedupDoesNotFireSupersededHook(t *testing.T) {
+	pid := os.Getpid()
+	repo := newMockRepo()
+	now := time.Now().Unix()
+	repo.states["dup-old"] = &session.SessionState{
+		SessionID:      "dup-old",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		PID:            pid,
+		TranscriptPath: "/tmp/dup-old.jsonl",
+		FirstSeen:      now - 100,
+		UpdatedAt:      now,
+	}
+	repo.states["dup-new"] = &session.SessionState{
+		SessionID:      "dup-new",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		PID:            pid,
+		TranscriptPath: "/tmp/dup-new.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	}
+	states := []*session.SessionState{repo.states["dup-old"], repo.states["dup-new"]}
+
+	var superseded []supersededPair
+	newPIDManagerForTestWithSupersededSpy(repo, &superseded).SeedPIDs(states)
+
+	if repo.states["dup-old"] != nil {
+		t.Fatal("older duplicate should still be deleted by dedupeByPID")
+	}
+	if len(superseded) != 0 {
+		t.Fatalf("dedup is not a presession reconciliation — onSessionSuperseded should not fire, got %v", superseded)
+	}
+}
+
+// TestCheckPIDLiveness_FiresSupersededHookForPreSessionSweep: the periodic
+// pre-session sweep (sweepSupersededPreSessionsPeriodic) is a third,
+// independent reconciliation path — mirrors
+// TestCheckPIDLiveness_PIDMatchPreSession_SweptImmediately with the spy
+// wired in.
+func TestCheckPIDLiveness_FiresSupersededHookForPreSessionSweep(t *testing.T) {
+	tmp := t.TempDir()
+	transcript := filepath.Join(tmp, "real.jsonl")
+	writeTranscript(t, transcript, time.Now())
+
+	pid := os.Getpid()
+	repo := newMockRepo()
+	repo.states["real"] = &session.SessionState{
+		SessionID:      "real",
+		Adapter:        "claude-code",
+		State:          session.StateReady,
+		PID:            pid,
+		CWD:            tmp,
+		TranscriptPath: transcript,
+		UpdatedAt:      time.Now().Unix(),
+	}
+	repo.states["proc-same"] = &session.SessionState{
+		SessionID: "proc-same",
+		Adapter:   "claude-code",
+		State:     session.StateReady,
+		PID:       pid,
+		CWD:       tmp,
+		FirstSeen: time.Now().Unix(),
+		UpdatedAt: time.Now().Unix(),
+	}
+
+	var superseded []supersededPair
+	newPIDManagerForTestWithSupersededSpy(repo, &superseded).CheckPIDLiveness()
+
+	if len(superseded) != 1 || superseded[0] != (supersededPair{oldID: "proc-same", newID: "real"}) {
+		t.Fatalf("onSessionSuperseded pairs = %v, want [{proc-same real}]", superseded)
+	}
+	if repo.states["proc-same"] != nil {
+		t.Fatal("PID-matched pre-session should be swept immediately (no grace)")
+	}
+}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -225,6 +225,15 @@ type SessionDetector struct {
 	// and never races processActivity. Non-blocking sender; a dropped signal is
 	// re-sent on the observer's next poll (issue #732).
 	uiSignals chan terminalUISignal
+
+	// onSessionSuperseded is called whenever a presession is retired in favor
+	// of a reconciled real session, from cleanupPreSessionsForProject's own
+	// project/CWD match — the one reconciliation path that deletes its row
+	// directly rather than through PIDManager. Installed via
+	// SetSessionSupersededHandler, which also forwards to pidMgr's own hook so
+	// external code has a single registration point covering every
+	// reconciliation path (issue #997).
+	onSessionSuperseded func(oldID, newID string)
 }
 
 // terminalUISignal is an edge in a session's rendered-terminal UI state,
@@ -307,6 +316,17 @@ func NewSessionDetector(watchers []inbound.Watcher, deps SessionDetectorDeps) *S
 // Intended for tests that need immediate re-creation.
 func (d *SessionDetector) SetDeletedCooldown(dur time.Duration) {
 	d.deletedCooldown = dur
+}
+
+// SetSessionSupersededHandler registers fn to run whenever any presession
+// reconciliation path retires a presession in favor of a real session — both
+// the PIDManager-owned paths (same-PID match at PID-assignment time, and the
+// seed-time/periodic pre-session sweeps) and cleanupPreSessionsForProject's
+// own project/CWD match, which deletes its row directly rather than through
+// PIDManager. A single call here covers every path (issue #997).
+func (d *SessionDetector) SetSessionSupersededHandler(fn func(oldID, newID string)) {
+	d.onSessionSuperseded = fn
+	d.pidMgr.SetSessionSupersededHandler(fn)
 }
 
 // SetBackgroundProbeForTest overrides the background-process liveness probe so

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -225,15 +225,6 @@ type SessionDetector struct {
 	// and never races processActivity. Non-blocking sender; a dropped signal is
 	// re-sent on the observer's next poll (issue #732).
 	uiSignals chan terminalUISignal
-
-	// onSessionSuperseded is called whenever a presession is retired in favor
-	// of a reconciled real session, from cleanupPreSessionsForProject's own
-	// project/CWD match — the one reconciliation path that deletes its row
-	// directly rather than through PIDManager. Installed via
-	// SetSessionSupersededHandler, which also forwards to pidMgr's own hook so
-	// external code has a single registration point covering every
-	// reconciliation path (issue #997).
-	onSessionSuperseded func(oldID, newID string)
 }
 
 // terminalUISignal is an edge in a session's rendered-terminal UI state,
@@ -323,9 +314,10 @@ func (d *SessionDetector) SetDeletedCooldown(dur time.Duration) {
 // the PIDManager-owned paths (same-PID match at PID-assignment time, and the
 // seed-time/periodic pre-session sweeps) and cleanupPreSessionsForProject's
 // own project/CWD match, which deletes its row directly rather than through
-// PIDManager. A single call here covers every path (issue #997).
+// PIDManager. A single call here covers every path (issue #997). Stored only
+// on pidMgr — cleanupPreSessionsForProject reads it back from there (same
+// package) rather than keeping a second copy on SessionDetector.
 func (d *SessionDetector) SetSessionSupersededHandler(fn func(oldID, newID string)) {
-	d.onSessionSuperseded = fn
 	d.pidMgr.SetSessionSupersededHandler(fn)
 }
 

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -300,7 +300,7 @@ func (d *SessionDetector) finalizeNewSession(id agent.Identity, ev agent.Event, 
 	// (issue #996) can see its return value.
 	supersedingLivePreSession := false
 	if ev.TranscriptPath != "" {
-		supersedingLivePreSession = d.cleanupPreSessionsForProject(ev.ProjectDir, state.CWD, id.Name)
+		supersedingLivePreSession = d.cleanupPreSessionsForProject(ev.ProjectDir, state.CWD, id.Name, ev.SessionID)
 	}
 
 	// Record initial state transition(s): the ordinary flat "new session

--- a/core/application/services/session_detector_backchannel_reconcile_test.go
+++ b/core/application/services/session_detector_backchannel_reconcile_test.go
@@ -1,0 +1,115 @@
+package services
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/backchannel"
+	"irrlicht/core/domain/session"
+)
+
+// This file is the end-to-end regression for issue #997, reproducing the
+// exact sequence observed in the mistral-vibe recording
+// (replaydata/agents/mistral-vibe/scenarios/6-2_backchannel-observe):
+//
+//  1. A presession (proc-<PID>) is born ready.
+//  2. A trust dialog opens; TerminalObserver's poll detects it and forces
+//     the presession into Waiting.
+//  3. The real session is born and PID discovery reconciles it onto the
+//     same PID, retiring (deleting) the presession.
+//  4. The dialog closes.
+//
+// Before the #997 fix, step 2's Waiting state and TerminalObserver's edge
+// cache both stayed attached to the presession id, so step 3's delete threw
+// them away — the real session never showed a waiting transition, and step
+// 4's clearing edge fired against a row that no longer existed. This test
+// wires TerminalObserver and SessionDetector together exactly as
+// core/cmd/irrlichd/startup.go's setupBackchannel does (SetSessionSupersededHandler
+// combining ReconcilePreSessionBackchannel + RekeySession) and asserts the
+// reconciled real session carries the full waiting→working arc instead.
+func TestBackchannelReconciliation_PreSessionToRealSession_Issue997(t *testing.T) {
+	const presessionID = "proc-59047"
+	const realSessionID = "session_20260713_113057_3a899ae1"
+	const pid = 59047
+	const adapter = "mistral-vibe"
+
+	repo := newUIRepo(&session.SessionState{
+		SessionID: presessionID, Adapter: adapter, State: session.StateReady, PID: pid,
+	})
+	reader := &uiReader{
+		readable: map[string]bool{presessionID: true, realSessionID: true},
+		screen:   map[string]string{presessionID: `Permission for the bash tool (touch *)`},
+	}
+	consent := uiConsent{map[string]bool{adapter: true}}
+
+	d, rec := newFusionDetector(repo)
+	obs := NewTerminalObserver(repo, reader, consent, func() bool { return true }, d, bcNopLog{})
+
+	// Wire the reconciliation callback exactly as setupBackchannel does in
+	// startup.go: a single registration fans out to both halves.
+	d.SetSessionSupersededHandler(func(oldID, newID string) {
+		d.ReconcilePreSessionBackchannel(oldID, newID)
+		obs.RekeySession(oldID, newID)
+	})
+
+	// Step 1+2: the dialog is already open when the observer's first poll
+	// sees the presession. Drain the resulting signal the same way Run()'s
+	// event loop would (handleTerminalUISignal, off d.uiSignals).
+	obs.observe(presessionID, adapter)
+	d.handleTerminalUISignal(<-d.uiSignals)
+
+	preState, err := d.repo.Load(presessionID)
+	if err != nil || preState == nil || preState.State != session.StateWaiting {
+		t.Fatalf("presession should be forced into waiting by the terminal-observer signal, got %+v (err=%v)", preState, err)
+	}
+
+	// Step 3: the real session is born and PID discovery reconciles it onto
+	// the same PID — this is the exact path that fired in the recording
+	// (cleanupStalePIDHolders), and it must carry the waiting state and the
+	// observer's edge cache forward before deleting the presession.
+	if err := d.repo.Save(&session.SessionState{
+		SessionID: realSessionID, Adapter: adapter, State: session.StateReady,
+	}); err != nil {
+		t.Fatalf("seed real session: %v", err)
+	}
+	d.pidMgr.HandlePIDAssigned(pid, realSessionID)
+
+	if _, err := d.repo.Load(presessionID); err == nil {
+		t.Fatal("presession should have been deleted by reconciliation")
+	}
+	realState, err := d.repo.Load(realSessionID)
+	if err != nil || realState == nil {
+		t.Fatalf("real session should still exist: %v", err)
+	}
+	if realState.State != session.StateWaiting {
+		t.Fatalf("reconciled session state = %q, want waiting — the presession's waiting state was lost on reconciliation (issue #997)", realState.State)
+	}
+	if !rec.hasTransitionTo(session.StateWaiting) {
+		t.Error("expected a state_transition to waiting on the reconciled real session")
+	}
+
+	// Step 4: the dialog closes. Because RekeySession moved the observer's
+	// edge-detection cache onto realSessionID, this poll of the LIVE id
+	// correctly sees a falling edge (trust_dialog → none) instead of either
+	// missing the edge entirely or targeting the now-deleted presession.
+	reader.screen[realSessionID] = "back to work"
+	obs.observe(realSessionID, adapter)
+	d.handleTerminalUISignal(<-d.uiSignals)
+
+	finalState, err := d.repo.Load(realSessionID)
+	if err != nil || finalState == nil {
+		t.Fatalf("real session should still exist after clearing: %v", err)
+	}
+	if finalState.State == session.StateWaiting {
+		t.Fatal("reconciled session stranded in waiting — the clearing edge never reached it after reconciliation")
+	}
+	if !rec.hasTransitionFrom(session.StateWaiting) {
+		t.Error("expected a state_transition out of waiting on the reconciled real session")
+	}
+
+	// Sanity: DetectUI itself really does recognize vibe's dialog phrasing —
+	// confirms this test is exercising the same marker #988 fixed, not a
+	// stale/looser string.
+	if backchannel.DetectUI(`Permission for the bash tool (touch *)`) != backchannel.UIKindTrustDialog {
+		t.Fatal("test fixture screen text no longer matches DetectUI's trust-dialog markers")
+	}
+}

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -103,9 +103,10 @@ func (d *SessionDetector) cleanupPreSessionsForProject(projectDir, realCWD, adap
 	for _, sid := range ids {
 		state, _ := d.repo.Load(sid)
 		// Fire before the delete so a re-key handler's own Load(sid) is
-		// guaranteed to still succeed (issue #997).
-		if d.onSessionSuperseded != nil {
-			d.onSessionSuperseded(sid, newSessionID)
+		// guaranteed to still succeed (issue #997). Read directly off pidMgr
+		// (same package) rather than keeping a second copy of the handler here.
+		if d.pidMgr.onSessionSuperseded != nil {
+			d.pidMgr.onSessionSuperseded(sid, newSessionID)
 		}
 		_ = d.repo.Delete(sid)
 		adapterName := adapter

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -101,22 +101,30 @@ func (d *SessionDetector) cleanupPreSessionsForProject(projectDir, realCWD, adap
 	}
 
 	for _, sid := range ids {
-		state, _ := d.repo.Load(sid)
-		// Fire before the delete so a re-key handler's own Load(sid) is
-		// guaranteed to still succeed (issue #997). Read directly off pidMgr
-		// (same package) rather than keeping a second copy of the handler here.
-		if d.pidMgr.onSessionSuperseded != nil {
-			d.pidMgr.onSessionSuperseded(sid, newSessionID)
-		}
-		_ = d.repo.Delete(sid)
-		adapterName := adapter
-		if state != nil {
-			adapterName = state.Adapter
-			d.broadcast(outbound.PushTypeDeleted, state)
-		}
-		d.record(lifecycle.Event{Kind: lifecycle.KindPreSessionRemoved, SessionID: sid, Adapter: adapterName, Reason: "superseded by real session for project"})
-		d.log.LogInfo(logComponentSessionDetector, sid,
-			fmt.Sprintf("removed pre-session — real session arrived in %s", projectDir))
+		d.retirePreSession(sid, newSessionID, adapter, projectDir)
 	}
 	return len(ids) > 0
+}
+
+// retirePreSession fires the supersession hook and deletes a single retired
+// pre-session, then records + logs its removal. Extracted from
+// cleanupPreSessionsForProject's per-id loop to keep that function's
+// cognitive complexity down — pure refactor, no behavior change (issue #997).
+func (d *SessionDetector) retirePreSession(sid, newSessionID, adapter, projectDir string) {
+	state, _ := d.repo.Load(sid)
+	// Fire before the delete so a re-key handler's own Load(sid) is
+	// guaranteed to still succeed (issue #997). Read directly off pidMgr
+	// (same package) rather than keeping a second copy of the handler here.
+	if d.pidMgr.onSessionSuperseded != nil {
+		d.pidMgr.onSessionSuperseded(sid, newSessionID)
+	}
+	_ = d.repo.Delete(sid)
+	adapterName := adapter
+	if state != nil {
+		adapterName = state.Adapter
+		d.broadcast(outbound.PushTypeDeleted, state)
+	}
+	d.record(lifecycle.Event{Kind: lifecycle.KindPreSessionRemoved, SessionID: sid, Adapter: adapterName, Reason: "superseded by real session for project"})
+	d.log.LogInfo(logComponentSessionDetector, sid,
+		fmt.Sprintf("removed pre-session — real session arrived in %s", projectDir))
 }

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -65,7 +65,10 @@ func (d *SessionDetector) broadcast(msgType string, state *session.SessionState)
 // arrived. Returns whether at least one pre-session was actually retired —
 // callers feed this into ShouldSynthesizeCatchUpTurn (state_classifier.go)
 // as its "was this daemon already live-tracking the process" signal.
-func (d *SessionDetector) cleanupPreSessionsForProject(projectDir, realCWD, adapter string) bool {
+// newSessionID (the real session's id) lets it fire onSessionSuperseded so
+// TerminalObserver/SessionDetector can carry per-session backchannel state
+// forward before the pre-session row is deleted (issue #997).
+func (d *SessionDetector) cleanupPreSessionsForProject(projectDir, realCWD, adapter, newSessionID string) bool {
 	// Collect candidates under the lock; defer I/O (repo.Load) to outside.
 	d.mu.Lock()
 	var ids []string
@@ -99,6 +102,11 @@ func (d *SessionDetector) cleanupPreSessionsForProject(projectDir, realCWD, adap
 
 	for _, sid := range ids {
 		state, _ := d.repo.Load(sid)
+		// Fire before the delete so a re-key handler's own Load(sid) is
+		// guaranteed to still succeed (issue #997).
+		if d.onSessionSuperseded != nil {
+			d.onSessionSuperseded(sid, newSessionID)
+		}
 		_ = d.repo.Delete(sid)
 		adapterName := adapter
 		if state != nil {

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -191,6 +191,52 @@ func (d *SessionDetector) HandlePIDAssigned(pid int, sessionID string) {
 	d.pidMgr.HandlePIDAssigned(pid, sessionID)
 }
 
+// ReconcilePreSessionBackchannel carries a still-open trust-dialog Waiting
+// state from a presession onto the real session that superseded it (issue
+// #997). Every reconciliation path retires the presession by deleting its row
+// outright; if TerminalObserver had already forced it into Waiting via a
+// terminal read-back edge (handleTerminalUISignal persists that directly onto
+// the presession's own row), that fact is lost the moment the row disappears
+// unless it's copied forward first. Registered as (half of) the callback
+// SetSessionSupersededHandler installs — the other half re-keys
+// TerminalObserver's own edge-detection cache, wired alongside this one at
+// startup since SessionDetector has no reference to TerminalObserver.
+//
+// Runs under WithSessionStateLock, the same lock handleTerminalUISignal's own
+// load-modify-save takes, so this can't race a concurrent terminal-UI signal
+// for either id. A no-op when the presession was never forced into Waiting,
+// or when the new session already is (e.g. its own terminal-observer poll
+// already caught up).
+func (d *SessionDetector) ReconcilePreSessionBackchannel(oldID, newID string) {
+	d.pidMgr.WithSessionStateLock(func() {
+		old, err := d.repo.Load(oldID)
+		if err != nil || old == nil || old.State != session.StateWaiting {
+			return // nothing to carry forward
+		}
+		newState, err := d.repo.Load(newID)
+		if err != nil || newState == nil || newState.State == session.StateWaiting {
+			return // already waiting, or gone
+		}
+
+		prevState := newState.State
+		newState.State = session.StateWaiting
+		newState.WaitingStartTime = old.WaitingStartTime
+		newState.UpdatedAt = time.Now().Unix()
+		if err := d.repo.Save(newState); err != nil {
+			d.log.LogError(logComponentSessionDetector, newID,
+				fmt.Sprintf("failed to carry forward waiting state from presession %s: %v", oldID, err))
+			return
+		}
+
+		d.record(lifecycle.Event{
+			Kind: lifecycle.KindStateTransition, SessionID: newID,
+			PrevState: prevState, NewState: session.StateWaiting,
+			Reason: fmt.Sprintf("carried forward from superseded presession %s", oldID),
+		})
+		d.broadcast(outbound.PushTypeUpdated, newState)
+	})
+}
+
 // HandlePermissionHook processes a Claude Code PermissionRequest, PreToolUse,
 // PostToolUse, or PostToolUseFailure hook event. It updates the in-memory
 // permission-pending flag and injects a synthetic activity event to trigger

--- a/core/application/services/terminal_observer.go
+++ b/core/application/services/terminal_observer.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	"irrlicht/core/domain/backchannel"
@@ -43,8 +44,13 @@ type TerminalObserver struct {
 
 	// lastUI tracks the last UI kind seen per session so only edges
 	// (appear/clear) reach the event loop — one lifecycle record per dialog
-	// appearance, not one per poll. Owned by the ticker goroutine; no lock.
-	lastUI map[string]backchannel.UIKind
+	// appearance, not one per poll. Normally only the ticker goroutine
+	// (tick/observe) touches it, but RekeySession is also called from a
+	// presession-reconciliation call site (a PID-discovery or sweep
+	// goroutine, never the ticker) when a presession is superseded — issue
+	// #997 — so all access goes through lastUIMu.
+	lastUIMu sync.Mutex
+	lastUI   map[string]backchannel.UIKind
 }
 
 // NewTerminalObserver constructs a TerminalObserver. betaOn reports whether the
@@ -80,9 +86,11 @@ func (o *TerminalObserver) tick() {
 	if !o.betaOn() {
 		// Backchannel off: forget edge state so a re-enable detects cleanly
 		// instead of suppressing a dialog that was already on screen.
+		o.lastUIMu.Lock()
 		if len(o.lastUI) > 0 {
 			o.lastUI = make(map[string]backchannel.UIKind)
 		}
+		o.lastUIMu.Unlock()
 		return
 	}
 	states, err := o.repo.ListAll()
@@ -96,11 +104,13 @@ func (o *TerminalObserver) tick() {
 		o.observe(st.SessionID, st.Adapter)
 	}
 	// Drop edge state for sessions that have gone away.
+	o.lastUIMu.Lock()
 	for id := range o.lastUI {
 		if !seen[id] {
 			delete(o.lastUI, id)
 		}
 	}
+	o.lastUIMu.Unlock()
 }
 
 // observe captures one session and forwards a signal only when its UI state
@@ -121,9 +131,34 @@ func (o *TerminalObserver) observe(sessionID, adapter string) {
 		return
 	}
 	ui := backchannel.DetectUI(string(screen))
-	if ui == o.lastUI[sessionID] {
-		return // no edge
+
+	o.lastUIMu.Lock()
+	noEdge := ui == o.lastUI[sessionID]
+	if !noEdge {
+		o.lastUI[sessionID] = ui
 	}
-	o.lastUI[sessionID] = ui
+	o.lastUIMu.Unlock()
+	if noEdge {
+		return
+	}
 	o.sink.EnqueueTerminalUISignal(sessionID, ui)
+}
+
+// RekeySession moves oldID's lastUI entry (if any) onto newID, so a dialog
+// TerminalObserver already saw open on a presession isn't mistaken for a
+// fresh rising edge once the presession is superseded and its own id
+// retired — and so a later clearing poll compares against the carried-
+// forward kind and produces the falling edge against newID instead of a row
+// that no longer exists (issue #997). Called from a presession-reconciliation
+// call site, never the polling ticker, hence the lock shared with
+// tick()/observe(). A no-op when oldID has no tracked edge state.
+func (o *TerminalObserver) RekeySession(oldID, newID string) {
+	o.lastUIMu.Lock()
+	defer o.lastUIMu.Unlock()
+	ui, ok := o.lastUI[oldID]
+	if !ok {
+		return
+	}
+	delete(o.lastUI, oldID)
+	o.lastUI[newID] = ui
 }

--- a/core/application/services/terminal_observer_internal_test.go
+++ b/core/application/services/terminal_observer_internal_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"irrlicht/core/domain/backchannel"
 	"irrlicht/core/domain/lifecycle"
@@ -150,6 +151,54 @@ func TestObserverGates(t *testing.T) {
 	})
 }
 
+// --- RekeySession (presession→real-session reconciliation, issue #997) ---
+
+func TestRekeySession_CarriesEdgeStateForward(t *testing.T) {
+	reader := &uiReader{
+		readable: map[string]bool{"old": true, "new": true},
+		screen:   map[string]string{"old": "Do you want to proceed?"},
+	}
+	sink := &recordingSink{}
+	consent := uiConsent{map[string]bool{"claude-code": true}}
+	o := NewTerminalObserver(newUIRepo(), reader, consent, func() bool { return true }, sink, bcNopLog{})
+
+	// Presession sees the dialog rise.
+	o.observe("old", "claude-code")
+	if len(sink.got) != 1 || sink.got[0].ui != backchannel.UIKindTrustDialog {
+		t.Fatalf("presession rising edge: want 1 trust_dialog signal, got %v", sink.got)
+	}
+
+	// Reconciliation retires "old" in favor of "new".
+	o.RekeySession("old", "new")
+
+	// A poll of "new" showing the SAME still-open dialog must not re-fire as
+	// a fresh rising edge — the carried-forward state already reflects
+	// trust_dialog.
+	reader.screen["new"] = "Do you want to proceed?"
+	o.observe("new", "claude-code")
+	if len(sink.got) != 1 {
+		t.Fatalf("carried-forward dialog re-fired as a fresh rising edge: got %v", sink.got)
+	}
+
+	// When the dialog clears, the falling edge fires against "new" — the
+	// live id — not the retired "old".
+	reader.screen["new"] = "back to work"
+	o.observe("new", "claude-code")
+	if len(sink.got) != 2 || sink.got[1].sessionID != "new" || sink.got[1].ui != backchannel.UIKindNone {
+		t.Fatalf("clearing edge: want a UIKindNone signal for 'new', got %v", sink.got)
+	}
+}
+
+func TestRekeySession_NoOpWhenSourceUntracked(t *testing.T) {
+	o := NewTerminalObserver(newUIRepo(), &uiReader{}, uiConsent{}, func() bool { return true }, &recordingSink{}, bcNopLog{})
+
+	o.RekeySession("missing", "new") // must not panic or create a spurious entry
+
+	if _, ok := o.lastUI["new"]; ok {
+		t.Fatal("RekeySession should not create an entry when the source id was never tracked")
+	}
+}
+
 // --- fusion (handleTerminalUISignal applies state on the single writer) ---
 
 // newFusionDetector builds a real SessionDetector (so handleTerminalUISignal's
@@ -253,6 +302,71 @@ func TestHandleTerminalUISignal_ClearingWhileWorkingNoOp(t *testing.T) {
 	}
 	if len(rec.events) != 0 {
 		t.Fatalf("clearing while working: want no events, got %v", rec.events)
+	}
+}
+
+// --- ReconcilePreSessionBackchannel (presession→real-session reconciliation,
+// issue #997) ---
+
+func TestReconcilePreSessionBackchannel_CarriesWaitingForward(t *testing.T) {
+	now := time.Now().Unix()
+	old := &session.SessionState{
+		SessionID: "proc-42", Adapter: "mistral-vibe", State: session.StateWaiting,
+		WaitingStartTime: &now,
+	}
+	newSt := &session.SessionState{
+		SessionID: "session_new", Adapter: "mistral-vibe", State: session.StateReady,
+	}
+	d, rec := newFusionDetector(newUIRepo(old, newSt))
+
+	d.ReconcilePreSessionBackchannel(old.SessionID, newSt.SessionID)
+
+	if newSt.State != session.StateWaiting {
+		t.Fatalf("reconciled session state = %q, want waiting", newSt.State)
+	}
+	if newSt.WaitingStartTime == nil || *newSt.WaitingStartTime != now {
+		t.Fatalf("WaitingStartTime not carried forward: got %v, want %d", newSt.WaitingStartTime, now)
+	}
+	if !rec.hasTransitionTo(session.StateWaiting) {
+		t.Error("expected a state_transition to waiting on the reconciled session")
+	}
+}
+
+func TestReconcilePreSessionBackchannel_NoOpWhenPresessionNeverWaited(t *testing.T) {
+	old := &session.SessionState{SessionID: "proc-42", Adapter: "mistral-vibe", State: session.StateReady}
+	newSt := &session.SessionState{SessionID: "session_new", Adapter: "mistral-vibe", State: session.StateReady}
+	d, rec := newFusionDetector(newUIRepo(old, newSt))
+
+	d.ReconcilePreSessionBackchannel(old.SessionID, newSt.SessionID)
+
+	if newSt.State != session.StateReady {
+		t.Fatalf("untouched session state = %q, want ready", newSt.State)
+	}
+	if len(rec.events) != 0 {
+		t.Fatalf("want no events when the presession never waited, got %v", rec.events)
+	}
+}
+
+func TestReconcilePreSessionBackchannel_NoOpWhenNewAlreadyWaiting(t *testing.T) {
+	oldStart := time.Now().Add(-time.Minute).Unix()
+	old := &session.SessionState{
+		SessionID: "proc-42", Adapter: "mistral-vibe", State: session.StateWaiting,
+		WaitingStartTime: &oldStart,
+	}
+	newStart := time.Now().Unix()
+	newSt := &session.SessionState{
+		SessionID: "session_new", Adapter: "mistral-vibe", State: session.StateWaiting,
+		WaitingStartTime: &newStart,
+	}
+	d, rec := newFusionDetector(newUIRepo(old, newSt))
+
+	d.ReconcilePreSessionBackchannel(old.SessionID, newSt.SessionID)
+
+	if newSt.WaitingStartTime == nil || *newSt.WaitingStartTime != newStart {
+		t.Fatalf("already-waiting session's own WaitingStartTime should not be overwritten: got %v, want %d", newSt.WaitingStartTime, newStart)
+	}
+	if len(rec.events) != 0 {
+		t.Fatalf("want no events when the reconciled session is already waiting, got %v", rec.events)
 	}
 }
 

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -876,6 +876,17 @@ func setupBackchannel(mux *http.ServeMux, deps setupBackchannelDeps) (*services.
 	terminalReader := control.NewReader(deps.CachedRepo, logger)
 	terminalObserver := services.NewTerminalObserver(deps.CachedRepo, terminalReader, deps.PermService, backchannelStore.Enabled, deps.Detector, logger)
 
+	// Re-key the presession's backchannel bookkeeping onto the reconciled
+	// real session whenever any reconciliation path retires a presession
+	// (issue #997): SessionDetector carries forward any Waiting state a live
+	// terminal-observer signal already persisted onto the presession's own
+	// row, and TerminalObserver re-keys its own edge-detection cache so the
+	// next poll compares against the right session id.
+	deps.Detector.SetSessionSupersededHandler(func(oldID, newID string) {
+		deps.Detector.ReconcilePreSessionBackchannel(oldID, newID)
+		terminalObserver.RekeySession(oldID, newID)
+	})
+
 	return backchannelEngine, terminalObserver
 }
 

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -881,9 +881,12 @@ func setupBackchannel(mux *http.ServeMux, deps setupBackchannelDeps) (*services.
 	// (issue #997): SessionDetector carries forward any Waiting state a live
 	// terminal-observer signal already persisted onto the presession's own
 	// row, and TerminalObserver re-keys its own edge-detection cache so the
-	// next poll compares against the right session id.
-	deps.Detector.SetSessionSupersededHandler(func(oldID, newID string) {
-		deps.Detector.ReconcilePreSessionBackchannel(oldID, newID)
+	// next poll compares against the right session id. Bind the one
+	// long-lived reference this closure needs (detector) instead of closing
+	// over the whole setupBackchannelDeps struct.
+	detector := deps.Detector
+	detector.SetSessionSupersededHandler(func(oldID, newID string) {
+		detector.ReconcilePreSessionBackchannel(oldID, newID)
 		terminalObserver.RekeySession(oldID, newID)
 	})
 


### PR DESCRIPTION
## Summary

`TerminalObserver`'s edge-detection cache (`lastUI`, keyed by session id) and
any `Waiting` state `handleTerminalUISignal` persisted were both keyed to the
**transient presession id** (`proc-<PID>`). When reconciliation later retired
the presession in favor of the **real session** that superseded it (same-PID
match, or project/CWD match), that state was discarded along with the deleted
presession row instead of carrying forward — so a trust dialog observed via
terminal read-back before reconciliation vanished from the session everything
else (the fixture, the UI, any downstream observer) actually tracks.

This was surfaced re-recording `6-2_backchannel-observe` against the marker
fix from #988 — the marker fix is confirmed correct; this is the separate,
newly-exposed identity-reconciliation gap described in #997.

## Fix

Adds a `SetSessionSupersededHandler(oldID, newID string)` callback — the same
shape as the existing `SetChildDeletedHandler`/`onSessionDeleted` idiom —
fired from every reconciliation path that retires a presession, before its row
is deleted:

- `cleanupStalePIDHolders` (same-PID match — the path that actually fired in
  the recording)
- `sweepSupersededPreSessions` / `sweepSupersededPreSessionsPeriodic`
  (seed-time and periodic pre-session sweeps)
- `cleanupPreSessionsForProject` (project/CWD match)

A single registration (wired once in `startup.go`) fans out to both halves:
- `SessionDetector.ReconcilePreSessionBackchannel` copies a `Waiting`
  state + `WaitingStartTime` forward onto the real session's row.
- `TerminalObserver.RekeySession` moves the `lastUI` edge-detection entry
  onto the new id (now behind a mutex, since the rekey call arrives from a
  different goroutine than the polling ticker).

A plain same-PID **dedup** of two real sessions (`dedupeByPID`, e.g. an orphan
left by `/clear`) deliberately does NOT fire the hook — there's no single
superseding identity to re-key state onto for that case.

## Tests

- `terminal_observer_internal_test.go` — `RekeySession` carries/discards edge
  state correctly; `ReconcilePreSessionBackchannel` carries `Waiting` state
  forward (and is a no-op when the presession never waited, or the real
  session is already waiting).
- `pid_manager_test.go` — a spy proves `onSessionSuperseded` fires with the
  right `(oldID, newID)` pair at each of the three PIDManager-owned call
  sites, and does NOT fire for the plain dedup path.
- `session_detector_backchannel_reconcile_test.go` (new) — an end-to-end
  regression reproducing the exact recorded sequence: presession dialog
  opens → real session born → PID reconciles → dialog closes. Verified this
  test actually fails without the fix (temporarily disabled the wiring
  locally, confirmed the reconciled session lands on `ready` instead of
  `waiting`) before restoring it.

Full suite green: `go test ./core/... -race -count=1`, `tools/preflight.sh`
(gofmt, full test matrix, replaydata validate, recording-rig smoke test,
ARS gate, security scan) — all pass.

## Re-recording attempt (inline, per plan)

Attempted to re-record `6-2_backchannel-observe` live against a daemon built
from this branch (coexisting on an alternate port alongside the running
production daemon, so as not to disturb it) to get concrete proof the fixture
flips to 7/7. Two attempts hit driver-timing issues unrelated to this fix
(fixed-sleep recipe timing vs. mistral-vibe's variable API latency — see
#1003): attempt 1 never got a session dir within the recipe's fixed window
(model stuck "Generating…"); attempt 2 completed the whole turn in ~1s —
faster than the terminal-observer's 1Hz poll — so zero `ui_detected` events
fired at all, making it non-diagnostic for #997. Both attempts were discarded
(never committed); the repo and the existing committed recording are
untouched. Filed as a fast-follow (#1003) rather than stalling this PR, since
the daemon-side fix has its own unit + e2e regression coverage independent of
a fresh live capture.

## Follow-up issues filed

- #1002 — `BackchannelEngine` (`core/application/services/backchannel_service.go`)
  has the identical per-session-map-not-rekeyed shape in a different
  subsystem — deliberately out of scope here (issue #997 named
  `terminal_observer.go` specifically).
- #1003 — the mistral-vibe driver recipe's fixed-sleep timing vs. the CLI's
  variable API latency, which blocked the inline re-recording attempt above.

Closes #997

🤖 Generated with [Claude Code](https://claude.com/claude-code)