### PR TITLE
fix(onboarding-factory): condition-based dialog wait for mistral-vibe's tool-permission step

### DIFF
--- a/replaydata/agents/mistral-vibe/driver-interactive.sh
+++ b/replaydata/agents/mistral-vibe/driver-interactive.sh
@@ -347,7 +347,7 @@ wait_turn() {
       return 0
     fi
     if tmux capture-pane -t "$SESSION" -p -S -50 2>/dev/null \
-         | grep -qE 'Permission for the|Allow for remainder of this session'; then
+         | grep -qiE 'Permission for the|Allow for remainder of this session'; then
       tmux send-keys -t "$SESSION" Enter
       echo "[driver] wait_turn[s$ACTIVE]: dismissed tool-permission dialog" >&2
     fi

--- a/replaydata/agents/mistral-vibe/driver-interactive.sh
+++ b/replaydata/agents/mistral-vibe/driver-interactive.sh
@@ -318,6 +318,21 @@ launch_repl() {
 # stop_reason=="end_turn"; codex polls the rollout for task_complete; opencode
 # polls the SQLite store for a step-finish. Return 0 when a NEW turn completed
 # (or times out via remaining_seconds()).
+#
+# A tool call that resolves to ToolPermission.ASK holds the turn on a TUI-only
+# approval_app dialog ("Permission for the <tool> tool" / "Allow for remainder
+# of this session") that never touches messages.jsonl (see sibling
+# 2-19_tool-gate-permission-prompt) — turn_count alone would stall on that
+# until DEADLINE. Poll the live pane on every tick and dismiss the dialog the
+# instant it renders, instead of guessing a fixed sleep window that's
+# sometimes too short (dialog still rendering — recording fails as
+# transcript_missing/timeout) and sometimes irrelevant (the turn already
+# resolved, so a blind wait only delays an already-done recording) — issue
+# #1003. This mirrors antigravity/driver-interactive.sh's wait_turn(), which
+# already merges an identical mid-turn dialog dismiss into its own poll loop.
+# The marker text matches the daemon's own trustDialogMarkers
+# (core/domain/backchannel/uidetect.go) so the driver and the daemon agree on
+# what "the dialog is up" means.
 wait_turn() {
   resolve_transcript || {
     echo "[driver] wait_turn[s$ACTIVE]: vibe never created a session dir under ~/.vibe/logs/session" >&2
@@ -330,6 +345,11 @@ wait_turn() {
     if [[ $now -ge $EXPECTED_TURNS ]]; then
       echo "[driver] wait_turn[s$ACTIVE]: count=$now (expected >= $EXPECTED_TURNS)" >&2
       return 0
+    fi
+    if tmux capture-pane -t "$SESSION" -p -S -50 2>/dev/null \
+         | grep -qE 'Permission for the|Allow for remainder of this session'; then
+      tmux send-keys -t "$SESSION" Enter
+      echo "[driver] wait_turn[s$ACTIVE]: dismissed tool-permission dialog" >&2
     fi
     sleep 1
   done

--- a/replaydata/agents/mistral-vibe/scenarios/6-2_backchannel-observe/metadata.json
+++ b/replaydata/agents/mistral-vibe/scenarios/6-2_backchannel-observe/metadata.json
@@ -86,16 +86,11 @@
           "text": "Run the shell command: touch onboarding-backchannel-observe.txt"
         },
         {
-          "type": "sleep",
-          "seconds": 15
-        },
-        {
-          "type": "keys",
-          "keys": "Enter"
+          "type": "wait_turn"
         },
         {
           "type": "sleep",
-          "seconds": 8
+          "seconds": 4
         }
       ],
       "verify": [

--- a/replaydata/agents/mistral-vibe/scenarios/6-2_backchannel-observe/metadata.json
+++ b/replaydata/agents/mistral-vibe/scenarios/6-2_backchannel-observe/metadata.json
@@ -7,7 +7,7 @@
     "agent_cli_version": "2.19.0",
     "daemon_version": "0.5.5+5e22e47.dirty",
     "confidence": 0.9,
-    "notes": "RE-ASSESS after Control fix (5e22e47c). agent=yes (vibe renders a TUI-only tool-permission dialog); daemon=bug — RE-RECORDED 2026-07-13 against irrlichd 0.5.7+62118c4 (issue #988 worktree): the DetectUI marker fix is CONFIRMED CORRECT (captured screen text exactly matches; ui_detected + a real ready->waiting/waiting->working arc now fire via terminal read-back) but a DISTINCT, newly-exposed presession-identity-continuity gap keeps this known_failing — the waiting arc fires on the transient proc-<PID> presession, not the reconciled real session_<id> the spec anchors to (matcher can't find it; 4/7 phases pass). See issue #988. driver=ready (send+sleep+keys). Known-failing."
+    "notes": "RE-ASSESS after Control fix (5e22e47c). agent=yes (vibe renders a TUI-only tool-permission dialog); daemon=bug — RE-RECORDED 2026-07-13 against irrlichd 0.5.7+62118c4 (issue #988 worktree): the DetectUI marker fix is CONFIRMED CORRECT (captured screen text exactly matches; ui_detected + a real ready->waiting/waiting->working arc now fire via terminal read-back) but a DISTINCT, newly-exposed presession-identity-continuity gap keeps this known_failing — the waiting arc fires on the transient proc-<PID> presession, not the reconciled real session_<id> the spec anchors to (matcher can't find it; 4/7 phases pass). See issue #988. driver=ready (send+wait_turn, dialog dismissed via wait_turn's own capture-pane poll — issue #1003). Known-failing."
   },
   "details": {
     "assessment": {


### PR DESCRIPTION
## Summary

- mistral-vibe's `6-2_backchannel-observe` recipe blindly slept 15s before pressing Enter on vibe's tool-permission dialog, then 8s after — a duration guess that fails in both directions: too slow (dialog isn't rendered yet, recording fails `transcript_missing`) and too fast (the whole turn resolves before the daemon's 1Hz `TerminalObserver` poll ever samples it, zero `ui_detected` events, non-diagnostic recording).
- `wait_turn()` in `replaydata/agents/mistral-vibe/driver-interactive.sh` now polls `tmux capture-pane` for vibe's trust-dialog markers (`"Permission for the"` / `"Allow for remainder of this session"` — the same literal strings the daemon's own `DetectUI` in `core/domain/backchannel/uidetect.go` recognizes) on every tick and dismisses the dialog the instant it renders, mirroring `antigravity/driver-interactive.sh`'s `wait_turn()`, which already merges an identical mid-turn dialog dismiss into its own poll loop.
- The recipe's script (`replaydata/agents/mistral-vibe/scenarios/6-2_backchannel-observe/metadata.json`) simplifies from `send` → `sleep(15)` → `keys(Enter)` → `sleep(8)` to `send` → `wait_turn` → `sleep(4)`, matching sibling `2-11_auto-classified-permission`'s existing convention.
- No changes to `tools/onboarding-factory/scripts/run-cell.sh` or `core/application/services/terminal_observer.go` — `TIMEOUT_S` already flows through unchanged, and the daemon's 1Hz poll rate is out of scope for this driver-side fix.

Closes #1003

## Test plan

- [x] `bash -n replaydata/agents/mistral-vibe/driver-interactive.sh`
- [x] `bash tools/onboarding-factory/scripts/smoke-test.sh` — PASS
- [x] `go run ./tools/onboarding-factory/cmd/of validate` — schema + referential integrity OK
- [x] `bash tools/onboarding-factory/scripts/lib/recipe-lint.sh backchannel-observe mistral-vibe ...` and the `auto-classified-permission` sibling — both clean (grammar + semantic)
- [x] `tools/preflight.sh` (full local CI parity, via the pre-push hook) — all gates PASS: gofmt, core module tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, both web suites, ARS architecture gate, security scan
- [ ] **Follow-up (not done in this PR):** a live re-recording of `6-2_backchannel-observe` against a real `vibe` process, to confirm the dialog is now reliably caught and dismissed under real API latency. This sandbox has no Mistral API auth / interactive vibe session to drive, so the fix is statically verified but not yet proven against a live recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)