### PR TITLE
refactor(onboarding-factory): one owner for the record-daemon lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ beyond), see the [Roadmap](https://irrlicht.io/docs/roadmap.html).
 **Fixed**
 - The agent hooks the daemon installs now POST to the port the daemon actually binds, instead of a hardcoded `:7837`. A daemon on an alternate port — a `separate`-mode dev instance, or the onboarding factory's coexist recorder — installed Claude Code and Codex hooks (and the Claude Code statusline feed) that delivered to whatever owned `:7837`, so its own hook-authoritative waiting/ready tier silently received nothing. All three installers derive the endpoint from `IRRLICHT_BIND_ADDR`, and the entry sentinels are now port-independent, so an existing `:7837` install is still recognized as ours and repointed in place rather than orphaned beside a duplicate. The onboarding factory's recorder snapshots and restores the shared agent config it rewrites, so a recording no longer leaves the production daemon's hooks pointing at it. (#1178)
 
+**Changed**
+- The onboarding factory's two recording scripts (`run-cell.sh`, `run-cell-multi.sh`) now share one `lib/spawn-record-daemon.sh` for the record-daemon lifecycle, so a recorder fix can no longer reach only one of them. (#1214)
+
 ## [0.5.9] — 2026-07-15
 
 ### A correctness release: sessions no longer wedge at "working" after a background subagent, and agents whose session directories are relocated by an env var or config key are finally visible instead of silently absent

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# spawn-record-daemon.sh — the recording daemon's whole lifecycle, owned once.
+#
+# Two scripts record fixtures against an `irrlichd --record` daemon:
+# run-cell.sh (one adapter) and run-cell-multi.sh (a cross-adapter pair). Both
+# need the same five things — the same env assembly, the same spawn, the same
+# socket-ready wait, the same INT→TERM→KILL shutdown ladder, and the same
+# snapshot/restore of the shared agent config the daemon rewrites. Each used to
+# carry its own copy, so a recorder-lifecycle fix reached only whichever script
+# the author happened to be editing: #1178's hook-config snapshot landed in
+# run-cell.sh alone, and the cross-adapter recorder would still have exited
+# leaving the user's ~/.claude/settings.json repointed at a dead port (#1214).
+#
+# Usage — one call to start, one to stop:
+#   source "$SCRIPT_DIR/lib/spawn-record-daemon.sh"
+#   spawn_record_daemon "$DAEMON" "$STAGING" "$BIND_ADDR" "$ONBOARD_HOME" || exit 1
+#   ... drive the agent ...
+#   stop_record_daemon; trap - EXIT      # drain before reading the recording
+#
+# spawn_record_daemon installs `stop_record_daemon` as the EXIT trap itself, so
+# any failure between spawn and drain still shuts the daemon down and hands the
+# user's config back. Call it explicitly (then clear the trap) when you need the
+# recorder flushed before continuing.
+#
+# Artifacts it writes under <staging>:
+#   daemon.log           — the daemon's stdout+stderr
+#   daemon.shutdown      — how it ended: sigint | sigterm | sigkill | unknown
+#   hook-config-backup/  — the pre-run copy of the shared agent config
+#   recordings/          — IRRLICHT_RECORDINGS_DIR (the caller mkdir -p's it)
+
+# shellcheck source=lib/hook-config-snapshot.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/hook-config-snapshot.sh"
+
+# State published for the caller (and read back by stop_record_daemon).
+RECORD_DAEMON_PID=""
+RECORD_DAEMON_SOCK=""
+RECORD_DAEMON_STAGING=""
+
+# Poll knobs, read at call time. The defaults ARE the production timings; they
+# are overridable only so the unit tests can drive the ladder without spending
+# the grace periods in real seconds.
+#   RECORD_DAEMON_SOCK_TICKS  × SOCK_TICK_S  = 40 × 0.25s = 10s for the socket
+#   RECORD_DAEMON_INT_TICKS   × KILL_TICK_S  = 12 × 0.5s  = 6s grace after INT,
+#                                              i.e. the recorder's 5s flush
+#                                              interval + 1s slack
+#   RECORD_DAEMON_TERM_TICKS  × KILL_TICK_S  =  6 × 0.5s  = 3s grace after TERM
+
+# record_daemon_sock <irrlicht-home> prints the unix socket the daemon will
+# listen on. A non-empty home is coexist mode (the daemon keeps its socket,
+# addr file and state under there); empty means the production layout.
+record_daemon_sock() {
+  local home="${1:-}"
+  if [[ -n "$home" ]]; then
+    printf '%s\n' "$home/irrlichd.sock"
+  else
+    printf '%s\n' "$HOME/.local/share/irrlicht/irrlichd.sock"
+  fi
+}
+
+# record_daemon_env <recordings-dir> <bind-addr> [<irrlicht-home>] prints the
+# daemon's environment, one NAME=VALUE per line, for `env` to apply.
+#
+# grant-all: the consent-first permission gate (#570) would otherwise leave a
+# fresh recording daemon monitoring nothing until a wizard is answered —
+# fixtures must never hang on consent.
+# IRRLICHT_HOME is emitted only in coexist mode; IRRLICHT_READY_SESSION_TTL only
+# when the caller set one (idle-survival cells shrink the 30-min production
+# default to a recordable window), because an explicit env array would otherwise
+# drop the inherited override.
+record_daemon_env() {
+  local recordings="$1" bind="$2" home="${3:-}"
+  printf '%s\n' "IRRLICHT_RECORDINGS_DIR=$recordings"
+  printf '%s\n' "IRRLICHT_BIND_ADDR=$bind"
+  printf '%s\n' "IRRLICHT_PERMISSION_MODE=grant-all"
+  [[ -n "$home" ]] && printf '%s\n' "IRRLICHT_HOME=$home"
+  [[ -n "${IRRLICHT_READY_SESSION_TTL:-}" ]] && printf '%s\n' "IRRLICHT_READY_SESSION_TTL=$IRRLICHT_READY_SESSION_TTL"
+  return 0
+}
+
+# spawn_record_daemon <daemon-bin> <staging-dir> <bind-addr> [<irrlicht-home>]
+# snapshots the shared agent config, starts the daemon, arms the EXIT trap, and
+# waits for its socket. Returns non-zero (after reporting to stderr) if the
+# socket never appears, so the caller can add its own failure bookkeeping —
+# run-cell-multi.sh writes an ERROR run-manifest — before exiting.
+spawn_record_daemon() {
+  local daemon_bin="$1" staging="$2" bind="$3" home="${4:-}"
+
+  RECORD_DAEMON_STAGING="$staging"
+  RECORD_DAEMON_SOCK="$(record_daemon_sock "$home")"
+
+  # Save the shared agent config the daemon is about to rewrite (see
+  # lib/hook-config-snapshot.sh); the shutdown hands it back. Refuse to start if
+  # the backup dir can't be created: restore_hook_configs reads "no backup for
+  # this file" as "the daemon created it", so an unwritable snapshot would end
+  # the run by DELETING the user's real ~/.claude/settings.json.
+  if ! mkdir -p "$staging/hook-config-backup"; then
+    echo "cannot create the hook-config backup dir: $staging/hook-config-backup" >&2
+    return 1
+  fi
+  snapshot_hook_configs "$staging/hook-config-backup"
+
+  # Read the env into an array so a value containing spaces (e.g. an
+  # IRRLICHT_HOME path with a space) stays one word — an unquoted
+  # ${home:+VAR="$home"} would word-split on it.
+  local daemon_env=() kv
+  while IFS= read -r kv; do daemon_env+=("$kv"); done \
+    < <(record_daemon_env "$staging/recordings" "$bind" "$home")
+
+  env "${daemon_env[@]}" "$daemon_bin" --record >"$staging/daemon.log" 2>&1 &
+  RECORD_DAEMON_PID=$!
+  echo "daemon started (pid $RECORD_DAEMON_PID, bind=$bind${home:+, home=$home})"
+
+  trap stop_record_daemon EXIT
+
+  wait_for_record_daemon
+}
+
+# wait_for_record_daemon polls for the unix socket, which signals the daemon is
+# ready to accept connections.
+wait_for_record_daemon() {
+  local _
+  for _ in $(seq 1 "${RECORD_DAEMON_SOCK_TICKS:-40}"); do
+    [[ -S "$RECORD_DAEMON_SOCK" ]] && return 0
+    sleep "${RECORD_DAEMON_SOCK_TICK_S:-0.25}"
+  done
+  echo "daemon socket never appeared: $RECORD_DAEMON_SOCK" >&2
+  return 1
+}
+
+# kill_record_daemon escalates INT -> TERM -> KILL, giving the recorder time to
+# flush between each, and records which signal ended it in <staging>/daemon.shutdown.
+# A daemon that is already gone (or was never spawned) leaves "unknown" there,
+# matching what the pre-extraction scripts wrote.
+kill_record_daemon() {
+  [[ -n "$RECORD_DAEMON_STAGING" ]] || return 0
+  local shutdown_file="$RECORD_DAEMON_STAGING/daemon.shutdown"
+  local reason="unknown" _
+  if [[ -n "$RECORD_DAEMON_PID" ]] && kill -0 "$RECORD_DAEMON_PID" 2>/dev/null; then
+    reason="sigint"
+    kill -INT "$RECORD_DAEMON_PID" 2>/dev/null || true
+    for _ in $(seq 1 "${RECORD_DAEMON_INT_TICKS:-12}"); do
+      kill -0 "$RECORD_DAEMON_PID" 2>/dev/null || { echo "$reason" > "$shutdown_file"; return 0; }
+      sleep "${RECORD_DAEMON_KILL_TICK_S:-0.5}"
+    done
+    reason="sigterm"
+    kill -TERM "$RECORD_DAEMON_PID" 2>/dev/null || true
+    for _ in $(seq 1 "${RECORD_DAEMON_TERM_TICKS:-6}"); do
+      kill -0 "$RECORD_DAEMON_PID" 2>/dev/null || { echo "$reason" > "$shutdown_file"; return 0; }
+      sleep "${RECORD_DAEMON_KILL_TICK_S:-0.5}"
+    done
+    reason="sigkill"
+    kill -KILL "$RECORD_DAEMON_PID" 2>/dev/null || true
+  fi
+  echo "$reason" > "$shutdown_file"
+}
+
+# stop_record_daemon is the whole teardown: drain the daemon, then hand the
+# user's agent config back. Armed as the EXIT trap by spawn_record_daemon, and
+# safe to call explicitly before clearing that trap.
+stop_record_daemon() {
+  kill_record_daemon
+  restore_hook_configs
+}

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
@@ -15,12 +15,12 @@
 #   source "$SCRIPT_DIR/lib/spawn-record-daemon.sh"
 #   spawn_record_daemon "$DAEMON" "$STAGING" "$BIND_ADDR" "$ONBOARD_HOME" || exit 1
 #   ... drive the agent ...
-#   stop_record_daemon; trap - EXIT      # drain before reading the recording
+#   stop_record_daemon                   # drain before reading the recording
 #
-# spawn_record_daemon installs `stop_record_daemon` as the EXIT trap itself, so
-# any failure between spawn and drain still shuts the daemon down and hands the
-# user's config back. Call it explicitly (then clear the trap) when you need the
-# recorder flushed before continuing.
+# The EXIT trap is the lib's, both halves: spawn_record_daemon arms
+# stop_record_daemon (so any failure between spawn and drain still shuts the
+# daemon down and hands the user's config back), and stop_record_daemon disarms
+# it. Callers never write `trap` themselves.
 #
 # Artifacts it writes under <staging>:
 #   daemon.log           — the daemon's stdout+stderr
@@ -28,7 +28,8 @@
 #   hook-config-backup/  — the pre-run copy of the shared agent config
 #   recordings/          — IRRLICHT_RECORDINGS_DIR (the caller mkdir -p's it)
 
-# shellcheck source=lib/hook-config-snapshot.sh
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=hook-config-snapshot.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/hook-config-snapshot.sh"
 
 # State published for the caller (and read back by stop_record_daemon).
@@ -38,12 +39,12 @@ RECORD_DAEMON_STAGING=""
 
 # Poll knobs, read at call time. The defaults ARE the production timings; they
 # are overridable only so the unit tests can drive the ladder without spending
-# the grace periods in real seconds.
-#   RECORD_DAEMON_SOCK_TICKS  × SOCK_TICK_S  = 40 × 0.25s = 10s for the socket
-#   RECORD_DAEMON_INT_TICKS   × KILL_TICK_S  = 12 × 0.5s  = 6s grace after INT,
-#                                              i.e. the recorder's 5s flush
-#                                              interval + 1s slack
-#   RECORD_DAEMON_TERM_TICKS  × KILL_TICK_S  =  6 × 0.5s  = 3s grace after TERM
+# the grace periods in real seconds. Each loop keeps its own tick DEFAULT;
+# RECORD_DAEMON_POLL_TICK_S overrides them together.
+#   RECORD_DAEMON_SOCK_TICKS = 40 × 0.25s = 10s for the socket to appear
+#   RECORD_DAEMON_INT_TICKS  = 12 × 0.5s  = 6s grace after INT, i.e. the
+#                                           recorder's 5s flush interval + 1s slack
+#   RECORD_DAEMON_TERM_TICKS =  6 × 0.5s  = 3s grace after TERM
 
 # record_daemon_sock <irrlicht-home> prints the unix socket the daemon will
 # listen on. A non-empty home is coexist mode (the daemon keeps its socket,
@@ -58,7 +59,10 @@ record_daemon_sock() {
 }
 
 # record_daemon_env <recordings-dir> <bind-addr> [<irrlicht-home>] prints the
-# daemon's environment, one NAME=VALUE per line, for `env` to apply.
+# daemon's environment, one NAME=VALUE per line, for `env` to apply. One per
+# line (rather than an array) so it can be asserted directly by the unit tests;
+# spaces in a value survive, a literal newline in one would not — no caller can
+# produce one (a bind address, and paths under the repo root).
 #
 # grant-all: the consent-first permission gate (#570) would otherwise leave a
 # fresh recording daemon monitoring nothing until a wizard is answered —
@@ -121,9 +125,21 @@ wait_for_record_daemon() {
   local _
   for _ in $(seq 1 "${RECORD_DAEMON_SOCK_TICKS:-40}"); do
     [[ -S "$RECORD_DAEMON_SOCK" ]] && return 0
-    sleep "${RECORD_DAEMON_SOCK_TICK_S:-0.25}"
+    sleep "${RECORD_DAEMON_POLL_TICK_S:-0.25}"
   done
   echo "daemon socket never appeared: $RECORD_DAEMON_SOCK" >&2
+  return 1
+}
+
+# signal_record_daemon <signal-name> <grace-ticks> sends the signal and polls for
+# the daemon to go. 0 if it died within the grace, 1 if it outlived it.
+signal_record_daemon() {
+  local sig="$1" ticks="$2" _
+  kill -"$sig" "$RECORD_DAEMON_PID" 2>/dev/null || true
+  for _ in $(seq 1 "$ticks"); do
+    kill -0 "$RECORD_DAEMON_PID" 2>/dev/null || return 0
+    sleep "${RECORD_DAEMON_POLL_TICK_S:-0.5}"
+  done
   return 1
 }
 
@@ -133,31 +149,28 @@ wait_for_record_daemon() {
 # matching what the pre-extraction scripts wrote.
 kill_record_daemon() {
   [[ -n "$RECORD_DAEMON_STAGING" ]] || return 0
-  local shutdown_file="$RECORD_DAEMON_STAGING/daemon.shutdown"
-  local reason="unknown" _
+  local reason="unknown"
   if [[ -n "$RECORD_DAEMON_PID" ]] && kill -0 "$RECORD_DAEMON_PID" 2>/dev/null; then
-    reason="sigint"
-    kill -INT "$RECORD_DAEMON_PID" 2>/dev/null || true
-    for _ in $(seq 1 "${RECORD_DAEMON_INT_TICKS:-12}"); do
-      kill -0 "$RECORD_DAEMON_PID" 2>/dev/null || { echo "$reason" > "$shutdown_file"; return 0; }
-      sleep "${RECORD_DAEMON_KILL_TICK_S:-0.5}"
-    done
-    reason="sigterm"
-    kill -TERM "$RECORD_DAEMON_PID" 2>/dev/null || true
-    for _ in $(seq 1 "${RECORD_DAEMON_TERM_TICKS:-6}"); do
-      kill -0 "$RECORD_DAEMON_PID" 2>/dev/null || { echo "$reason" > "$shutdown_file"; return 0; }
-      sleep "${RECORD_DAEMON_KILL_TICK_S:-0.5}"
-    done
-    reason="sigkill"
-    kill -KILL "$RECORD_DAEMON_PID" 2>/dev/null || true
+    if signal_record_daemon INT "${RECORD_DAEMON_INT_TICKS:-12}"; then
+      reason="sigint"
+    elif signal_record_daemon TERM "${RECORD_DAEMON_TERM_TICKS:-6}"; then
+      reason="sigterm"
+    else
+      reason="sigkill"
+      kill -KILL "$RECORD_DAEMON_PID" 2>/dev/null || true
+    fi
   fi
-  echo "$reason" > "$shutdown_file"
+  echo "$reason" > "$RECORD_DAEMON_STAGING/daemon.shutdown"
 }
 
-# stop_record_daemon is the whole teardown: drain the daemon, then hand the
-# user's agent config back. Armed as the EXIT trap by spawn_record_daemon, and
-# safe to call explicitly before clearing that trap.
+# stop_record_daemon is the whole teardown: drain the daemon, hand the user's
+# agent config back, and disarm the EXIT trap spawn_record_daemon armed. Owning
+# both halves of that trap is the point — a caller that had to remember its own
+# `trap - EXIT` would be back to a contract split across two files, which is the
+# shape of duplication this lib exists to remove. Callers just call it; running
+# as the trap itself, the disarm is a harmless no-op.
 stop_record_daemon() {
   kill_record_daemon
   restore_hook_configs
+  trap - EXIT
 }

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# spawn-record-daemon_test.sh — unit tests for spawn-record-daemon.sh. Plain
+# bash, no framework. Run directly or via scripts/smoke-test.sh.
+#
+# The lib is sourced (not run as a subprocess) so the tests drive its functions
+# directly. The shutdown ladder is exercised against a fake `kill` that shadows
+# the builtin and models a daemon which ignores a given set of signals: what the
+# ladder owns is the ESCALATION DECISION — which signal it sends next, how long
+# it waits, and which reason it records — not the kernel's signal delivery. A
+# shadowed kill makes that deterministic and instant; driving it with real
+# background processes instead made the outcome depend on bash's
+# ignore-SIGINT-in-async-jobs rule, which is not what is under test.
+#
+# The last case is the one that matters most: it asserts neither run-cell.sh nor
+# run-cell-multi.sh has grown its own copy of the lifecycle back. That
+# duplication is the actual defect of #1214 — #1178's hook-config snapshot
+# landed in one script only, and the other would still have exited leaving the
+# user's agent config repointed at a dead port.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(cd "$DIR/.." && pwd)"
+# shellcheck source=lib/spawn-record-daemon.sh
+source "$DIR/spawn-record-daemon.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Floor under every case: $HOME feeds record_daemon_sock's production branch and
+# hook-config-snapshot's file list, so point it somewhere harmless before the
+# first case runs — a test must never reach the developer's real
+# ~/.claude/settings.json (#1212).
+HOME="$TMP/nohome"
+
+fails=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]"; fails=$((fails + 1)); return 0; }
+assert_eq() {
+  [[ "$2" == "$3" ]] && pass "$1" || fail "$1" "$2" "$3"
+}
+
+# Spend no real time in the grace periods; the tick COUNTS stay >1 so the
+# escalation still has to poll its way through each rung.
+RECORD_DAEMON_KILL_TICK_S=0
+RECORD_DAEMON_INT_TICKS=3
+RECORD_DAEMON_TERM_TICKS=3
+RECORD_DAEMON_SOCK_TICK_S=0
+RECORD_DAEMON_SOCK_TICKS=3
+
+# fresh_staging gives a case its own staging dir and clears the lib's state.
+fresh_staging() {
+  STAGING="$TMP/$1"
+  mkdir -p "$STAGING/recordings"
+  RECORD_DAEMON_PID=""
+  RECORD_DAEMON_SOCK=""
+  RECORD_DAEMON_STAGING="$STAGING"
+}
+
+# fake_daemon <ignored-signals...> models a running daemon that survives the
+# named signals. It shadows the `kill` builtin for the ladder cases: -0 answers
+# the liveness probe, and a delivered signal kills the fake unless it is in the
+# ignore list (SIGKILL can never be ignored, as in the kernel). SIGNALS_SENT
+# records the escalation order.
+fake_daemon() {
+  FAKE_IGNORES=" $* "
+  FAKE_ALIVE=1
+  SIGNALS_SENT=""
+  RECORD_DAEMON_PID=4242
+  kill() {
+    case "$1" in
+      -0)  [[ "$FAKE_ALIVE" == "1" ]] && return 0 || return 1 ;;
+      -*)  local sig="${1#-}"
+           SIGNALS_SENT+="${SIGNALS_SENT:+,}$sig"
+           if [[ "$sig" == "KILL" || "$FAKE_IGNORES" != *" $sig "* ]]; then FAKE_ALIVE=0; fi
+           return 0 ;;
+    esac
+    return 0
+  }
+}
+
+echo "== the socket path follows coexist isolation =="
+assert_eq "coexist home owns the socket" "/tmp/onboard/irrlichd.sock" "$(record_daemon_sock /tmp/onboard)"
+assert_eq "no home means the production layout" "$HOME/.local/share/irrlicht/irrlichd.sock" "$(record_daemon_sock "")"
+
+echo "== the daemon env always carries the three recording knobs =="
+unset IRRLICHT_READY_SESSION_TTL
+assert_eq "production env" \
+  "IRRLICHT_RECORDINGS_DIR=/s/recordings
+IRRLICHT_BIND_ADDR=127.0.0.1:7837
+IRRLICHT_PERMISSION_MODE=grant-all" \
+  "$(record_daemon_env /s/recordings 127.0.0.1:7837 "")"
+
+echo "== coexist adds IRRLICHT_HOME, and only then =="
+assert_eq "coexist env" \
+  "IRRLICHT_RECORDINGS_DIR=/s/recordings
+IRRLICHT_BIND_ADDR=127.0.0.1:7838
+IRRLICHT_PERMISSION_MODE=grant-all
+IRRLICHT_HOME=/tmp/onboard" \
+  "$(record_daemon_env /s/recordings 127.0.0.1:7838 /tmp/onboard)"
+
+echo "== a home containing spaces stays a single env entry =="
+entries=0
+while IFS= read -r _; do entries=$((entries + 1)); done \
+  < <(record_daemon_env "/s/recordings" "127.0.0.1:7838" "/tmp/my onboard home")
+assert_eq "four entries, not five" "4" "$entries"
+
+echo "== a caller-set ready-session TTL is forwarded, absent otherwise =="
+IRRLICHT_READY_SESSION_TTL=45s
+assert_eq "TTL forwarded" "IRRLICHT_READY_SESSION_TTL=45s" \
+  "$(record_daemon_env /s/recordings 127.0.0.1:7837 "" | grep READY_SESSION_TTL)"
+unset IRRLICHT_READY_SESSION_TTL
+assert_eq "TTL absent" "" \
+  "$(record_daemon_env /s/recordings 127.0.0.1:7837 "" | grep READY_SESSION_TTL)"
+
+echo "== a daemon that honors SIGINT ends at sigint =="
+fresh_staging sigint
+fake_daemon
+kill_record_daemon
+assert_eq "shutdown reason" "sigint" "$(cat "$STAGING/daemon.shutdown")"
+assert_eq "no escalation past INT" "INT" "$SIGNALS_SENT"
+
+echo "== a daemon deaf to SIGINT escalates to SIGTERM =="
+fresh_staging sigterm
+fake_daemon INT
+kill_record_daemon
+assert_eq "shutdown reason" "sigterm" "$(cat "$STAGING/daemon.shutdown")"
+assert_eq "escalation order" "INT,TERM" "$SIGNALS_SENT"
+
+echo "== a daemon deaf to both escalates to SIGKILL =="
+fresh_staging sigkill
+fake_daemon INT TERM
+kill_record_daemon
+assert_eq "shutdown reason" "sigkill" "$(cat "$STAGING/daemon.shutdown")"
+assert_eq "escalation order" "INT,TERM,KILL" "$SIGNALS_SENT"
+
+echo "== a daemon that never started records 'unknown', not an error =="
+fresh_staging nodaemon
+unset -f kill    # back to the real builtin: there is no fake process to probe
+kill_record_daemon
+rc=$?
+assert_eq "returns 0" "0" "$rc"
+assert_eq "shutdown reason" "unknown" "$(cat "$STAGING/daemon.shutdown")"
+
+echo "== the teardown hands the shared agent config back =="
+fresh_staging restore
+mkdir -p "$TMP/restore-home/.claude"
+HOME="$TMP/restore-home"
+CODEX_HOME="$TMP/restore-codex"
+mkdir -p "$CODEX_HOME"
+printf '{"hooks":{"Stop":"localhost:7837"}}\n' > "$HOME/.claude/settings.json"
+snapshot_hook_configs "$STAGING/hook-config-backup"
+printf '{"hooks":{"Stop":"localhost:7838"}}\n' > "$HOME/.claude/settings.json"   # daemon repoints it
+stop_record_daemon
+assert_eq "settings.json restored" '{"hooks":{"Stop":"localhost:7837"}}' "$(cat "$HOME/.claude/settings.json")"
+HOME="$TMP/nohome"
+
+echo "== an unwritable backup dir refuses to start the daemon =="
+# restore_hook_configs reads "no backup for this file" as "the daemon created
+# it, remove it" — so a snapshot that silently did nothing would end the run by
+# deleting the user's real config. Refuse before anything is spawned.
+fresh_staging unwritable
+: > "$TMP/unwritable/hook-config-backup"   # a FILE where the dir must go
+err="$(spawn_record_daemon /nonexistent/irrlichd "$TMP/unwritable" 127.0.0.1:7838 "" 2>&1)"
+rc=$?
+assert_eq "returns non-zero" "1" "$rc"
+[[ "$err" == *"cannot create the hook-config backup dir"* ]] && got=yes || got=no
+assert_eq "says why" "yes" "$got"
+[[ -f "$TMP/unwritable/daemon.log" ]] && got=spawned || got=none
+assert_eq "nothing was spawned" "none" "$got"
+
+echo "== waiting on a socket that never appears fails loudly =="
+fresh_staging nosock
+RECORD_DAEMON_SOCK="$STAGING/irrlichd.sock"
+err="$(wait_for_record_daemon 2>&1)"
+rc=$?
+assert_eq "returns non-zero" "1" "$rc"
+assert_eq "names the socket" "daemon socket never appeared: $STAGING/irrlichd.sock" "$err"
+
+echo "== waiting succeeds once the socket is bound =="
+fresh_staging withsock
+RECORD_DAEMON_SOCK="$STAGING/irrlichd.sock"
+if command -v python3 >/dev/null 2>&1; then
+  python3 -c 'import socket,sys; s=socket.socket(socket.AF_UNIX); s.bind(sys.argv[1])' "$RECORD_DAEMON_SOCK"
+  wait_for_record_daemon
+  assert_eq "returns 0" "0" "$?"
+else
+  echo "  SKIP: python3 not available to bind a unix socket"
+fi
+
+echo "== the lifecycle has exactly one owner (#1214) =="
+# The defect this lib exists to prevent is a SECOND copy of the lifecycle
+# growing back in a caller: `kill -INT` is the shutdown ladder's fingerprint and
+# `snapshot_hook_configs` the hook-config snapshot's. Both now belong to the lib
+# alone; a caller may only ask for the lifecycle by name.
+for script in run-cell.sh run-cell-multi.sh; do
+  path="$SCRIPTS_DIR/$script"
+  assert_eq "$script delegates to the lib" "yes" \
+    "$(grep -q 'spawn_record_daemon' "$path" && echo yes || echo no)"
+  assert_eq "$script has no shutdown ladder of its own" "0" \
+    "$(grep -c 'kill -INT' "$path" | tr -d ' ')"
+  assert_eq "$script has no hook-config snapshot of its own" "0" \
+    "$(grep -c 'snapshot_hook_configs' "$path" | tr -d ' ')"
+done
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "spawn-record-daemon_test: ALL PASS"
+  exit 0
+fi
+echo "spawn-record-daemon_test: $fails FAILURE(S)" >&2
+exit 1

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
@@ -21,7 +21,8 @@ set -uo pipefail   # NOT -e: assertions capture non-zero return codes
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPTS_DIR="$(cd "$DIR/.." && pwd)"
-# shellcheck source=lib/spawn-record-daemon.sh
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=spawn-record-daemon.sh
 source "$DIR/spawn-record-daemon.sh"
 
 TMP="$(mktemp -d)"
@@ -42,10 +43,9 @@ assert_eq() {
 
 # Spend no real time in the grace periods; the tick COUNTS stay >1 so the
 # escalation still has to poll its way through each rung.
-RECORD_DAEMON_KILL_TICK_S=0
+RECORD_DAEMON_POLL_TICK_S=0
 RECORD_DAEMON_INT_TICKS=3
 RECORD_DAEMON_TERM_TICKS=3
-RECORD_DAEMON_SOCK_TICK_S=0
 RECORD_DAEMON_SOCK_TICKS=3
 
 # fresh_staging gives a case its own staging dir and clears the lib's state.
@@ -153,6 +153,11 @@ snapshot_hook_configs "$STAGING/hook-config-backup"
 printf '{"hooks":{"Stop":"localhost:7838"}}\n' > "$HOME/.claude/settings.json"   # daemon repoints it
 stop_record_daemon
 assert_eq "settings.json restored" '{"hooks":{"Stop":"localhost:7837"}}' "$(cat "$HOME/.claude/settings.json")"
+# The teardown owns BOTH halves of the trap spawn_record_daemon arms, so callers
+# never write `trap` themselves. That also clears this file's own EXIT trap —
+# re-arm it so $TMP is still cleaned up.
+assert_eq "EXIT trap disarmed" "" "$(trap -p EXIT)"
+trap 'rm -rf "$TMP"' EXIT
 HOME="$TMP/nohome"
 
 echo "== an unwritable backup dir refuses to start the daemon =="
@@ -190,17 +195,24 @@ fi
 
 echo "== the lifecycle has exactly one owner (#1214) =="
 # The defect this lib exists to prevent is a SECOND copy of the lifecycle
-# growing back in a caller: `kill -INT` is the shutdown ladder's fingerprint and
-# `snapshot_hook_configs` the hook-config snapshot's. Both now belong to the lib
-# alone; a caller may only ask for the lifecycle by name.
+# growing back in a caller. Each rung of the lifecycle has a fingerprint: a
+# signal sent to a process (the shutdown ladder), `snapshot_hook_configs` (the
+# config snapshot), and an `IRRLICHT_RECORDINGS_DIR=` assignment (the env
+# assembly). All three belong to the lib alone; a caller may only ask for the
+# lifecycle by name. The signal pattern covers the spellings a re-implementation
+# would plausibly use — `kill -INT`, `kill -s INT`, `kill -2` — rather than only
+# the literal text that leaked last time.
+SIGNAL_RE='kill +-(s +)?(INT|TERM|KILL|2|15|9)'
 for script in run-cell.sh run-cell-multi.sh; do
   path="$SCRIPTS_DIR/$script"
   assert_eq "$script delegates to the lib" "yes" \
     "$(grep -q 'spawn_record_daemon' "$path" && echo yes || echo no)"
-  assert_eq "$script has no shutdown ladder of its own" "0" \
-    "$(grep -c 'kill -INT' "$path" | tr -d ' ')"
+  assert_eq "$script signals no process of its own" "0" \
+    "$(grep -cE "$SIGNAL_RE" "$path" | tr -d ' ')"
   assert_eq "$script has no hook-config snapshot of its own" "0" \
     "$(grep -c 'snapshot_hook_configs' "$path" | tr -d ' ')"
+  assert_eq "$script assembles no daemon env of its own" "0" \
+    "$(grep -c 'IRRLICHT_RECORDINGS_DIR=' "$path" | tr -d ' ')"
 done
 
 echo ""

--- a/tools/onboarding-factory/scripts/run-cell-multi.sh
+++ b/tools/onboarding-factory/scripts/run-cell-multi.sh
@@ -242,8 +242,7 @@ for i in "${!DRV_PIDS[@]}"; do
 done
 
 # --- Drain the daemon ---------------------------------------------------
-stop_record_daemon
-trap - EXIT
+stop_record_daemon   # also disarms the EXIT trap it armed
 DAEMON_SHUTDOWN="$(cat "$STAGING/daemon.shutdown" 2>/dev/null || echo unknown)"
 
 # --- Locate the single recording ----------------------------------------

--- a/tools/onboarding-factory/scripts/run-cell-multi.sh
+++ b/tools/onboarding-factory/scripts/run-cell-multi.sh
@@ -54,8 +54,12 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [[ -n "$REPO_ROOT" ]] || { echo "not in a git repo" >&2; exit 1; }
 # shellcheck source=lib/shard-lib.sh
 source "$SCRIPT_DIR/lib/shard-lib.sh"   # per-scenario shard reader (#511)
-# shellcheck source=lib/hook-config-snapshot.sh
-source "$SCRIPT_DIR/lib/hook-config-snapshot.sh"   # save/restore shared agent config (#1178)
+# Recording-daemon lifecycle — env, spawn, socket wait, shutdown ladder, and the
+# shared agent config snapshot/restore (#1178) — shared with run-cell.sh, which
+# this script does NOT delegate to otherwise, so a recorder fix reaches both
+# recording paths rather than whichever one the author was editing (#1214).
+# shellcheck source=lib/spawn-record-daemon.sh
+source "$SCRIPT_DIR/lib/spawn-record-daemon.sh"
 
 # Session-id reconciliation helpers (daemon_sid_for_transcript,
 # sid_in_recording, reconcile_slot_csv) — shared + unit-tested in lib/.
@@ -87,7 +91,6 @@ if [[ -z "$ONBOARD_HOME" ]]; then
   exit 2
 fi
 ONBOARD_BIND="${IRRLICHT_ONBOARD_BIND_ADDR:-127.0.0.1:7838}"
-ONBOARD_SOCK="$ONBOARD_HOME/irrlichd.sock"
 export IRRLICHT_ONBOARD_HOME="$ONBOARD_HOME"
 export IRRLICHT_ONBOARD_BIND_ADDR="$ONBOARD_BIND"
 
@@ -196,49 +199,13 @@ write_error_manifest() {
 }
 
 # --- Spawn ONE isolated --record daemon ---------------------------------
-DAEMON_LOG="$STAGING/daemon.log"
-# Save the shared agent config the daemon is about to rewrite (see
-# lib/hook-config-snapshot.sh); cleanup hands it back. This script spawns its
-# own daemon rather than delegating to run-cell.sh, so it needs its own call.
-snapshot_hook_configs "$STAGING/hook-config-backup"
-# grant-all: the consent-first permission gate (#570) would otherwise leave
-# a fresh recording daemon monitoring nothing until a wizard is answered.
-env IRRLICHT_RECORDINGS_DIR="$STAGING/recordings" \
-  IRRLICHT_BIND_ADDR="$ONBOARD_BIND" \
-  IRRLICHT_HOME="$ONBOARD_HOME" \
-  IRRLICHT_PERMISSION_MODE=grant-all \
-  "$DAEMON" --record >"$DAEMON_LOG" 2>&1 &
-DAEMON_PID=$!
-echo "daemon started (pid $DAEMON_PID, bind=$ONBOARD_BIND, home=$ONBOARD_HOME)"
-
-SHUTDOWN_REASON="unknown"
-cleanup() {
-  if kill -0 "$DAEMON_PID" 2>/dev/null; then
-    SHUTDOWN_REASON="sigint"
-    kill -INT "$DAEMON_PID" 2>/dev/null || true
-    for _ in $(seq 1 12); do
-      kill -0 "$DAEMON_PID" 2>/dev/null || { echo "$SHUTDOWN_REASON" > "$STAGING/daemon.shutdown"; return; }
-      sleep 0.5
-    done
-    SHUTDOWN_REASON="sigterm"
-    kill -TERM "$DAEMON_PID" 2>/dev/null || true
-    for _ in $(seq 1 6); do
-      kill -0 "$DAEMON_PID" 2>/dev/null || { echo "$SHUTDOWN_REASON" > "$STAGING/daemon.shutdown"; return; }
-      sleep 0.5
-    done
-    SHUTDOWN_REASON="sigkill"
-    kill -KILL "$DAEMON_PID" 2>/dev/null || true
-  fi
-  echo "$SHUTDOWN_REASON" > "$STAGING/daemon.shutdown"
-  restore_hook_configs
-}
-trap cleanup EXIT
-
-for _ in $(seq 1 40); do
-  [[ -S "$ONBOARD_SOCK" ]] && break
-  sleep 0.25
-done
-[[ -S "$ONBOARD_SOCK" ]] || { echo "daemon socket never appeared: $ONBOARD_SOCK" >&2; write_error_manifest "daemon_socket_missing"; exit 1; }
+# The lib snapshots the shared agent config, spawns the daemon, arms
+# stop_record_daemon as the EXIT trap, and waits for its socket. A non-zero
+# return means the socket never appeared (it has already said so on stderr); the
+# trap still drains the daemon and restores the config on the way out, so all
+# that is left here is the ERROR manifest the implement skill reads.
+spawn_record_daemon "$DAEMON" "$STAGING" "$ONBOARD_BIND" "$ONBOARD_HOME" \
+  || { write_error_manifest "daemon_socket_missing"; exit 1; }
 
 # --- Launch every adapter's interactive driver CONCURRENTLY -------------
 # All share $SHARED_CWD (the same workspace). Each gets its own staging
@@ -275,7 +242,7 @@ for i in "${!DRV_PIDS[@]}"; do
 done
 
 # --- Drain the daemon ---------------------------------------------------
-cleanup
+stop_record_daemon
 trap - EXIT
 DAEMON_SHUTDOWN="$(cat "$STAGING/daemon.shutdown" 2>/dev/null || echo unknown)"
 

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -38,8 +38,11 @@ JSONL_GLOB='*.jsonl'
 
 # shellcheck source=lib/shard-lib.sh
 source "$SCRIPT_DIR/lib/shard-lib.sh"   # per-scenario shard reader (#511)
-# shellcheck source=lib/hook-config-snapshot.sh
-source "$SCRIPT_DIR/lib/hook-config-snapshot.sh"   # save/restore shared agent config (#1178)
+# Recording-daemon lifecycle — env, spawn, socket wait, shutdown ladder, and the
+# shared agent config snapshot/restore (#1178) — owned once and shared with
+# run-cell-multi.sh so a recorder fix can't reach only one of them (#1214).
+# shellcheck source=lib/spawn-record-daemon.sh
+source "$SCRIPT_DIR/lib/spawn-record-daemon.sh"
 
 RECORDER="off"
 ATTACH=0
@@ -193,10 +196,8 @@ if [[ -n "$ONBOARD_HOME" ]]; then
   # 7837 default here would make the one-knob `IRRLICHT_ONBOARD_HOME=…`
   # path abort at precheck.
   ONBOARD_BIND="${IRRLICHT_ONBOARD_BIND_ADDR:-127.0.0.1:7838}"
-  ONBOARD_SOCK="$ONBOARD_HOME/irrlichd.sock"
 else
   ONBOARD_BIND="${IRRLICHT_ONBOARD_BIND_ADDR:-127.0.0.1:7837}"
-  ONBOARD_SOCK="$HOME/.local/share/irrlicht/irrlichd.sock"
 fi
 
 # --- Daemon source ------------------------------------------------------
@@ -212,7 +213,6 @@ fi
 #    periodic flush, and pick the recording file from whatever the
 #    daemon is writing to (env override > default
 #    ~/.local/share/irrlicht/recordings/).
-DAEMON_PID=""
 if [[ "$ATTACH" == "1" ]]; then
   ATTACHED_RECORDINGS_DIR="${IRRLICHT_RECORDINGS_DIR:-$HOME/.local/share/irrlicht/recordings}"
   if [[ ! -d "$ATTACHED_RECORDINGS_DIR" ]]; then
@@ -247,72 +247,11 @@ if [[ "$ATTACH" == "1" ]]; then
   fi
   echo "attach: using running daemon's recordings at $ATTACHED_RECORDINGS_DIR"
 else
-  DAEMON_LOG="$STAGING/daemon.log"
-  # Build the env assignments as an array so a value containing spaces
-  # (e.g. an IRRLICHT_HOME path with a space) stays one word — an
-  # unquoted ${ONBOARD_HOME:+VAR="$ONBOARD_HOME"} would word-split on it.
-  # IRRLICHT_HOME is only added when ONBOARD_HOME is non-empty.
-  # grant-all: the consent-first permission gate (#570) would otherwise
-  # leave a fresh recording daemon monitoring nothing until a wizard is
-  # answered — fixtures must never hang on consent.
-  # Save the shared agent config the daemon is about to rewrite (see
-  # lib/hook-config-snapshot.sh); cleanup hands it back.
-  snapshot_hook_configs "$STAGING/hook-config-backup"
-
-  DAEMON_ENV=(IRRLICHT_RECORDINGS_DIR="$STAGING/recordings"
-              IRRLICHT_BIND_ADDR="$ONBOARD_BIND"
-              IRRLICHT_PERMISSION_MODE=grant-all)
-  [[ -n "$ONBOARD_HOME" ]] && DAEMON_ENV+=(IRRLICHT_HOME="$ONBOARD_HOME")
-  # Forward a caller-set ready-session TTL so idle-survival cells (1.3) can
-  # shrink the 30-min production default to a recordable window. The daemon's
-  # explicit env array would otherwise drop the inherited override.
-  [[ -n "${IRRLICHT_READY_SESSION_TTL:-}" ]] && DAEMON_ENV+=(IRRLICHT_READY_SESSION_TTL="$IRRLICHT_READY_SESSION_TTL")
-  env "${DAEMON_ENV[@]}" "$DAEMON" --record >"$DAEMON_LOG" 2>&1 &
-  DAEMON_PID=$!
-  echo "daemon started (pid $DAEMON_PID, bind=$ONBOARD_BIND${ONBOARD_HOME:+, home=$ONBOARD_HOME})"
-
-  # Cleanup: graceful shutdown, then hand the user's agent config back. Runs
-  # once: either via explicit call before transcript resolution (we must drain
-  # before continuing), or as the EXIT trap if we fail before reaching that
-  # point. `trap - EXIT` after the explicit call prevents double-invocation.
-  SHUTDOWN_REASON="unknown"
-  cleanup() {
-    stop_daemon
-    restore_hook_configs
-  }
-
-  # stop_daemon escalates INT -> TERM -> KILL, giving the recorder time to
-  # flush between each.
-  stop_daemon() {
-    if kill -0 "$DAEMON_PID" 2>/dev/null; then
-      SHUTDOWN_REASON="sigint"
-      kill -INT "$DAEMON_PID" 2>/dev/null || true
-      # 6s grace = 5s recorder flush interval + 1s slack.
-      for _ in $(seq 1 12); do
-        kill -0 "$DAEMON_PID" 2>/dev/null || { echo "$SHUTDOWN_REASON" > "$STAGING/daemon.shutdown"; return; }
-        sleep 0.5
-      done
-      SHUTDOWN_REASON="sigterm"
-      kill -TERM "$DAEMON_PID" 2>/dev/null || true
-      for _ in $(seq 1 6); do
-        kill -0 "$DAEMON_PID" 2>/dev/null || { echo "$SHUTDOWN_REASON" > "$STAGING/daemon.shutdown"; return; }
-        sleep 0.5
-      done
-      SHUTDOWN_REASON="sigkill"
-      kill -KILL "$DAEMON_PID" 2>/dev/null || true
-    fi
-    echo "$SHUTDOWN_REASON" > "$STAGING/daemon.shutdown"
-  }
-  trap cleanup EXIT
-
-  # Wait up to 10s for the unix socket to appear — signals the daemon is
-  # ready to accept connections.
-  SOCK="$ONBOARD_SOCK"
-  for _ in $(seq 1 40); do
-    [[ -S "$SOCK" ]] && break
-    sleep 0.25
-  done
-  [[ -S "$SOCK" ]] || { echo "daemon socket never appeared: $SOCK" >&2; exit 1; }
+  # The lib snapshots the shared agent config, spawns the daemon, arms
+  # stop_record_daemon as the EXIT trap, and waits for its socket. A non-zero
+  # return means the socket never appeared (it has already said so on stderr);
+  # the trap still drains the daemon and restores the config on the way out.
+  spawn_record_daemon "$DAEMON" "$STAGING" "$ONBOARD_BIND" "$ONBOARD_HOME" || exit 1
 fi
 
 # --- Drive the agent ----------------------------------------------------
@@ -341,12 +280,11 @@ DRIVER_REASON="$(cat "$STAGING/driver.exit-reason" 2>/dev/null || echo "unknown"
 #    slack is enough to land all writes from this run on disk. The
 #    user's daemon keeps running and the dashboard stays connected.
 if [[ "$ATTACH" == "1" ]]; then
-  SHUTDOWN_REASON="attached"
-  echo "$SHUTDOWN_REASON" > "$STAGING/daemon.shutdown"
+  echo "attached" > "$STAGING/daemon.shutdown"
   echo "attach: waiting 6s for recorder flush..."
   sleep 6
 else
-  cleanup
+  stop_record_daemon
   trap - EXIT
 fi
 

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -285,7 +285,6 @@ if [[ "$ATTACH" == "1" ]]; then
   sleep 6
 else
   stop_record_daemon
-  trap - EXIT
 fi
 
 # --- Read driver-resolved transcript + actual UUID ----------------------

--- a/tools/onboarding-factory/scripts/smoke-test.sh
+++ b/tools/onboarding-factory/scripts/smoke-test.sh
@@ -48,6 +48,10 @@ echo ""
 echo "== unit tests (lib/hook-config-snapshot_test.sh) =="
 bash "$SCRIPT_DIR/lib/hook-config-snapshot_test.sh" || rc=1
 
+echo ""
+echo "== unit tests (lib/spawn-record-daemon_test.sh) =="
+bash "$SCRIPT_DIR/lib/spawn-record-daemon_test.sh" || rc=1
+
 # completeness-gate / catalog-drift / consistency gates were retired (#528):
 # `of validate` + `of coverage` (Go) now own schema + referential + coverage
 # integrity, and a per-scenario shard is the single source for a cell, so the


### PR DESCRIPTION
Closes #1214.

## Problem

`run-cell.sh` and `run-cell-multi.sh` each carried their own copy of the `irrlichd --record` lifecycle: the same three env vars, the same spawn, the same socket-ready wait, the same INT→TERM→KILL ladder with the same 6s/3s graces, the same `daemon.shutdown` write, and — since #1178 — the same snapshot/restore of the shared agent config the daemon rewrites.

A fix to one reached only that one. #1178's hook-config snapshot landed in `run-cell.sh` alone, and the cross-adapter recorder would still have exited leaving the user's `~/.claude/settings.json` repointed at a dead `:7838`. Review caught it that time; the divergence is invisible because both scripts read as complete.

## Change

`lib/spawn-record-daemon.sh` owns the whole lifecycle; both scripts source it. Net −121/+33 in the callers.

- `spawn_record_daemon <bin> <staging> <bind-addr> [<home>]` — snapshot, env, spawn, arm the EXIT trap, wait for the socket. Returns non-zero (having said why on stderr) if the socket never appears, so the caller can add its own bookkeeping.
- `stop_record_daemon` — the ladder plus `restore_hook_configs`, armed as the EXIT trap and callable explicitly to drain before reading the recording.
- `record_daemon_env` / `record_daemon_sock` — the pure pieces, so they can be asserted directly.

The two callers' real differences stay parameterized rather than merged: `run-cell.sh` keeps its `ATTACH=1` mode (spawns nothing), and `run-cell-multi.sh` keeps mandatory coexist isolation plus its `write_error_manifest "daemon_socket_missing"` on a socket timeout.

**One behavior converges deliberately:** `run-cell-multi.sh` now also forwards a caller-set `IRRLICHT_READY_SESSION_TTL`, which only `run-cell.sh` used to. Forwarding an env var the caller explicitly set is the correct half of that divergence.

**One hardening:** the lib refuses to spawn if the hook-config backup dir can't be created. `restore_hook_configs` reads "no backup for this file" as "the daemon created it, remove it", so an unwritable snapshot would have ended a run by *deleting* the user's real `~/.claude/settings.json`. `errexit` covered that implicitly before the extraction; inside a `||`-guarded function call it no longer would, so it is now explicit.

## Tests

`lib/spawn-record-daemon_test.sh` (new, wired into `smoke-test.sh` alongside the other five lib suites) covers the escalation ladder and its recorded reason, env assembly incl. the coexist/TTL conditionals and a home containing spaces, socket-path derivation, socket-wait success and failure, the config restore, and the backup-dir guard.

Most of those are **locks** — this is an extraction, so they pass by construction and exist to pin the behavior in its new single home. The one that is a genuine **defect test** is the last case, "the lifecycle has exactly one owner": it asserts neither caller still carries a `kill -INT` ladder or its own `snapshot_hook_configs` call. Seen red before the callers were changed:

```
== the lifecycle has exactly one owner (#1214) ==
  FAIL: run-cell.sh delegates to the lib — expected [yes] got [no]
  FAIL: run-cell.sh has no shutdown ladder of its own — expected [0] got [1]
  FAIL: run-cell.sh has no hook-config snapshot of its own — expected [0] got [1]
  FAIL: run-cell-multi.sh delegates to the lib — expected [yes] got [no]
  FAIL: run-cell-multi.sh has no shutdown ladder of its own — expected [0] got [1]
  FAIL: run-cell-multi.sh has no hook-config snapshot of its own — expected [0] got [1]
```

The ladder cases drive a fake `kill` that shadows the builtin. What the ladder owns is the escalation *decision* — which signal next, how long it waits, which reason it records — not the kernel's delivery; a shadowed `kill` makes that deterministic and instant. Driving it with real background processes instead made the outcome depend on bash's ignore-SIGINT-in-async-jobs rule, which is not what is under test.

Ran green: `smoke-test.sh` (PASS), `go test ./tools/onboarding-factory/... -race -count=1` (all ok), `of validate` (OK).

Beyond the unit tests, the extracted lifecycle was exercised in situ against a fake daemon binary: the daemon saw all five env vars (incl. `IRRLICHT_READY_SESSION_TTL`), `spawn_record_daemon` returned only once the socket was bound, and a config the fake daemon rewrote mid-run came back byte-for-byte after `stop_record_daemon`. That harness reaches `sigterm` rather than `sigint` only because a backgrounded *shell* script inherits `SIG_IGN` for SIGINT and cannot re-trap it — unchanged from `main`, and not how the real daemon behaves: `core/cmd/irrlichd/main.go:380` calls `signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)`, which installs a handler over an inherited ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)