### PR TITLE
fix(ci): route star-history's own chart commit through a PR

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -45,17 +46,27 @@ jobs:
           go run ./tools/starhistory -repo ingo-eichhorst/Irrlicht -out assets/star-history.svg
 
       - name: Commit chart update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add assets/star-history.svg
           if git diff --staged --quiet; then
             echo "No chart changes to commit"
-          else
-            git commit -m "chore: update star history chart [skip ci]"
-            for i in 1 2 3 4 5; do
-              git pull --rebase origin main && git push && break
-              echo "Push attempt $i failed, retrying..."
-              sleep $((i * 3))
-            done
+            exit 0
           fi
+
+          # main requires a PR for every change (0 approvals, no required
+          # checks) — a direct push here always gets rejected with GH013.
+          # Route the update through a same-repo branch + auto-merged PR
+          # instead, so the update stays fully automated without weakening
+          # branch protection. See #1012.
+          branch="chore/star-history-update-${{ github.run_id }}"
+          git checkout -b "$branch"
+          git commit -m "chore: update star history chart [skip ci]"
+          git push origin "$branch"
+          gh pr create --base main --head "$branch" \
+            --title "chore: update star history chart" \
+            --body "Automated star history chart refresh."
+          gh pr merge "$branch" --squash --delete-branch


### PR DESCRIPTION
## Summary
- Follow-up to #1013. That PR fixed the stargazers-fetch 403, but the workflow's next step — a direct `git push` of the regenerated chart to `main` — has *also* been silently failing on every run, because main's "Protect Main" ruleset requires every change to go through a PR (`bypass_actors: []`, `current_user_can_bypass: "never"`). The retry loop swallowed the push failure instead of failing the job, so the chart on `main` has been stuck at 2026-07-07 (the date of the original feature PR) despite the workflow reporting green.
- Fixes the chart-commit step to open a same-repo branch + PR and squash-merge it instead of pushing to `main` directly. The ruleset requires 0 approvals and there are no required status checks, so this stays fully automated without weakening branch protection.
- Adds `pull-requests: write` to the job's permissions (needed for `gh pr create`/`gh pr merge`).
- Also fixes the silent-failure bug itself: the old retry loop had no `exit 1` after exhausting retries, so a push failure never failed the step.

Fixes #1012.

## Test plan
- [x] `tools/preflight.sh` (pre-push hook) passed in full
- [x] Verified the root cause directly: `gh api repos/ingo-eichhorst/Irrlicht/rulesets/15993081` shows `pull_request` rule active with `bypass_actors: []`; the prior run's log shows `remote: error: GH013: Repository rule violations found for refs/heads/main` on every retry
- [ ] Confirm the workflow's own PR-and-merge round-trip succeeds on the next push/scheduled run against main

🤖 Generated with [Claude Code](https://claude.com/claude-code)