### PR TITLE
fix(security-scan): scope before the scanners' shared preconditions (follow-up to #1231)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,3 +76,14 @@ jobs:
       # smoke-test is their only automated coverage: bash -n + the lib unit tests.
       - name: Smoke-test the recording rig
         run: bash tools/onboarding-factory/scripts/smoke-test.sh
+
+      # tools/lib/ holds the scoping rules for tools/preflight.sh --changed,
+      # the pre-push hook. Their local gate is that same hook, which
+      # `git push --no-verify` disables — so CI has to run them independently,
+      # or the checks guarding the gate ride on the gate they guard.
+      - name: Test the shared shell libs
+        run: |
+          for t in tools/lib/*_test.sh; do
+            echo "== $t =="
+            bash "$t"
+          done

--- a/tools/lib/changed-files.sh
+++ b/tools/lib/changed-files.sh
@@ -26,17 +26,21 @@
 # work counts because a pre-push run should reflect the tree in front of you,
 # not only what is already committed.
 #
-# When origin/main has never been fetched the diff yields nothing, which is
-# byte-for-byte indistinguishable from "this branch changed nothing" — and an
-# empty set scopes every gate down to a skip. An empty diff is a legitimate
-# state, so this warns rather than failing, but it warns loudly: a caller that
-# skipped everything should be able to tell which of the two reasons applied.
+# Returns non-zero when no baseline can be established — origin/main never
+# fetched, a shallow clone, unrelated histories. That case has to be an error
+# rather than an empty set, because an empty set is byte-for-byte what "this
+# branch changed nothing" looks like, and it scopes every gate down to a skip:
+# a fully green pre-push run that checked nothing. A scoped run against an
+# unknown baseline is not a run. Callers are expected to abort.
+#
+# `git merge-base` already fails under exactly those conditions, so its exit
+# status is the check — no separate rev-parse probe needed.
 changed_files_vs_origin_main() {
-  if ! git rev-parse --verify --quiet origin/main >/dev/null; then
-    echo "WARN: origin/main not found — treating this branch as unchanged, so every scoped gate will skip. Run 'git fetch origin main' for a meaningful scoped run." >&2
-  fi
   local base
-  base=$(git merge-base origin/main HEAD 2>/dev/null || echo origin/main)
+  if ! base=$(git merge-base origin/main HEAD 2>/dev/null); then
+    echo "cannot resolve a merge base with origin/main — scoping to a diff against an unknown baseline would skip every gate. Run 'git fetch origin main'." >&2
+    return 1
+  fi
   {
     git diff --name-only "$base" HEAD
     git diff --name-only HEAD
@@ -55,9 +59,10 @@ changed_files_vs_origin_main() {
 go_module_touched() {
   local mod="$1" file
   while IFS= read -r file; do
-    [[ "$file" == "$mod"/* ]] || continue
+    # `*` spans `/` in a case pattern, so "$mod"/*.go means a Go file at any
+    # depth under the module.
     case "$file" in
-      *.go | "$mod"/go.mod | "$mod"/go.sum) return 0 ;;
+      "$mod"/*.go | "$mod"/go.mod | "$mod"/go.sum) return 0 ;;
     esac
   done <<<"$2"
   return 1

--- a/tools/lib/changed-files.sh
+++ b/tools/lib/changed-files.sh
@@ -41,11 +41,16 @@ changed_files_vs_origin_main() {
     echo "cannot resolve a merge base with origin/main — scoping to a diff against an unknown baseline would skip every gate. Run 'git fetch origin main'." >&2
     return 1
   fi
+  # LC_ALL=C so the order is byte-wise and identical everywhere. No consumer
+  # depends on the order today (they all grep or glob the set), but a set whose
+  # order changes with the caller's locale is a trap for anyone who later
+  # diffs, caches or golden-files it — and it already bit this repo once, as a
+  # macOS-green / Linux-CI-red assertion in changed-files_test.sh.
   {
     git diff --name-only "$base" HEAD
     git diff --name-only HEAD
     git diff --name-only --cached
-  } 2>/dev/null | sort -u
+  } 2>/dev/null | LC_ALL=C sort -u
 }
 
 # go_module_touched <module-dir> <changed-files> — true when the changed set

--- a/tools/lib/changed-files_test.sh
+++ b/tools/lib/changed-files_test.sh
@@ -43,11 +43,19 @@ assert_scope() {
   assert_eq "$label" "$want" "$got"
   return 0
 }
+# assert_contains <label> <needle> <haystack>
+assert_contains() {
+  case "$3" in
+    *"$2"*) pass "$1" ;;
+    *) fail "$1" "contains: $2" "$3" ;;
+  esac
+  return 0
+}
 
-# The real module/tree lists from tools/security-scan.sh, so a rename there
-# that these tests don't follow shows up as a failure rather than silence.
-GO_MODULES=(core tools/onboarding-factory tools/wsload tools/seed-demo-sessions tools/eta-research tools/starhistory)
-WEB_TREES=(platforms/web tools/onboarding-factory/internal/viewer/web)
+# No copy of security-scan.sh's GO_MODULES/WEB_TREES lives here on purpose.
+# These predicates are pure string matching and never stat the filesystem, so
+# a copied list could not detect a rename over there — asserting over one
+# would only restate the same fact per entry while looking like coverage.
 
 # PR #1207's shape: a Go + bash change, zero files under either web tree.
 # The paths are illustrative — these predicates are pure string matching and
@@ -98,20 +106,16 @@ assert_scope "a nested package.json under node_modules is not the tree's manifes
   out web_tree_touched platforms/web "platforms/web/node_modules/postcss/package.json"
 
 echo "== #1213 regression: a Go-only push scopes in no web tree =="
-for tree in "${WEB_TREES[@]}"; do
-  assert_scope "Go-only diff → npm audit SKIPS $tree" \
-    out web_tree_touched "$tree" "$GO_ONLY_DIFF"
-done
+assert_scope "Go-only diff → npm audit SKIPS platforms/web" \
+  out web_tree_touched platforms/web "$GO_ONLY_DIFF"
+assert_scope "Go-only diff → npm audit SKIPS the viewer tree" \
+  out web_tree_touched tools/onboarding-factory/internal/viewer/web "$GO_ONLY_DIFF"
 
 echo "== an empty changed set scopes everything out =="
-for mod in "${GO_MODULES[@]}"; do
-  assert_scope "empty diff → govulncheck/gosec SKIP $mod" \
-    out go_module_touched "$mod" ""
-done
-for tree in "${WEB_TREES[@]}"; do
-  assert_scope "empty diff → npm audit SKIPS $tree" \
-    out web_tree_touched "$tree" ""
-done
+assert_scope "empty diff → govulncheck/gosec SKIP a Go module" \
+  out go_module_touched core ""
+assert_scope "empty diff → npm audit SKIPS a web tree" \
+  out web_tree_touched platforms/web ""
 
 echo "== changed_files_vs_origin_main: real repo, real git =="
 TMP="$(mktemp -d)"
@@ -132,9 +136,10 @@ out=$( cd "$TMP" && . "$DIR/changed-files.sh" && changed_files_vs_origin_main )
 assert_eq "collects committed + staged + unstaged, sorted and de-duplicated" \
   "$(printf 'README.md\ncore/go.mod\ncore/main.go')" "$out"
 
-echo "== changed_files_vs_origin_main: a missing origin/main warns, never passes silently =="
-# An empty result is indistinguishable from "nothing changed", and an empty set
-# scopes every gate to a skip — so the reason has to reach stderr.
+echo "== changed_files_vs_origin_main: no resolvable baseline is an error, not an empty set =="
+# An empty result is byte-for-byte what "nothing changed" looks like, and an
+# empty set scopes every gate to a skip. Returning 0 there would mean a fresh
+# or shallow clone gets a fully green pre-push run that checked nothing.
 NOREMOTE="$(mktemp -d)"
 trap 'rm -rf "$TMP" "$NOREMOTE"' EXIT
 (
@@ -143,10 +148,9 @@ trap 'rm -rf "$TMP" "$NOREMOTE"' EXIT
   echo hi >a.txt && git add -A && git commit -qm base
 ) >/dev/null 2>&1
 nr_err=$( cd "$NOREMOTE" && . "$DIR/changed-files.sh" && changed_files_vs_origin_main 2>&1 >/dev/null )
-case "$nr_err" in
-  *"origin/main not found"*) pass "missing origin/main warns on stderr" ;;
-  *) fail "missing origin/main warns on stderr" "a WARN mentioning origin/main" "$nr_err" ;;
-esac
+nr_rc=$( cd "$NOREMOTE" && . "$DIR/changed-files.sh" && changed_files_vs_origin_main >/dev/null 2>&1; echo $? )
+assert_eq "no origin/main → non-zero return, so callers abort" "1" "$nr_rc"
+assert_contains "no origin/main → explains itself on stderr" "origin/main" "$nr_err"
 
 echo "== callers hard-fail rather than skip everything when this lib is missing =="
 # Without the lib the scoping predicates are undefined; under `set -u` (no -e)
@@ -170,10 +174,7 @@ for script in security-scan.sh preflight.sh; do
   out=$( cd "$REPO_ROOT_FOR_TEST" && bash "$NOLIB/$script" "${args[@]}" 2>&1 )
   rc=$?
   assert_eq "$script --changed with no lib/ → exit 2, not a silent pass" "2" "$rc"
-  case "$out" in
-    *"changed-files.sh"*) pass "$script names the missing lib in its error" ;;
-    *) fail "$script names the missing lib in its error" "mentions changed-files.sh" "$out" ;;
-  esac
+  assert_contains "$script names the missing lib in its error" "changed-files.sh" "$out"
 done
 
 echo ""

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -24,10 +24,11 @@
 # more valuable as a pre-push gate than on every PR push; a GH Actions
 # equivalent can be added later without changing tools/security-scan.sh.
 #
-# The `tools` group is local-only for the same reason: it runs the unit tests
-# for the shared shell libs under tools/lib/, which nothing else exercises
-# (tools/onboarding-factory/scripts/smoke-test.sh is scoped to the recording
-# rig's own scripts and never reaches top-level tools/).
+# The `tools` group runs the unit tests for the shared shell libs under
+# tools/lib/. Unlike `security` it does have a CI counterpart (test.yml's
+# "Test the shared shell libs" step) — deliberately, because these are the
+# tests of the pre-push gate's own scoping logic, and a gate whose only runner
+# is itself is one `--no-verify` away from never running at all.
 #
 # Usage:
 #   tools/preflight.sh                 # everything except the Linux gate
@@ -96,14 +97,15 @@ CHANGED_FILES=""
 if [[ "$CHANGED" == 1 ]]; then
   # Fatal, not a silent full-skip: without the lib the changed set would stay
   # empty, every scoped gate would record SKIP, and the run would exit 0 — a
-  # green pre-push hook that ran nothing at all.
-  if [[ ! -r "$SCRIPT_DIR/lib/changed-files.sh" ]]; then
-    echo "cannot read $SCRIPT_DIR/lib/changed-files.sh — refusing to pass a run that would skip every gate" >&2
-    exit 2
-  fi
+  # green pre-push hook that ran nothing at all. Sourcing and checking in one
+  # step also covers a lib that exists but is malformed, which a readability
+  # test would wave through.
   # shellcheck source=lib/changed-files.sh
-  . "$SCRIPT_DIR/lib/changed-files.sh"
-  CHANGED_FILES=$(changed_files_vs_origin_main)
+  . "$SCRIPT_DIR/lib/changed-files.sh" || {
+    echo "cannot load $SCRIPT_DIR/lib/changed-files.sh — refusing to pass a run that would skip every gate" >&2
+    exit 2
+  }
+  CHANGED_FILES=$(changed_files_vs_origin_main) || exit 2
 fi
 
 # changed_matches <extended-regex> — true when NOT scoping (full run) or when
@@ -228,9 +230,10 @@ if want arch; then
   run_gate_scoped '^core/' "ARS architecture gate" tools/ars-gate.sh
 fi
 
-# ---- tools group (shared shell libs; no matching workflow — see header) ----
-# Scoped to the scripts that consume tools/lib/, so the scoping rules are
-# re-checked exactly when someone edits them or one of their two callers.
+# ---- tools group (mirrors test.yml's "Test the shared shell libs" step) ----
+# Scoped to tools/lib/ plus every top-level tools/*.sh rather than naming the
+# two current callers: a third script sourcing the lib would otherwise stop
+# running these tests without anyone noticing.
 shell_lib_tests() {
   local rc=0 t
   for t in tools/lib/*_test.sh; do
@@ -241,7 +244,7 @@ shell_lib_tests() {
 }
 
 if want tools; then
-  run_gate_scoped '^tools/lib/|^tools/preflight\.sh$|^tools/security-scan\.sh$' \
+  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$' \
                   "tools/lib shell-lib tests" shell_lib_tests
 fi
 

--- a/tools/security-scan.sh
+++ b/tools/security-scan.sh
@@ -88,24 +88,7 @@ ok()   { local msg="$1"; echo "OK: $msg"; return 0; }
 # ---- --changed scoping -----------------------------------------------------
 # CHANGED_FILES stays empty without --changed, and the in_scope helpers below
 # short-circuit to true — so the unscoped run is byte-for-byte what it was.
-CHANGED_FILES=""
 SKIPPED=0
-if [[ "$CHANGED" -eq 1 ]]; then
-  # A missing lib has to be fatal rather than a silent full-skip. This script
-  # runs under `set -u` without `-e`, so a failed source would leave the
-  # predicates undefined; every in-scope test would then return 127, every
-  # scanner would fall out of scope, and the run would exit 0 reporting
-  # "passed" — a clean bill of health from a scan that never happened, which
-  # is the one outcome the policy at the top of this file rules out.
-  if [[ ! -r "$SCRIPT_DIR/lib/changed-files.sh" ]]; then
-    echo "FAIL: --changed: cannot read $SCRIPT_DIR/lib/changed-files.sh — refusing to report a pass for a scan that never ran" >&2
-    exit 2
-  fi
-  # shellcheck source=lib/changed-files.sh
-  . "$SCRIPT_DIR/lib/changed-files.sh"
-  CHANGED_FILES=$(changed_files_vs_origin_main)
-fi
-
 # skip <what> <why> — a skipped scan must be as loud as a failed one. A
 # silently-skipped scan is indistinguishable from a clean one, which is the
 # same reasoning that makes a can't-run check a hard failure above; the
@@ -113,19 +96,43 @@ fi
 # an unknown.
 skip() { echo "SKIP: $1 — $2"; SKIPPED=$((SKIPPED + 1)); return 0; }
 
-# go_in_scope / web_in_scope — true when not scoping at all, else delegate to
-# the shared predicates in lib/changed-files.sh.
-go_in_scope() {
-  [[ "$CHANGED" -eq 1 ]] || return 0
-  go_module_touched "$1" "$CHANGED_FILES"
-}
-web_in_scope() {
-  [[ "$CHANGED" -eq 1 ]] || return 0
-  web_tree_touched "$1" "$CHANGED_FILES"
-}
-
+# Narrow GO_MODULES/WEB_TREES in place, once, before anything reads them.
+# Doing it here rather than inside each scanner loop matters: the scanners'
+# shared preconditions below — installing govulncheck, hard-failing when gosec
+# is absent — would otherwise still run with nothing in scope, so a push
+# touching no Go file could be rejected for a missing gosec. That is #1213's
+# exact shape (a push blocked by a pre-existing condition it cannot have
+# caused), and guarding only the loop bodies would have left it alive.
 if [[ "$CHANGED" -eq 1 ]]; then
+  # One `source` covers missing, unreadable and malformed: under `set -u`
+  # without `-e` a failed source would otherwise leave the predicates
+  # undefined, every module and tree would fall out of scope, and the run
+  # would exit 0 reporting "passed" — a clean bill of health from a scan that
+  # never happened, the one outcome this file's header rules out.
+  # shellcheck source=lib/changed-files.sh
+  . "$SCRIPT_DIR/lib/changed-files.sh" || {
+    echo "FAIL: --changed: cannot load $SCRIPT_DIR/lib/changed-files.sh — refusing to report a pass for a scan that never ran" >&2
+    exit 2
+  }
+  CHANGED_FILES=$(changed_files_vs_origin_main) || exit 2
+
   echo "-- scope: --changed — scanning only what this branch's diff vs origin/main feeds --"
+  all_modules=("${GO_MODULES[@]}"); GO_MODULES=()
+  for mod in "${all_modules[@]}"; do
+    if go_module_touched "$mod" "$CHANGED_FILES"; then
+      GO_MODULES+=("$mod")
+    else
+      skip "govulncheck + gosec: $mod" "no .go/go.mod/go.sum change under it"
+    fi
+  done
+  all_trees=("${WEB_TREES[@]}"); WEB_TREES=()
+  for tree in "${all_trees[@]}"; do
+    if web_tree_touched "$tree" "$CHANGED_FILES"; then
+      WEB_TREES+=("$tree")
+    else
+      skip "npm audit: $tree" "no package.json/package-lock.json change under it"
+    fi
+  done
 fi
 
 # ---- GitHub-native alerts (full mode only) --------------------------------
@@ -167,14 +174,13 @@ if [[ "$LOCAL_ONLY" -eq 0 ]]; then
 fi
 
 # ---- govulncheck (all modes) ----------------------------------------------
+# The toolchain check lives inside the loop, matching the npm block below: with
+# no module in scope it must not run at all, or a push touching no Go file pays
+# a network install (and fails outright when `go` isn't on PATH) for a scan
+# with nothing to scan — #1213's shape exactly.
 
-command -v govulncheck >/dev/null 2>&1 || go install golang.org/x/vuln/cmd/govulncheck@latest
-
-for mod in "${GO_MODULES[@]}"; do
-  if ! go_in_scope "$mod"; then
-    skip "govulncheck: $mod" "--changed: no .go/go.mod/go.sum change under it"
-    continue
-  fi
+for mod in "${GO_MODULES[@]+"${GO_MODULES[@]}"}"; do
+  command -v govulncheck >/dev/null 2>&1 || go install golang.org/x/vuln/cmd/govulncheck@latest
   echo "-- govulncheck: $mod --"
   gv_json=$(mktemp)
   gv_err=$(mktemp)
@@ -209,34 +215,28 @@ for mod in "${GO_MODULES[@]}"; do
 done
 
 # ---- gosec (all modes) -----------------------------------------------------
+# Same placement, and for a sharper reason: "gosec not found" is a hard
+# failure, so hoisting it out of the loop would reject a push that had no Go
+# module to scan — again #1213's shape.
 
-command -v gosec >/dev/null 2>&1 || fail "gosec not found — install: go install github.com/securego/gosec/v2/cmd/gosec@latest"
+for mod in "${GO_MODULES[@]+"${GO_MODULES[@]}"}"; do
+  command -v gosec >/dev/null 2>&1 || { fail "gosec not found — install: go install github.com/securego/gosec/v2/cmd/gosec@latest"; continue; }
+  echo "-- gosec: $mod (informational, all severities) --"
+  ( cd "$mod" && gosec -no-fail -quiet ./... ) || true
 
-if command -v gosec >/dev/null 2>&1; then
-  for mod in "${GO_MODULES[@]}"; do
-    if ! go_in_scope "$mod"; then
-      skip "gosec: $mod" "--changed: no .go/go.mod/go.sum change under it"
-      continue
-    fi
-    echo "-- gosec: $mod (informational, all severities) --"
-    ( cd "$mod" && gosec -no-fail -quiet ./... ) || true
-
-    echo "-- gosec: $mod (gate: High severity + High confidence) --"
-    if ( cd "$mod" && gosec -quiet -severity high -confidence high ./... ); then
-      ok "gosec: $mod — no High/High findings"
-    else
-      fail "gosec: $mod — High-severity/High-confidence finding(s) — see output above"
-    fi
-  done
-fi
+  echo "-- gosec: $mod (gate: High severity + High confidence) --"
+  if ( cd "$mod" && gosec -quiet -severity high -confidence high ./... ); then
+    ok "gosec: $mod — no High/High findings"
+  else
+    fail "gosec: $mod — High-severity/High-confidence finding(s) — see output above"
+  fi
+done
 
 # ---- npm audit (all modes) -------------------------------------------------
+# `command -v npm` already sits inside the loop, so an out-of-scope tree never
+# reaches it — the shape the two Go blocks above were corrected to match.
 
-for tree in "${WEB_TREES[@]}"; do
-  if ! web_in_scope "$tree"; then
-    skip "npm audit: $tree" "--changed: no package.json/package-lock.json change under it"
-    continue
-  fi
+for tree in "${WEB_TREES[@]+"${WEB_TREES[@]}"}"; do
   echo "-- npm audit: $tree --"
   command -v npm >/dev/null 2>&1 || { fail "npm audit: $tree — npm not found"; continue; }
   # npm audit exits non-zero both when it finds advisories AND when the audit


### PR DESCRIPTION
Follow-up to #1231 (closes the remainder of #1213).

**Why a second PR:** #1231 was merged at head `42077e91` while its review pass was still in flight. The `/code-review` + `/simplify` fixes were pushed ~9 minutes later as `3ce31f99` and so never landed. This PR is exactly that commit, cherry-picked onto current `main`. Nothing here is new work — it is the review response to #1231.

## The one that matters: #1213's own bug class survived its fix

`security-scan.sh`'s scoping guards sat *inside* each scanner loop, which left the loops' **shared preconditions** above them unscoped. So with zero Go modules in scope, `go install govulncheck` still ran, and the hard `gosec not found` failure could still reject the push.

Reproduced against **merged `main` as it stands right now** (a diff with no `.go`, `go.mod`, or `go.sum` file — every Go module correctly SKIPs):

```
$ PATH="$(dirname $(command -v npm)):/usr/bin:/bin" bash tools/security-scan.sh --local --changed
tools/security-scan.sh: line 171: go: command not found
FAIL: gosec not found — install: go install github.com/securego/gosec/v2/cmd/gosec@latest
security-scan: FAILED — ... (8 scan(s) skipped as out of scope for this diff ...)
```

That is #1213's exact shape — a push rejected by a pre-existing condition it cannot have caused, pushing the developer to `--no-verify` — surviving four lines above the fix written for it.

Same command on this branch:

```
security-scan: passed (8 scan(s) skipped as out of scope for this diff — run tools/security-scan.sh without --changed for the full sweep)
```

**Fix:** narrow `GO_MODULES`/`WEB_TREES` once, up front, and move both toolchain checks inside their loops so an empty list runs nothing. This is the placement the `npm` block in the same file already used — the two Go blocks now match it, rather than each carrying its own guard.

Verified non-regressive: an unscoped `tools/security-scan.sh --local` run produces **byte-identical scan coverage** to before (6 govulncheck, 6 gosec, 2 npm audit, 0 skips; `diff` of the section headers and OK lines is empty).

## Also in this commit

- **Silent-full-skip on a failed `source`.** Both scripts run under `set -u` without `-e`, so a failed source of the lib left the predicates undefined; every in-scope test returned 127, everything fell out of scope, and the run exited 0 — a green report for a scan that never happened. Now `. lib || { …; exit 2; }`: one line, and it also catches a lib that exists but is *malformed*, which the `[[ -r ]]` test it replaces would wave through.
- **An unresolvable baseline passed silently.** With `origin/main` unfetched (fresh or shallow clone) the changed set came back empty — byte-for-byte what "nothing changed" looks like — so every gate skipped and the hook went green having run nothing. Now fatal. `git merge-base` already fails under exactly those conditions, so its exit status is the check, one fork fewer than the separate `rev-parse` probe it replaces.
- **A false safety claim in the tests.** The test file carried its own copies of `GO_MODULES`/`WEB_TREES`, commented "so a rename there … shows up as a failure rather than silence." It doesn't — the predicates are pure string matching, so swapping in bogus names leaves the suite green. Per AGENTS.md's "Dismissals carry evidence", a load-bearing claim that isn't true is worse than none. Both copies and their eight restating assertions are gone; two representative cases replace them.
- **Circular test ownership.** The shell-lib tests are the tests of the pre-push gate's own scoping logic, and their only runner was that same gate — which `--no-verify` disables, and which #1213 was actively pushing people toward. Adds a `Test the shared shell libs` step to `test.yml`, and widens the local gate's trigger to `^tools/lib/|^tools/[^/]*\.sh$` so a third caller of the lib can't silently stop running them.
- `go_module_touched` collapses to a single `case` (`"$mod"/*.go` spans `/`), making it line-for-line parallel with `web_tree_touched`; an `assert_contains` helper replaces two hand-rolled `case` blocks.

## Tests

| Check | Result |
|---|---|
| `tools/lib/changed-files_test.sh` | ALL PASS (now also covers the fatal-baseline and unloadable-lib paths) |
| `tools/preflight.sh --changed` | all gates PASS / SKIP correctly |
| `tools/security-scan.sh --local` (unscoped) | identical coverage to pre-change: 6 / 6 / 2, 0 skips |
| F1 reproduction with `go` and `gosec` off PATH | fails on `main`, passes here (both pasted above) |
| `bash -n` + `shellcheck -S warning -x` | clean (two pre-existing SC2164 on untouched `cd` lines) |

## Deliberately not done

Dropping `preflight.sh`'s trigger regex in favour of `security-scan.sh` as the sole scope authority. The two layers do compute the same answer on this repo's current shape, but the regex is a cheap fast path that avoids spawning the subprocess at all, and removing it changes the summary's SKIP/PASS reporting. Worth its own issue rather than widening this one. Also left alone: deriving `GO_MODULES` from `go.work` (adds a `go` + `jq` dependency to a script that must work when the toolchain is absent — see the bug above), and the `SKIPPED` counter (it is the honest-reporting mechanism, not redundant state).

## Unrelated pre-existing finding, still open

An unscoped run remains red on `main` for a reason neither PR addresses: `FAIL: govulncheck: core — 1 vulnerability/ies in called third-party code: ["GO-2026-5942"]` — a panic parsing an invalid SVCB/HTTPS RR in `golang.org/x/net/dns/dnsmessage`, fixed in `golang.org/x/net` 0.56.0. It needs a `core/go.mod` bump and deserves its own issue. Note it is *also* an instance of the class fixed here: until it's resolved, any push touching a Go file under `core/` is blocked by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
