### PR TITLE
fix(daemon): synthesize swallowed first-turn transition for child sessions (#999)

### DIFF
--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -913,13 +913,53 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 // IsPIDAlive reports whether pid still refers to a live OS process, using the
 // same syscall.Kill(pid, 0) probe reapDeadOrInfraPID already uses for
 // dead-PID reaping. Exposed as a standalone predicate so callers outside the
-// periodic sweep (e.g. SessionDetector.parentProcessLive, issue #999) can
-// reuse the exact same liveness semantics instead of re-deriving them. Note:
-// like reapDeadOrInfraPID's own check, this can't distinguish a still-alive
-// original process from an unrelated process that later reused the same PID
-// — an existing, accepted risk, not one this helper introduces.
+// periodic sweep (e.g. parentProcessLive, issue #999) can reuse the exact
+// same liveness semantics instead of re-deriving them. A pid <= 0 is never
+// alive (mirrors reapDeadOrInfraPID's own guard, which never calls this probe
+// for such a pid, but a defensive check keeps this exported predicate safe
+// for any future caller). Note: like reapDeadOrInfraPID's own check, this
+// can't distinguish a still-alive original process from an unrelated process
+// that later reused the same PID — an existing, accepted risk, not one this
+// helper introduces.
 func (pm *PIDManager) IsPIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
 	return syscall.Kill(pid, 0) != syscall.ESRCH
+}
+
+// parentProcessLive is the child-session analog of a superseded live
+// pre-session (see finalizeNewSession's liveSignal computation in
+// session_detector_activity.go): proof that a subagent's parent OS process is
+// still running right now, as opposed to the daemon cold-rediscovering an
+// already-finished historical subagent after a restart (issue #999). Returns
+// false — and thus no synthesis — when the parent session is unknown or was
+// never PID-bound (state.PID <= 0), so a genuinely live but
+// very-recently-spawned parent (PID discovery still in flight) is treated the
+// same as a dead one: a narrow, deliberately accepted false-negative window
+// traded for guaranteed safety against a backlog flood.
+//
+// Lives on PIDManager rather than SessionDetector because every dependency it
+// touches — repo, WithSessionStateLock, IsPIDAlive — already lives here; it is
+// pure PID-liveness plumbing, not session-detection policy (unlike
+// holdParentWorkingForNewChild, which mutates the parent's classified state
+// and stays a SessionDetector-level decision).
+//
+// Runs under WithSessionStateLock, matching holdParentWorkingForNewChild's
+// existing parent-load pattern: the parent may have its own PID-discovery
+// goroutine in flight, and reading its fields without the lock would race
+// that goroutine's assignPIDLocked write to the same shared *SessionState
+// (issue #606).
+func (pm *PIDManager) parentProcessLive(parentID string) bool {
+	live := false
+	pm.WithSessionStateLock(func() {
+		parent, err := pm.repo.Load(parentID)
+		if err != nil || parent == nil || parent.PID <= 0 {
+			return
+		}
+		live = pm.IsPIDAlive(parent.PID)
+	})
+	return live
 }
 
 // reapDeadOrInfraPID handles the two ways a bound PID can prove the session is

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -910,6 +910,18 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 	return foundDead
 }
 
+// IsPIDAlive reports whether pid still refers to a live OS process, using the
+// same syscall.Kill(pid, 0) probe reapDeadOrInfraPID already uses for
+// dead-PID reaping. Exposed as a standalone predicate so callers outside the
+// periodic sweep (e.g. SessionDetector.parentProcessLive, issue #999) can
+// reuse the exact same liveness semantics instead of re-deriving them. Note:
+// like reapDeadOrInfraPID's own check, this can't distinguish a still-alive
+// original process from an unrelated process that later reused the same PID
+// — an existing, accepted risk, not one this helper introduces.
+func (pm *PIDManager) IsPIDAlive(pid int) bool {
+	return syscall.Kill(pid, 0) != syscall.ESRCH
+}
+
 // reapDeadOrInfraPID handles the two ways a bound PID can prove the session is
 // gone: the process has actually exited (ESRCH), or — for the case ESRCH can
 // never catch — the PID is alive but is the adapter's background infra (e.g.

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -307,12 +307,18 @@ func (d *SessionDetector) finalizeNewSession(id agent.Identity, ev agent.Event, 
 	// created" record, or — if catching up on a swallowed first turn
 	// (issue #996) — a synthetic ready->working->ready pair instead, mirroring
 	// synthesizeCollapsedTurnBoundaryIfNeeded's pattern (issue #988) for a
-	// different collapsed-boundary shape. Scoped to top-level sessions:
-	// pre-sessions are only ever minted for a top-level OS process, so a
-	// child/subagent session can't be the one superseding one — children
-	// keep today's behavior (correct final state, no synthesized transition)
-	// as a separate, deliberately unfixed gap (issue #999).
-	if state.ParentSessionID == "" && ShouldSynthesizeCatchUpTurn(supersedingLivePreSession, state.Metrics) {
+	// different collapsed-boundary shape. The liveness proof fed into
+	// ShouldSynthesizeCatchUpTurn differs by branch: top-level sessions use
+	// supersedingLivePreSession (a pre-session is only ever minted for a
+	// top-level OS process); child/subagent sessions have no pre-session of
+	// their own, so they use parentProcessLive instead — proof their parent's
+	// OS process is still running right now, not a cold-restart rediscovery
+	// of old history (issue #999).
+	liveSignal := supersedingLivePreSession
+	if state.ParentSessionID != "" {
+		liveSignal = d.parentProcessLive(state.ParentSessionID)
+	}
+	if ShouldSynthesizeCatchUpTurn(liveSignal, state.Metrics) {
 		d.recordCatchUpTurn(ev.SessionID, state)
 	} else {
 		d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: ev.SessionID, NewState: state.State, Reason: "new session created"})
@@ -330,6 +336,33 @@ func (d *SessionDetector) finalizeNewSession(id agent.Identity, ev agent.Event, 
 	}
 
 	return true
+}
+
+// parentProcessLive is the child-side analog of a superseded live pre-session
+// (see finalizeNewSession's liveSignal computation): proof that a subagent's
+// parent OS process is still running right now, as opposed to the daemon
+// cold-rediscovering an already-finished historical subagent after a restart
+// (issue #999). Returns false — and thus no synthesis — when the parent
+// session is unknown or was never PID-bound (state.PID <= 0), so a genuinely
+// live but very-recently-spawned parent (PID discovery still in flight) is
+// treated the same as a dead one: a narrow, deliberately accepted
+// false-negative window traded for guaranteed safety against a backlog flood.
+//
+// Runs under d.pidMgr.WithSessionStateLock, matching
+// holdParentWorkingForNewChild's existing parent-load pattern: the parent may
+// have its own PID-discovery goroutine in flight, and reading its fields
+// without the lock would race that goroutine's assignPIDLocked write to the
+// same shared *SessionState (issue #606).
+func (d *SessionDetector) parentProcessLive(parentID string) bool {
+	live := false
+	d.pidMgr.WithSessionStateLock(func() {
+		parent, err := d.repo.Load(parentID)
+		if err != nil || parent == nil || parent.PID <= 0 {
+			return
+		}
+		live = d.pidMgr.IsPIDAlive(parent.PID)
+	})
+	return live
 }
 
 // recordCatchUpTurn emits the synthetic ready->working->ready pair

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -316,7 +316,7 @@ func (d *SessionDetector) finalizeNewSession(id agent.Identity, ev agent.Event, 
 	// of old history (issue #999).
 	liveSignal := supersedingLivePreSession
 	if state.ParentSessionID != "" {
-		liveSignal = d.parentProcessLive(state.ParentSessionID)
+		liveSignal = d.pidMgr.parentProcessLive(state.ParentSessionID)
 	}
 	if ShouldSynthesizeCatchUpTurn(liveSignal, state.Metrics) {
 		d.recordCatchUpTurn(ev.SessionID, state)
@@ -336,33 +336,6 @@ func (d *SessionDetector) finalizeNewSession(id agent.Identity, ev agent.Event, 
 	}
 
 	return true
-}
-
-// parentProcessLive is the child-side analog of a superseded live pre-session
-// (see finalizeNewSession's liveSignal computation): proof that a subagent's
-// parent OS process is still running right now, as opposed to the daemon
-// cold-rediscovering an already-finished historical subagent after a restart
-// (issue #999). Returns false — and thus no synthesis — when the parent
-// session is unknown or was never PID-bound (state.PID <= 0), so a genuinely
-// live but very-recently-spawned parent (PID discovery still in flight) is
-// treated the same as a dead one: a narrow, deliberately accepted
-// false-negative window traded for guaranteed safety against a backlog flood.
-//
-// Runs under d.pidMgr.WithSessionStateLock, matching
-// holdParentWorkingForNewChild's existing parent-load pattern: the parent may
-// have its own PID-discovery goroutine in flight, and reading its fields
-// without the lock would race that goroutine's assignPIDLocked write to the
-// same shared *SessionState (issue #606).
-func (d *SessionDetector) parentProcessLive(parentID string) bool {
-	live := false
-	d.pidMgr.WithSessionStateLock(func() {
-		parent, err := d.repo.Load(parentID)
-		if err != nil || parent == nil || parent.PID <= 0 {
-			return
-		}
-		live = d.pidMgr.IsPIDAlive(parent.PID)
-	})
-	return live
 }
 
 // recordCatchUpTurn emits the synthetic ready->working->ready pair

--- a/core/application/services/session_detector_catchup_test.go
+++ b/core/application/services/session_detector_catchup_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -199,5 +200,151 @@ func TestSessionDetector_CatchUpTurn_NoSynthesisWhenTurnNotYetDone(t *testing.T)
 	}
 	if transitions[0].NewState != session.StateReady || transitions[0].Reason != "new session created" {
 		t.Errorf("transition = %+v, want the ordinary flat new_state=ready reason=\"new session created\"", transitions[0])
+	}
+}
+
+// TestSessionDetector_CatchUpTurn_ChildSynthesizesWhenParentProcessLive is the
+// regression test for issue #999: a child (subagent) session never gets a
+// pre-session of its own, so finalizeNewSession's synthesis gate can't use
+// supersedingLivePreSession for it as it does for a top-level session (see
+// TestSessionDetector_CatchUpTurn_SynthesizesWhenSupersedingLivePreSession
+// above). Instead it uses parentProcessLive — proof the parent's OS process
+// is still running right now. When the parent is alive and the child's very
+// first observation already shows a completed turn, the missing
+// working->ready cycle must be synthesized, mirroring the top-level case.
+func TestSessionDetector_CatchUpTurn_ChildSynthesizesWhenParentProcessLive(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	rec := &mockRecorder{}
+
+	metrics := &funcMetrics{fn: func(path, adapter string) (*session.SessionMetrics, error) {
+		if path == "" {
+			return nil, nil
+		}
+		return &session.SessionMetrics{LastEventType: "turn_done"}, nil
+	}}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	det.SetRecorder(rec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	time.Sleep(20 * time.Millisecond)
+
+	// The parent is a real, live OS process — PID = the test process's own
+	// PID, the reliably-alive convention already used elsewhere in this
+	// suite (see pid_manager_test.go's livePID).
+	now := time.Now().Unix()
+	repo.Save(&session.SessionState{
+		SessionID:      "parent-999-live",
+		State:          session.StateWorking,
+		PID:            os.Getpid(),
+		TranscriptPath: "/home/.claude/projects/-Users-test/parent-999-live.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	})
+
+	// The child's transcript is discovered late, already showing a completed
+	// turn — the same swallowed-first-turn shape as #996, one level down.
+	tw.ch <- agent.Event{
+		Type:            agent.EventNewSession,
+		SessionID:       "child-999-live",
+		ProjectDir:      "subagents",
+		TranscriptPath:  "/home/.claude/projects/-Users-test/parent-999-live/subagents/child-999-live.jsonl",
+		ParentSessionID: "parent-999-live",
+	}
+	waitForCondition(func() bool { s, _ := repo.Load("child-999-live"); return s != nil }, time.Second)
+	cancel()
+	<-done
+
+	transitions := transitionsFor(rec, "child-999-live")
+	if len(transitions) != 2 {
+		t.Fatalf("expected 2 synthesized state transitions for child-999-live, got %d: %+v", len(transitions), transitions)
+	}
+	if transitions[0].NewState != session.StateWorking || transitions[0].Reason != services.SyntheticCatchUpTurnStartReason {
+		t.Errorf("first transition = %+v, want new_state=working reason=%q", transitions[0], services.SyntheticCatchUpTurnStartReason)
+	}
+	if transitions[1].PrevState != session.StateWorking || transitions[1].NewState != session.StateReady ||
+		transitions[1].Reason != services.SyntheticCatchUpTurnDoneReason {
+		t.Errorf("second transition = %+v, want working->ready reason=%q", transitions[1], services.SyntheticCatchUpTurnDoneReason)
+	}
+}
+
+// TestSessionDetector_CatchUpTurn_ChildNoSynthesisWithoutLiveParent is the
+// critical regression guard for issue #999's design decision, mirroring
+// #996's own NoSynthesisWithoutLivePreSession guard one level down: a child
+// whose parent's OS process is confirmed dead, or whose parent session is
+// unknown altogether — exactly what a daemon restart rediscovering old
+// historical subagents looks like — must NOT get a synthetic bounce even
+// though its own first observation already shows a completed turn. Firing
+// unconditionally on metrics.IsAgentDone() alone would flood the lifecycle
+// stream with spurious bounces for every already-finished historical
+// subagent within the backlog-scan's age cutoff.
+func TestSessionDetector_CatchUpTurn_ChildNoSynthesisWithoutLiveParent(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	rec := &mockRecorder{}
+
+	metrics := &funcMetrics{fn: func(path, adapter string) (*session.SessionMetrics, error) {
+		if path == "" {
+			return nil, nil
+		}
+		return &session.SessionMetrics{LastEventType: "turn_done"}, nil
+	}}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	det.SetRecorder(rec)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	time.Sleep(20 * time.Millisecond)
+
+	// Parent exists in the repo but its OS process is confirmed dead — a
+	// historical subagent's parent, long gone.
+	now := time.Now().Unix()
+	repo.Save(&session.SessionState{
+		SessionID:      "parent-999-dead",
+		State:          session.StateReady,
+		PID:            deadPIDForTest(t),
+		TranscriptPath: "/home/.claude/projects/-Users-test/parent-999-dead.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	})
+
+	tw.ch <- agent.Event{
+		Type:            agent.EventNewSession,
+		SessionID:       "child-999-dead-parent",
+		ProjectDir:      "subagents",
+		TranscriptPath:  "/home/.claude/projects/-Users-test/parent-999-dead/subagents/child-999-dead-parent.jsonl",
+		ParentSessionID: "parent-999-dead",
+	}
+	waitForCondition(func() bool { s, _ := repo.Load("child-999-dead-parent"); return s != nil }, time.Second)
+
+	// No parent session at all — an even colder case than a dead PID.
+	tw.ch <- agent.Event{
+		Type:            agent.EventNewSession,
+		SessionID:       "child-999-no-parent",
+		ProjectDir:      "subagents",
+		TranscriptPath:  "/home/.claude/projects/-Users-test/parent-999-missing/subagents/child-999-no-parent.jsonl",
+		ParentSessionID: "parent-999-missing",
+	}
+	waitForCondition(func() bool { s, _ := repo.Load("child-999-no-parent"); return s != nil }, time.Second)
+
+	time.Sleep(30 * time.Millisecond) // let any (undesired) second transition land before asserting
+	cancel()
+	<-done
+
+	for _, sid := range []string{"child-999-dead-parent", "child-999-no-parent"} {
+		transitions := transitionsFor(rec, sid)
+		if len(transitions) != 1 {
+			t.Fatalf("%s: expected 1 (unchanged) state transition, got %d: %+v", sid, len(transitions), transitions)
+		}
+		if transitions[0].NewState != session.StateReady || transitions[0].Reason != "new session created" {
+			t.Errorf("%s: transition = %+v, want the ordinary flat new_state=ready reason=\"new session created\"", sid, transitions[0])
+		}
 	}
 }

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -228,14 +228,18 @@ const SyntheticCatchUpTurnDoneReason = "turn already complete at first discovery
 // delayed long enough that the first turn already completed (metrics.IsAgentDone())
 // before the daemon ever looked, which would otherwise silently swallow it
 // and mislead downstream turn-boundary consumers about which turn was first
-// (issue #996).
+// (issue #996, extended to child/subagent sessions by issue #999).
 //
-// supersedingLivePreSession is the load-bearing half of the gate: it's only
-// true when this session is superseding a pre-session (proc-<pid>) the
-// daemon was already live-tracking for the same project/cwd — proof this is
-// a genuine live-launch race, not an ordinary cold-start rediscovery of a
-// large backlog of old, already-finished sessions (which must never get a
-// spurious bounce; see cleanupPreSessionsForProject's doc comment).
-func ShouldSynthesizeCatchUpTurn(supersedingLivePreSession bool, metrics *session.SessionMetrics) bool {
-	return supersedingLivePreSession && metrics.IsAgentDone()
+// hasLiveOrigin is the load-bearing half of the gate — proof of a genuinely
+// live precursor, not an ordinary cold-start rediscovery of a large backlog
+// of old, already-finished sessions (which must never get a spurious
+// bounce). Its meaning depends on the caller: for a top-level session it's
+// true only when this session is superseding a pre-session (proc-<pid>) the
+// daemon was already live-tracking for the same project/cwd (see
+// cleanupPreSessionsForProject's doc comment); for a child/subagent session,
+// which never gets a pre-session of its own, it's true when the parent
+// session's own OS process is still alive right now (see
+// SessionDetector.parentProcessLive).
+func ShouldSynthesizeCatchUpTurn(hasLiveOrigin bool, metrics *session.SessionMetrics) bool {
+	return hasLiveOrigin && metrics.IsAgentDone()
 }

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -239,7 +239,7 @@ const SyntheticCatchUpTurnDoneReason = "turn already complete at first discovery
 // cleanupPreSessionsForProject's doc comment); for a child/subagent session,
 // which never gets a pre-session of its own, it's true when the parent
 // session's own OS process is still alive right now (see
-// SessionDetector.parentProcessLive).
+// PIDManager.parentProcessLive).
 func ShouldSynthesizeCatchUpTurn(hasLiveOrigin bool, metrics *session.SessionMetrics) bool {
 	return hasLiveOrigin && metrics.IsAgentDone()
 }


### PR DESCRIPTION
## Summary

#996 taught the daemon to notice when a top-level session's first turn finished before its transcript was ever discovered, and to synthesize the missing ready→working→ready transition instead of silently swallowing it — but only for top-level sessions. Subagents have the identical gap: a child's entire brief working life can finish before the daemon ever gets around to reading its transcript for the first time, and today that history is dropped with no recorded turn.

This extends the same synthesis to children, gated on a new child-specific liveness signal instead of firing unconditionally — investigation showed children are rediscovered by the exact same backlog scan on daemon restart that #996's gate was built to guard against, so an unconditional rule would flood the lifecycle stream with spurious bounces for historical subagents.

- `PIDManager.IsPIDAlive(pid int) bool` — thin wrapper around the existing `syscall.Kill(pid, 0)` dead-PID probe `reapDeadOrInfraPID` already uses.
- `SessionDetector.parentProcessLive(parentID string) bool` — the child-side analog of #996's live-pre-session proof: loads the parent under `d.pidMgr.WithSessionStateLock` (matching `holdParentWorkingForNewChild`'s existing pattern, required to avoid the #606-class race) and checks whether its bound PID is still alive.
- `finalizeNewSession` now computes a per-branch liveness signal — `supersedingLivePreSession` for top-level sessions, `parentProcessLive(...)` for children — both feeding the same unmodified `ShouldSynthesizeCatchUpTurn` gate, instead of hard-excluding every `ParentSessionID != ""` session.
- `ShouldSynthesizeCatchUpTurn`'s doc comment and parameter name generalized (`supersedingLivePreSession` → `hasLiveOrigin`) to describe both meanings — no logic change.
- 2 new regression tests mirroring the existing top-level ones: child synthesizes when parent's PID is alive; child does NOT synthesize when parent's PID is confirmed dead or when no parent session exists.

Closes #999

## Test plan

- [x] `go test ./core/... -race -count=1` — all packages pass
- [x] `tools/replay-fixtures.sh` — smoke check, no golden changes (no onboarding-factory scenario currently exercises this path)
- [x] `tools/preflight.sh` (via pre-push hook) — all gates pass (gofmt, core+onboarding-factory tests, replaydata validate, recording-rig smoke, web tests, ARS architecture gate, security scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)