### PR TITLE
fix: preserve Codex 7d-only quota snapshots

### DIFF
--- a/core/adapters/inbound/agents/codex/parser_test.go
+++ b/core/adapters/inbound/agents/codex/parser_test.go
@@ -1115,6 +1115,42 @@ func TestParser_RateLimits_V3Schema(t *testing.T) {
 	}
 }
 
+// TestParser_RateLimits_SingleWeeklyWindow covers the current Codex schema,
+// which can report only a 7-day primary window. The parser must preserve that
+// source-of-truth shape and must not invent a missing five-hour window.
+func TestParser_RateLimits_SingleWeeklyWindow(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type": "event_msg",
+		"payload": map[string]interface{}{
+			"type": "token_count",
+			"rate_limits": map[string]interface{}{
+				"limit_id": "codex",
+				"primary": map[string]interface{}{
+					"used_percent":   7.0,
+					"window_minutes": 10080.0,
+					"resets_at":      1784509226.0,
+				},
+				"secondary": nil,
+				"plan_type": "plus",
+			},
+		},
+	})
+	if ev == nil || !ev.Skip {
+		t.Fatal("expected token_count to be skipped (post-rate-limit extraction)")
+	}
+	if ev.RateLimit == nil {
+		t.Fatal("expected RateLimit snapshot on token_count event")
+	}
+	if got := ev.RateLimit.Windows; len(got) != 1 {
+		t.Fatalf("windows = %+v, want exactly one reported weekly window", got)
+	}
+	weekly := ev.RateLimit.Windows[0]
+	if weekly.WindowMinutes != 10080 || weekly.UsedPercent != 7.0 || weekly.ResetsAt != 1784509226 {
+		t.Errorf("weekly window = %+v, want 7%% / 10080m / 1784509226", weekly)
+	}
+}
+
 // TestParser_RateLimits_V2WithCredits exercises the API-key / usage-path
 // shape where plan_type is null and credits carries a balance.
 func TestParser_RateLimits_V2WithCredits(t *testing.T) {

--- a/core/domain/session/rate_limit.go
+++ b/core/domain/session/rate_limit.go
@@ -6,16 +6,17 @@ import (
 
 // RateLimitSnapshot is one provider-emitted reading of subscription quota.
 // Codex's schema is the superset; Claude Code's statusline JSON is a strict
-// subset that maps to a two-window snapshot (five_hour, seven_day) with no
-// credits and no reached-type.
+// subset that maps to a five-hour and/or seven-day snapshot with no credits
+// and no reached-type.
 //
 // Snapshots are per-account: a Claude Pro/Max user running multiple sessions
 // on the same OAuth account sees identical Windows in every snapshot — the
 // bucket is account-scoped, not per-session.
 type RateLimitSnapshot struct {
-	// Windows holds one entry per rate-limit window (typically two: a 5-hour
-	// primary and a 7-day secondary). Order is provider-defined; callers
-	// pick the most-imminent for display.
+	// Windows holds the provider-emitted rate-limit windows. Providers may
+	// report one, both, or neither of the commonly observed 5-hour and 7-day
+	// windows; an absent window was not reported and must not be synthesized.
+	// Order is provider-defined; callers pick the most-imminent for display.
 	Windows []RateLimitWindow `json:"windows"`
 
 	// PlanType identifies the subscription tier when the provider supplies
@@ -45,11 +46,10 @@ type RateLimitWindow struct {
 	// 14.000000000000002) which the UI should round, not the parser.
 	UsedPercent float64 `json:"used_percent"`
 
-	// WindowMinutes is the nominal window length. Codex emits this
-	// explicitly (300, 10080); Claude Code's flat five_hour / seven_day
-	// fields map to 300 and 10080 respectively. Some Codex v1 samples
-	// emit 299 / 10079 due to a server-side rounding quirk — the parser
-	// must tolerate both.
+	// WindowMinutes is the nominal window length. Codex emits the duration
+	// explicitly; Claude Code's flat five_hour / seven_day fields map to 300
+	// and 10080 respectively. Some Codex v1 samples emit 299 / 10079 due to
+	// a server-side rounding quirk — the parser must tolerate both.
 	WindowMinutes int `json:"window_minutes"`
 
 	// ResetsAt is the wall-clock time (Unix seconds) at which the window

--- a/platforms/macos/Irrlicht/Models/MenuBarStyle.swift
+++ b/platforms/macos/Irrlicht/Models/MenuBarStyle.swift
@@ -46,7 +46,7 @@ enum MenuBarQuotaProvider {
 }
 
 /// How the quota portion of the icon renders when MenuBarStyle is `.usage`
-/// or `.combined`: the stacked 5h/7d bars, or a single compact ring for the
+/// or `.combined`: the stacked provider-reported quota bars, or a single compact ring for the
 /// most-imminent window (mirrors Claude Usage Tracker's "Compact" icon
 /// style, requested alongside issue #909). Stored under
 /// @AppStorage("menuBarQuotaVisual"); defaults to `.bars`.

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -586,7 +586,7 @@ private struct HistoryQuotaTabContent: View {
     }
 
     /// One projection view-model per active subscription provider, each carrying
-    /// its 5h/7d windows. Reads the live session snapshots (not the history API),
+    /// its reported quota windows. Reads the live session snapshots (not the history API),
     /// so it's independent of the selected range. Mirrors the per-provider dedup
     /// in SessionListView.quotaChipData: one bucket per provider, the freshest
     /// non-stale snapshot wins.

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -590,7 +590,7 @@ struct SessionListView: View {
     }
 
     /// Render mode for a provider chip. Subscription chips show the
-    /// 5h/7d bars; usage chips show cumulative spend across all
+    /// provider-emitted quota bars; usage chips show cumulative spend across all
     /// sessions on that provider.
     private enum QuotaMode {
         case subscription
@@ -742,7 +742,7 @@ struct SessionListView: View {
     }
 
     /// The chip-style header widget. Dispatches on mode:
-    ///   - subscription → provider icon + stacked 5h/7d bars (mockup 1/2)
+    ///   - subscription → provider icon + its reported quota bars (mockup 1/2)
     ///   - usage        → provider icon + windowed spend, click-to-cycle (mockup 2)
     @ViewBuilder
     private func quotaChipView(_ d: QuotaWidgetData, compact: Bool) -> some View {
@@ -801,7 +801,7 @@ struct SessionListView: View {
     /// cycle the timeframe (day → week → month → year), mirroring the
     /// project-group cost text; the choice is shared across all usage
     /// chips via `usageCostTimeframe`. Always 2 lines so the chip has the
-    /// same height as the subscription variant (5h + 7d rows) and the two
+    /// same height as the usual two-row subscription variant and the two
     /// render cleanly side-by-side in the header.
     ///
     /// Sourced from the daemon's per-provider cost rollup (`provider_costs`),
@@ -999,7 +999,8 @@ struct SessionListView: View {
     }
 
     private func quotaWindowLabel(_ minutes: Int) -> String {
-        // Tolerate Codex v1's 299 / 10079 off-by-one quirk.
+        // Tolerate Codex v1's 299 / 10079 off-by-one quirk. Codex may report
+        // a single weekly window, so label every supplied duration directly.
         switch minutes {
         case 299, 300: return "5h"
         case 10079, 10080: return "7d"

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -127,7 +127,7 @@ struct SettingsView: View {
                                 .font(.caption)
                                 .fontWeight(.medium)
                                 .foregroundColor(.secondary)
-                            InfoIcon(text: "Lights shows session-state dots (today's default). Usage replaces them with 5h/7d subscription quota bars. Combined shows both side by side.")
+                            InfoIcon(text: "Lights shows session-state dots (today's default). Usage replaces them with reported subscription quota bars. Combined shows both side by side.")
                             Spacer()
                         }
                         // A real Picker(pickerStyle: .segmented) only centers

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -60,7 +60,7 @@
         <input type="checkbox" data-quota-setting="showQuotaForecast">
         <span class="settings-label-text">
           <span class="settings-title">Show quota forecast in header</span>
-          <span class="settings-hint">Replace the version line with provider 5h/7d bars when rate-limit data is available.</span>
+          <span class="settings-hint">Replace the version line with provider quota bars when rate-limit data is available.</span>
         </span>
       </label>
       <div id="settings-providers"></div>

--- a/platforms/web/quotaChips.js
+++ b/platforms/web/quotaChips.js
@@ -138,8 +138,9 @@ function barColorClass(used, pace) {
   return 'quota-bar-fill--green';
 }
 
-function quotaWindowLabel(minutes) {
-  // Tolerate Codex v1's 299 / 10079 off-by-one quirk.
+export function quotaWindowLabel(minutes) {
+  // Tolerate Codex v1's 299 / 10079 off-by-one quirk. Codex may report a
+  // single weekly window, so derive every label from its supplied duration.
   if (minutes === 299 || minutes === 300) return '5h';
   if (minutes === 10079 || minutes === 10080) return '7d';
   if (minutes >= 1440) return Math.floor(minutes / 1440) + 'd';

--- a/platforms/web/quotaChips.test.js
+++ b/platforms/web/quotaChips.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'vitest';
+import { quotaWindowLabel } from './quotaChips.js';
+
+describe('quotaWindowLabel', () => {
+  test('labels a Codex single-weekly snapshot without inferring a five-hour window', () => {
+    expect(quotaWindowLabel(10080)).toBe('7d');
+  });
+
+  test('continues to label a reported five-hour window', () => {
+    expect(quotaWindowLabel(300)).toBe('5h');
+  });
+});


### PR DESCRIPTION
## Summary
- preserve Codex’s provider-emitted single 7-day quota window without inventing a missing 5-hour bucket
- add parser and web label regressions for the current payload shape
- update macOS and web copy so it does not promise a fixed 5h/7d pair

## Verification
- `go test ./core/... -race -count=1`
- `go test ./tools/onboarding-factory/... -race -count=1`
- `tools/replay-fixtures.sh`
- `go run ./tools/onboarding-factory/cmd/of validate`
- `bash tools/onboarding-factory/scripts/smoke-test.sh`
- `tools/preflight.sh --only web`
- `tools/preflight.sh --only arch`
- `swift test --filter QuotaMenuBarRendererTests`

`swift test` otherwise has two unrelated existing ghost-row snapshot mismatches (`testFixtureAntigravityGhost`, `testGhostRowPID0NilMetrics`); the quota suite passes.

Closes #1051

🤖 Generated with [Claude Code]