### PR TITLE
fix(ci): use a PAT for star-history stargazers fetch, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -32,8 +32,14 @@ jobs:
           cache: false
 
       - name: Generate star history chart
+        # The default GITHUB_TOKEN is a GitHub App installation token, which
+        # GitHub blocks from reading the starred_at-enriched stargazers
+        # listing (403 "You do not have permission to view the stargazers
+        # of this repository") no matter what `permissions:` this workflow
+        # declares — there's no fine-grained permission that grants it. A
+        # PAT with public-repo read access is required instead. See #1012.
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.STARHISTORY_TOKEN }}
         run: |
           mkdir -p assets
           go run ./tools/starhistory -repo ingo-eichhorst/Irrlicht -out assets/star-history.svg


### PR DESCRIPTION
## Summary
- The `Update Star History Chart` workflow has 403'd on every run since #903 landed it — `GITHUB_TOKEN` (an Actions installation token) is blocked by GitHub from reading the `starred_at`-enriched stargazers listing, no matter what `permissions:` the workflow declares.
- Switches the stargazers-fetch step to a new `STARHISTORY_TOKEN` secret (a PAT), same pattern already used for `GIST_SECRET` in the coverage/CodeScene badge workflows. No code changes needed — `tools/starhistory` already just reads whatever token is in `GITHUB_TOKEN`'s env slot.

Fixes #1012.

## Follow-up needed (can't be done from here)
This PR alone won't turn the workflow green — a repo secret named `STARHISTORY_TOKEN` still needs to be added:
1. Create a PAT with read access to public repos (fine-grained PAT scoped to this repo with "Public Repositories (read-only)", or a classic PAT with the `public_repo` scope).
2. `gh secret set STARHISTORY_TOKEN --repo ingo-eichhorst/Irrlicht` (paste the token when prompted), or add it via the repo's Settings → Secrets and variables → Actions.

## Test plan
- [x] `go build ./tools/starhistory/...` and `go test ./tools/starhistory/...` pass
- [x] `tools/preflight.sh` (pre-push hook) passed in full
- [x] Verified directly against the live API: `GET /repos/ingo-eichhorst/Irrlicht/stargazers` with `Accept: application/vnd.github.star+json` returns 200 with a real PAT, 403 with the Actions bot token
- [ ] Confirm the workflow goes green on main after `STARHISTORY_TOKEN` is added (needs a manual trigger or the next push/scheduled run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)