### PR TITLE
fix(fswatcher): reconcile sweep so a dropped kqueue event can't hide a session

### DIFF
--- a/core/adapters/inbound/agents/fswatcher/reconcile_test.go
+++ b/core/adapters/inbound/agents/fswatcher/reconcile_test.go
@@ -1,0 +1,465 @@
+package fswatcher
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	"irrlicht/core/domain/agent"
+)
+
+// newFsnotify returns a real fsnotify watcher for the direct reconcile tests,
+// closed when the test ends. reconcile only uses it to arm directories.
+func newFsnotify(t *testing.T) *fsnotify.Watcher {
+	t.Helper()
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fsw.Close() })
+	return fsw
+}
+
+// writeTranscript writes content to path, failing the test on error.
+func writeTranscript(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// mkdir creates dir and any parents, failing the test on error, and returns it.
+func mkdir(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// expectEvent asserts the next event on ch has the wanted type and session ID.
+func expectEvent(t *testing.T, ch <-chan agent.Event, want agent.EventType, sessionID string) agent.Event {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		if ev.Type != want {
+			t.Errorf("event type = %q, want %q", ev.Type, want)
+		}
+		if ev.SessionID != sessionID {
+			t.Errorf("session ID = %q, want %q", ev.SessionID, sessionID)
+		}
+		return ev
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %q event for %q", want, sessionID)
+		return agent.Event{}
+	}
+}
+
+// expectNoEvent asserts nothing arrives on ch within d. A negative assertion
+// needs some bound; d is kept short because every path that would emit here is
+// synchronous with the call under test.
+func expectNoEvent(t *testing.T, ch <-chan agent.Event, d time.Duration) {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		t.Fatalf("unexpected %q event for %q", ev.Type, ev.TranscriptPath)
+	case <-time.After(d):
+	}
+}
+
+func TestEffectiveReconcileInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		set  time.Duration
+		want time.Duration
+	}{
+		{"zero uses the default", 0, defaultReconcileInterval},
+		{"negative disables the sweep", -1, 0},
+		{"positive is honored", 250 * time.Millisecond, 250 * time.Millisecond},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := NewWithRoot("/tmp/fake", testAdapter, 0).WithReconcileInterval(tc.set)
+			if got := w.effectiveReconcileInterval(); got != tc.want {
+				t.Errorf("effectiveReconcileInterval() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A transcript file that fsnotify never reported is surfaced by the sweep —
+// the dropped-notification failure mode behind issue #1248, where the symptom
+// is an event that never arrives rather than one that arrives late.
+func TestReconcile_EmitsNewSessionForFileFsnotifyMissed(t *testing.T) {
+	root := setupFakeProjects(t)
+	w := NewWithRoot(root, testAdapter, 0)
+	ch := w.Subscribe()
+
+	path := filepath.Join(root, "-Users-test-myproject", "ghost.jsonl")
+	writeTranscript(t, path, `{"type":"init"}`+"\n")
+
+	// No fsnotify event is ever delivered for ghost.jsonl: the sweep is the
+	// only thing that can find it.
+	w.reconcile(context.Background(), newFsnotify(t))
+
+	ev := expectEvent(t, ch, agent.EventNewSession, "ghost")
+	if ev.ProjectDir != "-Users-test-myproject" {
+		t.Errorf("project dir = %q, want %q", ev.ProjectDir, "-Users-test-myproject")
+	}
+	if ev.Size == 0 {
+		t.Error("size = 0, want the file's actual size")
+	}
+}
+
+// The sweep must be silent when fsnotify is doing its job, or every interval
+// would replay the whole tree as new sessions.
+func TestReconcile_DoesNotReEmitWhatWasAlreadyReported(t *testing.T) {
+	root := setupFakeProjects(t)
+	w := NewWithRoot(root, testAdapter, 0)
+	ch := w.Subscribe()
+	fsw := newFsnotify(t)
+
+	path := filepath.Join(root, "-Users-test-myproject", "abc-123.jsonl")
+	writeTranscript(t, path, `{"type":"init"}`+"\n")
+
+	w.reconcile(context.Background(), fsw)
+	expectEvent(t, ch, agent.EventNewSession, "abc-123")
+
+	// Nothing changed on disk, so two further sweeps must emit nothing.
+	w.reconcile(context.Background(), fsw)
+	w.reconcile(context.Background(), fsw)
+	expectNoEvent(t, ch, 100*time.Millisecond)
+}
+
+// A write fsnotify missed shows up as activity, not as a second new session.
+func TestReconcile_EmitsActivityWhenFileGrewUnobserved(t *testing.T) {
+	root := setupFakeProjects(t)
+	w := NewWithRoot(root, testAdapter, 0)
+	ch := w.Subscribe()
+	fsw := newFsnotify(t)
+
+	path := filepath.Join(root, "-Users-test-myproject", "abc-123.jsonl")
+	writeTranscript(t, path, `{"type":"init"}`+"\n")
+	w.reconcile(context.Background(), fsw)
+	expectEvent(t, ch, agent.EventNewSession, "abc-123")
+
+	writeTranscript(t, path, `{"type":"init"}`+"\n"+`{"type":"user"}`+"\n")
+	w.reconcile(context.Background(), fsw)
+	expectEvent(t, ch, agent.EventActivity, "abc-123")
+}
+
+// A file the normal event path already emitted must not be re-reported by the
+// following sweep — the guard against duplicate events in the healthy case.
+func TestReconcile_SilentAfterNormalEventPathEmitted(t *testing.T) {
+	root := setupFakeProjects(t)
+	w := NewWithRoot(root, testAdapter, 0)
+	ch := w.Subscribe()
+	fsw := newFsnotify(t)
+
+	path := filepath.Join(root, "-Users-test-myproject", "abc-123.jsonl")
+	writeTranscript(t, path, `{"type":"init"}`+"\n")
+	// Drive the ordinary create path, as Watch's select loop would.
+	w.handleEvent(fsw, fsnotify.Event{Name: path, Op: fsnotify.Create})
+	expectEvent(t, ch, agent.EventNewSession, "abc-123")
+
+	w.reconcile(context.Background(), fsw)
+	expectNoEvent(t, ch, 100*time.Millisecond)
+}
+
+// A recreated path is a new session again, not activity on the old one.
+func TestReconcile_RecreatedFileIsANewSessionAgain(t *testing.T) {
+	root := setupFakeProjects(t)
+	w := NewWithRoot(root, testAdapter, 0)
+	ch := w.Subscribe()
+	fsw := newFsnotify(t)
+
+	path := filepath.Join(root, "-Users-test-myproject", "abc-123.jsonl")
+	writeTranscript(t, path, `{"a":1}`+"\n")
+	w.reconcile(context.Background(), fsw)
+	expectEvent(t, ch, agent.EventNewSession, "abc-123")
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	w.handleEvent(fsw, fsnotify.Event{Name: path, Op: fsnotify.Remove})
+	expectEvent(t, ch, agent.EventRemoved, "abc-123")
+
+	writeTranscript(t, path, `{"a":1}`+"\n")
+	w.reconcile(context.Background(), fsw)
+	expectEvent(t, ch, agent.EventNewSession, "abc-123")
+}
+
+// For header-linked adapters the sweep defers a zero-byte file exactly like a
+// zero-byte Create does, so a child never surfaces before its parent link is
+// readable.
+func TestReconcile_DefersZeroByteFileForHeaderLinkedAdapter(t *testing.T) {
+	root := setupFakeProjects(t)
+	w := NewWithRoot(root, testAdapter, 0).WithParentSessionID(func(path string) string {
+		data, err := os.ReadFile(path)
+		if err != nil || len(data) == 0 {
+			return ""
+		}
+		return strings.TrimSuffix(string(data), "\n")
+	})
+	ch := w.Subscribe()
+	fsw := newFsnotify(t)
+
+	path := filepath.Join(root, "-Users-test-myproject", "child.jsonl")
+	writeTranscript(t, path, "")
+	w.reconcile(context.Background(), fsw)
+	expectNoEvent(t, ch, 100*time.Millisecond)
+
+	writeTranscript(t, path, "parent-thread\n")
+	w.reconcile(context.Background(), fsw)
+	ev := expectEvent(t, ch, agent.EventNewSession, "child")
+	if ev.ParentSessionID != "parent-thread" {
+		t.Errorf("ParentSessionID = %q, want %q", ev.ParentSessionID, "parent-thread")
+	}
+}
+
+// The sweep honors the same staleness cutoff as the normal event path.
+func TestReconcile_SkipsStaleFile(t *testing.T) {
+	root := setupFakeProjects(t)
+	w := NewWithRoot(root, testAdapter, 1*time.Hour)
+	ch := w.Subscribe()
+
+	path := filepath.Join(root, "-Users-test-myproject", "old.jsonl")
+	writeTranscript(t, path, `{"a":1}`+"\n")
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	w.reconcile(context.Background(), newFsnotify(t))
+	expectNoEvent(t, ch, 100*time.Millisecond)
+}
+
+// A custom session-ID extractor returning "" still means "skip this file".
+func TestReconcile_SkipsFileWithoutSessionID(t *testing.T) {
+	root := setupFakeProjects(t)
+	w := NewWithRoot(root, testAdapter, 0).WithSessionID(func(string) string { return "" })
+	ch := w.Subscribe()
+
+	path := filepath.Join(root, "-Users-test-myproject", "ignored.jsonl")
+	writeTranscript(t, path, `{"a":1}`+"\n")
+
+	w.reconcile(context.Background(), newFsnotify(t))
+	expectNoEvent(t, ch, 100*time.Millisecond)
+}
+
+// Adapters with a flat layout keep transcripts directly under the root with no
+// project directory at all (kiro-cli: sessions/cli/<uuid>.jsonl). Walking only
+// the subdirectories would make the sweep inert for them — the fix would ship
+// while doing nothing for that adapter.
+func TestReconcile_EmitsForFlatLayoutFileDirectlyUnderRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "cli")
+	mkdir(t, root)
+	w := NewWithRoot(root, testAdapter, 0)
+	ch := w.Subscribe()
+
+	writeTranscript(t, filepath.Join(root, "flat-session.jsonl"), `{"a":1}`+"\n")
+
+	w.reconcile(context.Background(), newFsnotify(t))
+	expectEvent(t, ch, agent.EventNewSession, "flat-session")
+}
+
+// The startup scan has to cover the flat layout too, not just the sweep.
+// Ready() promises "every pre-existing transcript file has already been
+// emitted"; walking only subdirectories made that false for kiro-cli, whose
+// whole backlog sits directly under the root — its sessions were invisible
+// after a daemon restart until something wrote to them. The sweep is disabled
+// here so this measures the startup scan alone.
+func TestWatch_StartupScanEmitsFlatLayoutBacklog(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "cli")
+	mkdir(t, root)
+	writeTranscript(t, filepath.Join(root, "pre-existing.jsonl"), `{"a":1}`+"\n")
+
+	w := NewWithRoot(root, testAdapter, 0).WithReconcileInterval(-1)
+	ch := w.Subscribe()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = w.Watch(ctx) }()
+
+	select {
+	case <-w.Ready():
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not signal Ready")
+	}
+	expectEvent(t, ch, agent.EventNewSession, "pre-existing")
+}
+
+// The dedup has to work in both directions. fsnotify's event channel is
+// unbuffered, so a Create can sit blocked in the producer while a sweep walks
+// the same file and reports it, and only then be delivered to the ordinary
+// create path — which would emit a second new-session event for one file.
+func TestReconcile_ThenFsnotifyCreateDoesNotDuplicateNewSession(t *testing.T) {
+	root := setupFakeProjects(t)
+	w := NewWithRoot(root, testAdapter, 0)
+	ch := w.Subscribe()
+	fsw := newFsnotify(t)
+
+	path := filepath.Join(root, "-Users-test-myproject", "abc-123.jsonl")
+	writeTranscript(t, path, `{"type":"init"}`+"\n")
+
+	// Sweep reports it first...
+	w.reconcile(context.Background(), fsw)
+	expectEvent(t, ch, agent.EventNewSession, "abc-123")
+
+	// ...then the create event that was blocked in the producer arrives.
+	w.handleEvent(fsw, fsnotify.Event{Name: path, Op: fsnotify.Create})
+	expectNoEvent(t, ch, 100*time.Millisecond)
+}
+
+// A directory deleted and recreated at the same path must be armed again.
+// fsnotify drops the watch when the directory goes away, so a watcher that
+// still believes it is watched would leave that whole subtree event-blind.
+func TestHandleEvent_RemovedDirIsRearmedWhenRecreated(t *testing.T) {
+	root := setupFakeProjects(t)
+	w := NewWithRoot(root, testAdapter, 0)
+	w.Subscribe()
+	fsw := newFsnotify(t)
+
+	proj := filepath.Join(root, "-Users-test-myproject")
+	w.addWatch(fsw, proj)
+	if _, armed := w.watched[proj]; !armed {
+		t.Fatal("precondition: directory should be armed")
+	}
+
+	// The directory goes away; fsnotify reports it and drops its own watch.
+	if err := os.RemoveAll(proj); err != nil {
+		t.Fatal(err)
+	}
+	w.handleEvent(fsw, fsnotify.Event{Name: proj, Op: fsnotify.Remove})
+	if _, armed := w.watched[proj]; armed {
+		t.Fatal("a removed directory must not stay recorded as watched, or it is never re-armed")
+	}
+
+	// Recreated at the same path: addWatch must actually attempt the
+	// registration again instead of short-circuiting on a stale entry.
+	//
+	// The retry goes through a fresh fsnotify watcher deliberately. Re-adding
+	// the path through the same one races with that watcher's own teardown of
+	// the deleted directory's file descriptor and intermittently returns
+	// EBADF — observed 1 run in ~150. Production already copes, because a
+	// rejected registration is not recorded and the next sweep retries it;
+	// asserting on a single immediate attempt would just make this test flaky,
+	// which is the opposite of the point of this PR.
+	mkdir(t, proj)
+	w.addWatch(newFsnotify(t), proj)
+	if _, armed := w.watched[proj]; !armed {
+		t.Error("a recreated directory should be armed again")
+	}
+}
+
+// A directory the sweep already armed is not re-registered on the next sweep,
+// and one that is still rejected is reported once rather than once per sweep —
+// otherwise #1255's log line would repeat every interval forever.
+func TestAddWatch_RetriesRejectedDirWithoutRepeatingTheLog(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses the directory permissions this test relies on")
+	}
+	root := setupFakeProjects(t)
+	log := &recordingLogger{}
+	w := NewWithRoot(root, testAdapter, 0).WithLogger(log)
+	ch := w.Subscribe()
+	fsw := newFsnotify(t)
+
+	blind := filepath.Join(root, "-Users-test-blind")
+	mkdir(t, blind)
+	if err := os.Chmod(blind, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(blind, 0755) })
+
+	// Three sweeps over a directory that keeps failing: one report, not three.
+	for i := 0; i < 3; i++ {
+		w.reconcile(context.Background(), fsw)
+	}
+	if got := log.matching(blind); len(got) != 1 {
+		t.Fatalf("logged %d errors naming %q across 3 sweeps, want 1 (all: %v)", len(got), blind, got)
+	}
+	if _, armed := w.watched[blind]; armed {
+		t.Error("a rejected directory must not be recorded as watched, or it is never retried")
+	}
+
+	// Once the condition clears, the retry arms it and its contents surface —
+	// the blind spot closes without a restart.
+	if err := os.Chmod(blind, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeTranscript(t, filepath.Join(blind, "late.jsonl"), `{"a":1}`+"\n")
+	w.reconcile(context.Background(), fsw)
+	expectEvent(t, ch, agent.EventNewSession, "late")
+	if _, armed := w.watched[blind]; !armed {
+		t.Error("a recovered directory should be recorded as watched")
+	}
+}
+
+// End-to-end through Watch, with a genuinely unobservable file.
+//
+// A directory whose watch registration failed is one fsnotify structurally
+// cannot report on: no event for anything created inside it will ever be
+// delivered. That is the same observable situation as a dropped kqueue
+// notification, and unlike a real drop it can be produced on demand — which is
+// what makes this the deterministic stand-in for issue #1248's failure mode.
+//
+// The disabled-sweep subtest is the control: it pins that the file really is
+// invisible to fsnotify, so the recovered case is evidence about the sweep
+// rather than about fsnotify quietly delivering the event anyway.
+func TestWatch_ReconcileRecoversFileUnderAnUnwatchableDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses the directory permissions this test relies on")
+	}
+
+	run := func(t *testing.T, interval time.Duration) <-chan agent.Event {
+		t.Helper()
+		root := setupFakeProjects(t)
+		blind := filepath.Join(root, "-Users-test-blind")
+		mkdir(t, blind)
+		// Unreadable at Watch time, so the watch registration for it fails and
+		// the directory is never armed.
+		if err := os.Chmod(blind, 0000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(blind, 0755) })
+
+		w := NewWithRoot(root, testAdapter, 0).WithReconcileInterval(interval)
+		ch := w.Subscribe()
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		go func() { _ = w.Watch(ctx) }()
+
+		select {
+		case <-w.Ready():
+		case <-time.After(2 * time.Second):
+			t.Fatal("watcher did not signal Ready")
+		}
+
+		// Now make it readable and drop a transcript in. The root watch cannot
+		// see this: creating a file inside blind/ does not change root's own
+		// directory entries.
+		if err := os.Chmod(blind, 0755); err != nil {
+			t.Fatal(err)
+		}
+		writeTranscript(t, filepath.Join(blind, "unseen.jsonl"), `{"a":1}`+"\n")
+		return ch
+	}
+
+	t.Run("sweep enabled recovers it", func(t *testing.T) {
+		ch := run(t, 50*time.Millisecond)
+		ev := expectEvent(t, ch, agent.EventNewSession, "unseen")
+		if ev.ProjectDir != "-Users-test-blind" {
+			t.Errorf("project dir = %q, want %q", ev.ProjectDir, "-Users-test-blind")
+		}
+	})
+
+	t.Run("sweep disabled leaves it invisible", func(t *testing.T) {
+		ch := run(t, -1)
+		expectNoEvent(t, ch, 500*time.Millisecond)
+	})
+}

--- a/core/adapters/inbound/agents/fswatcher/watcher.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher.go
@@ -25,6 +25,23 @@ import (
 // transcriptExt is the file extension for agent transcript files.
 const transcriptExt = ".jsonl"
 
+// defaultReconcileInterval is how often Watch re-walks the tree to catch
+// anything fsnotify never reported. It bounds the blind spot left by a
+// dropped kernel notification (issue #1248) without turning the watcher into
+// a poller: notifications remain the fast path and this is the safety net.
+//
+// The cost of one sweep is a ReadDir per directory plus a stat per transcript
+// file — every transcript ever written, not just the recent ones, because
+// maxAge is applied after the stat rather than pruning the walk. On a
+// heavily-used machine three of the eight roots alone hold ~794 directories
+// and ~1541 transcripts, of which only ~101 are inside the 5-day window; treat
+// that as a lower bound on the per-sweep cost, not a total. It is cheap enough
+// at this interval, but it scales with total history rather than with active
+// sessions, so pruning the descent (skipping directories whose mtime hasn't
+// moved, and stat-ing only known paths for growth) is the prerequisite for
+// shortening this.
+const defaultReconcileInterval = 15 * time.Second
+
 // Watcher watches a directory tree for .jsonl transcript file events.
 // It implements inbound.Watcher.
 type Watcher struct {
@@ -48,6 +65,31 @@ type Watcher struct {
 	// Deferring them until the first Write lets the adapter read the metadata
 	// header and prevents a child from briefly appearing as a top-level row.
 	pendingNew map[string]struct{}
+
+	// reconcileInterval overrides how often the reconcile sweep runs (see
+	// WithReconcileInterval). Zero means defaultReconcileInterval; negative
+	// disables the sweep.
+	reconcileInterval time.Duration
+	// emitted records the size last broadcast for each transcript path, so the
+	// reconcile sweep can distinguish state fsnotify already reported from
+	// state it missed. Entries are removed when a file is deleted, so a
+	// recreated path is reported as a new session again. It is otherwise
+	// bounded by the number of transcript files this run has reported on —
+	// the same order as the tree the watcher already walks — so it is not
+	// pruned on any other schedule.
+	emitted map[string]int64
+	// watched records directories already registered with fsnotify, so the
+	// reconcile sweep re-arms only the ones that are genuinely new — and
+	// retries any whose earlier Add failed.
+	watched map[string]struct{}
+	// watchFailed records directories whose rejected registration has already
+	// been reported, so the sweep's retry doesn't re-log the same blind spot
+	// every interval.
+	//
+	// pendingNew, emitted, watched and watchFailed are all confined to Watch's
+	// goroutine (handleEvent, the backlog scan and reconcile all run on it), so
+	// none of them take a lock.
+	watchFailed map[string]struct{}
 
 	subMu sync.Mutex
 	subs  []chan agent.Event
@@ -81,7 +123,9 @@ type Watcher struct {
 // then continues and Ready() still fires: one unreadable directory must not
 // strand the whole watcher. What that costs is a blind spot under that one
 // subtree, so addWatch reports every rejection through the Logger set by
-// WithLogger rather than discarding it (#1255).
+// WithLogger rather than discarding it (#1255), and the reconcile sweep
+// retries the registration so the blind spot closes on its own if whatever
+// rejected it clears (#1248).
 func (w *Watcher) Ready() <-chan struct{} { return w.readyChan() }
 
 // readyChan lazily creates the ready channel so the literal constructors
@@ -137,6 +181,17 @@ func (w *Watcher) WithSessionID(fn func(path string) string) *Watcher {
 // the header before the new-session event reaches the session detector.
 func (w *Watcher) WithParentSessionID(fn func(path string) string) *Watcher {
 	w.parentSessionID = fn
+	return w
+}
+
+// WithReconcileInterval overrides how often Watch runs the reconcile sweep
+// that catches transcript files fsnotify never reported. Zero (the default)
+// uses defaultReconcileInterval; a negative value disables the sweep entirely,
+// leaving fsnotify as the only source of events. Returns the watcher for
+// chaining. Tests use it to pull the safety net inside their own deadline;
+// production wiring leaves it at the default.
+func (w *Watcher) WithReconcileInterval(d time.Duration) *Watcher {
+	w.reconcileInterval = d
 	return w
 }
 
@@ -221,6 +276,8 @@ func (w *Watcher) Watch(ctx context.Context) error {
 		return err
 	}
 
+	w.resetRunState()
+
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return err
@@ -259,10 +316,15 @@ func (w *Watcher) Watch(ctx context.Context) error {
 	// waiting on Ready() before mutating files.
 	w.signalReady()
 
+	reconcileC, stopReconcile := w.reconcileTicker()
+	defer stopReconcile()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-reconcileC:
+			w.reconcile(ctx, watcher)
 		case ev, ok := <-watcher.Events:
 			if !w.dispatchEvent(watcher, ev, ok) {
 				return nil
@@ -273,6 +335,53 @@ func (w *Watcher) Watch(ctx context.Context) error {
 			}
 			// Transient errors — continue watching.
 		}
+	}
+}
+
+// resetRunState starts a Watch run's bookkeeping from empty, so a Watcher
+// driven twice doesn't inherit the previous run's view of what was already
+// emitted or already armed. pendingNew is left nil because its write sites
+// allocate it lazily.
+func (w *Watcher) resetRunState() {
+	w.emitted = make(map[string]int64)
+	w.watched = make(map[string]struct{})
+	w.watchFailed = make(map[string]struct{})
+	w.pendingNew = nil
+}
+
+// reconcileTicker returns the channel Watch selects on to run the sweep that
+// periodically re-walks the tree, plus the func to stop it.
+//
+// The sweep exists because fsnotify's macOS kqueue backend discovers new files
+// by diffing a directory listing rather than receiving a per-file
+// notification, so a creation can be missed outright — the failure mode behind
+// issue #1248, where the symptom is an event that never arrives rather than
+// one that arrives late. A dropped notification would otherwise leave that
+// session invisible for the daemon's whole lifetime; this bounds it to one
+// interval.
+//
+// When the sweep is disabled the channel is nil, which parks Watch's reconcile
+// select case forever, and the stop func is a no-op — so the caller needs no
+// conditional of its own.
+func (w *Watcher) reconcileTicker() (<-chan time.Time, func()) {
+	interval := w.effectiveReconcileInterval()
+	if interval <= 0 {
+		return nil, func() {}
+	}
+	ticker := time.NewTicker(interval)
+	return ticker.C, ticker.Stop
+}
+
+// effectiveReconcileInterval resolves the configured sweep interval: zero
+// means the default, negative means disabled (reported as zero).
+func (w *Watcher) effectiveReconcileInterval() time.Duration {
+	switch {
+	case w.reconcileInterval == 0:
+		return defaultReconcileInterval
+	case w.reconcileInterval < 0:
+		return 0
+	default:
+		return w.reconcileInterval
 	}
 }
 
@@ -323,6 +432,16 @@ func (w *Watcher) handleEvent(watcher *fsnotify.Watcher, ev fsnotify.Event) {
 		return
 	}
 
+	if ev.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+		// A path that goes away takes any fsnotify watch on it with it, so
+		// forget it here: otherwise a directory recreated at the same path is
+		// short-circuited by addWatch as already-watched and never re-armed,
+		// leaving that subtree reachable only by the reconcile sweep. A
+		// no-op for transcript files, which are never in these maps.
+		delete(w.watched, name)
+		delete(w.watchFailed, name)
+	}
+
 	// Only process .jsonl files (transcript files).
 	if !strings.HasSuffix(name, transcriptExt) {
 		return
@@ -344,6 +463,9 @@ func (w *Watcher) handleEvent(watcher *fsnotify.Watcher, ev fsnotify.Event) {
 
 	case ev.Op&(fsnotify.Remove|fsnotify.Rename) != 0:
 		delete(w.pendingNew, name)
+		// Forget the emitted size too, so a path that is recreated later is
+		// reported as a new session rather than as activity.
+		delete(w.emitted, name)
 		w.broadcast(w.eventFor(agent.EventRemoved, sessionID, projectDir, name, 0))
 	}
 }
@@ -364,7 +486,7 @@ func (w *Watcher) handleTranscriptCreate(name, sessionID, projectDir string) {
 		w.pendingNew[name] = struct{}{}
 		return
 	}
-	w.broadcast(w.eventFor(agent.EventNewSession, sessionID, projectDir, name, size))
+	w.emit(agent.EventNewSession, sessionID, projectDir, name, size)
 }
 
 // handleTranscriptWrite emits EventActivity for a write to a known transcript,
@@ -377,10 +499,10 @@ func (w *Watcher) handleTranscriptWrite(name, sessionID, projectDir string) {
 	}
 	if _, pending := w.pendingNew[name]; pending {
 		delete(w.pendingNew, name)
-		w.broadcast(w.eventFor(agent.EventNewSession, sessionID, projectDir, name, size))
+		w.emit(agent.EventNewSession, sessionID, projectDir, name, size)
 		return
 	}
-	w.broadcast(w.eventFor(agent.EventActivity, sessionID, projectDir, name, size))
+	w.emit(agent.EventActivity, sessionID, projectDir, name, size)
 }
 
 // handleDirCreate handles a Create event that names a directory: starts
@@ -409,6 +531,29 @@ func (w *Watcher) handleDirCreate(watcher *fsnotify.Watcher, name string) bool {
 // A non-positive maxAge disables the cutoff.
 func (w *Watcher) isStale(mtime time.Time) bool {
 	return w.maxAge > 0 && !mtime.IsZero() && time.Since(mtime) > w.maxAge
+}
+
+// emit records the size being reported for path and broadcasts the event.
+// Every new-session and activity emission goes through here so the reconcile
+// sweep can tell the state fsnotify already reported from the state it missed,
+// and therefore never re-reports a file the normal event path handled.
+// EventRemoved deliberately does not: it deletes the entry instead.
+func (w *Watcher) emit(typ agent.EventType, sessionID, projectDir, path string, size int64) {
+	// The guard is symmetric: the sweep skips what fsnotify already reported,
+	// and this skips what the sweep already reported. Both directions matter,
+	// because fsnotify's event channel is unbuffered — a Create can sit blocked
+	// in the producer while a sweep runs, walks the same file and reports it,
+	// and only then get delivered to the ordinary create path. Restricted to
+	// new-session events: a repeated activity event is absorbed downstream by
+	// the detector's debounce, and suppressing one could hide a real write.
+	if prev, ok := w.emitted[path]; ok && prev == size && typ == agent.EventNewSession {
+		return
+	}
+	if w.emitted == nil {
+		w.emitted = make(map[string]int64)
+	}
+	w.emitted[path] = size
+	w.broadcast(w.eventFor(typ, sessionID, projectDir, path, size))
 }
 
 // broadcast sends an event to all subscribers. Non-blocking: drops if consumer
@@ -522,6 +667,14 @@ func (w *Watcher) addExistingDirs(ctx context.Context, watcher *fsnotify.Watcher
 	if err != nil {
 		return nil // root existence already confirmed by waitForRoot; treat as empty
 	}
+	// Root's own transcript files, before descending. The root is watched but
+	// is never itself a WalkDir start point below, so without this a flat
+	// layout — kiro-cli keeps <uuid>.jsonl directly under sessions/cli with no
+	// project directory — has its entire pre-existing backlog skipped, and
+	// Ready()'s "every pre-existing transcript file has already been emitted"
+	// is false for that adapter. The reconcile sweep applies the same rule on
+	// a timer; this is what makes that a schedule rather than a special case.
+	w.emitExistingFiles(w.root)
 	for _, dir := range newestFirst(w.root, entries) {
 		if ctx.Err() != nil {
 			return nil // Watch's own select loop will observe ctx.Done() and return
@@ -554,9 +707,34 @@ func (w *Watcher) addExistingDirs(ctx context.Context, watcher *fsnotify.Watcher
 // originally discarded), but it is reported through the Logger per Key
 // Conventions' logged-not-propagated rule, so the blind spot leaves a trace
 // instead of none at all (#1255).
+// A rejected directory is retried by the next reconcile sweep, because only a
+// successful registration is recorded in watched — so a watch lost to a
+// transient condition recovers on its own instead of staying blind for the
+// daemon's lifetime. The rejection is reported once per directory rather than
+// once per retry (watchFailed), so a genuinely unreadable directory leaves a
+// trace without repeating it every sweep; clearing the entry on success means
+// a later failure is reported again.
 func (w *Watcher) addWatch(watcher *fsnotify.Watcher, dir string) {
+	if _, ok := w.watched[dir]; ok {
+		return // already armed — re-registering every sweep would be churn
+	}
 	err := watcher.Add(dir)
-	if err == nil || w.logger == nil {
+	if err == nil {
+		if w.watched == nil {
+			w.watched = make(map[string]struct{})
+		}
+		w.watched[dir] = struct{}{}
+		delete(w.watchFailed, dir)
+		return
+	}
+	if _, reported := w.watchFailed[dir]; reported {
+		return
+	}
+	if w.watchFailed == nil {
+		w.watchFailed = make(map[string]struct{})
+	}
+	w.watchFailed[dir] = struct{}{}
+	if w.logger == nil {
 		return
 	}
 	w.logger.LogError("fswatcher", "", fmt.Sprintf(
@@ -591,10 +769,15 @@ func (w *Watcher) drainPendingEvents(watcher *fsnotify.Watcher) {
 }
 
 // newestFirst returns the absolute paths of root's directory entries, sorted
-// by modification time descending (newest first). Non-directory entries
-// (loose files directly under root — no adapter's layout uses these) are
-// skipped; an entry whose mtime can't be read sorts as if it were the oldest
-// rather than aborting the scan.
+// by modification time descending (newest first). Non-directory entries are
+// skipped — a flat layout's transcripts (kiro-cli) are handled by the caller
+// before it descends, not here; an entry whose mtime can't be read sorts as if
+// it were the oldest rather than aborting the scan.
+//
+// Only the startup scan uses this. The ordering exists to bound *first*
+// discovery latency over a one-shot backlog (#998); the reconcile sweep visits
+// every directory unconditionally and repeats, so ordering changes nothing
+// observable there and it walks entries directly instead.
 func newestFirst(root string, entries []os.DirEntry) []string {
 	type dirMtime struct {
 		path  string
@@ -656,10 +839,111 @@ func (w *Watcher) emitExistingFiles(dir string) {
 			continue
 		}
 		size, mtime := fileSizeAndMtime(fullPath)
-		if w.maxAge > 0 && !mtime.IsZero() && time.Since(mtime) > w.maxAge {
+		if w.isStale(mtime) {
 			continue
 		}
-		w.broadcast(w.eventFor(agent.EventNewSession, sessionID, projectDir, fullPath, size))
+		w.emit(agent.EventNewSession, sessionID, projectDir, fullPath, size)
+	}
+}
+
+// reconcile re-walks the tree and reports anything fsnotify never did: a
+// transcript file with no emission recorded for it becomes an EventNewSession,
+// and one whose size has moved since the last emission becomes an
+// EventActivity. In the healthy case every file's recorded size already
+// matches what is on disk and the sweep emits nothing at all, so this is
+// invisible unless a notification was genuinely lost (issue #1248).
+//
+// Deletions are deliberately not reconciled. Inferring EventRemoved from a
+// file's absence would turn any transient ReadDir failure into a spurious
+// teardown of every session under that directory, and a lost Remove is far
+// less costly than a lost creation — the session is stale rather than
+// invisible.
+//
+// Like the backlog scan in addExistingDirs, this drains fsnotify's (unbuffered
+// on kqueue) event channel between top-level directories so a live event isn't
+// left blocked behind a long walk, and checks ctx there so cancellation isn't
+// delayed by the rest of the sweep. It runs on Watch's goroutine, which is what
+// makes its use of pendingNew/emitted/watched lock-free.
+func (w *Watcher) reconcile(ctx context.Context, watcher *fsnotify.Watcher) {
+	entries, err := os.ReadDir(w.root)
+	if err != nil {
+		return
+	}
+	// One pass over root's entries, handling its own transcript files inline
+	// rather than only descending into subdirectories: a flat layout —
+	// kiro-cli keeps <uuid>.jsonl directly under sessions/cli with no project
+	// directory at all — would otherwise gain nothing from this sweep. This
+	// deliberately does not sort via newestFirst: see its doc comment, the
+	// ordering earns nothing here and costs an lstat per directory per sweep.
+	for _, e := range entries {
+		path := filepath.Join(w.root, e.Name())
+		if !e.IsDir() {
+			w.reconcileFile(path)
+			continue
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		_ = filepath.WalkDir(path, func(p string, d os.DirEntry, err error) error {
+			if err != nil {
+				return nil // skip unreadable dirs
+			}
+			if d.IsDir() {
+				w.addWatch(watcher, p)
+				return nil
+			}
+			w.reconcileFile(p)
+			return nil
+		})
+		w.drainPendingEvents(watcher)
+	}
+}
+
+// reconcileFile emits the event fsnotify should have delivered for path, if
+// any. It mirrors handleTranscriptCreate/handleTranscriptWrite's rules — same
+// session-ID extraction, same staleness cutoff, same zero-byte deferral for
+// header-linked adapters — so a file recovered by the sweep is indistinguishable
+// from one reported normally.
+// The filters run cheapest-first, and that ordering is load-bearing rather
+// than cosmetic. A stat plus two map lookups is a syscall; idFor can be far
+// more than that — codex derives its session ID by opening the transcript and
+// JSON-decoding its first record (codex.sessionIDFromPath), so hoisting it
+// above the size compare made every sweep re-read every transcript in the tree
+// to produce nothing. Measured on a real 301-file codex tree that is ~250ms
+// per sweep versus ~3ms, spent on the goroutine that also dispatches fsnotify
+// events — the sweep would have been delaying the fast path it exists to back
+// up. Only files with a valid session ID are ever recorded in emitted, so
+// consulting it before idFor cannot mask a file idFor would have skipped.
+func (w *Watcher) reconcileFile(path string) {
+	if !strings.HasSuffix(path, transcriptExt) {
+		return
+	}
+	size, mtime := fileSizeAndMtime(path)
+	if w.isStale(mtime) {
+		return
+	}
+	prev, known := w.emitted[path]
+	if known && prev == size {
+		return // fsnotify already reported this exact state
+	}
+	sessionID := w.idFor(path)
+	if sessionID == "" {
+		return
+	}
+	projectDir := filepath.Base(filepath.Dir(path))
+	switch {
+	case known:
+		w.emit(agent.EventActivity, sessionID, projectDir, path, size)
+	case size == 0 && w.parentSessionID != nil:
+		// Same deferral as a zero-byte Create: park it so the header is
+		// readable before the new-session event goes out.
+		if w.pendingNew == nil {
+			w.pendingNew = make(map[string]struct{})
+		}
+		w.pendingNew[path] = struct{}{}
+	default:
+		delete(w.pendingNew, path)
+		w.emit(agent.EventNewSession, sessionID, projectDir, path, size)
 	}
 }
 

--- a/core/adapters/inbound/agents/fswatcher/watcher_test.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher_test.go
@@ -159,9 +159,16 @@ done:
 // TestWatch_MetadataParentIsPresentOnFirstNewEvent proves that an adapter
 // whose relationship lives in its first transcript record does not expose a
 // zero-byte Create as an unlinked top-level session before the header arrives.
+//
+// The short reconcile interval is what makes this test's own event delivery
+// unconditional rather than dependent on fsnotify never dropping a
+// notification (issue #1248): the failure it used to show was a create event
+// that never arrived at all, so the reconcile sweep — not a longer deadline —
+// is what closes it. The sweep is a fallback, so the assertions below still
+// exercise the ordinary event path in the overwhelmingly common case.
 func TestWatch_MetadataParentIsPresentOnFirstNewEvent(t *testing.T) {
 	root := setupFakeProjects(t)
-	w := NewWithRoot(root, testAdapter, 0).WithParentSessionID(func(path string) string {
+	w := NewWithRoot(root, testAdapter, 0).WithReconcileInterval(50 * time.Millisecond).WithParentSessionID(func(path string) string {
 		contents, _ := os.ReadFile(path)
 		if strings.Contains(string(contents), "parent-thread") {
 			return "parent-thread"


### PR DESCRIPTION
Closes #1248.

## The failure mode

#1248's investigation pinned the symptom precisely: the flake is always
`watcher_test.go` *"timed out waiting for linked new-session event"* — an event
that **never arrives**, not one that arrives late. Across 660 instrumented runs
with every core saturated the event arrived every time, worst case **9.9 ms**.
Two causes were ruled out with evidence (CPU-load latency; a failed
`watcher.Add`). The surviving lead was a genuinely dropped event inside
fsnotify's macOS kqueue backend, which discovers new files by diffing a
directory listing rather than receiving a per-file notification.

Scope for this PR was confirmed with the maintainer: **fswatcher only** (not the
wider `./core/...` flake family), fixed by **closing the production hole** rather
than instrumenting and soaking. That matters because the same drop in production
means a session that is *simply never observed* for the daemon's whole lifetime —
the same silent-blind-spot class as #1255, which this builds directly on.

## What changed

`Watch` now runs a periodic **reconcile sweep** (`defaultReconcileInterval`, 15s;
`WithReconcileInterval` overrides, negative disables) that re-walks the tree and
reports what fsnotify didn't:

- a transcript with no emission recorded → `EventNewSession`
- one whose size moved since the last emission → `EventActivity`

Every emission now goes through a new `emit()` that records the reported size, so
**in the healthy case the sweep finds nothing to say and stays silent** —
notifications remain the fast path, this is only the safety net. It runs on
`Watch`'s goroutine (so `pendingNew`/`emitted`/`watched` stay lock-free) and
drains fsnotify's unbuffered channel between top-level directories, the same way
the existing backlog scan does.

**Deletions are deliberately not reconciled.** Inferring `EventRemoved` from a
file's absence would turn a transient `ReadDir` failure into a spurious teardown
of every session under that directory; a lost `Remove` leaves a session stale
rather than invisible, which is the cheaper failure.

### Interaction with #1255 (merged mid-branch)

#1255 landed while this was in flight and touches the same function, so this
rebase folds the two together rather than duplicating them. `addWatch` keeps
#1255's logging and gains this PR's semantics:

- **already-armed dirs are skipped**, so the sweep isn't re-registering the whole tree every interval;
- **a rejected registration is not recorded**, so the next sweep *retries* it — a watch lost to FD exhaustion or a permissions blip now recovers on its own instead of staying blind until restart;
- **the rejection is logged once per directory**, not once per retry — without this, #1255's log line would repeat every 15s forever for a genuinely unreadable directory.

## Why the tests are trustworthy

A real dropped kqueue notification can't be forced (that's what 660 runs
established). The stand-in is a directory whose watch registration **fails**:
fsnotify then structurally cannot report anything created inside it, which is the
same observable situation — and unlike a real drop, it can be produced on demand.

`TestWatch_ReconcileRecoversFileUnderAnUnwatchableDir` carries its own control:
the `sweep disabled` subtest pins that the file really is invisible to fsnotify,
so the recovered case is evidence about the sweep rather than about fsnotify
quietly delivering the event anyway.

### Seen red (per AGENTS.md)

Every new assertion was run against a deliberate mutation and observed failing:

| Mutation | Result |
|---|---|
| `reconcile` is a no-op | 6 tests fail, incl. `sweep enabled recovers it` — *timed out waiting for "new_session"* |
| dedup guard never fires | `DoesNotReEmitWhatWasAlreadyReported`, `SilentAfterNormalEventPathEmitted` — *unexpected "activity" event* |
| `Remove` no longer forgets the emitted size | `RecreatedFileIsANewSessionAgain` — *event type = "removed", want "new_session"* |
| negative interval no longer disables the sweep | `EffectiveReconcileInterval/negative` — *= -1ns, want 0s* |
| `reconcileFile` ignores the staleness cutoff | `SkipsStaleFile` — *unexpected "new_session"* |
| `reconcileFile` ignores an empty session ID | `SkipsFileWithoutSessionID` — *unexpected "new_session"* |
| every retry re-logs | `AddWatch_Retries…` — *logged 3 errors …, want 1* |
| a rejected dir is recorded as watched | `AddWatch_Retries…` — *must not be recorded as watched, or it is never retried* |

Two earlier mutation attempts (deleting the guards outright) were discarded as
invalid — they orphan `prev`/`mtime` and fail to compile, so they proved nothing.

## Verification

- `go test ./core/... -race -count=1` — **2 consecutive green runs**, 49 packages, 0 failures (plus 3 green before the #1255 rebase).
- `TestWatch_MetadataParentIsPresentOnFirstNewEvent` — `-race -count=50`, green.
- `tools/preflight.sh --changed` via the pre-push hook: gofmt, core module tests, ARS architecture gate, security scan all **PASS**.

### One unrelated flake seen, reported not dismissed

During the first full-suite run, `TestAnyLiveOutputWriter_RealProcess`
(`core/application/services`) failed once: *"probe reported no live writer while
background process is running"*. Evidence that it is not from this change:
this branch touches only `core/adapters/inbound/agents/fswatcher/` (3 files), and
that probe's code path is byte-identical to `origin/main`. It polls `lsof` — which
scans every process — against a **2-second** deadline, so it is load-sensitive by
construction. It did **not** reproduce in 30 `-race` runs under full CPU
saturation, nor in 4 subsequent full-suite runs. Marked as *not reproduced*: this
looks like a third member of the load-dependent flake family #1248's follow-up
comment describes, and is worth its own issue rather than a fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)