### PR TITLE
feat(daemon): resolve the agent hook endpoint from the daemon's bind address

### DIFF
--- a/.claude/skills/ir:agent-releases/references/monitoring-surface.md
+++ b/.claude/skills/ir:agent-releases/references/monitoring-surface.md
@@ -215,7 +215,7 @@ The single highest-value thing to know per adapter. **Four adapters get an expli
 - **Assistant text**: last assistant message checked for trailing `?` (waiting heuristic)
 - **Token/cost fields**: `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`
 - **Model name field**: normalized (e.g., `sonnet` -> `claude-sonnet-4-6`)
-- **Hooks**: the hook matcher (`hookinstaller.go:34`) hardcodes `Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*|AskUserQuestion|ExitPlanMode`. Note hooks post to a **hardcoded port 7837**, so hook-delivered observations can't be re-recorded against a dev daemon on an alt port.
+- **Hooks**: the hook matcher (`hookinstaller.go:34`) hardcodes `Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*|AskUserQuestion|ExitPlanMode`. Since #1178 the hook endpoint follows the daemon's own `IRRLICHT_BIND_ADDR`, so hook-delivered observations *can* be recorded against a dev daemon on an alt port.
 
 #### Process-level dependencies
 - Binary named `claude` found via `pgrep -x claude`

--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -30,9 +30,10 @@ independent axes:
     daemon binds port **7838** and stores its state under a worktree-local
     `IRRLICHT_HOME`; the dev app is assembled at `/tmp/IrrlichtDev.app` and
     connects to 7838 via `IRRLICHT_DAEMON_PORT`. Production stays up
-    untouched on 7837. Note: the Claude Code statusline hook is hardcoded to
-    POST quota data to 7837, so a separate dev instance shows the
-    **subscription empty-state** (no rate-limit data) — that's expected.
+    untouched on 7837. Since #1178 the Claude Code hooks and statusline feed
+    follow the daemon's own bind address, so the dev daemon receives them —
+    but it installs them into the shared `~/.claude/settings.json`, which
+    repoints production's hooks at 7838 until production restarts.
 - **TARGET** — `full` (default), `daemon`, or `macos`:
   - **full** — rebuild and restart both the daemon and the app. Today's only
     behavior before this axis existed.
@@ -89,7 +90,7 @@ independent axes:
    esac
 
    if [ "$MODE" = "replace" ]; then
-     PORT=7837                                          # production port (statusline quota hook targets this)
+     PORT=7837                                          # production port
      DEV_HOME=""                                        # no IRRLICHT_HOME override → production state dir
      SOCK="$HOME/.local/share/irrlicht/irrlichd.sock"   # production socket
      APP_TARGET="$PROD_APP"
@@ -443,7 +444,7 @@ independent axes:
 
 ## Notes
 - **separate mode — production keeps running.** The production Irrlicht.app (from DMG) and its bundled daemon stay on port 7837 with state under `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/`. The dev instance binds port 7838 and routes its WRITTEN state — socket, recordings, history, session store, ledgers, and cost store — beneath `IRRLICHT_HOME=$DEV_HOME`, so it never prunes or mutates production's session/cost data. The dev app reaches the dev daemon because `IRRLICHT_DAEMON_PORT` (via `open --env`) overrides the hardcoded default; `DaemonManager` also skips its global `pkill` when a custom port is set, so it can't take production down.
-- **separate mode shares with production:** it reads the same `~/.claude` transcripts (so the dev UI shows the same live sessions) and appends to the same `~/Library/Application Support/Irrlicht/logs/events.log`. It does NOT share the on-disk session/ledger/cost stores — and it does NOT receive the statusline quota feed (that hook posts only to 7837), so the subscription panel shows its empty-state.
+- **separate mode shares with production:** it reads the same `~/.claude` transcripts (so the dev UI shows the same live sessions) and appends to the same `~/Library/Application Support/Irrlicht/logs/events.log`. It does NOT share the on-disk session/ledger/cost stores. It DOES receive the hook + statusline quota feed since #1178 (both follow `IRRLICHT_BIND_ADDR`), at the cost of repointing the shared `~/.claude/settings.json` at 7838 for as long as the dev daemon is the last one to have installed — production picks its own port back up on its next start.
 - **replace mode — single instance on production's footprint.** Runs the dev binaries on port 7837 with the production state dir (no `IRRLICHT_HOME`), so the statusline quota feed and the production session/cost/ledger stores all apply, and (for `TARGET=macos`/`full`) the Swift app is installed directly into `/Applications/Irrlicht.app` rather than a parallel bundle. Because the dev daemon runs with `--record`, recordings land in the production recordings dir (`~/.local/share/irrlicht/recordings/`). **⚠️ The dev daemon mutates production data.** Without `IRRLICHT_HOME` its startup sweeps (`PruneStale` / dead-proc / orphan-ledger / cost prune) run against the real `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/` stores — this is exactly the isolation #448 added, deliberately removed here. Only use replace mode when the dev build's on-disk schema matches the installed production build; a dev branch mid-migration can prune or rewrite production sessions/ledgers/cost rows that the production binary then misreads. **Returning to production requires the teardown step** (run `restore-prod.sh`) — quitting the app does NOT stop the adopted daemon, and a relaunched (or freshly *reinstalled*) production app will silently adopt the leftover dev daemon on 7837 if you skip it. Running the installer is not a substitute: it replaces the app bundle, not the running daemon.
 - **Backup freshness.** `PROD_BACKUP` is refreshed automatically whenever step 5 finds `$PROD_APP` still Developer-ID-signed (i.e. a genuine, untouched production build) — so installing a *new* production release via the DMG/PKG installer, then running replace mode again, correctly captures the new release as the restore baseline instead of reinstalling a stale one. If `$PROD_APP` is already dev-signed (mid-test) and `PROD_BACKUP` is missing (e.g. `.build` was wiped), step 5 refuses to proceed rather than overwriting the last remaining copy with no safety net — reinstall via the DMG/PKG installer to recover.
 - Daemon logs: `/tmp/irrlichd-dev.log` · Swift app logs: `/tmp/irrlicht-app-dev.log`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ beyond), see the [Roadmap](https://irrlicht.io/docs/roadmap.html).
 
 ## [Unreleased]
 
+**Fixed**
+- The agent hooks the daemon installs now POST to the port the daemon actually binds, instead of a hardcoded `:7837`. A daemon on an alternate port — a `separate`-mode dev instance, or the onboarding factory's coexist recorder — installed Claude Code and Codex hooks (and the Claude Code statusline feed) that delivered to whatever owned `:7837`, so its own hook-authoritative waiting/ready tier silently received nothing. All three installers derive the endpoint from `IRRLICHT_BIND_ADDR`, and the entry sentinels are now port-independent, so an existing `:7837` install is still recognized as ours and repointed in place rather than orphaned beside a duplicate. The onboarding factory's recorder snapshots and restores the shared agent config it rewrites, so a recording no longer leaves the production daemon's hooks pointing at it. (#1178)
+
 ## [0.5.9] — 2026-07-15
 
 ### A correctness release: sessions no longer wedge at "working" after a background subagent, and agents whose session directories are relocated by an env var or config key are finally visible instead of silently absent

--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -82,7 +82,7 @@ func Agent() agent.Agent {
 				Touches:         "Writes 6 hook entries to ~/.claude/settings.json",
 				Detail: "Adds PermissionRequest, PreToolUse, PostToolUse, " +
 					"PostToolUseFailure, PreCompact, and Stop hook entries that POST " +
-					"the hook payload to the local daemon at " + hookEndpointURL +
+					"the hook payload to the local daemon at " + hookEndpointURL() +
 					" via Claude Code's native http hook (no shell/curl). Toggling " +
 					"off removes exactly these entries (also available via " +
 					"`irrlichd --uninstall-hooks`).",
@@ -95,7 +95,7 @@ func Agent() agent.Agent {
 				Title:           "Install statusline feed",
 				FeatureUnlocked: "Rate-limit / quota forecast for Pro & Max subscriptions",
 				Touches:         "Sets statusLine.command in ~/.claude/settings.json",
-				Detail: "Sets statusLine.command to: " + installedStatuslineCommand +
+				Detail: "Sets statusLine.command to: " + installedStatuslineCommand() +
 					" — POSTs Claude Code's statusline JSON (carrying rate-limit " +
 					"data) to the local daemon. An existing user statusline is " +
 					"chained, not replaced. Toggling off restores the previous " +

--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -13,11 +13,16 @@ import (
 	"irrlicht/core/pkg/daemonaddr"
 )
 
-// hookEndpointPath is the daemon's Claude Code hook path. Host and port are
+// HookEndpointPath is the daemon's Claude Code hook path. Host and port are
 // resolved at install time from the daemon's own bind address, so a daemon on
 // an alternate port installs hooks that reach it rather than whatever owns
 // :7837 (issue #1178).
-const hookEndpointPath = "/api/v1/hooks/claudecode"
+//
+// Exported so the daemon registers its route from the same constant the
+// installer writes and matches on. Since #1178 this path *is* the sentinel, so
+// drift between route and installer would not 404 — it would stop recognizing
+// every existing entry as ours.
+const HookEndpointPath = "/api/v1/hooks/claudecode"
 
 // hookSentinel is the substring in the hook entry (curl command or http url)
 // that identifies irrlicht-managed entries. Used by both install (idempotency
@@ -31,7 +36,7 @@ const hookEndpointPath = "/api/v1/hooks/claudecode"
 // It is also a prefix of statuslineSentinel, which is harmless: hook entries
 // and statusLine.command live under disjoint keys of settings.json and are
 // never matched against each other.
-const hookSentinel = hookEndpointPath
+const hookSentinel = HookEndpointPath
 
 // hookEndpointURL is the daemon endpoint the installed hook posts to. Claude
 // Code delivers the hook payload as a JSON POST body directly to this URL via
@@ -41,7 +46,7 @@ const hookSentinel = hookEndpointPath
 // fallback (#488) exists to cover; that fallback is retained (it still covers a
 // down/unreachable daemon), but its primary trigger is now gone.
 func hookEndpointURL() string {
-	return daemonaddr.LocalURL(hookEndpointPath)
+	return daemonaddr.LocalURL(HookEndpointPath)
 }
 
 // hookTimeoutSeconds bounds how long Claude Code waits on the daemon before

--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -10,14 +10,28 @@ import (
 	"path/filepath"
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/pkg/daemonaddr"
 )
+
+// hookEndpointPath is the daemon's Claude Code hook path. Host and port are
+// resolved at install time from the daemon's own bind address, so a daemon on
+// an alternate port installs hooks that reach it rather than whatever owns
+// :7837 (issue #1178).
+const hookEndpointPath = "/api/v1/hooks/claudecode"
 
 // hookSentinel is the substring in the hook entry (curl command or http url)
 // that identifies irrlicht-managed entries. Used by both install (idempotency
-// check) and uninstall, and by the curl→http migration. It is a substring of
-// both the legacy command and the current URL, so a pre-#1161 install is still
-// recognized as ours and upgraded in place.
-const hookSentinel = "localhost:7837/api/v1/hooks/claudecode"
+// check) and uninstall, and by the delivery-form migration. It is deliberately
+// port-independent: a sentinel carrying a port would stop recognizing our own
+// entries the moment the daemon moves, orphaning them and appending a
+// duplicate group instead of upgrading in place (#1178). As the bare endpoint
+// path it is a substring of the legacy curl command, of a pre-#1178 :7837
+// url, and of the current url alike.
+//
+// It is also a prefix of statuslineSentinel, which is harmless: hook entries
+// and statusLine.command live under disjoint keys of settings.json and are
+// never matched against each other.
+const hookSentinel = hookEndpointPath
 
 // hookEndpointURL is the daemon endpoint the installed hook posts to. Claude
 // Code delivers the hook payload as a JSON POST body directly to this URL via
@@ -26,7 +40,9 @@ const hookSentinel = "localhost:7837/api/v1/hooks/claudecode"
 // missing from PATH, which was the failure mode the OpenToolStalled transcript
 // fallback (#488) exists to cover; that fallback is retained (it still covers a
 // down/unreachable daemon), but its primary trigger is now gone.
-const hookEndpointURL = "http://localhost:7837/api/v1/hooks/claudecode"
+func hookEndpointURL() string {
+	return daemonaddr.LocalURL(hookEndpointPath)
+}
 
 // hookTimeoutSeconds bounds how long Claude Code waits on the daemon before
 // giving up on a hook delivery. The daemon's handler is near-instant (an
@@ -103,7 +119,7 @@ func matcherForEvent(event string) string {
 func ourHookEntry() map[string]interface{} {
 	return map[string]interface{}{
 		"type":    "http",
-		"url":     hookEndpointURL,
+		"url":     hookEndpointURL(),
 		"timeout": hookTimeoutSeconds,
 	}
 }
@@ -173,11 +189,15 @@ func writeClaudeSettings(path string, settings map[string]interface{}) error {
 // legacy `command` key. The timeout value is deliberately not part of the
 // identity check, so tuning hookTimeoutSeconds never forces a churny rewrite of
 // every existing install.
+//
+// The url comparison is against the *currently resolved* endpoint, so an entry
+// left behind by a daemon on a different port reads as stale and is rewritten
+// in place by upgradeStaleHookDelivery (#1178).
 func hookEntryIsCanonical(hook map[string]interface{}) bool {
 	if _, hasCmd := hook["command"]; hasCmd {
 		return false
 	}
 	t, _ := hook["type"].(string)
 	u, _ := hook["url"].(string)
-	return t == "http" && u == hookEndpointURL
+	return t == "http" && u == hookEndpointURL()
 }

--- a/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller_test.go
@@ -5,14 +5,27 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"irrlicht/core/pkg/daemonaddr"
 )
 
 // withTempHome overrides $HOME for the duration of the test so that
-// claudeSettingsPath() resolves to a temp directory.
+// claudeSettingsPath() resolves to a temp directory. It also pins the daemon
+// bind address to the default, so the endpoint port the installers resolve
+// (#1178) is the same whatever the developer's shell exports.
 func withTempHome(t *testing.T) string {
 	t.Helper()
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv(daemonaddr.EnvBindAddr, "")
+	return tmp
+}
+
+// withTempHomeOnPort is withTempHome for a daemon bound to an alternate port.
+func withTempHomeOnPort(t *testing.T, bindAddr string) string {
+	t.Helper()
+	tmp := withTempHome(t)
+	t.Setenv(daemonaddr.EnvBindAddr, bindAddr)
 	return tmp
 }
 
@@ -80,8 +93,8 @@ func assertHTTPEntry(t *testing.T, group map[string]interface{}) {
 	if ty, _ := hook["type"].(string); ty != "http" {
 		t.Errorf("type = %q, want %q", ty, "http")
 	}
-	if u, _ := hook["url"].(string); u != hookEndpointURL {
-		t.Errorf("url = %q, want %q", u, hookEndpointURL)
+	if u, _ := hook["url"].(string); u != hookEndpointURL() {
+		t.Errorf("url = %q, want %q", u, hookEndpointURL())
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/hookport_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookport_test.go
@@ -1,0 +1,267 @@
+// hookport_test.go covers issue #1178: the endpoint the Claude Code hook and
+// statusline installers write is resolved from the daemon's bind address, and
+// entries left behind by a daemon on a different port are still recognized as
+// ours and rewritten in place rather than orphaned or double-wrapped.
+package claudecode
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const altBindAddr = "127.0.0.1:7838"
+
+// legacyPortHookURL is the pre-#1178 hard-coded endpoint, used to seed
+// fixtures that simulate an install made by a daemon on the default port.
+const legacyPortHookURL = "http://localhost:7837/api/v1/hooks/claudecode"
+
+// seedSettings writes settings to the temp home's ~/.claude/settings.json.
+func seedSettings(t *testing.T, home string, settings map[string]interface{}) string {
+	t.Helper()
+	path := filepath.Join(home, ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// onlyHookURL returns the url of the single inner hook in the event's single
+// matcher group, failing if the shape is anything else — which is the point:
+// an upgrade must not append a second group.
+func onlyHookURL(t *testing.T, path, event string) string {
+	t.Helper()
+	settings := readJSON(t, path)
+	hooksMap, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("missing hooks map in %s", path)
+	}
+	arr, ok := hooksMap[event].([]interface{})
+	if !ok {
+		t.Fatalf("missing %s array", event)
+	}
+	if len(arr) != 1 {
+		t.Fatalf("expected exactly 1 %s matcher group (in-place upgrade, no append), got %d", event, len(arr))
+	}
+	group := arr[0].(map[string]interface{})
+	inner, ok := group["hooks"].([]interface{})
+	if !ok || len(inner) != 1 {
+		t.Fatalf("expected exactly 1 inner hook, got %v", group["hooks"])
+	}
+	url, _ := inner[0].(map[string]interface{})["url"].(string)
+	return url
+}
+
+func TestHookEndpointURL_FollowsBindAddr(t *testing.T) {
+	t.Setenv("IRRLICHT_BIND_ADDR", "")
+	if got, want := hookEndpointURL(), legacyPortHookURL; got != want {
+		t.Errorf("default: hookEndpointURL() = %q, want %q", got, want)
+	}
+	t.Setenv("IRRLICHT_BIND_ADDR", altBindAddr)
+	if got, want := hookEndpointURL(), "http://localhost:7838/api/v1/hooks/claudecode"; got != want {
+		t.Errorf("alt port: hookEndpointURL() = %q, want %q", got, want)
+	}
+}
+
+// TestEnsureHooksInstalled_UsesResolvedPort is the core of #1178: a daemon on
+// :7838 must install hooks that reach *it*, not whatever owns :7837.
+func TestEnsureHooksInstalled_UsesResolvedPort(t *testing.T) {
+	home := withTempHomeOnPort(t, altBindAddr)
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(home, ".claude", "settings.json")
+	settings := readJSON(t, path)
+	hooksMap := settings["hooks"].(map[string]interface{})
+	for _, event := range installedHookEvents {
+		arr, ok := hooksMap[event].([]interface{})
+		if !ok || len(arr) != 1 {
+			t.Fatalf("event %s: expected 1 matcher group, got %v", event, hooksMap[event])
+		}
+		assertHTTPEntry(t, arr[0].(map[string]interface{}))
+		if url := onlyHookURL(t, path, event); !strings.Contains(url, ":7838/") {
+			t.Errorf("event %s: url = %q, want the resolved :7838 port", event, url)
+		}
+	}
+
+	// Idempotent on the same port.
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modified {
+		t.Error("second install on the same port: got modified=true, want false")
+	}
+}
+
+// TestEnsureHooksInstalled_UpgradesDefaultPortInstallInPlace is the
+// back-compat requirement: an existing :7837 entry must still be recognized as
+// ours (the sentinel is port-independent) and rewritten in place to the
+// resolved port — not left orphaned with a duplicate group appended.
+func TestEnsureHooksInstalled_UpgradesDefaultPortInstallInPlace(t *testing.T) {
+	home := withTempHomeOnPort(t, altBindAddr)
+	path := seedSettings(t, home, map[string]interface{}{
+		"hooks": map[string]interface{}{
+			HookPostToolUse: []interface{}{
+				map[string]interface{}{
+					"matcher": hookMatcher,
+					"hooks": []interface{}{
+						map[string]interface{}{
+							"type":    "http",
+							"url":     legacyPortHookURL,
+							"timeout": hookTimeoutSeconds,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true when repointing a :7837 install at the resolved port")
+	}
+	if got, want := onlyHookURL(t, path, HookPostToolUse), hookEndpointURL(); got != want {
+		t.Errorf("url = %q, want %q", got, want)
+	}
+}
+
+// TestEnsureHooksInstalled_UpgradesLegacyCurlOnAltPort pins that the pre-#1161
+// curl form still migrates when the daemon is on a non-default port — the
+// sentinel has to match a command carrying a *different* port than the one we
+// are about to install.
+func TestEnsureHooksInstalled_UpgradesLegacyCurlOnAltPort(t *testing.T) {
+	home := withTempHomeOnPort(t, altBindAddr)
+	path := seedSettings(t, home, map[string]interface{}{
+		"hooks": map[string]interface{}{
+			HookPostToolUse: []interface{}{makeHookGroup(legacyMatcher, legacyCurlHookCommand)},
+		},
+	})
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := onlyHookURL(t, path, HookPostToolUse), hookEndpointURL(); got != want {
+		t.Errorf("url = %q, want %q", got, want)
+	}
+}
+
+// TestUninstallHooks_RemovesDefaultPortInstall pins that uninstall is not
+// port-scoped: a daemon on :7838 must still clean up entries written by one on
+// :7837, or `irrlichd --uninstall-hooks` would leave junk behind.
+func TestUninstallHooks_RemovesDefaultPortInstall(t *testing.T) {
+	home := withTempHomeOnPort(t, altBindAddr)
+	path := seedSettings(t, home, map[string]interface{}{
+		"hooks": map[string]interface{}{
+			HookPostToolUse: []interface{}{
+				map[string]interface{}{
+					"matcher": hookMatcher,
+					"hooks": []interface{}{
+						map[string]interface{}{"type": "http", "url": legacyPortHookURL},
+					},
+				},
+			},
+		},
+	})
+
+	modified, err := UninstallHooks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true removing a :7837 install from a :7838 daemon")
+	}
+	settings := readJSON(t, path)
+	hooksMap, _ := settings["hooks"].(map[string]interface{})
+	if _, still := hooksMap[HookPostToolUse]; still {
+		t.Errorf("%s entry survived uninstall: %v", HookPostToolUse, hooksMap[HookPostToolUse])
+	}
+}
+
+func TestInstalledStatuslineCommand_FollowsBindAddr(t *testing.T) {
+	t.Setenv("IRRLICHT_BIND_ADDR", altBindAddr)
+	if got := installedStatuslineCommand(); !strings.Contains(got, "http://localhost:7838/api/v1/hooks/claudecode/statusline") {
+		t.Errorf("statusline command = %q, want the resolved :7838 endpoint", got)
+	}
+}
+
+// TestChainStatuslineCommand_RewritesDefaultPortStandalone: a bare :7837
+// install is ours (port-independent sentinel), so it must be rewritten to the
+// resolved port rather than mistaken for a third-party command and wrapped.
+func TestChainStatuslineCommand_RewritesDefaultPortStandalone(t *testing.T) {
+	t.Setenv("IRRLICHT_BIND_ADDR", altBindAddr)
+	stale := "curl -fsS --max-time 1 -X POST --data-binary @- " +
+		"http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true"
+
+	got := chainStatuslineCommand(stale)
+	if got != installedStatuslineCommand() {
+		t.Errorf("expected rewrite to the resolved port, got %q", got)
+	}
+}
+
+// TestChainStatuslineCommand_RepointsWrapPreservingUserCommand is the
+// regression this issue's v3-unchain rework guards: a wrap written on one port
+// must unwind structurally on another, so the user's own statusline command
+// survives the repoint instead of being clobbered by the standalone install.
+func TestChainStatuslineCommand_RepointsWrapPreservingUserCommand(t *testing.T) {
+	user := "/usr/local/bin/my-statusline --foo"
+
+	t.Setenv("IRRLICHT_BIND_ADDR", "")
+	wrappedOnDefault := chainStatuslineCommand(user)
+	if !strings.Contains(wrappedOnDefault, ":7837/") {
+		t.Fatalf("fixture should carry the default port, got %q", wrappedOnDefault)
+	}
+
+	t.Setenv("IRRLICHT_BIND_ADDR", altBindAddr)
+	got := chainStatuslineCommand(wrappedOnDefault)
+	if !strings.Contains(got, user) {
+		t.Errorf("user command lost on repoint: %q", got)
+	}
+	if !strings.Contains(got, ":7838/") {
+		t.Errorf("expected the resolved :7838 port after repoint, got %q", got)
+	}
+	if strings.Contains(got, ":7837/") {
+		t.Errorf("stale :7837 endpoint survived the repoint: %q", got)
+	}
+	if u := unchainStatuslineCommand(got); u != user {
+		t.Errorf("repointed wrap does not round-trip: got %q want %q", u, user)
+	}
+}
+
+// TestUninstallStatusline_RestoresUserCommandFromDefaultPortWrap pins the
+// same structural unchain on the uninstall side.
+func TestUninstallStatusline_RestoresUserCommandFromDefaultPortWrap(t *testing.T) {
+	user := "/usr/local/bin/my-statusline --foo"
+
+	home := withTempHome(t)
+	wrappedOnDefault := chainStatuslineCommand(user)
+	path := seedSettings(t, home, map[string]interface{}{
+		"statusLine": map[string]interface{}{"type": "command", "command": wrappedOnDefault},
+	})
+
+	t.Setenv("IRRLICHT_BIND_ADDR", altBindAddr)
+	modified, err := UninstallStatusline()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true uninstalling a :7837 wrap from a :7838 daemon")
+	}
+	if got := readStatuslineCommand(readJSON(t, path)); got != user {
+		t.Errorf("statusLine.command = %q, want the user's original %q", got, user)
+	}
+}

--- a/core/adapters/inbound/agents/claudecode/hookport_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookport_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"irrlicht/core/pkg/daemonaddr"
 )
 
 const altBindAddr = "127.0.0.1:7838"
@@ -62,11 +64,11 @@ func onlyHookURL(t *testing.T, path, event string) string {
 }
 
 func TestHookEndpointURL_FollowsBindAddr(t *testing.T) {
-	t.Setenv("IRRLICHT_BIND_ADDR", "")
+	t.Setenv(daemonaddr.EnvBindAddr, "")
 	if got, want := hookEndpointURL(), legacyPortHookURL; got != want {
 		t.Errorf("default: hookEndpointURL() = %q, want %q", got, want)
 	}
-	t.Setenv("IRRLICHT_BIND_ADDR", altBindAddr)
+	t.Setenv(daemonaddr.EnvBindAddr, altBindAddr)
 	if got, want := hookEndpointURL(), "http://localhost:7838/api/v1/hooks/claudecode"; got != want {
 		t.Errorf("alt port: hookEndpointURL() = %q, want %q", got, want)
 	}
@@ -89,10 +91,9 @@ func TestEnsureHooksInstalled_UsesResolvedPort(t *testing.T) {
 		if !ok || len(arr) != 1 {
 			t.Fatalf("event %s: expected 1 matcher group, got %v", event, hooksMap[event])
 		}
+		// assertHTTPEntry compares against hookEndpointURL(), which under
+		// altBindAddr is the :7838 form — so this pins the resolved port too.
 		assertHTTPEntry(t, arr[0].(map[string]interface{}))
-		if url := onlyHookURL(t, path, event); !strings.Contains(url, ":7838/") {
-			t.Errorf("event %s: url = %q, want the resolved :7838 port", event, url)
-		}
 	}
 
 	// Idempotent on the same port.
@@ -193,7 +194,7 @@ func TestUninstallHooks_RemovesDefaultPortInstall(t *testing.T) {
 }
 
 func TestInstalledStatuslineCommand_FollowsBindAddr(t *testing.T) {
-	t.Setenv("IRRLICHT_BIND_ADDR", altBindAddr)
+	t.Setenv(daemonaddr.EnvBindAddr, altBindAddr)
 	if got := installedStatuslineCommand(); !strings.Contains(got, "http://localhost:7838/api/v1/hooks/claudecode/statusline") {
 		t.Errorf("statusline command = %q, want the resolved :7838 endpoint", got)
 	}
@@ -203,10 +204,10 @@ func TestInstalledStatuslineCommand_FollowsBindAddr(t *testing.T) {
 // install is ours (port-independent sentinel), so it must be rewritten to the
 // resolved port rather than mistaken for a third-party command and wrapped.
 func TestChainStatuslineCommand_RewritesDefaultPortStandalone(t *testing.T) {
-	t.Setenv("IRRLICHT_BIND_ADDR", altBindAddr)
-	stale := "curl -fsS --max-time 1 -X POST --data-binary @- " +
-		"http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true"
+	t.Setenv(daemonaddr.EnvBindAddr, "")
+	stale := installedStatuslineCommand() // what a :7837 daemon installed
 
+	t.Setenv(daemonaddr.EnvBindAddr, altBindAddr)
 	got := chainStatuslineCommand(stale)
 	if got != installedStatuslineCommand() {
 		t.Errorf("expected rewrite to the resolved port, got %q", got)
@@ -220,13 +221,13 @@ func TestChainStatuslineCommand_RewritesDefaultPortStandalone(t *testing.T) {
 func TestChainStatuslineCommand_RepointsWrapPreservingUserCommand(t *testing.T) {
 	user := "/usr/local/bin/my-statusline --foo"
 
-	t.Setenv("IRRLICHT_BIND_ADDR", "")
+	t.Setenv(daemonaddr.EnvBindAddr, "")
 	wrappedOnDefault := chainStatuslineCommand(user)
 	if !strings.Contains(wrappedOnDefault, ":7837/") {
 		t.Fatalf("fixture should carry the default port, got %q", wrappedOnDefault)
 	}
 
-	t.Setenv("IRRLICHT_BIND_ADDR", altBindAddr)
+	t.Setenv(daemonaddr.EnvBindAddr, altBindAddr)
 	got := chainStatuslineCommand(wrappedOnDefault)
 	if !strings.Contains(got, user) {
 		t.Errorf("user command lost on repoint: %q", got)
@@ -242,6 +243,23 @@ func TestChainStatuslineCommand_RepointsWrapPreservingUserCommand(t *testing.T) 
 	}
 }
 
+// TestChainStatuslineCommand_LeavesForeignTeePipelineWhole guards the other
+// edge of the structural unchain: a third-party command that happens to look
+// like a wrap but carries none of our sentinel must be wrapped whole, not
+// mistaken for one of ours and truncated to its first half.
+func TestChainStatuslineCommand_LeavesForeignTeePipelineWhole(t *testing.T) {
+	t.Setenv(daemonaddr.EnvBindAddr, "")
+	foreign := `tee >(/usr/local/bin/log) | curl -s https://example.invalid/statusline`
+
+	got := chainStatuslineCommand(foreign)
+	if !strings.Contains(got, foreign) {
+		t.Errorf("foreign tee|curl pipeline was not preserved whole: %q", got)
+	}
+	if u := unchainStatuslineCommand(got); u != foreign {
+		t.Errorf("wrapped foreign command does not round-trip: got %q want %q", u, foreign)
+	}
+}
+
 // TestUninstallStatusline_RestoresUserCommandFromDefaultPortWrap pins the
 // same structural unchain on the uninstall side.
 func TestUninstallStatusline_RestoresUserCommandFromDefaultPortWrap(t *testing.T) {
@@ -253,7 +271,7 @@ func TestUninstallStatusline_RestoresUserCommandFromDefaultPortWrap(t *testing.T
 		"statusLine": map[string]interface{}{"type": "command", "command": wrappedOnDefault},
 	})
 
-	t.Setenv("IRRLICHT_BIND_ADDR", altBindAddr)
+	t.Setenv(daemonaddr.EnvBindAddr, altBindAddr)
 	modified, err := UninstallStatusline()
 	if err != nil {
 		t.Fatal(err)

--- a/core/adapters/inbound/agents/claudecode/statusline_installer.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_installer.go
@@ -12,30 +12,30 @@ import (
 	"irrlicht/core/pkg/daemonaddr"
 )
 
-// unchainBoundary matches the boundary between the user's tee-fed
-// command and the trailing curl pipeline in the legacy v1/v2 wrap format.
-// Whitespace-tolerant so a hand-edited wrap with extra spaces still
-// round-trips through unchainStatuslineCommand.
-var unchainBoundary = regexp.MustCompile(`\)\s*\|\s*curl\s`)
-
-// wrapPipeBoundary matches the `) | ` that closes the process substitution in
-// a v3 wrap and opens the rest of the pipeline. Whitespace-tolerant for the
-// same reason as unchainBoundary.
+// wrapPipeBoundary matches the `) | ` that closes the `tee >(…)` process
+// substitution and opens the rest of the pipeline, in every wrap format we
+// have shipped. Whitespace-tolerant so a hand-edited wrap with extra spaces
+// still round-trips through unchainStatuslineCommand. It is the read half of
+// wrapPipe below — keep the two in step.
 var wrapPipeBoundary = regexp.MustCompile(`\)\s*\|\s*`)
 
-// v3WrapOpen is the fixed opening literal of the current wrap format. Only the
-// opening is fixed: the curl command that follows carries the resolved daemon
-// port (#1178), so a v3 wrap is recognized structurally — see unchainV3 —
-// rather than by matching a full literal prefix.
-const v3WrapOpen = `bash -c 'tee >(`
+// bashEnvelopeOpen / teeSubOpen / wrapPipe are the fixed parts of the current
+// wrap format, `bash -c 'tee >(<our curl>) | <user command>'`. Everything
+// between them varies: our curl carries the resolved daemon port (#1178) and
+// the user's command is arbitrary, so unchainStatuslineCommand recognises a
+// wrap by these anchors plus which side of the pipe our sentinel lands on —
+// never by a longer literal prefix.
+const (
+	bashEnvelopeOpen = `bash -c '`
+	teeSubOpen       = `tee >(`
+	wrapPipe         = `) | `
+)
 
-// v3WrapPipe is the literal separating our curl process substitution from the
-// user's command in a v3 wrap.
-const v3WrapPipe = `) | `
-
-// statuslineEndpointPath is the daemon's statusline ingest path. Host and port
+// StatuslineEndpointPath is the daemon's statusline ingest path. Host and port
 // are resolved at install time from the daemon's own bind address (#1178).
-const statuslineEndpointPath = "/api/v1/hooks/claudecode/statusline"
+// Exported so the daemon's route comes from the same constant the installer
+// writes — see HookEndpointPath for why drift matters.
+const StatuslineEndpointPath = "/api/v1/hooks/claudecode/statusline"
 
 // statuslineSentinel is the substring that identifies an irrlicht-managed
 // statusline command. Used for idempotency checks and chained-command
@@ -43,7 +43,7 @@ const statuslineEndpointPath = "/api/v1/hooks/claudecode/statusline"
 // installed by a daemon on one port must still be recognized — and rewritten
 // in place — by a daemon on another, rather than being mistaken for a
 // third-party command and wrapped a second time (#1178).
-const statuslineSentinel = statuslineEndpointPath
+const statuslineSentinel = StatuslineEndpointPath
 
 // installedStatuslineCommand is the canonical statusLine.command we install.
 // Reads the statusline JSON from stdin, POSTs it to the daemon, then echoes
@@ -58,7 +58,7 @@ const statuslineSentinel = statuslineEndpointPath
 //   - || true: don't surface non-zero exit (e.g. daemon down) to Claude Code
 func installedStatuslineCommand() string {
 	return "curl -fsS --max-time 1 -X POST --data-binary @- " +
-		daemonaddr.LocalURL(statuslineEndpointPath) + " >/dev/null 2>&1 || true"
+		daemonaddr.LocalURL(StatuslineEndpointPath) + " >/dev/null 2>&1 || true"
 }
 
 // EnsureStatuslineInstalled adds (or upgrades) the statusLine.command entry
@@ -204,70 +204,58 @@ func chainStatuslineCommand(current string) string {
 // runs last so its stdout reaches Claude Code directly.
 func wrapStatuslineCommand(user string) string {
 	escaped := strings.ReplaceAll(user, "'", `'\''`)
-	return v3WrapOpen + installedStatuslineCommand() + v3WrapPipe + escaped + `'`
+	return bashEnvelopeOpen + teeSubOpen + installedStatuslineCommand() + wrapPipe + escaped + `'`
 }
 
 // unchainStatuslineCommand returns the user's original command when current
-// was a chained wrap, or "" otherwise (standalone install, unknown shape).
+// was a chained wrap of ours, or "" otherwise (standalone install, unknown
+// shape, or a command that isn't ours at all).
 //
-// Recognises three wrap formats:
-//   - v3 (current):  `bash -c 'tee >(<curl+sentinel>) | <user>'`
+// Every wrap we have shipped is `[bash -c ']tee >(A) | B`, differing only in
+// which half holds the user's command:
+//
+//   - v3 (current):  `bash -c 'tee >(<our curl>) | <user>'`
 //   - v2 (legacy):   `bash -c 'tee >(<user>) | curl … sentinel … || true'`
 //   - v1 (broken):   `tee >(<user>) | curl … sentinel … || true`
 //
+// So one parse handles all three: strip the optional `bash -c '…'` envelope
+// and the `tee >(` opener, split on the first pipe boundary, and take whichever
+// half does *not* carry our sentinel. Deciding by sentinel side rather than by
+// a literal prefix is what lets a wrap written by a daemon on one port unwind
+// under another — our curl carries the resolved port (#1178), so a prefix match
+// would fail and silently drop the user's command on a repoint.
+//
 // v1 and v2 are still recognised for migration; new installs always emit v3.
 func unchainStatuslineCommand(current string) string {
-	if user, ok := unchainV3(current); ok {
-		return user
+	// Not ours at all — a third-party `tee >(x) | curl y` must be left whole
+	// for chainStatuslineCommand to wrap, not truncated to its first half.
+	if !strings.Contains(current, statuslineSentinel) {
+		return ""
 	}
-	return unchainLegacyWrap(current)
-}
-
-// unchainV3 recovers the user's command from a v3 wrap:
-//
-//	bash -c 'tee >(<our curl>) | <user>'
-//
-// Detection is structural rather than a full literal-prefix match, because our
-// curl carries the resolved daemon port — a wrap written by a daemon on one
-// port must still unwind under another, or the user's command would be
-// silently dropped when the port changes (#1178). What separates v3 from the
-// v2 wrap (`bash -c 'tee >(<user>) | curl … sentinel …'`) is which side of the
-// pipe our sentinel sits on: left for v3, right for v2.
-func unchainV3(current string) (string, bool) {
-	if !strings.HasPrefix(current, v3WrapOpen) || !strings.HasSuffix(current, "'") {
-		return "", false
-	}
-	rest := current[len(v3WrapOpen) : len(current)-1]
-	loc := wrapPipeBoundary.FindStringIndex(rest)
-	if loc == nil || !strings.Contains(rest[:loc[0]], statuslineSentinel) {
-		return "", false
-	}
-	return strings.ReplaceAll(rest[loc[1]:], `'\''`, "'"), true
-}
-
-// unchainLegacyWrap recovers the user's command from a v1 or v2 wrap, where
-// the user's command sits before the `) | curl ` boundary. Returns "" when
-// current is neither shape.
-func unchainLegacyWrap(current string) string {
-	for _, prefix := range []string{`bash -c 'tee >(`, `tee >(`} {
-		if !strings.HasPrefix(current, prefix) {
-			continue
+	body := current
+	if envelope := strings.TrimPrefix(body, bashEnvelopeOpen); envelope != body {
+		if !strings.HasSuffix(envelope, `'`) {
+			return ""
 		}
-		rest := current[len(prefix):]
-		// Whitespace-tolerant match for `) | curl ` so a hand-edited
-		// wrap (e.g. with extra spaces around the pipe) still unwinds
-		// cleanly. The first match wins — user commands containing a
-		// literal ") | curl " inside their own command would still
-		// round-trip wrong, but that's a pathological case.
-		loc := unchainBoundary.FindStringIndex(rest)
-		if loc == nil {
-			continue
-		}
-		inner := rest[:loc[0]]
-		// Reverse the single-quote escaping for v2 wraps; v1 wraps were
-		// never escaped, but the replace is a safe no-op when no escapes
-		// are present.
-		return strings.ReplaceAll(inner, `'\''`, "'")
+		body = envelope[:len(envelope)-1]
 	}
-	return ""
+	if !strings.HasPrefix(body, teeSubOpen) {
+		return "" // standalone install — no user command to preserve
+	}
+	body = body[len(teeSubOpen):]
+	// The first boundary is always the one closing `tee >(`: our curl contains
+	// no ")". A user command containing a literal ") | " round-trips wrong only
+	// when it is the one inside the process substitution (v1/v2), which is the
+	// same pathological case this has always had.
+	loc := wrapPipeBoundary.FindStringIndex(body)
+	if loc == nil {
+		return ""
+	}
+	user := body[:loc[0]]
+	if strings.Contains(user, statuslineSentinel) {
+		user = body[loc[1]:] // v3: ours is in the process sub, theirs follows
+	}
+	// Reverse the single-quote escaping applied by wrapStatuslineCommand. v1
+	// wraps were never escaped, but the replace is a safe no-op there.
+	return strings.ReplaceAll(user, `'\''`, "'")
 }

--- a/core/adapters/inbound/agents/claudecode/statusline_installer.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_installer.go
@@ -8,6 +8,8 @@ package claudecode
 import (
 	"regexp"
 	"strings"
+
+	"irrlicht/core/pkg/daemonaddr"
 )
 
 // unchainBoundary matches the boundary between the user's tee-fed
@@ -16,15 +18,32 @@ import (
 // round-trips through unchainStatuslineCommand.
 var unchainBoundary = regexp.MustCompile(`\)\s*\|\s*curl\s`)
 
-// v3WrapPrefix is the fixed leading literal of the current wrap format.
-// The user's command follows immediately after this prefix and is
-// terminated by a closing single quote.
-const v3WrapPrefix = `bash -c 'tee >(` + installedStatuslineCommand + `) | `
+// wrapPipeBoundary matches the `) | ` that closes the process substitution in
+// a v3 wrap and opens the rest of the pipeline. Whitespace-tolerant for the
+// same reason as unchainBoundary.
+var wrapPipeBoundary = regexp.MustCompile(`\)\s*\|\s*`)
+
+// v3WrapOpen is the fixed opening literal of the current wrap format. Only the
+// opening is fixed: the curl command that follows carries the resolved daemon
+// port (#1178), so a v3 wrap is recognized structurally — see unchainV3 —
+// rather than by matching a full literal prefix.
+const v3WrapOpen = `bash -c 'tee >(`
+
+// v3WrapPipe is the literal separating our curl process substitution from the
+// user's command in a v3 wrap.
+const v3WrapPipe = `) | `
+
+// statuslineEndpointPath is the daemon's statusline ingest path. Host and port
+// are resolved at install time from the daemon's own bind address (#1178).
+const statuslineEndpointPath = "/api/v1/hooks/claudecode/statusline"
 
 // statuslineSentinel is the substring that identifies an irrlicht-managed
 // statusline command. Used for idempotency checks and chained-command
-// upgrades.
-const statuslineSentinel = "localhost:7837/api/v1/hooks/claudecode/statusline"
+// upgrades. Port-independent for the same reason as hookSentinel: a command
+// installed by a daemon on one port must still be recognized — and rewritten
+// in place — by a daemon on another, rather than being mistaken for a
+// third-party command and wrapped a second time (#1178).
+const statuslineSentinel = statuslineEndpointPath
 
 // installedStatuslineCommand is the canonical statusLine.command we install.
 // Reads the statusline JSON from stdin, POSTs it to the daemon, then echoes
@@ -37,8 +56,10 @@ const statuslineSentinel = "localhost:7837/api/v1/hooks/claudecode/statusline"
 //   - -fsS  : fail silently on HTTP errors, but show curl errors on stderr
 //   - --max-time 1 : abort if the daemon is unreachable, keeps statusline snappy
 //   - || true: don't surface non-zero exit (e.g. daemon down) to Claude Code
-const installedStatuslineCommand = "curl -fsS --max-time 1 -X POST --data-binary @- " +
-	"http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true"
+func installedStatuslineCommand() string {
+	return "curl -fsS --max-time 1 -X POST --data-binary @- " +
+		daemonaddr.LocalURL(statuslineEndpointPath) + " >/dev/null 2>&1 || true"
+}
 
 // EnsureStatuslineInstalled adds (or upgrades) the statusLine.command entry
 // in ~/.claude/settings.json. Returns true when the file was modified.
@@ -155,8 +176,9 @@ func writeStatuslineCommand(settings map[string]interface{}, cmd string) {
 // tee pipeline; v2: user command in the process sub) are migrated on the
 // next daemon start via unchainStatuslineCommand + re-chain.
 func chainStatuslineCommand(current string) string {
-	if current == "" || current == installedStatuslineCommand {
-		return installedStatuslineCommand
+	canonical := installedStatuslineCommand()
+	if current == "" || current == canonical {
+		return canonical
 	}
 	// If current is already a managed wrap (old or new format), unchain to
 	// recover the user's original command, then re-chain in the canonical
@@ -168,7 +190,7 @@ func chainStatuslineCommand(current string) string {
 	}
 	if strings.Contains(current, statuslineSentinel) {
 		// Managed standalone — no user command to preserve. Force canonical.
-		return installedStatuslineCommand
+		return canonical
 	}
 	// Pure user command — wrap it.
 	return wrapStatuslineCommand(current)
@@ -182,7 +204,7 @@ func chainStatuslineCommand(current string) string {
 // runs last so its stdout reaches Claude Code directly.
 func wrapStatuslineCommand(user string) string {
 	escaped := strings.ReplaceAll(user, "'", `'\''`)
-	return v3WrapPrefix + escaped + `'`
+	return v3WrapOpen + installedStatuslineCommand() + v3WrapPipe + escaped + `'`
 }
 
 // unchainStatuslineCommand returns the user's original command when current
@@ -195,15 +217,38 @@ func wrapStatuslineCommand(user string) string {
 //
 // v1 and v2 are still recognised for migration; new installs always emit v3.
 func unchainStatuslineCommand(current string) string {
-	// v3: user command follows the fixed curl-in-sub prefix and a closing quote.
-	// Note: v2 also ends with "'" (its bash -c closing quote), but v2 starts
-	// with `bash -c 'tee >(user`, not `bash -c 'tee >(curl`, so the HasPrefix
-	// check is unambiguous.
-	if strings.HasPrefix(current, v3WrapPrefix) && strings.HasSuffix(current, "'") {
-		inner := current[len(v3WrapPrefix) : len(current)-1]
-		return strings.ReplaceAll(inner, `'\''`, "'")
+	if user, ok := unchainV3(current); ok {
+		return user
 	}
-	// v1/v2: user command is before the `) | curl ` boundary.
+	return unchainLegacyWrap(current)
+}
+
+// unchainV3 recovers the user's command from a v3 wrap:
+//
+//	bash -c 'tee >(<our curl>) | <user>'
+//
+// Detection is structural rather than a full literal-prefix match, because our
+// curl carries the resolved daemon port — a wrap written by a daemon on one
+// port must still unwind under another, or the user's command would be
+// silently dropped when the port changes (#1178). What separates v3 from the
+// v2 wrap (`bash -c 'tee >(<user>) | curl … sentinel …'`) is which side of the
+// pipe our sentinel sits on: left for v3, right for v2.
+func unchainV3(current string) (string, bool) {
+	if !strings.HasPrefix(current, v3WrapOpen) || !strings.HasSuffix(current, "'") {
+		return "", false
+	}
+	rest := current[len(v3WrapOpen) : len(current)-1]
+	loc := wrapPipeBoundary.FindStringIndex(rest)
+	if loc == nil || !strings.Contains(rest[:loc[0]], statuslineSentinel) {
+		return "", false
+	}
+	return strings.ReplaceAll(rest[loc[1]:], `'\''`, "'"), true
+}
+
+// unchainLegacyWrap recovers the user's command from a v1 or v2 wrap, where
+// the user's command sits before the `) | curl ` boundary. Returns "" when
+// current is neither shape.
+func unchainLegacyWrap(current string) string {
 	for _, prefix := range []string{`bash -c 'tee >(`, `tee >(`} {
 		if !strings.HasPrefix(current, prefix) {
 			continue

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -136,14 +136,14 @@ func TestStatuslineHandler_SampledAtUsesClock(t *testing.T) {
 
 func TestChainStatuslineCommand_BareInstall(t *testing.T) {
 	got := chainStatuslineCommand("")
-	if got != installedStatuslineCommand {
+	if got != installedStatuslineCommand() {
 		t.Errorf("expected canonical command on empty input, got %q", got)
 	}
 }
 
 func TestChainStatuslineCommand_IdempotentOnCanonical(t *testing.T) {
-	got := chainStatuslineCommand(installedStatuslineCommand)
-	if got != installedStatuslineCommand {
+	got := chainStatuslineCommand(installedStatuslineCommand())
+	if got != installedStatuslineCommand() {
 		t.Errorf("expected idempotency, got %q", got)
 	}
 }
@@ -165,7 +165,7 @@ func TestChainStatuslineCommand_WrapsThirdPartyCommand(t *testing.T) {
 func TestChainStatuslineCommand_RewritesStaleManagedForm(t *testing.T) {
 	stale := "curl --silent " + statuslineSentinel + " /old"
 	got := chainStatuslineCommand(stale)
-	if got != installedStatuslineCommand {
+	if got != installedStatuslineCommand() {
 		t.Errorf("expected stale managed command to be rewritten to canonical, got %q", got)
 	}
 }
@@ -179,7 +179,7 @@ func TestUnchainStatuslineCommand_RoundTripsUserCommand(t *testing.T) {
 }
 
 func TestUnchainStatuslineCommand_StandaloneReturnsEmpty(t *testing.T) {
-	if got := unchainStatuslineCommand(installedStatuslineCommand); got != "" {
+	if got := unchainStatuslineCommand(installedStatuslineCommand()); got != "" {
 		t.Errorf("expected empty for standalone install, got %q", got)
 	}
 }
@@ -256,7 +256,7 @@ func TestChainStatuslineCommand_MigratesOldWrapsToV3(t *testing.T) {
 		`http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true'`
 	for _, old := range []string{v1, v2} {
 		got := chainStatuslineCommand(old)
-		if !strings.HasPrefix(got, v3WrapPrefix) {
+		if !strings.HasPrefix(got, v3WrapOpen+installedStatuslineCommand()+v3WrapPipe) {
 			t.Errorf("expected v3 form after migration, got %q", got)
 		}
 		if !strings.Contains(got, userCmd) {

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -256,7 +256,7 @@ func TestChainStatuslineCommand_MigratesOldWrapsToV3(t *testing.T) {
 		`http://localhost:7837/api/v1/hooks/claudecode/statusline >/dev/null 2>&1 || true'`
 	for _, old := range []string{v1, v2} {
 		got := chainStatuslineCommand(old)
-		if !strings.HasPrefix(got, v3WrapOpen+installedStatuslineCommand()+v3WrapPipe) {
+		if !strings.HasPrefix(got, bashEnvelopeOpen+teeSubOpen+installedStatuslineCommand()+wrapPipe) {
 			t.Errorf("expected v3 form after migration, got %q", got)
 		}
 		if !strings.Contains(got, userCmd) {

--- a/core/adapters/inbound/agents/codex/agent.go
+++ b/core/adapters/inbound/agents/codex/agent.go
@@ -69,7 +69,7 @@ func Agent() agent.Agent {
 				Touches:         "Writes hook entries to ~/.codex/hooks.json",
 				Detail: "Adds PermissionRequest, PostToolUse and Stop hooks to " +
 					"~/.codex/hooks.json (a dedicated file, never config.toml) that " +
-					"POST the hook payload to the local daemon at " + hookEndpointURL +
+					"POST the hook payload to the local daemon at " + hookEndpointURL() +
 					" via curl. PermissionRequest drives a live waiting transition " +
 					"the moment an approval prompt appears; Stop carries the final " +
 					"assistant message for turn-end. Install is version-gated on the " +

--- a/core/adapters/inbound/agents/codex/hookinstaller.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller.go
@@ -16,22 +16,37 @@ import (
 	"strings"
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/pkg/daemonaddr"
 )
+
+// hookEndpointPath is the daemon's Codex hook path. Host and port are resolved
+// at install time from the daemon's own bind address, so a daemon on an
+// alternate port installs hooks that reach it rather than whatever owns :7837
+// (issue #1178).
+const hookEndpointPath = "/api/v1/hooks/codex"
 
 // hookSentinel is the substring in a hook entry's curl command that identifies
 // irrlicht-managed entries. Used by both install (idempotency) and uninstall.
-const hookSentinel = "localhost:7837/api/v1/hooks/codex"
+// Deliberately port-independent: a sentinel carrying a port would stop
+// recognizing our own entries the moment the daemon moves, orphaning them and
+// appending a duplicate group instead of upgrading in place. As the bare
+// endpoint path it still matches a pre-#1178 :7837 command.
+const hookSentinel = hookEndpointPath
 
 // hookEndpointURL is the daemon endpoint the installed hook posts to. Codex
 // execs the curl command below with the hook payload on stdin (Codex has no
 // native http-delivery hook like Claude Code's, so a curl command is used).
-const hookEndpointURL = "http://localhost:7837/api/v1/hooks/codex"
+func hookEndpointURL() string {
+	return daemonaddr.LocalURL(hookEndpointPath)
+}
 
 // hookDeliveryCommand is the shell command Codex runs for each installed hook.
 // It streams the payload (stdin, @-) to the daemon and never fails the turn
 // (|| true): a down/unreachable daemon fails the connection fast, well under
 // the --max-time ceiling, and the transcript path still covers turn-end.
-const hookDeliveryCommand = "curl -fsS --max-time 1 -X POST --data-binary @- " + hookEndpointURL + " || true"
+func hookDeliveryCommand() string {
+	return "curl -fsS --max-time 1 -X POST --data-binary @- " + hookEndpointURL() + " || true"
+}
 
 // hookTimeoutSeconds bounds how long Codex waits on the hook command. The
 // daemon's handler is near-instant (a map write plus a channel send); this is
@@ -78,7 +93,7 @@ func matcherForEvent(event string) string {
 func ourHookEntry() map[string]interface{} {
 	return map[string]interface{}{
 		"type":    "command",
-		"command": hookDeliveryCommand,
+		"command": hookDeliveryCommand(),
 		"timeout": hookTimeoutSeconds,
 	}
 }
@@ -295,8 +310,12 @@ func atomicWriteFile(path string, data []byte) error {
 // current canonical form: type "command" with our exact delivery command. The
 // timeout value is deliberately excluded from the identity check so tuning
 // hookTimeoutSeconds never forces a churny rewrite of every existing install.
+//
+// The command comparison is against the *currently resolved* endpoint, so an
+// entry left behind by a daemon on a different port reads as stale and is
+// rewritten in place by upgradeStaleHookCommand (#1178).
 func hookEntryIsCanonical(hook map[string]interface{}) bool {
 	t, _ := hook["type"].(string)
 	cmd, _ := hook["command"].(string)
-	return t == "command" && cmd == hookDeliveryCommand
+	return t == "command" && cmd == hookDeliveryCommand()
 }

--- a/core/adapters/inbound/agents/codex/hookinstaller.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller.go
@@ -19,11 +19,13 @@ import (
 	"irrlicht/core/pkg/daemonaddr"
 )
 
-// hookEndpointPath is the daemon's Codex hook path. Host and port are resolved
+// HookEndpointPath is the daemon's Codex hook path. Host and port are resolved
 // at install time from the daemon's own bind address, so a daemon on an
 // alternate port installs hooks that reach it rather than whatever owns :7837
-// (issue #1178).
-const hookEndpointPath = "/api/v1/hooks/codex"
+// (issue #1178). Exported so the daemon's route comes from the same constant
+// the installer writes and matches on — since #1178 this path *is* the
+// sentinel, so drift would orphan every existing entry rather than 404.
+const HookEndpointPath = "/api/v1/hooks/codex"
 
 // hookSentinel is the substring in a hook entry's curl command that identifies
 // irrlicht-managed entries. Used by both install (idempotency) and uninstall.
@@ -31,13 +33,13 @@ const hookEndpointPath = "/api/v1/hooks/codex"
 // recognizing our own entries the moment the daemon moves, orphaning them and
 // appending a duplicate group instead of upgrading in place. As the bare
 // endpoint path it still matches a pre-#1178 :7837 command.
-const hookSentinel = hookEndpointPath
+const hookSentinel = HookEndpointPath
 
 // hookEndpointURL is the daemon endpoint the installed hook posts to. Codex
 // execs the curl command below with the hook payload on stdin (Codex has no
 // native http-delivery hook like Claude Code's, so a curl command is used).
 func hookEndpointURL() string {
-	return daemonaddr.LocalURL(hookEndpointPath)
+	return daemonaddr.LocalURL(HookEndpointPath)
 }
 
 // hookDeliveryCommand is the shell command Codex runs for each installed hook.

--- a/core/adapters/inbound/agents/codex/hookport_test.go
+++ b/core/adapters/inbound/agents/codex/hookport_test.go
@@ -1,0 +1,166 @@
+// hookport_test.go covers issue #1178: the endpoint the Codex hook installer
+// writes is resolved from the daemon's bind address, and entries left behind
+// by a daemon on a different port are still recognized as ours and rewritten
+// in place rather than orphaned alongside a duplicate group.
+package codex
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"irrlicht/core/pkg/daemonaddr"
+)
+
+const altBindAddr = "127.0.0.1:7838"
+
+// legacyPortDeliveryCommand is the pre-#1178 hard-coded curl command, used to
+// seed a fixture that simulates an install made by a daemon on :7837.
+const legacyPortDeliveryCommand = "curl -fsS --max-time 1 -X POST --data-binary @- " +
+	"http://localhost:7837/api/v1/hooks/codex || true"
+
+// codexHomeOnPort points the installer at a temp $CODEX_HOME and pins the
+// daemon bind address, so the resolved endpoint is the same whatever the
+// developer's shell exports.
+func codexHomeOnPort(t *testing.T, bindAddr string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv(codexHomeEnvVar, home)
+	t.Setenv(daemonaddr.EnvBindAddr, bindAddr)
+	return home
+}
+
+// onlyHookCommand returns the command of the single inner hook in the event's
+// single matcher group, failing on any other shape — an upgrade must not
+// append a second group.
+func onlyHookCommand(t *testing.T, home, event string) string {
+	t.Helper()
+	hooks := readHooks(t, home)
+	arr, ok := hooks[event].([]interface{})
+	if !ok {
+		t.Fatalf("missing %s array", event)
+	}
+	if len(arr) != 1 {
+		t.Fatalf("expected exactly 1 %s matcher group (in-place upgrade, no append), got %d", event, len(arr))
+	}
+	group := arr[0].(map[string]interface{})
+	inner, ok := group["hooks"].([]interface{})
+	if !ok || len(inner) != 1 {
+		t.Fatalf("expected exactly 1 inner hook, got %v", group["hooks"])
+	}
+	cmd, _ := inner[0].(map[string]interface{})["command"].(string)
+	return cmd
+}
+
+func seedCodexHooks(t *testing.T, home string, hooks map[string]interface{}) {
+	t.Helper()
+	path := filepath.Join(home, "hooks.json")
+	data, err := json.Marshal(map[string]interface{}{"hooks": hooks})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHookEndpointURL_FollowsBindAddr(t *testing.T) {
+	t.Setenv(daemonaddr.EnvBindAddr, "")
+	if got, want := hookEndpointURL(), "http://localhost:7837/api/v1/hooks/codex"; got != want {
+		t.Errorf("default: hookEndpointURL() = %q, want %q", got, want)
+	}
+	if got, want := hookDeliveryCommand(), legacyPortDeliveryCommand; got != want {
+		t.Errorf("default: hookDeliveryCommand() = %q, want %q", got, want)
+	}
+
+	t.Setenv(daemonaddr.EnvBindAddr, altBindAddr)
+	if got, want := hookEndpointURL(), "http://localhost:7838/api/v1/hooks/codex"; got != want {
+		t.Errorf("alt port: hookEndpointURL() = %q, want %q", got, want)
+	}
+}
+
+// TestEnsureHooksInstalled_UsesResolvedPort is the core of #1178: a daemon on
+// :7838 must install hooks that reach *it*, not whatever owns :7837. Without
+// it, the onboarding factory's coexist recorder can never observe a Codex hook.
+func TestEnsureHooksInstalled_UsesResolvedPort(t *testing.T) {
+	home := codexHomeOnPort(t, altBindAddr)
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+	for _, event := range installedHookEvents {
+		cmd := onlyHookCommand(t, home, event)
+		if !strings.Contains(cmd, ":7838/") {
+			t.Errorf("event %s: command = %q, want the resolved :7838 port", event, cmd)
+		}
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("second EnsureHooksInstalled: %v", err)
+	}
+	if modified {
+		t.Error("second install on the same port: got modified=true, want false")
+	}
+}
+
+// TestEnsureHooksInstalled_UpgradesDefaultPortInstallInPlace is the
+// back-compat requirement: an existing :7837 command must still be recognized
+// as ours (the sentinel is port-independent) and rewritten in place.
+func TestEnsureHooksInstalled_UpgradesDefaultPortInstallInPlace(t *testing.T) {
+	home := codexHomeOnPort(t, altBindAddr)
+	seedCodexHooks(t, home, map[string]interface{}{
+		HookPostToolUse: []interface{}{
+			map[string]interface{}{
+				"matcher": hookMatcher,
+				"hooks": []interface{}{
+					map[string]interface{}{
+						"type":    "command",
+						"command": legacyPortDeliveryCommand,
+						"timeout": hookTimeoutSeconds,
+					},
+				},
+			},
+		},
+	})
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true when repointing a :7837 install at the resolved port")
+	}
+	if got, want := onlyHookCommand(t, home, HookPostToolUse), hookDeliveryCommand(); got != want {
+		t.Errorf("command = %q, want %q", got, want)
+	}
+}
+
+// TestUninstallHooks_RemovesDefaultPortInstall pins that uninstall is not
+// port-scoped: a daemon on :7838 must still clean up entries written by one on
+// :7837, or `irrlichd --uninstall-hooks` would leave junk behind.
+func TestUninstallHooks_RemovesDefaultPortInstall(t *testing.T) {
+	home := codexHomeOnPort(t, altBindAddr)
+	seedCodexHooks(t, home, map[string]interface{}{
+		HookStop: []interface{}{
+			map[string]interface{}{
+				"hooks": []interface{}{
+					map[string]interface{}{"type": "command", "command": legacyPortDeliveryCommand},
+				},
+			},
+		},
+	})
+
+	modified, err := UninstallHooks()
+	if err != nil {
+		t.Fatalf("UninstallHooks: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true removing a :7837 install from a :7838 daemon")
+	}
+	if eventHasSentinel(readHooks(t, home), HookStop) {
+		t.Errorf("%s entry survived uninstall", HookStop)
+	}
+}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -52,24 +51,10 @@ func (l lazyControl) Interrupt(id string) error {
 	return fmt.Errorf("relay control: input service not ready")
 }
 
-const (
-	defaultBindAddr = "127.0.0.1:7837"
-	tcpPort         = 7837
-	envUIDir        = "IRRLICHT_UI_DIR"
-)
-
-// resolveBindAddr returns the TCP bind address for the daemon. Default is
-// loopback-only; set IRRLICHT_BIND_ADDR to override (e.g. "0.0.0.0:7837" to
-// expose the daemon on the LAN).
-func resolveBindAddr(envValue string) string {
-	if envValue == "" {
-		return defaultBindAddr
-	}
-	if _, _, err := net.SplitHostPort(envValue); err != nil {
-		return defaultBindAddr
-	}
-	return envValue
-}
+// The daemon's bind address and default port live in core/pkg/daemonaddr, so
+// the agent hook installers resolve the same endpoint the daemon actually
+// listens on rather than agreeing with it by convention (#1178).
+const envUIDir = "IRRLICHT_UI_DIR"
 
 func hasFlag(name string) bool {
 	for _, arg := range os.Args[1:] {

--- a/core/cmd/irrlichd/main_test.go
+++ b/core/cmd/irrlichd/main_test.go
@@ -221,23 +221,6 @@ func TestGate_WebSocketRejectsForeignOrigin(t *testing.T) {
 	}
 }
 
-func TestResolveBindAddr(t *testing.T) {
-	tests := []struct {
-		in, want string
-	}{
-		{"", defaultBindAddr},
-		{"garbage", defaultBindAddr},
-		{"127.0.0.1:7837", "127.0.0.1:7837"},
-		{"0.0.0.0:7837", "0.0.0.0:7837"},
-		{":7837", ":7837"},
-	}
-	for _, tt := range tests {
-		if got := resolveBindAddr(tt.in); got != tt.want {
-			t.Errorf("resolveBindAddr(%q) = %q, want %q", tt.in, got, tt.want)
-		}
-	}
-}
-
 func TestDataDir(t *testing.T) {
 	// Default: derived from the passed-in home dir.
 	t.Run("default", func(t *testing.T) {

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -906,11 +906,11 @@ func setupBackchannel(mux *http.ServeMux, deps setupBackchannelDeps) (*services.
 // pre-consent daemon keep firing until the wizard is answered, so payloads are
 // dropped while pending.
 func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, metricsCollector outbound.MetricsCollector, permService *services.PermissionService, logger outbound.Logger) {
-	mux.HandleFunc("POST /api/v1/hooks/claudecode",
+	mux.HandleFunc("POST "+claudecode.HookEndpointPath,
 		claudecode.NewHookHandler(detector, metricsCollector, permService, logger))
-	mux.HandleFunc("POST /api/v1/hooks/claudecode/statusline",
+	mux.HandleFunc("POST "+claudecode.StatuslineEndpointPath,
 		claudecode.NewStatuslineHandler(metricsCollector, permService, logger))
-	mux.HandleFunc("POST /api/v1/hooks/codex",
+	mux.HandleFunc("POST "+codex.HookEndpointPath,
 		codex.NewHookHandler(detector, permService, logger))
 }
 

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -9,7 +9,6 @@ import (
 	"net/http/pprof"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -36,6 +35,7 @@ import (
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/config"
 	"irrlicht/core/domain/session"
+	"irrlicht/core/pkg/daemonaddr"
 	"irrlicht/core/ports/inbound"
 	"irrlicht/core/ports/outbound"
 )
@@ -473,7 +473,7 @@ func setupUnixSocket(logger outbound.Logger) (string, net.Listener) {
 // parallel). Returns the listener and its actual bound address (the
 // OS-assigned port when the request was :0).
 func setupTCPListener(logger outbound.Logger) (net.Listener, string) {
-	bindAddr := resolveBindAddr(os.Getenv("IRRLICHT_BIND_ADDR"))
+	bindAddr := daemonaddr.BindAddr()
 	tcpL, err := net.Listen("tcp", bindAddr)
 	if err != nil {
 		logger.LogError("startup", "", fmt.Sprintf("failed to listen on TCP %s: %v", bindAddr, err))
@@ -485,20 +485,16 @@ func setupTCPListener(logger outbound.Logger) (net.Listener, string) {
 // setupMDNS advertises _irrlicht._tcp on the local network, opt-in via
 // IRRLICHT_MDNS=1 to avoid broadcasting the daemon on networks the user did
 // not intend to share on. Advertises the port actually bound (resolvedAddr),
-// not the compile-time default — otherwise a daemon on a custom/ephemeral
-// port would point discovery clients at 7837 (a dead or production port).
+// not the default — otherwise a daemon on a custom/ephemeral port would point
+// discovery clients at 7837 (a dead or production port). resolvedAddr carries
+// the OS-assigned port when the request was :0, so PortOf's own :0 fallback is
+// never reached here.
 func setupMDNS(resolvedAddr string, logger outbound.Logger) *mdns.Advertiser {
 	if os.Getenv("IRRLICHT_MDNS") != "1" {
 		logger.LogInfo("startup", "", "mDNS: disabled (set IRRLICHT_MDNS=1 to advertise)")
 		return nil
 	}
-	advPort := tcpPort
-	if _, p, err := net.SplitHostPort(resolvedAddr); err == nil {
-		if n, err := strconv.Atoi(p); err == nil {
-			advPort = n
-		}
-	}
-	adv, err := mdns.New(advPort)
+	adv, err := mdns.New(daemonaddr.PortOf(resolvedAddr))
 	if err != nil {
 		logger.LogError("startup", "", fmt.Sprintf("mDNS advertisement failed (non-fatal): %v", err))
 		return nil

--- a/core/pkg/daemonaddr/daemonaddr.go
+++ b/core/pkg/daemonaddr/daemonaddr.go
@@ -1,0 +1,87 @@
+// Package daemonaddr is the single source of truth for the address the
+// irrlicht daemon binds to, and for the loopback URL that same-machine
+// clients — agent hooks, the Claude Code statusline feed — must deliver to.
+//
+// Both sides read the same knob (IRRLICHT_BIND_ADDR), so a daemon on an
+// alternate port installs hooks that reach *it* rather than whatever happens
+// to own the default port. Before issue #1178 the installers baked
+// "localhost:7837" in as a constant, which meant a dev or onboarding-factory
+// daemon on :7838 silently delivered every hook to the production daemon.
+//
+// Resolution is a pure function of the environment, deliberately: the hook
+// installers run from permission Apply closures inside adapter packages, which
+// are constructed before the TCP listener exists, so there is no resolved
+// address to thread down to them. Reading the same env var they would have
+// been handed keeps the two in agreement without a startup-ordering
+// constraint or process-wide mutable state.
+package daemonaddr
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+)
+
+const (
+	// EnvBindAddr overrides the daemon's TCP bind address, e.g. "0.0.0.0:7837"
+	// to expose it on the LAN, or "127.0.0.1:7838" to run a dev daemon
+	// alongside production.
+	EnvBindAddr = "IRRLICHT_BIND_ADDR"
+
+	// DefaultPort is the daemon's TCP port when EnvBindAddr is unset.
+	DefaultPort = 7837
+
+	// DefaultBindAddr is the default bind address: loopback only, so the
+	// daemon is not exposed to the network unless the user opts in.
+	DefaultBindAddr = "127.0.0.1:7837"
+)
+
+// ResolveBindAddr returns the TCP bind address for the daemon given the raw
+// EnvBindAddr value. An empty or malformed value falls back to
+// DefaultBindAddr — a typo must not silently bind somewhere unexpected.
+func ResolveBindAddr(envValue string) string {
+	if envValue == "" {
+		return DefaultBindAddr
+	}
+	if _, _, err := net.SplitHostPort(envValue); err != nil {
+		return DefaultBindAddr
+	}
+	return envValue
+}
+
+// BindAddr returns the resolved bind address for the current environment.
+func BindAddr() string {
+	return ResolveBindAddr(os.Getenv(EnvBindAddr))
+}
+
+// PortOf extracts the TCP port from a host:port address, falling back to
+// DefaultPort when the address is unparseable or carries no usable fixed
+// port. Port 0 falls back too: it asks the OS for an ephemeral port, which
+// has no value a client can be pointed at ahead of the actual bind.
+func PortOf(addr string) int {
+	_, p, err := net.SplitHostPort(addr)
+	if err != nil {
+		return DefaultPort
+	}
+	n, err := strconv.Atoi(p)
+	if err != nil || n <= 0 || n > 65535 {
+		return DefaultPort
+	}
+	return n
+}
+
+// Port returns the TCP port same-machine clients should reach the daemon on,
+// resolved from the current environment.
+func Port() int {
+	return PortOf(BindAddr())
+}
+
+// LocalURL builds the loopback URL a same-machine client should call for path
+// (which must start with "/"). The host is always loopback no matter what the
+// daemon binds to: a daemon on 0.0.0.0 is still reachable at localhost, and a
+// hook installed into a user's agent config must never point at a wildcard
+// address.
+func LocalURL(path string) string {
+	return fmt.Sprintf("http://localhost:%d%s", Port(), path)
+}

--- a/core/pkg/daemonaddr/daemonaddr.go
+++ b/core/pkg/daemonaddr/daemonaddr.go
@@ -75,10 +75,17 @@ func PortOf(addr string) int {
 		return defaultPort
 	}
 	n, err := strconv.Atoi(p)
-	if err != nil || n <= 0 || n > 65535 {
+	if err != nil || !isFixedPort(n) {
 		return defaultPort
 	}
 	return n
+}
+
+// isFixedPort reports whether n is a port a client can be pointed at ahead of
+// the daemon's bind: in range, and not 0 — which does not name a port at all,
+// it asks the OS to pick one.
+func isFixedPort(n int) bool {
+	return n > 0 && n <= 65535
 }
 
 // LocalURL builds the loopback URL a same-machine client should call for path

--- a/core/pkg/daemonaddr/daemonaddr.go
+++ b/core/pkg/daemonaddr/daemonaddr.go
@@ -1,6 +1,6 @@
 // Package daemonaddr is the single source of truth for the address the
-// irrlicht daemon binds to, and for the loopback URL that same-machine
-// clients — agent hooks, the Claude Code statusline feed — must deliver to.
+// irrlicht daemon binds to, and for the loopback URL that the agent hooks it
+// installs must deliver to.
 //
 // Both sides read the same knob (IRRLICHT_BIND_ADDR), so a daemon on an
 // alternate port installs hooks that reach *it* rather than whatever happens
@@ -8,12 +8,22 @@
 // "localhost:7837" in as a constant, which meant a dev or onboarding-factory
 // daemon on :7838 silently delivered every hook to the production daemon.
 //
-// Resolution is a pure function of the environment, deliberately: the hook
-// installers run from permission Apply closures inside adapter packages, which
-// are constructed before the TCP listener exists, so there is no resolved
-// address to thread down to them. Reading the same env var they would have
-// been handed keeps the two in agreement without a startup-ordering
-// constraint or process-wide mutable state.
+// Resolution is a pure function of the environment rather than a resolved
+// address threaded down from the composition root, because the installers run
+// from permission Apply closures on the values `agents.All()` builds — and
+// that constructor is shared with tooling that has no daemon at all (the
+// onboarding-factory viewer, `irrlichd --diagnose`), where a bind address
+// would be a meaningless parameter. It also builds each permission's Detail
+// prose as a plain string at construction time, which a threaded address would
+// force into a func. Reading the same env var the daemon reads keeps the two
+// in agreement without either cost, and without process-wide mutable state.
+//
+// One configuration is still exempt: IRRLICHT_BIND_ADDR=127.0.0.1:0 asks the
+// OS for an ephemeral port, whose value does not exist until the listener is
+// open. PortOf falls back to DefaultPort there. Only the headless smoke test
+// uses :0, and it runs against a temp HOME with permissions unanswered, so it
+// installs nothing — but a :0 daemon that did install would write an endpoint
+// it does not serve.
 package daemonaddr
 
 import (
@@ -23,58 +33,52 @@ import (
 	"strconv"
 )
 
+// EnvBindAddr overrides the daemon's TCP bind address, e.g. "0.0.0.0:7837" to
+// expose it on the LAN, or "127.0.0.1:7838" to run a dev daemon alongside
+// production.
+const EnvBindAddr = "IRRLICHT_BIND_ADDR"
+
 const (
-	// EnvBindAddr overrides the daemon's TCP bind address, e.g. "0.0.0.0:7837"
-	// to expose it on the LAN, or "127.0.0.1:7838" to run a dev daemon
-	// alongside production.
-	EnvBindAddr = "IRRLICHT_BIND_ADDR"
+	// defaultPort is the daemon's TCP port when EnvBindAddr is unset. It is
+	// the port in defaultBindAddr; TestDefaultsAgree pins them together.
+	defaultPort = 7837
 
-	// DefaultPort is the daemon's TCP port when EnvBindAddr is unset.
-	DefaultPort = 7837
-
-	// DefaultBindAddr is the default bind address: loopback only, so the
+	// defaultBindAddr is the default bind address: loopback only, so the
 	// daemon is not exposed to the network unless the user opts in.
-	DefaultBindAddr = "127.0.0.1:7837"
+	defaultBindAddr = "127.0.0.1:7837"
 )
 
-// ResolveBindAddr returns the TCP bind address for the daemon given the raw
+// resolveBindAddr returns the TCP bind address for the daemon given the raw
 // EnvBindAddr value. An empty or malformed value falls back to
-// DefaultBindAddr — a typo must not silently bind somewhere unexpected.
-func ResolveBindAddr(envValue string) string {
+// defaultBindAddr — a typo must not silently bind somewhere unexpected.
+func resolveBindAddr(envValue string) string {
 	if envValue == "" {
-		return DefaultBindAddr
+		return defaultBindAddr
 	}
 	if _, _, err := net.SplitHostPort(envValue); err != nil {
-		return DefaultBindAddr
+		return defaultBindAddr
 	}
 	return envValue
 }
 
 // BindAddr returns the resolved bind address for the current environment.
 func BindAddr() string {
-	return ResolveBindAddr(os.Getenv(EnvBindAddr))
+	return resolveBindAddr(os.Getenv(EnvBindAddr))
 }
 
-// PortOf extracts the TCP port from a host:port address, falling back to
-// DefaultPort when the address is unparseable or carries no usable fixed
-// port. Port 0 falls back too: it asks the OS for an ephemeral port, which
-// has no value a client can be pointed at ahead of the actual bind.
+// PortOf extracts the TCP port from a host:port address, falling back to the
+// default when the address is unparseable or carries no usable fixed port.
+// Port 0 falls back too — see the package doc.
 func PortOf(addr string) int {
 	_, p, err := net.SplitHostPort(addr)
 	if err != nil {
-		return DefaultPort
+		return defaultPort
 	}
 	n, err := strconv.Atoi(p)
 	if err != nil || n <= 0 || n > 65535 {
-		return DefaultPort
+		return defaultPort
 	}
 	return n
-}
-
-// Port returns the TCP port same-machine clients should reach the daemon on,
-// resolved from the current environment.
-func Port() int {
-	return PortOf(BindAddr())
 }
 
 // LocalURL builds the loopback URL a same-machine client should call for path
@@ -83,5 +87,5 @@ func Port() int {
 // hook installed into a user's agent config must never point at a wildcard
 // address.
 func LocalURL(path string) string {
-	return fmt.Sprintf("http://localhost:%d%s", Port(), path)
+	return fmt.Sprintf("http://localhost:%d%s", PortOf(BindAddr()), path)
 }

--- a/core/pkg/daemonaddr/daemonaddr_test.go
+++ b/core/pkg/daemonaddr/daemonaddr_test.go
@@ -1,0 +1,72 @@
+package daemonaddr
+
+import "testing"
+
+func TestResolveBindAddr(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", DefaultBindAddr},
+		{"garbage", DefaultBindAddr},
+		{"127.0.0.1:7837", "127.0.0.1:7837"},
+		{"0.0.0.0:7837", "0.0.0.0:7837"},
+		{":7837", ":7837"},
+		{"127.0.0.1:7838", "127.0.0.1:7838"},
+	}
+	for _, tt := range tests {
+		if got := ResolveBindAddr(tt.in); got != tt.want {
+			t.Errorf("ResolveBindAddr(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestPortOf(t *testing.T) {
+	tests := []struct {
+		in   string
+		want int
+	}{
+		{"127.0.0.1:7837", 7837},
+		{"127.0.0.1:7838", 7838},
+		{":7838", 7838},
+		{"0.0.0.0:9000", 9000},
+		{"garbage", DefaultPort},
+		{"127.0.0.1:notaport", DefaultPort},
+		// An ephemeral request has no value a client can be pointed at.
+		{"127.0.0.1:0", DefaultPort},
+		{"127.0.0.1:99999", DefaultPort},
+	}
+	for _, tt := range tests {
+		if got := PortOf(tt.in); got != tt.want {
+			t.Errorf("PortOf(%q) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestPortAndLocalURLFollowEnv(t *testing.T) {
+	t.Run("unset falls back to the default port", func(t *testing.T) {
+		t.Setenv(EnvBindAddr, "")
+		if got := Port(); got != DefaultPort {
+			t.Errorf("Port() = %d, want %d", got, DefaultPort)
+		}
+		if got, want := LocalURL("/api/v1/hooks/codex"), "http://localhost:7837/api/v1/hooks/codex"; got != want {
+			t.Errorf("LocalURL = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("alternate port", func(t *testing.T) {
+		t.Setenv(EnvBindAddr, "127.0.0.1:7838")
+		if got := Port(); got != 7838 {
+			t.Errorf("Port() = %d, want 7838", got)
+		}
+		if got, want := LocalURL("/api/v1/hooks/codex"), "http://localhost:7838/api/v1/hooks/codex"; got != want {
+			t.Errorf("LocalURL = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("wildcard bind still yields a loopback client URL", func(t *testing.T) {
+		t.Setenv(EnvBindAddr, "0.0.0.0:7900")
+		if got, want := LocalURL("/api/v1/hooks/claudecode"), "http://localhost:7900/api/v1/hooks/claudecode"; got != want {
+			t.Errorf("LocalURL = %q, want %q", got, want)
+		}
+	})
+}

--- a/core/pkg/daemonaddr/daemonaddr_test.go
+++ b/core/pkg/daemonaddr/daemonaddr_test.go
@@ -2,20 +2,29 @@ package daemonaddr
 
 import "testing"
 
+// TestDefaultsAgree pins the two spellings of the default together: PortOf's
+// fallback and the address the daemon binds must never drift apart, or an
+// unset environment would resolve a hook endpoint the daemon does not serve.
+func TestDefaultsAgree(t *testing.T) {
+	if got := PortOf(defaultBindAddr); got != defaultPort {
+		t.Errorf("PortOf(%q) = %d, want defaultPort %d", defaultBindAddr, got, defaultPort)
+	}
+}
+
 func TestResolveBindAddr(t *testing.T) {
 	tests := []struct {
 		in, want string
 	}{
-		{"", DefaultBindAddr},
-		{"garbage", DefaultBindAddr},
+		{"", defaultBindAddr},
+		{"garbage", defaultBindAddr},
 		{"127.0.0.1:7837", "127.0.0.1:7837"},
 		{"0.0.0.0:7837", "0.0.0.0:7837"},
 		{":7837", ":7837"},
 		{"127.0.0.1:7838", "127.0.0.1:7838"},
 	}
 	for _, tt := range tests {
-		if got := ResolveBindAddr(tt.in); got != tt.want {
-			t.Errorf("ResolveBindAddr(%q) = %q, want %q", tt.in, got, tt.want)
+		if got := resolveBindAddr(tt.in); got != tt.want {
+			t.Errorf("resolveBindAddr(%q) = %q, want %q", tt.in, got, tt.want)
 		}
 	}
 }
@@ -29,11 +38,11 @@ func TestPortOf(t *testing.T) {
 		{"127.0.0.1:7838", 7838},
 		{":7838", 7838},
 		{"0.0.0.0:9000", 9000},
-		{"garbage", DefaultPort},
-		{"127.0.0.1:notaport", DefaultPort},
+		{"garbage", defaultPort},
+		{"127.0.0.1:notaport", defaultPort},
 		// An ephemeral request has no value a client can be pointed at.
-		{"127.0.0.1:0", DefaultPort},
-		{"127.0.0.1:99999", DefaultPort},
+		{"127.0.0.1:0", defaultPort},
+		{"127.0.0.1:99999", defaultPort},
 	}
 	for _, tt := range tests {
 		if got := PortOf(tt.in); got != tt.want {
@@ -42,31 +51,22 @@ func TestPortOf(t *testing.T) {
 	}
 }
 
-func TestPortAndLocalURLFollowEnv(t *testing.T) {
-	t.Run("unset falls back to the default port", func(t *testing.T) {
-		t.Setenv(EnvBindAddr, "")
-		if got := Port(); got != DefaultPort {
-			t.Errorf("Port() = %d, want %d", got, DefaultPort)
-		}
-		if got, want := LocalURL("/api/v1/hooks/codex"), "http://localhost:7837/api/v1/hooks/codex"; got != want {
-			t.Errorf("LocalURL = %q, want %q", got, want)
-		}
-	})
-
-	t.Run("alternate port", func(t *testing.T) {
-		t.Setenv(EnvBindAddr, "127.0.0.1:7838")
-		if got := Port(); got != 7838 {
-			t.Errorf("Port() = %d, want 7838", got)
-		}
-		if got, want := LocalURL("/api/v1/hooks/codex"), "http://localhost:7838/api/v1/hooks/codex"; got != want {
-			t.Errorf("LocalURL = %q, want %q", got, want)
-		}
-	})
-
-	t.Run("wildcard bind still yields a loopback client URL", func(t *testing.T) {
-		t.Setenv(EnvBindAddr, "0.0.0.0:7900")
-		if got, want := LocalURL("/api/v1/hooks/claudecode"), "http://localhost:7900/api/v1/hooks/claudecode"; got != want {
-			t.Errorf("LocalURL = %q, want %q", got, want)
-		}
-	})
+func TestLocalURLFollowsEnv(t *testing.T) {
+	tests := []struct {
+		name, bindAddr, want string
+	}{
+		{"unset falls back to the default port", "", "http://localhost:7837/x"},
+		{"alternate port", "127.0.0.1:7838", "http://localhost:7838/x"},
+		// A daemon on 0.0.0.0 is still reached at loopback; never point a
+		// hook at a wildcard address.
+		{"wildcard bind still yields a loopback URL", "0.0.0.0:7900", "http://localhost:7900/x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(EnvBindAddr, tt.bindAddr)
+			if got := LocalURL("/x"); got != tt.want {
+				t.Errorf("LocalURL(\"/x\") = %q, want %q", got, tt.want)
+			}
+		})
+	}
 }

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -129,7 +129,7 @@
             <td><code>IRRLICHT_BIND_ADDR</code></td>
             <td>host:port</td>
             <td><code>127.0.0.1:7837</code></td>
-            <td>Override the daemon's TCP bind &mdash; use <code>0.0.0.0:7837</code> to expose on the LAN</td>
+            <td>Override the daemon's TCP bind &mdash; use <code>0.0.0.0:7837</code> to expose on the LAN, or <code>127.0.0.1:7838</code> to run a second daemon alongside your production one. The agent hooks and Claude Code statusline feed the daemon installs POST to whichever port this resolves to, so a daemon on an alternate port receives its own hook traffic instead of the default port's.</td>
           </tr>
           <tr>
             <td><code>IRRLICHT_MDNS</code></td>

--- a/tools/onboarding-factory/scripts/lib/hook-config-snapshot.sh
+++ b/tools/onboarding-factory/scripts/lib/hook-config-snapshot.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# hook-config-snapshot.sh — save and restore the agent config files a recording
+# daemon rewrites, so a recording never outlives its own edits.
+#
+# A recording daemon runs with IRRLICHT_PERMISSION_MODE=grant-all and installs
+# its hooks into the user's REAL agent config — ~/.claude/settings.json and
+# $CODEX_HOME/hooks.json follow $HOME, not IRRLICHT_HOME, so
+# IRRLICHT_ONBOARD_HOME does not isolate them. Since #1178 the endpoint written
+# there carries the daemon's own bind port, so a coexist recording on :7838
+# repoints a running production daemon's hooks at the recorder and leaves them
+# that way. grant-all can also install entries the user had explicitly denied.
+#
+# Usage — call the first before spawning the daemon, the second from cleanup:
+#   source "$SCRIPT_DIR/lib/hook-config-snapshot.sh"
+#   snapshot_hook_configs "$STAGING/hook-config-backup"
+#   ... spawn daemon, drive agent ...
+#   restore_hook_configs
+#
+# Both are no-ops if the snapshot never ran, so restore is safe to call
+# unconditionally from an EXIT trap.
+
+# HOOK_CONFIG_FILES is the set of shared agent config files a recording daemon
+# may rewrite. Set by snapshot_hook_configs and read by restore_hook_configs.
+HOOK_CONFIG_FILES=()
+HOOK_CONFIG_BACKUP_DIR=""
+
+# snapshot_hook_configs <backup-dir> copies each shared agent config aside.
+# A file that does not exist is recorded as absent (no backup written), so
+# restore removes one the daemon created from nothing.
+snapshot_hook_configs() {
+  HOOK_CONFIG_BACKUP_DIR="$1"
+  HOOK_CONFIG_FILES=("$HOME/.claude/settings.json" "${CODEX_HOME:-$HOME/.codex}/hooks.json")
+  mkdir -p "$HOOK_CONFIG_BACKUP_DIR"
+  local i
+  for i in "${!HOOK_CONFIG_FILES[@]}"; do
+    if [[ -f "${HOOK_CONFIG_FILES[$i]}" ]]; then
+      cp "${HOOK_CONFIG_FILES[$i]}" "$HOOK_CONFIG_BACKUP_DIR/$i"
+    fi
+  done
+}
+
+# restore_hook_configs puts each snapshotted file back exactly as it was.
+# No backup for an index means the file did not exist when we snapshotted, so
+# whatever is there now is ours to remove.
+restore_hook_configs() {
+  [[ -n "$HOOK_CONFIG_BACKUP_DIR" ]] || return 0
+  local i
+  for i in "${!HOOK_CONFIG_FILES[@]}"; do
+    if [[ -f "$HOOK_CONFIG_BACKUP_DIR/$i" ]]; then
+      cp "$HOOK_CONFIG_BACKUP_DIR/$i" "${HOOK_CONFIG_FILES[$i]}"
+    else
+      rm -f "${HOOK_CONFIG_FILES[$i]}"
+    fi
+  done
+}

--- a/tools/onboarding-factory/scripts/lib/hook-config-snapshot_test.sh
+++ b/tools/onboarding-factory/scripts/lib/hook-config-snapshot_test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# hook-config-snapshot_test.sh — unit tests for hook-config-snapshot.sh. Plain
+# bash, no framework. Run directly or via scripts/smoke-test.sh.
+#
+# The lib is sourced (not run as a subprocess) so the tests drive its two
+# functions directly against a fake $HOME / $CODEX_HOME. What matters is that a
+# recording daemon's edits to the user's shared agent config never survive the
+# run — including the case where the daemon created a config file that was not
+# there before (#1178).
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/hook-config-snapshot.sh
+source "$DIR/hook-config-snapshot.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]"; fails=$((fails + 1)); return 0; }
+assert_eq() {
+  [[ "$2" == "$3" ]] && pass "$1" || fail "$1" "$2" "$3"
+}
+
+# fresh_env points $HOME and $CODEX_HOME at a clean subdir, sets $ROOT, and
+# clears the lib's state so each case starts from nothing. It must NOT be
+# called in a command substitution — the env assignments have to land in this
+# shell, not a subshell.
+fresh_env() {
+  ROOT="$TMP/$1"
+  mkdir -p "$ROOT/home/.claude" "$ROOT/codex"
+  HOME="$ROOT/home"
+  CODEX_HOME="$ROOT/codex"
+  HOOK_CONFIG_FILES=()
+  HOOK_CONFIG_BACKUP_DIR=""
+}
+
+echo "== an existing config is restored byte-for-byte =="
+fresh_env existing
+printf '{"hooks":{"Stop":"localhost:7837"}}\n' > "$HOME/.claude/settings.json"
+snapshot_hook_configs "$ROOT/backup"
+printf '{"hooks":{"Stop":"localhost:7838"}}\n' > "$HOME/.claude/settings.json"   # daemon repoints it
+restore_hook_configs
+assert_eq "settings.json restored" '{"hooks":{"Stop":"localhost:7837"}}' "$(cat "$HOME/.claude/settings.json")"
+
+echo "== a config the daemon created from nothing is removed =="
+fresh_env created
+snapshot_hook_configs "$ROOT/backup"
+printf '{"hooks":{}}\n' > "$CODEX_HOME/hooks.json"                               # daemon creates it
+restore_hook_configs
+[[ -e "$CODEX_HOME/hooks.json" ]] && got=present || got=absent
+assert_eq "hooks.json removed" "absent" "$got"
+
+echo "== an untouched config survives a restore unchanged =="
+fresh_env untouched
+printf 'original\n' > "$CODEX_HOME/hooks.json"
+snapshot_hook_configs "$ROOT/backup"
+restore_hook_configs
+assert_eq "hooks.json unchanged" "original" "$(cat "$CODEX_HOME/hooks.json")"
+
+echo "== restore without a snapshot is a no-op, not an error =="
+fresh_env nosnapshot
+printf 'untouched\n' > "$HOME/.claude/settings.json"
+restore_hook_configs
+rc=$?
+assert_eq "restore returns 0" "0" "$rc"
+assert_eq "file left alone" "untouched" "$(cat "$HOME/.claude/settings.json")"
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "hook-config-snapshot_test: ALL PASS"
+  exit 0
+fi
+echo "hook-config-snapshot_test: $fails FAILURE(S)" >&2
+exit 1

--- a/tools/onboarding-factory/scripts/lib/hook-config-snapshot_test.sh
+++ b/tools/onboarding-factory/scripts/lib/hook-config-snapshot_test.sh
@@ -17,6 +17,18 @@ source "$DIR/hook-config-snapshot.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# Floor under every case: point $HOME and $CODEX_HOME somewhere harmless before
+# the first one runs. fresh_env overrides both per-case, so this changes nothing
+# about what the tests exercise — it exists so a case that is added above the
+# first fresh_env call, or forgets it, cannot reach the developer's real
+# ~/.claude/settings.json. That is not hypothetical: a draft of this file did
+# exactly that and wiped a live config's statusLine and all seven irrlicht hook
+# entries (#1212). These paths are deliberately NOT created — an omitted
+# fresh_env then fails loudly on a missing directory instead of silently
+# writing somewhere plausible.
+HOME="$TMP/nohome"
+CODEX_HOME="$TMP/nocodex"
+
 fails=0
 pass() { echo "  PASS: $1"; return 0; }
 fail() { echo "  FAIL: $1 — expected [$2] got [$3]"; fails=$((fails + 1)); return 0; }

--- a/tools/onboarding-factory/scripts/precheck.sh
+++ b/tools/onboarding-factory/scripts/precheck.sh
@@ -55,7 +55,9 @@ elif [[ -n "${IRRLICHT_ONBOARD_HOME:-}" ]]; then
   # Coexist mode: the recording daemon gets its OWN IRRLICHT_HOME (socket
   # + state) and an alternate bind port, so a running production irrlichd
   # is fine — they don't share a socket or port. We only require that OUR
-  # target port is free and that the adapter is filesystem-observed.
+  # target port is free. Hook-driven adapters work here too since #1178:
+  # the endpoint their installers write follows IRRLICHT_BIND_ADDR, so
+  # hooks reach $ONBOARD_BIND rather than production.
   ONBOARD_BIND="${IRRLICHT_ONBOARD_BIND_ADDR:-127.0.0.1:7838}"
   ONBOARD_PORT="${ONBOARD_BIND##*:}"
   if [[ ! "$ONBOARD_PORT" =~ ^[0-9]+$ ]]; then
@@ -67,12 +69,6 @@ elif [[ -n "${IRRLICHT_ONBOARD_HOME:-}" ]]; then
   if lsof -nP -iTCP:"$ONBOARD_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
     fail "coexist port $ONBOARD_PORT is already in use; pick another IRRLICHT_ONBOARD_BIND_ADDR"
   fi
-  # Hook-driven adapters (claudecode, codex) used to be unrecordable here: the
-  # endpoint their installers wrote was hardcoded to :7837, so their hooks
-  # reached production rather than the isolated daemon. Since #1178 the
-  # endpoint follows IRRLICHT_BIND_ADDR, so they deliver to $ONBOARD_BIND like
-  # every other observation — and run-cell.sh snapshots/restores the shared
-  # agent config the recorder rewrites, so production's hooks are put back.
 else
   if pgrep -x irrlichd >/dev/null 2>&1; then
     fail "another irrlichd is running (pgrep -x irrlichd); stop it first, rerun with --attach, or set IRRLICHT_ONBOARD_HOME + IRRLICHT_ONBOARD_BIND_ADDR to record on an isolated port"

--- a/tools/onboarding-factory/scripts/precheck.sh
+++ b/tools/onboarding-factory/scripts/precheck.sh
@@ -67,9 +67,12 @@ elif [[ -n "${IRRLICHT_ONBOARD_HOME:-}" ]]; then
   if lsof -nP -iTCP:"$ONBOARD_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
     fail "coexist port $ONBOARD_PORT is already in use; pick another IRRLICHT_ONBOARD_BIND_ADDR"
   fi
-  if [[ "$ADAPTER" == "claudecode" && "${IRRLICHT_ONBOARD_MULTI:-0}" != "1" ]]; then
-    fail "claudecode cannot record in coexist mode: its hooks POST to a hardcoded :7837, so they'd reach the production daemon, not the isolated one. Stop production and record claudecode in default mode instead. (run-cell-multi.sh sets IRRLICHT_ONBOARD_MULTI=1 — its cross-adapter recording observes claudecode via the transcript fswatcher, not hooks.)"
-  fi
+  # Hook-driven adapters (claudecode, codex) used to be unrecordable here: the
+  # endpoint their installers wrote was hardcoded to :7837, so their hooks
+  # reached production rather than the isolated daemon. Since #1178 the
+  # endpoint follows IRRLICHT_BIND_ADDR, so they deliver to $ONBOARD_BIND like
+  # every other observation — and run-cell.sh snapshots/restores the shared
+  # agent config the recorder rewrites, so production's hooks are put back.
 else
   if pgrep -x irrlichd >/dev/null 2>&1; then
     fail "another irrlichd is running (pgrep -x irrlichd); stop it first, rerun with --attach, or set IRRLICHT_ONBOARD_HOME + IRRLICHT_ONBOARD_BIND_ADDR to record on an isolated port"

--- a/tools/onboarding-factory/scripts/run-cell-multi.sh
+++ b/tools/onboarding-factory/scripts/run-cell-multi.sh
@@ -20,12 +20,12 @@
 #     → replay each staged transcript
 #     → write run-manifest.json
 #
-# claudecode observation: the isolated daemon is NOT on :7837, so
-# claudecode's hooks (hardcoded to :7837) reach production, not us. That's
-# fine — the daemon also observes claudecode via its transcript fswatcher
-# (~/.claude/projects, keyed off the real $HOME), which is enough for this
-# scenario's working->ready arcs. IRRLICHT_ONBOARD_MULTI=1 tells precheck
-# to allow claudecode in coexist mode for exactly this reason.
+# claudecode observation: the isolated daemon is NOT on :7837, but since
+# #1178 the hook endpoint follows IRRLICHT_BIND_ADDR, so claudecode's hooks
+# reach us rather than production. The transcript fswatcher (~/.claude/projects,
+# keyed off the real $HOME) covers this scenario's working->ready arcs either
+# way. run-cell.sh snapshots and restores the shared ~/.claude/settings.json
+# it rewrites, so production's hooks are put back when the recording ends.
 #
 # Coexist is MANDATORY here: IRRLICHT_ONBOARD_HOME must be set (defaulting
 # the bind port to 7838) so we never touch the running production daemon.
@@ -87,6 +87,9 @@ ONBOARD_BIND="${IRRLICHT_ONBOARD_BIND_ADDR:-127.0.0.1:7838}"
 ONBOARD_SOCK="$ONBOARD_HOME/irrlichd.sock"
 export IRRLICHT_ONBOARD_HOME="$ONBOARD_HOME"
 export IRRLICHT_ONBOARD_BIND_ADDR="$ONBOARD_BIND"
+# Marks this as the cross-adapter run for anything downstream that cares. It
+# used to double as precheck's bypass for claudecode-in-coexist-mode; that
+# refusal is gone since #1178 made the hook endpoint follow the bind address.
 export IRRLICHT_ONBOARD_MULTI=1
 
 # --- Resolve the cross-adapter cell -------------------------------------

--- a/tools/onboarding-factory/scripts/run-cell-multi.sh
+++ b/tools/onboarding-factory/scripts/run-cell-multi.sh
@@ -24,8 +24,9 @@
 # #1178 the hook endpoint follows IRRLICHT_BIND_ADDR, so claudecode's hooks
 # reach us rather than production. The transcript fswatcher (~/.claude/projects,
 # keyed off the real $HOME) covers this scenario's working->ready arcs either
-# way. run-cell.sh snapshots and restores the shared ~/.claude/settings.json
-# it rewrites, so production's hooks are put back when the recording ends.
+# way. This script snapshots and restores the shared agent config the daemon
+# rewrites (lib/hook-config-snapshot.sh), so production's hooks are put back
+# when the recording ends.
 #
 # Coexist is MANDATORY here: IRRLICHT_ONBOARD_HOME must be set (defaulting
 # the bind port to 7838) so we never touch the running production daemon.
@@ -53,6 +54,8 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [[ -n "$REPO_ROOT" ]] || { echo "not in a git repo" >&2; exit 1; }
 # shellcheck source=lib/shard-lib.sh
 source "$SCRIPT_DIR/lib/shard-lib.sh"   # per-scenario shard reader (#511)
+# shellcheck source=lib/hook-config-snapshot.sh
+source "$SCRIPT_DIR/lib/hook-config-snapshot.sh"   # save/restore shared agent config (#1178)
 
 # Session-id reconciliation helpers (daemon_sid_for_transcript,
 # sid_in_recording, reconcile_slot_csv) — shared + unit-tested in lib/.
@@ -87,10 +90,6 @@ ONBOARD_BIND="${IRRLICHT_ONBOARD_BIND_ADDR:-127.0.0.1:7838}"
 ONBOARD_SOCK="$ONBOARD_HOME/irrlichd.sock"
 export IRRLICHT_ONBOARD_HOME="$ONBOARD_HOME"
 export IRRLICHT_ONBOARD_BIND_ADDR="$ONBOARD_BIND"
-# Marks this as the cross-adapter run for anything downstream that cares. It
-# used to double as precheck's bypass for claudecode-in-coexist-mode; that
-# refusal is gone since #1178 made the hook endpoint follow the bind address.
-export IRRLICHT_ONBOARD_MULTI=1
 
 # --- Resolve the cross-adapter cell -------------------------------------
 # Post-consolidation (#511): there is no `cross_adapter[]` list. The cell lives
@@ -198,6 +197,10 @@ write_error_manifest() {
 
 # --- Spawn ONE isolated --record daemon ---------------------------------
 DAEMON_LOG="$STAGING/daemon.log"
+# Save the shared agent config the daemon is about to rewrite (see
+# lib/hook-config-snapshot.sh); cleanup hands it back. This script spawns its
+# own daemon rather than delegating to run-cell.sh, so it needs its own call.
+snapshot_hook_configs "$STAGING/hook-config-backup"
 # grant-all: the consent-first permission gate (#570) would otherwise leave
 # a fresh recording daemon monitoring nothing until a wizard is answered.
 env IRRLICHT_RECORDINGS_DIR="$STAGING/recordings" \
@@ -227,6 +230,7 @@ cleanup() {
     kill -KILL "$DAEMON_PID" 2>/dev/null || true
   fi
   echo "$SHUTDOWN_REASON" > "$STAGING/daemon.shutdown"
+  restore_hook_configs
 }
 trap cleanup EXIT
 

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -38,6 +38,8 @@ JSONL_GLOB='*.jsonl'
 
 # shellcheck source=lib/shard-lib.sh
 source "$SCRIPT_DIR/lib/shard-lib.sh"   # per-scenario shard reader (#511)
+# shellcheck source=lib/hook-config-snapshot.sh
+source "$SCRIPT_DIR/lib/hook-config-snapshot.sh"   # save/restore shared agent config (#1178)
 
 RECORDER="off"
 ATTACH=0
@@ -253,37 +255,9 @@ else
   # grant-all: the consent-first permission gate (#570) would otherwise
   # leave a fresh recording daemon monitoring nothing until a wizard is
   # answered — fixtures must never hang on consent.
-  # The recording daemon installs its hooks into the user's REAL agent config
-  # (~/.claude/settings.json, $CODEX_HOME/hooks.json) — those paths follow
-  # $HOME, not IRRLICHT_HOME, so IRRLICHT_ONBOARD_HOME does not isolate them —
-  # and since #1178 the endpoint it writes carries $ONBOARD_BIND's port. On an
-  # alternate port that repoints a running production daemon's hooks at the
-  # recorder, and grant-all can install entries the user had denied. Snapshot
-  # before the daemon starts, restore on cleanup, so a recording never outlives
-  # its own edits to config it does not own.
-  HOOK_BACKUP_DIR="$STAGING/hook-config-backup"
-  HOOK_CONFIG_FILES=("$HOME/.claude/settings.json" "${CODEX_HOME:-$HOME/.codex}/hooks.json")
-  mkdir -p "$HOOK_BACKUP_DIR"
-  for i in "${!HOOK_CONFIG_FILES[@]}"; do
-    if [[ -f "${HOOK_CONFIG_FILES[$i]}" ]]; then
-      cp "${HOOK_CONFIG_FILES[$i]}" "$HOOK_BACKUP_DIR/$i"
-    else
-      : > "$HOOK_BACKUP_DIR/$i.absent"
-    fi
-  done
-
-  # restore_hook_configs puts each snapshotted file back exactly as it was —
-  # including removing one the daemon created from nothing.
-  restore_hook_configs() {
-    local i
-    for i in "${!HOOK_CONFIG_FILES[@]}"; do
-      if [[ -f "$HOOK_BACKUP_DIR/$i" ]]; then
-        cp "$HOOK_BACKUP_DIR/$i" "${HOOK_CONFIG_FILES[$i]}"
-      elif [[ -f "$HOOK_BACKUP_DIR/$i.absent" ]]; then
-        rm -f "${HOOK_CONFIG_FILES[$i]}"
-      fi
-    done
-  }
+  # Save the shared agent config the daemon is about to rewrite (see
+  # lib/hook-config-snapshot.sh); cleanup hands it back.
+  snapshot_hook_configs "$STAGING/hook-config-backup"
 
   DAEMON_ENV=(IRRLICHT_RECORDINGS_DIR="$STAGING/recordings"
               IRRLICHT_BIND_ADDR="$ONBOARD_BIND"

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -180,9 +180,10 @@ REPLAY_BIN="$REPO_ROOT/.build/refresh/bin/replay"
 # bind port, so it coexists with a running production irrlichd instead of
 # clashing on 7837. Filesystem-observed adapters (codex/pi/aider/opencode)
 # record fine this way because they watch the real $HOME (e.g.
-# ~/.codex/sessions) regardless of IRRLICHT_HOME. claudecode is the one
-# exception — its hooks POST to a hardcoded :7837 — so precheck refuses
-# claudecode in coexist mode.
+# ~/.codex/sessions) regardless of IRRLICHT_HOME. Hook-driven observation
+# (claudecode, codex) works too since #1178: the endpoint the installers write
+# follows IRRLICHT_BIND_ADDR, so hooks reach this daemon rather than
+# production's.
 ONBOARD_HOME="${IRRLICHT_ONBOARD_HOME:-}"
 if [[ -n "$ONBOARD_HOME" ]]; then
   # Coexist mode: default to an alternate port so we don't clash with a
@@ -252,6 +253,38 @@ else
   # grant-all: the consent-first permission gate (#570) would otherwise
   # leave a fresh recording daemon monitoring nothing until a wizard is
   # answered — fixtures must never hang on consent.
+  # The recording daemon installs its hooks into the user's REAL agent config
+  # (~/.claude/settings.json, $CODEX_HOME/hooks.json) — those paths follow
+  # $HOME, not IRRLICHT_HOME, so IRRLICHT_ONBOARD_HOME does not isolate them —
+  # and since #1178 the endpoint it writes carries $ONBOARD_BIND's port. On an
+  # alternate port that repoints a running production daemon's hooks at the
+  # recorder, and grant-all can install entries the user had denied. Snapshot
+  # before the daemon starts, restore on cleanup, so a recording never outlives
+  # its own edits to config it does not own.
+  HOOK_BACKUP_DIR="$STAGING/hook-config-backup"
+  HOOK_CONFIG_FILES=("$HOME/.claude/settings.json" "${CODEX_HOME:-$HOME/.codex}/hooks.json")
+  mkdir -p "$HOOK_BACKUP_DIR"
+  for i in "${!HOOK_CONFIG_FILES[@]}"; do
+    if [[ -f "${HOOK_CONFIG_FILES[$i]}" ]]; then
+      cp "${HOOK_CONFIG_FILES[$i]}" "$HOOK_BACKUP_DIR/$i"
+    else
+      : > "$HOOK_BACKUP_DIR/$i.absent"
+    fi
+  done
+
+  # restore_hook_configs puts each snapshotted file back exactly as it was —
+  # including removing one the daemon created from nothing.
+  restore_hook_configs() {
+    local i
+    for i in "${!HOOK_CONFIG_FILES[@]}"; do
+      if [[ -f "$HOOK_BACKUP_DIR/$i" ]]; then
+        cp "$HOOK_BACKUP_DIR/$i" "${HOOK_CONFIG_FILES[$i]}"
+      elif [[ -f "$HOOK_BACKUP_DIR/$i.absent" ]]; then
+        rm -f "${HOOK_CONFIG_FILES[$i]}"
+      fi
+    done
+  }
+
   DAEMON_ENV=(IRRLICHT_RECORDINGS_DIR="$STAGING/recordings"
               IRRLICHT_BIND_ADDR="$ONBOARD_BIND"
               IRRLICHT_PERMISSION_MODE=grant-all)
@@ -264,12 +297,19 @@ else
   DAEMON_PID=$!
   echo "daemon started (pid $DAEMON_PID, bind=$ONBOARD_BIND${ONBOARD_HOME:+, home=$ONBOARD_HOME})"
 
-  # Cleanup: graceful shutdown. Runs once: either via explicit call
-  # before transcript resolution (we must drain before continuing), or
-  # as the EXIT trap if we fail before reaching that point. `trap - EXIT`
-  # after the explicit call prevents double-invocation.
+  # Cleanup: graceful shutdown, then hand the user's agent config back. Runs
+  # once: either via explicit call before transcript resolution (we must drain
+  # before continuing), or as the EXIT trap if we fail before reaching that
+  # point. `trap - EXIT` after the explicit call prevents double-invocation.
   SHUTDOWN_REASON="unknown"
   cleanup() {
+    stop_daemon
+    restore_hook_configs
+  }
+
+  # stop_daemon escalates INT -> TERM -> KILL, giving the recorder time to
+  # flush between each.
+  stop_daemon() {
     if kill -0 "$DAEMON_PID" 2>/dev/null; then
       SHUTDOWN_REASON="sigint"
       kill -INT "$DAEMON_PID" 2>/dev/null || true

--- a/tools/onboarding-factory/scripts/smoke-test.sh
+++ b/tools/onboarding-factory/scripts/smoke-test.sh
@@ -44,6 +44,10 @@ echo ""
 echo "== unit tests (lib/classify-failure_test.sh) =="
 bash "$SCRIPT_DIR/lib/classify-failure_test.sh" || rc=1
 
+echo ""
+echo "== unit tests (lib/hook-config-snapshot_test.sh) =="
+bash "$SCRIPT_DIR/lib/hook-config-snapshot_test.sh" || rc=1
+
 # completeness-gate / catalog-drift / consistency gates were retired (#528):
 # `of validate` + `of coverage` (Go) now own schema + referential + coverage
 # integrity, and a per-scenario shard is the single source for a cell, so the


### PR DESCRIPTION
Closes #1178

## Problem

The port installed agent hooks POST to was hardcoded to `:7837` in each adapter's installer, so a daemon on any other port installed hooks that delivered to whatever owned `:7837`:

- a `separate`-mode dev daemon's hook-authoritative waiting/ready tier silently received nothing;
- the onboarding factory's `:7838` coexist recorder could never observe a hook-driven cell — which is why `codex × 2-19_tool-gate-permission-prompt` (#1171) is `daemon_capability: full` but stuck at `pending-record`.

## Approach

`core/pkg/daemonaddr` is the single source of truth for the daemon's bind address and for the loopback URL same-machine clients should reach it on, resolved from `IRRLICHT_BIND_ADDR`. `main.go`/`startup.go` delegate to it, and so do the three installers.

Resolution is a pure function of the environment on purpose: the installers run from permission `Apply` closures inside adapter packages that are constructed *before* the TCP listener exists (`agents.All()` at `main.go:234`, `setupTCPListener` at `:289`), so there is no resolved address to thread down to them and no process-wide mutable state is introduced.

## Back-compat

The sentinels that identify irrlicht-managed entries drop the `localhost:7837` prefix and become port-independent path substrings (`/api/v1/hooks/claudecode`, `/api/v1/hooks/codex`). An existing `:7837` entry therefore still reads as ours, and because `hookEntryIsCanonical` compares against the *currently resolved* endpoint, the existing stale-delivery upgrade rewrites it in place at the new port rather than orphaning it beside an appended duplicate. Uninstall stays port-agnostic for the same reason.

The Claude Code statusline v3 wrap is now detected structurally — our sentinel sitting left of the `) | ` boundary, which is what distinguishes it from a v2 wrap — instead of by a full literal prefix. Without that, a port change would fail the prefix match, fall through to the v1/v2 branch, fail again, and clobber a user's own chained statusline command with the standalone install.

## Recorder safety

`~/.claude/settings.json` and `$CODEX_HOME/hooks.json` follow `$HOME`, not `IRRLICHT_HOME`, so `IRRLICHT_ONBOARD_HOME` never isolated them. Now that the recorder writes its *own* port there, `run-cell.sh` snapshots both files before starting the daemon and restores them on cleanup — otherwise a coexist recording would leave the production daemon's hooks pointing at the recorder. With that in place, `precheck.sh`'s refusal to record claudecode in coexist mode is obsolete and removed.

## Verification

- `go test ./core/... -race -count=1` — pass
- `go test ./tools/onboarding-factory/... -race -count=1` — pass
- `tools/replay-fixtures.sh`, `of validate`, `smoke-test.sh` — pass
- `tools/preflight.sh` — every gate passes except the security scan, which fails on a pre-existing high `postcss` advisory in `tools/onboarding-factory/internal/viewer/web`; that tree is untouched by this diff.

New coverage: `core/pkg/daemonaddr/daemonaddr_test.go`, plus `hookport_test.go` in each of the two adapters — alt-port install, in-place upgrade of a `:7837` install (asserting no duplicate group), legacy-curl migration on an alt port, port-agnostic uninstall, and for the statusline, that repointing a wrap preserves and round-trips the user's own command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)