### PR TITLE
fix(ir:exec): detect when the running playbook is stale

### DIFF
--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -119,7 +119,11 @@ worktree name. `close` additionally resolves it from `pwd` / `git status -sb` /
    frequently changed in the repo — so from here on you would be editing current
    code while following superseded instructions.
    ```bash
-   diff -q .claude/skills/ir:exec/SKILL.md <main-repo>/.claude/skills/ir:exec/SKILL.md
+   # Both paths absolute on purpose: written relative to cwd, a run from the
+   # main checkout compares the file to itself and always reports "current" —
+   # a false negative in the one check whose job is catching a silent pass.
+   diff -q <worktree>/.claude/skills/ir:exec/SKILL.md \
+           <main-repo>/.claude/skills/ir:exec/SKILL.md
    ```
    On a difference, **re-read the worktree's copy and follow that**, and say so in
    one line of response text. Don't reconcile the two by judgment: the worktree

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -112,6 +112,32 @@ worktree name. `close` additionally resolves it from `pwd` / `git status -sb` /
    ```
    `.claude/worktrees/` is gitignored. **Do all work via the worktree path** — editing
    the main checkout's files by absolute path touches the wrong tree.
+2a. **Confirm you are running the current playbook.** The skill text you are
+   executing was loaded into this session from the **main checkout** at startup;
+   the worktree you just created is off fresh `origin/main`. Those disagree
+   whenever the main checkout is behind, and this file is among the most
+   frequently changed in the repo — so from here on you would be editing current
+   code while following superseded instructions.
+   ```bash
+   diff -q .claude/skills/ir:exec/SKILL.md <main-repo>/.claude/skills/ir:exec/SKILL.md
+   ```
+   On a difference, **re-read the worktree's copy and follow that**, and say so in
+   one line of response text. Don't reconcile the two by judgment: the worktree
+   copy is authoritative because it is what every agent working from current
+   `main` is running.
+
+   Unlike the other Phase 1 checks this one does **not** pause — it is a
+   correction, not a conflict, and the corrected instructions are right there.
+
+   (Real incident, #1275: a run started from a checkout 59 commits behind
+   followed a step 13 that said to invoke `/code-review` — which is
+   `disable-model-invocation` and unreachable. #1217 had already replaced it
+   with the subagent delegation below. The review gate degraded to an improvised
+   inline pass, and the run's final report proposed, as its top improvement, a
+   fix that had shipped days earlier. Note which guards did *not* catch this:
+   step 13's `test -f` confirms the **reviewer** exists, never that the
+   **instructions** are current — a stale playbook passes every check it
+   contains, because those checks are stale too.)
 
 ## Phase 2 — Investigate & plan
 


### PR DESCRIPTION
Closes #1275

## The gap

A session's skills are loaded from the **main checkout** at startup, but
`ir:exec` creates its worktree off fresh `origin/main`. From step 2 onward the
agent edits current code while following whatever version of the playbook the
main checkout happened to be sitting on. Nothing detects that.

## The incident

A `/ir:exec 1225` run started from `88b2c51e` — measured at **59 commits**
behind `origin/main` — and followed that copy's step 13:

```
13. **Review the diff** ... Run the
    `/code-review` skill with the **explicit base** `origin/main...HEAD`
```

`/code-review` is `disable-model-invocation`: unreachable from the `Skill`
tool. PR #1217 (`e0291757`) had **already** replaced that step with the
path-based review-subagent delegation, precisely because of #1205 — and that
fix was on `origin/main` for the entire run.

Two consequences, the second worse than the first:

1. The review gate degraded to an improvised inline pass.
2. The run's final report proposed, as its **top** process improvement, a fix
   that had shipped days earlier — a confidently wrong claim of exactly the
   kind `AGENTS.md`'s "dismissals carry evidence" rule exists to prevent.

## Why no existing guard catches it

Step 13 already opens with `test -f .claude/skills/ir:code-review/SKILL.md`,
and that guard passes — the file *is* there in the worktree. It confirms the
**reviewer** exists; it says nothing about whether the **instructions being
followed** are current. A stale playbook passes every check it contains,
because those checks are stale too. The gap is structural, not an oversight in
any one step.

## The fix

Phase 1 already has everything needed: the worktree is off fresh `origin/main`,
so the authoritative copy of this file is on disk right beside the one being
executed. New step 2a diffs them, and on a difference re-reads the worktree
copy and follows that.

It **corrects rather than pauses**, unlike the other Phase 1 checks. Those pause
because they surface a conflict only a human can resolve (a duplicate branch, an
open PR). This one isn't a conflict — the correct instructions are already
local, and stopping to ask would be ceremony.

## Verification

Run against the incident's actual condition rather than a synthetic one:

| Case | `diff -q` exit | Meaning |
|---|---|---|
| `88b2c51e` (the real stale checkout) vs `origin/main` | `1` | staleness detected |
| identical copies | `0` | no false positive |

Also confirmed the stale copy genuinely contains the superseded instruction —
`git show 88b2c51e:.claude/skills/ir:exec/SKILL.md` lines 252–256 read "Run the
`/code-review` skill", which wraps across a line break (an initial `grep` for
the phrase returned 0 for that reason, not because the text was absent).

Documentation-only change to one skill file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)