### PR TITLE
test: enforce monitoring-surface.md's structural claims as census tests

### DIFF
--- a/.claude/skills/ir:agent-releases/references/monitoring-surface.md
+++ b/.claude/skills/ir:agent-releases/references/monitoring-surface.md
@@ -30,10 +30,17 @@ An adapter's `Source` variant determines how sessions are found at all. This is 
 | Variant | Adapters | How sessions are discovered |
 |---|---|---|
 | `agent.FilesUnderRoot` | claude-code, codex, pi, gemini-cli, mistral-vibe, kiro-cli, antigravity | fswatcher over a `$HOME`-relative root |
-| `agent.FilesUnderCWD` | **aider only** | **No watcher at all** — the process scanner stat-polls `<pid's CWD>/<filename>` |
-| `agent.ProcessOwnedStore` | **opencode only** | Dedicated SQLite watcher; full tailer bypass |
+| `agent.FilesUnderCWD` | aider | **No watcher at all** — the process scanner stat-polls `<pid's CWD>/<filename>` |
+| `agent.ProcessOwnedStore` | opencode | Dedicated SQLite watcher; full tailer bypass |
 
 `core/domain/agent/source.go`; wired in `core/cmd/irrlichd/wiring.go:53-86` (which **panics** for any `ProcessOwnedStore` adapter other than opencode, `wiring.go:66`).
+
+> **This table is enforced, not asserted.** `TestSourceCensus`
+> (`core/adapters/inbound/agents/maps_test.go`) runs the same type-switch over
+> the real `agents.All()` and fails when any adapter's variant changes. `Source`
+> is a sealed sum, so a brand-new variant fails there too. Don't hand-audit
+> these columns — if the test is green, they're right; if you change them, the
+> test tells you.
 
 ### Tailer tiers
 
@@ -93,10 +100,17 @@ Adapters with no timestamps in-band at all (**vibe**, **aider**, and every kiro 
 
 ### User-blocking tools — a hardcoded, Claude-flavored list
 
-The list is **`AskUserQuestion`, `ExitPlanMode`, `question`**, hardcoded in **two** places (deliberate duplication to avoid a domain import):
+The list is `AskUserQuestion`, `ExitPlanMode`, `question`, hardcoded in **two** places (deliberate duplication to avoid a domain import):
 
 - `core/pkg/tailer/tailer_config.go:34-40` — feeds `SawUserBlockingToolClosedThisPass`
 - `core/domain/session/metrics.go:380-382` — the **classifier-facing** one, via `NeedsUserAttention()`
+
+> **The duplication is pinned, not just documented.** Both predicates are probed
+> against one shared table (`core/internal/contracttesting/userblocking`) by a
+> paired `TestUserBlockingListsAgree` in each package, so editing one list
+> without the other turns that side red. The duplication is deliberate — pin it,
+> don't "fix" it by extracting a shared constant; the tailer's copy exists
+> precisely to avoid the domain import.
 
 The names are Claude Code's, but the mechanism is name-matching, so **any adapter that emits one of those names gets user-blocking detection**. Codex earns it by *aliasing*: it synthesizes a fake tool call named `ExitPlanMode` for its `<proposed_plan>` block (`codex/parser.go:294-300`).
 
@@ -109,16 +123,23 @@ Adjacent hardcoded list: `isPermissionGatedEditTool` (`metrics.go:388-397`) matc
 | Seam | Implementers |
 |---|---|
 | `TranscriptParser` (required) | all |
-| `RawLineParser` | **aider** only |
-| `idleFlusher` | **aider** only |
-| `rotationResetter` (`ResetForRotation`) | **vibe** only |
-| `queuedTurnSplitter` | **vibe** only |
-| `TranscriptPathAware` | **vibe**, **kiro-cli**, **antigravity** |
-| `pendingContributor` | **claude-code** only |
-| `ParserStateProvider` | **claude-code**, **codex** |
-| `ReplayStoreStager` | **antigravity** only |
+| `RawLineParser` | aider |
+| `idleFlusher` | aider |
+| `rotationResetter` (`ResetForRotation`) | vibe |
+| `queuedTurnSplitter` | vibe |
+| `TranscriptPathAware` | vibe, kiro-cli, antigravity |
+| `pendingContributor` | claude-code |
+| `ParserStateProvider` | claude-code, codex |
+| `ReplayStoreStager` | antigravity |
 
 `core/pkg/tailer/parser.go:381-509`.
+
+> **This table is enforced, not asserted.** `TestParserSeamCensus`
+> (`core/adapters/inbound/agents/maps_test.go`) type-asserts every seam against
+> every parser in `agents.All()`, one subtest per row. An adapter that gains or
+> loses a seam fails the matching row. Each seam is consumed by a type assertion
+> in the tailer, so implementing one silently changes runtime behavior — which is
+> why the row set is worth pinning rather than restating.
 
 ---
 

--- a/core/adapters/inbound/agents/maps_test.go
+++ b/core/adapters/inbound/agents/maps_test.go
@@ -2,16 +2,23 @@ package agents_test
 
 import (
 	"reflect"
+	"sort"
 	"testing"
+	"time"
 
 	"irrlicht/core/adapters/inbound/agents"
 	"irrlicht/core/adapters/inbound/agents/aider"
+	"irrlicht/core/adapters/inbound/agents/antigravity"
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/adapters/inbound/agents/codex"
+	"irrlicht/core/adapters/inbound/agents/geminicli"
+	"irrlicht/core/adapters/inbound/agents/kirocli"
 	"irrlicht/core/adapters/inbound/agents/opencode"
 	"irrlicht/core/adapters/inbound/agents/pi"
+	"irrlicht/core/adapters/inbound/agents/vibe"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/backchannel"
+	"irrlicht/core/pkg/tailer"
 )
 
 // testAgents mirrors the production agents slice used by main.go and replay.
@@ -110,6 +117,176 @@ func TestMetricsProviders_onlyOpencode(t *testing.T) {
 	for _, name := range []string{claudecode.AdapterName, codex.AdapterName, pi.AdapterName, aider.AdapterName} {
 		if _, ok := m[name]; ok {
 			t.Errorf("MetricsProviders should not include %q", name)
+		}
+	}
+}
+
+// --- Census tests over the REAL agents.All() ---
+//
+// The tests above deliberately use the hand-rolled testAgents() to exercise
+// the maps.go builders against a fixed, minimal input. The censuses below
+// instead run over agents.All() — the production adapter slice — because
+// their whole purpose is to notice when a NEW adapter (or a new seam
+// implementation) changes the shape of the monitoring surface.
+//
+// They exist because .claude/skills/ir:agent-releases/references/
+// monitoring-surface.md used to assert these facts in prose ("opencode is
+// the only ProcessOwnedStore adapter", the 9-row parser-seam table). Prose
+// drifts silently; issue #1096 converted the mechanically-checkable claims
+// into invariants. When one of these fails, the fix is usually to update the
+// literal below AND the doc — the failure is the reminder to do both.
+
+// TestSourceCensus pins which adapters use each agent.Source variant.
+// agent.Source is a sealed sum (unexported isSource marker), so this
+// type-switch is exhaustive by construction: a brand-new variant lands in
+// the default arm and fails, mirroring the panic in
+// core/cmd/irrlichd/wiring.go's buildAgentWatchers.
+func TestSourceCensus(t *testing.T) {
+	want := map[string][]string{
+		"FilesUnderRoot": {
+			claudecode.AdapterName, codex.AdapterName, pi.AdapterName,
+			kirocli.AdapterName, geminicli.AdapterName,
+			antigravity.AdapterName, vibe.AdapterName,
+		},
+		"FilesUnderCWD":     {aider.AdapterName},
+		"ProcessOwnedStore": {opencode.AdapterName},
+	}
+
+	got := map[string][]string{}
+	for _, a := range agents.All() {
+		name := a.Identity.Name
+		switch a.Source.(type) {
+		case agent.FilesUnderRoot:
+			got["FilesUnderRoot"] = append(got["FilesUnderRoot"], name)
+		case agent.FilesUnderCWD:
+			got["FilesUnderCWD"] = append(got["FilesUnderCWD"], name)
+		case agent.ProcessOwnedStore:
+			got["ProcessOwnedStore"] = append(got["ProcessOwnedStore"], name)
+		default:
+			t.Errorf("adapter %q has unhandled agent.Source variant %T — add a case here, "+
+				"wire its watcher in buildAgentWatchers, and document it in monitoring-surface.md",
+				name, a.Source)
+		}
+	}
+
+	assertNameSets(t, "agent.Source variant", want, got)
+}
+
+// TestParserSeamCensus pins which adapters implement each optional parser
+// seam — the "Optional parser seams — who implements what" table in
+// monitoring-surface.md. Each seam is consumed by the tailer (or the replay
+// engine) via a type assertion, so implementing one silently changes
+// runtime behavior; this test makes that visible.
+//
+// Four of the seams are unexported in package tailer and cannot be named
+// from this external test package. They are mirrored below as structurally
+// identical local interfaces — Go satisfies interfaces structurally, so a
+// mirror matches exactly what the tailer asserts. The mirrors must be kept
+// in sync with core/pkg/tailer/parser.go by hand: if a seam's method
+// signature changes there, update the mirror here too (a stale mirror makes
+// this test assert the wrong contract rather than fail loudly).
+func TestParserSeamCensus(t *testing.T) {
+	type (
+		// mirrors tailer.idleFlusher (parser.go)
+		idleFlusher interface {
+			IdleFlush(idleFor time.Duration) *tailer.ParsedEvent
+		}
+		// mirrors tailer.queuedTurnSplitter (parser.go)
+		queuedTurnSplitter interface{ SplitsQueuedFollowUpTurns() bool }
+		// mirrors tailer.rotationResetter (parser.go)
+		rotationResetter interface{ ResetForRotation() }
+	)
+
+	seams := []struct {
+		seam       string
+		implements func(any) bool
+		want       []string
+	}{
+		// tailer.RawLineParser (exported) — the interface, not the
+		// agent.RawLineParser FileParser struct of the same name.
+		{"RawLineParser", func(p any) bool { _, ok := p.(tailer.RawLineParser); return ok },
+			[]string{aider.AdapterName}},
+		{"idleFlusher", func(p any) bool { _, ok := p.(idleFlusher); return ok },
+			[]string{aider.AdapterName}},
+		{"queuedTurnSplitter", func(p any) bool { _, ok := p.(queuedTurnSplitter); return ok },
+			[]string{vibe.AdapterName}},
+		{"rotationResetter (ResetForRotation)", func(p any) bool { _, ok := p.(rotationResetter); return ok },
+			[]string{vibe.AdapterName}},
+		// agent.PendingContributor is the exported public twin of
+		// tailer.pendingContributor, kept in sync at file_parser.go.
+		{"pendingContributor", func(p any) bool { _, ok := p.(agent.PendingContributor); return ok },
+			[]string{claudecode.AdapterName}},
+		{"ParserStateProvider", func(p any) bool { _, ok := p.(tailer.ParserStateProvider); return ok },
+			[]string{claudecode.AdapterName, codex.AdapterName}},
+		{"TranscriptPathAware", func(p any) bool { _, ok := p.(tailer.TranscriptPathAware); return ok },
+			[]string{kirocli.AdapterName, vibe.AdapterName, antigravity.AdapterName}},
+		{"ReplayStoreStager", func(p any) bool { _, ok := p.(tailer.ReplayStoreStager); return ok },
+			[]string{antigravity.AdapterName}},
+	}
+
+	all := agents.All()
+	for _, s := range seams {
+		t.Run(s.seam, func(t *testing.T) {
+			var got []string
+			for _, a := range all {
+				p := parserOf(t, a)
+				if p == nil {
+					continue // ProcessOwnedStore carries no parser factory
+				}
+				if s.implements(p) {
+					got = append(got, a.Identity.Name)
+				}
+			}
+			assertNameSets(t, s.seam+" implementers",
+				map[string][]string{s.seam: s.want}, map[string][]string{s.seam: got})
+		})
+	}
+}
+
+// parserOf returns a fresh parser instance for a's Source, or nil when the
+// variant carries no parser factory (ProcessOwnedStore reads a store
+// instead). Fails the test on an unhandled variant so a new sum member
+// can't slip past the seam census by silently yielding nil.
+func parserOf(t *testing.T, a agent.Agent) any {
+	t.Helper()
+	switch s := a.Source.(type) {
+	case agent.FilesUnderRoot:
+		switch p := s.Parser.(type) {
+		case agent.JSONLineParser:
+			return p.NewParser()
+		case agent.RawLineParser:
+			return p.NewParser()
+		default:
+			t.Errorf("adapter %q: unhandled agent.FileParser variant %T", a.Identity.Name, s.Parser)
+			return nil
+		}
+	case agent.FilesUnderCWD:
+		return s.Parser.NewParser()
+	case agent.ProcessOwnedStore:
+		return nil
+	default:
+		t.Errorf("adapter %q: unhandled agent.Source variant %T", a.Identity.Name, a.Source)
+		return nil
+	}
+}
+
+// assertNameSets compares want/got adapter-name sets per key, order-
+// insensitively, reporting each key's difference on its own line.
+func assertNameSets(t *testing.T, subject string, want, got map[string][]string) {
+	t.Helper()
+	keys := map[string]bool{}
+	for k := range want {
+		keys[k] = true
+	}
+	for k := range got {
+		keys[k] = true
+	}
+	for k := range keys {
+		w, g := append([]string(nil), want[k]...), append([]string(nil), got[k]...)
+		sort.Strings(w)
+		sort.Strings(g)
+		if !reflect.DeepEqual(w, g) {
+			t.Errorf("%s %q: got %v, want %v", subject, k, g, w)
 		}
 	}
 }

--- a/core/domain/session/userblocking_contract_test.go
+++ b/core/domain/session/userblocking_contract_test.go
@@ -1,0 +1,18 @@
+package session
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting/userblocking"
+)
+
+// TestUserBlockingListsAgree is one half of a paired contract: the same
+// assertion runs against tailer.isUserBlockingToolName in
+// core/pkg/tailer/userblocking_contract_test.go. The two predicates are
+// deliberately duplicated (the tailer avoids a domain import), so this pins
+// the thing the duplication actually risks — silent drift between them.
+//
+// In-package (not session_test) because isUserBlockingTool is unexported.
+func TestUserBlockingListsAgree(t *testing.T) {
+	userblocking.AssertMatchesCanonical(t, "session.isUserBlockingTool", isUserBlockingTool)
+}

--- a/core/internal/contracttesting/userblocking/userblocking.go
+++ b/core/internal/contracttesting/userblocking/userblocking.go
@@ -1,0 +1,55 @@
+// Package userblocking pins the canonical user-blocking tool list that
+// core/pkg/tailer and core/domain/session each hardcode independently:
+// tailer.isUserBlockingToolName and session.isUserBlockingTool.
+//
+// The duplication is DELIBERATE and must not be "fixed" by extracting a
+// shared production constant — the tailer keeps its copy local precisely to
+// avoid importing the domain package (see the comment on
+// isUserBlockingToolName in core/pkg/tailer/tailer_config.go). What the
+// duplication does not defend against is drift: nothing makes the two lists
+// fail when only one of them changes. This package is the shared table both
+// sides' in-package tests probe, so a one-sided edit turns one of them red.
+//
+// Both predicates are unexported functions with inline switch/|| bodies —
+// there is no enumerable var to compare — so agreement is asserted
+// behaviorally, by probing each predicate with the same inputs rather than
+// by diffing two lists.
+//
+// It lives in its own leaf package rather than in contracttesting itself
+// because contracttesting imports core/domain/session; an in-package test in
+// package session could not import that without an import cycle. It
+// therefore imports nothing outside the standard library — keep it that way.
+package userblocking
+
+import "testing"
+
+// Canonical is the exact set of tools that always block the agent until the
+// user responds. Both predicates must return true for every entry.
+var Canonical = []string{"AskUserQuestion", "ExitPlanMode", "question"}
+
+// NonBlocking are tools both predicates must reject. "Agent" and
+// "SendMessage" are the load-bearing entries: tailer.surviveTurnDone (a
+// different, overlapping list in the same file) does include them, so a
+// predicate that accidentally consults the wrong list fails here. The rest
+// guard against a predicate that returns true unconditionally, which would
+// otherwise satisfy the Canonical half of this assertion vacuously.
+var NonBlocking = []string{"Agent", "SendMessage", "Bash", "Read", "Edit", "Task", "AskUser", ""}
+
+// AssertMatchesCanonical probes pred with the canonical and non-blocking
+// tables. name identifies the predicate under test in failure output.
+func AssertMatchesCanonical(t *testing.T, name string, pred func(string) bool) {
+	t.Helper()
+	for _, tool := range Canonical {
+		if !pred(tool) {
+			t.Errorf("%s(%q) = false, want true — the user-blocking list drifted; "+
+				"the canonical list is %v and is duplicated in core/pkg/tailer/tailer_config.go "+
+				"and core/domain/session/metrics.go, which must agree", name, tool, Canonical)
+		}
+	}
+	for _, tool := range NonBlocking {
+		if pred(tool) {
+			t.Errorf("%s(%q) = true, want false — %q is not a user-blocking tool; "+
+				"the canonical list is exactly %v", name, tool, tool, Canonical)
+		}
+	}
+}

--- a/core/pkg/tailer/userblocking_contract_test.go
+++ b/core/pkg/tailer/userblocking_contract_test.go
@@ -1,0 +1,18 @@
+package tailer
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting/userblocking"
+)
+
+// TestUserBlockingListsAgree is one half of a paired contract: the same
+// assertion runs against session.isUserBlockingTool in
+// core/domain/session/userblocking_contract_test.go. The two predicates are
+// deliberately duplicated (the tailer avoids a domain import), so this pins
+// the thing the duplication actually risks — silent drift between them.
+//
+// In-package (not tailer_test) because isUserBlockingToolName is unexported.
+func TestUserBlockingListsAgree(t *testing.T) {
+	userblocking.AssertMatchesCanonical(t, "tailer.isUserBlockingToolName", isUserBlockingToolName)
+}


### PR DESCRIPTION
Closes #1096.

`monitoring-surface.md` asserted a set of mechanically-checkable structural facts in bold prose. This converts the checkable ones into invariants over the real `agents.All()`, and repoints the doc at the tests.

## What's enforced

| Test | Pins |
|---|---|
| `TestSourceCensus` | Each `agent.Source` variant's adapter set — the doc's whole discovery table. `Source` is a sealed sum, so a new variant lands in the `default` arm and fails (mirroring `wiring.go:66`'s panic). |
| `TestParserSeamCensus` | All 8 optional parser seams, one subtest per doc row, type-asserted against every parser in `agents.All()`. |
| `TestUserBlockingListsAgree` | The two deliberately-duplicated user-blocking predicates, probed against one shared table. Paired: one test in `package tailer`, one in `package session`. |

Both censuses run over the **real** `agents.All()` (9 adapters), not the hand-rolled `testAgents()` (5) the existing tests use — that helper is left alone, so this is additive.

## Verified the tests actually fail

A census that passes vacuously is worse than none, so each invariant was broken and confirmed red:

1. **gemini-cli → a second `ProcessOwnedStore`** → `ProcessOwnedStore: got [gemini-cli opencode], want [opencode]`
2. **`ResetForRotation()` added to pi's parser** → `rotationResetter: got [mistral-vibe pi], want [mistral-vibe]`
3. **`"question"` dropped from the tailer's list only** → tailer RED, session GREEN — the asymmetric-drift case the pairing exists to catch

## Notes for review

- **The user-blocking duplication is preserved, not "fixed."** It exists to avoid a domain import. Both predicates are unexported funcs with inline bodies, so there's no list to diff — agreement is asserted behaviorally.
- **The seam needed a new leaf package**, `core/internal/contracttesting/userblocking`. It can't live in `contracttesting` itself: that package imports `core/domain/session`, so a `package session` in-package test importing it would be an import cycle. The leaf imports nothing outside stdlib.
- **4 of the 8 seams are unexported** in `package tailer` and can't be named from `package agents_test`. They're mirrored as structurally-identical local interfaces (Go matches structurally). Documented in-test as hand-sync points — a stale mirror asserts the wrong contract rather than failing loudly. `pendingContributor` uses its existing exported twin `agent.PendingContributor` instead.

## Scope

Doc edits are confined to the three canonical structural blocks (discovery table, user-blocking, seam table) to avoid collision with #1095 (vibe/§5) and #1097 (stale comment annotations). Per-adapter restatements of "X only" in §5/§8/§9 are left to those PRs. The doc's behavioral analysis and file:line citations are out of scope per the issue.

`go test ./core/... -race -count=1` green; full `preflight.sh` green via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)