### PR TITLE
feat(skills): red-first test gate + evidence bar for dismissals (#1126)

### DIFF
--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -213,6 +213,29 @@ Nobody is gating on the plan, so skip the HTML artifact and the wait entirely:
     scoped it to** — open the macOS app (`/ir:test-mac`) and/or the web dashboard and
     look. A passing test suite in the same area is not evidence the specific feature
     exists on a specific platform — name the exact test that covers the claim, or look.
+11a. **Prove red-first.** For every test asserting a claimed defect, run it
+    **before** the fix exists and confirm it **fails**. Paste the failure — in
+    the PR body, or the issue if you're reporting back there. Do this during
+    step 10 (write the test first; or checkpoint the fix with a local commit and
+    revert it to re-run — never `git stash`, per AGENTS.md).
+
+    A test that **passes** on `main` is not a regression test. Either the
+    diagnosis is wrong, or the test doesn't reach the defect — e.g. it exercises
+    a stub that is blind to the field it asserts on. **STOP and report.** Do not
+    proceed on a green that proves nothing.
+
+    **Locks** — tests pinning behavior that must *not* change — pass on `main` by
+    construction. Say which tests those are explicitly, rather than letting their
+    green read as a red-first proof.
+
+    This applies to test code the *issue itself* pasted. A code block in an issue
+    is a proposal, not evidence: `/ir:triage` marks such a test **unproven** on
+    its Verifiability axis, and an untriaged one owes you the same run. (Real
+    incident: #1076 shipped seven ACs with complete test code aimed at
+    `core/pkg/tailer`, whose `handleTestSystemEvent` stub never reads the field
+    under test — the literal AC would have passed on `main` while the bug
+    shipped. Three of six issues in that batch specified tests that pass on
+    `main`; nothing in this skill caught it.)
 
 ## Phase 5 — PR, review, simplify
 
@@ -313,3 +336,6 @@ Phase 6.
 - User-facing features ship on every applicable frontend (macOS + web), or the plan
   says explicitly why not (Phase 2). Verify each one directly rather than trusting an
   adjacent green test suite (Phase 4) — see the Activity Matrix incident above.
+- A defect test proves nothing until it has been seen red (Phase 4 step 11a). This
+  binds regardless of where the test came from — the issue, `/ir:triage`, or your
+  own diagnosis; a green that was never red is the failure mode, not the author.

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -216,8 +216,10 @@ Nobody is gating on the plan, so skip the HTML artifact and the wait entirely:
 11a. **Prove red-first.** For every test asserting a claimed defect, run it
     **before** the fix exists and confirm it **fails**. Paste the failure — in
     the PR body, or the issue if you're reporting back there. Do this during
-    step 10 (write the test first; or checkpoint the fix with a local commit and
-    revert it to re-run — never `git stash`, per AGENTS.md).
+    step 10: write the test first, before the fix exists. If the fix is already
+    in your worktree, checkpoint it (`git commit -m wip`), revert the fix, run
+    the test, then restore — never `git stash`, whose stack is shared across
+    worktrees (AGENTS.md).
 
     A test that **passes** on `main` is not a regression test. Either the
     diagnosis is wrong, or the test doesn't reach the defect — e.g. it exercises

--- a/.claude/skills/ir:triage/SKILL.md
+++ b/.claude/skills/ir:triage/SKILL.md
@@ -57,6 +57,16 @@ Every comment posted during triage **must** start with:
 5. **Post** the assessment using the template below.
 6. **Label and milestone** in a single `gh issue edit` call (one round-trip per issue). Close if `wontfix`.
 
+## Dismissals carry evidence
+
+A **dismissal** is any claim whose function is *"you don't need to look here"* — *already fixed in #X* / *self-heals* / *likely benign* / *non-issue* / *out of scope anyway*. It is the highest-leverage sentence in an issue, because when it is wrong nobody looks. It gets the same evidence bar as the headline claim, in both directions:
+
+**Reading the issue.** An unmarked dismissal in the body is an *assumption*, not a finding — do not inherit it as fact into your scoring, and do not let it shrink Scope or excuse a ✗. Where a dismissal is load-bearing (it's why the issue is documentation-only, or why an axis passes), spend one of step 2's light checks on it — `git grep`, read the function, check whether #X actually touched that path. If it doesn't hold, that's a **Specification** ✗ and a named blocker. If you can't check it cheaply, say so in the one-liner rather than scoring around it.
+
+**Writing the comment.** Mark your own claims. Cite what you ran or read (`[verified]` / `git grep + go list`), or mark the claim assumed — the existing `— exact code paths cited (and verified extant)` phrasing is the model. A one-liner that dismisses an axis's risk without saying what was checked is the same defect one level up.
+
+Real incident: #1088's one real bug sat in an unmarked aside asserting a sweep "self-heals" a field. It does not — the sweep deliberately preserves exactly the names that pinned the session to `waiting` forever. Meanwhile that same issue's three *explicitly labelled* "unverified" claims were all investigated and all came back not real. Confidence ran inversely to correctness, and only the marking told them apart. #1089's dismissal (*"the consequence is fixed in #1078"*) was the stated basis for treating it as documentation-only; it was wrong, and became #1104.
+
 ## Readiness Rubric (7 axes)
 
 Each axis scores ✓ (pass) or ✗ (fail) with a one-line justification grounded in the issue body. Any ✗ **on the first six axes** → `needs-info`. All ✓ → `ready-for-agent`. **Observability is the exception** — a ✗ there is priced, not fatal; see its cost rule below.
@@ -65,7 +75,7 @@ Each axis scores ✓ (pass) or ✗ (fail) with a one-line justification grounded
 |---|---|---|
 | **Scope** | The change is bounded — number of files / packages touched is knowable from the issue, no "and also" creep. | "Refactor the codebase", "improve performance", any wording that fans out unboundedly. |
 | **Specification** | The desired outcome is stated (what, not how). Edge cases either listed or absent because they don't exist. | Outcome is implied or aspirational; "make it better"; multiple plausible interpretations. |
-| **Verifiability** | A concrete signal exists for "done": a unit test, a replay scenario, a CLI command output, a UI behavior, a metric threshold. | No way to mechanically tell if the fix worked; only "looks right" judgment. |
+| **Verifiability** | A concrete signal exists for "done": a unit test, a replay scenario, a CLI command output, a UI behavior, a metric threshold — *and* it would discriminate today, i.e. fail on `main`. Mark it **unproven** when that's asserted but not shown; see the red-first rule below. | No way to mechanically tell if the fix worked; only "looks right" judgment. |
 | **Observability** | The behavior can be reproduced *and* observed with what exists today — a recording, replay scenario, `events.jsonl`, an `of` query, a metric, a CLI output, a snapshot test. | Reproduction is possible but the effect is invisible (no durable artifact to assert on), or reproduction itself needs a rig that doesn't exist. |
 | **Context** | Relevant code paths / docs / prior PRs are cited or trivially findable. The agent has a starting point. | Issue is abstract or implicates code with no obvious entry point. |
 | **Independence** | Not blocked on another issue / PR / external decision. No concurrent work that would conflict. | Depends on #N which is open / unresolved / unmerged; depends on a maintainer decision not yet made. |
@@ -76,6 +86,21 @@ Each axis scores ✓ (pass) or ✗ (fail) with a one-line justification grounded
 These two are adjacent by design and must not be scored as one. **Verifiability names the measurement; Observability asks whether the instrument to take it exists today.**
 
 "A replay scenario asserts `working → ready` within 500ms" is a fine measurement — but if no recording of that adapter × scenario exists, there is nothing to replay. ✓ Verifiability with ✗ Observability is the common and interesting case: everyone agrees what "done" looks like, and nothing can currently show it. If both axes' one-liners say the same thing, you've scored the same concern twice — Verifiability is about the *criterion*, Observability about the *evidence*.
+
+### Verifiability: a pasted test is **unproven** until it has been run red
+
+The axis asks *"would that test fail today?"*, not *"is there a test?"* — a signal that can't discriminate measures nothing, however much test code was pasted.
+
+Test code or ACs in an issue body are a **proposal, not evidence**. They count as proof only when the author says they ran it against `main` and pasted the failure. Otherwise the axis can still pass on the *criterion* — but the one-liner must carry the word **unproven**, so the implementer knows it owes a red-first run (`ir:exec` Phase 4 step 11a) rather than trusting the code block:
+
+- ✓ **Verifiability** — AC3 asserts `pendingBackgroundAgentCount` after a turn-done sweep; **unproven** (test code pasted, no red run shown).
+
+Two failure modes to hold apart:
+
+- Don't ✗ the axis for unprovenness alone — an unproven test is still a stated criterion. ✗ only when no discriminating signal is named at all.
+- Don't upgrade an unproven paste to a verified one by reading the code and judging it plausible. Plausible is exactly what a test aimed at a stub blind to the asserted field looks like — #1076's AC3 shipped as complete, correct-looking test code, and as literally written would have passed on `main` while the bug shipped.
+
+Author-written **lock** tests — pinning behavior that must *not* change — pass on `main` by construction and are not unproven. Say so in the one-liner so nobody mistakes their green for a red-first proof.
 
 ### Observability cost rule
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,15 @@
 Worktrees share the parent repo's `.git` dir, so **`git stash` is not isolated per worktree** — it's a single shared stack. Concurrent agents stashing in different worktrees can pop each other's WIP. Use a local commit as a checkpoint instead (`git commit -m wip`, amend/reset later).
 When encountering suboptimal processes or issues make improvment suggestions in you final answer to the user.
 
+**Dismissals carry evidence.** Any claim whose function is *"you don't need to look
+here"* — *already fixed in #X*, *self-heals*, *likely benign*, *non-issue* — gets the
+same bar as the claim it supports: cite what you ran or read, or mark it assumed. This
+binds wherever a finding is written down (issue bodies, PR descriptions, triage
+comments, final answers), because a wrong dismissal is the one kind of error that stops
+anyone from checking it. Marking works: in #1088 every claim explicitly labelled
+"unverified" was investigated and came back not real, while that issue's one real bug
+hid in an unmarked aside.
+
 ## Build Artifacts
 
 Use `./.build` for build artifacts.
@@ -41,6 +50,13 @@ Use `./.build` for build artifacts.
 - Adapters declare `Permissions` on `agent.Agent` (with Apply/Remove effect closures); every read or modification an adapter performs must be consent-gated behind one of its declared permissions — nothing is exercised while pending or denied
 
 ## Testing
+
+**A defect test proves nothing until it has been seen red.** Run it before the fix
+exists, confirm it fails, paste the failure. A test that passes on `main` means either
+the diagnosis is wrong or the test doesn't reach the defect (a stub blind to the
+asserted field is the classic) — stop and report rather than shipping the green. Locks
+— tests pinning behavior that must *not* change — pass by construction; say which ones
+those are. `ir:exec` enforces this at Phase 4 step 11a; it binds outside `ir:exec` too.
 
 Before marking a ticket done, run the full suite — every layer must pass:
 


### PR DESCRIPTION
Closes #1126

Three of six agent-written issues in a recent batch specified regression tests that **pass on `main`**. Nothing in the tooling would have caught it — `ir:exec` Phase 4 only said "run the test suites relevant to what you touched", which a test that proves nothing satisfies.

## What changed

**1. `ir:exec` — new Phase 4 step 11a (red-first gate).** Every test asserting a claimed defect must be run *before* the fix and seen to fail, with the failure pasted. A green that was never red means either the diagnosis is wrong or the test doesn't reach the defect (a stub blind to the asserted field is the classic) — **STOP and report**. Locks (tests pinning behavior that must *not* change) pass by construction and must be named as such. Explicitly binds to test code the issue itself pasted.

Numbered `11a` rather than `12` so steps 12–21 and their five cross-reference sites (the Phase 5 tier table's "Step 13 / Step 14" columns, the two "steps 13–14" prose refs, and the Notes line) keep their numbers. Since it directly follows step 11 with no blank line, it renders as a continuation of that list item, which keeps the indented paragraphs correct.

**2. `ir:triage` — Verifiability asks "would that test fail today?"** The axis previously asked "is there a test?", so #1076 — seven ACs with complete test code — would have scored ✓ enthusiastically. Now pasted test code is a **proposal, not evidence**: it scores **unproven** unless the author ran it against `main` and pasted the failure, telling the implementer it owes a red-first proof. Unprovenness alone doesn't ✗ the axis, and the new text explicitly forbids upgrading an unproven paste to verified by reading it and judging it plausible.

**3. Dismissals carry evidence** — `ir:triage` (new section) + `AGENTS.md` (repo-wide). A claim whose function is *"you don't need to look here"* (*already fixed in #X*, *self-heals*, *likely benign*) gets the same bar as the claim it supports. For triage that cuts both ways: don't inherit the issue's unmarked dismissals as fact, and mark your own claims in the comment.

## Scope decision

The issue carried `needs-info` because proposal 3 named two mutually exclusive homes. I took **`ir:triage` + `AGENTS.md`** rather than a new skill owning sweep→issue — smaller blast radius, and both files were already in the issue's stated scope. All three proposals are included (the issue notes 1 is worth little without 3).

## Verification — red-first, applied to itself

The issue's stated acceptance is a grep, and its baseline claim was `[verified] zero red-first|fails on main hits in ir:exec today`. Confirmed that baseline red before the change, then green after:

```
$ git grep -c -iE 'red-first|fails on main|passes on .main.' origin/main -- \
    '.claude/skills/ir:exec/SKILL.md' '.claude/skills/ir:triage/SKILL.md' 'AGENTS.md'
(no matches on origin/main — baseline red confirmed)
```

After: hits in all three files (`ir:exec` 216/229/232, `ir:triage` 60/78/90/94/96/103, `AGENTS.md` 15/55).

Markdown-only diff (3 files, +68/-1) — no Go, Swift, web, or replaydata surface touched, so no code suite applies.

Two factual overclaims in my own first draft were caught and corrected before commit: "seven ACs, all of which would have passed on `main`" (only AC3-as-literally-written does; rerouted, AC1/AC3 fail and AC2/AC4 are locks) and "the one real bug across six issues" (it was #1088's one real bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)