### PR TITLE
fix(tooling): close skill-lint silent-pass paths, widen scope, simplify

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # .claude/skills/**/*.md are executable instructions — they decide how
+      # agents triage, plan, implement and review — and until #1209 no gate
+      # read them. PR #1204 changed two skill files: preflight skipped all ten
+      # gates and all thirteen PR checks went green having checked nothing that
+      # changed. This step is the missing CI reader.
+      #
+      # First step after checkout, before setup-go: it needs no toolchain and
+      # takes a fraction of a second, and behind the Go suites a `go test`
+      # failure would abort the job and give a skills-only PR no skill feedback
+      # at all. Deliberately unscoped — scoping is what let the gap exist.
+      # Unresolved conflict markers, leftover template scaffolding and an
+      # unbalanced code fence fail; the reference/list/frontmatter heuristics
+      # only warn until their noise floor is known (`--strict` promotes them).
+      - name: Lint skill files
+        run: tools/skill-lint.sh
+
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
@@ -92,16 +108,3 @@ jobs:
             echo "== $t =="
             bash "$t"
           done
-
-      # .claude/skills/**/*.md are executable instructions — they decide how
-      # agents triage, plan, implement and review — and until #1209 no gate
-      # read them. PR #1204 changed two skill files: preflight skipped all ten
-      # gates and all thirteen PR checks went green having checked nothing that
-      # changed. This step is the missing CI reader. It is deliberately
-      # unscoped (the whole corpus, every push) — the run is a fraction of a
-      # second, and scoping is what let the gap exist in the first place.
-      # Unresolved conflict markers and leftover template scaffolding fail;
-      # the reference/list/frontmatter heuristics only warn until their noise
-      # floor is known (tools/skill-lint.sh --strict promotes them).
-      - name: Lint skill files
-        run: tools/skill-lint.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,19 +34,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      # .claude/skills/**/*.md are executable instructions — they decide how
-      # agents triage, plan, implement and review — and until #1209 no gate
-      # read them. PR #1204 changed two skill files: preflight skipped all ten
-      # gates and all thirteen PR checks went green having checked nothing that
-      # changed. This step is the missing CI reader.
-      #
-      # First step after checkout, before setup-go: it needs no toolchain and
-      # takes a fraction of a second, and behind the Go suites a `go test`
-      # failure would abort the job and give a skills-only PR no skill feedback
-      # at all. Deliberately unscoped — scoping is what let the gap exist.
-      # Unresolved conflict markers, leftover template scaffolding and an
-      # unbalanced code fence fail; the reference/list/frontmatter heuristics
-      # only warn until their noise floor is known (`--strict` promotes them).
+      # Reads .claude/skills/**/*.md (and any other SKILL.md), which no gate
+      # read until #1209 — see the header of tools/skill-lint.sh for why.
+      # Runs first, before setup-go: it needs no toolchain and takes a fraction
+      # of a second, and behind the Go suites a `go test` failure would abort
+      # the job and leave a skills-only PR with no skill feedback at all.
       - name: Lint skill files
         run: tools/skill-lint.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,23 +112,28 @@ Before marking a ticket done, run the full suite — every layer must pass:
   assertion lands with the deliberate mutation that was seen red for each
   obligation recorded in its PR — the same bar the red-first rule above sets
   for defect tests.
-- Skill files: `tools/skill-lint.sh` reads `.claude/skills/**/*.md` — the
-  files that tell agents how to triage, plan, implement and review, and which
-  had no mechanical coverage at all until #1209 (PR #1204 changed two of them,
-  `preflight.sh --changed` skipped all ten gates, and thirteen PR checks went
-  green having read nothing that changed). Unresolved conflict markers,
-  leftover `{{TOKEN}}` / `REPEAT:` / `OPTIONAL:` template scaffolding and an
-  unbalanced code fence are hard failures; the internal-reference, list-count
-  and frontmatter checks are heuristics and only warn until their noise floor
-  is known (`--strict` promotes them, which is how one gets hardened). The
-  fence and frontmatter checks exist because blanking is how the linter tells
-  "documents a marker" from "has one", so an unbalanced delimiter would
-  otherwise silence the rest of the file. Runs as its own
-  `skill-file lint` gate in `tools/preflight.sh` (scoped to skill markdown plus
-  the linter itself) and unscoped as test.yml's "Lint skill files" step. Its
-  own tests are `tools/lib/skill-lint_test.sh`, over the fixture corpus under
+- Skill files: `tools/skill-lint.sh` reads every `.md` under
+  `.claude/skills/` plus any other tracked `SKILL.md` (there is one under
+  `tools/irrlicht-design-system/`) — the files that tell agents how to triage,
+  plan, implement and review, and which had no mechanical coverage at all
+  until #1209 (PR #1204 changed two of them, `preflight.sh --changed` skipped
+  all ten gates, and thirteen PR checks went green having read nothing that
+  changed). Unresolved conflict markers, leftover `{{TOKEN}}` / `REPEAT:` /
+  `OPTIONAL:` template scaffolding and an unbalanced code fence are hard
+  failures; the internal-reference, list-count and frontmatter checks are
+  heuristics and only warn until their noise floor is known (`--strict`
+  promotes them, which is how one gets hardened). The fence and frontmatter
+  checks exist because skipping is how the linter tells "documents a marker"
+  from "has one" — so an unbalanced delimiter would otherwise silence the rest
+  of the file, and the rule is that when a file cannot be parsed with
+  confidence the linter degrades toward *more* checking, never less. Runs as
+  its own `skill-file lint` gate in `tools/preflight.sh` (scoped to skill
+  markdown plus the linter itself) and unscoped as test.yml's "Lint skill
+  files" step — first in the job, before `setup-go`. Its own tests are
+  `tools/lib/skill-lint_test.sh`, over the fixture corpus under
   `tools/lib/testdata/skill-lint/` — so the assertions never move when a real
-  skill file is edited.
+  skill file is edited, and `testdata/` is excluded from the gate's own walk
+  because those fixtures are deliberately corrupt.
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh`
 - Replay goldens (when a recording or replay-output change is in play):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,11 +116,14 @@ Before marking a ticket done, run the full suite — every layer must pass:
   files that tell agents how to triage, plan, implement and review, and which
   had no mechanical coverage at all until #1209 (PR #1204 changed two of them,
   `preflight.sh --changed` skipped all ten gates, and thirteen PR checks went
-  green having read nothing that changed). Unresolved conflict markers and
-  leftover `{{TOKEN}}` / `REPEAT:` / `OPTIONAL:` template scaffolding are hard
-  failures; the internal-reference, list-count and frontmatter checks are
-  heuristics and only warn until their noise floor is known (`--strict`
-  promotes them, which is how one gets hardened). Runs as its own
+  green having read nothing that changed). Unresolved conflict markers,
+  leftover `{{TOKEN}}` / `REPEAT:` / `OPTIONAL:` template scaffolding and an
+  unbalanced code fence are hard failures; the internal-reference, list-count
+  and frontmatter checks are heuristics and only warn until their noise floor
+  is known (`--strict` promotes them, which is how one gets hardened). The
+  fence and frontmatter checks exist because blanking is how the linter tells
+  "documents a marker" from "has one", so an unbalanced delimiter would
+  otherwise silence the rest of the file. Runs as its own
   `skill-file lint` gate in `tools/preflight.sh` (scoped to skill markdown plus
   the linter itself) and unscoped as test.yml's "Lint skill files" step. Its
   own tests are `tools/lib/skill-lint_test.sh`, over the fixture corpus under

--- a/tools/lib/skill-lint_test.sh
+++ b/tools/lib/skill-lint_test.sh
@@ -11,12 +11,31 @@
 # than against real skill files, so the assertions do not move when a real
 # skill is edited.
 #
+# Two properties are asserted everywhere, both learned from review:
+#
+#   * the SUMMARY LINE, not just the exit status. A fixture trips several
+#     sub-checks at once, so `$RC == 1` alone is satisfied by any one of them
+#     still being an ERROR — three of the five hard-fail sub-checks could be
+#     demoted to WARN with the suite staying green. Pinning
+#     "N error(s), M warning(s)" makes each severity load-bearing.
+#   * the SEVERITY WORD on the finding line. It is printed as text rather than
+#     encoded in ANSI color precisely so it survives a pipe — which is what a
+#     GitHub Actions log is, and what these assertions read.
+#
 # The clean fixtures carry as much weight as the broken ones. `good/SKILL.md`
 # is built out of exactly the constructs that would make a naive linter
 # unusable here: prose that *documents* {{TOKEN}} and REPEAT:/OPTIONAL: markers
 # inside backticks (which is how .claude/skills/ir:exec/SKILL.md really reads),
-# a conflict marker shown inside a fence, a correct above/below reference, and
-# a lead-in count that matches its list once nested items are excluded.
+# a conflict marker shown inside a fence, correct above/below references
+# (including one to a heading with a parenthetical), and a lead-in count that
+# matches its list once nested items are excluded.
+#
+# The `unclosed-fence`, `openfm`, `nofmclose` and `fmtoken` fixtures exist for
+# one shared reason: blanking is how this linter tells "documents a marker"
+# from "has one", and every blanked line is a line no check reads. An
+# unbalanced fence or an unterminated frontmatter therefore used to SILENCE the
+# rest of the file — a corrupted skill file linting 0 errors and exiting 0,
+# which is the exact failure #1209 exists to remove.
 
 set -uo pipefail   # NOT -e: assertions capture non-zero return codes
 
@@ -58,7 +77,9 @@ OUT=""
 RC=0
 # lint <args...> — run the linter, capturing combined output in OUT and the
 # exit status in RC. Run from the repo root so relative paths in the output
-# match what a developer would see.
+# match what a developer would see. OUT is a pipe, never a TTY, so colors are
+# off and severity words are the only severity signal — deliberately the same
+# view CI gets.
 lint() {
   OUT=$(cd "$ROOT" && bash "$LINT" "$@" 2>&1)
   RC=$?
@@ -71,54 +92,112 @@ fixture() {
   if [[ -f "$d/SKILL.md" ]]; then echo "$d/SKILL.md"; else echo "$d/reference.md"; fi
 }
 
+# assert_tally <label> <errors> <warnings> — pin the summary line, so no
+# individual sub-check can change severity unnoticed.
+assert_tally() {
+  assert_contains "$1" "$2 error(s), $3 warning(s)" "$OUT"
+  return 0
+}
+
 echo "== check 1: unresolved conflict markers are ERRORS =="
 lint "$(fixture conflict)"
-assert_contains "flags <<<<<<<"          "unresolved merge conflict marker <<<<<<<" "$OUT"
-assert_contains "flags ======="          "unresolved merge conflict marker =======" "$OUT"
-assert_contains "flags >>>>>>>"          "unresolved merge conflict marker >>>>>>>" "$OUT"
+assert_contains "flags <<<<<<< as an ERROR" "ERROR unresolved merge conflict marker <<<<<<<" "$OUT"
+assert_contains "flags ======= as an ERROR" "ERROR unresolved merge conflict marker =======" "$OUT"
+assert_contains "flags >>>>>>> as an ERROR" "ERROR unresolved merge conflict marker >>>>>>>" "$OUT"
+assert_tally    "all three markers, nothing else" 3 0
 assert_eq       "a conflict marker fails the gate" "1" "$RC"
 
 echo "== check 2: unfilled tokens and leftover scaffolding are ERRORS =="
 lint "$(fixture template)"
-assert_contains "flags an unfilled {{TOKEN}}"   "unfilled template token {{TLDR}}" "$OUT"
-assert_contains "flags a REPEAT:/OPTIONAL: comment" "[template-scaffold]" "$OUT"
+assert_contains "flags an unfilled {{TOKEN}} as an ERROR" "ERROR unfilled template token {{TLDR}}" "$OUT"
+assert_contains "flags a REPEAT:/OPTIONAL: comment as an ERROR" \
+  "ERROR template scaffolding comment left in output" "$OUT"
+assert_tally    "one token plus four scaffolding comments" 5 0
 assert_eq       "leftover scaffolding fails the gate" "1" "$RC"
 
 echo "== check 3: internal references are WARNINGS =="
 lint "$(fixture refs)"
-assert_contains "flags a backwards direction"  "[ref-direction]" "$OUT"
-assert_contains "names the heading and its real side" 'that heading is above' "$OUT"
-assert_contains "flags a reference naming no heading" "[ref-dangling]" "$OUT"
+assert_contains "flags a backwards direction as a WARN" "WARN  says \"scoring rubric\" below" "$OUT"
+assert_contains "names the heading and its real side" 'that heading is above (line 8)' "$OUT"
+assert_contains "flags a reference naming no heading" "WARN  reference to \"instrument menu\" above" "$OUT"
+assert_contains "matches a heading through its parenthetical" \
+  'says "readiness rubric" above, but that heading is below' "$OUT"
+assert_tally    "three reference warnings, no errors" 0 3
 assert_eq       "warnings alone do not fail the gate" "0" "$RC"
 
 echo "== check 4: an announced count that disagrees with the list is a WARNING =="
 lint "$(fixture listcount)"
-assert_contains "flags three-announced/four-listed" "[list-count]" "$OUT"
-assert_contains "reports both numbers"              'announces "three" (3) but 4 list item' "$OUT"
+assert_contains "reports both numbers, as a WARN" \
+  'WARN  lead-in announces "three" (3) but 4 list item' "$OUT"
+assert_tally    "one list-count warning" 0 1
 assert_eq       "warnings alone do not fail the gate" "0" "$RC"
 
 echo "== check 5: frontmatter sanity is a WARNING, and SKILL.md-only =="
 lint "$(fixture wrongname)"
 assert_contains "flags name: disagreeing with the directory" \
-  'name: is "some-other-name" but the directory says "wrongname"' "$OUT"
+  'WARN  name: is "some-other-name" but the directory says "wrongname"' "$OUT"
+assert_tally "one frontmatter warning" 0 1
 lint "$(fixture nodesc)"
-assert_contains "flags an empty folded description:" "description: is empty" "$OUT"
+assert_contains "flags an empty folded description:" "WARN  description: is empty" "$OUT"
+assert_tally "one frontmatter warning" 0 1
 lint "$(fixture reference-doc)"
 assert_not_contains "a non-SKILL.md file is not checked for frontmatter" "[frontmatter]" "$OUT"
-assert_eq "a reference file with a matching count is clean" "0" "$RC"
+# This fixture is also the positive case for check 4: "Three moves:" over three
+# items must produce NO warning. Asserting RC alone would not see a warning.
+assert_tally "a matching announced count produces no finding" 0 0
+assert_eq    "and the file passes" "0" "$RC"
 
 echo "== the nested-skill name rule: name: carries the parent prefix =="
 lint "$(fixture parent/child)"
-assert_not_contains "parent/child SKILL.md is not a name mismatch" "[frontmatter]" "$OUT"
-assert_eq "nested skill lints clean" "0" "$RC"
+assert_tally "parent/child SKILL.md is not a name mismatch" 0 0
+assert_eq    "nested skill lints clean" "0" "$RC"
+
+echo "== an unbalanced code fence must not silence the rest of the file =="
+# The silencer: every line after an unclosed fence used to be blanked, so both
+# ERROR checks were defeated by one missing backtick line and the file reported
+# 0 errors, exit 0.
+lint "$(fixture unclosed-fence)"
+assert_contains "reports the unbalanced fence itself" \
+  "ERROR odd number of code-fence delimiters" "$OUT"
+assert_contains "still sees the conflict markers past the fence" \
+  "ERROR unresolved merge conflict marker <<<<<<<" "$OUT"
+assert_contains "still sees the token past the fence" \
+  "ERROR unfilled template token {{UNFILLED}}" "$OUT"
+assert_contains "still sees the scaffolding past the fence" \
+  "ERROR template scaffolding comment left in output" "$OUT"
+assert_tally "fence + 3 markers + token + scaffolding" 6 0
+assert_eq    "an unbalanced fence fails the gate" "1" "$RC"
+
+echo "== unterminated frontmatter must not swallow the body =="
+lint "$(fixture openfm)"
+assert_contains "diagnoses the frontmatter itself" \
+  "WARN  frontmatter contains a line that is not YAML" "$OUT"
+assert_contains "still sees the token inside the swallowed span" \
+  "ERROR unfilled template token {{UNFILLED}}" "$OUT"
+assert_tally "token + scaffolding as errors, frontmatter as a warning" 2 1
+assert_eq    "and the file fails the gate" "1" "$RC"
+
+lint "$(fixture nofmclose)"
+assert_contains "a frontmatter that never closes is bounded, not run to EOF" \
+  "WARN  frontmatter opens with --- but never closes within the first 40 lines" "$OUT"
+assert_tally "unterminated plus the resulting missing-frontmatter warning" 0 2
+
+echo "== frontmatter is structured data, so check 2 reads it =="
+# {{DESCRIPTION}} is not empty, so the frontmatter check alone passes it — and
+# description: is the field the skill loader matches a skill on.
+lint "$(fixture fmtoken)"
+assert_contains "an unfilled token in description: is an ERROR" \
+  "ERROR unfilled template token {{DESCRIPTION}}" "$OUT"
+assert_tally "exactly that one error" 1 0
+assert_eq    "and it fails the gate" "1" "$RC"
 
 echo "== the clean fixture: documenting markers is not using them =="
 # This is the regression that decides whether the linter is usable at all.
 # ir:exec/SKILL.md mentions {{TOKEN}}, REPEAT: and OPTIONAL: a dozen times in
 # backticks; a linter that reads the raw bytes hard-fails the repo on day one.
 lint "$(fixture good)"
-assert_eq       "the good fixture produces no findings" "0" "$RC"
-assert_contains "and reports zero of each" "0 error(s), 0 warning(s)" "$OUT"
+assert_tally "the good fixture produces no findings" 0 0
+assert_eq    "and passes" "0" "$RC"
 
 echo "== --strict promotes warnings to failures =="
 # The documented path to hardening checks 3-5 once their noise floor is known.
@@ -127,18 +206,37 @@ assert_eq "--strict turns a warning into a non-zero exit" "1" "$RC"
 lint --strict "$(fixture good)"
 assert_eq "--strict still passes a clean file" "0" "$RC"
 
-echo "== a missing file is an error, not a silent pass =="
+echo "== a file the linter cannot read is a failure, not a clean file =="
 lint "$FIXTURES/does-not-exist/SKILL.md"
-assert_eq "a path that does not exist fails" "1" "$RC"
+assert_contains "a path that does not exist is named" "no such file" "$OUT"
+assert_eq       "and fails" "1" "$RC"
+# awk's exit status used to be discarded by process substitution, so an awk
+# that could not read the file — or that rejected a construct in the program —
+# produced zero findings and the file was tallied clean. Root can read a 000
+# file, so skip the assertion there rather than assert something untrue.
+if [[ "$(id -u)" != "0" ]]; then
+  UNREADABLE="$(mktemp -d)/SKILL.md"
+  cp "$(fixture conflict)" "$UNREADABLE" && chmod 000 "$UNREADABLE"
+  lint "$UNREADABLE"
+  assert_contains "an awk failure is surfaced, not swallowed" "awk failed on" "$OUT"
+  assert_eq       "and counts as an error" "1" "$RC"
+  chmod 644 "$UNREADABLE"; rm -rf "$(dirname "$UNREADABLE")"
+else
+  echo "  SKIP: running as root, a 000-mode file is still readable"
+fi
 
 echo "== the default file set: the glob and the preflight gate must agree =="
 # With no arguments the linter walks .claude/skills/. An empty walk would make
 # the gate green while reading nothing — the exact failure #1209 is about — so
-# the script exits 2 there rather than 0, and this pins that the real tree is
-# discovered.
+# the script exits 2 there rather than 0.
 lint
 assert_eq "the repo's own skill corpus has zero ERRORS" "0" "$RC"
-assert_not_contains "no file in .claude/skills/ is left unread" "0 file(s)" "$OUT"
+found=$(sed -n 's/^skill-lint: \([0-9][0-9]*\) file(s).*/\1/p' <<<"$OUT")
+if [[ -n "$found" && "$found" -ge 10 ]]; then
+  pass "the walk found the real corpus ($found files)"
+else
+  fail "the walk found the real corpus" ">= 10 files" "${found:-<no summary line>}"
+fi
 
 echo ""
 if [[ "$fails" -eq 0 ]]; then

--- a/tools/lib/skill-lint_test.sh
+++ b/tools/lib/skill-lint_test.sh
@@ -86,11 +86,10 @@ lint() {
   return 0
 }
 
-# fixture <name> — the single .md file of a fixture skill directory.
-fixture() {
-  local d="$FIXTURES/$1"
-  if [[ -f "$d/SKILL.md" ]]; then echo "$d/SKILL.md"; else echo "$d/reference.md"; fi
-}
+# fixture <name> — the SKILL.md of a fixture skill directory. The one fixture
+# that is deliberately NOT a SKILL.md is spelled out at its call site, where
+# that is the whole point of the assertion.
+fixture() { echo "$FIXTURES/$1/SKILL.md"; }
 
 # assert_tally <label> <errors> <warnings> — pin the summary line, so no
 # individual sub-check can change severity unnoticed.
@@ -140,7 +139,7 @@ assert_tally "one frontmatter warning" 0 1
 lint "$(fixture nodesc)"
 assert_contains "flags an empty folded description:" "WARN  description: is empty" "$OUT"
 assert_tally "one frontmatter warning" 0 1
-lint "$(fixture reference-doc)"
+lint "$FIXTURES/reference-doc/reference.md"
 assert_not_contains "a non-SKILL.md file is not checked for frontmatter" "[frontmatter]" "$OUT"
 # This fixture is also the positive case for check 4: "Three moves:" over three
 # items must produce NO warning. Asserting RC alone would not see a warning.
@@ -226,16 +225,43 @@ else
 fi
 
 echo "== the default file set: the glob and the preflight gate must agree =="
-# With no arguments the linter walks .claude/skills/. An empty walk would make
-# the gate green while reading nothing — the exact failure #1209 is about — so
-# the script exits 2 there rather than 0.
+# With no arguments the linter walks the repo's skill files. An empty walk
+# would make the gate green while reading nothing — the exact failure #1209 is
+# about — so the script exits 2 there rather than 0.
+#
+# Only the SIZE of the walk is asserted, not its verdict. Whether the real
+# corpus is clean is the gate's job (preflight's `skill-file lint` and
+# test.yml's "Lint skill files"), and asserting it here too would report a
+# defect in a real skill file as a unit-test failure of the linter — the worst
+# of the three places to see it — while contradicting this file's own rule that
+# assertions run against fixtures so they do not move when a skill is edited.
 lint
-assert_eq "the repo's own skill corpus has zero ERRORS" "0" "$RC"
 found=$(sed -n 's/^skill-lint: \([0-9][0-9]*\) file(s).*/\1/p' <<<"$OUT")
 if [[ -n "$found" && "$found" -ge 10 ]]; then
   pass "the walk found the real corpus ($found files)"
 else
   fail "the walk found the real corpus" ">= 10 files" "${found:-<no summary line>}"
+fi
+
+echo "== the template's marker vocabulary and the linter's must not drift =="
+# ir:exec's plan.html is where {{TOKEN}} and REPEAT:/OPTIONAL: come from, and it
+# is deliberately NOT linted (it carries dozens of each by construction, and the
+# markdown machinery is meaningless in HTML). That leaves the spelling defined
+# in two unconnected places: rename the convention in the template and check 2
+# silently stops detecting leftovers, with every fixture still green because the
+# fixtures embed the old spelling too. Pointing the linter at the template makes
+# it the vocabulary's fixture instead of a second definition.
+TEMPLATE="$ROOT/.claude/skills/ir:exec/templates/plan.html"
+if [[ -f "$TEMPLATE" ]]; then
+  # The template is HTML, so lint it as a one-off file argument (the walk never
+  # picks it up). Every token and marker it contains must be one check 2 knows.
+  lint "$TEMPLATE"
+  assert_contains "the linter recognises the template's {{TOKEN}} spelling" \
+    "[template-token]" "$OUT"
+  assert_contains "the linter recognises the template's REPEAT:/OPTIONAL: spelling" \
+    "[template-scaffold]" "$OUT"
+else
+  echo "  SKIP: $TEMPLATE not found — ir:exec template moved or removed"
 fi
 
 echo ""

--- a/tools/lib/testdata/skill-lint/skills/fmtoken/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/fmtoken/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: fmtoken
+description: {{DESCRIPTION}}
+---
+
+# Frontmatter-token fixture
+
+The frontmatter is well-formed, but `description:` — the field the skill
+loader matches on — still carries its template token. It is not empty, so
+the frontmatter check alone would pass it.

--- a/tools/lib/testdata/skill-lint/skills/good/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/good/SKILL.md
@@ -21,7 +21,7 @@ Two flavors:
   - nested c
 - the second
 
-## Tier table
+## Tier table (three tiers)
 
 Documenting a template must not read as using one: replace every `{{TOKEN}}`,
 duplicate each `REPEAT:step` region, and delete any unused `OPTIONAL:ui` block.

--- a/tools/lib/testdata/skill-lint/skills/nofmclose/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/nofmclose/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: nofmclose
+description: Fixture for the frontmatter bound — this file opens frontmatter and never closes it anywhere.
+
+# No-close fixture
+
+There is no second `---` in this file at all, so the scan has to give up at
+its bound rather than run to EOF treating the whole file as frontmatter.

--- a/tools/lib/testdata/skill-lint/skills/openfm/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/openfm/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: openfm
+description: Fixture for unterminated frontmatter — the closing --- is missing.
+
+# Open-frontmatter fixture
+
+Without a bound, the closing delimiter binds to the thematic break further
+down and swallows everything in between, including this:
+
+{{UNFILLED}}
+
+<!-- REPEAT:step -->
+
+---
+
+Body after the thematic rule.

--- a/tools/lib/testdata/skill-lint/skills/refs/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/refs/SKILL.md
@@ -16,3 +16,10 @@ issue #1209 describes: the table forward-references a section the reader has
 already passed.
 
 See the "Instrument menu" section above for the cheapest surface.
+
+The **Readiness rubric** above scores it — but that heading carries a
+parenthetical, and is below, so matching only verbatim would miss this.
+
+## Readiness rubric (7 axes)
+
+The rubric body.

--- a/tools/lib/testdata/skill-lint/skills/unclosed-fence/SKILL.md
+++ b/tools/lib/testdata/skill-lint/skills/unclosed-fence/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: unclosed-fence
+description: Fixture for the silencer — one missing closing fence must not hide the rest of the file.
+---
+
+# Unclosed fence fixture
+
+```bash
+echo "this block is never closed"
+
+Everything below here used to be blanked out and read by nothing:
+
+<<<<<<< HEAD
+one side
+=======
+the other side
+>>>>>>> other
+
+{{UNFILLED}}
+
+<!-- REPEAT:step -->

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -82,6 +82,24 @@ while [[ $# -gt 0 ]]; do
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
+# An unrecognised --only value used to select no group at all: every `want`
+# returned false, no gate ran, the summary printed empty and the script exited
+# 0. `tools/preflight.sh --only skils` was a fully green run that checked
+# nothing — the same silent-pass shape #1209 is about, reachable by one typo,
+# in the harness that hosts the gate for it.
+# Not `GROUPS` — that is a bash built-in holding the caller's supplementary
+# group IDs, and assigning to it silently does nothing, so the check would
+# compare against a list of numeric gids and reject every real group name.
+VALID_GROUPS=(go web arch tools skills security linux)
+if [[ -n "$ONLY" ]]; then
+  known=0
+  for g in "${VALID_GROUPS[@]}"; do [[ "$ONLY" == "$g" ]] && known=1; done
+  if [[ "$known" != 1 ]]; then
+    echo "unknown --only group: $ONLY (valid: ${VALID_GROUPS[*]})" >&2
+    exit 2
+  fi
+fi
+
 [[ "$ONLY" == "linux" ]] && RUN_LINUX=1
 
 want() {
@@ -261,13 +279,15 @@ if want tools; then
 fi
 
 # ---- skills group (mirrors test.yml's "Lint skill files" step) ------------
-# Scoped to the skill markdown itself plus the linter, so editing a check
-# re-lints the corpus it governs. The whole corpus is linted whenever the gate
-# fires rather than just the changed files: it is 22 small files and a fraction
-# of a second, and a finding that a *neighbouring* file already carries is
-# worth surfacing on the push that finally reads it.
+# Scoped to skill markdown plus the linter, so editing a check re-lints the
+# corpus it governs. `SKILL.md` matches at any path because skills are not all
+# under .claude/skills/ — tools/irrlicht-design-system/ holds one. The whole
+# corpus is linted whenever the gate fires rather than just the changed files:
+# it is ~23 small files and a fraction of a second, and a finding a
+# *neighbouring* file already carries is worth surfacing on the push that
+# finally reads it.
 if want skills; then
-  run_gate_scoped '^\.claude/skills/.*\.md$|^tools/skill-lint\.sh$' \
+  run_gate_scoped '^\.claude/skills/.*\.md$|(^|/)SKILL\.md$|^tools/skill-lint\.sh$' \
                   "skill-file lint" tools/skill-lint.sh
 fi
 
@@ -305,6 +325,12 @@ echo
 echo "$SEPARATOR"
 echo "  summary"
 echo "$SEPARATOR"
+if [[ ${#NAMES[@]} -eq 0 ]]; then
+  # Belt to the --only braces above: a run that recorded no gate at all is not
+  # a pass, whatever selected it down to nothing.
+  echo "  (no gates ran — refusing to report a green run that checked nothing)"
+  exit 2
+fi
 for i in "${!NAMES[@]}"; do
   printf "  %-58s %s\n" "${NAMES[$i]}" "${RESULTS[$i]}"
 done

--- a/tools/skill-lint.sh
+++ b/tools/skill-lint.sh
@@ -13,11 +13,13 @@
 #   1. conflict-marker    ERROR  unresolved <<<<<<< / ======= / >>>>>>> / |||||||
 #   2. template-token     ERROR  {{TOKEN}} left unfilled
 #      template-scaffold  ERROR  <!-- REPEAT:x --> / <!-- OPTIONAL:x --> left in
+#      unbalanced-fence   ERROR  an odd number of ``` / ~~~ delimiters
 #   3. ref-direction      WARN   "X above" where heading X is below (or vice versa)
 #      ref-dangling       WARN   a delimited "X above/below" naming no heading
 #   4. list-count         WARN   "Three moves:" followed by a list of four
 #   5. frontmatter        WARN   SKILL.md name: disagrees with its directory,
-#                                or description: missing/empty
+#                                description: missing/empty, or the block never
+#                                closes / holds something that is not YAML
 #
 # Checks 1–2 are unambiguous, so they fail the gate. 3–5 are heuristics with a
 # real false-positive rate and only warn; `--strict` promotes them to failures,
@@ -30,11 +32,22 @@
 # `.claude/skills/ir:exec/SKILL.md` documents the plan.html template and so
 # mentions `{{TOKEN}}`, `REPEAT:step` and `OPTIONAL:ui` a dozen times — always
 # inside backticks. So checks 2 and 4 read a prose view of each file with
-# fenced code blocks, inline code spans and YAML frontmatter blanked out.
-# Check 3 keeps inline code (a reference can legitimately be written
-# `` `Auto mode` below ``) and check 1 reads raw lines outside fences, because
-# a conflict marker inside a fence is illustrative but anywhere else is a
-# corrupted file.
+# fenced code blocks and inline code spans blanked out. Check 3 keeps inline
+# code (a reference can legitimately be written `` `Auto mode` below ``) and
+# check 1 reads raw lines outside fences, because a conflict marker inside a
+# fence is illustrative but anywhere else is a corrupted file. Frontmatter is
+# structured data, never prose that documents a marker, so check 2 reads it —
+# an unfilled {{TOKEN}} in `description:` is what the skill loader matches on
+# — while checks 3 and 4 skip it, since a description legitimately contains
+# quoted phrases and counted lead-ins.
+#
+# Blanking is the whole mechanism, which makes an unbalanced delimiter a
+# silencer: every blanked line is a line no check reads, so one missing closing
+# fence used to hide the entire rest of the file, and an unterminated
+# frontmatter used to swallow however much of the body sat above the next `---`.
+# Both are therefore detected first, reported, and then not allowed to blank
+# anything — a corrupted skill file reporting 0 errors is the exact failure
+# this script exists to remove.
 #
 # Known limits (deliberate, not oversights)
 # ----------------------------------------
@@ -43,8 +56,10 @@
 #   two markers and so passes. Counting what a reader would call an item is a
 #   judgement call; counting markers is not.
 # * Check 3 only recognises a reference when the name is delimited
-#   (`"X"`, `` `X` ``, `**X**`) or matches a heading verbatim. "see the rule
-#   above" names nothing checkable and is ignored by design.
+#   (`"X"`, `` `X` ``, `**X**`) or matches a heading — verbatim, or up to a
+#   trailing parenthetical, so "Readiness Rubric" finds
+#   `## Readiness Rubric (7 axes)`. "see the rule above" names nothing
+#   checkable and is ignored by design.
 # * Setext headings (underlined with === or ---) are not indexed as headings;
 #   every heading in this repo's skill files is ATX (#).
 #
@@ -146,44 +161,90 @@ function phrase_at(hay, needle, pos,   before, after) {
 { n++; raw[n] = $0 }
 
 END {
-  # ---- build the three views ---------------------------------------------
+  # ---- build the views ----------------------------------------------------
   # raw[]   verbatim, for conflict markers
   # text[]  fences + frontmatter blanked, inline code KEPT   (checks 3, 4)
-  # prose[] text[] with inline code spans blanked too        (check 2)
-  fm_end = 0
+  # prose[] text[] with inline code spans blanked too, but frontmatter KEPT
+  #                                                          (check 2)
+  #
+  # Blanking is how the linter tells "documents a marker" from "has one", and
+  # every line it blanks is a line no check reads. That makes an unbalanced
+  # delimiter a silencer: one missing closing fence, or a frontmatter that
+  # never closes, and the rest of the file passes unread — a corrupted skill
+  # file linting 0/0, which is the exact failure #1209 is about. So both are
+  # detected up front, reported, and then NOT allowed to blank anything.
+
+  # Frontmatter must close within FM_MAX lines. Unbounded, the closing `---`
+  # binds to the first thematic break in the body — arbitrarily far down —
+  # and swallows everything in between. The longest real one in this repo is
+  # a folded description of ~10 lines.
+  FM_MAX = 40
+  fm_end = 0; fm_unterminated = 0
   if (n >= 1 && raw[1] ~ /^---[ \t\r]*$/) {
-    for (i = 2; i <= n; i++)
+    for (i = 2; i <= n && i <= FM_MAX; i++)
       if (raw[i] ~ /^---[ \t\r]*$/) { fm_end = i; break }
+    if (fm_end == 0) fm_unterminated = 1
   }
+
+  # Fence balance, decided before any blanking. An odd number of delimiters
+  # means the file's own view of what is code is untrustworthy, so treat none
+  # of it as fenced and let every check read the whole file.
+  fences = 0
+  for (i = 1; i <= n; i++)
+    if (raw[i] ~ /^[ \t]*(```|~~~)/) fences++
+  fence_broken = (fences % 2)
 
   fence = 0
   for (i = 1; i <= n; i++) {
     line = raw[i]
     sub(/\r$/, "", line)
 
-    if (line ~ /^[ \t]*(```|~~~)/) {
+    if (!fence_broken && line ~ /^[ \t]*(```|~~~)/) {
       infence[i] = 1          # the delimiter itself is never prose
       fence = !fence
       text[i] = ""; prose[i] = ""
       continue
     }
     infence[i] = fence
-    if (fence || (fm_end > 0 && i <= fm_end)) { text[i] = ""; prose[i] = ""; continue }
 
-    text[i] = line
     p = line
     gsub(/`[^`]*`/, " ", p)
+
+    if (fence) { text[i] = ""; prose[i] = ""; continue }
+    if (fm_end > 0 && i <= fm_end) {
+      # Frontmatter is structured data, never prose that *documents* a marker,
+      # so check 2 reads it — an unfilled {{TOKEN}} in `description:` is what
+      # the skill loader matches on. Checks 3 and 4 still skip it: a
+      # description legitimately contains quoted phrases and counted lead-ins.
+      text[i] = ""; prose[i] = p
+      continue
+    }
+
+    text[i] = line
     prose[i] = p
 
-    if (line ~ /^#{1,6}[ \t]+/) {
+    # `#+` rather than `#{1,6}`: ERE interval expressions are not supported by
+    # every awk this may run on, and an awk that silently matches no heading
+    # would leave check 3a dead and check 3b flagging every reference.
+    if (line ~ /^#+[ \t]+/) {
       h = line
       sub(/^#+[ \t]+/, "", h)
       sub(/[ \t]+#+[ \t]*$/, "", h)
       nh++
       hline[nh] = i
       htext[nh] = normalize(h)
+      # A second searchable form without a trailing parenthetical, so prose
+      # referring to "Readiness Rubric" finds `## Readiness Rubric (7 axes)`.
+      hshort[nh] = htext[nh]
+      sub(/[ \t]*\(.*$/, "", hshort[nh])
+      if (hshort[nh] == "" || hshort[nh] == htext[nh]) hshort[nh] = ""
     }
   }
+
+  if (fence_broken)
+    err(1, "unbalanced-fence", "odd number of code-fence delimiters — the file's code blocks cannot be identified, so nothing was treated as fenced")
+  if (fm_unterminated)
+    warn(1, "frontmatter", "frontmatter opens with --- but never closes within the first " FM_MAX " lines")
 
   # ---- 1. unresolved conflict markers (ERROR) -----------------------------
   open_conflict = 0
@@ -195,7 +256,7 @@ END {
     } else if (raw[i] ~ /^>>>>>>>([ \t]|$)/) {
       err(i, "conflict-marker", "unresolved merge conflict marker >>>>>>>")
       open_conflict = 0
-    } else if (open_conflict && raw[i] ~ /^=======[ \t]*$/) {
+    } else if (open_conflict && raw[i] ~ /^=======[ \t\r]*$/) {
       # Only inside an open conflict: a bare row of = is also a setext H2
       # underline, and flagging those would be a false positive on real prose.
       err(i, "conflict-marker", "unresolved merge conflict marker =======")
@@ -223,11 +284,18 @@ END {
     lp = normalize(text[i])
     for (j = 1; j <= nh; j++) {
       if (hline[j] == i) continue
-      if (length(htext[j]) < 4) continue
-      pos = index(lp, htext[j])
-      if (pos == 0) continue
-      if (!phrase_at(lp, htext[j], pos)) continue
-      tail = substr(lp, pos + length(htext[j]), 40)
+      # Try the full heading, then the form without its trailing parenthetical
+      # — `## Readiness Rubric (7 axes)` is referred to as "Readiness Rubric",
+      # and matching only verbatim leaves a wrong direction on this repo's most
+      # common heading shape invisible.
+      hname = htext[j]
+      if (length(hname) >= 4 && index(lp, hname) > 0 && phrase_at(lp, hname, index(lp, hname))) {
+        pos = index(lp, hname)
+      } else if (hshort[j] != "" && length(hshort[j]) >= 4 && index(lp, hshort[j]) > 0 && phrase_at(lp, hshort[j], index(lp, hshort[j]))) {
+        hname = hshort[j]
+        pos = index(lp, hname)
+      } else continue
+      tail = substr(lp, pos + length(hname), 40)
       # The direction word has to follow the name directly — at most one
       # structural noun and a comma in between. Anything looser binds a stray
       # "below" to whatever heading-shaped word happened to appear earlier in
@@ -240,7 +308,7 @@ END {
       said = (substr(tail, RSTART, RLENGTH) ~ /above/) ? "above" : "below"
       actual = (hline[j] < i) ? "above" : "below"
       if (said != actual)
-        warn(i, "ref-direction", "says \"" htext[j] "\" " said ", but that heading is " actual " (line " hline[j] ")")
+        warn(i, "ref-direction", "says \"" hname "\" " said ", but that heading is " actual " (line " hline[j] ")")
     }
   }
 
@@ -263,8 +331,10 @@ END {
       name = normalize(name)
       if (name == "") continue
       found = 0
+      # hshort[] too, so `**Readiness Rubric** below` is not called dangling
+      # when the heading is `## Readiness Rubric (7 axes)`.
       for (j = 1; j <= nh; j++)
-        if (htext[j] == name) { found = 1; break }
+        if (htext[j] == name || hshort[j] == name) { found = 1; break }
       if (!found)
         warn(i, "ref-dangling", "reference to \"" name "\" " (m ~ /above([^A-Za-z]|$)$/ ? "above" : "below") " names no heading in this file")
     }
@@ -295,14 +365,14 @@ END {
     if (want == 0) continue
 
     j = i + 1
-    while (j <= n && raw[j] ~ /^[ \t]*$/) j++
+    while (j <= n && raw[j] ~ /^[ \t\r]*$/) j++
     if (j > n || infence[j] || !is_list_marker(raw[j])) continue
 
     base = indent_of(raw[j])
     got = 1
     blanks = 0
     for (k = j + 1; k <= n; k++) {
-      if (raw[k] ~ /^[ \t]*$/) { blanks++; if (blanks >= 2) break; continue }
+      if (raw[k] ~ /^[ \t\r]*$/) { blanks++; if (blanks >= 2) break; continue }
       ind = indent_of(raw[k])
       if (ind > base) { blanks = 0; continue }           # continuation or nested
       if (ind == base && is_list_marker(raw[k])) { got++; blanks = 0; continue }
@@ -332,6 +402,19 @@ END {
           gsub(/^[ \t\r]+|[ \t\r]+$/, "", desc_value)
         }
       }
+      # A frontmatter span containing prose is a frontmatter whose closing ---
+      # went missing and bound to a thematic break further down: the span then
+      # covers body text, and everything in it is read as YAML. Checks 3 and 4
+      # skip that span, so without this the only symptom is silence. A line is
+      # not YAML when it is unindented (not a continuation), not a `key:`, not
+      # a `- ` item, and not a `#` comment.
+      for (i = 2; i < fm_end; i++) {
+        if (raw[i] ~ /^[ \t\r]*$/ || raw[i] ~ /^[ \t#]/ || raw[i] ~ /^-[ \t]/) continue
+        if (raw[i] ~ /^[A-Za-z_][A-Za-z0-9_.-]*:/) continue
+        warn(i, "frontmatter", "frontmatter contains a line that is not YAML — the closing --- is probably missing")
+        break
+      }
+
       if (namelines == 0)
         warn(1, "frontmatter", "frontmatter has no name: key")
       else if (expected_name != "" && gotname != expected_name)
@@ -360,6 +443,9 @@ if [[ -t 1 ]]; then RED=$'\033[31m'; YELLOW=$'\033[33m'; BOLD=$'\033[1m'; RESET=
 
 errors=0
 warnings=0
+FINDINGS="$(mktemp)"
+trap 'rm -f "$FINDINGS"' EXIT
+
 for f in "${FILES[@]}"; do
   if [[ ! -f "$f" ]]; then
     echo "skill-lint: no such file: $f" >&2
@@ -372,16 +458,31 @@ for f in "${FILES[@]}"; do
     is_skill_md=1
     expected="$(expected_skill_name "$f")"
   fi
+  # Via a temp file, not process substitution: `done < <(awk …)` discards
+  # awk's exit status, so an awk that cannot read the file — or that rejects
+  # a construct in the program — yields zero lines and the file is tallied as
+  # clean. That would turn any awk incompatibility into a silently green gate,
+  # which is the failure mode this whole script exists to remove.
+  if ! awk -v is_skill_md="$is_skill_md" -v expected_name="$expected" "$LINT_AWK" "$f" >"$FINDINGS"; then
+    echo "skill-lint: awk failed on $f — treating as a failure, not a clean file" >&2
+    errors=$((errors + 1))
+    continue
+  fi
   while IFS=$'\t' read -r sev line check msg; do
     [[ -z "$sev" ]] && continue
     if [[ "$sev" == "ERROR" ]]; then
       errors=$((errors + 1))
-      printf '%s%s:%s:%s %s [%s]\n' "$RED" "$f" "$line" "$RESET" "$msg" "$check"
+      color="$RED"
     else
       warnings=$((warnings + 1))
-      printf '%s%s:%s:%s %s [%s]\n' "$YELLOW" "$f" "$line" "$RESET" "$msg" "$check"
+      color="$YELLOW"
     fi
-  done < <(awk -v is_skill_md="$is_skill_md" -v expected_name="$expected" "$LINT_AWK" "$f")
+    # The severity is printed as a word, not encoded in the color: colors are
+    # suppressed whenever stdout is not a TTY, which is exactly the case in a
+    # GitHub Actions log — where a developer looking at a failed gate most
+    # needs to tell the blocking lines from the advisory ones.
+    printf '%s%s:%s:%s %-5s %s [%s]\n' "$color" "$f" "$line" "$RESET" "$sev" "$msg" "$check"
+  done <"$FINDINGS"
 done
 
 printf '\n%sskill-lint:%s %d file(s), %d error(s), %d warning(s)\n' \

--- a/tools/skill-lint.sh
+++ b/tools/skill-lint.sh
@@ -31,21 +31,21 @@
 # Markdown that *talks about* markers is not markdown that *has* them.
 # `.claude/skills/ir:exec/SKILL.md` documents the plan.html template and so
 # mentions `{{TOKEN}}`, `REPEAT:step` and `OPTIONAL:ui` a dozen times — always
-# inside backticks. So checks 2 and 4 read a prose view of each file with
-# fenced code blocks and inline code spans blanked out. Check 3 keeps inline
-# code (a reference can legitimately be written `` `Auto mode` below ``) and
-# check 1 reads raw lines outside fences, because a conflict marker inside a
-# fence is illustrative but anywhere else is a corrupted file. Frontmatter is
+# inside backticks. So checks 2 and 4 skip fenced blocks and blank inline code
+# spans. Check 3 keeps inline code (a reference can legitimately be written
+# `` `Auto mode` below ``) and check 1 reads raw lines outside fences, because
+# a conflict marker inside a fence is illustrative but anywhere else is a
+# corrupted file. Frontmatter is
 # structured data, never prose that documents a marker, so check 2 reads it —
 # an unfilled {{TOKEN}} in `description:` is what the skill loader matches on
 # — while checks 3 and 4 skip it, since a description legitimately contains
 # quoted phrases and counted lead-ins.
 #
-# Blanking is the whole mechanism, which makes an unbalanced delimiter a
-# silencer: every blanked line is a line no check reads, so one missing closing
+# Skipping is the whole mechanism, which makes an unbalanced delimiter a
+# silencer: every skipped line is a line no check reads, so one missing closing
 # fence used to hide the entire rest of the file, and an unterminated
 # frontmatter used to swallow however much of the body sat above the next `---`.
-# Both are therefore detected first, reported, and then not allowed to blank
+# Both are therefore detected first, reported, and then not allowed to suppress
 # anything — a corrupted skill file reporting 0 errors is the exact failure
 # this script exists to remove.
 #
@@ -57,14 +57,19 @@
 #   judgement call; counting markers is not.
 # * Check 3 only recognises a reference when the name is delimited
 #   (`"X"`, `` `X` ``, `**X**`) or matches a heading — verbatim, or up to a
-#   trailing parenthetical, so "Readiness Rubric" finds
-#   `## Readiness Rubric (7 axes)`. "see the rule above" names nothing
-#   checkable and is ignored by design.
+#   subtitle separator, so "Readiness Rubric" finds
+#   `## Readiness Rubric (7 axes)` and "Phase 1" finds `## Phase 1 — Worktree`.
+#   "see the rule above" names nothing checkable and is ignored by design.
 # * Setext headings (underlined with === or ---) are not indexed as headings;
 #   every heading in this repo's skill files is ATX (#).
 #
+# Scope: every `.md` under `.claude/skills/`, plus any other tracked `SKILL.md`
+# in the repo (`tools/irrlicht-design-system/SKILL.md` is one — a real skill
+# that lived outside every gate). `testdata/` is excluded: the fixture corpus is
+# deliberately broken and is driven by the unit test, not by the gate.
+#
 # Usage:
-#   tools/skill-lint.sh                  # lint every .claude/skills/**/*.md
+#   tools/skill-lint.sh                  # lint every skill markdown file
 #   tools/skill-lint.sh --strict         # warnings fail too
 #   tools/skill-lint.sh FILE...          # lint just these files (used by tests)
 #   tools/skill-lint.sh --strict FILE...
@@ -73,7 +78,8 @@
 # the nearest `skills/` ancestor — `ir:exec`, or `ir:onboarding-factory/assess`
 # for a nested one. Deriving it from the path rather than a hard-coded list is
 # what lets the fixture corpus under tools/lib/testdata/ exercise check 5
-# without living in .claude/skills/.
+# without living in .claude/skills/, and what lets a skill outside
+# `.claude/skills/` be linted with the name check simply switched off.
 set -uo pipefail
 
 STRICT=0
@@ -90,14 +96,25 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 if [[ ${#FILES[@]} -eq 0 ]]; then
   cd "$ROOT_DIR" || exit 2
+  # Two roots, not one: `.claude/skills/` is where skills normally live, but a
+  # SKILL.md anywhere else is still a skill by every definition these checks
+  # use, and scoping to one directory left `tools/irrlicht-design-system/`
+  # outside every gate. `testdata/` is excluded because the fixture corpus is
+  # deliberately corrupt — the unit test drives it, the gate must not.
+  #
+  # The index rather than `find`: `find .` would descend into
+  # `.claude/worktrees/`, which holds entire checkouts of this repo, and lint
+  # every other branch's skill files as if they were this one's. Staged files
+  # are index entries, so a newly added skill is covered on the push that adds
+  # it.
   while IFS= read -r f; do
+    [[ "$f" == */testdata/* ]] && continue
     FILES+=("$f")
-  done < <(find .claude/skills -name '*.md' -type f | LC_ALL=C sort)
+  done < <(git ls-files -- '.claude/skills/*.md' '*/SKILL.md' 'SKILL.md' | LC_ALL=C sort -u)
 fi
 
 if [[ ${#FILES[@]} -eq 0 ]]; then
@@ -112,8 +129,7 @@ fi
 # when the path has no `skills/` ancestor, which turns the name comparison off
 # rather than inventing an expectation.
 expected_skill_name() {
-  local path="$1" dir
-  dir="$(dirname "$path")"
+  local dir="${1%/*}"
   case "$dir" in
     */skills/*) echo "${dir##*/skills/}" ;;
     *) echo "" ;;
@@ -141,6 +157,16 @@ function finding(sev, line, check, msg) {
 function err(line, check, msg)  { finding("ERROR", line, check, msg) }
 function warn(line, check, msg) { finding("WARN",  line, check, msg) }
 
+# One parser for both keys. As two near-identical blocks they had drifted:
+# `name:` trimmed trailing whitespace only, so a leading space survived into
+# the mismatch message while `description:` trimmed both ends.
+function fm_value(s, key,   v) {
+  v = s
+  sub("^" key ":[ \t]*", "", v)
+  gsub(/^["']|["'][ \t]*$/, "", v)
+  gsub(/^[ \t]+|[ \t]+$/, "", v)
+  return v
+}
 function indent_of(s,   t) {
   t = s
   sub(/[^ \t].*$/, "", t)
@@ -150,6 +176,13 @@ function indent_of(s,   t) {
 function is_list_marker(s) {
   return (s ~ /^[ \t]*([-*+]|[0-9]+[.)])[ \t]+/)
 }
+# nonprose(i) — lines no prose check may read: inside a fence, or inside the
+# frontmatter span. Checks 3 and 4 skip frontmatter because a description
+# legitimately contains quoted phrases and counted lead-ins; check 2 does NOT
+# skip it, since frontmatter is structured data that never *documents* a
+# marker, and an unfilled {{TOKEN}} in `description:` is the field the skill
+# loader matches on.
+function nonprose(i) { return (infence[i] || (fm_end > 0 && i <= fm_end)) }
 # Word-boundary containment: index() would match "modes" inside "submodes".
 function phrase_at(hay, needle, pos,   before, after) {
   before = (pos > 1) ? substr(hay, pos - 1, 1) : " "
@@ -158,21 +191,23 @@ function phrase_at(hay, needle, pos,   before, after) {
   return (before !~ /[A-Za-z0-9]/ && after !~ /[A-Za-z0-9]/)
 }
 
-{ n++; raw[n] = $0 }
+# `\r` is stripped once, here, rather than defended against in a dozen
+# regexes downstream — a per-regex `[ \t\r]` vs `[ \t]` decision that every
+# future check would have to re-make, and get silently wrong. Fence balance is
+# counted on the way past for the same reason: it needs a whole traversal, and
+# this is already one.
+{ sub(/\r$/, ""); n++; raw[n] = $0; if ($0 ~ /^[ \t]*(```|~~~)/) fences++ }
 
 END {
-  # ---- build the views ----------------------------------------------------
-  # raw[]   verbatim, for conflict markers
-  # text[]  fences + frontmatter blanked, inline code KEPT   (checks 3, 4)
-  # prose[] text[] with inline code spans blanked too, but frontmatter KEPT
-  #                                                          (check 2)
-  #
-  # Blanking is how the linter tells "documents a marker" from "has one", and
-  # every line it blanks is a line no check reads. That makes an unbalanced
-  # delimiter a silencer: one missing closing fence, or a frontmatter that
-  # never closes, and the rest of the file passes unread — a corrupted skill
-  # file linting 0/0, which is the exact failure #1209 is about. So both are
-  # detected up front, reported, and then NOT allowed to blank anything.
+  # ---- classify each line -------------------------------------------------
+  # Checks read raw[] and ask nonprose() what to skip, rather than each
+  # consulting its own blanked copy of the file. Skipping is how the linter
+  # tells "documents a marker" from "has one", and every skipped line is a line
+  # no check reads. That makes an unbalanced delimiter a silencer: one missing
+  # closing fence, or a frontmatter that never closes, and the rest of the file
+  # passes unread — a corrupted skill file linting 0/0, which is the exact
+  # failure #1209 is about. So both are detected up front, reported, and then
+  # NOT allowed to suppress anything.
 
   # Frontmatter must close within FM_MAX lines. Unbounded, the closing `---`
   # binds to the first thematic break in the body — arbitrarily far down —
@@ -180,64 +215,59 @@ END {
   # a folded description of ~10 lines.
   FM_MAX = 40
   fm_end = 0; fm_unterminated = 0
-  if (n >= 1 && raw[1] ~ /^---[ \t\r]*$/) {
+  if (n >= 1 && raw[1] ~ /^---[ \t]*$/) {
     for (i = 2; i <= n && i <= FM_MAX; i++)
-      if (raw[i] ~ /^---[ \t\r]*$/) { fm_end = i; break }
+      if (raw[i] ~ /^---[ \t]*$/) { fm_end = i; break }
     if (fm_end == 0) fm_unterminated = 1
   }
 
-  # Fence balance, decided before any blanking. An odd number of delimiters
-  # means the file's own view of what is code is untrustworthy, so treat none
-  # of it as fenced and let every check read the whole file.
-  fences = 0
-  for (i = 1; i <= n; i++)
-    if (raw[i] ~ /^[ \t]*(```|~~~)/) fences++
+  # An odd number of fence delimiters means the file's own view of what is code
+  # is untrustworthy, so treat none of it as fenced and let every check read
+  # everything. The invariant for any suppression-based linter: when the file
+  # cannot be parsed with confidence, degrade toward MORE checking, never less.
   fence_broken = (fences % 2)
 
   fence = 0
   for (i = 1; i <= n; i++) {
-    line = raw[i]
-    sub(/\r$/, "", line)
-
-    if (!fence_broken && line ~ /^[ \t]*(```|~~~)/) {
+    if (!fence_broken && raw[i] ~ /^[ \t]*(```|~~~)/) {
       infence[i] = 1          # the delimiter itself is never prose
       fence = !fence
-      text[i] = ""; prose[i] = ""
       continue
     }
     infence[i] = fence
-
-    p = line
-    gsub(/`[^`]*`/, " ", p)
-
-    if (fence) { text[i] = ""; prose[i] = ""; continue }
-    if (fm_end > 0 && i <= fm_end) {
-      # Frontmatter is structured data, never prose that *documents* a marker,
-      # so check 2 reads it — an unfilled {{TOKEN}} in `description:` is what
-      # the skill loader matches on. Checks 3 and 4 still skip it: a
-      # description legitimately contains quoted phrases and counted lead-ins.
-      text[i] = ""; prose[i] = p
-      continue
-    }
-
-    text[i] = line
-    prose[i] = p
+    if (fence) continue
 
     # `#+` rather than `#{1,6}`: ERE interval expressions are not supported by
-    # every awk this may run on, and an awk that silently matches no heading
+    # every awk this may run on, and an awk that silently matched no heading
     # would leave check 3a dead and check 3b flagging every reference.
-    if (line ~ /^#+[ \t]+/) {
-      h = line
+    if (raw[i] ~ /^#+[ \t]+/) {
+      h = raw[i]
       sub(/^#+[ \t]+/, "", h)
       sub(/[ \t]+#+[ \t]*$/, "", h)
-      nh++
-      hline[nh] = i
-      htext[nh] = normalize(h)
-      # A second searchable form without a trailing parenthetical, so prose
-      # referring to "Readiness Rubric" finds `## Readiness Rubric (7 axes)`.
-      hshort[nh] = htext[nh]
-      sub(/[ \t]*\(.*$/, "", hshort[nh])
-      if (hshort[nh] == "" || hshort[nh] == htext[nh]) hshort[nh] = ""
+      nh++; hline[nh] = i; htext[nh] = normalize(h)
+      # A subtitled heading gets a second ROW in the same table rather than a
+      # parallel column, so both forms match through one code path. Prose says
+      # "Readiness Rubric" for `## Readiness Rubric (7 axes)` and "Phase 1" for
+      # `## Phase 1 — Worktree`; the corpus has 91 of the first shape and 48 of
+      # the second, so handling only parentheses covered a third of nothing.
+      # Written as separate sub()s, not one bracket class: the dashes are
+      # multi-byte, and a byte-oriented awk would match their bytes piecemeal
+      # inside an unrelated character.
+      #
+      # Parentheses and dashes only — NOT a colon. `## Step 6: Build Artifacts`
+      # would shorten to "step 6", and ir:release's prose says "step 6" a dozen
+      # times meaning *something inside* step 6, not the heading: it produced a
+      # false "says step 6 below, but that heading is above" on the first run.
+      # A parenthetical or dashed tail is a subtitle; a colon here yields a
+      # label the body then reuses as an ordinary noun.
+      short = htext[nh]
+      sub(/[ \t]*\(.*$/, "", short)
+      sub(/[ \t]*—.*$/, "", short)
+      sub(/[ \t]*–.*$/, "", short)
+      if (short != "" && short != htext[nh] && !seen_heading[short]) {
+        nh++; hline[nh] = i; htext[nh] = short
+      }
+      seen_heading[htext[nh]] = 1
     }
   }
 
@@ -267,10 +297,12 @@ END {
 
   # ---- 2. unfilled template tokens / leftover scaffolding (ERROR) ---------
   for (i = 1; i <= n; i++) {
-    if (prose[i] == "") continue
-    if (match(prose[i], /\{\{[A-Za-z0-9_.-]+\}\}/))
-      err(i, "template-token", "unfilled template token " substr(prose[i], RSTART, RLENGTH))
-    if (prose[i] ~ /<!--[ \t]*\/?(REPEAT|OPTIONAL):/)
+    if (infence[i]) continue          # NOT nonprose(): frontmatter is in scope
+    p = raw[i]
+    gsub(/`[^`]*`/, " ", p)
+    if (match(p, /\{\{[A-Za-z0-9_.-]+\}\}/))
+      err(i, "template-token", "unfilled template token " substr(p, RSTART, RLENGTH))
+    if (p ~ /<!--[ \t]*\/?(REPEAT|OPTIONAL):/)
       err(i, "template-scaffold", "template scaffolding comment left in output (REPEAT:/OPTIONAL:)")
   }
 
@@ -280,22 +312,23 @@ END {
   # reported — a correct forward reference is the overwhelmingly common case
   # and saying so would drown the real ones.
   for (i = 1; i <= n; i++) {
-    if (text[i] == "") continue
-    lp = normalize(text[i])
+    if (nonprose(i)) continue
+    lp = normalize(raw[i])
+    # This check can only fire on a line that says "above" or "below" — 94 of
+    # the corpus's 6,416 lines. Without the guard the other 98.5% each pay a
+    # full sweep of the heading table to reach `continue`, which is O(lines ×
+    # headings): measured at 57% of the awk CPU on the largest skill file, and
+    # growing ~3.2x per doubling of file size. Guarding on the normalized line
+    # rather than the raw one also catches "Above"/"BELOW".
+    if (lp !~ /above|below/) continue
     for (j = 1; j <= nh; j++) {
-      if (hline[j] == i) continue
-      # Try the full heading, then the form without its trailing parenthetical
-      # — `## Readiness Rubric (7 axes)` is referred to as "Readiness Rubric",
-      # and matching only verbatim leaves a wrong direction on this repo's most
-      # common heading shape invisible.
-      hname = htext[j]
-      if (length(hname) >= 4 && index(lp, hname) > 0 && phrase_at(lp, hname, index(lp, hname))) {
-        pos = index(lp, hname)
-      } else if (hshort[j] != "" && length(hshort[j]) >= 4 && index(lp, hshort[j]) > 0 && phrase_at(lp, hshort[j], index(lp, hshort[j]))) {
-        hname = hshort[j]
-        pos = index(lp, hname)
-      } else continue
-      tail = substr(lp, pos + length(hname), 40)
+      if (hline[j] == i || length(htext[j]) < 4) continue
+      # The 4-character floor is a noise guard: without it a heading like "the"
+      # or "and" would match half the prose in the file. No real heading in
+      # this repo is shorter.
+      pos = index(lp, htext[j])
+      if (pos == 0 || !phrase_at(lp, htext[j], pos)) continue
+      tail = substr(lp, pos + length(htext[j]), 40)
       # The direction word has to follow the name directly — at most one
       # structural noun and a comma in between. Anything looser binds a stray
       # "below" to whatever heading-shaped word happened to appear earlier in
@@ -308,7 +341,7 @@ END {
       said = (substr(tail, RSTART, RLENGTH) ~ /above/) ? "above" : "below"
       actual = (hline[j] < i) ? "above" : "below"
       if (said != actual)
-        warn(i, "ref-direction", "says \"" hname "\" " said ", but that heading is " actual " (line " hline[j] ")")
+        warn(i, "ref-direction", "says \"" htext[j] "\" " said ", but that heading is " actual " (line " hline[j] ")")
     }
   }
 
@@ -318,34 +351,42 @@ END {
   # prose about identifiers routinely says "…the caveat `KIRO_HOME` below
   # carries" while pointing at a bullet, not a heading — so backticks need an
   # explicit structural noun ("`X` section below") before this fires.
+  # Built once and used three times: match(), the backtick exemption and the
+  # sub() that strips the suffix back off must describe the SAME span, and as
+  # three hand-copied literals an edit to one silently changed what `name`
+  # ended up being. 3b's nouns are narrower than 3a's on purpose — 3a's name
+  # comes from the heading table and is already known to be a heading, so it
+  # can afford "list"/"rule"/"step"; 3b's is arbitrary quoted prose.
+  NOUN = "((sub-?)?section|table|heading|chapter)"
+  DIRSUF = "[ \t]*" NOUN "?[ \t]*,?[ \t]*(above|below)([^A-Za-z]|$)"
   for (i = 1; i <= n; i++) {
-    if (text[i] == "") continue
-    s = text[i]
-    while (match(s, /("[^"]+"|`[^`]+`|\*\*[^*]+\*\*)[ \t]*((sub-?)?section|table|heading|chapter)?[ \t]*,?[ \t]*(above|below)([^A-Za-z]|$)/)) {
+    if (nonprose(i)) continue
+    s = raw[i]
+    while (match(s, "(\"[^\"]+\"|`[^`]+`|\\*\\*[^*]+\\*\\*)" DIRSUF)) {
       m = substr(s, RSTART, RLENGTH)
       s = substr(s, RSTART + RLENGTH)
-      if (m ~ /^`/ && m !~ /((sub-?)?section|table|heading|chapter)/) continue
+      if (m ~ /^`/ && m !~ NOUN) continue
       name = m
-      sub(/[ \t]*((sub-?)?section|table|heading|chapter)?[ \t]*,?[ \t]*(above|below)([^A-Za-z]|$)$/, "", name)
+      sub(DIRSUF "$", "", name)
       gsub(/^[`"*]+/, "", name); gsub(/[`"*]+$/, "", name)
       name = normalize(name)
       if (name == "") continue
       found = 0
-      # hshort[] too, so `**Readiness Rubric** below` is not called dangling
-      # when the heading is `## Readiness Rubric (7 axes)`.
       for (j = 1; j <= nh; j++)
-        if (htext[j] == name || hshort[j] == name) { found = 1; break }
+        if (htext[j] == name) { found = 1; break }
       if (!found)
         warn(i, "ref-dangling", "reference to \"" name "\" " (m ~ /above([^A-Za-z]|$)$/ ? "above" : "below") " names no heading in this file")
     }
   }
 
   # ---- 4. announced count vs list length (WARN) ---------------------------
-  split("two three four five six seven eight nine ten", words, " ")
-  for (w = 1; w <= 9; w++) numword[words[w]] = w + 1
+  # The value IS the index: words[1]="two" means 2, so `w + 1` replaces a
+  # lookup table. nw rather than a literal 9, so adding a count word is a
+  # one-place edit.
+  nw = split("two three four five six seven eight nine ten", words, " ")
 
   for (i = 1; i <= n; i++) {
-    if (text[i] == "" || text[i] !~ /:[ \t]*$/) continue
+    if (nonprose(i) || raw[i] !~ /:[ \t]*$/) continue
     want = 0; wantword = ""
     # Only the announcing sentence counts — the last one before the colon. A
     # count word stranded in an earlier sentence is describing something else:
@@ -353,30 +394,31 @@ END {
     # below:" introduces three items and announces none of them. Sentence
     # breaks only: splitting on an em dash too would lose the common
     # "**Two flavors** — pick one:" shape, which does announce its list.
-    lp = tolower(text[i])
+    lp = tolower(raw[i])
     if (match(lp, /^.*(\. |; )/)) lp = substr(lp, RSTART + RLENGTH)
-    for (w = 1; w <= 9; w++) {
+    for (w = 1; w <= nw; w++) {
       # Not hyphenated ("three-tier" is an adjective, not a count) and not
       # inside a longer word.
       if (match(lp, "(^|[^a-z-])" words[w] "([^a-z-]|$)")) {
-        if (want == 0 || RSTART < firstpos) { want = numword[words[w]]; wantword = words[w]; firstpos = RSTART }
+        if (want == 0 || RSTART < firstpos) { want = w + 1; wantword = words[w]; firstpos = RSTART }
       }
     }
     if (want == 0) continue
 
     j = i + 1
-    while (j <= n && raw[j] ~ /^[ \t\r]*$/) j++
+    while (j <= n && raw[j] ~ /^[ \t]*$/) j++
     if (j > n || infence[j] || !is_list_marker(raw[j])) continue
 
     base = indent_of(raw[j])
     got = 1
     blanks = 0
     for (k = j + 1; k <= n; k++) {
-      if (raw[k] ~ /^[ \t\r]*$/) { blanks++; if (blanks >= 2) break; continue }
+      if (raw[k] ~ /^[ \t]*$/) { if (++blanks >= 2) break; continue }
+      blanks = 0
       ind = indent_of(raw[k])
-      if (ind > base) { blanks = 0; continue }           # continuation or nested
-      if (ind == base && is_list_marker(raw[k])) { got++; blanks = 0; continue }
-      break
+      if (ind > base) continue                           # continuation or nested
+      if (ind < base || !is_list_marker(raw[k])) break
+      got++
     }
     if (got != want)
       warn(i, "list-count", "lead-in announces \"" wantword "\" (" want ") but " got " list item" (got == 1 ? "" : "s") " follow")
@@ -387,20 +429,10 @@ END {
     if (fm_end == 0) {
       warn(1, "frontmatter", "SKILL.md has no YAML frontmatter block")
     } else {
-      gotname = ""; namelines = 0; desc_line = 0; desc_value = ""
+      gotname = ""; has_name = 0; desc_line = 0; desc_value = ""
       for (i = 2; i < fm_end; i++) {
-        if (raw[i] ~ /^name:[ \t]*/) {
-          gotname = raw[i]; sub(/^name:[ \t]*/, "", gotname)
-          gsub(/^["']|["'][ \t\r]*$/, "", gotname)
-          gsub(/[ \t\r]+$/, "", gotname)
-          namelines++
-        }
-        if (raw[i] ~ /^description:[ \t]*/) {
-          desc_line = i
-          desc_value = raw[i]; sub(/^description:[ \t]*/, "", desc_value)
-          gsub(/^["']|["'][ \t\r]*$/, "", desc_value)
-          gsub(/^[ \t\r]+|[ \t\r]+$/, "", desc_value)
-        }
+        if (raw[i] ~ /^name:[ \t]*/)        { gotname = fm_value(raw[i], "name"); has_name = 1 }
+        if (raw[i] ~ /^description:[ \t]*/) { desc_line = i; desc_value = fm_value(raw[i], "description") }
       }
       # A frontmatter span containing prose is a frontmatter whose closing ---
       # went missing and bound to a thematic break further down: the span then
@@ -409,13 +441,13 @@ END {
       # not YAML when it is unindented (not a continuation), not a `key:`, not
       # a `- ` item, and not a `#` comment.
       for (i = 2; i < fm_end; i++) {
-        if (raw[i] ~ /^[ \t\r]*$/ || raw[i] ~ /^[ \t#]/ || raw[i] ~ /^-[ \t]/) continue
+        if (raw[i] ~ /^[ \t]*$/ || raw[i] ~ /^[ \t#]/ || raw[i] ~ /^-[ \t]/) continue
         if (raw[i] ~ /^[A-Za-z_][A-Za-z0-9_.-]*:/) continue
         warn(i, "frontmatter", "frontmatter contains a line that is not YAML — the closing --- is probably missing")
         break
       }
 
-      if (namelines == 0)
+      if (!has_name)
         warn(1, "frontmatter", "frontmatter has no name: key")
       else if (expected_name != "" && gotname != expected_name)
         warn(1, "frontmatter", "name: is \"" gotname "\" but the directory says \"" expected_name "\"")
@@ -443,8 +475,6 @@ if [[ -t 1 ]]; then RED=$'\033[31m'; YELLOW=$'\033[33m'; BOLD=$'\033[1m'; RESET=
 
 errors=0
 warnings=0
-FINDINGS="$(mktemp)"
-trap 'rm -f "$FINDINGS"' EXIT
 
 for f in "${FILES[@]}"; do
   if [[ ! -f "$f" ]]; then
@@ -454,16 +484,16 @@ for f in "${FILES[@]}"; do
   fi
   is_skill_md=0
   expected=""
-  if [[ "$(basename "$f")" == "SKILL.md" ]]; then
+  if [[ "${f##*/}" == "SKILL.md" ]]; then
     is_skill_md=1
     expected="$(expected_skill_name "$f")"
   fi
-  # Via a temp file, not process substitution: `done < <(awk …)` discards
-  # awk's exit status, so an awk that cannot read the file — or that rejects
-  # a construct in the program — yields zero lines and the file is tallied as
+  # Command substitution, NOT process substitution: `done < <(awk …)` discards
+  # awk's exit status, so an awk that cannot read the file — or that rejects a
+  # construct in the program — yields zero lines and the file is tallied as
   # clean. That would turn any awk incompatibility into a silently green gate,
   # which is the failure mode this whole script exists to remove.
-  if ! awk -v is_skill_md="$is_skill_md" -v expected_name="$expected" "$LINT_AWK" "$f" >"$FINDINGS"; then
+  if ! found="$(awk -v is_skill_md="$is_skill_md" -v expected_name="$expected" "$LINT_AWK" "$f")"; then
     echo "skill-lint: awk failed on $f — treating as a failure, not a clean file" >&2
     errors=$((errors + 1))
     continue
@@ -482,7 +512,7 @@ for f in "${FILES[@]}"; do
     # GitHub Actions log — where a developer looking at a failed gate most
     # needs to tell the blocking lines from the advisory ones.
     printf '%s%s:%s:%s %-5s %s [%s]\n' "$color" "$f" "$line" "$RESET" "$sev" "$msg" "$check"
-  done <"$FINDINGS"
+  done <<<"$found"
 done
 
 printf '\n%sskill-lint:%s %d file(s), %d error(s), %d warning(s)\n' \


### PR DESCRIPTION
Follow-up to #1280, which merged with **only its first commit** — so `main`
carries `tools/skill-lint.sh` without the fixes from its code review. Everything
below was found by reviewing #1280 and reproduced before being fixed.

## The headline: main's linter can be silenced

Reproduced against `main`'s actual version of the script, on a file containing an
unclosed code fence, three conflict markers, an unfilled `{{TOKEN}}` and a
leftover `<!-- REPEAT:step -->`:

```
skill-lint: 1 file(s), 0 error(s), 0 warning(s)
exit=0
```

One missing closing backtick suppresses the rest of the file and both hard-fail
checks go quiet — the #1209 failure mode reproduced inside the fix for #1209.
After this PR the same file reports **6 errors, exit 1**.

## Silent-pass paths closed

| Path | Was | Now |
|---|---|---|
| Unclosed code fence | every following line skipped, both ERROR checks defeated | fence balance decided before anything is skipped; odd count is itself an ERROR and nothing is treated as fenced |
| Unterminated frontmatter | closing `---` bound to the first thematic break in the body, swallowing everything between | scan bounded; a frontmatter span holding a non-YAML line says so |
| `{{TOKEN}}` in `description:` | frontmatter skipped by check 2, so the field the loader matches on was never read | check 2 reads frontmatter (it is structured data and never *documents* a marker) |
| `awk` fails | exit status discarded by process substitution → file tallied clean | command substitution; a failed awk is an error, not a clean file |
| ERROR vs WARN in CI | encoded only in ANSI colour, which is off whenever stdout is not a TTY | severity printed as a word |
| `/^#{1,6}/` | the one ERE interval; an awk without interval support indexes no heading and degrades check 3 invisibly | `/^#+/` |

The invariant is now stated explicitly in the code: **when a file cannot be
parsed with confidence, degrade toward *more* checking, never less.**

## Scope and harness holes

- **`tools/irrlicht-design-system/SKILL.md`** is a tracked skill with real
  frontmatter that neither the walk nor the preflight trigger could see — a skill
  outside every gate, in a PR whose thesis is "no gate read these files". The walk
  now reads the **git index** (not `find`, which would descend into
  `.claude/worktrees/` and lint other branches' skill files) for `.claude/skills/**/*.md`
  plus any other `SKILL.md`, excluding the deliberately-corrupt `testdata/` corpus.
  23 files now, was 22.
- **`tools/preflight.sh --only skils`** (typo) ran nothing, printed an empty
  summary and **exited 0**. Same silent-green shape, one typo away, in the harness
  that hosts the gate for #1209. `--only` is now validated against the group list,
  and a run that recorded no gate at all exits 2.
  *(Note: `GROUPS` is a bash built-in holding the caller's supplementary group IDs
  and is read-only — the first version of this check silently compared against a
  list of numeric gids. Caught by running it.)*

## Test hardening

The suite asserted only `$?`. Since each fixture trips several sub-checks, **three
of the five hard-fail sub-checks could be demoted to WARN with the suite staying
green** — verified by mutation. Every fixture now pins its exact
`N error(s), M warning(s)` summary and the severity word on each finding. The same
mutation now fails 5 assertions.

Four new fixtures (`unclosed-fence`, `openfm`, `nofmclose`, `fmtoken`) cover the
silencer paths. `plan.html` becomes the marker vocabulary's *fixture* rather than
a second definition of it: a test asserts the linter recognises the tokens the
template actually contains, so renaming the convention there cannot silently stop
check 2 from detecting leftovers.

## Cleanups (from a four-angle `/simplify` pass)

Output verified **identical across all 101 tracked `.md` files**, except one false
positive deliberately removed.

- Dropped the `prose[]`/`text[]` whole-file copies and the `hshort[]` parallel
  column in favour of a `nonprose()` predicate and a second *row* in the heading
  table; `\r` stripped once at input rather than defended against in ten regexes;
  fences counted on the read pass; `numword[]` was dead state (the loop index is
  the value).
- One `fm_value()` parser for `name:`/`description:`, which had drifted apart on
  whitespace trimming; one built-once regex for check 3b's noun list, which
  existed as three hand-copied literals that had to stay in lockstep.
- **Performance** (measured, not guessed): check 3a now skips lines containing
  neither "above" nor "below" — 98.5% of them. It was 57% of awk CPU on the
  largest skill file and grew ~3.2× per doubling of file size; it is now linear.
  `basename`/`dirname` forks replaced with parameter expansion. **1.5s → 0.67s**
  for a gate that runs in the pre-push hook and as CI's first step.
- `ref-*` now matches a heading up to a parenthetical **or an en/em dash** — 48
  corpus headings use the dash form, and the old rule produced a demonstrated
  false positive (`"Local CI parity" below` in `AGENTS.md`, whose heading is
  `### Local CI parity — catch failures before pushing`). That warning is the one
  output line intentionally removed. **Not colons**: `## Step 6: Build Artifacts`
  shortens to "step 6", which `ir:release`'s prose reuses as an ordinary noun —
  that produced a fresh false positive on the first run and the rule was dropped.

## Verification

```
equivalence   101 files, output identical except the one removed false positive
suite         ALL PASS; severity-demotion mutation fails 5 assertions
default gate  23 file(s), 0 error(s), 0 warning(s)
silencers     unclosed-fence 6 errors · openfm 2+1 · fmtoken 1 error  (all exit 1)
timing        1.5s → 0.67s
shellcheck    skill-lint.sh clean; preflight.sh codes identical to main's
preflight     --changed: gofmt PASS, tools/lib PASS, skill-file lint PASS
```

## Deliberately not done (follow-ups worth filing)

- **Widening the ERROR checks beyond skill files.** Conflict markers, unfilled
  tokens and unbalanced fences are not skill-specific, and measured over the 27
  other tracked markdown files they produce **0 errors** — so an `--errors-only`
  pass over all markdown would cost nothing today. Splitting by *severity* rather
  than by *directory* is arguably the right altitude. Out of scope for #1209.
- **Moving `tools/lib/skill-lint_test.sh` → `tools/skill-lint_test.sh`.**
  `tools/lib/` is documented as "the shared shell libs"; the test lives there to
  be found by an existing `tools/lib/*_test.sh` glob it doesn't really belong to.
  The fix is widening the glob in two places, but it renames a gate and is better
  as its own change.

Refs #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)
