### PR TITLE
fix(fswatcher): cap watch-failure logging, skip vanished dirs, pin the wiring

### DIFF
--- a/core/adapters/inbound/agents/fswatcher/watcher.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher.go
@@ -8,7 +8,9 @@ package fswatcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -41,6 +43,17 @@ const transcriptExt = ".jsonl"
 // moved, and stat-ing only known paths for growth) is the prerequisite for
 // shortening this.
 const defaultReconcileInterval = 15 * time.Second
+
+// maxLoggedWatchFailures caps how many rejected watch registrations one tree
+// scan reports individually before addWatch falls back to counting them for
+// the summary line. The failure modes worth reporting at all are mostly
+// process-global — FD exhaustion, Linux's fs.inotify.max_user_watches — so
+// once one trips mid-scan every remaining Add fails too. One line per
+// directory would then be tens of thousands of lines per boot across every
+// adapter's watcher, rotating the log out from under the first few lines:
+// exactly the ones naming where the budget ran out. Capping keeps the trace
+// this reporting exists to leave (#1255).
+const maxLoggedWatchFailures = 10
 
 // Watcher watches a directory tree for .jsonl transcript file events.
 // It implements inbound.Watcher.
@@ -90,6 +103,13 @@ type Watcher struct {
 	// goroutine (handleEvent, the backlog scan and reconcile all run on it), so
 	// none of them take a lock.
 	watchFailed map[string]struct{}
+	// watchFailures counts directories fsnotify refused to watch;
+	// loggedWatchFailures is how many of those were reported individually
+	// before maxLoggedWatchFailures capped them. Both are touched only from
+	// the Watch goroutine — addExistingDirs directly, addSubtree via
+	// handleEvent — so, like the maps above, they need no lock.
+	watchFailures       int
+	loggedWatchFailures int
 
 	subMu sync.Mutex
 	subs  []chan agent.Event
@@ -167,6 +187,13 @@ func (w *Watcher) WithLogger(l outbound.Logger) *Watcher {
 	w.logger = l
 	return w
 }
+
+// Logger returns the logger supplied via WithLogger, or nil if it was never
+// called. Exported so cmd/irrlichd's wiring test can assert the daemon
+// actually attaches one: without it, dropping the WithLogger call keeps the
+// whole suite green while production silently reverts to discarding watch
+// failures — the same invisible regression #1255 was filed about.
+func (w *Watcher) Logger() outbound.Logger { return w.logger }
 
 // WithSessionID sets a custom session-ID extractor (see the sessionID field).
 // Returns the watcher for chaining. Callers in cmd/irrlichd/wiring.go invoke
@@ -691,6 +718,7 @@ func (w *Watcher) addExistingDirs(ctx context.Context, watcher *fsnotify.Watcher
 		})
 		w.drainPendingEvents(watcher)
 	}
+	w.reportWatchFailureTotal()
 	return nil
 }
 
@@ -727,6 +755,20 @@ func (w *Watcher) addWatch(watcher *fsnotify.Watcher, dir string) {
 		delete(w.watchFailed, dir)
 		return
 	}
+	// A directory that vanished between being enumerated and being armed is
+	// not a blind spot — there is nothing left under it to observe — so it
+	// is neither counted nor reported, and it is deliberately not recorded in
+	// watchFailed either: should the path come back, the next sweep treats it
+	// as new rather than as an already-reported failure. Both backends surface
+	// the bare errno here (inotify_add_watch's, and kqueue's from os.Open), so
+	// this matches on either platform. The window is real on both scan paths:
+	// the startup walk and handleDirCreate's Stat each precede this call.
+	if errors.Is(err, fs.ErrNotExist) {
+		return
+	}
+	// Counting and logging are both gated on watchFailed, so a directory that
+	// keeps failing contributes one failure and at most one line for the
+	// daemon's lifetime rather than one per reconcile sweep.
 	if _, reported := w.watchFailed[dir]; reported {
 		return
 	}
@@ -734,12 +776,27 @@ func (w *Watcher) addWatch(watcher *fsnotify.Watcher, dir string) {
 		w.watchFailed = make(map[string]struct{})
 	}
 	w.watchFailed[dir] = struct{}{}
-	if w.logger == nil {
+	w.watchFailures++
+	if w.logger == nil || w.loggedWatchFailures >= maxLoggedWatchFailures {
 		return
 	}
+	w.loggedWatchFailures++
 	w.logger.LogError("fswatcher", "", fmt.Sprintf(
 		"%s: failed to watch %s — transcript changes under it will not be observed: %v",
 		w.adapter, dir, err))
+}
+
+// reportWatchFailureTotal emits one summary line when the tree scan hit more
+// rejections than addWatch reported individually, so the true size of the
+// blind spot stays visible even though the per-directory lines were capped.
+// Silent when nothing was capped — the individual lines already say it all.
+func (w *Watcher) reportWatchFailureTotal() {
+	if w.logger == nil || w.watchFailures <= w.loggedWatchFailures {
+		return
+	}
+	w.logger.LogError("fswatcher", "", fmt.Sprintf(
+		"%s: %d directories under %s could not be watched (%d reported individually above) — transcript changes under them will not be observed",
+		w.adapter, w.watchFailures, w.root, w.loggedWatchFailures))
 }
 
 // drainPendingEvents processes any fsnotify events already queued on

--- a/core/adapters/inbound/agents/fswatcher/watcher_test.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher_test.go
@@ -821,13 +821,54 @@ func (l *recordingLogger) matching(substr string) []string {
 	return out
 }
 
+// closedWatcher returns an fsnotify watcher that rejects every Add with
+// ErrClosed. That is the one registration failure reproducible on every
+// backend regardless of the caller's privileges — unlike the mode-0000
+// directory the end-to-end tests need, which root defeats — and unlike a
+// missing path it is not ENOENT, so it exercises the reporting branch rather
+// than addWatch's vanished-directory shortcut.
+func closedWatcher(t *testing.T) *fsnotify.Watcher {
+	t.Helper()
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fsw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return fsw
+}
+
 // TestAddWatch_LogsFailure is the platform-independent half of the #1255
 // regression: addWatch is the sole place either tree scan arms a directory,
 // and a rejected registration must leave a trace naming the directory rather
-// than being discarded. An unreachable path fails on every backend (kqueue
-// lstats, inotify stats) regardless of the caller's privileges, which the
-// chmod-based test below cannot promise.
+// than being discarded.
 func TestAddWatch_LogsFailure(t *testing.T) {
+	log := &recordingLogger{}
+	dir := t.TempDir()
+	w := NewWithRoot(dir, testAdapter, 0).WithLogger(log)
+
+	w.addWatch(closedWatcher(t), dir)
+
+	got := log.matching(dir)
+	if len(got) != 1 {
+		t.Fatalf("addWatch on a rejected registration logged %d errors naming %q, want 1 (all: %v)",
+			len(got), dir, log.matching(""))
+	}
+	if !strings.Contains(got[0], testAdapter) {
+		t.Errorf("logged error %q does not name the adapter %q", got[0], testAdapter)
+	}
+	if w.watchFailures != 1 {
+		t.Errorf("watchFailures = %d, want 1", w.watchFailures)
+	}
+}
+
+// TestAddWatch_VanishedDirIsNotReported pins the ENOENT shortcut: a directory
+// removed between being enumerated and being armed — a real TOCTOU window on
+// both scan paths — is not a monitoring blind spot, because nothing is left
+// under it to observe. Reporting it would send whoever reads the log after a
+// real incident chasing a path that no longer exists.
+func TestAddWatch_VanishedDirIsNotReported(t *testing.T) {
 	log := &recordingLogger{}
 	w := NewWithRoot(t.TempDir(), testAdapter, 0).WithLogger(log)
 
@@ -837,16 +878,76 @@ func TestAddWatch_LogsFailure(t *testing.T) {
 	}
 	defer fsw.Close()
 
-	missing := filepath.Join(t.TempDir(), "does-not-exist")
-	w.addWatch(fsw, missing)
+	w.addWatch(fsw, filepath.Join(t.TempDir(), "already-gone"))
 
-	got := log.matching(missing)
-	if len(got) != 1 {
-		t.Fatalf("addWatch on an unwatchable path logged %d errors naming %q, want 1 (all: %v)",
-			len(got), missing, log.errors)
+	if got := log.matching(""); len(got) != 0 {
+		t.Errorf("addWatch on a vanished dir logged %v, want nothing", got)
 	}
-	if !strings.Contains(got[0], testAdapter) {
-		t.Errorf("logged error %q does not name the adapter %q", got[0], testAdapter)
+	if w.watchFailures != 0 {
+		t.Errorf("watchFailures = %d, want 0 — a vanished dir is not a blind spot", w.watchFailures)
+	}
+}
+
+// TestAddExistingDirs_CapsFailureLogging covers the flood the failure modes
+// this reporting targets actually produce: EMFILE and inotify's watch limit
+// are process-global, so once one trips every remaining Add in the scan
+// fails. Reporting each one would rotate the log out from under the first
+// lines — the ones naming where the budget ran out — so the scan reports the
+// first maxLoggedWatchFailures individually and then one summary carrying
+// the true total.
+func TestAddExistingDirs_CapsFailureLogging(t *testing.T) {
+	const dirs = maxLoggedWatchFailures + 5
+
+	root := t.TempDir()
+	for i := 0; i < dirs; i++ {
+		if err := os.MkdirAll(filepath.Join(root, fmt.Sprintf("proj-%02d", i)), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	log := &recordingLogger{}
+	w := NewWithRoot(root, testAdapter, 0).WithLogger(log)
+
+	// A closed watcher fails every Add, standing in for the global
+	// exhaustion without having to actually exhaust the host's FDs.
+	if err := w.addExistingDirs(context.Background(), closedWatcher(t)); err != nil {
+		t.Fatalf("addExistingDirs returned %v, want nil — a failed Add must not abort the scan", err)
+	}
+
+	perDir := log.matching("failed to watch")
+	if len(perDir) != maxLoggedWatchFailures {
+		t.Errorf("logged %d individual failures, want the cap of %d", len(perDir), maxLoggedWatchFailures)
+	}
+	summary := log.matching("could not be watched")
+	if len(summary) != 1 {
+		t.Fatalf("logged %d summary lines, want 1 (all: %v)", len(summary), log.matching(""))
+	}
+	if !strings.Contains(summary[0], fmt.Sprintf("%d directories", dirs)) {
+		t.Errorf("summary %q does not carry the true total of %d", summary[0], dirs)
+	}
+}
+
+// TestAddExistingDirs_NoSummaryWhenUncapped is the counterpart lock: below
+// the cap the individual lines already say everything, so a redundant
+// summary would just be noise.
+func TestAddExistingDirs_NoSummaryWhenUncapped(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "only-project"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	log := &recordingLogger{}
+	w := NewWithRoot(root, testAdapter, 0).WithLogger(log)
+
+	if err := w.addExistingDirs(context.Background(), closedWatcher(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := log.matching("could not be watched"); len(got) != 0 {
+		t.Errorf("logged a summary %v below the cap, want none", got)
+	}
+	if got := log.matching("failed to watch"); len(got) != 1 {
+		t.Errorf("logged %d individual failures, want 1", len(got))
 	}
 }
 
@@ -873,17 +974,17 @@ func TestAddWatch_SucceedsSilently(t *testing.T) {
 
 // TestAddWatch_NilLoggerDoesNotPanic covers the e2e and test callers that
 // never call WithLogger: a failure there stays unreported, but must not take
-// the watcher down.
+// the watcher down — and must still be counted.
 func TestAddWatch_NilLoggerDoesNotPanic(t *testing.T) {
-	w := NewWithRoot(t.TempDir(), testAdapter, 0)
+	dir := t.TempDir()
+	w := NewWithRoot(dir, testAdapter, 0)
 
-	fsw, err := fsnotify.NewWatcher()
-	if err != nil {
-		t.Fatal(err)
+	w.addWatch(closedWatcher(t), dir)
+	w.reportWatchFailureTotal()
+
+	if w.watchFailures != 1 {
+		t.Errorf("watchFailures = %d, want 1", w.watchFailures)
 	}
-	defer fsw.Close()
-
-	w.addWatch(fsw, filepath.Join(t.TempDir(), "does-not-exist"))
 }
 
 // TestWatch_UnwatchableSubdir_IsReportedNotSwallowed is the end-to-end half:
@@ -927,7 +1028,7 @@ func TestWatch_UnwatchableSubdir_IsReportedNotSwallowed(t *testing.T) {
 
 	if got := log.matching(locked); len(got) != 1 {
 		t.Fatalf("startup scan logged %d errors naming the unwatchable dir %q, want 1 (all: %v)",
-			len(got), locked, log.errors)
+			len(got), locked, log.matching(""))
 	}
 
 	// The watch is still live for the rest of the tree.

--- a/core/cmd/irrlichd/wiring_test.go
+++ b/core/cmd/irrlichd/wiring_test.go
@@ -18,11 +18,19 @@ import (
 func countWatcherKinds(t *testing.T, name string, watchers []inbound.Watcher) (scanners, fswatchers, stores int) {
 	t.Helper()
 	for _, w := range watchers {
-		switch w.(type) {
+		switch fsw := w.(type) {
 		case *processlifecycle.Scanner:
 			scanners++
 		case *fswatcher.Watcher:
 			fswatchers++
+			// Every fswatcher must carry the daemon's logger, or a failed
+			// watch registration goes back to being discarded silently
+			// (#1255). Nothing else can catch that: Watcher.logger is
+			// unexported, so dropping the WithLogger call in wiring.go
+			// otherwise leaves the whole suite green.
+			if fsw.Logger() == nil {
+				t.Errorf("%s: fswatcher for %s has no logger — wiring.go must pass one via WithLogger", name, fsw.Root())
+			}
 		case *opencode.Watcher:
 			stores++
 		default:
@@ -72,7 +80,7 @@ func assertWatcherCountsForSource(t *testing.T, name string, source agent.Source
 // one process scanner, plus the Source variant's dedicated watcher.
 func assertAgentWatcherSet(t *testing.T, a agent.Agent, noCheck func(string, int) bool) {
 	t.Helper()
-	watchers, _ := buildAgentWatchers(a, time.Minute, noCheck, nil)
+	watchers, _ := buildAgentWatchers(a, time.Minute, noCheck, e2eLog{})
 	scanners, fswatchers, stores := countWatcherKinds(t, a.Identity.Name, watchers)
 	if scanners != 1 {
 		t.Errorf("%s: got %d process scanners, want 1", a.Identity.Name, scanners)


### PR DESCRIPTION
Follow-up to #1279 (issue #1255). **The four review findings on #1279 did not make it onto `main`** — that PR was squash-merged capturing only its first commit (`+214/−9`); the review-round commit was on the branch but the squash landed the pre-review version. This PR carries that commit, cherry-picked onto current `main`.

## What's missing from main

**1. Log flood on the failure modes this reporting exists for.** Every one of them — `EMFILE`, Linux's `fs.inotify.max_user_watches` — is *process-global*: once it trips mid-scan, every remaining `Add` in `addExistingDirs` fails too, so the merged code emits one ~250-byte error line per directory for the rest of the tree, across every `FilesUnderRoot` adapter's watcher. On a large tree that is tens of thousands of lines in one boot; the logger rotates at 10 MB × 5, so a single boot can push out the *first* lines — the ones naming where the budget ran out. The change's whole purpose ("the blind spot leaves a trace instead of none at all") is what gets erased.

  Fix: report the first `maxLoggedWatchFailures` (10) individually, then one summary line carrying the true total. That also delivers issue #1255's option 2 (a queryable count) for free.

**2. A vanished directory is reported as a monitoring blind spot.** The merged `addWatch` logs *any* non-nil error with the fixed text "transcript changes under it will not be observed". `ENOENT` — the directory was removed in the TOCTOU window between `filepath.WalkDir` enumerating it and `watcher.Add` arming it — is not a blind spot; there is nothing left under it to observe. The window is real on both scan paths, and wider still on `addSubtree`, where `handleDirCreate`'s `os.Stat` precedes the `Add`. Both backends surface the bare errno, so `errors.Is(err, fs.ErrNotExist)` matches on either platform.

**3. The production wiring is unpinned.** `Watcher.logger` is unexported and `cmd/irrlichd` is a different package, so nothing can observe whether `wiring.go` actually calls `WithLogger`. Delete that call in a future refactor — or drop the argument during a signature cleanup — and `go build` and `go test ./core/...` both stay green while the daemon silently reverts to the pre-#1255 swallow. That is the same invisible-regression class #1255 was filed about. Fix: a `Logger()` accessor, asserted in `wiring_test.go` for every `FilesUnderRoot` fswatcher.

**4. Two unguarded reads of a mutex-guarded field.** `recordingLogger`'s doc comment states every field is mutex-guarded, but two `t.Fatalf` format args read `log.errors` directly while `w.Watch` is still running. Latent today (no concurrent writer on those paths), but it corrupts the diagnostic exactly when the assertion has already failed. Fix: use the existing `matching("")` accessor.

## Red-first proof

With the cap and the `ENOENT` shortcut removed from `addWatch`:

```
=== RUN   TestAddWatch_VanishedDirIsNotReported
    watcher_test.go:877: addWatch on a vanished dir logged [... already-gone — transcript
        changes under it will not be observed: ...], want nothing
    watcher_test.go:880: watchFailures = 1, want 0 — a vanished dir is not a blind spot
--- FAIL: TestAddWatch_VanishedDirIsNotReported (0.00s)
=== RUN   TestAddExistingDirs_CapsFailureLogging
    watcher_test.go:912: logged 15 individual failures, want the cap of 10
    watcher_test.go:916: logged 0 summary lines, want 1
--- FAIL: TestAddExistingDirs_CapsFailureLogging (0.00s)
```

**Locks** — green by construction, stated as such rather than passed off as red-first proof: `TestAddExistingDirs_NoSummaryWhenUncapped`, `TestAddWatch_SucceedsSilently`, `TestAddWatch_NilLoggerDoesNotPanic`.

`TestAddWatch_LogsFailure` is reworked to drive the failure through a **closed fsnotify watcher** rather than a missing path. That is reproducible on every backend regardless of privileges (unlike the mode-`0000` directory the end-to-end test needs, which root defeats), and it is not `ENOENT`, so it exercises the reporting branch instead of the new shortcut. The same helper stands in for global exhaustion in the cap test without having to actually exhaust the host's FDs.

## Verification

- `go test ./core/adapters/inbound/agents/fswatcher/ ./core/cmd/irrlichd/ -race -count=1` — pass.
- `go test ./core/... -race -count=1` — 48/49 packages pass; `core/application/services` is an unrelated pre-existing flake. Evidence: it failed once here on `TestAnyLiveOutputWriter_RealProcess` + `TestDebounce_TerminalEventShortCircuits` (both timing-sensitive), then passed on re-run — and it also fails 1-in-3 runs on **clean `origin/main`** with none of this diff present. `go list -test -deps ./core/application/services` shows no dependency on `fswatcher`, and this PR touches nothing else outside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)