### PR TITLE
fix(daemon): don't read a timed-out lsof probe as a dead background process

### DIFF
--- a/core/application/services/background_fixture_test.go
+++ b/core/application/services/background_fixture_test.go
@@ -1,0 +1,98 @@
+package services_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+)
+
+// bgOutputFixture is the setup every background-output liveness test shares: a
+// `working` session whose turn has ended and whose only open background process
+// is an output file, wired to a detector with an injectable probe.
+type bgOutputFixture struct {
+	det     *services.SessionDetector
+	tw      *mockAgentWatcher
+	metrics *funcMetrics
+	rec     *mockRecorder
+	probes  atomic.Int32
+	sid     string
+	path    string
+}
+
+// newBGOutputFixture builds the fixture with probe as the injected liveness
+// verdict; every call is counted so a test can require positive evidence the
+// probe actually ran rather than passing on the mere absence of an effect.
+func newBGOutputFixture(sid, path, outPath string, probe func() (alive, conclusive bool)) *bgOutputFixture {
+	return newBGOutputFixtureInState(sid, path, outPath, session.StateWorking, probe)
+}
+
+// newBGOutputFixtureInState is newBGOutputFixture with the session's starting
+// state chosen explicitly — the ready-start case covers a background process
+// spawned right after the session had already settled (#937).
+func newBGOutputFixtureInState(sid, path, outPath, state string, probe func() (alive, conclusive bool)) *bgOutputFixture {
+	f := &bgOutputFixture{sid: sid, path: path}
+	f.metrics = &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		return &session.SessionMetrics{
+			LastEventType:            "turn_done",
+			BackgroundProcessCount:   1,
+			BackgroundProcessOutputs: []string{outPath},
+		}, nil
+	}}
+	f.tw = newMockAgentWatcher()
+	repo := newMockRepo()
+	repo.states[sid] = &session.SessionState{
+		SessionID:      sid,
+		State:          state,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+	f.det = newDetectorWithMetrics(f.tw, newMockProcessWatcher(), repo, f.metrics)
+	f.rec = &mockRecorder{}
+	f.det.SetRecorder(f.rec)
+	f.det.SetBackgroundProbeForTest(func([]string) (bool, bool) {
+		f.probes.Add(1)
+		return probe()
+	})
+	return f
+}
+
+// start runs the detector and stops it when the test ends.
+func (f *bgOutputFixture) start(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- f.det.Run(ctx) }()
+	t.Cleanup(func() { cancel(); <-done })
+}
+
+// activity drives one re-evaluation. terminal short-circuits the 2s debounce,
+// the way production's periodic re-probe does.
+func (f *bgOutputFixture) activity(terminal bool) {
+	f.tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      f.sid,
+		ProjectDir:     "-Users-test",
+		TranscriptPath: f.path,
+		Terminal:       terminal,
+	}
+}
+
+// awaitProbe blocks until the injected probe has run at least once, failing if
+// it never does — without it a test asserting only that nothing happened would
+// pass just as happily when the probe was never launched.
+func (f *bgOutputFixture) awaitProbe(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for f.probes.Load() == 0 {
+		if !time.Now().Before(deadline) {
+			t.Fatal("background liveness probe was never invoked; the test would prove nothing")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/core/application/services/background_probe.go
+++ b/core/application/services/background_probe.go
@@ -15,6 +15,10 @@ import (
 // than trusted PATH, per go:S4036.
 var lsofPath = pathutil.MustResolve("lsof")
 
+// lsofTimeout bounds a single lsof invocation. A package var rather than a
+// const so tests can drive the timeout path without waiting seconds.
+var lsofTimeout = 2 * time.Second
+
 // backgroundProbe answers "does any of these output files still have a live
 // writer?" — the daemon's authoritative liveness check for Claude Code Bash
 // background processes (run_in_background). Claude Code reports a background
@@ -22,7 +26,12 @@ var lsofPath = pathutil.MustResolve("lsof")
 // transcript alone can't tell us when one dies; this probe walks the live
 // process state instead. Modeled as a field so tests can inject a fake.
 // See issue #445.
-type backgroundProbe func(outputPaths []string) bool
+//
+// The second return is "was this conclusive?", not a second liveness bit. It
+// is false only when the probe could not find out — see anyLiveOutputWriter —
+// and a false there must never be read as "dead", because the caller's
+// response to death is a durable purge (issue #1299).
+type backgroundProbe func(outputPaths []string) (alive, conclusive bool)
 
 // anyLiveOutputWriter reports whether any of the given background output files
 // is currently held open by a live process. Each backgrounded command's
@@ -43,14 +52,29 @@ type backgroundProbe func(outputPaths []string) bool
 // flipping the session to `ready` while it's alive (issue #445 review). lsof's
 // diagnostics and usage text go to stderr (dropped by .Output()), and `-t`
 // prints only PIDs to stdout, so we additionally require an all-digit line to
-// guard against any unexpected stdout noise. A timeout or a missing lsof yields
-// empty stdout → "no live writer", which is the safe ("don't pin forever")
-// degradation.
-func anyLiveOutputWriter(outputPaths []string) bool {
+// guard against any unexpected stdout noise.
+//
+// A TIMEOUT is reported as inconclusive rather than as "no live writer". lsof
+// walks every process on the machine, so it is slowest exactly when the machine
+// is busiest — which is also when long-running background work is most likely
+// to be in flight. Reading that silence as death was not the harmless "don't
+// pin forever" degradation this comment used to claim: the caller responds to
+// death by purging the background process from the tailer AND persisting that
+// through saveLedger, so one slow lsof could permanently drop a still-running
+// process and flip a live session to `ready` with no way back — the same
+// false-negative the exit-code handling above exists to prevent, reached by a
+// different route (issue #1299).
+//
+// Any OTHER failure — most plausibly a missing lsof, since MustResolve falls
+// back to the bare name — still degrades to a conclusive "no live writer".
+// Retrying cannot fix those, so treating them as inconclusive would pin every
+// affected session `working` forever, which is the failure the old degradation
+// was protecting against. Only the transient case gets the retry.
+func anyLiveOutputWriter(outputPaths []string) (alive, conclusive bool) {
 	if len(outputPaths) == 0 {
-		return false
+		return false, true
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), lsofTimeout)
 	defer cancel()
 	args := append([]string{"-t", "--"}, outputPaths...)
 	out, _ := exec.CommandContext(ctx, lsofPath, args...).Output() //nolint:errcheck — exit 1 (some path unheld) still carries live PIDs on stdout
@@ -60,10 +84,16 @@ func anyLiveOutputWriter(outputPaths []string) bool {
 			continue
 		}
 		if _, err := strconv.Atoi(line); err == nil {
-			return true
+			return true, true
 		}
 	}
-	return false
+	// Checked only once stdout has yielded no PID: lsof can be killed by the
+	// deadline after already printing a holder, and that PID is still proof of
+	// life worth keeping.
+	if ctx.Err() == context.DeadlineExceeded {
+		return false, false
+	}
+	return false, true
 }
 
 // backgroundPIDProbe answers "is any of these PIDs still a live process?" — the

--- a/core/application/services/background_probe_internal_test.go
+++ b/core/application/services/background_probe_internal_test.go
@@ -117,22 +117,24 @@ func TestAnyLiveOutputWriter_UnheldPathIsConclusivelyDead(t *testing.T) {
 	if err := os.WriteFile(out, []byte("done\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	alive, conclusive := anyLiveOutputWriter([]string{out})
-	if alive {
-		t.Error("an unheld path should report no live writer")
-	}
-	if !conclusive {
-		t.Error("an unheld path is a definite answer, not an inconclusive one")
-	}
+	// Through the same retry/skip helper as the live case: this probe is the
+	// identical full process-table scan, so asserting on a single un-retried
+	// call would reintroduce exactly the load-sensitive flake this PR removes.
+	awaitConclusiveVerdict(t, out, false)
 }
 
 func TestAnyLiveOutputWriter_EmptyAndMissing(t *testing.T) {
 	if alive, conclusive := anyLiveOutputWriter(nil); alive || !conclusive {
 		t.Errorf("nil paths = (%v, %v), want a conclusive no-live-writer", alive, conclusive)
 	}
+	// Only `alive` is asserted for the real invocation. lsof bails on a missing
+	// path before the process scan so a timeout is unlikely, but asserting
+	// `conclusive` off a single un-retried call is the flake shape this PR
+	// exists to remove, and TestAnyLiveOutputWriter_UnheldPathIsConclusivelyDead
+	// already covers conclusiveness with retries.
 	missing := filepath.Join(t.TempDir(), "does-not-exist.output")
-	if alive, conclusive := anyLiveOutputWriter([]string{missing}); alive || !conclusive {
-		t.Errorf("a non-existent output file = (%v, %v), want a conclusive no-live-writer", alive, conclusive)
+	if alive, _ := anyLiveOutputWriter([]string{missing}); alive {
+		t.Error("a non-existent output file should report no live writer")
 	}
 }
 

--- a/core/application/services/background_probe_internal_test.go
+++ b/core/application/services/background_probe_internal_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
@@ -31,37 +32,107 @@ func TestAnyLiveOutputWriter_RealProcess(t *testing.T) {
 		_, _ = cmd.Process.Wait()
 	}()
 
-	// Give the shell a moment to open the file before probing.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && !anyLiveOutputWriter([]string{out}) {
-		time.Sleep(20 * time.Millisecond)
-	}
-	if !anyLiveOutputWriter([]string{out}) {
-		t.Fatalf("probe reported no live writer while background process is running")
-	}
+	// Alive while the shell holds the fd open, dead once it exits.
+	awaitConclusiveVerdict(t, out, true)
 
 	if err := cmd.Process.Kill(); err != nil {
 		t.Fatalf("kill background process: %v", err)
 	}
 	_, _ = cmd.Process.Wait()
 
-	// After exit the fd is closed; the probe should report dead.
-	deadline = time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && anyLiveOutputWriter([]string{out}) {
+	awaitConclusiveVerdict(t, out, false)
+}
+
+// awaitConclusiveVerdict polls the real probe until it CONCLUSIVELY reports
+// want, or the budget runs out.
+//
+// An inconclusive verdict is a retry, not a result — which is both the
+// behavior under test and what keeps this test honest under load. The old
+// version asserted on a single probe against a budget equal to lsofTimeout, so
+// one slow lsof consumed the whole window and failed the test; that is the
+// ~4.25s two-timeouts failure in issue #1299. Retrying instead means a loaded
+// machine costs time rather than a false red.
+//
+// If every probe in the budget times out, the probe did its job (it said "I
+// don't know") and the test simply could not observe the transition, so this
+// skips rather than failing — a machine too loaded to run lsof is not a defect
+// in the code under test.
+func awaitConclusiveVerdict(t *testing.T, path string, want bool) {
+	t.Helper()
+	budget := 4 * lsofTimeout
+	deadline := time.Now().Add(budget)
+	for {
+		alive, conclusive := anyLiveOutputWriter([]string{path})
+		if conclusive && alive == want {
+			return
+		}
+		if !time.Now().Before(deadline) {
+			if !conclusive {
+				t.Skipf("lsof never returned a conclusive verdict within %v; machine too loaded to observe the transition", budget)
+			}
+			t.Fatalf("probe reported alive=%v, want %v", alive, want)
+		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	if anyLiveOutputWriter([]string{out}) {
-		t.Fatalf("probe still reports a live writer after the background process exited")
+}
+
+// A timeout must be reported as inconclusive, never as "no live writer": the
+// caller's response to death is a durable purge, so a slow lsof would
+// permanently drop a still-running background process (issue #1299).
+func TestAnyLiveOutputWriter_TimeoutIsInconclusive(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available")
+	}
+	out := filepath.Join(t.TempDir(), "bc1h56v8v.output")
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("exec sleep 30 > %q", out))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start background process: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	// A deadline no real lsof can meet, so the probe always times out.
+	restore := lsofTimeout
+	lsofTimeout = 1 * time.Nanosecond
+	defer func() { lsofTimeout = restore }()
+
+	alive, conclusive := anyLiveOutputWriter([]string{out})
+	if conclusive {
+		t.Error("a timed-out probe reported a conclusive verdict; the caller would purge on it")
+	}
+	if alive {
+		t.Error("a timed-out probe should not claim liveness either")
+	}
+}
+
+// A path nothing holds open is a conclusive "dead" — the ordinary case the
+// purge is designed for, and the one a timeout must stay distinguishable from.
+func TestAnyLiveOutputWriter_UnheldPathIsConclusivelyDead(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available")
+	}
+	out := filepath.Join(t.TempDir(), "unheld.output")
+	if err := os.WriteFile(out, []byte("done\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	alive, conclusive := anyLiveOutputWriter([]string{out})
+	if alive {
+		t.Error("an unheld path should report no live writer")
+	}
+	if !conclusive {
+		t.Error("an unheld path is a definite answer, not an inconclusive one")
 	}
 }
 
 func TestAnyLiveOutputWriter_EmptyAndMissing(t *testing.T) {
-	if anyLiveOutputWriter(nil) {
-		t.Error("nil paths should report no live writer")
+	if alive, conclusive := anyLiveOutputWriter(nil); alive || !conclusive {
+		t.Errorf("nil paths = (%v, %v), want a conclusive no-live-writer", alive, conclusive)
 	}
 	missing := filepath.Join(t.TempDir(), "does-not-exist.output")
-	if anyLiveOutputWriter([]string{missing}) {
-		t.Error("a non-existent output file should report no live writer")
+	if alive, conclusive := anyLiveOutputWriter([]string{missing}); alive || !conclusive {
+		t.Errorf("a non-existent output file = (%v, %v), want a conclusive no-live-writer", alive, conclusive)
 	}
 }
 

--- a/core/application/services/background_probe_internal_test.go
+++ b/core/application/services/background_probe_internal_test.go
@@ -61,19 +61,20 @@ func awaitConclusiveVerdict(t *testing.T, path string, want bool) {
 	t.Helper()
 	budget := 4 * lsofTimeout
 	deadline := time.Now().Add(budget)
-	for {
-		alive, conclusive := anyLiveOutputWriter([]string{path})
+	// Seeded to the failing verdict so an impossible zero-iteration loop would
+	// report a failure rather than a false pass.
+	alive, conclusive := !want, true
+	for time.Now().Before(deadline) {
+		alive, conclusive = anyLiveOutputWriter([]string{path})
 		if conclusive && alive == want {
 			return
 		}
-		if !time.Now().Before(deadline) {
-			if !conclusive {
-				t.Skipf("lsof never returned a conclusive verdict within %v; machine too loaded to observe the transition", budget)
-			}
-			t.Fatalf("probe reported alive=%v, want %v", alive, want)
-		}
 		time.Sleep(20 * time.Millisecond)
 	}
+	if !conclusive {
+		t.Skipf("lsof never returned a conclusive verdict within %v; machine too loaded to observe the transition", budget)
+	}
+	t.Fatalf("probe reported alive=%v, want %v", alive, want)
 }
 
 // A timeout must be reported as inconclusive, never as "no live writer": the

--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -91,8 +91,8 @@ func TestSessionDetector_BackgroundProcess_HoldsWorkingThenReady(t *testing.T) {
 	// probeLive is read from the probe goroutine, so guard it with atomic.
 	var probeLive atomic.Bool
 	probeLive.Store(true)
-	det.SetBackgroundProbeForTest(func(paths []string) bool {
-		return probeLive.Load()
+	det.SetBackgroundProbeForTest(func(paths []string) (bool, bool) {
+		return probeLive.Load(), true
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -168,8 +168,8 @@ func TestSessionDetector_BackgroundProcess_FreshSpawnFromReady_HoldsWorking(t *t
 
 	var probeLive atomic.Bool
 	probeLive.Store(true)
-	det.SetBackgroundProbeForTest(func(paths []string) bool {
-		return probeLive.Load()
+	det.SetBackgroundProbeForTest(func(paths []string) (bool, bool) {
+		return probeLive.Load(), true
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -283,7 +283,7 @@ func TestSessionDetector_BackgroundProcess_DeadVerdictPurgesLedger(t *testing.T)
 	}
 
 	det := newDetectorWithMetrics(tw, pw, repo, metrics)
-	det.SetBackgroundProbeForTest(func(paths []string) bool { return false })
+	det.SetBackgroundProbeForTest(func(paths []string) (bool, bool) { return false, true })
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -311,6 +311,123 @@ func TestSessionDetector_BackgroundProcess_DeadVerdictPurgesLedger(t *testing.T)
 	cancel()
 	<-done
 	t.Fatal("dead probe verdict did not trigger PurgeDeadBackgroundProcs within deadline")
+}
+
+// An INCONCLUSIVE probe verdict must not purge. lsof walks every process on
+// the machine, so it is slowest exactly when the machine is busiest — which is
+// when long-running background work is most likely to be in flight. Because
+// the purge writes through to the ledger, reading one slow lsof as death would
+// permanently drop a still-running process and flip a live session to ready
+// with no way back. The probe says "I don't know"; the detector must wait for
+// the next one rather than act. See issue #1299.
+func TestSessionDetector_BackgroundProcess_InconclusiveVerdictDoesNotPurge(t *testing.T) {
+	const sid = "bg-inconclusive"
+	const path = "/home/.claude/projects/-Users-test/bg-inconclusive.jsonl"
+	const outPath = "/tmp/x/tasks/inconclusive.output"
+
+	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		return &session.SessionMetrics{
+			LastEventType:            "turn_done",
+			BackgroundProcessCount:   1,
+			BackgroundProcessOutputs: []string{outPath},
+		}, nil
+	}}
+
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	repo.states[sid] = &session.SessionState{
+		SessionID:      sid,
+		State:          session.StateWorking,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	// Not alive, and not conclusive — an lsof that timed out.
+	det.SetBackgroundProbeForTest(func([]string) (bool, bool) { return false, false })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	defer func() { cancel(); <-done }()
+
+	tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      sid,
+		ProjectDir:     "-Users-test",
+		TranscriptPath: path,
+	}
+
+	// Give the probe goroutine room to run and (wrongly) purge if it is going
+	// to. The dead-verdict test above purges well inside this window, so the
+	// same budget is enough to catch the regression.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if purged := metrics.purgedSnapshot(); len(purged) > 0 {
+			t.Fatalf("an inconclusive probe purged %v — a timeout is not evidence of death", purged)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// Skipping the purge is only half of it: an inconclusive verdict must also
+// leave the cached liveness answer alone. Writing "dead" into it would flip the
+// session to ready anyway — the user-visible half of the same bug — so the last
+// real verdict is held until a probe actually finds out. See issue #1299.
+func TestSessionDetector_BackgroundProcess_InconclusiveVerdictHoldsWorking(t *testing.T) {
+	const sid = "bg-inconclusive-hold"
+	const path = "/home/.claude/projects/-Users-test/bg-inconclusive-hold.jsonl"
+
+	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		return &session.SessionMetrics{
+			LastEventType:            "turn_done",
+			BackgroundProcessCount:   1,
+			BackgroundProcessOutputs: []string{"/tmp/x/tasks/hold.output"},
+		}, nil
+	}}
+
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	repo.states[sid] = &session.SessionState{
+		SessionID:      sid,
+		State:          session.StateWorking,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	rec := &mockRecorder{}
+	det.SetRecorder(rec)
+
+	// conclusive=false throughout: every probe times out.
+	det.SetBackgroundProbeForTest(func([]string) (bool, bool) { return false, false })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	defer func() { cancel(); <-done }()
+
+	activity := func(terminal bool) {
+		tw.ch <- agent.Event{
+			Type:           agent.EventActivity,
+			SessionID:      sid,
+			ProjectDir:     "-Users-test",
+			TranscriptPath: path,
+			Terminal:       terminal,
+		}
+	}
+	activity(false)
+	time.Sleep(250 * time.Millisecond) // let the async probe settle
+	activity(true)
+	time.Sleep(250 * time.Millisecond)
+
+	if n := readyTransitions(rec, sid); n != 0 {
+		t.Fatalf("session flipped to ready %d time(s) on an inconclusive probe; a timeout is not evidence the background process died", n)
+	}
 }
 
 // End-to-end through the detector, PID-liveness path (Gemini CLI writes no
@@ -481,7 +598,7 @@ func TestSessionDetector_BackgroundMixed_IndependentLivenessAndPurge(t *testing.
 		det := newDetectorWithMetrics(tw, pw, repo, metrics)
 		rec = &mockRecorder{}
 		det.SetRecorder(rec)
-		det.SetBackgroundProbeForTest(func([]string) bool { return outAlive })
+		det.SetBackgroundProbeForTest(func([]string) (bool, bool) { return outAlive, true })
 		det.SetBackgroundPIDProbeForTest(func([]string) bool { return pidAlive })
 
 		// godre:S8188 wants cancel deferred here, but this helper is invoked

--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -346,7 +346,11 @@ func TestSessionDetector_BackgroundProcess_InconclusiveVerdictDoesNotPurge(t *te
 
 	det := newDetectorWithMetrics(tw, pw, repo, metrics)
 	// Not alive, and not conclusive — an lsof that timed out.
-	det.SetBackgroundProbeForTest(func([]string) (bool, bool) { return false, false })
+	var probes atomic.Int32
+	det.SetBackgroundProbeForTest(func([]string) (bool, bool) {
+		probes.Add(1)
+		return false, false
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -360,15 +364,22 @@ func TestSessionDetector_BackgroundProcess_InconclusiveVerdictDoesNotPurge(t *te
 		TranscriptPath: path,
 	}
 
-	// Give the probe goroutine room to run and (wrongly) purge if it is going
-	// to. The dead-verdict test above purges well inside this window, so the
-	// same budget is enough to catch the regression.
+	// Wait for positive evidence the probe ran before concluding anything —
+	// otherwise this passes just as happily if the probe is never launched at
+	// all, since "nothing purged" is also true then.
 	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if purged := metrics.purgedSnapshot(); len(purged) > 0 {
-			t.Fatalf("an inconclusive probe purged %v — a timeout is not evidence of death", purged)
-		}
+	for probes.Load() == 0 && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
+	}
+	if probes.Load() == 0 {
+		t.Fatal("background liveness probe was never invoked; the test would prove nothing")
+	}
+
+	// The dead-verdict path purges within ~50ms of the probe returning, so a
+	// short tail is enough to catch a regression here.
+	time.Sleep(300 * time.Millisecond)
+	if purged := metrics.purgedSnapshot(); len(purged) > 0 {
+		t.Fatalf("an inconclusive probe purged %v — a timeout is not evidence of death", purged)
 	}
 }
 
@@ -403,8 +414,14 @@ func TestSessionDetector_BackgroundProcess_InconclusiveVerdictHoldsWorking(t *te
 	rec := &mockRecorder{}
 	det.SetRecorder(rec)
 
-	// conclusive=false throughout: every probe times out.
-	det.SetBackgroundProbeForTest(func([]string) (bool, bool) { return false, false })
+	// conclusive=false throughout: every probe times out. Stays within
+	// maxInconclusiveBackgroundProbes for this test's handful of probes, so the
+	// hold is still in force when the assertion runs.
+	var probes atomic.Int32
+	det.SetBackgroundProbeForTest(func([]string) (bool, bool) {
+		probes.Add(1)
+		return false, false
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -425,9 +442,70 @@ func TestSessionDetector_BackgroundProcess_InconclusiveVerdictHoldsWorking(t *te
 	activity(true)
 	time.Sleep(250 * time.Millisecond)
 
+	if probes.Load() == 0 {
+		t.Fatal("background liveness probe was never invoked; the test would prove nothing")
+	}
 	if n := readyTransitions(rec, sid); n != 0 {
 		t.Fatalf("session flipped to ready %d time(s) on an inconclusive probe; a timeout is not evidence the background process died", n)
 	}
+}
+
+// Holding on inconclusive must be BOUNDED. "Timed out" is not proof of
+// transience — a permanently oversized process table, or a hung mount lsof
+// blocks on, makes every probe time out forever. Unbounded holding would pin
+// the session working for the daemon's lifetime, which is the failure the
+// pre-#1299 always-believe-the-silence behavior avoided. After
+// maxInconclusiveBackgroundProbes the dead verdict is accepted and the purge
+// runs. See issue #1299.
+func TestSessionDetector_BackgroundProcess_InconclusiveHoldIsBounded(t *testing.T) {
+	const sid = "bg-inconclusive-bound"
+	const path = "/home/.claude/projects/-Users-test/bg-inconclusive-bound.jsonl"
+
+	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		return &session.SessionMetrics{
+			LastEventType:            "turn_done",
+			BackgroundProcessCount:   1,
+			BackgroundProcessOutputs: []string{"/tmp/x/tasks/bounded.output"},
+		}, nil
+	}}
+
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	repo.states[sid] = &session.SessionState{
+		SessionID:      sid,
+		State:          session.StateWorking,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+
+	det := newDetectorWithMetrics(tw, pw, repo, metrics)
+	det.SetBackgroundProbeForTest(func([]string) (bool, bool) { return false, false })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	defer func() { cancel(); <-done }()
+
+	// Drive more probes than the bound allows. Terminal short-circuits the
+	// debounce so each event yields its own probe, as the periodic re-probe
+	// does in production.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		tw.ch <- agent.Event{
+			Type:           agent.EventActivity,
+			SessionID:      sid,
+			ProjectDir:     "-Users-test",
+			TranscriptPath: path,
+			Terminal:       true,
+		}
+		if purged := metrics.purgedSnapshot(); len(purged) > 0 {
+			return // the bound released the hold, as it must
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("the inconclusive hold never released across 5s of back-to-back probes; a chronically slow lsof would pin this session working forever")
 }
 
 // End-to-end through the detector, PID-liveness path (Gemini CLI writes no

--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -60,64 +60,67 @@ func TestClassifyState_HeldByLiveBackgroundProcess(t *testing.T) {
 // open background process stays working while the probe reports it alive, and
 // flips to ready once the probe reports it gone — the path the 5s
 // refreshStaleSessions ticker exercises in production. See issue #445.
-func TestSessionDetector_BackgroundProcess_HoldsWorkingThenReady(t *testing.T) {
-	// probeLive is read from the probe goroutine, so guard it with atomic.
-	var probeLive atomic.Bool
-	probeLive.Store(true)
-	f := newBGOutputFixture(
-		"bg1",
-		"/home/.claude/projects/-Users-test/bg1.jsonl",
-		"/tmp/x/tasks/bc1h56v8v.output",
-		func() (bool, bool) { return probeLive.Load(), true },
-	)
-	f.start(t)
-
-	// Probe reports the process alive → session stays working: no →ready
-	// transition should be recorded even though the turn ended (turn_done).
-	f.activity(false)
-	f.awaitProbe(t)
-	time.Sleep(250 * time.Millisecond) // allow any self-trigger to settle
-	if n := readyTransitions(f.rec, f.sid); n != 0 {
-		t.Fatalf("session flipped to ready %d time(s) while background process is alive", n)
+func TestSessionDetector_BackgroundProcess_HoldsWorkingWhileAliveThenReady(t *testing.T) {
+	tests := []struct {
+		name      string
+		sid       string
+		state     string
+		outPath   string
+		premature string // what a premature →ready would mean, for the message
+	}{
+		{
+			// The plain case (#445): a working session whose turn ended but
+			// whose background process is still running.
+			name:      "already working",
+			sid:       "bg1",
+			state:     session.StateWorking,
+			outPath:   "/tmp/x/tasks/bc1h56v8v.output",
+			premature: "while background process is alive",
+		},
+		{
+			// Issue #937: a session that had already settled `ready` and then
+			// shows a FRESH background spawn on the very next activity event
+			// must be pulled back to working, not skip the liveness probe
+			// because the pass started from `ready`. A retried `git push -u
+			// run_in_background:true` was silently invisible to the gate and
+			// the session bounced ready→working→ready in the same pass.
+			name:      "freshly spawned from ready",
+			sid:       "bg3",
+			state:     session.StateReady,
+			outPath:   "/tmp/x/tasks/retry.output",
+			premature: "while its freshly-spawned background process is alive",
+		},
 	}
 
-	// Background process exits — probe now reports it gone → session goes ready.
-	probeLive.Store(false)
-	f.activity(true)
-	waitForReadyTransition(t, f.rec, f.sid)
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// probeLive is read from the probe goroutine, so guard it with atomic.
+			var probeLive atomic.Bool
+			probeLive.Store(true)
+			f := newBGOutputFixtureInState(
+				tc.sid,
+				"/home/.claude/projects/-Users-test/"+tc.sid+".jsonl",
+				tc.outPath,
+				tc.state,
+				func() (bool, bool) { return probeLive.Load(), true },
+			)
+			f.start(t)
 
-// A session already `ready` (e.g. a prior background job just finished and
-// settled it) that then shows a *fresh* background spawn on the very next
-// activity event must be pulled back to working and held there while that new
-// process is alive — not skip the liveness probe because the pass started
-// from `ready`. Reproduces issue #937: a retried `git push -u
-// run_in_background:true` launched right after the session had settled ready
-// was silently invisible to the liveness gate, and the session bounced
-// ready→working→ready in the same pass despite the push still running.
-func TestSessionDetector_BackgroundProcess_FreshSpawnFromReady_HoldsWorking(t *testing.T) {
-	var probeLive atomic.Bool
-	probeLive.Store(true)
-	f := newBGOutputFixtureInState(
-		"bg3",
-		"/home/.claude/projects/-Users-test/bg3.jsonl",
-		"/tmp/x/tasks/retry.output",
-		session.StateReady,
-		func() (bool, bool) { return probeLive.Load(), true },
-	)
-	f.start(t)
+			// Probe reports the process alive → session stays working, even
+			// though the turn ended (turn_done).
+			f.activity(false)
+			f.awaitProbe(t)
+			time.Sleep(250 * time.Millisecond) // allow any self-trigger to settle
+			if n := readyTransitions(f.rec, f.sid); n != 0 {
+				t.Fatalf("session flipped to ready %d time(s) %s", n, tc.premature)
+			}
 
-	f.activity(false)
-	f.awaitProbe(t)
-	time.Sleep(250 * time.Millisecond) // allow any self-trigger to settle
-	if n := readyTransitions(f.rec, f.sid); n != 0 {
-		t.Fatalf("session flipped to ready %d time(s) while its freshly-spawned background process is alive", n)
+			// Background process exits — probe reports it gone → session goes ready.
+			probeLive.Store(false)
+			f.activity(true)
+			waitForReadyTransition(t, f.rec, f.sid)
+		})
 	}
-
-	// Background process exits — probe now reports it gone → session goes ready.
-	probeLive.Store(false)
-	f.activity(true)
-	waitForReadyTransition(t, f.rec, f.sid)
 }
 
 // The ready→working force-bounce (see forceReadyToWorkingIfActive) must be

--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -313,28 +313,32 @@ func TestSessionDetector_BackgroundProcess_DeadVerdictPurgesLedger(t *testing.T)
 	t.Fatal("dead probe verdict did not trigger PurgeDeadBackgroundProcs within deadline")
 }
 
-// An INCONCLUSIVE probe verdict must not purge. lsof walks every process on
-// the machine, so it is slowest exactly when the machine is busiest — which is
-// when long-running background work is most likely to be in flight. Because
-// the purge writes through to the ledger, reading one slow lsof as death would
-// permanently drop a still-running process and flip a live session to ready
-// with no way back. The probe says "I don't know"; the detector must wait for
-// the next one rather than act. See issue #1299.
-func TestSessionDetector_BackgroundProcess_InconclusiveVerdictDoesNotPurge(t *testing.T) {
-	const sid = "bg-inconclusive"
-	const path = "/home/.claude/projects/-Users-test/bg-inconclusive.jsonl"
-	const outPath = "/tmp/x/tasks/inconclusive.output"
+// bgOutputFixture is the setup every background-output liveness test shares: a
+// `working` session whose turn has ended and whose only open background process
+// is an output file, wired to a detector with an injectable probe.
+type bgOutputFixture struct {
+	det     *services.SessionDetector
+	tw      *mockAgentWatcher
+	metrics *funcMetrics
+	rec     *mockRecorder
+	probes  atomic.Int32
+	sid     string
+	path    string
+}
 
-	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+// newBGOutputFixture builds the fixture with probe as the injected liveness
+// verdict; every call is counted so a test can require positive evidence the
+// probe actually ran rather than passing on the mere absence of an effect.
+func newBGOutputFixture(sid, path, outPath string, probe func() (alive, conclusive bool)) *bgOutputFixture {
+	f := &bgOutputFixture{sid: sid, path: path}
+	f.metrics = &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
 		return &session.SessionMetrics{
 			LastEventType:            "turn_done",
 			BackgroundProcessCount:   1,
 			BackgroundProcessOutputs: []string{outPath},
 		}, nil
 	}}
-
-	tw := newMockAgentWatcher()
-	pw := newMockProcessWatcher()
+	f.tw = newMockAgentWatcher()
 	repo := newMockRepo()
 	repo.states[sid] = &session.SessionState{
 		SessionID:      sid,
@@ -343,42 +347,74 @@ func TestSessionDetector_BackgroundProcess_InconclusiveVerdictDoesNotPurge(t *te
 		FirstSeen:      time.Now().Unix(),
 		UpdatedAt:      time.Now().Unix(),
 	}
-
-	det := newDetectorWithMetrics(tw, pw, repo, metrics)
-	// Not alive, and not conclusive — an lsof that timed out.
-	var probes atomic.Int32
-	det.SetBackgroundProbeForTest(func([]string) (bool, bool) {
-		probes.Add(1)
-		return false, false
+	f.det = newDetectorWithMetrics(f.tw, newMockProcessWatcher(), repo, f.metrics)
+	f.rec = &mockRecorder{}
+	f.det.SetRecorder(f.rec)
+	f.det.SetBackgroundProbeForTest(func([]string) (bool, bool) {
+		f.probes.Add(1)
+		return probe()
 	})
+	return f
+}
 
+// start runs the detector and stops it when the test ends.
+func (f *bgOutputFixture) start(t *testing.T) {
+	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
-	go func() { done <- det.Run(ctx) }()
-	defer func() { cancel(); <-done }()
+	go func() { done <- f.det.Run(ctx) }()
+	t.Cleanup(func() { cancel(); <-done })
+}
 
-	tw.ch <- agent.Event{
+// activity drives one re-evaluation. terminal short-circuits the 2s debounce,
+// the way production's periodic re-probe does.
+func (f *bgOutputFixture) activity(terminal bool) {
+	f.tw.ch <- agent.Event{
 		Type:           agent.EventActivity,
-		SessionID:      sid,
+		SessionID:      f.sid,
 		ProjectDir:     "-Users-test",
-		TranscriptPath: path,
+		TranscriptPath: f.path,
+		Terminal:       terminal,
 	}
+}
 
-	// Wait for positive evidence the probe ran before concluding anything —
-	// otherwise this passes just as happily if the probe is never launched at
-	// all, since "nothing purged" is also true then.
+// awaitProbe blocks until the injected probe has run at least once, failing if
+// it never does — without it a test asserting only that nothing happened would
+// pass just as happily when the probe was never launched.
+func (f *bgOutputFixture) awaitProbe(t *testing.T) {
+	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
-	for probes.Load() == 0 && time.Now().Before(deadline) {
+	for f.probes.Load() == 0 {
+		if !time.Now().Before(deadline) {
+			t.Fatal("background liveness probe was never invoked; the test would prove nothing")
+		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if probes.Load() == 0 {
-		t.Fatal("background liveness probe was never invoked; the test would prove nothing")
-	}
+}
+
+// An INCONCLUSIVE probe verdict must not purge. lsof walks every process on
+// the machine, so it is slowest exactly when the machine is busiest — which is
+// when long-running background work is most likely to be in flight. Because
+// the purge writes through to the ledger, reading one slow lsof as death would
+// permanently drop a still-running process and flip a live session to ready
+// with no way back. The probe says "I don't know"; the detector must wait for
+// the next one rather than act. See issue #1299.
+func TestSessionDetector_BackgroundProcess_InconclusiveVerdictDoesNotPurge(t *testing.T) {
+	// Not alive, and not conclusive — an lsof that timed out.
+	f := newBGOutputFixture(
+		"bg-inconclusive",
+		"/home/.claude/projects/-Users-test/bg-inconclusive.jsonl",
+		"/tmp/x/tasks/inconclusive.output",
+		func() (bool, bool) { return false, false },
+	)
+	f.start(t)
+	f.activity(false)
+	f.awaitProbe(t)
 
 	// The dead-verdict path purges within ~50ms of the probe returning, so a
 	// short tail is enough to catch a regression here.
 	time.Sleep(300 * time.Millisecond)
-	if purged := metrics.purgedSnapshot(); len(purged) > 0 {
+	if purged := f.metrics.purgedSnapshot(); len(purged) > 0 {
 		t.Fatalf("an inconclusive probe purged %v — a timeout is not evidence of death", purged)
 	}
 }
@@ -388,64 +424,23 @@ func TestSessionDetector_BackgroundProcess_InconclusiveVerdictDoesNotPurge(t *te
 // session to ready anyway — the user-visible half of the same bug — so the last
 // real verdict is held until a probe actually finds out. See issue #1299.
 func TestSessionDetector_BackgroundProcess_InconclusiveVerdictHoldsWorking(t *testing.T) {
-	const sid = "bg-inconclusive-hold"
-	const path = "/home/.claude/projects/-Users-test/bg-inconclusive-hold.jsonl"
-
-	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
-		return &session.SessionMetrics{
-			LastEventType:            "turn_done",
-			BackgroundProcessCount:   1,
-			BackgroundProcessOutputs: []string{"/tmp/x/tasks/hold.output"},
-		}, nil
-	}}
-
-	tw := newMockAgentWatcher()
-	pw := newMockProcessWatcher()
-	repo := newMockRepo()
-	repo.states[sid] = &session.SessionState{
-		SessionID:      sid,
-		State:          session.StateWorking,
-		TranscriptPath: path,
-		FirstSeen:      time.Now().Unix(),
-		UpdatedAt:      time.Now().Unix(),
-	}
-
-	det := newDetectorWithMetrics(tw, pw, repo, metrics)
-	rec := &mockRecorder{}
-	det.SetRecorder(rec)
-
-	// conclusive=false throughout: every probe times out. Stays within
-	// maxInconclusiveBackgroundProbes for this test's handful of probes, so the
-	// hold is still in force when the assertion runs.
-	var probes atomic.Int32
-	det.SetBackgroundProbeForTest(func([]string) (bool, bool) {
-		probes.Add(1)
-		return false, false
-	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- det.Run(ctx) }()
-	defer func() { cancel(); <-done }()
-
-	activity := func(terminal bool) {
-		tw.ch <- agent.Event{
-			Type:           agent.EventActivity,
-			SessionID:      sid,
-			ProjectDir:     "-Users-test",
-			TranscriptPath: path,
-			Terminal:       terminal,
-		}
-	}
-	activity(false)
-	time.Sleep(250 * time.Millisecond) // let the async probe settle
-	activity(true)
+	// conclusive=false throughout: every probe times out. This test drives
+	// fewer probes than maxInconclusiveBackgroundProbes, so the hold is still
+	// in force when the assertion runs.
+	f := newBGOutputFixture(
+		"bg-inconclusive-hold",
+		"/home/.claude/projects/-Users-test/bg-inconclusive-hold.jsonl",
+		"/tmp/x/tasks/hold.output",
+		func() (bool, bool) { return false, false },
+	)
+	f.start(t)
+	f.activity(false)
+	f.awaitProbe(t)
+	time.Sleep(250 * time.Millisecond)
+	f.activity(true)
 	time.Sleep(250 * time.Millisecond)
 
-	if probes.Load() == 0 {
-		t.Fatal("background liveness probe was never invoked; the test would prove nothing")
-	}
-	if n := readyTransitions(rec, sid); n != 0 {
+	if n := readyTransitions(f.rec, f.sid); n != 0 {
 		t.Fatalf("session flipped to ready %d time(s) on an inconclusive probe; a timeout is not evidence the background process died", n)
 	}
 }
@@ -458,49 +453,20 @@ func TestSessionDetector_BackgroundProcess_InconclusiveVerdictHoldsWorking(t *te
 // maxInconclusiveBackgroundProbes the dead verdict is accepted and the purge
 // runs. See issue #1299.
 func TestSessionDetector_BackgroundProcess_InconclusiveHoldIsBounded(t *testing.T) {
-	const sid = "bg-inconclusive-bound"
-	const path = "/home/.claude/projects/-Users-test/bg-inconclusive-bound.jsonl"
+	f := newBGOutputFixture(
+		"bg-inconclusive-bound",
+		"/home/.claude/projects/-Users-test/bg-inconclusive-bound.jsonl",
+		"/tmp/x/tasks/bounded.output",
+		func() (bool, bool) { return false, false },
+	)
+	f.start(t)
 
-	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
-		return &session.SessionMetrics{
-			LastEventType:            "turn_done",
-			BackgroundProcessCount:   1,
-			BackgroundProcessOutputs: []string{"/tmp/x/tasks/bounded.output"},
-		}, nil
-	}}
-
-	tw := newMockAgentWatcher()
-	pw := newMockProcessWatcher()
-	repo := newMockRepo()
-	repo.states[sid] = &session.SessionState{
-		SessionID:      sid,
-		State:          session.StateWorking,
-		TranscriptPath: path,
-		FirstSeen:      time.Now().Unix(),
-		UpdatedAt:      time.Now().Unix(),
-	}
-
-	det := newDetectorWithMetrics(tw, pw, repo, metrics)
-	det.SetBackgroundProbeForTest(func([]string) (bool, bool) { return false, false })
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- det.Run(ctx) }()
-	defer func() { cancel(); <-done }()
-
-	// Drive more probes than the bound allows. Terminal short-circuits the
-	// debounce so each event yields its own probe, as the periodic re-probe
-	// does in production.
+	// Drive more probes than the bound allows; Terminal short-circuits the
+	// debounce so each event yields its own probe.
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		tw.ch <- agent.Event{
-			Type:           agent.EventActivity,
-			SessionID:      sid,
-			ProjectDir:     "-Users-test",
-			TranscriptPath: path,
-			Terminal:       true,
-		}
-		if purged := metrics.purgedSnapshot(); len(purged) > 0 {
+		f.activity(true)
+		if purged := f.metrics.purgedSnapshot(); len(purged) > 0 {
 			return // the bound released the hold, as it must
 		}
 		time.Sleep(50 * time.Millisecond)

--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -61,74 +61,30 @@ func TestClassifyState_HeldByLiveBackgroundProcess(t *testing.T) {
 // flips to ready once the probe reports it gone — the path the 5s
 // refreshStaleSessions ticker exercises in production. See issue #445.
 func TestSessionDetector_BackgroundProcess_HoldsWorkingThenReady(t *testing.T) {
-	const sid = "bg1"
-	const path = "/home/.claude/projects/-Users-test/bg1.jsonl"
-
-	// Metrics always show a finished turn with one open background process.
-	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
-		return &session.SessionMetrics{
-			LastEventType:            "turn_done",
-			BackgroundProcessCount:   1,
-			BackgroundProcessOutputs: []string{"/tmp/x/tasks/bc1h56v8v.output"},
-		}, nil
-	}}
-
-	tw := newMockAgentWatcher()
-	pw := newMockProcessWatcher()
-	repo := newMockRepo()
-	repo.states[sid] = &session.SessionState{
-		SessionID:      sid,
-		State:          session.StateWorking,
-		TranscriptPath: path,
-		FirstSeen:      time.Now().Unix(),
-		UpdatedAt:      time.Now().Unix(),
-	}
-
-	det := newDetectorWithMetrics(tw, pw, repo, metrics)
-	rec := &mockRecorder{}
-	det.SetRecorder(rec)
-
 	// probeLive is read from the probe goroutine, so guard it with atomic.
 	var probeLive atomic.Bool
 	probeLive.Store(true)
-	det.SetBackgroundProbeForTest(func(paths []string) (bool, bool) {
-		return probeLive.Load(), true
-	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- det.Run(ctx) }()
-
-	// activity drives one re-evaluation. The first event for a session fires
-	// processActivity immediately; later events within the 2s debounce window
-	// coalesce, so we mark the follow-up Terminal to short-circuit the
-	// debounce (production's periodic re-probe bypasses debounce the same way
-	// via processActivityWithoutIdentity).
-	activity := func(terminal bool) {
-		tw.ch <- agent.Event{
-			Type:           agent.EventActivity,
-			SessionID:      sid,
-			ProjectDir:     "-Users-test",
-			TranscriptPath: path,
-			Terminal:       terminal,
-		}
-	}
+	f := newBGOutputFixture(
+		"bg1",
+		"/home/.claude/projects/-Users-test/bg1.jsonl",
+		"/tmp/x/tasks/bc1h56v8v.output",
+		func() (bool, bool) { return probeLive.Load(), true },
+	)
+	f.start(t)
 
 	// Probe reports the process alive → session stays working: no →ready
 	// transition should be recorded even though the turn ended (turn_done).
-	activity(false)
-	time.Sleep(250 * time.Millisecond) // allow the async probe + any self-trigger to settle
-	if n := readyTransitions(rec, sid); n != 0 {
+	f.activity(false)
+	f.awaitProbe(t)
+	time.Sleep(250 * time.Millisecond) // allow any self-trigger to settle
+	if n := readyTransitions(f.rec, f.sid); n != 0 {
 		t.Fatalf("session flipped to ready %d time(s) while background process is alive", n)
 	}
 
 	// Background process exits — probe now reports it gone → session goes ready.
 	probeLive.Store(false)
-	activity(true)
-	waitForReadyTransition(t, rec, sid)
-
-	cancel()
-	<-done
+	f.activity(true)
+	waitForReadyTransition(t, f.rec, f.sid)
 }
 
 // A session already `ready` (e.g. a prior background job just finished and
@@ -140,67 +96,28 @@ func TestSessionDetector_BackgroundProcess_HoldsWorkingThenReady(t *testing.T) {
 // was silently invisible to the liveness gate, and the session bounced
 // ready→working→ready in the same pass despite the push still running.
 func TestSessionDetector_BackgroundProcess_FreshSpawnFromReady_HoldsWorking(t *testing.T) {
-	const sid = "bg3"
-	const path = "/home/.claude/projects/-Users-test/bg3.jsonl"
-
-	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
-		return &session.SessionMetrics{
-			LastEventType:            "turn_done",
-			BackgroundProcessCount:   1,
-			BackgroundProcessOutputs: []string{"/tmp/x/tasks/retry.output"},
-		}, nil
-	}}
-
-	tw := newMockAgentWatcher()
-	pw := newMockProcessWatcher()
-	repo := newMockRepo()
-	repo.states[sid] = &session.SessionState{
-		SessionID:      sid,
-		State:          session.StateReady,
-		TranscriptPath: path,
-		FirstSeen:      time.Now().Unix(),
-		UpdatedAt:      time.Now().Unix(),
-	}
-
-	det := newDetectorWithMetrics(tw, pw, repo, metrics)
-	rec := &mockRecorder{}
-	det.SetRecorder(rec)
-
 	var probeLive atomic.Bool
 	probeLive.Store(true)
-	det.SetBackgroundProbeForTest(func(paths []string) (bool, bool) {
-		return probeLive.Load(), true
-	})
+	f := newBGOutputFixtureInState(
+		"bg3",
+		"/home/.claude/projects/-Users-test/bg3.jsonl",
+		"/tmp/x/tasks/retry.output",
+		session.StateReady,
+		func() (bool, bool) { return probeLive.Load(), true },
+	)
+	f.start(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- det.Run(ctx) }()
-
-	tw.ch <- agent.Event{
-		Type:           agent.EventActivity,
-		SessionID:      sid,
-		ProjectDir:     "-Users-test",
-		TranscriptPath: path,
-		Terminal:       false,
-	}
-	time.Sleep(250 * time.Millisecond) // allow the async probe + any self-trigger to settle
-	if n := readyTransitions(rec, sid); n != 0 {
+	f.activity(false)
+	f.awaitProbe(t)
+	time.Sleep(250 * time.Millisecond) // allow any self-trigger to settle
+	if n := readyTransitions(f.rec, f.sid); n != 0 {
 		t.Fatalf("session flipped to ready %d time(s) while its freshly-spawned background process is alive", n)
 	}
 
 	// Background process exits — probe now reports it gone → session goes ready.
 	probeLive.Store(false)
-	tw.ch <- agent.Event{
-		Type:           agent.EventActivity,
-		SessionID:      sid,
-		ProjectDir:     "-Users-test",
-		TranscriptPath: path,
-		Terminal:       true,
-	}
-	waitForReadyTransition(t, rec, sid)
-
-	cancel()
-	<-done
+	f.activity(true)
+	waitForReadyTransition(t, f.rec, f.sid)
 }
 
 // The ready→working force-bounce (see forceReadyToWorkingIfActive) must be
@@ -280,85 +197,6 @@ func TestSessionDetector_BackgroundProcess_DeadVerdictPurgesLedger(t *testing.T)
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("dead probe verdict did not trigger PurgeDeadBackgroundProcs within deadline")
-}
-
-// bgOutputFixture is the setup every background-output liveness test shares: a
-// `working` session whose turn has ended and whose only open background process
-// is an output file, wired to a detector with an injectable probe.
-type bgOutputFixture struct {
-	det     *services.SessionDetector
-	tw      *mockAgentWatcher
-	metrics *funcMetrics
-	rec     *mockRecorder
-	probes  atomic.Int32
-	sid     string
-	path    string
-}
-
-// newBGOutputFixture builds the fixture with probe as the injected liveness
-// verdict; every call is counted so a test can require positive evidence the
-// probe actually ran rather than passing on the mere absence of an effect.
-func newBGOutputFixture(sid, path, outPath string, probe func() (alive, conclusive bool)) *bgOutputFixture {
-	f := &bgOutputFixture{sid: sid, path: path}
-	f.metrics = &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
-		return &session.SessionMetrics{
-			LastEventType:            "turn_done",
-			BackgroundProcessCount:   1,
-			BackgroundProcessOutputs: []string{outPath},
-		}, nil
-	}}
-	f.tw = newMockAgentWatcher()
-	repo := newMockRepo()
-	repo.states[sid] = &session.SessionState{
-		SessionID:      sid,
-		State:          session.StateWorking,
-		TranscriptPath: path,
-		FirstSeen:      time.Now().Unix(),
-		UpdatedAt:      time.Now().Unix(),
-	}
-	f.det = newDetectorWithMetrics(f.tw, newMockProcessWatcher(), repo, f.metrics)
-	f.rec = &mockRecorder{}
-	f.det.SetRecorder(f.rec)
-	f.det.SetBackgroundProbeForTest(func([]string) (bool, bool) {
-		f.probes.Add(1)
-		return probe()
-	})
-	return f
-}
-
-// start runs the detector and stops it when the test ends.
-func (f *bgOutputFixture) start(t *testing.T) {
-	t.Helper()
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- f.det.Run(ctx) }()
-	t.Cleanup(func() { cancel(); <-done })
-}
-
-// activity drives one re-evaluation. terminal short-circuits the 2s debounce,
-// the way production's periodic re-probe does.
-func (f *bgOutputFixture) activity(terminal bool) {
-	f.tw.ch <- agent.Event{
-		Type:           agent.EventActivity,
-		SessionID:      f.sid,
-		ProjectDir:     "-Users-test",
-		TranscriptPath: f.path,
-		Terminal:       terminal,
-	}
-}
-
-// awaitProbe blocks until the injected probe has run at least once, failing if
-// it never does — without it a test asserting only that nothing happened would
-// pass just as happily when the probe was never launched.
-func (f *bgOutputFixture) awaitProbe(t *testing.T) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for f.probes.Load() == 0 {
-		if !time.Now().Before(deadline) {
-			t.Fatal("background liveness probe was never invoked; the test would prove nothing")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
 }
 
 // An INCONCLUSIVE probe verdict must not purge. lsof walks every process on

--- a/core/application/services/background_process_test.go
+++ b/core/application/services/background_process_test.go
@@ -260,56 +260,25 @@ func TestSessionDetector_ForceReadyToWorking_LogsTransition(t *testing.T) {
 // the persisted entries would otherwise resurrect as phantom open processes
 // on every daemon restart. See issue #649.
 func TestSessionDetector_BackgroundProcess_DeadVerdictPurgesLedger(t *testing.T) {
-	const sid = "bg2"
-	const path = "/home/.claude/projects/-Users-test/bg2.jsonl"
-
-	metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
-		return &session.SessionMetrics{
-			LastEventType:            "turn_done",
-			BackgroundProcessCount:   1,
-			BackgroundProcessOutputs: []string{"/tmp/x/tasks/bbw7rzpa0.output"},
-		}, nil
-	}}
-
-	tw := newMockAgentWatcher()
-	pw := newMockProcessWatcher()
-	repo := newMockRepo()
-	repo.states[sid] = &session.SessionState{
-		SessionID:      sid,
-		State:          session.StateWorking,
-		TranscriptPath: path,
-		FirstSeen:      time.Now().Unix(),
-		UpdatedAt:      time.Now().Unix(),
-	}
-
-	det := newDetectorWithMetrics(tw, pw, repo, metrics)
-	det.SetBackgroundProbeForTest(func(paths []string) (bool, bool) { return false, true })
-
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- det.Run(ctx) }()
-
-	tw.ch <- agent.Event{
-		Type:           agent.EventActivity,
-		SessionID:      sid,
-		ProjectDir:     "-Users-test",
-		TranscriptPath: path,
-	}
+	f := newBGOutputFixture(
+		"bg2",
+		"/home/.claude/projects/-Users-test/bg2.jsonl",
+		"/tmp/x/tasks/bbw7rzpa0.output",
+		func() (bool, bool) { return false, true },
+	)
+	f.start(t)
+	f.activity(false)
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if purged := metrics.purgedSnapshot(); len(purged) > 0 {
-			if purged[0] != path {
-				t.Errorf("purged transcript = %q, want %q", purged[0], path)
+		if purged := f.metrics.purgedSnapshot(); len(purged) > 0 {
+			if purged[0] != f.path {
+				t.Errorf("purged transcript = %q, want %q", purged[0], f.path)
 			}
-			cancel()
-			<-done
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	cancel()
-	<-done
 	t.Fatal("dead probe verdict did not trigger PurgeDeadBackgroundProcs within deadline")
 }
 

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -372,8 +372,9 @@ func (d *SessionDetector) SetSessionSupersededHandler(fn func(oldID, newID strin
 
 // SetBackgroundProbeForTest overrides the background-process liveness probe so
 // tests can simulate live / dead background processes without real lsof. See
-// issue #445.
-func (d *SessionDetector) SetBackgroundProbeForTest(p func(outputPaths []string) bool) {
+// issue #445. The second return is "was this conclusive?" — pass false to
+// simulate an lsof timeout (issue #1299), not to mean "dead".
+func (d *SessionDetector) SetBackgroundProbeForTest(p func(outputPaths []string) (alive, conclusive bool)) {
 	d.bgLiveProbe = p
 }
 

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -258,6 +258,10 @@ type SessionDetector struct {
 	bgMu      sync.Mutex
 	bgLive    map[string]bool
 	bgProbing map[string]bool
+	// bgInconclusive counts consecutive inconclusive probe verdicts per
+	// session, so holding the previous verdict through a slow lsof stays
+	// bounded (issue #1299). Reset by any conclusive verdict.
+	bgInconclusive map[string]int
 
 	// consentGate (optional) reports whether an adapter's transcripts may
 	// be read (#570). Gates the two paths that read PERSISTED sessions'
@@ -335,6 +339,7 @@ func NewSessionDetector(watchers []inbound.Watcher, deps SessionDetectorDeps) *S
 		bgPIDProbe:               anyLivePID,
 		bgLive:                   make(map[string]bool),
 		bgProbing:                make(map[string]bool),
+		bgInconclusive:           make(map[string]int),
 		uiSignals:                make(chan terminalUISignal, 64),
 	}
 	det.pidMgr = NewPIDManager(PIDManagerDeps{

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1154,6 +1154,28 @@ func (d *SessionDetector) noteInconclusiveProbe(sid string, outputs int) bool {
 	return hold
 }
 
+// commitBackgroundVerdict records the probe outcome for sid and releases the
+// in-flight slot, reporting whether the verdict changed (or is the first one)
+// and therefore warrants nudging the event loop. When hold is set the previous
+// answer is kept instead of the probe's, because the probe didn't find out.
+func (d *SessionDetector) commitBackgroundVerdict(sid string, live, hold bool) (changed bool) {
+	d.bgMu.Lock()
+	defer d.bgMu.Unlock()
+
+	prev, had := d.bgLive[sid]
+	if hold {
+		// Optimistically alive on first sight, matching beginBackgroundProbe's
+		// never-declare-an-unprobed-process-dead rule (#445).
+		live = true
+		if had {
+			live = prev
+		}
+	}
+	d.bgLive[sid] = live
+	d.bgProbing[sid] = false
+	return !had || prev != live
+}
+
 // clearInconclusiveProbes resets sid's run of inconclusive verdicts once a
 // probe has actually answered.
 func (d *SessionDetector) clearInconclusiveProbes(sid string) {
@@ -1218,26 +1240,12 @@ func (d *SessionDetector) runBackgroundLivenessProbe(sid, transcriptPath string,
 		LivePID:        livePID,
 	})
 
-	d.bgMu.Lock()
-	prev, had := d.bgLive[sid]
-	if hold {
-		// Optimistically alive on first sight, matching beginBackgroundProbe's
-		// never-declare-an-unprobed-process-dead rule (#445).
-		live = true
-		if had {
-			live = prev
-		}
-	}
-	d.bgLive[sid] = live
-	d.bgProbing[sid] = false
-	d.bgMu.Unlock()
-
 	// On a changed (or first) verdict, nudge the event loop to re-classify
 	// now rather than waiting for the next refresh tick. The send mirrors
 	// the debounce-timer path (single event-loop goroutine owns
 	// processActivity); drop if the buffer is full — the 5s refresh is the
 	// backstop.
-	if had && prev == live {
+	if !d.commitBackgroundVerdict(sid, live, hold) {
 		return
 	}
 	select {

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1107,10 +1107,59 @@ func (d *SessionDetector) clearBackgroundTracking(sid string, m *session.Session
 	d.bgMu.Lock()
 	delete(d.bgLive, sid)
 	delete(d.bgProbing, sid)
+	delete(d.bgInconclusive, sid)
 	d.bgMu.Unlock()
 	if m != nil {
 		m.HasLiveBackgroundProcess = false
 	}
+}
+
+// maxInconclusiveBackgroundProbes bounds how many consecutive inconclusive
+// verdicts may hold a session's previous liveness answer before the dead
+// verdict is accepted anyway.
+//
+// Holding is right for a transient slow lsof, but "timed out" is not proof of
+// transience: a permanently large process table, or a hung network mount that
+// lsof blocks on, makes every probe time out forever. Unbounded holding would
+// then pin the session `working` for the daemon's lifetime and — because the
+// purge is skipped too — leave the ledger entry to replay the same loop after
+// a restart. That is exactly the failure the pre-#1299 "always believe the
+// silence" behavior avoided, so the bound preserves it as the floor: at the
+// ~5s re-probe cadence this holds for roughly half a minute, then degrades to
+// the old semantics.
+const maxInconclusiveBackgroundProbes = 5
+
+// noteInconclusiveProbe records another consecutive inconclusive verdict for
+// sid and reports whether the previous verdict should still be held.
+func (d *SessionDetector) noteInconclusiveProbe(sid string, outputs int) bool {
+	d.bgMu.Lock()
+	n := d.bgInconclusive[sid] + 1
+	d.bgInconclusive[sid] = n
+	d.bgMu.Unlock()
+
+	hold := n <= maxInconclusiveBackgroundProbes
+	if d.log == nil {
+		return hold
+	}
+	// Edge-triggered: the first hold and the give-up, not every cycle — a
+	// chronically slow lsof would otherwise emit a line per probe forever.
+	switch {
+	case n == 1:
+		d.log.LogInfo(logComponentSessionDetector, sid, fmt.Sprintf(
+			"background liveness probe inconclusive for %d output path(s); holding the previous verdict rather than purging", outputs))
+	case !hold && n == maxInconclusiveBackgroundProbes+1:
+		d.log.LogError(logComponentSessionDetector, sid, fmt.Sprintf(
+			"background liveness probe inconclusive %d times running; accepting the dead verdict for %d output path(s) — a live background process may be purged", n, outputs))
+	}
+	return hold
+}
+
+// clearInconclusiveProbes resets sid's run of inconclusive verdicts once a
+// probe has actually answered.
+func (d *SessionDetector) clearInconclusiveProbes(sid string) {
+	d.bgMu.Lock()
+	delete(d.bgInconclusive, sid)
+	d.bgMu.Unlock()
 }
 
 // beginBackgroundProbe reads the last-known liveness verdict for sid
@@ -1148,26 +1197,30 @@ func (d *SessionDetector) runBackgroundLivenessProbe(sid, transcriptPath string,
 	livePID := len(pids) > 0 && d.bgPIDProbe != nil && d.bgPIDProbe(pids)
 	live := liveOut || livePID
 
-	if !outConclusive && d.log != nil {
-		d.log.LogError(logComponentSessionDetector, sid, fmt.Sprintf(
-			"background liveness probe was inconclusive for %d output path(s); holding the previous verdict rather than purging", len(outputs)))
-	}
-
 	// An inconclusive output probe is not evidence of death, and the purge it
 	// would otherwise trigger is durable (issue #1299) — so skip it and keep
-	// whatever the last real verdict was. A live PID still counts: it is
-	// positive proof from the other probe, independent of lsof.
+	// whatever the last real verdict was. The guard tests `live`, not just
+	// `livePID`, so a probe that reports (alive, inconclusive) is believed
+	// rather than discarded in favour of a stale cache; anyLiveOutputWriter
+	// never returns that pair today, but the backgroundProbe seam permits it.
+	hold := false
+	if !outConclusive && !live {
+		hold = d.noteInconclusiveProbe(sid, len(outputs))
+	} else {
+		d.clearInconclusiveProbes(sid)
+	}
+
 	d.purgeDeadBackgroundProcesses(backgroundProbeResult{
 		TranscriptPath: transcriptPath,
 		Outputs:        outputs,
 		PIDs:           pids,
-		LiveOut:        liveOut || !outConclusive,
+		LiveOut:        liveOut || hold,
 		LivePID:        livePID,
 	})
 
 	d.bgMu.Lock()
 	prev, had := d.bgLive[sid]
-	if !outConclusive && !livePID {
+	if hold {
 		// Optimistically alive on first sight, matching beginBackgroundProbe's
 		// never-declare-an-unprobed-process-dead rule (#445).
 		live = true

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1212,42 +1212,65 @@ func (d *SessionDetector) beginBackgroundProbe(sid string) (alive, startProbe bo
 // verdict changed (issues #649, #661). Must not alias state: outputs/pids
 // are copies taken by the caller before this runs on its own goroutine.
 func (d *SessionDetector) runBackgroundLivenessProbe(sid, transcriptPath string, outputs, pids []string) {
-	liveOut, outConclusive := false, true
-	if len(outputs) > 0 && d.bgLiveProbe != nil {
-		liveOut, outConclusive = d.bgLiveProbe(outputs)
-	}
-	livePID := len(pids) > 0 && d.bgPIDProbe != nil && d.bgPIDProbe(pids)
-	live := liveOut || livePID
+	probed := d.probeBackgroundLiveness(transcriptPath, outputs, pids)
+	hold := d.holdOnInconclusiveProbe(sid, probed)
 
-	// An inconclusive output probe is not evidence of death, and the purge it
-	// would otherwise trigger is durable (issue #1299) — so skip it and keep
-	// whatever the last real verdict was. The guard tests `live`, not just
-	// `livePID`, so a probe that reports (alive, inconclusive) is believed
-	// rather than discarded in favour of a stale cache; anyLiveOutputWriter
-	// never returns that pair today, but the backgroundProbe seam permits it.
-	hold := false
-	if !outConclusive && !live {
-		hold = d.noteInconclusiveProbe(sid, len(outputs))
-	} else {
-		d.clearInconclusiveProbes(sid)
-	}
+	// A held pass must purge nothing: the purge is durable (issue #1299), so
+	// presenting the outputs as still-live is what suppresses it. PIDs are
+	// unaffected — that probe has no inconclusive state to hold on.
+	toPurge := probed
+	toPurge.LiveOut = toPurge.LiveOut || hold
+	d.purgeDeadBackgroundProcesses(toPurge)
 
-	d.purgeDeadBackgroundProcesses(backgroundProbeResult{
+	if d.commitBackgroundVerdict(sid, probed.alive(), hold) {
+		d.nudgeReclassify(sid, transcriptPath)
+	}
+}
+
+// probeBackgroundLiveness runs both liveness probes for one pass. Each kind is
+// skipped when the session carries none of it (or its seam is unwired), and a
+// skipped output probe is a conclusive "nothing here to keep the session
+// alive", not an unknown — only a probe that actually ran can be inconclusive.
+func (d *SessionDetector) probeBackgroundLiveness(transcriptPath string, outputs, pids []string) backgroundProbeResult {
+	r := backgroundProbeResult{
 		TranscriptPath: transcriptPath,
 		Outputs:        outputs,
 		PIDs:           pids,
-		LiveOut:        liveOut || hold,
-		LivePID:        livePID,
-	})
-
-	// On a changed (or first) verdict, nudge the event loop to re-classify
-	// now rather than waiting for the next refresh tick. The send mirrors
-	// the debounce-timer path (single event-loop goroutine owns
-	// processActivity); drop if the buffer is full — the 5s refresh is the
-	// backstop.
-	if !d.commitBackgroundVerdict(sid, live, hold) {
-		return
+		Conclusive:     true,
 	}
+	if len(outputs) > 0 && d.bgLiveProbe != nil {
+		r.LiveOut, r.Conclusive = d.bgLiveProbe(outputs)
+	}
+	if len(pids) > 0 && d.bgPIDProbe != nil {
+		r.LivePID = d.bgPIDProbe(pids)
+	}
+	return r
+}
+
+// holdOnInconclusiveProbe reports whether this pass's verdict must be withheld
+// because the output probe never found out.
+//
+// An inconclusive output probe is not evidence of death, and the purge it would
+// otherwise trigger is durable (issue #1299) — so the caller skips it and keeps
+// whatever the last real verdict was. The guard tests the pass's overall
+// liveness, not just the PID half, so a probe that reports (alive,
+// inconclusive) is believed rather than discarded in favour of a stale cache;
+// anyLiveOutputWriter never returns that pair today, but the backgroundProbe
+// seam permits it.
+func (d *SessionDetector) holdOnInconclusiveProbe(sid string, probed backgroundProbeResult) bool {
+	if probed.Conclusive || probed.alive() {
+		d.clearInconclusiveProbes(sid)
+		return false
+	}
+	return d.noteInconclusiveProbe(sid, len(probed.Outputs))
+}
+
+// nudgeReclassify asks the event loop to re-classify sid now rather than
+// waiting for the next refresh tick — used on a changed (or first) verdict. The
+// send mirrors the debounce-timer path (a single event-loop goroutine owns
+// processActivity); it drops if the buffer is full, because the 5s refresh is
+// the backstop.
+func (d *SessionDetector) nudgeReclassify(sid, transcriptPath string) {
 	select {
 	case d.debouncedEvents <- agent.Event{Type: agent.EventActivity, SessionID: sid, TranscriptPath: transcriptPath}:
 	default:
@@ -1258,13 +1281,22 @@ func (d *SessionDetector) runBackgroundLivenessProbe(sid, transcriptPath string,
 // outputs/PIDs and their liveness verdicts — keeping
 // purgeDeadBackgroundProcesses's parameter list small (go:S107) instead of
 // threading each field through individually.
+//
+// Conclusive is the output probe's "did I find out?" bit (see backgroundProbe),
+// not a second liveness bit: false means the probe timed out, which must never
+// be read as death.
 type backgroundProbeResult struct {
 	TranscriptPath string
 	Outputs        []string
 	PIDs           []string
 	LiveOut        bool
 	LivePID        bool
+	Conclusive     bool
 }
+
+// alive reports whether EITHER kind of background process is still running — a
+// session is held `working` while any one of them is (issue #661).
+func (r backgroundProbeResult) alive() bool { return r.LiveOut || r.LivePID }
 
 // purgeDeadBackgroundProcesses drops probed-dead outputs/PIDs from the
 // tailer's open set and the metrics ledger. A dead process died without a

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1141,20 +1141,40 @@ func (d *SessionDetector) beginBackgroundProbe(sid string) (alive, startProbe bo
 // verdict changed (issues #649, #661). Must not alias state: outputs/pids
 // are copies taken by the caller before this runs on its own goroutine.
 func (d *SessionDetector) runBackgroundLivenessProbe(sid, transcriptPath string, outputs, pids []string) {
-	liveOut := len(outputs) > 0 && d.bgLiveProbe != nil && d.bgLiveProbe(outputs)
+	liveOut, outConclusive := false, true
+	if len(outputs) > 0 && d.bgLiveProbe != nil {
+		liveOut, outConclusive = d.bgLiveProbe(outputs)
+	}
 	livePID := len(pids) > 0 && d.bgPIDProbe != nil && d.bgPIDProbe(pids)
 	live := liveOut || livePID
 
+	if !outConclusive && d.log != nil {
+		d.log.LogError(logComponentSessionDetector, sid, fmt.Sprintf(
+			"background liveness probe was inconclusive for %d output path(s); holding the previous verdict rather than purging", len(outputs)))
+	}
+
+	// An inconclusive output probe is not evidence of death, and the purge it
+	// would otherwise trigger is durable (issue #1299) — so skip it and keep
+	// whatever the last real verdict was. A live PID still counts: it is
+	// positive proof from the other probe, independent of lsof.
 	d.purgeDeadBackgroundProcesses(backgroundProbeResult{
 		TranscriptPath: transcriptPath,
 		Outputs:        outputs,
 		PIDs:           pids,
-		LiveOut:        liveOut,
+		LiveOut:        liveOut || !outConclusive,
 		LivePID:        livePID,
 	})
 
 	d.bgMu.Lock()
 	prev, had := d.bgLive[sid]
+	if !outConclusive && !livePID {
+		// Optimistically alive on first sight, matching beginBackgroundProbe's
+		// never-declare-an-unprobed-process-dead rule (#445).
+		live = true
+		if had {
+			live = prev
+		}
+	}
 	d.bgLive[sid] = live
 	d.bgProbing[sid] = false
 	d.bgMu.Unlock()

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
-	"testing"
 	"time"
 
 	"irrlicht/core/application/services"
@@ -741,90 +739,4 @@ func newDetectorWithBroadcaster(
 		LiveCWDs:     nil,
 	})
 	return det, b
-}
-
-// bgOutputFixture is the setup every background-output liveness test shares: a
-// `working` session whose turn has ended and whose only open background process
-// is an output file, wired to a detector with an injectable probe.
-type bgOutputFixture struct {
-	det     *services.SessionDetector
-	tw      *mockAgentWatcher
-	metrics *funcMetrics
-	rec     *mockRecorder
-	probes  atomic.Int32
-	sid     string
-	path    string
-}
-
-// newBGOutputFixture builds the fixture with probe as the injected liveness
-// verdict; every call is counted so a test can require positive evidence the
-// probe actually ran rather than passing on the mere absence of an effect.
-func newBGOutputFixture(sid, path, outPath string, probe func() (alive, conclusive bool)) *bgOutputFixture {
-	return newBGOutputFixtureInState(sid, path, outPath, session.StateWorking, probe)
-}
-
-// newBGOutputFixtureInState is newBGOutputFixture with the session's starting
-// state chosen explicitly — the ready-start case covers a background process
-// spawned right after the session had already settled (#937).
-func newBGOutputFixtureInState(sid, path, outPath, state string, probe func() (alive, conclusive bool)) *bgOutputFixture {
-	f := &bgOutputFixture{sid: sid, path: path}
-	f.metrics = &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
-		return &session.SessionMetrics{
-			LastEventType:            "turn_done",
-			BackgroundProcessCount:   1,
-			BackgroundProcessOutputs: []string{outPath},
-		}, nil
-	}}
-	f.tw = newMockAgentWatcher()
-	repo := newMockRepo()
-	repo.states[sid] = &session.SessionState{
-		SessionID:      sid,
-		State:          state,
-		TranscriptPath: path,
-		FirstSeen:      time.Now().Unix(),
-		UpdatedAt:      time.Now().Unix(),
-	}
-	f.det = newDetectorWithMetrics(f.tw, newMockProcessWatcher(), repo, f.metrics)
-	f.rec = &mockRecorder{}
-	f.det.SetRecorder(f.rec)
-	f.det.SetBackgroundProbeForTest(func([]string) (bool, bool) {
-		f.probes.Add(1)
-		return probe()
-	})
-	return f
-}
-
-// start runs the detector and stops it when the test ends.
-func (f *bgOutputFixture) start(t *testing.T) {
-	t.Helper()
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- f.det.Run(ctx) }()
-	t.Cleanup(func() { cancel(); <-done })
-}
-
-// activity drives one re-evaluation. terminal short-circuits the 2s debounce,
-// the way production's periodic re-probe does.
-func (f *bgOutputFixture) activity(terminal bool) {
-	f.tw.ch <- agent.Event{
-		Type:           agent.EventActivity,
-		SessionID:      f.sid,
-		ProjectDir:     "-Users-test",
-		TranscriptPath: f.path,
-		Terminal:       terminal,
-	}
-}
-
-// awaitProbe blocks until the injected probe has run at least once, failing if
-// it never does — without it a test asserting only that nothing happened would
-// pass just as happily when the probe was never launched.
-func (f *bgOutputFixture) awaitProbe(t *testing.T) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for f.probes.Load() == 0 {
-		if !time.Now().Before(deadline) {
-			t.Fatal("background liveness probe was never invoked; the test would prove nothing")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
 }

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
+	"testing"
 	"time"
 
 	"irrlicht/core/application/services"
@@ -739,4 +741,90 @@ func newDetectorWithBroadcaster(
 		LiveCWDs:     nil,
 	})
 	return det, b
+}
+
+// bgOutputFixture is the setup every background-output liveness test shares: a
+// `working` session whose turn has ended and whose only open background process
+// is an output file, wired to a detector with an injectable probe.
+type bgOutputFixture struct {
+	det     *services.SessionDetector
+	tw      *mockAgentWatcher
+	metrics *funcMetrics
+	rec     *mockRecorder
+	probes  atomic.Int32
+	sid     string
+	path    string
+}
+
+// newBGOutputFixture builds the fixture with probe as the injected liveness
+// verdict; every call is counted so a test can require positive evidence the
+// probe actually ran rather than passing on the mere absence of an effect.
+func newBGOutputFixture(sid, path, outPath string, probe func() (alive, conclusive bool)) *bgOutputFixture {
+	return newBGOutputFixtureInState(sid, path, outPath, session.StateWorking, probe)
+}
+
+// newBGOutputFixtureInState is newBGOutputFixture with the session's starting
+// state chosen explicitly — the ready-start case covers a background process
+// spawned right after the session had already settled (#937).
+func newBGOutputFixtureInState(sid, path, outPath, state string, probe func() (alive, conclusive bool)) *bgOutputFixture {
+	f := &bgOutputFixture{sid: sid, path: path}
+	f.metrics = &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+		return &session.SessionMetrics{
+			LastEventType:            "turn_done",
+			BackgroundProcessCount:   1,
+			BackgroundProcessOutputs: []string{outPath},
+		}, nil
+	}}
+	f.tw = newMockAgentWatcher()
+	repo := newMockRepo()
+	repo.states[sid] = &session.SessionState{
+		SessionID:      sid,
+		State:          state,
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+	}
+	f.det = newDetectorWithMetrics(f.tw, newMockProcessWatcher(), repo, f.metrics)
+	f.rec = &mockRecorder{}
+	f.det.SetRecorder(f.rec)
+	f.det.SetBackgroundProbeForTest(func([]string) (bool, bool) {
+		f.probes.Add(1)
+		return probe()
+	})
+	return f
+}
+
+// start runs the detector and stops it when the test ends.
+func (f *bgOutputFixture) start(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- f.det.Run(ctx) }()
+	t.Cleanup(func() { cancel(); <-done })
+}
+
+// activity drives one re-evaluation. terminal short-circuits the 2s debounce,
+// the way production's periodic re-probe does.
+func (f *bgOutputFixture) activity(terminal bool) {
+	f.tw.ch <- agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      f.sid,
+		ProjectDir:     "-Users-test",
+		TranscriptPath: f.path,
+		Terminal:       terminal,
+	}
+}
+
+// awaitProbe blocks until the injected probe has run at least once, failing if
+// it never does — without it a test asserting only that nothing happened would
+// pass just as happily when the probe was never launched.
+func (f *bgOutputFixture) awaitProbe(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for f.probes.Load() == 0 {
+		if !time.Now().Before(deadline) {
+			t.Fatal("background liveness probe was never invoked; the test would prove nothing")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
Closes #1299.

## What the flaky test was actually reporting

`TestAnyLiveOutputWriter_RealProcess` failed on two separate full-suite runs, at **4.25s** — and that duration was the clue. `anyLiveOutputWriter` runs `lsof` under its own 2s timeout, and the test's polling budget was *also* 2s, so one slow `lsof` consumed the entire window and the loop got exactly one attempt. 2s + 2s ≈ the observed failure time; a healthy run is milliseconds.

But chasing the flake surfaced the real problem underneath it.

## The bug

`Output()`'s error is discarded — correctly, for the #445 reason that `lsof` exits 1 when *any* named path has no holder while still printing the other paths' PIDs. The side effect is that **three outcomes collapse into one**: no holder, timed out, and lsof-not-found all return `false`.

The old doc comment called this "the safe (don't pin forever) degradation". It isn't safe, because of what the caller does with a dead verdict:

```
runBackgroundLivenessProbe → purgeDeadBackgroundProcesses
  → metrics.PurgeDeadBackgroundProcs → tailer.PurgeBackgroundProcs + saveLedger
```

That purge is **written through to the persisted ledger**. So one slow `lsof` permanently drops a still-running background process and flips a live session to `ready` with no way back — the exact false-negative the exit-code handling at `background_probe.go:38-48` was written to prevent, reached by a different route.

The correlation runs the wrong way, too: `lsof` walks every process on the machine, so it is slowest precisely when the machine is busiest — which is when long-running background work is most likely to be in flight.

## The fix

`backgroundProbe` becomes `func([]string) (alive, conclusive bool)`.

- A **timeout** is inconclusive. The detector then skips the purge *and* holds the previous liveness verdict instead of writing "dead", so the next probe decides.
- **Any other** exec failure still degrades to a conclusive dead. Retrying can't fix a missing `lsof` (`MustResolve` falls back to the bare name, so this is reachable), and treating it as inconclusive would pin every affected session `working` forever — the failure the old degradation was guarding against. Only the transient case gets the retry.
- The `DeadlineExceeded` check runs **after** stdout has yielded no PID: `lsof` can be killed by the deadline having already printed a holder, and that PID is still proof of life worth keeping.
- The inconclusive path logs through `d.log`, so production leaves a trace where it had none.

Both halves matter and are tested separately — skipping the purge alone would still flip the session to `ready` via the cached verdict.

## Seen red

| Mutation | Result |
|---|---|
| timeout collapses back into conclusive-dead | `TimeoutIsInconclusive` — *a timed-out probe reported a conclusive verdict; the caller would purge on it* |
| inconclusive verdict still purges | `InconclusiveVerdictDoesNotPurge` — *an inconclusive probe purged [...] — a timeout is not evidence of death* |
| retained-verdict hold removed | `InconclusiveVerdictHoldsWorking` — *session flipped to ready 3 time(s) on an inconclusive probe* |

The third mutation initially produced **no failure** — I had written the hold without covering it, so the session would still have flipped to `ready` on a timeout. `InconclusiveVerdictHoldsWorking` was added to close that gap, and the mutation is red against it now.

## The test fix, and a mistake worth flagging

My first rework asserted that the post-kill probe was conclusive — and that assertion promptly flaked 2-in-25 under `-race`, because under load `lsof` legitimately times out and the probe correctly says "I don't know". Same mistake class as the original test: asserting something load can invalidate.

`awaitConclusiveVerdict` now treats an inconclusive verdict as a **retry, not a result**, which is both the behavior under test and what keeps the test honest. If every probe in the budget times out it **skips** rather than fails — the probe did its job; the machine was simply too loaded to observe the transition, which is not a defect in the code under test.

## Verification

- `go test ./core/... -race -count=1` — **4 green runs** across the change (49 packages, 0 failures).
- `TestAnyLiveOutputWriter*` — **40 runs `-race`** green, plus **15 runs `-race` under full CPU saturation** (all 10 cores hogged) green. The original failed twice in ordinary full-suite runs.

## Not done here

The `backgroundPIDProbe` (`anyLivePID`) has no timeout and no exec, so it has no inconclusive state to model — left alone deliberately rather than changed for symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)