### PR TITLE
fix(tailer): clear openToolCalls on rotation; verify #1088's three relocation/prune edges

### DIFF
--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -117,6 +117,35 @@ func (d *SessionDetector) onRelocated(ev agent.Event, newPath string) {
 // and fall through to the normal removal path. filepath.Glob only returns paths
 // that exist, and the removed path no longer does, so any other match is a live
 // relocated copy.
+//
+// Two consequences of that Glob-only-returns-existing-paths property were
+// assessed in issue #1088 and both came back benign:
+//
+//  1. Ordering. Relying on the destination already existing when the Remove
+//     arrives would break if Claude Code deleted the source before writing the
+//     destination. It does not: a census of every relocated transcript on a
+//     real machine (50 files, 2104 relocation markers, up to 179 moves in a
+//     single session) found birthtime == the session's first-line timestamp in
+//     50/50 cases, while the files kept growing for hours afterwards. The inode
+//     is preserved across every move, i.e. the transcript is renamed, never
+//     copied or recreated — so the destination exists at the instant the source
+//     stops existing. If that ever changed, the fallback here is graceful, not
+//     corrupting: the glob returns "", the session flips ready, and the next
+//     activity event revives it. That fallback is pinned by
+//     TestSessionDetector_Removed_TranscriptGone_FlipsReady.
+//
+//  2. Subagents. Dir(Dir(removedPath)) resolves a subagent path
+//     (<slug>/<parent-id>/subagents/<x>.jsonl) to <slug>/<parent-id>, so
+//     sibling slugs are never searched and a relocated subagent is not detected
+//     as such. That path is unreachable rather than merely harmless: Claude Code
+//     relocates a parent by renaming the whole <parent-id>/ subtree, and
+//     renaming a directory leaves the child files' vnodes untouched, so
+//     fswatcher (which only emits events for paths ending in .jsonl) never
+//     delivers a Remove for the subagent at all. The watcher instead re-walks
+//     the destination dir and re-emits the child as a new session at its new
+//     path. onRemoved is therefore never called for a relocating subagent.
+//     TestRelocatedTranscript pins the limitation so the reasoning is
+//     discoverable if the watcher's dir handling ever changes.
 func relocatedTranscript(removedPath string) string {
 	if removedPath == "" {
 		return ""

--- a/core/application/services/session_detector_lifecycle_internal_test.go
+++ b/core/application/services/session_detector_lifecycle_internal_test.go
@@ -1,0 +1,69 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// relocatedTranscript's unit-level contract, including the subagent limitation
+// assessed in issue #1088.
+//
+// The subagent case is pinned as a KNOWN, benign limitation rather than a bug:
+// onRemoved is never reached for a relocating subagent, because Claude Code
+// relocates a parent by renaming the whole <parent-id>/ subtree and renaming a
+// directory leaves the child files' vnodes untouched — fswatcher only emits
+// events for paths ending in .jsonl, so no Remove is ever delivered for the
+// child. See relocatedTranscript's doc comment for the full reasoning and the
+// on-disk evidence. If fswatcher ever starts emitting Removes for files inside
+// a renamed directory, this expectation is the thing to revisit.
+func TestRelocatedTranscript(t *testing.T) {
+	root := t.TempDir()
+	const (
+		mainSlug = "-Users-test"
+		wtSlug   = "-Users-test--claude-worktrees-1088"
+		parentID = "11111111-2222-3333-4444-555555555555"
+	)
+
+	// A top-level session transcript that moved main → worktree slug: the
+	// source is absent, only the destination exists.
+	if err := os.MkdirAll(filepath.Join(root, wtSlug), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	parentGone := filepath.Join(root, mainSlug, parentID+".jsonl")
+	parentLive := filepath.Join(root, wtSlug, parentID+".jsonl")
+	if err := os.WriteFile(parentLive, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A subagent transcript that moved with it, one level deeper.
+	subLiveDir := filepath.Join(root, wtSlug, parentID, "subagents")
+	if err := os.MkdirAll(subLiveDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	subGone := filepath.Join(root, mainSlug, parentID, "subagents", "agent-abc.jsonl")
+	if err := os.WriteFile(filepath.Join(subLiveDir, "agent-abc.jsonl"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A genuinely deleted transcript: no surviving copy anywhere.
+	reallyGone := filepath.Join(root, mainSlug, "deleted.jsonl")
+
+	tests := []struct {
+		name    string
+		removed string
+		want    string
+	}{
+		{name: "top-level relocation is detected", removed: parentGone, want: parentLive},
+		{name: "subagent relocation is not detected (known, benign)", removed: subGone, want: ""},
+		{name: "genuine deletion", removed: reallyGone, want: ""},
+		{name: "empty path", removed: "", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := relocatedTranscript(tc.removed); got != tc.want {
+				t.Errorf("relocatedTranscript(%q) = %q, want %q", tc.removed, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/application/services/session_detector_lifecycle_test.go
+++ b/core/application/services/session_detector_lifecycle_test.go
@@ -225,6 +225,72 @@ func TestSessionDetector_Removed_TranscriptRelocation_StaysAlive(t *testing.T) {
 	}
 }
 
+// The companion to the relocation test above: when the transcript is really
+// gone — no surviving copy under any sibling slug — onRemoved must take the
+// normal removal path and flip the session to ready.
+//
+// This is the documented fallback for issue #1088's first edge. relocatedTranscript
+// depends on the destination already existing when the Remove arrives, which
+// holds because Claude Code renames transcripts rather than copying them (see
+// that function's doc comment for the on-disk census). This test pins what
+// happens if that assumption is ever violated — a clean, self-recovering flip
+// to ready rather than a hang or a wrong path — so the fallback stays a
+// deliberate behaviour rather than an accident. It passes on main by
+// construction; it is a lock, not a bug reproduction.
+func TestSessionDetector_Removed_TranscriptGone_FlipsReady(t *testing.T) {
+	root := t.TempDir()
+	// Both slugs exist, but the transcript is absent from both: a genuine
+	// deletion, not a relocation.
+	gonePath := filepath.Join(root, "-Users-test", "gone1.jsonl")
+	if err := os.MkdirAll(filepath.Join(root, "-Users-test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "-Users-test--claude-worktrees-1088"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	repo.states["gone1"] = &session.SessionState{
+		SessionID:      "gone1",
+		State:          session.StateWorking,
+		TranscriptPath: gonePath,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	det := newDetector(tw, pw, repo)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventRemoved,
+		SessionID:      "gone1",
+		TranscriptPath: gonePath,
+	}
+
+	waitForCondition(func() bool {
+		repo.mu.Lock()
+		defer repo.mu.Unlock()
+		return repo.lastSavedState["gone1"] == string(session.StateReady)
+	}, time.Second)
+	cancel()
+	<-done
+
+	repo.mu.Lock()
+	gotState := repo.lastSavedState["gone1"]
+	repo.mu.Unlock()
+	if gotState != string(session.StateReady) {
+		t.Errorf("state: got %q, want ready (a genuine removal must flip the session to ready)", gotState)
+	}
+	// The dead path must be left as-is — there is no surviving copy to follow.
+	if got := repo.transcriptPathOf("gone1"); got != gonePath {
+		t.Errorf("transcript_path: got %q, want %q (unchanged on a genuine removal)", got, gonePath)
+	}
+}
+
 func TestSessionDetector_ExistingSession_UpdatesTranscriptPath(t *testing.T) {
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()

--- a/core/pkg/tailer/rotation_reset_test.go
+++ b/core/pkg/tailer/rotation_reset_test.go
@@ -2,8 +2,82 @@ package tailer
 
 import (
 	"os"
+	"sort"
 	"testing"
 )
+
+// openToolParser emits a tool_use for {"tool_use":"<id>","name":"<n>"} lines,
+// so a test can leave tool calls open across a rotation without depending on
+// any real adapter's parsing logic. No line ever closes a call: the point is
+// what survives a rotation, not pair matching.
+type openToolParser struct{}
+
+func (p *openToolParser) ParseLine(raw map[string]interface{}) *ParsedEvent {
+	if id, ok := raw["tool_use"].(string); ok {
+		name, _ := raw["name"].(string)
+		return &ParsedEvent{EventType: "assistant", ToolUses: []ToolUse{{ID: id, Name: name}}}
+	}
+	return &ParsedEvent{Skip: true}
+}
+
+// TestResetAccumulatorsForRotation_ClearsOpenToolCalls is the regression test
+// for issue #1088's fourth edge: openToolCalls was missing from
+// resetAccumulatorsForRotation's reset list.
+//
+// Re-reading a rotated file from byte 0 re-inserts every surviving tool_use by
+// ID, so the id-keyed map self-corrects for anything the new file still
+// contains. What it cannot correct is a call left open in the *pre*-rotation
+// content: no surviving line re-inserts or closes it. The pre-fix behaviour
+// leaked all three ids below into the post-rotation count (4 instead of 1).
+//
+// sweepOpenToolCallsOnTurnDone was assumed to self-heal this at the next turn
+// end, but it only half-does: it deliberately preserves the surviveTurnDone
+// names, which are exactly the user-blocking ones NeedsUserAttention() reads —
+// so a stale AskUserQuestion survived every subsequent sweep and pinned the
+// session to `waiting` forever. That is why two of the three ids below use
+// surviveTurnDone names: no later sweep could have rescued them, so the reset
+// is the only thing that can.
+func TestResetAccumulatorsForRotation_ClearsOpenToolCalls(t *testing.T) {
+	// Pre-rotation: three calls left open — one ordinary, two that survive a
+	// turn_done sweep (so the sweep can't be what rescues us).
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"tool_use": "T1", "name": "Bash"},
+		{"tool_use": "T2", "name": "AskUserQuestion"},
+		{"tool_use": "T3", "name": "Agent"},
+	})
+	tl := NewTranscriptTailer(path, &openToolParser{}, "test-adapter")
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("first TailAndProcess: %v", err)
+	}
+	if m.OpenToolCallCount != 3 {
+		t.Fatalf("pre-rotation OpenToolCallCount = %d, want 3 (test setup)", m.OpenToolCallCount)
+	}
+
+	// Rotate: a strictly smaller file whose content shares no tool id with the
+	// previous one — a fresh session, exactly what the prior file's open calls
+	// must not survive into.
+	if err := os.WriteFile(path, []byte(`{"tool_use":"NEW1","name":"Read"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err = tl.TailAndProcess()
+	if err != nil {
+		t.Fatalf("second (rotated) TailAndProcess: %v", err)
+	}
+	if m.OpenToolCallCount != 1 {
+		t.Errorf("post-rotation OpenToolCallCount = %d, want 1 (only the rotated file's NEW1); pre-rotation calls leaked", m.OpenToolCallCount)
+	}
+	// The user-visible consequence lives in the domain layer:
+	// SessionMetrics.NeedsUserAttention reads LastOpenToolNames and pins the
+	// session to `waiting` when a user-blocking tool is open. A leaked
+	// AskUserQuestion would therefore strand the session forever, so assert
+	// the exact surviving name set, not just the count.
+	got := append([]string(nil), m.LastOpenToolNames...)
+	sort.Strings(got)
+	if len(got) != 1 || got[0] != "Read" {
+		t.Errorf("post-rotation LastOpenToolNames = %v, want [Read] — a pre-rotation tool call leaked (AskUserQuestion/Agent survive the turn_done sweep, so nothing else would ever clear them)", got)
+	}
+}
 
 // rotationResetParser is a minimal TranscriptParser that also implements
 // rotationResetter, so tests can observe whether/when the tailer invokes the

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -497,6 +497,20 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 	case fileSize < t.lastOffset:
 		// File rotated/truncated — reset cumulative accumulators to avoid
 		// double-counting tokens from the previous file.
+		//
+		// A shrink also covers Claude Code v2.1.208's transcript prune ("up to
+		// 79x smaller" by dropping superseded file-history backups), which
+		// rebuilds cumulative totals from the surviving lines only. That is
+		// safe because the prune does not touch usage-carrying lines: it
+		// targets the separate top-level `file-history-snapshot` event type,
+		// whose records carry no `usage`, `requestId`, `uuid` or `parentUuid`
+		// at all (0 of 3624 on a real machine) and sit outside the
+		// uuid/parentUuid message chain. Each such record repeats the entire
+		// cumulative trackedFileBackups map, so earlier ones are wholly
+		// superseded — that redundancy is what the prune reclaims. Every one of
+		// 109,248 assistant lines across that same corpus still carried
+		// message.usage under 2.1.210. Re-verify if a future release starts
+		// pruning assistant lines. See issue #1088.
 		startPos = 0
 		t.resetAccumulatorsForRotation()
 	case t.lastOffset > 0:
@@ -581,6 +595,17 @@ func (t *TranscriptTailer) resetAccumulatorsForRotation() {
 	t.tasks = nil
 	t.taskSeq = 0
 	t.pendingTaskCreates = make(map[string]string)
+	// Open tool calls belong to the prior file. Re-reading from byte 0
+	// re-inserts every surviving tool_use by ID (the map is id-keyed, so that
+	// much is idempotent), but a call left open in the *pre*-rotation content
+	// has no surviving line to re-insert or close it — it would linger
+	// forever. sweepOpenToolCallsOnTurnDone only half-heals that: it
+	// deliberately preserves the surviveTurnDone names (Agent,
+	// AskUserQuestion, ExitPlanMode), which are exactly the user-blocking ones
+	// SessionMetrics.NeedsUserAttention reads — so a stale AskUserQuestion
+	// pinned the session to `waiting` indefinitely. Same reasoning as
+	// openBackgroundProcs below (issue #445). See issue #1088.
+	t.openToolCalls = make(map[string]string)
 	// Background-process set belongs to the prior file; drop it so a
 	// rotated/truncated transcript doesn't keep a stale session `working`.
 	// See issue #445.


### PR DESCRIPTION
Closes #1088.

#1088 was a **verification task**, not a bug report: four narrow edges in Claude Code transcript relocation and prune handling that survived assessment as genuinely unverified, none known to be broken. Verdict: **three are not real; one is real and is fixed here.**

The headline relocation finding from the parent issue (#1065) was already solved in #877 — untouched here.

| # | Edge | Verdict | Deliverable |
|---|---|---|---|
| 1 | Delete-then-create ordering during relocation | **Not real** | Lock test + documented evidence |
| 2 | Subagent relocation not detected | **Not real** (unreachable) | Lock test + documented evidence |
| 3 | Prune vs. cumulative totals | **Not real** | Documented evidence |
| 4 | `openToolCalls` missing from rotation reset | **REAL** | **Fixed** + regression test |

---

## Edge 4 — REAL, fixed

`resetAccumulatorsForRotation` cleared every other per-file accumulator but not `openToolCalls`.

Re-reading from byte 0 re-inserts every surviving `tool_use` by id — the map is id-keyed, so that much is idempotent. What it cannot fix is a call left open in the **pre**-rotation content: no surviving line re-inserts or closes it.

The issue assumed `sweepOpenToolCallsOnTurnDone` self-heals this at the next turn end. **It only half-does.** The sweep deliberately preserves the `surviveTurnDone` names (`Agent`, `AskUserQuestion`, `ExitPlanMode`) — which are exactly the user-blocking ones `SessionMetrics.NeedsUserAttention` reads. So a stale `AskUserQuestion` survived every subsequent sweep and **pinned the session to `waiting` indefinitely**.

Same class of bug as #445 (`openBackgroundProcs` keeping a session `working` after a rotation), same one-line fix.

Measured on main, pre-fix — three calls open, then a rotation to a file sharing no tool id:

```
PRE-rotation : OpenToolCallCount=3  [Bash AskUserQuestion Agent]
POST-rotation: OpenToolCallCount=4  [Bash AskUserQuestion Agent Read]   ← want 1 ([Read])
AFTER turn_done: OpenToolCallCount=2  [AskUserQuestion Agent]           ← leaked forever
```

The fix is safe for the legitimate prune case: the clear is always paired with `startPos = 0` in the same branch, so the full surviving content is re-read and the true open set rebuilt. The test asserts both directions — dead pre-rotation ids dropped, a call surviving *in* the rotated file still open.

## Edge 1 — not real (ordering)

The hazard needs Claude Code to delete the source before writing the destination. It doesn't.

Census of every relocated transcript on a real machine — **50 files, 2104 `relocated` markers, up to 179 moves in one session**:

- `birthtime == the session's first-line timestamp` in **50/50** cases (median delta 0.0s, max 0.3s), while those same files kept growing for up to 28 hours afterwards.
- The inode is preserved across every move ⇒ the transcript is **renamed**, never copied or recreated ⇒ the destination exists at the instant the source stops existing, so the glob cannot miss it.
- Corroborated against a real fswatcher: on a rename the destination's `new_session` events arrive *before* the source's `removed`.

Cross-check that the file really moves: all 50/50 relocated transcripts live in the slug dir implied by their last `relocatedCwd`, and 50/50 carry real conversation history *before* their first `relocated` marker (none is a fresh file).

The destination-absent fallback is graceful anyway — glob returns `""`, session flips ready, next activity event revives it. `TestSessionDetector_Removed_TranscriptGone_FlipsReady` now pins that fallback so it stays deliberate.

`fs_usage`/`dtruss` were **not** needed and not run.

## Edge 2 — not real (unreachable, not merely benign)

Claude Code relocates a parent by renaming the whole `<parent-id>/` subtree — confirmed on disk: **31/31** relocated parents that have a `subagents/` dir have it in the parent's *final* slug, 0 left in a stale slug.

But renaming a directory leaves the child files' vnodes untouched, and fswatcher only emits events for paths ending in `.jsonl` (`watcher.go:303`). Verified against a real fswatcher by renaming a `<pid>/` subtree:

```
EventRemoved for PARENT transcript   = true    ← what #877 handles
EventRemoved for SUBAGENT transcript = false   ← never delivered
+ new_session for the subagent at its NEW path ← dir-create walk re-discovers it
```

So `onRemoved` is **never called** for a relocating subagent; the `Dir(Dir())` limitation is never exercised, and the described failure mode (child flips ready, keeps a dead path until `reapStaleChild`) cannot occur via this path. Also consistent: **0 of 888** subagent transcripts contain a `relocated` record.

`TestRelocatedTranscript` pins the limitation as known-and-benign so the reasoning is discoverable if fswatcher's dir handling ever changes.

## Edge 3 — not real (prune vs. totals)

The crux was what v2.1.208's prune actually removes. It targets the separate top-level `file-history-snapshot` event type, not usage-carrying assistant lines:

- **0 of 3624** `file-history-snapshot` records carry `usage`, `requestId`, `uuid`, or `parentUuid` — they only ever have keys `{type, messageId, snapshot{messageId, trackedFileBackups, timestamp}, isSnapshotUpdate}`, and sit entirely outside the `uuid`/`parentUuid` message chain.
- Each record repeats the **entire cumulative** `trackedFileBackups` map (observed growing 236 B / 0 files → 8234 B / 55 files within one session, each a strict superset of the prior). Earlier records are wholly superseded — that quadratic redundancy is precisely what "pruning superseded file-history backups" reclaims. Backup *contents* aren't inline; they live in `~/.claude/file-history/`.
- **109,248 of 109,248** assistant lines across the whole corpus (1611 transcripts, 823 MB) still carry `message.usage` — 100.000%. The 25 without `requestId` are `<synthetic>` local error messages that never had one.
- Installed version is **2.1.210**, so the prune code is live; 138 transcripts were written under 2.1.209/2.1.210 and show perfect usage retention. 0 dangling `parentUuid` refs across 3037 uuid-bearing lines in the 25 newest.

Cumulative cost/token totals cannot regress from this prune. Documented at the shrink-detection site with a re-verify trigger if a future release starts pruning assistant lines.

**Residual caveat, stated honestly:** no *direct* observation of a prune event was found on disk (the corpus shows no retroactive rewrite; the prune appears to act at write time). The verdict rests on structural evidence — a record type incapable of carrying `usage` — plus 100% usage integrity. That is strong, but it is inference from structure rather than a captured before/after diff.

---

## Verification

- `go test ./core/... -race -count=1` → **exit 0**, 46 packages ok
- `tools/replay-fixtures.sh` → **exit 0**
- `tools/preflight.sh` → green (see PR checks)
- `gofmt -l core/` clean, `go vet` clean

**Failed-on-main confirmation:** `TestResetAccumulatorsForRotation_ClearsOpenToolCalls` fails without the fix (`OpenToolCallCount = 4`, `LastOpenToolNames = [Agent AskUserQuestion Bash Read]`) and passes with it. The two lock tests pass on main by construction — that is the point of a lock, not a defect reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
