### PR TITLE
fix(state): detect waiting cues/questions past the 200-rune display tail (#1150)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 
+	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/pkg/transcript"
 )
@@ -766,10 +767,22 @@ func isAssistantEventType(eventType string) bool {
 func applyAssistantText(raw map[string]interface{}, ev *tailer.ParsedEvent, eventType, askUserQuestion string) {
 	switch eventType {
 	case "assistant", eventTypeAssistantStreaming, "assistant_message", "assistant_output":
-		ev.AssistantText = tailer.ExtractAssistantText(raw)
+		full := tailer.ExtractAssistantFullText(raw)
+		ev.AssistantText = tailer.TruncateAssistantText(full)
 		if ev.AssistantText == "" && askUserQuestion != "" {
+			full = askUserQuestion
 			ev.AssistantText = tailer.TruncateAssistantText(askUserQuestion)
 		}
+		// issue #1150: the prose waiting heuristics see only the tail-truncated
+		// AssistantText, so a cue or question sitting before the trailing 200
+		// runes is invisible to them. Scan a larger (but bounded) tail window
+		// here and carry the verdict as a boolean — the prose analogue of the
+		// TaskQuestion marker path. Bounded, not full text: ExtractWaitingCue
+		// over-fires on very long turns (see MaxWaitingScanRunes). Kept a boolean
+		// (not the string) so the tailer/domain metrics and ledger stay lean.
+		win := tailer.WaitingScanWindow(full)
+		ev.PendingWaitingCue = win != "" &&
+			(session.ExtractQuestionSnippet(win) != "" || session.ExtractWaitingCue(win) != "")
 	case "user", "user_message", "user_input":
 		ev.ClearToolNames = true
 		ev.UserText = tailer.ExtractUserText(raw)

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -780,6 +780,12 @@ func applyAssistantText(raw map[string]interface{}, ev *tailer.ParsedEvent, even
 		// TaskQuestion marker path. Bounded, not full text: ExtractWaitingCue
 		// over-fires on very long turns (see MaxWaitingScanRunes). Kept a boolean
 		// (not the string) so the tailer/domain metrics and ledger stay lean.
+		//
+		// Wired for Claude Code only (the adapter #1150 was filed against). Other
+		// adapters that set AssistantText via the same ExtractAssistantText
+		// truncation (e.g. codex) share this beyond-tail blind spot; the plumbing
+		// (ParsedEvent.PendingWaitingCue → tailer → domain) is adapter-agnostic,
+		// so each can adopt it by computing PendingWaitingCue the same way here.
 		win := tailer.WaitingScanWindow(full)
 		ev.PendingWaitingCue = win != "" &&
 			(session.ExtractQuestionSnippet(win) != "" || session.ExtractWaitingCue(win) != "")

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -77,6 +77,7 @@ func (mc *MetricsConverter) Convert(m *tailer.SessionMetrics) *session.SessionMe
 		CumCacheCreationTokens:            m.CumCacheCreationTokens,
 		LastCWD:                           m.LastCWD,
 		LastAssistantText:                 m.LastAssistantText,
+		PendingWaitingCue:                 m.PendingWaitingCue,
 		PermissionMode:                    m.PermissionMode,
 		SawUserBlockingToolClosedThisPass: m.SawUserBlockingToolClosedThisPass,
 		NoSubstantiveActivity:             m.NoSubstantiveActivity,

--- a/core/application/replayengine/metrics_test.go
+++ b/core/application/replayengine/metrics_test.go
@@ -153,6 +153,29 @@ func TestConvert_PendingQuestionMarker(t *testing.T) {
 	})
 }
 
+// TestConvert_PendingWaitingCue pins issue #1150: the full-text waiting-cue
+// verdict the adapter parser computes rides through the tailer→domain
+// conversion untouched, so the classifier sees it. The parser derives it from
+// the FULL assistant text; the conversion is a plain passthrough.
+func TestConvert_PendingWaitingCue(t *testing.T) {
+	t.Run("flag set on tailer metrics → copied to domain", func(t *testing.T) {
+		m := &tailer.SessionMetrics{
+			LastAssistantText: "a declarative status tail with no cue",
+			PendingWaitingCue: true,
+		}
+		if got := TailerToDomain(m); !got.PendingWaitingCue {
+			t.Error("PendingWaitingCue = false, want true — the parser's full-text verdict must pass through")
+		}
+	})
+
+	t.Run("flag unset → stays false", func(t *testing.T) {
+		m := &tailer.SessionMetrics{LastAssistantText: "a declarative status tail with no cue"}
+		if got := TailerToDomain(m); got.PendingWaitingCue {
+			t.Error("PendingWaitingCue = true, want false when the parser set no cue")
+		}
+	})
+}
+
 func TestTailerToDomain_NilCompactor_HeadlinesAreIdentity(t *testing.T) {
 	m := &tailer.SessionMetrics{
 		TaskSummary:       &tailer.TaskSummary{Text: "add the logout button", ObservedAt: 100},

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -220,6 +220,16 @@ type SessionMetrics struct {
 	// tailer→domain conversion, so it is transient and not persisted.
 	PendingQuestionMarker bool `json:"-"`
 
+	// PendingWaitingCue is true when the most recent assistant message's FULL
+	// (untruncated) text carried a literal question or an imperative waiting cue
+	// (issue #1150). It is the prose-heuristic analogue of PendingQuestionMarker:
+	// derived by the adapter parser from the complete text, not from the
+	// tail-truncated LastAssistantText the prose detectors below would otherwise
+	// see, so a cue/question sitting before the trailing 200 runes still flips
+	// the session to waiting. Recomputed fresh each pass (restored from the
+	// tailer ledger on restart), so it is transient and not persisted here.
+	PendingWaitingCue bool `json:"-"`
+
 	// PermissionMode is the session's permission mode from the JSONL.
 	// Verified on-disk census across 320 local Claude Code transcripts
 	// (v2.1.210, 2026-07-15): "auto" 5000, "plan" 331, "default" 8,
@@ -558,6 +568,7 @@ func newMergedMetrics(newM *SessionMetrics) *SessionMetrics {
 		IntentHeadline:           newM.IntentHeadline,
 		QuestionHeadline:         newM.QuestionHeadline,
 		PendingQuestionMarker:    newM.PendingQuestionMarker,
+		PendingWaitingCue:        newM.PendingWaitingCue,
 		PermissionMode:           newM.PermissionMode,
 		SubagentCompletions:      newM.SubagentCompletions,
 		AppliedTaskDeltas:        newM.AppliedTaskDeltas,

--- a/core/domain/session/waiting_cue.go
+++ b/core/domain/session/waiting_cue.go
@@ -48,6 +48,14 @@ func (m *SessionMetrics) IsWaitingForUserInput() bool {
 	if m.PendingQuestionMarker {
 		return true
 	}
+	// PendingWaitingCue is the prose analogue: the adapter parser ran these same
+	// detectors against the FULL assistant text (issue #1150), so an imperative
+	// cue or literal question sitting before the trailing 200 runes is caught
+	// even though the tail-only scans below cannot see it. The tail scans remain
+	// for adapters/passes that don't populate it (the flag stays false then).
+	if m.PendingWaitingCue {
+		return true
+	}
 	if ExtractQuestionSnippet(m.LastAssistantText) != "" {
 		return true
 	}

--- a/core/domain/session/waiting_cue_test.go
+++ b/core/domain/session/waiting_cue_test.go
@@ -270,3 +270,29 @@ func TestIsWaitingForUserInput_PendingQuestionMarker(t *testing.T) {
 		}
 	})
 }
+
+// TestIsWaitingForUserInput_PendingWaitingCue pins issue #1150: a prose waiting
+// cue (imperative, no marker) that sits before the trailing 200 runes is
+// invisible to the tail-only scans on LastAssistantText, so the adapter parser
+// scans the FULL text and carries the verdict as PendingWaitingCue. That flag
+// must flip the session to waiting on its own, mirroring PendingQuestionMarker.
+func TestIsWaitingForUserInput_PendingWaitingCue(t *testing.T) {
+	// The tail the display kept is a declarative fragment (the cue sat earlier
+	// in the long final turn), so the tail scan alone returns false — only the
+	// full-text-derived flag flips it to waiting.
+	declarativeTail := "…so the classifier now receives an accurate signal on every pass instead of relying on the trailing fragment that used to hide the earlier sentence."
+
+	t.Run("cue flag set with declarative tail → waiting", func(t *testing.T) {
+		m := &SessionMetrics{LastAssistantText: declarativeTail, PendingWaitingCue: true}
+		if !m.IsWaitingForUserInput() {
+			t.Error("IsWaitingForUserInput() = false, want true when PendingWaitingCue is set")
+		}
+	})
+
+	t.Run("sanity: same tail without the flag → not waiting", func(t *testing.T) {
+		m := &SessionMetrics{LastAssistantText: declarativeTail}
+		if m.IsWaitingForUserInput() {
+			t.Error("IsWaitingForUserInput() = true, want false for a declarative tail with no cue flag (guards against the flag path masking a prose regression)")
+		}
+	})
+}

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -212,8 +212,15 @@ type ParsedEvent struct {
 	CumulativeTokens *TokenSnapshot
 	RequestID        string
 	AssistantText    string // ≤200 chars, for waiting-state display
-	CWD              string // working directory if found
-	PermissionMode   string // Claude Code only
+	// PendingWaitingCue is true when the FULL (untruncated) assistant text of
+	// this event carries a literal question or an imperative waiting cue. The
+	// adapter parser computes it from the complete text because AssistantText
+	// above is tail-truncated to 200 runes and would hide a cue/question that
+	// sits before the trailing text — the prose-heuristic analogue of the
+	// TaskQuestion marker path. See issue #1150.
+	PendingWaitingCue bool
+	CWD               string // working directory if found
+	PermissionMode    string // Claude Code only
 
 	// RateLimit, when non-nil, is a subscription-quota snapshot extracted from
 	// this event. Codex emits one per token_count event_msg; Claude Code feeds
@@ -603,6 +610,16 @@ type LedgerState struct {
 	// (turn ended on a question) loses the question text on restart and the seed
 	// re-classification demotes it to `ready`. See issue #705.
 	LastAssistantText string `json:"last_assistant_text,omitempty"`
+	// PendingWaitingCue persists the full-text waiting-cue signal (issue #1150)
+	// so a daemon restart that resumes at LastOffset (zero new lines) keeps a
+	// session whose turn ended on a cue/question beyond the 200-rune tail in
+	// `waiting` instead of demoting it to `ready` — the cue analogue of the
+	// LastAssistantText heal above (#705). Deliberately added WITHOUT a schema
+	// bump: a ledger written before this field simply lacks it and rehydrates to
+	// false, which falls back to the tail-truncated scan (the pre-fix behaviour),
+	// so discarding every live session's ledger to force a re-scan would be a
+	// bigger hammer than this narrow gap warrants.
+	PendingWaitingCue bool `json:"pending_waiting_cue,omitempty"`
 	// PendingBackgroundAgentCount persists Claude Code's last-reported
 	// background-agent count so a daemon restart that resumes at LastOffset
 	// (zero new lines) keeps holding the parent `working` while agents are
@@ -682,10 +699,20 @@ func NormalizeModelName(rawModel string) string {
 	return normalized
 }
 
-// ExtractAssistantText extracts and concatenates text blocks from an assistant
-// message, returning at most 200 characters. Checks both Claude Code
-// (message.content[].text) and Codex (content[].text / content[].output_text) formats.
+// ExtractAssistantText extracts the assistant message's text blocks, truncated
+// to ~200 runes for waiting-state display. It is the display form of
+// ExtractAssistantFullText.
 func ExtractAssistantText(raw map[string]interface{}) string {
+	return TruncateAssistantText(ExtractAssistantFullText(raw))
+}
+
+// ExtractAssistantFullText concatenates the text blocks of an assistant message
+// WITHOUT the ~200-rune display truncation ExtractAssistantText applies. Checks
+// both Claude Code (message.content[].text) and Codex (content[].text /
+// content[].output_text) formats. The prose waiting-state heuristics need the
+// full text so a cue or question sitting before the trailing 200 runes is still
+// visible; the truncated form is display-only. See issue #1150.
+func ExtractAssistantFullText(raw map[string]interface{}) string {
 	var parts []string
 
 	// Claude Code: message.content[]
@@ -699,7 +726,7 @@ func ExtractAssistantText(raw map[string]interface{}) string {
 		collectAssistantTextBlocks(arr, &parts)
 	}
 
-	return TruncateAssistantText(strings.Join(parts, " "))
+	return strings.Join(parts, " ")
 }
 
 // collectAssistantTextBlocks appends the text of each "text"/"output_text"
@@ -769,6 +796,31 @@ func collectUserTextBlocks(arr []interface{}, parts *[]string) {
 
 // MaxAssistantTextRunes caps the assistant text kept for waiting-state display.
 const MaxAssistantTextRunes = 200
+
+// MaxWaitingScanRunes bounds how much of an assistant message's tail the prose
+// waiting-state heuristics scan (issue #1150). It is deliberately larger than
+// MaxAssistantTextRunes (the display cap) so a cue or question pushed past the
+// 200-rune display tail by trailing text is still seen — but still bounded, so a
+// long declarative or creative-writing turn can't manufacture a spurious cue
+// from mid-message prose. ExtractWaitingCue's false-positive rate grows with
+// scan length (see issue #381 and the 2-16 oversized-transcript-line fixture,
+// an 18k-rune poem that reads as a cue once the whole message is scanned), so
+// the detection window stays coupled to a bound — just a larger one than
+// display. Twice the display cap.
+const MaxWaitingScanRunes = 2 * MaxAssistantTextRunes
+
+// WaitingScanWindow returns the trailing MaxWaitingScanRunes runes of s — the
+// bounded input the prose waiting-state heuristics scan. Unlike
+// TruncateAssistantText it adds no ellipsis: the result feeds the detectors, not
+// the UI. See issue #1150.
+func WaitingScanWindow(s string) string {
+	text := strings.TrimSpace(s)
+	runes := []rune(text)
+	if len(runes) > MaxWaitingScanRunes {
+		return string(runes[len(runes)-MaxWaitingScanRunes:])
+	}
+	return text
+}
 
 // TruncateAssistantText reduces s to the assistant text kept for waiting-state
 // display: trimmed, then at most the trailing MaxAssistantTextRunes runes with a

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -814,12 +814,22 @@ const MaxWaitingScanRunes = 2 * MaxAssistantTextRunes
 // TruncateAssistantText it adds no ellipsis: the result feeds the detectors, not
 // the UI. See issue #1150.
 func WaitingScanWindow(s string) string {
+	tail, _ := tailRunes(s, MaxWaitingScanRunes)
+	return tail
+}
+
+// tailRunes trims s and returns its trailing n runes (all of it when shorter),
+// plus whether any leading runes were dropped. "Keep the tail, not the head"
+// preserves the agent's most recent words — where a waiting question/cue lands.
+// Shared by the two tail-keeping helpers: TruncateAssistantText (display) and
+// WaitingScanWindow (detection).
+func tailRunes(s string, n int) (tail string, truncated bool) {
 	text := strings.TrimSpace(s)
 	runes := []rune(text)
-	if len(runes) > MaxWaitingScanRunes {
-		return string(runes[len(runes)-MaxWaitingScanRunes:])
+	if len(runes) > n {
+		return string(runes[len(runes)-n:]), true
 	}
-	return text
+	return text, false
 }
 
 // TruncateAssistantText reduces s to the assistant text kept for waiting-state
@@ -832,12 +842,11 @@ func WaitingScanWindow(s string) string {
 // Adapters MUST scan the full text for markers (ScanTaskEstimate) BEFORE calling
 // this — the dropped head can carry a task-estimate marker.
 func TruncateAssistantText(s string) string {
-	text := strings.TrimSpace(s)
-	runes := []rune(text)
-	if len(runes) > MaxAssistantTextRunes {
-		return "…" + string(runes[len(runes)-MaxAssistantTextRunes:])
+	tail, truncated := tailRunes(s, MaxAssistantTextRunes)
+	if truncated {
+		return "…" + tail
 	}
-	return text
+	return tail
 }
 
 // ExtractUsage pulls token breakdown fields from a usage map.

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -151,6 +151,12 @@ type SessionMetrics struct {
 	// message, truncated to ~200 characters.
 	LastAssistantText string `json:"last_assistant_text,omitempty"`
 
+	// PendingWaitingCue is true when the most recent assistant message's FULL
+	// text carried a literal question or imperative waiting cue (issue #1150).
+	// Transient like the domain PendingQuestionMarker — recomputed each pass and
+	// restored from the ledger on restart, never serialized into session JSON.
+	PendingWaitingCue bool `json:"-"`
+
 	// PermissionMode is the session's permission mode. Extracted from
 	// "permission-mode" events. A census of 320 live Claude Code transcripts
 	// found the values actually in use are overwhelmingly "auto" (~5000
@@ -350,6 +356,12 @@ type TranscriptTailer struct {
 	// lastAssistantText holds the text content of the most recent assistant
 	// message, truncated to ~200 characters.
 	lastAssistantText string
+
+	// lastPendingWaitingCue holds the full-text waiting-cue signal derived from
+	// the most recent assistant message (issue #1150), kept in lockstep with
+	// lastAssistantText: set from the parsed event's PendingWaitingCue whenever
+	// the assistant text updates, cleared when a user message clears the text.
+	lastPendingWaitingCue bool
 
 	// lastTaskEstimate holds the most recent agent-emitted task-progress
 	// marker. Markers are sporadic (model-discretion, every few turns), so
@@ -1104,9 +1116,12 @@ func (t *TranscriptTailer) updateInterruptAndDenialFlags(parsed *ParsedEvent) {
 func (t *TranscriptTailer) applyAssistantTextAndMarkers(parsed *ParsedEvent) {
 	if parsed.AssistantText != "" {
 		t.lastAssistantText = parsed.AssistantText
+		// Kept in lockstep with the text it was derived from (issue #1150).
+		t.lastPendingWaitingCue = parsed.PendingWaitingCue
 	}
 	if parsed.ClearToolNames {
 		t.lastAssistantText = ""
+		t.lastPendingWaitingCue = false
 	}
 	if parsed.TaskEstimate != nil {
 		t.applyTaskEstimate(parsed.TaskEstimate)

--- a/core/pkg/tailer/tailer_ledger.go
+++ b/core/pkg/tailer/tailer_ledger.go
@@ -14,6 +14,7 @@ func (t *TranscriptTailer) GetLedgerState() LedgerState {
 		AgentVersion:                t.metrics.AgentVersion,
 		LastEventType:               t.metrics.LastEventType,
 		LastAssistantText:           t.lastAssistantText,
+		PendingWaitingCue:           t.lastPendingWaitingCue,
 		PendingBackgroundAgentCount: t.lastPendingBackgroundAgentCount,
 	}
 	if len(t.cumByModel) > 0 {
@@ -93,6 +94,13 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 		t.lastAssistantText = s.LastAssistantText
 		t.metrics.LastAssistantText = s.LastAssistantText
 	}
+	// Restore the full-text waiting-cue signal the same way (issue #1150) so a
+	// resume-at-EOF pass keeps a beyond-tail cue/question session `waiting`.
+	// surfaceSporadicMetrics republishes it onto t.metrics every pass (above
+	// computeMetrics' empty-history early return), so only the private field
+	// needs restoring — unlike LastAssistantText above, whose t.metrics copy
+	// lives below that early return.
+	t.lastPendingWaitingCue = s.PendingWaitingCue
 	// Restore the background-agent hold: a resume-at-EOF pass reads no
 	// turn_duration, so without this the #1037 guard goes inert on every
 	// restart and the parent flips `ready` while agents are still running

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -405,6 +405,7 @@ func (t *TranscriptTailer) surfaceSporadicMetrics() {
 	t.metrics.FirstUserText = t.firstUserText
 
 	t.metrics.TaskQuestion = t.lastTaskQuestion
+	t.metrics.PendingWaitingCue = t.lastPendingWaitingCue
 	t.metrics.AwaySummary = t.lastAwaySummary
 	t.metrics.PendingBackgroundAgentCount = t.lastPendingBackgroundAgentCount
 }

--- a/replaydata/agents/claudecode/regressions/06-cost-calculation-07f5cca9/recordings/2026-04-07-19-57-20_irrlichd-unknown/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/regressions/06-cost-calculation-07f5cca9/recordings/2026-04-07-19-57-20_irrlichd-unknown/transcript.jsonl.replay.json.golden
@@ -15,8 +15,8 @@
     "last_event_time": "2026-04-07T23:15:42.607Z",
     "wall_clock_session_duration": 11901617000000,
     "state_durations": {
-      "ready": 2907257000000,
-      "waiting": 1444744000000,
+      "ready": 2869896000000,
+      "waiting": 1482105000000,
       "working": 7549616000000
     },
     "flicker_count": 1,
@@ -500,7 +500,7 @@
       "has_open_tool": false,
       "is_agent_done": true,
       "needs_user_attention": false,
-      "waiting_for_user_input": false,
+      "waiting_for_user_input": true,
       "last_assistant_text_head": "…ow-up issue for the Codex stale-timer signal (14 flickers + 29 stale fires on…"
     },
     {
@@ -509,13 +509,13 @@
       "virtual_time": "2026-04-07T22:56:20.018Z",
       "cause": "debounce_coalesce",
       "prev_state": "working",
-      "new_state": "ready",
-      "reason": "agent finished turn → ready",
+      "new_state": "waiting",
+      "reason": "turn ended with question or cue → waiting",
       "last_event_type": "assistant",
       "has_open_tool": false,
       "is_agent_done": true,
       "needs_user_attention": false,
-      "waiting_for_user_input": false,
+      "waiting_for_user_input": true,
       "last_assistant_text_head": "…ow-up issue for the Codex stale-timer signal (14 flickers + 29 stale fires on…"
     },
     {
@@ -523,9 +523,9 @@
       "event_index": 1029,
       "virtual_time": "2026-04-07T22:56:57.379Z",
       "cause": "event",
-      "prev_state": "ready",
+      "prev_state": "waiting",
       "new_state": "working",
-      "reason": "force ready→working on first activity",
+      "reason": "transcript activity (waiting → working)",
       "last_event_type": "user",
       "has_open_tool": false,
       "is_agent_done": false,

--- a/tools/onboarding-factory/cmd/replay/main_test.go
+++ b/tools/onboarding-factory/cmd/replay/main_test.go
@@ -536,6 +536,71 @@ func TestReplay_Issue1138_QuestionMarkerWaiting(t *testing.T) {
 	}
 }
 
+// TestReplay_Issue1150_WaitingCueBeyondTailWaiting is the end-to-end regression
+// for issue #1150, the cue analogue of TestReplay_Issue1138_QuestionMarkerWaiting:
+// a turn ends with an imperative waiting cue (no marker, no literal question)
+// that sits EARLY in a long final message, while the tail (all LastAssistantText
+// keeps — 200 runes) is a declarative padding sentence. Before the fix the prose
+// heuristics saw only the truncated tail and the session went straight to ready;
+// after it, the adapter parser scans the FULL assistant text, derives
+// PendingWaitingCue, and the finished turn routes to waiting via the same
+// turn-done cue path #1138 uses for the marker.
+//
+// Modeled inline rather than as a replaydata cell for the same reason #1138 is:
+// the fix lives in the parser + tailer→domain conversion + classifier, and a
+// full recording cell would be disproportionate ceremony for a state-classifier
+// guard.
+func TestReplay_Issue1150_WaitingCueBeyondTailWaiting(t *testing.T) {
+	dir := t.TempDir()
+	transcript := filepath.Join(dir, "session.jsonl")
+
+	// Assistant turn: the cue ("Please review the diff and let me know before I
+	// merge.") is the FIRST sentence, followed by a single ~290-rune declarative
+	// sentence so the trailing 200 runes (all TruncateAssistantText keeps) fall
+	// entirely inside the padding — the cue is outside the tail window. No
+	// irrlicht-question marker, so only the full-text cue scan can flip it.
+	transcriptBody := `{"type":"user","timestamp":"2026-04-11T10:00:00Z","message":{"role":"user","content":"Is the waiting-cue fix ready?"}}
+{"type":"assistant","timestamp":"2026-04-11T10:00:01Z","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"Please review the diff and let me know before I merge. I have already wired the full-text scan through the parser and the tailer and the ledger and the shared conversion so the classifier now receives an accurate signal on every pass instead of relying on the trailing fragment that used to hide this earlier sentence from the heuristics entirely."}]}}
+{"type":"system","subtype":"turn_duration","timestamp":"2026-04-11T10:00:02Z"}
+`
+	if err := os.WriteFile(transcript, []byte(transcriptBody), 0644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	report, err := replay(transcript, reportSettings{
+		Adapter:            claudecode.AdapterName,
+		DebounceWindow:     2 * time.Second,
+		FlickerMaxDuration: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+
+	waitingIdx := -1
+	for i := range report.Transitions {
+		if report.Transitions[i].NewState == session.StateWaiting {
+			waitingIdx = i
+		}
+	}
+	if waitingIdx < 0 {
+		t.Fatalf("no transition to waiting; the finished cue turn was not detected as waiting. transitions: %+v", report.Transitions)
+	}
+	waiting := report.Transitions[waitingIdx]
+	// No open/blocking tool, and the cue sits outside the 200-rune tail, so the
+	// ONLY route to waiting is classifyAgentDone's cue path fed by the full-text
+	// PendingWaitingCue flag. Assert that exact route.
+	if !waiting.IsAgentDone {
+		t.Errorf("waiting transition IsAgentDone = false, want true (should be the turn-done cue route)")
+	}
+	const wantReason = "turn ended with question or cue → waiting"
+	if waiting.Reason != wantReason {
+		t.Errorf("waiting transition reason = %q, want %q (the agent-done cue route, which only fires here via the full-text scan)", waiting.Reason, wantReason)
+	}
+	if waiting.NeedsAttn {
+		t.Errorf("waiting transition NeedsAttn = true, want false — reached waiting via a cue, not a blocking tool")
+	}
+}
+
 func TestDetectAdapter(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Problem

The prose waiting-state heuristics (`ExtractQuestionSnippet` / `ExtractWaitingCue` in `core/domain/session/waiting_cue.go`) only see `LastAssistantText`, which the claudecode parser tail-truncates to 200 runes **for display**. An imperative waiting cue (or literal question) sitting *before* 200 runes of trailing text is invisible to them, so the session never flips to `waiting`. PR #1145 (issue #1138) routed only the marker-backed *question* case around this via `PendingQuestionMarker`; every marker-less prose signal was still blind past the tail.

## Fix

Mirror the #1138 plumbing for the marker-less prose case. The claudecode parser scans a **bounded tail window** of the FULL assistant text and carries the verdict as a per-pass boolean `PendingWaitingCue`, threaded exactly like `PendingQuestionMarker`:

`ParsedEvent.PendingWaitingCue` → tailer `lastPendingWaitingCue` (kept in lockstep with `lastAssistantText`, persisted in the ledger so a restart-at-EOF pass keeps a beyond-tail cue session `waiting`, per #705) → `tailer.SessionMetrics.PendingWaitingCue` → `TailerToDomain` → `session.SessionMetrics.PendingWaitingCue` → OR'd into `IsWaitingForUserInput`.

Display truncation is unchanged — the sidebar/tooltip contract (`LastAssistantText`, `QuestionHeadline`) is untouched.

### Why bounded, not full text

`ExtractWaitingCue`'s false-positive rate grows with scan length — the 200-rune truncation was doubling as the detection bound. Scanning the *entire* message makes an 18k-rune creative-writing turn read as a cue (the `2-16_oversized-transcript-line` fixture). So detection is decoupled from display but stays bounded: `MaxWaitingScanRunes = 2 × MaxAssistantTextRunes` (400). That keeps the poem fixture correctly **non-waiting** while catching cues pushed just past the 200-rune display tail.

## Tests

- **Replay (end-to-end):** `TestReplay_Issue1150_WaitingCueBeyondTailWaiting` — a cue beyond the tail must reach `waiting`. Proven to fail without the fix (session goes straight to `ready`).
- **Domain unit:** `TestIsWaitingForUserInput_PendingWaitingCue`.
- **Conversion passthrough:** `TestConvert_PendingWaitingCue`.
- **Golden:** the `06-cost-calculation` claudecode regression fixture updates — it contains a **real** beyond-tail cue (*"Let me know if you'd like me to open a follow-up issue…"*) now correctly classified as a `working → waiting → working` episode.

Full local preflight (all PR gates + ARS + security scan) is green.

Closes #1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)