### PR TITLE
fix(claudecode): let the pendingBackgroundAgentCount guard actually release (#1076)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -230,6 +230,23 @@ func handleSystemEvent(raw map[string]interface{}, ev *tailer.ParsedEvent) {
 		if v, ok := raw["pendingBackgroundAgentCount"].(float64); ok {
 			n := int(v)
 			ev.PendingBackgroundAgentCount = &n
+		} else if subtype == "turn_duration" {
+			// Claude Code serializes the count with omitempty: zero is
+			// written as absence, never as an explicit 0 (verified across
+			// 1,698 turn_duration lines — the value 0 never appears, and the
+			// same CC version emits the field only when it is > 0). A
+			// turn_duration is an authoritative end-of-turn snapshot, so
+			// absence here means "none pending" — normalize it so the
+			// tailer's sticky counter can actually fall back to 0 and the
+			// #1037 hold can release. See issue #1076.
+			//
+			// Deliberately NOT applied to stop_hook_summary, which shares
+			// this branch but never carries the field (0 of 88 observed
+			// lines): absence there is "no information", not zero, and
+			// normalizing it would clobber a live count on every stop-hook
+			// event and re-open #1036.
+			n := 0
+			ev.PendingBackgroundAgentCount = &n
 		}
 		return
 	}

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -227,27 +227,7 @@ func handleSystemEvent(raw map[string]interface{}, ev *tailer.ParsedEvent) {
 	subtype, _ := raw["subtype"].(string)
 	if subtype == "turn_duration" || subtype == "stop_hook_summary" {
 		ev.EventType = "turn_done"
-		if v, ok := raw["pendingBackgroundAgentCount"].(float64); ok {
-			n := int(v)
-			ev.PendingBackgroundAgentCount = &n
-		} else if subtype == "turn_duration" {
-			// Claude Code serializes the count with omitempty: zero is
-			// written as absence, never as an explicit 0 (verified across
-			// 1,698 turn_duration lines — the value 0 never appears, and the
-			// same CC version emits the field only when it is > 0). A
-			// turn_duration is an authoritative end-of-turn snapshot, so
-			// absence here means "none pending" — normalize it so the
-			// tailer's sticky counter can actually fall back to 0 and the
-			// #1037 hold can release. See issue #1076.
-			//
-			// Deliberately NOT applied to stop_hook_summary, which shares
-			// this branch but never carries the field (0 of 88 observed
-			// lines): absence there is "no information", not zero, and
-			// normalizing it would clobber a live count on every stop-hook
-			// event and re-open #1036.
-			n := 0
-			ev.PendingBackgroundAgentCount = &n
-		}
+		applyPendingBackgroundAgentCount(raw, ev, subtype)
 		return
 	}
 	if subtype == "compact_boundary" {
@@ -267,6 +247,36 @@ func handleSystemEvent(raw map[string]interface{}, ev *tailer.ParsedEvent) {
 		}
 	}
 	ev.Skip = true
+}
+
+// applyPendingBackgroundAgentCount reads Claude Code's background-agent count
+// off a turn-boundary event onto ev, resolving what an *absent* field means —
+// which differs by subtype, and is the whole point of this function.
+//
+// On turn_duration, absence means zero. Claude Code serializes the count with
+// omitempty: zero is written as absence, never as an explicit 0 (verified
+// across 1,698 turn_duration lines — the value 0 never appears, and the same
+// CC version emits the field only when it is > 0). A turn_duration is an
+// authoritative end-of-turn snapshot, so absence is a real "none pending"
+// verdict and is normalized to an explicit 0 — otherwise the tailer's sticky
+// counter can never fall back to 0 and the #1037 hold never releases.
+//
+// On stop_hook_summary, absence means nothing at all: it shares the turn_done
+// branch but never carries the field (0 of 88 observed lines). Leaving the
+// pointer nil keeps the tailer's last known count intact; normalizing it to 0
+// here would clobber a live count on every stop-hook event and re-open #1036.
+//
+// See issue #1076.
+func applyPendingBackgroundAgentCount(raw map[string]interface{}, ev *tailer.ParsedEvent, subtype string) {
+	if v, ok := raw["pendingBackgroundAgentCount"].(float64); ok {
+		n := int(v)
+		ev.PendingBackgroundAgentCount = &n
+		return
+	}
+	if subtype == "turn_duration" {
+		n := 0
+		ev.PendingBackgroundAgentCount = &n
+	}
 }
 
 // handleUserEvent handles the user event variants that should short-circuit

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -266,10 +266,14 @@ func TestParser_SystemEvent_TurnDone_PendingBackgroundAgentCount(t *testing.T) {
 	}
 }
 
-func TestParser_SystemEvent_TurnDone_PendingBackgroundAgentCountAbsent(t *testing.T) {
-	// Older Claude Code versions write turn_duration with no
-	// pendingBackgroundAgentCount field at all — absence must not be read
-	// as an explicit zero. See issue #1036.
+// TestParser_SystemEvent_TurnDone_PendingBackgroundAgentCountAbsentMeansZero
+// replaces the former …CountAbsent test, which asserted absence stays nil on
+// the premise that only "older Claude Code versions" omit the field. Not so:
+// the same version emits turn_duration with the field when the count is > 0
+// and without it when the count is 0 (omitempty), so absence on an
+// authoritative end-of-turn snapshot means "none pending". Without this, the
+// #1037 guard's release condition is unreachable. See issue #1076.
+func TestParser_SystemEvent_TurnDone_PendingBackgroundAgentCountAbsentMeansZero(t *testing.T) {
 	p := &Parser{}
 	ev := p.ParseLine(map[string]interface{}{
 		"type":      "system",
@@ -279,8 +283,32 @@ func TestParser_SystemEvent_TurnDone_PendingBackgroundAgentCountAbsent(t *testin
 	if ev == nil {
 		t.Fatal("expected non-nil event")
 	}
+	if ev.PendingBackgroundAgentCount == nil {
+		t.Fatal("expected an explicit 0 — a fieldless turn_duration is the drain-to-zero signal")
+	}
+	if *ev.PendingBackgroundAgentCount != 0 {
+		t.Errorf("PendingBackgroundAgentCount = %d, want 0", *ev.PendingBackgroundAgentCount)
+	}
+}
+
+// stop_hook_summary shares handleSystemEvent's turn_done branch but never
+// carries the count (0 of 88 observed lines). Absence there is "no
+// information", not zero — normalizing it would clobber a live count and
+// re-open #1036. This test is what stops the turn_duration absent→0 rule from
+// being widened to the whole branch. See issue #1076.
+func TestParser_SystemEvent_StopHookSummary_PendingCountAbsentStaysNil(t *testing.T) {
+	p := &Parser{}
+	ev := p.ParseLine(map[string]interface{}{
+		"type":      "system",
+		"subtype":   "stop_hook_summary",
+		"timestamp": "2026-04-05T22:00:00Z",
+	})
+	if ev == nil {
+		t.Fatal("expected non-nil event")
+	}
 	if ev.PendingBackgroundAgentCount != nil {
-		t.Errorf("PendingBackgroundAgentCount = %v, want nil when the field is absent", *ev.PendingBackgroundAgentCount)
+		t.Errorf("PendingBackgroundAgentCount = %d, want nil on a fieldless stop_hook_summary",
+			*ev.PendingBackgroundAgentCount)
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/pending_background_agent_test.go
+++ b/core/adapters/inbound/agents/claudecode/pending_background_agent_test.go
@@ -1,0 +1,104 @@
+package claudecode
+
+import (
+	"testing"
+)
+
+// The #1037 guard holds a parent `working` while Claude Code reports
+// background agents still pending. These tests drive the real parser through
+// the real tailer, because the defect they lock is the seam between the two:
+// the parser decides what an omitted pendingBackgroundAgentCount means, and
+// the tailer's sticky counter can only fall to 0 if the parser ever hands it
+// an explicit 0. A stub parser would prove nothing here. See issue #1076.
+
+// TestTailer_PendingBackgroundAgentCount_DrainsToZeroOnFieldlessTurnDone
+// replays the drain observed live in session b52ce0f9 (CC 2.1.210),
+// compressed: the count ticks down while agents finish, and when the last one
+// is done Claude Code omits the field rather than writing 0. Before #1076 the
+// counter stuck at the last non-zero value forever, so the parent could never
+// be released back to `ready`.
+func TestTailer_PendingBackgroundAgentCount_DrainsToZeroOnFieldlessTurnDone(t *testing.T) {
+	path := writeTranscript(t, []map[string]interface{}{
+		{"type": "assistant", "timestamp": ts(0)},
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(1), "pendingBackgroundAgentCount": float64(2)},
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(2), "pendingBackgroundAgentCount": float64(1)},
+		// Last agent finished: Claude Code omits the field rather than writing 0.
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(3)},
+	})
+
+	m, err := newCCTailer(path).TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.PendingBackgroundAgentCount != 0 {
+		t.Errorf("PendingBackgroundAgentCount = %d, want 0 — the counter must be able to reach zero, or the #1037 hold never releases",
+			m.PendingBackgroundAgentCount)
+	}
+}
+
+// TestTailer_PendingBackgroundAgentCount_UnchangedByFieldlessStopHookSummary
+// is the scoping lock's tailer-level counterpart to
+// TestParser_SystemEvent_StopHookSummary_PendingCountAbsentStaysNil: a
+// stop_hook_summary carries no count, so it must leave a live one alone.
+// Zeroing it here would silently release the hold while agents are still
+// running — #1036 verbatim.
+func TestTailer_PendingBackgroundAgentCount_UnchangedByFieldlessStopHookSummary(t *testing.T) {
+	path := writeTranscript(t, []map[string]interface{}{
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(0), "pendingBackgroundAgentCount": float64(2)},
+		{"type": "system", "subtype": "stop_hook_summary", "timestamp": ts(1)},
+	})
+
+	m, err := newCCTailer(path).TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.PendingBackgroundAgentCount != 2 {
+		t.Errorf("PendingBackgroundAgentCount = %d, want 2 — stop_hook_summary carries no count and must not zero it",
+			m.PendingBackgroundAgentCount)
+	}
+}
+
+// TestLedger_PersistsPendingBackgroundAgentCount is the Hole 2 regression
+// (issue #1076), mirroring TestLedger_PersistsLastEventType (#649): a daemon
+// restart rehydrates the tailer at LastOffset, so the next pass processes zero
+// lines and can only report what the ledger carried. Without the count in
+// LedgerState the guard goes inert on every restart and the parent is free to
+// flip `ready` mid-run.
+//
+// It lives in the claudecode package rather than next to its tailer-package
+// sibling because seeding a non-zero count end-to-end needs the real parser —
+// the tailer package's stub parser does not read the field.
+func TestLedger_PersistsPendingBackgroundAgentCount(t *testing.T) {
+	path := writeTranscript(t, []map[string]interface{}{
+		{"type": "assistant", "timestamp": ts(0)},
+		{"type": "system", "subtype": "turn_duration", "timestamp": ts(1), "pendingBackgroundAgentCount": float64(3)},
+	})
+
+	tl1 := newCCTailer(path)
+	m, err := tl1.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.PendingBackgroundAgentCount != 3 {
+		t.Fatalf("pre-restart PendingBackgroundAgentCount = %d, want 3", m.PendingBackgroundAgentCount)
+	}
+
+	ledger := tl1.GetLedgerState()
+	if ledger.PendingBackgroundAgentCount != 3 {
+		t.Fatalf("ledger PendingBackgroundAgentCount = %d, want 3", ledger.PendingBackgroundAgentCount)
+	}
+
+	// Restart: a fresh tailer rehydrated from the ledger resumes at EOF —
+	// zero lines processed — and must still report three agents pending, or
+	// the parent flips ready mid-run (#1036).
+	tl2 := newCCTailer(path)
+	tl2.SetLedgerState(ledger)
+	m, err = tl2.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.PendingBackgroundAgentCount != 3 {
+		t.Errorf("post-restart PendingBackgroundAgentCount = %d, want 3 (resume-at-EOF must not forget the hold)",
+			m.PendingBackgroundAgentCount)
+	}
+}

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -591,6 +591,17 @@ type LedgerState struct {
 	// (turn ended on a question) loses the question text on restart and the seed
 	// re-classification demotes it to `ready`. See issue #705.
 	LastAssistantText string `json:"last_assistant_text,omitempty"`
+	// PendingBackgroundAgentCount persists Claude Code's last-reported
+	// background-agent count so a daemon restart that resumes at LastOffset
+	// (zero new lines) keeps holding the parent `working` while agents are
+	// still running. Without it the #1037 guard goes inert on every restart
+	// and the parent is free to flip `ready` mid-run. See issue #1076.
+	//
+	// omitempty is safe here: the value it drops is 0, which is also the zero
+	// value the field rehydrates to — so a ledger written before this field
+	// existed restores exactly the (inert-guard) behaviour it had when it was
+	// written, and no schema bump is needed to read it.
+	PendingBackgroundAgentCount int `json:"pending_background_agent_count,omitempty"`
 }
 
 // --- Shared helpers used by multiple parsers ---

--- a/core/pkg/tailer/tailer_ledger.go
+++ b/core/pkg/tailer/tailer_ledger.go
@@ -6,13 +6,14 @@ import "maps"
 // can be persisted to disk and rehydrated after a daemon restart.
 func (t *TranscriptTailer) GetLedgerState() LedgerState {
 	s := LedgerState{
-		SchemaVersion:      LedgerSchemaVersion,
-		LastOffset:         t.lastOffset,
-		CumProviderCostUSD: t.cumProviderCostUSD,
-		ModelName:          t.metrics.ModelName,
-		AgentVersion:       t.metrics.AgentVersion,
-		LastEventType:      t.metrics.LastEventType,
-		LastAssistantText:  t.lastAssistantText,
+		SchemaVersion:               LedgerSchemaVersion,
+		LastOffset:                  t.lastOffset,
+		CumProviderCostUSD:          t.cumProviderCostUSD,
+		ModelName:                   t.metrics.ModelName,
+		AgentVersion:                t.metrics.AgentVersion,
+		LastEventType:               t.metrics.LastEventType,
+		LastAssistantText:           t.lastAssistantText,
+		PendingBackgroundAgentCount: t.lastPendingBackgroundAgentCount,
 	}
 	if len(t.cumByModel) > 0 {
 		// Direct assignment is safe: the caller JSON-marshals immediately
@@ -87,6 +88,14 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 		t.lastAssistantText = s.LastAssistantText
 		t.metrics.LastAssistantText = s.LastAssistantText
 	}
+	// Restore the background-agent hold: a resume-at-EOF pass reads no
+	// turn_duration, so without this the #1037 guard goes inert on every
+	// restart and the parent flips `ready` while agents are still running
+	// (issue #1076). Only the private field needs setting — unlike
+	// LastAssistantText above, surfaceSporadicMetrics copies it onto
+	// t.metrics on every pass, above computeMetrics' empty-MessageHistory
+	// early return.
+	t.lastPendingBackgroundAgentCount = s.PendingBackgroundAgentCount
 	t.restoreParserState(s.ParserState)
 	if len(s.Tasks) > 0 {
 		t.tasks = append([]Task(nil), s.Tasks...)


### PR DESCRIPTION
Closes #1076

## The problem

The `pendingBackgroundAgentCount` guard added in #1037 (v0.5.8) **can never release**. Its release condition — observing `pendingBackgroundAgentCount: 0` — never occurs, because Claude Code serializes the count with `omitempty`: zero is written as *absence*, never as an explicit `0`.

The evidence in the issue is unambiguous — across 1,698 `turn_duration` lines the value `0` appears **zero** times, while `1`–`13` appear 176 times and the field is omitted 1,522 times. It's value-driven, not version-driven: the same CC version emits the field only when the count is > 0.

Net effect: #1037 traded a false-`ready` for a permanent false-`working`. Once a session spawned a single background subagent, its parent could never reach `ready` again for the life of that tailer.

A second, independent hole: the count wasn't persisted in the ledger, so a daemon restart mid-run silently zeroed it and re-opened #1036.

## The fix

**Part 1 — normalize absent → `0`, on `turn_duration` only** (`claudecode/parser.go`). A `turn_duration` is an authoritative end-of-turn snapshot, so absence there means "none pending".

The scoping is load-bearing and deliberate: `stop_hook_summary` shares the same `turn_done` branch but **never** carries the field (0 of 88 observed lines). Absence on `turn_duration` means "zero"; absence on `stop_hook_summary` means "no information". Conflating them would clobber a live non-zero count on every stop-hook event and re-open #1036. Two tests (AC2/AC4) exist purely to lock that scoping.

**Part 2 — persist the count in `LedgerState`** (`tailer/parser.go`, `tailer/tailer_ledger.go`), alongside the existing restart-survival fields (`BackgroundProcs` #445, `LastEventType` #649). A restart resumes at `LastOffset` and processes zero lines, so without this the guard went inert on every restart.

### No schema bump

`LedgerSchemaVersion` stays at 5. Bumps 4 and 5 were justified because the forced re-scan *healed* stranded sessions; there's nothing analogous to heal here. A ledger written before this field existed lacks the key and rehydrates to `0` — which is exactly the (inert-guard) behaviour it had when it was written, so it's strictly no worse than today.

## Verification

| AC | What | Failed on main first? |
|---|---|---|
| AC1 | fieldless `turn_duration` → explicit `0` | **yes** — "expected an explicit 0" |
| AC2 | fieldless `stop_hook_summary` stays `nil` | no — scoping lock (passes on main by construction) |
| AC3 | sticky counter drains to `0` | **yes** — `count = 1, want 0` (Hole 1 reproduced) |
| AC4 | `stop_hook_summary` doesn't zero a live count | no — scoping lock |
| AC5 | count survives a restart | **yes** — `ledger = 0, want 3` (Hole 2 reproduced) |
| AC6 | #1037's hold still works | stays green |
| AC7 | full suite + replay | green |

Each of the three ACs that map to a real production defect was confirmed red on `main` before the fix.

**Test placement note.** AC3–AC5 live in the `claudecode` package (via the existing `newCCTailer`/`writeTranscript` helpers — real parser + real tailer) rather than in `core/pkg/tailer` as the issue sketched. The tailer package's `testParser` stub does not read `pendingBackgroundAgentCount` at all, so the issue's literal AC3 would have passed trivially on `main` and proved nothing. The defect lives in the seam between parser and tailer, so the test has to drive both.

**Replay fixtures.** `tools/replay-fixtures.sh` exits 0 with no golden churn. Checked the two fixtures the issue flagged: `3-2_background-subagent`'s transcript has exactly one `turn_duration` and it carries `pending=3` (field *present*, so the new branch never fires); `3-1_foreground-subagent` carries the field nowhere, so its count is `0` either way. No recording change is in play — no goldens regenerated.

### Commands run

- `go test ./core/... -race -count=1` → exit 0, zero FAIL lines
- `tools/replay-fixtures.sh` → exit 0, git clean
- `tools/preflight.sh` → exit 0, all 10 gates PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)