### PR TITLE
fix(vibe): honor $VIBE_HOME for session discovery

### DIFF
--- a/.claude/skills/ir:agent-releases/references/monitoring-surface.md
+++ b/.claude/skills/ir:agent-releases/references/monitoring-surface.md
@@ -235,12 +235,9 @@ The single highest-value thing to know per adapter. **Four adapters get an expli
 
 ### 5. Mistral Vibe (`mistral-vibe`)
 
-- **Transcript path**: `~/.vibe/logs/session/<session-dir>/messages.jsonl`, plus a **sibling `meta.json`** (tier (b) — load-bearing, see below).
+- **Transcript path**: `$VIBE_HOME/logs/session/<session-dir>/messages.jsonl` (default `~/.vibe/logs/session`), plus a **sibling `meta.json`** (tier (b) — load-bearing, see below).
 - **Session ID = the directory name, and irrlicht reads no naming shape.** ⚠️ **corrected (#1090):** there is no glob and no regex. `sessionIDFromPath` (`adapter.go:56-65`) accepts a file iff its basename is exactly `messages.jsonl`, then takes `filepath.Base(filepath.Dir(path))` as the ID. Upstream *does* mint `session_<ts>_<shortid>`, but **nothing in irrlicht parses it** — a bare `<session-id>` dir would work identically. Do not write that irrlicht depends on the timestamp pattern.
-- **Env override: irrlicht honors NONE — and this may already be a live gap.** ⚠️ **corrected (#1090), then re-corrected — read carefully, the two halves are about different subjects:**
-  - **irrlicht side**: `sessionsDir()` (`adapter.go:30`) is a bare constant. No `$VIBE_HOME` support. Its comment justifies this with "Vibe documents no env var that relocates this root" — but *undocumented* is not *absent*, and that comment appears to have been written from upstream's **docs**, not its source.
-  - **upstream side**: `tracked-releases.md:235` records, verified against upstream **source** at tag, `SESSION_LOG_DIR = VIBE_HOME/"logs"/"session"` with `VIBE_HOME = ~/.vibe` **overridable via `$VIBE_HOME`**.
-  - **If that holds, this is not a hypothetical break — it is a live blackout**: any user who sets `$VIBE_HOME` has every vibe session silently invisible to irrlicht today (the watcher blocks in `waitForRoot` on a directory that never appears). **Not yet confirmed against a vibe checkout — tracked as #1095; resolve it before trusting either claim.** Whichever way it lands, exactly one file should assert it.
+- **Env override**: **`VIBE_HOME`** (#1095, `adapter.go`) → `<VIBE_HOME>/logs/session`. **Absolute paths only** — a relative or `~`-prefixed value is logged and ignored, so irrlicht is narrower than upstream, which also `expanduser().resolve()`s those. Same two caveats as `KIRO_HOME` below: it's a **boot-time snapshot**, and irrlicht watches **exactly one** root. Upstream honors it in **source but not in its docs** (v2.19.1 `vibe/core/paths/_vibe_home.py`) — which is why the adapter was hardcoded until #1095; the old "Vibe documents no env var" comment read the docs, not the source. `adapter.go`'s `vibeHomeEnvVar` is the single assertion of this fact.
 - **Process**: `agent.CommandPattern{Regex: "(^|/)vibe( |$)|mistral-vibe/bin/python"}` → `pgrep -f` over the **full command line** (`adapter.go:43`, `agent.go:30`). Vibe is a Python console-script with no `setproctitle`, so `ExactName{"vibe"}` would never fire. No `ExcludeArgv`.
 - **PID discovery**: `DiscoverPIDByCWDAndCmdLine` (`pid.go:16-21`) — cmdline regex, then narrow by CWD.
 - **CWD comes only from `meta.json`.** The JSONL carries none. **No sidecar → no cwd → `DiscoverPID` early-returns `0, nil` → no PID bind**, and the session is exposed to the unbound-ghost reaper.
@@ -270,7 +267,7 @@ Read on `turn_done` only; memoized by `(mtime, size)`; failures return last-good
 
 #### What breaks it
 - Rename `messages.jsonl`, move the root, drop the `.jsonl` extension, or flatten to `<root>/<id>.jsonl` (which would collapse every session onto the ID `session`) → **silent total blackout**.
-- `$VIBE_HOME` (see above — possibly already live) or any XDG relocation → same.
+- Any XDG relocation, or a **second** relocation seam landing alongside `$VIBE_HOME` → same. (`$VIBE_HOME` itself is handled — see Env override above.) One such seam already exists and is **unhandled**: `[session_logging].save_dir` in `config.toml` overrides the session root outright (`vibe/core/config/models.py`, defaulting to `SESSION_LOG_DIR`); irrlicht reads no vibe config, so a user who sets it is invisible.
 - Drop/rename `meta.json` or `environment.working_directory` → no PID bind, no model, no tokens, no context window, in one stroke.
 - Adopt `setproctitle`, or launch as `python -m vibe.cli` → the cmdline regex never fires.
 - Emit a trailing summary/telemetry line after the final assistant message → premature `ready`.

--- a/core/adapters/inbound/agents/vibe/adapter.go
+++ b/core/adapters/inbound/agents/vibe/adapter.go
@@ -1,5 +1,6 @@
 // Package vibe provides an inbound adapter that watches Mistral Vibe
-// transcript files under ~/.vibe/logs/session/<session-id>/messages.jsonl.
+// transcript files under $VIBE_HOME/logs/session/<session-id>/messages.jsonl
+// (default ~/.vibe/logs/session).
 //
 // Mistral Vibe (https://github.com/mistralai/mistral-vibe) is Mistral AI's
 // open-source CLI coding agent. It appends one JSON object per line to a
@@ -12,6 +13,8 @@ package vibe
 import (
 	"path/filepath"
 	"regexp"
+
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
 )
 
 // AdapterName identifies sessions originating from Mistral Vibe. It matches
@@ -23,11 +26,34 @@ const AdapterName = "mistral-vibe"
 const transcriptFilename = "messages.jsonl"
 
 // defaultRootDir is the path relative to $HOME where Vibe stores session
-// directories. Each session is a <session-id>/ folder holding messages.jsonl
-// (the conversation) and meta.json (the sidecar). Vibe documents no env var
-// that relocates this root, so it is constant — kept as a function to mirror
-// the sibling adapters.
-func sessionsDir() string { return ".vibe/logs/session" }
+// directories when $VIBE_HOME is unset. Each session is a <session-id>/
+// folder holding messages.jsonl (the conversation) and meta.json (the
+// sidecar).
+const defaultRootDir = ".vibe/logs/session"
+
+// vibeHomeEnvVar is the upstream Vibe env var that relocates the agent's home
+// directory (default: ~/.vibe). Verified against the installed package source
+// at v2.19.1 — vibe/core/paths/_vibe_home.py resolves
+//
+//	SESSION_LOG_DIR = VIBE_HOME/"logs"/"session"
+//	VIBE_HOME       = os.getenv("VIBE_HOME") or ~/.vibe
+//
+// so when it is set, sessions move to $VIBE_HOME/logs/session. It is honored
+// in source but absent from Vibe's docs — the previous justification here
+// ("Vibe documents no env var that relocates this root") read the docs, not
+// the source, and was wrong: undocumented is not absent.
+//
+// Note a deliberate narrowing vs upstream: Vibe applies expanduser().resolve()
+// to the value, so it also accepts "~/x" and cwd-relative paths. irrlicht
+// honors absolute values only (agentpaths.FromEnv logs and ignores the rest),
+// matching every sibling adapter rather than reimplementing shell expansion.
+const vibeHomeEnvVar = "VIBE_HOME"
+
+// sessionsDir returns the directory the Vibe adapter should watch —
+// $VIBE_HOME/logs/session when that override is set, else defaultRootDir.
+func sessionsDir() string {
+	return agentpaths.FromEnv("vibe", vibeHomeEnvVar, defaultRootDir, "logs", "session")
+}
 
 // processCmdPattern recognizes a running Vibe process on the full command
 // line. Vibe ships as a Python console-script (no setproctitle), so the OS

--- a/core/adapters/inbound/agents/vibe/adapter_test.go
+++ b/core/adapters/inbound/agents/vibe/adapter_test.go
@@ -7,6 +7,33 @@ import (
 	"irrlicht/core/domain/backchannel"
 )
 
+// TestSessionsDir pins the $VIBE_HOME seam. Upstream honors the override in
+// source (v2.19.1, vibe/core/paths/_vibe_home.py) though not in its docs, so
+// a hardcoded root would make every session of a $VIBE_HOME user invisible.
+// Absolute-only, matching the sibling adapters: irrlicht performs no shell
+// expansion, so a relative or "~"-prefixed value is logged and ignored.
+func TestSessionsDir(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{"empty falls back to default", "", defaultRootDir},
+		{"absolute override produces $VIBE_HOME/logs/session", "/tmp/vibe-home", "/tmp/vibe-home/logs/session"},
+		{"trailing slash is cleaned", "/tmp/vibe-home/", "/tmp/vibe-home/logs/session"},
+		{"relative override is rejected (falls back to default)", "relative/home", defaultRootDir},
+		{"tilde-prefixed override is rejected (no shell expansion)", "~/custom", defaultRootDir},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(vibeHomeEnvVar, tc.env)
+			if got := sessionsDir(); got != tc.want {
+				t.Errorf("sessionsDir() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAgent_Identity(t *testing.T) {
 	a := Agent()
 	if a.Identity.Name != AdapterName {
@@ -21,12 +48,17 @@ func TestAgent_Identity(t *testing.T) {
 }
 
 func TestAgent_Source_FilesUnderRoot(t *testing.T) {
+	// Pin the default root explicitly: Agent() resolves Dir through
+	// sessionsDir(), so a $VIBE_HOME set in the developer's own shell would
+	// otherwise leak into this assertion.
+	t.Setenv(vibeHomeEnvVar, "")
+
 	src, ok := Agent().Source.(agent.FilesUnderRoot)
 	if !ok {
 		t.Fatalf("Source is %T, want FilesUnderRoot", Agent().Source)
 	}
-	if src.Dir != ".vibe/logs/session" {
-		t.Errorf("Dir = %q", src.Dir)
+	if src.Dir != defaultRootDir {
+		t.Errorf("Dir = %q, want %q", src.Dir, defaultRootDir)
 	}
 	if src.SessionIDFromPath == nil {
 		t.Error("expected SessionIDFromPath (filename is the constant messages.jsonl)")


### PR DESCRIPTION
Closes #1095.

## Verdict: upstream **does** honor `$VIBE_HOME` — the adapter was wrong, the changelog was right

#1095 asked which of two contradicting in-repo claims was true. Settled against the **installed `mistral-vibe` v2.19.1 package** (uv tool), two independent ways.

**1. Source read** — `vibe/core/paths/_vibe_home.py`:

```python
_DEFAULT_VIBE_HOME = Path.home() / ".vibe"

def _get_vibe_home() -> Path:
    if vibe_home := os.getenv("VIBE_HOME"):
        return Path(vibe_home).expanduser().resolve()
    return _DEFAULT_VIBE_HOME

VIBE_HOME       = GlobalPath(_get_vibe_home)
SESSION_LOG_DIR = GlobalPath(lambda: VIBE_HOME.path / "logs" / "session")
```

**2. Empirically**, executing that same installed code:

| `VIBE_HOME` | resolved `SESSION_LOG_DIR` |
|---|---|
| *(unset)* | `/Users/ingo/.vibe/logs/session` |
| `/tmp/vibe-test` | `/private/tmp/vibe-test/logs/session` |

So `tracked-releases.md:235` was **correct** and is left untouched. `vibe/adapter.go`'s justification — *"Vibe documents no env var that relocates this root"* — read upstream's **docs**, not its **source**. Undocumented is not absent.

## Impact — this was a live blackout, not a hypothetical

`sessionsDir()` had no env seam, so irrlicht watched `~/.vibe/logs/session` unconditionally. For any user with `$VIBE_HOME` set, **every vibe session was invisible**: the fswatcher blocks in `waitForRoot` on a directory that never appears. No error, no log — indistinguishable from "no vibe sessions exist".

## The fix

Route `sessionsDir()` through `agentpaths.FromEnv` — the seam `kirocli` already uses for `KIRO_HOME` (#1074), and the fifth adapter to adopt it.

**Absolute-only, a deliberate narrowing vs upstream**: vibe applies `expanduser().resolve()`, so it also accepts `~/x` and cwd-relative values; irrlicht performs no shell expansion and logs+ignores those. Consistent with every sibling adapter rather than reimplementing shell semantics — and documented as such in both the code comment and §5.

## Exactly one file asserts the fact

`adapter.go`'s `vibeHomeEnvVar` comment is now the single assertion (cited to the upstream file + tag). `monitoring-surface.md` §5 drops the open question and adopts the sibling `KIRO_HOME` bullet shape; `tracked-releases.md` is untouched.

## Bonus finding (documented, not fixed)

Verification surfaced a **second, still-unhandled** relocation seam: `[session_logging].save_dir` in `config.toml` overrides the session root outright (`vibe/core/config/models.py`, defaulting to `SESSION_LOG_DIR`). irrlicht reads no vibe config, so a user who sets it is still invisible. Recorded under §5 "What breaks it" rather than fixed here — out of this issue's scope, and worth its own ticket.

## Tests

- New `TestSessionsDir` (mirrors kirocli's): default, absolute, trailing-slash, relative-rejected, tilde-rejected.
- `TestAgent_Source_FilesUnderRoot` made hermetic — it asserted the bare literal, so a developer's own `$VIBE_HOME` would have leaked into it; now pins `defaultRootDir` with `t.Setenv`.
- `go test ./core/... -race -count=1` → **exit 0, 46 packages ok**.
- `tools/preflight.sh --only go` → all 6 gates PASS. `--only arch` → ARS PASS, non-regressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)