### PR TITLE
fix(core): stop flagging a slow-but-executing edit as stalled

### DIFF
--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -41,6 +41,25 @@ const activityDebounceWindow = 2 * time.Second
 // transcript on this interval catches the missed events.
 const staleWorkingRefreshInterval = 5 * time.Second
 
+// stalledEditToolThreshold is how long a permission-gated file-edit tool
+// (Edit/Write/MultiEdit/NotebookEdit) may stay open before the detector treats
+// it as a held permission prompt and sets OpenToolStalled — the transcript
+// -based fallback for when the PermissionRequest hook can't reach the daemon
+// (#488, ClassifyState rule 1b).
+//
+// It is deliberately NOT staleWorkingRefreshInterval. That constant is a
+// polling cadence (how often a lingering working session is re-read); reusing
+// it as the "a human is looking at a prompt" threshold conflated two unrelated
+// quantities. Edit tools are usually near-instant (observed median ~0.1s, mean
+// ~1.4s), but a real minority run long — legitimately-executing, prompt-free
+// edits of 14–16s have been observed — so a 5s gate sat inside that tail and
+// mislabelled slow-but-progressing edits as stalled, flickering
+// working→waiting→working (#1130). 30s clears the observed tail with margin
+// while still catching a genuinely held prompt, which stays open until the
+// user answers. The window is tracked from first observation, so a fresh
+// tool_use is never flagged on the spot.
+const stalledEditToolThreshold = 30 * time.Second
+
 // maxIdleProjectResolveAttempts bounds how many refreshStaleSessions ticks
 // retry CWD/project resolution for an idle (waiting/ready) session whose
 // ProjectName never resolved — e.g. mistral-vibe's meta.json sidecar hadn't

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1191,18 +1191,24 @@ func (d *SessionDetector) purgeDeadBackgroundProcesses(result backgroundProbeRes
 
 // markStalledEditTool maintains the per-session editToolOpenSince window and
 // sets metrics.OpenToolStalled when a permission-gated edit tool
-// (Edit/Write/MultiEdit/NotebookEdit) has been open past the stale-refresh
-// interval — the transcript-based fallback for a held permission prompt when
-// the curl-delivered PermissionRequest hook can't reach the daemon (#488).
+// (Edit/Write/MultiEdit/NotebookEdit) has been open past
+// stalledEditToolThreshold — the transcript-based fallback for a held
+// permission prompt when the curl-delivered PermissionRequest hook can't
+// reach the daemon (#488).
 //
-// Those tools run in-process and complete near-instantly, so one still open
-// after the window means the agent is blocked on the prompt, not executing.
-// The window is tracked from first observation (not state.UpdatedAt), so a
-// fresh tool_use write is never flagged on the spot — only the 5s
-// refreshStaleSessions re-evaluation of a lingering open tool is, which also
-// lets a held prompt flip without any new transcript write. The flag is
-// redundant once PermissionPending fired (the classifier prefers the hook),
-// so it is skipped then. now is injected for testability.
+// Those tools are usually near-instant, but a real minority run long
+// (observed median ~0.1s, mean ~1.4s, with a tail up to ~16s), and a slow
+// edit that is still executing is not blocked on a prompt — so "open past the
+// 5s poll cadence" is not a safe stalled signal (#1130). The flag therefore
+// fires only after stalledEditToolThreshold, which is decoupled from
+// staleWorkingRefreshInterval and set well past the observed tail; a genuinely
+// held prompt stays open indefinitely and still trips it. The window is
+// tracked from first observation (not state.UpdatedAt), so a fresh tool_use
+// write is never flagged on the spot — only a later refreshStaleSessions
+// re-evaluation of a lingering open tool is, which also lets a held prompt
+// flip without any new transcript write. The flag is redundant once
+// PermissionPending fired (the classifier prefers the hook), so it is skipped
+// then. now is injected for testability.
 // applyCompactHold maintains the PreCompact force-working hold (#657) for one
 // session. While a manual /compact is in flight the transcript receives no
 // writes, so this overlays CompactInProgress to keep the session in working
@@ -1249,7 +1255,7 @@ func (d *SessionDetector) markStalledEditTool(sessionID string, m *session.Sessi
 		since = now
 		d.editToolOpenSince[sessionID] = since
 	}
-	if !m.PermissionPending && now-since >= int64(staleWorkingRefreshInterval.Seconds()) {
+	if !m.PermissionPending && now-since >= int64(stalledEditToolThreshold.Seconds()) {
 		m.OpenToolStalled = true
 	}
 }

--- a/core/application/services/session_detector_stalled_test.go
+++ b/core/application/services/session_detector_stalled_test.go
@@ -102,13 +102,13 @@ func markStalledEditToolCases(threshold int64) []markStalledEditToolCase {
 }
 
 // TestMarkStalledEditTool covers the transcript-based stalled-edit-tool
-// fallback (#488): an open permission-gated edit tool that lingers past the
-// stale-refresh interval is flagged OpenToolStalled, while a fresh one, a
+// fallback (#488): an open permission-gated edit tool that lingers past
+// stalledEditToolThreshold is flagged OpenToolStalled, while a fresh one, a
 // non-edit tool, or one already covered by the hook is not. White-box so it
 // can exercise the unexported method + editToolOpenSince map directly,
-// injecting `now` instead of sleeping out the real 5s window.
+// injecting `now` instead of sleeping out the real window.
 func TestMarkStalledEditTool(t *testing.T) {
-	threshold := int64(staleWorkingRefreshInterval.Seconds())
+	threshold := int64(stalledEditToolThreshold.Seconds())
 
 	for _, tt := range markStalledEditToolCases(threshold) {
 		t.Run(tt.name, func(t *testing.T) {
@@ -162,7 +162,7 @@ func assertOpenSinceEquals(t *testing.T, d *SessionDetector, key string, want in
 // held Edit prompt observed across two passes flips to stalled on the second
 // (a stale-refresh) pass; an arriving tool_result then clears the window.
 func TestMarkStalledEditTool_HeldPromptSequence(t *testing.T) {
-	threshold := int64(staleWorkingRefreshInterval.Seconds())
+	threshold := int64(stalledEditToolThreshold.Seconds())
 	d := &SessionDetector{editToolOpenSince: map[string]int64{}}
 	start := time.Now().Unix()
 
@@ -183,4 +183,53 @@ func TestMarkStalledEditTool_HeldPromptSequence(t *testing.T) {
 	if _, ok := d.editToolOpenSince["s"]; ok {
 		t.Fatal("approval must clear the window")
 	}
+}
+
+// TestMarkStalledEditTool_SlowEditNotFlagged reproduces issue #1130: a
+// permission-gated Edit that is legitimately executing (not blocked on a
+// prompt) must not be flagged OpenToolStalled just because it runs longer than
+// the 5s poll cadence. The fixture pins the real timings from the report: the
+// Edit opens at T+0, is still open when a stale-refresh re-reads it at T+11s,
+// and completes successfully (tool_result, is_error unset) at T+16.2s. Across
+// that whole span nothing is ever flagged, so ClassifyState never routes to
+// waiting.
+//
+// The paired positive case confirms the #488 fallback is intact: an edit that
+// stays open past stalledEditToolThreshold with no result still flags.
+func TestMarkStalledEditTool_SlowEditNotFlagged(t *testing.T) {
+	editOpen := func() *session.SessionMetrics {
+		return &session.SessionMetrics{HasOpenToolCall: true, LastOpenToolNames: []string{"Edit"}}
+	}
+
+	t.Run("slow-but-executing edit never flags across its lifetime", func(t *testing.T) {
+		d := &SessionDetector{editToolOpenSince: map[string]int64{}}
+		const start = int64(0)
+
+		// T+0: tool_use observed, the open-since window is recorded.
+		m0 := editOpen()
+		d.markStalledEditTool("s", m0, start)
+		assertOpenToolStalled(t, m0, false)
+
+		// T+11s: a stale-refresh re-reads the still-open edit. This is the
+		// exact instant the daemon misfired in the report; it must not flag.
+		m11 := editOpen()
+		d.markStalledEditTool("s", m11, start+11)
+		assertOpenToolStalled(t, m11, false)
+
+		// T+16.2s (17s whole): tool_result lands (is_error unset), the tool
+		// closes. Still under threshold and now resolved, so the window clears
+		// and nothing was ever flagged.
+		m16 := &session.SessionMetrics{HasOpenToolCall: false}
+		d.markStalledEditTool("s", m16, start+17)
+		assertOpenToolStalled(t, m16, false)
+		assertOpenSinceCleared(t, d, "s")
+	})
+
+	t.Run("genuinely stalled edit past threshold still flags (#488)", func(t *testing.T) {
+		threshold := int64(stalledEditToolThreshold.Seconds())
+		d := &SessionDetector{editToolOpenSince: map[string]int64{"s": 0}}
+		m := editOpen()
+		d.markStalledEditTool("s", m, threshold) // open past the window, no tool_result
+		assertOpenToolStalled(t, m, true)
+	})
 }

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -242,10 +242,12 @@ type SessionMetrics struct {
 
 	// OpenToolStalled is a transient, live-only signal set by the detector
 	// when a permission-gated file-edit tool (Edit/Write/MultiEdit/
-	// NotebookEdit) has stayed open with no transcript progress long enough
+	// NotebookEdit) has stayed open long enough (stalledEditToolThreshold)
 	// that the agent is almost certainly blocked on a permission prompt
-	// rather than mid-execution (those tools complete near-instantly). It is
-	// the transcript-based fallback for permission detection when the
+	// rather than mid-execution. Those tools are usually fast, but a minority
+	// run long (a ~16s tail has been observed), so the threshold is set well
+	// past that tail to avoid flagging a slow-but-executing edit (#1130). It
+	// is the transcript-based fallback for permission detection when the
 	// curl-delivered PermissionRequest hook can't reach the daemon (#488).
 	// Like HasLiveBackgroundProcess it is wall-clock derived and never set
 	// under replay. Read by ClassifyState.
@@ -395,11 +397,13 @@ func isUserBlockingTool(name string) bool {
 
 // HasOpenEditPermissionTool reports whether an open tool call is a
 // permission-gated file-edit tool (Edit/Write/MultiEdit/NotebookEdit). These
-// run in-process and complete near-instantly, so an open one that lingers is
-// a strong signal the agent is blocked on a permission prompt — the basis for
-// the OpenToolStalled fallback (#488). Bash/WebFetch/MCP are deliberately
-// excluded: they can legitimately run for seconds, so duration alone can't
-// distinguish "blocked" from "executing" for them (they rely on the hook).
+// are usually fast, and while a minority run long their duration tail is
+// bounded (~16s observed), so an open one that has lingered well past that
+// tail (stalledEditToolThreshold) is a reasonable signal the agent is blocked
+// on a permission prompt — the basis for the OpenToolStalled fallback (#488,
+// #1130). Bash/WebFetch/MCP are deliberately excluded: they can run for
+// minutes, so no fixed duration distinguishes "blocked" from "executing" for
+// them (they rely on the hook).
 func (m *SessionMetrics) HasOpenEditPermissionTool() bool {
 	if m == nil || !m.HasOpenToolCall {
 		return false


### PR DESCRIPTION
## Summary

`markStalledEditTool` set `OpenToolStalled` as soon as a permission-gated edit tool (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`) had been open for `staleWorkingRefreshInterval` (**5s**), and `ClassifyState` rule 1b routed that straight to `waiting`. But that 5s constant is a *poll cadence*, not a "a human is looking at a prompt" threshold. Edit tools are usually near-instant (median ~0.1s, mean ~1.4s), yet a real minority run long — legitimately-executing, prompt-free edits of **14–16s** have been observed. The 5s gate sat inside that tail, so a slow-but-executing edit was mislabelled stalled and flickered `working → waiting → working` (#1130).

This decouples the flag threshold from the poll cadence.

## Why this approach

The issue outlines two directions: (1) gate rule 1b on hook health, or (2) decouple the threshold from the poll cadence and raise it past the observed tail, with the note that (2) is "a reasonable interim." This PR does (2): the smallest, lowest-risk change that fixes the reported misfire without new per-session hook-receipt plumbing.

- A new named `stalledEditToolThreshold` (**30s**) replaces the reused `staleWorkingRefreshInterval` in `markStalledEditTool`, with a comment justifying the value against the measured duration distribution (median ~0.1s, mean ~1.4s, tail ~16s). 30s clears the tail with margin.
- A genuinely held permission prompt stays open indefinitely and still trips the flag, so the #488 hook-unavailable fallback is preserved.
- `refreshStaleSessions` still re-reads lingering working sessions on the 5s cadence — only the *flag threshold* moved.

I also corrected the doc comments that made the bug look correct on reading — the "these tools complete near-instantly, so an open one is blocked on a prompt" claims at `core/domain/session/metrics.go` (`OpenToolStalled` field and `HasOpenEditPermissionTool`) and `core/application/services/session_detector_activity.go` (`markStalledEditTool`).

## Test plan

Regression test in `core/application/services/session_detector_stalled_test.go` (`TestMarkStalledEditTool_SlowEditNotFlagged`), reusing the existing `assertOpenToolStalled` / `assertOpenSinceCleared` helpers:

- **Negative (the fix):** pins the report's timings — an `Edit` opens at T+0, is still open when a stale-refresh re-reads it at T+11s, and closes successfully (`tool_result`, `is_error` unset) at T+16.2s. `OpenToolStalled` is never set, so the classifier never routes to `waiting`. Fails on `main` (flagged at T+5s), passes here.
- **Positive (no #488 regression):** an edit open past `stalledEditToolThreshold` with no result still flags `OpenToolStalled`.

The existing `TestMarkStalledEditTool` / `TestMarkStalledEditTool_HeldPromptSequence` are re-pointed at the new constant and still pass.

```
go test ./core/... -race -count=1
ok  irrlicht/core/application/services   19.7s
ok  irrlicht/core/domain/session          2.6s
...all core packages ok
```

`gofmt -l` and `go vet ./core/...` are clean on the touched files.

Fixes #1130
