### PR TITLE
fix(tailer): stop non-claude adapters falling back to Claude's model config

### DIFF
--- a/core/pkg/tailer/model_fallback_test.go
+++ b/core/pkg/tailer/model_fallback_test.go
@@ -4,9 +4,36 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"irrlicht/core/pkg/capacity"
 )
+
+// writeClaudeSettingsFixture creates a hermetic HOME with a
+// ~/.claude/settings.json configured to model, and points HOME at it for the
+// rest of the test. Returns home so callers that need to re-derive the
+// expected value (e.g. via getClaudeModel) can do so.
+func writeClaudeSettingsFixture(t *testing.T, model string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"),
+		[]byte(`{"model":"`+model+`"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// noInBandModelLines is a minimal user/assistant transcript that carries no
+// model field of its own, so ModelName can only come from the config
+// fallback (or stay empty).
+func noInBandModelLines() []map[string]interface{} {
+	return []map[string]interface{}{
+		{"type": "user", "timestamp": ts(0)},
+		{"type": "assistant", "timestamp": ts(1)},
+	}
+}
 
 // TestModelConfigFallback_GateControlsConfigRead pins issue #440: when a
 // transcript carries no in-band model, the daemon path fills ModelName from
@@ -16,16 +43,7 @@ import (
 func TestModelConfigFallback_GateControlsConfigRead(t *testing.T) {
 	// Hermetic HOME with a configured default model. The transcript has no
 	// in-band model, so ONLY the config fallback could populate ModelName.
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"),
-		[]byte(`{"model":"claude-sonnet-4-20250514"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	home := writeClaudeSettingsFixture(t, "claude-sonnet-4-20250514")
 
 	// Derive the expected value from the same code the daemon uses, so the
 	// assertion is independent of NormalizeModelName's exact mapping.
@@ -34,10 +52,7 @@ func TestModelConfigFallback_GateControlsConfigRead(t *testing.T) {
 		t.Fatalf("test setup: getClaudeModel(%q) returned empty", home)
 	}
 
-	lines := []map[string]interface{}{
-		{"type": "user", "timestamp": ts(0)},
-		{"type": "assistant", "timestamp": ts(1)},
-	}
+	lines := noInBandModelLines()
 
 	t.Run("daemon path fills from config", func(t *testing.T) {
 		tl := newTestTailer(writeTranscriptLines(t, lines))
@@ -73,24 +88,10 @@ func TestModelConfigFallback_GateControlsConfigRead(t *testing.T) {
 // Claude's config for any adapter, contaminating the session with a
 // claude-sonnet model name it never used.
 func TestModelConfigFallback_NonClaudeAdapterStaysEmpty(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"),
-		[]byte(`{"model":"claude-sonnet-4-20250514"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeClaudeSettingsFixture(t, "claude-sonnet-4-20250514")
+	lines := noInBandModelLines()
 
-	lines := []map[string]interface{}{
-		{"type": "user", "timestamp": ts(0)},
-		{"type": "assistant", "timestamp": ts(1)},
-	}
-
-	tl := NewTranscriptTailer(writeTranscriptLines(t, lines), &testParser{}, "mistral-vibe")
-	tl.capacityMgr = capacity.NewForTest(testCapacityFixture)
+	tl := newTestTailerForAdapter(writeTranscriptLines(t, lines), "mistral-vibe")
 	m, err := tl.TailAndProcess()
 	if err != nil {
 		t.Fatal(err)

--- a/core/pkg/tailer/model_fallback_test.go
+++ b/core/pkg/tailer/model_fallback_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"irrlicht/core/pkg/capacity"
 )
 
 // TestModelConfigFallback_GateControlsConfigRead pins issue #440: when a
@@ -59,4 +61,41 @@ func TestModelConfigFallback_GateControlsConfigRead(t *testing.T) {
 			t.Fatalf("ModelName = %q, want %q (fallback disabled; config must not be read)", m.ModelName, "")
 		}
 	})
+}
+
+// TestModelConfigFallback_NonClaudeAdapterStaysEmpty pins issue #1019: a
+// mistral-vibe session whose meta.json sidecar hasn't been written yet (e.g.
+// the brief window right after a `/clear` rotation, before Vibe's next
+// message lazily creates the new session directory) must NOT pick up the
+// operator's unrelated claude-code model preference from
+// ~/.claude/settings.json. Before the fix, "mistral-vibe" matched neither the
+// "pi" nor "codex" switch case and fell into a catch-all default that read
+// Claude's config for any adapter, contaminating the session with a
+// claude-sonnet model name it never used.
+func TestModelConfigFallback_NonClaudeAdapterStaysEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"),
+		[]byte(`{"model":"claude-sonnet-4-20250514"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lines := []map[string]interface{}{
+		{"type": "user", "timestamp": ts(0)},
+		{"type": "assistant", "timestamp": ts(1)},
+	}
+
+	tl := NewTranscriptTailer(writeTranscriptLines(t, lines), &testParser{}, "mistral-vibe")
+	tl.capacityMgr = capacity.NewForTest(testCapacityFixture)
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.ModelName != "" {
+		t.Fatalf("ModelName = %q, want empty (mistral-vibe has no meta.json yet and must not fall back to claude-code's config)", m.ModelName)
+	}
 }

--- a/core/pkg/tailer/tailer_config.go
+++ b/core/pkg/tailer/tailer_config.go
@@ -42,19 +42,26 @@ func isUserBlockingToolName(name string) bool {
 // --- Model config fallback ---
 
 // getDefaultModelFromConfig reads the default model from the appropriate config
-// based on adapter name.
+// based on adapter name. Adapters with no known operator-config source return
+// "" rather than falling through to Claude's settings.json — issue #1019
+// found a mistral-vibe session (whose own meta.json sidecar hadn't been
+// written yet) picking up an unrelated claude-code session's model name this
+// way, since "mistral-vibe" matched neither "pi" nor "codex" and fell into
+// what used to be a catch-all default.
 func getDefaultModelFromConfig(adapter string) string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return ""
 	}
 	switch adapter {
+	case "claude-code":
+		return getClaudeModel(homeDir)
 	case "pi":
 		return getPiModel(homeDir)
 	case "codex":
 		return getCodexModel(homeDir)
 	default:
-		return getClaudeModel(homeDir)
+		return ""
 	}
 }
 

--- a/core/pkg/tailer/tool_call_test.go
+++ b/core/pkg/tailer/tool_call_test.go
@@ -388,7 +388,13 @@ func (p *testParser) PendingContribution() *PerTurnContribution {
 // deterministic testCapacityFixture capacity manager. Tests must not depend
 // on the real on-disk LiteLLM cache.
 func newTestTailer(path string) *TranscriptTailer {
-	t := NewTranscriptTailer(path, &testParser{}, "claude-code")
+	return newTestTailerForAdapter(path, "claude-code")
+}
+
+// newTestTailerForAdapter is newTestTailer for a caller that needs a specific
+// adapter name (e.g. to exercise adapter-specific config-fallback behavior).
+func newTestTailerForAdapter(path, adapter string) *TranscriptTailer {
+	t := NewTranscriptTailer(path, &testParser{}, adapter)
 	t.capacityMgr = capacity.NewForTest(testCapacityFixture)
 	return t
 }


### PR DESCRIPTION
## Summary

Fixes the model_name contamination half of #1019. `getDefaultModelFromConfig` (`core/pkg/tailer/tailer_config.go`) special-cased only `"pi"` and `"codex"`, so every other adapter — including `mistral-vibe`, but also `aider`, `antigravity`, `gemini-cli`, `kiro-cli`, `opencode` — fell through to a catch-all `default` that read the operator's `~/.claude/settings.json` and returned that as the model name.

In the reported repro, a mistral-vibe session right after a `/clear` rotation had no `meta.json` sidecar yet (Vibe lazily creates the new session directory on the *next* message, not at `/clear` time), so `ModelName` was empty and the tailer's config-fallback fired — surfacing an unrelated Claude Code session's model name (`claude-sonnet-4-6`) on a Mistral Vibe session.

Fix: the switch now only reads Claude's config for the `"claude-code"` adapter explicitly; every other unmatched adapter returns `""` (no fallback) instead of guessing Claude's config.

- `core/pkg/tailer/tailer_config.go` — explicit `"claude-code"` case; default returns `""`.
- `core/pkg/tailer/model_fallback_test.go` — new regression test (`TestModelConfigFallback_NonClaudeAdapterStaysEmpty`) pinning that a `mistral-vibe` tailer with no in-band model and a configured `~/.claude/settings.json` stays empty rather than inheriting Claude's model.

## Out of scope (tracked separately)

Issue #1019 also reported that the post-`/clear` session loses `cwd`/`project_name`/`git_branch` binding (lands in the `unknown` group). That's a real, but architecturally separate gap: `refreshStaleSessions` (the only periodic re-check besides fswatcher events) only retries sessions in the `working` state, so an idle session whose `meta.json` appears after its last observed transcript activity never gets revisited. Fixing it properly needs its own design pass (how long to keep retrying, which states to cover), so I filed it as #1021 rather than bundling a speculative fix into this narrow correctness fix.

## Test plan
- [x] `go test ./core/... -race -count=1` — all packages pass, including the new regression test
- [x] `tools/replay-fixtures.sh` — all recorded cells pass (cell-integrity clean)
- [x] `tools/preflight.sh` (via pre-push hook) — gofmt, core+factory tests, replaydata validate, recording-rig smoke test, web suites, ARS gate, security scan all PASS

Closes #1019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)