### PR TITLE
fix(ir:exec): delegate step 13 to a review subagent running a repo-owned ir:code-review skill

### DIFF
--- a/.claude/skills/ir:code-review/SKILL.md
+++ b/.claude/skills/ir:code-review/SKILL.md
@@ -40,8 +40,9 @@ git diff --stat <base>                     # scope
 git diff <base>                            # the review surface
 ```
 
-Pass `base` explicitly when reviewing inside a worktree, because both of the
-convenient defaults mislead there: the local `main` ref is stale (never updated
+This skill already defaults to `origin/main...HEAD`. Keep it — inside a
+worktree, both of the defaults you'd otherwise reach for by hand mislead:
+the local `main` ref is stale (never updated
 when other PRs merge, so `main...HEAD` drags in already-merged hunks), and once
 the branch has been pushed with `git push -u`, `@{upstream}...HEAD` is ~empty
 (upstream now points at the pushed branch, so it reviews nothing).
@@ -127,11 +128,17 @@ Rank **most-severe first**. Every finding carries:
 | `category` | `correctness` · `convention` · `test-coverage` · `efficiency` · `simplification` |
 | `verdict` | `CONFIRMED` / `PLAUSIBLE` — omit at `low`, where no verify pass ran |
 
-If the `ReportFindings` tool is available, call it once with the surviving
-findings (empty array if none survived) and do not also print them as prose.
-Otherwise return the same fields as your final text — when running as a
-subagent, that text **is** the return value to the caller, so it must be the
-findings themselves, not a description of having reviewed.
+**Always put the findings in your final text**, carrying the fields above.
+This is not optional and not a fallback: when you run as a subagent — the
+common case, and the one `ir:exec` step 13 depends on — your tool calls never
+reach the agent that spawned you. Only your final text does. A reply like
+*"reviewed at medium effort, 3 findings reported"* delivers nothing to the
+caller, and worse, reads to it as a **clean** gate.
+
+`ReportFindings` is an *additional* rendering channel, not a substitute for
+that text. Call it once (empty array if nothing survived) only when you are
+the main-loop agent and the active review instructions ask for it; a subagent
+should skip it and simply return the findings.
 
 Always state the effort you actually ran at, and say **"no findings"**
 explicitly when that's the outcome — a silent report is indistinguishable from

--- a/.claude/skills/ir:code-review/SKILL.md
+++ b/.claude/skills/ir:code-review/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: ir:code-review
+description: Review a working diff for defects and report findings worst-first — the repo-owned, agent-invocable counterpart to the built-in `/code-review`, which is `disable-model-invocation` and can only be run by a human. Scales from a single read to an adversarially-verified pass, and checks this repo's own conventions (three-state model, hexagonal layering, permission gating, defect-tests-seen-red) on top of ordinary correctness. Invoked as `/ir:code-review [effort] [base]`. Triggers on "/ir:code-review", "review the diff", "review my changes", "review this branch", or when `ir:exec` Phase 5 reaches its review gate.
+---
+
+# Review the Working Diff
+
+```
+/ir:code-review [effort] [base]
+```
+
+| Argument | Values | Default |
+|---|---|---|
+| `effort` | `low` · `medium` · `high` · `xhigh` · `max` | `medium` |
+| `base` | any git diff spec | `origin/main...HEAD` |
+
+Both are positional and both optional: `/ir:code-review`, `/ir:code-review high`,
+and `/ir:code-review low origin/main...HEAD` are all valid. A bare effort word is
+an **effort**, never a PR number — this skill reviews a local diff and never
+takes a PR argument.
+
+## Why this skill exists
+
+The built-in `/code-review` is marked `disable-model-invocation`: the `Skill`
+tool refuses it and it cannot be reached from `Bash` either. It is a
+human-triggered path. That left `ir:exec`'s review gate unrunnable (#1205),
+so this is the repo's own reviewer — same job, agent-invocable, and aware of
+conventions in `AGENTS.md` that a general-purpose reviewer wouldn't check.
+
+It is **not** a replacement for the real thing. For a large or risky diff,
+a human running `/code-review <tier> origin/main...HEAD` — or `/code-review
+ultra` for the cloud multi-agent pass — is still the stronger review, and
+recommending that is a legitimate outcome of this skill.
+
+## 1 · Resolve the diff
+
+```bash
+git fetch origin main                      # refresh the base before diffing
+git diff --stat <base>                     # scope
+git diff <base>                            # the review surface
+```
+
+Pass `base` explicitly when reviewing inside a worktree, because both of the
+convenient defaults mislead there: the local `main` ref is stale (never updated
+when other PRs merge, so `main...HEAD` drags in already-merged hunks), and once
+the branch has been pushed with `git push -u`, `@{upstream}...HEAD` is ~empty
+(upstream now points at the pushed branch, so it reviews nothing).
+`origin/main...HEAD` after a fetch is the honest surface.
+
+Review **only** what the diff changed, plus whatever the change puts at risk.
+An unrelated pre-existing wart is not a finding.
+
+## 2 · Effort ladder
+
+Effort buys depth, and above `low` it buys an adversarial verify pass. Each tier
+includes everything below it.
+
+| Effort | Find | Verify pass |
+|---|---|---|
+| `low` | One careful read of the whole diff; obvious correctness and convention breaks | none — report findings unverified |
+| `medium` | Trace each changed code path to its callers; check the tests that cover it | one refutation attempt per finding |
+| `high` | Probe blast radius beyond the diff; confirm tests genuinely exercise the new behaviour rather than merely passing | 3 independent refutation attempts per finding |
+| `xhigh` | Re-derive the change's intent from the issue/PR and check the diff actually achieves it; hunt edge cases by construction | 3 attempts, each from a distinct lens (correctness · security · does-it-reproduce) |
+| `max` | Everything above, plus a completeness critic: what did this review not look at? | 3 distinct-lens attempts, then re-review whatever the critic surfaced |
+
+Never escalate past the effort you were given. If the diff clearly warrants
+more, say so in the report instead of silently spending it.
+
+## 3 · Dimensions
+
+Defects first — this skill hunts bugs. Quality cleanups are secondary here
+(`/simplify` owns that pass, and `ir:exec` runs it separately).
+
+- **Correctness** — logic errors, off-by-one, nil/zero-value handling, error
+  paths that swallow or mis-wrap, concurrency (races, unsynchronised shared
+  state, aliasing of returned structs), resource leaks, boundary conditions.
+- **Repo conventions** (`AGENTS.md` Key Conventions — a break here is a real
+  finding, not a nit):
+  - Three session states only — `working`, `waiting`, `ready`. No cancelled state.
+  - Hexagonal import direction: `domain/` → `ports/` → `adapters/` →
+    `application/services/`. `domain/` and `ports/` must not import outward;
+    `application/services/` reaches `adapters/inbound/` only through `ports/`.
+  - Errors are logged via the `Logger` interface, not propagated with `fmt.Errorf`.
+  - Child sessions (subagents, background agents) link via `ParentSessionID`.
+  - Every adapter read or modification is consent-gated behind one of its
+    declared `Permissions` — nothing exercised while pending or denied.
+  - Format-specific transcript parsers live in the agent adapter package, not
+    in shared tailer code.
+- **Test coverage** — does a test actually reach the changed behaviour? A
+  defect fix needs a test that was **seen red** before the fix existed; a test
+  that passes on `main` either doesn't reach the defect or the diagnosis is
+  wrong. Flag a green-that-was-never-red as a finding.
+- **Efficiency** — needless O(n²) over a hot path, repeated work in a loop,
+  redundant I/O or process scans.
+- **Simplification / altitude** — only when the diff reimplements something
+  the repo already has, or sits at the wrong layer.
+
+## 4 · Verify (skipped at `low`)
+
+An unverified finding is a guess. For each candidate, try to **refute** it:
+construct the concrete input and state that would trigger it, then look for the
+guard, caller check, or type constraint that already prevents it.
+
+- **Default to refuted when uncertain.** A finding you can't demonstrate is
+  noise, and noise is what makes reviews get ignored.
+- At `high` and above, run the attempts independently and kill the finding when
+  a majority refute it.
+- Survivors carry a verdict: **`CONFIRMED`** when you traced a concrete path to
+  the failure, **`PLAUSIBLE`** when the reasoning holds but you could not prove
+  the trigger reachable.
+
+Applies to your own dismissals too, per `AGENTS.md`: *"already handled
+upstream"* or *"self-heals"* needs the same evidence as the finding it kills —
+cite what you read, or mark it assumed.
+
+## 5 · Report
+
+Rank **most-severe first**. Every finding carries:
+
+| Field | Content |
+|---|---|
+| `file` | repo-relative path |
+| `line` | 1-indexed line it anchors to |
+| `short_summary` | ≤60 chars — the claim alone, no rationale |
+| `summary` | one sentence stating the defect |
+| `failure_scenario` | concrete inputs/state → wrong output or crash |
+| `category` | `correctness` · `convention` · `test-coverage` · `efficiency` · `simplification` |
+| `verdict` | `CONFIRMED` / `PLAUSIBLE` — omit at `low`, where no verify pass ran |
+
+If the `ReportFindings` tool is available, call it once with the surviving
+findings (empty array if none survived) and do not also print them as prose.
+Otherwise return the same fields as your final text — when running as a
+subagent, that text **is** the return value to the caller, so it must be the
+findings themselves, not a description of having reviewed.
+
+Always state the effort you actually ran at, and say **"no findings"**
+explicitly when that's the outcome — a silent report is indistinguishable from
+a skipped gate.
+
+**Do not fix anything.** Report only; the caller owns the worktree and decides
+what to act on. Where the diff is large or risky enough that this pass isn't
+enough, say so and recommend a human `/code-review`.

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ir:exec
-description: End-to-end execution of a GitHub issue via `/ir:exec [mode] <N>` — open a worktree, investigate, then either present a visual HTML plan for approval or proceed straight to implementation (mode-dependent), open a PR, review it with /code-review, fix findings, simplify, hand back the PR link with a test-or-merge recommendation, and land the merge on request. `mode` defaults to `auto`, which picks `plan` or `full` from the issue's `/ir:triage` signals. Triggers on "/ir:exec", "exec issue", "implement issue", "plan issue", or when the user gives an issue number/URL and asks to plan, implement, or land it.
+description: End-to-end execution of a GitHub issue via `/ir:exec [mode] <N>` — open a worktree, investigate, then either present a visual HTML plan for approval or proceed straight to implementation (mode-dependent), open a PR, review it with a dedicated review subagent, fix findings, simplify, hand back the PR link with a test-or-merge recommendation, and land the merge on request. `mode` defaults to `auto`, which picks `plan` or `full` from the issue's `/ir:triage` signals. Triggers on "/ir:exec", "exec issue", "implement issue", "plan issue", or when the user gives an issue number/URL and asks to plan, implement, or land it.
 ---
 
 # Execute a GitHub Issue, End to End
@@ -21,7 +21,7 @@ argument.
   → worktree → investigate → (auto resolves to plan or full here)
     → plan: HTML + ⛔ approval, or full: inline summary → assign issue
     → implement → verify
-    → PR → /code-review (effort scaled to diff) → fix → /simplify (or inline) → recommendation [plan / full stop here]
+    → PR → review subagent (effort scaled to diff) → fix → /simplify (or inline) → recommendation [plan / full stop here]
     → land: confirm mergeable → squash-merge → remove worktree   [close]
 ```
 
@@ -273,7 +273,7 @@ git diff --shortstat origin/main...HEAD   # files + lines; origin/main, not loca
 many packages?) and read it into one of four tiers. These are calibration
 anchors, not hard gates — use judgment at the boundaries:
 
-| Diff tier | Looks like | Step 13 review | Step 14 simplify |
+| Diff tier | Looks like | Step 13 review effort | Step 14 simplify |
 |---|---|---|---|
 | **Trivial** | docs / comments / string-constants / config only, or ≤~30 non-test lines in 1 file | `low` | **skip the fan-out** — do an inline reuse/simplification/efficiency/altitude glance and say so |
 | **Small** | 1–3 files, one concern, no new logic, <~150 lines | `low` | inline glance, no 4-agent fan-out |
@@ -287,10 +287,12 @@ predicted level is a budget, a real diff is evidence. A large gap in either
 direction is worth one line in the Phase 6 hand-back: it is the only feedback
 the levelling scale ever gets.
 
-**Guardrails (unconditional):** never auto-select `/code-review ultra` (the
-cloud, billed, human-only path) and never use the Workflow tool for either
-step. The auto range is bounded **low↔high**; `max`/`ultra` stay
-human-triggered.
+**Guardrails (unconditional):** the built-in `/code-review` is human-only at
+*every* tier (it is `disable-model-invocation`), so no run auto-selects it —
+least of all `ultra`, the cloud, billed path. Step 13 is bounded to **one**
+review subagent at **low↔high** effort; `xhigh`/`max` and anything reaching for
+the built-in stay human-triggered, and the Workflow tool is never used for
+either step.
 
 12. **Open the PR** against `main`:
     ```bash
@@ -298,16 +300,37 @@ human-triggered.
     gh pr create --base main --fill   # or a written title/body; reference "Closes #<N>"
     ```
     End the PR body with the `🤖 Generated with [Claude Code]` line.
-13. **Review the diff** at the **calibrated effort** (`low` for trivial/small,
-    up to `high` for large/risky — never `ultra`/Workflow). Run the
-    `/code-review` skill with the **explicit base** `origin/main...HEAD` (e.g.
-    `/code-review low origin/main...HEAD`), then fix every finding it surfaces
-    in the worktree and push the fixes. A single review pass, not a fan-out.
-    Pass the base explicitly because in this worktree *both* of the skill's own
+13. **Review the diff** at the **calibrated effort** — by delegating to a
+    single review subagent, not by reviewing it yourself (the mind that just
+    wrote the code is the weakest available reviewer of it). Spawn one `Agent`
+    (`subagent_type: general-purpose`, `run_in_background: false` so Phase 5
+    can't race past its own gate) whose prompt names:
+    - the worktree path, the issue number, and one line of intent — a fresh
+      reviewer knows nothing about the plan, so a deliberate decision left
+      unstated comes back as a finding;
+    - the **effort** from the tier table above;
+    - the **explicit base** `origin/main...HEAD`;
+    - the instruction to follow `.claude/skills/ir:code-review/SKILL.md` —
+      point at it *by path*, which works whether or not skill invocation is
+      available inside a subagent.
+
+    The reviewer reports; **you** fix. Apply every surviving finding in the
+    worktree, push, and state in the transcript what came back — including an
+    explicit "no findings", so a clean gate stays distinguishable from a
+    skipped one. **One subagent, never a fan-out**, and never the Workflow tool.
+
+    Pass the base explicitly because in this worktree *both* of the convenient
     defaults mislead: the local `main` ref is stale (never updated when other
     PRs merge, so `main...HEAD` drags in already-merged hunks) and after step
     12's `git push -u`, `@{upstream}...HEAD` is ~empty (upstream now points at
     the pushed branch, so it reviews nothing).
+
+    ⚠ **Neither built-in review skill is a substitute.** `/code-review` is
+    `disable-model-invocation`: the `Skill` tool refuses it and it cannot be
+    reached from `Bash` either — don't attempt it. `/review` is *not* a
+    fallback either; it parses its first argument as a PR number, so
+    `/review low origin/main...HEAD` runs `gh pr view low` and reviews a PR
+    that doesn't exist. A *human* can still run `/code-review` — see step 15.
 14. **Simplify per the tier.** For **Medium/Large** diffs run the `/simplify`
     skill with the same explicit base (`/simplify origin/main...HEAD`, for the
     reason in step 13); for **Trivial/Small** diffs skip its 4-agent fan-out
@@ -318,13 +341,16 @@ human-triggered.
 
 15. **Present the final PR link** and ask whether the user wants to **test** or **merge**.
     Make a recommendation, and let your **confidence** decide which you lead with:
-    - **Lean merge** when: `/code-review` came back clean (no unresolved findings), all
-      relevant suites are green, and the diff is small/low-risk and fully covered by
-      tests. Suggested: proceed to Phase 7 (land), or `/ir:exec close`.
+    - **Lean merge** when: the review subagent came back clean (no unresolved
+      findings), all relevant suites are green, and the diff is small/low-risk and
+      fully covered by tests. Suggested: proceed to Phase 7 (land), or `/ir:exec close`.
     - **Lean test-first** when: review raised non-trivial findings, tests are
       failing/flaky/absent for the behavior, the diff is large or risky, or the change
       is user-visible and only confirmable by running it. Point at `/verify`, or
-      `/ir:test-mac` for macOS-app changes.
+      `/ir:test-mac` for macOS-app changes. For a **large or risky** diff, also say
+      plainly that step 13's subagent is the weaker reviewer and suggest the user run
+      `/code-review <tier> origin/main...HEAD` themselves before merging — that path
+      is human-only, so offering it is the only way it ever happens.
     State the recommendation in one line with the reason; the merge decision is the
     user's. A reply of "merge" (or `/ir:exec close`) moves into Phase 7.
 
@@ -358,7 +384,9 @@ Phase 6.
 - One worktree + one branch + one PR per issue.
 - Scale Phase 5 to the diff (the tier table there): trivial changes get a `low`
   review and an inline simplify glance, not a `high` review and a four-agent
-  fan-out. Depth follows the change, and never auto-escalates to `ultra`/Workflow.
+  fan-out. Depth follows the change. Step 13 always delegates to exactly one
+  review subagent running `.claude/skills/ir:code-review/SKILL.md` — it never
+  reaches for the built-in `/code-review` (human-only) and never uses Workflow.
 - User-facing features ship on every applicable frontend (macOS + web), or the plan
   says explicitly why not (Phase 2). Verify each one directly rather than trusting an
   adjacent green test suite (Phase 4) — see the Activity Matrix incident above.

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -280,6 +280,25 @@ anchors, not hard gates — use judgment at the boundaries:
 | **Medium** | 2–5 files / one slice / some new logic | `medium` | run `/simplify` (fan-out is fine) |
 | **Large / risky** | multi-package, schema, cross-adapter, logic-heavy, >~400 lines | `high` | run `/simplify` (fan-out) |
 
+**The two columns are read independently.** A diff can legitimately land on
+different rows for review and for simplify, and forcing one row on both is a
+misread, not consistency. Take each column from whichever row describes that
+axis best:
+
+- **Review effort** follows how much *new behaviour or procedure* the diff
+  introduces — how much there is to get wrong.
+- **Simplify depth** follows what *kind of material* changed — a 4-agent
+  code-simplification fan-out returns nothing on prose, config, or fixtures
+  no matter how long the diff is.
+
+Worked example (this skill's own #1205 PR): docs-only markdown, which is the
+**Trivial** row's decisive clause for simplify — but two files of substantive
+new procedure, so **Medium** for review. Split that way, the `medium` review
+found a real defect that a `low` pass would have missed, while a `/simplify`
+fan-out would have had nothing to chew on. **Say which row you took each
+column from** whenever they differ, so the split is a visible decision rather
+than a silent inconsistency.
+
 **These tiers are the post-hoc correction.** Triage's run plan set a *predicted*
 review effort before any code existed; this table measures what the change
 actually turned out to be. When the two disagree, **this table wins** — a
@@ -302,9 +321,22 @@ either step.
     End the PR body with the `🤖 Generated with [Claude Code]` line.
 13. **Review the diff** at the **calibrated effort** — by delegating to a
     single review subagent, not by reviewing it yourself (the mind that just
-    wrote the code is the weakest available reviewer of it). Spawn one `Agent`
-    (`subagent_type: general-purpose`, `run_in_background: false` so Phase 5
-    can't race past its own gate) whose prompt names:
+    wrote the code is the weakest available reviewer of it).
+
+    **Confirm the reviewer exists first.** This step's entire substance lives
+    in another file, so a moved or renamed skill leaves the subagent pointed at
+    a dead path, reviewing from nothing — the same silent degradation #1205 was
+    about, wearing a different mask:
+    ```bash
+    test -f .claude/skills/ir:code-review/SKILL.md && echo OK || echo MISSING
+    ```
+    On `MISSING`, **surface it and pause** — don't improvise a review, don't
+    fall through to step 14 — the idiom step 9 uses for a failed self-assign
+    and step 18 for an unmergeable PR.
+
+    Then spawn one `Agent` (`subagent_type: general-purpose`,
+    `run_in_background: false` so Phase 5 can't race past its own gate) whose
+    prompt names:
     - the worktree path, the issue number, and one line of intent — a fresh
       reviewer knows nothing about the plan, so a deliberate decision left
       unstated comes back as a finding;

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -312,7 +312,12 @@ either step.
     - the **explicit base** `origin/main...HEAD`;
     - the instruction to follow `.claude/skills/ir:code-review/SKILL.md` —
       point at it *by path*, which works whether or not skill invocation is
-      available inside a subagent.
+      available inside a subagent;
+    - an explicit **"return the findings themselves as your final text"**. A
+      subagent's tool calls never reach you — only its final message does — so
+      a reviewer that files its findings through a tool and replies "3 findings
+      reported" hands you nothing, and an empty-looking return reads as a clean
+      gate at step 15.
 
     The reviewer reports; **you** fix. Apply every surviving finding in the
     worktree, push, and state in the transcript what came back — including an


### PR DESCRIPTION
## Problem

`ir:exec` Phase 5 step 13 instructed the agent to run the `/code-review` skill. It can't: `/code-review` is `disable-model-invocation`, so the `Skill` tool refuses it outright and it isn't reachable from `Bash` either.

```
Skill(code-review, "low origin/main...HEAD")
  → Error: Skill code-review cannot be used with Skill tool due to
    disable-model-invocation
```

The step was unrunnable as written, so every `ir:exec` run silently degraded at its review gate and what happened next depended on whichever fallback the agent improvised. The natural fallback is worse than nothing — `/review` parses its first argument as a PR number:

```
/review low origin/main...HEAD  →  gh pr view low  →  reviews a PR that doesn't exist
```

## Fix

**New: `.claude/skills/ir:code-review/SKILL.md`** — a repo-owned, agent-invocable reviewer, authored against this repo rather than lifted from anywhere. It mirrors the built-in's contract as closely as it can be observed from the outside:

- worst-first findings carrying `file` / `line` / `short_summary` / `summary` / `failure_scenario` / `category`
- `CONFIRMED` vs `PLAUSIBLE` verdicts, with the verdict omitted at `low` where no verify pass runs
- `low` → `medium` → `high` → `xhigh` → `max` effort ladder, each tier buying concrete extra work
- dimensions → find → adversarially verify → report, with "default to refuted when uncertain"
- emits via `ReportFindings` when that tool is available, else the same fields as its final text

On top of that it checks what a general-purpose reviewer wouldn't know to look for, from `AGENTS.md`: three session states only, hexagonal import direction, `Logger` over `fmt.Errorf`, `ParentSessionID` linking, permission gating on every adapter read/write, parsers-in-adapters, and defect-tests-seen-red.

It's independently useful — `/ir:code-review medium origin/main...HEAD` works outside `ir:exec` entirely.

**Changed: step 13** now spawns exactly one synchronous review subagent pointed at that skill *by path* (robust whether or not skill invocation is available inside a subagent), passing the tier, the base, the issue number, and one line of intent. The review runs outside the implementer's context, and the reviewer isn't the mind that just wrote the code. The orchestrator fixes what comes back and must state the outcome in the transcript — including an explicit "no findings", so a clean gate stays distinguishable from a skipped one.

## Also swept

The issue named step 13, but five further sites still referenced the uncallable skill:

| Site | Was |
|---|---|
| frontmatter `description:` | "review it with /code-review" — the dispatcher-visible summary |
| flow diagram (line 24) | `→ PR → /code-review (effort scaled to diff) →` |
| guardrails ¶ | "never auto-select `/code-review ultra`" — implied other tiers *were* selectable |
| Phase 6 merge criterion | "`/code-review` came back clean" — never evaluable, nothing by that name ran |
| Notes bullet | same misleading `ultra`/Workflow framing |

Phase 6 now also tells the user, for large or risky diffs, that step 13's subagent is the weaker reviewer and a human-run `/code-review` is worth it before merging — that path is human-only, so offering it is the only way it happens.

Preserved unchanged: #1152's tier calibration (row values untouched — only the column header retitled) and #1160's `origin/main...HEAD` base plus its two-part rationale, which step 14 still cross-references.

## Verification

- No surviving `/code-review` mention reads as an instruction to the agent — all seven are either about the human-only path or the path to the new repo skill.
- Step numbering 12→13→14→15 contiguous; step 14's "for the reason in step 13" still resolves to surviving text.
- Skills-only diff: touches no Go or web package, so those suites are unaffected.
- This PR's own Phase 5 is the first live exercise of the new path.

Closes #1205

🤖 Generated with [Claude Code](https://claude.com/claude-code)