### PR TITLE
fix(security): close the 4 open CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/codescene-badge.yml
+++ b/.github/workflows/codescene-badge.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# The badge is published by PATCHing a gist with a separate GIST_SECRET PAT,
+# not the workflow token — so the default token needs checkout and nothing more.
+permissions:
+  contents: read
+
 jobs:
   badge:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ on:
   push:
     branches: [main]
 
+# Checkout is the only thing the default token is used for here — no job
+# writes back to the repo, comments on a PR, or publishes anything.
+permissions:
+  contents: read
+
 jobs:
   go-test:
     # macOS gate — the platform developers build and run on, and where the

--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -2,6 +2,10 @@ name: web-test
 
 on: [push, pull_request]
 
+# Checkout only — the matrix runs npm ci + vitest and writes nothing back.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/core/adapters/inbound/agents/codex/session_meta.go
+++ b/core/adapters/inbound/agents/codex/session_meta.go
@@ -48,6 +48,16 @@ func parentSessionIDFromPath(path string) string {
 }
 
 func sessionMetaPayload(path string) map[string]interface{} {
+	// Sink-local traversal guard. Every real caller already hands over a
+	// confined path — hooks.go rebuilds it from the trusted sessions root, and
+	// hookinstaller walks that root itself — but the plain ".." check is the
+	// form CodeQL's go/path-injection query recognizes as a sanitizer, which
+	// the Rel-based confinement in confineToSessionsDir is not (same lesson as
+	// store.go's underRoot in #910). A rejected path falls through to the same
+	// "no metadata" result an unreadable file already produces.
+	if strings.Contains(path, "..") {
+		return nil
+	}
 	f, err := os.Open(path)
 	if err != nil {
 		return nil

--- a/core/adapters/inbound/agents/codex/session_meta_test.go
+++ b/core/adapters/inbound/agents/codex/session_meta_test.go
@@ -62,6 +62,32 @@ func TestSessionIDFromPath_FallsBackToRolloutThreadID(t *testing.T) {
 	}
 }
 
+// TestSessionMetaPayload_RejectsParentTraversal pins the sink-local traversal
+// guard: a path that resolves to a real, readable session_meta file is still
+// refused when a literal ".." got into it, so neither extractor opens it.
+func TestSessionMetaPayload_RejectsParentTraversal(t *testing.T) {
+	real := writeSessionMeta(t, `{"type":"session_meta","payload":{"id":"`+childThreadID+`","thread_source":"subagent","parent_thread_id":"`+parentThreadID+`"}}`)
+	dir := filepath.Dir(real)
+	// dir/../<dir base>/<file> resolves to the same file, so only the guard —
+	// not a failing open — can make the extractors return empty. Assembled by
+	// hand because filepath.Join would Clean the ".." straight back out.
+	sep := string(filepath.Separator)
+	traversal := dir + sep + ".." + sep + filepath.Base(dir) + sep + filepath.Base(real)
+	if _, err := os.Stat(traversal); err != nil {
+		t.Fatalf("setup: traversal path should resolve to the real file: %v", err)
+	}
+	if got := sessionMetaPayload(traversal); got != nil {
+		t.Errorf("sessionMetaPayload(%q) = %v; want nil (traversal rejected)", traversal, got)
+	}
+	if got := sessionIDFromPath(traversal); got != childThreadID {
+		// The filename fallback still applies — it parses the string only.
+		t.Errorf("sessionIDFromPath(%q) = %q, want the filename fallback %q", traversal, got, childThreadID)
+	}
+	if got := parentSessionIDFromPath(traversal); got != "" {
+		t.Errorf("parentSessionIDFromPath(%q) = %q, want empty (traversal rejected)", traversal, got)
+	}
+}
+
 func TestAgent_DeclaresCodexMetadataExtractors(t *testing.T) {
 	source, ok := Agent().Source.(agent.FilesUnderRoot)
 	if !ok {


### PR DESCRIPTION
Closes #1259.

Clears the code-scanning dashboard: 3 medium `actions/missing-workflow-permissions`
(alerts [56](https://github.com/ingo-eichhorst/Irrlicht/security/code-scanning/56) /
[58](https://github.com/ingo-eichhorst/Irrlicht/security/code-scanning/58) /
[60](https://github.com/ingo-eichhorst/Irrlicht/security/code-scanning/60)) and 1 high
`go/path-injection` ([59](https://github.com/ingo-eichhorst/Irrlicht/security/code-scanning/59)).

## Workflow permissions (56 / 58 / 60)

`test.yml`, `web-test.yml` and `codescene-badge.yml` were the only three workflows in
the repo without a `permissions:` block — every other one already scopes the token — so
their jobs ran with the default broad `GITHUB_TOKEN`. Each gets `contents: read`.

That's the correct floor for all three, verified by reading each file rather than
assuming: none writes back to the repo, opens a PR, or comments. `codescene-badge`
looks like a writer but isn't — it publishes the badge by `PATCH`ing a gist with a
separate `GIST_SECRET` PAT (`codescene-badge.yml:51-76`), so the workflow token only
ever serves the checkout.

## Path injection (59)

**This is defense-in-depth, not a live vulnerability.** The hook path reaching
`sessionMetaPayload` is already confined: `confineToSessionsDir` (`hooks.go:168-185`)
requires a `.jsonl` extension, resolves symlinks, and rejects anything whose
`filepath.Rel` against `$CODEX_HOME/sessions` escapes the root — then rebuilds the path
from the trusted root so no caller-controlled string reaches `os.Open`.

CodeQL flags it anyway because `filepath.Rel` + `HasPrefix` is not a shape its
`go/path-injection` query recognizes as a sanitizer, whereas a plain
`strings.Contains(x, "..")` check is. That's the exact lesson b9324ac learned on
`store.go`'s `underRoot` in #910, where the same confinement idiom left an alert open
until the recognized check led. So `sessionMetaPayload` gets a sink-local guard.

Guarding at the sink rather than in `confineToSessionsDir` also covers the other
caller (`hookinstaller.go:238`), and a rejected path falls through to the same
"no metadata" result an unreadable file already produces — no panic, no new error shape.

I deliberately did *not* add a redundant `strings.Contains` to `confineToSessionsDir`:
its existing confinement is genuinely correct, and no alert points there.

## Verification

- **The new test was seen red before the fix.** First attempt was red for the wrong
  reason — `filepath.Join` cleans `..` straight back out — so the traversal path is
  assembled by hand. Corrected, it fails on unfixed code with
  `sessionMetaPayload(...) = map[id:... parent_thread_id:...]; want nil`, i.e. the path
  resolves to a real readable file and only the guard can reject it. Green after.
- `tools/preflight.sh --changed`: gofmt, core module tests, ARS architecture gate and
  the security scan all PASS.
- The dashboard gate in `security-scan.sh`'s full (non-`--local`) mode still reports
  alert 59 open — it reads the live dashboard, so it clears only once this merges and
  GitHub rescans. Preflight's `--local` mode correctly skips that check.

Rebased onto current `origin/main` to pick up #1252's `golang.org/x/net` bump; without
it the security gate also failed on `GO-2026-5942` (unrelated to this diff, already
fixed on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)