### PR TITLE
fix(homebrew): use symbol form for depends_on macos

### DIFF
--- a/tools/homebrew-tap/Casks/irrlicht.rb
+++ b/tools/homebrew-tap/Casks/irrlicht.rb
@@ -13,7 +13,7 @@ cask "irrlicht" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "Irrlicht.app"
 


### PR DESCRIPTION
## Summary

Homebrew deprecated the string-comparison form `depends_on macos: ">= :ventura"` in casks — every `brew upgrade` now prints:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated!
Use `depends_on macos: :ventura` instead.
```

The bare symbol `:ventura` is Homebrew's own recommended equivalent and already means "Ventura or newer", so this is behavior-preserving. The fix lands in the canonical template `tools/homebrew-tap/Casks/irrlicht.rb`, which `update-cask.sh` copies verbatim into the external tap on each release — so the live tap picks it up on the next release.

## Test plan

- [x] `brew style` on the cask — **before:** `Homebrew/OSDependsOn: Use depends_on macos: :ventura.` (1 offense); **after:** `1 file inspected, no offenses detected`
- [x] Behavior-preserving — the Go/web/replay suites don't touch this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)