### PR TITLE
fix(backchannel): re-key BackchannelEngine's edge state across presession reconciliation

### DIFF
--- a/core/application/services/backchannel_service.go
+++ b/core/application/services/backchannel_service.go
@@ -237,30 +237,10 @@ func (e *BackchannelEngine) RekeySession(oldID, newID string) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	if v, ok := e.prevState[oldID]; ok {
-		delete(e.prevState, oldID)
-		if _, exists := e.prevState[newID]; !exists {
-			e.prevState[newID] = v
-		}
-	}
-	if v, ok := e.prevUtil[oldID]; ok {
-		delete(e.prevUtil, oldID)
-		if _, exists := e.prevUtil[newID]; !exists {
-			e.prevUtil[newID] = v
-		}
-	}
-	if v, ok := e.prevTokens[oldID]; ok {
-		delete(e.prevTokens, oldID)
-		if _, exists := e.prevTokens[newID]; !exists {
-			e.prevTokens[newID] = v
-		}
-	}
-	if v, ok := e.recent[oldID]; ok {
-		delete(e.recent, oldID)
-		if _, exists := e.recent[newID]; !exists {
-			e.recent[newID] = v
-		}
-	}
+	rekeyMapEntry(e.prevState, oldID, newID)
+	rekeyMapEntry(e.prevUtil, oldID, newID)
+	rekeyMapEntry(e.prevTokens, oldID, newID)
+	rekeyMapEntry(e.recent, oldID, newID)
 
 	oldSuffix := "\x00" + oldID
 	newSuffix := "\x00" + newID
@@ -273,6 +253,23 @@ func (e *BackchannelEngine) RekeySession(oldID, newID string) {
 		if _, exists := e.lastFired[newKey]; !exists {
 			e.lastFired[newKey] = v
 		}
+	}
+}
+
+// rekeyMapEntry moves m[oldID] onto m[newID], but only when newID doesn't
+// already have an entry (see RekeySession's fill-if-absent rationale) — a
+// no-op when oldID has no tracked entry. Shared by every scalar per-session
+// map RekeySession carries forward; lastFired's composite-key rewrite
+// doesn't fit this shape (it matches by suffix, not by direct key) so it
+// stays inline in RekeySession.
+func rekeyMapEntry[V any](m map[string]V, oldID, newID string) {
+	v, ok := m[oldID]
+	if !ok {
+		return
+	}
+	delete(m, oldID)
+	if _, exists := m[newID]; !exists {
+		m[newID] = v
 	}
 }
 

--- a/core/application/services/backchannel_service.go
+++ b/core/application/services/backchannel_service.go
@@ -216,6 +216,66 @@ func (e *BackchannelEngine) forget(sessionID string) {
 	}
 }
 
+// RekeySession moves oldID's per-session bookkeeping onto newID when a
+// presession (proc-<PID>) is reconciled into the real session that
+// superseded it — otherwise an edge-crossing baseline already established on
+// the presession (e.g. context utilization already past a rule's threshold)
+// is discarded outright, and the real session re-establishes a fresh
+// "first sight, never fire" baseline on its own id instead of firing on the
+// crossing that already happened (issue #1002, mirroring TerminalObserver.
+// RekeySession from issue #997 — see that method for the analogous fix on a
+// different subsystem's per-session cache).
+//
+// Unlike TerminalObserver's unconditional overwrite, this only fills newID's
+// entry when it doesn't already have one: if the real session already
+// observed its own baseline independently (its first live push arrived
+// before the reconciliation hook fired), overwriting it with the
+// presession's older reading could revert already-advanced state and cause a
+// rule to fire twice for one crossing — worse than the bug being fixed here.
+// A no-op for any map where oldID has no tracked entry.
+func (e *BackchannelEngine) RekeySession(oldID, newID string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if v, ok := e.prevState[oldID]; ok {
+		delete(e.prevState, oldID)
+		if _, exists := e.prevState[newID]; !exists {
+			e.prevState[newID] = v
+		}
+	}
+	if v, ok := e.prevUtil[oldID]; ok {
+		delete(e.prevUtil, oldID)
+		if _, exists := e.prevUtil[newID]; !exists {
+			e.prevUtil[newID] = v
+		}
+	}
+	if v, ok := e.prevTokens[oldID]; ok {
+		delete(e.prevTokens, oldID)
+		if _, exists := e.prevTokens[newID]; !exists {
+			e.prevTokens[newID] = v
+		}
+	}
+	if v, ok := e.recent[oldID]; ok {
+		delete(e.recent, oldID)
+		if _, exists := e.recent[newID]; !exists {
+			e.recent[newID] = v
+		}
+	}
+
+	oldSuffix := "\x00" + oldID
+	newSuffix := "\x00" + newID
+	for k, v := range e.lastFired {
+		if !strings.HasSuffix(k, oldSuffix) {
+			continue
+		}
+		delete(e.lastFired, k)
+		newKey := strings.TrimSuffix(k, oldSuffix) + newSuffix
+		if _, exists := e.lastFired[newKey]; !exists {
+			e.lastFired[newKey] = v
+		}
+	}
+}
+
 // triggered reports whether a trigger matches this transition. State triggers
 // fire on the edge into the state; context_pressure / context_pressure_tokens
 // fire on the rising crossing of the threshold (hysteresis is inherent in

--- a/core/application/services/backchannel_service_test.go
+++ b/core/application/services/backchannel_service_test.go
@@ -283,3 +283,139 @@ func TestEvaluate_AdapterScope(t *testing.T) {
 		t.Fatalf("rule scoped to another adapter must not fire, got %d", len(got))
 	}
 }
+
+// --- RekeySession (issue #1002, mirroring TerminalObserver's #997 fix) ---
+
+// sessID is sess/sessTokens with a caller-chosen SessionID, for RekeySession
+// tests that need two distinct ids (the presession's and the reconciled real
+// session's) in play at once.
+func sessID(id, state string, util float64) *session.SessionState {
+	s := sess(state, util)
+	s.SessionID = id
+	return s
+}
+
+func TestBackchannelRekeySession_CarriesBaselineForwardSoThresholdCrossingIsCaught(t *testing.T) {
+	on := true
+	clk := time.Unix(1000, 0)
+	r := backchannel.Rule{ID: "p", Enabled: true,
+		Trigger:         backchannel.Trigger{Event: backchannel.EventContextPressure, Threshold: 80},
+		Actions:         []backchannel.Action{{Kind: backchannel.ActionInput, Data: "/compact\r"}},
+		CooldownSeconds: 1}
+	e := newEngine([]backchannel.Rule{r}, &on, &clk)
+
+	// The presession accumulates a below-threshold baseline before it's
+	// reconciled — the crossing hasn't happened yet, so nothing fires here.
+	e.evaluate(sessID("proc-123", "working", 50)) // baseline
+	if got := e.evaluate(sessID("proc-123", "working", 70)); got != nil {
+		t.Fatalf("still below threshold must not fire, got %d", len(got))
+	}
+
+	// Reconciliation: the presession is retired in favor of the real session.
+	e.RekeySession("proc-123", "real-abc")
+
+	// The real session's first-ever observation crosses the threshold. Without
+	// the carried-forward baseline this would hit the "!seen" branch and
+	// establish a fresh baseline instead of firing (issue #1002).
+	if got := e.evaluate(sessID("real-abc", "working", 85)); len(got) != 1 {
+		t.Fatalf("carried-forward baseline should let the crossing fire, got %d", len(got))
+	}
+}
+
+func TestBackchannelRekeySession_RemovesOldEntries(t *testing.T) {
+	on := true
+	clk := time.Unix(1000, 0)
+	e := newEngine([]backchannel.Rule{waitingRule()}, &on, &clk)
+
+	e.evaluate(sessID("proc-1", "working", 0)) // baseline
+	if len(e.evaluate(sessID("proc-1", "waiting", 0))) != 1 {
+		t.Fatal("first waiting edge should fire")
+	}
+
+	e.RekeySession("proc-1", "real-1")
+
+	e.mu.Lock()
+	_, stateLeft := e.prevState["proc-1"]
+	_, utilLeft := e.prevUtil["proc-1"]
+	_, firedLeft := e.lastFired["r1\x00proc-1"]
+	e.mu.Unlock()
+	if stateLeft || utilLeft || firedLeft {
+		t.Fatalf("RekeySession left old entries behind: state=%v util=%v fired=%v", stateLeft, utilLeft, firedLeft)
+	}
+
+	e.mu.Lock()
+	newState, stateMoved := e.prevState["real-1"]
+	_, firedMoved := e.lastFired["r1\x00real-1"]
+	e.mu.Unlock()
+	if !stateMoved || newState != "waiting" || !firedMoved {
+		t.Fatalf("RekeySession did not carry entries onto the new id: state=%q moved=%v fired=%v", newState, stateMoved, firedMoved)
+	}
+}
+
+func TestBackchannelRekeySession_DoesNotClobberExistingDestinationBaseline(t *testing.T) {
+	on := true
+	clk := time.Unix(1000, 0)
+	r := backchannel.Rule{ID: "p", Enabled: true,
+		Trigger:         backchannel.Trigger{Event: backchannel.EventContextPressure, Threshold: 80},
+		Actions:         []backchannel.Action{{Kind: backchannel.ActionInput, Data: "/compact\r"}},
+		CooldownSeconds: 1}
+	e := newEngine([]backchannel.Rule{r}, &on, &clk)
+
+	// The presession's own (stale) baseline.
+	e.evaluate(sessID("proc-1", "working", 90)) // baseline, already "high"
+
+	// The real session has ALREADY been observed independently — its own
+	// baseline is below threshold — before the reconciliation hook fires.
+	e.evaluate(sessID("real-1", "working", 60)) // baseline
+
+	e.RekeySession("proc-1", "real-1")
+
+	e.mu.Lock()
+	util := e.prevUtil["real-1"]
+	e.mu.Unlock()
+	if util != 60 {
+		t.Fatalf("RekeySession must not clobber an already-established destination baseline: prevUtil[real-1] = %v, want 60", util)
+	}
+
+	// Confirms the guard is load-bearing: crossing from the (preserved) 60
+	// baseline still fires normally.
+	if len(e.evaluate(sessID("real-1", "working", 85))) != 1 {
+		t.Fatal("crossing from the preserved real-session baseline should still fire")
+	}
+}
+
+func TestBackchannelRekeySession_CarriesCooldownForward(t *testing.T) {
+	on := true
+	clk := time.Unix(1000, 0)
+	r := waitingRule()
+	r.CooldownSeconds = 60
+	e := newEngine([]backchannel.Rule{r}, &on, &clk)
+
+	e.evaluate(sessID("proc-1", "working", 0))
+	if len(e.evaluate(sessID("proc-1", "waiting", 0))) != 1 {
+		t.Fatal("first waiting edge should fire")
+	}
+
+	e.RekeySession("proc-1", "real-1")
+	e.evaluate(sessID("real-1", "working", 0)) // leave waiting
+
+	clk = clk.Add(5 * time.Second) // well within the 60s cooldown
+	if got := e.evaluate(sessID("real-1", "waiting", 0)); got != nil {
+		t.Fatalf("cooldown recorded on the presession should still suppress a re-fire on the reconciled id, got %d", len(got))
+	}
+}
+
+func TestBackchannelRekeySession_NoOpWhenSourceUntracked(t *testing.T) {
+	on := true
+	clk := time.Unix(1000, 0)
+	e := newEngine([]backchannel.Rule{waitingRule()}, &on, &clk)
+
+	e.RekeySession("never-seen", "real-1") // must not panic or create a spurious entry
+
+	e.mu.Lock()
+	_, ok := e.prevState["real-1"]
+	e.mu.Unlock()
+	if ok {
+		t.Fatal("RekeySession should not create an entry when the source id was never tracked")
+	}
+}

--- a/core/application/services/session_detector_backchannel_reconcile_test.go
+++ b/core/application/services/session_detector_backchannel_reconcile_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"testing"
+	"time"
 
 	"irrlicht/core/domain/backchannel"
 	"irrlicht/core/domain/session"
@@ -111,5 +112,86 @@ func TestBackchannelReconciliation_PreSessionToRealSession_Issue997(t *testing.T
 	// stale/looser string.
 	if backchannel.DetectUI(`Permission for the bash tool (touch *)`) != backchannel.UIKindTrustDialog {
 		t.Fatal("test fixture screen text no longer matches DetectUI's trust-dialog markers")
+	}
+}
+
+// TestBackchannelReconciliation_PreSessionToRealSession_Issue1002 is the
+// end-to-end regression for issue #1002, the follow-up #997 deliberately
+// scoped out: BackchannelEngine keeps its own per-session edge-crossing
+// baselines (prevState/prevUtil/prevTokens/lastFired), separate from
+// TerminalObserver's dialog-edge cache, and they had the identical gap —
+// dropped instead of carried forward across presession reconciliation.
+//
+//  1. A presession (proc-<PID>) accumulates a below-threshold context
+//     baseline (mirrors evaluate() being fed each push update the way
+//     BackchannelEngine.Run() would).
+//  2. The real session is born and PID discovery reconciles it onto the same
+//     PID (cleanupStalePIDHolders — the same call site #997/#1002 both fix),
+//     retiring (deleting) the presession.
+//  3. The real session's first observation crosses the rule's threshold.
+//
+// Before #1002's fix, step 2's forget(presessionID) discarded the baseline
+// outright, so step 3 hit evaluate's "!seen" branch and silently established
+// a fresh baseline instead of firing on the crossing that already happened
+// relative to the presession's observed history. This test wires
+// BackchannelEngine into the exact SetSessionSupersededHandler closure
+// core/cmd/irrlichd/startup.go's setupBackchannel uses (all three re-key
+// calls fanned out from one registration) and asserts the crossing fires on
+// the reconciled real session instead of being silently swallowed.
+func TestBackchannelReconciliation_PreSessionToRealSession_Issue1002(t *testing.T) {
+	const presessionID = "proc-59048"
+	const realSessionID = "session_20260713_120000_deadbeef"
+	const pid = 59048
+	const adapter = "mistral-vibe"
+
+	repo := newUIRepo(&session.SessionState{
+		SessionID: presessionID, Adapter: adapter, State: session.StateReady, PID: pid,
+	})
+	d, _ := newFusionDetector(repo)
+
+	on := true
+	clk := time.Unix(1000, 0)
+	rule := backchannel.Rule{ID: "ctx", Enabled: true,
+		Trigger:         backchannel.Trigger{Event: backchannel.EventContextPressure, Threshold: 80},
+		Actions:         []backchannel.Action{{Kind: backchannel.ActionInput, Data: "/compact\r"}},
+		CooldownSeconds: 1}
+	e := newEngine([]backchannel.Rule{rule}, &on, &clk)
+
+	// Wire the reconciliation callback exactly as setupBackchannel does in
+	// startup.go: a single registration fans out to all three re-key calls
+	// (this test only exercises the BackchannelEngine third of it).
+	d.SetSessionSupersededHandler(func(oldID, newID string) {
+		d.ReconcilePreSessionBackchannel(oldID, newID)
+		e.RekeySession(oldID, newID)
+	})
+
+	// Step 1: the presession accumulates a below-threshold baseline — the
+	// crossing hasn't happened yet, so nothing fires here.
+	e.evaluate(&session.SessionState{SessionID: presessionID, Adapter: adapter, State: session.StateWorking,
+		Metrics: &session.SessionMetrics{ContextUtilization: 50}}) // baseline
+	if got := e.evaluate(&session.SessionState{SessionID: presessionID, Adapter: adapter, State: session.StateWorking,
+		Metrics: &session.SessionMetrics{ContextUtilization: 70}}); got != nil {
+		t.Fatalf("still below threshold must not fire, got %d", len(got))
+	}
+
+	// Step 2: the real session is born and PID discovery reconciles it onto
+	// the same PID — the exact path that fired in the #997 recording
+	// (cleanupStalePIDHolders) — and must carry BackchannelEngine's baseline
+	// forward before deleting the presession.
+	if err := d.repo.Save(&session.SessionState{
+		SessionID: realSessionID, Adapter: adapter, State: session.StateReady,
+	}); err != nil {
+		t.Fatalf("seed real session: %v", err)
+	}
+	d.pidMgr.HandlePIDAssigned(pid, realSessionID)
+
+	if _, err := d.repo.Load(presessionID); err == nil {
+		t.Fatal("presession should have been deleted by reconciliation")
+	}
+
+	// Step 3: the real session's first observation crosses the threshold.
+	if got := e.evaluate(&session.SessionState{SessionID: realSessionID, Adapter: adapter, State: session.StateWorking,
+		Metrics: &session.SessionMetrics{ContextUtilization: 85}}); len(got) != 1 {
+		t.Fatalf("carried-forward baseline should let the crossing fire on the reconciled session (issue #1002), got %d", len(got))
 	}
 }

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -878,16 +878,22 @@ func setupBackchannel(mux *http.ServeMux, deps setupBackchannelDeps) (*services.
 
 	// Re-key the presession's backchannel bookkeeping onto the reconciled
 	// real session whenever any reconciliation path retires a presession
-	// (issue #997): SessionDetector carries forward any Waiting state a live
-	// terminal-observer signal already persisted onto the presession's own
-	// row, and TerminalObserver re-keys its own edge-detection cache so the
-	// next poll compares against the right session id. Bind the one
-	// long-lived reference this closure needs (detector) instead of closing
-	// over the whole setupBackchannelDeps struct.
+	// (issue #997, extended by #1002): SessionDetector carries forward any
+	// Waiting state a live terminal-observer signal already persisted onto
+	// the presession's own row, TerminalObserver re-keys its own
+	// edge-detection cache so the next poll compares against the right
+	// session id, and BackchannelEngine re-keys its own edge-crossing
+	// baselines (prevState/prevUtil/prevTokens/lastFired) so a rule that
+	// already crossed its threshold on the presession fires against the
+	// reconciled id instead of the real session silently re-establishing a
+	// fresh "first sight" baseline (issue #1002). Bind the one long-lived
+	// reference this closure needs (detector) instead of closing over the
+	// whole setupBackchannelDeps struct.
 	detector := deps.Detector
 	detector.SetSessionSupersededHandler(func(oldID, newID string) {
 		detector.ReconcilePreSessionBackchannel(oldID, newID)
 		terminalObserver.RekeySession(oldID, newID)
+		backchannelEngine.RekeySession(oldID, newID)
 	})
 
 	return backchannelEngine, terminalObserver


### PR DESCRIPTION
## Summary

`BackchannelEngine.evaluate` keeps four per-session maps (`prevState`,
`prevUtil`, `prevTokens`, `lastFired`) plus a `recent` fire-timestamp list,
all keyed by session id, to edge-detect rule crossings (e.g. "context
pressure crossed 80% → fire `/compact`"). When a presession (`proc-<PID>`)
was reconciled into its real session, `forget(oldID)` simply dropped these
rows instead of carrying them onto the new id — so the real session silently
re-established a fresh "first sight, never fire" baseline instead of firing
on a crossing that already happened relative to the presession's observed
history. This is the same shape of bug issue #997 fixed for
`TerminalObserver`, deliberately left out of that issue's scope as a
follow-up (#1002).

- Adds `BackchannelEngine.RekeySession(oldID, newID)`, wired into the same
  `SetSessionSupersededHandler` closure #997 introduced in
  `core/cmd/irrlichd/startup.go`'s `setupBackchannel`, alongside
  `ReconcilePreSessionBackchannel` and `TerminalObserver.RekeySession`.
- Deliberate deviation from `TerminalObserver.RekeySession`'s unconditional
  overwrite: fills `newID`'s entries only when absent. If the real session
  already established its own baseline independently before the
  reconciliation hook fired, overwriting it with the presession's older
  reading could revert already-advanced state and cause a rule to fire
  *twice* for one crossing — worse than the bug being fixed.
- A known, accepted limitation (documented in code and in the review): there
  is a benign cross-goroutine race between the synchronous `RekeySession`
  call and `BackchannelEngine.Run()`'s asynchronous `forget(oldID)` (fired
  when it separately consumes the presession's `PushTypeDeleted` broadcast).
  If `forget` wins, the fix silently no-ops for that one reconciliation —
  the same failure mode described in the issue, not a new or worse one.

Closes #1002

## Test plan

- [x] `go test ./core/... -race -count=1` — full suite green (includes the
      architecture test and the headless daemon smoke test)
- [x] New unit tests in `backchannel_service_test.go`
      (`TestBackchannelRekeySession_*`): carries a below-threshold baseline
      forward so a crossing on the reconciled id fires correctly, removes
      old entries, does not clobber an already-established destination
      baseline, carries a cooldown forward, no-ops when the source id was
      never tracked.
- [x] New end-to-end regression
      `TestBackchannelReconciliation_PreSessionToRealSession_Issue1002` in
      `session_detector_backchannel_reconcile_test.go`, wiring
      `SetSessionSupersededHandler` exactly as `startup.go`'s
      `setupBackchannel` does, alongside the existing #997 regression.
- [x] `tools/preflight.sh` (via the pre-push hook) — gofmt, full core+tools
      test suite, replaydata validate, web suites, ARS architecture gate,
      security scan — all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)