### PR TITLE
docs(ir:release): follow ir:refresh-aliases by path, not by name (#1249)

### DIFF
--- a/.claude/skills/ir:release/SKILL.md
+++ b/.claude/skills/ir:release/SKILL.md
@@ -41,9 +41,13 @@ The argument (if any) is the bump type: `patch` (default), `minor`, or `major`.
 
 ## Step 1.5: Refresh Model Aliases (codeburn sync)
 
-Run the `/ir:refresh-aliases` workflow inline before drafting release notes so
-any new frontend aliases ship with this release instead of waiting another
-cycle. The map in `core/pkg/capacity/aliases.go` is a hand-translated port of
+Run the `/ir:refresh-aliases` workflow inline — see
+`.claude/skills/ir:refresh-aliases/SKILL.md` for the full procedure — before
+drafting release notes so any new frontend aliases ship with this release
+instead of waiting another cycle. Follow the file by path rather than
+invoking the skill by name: a skill added or renamed after this session
+started is not registered in it, so the `Skill` call is rejected while the
+file is right there (#1249). The map in `core/pkg/capacity/aliases.go` is a hand-translated port of
 codeburn's `BUILTIN_ALIASES`; new entries upstream mean real users on new
 frontends (Cursor variants, Antigravity Gemini models, etc.) price at $0
 until we sync.


### PR DESCRIPTION
## What #1249 asked for is mostly already done

#1249 was filed after two agents in the #1213–#1216 fleet hit a rejected `Skill` call for `ir:code-review` and had to improvise a subagent fallback. **That specific gap is already closed on `main` by #1217**, which landed mid-fleet — those agents were running the pre-#1217 skill loaded at their start.

Verified rather than assumed, on `main`:

- `grep` for a `Skill(` invocation of `ir:code-review` across `ir:exec/SKILL.md` → **no matches**. Step 13 never invokes it by name.
- Step 13 instead spawns one review subagent and tells it to follow `.claude/skills/ir:code-review/SKILL.md` — "point at it *by path*, which works whether or not skill invocation is available inside a subagent" — plus a `test -f` precondition that surfaces-and-pauses on `MISSING`.

So no change is needed there, and shipping one would have been a no-op.

## The one thing that was left

#1249's broader point — *"the same note is worth having wherever a skill instructs an agent to invoke another repo-owned skill by name"* — still had exactly one live instance.

`ir:release` Step 4b already points at `.claude/skills/ir:doc-review/SKILL.md` by path, and explicitly calls Step 1.5 "the same pattern as Step 1.5's `/ir:refresh-aliases`". But Step 1.5 only named the skill. This makes the two consistent and states the reason.

## Change

One paragraph in `.claude/skills/ir:release/SKILL.md` Step 1.5: name `.claude/skills/ir:refresh-aliases/SKILL.md` and say to follow it by path.

## Verification

Docs-only, no code path. `test -f .claude/skills/ir:refresh-aliases/SKILL.md` → present, so the new reference resolves.

Closes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)