### PR TITLE
docs(site): add a Tips & Tricks page to the docs site

### DIFF
--- a/site/docs/adapters.html
+++ b/site/docs/adapters.html
@@ -59,6 +59,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/api-reference.html
+++ b/site/docs/api-reference.html
@@ -59,6 +59,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html" class="active">API Reference</a>
     </div>

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -58,6 +58,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/changelog.html
+++ b/site/docs/changelog.html
@@ -59,6 +59,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/cli-tools.html
+++ b/site/docs/cli-tools.html
@@ -57,6 +57,8 @@
     <div class="sidebar-section">
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
+      <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html" class="active">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>
@@ -296,9 +298,9 @@ go build ./cmd/irrlichtrelay/   # standalone relay server</code></pre>
 
       <!-- ── Bottom nav ── -->
       <div class="docs-nav-bottom">
-        <a href="macos-setup.html">
+        <a href="tips-and-tricks.html">
           <span class="label">Previous</span>
-          macOS Setup
+          Tips &amp; Tricks
         </a>
         <a href="api-reference.html">
           <span class="label">Next</span>

--- a/site/docs/cli-tools.html
+++ b/site/docs/cli-tools.html
@@ -191,7 +191,7 @@ ready    api-server   e5f6g7h8 gpt-5 3% 400k codex  (1m ago)</code></pre>
 
       <h3>Installation</h3>
 
-      <p><code>irrlicht-ls</code> ships inside <code>Irrlicht.app</code> and lands on your PATH automatically: the PKG installer and the <code>curl … | sh</code> installer symlink it to <code>/usr/local/bin/irrlicht-ls</code>. If you installed by dragging the DMG, open the menu bar panel → Settings → <em>Install Command-Line Tool</em>. Building from source (from the repo root): <code>cd core &amp;&amp; go build ./cmd/irrlicht-ls/</code>.</p>
+      <p><code>irrlicht-ls</code> ships inside <code>Irrlicht.app</code> and lands on your PATH automatically: the PKG installer and the <code>curl … | sh</code> installer symlink it to <code>/usr/local/bin/irrlicht-ls</code>. If you installed by dragging the DMG, open the menu bar panel → Settings… → Advanced Settings → Command-Line Tool → <em>Install Command-Line Tool</em>. Building from source (from the repo root): <code>cd core &amp;&amp; go build ./cmd/irrlicht-ls/</code>.</p>
 
       <!-- ── irrlicht-focus ── -->
       <h2>irrlicht-focus</h2>

--- a/site/docs/co2-methodology.html
+++ b/site/docs/co2-methodology.html
@@ -59,6 +59,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/code-of-conduct.html
+++ b/site/docs/code-of-conduct.html
@@ -59,6 +59,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -59,6 +59,7 @@
       <h4>Usage</h4>
       <a href="configuration.html" class="active">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -407,7 +407,7 @@ launchctl setenv IRRLICHT_DEBUG 1
       <!-- ── App Settings ── -->
       <h2>App Settings</h2>
 
-      <p>The macOS app has a Settings panel accessible via the gear icon:</p>
+      <p>The macOS app has a Settings panel, opened from the <strong>Settings…</strong> button along the bottom of the popover:</p>
 
       <h3>Notifications</h3>
 

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -59,6 +59,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -156,6 +156,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>
@@ -271,6 +272,14 @@
           </div>
           <h3>macOS Setup</h3>
           <p>Keep the status dot visible in full screen, enable login autostart, and grant the permissions Irrlicht needs.</p>
+        </a>
+
+        <a href="tips-and-tricks.html" class="doc-card">
+          <div class="doc-card-icon green">
+            <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M10 2a5 5 0 00-3 9v2h6v-2a5 5 0 00-3-9z"/><path d="M8 16h4"/></svg>
+          </div>
+          <h3>Tips &amp; Tricks</h3>
+          <p>Easy-to-miss settings that pay off: menu bar icon styles, quota forecasts, spoken alerts, click-to-jump, usage exports, and backchannel rules.</p>
         </a>
 
         <a href="cli-tools.html" class="doc-card">

--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -58,6 +58,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/light-system.html
+++ b/site/docs/light-system.html
@@ -58,6 +58,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/macos-setup.html
+++ b/site/docs/macos-setup.html
@@ -59,6 +59,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html" class="active">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>
@@ -98,7 +99,7 @@
       <p>The wizard appears on whichever surface you're looking at &mdash; the macOS popover or the web dashboard &mdash; and the first answer wins. You can revisit every decision later under <strong>Settings &rarr; Permissions &rarr; Review</strong>; toggling a permission off actively undoes it (hooks uninstall, watchers stop). While permissions are unanswered, monitoring for that agent is paused &mdash; if Irrlicht looks idle right after an upgrade, answer the wizard.</p>
 
       <!-- ── Status line in full screen ── -->
-      <h2>Status Line in Full Screen</h2>
+      <h2 id="status-line-full-screen">Status Line in Full Screen</h2>
 
       <p>By default, macOS hides the menu bar whenever an app goes full screen. That means the Irrlicht flame &mdash; your live indicator of every agent's state &mdash; disappears exactly when you're heads-down in a terminal or editor.</p>
 
@@ -183,9 +184,9 @@ listen_on unix:/tmp/kitty-{kitty_pid}</code></pre>
           <span class="label">Previous</span>
           Configuration
         </a>
-        <a href="cli-tools.html" style="text-align:right">
+        <a href="tips-and-tricks.html" style="text-align:right">
           <span class="label">Next</span>
-          CLI Tools &rarr;
+          Tips &amp; Tricks &rarr;
         </a>
       </nav>
 

--- a/site/docs/macos-setup.html
+++ b/site/docs/macos-setup.html
@@ -125,14 +125,14 @@
 
       <ol class="steps">
         <li>Click the flame icon in the menu bar to open the session list.</li>
-        <li>Click the gear icon to open <strong>Settings</strong>.</li>
+        <li>Click <strong>Settings…</strong> in the row of buttons along the bottom.</li>
         <li>Check <strong>Open at Login</strong> &mdash; it is on by default, and Irrlicht will start automatically at each login. Toggle it off if you would rather launch the app yourself.</li>
       </ol>
 
       <p>Irrlicht registers itself via <code>SMAppService</code> so macOS manages the lifecycle &mdash; it starts early in the login sequence, before most apps open.</p>
 
       <!-- ── Notification permissions ── -->
-      <h2>Notification Permissions</h2>
+      <h2 id="notification-permissions">Notification Permissions</h2>
 
       <p>Irrlicht can alert you when an agent transitions to <span class="badge badge-waiting">waiting</span> (needs input) or <span class="badge badge-ready">ready</span> (done). On first launch the system asks for permission.</p>
 
@@ -147,7 +147,7 @@
       <p>Notification thresholds (which transitions trigger an alert) are configurable inside Irrlicht's own Settings panel.</p>
 
       <!-- ── Accessibility permission ── -->
-      <h2>Accessibility Permission (Window Focus)</h2>
+      <h2 id="accessibility-permission">Accessibility Permission (Window Focus)</h2>
 
       <p>Clicking a session row in the popover raises the terminal window that owns that session. This uses the macOS Accessibility API, which requires a one-time grant:</p>
 

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -59,6 +59,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/roadmap.html
+++ b/site/docs/roadmap.html
@@ -382,6 +382,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/session-detection.html
+++ b/site/docs/session-detection.html
@@ -59,6 +59,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/state-machine.html
+++ b/site/docs/state-machine.html
@@ -58,6 +58,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/story.html
+++ b/site/docs/story.html
@@ -58,6 +58,7 @@
       <h4>Usage</h4>
       <a href="configuration.html">Configuration</a>
       <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html">Tips &amp; Tricks</a>
       <a href="cli-tools.html">CLI Tools</a>
       <a href="api-reference.html">API Reference</a>
     </div>

--- a/site/docs/tips-and-tricks.html
+++ b/site/docs/tips-and-tricks.html
@@ -120,7 +120,7 @@
       <figure style="margin: 0.5rem 0 1rem; max-width: 420px;">
         <picture>
           <source srcset="../assets/releases/v0.5.6/quota-menu-bar-icon.webp" type="image/webp">
-          <img src="../assets/releases/v0.5.6/quota-menu-bar-icon.png" alt="Irrlicht Settings panel showing the Show Estimated Cost and Show Quota Forecast toggles, per-provider quota modes, and the Menu Bar Icon segmented control set to Combined with Quota shape set to Circle." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
+          <img loading="lazy" src="../assets/releases/v0.5.6/quota-menu-bar-icon.png" alt="Irrlicht Settings panel showing the Show Estimated Cost and Show Quota Forecast toggles, per-provider quota modes, and the Menu Bar Icon segmented control set to Combined with Quota shape set to Circle." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
         </picture>
       </figure>
 
@@ -161,7 +161,7 @@
       <figure style="margin: 0.5rem 0 1rem;">
         <picture>
           <source srcset="../assets/releases/v0.5.2/configurable-alerts.webp" type="image/webp">
-          <img src="../assets/releases/v0.5.2/configurable-alerts.png" alt="The Context pressure alert row in Irrlicht Settings: the event toggle switched on, the sound set to Speak aloud (Zoe, Premium) with a preview button, and an Alert at threshold of 80 percent." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
+          <img loading="lazy" src="../assets/releases/v0.5.2/configurable-alerts.png" alt="The Context pressure alert row in Irrlicht Settings: the event toggle switched on, the sound set to Speak aloud (Zoe, Premium) with a preview button, and an Alert at threshold of 80 percent." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
         </picture>
       </figure>
 
@@ -189,7 +189,7 @@
       <figure style="margin: 0.5rem 0 1rem; max-width: 420px;">
         <picture>
           <source srcset="../assets/releases/v0.5.4/history-analytics.webp" type="image/webp">
-          <img src="../assets/releases/v0.5.4/history-analytics.png" alt="The History panel's Usage tab: a stacked cumulative cost chart broken down by project with a dashed projection, a month-to-date total of $18.35 with a projected $20.64, a per-project legend, and Export CSV and Export JSON buttons." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
+          <img loading="lazy" src="../assets/releases/v0.5.4/history-analytics.png" alt="The History panel's Usage tab: a stacked cumulative cost chart broken down by project with a dashed projection, a month-to-date total of $18.35 with a projected $20.64, a per-project legend, and Export CSV and Export JSON buttons." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
         </picture>
       </figure>
 
@@ -212,7 +212,7 @@
       <figure style="margin: 0.5rem 0 1rem; max-width: 420px;">
         <picture>
           <source srcset="../assets/releases/v0.5.4/backchannel-rules.webp" type="image/webp">
-          <img src="../assets/releases/v0.5.4/backchannel-rules.png" alt="The Backchannel Rules editor with a rule named Auto-compact: when Context (%) is greater than or equal to 85, for any agent, send the response Compact." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
+          <img loading="lazy" src="../assets/releases/v0.5.4/backchannel-rules.png" alt="The Backchannel Rules editor with a rule named Auto-compact: when Context (%) is greater than or equal to 85, for any agent, send the response Compact." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
         </picture>
       </figure>
 

--- a/site/docs/tips-and-tricks.html
+++ b/site/docs/tips-and-tricks.html
@@ -92,9 +92,9 @@
 
       <p>Irrlicht works out of the box, so it is entirely possible to run it for months on defaults. These are the things people tend to discover by accident. Each tip says where the control lives; where a full walkthrough already exists elsewhere in these docs, the tip links to it rather than repeating it.</p>
 
-      <div class="callout">
+      <div class="callout callout-info">
         <strong>Where "Settings" is</strong>
-        Click the flame in the menu bar to open the session list, then the gear icon. Everything below labelled <em>Settings &rarr; …</em> lives in that panel. The web dashboard at <code>http://127.0.0.1:7837</code> has its own settings panel with a subset of the same controls &mdash; each tip notes which surfaces it applies to.
+        Click the flame in the menu bar to open the session list, then the <em>Settings…</em> button in the row along the bottom. Everything below labelled <em>Settings &rarr; …</em> lives in that panel. The web dashboard at <code>http://127.0.0.1:7837</code> has its own settings panel &mdash; the ⚙ button in its header &mdash; with a subset of the same controls, so each tip notes which surfaces it applies to.
       </div>
 
       <!-- ── Menu bar visibility ── -->
@@ -127,13 +127,13 @@
       <!-- ── Quota forecast ── -->
       <h2>Watch Your Subscription Burn Rate</h2>
 
-      <p><strong>macOS and web.</strong> Turn on <strong>Settings &rarr; Show Quota Forecast</strong> and the app version in the popover header is replaced by a live burn-rate forecast against your Pro/Max or ChatGPT subscription cap. It only appears while a subscription session is actually running. Turning it on also reveals a <strong>Provider</strong> group where you set the mode per provider (Anthropic, OpenAI) &mdash; useful if only one of your accounts is a subscription.</p>
+      <p><strong>macOS and web.</strong> <strong>Settings &rarr; Show Quota Forecast</strong> puts a live burn-rate forecast against your plan's cap in the popover header, in place of the app name (on the web dashboard, in place of the version chip). It is <em>on by default</em> on both surfaces, and the chips appear as soon as a session reports quota data &mdash; so if your header only ever shows the app name, no monitored session is reporting any.</p>
 
-      <p>On the web dashboard the same toggle is called <strong>"Show quota forecast in header"</strong>, under <strong>Provider quota</strong>.</p>
+      <p>What is worth changing is the <strong>Provider</strong> group underneath it, where you set the mode per provider (Anthropic, OpenAI): pin the one that is a subscription rather than leaving both on Auto, and the forecast stops guessing. On the web dashboard the toggle is called <strong>"Show quota forecast in header"</strong>, under <strong>Provider quota</strong>.</p>
 
       <div class="callout callout-tip">
         <strong>Also worth knowing</strong>
-        The <em>Quota</em> tab in the History window shows the same per-provider rate-limit forecast in full, and is always available &mdash; it is <em>not</em> gated by this toggle. The toggle only controls the compact header readout.
+        On macOS the History panel has a <em>Quota</em> tab showing the same per-provider rate-limit forecast in full, and it is always available &mdash; it is <em>not</em> gated by this toggle, which only controls the compact header readout. The web dashboard has no equivalent view.
       </div>
 
       <!-- ── Cost display ── -->
@@ -141,7 +141,7 @@
 
       <p><strong>macOS and web.</strong> <strong>Settings &rarr; Show Estimated Cost</strong> puts a running USD estimate on each session and each project group. Estimates are approximate &mdash; they are derived from reported token counts and published prices, not from your provider invoice.</p>
 
-      <p>On the web dashboard the toggle is called <strong>"Show cost"</strong>, and it has an extra trick: <strong>click the cost figure in a row</strong> to switch that display to an estimated CO<sub>2</sub> footprint instead. Clicking a group header's cost cycles the time frame it is summed over. See <a href="co2-methodology.html">CO2 Methodology</a> for how the footprint is derived.</p>
+      <p>On the web dashboard the toggle is called <strong>"Show cost"</strong>, and the figures themselves are buttons: <strong>click any row's cost</strong> and every row switches to an estimated CO<sub>2</sub> footprint instead; <strong>click any group header's cost</strong> and every group cycles the time frame it is summed over (day &rarr; week &rarr; month &rarr; year). Both are global and both are remembered across reloads. See <a href="co2-methodology.html">CO2 Methodology</a> for how the footprint is derived.</p>
 
       <!-- ── Notifications ── -->
       <h2>Let Irrlicht Tell You, So You Can Look Away</h2>
@@ -154,7 +154,7 @@
         <li><strong>Context pressure alert</strong> &mdash; the session is approaching its context limit.</li>
       </ul>
 
-      <p>Each event gets its own sound: one of the built-ins (Ping, Chime, Funk, Whoosh, Sosumi), <strong>None</strong>, a <strong>Custom audio file…</strong>, or &mdash; the part people miss &mdash; <strong>Speak aloud</strong>, which reads the message out with the system voice (a premium voice can be picked instead of the default). Spoken alerts mean you can leave the screen entirely and still know which agent needs you. There is a ▶ preview button next to each picker so you can audition a sound without waiting for the event.</p>
+      <p>Each event gets its own sound from a single picker: one of the built-ins (Ping, Chime, Funk, Whoosh, Sosumi), <strong>None</strong>, a <strong>Custom audio file…</strong>, or &mdash; the part people miss &mdash; one of the three spoken options, <strong>Speak aloud (Default)</strong>, <strong>Speak aloud (Zoe, Premium)</strong> and <strong>Speak aloud (Jamie, Premium)</strong>, which read the message out instead of chiming. Spoken alerts mean you can leave the screen entirely and still know which agent needs you. There is a ▶ preview button next to each picker so you can audition a sound without waiting for the event.</p>
 
       <p><strong>Context pressure alert</strong> adds an <strong>Alert at</strong> threshold you set in either <strong>%</strong> or raw <strong>tokens</strong> &mdash; so you can be warned at 80% and still have room to wrap up or compact deliberately, instead of being surprised.</p>
 
@@ -165,31 +165,31 @@
         </picture>
       </figure>
 
-      <p>The web dashboard has the three notification toggles too, but no per-event sounds and no spoken alerts &mdash; those are macOS-only. If macOS never asks for notification permission, or you denied it once, see <a href="macos-setup.html">macOS Setup &rarr; Notification Permissions</a>.</p>
+      <p>The web dashboard has the three notification toggles too, but no per-event sounds and no spoken alerts &mdash; those are macOS-only. If macOS never asks for notification permission, or you denied it once, see <a href="macos-setup.html#notification-permissions">macOS Setup &rarr; Notification Permissions</a>.</p>
 
       <!-- ── Click to jump ── -->
       <h2>Click a Session to Jump Straight to It</h2>
 
       <p><strong>macOS.</strong> Session rows in the popover are not just readouts &mdash; clicking one brings the terminal or editor window that owns that session to the front. With several agents running across several windows, this replaces the entire "which window was that in" hunt.</p>
 
-      <p>It needs the macOS <strong>Accessibility</strong> permission granted once (<a href="macos-setup.html">macOS Setup &rarr; Accessibility Permission</a>); without it, focusing works for some terminals and silently fails for others. If you use Kitty, two lines in <code>kitty.conf</code> let Irrlicht land on the exact <em>tab</em> rather than just the window &mdash; see <a href="macos-setup.html#kitty">Kitty Terminal &mdash; Precise Tab Focus</a>.</p>
+      <p>It needs the macOS <strong>Accessibility</strong> permission granted once (<a href="macos-setup.html#accessibility-permission">macOS Setup &rarr; Accessibility Permission (Window Focus)</a>); without it, focusing works for some terminals and silently fails for others. If you use Kitty, two lines in <code>kitty.conf</code> let Irrlicht land on the exact <em>tab</em> rather than just the window &mdash; see <a href="macos-setup.html#kitty">Kitty Terminal &mdash; Precise Tab Focus</a>.</p>
 
-      <div class="callout">
+      <div class="callout callout-info">
         <strong>macOS only</strong>
-        Click-to-jump has no web equivalent &mdash; a browser tab cannot raise another application's window. The web dashboard's row clicks toggle cost display and group collapse instead.
+        Click-to-jump has no web equivalent &mdash; a browser tab cannot raise another application's window. On the web dashboard, clicking a row does nothing; it is the cost figures and group headers that are clickable.
       </div>
 
       <!-- ── History ── -->
       <h2>Dig Into Usage History &mdash; and Export It</h2>
 
-      <p><strong>macOS and web.</strong> The History window's <strong>Usage</strong> tab is a full analytics surface, not just a chart. Three pickers drive it: <strong>Range</strong> (the time window), <strong>Chart</strong> (cost, tokens, CO<sub>2</sub>, and more), and <strong>Group</strong> &mdash; project, branch, provider, model, session, or token type.</p>
+      <p><strong>macOS and web.</strong> On macOS, the History panel's <strong>Usage</strong> tab is a full analytics surface, not just a chart. Three compact pickers along the top drive it: a time range, the metric to chart (cost, tokens, CO<sub>2</sub>, and more), and what to group by &mdash; project, branch, provider, model, session, or token type. They carry no labels on macOS and the group names are abbreviated (<code>Proj</code>, <code>Branch</code>, <code>Prov</code>, <code>Model</code>, <code>Sess</code>, <code>Type</code>), which is why they are easy to overlook; the web dashboard spells the same three out as <strong>Range</strong>, <strong>Chart</strong> and <strong>Group</strong>.</p>
 
       <p>Click a segment to drill into it: project &rarr; branch &rarr; session answers "what did this feature actually cost me", and provider &rarr; model &rarr; session answers "which model is eating the budget". <strong>Export CSV</strong> and <strong>Export JSON</strong> buttons sit under the chart, so any view you can build you can also hand to a spreadsheet or a script.</p>
 
       <figure style="margin: 0.5rem 0 1rem; max-width: 420px;">
         <picture>
           <source srcset="../assets/releases/v0.5.4/history-analytics.webp" type="image/webp">
-          <img src="../assets/releases/v0.5.4/history-analytics.png" alt="The History window's Usage tab: a stacked cumulative cost chart broken down by project with a dashed projection, a month-to-date total of $18.35 with a projected $20.64, a per-project legend, and Export CSV and Export JSON buttons." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
+          <img src="../assets/releases/v0.5.4/history-analytics.png" alt="The History panel's Usage tab: a stacked cumulative cost chart broken down by project with a dashed projection, a month-to-date total of $18.35 with a projected $20.64, a per-project legend, and Export CSV and Export JSON buttons." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
         </picture>
       </figure>
 
@@ -224,9 +224,9 @@
       <!-- ── Scripting ── -->
       <h2>Script It</h2>
 
-      <p><strong>Any platform.</strong> Everything the UIs show comes from the daemon's HTTP API on <code>http://127.0.0.1:7837</code>, and it is yours to query. <code>irrlicht-ls</code> prints the same hierarchical session view from the shell (handy in a status line, a tmux bar, or a cron check), and <code>irrlicht-focus &lt;sessionID&gt;</code> raises a session's window from a script or a hotkey.</p>
+      <p>Everything the UIs show comes from the daemon's HTTP API on <code>http://127.0.0.1:7837</code>, and it is yours to query. <code>irrlicht-ls</code> prints the same hierarchical session view from the shell &mdash; handy in a status line, a tmux bar, or a cron check &mdash; and works anywhere the daemon does. <code>irrlicht-focus &lt;sessionID&gt;</code> raises a session's window from a script or a hotkey; it asks the daemon to broadcast the request, and the macOS app is what actually performs the raise, so it is a no-op without that app running.</p>
 
-      <p>If <code>irrlicht-ls</code> is not on your <code>PATH</code> &mdash; DMG installs do not symlink it &mdash; use <strong>Settings &rarr; Install Command-Line Tool</strong>. See <a href="cli-tools.html">CLI Tools</a> for every binary and <a href="api-reference.html">API Reference</a> for the endpoints behind them.</p>
+      <p>If <code>irrlicht-ls</code> is not on your <code>PATH</code> &mdash; DMG installs do not symlink it &mdash; use <strong>Settings &rarr; Advanced Settings &rarr; Command-Line Tool &rarr; Install Command-Line Tool</strong> (the button only appears while it is not installed). See <a href="cli-tools.html">CLI Tools</a> for every binary and <a href="api-reference.html">API Reference</a> for the endpoints behind them.</p>
 
       <!-- ── Bottom nav ── -->
       <nav class="docs-nav-bottom" aria-label="Previous and next page">

--- a/site/docs/tips-and-tricks.html
+++ b/site/docs/tips-and-tricks.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Tips &amp; Tricks — Irrlicht Docs</title>
+<meta name="description" content="Practical, easy-to-miss ways to get more out of Irrlicht — menu bar icon styles, quota forecasts, spoken alerts, click-to-jump, usage exports, and backchannel rules.">
+<link rel="canonical" href="https://irrlicht.io/docs/tips-and-tricks.html">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Tips &amp; Tricks — Irrlicht Docs">
+<meta property="og:description" content="Practical, easy-to-miss ways to get more out of Irrlicht — menu bar icon styles, quota forecasts, spoken alerts, click-to-jump, usage exports, and backchannel rules.">
+<meta property="og:url" content="https://irrlicht.io/docs/tips-and-tricks.html">
+<meta property="og:site_name" content="Irrlicht">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Tips &amp; Tricks — Irrlicht Docs">
+<meta name="twitter:description" content="Practical, easy-to-miss ways to get more out of Irrlicht — menu bar icon styles, quota forecasts, spoken alerts, click-to-jump, usage exports, and backchannel rules.">
+
+<link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="../assets/favicon-16x16.png">
+<link rel="apple-touch-icon" sizes="180x180" href="../assets/apple-touch-icon.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="preconnect" href="https://cdn.counter.dev">
+<link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=DM+Mono:wght@300;400;500&family=Outfit:wght@200;300;400;500;600&display=swap">
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=DM+Mono:wght@300;400;500&family=Outfit:wght@200;300;400;500;600&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+<noscript><link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,600;1,300;1,400&family=DM+Mono:wght@300;400;500&family=Outfit:wght@200;300;400;500;600&display=swap" rel="stylesheet"></noscript>
+<link rel="stylesheet" href="docs.css">
+</head>
+<body>
+
+<div class="docs-layout">
+
+  <!-- ─── Sidebar ─── -->
+  <nav class="sidebar" aria-label="Documentation sections">
+    <a href="../index.html" class="sidebar-logo">
+      <span class="dot"></span>
+      <span>Irrlicht</span>
+      <small>docs</small>
+    </a>
+
+    <div class="sidebar-section">
+      <h4>Getting Started</h4>
+      <a href="index.html">Overview</a>
+      <a href="installation.html">Installation</a>
+      <a href="quickstart.html">Quick Start</a>
+    </div>
+
+    <div class="sidebar-section">
+      <h4>Core Concepts</h4>
+      <a href="story.html">The Story</a>
+      <a href="light-system.html">The Light System</a>
+      <a href="state-machine.html">State Machine</a>
+      <a href="session-detection.html">Session Detection</a>
+      <a href="co2-methodology.html">CO2 Methodology</a>
+    </div>
+
+    <div class="sidebar-section">
+      <h4>Usage</h4>
+      <a href="configuration.html">Configuration</a>
+      <a href="macos-setup.html">macOS Setup</a>
+      <a href="tips-and-tricks.html" class="active">Tips &amp; Tricks</a>
+      <a href="cli-tools.html">CLI Tools</a>
+      <a href="api-reference.html">API Reference</a>
+    </div>
+
+    <div class="sidebar-section">
+      <h4>Architecture</h4>
+      <a href="architecture.html">System Design</a>
+      <a href="adapters.html">Adapters</a>
+    </div>
+
+    <div class="sidebar-section">
+      <h4>Project</h4>
+      <a href="roadmap.html">Roadmap</a>
+      <a href="changelog.html">Changelog</a>
+    </div>
+
+    <div class="sidebar-section">
+      <h4>Community</h4>
+      <a href="contributing.html">Contributing</a>
+      <a href="code-of-conduct.html">Code of Conduct</a>
+    </div>
+  </nav>
+
+  <!-- ─── Main ─── -->
+  <main class="docs-main">
+    <div class="docs-content">
+
+      <h1>Tips &amp; Tricks</h1>
+      <p class="page-subtitle">Small settings and habits that make Irrlicht noticeably more useful &mdash; most of them one toggle away, and most of them easy to never find.</p>
+
+      <p>Irrlicht works out of the box, so it is entirely possible to run it for months on defaults. These are the things people tend to discover by accident. Each tip says where the control lives; where a full walkthrough already exists elsewhere in these docs, the tip links to it rather than repeating it.</p>
+
+      <div class="callout">
+        <strong>Where "Settings" is</strong>
+        Click the flame in the menu bar to open the session list, then the gear icon. Everything below labelled <em>Settings &rarr; …</em> lives in that panel. The web dashboard at <code>http://127.0.0.1:7837</code> has its own settings panel with a subset of the same controls &mdash; each tip notes which surfaces it applies to.
+      </div>
+
+      <!-- ── Menu bar visibility ── -->
+      <h2>Keep the Flame Visible in Full Screen</h2>
+
+      <p><strong>macOS.</strong> By default macOS hides the menu bar whenever an app goes full screen &mdash; which is exactly when you are heads-down in a terminal and most want to know whether an agent is still working. Set <strong>System Settings &rarr; Control Center &rarr; "Automatically hide and show the menu bar"</strong> to <strong>Never</strong> and the flame stays visible on every Space.</p>
+
+      <p>Full instructions: <a href="macos-setup.html#status-line-full-screen">macOS Setup &rarr; Status Line in Full Screen</a>. Irrlicht's popover is already configured to open on any Space, so once the menu bar is visible the session list is one click away from wherever you are.</p>
+
+      <!-- ── Menu bar icon style ── -->
+      <h2>Choose What the Menu Bar Icon Shows</h2>
+
+      <p><strong>macOS.</strong> Under <strong>Settings &rarr; Menu Bar Icon</strong> there are three styles, and the right one depends on what you tend to run out of first:</p>
+
+      <ul>
+        <li><strong>Lights</strong> &mdash; session-state dots: how many agents are <span class="badge badge-working">working</span>, <span class="badge badge-waiting">waiting</span>, or <span class="badge badge-ready">ready</span>. The default.</li>
+        <li><strong>Usage</strong> &mdash; replaces the dots with reported subscription quota bars, so the menu bar answers "how much of my plan is left" instead.</li>
+        <li><strong>Combined</strong> &mdash; both, side by side.</li>
+      </ul>
+
+      <p>Picking anything other than Lights reveals two more controls: <strong>Quota provider</strong> (Auto, or pin it to one provider) and <strong>Quota shape</strong> (<strong>Bars</strong> or <strong>Circle</strong>). Circle is the more compact of the two if your menu bar is crowded.</p>
+
+      <figure style="margin: 0.5rem 0 1rem; max-width: 420px;">
+        <picture>
+          <source srcset="../assets/releases/v0.5.6/quota-menu-bar-icon.webp" type="image/webp">
+          <img src="../assets/releases/v0.5.6/quota-menu-bar-icon.png" alt="Irrlicht Settings panel showing the Show Estimated Cost and Show Quota Forecast toggles, per-provider quota modes, and the Menu Bar Icon segmented control set to Combined with Quota shape set to Circle." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
+        </picture>
+      </figure>
+
+      <!-- ── Quota forecast ── -->
+      <h2>Watch Your Subscription Burn Rate</h2>
+
+      <p><strong>macOS and web.</strong> Turn on <strong>Settings &rarr; Show Quota Forecast</strong> and the app version in the popover header is replaced by a live burn-rate forecast against your Pro/Max or ChatGPT subscription cap. It only appears while a subscription session is actually running. Turning it on also reveals a <strong>Provider</strong> group where you set the mode per provider (Anthropic, OpenAI) &mdash; useful if only one of your accounts is a subscription.</p>
+
+      <p>On the web dashboard the same toggle is called <strong>"Show quota forecast in header"</strong>, under <strong>Provider quota</strong>.</p>
+
+      <div class="callout callout-tip">
+        <strong>Also worth knowing</strong>
+        The <em>Quota</em> tab in the History window shows the same per-provider rate-limit forecast in full, and is always available &mdash; it is <em>not</em> gated by this toggle. The toggle only controls the compact header readout.
+      </div>
+
+      <!-- ── Cost display ── -->
+      <h2>See What a Session Costs</h2>
+
+      <p><strong>macOS and web.</strong> <strong>Settings &rarr; Show Estimated Cost</strong> puts a running USD estimate on each session and each project group. Estimates are approximate &mdash; they are derived from reported token counts and published prices, not from your provider invoice.</p>
+
+      <p>On the web dashboard the toggle is called <strong>"Show cost"</strong>, and it has an extra trick: <strong>click the cost figure in a row</strong> to switch that display to an estimated CO<sub>2</sub> footprint instead. Clicking a group header's cost cycles the time frame it is summed over. See <a href="co2-methodology.html">CO2 Methodology</a> for how the footprint is derived.</p>
+
+      <!-- ── Notifications ── -->
+      <h2>Let Irrlicht Tell You, So You Can Look Away</h2>
+
+      <p><strong>macOS.</strong> The single highest-value setting for anyone running more than one agent. Under <strong>Settings &rarr; Notifications</strong>, enable notifications and then configure each of the three events independently:</p>
+
+      <ul>
+        <li><strong>Agent ready</strong> &mdash; the agent finished its turn.</li>
+        <li><strong>Agent waiting for input</strong> &mdash; it is blocked on you.</li>
+        <li><strong>Context pressure alert</strong> &mdash; the session is approaching its context limit.</li>
+      </ul>
+
+      <p>Each event gets its own sound: one of the built-ins (Ping, Chime, Funk, Whoosh, Sosumi), <strong>None</strong>, a <strong>Custom audio file…</strong>, or &mdash; the part people miss &mdash; <strong>Speak aloud</strong>, which reads the message out with the system voice (a premium voice can be picked instead of the default). Spoken alerts mean you can leave the screen entirely and still know which agent needs you. There is a ▶ preview button next to each picker so you can audition a sound without waiting for the event.</p>
+
+      <p><strong>Context pressure alert</strong> adds an <strong>Alert at</strong> threshold you set in either <strong>%</strong> or raw <strong>tokens</strong> &mdash; so you can be warned at 80% and still have room to wrap up or compact deliberately, instead of being surprised.</p>
+
+      <figure style="margin: 0.5rem 0 1rem;">
+        <picture>
+          <source srcset="../assets/releases/v0.5.2/configurable-alerts.webp" type="image/webp">
+          <img src="../assets/releases/v0.5.2/configurable-alerts.png" alt="The Context pressure alert row in Irrlicht Settings: the event toggle switched on, the sound set to Speak aloud (Zoe, Premium) with a preview button, and an Alert at threshold of 80 percent." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
+        </picture>
+      </figure>
+
+      <p>The web dashboard has the three notification toggles too, but no per-event sounds and no spoken alerts &mdash; those are macOS-only. If macOS never asks for notification permission, or you denied it once, see <a href="macos-setup.html">macOS Setup &rarr; Notification Permissions</a>.</p>
+
+      <!-- ── Click to jump ── -->
+      <h2>Click a Session to Jump Straight to It</h2>
+
+      <p><strong>macOS.</strong> Session rows in the popover are not just readouts &mdash; clicking one brings the terminal or editor window that owns that session to the front. With several agents running across several windows, this replaces the entire "which window was that in" hunt.</p>
+
+      <p>It needs the macOS <strong>Accessibility</strong> permission granted once (<a href="macos-setup.html">macOS Setup &rarr; Accessibility Permission</a>); without it, focusing works for some terminals and silently fails for others. If you use Kitty, two lines in <code>kitty.conf</code> let Irrlicht land on the exact <em>tab</em> rather than just the window &mdash; see <a href="macos-setup.html#kitty">Kitty Terminal &mdash; Precise Tab Focus</a>.</p>
+
+      <div class="callout">
+        <strong>macOS only</strong>
+        Click-to-jump has no web equivalent &mdash; a browser tab cannot raise another application's window. The web dashboard's row clicks toggle cost display and group collapse instead.
+      </div>
+
+      <!-- ── History ── -->
+      <h2>Dig Into Usage History &mdash; and Export It</h2>
+
+      <p><strong>macOS and web.</strong> The History window's <strong>Usage</strong> tab is a full analytics surface, not just a chart. Three pickers drive it: <strong>Range</strong> (the time window), <strong>Chart</strong> (cost, tokens, CO<sub>2</sub>, and more), and <strong>Group</strong> &mdash; project, branch, provider, model, session, or token type.</p>
+
+      <p>Click a segment to drill into it: project &rarr; branch &rarr; session answers "what did this feature actually cost me", and provider &rarr; model &rarr; session answers "which model is eating the budget". <strong>Export CSV</strong> and <strong>Export JSON</strong> buttons sit under the chart, so any view you can build you can also hand to a spreadsheet or a script.</p>
+
+      <figure style="margin: 0.5rem 0 1rem; max-width: 420px;">
+        <picture>
+          <source srcset="../assets/releases/v0.5.4/history-analytics.webp" type="image/webp">
+          <img src="../assets/releases/v0.5.4/history-analytics.png" alt="The History window's Usage tab: a stacked cumulative cost chart broken down by project with a dashed projection, a month-to-date total of $18.35 with a projected $20.64, a per-project legend, and Export CSV and Export JSON buttons." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
+        </picture>
+      </figure>
+
+      <p>The web dashboard exposes the same chart and grouping controls in a single History panel (with export buttons labelled just <strong>CSV</strong> and <strong>JSON</strong>) rather than as separate tabs.</p>
+
+      <!-- ── Pending questions ── -->
+      <h2>Tame the List When Several Agents Ask at Once</h2>
+
+      <p><strong>macOS and web.</strong> A session that is <span class="badge badge-waiting">waiting</span> shows the question it is blocked on inline, so you can answer the right agent without opening every window. When four agents ask at once that is a lot of text, so both surfaces let you collapse them: on macOS the summary display control switches between collapsed and question-showing, and on the web dashboard the header has a <strong>Collapse all pending questions</strong> button.</p>
+
+      <p>Sessions that are <span class="badge badge-working">working</span> or <span class="badge badge-ready">ready</span> deliberately show no question pill &mdash; the text only appears when there is something to answer.</p>
+
+      <!-- ── Backchannel ── -->
+      <h2>Answer for Yourself &mdash; Automatically</h2>
+
+      <p><strong>macOS.</strong> <strong>Settings &rarr; Advanced Settings &rarr; Backchannel (control sessions)</strong> &mdash; marked <strong>beta</strong> in the app &mdash; lets Irrlicht send input and interrupts <em>into</em> a running session through its terminal backend (tmux, kitty, …), instead of you switching to that window. It is off by default, and each agent additionally needs the <strong>control</strong> permission granted &mdash; consent-first, like everything else Irrlicht touches.</p>
+
+      <p>Turning it on reveals a <strong>Rules</strong> editor: an event (<strong>Waiting</strong>, <strong>Ready</strong>, <strong>Working</strong>, <strong>Context (%)</strong>, <strong>Context (tokens)</strong>), an optional agent filter, and an action (<strong>Send</strong> a response, or <strong>Interrupt</strong>). The classic rule is the one below &mdash; compact automatically at 85% context, so a long-running agent never stalls waiting for you to notice.</p>
+
+      <figure style="margin: 0.5rem 0 1rem; max-width: 420px;">
+        <picture>
+          <source srcset="../assets/releases/v0.5.4/backchannel-rules.webp" type="image/webp">
+          <img src="../assets/releases/v0.5.4/backchannel-rules.png" alt="The Backchannel Rules editor with a rule named Auto-compact: when Context (%) is greater than or equal to 85, for any agent, send the response Compact." style="display:block; width:100%; height:auto; border-radius:6px; border:1px solid var(--border);">
+        </picture>
+      </figure>
+
+      <div class="callout callout-warning">
+        <strong>It really does type for you</strong>
+        A rule sends real input to a real session. Start with one narrow rule, watch it fire once, and only then add more. Backchannel has no web dashboard equivalent.
+      </div>
+
+      <!-- ── Scripting ── -->
+      <h2>Script It</h2>
+
+      <p><strong>Any platform.</strong> Everything the UIs show comes from the daemon's HTTP API on <code>http://127.0.0.1:7837</code>, and it is yours to query. <code>irrlicht-ls</code> prints the same hierarchical session view from the shell (handy in a status line, a tmux bar, or a cron check), and <code>irrlicht-focus &lt;sessionID&gt;</code> raises a session's window from a script or a hotkey.</p>
+
+      <p>If <code>irrlicht-ls</code> is not on your <code>PATH</code> &mdash; DMG installs do not symlink it &mdash; use <strong>Settings &rarr; Install Command-Line Tool</strong>. See <a href="cli-tools.html">CLI Tools</a> for every binary and <a href="api-reference.html">API Reference</a> for the endpoints behind them.</p>
+
+      <!-- ── Bottom nav ── -->
+      <nav class="docs-nav-bottom" aria-label="Previous and next page">
+        <a href="macos-setup.html">
+          <span class="label">Previous</span>
+          macOS Setup
+        </a>
+        <a href="cli-tools.html" style="text-align:right">
+          <span class="label">Next</span>
+          CLI Tools &rarr;
+        </a>
+      </nav>
+
+    </div>
+  </main>
+
+</div>
+
+<script async src="https://cdn.counter.dev/script.js" data-id="2d845c2a-ed61-4410-8850-e6339766176f" data-utcoffset="1"></script>
+</body>
+</html>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -12,6 +12,7 @@ Irrlicht provides menu-bar telemetry for AI coding agents like Claude Code, Open
 - [State Machine](https://irrlicht.io/docs/state-machine.html): Deterministic session state transitions
 - [Session Detection](https://irrlicht.io/docs/session-detection.html): How sessions are discovered and tracked
 - [Configuration](https://irrlicht.io/docs/configuration.html): Environment variables and settings
+- [Tips & Tricks](https://irrlicht.io/docs/tips-and-tricks.html): Easy-to-miss settings — menu bar styles, quota forecasts, spoken alerts, click-to-jump, backchannel rules
 - [CLI Tools](https://irrlicht.io/docs/cli-tools.html): The irrlichd daemon and irrlicht-ls tool
 - [API Reference](https://irrlicht.io/docs/api-reference.html): HTTP and WebSocket API
 - [Architecture](https://irrlicht.io/docs/architecture.html): Hexagonal architecture with ports and adapters

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -41,6 +41,11 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://irrlicht.io/docs/tips-and-tricks.html</loc>
+    <lastmod>2026-08-02</lastmod>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://irrlicht.io/docs/cli-tools.html</loc>
     <lastmod>2026-04-04</lastmod>
     <priority>0.6</priority>


### PR DESCRIPTION
Closes #954

Adds `site/docs/tips-and-tricks.html` — a home for the practical, easy-to-miss ways to get more out of Irrlicht, the kind of thing users currently only find by accident.

The motivating example from the issue is the "keep the menu bar always visible" tip: already documented, but buried inside macOS Setup where nobody looks for general advice. It now leads the page and links back to the instructions rather than duplicating them (a new `id="status-line-full-screen"` anchor on that heading makes the deep link possible).

### Tips on the page

Ten sections, each labelled with the surfaces it applies to — several are macOS-only and the page says so plainly rather than implying parity with the web dashboard:

menu bar visibility in full screen · menu bar icon style (Lights / Usage / Combined) · quota-forecast burn rate · estimated cost (and the web-only click-to-CO₂ trick) · per-event notification sounds and spoken alerts · click-to-jump · History usage drill-down and CSV/JSON export · collapsing pending questions · Backchannel rules (beta) · scripting via `irrlicht-ls` / `irrlicht-focus` / the HTTP API.

**Every claim is grounded in the shipped UI.** Exact toggle labels, menu paths and tab names were verified against `platforms/macos/` and `platforms/web/` before being written, not recalled. Two consequences worth noting:

- The issue's seed list said "Show Quota Forecast … in the menu bar / History → Quota tab". That conflates two things: the toggle controls the **popover header** readout (`SettingsView.swift:107-111`), while the History **Quota** tab is always present and not gated by it (`HistoryView.swift:19-31`). The page says so.
- The seed idea from the issue comments about "a summary of the initial prompt so you know what the agent was working on" is **not documented** — that purple intent pill was removed on both platforms in #979 (`SessionRowView.swift:143-149`). What remains is the waiting-question pill, which is what the page describes instead.

### Visuals

Per the "add screenshots or other visuals" comment, four existing product screenshots are reused from `site/assets/releases/` (menu bar icon picker, context-pressure alert with a spoken voice, History usage chart with exports, Backchannel auto-compact rule), using the `<figure><picture>` webp+png pattern already used in `changelog.html`. No new assets.

### Nav fan-out

- Sidebar entry added to all 18 `site/docs/*.html` pages (the nav is duplicated per page, no shared template), a doc-card in the index grid, prev/next rewired on the two neighbours, and `sitemap.xml` + `llms.txt` entries.
- **Pre-existing gap fixed:** `cli-tools.html`'s sidebar was missing the macOS Setup entry entirely — it had 4 Usage links where every other page had 5.

### Verification

Docs-only; no code paths touched, so no defect test applies and nothing was claimed as a regression fix.

- HTML well-formedness checked with a tag-balance parser on all four hand-edited files — clean.
- Link/asset integrity checked across every `site/docs/*.html`: every relative `href`/`src`/`srcset` resolves on disk, and every `#fragment` target exists in the file it points at — no breakage.
- Rendered and read end to end in Chrome over a local static server, plus the index card grid and the new `#status-line-full-screen` deep link.
- One rendering defect found and fixed this way: `docs.css` sets `.callout strong { display: block }`, so bold text inside a callout body was breaking onto its own line. Those are now `<em>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
