### PR TITLE
fix(macos): stop hidden-panel rendering that burned ~10% CPU

### DIFF
--- a/platforms/macos/Irrlicht/App/MenuBarController.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarController.swift
@@ -102,7 +102,12 @@ final class MenuBarController: NSObject {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.delegate = self
 
-        panel.contentViewController = hostingController
+        // The hosting controller is NOT attached here: the panel starts
+        // hidden, and an attached hosting view keeps animating and laying
+        // out the whole SwiftUI tree even while the window is ordered out
+        // (the working-dot breathe alone re-renders at frame rate) — ~10%
+        // CPU with the panel closed. showPanel() attaches on demand;
+        // hidePanel() detaches again.
 
         // Rounded corners to match the previous MenuBarExtra(.window) look.
         // Panel is already transparent (isOpaque = false, backgroundColor =
@@ -201,6 +206,16 @@ final class MenuBarController: NSObject {
     }
 
     private func showPanel() {
+        // Attach the SwiftUI content (detached while hidden — see
+        // configurePanel). Ordering matters: attach first, then flush, so
+        // the layout pass below measures current data.
+        if panel.contentViewController == nil {
+            panel.contentViewController = hostingController
+        }
+        // Switch the coalesced refresh back to the visible window and apply
+        // any updates accumulated on the hidden window — before the layout
+        // pass below, so the measured content is current.
+        sessionManager.setPanelVisible(true)
         // Force the hosting controller to lay out so preferredContentSize
         // is measured before we position the panel.
         hostingController.view.layoutSubtreeIfNeeded()
@@ -215,7 +230,13 @@ final class MenuBarController: NSObject {
     }
 
     private func hidePanel() {
+        sessionManager.setPanelVisible(false)
         panel.orderOut(nil)
+        // Detach the SwiftUI content: orderOut alone keeps the hosting view
+        // window-attached and rendering off screen (see configurePanel).
+        // The hosting controller (and its view state) is retained by this
+        // controller, so reattaching on the next show is lossless.
+        panel.contentViewController = nil
         removeDismissMonitors()
         statusItem.button?.highlight(false)
     }

--- a/platforms/macos/Irrlicht/Managers/SessionManager+WebSocket.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+WebSocket.swift
@@ -311,10 +311,19 @@ extension SessionManager {
     // the notifications that depend on them (ready/waiting sounds and banners)
     // still fire synchronously at message time; only context-pressure alerts —
     // which ride `rebuildSessionsFromMap` — are deferred, by at most one window.
+    //
+    // The window is visibility-tiered: `orderOut` keeps the hosting view
+    // attached, so each flush re-lays out the whole list even off screen —
+    // at the visible cadence that alone was ~10% CPU with the panel closed.
+    // Hidden flushes ride `uiRefreshHiddenInterval` instead, which keeps the
+    // hidden-time consumers (menu-bar quota bars, context-pressure alerts,
+    // debug-state file) fresh within that window; `setPanelVisible(true)`
+    // flushes on open so the visible list never starts stale.
 
     /// Queue a session for the next coalesced UI refresh. `immediate` bypasses
     /// the window (used for state transitions, which are rare and want to feel
-    /// instant); the metric-tick storm always coalesces.
+    /// instant); the metric-tick storm always coalesces. The window widens
+    /// while the panel is hidden — see `uiRefreshHiddenInterval`.
     func enqueueUIRefresh(for sessionID: String, immediate: Bool) {
         pendingDirtySessionIDs.insert(sessionID)
         if immediate {
@@ -323,9 +332,31 @@ extension SessionManager {
         }
         guard !uiRefreshScheduled else { return }
         uiRefreshScheduled = true
-        Timer.scheduledTimer(withTimeInterval: uiRefreshInterval, repeats: false) { [weak self] _ in
+        uiRefreshTimer = Timer.scheduledTimer(
+            withTimeInterval: currentUIRefreshWindow, repeats: false
+        ) { [weak self] _ in
             Task { @MainActor [weak self] in self?.flushUIRefresh() }
         }
+    }
+
+    /// The coalescing window for the panel's current visibility.
+    var currentUIRefreshWindow: TimeInterval {
+        isPanelVisible ? uiRefreshInterval : uiRefreshHiddenInterval
+    }
+
+    /// MenuBarController reports panel show/hide here. Showing cancels any
+    /// pending hidden-window timer and flushes synchronously, so the list the
+    /// user sees on open is current — the caller lays out the hosting view
+    /// right after this returns. Hiding just flips the flag; a fast timer
+    /// already in flight fires once more, then subsequent ticks coalesce on
+    /// the hidden window.
+    func setPanelVisible(_ visible: Bool) {
+        isPanelVisible = visible
+        guard visible else { return }
+        uiRefreshTimer?.invalidate()
+        uiRefreshTimer = nil
+        uiRefreshScheduled = false
+        flushUIRefresh()
     }
 
     /// Apply all pending session updates in one pass: a single flat-surface
@@ -333,6 +364,8 @@ extension SessionManager {
     /// one synchronous turn, so SwiftUI coalesces them into a single render.
     func flushUIRefresh() {
         uiRefreshScheduled = false
+        uiRefreshTimer?.invalidate()
+        uiRefreshTimer = nil
         guard !pendingDirtySessionIDs.isEmpty else { return }
         let dirty = pendingDirtySessionIDs
         pendingDirtySessionIDs.removeAll()

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -161,8 +161,24 @@ class SessionManager: ObservableObject {
     var pendingDirtySessionIDs = Set<String>()
     /// True while a trailing flush is already scheduled (dedupes timers).
     var uiRefreshScheduled = false
-    /// Refresh window. Injectable so tests can flush deterministically.
+    /// The scheduled trailing flush, kept so showing the panel can cancel a
+    /// pending hidden-window timer and flush immediately instead.
+    var uiRefreshTimer: Timer?
+    /// Refresh window while the panel is visible. Injectable so tests can
+    /// flush deterministically.
     var uiRefreshInterval: TimeInterval = 0.1
+    /// Refresh window while the panel is hidden. The hosting view stays
+    /// attached when the panel is ordered out, so every flush still re-lays
+    /// out the whole SwiftUI session list — at the visible cadence that
+    /// burned ~10% CPU with the panel closed whenever any agent was working.
+    /// The slow window keeps the consumers that matter while hidden — the
+    /// menu-bar quota bars, context-pressure alerts, and the debug-state
+    /// file — fresh at negligible cost; `setPanelVisible(true)` flushes
+    /// immediately so opening the panel never shows stale rows.
+    var uiRefreshHiddenInterval: TimeInterval = 2.0
+    /// Whether the menu-bar panel is currently on screen — flipped by
+    /// MenuBarController on show/hide. Starts hidden, matching the panel.
+    var isPanelVisible = false
     /// Count of coalesced flushes performed — test seam proving a burst of N
     /// pushes collapses into far fewer renders.
     var uiRefreshFlushCount = 0

--- a/platforms/macos/Tests/SessionManagerCoalescingTests.swift
+++ b/platforms/macos/Tests/SessionManagerCoalescingTests.swift
@@ -26,9 +26,10 @@ final class SessionManagerCoalescingTests: XCTestCase {
         // as the apiGroups tests).
         originalProjectGroupOrder = UserDefaults.standard.object(forKey: "projectGroupOrder")
         sut = SessionManager()
-        // Long window so the trailing timer never fires mid-test — flushes are
+        // Long windows so the trailing timer never fires mid-test — flushes are
         // driven explicitly via flushPendingUIRefreshForTests().
         sut.uiRefreshInterval = 1000
+        sut.uiRefreshHiddenInterval = 1000
     }
 
     override func tearDown() async throws {
@@ -76,6 +77,50 @@ final class SessionManagerCoalescingTests: XCTestCase {
                        "a state transition flushes immediately, without waiting for the window")
         let stateA = sut.apiGroups.flatMap { $0.agents ?? [] }.first { $0.id == "a" }?.state
         XCTAssertEqual(stateA, .waiting, "the transition is reflected in the list-view surface")
+    }
+
+    /// The coalescing window follows panel visibility: hidden sessions ride
+    /// the slow window so off-screen flushes stop burning CPU, visible ones
+    /// keep the snappy 0.1s cadence.
+    func testRefreshWindowFollowsPanelVisibility() {
+        sut.uiRefreshInterval = 0.1
+        sut.uiRefreshHiddenInterval = 2.0
+
+        XCTAssertEqual(sut.currentUIRefreshWindow, 2.0,
+                       "the panel starts hidden, so coalescing starts on the slow window")
+
+        sut.setPanelVisible(true)
+        XCTAssertEqual(sut.currentUIRefreshWindow, 0.1,
+                       "a visible panel coalesces on the fast window")
+
+        sut.setPanelVisible(false)
+        XCTAssertEqual(sut.currentUIRefreshWindow, 2.0,
+                       "hiding the panel returns to the slow window")
+    }
+
+    /// Opening the panel must not show rows that are up to a hidden-window
+    /// stale: pending updates flush synchronously on show.
+    func testShowingPanelFlushesPendingUpdates() {
+        seedWorkingSessions(["a"])
+        sut.handleWsMessage(updatedEnvelope(id: "a", seq: 1, cost: 7))
+        XCTAssertEqual(sut.uiRefreshFlushCount, 0, "metric push coalesces while hidden")
+
+        sut.setPanelVisible(true)
+
+        XCTAssertEqual(sut.uiRefreshFlushCount, 1, "showing the panel applies pending updates")
+        let costA = sut.apiGroups.flatMap { $0.agents ?? [] }.first { $0.id == "a" }?.metrics?.estimatedCostUSD
+        XCTAssertEqual(costA, 7, "the update accumulated on the hidden window is visible on open")
+    }
+
+    /// Show/hide with nothing pending is a no-op — no phantom render passes.
+    func testPanelVisibilityWithNothingPendingDoesNotFlush() {
+        seedWorkingSessions(["a"])
+
+        sut.setPanelVisible(true)
+        sut.setPanelVisible(false)
+
+        XCTAssertEqual(sut.uiRefreshFlushCount, 0,
+                       "visibility changes alone must not trigger render passes")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

With the menu-bar panel closed, the app constantly consumed >10% CPU whenever any agent session was working. `orderOut()` keeps the `NSHostingView` window-attached, so the whole SwiftUI session list kept animating and laying out off screen: the working-dot `repeatForever` breathe re-rendered at frame rate, and every coalesced WebSocket flush (10/s under load, #690) re-laid-out the full non-virtualized list. A 5s `sample` of the production app showed ~13% of main-thread wall time in pure SwiftUI layout (`StackLayout.sizeThatFits`, `DisplayList.ViewUpdater`) with the panel closed.

## Changes

- `MenuBarController`: attach the hosting controller only while the panel is shown; detach on hide (and don't attach at init) — a hidden panel renders nothing.
- `SessionManager`: visibility-tiered coalescing window — 0.1s visible (unchanged), 2s hidden. The consumers that matter while hidden (menu-bar quota bars for the `.usage`/`.combined` styles, context-pressure alerts, the `debugMode` state file) stay fresh within that window instead of riding the full metric rate. All immediate-path behavior (state transitions → icon dots, ready/waiting sounds and banners) is untouched.
- `setPanelVisible(true)` cancels the hidden-window timer and flushes synchronously before the show-time layout pass, so the panel never opens stale.

## Test plan

- [x] Swift suite passes (`swift test`): 5 coalescing tests including 3 new ones for the visibility tiering; the 3 failures on this machine (`SessionRowSnapshotTests` ×2, `testTitleMatchScoreSkipsGenericTopsAndHomeBasename`) were verified identical on `main` (environment-specific, pre-existing)
- [x] Added tests: window follows visibility, show flushes pending updates, visibility changes alone don't flush
- [x] Manually exercised: dev build against a live daemon with 5+ active sessions — panel opens with current rows, quota header renders, close/reopen works, live updates while open
- [x] Measured: 60s cputime delta with panel closed and sessions working — **~11% → ~0.6% CPU**
- [ ] Go/web CI gates (diff is Swift-only; no Go toolchain on the dev machine)

## Related issues

None filed — root-caused directly from a `sample` profile.

## Checklist

- [x] Follows AGENTS.md / CONTRIBUTING.md conventions
- [x] Conventional Commits
- [x] No new abstractions ahead of need
- [x] No documentation impact (no user-visible behavior change)
- [x] No `cancelled` session state introduced