### PR TITLE
fix(security-scan): distinguish a network-failed npm audit from a real advisory

### DIFF
--- a/tools/security-scan.sh
+++ b/tools/security-scan.sh
@@ -26,8 +26,14 @@
 #     logged prominently as an upgrade recommendation, not blocking.
 #   - gosec: High-severity + High-confidence findings fail the gate.
 #     Everything else is logged for visibility, not blocking.
-#   - npm audit --audit-level=high already implements this split natively
-#     (fails only on high/critical advisories).
+#   - npm audit: gate on the High+Critical count in the JSON report's
+#     `.metadata.vulnerabilities` block. A non-zero exit alone is ambiguous —
+#     npm exits non-zero both when it finds advisories and when the audit
+#     itself can't run (registry unreachable, TLS failure) — so a report with
+#     no metadata (an `.error`/`.message` payload instead) is classified as
+#     "could not run" and reported as such, not as a fabricated advisory. Per
+#     the "can't run at all" policy below that is still a hard failure, just
+#     an accurately-labelled one.
 #
 # A check that can't run at all — missing tool, `gh` auth/scope failure — is
 # a hard failure, not a skip. A silently-skipped scan is indistinguishable
@@ -160,10 +166,28 @@ fi
 for tree in "${WEB_TREES[@]}"; do
   echo "-- npm audit: $tree --"
   command -v npm >/dev/null 2>&1 || { fail "npm audit: $tree — npm not found"; continue; }
-  if ( cd "$tree" && npm audit --audit-level=high ); then
-    ok "npm audit: $tree — no High/Critical advisories"
+  # npm audit exits non-zero both when it finds advisories AND when the audit
+  # can't run at all (registry unreachable, TLS failure) — so the exit code
+  # alone can't tell the two apart. Parse the JSON report and branch on its
+  # shape, the same way the govulncheck block distinguishes a real finding
+  # from a scan error: a completed audit carries a `.metadata.vulnerabilities`
+  # block; a failed audit has no metadata and instead carries an
+  # `.error`/`.message` payload.
+  na_json=$( cd "$tree" && npm audit --json 2>/dev/null )
+  if echo "$na_json" | jq -e '.metadata.vulnerabilities' >/dev/null 2>&1; then
+    hc=$(echo "$na_json" | jq '(.metadata.vulnerabilities.high // 0) + (.metadata.vulnerabilities.critical // 0)')
+    if [[ "$hc" -gt 0 ]]; then
+      fail "npm audit: $tree — $hc High/Critical advisory/ies found; fix with npm audit fix, or document a suppression"
+      echo "$na_json" | jq -r '.vulnerabilities // {} | to_entries[] | select(.value.severity=="high" or .value.severity=="critical") | "  - " + .key + " (" + .value.severity + ")"' >&2
+    else
+      ok "npm audit: $tree — no High/Critical advisories"
+    fi
   else
-    fail "npm audit: $tree — High/Critical advisory/ies found (see above); fix with npm audit fix, or document a suppression"
+    # No metadata block: the audit never completed. A silently-skipped scan is
+    # indistinguishable from a clean one, so this is a hard failure — but named
+    # accurately (registry/network) rather than misreported as an advisory.
+    na_msg=$(echo "$na_json" | jq -r '.message // .error.summary // .error.detail // empty' 2>/dev/null)
+    fail "npm audit: $tree — audit could not run (registry unreachable / network failure): ${na_msg:-no error detail} — re-run; this is NOT a vulnerability finding"
   fi
 done
 

--- a/tools/security-scan.sh
+++ b/tools/security-scan.sh
@@ -173,7 +173,8 @@ for tree in "${WEB_TREES[@]}"; do
   # from a scan error: a completed audit carries a `.metadata.vulnerabilities`
   # block; a failed audit has no metadata and instead carries an
   # `.error`/`.message` payload.
-  na_json=$( cd "$tree" && npm audit --json 2>/dev/null )
+  na_err=$(mktemp)
+  na_json=$( cd "$tree" && npm audit --json 2>"$na_err" )
   if echo "$na_json" | jq -e '.metadata.vulnerabilities' >/dev/null 2>&1; then
     hc=$(echo "$na_json" | jq '(.metadata.vulnerabilities.high // 0) + (.metadata.vulnerabilities.critical // 0)')
     if [[ "$hc" -gt 0 ]]; then
@@ -185,10 +186,14 @@ for tree in "${WEB_TREES[@]}"; do
   else
     # No metadata block: the audit never completed. A silently-skipped scan is
     # indistinguishable from a clean one, so this is a hard failure — but named
-    # accurately (registry/network) rather than misreported as an advisory.
+    # for the real cause rather than misreported as an advisory. Prefer the
+    # JSON error payload; fall back to npm's stderr when the report is empty
+    # (e.g. the tree is missing or npm errored before emitting JSON).
     na_msg=$(echo "$na_json" | jq -r '.message // .error.summary // .error.detail // empty' 2>/dev/null)
-    fail "npm audit: $tree — audit could not run (registry unreachable / network failure): ${na_msg:-no error detail} — re-run; this is NOT a vulnerability finding"
+    [[ -z "$na_msg" ]] && na_msg=$(tr '\n' ' ' <"$na_err" | sed 's/  */ /g; s/^ *//; s/ *$//')
+    fail "npm audit: $tree — audit could not run (could not reach the npm registry, or the audit errored): ${na_msg:-no detail available} — re-run; this is NOT a vulnerability finding"
   fi
+  rm -f "$na_err"
 done
 
 echo


### PR DESCRIPTION
## What

`tools/security-scan.sh` treated any non-zero `npm audit` exit as "High/Critical advisory found". npm exits non-zero **both** when it finds advisories and when the audit itself can't run (registry unreachable, TLS failure), so a transient network failure was misreported as a fabricated advisory — and, via `preflight.sh`'s pre-push hook, rejected the push with a remediation (`npm audit fix`) for a finding that did not exist. Observed during the v0.5.9 release.

## Fix

Parse `npm audit --json` and branch on the report's shape, mirroring the govulncheck block's real-finding-vs-scan-error split already in the script:

- **Audit ran** — report carries a `.metadata.vulnerabilities` block → gate on the `high + critical` count (fail + list the offending packages if >0, else OK).
- **Audit could not run** — no metadata; instead an `.error`/`.message` payload → fail with an accurate message: `audit could not run (registry unreachable / network failure): <reason> — re-run; this is NOT a vulnerability finding`.

Per the script's existing "a check that can't run at all is a hard failure, not a skip" policy (and `ir:release` Step 5.5), the could-not-run case still fails the gate — the bug was misattribution, not that it failed.

## Verification

Exercised the **actual** npm-audit block (extracted verbatim from the file), not a paraphrase:

- Clean run (reachable registry): `OK: … no High/Critical advisories`, gate passes.
- Network failure (`npm_config_registry` → black-hole IP, the issue's repro): `FAIL: … audit could not run (registry unreachable / network failure): request to … failed, reason: connect ETIMEDOUT … — re-run; this is NOT a vulnerability finding`. Distinct, accurate, no fabricated advisory.
- Synthetic report with 1 high + 1 critical advisory: still fails, lists `lodash (high)` / `minimist (critical)`, excludes moderate.
- `shellcheck` clean (the one pre-existing SC2164 on `cd "$REPO_ROOT"` is unchanged and unrelated); `bash -n` passes.

Closes #1131

🤖 Generated with [Claude Code](https://claude.com/claude-code)