### PR TITLE
fix(test-mac): stamp dev version string in replace-mode Info.plist

### DIFF
--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -233,6 +233,14 @@ independent axes:
          # sees the same result in replace mode as in separate mode instead of
          # a stale production copy.
          cp "$REPO_ROOT/platforms/macos/Irrlicht/Resources/AppIcon.icns" "$APP_TARGET/Contents/Resources/AppIcon.icns"
+         # Stamp the version string too — otherwise Info.plist still carries
+         # whatever release version was last installed (e.g. "0.5.7"), so
+         # Settings/About would show a stale release version on a dev build
+         # even though the binary itself is freshly compiled from source.
+         # Matches separate mode's hardcoded "dev" (see its Info.plist template
+         # below) so both modes read the same in the UI.
+         /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString dev" "$APP_TARGET/Contents/Info.plist"
+         /usr/libexec/PlistBuddy -c "Set :CFBundleVersion dev" "$APP_TARGET/Contents/Info.plist"
          # The SwiftPM debug binary links Sparkle as @rpath/Sparkle.framework but only
          # carries an @loader_path rpath (= Contents/MacOS) — it lacks the bundle-layout
          # rpath a release .app build adds. Without this, dyld can't find the embedded


### PR DESCRIPTION
## Summary
- `ir:test-mac` in `replace` mode (the default since #786) installs the dev build straight into `/Applications/Irrlicht.app` but never touched `CFBundleShortVersionString`, so the app's Settings/About panel kept showing the last-installed release version (e.g. `0.5.7`) instead of `dev`, even though the daemon/app binaries underneath were freshly built from source.
- Stamp `CFBundleShortVersionString` and `CFBundleVersion` to `dev` in the replace-mode install step, matching what `separate` mode's Info.plist template already hardcodes.
- Reversible: the production backup (`PROD_BACKUP`) is taken before this mutation, so `restore-prod.sh` still restores the true original bundle on teardown.

## Test plan
- [x] Dry-ran the `PlistBuddy -c "Set ..."` commands against a scratch copy of the installed `Info.plist` to confirm the syntax/keys are correct.
- [ ] Run `/ir:test-mac` (replace/full) from this branch and confirm Settings/About shows `dev` instead of the last release version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)