### PR TITLE
fix(examples): install claude-code with --ignore-scripts (docker:S6505)

### DIFF
--- a/examples/roundtrip/agent.Dockerfile
+++ b/examples/roundtrip/agent.Dockerfile
@@ -46,11 +46,14 @@ ARG CLAUDE_CODE_VERSION
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl git procps tini \
     && rm -rf /var/lib/apt/lists/* \
-    # No --ignore-scripts here, unlike the sibling coding-factory image: this
-    # package ships bin/claude as a placeholder and its postinstall copies the
-    # matching native binary from optionalDependencies over it. Skipping scripts
-    # leaves the stub, so `claude` never runs and the testbed observes nothing.
-    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    # --ignore-scripts, like the sibling coding-factory image — but this package
+    # ships bin/claude as a placeholder that its own postinstall replaces with the
+    # matching native binary from optionalDependencies, so skipping every script
+    # leaves `claude` exiting "native binary not installed" and the testbed
+    # observes nothing. Hence: block the whole dependency tree's install hooks,
+    # then run that one script explicitly, by name (docker:S6505).
+    && npm install -g --ignore-scripts "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+    && node "$(npm root -g)/@anthropic-ai/claude-code/install.cjs" \
     && useradd --create-home --shell /bin/bash agent
 COPY --from=build /out/irrlichd /usr/local/bin/irrlichd
 COPY examples/roundtrip/entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
Follow-up to #1262, which left this finding open as "a documented trade-off needing a SonarCloud-side disposition". It turned out to have a real fix.

## The finding

`examples/roundtrip/agent.Dockerfile` installed `@anthropic-ai/claude-code` **without** `--ignore-scripts`, so every package in the dependency tree could run arbitrary install hooks. The in-file comment explained why:

> No `--ignore-scripts` here, unlike the sibling coding-factory image: this package ships `bin/claude` as a placeholder and its postinstall copies the matching native binary from optionalDependencies over it.

That is accurate — I confirmed it in a throwaway `node:22-bookworm-slim` container:

```
$ npm install -g --ignore-scripts "@anthropic-ai/claude-code@2.1.220" && claude --version
Error: claude native binary not installed.
Either postinstall did not run (--ignore-scripts, some pnpm configs)
```

## The fix

Needing *that one* script does not mean needing *every* script. The package exposes it by name — `package.json` has `"postinstall": "node install.cjs"` — so the install can block the whole tree's hooks and then run just that one, explicitly:

```dockerfile
&& npm install -g --ignore-scripts "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
&& node "$(npm root -g)/@anthropic-ai/claude-code/install.cjs" \
```

This is **strictly safer than before**, not a lint workaround: previously the entire transitive dependency tree could execute install hooks; now nothing runs implicitly, and the single script that does run is named, auditable, and from the package the image already trusts.

## Verification

Not just a `--check` lint pass — the real image, end to end:

```
$ docker build -f examples/roundtrip/agent.Dockerfile -t irrlicht-roundtrip-sonarcheck .
... DONE
$ docker run --rm --entrypoint sh irrlicht-roundtrip-sonarcheck -c 'claude --version'
2.1.220 (Claude Code)
```

Plus `tools/preflight.sh` — **11/11 PASS**.

## Backlog status

With this merged, the 80-finding sweep is fully resolved: 68 fixed in code, 12 `go:S1135` marked False Positive (the rule matches the standalone word "todo", which is vibe's *tool name* — see the per-issue comments in SonarCloud), and 1 `swift:S1075` Accepted (irrlicht's own docs URL; moving it to `Info.plist` was tried and reverted because it turned `testHistoryCO2EmptyStateStillShowsMethodologyLink` red — any bundle missing the key silently drops the link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)