### PR TITLE
refactor(adapters): extract the duplicated sessionsDir() env-override helper

### DIFF
--- a/core/adapters/inbound/agents/agentpaths/agentpaths.go
+++ b/core/adapters/inbound/agents/agentpaths/agentpaths.go
@@ -1,0 +1,40 @@
+// Package agentpaths resolves the transcript directory an inbound agent
+// adapter should watch, honoring the upstream agent's own env-var override
+// for its home or session root.
+//
+// Several upstream agents let the user relocate that root (CODEX_HOME,
+// CLAUDE_CONFIG_DIR, PI_CODING_AGENT_SESSION_DIR, KIRO_HOME, ...). The rule
+// for honoring one is identical in every case, so it lives here once instead
+// of being reimplemented per adapter — and forgotten by the next one.
+package agentpaths
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// FromEnv returns the directory the named adapter should watch.
+//
+// When envVar holds an absolute path, the result is that path joined with
+// subdir — pass no subdir when the env var names the watched directory
+// itself rather than a root above it. Otherwise defaultDir is returned as-is;
+// callers pass a $HOME-relative default, which fswatcher.New resolves against
+// the user's home directory.
+//
+// Non-absolute env values are rejected: nothing expands a shell metacharacter
+// here, so a value like "~/custom" is a misconfiguration rather than a path.
+// Rejections are logged under adapter's name so they surface instead of
+// silently watching the wrong place. adapter is the log prefix, which is not
+// necessarily the adapter's AdapterName constant (e.g. the claudecode package
+// logs "claudecode" while its AdapterName is "claude-code").
+func FromEnv(adapter, envVar, defaultDir string, subdir ...string) string {
+	if v := os.Getenv(envVar); v != "" {
+		cleaned := filepath.Clean(v)
+		if filepath.IsAbs(cleaned) {
+			return filepath.Join(append([]string{cleaned}, subdir...)...)
+		}
+		log.Printf("%s: ignoring %s=%q — must be an absolute path (no shell expansion)", adapter, envVar, v)
+	}
+	return defaultDir
+}

--- a/core/adapters/inbound/agents/agentpaths/agentpaths_test.go
+++ b/core/adapters/inbound/agents/agentpaths/agentpaths_test.go
@@ -1,0 +1,80 @@
+package agentpaths
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureLog redirects the standard logger into a buffer for the duration of
+// the test, restoring stderr and the default flags afterwards.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(log.LstdFlags)
+	})
+	return &buf
+}
+
+const testEnvVar = "IRRLICHT_AGENTPATHS_TEST_HOME"
+
+func TestFromEnv(t *testing.T) {
+	tests := []struct {
+		name   string
+		env    string
+		subdir []string
+		want   string
+	}{
+		{"empty falls back to default", "", []string{"sessions"}, "default/dir"},
+		{"absolute override joins subdir", "/tmp/home", []string{"sessions"}, "/tmp/home/sessions"},
+		{"absolute override with no subdir is used as-is", "/tmp/sessions", nil, "/tmp/sessions"},
+		{"absolute override joins nested subdirs", "/tmp/home", []string{"sessions", "cli"}, "/tmp/home/sessions/cli"},
+		{"trailing slash is cleaned", "/tmp/home/", []string{"sessions"}, "/tmp/home/sessions"},
+		{"trailing slash is cleaned with no subdir", "/tmp/sessions/", nil, "/tmp/sessions"},
+		{"relative override is rejected (falls back to default)", "relative/home", []string{"sessions"}, "default/dir"},
+		{"tilde-prefixed override is rejected (no shell expansion)", "~/custom", []string{"sessions"}, "default/dir"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(testEnvVar, tc.env)
+			if got := FromEnv("testagent", testEnvVar, "default/dir", tc.subdir...); got != tc.want {
+				t.Errorf("FromEnv() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFromEnvLogsRejectionUnderAdapterName pins the operator-visible log line:
+// a rejected override must name the adapter and the offending value, so the
+// misconfiguration is greppable rather than silent.
+func TestFromEnvLogsRejectionUnderAdapterName(t *testing.T) {
+	buf := captureLog(t)
+
+	t.Setenv(testEnvVar, "~/custom")
+	FromEnv("kirocli", testEnvVar, "default/dir", "sessions", "cli")
+
+	got := strings.TrimSpace(buf.String())
+	want := `kirocli: ignoring ` + testEnvVar + `="~/custom" — must be an absolute path (no shell expansion)`
+	if got != want {
+		t.Errorf("log line = %q, want %q", got, want)
+	}
+}
+
+// TestFromEnvDoesNotLogOnAcceptedOverride guards against noise: a valid
+// absolute override is the supported path, not something to warn about.
+func TestFromEnvDoesNotLogOnAcceptedOverride(t *testing.T) {
+	buf := captureLog(t)
+
+	t.Setenv(testEnvVar, "/tmp/home")
+	FromEnv("codex", testEnvVar, "default/dir", "sessions")
+
+	if buf.Len() != 0 {
+		t.Errorf("accepted override logged %q, want no output", buf.String())
+	}
+}

--- a/core/adapters/inbound/agents/claudecode/adapter.go
+++ b/core/adapters/inbound/agents/claudecode/adapter.go
@@ -2,11 +2,7 @@
 // transcript files under ~/.claude/projects/*/*.jsonl.
 package claudecode
 
-import (
-	"log"
-	"os"
-	"path/filepath"
-)
+import "irrlicht/core/adapters/inbound/agents/agentpaths"
 
 // AdapterName identifies sessions originating from Claude Code.
 const AdapterName = "claude-code"
@@ -31,12 +27,5 @@ const configDirEnvVar = "CLAUDE_CONFIG_DIR"
 // Non-absolute env values are rejected so a misconfigured path surfaces in
 // logs instead of silently watching the wrong place.
 func transcriptsDir() string {
-	if v := os.Getenv(configDirEnvVar); v != "" {
-		cleaned := filepath.Clean(v)
-		if filepath.IsAbs(cleaned) {
-			return filepath.Join(cleaned, "projects")
-		}
-		log.Printf("claudecode: ignoring %s=%q — must be an absolute path (no shell expansion)", configDirEnvVar, v)
-	}
-	return defaultProjectsDir
+	return agentpaths.FromEnv("claudecode", configDirEnvVar, defaultProjectsDir, "projects")
 }

--- a/core/adapters/inbound/agents/claudecode/adapter.go
+++ b/core/adapters/inbound/agents/claudecode/adapter.go
@@ -23,9 +23,9 @@ const defaultProjectsDir = ".claude/projects"
 // is unverified, so pid.go intentionally keeps the hardcoded path.
 const configDirEnvVar = "CLAUDE_CONFIG_DIR"
 
-// transcriptsDir returns the directory the Claude Code adapter should watch.
-// Non-absolute env values are rejected so a misconfigured path surfaces in
-// logs instead of silently watching the wrong place.
+// transcriptsDir returns the directory the Claude Code adapter should watch —
+// $CLAUDE_CONFIG_DIR/projects when that override is set, else
+// defaultProjectsDir.
 func transcriptsDir() string {
 	return agentpaths.FromEnv("claudecode", configDirEnvVar, defaultProjectsDir, "projects")
 }

--- a/core/adapters/inbound/agents/codex/adapter.go
+++ b/core/adapters/inbound/agents/codex/adapter.go
@@ -2,11 +2,7 @@
 // transcript files under ~/.codex/*/*.jsonl.
 package codex
 
-import (
-	"log"
-	"os"
-	"path/filepath"
-)
+import "irrlicht/core/adapters/inbound/agents/agentpaths"
 
 // AdapterName identifies sessions originating from OpenAI Codex.
 const AdapterName = "codex"
@@ -29,12 +25,5 @@ const codexHomeEnvVar = "CODEX_HOME"
 // absolute env values are rejected so a misconfigured path surfaces in
 // logs instead of silently watching the wrong place.
 func sessionsDir() string {
-	if v := os.Getenv(codexHomeEnvVar); v != "" {
-		cleaned := filepath.Clean(v)
-		if filepath.IsAbs(cleaned) {
-			return filepath.Join(cleaned, "sessions")
-		}
-		log.Printf("codex: ignoring %s=%q — must be an absolute path (no shell expansion)", codexHomeEnvVar, v)
-	}
-	return defaultRootDir
+	return agentpaths.FromEnv("codex", codexHomeEnvVar, defaultRootDir, "sessions")
 }

--- a/core/adapters/inbound/agents/codex/adapter.go
+++ b/core/adapters/inbound/agents/codex/adapter.go
@@ -21,9 +21,8 @@ const defaultRootDir = ".codex/sessions"
 // $CODEX_HOME/sessions.
 const codexHomeEnvVar = "CODEX_HOME"
 
-// sessionsDir returns the directory the Codex adapter should watch. Non-
-// absolute env values are rejected so a misconfigured path surfaces in
-// logs instead of silently watching the wrong place.
+// sessionsDir returns the directory the Codex adapter should watch —
+// $CODEX_HOME/sessions when that override is set, else defaultRootDir.
 func sessionsDir() string {
 	return agentpaths.FromEnv("codex", codexHomeEnvVar, defaultRootDir, "sessions")
 }

--- a/core/adapters/inbound/agents/kirocli/adapter.go
+++ b/core/adapters/inbound/agents/kirocli/adapter.go
@@ -28,9 +28,8 @@ const defaultRootDir = ".kiro/sessions/cli"
 // move to $KIRO_HOME/sessions/cli.
 const kiroHomeEnvVar = "KIRO_HOME"
 
-// sessionsDir returns the directory the Kiro CLI adapter should watch. Non-
-// absolute env values are rejected so a misconfigured path surfaces in logs
-// instead of silently watching the wrong place.
+// sessionsDir returns the directory the Kiro CLI adapter should watch —
+// $KIRO_HOME/sessions/cli when that override is set, else defaultRootDir.
 func sessionsDir() string {
 	return agentpaths.FromEnv("kirocli", kiroHomeEnvVar, defaultRootDir, "sessions", "cli")
 }

--- a/core/adapters/inbound/agents/kirocli/adapter.go
+++ b/core/adapters/inbound/agents/kirocli/adapter.go
@@ -2,11 +2,7 @@
 // transcript files under ~/.kiro/sessions/cli/<uuid>.jsonl.
 package kirocli
 
-import (
-	"log"
-	"os"
-	"path/filepath"
-)
+import "irrlicht/core/adapters/inbound/agents/agentpaths"
 
 // AdapterName identifies sessions originating from Kiro CLI.
 const AdapterName = "kiro-cli"
@@ -36,12 +32,5 @@ const kiroHomeEnvVar = "KIRO_HOME"
 // absolute env values are rejected so a misconfigured path surfaces in logs
 // instead of silently watching the wrong place.
 func sessionsDir() string {
-	if v := os.Getenv(kiroHomeEnvVar); v != "" {
-		cleaned := filepath.Clean(v)
-		if filepath.IsAbs(cleaned) {
-			return filepath.Join(cleaned, "sessions", "cli")
-		}
-		log.Printf("kirocli: ignoring %s=%q — must be an absolute path (no shell expansion)", kiroHomeEnvVar, v)
-	}
-	return defaultRootDir
+	return agentpaths.FromEnv("kirocli", kiroHomeEnvVar, defaultRootDir, "sessions", "cli")
 }

--- a/core/adapters/inbound/agents/pi/adapter.go
+++ b/core/adapters/inbound/agents/pi/adapter.go
@@ -21,9 +21,9 @@ const defaultRootDir = ".pi/agent/sessions"
 // directory itself (not a parent).
 const sessionDirEnvVar = "PI_CODING_AGENT_SESSION_DIR"
 
-// sessionsDir returns the directory the Pi adapter should watch. Non-
-// absolute env values are rejected so a misconfigured path surfaces in
-// logs instead of silently watching the wrong place.
+// sessionsDir returns the directory the Pi adapter should watch —
+// $PI_CODING_AGENT_SESSION_DIR itself when that override is set (it names the
+// session directory, not a root above it), else defaultRootDir.
 func sessionsDir() string {
 	return agentpaths.FromEnv("pi", sessionDirEnvVar, defaultRootDir)
 }

--- a/core/adapters/inbound/agents/pi/adapter.go
+++ b/core/adapters/inbound/agents/pi/adapter.go
@@ -2,11 +2,7 @@
 // transcript files under ~/.pi/agent/sessions/--<cwd>--/*.jsonl.
 package pi
 
-import (
-	"log"
-	"os"
-	"path/filepath"
-)
+import "irrlicht/core/adapters/inbound/agents/agentpaths"
 
 // AdapterName identifies sessions originating from Pi coding agent.
 const AdapterName = "pi"
@@ -29,12 +25,5 @@ const sessionDirEnvVar = "PI_CODING_AGENT_SESSION_DIR"
 // absolute env values are rejected so a misconfigured path surfaces in
 // logs instead of silently watching the wrong place.
 func sessionsDir() string {
-	if v := os.Getenv(sessionDirEnvVar); v != "" {
-		cleaned := filepath.Clean(v)
-		if filepath.IsAbs(cleaned) {
-			return cleaned
-		}
-		log.Printf("pi: ignoring %s=%q — must be an absolute path (no shell expansion)", sessionDirEnvVar, v)
-	}
-	return defaultRootDir
+	return agentpaths.FromEnv("pi", sessionDirEnvVar, defaultRootDir)
 }


### PR DESCRIPTION
Closes #1085

Four adapters carried a byte-identical env-override body, differing only in env var, appended subdir, and log prefix. SonarCloud flagged the aggregate on #1074 (`new_duplicated_lines_density` 7.5% > 3%). Pure duplication cleanup — no behavior change.

## What changed

New peer package `core/adapters/inbound/agents/agentpaths`:

```go
func FromEnv(adapter, envVar, defaultDir string, subdir ...string) string
```

Each adapter keeps its `sessionsDir()` / `transcriptsDir()` as a one-line delegation:

| adapter | call |
|---|---|
| `codex` | `agentpaths.FromEnv("codex", codexHomeEnvVar, defaultRootDir, "sessions")` |
| `claudecode` | `agentpaths.FromEnv("claudecode", configDirEnvVar, defaultProjectsDir, "projects")` |
| `pi` | `agentpaths.FromEnv("pi", sessionDirEnvVar, defaultRootDir)` |
| `kirocli` | `agentpaths.FromEnv("kirocli", kiroHomeEnvVar, defaultRootDir, "sessions", "cli")` |

## Three decisions worth reviewing

**Placement.** `agentpaths` sits alongside `fswatcher` and `processlifecycle` under `agents/`. `processlifecycle` is already imported by nine adapters, so adapter→sibling-adapter is the established shape. `core/architecture_test.go` only constrains `domain/`, `ports/`, and `application/services/` as import *sources* — nothing inward-facing reaches outward for this, and the test passes.

**Variadic `subdir`, not the issue's suggested `subdir string`.** kirocli joins two components (`"sessions", "cli"`); variadic preserves that exactly without introducing a `"sessions/cli"` slash-literal. pi's "the var IS the sessions dir" case then falls out with zero args rather than an `""` sentinel.

**The log prefix is a literal, not `AdapterName`.** `claudecode` logs `"claudecode"` while its `AdapterName` is `"claude-code"` (likewise `kirocli` vs `"kiro-cli"`). Threading the constant would have silently changed operator-visible log text, so the caller passes the package-name literal and every message stays byte-identical.

## Verification

The four existing `adapter_test.go` table tests are **unchanged** (`git diff origin/main -- '*adapter_test.go'` is empty) and pass — that's the safety net for this refactor. `agentpaths` also gets its own table test covering the no-subdir / single-subdir / nested-subdir cases, plus two tests pinning the log line: the rejection message text, and that an accepted override logs nothing.

- `go test ./core/... -race -count=1` — exit 0, 46 packages ok, `irrlicht/core` (architecture test) ok
- `tools/preflight.sh` — all 10 gates PASS, including the ARS architecture gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)