### PR TITLE
fix(session-detector): retry cwd/project resolution for idle vibe sessions

### DIFF
--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -41,6 +41,14 @@ const activityDebounceWindow = 2 * time.Second
 // transcript on this interval catches the missed events.
 const staleWorkingRefreshInterval = 5 * time.Second
 
+// maxIdleProjectResolveAttempts bounds how many refreshStaleSessions ticks
+// retry CWD/project resolution for an idle (waiting/ready) session whose
+// ProjectName never resolved — e.g. mistral-vibe's meta.json sidecar hadn't
+// been written yet at the moment the transcript went quiet (#1021). Without
+// a cap, a session in a non-git cwd, or on an adapter with no sidecar at
+// all, would be re-read on this ticker forever.
+const maxIdleProjectResolveAttempts = 12
+
 // Logger component tags shared by SessionDetector's collaborators, split
 // across this file, session_detector_activity.go, session_detector_lifecycle.go,
 // session_detector_subagent.go, and pid_manager.go.
@@ -191,6 +199,13 @@ type SessionDetector struct {
 	// removed.
 	editToolOpenSince map[string]int64 // sessionID → unix seconds
 
+	// idleProjectRetryAttempts tracks, per session, how many
+	// refreshStaleSessions ticks have retried CWD/project resolution while
+	// idle with an unresolved ProjectName. Guarded by permMu. Capped at
+	// maxIdleProjectResolveAttempts (#1021); cleared when the session is
+	// removed (onRemoved).
+	idleProjectRetryAttempts map[string]int // sessionID → attempts so far
+
 	// bgLiveProbe answers "does this session still have a live background
 	// process?" from its output-file paths. Defaults to anyLiveOutputWriter
 	// (lsof); tests override it. See issue #445.
@@ -265,28 +280,29 @@ func NewSessionDetector(watchers []inbound.Watcher, deps SessionDetectorDeps) *S
 		}
 	}
 	det := &SessionDetector{
-		watchers:          watchers,
-		merged:            make(chan identifiedEvent, 16),
-		repo:              deps.Repo,
-		log:               deps.Log,
-		broadcaster:       deps.Broadcaster,
-		version:           deps.Version,
-		enricher:          newMetadataEnricher(deps.Git, deps.Metrics),
-		metrics:           deps.Metrics,
-		projectSessions:   make(map[string]string),
-		deletedSessions:   make(map[string]int64),
-		hostGateRejected:  make(map[string]struct{}),
-		debounce:          make(map[string]*debounceEntry),
-		debouncedEvents:   make(chan agent.Event, 64),
-		deletedCooldown:   10 * time.Second,
-		permissionPending: make(map[string]bool),
-		compactPending:    make(map[string]int64),
-		editToolOpenSince: make(map[string]int64),
-		bgLiveProbe:       anyLiveOutputWriter,
-		bgPIDProbe:        anyLivePID,
-		bgLive:            make(map[string]bool),
-		bgProbing:         make(map[string]bool),
-		uiSignals:         make(chan terminalUISignal, 64),
+		watchers:                 watchers,
+		merged:                   make(chan identifiedEvent, 16),
+		repo:                     deps.Repo,
+		log:                      deps.Log,
+		broadcaster:              deps.Broadcaster,
+		version:                  deps.Version,
+		enricher:                 newMetadataEnricher(deps.Git, deps.Metrics),
+		metrics:                  deps.Metrics,
+		projectSessions:          make(map[string]string),
+		deletedSessions:          make(map[string]int64),
+		hostGateRejected:         make(map[string]struct{}),
+		debounce:                 make(map[string]*debounceEntry),
+		debouncedEvents:          make(chan agent.Event, 64),
+		deletedCooldown:          10 * time.Second,
+		permissionPending:        make(map[string]bool),
+		compactPending:           make(map[string]int64),
+		editToolOpenSince:        make(map[string]int64),
+		idleProjectRetryAttempts: make(map[string]int),
+		bgLiveProbe:              anyLiveOutputWriter,
+		bgPIDProbe:               anyLivePID,
+		bgLive:                   make(map[string]bool),
+		bgProbing:                make(map[string]bool),
+		uiSignals:                make(chan terminalUISignal, 64),
 	}
 	det.pidMgr = NewPIDManager(PIDManagerDeps{
 		PW:               deps.PW,

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1253,19 +1253,12 @@ func (d *SessionDetector) markStalledEditTool(sessionID string, m *session.Sessi
 	}
 }
 
-// refreshStaleSessions re-reads transcripts for two categories of session the
-// normal fswatcher-driven pipeline can't self-correct:
-//   - working sessions that haven't received a file-system watcher event
-//     recently. This catches tool calls (AskUserQuestion, ExitPlanMode) that
-//     were missed because the subscriber channel was full during concurrent
-//     bursts.
-//   - idle (waiting/ready) sessions whose ProjectName never resolved because
-//     their adapter's metadata sidecar (e.g. mistral-vibe's meta.json)
-//     hadn't been written yet at the moment the transcript went quiet —
-//     nothing else ever revisits an idle session, so without this the
-//     session would stay in the "unknown" project group forever even once
-//     the sidecar appears (#1021). Bounded by maxIdleProjectResolveAttempts,
-//     since a non-git cwd or a sidecar-less adapter never resolves.
+// refreshStaleSessions re-reads working sessions that haven't received a
+// file-system watcher event recently. This catches tool calls
+// (AskUserQuestion, ExitPlanMode) that were missed because the subscriber
+// channel was full during concurrent bursts. It also drives
+// retryIdleProjectResolution for idle sessions on the same tick — see that
+// method for why idle sessions need a distinct, lighter-weight path (#1021).
 func (d *SessionDetector) refreshStaleSessions() {
 	sessions, err := d.repo.ListAll()
 	if err != nil {
@@ -1278,38 +1271,65 @@ func (d *SessionDetector) refreshStaleSessions() {
 			if now.Sub(time.Unix(state.UpdatedAt, 0)) < staleWorkingRefreshInterval {
 				continue
 			}
-		case session.StateWaiting, session.StateReady:
-			if state.ProjectName != "" || !d.shouldRetryIdleProjectResolution(state.SessionID) {
+			if state.TranscriptPath == "" {
 				continue
 			}
-		default:
-			continue
+			// Consent-gated per adapter (#570): this refresh re-reads the
+			// transcript independently of the (gated) watcher pipeline. After
+			// a revoke, persisted working sessions would otherwise keep being
+			// re-read and re-broadcast every tick — "existing sessions stop
+			// updating" must hold.
+			if !d.observeAllowed(state.Adapter) {
+				continue
+			}
+			d.processActivityWithoutIdentity(agent.Event{
+				Type:           agent.EventActivity,
+				SessionID:      state.SessionID,
+				TranscriptPath: state.TranscriptPath,
+			})
+		case session.StateWaiting, session.StateReady:
+			d.retryIdleProjectResolution(state, now)
 		}
-		if state.TranscriptPath == "" {
-			continue
-		}
-		// Consent-gated per adapter (#570): this refresh re-reads the
-		// transcript independently of the (gated) watcher pipeline. After
-		// a revoke, persisted working sessions would otherwise keep being
-		// re-read and re-broadcast every tick — "existing sessions stop
-		// updating" must hold.
-		if !d.observeAllowed(state.Adapter) {
-			continue
-		}
-		d.processActivityWithoutIdentity(agent.Event{
-			Type:           agent.EventActivity,
-			SessionID:      state.SessionID,
-			TranscriptPath: state.TranscriptPath,
-		})
 	}
 }
 
-// shouldRetryIdleProjectResolution reports whether an idle session with an
-// unresolved ProjectName should get another CWD/project-resolution pass this
-// tick, and records the attempt. Bounded by maxIdleProjectResolveAttempts so
-// a session whose cwd is genuinely unresolvable (non-git, or an adapter with
-// no sidecar) stops being re-read after a bounded window rather than forever
-// (#1021).
+// retryIdleProjectResolution re-attempts CWD/project/branch backfill for an
+// idle session whose ProjectName never resolved — e.g. mistral-vibe's
+// meta.json sidecar hadn't been written yet at the moment the transcript
+// went quiet. Nothing else ever revisits an idle session, so without this a
+// session would stay in the "unknown" project group forever even once the
+// sidecar appears (#1021).
+//
+// Deliberately narrower than the working-session refresh above: it reuses
+// metadataEnricher.backfillOne (the same startup-seed backfill path, see
+// seedBackfillMetadata) instead of the full processActivityWithoutIdentity
+// pipeline, so an idle session already sitting at rest never gets its
+// metrics recomputed or its state reclassified — just its CWD/branch/
+// project. Bounded by maxIdleProjectResolveAttempts so a session whose cwd
+// is genuinely unresolvable (non-git, or an adapter with no sidecar) stops
+// being re-read after a bounded window rather than forever.
+func (d *SessionDetector) retryIdleProjectResolution(state *session.SessionState, now time.Time) {
+	if state.ProjectName != "" || state.TranscriptPath == "" || !d.observeAllowed(state.Adapter) {
+		return
+	}
+	if !d.shouldRetryIdleProjectResolution(state.SessionID) {
+		return
+	}
+	if !d.enricher.backfillOne(state) {
+		return
+	}
+	state.UpdatedAt = now.Unix()
+	if err := d.repo.Save(state); err != nil {
+		d.log.LogError(logComponentSessionDetector, state.SessionID,
+			fmt.Sprintf("failed to backfill idle project metadata: %v", err))
+		return
+	}
+	d.broadcast(outbound.PushTypeUpdated, state)
+}
+
+// shouldRetryIdleProjectResolution reports whether an idle session should
+// get another retryIdleProjectResolution pass this tick, and records the
+// attempt. See maxIdleProjectResolveAttempts for the bound and its rationale.
 func (d *SessionDetector) shouldRetryIdleProjectResolution(sessionID string) bool {
 	d.permMu.Lock()
 	defer d.permMu.Unlock()

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1253,10 +1253,19 @@ func (d *SessionDetector) markStalledEditTool(sessionID string, m *session.Sessi
 	}
 }
 
-// refreshStaleSessions re-reads transcripts for working sessions that haven't
-// received a file-system watcher event recently. This catches tool calls
-// (AskUserQuestion, ExitPlanMode) that were missed because the subscriber
-// channel was full during concurrent bursts.
+// refreshStaleSessions re-reads transcripts for two categories of session the
+// normal fswatcher-driven pipeline can't self-correct:
+//   - working sessions that haven't received a file-system watcher event
+//     recently. This catches tool calls (AskUserQuestion, ExitPlanMode) that
+//     were missed because the subscriber channel was full during concurrent
+//     bursts.
+//   - idle (waiting/ready) sessions whose ProjectName never resolved because
+//     their adapter's metadata sidecar (e.g. mistral-vibe's meta.json)
+//     hadn't been written yet at the moment the transcript went quiet —
+//     nothing else ever revisits an idle session, so without this the
+//     session would stay in the "unknown" project group forever even once
+//     the sidecar appears (#1021). Bounded by maxIdleProjectResolveAttempts,
+//     since a non-git cwd or a sidecar-less adapter never resolves.
 func (d *SessionDetector) refreshStaleSessions() {
 	sessions, err := d.repo.ListAll()
 	if err != nil {
@@ -1264,7 +1273,16 @@ func (d *SessionDetector) refreshStaleSessions() {
 	}
 	now := time.Now()
 	for _, state := range sessions {
-		if state.State != session.StateWorking {
+		switch state.State {
+		case session.StateWorking:
+			if now.Sub(time.Unix(state.UpdatedAt, 0)) < staleWorkingRefreshInterval {
+				continue
+			}
+		case session.StateWaiting, session.StateReady:
+			if state.ProjectName != "" || !d.shouldRetryIdleProjectResolution(state.SessionID) {
+				continue
+			}
+		default:
 			continue
 		}
 		if state.TranscriptPath == "" {
@@ -1278,13 +1296,26 @@ func (d *SessionDetector) refreshStaleSessions() {
 		if !d.observeAllowed(state.Adapter) {
 			continue
 		}
-		if now.Sub(time.Unix(state.UpdatedAt, 0)) < staleWorkingRefreshInterval {
-			continue
-		}
 		d.processActivityWithoutIdentity(agent.Event{
 			Type:           agent.EventActivity,
 			SessionID:      state.SessionID,
 			TranscriptPath: state.TranscriptPath,
 		})
 	}
+}
+
+// shouldRetryIdleProjectResolution reports whether an idle session with an
+// unresolved ProjectName should get another CWD/project-resolution pass this
+// tick, and records the attempt. Bounded by maxIdleProjectResolveAttempts so
+// a session whose cwd is genuinely unresolvable (non-git, or an adapter with
+// no sidecar) stops being re-read after a bounded window rather than forever
+// (#1021).
+func (d *SessionDetector) shouldRetryIdleProjectResolution(sessionID string) bool {
+	d.permMu.Lock()
+	defer d.permMu.Unlock()
+	if d.idleProjectRetryAttempts[sessionID] >= maxIdleProjectResolveAttempts {
+		return false
+	}
+	d.idleProjectRetryAttempts[sessionID]++
+	return true
 }

--- a/core/application/services/session_detector_idle_project_retry_internal_test.go
+++ b/core/application/services/session_detector_idle_project_retry_internal_test.go
@@ -1,0 +1,44 @@
+package services
+
+import "testing"
+
+// TestShouldRetryIdleProjectResolution_CapsAtMax pins the exact bound
+// maxIdleProjectResolveAttempts places on shouldRetryIdleProjectResolution
+// (#1021): the first maxIdleProjectResolveAttempts calls for a session must
+// each report "retry", and every call after that must report "give up" —
+// forever, not just once past the cap.
+func TestShouldRetryIdleProjectResolution_CapsAtMax(t *testing.T) {
+	d := &SessionDetector{idleProjectRetryAttempts: map[string]int{}}
+
+	for i := range maxIdleProjectResolveAttempts {
+		if !d.shouldRetryIdleProjectResolution("s") {
+			t.Fatalf("attempt %d: expected retry allowed within the cap", i+1)
+		}
+	}
+
+	for i := range 3 {
+		if d.shouldRetryIdleProjectResolution("s") {
+			t.Fatalf("attempt past cap (extra call %d): expected retry to be refused", i+1)
+		}
+	}
+
+	if got := d.idleProjectRetryAttempts["s"]; got != maxIdleProjectResolveAttempts {
+		t.Fatalf("attempt counter = %d, want it to stay pinned at %d", got, maxIdleProjectResolveAttempts)
+	}
+}
+
+// TestShouldRetryIdleProjectResolution_PerSessionIndependent verifies the
+// retry budget is tracked independently per session, so a capped-out session
+// doesn't starve a different session's retries.
+func TestShouldRetryIdleProjectResolution_PerSessionIndependent(t *testing.T) {
+	d := &SessionDetector{idleProjectRetryAttempts: map[string]int{
+		"exhausted": maxIdleProjectResolveAttempts,
+	}}
+
+	if d.shouldRetryIdleProjectResolution("exhausted") {
+		t.Fatal("expected the exhausted session to be refused")
+	}
+	if !d.shouldRetryIdleProjectResolution("fresh") {
+		t.Fatal("expected a different session to still get its own retry budget")
+	}
+}

--- a/core/application/services/session_detector_idle_project_retry_test.go
+++ b/core/application/services/session_detector_idle_project_retry_test.go
@@ -8,23 +8,24 @@ import (
 	"irrlicht/core/domain/session"
 )
 
-// delayedCWDGit fails to resolve a cwd for the first failFor calls to
-// GetCWDFromTranscript, then returns cwd — modeling an adapter sidecar (e.g.
-// mistral-vibe's meta.json) that's lazily created a few ticks after the
-// transcript goes idle (#1021).
-type delayedCWDGit struct {
-	mockGit
-	calls   int
-	failFor int
-	cwd     string
-}
-
-func (g *delayedCWDGit) GetCWDFromTranscript(path string) string {
-	g.calls++
-	if g.calls <= g.failFor {
-		return ""
-	}
-	return g.cwd
+// newIdleUnresolvedSession persists an idle session fixture with an
+// unresolved ProjectName — the #1021 precondition (a metadata sidecar, e.g.
+// mistral-vibe's meta.json, wasn't readable yet when the transcript went
+// quiet). Shared by the retry-cap tests below.
+func newIdleUnresolvedSession(t *testing.T, repo *mockRepo, sessionID, state string) {
+	t.Helper()
+	transcriptPath := filepath.Join(t.TempDir(), sessionID+".jsonl")
+	writeOldTranscript(t, transcriptPath, 0)
+	now := time.Now().Unix()
+	repo.Save(&session.SessionState{
+		SessionID:      sessionID,
+		State:          state,
+		Adapter:        "mistral-vibe",
+		TranscriptPath: transcriptPath,
+		PID:            4242,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	})
 }
 
 // TestSessionDetector_IdleUnresolvedProject_RetriesUntilSidecarAppears
@@ -39,22 +40,9 @@ func TestSessionDetector_IdleUnresolvedProject_RetriesUntilSidecarAppears(t *tes
 	pw := newMockProcessWatcher()
 	repo := newMockRepo()
 
-	git := &delayedCWDGit{failFor: 2, cwd: t.TempDir()}
+	git := &cwdGit{cwd: t.TempDir(), failFor: 2}
 	det := newDetectorWithLiveCWDs(tw, pw, repo, git, nil, nil)
-
-	transcriptPath := filepath.Join(t.TempDir(), "vibe1.jsonl")
-	writeOldTranscript(t, transcriptPath, 0)
-
-	now := time.Now().Unix()
-	repo.Save(&session.SessionState{
-		SessionID:      "vibe1",
-		State:          session.StateWaiting,
-		Adapter:        "mistral-vibe",
-		TranscriptPath: transcriptPath,
-		PID:            4242,
-		FirstSeen:      now,
-		UpdatedAt:      now,
-	})
+	newIdleUnresolvedSession(t, repo, "vibe1", session.StateWaiting)
 
 	for range 3 {
 		det.RunStaleSessionRefreshForTest()
@@ -79,22 +67,9 @@ func TestSessionDetector_IdleUnresolvedProject_StopsRetryingAfterCap(t *testing.
 	pw := newMockProcessWatcher()
 	repo := newMockRepo()
 
-	git := &delayedCWDGit{failFor: 1000} // never resolves within this test
+	git := &cwdGit{failFor: 1000} // never resolves within this test
 	det := newDetectorWithLiveCWDs(tw, pw, repo, git, nil, nil)
-
-	transcriptPath := filepath.Join(t.TempDir(), "vibe2.jsonl")
-	writeOldTranscript(t, transcriptPath, 0)
-
-	now := time.Now().Unix()
-	repo.Save(&session.SessionState{
-		SessionID:      "vibe2",
-		State:          session.StateReady,
-		Adapter:        "mistral-vibe",
-		TranscriptPath: transcriptPath,
-		PID:            4242,
-		FirstSeen:      now,
-		UpdatedAt:      now,
-	})
+	newIdleUnresolvedSession(t, repo, "vibe2", session.StateReady)
 
 	for range 20 {
 		det.RunStaleSessionRefreshForTest()

--- a/core/application/services/session_detector_idle_project_retry_test.go
+++ b/core/application/services/session_detector_idle_project_retry_test.go
@@ -1,0 +1,117 @@
+package services_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// delayedCWDGit fails to resolve a cwd for the first failFor calls to
+// GetCWDFromTranscript, then returns cwd — modeling an adapter sidecar (e.g.
+// mistral-vibe's meta.json) that's lazily created a few ticks after the
+// transcript goes idle (#1021).
+type delayedCWDGit struct {
+	mockGit
+	calls   int
+	failFor int
+	cwd     string
+}
+
+func (g *delayedCWDGit) GetCWDFromTranscript(path string) string {
+	g.calls++
+	if g.calls <= g.failFor {
+		return ""
+	}
+	return g.cwd
+}
+
+// TestSessionDetector_IdleUnresolvedProject_RetriesUntilSidecarAppears
+// reproduces #1021: an idle (waiting) session whose ProjectName never
+// resolved because the metadata sidecar wasn't readable yet at the moment
+// the transcript went quiet. Nothing else revisits an idle session, so
+// refreshStaleSessions must keep retrying CWD/project resolution on its own
+// ticker until the sidecar appears, instead of leaving the session in the
+// "unknown" project group forever.
+func TestSessionDetector_IdleUnresolvedProject_RetriesUntilSidecarAppears(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	git := &delayedCWDGit{failFor: 2, cwd: t.TempDir()}
+	det := newDetectorWithLiveCWDs(tw, pw, repo, git, nil, nil)
+
+	transcriptPath := filepath.Join(t.TempDir(), "vibe1.jsonl")
+	writeOldTranscript(t, transcriptPath, 0)
+
+	now := time.Now().Unix()
+	repo.Save(&session.SessionState{
+		SessionID:      "vibe1",
+		State:          session.StateWaiting,
+		Adapter:        "mistral-vibe",
+		TranscriptPath: transcriptPath,
+		PID:            4242,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	})
+
+	for range 3 {
+		det.RunStaleSessionRefreshForTest()
+	}
+
+	state, err := repo.Load("vibe1")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if state.ProjectName == "" {
+		t.Fatalf("expected ProjectName resolved once the sidecar appears, got %q (cwd=%q)", state.ProjectName, state.CWD)
+	}
+}
+
+// TestSessionDetector_IdleUnresolvedProject_StopsRetryingAfterCap covers the
+// other half of #1021's ask: a session whose cwd is genuinely unresolvable
+// (non-git cwd, or an adapter with no sidecar at all) must not be re-read by
+// refreshStaleSessions forever. Runs the ticker well past any reasonable
+// retry budget and asserts the resolution attempts stop growing.
+func TestSessionDetector_IdleUnresolvedProject_StopsRetryingAfterCap(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	git := &delayedCWDGit{failFor: 1000} // never resolves within this test
+	det := newDetectorWithLiveCWDs(tw, pw, repo, git, nil, nil)
+
+	transcriptPath := filepath.Join(t.TempDir(), "vibe2.jsonl")
+	writeOldTranscript(t, transcriptPath, 0)
+
+	now := time.Now().Unix()
+	repo.Save(&session.SessionState{
+		SessionID:      "vibe2",
+		State:          session.StateReady,
+		Adapter:        "mistral-vibe",
+		TranscriptPath: transcriptPath,
+		PID:            4242,
+		FirstSeen:      now,
+		UpdatedAt:      now,
+	})
+
+	for range 20 {
+		det.RunStaleSessionRefreshForTest()
+	}
+	callsAfter20 := git.calls
+	if callsAfter20 == 0 {
+		t.Fatal("expected at least one resolution attempt")
+	}
+
+	for range 20 {
+		det.RunStaleSessionRefreshForTest()
+	}
+	if git.calls != callsAfter20 {
+		t.Fatalf("expected retries to stop after a bounded cap, got %d calls after 20 ticks then %d after 40", callsAfter20, git.calls)
+	}
+
+	if state, _ := repo.Load("vibe2"); state.ProjectName != "" {
+		t.Fatalf("expected ProjectName to remain unresolved, got %q", state.ProjectName)
+	}
+}

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -46,6 +46,7 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	delete(d.permissionPending, ev.SessionID)
 	delete(d.compactPending, ev.SessionID)
 	delete(d.editToolOpenSince, ev.SessionID)
+	delete(d.idleProjectRetryAttempts, ev.SessionID)
 	d.permMu.Unlock()
 
 	state, err := d.repo.Load(ev.SessionID)

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -319,12 +319,26 @@ func (g *mockGit) GetCWDFromTranscript(path string) string    { return "" }
 // cwdGit is a mockGit whose GetCWDFromTranscript returns a fixed cwd. It
 // mimics the production fswatcher path, where EventNewSession carries no
 // CWD and the cwd comes from transcript content (issue #576 rescue).
+//
+// failFor optionally models an adapter sidecar (e.g. mistral-vibe's
+// meta.json) that isn't readable yet: the first failFor calls return "" and
+// only later calls return cwd. Zero (the default used by every other caller)
+// means "always resolve immediately" — today's behavior. calls records the
+// running call count so #1021's bounded-retry tests can assert on it.
 type cwdGit struct {
 	mockGit
-	cwd string
+	cwd     string
+	failFor int
+	calls   int
 }
 
-func (g *cwdGit) GetCWDFromTranscript(path string) string { return g.cwd }
+func (g *cwdGit) GetCWDFromTranscript(path string) string {
+	g.calls++
+	if g.calls <= g.failFor {
+		return ""
+	}
+	return g.cwd
+}
 
 // defaultSessionDetectorDeps returns the SessionDetectorDeps most detector
 // tests in this file build identically (mockLogger/mockGit/mockMetrics, no


### PR DESCRIPTION
## Summary

- Idle (waiting/ready) mistral-vibe sessions whose `ProjectName` was still unresolved when the transcript went quiet stayed stuck in the "unknown" project group forever, even after the adapter's lazily-created `meta.json` sidecar later appeared on disk — nothing ever re-triggered CWD/project resolution once a session left the `working` state.
- Extends `refreshStaleSessions`'s existing 5s ticker (previously scoped to `working` sessions only) to also retry CWD/project resolution for idle sessions with an unresolved `ProjectName`, bounded by a new `maxIdleProjectResolveAttempts` cap (12 attempts) so a session that's genuinely unresolvable (non-git cwd, or an adapter with no sidecar at all) stops being re-read after a bounded window instead of forever.
- Per-session retry counters live in a new `idleProjectRetryAttempts` map (guarded by the existing `permMu`, cleaned up in `onRemoved` alongside the other ephemeral per-session maps).

Closes #1021

## Test plan

- [x] `go test ./core/... -race -count=1` — full suite green
- [x] New tests:
  - `TestSessionDetector_IdleUnresolvedProject_RetriesUntilSidecarAppears` — an idle session with an unresolved project picks up `ProjectName` once the (mocked) sidecar becomes readable on a later tick
  - `TestSessionDetector_IdleUnresolvedProject_StopsRetryingAfterCap` — a session that never resolves stops accumulating resolution attempts after a bounded number of ticks
  - `TestShouldRetryIdleProjectResolution_CapsAtMax` / `TestShouldRetryIdleProjectResolution_PerSessionIndependent` — white-box coverage of the retry-cap bookkeeping
- [x] `tools/preflight.sh` (pre-push hook) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)