### PR TITLE
perf(hooks): scope pre-push preflight to the push's changed packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,8 +120,16 @@ tools/preflight.sh --only arch    # just the ARS architecture gate
 
 `tools/install-git-hooks.sh` (run once per clone; worktrees share the parent
 repo's hooks automatically) wires `tools/preflight.sh`'s fast gates as a
-pre-push hook, so a push that would fail CI is rejected locally instead.
-Skip once with `git push --no-verify`.
+pre-push hook, so a push that would fail CI is rejected locally instead. The
+hook runs `tools/preflight.sh --changed`, which scopes every gate to the
+packages and web trees the push's diff actually touches (vs `origin/main`), so
+a typical push finishes in seconds rather than re-running the whole suite —
+important for automated callers, whose bounded command timeout the full run
+routinely blew past, killing the push after the commit had already landed. A
+large or cross-cutting diff (or a `go.mod`/`go.sum` change, which falls back to
+the full core suite) can still take a few minutes. Skip once with `git push
+--no-verify`; run `tools/preflight.sh` manually (no `--changed`) for the
+unscoped full gate.
 
 Two of the failure modes it won't catch: environment-specific timing flakes
 that only manifest on loaded Linux CI runners (not this machine), and true

--- a/tools/git-hooks/pre-push
+++ b/tools/git-hooks/pre-push
@@ -2,9 +2,15 @@
 # pre-push hook — runs tools/preflight.sh's fast gate set (the go + web CI
 # jobs; not the slow opt-in --linux Docker gate) before a push leaves this
 # machine, so a failure shows up here instead of several minutes later on
-# GitHub Actions. Installed via tools/install-git-hooks.sh (not automatic —
-# git doesn't version .git/hooks/, so every clone needs one run; worktrees
-# share the parent repo's hooks automatically).
+# GitHub Actions. Runs with --changed, so each gate is scoped to the packages
+# and web trees this push actually touches (vs origin/main) — a small diff
+# pushes in seconds instead of re-running the whole suite, which routinely
+# exceeded an automated caller's command timeout and left the push half-done
+# (committed locally, never sent). Run tools/preflight.sh manually (no
+# --changed) for the unscoped full gate. Installed via
+# tools/install-git-hooks.sh (not automatic — git doesn't version .git/hooks/,
+# so every clone needs one run; worktrees share the parent repo's hooks
+# automatically).
 #
 # Git runs hooks with CWD set to the working tree performing the push — a
 # worktree's own root, not wherever tools/install-git-hooks.sh was run from
@@ -27,5 +33,10 @@ set -uo pipefail
 # Unset them so preflight's git-touching tests see a clean environment.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
-echo "pre-push: running tools/preflight.sh (skip with --no-verify)"
-./tools/preflight.sh
+echo "pre-push: running tools/preflight.sh --changed"
+echo "pre-push: gates are scoped to this push's diff vs origin/main — usually"
+echo "pre-push: seconds, but a large or cross-cutting diff (or a go.mod/go.sum"
+echo "pre-push: change) can still take a few minutes. Skip with"
+echo "pre-push: 'git push --no-verify' (run tools/preflight.sh manually for the"
+echo "pre-push: full unscoped gate)."
+./tools/preflight.sh --changed

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -32,6 +32,11 @@
 #   tools/preflight.sh --only arch     # just the ARS architecture gate
 #   tools/preflight.sh --only security # just govulncheck + gosec + npm audit
 #   tools/preflight.sh --only linux    # just the Linux Docker gate
+#   tools/preflight.sh --changed       # scope every gate to the packages/trees
+#                                        this branch changes vs origin/main —
+#                                        used by the pre-push hook so a small
+#                                        push finishes in seconds. Without it
+#                                        the full run above is unchanged.
 #
 # PLATFORMS overrides the Linux gate's docker --platform (default: linux/amd64,
 # matching linux.yml's ubuntu-latest runner — QEMU-emulated on Apple Silicon,
@@ -44,10 +49,12 @@ cd "$ROOT_DIR"
 
 RUN_LINUX=0
 ONLY=""
+CHANGED=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --linux) RUN_LINUX=1; shift ;;
     --only)  ONLY="${2:-}"; shift 2 ;;
+    --changed) CHANGED=1; shift ;;
     -h|--help) sed -n '2,24p' "$0"; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
@@ -58,6 +65,31 @@ want() {
   local group="$1"
   [[ -z "$ONLY" || "$ONLY" == "$group" ]]
   return $?
+}
+
+# ---- --changed scoping ---------------------------------------------------
+# In --changed mode (the pre-push hook's path) every gate is limited to the
+# files this branch changes vs origin/main, so a push only re-runs the checks
+# its own diff can actually break. Without --changed, CHANGED_FILES stays
+# empty and changed_matches always returns true, so every gate runs
+# unconditionally — the manual `tools/preflight.sh` full run is byte-for-byte
+# identical to before.
+CHANGED_FILES=""
+if [[ "$CHANGED" == 1 ]]; then
+  base=$(git merge-base origin/main HEAD 2>/dev/null || echo origin/main)
+  CHANGED_FILES=$(
+    { git diff --name-only "$base" HEAD
+      git diff --name-only HEAD
+      git diff --name-only --cached
+    } 2>/dev/null | sort -u
+  )
+fi
+
+# changed_matches <extended-regex> — true when NOT scoping (full run) or when
+# some changed file matches. Lets a full-mode gate stay unconditional.
+changed_matches() {
+  [[ "$CHANGED" == 1 ]] || return 0
+  grep -qE "$1" <<<"$CHANGED_FILES"
 }
 
 NAMES=()
@@ -80,6 +112,23 @@ run_gate() {
   return 0
 }
 
+# run_gate_scoped <extended-regex> <name> <cmd...> — like run_gate, but in
+# --changed mode records SKIP (no effect on the exit code) unless a changed
+# file matches <extended-regex>. In full mode it always runs, so behaviour is
+# unchanged there.
+run_gate_scoped() {
+  local re="$1"; shift
+  if ! changed_matches "$re"; then
+    echo
+    echo "$SEPARATOR"
+    echo "  $1  — SKIP (no changed files match)"
+    echo "$SEPARATOR"
+    NAMES+=("$1"); RESULTS+=("SKIP")
+    return 0
+  fi
+  run_gate "$@"
+}
+
 # ---- go group (mirrors test.yml) ----------------------------------------
 gofmt_check() {
   local unformatted
@@ -91,13 +140,48 @@ gofmt_check() {
   fi
 }
 
+# changed_core_packages — import paths of the changed core/ packages that
+# still exist (renames/deletions are dropped by the `go list` guard), plus the
+# module-root package irrlicht/core that hosts architecture_test.go. Including
+# that root package means the hexagonal-layering rules are re-checked on every
+# scoped run regardless of which package changed, since architecture_test.go
+# loads the whole module ("./...") itself.
+changed_core_packages() {
+  local pkgs=("irrlicht/core") dir
+  while IFS= read -r dir; do
+    [[ -z "$dir" ]] && continue
+    go list "irrlicht/$dir" >/dev/null 2>&1 && pkgs+=("irrlicht/$dir")
+  done < <(grep -E '^core/.*\.go$' <<<"$CHANGED_FILES" | sed -E 's#/[^/]+\.go$##' | sort -u)
+  printf '%s\n' "${pkgs[@]}" | sort -u
+}
+
+# core_module_tests — full module under -race in full mode; in --changed mode,
+# only the changed packages (plus the arch-test root). A go.mod/go.sum change
+# can alter any package's build, so that falls back to the full run.
+core_module_tests() {
+  if [[ "$CHANGED" != 1 ]] || changed_matches '^core/go\.(mod|sum)$'; then
+    go test ./core/... -race -count=1
+    return
+  fi
+  local pkgs
+  pkgs=$(changed_core_packages)
+  echo "scoped to changed packages:"
+  printf '  %s\n' $pkgs
+  go test $pkgs -race -count=1
+}
+
 if want go; then
-  run_gate "gofmt"                    gofmt_check
-  run_gate "core module tests"        go test ./core/... -race -count=1
-  run_gate "onboarding-factory tests" go test ./tools/onboarding-factory/... -count=1
-  run_gate "replaydata validate"      go run ./tools/onboarding-factory/cmd/of validate
-  run_gate "recording-rig smoke test" bash tools/onboarding-factory/scripts/smoke-test.sh
-  run_gate "starhistory tests"        go test ./tools/starhistory/... -count=1
+  run_gate        "gofmt"                    gofmt_check
+  run_gate_scoped '^core/.*\.go$|^core/go\.(mod|sum)$' \
+                  "core module tests"        core_module_tests
+  run_gate_scoped '^tools/onboarding-factory/.*\.go$' \
+                  "onboarding-factory tests" go test ./tools/onboarding-factory/... -count=1
+  run_gate_scoped '^replaydata/|^tools/onboarding-factory/' \
+                  "replaydata validate"      go run ./tools/onboarding-factory/cmd/of validate
+  run_gate_scoped '^tools/onboarding-factory/' \
+                  "recording-rig smoke test" bash tools/onboarding-factory/scripts/smoke-test.sh
+  run_gate_scoped '^tools/starhistory/' \
+                  "starhistory tests"        go test ./tools/starhistory/... -count=1
 fi
 
 # ---- web group (mirrors web-test.yml) -----------------------------------
@@ -108,20 +192,25 @@ web_tree() {
 }
 
 if want web; then
-  run_gate "web: platforms/web"             web_tree platforms/web
-  run_gate "web: onboarding-factory viewer" web_tree tools/onboarding-factory/internal/viewer/web
+  run_gate_scoped '^platforms/web/' \
+                  "web: platforms/web"             web_tree platforms/web
+  run_gate_scoped '^tools/onboarding-factory/internal/viewer/web/' \
+                  "web: onboarding-factory viewer" web_tree tools/onboarding-factory/internal/viewer/web
 fi
 
 # ---- arch group (mirrors ars-gate.yml) -----------------------------------
+# ars-gate.sh scans core/, so an ARS regression can only come from a core/
+# change.
 if want arch; then
-  run_gate "ARS architecture gate" tools/ars-gate.sh
+  run_gate_scoped '^core/' "ARS architecture gate" tools/ars-gate.sh
 fi
 
 # ---- security group (mirrors tools/security-scan.sh's local mode; the same
 # script's full mode, with GitHub Dependabot/CodeQL alert checks, runs at
 # release time from ir:release's Step 5.5, not here) ------------------------
 if want security; then
-  run_gate "security scan (govulncheck + gosec + npm audit)" tools/security-scan.sh --local
+  run_gate_scoped '\.go$|(^|/)go\.(mod|sum)$|(^|/)package(-lock)?\.json$' \
+                  "security scan (govulncheck + gosec + npm audit)" tools/security-scan.sh --local
 fi
 
 # ---- linux group (mirrors linux.yml, opt-in: --linux or --only linux) ---


### PR DESCRIPTION
## Problem

The pre-push hook (`tools/git-hooks/pre-push`) ran `tools/preflight.sh`'s full fast-gate set on **every** push: the whole `-race` Go suite (minutes), both web trees' `npm ci && npm test`, the ARS double-scan, and the security scan. For an automated caller driving `git push` through a bounded command timeout, the hook routinely exceeded it — the push was killed mid-hook and aborted **after the commit had already landed locally**, presenting as a hang with a committed-but-unpushed branch (issue #1151).

## Change

Implements the issue's **Option 1** (scope to changed packages), applied uniformly, plus the cheap **Option 2** (upfront discoverability line) and **Option 3** (AGENTS.md note).

A new `--changed` mode in `tools/preflight.sh` scopes every gate to the files the branch changes vs `origin/main`:

- **core module tests** run only the changed `core/` packages — always **plus** the module-root `irrlicht/core` package that hosts `architecture_test.go`, so the hexagonal-layering rules stay enforced across the whole module regardless of which package changed. A `go.mod`/`go.sum` change falls back to the full `./core/...` run.
- **onboarding-factory tests, replaydata validate, recording-rig smoke, starhistory, both web trees, ARS gate, and security scan** each run only when a matching path changed.

Only the pre-push hook uses `--changed`. **Without `--changed` nothing changes**: `CHANGED_FILES` stays empty, `changed_matches` always returns true, so the manual `tools/preflight.sh` full run is byte-for-byte identical to before. The `--no-verify` escape hatch is preserved (and now advertised by an upfront line the hook prints).

### Why scope every gate, not just the Go suite

The issue framed the cost as "the full Go suite," but the hook actually ran the whole non-Linux preflight. On this machine the `-race` core suite is ~32s warm (much worse cold / under CI), but the two web trees' `npm ci` (no `node_modules` in a fresh worktree), the ARS double-scan, and the security scan are what push the total past a 2-minute timeout. Scoping only the Go gate would have left those re-running on every push and not delivered the wall-clock win the issue asks for. The same "scope to the diff" mechanism handles all of them via one small helper.

## Files

- `tools/preflight.sh` — `--changed` flag, `changed_matches` / `run_gate_scoped` helpers, `core_module_tests` / `changed_core_packages`, per-gate path predicates.
- `tools/git-hooks/pre-push` — calls `tools/preflight.sh --changed`; upfront scoping/`--no-verify` line; updated header.
- `AGENTS.md` — Local CI parity note updated to describe the scoped hook.

## Verification (local)

- **Negative:** a tooling/doc-only diff → all Go/web/arch/security gates SKIP, only `gofmt` runs, hook completes in **0.17s**.
- **Positive:** a deliberately-broken test staged in `core/domain/dora` → the scoped run targeted exactly `irrlicht/core` (arch root) + `irrlicht/core/domain/dora`, the broken package **FAILED**, exit 1, in 2.66s (vs 32s+ full).
- **Full mode unchanged:** `tools/preflight.sh --only go` (no `--changed`) → all 6 gates run (no SKIP), all PASS.

Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)