### PR TITLE
feat(claudecode): wire the Stop hook → authoritative ready (#1161)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -79,12 +79,13 @@ func Agent() agent.Agent {
 				Kind:            permission.KindModify,
 				Title:           "Install status hooks",
 				FeatureUnlocked: "Instant waiting-state detection (permission prompts, plan approval, questions)",
-				Touches:         "Writes 4 hook entries to ~/.claude/settings.json",
-				Detail: "Adds PermissionRequest, PreToolUse, PostToolUse, and " +
-					"PostToolUseFailure hook entries whose command is: " +
-					installedHookCommand + " — each POSTs the hook payload to the " +
-					"local daemon. Toggling off removes exactly these entries " +
-					"(also available via `irrlichd --uninstall-hooks`).",
+				Touches:         "Writes 6 hook entries to ~/.claude/settings.json",
+				Detail: "Adds PermissionRequest, PreToolUse, PostToolUse, " +
+					"PostToolUseFailure, PreCompact, and Stop hook entries that POST " +
+					"the hook payload to the local daemon at " + hookEndpointURL +
+					" via Claude Code's native http hook (no shell/curl). Toggling " +
+					"off removes exactly these entries (also available via " +
+					"`irrlichd --uninstall-hooks`).",
 				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
 				Remove: func() error { _, err := UninstallHooks(); return err },
 			},

--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -1,30 +1,40 @@
 // hookinstaller.go manages Claude Code hook entries in ~/.claude/settings.json
 // for the irrlicht daemon. It installs PermissionRequest, PreToolUse,
-// PostToolUse, and PostToolUseFailure hooks that POST to the daemon's HTTP
-// endpoint, and can remove them cleanly. (Issues #108, #307.)
+// PostToolUse, PostToolUseFailure, PreCompact and Stop hooks that POST to the
+// daemon's HTTP endpoint via native `type: http` delivery, and can remove them
+// cleanly. (Issues #108, #307, #657, #1161.)
 package claudecode
 
 import (
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
 
-// hookSentinel is the substring in the hook command that identifies irrlicht-
-// managed entries. Used by both install (idempotency check) and uninstall.
+// hookSentinel is the substring in the hook entry (curl command or http url)
+// that identifies irrlicht-managed entries. Used by both install (idempotency
+// check) and uninstall, and by the curl→http migration. It is a substring of
+// both the legacy command and the current URL, so a pre-#1161 install is still
+// recognized as ours and upgraded in place.
 const hookSentinel = "localhost:7837/api/v1/hooks/claudecode"
 
-// installedHookCommand is the curl command installed as the hook handler. It
-// pipes the hook payload (stdin) to the daemon's HTTP endpoint. Flags:
-//   - -f: fail silently on HTTP errors (non-blocking)
-//   - -sS: silent but show errors
-//   - --max-time 1: abort after 1 second (fast no-op when daemon is down)
-//
-// `|| true` keeps exit status 0 when the daemon is down so Claude Code
-// doesn't surface "connection refused" as a PostToolUse hook error.
-const installedHookCommand = "curl -fsS --max-time 1 -X POST --data-binary @- http://localhost:7837/api/v1/hooks/claudecode || true"
+// hookEndpointURL is the daemon endpoint the installed hook posts to. Claude
+// Code delivers the hook payload as a JSON POST body directly to this URL via
+// its native `type: http` hook — no shell, no curl (issue #1161). Removing the
+// curl dependency means hook delivery no longer silently no-ops when curl is
+// missing from PATH, which was the failure mode the OpenToolStalled transcript
+// fallback (#488) exists to cover; that fallback is retained (it still covers a
+// down/unreachable daemon), but its primary trigger is now gone.
+const hookEndpointURL = "http://localhost:7837/api/v1/hooks/claudecode"
+
+// hookTimeoutSeconds bounds how long Claude Code waits on the daemon before
+// giving up on a hook delivery. The daemon's handler is near-instant (an
+// in-memory map write plus a channel send) and a down daemon fails the
+// connection immediately, so this is only a safety ceiling against a wedged
+// daemon — well below Claude Code's 600s default so a hook can never stall a
+// turn.
+const hookTimeoutSeconds = 5
 
 // hookMatcher is the matcher used by PermissionRequest, PostToolUse, and
 // PostToolUseFailure. AskUserQuestion / ExitPlanMode are included so the
@@ -53,31 +63,37 @@ var installedHookEvents = []string{
 	HookPostToolUse,
 	HookPostToolUseFailure,
 	HookPreCompact,
+	HookStop,
 }
 
 // matcherForEvent returns the matcher we install for the given event. For most
 // events this is a tool-name regex; for PreCompact it is the compaction trigger
-// ("manual").
+// ("manual"); for Stop it is empty — Claude Code's Stop hook takes no matcher
+// (it fires at every turn end) and rejects settings.json that gives it one, so
+// addOurHook omits the matcher key entirely for an empty matcher.
 func matcherForEvent(event string) string {
 	switch event {
 	case HookPreToolUse:
 		return hookMatcherPreToolUse
 	case HookPreCompact:
 		return hookMatcherPreCompact
+	case HookStop:
+		return ""
 	default:
 		return hookMatcher
 	}
 }
 
-// HookDeliveryAvailable reports whether the tool the installed hook command
-// relies on to reach the daemon is on PATH. installedHookCommand POSTs via
-// `curl`, so a missing curl means every hook silently no-ops (the trailing
-// `|| true` swallows "command not found") and permission prompts never
-// surface as `waiting`. main.go calls this at startup to turn that otherwise
-// invisible failure into a logged warning (#488).
-func HookDeliveryAvailable() bool {
-	_, err := exec.LookPath("curl")
-	return err == nil
+// ourHookEntry builds the inner hook object we install: native `type: http`
+// delivery straight to the daemon (issue #1161), no shell wrapper. Claude Code
+// POSTs the hook payload as a JSON body to url and treats a 2xx with no body as
+// "no decision" — exactly the daemon's behaviour.
+func ourHookEntry() map[string]interface{} {
+	return map[string]interface{}{
+		"type":    "http",
+		"url":     hookEndpointURL,
+		"timeout": hookTimeoutSeconds,
+	}
 }
 
 // EnsureHooksInstalled adds irrlicht hook entries to ~/.claude/settings.json
@@ -99,7 +115,7 @@ func EnsureHooksInstalled() (bool, error) {
 	modified := false
 	for _, event := range installedHookEvents {
 		expected := matcherForEvent(event)
-		if upgradeStaleHookCommands(hooksMap, event) {
+		if upgradeStaleHookDelivery(hooksMap, event) {
 			modified = true
 		}
 		if upgradeStaleHookMatchers(hooksMap, event, expected) {
@@ -216,28 +232,30 @@ func hasOurHook(hooksMap map[string]interface{}, event string) bool {
 	return false
 }
 
-// upgradeStaleHookCommands rewrites any hook command that contains hookSentinel
-// but isn't the canonical installedHookCommand. Returns true if any entry was
-// rewritten. This migrates users whose settings.json still has an older form
-// of our command (e.g., missing the trailing `|| true`).
-func upgradeStaleHookCommands(hooksMap map[string]interface{}, event string) bool {
+// upgradeStaleHookDelivery rewrites any sentinel-bearing inner hook that is not
+// the canonical native-http entry to the current form. Returns true if any
+// entry was rewritten. This migrates an existing install from the legacy curl
+// `command` wrapper to native `type: http` delivery (issue #1161) — and, more
+// generally, any older shape carrying our sentinel — in place, without
+// appending a duplicate group.
+func upgradeStaleHookDelivery(hooksMap map[string]interface{}, event string) bool {
 	arr, ok := hooksMap[event].([]interface{})
 	if !ok {
 		return false
 	}
 	upgraded := false
 	for _, g := range arr {
-		if upgradeGroupHookCommand(g) {
+		if upgradeGroupHookDelivery(g) {
 			upgraded = true
 		}
 	}
 	return upgraded
 }
 
-// upgradeGroupHookCommand rewrites the command of any inner hook entry in a
-// single matcher group that contains hookSentinel but isn't the canonical
-// installedHookCommand. Returns true if any entry was rewritten.
-func upgradeGroupHookCommand(g interface{}) bool {
+// upgradeGroupHookDelivery rewrites, in one matcher group, every inner hook that
+// carries our sentinel but isn't the canonical native-http entry (e.g. the
+// legacy curl command). Returns true if any entry was rewritten.
+func upgradeGroupHookDelivery(g interface{}) bool {
 	group, ok := g.(map[string]interface{})
 	if !ok {
 		return false
@@ -247,28 +265,25 @@ func upgradeGroupHookCommand(g interface{}) bool {
 		return false
 	}
 	upgraded := false
-	for _, h := range innerHooks {
+	for i, h := range innerHooks {
 		hook, ok := h.(map[string]interface{})
 		if !ok {
 			continue
 		}
-		cmd, ok := hook["command"].(string)
-		if !ok {
-			continue
-		}
-		if strings.Contains(cmd, hookSentinel) && cmd != installedHookCommand {
-			hook["command"] = installedHookCommand
+		if hookEntryIsSentinel(hook) && !hookEntryIsCanonical(hook) {
+			innerHooks[i] = ourHookEntry()
 			upgraded = true
 		}
 	}
 	return upgraded
 }
 
-// upgradeStaleHookMatchers rewrites the matcher of any group containing our
-// sentinel whose matcher differs from the expected value. Used to migrate
-// existing installs when we widen (or change) the matcher for an event — for
-// example, the #307 expansion that adds AskUserQuestion|ExitPlanMode to the
-// PostToolUse matcher.
+// upgradeStaleHookMatchers reconciles the matcher of any group containing our
+// sentinel with the expected value. Used to migrate existing installs when we
+// widen or change an event's matcher (e.g. the #307 expansion that added
+// AskUserQuestion|ExitPlanMode to the PostToolUse matcher). For an event whose
+// expected matcher is empty (Stop, #1161) it strips any matcher key entirely,
+// since Claude Code rejects a Stop hook that carries one.
 func upgradeStaleHookMatchers(hooksMap map[string]interface{}, event, expected string) bool {
 	arr, ok := hooksMap[event].([]interface{})
 	if !ok {
@@ -283,24 +298,41 @@ func upgradeStaleHookMatchers(hooksMap map[string]interface{}, event, expected s
 		if !containsHookSentinel(g) {
 			continue
 		}
-		if m, _ := group["matcher"].(string); m != expected {
-			group["matcher"] = expected
+		if reconcileGroupMatcher(group, expected) {
 			upgraded = true
 		}
 	}
 	return upgraded
 }
 
-// addOurHook appends a matcher group with our hook command to the event's array.
+// reconcileGroupMatcher brings one sentinel-bearing group's matcher into line
+// with expected: sets it when it differs, or deletes the key when expected is
+// empty (a Stop hook must carry no matcher). Returns true if it changed the group.
+func reconcileGroupMatcher(group map[string]interface{}, expected string) bool {
+	m, has := group["matcher"].(string)
+	if expected == "" {
+		if has {
+			delete(group, "matcher")
+			return true
+		}
+		return false
+	}
+	if m != expected {
+		group["matcher"] = expected
+		return true
+	}
+	return false
+}
+
+// addOurHook appends a matcher group with our native-http hook entry to the
+// event's array. The matcher key is omitted entirely for an empty matcher
+// (Stop), which Claude Code requires.
 func addOurHook(hooksMap map[string]interface{}, event, matcher string) {
 	entry := map[string]interface{}{
-		"matcher": matcher,
-		"hooks": []interface{}{
-			map[string]interface{}{
-				"type":    "command",
-				"command": installedHookCommand,
-			},
-		},
+		"hooks": []interface{}{ourHookEntry()},
+	}
+	if matcher != "" {
+		entry["matcher"] = matcher
 	}
 
 	existing, ok := hooksMap[event]
@@ -342,7 +374,8 @@ func removeOurHook(hooksMap map[string]interface{}, event string) bool {
 	return true
 }
 
-// containsHookSentinel checks if a matcher group contains a hook command with our sentinel.
+// containsHookSentinel checks if a matcher group contains an inner hook entry
+// carrying our sentinel — either the legacy curl command or the native-http url.
 func containsHookSentinel(g interface{}) bool {
 	group, ok := g.(map[string]interface{})
 	if !ok {
@@ -357,9 +390,36 @@ func containsHookSentinel(g interface{}) bool {
 		if !ok {
 			continue
 		}
-		if cmd, ok := hook["command"].(string); ok && strings.Contains(cmd, hookSentinel) {
+		if hookEntryIsSentinel(hook) {
 			return true
 		}
 	}
 	return false
+}
+
+// hookEntryIsSentinel reports whether an inner hook object is one of ours,
+// identified by our sentinel appearing in either the legacy `command` (curl) or
+// the current `url` (native http) field.
+func hookEntryIsSentinel(hook map[string]interface{}) bool {
+	if cmd, ok := hook["command"].(string); ok && strings.Contains(cmd, hookSentinel) {
+		return true
+	}
+	if url, ok := hook["url"].(string); ok && strings.Contains(url, hookSentinel) {
+		return true
+	}
+	return false
+}
+
+// hookEntryIsCanonical reports whether an inner hook object is already in the
+// current native-http form: type "http", our endpoint url, and no leftover
+// legacy `command` key. The timeout value is deliberately not part of the
+// identity check, so tuning hookTimeoutSeconds never forces a churny rewrite of
+// every existing install.
+func hookEntryIsCanonical(hook map[string]interface{}) bool {
+	if _, hasCmd := hook["command"]; hasCmd {
+		return false
+	}
+	t, _ := hook["type"].(string)
+	u, _ := hook["url"].(string)
+	return t == "http" && u == hookEndpointURL
 }

--- a/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
@@ -34,8 +34,14 @@ func readJSON(t *testing.T, path string) map[string]interface{} {
 // AskUserQuestion / ExitPlanMode expansion.
 const legacyMatcher = "Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*"
 
+// legacyCurlHookCommand is the pre-#1161 curl command form of our hook, used to
+// seed fixtures that simulate an existing install from before native http
+// delivery, so the migration path can be exercised.
+const legacyCurlHookCommand = "curl -fsS --max-time 1 -X POST --data-binary @- http://localhost:7837/api/v1/hooks/claudecode || true"
+
 // makeHookGroup builds a settings.json hook matcher group with the given
-// matcher and command. Used by tests to seed fixtures.
+// matcher and a legacy `type: command` inner hook. Used by tests to seed
+// pre-#1161 (curl) and foreign fixtures.
 func makeHookGroup(matcher, command string) map[string]interface{} {
 	return map[string]interface{}{
 		"matcher": matcher,
@@ -45,6 +51,37 @@ func makeHookGroup(matcher, command string) map[string]interface{} {
 				"command": command,
 			},
 		},
+	}
+}
+
+// ourHookGroup builds a settings.json group in our current native-http form
+// (matcher key omitted when empty), mirroring addOurHook. Used to seed fixtures
+// that simulate an already-migrated install.
+func ourHookGroup(matcher string) map[string]interface{} {
+	group := map[string]interface{}{"hooks": []interface{}{ourHookEntry()}}
+	if matcher != "" {
+		group["matcher"] = matcher
+	}
+	return group
+}
+
+// assertHTTPEntry fails unless the group's single inner hook is our canonical
+// native-http entry: type "http", our endpoint url, and no leftover command key.
+func assertHTTPEntry(t *testing.T, group map[string]interface{}) {
+	t.Helper()
+	inner, ok := group["hooks"].([]interface{})
+	if !ok || len(inner) != 1 {
+		t.Fatalf("expected exactly 1 inner hook, got %v", group["hooks"])
+	}
+	hook := inner[0].(map[string]interface{})
+	if _, hasCmd := hook["command"]; hasCmd {
+		t.Errorf("http entry must not carry a legacy command key: %v", hook)
+	}
+	if ty, _ := hook["type"].(string); ty != "http" {
+		t.Errorf("type = %q, want %q", ty, "http")
+	}
+	if u, _ := hook["url"].(string); u != hookEndpointURL {
+		t.Errorf("url = %q, want %q", u, hookEndpointURL)
 	}
 }
 
@@ -128,22 +165,20 @@ func TestEnsureHooksInstalled_PreservesExistingHooks(t *testing.T) {
 	}
 }
 
-func TestEnsureHooksInstalled_UpgradesStaleCommand(t *testing.T) {
+// TestEnsureHooksInstalled_MigratesCurlToHTTP verifies that a pre-#1161 install
+// whose hook is the legacy curl `command` is migrated in place to native
+// `type: http` delivery — the command key dropped, the http url set, no group
+// appended — and that the matcher is reconciled at the same time (#1161).
+func TestEnsureHooksInstalled_MigratesCurlToHTTP(t *testing.T) {
 	home := withTempHome(t)
 	path := filepath.Join(home, ".claude", "settings.json")
 
-	// Stale command: same sentinel, but missing the trailing `|| true`.
-	const staleCommand = "curl -fsS --max-time 1 -X POST --data-binary @- http://localhost:7837/api/v1/hooks/claudecode"
-	if staleCommand == installedHookCommand {
-		t.Fatal("stale command must differ from canonical command for this test to be meaningful")
-	}
-
 	// Legacy install: a single PostToolUse group with the pre-#307 narrow
-	// matcher and the stale command. EnsureHooksInstalled should upgrade
-	// both the command and the matcher in place — no group append.
+	// matcher and the curl command. EnsureHooksInstalled should upgrade both the
+	// delivery (curl → http) and the matcher in place — no group append.
 	existing := map[string]interface{}{
 		"hooks": map[string]interface{}{
-			HookPostToolUse: []interface{}{makeHookGroup(legacyMatcher, staleCommand)},
+			HookPostToolUse: []interface{}{makeHookGroup(legacyMatcher, legacyCurlHookCommand)},
 		},
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -159,7 +194,7 @@ func TestEnsureHooksInstalled_UpgradesStaleCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !modified {
-		t.Fatal("expected modified=true when upgrading stale command")
+		t.Fatal("expected modified=true when migrating curl → http")
 	}
 
 	settings := readJSON(t, path)
@@ -177,11 +212,7 @@ func TestEnsureHooksInstalled_UpgradesStaleCommand(t *testing.T) {
 	if m, _ := group["matcher"].(string); m != hookMatcher {
 		t.Errorf("expected matcher upgraded to %q, got %q", hookMatcher, m)
 	}
-	innerHooks := group["hooks"].([]interface{})
-	cmd := innerHooks[0].(map[string]interface{})["command"].(string)
-	if cmd != installedHookCommand {
-		t.Fatalf("expected upgraded command, got %q", cmd)
-	}
+	assertHTTPEntry(t, group)
 
 	// Second call must be idempotent.
 	modified, err = EnsureHooksInstalled()
@@ -300,6 +331,69 @@ func TestEnsureHooksInstalled_InstallsPreToolUseAndExpandedMatcher(t *testing.T)
 	if m, _ := preCompactGroup["matcher"].(string); m != hookMatcherPreCompact {
 		t.Errorf("PreCompact matcher = %q, want %q", m, hookMatcherPreCompact)
 	}
+
+	// Stop: one group with NO matcher key (Claude Code rejects a Stop matcher)
+	// and native http delivery (#1161).
+	stop, ok := hooksMap[HookStop].([]interface{})
+	if !ok || len(stop) != 1 {
+		t.Fatalf("expected 1 Stop group, got %d", len(stop))
+	}
+	stopGroup := stop[0].(map[string]interface{})
+	if _, has := stopGroup["matcher"]; has {
+		t.Errorf("Stop group must not carry a matcher key, got %v", stopGroup["matcher"])
+	}
+	assertHTTPEntry(t, stopGroup)
+}
+
+// TestEnsureHooksInstalled_AddsStopToExistingInstall verifies the idempotent
+// installer adds the newly-listed Stop event to a settings.json that already
+// carries the five prior events (in native-http form), without duplicating them
+// — the upgrade path for existing installs (#1161).
+func TestEnsureHooksInstalled_AddsStopToExistingInstall(t *testing.T) {
+	home := withTempHome(t)
+
+	existing := map[string]interface{}{"hooks": map[string]interface{}{}}
+	hooks := existing["hooks"].(map[string]interface{})
+	for _, ev := range []string{HookPermissionRequest, HookPreToolUse, HookPostToolUse, HookPostToolUseFailure, HookPreCompact} {
+		hooks[ev] = []interface{}{ourHookGroup(matcherForEvent(ev))}
+	}
+	path := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(existing)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true (Stop was missing)")
+	}
+
+	settings := readJSON(t, path)
+	hooksMap := settings["hooks"].(map[string]interface{})
+	stop, ok := hooksMap[HookStop].([]interface{})
+	if !ok || len(stop) != 1 {
+		t.Fatalf("expected exactly 1 Stop group after upgrade, got %d", len(stop))
+	}
+	stopGroup := stop[0].(map[string]interface{})
+	if _, has := stopGroup["matcher"]; has {
+		t.Errorf("Stop group must not carry a matcher key, got %v", stopGroup["matcher"])
+	}
+	assertHTTPEntry(t, stopGroup)
+
+	// Re-running must be a no-op now that all six events are present.
+	modified, err = EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modified {
+		t.Errorf("expected modified=false on second run (already installed)")
+	}
 }
 
 // TestEnsureHooksInstalled_AddsPreCompactToExistingInstall verifies the
@@ -313,7 +407,7 @@ func TestEnsureHooksInstalled_AddsPreCompactToExistingInstall(t *testing.T) {
 	existing := map[string]interface{}{"hooks": map[string]interface{}{}}
 	hooks := existing["hooks"].(map[string]interface{})
 	for _, ev := range []string{HookPermissionRequest, HookPreToolUse, HookPostToolUse, HookPostToolUseFailure} {
-		hooks[ev] = []interface{}{makeHookGroup(matcherForEvent(ev), installedHookCommand)}
+		hooks[ev] = []interface{}{ourHookGroup(matcherForEvent(ev))}
 	}
 	path := filepath.Join(home, ".claude", "settings.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -359,7 +453,7 @@ func TestEnsureHooksInstalled_MigratesLegacyMatchers(t *testing.T) {
 	path := filepath.Join(home, ".claude", "settings.json")
 
 	legacy := func() []interface{} {
-		return []interface{}{makeHookGroup(legacyMatcher, installedHookCommand)}
+		return []interface{}{makeHookGroup(legacyMatcher, legacyCurlHookCommand)}
 	}
 	existing := map[string]interface{}{
 		"hooks": map[string]interface{}{

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -294,12 +294,21 @@ func handleStopHook(target HookTarget, log outbound.Logger, sessionID string, pa
 	log.LogInfo(logComponentHookReceiver, sessionID,
 		fmt.Sprintf("received %s (%d chars of assistant text)", payload.HookEventName, len(payload.LastAssistantMessage)))
 
-	win := tailer.WaitingScanWindow(payload.LastAssistantMessage)
-	waitingCue := win != "" &&
-		(session.ExtractQuestionSnippet(win) != "" || session.ExtractWaitingCue(win) != "")
-
 	target.HandleStopHook(sessionID, payload.TranscriptPath,
-		tailer.TruncateAssistantText(payload.LastAssistantMessage), waitingCue)
+		tailer.TruncateAssistantText(payload.LastAssistantMessage),
+		waitingCueInTail(payload.LastAssistantMessage))
+}
+
+// waitingCueInTail reports whether the bounded tail window of an assistant
+// message carries a trailing question or an imperative waiting cue (issue
+// #1150). Bounded, not full text: ExtractWaitingCue over-fires on very long
+// turns (see tailer.MaxWaitingScanRunes). Shared by the transcript parser
+// (PendingWaitingCue) and the Stop-hook handler (#1161) so the window size and
+// the OR-of-two-detectors rule can't drift between the two paths.
+func waitingCueInTail(full string) bool {
+	win := tailer.WaitingScanWindow(full)
+	return win != "" &&
+		(session.ExtractQuestionSnippet(win) != "" || session.ExtractWaitingCue(win) != "")
 }
 
 // handlePreToolUseHook processes a PreToolUse hook event: scans the tool

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -1,9 +1,11 @@
 // hooks.go provides the HTTP handler for receiving Claude Code hook events.
-// Claude Code fires hooks on PermissionRequest, PreToolUse, PostToolUse, and
-// PostToolUseFailure — the daemon uses these to surface user-blocking state
-// in the classifier. PermissionRequest covers permission gates (issue #108);
-// PreToolUse on AskUserQuestion / ExitPlanMode covers user-input overlays
-// that block the agent before the transcript is flushed (issue #307).
+// Claude Code fires hooks on PermissionRequest, PreToolUse, PostToolUse,
+// PostToolUseFailure, PreCompact and Stop — the daemon uses these to surface
+// user-blocking and turn-done state in the classifier. PermissionRequest covers
+// permission gates (issue #108); PreToolUse on AskUserQuestion / ExitPlanMode
+// covers user-input overlays that block the agent before the transcript is
+// flushed (issue #307); Stop is the authoritative per-turn done signal
+// delivered at true turn end, carrying the final assistant text (issue #1161).
 package claudecode
 
 import (
@@ -20,13 +22,16 @@ import (
 )
 
 // Hook event names. Claude Code fires these; the daemon recognizes only
-// these five and ignores everything else.
+// these six and ignores everything else.
 const (
 	HookPermissionRequest  = "PermissionRequest"
 	HookPreToolUse         = "PreToolUse"
 	HookPostToolUse        = "PostToolUse"
 	HookPostToolUseFailure = "PostToolUseFailure"
 	HookPreCompact         = "PreCompact"
+	// HookStop fires once at true turn end, carrying last_assistant_message.
+	// It is the authoritative turn-done signal for claudecode (issue #1161).
+	HookStop = "Stop"
 )
 
 // compactTriggerManual is the PreCompact trigger value for a user-invoked
@@ -61,6 +66,9 @@ type hookPayload struct {
 	// Trigger is "manual" or "auto" on PreCompact events (the compaction
 	// cause). Empty on other hook events.
 	Trigger string `json:"trigger,omitempty"`
+	// LastAssistantMessage is the full text of the turn's final assistant
+	// message, carried by the Stop hook (issue #1161). Empty on other events.
+	LastAssistantMessage string `json:"last_assistant_message,omitempty"`
 }
 
 // HookTarget is the interface the handler calls into. Satisfied by
@@ -71,6 +79,12 @@ type HookTarget interface {
 	// manual /compact, whose compaction window writes nothing to the transcript
 	// (#657). trigger is the PreCompact cause ("manual" / "auto").
 	HandleCompactHook(sessionID, transcriptPath, trigger string)
+	// HandleStopHook records the authoritative turn-done signal from Claude
+	// Code's Stop hook (#1161). lastAssistantText is the turn's final assistant
+	// text, already display-truncated; waitingCue reports whether that message
+	// carried a question or imperative cue (computed from the full text so a cue
+	// beyond the display tail still routes the turn to waiting, not ready).
+	HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool)
 }
 
 // MarkerTarget is the narrow interface for hook-carried task-estimate
@@ -235,6 +249,8 @@ func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGrant
 		handlePreCompactHook(target, log, sessionID, payload)
 	case HookPreToolUse:
 		handlePreToolUseHook(markers, log, sessionID, payload, dispatch)
+	case HookStop:
+		handleStopHook(target, log, sessionID, payload)
 	default:
 		// Unrecognized hook event — accept but ignore.
 		log.LogInfo(logComponentHookReceiver, sessionID,
@@ -261,6 +277,29 @@ func handlePreCompactHook(target HookTarget, log outbound.Logger, sessionID stri
 		log.LogInfo(logComponentHookReceiver, sessionID,
 			fmt.Sprintf("ignored %s (trigger=%q, not manual)", payload.HookEventName, payload.Trigger))
 	}
+}
+
+// handleStopHook processes a Claude Code Stop hook — the authoritative
+// turn-done push delivered at true turn end (#1161). It forwards a turn-done
+// signal plus the turn's final assistant text so the classifier decides
+// ready-vs-waiting from the same message IsWaitingForUserInput reads, without
+// depending on the transcript-tail heuristic (and its codex carve-out).
+//
+// The forwarded text is display-truncated; the waiting-cue verdict is computed
+// from a bounded tail window (WaitingScanWindow) of the FULL message — the same
+// window parser.go uses for PendingWaitingCue — so a question or cue sitting
+// before the display tail still routes the turn to waiting, while ExtractWaitingCue
+// is not fed the whole (possibly very long) turn, where it over-fires.
+func handleStopHook(target HookTarget, log outbound.Logger, sessionID string, payload hookPayload) {
+	log.LogInfo(logComponentHookReceiver, sessionID,
+		fmt.Sprintf("received %s (%d chars of assistant text)", payload.HookEventName, len(payload.LastAssistantMessage)))
+
+	win := tailer.WaitingScanWindow(payload.LastAssistantMessage)
+	waitingCue := win != "" &&
+		(session.ExtractQuestionSnippet(win) != "" || session.ExtractWaitingCue(win) != "")
+
+	target.HandleStopHook(sessionID, payload.TranscriptPath,
+		tailer.TruncateAssistantText(payload.LastAssistantMessage), waitingCue)
 }
 
 // handlePreToolUseHook processes a PreToolUse hook event: scans the tool

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -13,12 +13,13 @@ import (
 	"irrlicht/core/internal/contracttesting"
 )
 
-// mockTarget records calls to HandlePermissionHook and HandleCompactHook for
-// assertions.
+// mockTarget records calls to HandlePermissionHook, HandleCompactHook and
+// HandleStopHook for assertions.
 type mockTarget struct {
 	mu           sync.Mutex
 	calls        []hookCall
 	compactCalls []compactCall
+	stopCalls    []stopCall
 }
 
 type hookCall struct {
@@ -27,6 +28,11 @@ type hookCall struct {
 
 type compactCall struct {
 	sessionID, transcriptPath, trigger string
+}
+
+type stopCall struct {
+	sessionID, transcriptPath, lastAssistantText string
+	waitingCue                                   bool
 }
 
 func (m *mockTarget) HandlePermissionHook(sessionID, transcriptPath, hookEventName string) {
@@ -41,6 +47,12 @@ func (m *mockTarget) HandleCompactHook(sessionID, transcriptPath, trigger string
 	m.compactCalls = append(m.compactCalls, compactCall{sessionID, transcriptPath, trigger})
 }
 
+func (m *mockTarget) HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopCalls = append(m.stopCalls, stopCall{sessionID, transcriptPath, lastAssistantText, waitingCue})
+}
+
 func (m *mockTarget) getCalls() []hookCall {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -51,6 +63,7 @@ func (m *mockTarget) reset() {
 	m.mu.Lock()
 	m.calls = nil
 	m.compactCalls = nil
+	m.stopCalls = nil
 	m.mu.Unlock()
 }
 
@@ -58,6 +71,12 @@ func (m *mockTarget) getCompactCalls() []compactCall {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return append([]compactCall{}, m.compactCalls...)
+}
+
+func (m *mockTarget) getStopCalls() []stopCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]stopCall{}, m.stopCalls...)
 }
 
 // mockLogger satisfies outbound.Logger.
@@ -260,6 +279,77 @@ func TestHookHandler_PreCompactAuto(t *testing.T) {
 	}
 	if got := target.getCompactCalls(); len(got) != 0 {
 		t.Errorf("auto PreCompact should not dispatch; got %+v", got)
+	}
+}
+
+// TestHookHandler_Stop verifies a Stop hook routes to HandleStopHook with the
+// turn's final assistant text (display-truncated) and waitingCue=false when the
+// message is a plain completion, so the classifier can mark the turn done →
+// ready (#1161). It must not reach the permission or compact paths.
+func TestHookHandler_Stop(t *testing.T) {
+	target := &mockTarget{}
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
+
+	payload := hookPayload{
+		TranscriptPath:       "/Users/u/.claude/projects/p/sess-stop.jsonl",
+		HookEventName:        "Stop",
+		LastAssistantMessage: "All tests pass. The refactor is complete.",
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if len(target.getCalls()) != 0 || len(target.getCompactCalls()) != 0 {
+		t.Errorf("Stop must not reach permission/compact paths; perm=%+v compact=%+v",
+			target.getCalls(), target.getCompactCalls())
+	}
+	stops := target.getStopCalls()
+	if len(stops) != 1 {
+		t.Fatalf("got %d HandleStopHook calls, want 1", len(stops))
+	}
+	if stops[0].sessionID != "sess-stop" {
+		t.Errorf("sessionID = %q, want %q", stops[0].sessionID, "sess-stop")
+	}
+	if stops[0].lastAssistantText != "All tests pass. The refactor is complete." {
+		t.Errorf("lastAssistantText = %q, want the full (short) message", stops[0].lastAssistantText)
+	}
+	if stops[0].waitingCue {
+		t.Errorf("waitingCue = true for a plain completion message, want false")
+	}
+}
+
+// TestHookHandler_StopEndingInQuestion verifies a Stop hook whose final message
+// ends on a question is reported with waitingCue=true, so a turn that ended by
+// asking the user routes to waiting rather than ready (#1161).
+func TestHookHandler_StopEndingInQuestion(t *testing.T) {
+	target := &mockTarget{}
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
+
+	payload := hookPayload{
+		TranscriptPath:       "/Users/u/.claude/projects/p/sess-q.jsonl",
+		HookEventName:        "Stop",
+		LastAssistantMessage: "I can take either approach. Which option do you prefer?",
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	stops := target.getStopCalls()
+	if len(stops) != 1 {
+		t.Fatalf("got %d HandleStopHook calls, want 1", len(stops))
+	}
+	if !stops[0].waitingCue {
+		t.Errorf("waitingCue = false for a message ending in a question, want true")
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"strings"
 
-	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/pkg/transcript"
 )
@@ -786,9 +785,7 @@ func applyAssistantText(raw map[string]interface{}, ev *tailer.ParsedEvent, even
 		// truncation (e.g. codex) share this beyond-tail blind spot; the plumbing
 		// (ParsedEvent.PendingWaitingCue → tailer → domain) is adapter-agnostic,
 		// so each can adopt it by computing PendingWaitingCue the same way here.
-		win := tailer.WaitingScanWindow(full)
-		ev.PendingWaitingCue = win != "" &&
-			(session.ExtractQuestionSnippet(win) != "" || session.ExtractWaitingCue(win) != "")
+		ev.PendingWaitingCue = waitingCueInTail(full)
 	case "user", "user_message", "user_input":
 		ev.ClearToolNames = true
 		ev.UserText = tailer.ExtractUserText(raw)

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -210,6 +210,15 @@ type SessionDetector struct {
 	// permissionPending.
 	compactPending map[string]int64 // sessionID → unix seconds (hook fire time)
 
+	// hookTurnDone tracks sessions whose Claude Code Stop hook (#1161) has fired
+	// but whose resulting classify pass hasn't consumed it yet: sessionID → the
+	// turn's final assistant text (display-truncated) and whether it carried a
+	// waiting cue. Set by HandleStopHook; consumed and cleared by
+	// overlayHookTurnDone on the next classify pass (consume-once, so the
+	// authoritative turn-done signal never bleeds into the following turn).
+	// Guarded by permMu — same goroutine-crossing story as permissionPending.
+	hookTurnDone map[string]hookStopSignal // sessionID → Stop-hook payload
+
 	// editToolOpenSince tracks, per session, the Unix time a permission-gated
 	// file-edit tool first appeared open. Guarded by permMu. Drives the
 	// OpenToolStalled transcript fallback (#488): an edit tool open past
@@ -315,6 +324,7 @@ func NewSessionDetector(watchers []inbound.Watcher, deps SessionDetectorDeps) *S
 		deletedCooldown:          10 * time.Second,
 		permissionPending:        make(map[string]bool),
 		compactPending:           make(map[string]int64),
+		hookTurnDone:             make(map[string]hookStopSignal),
 		editToolOpenSince:        make(map[string]int64),
 		idleProjectRetryAttempts: make(map[string]int),
 		bgLiveProbe:              anyLiveOutputWriter,

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -778,6 +778,11 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 	// fswatcher re-evaluations while the permission prompt is shown.
 	d.overlayPermissionPending(state)
 
+	// Overlay the authoritative Stop-hook turn-done signal (#1161). Consume-once:
+	// makes IsAgentDone authoritative for this pass and refreshes the
+	// waiting-vs-ready inputs from the hook's final assistant message.
+	d.overlayHookTurnDone(state)
+
 	// Overlay the PreCompact force-working hold (#657).
 	d.applyCompactHold(ev.SessionID, state.Metrics, time.Now().Unix())
 
@@ -860,6 +865,42 @@ func (d *SessionDetector) overlayPermissionPending(state *session.SessionState) 
 		return
 	}
 	state.Metrics.PermissionPending = true
+}
+
+// overlayHookTurnDone folds the Claude Code Stop-hook turn-done signal (#1161)
+// onto metrics for one classify pass. It is consume-once: the entry is deleted
+// as it is read, so the authoritative done-signal applies to exactly the pass
+// the Stop hook triggered and never bleeds into the next turn (a later real
+// turn's first activity re-opens the session normally via
+// forceReadyToWorkingIfActive). Must run after RefreshOnActivity (which rebuilds
+// metrics from the transcript, zeroing this transient field) and before
+// ClassifyState / IsAgentDone, which read it.
+//
+// The final assistant text overwrites LastAssistantText for display; the
+// waiting-cue verdict — computed by the adapter from the message's full text —
+// only ever adds to PendingWaitingCue, never clears the parser's own verdict,
+// so the hook can push a turn to waiting but never mask a cue the transcript
+// already found.
+func (d *SessionDetector) overlayHookTurnDone(state *session.SessionState) {
+	if state.Metrics == nil {
+		return
+	}
+	d.permMu.Lock()
+	defer d.permMu.Unlock()
+
+	sig, ok := d.hookTurnDone[state.SessionID]
+	if !ok {
+		return
+	}
+	delete(d.hookTurnDone, state.SessionID)
+
+	state.Metrics.HookTurnDone = true
+	if sig.lastAssistantText != "" {
+		state.Metrics.LastAssistantText = sig.lastAssistantText
+	}
+	if sig.waitingCue {
+		state.Metrics.PendingWaitingCue = true
+	}
 }
 
 // holdParentForActiveChildren fast-forwards a parent's own transition when

--- a/core/application/services/session_detector_hook_turn_done_test.go
+++ b/core/application/services/session_detector_hook_turn_done_test.go
@@ -1,0 +1,90 @@
+package services
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestOverlayHookTurnDone covers the Stop-hook turn-done overlay (#1161):
+// consume-once semantics, the display-text overwrite, the additive waiting-cue
+// verdict, and the no-op guards. White-box so it can drive the unexported
+// overlay + hookTurnDone map directly.
+func TestOverlayHookTurnDone(t *testing.T) {
+	const sid = "s"
+
+	t.Run("fresh signal is applied and consumed once", func(t *testing.T) {
+		d := &SessionDetector{hookTurnDone: map[string]hookStopSignal{
+			sid: {lastAssistantText: "Which option?", waitingCue: true},
+		}}
+		state := &session.SessionState{SessionID: sid, Metrics: &session.SessionMetrics{}}
+
+		d.overlayHookTurnDone(state)
+		if !state.Metrics.HookTurnDone {
+			t.Error("HookTurnDone must be set for a session with a pending Stop signal")
+		}
+		if state.Metrics.LastAssistantText != "Which option?" {
+			t.Errorf("LastAssistantText = %q, want the hook's message", state.Metrics.LastAssistantText)
+		}
+		if !state.Metrics.PendingWaitingCue {
+			t.Error("PendingWaitingCue must be set when the hook reported a waiting cue")
+		}
+		if _, ok := d.hookTurnDone[sid]; ok {
+			t.Error("signal must be consumed (deleted) after one overlay pass")
+		}
+
+		// Consume-once: a second pass on a fresh metrics struct must NOT re-apply.
+		next := &session.SessionState{SessionID: sid, Metrics: &session.SessionMetrics{}}
+		d.overlayHookTurnDone(next)
+		if next.Metrics.HookTurnDone {
+			t.Error("consumed signal must not bleed into the next pass")
+		}
+	})
+
+	t.Run("empty text does not clobber existing LastAssistantText", func(t *testing.T) {
+		d := &SessionDetector{hookTurnDone: map[string]hookStopSignal{
+			sid: {lastAssistantText: "", waitingCue: false},
+		}}
+		state := &session.SessionState{SessionID: sid, Metrics: &session.SessionMetrics{
+			LastAssistantText: "prior text",
+		}}
+		d.overlayHookTurnDone(state)
+		if state.Metrics.LastAssistantText != "prior text" {
+			t.Errorf("LastAssistantText = %q, want the prior text preserved", state.Metrics.LastAssistantText)
+		}
+		if !state.Metrics.HookTurnDone {
+			t.Error("HookTurnDone must still be set even with an empty message")
+		}
+	})
+
+	t.Run("waitingCue is additive — never clears the parser's verdict", func(t *testing.T) {
+		d := &SessionDetector{hookTurnDone: map[string]hookStopSignal{
+			sid: {lastAssistantText: "done", waitingCue: false},
+		}}
+		state := &session.SessionState{SessionID: sid, Metrics: &session.SessionMetrics{
+			PendingWaitingCue: true, // the parser already found a cue
+		}}
+		d.overlayHookTurnDone(state)
+		if !state.Metrics.PendingWaitingCue {
+			t.Error("a false hook cue must not clear a PendingWaitingCue the parser set")
+		}
+	})
+
+	t.Run("no pending signal is a no-op", func(t *testing.T) {
+		d := &SessionDetector{hookTurnDone: map[string]hookStopSignal{}}
+		state := &session.SessionState{SessionID: sid, Metrics: &session.SessionMetrics{}}
+		d.overlayHookTurnDone(state)
+		if state.Metrics.HookTurnDone {
+			t.Error("a session with no pending Stop signal must not be marked done")
+		}
+	})
+
+	t.Run("nil metrics is a no-op", func(t *testing.T) {
+		d := &SessionDetector{hookTurnDone: map[string]hookStopSignal{sid: {}}}
+		state := &session.SessionState{SessionID: sid, Metrics: nil}
+		d.overlayHookTurnDone(state) // must not panic
+		if _, ok := d.hookTurnDone[sid]; !ok {
+			t.Error("nil metrics must leave the pending signal untouched")
+		}
+	})
+}

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -45,6 +45,7 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	d.permMu.Lock()
 	delete(d.permissionPending, ev.SessionID)
 	delete(d.compactPending, ev.SessionID)
+	delete(d.hookTurnDone, ev.SessionID)
 	delete(d.editToolOpenSince, ev.SessionID)
 	delete(d.idleProjectRetryAttempts, ev.SessionID)
 	d.permMu.Unlock()
@@ -322,6 +323,42 @@ func (d *SessionDetector) dispatchHookActivity(sessionID, transcriptPath, hookNa
 		d.log.LogError("hook-receiver", sessionID,
 			fmt.Sprintf("debouncedEvents channel full, %s hook event dropped", hookName))
 	}
+}
+
+// hookStopSignal carries what Claude Code's Stop hook (#1161) delivers for one
+// turn: the turn's final assistant text (already display-truncated by the
+// adapter) and whether that message carried a question / imperative waiting cue
+// (computed by the adapter from the full text). Stored per session until the
+// next classify pass consumes it.
+type hookStopSignal struct {
+	lastAssistantText string
+	waitingCue        bool
+}
+
+// HandleStopHook records the authoritative turn-done signal from Claude Code's
+// Stop hook (issue #1161), which fires once at true turn end and carries the
+// turn's final assistant text. Marking hookTurnDone makes the next classify
+// pass overlay SessionMetrics.HookTurnDone (so IsAgentDone is authoritative,
+// not inferred from the transcript tail) and overwrite LastAssistantText /
+// PendingWaitingCue from the hook's message — so a turn that ended on a
+// question still routes to waiting, not ready.
+//
+// Safe to call from any goroutine (e.g. the HTTP handler).
+func (d *SessionDetector) HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool) {
+	d.permMu.Lock()
+	d.hookTurnDone[sessionID] = hookStopSignal{
+		lastAssistantText: lastAssistantText,
+		waitingCue:        waitingCue,
+	}
+	d.permMu.Unlock()
+
+	// classifyAndTransition overlays HookTurnDone onto the metrics before
+	// calling ClassifyState. The Stop hook fires at true turn end (after the
+	// transcript flush), so a synthetic activity event is what drives the
+	// re-classification now rather than waiting for the next fswatcher pass.
+	// The literal "Stop" mirrors HandleCompactHook's "PreCompact" — the services
+	// layer must not import the claudecode adapter for its HookStop constant.
+	d.dispatchHookActivity(sessionID, transcriptPath, "Stop")
 }
 
 // HandleCompactHook processes a Claude Code PreCompact hook for a manual

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -61,7 +61,11 @@ func ClassifyState(currentState string, metrics *session.SessionMetrics) (string
 		return transitionTo(currentState, session.StateWaiting, "stalled edit tool → likely permission prompt → waiting")
 	}
 
-	// 2. Agent finished turn — check if waiting for user input first.
+	// 2. Agent finished turn — check if waiting for user input first. A
+	// hook-delivered Stop (claudecode, #1161) is authoritative here: IsAgentDone
+	// consults metrics.HookTurnDone ahead of the transcript-tail heuristic, so a
+	// Stop routes through the same classifyAgentDone path (a turn that ended on a
+	// question/cue still lands in waiting, not ready).
 	if metrics.IsAgentDone() {
 		return classifyAgentDone(currentState, metrics)
 	}

--- a/core/application/services/state_classifier_test.go
+++ b/core/application/services/state_classifier_test.go
@@ -287,6 +287,54 @@ func TestClassifyState(t *testing.T) {
 			},
 			wantState: session.StateReady,
 		},
+
+		// Rule 2 via the Stop hook (#1161): HookTurnDone is authoritative even
+		// when the transcript-tail signal (LastEventType) hasn't landed yet.
+		{
+			name:    "working → ready (hook Stop, no cue, no turn_done)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				HookTurnDone:      true,
+				LastEventType:     "assistant_streaming", // not a transcript-done signal
+				LastAssistantText: "Done. The tests pass.",
+			},
+			wantState:  session.StateReady,
+			wantReason: true,
+		},
+		{
+			name:    "working → waiting (hook Stop carried a waiting cue)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				HookTurnDone:      true,
+				PendingWaitingCue: true,
+				LastAssistantText: "Which option do you prefer?",
+			},
+			wantState:  session.StateWaiting,
+			wantReason: true,
+		},
+		{
+			// A Stop that fires while a sub-agent tool is still open must NOT
+			// flip the session to ready — the open-tool guard in IsAgentDone
+			// wins over HookTurnDone.
+			name:    "working stays working (hook Stop but tool still open)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				HookTurnDone:    true,
+				HasOpenToolCall: true,
+			},
+			wantState: session.StateWorking,
+		},
+		{
+			// Likewise a live background process (Bash run_in_background)
+			// outlives the turn — HookTurnDone does not override it (#445).
+			name:    "working stays working (hook Stop but live background process)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				HookTurnDone:             true,
+				HasLiveBackgroundProcess: true,
+			},
+			wantState: session.StateWorking,
+		},
 		{
 			// Codex emits preliminary assistant_message events BEFORE tool
 			// calls in the same turn — treating them as terminal would cause

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -1010,14 +1010,11 @@ func startBackgroundLoops(deps startBackgroundLoopsDeps) context.CancelFunc {
 
 	if !deps.DemoMode {
 		deps.PermService.Start(detectorCtx)
-		// The installed hooks POST via curl; without it they silently no-op
-		// and tool-use permission prompts never surface as `waiting`. Warn
-		// loudly so this isn't an invisible failure (the transcript
-		// heuristic still covers held file-edit prompts). See #488.
-		if deps.PermService.Granted(claudecode.AdapterName, claudecode.PermissionKeyHooks) &&
-			!claudecode.HookDeliveryAvailable() {
-			logger.LogError("startup", "", "curl not found on PATH — Claude Code permission-prompt detection is degraded: hooks POST via curl, so without it permission prompts may not surface as 'waiting'. Install curl to restore full detection (#488).")
-		}
+		// Hooks are delivered by Claude Code's native `type: http` transport
+		// straight to the daemon (#1161) — no curl, no shell — so there is no
+		// external tool whose absence could silently no-op delivery (the reason
+		// the pre-#1161 curl-on-PATH startup warning existed). The transcript
+		// OpenToolStalled fallback (#488) still covers a down/unreachable daemon.
 	}
 
 	return detectorCancel

--- a/core/domain/session/hook_turn_done_test.go
+++ b/core/domain/session/hook_turn_done_test.go
@@ -1,0 +1,55 @@
+package session
+
+import "testing"
+
+// IsAgentDone must treat the Claude Code Stop hook (HookTurnDone) as an
+// authoritative turn-done signal — true even when the transcript-tail
+// LastEventType hasn't landed a done signal — while still yielding to the
+// open-tool and live-background-process guards, which outlive the turn. See
+// issue #1161 (and #445 for the background-process guard).
+func TestIsAgentDone_HookTurnDone(t *testing.T) {
+	cases := []struct {
+		name string
+		m    *SessionMetrics
+		want bool
+	}{
+		{
+			name: "hook Stop, no transcript done signal → done",
+			m:    &SessionMetrics{HookTurnDone: true, LastEventType: "assistant_streaming"},
+			want: true,
+		},
+		{
+			name: "hook Stop with open tool call → not done",
+			m:    &SessionMetrics{HookTurnDone: true, HasOpenToolCall: true},
+			want: false,
+		},
+		{
+			name: "hook Stop with live background process → not done",
+			m:    &SessionMetrics{HookTurnDone: true, HasLiveBackgroundProcess: true},
+			want: false,
+		},
+		{
+			name: "no hook, no transcript done signal → not done",
+			m:    &SessionMetrics{LastEventType: "assistant_streaming"},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.m.IsAgentDone(); got != tc.want {
+				t.Errorf("IsAgentDone() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// HookTurnDone is a per-pass overlay the detector re-sets fresh each pass, so
+// MergeMetrics must not carry it forward from the prior pass — otherwise a
+// single Stop hook would strand the session as "done" across the next turn.
+func TestMergeMetrics_HookTurnDoneNotCarriedForward(t *testing.T) {
+	old := &SessionMetrics{HookTurnDone: true}
+	merged := MergeMetrics(&SessionMetrics{LastEventType: "assistant_streaming"}, old)
+	if merged.HookTurnDone {
+		t.Errorf("HookTurnDone carried forward from prior pass; want reset to false")
+	}
+}

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -244,6 +244,16 @@ type SessionMetrics struct {
 	// set by the hook receiver in processActivity, not derived from transcript.
 	PermissionPending bool `json:"-"`
 
+	// HookTurnDone is true when Claude Code's Stop hook fired for this session's
+	// current turn — an authoritative, per-adapter turn-done push delivered at
+	// true turn end (issue #1161). Transient and live-only: the detector's
+	// overlayHookTurnDone sets it for the single classify pass triggered by the
+	// Stop hook and then clears its backing map (consume-once), so it never
+	// bleeds into the next turn and is never set under replay. IsAgentDone()
+	// treats it as authoritative, taking precedence over the transcript-tail
+	// heuristic (and its codex carve-out) below.
+	HookTurnDone bool `json:"-"`
+
 	// SawUserBlockingToolClosedThisPass reflects the last tailer pass: true
 	// when an AskUserQuestion / ExitPlanMode tool_use and its tool_result
 	// were processed together in one pass. Triggers the daemon's synthetic
@@ -492,6 +502,17 @@ func (m *SessionMetrics) IsAgentDone() bool {
 	if m.HasLiveBackgroundProcess {
 		return false
 	}
+	// Authoritative: Claude Code's Stop hook fired at true turn end (#1161),
+	// overlaid by the detector for claudecode. It takes precedence over the
+	// transcript-tail signals below — a clean, per-adapter turn-done push that
+	// doesn't depend on the "assistant"/"assistant_output" heuristic (and its
+	// codex carve-out). Only ever set live, never under replay. Checked after
+	// the open-tool / live-background guards so a Stop that fires while a
+	// sub-agent tool or Bash run_in_background is still outstanding does not
+	// prematurely flip the session to ready.
+	if m.HookTurnDone {
+		return true
+	}
 	// Primary: Claude Code writes a system/turn_duration event at end of turn.
 	if m.LastEventType == "turn_done" {
 		return true
@@ -529,10 +550,10 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 
 // newMergedMetrics copies the fields a fresh tailer pass always recomputes
 // verbatim from newM. Fields not listed here are deliberately left at their
-// zero value: LastCWD, PermissionPending, SawUserBlockingToolClosedThisPass,
-// OpenToolStalled, and CompactInProgress are per-pass overlay/transient
-// signals that the detector (re-)sets fresh after each merge, so carrying
-// stale values here would be a bug, not a convenience.
+// zero value: LastCWD, PermissionPending, HookTurnDone,
+// SawUserBlockingToolClosedThisPass, OpenToolStalled, and CompactInProgress are
+// per-pass overlay/transient signals that the detector (re-)sets fresh after
+// each merge, so carrying stale values here would be a bug, not a convenience.
 func newMergedMetrics(newM *SessionMetrics) *SessionMetrics {
 	return &SessionMetrics{
 		ElapsedSeconds:       newM.ElapsedSeconds,


### PR DESCRIPTION
Phase 1a of epic #1129. Installs and consumes Claude Code's **`Stop`** hook so `ready` (and the waiting-vs-ready decision) come from an authoritative push at true turn end, instead of being inferred from the transcript tail — `IsAgentDone`'s `assistant`/`assistant_output` heuristic and its codex carve-out (the landmine for every new adapter).

## What changed

- **Installer** (`hookinstaller.go`): register `Stop` in `installedHookEvents` with **no matcher** (Claude Code *rejects* a Stop matcher, so `addOurHook` omits the matcher key and `upgradeStaleHookMatchers` strips any stray one). Install idempotency + clean uninstall reuse the existing sentinel-based machinery.
- **Native HTTP delivery**: move the installed hook from the `curl` wrapper to Claude Code's native `type: http` transport (POSTs the payload straight to the daemon). This removes curl's PATH dependency — the primary reason the `OpenToolStalled` #488 fallback exists. **The #488 rule is retained** (it still covers a down/unreachable daemon); only its obsolete curl-on-PATH startup warning is dropped. Existing curl installs **migrate in place** (`upgradeStaleHookDelivery`), and the sentinel matches both the legacy command and the new url so dedup/uninstall keep working.
- **Handler** (`hooks.go`): parse `last_assistant_message`, forward a turn-done signal plus the display-truncated text and a full-text waiting-cue verdict — computed via the same `WaitingScanWindow` the parser uses for `PendingWaitingCue`, so a cue before the display tail still routes to waiting (and `ExtractWaitingCue` isn't fed the whole long turn, where it over-fires).
- **Classifier wiring**: `HandleStopHook` → `hookTurnDone` map → `overlayHookTurnDone` (consume-once) → transient `SessionMetrics.HookTurnDone`. `IsAgentDone` treats `HookTurnDone` as authoritative — **ahead of** the transcript-tail heuristic, **behind** the open-tool / live-background guards (so a Stop that fires while a sub-agent tool or `Bash run_in_background` is outstanding doesn't prematurely flip to ready). A Stop still routes through `classifyAgentDone`, so a turn ending on a question lands in `waiting`.

## Acceptance criteria

- [x] A claudecode session transitions to `ready` on turn completion driven by the `Stop` hook, not only by transcript tailing.
- [x] A turn ending on a question/cue still lands in `waiting` (the Stop-carried `last_assistant_message` feeds the cue check).
- [x] `Stop` is installed into `~/.claude/settings.json` on startup and removed cleanly on uninstall, idempotently.
- [x] `waiting_cue` and the transcript `IsAgentDone` fallback stay reachable — not removed.
- [x] Existing replay goldens pass; new unit tests cover the Stop → ready/waiting paths and the installer.

## Known constraint — fixture story (decided)

Hooks post to hardcoded `localhost:7837`, so a hook-delivered observation **can't be re-recorded against a dev daemon on an alt port**. Rather than making the port configurable (a broader, cross-file concern outside this cohesive claudecode slice), the Stop path is covered by **unit tests**: installer idempotency/uninstall + curl→http migration + Stop-no-matcher, handler payload → ready/waiting, classifier precedence (incl. open-tool / background guards), and the detector overlay (consume-once, additive cue). `HookTurnDone` is live-only (`json:"-"`, never set under replay), so **existing replay goldens are unchanged**.

## Out of scope (per issue)

`Notification`/`idle_prompt` → waiting (Phase 1b), removing `IsAgentDone`/the codex carve-out, and OTel (Phase 4).

## Compatibility note

Native `type: http` hooks require a Claude Code version that supports them; if an older Claude Code ignores them, state detection degrades gracefully to the retained transcript-tail path (`IsAgentDone` + `waiting_cue`) rather than breaking.

## Testing

`go test ./core/... -race -count=1` (incl. architecture + e2e smoke), `tools/replay-fixtures.sh`, and the full pre-push preflight gate (web suites, ARS architecture gate, security scan) all pass.

Closes #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)