### PR TITLE
feat(headline): topic-prefix pending questions; retire summary marker (#1186)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -1,7 +1,8 @@
 // instructioninstaller.go manages the Irrlicht-managed emission rules in the
 // user-level Claude Code instruction file ~/.claude/CLAUDE.md: the task-eta
-// progress marker (issue #558), the task-summary marker (issue #738) and the
-// task-question marker (issue #759), each in its own BEGIN/END-delimited block.
+// progress marker (issue #558) and the task-question marker (issue #759), each
+// in its own BEGIN/END-delimited block. The task-summary marker (issue #738)
+// was retired in #1186 — its block is now actively uninstalled, not written.
 // The blocks instruct the agent to emit in-band markers; with them in the
 // user-level file every project inherits the rules without per-repo opt-in.
 //
@@ -88,38 +89,18 @@ appended to the ` + descriptionFieldLiteral + ` of the next Bash call you make, 
 response text when no Bash call is coming.
 ` + taskEtaEndSentinel
 
-// Sentinels delimiting the task-summary managed block (issue #738). Distinct
-// from the task-eta pair so both blocks can coexist and be patched/removed
-// independently.
+// Sentinels delimiting the (now-retired) task-summary managed block. The
+// irrlicht-summary agent instruction was removed in issue #1186 — everything
+// the user sees now lives in the question headline, and TaskSummary /
+// IntentHeadline have been decoded-but-never-rendered since #979. The
+// sentinels stay so applyInstructionBlocks can UNINSTALL a block any prior
+// version installed, cleaning it out of ~/.claude/CLAUDE.md on the next daemon
+// start. The tailer's ScanTaskSummary is left tolerant so an older marker in a
+// live transcript still parses harmlessly.
 const (
 	taskSummaryBeginSentinel = "<!-- BEGIN IRRLICHT MANAGED BLOCK (task-summary) -->"
 	taskSummaryEndSentinel   = "<!-- END IRRLICHT MANAGED BLOCK (task-summary) -->"
 )
-
-// managedTaskSummaryBlock instructs the agent to emit a one-line description
-// of the current task so a human scanning sessions can tell what each is
-// about — surfaced in both the waiting and ready states (issue #738). The
-// summary is the stable companion to the task-eta progress marker: emitted
-// once near the start, not churned per phase. The example marker MUST sit
-// inside a fenced code block for the same reason as the task-eta block —
-// Claude Code strips bare HTML comments from CLAUDE.md at injection time. The
-// `+"`description`"+` carrier mirrors the eta block so the marker survives the
-// claude ≥2.1.162 transcript text-drop via the PreToolUse hook.
-const managedTaskSummaryBlock = taskSummaryBeginSentinel + `
-## Task summary marker (managed by Irrlicht)
-
-So a human scanning sessions can tell what each one is about, emit a one-line
-summary of the overall task as a hidden marker, early in the task:
-
-` + "```" + `
-<!-- {"marker":"irrlicht-summary","summary":"<one sentence: what this task is about>"} -->
-` + "```" + `
-
-Emit it once near the start by appending it to the ` + descriptionFieldLiteral + ` of an
-early Bash call (never to the command itself). Re-emit only if the task
-fundamentally changes. Keep it a short one-liner — under ~70 characters, plain
-prose, no secrets.
-` + taskSummaryEndSentinel
 
 // Sentinels delimiting the task-question managed block (issue #759). Distinct
 // from the eta/summary pairs so all three blocks coexist and are patched or
@@ -153,6 +134,17 @@ const (
 // example placeholder and prose change; the marker key and sentinels are
 // untouched, so patchManagedBlock upgrades installed v1 blocks in place on
 // the next daemon start.
+//
+// v3 (#1186): the headline shape is now the explicit "<3–5 word topic>:
+// <question>" — a chat-conversation-title topic, then a colon, then the ask.
+// This is the same shape the daemon composes for the no-marker fallback path
+// (a topic derived from the first user prompt + the extracted question), so
+// marker and heuristic paths surface one consistent form. The marker carries
+// the whole line to question_headline verbatim (issue #1186 routes an
+// agent-authored marker through the verbatim compaction kind — no
+// sentence-selection that would drop the topic off a two-sentence marker).
+// Only the placeholder and examples change; the marker key and sentinels stay
+// put, so patchManagedBlock upgrades installed v1/v2 blocks in place.
 const managedTaskQuestionBlock = taskQuestionBeginSentinel + `
 ## Pending-question marker (managed by Irrlicht)
 
@@ -160,18 +152,19 @@ When you end your turn by asking the user a question, also emit a hidden
 one-line version of that question so tools can show a terse headline:
 
 ` + "```" + `
-<!-- {"marker":"irrlicht-question","question":"<topic — what happened — the choice>"} -->
+<!-- {"marker":"irrlicht-question","question":"<3–5 word topic>: <what happened — the choice>"} -->
 ` + "```" + `
 
 Emit it on its own line at the very end of your response, only when you are
 actually waiting on the user.
 
-Structure the headline so someone who never saw the session understands it:
-lead with the topic, then what just happened, then the choice — context,
-then state, then the ask. Keep it high-signal; aim for ~90 characters, and
-when clarity and brevity conflict, choose clarity.
+Start with a 3–5 word topic (like a chat conversation title), then ": ", then
+the question. The topic is the context; what follows the colon is the state
+then the ask — context, then state, then the ask — so someone who never saw
+the session understands it at a glance. Keep it high-signal; aim for ~90
+characters, and when clarity and brevity conflict, choose clarity.
 
-- Bad "Should I proceed?" → Good "DB migration ready; drops users.legacy_id — run it or keep the column?"
+- Bad "Should I proceed?" → Good "DB migration: drops users.legacy_id — run it or keep the column?"
 - Bad "Which approach?" → Good "Auth refactor: 2 endpoints still untested — ship now or add tests first?"
 - Bad "Yes or no?" → Good "PR #482 review: 1 blocking finding left — fix now or merge and follow up?"
 ` + taskQuestionEndSentinel
@@ -236,14 +229,8 @@ func UninstallTaskEtaBlock() (bool, error) {
 	return uninstallBlock(taskEtaBeginSentinel, taskEtaEndSentinel)
 }
 
-// EnsureTaskSummaryBlockInstalled writes-or-patches the task-summary managed
-// block (issue #738) — installed alongside the task-eta block under the same
-// instructions permission.
-func EnsureTaskSummaryBlockInstalled() (bool, error) {
-	return ensureBlockInstalled(taskSummaryBeginSentinel, taskSummaryEndSentinel, managedTaskSummaryBlock)
-}
-
-// UninstallTaskSummaryBlock removes only the task-summary managed block.
+// UninstallTaskSummaryBlock removes only the (retired, issue #1186) task-summary
+// managed block — the cleanup path for CLAUDE.md files a prior version wrote.
 func UninstallTaskSummaryBlock() (bool, error) {
 	return uninstallBlock(taskSummaryBeginSentinel, taskSummaryEndSentinel)
 }
@@ -260,14 +247,17 @@ func UninstallTaskQuestionBlock() (bool, error) {
 	return uninstallBlock(taskQuestionBeginSentinel, taskQuestionEndSentinel)
 }
 
-// applyInstructionBlocks installs both managed blocks — the grant effect of
-// the instructions permission. Both are installed together so a single toggle
-// governs all irrlicht-managed instruction text. Returns on the first error.
+// applyInstructionBlocks installs the managed instruction blocks — the grant
+// effect of the instructions permission. All are governed by a single toggle
+// so it covers every irrlicht-managed instruction. The retired irrlicht-summary
+// block (issue #1186) is actively uninstalled here rather than installed, so a
+// CLAUDE.md a prior version wrote is cleaned up on the next granted daemon
+// start. Returns on the first error.
 func applyInstructionBlocks() error {
 	if _, err := EnsureTaskEtaBlockInstalled(); err != nil {
 		return err
 	}
-	if _, err := EnsureTaskSummaryBlockInstalled(); err != nil {
+	if _, err := UninstallTaskSummaryBlock(); err != nil {
 		return err
 	}
 	_, err := EnsureTaskQuestionBlockInstalled()

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -395,23 +395,6 @@ func TestPatchManagedBlock_BeginWithoutEndAppendsFresh(t *testing.T) {
 	}
 }
 
-func TestEnsureTaskSummaryBlock_CreatesFileIfAbsent(t *testing.T) {
-	home := withTempHome(t)
-	modified, err := EnsureTaskSummaryBlockInstalled()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !modified {
-		t.Fatal("expected modified=true on first install")
-	}
-	content := readFileString(t, memoryPathFor(home))
-	for _, want := range []string{taskSummaryBeginSentinel, taskSummaryEndSentinel, `"marker":"irrlicht-summary"`} {
-		if !strings.Contains(content, want) {
-			t.Errorf("installed file missing %q", want)
-		}
-	}
-}
-
 func TestEnsureTaskQuestionBlock_CreatesFileIfAbsent(t *testing.T) {
 	home := withTempHome(t)
 	modified, err := EnsureTaskQuestionBlockInstalled()
@@ -449,9 +432,16 @@ func TestTaskQuestionBlock_DocumentsStructureAndExamples(t *testing.T) {
 	if strings.Contains(managedTaskQuestionBlock, "under ~70 characters") {
 		t.Error("task-question block still carries the old hard ~70-char rule (issue #1142 relaxed it to ~90)")
 	}
+	// v3 (#1186): the block teaches the explicit "<topic>: <question>" shape.
+	if !strings.Contains(managedTaskQuestionBlock, `"<3–5 word topic>: <what happened — the choice>"`) {
+		t.Error("task-question block missing the v3 <topic>: <question> placeholder (issue #1186)")
+	}
+	if !strings.Contains(managedTaskQuestionBlock, `then ": ", then`) {
+		t.Error("task-question block must teach the colon join (issue #1186)")
+	}
 }
 
-func TestApplyInstructionBlocks_InstallsAllAndCoexist(t *testing.T) {
+func TestApplyInstructionBlocks_InstallsEtaAndQuestion_RetiresSummary(t *testing.T) {
 	home := withTempHome(t)
 	if err := applyInstructionBlocks(); err != nil {
 		t.Fatal(err)
@@ -459,11 +449,16 @@ func TestApplyInstructionBlocks_InstallsAllAndCoexist(t *testing.T) {
 	content := readFileString(t, memoryPathFor(home))
 	for _, want := range []string{
 		taskEtaBeginSentinel, taskEtaEndSentinel, `"marker":"irrlicht-eta"`,
-		taskSummaryBeginSentinel, taskSummaryEndSentinel, `"marker":"irrlicht-summary"`,
 		taskQuestionBeginSentinel, taskQuestionEndSentinel, `"marker":"irrlicht-question"`,
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("file missing %q after applyInstructionBlocks", want)
+		}
+	}
+	// The retired summary marker (#1186) is never installed.
+	for _, absent := range []string{taskSummaryBeginSentinel, `"marker":"irrlicht-summary"`} {
+		if strings.Contains(content, absent) {
+			t.Errorf("file unexpectedly contains retired summary marker %q", absent)
 		}
 	}
 	// Idempotent: re-applying changes nothing.
@@ -472,6 +467,40 @@ func TestApplyInstructionBlocks_InstallsAllAndCoexist(t *testing.T) {
 	}
 	if readFileString(t, memoryPathFor(home)) != content {
 		t.Error("re-applying instruction blocks changed bytes")
+	}
+}
+
+// TestApplyInstructionBlocks_UninstallsLegacySummaryBlock pins issue #1186: a
+// CLAUDE.md an older daemon left with the irrlicht-summary block installed is
+// cleaned up on the next granted apply, with surrounding user content and the
+// other managed blocks intact.
+func TestApplyInstructionBlocks_UninstallsLegacySummaryBlock(t *testing.T) {
+	home := withTempHome(t)
+	path := memoryPathFor(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacySummary := taskSummaryBeginSentinel + "\n## Task summary marker\n" +
+		`<!-- {"marker":"irrlicht-summary","summary":"old"} -->` + "\n" + taskSummaryEndSentinel
+	seeded := "# My setup\n\nAlways use tabs.\n\n" + legacySummary + "\n"
+	if err := os.WriteFile(path, []byte(seeded), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := applyInstructionBlocks(); err != nil {
+		t.Fatal(err)
+	}
+	content := readFileString(t, path)
+	if strings.Contains(content, taskSummaryBeginSentinel) || strings.Contains(content, `"marker":"irrlicht-summary"`) {
+		t.Errorf("legacy summary block survived apply:\n%s", content)
+	}
+	if !strings.HasPrefix(content, "# My setup\n\nAlways use tabs.\n") {
+		t.Errorf("user content not preserved:\n%s", content)
+	}
+	for _, want := range []string{taskEtaBeginSentinel, taskQuestionBeginSentinel} {
+		if !strings.Contains(content, want) {
+			t.Errorf("expected block %q installed alongside the cleanup", want)
+		}
 	}
 }
 

--- a/core/adapters/outbound/compaction/compaction_test.go
+++ b/core/adapters/outbound/compaction/compaction_test.go
@@ -43,6 +43,40 @@ func TestDeterministic_Question_UsesQuestionSnippet(t *testing.T) {
 	}
 }
 
+func TestDeterministic_QuestionVerbatim_KeepsAllSentences(t *testing.T) {
+	// A multi-sentence, already-composed "<topic>: <question>" marker must
+	// survive whole — CompactQuestion would sentence-select and drop the topic
+	// (issue #1186).
+	in := "Auth refactor: 2 endpoints still untested. Ship now or add tests first?"
+	got := (DeterministicCompactor{}).Compact(in, outbound.CompactQuestionVerbatim)
+	if got != in {
+		t.Errorf("Compact(verbatim) = %q, want the whole line kept", got)
+	}
+	// Contrast: CompactQuestion selects a single sentence and loses the topic.
+	if q := (DeterministicCompactor{}).Compact(in, outbound.CompactQuestion); q == in {
+		t.Errorf("CompactQuestion should sentence-select, got the whole line %q", q)
+	}
+}
+
+func TestDeterministic_QuestionVerbatim_StripsAndCaps(t *testing.T) {
+	// Verbatim still strips noise/markdown, collapses whitespace and caps runes.
+	in := "Topic:   fix the **flaky** `TestThing`   now?"
+	got := (DeterministicCompactor{}).Compact(in, outbound.CompactQuestionVerbatim)
+	if got != "Topic: fix the flaky TestThing now?" {
+		t.Errorf("Compact(verbatim) = %q, want stripped + whitespace-collapsed", got)
+	}
+
+	long := "Topic: " + strings.Repeat("word ", 100)
+	capped := (DeterministicCompactor{}).Compact(long, outbound.CompactQuestionVerbatim)
+	runes := []rune(capped)
+	if len(runes) > maxHeadlineRunes {
+		t.Errorf("verbatim len = %d runes, want <= %d", len(runes), maxHeadlineRunes)
+	}
+	if !strings.HasPrefix(capped, "Topic: ") {
+		t.Errorf("verbatim cap dropped the leading topic: %q", capped)
+	}
+}
+
 func TestDeterministic_Question_FallsBackToFirstLine(t *testing.T) {
 	in := "Let me know how you want to proceed.\nSecond line should be ignored."
 	got := (DeterministicCompactor{}).Compact(in, outbound.CompactQuestion)

--- a/core/adapters/outbound/compaction/deterministic.go
+++ b/core/adapters/outbound/compaction/deterministic.go
@@ -28,10 +28,11 @@ var (
 
 // DeterministicCompactor is the default pure-heuristic strategy: it strips
 // fenced code, HTML-comment markers and system-reminder tags, picks the most
-// headline-worthy fragment per kind (the question sentence, or the first
-// sentence of an intent), strips inline markdown, collapses whitespace and caps
-// the result to ~70 runes with an ellipsis on a rune boundary. Empty in → empty
-// out. It never errors. See issue #759.
+// headline-worthy fragment per kind (the question sentence, the first sentence
+// of an intent, or — for the verbatim kind — the whole already-composed line),
+// strips inline markdown, collapses whitespace and caps the result to
+// maxHeadlineRunes with an ellipsis on a rune boundary. Empty in → empty out.
+// It never errors. See issues #759 and #1186.
 type DeterministicCompactor struct{}
 
 var _ outbound.TextCompactor = DeterministicCompactor{}
@@ -56,6 +57,13 @@ func (DeterministicCompactor) Compact(text string, kind outbound.CompactKind) st
 		} else {
 			headline = session.ExtractStatusFallback(cleaned)
 		}
+	case outbound.CompactQuestionVerbatim:
+		// Already a one-line "<topic>: <question>" — keep the whole thing so a
+		// multi-sentence marker doesn't lose its topic prefix to sentence
+		// selection (issue #1186). The shared strip/collapse/cap below still
+		// runs, so the 200-rune budget is enforced (trimming the question tail,
+		// never the leading topic).
+		headline = cleaned
 	default: // CompactIntent
 		headline = firstSentence(cleaned)
 	}

--- a/core/adapters/outbound/compaction/deterministic.go
+++ b/core/adapters/outbound/compaction/deterministic.go
@@ -70,7 +70,7 @@ func (DeterministicCompactor) Compact(text string, kind outbound.CompactKind) st
 
 	headline = stripInlineMarkdown(headline)
 	headline = strings.Join(strings.Fields(headline), " ")
-	return capRunes(headline, maxHeadlineRunes)
+	return session.CapRunes(headline, maxHeadlineRunes)
 }
 
 // stripNoise removes fenced code, HTML comments and system-reminder blocks —
@@ -111,15 +111,4 @@ func firstSentence(s string) string {
 		}
 	}
 	return strings.TrimSpace(s)
-}
-
-// capRunes truncates s to at most max runes, replacing the last kept rune with
-// an ellipsis when it has to drop text (so the total never exceeds max).
-func capRunes(s string, max int) string {
-	runes := []rune(s)
-	if len(runes) <= max {
-		return s
-	}
-	truncated := strings.TrimRight(string(runes[:max-1]), " ")
-	return truncated + "…"
 }

--- a/core/adapters/outbound/metrics/question_headline_test.go
+++ b/core/adapters/outbound/metrics/question_headline_test.go
@@ -1,0 +1,95 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"irrlicht/core/adapters/outbound/compaction"
+	"irrlicht/core/application/replayengine"
+	"irrlicht/core/pkg/tailer"
+)
+
+// These exercise the production question-headline wiring end to end — the
+// deterministic compactor behind the shared converter — for issue #1186. The
+// unit-level pieces (topic derivation, verbatim compaction, routing) are
+// tested in their own packages; this proves they compose as shipped.
+func questionHeadlineFor(m *tailer.SessionMetrics) string {
+	return replayengine.NewMetricsConverter(compaction.DeterministicCompactor{}).Convert(m).QuestionHeadline
+}
+
+func TestQuestionHeadline_MarkerKeptVerbatim_MultiSentence(t *testing.T) {
+	// AC1: an agent-authored marker carrying a topic prefix across two
+	// sentences survives whole — sentence selection would drop the topic.
+	m := &tailer.SessionMetrics{
+		LastAssistantText: "a long rambling status with a question buried in it?",
+		TaskQuestion:      &tailer.TaskQuestion{Text: "Auth refactor: 2 endpoints still untested. Ship now or add tests first?", ObservedAt: 100},
+	}
+	got := questionHeadlineFor(m)
+	want := "Auth refactor: 2 endpoints still untested. Ship now or add tests first?"
+	if got != want {
+		t.Errorf("QuestionHeadline = %q, want the marker verbatim with its prefix intact", got)
+	}
+}
+
+func TestQuestionHeadline_RegexPath_ComposesTopicPrefix(t *testing.T) {
+	// AC2: no marker — prefix a 3–5 word topic from the first prompt onto the
+	// extracted question, joined by ": ".
+	m := &tailer.SessionMetrics{
+		FirstUserText:     "Add OAuth login to the web dashboard",
+		LastAssistantText: "Here's the plan. Should I use PKCE or the implicit flow?",
+	}
+	got := questionHeadlineFor(m)
+	want := "Add OAuth login: Should I use PKCE or the implicit flow?"
+	if got != want {
+		t.Errorf("QuestionHeadline = %q, want %q", got, want)
+	}
+}
+
+func TestQuestionHeadline_RegexPath_StripsSlashCommandFromPrefix(t *testing.T) {
+	// AC3: a slash-command first prompt must not seed the topic with "/ir:exec".
+	m := &tailer.SessionMetrics{
+		FirstUserText:     "/ir:exec 1042 push this through",
+		LastAssistantText: "Should I proceed?",
+	}
+	got := questionHeadlineFor(m)
+	if strings.HasPrefix(got, "/ir:exec") {
+		t.Errorf("QuestionHeadline = %q, want no leading slash command in the topic", got)
+	}
+	if !strings.HasSuffix(got, ": Should I proceed?") {
+		t.Errorf("QuestionHeadline = %q, want a topic prefix then the question", got)
+	}
+}
+
+func TestQuestionHeadline_RegexPath_NoDoublePrefix(t *testing.T) {
+	// AC4: the question already opens with the derived topic — don't prepend a
+	// second copy.
+	m := &tailer.SessionMetrics{
+		FirstUserText:     "Add OAuth login to the web dashboard",
+		LastAssistantText: "Add OAuth login now, or add tests first?",
+	}
+	got := questionHeadlineFor(m)
+	want := "Add OAuth login now, or add tests first?"
+	if got != want {
+		t.Errorf("QuestionHeadline = %q, want no double topic prefix (%q)", got, want)
+	}
+}
+
+func TestQuestionHeadline_RegexPath_CapKeepsQuestion(t *testing.T) {
+	// The composed headline stays within the rune budget and never truncates
+	// away the question to leave only the topic.
+	longQuestion := "Should I " + strings.Repeat("carefully weigh every option ", 20) + "now?"
+	m := &tailer.SessionMetrics{
+		FirstUserText:     "Refactor the auth layer",
+		LastAssistantText: longQuestion,
+	}
+	got := questionHeadlineFor(m)
+	if !strings.HasPrefix(got, "Refactor the auth layer: Should I ") {
+		t.Errorf("QuestionHeadline = %q, want the topic + start of the question preserved", got)
+	}
+	if strings.HasSuffix(got, "auth layer:") || strings.HasSuffix(got, "auth layer: ") {
+		t.Errorf("QuestionHeadline = %q, cap left only the topic", got)
+	}
+	if runes := []rune(got); len(runes) > 200 {
+		t.Errorf("QuestionHeadline = %d runes, want <= 200", len(runes))
+	}
+}

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -143,7 +143,8 @@ func (mc *MetricsConverter) Convert(m *tailer.SessionMetrics) *session.SessionMe
 	if m.AwaySummary != nil && m.AwaySummary.Text != "" {
 		questionSource = m.AwaySummary.Text
 	}
-	if m.TaskQuestion != nil && m.TaskQuestion.Text != "" {
+	markerAuthored := m.TaskQuestion != nil && m.TaskQuestion.Text != ""
+	if markerAuthored {
 		questionSource = m.TaskQuestion.Text
 		// Only the deliberate irrlicht-question marker feeds the waiting-state
 		// classifier (issue #1138) — not the away_summary recap (a passive
@@ -152,8 +153,36 @@ func (mc *MetricsConverter) Convert(m *tailer.SessionMetrics) *session.SessionMe
 		// SessionMetrics.PendingQuestionMarker / IsWaitingForUserInput.
 		result.PendingQuestionMarker = true
 	}
-	result.QuestionHeadline = mc.compact(questionSource, outbound.CompactQuestion)
+	result.QuestionHeadline = mc.questionHeadline(questionSource, markerAuthored, m.FirstUserText)
 	return result
+}
+
+// questionHeadline shapes the surfaced pending-question headline as
+// "<3–5 word topic>: <question>" (issue #1186).
+//
+// An agent-authored marker already carries that shape, so it is compacted
+// VERBATIM — no sentence selection, which would drop the topic off a
+// multi-sentence marker. Otherwise the daemon composes the shape itself: it
+// compacts the raw question, then prefixes a topic derived from the session's
+// first user prompt, unless the question already leads with one. The prefix is
+// a compaction-tier refinement — skipped on the identity path (nil compactor),
+// where headlines intentionally carry the raw text, so the replay path is
+// unchanged. The join is re-capped through the verbatim kind so the topic and
+// question share one rune budget, trimming the question tail rather than the
+// topic.
+func (mc *MetricsConverter) questionHeadline(source string, markerAuthored bool, firstUserText string) string {
+	if markerAuthored {
+		return mc.compact(source, outbound.CompactQuestionVerbatim)
+	}
+	q := mc.compact(source, outbound.CompactQuestion)
+	if q == "" || mc == nil || mc.compactor == nil {
+		return q
+	}
+	topic := session.DeriveTopicPrefix(firstUserText)
+	if topic == "" || session.QuestionHasTopicPrefix(q, topic) {
+		return q
+	}
+	return mc.compact(topic+": "+q, outbound.CompactQuestionVerbatim)
 }
 
 // copyTailerTaskEstimate copies a tailer task estimate struct so a timeline

--- a/core/application/replayengine/metrics_test.go
+++ b/core/application/replayengine/metrics_test.go
@@ -17,6 +17,8 @@ func (fakeCompactor) Compact(text string, kind outbound.CompactKind) string {
 		return "intent:" + text
 	case outbound.CompactQuestion:
 		return "question:" + text
+	case outbound.CompactQuestionVerbatim:
+		return "verbatim:" + text
 	default:
 		return text
 	}
@@ -70,8 +72,8 @@ func TestConvert_QuestionHeadline_MarkerWinsOverLastAssistantText(t *testing.T) 
 		TaskQuestion:      &tailer.TaskQuestion{Text: "run the migration?", ObservedAt: 100},
 	}
 	got := NewMetricsConverter(fakeCompactor{}).Convert(m)
-	if got.QuestionHeadline != "question:run the migration?" {
-		t.Errorf("QuestionHeadline = %q, want the marker to win", got.QuestionHeadline)
+	if got.QuestionHeadline != "verbatim:run the migration?" {
+		t.Errorf("QuestionHeadline = %q, want the marker to win (compacted verbatim, #1186)", got.QuestionHeadline)
 	}
 	// The full last-assistant text is preserved for the tooltip + classifier.
 	if got.LastAssistantText != "a long rambling message ending in a question?" {
@@ -107,10 +109,30 @@ func TestConvert_QuestionHeadline_MarkerWinsOverAwaySummary(t *testing.T) {
 		TaskQuestion:      &tailer.TaskQuestion{Text: "run the migration?", ObservedAt: 200},
 	}
 	got := NewMetricsConverter(fakeCompactor{}).Convert(m)
-	if got.QuestionHeadline != "question:run the migration?" {
-		t.Errorf("QuestionHeadline = %q, want the agent's own marker to win over the away_summary recap", got.QuestionHeadline)
+	if got.QuestionHeadline != "verbatim:run the migration?" {
+		t.Errorf("QuestionHeadline = %q, want the agent's own marker to win over the away_summary recap (verbatim, #1186)", got.QuestionHeadline)
 	}
 }
+
+// TestConvert_QuestionHeadline_ComposesTopicPrefix pins issue #1186: on the
+// no-marker (regex/heuristic) path, the converter prefixes a 3–5 word topic
+// derived from the first user prompt onto the compacted question, joined by
+// ": " and re-capped through the verbatim kind. Uses the fakeCompactor so the
+// composition/routing is visible in the output tags.
+func TestConvert_QuestionHeadline_ComposesTopicPrefix(t *testing.T) {
+	m := &tailer.SessionMetrics{
+		LastAssistantText: "should I proceed?",
+		FirstUserText:     "Add OAuth login to the web dashboard",
+	}
+	got := NewMetricsConverter(fakeCompactor{}).Convert(m)
+	// fakeCompactor tags each stage: the question is compacted (question:),
+	// then the "<topic>: <question>" join is re-compacted verbatim (verbatim:).
+	want := "verbatim:Add OAuth login: question:should I proceed?"
+	if got.QuestionHeadline != want {
+		t.Errorf("QuestionHeadline = %q, want the topic prefix composed (%q)", got.QuestionHeadline, want)
+	}
+}
+
 
 // TestConvert_PendingQuestionMarker pins issue #1138: only the deliberate
 // irrlicht-question marker sets PendingQuestionMarker (the waiting-state

--- a/core/application/replayengine/metrics_test.go
+++ b/core/application/replayengine/metrics_test.go
@@ -133,7 +133,6 @@ func TestConvert_QuestionHeadline_ComposesTopicPrefix(t *testing.T) {
 	}
 }
 
-
 // TestConvert_PendingQuestionMarker pins issue #1138: only the deliberate
 // irrlicht-question marker sets PendingQuestionMarker (the waiting-state
 // classifier's authoritative signal). The away_summary recap and the

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -191,8 +191,9 @@ type SessionMetrics struct {
 	// marker was retired in #1186, so this is now sourced from the first user
 	// message heuristic (an older marker in a live transcript still parses).
 	// Decoded-but-not-rendered by any UI since the intent pill was removed
-	// (#979); kept as the full text and as the prefix source for the question
-	// headline's regex path.
+	// (#979) — a tolerated no-op, like IntentHeadline. (The question headline's
+	// topic prefix is derived from the tailer's FirstUserText directly, not from
+	// this field.)
 	TaskSummary string `json:"task_summary,omitempty"`
 
 	// IntentHeadline is the terse one-line version of TaskSummary, produced by

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -187,25 +187,27 @@ type SessionMetrics struct {
 	LastAssistantText string `json:"last_assistant_text,omitempty"`
 
 	// TaskSummary is a human-readable one-line description of what the
-	// session's current task is about (issue #738). Sourced from the agent's
-	// in-band irrlicht-summary marker when present, else a daemon-side
-	// heuristic (the first user message). Surfaced in both the waiting and
-	// ready states so a human can tell what a session was about at a glance.
-	// Kept as the full text; the sidebar shows IntentHeadline and uses this as
-	// the hover tooltip.
+	// session's current task is about (issue #738). The irrlicht-summary agent
+	// marker was retired in #1186, so this is now sourced from the first user
+	// message heuristic (an older marker in a live transcript still parses).
+	// Decoded-but-not-rendered by any UI since the intent pill was removed
+	// (#979); kept as the full text and as the prefix source for the question
+	// headline's regex path.
 	TaskSummary string `json:"task_summary,omitempty"`
 
-	// IntentHeadline is the terse ~70-char one-line version of TaskSummary,
-	// produced by the compaction seam (issue #759). The sidebar renders this in
-	// the purple "intent" block; the full TaskSummary is the tooltip. Empty
-	// when there is no summary source.
+	// IntentHeadline is the terse one-line version of TaskSummary, produced by
+	// the compaction seam (issue #759). Decoded-but-not-rendered by any UI
+	// since the intent pill was removed (#979); retained as a tolerated no-op.
 	IntentHeadline string `json:"intent_headline,omitempty"`
 
-	// QuestionHeadline is the terse ~70-char one-line version of the pending
-	// question, produced by the compaction seam from the agent's in-band
-	// irrlicht-question marker when present, else from LastAssistantText (issue
-	// #759). The sidebar renders this in the orange "waiting" block; the full
-	// LastAssistantText is the tooltip. Empty when there is no question source.
+	// QuestionHeadline is the terse one-line pending-question headline, shaped
+	// as "<3–5 word topic>: <question>" (issue #1186). An agent-authored
+	// irrlicht-question marker carries that whole shape (compacted verbatim);
+	// otherwise the daemon composes it — a topic derived from the session's
+	// first user prompt joined to the question extracted from LastAssistantText
+	// / away_summary (issue #759). The sidebar renders this in the orange
+	// "waiting" block; the full LastAssistantText is the tooltip. Empty when
+	// there is no question source.
 	QuestionHeadline string `json:"question_headline,omitempty"`
 
 	// PendingQuestionMarker is true when the agent emitted an explicit in-band

--- a/core/domain/session/topic_prefix.go
+++ b/core/domain/session/topic_prefix.go
@@ -1,0 +1,97 @@
+// topic_prefix.go derives the short "ChatGPT-conversation-title"-style topic
+// that prefixes a surfaced pending-question headline, so a watcher scanning
+// waiting sessions sees WHAT the question is about, not just the bare ask
+// (issue #1186). The prefix source is the session's first user prompt; the
+// composition ("<topic>: <question>") happens in the tailer→domain conversion.
+package session
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// maxTopicPrefixRunes bounds the derived topic so it can never dominate the
+// headline budget: a pasted URL or a wall-of-text first prompt collapses to a
+// single long "word", and the join must still leave room for the question.
+// Generous for a 3–5 word topic.
+const maxTopicPrefixRunes = 48
+
+// topicWordMax is the upper end of the "3–5 word" topic window: the derived
+// topic keeps at most this many leading words.
+const topicWordMax = 5
+
+// topicTrailingPunct are characters trimmed from the end of a derived topic so
+// the ": " join reads cleanly (no "DB migration -: …").
+const topicTrailingPunct = " \t.,;:!?-—–"
+
+// topicTrailingStopwords are articles/prepositions/conjunctions trimmed from
+// the END of a topic so it doesn't dangle on "... to the". Only trailing ones
+// are dropped, and never the last remaining word.
+var topicTrailingStopwords = map[string]bool{
+	"a": true, "an": true, "the": true, "to": true, "of": true, "for": true,
+	"and": true, "or": true, "in": true, "on": true, "with": true, "at": true,
+	"by": true, "from": true, "into": true, "as": true,
+}
+
+// DeriveTopicPrefix turns a session's first user prompt into a short topic
+// (3–5 words) for prefixing the pending-question headline (issue #1186). It
+// strips a leading slash-command token (e.g. "/ir:exec 1042 …"), collapses
+// whitespace, keeps the first few words on a word boundary, trims trailing
+// stopwords and punctuation, and caps the result. Returns "" when the prompt
+// yields nothing usable — the caller then emits the bare question rather than
+// a dangling ": ".
+func DeriveTopicPrefix(prompt string) string {
+	fields := strings.Fields(prompt)
+	// Drop a leading "/command" token (e.g. "/ir:exec"): it names the tool, not
+	// the task, and would make a useless topic.
+	if len(fields) > 0 && strings.HasPrefix(fields[0], "/") {
+		fields = fields[1:]
+	}
+	if len(fields) == 0 {
+		return ""
+	}
+	if len(fields) > topicWordMax {
+		fields = fields[:topicWordMax]
+	}
+	// Trim trailing filler words so the topic doesn't dangle on "to the".
+	for len(fields) > 1 && topicTrailingStopwords[strings.ToLower(strings.Trim(fields[len(fields)-1], topicTrailingPunct))] {
+		fields = fields[:len(fields)-1]
+	}
+	topic := strings.TrimRight(strings.Join(fields, " "), topicTrailingPunct)
+	return capTopicRunes(topic, maxTopicPrefixRunes)
+}
+
+// QuestionHasTopicPrefix reports whether question already leads with a topic —
+// either it starts with topic itself, or it carries its own short "Lead: "
+// colon prefix — so the caller doesn't prepend a second one (issue #1186).
+func QuestionHasTopicPrefix(question, topic string) bool {
+	q := strings.TrimSpace(question)
+	if topic != "" && strings.HasPrefix(strings.ToLower(q), strings.ToLower(topic)) {
+		return true
+	}
+	// A short "Lead words: …" already present in the question counts as a
+	// topic prefix. Bounded to the topic budget and to a few words — and
+	// vetoed by sentence punctuation before the colon — so a mid-sentence
+	// colon (or a "PKCE: implicit" style clause) doesn't false-match.
+	if idx := strings.Index(q, ": "); idx > 0 {
+		lead := q[:idx]
+		if utf8.RuneCountInString(lead) <= maxTopicPrefixRunes &&
+			len(strings.Fields(lead)) <= topicWordMax &&
+			!strings.ContainsAny(lead, "?!.") {
+			return true
+		}
+	}
+	return false
+}
+
+// capTopicRunes truncates s to at most max runes on a rune boundary, with a
+// trailing ellipsis when it drops text. Mirrors the compaction adapter's
+// capRunes; kept here so the domain owns its own bound without importing an
+// outbound adapter.
+func capTopicRunes(s string, max int) string {
+	if utf8.RuneCountInString(s) <= max {
+		return s
+	}
+	runes := []rune(s)
+	return strings.TrimRight(string(runes[:max-1]), " ") + "…"
+}

--- a/core/domain/session/topic_prefix.go
+++ b/core/domain/session/topic_prefix.go
@@ -7,6 +7,7 @@ package session
 
 import (
 	"strings"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -58,7 +59,7 @@ func DeriveTopicPrefix(prompt string) string {
 		fields = fields[:len(fields)-1]
 	}
 	topic := strings.TrimRight(strings.Join(fields, " "), topicTrailingPunct)
-	return capTopicRunes(topic, maxTopicPrefixRunes)
+	return CapRunes(topic, maxTopicPrefixRunes)
 }
 
 // QuestionHasTopicPrefix reports whether question already leads with a topic —
@@ -66,8 +67,13 @@ func DeriveTopicPrefix(prompt string) string {
 // colon prefix — so the caller doesn't prepend a second one (issue #1186).
 func QuestionHasTopicPrefix(question, topic string) bool {
 	q := strings.TrimSpace(question)
-	if topic != "" && strings.HasPrefix(strings.ToLower(q), strings.ToLower(topic)) {
-		return true
+	if topic != "" {
+		lq, lt := strings.ToLower(q), strings.ToLower(topic)
+		// Require a word boundary after the match so a short topic ("Add")
+		// doesn't count as a prefix of a longer first word ("Additional").
+		if strings.HasPrefix(lq, lt) && endsOnWordBoundary(lq[len(lt):]) {
+			return true
+		}
 	}
 	// A short "Lead words: …" already present in the question counts as a
 	// topic prefix. Bounded to the topic budget and to a few words — and
@@ -84,11 +90,25 @@ func QuestionHasTopicPrefix(question, topic string) bool {
 	return false
 }
 
-// capTopicRunes truncates s to at most max runes on a rune boundary, with a
-// trailing ellipsis when it drops text. Mirrors the compaction adapter's
-// capRunes; kept here so the domain owns its own bound without importing an
-// outbound adapter.
-func capTopicRunes(s string, max int) string {
+// endsOnWordBoundary reports whether rest (the text immediately after a
+// prefix match) begins at a word boundary — i.e. it is empty or starts with a
+// non-alphanumeric rune (space, punctuation). This keeps "Add" from matching
+// inside "Additional" while still treating "login, or…" or "login now" as a
+// boundary after the topic "…login".
+func endsOnWordBoundary(rest string) bool {
+	if rest == "" {
+		return true
+	}
+	r, _ := utf8.DecodeRuneInString(rest)
+	return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+}
+
+// CapRunes truncates s to at most max runes, trimming trailing spaces and
+// appending an ellipsis on a rune boundary when it drops text (so the result
+// never exceeds max). The canonical one-line-headline rune bound: the
+// compaction adapter reuses it for its own cap (it already depends on this
+// package), so live and derived headlines share one truncation rule.
+func CapRunes(s string, max int) string {
 	if utf8.RuneCountInString(s) <= max {
 		return s
 	}

--- a/core/domain/session/topic_prefix.go
+++ b/core/domain/session/topic_prefix.go
@@ -67,27 +67,34 @@ func DeriveTopicPrefix(prompt string) string {
 // colon prefix — so the caller doesn't prepend a second one (issue #1186).
 func QuestionHasTopicPrefix(question, topic string) bool {
 	q := strings.TrimSpace(question)
-	if topic != "" {
-		lq, lt := strings.ToLower(q), strings.ToLower(topic)
-		// Require a word boundary after the match so a short topic ("Add")
-		// doesn't count as a prefix of a longer first word ("Additional").
-		if strings.HasPrefix(lq, lt) && endsOnWordBoundary(lq[len(lt):]) {
-			return true
-		}
+	return startsWithTopic(q, topic) || hasOwnColonLead(q)
+}
+
+// startsWithTopic reports whether q begins with topic followed by a word
+// boundary — so a short topic ("Add") doesn't count as a prefix of a longer
+// first word ("Additional").
+func startsWithTopic(q, topic string) bool {
+	if topic == "" {
+		return false
 	}
-	// A short "Lead words: …" already present in the question counts as a
-	// topic prefix. Bounded to the topic budget and to a few words — and
-	// vetoed by sentence punctuation before the colon — so a mid-sentence
-	// colon (or a "PKCE: implicit" style clause) doesn't false-match.
-	if idx := strings.Index(q, ": "); idx > 0 {
-		lead := q[:idx]
-		if utf8.RuneCountInString(lead) <= maxTopicPrefixRunes &&
-			len(strings.Fields(lead)) <= topicWordMax &&
-			!strings.ContainsAny(lead, "?!.") {
-			return true
-		}
+	lq, lt := strings.ToLower(q), strings.ToLower(topic)
+	return strings.HasPrefix(lq, lt) && endsOnWordBoundary(lq[len(lt):])
+}
+
+// hasOwnColonLead reports whether q already opens with its own short
+// "Lead words: …" topic. Bounded to the topic budget and to a few words, and
+// vetoed by sentence punctuation before the colon, so a mid-sentence colon (or
+// a "PKCE: implicit" style clause) doesn't false-match.
+func hasOwnColonLead(q string) bool {
+	idx := strings.Index(q, ": ")
+	if idx <= 0 {
+		return false
 	}
-	return false
+	lead := q[:idx]
+	shortEnough := utf8.RuneCountInString(lead) <= maxTopicPrefixRunes
+	fewWords := len(strings.Fields(lead)) <= topicWordMax
+	noSentencePunct := !strings.ContainsAny(lead, "?!.")
+	return shortEnough && fewWords && noSentencePunct
 }
 
 // endsOnWordBoundary reports whether rest (the text immediately after a

--- a/core/domain/session/topic_prefix_test.go
+++ b/core/domain/session/topic_prefix_test.go
@@ -54,6 +54,8 @@ func TestQuestionHasTopicPrefix(t *testing.T) {
 	}{
 		{"question starts with topic", "Add OAuth login now or later?", "Add OAuth login", true},
 		{"case-insensitive start match", "add oauth LOGIN now?", "Add OAuth login", true},
+		{"punctuation boundary after topic", "Add OAuth login, or add tests first?", "Add OAuth login", true},
+		{"short topic is not a mid-word prefix", "Additional context needed?", "Add", false},
 		{"question carries its own colon lead", "Auth refactor: ship now or wait?", "Something else", true},
 		{"no prefix present", "Should I use PKCE or implicit?", "Auth refactor", false},
 		{"mid-sentence colon is not a topic lead", "Should I use this ratio 3:2 or 16:9?", "Layout", false},

--- a/core/domain/session/topic_prefix_test.go
+++ b/core/domain/session/topic_prefix_test.go
@@ -1,0 +1,70 @@
+package session
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestDeriveTopicPrefix(t *testing.T) {
+	cases := []struct {
+		name   string
+		prompt string
+		want   string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   \n\t ", ""},
+		{"short prompt kept whole", "Fix the login loop", "Fix the login loop"},
+		{"trims trailing stopword", "Add OAuth login to the web dashboard", "Add OAuth login"},
+		{"caps at five words", "one two three four five six seven", "one two three four five"},
+		{"strips leading slash command", "/ir:exec 1042 push this through", "1042 push this through"},
+		{"slash command only leaves nothing usable after cap", "/help", ""},
+		{"collapses whitespace", "DB    migration\tready now", "DB migration ready now"},
+		{"drops trailing punctuation", "Auth refactor:", "Auth refactor"},
+		{"keeps single non-stopword word", "the", "the"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DeriveTopicPrefix(tc.prompt); got != tc.want {
+				t.Errorf("DeriveTopicPrefix(%q) = %q, want %q", tc.prompt, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeriveTopicPrefix_CapsLongSingleWord(t *testing.T) {
+	// A pasted URL is one whitespace-delimited "word"; it must not blow the
+	// topic budget (issue #1186).
+	url := "https://example.com/" + strings.Repeat("a", 200)
+	got := DeriveTopicPrefix(url)
+	if utf8.RuneCountInString(got) > maxTopicPrefixRunes {
+		t.Errorf("DeriveTopicPrefix(url) = %d runes, want <= %d", utf8.RuneCountInString(got), maxTopicPrefixRunes)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("DeriveTopicPrefix(url) = %q, want a trailing ellipsis when capped", got)
+	}
+}
+
+func TestQuestionHasTopicPrefix(t *testing.T) {
+	cases := []struct {
+		name     string
+		question string
+		topic    string
+		want     bool
+	}{
+		{"question starts with topic", "Add OAuth login now or later?", "Add OAuth login", true},
+		{"case-insensitive start match", "add oauth LOGIN now?", "Add OAuth login", true},
+		{"question carries its own colon lead", "Auth refactor: ship now or wait?", "Something else", true},
+		{"no prefix present", "Should I use PKCE or implicit?", "Auth refactor", false},
+		{"mid-sentence colon is not a topic lead", "Should I use this ratio 3:2 or 16:9?", "Layout", false},
+		{"long lead before colon is not a topic", "This is a very long clause that runs well past a short topic: decide?", "X", false},
+		{"empty topic and no colon lead", "Should I proceed?", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := QuestionHasTopicPrefix(tc.question, tc.topic); got != tc.want {
+				t.Errorf("QuestionHasTopicPrefix(%q, %q) = %v, want %v", tc.question, tc.topic, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/ports/outbound/compaction.go
+++ b/core/ports/outbound/compaction.go
@@ -11,8 +11,17 @@ const (
 	// task-summary marker or the first user prompt) into a one-line headline.
 	CompactIntent CompactKind = iota
 	// CompactQuestion compacts the agent's pending question (the task-question
-	// marker or the raw last-assistant text) into a one-line headline.
+	// marker or the raw last-assistant text) into a one-line headline. It runs
+	// question-sentence selection, keeping the single most headline-worthy
+	// sentence — the right shape for the raw, multi-sentence fallback sources.
 	CompactQuestion
+	// CompactQuestionVerbatim compacts an already-composed one-line headline
+	// (an agent-authored "<topic>: <question>" marker, or the daemon's own
+	// "topic: question" join) WITHOUT sentence selection: it strips noise and
+	// markdown, collapses whitespace and caps runes, but keeps every sentence.
+	// Sentence selection would drop the topic prefix off a multi-sentence
+	// marker; this kind preserves it (issue #1186).
+	CompactQuestionVerbatim
 )
 
 // TextCompactor turns a possibly-bloated piece of session text into a terse


### PR DESCRIPTION
Closes #1186.

## What

Waiting-state headlines now show **what** a question is about, not just the bare ask. Every `question_headline` is shaped `<3–5 word topic>: <question>` (ChatGPT-conversation-title style).

## Two production paths, one output shape

- **Marker path (agent-authored).** The `irrlicht-question` instruction block becomes **v3**, asking the agent to write the `<topic>: <question>` shape directly. The marker is routed through a new `CompactQuestionVerbatim` compaction kind — no sentence-selection, so a multi-sentence marker keeps its topic prefix instead of dropping it. `patchManagedBlock` upgrades installed v1/v2 blocks in place.
- **Regex/heuristic path (no marker).** When compacting, the daemon derives a 3–5 word topic from the session's first user prompt (leading `/command` stripped, whitespace-collapsed, cut on a word boundary, trailing stopwords/punctuation trimmed, rune-capped) and joins it to the extracted question, re-capped through the verbatim kind so the topic and question **share one rune budget** — the question tail is trimmed, never the topic. Guards against double-prefixing and dangling `": "`.

The prefix is a compaction-tier refinement, so it's **skipped on the identity/replay path** (nil compactor) — replay goldens are byte-identical and needed no regeneration.

## Retire the `irrlicht-summary` marker

Its context now lives in the question headline. The block is no longer installed; `applyInstructionBlocks` actively **uninstalls** it on a granted daemon start so a `CLAUDE.md` a prior version wrote is cleaned up. The tolerant `ScanTaskSummary` and the `TaskSummary`/`IntentHeadline` fields stay as no-ops (`FirstUserText` remains the question-prefix source).

## UI

No UI changes: `SessionRowView.swift` and `irrlicht.js` already render `question_headline` verbatim, so the prefix ships on **both** the macOS app and the web dashboard.

## Tests

- New: `session/topic_prefix_test.go` (topic derivation + double-prefix guard), verbatim compaction (`compaction_test.go`), routing (`replayengine/metrics_test.go`), and **end-to-end through the real deterministic compactor** in `metrics/question_headline_test.go` (AC1–AC4 + rune-budget preservation).
- `go test ./core/... -race -count=1` ✅ · `go vet` ✅ · `tools/replay-fixtures.sh` ✅ · `of validate` ✅ · replay goldens unchanged ✅ · `go test ./tools/onboarding-factory/... -race` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)