### PR TITLE
fix(web): let [hidden] actually hide History control rows (#1079)

### DIFF
--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1326,10 +1326,8 @@
 
     .history-controls { display: flex; flex-direction: column; gap: 8px; margin-bottom: 14px; }
     .history-ctl-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-    /* Author display: flex above outranks the UA [hidden] { display: none }
-       rule, so the per-chart row toggles in historyTab.js (syncHistoryRangeRow,
-       syncGranularityRow, syncDoraProjectRow) need this hatch to take effect
-       (#1079). Same pattern as .history-matrix-scroll[hidden] below. */
+    /* The author display above outranks the UA [hidden] rule, so historyTab.js's
+       per-chart row toggles are inert without this hatch (#1079). */
     .history-ctl-row[hidden] { display: none; }
     .history-ctl-label {
       font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em;
@@ -1427,10 +1425,9 @@
       border-radius: 8px; padding: 10px;
     }
     #history-chart { width: 100%; height: 100%; display: block; }
-    /* Needs the id to outrank #history-chart's author display: block above —
-       a bare [hidden] or class hatch would lose the cascade. Without it
-       syncHistoryMatrixVisibility's canvas.hidden is inert and the stale
-       chart bleeds through behind the (background-less) activity matrix. */
+    /* Same as .history-ctl-row[hidden] (#1079), but must repeat the id to
+       outrank the display above — a bare [hidden] hatch would lose. Otherwise
+       the stale chart stays painted behind the activity matrix. */
     #history-chart[hidden] { display: none; }
     .history-chart-empty {
       position: absolute; inset: 0; display: none; align-items: center; justify-content: center;

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1326,6 +1326,11 @@
 
     .history-controls { display: flex; flex-direction: column; gap: 8px; margin-bottom: 14px; }
     .history-ctl-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+    /* Author display: flex above outranks the UA [hidden] { display: none }
+       rule, so the per-chart row toggles in historyTab.js (syncHistoryRangeRow,
+       syncGranularityRow, syncDoraProjectRow) need this hatch to take effect
+       (#1079). Same pattern as .history-matrix-scroll[hidden] below. */
+    .history-ctl-row[hidden] { display: none; }
     .history-ctl-label {
       font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em;
       text-transform: uppercase; color: var(--muted); width: 52px; flex-shrink: 0;
@@ -1422,6 +1427,11 @@
       border-radius: 8px; padding: 10px;
     }
     #history-chart { width: 100%; height: 100%; display: block; }
+    /* Needs the id to outrank #history-chart's author display: block above —
+       a bare [hidden] or class hatch would lose the cascade. Without it
+       syncHistoryMatrixVisibility's canvas.hidden is inert and the stale
+       chart bleeds through behind the (background-less) activity matrix. */
+    #history-chart[hidden] { display: none; }
     .history-chart-empty {
       position: absolute; inset: 0; display: none; align-items: center; justify-content: center;
       font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.1em;

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -961,7 +961,7 @@ describe('[hidden] survives the author display cascade (#1079)', () => {
     style.textContent = readCss()
     document.head.append(style)
   })
-  afterAll(() => style.remove())
+  afterAll(() => style?.remove())
 
   const displayOf = (markup) => {
     const host = document.createElement('div')

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, beforeAll, afterAll } from 'vitest'
 
 import { formatCO2, co2TierTitle } from './formatters.js'
+import { readCss } from './snapshots/serialize.js'
 import {
   pendingWizardAgents,
   stillPendingForAgents,
@@ -941,6 +942,56 @@ describe('Activity chart beta gate (#1075)', () => {
     btn('agents').click()
     leaveActivityChartIfSelected()
     expect(isActive('agents')).toBe(true)
+  })
+})
+
+// The three per-chart row toggles in historyTab.js set el.hidden, which only
+// hides anything if the cascade lets the UA's [hidden] { display: none } rule
+// win. .history-ctl-row and #history-chart both set an author display, which
+// outranks it — so every toggle was silently inert (#1079). Asserting
+// el.hidden here would prove nothing (the property always flipped correctly);
+// the regression only shows up in the computed style, so this suite injects
+// the real stylesheet and reads getComputedStyle. Verified falsifiable: against
+// pristine origin/main CSS these resolve to flex/block rather than none.
+describe('[hidden] survives the author display cascade (#1079)', () => {
+  let style
+
+  beforeAll(() => {
+    style = document.createElement('style')
+    style.textContent = readCss()
+    document.head.append(style)
+  })
+  afterAll(() => style.remove())
+
+  const displayOf = (markup) => {
+    const host = document.createElement('div')
+    host.innerHTML = markup
+    document.body.append(host)
+    const display = getComputedStyle(host.firstElementChild).display
+    host.remove()
+    return display
+  }
+
+  test('a hidden control row computes to display:none', () => {
+    // As they ship in index.html: #history-dora-row and #history-granularity-row
+    // carry the attribute in the markup, so this is the default-load state too.
+    expect(displayOf('<div class="history-ctl-row" id="history-dora-row" hidden></div>')).toBe('none')
+    expect(displayOf('<div class="history-ctl-row" id="history-granularity-row" hidden></div>')).toBe('none')
+    expect(displayOf('<div class="history-ctl-row" id="history-range-row" hidden></div>')).toBe('none')
+  })
+
+  test('a visible control row still lays out as flex', () => {
+    // Guards against a fix that over-reaches and hides the rows unconditionally.
+    expect(displayOf('<div class="history-ctl-row" id="history-range-row"></div>')).toBe('flex')
+  })
+
+  test('the hidden chart canvas computes to display:none', () => {
+    // Needs an id-level hatch to outrank #history-chart's author display:block.
+    expect(displayOf('<canvas id="history-chart" hidden></canvas>')).toBe('none')
+  })
+
+  test('the visible chart canvas still lays out as block', () => {
+    expect(displayOf('<canvas id="history-chart"></canvas>')).toBe('block')
   })
 })
 


### PR DESCRIPTION
Closes #1079

## Problem

`.history-ctl-row` sets an author `display: flex`, which outranks the user-agent `[hidden] { display: none }` rule. So every `el.hidden = true` on a History control row flipped the property but left the row on screen — all three per-chart toggles in `historyTab.js` (`syncHistoryRangeRow`, `syncGranularityRow`, `syncDoraProjectRow`) were silently inert.

This isn't only a stuck-after-toggle bug: `#history-dora-row` and `#history-granularity-row` ship the `hidden` attribute *in `index.html`*, so the **default page load** mis-rendered too.

`#history-chart` has the same shape with an author `display: block`, so `syncHistoryMatrixVisibility`'s `canvas.hidden` never took effect either.

## Fix

Two scoped hatches, mirroring the existing `.history-matrix-scroll[hidden]` precedent — the one element that already worked, because someone hit this exact bug there and patched it locally while the siblings were missed:

```css
.history-ctl-row[hidden] { display: none; }
#history-chart[hidden] { display: none; }
```

The canvas rule needs the **id** to win the cascade (`#history-chart[hidden]` = 1,1,0 beats `#history-chart` = 1,0,0); a bare `[hidden]` or class-based hatch would lose.

**Deliberately scoped, not a global `[hidden] { display: none !important }` reset.** The issue floats that as "more durable", but it would change every element in the app currently relying on the buggy behavior and wants its own sweep of `.hidden =` call sites first — a much larger blast radius than this bug warrants.

### Audit: no other instances

Swept the whole `platforms/web/` tree. DOM `hidden` toggling happens **exclusively** in `historyTab.js` (12 call sites); everything else hides via `classList` toggles, which is not this bug shape. Of the 12, the 4 fixed here were the only unhatched ones. Nothing else to chase.

## This is a real visible change

Rows users currently *see* start disappearing (correctly), per each helper's stated intent.

Verified in Chrome across **all 9 chart modes**, A/B against a second daemon serving pristine `main`:

| Chart | Row | Before | After |
|---|---|---|---|
| cost / tokens / co2 / models / providers / agents / yield | granularity | `hidden=true display=flex` ❌ | `display=none` ✅ |
| | project (dora) | `hidden=true display=flex` ❌ | `display=none` ✅ |
| **state** (Activity) | range | `hidden=true display=flex` ❌ | `display=none` ✅ |
| | project (dora) | `hidden=true display=flex` ❌ | `display=none` ✅ |
| | canvas | `hidden=true display=block` ❌ | `display=none` ✅ |
| **dora** | granularity | `hidden=true display=flex` ❌ | `display=none` ✅ |
| | project | `hidden=false display=flex` ✅ | unchanged ✅ |

The canvas fix has a visible payoff beyond tidiness: on `chart=state` the stale cost-chart pixels previously stayed painted while the (background-less) activity matrix overlaid them, leaving the "NO RECORDINGS IN THIS RANGE YET" empty state rendered illegibly on top of a purple area chart. It's now a clean card.

## Tests

Added `[hidden] survives the author display cascade (#1079)` to `irrlicht.test.js`. jsdom does **not** load the stylesheet, so asserting `el.hidden` would prove nothing — the property always flipped correctly; the regression only exists in the computed style. The suite injects the real `irrlicht.css` via the existing `readCss()` hook and asserts `getComputedStyle(...).display`.

**Verified falsifiable**: against pristine `origin/main` CSS the two "hidden → none" tests fail (`flex`/`block`) and pass with the fix. The two visible-state tests guard against an over-reaching fix that hides rows unconditionally.

`npm test` in `platforms/web/`: **173 passed** (169 + 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)