### PR TITLE
refactor(onboarding-factory): extract shared TUI-dialog-dismiss poll into _lib/drive

### DIFF
--- a/replaydata/_lib/drive/dialogs.sh
+++ b/replaydata/_lib/drive/dialogs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# dialogs.sh — shared mid-turn TUI-dialog-dismiss poll for the interactive
+# recording drivers (#1009). Extracted from drive-mistral-vibe-interactive.sh
+# and drive-antigravity-interactive.sh's wait_turn(), whose "is a blocking
+# permission dialog on screen right now? dismiss it with Enter" block was
+# byte-identical except each adapter's own marker regex and log wording
+# (#1003 added the mistral-vibe copy; antigravity's predates it). A third
+# adapter needing the same shape would have made it a third copy-paste, so
+# this lib owns ONLY the poll+dismiss mechanics — capture the pane, match the
+# caller's regex, send Enter. The marker regex and any adapter-specific log
+# message stay in the driver, still coupled to that adapter's own
+# DetectUI/marker set (core/adapters/inbound/agents/<adapter>) — this lib has
+# no opinion on what the dialog says, only on how to poll and dismiss one.
+#
+# Sourced as a library; MUST NOT call `set` at top level.
+
+# dismiss_dialog_if_visible <session> <marker-regex>
+#   One-shot poll (the caller's own loop ticks this every iteration of
+#   wait_turn): capture the last ~50 lines of tmux pane <session> and, if they
+#   match the extended, case-insensitive <marker-regex>, send a bare Enter —
+#   every dialog this guards pre-highlights its accepting choice, so Enter
+#   alone dismisses/grants it — and return 0. Returns 1 when the marker isn't
+#   currently on screen; the caller decides what to log on a 0 return, since
+#   the wording ("dismissed tool-permission dialog" vs "granted agy
+#   run_command permission dialog") is adapter-specific context this helper
+#   doesn't have.
+dismiss_dialog_if_visible() { # <session> <marker-regex>
+  local session="$1" regex="$2"
+  tmux capture-pane -t "$session" -p -S -50 2>/dev/null | grep -qiE "$regex" || return 1
+  tmux send-keys -t "$session" Enter
+  return 0
+}

--- a/replaydata/_lib/drive/dialogs.sh
+++ b/replaydata/_lib/drive/dialogs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# dialogs.sh — shared mid-turn TUI-dialog-dismiss poll for the interactive
-# recording drivers (#1009). Extracted from drive-mistral-vibe-interactive.sh
-# and drive-antigravity-interactive.sh's wait_turn(), whose "is a blocking
+# dialogs.sh — shared TUI-dialog-dismiss poll for the interactive recording
+# drivers (#1009). Extracted from drive-mistral-vibe-interactive.sh and
+# drive-antigravity-interactive.sh's wait_turn(), whose "is a blocking
 # permission dialog on screen right now? dismiss it with Enter" block was
 # byte-identical except each adapter's own marker regex and log wording
 # (#1003 added the mistral-vibe copy; antigravity's predates it). A third
@@ -10,20 +10,24 @@
 # caller's regex, send Enter. The marker regex and any adapter-specific log
 # message stay in the driver, still coupled to that adapter's own
 # DetectUI/marker set (core/adapters/inbound/agents/<adapter>) — this lib has
-# no opinion on what the dialog says, only on how to poll and dismiss one.
+# no opinion on what the dialog says, only on how to poll and dismiss one. The
+# same helper also covers antigravity's boot-time "trust this folder" gate in
+# launch_repl (a one-shot poll inside a bounded wait, not wait_turn's per-tick
+# loop) — the mechanic is identical regardless of which caller loop drives it.
 #
 # Sourced as a library; MUST NOT call `set` at top level.
 
 # dismiss_dialog_if_visible <session> <marker-regex>
-#   One-shot poll (the caller's own loop ticks this every iteration of
-#   wait_turn): capture the last ~50 lines of tmux pane <session> and, if they
-#   match the extended, case-insensitive <marker-regex>, send a bare Enter —
-#   every dialog this guards pre-highlights its accepting choice, so Enter
-#   alone dismisses/grants it — and return 0. Returns 1 when the marker isn't
-#   currently on screen; the caller decides what to log on a 0 return, since
-#   the wording ("dismissed tool-permission dialog" vs "granted agy
-#   run_command permission dialog") is adapter-specific context this helper
-#   doesn't have.
+#   One-shot poll (the caller's own loop ticks this, whether that's
+#   wait_turn's per-turn poll or a boot-time readiness wait): capture the last
+#   ~50 lines of tmux pane <session> and, if they match the extended,
+#   case-insensitive <marker-regex>, send a bare Enter — every dialog this
+#   guards pre-highlights its accepting choice, so Enter alone dismisses/grants
+#   it — and return 0. Returns 1 when the marker isn't currently on screen; the
+#   caller decides what to log on a 0 return, since the wording ("dismissed
+#   tool-permission dialog" vs "granted agy run_command permission dialog" vs
+#   "accepted agy trust-folder prompt") is adapter/call-site-specific context
+#   this helper doesn't have.
 dismiss_dialog_if_visible() { # <session> <marker-regex>
   local session="$1" regex="$2"
   tmux capture-pane -t "$session" -p -S -50 2>/dev/null | grep -qiE "$regex" || return 1

--- a/replaydata/_lib/drive/drive-lib_test.sh
+++ b/replaydata/_lib/drive/drive-lib_test.sh
@@ -83,38 +83,38 @@ echo "== dismiss_dialog_if_visible: poll+dismiss mechanics only (tmux faked) =="
 # A fake `tmux` shell function shadows the real binary for the rest of this
 # script (bash resolves a function before PATH), so the mechanics can be
 # checked without a live tmux/agent: capture-pane replays $FAKE_PANE, and
-# send-keys records its args so a test can assert Enter reached the right
-# session.
+# send-keys records its args in a plain variable (one call per test case,
+# same shell — no file/mktemp needed) so a test can assert Enter reached the
+# right session.
 FAKE_PANE=""
-SENDKEYS_LOG="$TMP/sendkeys.log"
+SENDKEYS_LOG=""
 tmux() {
   case "$1" in
     capture-pane) printf '%s\n' "$FAKE_PANE" ;;
-    send-keys)    shift; echo "$*" >> "$SENDKEYS_LOG" ;;
-    *)            : ;;
+    send-keys)    shift; SENDKEYS_LOG="$*" ;;
   esac
 }
 
 FAKE_PANE=$'some noise\nPermission for the bash tool\nmore noise'
-: > "$SENDKEYS_LOG"
+SENDKEYS_LOG=""
 dismiss_dialog_if_visible "vibe-sess" 'Permission for the|Allow for remainder of this session'
 assert_eq "vibe marker present -> returns 0" 0 "$?"
-assert_eq "sends Enter to the right session"  "-t vibe-sess Enter" "$(cat "$SENDKEYS_LOG")"
+assert_eq "sends Enter to the right session"  "-t vibe-sess Enter" "$SENDKEYS_LOG"
 
 FAKE_PANE="nothing dialog-shaped here"
-: > "$SENDKEYS_LOG"
+SENDKEYS_LOG=""
 dismiss_dialog_if_visible "vibe-sess" 'Permission for the|Allow for remainder of this session'
 assert_eq "marker absent -> returns 1" 1 "$?"
-assert_eq "no Enter sent when marker absent" "" "$(cat "$SENDKEYS_LOG")"
+assert_eq "no Enter sent when marker absent" "" "$SENDKEYS_LOG"
 
 FAKE_PANE="Requesting permission for run_command: rm -rf /tmp/x"
-: > "$SENDKEYS_LOG"
+SENDKEYS_LOG=""
 dismiss_dialog_if_visible "agy-sess" 'Requesting permission for|Do you want to proceed'
 assert_eq "antigravity's own marker regex matches its own dialog" 0 "$?"
-assert_eq "antigravity dismiss targets its own session" "-t agy-sess Enter" "$(cat "$SENDKEYS_LOG")"
+assert_eq "antigravity dismiss targets its own session" "-t agy-sess Enter" "$SENDKEYS_LOG"
 
 FAKE_PANE="Permission for the bash tool"
-: > "$SENDKEYS_LOG"
+SENDKEYS_LOG=""
 dismiss_dialog_if_visible "agy-sess" 'Requesting permission for|Do you want to proceed'
 assert_eq "adapters' marker regexes stay independent (vibe text doesn't trip agy's)" 1 "$?"
 

--- a/replaydata/_lib/drive/drive-lib_test.sh
+++ b/replaydata/_lib/drive/drive-lib_test.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # drive-lib_test.sh — unit tests for the shared interactive-driver helpers
-# extracted in #508 #3 (lib/drive/slots.sh + contracts.sh). Plain bash, no
-# framework. The interactive drivers themselves can't run in CI (they need a
-# live agent CLI + tmux + daemon), so these pure helpers — slot bookkeeping and
-# staging-contract emission, which touch only bash arrays + the filesystem — are
-# the automated net for the extraction. Run directly or via scripts/smoke-test.sh.
+# extracted in #508 #3 (lib/drive/slots.sh + contracts.sh) and #1009
+# (lib/drive/dialogs.sh). Plain bash, no framework. The interactive drivers
+# themselves can't run in CI (they need a live agent CLI + tmux + daemon), so
+# these pure helpers — slot bookkeeping, staging-contract emission, and the
+# mid-turn dialog-dismiss poll, which touch only bash arrays + the filesystem
+# (dialogs.sh's tmux calls are faked below) — are the automated net for the
+# extraction. Run directly or via scripts/smoke-test.sh.
 
 set -uo pipefail   # NOT -e: assertions capture non-zero return codes
 
@@ -13,6 +15,8 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$DIR/slots.sh"
 # shellcheck source=contracts.sh
 source "$DIR/contracts.sh"
+# shellcheck source=dialogs.sh
+source "$DIR/dialogs.sh"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -74,6 +78,47 @@ echo "== drive_exit: EXIT_REASON → exit code =="
 ( EXIT_REASON="timeout";       drive_exit ); assert_eq "timeout → 124"    124 "$?"
 ( EXIT_REASON="nonzero(2)";    drive_exit ); assert_eq "nonzero(2) → 2"   2   "$?"
 ( EXIT_REASON="weird";         drive_exit ); assert_eq "unknown → 1"      1   "$?"
+
+echo "== dismiss_dialog_if_visible: poll+dismiss mechanics only (tmux faked) =="
+# A fake `tmux` shell function shadows the real binary for the rest of this
+# script (bash resolves a function before PATH), so the mechanics can be
+# checked without a live tmux/agent: capture-pane replays $FAKE_PANE, and
+# send-keys records its args so a test can assert Enter reached the right
+# session.
+FAKE_PANE=""
+SENDKEYS_LOG="$TMP/sendkeys.log"
+tmux() {
+  case "$1" in
+    capture-pane) printf '%s\n' "$FAKE_PANE" ;;
+    send-keys)    shift; echo "$*" >> "$SENDKEYS_LOG" ;;
+    *)            : ;;
+  esac
+}
+
+FAKE_PANE=$'some noise\nPermission for the bash tool\nmore noise'
+: > "$SENDKEYS_LOG"
+dismiss_dialog_if_visible "vibe-sess" 'Permission for the|Allow for remainder of this session'
+assert_eq "vibe marker present -> returns 0" 0 "$?"
+assert_eq "sends Enter to the right session"  "-t vibe-sess Enter" "$(cat "$SENDKEYS_LOG")"
+
+FAKE_PANE="nothing dialog-shaped here"
+: > "$SENDKEYS_LOG"
+dismiss_dialog_if_visible "vibe-sess" 'Permission for the|Allow for remainder of this session'
+assert_eq "marker absent -> returns 1" 1 "$?"
+assert_eq "no Enter sent when marker absent" "" "$(cat "$SENDKEYS_LOG")"
+
+FAKE_PANE="Requesting permission for run_command: rm -rf /tmp/x"
+: > "$SENDKEYS_LOG"
+dismiss_dialog_if_visible "agy-sess" 'Requesting permission for|Do you want to proceed'
+assert_eq "antigravity's own marker regex matches its own dialog" 0 "$?"
+assert_eq "antigravity dismiss targets its own session" "-t agy-sess Enter" "$(cat "$SENDKEYS_LOG")"
+
+FAKE_PANE="Permission for the bash tool"
+: > "$SENDKEYS_LOG"
+dismiss_dialog_if_visible "agy-sess" 'Requesting permission for|Do you want to proceed'
+assert_eq "adapters' marker regexes stay independent (vibe text doesn't trip agy's)" 1 "$?"
+
+unset -f tmux
 
 echo ""
 if [[ "$fails" -eq 0 ]]; then

--- a/replaydata/agents/antigravity/driver-interactive.sh
+++ b/replaydata/agents/antigravity/driver-interactive.sh
@@ -210,8 +210,7 @@ launch_repl() {
   # send isn't swallowed, then settle briefly so Ink finishes mounting the prompt.
   local waited=0
   while (( waited < 40 )); do
-    if tmux capture-pane -t "$SESSION" -p -S -50 2>/dev/null | grep -qiE 'trust the contents|trust this folder'; then
-      tmux send-keys -t "$SESSION" Enter
+    if dismiss_dialog_if_visible "$SESSION" 'trust the contents|trust this folder'; then
       echo "[driver] accepted agy trust-folder prompt" >&2
       break
     fi

--- a/replaydata/agents/antigravity/driver-interactive.sh
+++ b/replaydata/agents/antigravity/driver-interactive.sh
@@ -95,6 +95,8 @@ DRIVE_MARKER_PREFIX="$STAGING/.antigravity-marker"
 source "$_DRIVE_LIB/slots.sh"
 # shellcheck source=/dev/null
 source "$_DRIVE_LIB/contracts.sh"
+# shellcheck source=/dev/null
+source "$_DRIVE_LIB/dialogs.sh"
 
 # Slot state the lib reads/writes (the driver owns these globals). A run starts
 # with zero slots; launch_repl allocs slot 1, and restart/start_session alloc
@@ -309,7 +311,10 @@ turn_count() {
 # Option 1 "Yes" is pre-highlighted, so a bare Enter grants it. A multi-tool turn
 # fires the dialog once PER tool call, so accept it every time it is on screen
 # (Enter on an empty input box mid-generation is a harmless no-op). This mirrors
-# the claudecode driver's in-turn "Run a dynamic workflow?" auto-accept.
+# the claudecode driver's in-turn "Run a dynamic workflow?" auto-accept, and
+# shares its poll+dismiss mechanics with mistral-vibe's identical mid-turn
+# dialog wait via the shared _lib/drive/dialogs.sh helper (#1009) — only the
+# marker regex below stays adapter-local.
 wait_turn() {
   resolve_transcript || {
     echo "[driver] wait_turn[s$ACTIVE]: agy never created a transcript under $ANTIGRAVITY_BRAIN_ROOT" >&2
@@ -322,9 +327,7 @@ wait_turn() {
       echo "[driver] wait_turn[s$ACTIVE]: count=$now (expected ≥ $EXPECTED_TURNS)" >&2
       return 0
     fi
-    if tmux capture-pane -t "$SESSION" -p -S -50 2>/dev/null \
-         | grep -qiE 'Requesting permission for|Do you want to proceed'; then
-      tmux send-keys -t "$SESSION" Enter
+    if dismiss_dialog_if_visible "$SESSION" 'Requesting permission for|Do you want to proceed'; then
       echo "[driver] wait_turn[s$ACTIVE]: granted agy run_command permission dialog" >&2
     fi
     sleep 1

--- a/replaydata/agents/mistral-vibe/driver-interactive.sh
+++ b/replaydata/agents/mistral-vibe/driver-interactive.sh
@@ -95,6 +95,8 @@ DRIVE_MARKER_PREFIX="$STAGING/.mistral-vibe-marker"
 source "$_DRIVE_LIB/slots.sh"
 # shellcheck source=/dev/null
 source "$_DRIVE_LIB/contracts.sh"
+# shellcheck source=/dev/null
+source "$_DRIVE_LIB/dialogs.sh"
 
 # Slot state the lib reads/writes (the driver owns these globals). A run starts
 # with zero slots; launch_repl allocs slot 1, and restart/start_session alloc
@@ -329,8 +331,10 @@ launch_repl() {
 # transcript_missing/timeout) and sometimes irrelevant (the turn already
 # resolved, so a blind wait only delays an already-done recording) — issue
 # #1003. This mirrors antigravity/driver-interactive.sh's wait_turn(), which
-# already merges an identical mid-turn dialog dismiss into its own poll loop.
-# The marker text matches the daemon's own trustDialogMarkers
+# already merges an identical mid-turn dialog dismiss into its own poll loop —
+# both now call the shared _lib/drive/dialogs.sh helper (#1009) so the
+# poll+dismiss mechanics live in one place; only the marker regex below stays
+# adapter-local. The marker text matches the daemon's own trustDialogMarkers
 # (core/domain/backchannel/uidetect.go) so the driver and the daemon agree on
 # what "the dialog is up" means.
 wait_turn() {
@@ -346,9 +350,7 @@ wait_turn() {
       echo "[driver] wait_turn[s$ACTIVE]: count=$now (expected >= $EXPECTED_TURNS)" >&2
       return 0
     fi
-    if tmux capture-pane -t "$SESSION" -p -S -50 2>/dev/null \
-         | grep -qiE 'Permission for the|Allow for remainder of this session'; then
-      tmux send-keys -t "$SESSION" Enter
+    if dismiss_dialog_if_visible "$SESSION" 'Permission for the|Allow for remainder of this session'; then
       echo "[driver] wait_turn[s$ACTIVE]: dismissed tool-permission dialog" >&2
     fi
     sleep 1


### PR DESCRIPTION
## Summary

- `antigravity` and `mistral-vibe`'s `wait_turn()` each inlined an identical "poll `tmux capture-pane` every tick for a marker regex, `tmux send-keys ... Enter` the instant it renders" block to auto-dismiss a mid-turn permission dialog (#1003 added the mistral-vibe copy; antigravity's predates it).
- Factors the shared poll+dismiss mechanics into `dismiss_dialog_if_visible <session> <marker-regex>` in a new `replaydata/_lib/drive/dialogs.sh`, alongside the existing `slots.sh`/`contracts.sh` helper modules, and wires both drivers' `wait_turn()` to call it instead of inlining the block.
- Each adapter's own marker regex and log wording stay adapter-local and byte-identical to before — this is a pure mechanics extraction, not a behavior change. Recordings/scenarios for both adapters are unaffected.

## Test plan

- [x] `bash -n` on both touched driver scripts and the new `dialogs.sh` — all pass
- [x] Extended `replaydata/_lib/drive/drive-lib_test.sh` with unit tests for `dismiss_dialog_if_visible` (tmux faked via a shadowing shell function): dismiss-on-match + send-keys-to-the-right-session, no-op-on-no-match, and adapter-marker-regex independence — all pass
- [x] `bash tools/onboarding-factory/scripts/smoke-test.sh` — PASS (bash -n across the rig + all lib unit tests, including the extended drive-lib_test.sh; advisory shellcheck findings are pre-existing/unrelated to this change)
- [x] `go run ./tools/onboarding-factory/cmd/of validate` — OK
- [x] `tools/preflight.sh` (via the pre-push hook) — full local CI parity gate, all PASS (go tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, web suites, ARS architecture gate, security scan)
- No `core/` Go code changed, so `go test ./core/... -race -count=1` wasn't required by the task's own rule, but it ran anyway as part of the preflight gate above and passed.

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)