### PR TITLE
docs: fix six stale source comments and drop their remote annotations

### DIFF
--- a/.claude/skills/ir:agent-releases/references/monitoring-surface.md
+++ b/.claude/skills/ir:agent-releases/references/monitoring-surface.md
@@ -66,7 +66,7 @@ An adapter's `Source` variant determines how sessions are found at all. This is 
 
 `core/adapters/inbound/agents/fswatcher/watcher.go`
 
-- **Recursive, unbounded depth** — `filepath.WalkDir` per root child (`watcher.go:490-499`), plus `addSubtree` for dirs created at runtime (`watcher.go:566-577`). ⚠️ The package doc comment (`watcher.go:2-3`) still says "two-level directory tree" — **it is stale**; the recursion is load-bearing for Claude Code's `subagents/`, gemini's `chats/<uuid>/`, vibe's `agents/`, and antigravity's 3-deep layout.
+- **Recursive, unbounded depth** — `filepath.WalkDir` per root child (`watcher.go:490-499`), plus `addSubtree` for dirs created at runtime (`watcher.go:566-577`). The recursion is load-bearing for Claude Code's `subagents/`, gemini's `chats/<uuid>/`, vibe's `agents/`, and antigravity's 3-deep layout.
 - **`.jsonl` only** (`transcriptExt`, `watcher.go:21`; enforced `:303`, `:588`, `:610`). This is how sibling non-transcripts are ignored for free (gemini's `logs.json`/`.project_root`, vibe's `meta.json`, kiro's `.json`/`.lock`). aider's `.md` is invisible to it entirely — hence `FilesUnderCWD`.
 - **Session ID** defaults to the filename stem (`extractSessionID`, `watcher.go:608-614`), overridable per adapter via `FilesUnderRoot.SessionIDFromPath`; returning `""` **skips the file** (antigravity uses this to ignore `transcript_full.jsonl`).
 - **Max session age**: default **5 days** (`core/domain/config/config.go:13`), overridable via `IRRLICHT_MAX_SESSION_AGE`. Applied to Create/Write, **not** to Remove/Rename (`watcher.go:341-344`).
@@ -89,7 +89,7 @@ Adapters with no timestamps in-band at all (**vibe**, **aider**, and every kiro 
 
 `ComputeContextUtilization` (`tailer_metrics.go:548-579`). Window precedence: `contextWindowOverride` > `capacityMgr.GetModelCapacity(model).ContextWindow`. Thresholds: ≥90 critical, ≥80 warning, ≥60 caution.
 
-⚠️ `tailer.go:66-70` documents `ContextWindowUnknown` as "true when ContextWindow is the 32k sentinel fallback". **There is no 32k sentinel** — `GetModelCapacity` returns a zero value on miss (`capacity.go:97-99`). Don't repeat the 32k claim.
+**There is no 32k sentinel fallback** — `GetModelCapacity` returns a zero value on miss (`capacity.go:97-99`), and `ContextWindowUnknown` is what marks that zero as "unknown" rather than "not yet computed".
 
 ### User-blocking tools — a hardcoded, Claude-flavored list
 
@@ -124,7 +124,7 @@ Adjacent hardcoded list: `isPermissionGatedEditTool` (`metrics.go:388-397`) matc
 
 ## State Classification Logic
 
-⚠️ **corrected (#1090):** this was documented as a 5-step order. The real body (`core/application/services/state_classifier.go:22-87`) evaluates **seven** rules. The source file's *own* header comment (`:15-19`) still claims four — don't trust it either.
+⚠️ **corrected (#1090):** this was documented as a 5-step order. The real body (`core/application/services/state_classifier.go:22-87`) evaluates **seven** rules.
 
 | # | Condition | Result |
 |---|---|---|
@@ -408,7 +408,7 @@ Per-step (not cumulative) tokens from `part.data.tokens`; `cost` is a top-level 
 - **Model** comes *only* from a regex over a `<USER_SETTINGS_CHANGE>` block in USER_INPUT content (`Model Selection…from X to Y`), updated on **every** occurrence (mid-session `/model` switches). It's then superseded by the store's canonical id on turn_done — so **before the first turn_done, a session shows no model**.
 - **CWD** comes only from a `run_command` call's `Cwd` arg, with the sandbox scratch dir rejected by a `Contains(".gemini/antigravity")` + `Contains("/scratch")` match. Fallback: the `<root>/history.jsonl` index (keys `conversationId`/`workspace`).
 - **`created_at`** is parsed as **strict RFC3339**; anything else silently falls back to `time.Now()`.
-- **Never read, despite being present**: `status` (on every line), `thinking`, `truncated_fields`. ⚠️ The parser's own doc comment claims the envelope includes "thinking text", implying use — **the code never touches it**.
+- **Never read, despite being present**: `status` (on every line), `thinking`, `truncated_fields`.
 - **User-blocking: none.** Plan-approval gates are live UI prompts, **never persisted to the transcript**, so no `waiting` episode is ever written. `waiting` can only come from generic text cues.
 - **Subagent linking** depends on the parent writing the child's conv-id into its transcript, found by a **substring scan** — safe only because conv-ids are random UUIDs (non-UUID ids would false-positive). Bounded by three heuristic constants upstream timing could invalidate: a 2-minute spawn window, a 40-sibling scan cap, and a 256KB tail.
 
@@ -427,7 +427,7 @@ Per-step (not cumulative) tokens from `part.data.tokens`; `cost` is a top-level 
 - **Transcript**: **`.aider.chat.history.md`** — a Markdown chat history, living in the **aider process's CWD**, not under `$HOME`.
 - **Source model**: `agent.FilesUnderCWD` — **the only adapter**. It carries a **basename only**; it structurally cannot express a path. **No root, no glob, and no fswatcher is constructed** (`wiring.go:71-75`). Discovery is a **stat poll of `<pid's CWD>/<filename>`** by the process scanner (1s, backing off to 5s when the PID set is stable): first sight → new session, size change → activity.
 - ⚠️ **Consequence: if aider's process isn't matched, the transcript is never found**, no matter that it's sitting on disk. Every other adapter's watcher would still see the file. **aider's process matcher is a hard dependency of transcript detection**, not just of PID features.
-- **Process**: `agent.CommandPattern{Regex: "/aider"}` over the full command line — aider's real OS process is `python` invoking a console script (**the same problem as vibe**), so `pgrep -x aider` finds nothing. The leading slash anchors to the binary path and excludes wrappers (tmux, sh) that merely mention "aider". ⚠️ `adapter.go:6-8` claims `ProcessName` is "used by the process scanner via `pgrep -x`" — **stale comment**; `wiring.go:99-103` is authoritative: the `CommandPattern` path bypasses `pgrep -x` and the name is never matched.
+- **Process**: `agent.CommandPattern{Regex: "/aider"}` over the full command line — aider's real OS process is `python` invoking a console script (**the same problem as vibe**), so `pgrep -x aider` finds nothing. The leading slash anchors to the binary path and excludes wrappers (tmux, sh) that merely mention "aider". The `CommandPattern` path bypasses `pgrep -x` entirely (`wiring.go:99-103`), so the adapter's `ProcessName` const is never matched against running processes.
 - **Config**: ⚠️ **corrected (#1090): `~/.aider.conf.yml` is read nowhere in irrlicht** — zero matches repo-wide. It's purely how *the user* configures aider. **Corollary: if `> Model:` is absent from the transcript, irrlicht has no fallback model source for aider at all.**
 - **Session ID = `proc-<pid>`** — **session identity is the aider process, not the file.** An append-only `.md` needs no session boundary because the boundary *is* the process lifetime. Aider's own `# aider chat started at …` delimiter is **explicitly discarded**.
 

--- a/core/adapters/inbound/agents/aider/adapter.go
+++ b/core/adapters/inbound/agents/aider/adapter.go
@@ -3,6 +3,9 @@ package aider
 // AdapterName identifies sessions originating from the Aider coding agent.
 const AdapterName = "aider"
 
-// ProcessName is the OS-level executable name for Aider, used by the
-// process scanner via `pgrep -x`.
+// ProcessName is the OS-level executable name for Aider. It is not used for
+// process matching: Aider runs under python, so the adapter matches on the
+// command line instead (agent.CommandPattern in agent.go), and the scanner's
+// command-line path bypasses `pgrep -x` entirely — see processNameFor in
+// cmd/irrlichd/wiring.go. Nothing outside this declaration reads it today.
 const ProcessName = "aider"

--- a/core/adapters/inbound/agents/antigravity/parser.go
+++ b/core/adapters/inbound/agents/antigravity/parser.go
@@ -12,7 +12,9 @@ import (
 // Parser implements tailer.TranscriptParser for Antigravity session transcripts
 // (the filtered transcript.jsonl). Each line is one step sharing the envelope
 // {step_index, source, type, status, created_at, content} plus an optional
-// tool_calls array and thinking text. The shapes:
+// tool_calls array and thinking text. The parser reads step_index, source,
+// type, created_at, content and tool_calls; status, thinking and
+// truncated_fields are on the wire but never read. The shapes:
 //
 //   - source "USER_EXPLICIT", type "USER_INPUT" — the user's prompt, wrapped in
 //     <USER_REQUEST>…</USER_REQUEST> plus metadata blocks. Opens a turn. A

--- a/core/adapters/inbound/agents/fswatcher/watcher.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher.go
@@ -1,6 +1,9 @@
 // Package fswatcher implements a generic fsnotify-based watcher for agent
-// transcript files. It watches a two-level directory tree (root/<project>/<id>.jsonl)
-// and emits TranscriptEvents tagged with the adapter name.
+// transcript files. It watches a directory tree recursively, to unbounded depth
+// (root/<project>/<id>.jsonl is the common shape, but nested layouts — Claude
+// Code's subagents/, gemini's chats/<uuid>/, vibe's agents/, antigravity's
+// 3-deep tree — are covered by the same recursion), and emits TranscriptEvents
+// tagged with the adapter name.
 package fswatcher
 
 import (

--- a/core/adapters/inbound/agents/maps.go
+++ b/core/adapters/inbound/agents/maps.go
@@ -88,8 +88,8 @@ func ProcessNames(agents []agent.Agent) map[string]string {
 // the liveness sweep's infra re-validation: a session bound to a still-alive PID
 // whose argv the adapter rejects (e.g. Claude Code's --bg-spare pool helper) is a
 // ghost and must be reaped (#727). Only adapters that declare a non-nil
-// Process.ExcludeArgv appear (today: claude-code); the rest get no entry, so the
-// sweep leaves their sessions untouched.
+// Process.ExcludeArgv appear (today: claude-code and gemini-cli); the rest get
+// no entry, so the sweep leaves their sessions untouched.
 func ArgvExcluders(agents []agent.Agent) map[string]func([]string) bool {
 	m := make(map[string]func([]string) bool)
 	for _, a := range agents {

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -1,6 +1,6 @@
 // StateClassifier provides pure functions for session state classification.
-// These functions encapsulate the four-way decision tree used to determine
-// whether a session is working, waiting, or ready based on transcript metrics.
+// These functions encapsulate the decision tree used to determine whether a
+// session is working, waiting, or ready based on transcript metrics.
 package services
 
 import (
@@ -9,14 +9,17 @@ import (
 	"irrlicht/core/domain/session"
 )
 
-// ClassifyState applies the four-way decision tree to determine what state a
-// session should be in based on its current state and latest metrics.
+// ClassifyState applies the decision tree to determine what state a session
+// should be in based on its current state and latest metrics.
 //
-// Decision order:
-//  1. NeedsUserAttention → waiting
-//  2. IsAgentDone → ready (from working/waiting only)
-//  3. ESC cancellation (user + error + no open tools) → ready
-//  4. Default → working
+// Decision order (the body's rule numbering in parentheses):
+//   - PermissionPending → waiting (0)
+//   - CompactInProgress → working (0b)
+//   - NeedsUserAttention → waiting (1)
+//   - OpenToolStalled → waiting (1b)
+//   - IsAgentDone → ready, from working/waiting only (2)
+//   - ESC cancellation / tool denial (user + error + no open tools) → ready (3)
+//   - Default → working (4)
 //
 // Returns (newState, reason). An empty reason means no transition occurred.
 func ClassifyState(currentState string, metrics *session.SessionMetrics) (string, string) {

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -27,11 +27,11 @@ type SessionMetrics struct {
 	ContextUtilization float64 `json:"context_utilization_percentage"`
 	PressureLevel      string  `json:"pressure_level"`
 
-	// ContextWindowUnknown signals that the model has no LiteLLM pricing
-	// entry, so ContextWindow is a sentinel fallback (32k) rather than a
-	// known value. The UI uses this to render a tentative bar (dashed
-	// outline / "~" prefix) instead of suppressing context display
-	// entirely. Without this fallback, sessions on local models like
+	// ContextWindowUnknown signals that no context window could be resolved
+	// for the model (e.g. no LiteLLM pricing entry), so ContextWindow is
+	// left at zero rather than a known value. The UI uses this to keep
+	// showing tokens — without a percentage — instead of suppressing the
+	// context display entirely. Without this signal, sessions on local models like
 	// `gemma-4-26b-a4b` (aider via LM Studio) had pressure_level="unknown"
 	// which the macOS app treated as "no data" and hid the row's context
 	// column.

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -63,11 +63,12 @@ type SessionMetrics struct {
 	ContextUtilization float64 `json:"context_utilization_percentage,omitempty"`
 	PressureLevel      string  `json:"pressure_level,omitempty"` // "safe", "caution", "warning", "critical"
 
-	// ContextWindowUnknown is true when ContextWindow is the 32k sentinel
-	// fallback (no LiteLLM pricing for this model) rather than a known
-	// value. The macOS app uses this to render a tentative bar (dashed
-	// outline / "~" prefix). See computeContextUtilization in
-	// tailer_metrics.go.
+	// ContextWindowUnknown is true when no context window could be resolved
+	// for this model (no override, and no capacity entry — e.g. no LiteLLM
+	// pricing), leaving ContextWindow at zero rather than a known value.
+	// Clients use it to distinguish "unknown" from "not yet computed": the
+	// macOS app renders tokens only, with no percentage, and shows "—" in
+	// the cost/CO2 slots. See computeContextUtilization in tailer_metrics.go.
 	ContextWindowUnknown bool `json:"context_window_unknown,omitempty"`
 
 	// Raw event data for real-time client-side calculations


### PR DESCRIPTION
Closes #1097

Six in-repo comments were wrong about their own code. #1092 *annotated their wrongness* in `monitoring-surface.md` rather than fixing it — inverted altitude: a wrong comment two lines from the code is cheaper to fix than to document remotely, and the remote annotation goes stale the moment someone fixes the comment.

**This diff is comment-only. No behavior changes** — verified: every changed line in `core/**/*.go` is a comment or blank.

## Fixed

| File | Was | Now |
|---|---|---|
| `fswatcher/watcher.go` | "watches a **two-level** directory tree" | Fully recursive, unbounded depth — and says why it's load-bearing |
| `pkg/tailer/tailer.go` | `ContextWindowUnknown` is "the **32k sentinel** fallback" | No sentinel exists; `GetModelCapacity` returns zero on miss |
| `domain/session/metrics.go` | same 32k-sentinel myth, **second instance** | same correction |
| `application/services/state_classifier.go` | documents a **four**-way tree | Seven rules, matching the body |
| `aider/adapter.go` | `ProcessName` "used by the scanner via `pgrep -x`" | The `CommandPattern` path bypasses `pgrep -x`; the name is never matched |
| `antigravity/parser.go` | envelope "includes thinking text", implying use | `thinking` is present but never read |
| `agents/maps.go` | ExcludeArgv declared "today: claude-code" | claude-code **and** gemini-cli |

The `metrics.go` one wasn't in the issue's list — the same false "32k sentinel" claim turned out to exist in a second place, so both are fixed rather than just the one named.

## Doc

Removed the five "⚠️ this comment is stale" annotations from `monitoring-surface.md` while **keeping the underlying factual claims** (e.g. kept "the watcher is recursive, unbounded depth"; dropped only "⚠️ the package doc still says two-level — it is stale"). The doc no longer tracks the comments' wrongness, because they're no longer wrong.

## Testing

`go test ./core/... -race -count=1` → 46 packages ok, 0 failures. Pushed with the pre-push `preflight.sh` hook intact (passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)