### PR TITLE
fix: hold parent working on Claude Code's own pendingBackgroundAgentCount

### DIFF
--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -227,6 +227,10 @@ func handleSystemEvent(raw map[string]interface{}, ev *tailer.ParsedEvent) {
 	subtype, _ := raw["subtype"].(string)
 	if subtype == "turn_duration" || subtype == "stop_hook_summary" {
 		ev.EventType = "turn_done"
+		if v, ok := raw["pendingBackgroundAgentCount"].(float64); ok {
+			n := int(v)
+			ev.PendingBackgroundAgentCount = &n
+		}
 		return
 	}
 	if subtype == "compact_boundary" {

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -247,6 +247,43 @@ func TestParser_SystemEvent_TurnDone(t *testing.T) {
 	}
 }
 
+func TestParser_SystemEvent_TurnDone_PendingBackgroundAgentCount(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type":                        "system",
+		"subtype":                     "turn_duration",
+		"timestamp":                   "2026-04-05T22:00:00Z",
+		"pendingBackgroundAgentCount": float64(2),
+	})
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if ev.PendingBackgroundAgentCount == nil {
+		t.Fatal("expected PendingBackgroundAgentCount to be set")
+	}
+	if *ev.PendingBackgroundAgentCount != 2 {
+		t.Errorf("PendingBackgroundAgentCount = %d, want 2", *ev.PendingBackgroundAgentCount)
+	}
+}
+
+func TestParser_SystemEvent_TurnDone_PendingBackgroundAgentCountAbsent(t *testing.T) {
+	// Older Claude Code versions write turn_duration with no
+	// pendingBackgroundAgentCount field at all — absence must not be read
+	// as an explicit zero. See issue #1036.
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type":      "system",
+		"subtype":   "turn_duration",
+		"timestamp": "2026-04-05T22:00:00Z",
+	})
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
+	if ev.PendingBackgroundAgentCount != nil {
+		t.Errorf("PendingBackgroundAgentCount = %v, want nil when the field is absent", *ev.PendingBackgroundAgentCount)
+	}
+}
+
 func TestParser_SystemEvent_StopHookSummary(t *testing.T) {
 	p := &Parser{}
 	ev := p.ParseLine(map[string]interface{}{

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -63,6 +63,7 @@ func (mc *MetricsConverter) Convert(m *tailer.SessionMetrics) *session.SessionMe
 		BackgroundProcessCount:            m.BackgroundProcessCount,
 		BackgroundProcessOutputs:          m.BackgroundProcessOutputs,
 		BackgroundProcessPIDs:             m.BackgroundProcessPIDs,
+		PendingBackgroundAgentCount:       m.PendingBackgroundAgentCount,
 		LastEventType:                     m.LastEventType,
 		LastOpenToolNames:                 copyStrings(m.LastOpenToolNames),
 		LastWasUserInterrupt:              m.LastWasUserInterrupt,
@@ -81,9 +82,6 @@ func (mc *MetricsConverter) Convert(m *tailer.SessionMetrics) *session.SessionMe
 		NoSubstantiveActivity:             m.NoSubstantiveActivity,
 		SawManualCompactBoundary:          m.SawManualCompactBoundary,
 		SawMidPassTurnBoundary:            m.SawMidPassTurnBoundary,
-	}
-	if m.PendingBackgroundAgentCount != nil {
-		result.PendingBackgroundAgentCount = *m.PendingBackgroundAgentCount
 	}
 	if len(m.SubagentCompletions) > 0 {
 		result.SubagentCompletions = make([]session.SubagentCompletion, len(m.SubagentCompletions))

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -82,6 +82,9 @@ func (mc *MetricsConverter) Convert(m *tailer.SessionMetrics) *session.SessionMe
 		SawManualCompactBoundary:          m.SawManualCompactBoundary,
 		SawMidPassTurnBoundary:            m.SawMidPassTurnBoundary,
 	}
+	if m.PendingBackgroundAgentCount != nil {
+		result.PendingBackgroundAgentCount = *m.PendingBackgroundAgentCount
+	}
 	if len(m.SubagentCompletions) > 0 {
 		result.SubagentCompletions = make([]session.SubagentCompletion, len(m.SubagentCompletions))
 		for i, c := range m.SubagentCompletions {

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -870,10 +870,17 @@ func (d *SessionDetector) overlayPermissionPending(state *session.SessionState) 
 // "orphaned" children — subagents whose own tail has no open tool calls but
 // whose transcript ends with `stop_reason: null` (Claude Code never writes
 // end_turn for in-process subagents) — via holdIfChildrenActive, so a merely
-// stale child doesn't hold the parent forever. Returns the (possibly
-// overridden) newState/reason and whether the hold fired, so the caller can
-// skip the same-pass collapsed-waiting synthesis: that path would otherwise
-// reclassify from waiting and undo the hold.
+// stale child doesn't hold the parent forever. Also holds when Claude Code's
+// own pendingBackgroundAgentCount (issue #1036) still reports a background
+// subagent running — an independent signal from the file-based child-session
+// check, needed because a child's transcript can finish and get reclassified
+// to ready (and cleaned up) a few seconds before Claude Code delivers the
+// task-notification that gives the parent a reason to keep working; without
+// this, hasActiveChildren finds nothing in that gap and the parent flips to
+// ready. Returns the (possibly overridden) newState/reason and whether the
+// hold fired, so the caller can skip the same-pass collapsed-waiting
+// synthesis: that path would otherwise reclassify from waiting and undo the
+// hold.
 func (d *SessionDetector) holdParentForActiveChildren(state *session.SessionState, ev agent.Event, newState, reason string) (string, string, bool) {
 	if state.ParentSessionID != "" {
 		return newState, reason, false
@@ -885,12 +892,17 @@ func (d *SessionDetector) holdParentForActiveChildren(state *session.SessionStat
 	if newState != session.StateReady && !turnDoneWaiting {
 		return newState, reason, false
 	}
-	if !d.holdIfChildrenActive(state.SessionID) {
+	activeChildren := d.holdIfChildrenActive(state.SessionID)
+	if !activeChildren && !hasPendingBackgroundAgents(state.Metrics) {
 		return newState, reason, false
 	}
-	logMsg := "holding parent working — active children still running"
+	holdSource := "active children still running"
+	if !activeChildren {
+		holdSource = "Claude Code reports a background agent still pending"
+	}
+	logMsg := "holding parent working — " + holdSource
 	if turnDoneWaiting {
-		logMsg = "holding parent working — active children still running (turn ended in waiting cue)"
+		logMsg += " (turn ended in waiting cue)"
 	}
 	d.log.LogInfo(logComponentSessionDetector, ev.SessionID, logMsg)
 	return session.StateWorking, "", true

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -864,23 +864,17 @@ func (d *SessionDetector) overlayPermissionPending(state *session.SessionState) 
 
 // holdParentForActiveChildren fast-forwards a parent's own transition when
 // it would otherwise land on ready, or on a turn-done "waiting"
-// (question/cue), while a child subagent is still working or waiting —
-// mirroring the ready case so the dashboard doesn't read "nothing happening"
-// while a subagent runs (issue #897). Before holding, it fast-forwards any
-// "orphaned" children — subagents whose own tail has no open tool calls but
-// whose transcript ends with `stop_reason: null` (Claude Code never writes
-// end_turn for in-process subagents) — via holdIfChildrenActive, so a merely
-// stale child doesn't hold the parent forever. Also holds when Claude Code's
-// own pendingBackgroundAgentCount (issue #1036) still reports a background
-// subagent running — an independent signal from the file-based child-session
-// check, needed because a child's transcript can finish and get reclassified
-// to ready (and cleaned up) a few seconds before Claude Code delivers the
-// task-notification that gives the parent a reason to keep working; without
-// this, hasActiveChildren finds nothing in that gap and the parent flips to
-// ready. Returns the (possibly overridden) newState/reason and whether the
-// hold fired, so the caller can skip the same-pass collapsed-waiting
-// synthesis: that path would otherwise reclassify from waiting and undo the
-// hold.
+// (question/cue), while a child subagent is still working or waiting, per
+// holdIfChildrenActive/hasActiveChildren — mirroring the ready case so the
+// dashboard doesn't read "nothing happening" while a subagent runs (issue
+// #897). Before holding, it fast-forwards any "orphaned" children —
+// subagents whose own tail has no open tool calls but whose transcript ends
+// with `stop_reason: null` (Claude Code never writes end_turn for in-process
+// subagents) — via holdIfChildrenActive, so a merely stale child doesn't
+// hold the parent forever. Returns the (possibly overridden) newState/reason
+// and whether the hold fired, so the caller can skip the same-pass
+// collapsed-waiting synthesis: that path would otherwise reclassify from
+// waiting and undo the hold.
 func (d *SessionDetector) holdParentForActiveChildren(state *session.SessionState, ev agent.Event, newState, reason string) (string, string, bool) {
 	if state.ParentSessionID != "" {
 		return newState, reason, false
@@ -892,17 +886,12 @@ func (d *SessionDetector) holdParentForActiveChildren(state *session.SessionStat
 	if newState != session.StateReady && !turnDoneWaiting {
 		return newState, reason, false
 	}
-	activeChildren := d.holdIfChildrenActive(state.SessionID)
-	if !activeChildren && !hasPendingBackgroundAgents(state.Metrics) {
+	if !d.holdIfChildrenActive(state.SessionID, state.Metrics) {
 		return newState, reason, false
 	}
-	holdSource := "active children still running"
-	if !activeChildren {
-		holdSource = "Claude Code reports a background agent still pending"
-	}
-	logMsg := "holding parent working — " + holdSource
+	logMsg := "holding parent working — active children still running"
 	if turnDoneWaiting {
-		logMsg += " (turn ended in waiting cue)"
+		logMsg = "holding parent working — active children still running (turn ended in waiting cue)"
 	}
 	d.log.LogInfo(logComponentSessionDetector, ev.SessionID, logMsg)
 	return session.StateWorking, "", true

--- a/core/application/services/session_detector_subagent.go
+++ b/core/application/services/session_detector_subagent.go
@@ -193,9 +193,20 @@ func (d *SessionDetector) applyOneSubagentCompletion(s *session.SessionState, pa
 }
 
 // hasActiveChildren returns true if any child session of the given parent is
-// still working or waiting. Used to prevent a parent from transitioning to
-// ready while background/foreground subagents are still processing.
-func (d *SessionDetector) hasActiveChildren(parentID string) bool {
+// still working or waiting, OR Claude Code's own turn_duration accounting
+// (issue #1036) says a background subagent is still running. The two are
+// independent signals for the same question — has the parent's background
+// work actually finished — combined here so every caller gets one
+// indivisible verdict instead of two booleans it would otherwise have to
+// remember to OR together. The metrics-based signal matters because a child
+// subagent's transcript can finish and get reclassified to ready (and
+// cleaned up) a few seconds before Claude Code delivers the
+// task-notification that would give the parent a reason to keep working —
+// in that gap the file-based check below finds nothing on its own.
+func (d *SessionDetector) hasActiveChildren(parentID string, metrics *session.SessionMetrics) bool {
+	if metrics != nil && metrics.PendingBackgroundAgentCount > 0 {
+		return true
+	}
 	states, err := d.repo.ListAll()
 	if err != nil {
 		return false
@@ -211,26 +222,13 @@ func (d *SessionDetector) hasActiveChildren(parentID string) bool {
 
 // holdIfChildrenActive fast-forwards any orphaned children of sessionID
 // (see finishOrphanedChildren) and reports whether a genuinely active one
-// remains. Shared by processActivity's ready and turn-done-waiting branches,
-// which both hold the parent working identically when it does (#897) — a
-// single call site keeps that hold logic from drifting out of sync between
-// the two.
-func (d *SessionDetector) holdIfChildrenActive(sessionID string) bool {
+// remains, per hasActiveChildren. Shared by processActivity's ready and
+// turn-done-waiting branches, which both hold the parent working identically
+// when it does (#897) — a single call site keeps that hold logic from
+// drifting out of sync between the two.
+func (d *SessionDetector) holdIfChildrenActive(sessionID string, metrics *session.SessionMetrics) bool {
 	d.finishOrphanedChildren(sessionID)
-	return d.hasActiveChildren(sessionID)
-}
-
-// hasPendingBackgroundAgents reports whether Claude Code's own turn_duration
-// accounting (issue #1036) says a background subagent is still running. This
-// is a second, independent signal alongside hasActiveChildren's file-based
-// child-session tracking — it closes a race where a child subagent's
-// transcript finishes and gets reclassified to ready (and cleaned up) a few
-// seconds before Claude Code delivers the task-notification that would give
-// the parent a reason to keep working. Used by both holdParentForActiveChildren
-// (the parent's own activity pass) and reevaluateParent (triggered by a
-// child's state change), which share the identical race.
-func hasPendingBackgroundAgents(m *session.SessionMetrics) bool {
-	return m != nil && m.PendingBackgroundAgentCount > 0
+	return d.hasActiveChildren(sessionID, metrics)
 }
 
 // holdParentWorkingForNewChild forces a parent session that is sitting at
@@ -300,9 +298,8 @@ func (d *SessionDetector) reevaluateParent(parentID string) {
 	// — see finishOrphanedChildren doc for rationale.
 	d.finishOrphanedChildren(parentID)
 
-	// Still have active children, or Claude Code's own accounting says a
-	// background subagent is still pending (issue #1036) — stay working.
-	if d.hasActiveChildren(parentID) || hasPendingBackgroundAgents(parent.Metrics) {
+	// Still have active children, per hasActiveChildren — stay working.
+	if d.hasActiveChildren(parentID, parent.Metrics) {
 		return
 	}
 

--- a/core/application/services/session_detector_subagent.go
+++ b/core/application/services/session_detector_subagent.go
@@ -220,6 +220,19 @@ func (d *SessionDetector) holdIfChildrenActive(sessionID string) bool {
 	return d.hasActiveChildren(sessionID)
 }
 
+// hasPendingBackgroundAgents reports whether Claude Code's own turn_duration
+// accounting (issue #1036) says a background subagent is still running. This
+// is a second, independent signal alongside hasActiveChildren's file-based
+// child-session tracking — it closes a race where a child subagent's
+// transcript finishes and gets reclassified to ready (and cleaned up) a few
+// seconds before Claude Code delivers the task-notification that would give
+// the parent a reason to keep working. Used by both holdParentForActiveChildren
+// (the parent's own activity pass) and reevaluateParent (triggered by a
+// child's state change), which share the identical race.
+func hasPendingBackgroundAgents(m *session.SessionMetrics) bool {
+	return m != nil && m.PendingBackgroundAgentCount > 0
+}
+
 // holdParentWorkingForNewChild forces a parent session that is sitting at
 // ready back to working the moment a new child of it is discovered.
 //
@@ -287,8 +300,9 @@ func (d *SessionDetector) reevaluateParent(parentID string) {
 	// — see finishOrphanedChildren doc for rationale.
 	d.finishOrphanedChildren(parentID)
 
-	// Still have active children — stay working.
-	if d.hasActiveChildren(parentID) {
+	// Still have active children, or Claude Code's own accounting says a
+	// background subagent is still pending (issue #1036) — stay working.
+	if d.hasActiveChildren(parentID) || hasPendingBackgroundAgents(parent.Metrics) {
 		return
 	}
 

--- a/core/application/services/session_detector_subagent_test.go
+++ b/core/application/services/session_detector_subagent_test.go
@@ -158,6 +158,69 @@ func TestSessionDetector_ParentHeldWorking_WhenChildrenActive(t *testing.T) {
 	<-done
 }
 
+// TestSessionDetector_ParentHeldWorking_ByPendingBackgroundAgentCount
+// reproduces issue #1036: a child subagent's transcript finishes and gets
+// reclassified to ready (and cleaned up) a few seconds before Claude Code
+// delivers the task-notification that would give the parent a reason to
+// keep working. In that gap the file-based hasActiveChildren check finds
+// nothing — here there is no child session in the repo at all — so without
+// consulting Claude Code's own pendingBackgroundAgentCount signal the parent
+// would incorrectly flip to ready while a background subagent is still
+// actually running.
+func TestSessionDetector_ParentHeldWorking_ByPendingBackgroundAgentCount(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+
+	// Parent session: turn is done, no open tool calls, and no child session
+	// exists in the repo — but Claude Code's own turn_duration event still
+	// reports one background agent pending.
+	repo.Save(&session.SessionState{
+		SessionID:      "parent-1036",
+		State:          session.StateWorking,
+		TranscriptPath: "/home/.claude/projects/-Users-test/parent-1036.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:               "turn_done",
+			HasOpenToolCall:             false,
+			LastAssistantText:           "Waiting on the other investigation.",
+			PendingBackgroundAgentCount: 1,
+		},
+	})
+
+	// Trigger parent activity — should be held in working because Claude
+	// Code's own count says a background agent is still pending, even
+	// though the repo has no child session tracking it.
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "parent-1036",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: "/home/.claude/projects/-Users-test/parent-1036.jsonl",
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	state, _ := repo.Load("parent-1036")
+	if state.State != session.StateWorking {
+		t.Errorf("parent state: got %q, want working (PendingBackgroundAgentCount=1)", state.State)
+	}
+
+	cancel()
+	<-done
+}
+
 // TestSessionDetector_ParentHeldWorking_WhenNewChildDiscoveredWhileReady
 // reproduces issue #889: a parent running a background Workflow-tool call can
 // have its own turn-done fire while it has zero active children — either
@@ -307,6 +370,87 @@ func TestSessionDetector_ParentReleasedToReady_WhenChildFinishes(t *testing.T) {
 	repo.mu.Unlock()
 	if got != session.StateReady {
 		t.Errorf("parent state: got %q, want ready (child finished, parent turn was done)", got)
+	}
+
+	cancel()
+	<-done
+}
+
+// TestSessionDetector_ReevaluateParent_HeldByPendingBackgroundAgentCount
+// reproduces the exact issue #1036 incident: two subagents are running, one
+// finishes first, its own activity pass transitions it to ready and (via
+// finalizeActivityPass) triggers reevaluateParent on the parent — the same
+// path TestSessionDetector_ParentReleasedToReady_WhenChildFinishes exercises.
+// But here the parent's own turn_duration event still reports ONE background
+// agent pending (the other subagent, not tracked as a child session in this
+// test — mirroring the real race where it had already been cleaned up).
+// hasActiveChildren alone would find nothing and release the parent to
+// ready; the PendingBackgroundAgentCount check must hold it instead.
+func TestSessionDetector_ReevaluateParent_HeldByPendingBackgroundAgentCount(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+
+	// Parent: turn done, held in working — Claude Code's own accounting
+	// says one background agent (not the tracked child below) is still
+	// pending.
+	repo.Save(&session.SessionState{
+		SessionID:      "parent-1036b",
+		State:          session.StateWorking,
+		TranscriptPath: "/home/.claude/projects/-Users-test/parent-1036b.jsonl",
+		FirstSeen:      now,
+		UpdatedAt:      now,
+		EventCount:     5,
+		Metrics: &session.SessionMetrics{
+			LastEventType:               "turn_done",
+			HasOpenToolCall:             false,
+			LastAssistantText:           "Web implementation mapped — waiting on the other investigation.",
+			PendingBackgroundAgentCount: 1,
+		},
+	})
+
+	// Tracked child: finishes this pass.
+	repo.Save(&session.SessionState{
+		SessionID:       "child-1036b",
+		State:           session.StateWorking,
+		ParentSessionID: "parent-1036b",
+		TranscriptPath:  "/home/.claude/projects/-Users-test/parent-1036b/subagents/child-1036b.jsonl",
+		FirstSeen:       now,
+		UpdatedAt:       now,
+		EventCount:      3,
+		Metrics: &session.SessionMetrics{
+			LastEventType:   "turn_done",
+			HasOpenToolCall: false,
+		},
+	})
+
+	// Trigger the tracked child's activity — it transitions to ready and
+	// reevaluates the parent. The parent must stay working: its own
+	// PendingBackgroundAgentCount still says a (differently-tracked)
+	// background agent is running.
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      "child-1036b",
+		ProjectDir:     "-Users-test",
+		TranscriptPath: "/home/.claude/projects/-Users-test/parent-1036b/subagents/child-1036b.jsonl",
+	}
+
+	waitForSessionState(repo, "child-1036b", session.StateReady, 500*time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
+
+	parent, _ := repo.Load("parent-1036b")
+	if parent.State != session.StateWorking {
+		t.Errorf("parent state: got %q, want working — PendingBackgroundAgentCount=1 must hold it even though the tracked child finished", parent.State)
 	}
 
 	cancel()

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -47,6 +47,20 @@ type SessionMetrics struct {
 	// domain model is agnostic to how each adapter represents subagents.
 	OpenSubagents int `json:"open_subagents,omitempty"`
 
+	// PendingBackgroundAgentCount is Claude Code's own last-reported count of
+	// still-running background subagents (Agent-tool launches), read from the
+	// transcript's turn_duration system event. It is a second, independent
+	// signal alongside the file-based child-session tracking that
+	// holdParentForActiveChildren normally relies on — Claude Code's own
+	// accounting closes a race where a child subagent's transcript finishes
+	// and gets reclassified to ready moments before Claude Code delivers the
+	// task-notification that gives the parent a reason to keep working (issue
+	// #1036). Zero when Claude Code reports none pending, or when the
+	// adapter/version doesn't surface this field at all — either way, the
+	// file-based check remains the source of truth this signal is only ORed
+	// against, never a replacement for it.
+	PendingBackgroundAgentCount int `json:"pending_background_agent_count,omitempty"`
+
 	// BackgroundProcessCount is the number of agent-spawned background
 	// processes the transcript shows as still open — for Claude Code, a
 	// `Bash` tool call with `run_in_background: true` that has not yet been
@@ -479,6 +493,12 @@ func newMergedMetrics(newM *SessionMetrics) *SessionMetrics {
 		HasOpenToolCall:      newM.HasOpenToolCall,
 		OpenToolCallCount:    newM.OpenToolCallCount,
 		OpenSubagents:        newM.OpenSubagents,
+		// PendingBackgroundAgentCount is already sticky one layer down (the
+		// tailer carries the last-observed value across passes with no fresh
+		// turn_duration event), and 0 is a legitimate, must-not-be-overridden
+		// "none pending" verdict — so it's copied verbatim, like
+		// BackgroundProcessCount, with no zero-carry-forward here.
+		PendingBackgroundAgentCount: newM.PendingBackgroundAgentCount,
 		// Background-process fields are recomputed from the transcript every
 		// pass (count + output paths + PIDs) — copy the new values verbatim.
 		// HasLiveBackgroundProcess is set by the detector's probe *after* this

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -130,6 +130,13 @@ type ParsedEvent struct {
 	// the PreCompact force-working hold (#657). Auto-compaction never sets this.
 	IsManualCompactBoundary bool
 
+	// PendingBackgroundAgentCount, when non-nil, is Claude Code's own
+	// live count of background subagents (Agent-tool launches) still
+	// running as of this turn_duration event. Nil when the transcript's
+	// turn_duration event carries no such field (older Claude Code
+	// versions) — absence must not be read as zero. See issue #1036.
+	PendingBackgroundAgentCount *int
+
 	// IsToolDenial is true when the user denied a permission prompt for a
 	// tool call ("[Request interrupted by user for tool use]" text marker).
 	// This is a *different* signal from IsUserInterrupt: a tool denial does

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -247,6 +247,13 @@ type SessionMetrics struct {
 	// waiting headline when no agent marker is present. Cleared on a real
 	// user message, like TaskQuestion.
 	AwaySummary *AwaySummary `json:"away_summary,omitempty"`
+
+	// PendingBackgroundAgentCount is Claude Code's own last-reported count
+	// of still-running background subagents (issue #1036), read from the
+	// turn_duration system event's pendingBackgroundAgentCount field. Nil
+	// when never observed — adapters other than claudecode, and older
+	// Claude Code versions, never set this.
+	PendingBackgroundAgentCount *int `json:"pending_background_agent_count,omitempty"`
 }
 
 // TranscriptTailer monitors transcript files and computes metrics.
@@ -367,6 +374,13 @@ type TranscriptTailer struct {
 	// (issue #979). Sporadic and lower-priority than lastTaskQuestion — the
 	// last one seen persists across passes; cleared on a real user message.
 	lastAwaySummary *AwaySummary
+
+	// lastPendingBackgroundAgentCount holds Claude Code's own last-reported
+	// count of still-running background subagents, from the turn_duration
+	// system event's pendingBackgroundAgentCount field (issue #1036).
+	// Sticky like lastAwaySummary — persists across passes that carry no
+	// fresh turn_duration event; nil when never observed.
+	lastPendingBackgroundAgentCount *int
 
 	// tasks accumulates the session's task list from TaskCreate / TaskUpdate
 	// tool_use events parsed by the Claude Code adapter.

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -250,10 +250,14 @@ type SessionMetrics struct {
 
 	// PendingBackgroundAgentCount is Claude Code's own last-reported count
 	// of still-running background subagents (issue #1036), read from the
-	// turn_duration system event's pendingBackgroundAgentCount field. Nil
+	// turn_duration system event's pendingBackgroundAgentCount field. Zero
 	// when never observed — adapters other than claudecode, and older
-	// Claude Code versions, never set this.
-	PendingBackgroundAgentCount *int `json:"pending_background_agent_count,omitempty"`
+	// Claude Code versions, never set this — same as zero meaning "Claude
+	// Code reports none pending"; nothing downstream needs to tell the two
+	// apart (ParsedEvent's own field stays a pointer, since applyMetadata
+	// does need to tell "this event carried no field" from "carried zero"
+	// to decide whether to touch the sticky value at all).
+	PendingBackgroundAgentCount int `json:"pending_background_agent_count,omitempty"`
 }
 
 // TranscriptTailer monitors transcript files and computes metrics.
@@ -379,8 +383,8 @@ type TranscriptTailer struct {
 	// count of still-running background subagents, from the turn_duration
 	// system event's pendingBackgroundAgentCount field (issue #1036).
 	// Sticky like lastAwaySummary — persists across passes that carry no
-	// fresh turn_duration event; nil when never observed.
-	lastPendingBackgroundAgentCount *int
+	// fresh turn_duration event.
+	lastPendingBackgroundAgentCount int
 
 	// tasks accumulates the session's task list from TaskCreate / TaskUpdate
 	// tool_use events parsed by the Claude Code adapter.

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -22,7 +22,7 @@ func (t *TranscriptTailer) applyMetadata(parsed *ParsedEvent) {
 		t.ingestRateLimit(parsed.RateLimit)
 	}
 	if parsed.PendingBackgroundAgentCount != nil {
-		t.lastPendingBackgroundAgentCount = parsed.PendingBackgroundAgentCount
+		t.lastPendingBackgroundAgentCount = *parsed.PendingBackgroundAgentCount
 	}
 }
 

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -21,6 +21,9 @@ func (t *TranscriptTailer) applyMetadata(parsed *ParsedEvent) {
 	if parsed.RateLimit != nil {
 		t.ingestRateLimit(parsed.RateLimit)
 	}
+	if parsed.PendingBackgroundAgentCount != nil {
+		t.lastPendingBackgroundAgentCount = parsed.PendingBackgroundAgentCount
+	}
 }
 
 // IngestRateLimit accepts an externally-sourced snapshot (the Claude Code
@@ -403,6 +406,7 @@ func (t *TranscriptTailer) surfaceSporadicMetrics() {
 
 	t.metrics.TaskQuestion = t.lastTaskQuestion
 	t.metrics.AwaySummary = t.lastAwaySummary
+	t.metrics.PendingBackgroundAgentCount = t.lastPendingBackgroundAgentCount
 }
 
 // computeBackgroundProcessMetrics surfaces background-process bookkeeping.


### PR DESCRIPTION
## Summary

- A parent session could briefly flip to `ready` while a background subagent was still running. The file-based `hasActiveChildren` check that's supposed to hold the parent loses a short race: a child subagent's transcript finishes and gets reclassified to `ready` (and cleaned up) a few seconds before Claude Code delivers the task-notification that would give the parent a reason to keep working.
- Claude Code already reports this itself: its `turn_duration` system event carries a `pendingBackgroundAgentCount` field that Irrlicht previously parsed and discarded. This PR parses it and folds it into `holdParentForActiveChildren` (the parent's own activity pass) and `reevaluateParent` (triggered by a child's state change) as a second, independent OR-condition alongside the existing file-based check — closing the race without touching the existing repo-based mechanism.
- Wired end-to-end: `claudecode` parser → `tailer.ParsedEvent`/`tailer.SessionMetrics` (sticky across passes, like `AwaySummary`) → `replayengine`'s tailer→domain `Convert()` → `session.SessionMetrics` (copied verbatim in `MergeMetrics`, no carry-forward — `0` is a legitimate "none pending" verdict that must not be resurrected from a stale prior value).

## Test plan

- [x] `go test ./core/... -race -count=1` — full suite green
- [x] New regression tests reproduce the exact race from both trigger paths:
  - `TestSessionDetector_ParentHeldWorking_ByPendingBackgroundAgentCount` (parent's own activity pass, zero tracked children)
  - `TestSessionDetector_ReevaluateParent_HeldByPendingBackgroundAgentCount` (the actual incident shape: a *different*, untracked subagent still pending when the tracked child finishes and triggers `reevaluateParent`)
  - `TestParser_SystemEvent_TurnDone_PendingBackgroundAgentCount(Absent)` — presence/absence parsing, `ok`-gated since older Claude Code versions omit the field entirely
- [x] Existing `TestSessionDetector_ParentReleasedToReady_WhenChildFinishes` still passes unmodified — confirms the zero-value case still releases to `ready` correctly
- [x] `tools/replay-fixtures.sh` — all fixtures pass, no golden drift
- [x] `tools/preflight.sh` (via pre-push hook) — gofmt, core tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, web suites, ARS architecture gate, security scan all green

Closes #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)