### PR TITLE
feat(claudecode): wire the Notification/idle_prompt hook → waiting (#1173)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -1,8 +1,8 @@
 // hookinstaller.go manages Claude Code hook entries in ~/.claude/settings.json
 // for the irrlicht daemon. It installs PermissionRequest, PreToolUse,
-// PostToolUse, PostToolUseFailure, PreCompact and Stop hooks that POST to the
-// daemon's HTTP endpoint via native `type: http` delivery, and can remove them
-// cleanly. (Issues #108, #307, #657, #1161.)
+// PostToolUse, PostToolUseFailure, PreCompact, Stop and Notification hooks that
+// POST to the daemon's HTTP endpoint via native `type: http` delivery, and can
+// remove them cleanly. (Issues #108, #307, #657, #1161, #1173.)
 package claudecode
 
 import (
@@ -56,6 +56,14 @@ const hookMatcherPreToolUse = "AskUserQuestion|ExitPlanMode"
 // so forcing working there would be a spurious blip (#657).
 const hookMatcherPreCompact = "manual"
 
+// hookMatcherNotification is the matcher for the Notification event. Like
+// PreCompact (whose matcher is the compaction trigger), Claude Code's
+// Notification matcher matches the notification_type rather than a tool name.
+// We install "idle_prompt" so the hook fires only when the agent goes idle at
+// the prompt (issue #1173) — permission_prompt is already covered by the
+// blocking PermissionRequest hook, and the other types don't affect state.
+const hookMatcherNotification = "idle_prompt"
+
 // installedHookEvents are the Claude Code hook events we install handlers for.
 var installedHookEvents = []string{
 	HookPermissionRequest,
@@ -64,19 +72,23 @@ var installedHookEvents = []string{
 	HookPostToolUseFailure,
 	HookPreCompact,
 	HookStop,
+	HookNotification,
 }
 
 // matcherForEvent returns the matcher we install for the given event. For most
 // events this is a tool-name regex; for PreCompact it is the compaction trigger
-// ("manual"); for Stop it is empty — Claude Code's Stop hook takes no matcher
-// (it fires at every turn end) and rejects settings.json that gives it one, so
-// addOurHook omits the matcher key entirely for an empty matcher.
+// ("manual"); for Notification it is the notification_type ("idle_prompt"); for
+// Stop it is empty — Claude Code's Stop hook takes no matcher (it fires at every
+// turn end) and rejects settings.json that gives it one, so addOurHook omits the
+// matcher key entirely for an empty matcher.
 func matcherForEvent(event string) string {
 	switch event {
 	case HookPreToolUse:
 		return hookMatcherPreToolUse
 	case HookPreCompact:
 		return hookMatcherPreCompact
+	case HookNotification:
+		return hookMatcherNotification
 	case HookStop:
 		return ""
 	default:

--- a/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
@@ -343,6 +343,70 @@ func TestEnsureHooksInstalled_InstallsPreToolUseAndExpandedMatcher(t *testing.T)
 		t.Errorf("Stop group must not carry a matcher key, got %v", stopGroup["matcher"])
 	}
 	assertHTTPEntry(t, stopGroup)
+
+	// Notification: one group whose matcher is the notification_type
+	// "idle_prompt" (not a tool-name regex), so the hook fires only when the
+	// agent goes idle at the prompt (#1173).
+	notif, ok := hooksMap[HookNotification].([]interface{})
+	if !ok || len(notif) != 1 {
+		t.Fatalf("expected 1 Notification group, got %d", len(notif))
+	}
+	notifGroup := notif[0].(map[string]interface{})
+	if m, _ := notifGroup["matcher"].(string); m != hookMatcherNotification {
+		t.Errorf("Notification matcher = %q, want %q", m, hookMatcherNotification)
+	}
+	assertHTTPEntry(t, notifGroup)
+}
+
+// TestEnsureHooksInstalled_AddsNotificationToExistingInstall verifies the
+// idempotent installer adds the newly-listed Notification event to a
+// settings.json that already carries the six prior events, without duplicating
+// them — the upgrade path for existing installs (#1173).
+func TestEnsureHooksInstalled_AddsNotificationToExistingInstall(t *testing.T) {
+	home := withTempHome(t)
+
+	existing := map[string]interface{}{"hooks": map[string]interface{}{}}
+	hooks := existing["hooks"].(map[string]interface{})
+	for _, ev := range []string{HookPermissionRequest, HookPreToolUse, HookPostToolUse, HookPostToolUseFailure, HookPreCompact, HookStop} {
+		hooks[ev] = []interface{}{ourHookGroup(matcherForEvent(ev))}
+	}
+	path := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.Marshal(existing)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true (Notification was missing)")
+	}
+
+	settings := readJSON(t, path)
+	hooksMap := settings["hooks"].(map[string]interface{})
+	notif, ok := hooksMap[HookNotification].([]interface{})
+	if !ok || len(notif) != 1 {
+		t.Fatalf("expected exactly 1 Notification group after upgrade, got %d", len(notif))
+	}
+	notifGroup := notif[0].(map[string]interface{})
+	if m, _ := notifGroup["matcher"].(string); m != hookMatcherNotification {
+		t.Errorf("Notification matcher = %q, want %q", m, hookMatcherNotification)
+	}
+	assertHTTPEntry(t, notifGroup)
+
+	// Re-running must be a no-op now that all seven events are present.
+	modified, err = EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modified {
+		t.Errorf("expected modified=false on second run (already installed)")
+	}
 }
 
 // TestEnsureHooksInstalled_AddsStopToExistingInstall verifies the idempotent

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -5,7 +5,9 @@
 // permission gates (issue #108); PreToolUse on AskUserQuestion / ExitPlanMode
 // covers user-input overlays that block the agent before the transcript is
 // flushed (issue #307); Stop is the authoritative per-turn done signal
-// delivered at true turn end, carrying the final assistant text (issue #1161).
+// delivered at true turn end, carrying the final assistant text (issue #1161);
+// Notification/idle_prompt is the authoritative "idle at the prompt waiting for
+// the user" signal for turns that end with no prose waiting-cue (issue #1173).
 package claudecode
 
 import (
@@ -32,7 +34,20 @@ const (
 	// HookStop fires once at true turn end, carrying last_assistant_message.
 	// It is the authoritative turn-done signal for claudecode (issue #1161).
 	HookStop = "Stop"
+	// HookNotification fires for Claude Code UI notifications, carrying a
+	// notification_type discriminator. The daemon acts only on the idle_prompt
+	// type — the agent finished its turn and is idle at the prompt waiting for
+	// the user — as an authoritative waiting signal (issue #1173).
+	HookNotification = "Notification"
 )
+
+// notificationTypeIdlePrompt is the Notification hook's notification_type value
+// for "the agent is idle at the prompt waiting for the user" — the only
+// notification the daemon acts on (issue #1173). Claude Code's Notification
+// matcher filters on notification_type; the handler re-checks it as
+// defense-in-depth so a broadened matcher can't dispatch other notification
+// types (auth_success, permission_prompt, …).
+const notificationTypeIdlePrompt = "idle_prompt"
 
 // compactTriggerManual is the PreCompact trigger value for a user-invoked
 // /compact (as opposed to "auto"). Only manual compaction forces working — an
@@ -69,6 +84,9 @@ type hookPayload struct {
 	// LastAssistantMessage is the full text of the turn's final assistant
 	// message, carried by the Stop hook (issue #1161). Empty on other events.
 	LastAssistantMessage string `json:"last_assistant_message,omitempty"`
+	// NotificationType is the Notification hook's discriminator (e.g.
+	// "idle_prompt", "permission_prompt"). Empty on other events (issue #1173).
+	NotificationType string `json:"notification_type,omitempty"`
 }
 
 // HookTarget is the interface the handler calls into. Satisfied by
@@ -85,6 +103,11 @@ type HookTarget interface {
 	// carried a question or imperative cue (computed from the full text so a cue
 	// beyond the display tail still routes the turn to waiting, not ready).
 	HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool)
+	// HandleIdlePromptHook records the Notification/idle_prompt signal — the
+	// agent finished its turn and is idle at the prompt waiting for the user
+	// (issue #1173). An authoritative waiting signal for the case the prose
+	// waiting-cue heuristic can't detect (a turn that ended on a plain statement).
+	HandleIdlePromptHook(sessionID, transcriptPath string)
 }
 
 // MarkerTarget is the narrow interface for hook-carried task-estimate
@@ -251,6 +274,8 @@ func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGrant
 		handlePreToolUseHook(markers, log, sessionID, payload, dispatch)
 	case HookStop:
 		handleStopHook(target, log, sessionID, payload)
+	case HookNotification:
+		handleNotificationHook(target, log, sessionID, payload)
 	default:
 		// Unrecognized hook event — accept but ignore.
 		log.LogInfo(logComponentHookReceiver, sessionID,
@@ -309,6 +334,25 @@ func waitingCueInTail(full string) bool {
 	win := tailer.WaitingScanWindow(full)
 	return win != "" &&
 		(session.ExtractQuestionSnippet(win) != "" || session.ExtractWaitingCue(win) != "")
+}
+
+// handleNotificationHook processes a Claude Code Notification hook. It acts only
+// on the idle_prompt type — the agent finished its turn and is idle at the
+// prompt waiting for the user (issue #1173) — forwarding it as an authoritative
+// waiting signal. Every other notification_type (permission_prompt is already
+// covered by the blocking PermissionRequest hook; auth_success and friends are
+// irrelevant to state) is accepted and ignored, mirroring handlePreToolUseHook's
+// defense-in-depth reject: the installer matches only idle_prompt, but the
+// handler re-checks so a broadened settings.json matcher can't dispatch others.
+func handleNotificationHook(target HookTarget, log outbound.Logger, sessionID string, payload hookPayload) {
+	if payload.NotificationType != notificationTypeIdlePrompt {
+		log.LogInfo(logComponentHookReceiver, sessionID,
+			fmt.Sprintf("ignored Notification of type %q (only %s drives state)", payload.NotificationType, notificationTypeIdlePrompt))
+		return
+	}
+	log.LogInfo(logComponentHookReceiver, sessionID,
+		fmt.Sprintf("received %s (type=%s)", payload.HookEventName, payload.NotificationType))
+	target.HandleIdlePromptHook(sessionID, payload.TranscriptPath)
 }
 
 // handlePreToolUseHook processes a PreToolUse hook event: scans the tool

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -13,13 +13,14 @@ import (
 	"irrlicht/core/internal/contracttesting"
 )
 
-// mockTarget records calls to HandlePermissionHook, HandleCompactHook and
-// HandleStopHook for assertions.
+// mockTarget records calls to HandlePermissionHook, HandleCompactHook,
+// HandleStopHook and HandleIdlePromptHook for assertions.
 type mockTarget struct {
-	mu           sync.Mutex
-	calls        []hookCall
-	compactCalls []compactCall
-	stopCalls    []stopCall
+	mu              sync.Mutex
+	calls           []hookCall
+	compactCalls    []compactCall
+	stopCalls       []stopCall
+	idlePromptCalls []idlePromptCall
 }
 
 type hookCall struct {
@@ -33,6 +34,10 @@ type compactCall struct {
 type stopCall struct {
 	sessionID, transcriptPath, lastAssistantText string
 	waitingCue                                   bool
+}
+
+type idlePromptCall struct {
+	sessionID, transcriptPath string
 }
 
 func (m *mockTarget) HandlePermissionHook(sessionID, transcriptPath, hookEventName string) {
@@ -53,6 +58,12 @@ func (m *mockTarget) HandleStopHook(sessionID, transcriptPath, lastAssistantText
 	m.stopCalls = append(m.stopCalls, stopCall{sessionID, transcriptPath, lastAssistantText, waitingCue})
 }
 
+func (m *mockTarget) HandleIdlePromptHook(sessionID, transcriptPath string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.idlePromptCalls = append(m.idlePromptCalls, idlePromptCall{sessionID, transcriptPath})
+}
+
 func (m *mockTarget) getCalls() []hookCall {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -64,7 +75,14 @@ func (m *mockTarget) reset() {
 	m.calls = nil
 	m.compactCalls = nil
 	m.stopCalls = nil
+	m.idlePromptCalls = nil
 	m.mu.Unlock()
+}
+
+func (m *mockTarget) getIdlePromptCalls() []idlePromptCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]idlePromptCall{}, m.idlePromptCalls...)
 }
 
 func (m *mockTarget) getCompactCalls() []compactCall {
@@ -350,6 +368,78 @@ func TestHookHandler_StopEndingInQuestion(t *testing.T) {
 	}
 	if !stops[0].waitingCue {
 		t.Errorf("waitingCue = false for a message ending in a question, want true")
+	}
+}
+
+func TestHookHandler_NotificationIdlePrompt(t *testing.T) {
+	target := &mockTarget{}
+	handler := NewHookHandler(target, nil, nil, mockLogger{})
+
+	rec := postHook(t, handler, hookPayload{
+		TranscriptPath:   "/Users/u/.claude/projects/p/sess-idle.jsonl",
+		HookEventName:    "Notification",
+		NotificationType: "idle_prompt",
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if len(target.getCalls()) != 0 || len(target.getStopCalls()) != 0 || len(target.getCompactCalls()) != 0 {
+		t.Errorf("idle_prompt Notification must not reach permission/stop/compact paths")
+	}
+	idles := target.getIdlePromptCalls()
+	if len(idles) != 1 {
+		t.Fatalf("got %d HandleIdlePromptHook calls, want 1", len(idles))
+	}
+	if idles[0].sessionID != "sess-idle" {
+		t.Errorf("sessionID = %q, want %q", idles[0].sessionID, "sess-idle")
+	}
+	if idles[0].transcriptPath != "/Users/u/.claude/projects/p/sess-idle.jsonl" {
+		t.Errorf("transcriptPath = %q, want the payload path", idles[0].transcriptPath)
+	}
+}
+
+// TestHookHandler_NotificationNonIdleType asserts the defense-in-depth reject:
+// only idle_prompt drives state, even though the installer already narrows the
+// matcher — a broadened settings.json matcher must not dispatch other types.
+func TestHookHandler_NotificationNonIdleType(t *testing.T) {
+	for _, ntype := range []string{"permission_prompt", "auth_success", "agent_completed", ""} {
+		target := &mockTarget{}
+		handler := NewHookHandler(target, nil, nil, mockLogger{})
+
+		rec := postHook(t, handler, hookPayload{
+			TranscriptPath:   "/Users/u/.claude/projects/p/sess-n.jsonl",
+			HookEventName:    "Notification",
+			NotificationType: ntype,
+		})
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("type %q: status = %d, want %d", ntype, rec.Code, http.StatusOK)
+		}
+		if n := len(target.getIdlePromptCalls()); n != 0 {
+			t.Errorf("type %q: got %d HandleIdlePromptHook calls, want 0", ntype, n)
+		}
+	}
+}
+
+// TestHookHandler_NotificationConsentGated confirms the Notification path is
+// behind the same "hooks" consent gate as every other event: nothing is
+// dispatched while the permission is not granted.
+func TestHookHandler_NotificationConsentGated(t *testing.T) {
+	target := &mockTarget{}
+	handler := NewHookHandler(target, nil, fakeGate(false), mockLogger{})
+
+	rec := postHook(t, handler, hookPayload{
+		TranscriptPath:   "/Users/u/.claude/projects/p/sess-gated.jsonl",
+		HookEventName:    "Notification",
+		NotificationType: "idle_prompt",
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if n := len(target.getIdlePromptCalls()); n != 0 {
+		t.Fatalf("dispatched %d idle-prompt calls while permission not granted", n)
 	}
 }
 

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -219,6 +219,16 @@ type SessionDetector struct {
 	// Guarded by permMu — same goroutine-crossing story as permissionPending.
 	hookTurnDone map[string]hookStopSignal // sessionID → Stop-hook payload
 
+	// idlePromptPending tracks sessions whose Claude Code Notification/idle_prompt
+	// hook reported the agent is idle at the prompt waiting for the user (#1173):
+	// sessionID → true. Set by HandleIdlePromptHook; overlaid onto metrics by
+	// overlayIdlePrompt every classify pass while the finished turn stays idle,
+	// and cleared there the moment new activity arrives (IsAgentDone flips false)
+	// — so it holds the session in waiting without pinning it into the next turn.
+	// Persistent (not consume-once, unlike hookTurnDone): a lower-tier reclassify
+	// must never revert the corrected waiting back to ready. Guarded by permMu.
+	idlePromptPending map[string]bool // sessionID → true
+
 	// editToolOpenSince tracks, per session, the Unix time a permission-gated
 	// file-edit tool first appeared open. Guarded by permMu. Drives the
 	// OpenToolStalled transcript fallback (#488): an edit tool open past
@@ -325,6 +335,7 @@ func NewSessionDetector(watchers []inbound.Watcher, deps SessionDetectorDeps) *S
 		permissionPending:        make(map[string]bool),
 		compactPending:           make(map[string]int64),
 		hookTurnDone:             make(map[string]hookStopSignal),
+		idlePromptPending:        make(map[string]bool),
 		editToolOpenSince:        make(map[string]int64),
 		idleProjectRetryAttempts: make(map[string]int),
 		bgLiveProbe:              anyLiveOutputWriter,

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -783,6 +783,11 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 	// waiting-vs-ready inputs from the hook's final assistant message.
 	d.overlayHookTurnDone(state)
 
+	// Overlay the Notification/idle_prompt hook's idle-waiting signal (#1173).
+	// Persistent (held while the turn stays idle), so ClassifyState rule 1c can
+	// correct a turn that ended with no prose cue from ready to waiting.
+	d.overlayIdlePrompt(state)
+
 	// Overlay the PreCompact force-working hold (#657).
 	d.applyCompactHold(ev.SessionID, state.Metrics, time.Now().Unix())
 
@@ -839,6 +844,17 @@ func (d *SessionDetector) forceReadyToWorkingIfActive(state *session.SessionStat
 		return
 	}
 	if !transcriptGrew && !ev.Synthetic {
+		return
+	}
+	// The Notification/idle_prompt hook (#1173) dispatches a synthetic activity
+	// on an already-ready session to correct it ready→waiting. Skip the bounce
+	// while that signal is pending: without this, the synthetic event would
+	// force ready→working here and then classify working→waiting, recording a
+	// spurious working blip between the two (the flap this reconcile must avoid).
+	// ClassifyState still routes correctly on its own — to waiting via rule 1c
+	// (idle case), or to working via rule 4 should real activity have arrived in
+	// the same pass (overlayIdlePrompt clears the flag when IsAgentDone flips).
+	if d.hasPendingIdlePrompt(state.SessionID) {
 		return
 	}
 	d.log.LogInfo(logComponentSessionDetector, ev.SessionID, ForceReadyToWorkingReason)
@@ -901,6 +917,48 @@ func (d *SessionDetector) overlayHookTurnDone(state *session.SessionState) {
 	if sig.waitingCue {
 		state.Metrics.PendingWaitingCue = true
 	}
+}
+
+// overlayIdlePrompt folds the Claude Code Notification/idle_prompt hook signal
+// (#1173) onto metrics for the classify pass. Unlike overlayHookTurnDone it is
+// persistent, not consume-once: the flag is re-applied every pass so a stray
+// lower-tier reclassify (e.g. an fswatcher touch that re-runs ClassifyState)
+// can't flip the corrected waiting back to ready via rule 2.
+//
+// The signal holds only while the finished turn is still the last thing on the
+// transcript. IsAgentDone is the gate: while it is true the turn is genuinely
+// idle, so keep the entry and overlay IdlePromptPending (rule 1c → waiting). The
+// moment new activity arrives — the user replied, a new turn began — IsAgentDone
+// flips false; the idle window is over, so drop the backing entry and overlay
+// nothing, letting the session transition out of waiting normally. An open tool
+// (IsAgentDone false via HasOpenToolCall) likewise clears it: the open-tool
+// rules own that case, not idle-prompt. Must run after RefreshOnActivity (which
+// rebuilds metrics from the transcript, zeroing this transient field) and before
+// ClassifyState, which reads it.
+func (d *SessionDetector) overlayIdlePrompt(state *session.SessionState) {
+	if state.Metrics == nil {
+		return
+	}
+	d.permMu.Lock()
+	defer d.permMu.Unlock()
+
+	if !d.idlePromptPending[state.SessionID] {
+		return
+	}
+	if !state.Metrics.IsAgentDone() {
+		delete(d.idlePromptPending, state.SessionID)
+		return
+	}
+	state.Metrics.IdlePromptPending = true
+}
+
+// hasPendingIdlePrompt reports whether an idle_prompt hook signal is pending for
+// the session (#1173). Read by forceReadyToWorkingIfActive to skip the
+// ready→working bounce on the hook's synthetic reclassify. Guarded by permMu.
+func (d *SessionDetector) hasPendingIdlePrompt(sessionID string) bool {
+	d.permMu.Lock()
+	defer d.permMu.Unlock()
+	return d.idlePromptPending[sessionID]
 }
 
 // holdParentForActiveChildren fast-forwards a parent's own transition when

--- a/core/application/services/session_detector_idle_prompt_e2e_test.go
+++ b/core/application/services/session_detector_idle_prompt_e2e_test.go
@@ -1,0 +1,105 @@
+package services_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+)
+
+// TestSessionDetector_IdlePromptHook_ReconcilesReadyToWaiting is the end-to-end
+// #1173 lifecycle. A turn that ended on a plain statement (no question/cue) sits
+// ready — waiting_cue can't reach it. When Claude Code's Notification/idle_prompt
+// hook fires (HandleIdlePromptHook), the detector must correct the session
+// ready→waiting in a single transition (no working blip), hold it there, then
+// release it back to working the moment the user replies — without leaking the
+// idle signal into the next turn.
+func TestSessionDetector_IdlePromptHook_ReconcilesReadyToWaiting(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	const path = "/home/.claude/projects/-Users-test/idle1.jsonl"
+
+	// phase drives what ComputeMetrics reports across the lifecycle:
+	//   "idle"    — turn finished on a plain statement (IsAgentDone true)
+	//   "replied" — user sent a new message (IsAgentDone false)
+	var mu sync.Mutex
+	phase := "idle"
+	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if phase == "replied" {
+			return &session.SessionMetrics{LastEventType: "user"}, nil
+		}
+		// A plain completion: turn_done, no trailing question or cue, so
+		// IsWaitingForUserInput is false and rule 2 alone would say ready.
+		return &session.SessionMetrics{
+			LastEventType:     "turn_done",
+			LastAssistantText: "Done. All tests pass.",
+		}, nil
+	}}
+	setPhase := func(p string) { mu.Lock(); phase = p; mu.Unlock() }
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+
+	repo.states["idle1"] = &session.SessionState{
+		SessionID:      "idle1",
+		State:          session.StateReady,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+		Metrics:        &session.SessionMetrics{LastEventType: "turn_done"},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	defer func() { cancel(); <-done }()
+	go func() { done <- det.Run(ctx) }()
+
+	time.Sleep(20 * time.Millisecond) // let seedFromDisk finish
+
+	// idle_prompt hook fires → correct ready → waiting.
+	det.HandleIdlePromptHook("idle1", path)
+	waitForSessionState(repo, "idle1", session.StateWaiting, 5*time.Second)
+
+	repo.mu.Lock()
+	got := repo.lastSavedState["idle1"]
+	repo.mu.Unlock()
+	if got != session.StateWaiting {
+		t.Fatalf("after idle_prompt hook: state = %q, want waiting", got)
+	}
+
+	// A re-evaluation while still idle must HOLD waiting — the persistent
+	// overlay must not let rule 2 leak the session back to ready.
+	tw.ch <- agent.Event{Type: agent.EventActivity, SessionID: "idle1", ProjectDir: "-Users-test", TranscriptPath: path}
+	waitForCondition(func() bool { return repo.eventCountOf("idle1") >= 1 }, 5*time.Second)
+	repo.mu.Lock()
+	got = repo.lastSavedState["idle1"]
+	repo.mu.Unlock()
+	if got != session.StateWaiting {
+		t.Fatalf("idle re-eval: state = %q, want waiting (overlay must survive re-evaluation)", got)
+	}
+
+	// User replies: new activity, IsAgentDone false → release waiting → working
+	// and drop the idle signal.
+	setPhase("replied")
+	tw.ch <- agent.Event{Type: agent.EventActivity, SessionID: "idle1", ProjectDir: "-Users-test", TranscriptPath: path}
+	waitForSessionState(repo, "idle1", session.StateWorking, 5*time.Second)
+
+	// The new turn completes (turn_done again). With the idle signal correctly
+	// cleared, this must route to ready — NOT re-pin waiting from a leaked signal.
+	setPhase("idle")
+	tw.ch <- agent.Event{Type: agent.EventActivity, SessionID: "idle1", ProjectDir: "-Users-test", TranscriptPath: path}
+	waitForSessionState(repo, "idle1", session.StateReady, 5*time.Second)
+
+	repo.mu.Lock()
+	got = repo.lastSavedState["idle1"]
+	repo.mu.Unlock()
+	if got != session.StateReady {
+		t.Errorf("next turn completed: state = %q, want ready (idle signal must not leak into the next turn)", got)
+	}
+}

--- a/core/application/services/session_detector_idle_prompt_test.go
+++ b/core/application/services/session_detector_idle_prompt_test.go
@@ -1,0 +1,106 @@
+package services
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// idleDoneMetrics returns metrics for a turn that has genuinely finished and is
+// idle at the prompt (IsAgentDone true): no open tool, no live background
+// process, transcript tail ends on turn_done.
+func idleDoneMetrics() *session.SessionMetrics {
+	return &session.SessionMetrics{LastEventType: "turn_done"}
+}
+
+// TestOverlayIdlePrompt covers the Notification/idle_prompt overlay (#1173):
+// persistent (not consume-once) while the turn stays idle, cleared the moment a
+// new turn begins, and the no-op guards. White-box so it can drive the
+// unexported overlay + idlePromptPending map directly.
+func TestOverlayIdlePrompt(t *testing.T) {
+	const sid = "s"
+
+	t.Run("applied while the turn is idle, and held (not consumed)", func(t *testing.T) {
+		d := &SessionDetector{idlePromptPending: map[string]bool{sid: true}}
+
+		state := &session.SessionState{SessionID: sid, Metrics: idleDoneMetrics()}
+		d.overlayIdlePrompt(state)
+		if !state.Metrics.IdlePromptPending {
+			t.Error("IdlePromptPending must be set while the finished turn is idle")
+		}
+		if !d.idlePromptPending[sid] {
+			t.Error("signal must be held (not consumed) after an overlay pass")
+		}
+
+		// A second pass on fresh metrics must re-apply — persistent, unlike the
+		// consume-once Stop overlay, so a lower-tier reclassify can't revert the
+		// corrected waiting back to ready.
+		next := &session.SessionState{SessionID: sid, Metrics: idleDoneMetrics()}
+		d.overlayIdlePrompt(next)
+		if !next.Metrics.IdlePromptPending {
+			t.Error("held signal must re-apply on the next pass")
+		}
+	})
+
+	t.Run("cleared when a new turn begins (IsAgentDone false)", func(t *testing.T) {
+		d := &SessionDetector{idlePromptPending: map[string]bool{sid: true}}
+		// New user activity: not turn_done → IsAgentDone false.
+		state := &session.SessionState{SessionID: sid, Metrics: &session.SessionMetrics{LastEventType: "user"}}
+
+		d.overlayIdlePrompt(state)
+		if state.Metrics.IdlePromptPending {
+			t.Error("IdlePromptPending must NOT be set once a new turn started")
+		}
+		if _, ok := d.idlePromptPending[sid]; ok {
+			t.Error("signal must be dropped when the idle window ends")
+		}
+	})
+
+	t.Run("cleared when an open tool blocks the turn", func(t *testing.T) {
+		d := &SessionDetector{idlePromptPending: map[string]bool{sid: true}}
+		// An open tool call makes IsAgentDone false — the open-tool rules own
+		// that case, not idle-prompt.
+		state := &session.SessionState{SessionID: sid, Metrics: &session.SessionMetrics{
+			LastEventType:   "turn_done",
+			HasOpenToolCall: true,
+		}}
+
+		d.overlayIdlePrompt(state)
+		if state.Metrics.IdlePromptPending {
+			t.Error("IdlePromptPending must NOT be set while a tool call is open")
+		}
+		if _, ok := d.idlePromptPending[sid]; ok {
+			t.Error("signal must be dropped when an open tool blocks the turn")
+		}
+	})
+
+	t.Run("no pending signal is a no-op", func(t *testing.T) {
+		d := &SessionDetector{idlePromptPending: map[string]bool{}}
+		state := &session.SessionState{SessionID: sid, Metrics: idleDoneMetrics()}
+		d.overlayIdlePrompt(state)
+		if state.Metrics.IdlePromptPending {
+			t.Error("a session with no pending idle-prompt signal must not be marked waiting")
+		}
+	})
+
+	t.Run("nil metrics is a no-op and preserves the signal", func(t *testing.T) {
+		d := &SessionDetector{idlePromptPending: map[string]bool{sid: true}}
+		state := &session.SessionState{SessionID: sid, Metrics: nil}
+		d.overlayIdlePrompt(state) // must not panic
+		if !d.idlePromptPending[sid] {
+			t.Error("nil metrics must leave the pending signal untouched")
+		}
+	})
+}
+
+// TestHasPendingIdlePrompt covers the guard forceReadyToWorkingIfActive reads to
+// skip the ready→working bounce on the idle-prompt hook's synthetic reclassify.
+func TestHasPendingIdlePrompt(t *testing.T) {
+	d := &SessionDetector{idlePromptPending: map[string]bool{"has": true}}
+	if !d.hasPendingIdlePrompt("has") {
+		t.Error("hasPendingIdlePrompt must report true for a session with a pending signal")
+	}
+	if d.hasPendingIdlePrompt("none") {
+		t.Error("hasPendingIdlePrompt must report false for a session with no signal")
+	}
+}

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -46,6 +46,7 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	delete(d.permissionPending, ev.SessionID)
 	delete(d.compactPending, ev.SessionID)
 	delete(d.hookTurnDone, ev.SessionID)
+	delete(d.idlePromptPending, ev.SessionID)
 	delete(d.editToolOpenSince, ev.SessionID)
 	delete(d.idleProjectRetryAttempts, ev.SessionID)
 	d.permMu.Unlock()
@@ -359,6 +360,33 @@ func (d *SessionDetector) HandleStopHook(sessionID, transcriptPath, lastAssistan
 	// The literal "Stop" mirrors HandleCompactHook's "PreCompact" — the services
 	// layer must not import the claudecode adapter for its HookStop constant.
 	d.dispatchHookActivity(sessionID, transcriptPath, "Stop")
+}
+
+// HandleIdlePromptHook records Claude Code's Notification/idle_prompt hook
+// (issue #1173): the agent has finished its turn and is now idle at the prompt
+// waiting for the user. Marking idlePromptPending makes every subsequent
+// classify pass overlay SessionMetrics.IdlePromptPending (ClassifyState rule 1c)
+// so the session shows waiting even when the turn ended on a plain statement
+// that PendingWaitingCue's prose heuristic can't detect. The flag is held until
+// the next turn begins (overlayIdlePrompt clears it once IsAgentDone flips
+// false), not consumed once — a lower-tier reclassify must not revert the
+// corrected waiting back to ready.
+//
+// The idle_prompt hook fires after the turn goes idle (the session is typically
+// already ready by then), so this is a reconcile-and-correct: the synthetic
+// activity below drives a ready→waiting transition without the intermediate
+// working blip forceReadyToWorkingIfActive would otherwise record (it skips the
+// bounce while this flag is pending). The literal "Notification" mirrors
+// HandleStopHook's "Stop" — the services layer must not import the claudecode
+// adapter for its HookNotification constant.
+//
+// Safe to call from any goroutine (e.g. the HTTP handler).
+func (d *SessionDetector) HandleIdlePromptHook(sessionID, transcriptPath string) {
+	d.permMu.Lock()
+	d.idlePromptPending[sessionID] = true
+	d.permMu.Unlock()
+
+	d.dispatchHookActivity(sessionID, transcriptPath, "Notification")
 }
 
 // HandleCompactHook processes a Claude Code PreCompact hook for a manual

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -17,6 +17,7 @@ import (
 //   - CompactInProgress → working (0b)
 //   - NeedsUserAttention → waiting (1)
 //   - OpenToolStalled → waiting (1b)
+//   - IdlePromptPending → waiting (1c)
 //   - IsAgentDone → ready, from working/waiting only (2)
 //   - ESC cancellation / tool denial (user + error + no open tools) → ready (3)
 //   - Default → working (4)
@@ -59,6 +60,17 @@ func ClassifyState(currentState string, metrics *session.SessionMetrics) (string
 	// progress, so this never fires on a tool that is actively executing.
 	if metrics.OpenToolStalled {
 		return transitionTo(currentState, session.StateWaiting, "stalled edit tool → likely permission prompt → waiting")
+	}
+
+	// 1c. Claude Code's Notification/idle_prompt hook reported the agent is idle
+	// at the prompt waiting for the user (#1173) → waiting. Authoritative tier
+	// above the turn-done → ready verdict below: it corrects the case where the
+	// turn ended on a plain statement with no trailing question/cue, which rule 2
+	// would otherwise route to ready. Live-only — the detector's overlayIdlePrompt
+	// only sets this while the finished turn is still idle (and never under
+	// replay), so this rule is inert for every non-hook path.
+	if metrics.IdlePromptPending {
+		return transitionTo(currentState, session.StateWaiting, "idle prompt hook → waiting")
 	}
 
 	// 2. Agent finished turn — check if waiting for user input first. A

--- a/core/application/services/state_classifier_test.go
+++ b/core/application/services/state_classifier_test.go
@@ -137,6 +137,62 @@ func TestClassifyState(t *testing.T) {
 			wantState: session.StateWorking,
 		},
 
+		// Rule 1c: IdlePromptPending (Notification/idle_prompt hook) → waiting.
+		{
+			name:    "ready → waiting (idle prompt hook)",
+			current: session.StateReady,
+			metrics: &session.SessionMetrics{
+				IdlePromptPending: true,
+			},
+			wantState:  session.StateWaiting,
+			wantReason: true,
+		},
+		{
+			name:    "working → waiting (idle prompt hook)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				IdlePromptPending: true,
+			},
+			wantState:  session.StateWaiting,
+			wantReason: true,
+		},
+		{
+			name:    "waiting stays waiting (idle prompt hook, already waiting)",
+			current: session.StateWaiting,
+			metrics: &session.SessionMetrics{
+				IdlePromptPending: true,
+			},
+			wantState: session.StateWaiting,
+		},
+		{
+			// The core correction: a turn that ended on a plain statement (no
+			// question/cue) would route to ready via rule 2, but the idle-prompt
+			// hook overrides it to waiting — the false-negative gap #1173 closes.
+			name:    "ready → waiting (idle prompt overrides turn-done ready verdict)",
+			current: session.StateReady,
+			metrics: &session.SessionMetrics{
+				IdlePromptPending: true,
+				LastEventType:     "turn_done",
+				LastAssistantText: "Done. All tests pass.",
+			},
+			wantState:  session.StateWaiting,
+			wantReason: true,
+		},
+		{
+			// Regression guard: with no idle-prompt signal, the same plain
+			// turn-done metrics still route to ready (rule 1c is inert without
+			// the live hook — no behavior change for the non-hook path).
+			name:    "working → ready (turn done, no idle prompt, no cue)",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				IdlePromptPending: false,
+				LastEventType:     "turn_done",
+				LastAssistantText: "Done. All tests pass.",
+			},
+			wantState:  session.StateReady,
+			wantReason: true,
+		},
+
 		// Rule 1: NeedsUserAttention → waiting.
 		{
 			name:    "working → waiting (AskUserQuestion)",

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -254,6 +254,18 @@ type SessionMetrics struct {
 	// heuristic (and its codex carve-out) below.
 	HookTurnDone bool `json:"-"`
 
+	// IdlePromptPending is true when Claude Code's Notification/idle_prompt hook
+	// reported that the agent has finished its turn and is now sitting idle at
+	// the prompt waiting for the user (issue #1173) — the authoritative signal
+	// for the "turn ended with no trailing question or cue" case that
+	// PendingWaitingCue's prose heuristic (rule 2) cannot reach. Transient and
+	// live-only: set by the detector's overlayIdlePrompt from a per-session map
+	// held only while the finished turn is still the last thing on the
+	// transcript, and never set under replay. ClassifyState reads it as an
+	// authoritative waiting tier above the turn-done → ready verdict, so a turn
+	// that ends on a plain statement still routes to waiting once the hook lands.
+	IdlePromptPending bool `json:"-"`
+
 	// SawUserBlockingToolClosedThisPass reflects the last tailer pass: true
 	// when an AskUserQuestion / ExitPlanMode tool_use and its tool_result
 	// were processed together in one pass. Triggers the daemon's synthetic
@@ -550,7 +562,7 @@ func MergeMetrics(newM, oldM *SessionMetrics) *SessionMetrics {
 
 // newMergedMetrics copies the fields a fresh tailer pass always recomputes
 // verbatim from newM. Fields not listed here are deliberately left at their
-// zero value: LastCWD, PermissionPending, HookTurnDone,
+// zero value: LastCWD, PermissionPending, HookTurnDone, IdlePromptPending,
 // SawUserBlockingToolClosedThisPass, OpenToolStalled, and CompactInProgress are
 // per-pass overlay/transient signals that the detector (re-)sets fresh after
 // each merge, so carrying stale values here would be a bug, not a convenience.


### PR DESCRIPTION
## What

Phase 1b of the state-detection epic (#1129). Wires Claude Code's `Notification`/`idle_prompt` hook as an authoritative **`waiting`** signal, so we stop relying solely on `waiting_cue`'s prose heuristic to answer "is a human blocked at the prompt right now?"

The gap it closes: a turn that ends on a plain statement ("Done. Tests pass.") with no trailing question or cue classifies as **ready** even though the agent is genuinely idle, blocked on the user. `idle_prompt` fires precisely for that state — the false-negative the heuristic can't reach.

## How — reconcile, not a naive drop-in

The spike (#1141) proved this hook is **late but authoritative**, so it ships with the minimal reconcile slice (the seed of Phase 3):

- New live-only overlay **`IdlePromptPending`**, set by the hook via a **persistent** per-session map (`idlePromptPending`), consumed by a new classifier **rule 1c** that overrides rule 2's `ready` verdict. Held while the finished turn stays idle; **cleared the moment a new turn begins** (`IsAgentDone` flips false) so it never pins `waiting` into the next turn.
- `forceReadyToWorkingIfActive` **skips its bounce** while the signal is pending — so the correction lands as a single `ready→waiting` transition rather than `ready→working→waiting` (the flap the epic requires this to avoid).
- Adapter: `HookNotification` receiver + installer (matcher `idle_prompt`), with a defense-in-depth handler that dispatches **only** `idle_prompt`. Reuses the existing `hooks` consent gate and native `http` delivery (#1161) — no new permission, no curl.

`waiting_cue` stays as the instant first-guess; the hook confirms/upgrades-provenance or corrects it. Rule 1c is **purely additive and inert** for every non-hook and replay path (the signal is only ever set by the live hook).

## Scope notes

- **No frontend work.** This is a daemon-only state-detection change; the macOS and web frontends already render the `waiting` state, so there's nothing per-frontend to implement.
- **Already done / out of scope by design:** native `http` hook delivery is already in place (from #1161), and `OpenToolStalled`/#488 is deliberately *retained* as the down-daemon fallback — so the epic's "move to http / likely removes #488" line needs no work here. `permission_prompt` is already covered by the blocking `PermissionRequest` hook.

## ⚠️ Needs live verification before merge

The unit + e2e tests fully cover the reconcile state machine, but the **live `idle_prompt` firing + latency** could not be exercised here (needs a real Claude Code session going idle). The docs' example message references a multi-minute idle threshold while the spike measured the `Notification` family at ~6s — these may refer to different things. **Recommend driving a real idle session and confirming `idle_prompt` fires (and its latency) against a dev daemon before merging.** If it turns out to be a multi-minute threshold, the reconcile still works but the badge is slow, and the matcher/notification-type choice should be revisited.

## Tests

- `state_classifier_test.go` — rule 1c cases incl. the core "idle overrides turn-done ready verdict" correction + a regression guard that the non-hook path is unchanged.
- `session_detector_idle_prompt_test.go` — white-box overlay: persistent (not consumed), cleared on new turn / open tool, no-op guards; `hasPendingIdlePrompt`.
- `session_detector_idle_prompt_e2e_test.go` — end-to-end through a real detector: `ready →(hook)→ waiting` (single transition), holds waiting across re-eval, `→(reply)→ working`, and **no signal leak into the next turn**.
- `hooks_test.go` / `hookinstaller_test.go` — handler dispatch, non-idle-type reject, consent-gating, installer matcher + idempotent upgrade path.
- Full suite green: `go test ./core/... -race -count=1`, architecture test, permission-gate contract test.

Closes #1173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)