### PR TITLE
feat(state): explicit signal tiers + shared reconcile mechanism (#1288)

### DIFF
--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -66,7 +66,7 @@ const hookMatcher = "Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*|Ask
 
 // hookMatcherPreToolUse is the narrow matcher for the PreToolUse event. We
 // only want to flip working→waiting on the user-input tools — matching every
-// Bash/Write/… would set permissionPending on every tool call. (Issue #307.)
+// Bash/Write/… would hold SignalPermissionPrompt on every tool call. (Issue #307.)
 const hookMatcherPreToolUse = "AskUserQuestion|ExitPlanMode"
 
 // hookMatcherPreCompact is the matcher for the PreCompact event. Unlike the

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -193,12 +193,25 @@ type SessionDetector struct {
 	recorder    outbound.EventRecorder
 	recorderSeq int64
 
-	// permMu guards permissionPending. The map tracks sessions with an active
-	// PermissionRequest hook that hasn't been cleared by PostToolUse/
-	// PostToolUseFailure. Written by HandlePermissionHook (HTTP handler
-	// goroutine), read by processActivity (event-loop goroutine).
-	permMu            sync.Mutex
-	permissionPending map[string]bool // sessionID → true
+	// signals holds the out-of-band state signals (hook-delivered today,
+	// OTel/process/screen in the later phases of #1129) between arrival on
+	// their own goroutine and the classify pass that consumes them. It
+	// replaces the three hand-rolled per-signal overlay maps this struct
+	// carried before #1288 — permissionPending, hookTurnDone and
+	// idlePromptPending — each of which had its own lifecycle rule spelled
+	// out in its own overlay method. The per-signal policy now lives in
+	// session.signalPolicies; adding a Phase 4-7 signal is a row there, not a
+	// fourth map and a fourth overlay here.
+	//
+	// Carries its own lock (hooks arrive on HTTP handler goroutines, the
+	// event loop classifies), so it is deliberately NOT guarded by permMu.
+	signals *session.SignalHolds
+
+	// permMu guards the remaining per-session hook/bookkeeping maps below
+	// (compactPending, editToolOpenSince, idleProjectRetryAttempts). Written
+	// from HTTP handler goroutines, read by processActivity (event-loop
+	// goroutine).
+	permMu sync.Mutex
 
 	// compactPending tracks sessions in a manual /compact: sessionID → the Unix
 	// time the PreCompact hook fired. Set by HandleCompactHook; cleared when the
@@ -209,25 +222,6 @@ type SessionDetector struct {
 	// window (#657). Guarded by permMu — same goroutine-crossing story as
 	// permissionPending.
 	compactPending map[string]int64 // sessionID → unix seconds (hook fire time)
-
-	// hookTurnDone tracks sessions whose Claude Code Stop hook (#1161) has fired
-	// but whose resulting classify pass hasn't consumed it yet: sessionID → the
-	// turn's final assistant text (display-truncated) and whether it carried a
-	// waiting cue. Set by HandleStopHook; consumed and cleared by
-	// overlayHookTurnDone on the next classify pass (consume-once, so the
-	// authoritative turn-done signal never bleeds into the following turn).
-	// Guarded by permMu — same goroutine-crossing story as permissionPending.
-	hookTurnDone map[string]hookStopSignal // sessionID → Stop-hook payload
-
-	// idlePromptPending tracks sessions whose Claude Code Notification/idle_prompt
-	// hook reported the agent is idle at the prompt waiting for the user (#1173):
-	// sessionID → true. Set by HandleIdlePromptHook; overlaid onto metrics by
-	// overlayIdlePrompt every classify pass while the finished turn stays idle,
-	// and cleared there the moment new activity arrives (IsAgentDone flips false)
-	// — so it holds the session in waiting without pinning it into the next turn.
-	// Persistent (not consume-once, unlike hookTurnDone): a lower-tier reclassify
-	// must never revert the corrected waiting back to ready. Guarded by permMu.
-	idlePromptPending map[string]bool // sessionID → true
 
 	// editToolOpenSince tracks, per session, the Unix time a permission-gated
 	// file-edit tool first appeared open. Guarded by permMu. Drives the
@@ -332,10 +326,8 @@ func NewSessionDetector(watchers []inbound.Watcher, deps SessionDetectorDeps) *S
 		debounce:                 make(map[string]*debounceEntry),
 		debouncedEvents:          make(chan agent.Event, 64),
 		deletedCooldown:          10 * time.Second,
-		permissionPending:        make(map[string]bool),
+		signals:                  session.NewSignalHolds(),
 		compactPending:           make(map[string]int64),
-		hookTurnDone:             make(map[string]hookStopSignal),
-		idlePromptPending:        make(map[string]bool),
 		editToolOpenSince:        make(map[string]int64),
 		idleProjectRetryAttempts: make(map[string]int),
 		bgLiveProbe:              anyLiveOutputWriter,
@@ -534,7 +526,23 @@ func classifierInputs(m *session.SessionMetrics) *lifecycle.ClassifierInputs {
 		LastEventType:                     m.LastEventType,
 		LastWasUserInterrupt:              m.LastWasUserInterrupt,
 		LastWasToolDenial:                 m.LastWasToolDenial,
+		HookTurnDone:                      m.HookTurnDone,
+		IdlePromptPending:                 m.IdlePromptPending,
 	}
+}
+
+// withProvenance stamps the deciding rule and tier onto a classifier-inputs
+// snapshot. Separate from classifierInputs because provenance is a property of
+// the *verdict*, not of the metrics: the synthesizers emit transitions that no
+// rule decided, and those must record no tier rather than borrow whichever one
+// the ladder would have reached on its own.
+func withProvenance(in *lifecycle.ClassifierInputs, v StateVerdict) *lifecycle.ClassifierInputs {
+	if in == nil || !v.Tier.Known() {
+		return in
+	}
+	in.DecidedByTier = v.Tier.String()
+	in.DecidedByRule = v.Rule
+	return in
 }
 
 // AddWatcher registers a watcher with the running (or not-yet-running)

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -45,7 +45,7 @@ const staleWorkingRefreshInterval = 5 * time.Second
 // (Edit/Write/MultiEdit/NotebookEdit) may stay open before the detector treats
 // it as a held permission prompt and sets OpenToolStalled — the transcript
 // -based fallback for when the PermissionRequest hook can't reach the daemon
-// (#488, ClassifyState rule 1b).
+// (#488, ClassifyState's open_tool_stalled rule).
 //
 // It is deliberately NOT staleWorkingRefreshInterval. That constant is a
 // polling cadence (how often a lingering working session is re-read); reusing
@@ -219,8 +219,9 @@ type SessionDetector struct {
 	// elapses (the safety net for an interrupted compaction that never writes a
 	// boundary). While set, processActivity overlays CompactInProgress so
 	// ClassifyState holds the session in working through the silent compaction
-	// window (#657). Guarded by permMu — same goroutine-crossing story as
-	// permissionPending.
+	// window (#657). Guarded by permMu — written from the hook receiver's
+	// goroutine, read by the event loop, the same goroutine-crossing story the
+	// signals store above handles under its own lock.
 	compactPending map[string]int64 // sessionID → unix seconds (hook fire time)
 
 	// editToolOpenSince tracks, per session, the Unix time a permission-gated

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -855,9 +855,10 @@ func (d *SessionDetector) forceReadyToWorkingIfActive(state *session.SessionStat
 	// while that signal is pending: without this, the synthetic event would
 	// force ready→working here and then classify working→waiting, recording a
 	// spurious working blip between the two (the flap this reconcile must avoid).
-	// ClassifyState still routes correctly on its own — to waiting via rule 1c
-	// (idle case), or to working via rule 4 should real activity have arrived in
-	// the same pass (overlayIdlePrompt clears the flag when IsAgentDone flips).
+	// ClassifyState still routes correctly on its own — to waiting via the
+	// idle_prompt rule (idle case), or to working via transcript_activity should
+	// real activity have arrived in
+	// the same pass (the SignalIdlePrompt policy goes stale when IsAgentDone flips).
 	if d.hasPendingIdlePrompt(state.SessionID) {
 		return
 	}
@@ -967,7 +968,7 @@ func (d *SessionDetector) synthesizeCollapsedTurnBoundaryIfNeeded(state *session
 // correct "while waiting" phrasing. Skipped when
 // holdParentForActiveChildren already rewrote newState: that parent has
 // active children and must stay working, and reclassifying from waiting
-// would let rule 3 fire and transition it to ready despite children still
+// would let the user_interrupt rule fire and transition it to ready despite children still
 // running — undoing the hold.
 func (d *SessionDetector) synthesizeCollapsedWaitingIfNeeded(state *session.SessionState, ev agent.Event, candidate classifierCandidate) (string, string) {
 	newState, reason := candidate.NewState, candidate.Reason
@@ -1228,7 +1229,7 @@ func (d *SessionDetector) purgeDeadBackgroundProcesses(result backgroundProbeRes
 // applyCompactHold maintains the PreCompact force-working hold (#657) for one
 // session. While a manual /compact is in flight the transcript receives no
 // writes, so this overlays CompactInProgress to keep the session in working
-// (ClassifyState rule 0b) through that silent window.
+// (ClassifyState's compact_in_progress rule) through that silent window.
 //
 // The hold clears on the first of:
 //   - the manual compact_boundary landing (SawManualCompactBoundary): the

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -771,22 +771,18 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 	// Ready→working (if applicable) already ran in processActivityLocked,
 	// before applyBackgroundLiveness — see that call site.
 
-	// Overlay hook-based permission-pending signal onto metrics. Must happen
-	// after RefreshOnActivity (which recomputes metrics from the transcript)
-	// and before ClassifyState (which reads the flag). The flag persists in
-	// the map until PostToolUse/PostToolUseFailure clears it, so it survives
-	// fswatcher re-evaluations while the permission prompt is shown.
-	d.overlayPermissionPending(state)
-
-	// Overlay the authoritative Stop-hook turn-done signal (#1161). Consume-once:
-	// makes IsAgentDone authoritative for this pass and refreshes the
-	// waiting-vs-ready inputs from the hook's final assistant message.
-	d.overlayHookTurnDone(state)
-
-	// Overlay the Notification/idle_prompt hook's idle-waiting signal (#1173).
-	// Persistent (held while the turn stays idle), so ClassifyState rule 1c can
-	// correct a turn that ended with no prose cue from ready to waiting.
-	d.overlayIdlePrompt(state)
+	// Overlay every held out-of-band signal — the permission prompt (#108),
+	// the Stop hook's authoritative turn-done (#1161) and the idle_prompt
+	// correction (#1173) — onto the metrics ClassifyState is about to read.
+	// Each signal's own lifecycle rule (persistent vs consume-once, and when
+	// it goes stale) is declared in session.signalPolicies rather than spelled
+	// out here; see SignalHolds.Overlay for why their application order is
+	// load-bearing.
+	//
+	// Must happen after RefreshOnActivity, which rebuilds metrics from the
+	// transcript and so zeroes every transient field these signals set, and
+	// before ClassifyState, which reads them.
+	d.signals.Overlay(state.SessionID, state.Metrics)
 
 	// Overlay the PreCompact force-working hold (#657).
 	d.applyCompactHold(ev.SessionID, state.Metrics, time.Now().Unix())
@@ -794,9 +790,12 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 	// Overlay the transcript-based stalled-edit-tool fallback (#488).
 	d.markStalledEditTool(ev.SessionID, state.Metrics, time.Now().Unix())
 
-	// Content-based state detection.
+	// Content-based state detection. The tiered form is used here (and only
+	// here) so the deciding rule and its authority tier reach the recorded
+	// lifecycle event as provenance (#1288).
 	now := time.Now().Unix()
-	newState, reason := ClassifyState(state.State, state.Metrics)
+	verdict := ClassifyStateTiered(state.State, state.Metrics)
+	newState, reason := verdict.State, verdict.Reason
 	newState, reason, parentHeldWorking := d.holdParentForActiveChildren(state, ev, newState, reason)
 	newState, reason = d.synthesizeCollapsedTurnBoundaryIfNeeded(state, ev, classifierCandidate{
 		NewState:          newState,
@@ -810,11 +809,16 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 	})
 
 	if newState != state.State {
-		d.applyStateTransition(state, ev, stateTransitionUpdate{
-			NewState: newState,
-			Reason:   reason,
-			Now:      now,
-		})
+		// Attach provenance only when the ladder's verdict is still what is
+		// being applied. The parent-hold and the two synthesizers above can
+		// each override it, and a transition they authored was not decided by
+		// the rule that fired — stamping its tier anyway would put a
+		// confident, wrong attribution into the permanent trace.
+		applied := stateTransitionUpdate{NewState: newState, Reason: reason, Now: now}
+		if newState == verdict.State && reason == verdict.Reason {
+			applied.Verdict = verdict
+		}
+		d.applyStateTransition(state, ev, applied)
 	}
 
 	// Cache-creation regression detection (#374). Driven every substantive
@@ -862,103 +866,11 @@ func (d *SessionDetector) forceReadyToWorkingIfActive(state *session.SessionStat
 	state.State = session.StateWorking
 }
 
-// overlayPermissionPending folds the hook-based permission-pending signal
-// onto metrics. See classifyAndTransition's call site for the ordering
-// requirement relative to RefreshOnActivity and ClassifyState.
-func (d *SessionDetector) overlayPermissionPending(state *session.SessionState) {
-	d.permMu.Lock()
-	defer d.permMu.Unlock()
-
-	if !d.permissionPending[state.SessionID] || state.Metrics == nil {
-		return
-	}
-	if state.Metrics.LastWasToolDenial {
-		// Permission was denied — Claude Code doesn't fire PostToolUseFailure
-		// on denial, so clear from transcript evidence. The denial text
-		// "[Request interrupted by user for tool use]" sets LastWasToolDenial
-		// in the parser.
-		delete(d.permissionPending, state.SessionID)
-		return
-	}
-	state.Metrics.PermissionPending = true
-}
-
-// overlayHookTurnDone folds the Claude Code Stop-hook turn-done signal (#1161)
-// onto metrics for one classify pass. It is consume-once: the entry is deleted
-// as it is read, so the authoritative done-signal applies to exactly the pass
-// the Stop hook triggered and never bleeds into the next turn (a later real
-// turn's first activity re-opens the session normally via
-// forceReadyToWorkingIfActive). Must run after RefreshOnActivity (which rebuilds
-// metrics from the transcript, zeroing this transient field) and before
-// ClassifyState / IsAgentDone, which read it.
-//
-// The final assistant text overwrites LastAssistantText for display; the
-// waiting-cue verdict — computed by the adapter from the message's full text —
-// only ever adds to PendingWaitingCue, never clears the parser's own verdict,
-// so the hook can push a turn to waiting but never mask a cue the transcript
-// already found.
-func (d *SessionDetector) overlayHookTurnDone(state *session.SessionState) {
-	if state.Metrics == nil {
-		return
-	}
-	d.permMu.Lock()
-	defer d.permMu.Unlock()
-
-	sig, ok := d.hookTurnDone[state.SessionID]
-	if !ok {
-		return
-	}
-	delete(d.hookTurnDone, state.SessionID)
-
-	state.Metrics.HookTurnDone = true
-	if sig.lastAssistantText != "" {
-		state.Metrics.LastAssistantText = sig.lastAssistantText
-	}
-	if sig.waitingCue {
-		state.Metrics.PendingWaitingCue = true
-	}
-}
-
-// overlayIdlePrompt folds the Claude Code Notification/idle_prompt hook signal
-// (#1173) onto metrics for the classify pass. Unlike overlayHookTurnDone it is
-// persistent, not consume-once: the flag is re-applied every pass so a stray
-// lower-tier reclassify (e.g. an fswatcher touch that re-runs ClassifyState)
-// can't flip the corrected waiting back to ready via rule 2.
-//
-// The signal holds only while the finished turn is still the last thing on the
-// transcript. IsAgentDone is the gate: while it is true the turn is genuinely
-// idle, so keep the entry and overlay IdlePromptPending (rule 1c → waiting). The
-// moment new activity arrives — the user replied, a new turn began — IsAgentDone
-// flips false; the idle window is over, so drop the backing entry and overlay
-// nothing, letting the session transition out of waiting normally. An open tool
-// (IsAgentDone false via HasOpenToolCall) likewise clears it: the open-tool
-// rules own that case, not idle-prompt. Must run after RefreshOnActivity (which
-// rebuilds metrics from the transcript, zeroing this transient field) and before
-// ClassifyState, which reads it.
-func (d *SessionDetector) overlayIdlePrompt(state *session.SessionState) {
-	if state.Metrics == nil {
-		return
-	}
-	d.permMu.Lock()
-	defer d.permMu.Unlock()
-
-	if !d.idlePromptPending[state.SessionID] {
-		return
-	}
-	if !state.Metrics.IsAgentDone() {
-		delete(d.idlePromptPending, state.SessionID)
-		return
-	}
-	state.Metrics.IdlePromptPending = true
-}
-
-// hasPendingIdlePrompt reports whether an idle_prompt hook signal is pending for
-// the session (#1173). Read by forceReadyToWorkingIfActive to skip the
-// ready→working bounce on the hook's synthetic reclassify. Guarded by permMu.
+// hasPendingIdlePrompt reports whether an idle_prompt hook signal is being held
+// for the session (#1173). Read by forceReadyToWorkingIfActive to skip the
+// ready→working bounce on the hook's synthetic reclassify.
 func (d *SessionDetector) hasPendingIdlePrompt(sessionID string) bool {
-	d.permMu.Lock()
-	defer d.permMu.Unlock()
-	return d.idlePromptPending[sessionID]
+	return d.signals.Held(sessionID, session.SignalIdlePrompt)
 }
 
 // holdParentForActiveChildren fast-forwards a parent's own transition when
@@ -1083,6 +995,11 @@ type stateTransitionUpdate struct {
 	NewState string
 	Reason   string
 	Now      int64
+	// Verdict is the classifier result this transition came from, carried
+	// only so its provenance (deciding rule + tier) reaches the recorded
+	// lifecycle event. Zero when the transition was synthesized rather than
+	// classified, which records no tier — see withProvenance.
+	Verdict StateVerdict
 }
 
 // applyStateTransition records and applies a state transition already
@@ -1094,7 +1011,7 @@ func (d *SessionDetector) applyStateTransition(state *session.SessionState, ev a
 	if reason != "" {
 		d.log.LogInfo(logComponentSessionDetector, ev.SessionID, reason)
 	}
-	d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: ev.SessionID, PrevState: state.State, NewState: newState, Reason: reason, Inputs: classifierInputs(state.Metrics)})
+	d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: ev.SessionID, PrevState: state.State, NewState: newState, Reason: reason, Inputs: withProvenance(classifierInputs(state.Metrics), update.Verdict)})
 	state.State = newState
 	state.UpdatedAt = now
 

--- a/core/application/services/session_detector_hook_turn_done_test.go
+++ b/core/application/services/session_detector_hook_turn_done_test.go
@@ -9,11 +9,16 @@ import (
 // hookTurnDoneSID is the session id every case below drives the overlay with.
 const hookTurnDoneSID = "s"
 
-// TestOverlayHookTurnDone covers the Stop-hook turn-done overlay (#1161):
+// TestOverlayHookTurnDone covers the Stop-hook turn-done signal (#1161):
 // consume-once semantics, the display-text overwrite, the additive waiting-cue
-// verdict, and the no-op guards. White-box so it can drive the unexported
-// overlay + hookTurnDone map directly. Each case is a named function rather
-// than an inline closure so no single function accumulates all their branches.
+// verdict, and the no-op guards.
+//
+// These assertions predate #1288 and are deliberately unchanged by it: the
+// signal moved from a bespoke overlay method to a declared policy in
+// session.signalPolicies, and this suite is the lock proving that move altered
+// no behaviour. White-box so it can drive the detector's unexported holds
+// directly. Each case is a named function rather than an inline closure so no
+// single function accumulates all their branches.
 func TestOverlayHookTurnDone(t *testing.T) {
 	t.Run("fresh signal is applied and consumed once", hookTurnDoneAppliedOnce)
 	t.Run("empty text does not clobber existing LastAssistantText", hookTurnDoneKeepsPriorText)
@@ -22,13 +27,21 @@ func TestOverlayHookTurnDone(t *testing.T) {
 	t.Run("nil metrics is a no-op", hookTurnDoneNilMetricsIsNoOp)
 }
 
+// detectorHolding returns a detector whose signal store already holds one
+// signal for hookTurnDoneSID — the state the hook receiver would have left.
+func detectorHolding(kind session.SignalKind, p session.SignalPayload) *SessionDetector {
+	d := &SessionDetector{signals: session.NewSignalHolds()}
+	d.signals.Hold(hookTurnDoneSID, kind, p)
+	return d
+}
+
 func hookTurnDoneAppliedOnce(t *testing.T) {
-	d := &SessionDetector{hookTurnDone: map[string]hookStopSignal{
-		hookTurnDoneSID: {lastAssistantText: "Which option?", waitingCue: true},
-	}}
+	d := detectorHolding(session.SignalTurnDone, session.SignalPayload{
+		LastAssistantText: "Which option?", WaitingCue: true,
+	})
 	state := &session.SessionState{SessionID: hookTurnDoneSID, Metrics: &session.SessionMetrics{}}
 
-	d.overlayHookTurnDone(state)
+	d.signals.Overlay(state.SessionID, state.Metrics)
 	if !state.Metrics.HookTurnDone {
 		t.Error("HookTurnDone must be set for a session with a pending Stop signal")
 	}
@@ -38,26 +51,24 @@ func hookTurnDoneAppliedOnce(t *testing.T) {
 	if !state.Metrics.PendingWaitingCue {
 		t.Error("PendingWaitingCue must be set when the hook reported a waiting cue")
 	}
-	if _, ok := d.hookTurnDone[hookTurnDoneSID]; ok {
-		t.Error("signal must be consumed (deleted) after one overlay pass")
+	if d.signals.Held(hookTurnDoneSID, session.SignalTurnDone) {
+		t.Error("signal must be consumed (released) after one overlay pass")
 	}
 
 	// Consume-once: a second pass on a fresh metrics struct must NOT re-apply.
 	next := &session.SessionState{SessionID: hookTurnDoneSID, Metrics: &session.SessionMetrics{}}
-	d.overlayHookTurnDone(next)
+	d.signals.Overlay(next.SessionID, next.Metrics)
 	if next.Metrics.HookTurnDone {
 		t.Error("consumed signal must not bleed into the next pass")
 	}
 }
 
 func hookTurnDoneKeepsPriorText(t *testing.T) {
-	d := &SessionDetector{hookTurnDone: map[string]hookStopSignal{
-		hookTurnDoneSID: {lastAssistantText: "", waitingCue: false},
-	}}
+	d := detectorHolding(session.SignalTurnDone, session.SignalPayload{})
 	state := &session.SessionState{SessionID: hookTurnDoneSID, Metrics: &session.SessionMetrics{
 		LastAssistantText: "prior text",
 	}}
-	d.overlayHookTurnDone(state)
+	d.signals.Overlay(state.SessionID, state.Metrics)
 	if state.Metrics.LastAssistantText != "prior text" {
 		t.Errorf("LastAssistantText = %q, want the prior text preserved", state.Metrics.LastAssistantText)
 	}
@@ -67,32 +78,30 @@ func hookTurnDoneKeepsPriorText(t *testing.T) {
 }
 
 func hookTurnDoneCueIsAdditive(t *testing.T) {
-	d := &SessionDetector{hookTurnDone: map[string]hookStopSignal{
-		hookTurnDoneSID: {lastAssistantText: "done", waitingCue: false},
-	}}
+	d := detectorHolding(session.SignalTurnDone, session.SignalPayload{LastAssistantText: "done"})
 	state := &session.SessionState{SessionID: hookTurnDoneSID, Metrics: &session.SessionMetrics{
 		PendingWaitingCue: true, // the parser already found a cue
 	}}
-	d.overlayHookTurnDone(state)
+	d.signals.Overlay(state.SessionID, state.Metrics)
 	if !state.Metrics.PendingWaitingCue {
 		t.Error("a false hook cue must not clear a PendingWaitingCue the parser set")
 	}
 }
 
 func hookTurnDoneNoSignalIsNoOp(t *testing.T) {
-	d := &SessionDetector{hookTurnDone: map[string]hookStopSignal{}}
+	d := &SessionDetector{signals: session.NewSignalHolds()}
 	state := &session.SessionState{SessionID: hookTurnDoneSID, Metrics: &session.SessionMetrics{}}
-	d.overlayHookTurnDone(state)
+	d.signals.Overlay(state.SessionID, state.Metrics)
 	if state.Metrics.HookTurnDone {
 		t.Error("a session with no pending Stop signal must not be marked done")
 	}
 }
 
 func hookTurnDoneNilMetricsIsNoOp(t *testing.T) {
-	d := &SessionDetector{hookTurnDone: map[string]hookStopSignal{hookTurnDoneSID: {}}}
+	d := detectorHolding(session.SignalTurnDone, session.SignalPayload{})
 	state := &session.SessionState{SessionID: hookTurnDoneSID, Metrics: nil}
-	d.overlayHookTurnDone(state) // must not panic
-	if _, ok := d.hookTurnDone[hookTurnDoneSID]; !ok {
+	d.signals.Overlay(state.SessionID, state.Metrics) // must not panic
+	if !d.signals.Held(hookTurnDoneSID, session.SignalTurnDone) {
 		t.Error("nil metrics must leave the pending signal untouched")
 	}
 }

--- a/core/application/services/session_detector_idle_prompt_test.go
+++ b/core/application/services/session_detector_idle_prompt_test.go
@@ -16,10 +16,15 @@ func idleDoneMetrics() *session.SessionMetrics {
 	return &session.SessionMetrics{LastEventType: "turn_done"}
 }
 
-// TestOverlayIdlePrompt covers the Notification/idle_prompt overlay (#1173):
+// TestOverlayIdlePrompt covers the Notification/idle_prompt signal (#1173):
 // persistent (not consume-once) while the turn stays idle, cleared the moment a
-// new turn begins, and the no-op guards. White-box so it can drive the
-// unexported overlay + idlePromptPending map directly.
+// new turn begins, and the no-op guards.
+//
+// These assertions predate #1288 and are deliberately unchanged by it: the
+// signal moved from a bespoke overlay method to a declared policy in
+// session.signalPolicies, and this suite is the lock proving that move altered
+// no behaviour. White-box so it can drive the detector's unexported holds
+// directly.
 func TestOverlayIdlePrompt(t *testing.T) {
 	t.Run("applied while the turn is idle, and held (not consumed)", idlePromptHeldWhileIdle)
 	t.Run("cleared when a new turn begins (IsAgentDone false)", idlePromptClearedOnNewTurn)
@@ -29,14 +34,15 @@ func TestOverlayIdlePrompt(t *testing.T) {
 }
 
 func idlePromptHeldWhileIdle(t *testing.T) {
-	d := &SessionDetector{idlePromptPending: map[string]bool{idlePromptSID: true}}
+	d := &SessionDetector{signals: session.NewSignalHolds()}
+	d.signals.Hold(idlePromptSID, session.SignalIdlePrompt, session.SignalPayload{})
 
 	state := &session.SessionState{SessionID: idlePromptSID, Metrics: idleDoneMetrics()}
-	d.overlayIdlePrompt(state)
+	d.signals.Overlay(state.SessionID, state.Metrics)
 	if !state.Metrics.IdlePromptPending {
 		t.Error("IdlePromptPending must be set while the finished turn is idle")
 	}
-	if !d.idlePromptPending[idlePromptSID] {
+	if !d.signals.Held(idlePromptSID, session.SignalIdlePrompt) {
 		t.Error("signal must be held (not consumed) after an overlay pass")
 	}
 
@@ -44,28 +50,30 @@ func idlePromptHeldWhileIdle(t *testing.T) {
 	// consume-once Stop overlay, so a lower-tier reclassify can't revert the
 	// corrected waiting back to ready.
 	next := &session.SessionState{SessionID: idlePromptSID, Metrics: idleDoneMetrics()}
-	d.overlayIdlePrompt(next)
+	d.signals.Overlay(next.SessionID, next.Metrics)
 	if !next.Metrics.IdlePromptPending {
 		t.Error("held signal must re-apply on the next pass")
 	}
 }
 
 func idlePromptClearedOnNewTurn(t *testing.T) {
-	d := &SessionDetector{idlePromptPending: map[string]bool{idlePromptSID: true}}
+	d := &SessionDetector{signals: session.NewSignalHolds()}
+	d.signals.Hold(idlePromptSID, session.SignalIdlePrompt, session.SignalPayload{})
 	// New user activity: not turn_done → IsAgentDone false.
 	state := &session.SessionState{SessionID: idlePromptSID, Metrics: &session.SessionMetrics{LastEventType: "user"}}
 
-	d.overlayIdlePrompt(state)
+	d.signals.Overlay(state.SessionID, state.Metrics)
 	if state.Metrics.IdlePromptPending {
 		t.Error("IdlePromptPending must NOT be set once a new turn started")
 	}
-	if _, ok := d.idlePromptPending[idlePromptSID]; ok {
+	if d.signals.Held(idlePromptSID, session.SignalIdlePrompt) {
 		t.Error("signal must be dropped when the idle window ends")
 	}
 }
 
 func idlePromptClearedByOpenTool(t *testing.T) {
-	d := &SessionDetector{idlePromptPending: map[string]bool{idlePromptSID: true}}
+	d := &SessionDetector{signals: session.NewSignalHolds()}
+	d.signals.Hold(idlePromptSID, session.SignalIdlePrompt, session.SignalPayload{})
 	// An open tool call makes IsAgentDone false — the open-tool rules own
 	// that case, not idle-prompt.
 	state := &session.SessionState{SessionID: idlePromptSID, Metrics: &session.SessionMetrics{
@@ -73,29 +81,30 @@ func idlePromptClearedByOpenTool(t *testing.T) {
 		HasOpenToolCall: true,
 	}}
 
-	d.overlayIdlePrompt(state)
+	d.signals.Overlay(state.SessionID, state.Metrics)
 	if state.Metrics.IdlePromptPending {
 		t.Error("IdlePromptPending must NOT be set while a tool call is open")
 	}
-	if _, ok := d.idlePromptPending[idlePromptSID]; ok {
+	if d.signals.Held(idlePromptSID, session.SignalIdlePrompt) {
 		t.Error("signal must be dropped when an open tool blocks the turn")
 	}
 }
 
 func idlePromptNoSignalIsNoOp(t *testing.T) {
-	d := &SessionDetector{idlePromptPending: map[string]bool{}}
+	d := &SessionDetector{signals: session.NewSignalHolds()}
 	state := &session.SessionState{SessionID: idlePromptSID, Metrics: idleDoneMetrics()}
-	d.overlayIdlePrompt(state)
+	d.signals.Overlay(state.SessionID, state.Metrics)
 	if state.Metrics.IdlePromptPending {
 		t.Error("a session with no pending idle-prompt signal must not be marked waiting")
 	}
 }
 
 func idlePromptNilMetricsIsNoOp(t *testing.T) {
-	d := &SessionDetector{idlePromptPending: map[string]bool{idlePromptSID: true}}
+	d := &SessionDetector{signals: session.NewSignalHolds()}
+	d.signals.Hold(idlePromptSID, session.SignalIdlePrompt, session.SignalPayload{})
 	state := &session.SessionState{SessionID: idlePromptSID, Metrics: nil}
-	d.overlayIdlePrompt(state) // must not panic
-	if !d.idlePromptPending[idlePromptSID] {
+	d.signals.Overlay(state.SessionID, state.Metrics) // must not panic
+	if !d.signals.Held(idlePromptSID, session.SignalIdlePrompt) {
 		t.Error("nil metrics must leave the pending signal untouched")
 	}
 }
@@ -103,7 +112,8 @@ func idlePromptNilMetricsIsNoOp(t *testing.T) {
 // TestHasPendingIdlePrompt covers the guard forceReadyToWorkingIfActive reads to
 // skip the ready→working bounce on the idle-prompt hook's synthetic reclassify.
 func TestHasPendingIdlePrompt(t *testing.T) {
-	d := &SessionDetector{idlePromptPending: map[string]bool{"has": true}}
+	d := &SessionDetector{signals: session.NewSignalHolds()}
+	d.signals.Hold("has", session.SignalIdlePrompt, session.SignalPayload{})
 	if !d.hasPendingIdlePrompt("has") {
 		t.Error("hasPendingIdlePrompt must report true for a session with a pending signal")
 	}

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -39,14 +39,13 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	delete(d.projectSessions, ev.SessionID)
 	d.mu.Unlock()
 
-	// Drop any leftover permission-pending flag — otherwise a hook that
-	// fired without a clearing partner (e.g. agent crash mid-overlay) would
-	// keep the entry forever, and a recycled session ID would inherit it.
+	// Drop any leftover held signal — otherwise a hook that fired without a
+	// clearing partner (e.g. agent crash mid-overlay) would keep the entry
+	// forever, and a recycled session ID would inherit it.
+	d.signals.DropSession(ev.SessionID)
+
 	d.permMu.Lock()
-	delete(d.permissionPending, ev.SessionID)
 	delete(d.compactPending, ev.SessionID)
-	delete(d.hookTurnDone, ev.SessionID)
-	delete(d.idlePromptPending, ev.SessionID)
 	delete(d.editToolOpenSince, ev.SessionID)
 	delete(d.idleProjectRetryAttempts, ev.SessionID)
 	d.permMu.Unlock()
@@ -281,14 +280,12 @@ func (d *SessionDetector) ReconcilePreSessionBackchannel(oldID, newID string) {
 //
 // Safe to call from any goroutine (e.g. HTTP handler).
 func (d *SessionDetector) HandlePermissionHook(sessionID, transcriptPath, hookEventName string) {
-	d.permMu.Lock()
 	switch hookEventName {
 	case "PermissionRequest", "PreToolUse":
-		d.permissionPending[sessionID] = true
+		d.signals.Hold(sessionID, session.SignalPermissionPrompt, session.SignalPayload{})
 	case "PostToolUse", "PostToolUseFailure":
-		delete(d.permissionPending, sessionID)
+		d.signals.Release(sessionID, session.SignalPermissionPrompt)
 	}
-	d.permMu.Unlock()
 
 	// processActivity overlays PermissionPending onto the metrics before
 	// calling ClassifyState.
@@ -326,32 +323,21 @@ func (d *SessionDetector) dispatchHookActivity(sessionID, transcriptPath, hookNa
 	}
 }
 
-// hookStopSignal carries what Claude Code's Stop hook (#1161) delivers for one
-// turn: the turn's final assistant text (already display-truncated by the
-// adapter) and whether that message carried a question / imperative waiting cue
-// (computed by the adapter from the full text). Stored per session until the
-// next classify pass consumes it.
-type hookStopSignal struct {
-	lastAssistantText string
-	waitingCue        bool
-}
-
 // HandleStopHook records the authoritative turn-done signal from Claude Code's
 // Stop hook (issue #1161), which fires once at true turn end and carries the
-// turn's final assistant text. Marking hookTurnDone makes the next classify
+// turn's final assistant text. Holding SignalTurnDone makes the next classify
 // pass overlay SessionMetrics.HookTurnDone (so IsAgentDone is authoritative,
 // not inferred from the transcript tail) and overwrite LastAssistantText /
 // PendingWaitingCue from the hook's message — so a turn that ended on a
-// question still routes to waiting, not ready.
+// question still routes to waiting, not ready. The hold is consume-once (see
+// session.signalPolicies), so it never bleeds into the following turn.
 //
 // Safe to call from any goroutine (e.g. the HTTP handler).
 func (d *SessionDetector) HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool) {
-	d.permMu.Lock()
-	d.hookTurnDone[sessionID] = hookStopSignal{
-		lastAssistantText: lastAssistantText,
-		waitingCue:        waitingCue,
-	}
-	d.permMu.Unlock()
+	d.signals.Hold(sessionID, session.SignalTurnDone, session.SignalPayload{
+		LastAssistantText: lastAssistantText,
+		WaitingCue:        waitingCue,
+	})
 
 	// classifyAndTransition overlays HookTurnDone onto the metrics before
 	// calling ClassifyState. The Stop hook fires at true turn end (after the
@@ -364,13 +350,14 @@ func (d *SessionDetector) HandleStopHook(sessionID, transcriptPath, lastAssistan
 
 // HandleIdlePromptHook records Claude Code's Notification/idle_prompt hook
 // (issue #1173): the agent has finished its turn and is now idle at the prompt
-// waiting for the user. Marking idlePromptPending makes every subsequent
-// classify pass overlay SessionMetrics.IdlePromptPending (ClassifyState rule 1c)
+// waiting for the user. Holding SignalIdlePrompt makes every subsequent
+// classify pass overlay SessionMetrics.IdlePromptPending (the idle_prompt rule)
 // so the session shows waiting even when the turn ended on a plain statement
-// that PendingWaitingCue's prose heuristic can't detect. The flag is held until
-// the next turn begins (overlayIdlePrompt clears it once IsAgentDone flips
-// false), not consumed once — a lower-tier reclassify must not revert the
-// corrected waiting back to ready.
+// that PendingWaitingCue's prose heuristic can't detect. The hold is persistent
+// rather than consume-once (see session.signalPolicies) and lasts until the
+// next turn begins, when its staleness rule drops it as IsAgentDone flips
+// false — a lower-tier reclassify must not revert the corrected waiting back to
+// ready.
 //
 // The idle_prompt hook fires after the turn goes idle (the session is typically
 // already ready by then), so this is a reconcile-and-correct: the synthetic
@@ -382,9 +369,7 @@ func (d *SessionDetector) HandleStopHook(sessionID, transcriptPath, lastAssistan
 //
 // Safe to call from any goroutine (e.g. the HTTP handler).
 func (d *SessionDetector) HandleIdlePromptHook(sessionID, transcriptPath string) {
-	d.permMu.Lock()
-	d.idlePromptPending[sessionID] = true
-	d.permMu.Unlock()
+	d.signals.Hold(sessionID, session.SignalIdlePrompt, session.SignalPayload{})
 
 	d.dispatchHookActivity(sessionID, transcriptPath, "Notification")
 }

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -265,7 +265,7 @@ func transitionTo(currentState, target, reason string) (string, string) {
 	return currentState, ""
 }
 
-// classifyAgentDone handles rule 2 of ClassifyState: the agent has finished
+// classifyAgentDone handles the agent_done rule of ClassifyState: the agent has finished
 // its turn. It routes to waiting first when the turn ended with a question
 // or imperative cue (issue #381), otherwise to ready.
 func classifyAgentDone(currentState string, metrics *session.SessionMetrics) (string, string) {
@@ -278,7 +278,7 @@ func classifyAgentDone(currentState string, metrics *session.SessionMetrics) (st
 	return currentState, ""
 }
 
-// isUserInterruptReady reports whether rule 3 of ClassifyState applies: the
+// isUserInterruptReady reports whether the user_interrupt rule of ClassifyState applies: the
 // session was working/waiting with no open tool call, the last transcript
 // event was from the user, and that event was an ESC interrupt or
 // tool-permission denial — meaning the agent's turn is effectively over.
@@ -313,10 +313,10 @@ const ForceReadyToWorkingReason = "force ready→working on first activity"
 //
 //   - Case A: tool_result carries is_error=true AND a trailing user text
 //     "[Request interrupted by user for tool use]" sets LastWasToolDenial.
-//     Classifier returns ready via rule 3.
+//     Classifier returns ready via the user_interrupt rule.
 //   - Case B: the denial user text is followed by another user event in
 //     the same pass, which clears LastWasToolDenial. Classifier then
-//     returns working via rule 4 default. Without this helper the user
+//     returns working via the transcript_activity default. Without this helper the user
 //     never sees the waiting episode at all.
 //
 // Callers (SessionDetector.processActivity and the replay harness) should,

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -9,100 +9,250 @@ import (
 	"irrlicht/core/domain/session"
 )
 
-// ClassifyState applies the decision tree to determine what state a session
+// StateVerdict is the full result of a classification pass: the state to move
+// to, the human-readable reason, and — the part #1288 adds — which rule
+// decided and on what tier of the authority ladder its evidence arrived.
+//
+// The tier is provenance, not prose. It is recorded as structured data on the
+// lifecycle event rather than folded into Reason, because Reason strings are
+// pinned byte-for-byte by 338 committed replay goldens: putting the tier there
+// would rewrite every one of them and destroy their value as a regression net
+// for this very refactor.
+type StateVerdict struct {
+	State  string
+	Reason string
+	// Tier is where the deciding evidence came from. TierNone when no rule
+	// fired at all.
+	Tier session.SignalTier
+	// Rule is the deciding rule's stable id, for logs and traces.
+	Rule string
+}
+
+// stateRule is one rung of the classifier's authority ladder.
+//
+// Before #1288 these were bare if-statements in a fixed sequence, and the fact
+// that a hook's verdict outranked a transcript guess was encoded as nothing
+// more than which if-statement was written first. Declaring each rule's tier
+// makes that arbitration checkable — see TestStateRules_OrderIsTierConsistent,
+// which fails if a future edit reorders the ladder so a lower tier preempts a
+// higher one for signals that can be true at the same time.
+type stateRule struct {
+	// id is a stable identifier for logs and traces.
+	id string
+
+	// tier reports the authority of this rule's evidence. It is a function
+	// because one rule genuinely has two tiers: agent-done is TierHook when a
+	// Stop hook delivered it and TierTranscript when it was inferred from the
+	// transcript tail — the exact distinction AC3 asks to be able to see.
+	tier func(m *session.SessionMetrics) session.SignalTier
+
+	// eval reports whether this rule claims the decision, and if so what it
+	// decides. fired=true with an empty reason is normal and meaningful: the
+	// rule owns the outcome but the session is already in the target state,
+	// so no transition is emitted and no lower rule may run.
+	eval func(currentState string, m *session.SessionMetrics) (state, reason string, fired bool)
+}
+
+// tierAlways returns a tier function for a rule whose evidence always arrives
+// on the same tier.
+func tierAlways(t session.SignalTier) func(*session.SessionMetrics) session.SignalTier {
+	return func(*session.SessionMetrics) session.SignalTier { return t }
+}
+
+// stateRules is the classifier's decision ladder, most authoritative first.
+//
+// Order is still significant — the first rule to fire decides — but it is no
+// longer the *only* record of the intended arbitration: each rule now carries
+// the tier its evidence arrives on, so the ordering can be asserted rather
+// than merely commented.
+//
+// Two transcript-tier rules (user_blocking_tool, open_tool_stalled) sit above
+// the hook-tier idle_prompt rule, which looks like an inversion and is not:
+// both require an open tool call, an open tool call makes IsAgentDone false,
+// and the idle_prompt hold is dropped as stale the moment IsAgentDone goes
+// false. The three can never contend for the same pass. That claim is not left
+// to inspection — TestStateRules_OrderIsTierConsistent enforces it by finding
+// metrics where a pair does contend, and would fail if a future change made
+// these reachable together.
+var stateRules = []stateRule{
+	{
+		// Permission prompt is open (hook-based signal) → waiting.
+		// The most authoritative signal available, and the only instant one.
+		// Checked before NeedsUserAttention because it doesn't depend on
+		// HasOpenToolCall (avoids the race where the hook fires before
+		// fswatcher processes the tool_use JSONL event).
+		id:   "permission_prompt",
+		tier: tierAlways(session.TierHook),
+		eval: func(cur string, m *session.SessionMetrics) (string, string, bool) {
+			if !m.PermissionPending {
+				return "", "", false
+			}
+			s, r := transitionTo(cur, session.StateWaiting, "permission prompt open → waiting")
+			return s, r, true
+		},
+	},
+	{
+		// Manual /compact in progress (PreCompact hook) → working, regardless
+		// of the stale pre-compact turn_done that IsAgentDone() would
+		// otherwise read as ready. Compaction writes nothing to the transcript
+		// for tens of seconds to minutes; this overlay holds the session busy
+		// for that window (#657). The detector clears it the pass the manual
+		// compact_boundary lands, which then routes to ready via agent_done
+		// (#656).
+		id:   "compact_in_progress",
+		tier: tierAlways(session.TierHook),
+		eval: func(cur string, m *session.SessionMetrics) (string, string, bool) {
+			if !m.CompactInProgress {
+				return "", "", false
+			}
+			s, r := transitionTo(cur, session.StateWorking, "manual /compact in progress → working")
+			return s, r, true
+		},
+	},
+	{
+		// User-blocking tool open → waiting.
+		id:   "user_blocking_tool",
+		tier: tierAlways(session.TierTranscript),
+		eval: func(cur string, m *session.SessionMetrics) (string, string, bool) {
+			if !m.NeedsUserAttention() {
+				return "", "", false
+			}
+			s, r := transitionTo(cur, session.StateWaiting, "user-blocking tool open → waiting")
+			return s, r, true
+		},
+	},
+	{
+		// A permission-gated file-edit tool has been open and idle long enough
+		// that the agent is almost certainly blocked on a permission prompt →
+		// waiting. Transcript-based fallback for when the curl-delivered
+		// PermissionRequest hook can't reach the daemon (#488). The detector
+		// sets OpenToolStalled only after the open tool has lingered with no
+		// transcript progress, so this never fires on a tool that is actively
+		// executing.
+		id:   "open_tool_stalled",
+		tier: tierAlways(session.TierTranscript),
+		eval: func(cur string, m *session.SessionMetrics) (string, string, bool) {
+			if !m.OpenToolStalled {
+				return "", "", false
+			}
+			s, r := transitionTo(cur, session.StateWaiting, "stalled edit tool → likely permission prompt → waiting")
+			return s, r, true
+		},
+	},
+	{
+		// Claude Code's Notification/idle_prompt hook reported the agent is
+		// idle at the prompt waiting for the user (#1173) → waiting.
+		// Authoritative tier above the turn-done → ready verdict below: it
+		// corrects the case where the turn ended on a plain statement with no
+		// trailing question/cue, which agent_done would otherwise route to
+		// ready. Live-only — the hold is only ever placed while the finished
+		// turn is still idle (and never under replay), so this rule is inert
+		// for every non-hook path.
+		id:   "idle_prompt",
+		tier: tierAlways(session.TierHook),
+		eval: func(cur string, m *session.SessionMetrics) (string, string, bool) {
+			if !m.IdlePromptPending {
+				return "", "", false
+			}
+			s, r := transitionTo(cur, session.StateWaiting, "idle prompt hook → waiting")
+			return s, r, true
+		},
+	},
+	{
+		// Agent finished turn — check if waiting for user input first. A
+		// hook-delivered Stop (#1161, #1171) is authoritative here: IsAgentDone
+		// consults metrics.HookTurnDone ahead of the transcript-tail heuristic,
+		// so a Stop routes through the same classifyAgentDone path (a turn that
+		// ended on a question/cue still lands in waiting, not ready).
+		//
+		// This is the one rule whose tier is genuinely dynamic — the same
+		// verdict is authoritative when a hook delivered it and inferred when
+		// the transcript tail did.
+		id:   "agent_done",
+		tier: tierAgentDone,
+		eval: func(cur string, m *session.SessionMetrics) (string, string, bool) {
+			if !m.IsAgentDone() {
+				return "", "", false
+			}
+			s, r := classifyAgentDone(cur, m)
+			return s, r, true
+		},
+	},
+	{
+		// User interruption: ESC or tool-permission denial while
+		// working/waiting with no open tool calls → ready.
+		//
+		// ESC signal: "[Request interrupted by user]" (LastWasUserInterrupt).
+		// Denial signal: "[Request interrupted by user for tool use]"
+		// (LastWasToolDenial). After denial, Claude Code typically returns to
+		// the prompt — the agent's turn is over. If the agent does continue
+		// (writes a new assistant message), the next activity will transition
+		// back to working.
+		id:   "user_interrupt",
+		tier: tierAlways(session.TierTranscript),
+		eval: func(cur string, m *session.SessionMetrics) (string, string, bool) {
+			if !isUserInterruptReady(cur, m) {
+				return "", "", false
+			}
+			reason := "user ESC interrupt"
+			if m.LastWasToolDenial {
+				reason = "tool permission denied"
+			}
+			return session.StateReady, fmt.Sprintf("%s while %s → ready", reason, cur), true
+		},
+	},
+	{
+		// Default: transcript activity → working. Always fires, so the ladder
+		// is total and every pass has a decision.
+		id:   "transcript_activity",
+		tier: tierAlways(session.TierTranscript),
+		eval: func(cur string, m *session.SessionMetrics) (string, string, bool) {
+			s, r := transitionTo(cur, session.StateWorking,
+				fmt.Sprintf("transcript activity (%s → working)", cur))
+			return s, r, true
+		},
+	},
+}
+
+// tierAgentDone reports the tier the agent-done verdict rests on: TierHook
+// when a Stop hook delivered it, TierTranscript when it was inferred from the
+// transcript tail. This is the distinction that makes a hook-delivered ready
+// distinguishable from a guessed one in a recorded trace.
+func tierAgentDone(m *session.SessionMetrics) session.SignalTier {
+	if m.HookTurnDone {
+		return session.TierHook
+	}
+	return session.TierTranscript
+}
+
+// ClassifyState applies the decision ladder to determine what state a session
 // should be in based on its current state and latest metrics.
 //
-// Decision order (the body's rule numbering in parentheses):
-//   - PermissionPending → waiting (0)
-//   - CompactInProgress → working (0b)
-//   - NeedsUserAttention → waiting (1)
-//   - OpenToolStalled → waiting (1b)
-//   - IdlePromptPending → waiting (1c)
-//   - IsAgentDone → ready, from working/waiting only (2)
-//   - ESC cancellation / tool denial (user + error + no open tools) → ready (3)
-//   - Default → working (4)
-//
 // Returns (newState, reason). An empty reason means no transition occurred.
+// This is the ubiquitous entry point; use ClassifyStateTiered where the
+// deciding tier is wanted too.
 func ClassifyState(currentState string, metrics *session.SessionMetrics) (string, string) {
+	v := ClassifyStateTiered(currentState, metrics)
+	return v.State, v.Reason
+}
+
+// ClassifyStateTiered is ClassifyState with provenance: it reports which rule
+// decided and which tier of the authority ladder its evidence arrived on.
+func ClassifyStateTiered(currentState string, metrics *session.SessionMetrics) StateVerdict {
 	if metrics == nil {
-		return currentState, ""
+		return StateVerdict{State: currentState}
 	}
-
-	// 0. Permission prompt is open (hook-based signal) → waiting.
-	// This is the most authoritative signal — deterministic from Claude Code's
-	// own hook system. Checked before NeedsUserAttention because it doesn't
-	// depend on HasOpenToolCall (avoids race where hook fires before fswatcher
-	// processes the tool_use JSONL event).
-	if metrics.PermissionPending {
-		return transitionTo(currentState, session.StateWaiting, "permission prompt open → waiting")
-	}
-
-	// 0b. Manual /compact in progress (PreCompact hook) → working, regardless
-	// of the stale pre-compact turn_done that IsAgentDone() would otherwise read
-	// as ready. Compaction writes nothing to the transcript for tens of seconds
-	// to minutes; this overlay holds the session busy for that window (#657).
-	// The detector clears it the pass the manual compact_boundary lands, which
-	// then routes to ready via rule 2 (#656).
-	if metrics.CompactInProgress {
-		return transitionTo(currentState, session.StateWorking, "manual /compact in progress → working")
-	}
-
-	// 1. User-blocking tool open → waiting.
-	if metrics.NeedsUserAttention() {
-		return transitionTo(currentState, session.StateWaiting, "user-blocking tool open → waiting")
-	}
-
-	// 1b. A permission-gated file-edit tool has been open and idle long enough
-	// that the agent is almost certainly blocked on a permission prompt →
-	// waiting. Transcript-based fallback for when the curl-delivered
-	// PermissionRequest hook can't reach the daemon (#488). The detector sets
-	// OpenToolStalled only after the open tool has lingered with no transcript
-	// progress, so this never fires on a tool that is actively executing.
-	if metrics.OpenToolStalled {
-		return transitionTo(currentState, session.StateWaiting, "stalled edit tool → likely permission prompt → waiting")
-	}
-
-	// 1c. Claude Code's Notification/idle_prompt hook reported the agent is idle
-	// at the prompt waiting for the user (#1173) → waiting. Authoritative tier
-	// above the turn-done → ready verdict below: it corrects the case where the
-	// turn ended on a plain statement with no trailing question/cue, which rule 2
-	// would otherwise route to ready. Live-only — the detector's overlayIdlePrompt
-	// only sets this while the finished turn is still idle (and never under
-	// replay), so this rule is inert for every non-hook path.
-	if metrics.IdlePromptPending {
-		return transitionTo(currentState, session.StateWaiting, "idle prompt hook → waiting")
-	}
-
-	// 2. Agent finished turn — check if waiting for user input first. A
-	// hook-delivered Stop (claudecode, #1161) is authoritative here: IsAgentDone
-	// consults metrics.HookTurnDone ahead of the transcript-tail heuristic, so a
-	// Stop routes through the same classifyAgentDone path (a turn that ended on a
-	// question/cue still lands in waiting, not ready).
-	if metrics.IsAgentDone() {
-		return classifyAgentDone(currentState, metrics)
-	}
-
-	// 3. User interruption: ESC or tool-permission denial while
-	// working/waiting with no open tool calls → ready.
-	//
-	// ESC signal: "[Request interrupted by user]" (LastWasUserInterrupt).
-	// Denial signal: "[Request interrupted by user for tool use]"
-	// (LastWasToolDenial). After denial, Claude Code typically returns to
-	// the prompt — the agent's turn is over. If the agent does continue
-	// (writes a new assistant message), the next activity will transition
-	// back to working.
-	if isUserInterruptReady(currentState, metrics) {
-		reason := "user ESC interrupt"
-		if metrics.LastWasToolDenial {
-			reason = "tool permission denied"
+	for _, rule := range stateRules {
+		state, reason, fired := rule.eval(currentState, metrics)
+		if !fired {
+			continue
 		}
-		return session.StateReady,
-			fmt.Sprintf("%s while %s → ready", reason, currentState)
+		return StateVerdict{State: state, Reason: reason, Tier: rule.tier(metrics), Rule: rule.id}
 	}
-
-	// 4. Default: transcript activity → working.
-	return transitionTo(currentState, session.StateWorking,
-		fmt.Sprintf("transcript activity (%s → working)", currentState))
+	// Unreachable while the ladder ends in an always-firing rule; kept so a
+	// future edit that removes it degrades to "no transition" rather than to
+	// an out-of-range panic.
+	return StateVerdict{State: currentState}
 }
 
 // transitionTo returns (target, reason) when currentState differs from

--- a/core/application/services/state_classifier_tier_test.go
+++ b/core/application/services/state_classifier_tier_test.go
@@ -1,0 +1,277 @@
+package services
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestClassify_HookOutranksTranscript is AC2 stated at its simplest: when a
+// hook-tier signal and a transcript-tier signal disagree about the same pass,
+// the hook wins.
+//
+// The conflict is real and is the #1173 case: the transcript tail says the turn
+// ended (agent_done → ready) while the idle_prompt hook says the user is
+// actually sitting blocked at the prompt (→ waiting). Before hooks existed this
+// pass produced `ready` and the badge was wrong.
+func TestClassify_HookOutranksTranscript(t *testing.T) {
+	m := &session.SessionMetrics{
+		LastEventType:     "turn_done", // transcript tier: the turn is over → ready
+		IdlePromptPending: true,        // hook tier: the user is blocked → waiting
+	}
+
+	v := ClassifyStateTiered(session.StateWorking, m)
+
+	if v.State != session.StateWaiting {
+		t.Errorf("state = %q, want waiting — the hook tier must win", v.State)
+	}
+	if v.Tier != session.TierHook {
+		t.Errorf("tier = %v, want TierHook", v.Tier)
+	}
+	if v.Rule != "idle_prompt" {
+		t.Errorf("rule = %q, want idle_prompt", v.Rule)
+	}
+}
+
+// TestStateRules_LadderIsTierConsistent is AC2's real content: it asserts the
+// ladder's arbitration is correct *as a property*, rather than asserting the
+// particular sequence the rules happen to be written in.
+//
+// For every reachable combination of signals it finds which rule wins and
+// checks that no rule further down the ladder — one that would also have fired
+// on the same metrics — sits on a strictly higher tier. An edit that reorders
+// the ladder so a transcript guess preempts a hook fails here.
+//
+// "Reachable" is load-bearing and is why the corpus is built by placing real
+// holds and running SignalHolds.Overlay rather than by setting metrics fields
+// directly. Two transcript-tier rules (user_blocking_tool, open_tool_stalled)
+// are written *above* the hook-tier idle_prompt rule, which is only sound
+// because an open tool call makes IsAgentDone false, which makes the
+// idle_prompt hold stale, which means the pair can never contend. Building the
+// corpus through Overlay is what tests that argument instead of assuming it: if
+// a future change let the two co-occur, this test fails rather than the badge
+// silently regressing.
+func TestStateRules_LadderIsTierConsistent(t *testing.T) {
+	for _, base := range reachableMetricFixtures(t) {
+		for _, cur := range []string{session.StateWorking, session.StateWaiting, session.StateReady} {
+			winner, winnerIdx := firstFiringRule(cur, base.metrics)
+			if winnerIdx < 0 {
+				t.Fatalf("%s: no rule fired — the ladder must be total", base.name)
+			}
+			winnerTier := stateRules[winnerIdx].tier(base.metrics)
+
+			for i := winnerIdx + 1; i < len(stateRules); i++ {
+				if _, _, fired := stateRules[i].eval(cur, base.metrics); !fired {
+					continue
+				}
+				if lower := stateRules[i].tier(base.metrics); lower.Outranks(winnerTier) {
+					t.Errorf("%s (current=%s): rule %q (tier %v) decided, but lower rule %q (tier %v) outranks it",
+						base.name, cur, winner, winnerTier, stateRules[i].id, lower)
+				}
+			}
+		}
+	}
+}
+
+// firstFiringRule returns the id and index of the rule that claims the
+// decision, mirroring ClassifyStateTiered's own walk.
+func firstFiringRule(cur string, m *session.SessionMetrics) (string, int) {
+	for i, r := range stateRules {
+		if _, _, fired := r.eval(cur, m); fired {
+			return r.id, i
+		}
+	}
+	return "", -1
+}
+
+type metricFixture struct {
+	name    string
+	metrics *session.SessionMetrics
+}
+
+// reachableMetricFixtures builds the corpus for the ladder property test: every
+// combination of transcript shapes crossed with every subset of held hook
+// signals, each run through SignalHolds.Overlay so the resulting metrics are
+// only ever ones the live detector could actually hand the classifier.
+func reachableMetricFixtures(t *testing.T) []metricFixture {
+	t.Helper()
+
+	transcripts := []metricFixture{
+		{"idle-turn-done", &session.SessionMetrics{LastEventType: "turn_done"}},
+		{"assistant-tail", &session.SessionMetrics{LastEventType: "assistant"}},
+		{"user-tail", &session.SessionMetrics{LastEventType: "user"}},
+		{"esc-interrupt", &session.SessionMetrics{LastEventType: "user", LastWasUserInterrupt: true}},
+		{"tool-denial", &session.SessionMetrics{LastEventType: "user", LastWasToolDenial: true}},
+		{"user-blocking-tool-open", &session.SessionMetrics{
+			LastEventType: "assistant", HasOpenToolCall: true,
+			LastOpenToolNames: []string{"AskUserQuestion"},
+		}},
+		{"edit-tool-open", &session.SessionMetrics{
+			LastEventType: "assistant", HasOpenToolCall: true,
+			LastOpenToolNames: []string{"Edit"},
+		}},
+		{"stalled-edit-tool", &session.SessionMetrics{
+			LastEventType: "assistant", HasOpenToolCall: true,
+			LastOpenToolNames: []string{"Edit"}, OpenToolStalled: true,
+		}},
+		{"live-background-process", &session.SessionMetrics{
+			LastEventType: "turn_done", HasLiveBackgroundProcess: true,
+		}},
+		{"compacting", &session.SessionMetrics{LastEventType: "assistant", CompactInProgress: true}},
+	}
+
+	holdSets := []struct {
+		name  string
+		kinds []session.SignalKind
+	}{
+		{"no-hooks", nil},
+		{"permission", []session.SignalKind{session.SignalPermissionPrompt}},
+		{"turn-done", []session.SignalKind{session.SignalTurnDone}},
+		{"idle-prompt", []session.SignalKind{session.SignalIdlePrompt}},
+		{"turn-done+idle-prompt", []session.SignalKind{session.SignalTurnDone, session.SignalIdlePrompt}},
+		{"permission+idle-prompt", []session.SignalKind{session.SignalPermissionPrompt, session.SignalIdlePrompt}},
+		{"all", []session.SignalKind{session.SignalPermissionPrompt, session.SignalTurnDone, session.SignalIdlePrompt}},
+	}
+
+	var out []metricFixture
+	for _, tr := range transcripts {
+		for _, hs := range holdSets {
+			m := *tr.metrics // copy: Overlay mutates
+			holds := session.NewSignalHolds()
+			for _, k := range hs.kinds {
+				holds.Hold("s", k, session.SignalPayload{})
+			}
+			holds.Overlay("s", &m)
+			out = append(out, metricFixture{name: tr.name + "/" + hs.name, metrics: &m})
+		}
+	}
+	return out
+}
+
+// TestClassify_ProvenanceDistinguishesHookFromInference is AC3: two passes that
+// produce the identical state AND the identical human-readable reason must
+// still be tellable apart by where their evidence came from.
+//
+// This is the concrete gap the epic named — a recorded trace could show a
+// session going ready but not whether Claude Code's Stop hook said so or a
+// heuristic guessed it from the transcript tail. The Reason string is
+// deliberately identical in both cases: it is pinned byte-for-byte by 338
+// replay goldens, so provenance had to land somewhere other than the prose.
+func TestClassify_ProvenanceDistinguishesHookFromInference(t *testing.T) {
+	inferred := ClassifyStateTiered(session.StateWorking, &session.SessionMetrics{
+		LastEventType: "turn_done", // transcript tail heuristic
+	})
+	hooked := ClassifyStateTiered(session.StateWorking, &session.SessionMetrics{
+		LastEventType: "assistant_message", // tail alone would NOT say done
+		HookTurnDone:  true,                // the Stop hook did
+	})
+
+	if inferred.State != session.StateReady || hooked.State != session.StateReady {
+		t.Fatalf("both must reach ready: inferred=%q hooked=%q", inferred.State, hooked.State)
+	}
+	if inferred.Reason != hooked.Reason {
+		t.Fatalf("precondition failed: the two paths must share a reason string, got %q vs %q",
+			inferred.Reason, hooked.Reason)
+	}
+
+	if inferred.Tier != session.TierTranscript {
+		t.Errorf("inferred ready tier = %v, want TierTranscript", inferred.Tier)
+	}
+	if hooked.Tier != session.TierHook {
+		t.Errorf("hook-delivered ready tier = %v, want TierHook", hooked.Tier)
+	}
+}
+
+// TestWithProvenance_StampsOnlyClassifierVerdicts pins that provenance is a
+// property of a verdict, not of metrics: a synthesized transition (emitted by
+// the collapse/catch-up synthesizers, which no rule decided) must record no
+// tier rather than borrowing one.
+func TestWithProvenance_StampsOnlyClassifierVerdicts(t *testing.T) {
+	m := &session.SessionMetrics{LastEventType: "turn_done", HookTurnDone: true}
+
+	stamped := withProvenance(classifierInputs(m), ClassifyStateTiered(session.StateWorking, m))
+	if stamped.DecidedByTier != "hook" || stamped.DecidedByRule != "agent_done" {
+		t.Errorf("classifier verdict must stamp provenance, got tier=%q rule=%q",
+			stamped.DecidedByTier, stamped.DecidedByRule)
+	}
+
+	synthetic := withProvenance(classifierInputs(m), StateVerdict{})
+	if synthetic.DecidedByTier != "" || synthetic.DecidedByRule != "" {
+		t.Errorf("a synthesized transition must record no provenance, got tier=%q rule=%q",
+			synthetic.DecidedByTier, synthetic.DecidedByRule)
+	}
+}
+
+// TestClassifierInputs_CapturesHookSignals covers the two fields that were
+// missing from the recorded snapshot before #1288 — without them a trace could
+// not show which tier decided even when the classifier knew.
+func TestClassifierInputs_CapturesHookSignals(t *testing.T) {
+	in := classifierInputs(&session.SessionMetrics{HookTurnDone: true, IdlePromptPending: true})
+	if !in.HookTurnDone || !in.IdlePromptPending {
+		t.Errorf("hook signals must be captured in the trace snapshot: %+v", in)
+	}
+}
+
+// TestClassify_LateAuthoritativeSignalDoesNotFlap is AC5, and the reason
+// Phase 3 exists at all: the authoritative signal arrives *after* the
+// lower-tier guess has already been shown.
+//
+// The measured live sequence (#1141): the turn ends on a plain statement with
+// no question or cue, so the transcript tier says ready and the badge shows
+// ready. ~6s later the idle_prompt hook lands saying the user is actually
+// blocked. The correction must be a single clean ready→waiting, and must then
+// hold across every subsequent reclassify — an fswatcher touch re-running the
+// classifier must not walk it back to ready, which is what an unheld signal
+// would do on the very next pass.
+func TestClassify_LateAuthoritativeSignalDoesNotFlap(t *testing.T) {
+	holds := session.NewSignalHolds()
+	const sid = "s"
+
+	// The turn ends; no hook has landed yet. Transcript tier decides.
+	m := &session.SessionMetrics{LastEventType: "turn_done"}
+	holds.Overlay(sid, m)
+	v := ClassifyStateTiered(session.StateWorking, m)
+	if v.State != session.StateReady {
+		t.Fatalf("before the hook lands, the transcript tier must say ready, got %q", v.State)
+	}
+	if v.Tier != session.TierTranscript {
+		t.Fatalf("that verdict must be marked as inferred, got tier %v", v.Tier)
+	}
+	state := v.State
+
+	// ~6s later: the idle_prompt hook lands and corrects the guess.
+	holds.Hold(sid, session.SignalIdlePrompt, session.SignalPayload{})
+
+	corrected := &session.SessionMetrics{LastEventType: "turn_done"}
+	holds.Overlay(sid, corrected)
+	v = ClassifyStateTiered(state, corrected)
+	if v.State != session.StateWaiting {
+		t.Fatalf("the hook must correct ready→waiting, got %q", v.State)
+	}
+	if v.Tier != session.TierHook {
+		t.Errorf("the correction must be attributed to the hook tier, got %v", v.Tier)
+	}
+	state = v.State
+
+	// Every later reclassify while the user is still blocked must stay put —
+	// no oscillation back through ready.
+	for pass := 1; pass <= 3; pass++ {
+		again := &session.SessionMetrics{LastEventType: "turn_done"}
+		holds.Overlay(sid, again)
+		v = ClassifyStateTiered(state, again)
+		if v.State != session.StateWaiting {
+			t.Fatalf("pass %d: state flapped to %q; the held signal must keep it in waiting", pass, v.State)
+		}
+		if v.Reason != "" {
+			t.Errorf("pass %d: a no-op re-classification must not emit a transition, got reason %q", pass, v.Reason)
+		}
+	}
+
+	// The user finally replies: the hold goes stale and the session moves on.
+	replied := &session.SessionMetrics{LastEventType: "user"}
+	holds.Overlay(sid, replied)
+	v = ClassifyStateTiered(state, replied)
+	if v.State != session.StateWorking {
+		t.Errorf("after the user replies the session must resume working, got %q", v.State)
+	}
+}

--- a/core/domain/lifecycle/event.go
+++ b/core/domain/lifecycle/event.go
@@ -151,4 +151,25 @@ type ClassifierInputs struct {
 	LastEventType                     string   `json:"last_event_type,omitempty"`
 	LastWasUserInterrupt              bool     `json:"last_was_user_interrupt,omitempty"`
 	LastWasToolDenial                 bool     `json:"last_was_tool_denial,omitempty"`
+
+	// HookTurnDone and IdlePromptPending are the two hook-delivered signals
+	// (#1161, #1173) that were missing from this snapshot: a trace could show
+	// that a session went ready but not whether a Stop hook said so or a
+	// transcript-tail heuristic guessed it — the exact question a tiered state
+	// layer has to be able to answer about its own history (#1288).
+	HookTurnDone      bool `json:"hook_turn_done,omitempty"`
+	IdlePromptPending bool `json:"idle_prompt_pending,omitempty"`
+
+	// DecidedByTier is the authority tier of the evidence that decided this
+	// transition ("hook", "transcript", …) and DecidedByRule the id of the
+	// rule that claimed it. Together they are the provenance half of #1288:
+	// two transitions with identical Reason prose ("agent finished turn →
+	// ready") are no longer indistinguishable when one came from a Stop hook
+	// and the other from a guess at the transcript tail.
+	//
+	// Empty on synthetic transitions, which are emitted by the collapse/
+	// catch-up synthesizers rather than decided by the ladder — an absent
+	// tier means "not a classifier verdict", never "unknown tier".
+	DecidedByTier string `json:"decided_by_tier,omitempty"`
+	DecidedByRule string `json:"decided_by_rule,omitempty"`
 }

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -250,7 +250,7 @@ type SessionMetrics struct {
 	// HookTurnDone is true when Claude Code's Stop hook fired for this session's
 	// current turn — an authoritative, per-adapter turn-done push delivered at
 	// true turn end (issue #1161). Transient and live-only: the detector's
-	// overlayHookTurnDone sets it for the single classify pass triggered by the
+	// SignalTurnDone policy (consume-once) applies it for the single classify pass triggered by the
 	// Stop hook and then clears its backing map (consume-once), so it never
 	// bleeds into the next turn and is never set under replay. IsAgentDone()
 	// treats it as authoritative, taking precedence over the transcript-tail
@@ -261,8 +261,8 @@ type SessionMetrics struct {
 	// reported that the agent has finished its turn and is now sitting idle at
 	// the prompt waiting for the user (issue #1173) — the authoritative signal
 	// for the "turn ended with no trailing question or cue" case that
-	// PendingWaitingCue's prose heuristic (rule 2) cannot reach. Transient and
-	// live-only: set by the detector's overlayIdlePrompt from a per-session map
+	// PendingWaitingCue's prose heuristic (the agent_done rule) cannot reach. Transient and
+	// live-only: applied by the SignalIdlePrompt policy from a SignalHolds entry
 	// held only while the finished turn is still the last thing on the
 	// transcript, and never set under replay. ClassifyState reads it as an
 	// authoritative waiting tier above the turn-done → ready verdict, so a turn

--- a/core/domain/session/signal_hold.go
+++ b/core/domain/session/signal_hold.go
@@ -210,16 +210,21 @@ func (h *SignalHolds) DropSession(sessionID string) {
 }
 
 // Overlay folds every currently-valid held signal for sessionID onto m, in
-// signalOrder, and returns the highest tier it actually applied (TierNone if
-// it applied nothing). Stale holds are dropped without being applied;
-// consume-once holds are dropped as they are applied.
+// signalOrder. Stale holds are dropped without being applied; consume-once
+// holds are dropped as they are applied.
 //
 // Call this after the metrics have been rebuilt from the transcript — which
 // zeroes the transient fields these signals set — and before classification,
 // which reads them.
-func (h *SignalHolds) Overlay(sessionID string, m *SessionMetrics) SignalTier {
+//
+// Note that staleness is evaluated before apply on every pass, including the
+// first: a signal that is already contradicted when it arrives is discarded
+// rather than applied once. That matters for a late signal (the ~6s
+// idle_prompt, or a retrospective OTel span) that lands after the condition it
+// describes has already ended.
+func (h *SignalHolds) Overlay(sessionID string, m *SessionMetrics) {
 	if m == nil {
-		return TierNone
+		return
 	}
 
 	h.mu.Lock()
@@ -227,10 +232,9 @@ func (h *SignalHolds) Overlay(sessionID string, m *SessionMetrics) SignalTier {
 
 	holds := h.held[sessionID]
 	if len(holds) == 0 {
-		return TierNone
+		return
 	}
 
-	applied := TierNone
 	for _, kind := range signalOrder {
 		payload, ok := holds[kind]
 		if !ok {
@@ -244,9 +248,6 @@ func (h *SignalHolds) Overlay(sessionID string, m *SessionMetrics) SignalTier {
 		}
 
 		policy.apply(m, payload)
-		if policy.tier.Outranks(applied) {
-			applied = policy.tier
-		}
 		if policy.consumeOnce {
 			delete(holds, kind)
 		}
@@ -255,5 +256,4 @@ func (h *SignalHolds) Overlay(sessionID string, m *SessionMetrics) SignalTier {
 	if len(holds) == 0 {
 		delete(h.held, sessionID)
 	}
-	return applied
 }

--- a/core/domain/session/signal_hold.go
+++ b/core/domain/session/signal_hold.go
@@ -1,0 +1,259 @@
+package session
+
+import "sync"
+
+// SignalKind identifies one out-of-band state signal that is held for a
+// session between the moment it arrives and the moment it stops describing
+// reality.
+//
+// A hold exists because every signal above TierTranscript arrives on a
+// different goroutine than the one that classifies, and — per the #1141 spike
+// — usually arrives *late*: the Notification/idle_prompt hook fires ~6s after
+// the turn goes idle, by which point the transcript tier has already guessed
+// and the badge already says something. Holding the authoritative signal is
+// what lets it correct that guess instead of racing it.
+type SignalKind string
+
+const (
+	// SignalPermissionPrompt is Claude Code's / Codex's PermissionRequest
+	// hook: a permission prompt is open and the user is blocked on it right
+	// now (#108, #1171). The one genuinely instant signal in the system.
+	SignalPermissionPrompt SignalKind = "permission_prompt"
+
+	// SignalTurnDone is the Stop hook: the turn ended, authoritatively, at
+	// true turn end (#1161, #1171).
+	SignalTurnDone SignalKind = "turn_done"
+
+	// SignalIdlePrompt is the Notification/idle_prompt hook: the agent is
+	// sitting idle at the prompt waiting for the user (#1173). The signal
+	// waiting_cue's prose regex exists to approximate.
+	SignalIdlePrompt SignalKind = "idle_prompt"
+)
+
+// SignalPayload is the data a held signal carries beyond its own existence.
+// Only SignalTurnDone populates it today; the zero value is correct for a
+// signal whose whole content is "this happened".
+type SignalPayload struct {
+	// LastAssistantText is the turn's final assistant message as the hook
+	// delivered it (display-truncated). The Stop hook carries this, which is
+	// why it does double duty: IsWaitingForUserInput needs the final text,
+	// and the hook has it before the transcript flush does.
+	LastAssistantText string
+
+	// WaitingCue is the adapter's waiting-cue verdict computed over the
+	// hook's *full* message text, rather than the 200-rune transcript tail
+	// the classifier would otherwise see (#1150).
+	WaitingCue bool
+}
+
+// signalPolicy declares how one kind of held signal behaves — how long it
+// outranks lower tiers, when it stops being true, and what it folds onto
+// metrics. It is deliberately data rather than code: before #1288 each of
+// these three was a hand-written overlay method on SessionDetector with its
+// own lifecycle rule, plus a fourth copy in the replay harness, and the
+// remaining phases of #1129 would have added six more. Adding a signal should
+// mean adding a row here.
+type signalPolicy struct {
+	// tier is where this signal sits on the authority ladder.
+	tier SignalTier
+
+	// consumeOnce drops the hold as it is applied, so it affects exactly the
+	// one classify pass it triggered and never bleeds into the next turn.
+	// The alternative — persistent — re-applies every pass until stale
+	// reports the signal no longer describes reality, so that a lower-tier
+	// reclassify in between cannot revert the correction.
+	consumeOnce bool
+
+	// stale reports that the held signal has stopped describing reality and
+	// must be dropped *without* being applied. Nil means "only consumeOnce
+	// or an explicit Release ends this hold".
+	stale func(m *SessionMetrics) bool
+
+	// apply folds the signal onto the metrics the classifier is about to
+	// read.
+	apply func(m *SessionMetrics, p SignalPayload)
+}
+
+// signalPolicies is the declared behaviour of every out-of-band signal.
+//
+// All three are TierHook today. That is not a redundancy to factor out — it
+// is the current state of a ladder whose other tiers are filed and unbuilt
+// (Phases 4-7 of #1129), and the field is what lets a Phase 4 OTel signal
+// land as a row here rather than as another bespoke overlay.
+var signalPolicies = map[SignalKind]signalPolicy{
+	SignalPermissionPrompt: {
+		tier: TierHook,
+		// Persistent: the prompt stays open until the agent acts on it, and
+		// the hold must survive every fswatcher re-evaluation in between.
+		// Cleared normally by PostToolUse/PostToolUseFailure via Release.
+		//
+		// Denial is the case that needs stale: Claude Code fires no
+		// PostToolUseFailure when the user rejects a prompt, so the only
+		// evidence the prompt closed is the transcript's own
+		// "[Request interrupted by user for tool use]" marker. A lower tier
+		// retiring a higher one reads backwards, but it is sound here — this
+		// is not the transcript overruling the hook's verdict, it is the
+		// transcript supplying the end-of-life notice the hook never sends.
+		stale: func(m *SessionMetrics) bool { return m.LastWasToolDenial },
+		apply: func(m *SessionMetrics, _ SignalPayload) { m.PermissionPending = true },
+	},
+
+	SignalTurnDone: {
+		tier:        TierHook,
+		consumeOnce: true,
+		apply: func(m *SessionMetrics, p SignalPayload) {
+			m.HookTurnDone = true
+			if p.LastAssistantText != "" {
+				m.LastAssistantText = p.LastAssistantText
+			}
+			// Only ever adds to the cue verdict, never clears it: the hook
+			// can push a finished turn to waiting, but must not mask a cue
+			// the transcript already found on its own.
+			if p.WaitingCue {
+				m.PendingWaitingCue = true
+			}
+		},
+	},
+
+	SignalIdlePrompt: {
+		tier: TierHook,
+		// Persistent, and deliberately so: this is the hold that makes the
+		// ~6s-late correction stick. A stray lower-tier reclassify between
+		// the hook landing and the user replying would otherwise route the
+		// corrected waiting straight back to ready via the turn-done rule.
+		//
+		// The signal holds only while the finished turn is still the last
+		// thing that happened. IsAgentDone going false means either the user
+		// replied or a tool opened — either way the idle window is over and
+		// the rules that own those cases take it from here.
+		stale: func(m *SessionMetrics) bool { return !m.IsAgentDone() },
+		apply: func(m *SessionMetrics, _ SignalPayload) { m.IdlePromptPending = true },
+	},
+}
+
+// signalOrder fixes the sequence in which held signals are applied.
+//
+// THIS ORDER IS LOAD-BEARING, and a map range would silently randomise it.
+// SignalIdlePrompt's staleness test calls IsAgentDone, which reads the
+// HookTurnDone that SignalTurnDone.apply has just set. Applied in this order,
+// a Stop hook and an idle_prompt hook arriving for the same turn agree — the
+// turn is done, so the idle hold survives and correctly holds the session in
+// waiting. Reverse them and idle_prompt evaluates staleness against metrics
+// that do not yet know the turn ended: on any adapter whose transcript tail
+// is not literally "turn_done", IsAgentDone reads false, the hold is dropped
+// as stale, and the correction the hook exists to deliver is thrown away one
+// instruction before it would have been applied.
+var signalOrder = []SignalKind{
+	SignalPermissionPrompt,
+	SignalTurnDone,
+	SignalIdlePrompt,
+}
+
+// SignalHolds is the per-session store of out-of-band signals awaiting a
+// classify pass — one mechanism shared by the daemon's live path and the
+// offline replay harness, which before #1288 each carried their own copy of
+// the same overlay logic and could drift apart without any test noticing.
+//
+// Safe for concurrent use: hooks arrive on HTTP handler goroutines while the
+// event loop classifies.
+type SignalHolds struct {
+	mu   sync.Mutex
+	held map[string]map[SignalKind]SignalPayload
+}
+
+// NewSignalHolds returns an empty, ready-to-use store.
+func NewSignalHolds() *SignalHolds {
+	return &SignalHolds{held: map[string]map[SignalKind]SignalPayload{}}
+}
+
+// Hold records that kind has fired for sessionID, replacing any previous hold
+// of the same kind — a second Stop hook for the same session describes the
+// same turn ending, and its payload is the fresher one.
+func (h *SignalHolds) Hold(sessionID string, kind SignalKind, p SignalPayload) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.held[sessionID] == nil {
+		h.held[sessionID] = map[SignalKind]SignalPayload{}
+	}
+	h.held[sessionID][kind] = p
+}
+
+// Release drops one held signal — the explicit end-of-life path, used when
+// something other than the policy's own staleness rule ends the hold (a
+// PostToolUse closing a permission prompt).
+func (h *SignalHolds) Release(sessionID string, kind SignalKind) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if s := h.held[sessionID]; s != nil {
+		delete(s, kind)
+		if len(s) == 0 {
+			delete(h.held, sessionID)
+		}
+	}
+}
+
+// Held reports whether kind is currently held for sessionID, without applying
+// or consuming it.
+func (h *SignalHolds) Held(sessionID string, kind SignalKind) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, ok := h.held[sessionID][kind]
+	return ok
+}
+
+// DropSession forgets every hold for a session, for when the session itself
+// goes away.
+func (h *SignalHolds) DropSession(sessionID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.held, sessionID)
+}
+
+// Overlay folds every currently-valid held signal for sessionID onto m, in
+// signalOrder, and returns the highest tier it actually applied (TierNone if
+// it applied nothing). Stale holds are dropped without being applied;
+// consume-once holds are dropped as they are applied.
+//
+// Call this after the metrics have been rebuilt from the transcript — which
+// zeroes the transient fields these signals set — and before classification,
+// which reads them.
+func (h *SignalHolds) Overlay(sessionID string, m *SessionMetrics) SignalTier {
+	if m == nil {
+		return TierNone
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	holds := h.held[sessionID]
+	if len(holds) == 0 {
+		return TierNone
+	}
+
+	applied := TierNone
+	for _, kind := range signalOrder {
+		payload, ok := holds[kind]
+		if !ok {
+			continue
+		}
+		policy := signalPolicies[kind]
+
+		if policy.stale != nil && policy.stale(m) {
+			delete(holds, kind)
+			continue
+		}
+
+		policy.apply(m, payload)
+		if policy.tier.Outranks(applied) {
+			applied = policy.tier
+		}
+		if policy.consumeOnce {
+			delete(holds, kind)
+		}
+	}
+
+	if len(holds) == 0 {
+		delete(h.held, sessionID)
+	}
+	return applied
+}

--- a/core/domain/session/signal_hold_test.go
+++ b/core/domain/session/signal_hold_test.go
@@ -1,0 +1,220 @@
+package session
+
+import (
+	"sync"
+	"testing"
+)
+
+const holdSID = "sess-1"
+
+// TestSignalHolds_ConsumeOnce pins the Stop-hook policy: the hold applies to
+// exactly the pass it triggered and is gone afterwards, so an authoritative
+// turn-done can never bleed into the following turn.
+func TestSignalHolds_ConsumeOnce(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold(holdSID, SignalTurnDone, SignalPayload{LastAssistantText: "done", WaitingCue: true})
+
+	m := &SessionMetrics{}
+	if tier := h.Overlay(holdSID, m); tier != TierHook {
+		t.Errorf("Overlay tier = %v, want TierHook", tier)
+	}
+	if !m.HookTurnDone || m.LastAssistantText != "done" || !m.PendingWaitingCue {
+		t.Fatalf("turn-done payload not applied: %+v", m)
+	}
+	if h.Held(holdSID, SignalTurnDone) {
+		t.Error("consume-once hold must be released as it is applied")
+	}
+
+	next := &SessionMetrics{}
+	if tier := h.Overlay(holdSID, next); tier != TierNone {
+		t.Errorf("second Overlay tier = %v, want TierNone", tier)
+	}
+	if next.HookTurnDone {
+		t.Error("a consumed signal must not re-apply on the next pass")
+	}
+}
+
+// TestSignalHolds_PersistentUntilStale pins the idle_prompt policy — the one
+// that makes the ~6s-late correction stick. The hold must survive repeated
+// passes while the turn stays idle, then drop itself the moment the turn is no
+// longer idle.
+func TestSignalHolds_PersistentUntilStale(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold(holdSID, SignalIdlePrompt, SignalPayload{})
+
+	for pass := 1; pass <= 3; pass++ {
+		m := &SessionMetrics{LastEventType: "turn_done"}
+		h.Overlay(holdSID, m)
+		if !m.IdlePromptPending {
+			t.Fatalf("pass %d: IdlePromptPending must re-apply while the turn is idle", pass)
+		}
+		if !h.Held(holdSID, SignalIdlePrompt) {
+			t.Fatalf("pass %d: persistent hold must not be consumed", pass)
+		}
+	}
+
+	// The user replied — IsAgentDone goes false, so the idle window is over.
+	m := &SessionMetrics{LastEventType: "user"}
+	h.Overlay(holdSID, m)
+	if m.IdlePromptPending {
+		t.Error("IdlePromptPending must not be applied once the turn is no longer idle")
+	}
+	if h.Held(holdSID, SignalIdlePrompt) {
+		t.Error("a stale hold must be dropped")
+	}
+}
+
+// TestSignalHolds_PermissionStaleOnDenial pins the permission policy's one
+// unusual edge: Claude Code fires no PostToolUseFailure when the user rejects a
+// prompt, so the transcript's own denial marker is the only end-of-life notice
+// the hold ever gets.
+func TestSignalHolds_PermissionStaleOnDenial(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold(holdSID, SignalPermissionPrompt, SignalPayload{})
+
+	open := &SessionMetrics{}
+	h.Overlay(holdSID, open)
+	if !open.PermissionPending {
+		t.Error("an open permission prompt must be applied")
+	}
+
+	denied := &SessionMetrics{LastWasToolDenial: true}
+	h.Overlay(holdSID, denied)
+	if denied.PermissionPending {
+		t.Error("a denied prompt must not be applied")
+	}
+	if h.Held(holdSID, SignalPermissionPrompt) {
+		t.Error("denial must drop the hold")
+	}
+}
+
+// TestSignalHolds_ApplicationOrderIsLoadBearing is the regression test for the
+// subtlety that signalOrder exists to defend, and the reason a map range would
+// be a latent bug rather than a style question.
+//
+// SignalIdlePrompt's staleness test calls IsAgentDone, which reads the
+// HookTurnDone that SignalTurnDone.apply sets. When a Stop hook and an
+// idle_prompt hook both land for the same finished turn — the exact live
+// sequence on claudecode — turn-done must be applied first, or idle_prompt
+// evaluates staleness against metrics that do not yet know the turn ended,
+// drops itself, and throws away the correction it exists to deliver.
+//
+// The transcript tail here is deliberately NOT "turn_done": that is what makes
+// the ordering observable. With a turn_done tail, IsAgentDone is true either
+// way and the bug hides.
+func TestSignalHolds_ApplicationOrderIsLoadBearing(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold(holdSID, SignalTurnDone, SignalPayload{LastAssistantText: "All set."})
+	h.Hold(holdSID, SignalIdlePrompt, SignalPayload{})
+
+	m := &SessionMetrics{LastEventType: "assistant_message"}
+	h.Overlay(holdSID, m)
+
+	if !m.HookTurnDone {
+		t.Fatal("turn-done must be applied")
+	}
+	if !m.IdlePromptPending {
+		t.Error("idle_prompt must survive: turn-done ran first, so IsAgentDone was already true")
+	}
+	if !h.Held(holdSID, SignalIdlePrompt) {
+		t.Error("idle_prompt must still be held after the pass")
+	}
+}
+
+// TestSignalHolds_SignalOrderCoversEveryPolicy guards the other half of that
+// invariant: a signal added to signalPolicies but forgotten in signalOrder
+// would simply never be applied — a silent no-op, not a compile error.
+func TestSignalHolds_SignalOrderCoversEveryPolicy(t *testing.T) {
+	inOrder := map[SignalKind]bool{}
+	for _, k := range signalOrder {
+		if inOrder[k] {
+			t.Errorf("signalOrder lists %q twice", k)
+		}
+		inOrder[k] = true
+		if _, ok := signalPolicies[k]; !ok {
+			t.Errorf("signalOrder lists %q, which has no policy", k)
+		}
+	}
+	for k := range signalPolicies {
+		if !inOrder[k] {
+			t.Errorf("policy %q is missing from signalOrder — it would never be applied", k)
+		}
+	}
+}
+
+// TestSignalHolds_EveryPolicyIsWellFormed keeps a future Phase 4-7 row from
+// landing half-declared: a policy with no apply would be silently inert, and
+// one with no tier would report TierNone and lose every arbitration.
+func TestSignalHolds_EveryPolicyIsWellFormed(t *testing.T) {
+	for kind, p := range signalPolicies {
+		if p.apply == nil {
+			t.Errorf("policy %q has no apply func", kind)
+		}
+		if !p.tier.Known() {
+			t.Errorf("policy %q has tier %v, which is not a real tier", kind, p.tier)
+		}
+		if p.consumeOnce && p.stale != nil {
+			t.Errorf("policy %q is both consume-once and staleness-gated; the stale rule can never be reached on a second pass", kind)
+		}
+	}
+}
+
+// TestSignalHolds_ReleaseAndDropSession covers the explicit end-of-life paths.
+func TestSignalHolds_ReleaseAndDropSession(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold(holdSID, SignalPermissionPrompt, SignalPayload{})
+	h.Hold(holdSID, SignalIdlePrompt, SignalPayload{})
+
+	h.Release(holdSID, SignalPermissionPrompt)
+	if h.Held(holdSID, SignalPermissionPrompt) {
+		t.Error("Release must drop the named signal")
+	}
+	if !h.Held(holdSID, SignalIdlePrompt) {
+		t.Error("Release must not touch other signals")
+	}
+
+	h.DropSession(holdSID)
+	if h.Held(holdSID, SignalIdlePrompt) {
+		t.Error("DropSession must forget every hold for the session")
+	}
+}
+
+// TestSignalHolds_SessionsAreIsolated guards against a recycled or concurrent
+// session inheriting another's signal.
+func TestSignalHolds_SessionsAreIsolated(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold("a", SignalIdlePrompt, SignalPayload{})
+
+	m := &SessionMetrics{LastEventType: "turn_done"}
+	h.Overlay("b", m)
+	if m.IdlePromptPending {
+		t.Error("session b must not see session a's held signal")
+	}
+}
+
+// TestSignalHolds_NilMetricsPreservesHolds pins the guard that keeps a
+// classify pass with no metrics from silently eating an authoritative signal.
+func TestSignalHolds_NilMetricsPreservesHolds(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold(holdSID, SignalTurnDone, SignalPayload{})
+	if tier := h.Overlay(holdSID, nil); tier != TierNone {
+		t.Errorf("Overlay(nil) tier = %v, want TierNone", tier)
+	}
+	if !h.Held(holdSID, SignalTurnDone) {
+		t.Error("nil metrics must leave the hold intact for a later pass")
+	}
+}
+
+// TestSignalHolds_ConcurrentAccess exercises the lock under -race: hooks arrive
+// on HTTP handler goroutines while the event loop classifies.
+func TestSignalHolds_ConcurrentAccess(t *testing.T) {
+	h := NewSignalHolds()
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(3)
+		go func() { defer wg.Done(); h.Hold(holdSID, SignalPermissionPrompt, SignalPayload{}) }()
+		go func() { defer wg.Done(); h.Overlay(holdSID, &SessionMetrics{}) }()
+		go func() { defer wg.Done(); h.Held(holdSID, SignalPermissionPrompt) }()
+	}
+	wg.Wait()
+}

--- a/core/domain/session/signal_hold_test.go
+++ b/core/domain/session/signal_hold_test.go
@@ -15,9 +15,7 @@ func TestSignalHolds_ConsumeOnce(t *testing.T) {
 	h.Hold(holdSID, SignalTurnDone, SignalPayload{LastAssistantText: "done", WaitingCue: true})
 
 	m := &SessionMetrics{}
-	if tier := h.Overlay(holdSID, m); tier != TierHook {
-		t.Errorf("Overlay tier = %v, want TierHook", tier)
-	}
+	h.Overlay(holdSID, m)
 	if !m.HookTurnDone || m.LastAssistantText != "done" || !m.PendingWaitingCue {
 		t.Fatalf("turn-done payload not applied: %+v", m)
 	}
@@ -26,9 +24,7 @@ func TestSignalHolds_ConsumeOnce(t *testing.T) {
 	}
 
 	next := &SessionMetrics{}
-	if tier := h.Overlay(holdSID, next); tier != TierNone {
-		t.Errorf("second Overlay tier = %v, want TierNone", tier)
-	}
+	h.Overlay(holdSID, next)
 	if next.HookTurnDone {
 		t.Error("a consumed signal must not re-apply on the next pass")
 	}
@@ -145,6 +141,13 @@ func TestSignalHolds_SignalOrderCoversEveryPolicy(t *testing.T) {
 // TestSignalHolds_EveryPolicyIsWellFormed keeps a future Phase 4-7 row from
 // landing half-declared: a policy with no apply would be silently inert, and
 // one with no tier would report TierNone and lose every arbitration.
+//
+// It deliberately does NOT forbid combining consumeOnce with stale. Overlay
+// evaluates stale before apply on every pass, including the first, so the
+// combination is meaningful — "consume this on the pass it fires, unless the
+// metrics already contradict it, in which case drop it unapplied". That is
+// exactly the shape a retrospective OTel signal would need (#1141): a span that
+// exports after the user has already replied must be discarded, not applied.
 func TestSignalHolds_EveryPolicyIsWellFormed(t *testing.T) {
 	for kind, p := range signalPolicies {
 		if p.apply == nil {
@@ -153,9 +156,27 @@ func TestSignalHolds_EveryPolicyIsWellFormed(t *testing.T) {
 		if !p.tier.Known() {
 			t.Errorf("policy %q has tier %v, which is not a real tier", kind, p.tier)
 		}
-		if p.consumeOnce && p.stale != nil {
-			t.Errorf("policy %q is both consume-once and staleness-gated; the stale rule can never be reached on a second pass", kind)
-		}
+	}
+}
+
+// TestSignalHolds_StaleIsCheckedOnTheFirstPass pins the property the
+// well-formedness test above relies on: staleness is evaluated before apply on
+// every pass, so a signal that is already contradicted when it first arrives is
+// dropped rather than applied once and then consumed.
+func TestSignalHolds_StaleIsCheckedOnTheFirstPass(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold(holdSID, SignalIdlePrompt, SignalPayload{})
+
+	// The user replied before the ~6s-late hook ever landed: the very first
+	// Overlay must discard it, not honour it once.
+	m := &SessionMetrics{LastEventType: "user"}
+	h.Overlay(holdSID, m)
+
+	if m.IdlePromptPending {
+		t.Error("a signal already contradicted on arrival must not be applied even once")
+	}
+	if h.Held(holdSID, SignalIdlePrompt) {
+		t.Error("it must also be dropped")
 	}
 }
 
@@ -197,9 +218,7 @@ func TestSignalHolds_SessionsAreIsolated(t *testing.T) {
 func TestSignalHolds_NilMetricsPreservesHolds(t *testing.T) {
 	h := NewSignalHolds()
 	h.Hold(holdSID, SignalTurnDone, SignalPayload{})
-	if tier := h.Overlay(holdSID, nil); tier != TierNone {
-		t.Errorf("Overlay(nil) tier = %v, want TierNone", tier)
-	}
+	h.Overlay(holdSID, nil)
 	if !h.Held(holdSID, SignalTurnDone) {
 		t.Error("nil metrics must leave the hold intact for a later pass")
 	}

--- a/core/domain/session/signal_tier.go
+++ b/core/domain/session/signal_tier.go
@@ -1,0 +1,109 @@
+package session
+
+// SignalTier ranks the channels a session-state signal can arrive on, from the
+// most authoritative to the least.
+//
+// irrlicht has always had this ordering — "the agent's own hook outranks a
+// regex over its prose" is the premise the whole state layer rests on — but
+// until #1288 it existed only as the comment-numbered order of the if-statements
+// inside ClassifyState. Nothing in a type said a hook outranks a transcript
+// guess, so the invariant survived only as long as nobody reordered the
+// function. This type is that invariant made explicit and testable, and it is
+// what the remaining phases of #1129 plug into: each adds a signal *source*,
+// and without a declared ladder each would also have to re-litigate where its
+// signal sits relative to every other.
+//
+// Numerically lower means more authoritative, so the tiers can be compared
+// directly — but use Outranks rather than `<`, which gets the zero value
+// backwards (see TierNone).
+type SignalTier uint8
+
+const (
+	// TierNone is the zero value: no tiered signal is attached. It is not a
+	// tier — it outranks nothing and everything outranks it — so a struct
+	// that never sets a tier degrades to "unknown provenance" rather than
+	// silently claiming the top of the ladder, which a bare `<` comparison
+	// would give it.
+	TierNone SignalTier = 0
+
+	// TierHook is an out-of-band push from the agent's own hook system:
+	// Claude Code's PermissionRequest/Stop/Notification (#108, #1161, #1173)
+	// and Codex's equivalents (#1171). The most authoritative tier available
+	// — the agent reporting its own state rather than irrlicht guessing at
+	// it — though not the fastest: only the blocking PermissionRequest hook
+	// is instant, while Notification/idle_prompt was measured at ~6s (#1141).
+	// Authoritative and late is exactly the combination SignalHolds exists to
+	// reconcile.
+	TierHook SignalTier = 1
+
+	// TierStructured is a structured machine-readable stream that is not a
+	// hook: OTel spans (Phase 4) and ACP session/update (Phase 7). Reserved —
+	// nothing emits it yet. Below hooks because the OTel spike (#1141) found
+	// its state-bearing span retrospective: it exports at the *end* of a
+	// block, so it can corroborate a state but never open one live.
+	TierStructured SignalTier = 2
+
+	// TierProcess is derived from the OS view of the agent process: an
+	// in-flight model API request seen as per-process network activity
+	// (Phase 5). Reserved — nothing emits it yet.
+	TierProcess SignalTier = 3
+
+	// TierScreen is derived from the agent's rendered terminal output —
+	// screen-stability or manifest matching against the live buffer
+	// (Phase 6). Reserved — nothing emits it yet.
+	TierScreen SignalTier = 4
+
+	// TierTranscript is inference from the transcript's own content: the
+	// turn-done heuristics, the open-tool rules, and waiting_cue's prose
+	// regex. The least authoritative tier and the only one that answers a UI
+	// question ("is a human blocked right now?") from a content log that was
+	// never asked it — which is the inversion #1129 exists to undo.
+	//
+	// It is nonetheless load-bearing and stays that way: it is the instant
+	// first guess for the two adapters that have hooks, and the *only* signal
+	// for the seven that don't. Bottom of the ladder is not deprecated.
+	TierTranscript SignalTier = 5
+)
+
+// Known reports whether t is an actual tier rather than the TierNone zero
+// value.
+func (t SignalTier) Known() bool {
+	return t >= TierHook && t <= TierTranscript
+}
+
+// Outranks reports whether t is strictly more authoritative than other.
+//
+// Always prefer this to comparing tiers with `<`: TierNone is numerically
+// lowest but is the *absence* of a tier, so a raw comparison would have it
+// outrank every real signal — the one mistake this ladder cannot afford,
+// since an untagged signal is exactly the case where nothing is known.
+func (t SignalTier) Outranks(other SignalTier) bool {
+	if !t.Known() {
+		return false
+	}
+	if !other.Known() {
+		return true
+	}
+	return t < other
+}
+
+// String renders the tier for logs and recorded lifecycle traces. The values
+// are stable identifiers, not display prose: they are written into
+// lifecycle.ClassifierInputs and read back by offline replay tooling, so
+// renaming one silently reinterprets every trace already on disk.
+func (t SignalTier) String() string {
+	switch t {
+	case TierHook:
+		return "hook"
+	case TierStructured:
+		return "structured"
+	case TierProcess:
+		return "process"
+	case TierScreen:
+		return "screen"
+	case TierTranscript:
+		return "transcript"
+	default:
+		return ""
+	}
+}

--- a/core/domain/session/signal_tier.go
+++ b/core/domain/session/signal_tier.go
@@ -73,6 +73,12 @@ func (t SignalTier) Known() bool {
 
 // Outranks reports whether t is strictly more authoritative than other.
 //
+// This is the ladder's comparison semantics as a named, tested primitive. Its
+// caller today is the invariant test that enforces the classifier's rule order
+// against the declared tiers (TestStateRules_LadderIsTierConsistent); the
+// Phase 4-7 signals of #1129, which are the first to introduce tiers that
+// actually differ, arbitrate with it directly.
+//
 // Always prefer this to comparing tiers with `<`: TierNone is numerically
 // lowest but is the *absence* of a tier, so a raw comparison would have it
 // outrank every real signal — the one mistake this ladder cannot afford,

--- a/core/domain/session/signal_tier_test.go
+++ b/core/domain/session/signal_tier_test.go
@@ -1,0 +1,68 @@
+package session
+
+import "testing"
+
+// TestSignalTier_Outranks pins the comparison semantics, and in particular the
+// TierNone case that a bare `<` gets backwards: TierNone is numerically the
+// lowest value but means "no tier known", so it must lose to every real tier
+// rather than winning against all of them.
+func TestSignalTier_Outranks(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b SignalTier
+		want bool
+	}{
+		{"hook outranks transcript", TierHook, TierTranscript, true},
+		{"transcript does not outrank hook", TierTranscript, TierHook, false},
+		{"hook outranks structured", TierHook, TierStructured, true},
+		{"structured outranks screen", TierStructured, TierScreen, true},
+		{"equal tiers do not outrank", TierHook, TierHook, false},
+		{"a real tier outranks TierNone", TierTranscript, TierNone, true},
+		{"TierNone outranks nothing", TierNone, TierTranscript, false},
+		{"TierNone does not outrank itself", TierNone, TierNone, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.a.Outranks(tc.b); got != tc.want {
+				t.Errorf("%v.Outranks(%v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSignalTier_Known separates real tiers from the zero value and from any
+// out-of-range value a future edit might introduce.
+func TestSignalTier_Known(t *testing.T) {
+	for _, tier := range []SignalTier{TierHook, TierStructured, TierProcess, TierScreen, TierTranscript} {
+		if !tier.Known() {
+			t.Errorf("tier %d must be Known", tier)
+		}
+	}
+	if TierNone.Known() {
+		t.Error("TierNone must not be Known")
+	}
+	if SignalTier(99).Known() {
+		t.Error("an out-of-range tier must not be Known")
+	}
+}
+
+// TestSignalTier_StringIsStable pins the wire strings. These are written into
+// lifecycle.ClassifierInputs and read back by offline replay tooling, so they
+// are an on-disk format: renaming one silently reinterprets every trace already
+// recorded. TierNone deliberately renders empty so the omitempty field stays
+// absent rather than recording a literal "none".
+func TestSignalTier_StringIsStable(t *testing.T) {
+	want := map[SignalTier]string{
+		TierNone:       "",
+		TierHook:       "hook",
+		TierStructured: "structured",
+		TierProcess:    "process",
+		TierScreen:     "screen",
+		TierTranscript: "transcript",
+	}
+	for tier, str := range want {
+		if got := tier.String(); got != str {
+			t.Errorf("SignalTier(%d).String() = %q, want %q", tier, got, str)
+		}
+	}
+}

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -193,7 +193,7 @@ type SessionMetrics struct {
 	// processParsedEvent call). Lets the detector treat post-turn writes
 	// like Claude Code's `system/away_summary` recap as activity for
 	// timestamp purposes only — the state machine must not be re-run, since
-	// LastEventType still carries the prior turn_done and rule 4 would
+	// LastEventType still carries the prior turn_done and transcript_activity would
 	// bounce a ready session back to working. Per-pass transient
 	// (issue #329).
 	NoSubstantiveActivity bool `json:"-"`

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,13 +1,9 @@
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
-golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZrmR51cJDQxmJUHUOfRAaNyWBM+R+548=
-golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959/go.mod h1:LV7u5Oco+Z/g6XI7PqN+EUUUGGkEcmB1uj2ceI0fOVg=
 golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
-golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
-golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,9 +1,13 @@
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
+golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
 golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZrmR51cJDQxmJUHUOfRAaNyWBM+R+548=
+golang.org/x/telemetry v0.0.0-20260708182218-49f421fb7959/go.mod h1:LV7u5Oco+Z/g6XI7PqN+EUUUGGkEcmB1uj2ceI0fOVg=
 golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
+golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=

--- a/tools/onboarding-factory/cmd/replay/replay_sidecar.go
+++ b/tools/onboarding-factory/cmd/replay/replay_sidecar.go
@@ -214,11 +214,17 @@ type sidecarReplayer struct {
 	stateDurations   map[string]time.Duration
 	lastMetrics      *tailer.SessionMetrics
 
-	// permissionPending mirrors SessionDetector.permissionPending for the
-	// primary session. Set by PermissionRequest hooks and cleared by
-	// PostToolUse / PostToolUseFailure hooks, then overlaid onto metrics
-	// before ClassifyState so rule 0 can fire.
-	permissionPending bool
+	// signals holds out-of-band hook signals for the primary session, using
+	// the same session.SignalHolds mechanism and the same declared policies
+	// as the live SessionDetector.
+	//
+	// It used to be a local bool plus a hand-written overlay method that
+	// "mirrored" the detector's — a fourth copy of a lifecycle rule that no
+	// test compared against the original, so the harness whose entire job is
+	// catching classifier regressions could itself drift out of agreement
+	// with the classifier (#1288). Sharing the mechanism makes that class of
+	// drift unrepresentable.
+	signals *session.SignalHolds
 
 	// children carries the subagents discovered via parent_linked. Each
 	// entry's state is updated as child transitions fire on the timeline;
@@ -283,6 +289,7 @@ func newSidecarReplayer(transcriptPath string, srcBytes []byte, cfg reportSettin
 		prevTransitionAt: fswatches[0].Timestamp,
 		stateDurations:   map[string]time.Duration{},
 		children:         children,
+		signals:          session.NewSignalHolds(),
 	}
 	r.emit(transition{
 		EventIndex:  -1,
@@ -313,19 +320,17 @@ func (r *sidecarReplayer) addDuration(s string, d time.Duration) {
 	}
 }
 
-// overlayPermissionPending mirrors SessionDetector's overlay step: set the
-// flag on metrics so ClassifyState's rule 0 fires. Tool-denial short-
-// circuits the flag — Claude Code doesn't emit PostToolUseFailure on
-// denial, so the denial text in the transcript is what clears it.
-func (r *sidecarReplayer) overlayPermissionPending(m *session.SessionMetrics) {
-	if m == nil || !r.permissionPending {
-		return
-	}
-	if m.LastWasToolDenial {
-		r.permissionPending = false
-		return
-	}
-	m.PermissionPending = true
+// replaySessionKey is the SignalHolds key for the session under replay. The
+// replayer is single-session by construction, so one fixed key stands in for
+// the live detector's per-session map.
+const replaySessionKey = "primary"
+
+// overlayHeldSignals folds every held hook signal onto the metrics about to be
+// classified, exactly as the live detector's classify pass does — including
+// the tool-denial staleness rule (Claude Code emits no PostToolUseFailure on
+// denial, so the transcript's denial marker is what ends the hold).
+func (r *sidecarReplayer) overlayHeldSignals(m *session.SessionMetrics) {
+	r.signals.Overlay(replaySessionKey, m)
 }
 
 // anyChildActive reports whether any subagent discovered via parent_linked
@@ -428,7 +433,7 @@ func (r *sidecarReplayer) classifyAt(fileSize int64, ctx transitionCtx) error {
 	}
 	r.lastMetrics = metrics
 	domainMetrics := replayengine.TailerToDomain(metrics)
-	r.overlayPermissionPending(domainMetrics)
+	r.overlayHeldSignals(domainMetrics)
 	r.runClassifier(domainMetrics, ctx, grew)
 	return nil
 }
@@ -440,9 +445,9 @@ func (r *sidecarReplayer) classifyAt(fileSize int64, ctx transitionCtx) error {
 func (r *sidecarReplayer) applyHookEvent(hookEv lifecycle.Event) {
 	switch hookEv.HookName {
 	case claudecode.HookPermissionRequest:
-		r.permissionPending = true
+		r.signals.Hold(replaySessionKey, session.SignalPermissionPrompt, session.SignalPayload{})
 	case claudecode.HookPostToolUse, claudecode.HookPostToolUseFailure:
-		r.permissionPending = false
+		r.signals.Release(replaySessionKey, session.SignalPermissionPrompt)
 	default:
 		return
 	}
@@ -450,7 +455,7 @@ func (r *sidecarReplayer) applyHookEvent(hookEv lifecycle.Event) {
 		return
 	}
 	domainMetrics := replayengine.TailerToDomain(r.lastMetrics)
-	r.overlayPermissionPending(domainMetrics)
+	r.overlayHeldSignals(domainMetrics)
 	r.runClassifier(domainMetrics, transitionCtx{eventIdx: -1, virtTime: hookEv.Timestamp, cause: causeHook}, true)
 }
 
@@ -651,7 +656,7 @@ func (r *sidecarReplayer) applyChildOrphan(orphan orphanTrigger, d *debounceStat
 		return nil
 	}
 	domainMetrics := replayengine.TailerToDomain(r.lastMetrics)
-	r.overlayPermissionPending(domainMetrics)
+	r.overlayHeldSignals(domainMetrics)
 	// grew=false: r.state != StateReady is already guaranteed by the check
 	// above, so the force-bounce branch never evaluates this value here.
 	r.runClassifier(domainMetrics, transitionCtx{eventIdx: -1, virtTime: orphan.at, cause: causeEvent}, false)


### PR DESCRIPTION
Closes #1288. Phase 3 of #1129.

## What this is

The classifier's authority ladder existed only as the comment-numbered order of the if-statements inside `ClassifyState`. Nothing in a type said a hook outranks a transcript guess — the invariant survived exactly as long as nobody reordered the function. Meanwhile each of the three hook signals had grown its own hand-written overlay with its own lifecycle rule, plus a fourth copy in the replay harness:

| Overlay | Policy |
|---|---|
| `overlayPermissionPending` | persistent; cleared by transcript evidence (`LastWasToolDenial`) |
| `overlayHookTurnDone` | consume-once — deleted as read |
| `overlayIdlePrompt` | persistent — re-applied every pass, gated on `IsAgentDone` |
| `sidecarReplayer.overlayPermissionPending` | a fourth, "mirrors SessionDetector" by hand |

Phases 4–7 add four more signal sources. This replaces all of that with one declared mechanism.

## Changes

- **`session.SignalTier`** — the five-tier ladder (hook → structured → process → screen → transcript) as a domain type. `Outranks` handles the `TierNone` zero value explicitly, which a bare `<` gets backwards.
- **`session.SignalHolds` + `signalPolicies`** — each signal's tier, persistence and staleness rule declared as *data*. Adding a Phase 4–7 signal is a row in the table, not a fourth map and a fourth overlay.
- **Table-driven ladder** — each `stateRule` carries the tier its evidence arrives on. `agent_done` is deliberately dynamic: `TierHook` when a Stop hook delivered it, `TierTranscript` when the transcript tail was guessed at.
- **Structured provenance** — `ClassifierInputs` gains `DecidedByTier` / `DecidedByRule`, plus the `HookTurnDone` / `IdlePromptPending` fields that were missing from the recorded snapshot entirely.
- **The replay harness now shares the mechanism**, killing the fourth copy.

## A deliberate deviation from AC3

The issue's AC3 says the tier should go "in the transition reason". It can't: **338 committed replay goldens pin `Reason` strings byte-for-byte**, so prose-encoding the tier would rewrite every one of them — destroying the regression net that protects this very refactor (AC1). Provenance therefore lands as **structured fields** on the lifecycle event, which is not in the goldens' curated `transition` struct. This satisfies AC3's stated intent ("a hook-delivered ready is distinguishable from a transcript-tail-inferred ready") and is queryable in a way prose never was.

## Verification

`tools/preflight.sh`: **all 12 gates PASS**, including the ARS architecture gate (AC6).

**AC1 — behaviour is unchanged.** All 338 replay goldens byte-identical, zero `replaydata/` churn; full `go test ./core/... -race` green. Reason strings are untouched by design.

**These are locks, not defect tests** — they pin behaviour that must not change, so they pass on `main` by construction. Per AGENTS.md, their value is that they *can* fail, so each new invariant was proven red by deliberate mutation:

| # | Mutation | Result |
|---|---|---|
| 1 | Reverse `signalOrder` (idle_prompt before turn_done) | 🔴 `ApplicationOrderIsLoadBearing`: *"idle_prompt must survive: turn-done ran first…"* |
| 2 | Move the hook-tier `idle_prompt` rule below `agent_done` | 🔴 3 tests, incl. *"rule `agent_done` (tier transcript) decided, but lower rule `idle_prompt` (tier hook) outranks it"* |
| 3 | Drop a policy from `signalOrder` | 🔴 *"policy `idle_prompt` is missing from signalOrder — it would never be applied"* |
| 4 | Remove `idle_prompt`'s staleness rule | 🔴 *"user-blocking-tool-open/idle-prompt: rule `user_blocking_tool` (tier transcript) decided, but lower rule `idle_prompt` (tier hook) outranks it"* |

Mutation 4 is the load-bearing one. Two transcript-tier rules sit *above* the hook-tier `idle_prompt` rule, which is only sound because an open tool makes `IsAgentDone` false, which makes the idle hold stale, so the pair can never contend. `TestStateRules_LadderIsTierConsistent` builds its corpus by running real holds through `Overlay` rather than setting metrics fields directly — so it **tests** that reachability argument instead of assuming it, and names the contending pair the moment it stops holding.

Mutation 1 is worth flagging too: `signalOrder` replaced a map, and a map range would have randomised it. `idle_prompt`'s staleness check reads the `HookTurnDone` that `turn_done` sets one step earlier — so on any adapter whose transcript tail isn't literally `turn_done`, the wrong order silently discards the correction the hook exists to deliver.

## Not in scope

`waiting_cue.go` is untouched and stays that way — it is the instant first guess for the two adapters with hooks and the only signal for the seven without. Deleting it is gated on Phases 4–6. No new signal *source* here; this is the arbitration they plug into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
