### PR TITLE
fix(security-scan): derive the module list from go.work, assert dependabot

### DIFF
--- a/tools/lib/module-list_test.sh
+++ b/tools/lib/module-list_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# module-list_test.sh — hold .github/dependabot.yml's directory lists against
+# the repo's real inventory of Go modules and web trees (#1291).
+#
+# Why this exists rather than deriving, as tools/security-scan.sh now does:
+# dependabot.yml is static YAML read by GitHub's infrastructure, not by us, so
+# there is nothing to derive at. It can only be asserted. Left unasserted, a
+# seventh go.work module means that module is never dependency-updated — and
+# nothing surfaces that, because the repo builds and tests exactly as before.
+#
+# This is a lock, not a defect test: it passes by construction against a
+# correct repo. Its whole value is that it *can* fail, so both assertions were
+# seen red against a deliberately mutated dependabot.yml before landing.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+# Every path below is repo-relative, so a failed cd would compare whatever
+# happens to sit in the caller's cwd — most likely nothing, which reads as a
+# pass. Exit instead (SC2164).
+cd "$REPO_ROOT" || { echo "FAIL: cannot cd to repo root $REPO_ROOT" >&2; exit 1; }
+
+DEPENDABOT=.github/dependabot.yml
+rc=0
+fail() { echo "FAIL: $1" >&2; rc=1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "SKIP: module-list_test — $1 not found"; exit 0; }; }
+need go
+need jq
+need python3
+
+# Read one ecosystem's directories out of dependabot.yml, newline-separated and
+# leading-slash-stripped so both sides of every comparison share a shape.
+dependabot_dirs() {
+  python3 -c '
+import sys, yaml
+eco = sys.argv[1]
+cfg = yaml.safe_load(open(sys.argv[2]))
+for u in cfg.get("updates", []):
+    if u.get("package-ecosystem") == eco:
+        for d in (u.get("directories") or [u.get("directory")]):
+            if d:
+                print(d.lstrip("/"))
+' "$1" "$DEPENDABOT" 2>/dev/null | sort
+}
+
+# --- gomod: dependabot must cover exactly go.work's modules -----------------
+go_work_modules=$(go work edit -json | jq -r '.Use[].DiskPath | sub("^\\./"; "")' | sort)
+gomod_dirs=$(dependabot_dirs gomod)
+
+if [[ "$go_work_modules" != "$gomod_dirs" ]]; then
+  fail "dependabot.yml's gomod directories do not match go.work's modules"
+  diff <(echo "$go_work_modules") <(echo "$gomod_dirs") \
+    | sed 's/^/  /; s/^  </  only in go.work: /; s/^  >/  only in dependabot.yml: /' >&2
+fi
+
+# --- npm: dependabot must cover exactly security-scan.sh's WEB_TREES --------
+# Sourcing security-scan.sh would run the whole scan, so read the literal.
+web_trees=$(sed -n 's/^WEB_TREES=(\(.*\))$/\1/p' tools/security-scan.sh | tr ' ' '\n' | sed '/^$/d' | sort)
+npm_dirs=$(dependabot_dirs npm)
+
+if [[ -z "$web_trees" ]]; then
+  fail "could not read WEB_TREES from tools/security-scan.sh — the assertion below would compare against nothing"
+elif [[ "$web_trees" != "$npm_dirs" ]]; then
+  fail "dependabot.yml's npm directories do not match security-scan.sh's WEB_TREES"
+  diff <(echo "$web_trees") <(echo "$npm_dirs") \
+    | sed 's/^/  /; s/^  </  only in security-scan.sh: /; s/^  >/  only in dependabot.yml: /' >&2
+fi
+
+[[ "$rc" -eq 0 ]] && echo "OK: module-list_test — dependabot.yml matches go.work and WEB_TREES"
+exit "$rc"

--- a/tools/lib/module-list_test.sh
+++ b/tools/lib/module-list_test.sh
@@ -23,7 +23,13 @@ DEPENDABOT=.github/dependabot.yml
 rc=0
 fail() { echo "FAIL: $1" >&2; rc=1; }
 
-need() { command -v "$1" >/dev/null 2>&1 || { echo "SKIP: module-list_test — $1 not found"; exit 0; }; }
+# A missing tool is a hard failure, not a skip. Exiting 0 here would read as a
+# PASS to preflight's shell_lib_tests (`bash "$t" || rc=1`), so the gate would
+# go green having asserted nothing — the same "green report for work that never
+# ran" changed-files_test.sh guards against, and the exact policy in
+# security-scan.sh's header. All three tools are already hard requirements of
+# the gates this test runs beside.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: module-list_test — $1 not found; cannot verify the module lists agree" >&2; exit 1; }; }
 need go
 need jq
 need python3
@@ -47,7 +53,14 @@ for u in cfg.get("updates", []):
 go_work_modules=$(go work edit -json | jq -r '.Use[].DiskPath | sub("^\\./"; "")' | sort)
 gomod_dirs=$(dependabot_dirs gomod)
 
-if [[ "$go_work_modules" != "$gomod_dirs" ]]; then
+# Guard emptiness on both sides before comparing: two empty strings are equal,
+# so an unreadable go.work plus a dependabot.yml with no gomod entry would
+# otherwise report a positive match having compared nothing.
+if [[ -z "$go_work_modules" ]]; then
+  fail "could not read any module from go.work — the assertion below would compare nothing against nothing and call it a match"
+elif [[ -z "$gomod_dirs" ]]; then
+  fail "dependabot.yml declares no gomod directories — every Go module is unwatched"
+elif [[ "$go_work_modules" != "$gomod_dirs" ]]; then
   fail "dependabot.yml's gomod directories do not match go.work's modules"
   diff <(echo "$go_work_modules") <(echo "$gomod_dirs") \
     | sed 's/^/  /; s/^  </  only in go.work: /; s/^  >/  only in dependabot.yml: /' >&2
@@ -60,10 +73,29 @@ npm_dirs=$(dependabot_dirs npm)
 
 if [[ -z "$web_trees" ]]; then
   fail "could not read WEB_TREES from tools/security-scan.sh — the assertion below would compare against nothing"
+elif [[ -z "$npm_dirs" ]]; then
+  fail "dependabot.yml declares no npm directories — both web trees are unwatched"
 elif [[ "$web_trees" != "$npm_dirs" ]]; then
   fail "dependabot.yml's npm directories do not match security-scan.sh's WEB_TREES"
   diff <(echo "$web_trees") <(echo "$npm_dirs") \
     | sed 's/^/  /; s/^  </  only in security-scan.sh: /; s/^  >/  only in dependabot.yml: /' >&2
+fi
+
+# --- security-scan.sh refuses to run on an unreadable module list -----------
+# The derivation replaced a hardcoded array, so its "empty means broken, not
+# 'no Go code'" guard is the single point where a silent zero-module scan gets
+# caught. Pin it here rather than trusting a one-off manual check, the same
+# reason #1231's guards landed with tests in changed-files_test.sh.
+gostub=$(mktemp -d)
+trap 'rm -rf "$gostub"' EXIT
+printf '#!/bin/sh\nexit 1\n' > "$gostub/go"
+chmod +x "$gostub/go"
+guard_out=$(PATH="$gostub:$PATH" bash tools/security-scan.sh --local 2>&1)
+guard_rc=$?
+if [[ "$guard_rc" -ne 2 ]]; then
+  fail "security-scan.sh should exit 2 when the module list cannot be read, got $guard_rc"
+elif [[ "$guard_out" != *"refusing to report a pass"* ]]; then
+  fail "security-scan.sh exited 2 but without naming the cause; got: $guard_out"
 fi
 
 [[ "$rc" -eq 0 ]] && echo "OK: module-list_test — dependabot.yml matches go.work and WEB_TREES"

--- a/tools/lib/module-list_test.sh
+++ b/tools/lib/module-list_test.sh
@@ -32,21 +32,49 @@ fail() { echo "FAIL: $1" >&2; rc=1; }
 need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: module-list_test — $1 not found; cannot verify the module lists agree" >&2; exit 1; }; }
 need go
 need jq
-need python3
 
 # Read one ecosystem's directories out of dependabot.yml, newline-separated and
 # leading-slash-stripped so both sides of every comparison share a shape.
+#
+# Deliberately awk, not a YAML library. The first version used python3 with
+# PyYAML: it passed locally and failed in CI, where python3 exists but PyYAML
+# does not — `import yaml` raised, stderr was swallowed, and both ecosystems
+# came back empty. Adding a pip install to CI to satisfy one assertion is a
+# worse trade than parsing a file whose shape this repo controls.
+#
+# Brittleness is bounded by the emptiness guards below: a shape this parser
+# cannot read yields nothing, and nothing is a loud failure rather than a
+# vacuous match. That is how the CI break above surfaced at all.
 dependabot_dirs() {
-  python3 -c '
-import sys, yaml
-eco = sys.argv[1]
-cfg = yaml.safe_load(open(sys.argv[2]))
-for u in cfg.get("updates", []):
-    if u.get("package-ecosystem") == eco:
-        for d in (u.get("directories") or [u.get("directory")]):
-            if d:
-                print(d.lstrip("/"))
-' "$1" "$DEPENDABOT" 2>/dev/null | sort
+  awk -v want="$1" '
+    # A new list item resets block state; capture the ecosystem it declares.
+    /^[[:space:]]*-[[:space:]]*package-ecosystem:[[:space:]]*/ {
+      eco = $NF; in_dirs = 0; next
+    }
+    # Plural form: `directories:` opens a list of paths.
+    /^[[:space:]]*directories:[[:space:]]*$/ { in_dirs = (eco == want); next }
+    # Singular form: `directory: /` carries its value inline.
+    /^[[:space:]]*directory:[[:space:]]*/ {
+      if (eco == want) { v = $NF; gsub(/^"|"$/, "", v); print v }
+      in_dirs = 0; next
+    }
+    # Inside a directories: block, list items are the paths. Anything else
+    # (schedule:, groups:, a comment) closes it — which is what keeps the
+    # `- "*"` items under groups.patterns from being read as directories.
+    {
+      if (in_dirs && $0 ~ /^[[:space:]]*-[[:space:]]/) {
+        v = $NF; gsub(/^"|"$/, "", v); print v
+      } else if ($0 !~ /^[[:space:]]*-[[:space:]]/) {
+        in_dirs = 0
+      }
+    }
+  ' "$DEPENDABOT" |
+    # Repo-relative, to match go.work's and WEB_TREES' shape. The repo root is
+    # "/" in dependabot's spelling; stripping the slash would leave the empty
+    # string, which the blank-line filter would then drop — silently losing an
+    # ecosystem that watches the root (github-actions does). Map it to "." so
+    # it survives as a real entry.
+    sed 's|^/||; s|^$|.|' | sed '/^$/d' | sort
 }
 
 # --- gomod: dependabot must cover exactly go.work's modules -----------------

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -256,7 +256,11 @@ shell_lib_tests() {
 }
 
 if want tools; then
-  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$' \
+  # go.work and .github/dependabot.yml are in scope because module-list_test.sh
+  # asserts they agree — and a commit touching only one of those two is exactly
+  # the commit that breaks the invariant, so leaving them out would skip the
+  # test precisely when it matters (#1291).
+  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^go\.work$|^\.github/dependabot\.yml$' \
                   "tools/lib shell-lib tests" shell_lib_tests
 fi
 

--- a/tools/security-scan.sh
+++ b/tools/security-scan.sh
@@ -77,7 +77,29 @@ done
 # narrower go-test set: only core, onboarding-factory, and starhistory have
 # test suites today, but a vuln/SAST scan doesn't need tests to pass, so all
 # six run).
-GO_MODULES=(core tools/onboarding-factory tools/wsload tools/seed-demo-sessions tools/eta-research tools/starhistory)
+#
+# Read from go.work rather than restated here (#1291). A hand-maintained copy
+# drifts silently in the one direction that matters: add a seventh module and
+# forget this line, and that module is never scanned — it builds, it tests, and
+# nothing says otherwise. `go work edit -json` is Go's own parse of the file,
+# so this cannot disagree with what the toolchain builds.
+GO_MODULES=()
+while IFS= read -r mod; do
+  [[ -n "$mod" ]] && GO_MODULES+=("$mod")
+done < <(go work edit -json 2>/dev/null | jq -r '.Use[].DiskPath | sub("^\\./"; "")')
+# An empty list here would sail through every loop below and report a pass
+# having scanned nothing — the "silently-skipped scan is indistinguishable from
+# a clean one" failure this file's header rules out. A parse that yields no
+# modules means go/jq/go.work is broken, not that the repo has no Go code.
+if [[ ${#GO_MODULES[@]} -eq 0 ]]; then
+  echo "FAIL: could not read the module list from go.work (go work edit -json | jq) — refusing to report a pass for a scan that would cover nothing" >&2
+  exit 2
+fi
+
+# No equivalent source of truth exists for the npm trees — nothing in the repo
+# enumerates them the way go.work enumerates modules — so this list stays
+# hand-maintained. tools/lib/module-list_test.sh holds both it and GO_MODULES
+# against .github/dependabot.yml.
 WEB_TREES=(platforms/web tools/onboarding-factory/internal/viewer/web)
 
 FAILED=0


### PR DESCRIPTION
Closes #1291

## Problem

Three files independently hardcoded the same six Go modules:

| File | Form |
|---|---|
| `go.work` | `use (...)` — the real source of truth |
| `tools/security-scan.sh:80` | `GO_MODULES=(core tools/onboarding-factory ...)` |
| `.github/dependabot.yml` | the `gomod` entry's `directories:` |

Nothing enforced their equality. Add a seventh module to `go.work`, forget the
other two, and that module is **never vulnerability-scanned and never
dependency-updated** — silently, because the repo builds and tests exactly as
before. Same class as #1225, where postcss was patched in one web tree and left
stale in the other: parallel lists that must agree, with no mechanism making
them agree.

## Fix

**One copy becomes zero.** `security-scan.sh` reads the list from
`go work edit -json` — Go's own parse of `go.work`, not a regex — so it cannot
disagree with what the toolchain actually builds. An empty parse hard-fails
(exit 2) rather than looping over nothing and reporting a pass; that is this
file's own header rule, that a silently-skipped scan is indistinguishable from
a clean one.

**One copy becomes asserted.** `dependabot.yml` is static YAML consumed by
GitHub's infrastructure, so it has nothing to derive at — it can only be
checked. `tools/lib/module-list_test.sh` holds its `gomod` directories against
`go.work` and its `npm` directories against `WEB_TREES`.

**The gate is scoped so it fires.** `preflight.sh`'s `tools` gate regex was
`^tools/lib/|^tools/[^/]*\.sh$`, so under `--changed` a commit touching only
`go.work` or `.github/dependabot.yml` — exactly the commits that break the
invariant — would skip the test that checks it. Both paths are now in scope.

`WEB_TREES` stays hardcoded: nothing in the repo enumerates the npm trees the
way `go.work` enumerates modules, so there is no source of truth to derive
from. It gets the assertion instead.

Net: one hardcoded list (`go.work`, its rightful home), one derived, one
asserted.

## Seen red

The test is a **lock** — it passes by construction against a correct repo — so
per `AGENTS.md` both assertions were driven red against a deliberately mutated
`dependabot.yml` before landing:

| Mutation | Result |
|---|---|
| drop `/tools/wsload` from `gomod` | `FAIL: ... gomod directories do not match go.work's modules` → `only in go.work: tools/wsload` |
| drop the viewer tree from `npm` | `FAIL: ... npm directories do not match security-scan.sh's WEB_TREES` → `only in security-scan.sh: tools/onboarding-factory/internal/viewer/web` |
| restored | `OK: module-list_test — dependabot.yml matches go.work and WEB_TREES` |

The empty-list guard was also seen red: running with `go` off `PATH` prints
`FAIL: could not read the module list from go.work ... refusing to report a
pass for a scan that would cover nothing` and exits 2, instead of passing
having scanned zero modules.

## Verification

- Derived set is **identical** to the list it replaces (`diff` of the two,
  empty) — scan behaviour unchanged, only its source moved.
- `tools/security-scan.sh --local` → `security-scan: passed`, exit 0, all six
  modules scanned by both govulncheck and gosec.
- `--changed` enumerates all six derived modules in its SKIP lines.
- All three `tools/lib/*_test.sh` pass; `shellcheck` clean on the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)