### PR TITLE
fix(tailer): detect in-place transcript rewrites, not just shrinks

### DIFF
--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -442,9 +442,11 @@ type queuedTurnSplitter interface {
 // holds session-scoped accumulated state derived from an upstream MONOTONIC
 // counter — one that only ever increases across a session, so the parser
 // tracks its own high-water mark to compute per-turn deltas. When the tailer
-// detects a legitimate rotation/truncation (fileSize < lastOffset) it already
-// zeroes its OWN cumulative accumulators (resetAccumulatorsForRotation) so a
-// replay from byte 0 doesn't double-count; without this hook a parser's own
+// detects a legitimate rotation/truncation (the file shrank below lastOffset,
+// or the consumed bytes ending at lastOffset changed under it — an in-place
+// rewrite, see issue #1104) it already zeroes its OWN cumulative accumulators
+// (resetAccumulatorsForRotation) so a replay from byte 0 doesn't
+// double-count; without this hook a parser's own
 // high-water mark would stay stale, computing deltas against the PREVIOUS
 // file's counters instead of the fresh one's — for a monotonic counter that
 // resets lower after rotation, the delta clamps negative-to-zero and can
@@ -525,8 +527,18 @@ const LedgerSchemaVersion = 5
 // to disk after every TailAndProcess pass so that daemon restarts don't reset
 // cumulative cost to zero for in-flight sessions.
 type LedgerState struct {
-	SchemaVersion      int                        `json:"schema_version"`
-	LastOffset         int64                      `json:"last_offset"`
+	SchemaVersion int   `json:"schema_version"`
+	LastOffset    int64 `json:"last_offset"`
+	// ResumeFingerprint hashes the consumed bytes ending at LastOffset so an
+	// in-place rewrite that lands while the daemon is down is still detected
+	// on the next pass — without it, a restart would trust LastOffset blindly
+	// and resume inside rewritten content. Deliberately added WITHOUT a schema
+	// bump: a pre-#1104 ledger simply lacks the field, and a zero value means
+	// "no fingerprint", which the tailer already reads as "can't tell — resume
+	// at the offset", exactly the pre-#1104 behavior. Discarding every live
+	// session's ledger to force a re-scan would be a far bigger hammer than
+	// this latent gap warrants. See issue #1104.
+	ResumeFingerprint  uint64                     `json:"resume_fingerprint,omitempty"`
 	CumByModel         map[string]*UsageBreakdown `json:"cum_by_model,omitempty"`
 	CumProviderCostUSD float64                    `json:"cum_provider_cost_usd,omitempty"`
 	ParserState        *ParserLedger              `json:"parser_state,omitempty"`

--- a/core/pkg/tailer/rotation_detect.go
+++ b/core/pkg/tailer/rotation_detect.go
@@ -1,0 +1,163 @@
+package tailer
+
+import (
+	"hash/fnv"
+	"io"
+	"time"
+)
+
+// This file owns rotation handling: deciding whether the tailer's resume point
+// is still valid (resolveStartPos and the resume fingerprint below), and
+// clearing the state that belongs to the previous contents once it isn't
+// (resetAccumulatorsForRotation). Its tests live in rotation_reset_test.go.
+
+// resolveStartPos decides where this pass should begin reading, and resets the
+// accumulators as a side effect when the resume point turns out to be invalid.
+//
+// The tailer's resume has exactly one correctness precondition: the bytes below
+// lastOffset are still the bytes it read. fileSize < lastOffset was never a
+// check of that — only a cheap proxy catching the shrink-shaped subset — so it
+// is paired here with a direct check of the precondition (issue #1104).
+func (t *TranscriptTailer) resolveStartPos(r io.ReaderAt, fileSize int64) int64 {
+	switch {
+	case t.lastOffset == 0:
+		// First open (or a resume with no persisted offset): read from the top.
+		return 0
+
+	case fileSize < t.lastOffset || t.resumePrefixChanged(r):
+		// Rotated, truncated, or rewritten in place — the bytes this tailer
+		// already consumed are gone or are no longer the bytes it consumed.
+		// Reset cumulative accumulators and replay from byte 0 so tokens from
+		// the previous contents aren't double-counted.
+		//
+		// The shrink half also covers Claude Code v2.1.208's transcript prune
+		// ("up to 79x smaller" by dropping superseded file-history backups),
+		// which rebuilds cumulative totals from the surviving lines only. That
+		// is safe because the prune does not touch usage-carrying lines: it
+		// targets the separate top-level `file-history-snapshot` event type,
+		// whose records carry no `usage`, `requestId`, `uuid` or `parentUuid`
+		// at all (0 of 3624 on a real machine) and sit outside the
+		// uuid/parentUuid message chain. Each such record repeats the entire
+		// cumulative trackedFileBackups map, so earlier ones are wholly
+		// superseded — that redundancy is what the prune reclaims. Every one of
+		// 109,248 assistant lines across that same corpus still carried
+		// message.usage under 2.1.210. Re-verify if a future release starts
+		// pruning assistant lines. See issue #1088.
+		t.resetAccumulatorsForRotation()
+		return 0
+
+	default:
+		// Normal incremental path: never skip ahead of the last processed byte.
+		return t.lastOffset
+	}
+}
+
+// resumeFingerprintWindow is how many bytes ending at lastOffset are hashed to
+// anchor the resume point — wide enough that any rewrite which SHIFTS content
+// disturbs it, small enough to stay a negligible fixed read on a per-write path.
+//
+// Residual gap: a SIZE-NEUTRAL edit further back than this window leaves the
+// window byte-identical, so it still resumes incrementally over stale
+// accumulators. Closing it needs a rolling hash of the whole consumed prefix —
+// O(filesize) per pass, which this path cannot afford. Left open because every
+// rewrite shape observed in-tree either shrinks the file (claudecode's rewind)
+// or changes an edited message's length (vibe's _overwrite_messages_sync), and
+// both are caught.
+const resumeFingerprintWindow = 512
+
+// resumePrefixChanged reports whether the already-consumed bytes ending at
+// lastOffset differ from what this tailer actually consumed — i.e. the
+// transcript was rewritten in place rather than appended to. It is the half of
+// rotation detection that a size check cannot cover: a rewrite whose new size
+// is >= lastOffset leaves the size test happy while the offset now points into
+// unrelated content, so the tailer would resume mid-record and keep
+// accumulating on top of pre-rewrite state (issue #1104).
+//
+// An append never rewrites bytes below lastOffset, so a matching window means
+// a genuine append. Every uncertain case — no anchor yet, a pre-#1104 ledger,
+// an unreadable window — reports false, keeping the historical
+// resume-at-offset behavior rather than forcing a re-read.
+func (t *TranscriptTailer) resumePrefixChanged(r io.ReaderAt) bool {
+	if t.resumeFingerprint == 0 {
+		return false
+	}
+	fp := fingerprintEndingAt(r, t.lastOffset)
+	return fp != 0 && fp != t.resumeFingerprint
+}
+
+// captureResumeFingerprint anchors the rewrite detector at the current
+// lastOffset. A window that can't be read leaves the tailer unanchored, which
+// resumePrefixChanged reads as "can't tell".
+func (t *TranscriptTailer) captureResumeFingerprint(r io.ReaderAt) {
+	t.resumeFingerprint = fingerprintEndingAt(r, t.lastOffset)
+}
+
+// fingerprintEndingAt hashes the up-to-resumeFingerprintWindow bytes ending at
+// off, returning 0 ("unknown") when there is nothing to hash (off <= 0) or the
+// read fails. FNV-1a is chosen over a cryptographic hash deliberately: this
+// detects an accidental rewrite by a cooperating agent, not a forged collision.
+func fingerprintEndingAt(r io.ReaderAt, off int64) uint64 {
+	if off <= 0 {
+		return 0
+	}
+	n := min(off, int64(resumeFingerprintWindow))
+	buf := make([]byte, n)
+	if _, err := r.ReadAt(buf, off-n); err != nil {
+		return 0
+	}
+	h := fnv.New64a()
+	h.Write(buf) // hash.Hash.Write never returns an error
+	return h.Sum64()
+}
+
+// resetAccumulatorsForRotation clears every accumulator that belongs to the
+// previous transcript file's contents. TailAndProcess calls this when it
+// detects that the consumed bytes are gone or changed — the transcript was
+// rotated, truncated, or rewritten in place — so replaying from byte 0 doesn't
+// double-count tokens, resurrect stale background processes, or misattribute
+// the previous file's tasks.
+//
+// This only resets the TAILER's own accumulators. A parser that tracks its
+// own session-scoped state derived from an upstream monotonic counter (e.g.
+// Mistral Vibe's token high-water mark, issue #1063) must reset that state
+// too, or its next delta computation will be measured against the stale
+// pre-rotation value. See the rotationResetter optional interface.
+func (t *TranscriptTailer) resetAccumulatorsForRotation() {
+	if resetter, ok := t.parser.(rotationResetter); ok {
+		resetter.ResetForRotation()
+	}
+	t.cumInputTokens = 0
+	t.cumOutputTokens = 0
+	t.cumCacheReadTokens = 0
+	t.cumCacheCreationTokens = 0
+	t.lastRequestID = ""
+	t.pendingSnapshot = nil
+	t.cumByModel = make(map[string]*UsageBreakdown)
+	t.cumProviderCostUSD = 0
+	t.tasks = nil
+	t.taskSeq = 0
+	t.pendingTaskCreates = make(map[string]string)
+	// Open tool calls belong to the prior file. Re-reading from byte 0
+	// re-inserts every surviving tool_use by ID (the map is id-keyed, so that
+	// much is idempotent), but a call left open in the *pre*-rotation content
+	// has no surviving line to re-insert or close it — it would linger
+	// forever. sweepOpenToolCallsOnTurnDone only half-heals that: it
+	// deliberately preserves the surviveTurnDone names (Agent,
+	// AskUserQuestion, ExitPlanMode), which are exactly the user-blocking ones
+	// SessionMetrics.NeedsUserAttention reads — so a stale AskUserQuestion
+	// pinned the session to `waiting` indefinitely. Same reasoning as
+	// openBackgroundProcs below (issue #445). See issue #1088.
+	t.openToolCalls = make(map[string]string)
+	// Background-process set belongs to the prior file; drop it so a
+	// rotated/truncated transcript doesn't keep a stale session `working`.
+	// See issue #445.
+	t.openBackgroundProcs = make(map[string]string)
+	t.pendingBashPolls = make(map[string]string)
+	// Drop the pre-rotation idle anchor so the post-scan idleFlusher
+	// hook doesn't synthesize a phantom turn_done against stale time.
+	t.lastLineSeenAt = time.Time{}
+	// The resume anchor describes the previous contents, so it is meaningless
+	// now. Clearing it also keeps TailAndProcess's skip-the-re-anchor guard
+	// honest: a rotated pass always re-anchors, because unknown forces it to.
+	t.resumeFingerprint = 0
+}

--- a/core/pkg/tailer/rotation_reset_test.go
+++ b/core/pkg/tailer/rotation_reset_test.go
@@ -81,12 +81,16 @@ func TestResetAccumulatorsForRotation_ClearsOpenToolCalls(t *testing.T) {
 
 // rotationResetParser is a minimal TranscriptParser that also implements
 // rotationResetter, so tests can observe whether/when the tailer invokes the
-// hook without depending on any real adapter's parsing logic.
+// hook without depending on any real adapter's parsing logic. parsedLines
+// counts ParseLine calls, which lets a test distinguish a full re-read from
+// byte 0 from a resume at a stale offset.
 type rotationResetParser struct {
-	resetCalls int
+	resetCalls  int
+	parsedLines int
 }
 
 func (p *rotationResetParser) ParseLine(raw map[string]interface{}) *ParsedEvent {
+	p.parsedLines++
 	return &ParsedEvent{Skip: true}
 }
 
@@ -126,6 +130,205 @@ func TestResetAccumulatorsForRotation_InvokesParserHook(t *testing.T) {
 	}
 	if p.resetCalls != 1 {
 		t.Fatalf("resetCalls = %d after a rotated pass, want 1", p.resetCalls)
+	}
+}
+
+// TestTailAndProcess_InPlaceRewriteWithGrowthIsRotation is the regression test
+// for issue #1104. The tailer used to detect rotation ONLY by the file
+// shrinking (fileSize < lastOffset). An in-place rewrite whose new size is
+// >= lastOffset slipped through: the tailer seeked to a stale byte offset
+// inside content that had since changed, resumed mid-record, and kept
+// accumulating on top of pre-rewrite state — silently wrong tokens/cost and
+// missed messages, the same failure class #1063/#1078 fixed for the shrink
+// path.
+//
+// The rewrite here both changes the already-consumed bytes AND grows the file,
+// which is the exact shape that escaped detection (vibe's fingerprint-mismatch
+// rewrite; a truncate-then-append coalesced into one debounced pass).
+func TestTailAndProcess_InPlaceRewriteWithGrowthIsRotation(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"line": 1},
+		{"line": 2},
+		{"line": 3},
+	})
+	p := &rotationResetParser{}
+	tl := NewTranscriptTailer(path, p, "test-adapter")
+
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("first TailAndProcess: %v", err)
+	}
+	consumed := tl.lastOffset
+	p.parsedLines = 0
+
+	// Rewrite in place: different content in the already-consumed region, and
+	// a net-larger file, so the historical fileSize < lastOffset test cannot
+	// see it.
+	rewritten := []byte(`{"line":11}` + "\n" + `{"line":22}` + "\n" + `{"line":33}` + "\n" + `{"line":44}` + "\n")
+	if err := os.WriteFile(path, rewritten, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(rewritten)) < consumed {
+		t.Fatalf("test setup is wrong: rewritten file (%d bytes) is smaller than the consumed offset (%d) — "+
+			"the shrink check would catch it and the #1104 gap wouldn't be exercised", len(rewritten), consumed)
+	}
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("second (rewritten) TailAndProcess: %v", err)
+	}
+
+	if p.resetCalls != 1 {
+		t.Errorf("resetCalls = %d after an in-place rewrite that grew the file, want 1: "+
+			"the rewrite went undetected and stale accumulators carried over", p.resetCalls)
+	}
+	if p.parsedLines != 4 {
+		t.Errorf("parsedLines = %d on the pass after the rewrite, want 4 (a full re-read from byte 0): "+
+			"the tailer resumed at the stale offset %d and read only part of the rewritten file", p.parsedLines, consumed)
+	}
+}
+
+// TestTailAndProcess_AppendIsNotRotation pins the other side of issue #1104's
+// resume check: an ordinary append must stay on the cheap incremental path.
+// Detecting a rewrite by re-hashing the consumed bytes is only sound because an
+// append never rewrites bytes below lastOffset — a false positive here would
+// re-read and re-reset the world on every single transcript write.
+func TestTailAndProcess_AppendIsNotRotation(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"line": 1},
+		{"line": 2},
+	})
+	p := &rotationResetParser{}
+	tl := NewTranscriptTailer(path, p, "test-adapter")
+
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("first TailAndProcess: %v", err)
+	}
+	p.parsedLines = 0
+
+	appendTranscriptLine(t, path, map[string]interface{}{"line": 3})
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("second (appended) TailAndProcess: %v", err)
+	}
+
+	if p.resetCalls != 0 {
+		t.Errorf("resetCalls = %d after a plain append, want 0 (an append is not a rotation)", p.resetCalls)
+	}
+	if p.parsedLines != 1 {
+		t.Errorf("parsedLines = %d after a plain append, want 1 (only the appended line): "+
+			"the tailer re-read content it had already consumed", p.parsedLines)
+	}
+}
+
+// TestTailAndProcess_IdenticalRewriteIsNotRotation pins the benign case issue
+// #1104 called out explicitly: a rewrite that reproduces the same bytes (a
+// legacy no-fingerprint full rewrite of unchanged content) leaves the consumed
+// prefix intact, so there is nothing to re-read and no reason to reset.
+func TestTailAndProcess_IdenticalRewriteIsNotRotation(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"line": 1},
+		{"line": 2},
+	})
+	p := &rotationResetParser{}
+	tl := NewTranscriptTailer(path, p, "test-adapter")
+
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("first TailAndProcess: %v", err)
+	}
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.parsedLines = 0
+
+	// Same path, same bytes, new write.
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("second (identical rewrite) TailAndProcess: %v", err)
+	}
+
+	if p.resetCalls != 0 {
+		t.Errorf("resetCalls = %d after a byte-identical rewrite, want 0 (content never changed)", p.resetCalls)
+	}
+	if p.parsedLines != 0 {
+		t.Errorf("parsedLines = %d after a byte-identical rewrite, want 0 (offset already at EOF)", p.parsedLines)
+	}
+}
+
+// TestSetLedgerState_DetectsRewriteAcrossRestart pins that the resume
+// fingerprint survives a daemon restart (issue #1104). The ledger persists
+// lastOffset, so without a persisted fingerprint a rewrite landing while the
+// daemon is DOWN would be trusted blindly on the next boot — the restart is
+// precisely when the tailer has no in-memory memory of what it consumed.
+func TestSetLedgerState_DetectsRewriteAcrossRestart(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"line": 1},
+		{"line": 2},
+		{"line": 3},
+	})
+	before := NewTranscriptTailer(path, &rotationResetParser{}, "test-adapter")
+	if _, err := before.TailAndProcess(); err != nil {
+		t.Fatalf("pre-restart TailAndProcess: %v", err)
+	}
+	ledger := before.GetLedgerState()
+	if ledger.ResumeFingerprint == 0 {
+		t.Fatalf("ledger carries no ResumeFingerprint after a pass that consumed %d bytes; "+
+			"a restart would have nothing to validate the offset against", ledger.LastOffset)
+	}
+
+	// The transcript is rewritten in place (bigger, different) while "down".
+	if err := os.WriteFile(path, []byte(`{"line":11}`+"\n"+`{"line":22}`+"\n"+`{"line":33}`+"\n"+`{"line":44}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := &rotationResetParser{}
+	after := NewTranscriptTailer(path, p, "test-adapter")
+	after.SetLedgerState(ledger)
+	if _, err := after.TailAndProcess(); err != nil {
+		t.Fatalf("post-restart TailAndProcess: %v", err)
+	}
+
+	if p.resetCalls != 1 {
+		t.Errorf("resetCalls = %d on the first post-restart pass, want 1: the rehydrated offset was "+
+			"trusted even though the file had been rewritten underneath it", p.resetCalls)
+	}
+	if p.parsedLines != 4 {
+		t.Errorf("parsedLines = %d on the first post-restart pass, want 4 (a full re-read from byte 0)", p.parsedLines)
+	}
+}
+
+// TestSetLedgerState_PreFingerprintLedgerResumesAtOffset pins the backward
+// compatibility that let #1104's fingerprint land WITHOUT a LedgerSchemaVersion
+// bump: a ledger written before the field existed carries an offset and no
+// fingerprint, and must resume exactly as it always did rather than being
+// treated as a rewrite. Bumping the schema instead would discard every live
+// session's accumulated cost to re-scan for a latent gap.
+func TestSetLedgerState_PreFingerprintLedgerResumesAtOffset(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"line": 1},
+		{"line": 2},
+	})
+	seed := NewTranscriptTailer(path, &rotationResetParser{}, "test-adapter")
+	if _, err := seed.TailAndProcess(); err != nil {
+		t.Fatalf("seed TailAndProcess: %v", err)
+	}
+
+	// A pre-#1104 ledger: offset only, no fingerprint.
+	legacy := LedgerState{SchemaVersion: LedgerSchemaVersion, LastOffset: seed.lastOffset}
+
+	p := &rotationResetParser{}
+	tl := NewTranscriptTailer(path, p, "test-adapter")
+	tl.SetLedgerState(legacy)
+	appendTranscriptLine(t, path, map[string]interface{}{"line": 3})
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatalf("TailAndProcess on a legacy ledger: %v", err)
+	}
+
+	if p.resetCalls != 0 {
+		t.Errorf("resetCalls = %d resuming a pre-#1104 ledger, want 0: a missing fingerprint means "+
+			"'can't tell', which must fall back to trusting the offset, not to a spurious rotation", p.resetCalls)
+	}
+	if p.parsedLines != 1 {
+		t.Errorf("parsedLines = %d resuming a pre-#1104 ledger, want 1 (only the newly appended line)", p.parsedLines)
 	}
 }
 

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"log"
 	"os"
@@ -431,6 +432,16 @@ type TranscriptTailer struct {
 	// statusline events repopulate the history before forecasting resumes.
 	rateLimit        *RateLimitSnapshot
 	rateLimitHistory []RateLimitSnapshot
+
+	// resumeFingerprint hashes the bytes immediately preceding lastOffset —
+	// the tail of the content this tailer has already consumed. Re-hashing
+	// that window on the next pass is what lets the tailer notice an in-place
+	// rewrite whose new size is >= lastOffset, which the size-shrink check
+	// alone cannot see. hasResumeFingerprint distinguishes "window hashed to
+	// zero" from "never computed" (a pre-#1104 ledger, where the only safe
+	// read is the historical one: trust the offset). See issue #1104.
+	resumeFingerprint    uint64
+	hasResumeFingerprint bool
 }
 
 // rateLimitHistoryCap caps the rolling history at a small number of changed
@@ -495,14 +506,18 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 
 	startPos := int64(0)
 	switch {
-	case fileSize < t.lastOffset:
-		// File rotated/truncated — reset cumulative accumulators to avoid
-		// double-counting tokens from the previous file.
+	case t.lastOffset == 0:
+		// First open (or a resume with no persisted offset): read from the top.
+	case fileSize < t.lastOffset || t.resumePrefixChanged(file):
+		// Rotated, truncated, or rewritten in place — the bytes this tailer
+		// already consumed are gone or are no longer the bytes it consumed.
+		// Reset cumulative accumulators and replay from byte 0 so tokens from
+		// the previous contents aren't double-counted.
 		//
-		// A shrink also covers Claude Code v2.1.208's transcript prune ("up to
-		// 79x smaller" by dropping superseded file-history backups), which
-		// rebuilds cumulative totals from the surviving lines only. That is
-		// safe because the prune does not touch usage-carrying lines: it
+		// The shrink half also covers Claude Code v2.1.208's transcript prune
+		// ("up to 79x smaller" by dropping superseded file-history backups),
+		// which rebuilds cumulative totals from the surviving lines only. That
+		// is safe because the prune does not touch usage-carrying lines: it
 		// targets the separate top-level `file-history-snapshot` event type,
 		// whose records carry no `usage`, `requestId`, `uuid` or `parentUuid`
 		// at all (0 of 3624 on a real machine) and sit outside the
@@ -514,7 +529,7 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 		// pruning assistant lines. See issue #1088.
 		startPos = 0
 		t.resetAccumulatorsForRotation()
-	case t.lastOffset > 0:
+	default:
 		// Normal incremental path: never skip ahead of the last processed byte.
 		startPos = t.lastOffset
 	}
@@ -529,6 +544,10 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 	reader := bufio.NewReaderSize(file, 64*1024)
 	scan := t.scanNewLines(reader, startPos)
 	t.lastOffset = scan.endOffset
+	// Re-anchor the rewrite detector at the new resume point. Safe to read
+	// after the scan even against a live writer: an append only adds bytes at
+	// or beyond lastOffset, so the window ending at lastOffset is stable.
+	t.captureResumeFingerprint(file)
 
 	// Idle-flush hook: parsers whose transcript has no in-band end-of-turn
 	// marker (currently aider) synthesize turn_done when the file has been
@@ -570,11 +589,65 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 	return t.metrics, scan.err
 }
 
+// resumeFingerprintWindow is how many bytes ending at lastOffset are hashed to
+// anchor the resume point. It only has to be wide enough that a rewrite is
+// overwhelmingly likely to disturb it — well over a typical JSONL record, so a
+// rewrite that shifts content by even one byte changes the window — while
+// staying a fixed, negligible read on a path that runs per transcript write
+// plus once every 5s per active session.
+const resumeFingerprintWindow = 512
+
+// resumePrefixChanged reports whether the already-consumed bytes ending at
+// lastOffset differ from what this tailer actually consumed — i.e. the
+// transcript was rewritten in place rather than appended to. It is the half of
+// rotation detection that a size check cannot cover: a rewrite whose new size
+// is >= lastOffset leaves the size test happy while the offset now points into
+// unrelated content, so the tailer would resume mid-record and keep
+// accumulating on top of pre-rewrite state (issue #1104).
+//
+// An append never rewrites bytes below lastOffset, so a matching window means
+// a genuine append. Both uncertain cases — a pre-#1104 ledger that carries an
+// offset but no fingerprint, and an unreadable window — return false, keeping
+// the historical resume-at-offset behavior rather than forcing a re-read.
+func (t *TranscriptTailer) resumePrefixChanged(r io.ReaderAt) bool {
+	if !t.hasResumeFingerprint {
+		return false
+	}
+	fp, ok := fingerprintEndingAt(r, t.lastOffset)
+	return ok && fp != t.resumeFingerprint
+}
+
+// captureResumeFingerprint anchors the rewrite detector at the current
+// lastOffset. A window that can't be read leaves the tailer with no
+// fingerprint, which resumePrefixChanged reads as "can't tell".
+func (t *TranscriptTailer) captureResumeFingerprint(r io.ReaderAt) {
+	t.resumeFingerprint, t.hasResumeFingerprint = fingerprintEndingAt(r, t.lastOffset)
+}
+
+// fingerprintEndingAt hashes the up-to-resumeFingerprintWindow bytes ending at
+// off, reporting false when there is nothing to hash (off <= 0) or the read
+// fails. FNV-1a is chosen over a cryptographic hash deliberately: this detects
+// an accidental rewrite by a cooperating agent, not a forged collision.
+func fingerprintEndingAt(r io.ReaderAt, off int64) (uint64, bool) {
+	if off <= 0 {
+		return 0, false
+	}
+	n := min(off, int64(resumeFingerprintWindow))
+	buf := make([]byte, n)
+	if _, err := r.ReadAt(buf, off-n); err != nil {
+		return 0, false
+	}
+	h := fnv.New64a()
+	h.Write(buf) // hash.Hash.Write never returns an error
+	return h.Sum64(), true
+}
+
 // resetAccumulatorsForRotation clears every accumulator that belongs to the
 // previous transcript file's contents. TailAndProcess calls this when it
-// detects fileSize < lastOffset — the transcript was rotated or truncated —
-// so replaying from byte 0 doesn't double-count tokens, resurrect stale
-// background processes, or misattribute the previous file's tasks.
+// detects that the consumed bytes are gone or changed — the transcript was
+// rotated, truncated, or rewritten in place — so replaying from byte 0 doesn't
+// double-count tokens, resurrect stale background processes, or misattribute
+// the previous file's tasks.
 //
 // This only resets the TAILER's own accumulators. A parser that tracks its
 // own session-scoped state derived from an upstream monotonic counter (e.g.

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash/fnv"
 	"io"
 	"log"
 	"os"
@@ -509,35 +508,9 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 	t.metrics.SubagentCompletions = nil
 	t.metrics.AppliedTaskDeltas = nil
 
-	startPos := int64(0)
-	switch {
-	case t.lastOffset == 0:
-		// First open (or a resume with no persisted offset): read from the top.
-	case fileSize < t.lastOffset || t.resumePrefixChanged(file):
-		// Rotated, truncated, or rewritten in place — the bytes this tailer
-		// already consumed are gone or are no longer the bytes it consumed.
-		// Reset cumulative accumulators and replay from byte 0 so tokens from
-		// the previous contents aren't double-counted.
-		//
-		// The shrink half also covers Claude Code v2.1.208's transcript prune
-		// ("up to 79x smaller" by dropping superseded file-history backups),
-		// which rebuilds cumulative totals from the surviving lines only. That
-		// is safe because the prune does not touch usage-carrying lines: it
-		// targets the separate top-level `file-history-snapshot` event type,
-		// whose records carry no `usage`, `requestId`, `uuid` or `parentUuid`
-		// at all (0 of 3624 on a real machine) and sit outside the
-		// uuid/parentUuid message chain. Each such record repeats the entire
-		// cumulative trackedFileBackups map, so earlier ones are wholly
-		// superseded — that redundancy is what the prune reclaims. Every one of
-		// 109,248 assistant lines across that same corpus still carried
-		// message.usage under 2.1.210. Re-verify if a future release starts
-		// pruning assistant lines. See issue #1088.
-		startPos = 0
-		t.resetAccumulatorsForRotation()
-	default:
-		// Normal incremental path: never skip ahead of the last processed byte.
-		startPos = t.lastOffset
-	}
+	// Where to resume, and whether the previous contents' accumulators survive
+	// this pass. See rotation_detect.go.
+	startPos := t.resolveStartPos(file, fileSize)
 
 	if _, err := file.Seek(startPos, io.SeekStart); err != nil {
 		return nil, fmt.Errorf("failed to seek transcript: %w", err)
@@ -599,116 +572,6 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 	t.computeContextUtilization()
 
 	return t.metrics, scan.err
-}
-
-// resumeFingerprintWindow is how many bytes ending at lastOffset are hashed to
-// anchor the resume point — wide enough that any rewrite which SHIFTS content
-// disturbs it, small enough to stay a negligible fixed read on a per-write path.
-//
-// Residual gap: a SIZE-NEUTRAL edit further back than this window leaves the
-// window byte-identical, so it still resumes incrementally over stale
-// accumulators. Closing it needs a rolling hash of the whole consumed prefix —
-// O(filesize) per pass, which this path cannot afford. Left open because every
-// rewrite shape observed in-tree either shrinks the file (claudecode's rewind)
-// or changes an edited message's length (vibe's _overwrite_messages_sync), and
-// both are caught.
-const resumeFingerprintWindow = 512
-
-// resumePrefixChanged reports whether the already-consumed bytes ending at
-// lastOffset differ from what this tailer actually consumed — i.e. the
-// transcript was rewritten in place rather than appended to. It is the half of
-// rotation detection that a size check cannot cover: a rewrite whose new size
-// is >= lastOffset leaves the size test happy while the offset now points into
-// unrelated content, so the tailer would resume mid-record and keep
-// accumulating on top of pre-rewrite state (issue #1104).
-//
-// An append never rewrites bytes below lastOffset, so a matching window means
-// a genuine append. Every uncertain case — no anchor yet, a pre-#1104 ledger,
-// an unreadable window — reports false, keeping the historical
-// resume-at-offset behavior rather than forcing a re-read.
-func (t *TranscriptTailer) resumePrefixChanged(r io.ReaderAt) bool {
-	if t.resumeFingerprint == 0 {
-		return false
-	}
-	fp := fingerprintEndingAt(r, t.lastOffset)
-	return fp != 0 && fp != t.resumeFingerprint
-}
-
-// captureResumeFingerprint anchors the rewrite detector at the current
-// lastOffset. A window that can't be read leaves the tailer unanchored, which
-// resumePrefixChanged reads as "can't tell".
-func (t *TranscriptTailer) captureResumeFingerprint(r io.ReaderAt) {
-	t.resumeFingerprint = fingerprintEndingAt(r, t.lastOffset)
-}
-
-// fingerprintEndingAt hashes the up-to-resumeFingerprintWindow bytes ending at
-// off, returning 0 ("unknown") when there is nothing to hash (off <= 0) or the
-// read fails. FNV-1a is chosen over a cryptographic hash deliberately: this
-// detects an accidental rewrite by a cooperating agent, not a forged collision.
-func fingerprintEndingAt(r io.ReaderAt, off int64) uint64 {
-	if off <= 0 {
-		return 0
-	}
-	n := min(off, int64(resumeFingerprintWindow))
-	buf := make([]byte, n)
-	if _, err := r.ReadAt(buf, off-n); err != nil {
-		return 0
-	}
-	h := fnv.New64a()
-	h.Write(buf) // hash.Hash.Write never returns an error
-	return h.Sum64()
-}
-
-// resetAccumulatorsForRotation clears every accumulator that belongs to the
-// previous transcript file's contents. TailAndProcess calls this when it
-// detects that the consumed bytes are gone or changed — the transcript was
-// rotated, truncated, or rewritten in place — so replaying from byte 0 doesn't
-// double-count tokens, resurrect stale background processes, or misattribute
-// the previous file's tasks.
-//
-// This only resets the TAILER's own accumulators. A parser that tracks its
-// own session-scoped state derived from an upstream monotonic counter (e.g.
-// Mistral Vibe's token high-water mark, issue #1063) must reset that state
-// too, or its next delta computation will be measured against the stale
-// pre-rotation value. See the rotationResetter optional interface.
-func (t *TranscriptTailer) resetAccumulatorsForRotation() {
-	if resetter, ok := t.parser.(rotationResetter); ok {
-		resetter.ResetForRotation()
-	}
-	t.cumInputTokens = 0
-	t.cumOutputTokens = 0
-	t.cumCacheReadTokens = 0
-	t.cumCacheCreationTokens = 0
-	t.lastRequestID = ""
-	t.pendingSnapshot = nil
-	t.cumByModel = make(map[string]*UsageBreakdown)
-	t.cumProviderCostUSD = 0
-	t.tasks = nil
-	t.taskSeq = 0
-	t.pendingTaskCreates = make(map[string]string)
-	// Open tool calls belong to the prior file. Re-reading from byte 0
-	// re-inserts every surviving tool_use by ID (the map is id-keyed, so that
-	// much is idempotent), but a call left open in the *pre*-rotation content
-	// has no surviving line to re-insert or close it — it would linger
-	// forever. sweepOpenToolCallsOnTurnDone only half-heals that: it
-	// deliberately preserves the surviveTurnDone names (Agent,
-	// AskUserQuestion, ExitPlanMode), which are exactly the user-blocking ones
-	// SessionMetrics.NeedsUserAttention reads — so a stale AskUserQuestion
-	// pinned the session to `waiting` indefinitely. Same reasoning as
-	// openBackgroundProcs below (issue #445). See issue #1088.
-	t.openToolCalls = make(map[string]string)
-	// Background-process set belongs to the prior file; drop it so a
-	// rotated/truncated transcript doesn't keep a stale session `working`.
-	// See issue #445.
-	t.openBackgroundProcs = make(map[string]string)
-	t.pendingBashPolls = make(map[string]string)
-	// Drop the pre-rotation idle anchor so the post-scan idleFlusher
-	// hook doesn't synthesize a phantom turn_done against stale time.
-	t.lastLineSeenAt = time.Time{}
-	// The resume anchor describes the previous contents, so it is meaningless
-	// now. Clearing it also keeps TailAndProcess's skip-the-re-anchor guard
-	// honest: a rotated pass always re-anchors, because unknown forces it to.
-	t.resumeFingerprint = 0
 }
 
 // transcriptScanResult carries the outcomes of one scanNewLines pass: how far

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -437,11 +437,16 @@ type TranscriptTailer struct {
 	// the tail of the content this tailer has already consumed. Re-hashing
 	// that window on the next pass is what lets the tailer notice an in-place
 	// rewrite whose new size is >= lastOffset, which the size-shrink check
-	// alone cannot see. hasResumeFingerprint distinguishes "window hashed to
-	// zero" from "never computed" (a pre-#1104 ledger, where the only safe
-	// read is the historical one: trust the offset). See issue #1104.
-	resumeFingerprint    uint64
-	hasResumeFingerprint bool
+	// alone cannot see. See issue #1104.
+	//
+	// Zero means "unknown": no pass has anchored it yet, the window was
+	// unreadable, or the ledger predates #1104. Every such case resumes at
+	// lastOffset exactly as the tailer always has. A window that genuinely
+	// hashes to zero (1-in-2^64) reads as unknown too and costs a single pass
+	// of that same pre-#1104 behavior — cheaper than a second field to tell
+	// the two apart, especially since the ledger would have to collapse them
+	// back into one number anyway.
+	resumeFingerprint uint64
 }
 
 // rateLimitHistoryCap caps the rolling history at a small number of changed
@@ -547,7 +552,14 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 	// Re-anchor the rewrite detector at the new resume point. Safe to read
 	// after the scan even against a live writer: an append only adds bytes at
 	// or beyond lastOffset, so the window ending at lastOffset is stable.
-	t.captureResumeFingerprint(file)
+	//
+	// Skipped when the scan advanced nothing and we already hold an anchor —
+	// the window is then the very one resumePrefixChanged just verified, so
+	// re-reading it would recompute a value already in hand. That is the
+	// common case: the unconditional 5s sweep over an idle session.
+	if scan.endOffset != startPos || t.resumeFingerprint == 0 {
+		t.captureResumeFingerprint(file)
+	}
 
 	// Idle-flush hook: parsers whose transcript has no in-band end-of-turn
 	// marker (currently aider) synthesize turn_done when the file has been
@@ -590,11 +602,16 @@ func (t *TranscriptTailer) TailAndProcess() (*SessionMetrics, error) {
 }
 
 // resumeFingerprintWindow is how many bytes ending at lastOffset are hashed to
-// anchor the resume point. It only has to be wide enough that a rewrite is
-// overwhelmingly likely to disturb it — well over a typical JSONL record, so a
-// rewrite that shifts content by even one byte changes the window — while
-// staying a fixed, negligible read on a path that runs per transcript write
-// plus once every 5s per active session.
+// anchor the resume point — wide enough that any rewrite which SHIFTS content
+// disturbs it, small enough to stay a negligible fixed read on a per-write path.
+//
+// Residual gap: a SIZE-NEUTRAL edit further back than this window leaves the
+// window byte-identical, so it still resumes incrementally over stale
+// accumulators. Closing it needs a rolling hash of the whole consumed prefix —
+// O(filesize) per pass, which this path cannot afford. Left open because every
+// rewrite shape observed in-tree either shrinks the file (claudecode's rewind)
+// or changes an edited message's length (vibe's _overwrite_messages_sync), and
+// both are caught.
 const resumeFingerprintWindow = 512
 
 // resumePrefixChanged reports whether the already-consumed bytes ending at
@@ -606,40 +623,40 @@ const resumeFingerprintWindow = 512
 // accumulating on top of pre-rewrite state (issue #1104).
 //
 // An append never rewrites bytes below lastOffset, so a matching window means
-// a genuine append. Both uncertain cases — a pre-#1104 ledger that carries an
-// offset but no fingerprint, and an unreadable window — return false, keeping
-// the historical resume-at-offset behavior rather than forcing a re-read.
+// a genuine append. Every uncertain case — no anchor yet, a pre-#1104 ledger,
+// an unreadable window — reports false, keeping the historical
+// resume-at-offset behavior rather than forcing a re-read.
 func (t *TranscriptTailer) resumePrefixChanged(r io.ReaderAt) bool {
-	if !t.hasResumeFingerprint {
+	if t.resumeFingerprint == 0 {
 		return false
 	}
-	fp, ok := fingerprintEndingAt(r, t.lastOffset)
-	return ok && fp != t.resumeFingerprint
+	fp := fingerprintEndingAt(r, t.lastOffset)
+	return fp != 0 && fp != t.resumeFingerprint
 }
 
 // captureResumeFingerprint anchors the rewrite detector at the current
-// lastOffset. A window that can't be read leaves the tailer with no
-// fingerprint, which resumePrefixChanged reads as "can't tell".
+// lastOffset. A window that can't be read leaves the tailer unanchored, which
+// resumePrefixChanged reads as "can't tell".
 func (t *TranscriptTailer) captureResumeFingerprint(r io.ReaderAt) {
-	t.resumeFingerprint, t.hasResumeFingerprint = fingerprintEndingAt(r, t.lastOffset)
+	t.resumeFingerprint = fingerprintEndingAt(r, t.lastOffset)
 }
 
 // fingerprintEndingAt hashes the up-to-resumeFingerprintWindow bytes ending at
-// off, reporting false when there is nothing to hash (off <= 0) or the read
-// fails. FNV-1a is chosen over a cryptographic hash deliberately: this detects
-// an accidental rewrite by a cooperating agent, not a forged collision.
-func fingerprintEndingAt(r io.ReaderAt, off int64) (uint64, bool) {
+// off, returning 0 ("unknown") when there is nothing to hash (off <= 0) or the
+// read fails. FNV-1a is chosen over a cryptographic hash deliberately: this
+// detects an accidental rewrite by a cooperating agent, not a forged collision.
+func fingerprintEndingAt(r io.ReaderAt, off int64) uint64 {
 	if off <= 0 {
-		return 0, false
+		return 0
 	}
 	n := min(off, int64(resumeFingerprintWindow))
 	buf := make([]byte, n)
 	if _, err := r.ReadAt(buf, off-n); err != nil {
-		return 0, false
+		return 0
 	}
 	h := fnv.New64a()
 	h.Write(buf) // hash.Hash.Write never returns an error
-	return h.Sum64(), true
+	return h.Sum64()
 }
 
 // resetAccumulatorsForRotation clears every accumulator that belongs to the
@@ -688,6 +705,10 @@ func (t *TranscriptTailer) resetAccumulatorsForRotation() {
 	// Drop the pre-rotation idle anchor so the post-scan idleFlusher
 	// hook doesn't synthesize a phantom turn_done against stale time.
 	t.lastLineSeenAt = time.Time{}
+	// The resume anchor describes the previous contents, so it is meaningless
+	// now. Clearing it also keeps TailAndProcess's skip-the-re-anchor guard
+	// honest: a rotated pass always re-anchors, because unknown forces it to.
+	t.resumeFingerprint = 0
 }
 
 // transcriptScanResult carries the outcomes of one scanNewLines pass: how far

--- a/core/pkg/tailer/tailer_ledger.go
+++ b/core/pkg/tailer/tailer_ledger.go
@@ -8,6 +8,7 @@ func (t *TranscriptTailer) GetLedgerState() LedgerState {
 	s := LedgerState{
 		SchemaVersion:               LedgerSchemaVersion,
 		LastOffset:                  t.lastOffset,
+		ResumeFingerprint:           t.resumeFingerprint,
 		CumProviderCostUSD:          t.cumProviderCostUSD,
 		ModelName:                   t.metrics.ModelName,
 		AgentVersion:                t.metrics.AgentVersion,
@@ -63,6 +64,12 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 		return
 	}
 	t.lastOffset = s.LastOffset
+	// A zero fingerprint means the ledger predates #1104 (or the window
+	// genuinely hashed to zero, 1-in-2^64): leave hasResumeFingerprint false so
+	// the first post-restart pass resumes at the offset as it always has, and
+	// re-anchors itself afterwards.
+	t.resumeFingerprint = s.ResumeFingerprint
+	t.hasResumeFingerprint = s.ResumeFingerprint != 0
 	t.restoreCumByModel(s.CumByModel)
 	t.cumProviderCostUSD = s.CumProviderCostUSD
 	if s.ModelName != "" {

--- a/core/pkg/tailer/tailer_ledger.go
+++ b/core/pkg/tailer/tailer_ledger.go
@@ -64,12 +64,10 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 		return
 	}
 	t.lastOffset = s.LastOffset
-	// A zero fingerprint means the ledger predates #1104 (or the window
-	// genuinely hashed to zero, 1-in-2^64): leave hasResumeFingerprint false so
-	// the first post-restart pass resumes at the offset as it always has, and
+	// Zero (a pre-#1104 ledger, which simply lacks the field) means "unknown",
+	// so the first post-restart pass resumes at the offset as it always has and
 	// re-anchors itself afterwards.
 	t.resumeFingerprint = s.ResumeFingerprint
-	t.hasResumeFingerprint = s.ResumeFingerprint != 0
 	t.restoreCumByModel(s.CumByModel)
 	t.cumProviderCostUSD = s.CumProviderCostUSD
 	if s.ModelName != "" {


### PR DESCRIPTION
Closes #1104.

## The gap

`TranscriptTailer.TailAndProcess` had exactly one rotation check — `fileSize < t.lastOffset`. An **in-place rewrite whose new size is `>= lastOffset`** took the incremental arm: the tailer seeked to a stale byte offset inside a file whose bytes *before* that offset were now different content, resumed mid-record, and kept accumulating on top of pre-rewrite state. Only the *shrink* case was caught.

Because `resetAccumulatorsForRotation` is the only caller of `ResetForRotation()`, #1063/#1078's `rotationResetter` opt-in inherited this blind spot exactly — those fixed *what happens on* a detected rotation, not *rotation detection itself*. Rotation handling was complete only for shrinks.

## The fix

Anchor the resume point with a fingerprint: hash the up-to-512 bytes ending at `lastOffset` after each pass, then re-hash that window before trusting the offset on the next one.

The soundness argument is one line: **an append never rewrites bytes below `lastOffset`.** So a matching window means a genuine append (stay on the cheap incremental path), and a mismatch means the consumed prefix was rewritten — which now routes through the same reset-and-replay-from-byte-0 path a shrink already used.

Of the three directions the issue floated, this is the "cheap content check", strengthened. A bare newline-boundary probe was rejected as insufficient: it only catches landing *mid-line*, but the prefix is corrupt whether or not the stale offset happens to land on a boundary. Inode identity was rejected as the wrong signal — an in-place rewrite keeps the inode, and reading it needs build-tagged files on a platform-neutral package.

**Failure modes are asymmetric by design.** Both uncertain cases — a pre-#1104 ledger carrying an offset but no fingerprint, and an unreadable window — fall back to the historical resume-at-offset behavior. A false positive costs a full re-read and rebuild (correct, just not free); a false negative is what main does today. So this can only turn a silent mis-accumulation into a correct re-read.

## Ledger

The fingerprint is persisted in `LedgerState`, so a rewrite landing while the daemon is **down** is caught on the next boot — the restart is precisely when the tailer has no in-memory record of what it consumed.

Deliberately **without** a `LedgerSchemaVersion` bump: a pre-#1104 ledger simply lacks the field, and a zero value already degrades to the pre-#1104 behavior. Bumping discards every live session's accumulated cost to force a re-scan — a far bigger hammer than a latent gap warrants.

## Verification

The two regression tests were confirmed to **fail on main's detection logic** — not just to pass here. With the size-only check restored, the rewrite pass reported `parsedLines = 1` (one fragment read from stale offset 33) and `resetCalls = 0`; with the fix, all 4 records re-read and the reset fires. Five tests total, covering both directions:

| Test | Pins |
|---|---|
| `InPlaceRewriteWithGrowthIsRotation` | the #1104 gap — rewrite that changes consumed bytes **and** grows |
| `AppendIsNotRotation` | no false positive on the hot path (an append must stay incremental) |
| `IdenticalRewriteIsNotRotation` | the benign equal-size rewrite the issue called out |
| `SetLedgerState_DetectsRewriteAcrossRestart` | the fingerprint survives a restart |
| `SetLedgerState_PreFingerprintLedgerResumesAtOffset` | pre-#1104 ledgers resume unchanged (backward compat) |

`tools/preflight.sh` fully green (all 10 gates, incl. core `-race`, replay fixtures with no golden drift, ARS, security scan).

## Scope

No user-facing surface, so no macOS/web frontend work applies — this is entirely internal to the tailer's resume path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)