### PR TITLE
refactor(hooks): extract a shared hookjson installer + one waiting-cue rule (#1179)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -6,10 +6,10 @@
 package claudecode
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 )
 
 // hookSentinel is the substring in the hook entry (curl command or http url)
@@ -79,7 +79,7 @@ var installedHookEvents = []string{
 // events this is a tool-name regex; for PreCompact it is the compaction trigger
 // ("manual"); for Notification it is the notification_type ("idle_prompt"); for
 // Stop it is empty — Claude Code's Stop hook takes no matcher (it fires at every
-// turn end) and rejects settings.json that gives it one, so addOurHook omits the
+// turn end) and rejects settings.json that gives it one, so hookjson omits the
 // matcher key entirely for an empty matcher.
 func matcherForEvent(event string) string {
 	switch event {
@@ -108,6 +108,24 @@ func ourHookEntry() map[string]interface{} {
 	}
 }
 
+// hookConfig describes this adapter's install to the shared hookjson
+// machinery (issue #1179): which file to merge into, which sentinel marks our
+// entries, which events get installed with which matcher, and what the
+// canonical inner entry looks like. Everything the two JSON-hook adapters have
+// in common — the merge, idempotency, in-place upgrade and removal logic —
+// lives there; everything Claude-Code-specific stays here.
+func hookConfig(path string) hookjson.Config {
+	return hookjson.Config{
+		Path:        path,
+		Sentinel:    hookSentinel,
+		Events:      installedHookEvents,
+		MatcherFor:  matcherForEvent,
+		Entry:       ourHookEntry,
+		IsCanonical: hookEntryIsCanonical,
+		WriteFile:   atomicWriteFile,
+	}
+}
+
 // EnsureHooksInstalled adds irrlicht hook entries to ~/.claude/settings.json
 // if they are not already present. Creates the file if it doesn't exist.
 // Returns true if the file was modified, false if hooks were already installed.
@@ -116,34 +134,7 @@ func EnsureHooksInstalled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	settings, err := readClaudeSettings(path)
-	if err != nil {
-		return false, err
-	}
-
-	hooksMap := ensureHooksMap(settings)
-
-	modified := false
-	for _, event := range installedHookEvents {
-		expected := matcherForEvent(event)
-		if upgradeStaleHookDelivery(hooksMap, event) {
-			modified = true
-		}
-		if upgradeStaleHookMatchers(hooksMap, event, expected) {
-			modified = true
-		}
-		if !hasOurHook(hooksMap, event) {
-			addOurHook(hooksMap, event, expected)
-			modified = true
-		}
-	}
-
-	if !modified {
-		return false, nil
-	}
-
-	return true, writeClaudeSettings(path, settings)
+	return hookjson.EnsureInstalled(hookConfig(path))
 }
 
 // UninstallHooks removes irrlicht hook entries from ~/.claude/settings.json.
@@ -153,33 +144,7 @@ func UninstallHooks() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	settings, err := readClaudeSettings(path)
-	if err != nil {
-		return false, err
-	}
-
-	hooksObj, ok := settings["hooks"]
-	if !ok {
-		return false, nil
-	}
-	hooksMap, ok := hooksObj.(map[string]interface{})
-	if !ok {
-		return false, nil
-	}
-
-	modified := false
-	for _, event := range installedHookEvents {
-		if removeOurHook(hooksMap, event) {
-			modified = true
-		}
-	}
-
-	if !modified {
-		return false, nil
-	}
-
-	return true, writeClaudeSettings(path, settings)
+	return hookjson.Uninstall(hookConfig(path))
 }
 
 // --- helpers ---
@@ -192,234 +157,15 @@ func claudeSettingsPath() (string, error) {
 	return filepath.Join(home, ".claude", "settings.json"), nil
 }
 
+// readClaudeSettings / writeClaudeSettings are thin adapters onto the shared
+// codec so the statusline installer, which merges into the same settings.json,
+// keeps reading and writing it exactly the way the hook installer does.
 func readClaudeSettings(path string) (map[string]interface{}, error) {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return map[string]interface{}{}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	var settings map[string]interface{}
-	if err := json.Unmarshal(data, &settings); err != nil {
-		return nil, err
-	}
-	return settings, nil
+	return hookjson.ReadSettings(path)
 }
 
 func writeClaudeSettings(path string, settings map[string]interface{}) error {
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	return atomicWriteFile(path, data)
-}
-
-// ensureHooksMap returns (or creates) the top-level "hooks" map in settings.
-func ensureHooksMap(settings map[string]interface{}) map[string]interface{} {
-	if h, ok := settings["hooks"]; ok {
-		if m, ok := h.(map[string]interface{}); ok {
-			return m
-		}
-	}
-	m := map[string]interface{}{}
-	settings["hooks"] = m
-	return m
-}
-
-// hasOurHook checks if any matcher group containing our sentinel command
-// already exists in the event's hook array. Matcher-agnostic: a group with
-// our sentinel is "ours" regardless of which matcher string it carries.
-func hasOurHook(hooksMap map[string]interface{}, event string) bool {
-	arr, ok := hooksMap[event].([]interface{})
-	if !ok {
-		return false
-	}
-	for _, g := range arr {
-		if containsHookSentinel(g) {
-			return true
-		}
-	}
-	return false
-}
-
-// upgradeStaleHookDelivery rewrites any sentinel-bearing inner hook that is not
-// the canonical native-http entry to the current form. Returns true if any
-// entry was rewritten. This migrates an existing install from the legacy curl
-// `command` wrapper to native `type: http` delivery (issue #1161) — and, more
-// generally, any older shape carrying our sentinel — in place, without
-// appending a duplicate group.
-func upgradeStaleHookDelivery(hooksMap map[string]interface{}, event string) bool {
-	arr, ok := hooksMap[event].([]interface{})
-	if !ok {
-		return false
-	}
-	upgraded := false
-	for _, g := range arr {
-		if upgradeGroupHookDelivery(g) {
-			upgraded = true
-		}
-	}
-	return upgraded
-}
-
-// upgradeGroupHookDelivery rewrites, in one matcher group, every inner hook that
-// carries our sentinel but isn't the canonical native-http entry (e.g. the
-// legacy curl command). Returns true if any entry was rewritten.
-func upgradeGroupHookDelivery(g interface{}) bool {
-	group, ok := g.(map[string]interface{})
-	if !ok {
-		return false
-	}
-	innerHooks, ok := group["hooks"].([]interface{})
-	if !ok {
-		return false
-	}
-	upgraded := false
-	for i, h := range innerHooks {
-		hook, ok := h.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if hookEntryIsSentinel(hook) && !hookEntryIsCanonical(hook) {
-			innerHooks[i] = ourHookEntry()
-			upgraded = true
-		}
-	}
-	return upgraded
-}
-
-// upgradeStaleHookMatchers reconciles the matcher of any group containing our
-// sentinel with the expected value. Used to migrate existing installs when we
-// widen or change an event's matcher (e.g. the #307 expansion that added
-// AskUserQuestion|ExitPlanMode to the PostToolUse matcher). For an event whose
-// expected matcher is empty (Stop, #1161) it strips any matcher key entirely,
-// since Claude Code rejects a Stop hook that carries one.
-func upgradeStaleHookMatchers(hooksMap map[string]interface{}, event, expected string) bool {
-	arr, ok := hooksMap[event].([]interface{})
-	if !ok {
-		return false
-	}
-	upgraded := false
-	for _, g := range arr {
-		group, ok := g.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if !containsHookSentinel(g) {
-			continue
-		}
-		if reconcileGroupMatcher(group, expected) {
-			upgraded = true
-		}
-	}
-	return upgraded
-}
-
-// reconcileGroupMatcher brings one sentinel-bearing group's matcher into line
-// with expected: sets it when it differs, or deletes the key when expected is
-// empty (a Stop hook must carry no matcher). Returns true if it changed the group.
-func reconcileGroupMatcher(group map[string]interface{}, expected string) bool {
-	m, has := group["matcher"].(string)
-	if expected == "" {
-		if has {
-			delete(group, "matcher")
-			return true
-		}
-		return false
-	}
-	if m != expected {
-		group["matcher"] = expected
-		return true
-	}
-	return false
-}
-
-// addOurHook appends a matcher group with our native-http hook entry to the
-// event's array. The matcher key is omitted entirely for an empty matcher
-// (Stop), which Claude Code requires.
-func addOurHook(hooksMap map[string]interface{}, event, matcher string) {
-	entry := map[string]interface{}{
-		"hooks": []interface{}{ourHookEntry()},
-	}
-	if matcher != "" {
-		entry["matcher"] = matcher
-	}
-
-	existing, ok := hooksMap[event]
-	if ok {
-		if arr, ok := existing.([]interface{}); ok {
-			hooksMap[event] = append(arr, entry)
-			return
-		}
-	}
-	hooksMap[event] = []interface{}{entry}
-}
-
-// removeOurHook removes matcher groups containing our sentinel from the event's
-// array. Returns true if any were removed.
-func removeOurHook(hooksMap map[string]interface{}, event string) bool {
-	arr, ok := hooksMap[event].([]interface{})
-	if !ok {
-		return false
-	}
-
-	var kept []interface{}
-	removed := false
-	for _, g := range arr {
-		if containsHookSentinel(g) {
-			removed = true
-			continue
-		}
-		kept = append(kept, g)
-	}
-	if !removed {
-		return false
-	}
-
-	if len(kept) == 0 {
-		delete(hooksMap, event)
-	} else {
-		hooksMap[event] = kept
-	}
-	return true
-}
-
-// containsHookSentinel checks if a matcher group contains an inner hook entry
-// carrying our sentinel — either the legacy curl command or the native-http url.
-func containsHookSentinel(g interface{}) bool {
-	group, ok := g.(map[string]interface{})
-	if !ok {
-		return false
-	}
-	innerHooks, ok := group["hooks"].([]interface{})
-	if !ok {
-		return false
-	}
-	for _, h := range innerHooks {
-		hook, ok := h.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if hookEntryIsSentinel(hook) {
-			return true
-		}
-	}
-	return false
-}
-
-// hookEntryIsSentinel reports whether an inner hook object is one of ours,
-// identified by our sentinel appearing in either the legacy `command` (curl) or
-// the current `url` (native http) field.
-func hookEntryIsSentinel(hook map[string]interface{}) bool {
-	if cmd, ok := hook["command"].(string); ok && strings.Contains(cmd, hookSentinel) {
-		return true
-	}
-	if url, ok := hook["url"].(string); ok && strings.Contains(url, hookSentinel) {
-		return true
-	}
-	return false
+	return hookjson.WriteSettings(path, settings, atomicWriteFile)
 }
 
 // hookEntryIsCanonical reports whether an inner hook object is already in the

--- a/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
@@ -55,7 +55,7 @@ func makeHookGroup(matcher, command string) map[string]interface{} {
 }
 
 // ourHookGroup builds a settings.json group in our current native-http form
-// (matcher key omitted when empty), mirroring addOurHook. Used to seed fixtures
+// (matcher key omitted when empty), mirroring hookjson's. Used to seed fixtures
 // that simulate an already-migrated install.
 func ourHookGroup(matcher string) map[string]interface{} {
 	group := map[string]interface{}{"hooks": []interface{}{ourHookEntry()}}

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/ports/outbound"
@@ -190,13 +191,11 @@ func walkMarkerValue(v interface{}, observedAt time.Time, est **tailer.TaskEstim
 	}
 }
 
-// ConsentGranter reports whether the user has granted a permission (issue
-// #570). Satisfied by *services.PermissionService. Hooks installed by a
-// pre-consent daemon version keep firing until answered, so the receivers
-// drop payloads while their permission is pending or denied.
-type ConsentGranter interface {
-	Granted(agentName, key string) bool
-}
+// ConsentGranter is the shared consent check every JSON-hook receiver gates on
+// (issue #570) — an alias, not a copy, so this adapter and codex cannot drift
+// on it (issue #1179). See hookjson for why the HookTarget above is NOT shared
+// the same way.
+type ConsentGranter = hookjson.ConsentGranter
 
 // sessionIDFromTranscriptPath extracts irrlicht's session ID (the UUID
 // filename stem) from a Claude Code transcript path. The hook payload's
@@ -321,19 +320,7 @@ func handleStopHook(target HookTarget, log outbound.Logger, sessionID string, pa
 
 	target.HandleStopHook(sessionID, payload.TranscriptPath,
 		tailer.TruncateAssistantText(payload.LastAssistantMessage),
-		waitingCueInTail(payload.LastAssistantMessage))
-}
-
-// waitingCueInTail reports whether the bounded tail window of an assistant
-// message carries a trailing question or an imperative waiting cue (issue
-// #1150). Bounded, not full text: ExtractWaitingCue over-fires on very long
-// turns (see tailer.MaxWaitingScanRunes). Shared by the transcript parser
-// (PendingWaitingCue) and the Stop-hook handler (#1161) so the window size and
-// the OR-of-two-detectors rule can't drift between the two paths.
-func waitingCueInTail(full string) bool {
-	win := tailer.WaitingScanWindow(full)
-	return win != "" &&
-		(session.ExtractQuestionSnippet(win) != "" || session.ExtractWaitingCue(win) != "")
+		session.ProseIndicatesWaiting(tailer.WaitingScanWindow(payload.LastAssistantMessage)))
 }
 
 // handleNotificationHook processes a Claude Code Notification hook. It acts only

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 
+	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/pkg/transcript"
 )
@@ -785,7 +786,7 @@ func applyAssistantText(raw map[string]interface{}, ev *tailer.ParsedEvent, even
 		// truncation (e.g. codex) share this beyond-tail blind spot; the plumbing
 		// (ParsedEvent.PendingWaitingCue → tailer → domain) is adapter-agnostic,
 		// so each can adopt it by computing PendingWaitingCue the same way here.
-		ev.PendingWaitingCue = waitingCueInTail(full)
+		ev.PendingWaitingCue = session.ProseIndicatesWaiting(tailer.WaitingScanWindow(full))
 	case "user", "user_message", "user_input":
 		ev.ClearToolNames = true
 		ev.UserText = tailer.ExtractUserText(raw)

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -2130,4 +2131,57 @@ func TestTailer_PrunedToEmpty_EmitsNonNilTasks(t *testing.T) {
 	if len(m.Tasks) != 0 {
 		t.Fatalf("Tasks = %+v, want empty", m.Tasks)
 	}
+}
+
+// TestParser_PendingWaitingCue_BeyondDisplayTail pins issue #1150 at the parser
+// level: a question sitting BEFORE the trailing 200 runes is invisible to the
+// display-truncated AssistantText the prose heuristics normally scan, so the
+// parser computes the verdict from a larger bounded window of the FULL text and
+// carries it as PendingWaitingCue. Without this the turn would classify ready
+// instead of waiting.
+//
+// It also guards the shared rule extracted in #1179: this parser and codex's
+// both call session.ProseIndicatesWaiting(tailer.WaitingScanWindow(full)), and
+// this is the assertion that fails if that composition is dropped or rewritten.
+func TestParser_PendingWaitingCue_BeyondDisplayTail(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"question before the display tail", questionBeyondTail(), true},
+		{"plain statement", plainStatementBeyondTail(), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Parser{}
+			ev := p.ParseLine(map[string]interface{}{
+				"type": "assistant",
+				"message": map[string]interface{}{
+					"role":    "assistant",
+					"content": []interface{}{map[string]interface{}{"type": "text", "text": tc.text}},
+				},
+			})
+			if ev == nil {
+				t.Fatal("expected non-nil event")
+			}
+			if ev.PendingWaitingCue != tc.want {
+				t.Errorf("PendingWaitingCue = %v, want %v", ev.PendingWaitingCue, tc.want)
+			}
+			if strings.Contains(ev.AssistantText, "?") {
+				t.Fatalf("test is not exercising the beyond-tail path: the question survived truncation into AssistantText %q", ev.AssistantText)
+			}
+		})
+	}
+}
+
+// questionBeyondTail builds an assistant message whose question sits outside
+// the trailing MaxAssistantTextRunes shown in the UI, but inside the larger
+// MaxWaitingScanRunes window the parser scans.
+func questionBeyondTail() string {
+	return "Which option do you want? " + strings.Repeat("x", 250)
+}
+
+func plainStatementBeyondTail() string {
+	return "The refactor is complete. " + strings.Repeat("x", 250)
 }

--- a/core/adapters/inbound/agents/codex/hookinstaller.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller.go
@@ -9,12 +9,13 @@
 package codex
 
 import (
-	"encoding/json"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 )
 
 // hookSentinel is the substring in a hook entry's curl command that identifies
@@ -63,7 +64,7 @@ var installedHookEvents = []string{
 }
 
 // matcherForEvent returns the matcher we install for the given event. Stop
-// takes no matcher (it fires at every turn end); addOurHook omits the matcher
+// takes no matcher (it fires at every turn end); hookjson omits the matcher
 // key entirely for an empty matcher.
 func matcherForEvent(event string) string {
 	if event == HookStop {
@@ -82,6 +83,24 @@ func ourHookEntry() map[string]interface{} {
 	}
 }
 
+// hookConfig describes this adapter's install to the shared hookjson
+// machinery (issue #1179): which file to merge into, which sentinel marks our
+// entries, which events get installed with which matcher, and what the
+// canonical inner entry looks like. Everything the two JSON-hook adapters have
+// in common — the merge, idempotency, in-place upgrade and removal logic —
+// lives there; everything Codex-specific stays here.
+func hookConfig(path string) hookjson.Config {
+	return hookjson.Config{
+		Path:        path,
+		Sentinel:    hookSentinel,
+		Events:      installedHookEvents,
+		MatcherFor:  matcherForEvent,
+		Entry:       ourHookEntry,
+		IsCanonical: hookEntryIsCanonical,
+		WriteFile:   atomicWriteFile,
+	}
+}
+
 // EnsureHooksInstalled adds irrlicht hook entries to ~/.codex/hooks.json if
 // they are not already present. Creates the file if it doesn't exist. Returns
 // true if the file was modified, false if hooks were already installed.
@@ -90,34 +109,7 @@ func EnsureHooksInstalled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	settings, err := readCodexHooks(path)
-	if err != nil {
-		return false, err
-	}
-
-	hooksMap := ensureHooksMap(settings)
-
-	modified := false
-	for _, event := range installedHookEvents {
-		expected := matcherForEvent(event)
-		if upgradeStaleHookCommand(hooksMap, event) {
-			modified = true
-		}
-		if upgradeStaleHookMatchers(hooksMap, event, expected) {
-			modified = true
-		}
-		if !hasOurHook(hooksMap, event) {
-			addOurHook(hooksMap, event, expected)
-			modified = true
-		}
-	}
-
-	if !modified {
-		return false, nil
-	}
-
-	return true, writeCodexHooks(path, settings)
+	return hookjson.EnsureInstalled(hookConfig(path))
 }
 
 // UninstallHooks removes irrlicht hook entries from ~/.codex/hooks.json.
@@ -127,33 +119,7 @@ func UninstallHooks() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	settings, err := readCodexHooks(path)
-	if err != nil {
-		return false, err
-	}
-
-	hooksObj, ok := settings["hooks"]
-	if !ok {
-		return false, nil
-	}
-	hooksMap, ok := hooksObj.(map[string]interface{})
-	if !ok {
-		return false, nil
-	}
-
-	modified := false
-	for _, event := range installedHookEvents {
-		if removeOurHook(hooksMap, event) {
-			modified = true
-		}
-	}
-
-	if !modified {
-		return false, nil
-	}
-
-	return true, writeCodexHooks(path, settings)
+	return hookjson.Uninstall(hookConfig(path))
 }
 
 // applyCodexHooks is the Apply closure for the "hooks" permission: it
@@ -297,34 +263,6 @@ func codexHooksPath() (string, error) {
 	return filepath.Join(home, "hooks.json"), nil
 }
 
-func readCodexHooks(path string) (map[string]interface{}, error) {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return map[string]interface{}{}, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	// An empty file is valid (nothing to merge onto yet).
-	if len(strings.TrimSpace(string(data))) == 0 {
-		return map[string]interface{}{}, nil
-	}
-	var settings map[string]interface{}
-	if err := json.Unmarshal(data, &settings); err != nil {
-		return nil, err
-	}
-	return settings, nil
-}
-
-func writeCodexHooks(path string, settings map[string]interface{}) error {
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-	return atomicWriteFile(path, data)
-}
-
 // atomicWriteFile writes data to path via a temp file + rename so a reader (or
 // Codex) never observes a half-written hooks.json. Creates the parent dir.
 func atomicWriteFile(path string, data []byte) error {
@@ -351,186 +289,6 @@ func atomicWriteFile(path string, data []byte) error {
 		return err
 	}
 	return os.Rename(tmpName, path)
-}
-
-// ensureHooksMap returns (or creates) the top-level "hooks" map in settings.
-func ensureHooksMap(settings map[string]interface{}) map[string]interface{} {
-	if h, ok := settings["hooks"]; ok {
-		if m, ok := h.(map[string]interface{}); ok {
-			return m
-		}
-	}
-	m := map[string]interface{}{}
-	settings["hooks"] = m
-	return m
-}
-
-// hasOurHook reports whether any matcher group carrying our sentinel already
-// exists in the event's hook array (matcher-agnostic).
-func hasOurHook(hooksMap map[string]interface{}, event string) bool {
-	arr, ok := hooksMap[event].([]interface{})
-	if !ok {
-		return false
-	}
-	for _, g := range arr {
-		if containsHookSentinel(g) {
-			return true
-		}
-	}
-	return false
-}
-
-// upgradeStaleHookCommand rewrites any sentinel-bearing inner hook whose command
-// differs from the current canonical one (e.g. after a curl-flag change) to
-// ourHookEntry, in place. Returns true if any entry was rewritten.
-func upgradeStaleHookCommand(hooksMap map[string]interface{}, event string) bool {
-	arr, ok := hooksMap[event].([]interface{})
-	if !ok {
-		return false
-	}
-	upgraded := false
-	for _, g := range arr {
-		if upgradeGroupHookCommand(g) {
-			upgraded = true
-		}
-	}
-	return upgraded
-}
-
-func upgradeGroupHookCommand(g interface{}) bool {
-	group, ok := g.(map[string]interface{})
-	if !ok {
-		return false
-	}
-	innerHooks, ok := group["hooks"].([]interface{})
-	if !ok {
-		return false
-	}
-	upgraded := false
-	for i, h := range innerHooks {
-		hook, ok := h.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if hookEntryIsSentinel(hook) && !hookEntryIsCanonical(hook) {
-			innerHooks[i] = ourHookEntry()
-			upgraded = true
-		}
-	}
-	return upgraded
-}
-
-// upgradeStaleHookMatchers reconciles the matcher of any sentinel-bearing group
-// with the expected value (used if an event's matcher changes). For Stop
-// (expected empty) it strips any matcher key entirely.
-func upgradeStaleHookMatchers(hooksMap map[string]interface{}, event, expected string) bool {
-	arr, ok := hooksMap[event].([]interface{})
-	if !ok {
-		return false
-	}
-	upgraded := false
-	for _, g := range arr {
-		group, ok := g.(map[string]interface{})
-		if !ok || !containsHookSentinel(g) {
-			continue
-		}
-		if reconcileGroupMatcher(group, expected) {
-			upgraded = true
-		}
-	}
-	return upgraded
-}
-
-func reconcileGroupMatcher(group map[string]interface{}, expected string) bool {
-	m, has := group["matcher"].(string)
-	if expected == "" {
-		if has {
-			delete(group, "matcher")
-			return true
-		}
-		return false
-	}
-	if m != expected {
-		group["matcher"] = expected
-		return true
-	}
-	return false
-}
-
-// addOurHook appends a matcher group with our hook entry to the event's array.
-// The matcher key is omitted entirely for an empty matcher (Stop).
-func addOurHook(hooksMap map[string]interface{}, event, matcher string) {
-	entry := map[string]interface{}{
-		"hooks": []interface{}{ourHookEntry()},
-	}
-	if matcher != "" {
-		entry["matcher"] = matcher
-	}
-
-	if existing, ok := hooksMap[event].([]interface{}); ok {
-		hooksMap[event] = append(existing, entry)
-		return
-	}
-	hooksMap[event] = []interface{}{entry}
-}
-
-// removeOurHook removes matcher groups containing our sentinel from the event's
-// array. Returns true if any were removed.
-func removeOurHook(hooksMap map[string]interface{}, event string) bool {
-	arr, ok := hooksMap[event].([]interface{})
-	if !ok {
-		return false
-	}
-
-	var kept []interface{}
-	removed := false
-	for _, g := range arr {
-		if containsHookSentinel(g) {
-			removed = true
-			continue
-		}
-		kept = append(kept, g)
-	}
-	if !removed {
-		return false
-	}
-
-	if len(kept) == 0 {
-		delete(hooksMap, event)
-	} else {
-		hooksMap[event] = kept
-	}
-	return true
-}
-
-// containsHookSentinel reports whether a matcher group contains an inner hook
-// entry carrying our sentinel.
-func containsHookSentinel(g interface{}) bool {
-	group, ok := g.(map[string]interface{})
-	if !ok {
-		return false
-	}
-	innerHooks, ok := group["hooks"].([]interface{})
-	if !ok {
-		return false
-	}
-	for _, h := range innerHooks {
-		hook, ok := h.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if hookEntryIsSentinel(hook) {
-			return true
-		}
-	}
-	return false
-}
-
-// hookEntryIsSentinel reports whether an inner hook object is one of ours,
-// identified by our sentinel appearing in its curl command.
-func hookEntryIsSentinel(hook map[string]interface{}) bool {
-	cmd, ok := hook["command"].(string)
-	return ok && strings.Contains(cmd, hookSentinel)
 }
 
 // hookEntryIsCanonical reports whether an inner hook object already matches the

--- a/core/adapters/inbound/agents/codex/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/permission"
 	"irrlicht/core/internal/contracttesting"
 )
@@ -57,16 +58,7 @@ func readHooks(t *testing.T, home string) map[string]interface{} {
 }
 
 func eventHasSentinel(hooks map[string]interface{}, event string) bool {
-	arr, ok := hooks[event].([]interface{})
-	if !ok {
-		return false
-	}
-	for _, g := range arr {
-		if containsHookSentinel(g) {
-			return true
-		}
-	}
-	return false
+	return hookjson.HasOurHook(hooks, event, hookSentinel)
 }
 
 func TestEnsureAndUninstallHooks(t *testing.T) {

--- a/core/adapters/inbound/agents/codex/hooks.go
+++ b/core/adapters/inbound/agents/codex/hooks.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/ports/outbound"
@@ -72,13 +73,11 @@ type HookTarget interface {
 	HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool)
 }
 
-// ConsentGranter reports whether the user has granted a permission (issue
-// #570). Satisfied by *services.PermissionService. Hooks installed by a
-// pre-consent daemon keep firing until answered, so the receiver drops
-// payloads while its permission is pending or denied.
-type ConsentGranter interface {
-	Granted(agentName, key string) bool
-}
+// ConsentGranter is the shared consent check every JSON-hook receiver gates on
+// (issue #570) — an alias, not a copy, so this adapter and claudecode cannot
+// drift on it (issue #1179). See hookjson for why the HookTarget below is NOT
+// shared the same way.
+type ConsentGranter = hookjson.ConsentGranter
 
 // NewHookHandler returns an http.HandlerFunc that receives Codex hook events
 // (PermissionRequest, PostToolUse, Stop) and dispatches them to the target.
@@ -217,16 +216,5 @@ func handleStopHook(target HookTarget, log outbound.Logger, sessionID string, pa
 
 	target.HandleStopHook(sessionID, payload.TranscriptPath,
 		tailer.TruncateAssistantText(payload.LastAssistantMessage),
-		waitingCueInTail(payload.LastAssistantMessage))
-}
-
-// waitingCueInTail reports whether the bounded tail window of an assistant
-// message carries a trailing question or an imperative waiting cue. Bounded,
-// not full text: ExtractWaitingCue over-fires on very long turns. Mirrors the
-// same window+OR rule parser.go uses for PendingWaitingCue and claudecode's
-// hooks.go uses for its Stop hook (issue #1171 — see the DRY note in the PR).
-func waitingCueInTail(full string) bool {
-	win := tailer.WaitingScanWindow(full)
-	return win != "" &&
-		(session.ExtractQuestionSnippet(win) != "" || session.ExtractWaitingCue(win) != "")
+		session.ProseIndicatesWaiting(tailer.WaitingScanWindow(payload.LastAssistantMessage)))
 }

--- a/core/adapters/inbound/agents/codex/parser.go
+++ b/core/adapters/inbound/agents/codex/parser.go
@@ -304,9 +304,7 @@ func parseCodexMessage(raw map[string]interface{}, ev *tailer.ParsedEvent) bool 
 		// assistant_message from its fallback (codex settles only on the
 		// turn_done primary path from task_complete), so a mid-turn cue can't
 		// route to waiting — only the last assistant text before turn_done does.
-		win := tailer.WaitingScanWindow(full)
-		ev.PendingWaitingCue = win != "" &&
-			(session.ExtractQuestionSnippet(win) != "" || session.ExtractWaitingCue(win) != "")
+		ev.PendingWaitingCue = session.ProseIndicatesWaiting(tailer.WaitingScanWindow(full))
 		scanCodexTaskEstimate(raw, ev)
 		// Codex's `<proposed_plan>` block has no structured tool-use; map
 		// it to ExitPlanMode so the classifier treats it as user-blocking.

--- a/core/adapters/inbound/agents/codex/parser_test.go
+++ b/core/adapters/inbound/agents/codex/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1333,5 +1334,47 @@ func TestParser_TaskEstimate_UserMessageIgnored(t *testing.T) {
 	})
 	if ev.TaskEstimate != nil {
 		t.Fatalf("user-pasted marker must not feed the estimate, got %+v", ev.TaskEstimate)
+	}
+}
+
+// TestParser_PendingWaitingCue_BeyondDisplayTail pins issue #1159 (codex's
+// mirror of claudecode's #1150) at the parser level: a question sitting BEFORE
+// the trailing 200 runes is invisible to the display-truncated AssistantText
+// the prose heuristics normally scan, so the parser computes the verdict from a
+// larger bounded window of the FULL text and carries it as PendingWaitingCue.
+//
+// It also guards the shared rule extracted in #1179: this parser and
+// claudecode's both call session.ProseIndicatesWaiting(tailer.WaitingScanWindow(full)),
+// and this is the assertion that fails if that composition is dropped.
+func TestParser_PendingWaitingCue_BeyondDisplayTail(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"question before the display tail", "Which option do you want? " + strings.Repeat("x", 250), true},
+		{"plain statement", "The refactor is complete. " + strings.Repeat("x", 250), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Parser{}
+			ev := p.ParseLine(map[string]interface{}{
+				"type":      "message",
+				"role":      "assistant",
+				"timestamp": ts(1),
+				"content": []interface{}{
+					map[string]interface{}{"type": "output_text", "text": tc.text},
+				},
+			})
+			if ev == nil {
+				t.Fatal("expected non-nil event")
+			}
+			if ev.PendingWaitingCue != tc.want {
+				t.Errorf("PendingWaitingCue = %v, want %v", ev.PendingWaitingCue, tc.want)
+			}
+			if strings.Contains(ev.AssistantText, "?") {
+				t.Fatalf("test is not exercising the beyond-tail path: the question survived truncation into AssistantText %q", ev.AssistantText)
+			}
+		})
 	}
 }

--- a/core/adapters/inbound/agents/hookjson/consent.go
+++ b/core/adapters/inbound/agents/hookjson/consent.go
@@ -1,0 +1,15 @@
+// consent.go holds the one receiver-side type the JSON-hook adapters share
+// verbatim. Their HookTarget interfaces and payload structs deliberately stay
+// per-adapter — those differ in shape and in intent (Codex, for instance, does
+// not decode session_id at all, because a Codex session shares its id with
+// every child) and merging them would couple the adapters to each other's
+// event sets rather than to a common contract.
+package hookjson
+
+// ConsentGranter reports whether the user has granted a permission (issue
+// #570). Satisfied by *services.PermissionService. Hooks installed by a
+// pre-consent daemon keep firing until the prompt is answered, so a hook
+// receiver drops payloads while its permission is pending or denied.
+type ConsentGranter interface {
+	Granted(agentName, key string) bool
+}

--- a/core/adapters/inbound/agents/hookjson/hookjson.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson.go
@@ -134,9 +134,15 @@ func Uninstall(cfg Config) (bool, error) {
 
 // ReadSettings decodes a hook-settings JSON file into a generic map. A missing
 // or empty file is not an error — there is simply nothing to merge onto yet, so
-// both yield an empty map and the caller goes on to create the file. Exported
-// because claudecode's statusline installer merges into the same settings.json
-// and must read it exactly the same way.
+// both yield an empty map and the caller goes on to create the file. Malformed
+// JSON does error: overwriting it would destroy content the user meant to keep.
+// Exported because claudecode's statusline installer merges into the same
+// settings.json and must read it exactly the same way.
+//
+// A file holding a bare `null` decodes to a nil map with no error, which every
+// later write would panic on ("assignment to entry in nil map"), so it is
+// normalized to an empty map here — the one place that can catch it for all
+// callers.
 func ReadSettings(path string) (map[string]interface{}, error) {
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
@@ -151,6 +157,9 @@ func ReadSettings(path string) (map[string]interface{}, error) {
 	var settings map[string]interface{}
 	if err := json.Unmarshal(data, &settings); err != nil {
 		return nil, err
+	}
+	if settings == nil {
+		return map[string]interface{}{}, nil
 	}
 	return settings, nil
 }
@@ -171,7 +180,7 @@ func WriteSettings(path string, settings map[string]interface{}, writeFile func(
 // in the event's hook array. Matcher-agnostic: a group with our sentinel is
 // "ours" regardless of which matcher string it happens to carry.
 func HasOurHook(hooksMap map[string]interface{}, event, sentinel string) bool {
-	arr, ok := hooksMap[event].([]interface{})
+	arr, ok := eventGroups(hooksMap, event)
 	if !ok {
 		return false
 	}
@@ -201,7 +210,7 @@ func ensureHooksMap(settings map[string]interface{}) map[string]interface{} {
 // that is not cfg.IsCanonical to a fresh cfg.Entry(). Returns true if any entry
 // was rewritten.
 func upgradeStaleEntries(hooksMap map[string]interface{}, event string, cfg Config) bool {
-	arr, ok := hooksMap[event].([]interface{})
+	arr, ok := eventGroups(hooksMap, event)
 	if !ok {
 		return false
 	}
@@ -240,7 +249,7 @@ func upgradeGroupEntries(g interface{}, cfg Config) bool {
 // matcher is widened or changed; for an expected of "" it strips the key
 // entirely, since a Stop hook must carry no matcher.
 func upgradeStaleMatchers(hooksMap map[string]interface{}, event, expected, sentinel string) bool {
-	arr, ok := hooksMap[event].([]interface{})
+	arr, ok := eventGroups(hooksMap, event)
 	if !ok {
 		return false
 	}
@@ -297,7 +306,7 @@ func addOurHook(hooksMap map[string]interface{}, event, matcher string, entry ma
 // array, deleting the event key outright once nothing is left. Returns true if
 // any group was removed.
 func removeOurHook(hooksMap map[string]interface{}, event, sentinel string) bool {
-	arr, ok := hooksMap[event].([]interface{})
+	arr, ok := eventGroups(hooksMap, event)
 	if !ok {
 		return false
 	}
@@ -342,9 +351,20 @@ func containsSentinel(g interface{}, sentinel string) bool {
 	return false
 }
 
+// eventGroups returns an event's matcher-group array, or ok=false when the
+// event is absent or holds something that isn't an array.
+//
+// It and groupEntries are the two places that tolerate a settings file holding
+// a shape we don't expect. These are hand-editable configs, so every traversal
+// goes through one of them rather than asserting inline and repeating the
+// judgement about what a malformed value means.
+func eventGroups(hooksMap map[string]interface{}, event string) ([]interface{}, bool) {
+	arr, ok := hooksMap[event].([]interface{})
+	return arr, ok
+}
+
 // groupEntries returns a matcher group's inner hook array, or ok=false when the
-// value isn't a group in the expected shape (a hand-edited config can hold
-// anything).
+// value isn't a group in the expected shape.
 func groupEntries(g interface{}) ([]interface{}, bool) {
 	group, ok := g.(map[string]interface{})
 	if !ok {

--- a/core/adapters/inbound/agents/hookjson/hookjson.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson.go
@@ -84,15 +84,14 @@ func EnsureInstalled(cfg Config) (bool, error) {
 
 	modified := false
 	for _, event := range cfg.Events {
-		expected := cfg.MatcherFor(event)
 		if upgradeStaleEntries(hooksMap, event, cfg) {
 			modified = true
 		}
-		if upgradeStaleMatchers(hooksMap, event, expected, cfg.Sentinel) {
+		if upgradeStaleMatchers(hooksMap, event, cfg) {
 			modified = true
 		}
 		if !HasOurHook(hooksMap, event, cfg.Sentinel) {
-			addOurHook(hooksMap, event, expected, cfg.Entry())
+			addOurHook(hooksMap, event, cfg.MatcherFor(event), cfg.Entry())
 			modified = true
 		}
 	}
@@ -120,7 +119,7 @@ func Uninstall(cfg Config) (bool, error) {
 
 	modified := false
 	for _, event := range cfg.Events {
-		if removeOurHook(hooksMap, event, cfg.Sentinel) {
+		if removeOurHook(hooksMap, event, cfg) {
 			modified = true
 		}
 	}
@@ -245,18 +244,19 @@ func upgradeGroupEntries(g interface{}, cfg Config) bool {
 }
 
 // upgradeStaleMatchers reconciles the matcher of every sentinel-bearing group of
-// the event with expected. Used to migrate existing installs when an event's
-// matcher is widened or changed; for an expected of "" it strips the key
-// entirely, since a Stop hook must carry no matcher.
-func upgradeStaleMatchers(hooksMap map[string]interface{}, event, expected, sentinel string) bool {
+// the event with the one cfg now expects. Used to migrate existing installs
+// when an event's matcher is widened or changed; for an expected of "" it
+// strips the key entirely, since a Stop hook must carry no matcher.
+func upgradeStaleMatchers(hooksMap map[string]interface{}, event string, cfg Config) bool {
 	arr, ok := eventGroups(hooksMap, event)
 	if !ok {
 		return false
 	}
+	expected := cfg.MatcherFor(event)
 	upgraded := false
 	for _, g := range arr {
 		group, ok := g.(map[string]interface{})
-		if !ok || !containsSentinel(g, sentinel) {
+		if !ok || !containsSentinel(g, cfg.Sentinel) {
 			continue
 		}
 		if reconcileGroupMatcher(group, expected) {
@@ -305,7 +305,7 @@ func addOurHook(hooksMap map[string]interface{}, event, matcher string, entry ma
 // removeOurHook drops every sentinel-bearing matcher group from the event's
 // array, deleting the event key outright once nothing is left. Returns true if
 // any group was removed.
-func removeOurHook(hooksMap map[string]interface{}, event, sentinel string) bool {
+func removeOurHook(hooksMap map[string]interface{}, event string, cfg Config) bool {
 	arr, ok := eventGroups(hooksMap, event)
 	if !ok {
 		return false
@@ -314,7 +314,7 @@ func removeOurHook(hooksMap map[string]interface{}, event, sentinel string) bool
 	var kept []interface{}
 	removed := false
 	for _, g := range arr {
-		if containsSentinel(g, sentinel) {
+		if containsSentinel(g, cfg.Sentinel) {
 			removed = true
 			continue
 		}

--- a/core/adapters/inbound/agents/hookjson/hookjson.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson.go
@@ -1,0 +1,372 @@
+// Package hookjson implements the JSON hook-config machinery shared by agent
+// adapters that install the daemon's hooks into a JSON settings file and
+// receive the resulting callbacks over the daemon's HTTP endpoint —
+// ~/.claude/settings.json for Claude Code (issues #108, #1161),
+// ~/.codex/hooks.json for Codex (issue #1171).
+//
+// Both files carry the same shape: a top-level "hooks" object mapping an event
+// name to an array of matcher groups, each holding an array of inner hook
+// entries. So the merge, idempotency, in-place upgrade and removal logic is
+// identical, and only four things genuinely differ per adapter — the settings
+// path, the sentinel marking our entries, the event list plus per-event
+// matcher, and the shape of the inner entry itself (Claude Code uses native
+// `type: http` delivery, Codex a `type: command` curl). Config parameterizes
+// exactly those; nothing is force-merged.
+//
+// It sits beside the adapters rather than inside one of them for the same
+// reason agentpaths does: the rule is identical in every case, so it lives here
+// once instead of being reimplemented per adapter — and forgotten, or silently
+// drifted from, by the next one (issue #1179).
+package hookjson
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+// Config describes one adapter's hook install to the machinery below. Every
+// field is required; EnsureInstalled and Uninstall call the funcs directly.
+type Config struct {
+	// Path is the JSON settings file to merge into. The adapter resolves it
+	// (and reports any home-directory error) before building the Config.
+	Path string
+
+	// Sentinel is the substring that identifies irrlicht-managed entries in an
+	// inner hook object's `command` or `url` field. It must be a substring of
+	// every shape we have ever installed for this adapter, so a legacy install
+	// is still recognized as ours and upgraded in place rather than duplicated.
+	Sentinel string
+
+	// Events is the ordered list of hook event names to install handlers for.
+	Events []string
+
+	// MatcherFor returns the matcher to install for an event. An empty string
+	// means the group carries no `matcher` key at all — the shape a Stop hook
+	// requires in both Claude Code and Codex.
+	MatcherFor func(event string) string
+
+	// Entry builds the canonical inner hook object to install. Called fresh per
+	// entry so no two groups share a map.
+	Entry func() map[string]interface{}
+
+	// IsCanonical reports whether an existing inner hook object is already in
+	// the current form. A sentinel-bearing entry that is not canonical is
+	// rewritten in place by Entry(), which is how a delivery-shape change
+	// (Claude Code's curl→http migration, a Codex curl-flag change) reaches an
+	// existing install without appending a duplicate group.
+	IsCanonical func(hook map[string]interface{}) bool
+
+	// WriteFile persists the re-serialized settings. It is supplied by the
+	// adapter rather than fixed here because the two adapters' atomic writers
+	// differ deliberately: claudecode's is shared with its CLAUDE.md writer, so
+	// hardening it here would silently split that pair.
+	WriteFile func(path string, data []byte) error
+}
+
+// EnsureInstalled merges cfg's hook entries into the settings file at cfg.Path,
+// creating the file if it does not exist. Returns true if the file was
+// modified, false if the entries were already present and current.
+//
+// Three reconciliations run per event, in order: any sentinel-bearing entry
+// that is not canonical is rewritten in place; the matcher of any
+// sentinel-bearing group is brought in line with the expected value; and a
+// fresh group is appended only if no sentinel-bearing group exists at all. The
+// first two migrate an existing install without ever appending a duplicate.
+func EnsureInstalled(cfg Config) (bool, error) {
+	settings, err := ReadSettings(cfg.Path)
+	if err != nil {
+		return false, err
+	}
+
+	hooksMap := ensureHooksMap(settings)
+
+	modified := false
+	for _, event := range cfg.Events {
+		expected := cfg.MatcherFor(event)
+		if upgradeStaleEntries(hooksMap, event, cfg) {
+			modified = true
+		}
+		if upgradeStaleMatchers(hooksMap, event, expected, cfg.Sentinel) {
+			modified = true
+		}
+		if !HasOurHook(hooksMap, event, cfg.Sentinel) {
+			addOurHook(hooksMap, event, expected, cfg.Entry())
+			modified = true
+		}
+	}
+
+	if !modified {
+		return false, nil
+	}
+
+	return true, WriteSettings(cfg.Path, settings, cfg.WriteFile)
+}
+
+// Uninstall removes cfg's hook entries from the settings file at cfg.Path,
+// leaving every user-authored group untouched. Returns true if the file was
+// modified, false if none of our entries were found.
+func Uninstall(cfg Config) (bool, error) {
+	settings, err := ReadSettings(cfg.Path)
+	if err != nil {
+		return false, err
+	}
+
+	hooksMap, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		return false, nil
+	}
+
+	modified := false
+	for _, event := range cfg.Events {
+		if removeOurHook(hooksMap, event, cfg.Sentinel) {
+			modified = true
+		}
+	}
+
+	if !modified {
+		return false, nil
+	}
+
+	return true, WriteSettings(cfg.Path, settings, cfg.WriteFile)
+}
+
+// ReadSettings decodes a hook-settings JSON file into a generic map. A missing
+// or empty file is not an error — there is simply nothing to merge onto yet, so
+// both yield an empty map and the caller goes on to create the file. Exported
+// because claudecode's statusline installer merges into the same settings.json
+// and must read it exactly the same way.
+func ReadSettings(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return map[string]interface{}{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return map[string]interface{}{}, nil
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return nil, err
+	}
+	return settings, nil
+}
+
+// WriteSettings re-serializes settings (2-space indented, trailing newline —
+// the shape a hand-edited config file expects) and hands the bytes to writeFile.
+// Exported alongside ReadSettings for the same statusline caller.
+func WriteSettings(path string, settings map[string]interface{}, writeFile func(path string, data []byte) error) error {
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return writeFile(path, data)
+}
+
+// HasOurHook reports whether any matcher group carrying sentinel already exists
+// in the event's hook array. Matcher-agnostic: a group with our sentinel is
+// "ours" regardless of which matcher string it happens to carry.
+func HasOurHook(hooksMap map[string]interface{}, event, sentinel string) bool {
+	arr, ok := hooksMap[event].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, g := range arr {
+		if containsSentinel(g, sentinel) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- helpers ---
+
+// ensureHooksMap returns (or creates) the top-level "hooks" map in settings.
+func ensureHooksMap(settings map[string]interface{}) map[string]interface{} {
+	if h, ok := settings["hooks"]; ok {
+		if m, ok := h.(map[string]interface{}); ok {
+			return m
+		}
+	}
+	m := map[string]interface{}{}
+	settings["hooks"] = m
+	return m
+}
+
+// upgradeStaleEntries rewrites every sentinel-bearing inner hook of the event
+// that is not cfg.IsCanonical to a fresh cfg.Entry(). Returns true if any entry
+// was rewritten.
+func upgradeStaleEntries(hooksMap map[string]interface{}, event string, cfg Config) bool {
+	arr, ok := hooksMap[event].([]interface{})
+	if !ok {
+		return false
+	}
+	upgraded := false
+	for _, g := range arr {
+		if upgradeGroupEntries(g, cfg) {
+			upgraded = true
+		}
+	}
+	return upgraded
+}
+
+// upgradeGroupEntries rewrites, within one matcher group, every inner hook that
+// carries our sentinel but isn't canonical. Returns true if any was rewritten.
+func upgradeGroupEntries(g interface{}, cfg Config) bool {
+	entries, ok := groupEntries(g)
+	if !ok {
+		return false
+	}
+	upgraded := false
+	for i, h := range entries {
+		hook, ok := h.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if entryIsSentinel(hook, cfg.Sentinel) && !cfg.IsCanonical(hook) {
+			entries[i] = cfg.Entry()
+			upgraded = true
+		}
+	}
+	return upgraded
+}
+
+// upgradeStaleMatchers reconciles the matcher of every sentinel-bearing group of
+// the event with expected. Used to migrate existing installs when an event's
+// matcher is widened or changed; for an expected of "" it strips the key
+// entirely, since a Stop hook must carry no matcher.
+func upgradeStaleMatchers(hooksMap map[string]interface{}, event, expected, sentinel string) bool {
+	arr, ok := hooksMap[event].([]interface{})
+	if !ok {
+		return false
+	}
+	upgraded := false
+	for _, g := range arr {
+		group, ok := g.(map[string]interface{})
+		if !ok || !containsSentinel(g, sentinel) {
+			continue
+		}
+		if reconcileGroupMatcher(group, expected) {
+			upgraded = true
+		}
+	}
+	return upgraded
+}
+
+// reconcileGroupMatcher brings one sentinel-bearing group's matcher into line
+// with expected: sets it when it differs, or deletes the key when expected is
+// empty. Returns true if it changed the group.
+func reconcileGroupMatcher(group map[string]interface{}, expected string) bool {
+	m, has := group["matcher"].(string)
+	if expected == "" {
+		if has {
+			delete(group, "matcher")
+			return true
+		}
+		return false
+	}
+	if m != expected {
+		group["matcher"] = expected
+		return true
+	}
+	return false
+}
+
+// addOurHook appends a matcher group holding entry to the event's array. The
+// matcher key is omitted entirely for an empty matcher.
+func addOurHook(hooksMap map[string]interface{}, event, matcher string, entry map[string]interface{}) {
+	group := map[string]interface{}{
+		"hooks": []interface{}{entry},
+	}
+	if matcher != "" {
+		group["matcher"] = matcher
+	}
+
+	if existing, ok := hooksMap[event].([]interface{}); ok {
+		hooksMap[event] = append(existing, group)
+		return
+	}
+	hooksMap[event] = []interface{}{group}
+}
+
+// removeOurHook drops every sentinel-bearing matcher group from the event's
+// array, deleting the event key outright once nothing is left. Returns true if
+// any group was removed.
+func removeOurHook(hooksMap map[string]interface{}, event, sentinel string) bool {
+	arr, ok := hooksMap[event].([]interface{})
+	if !ok {
+		return false
+	}
+
+	var kept []interface{}
+	removed := false
+	for _, g := range arr {
+		if containsSentinel(g, sentinel) {
+			removed = true
+			continue
+		}
+		kept = append(kept, g)
+	}
+	if !removed {
+		return false
+	}
+
+	if len(kept) == 0 {
+		delete(hooksMap, event)
+	} else {
+		hooksMap[event] = kept
+	}
+	return true
+}
+
+// containsSentinel reports whether a matcher group holds an inner hook entry
+// carrying our sentinel.
+func containsSentinel(g interface{}, sentinel string) bool {
+	entries, ok := groupEntries(g)
+	if !ok {
+		return false
+	}
+	for _, h := range entries {
+		hook, ok := h.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if entryIsSentinel(hook, sentinel) {
+			return true
+		}
+	}
+	return false
+}
+
+// groupEntries returns a matcher group's inner hook array, or ok=false when the
+// value isn't a group in the expected shape (a hand-edited config can hold
+// anything).
+func groupEntries(g interface{}) ([]interface{}, bool) {
+	group, ok := g.(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+	entries, ok := group["hooks"].([]interface{})
+	if !ok {
+		return nil, false
+	}
+	return entries, true
+}
+
+// entryIsSentinel reports whether an inner hook object is one of ours, by our
+// sentinel appearing in either delivery field: `command` (a shell hook, which
+// is Codex's only form and Claude Code's legacy curl form) or `url` (Claude
+// Code's native http delivery). Checking both is what lets one predicate serve
+// an adapter that has migrated between the two.
+func entryIsSentinel(hook map[string]interface{}, sentinel string) bool {
+	for _, field := range []string{"command", "url"} {
+		if v, ok := hook[field].(string); ok && strings.Contains(v, sentinel) {
+			return true
+		}
+	}
+	return false
+}

--- a/core/adapters/inbound/agents/hookjson/hookjson.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson.go
@@ -269,16 +269,21 @@ func upgradeStaleMatchers(hooksMap map[string]interface{}, event string, cfg Con
 // reconcileGroupMatcher brings one sentinel-bearing group's matcher into line
 // with expected: sets it when it differs, or deletes the key when expected is
 // empty. Returns true if it changed the group.
+//
+// The delete branch keys off PRESENCE, not "is a string". A hand-edited file
+// can hold `"matcher": null` or `"matcher": 5`, and a type assertion would miss
+// those and leave a turn-end group carrying a matcher key that both upstreams
+// reject — permanently, since EnsureInstalled would then report no change and
+// never revisit it.
 func reconcileGroupMatcher(group map[string]interface{}, expected string) bool {
-	m, has := group["matcher"].(string)
 	if expected == "" {
-		if has {
+		if _, present := group["matcher"]; present {
 			delete(group, "matcher")
 			return true
 		}
 		return false
 	}
-	if m != expected {
+	if m, _ := group["matcher"].(string); m != expected {
 		group["matcher"] = expected
 		return true
 	}

--- a/core/adapters/inbound/agents/hookjson/hookjson_test.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson_test.go
@@ -2,6 +2,7 @@ package hookjson
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -207,11 +208,12 @@ func TestEnsureInstalled_MatcherKeyOmittedWhenEmpty(t *testing.T) {
 			cfg := build(filepath.Join(t.TempDir(), "settings.json"))
 			mustEnsure(t, cfg, "install", true)
 
-			if group := firstGroup(t, cfg.Path, eventNoMatcher); group["matcher"] != nil {
+			group := firstGroup(t, cfg.Path, eventNoMatcher)
+			if _, present := group["matcher"]; present {
 				t.Errorf("%s group carries a matcher key: %#v", eventNoMatcher, group)
 			}
-			group := firstGroup(t, cfg.Path, eventWithMatcher)
-			if m, _ := group["matcher"].(string); m != matcher {
+			withMatcher := firstGroup(t, cfg.Path, eventWithMatcher)
+			if m, _ := withMatcher["matcher"].(string); m != matcher {
 				t.Errorf("%s matcher = %q, want %q", eventWithMatcher, m, matcher)
 			}
 		})
@@ -334,8 +336,38 @@ func TestEnsureInstalled_StripsMatcherFromStaleTurnEndGroup(t *testing.T) {
 
 	mustEnsure(t, cfg, "install over a stale turn-end matcher", true)
 
-	if group := firstGroup(t, cfg.Path, eventNoMatcher); group["matcher"] != nil {
+	group := firstGroup(t, cfg.Path, eventNoMatcher)
+	if _, present := group["matcher"]; present {
 		t.Errorf("matcher key survived on the turn-end group: %#v", group)
+	}
+}
+
+// TestEnsureInstalled_StripsNonStringMatcherFromTurnEndGroup is the same strip,
+// against the shapes a hand-edited file can hold. A `"matcher": null` or a
+// numeric one must be deleted just like a string: a type-assertion check would
+// miss them, leaving a turn-end group carrying a key both upstreams reject —
+// and, because the install would then report no change, never revisiting it.
+func TestEnsureInstalled_StripsNonStringMatcherFromTurnEndGroup(t *testing.T) {
+	for _, bad := range []interface{}{nil, float64(5), []interface{}{"a"}} {
+		t.Run(fmt.Sprintf("%T", bad), func(t *testing.T) {
+			cfg := httpConfig(filepath.Join(t.TempDir(), "settings.json"))
+			seedSettings(t, cfg.Path, map[string]interface{}{
+				"hooks": map[string]interface{}{
+					eventNoMatcher: []interface{}{
+						map[string]interface{}{"matcher": bad, "hooks": []interface{}{cfg.Entry()}},
+					},
+				},
+			})
+
+			mustEnsure(t, cfg, "install over a non-string turn-end matcher", true)
+
+			group := firstGroup(t, cfg.Path, eventNoMatcher)
+			if _, present := group["matcher"]; present {
+				t.Errorf("matcher key survived on the turn-end group: %#v", group)
+			}
+			// It must also converge — not re-report a change on every run.
+			mustEnsure(t, cfg, "re-install after the strip", false)
+		})
 	}
 }
 

--- a/core/adapters/inbound/agents/hookjson/hookjson_test.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson_test.go
@@ -432,6 +432,30 @@ func TestReadSettings(t *testing.T) {
 		}
 	})
 
+	// A bare `null` decodes to a nil map with no error — and every later write
+	// would panic on it. Regression guard for that crash.
+	t.Run("null document is empty, not a nil map", func(t *testing.T) {
+		path := filepath.Join(dir, "null.json")
+		if err := os.WriteFile(path, []byte("null\n"), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		got, err := ReadSettings(path)
+		if err != nil {
+			t.Fatalf("ReadSettings: %v", err)
+		}
+		if got == nil {
+			t.Fatal("got a nil map; a later write would panic on it")
+		}
+		// The whole install must survive it, not just the read.
+		cfg := httpConfig(path)
+		if _, err := EnsureInstalled(cfg); err != nil {
+			t.Fatalf("EnsureInstalled over a null document: %v", err)
+		}
+		if !HasOurHook(readHooks(t, path), eventNoMatcher, cfg.Sentinel) {
+			t.Error("install did not recover from a null document")
+		}
+	})
+
 	// Malformed is different from blank: overwriting it would destroy content
 	// the user meant to keep, so it must surface as an error.
 	t.Run("malformed JSON errors", func(t *testing.T) {

--- a/core/adapters/inbound/agents/hookjson/hookjson_test.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson_test.go
@@ -1,0 +1,468 @@
+package hookjson
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The two delivery shapes this package must serve without force-merging them:
+// an http-delivered entry (Claude Code's native `type: http`) and a
+// command-delivered one (Codex's curl). Every behavioral test below runs
+// against both, so a change that only holds for one shape fails here.
+const (
+	httpSentinel = "localhost:7837/api/v1/hooks/httpagent"
+	httpURL      = "http://" + httpSentinel
+	cmdSentinel  = "localhost:7837/api/v1/hooks/cmdagent"
+	cmdCommand   = "curl -fsS -X POST --data-binary @- http://" + cmdSentinel + " || true"
+
+	eventWithMatcher = "PermissionRequest"
+	eventNoMatcher   = "Stop"
+	matcher          = "Bash|Write"
+)
+
+func httpConfig(path string) Config {
+	return Config{
+		Path:       path,
+		Sentinel:   httpSentinel,
+		Events:     []string{eventWithMatcher, eventNoMatcher},
+		MatcherFor: matcherForTestEvent,
+		Entry: func() map[string]interface{} {
+			return map[string]interface{}{"type": "http", "url": httpURL, "timeout": 5}
+		},
+		IsCanonical: func(hook map[string]interface{}) bool {
+			if _, hasCmd := hook["command"]; hasCmd {
+				return false
+			}
+			t, _ := hook["type"].(string)
+			u, _ := hook["url"].(string)
+			return t == "http" && u == httpURL
+		},
+		WriteFile: writeTestFile,
+	}
+}
+
+func cmdConfig(path string) Config {
+	return Config{
+		Path:       path,
+		Sentinel:   cmdSentinel,
+		Events:     []string{eventWithMatcher, eventNoMatcher},
+		MatcherFor: matcherForTestEvent,
+		Entry: func() map[string]interface{} {
+			return map[string]interface{}{"type": "command", "command": cmdCommand, "timeout": 5}
+		},
+		IsCanonical: func(hook map[string]interface{}) bool {
+			t, _ := hook["type"].(string)
+			c, _ := hook["command"].(string)
+			return t == "command" && c == cmdCommand
+		},
+		WriteFile: writeTestFile,
+	}
+}
+
+// matcherForTestEvent mirrors the real adapters' rule: every event but the
+// turn-end one carries a matcher.
+func matcherForTestEvent(event string) string {
+	if event == eventNoMatcher {
+		return ""
+	}
+	return matcher
+}
+
+// configs returns both delivery shapes for a table-driven subtest.
+func configs() map[string]func(string) Config {
+	return map[string]func(string) Config{"http": httpConfig, "command": cmdConfig}
+}
+
+// writeTestFile stands in for the adapters' atomic writers, which stay on their
+// side of Config precisely because they differ.
+func writeTestFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+// readHooks returns the "hooks" sub-map of the settings file at path.
+func readHooks(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	m, _ := settings["hooks"].(map[string]interface{})
+	return m
+}
+
+// groupsFor returns the matcher-group array installed for an event.
+func groupsFor(t *testing.T, hooks map[string]interface{}, event string) []interface{} {
+	t.Helper()
+	arr, ok := hooks[event].([]interface{})
+	if !ok {
+		t.Fatalf("event %s: no group array, got %#v", event, hooks[event])
+	}
+	return arr
+}
+
+func TestEnsureInstalled_CreatesIdempotentlyAndUninstalls(t *testing.T) {
+	for name, build := range configs() {
+		t.Run(name, func(t *testing.T) {
+			// A nested dir the writer must create.
+			path := filepath.Join(t.TempDir(), "nested", "settings.json")
+			cfg := build(path)
+
+			modified, err := EnsureInstalled(cfg)
+			if err != nil {
+				t.Fatalf("first install: %v", err)
+			}
+			if !modified {
+				t.Fatal("first install: modified=false, want true")
+			}
+
+			hooks := readHooks(t, path)
+			for _, event := range cfg.Events {
+				if !HasOurHook(hooks, event, cfg.Sentinel) {
+					t.Errorf("event %s: no entry installed", event)
+				}
+			}
+
+			if modified, err = EnsureInstalled(cfg); err != nil {
+				t.Fatalf("second install: %v", err)
+			} else if modified {
+				t.Error("second install: modified=true, want false (not idempotent)")
+			}
+
+			if modified, err = Uninstall(cfg); err != nil {
+				t.Fatalf("uninstall: %v", err)
+			} else if !modified {
+				t.Error("uninstall: modified=false, want true")
+			}
+			hooks = readHooks(t, path)
+			for _, event := range cfg.Events {
+				if HasOurHook(hooks, event, cfg.Sentinel) {
+					t.Errorf("event %s: entry survived uninstall", event)
+				}
+				if _, present := hooks[event]; present {
+					t.Errorf("event %s: key kept after its last group was removed", event)
+				}
+			}
+
+			if modified, err = Uninstall(cfg); err != nil {
+				t.Fatalf("second uninstall: %v", err)
+			} else if modified {
+				t.Error("second uninstall: modified=true, want false")
+			}
+		})
+	}
+}
+
+// TestEnsureInstalled_MatcherKeyOmittedWhenEmpty pins the shape a turn-end hook
+// requires in both Claude Code and Codex: no matcher key at all, not an empty
+// string. Both upstreams reject a Stop hook that carries one.
+func TestEnsureInstalled_MatcherKeyOmittedWhenEmpty(t *testing.T) {
+	for name, build := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			if _, err := EnsureInstalled(build(path)); err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			hooks := readHooks(t, path)
+
+			group := groupsFor(t, hooks, eventNoMatcher)[0].(map[string]interface{})
+			if _, has := group["matcher"]; has {
+				t.Errorf("%s group carries a matcher key: %#v", eventNoMatcher, group)
+			}
+
+			group = groupsFor(t, hooks, eventWithMatcher)[0].(map[string]interface{})
+			if m, _ := group["matcher"].(string); m != matcher {
+				t.Errorf("%s matcher = %q, want %q", eventWithMatcher, m, matcher)
+			}
+		})
+	}
+}
+
+// TestEnsureInstalled_PreservesUnrelatedContent is the safety property that
+// matters most: these are user-authored config files, and a merge must leave
+// every key and every foreign hook group exactly where it was.
+func TestEnsureInstalled_PreservesUnrelatedContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	existing := map[string]interface{}{
+		"model": "user-choice",
+		"hooks": map[string]interface{}{
+			eventWithMatcher: []interface{}{
+				map[string]interface{}{
+					"matcher": "Bash",
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "command", "command": "echo mine"},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cfg := httpConfig(path)
+	if _, err := EnsureInstalled(cfg); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	var settings map[string]interface{}
+	raw, _ := os.ReadFile(path)
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if settings["model"] != "user-choice" {
+		t.Errorf("unrelated top-level key lost: %#v", settings["model"])
+	}
+
+	hooks := readHooks(t, path)
+	groups := groupsFor(t, hooks, eventWithMatcher)
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups, want 2 (the user's plus ours)", len(groups))
+	}
+	userGroup := groups[0].(map[string]interface{})
+	if m, _ := userGroup["matcher"].(string); m != "Bash" {
+		t.Errorf("user group matcher rewritten to %q; only sentinel-bearing groups may be touched", m)
+	}
+
+	// Uninstall must give the file back exactly as seeded.
+	if _, err := Uninstall(cfg); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	groups = groupsFor(t, readHooks(t, path), eventWithMatcher)
+	if len(groups) != 1 {
+		t.Fatalf("after uninstall: got %d groups, want 1 (the user's)", len(groups))
+	}
+}
+
+// TestEnsureInstalled_UpgradesStaleEntryInPlace covers the migration path both
+// adapters depend on — Claude Code's curl→http switch (#1161) and a Codex
+// curl-flag change: an entry carrying our sentinel but no longer canonical is
+// rewritten where it sits, never appended alongside.
+func TestEnsureInstalled_UpgradesStaleEntryInPlace(t *testing.T) {
+	for name, build := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			cfg := build(path)
+
+			// A legacy entry: our sentinel inside an outdated command wrapper.
+			stale := map[string]interface{}{
+				"hooks": map[string]interface{}{
+					eventWithMatcher: []interface{}{
+						map[string]interface{}{
+							"matcher": "OldMatcher",
+							"hooks": []interface{}{
+								map[string]interface{}{
+									"type":    "command",
+									"command": "curl --old-flags http://" + cfg.Sentinel,
+								},
+							},
+						},
+					},
+				},
+			}
+			data, _ := json.MarshalIndent(stale, "", "  ")
+			if err := os.WriteFile(path, data, 0o600); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			if modified, err := EnsureInstalled(cfg); err != nil {
+				t.Fatalf("install: %v", err)
+			} else if !modified {
+				t.Fatal("modified=false, want true (a stale entry needs rewriting)")
+			}
+
+			groups := groupsFor(t, readHooks(t, path), eventWithMatcher)
+			if len(groups) != 1 {
+				t.Fatalf("got %d groups, want 1 — the stale entry was duplicated, not upgraded", len(groups))
+			}
+			group := groups[0].(map[string]interface{})
+			if m, _ := group["matcher"].(string); m != matcher {
+				t.Errorf("stale matcher = %q, want %q (not reconciled)", m, matcher)
+			}
+			entry := group["hooks"].([]interface{})[0].(map[string]interface{})
+			if !cfg.IsCanonical(entry) {
+				t.Errorf("entry not upgraded to canonical form: %#v", entry)
+			}
+
+			// And the upgrade converges: a re-run changes nothing.
+			if modified, err := EnsureInstalled(cfg); err != nil {
+				t.Fatalf("re-install: %v", err)
+			} else if modified {
+				t.Error("re-install after upgrade: modified=true, want false")
+			}
+		})
+	}
+}
+
+// TestEnsureInstalled_StripsMatcherFromStaleTurnEndGroup is the other half of
+// matcher reconciliation: an install predating the "Stop takes no matcher" rule
+// must have the key removed, not merely overwritten.
+func TestEnsureInstalled_StripsMatcherFromStaleTurnEndGroup(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	cfg := httpConfig(path)
+
+	stale := map[string]interface{}{
+		"hooks": map[string]interface{}{
+			eventNoMatcher: []interface{}{
+				map[string]interface{}{
+					"matcher": "*",
+					"hooks":   []interface{}{cfg.Entry()},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(stale, "", "  ")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if modified, err := EnsureInstalled(cfg); err != nil {
+		t.Fatalf("install: %v", err)
+	} else if !modified {
+		t.Fatal("modified=false, want true (the stale matcher key needs stripping)")
+	}
+
+	group := groupsFor(t, readHooks(t, path), eventNoMatcher)[0].(map[string]interface{})
+	if _, has := group["matcher"]; has {
+		t.Errorf("matcher key survived on the turn-end group: %#v", group)
+	}
+}
+
+// TestEnsureInstalled_ReplacesNonObjectHooksValue: these files are
+// hand-editable, so "hooks" can be anything. A non-object value is replaced
+// rather than crashing the install.
+func TestEnsureInstalled_ReplacesNonObjectHooksValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{"hooks": "not-an-object", "keep": 1}`), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cfg := httpConfig(path)
+	if _, err := EnsureInstalled(cfg); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !HasOurHook(readHooks(t, path), eventNoMatcher, cfg.Sentinel) {
+		t.Error("install did not recover from a non-object hooks value")
+	}
+}
+
+// TestUninstall_NoHooksKey: nothing to remove is not an error, and must not
+// rewrite the file.
+func TestUninstall_NoHooksKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := os.WriteFile(path, []byte(`{"model": "x"}`), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	cfg := httpConfig(path)
+	cfg.WriteFile = func(string, []byte) error {
+		t.Fatal("uninstall wrote the file despite finding nothing of ours")
+		return nil
+	}
+	if modified, err := Uninstall(cfg); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	} else if modified {
+		t.Error("modified=true, want false")
+	}
+}
+
+// TestSentinelMatchesEitherDeliveryField pins the one predicate the two
+// adapters share rather than parameterize: an entry is ours when the sentinel
+// appears in `command` (a shell hook) OR `url` (native http delivery). Checking
+// both is what lets a single predicate serve an adapter mid-migration.
+func TestSentinelMatchesEitherDeliveryField(t *testing.T) {
+	cases := []struct {
+		name string
+		hook map[string]interface{}
+		want bool
+	}{
+		{"command carries it", map[string]interface{}{"command": "curl " + httpURL}, true},
+		{"url carries it", map[string]interface{}{"url": httpURL}, true},
+		{"foreign command", map[string]interface{}{"command": "echo hi"}, false},
+		{"foreign url", map[string]interface{}{"url": "http://example.test/hook"}, false},
+		{"non-string field", map[string]interface{}{"command": 42}, false},
+		{"no delivery field", map[string]interface{}{"type": "http"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := entryIsSentinel(tc.hook, httpSentinel); got != tc.want {
+				t.Errorf("entryIsSentinel = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadSettings(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("missing file is empty, not an error", func(t *testing.T) {
+		got, err := ReadSettings(filepath.Join(dir, "absent.json"))
+		if err != nil {
+			t.Fatalf("ReadSettings: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %#v, want an empty map", got)
+		}
+	})
+
+	// A settings file the user (or a crashed writer) left blank must not block
+	// the install — there is simply nothing to merge onto yet.
+	t.Run("blank file is empty, not an error", func(t *testing.T) {
+		path := filepath.Join(dir, "blank.json")
+		if err := os.WriteFile(path, []byte("  \n\t "), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		got, err := ReadSettings(path)
+		if err != nil {
+			t.Fatalf("ReadSettings: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %#v, want an empty map", got)
+		}
+	})
+
+	// Malformed is different from blank: overwriting it would destroy content
+	// the user meant to keep, so it must surface as an error.
+	t.Run("malformed JSON errors", func(t *testing.T) {
+		path := filepath.Join(dir, "bad.json")
+		if err := os.WriteFile(path, []byte(`{"hooks":`), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if _, err := ReadSettings(path); err == nil {
+			t.Error("ReadSettings on malformed JSON: got nil error, want a decode error")
+		}
+	})
+}
+
+// TestWriteSettings_ShapeAndDelegation pins the on-disk shape (2-space indent,
+// trailing newline — these are hand-edited files) and that persistence is
+// delegated to the caller's writer rather than done here.
+func TestWriteSettings_ShapeAndDelegation(t *testing.T) {
+	var gotPath string
+	var gotData []byte
+	err := WriteSettings("/somewhere/settings.json", map[string]interface{}{"a": "b"},
+		func(path string, data []byte) error {
+			gotPath, gotData = path, data
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("WriteSettings: %v", err)
+	}
+	if gotPath != "/somewhere/settings.json" {
+		t.Errorf("path = %q, want the one passed in", gotPath)
+	}
+	if want := "{\n  \"a\": \"b\"\n}\n"; string(gotData) != want {
+		t.Errorf("data = %q, want %q", gotData, want)
+	}
+}

--- a/core/adapters/inbound/agents/hookjson/hookjson_test.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson_test.go
@@ -75,6 +75,8 @@ func configs() map[string]func(string) Config {
 	return map[string]func(string) Config{"http": httpConfig, "command": cmdConfig}
 }
 
+// --- helpers ---
+
 // writeTestFile stands in for the adapters' atomic writers, which stay on their
 // side of Config precisely because they differ.
 func writeTestFile(path string, data []byte) error {
@@ -82,6 +84,18 @@ func writeTestFile(path string, data []byte) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0o600)
+}
+
+// seedSettings writes a pre-existing settings file for a test to merge onto.
+func seedSettings(t *testing.T, path string, settings map[string]interface{}) {
+	t.Helper()
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
 }
 
 // readHooks returns the "hooks" sub-map of the settings file at path.
@@ -112,54 +126,67 @@ func groupsFor(t *testing.T, hooks map[string]interface{}, event string) []inter
 	return arr
 }
 
+// firstGroup returns the single matcher group installed for an event.
+func firstGroup(t *testing.T, path, event string) map[string]interface{} {
+	t.Helper()
+	return groupsFor(t, readHooks(t, path), event)[0].(map[string]interface{})
+}
+
+// mustEnsure runs EnsureInstalled and asserts whether it reported a change.
+func mustEnsure(t *testing.T, cfg Config, label string, wantModified bool) {
+	t.Helper()
+	modified, err := EnsureInstalled(cfg)
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+	if modified != wantModified {
+		t.Errorf("%s: modified=%v, want %v", label, modified, wantModified)
+	}
+}
+
+// mustUninstall runs Uninstall and asserts whether it reported a change.
+func mustUninstall(t *testing.T, cfg Config, label string, wantModified bool) {
+	t.Helper()
+	modified, err := Uninstall(cfg)
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
+	if modified != wantModified {
+		t.Errorf("%s: modified=%v, want %v", label, modified, wantModified)
+	}
+}
+
+// assertInstalled checks every one of cfg's events for the presence (or, with
+// want=false, the complete absence) of our entry. Absence is the stricter
+// check: the event key itself must be gone once its last group was removed.
+func assertInstalled(t *testing.T, cfg Config, want bool) {
+	t.Helper()
+	hooks := readHooks(t, cfg.Path)
+	for _, event := range cfg.Events {
+		if got := HasOurHook(hooks, event, cfg.Sentinel); got != want {
+			t.Errorf("event %s: installed=%v, want %v", event, got, want)
+		}
+		if _, present := hooks[event]; !want && present {
+			t.Errorf("event %s: key kept after its last group was removed", event)
+		}
+	}
+}
+
+// --- tests ---
+
 func TestEnsureInstalled_CreatesIdempotentlyAndUninstalls(t *testing.T) {
 	for name, build := range configs() {
 		t.Run(name, func(t *testing.T) {
 			// A nested dir the writer must create.
-			path := filepath.Join(t.TempDir(), "nested", "settings.json")
-			cfg := build(path)
+			cfg := build(filepath.Join(t.TempDir(), "nested", "settings.json"))
 
-			modified, err := EnsureInstalled(cfg)
-			if err != nil {
-				t.Fatalf("first install: %v", err)
-			}
-			if !modified {
-				t.Fatal("first install: modified=false, want true")
-			}
+			mustEnsure(t, cfg, "first install", true)
+			assertInstalled(t, cfg, true)
+			mustEnsure(t, cfg, "second install (idempotency)", false)
 
-			hooks := readHooks(t, path)
-			for _, event := range cfg.Events {
-				if !HasOurHook(hooks, event, cfg.Sentinel) {
-					t.Errorf("event %s: no entry installed", event)
-				}
-			}
-
-			if modified, err = EnsureInstalled(cfg); err != nil {
-				t.Fatalf("second install: %v", err)
-			} else if modified {
-				t.Error("second install: modified=true, want false (not idempotent)")
-			}
-
-			if modified, err = Uninstall(cfg); err != nil {
-				t.Fatalf("uninstall: %v", err)
-			} else if !modified {
-				t.Error("uninstall: modified=false, want true")
-			}
-			hooks = readHooks(t, path)
-			for _, event := range cfg.Events {
-				if HasOurHook(hooks, event, cfg.Sentinel) {
-					t.Errorf("event %s: entry survived uninstall", event)
-				}
-				if _, present := hooks[event]; present {
-					t.Errorf("event %s: key kept after its last group was removed", event)
-				}
-			}
-
-			if modified, err = Uninstall(cfg); err != nil {
-				t.Fatalf("second uninstall: %v", err)
-			} else if modified {
-				t.Error("second uninstall: modified=true, want false")
-			}
+			mustUninstall(t, cfg, "uninstall", true)
+			assertInstalled(t, cfg, false)
+			mustUninstall(t, cfg, "second uninstall", false)
 		})
 	}
 }
@@ -170,18 +197,13 @@ func TestEnsureInstalled_CreatesIdempotentlyAndUninstalls(t *testing.T) {
 func TestEnsureInstalled_MatcherKeyOmittedWhenEmpty(t *testing.T) {
 	for name, build := range configs() {
 		t.Run(name, func(t *testing.T) {
-			path := filepath.Join(t.TempDir(), "settings.json")
-			if _, err := EnsureInstalled(build(path)); err != nil {
-				t.Fatalf("install: %v", err)
-			}
-			hooks := readHooks(t, path)
+			cfg := build(filepath.Join(t.TempDir(), "settings.json"))
+			mustEnsure(t, cfg, "install", true)
 
-			group := groupsFor(t, hooks, eventNoMatcher)[0].(map[string]interface{})
-			if _, has := group["matcher"]; has {
+			if group := firstGroup(t, cfg.Path, eventNoMatcher); group["matcher"] != nil {
 				t.Errorf("%s group carries a matcher key: %#v", eventNoMatcher, group)
 			}
-
-			group = groupsFor(t, hooks, eventWithMatcher)[0].(map[string]interface{})
+			group := firstGroup(t, cfg.Path, eventWithMatcher)
 			if m, _ := group["matcher"].(string); m != matcher {
 				t.Errorf("%s matcher = %q, want %q", eventWithMatcher, m, matcher)
 			}
@@ -193,32 +215,18 @@ func TestEnsureInstalled_MatcherKeyOmittedWhenEmpty(t *testing.T) {
 // matters most: these are user-authored config files, and a merge must leave
 // every key and every foreign hook group exactly where it was.
 func TestEnsureInstalled_PreservesUnrelatedContent(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "settings.json")
-	existing := map[string]interface{}{
+	cfg := httpConfig(filepath.Join(t.TempDir(), "settings.json"))
+	seedSettings(t, cfg.Path, map[string]interface{}{
 		"model": "user-choice",
 		"hooks": map[string]interface{}{
-			eventWithMatcher: []interface{}{
-				map[string]interface{}{
-					"matcher": "Bash",
-					"hooks": []interface{}{
-						map[string]interface{}{"type": "command", "command": "echo mine"},
-					},
-				},
-			},
+			eventWithMatcher: []interface{}{userAuthoredGroup()},
 		},
-	}
-	data, _ := json.MarshalIndent(existing, "", "  ")
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
+	})
 
-	cfg := httpConfig(path)
-	if _, err := EnsureInstalled(cfg); err != nil {
-		t.Fatalf("install: %v", err)
-	}
+	mustEnsure(t, cfg, "install", true)
 
 	var settings map[string]interface{}
-	raw, _ := os.ReadFile(path)
+	raw, _ := os.ReadFile(cfg.Path)
 	if err := json.Unmarshal(raw, &settings); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -226,23 +234,29 @@ func TestEnsureInstalled_PreservesUnrelatedContent(t *testing.T) {
 		t.Errorf("unrelated top-level key lost: %#v", settings["model"])
 	}
 
-	hooks := readHooks(t, path)
-	groups := groupsFor(t, hooks, eventWithMatcher)
+	groups := groupsFor(t, readHooks(t, cfg.Path), eventWithMatcher)
 	if len(groups) != 2 {
 		t.Fatalf("got %d groups, want 2 (the user's plus ours)", len(groups))
 	}
-	userGroup := groups[0].(map[string]interface{})
-	if m, _ := userGroup["matcher"].(string); m != "Bash" {
+	if m, _ := groups[0].(map[string]interface{})["matcher"].(string); m != "Bash" {
 		t.Errorf("user group matcher rewritten to %q; only sentinel-bearing groups may be touched", m)
 	}
 
-	// Uninstall must give the file back exactly as seeded.
-	if _, err := Uninstall(cfg); err != nil {
-		t.Fatalf("uninstall: %v", err)
-	}
-	groups = groupsFor(t, readHooks(t, path), eventWithMatcher)
-	if len(groups) != 1 {
+	// Uninstall must give the file back as seeded.
+	mustUninstall(t, cfg, "uninstall", true)
+	if groups := groupsFor(t, readHooks(t, cfg.Path), eventWithMatcher); len(groups) != 1 {
 		t.Fatalf("after uninstall: got %d groups, want 1 (the user's)", len(groups))
+	}
+}
+
+// userAuthoredGroup is a hook group the daemon must never touch — it carries no
+// sentinel of ours.
+func userAuthoredGroup() map[string]interface{} {
+	return map[string]interface{}{
+		"matcher": "Bash",
+		"hooks": []interface{}{
+			map[string]interface{}{"type": "command", "command": "echo mine"},
+		},
 	}
 }
 
@@ -253,11 +267,10 @@ func TestEnsureInstalled_PreservesUnrelatedContent(t *testing.T) {
 func TestEnsureInstalled_UpgradesStaleEntryInPlace(t *testing.T) {
 	for name, build := range configs() {
 		t.Run(name, func(t *testing.T) {
-			path := filepath.Join(t.TempDir(), "settings.json")
-			cfg := build(path)
-
-			// A legacy entry: our sentinel inside an outdated command wrapper.
-			stale := map[string]interface{}{
+			cfg := build(filepath.Join(t.TempDir(), "settings.json"))
+			// A legacy entry: our sentinel inside an outdated command wrapper,
+			// under a matcher we no longer install.
+			seedSettings(t, cfg.Path, map[string]interface{}{
 				"hooks": map[string]interface{}{
 					eventWithMatcher: []interface{}{
 						map[string]interface{}{
@@ -271,38 +284,31 @@ func TestEnsureInstalled_UpgradesStaleEntryInPlace(t *testing.T) {
 						},
 					},
 				},
-			}
-			data, _ := json.MarshalIndent(stale, "", "  ")
-			if err := os.WriteFile(path, data, 0o600); err != nil {
-				t.Fatalf("seed: %v", err)
-			}
+			})
 
-			if modified, err := EnsureInstalled(cfg); err != nil {
-				t.Fatalf("install: %v", err)
-			} else if !modified {
-				t.Fatal("modified=false, want true (a stale entry needs rewriting)")
-			}
-
-			groups := groupsFor(t, readHooks(t, path), eventWithMatcher)
-			if len(groups) != 1 {
-				t.Fatalf("got %d groups, want 1 — the stale entry was duplicated, not upgraded", len(groups))
-			}
-			group := groups[0].(map[string]interface{})
-			if m, _ := group["matcher"].(string); m != matcher {
-				t.Errorf("stale matcher = %q, want %q (not reconciled)", m, matcher)
-			}
-			entry := group["hooks"].([]interface{})[0].(map[string]interface{})
-			if !cfg.IsCanonical(entry) {
-				t.Errorf("entry not upgraded to canonical form: %#v", entry)
-			}
-
-			// And the upgrade converges: a re-run changes nothing.
-			if modified, err := EnsureInstalled(cfg); err != nil {
-				t.Fatalf("re-install: %v", err)
-			} else if modified {
-				t.Error("re-install after upgrade: modified=true, want false")
-			}
+			mustEnsure(t, cfg, "install over a stale entry", true)
+			assertUpgradedInPlace(t, cfg)
+			// The upgrade converges: a re-run changes nothing.
+			mustEnsure(t, cfg, "re-install after upgrade", false)
 		})
+	}
+}
+
+// assertUpgradedInPlace checks that the seeded stale group was rewritten where
+// it sat — same single group, matcher reconciled, entry now canonical.
+func assertUpgradedInPlace(t *testing.T, cfg Config) {
+	t.Helper()
+	groups := groupsFor(t, readHooks(t, cfg.Path), eventWithMatcher)
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups, want 1 — the stale entry was duplicated, not upgraded", len(groups))
+	}
+	group := groups[0].(map[string]interface{})
+	if m, _ := group["matcher"].(string); m != matcher {
+		t.Errorf("stale matcher = %q, want %q (not reconciled)", m, matcher)
+	}
+	entry := group["hooks"].([]interface{})[0].(map[string]interface{})
+	if !cfg.IsCanonical(entry) {
+		t.Errorf("entry not upgraded to canonical form: %#v", entry)
 	}
 }
 
@@ -310,71 +316,48 @@ func TestEnsureInstalled_UpgradesStaleEntryInPlace(t *testing.T) {
 // matcher reconciliation: an install predating the "Stop takes no matcher" rule
 // must have the key removed, not merely overwritten.
 func TestEnsureInstalled_StripsMatcherFromStaleTurnEndGroup(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "settings.json")
-	cfg := httpConfig(path)
-
-	stale := map[string]interface{}{
+	cfg := httpConfig(filepath.Join(t.TempDir(), "settings.json"))
+	seedSettings(t, cfg.Path, map[string]interface{}{
 		"hooks": map[string]interface{}{
 			eventNoMatcher: []interface{}{
-				map[string]interface{}{
-					"matcher": "*",
-					"hooks":   []interface{}{cfg.Entry()},
-				},
+				map[string]interface{}{"matcher": "*", "hooks": []interface{}{cfg.Entry()}},
 			},
 		},
-	}
-	data, _ := json.MarshalIndent(stale, "", "  ")
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
+	})
 
-	if modified, err := EnsureInstalled(cfg); err != nil {
-		t.Fatalf("install: %v", err)
-	} else if !modified {
-		t.Fatal("modified=false, want true (the stale matcher key needs stripping)")
-	}
+	mustEnsure(t, cfg, "install over a stale turn-end matcher", true)
 
-	group := groupsFor(t, readHooks(t, path), eventNoMatcher)[0].(map[string]interface{})
-	if _, has := group["matcher"]; has {
+	if group := firstGroup(t, cfg.Path, eventNoMatcher); group["matcher"] != nil {
 		t.Errorf("matcher key survived on the turn-end group: %#v", group)
 	}
 }
 
 // TestEnsureInstalled_ReplacesNonObjectHooksValue: these files are
-// hand-editable, so "hooks" can be anything. A non-object value is replaced
+// hand-editable, so "hooks" can hold anything. A non-object value is replaced
 // rather than crashing the install.
 func TestEnsureInstalled_ReplacesNonObjectHooksValue(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "settings.json")
-	if err := os.WriteFile(path, []byte(`{"hooks": "not-an-object", "keep": 1}`), 0o600); err != nil {
+	cfg := httpConfig(filepath.Join(t.TempDir(), "settings.json"))
+	if err := os.WriteFile(cfg.Path, []byte(`{"hooks": "not-an-object", "keep": 1}`), 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
-	cfg := httpConfig(path)
-	if _, err := EnsureInstalled(cfg); err != nil {
-		t.Fatalf("install: %v", err)
-	}
-	if !HasOurHook(readHooks(t, path), eventNoMatcher, cfg.Sentinel) {
-		t.Error("install did not recover from a non-object hooks value")
-	}
+	mustEnsure(t, cfg, "install over a non-object hooks value", true)
+	assertInstalled(t, cfg, true)
 }
 
 // TestUninstall_NoHooksKey: nothing to remove is not an error, and must not
 // rewrite the file.
 func TestUninstall_NoHooksKey(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "settings.json")
-	if err := os.WriteFile(path, []byte(`{"model": "x"}`), 0o600); err != nil {
+	cfg := httpConfig(filepath.Join(t.TempDir(), "settings.json"))
+	if err := os.WriteFile(cfg.Path, []byte(`{"model": "x"}`), 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	cfg := httpConfig(path)
 	cfg.WriteFile = func(string, []byte) error {
-		t.Fatal("uninstall wrote the file despite finding nothing of ours")
+		t.Error("uninstall wrote the file despite finding nothing of ours")
 		return nil
 	}
-	if modified, err := Uninstall(cfg); err != nil {
-		t.Fatalf("uninstall: %v", err)
-	} else if modified {
-		t.Error("modified=true, want false")
-	}
+
+	mustUninstall(t, cfg, "uninstall with no hooks key", false)
 }
 
 // TestSentinelMatchesEitherDeliveryField pins the one predicate the two
@@ -403,70 +386,61 @@ func TestSentinelMatchesEitherDeliveryField(t *testing.T) {
 	}
 }
 
-func TestReadSettings(t *testing.T) {
-	dir := t.TempDir()
+// assertReadsEmpty asserts ReadSettings yields a usable empty map — never a nil
+// one, which every later write would panic on.
+func assertReadsEmpty(t *testing.T, path string) {
+	t.Helper()
+	got, err := ReadSettings(path)
+	if err != nil {
+		t.Fatalf("ReadSettings(%s): %v", path, err)
+	}
+	if got == nil {
+		t.Fatalf("ReadSettings(%s): got a nil map; a later write would panic on it", path)
+	}
+	if len(got) != 0 {
+		t.Errorf("ReadSettings(%s) = %#v, want an empty map", path, got)
+	}
+}
 
-	t.Run("missing file is empty, not an error", func(t *testing.T) {
-		got, err := ReadSettings(filepath.Join(dir, "absent.json"))
-		if err != nil {
-			t.Fatalf("ReadSettings: %v", err)
-		}
-		if len(got) != 0 {
-			t.Errorf("got %#v, want an empty map", got)
-		}
-	})
+// seedRaw writes a literal file body (bypassing JSON marshalling) and returns
+// its path, for the shapes a settings file can degenerate into.
+func seedRaw(t *testing.T, name, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("seed %s: %v", name, err)
+	}
+	return path
+}
 
-	// A settings file the user (or a crashed writer) left blank must not block
-	// the install — there is simply nothing to merge onto yet.
-	t.Run("blank file is empty, not an error", func(t *testing.T) {
-		path := filepath.Join(dir, "blank.json")
-		if err := os.WriteFile(path, []byte("  \n\t "), 0o600); err != nil {
-			t.Fatalf("seed: %v", err)
-		}
-		got, err := ReadSettings(path)
-		if err != nil {
-			t.Fatalf("ReadSettings: %v", err)
-		}
-		if len(got) != 0 {
-			t.Errorf("got %#v, want an empty map", got)
-		}
-	})
+func TestReadSettings_MissingFileIsEmpty(t *testing.T) {
+	assertReadsEmpty(t, filepath.Join(t.TempDir(), "absent.json"))
+}
 
-	// A bare `null` decodes to a nil map with no error — and every later write
-	// would panic on it. Regression guard for that crash.
-	t.Run("null document is empty, not a nil map", func(t *testing.T) {
-		path := filepath.Join(dir, "null.json")
-		if err := os.WriteFile(path, []byte("null\n"), 0o600); err != nil {
-			t.Fatalf("seed: %v", err)
-		}
-		got, err := ReadSettings(path)
-		if err != nil {
-			t.Fatalf("ReadSettings: %v", err)
-		}
-		if got == nil {
-			t.Fatal("got a nil map; a later write would panic on it")
-		}
-		// The whole install must survive it, not just the read.
-		cfg := httpConfig(path)
-		if _, err := EnsureInstalled(cfg); err != nil {
-			t.Fatalf("EnsureInstalled over a null document: %v", err)
-		}
-		if !HasOurHook(readHooks(t, path), eventNoMatcher, cfg.Sentinel) {
-			t.Error("install did not recover from a null document")
-		}
-	})
+// A settings file the user (or a crashed writer) left blank must not block the
+// install — there is simply nothing to merge onto yet.
+func TestReadSettings_BlankFileIsEmpty(t *testing.T) {
+	assertReadsEmpty(t, seedRaw(t, "blank.json", "  \n\t "))
+}
 
-	// Malformed is different from blank: overwriting it would destroy content
-	// the user meant to keep, so it must surface as an error.
-	t.Run("malformed JSON errors", func(t *testing.T) {
-		path := filepath.Join(dir, "bad.json")
-		if err := os.WriteFile(path, []byte(`{"hooks":`), 0o600); err != nil {
-			t.Fatalf("seed: %v", err)
-		}
-		if _, err := ReadSettings(path); err == nil {
-			t.Error("ReadSettings on malformed JSON: got nil error, want a decode error")
-		}
-	})
+// TestReadSettings_NullDocumentIsEmpty: a bare `null` decodes to a NIL map with
+// no error, and every later write would panic on it. Regression guard.
+func TestReadSettings_NullDocumentIsEmpty(t *testing.T) {
+	path := seedRaw(t, "null.json", "null\n")
+	assertReadsEmpty(t, path)
+
+	// The whole install must survive it, not just the read.
+	cfg := httpConfig(path)
+	mustEnsure(t, cfg, "install over a null document", true)
+	assertInstalled(t, cfg, true)
+}
+
+// Malformed is different from blank: overwriting it would destroy content the
+// user meant to keep, so it must surface as an error.
+func TestReadSettings_MalformedJSONErrors(t *testing.T) {
+	if _, err := ReadSettings(seedRaw(t, "bad.json", `{"hooks":`)); err == nil {
+		t.Error("ReadSettings on malformed JSON: got nil error, want a decode error")
+	}
 }
 
 // TestWriteSettings_ShapeAndDelegation pins the on-disk shape (2-space indent,

--- a/core/adapters/inbound/agents/hookjson/hookjson_test.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson_test.go
@@ -22,43 +22,50 @@ const (
 	matcher          = "Bash|Write"
 )
 
-func httpConfig(path string) Config {
+// testConfig holds everything the two shapes share, so httpConfig and cmdConfig
+// below differ by exactly what a real adapter differs by — sentinel, entry
+// builder, canonical predicate — and nothing else.
+func testConfig(path, sentinel string, entry func() map[string]interface{}, isCanonical func(map[string]interface{}) bool) Config {
 	return Config{
-		Path:       path,
-		Sentinel:   httpSentinel,
-		Events:     []string{eventWithMatcher, eventNoMatcher},
-		MatcherFor: matcherForTestEvent,
-		Entry: func() map[string]interface{} {
+		Path:        path,
+		Sentinel:    sentinel,
+		Events:      []string{eventWithMatcher, eventNoMatcher},
+		MatcherFor:  matcherForTestEvent,
+		Entry:       entry,
+		IsCanonical: isCanonical,
+		WriteFile:   writeTestFile,
+	}
+}
+
+// httpConfig models a claudecode-shaped adapter: native `type: http` delivery,
+// and a canonical check that rejects any leftover legacy `command` key.
+func httpConfig(path string) Config {
+	return testConfig(path, httpSentinel,
+		func() map[string]interface{} {
 			return map[string]interface{}{"type": "http", "url": httpURL, "timeout": 5}
 		},
-		IsCanonical: func(hook map[string]interface{}) bool {
+		func(hook map[string]interface{}) bool {
 			if _, hasCmd := hook["command"]; hasCmd {
 				return false
 			}
 			t, _ := hook["type"].(string)
 			u, _ := hook["url"].(string)
 			return t == "http" && u == httpURL
-		},
-		WriteFile: writeTestFile,
-	}
+		})
 }
 
+// cmdConfig models a codex-shaped adapter: a `type: command` curl, canonical
+// when the command matches ours exactly.
 func cmdConfig(path string) Config {
-	return Config{
-		Path:       path,
-		Sentinel:   cmdSentinel,
-		Events:     []string{eventWithMatcher, eventNoMatcher},
-		MatcherFor: matcherForTestEvent,
-		Entry: func() map[string]interface{} {
+	return testConfig(path, cmdSentinel,
+		func() map[string]interface{} {
 			return map[string]interface{}{"type": "command", "command": cmdCommand, "timeout": 5}
 		},
-		IsCanonical: func(hook map[string]interface{}) bool {
+		func(hook map[string]interface{}) bool {
 			t, _ := hook["type"].(string)
 			c, _ := hook["command"].(string)
 			return t == "command" && c == cmdCommand
-		},
-		WriteFile: writeTestFile,
-	}
+		})
 }
 
 // matcherForTestEvent mirrors the real adapters' rule: every event but the

--- a/core/domain/session/waiting_cue.go
+++ b/core/domain/session/waiting_cue.go
@@ -12,6 +12,27 @@ import (
 	"unicode/utf8"
 )
 
+// ProseIndicatesWaiting reports whether an assistant message carries a trailing
+// question or an imperative waiting cue — the OR of the two detectors below,
+// and the single place that rule lives (issue #1179). Before it was extracted
+// the same OR had been written out four times: IsWaitingForUserInput's tail
+// scan, both adapters' Stop-hook handlers, and both adapters' transcript
+// parsers.
+//
+// A caller judging a turn's FINAL message must pass a BOUNDED tail window
+// (tailer.WaitingScanWindow), never the whole turn — ExtractWaitingCue
+// over-fires on very long text — and never the display-truncated
+// LastAssistantText alone, which hides a cue sitting before the trailing 200
+// runes (issue #1150). The windowing stays at the call site rather than moving
+// in here because core/pkg/tailer, which owns the window, deliberately does not
+// import this package (see userblocking_contract_test.go).
+func ProseIndicatesWaiting(text string) bool {
+	if text == "" {
+		return false
+	}
+	return ExtractQuestionSnippet(text) != "" || ExtractWaitingCue(text) != ""
+}
+
 // trailingMarkdownNoise are characters that commonly appear AFTER a
 // question mark when models wrap questions in markdown or punctuation.
 // e.g. `**Question?**` (bold), `*Question?*` (italic), `_Question?_`,
@@ -56,10 +77,7 @@ func (m *SessionMetrics) IsWaitingForUserInput() bool {
 	if m.PendingWaitingCue {
 		return true
 	}
-	if ExtractQuestionSnippet(m.LastAssistantText) != "" {
-		return true
-	}
-	return ExtractWaitingCue(m.LastAssistantText) != ""
+	return ProseIndicatesWaiting(m.LastAssistantText)
 }
 
 // ExtractQuestionSnippet returns the first non-rhetorical question sentence

--- a/core/domain/session/waiting_cue.go
+++ b/core/domain/session/waiting_cue.go
@@ -52,9 +52,9 @@ const markdownWrapper = "*_~`\"')]"
 // "verify locally and reply with …") — both indicate the agent is gated on
 // the user even though no user-blocking tool is open.
 //
-// Two detectors are OR'd: ExtractQuestionSnippet (literal `?`, fired
-// anywhere in the text) and ExtractWaitingCue (cue regexes against the
-// trailing 1–2 sentences). See issue #381 for the cue coverage matrix.
+// The prose rule itself is ProseIndicatesWaiting above — ExtractQuestionSnippet
+// OR ExtractWaitingCue. See issue #381 for the cue coverage matrix it was built
+// against.
 func (m *SessionMetrics) IsWaitingForUserInput() bool {
 	if m == nil {
 		return false

--- a/core/domain/session/waiting_cue.go
+++ b/core/domain/session/waiting_cue.go
@@ -19,13 +19,17 @@ import (
 // scan, both adapters' Stop-hook handlers, and both adapters' transcript
 // parsers.
 //
-// A caller judging a turn's FINAL message must pass a BOUNDED tail window
-// (tailer.WaitingScanWindow), never the whole turn — ExtractWaitingCue
-// over-fires on very long text — and never the display-truncated
-// LastAssistantText alone, which hides a cue sitting before the trailing 200
-// runes (issue #1150). The windowing stays at the call site rather than moving
-// in here because core/pkg/tailer, which owns the window, deliberately does not
-// import this package (see userblocking_contract_test.go).
+// A caller that HAS the turn's full final message should pass a bounded tail
+// window of it (tailer.WaitingScanWindow), not the whole turn — ExtractWaitingCue
+// over-fires on very long text — and not the display-truncated LastAssistantText,
+// which hides a cue sitting before the trailing 200 runes (issue #1150). That is
+// what both adapters' parsers and Stop-hook handlers do. IsWaitingForUserInput
+// below passes LastAssistantText deliberately: it is the fallback for passes that
+// never populated PendingWaitingCue, where the truncated text is all there is.
+//
+// The windowing stays at the call site rather than moving in here because
+// core/pkg/tailer, which owns the window, deliberately does not import this
+// package (see userblocking_contract_test.go).
 func ProseIndicatesWaiting(text string) bool {
 	if text == "" {
 		return false


### PR DESCRIPTION
Closes #1179.

The Codex hook adapter (#1171) landed as a near-verbatim copy of the Claude Code hook stack — flagged by PR #1174's high-effort review, findings [6]/[7]/[8]. Two adapters were maintaining the same logic in parallel, and would silently drift the first time one was fixed and the other forgotten. All three duplicated surfaces are collapsed here.

## Surface 1 — installer merge/idempotency machinery

New `core/adapters/inbound/agents/hookjson` owns the JSON merge, idempotency check, in-place upgrade and removal control flow for both files. Only what genuinely differs is parameterized through `hookjson.Config`:

| Config field | claudecode | codex |
|---|---|---|
| `Path` | `~/.claude/settings.json` | `~/.codex/hooks.json` |
| `Sentinel` | `…/hooks/claudecode` | `…/hooks/codex` |
| `Events` + `MatcherFor` | 7 events, 4 distinct matchers | 3 events, `.*` |
| `Entry` / `IsCanonical` | native `type: http` | `type: command` curl |
| `WriteFile` | `path+".tmp"`, 0644 | `CreateTemp`, 0600 |

Nothing is force-merged, per the issue's Notes. The two atomic writers stay separate on purpose: claudecode's is deliberately shared with its CLAUDE.md writer ("a hardening change applies to both"), so moving settings.json onto codex's harder writer would have split exactly the pair that comment exists to keep together.

`readClaudeSettings` / `writeClaudeSettings` become thin delegates onto `hookjson.ReadSettings` / `WriteSettings`, so `statusline_installer.go` — which merges into the same settings.json — keeps reading and writing it identically, without a second codec.

## Surface 2 — the waiting-cue rule

The `WaitingScanWindow` + `ExtractQuestionSnippet || ExtractWaitingCue` OR had been written out **four** times: `IsWaitingForUserInput`'s tail scan, both adapters' Stop-hook handlers, and both adapters' transcript parsers. It now lives once as `session.ProseIndicatesWaiting`.

The windowing stays at the call site (`session.ProseIndicatesWaiting(tailer.WaitingScanWindow(full))`) rather than moving inside. The issue suggested `tailer` **or** `session` as the home; `session` is the only one available, because `core/pkg/tailer`'s in-package tests already import `core/domain/session` — so `session → tailer` is a hard import cycle, not a style call. Pulling the window down into `session` instead would have meant duplicating `MaxWaitingScanRunes` (derived from tailer's truncation limit), and making `tailer` import the domain would contradict the stated reason behind the paired `userblocking_contract_test.go`.

## Surface 3 — receiver types

`ConsentGranter` is now a type alias onto `hookjson.ConsentGranter` in both adapters — identical method and identical doc comment before, so an alias removes the drift risk at zero coupling cost.

`HookTarget` and the payload structs stay per-adapter, which the issue left open ("if it doesn't over-couple"). They differ in both shape and intent: claudecode's target has four methods to codex's two, and codex deliberately does **not** decode `session_id`, because a Codex session shares its id with every child. Sharing them would couple the adapters to each other's event sets rather than to a common contract. `hookjson/consent.go` records that reasoning next to the type that *is* shared.

## Behavior

Behavior-preserving throughout, with one deliberate widening: reading a **blank** settings.json is no longer an error but an empty merge base — the tolerance codex already had, now shared. Malformed JSON still errors (overwriting it would destroy content the user meant to keep), which the new suite pins.

## Testing

- `go test ./core/... -race -count=1` — green. Both adapters' `hookinstaller_test.go` and `hooks_test.go` pass; the only test edit is the codex helper's local sentinel walk, retargeted at the exported `hookjson.HasOurHook`.
- `tools/preflight.sh` — every gate PASS (gofmt, core, onboarding-factory, replaydata validate, rig smoke, starhistory, both web suites, ARS architecture gate). The one FAIL is the **pre-existing** `npm audit` postcss advisory in both web trees; this diff touches no `web/` or npm file.
- `tools/replay-fixtures.sh` — green, cell integrity intact.
- New `hookjson_test.go` runs every behavioral case (create/idempotent/uninstall, matcher-key omission, unrelated-content preservation, stale-entry in-place upgrade, stale-matcher stripping, non-object `hooks` recovery, sentinel field matching, read/write shape) against **both** delivery shapes, so a change that only holds for one fails.

Net: **-682 / +101** in the adapters, against ~370 lines of new shared implementation and ~380 of new tests where there were none before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)