### PR TITLE
fix: link Codex subagent rollouts

### DIFF
--- a/core/adapters/inbound/agents/codex/agent.go
+++ b/core/adapters/inbound/agents/codex/agent.go
@@ -36,7 +36,9 @@ func Agent() agent.Agent {
 			PIDForSession: DiscoverPID,
 		},
 		Source: agent.FilesUnderRoot{
-			Dir: sessionsDir(),
+			Dir:                     sessionsDir(),
+			SessionIDFromPath:       sessionIDFromPath,
+			ParentSessionIDFromPath: parentSessionIDFromPath,
 			Parser: agent.JSONLineParser{
 				NewParser: func() agent.LineParser { return &Parser{} },
 			},

--- a/core/adapters/inbound/agents/codex/session_meta.go
+++ b/core/adapters/inbound/agents/codex/session_meta.go
@@ -1,0 +1,86 @@
+package codex
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// sessionIDFromPath returns Codex's per-thread metadata ID. A session tree's
+// payload.session_id is deliberately not used: it is shared by the parent and
+// every child. The rollout filename ends in the same thread UUID, so it is a
+// safe fallback while a newly-created file has not yet received its header.
+func sessionIDFromPath(path string) string {
+	if payload := sessionMetaPayload(path); payload != nil {
+		if id, _ := payload["id"].(string); id != "" {
+			return id
+		}
+	}
+	return rolloutThreadID(path)
+}
+
+// parentSessionIDFromPath reads only a rollout's first metadata record. The
+// nested thread_spawn parent is authoritative; the two top-level fields cover
+// compatible Codex shapes. Ordinary conversation forks remain top-level:
+// their fallback fields are considered only when thread_source is subagent.
+func parentSessionIDFromPath(path string) string {
+	payload := sessionMetaPayload(path)
+	if payload == nil || payload["thread_source"] != "subagent" {
+		return ""
+	}
+	if source, ok := payload["source"].(map[string]interface{}); ok {
+		if subagent, ok := source["subagent"].(map[string]interface{}); ok {
+			if spawn, ok := subagent["thread_spawn"].(map[string]interface{}); ok {
+				if parent, _ := spawn["parent_thread_id"].(string); parent != "" {
+					return parent
+				}
+			}
+		}
+	}
+	for _, key := range []string{"parent_thread_id", "forked_from_id"} {
+		if parent, _ := payload[key].(string); parent != "" {
+			return parent
+		}
+	}
+	return ""
+}
+
+func sessionMetaPayload(path string) map[string]interface{} {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	// session_meta can embed the user's instructions, which routinely exceeds
+	// Scanner's small default token limit.
+	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
+	if !scanner.Scan() {
+		return nil
+	}
+	var record map[string]interface{}
+	if err := json.Unmarshal(scanner.Bytes(), &record); err != nil || record["type"] != "session_meta" {
+		return nil
+	}
+	payload, _ := record["payload"].(map[string]interface{})
+	return payload
+}
+
+func rolloutThreadID(path string) string {
+	base := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	if !strings.HasPrefix(base, "rollout-") {
+		return ""
+	}
+	if i := strings.LastIndex(base, "-"); i >= 0 && len(base)-i-1 == 12 {
+		// A UUID's final group is 12 characters. The preceding groups remain
+		// in the suffix and are restored by the fixed-width slice below.
+		const uuidLen = 36
+		if len(base) >= uuidLen {
+			return base[len(base)-uuidLen:]
+		}
+	}
+	return ""
+}

--- a/core/adapters/inbound/agents/codex/session_meta_test.go
+++ b/core/adapters/inbound/agents/codex/session_meta_test.go
@@ -1,0 +1,73 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+)
+
+const (
+	parentThreadID = "019f6249-055d-76d3-b381-cd9d3eb99189"
+	childThreadID  = "019f624a-cc95-7c50-b9fa-1db381270b73"
+)
+
+func writeSessionMeta(t *testing.T, record string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "rollout-2026-07-14T20-21-37-"+childThreadID+".jsonl")
+	if err := os.WriteFile(path, []byte(record+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestSessionMeta_UsesThreadIdentityAndAuthoritativeParent(t *testing.T) {
+	path := writeSessionMeta(t, `{"type":"session_meta","payload":{"id":"`+childThreadID+`","session_id":"shared-tree-id","thread_source":"subagent","source":{"subagent":{"thread_spawn":{"parent_thread_id":"`+parentThreadID+`"}}}}}`)
+	if got := sessionIDFromPath(path); got != childThreadID {
+		t.Errorf("sessionIDFromPath() = %q, want child thread ID %q", got, childThreadID)
+	}
+	if got := parentSessionIDFromPath(path); got != parentThreadID {
+		t.Errorf("parentSessionIDFromPath() = %q, want %q", got, parentThreadID)
+	}
+}
+
+func TestParentSessionIDFromPath_CompatibleFallbacks(t *testing.T) {
+	tests := []struct {
+		name, payload string
+		want          string
+	}{
+		{"parent_thread_id", `{"id":"` + childThreadID + `","thread_source":"subagent","parent_thread_id":"` + parentThreadID + `"}`, parentThreadID},
+		{"forked_from_id", `{"id":"` + childThreadID + `","thread_source":"subagent","forked_from_id":"` + parentThreadID + `"}`, parentThreadID},
+		{"top level", `{"id":"` + childThreadID + `","thread_source":"user","forked_from_id":"` + parentThreadID + `"}`, ""},
+		{"plain fork", `{"id":"` + childThreadID + `","forked_from_id":"` + parentThreadID + `"}`, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeSessionMeta(t, `{"type":"session_meta","payload":`+tc.payload+`}`)
+			if got := parentSessionIDFromPath(path); got != tc.want {
+				t.Errorf("parentSessionIDFromPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSessionIDFromPath_FallsBackToRolloutThreadID(t *testing.T) {
+	path := writeSessionMeta(t, `not json`)
+	if got := sessionIDFromPath(path); got != childThreadID {
+		t.Errorf("sessionIDFromPath() = %q, want filename thread ID %q", got, childThreadID)
+	}
+	if got := parentSessionIDFromPath(path); got != "" {
+		t.Errorf("parentSessionIDFromPath() = %q, want empty for malformed metadata", got)
+	}
+}
+
+func TestAgent_DeclaresCodexMetadataExtractors(t *testing.T) {
+	source, ok := Agent().Source.(agent.FilesUnderRoot)
+	if !ok {
+		t.Fatalf("Agent Source = %T, want agent.FilesUnderRoot", Agent().Source)
+	}
+	if source.SessionIDFromPath == nil || source.ParentSessionIDFromPath == nil {
+		t.Fatal("Codex source must declare both metadata extractors")
+	}
+}

--- a/core/adapters/inbound/agents/fswatcher/watcher.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher.go
@@ -34,6 +34,14 @@ type Watcher struct {
 	// filename is constant use this both to source the ID from a path component
 	// and to ignore sibling files (e.g. Antigravity's transcript_full.jsonl).
 	sessionID func(path string) string
+	// parentSessionID, when non-nil, derives a child transcript's parent from
+	// its contents before the event is emitted. The callback is only enabled
+	// for adapters that persist an authoritative header relationship.
+	parentSessionID func(path string) string
+	// pendingNew holds zero-byte Create events for header-linked adapters.
+	// Deferring them until the first Write lets the adapter read the metadata
+	// header and prevents a child from briefly appearing as a top-level row.
+	pendingNew map[string]struct{}
 
 	subMu sync.Mutex
 	subs  []chan agent.Event
@@ -100,6 +108,14 @@ func (w *Watcher) WithSessionID(fn func(path string) string) *Watcher {
 	return w
 }
 
+// WithParentSessionID sets a transcript-header parent-ID extractor. A
+// zero-byte Create is deferred until the first Write so the callback can read
+// the header before the new-session event reaches the session detector.
+func (w *Watcher) WithParentSessionID(fn func(path string) string) *Watcher {
+	w.parentSessionID = fn
+	return w
+}
+
 // idFor derives a transcript file's session ID using the custom extractor when
 // one is set, otherwise the default filename-stem rule. Returning "" means the
 // file should be skipped.
@@ -108,6 +124,24 @@ func (w *Watcher) idFor(path string) string {
 		return w.sessionID(path)
 	}
 	return extractSessionID(path)
+}
+
+func (w *Watcher) parentIDFor(path string) string {
+	if w.parentSessionID == nil {
+		return ""
+	}
+	return w.parentSessionID(path)
+}
+
+func (w *Watcher) eventFor(typ agent.EventType, sessionID, projectDir, path string, size int64) agent.Event {
+	return agent.Event{
+		Type:            typ,
+		SessionID:       sessionID,
+		ProjectDir:      projectDir,
+		TranscriptPath:  path,
+		Size:            size,
+		ParentSessionID: w.parentIDFor(path),
+	}
 }
 
 // New creates a Watcher for the given directory. If dir is absolute, it is
@@ -283,35 +317,30 @@ func (w *Watcher) handleEvent(watcher *fsnotify.Watcher, ev fsnotify.Event) {
 		if w.isStale(mtime) {
 			return
 		}
-		w.broadcast(agent.Event{
-			Type:           agent.EventNewSession,
-			SessionID:      sessionID,
-			ProjectDir:     projectDir,
-			TranscriptPath: name,
-			Size:           size,
-		})
+		if size == 0 && w.parentSessionID != nil {
+			if w.pendingNew == nil {
+				w.pendingNew = make(map[string]struct{})
+			}
+			w.pendingNew[name] = struct{}{}
+			return
+		}
+		w.broadcast(w.eventFor(agent.EventNewSession, sessionID, projectDir, name, size))
 
 	case ev.Op&fsnotify.Write != 0:
 		size, mtime := fileSizeAndMtime(name)
 		if w.isStale(mtime) {
 			return
 		}
-		w.broadcast(agent.Event{
-			Type:           agent.EventActivity,
-			SessionID:      sessionID,
-			ProjectDir:     projectDir,
-			TranscriptPath: name,
-			Size:           size,
-		})
+		if _, pending := w.pendingNew[name]; pending {
+			delete(w.pendingNew, name)
+			w.broadcast(w.eventFor(agent.EventNewSession, sessionID, projectDir, name, size))
+			return
+		}
+		w.broadcast(w.eventFor(agent.EventActivity, sessionID, projectDir, name, size))
 
 	case ev.Op&(fsnotify.Remove|fsnotify.Rename) != 0:
-		w.broadcast(agent.Event{
-			Type:           agent.EventRemoved,
-			SessionID:      sessionID,
-			ProjectDir:     projectDir,
-			TranscriptPath: name,
-			Size:           0,
-		})
+		delete(w.pendingNew, name)
+		w.broadcast(w.eventFor(agent.EventRemoved, sessionID, projectDir, name, 0))
 	}
 }
 
@@ -568,13 +597,7 @@ func (w *Watcher) emitExistingFiles(dir string) {
 		if w.maxAge > 0 && !mtime.IsZero() && time.Since(mtime) > w.maxAge {
 			continue
 		}
-		w.broadcast(agent.Event{
-			Type:           agent.EventNewSession,
-			SessionID:      sessionID,
-			ProjectDir:     projectDir,
-			TranscriptPath: fullPath,
-			Size:           size,
-		})
+		w.broadcast(w.eventFor(agent.EventNewSession, sessionID, projectDir, fullPath, size))
 	}
 }
 

--- a/core/adapters/inbound/agents/fswatcher/watcher_test.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher_test.go
@@ -155,6 +155,52 @@ done:
 	}
 }
 
+// TestWatch_MetadataParentIsPresentOnFirstNewEvent proves that an adapter
+// whose relationship lives in its first transcript record does not expose a
+// zero-byte Create as an unlinked top-level session before the header arrives.
+func TestWatch_MetadataParentIsPresentOnFirstNewEvent(t *testing.T) {
+	root := setupFakeProjects(t)
+	w := NewWithRoot(root, testAdapter, 0).WithParentSessionID(func(path string) string {
+		contents, _ := os.ReadFile(path)
+		if strings.Contains(string(contents), "parent-thread") {
+			return "parent-thread"
+		}
+		return ""
+	})
+	ch := w.Subscribe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- w.Watch(ctx) }()
+	select {
+	case <-w.Ready():
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not signal Ready")
+	}
+
+	path := filepath.Join(root, "-Users-test-myproject", "child.jsonl")
+	if err := os.WriteFile(path, []byte("parent-thread\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case ev := <-ch:
+		if ev.Type != agent.EventNewSession {
+			t.Errorf("event Type = %q, want new_session", ev.Type)
+		}
+		if ev.ParentSessionID != "parent-thread" {
+			t.Errorf("ParentSessionID = %q, want parent-thread", ev.ParentSessionID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for linked new-session event")
+	}
+
+	cancel()
+	if err := <-done; err != nil && err != context.Canceled {
+		t.Errorf("Watch returned unexpected error: %v", err)
+	}
+}
+
 func TestWatch_EmitsActivity(t *testing.T) {
 	root := setupFakeProjects(t)
 

--- a/core/application/services/session_detector_codex_subagent_test.go
+++ b/core/application/services/session_detector_codex_subagent_test.go
@@ -1,0 +1,101 @@
+package services_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+)
+
+// TestSessionDetector_CodexMetadataChildrenStayNested verifies the complete
+// lifecycle path exercised by Codex's flat rollout metadata: three children
+// arrive with explicit ParentSessionID values, never become dashboard roots,
+// hold their completed parent working, and release it only after the final
+// child is ready.
+func TestSessionDetector_CodexMetadataChildrenStayNested(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	metrics := &funcMetrics{fn: func(path, _ string) (*session.SessionMetrics, error) {
+		if strings.Contains(path, "codex-child-") {
+			return &session.SessionMetrics{LastEventType: "tool_use", HasOpenToolCall: true}, nil
+		}
+		return nil, nil
+	}}
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	time.Sleep(20 * time.Millisecond)
+
+	const parentID = "019f6249-055d-76d3-b381-cd9d3eb99189"
+	now := time.Now().Unix()
+	repo.Save(&session.SessionState{
+		SessionID: parentID, State: session.StateReady, ProjectName: "codex-project",
+		TranscriptPath: filepath.Join(t.TempDir(), "parent.jsonl"), FirstSeen: now, UpdatedAt: now,
+		Metrics: &session.SessionMetrics{LastEventType: "turn_done"},
+	})
+
+	childIDs := []string{
+		"019f624a-cc95-7c50-b9fa-1db381270b73",
+		"019f624b-cc95-7c50-b9fa-1db381270b74",
+		"019f624c-cc95-7c50-b9fa-1db381270b75",
+	}
+	for _, childID := range childIDs {
+		path := filepath.Join(t.TempDir(), "codex-child-"+childID+".jsonl")
+		if err := os.WriteFile(path, []byte("{}\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		tw.ch <- agent.Event{Type: agent.EventNewSession, SessionID: childID, ParentSessionID: parentID, TranscriptPath: path}
+	}
+
+	waitForSessionState(repo, parentID, session.StateWorking, time.Second)
+	waitForCondition(func() bool {
+		states, _ := repo.ListAll()
+		linked := 0
+		for _, state := range states {
+			if state.ParentSessionID == parentID {
+				linked++
+			}
+		}
+		return linked == len(childIDs)
+	}, time.Second)
+
+	states, _ := repo.ListAll()
+	groups := session.BuildDashboard(states, nil)
+	if len(groups) != 1 || len(groups[0].Agents) != 1 {
+		t.Fatalf("dashboard roots = %#v, want exactly one parent", groups)
+	}
+	if got := len(groups[0].Agents[0].Children); got != len(childIDs) {
+		t.Errorf("nested child count = %d, want %d", got, len(childIDs))
+	}
+
+	for _, childID := range childIDs[:2] {
+		child, _ := repo.Load(childID)
+		child.State = session.StateReady
+		repo.Save(child)
+	}
+	tw.ch <- agent.Event{Type: agent.EventActivity, SessionID: parentID, TranscriptPath: filepath.Join(t.TempDir(), "parent.jsonl")}
+	time.Sleep(50 * time.Millisecond)
+	if parent, _ := repo.Load(parentID); parent.State != session.StateWorking {
+		t.Errorf("parent State after two children complete = %q, want working", parent.State)
+	}
+
+	last, _ := repo.Load(childIDs[2])
+	last.State = session.StateReady
+	repo.Save(last)
+	tw.ch <- agent.Event{Type: agent.EventActivity, SessionID: parentID, TranscriptPath: filepath.Join(t.TempDir(), "parent.jsonl")}
+	waitForSessionState(repo, parentID, session.StateReady, time.Second)
+
+	cancel()
+	if err := <-done; err != nil && err != context.Canceled {
+		t.Errorf("detector Run() = %v", err)
+	}
+}

--- a/core/cmd/irrlichd/wiring.go
+++ b/core/cmd/irrlichd/wiring.go
@@ -55,6 +55,9 @@ func buildAgentWatchers(
 			if s.SessionIDFromPath != nil {
 				w = w.WithSessionID(s.SessionIDFromPath)
 			}
+			if s.ParentSessionIDFromPath != nil {
+				w = w.WithParentSessionID(s.ParentSessionIDFromPath)
+			}
 			watchers = append(watchers, w)
 			labels = append(labels, fmt.Sprintf("%s (%s)", a.Identity.Name, w.Root()))
 		}

--- a/core/domain/agent/source.go
+++ b/core/domain/agent/source.go
@@ -50,6 +50,13 @@ type FilesUnderRoot struct {
 	// function receives the absolute file path and returns "" for any file the
 	// adapter does not own (skipping it entirely).
 	SessionIDFromPath func(path string) string
+
+	// ParentSessionIDFromPath optionally derives a session's parent from its
+	// transcript before the watcher emits the event. It is used by flat
+	// transcript stores whose child relationship lives in a metadata header
+	// rather than their directory layout. Returning "" leaves the session
+	// top-level.
+	ParentSessionIDFromPath func(path string) string
 }
 
 func (FilesUnderRoot) isSource() {

--- a/replaydata/agents/codex/regressions/subagent-parent-link/README.md
+++ b/replaydata/agents/codex/regressions/subagent-parent-link/README.md
@@ -1,0 +1,6 @@
+# Codex subagent parent-link fixture
+
+Redacted Codex 0.144.4 rollout headers from issue #1050: one parent and three
+sibling child threads. Each child keeps its own `payload.id` and carries the
+same authoritative `source.subagent.thread_spawn.parent_thread_id`. The shared
+`payload.session_id` is deliberately present only to prove it is not identity.

--- a/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-30-019f6249-055d-76d3-b381-cd9d3eb99189.jsonl
+++ b/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-30-019f6249-055d-76d3-b381-cd9d3eb99189.jsonl
@@ -1,0 +1,1 @@
+{"type":"session_meta","payload":{"id":"019f6249-055d-76d3-b381-cd9d3eb99189","session_id":"019f6249-055d-76d3-b381-cd9d3eb99189","thread_source":"user","source":"cli"}}

--- a/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-30-019f6249-055d-76d3-b381-cd9d3eb99189.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-30-019f6249-055d-76d3-b381-cd9d3eb99189.jsonl.replay.json.golden
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "source_transcript": "",
+  "generated_at": "0001-01-01T00:00:00Z",
+  "settings": {
+    "adapter": "codex",
+    "debounce_window": 2000000000,
+    "flicker_max_duration": 10000000000
+  },
+  "summary": {
+    "total_events": 1,
+    "consumed_events": 1,
+    "total_transitions": 1,
+    "first_event_time": "0001-01-01T00:00:00Z",
+    "last_event_time": "0001-01-01T00:00:00Z",
+    "wall_clock_session_duration": 0,
+    "state_durations": {},
+    "flicker_count": 0,
+    "flickers_by_category": {},
+    "flickers_by_reason": {}
+  },
+  "transitions": [
+    {
+      "index": 0,
+      "event_index": -1,
+      "virtual_time": "0001-01-01T00:00:00Z",
+      "cause": "init",
+      "prev_state": "",
+      "new_state": "ready",
+      "reason": "initial state",
+      "last_event_type": "",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    }
+  ]
+}

--- a/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-37-019f624a-cc95-7c50-b9fa-1db381270b73.jsonl
+++ b/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-37-019f624a-cc95-7c50-b9fa-1db381270b73.jsonl
@@ -1,0 +1,1 @@
+{"type":"session_meta","payload":{"id":"019f624a-cc95-7c50-b9fa-1db381270b73","session_id":"019f6249-055d-76d3-b381-cd9d3eb99189","forked_from_id":"019f6249-055d-76d3-b381-cd9d3eb99189","parent_thread_id":"019f6249-055d-76d3-b381-cd9d3eb99189","thread_source":"subagent","source":{"subagent":{"thread_spawn":{"parent_thread_id":"019f6249-055d-76d3-b381-cd9d3eb99189","depth":1}}}}}

--- a/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-37-019f624a-cc95-7c50-b9fa-1db381270b73.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-37-019f624a-cc95-7c50-b9fa-1db381270b73.jsonl.replay.json.golden
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "source_transcript": "",
+  "generated_at": "0001-01-01T00:00:00Z",
+  "settings": {
+    "adapter": "codex",
+    "debounce_window": 2000000000,
+    "flicker_max_duration": 10000000000
+  },
+  "summary": {
+    "total_events": 1,
+    "consumed_events": 1,
+    "total_transitions": 1,
+    "first_event_time": "0001-01-01T00:00:00Z",
+    "last_event_time": "0001-01-01T00:00:00Z",
+    "wall_clock_session_duration": 0,
+    "state_durations": {},
+    "flicker_count": 0,
+    "flickers_by_category": {},
+    "flickers_by_reason": {}
+  },
+  "transitions": [
+    {
+      "index": 0,
+      "event_index": -1,
+      "virtual_time": "0001-01-01T00:00:00Z",
+      "cause": "init",
+      "prev_state": "",
+      "new_state": "ready",
+      "reason": "initial state",
+      "last_event_type": "",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    }
+  ]
+}

--- a/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-42-019f624b-cc95-7c50-b9fa-1db381270b74.jsonl
+++ b/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-42-019f624b-cc95-7c50-b9fa-1db381270b74.jsonl
@@ -1,0 +1,1 @@
+{"type":"session_meta","payload":{"id":"019f624b-cc95-7c50-b9fa-1db381270b74","session_id":"019f6249-055d-76d3-b381-cd9d3eb99189","thread_source":"subagent","source":{"subagent":{"thread_spawn":{"parent_thread_id":"019f6249-055d-76d3-b381-cd9d3eb99189","depth":1}}}}}

--- a/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-42-019f624b-cc95-7c50-b9fa-1db381270b74.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-42-019f624b-cc95-7c50-b9fa-1db381270b74.jsonl.replay.json.golden
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "source_transcript": "",
+  "generated_at": "0001-01-01T00:00:00Z",
+  "settings": {
+    "adapter": "codex",
+    "debounce_window": 2000000000,
+    "flicker_max_duration": 10000000000
+  },
+  "summary": {
+    "total_events": 1,
+    "consumed_events": 1,
+    "total_transitions": 1,
+    "first_event_time": "0001-01-01T00:00:00Z",
+    "last_event_time": "0001-01-01T00:00:00Z",
+    "wall_clock_session_duration": 0,
+    "state_durations": {},
+    "flicker_count": 0,
+    "flickers_by_category": {},
+    "flickers_by_reason": {}
+  },
+  "transitions": [
+    {
+      "index": 0,
+      "event_index": -1,
+      "virtual_time": "0001-01-01T00:00:00Z",
+      "cause": "init",
+      "prev_state": "",
+      "new_state": "ready",
+      "reason": "initial state",
+      "last_event_type": "",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    }
+  ]
+}

--- a/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-48-019f624c-cc95-7c50-b9fa-1db381270b75.jsonl
+++ b/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-48-019f624c-cc95-7c50-b9fa-1db381270b75.jsonl
@@ -1,0 +1,1 @@
+{"type":"session_meta","payload":{"id":"019f624c-cc95-7c50-b9fa-1db381270b75","session_id":"019f6249-055d-76d3-b381-cd9d3eb99189","thread_source":"subagent","source":{"subagent":{"thread_spawn":{"parent_thread_id":"019f6249-055d-76d3-b381-cd9d3eb99189","depth":1}}}}}

--- a/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-48-019f624c-cc95-7c50-b9fa-1db381270b75.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/regressions/subagent-parent-link/rollouts/rollout-2026-07-14T20-21-48-019f624c-cc95-7c50-b9fa-1db381270b75.jsonl.replay.json.golden
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "source_transcript": "",
+  "generated_at": "0001-01-01T00:00:00Z",
+  "settings": {
+    "adapter": "codex",
+    "debounce_window": 2000000000,
+    "flicker_max_duration": 10000000000
+  },
+  "summary": {
+    "total_events": 1,
+    "consumed_events": 1,
+    "total_transitions": 1,
+    "first_event_time": "0001-01-01T00:00:00Z",
+    "last_event_time": "0001-01-01T00:00:00Z",
+    "wall_clock_session_duration": 0,
+    "state_durations": {},
+    "flicker_count": 0,
+    "flickers_by_category": {},
+    "flickers_by_reason": {}
+  },
+  "transitions": [
+    {
+      "index": 0,
+      "event_index": -1,
+      "virtual_time": "0001-01-01T00:00:00Z",
+      "cause": "init",
+      "prev_state": "",
+      "new_state": "ready",
+      "reason": "initial state",
+      "last_event_type": "",
+      "has_open_tool": false,
+      "is_agent_done": false,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    }
+  ]
+}

--- a/replaydata/agents/codex/scenarios/3-1_foreground-subagent/metadata.json
+++ b/replaydata/agents/codex/scenarios/3-1_foreground-subagent/metadata.json
@@ -2,90 +2,43 @@
   "scenario_id": "foreground-subagent",
   "metadata": {
     "agent_supports": "yes",
-    "daemon_capability": "incapable",
+    "daemon_capability": "full",
     "driver_capability": "ready",
-    "agent_cli_version": "0.135.0",
-    "daemon_version": "0.4.8+a9ab9ea",
-    "confidence": 0.8,
-    "notes": "agent_supports: yes (multi_agent stable, spawn_agent); daemon_capability: incapable (no codex parent-link path); driver_capability: ready"
+    "agent_cli_version": "0.144.4",
+    "confidence": 0.95,
+    "notes": "Observed Codex 0.144.4 child rollouts carry an authoritative session_meta parent_thread_id; the adapter projects it before session creation. Route: record."
   },
   "details": {
     "assessment": {
       "schema_version": 1,
       "scenario_id": "foreground-subagent",
       "agent": "codex",
-      "assessed_at": "2026-05-31T00:00:00Z",
+      "assessed_at": "2026-07-14T00:00:00Z",
       "agent_supports": "yes",
-      "daemon_capability": "incapable",
+      "daemon_capability": "full",
       "driver_capability": "ready",
-      "confidence": 0.8,
-      "body": "## Verdict\n\nagent_supports: yes\ndaemon_capability: incapable\ndriver_capability: ready\n\nRoute: frozen — codex CAN spawn foreground subagents, but the irrlicht codex adapter has no mechanism to bind a codex child thread to its parent, so none of this scenario's load-bearing observables (ParentSessionID linkage, SubagentCount, parent_linked, child transcript under \u003cparent\u003e/subagents/) can be emitted today.\n\n## agent_supports = yes\n\nUnlike pi (which ships no subagent primitive), codex 0.135.0 has a first-class, default-on multi-agent / sub-agent control surface:\n\n- `codex features list` reports `multi_agent  stable  true` — the spawn-a-subagent feature is STABLE and enabled by default (no flag needed). (`multi_agent_v2` is the next-gen variant, still `under development`.)\n- The native binary's strings expose the full agent-control vocabulary: a `spawn_agent` tool (\"Spawn a sub-agent for a well-scoped task\", \"Spawns an agent to work on the specified task\"), `AgentControl`-spawned sub-agents with an `agent_role` / nickname, `_delegate` guidance prompts (\"Use a subagent when a subtask is easy enough... can run in parallel\", \"Do not redo delegated subagent tasks yourself\"), `SubAgentSource`, a `\"subAgentThreadSpawn\"` thread source, and `core/src/agent/control.rs` references (`spawn_agent fork requires a thread-spawn session source`, `skipping subagent thread analytics: failed to load parent thread metadata`).\n- Threads form a tree: the Thread schema carries `Session id shared by threads that belong to the same session tree` and `Source thread id when this thread was created by forking another thread`, plus an `agent_name`/`agent_status`/`last_task_message` inventory and `SubagentStart`/`SubagentStop` hooks.\n\nSo codex genuinely performs the behavior the scenario asserts: a parent delegates a bounded subtask to a child agent and integrates the result.\n\n## daemon_capability = incapable (the freeze)\n\nThe irrlicht codex adapter cannot OBSERVE the parent/child binding, for a structural reason:\n\n1. **No parent signal in the codex parser.** `core/adapters/inbound/agents/codex/parser.go` sets no `ParentSessionID` on any ParsedEvent (grep: zero hits for parent/subagent). It emits only assistant/user messages, function_call(_output), token/rate-limit, and turn_done.\n2. **Flat on-disk layout — no `\u003cparent\u003e/subagents/` directory.** Codex's Source is `FilesUnderRoot{~/.codex/sessions}` and every thread — parent OR child — is a sibling `sessions/YYYY/MM/DD/rollout-\u003cts\u003e-\u003cuuid\u003e.jsonl`. Confirmed against the local store (newest rollout header is a flat `session_meta` with `thread_source:\"user\"`, `source:\"cli\"`, and NO parent field; no `subagents/` subtree exists anywhere under `~/.codex/sessions`).\n3. **`deriveParentSession` recognizes only two formats, neither codex's.** `core/application/services/helpers.go` derives a parent ID from (a) the Claude-Code path pattern `.../\u003cparent\u003e/subagents/\u003cagent\u003e.jsonl` or (b) a Pi-style `{\"type\":\"session\",\"parentSession\":\"...\"}` header. A codex child rollout matches NEITHER: its filename is a flat `rollout-*.jsonl`, and its `session_meta` header has no `parentSession` key (codex's fork/spawn linkage lives in a different shape — a `subAgentThreadSpawn` source / fork source-thread-id — that no codex code path reads).\n\nConsequence: a codex parent + spawned child surface to the daemon as TWO UNRELATED top-level sessions. `ParentSessionID` stays empty, so `SubagentCount(parent)` is 0, no `parent_linked` event ever fires, and the parent's `working→ready` is governed only by its own turn (it does NOT wait on the child). Every load-bearing assertion of this scenario is unobservable.\n\nThis is `incapable` rather than `bug`: there is no codex trace today that the daemon mis-handles — the adapter has no parent-link rule at all, and the linkage field codex DOES write to a child thread's session_meta (a fork/spawn source) is not on any path the codex parser or `deriveParentSession` reads. Representing it would require a NEW codex-specific linkage rule (parser emits ParentSessionID from the child's session_meta fork/spawn-source, or a codex branch in `deriveParentSession`), i.e. an adapter capability that does not exist — not a fix to a mishandled signal.\n\n## driver_capability = ready\n\nNot the constraint, but recorded honestly: `replaydata/agents/codex/driver-interactive.sh` exposes `send`, `keys`, `interrupt`, `fork`, `reset_session`, `restart`, `resume`, `session`, `sigkill`, `exit_clean`. The recipe below (a single `send` that asks codex to delegate a file-read to a subagent + wait) needs only `send`/wait/sleep — all present. The driver could elicit the behavior the moment the daemon could observe it.\n\n## What would unblock\n\nA codex-adapter change that binds child→parent: emit `ParentSessionID` from the child rollout's `session_meta` fork/spawn source (the `subAgentThreadSpawn` thread source + fork source-thread-id codex already writes), or add a codex branch to `deriveParentSession`. Once a codex child carries a daemon-readable parent link, re-assess: agent=yes + driver=ready means the cell would flip to `record`.",
+      "confidence": 0.95,
+      "body": "## Verdict\n\nagent_supports: yes\ndaemon_capability: full\ndriver_capability: ready\n\nRoute: record. Codex 0.144.4 writes each spawned child as a flat rollout whose first session_meta payload identifies the child thread and declares thread_source: subagent. The nested source.subagent.thread_spawn.parent_thread_id is the authoritative parent edge; compatible payload.parent_thread_id and payload.forked_from_id fallbacks are accepted only for subagent threads.\n\nThe Codex adapter now derives both session identity and parent linkage from that header before fswatcher emits a new-session event. payload.id is the unique per-thread identity; payload.session_id is deliberately excluded because it is shared across the tree. Existing lifecycle and dashboard grouping then nest children and hold a completed parent working until every linked child settles.\n\n## Recording status\n\nThe prior frozen assumption is obsolete. The interactive driver already supplies the required send, wait_turn, and sleep steps. Run this recipe against Codex 0.144.4+ and promote its recording when it passes.",
       "caveats": [
-        "agent_supports=yes is grounded in the binary strings + `features list` (multi_agent stable/true), not a captured spawn_agent recording — the local ~/.codex/sessions store has no real subagent child thread to inspect, so the EXACT on-disk shape of a spawned child's session_meta linkage field (subAgentThreadSpawn source / fork source-thread-id) is inferred from strings, not observed. Confidence is held at 0.8 for that reason; a live spawn_agent capture would confirm the precise field name an adapter fix must read.",
-        "If codex's spawn_agent ran the child in a DETACHED thread that codex itself never persists as a local rollout (cloud-side only), the daemon would see only the parent — that would harden the verdict toward incapable for a transport reason too. Local strings suggest threads are persisted (FilesUnderRoot already tails them), but only a recording settles it."
+        "Only child rollouts materialized on disk can be represented. A future ephemeral child without a rollout remains intentionally invisible.",
+        "A normal Codex /fork is not a subagent: fallback parent fields are ignored unless thread_source is subagent."
       ],
       "sources": [
-        {
-          "kind": "command",
-          "ref": "codex features list",
-          "note": "0.135.0: `multi_agent  stable  true` — the subagent/spawn_agent surface is STABLE and on by default (multi_agent_v2 still under development)"
-        },
-        {
-          "kind": "command",
-          "ref": "strings @openai/codex-darwin-arm64/.../bin/codex | grep -iE 'spawn_agent|SubAgentSource|agent_role|subagent'",
-          "note": "native binary exposes spawn_agent tool ('Spawn a sub-agent for a well-scoped task'), AgentControl-spawned sub-agents, _delegate prompts, SubAgentSource, subAgentThreadSpawn thread source, core/src/agent/control.rs ('spawn_agent fork requires a thread-spawn session source')"
-        },
-        {
-          "kind": "file",
-          "ref": "core/adapters/inbound/agents/codex/parser.go",
-          "note": "codex parser sets NO ParentSessionID and has no subagent/parent path (grep: zero hits) — emits only message/function_call/token/turn_done"
-        },
-        {
-          "kind": "file",
-          "ref": "core/adapters/inbound/agents/codex/adapter.go",
-          "note": "Source = FilesUnderRoot{~/.codex/sessions}; flat sessions/YYYY/MM/DD/rollout-*.jsonl per thread — no \u003cparent\u003e/subagents/ directory exists for parent-link path-matching"
-        },
-        {
-          "kind": "file",
-          "ref": "core/application/services/helpers.go",
-          "note": "deriveParentSession recognizes ONLY the Claude-Code .../\u003cparent\u003e/subagents/\u003cagent\u003e.jsonl path pattern and the Pi {\"type\":\"session\",\"parentSession\":...} header — a flat codex rollout matches neither, so no parent ID is derived"
-        },
-        {
-          "kind": "file",
-          "ref": "~/.codex/sessions/2026/05/29/rollout-2026-05-29T23-41-35-...jsonl",
-          "note": "live codex rollout session_meta header: thread_source:\"user\", source:\"cli\", model_provider:\"openai\" — no parentSession / parent-thread field the daemon reads; no subagents/ subtree anywhere under ~/.codex/sessions"
-        }
+        {"kind": "issue", "ref": "#1050", "note": "Observed local Codex 0.144.4 session_meta child header with source.subagent.thread_spawn.parent_thread_id."},
+        {"kind": "file", "ref": "core/adapters/inbound/agents/codex/session_meta.go", "note": "Header identity and parent-link extraction."},
+        {"kind": "file", "ref": "core/application/services/session_detector_codex_subagent_test.go", "note": "Three-child nesting and parent hold regression."}
       ]
     },
     "recipe": {
       "applicable": true,
-      "preconditions": [
-        "codex CLI 0.135.0+ on PATH and authenticated; multi_agent feature stable/on by default (no flag needed)",
-        "irrlichd is recording (dev daemon with --record, isolated IRRLICHT_HOME)",
-        "FROZEN: this recipe is documentary — the daemon cannot bind the codex child to the parent today (daemon=incapable), so a recording would NOT satisfy the spec until an adapter parent-link rule lands"
-      ],
-      "setup": [
-        "Driver generates a fresh cwd under \u003cstaging\u003e/cwd/",
-        "A README.md with a single H1 heading is seeded into the cwd so the subagent has a deterministic file to read"
-      ],
+      "preconditions": ["Codex CLI 0.144.4+ authenticated", "irrlichd recording with transcript consent granted"],
+      "setup": ["Seed a README.md with one H1 in the driver's fresh working directory."],
       "script": [
-        {
-          "type": "send",
-          "text": "Use a subagent (spawn_agent) to read the README.md in the current directory and report its first heading. Wait for the subagent to finish, then reply 'done'."
-        },
-        {
-          "type": "wait_turn"
-        },
-        {
-          "type": "sleep",
-          "seconds": 6
-        }
+        {"type": "send", "text": "Use a subagent (spawn_agent) to read README.md and report its first heading. Wait for the subagent to finish, then reply done."},
+        {"type": "wait_turn"},
+        {"type": "sleep", "seconds": 6}
       ],
-      "verify": [
-        "(unblock-time) events.jsonl contains \u003e= 1 parent_linked event binding the codex child rollout to the parent UUID",
-        "(unblock-time) the parent stays working until the child reports back, then a single working-\u003eready",
-        "(unblock-time) final parent state is ready"
-      ],
+      "verify": ["events.jsonl contains parent_linked for the child rollout", "the child is nested under its parent", "the parent reaches ready after the child completes"],
       "settings": {},
       "timeout_seconds": 240
     }

--- a/replaydata/agents/codex/scenarios/3-2_background-subagent/metadata.json
+++ b/replaydata/agents/codex/scenarios/3-2_background-subagent/metadata.json
@@ -2,77 +2,45 @@
   "scenario_id": "background-subagent",
   "metadata": {
     "agent_supports": "yes",
-    "daemon_capability": "incapable",
+    "daemon_capability": "full",
     "driver_capability": "ready",
-    "agent_cli_version": "0.135.0",
-    "daemon_version": "0.4.8+5321b6d.dirty",
-    "confidence": 0.82,
-    "notes": "agent_supports: yes (codex 0.135.0 spawn_agent/wait_agent fire-and-forget) — daemon_capability: incapable: the parent→child spawn edge lives ONLY in ~/.codex/state_5.sqlite thread_spawn_edges (+ the in-memory thread manager), never in the rollout JSONL the codex adapter tails — so irrlicht can never link the sub-agent to its parent or hold the parent working → route: frozen"
+    "agent_cli_version": "0.144.4",
+    "confidence": 0.95,
+    "notes": "Observed Codex 0.144.4 rollout metadata exposes the local spawned-child edge. Route: record."
   },
   "details": {
     "assessment": {
       "schema_version": 1,
       "scenario_id": "background-subagent",
       "agent": "codex",
-      "assessed_at": "2026-05-31T00:00:00Z",
+      "assessed_at": "2026-07-14T00:00:00Z",
       "agent_supports": "yes",
-      "daemon_capability": "incapable",
+      "daemon_capability": "full",
       "driver_capability": "ready",
-      "confidence": 0.82,
-      "body": "## Verdict\n\nagent_supports: yes\ndaemon_capability: incapable; driver_capability: ready\n→ route: **frozen** (irrlicht's codex adapter fundamentally cannot link a spawned sub-agent to its parent)\n\n## The scenario's user-observable signal (unified rule)\n\n`background-subagent` (scenario id 3.2): the parent dispatches a fire-and-forget child, finishes its OWN reply (parent assistant turn reaches `end_turn`), yet the SESSION stays `working` while the detached child is alive; `SubagentCount(parent)` INCLUDES the live child; the session goes `working → ready` only after the last background child drains. Same daemon mechanism as `foreground-subagent` (reevaluateParent holds the parent on `hasActiveChildren`; ComputeSubagentSummary counts the live child); the distinguishing observable is the TIMING (parent `end_turn` lands BEFORE child drain). EVERY assertion here is a parent↔child LINK assertion — it presupposes the daemon has bound the child session to the parent.\n\n## agent_supports: yes (codex 0.135.0 ships background sub-agents)\n\nThe context that 'codex is a single-agent loop' is OBSOLETE at 0.135.0. The installed native binary exposes a full multi-agent toolset (`strings` scan):\n\n- `spawn_agent` — 'Spawns an agent to work on the specified task… the agent will have canonical task name `/root/task1/task_3`'. 'This spawn_agent tool provides you access to sub-agents that inherit your current model by default.'\n- `wait_agent` — 'Wait for agents to reach a final status… Call wait_agent very sparingly. Only call wait_agent when you need the result immediately for the next critical-path step and you are blocked until it returns.' → spawning is FIRE-AND-FORGET by default; blocking is the explicit, discouraged exception. This is exactly the background-subagent shape (parent continues; does not block on the child).\n- `send_input` / `resume_agent` / `close` — message/resume/close a named non-root agent; plus `SubagentStart`/`SubagentStop` lifecycle hooks and a thread manager (`core/src/agent/control.rs`).\n- The base prompt states: 'While the subagent is running in the background, do meaningful non-overlapping work immediately.'\n\nGate: 'Only use `spawn_agent` if and only if the user explicitly asks for sub-agents, delegation, or parallel agent work.' This is ELICITABLE — a recipe `send` that explicitly asks for parallel sub-agents satisfies the gate. So agent_supports is an honest `yes` (codex CAN perform the behavior), held at confidence 0.82 because the surface is read from binary strings, not yet exercised live, and the in-process tool plumbing (does the spawned child get its own model turn vs. an MCP elicitation) is not fully pinned from strings alone.\n\n## daemon_capability: incapable (the parent→child link never reaches the watched Source)\n\nThis is the load-bearing pillar. The irrlicht codex adapter (`core/adapters/inbound/agents/codex/agent.go`) is `Source: FilesUnderRoot{sessionsDir()}` (`~/.codex/sessions/**/*.jsonl` rollout JSONL) with `JSONLineParser{Parser}`. The parser (`parser.go`) has ZERO parent-linking logic — no `ParentSessionID`, no sidechain/child discovery, nothing analogous to claudecode's `\u003cparent\u003e/subagents/agent-*.jsonl` path. It only emits per-line model / token / turn_done events.\n\nWhere does codex record the spawn relationship? In `~/.codex/state_5.sqlite`:\n- a dedicated table `thread_spawn_edges(parent_thread_id, child_thread_id, status)` holds the edge (confirmed live: the table exists; it is empty = 0 rows on this machine because no sub-agent has been spawned, consistent with the explicit-request gate);\n- the `threads` table itself has NO parent column (confirmed via PRAGMA table_info: id, rollout_path, source, cwd, …, agent_nickname, agent_role, agent_path — but no parent_id / spawned_by);\n- the Thread protocol metadata that DOES carry linkage ('Session id shared by threads that belong to the same session tree', 'Source thread id when this thread was created by forking', `agent_nickname`/`agent_role` for an AgentControl-spawned sub-agent) is surfaced over the app-server protocol and the state DB — NOT written into the rollout JSONL the adapter tails.\n\nWorse, the Thread schema includes 'Whether the thread is ephemeral and should not be materialized on disk' — a spawned sub-agent may be EPHEMERAL, producing NO rollout file at all, in which case the daemon never even sees a second session.\n\nNet: when codex spawns a background sub-agent, irrlicht's codex Source receives — at best — an independent, UNLINKED rollout with no parent reference (or nothing, if ephemeral). The daemon cannot bind the child to the parent, so `SubagentCount(parent)` can never include it and `reevaluateParent` is never engaged — the parent simply settles `working → ready` at its own `end_turn`, with the (possibly invisible) child as a stray top-level session. The scenario's entire user-observable arc (parent held working by a linked live child; subagent count steps down; parent settles only after the last child drains) is UNOBSERVABLE with no local trace the adapter reads. This is an architecture limit of the codex adapter's transport, not a mishandled trace — hence `incapable`, not `bug`. (It is also NOT a driver gap: the recipe step types all exist; the limit is upstream of the driver.)\n\n## What would unblock this cell (re-assess triggers)\n\nThe agent CAN do it and the data EXISTS on disk — the gap is purely that the codex adapter doesn't read it. A future codex adapter that (a) reads `thread_spawn_edges` from `state_5.sqlite` (or a `ProcessOwnedStore`-style reader over the state DB) to recover parent_thread_id → child_thread_id and projects it as `ParentSessionID`, or (b) consumes a parent-link field if codex ever starts writing one into the rollout JSONL, would flip this to `daemon=full`. Until then the cell stays frozen. (Cross-ref: the opencode adapter already uses `ProcessOwnedStore` for a SQLite-backed agent — the same shape would apply if codex sub-agent linkage were wired.)\n\n## driver_capability: ready\n\nNot the blocker, but recorded for completeness: the codex interactive driver (`replaydata/agents/codex/driver-interactive.sh`) elicits `send wait_turn sleep slash keys fork resume reset_session restart sigkill exit_clean start_session session interrupt` — every step a background-subagent recipe would need (`send` the parallel-agents prompt, `sleep` across the child lifetime, `wait_turn`/`exit_clean`). No `gap:*`. The driver readiness is moot while daemon=incapable freezes the route.\n\n## Routing\n\nagent=yes, daemon=incapable, driver=ready → **frozen** (the agent performs it, but irrlicht fundamentally cannot observe it with the current codex transport). No recording; no spec phases beyond the meta. Re-assess when the codex adapter learns to read `thread_spawn_edges` / a rollout parent-link.",
+      "confidence": 0.95,
+      "body": "## Verdict\n\nagent_supports: yes\ndaemon_capability: full\ndriver_capability: ready\n\nRoute: record. The prior freeze was based on an obsolete transport assumption. In Codex 0.144.4, a materialized subagent rollout begins with session_meta containing thread_source: subagent and an authoritative source.subagent.thread_spawn.parent_thread_id. Irrlicht reads that header before session creation, keeps payload.id as the per-thread session identity, and never uses the shared payload.session_id.\n\nA linked live child participates in the existing file-based subagent summary and parent hold logic. Thus a parent that has finished its own turn remains working while one or more background children are live, and becomes ready only after the final linked child settles.\n\n## Recording status\n\nThe driver has the required foreground-independent steps. Record and promote the recipe below on Codex 0.144.4+ when it passes; the compact redacted incident fixture preserves the observed header shape in the meantime.",
       "caveats": [
-        "agent_supports=yes is read from a strings scan of the codex 0.135.0 native binary (spawn_agent/wait_agent/send_input/resume_agent tool descriptions + SubagentStart/Stop hooks + the 'do meaningful non-overlapping work while the subagent runs in the background' prompt), NOT from a live spawn. confidence 0.82: the toolset and fire-and-forget default are unambiguous in the binary, but the exact transcript shape a spawned sub-agent produces (own rollout vs ephemeral; whether the child turn lands in the parent's rollout as an MCP/tool round-trip) is not pinned from strings alone. A live run would settle it.",
-        "daemon=incapable is anchored in code + live DB inspection: the codex adapter Source is FilesUnderRoot over rollout JSONL with a parser that has no parent-linking logic, while the spawn edge is persisted ONLY in ~/.codex/state_5.sqlite thread_spawn_edges (table present, 0 rows = never spawned here) and the threads table has no parent column. If a future codex release writes a parent-thread id INTO the rollout JSONL, or the irrlicht adapter starts reading the state DB, this flips to daemon=full — re-assess on either.",
-        "Some spawned sub-agents may be ephemeral ('should not be materialized on disk' per the Thread schema), in which case the daemon sees NO second session at all — a strictly stronger form of the same incapability.",
-        "This is NOT cloud-background-agent (1.7): that is a separately-scoped hosted long-running surface. This cell is the LOCAL spawn_agent sub-agent."
+        "The adapter intentionally leaves ordinary non-subagent forks top-level.",
+        "Ephemeral children that create no local rollout cannot appear in the dashboard."
       ],
       "sources": [
-        {
-          "kind": "file",
-          "ref": "/Users/ingo/.nvm/versions/node/v22.18.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex",
-          "note": "strings scan of the codex 0.135.0 native (Mach-O arm64) binary. Tool descriptions: spawn_agent ('Spawns an agent to work on the specified task… inherit your current model by default'); wait_agent ('Call wait_agent very sparingly. Only call wait_agent when you need the result immediately… and you are blocked until it returns') → fire-and-forget by default; send_input / resume_agent / close; SubagentStart/SubagentStop hooks; thread manager (core/src/agent/control.rs); base prompt 'While the subagent is running in the background, do meaningful non-overlapping work immediately'; gate 'Only use spawn_agent if and only if the user explicitly asks for sub-agents, delegation, or parallel agent work'. ESTABLISHES agent_supports=yes; codex-is-single-agent is obsolete at 0.135.0."
-        },
-        {
-          "kind": "file",
-          "ref": "core/adapters/inbound/agents/codex/agent.go",
-          "note": "Source: FilesUnderRoot{sessionsDir()} with JSONLineParser{Parser} — the adapter tails ONLY ~/.codex/sessions/**/*.jsonl rollout JSONL. It does not read ~/.codex/state_5.sqlite. sessionsDir() (adapter.go) = $CODEX_HOME/sessions or .codex/sessions."
-        },
-        {
-          "kind": "file",
-          "ref": "core/adapters/inbound/agents/codex/parser.go",
-          "note": "The codex line parser has NO parent-linking logic whatsoever — no ParentSessionID assignment, no sidechain/child-thread discovery (contrast claudecode's parser, which knows about \u003cparent\u003e/subagents/agent-*.jsonl). It only emits model / token / turn_done / tool events per line. A spawned sub-agent's rollout, even if discovered as a session, would be an unlinked top-level codex session."
-        },
-        {
-          "kind": "file",
-          "ref": "/Users/ingo/.codex/state_5.sqlite",
-          "note": "Live state DB inspection. (1) thread_spawn_edges(parent_thread_id, child_thread_id TEXT PRIMARY KEY, status) — the ONLY place the parent→child spawn edge is persisted; table present, COUNT(*)=0 on this machine (no sub-agent ever spawned, consistent with the explicit-request gate). (2) PRAGMA table_info(threads): id, rollout_path, source, model_provider, cwd, …, agent_nickname, agent_role, agent_path, thread_source — NO parent_id / spawned_by column. The linkage the scenario needs exists on disk but NOT in any field the codex adapter reads."
-        },
-        {
-          "kind": "file",
-          "ref": ".claude/skills/ir:onboarding-factory/assess/SKILL.md",
-          "note": "Observation-vs-emission rule: the parent→child link is the spec's load-bearing observable; since it never reaches the codex Source (rollout JSONL), daemon=incapable is the right owner — an architecture/transport limit, not a parser bug (no trace to mis-handle) and not a driver gap (recipe step types all exist)."
-        },
-        {
-          "kind": "file",
-          "ref": "replaydata/agents/codex/driver-interactive.sh",
-          "note": "DRIVE_ELICITS includes send / wait_turn / sleep / slash / keys / fork / resume / reset_session / restart / sigkill / exit_clean / start_session / session / interrupt — every step a background-subagent recipe would need. driver_capability=ready (moot under the frozen route, recorded for completeness)."
-        },
-        {
-          "kind": "file",
-          "ref": "replaydata/agents/claudecode/scenarios/3-2_background-subagent/metadata.json",
-          "note": "Reference cell (claudecode, daemon=full): claude writes each child as \u003cparent\u003e/subagents/agent-*.jsonl UNDER the watched transcriptsDir, so the fswatcher discovers it as a file-based child SessionState and links by ParentSessionID. Codex has NO equivalent on-disk, adapter-readable parent reference — this is exactly the difference that makes codex incapable where claudecode is full."
-        }
+        {"kind": "issue", "ref": "#1050", "note": "Observed local Codex 0.144.4 rollout linkage."},
+        {"kind": "file", "ref": "replaydata/agents/codex/regressions/subagent-parent-link/README.md", "note": "Redacted parent plus three sibling child header fixture."},
+        {"kind": "file", "ref": "core/application/services/session_detector_codex_subagent_test.go", "note": "Parent hold, nesting, and final-child release regression."}
       ]
     },
     "recipe": {
-      "applicable": false,
-      "frozen_reason": "daemon=incapable: the codex adapter tails rollout JSONL only; the spawn_agent parent→child edge is persisted exclusively in ~/.codex/state_5.sqlite thread_spawn_edges (and the in-memory thread manager), with the threads table carrying no parent column and sub-agent threads possibly ephemeral. irrlicht cannot link the child to the parent, so the held-working / SubagentCount-includes-child arc this scenario asserts is unobservable. The agent CAN perform the behavior (spawn_agent/wait_agent in codex 0.135.0); the gap is purely that the adapter does not read the state DB. Unblock: teach the codex adapter to read thread_spawn_edges (ProcessOwnedStore-style, as opencode does for its SQLite store) and project parent_thread_id→child_thread_id as ParentSessionID — then re-assess to daemon=full.",
-      "preconditions": [],
-      "setup": [],
-      "script": [],
-      "verify": [],
+      "applicable": true,
+      "preconditions": ["Codex CLI 0.144.4+ authenticated", "irrlichd recording with transcript consent granted"],
+      "setup": ["Seed independent small read tasks in the driver's fresh working directory."],
+      "script": [
+        {"type": "send", "text": "Spawn a subagent to read README.md, continue with a small unrelated task without waiting, then wait for the child and reply done."},
+        {"type": "wait_turn"},
+        {"type": "sleep", "seconds": 6}
+      ],
+      "verify": ["events.jsonl contains parent_linked", "parent remains working after its own turn while the child is live", "parent reaches ready once the final child completes"],
       "settings": {},
-      "timeout_seconds": 0
+      "timeout_seconds": 240
     }
   }
 }


### PR DESCRIPTION
Closes #1050

- derive Codex thread identity and subagent parent linkage from rollout session metadata
- defer zero-byte child create events until their header is readable to prevent top-level flicker
- add Codex lifecycle, watcher, and replay-fixture coverage

🤖 Generated with [Claude Code]