### PR TITLE
fix(vibe): reset parser state on rotation; use effective per-model compact threshold

### DIFF
--- a/core/adapters/inbound/agents/vibe/metrics_test.go
+++ b/core/adapters/inbound/agents/vibe/metrics_test.go
@@ -48,8 +48,126 @@ func TestTokenAccounting_EndToEnd(t *testing.T) {
 		t.Errorf("CumOutputTokens = %d, want 320", m.CumOutputTokens)
 	}
 	// The context-utilization bar resolves from the sidecar's auto-compaction
-	// threshold (mistral models aren't in the capacity window map).
+	// threshold (mistral models aren't in the capacity window map). No
+	// config.models[] entries here, so this only pins the no-override
+	// fallback-to-global path; TestContextWindow_PerModelAutoCompactThresholdOverride
+	// below pins the per-model resolution (issue #1063).
 	if m.ContextWindow != 200000 {
 		t.Errorf("ContextWindow = %d, want 200000 (auto_compact_threshold)", m.ContextWindow)
+	}
+}
+
+// TestContextWindow_PerModelAutoCompactThresholdOverride pins issue #1063:
+// the EFFECTIVE auto-compaction threshold is the active model's own
+// config.models[] override, not the top-level global default, whenever the
+// two diverge. It also pins the alias-vs-name matching gotcha found in a
+// live 2.19.1 meta.json: config.active_model ("mistral-medium-3.5") matches
+// models[].alias, while models[].name ("mistral-vibe-cli-latest") is an
+// unrelated CLI/product label that must NOT be used for the match — a decoy
+// entry whose name equals active_model, but whose alias doesn't, is included
+// below to prove the resolution isn't accidentally matching on name.
+func TestContextWindow_PerModelAutoCompactThresholdOverride(t *testing.T) {
+	dir := t.TempDir()
+	transcript := filepath.Join(dir, transcriptFilename)
+	lines := `{"role":"assistant","content":"done","message_id":"a1"}` + "\n"
+	if err := os.WriteFile(transcript, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"environment":{"working_directory":"/tmp/p"},"config":{` +
+		`"active_model":"mistral-medium-3.5","auto_compact_threshold":200000,` +
+		`"models":[` +
+		`{"name":"mistral-medium-3.5","alias":"decoy-name-match","auto_compact_threshold":1},` +
+		`{"name":"mistral-vibe-cli-latest","alias":"mistral-medium-3.5","auto_compact_threshold":64000}` +
+		`]},"stats":{"context_tokens":9000,"session_prompt_tokens":8500,"session_completion_tokens":320}}`
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tl := tailer.NewTranscriptTailer(transcript, &Parser{}, AdapterName)
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+
+	if m.ContextWindow != 64000 {
+		t.Errorf("ContextWindow = %d, want 64000 (active model's own models[].alias-matched override, not the 200000 global default or the 1 name-matched decoy)", m.ContextWindow)
+	}
+}
+
+// TestTokenAccounting_ResumesAfterRotationReset pins issue #1063's primary
+// fix: a rotation/truncation reset must not flatline vibe's token accounting
+// at zero for the rest of the session.
+//
+// Vibe's meta.json session_prompt_tokens/session_completion_tokens are
+// monotonic within a session, so the parser tracks its own high-water mark
+// (lastPromptTokens/lastCompletionTokens) and emits only each turn's DELTA.
+// Vibe 2.19.1's ACP /rewind path rewrites messages.jsonl IN PLACE
+// (_overwrite_messages_sync with inplace=True) instead of forking a new
+// session directory the way the TUI's /rewind does, so a rewind can land as
+// a legitimate rotation under the tailer's watched root: the transcript
+// shrinks (fileSize < lastOffset) and meta.json's cumulative counters drop
+// to reflect the smaller, retained history.
+//
+// Before the fix: the tailer resets its OWN cumulative accumulators to 0 on
+// rotation, but the parser's stale (larger) high-water mark survives. The
+// next turn_done computes dPrompt/dCompletion against that stale mark, both
+// go negative, both clamp to zero, and emitContribution's early return skips
+// updating the high-water mark too — so every subsequent turn_done repeats
+// the same clamp-to-zero comparison and CumInputTokens/CumOutputTokens never
+// move off 0 again, even though real turns keep happening.
+//
+// After the fix: rotationResetter.ResetForRotation zeroes the parser's
+// high-water mark alongside the tailer's own accumulators, so the very next
+// turn_done's delta is computed against 0 and lands correctly.
+func TestTokenAccounting_ResumesAfterRotationReset(t *testing.T) {
+	dir := t.TempDir()
+	transcript := filepath.Join(dir, transcriptFilename)
+	metaPath := filepath.Join(dir, "meta.json")
+
+	// Pre-rewind: one turn, generous token counts.
+	preLines := `{"role":"assistant","content":"first turn done, plenty of padding text here so this line is longer than the post-rewind one","message_id":"a1"}` + "\n"
+	if err := os.WriteFile(transcript, []byte(preLines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	preMeta := `{"environment":{"working_directory":"/tmp/p"},"config":{"active_model":"mistral-medium-3.5","auto_compact_threshold":200000},"stats":{"context_tokens":9000,"session_prompt_tokens":8500,"session_completion_tokens":320}}`
+	if err := os.WriteFile(metaPath, []byte(preMeta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tl := tailer.NewTranscriptTailer(transcript, &Parser{}, AdapterName)
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("pre-rewind TailAndProcess: %v", err)
+	}
+	if m.CumInputTokens != 8500 || m.CumOutputTokens != 320 {
+		t.Fatalf("pre-rewind tokens = (%d, %d), want (8500, 320)", m.CumInputTokens, m.CumOutputTokens)
+	}
+
+	// Simulate the ACP in-place /rewind: a strictly SMALLER transcript
+	// (triggers the tailer's fileSize < lastOffset rotation detection) and a
+	// meta.json whose cumulative counters reset lower, reflecting the
+	// retained (rewound) history rather than continuing to grow from the
+	// pre-rewind totals.
+	postLines := `{"role":"assistant","content":"go","message_id":"a2"}` + "\n"
+	if len(postLines) >= len(preLines) {
+		t.Fatalf("test setup: post-rewind line (%d bytes) must be shorter than pre-rewind (%d bytes) to trigger rotation detection", len(postLines), len(preLines))
+	}
+	if err := os.WriteFile(transcript, []byte(postLines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	postMeta := `{"environment":{"working_directory":"/tmp/p"},"config":{"active_model":"mistral-medium-3.5","auto_compact_threshold":200000},"stats":{"context_tokens":3100,"session_prompt_tokens":3000,"session_completion_tokens":100}}`
+	if err := os.WriteFile(metaPath, []byte(postMeta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err = tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("post-rewind TailAndProcess: %v", err)
+	}
+	if m.CumInputTokens != 3000 {
+		t.Errorf("post-rewind CumInputTokens = %d, want 3000 (flatlined at 0 means the parser's high-water mark wasn't reset)", m.CumInputTokens)
+	}
+	if m.CumOutputTokens != 100 {
+		t.Errorf("post-rewind CumOutputTokens = %d, want 100 (flatlined at 0 means the parser's high-water mark wasn't reset)", m.CumOutputTokens)
 	}
 }

--- a/core/adapters/inbound/agents/vibe/parser.go
+++ b/core/adapters/inbound/agents/vibe/parser.go
@@ -56,6 +56,43 @@ func (p *Parser) SetTranscriptPath(path string) { p.path = path }
 // of collapsing both turns into one working→ready span.
 func (p *Parser) SplitsQueuedFollowUpTurns() bool { return true }
 
+// ResetForRotation implements the tailer's rotationResetter opt-in (issue
+// #1063). Vibe's meta.json session_prompt_tokens / session_completion_tokens
+// counters are monotonic within a session (only ever +=), so the parser
+// tracks its own high-water mark — lastPromptTokens / lastCompletionTokens —
+// to emit each turn's DELTA instead of the running cumulative total (see
+// emitContribution). Vibe 2.19.1's ACP /rewind path
+// (_overwrite_messages_sync with inplace=True) rewrites messages.jsonl in
+// place instead of forking a new session directory the way the TUI's
+// /rewind does, so a rewind can land as a legitimate rotation/truncation
+// under the tailer's watched root (fileSize < lastOffset). Without this
+// reset, the parser's stale (larger) high-water mark would out-run the
+// freshly-rewound session's smaller counters: emitContribution's dPrompt and
+// dCompletion both go negative, clamp to zero, and hit the early return —
+// which also skips updating lastPromptTokens/lastCompletionTokens, so every
+// subsequent turn_done repeats the same clamp-to-zero comparison. Tokens and
+// cost then flatline at zero for the rest of the session.
+//
+// todos (the TodoReconciler) is reset for the same reason: its synthetic
+// per-Key task IDs are assigned in lockstep with the tailer's own taskSeq
+// counter — both increment once per Create delta, in the same order, for
+// every vibe session (see TodoReconciler's doc comment). The tailer already
+// zeroes ITS taskSeq back to 0 on rotation (resetAccumulatorsForRotation);
+// leaving the reconciler's nextID/idByKey at their pre-rotation values would
+// desync the two counters and start handing the tailer IDs that collide with
+// (or never match) the fresh session's own numbering.
+//
+// path and sidecar are deliberately left alone: path is the transcript file
+// being tailed, which doesn't change across an in-place rewrite, and
+// sidecarCache is keyed by meta.json's own (mtime, size) — it self-invalidates
+// the moment Vibe rewrites the sidecar for the rewound session, so it needs
+// no manual reset here.
+func (p *Parser) ResetForRotation() {
+	p.lastPromptTokens = 0
+	p.lastCompletionTokens = 0
+	p.todos = tailer.TodoReconciler{}
+}
+
 // ParseLine normalizes one Vibe transcript line into a ParsedEvent. Each role
 // carries its own well-defined shape, so the per-role logic is delegated to a
 // dedicated parseXMessage function instead of growing one large switch body.

--- a/core/adapters/inbound/agents/vibe/sidecar.go
+++ b/core/adapters/inbound/agents/vibe/sidecar.go
@@ -26,11 +26,45 @@ type sidecarState struct {
 	// whole session cumulative once; later ones see no delta).
 	sessionPromptTokens     int64
 	sessionCompletionTokens int64
-	// contextWindow is vibe's auto-compaction threshold — the token budget vibe
-	// itself targets before compacting. It is the meaningful "context full" mark
-	// for a vibe session (mistral models aren't in the capacity window map), so
-	// the parser emits it as the context-utilization window.
+	// contextWindow is vibe's EFFECTIVE auto-compaction threshold for the
+	// active model — the token budget vibe itself targets before compacting.
+	// It is the meaningful "context full" mark for a vibe session (mistral
+	// models aren't in the capacity window map), so the parser emits it as
+	// the context-utilization window. Resolved by resolveAutoCompactThreshold:
+	// config.models[] can override the global config.auto_compact_threshold
+	// per model, and upstream's effective value is always the active model's
+	// own (config.get_active_model().auto_compact_threshold), not the global.
 	contextWindow int64
+}
+
+// vibeModelConfig is one entry of vibe's config.models[] array — the
+// per-model overrides layered on top of config.auto_compact_threshold.
+type vibeModelConfig struct {
+	// Alias is the model's short identifier — what config.active_model
+	// matches against (e.g. "mistral-medium-3.5" in a live 2.19.1 config).
+	// Deliberately NOT Name: models[].name carries an unrelated CLI/product
+	// label ("mistral-vibe-cli-latest" in that same config) that never
+	// matches active_model, so matching on Name silently fails to resolve
+	// any override at all.
+	Alias                string `json:"alias"`
+	AutoCompactThreshold int64  `json:"auto_compact_threshold"`
+}
+
+// resolveAutoCompactThreshold returns the EFFECTIVE auto-compaction threshold
+// for the active model: its own config.models[] override when one is set,
+// falling back to the global default otherwise. Upstream resolves this as
+// config.get_active_model().auto_compact_threshold —
+// _apply_global_auto_compact_threshold only pushes the global value into
+// models that didn't already set their own, so the two diverge whenever a
+// per-model override exists. Never returns something worse than the input
+// global: an unmatched or zero-valued override both fall through to it.
+func resolveAutoCompactThreshold(activeModel string, global int64, models []vibeModelConfig) int64 {
+	for _, m := range models {
+		if m.Alias == activeModel && m.AutoCompactThreshold > 0 {
+			return m.AutoCompactThreshold
+		}
+	}
+	return global
 }
 
 // sidecarCache memoizes the last decode by (mtime, size) so a backfill of a
@@ -75,8 +109,9 @@ func readSidecar(transcriptPath string, cache *sidecarCache) *sidecarState {
 			WorkingDirectory string `json:"working_directory"`
 		} `json:"environment"`
 		Config struct {
-			ActiveModel          string `json:"active_model"`
-			AutoCompactThreshold int64  `json:"auto_compact_threshold"`
+			ActiveModel          string            `json:"active_model"`
+			AutoCompactThreshold int64             `json:"auto_compact_threshold"`
+			Models               []vibeModelConfig `json:"models"`
 		} `json:"config"`
 		Stats struct {
 			ContextTokens          int64 `json:"context_tokens"`
@@ -94,7 +129,7 @@ func readSidecar(transcriptPath string, cache *sidecarCache) *sidecarState {
 		contextTokens:           raw.Stats.ContextTokens,
 		sessionPromptTokens:     raw.Stats.SessionPromptTokens,
 		sessionCompletionTokens: raw.Stats.SessionCompletionToken,
-		contextWindow:           raw.Config.AutoCompactThreshold,
+		contextWindow:           resolveAutoCompactThreshold(raw.Config.ActiveModel, raw.Config.AutoCompactThreshold, raw.Config.Models),
 	}
 	cache.mtime = fi.ModTime()
 	cache.size = fi.Size()

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -438,6 +438,28 @@ type queuedTurnSplitter interface {
 	SplitsQueuedFollowUpTurns() bool
 }
 
+// rotationResetter is an optional interface a parser implements when it
+// holds session-scoped accumulated state derived from an upstream MONOTONIC
+// counter — one that only ever increases across a session, so the parser
+// tracks its own high-water mark to compute per-turn deltas. When the tailer
+// detects a legitimate rotation/truncation (fileSize < lastOffset) it already
+// zeroes its OWN cumulative accumulators (resetAccumulatorsForRotation) so a
+// replay from byte 0 doesn't double-count; without this hook a parser's own
+// high-water mark would stay stale, computing deltas against the PREVIOUS
+// file's counters instead of the fresh one's — for a monotonic counter that
+// resets lower after rotation, the delta clamps negative-to-zero and can
+// flatline the parser's contribution forever. See issue #1063 (Mistral Vibe's
+// ACP /rewind path overwrites messages.jsonl in place, unlike the TUI path
+// which forks a new session directory instead).
+//
+// Deliberately opt-in and a no-op for every parser that doesn't implement
+// it (the common case: claudecode, codex, pi, kirocli, aider, antigravity
+// carry no such monotonic-counter state) — the tailer's type-assertion costs
+// nothing for them.
+type rotationResetter interface {
+	ResetForRotation()
+}
+
 // ParserLedger holds the durable state a stateful parser checkpoints across
 // daemon restarts. Fields are parser-specific; unused ones stay zero.
 type ParserLedger struct {

--- a/core/pkg/tailer/rotation_reset_test.go
+++ b/core/pkg/tailer/rotation_reset_test.go
@@ -1,0 +1,80 @@
+package tailer
+
+import (
+	"os"
+	"testing"
+)
+
+// rotationResetParser is a minimal TranscriptParser that also implements
+// rotationResetter, so tests can observe whether/when the tailer invokes the
+// hook without depending on any real adapter's parsing logic.
+type rotationResetParser struct {
+	resetCalls int
+}
+
+func (p *rotationResetParser) ParseLine(raw map[string]interface{}) *ParsedEvent {
+	return &ParsedEvent{Skip: true}
+}
+
+func (p *rotationResetParser) ResetForRotation() {
+	p.resetCalls++
+}
+
+// TestResetAccumulatorsForRotation_InvokesParserHook pins the shared seam
+// added for issue #1063: when the tailer detects a rotated/truncated
+// transcript (fileSize < lastOffset), it must call ResetForRotation on any
+// parser that implements the optional rotationResetter interface, in
+// addition to resetting its own cumulative accumulators. A normal
+// (non-rotated) pass must NOT call it.
+func TestResetAccumulatorsForRotation_InvokesParserHook(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"line": 1},
+		{"line": 2},
+		{"line": 3},
+	})
+	p := &rotationResetParser{}
+	tl := NewTranscriptTailer(path, p, "test-adapter")
+
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("first TailAndProcess: %v", err)
+	}
+	if p.resetCalls != 0 {
+		t.Fatalf("resetCalls = %d after a normal pass, want 0 (no rotation occurred)", p.resetCalls)
+	}
+
+	// Simulate rotation: replace the transcript with a strictly smaller file
+	// so fileSize < tl.lastOffset on the next pass.
+	if err := os.WriteFile(path, []byte(`{"line":1}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("second (rotated) TailAndProcess: %v", err)
+	}
+	if p.resetCalls != 1 {
+		t.Fatalf("resetCalls = %d after a rotated pass, want 1", p.resetCalls)
+	}
+}
+
+// TestResetAccumulatorsForRotation_NoOpForNonImplementingParser pins that the
+// rotationResetter type-assertion is a harmless no-op (no panic, no special
+// handling required) for the common case of a parser that doesn't implement
+// it — every adapter except mistral-vibe as of issue #1063.
+func TestResetAccumulatorsForRotation_NoOpForNonImplementingParser(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"type": "user", "timestamp": ts(0)},
+		{"type": "assistant", "timestamp": ts(1)},
+	})
+	tl := newTestTailer(path)
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("first TailAndProcess: %v", err)
+	}
+
+	// Rotate to a smaller file; must not panic even though testParser
+	// implements no reset hook.
+	if err := os.WriteFile(path, []byte(`{"type":"user","timestamp":"`+ts(0)+`"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("second (rotated) TailAndProcess: %v", err)
+	}
+}

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -150,8 +150,13 @@ type SessionMetrics struct {
 	// message, truncated to ~200 characters.
 	LastAssistantText string `json:"last_assistant_text,omitempty"`
 
-	// PermissionMode is the session's permission mode (e.g. "default",
-	// "plan", "bypassPermissions"). Extracted from "permission-mode" events.
+	// PermissionMode is the session's permission mode. Extracted from
+	// "permission-mode" events. A census of 320 live Claude Code transcripts
+	// found the values actually in use are overwhelmingly "auto" (~5000
+	// occurrences) and "plan" (331), with "default" (8) and "acceptEdits" (3)
+	// rare and "bypassPermissions" never observed. Claude Code v2.1.200
+	// renamed "default" to "manual". Pass-through field only — nothing here
+	// branches on its value.
 	PermissionMode string `json:"permission_mode,omitempty"`
 
 	// SawUserBlockingToolClosedThisPass is true when an AskUserQuestion or
@@ -555,7 +560,16 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 // detects fileSize < lastOffset — the transcript was rotated or truncated —
 // so replaying from byte 0 doesn't double-count tokens, resurrect stale
 // background processes, or misattribute the previous file's tasks.
+//
+// This only resets the TAILER's own accumulators. A parser that tracks its
+// own session-scoped state derived from an upstream monotonic counter (e.g.
+// Mistral Vibe's token high-water mark, issue #1063) must reset that state
+// too, or its next delta computation will be measured against the stale
+// pre-rotation value. See the rotationResetter optional interface.
 func (t *TranscriptTailer) resetAccumulatorsForRotation() {
+	if resetter, ok := t.parser.(rotationResetter); ok {
+		resetter.ResetForRotation()
+	}
 	t.cumInputTokens = 0
 	t.cumOutputTokens = 0
 	t.cumCacheReadTokens = 0


### PR DESCRIPTION
## Summary

Two well-scoped fixes for real bugs found while assessing issue #1063 — **not** the two fixes the issue text itself proposes (see "About #1063's proposed fixes" below).

### Fix 1 (primary): rotation reset didn't reset parser state → vibe tokens/cost flatline at 0

The tailer's rotation/truncation handler (`resetAccumulatorsForRotation`, `core/pkg/tailer/tailer.go`) zeroes its own cumulative token accumulators when it detects `fileSize < lastOffset`, but had no way to tell a stateful parser to reset its own accumulated state.

Vibe's parser (`core/adapters/inbound/agents/vibe/parser.go`) tracks a token high-water mark (`lastPromptTokens`/`lastCompletionTokens`) derived from `meta.json`'s session-cumulative `session_prompt_tokens`/`session_completion_tokens`, and emits each turn's *delta*. That upstream counter is monotonic within a session. This was previously unreachable because Vibe's `/rewind` always forked a new session directory — but Vibe **2.19.1** made it reachable via the **ACP path only**: `_overwrite_messages_sync` (tempfile + `os.replace`) is gated on `inplace=True`, which the TUI doesn't pass (defaults to `inplace=False` → forks) but ACP does. ACP shares the same session directory, so the rewrite lands under the tailer's watched root as a legitimate rotation.

Without a parser-side reset, the stale (larger) high-water mark computes a negative delta against the freshly-rewound session's smaller counters, both clamp to zero, and `emitContribution`'s early return skips updating the high-water mark too — so every subsequent `turn_done` repeats the same clamp, and session tokens/cost flatline at 0 for the rest of the session.

**Fix**: added an optional `rotationResetter` interface (`ResetForRotation()`) that the tailer type-asserts for in `resetAccumulatorsForRotation` — a no-op for the 6 other adapters sharing this tailer (claudecode, codex, pi, kirocli, aider, antigravity) that don't implement it. Vibe's `Parser.ResetForRotation` resets:
- `lastPromptTokens` / `lastCompletionTokens` — the token high-water mark itself.
- `todos` (the `TodoReconciler`) — its synthetic per-todo task IDs are assigned in lockstep with the tailer's own `taskSeq` counter (both increment once per Create delta, in the same order). The tailer already resets its `taskSeq` to 0 on rotation; leaving the reconciler's `nextID`/`idByKey` stale would desync the two ID spaces.

Deliberately **not** reset: `path` (the transcript file doesn't change across an in-place rewrite) and the `sidecarCache` (already self-invalidates via its own mtime/size check the moment Vibe rewrites `meta.json`).

Added a regression test (`TestTokenAccounting_ResumesAfterRotationReset` in `metrics_test.go`) that drives the production tailer through a pre-rewind turn, simulates the in-place rewrite (smaller transcript + smaller cumulative sidecar counters), and asserts tokens resume correctly instead of flatlining. Also added `core/pkg/tailer/rotation_reset_test.go` pinning the generic seam itself (hook fires on rotation, is a no-op for non-implementing parsers). I verified both tests actually catch the bug by temporarily reverting the tailer-side wiring and confirming they fail as expected, then restored the fix.

### Fix 2 (secondary, latent): `auto_compact_threshold` read the global default, not the effective per-model value

`core/adapters/inbound/agents/vibe/sidecar.go` decoded `config.auto_compact_threshold` (the global default) with no `config.models[]` parsing at all. Upstream's *effective* threshold is per-model (`config.get_active_model().auto_compact_threshold`); `_apply_global_auto_compact_threshold` only pushes the global into models that didn't set their own override, so the two values diverge whenever a per-model override exists. This feeds `SessionMetrics.ContextWindow` → the context-utilization bar, so it is user-visible once a divergence exists.

**Fix**: `resolveAutoCompactThreshold` now resolves `config.active_model` against `config.models[].alias` (not `.name` — a live 2.19.1 `meta.json` has `active_model: "mistral-medium-3.5"` matching `models[].alias`, while `models[].name` is the unrelated `"mistral-vibe-cli-latest"`; matching on name would silently fail to resolve anything), falling back to the global default when there's no match or the override is zero.

**This is a latent fix, not a live bug**: in the verified live `meta.json`, all three models carry the same value (200000) as the global, so nothing is visibly wrong today — it only diverges once a per-model override is set. Added `TestContextWindow_PerModelAutoCompactThresholdOverride`, including a decoy entry to prove the alias-vs-name matching direction, and updated the existing `TestTokenAccounting_EndToEnd` comment to note it only pins the no-override fallback path.

### Drive-by

Fixed a stale comment on `SessionMetrics.PermissionMode` (`core/pkg/tailer/tailer.go`) that listed `"default"`, `"plan"`, `"bypassPermissions"` as the values in use. A census of 320 live Claude Code transcripts shows `auto` (~5000), `plan` (331), `default` (8), `acceptEdits` (3), and `bypassPermissions` (0) — and Claude Code v2.1.200 renamed `"default"` to `"manual"`. Comment-only; the field is pass-through with no classifier branching on its value.

## About #1063's proposed fixes

The issue as filed proposes two HIGH-priority fixes. A deep assessment found both are **already handled or no-ops**, and they are deliberately **not implemented** here so the mismatch with the issue text doesn't confuse reviewers:

- "Add inode/truncation detection to the vibe tailer" — **already handled**. The shared tailer does `os.Open` + `defer file.Close()` every pass (no stale FD), and shrink detection already exists (`fileSize < t.lastOffset` → reset). This PR's Fix 1 is the *actual* gap underneath that report — the tailer's existing detection just didn't propagate to parser-side state.
- "Accept both `read_file` and `read` tool names" — a **no-op**. `vibe/parser.go` keys on exactly one tool name (`"todo"`) for the whole-list-replace decoder, which never changed, and `parseToolCalls` passes tool names through verbatim without ever reading args — there's nothing here that inspects `read_file`/`read` at all.
- A fixture audit found the replaydata fixtures clean (no `read`/`search_replace`/`edit` tool names across 243 files; all 36 recordings postdate the transient window described in the issue).

## Follow-up not implemented here

`isUserBlockingToolName` (`core/pkg/tailer/tailer_config.go`) doesn't match Vibe's `ask_user_question` tool — a real gap, but deliberately out of scope for this PR. It needs a fixture decision first: `replaydata/agents/mistral-vibe/scenarios/2-17_user-blocking-question/metadata.json` currently steers Vibe away from that tool and tests the trailing-`?` path instead.

## Test plan

- [x] `go test ./core/... -race -count=1` — full core suite green, including the architecture test.
- [x] `tools/preflight.sh --only go` — green.
- [x] Full `tools/preflight.sh` ran as the pre-push hook (gofmt, core tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, starhistory tests, both web suites, ARS architecture gate, security scan) — all green.
- [x] `go test ./tools/onboarding-factory/cmd/replay/... -count=1` — all `TestFixtureReplayByteIdentity` cases pass byte-identical across every adapter; no golden regeneration was needed (confirms Fix 1 didn't leak into any adapter's replay output).
- [x] Sanity-checked both new regression tests by temporarily reverting the tailer-side wiring and confirming they fail, then restoring the fix.

Partially addresses #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)