### PR TITLE
fix(daemon): route turns with an irrlicht-question marker to waiting (#1138)

### DIFF
--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -144,6 +144,12 @@ func (mc *MetricsConverter) Convert(m *tailer.SessionMetrics) *session.SessionMe
 	}
 	if m.TaskQuestion != nil && m.TaskQuestion.Text != "" {
 		questionSource = m.TaskQuestion.Text
+		// Only the deliberate irrlicht-question marker feeds the waiting-state
+		// classifier (issue #1138) — not the away_summary recap (a passive
+		// "here's what I was doing" note, not necessarily a question) and not
+		// the LastAssistantText fallback (populated on nearly every turn). See
+		// SessionMetrics.PendingQuestionMarker / IsWaitingForUserInput.
+		result.PendingQuestionMarker = true
 	}
 	result.QuestionHeadline = mc.compact(questionSource, outbound.CompactQuestion)
 	return result

--- a/core/application/replayengine/metrics_test.go
+++ b/core/application/replayengine/metrics_test.go
@@ -112,6 +112,47 @@ func TestConvert_QuestionHeadline_MarkerWinsOverAwaySummary(t *testing.T) {
 	}
 }
 
+// TestConvert_PendingQuestionMarker pins issue #1138: only the deliberate
+// irrlicht-question marker sets PendingQuestionMarker (the waiting-state
+// classifier's authoritative signal). The away_summary recap and the
+// LastAssistantText fallback — both of which can populate QuestionHeadline —
+// must NOT set it, or nearly every finished turn would read as waiting.
+func TestConvert_PendingQuestionMarker(t *testing.T) {
+	t.Run("marker present → set", func(t *testing.T) {
+		m := &tailer.SessionMetrics{
+			LastAssistantText: "a declarative status line with no question",
+			TaskQuestion:      &tailer.TaskQuestion{Text: "run the migration?", ObservedAt: 100},
+		}
+		if got := TailerToDomain(m); !got.PendingQuestionMarker {
+			t.Error("PendingQuestionMarker = false, want true when a TaskQuestion marker is present")
+		}
+	})
+
+	t.Run("only last-assistant text → not set", func(t *testing.T) {
+		m := &tailer.SessionMetrics{LastAssistantText: "should I proceed?"}
+		if got := TailerToDomain(m); got.PendingQuestionMarker {
+			t.Error("PendingQuestionMarker = true, want false — the LastAssistantText fallback must not set it")
+		}
+	})
+
+	t.Run("only away_summary → not set", func(t *testing.T) {
+		m := &tailer.SessionMetrics{
+			LastAssistantText: "a raw status line",
+			AwaySummary:       &tailer.AwaySummary{Text: "Goal was X. Next: merge or wait?", ObservedAt: 100},
+		}
+		if got := TailerToDomain(m); got.PendingQuestionMarker {
+			t.Error("PendingQuestionMarker = true, want false — the away_summary recap is not an authoritative question signal")
+		}
+	})
+
+	t.Run("empty marker text → not set", func(t *testing.T) {
+		m := &tailer.SessionMetrics{TaskQuestion: &tailer.TaskQuestion{Text: "", ObservedAt: 100}}
+		if got := TailerToDomain(m); got.PendingQuestionMarker {
+			t.Error("PendingQuestionMarker = true, want false for an empty marker")
+		}
+	})
+}
+
 func TestTailerToDomain_NilCompactor_HeadlinesAreIdentity(t *testing.T) {
 	m := &tailer.SessionMetrics{
 		TaskSummary:       &tailer.TaskSummary{Text: "add the logout button", ObservedAt: 100},

--- a/core/application/services/state_classifier_test.go
+++ b/core/application/services/state_classifier_test.go
@@ -214,6 +214,22 @@ func TestClassifyState(t *testing.T) {
 			wantState:  session.StateWaiting,
 			wantReason: true,
 		},
+		// Rule 2a (issue #1138): an explicit irrlicht-question marker routes to
+		// waiting even when the (tail-truncated) LastAssistantText carries no
+		// question or cue — the real question sat earlier in a long final
+		// message. Reproduces the 71f27332 session's shape.
+		{
+			name:    "working → waiting (turn_done + question marker, declarative tail)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				LastEventType:         "turn_done",
+				HasOpenToolCall:       false,
+				LastAssistantText:     "I can stand up the throwaway OTLP sink and drive a session through a permission prompt to capture the payload.",
+				PendingQuestionMarker: true,
+			},
+			wantState:  session.StateWaiting,
+			wantReason: true,
+		},
 
 		// Rule 2b: IsAgentDone without question → ready.
 		{
@@ -233,6 +249,21 @@ func TestClassifyState(t *testing.T) {
 			metrics: &session.SessionMetrics{
 				LastEventType:   "turn_done",
 				HasOpenToolCall: false,
+			},
+			wantState:  session.StateReady,
+			wantReason: true,
+		},
+		// Rule 2b guard (issue #1138): QuestionHeadline is populated from the
+		// LastAssistantText fallback on nearly every turn, so it must NOT by
+		// itself force waiting — only the real PendingQuestionMarker does.
+		{
+			name:    "working → ready (turn_done, QuestionHeadline set but no marker)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				LastEventType:     "turn_done",
+				HasOpenToolCall:   false,
+				LastAssistantText: "Done. The tests pass.",
+				QuestionHeadline:  "Done. The tests pass.",
 			},
 			wantState:  session.StateReady,
 			wantReason: true,

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -208,6 +208,18 @@ type SessionMetrics struct {
 	// LastAssistantText is the tooltip. Empty when there is no question source.
 	QuestionHeadline string `json:"question_headline,omitempty"`
 
+	// PendingQuestionMarker is true when the agent emitted an explicit in-band
+	// irrlicht-question marker in its latest turn (issue #1138). Unlike
+	// QuestionHeadline — whose source falls back to LastAssistantText and is
+	// therefore populated on nearly every turn — this is set only from the
+	// deliberate, agent-authored marker, so it is a trustworthy "the agent is
+	// blocked on the user" signal for state classification. It is the fix for
+	// the failure mode where the real question sits earlier in a long final
+	// message and the prose heuristic (which only sees the tail-truncated
+	// LastAssistantText) misses it. Recomputed fresh each pass by the
+	// tailer→domain conversion, so it is transient and not persisted.
+	PendingQuestionMarker bool `json:"-"`
+
 	// PermissionMode is the session's permission mode from the JSONL.
 	// Verified on-disk census across 320 local Claude Code transcripts
 	// (v2.1.210, 2026-07-15): "auto" 5000, "plan" 331, "default" 8,
@@ -545,6 +557,7 @@ func newMergedMetrics(newM *SessionMetrics) *SessionMetrics {
 		TaskSummary:              newM.TaskSummary,
 		IntentHeadline:           newM.IntentHeadline,
 		QuestionHeadline:         newM.QuestionHeadline,
+		PendingQuestionMarker:    newM.PendingQuestionMarker,
 		PermissionMode:           newM.PermissionMode,
 		SubagentCompletions:      newM.SubagentCompletions,
 		AppliedTaskDeltas:        newM.AppliedTaskDeltas,

--- a/core/domain/session/waiting_cue.go
+++ b/core/domain/session/waiting_cue.go
@@ -38,6 +38,16 @@ func (m *SessionMetrics) IsWaitingForUserInput() bool {
 	if m == nil {
 		return false
 	}
+	// An explicit agent-authored irrlicht-question marker is the most
+	// trustworthy "blocked on the user" signal — more so than the prose
+	// heuristics below, which only see the tail-truncated LastAssistantText and
+	// miss a question that sits earlier in a long final message (issue #1138).
+	// It is set (in the tailer→domain conversion) only from the deliberate
+	// marker, never from the LastAssistantText fallback, so it can't false-fire
+	// on an ordinary turn.
+	if m.PendingQuestionMarker {
+		return true
+	}
 	if ExtractQuestionSnippet(m.LastAssistantText) != "" {
 		return true
 	}

--- a/core/domain/session/waiting_cue_test.go
+++ b/core/domain/session/waiting_cue_test.go
@@ -235,3 +235,38 @@ func TestIsWaitingForUserInput_ImperativeCues(t *testing.T) {
 	}
 	runBoolCueCases(t, cases, isWaitingForUserInput)
 }
+
+// TestIsWaitingForUserInput_PendingQuestionMarker pins issue #1138: an explicit
+// agent-authored irrlicht-question marker must register as waiting even when the
+// (tail-truncated) LastAssistantText carries no question or cue — the real
+// question sat earlier in a long final message and never reached the prose
+// heuristic. The marker is the authoritative signal.
+func TestIsWaitingForUserInput_PendingQuestionMarker(t *testing.T) {
+	// The 71f27332 shape: the visible tail is a declarative sentence, so the
+	// prose heuristic alone returns false — only the marker flips it to waiting.
+	declarativeTail := "I can stand up the throwaway OTLP sink and drive a real claudecode session through a permission prompt via tmux to capture the payload and measure its latency."
+
+	t.Run("marker set with declarative tail → waiting", func(t *testing.T) {
+		m := &SessionMetrics{LastAssistantText: declarativeTail, PendingQuestionMarker: true}
+		if !m.IsWaitingForUserInput() {
+			t.Error("IsWaitingForUserInput() = false, want true when PendingQuestionMarker is set")
+		}
+	})
+
+	t.Run("sanity: same tail without the marker → not waiting", func(t *testing.T) {
+		m := &SessionMetrics{LastAssistantText: declarativeTail}
+		if m.IsWaitingForUserInput() {
+			t.Error("IsWaitingForUserInput() = true, want false for a declarative tail with no marker (guards against the marker path masking a prose regression)")
+		}
+	})
+
+	t.Run("QuestionHeadline populated but no marker → not waiting", func(t *testing.T) {
+		// QuestionHeadline falls back to LastAssistantText, so it is set on
+		// nearly every turn; it must NOT by itself imply waiting. Only
+		// PendingQuestionMarker (the real marker) does.
+		m := &SessionMetrics{LastAssistantText: declarativeTail, QuestionHeadline: "some compacted headline"}
+		if m.IsWaitingForUserInput() {
+			t.Error("IsWaitingForUserInput() = true, want false — QuestionHeadline must not force waiting without a real marker")
+		}
+	})
+}

--- a/tools/onboarding-factory/cmd/replay/main_test.go
+++ b/tools/onboarding-factory/cmd/replay/main_test.go
@@ -472,6 +472,70 @@ func TestReplay_Issue150_AskUserQuestion(t *testing.T) {
 	}
 }
 
+// TestReplay_Issue1138_QuestionMarkerWaiting is the end-to-end regression for
+// issue #1138, reproducing the real 71f27332 session: a turn ends asking the
+// user a question, but the visible question sits EARLY in a long final message
+// while the tail (which is all LastAssistantText keeps — 200 runes) is a
+// declarative sentence plus the hidden irrlicht-question marker. Before the fix
+// the prose heuristic saw no question in the tail and the session went straight
+// to ready; after it, the parsed marker (PendingQuestionMarker) routes the
+// finished turn to waiting.
+//
+// Modeled inline rather than as a replaydata cell on purpose: the fix lives in
+// the tailer→domain conversion + classifier, and a full recording cell (manifest
+// + events.jsonl goldens + `of validate`) would be disproportionate ceremony for
+// a pure state-classification guard.
+func TestReplay_Issue1138_QuestionMarkerWaiting(t *testing.T) {
+	dir := t.TempDir()
+	transcript := filepath.Join(dir, "session.jsonl")
+
+	// Assistant turn: the real question ("Want me to run the spike now?") is far
+	// enough from the end that it falls outside the 200-rune LastAssistantText
+	// tail; the tail is the declarative sentence + the marker comment (whose own
+	// trailing '?' is inside `"} -->` and is not a catchable sentence question).
+	transcriptBody := `{"type":"user","timestamp":"2026-04-11T10:00:00Z","message":{"role":"user","content":"Should we run the OTel blocked_on_user spike?"}}
+{"type":"assistant","timestamp":"2026-04-11T10:00:01Z","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"Here is my read on the OTel blocked_on_user spike, weighed against the recommendation already written up in the design doc. Want me to run the spike now? I can stand up the throwaway OTLP collector sink locally and drive a real claudecode session through a permission prompt via tmux to capture the blocked_on_user payload end to end and measure its wall-clock latency.\n\n<!-- {\"marker\":\"irrlicht-question\",\"question\":\"Run the OTel blocked_on_user spike now, or just keep the recommendation?\"} -->"}]}}
+{"type":"system","subtype":"turn_duration","timestamp":"2026-04-11T10:00:02Z"}
+`
+	if err := os.WriteFile(transcript, []byte(transcriptBody), 0644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	report, err := replay(transcript, reportSettings{
+		Adapter:            claudecode.AdapterName,
+		DebounceWindow:     2 * time.Second,
+		FlickerMaxDuration: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+
+	waitingIdx := -1
+	for i := range report.Transitions {
+		if report.Transitions[i].NewState == session.StateWaiting {
+			waitingIdx = i
+		}
+	}
+	if waitingIdx < 0 {
+		t.Fatalf("no transition to waiting; the finished question turn was not detected as waiting. transitions: %+v", report.Transitions)
+	}
+	waiting := report.Transitions[waitingIdx]
+	// The transcript has no open/blocking tool, so the ONLY route to waiting is
+	// classifyAgentDone's question path — and with a declarative tail, the prose
+	// heuristic sees no question, so the parsed irrlicht-question marker is what
+	// flips it. Assert that exact route: turn done + the question-waiting reason.
+	if !waiting.IsAgentDone {
+		t.Errorf("waiting transition IsAgentDone = false, want true (should be the turn-done question route)")
+	}
+	const wantReason = "turn ended with question or cue → waiting"
+	if waiting.Reason != wantReason {
+		t.Errorf("waiting transition reason = %q, want %q (the agent-done question route, which only fires here via the marker)", waiting.Reason, wantReason)
+	}
+	if waiting.NeedsAttn {
+		t.Errorf("waiting transition NeedsAttn = true, want false — reached waiting via a blocking tool, not the question marker")
+	}
+}
+
 func TestDetectAdapter(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

Closes #1138. A turn that ends by asking the user a question could stay **non-`waiting`**: the parsed `irrlicht-question` marker fed only the display headline, while the state classifier relied solely on `IsWaitingForUserInput()`, whose prose heuristics only see the tail-truncated (200-rune) `LastAssistantText`. When the real question sits earlier in a long final message, the tail is declarative and the heuristic misses it — so the headline showed the pending question while the state contradicted it.

Reproduced from the real session `71f27332`: the final message asks *"Want me to run the spike now?"* early, then a declarative sentence, then the marker — the tail carries no catchable question.

## What changed

- **`SessionMetrics.PendingQuestionMarker`** (`core/domain/session/metrics.go`) — a new transient classifier input, copied through `newMergedMetrics`.
- **`Convert`** (`core/application/replayengine/metrics.go`) — sets it in the single tailer→domain seam, **only** from a real `TaskQuestion` marker. Not from the `away_summary` recap (a passive "what I was doing" note) and not from the `LastAssistantText` fallback — both of which populate `QuestionHeadline`, so `QuestionHeadline` is *not* a safe waiting signal.
- **`IsWaitingForUserInput()`** (`core/domain/session/waiting_cue.go`) — honors the marker ahead of the prose heuristics.

The existing `IsAgentDone()` gate keeps this turn-end-only, and the tailer already clears the marker when the user replies (`applyAssistantTextAndMarkers`), so there's no stale-waiting risk.

## Tests

- `waiting_cue_test.go` — marker forces waiting past a declarative tail; sanity + `QuestionHeadline`-without-marker negatives.
- `state_classifier_test.go` — done turn + marker → waiting; `QuestionHeadline`-set-but-no-marker → ready guard.
- `replayengine/metrics_test.go` — `Convert` sets the field only from the marker (not away_summary / fallback / empty).
- `cmd/replay/main_test.go` — end-to-end `replay()` regression reproducing the `71f27332` shape.

All four **fail with the fix disabled** and pass with it. Full `go test ./core/... -race`, factory suite, `replay-fixtures.sh`, and `of validate` are green (no golden drift).

### Note
The end-to-end guard is modeled inline rather than as a full replaydata recording cell (manifest + events.jsonl goldens + `of validate` ceremony) — disproportionate for a pure state-classification fix. Rationale is in the test's doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)