### PR TITLE
feat(claudecode): structure the pending-question headline (context → state → ask)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -140,6 +140,19 @@ const (
 // Claude Code strips bare HTML comments from CLAUDE.md at injection time. The
 // daemon always falls back to compacting the raw last-assistant text, so the
 // marker is a refinement, not a requirement.
+//
+// v2 (#1142): the v1 guidance ("plain prose, under ~70 chars") produced
+// context-free headlines — the raw question with no hint of what task it
+// belongs to, cryptic to anyone scanning sessions. v2 asks for a
+// context → state → ask structure with good/bad examples, and relaxes the
+// hard ~70 cap to a soft ~90. That fuller headline survives to the UI: the
+// daemon-side compaction caps at 200 runes (not 70) since #979, and
+// ExtractQuestionSnippet keeps a single such sentence whole — the em-dash,
+// semicolon and colon separators used in the examples are not sentence
+// terminators (verified against core/domain/session's splitter). Only the
+// example placeholder and prose change; the marker key and sentinels are
+// untouched, so patchManagedBlock upgrades installed v1 blocks in place on
+// the next daemon start.
 const managedTaskQuestionBlock = taskQuestionBeginSentinel + `
 ## Pending-question marker (managed by Irrlicht)
 
@@ -147,11 +160,20 @@ When you end your turn by asking the user a question, also emit a hidden
 one-line version of that question so tools can show a terse headline:
 
 ` + "```" + `
-<!-- {"marker":"irrlicht-question","question":"<the question, ~70 chars>"} -->
+<!-- {"marker":"irrlicht-question","question":"<topic — what happened — the choice>"} -->
 ` + "```" + `
 
 Emit it on its own line at the very end of your response, only when you are
-actually waiting on the user. Keep it under ~70 characters, plain prose.
+actually waiting on the user.
+
+Structure the headline so someone who never saw the session understands it:
+lead with the topic, then what just happened, then the choice — context,
+then state, then the ask. Keep it high-signal; aim for ~90 characters, and
+when clarity and brevity conflict, choose clarity.
+
+- Bad "Should I proceed?" → Good "DB migration ready; drops users.legacy_id — run it or keep the column?"
+- Bad "Which approach?" → Good "Auth refactor: 2 endpoints still untested — ship now or add tests first?"
+- Bad "Yes or no?" → Good "PR #482 review: 1 blocking finding left — fix now or merge and follow up?"
 ` + taskQuestionEndSentinel
 
 // claudeMemoryPath returns the user-level Claude Code instruction file path.

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -429,6 +429,28 @@ func TestEnsureTaskQuestionBlock_CreatesFileIfAbsent(t *testing.T) {
 	}
 }
 
+// TestTaskQuestionBlock_DocumentsStructureAndExamples guards issue #1142: the
+// pending-question guidance must teach the context → state → ask structure and
+// carry good/bad examples, not just say "plain prose, ~70 chars". Assert on the
+// structural contract (the deliverable), tolerant of later wording tweaks to
+// the examples themselves.
+func TestTaskQuestionBlock_DocumentsStructureAndExamples(t *testing.T) {
+	for _, want := range []string{
+		"context",      // names the three-part structure...
+		"then the ask", // ...in order
+		"Bad ",         // carries labelled bad/good example pairs
+		"Good ",
+	} {
+		if !strings.Contains(managedTaskQuestionBlock, want) {
+			t.Errorf("task-question block missing %q — issue #1142 structure/examples regressed", want)
+		}
+	}
+	// The cap moved from a hard ~70 to a soft ~90; the old absolute rule must be gone.
+	if strings.Contains(managedTaskQuestionBlock, "under ~70 characters") {
+		t.Error("task-question block still carries the old hard ~70-char rule (issue #1142 relaxed it to ~90)")
+	}
+}
+
 func TestApplyInstructionBlocks_InstallsAllAndCoexist(t *testing.T) {
 	home := withTempHome(t)
 	if err := applyInstructionBlocks(); err != nil {


### PR DESCRIPTION
Closes #1142.

## What

The `irrlicht-question` marker guidance previously said only *"plain prose, under ~70 chars"*, which produced context-free headlines — the raw question with no hint of what task it belongs to, cryptic to anyone scanning waiting sessions (real example: `Bei Kap. 1 starten oder erst Kern-Blöcke 3/4/5? Und Kap. 11 behalten?`).

This restructures the guidance that the daemon installs into `~/.claude/CLAUDE.md` (`managedTaskQuestionBlock` in `instructioninstaller.go`) to require a **context → state → ask** headline, with three good/bad example pairs, and relaxes the hard ~70 cap to a soft ~90 (clarity over brevity).

Before → after (the installed guidance):
- Before: `Emit it … Keep it under ~70 characters, plain prose.`
- After: `Structure the headline so someone who never saw the session understands it: lead with the topic, then what just happened, then the choice …` + labelled Bad/Good pairs.

## Why it's safe end-to-end

The fuller headline survives to the UI unchanged — no daemon-side change was needed:
- Daemon-side compaction caps at **200 runes**, not 70, since #979 (`maxHeadlineRunes`).
- `ExtractQuestionSnippet` returns the first *question sentence* whole; the em-dash / semicolon / colon separators used in the new format are **not** sentence terminators (the `;`-looking terminator in `waiting_cue.go` is the Greek question mark U+037E, not ASCII `;`). Verified empirically against the real splitter before choosing the example format.

The marker key (`"marker":"irrlicht-question"`) and BEGIN/END sentinels are untouched, so `patchManagedBlock` upgrades already-installed v1 blocks in place on the next daemon start (idempotency covered by the existing `TestApplyInstructionBlocks_InstallsAllAndCoexist`).

## Tests

- New `TestTaskQuestionBlock_DocumentsStructureAndExamples` pins the deliverable: the block must teach the three-part structure and carry Bad/Good example pairs, and must no longer carry the old hard `~70` rule.
- Full `go test ./core/... -race -count=1` green; gofmt/vet clean; pre-push preflight (go + web + ARS + security) all pass.

## Not a per-frontend gap

This changes the guidance agents read, not any display code. The headline is already rendered on both web (`platforms/web/irrlicht.js`, `question_headline`) and the macOS pill — both live upstream of this change, so there's no frontend where the improvement fails to reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)