### PR TITLE
test(factory): floor $HOME so the snapshot test can never reach a real config

### DIFF
--- a/tools/onboarding-factory/scripts/lib/hook-config-snapshot_test.sh
+++ b/tools/onboarding-factory/scripts/lib/hook-config-snapshot_test.sh
@@ -17,6 +17,18 @@ source "$DIR/hook-config-snapshot.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# Floor under every case: point $HOME and $CODEX_HOME somewhere harmless before
+# the first one runs. fresh_env overrides both per-case, so this changes nothing
+# about what the tests exercise — it exists so a case that is added above the
+# first fresh_env call, or forgets it, cannot reach the developer's real
+# ~/.claude/settings.json. That is not hypothetical: a draft of this file did
+# exactly that and wiped a live config's statusLine and all seven irrlicht hook
+# entries (#1212). These paths are deliberately NOT created — an omitted
+# fresh_env then fails loudly on a missing directory instead of silently
+# writing somewhere plausible.
+HOME="$TMP/nohome"
+CODEX_HOME="$TMP/nocodex"
+
 fails=0
 pass() { echo "  PASS: $1"; return 0; }
 fail() { echo "  FAIL: $1 — expected [$2] got [$3]"; fails=$((fails + 1)); return 0; }


### PR DESCRIPTION
Closes #1212.

## Problem

`hook-config-snapshot_test.sh` only redirects `$HOME` **inside** `fresh_env()`. Any case that runs before it — or forgets to call it — writes to the developer's real `~/.claude/settings.json`.

That is not hypothetical. A draft of this very file did exactly that on 2026-07-31 at 16:41:51, writing its own fixture over a live config:

```
{"hooks":{"Stop":"localhost:7837"}}
```

It destroyed the `statusLine` entry **and** all seven irrlicht hook entries. The daemon kept detecting sessions via transcripts, so the only visible symptom was the Claude Code status line vanishing — statusline ingestion stopped dead for 18 minutes. No backup existed (no Time Machine destination; newest `settings.json.backup_*` was from Nov 2025), so recovery meant hand-reconstructing the file and re-running `EnsureHooksInstalled()` / `EnsureStatuslineInstalled()`.

The draft was fixed minutes later and the committed test is correctly isolated. This PR removes the residual hazard, which is structural: nothing stops the next case from being added above the first `fresh_env` call.

The risk is inherent to this area — per the lib's own header, `~/.claude/settings.json` and `$CODEX_HOME/hooks.json` follow `$HOME`, not `IRRLICHT_HOME`, so `IRRLICHT_ONBOARD_HOME` does not isolate them.

## Change

Point `$HOME` and `$CODEX_HOME` at non-existent paths under `$TMP`, immediately after `TMP` is created and before the first case:

```bash
HOME="$TMP/nohome"
CODEX_HOME="$TMP/nocodex"
```

`fresh_env` still overrides both per-case, so what the tests exercise is unchanged — this is purely a floor. The paths are **deliberately not created**, so an omitted `fresh_env` fails loudly on a missing directory instead of silently writing somewhere plausible.

Swept the four sibling `lib/*_test.sh` files: none of them touch `$HOME`, so the fix stays scoped to this one file.

## Verification

- `bash tools/onboarding-factory/scripts/lib/hook-config-snapshot_test.sh` — all 5 assertions pass.
- `bash tools/onboarding-factory/scripts/smoke-test.sh` — `smoke-test: PASS`.
- Real `~/.claude/settings.json` verified byte-identical (sha1) before and after both runs.
- Negative proof: injected a case that writes to `$HOME/.claude/settings.json` *before* any `fresh_env`. It targeted `$TMP/nohome/.claude/settings.json` and failed loudly with `No such file or directory`; the real config was untouched. (The destructive path was **not** re-run against a real `$HOME`.)

## Base branch

Targets `feat/1178-configurable-hook-port` (PR #1207), not `main` — the file it hardens does not exist on `main` yet; #1207 introduces it. Safe under either merge order: if #1207 lands first, this retargets to `main` and still applies; if this lands first, #1207 carries it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)