### PR TITLE
docs(ir:exec): guard against duplicate work and verify self-assign by login

### DIFF
--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -18,7 +18,7 @@ argument.
 
 ```
 /ir:exec [mode] <N>
-  → worktree → investigate → (auto resolves to plan or full here)
+  → not-already-claimed? → worktree → investigate → (auto resolves to plan or full here)
     → plan: HTML + ⛔ approval, or full: inline summary → assign issue
     → implement → verify
     → PR → /code-review (effort scaled to diff) → fix → /simplify (or inline) → recommendation [plan / full stop here]
@@ -86,6 +86,27 @@ worktree name. `close` additionally resolves it from `pwd` / `git status -sb` /
 ## Phase 1 — Worktree
 
 1. **Resolve the issue number** and a short kebab slug from its title.
+1a. **Confirm nobody is already on it** — a precondition of `worktree add`, not a
+   courtesy. Concurrent `ir:exec` agents are the normal mode of operation here,
+   and a collision is invisible from both sides: an issue number on its own says
+   nothing about work already in flight.
+   ```bash
+   gh pr list --state open --search "<N>" --json number,headRefName,title
+   git worktree list | grep -w "<N>"
+   git ls-remote --heads origin | grep -w "<N>"
+   ```
+   Step 2's own "skip if already in a clean, issue-matching worktree" guard does
+   not cover this: it inspects `pwd`, so it only ever sees the worktree this
+   session is standing in — never one another agent opened.
+
+   On any hit, **surface it and pause before creating anything** — the same idiom
+   step 9 and Phase 7 step 18 use. Report what you found and let the human choose:
+   continue the existing branch, review the open PR, or open a second one
+   deliberately. Never silently reimplement. (Real incident: #1178 had an open,
+   CI-green PR — #1207 — *and* a live worktree with uncommitted WIP. `ir:exec`
+   opened a second branch anyway, ran a complete independent implementation that
+   converged on the same design, and only tripped over the duplicate at Phase 5
+   while grepping for something unrelated. The entire branch was discarded.)
 2. **Open a dedicated worktree** off the latest `main` (skip if already in a clean,
    issue-matching worktree — run `pwd` + `git status -sb` to check):
    ```bash
@@ -212,12 +233,24 @@ Nobody is gating on the plan, so skip the HTML artifact and the wait entirely:
 9. **Assign the issue** — a gated precondition of starting Phase 4, not a step to
    fire-and-forget:
    ```bash
+   ME="$(gh api user -q .login)"
+   gh issue view <N> --json assignees -q '[.assignees[].login]'   # before: did @me already own it?
    gh issue edit <N> --add-assignee @me   # add --repo <owner/repo> for cross-repo
-   gh issue view <N> --json assignees -q '.assignees | length'
+   gh issue view <N> --json assignees -q "[.assignees[].login] | index(\"$ME\") != null"
    ```
-   If the count comes back `0`, retry the `edit` once and re-check; if it's still
-   `0`, **surface that and pause** rather than silently proceeding unassigned — the
-   same idiom Phase 7 uses for an unmergeable PR.
+   Verify by **login, not by count**. `.assignees | length` is `>= 1` whenever
+   *anyone* is assigned, so it reports success even when the `--add-assignee` did
+   nothing at all — which is exactly what happens when `@me` resolves to an account
+   that already owned the issue. If the check comes back `false`, retry the `edit`
+   once and re-check; if it's still `false`, **surface that and pause** rather than
+   silently proceeding unassigned — the same idiom Phase 7 uses for an unmergeable
+   PR.
+
+   The "before" read is what makes an abort safe. If the run is later abandoned,
+   **do not blanket-`gh issue edit <N> --remove-assignee @me`** on the way out:
+   when `@me` was already in that list, the removal strips a pre-existing human
+   assignment that was never yours to clear. Remove only what this step actually
+   added.
 10. **Push through the implementation** in the worktree.
     - If the work is complex/multi-part, break it into tasks with `TaskCreate` and work
       them in order (as you naturally would). For a small change, just implement it.
@@ -355,7 +388,9 @@ Phase 6.
 - Keep the plan tight: if Steps run past ~8–10 entries, you're over-planning; collapse.
 - If the issue is ambiguous, surface it under Risks/unknowns in the plan rather than
   guessing — that's what the approval gate is for.
-- One worktree + one branch + one PR per issue.
+- One worktree + one branch + one PR per issue. Phase 1 step 1a is what enforces
+  that against *other* agents' work, not just your own — run it before
+  `worktree add`, every time.
 - Scale Phase 5 to the diff (the tier table there): trivial changes get a `low`
   review and an inline simplify glance, not a `high` review and a four-agent
   fan-out. Depth follows the change, and never auto-escalates to `ultra`/Workflow.


### PR DESCRIPTION
Closes #1218.

Two gaps in `.claude/skills/ir:exec/SKILL.md`, both observed in a single real run (`/ir:exec full 1178`).

## 1. Phase 1 opened a worktree without checking for existing work — new step 1a

Phase 1 went straight from resolving the issue number to `git worktree add`. Its only guard, *"skip if already in a clean, issue-matching worktree"*, inspects `pwd` — so it only ever sees the worktree the current session is standing in, never one another agent opened.

Issue #1178 already had **open, CI-green PR #1207** *and* a live worktree with uncommitted WIP. `ir:exec` opened a second branch anyway and ran a complete independent implementation — which converged on the same design — before the duplicate was noticed at Phase 5, by accident, while grepping for something unrelated. The whole branch was thrown away.

Step 1a probes for an open PR, a local worktree, and a remote branch matching the issue, then **surfaces and pauses** on any hit (the same idiom step 9 and Phase 7 step 18 already use) rather than refusing outright — the human decides whether to continue the existing branch, review the PR, or open a second one deliberately.

## 2. Phase 4 step 9 verified self-assign by count — now by login

```
gh issue view <N> --json assignees -q '.assignees | length'
```

is `>= 1` whenever *anyone* is assigned, so it reports success even when the `--add-assignee` did nothing — which is exactly what happens when `@me` resolves to the account that already owned the issue. On #1178 the add was a no-op and the check returned `1`, verifying nothing.

Step 9 now reads the assignee list *before* the edit and verifies `@me` is in it *after*. The "before" read also makes the abort path safe: a blanket `--remove-assignee @me` on abandonment cleared the owner's pre-existing assignment on #1178 and had to be restored by hand — the step now says not to do that.

## Notes

- **Numbered `1a`**, mirroring the existing `11a`, deliberately: the skill's steps are one continuous 1–21 list, and seven references point at steps by number (`step 10`, `steps 13–14`, `Step 13`/`Step 14`, `step 11a` in both this file and `AGENTS.md`, `Phase 7 step 18`). Inserting a renumbering step would have silently broken all of them.
- **Docs-only** — one markdown file, no Go, no tests, no CI surface. No repo tooling reads this file (`git grep -l 'ir:exec/SKILL' -- '*.go' '*.sh' '*.js' '*.ts'` is empty), so there is nothing to test beyond the diff.
- Step 1a was **dogfooded on this very issue**: run against #1218 before the worktree was created, it correctly reported no PR, no worktree, no remote branch. The step 9 login check was likewise used to assign #1218 (`before: ""` → `after: ingo-eichhorst` → contains `@me`: `true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
