### PR TITLE
docs(ir:exec): review/simplify against origin/main...HEAD, not stale local main

### DIFF
--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -223,6 +223,7 @@ this guards against). The diff exists as soon as Phase 4 is done; measure it
 cheaply first:
 
 ```bash
+git fetch origin main                     # refresh origin/main first; steps 13–14 diff against it, not stale local main
 git diff --shortstat origin/main...HEAD   # files + lines; origin/main, not local (stale-ref footgun)
 ```
 
@@ -250,12 +251,19 @@ human-triggered.
     End the PR body with the `🤖 Generated with [Claude Code]` line.
 13. **Review the diff** at the **calibrated effort** (`low` for trivial/small,
     up to `high` for large/risky — never `ultra`/Workflow). Run the
-    `/code-review` skill on the local diff, then fix every finding it surfaces
+    `/code-review` skill with the **explicit base** `origin/main...HEAD` (e.g.
+    `/code-review low origin/main...HEAD`), then fix every finding it surfaces
     in the worktree and push the fixes. A single review pass, not a fan-out.
+    Pass the base explicitly because in this worktree *both* of the skill's own
+    defaults mislead: the local `main` ref is stale (never updated when other
+    PRs merge, so `main...HEAD` drags in already-merged hunks) and after step
+    12's `git push -u`, `@{upstream}...HEAD` is ~empty (upstream now points at
+    the pushed branch, so it reviews nothing).
 14. **Simplify per the tier.** For **Medium/Large** diffs run the `/simplify`
-    skill; for **Trivial/Small** diffs skip its 4-agent fan-out and do the
-    reuse/simplification/efficiency/altitude review inline, stating what you
-    checked. Push any cleanup.
+    skill with the same explicit base (`/simplify origin/main...HEAD`, for the
+    reason in step 13); for **Trivial/Small** diffs skip its 4-agent fan-out
+    and do the reuse/simplification/efficiency/altitude review inline, stating
+    what you checked. Push any cleanup.
 
 ## Phase 6 — Hand back
 


### PR DESCRIPTION
## Summary

`ir:exec` Phase 5 invoked `/code-review` (step 13) and `/simplify` (step 14) on "the local diff" with **no explicit base**. In an `ir:exec` worktree, both of the review/simplify skills' own fallbacks mislead:

- **`main...HEAD`** — the worktree's local `main` ref is stale (never updated when other PRs merge after the worktree was cut), so it drags in already-merged, unrelated hunks.
- **`@{upstream}...HEAD`** — after step 12's `git push -u`, `@{upstream}` repoints at the pushed feature branch, so the range is ~empty and reviews nothing.

## Change (`.claude/skills/ir:exec/SKILL.md`, Phase 5 only)

- Add `git fetch origin main` before the diff measurement so `origin/main` is current.
- Step 13: invoke `/code-review` with the **explicit base** `origin/main...HEAD` (e.g. `/code-review low origin/main...HEAD`), plus a note on why both bare-invocation defaults mislead.
- Step 14: invoke `/simplify` with the same explicit base (`/simplify origin/main...HEAD`).

Surgical: only Phase 5's review/simplify steps + the measurement fetch. No restructuring. Net `+12/−4` in one file.

## Evidence — the two bases on THIS branch

This being a docs change, "verification" is demonstrating the documented commands produce the correctly-scoped diff. Captured live in this worktree, whose local `main` (`#1144`) sat **10 already-merged commits behind** `origin/main` (`#1158`):

| Base | Result | Verdict |
|---|---|---|
| `git diff origin/main...HEAD` | **1 file, +12/−4**, 1 commit (`SKILL.md`) | correct — only this PR's work |
| `git diff main...HEAD` | **20 files, +676/−46**, 11 commits | wrong — pulls in #1145/#1146/#1148/#1150/#1153/#1154/… (Go source, tests, `star-history.svg`) this PR never touched |

A `/code-review` on the stale-`main` base would have reviewed ~675 lines of already-merged code across 20 files. With the fix's explicit `origin/main...HEAD`, it sees exactly the one file this PR changed.

## Dogfooding

This PR was produced by an `ir:exec full 1160` run, so Phase 5 hit exactly this bug. I applied the fix to my own review: ran `git fetch origin main` and invoked `/code-review low origin/main...HEAD` and `/simplify origin/main...HEAD` explicitly — both correctly scoped to the single SKILL.md file.

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)