### PR TITLE
feat(history): gate the Activity chart behind a beta toggle (#1075)

### DIFF
--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -29,6 +29,14 @@ enum HistoryTab: String, CaseIterable, Identifiable {
         case .quota: return "Quota"
         }
     }
+
+    /// The tabs to offer, given the Activity beta toggle (#1075). Activity is
+    /// opt-in because its matrix is reconstructed from recordings: a bucket
+    /// that was never recorded renders identically to an idle one, so without
+    /// recordings it reads as a grid of misleading blanks.
+    static func visible(activityEnabled: Bool) -> [HistoryTab] {
+        allCases.filter { $0 != .activity || activityEnabled }
+    }
 }
 
 /// Which analytic is shown inside the Metrics tab (#951) — a single-selection
@@ -80,6 +88,13 @@ struct HistoryView: View {
     // range/start/end entirely rather than adding to them (mirrors the
     // daemon's own chart=="state" special-case in resolveHistoryQuery).
     @State private var stateGranularity: HistoryGranularity = .hr24
+
+    // Activity is opt-in (#1075): the matrix is reconstructed from recordings,
+    // and a bucket that was never recorded looks exactly like an idle one, so
+    // without recordings enabled it reads as a grid of misleading blanks.
+    // Declared here as well as in SettingsView — the established shape for a
+    // flag that gates UI elsewhere (cf. showQuotaForecast).
+    @AppStorage("enableActivityChart") private var enableActivityChart: Bool = false
 
     @State private var response: HistoryResponse?
     @State private var yieldResponse: HistoryYieldResponse?
@@ -167,6 +182,13 @@ struct HistoryView: View {
             scope = nil
             if newTab == .usage, chart == .yieldRatio || chart == .dora { chart = .cost }
         }
+        // Settings is a separate window, so the toggle can go off while Activity
+        // is on screen. Without this the tab vanishes from the picker but stays
+        // selected — a segmented control with nothing lit, still showing the
+        // matrix underneath it.
+        .onChange(of: enableActivityChart) { enabled in
+            if !enabled, tab == .activity { tab = .usage }
+        }
     }
 
     // MARK: Header
@@ -174,11 +196,17 @@ struct HistoryView: View {
     /// Tab switcher row, below the shared `PanelHeader` (issue #940 — the
     /// header itself is now identical across every sub-panel; view-specific
     /// controls live in their own row underneath it).
+    /// Mirrors `visibleCharts`; the filter itself lives on HistoryTab so it's
+    /// testable without standing up a view.
+    private var visibleTabs: [HistoryTab] {
+        HistoryTab.visible(activityEnabled: enableActivityChart)
+    }
+
     private var tabSwitcher: some View {
         HStack {
             Spacer(minLength: 0)
             Picker("", selection: $tab) {
-                ForEach(HistoryTab.allCases) { Text($0.label).tag($0) }
+                ForEach(visibleTabs) { Text($0.label).tag($0) }
             }
             .pickerStyle(.segmented)
             .labelsHidden()

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -196,17 +196,11 @@ struct HistoryView: View {
     /// Tab switcher row, below the shared `PanelHeader` (issue #940 — the
     /// header itself is now identical across every sub-panel; view-specific
     /// controls live in their own row underneath it).
-    /// Mirrors `visibleCharts`; the filter itself lives on HistoryTab so it's
-    /// testable without standing up a view.
-    private var visibleTabs: [HistoryTab] {
-        HistoryTab.visible(activityEnabled: enableActivityChart)
-    }
-
     private var tabSwitcher: some View {
         HStack {
             Spacer(minLength: 0)
             Picker("", selection: $tab) {
-                ForEach(visibleTabs) { Text($0.label).tag($0) }
+                ForEach(HistoryTab.visible(activityEnabled: enableActivityChart)) { Text($0.label).tag($0) }
             }
             .pickerStyle(.segmented)
             .labelsHidden()

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -24,6 +24,8 @@ struct SettingsView: View {
     let sessionManager: SessionManager
     @EnvironmentObject var daemonManager: DaemonManager
     @AppStorage("debugMode") private var debugMode: Bool = false
+    /// Gates the History Activity tab (#1075); also read by HistoryView.
+    @AppStorage("enableActivityChart") private var enableActivityChart: Bool = false
     @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
     @AppStorage("showQuotaForecast") private var showQuotaForecast: Bool = true
     @AppStorage("launchAtLogin") private var launchAtLogin: Bool = true
@@ -366,7 +368,7 @@ struct SettingsView: View {
                             .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
-                        .tooltip("Show debug, task-estimate markers, sources, and the command-line tool")
+                        .tooltip("Show debug, activity chart, task-estimate markers, sources, and the command-line tool")
                         .accessibilityElement(children: .combine)
                         .accessibilityValue(advancedSettingsExpanded ? "expanded" : "collapsed")
 
@@ -375,6 +377,16 @@ struct SettingsView: View {
                                 isOn: $debugMode,
                                 label: "Debug Mode",
                                 info: "Show session IDs, creation time, and time since last update."
+                            )
+
+                            // Activity Matrix tab (issue #1075). Purely local UI
+                            // state — unlike the two activations below it, nothing
+                            // is installed, so there's no daemon to reconcile with.
+                            LeadingToggle(
+                                isOn: $enableActivityChart,
+                                label: "Activity Chart",
+                                info: "Adds a projects × time grid of session states to History. Reconstructed from opt-in recordings — a blank cell may mean \"not recorded\" rather than \"idle\".",
+                                beta: true
                             )
 
                             // Task-eta global activation (issue #558). The daemon is

--- a/platforms/macos/Tests/HistoryTabVisibilityTests.swift
+++ b/platforms/macos/Tests/HistoryTabVisibilityTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Irrlicht
+
+/// The Activity tab is gated behind a beta toggle (#1075). HistoryView reads the
+/// flag via @AppStorage, but the decision itself is a pure function on the enum,
+/// so these assert it directly rather than standing up a view and mutating the
+/// developer's real UserDefaults.
+final class HistoryTabVisibilityTests: XCTestCase {
+    func testActivityIsHiddenByDefault() {
+        XCTAssertEqual(HistoryTab.visible(activityEnabled: false), [.usage, .metrics, .quota])
+    }
+
+    func testActivityAppearsWhenEnabled() {
+        XCTAssertEqual(HistoryTab.visible(activityEnabled: true), [.usage, .activity, .metrics, .quota])
+    }
+
+    func testGatingOnlyAffectsActivity() {
+        // Every other tab is unconditional — the toggle must not disturb the
+        // order or membership of the rest of the picker.
+        let off = HistoryTab.visible(activityEnabled: false)
+        let on = HistoryTab.visible(activityEnabled: true)
+        XCTAssertEqual(off, on.filter { $0 != .activity })
+        XCTAssertEqual(on, HistoryTab.allCases)
+    }
+}

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -1030,6 +1030,26 @@ function clearHistoryDrilldown() {
   fetchHistory();
 }
 
+// setActivityChartEnabled gates the Activity chart (chart=state) behind the
+// Advanced Settings beta toggle (#1075). The matrix is reconstructed from
+// opt-in recordings, and a bucket with no recording renders identically to a
+// genuinely idle one (see renderStateMatrix), so anyone not recording reads a
+// grid of blanks as "idle" — misleading enough that it's off by default.
+export function setActivityChartEnabled(enabled) {
+  const btn = document.querySelector('#history-chart-sel button[data-chart="state"]');
+  if (btn) btn.hidden = !enabled;
+  // Turning it off while it's the live chart would otherwise strand the view on
+  // a chart the setting says is off — the matrix grid stays up, and the
+  // per-chart control rows only resync on a render. Fall back to the default
+  // chart, same shape as drillInto.
+  if (!enabled && historyState.chart === 'state') {
+    historyState.chart = 'cost';
+    historyState.scope = null;
+    syncHistorySelectors();
+    fetchHistory();
+  }
+}
+
 // syncHistorySelectors reflects historyState.chart/group onto the segmented
 // controls — drilldown and the models/providers presets change them
 // programmatically, so the active classes must follow.

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -1030,24 +1030,27 @@ function clearHistoryDrilldown() {
   fetchHistory();
 }
 
-// setActivityChartEnabled gates the Activity chart (chart=state) behind the
-// Advanced Settings beta toggle (#1075). The matrix is reconstructed from
-// opt-in recordings, and a bucket with no recording renders identically to a
-// genuinely idle one (see renderStateMatrix), so anyone not recording reads a
-// grid of blanks as "idle" — misleading enough that it's off by default.
-export function setActivityChartEnabled(enabled) {
+// syncActivityChartVisibility reflects the Activity beta toggle (#1075) onto the
+// chart selector. The matrix is reconstructed from opt-in recordings, and a
+// bucket with no recording renders identically to a genuinely idle one (see
+// renderStateMatrix), so anyone not recording reads a grid of blanks as "idle"
+// — misleading enough that it's off by default.
+export function syncActivityChartVisibility(enabled) {
   const btn = document.querySelector('#history-chart-sel button[data-chart="state"]');
   if (btn) btn.hidden = !enabled;
-  // Turning it off while it's the live chart would otherwise strand the view on
-  // a chart the setting says is off — the matrix grid stays up, and the
-  // per-chart control rows only resync on a render. Fall back to the default
-  // chart, same shape as drillInto.
-  if (!enabled && historyState.chart === 'state') {
-    historyState.chart = 'cost';
-    historyState.scope = null;
-    syncHistorySelectors();
-    fetchHistory();
-  }
+}
+
+// leaveActivityChartIfSelected backs out of chart=state when the gate is turned
+// off underneath it — otherwise the view strands on a chart the setting says is
+// off, with the matrix grid still up. No-op unless Activity is live, so it's
+// only the toggle's own change handler that needs to call it. Same shape as
+// drillInto.
+export function leaveActivityChartIfSelected() {
+  if (historyState.chart !== 'state') return;
+  historyState.chart = 'cost';
+  historyState.scope = null;
+  syncHistorySelectors();
+  fetchHistory();
 }
 
 // syncHistorySelectors reflects historyState.chart/group onto the segmented

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -99,6 +99,13 @@
             <span class="settings-hint">Show session IDs and elapsed time in each row.</span>
           </span>
         </label>
+        <label>
+          <input type="checkbox" data-setting="enableActivityChart">
+          <span class="settings-label-text">
+            <span class="settings-title">Activity chart <span class="beta-badge">Beta</span></span>
+            <span class="settings-hint">Adds a projects × time grid of session states to History. Reconstructed from opt-in recordings — a blank cell may mean "not recorded" rather than "idle".</span>
+          </span>
+        </label>
 
         <h2>Sources <span class="beta-badge">Beta</span></h2>
         <label>
@@ -195,7 +202,7 @@
             <button type="button" data-chart="models">Models</button>
             <button type="button" data-chart="providers">Providers</button>
             <button type="button" data-chart="agents">Agents</button>
-            <button type="button" data-chart="state" title="Working/waiting/ready mix per project over time">Activity</button>
+            <button type="button" data-chart="state" hidden title="Working/waiting/ready mix per project over time">Activity</button>
           </fieldset>
           <fieldset class="history-seg" id="history-metrics-sel" aria-label="Metrics">
             <button type="button" data-chart="yield" title="Metrics: productive vs reverted spend per project">Yield</button>

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -202,6 +202,8 @@
             <button type="button" data-chart="models">Models</button>
             <button type="button" data-chart="providers">Providers</button>
             <button type="button" data-chart="agents">Agents</button>
+            <!-- hidden here so a default-off gate never flashes it; applySettings
+                 unhides it. Keep in sync with SETTINGS_DEFAULTS.enableActivityChart. -->
             <button type="button" data-chart="state" hidden title="Working/waiting/ready mix per project over time">Activity</button>
           </fieldset>
           <fieldset class="history-seg" id="history-metrics-sel" aria-label="Metrics">

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1336,12 +1336,16 @@
       margin: 0; padding: 0; min-width: 0;
     }
     .history-seg button {
-      background: none; border: none; border-right: 1px solid var(--border);
+      background: none; border: none; border-left: 1px solid var(--border);
       color: var(--text); font-family: var(--font-mono); font-size: 10px;
       letter-spacing: 0.03em; padding: 4px 10px; cursor: pointer;
       transition: background 0.15s, color 0.15s;
     }
-    .history-seg button:last-child { border-right: none; }
+    /* Separators hang off each button's leading edge, not its trailing one, so
+       that hiding the last button (Activity, gated by a beta toggle — #1075)
+       can't strand a border against the fieldset's own right edge. */
+    .history-seg button:first-child { border-left: none; }
+    .history-seg button[hidden] { display: none; }
     .history-seg button:hover:not(:disabled):not(.active) {
       background: var(--surface-hover); color: var(--text-bright);
     }

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1,6 +1,6 @@
 import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
 import { isSummaryCollapsed, toggleSummaryCollapsed, getSummaryMode, toggleSummaryMode } from './collapsedSummaries.js';
-import { initHistoryTab } from './historyTab.js';
+import { initHistoryTab, setActivityChartEnabled } from './historyTab.js';
 import { initPermissionsWizard, refreshPermissions } from './permissionsWizard.js';
 import {
   showQuotaForecast, setShowQuotaForecast, renderHeaderTitle, refreshProviderSettings,
@@ -127,6 +127,9 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       notifyOnReady: false,
       notifyOnWaiting: false,
       notifyOnContextPressure: false,
+      // Activity chart (#1075): opt-in, since the matrix only means anything
+      // with recordings enabled. Mirrors the macOS enableActivityChart key.
+      enableActivityChart: false,
       // Sources: the local source (the origin that served this page) is on by
       // default; a relay source is opt-in by URL. Mirrors the macOS
       // useLocalDaemon / useRelayServer / relayServerURL @AppStorage keys.
@@ -158,6 +161,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     function applySettings() {
       document.body.classList.toggle('no-cost', !settings.showCostDisplay);
       document.body.classList.toggle('debug-mode', !!settings.debugMode);
+      setActivityChartEnabled(!!settings.enableActivityChart);
     }
     applySettings();
 
@@ -2144,4 +2148,5 @@ export {
   histDoraPerWeek, histDoraPercent, histDoraHours,
   CO2_EQUIVALENTS, pickCO2Equivalents,
   stateCellCounts, stateCellTotal, stateMatrixMaxTotal, stateBucketLabel,
+  setActivityChartEnabled,
 } from './historyTab.js';

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1,6 +1,6 @@
 import { isGroupCollapsed, toggleGroupCollapsed } from './collapsedGroups.js';
 import { isSummaryCollapsed, toggleSummaryCollapsed, getSummaryMode, toggleSummaryMode } from './collapsedSummaries.js';
-import { initHistoryTab, setActivityChartEnabled } from './historyTab.js';
+import { initHistoryTab, syncActivityChartVisibility, leaveActivityChartIfSelected } from './historyTab.js';
 import { initPermissionsWizard, refreshPermissions } from './permissionsWizard.js';
 import {
   showQuotaForecast, setShowQuotaForecast, renderHeaderTitle, refreshProviderSettings,
@@ -161,7 +161,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     function applySettings() {
       document.body.classList.toggle('no-cost', !settings.showCostDisplay);
       document.body.classList.toggle('debug-mode', !!settings.debugMode);
-      setActivityChartEnabled(!!settings.enableActivityChart);
+      syncActivityChartVisibility(!!settings.enableActivityChart);
     }
     applySettings();
 
@@ -2096,6 +2096,9 @@ import { reconcile, paintRowNum } from './domReconcile.js';
         refreshPermNote();
         // Source toggles/URL reconnect live, no page reload.
         if (SOURCE_SETTING_KEYS.has(key)) rebuildSources();
+        // Hiding the Activity button isn't enough if it's the chart on screen
+        // right now — back out of it too (#1075).
+        if (key === 'enableActivityChart' && !settings[key]) leaveActivityChartIfSelected();
       });
     }
 
@@ -2148,5 +2151,5 @@ export {
   histDoraPerWeek, histDoraPercent, histDoraHours,
   CO2_EQUIVALENTS, pickCO2Equivalents,
   stateCellCounts, stateCellTotal, stateMatrixMaxTotal, stateBucketLabel,
-  setActivityChartEnabled,
+  syncActivityChartVisibility, leaveActivityChartIfSelected,
 } from './historyTab.js';

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from 'vitest'
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
 import { formatCO2, co2TierTitle } from './formatters.js'
 import {
   pendingWizardAgents,
@@ -42,7 +42,13 @@ import {
   stateCellTotal,
   stateMatrixMaxTotal,
   stateBucketLabel,
+  setActivityChartEnabled,
 } from './irrlicht.js'
+// The gate's reset path needs the module's private historyState to actually be
+// on chart=state, which only a real click can do — so this suite drives the
+// wired-up control rather than a state literal. Same module instance irrlicht.js
+// imported (ESM caches), so historyState is shared.
+import { initHistoryTab } from './historyTab.js'
 
 describe('resolvedTheme', () => {
   beforeEach(() => localStorage.clear())
@@ -884,6 +890,54 @@ describe('agents chart (#751 Phase 3)', () => {
     expect(histCount(2)).toBe('2')
     expect(histCount(2.6)).toBe('3')
     expect(histCount(undefined)).toBe('0')
+  })
+})
+
+describe('Activity chart beta gate (#1075)', () => {
+  const btn = (chart) => document.querySelector(`#history-chart-sel button[data-chart="${chart}"]`)
+  const isActive = (chart) => btn(chart).classList.contains('active')
+  let host
+
+  beforeEach(() => {
+    // The real chart selector, trimmed to the three buttons this suite drives.
+    // Activity ships hidden in index.html so a default-off gate never flashes it.
+    host = document.createElement('div')
+    host.innerHTML = `
+      <fieldset id="history-chart-sel">
+        <button data-chart="cost" class="active">Cost</button>
+        <button data-chart="agents">Agents</button>
+        <button data-chart="state" hidden>Activity</button>
+      </fieldset>`
+    document.body.append(host)
+    initHistoryTab() // wires the click handler onto this fresh fieldset
+  })
+  afterEach(() => host.remove())
+
+  test('the Activity button is hidden until the toggle turns it on', () => {
+    expect(btn('state').hidden).toBe(true)
+    setActivityChartEnabled(true)
+    expect(btn('state').hidden).toBe(false)
+    setActivityChartEnabled(false)
+    expect(btn('state').hidden).toBe(true)
+  })
+
+  test('turning the toggle off while Activity is the live chart falls back to Cost', () => {
+    setActivityChartEnabled(true)
+    btn('state').click()
+    expect(isActive('state')).toBe(true)
+
+    setActivityChartEnabled(false)
+    // Otherwise the view strands on a chart the setting says is off, with the
+    // range row hidden and the granularity row showing.
+    expect(isActive('state')).toBe(false)
+    expect(isActive('cost')).toBe(true)
+  })
+
+  test('turning the toggle off leaves a non-Activity chart selected', () => {
+    setActivityChartEnabled(true)
+    btn('agents').click()
+    setActivityChartEnabled(false)
+    expect(isActive('agents')).toBe(true)
   })
 })
 

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -1,4 +1,5 @@
-import { describe, test, expect, beforeEach, afterEach } from 'vitest'
+import { describe, test, expect, beforeEach, beforeAll, afterAll } from 'vitest'
+
 import { formatCO2, co2TierTitle } from './formatters.js'
 import {
   pendingWizardAgents,
@@ -42,7 +43,8 @@ import {
   stateCellTotal,
   stateMatrixMaxTotal,
   stateBucketLabel,
-  setActivityChartEnabled,
+  syncActivityChartVisibility,
+  leaveActivityChartIfSelected,
 } from './irrlicht.js'
 // The gate's reset path needs the module's private historyState to actually be
 // on chart=state, which only a real click can do — so this suite drives the
@@ -898,7 +900,9 @@ describe('Activity chart beta gate (#1075)', () => {
   const isActive = (chart) => btn(chart).classList.contains('active')
   let host
 
-  beforeEach(() => {
+  // Wired once, not per test: initHistoryTab also registers a window resize
+  // listener, and it has no teardown to pair with.
+  beforeAll(() => {
     // The real chart selector, trimmed to the three buttons this suite drives.
     // Activity ships hidden in index.html so a default-off gate never flashes it.
     host = document.createElement('div')
@@ -909,34 +913,33 @@ describe('Activity chart beta gate (#1075)', () => {
         <button data-chart="state" hidden>Activity</button>
       </fieldset>`
     document.body.append(host)
-    initHistoryTab() // wires the click handler onto this fresh fieldset
+    initHistoryTab()
   })
-  afterEach(() => host.remove())
+  afterAll(() => host.remove())
 
   test('the Activity button is hidden until the toggle turns it on', () => {
-    expect(btn('state').hidden).toBe(true)
-    setActivityChartEnabled(true)
+    expect(btn('state').hidden).toBe(true) // as it ships in index.html
+    syncActivityChartVisibility(true)
     expect(btn('state').hidden).toBe(false)
-    setActivityChartEnabled(false)
+    syncActivityChartVisibility(false)
     expect(btn('state').hidden).toBe(true)
   })
 
   test('turning the toggle off while Activity is the live chart falls back to Cost', () => {
-    setActivityChartEnabled(true)
+    syncActivityChartVisibility(true)
     btn('state').click()
     expect(isActive('state')).toBe(true)
 
-    setActivityChartEnabled(false)
-    // Otherwise the view strands on a chart the setting says is off, with the
-    // range row hidden and the granularity row showing.
+    leaveActivityChartIfSelected()
+    // Otherwise the view strands on a chart the setting says is off.
     expect(isActive('state')).toBe(false)
     expect(isActive('cost')).toBe(true)
   })
 
   test('turning the toggle off leaves a non-Activity chart selected', () => {
-    setActivityChartEnabled(true)
+    syncActivityChartVisibility(true)
     btn('agents').click()
-    setActivityChartEnabled(false)
+    leaveActivityChartIfSelected()
     expect(isActive('agents')).toBe(true)
   })
 })


### PR DESCRIPTION
Closes #1075.

The Activity matrix is reconstructed from opt-in recordings, and `historyTab.js` already concedes that a never-recorded bucket renders identically to an idle one. For anyone not recording, that's a grid of blanks reading as "idle". This makes it opt-in rather than default-visible.

## Shape

A plain local display preference, `enableActivityChart`, default **off**, on both frontends. Unlike the task-eta (#558) and backchannel (#724) activations it sits beside in Advanced Settings, nothing is installed — so there's no `ActivationClient`, no daemon reconcile, no `.onAppear` mirror. The daemon still serves `chart=state` unconditionally.

**Web** — `SETTINGS_DEFAULTS` + an Advanced Settings row with the existing `beta-badge`. Two halves, deliberately split: `syncActivityChartVisibility()` hides `button[data-chart=state]` and rides `applySettings()` alongside the other reflect-onto-DOM toggles; `leaveActivityChartIfSelected()` backs out of a live Activity chart and hangs off the per-key effect path next to `SOURCE_SETTING_KEYS` — the mechanism already there for "this key needs an effect beyond a class toggle". (First draft had both in `applySettings()`, which meant editing `relayUrl` fired a history fetch. Caught in review.) The button ships `hidden` in `index.html` so a default-off gate never flashes it.

**macOS** — `@AppStorage("enableActivityChart")` + `LeadingToggle(beta: true)`; `HistoryTab.visible(activityEnabled:)` filters the picker, mirroring the existing `visibleCharts` precedent.

## Notes for the reviewer

**One AC in the issue was vacuous, and I didn't build it.** I wrote "a deep link to `?chart=state` falls back to the default chart" when filing — but `historyTab.js` never reads `window.location`, and the chart isn't persisted either. It's always `cost` on load, so the button is the only entry point and there's no backdoor to close. No URL parser here.

**The real hazard was the opposite one.** Turning the gate off while Activity is live would strand the view, so both platforms reset the selection (web → `cost`, macOS → `.usage`). On macOS this is reachable in normal use since Settings is a separate window.

**CSS separator swap.** `.history-seg button` moves from `border-right`/`:last-child` to `border-left`/`:first-child`. Rendering is identical with all buttons shown (the separators land in the same gaps), but hiding the *last* button — Activity — can no longer strand a border against the fieldset's own right edge.

## Verification

Both frontends were driven directly, not inferred from adjacent tests.

- **web**, live in Chrome: default-off hides the button (0px, six buttons in the selector); toggling on then selecting Activity then toggling off restores the Range row, re-hides Granularity, and re-selects Cost.
- **macOS**, dev build in the real app: picker reads `Usage | Metrics | Quota` with the toggle off and `Usage | Activity | Metrics | Quota` with it on.
- `npm test` 169 pass (3 new); `swift test` 266 pass (3 new); `swift build` clean.

## Found along the way: #1079

Verifying the row resync turned up a **pre-existing** bug, filed separately as #1079 and deliberately **not** fixed here. `.history-ctl-row { display: flex }` overrides the UA `[hidden] { display: none }` rule, so `el.hidden = true` never actually hides these rows. `syncHistoryRangeRow`, `syncGranularityRow`, and `syncDoraProjectRow` are all silently inert on `main`, and `#history-chart` (the canvas) has the same problem — on Activity it still renders under the matrix. `#history-matrix-scroll` is the sole survivor because it already carries an explicit `[hidden]` escape hatch.

It's out of scope here and not a no-op fix — rows users currently see would start disappearing (correctly) — so it deserves its own review rather than riding along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
