### PR TITLE
fix(macos): make the master "Enable notifications" toggle authoritative (#1183)

### DIFF
--- a/platforms/macos/Irrlicht/Managers/SessionManager+Notifications.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Notifications.swift
@@ -140,6 +140,12 @@ extension SessionManager {
         sessionID: String,
         event: NotificationEvent
     ) {
+        // Master gate (#1183). Every notification — banner, sound and the TTS
+        // below — leaves through here, so one guard silences all of them and no
+        // future caller can route around it. Gating here rather than at the two
+        // call sites is also why the spoken voice, which bypasses
+        // UNNotificationContent entirely, is covered.
+        guard NotificationSettings.masterEnabled() else { return }
         guard canUseUserNotifications else { return }
         let choice = Self.choice(for: event)
         let content = UNMutableNotificationContent()
@@ -158,8 +164,9 @@ extension SessionManager {
         // willPresent is unreliable for LSUIElement menubar-only apps — macOS
         // skips it when it considers the app not-in-foreground, and Irrlicht
         // sits in that grey zone. Drive speech from here (on @MainActor) so
-        // it actually fires for real state transitions. The per-event toggle
-        // is the off switch; users who pick a Speak aloud variant have opted in.
+        // it actually fires for real state transitions. The master gate above
+        // plus the per-event toggle are the off switches; users who pick a
+        // Speak aloud variant have opted in.
         // TTS bypasses UNNotificationContent entirely, so we must also gate on
         // Focus here — otherwise the loudest sound option leaks through DND.
         if let voice = Self.voiceForSpeak(choice: choice, focusActive: focusMonitor.isFocusActive) {

--- a/platforms/macos/Irrlicht/Models/NotificationEvent.swift
+++ b/platforms/macos/Irrlicht/Models/NotificationEvent.swift
@@ -42,3 +42,32 @@ enum NotificationEvent: String, CaseIterable {
         }
     }
 }
+
+/// The master "Enable notifications" gate (#940), made authoritative over the
+/// firing path in #1183. Owns the key and the single rule for reading it, so
+/// the Settings toggle and the code that decides whether to fire can't drift.
+enum NotificationSettings {
+    /// Deliberately NOT part of `SessionManager`'s `register(defaults:)` seed:
+    /// a registered value would make `object(forKey:)` non-nil forever, which
+    /// silently disables the upgrade fallback below.
+    static let masterEnabledKey = "notificationsEnabled"
+
+    /// Pure decision: is the master gate on? `master` is `nil` when the key has
+    /// never been written — an install that predates the toggle and hasn't
+    /// opened Settings since. That case falls back to the per-event OR, so an
+    /// already-configured setup keeps firing instead of going quiet on upgrade.
+    static func masterEnabled(master: Bool?, anyEventEnabled: Bool) -> Bool {
+        master ?? anyEventEnabled
+    }
+
+    /// `UserDefaults`-reading wrapper, used by the firing path and by
+    /// `SettingsView`'s one-time reconcile. Reads through `object(forKey:)`
+    /// rather than `bool(forKey:)` — the latter flattens "absent" to `false`
+    /// and would silence exactly the installs the fallback exists for.
+    static func masterEnabled(defaults: UserDefaults = .standard) -> Bool {
+        masterEnabled(
+            master: defaults.object(forKey: masterEnabledKey) as? Bool,
+            anyEventEnabled: NotificationEvent.allCases.contains { defaults.bool(forKey: $0.enabledKey) }
+        )
+    }
+}

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -49,8 +49,9 @@ struct SettingsView: View {
     // who don't want any of it. A brand-new key defaults to false, but
     // `reconcileNotificationsMasterDefault()` flips it true once on first
     // appearance for anyone upgrading with an event already enabled, so
-    // existing notification setups don't silently vanish.
-    @AppStorage("notificationsEnabled") private var notificationsEnabled: Bool = false
+    // existing notification setups don't silently vanish. Since #1183 this
+    // also gates the firing path itself (`NotificationSettings.masterEnabled`).
+    @AppStorage(NotificationSettings.masterEnabledKey) private var notificationsEnabled: Bool = false
     @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = false
     @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = false
     @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = false
@@ -688,9 +689,13 @@ struct SettingsView: View {
     /// behind a collapsed, seemingly-off section. Runs only while the key is
     /// still absent from `UserDefaults` — once set (by this reconcile or by
     /// the user), it's never overridden again.
+    ///
+    /// Materializes exactly what `NotificationSettings.masterEnabled()` already
+    /// computes for the absent-key case, so the firing path (#1183) and this
+    /// toggle share one definition of the fallback instead of two copies.
     private func reconcileNotificationsMasterDefault() {
-        guard UserDefaults.standard.object(forKey: "notificationsEnabled") == nil else { return }
-        notificationsEnabled = notifyOnReady || notifyOnWaiting || notifyOnContextPressure
+        guard UserDefaults.standard.object(forKey: NotificationSettings.masterEnabledKey) == nil else { return }
+        notificationsEnabled = NotificationSettings.masterEnabled()
     }
 
     private func checkNotificationAuth() {

--- a/platforms/macos/Tests/NotificationMasterGateTests.swift
+++ b/platforms/macos/Tests/NotificationMasterGateTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import Irrlicht
+
+/// Regression coverage for #1183: the master "Enable notifications" toggle was
+/// wired only to the Settings UI, so switching it off collapsed the section but
+/// left the per-event keys `true` underneath — banners kept posting and, most
+/// noticeably, the Speak-aloud voice kept talking.
+///
+/// `SessionManager.sendNotification` now guards on
+/// `NotificationSettings.masterEnabled()`. That funnel is where both the
+/// `UNNotificationRequest` (banner + sound) and the separate `SoundPlayer.speak`
+/// call live, so one gate covers every channel. The funnel itself can't run
+/// under xctest (`canUseUserNotifications` is false outside an app bundle),
+/// which is why the decision is extracted and asserted directly — the same
+/// pure-helper idiom `SessionManagerFocusTests` uses for the Focus/DND gate.
+final class NotificationMasterGateTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        // A throwaway suite, never `.standard` — these tests must not mutate the
+        // developer's real notification preferences.
+        suiteName = "io.irrlicht.tests.NotificationMasterGate.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - Pure decision
+
+    /// The reported bug. Turning the master off never cleared the per-event
+    /// keys, so "off" has to win over them rather than be ignored.
+    func testMasterOffSuppressesEvenWithEveryEventEnabled() {
+        XCTAssertFalse(NotificationSettings.masterEnabled(master: false, anyEventEnabled: true))
+    }
+
+    func testMasterOnFires() {
+        XCTAssertTrue(NotificationSettings.masterEnabled(master: true, anyEventEnabled: true))
+        XCTAssertTrue(NotificationSettings.masterEnabled(master: true, anyEventEnabled: false))
+    }
+
+    /// Upgrade path: the key is absent for anyone who configured notifications
+    /// before #940 and hasn't opened Settings since. Absent must mean "keep
+    /// firing", not "silence" — otherwise this fix would break working setups.
+    func testAbsentMasterFallsBackToPerEventOr() {
+        XCTAssertTrue(NotificationSettings.masterEnabled(master: nil, anyEventEnabled: true))
+        XCTAssertFalse(NotificationSettings.masterEnabled(master: nil, anyEventEnabled: false))
+    }
+
+    // MARK: - UserDefaults read
+
+    func testDefaultsReadWithMasterOffSuppressesEnabledEvents() {
+        defaults.set(true, forKey: NotificationEvent.ready.enabledKey)
+        defaults.set(true, forKey: NotificationEvent.waiting.enabledKey)
+        defaults.set(true, forKey: NotificationEvent.contextPressure.enabledKey)
+        defaults.set(false, forKey: NotificationSettings.masterEnabledKey)
+
+        XCTAssertFalse(NotificationSettings.masterEnabled(defaults: defaults))
+    }
+
+    func testDefaultsReadWithMasterOnFires() {
+        defaults.set(true, forKey: NotificationSettings.masterEnabledKey)
+
+        XCTAssertTrue(NotificationSettings.masterEnabled(defaults: defaults))
+    }
+
+    func testDefaultsReadWithAbsentMasterFollowsEnabledEvents() {
+        defaults.set(true, forKey: NotificationEvent.waiting.enabledKey)
+
+        XCTAssertTrue(NotificationSettings.masterEnabled(defaults: defaults))
+    }
+
+    func testDefaultsReadWithAbsentMasterAndNoEventsStaysSilent() {
+        XCTAssertFalse(NotificationSettings.masterEnabled(defaults: defaults))
+    }
+
+    /// Lock-in for the reason the helper reads `object(forKey:)`: `bool(forKey:)`
+    /// reports the same `false` for "absent" and for "explicitly off", which
+    /// would collapse the upgrade fallback into a silent-by-default gate.
+    func testAbsentKeyIsDistinguishableFromExplicitFalse() {
+        defaults.set(true, forKey: NotificationEvent.ready.enabledKey)
+        XCTAssertNil(defaults.object(forKey: NotificationSettings.masterEnabledKey))
+        XCTAssertFalse(defaults.bool(forKey: NotificationSettings.masterEnabledKey))
+        XCTAssertTrue(NotificationSettings.masterEnabled(defaults: defaults))
+
+        defaults.set(false, forKey: NotificationSettings.masterEnabledKey)
+        XCTAssertNotNil(defaults.object(forKey: NotificationSettings.masterEnabledKey))
+        XCTAssertFalse(NotificationSettings.masterEnabled(defaults: defaults))
+    }
+
+    /// The key is user-persisted state: renaming it would orphan every existing
+    /// user's setting and silently re-run the one-time reconcile.
+    func testMasterEnabledKeyIsStable() {
+        XCTAssertEqual(NotificationSettings.masterEnabledKey, "notificationsEnabled")
+    }
+}


### PR DESCRIPTION
Closes #1183

## Problem

The master **Enable notifications** toggle was wired only to the Settings UI. Switching it off collapsed the Notifications section but never reached the firing path — the three per-event keys stayed `true` behind the collapsed panel, so banners kept posting and, most noticeably, the **Speak-aloud voice kept talking**.

## Fix

One guard at the funnel every notification passes through:

- **`SessionManager.sendNotification`** now early-returns on `NotificationSettings.masterEnabled()`. This is where both the `UNNotificationRequest` (banner + sound) and the separate `SoundPlayer.speak` call live, so a single gate silences every channel. The issue suggested a guard at each of the two entry points; the funnel is one line instead of two, covers the TTS path (which bypasses `UNNotificationContent` entirely — the reported symptom), and can't be bypassed by a future third caller.
- **`NotificationSettings`** (new, in `Models/NotificationEvent.swift`) owns `masterEnabledKey` and the one rule for reading it: a pure `masterEnabled(master:anyEventEnabled:)` plus a `UserDefaults`-reading wrapper.
- **`SettingsView.reconcileNotificationsMasterDefault()`** keeps its "only while absent" guard but delegates the value to that helper, so the toggle and the gate share one definition instead of two copies of the same OR.

### The absent-key case

An install that predates the toggle (#940) and hasn't opened Settings since has no stored value for it. Reading it as a plain bool would silence every such user on upgrade — a worse regression than the bug. The helper reads `object(forKey:)` (not `bool(forKey:)`, which flattens absent to `false`) and falls back to the per-event OR. The key is deliberately absent from `SessionManager`'s `register(defaults:)` seed, which is what keeps that state reachable; there's a comment saying so, and a test asserting absent is distinguishable from explicit-false.

## Testing

`swift build` + `swift test` from `platforms/macos` — **278 tests, 0 failures** (5 pre-existing harness skips). New `NotificationMasterGateTests` adds 9 cases: master-off suppresses even with all three events on (the reported bug), master-on fires, absent + any event → fires, absent + none → silent, the `object`-vs-`bool` distinction, and key stability. Defaults tests run against a throwaway `UserDefaults(suiteName:)`, never `.standard`.

Per AGENTS.md the Swift suite is not CI-gated, so the green checks on this PR say nothing about this change — the run above is the evidence.

**Not done:** the hands-on audible check (master off + Speak-aloud + a real working→ready transition). There's no way for me to observe a spoken voice or a transient banner programmatically, and this diff changes no UI, so I skipped the app relaunch rather than perform a check I couldn't actually witness. Worth 30 seconds of your ears before merging.

## Notes

- macOS-only by construction: the web dashboard ships the three per-event checkboxes but no master toggle, so there is no equivalent gate to fix there.
- Left alone: `checkContextPressureAlerts` still records a threshold as fired before the send, so a session that crosses while notifications are off won't re-alert if they're turned back on mid-session. Pre-existing — the per-event switch already behaves this way.
- Per-event keys are untouched, so flipping the master back on restores exactly the prior setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)