### PR TITLE
fix(kirocli): honor KIRO_HOME for session discovery

### DIFF
--- a/core/adapters/inbound/agents/kirocli/adapter.go
+++ b/core/adapters/inbound/agents/kirocli/adapter.go
@@ -2,6 +2,12 @@
 // transcript files under ~/.kiro/sessions/cli/<uuid>.jsonl.
 package kirocli
 
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
 // AdapterName identifies sessions originating from Kiro CLI.
 const AdapterName = "kiro-cli"
 
@@ -19,9 +25,23 @@ const ProcessName = "kiro-cli"
 // next to it.
 const defaultRootDir = ".kiro/sessions/cli"
 
-// sessionsDir returns the directory the Kiro CLI adapter should watch.
-// Kiro documents no env var that relocates the session root, so this is
-// constant — kept as a function to mirror the sibling adapters.
+// kiroHomeEnvVar is the upstream Kiro CLI env var (added v2.3.0, 2026-05-12)
+// that relocates the agent's home directory (default: ~/.kiro). Kiro's docs
+// state it "[o]verrides the ~/.kiro directory used for global agents,
+// prompts, skills, steering, settings, and sessions" — so when set, sessions
+// move to $KIRO_HOME/sessions/cli.
+const kiroHomeEnvVar = "KIRO_HOME"
+
+// sessionsDir returns the directory the Kiro CLI adapter should watch. Non-
+// absolute env values are rejected so a misconfigured path surfaces in logs
+// instead of silently watching the wrong place.
 func sessionsDir() string {
+	if v := os.Getenv(kiroHomeEnvVar); v != "" {
+		cleaned := filepath.Clean(v)
+		if filepath.IsAbs(cleaned) {
+			return filepath.Join(cleaned, "sessions", "cli")
+		}
+		log.Printf("kirocli: ignoring %s=%q — must be an absolute path (no shell expansion)", kiroHomeEnvVar, v)
+	}
 	return defaultRootDir
 }

--- a/core/adapters/inbound/agents/kirocli/adapter_test.go
+++ b/core/adapters/inbound/agents/kirocli/adapter_test.go
@@ -1,0 +1,25 @@
+package kirocli
+
+import "testing"
+
+func TestSessionsDir(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"empty falls back to default", "", defaultRootDir},
+		{"absolute override produces $KIRO_HOME/sessions/cli", "/tmp/kiro-home", "/tmp/kiro-home/sessions/cli"},
+		{"trailing slash is cleaned", "/tmp/kiro-home/", "/tmp/kiro-home/sessions/cli"},
+		{"relative override is rejected (falls back to default)", "relative/home", defaultRootDir},
+		{"tilde-prefixed override is rejected (no shell expansion)", "~/custom", defaultRootDir},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(kiroHomeEnvVar, tc.env)
+			if got := sessionsDir(); got != tc.want {
+				t.Errorf("sessionsDir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/core/adapters/inbound/agents/kirocli/agent.go
+++ b/core/adapters/inbound/agents/kirocli/agent.go
@@ -49,8 +49,10 @@ func Agent() agent.Agent {
 				Kind:            permission.KindObserve,
 				Title:           "Read session transcripts",
 				FeatureUnlocked: "Session list, timeline & live state",
-				Touches:         "Reads session transcripts under ~/.kiro/sessions/cli/",
-				Detail: "Tails *.jsonl session files under ~/.kiro/sessions/cli/ to " +
+				Touches: "Reads session transcripts under ~/.kiro/sessions/cli/ " +
+					"(or $KIRO_HOME/sessions/cli/ if KIRO_HOME is set)",
+				Detail: "Tails *.jsonl session files under ~/.kiro/sessions/cli/ " +
+					"(relocated to $KIRO_HOME/sessions/cli/ if KIRO_HOME is set) to " +
 					"derive session state and activity, and reads the *.json " +
 					"metadata sidecar for the working directory. Read-only — no " +
 					"file is ever modified. Toggling off stops all reading " +


### PR DESCRIPTION
## What changed

The kirocli adapter hardcoded its session root to `~/.kiro/sessions/cli`. Kiro CLI v2.3.0 (2026-05-12) added `KIRO_HOME`, which upstream docs describe as:

> Overrides the `~/.kiro` directory used for global agents, prompts, skills, steering, settings, and **sessions**.

Because the adapter never read this var, setting `KIRO_HOME` made irrlicht's session discovery **silently find nothing** — no error, no log, just zero sessions.

This follows the pattern from `1165dcdf` ("fix(adapters): honor agent-CLI env vars for relocated session dirs (#349) (#362)"), which wired the same fix into `codex` (`CODEX_HOME`), `claudecode` (`CLAUDE_CONFIG_DIR`), and `pi` (`PI_CODING_AGENT_SESSION_DIR`). kirocli was authored later (PR #590, 2026-06-05) and was missed by that sweep — its `sessionsDir()` comment claiming "Kiro documents no env var that relocates the session root" was already false when written.

### Changes

- `core/adapters/inbound/agents/kirocli/adapter.go` — `sessionsDir()` now reads `KIRO_HOME`, rejects non-absolute values (logging why, same as the sibling adapters), and joins `sessions/cli` onto an absolute override. Default stays `.kiro/sessions/cli` (home-relative). Deleted the false comment.
- `core/adapters/inbound/agents/kirocli/adapter_test.go` — **new file** (kirocli had no adapter tests at all). Table test modeled on `codex/adapter_test.go`: empty→default, absolute→override, trailing slash cleaned, relative rejected, tilde rejected.
- `core/adapters/inbound/agents/kirocli/agent.go` — the `transcripts` permission's `Touches`/`Detail` consent copy hardcoded `~/.kiro/sessions/cli/`. Reworded (matching codex/claudecode/pi's phrasing) to note the path relocates to `$KIRO_HOME/sessions/cli/` when set, so the consent text stays truthful now that the path is overridable.

### The `sessions/cli` append question

**I could not fully confirm this from the docs.** I fetched `https://kiro.dev/docs/cli/reference/settings/`, which states verbatim: "Overrides the `~/.kiro` directory used for global agents, prompts, skills, steering, settings, and sessions" — it does **not** explicitly say whether sessions live directly under `$KIRO_HOME` or under a `sessions/cli` subdirectory.

Given that ambiguity, I implemented the append (`$KIRO_HOME/sessions/cli`) by analogy with `CODEX_HOME` (identical shape: relocates the agent home, sessions subdir appended) rather than guessing a flat layout. This mirrors the existing default-path relationship (`~/.kiro` → `~/.kiro/sessions/cli`), so I'm reasonably confident, but it is **not docs-confirmed** — flagging explicitly per the task instructions.

## Testing

- `go test ./core/... -race -count=1` — all packages pass (includes the architecture test).
- `tools/preflight.sh --only go` — all gates pass (gofmt, core tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, starhistory tests).
- The repo's pre-push hook additionally ran the full `tools/preflight.sh` (web tests, ARS architecture gate, security scan) — all passed.

## Scope

Partially addresses #1064 — this PR only covers the `KIRO_HOME` session-discovery fix. It does **not** do the `/rewind` fixture re-record also mentioned in that issue; that remains open. Out of scope per the task: `core/pkg/tailer/`, the vibe adapter, `replaydata/`, `.claude/skills/`, `core/domain/session/metrics.go` — none of these were touched, and the sidecar/PID paths (`sidecar_metrics.go`, `pid.go`) derive from `transcriptPath` so they follow the new root automatically without changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)