### PR TITLE
fix(deps): bump golang.org/x/net to v0.56.0 (#1247)

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/grandcat/zeroconf v1.0.0
-	golang.org/x/sys v0.45.0
+	golang.org/x/sys v0.46.0
 	golang.org/x/tools v0.42.0
 	modernc.org/sqlite v1.50.0
 )
@@ -21,7 +21,7 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/core/go.sum
+++ b/core/go.sum
@@ -36,8 +36,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
@@ -45,8 +45,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=


### PR DESCRIPTION
## Problem

The unscoped security gate was red on `main`:

```
FAIL: govulncheck: core — 1 vulnerability/ies in called third-party code: ["GO-2026-5942"]
security-scan: FAILED — resolve the Critical/High finding(s) above before shipping.
```

`core/go.mod` pinned `golang.org/x/net v0.55.0`; GO-2026-5942 is fixed in `v0.56.0`. This is **called** third-party code — `security-scan.sh` filters stdlib findings out, so it was not toolchain noise.

Because `tools/preflight.sh --changed` fires the security gate for any diff touching `.go`/`go.mod`/`go.sum`, **every push touching `core/**.go` was being rejected locally** by an advisory the pusher could not have caused — the same failure shape as #1213, surviving via a different trigger. During the #1213–#1216 fleet it forced `--no-verify` on two PRs, which disables *every* gate rather than just the false one.

## Change

`go get golang.org/x/net@v0.56.0 && go mod tidy` in `core/`. `golang.org/x/sys` moves `v0.45.0 → v0.46.0` as its transitive requirement. Lockfile-equivalent only — no source changes.

## Verification

- `tools/security-scan.sh --local` before: `FAIL … ["GO-2026-5942"]`. After: **`security-scan: passed`**.
- **This branch's own push passed the pre-push hook** with `security scan (govulncheck + gosec + npm audit)  PASS` — no `--no-verify`, which is the end-to-end confirmation.
- `go test ./core/... -race -count=1` green; `go build ./core/...` and `gofmt -l core/` clean.

## Note on a flake seen while verifying

One full-suite run on this branch hit `TestSessionDetector_NewSession_CreatesState` (`core/application/services`). It is **not** caused by this change — a `go.mod`-only diff cannot reach session-detection logic, the test passes `-count=5` in isolation both with and without the bump, and a re-run of the full suite on this branch is green. It is a second load-dependent flake in the same family as #1248, and is recorded there rather than here.

Closes #1247

🤖 Generated with [Claude Code](https://claude.com/claude-code)