### PR TITLE
feat(tooling): lint .claude/skills/**/*.md as its own preflight + CI gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,3 +92,16 @@ jobs:
             echo "== $t =="
             bash "$t"
           done
+
+      # .claude/skills/**/*.md are executable instructions — they decide how
+      # agents triage, plan, implement and review — and until #1209 no gate
+      # read them. PR #1204 changed two skill files: preflight skipped all ten
+      # gates and all thirteen PR checks went green having checked nothing that
+      # changed. This step is the missing CI reader. It is deliberately
+      # unscoped (the whole corpus, every push) — the run is a fraction of a
+      # second, and scoping is what let the gap exist in the first place.
+      # Unresolved conflict markers and leftover template scaffolding fail;
+      # the reference/list/frontmatter heuristics only warn until their noise
+      # floor is known (tools/skill-lint.sh --strict promotes them).
+      - name: Lint skill files
+        run: tools/skill-lint.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,20 @@ Before marking a ticket done, run the full suite — every layer must pass:
   assertion lands with the deliberate mutation that was seen red for each
   obligation recorded in its PR — the same bar the red-first rule above sets
   for defect tests.
+- Skill files: `tools/skill-lint.sh` reads `.claude/skills/**/*.md` — the
+  files that tell agents how to triage, plan, implement and review, and which
+  had no mechanical coverage at all until #1209 (PR #1204 changed two of them,
+  `preflight.sh --changed` skipped all ten gates, and thirteen PR checks went
+  green having read nothing that changed). Unresolved conflict markers and
+  leftover `{{TOKEN}}` / `REPEAT:` / `OPTIONAL:` template scaffolding are hard
+  failures; the internal-reference, list-count and frontmatter checks are
+  heuristics and only warn until their noise floor is known (`--strict`
+  promotes them, which is how one gets hardened). Runs as its own
+  `skill-file lint` gate in `tools/preflight.sh` (scoped to skill markdown plus
+  the linter itself) and unscoped as test.yml's "Lint skill files" step. Its
+  own tests are `tools/lib/skill-lint_test.sh`, over the fixture corpus under
+  `tools/lib/testdata/skill-lint/` — so the assertions never move when a real
+  skill file is edited.
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh`
 - Replay goldens (when a recording or replay-output change is in play):
@@ -163,6 +177,7 @@ tools/preflight.sh                # everything except the Linux Docker gate
 tools/preflight.sh --linux        # + full Linux parity (slow: needs Docker)
 tools/preflight.sh --only go      # just the test.yml-equivalent gates
 tools/preflight.sh --only arch    # just the ARS architecture gate
+tools/preflight.sh --only skills  # just the .claude/skills/**/*.md linter
 ```
 
 `tools/install-git-hooks.sh` (run once per clone; worktrees share the parent

--- a/tools/lib/skill-lint_test.sh
+++ b/tools/lib/skill-lint_test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# skill-lint_test.sh — unit tests for tools/skill-lint.sh. Plain bash (no
+# framework), matching the style of lib/changed-files_test.sh. Run directly, or
+# via tools/preflight.sh's `tools` gate and test.yml's "Test the shared shell
+# libs" step. Exits non-zero on any failed assertion.
+#
+# Covers issue #1209: nothing mechanical read .claude/skills/**/*.md, so a PR
+# touching only skill files went green having checked nothing. The linter is
+# exercised against a fixture corpus under testdata/skill-lint/skills/ — one
+# deliberately broken file per check, plus files that must stay clean — rather
+# than against real skill files, so the assertions do not move when a real
+# skill is edited.
+#
+# The clean fixtures carry as much weight as the broken ones. `good/SKILL.md`
+# is built out of exactly the constructs that would make a naive linter
+# unusable here: prose that *documents* {{TOKEN}} and REPEAT:/OPTIONAL: markers
+# inside backticks (which is how .claude/skills/ir:exec/SKILL.md really reads),
+# a conflict marker shown inside a fence, a correct above/below reference, and
+# a lead-in count that matches its list once nested items are excluded.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+LINT="$ROOT/tools/skill-lint.sh"
+FIXTURES="$DIR/testdata/skill-lint/skills"
+
+fails=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() {
+  echo "  FAIL: $1 — expected [$2] got [$3]"
+  fails=$((fails + 1))
+  return 0
+}
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  [[ "$expected" == "$actual" ]] && pass "$label" || fail "$label" "$expected" "$actual"
+  return 0
+}
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*) pass "$label" ;;
+    *) fail "$label" "contains: $needle" "$haystack" ;;
+  esac
+  return 0
+}
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*) fail "$label" "does NOT contain: $needle" "$haystack" ;;
+    *) pass "$label" ;;
+  esac
+  return 0
+}
+
+OUT=""
+RC=0
+# lint <args...> — run the linter, capturing combined output in OUT and the
+# exit status in RC. Run from the repo root so relative paths in the output
+# match what a developer would see.
+lint() {
+  OUT=$(cd "$ROOT" && bash "$LINT" "$@" 2>&1)
+  RC=$?
+  return 0
+}
+
+# fixture <name> — the single .md file of a fixture skill directory.
+fixture() {
+  local d="$FIXTURES/$1"
+  if [[ -f "$d/SKILL.md" ]]; then echo "$d/SKILL.md"; else echo "$d/reference.md"; fi
+}
+
+echo "== check 1: unresolved conflict markers are ERRORS =="
+lint "$(fixture conflict)"
+assert_contains "flags <<<<<<<"          "unresolved merge conflict marker <<<<<<<" "$OUT"
+assert_contains "flags ======="          "unresolved merge conflict marker =======" "$OUT"
+assert_contains "flags >>>>>>>"          "unresolved merge conflict marker >>>>>>>" "$OUT"
+assert_eq       "a conflict marker fails the gate" "1" "$RC"
+
+echo "== check 2: unfilled tokens and leftover scaffolding are ERRORS =="
+lint "$(fixture template)"
+assert_contains "flags an unfilled {{TOKEN}}"   "unfilled template token {{TLDR}}" "$OUT"
+assert_contains "flags a REPEAT:/OPTIONAL: comment" "[template-scaffold]" "$OUT"
+assert_eq       "leftover scaffolding fails the gate" "1" "$RC"
+
+echo "== check 3: internal references are WARNINGS =="
+lint "$(fixture refs)"
+assert_contains "flags a backwards direction"  "[ref-direction]" "$OUT"
+assert_contains "names the heading and its real side" 'that heading is above' "$OUT"
+assert_contains "flags a reference naming no heading" "[ref-dangling]" "$OUT"
+assert_eq       "warnings alone do not fail the gate" "0" "$RC"
+
+echo "== check 4: an announced count that disagrees with the list is a WARNING =="
+lint "$(fixture listcount)"
+assert_contains "flags three-announced/four-listed" "[list-count]" "$OUT"
+assert_contains "reports both numbers"              'announces "three" (3) but 4 list item' "$OUT"
+assert_eq       "warnings alone do not fail the gate" "0" "$RC"
+
+echo "== check 5: frontmatter sanity is a WARNING, and SKILL.md-only =="
+lint "$(fixture wrongname)"
+assert_contains "flags name: disagreeing with the directory" \
+  'name: is "some-other-name" but the directory says "wrongname"' "$OUT"
+lint "$(fixture nodesc)"
+assert_contains "flags an empty folded description:" "description: is empty" "$OUT"
+lint "$(fixture reference-doc)"
+assert_not_contains "a non-SKILL.md file is not checked for frontmatter" "[frontmatter]" "$OUT"
+assert_eq "a reference file with a matching count is clean" "0" "$RC"
+
+echo "== the nested-skill name rule: name: carries the parent prefix =="
+lint "$(fixture parent/child)"
+assert_not_contains "parent/child SKILL.md is not a name mismatch" "[frontmatter]" "$OUT"
+assert_eq "nested skill lints clean" "0" "$RC"
+
+echo "== the clean fixture: documenting markers is not using them =="
+# This is the regression that decides whether the linter is usable at all.
+# ir:exec/SKILL.md mentions {{TOKEN}}, REPEAT: and OPTIONAL: a dozen times in
+# backticks; a linter that reads the raw bytes hard-fails the repo on day one.
+lint "$(fixture good)"
+assert_eq       "the good fixture produces no findings" "0" "$RC"
+assert_contains "and reports zero of each" "0 error(s), 0 warning(s)" "$OUT"
+
+echo "== --strict promotes warnings to failures =="
+# The documented path to hardening checks 3-5 once their noise floor is known.
+lint --strict "$(fixture listcount)"
+assert_eq "--strict turns a warning into a non-zero exit" "1" "$RC"
+lint --strict "$(fixture good)"
+assert_eq "--strict still passes a clean file" "0" "$RC"
+
+echo "== a missing file is an error, not a silent pass =="
+lint "$FIXTURES/does-not-exist/SKILL.md"
+assert_eq "a path that does not exist fails" "1" "$RC"
+
+echo "== the default file set: the glob and the preflight gate must agree =="
+# With no arguments the linter walks .claude/skills/. An empty walk would make
+# the gate green while reading nothing — the exact failure #1209 is about — so
+# the script exits 2 there rather than 0, and this pins that the real tree is
+# discovered.
+lint
+assert_eq "the repo's own skill corpus has zero ERRORS" "0" "$RC"
+assert_not_contains "no file in .claude/skills/ is left unread" "0 file(s)" "$OUT"
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "skill-lint_test: ALL PASS"
+else
+  echo "skill-lint_test: $fails FAILED" >&2
+  exit 1
+fi

--- a/tools/lib/testdata/skill-lint/skills/conflict/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/conflict/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: conflict
+description: Fixture for check 1 — an unresolved merge conflict left in a skill file.
+---
+
+# Conflict fixture
+
+Instructions the agent would read as one thing or the other:
+
+<<<<<<< HEAD
+Assign the issue before implementing.
+=======
+Assign the issue after implementing.
+>>>>>>> feat/other-branch
+
+Trailing prose.

--- a/tools/lib/testdata/skill-lint/skills/good/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/good/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: good
+description: A known-good skill file. Every construct here is one the linter must NOT flag.
+---
+
+# Good skill
+
+## Auto mode
+
+Body text for the mode.
+
+## Modes
+
+The Auto mode above is the default, and the tier table below scales the run.
+
+Two flavors:
+
+- the first, with a nested list that must not be counted:
+  - nested a
+  - nested b
+  - nested c
+- the second
+
+## Tier table
+
+Documenting a template must not read as using one: replace every `{{TOKEN}}`,
+duplicate each `REPEAT:step` region, and delete any unused `OPTIONAL:ui` block.
+
+Prose about an identifier: one caveat of the two that `KIRO_HOME` below
+carries is that only one root is watched. That names a bullet, not a heading.
+
+A fenced block may show a conflict for illustration:
+
+```text
+<<<<<<< HEAD
+one side
+=======
+the other side
+>>>>>>> branch
+```
+
+Unlike the other six axes, this one is priced rather than blocking. Use the
+menu below:
+
+- Low
+- Medium
+- High

--- a/tools/lib/testdata/skill-lint/skills/listcount/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/listcount/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: listcount
+description: Fixture for check 4 — a lead-in whose announced count disagrees with the list.
+---
+
+# List-count fixture
+
+Three moves:
+
+- one
+- two
+- three
+- four

--- a/tools/lib/testdata/skill-lint/skills/nodesc/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/nodesc/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: nodesc
+description: >
+---
+
+# Empty-description fixture
+
+A folded scalar with no body is as empty as a missing key — the skill has no
+description for the loader to match on.

--- a/tools/lib/testdata/skill-lint/skills/parent/child/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/parent/child/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: parent/child
+description: >
+  A nested skill, whose frontmatter name carries the parent prefix — the shape
+  .claude/skills/ir:onboarding-factory/assess/SKILL.md uses. Folded scalars
+  count as a present description.
+---
+
+# Nested skill
+
+Nothing here should be flagged.

--- a/tools/lib/testdata/skill-lint/skills/reference-doc/reference.md
+++ b/tools/lib/testdata/skill-lint/skills/reference-doc/reference.md
@@ -1,0 +1,10 @@
+# A reference file, not a SKILL.md
+
+Files under a skill that are not `SKILL.md` carry no frontmatter, so check 5
+must not fire on them — only checks 1–4 apply.
+
+Three moves:
+
+- one
+- two
+- three

--- a/tools/lib/testdata/skill-lint/skills/refs/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/refs/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: refs
+description: Fixture for check 3 — a backwards reference and one naming no heading.
+---
+
+# Refs fixture
+
+## Scoring rubric
+
+The rubric body.
+
+## Axis table
+
+The verdict comes from the Scoring rubric below, which is the ordering defect
+issue #1209 describes: the table forward-references a section the reader has
+already passed.
+
+See the "Instrument menu" section above for the cheapest surface.

--- a/tools/lib/testdata/skill-lint/skills/template/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/template/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: template
+description: Fixture for check 2 — a rendered artifact still carrying its scaffolding.
+---
+
+# Template fixture
+
+## TL;DR
+
+{{TLDR}}
+
+<!-- REPEAT:step -->
+- A step that was never expanded.
+<!-- /REPEAT:step -->
+
+<!-- OPTIONAL:ui — delete this block when there is no UI -->
+An archetype block nobody deleted.
+<!-- /OPTIONAL:ui -->

--- a/tools/lib/testdata/skill-lint/skills/wrongname/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/wrongname/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: some-other-name
+description: Fixture for check 5 — frontmatter name disagreeing with the directory.
+---
+
+# Wrong-name fixture

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -8,7 +8,8 @@
 #
 # Mirrors:
 #   .github/workflows/test.yml      — gofmt, core + onboarding-factory tests,
-#                                      of validate, recording-rig smoke test
+#                                      of validate, recording-rig smoke test,
+#                                      shared shell libs, skill-file lint
 #   .github/workflows/web-test.yml  — npm test in both web trees
 #   .github/workflows/ars-gate.yml  — ARS architecture-regression gate
 #                                      (composite/category score vs origin/main)
@@ -30,6 +31,13 @@
 # tests of the pre-push gate's own scoping logic, and a gate whose only runner
 # is itself is one `--no-verify` away from never running at all.
 #
+# The `skills` group lints .claude/skills/**/*.md — the files that tell agents
+# how to triage, plan, implement and review. It exists because those files had
+# zero mechanical coverage (#1209): PR #1204 changed two of them and this
+# script skipped all ten gates, so thirteen green PR checks proved nothing
+# about the only files that changed. It mirrors test.yml's "Lint skill files"
+# step, for the same reason the `tools` group does.
+#
 # Usage:
 #   tools/preflight.sh                 # everything except the Linux gate
 #   tools/preflight.sh --linux         # + full Linux parity via Docker
@@ -38,6 +46,7 @@
 #   tools/preflight.sh --only arch     # just the ARS architecture gate
 #   tools/preflight.sh --only security # just govulncheck + gosec + npm audit
 #   tools/preflight.sh --only tools    # just the tools/lib shell-lib unit tests
+#   tools/preflight.sh --only skills   # just the .claude/skills/**/*.md linter
 #   tools/preflight.sh --only linux    # just the Linux Docker gate
 #   tools/preflight.sh --changed       # scope every gate to the packages/trees
 #                                        this branch changes vs origin/main —
@@ -249,6 +258,17 @@ shell_lib_tests() {
 if want tools; then
   run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$' \
                   "tools/lib shell-lib tests" shell_lib_tests
+fi
+
+# ---- skills group (mirrors test.yml's "Lint skill files" step) ------------
+# Scoped to the skill markdown itself plus the linter, so editing a check
+# re-lints the corpus it governs. The whole corpus is linted whenever the gate
+# fires rather than just the changed files: it is 22 small files and a fraction
+# of a second, and a finding that a *neighbouring* file already carries is
+# worth surfacing on the push that finally reads it.
+if want skills; then
+  run_gate_scoped '^\.claude/skills/.*\.md$|^tools/skill-lint\.sh$' \
+                  "skill-file lint" tools/skill-lint.sh
 fi
 
 # ---- security group (mirrors tools/security-scan.sh's local mode; the same

--- a/tools/skill-lint.sh
+++ b/tools/skill-lint.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+# skill-lint.sh — mechanical checks over .claude/skills/**/*.md, the files that
+# tell agents how to triage, plan, implement and review. Those files are
+# executable instructions, but until issue #1209 no gate read them: PR #1204
+# changed two skill files and `tools/preflight.sh --changed` skipped all ten
+# gates, so thirteen green checks proved nothing about the only files that
+# changed.
+#
+# This linter does not review wording — that stays a human judgement call. It
+# catches the defects a reviewer's eye slides over precisely because they look
+# like prose, and that a machine can decide without taste:
+#
+#   1. conflict-marker    ERROR  unresolved <<<<<<< / ======= / >>>>>>> / |||||||
+#   2. template-token     ERROR  {{TOKEN}} left unfilled
+#      template-scaffold  ERROR  <!-- REPEAT:x --> / <!-- OPTIONAL:x --> left in
+#   3. ref-direction      WARN   "X above" where heading X is below (or vice versa)
+#      ref-dangling       WARN   a delimited "X above/below" naming no heading
+#   4. list-count         WARN   "Three moves:" followed by a list of four
+#   5. frontmatter        WARN   SKILL.md name: disagrees with its directory,
+#                                or description: missing/empty
+#
+# Checks 1–2 are unambiguous, so they fail the gate. 3–5 are heuristics with a
+# real false-positive rate and only warn; `--strict` promotes them to failures,
+# which is the path to hardening one once its noise floor is known. Exit status
+# is 1 only when something failed at the severity in force.
+#
+# What the checks read
+# -------------------
+# Markdown that *talks about* markers is not markdown that *has* them.
+# `.claude/skills/ir:exec/SKILL.md` documents the plan.html template and so
+# mentions `{{TOKEN}}`, `REPEAT:step` and `OPTIONAL:ui` a dozen times — always
+# inside backticks. So checks 2 and 4 read a prose view of each file with
+# fenced code blocks, inline code spans and YAML frontmatter blanked out.
+# Check 3 keeps inline code (a reference can legitimately be written
+# `` `Auto mode` below ``) and check 1 reads raw lines outside fences, because
+# a conflict marker inside a fence is illustrative but anywhere else is a
+# corrupted file.
+#
+# Known limits (deliberate, not oversights)
+# ----------------------------------------
+# * Check 4 counts list markers. The ir:triage defect that motivated it — "Two
+#   flavors:" followed by three, the third orphaned *outside* the list — has
+#   two markers and so passes. Counting what a reader would call an item is a
+#   judgement call; counting markers is not.
+# * Check 3 only recognises a reference when the name is delimited
+#   (`"X"`, `` `X` ``, `**X**`) or matches a heading verbatim. "see the rule
+#   above" names nothing checkable and is ignored by design.
+# * Setext headings (underlined with === or ---) are not indexed as headings;
+#   every heading in this repo's skill files is ATX (#).
+#
+# Usage:
+#   tools/skill-lint.sh                  # lint every .claude/skills/**/*.md
+#   tools/skill-lint.sh --strict         # warnings fail too
+#   tools/skill-lint.sh FILE...          # lint just these files (used by tests)
+#   tools/skill-lint.sh --strict FILE...
+#
+# The expected frontmatter `name:` for a SKILL.md is its directory path below
+# the nearest `skills/` ancestor — `ir:exec`, or `ir:onboarding-factory/assess`
+# for a nested one. Deriving it from the path rather than a hard-coded list is
+# what lets the fixture corpus under tools/lib/testdata/ exercise check 5
+# without living in .claude/skills/.
+set -uo pipefail
+
+STRICT=0
+FILES=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --strict) STRICT=1; shift ;;
+    # Print the whole leading comment block, the same self-documenting idiom
+    # tools/preflight.sh uses, so --help can't drift from the header.
+    -h|--help) awk 'NR>1 && /^#/ {print; next} NR>1 {exit}' "$0"; exit 0 ;;
+    --) shift; FILES+=("$@"); break ;;
+    -*) echo "unknown arg: $1" >&2; exit 2 ;;
+    *) FILES+=("$1"); shift ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  cd "$ROOT_DIR" || exit 2
+  while IFS= read -r f; do
+    FILES+=("$f")
+  done < <(find .claude/skills -name '*.md' -type f | LC_ALL=C sort)
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  # Not a pass: the gate only runs when a skill file changed, so an empty file
+  # set means the glob and the gate's trigger disagree about where skills live.
+  echo "skill-lint: no skill files found — nothing was checked" >&2
+  exit 2
+fi
+
+# expected_skill_name <path> — the directory path below the nearest `skills/`
+# ancestor, which is what a SKILL.md's frontmatter `name:` must equal. Empty
+# when the path has no `skills/` ancestor, which turns the name comparison off
+# rather than inventing an expectation.
+expected_skill_name() {
+  local path="$1" dir
+  dir="$(dirname "$path")"
+  case "$dir" in
+    */skills/*) echo "${dir##*/skills/}" ;;
+    *) echo "" ;;
+  esac
+}
+
+# `read -d ''` hits EOF without ever seeing its delimiter and so returns 1 even
+# though LINT_AWK is assigned in full. That is fine here only because this
+# script runs without `set -e`; do not add it without changing this line.
+read -r -d '' LINT_AWK <<'AWK_END'
+# One pass per file. Emits findings as SEVERITY<TAB>line<TAB>check<TAB>message
+# on stdout; the shell wrapper formats and tallies them.
+
+function normalize(s,   t) {
+  t = tolower(s)
+  gsub(/[`*_]/, "", t)
+  gsub(/^[ \t]+/, "", t)
+  gsub(/[ \t]+$/, "", t)
+  gsub(/[ \t]+/, " ", t)
+  return t
+}
+function finding(sev, line, check, msg) {
+  printf "%s\t%d\t%s\t%s\n", sev, line, check, msg
+}
+function err(line, check, msg)  { finding("ERROR", line, check, msg) }
+function warn(line, check, msg) { finding("WARN",  line, check, msg) }
+
+function indent_of(s,   t) {
+  t = s
+  sub(/[^ \t].*$/, "", t)
+  gsub(/\t/, "    ", t)
+  return length(t)
+}
+function is_list_marker(s) {
+  return (s ~ /^[ \t]*([-*+]|[0-9]+[.)])[ \t]+/)
+}
+# Word-boundary containment: index() would match "modes" inside "submodes".
+function phrase_at(hay, needle, pos,   before, after) {
+  before = (pos > 1) ? substr(hay, pos - 1, 1) : " "
+  after  = substr(hay, pos + length(needle), 1)
+  if (after == "") after = " "
+  return (before !~ /[A-Za-z0-9]/ && after !~ /[A-Za-z0-9]/)
+}
+
+{ n++; raw[n] = $0 }
+
+END {
+  # ---- build the three views ---------------------------------------------
+  # raw[]   verbatim, for conflict markers
+  # text[]  fences + frontmatter blanked, inline code KEPT   (checks 3, 4)
+  # prose[] text[] with inline code spans blanked too        (check 2)
+  fm_end = 0
+  if (n >= 1 && raw[1] ~ /^---[ \t\r]*$/) {
+    for (i = 2; i <= n; i++)
+      if (raw[i] ~ /^---[ \t\r]*$/) { fm_end = i; break }
+  }
+
+  fence = 0
+  for (i = 1; i <= n; i++) {
+    line = raw[i]
+    sub(/\r$/, "", line)
+
+    if (line ~ /^[ \t]*(```|~~~)/) {
+      infence[i] = 1          # the delimiter itself is never prose
+      fence = !fence
+      text[i] = ""; prose[i] = ""
+      continue
+    }
+    infence[i] = fence
+    if (fence || (fm_end > 0 && i <= fm_end)) { text[i] = ""; prose[i] = ""; continue }
+
+    text[i] = line
+    p = line
+    gsub(/`[^`]*`/, " ", p)
+    prose[i] = p
+
+    if (line ~ /^#{1,6}[ \t]+/) {
+      h = line
+      sub(/^#+[ \t]+/, "", h)
+      sub(/[ \t]+#+[ \t]*$/, "", h)
+      nh++
+      hline[nh] = i
+      htext[nh] = normalize(h)
+    }
+  }
+
+  # ---- 1. unresolved conflict markers (ERROR) -----------------------------
+  open_conflict = 0
+  for (i = 1; i <= n; i++) {
+    if (infence[i]) continue
+    if (raw[i] ~ /^<<<<<<<([ \t]|$)/) {
+      err(i, "conflict-marker", "unresolved merge conflict marker <<<<<<<")
+      open_conflict = 1
+    } else if (raw[i] ~ /^>>>>>>>([ \t]|$)/) {
+      err(i, "conflict-marker", "unresolved merge conflict marker >>>>>>>")
+      open_conflict = 0
+    } else if (open_conflict && raw[i] ~ /^=======[ \t]*$/) {
+      # Only inside an open conflict: a bare row of = is also a setext H2
+      # underline, and flagging those would be a false positive on real prose.
+      err(i, "conflict-marker", "unresolved merge conflict marker =======")
+    } else if (open_conflict && raw[i] ~ /^\|\|\|\|\|\|\|([ \t]|$)/) {
+      err(i, "conflict-marker", "unresolved merge conflict marker ||||||| (diff3 base)")
+    }
+  }
+
+  # ---- 2. unfilled template tokens / leftover scaffolding (ERROR) ---------
+  for (i = 1; i <= n; i++) {
+    if (prose[i] == "") continue
+    if (match(prose[i], /\{\{[A-Za-z0-9_.-]+\}\}/))
+      err(i, "template-token", "unfilled template token " substr(prose[i], RSTART, RLENGTH))
+    if (prose[i] ~ /<!--[ \t]*\/?(REPEAT|OPTIONAL):/)
+      err(i, "template-scaffold", "template scaffolding comment left in output (REPEAT:/OPTIONAL:)")
+  }
+
+  # ---- 3a. reference direction (WARN) -------------------------------------
+  # For every heading, find prose that names it verbatim and then says
+  # above/below within the same clause. Only a disagreeing direction is
+  # reported — a correct forward reference is the overwhelmingly common case
+  # and saying so would drown the real ones.
+  for (i = 1; i <= n; i++) {
+    if (text[i] == "") continue
+    lp = normalize(text[i])
+    for (j = 1; j <= nh; j++) {
+      if (hline[j] == i) continue
+      if (length(htext[j]) < 4) continue
+      pos = index(lp, htext[j])
+      if (pos == 0) continue
+      if (!phrase_at(lp, htext[j], pos)) continue
+      tail = substr(lp, pos + length(htext[j]), 40)
+      # The direction word has to follow the name directly — at most one
+      # structural noun and a comma in between. Anything looser binds a stray
+      # "below" to whatever heading-shaped word happened to appear earlier in
+      # the sentence: "runs in two modes — the workflow below covers both"
+      # is about the workflow, not about the `## Modes` heading.
+      if (!match(tail, /^[ \t]*((sub-?)?section|table|list|rule|step|block|note|heading)?[ \t]*,?[ \t]*(above|below)([^a-z]|$)/)) continue
+      # Read the direction off the matched prefix, not off `tail` — a later
+      # "above" further down the line must not overrule the "below" that
+      # actually binds to this name.
+      said = (substr(tail, RSTART, RLENGTH) ~ /above/) ? "above" : "below"
+      actual = (hline[j] < i) ? "above" : "below"
+      if (said != actual)
+        warn(i, "ref-direction", "says \"" htext[j] "\" " said ", but that heading is " actual " (line " hline[j] ")")
+    }
+  }
+
+  # ---- 3b. dangling delimited reference (WARN) ----------------------------
+  # A quoted or bolded name reads as a title, so `"X" below` alone is enough to
+  # claim it points at a section. A BACKTICKED name is a code identifier, and
+  # prose about identifiers routinely says "…the caveat `KIRO_HOME` below
+  # carries" while pointing at a bullet, not a heading — so backticks need an
+  # explicit structural noun ("`X` section below") before this fires.
+  for (i = 1; i <= n; i++) {
+    if (text[i] == "") continue
+    s = text[i]
+    while (match(s, /("[^"]+"|`[^`]+`|\*\*[^*]+\*\*)[ \t]*((sub-?)?section|table|heading|chapter)?[ \t]*,?[ \t]*(above|below)([^A-Za-z]|$)/)) {
+      m = substr(s, RSTART, RLENGTH)
+      s = substr(s, RSTART + RLENGTH)
+      if (m ~ /^`/ && m !~ /((sub-?)?section|table|heading|chapter)/) continue
+      name = m
+      sub(/[ \t]*((sub-?)?section|table|heading|chapter)?[ \t]*,?[ \t]*(above|below)([^A-Za-z]|$)$/, "", name)
+      gsub(/^[`"*]+/, "", name); gsub(/[`"*]+$/, "", name)
+      name = normalize(name)
+      if (name == "") continue
+      found = 0
+      for (j = 1; j <= nh; j++)
+        if (htext[j] == name) { found = 1; break }
+      if (!found)
+        warn(i, "ref-dangling", "reference to \"" name "\" " (m ~ /above([^A-Za-z]|$)$/ ? "above" : "below") " names no heading in this file")
+    }
+  }
+
+  # ---- 4. announced count vs list length (WARN) ---------------------------
+  split("two three four five six seven eight nine ten", words, " ")
+  for (w = 1; w <= 9; w++) numword[words[w]] = w + 1
+
+  for (i = 1; i <= n; i++) {
+    if (text[i] == "" || text[i] !~ /:[ \t]*$/) continue
+    want = 0; wantword = ""
+    # Only the announcing sentence counts — the last one before the colon. A
+    # count word stranded in an earlier sentence is describing something else:
+    # "Unlike the other six axes … Price the gap instead, using the menu
+    # below:" introduces three items and announces none of them. Sentence
+    # breaks only: splitting on an em dash too would lose the common
+    # "**Two flavors** — pick one:" shape, which does announce its list.
+    lp = tolower(text[i])
+    if (match(lp, /^.*(\. |; )/)) lp = substr(lp, RSTART + RLENGTH)
+    for (w = 1; w <= 9; w++) {
+      # Not hyphenated ("three-tier" is an adjective, not a count) and not
+      # inside a longer word.
+      if (match(lp, "(^|[^a-z-])" words[w] "([^a-z-]|$)")) {
+        if (want == 0 || RSTART < firstpos) { want = numword[words[w]]; wantword = words[w]; firstpos = RSTART }
+      }
+    }
+    if (want == 0) continue
+
+    j = i + 1
+    while (j <= n && raw[j] ~ /^[ \t]*$/) j++
+    if (j > n || infence[j] || !is_list_marker(raw[j])) continue
+
+    base = indent_of(raw[j])
+    got = 1
+    blanks = 0
+    for (k = j + 1; k <= n; k++) {
+      if (raw[k] ~ /^[ \t]*$/) { blanks++; if (blanks >= 2) break; continue }
+      ind = indent_of(raw[k])
+      if (ind > base) { blanks = 0; continue }           # continuation or nested
+      if (ind == base && is_list_marker(raw[k])) { got++; blanks = 0; continue }
+      break
+    }
+    if (got != want)
+      warn(i, "list-count", "lead-in announces \"" wantword "\" (" want ") but " got " list item" (got == 1 ? "" : "s") " follow")
+  }
+
+  # ---- 5. frontmatter sanity (WARN, SKILL.md only) ------------------------
+  if (is_skill_md) {
+    if (fm_end == 0) {
+      warn(1, "frontmatter", "SKILL.md has no YAML frontmatter block")
+    } else {
+      gotname = ""; namelines = 0; desc_line = 0; desc_value = ""
+      for (i = 2; i < fm_end; i++) {
+        if (raw[i] ~ /^name:[ \t]*/) {
+          gotname = raw[i]; sub(/^name:[ \t]*/, "", gotname)
+          gsub(/^["']|["'][ \t\r]*$/, "", gotname)
+          gsub(/[ \t\r]+$/, "", gotname)
+          namelines++
+        }
+        if (raw[i] ~ /^description:[ \t]*/) {
+          desc_line = i
+          desc_value = raw[i]; sub(/^description:[ \t]*/, "", desc_value)
+          gsub(/^["']|["'][ \t\r]*$/, "", desc_value)
+          gsub(/^[ \t\r]+|[ \t\r]+$/, "", desc_value)
+        }
+      }
+      if (namelines == 0)
+        warn(1, "frontmatter", "frontmatter has no name: key")
+      else if (expected_name != "" && gotname != expected_name)
+        warn(1, "frontmatter", "name: is \"" gotname "\" but the directory says \"" expected_name "\"")
+
+      if (desc_line == 0) {
+        warn(1, "frontmatter", "frontmatter has no description: key")
+      } else if (desc_value == "" || desc_value == ">" || desc_value == "|" || desc_value == ">-" || desc_value == "|-") {
+        # A folded/literal scalar is empty only when no indented body follows
+        # it before the closing ---.
+        body = 0
+        for (i = desc_line + 1; i < fm_end; i++) {
+          if (raw[i] ~ /^[ \t]*$/) continue
+          if (raw[i] ~ /^[ \t]+[^ \t]/) { body = 1 }
+          break
+        }
+        if (!body) warn(desc_line, "frontmatter", "description: is empty")
+      }
+    }
+  }
+}
+AWK_END
+
+RED=""; YELLOW=""; BOLD=""; RESET=""
+if [[ -t 1 ]]; then RED=$'\033[31m'; YELLOW=$'\033[33m'; BOLD=$'\033[1m'; RESET=$'\033[0m'; fi
+
+errors=0
+warnings=0
+for f in "${FILES[@]}"; do
+  if [[ ! -f "$f" ]]; then
+    echo "skill-lint: no such file: $f" >&2
+    errors=$((errors + 1))
+    continue
+  fi
+  is_skill_md=0
+  expected=""
+  if [[ "$(basename "$f")" == "SKILL.md" ]]; then
+    is_skill_md=1
+    expected="$(expected_skill_name "$f")"
+  fi
+  while IFS=$'\t' read -r sev line check msg; do
+    [[ -z "$sev" ]] && continue
+    if [[ "$sev" == "ERROR" ]]; then
+      errors=$((errors + 1))
+      printf '%s%s:%s:%s %s [%s]\n' "$RED" "$f" "$line" "$RESET" "$msg" "$check"
+    else
+      warnings=$((warnings + 1))
+      printf '%s%s:%s:%s %s [%s]\n' "$YELLOW" "$f" "$line" "$RESET" "$msg" "$check"
+    fi
+  done < <(awk -v is_skill_md="$is_skill_md" -v expected_name="$expected" "$LINT_AWK" "$f")
+done
+
+printf '\n%sskill-lint:%s %d file(s), %d error(s), %d warning(s)\n' \
+  "$BOLD" "$RESET" "${#FILES[@]}" "$errors" "$warnings"
+
+if [[ "$errors" -gt 0 ]]; then
+  exit 1
+fi
+if [[ "$STRICT" == 1 && "$warnings" -gt 0 ]]; then
+  echo "skill-lint: --strict — warnings are failures" >&2
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem

`.claude/skills/**/*.md` had **zero mechanical coverage**. These files are
executable instructions — they decide how agents triage, plan, implement and
review — but no gate read them. On PR #1204, a change touching only two skill
files, `tools/preflight.sh --changed` skipped all ten gates and all thirteen PR
checks went green having proved nothing about the only files that changed.

## What this adds

`tools/skill-lint.sh` — five checks, tiered by how certain they are:

| Check | Severity | Catches |
|---|---|---|
| `conflict-marker` | **ERROR** | unresolved `<<<<<<<` / `=======` / `>>>>>>>` / `\|\|\|\|\|\|\|` |
| `template-token` / `template-scaffold` | **ERROR** | `{{TOKEN}}` left unfilled; `<!-- REPEAT:x -->` / `<!-- OPTIONAL:x -->` left in a rendered artifact |
| `ref-direction` / `ref-dangling` | warn | `"X" above` where heading X is below (the ordering defect in the issue); a delimited reference naming no heading |
| `list-count` | warn | `Three moves:` followed by a list of four |
| `frontmatter` | warn | a `SKILL.md` whose `name:` disagrees with its directory; an empty `description:` |

Checks 1–2 fail the gate. 3–5 are heuristics with a real false-positive rate and
only warn; `tools/skill-lint.sh --strict` promotes them, which is the path to
hardening one once its noise floor is known.

### The design constraint that shapes it

Markdown that *documents* a marker is not markdown that *has* one.
`.claude/skills/ir:exec/SKILL.md` mentions `{{TOKEN}}`, `REPEAT:step` and
`OPTIONAL:ui` a dozen times — always inside backticks. A linter reading raw
bytes hard-fails this repo on day one. So checks 2 and 4 read a prose view with
fenced blocks, inline code spans and YAML frontmatter blanked; check 3 keeps
inline code (a reference can legitimately be written `` `Auto mode` below ``);
check 1 reads raw lines outside fences, because a conflict marker inside a fence
is illustrative and anywhere else is a corrupted file.

### Wiring

- **`tools/preflight.sh`** — a new `skills` group and a `skill-file lint` gate,
  scoped to `^\.claude/skills/.*\.md$|^tools/skill-lint\.sh$` (editing a check
  re-lints the corpus it governs). `--only skills` works like the other groups.
- **`.github/workflows/test.yml`** — a "Lint skill files" step. The issue's
  Scope section named only the script + preflight + AGENTS.md, but its *title*
  says "No **CI** gate reads…", and the pre-push hook is one `--no-verify` away
  from never running — the same argument the "Test the shared shell libs" step
  already makes for `tools/lib`. Deliberately unscoped: the run is a fraction of
  a second, and scoping is what let the gap exist in the first place.
- **`AGENTS.md`** — a Testing row and the `--only skills` line.

## Verification

**Calibration against the real corpus.** The first run over the 22 real skill
files produced 3 warnings — all three inspected, all three false positives
(e.g. ``` `KIRO_HOME` below ``` at `monitoring-surface.md:261` really does point
below, at line 307 — it names a bullet, not a heading). Each was fixed by
narrowing the rule, not by suppressing the file:

- `ref-direction`: the direction word must follow the name directly (at most one
  structural noun), so `runs in two modes — the workflow below covers both`
  no longer binds "below" to the `## Modes` heading.
- `ref-dangling`: a **backticked** name is a code identifier and needs an
  explicit `section`/`table`/`heading` noun; quoted and bolded names read as
  titles and don't.
- `list-count`: only the announcing *sentence* before the colon is searched, so
  "Unlike the other **six** axes … using the menu below:" over three items is
  no longer a count mismatch.

The corpus now lints `22 file(s), 0 error(s), 0 warning(s)`.

**Each check seen firing**, against `tools/lib/testdata/skill-lint/skills/`
(one deliberately broken file per check, plus clean files):

```
conflict    3 errors  (<<<<<<< / ======= / >>>>>>>)          exit 1
template    5 errors  ({{TLDR}} + 4 REPEAT:/OPTIONAL: lines) exit 1
refs        2 warns   (ref-direction, ref-dangling)          exit 0
listcount   1 warn    (announces "three" (3) but 4 follow)   exit 0
wrongname   1 warn    (name: vs directory)                   exit 0
nodesc      1 warn    (empty folded description:)            exit 0
good        0         parent/child 0        reference-doc 0
```

`good/SKILL.md` is the load-bearing negative: it documents `{{TOKEN}}`,
`REPEAT:step` and `OPTIONAL:ui` in backticks, shows a conflict marker inside a
fence, makes a correct above/below reference, and announces a count that matches
its list once nested items are excluded.

**The issue's acceptance criterion** — a `--changed` run on a *skill-file-only*
diff must report PASS/FAIL, not SKIP. Reproduced in a throwaway clone whose
`origin/main` was pointed at this branch, with one skill `.md` edited:

```
  gofmt                                                      PASS
  core module tests                                          SKIP
  onboarding-factory tests                                   SKIP
  replaydata validate                                        SKIP
  recording-rig smoke test                                   SKIP
  starhistory tests                                          SKIP
  web: platforms/web                                         SKIP
  web: onboarding-factory viewer                             SKIP
  ARS architecture gate                                      SKIP
  tools/lib shell-lib tests                                  SKIP
  skill-file lint                                            PASS      <-- was absent
  security scan (govulncheck + gosec + npm audit)            SKIP
```

Same run with a conflict marker appended to `ir:triage/SKILL.md`:
`skill-file lint  FAIL`, naming all three marker lines.

**Suites.** `tools/preflight.sh --changed` on this branch: `gofmt` PASS,
`tools/lib shell-lib tests` PASS (which runs the new
`tools/lib/skill-lint_test.sh`, 27 assertions, all pass), `skill-file lint`
PASS, everything else correctly SKIP — the diff contains no Go, no web tree,
no replaydata. `test.yml` parses; its step list ends with "Lint skill files".

## Known limits (documented in the script header, not oversights)

- `list-count` counts list markers. The `ir:triage` defect that motivated it —
  "Two flavors:" followed by three, the third orphaned *outside* the list — has
  two markers and passes. Counting what a reader would call an item is a
  judgement call; counting markers is not.
- `ref-*` only recognises a reference when the name is delimited or matches a
  heading verbatim. "see the rule above" names nothing checkable.
- Setext headings aren't indexed; every heading in this repo's skill files is ATX.

Closes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)
