### PR TITLE
fix(daemon): share the hook-name → SignalKind table between detector and replay

### DIFF
--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -25,21 +25,26 @@ import (
 )
 
 // Hook event names. Claude Code fires these; the daemon recognizes only
-// these six and ignores everything else.
+// these seven and ignores everything else.
+//
+// The names themselves live in core/domain/session, next to the hook-name →
+// SignalKind table that the detector and the replay harness share — neither of
+// which may import this package (issue #1320). These are re-exports so
+// adapter-side call sites read in adapter terms.
 const (
-	HookPermissionRequest  = "PermissionRequest"
-	HookPreToolUse         = "PreToolUse"
-	HookPostToolUse        = "PostToolUse"
-	HookPostToolUseFailure = "PostToolUseFailure"
-	HookPreCompact         = "PreCompact"
+	HookPermissionRequest  = session.HookPermissionRequest
+	HookPreToolUse         = session.HookPreToolUse
+	HookPostToolUse        = session.HookPostToolUse
+	HookPostToolUseFailure = session.HookPostToolUseFailure
+	HookPreCompact         = session.HookPreCompact
 	// HookStop fires once at true turn end, carrying last_assistant_message.
 	// It is the authoritative turn-done signal for claudecode (issue #1161).
-	HookStop = "Stop"
+	HookStop = session.HookStop
 	// HookNotification fires for Claude Code UI notifications, carrying a
 	// notification_type discriminator. The daemon acts only on the idle_prompt
 	// type — the agent finished its turn and is idle at the prompt waiting for
 	// the user — as an authoritative waiting signal (issue #1173).
-	HookNotification = "Notification"
+	HookNotification = session.HookNotification
 )
 
 // notificationTypeIdlePrompt is the Notification hook's notification_type value

--- a/core/adapters/inbound/agents/codex/hooks.go
+++ b/core/adapters/inbound/agents/codex/hooks.go
@@ -38,11 +38,17 @@ import (
 
 // Hook event names. Codex fires these (among others); the daemon installs and
 // recognizes only these three and ignores everything else.
+//
+// Re-exports of the domain constants, like claudecode's: PermissionRequest and
+// PostToolUse route into the same SessionDetector.HandlePermissionHook, which
+// resolves them through session.HookSignal. Declaring them as independent
+// literals here would let a rename on this side silently stop matching the
+// shared table — the exact drift #1320 removed, one adapter over.
 const (
-	HookPermissionRequest = "PermissionRequest"
-	HookPostToolUse       = "PostToolUse"
+	HookPermissionRequest = session.HookPermissionRequest
+	HookPostToolUse       = session.HookPostToolUse
 	// HookStop fires once at true turn end, carrying last_assistant_message.
-	HookStop = "Stop"
+	HookStop = session.HookStop
 )
 
 // logComponentHookReceiver is the Logger component tag for every log line

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -279,11 +279,15 @@ func (d *SessionDetector) ReconcilePreSessionBackchannel(oldID, newID string) {
 //
 // Safe to call from any goroutine (e.g. HTTP handler).
 func (d *SessionDetector) HandlePermissionHook(sessionID, transcriptPath, hookEventName string) {
-	switch hookEventName {
-	case "PermissionRequest", "PreToolUse":
-		d.signals.Hold(sessionID, session.SignalPermissionPrompt, session.SignalPayload{}, time.Now())
-	case "PostToolUse", "PostToolUseFailure":
-		d.signals.Release(sessionID, session.SignalPermissionPrompt)
+	// session.HookSignal is the shared hook-name → SignalKind table, also read
+	// by the replay harness's applyHookEvent. It used to be a switch here and a
+	// second switch there, and they had drifted (issue #1320).
+	if effect, ok := session.HookSignal(hookEventName); ok {
+		if effect.Release {
+			d.signals.Release(sessionID, effect.Signal)
+		} else {
+			d.signals.Hold(sessionID, effect.Signal, session.SignalPayload{}, time.Now())
+		}
 	}
 
 	// processActivity overlays PermissionPending onto the metrics before
@@ -342,9 +346,7 @@ func (d *SessionDetector) HandleStopHook(sessionID, transcriptPath, lastAssistan
 	// calling ClassifyState. The Stop hook fires at true turn end (after the
 	// transcript flush), so a synthetic activity event is what drives the
 	// re-classification now rather than waiting for the next fswatcher pass.
-	// The literal "Stop" mirrors HandleCompactHook's "PreCompact" — the services
-	// layer must not import the claudecode adapter for its HookStop constant.
-	d.dispatchHookActivity(sessionID, transcriptPath, "Stop")
+	d.dispatchHookActivity(sessionID, transcriptPath, session.HookStop)
 }
 
 // HandleIdlePromptHook records Claude Code's Notification/idle_prompt hook
@@ -362,15 +364,13 @@ func (d *SessionDetector) HandleStopHook(sessionID, transcriptPath, lastAssistan
 // already ready by then), so this is a reconcile-and-correct: the synthetic
 // activity below drives a ready→waiting transition without the intermediate
 // working blip forceReadyToWorkingIfActive would otherwise record (it skips the
-// bounce while this flag is pending). The literal "Notification" mirrors
-// HandleStopHook's "Stop" — the services layer must not import the claudecode
-// adapter for its HookNotification constant.
+// bounce while this flag is pending).
 //
 // Safe to call from any goroutine (e.g. the HTTP handler).
 func (d *SessionDetector) HandleIdlePromptHook(sessionID, transcriptPath string) {
 	d.signals.Hold(sessionID, session.SignalIdlePrompt, session.SignalPayload{}, time.Now())
 
-	d.dispatchHookActivity(sessionID, transcriptPath, "Notification")
+	d.dispatchHookActivity(sessionID, transcriptPath, session.HookNotification)
 }
 
 // HandleCompactHook processes a Claude Code PreCompact hook for a manual
@@ -395,7 +395,7 @@ func (d *SessionDetector) HandleCompactHook(sessionID, transcriptPath, trigger s
 
 	// Flip the session to working immediately — there is no transcript flush
 	// coming during the compaction window to trigger a natural re-evaluation.
-	d.dispatchHookActivity(sessionID, transcriptPath, "PreCompact")
+	d.dispatchHookActivity(sessionID, transcriptPath, session.HookPreCompact)
 }
 
 // seedFromDisk populates the projectSessions map from existing sessions,

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -283,11 +283,7 @@ func (d *SessionDetector) HandlePermissionHook(sessionID, transcriptPath, hookEv
 	// by the replay harness's applyHookEvent. It used to be a switch here and a
 	// second switch there, and they had drifted (issue #1320).
 	if effect, ok := session.HookSignal(hookEventName); ok {
-		if effect.Release {
-			d.signals.Release(sessionID, effect.Signal)
-		} else {
-			d.signals.Hold(sessionID, effect.Signal, session.SignalPayload{}, time.Now())
-		}
+		d.signals.ApplyHook(sessionID, effect, time.Now())
 	}
 
 	// processActivity overlays PermissionPending onto the metrics before

--- a/core/domain/session/hook_signal.go
+++ b/core/domain/session/hook_signal.go
@@ -1,5 +1,7 @@
 package session
 
+import "time"
+
 // Hook event names, as the agent CLIs put them on the wire. Claude Code fires
 // all seven; Codex fires the PermissionRequest / PostToolUse / Stop subset.
 //
@@ -38,17 +40,29 @@ type HookSignalEffect struct {
 	Release bool
 }
 
-// hookSignalEffects is the single source of truth for hook-name → SignalKind,
-// covering every hook whose effect is *fully determined by its name*.
+// hookSignalEffects is the single source of truth for hook-name → SignalKind
+// for the hooks a caller may act on knowing only the name.
 //
-// It deliberately stops there. HookStop, HookNotification and HookPreCompact
-// are name-plus-payload: Stop carries the turn's final assistant text into
-// SignalPayload, Notification is only acted on for notification_type
-// "idle_prompt", and PreCompact only for trigger "manual". Their handlers must
-// read the payload, so a name-keyed lookup could not express them without
-// lying about what the name alone determines — they keep their own dedicated
-// entry points and are absent here on purpose. A caller that gets ok==false
-// has learned "this hook needs more than its name", not "this hook is unknown".
+// Three hooks are absent, for two different reasons — worth keeping apart,
+// because they imply different things about whether a future row belongs here:
+//
+//   - HookStop genuinely cannot be a row. Its effect carries a payload (the
+//     turn's final assistant text and the waiting-cue verdict computed from it)
+//     into SignalPayload, and a name-keyed lookup has no way to supply that.
+//     HandleStopHook stays a dedicated entry point.
+//   - HookNotification and HookPreCompact are excluded only because their
+//     *gate* is adapter-side: the claudecode HTTP handler forwards Notification
+//     solely for notification_type "idle_prompt" and PreCompact solely for
+//     trigger "manual", so the decision is already made before the detector is
+//     called. Both holds themselves are payload-free. A consumer reading
+//     post-gate events (the replay harness — dispatchHookActivity is the only
+//     writer of lifecycle.KindHookReceived, and it runs downstream of those
+//     gates, so a recorded PreCompact means manual by construction) could act
+//     on the name alone. They are absent because no recording fires one yet;
+//     when one does, a row here is the right fix, not a bespoke branch.
+//
+// A caller that gets ok==false has learned "I may not act on this name alone",
+// not "this hook is unknown".
 //
 // The rows below were previously written twice — once as a switch in
 // SessionDetector.HandlePermissionHook and once as a switch in the replay
@@ -75,4 +89,20 @@ var hookSignalEffects = map[string]HookSignalEffect{
 func HookSignal(hookName string) (HookSignalEffect, bool) {
 	effect, ok := hookSignalEffects[hookName]
 	return effect, ok
+}
+
+// ApplyHook applies a hook's effect to sessionID's holds — the assert/retract
+// branch that the detector and the replay harness would otherwise each write
+// out. Keeping it here means the two consumers of HookSignal share not just
+// the mapping but what they do with it, so a new row cannot be honoured by one
+// and half-honoured by the other (issue #1320).
+//
+// at is the observation time — wall-clock in the daemon, virtual time in
+// replay. Only the hold direction reads it; Release is time-independent.
+func (h *SignalHolds) ApplyHook(sessionID string, effect HookSignalEffect, at time.Time) {
+	if effect.Release {
+		h.Release(sessionID, effect.Signal)
+		return
+	}
+	h.Hold(sessionID, effect.Signal, SignalPayload{}, at)
 }

--- a/core/domain/session/hook_signal.go
+++ b/core/domain/session/hook_signal.go
@@ -1,0 +1,78 @@
+package session
+
+// Hook event names, as the agent CLIs put them on the wire. Claude Code fires
+// all seven; Codex fires the PermissionRequest / PostToolUse / Stop subset.
+//
+// These live in the domain rather than in the claudecode adapter that owns the
+// HTTP handler because three separate layers need to agree on them and two of
+// them cannot import that adapter:
+//
+//   - application/services (SessionDetector) — barred by core/architecture_test.go's
+//     "application/services must reach adapters through ports" rule, which is
+//     exactly why the detector used to restate every name as a bare literal;
+//   - tools/onboarding-factory's replay harness, which mirrors the detector's
+//     hook handling against frozen recordings.
+//
+// The claudecode adapter re-exports these as its own HookXxx constants, so
+// adapter-side call sites are unchanged.
+const (
+	HookPermissionRequest  = "PermissionRequest"
+	HookPreToolUse         = "PreToolUse"
+	HookPostToolUse        = "PostToolUse"
+	HookPostToolUseFailure = "PostToolUseFailure"
+	HookPreCompact         = "PreCompact"
+	// HookStop fires once at true turn end, carrying last_assistant_message.
+	// It is the authoritative turn-done signal (issue #1161).
+	HookStop = "Stop"
+	// HookNotification fires for agent UI notifications, carrying a
+	// notification_type discriminator; the daemon acts only on idle_prompt
+	// (issue #1173).
+	HookNotification = "Notification"
+)
+
+// HookSignalEffect is what one hook event name does to a session's signal
+// holds. Release distinguishes the two directions: a hook either asserts a
+// signal (Release false) or retracts one (Release true).
+type HookSignalEffect struct {
+	Signal  SignalKind
+	Release bool
+}
+
+// hookSignalEffects is the single source of truth for hook-name → SignalKind,
+// covering every hook whose effect is *fully determined by its name*.
+//
+// It deliberately stops there. HookStop, HookNotification and HookPreCompact
+// are name-plus-payload: Stop carries the turn's final assistant text into
+// SignalPayload, Notification is only acted on for notification_type
+// "idle_prompt", and PreCompact only for trigger "manual". Their handlers must
+// read the payload, so a name-keyed lookup could not express them without
+// lying about what the name alone determines — they keep their own dedicated
+// entry points and are absent here on purpose. A caller that gets ok==false
+// has learned "this hook needs more than its name", not "this hook is unknown".
+//
+// The rows below were previously written twice — once as a switch in
+// SessionDetector.HandlePermissionHook and once as a switch in the replay
+// harness's applyHookEvent — and had drifted: the harness silently ignored
+// PreToolUse, which the daemon holds on (issue #1320). Adding a name-determined
+// signal is now one row here rather than a row plus a detector case plus a
+// replay case.
+var hookSignalEffects = map[string]HookSignalEffect{
+	// A permission prompt is open and the user is blocked on it (#108, #1171).
+	HookPermissionRequest: {Signal: SignalPermissionPrompt},
+	// PreToolUse fires synchronously when the model emits a tool_use block,
+	// before the assistant message reaches the JSONL. For AskUserQuestion and
+	// ExitPlanMode (the installed matcher) that flips working → waiting without
+	// waiting on transcript flush latency (#307).
+	HookPreToolUse: {Signal: SignalPermissionPrompt},
+	// The tool ran, so whatever was blocking on it no longer is.
+	HookPostToolUse:        {Signal: SignalPermissionPrompt, Release: true},
+	HookPostToolUseFailure: {Signal: SignalPermissionPrompt, Release: true},
+}
+
+// HookSignal reports the signal effect of a hook event name. ok is false for a
+// name this table does not determine on its own — either an unrecognized hook,
+// or one of the payload-gated hooks documented on hookSignalEffects.
+func HookSignal(hookName string) (HookSignalEffect, bool) {
+	effect, ok := hookSignalEffects[hookName]
+	return effect, ok
+}

--- a/core/domain/session/hook_signal_test.go
+++ b/core/domain/session/hook_signal_test.go
@@ -1,0 +1,62 @@
+package session
+
+import "testing"
+
+// TestHookSignalTable pins the hook-name → SignalKind mapping that
+// SessionDetector.HandlePermissionHook and the replay harness's applyHookEvent
+// both read. Before #1320 each had its own copy and they had drifted: the
+// harness ignored PreToolUse, which the daemon holds on.
+//
+// A lock, not a defect test — it passes on main by construction, because the
+// daemon's side of the mapping was already correct. What it prevents is a
+// future edit silently changing what a hook name means for one caller.
+func TestHookSignalTable(t *testing.T) {
+	tests := []struct {
+		hookName    string
+		wantSignal  SignalKind
+		wantRelease bool
+		wantOK      bool
+	}{
+		{HookPermissionRequest, SignalPermissionPrompt, false, true},
+		{HookPreToolUse, SignalPermissionPrompt, false, true},
+		{HookPostToolUse, SignalPermissionPrompt, true, true},
+		{HookPostToolUseFailure, SignalPermissionPrompt, true, true},
+
+		// Payload-gated: the name alone does not determine the effect, so
+		// these are absent from the table by design (see hookSignalEffects).
+		{HookStop, "", false, false},
+		{HookNotification, "", false, false},
+		{HookPreCompact, "", false, false},
+
+		// Genuinely unknown.
+		{"SessionStart", "", false, false},
+		{"", "", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hookName, func(t *testing.T) {
+			effect, ok := HookSignal(tt.hookName)
+			if ok != tt.wantOK {
+				t.Fatalf("HookSignal(%q) ok = %v, want %v", tt.hookName, ok, tt.wantOK)
+			}
+			if effect.Signal != tt.wantSignal {
+				t.Errorf("HookSignal(%q).Signal = %q, want %q", tt.hookName, effect.Signal, tt.wantSignal)
+			}
+			if effect.Release != tt.wantRelease {
+				t.Errorf("HookSignal(%q).Release = %v, want %v", tt.hookName, effect.Release, tt.wantRelease)
+			}
+		})
+	}
+}
+
+// TestHookSignalEffectsReferenceKnownSignals guards the other end of the table:
+// every row must name a SignalKind that actually has a policy, or the hold it
+// creates would never be applied by Overlay.
+func TestHookSignalEffectsReferenceKnownSignals(t *testing.T) {
+	for hookName, effect := range hookSignalEffects {
+		if TierOf(effect.Signal) == TierNone {
+			t.Errorf("hook %q maps to SignalKind %q, which has no signalPolicies row",
+				hookName, effect.Signal)
+		}
+	}
+}

--- a/tools/onboarding-factory/cmd/replay/main_test.go
+++ b/tools/onboarding-factory/cmd/replay/main_test.go
@@ -731,9 +731,15 @@ not json at all
 	}
 }
 
-// TestReplayWithSidecar_HookEvents verifies that hook_received events in
-// the sidecar produce working→waiting transitions during replay.
-func TestReplayWithSidecar_HookEvents(t *testing.T) {
+// replayOneHookForWaiting writes a minimal two-message transcript plus a
+// sidecar whose only hook_received carries hookName, replays them, and reports
+// whether a hook-caused waiting transition came out.
+//
+// Shared by the tests below so the hook name is the single variable between
+// them: a failure for one name and not another isolates the hook-name → signal
+// mapping rather than anything about the surrounding replay machinery.
+func replayOneHookForWaiting(t *testing.T, hookName string) (bool, []transition) {
+	t.Helper()
 	dir := t.TempDir()
 	transcript := filepath.Join(dir, "session.jsonl")
 	sidecar := filepath.Join(dir, "session.events.jsonl")
@@ -748,7 +754,7 @@ func TestReplayWithSidecar_HookEvents(t *testing.T) {
 	sidecarBody := `{"seq":1,"ts":"2026-04-11T10:00:00Z","kind":"transcript_new","session_id":"sess-1","adapter":"claude-code"}
 {"seq":2,"ts":"2026-04-11T10:00:00.500Z","kind":"transcript_activity","session_id":"sess-1","file_size":93}
 {"seq":3,"ts":"2026-04-11T10:00:01Z","kind":"transcript_activity","session_id":"sess-1","file_size":192}
-{"seq":4,"ts":"2026-04-11T10:00:01.500Z","kind":"hook_received","session_id":"sess-1","hook_name":"PermissionRequest"}
+{"seq":4,"ts":"2026-04-11T10:00:01.500Z","kind":"hook_received","session_id":"sess-1","hook_name":"` + hookName + `"}
 `
 	if err := os.WriteFile(sidecar, []byte(sidecarBody), 0644); err != nil {
 		t.Fatalf("write sidecar: %v", err)
@@ -763,15 +769,20 @@ func TestReplayWithSidecar_HookEvents(t *testing.T) {
 		t.Fatalf("replayWithSidecar: %v", err)
 	}
 
-	var foundHookWaiting bool
 	for _, tr := range report.Transitions {
 		if tr.Cause == causeHook && tr.NewState == "waiting" {
-			foundHookWaiting = true
-			break
+			return true, report.Transitions
 		}
 	}
-	if !foundHookWaiting {
-		t.Errorf("expected a hook-caused working→waiting transition; transitions: %+v", report.Transitions)
+	return false, report.Transitions
+}
+
+// TestReplayWithSidecar_HookEvents verifies that hook_received events in
+// the sidecar produce working→waiting transitions during replay.
+func TestReplayWithSidecar_HookEvents(t *testing.T) {
+	found, transitions := replayOneHookForWaiting(t, claudecode.HookPermissionRequest)
+	if !found {
+		t.Errorf("expected a hook-caused working→waiting transition; transitions: %+v", transitions)
 	}
 }
 
@@ -790,51 +801,12 @@ func TestReplayWithSidecar_HookEvents(t *testing.T) {
 // hook_received events, and the recordings that do hold them are only ever
 // replayed transcript-only (issue #1326). This test is therefore the only
 // coverage the hook path has — not a supplement to fixture coverage.
-//
-// This is the same fixture as TestReplayWithSidecar_HookEvents with the hook
-// name swapped, so a failure here isolates the hook-name mapping rather than
-// anything about the surrounding replay machinery.
 func TestReplayWithSidecar_Issue1320_PreToolUseHold(t *testing.T) {
-	dir := t.TempDir()
-	transcript := filepath.Join(dir, "session.jsonl")
-	sidecar := filepath.Join(dir, "session.events.jsonl")
-
-	transcriptBody := `{"type":"user","timestamp":"2026-04-11T10:00:00Z","message":{"role":"user","content":"hello"}}
-{"type":"assistant","timestamp":"2026-04-11T10:00:01Z","message":{"role":"assistant","content":"Let me check."}}
-`
-	if err := os.WriteFile(transcript, []byte(transcriptBody), 0644); err != nil {
-		t.Fatalf("write transcript: %v", err)
-	}
-
-	sidecarBody := `{"seq":1,"ts":"2026-04-11T10:00:00Z","kind":"transcript_new","session_id":"sess-1","adapter":"claude-code"}
-{"seq":2,"ts":"2026-04-11T10:00:00.500Z","kind":"transcript_activity","session_id":"sess-1","file_size":93}
-{"seq":3,"ts":"2026-04-11T10:00:01Z","kind":"transcript_activity","session_id":"sess-1","file_size":192}
-{"seq":4,"ts":"2026-04-11T10:00:01.500Z","kind":"hook_received","session_id":"sess-1","hook_name":"PreToolUse"}
-`
-	if err := os.WriteFile(sidecar, []byte(sidecarBody), 0644); err != nil {
-		t.Fatalf("write sidecar: %v", err)
-	}
-
-	report, err := replayWithSidecar(transcript, sidecar, reportSettings{
-		Adapter:            claudecode.AdapterName,
-		DebounceWindow:     2 * time.Second,
-		FlickerMaxDuration: 10 * time.Second,
-	})
-	if err != nil {
-		t.Fatalf("replayWithSidecar: %v", err)
-	}
-
-	var foundHookWaiting bool
-	for _, tr := range report.Transitions {
-		if tr.Cause == causeHook && tr.NewState == "waiting" {
-			foundHookWaiting = true
-			break
-		}
-	}
-	if !foundHookWaiting {
+	found, transitions := replayOneHookForWaiting(t, claudecode.HookPreToolUse)
+	if !found {
 		t.Errorf("PreToolUse hook produced no hook-caused waiting transition — the replay harness "+
 			"dropped a hook the daemon holds SignalPermissionPrompt on (#1320); transitions: %+v",
-			report.Transitions)
+			transitions)
 	}
 }
 

--- a/tools/onboarding-factory/cmd/replay/main_test.go
+++ b/tools/onboarding-factory/cmd/replay/main_test.go
@@ -782,11 +782,14 @@ func TestReplayWithSidecar_HookEvents(t *testing.T) {
 // replay harness's applyHookEvent recognized only PermissionRequest and fell
 // through its default: return on PreToolUse.
 //
-// PreToolUse is not hypothetical — replaydata/ carries two of them today. Both
-// happen to be followed within ~100ms by a PermissionRequest that produces the
-// same hold, so no golden is currently wrong: the two paths agreed by luck, and
-// the harness whose job is catching classifier regressions was silently blind
-// to a hook the daemon honours.
+// PreToolUse is not hypothetical — replaydata/ carries two of them today, and
+// replaying those recordings with their sidecars does show the drift changing
+// the output (the transition moves ~19ms and ~136ms earlier). It went unnoticed
+// because no committed gate replays a hook-carrying recording through
+// applyHookEvent: the two fixtures the sidecar tests above use hold zero
+// hook_received events, and the recordings that do hold them are only ever
+// replayed transcript-only (issue #1326). This test is therefore the only
+// coverage the hook path has — not a supplement to fixture coverage.
 //
 // This is the same fixture as TestReplayWithSidecar_HookEvents with the hook
 // name swapped, so a failure here isolates the hook-name mapping rather than

--- a/tools/onboarding-factory/cmd/replay/main_test.go
+++ b/tools/onboarding-factory/cmd/replay/main_test.go
@@ -775,6 +775,66 @@ func TestReplayWithSidecar_HookEvents(t *testing.T) {
 	}
 }
 
+// TestReplayWithSidecar_Issue1320_PreToolUseHold is the defect test for #1320:
+// the hook-name → session.SignalKind mapping used to be written twice, and the
+// two copies had drifted. SessionDetector.HandlePermissionHook holds
+// SignalPermissionPrompt on PermissionRequest *and* PreToolUse, while the
+// replay harness's applyHookEvent recognized only PermissionRequest and fell
+// through its default: return on PreToolUse.
+//
+// PreToolUse is not hypothetical — replaydata/ carries two of them today. Both
+// happen to be followed within ~100ms by a PermissionRequest that produces the
+// same hold, so no golden is currently wrong: the two paths agreed by luck, and
+// the harness whose job is catching classifier regressions was silently blind
+// to a hook the daemon honours.
+//
+// This is the same fixture as TestReplayWithSidecar_HookEvents with the hook
+// name swapped, so a failure here isolates the hook-name mapping rather than
+// anything about the surrounding replay machinery.
+func TestReplayWithSidecar_Issue1320_PreToolUseHold(t *testing.T) {
+	dir := t.TempDir()
+	transcript := filepath.Join(dir, "session.jsonl")
+	sidecar := filepath.Join(dir, "session.events.jsonl")
+
+	transcriptBody := `{"type":"user","timestamp":"2026-04-11T10:00:00Z","message":{"role":"user","content":"hello"}}
+{"type":"assistant","timestamp":"2026-04-11T10:00:01Z","message":{"role":"assistant","content":"Let me check."}}
+`
+	if err := os.WriteFile(transcript, []byte(transcriptBody), 0644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	sidecarBody := `{"seq":1,"ts":"2026-04-11T10:00:00Z","kind":"transcript_new","session_id":"sess-1","adapter":"claude-code"}
+{"seq":2,"ts":"2026-04-11T10:00:00.500Z","kind":"transcript_activity","session_id":"sess-1","file_size":93}
+{"seq":3,"ts":"2026-04-11T10:00:01Z","kind":"transcript_activity","session_id":"sess-1","file_size":192}
+{"seq":4,"ts":"2026-04-11T10:00:01.500Z","kind":"hook_received","session_id":"sess-1","hook_name":"PreToolUse"}
+`
+	if err := os.WriteFile(sidecar, []byte(sidecarBody), 0644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+
+	report, err := replayWithSidecar(transcript, sidecar, reportSettings{
+		Adapter:            claudecode.AdapterName,
+		DebounceWindow:     2 * time.Second,
+		FlickerMaxDuration: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("replayWithSidecar: %v", err)
+	}
+
+	var foundHookWaiting bool
+	for _, tr := range report.Transitions {
+		if tr.Cause == causeHook && tr.NewState == "waiting" {
+			foundHookWaiting = true
+			break
+		}
+	}
+	if !foundHookWaiting {
+		t.Errorf("PreToolUse hook produced no hook-caused waiting transition — the replay harness "+
+			"dropped a hook the daemon holds SignalPermissionPrompt on (#1320); transitions: %+v",
+			report.Transitions)
+	}
+}
+
 // TestSessionFilter verifies that SessionFilter in reportSettings filters
 // sidecar events to the specified session ID.
 func TestSessionFilter(t *testing.T) {

--- a/tools/onboarding-factory/cmd/replay/replay_sidecar.go
+++ b/tools/onboarding-factory/cmd/replay/replay_sidecar.go
@@ -442,25 +442,32 @@ func (r *sidecarReplayer) classifyAt(fileSize int64, ctx transitionCtx) error {
 // this function used to carry its own switch, which recognized
 // PermissionRequest but fell through to default on PreToolUse — a hook the
 // daemon holds SignalPermissionPrompt on, and one that replaydata/ carries two
-// of. Nothing was visibly wrong only because both recordings follow the
-// PreToolUse with a PermissionRequest within ~100ms that produces the same
-// hold; the two paths agreed by luck rather than by construction (issue #1320).
+// of (issue #1320).
 //
-// Hooks whose effect needs more than their name — Stop, Notification and
-// PreCompact — are absent from that table and so are still ignored here. That
-// remains deliberate: no recording in replaydata/ fires one, so wiring them
-// would add branches no golden exercises. Add each together with the first
-// recording that fires it.
+// Why it stayed invisible is worth stating precisely, because the obvious
+// answer is wrong. It is *not* that a PermissionRequest follows each PreToolUse
+// closely enough to be equivalent — replaying those two recordings by hand
+// shows the corrected hold moving the transition 19ms and 136ms earlier and
+// flipping its cause from hook to debounce_coalesce. It stayed invisible
+// because no committed gate reaches *this function* over a recording that
+// carries a hook: the two tests that do drive replayWithSidecar over real
+// fixtures (10-full-lifecycle-839f0678, 13-full-lifecycle-continue-8a525d27)
+// contain zero hook_received events, and every recording that does carry one
+// is only ever replayed transcript-only — replay-fixtures.sh and the
+// byte-identity golden never enable sidecar mode, because resolveInputPaths
+// auto-detects only a sibling named <transcript>.events.jsonl while every
+// sidecar in replaydata/ is named plain events.jsonl. See issue #1326.
+//
+// Hooks absent from the table are still ignored here. Stop could not be a table
+// row (its effect needs a payload lifecycle.Event does not carry); Notification
+// and PreCompact could be, but no recording in replaydata/ fires one — add each
+// as a table row together with the first recording that does.
 func (r *sidecarReplayer) applyHookEvent(hookEv lifecycle.Event) {
 	effect, ok := session.HookSignal(hookEv.HookName)
 	if !ok {
 		return
 	}
-	if effect.Release {
-		r.signals.Release(replaySessionKey, effect.Signal)
-	} else {
-		r.signals.Hold(replaySessionKey, effect.Signal, session.SignalPayload{}, hookEv.Timestamp)
-	}
+	r.signals.ApplyHook(replaySessionKey, effect, hookEv.Timestamp)
 	if r.lastMetrics == nil {
 		return
 	}

--- a/tools/onboarding-factory/cmd/replay/replay_sidecar.go
+++ b/tools/onboarding-factory/cmd/replay/replay_sidecar.go
@@ -434,25 +434,32 @@ func (r *sidecarReplayer) classifyAt(fileSize int64, ctx transitionCtx) error {
 	return nil
 }
 
-// applyHookEvent mirrors SessionDetector.HandlePermissionHook: update the
-// permission-pending flag based on hook type, then trigger a re-
-// classification using the last-known metrics. Hook events other than the
-// three recognized Claude Code hooks are ignored.
+// applyHookEvent mirrors SessionDetector.HandlePermissionHook: apply the hook's
+// signal effect, then trigger a re-classification using the last-known metrics.
 //
-// PreCompact is deliberately not among them, even though #1297 made it a
-// signalPolicies row the harness could now hold like any other. No recording
-// in replaydata/ carries one: a grep for hook_name across the whole catalog
-// returns only PermissionRequest, PreToolUse, PostToolUse and
-// PostToolUseFailure. Wiring it would therefore add a branch no golden
-// exercises. Add it together with the first recording that fires one.
+// Both sides read the same session.HookSignal table, so a hook the daemon
+// honours can no longer be silently dropped here. That divergence was real:
+// this function used to carry its own switch, which recognized
+// PermissionRequest but fell through to default on PreToolUse — a hook the
+// daemon holds SignalPermissionPrompt on, and one that replaydata/ carries two
+// of. Nothing was visibly wrong only because both recordings follow the
+// PreToolUse with a PermissionRequest within ~100ms that produces the same
+// hold; the two paths agreed by luck rather than by construction (issue #1320).
+//
+// Hooks whose effect needs more than their name — Stop, Notification and
+// PreCompact — are absent from that table and so are still ignored here. That
+// remains deliberate: no recording in replaydata/ fires one, so wiring them
+// would add branches no golden exercises. Add each together with the first
+// recording that fires it.
 func (r *sidecarReplayer) applyHookEvent(hookEv lifecycle.Event) {
-	switch hookEv.HookName {
-	case claudecode.HookPermissionRequest:
-		r.signals.Hold(replaySessionKey, session.SignalPermissionPrompt, session.SignalPayload{}, hookEv.Timestamp)
-	case claudecode.HookPostToolUse, claudecode.HookPostToolUseFailure:
-		r.signals.Release(replaySessionKey, session.SignalPermissionPrompt)
-	default:
+	effect, ok := session.HookSignal(hookEv.HookName)
+	if !ok {
 		return
+	}
+	if effect.Release {
+		r.signals.Release(replaySessionKey, effect.Signal)
+	} else {
+		r.signals.Hold(replaySessionKey, effect.Signal, session.SignalPayload{}, hookEv.Timestamp)
 	}
 	if r.lastMetrics == nil {
 		return


### PR DESCRIPTION
Closes #1320.

## The drift

Which hook name produces which `session.SignalKind` was written twice:

- **Daemon** — `SessionDetector.HandlePermissionHook` held `SignalPermissionPrompt` on `PermissionRequest` **and** `PreToolUse`.
- **Replay harness** — `applyHookEvent` recognized only `PermissionRequest`, and fell through `default: return` on `PreToolUse`.

`replaydata/` carries two `PreToolUse` events today (`2-18_user-blocking-plan-mode-approval`, `5-4_architect-editor-pair`).

## Where the table went, and why not where the issue proposed

The issue proposed putting it next to the hook-name constants in `core/adapters/inbound/agents/claudecode/hooks.go`. That isn't reachable: `core/architecture_test.go:46-48` bars `application/services/` from importing `adapters/inbound/` — which is *precisely* why the detector restated every hook name as a bare literal, with three comments apologizing for it.

So the canonical hook names, `HookSignal(name) (HookSignalEffect, bool)`, and `SignalHolds.ApplyHook` land in the **domain**, at `core/domain/session/hook_signal.go` — reachable by the detector, both adapters and the replay harness alike. `claudecode`'s and `codex`'s `HookXxx` constants become re-exports, so no adapter-side call site moves and a rename on either side is compile-visible.

Both `HandlePermissionHook` and `applyHookEvent` now read that one table *and* apply it through one method, so a new row cannot be honoured by one consumer and half-honoured by the other. The detector's `"Stop"` / `"Notification"` / `"PreCompact"` literals become `session.HookStop` / `session.HookNotification` / `session.HookPreCompact`.

## What is deliberately *not* in the table — two different reasons

- **`Stop`** genuinely cannot be a row: its effect carries a payload (the turn's final assistant text and the waiting-cue verdict computed from it) that a name-keyed lookup cannot supply, and `lifecycle.Event` doesn't carry it either.
- **`Notification` / `PreCompact`** could be rows. Their gate is *adapter-side* (`notification_type: idle_prompt`, `trigger: manual`), and `dispatchHookActivity` — the sole writer of `lifecycle.KindHookReceived` — runs downstream of it, so a recorded `PreCompact` means manual by construction. They are absent only because no recording fires one yet. When one does, **a table row is the right fix, not a bespoke branch.**

That distinction is stated in the code, because collapsing it is how the next maintainer would reintroduce the two-places-to-edit shape this PR removes.

## Red-first evidence

`TestReplayWithSidecar_Issue1320_PreToolUseHold` (`tools/onboarding-factory/cmd/replay/main_test.go`) — the existing `TestReplayWithSidecar_HookEvents` fixture with the hook name swapped to `PreToolUse`, so a failure isolates the hook-name mapping. Run **before** the fix existed:

```
=== RUN   TestReplayWithSidecar_HookEvents
--- PASS: TestReplayWithSidecar_HookEvents (0.00s)
=== RUN   TestReplayWithSidecar_Issue1320_PreToolUseHold
    main_test.go:832: PreToolUse hook produced no hook-caused waiting transition — the replay
    harness dropped a hook the daemon holds SignalPermissionPrompt on (#1320); transitions:
    [{... Cause:init ... NewState:ready ...} {... Cause:event PrevState:ready NewState:working ...}]
--- FAIL: TestReplayWithSidecar_Issue1320_PreToolUseHold (0.00s)
FAIL	irrlicht/tools/onboarding-factory/cmd/replay	0.386s
```

The `PermissionRequest` control test passing in the same run pins the failure to the mapping rather than the surrounding replay machinery. Green after the fix. (Independently re-confirmed by the review subagent via `go test -overlay` against `origin/main`'s `replay_sidecar.go`.)

**Locks** (pass on `main` by construction — *not* red-first proofs): `TestHookSignalTable` and `TestHookSignalEffectsReferenceKnownSignals` in `core/domain/session/hook_signal_test.go`. The daemon's side of the mapping was already correct; these pin it so a future edit can't silently change what a hook name means for one caller.

## Coverage caveat — read this rather than the suite results

An earlier version of this PR body claimed "no goldens move" as evidence the change was safe. **That was vacuous and has been retracted.** No committed gate replays a hook-carrying recording through `applyHookEvent`:

- the two fixtures the sidecar tests use (`10-full-lifecycle-839f0678`, `13-full-lifecycle-continue-8a525d27`) contain **zero** `hook_received` events;
- every recording that *does* carry one is only ever replayed **transcript-only**, because `resolveInputPaths` auto-detects a sidecar named `<transcript>.events.jsonl` while all 335 sidecars are named plain `events.jsonl`. Replaying `2-18` through `replay-fixtures.sh` yields causes `['debounce_coalesce', 'init']` — no `hook` cause at all.

So goldens *could not* have moved, and their staying green proves nothing about this change. Filed as **#1326**.

Replaying the two `PreToolUse` recordings in explicit sidecar mode before/after does show a real difference — the corrected hold moves the transition 19 ms / 136 ms earlier and flips its cause from `hook` to `debounce_coalesce`. The post-fix output is the daemon-faithful one. The new unit test is this path's only committed coverage.

## Verification

- `go test ./core/... -race -count=1` — pass (includes `architecture_test.go`, which is what validates the domain placement).
- `go test ./tools/onboarding-factory/... -race -count=1` — pass.
- `tools/replay-fixtures.sh` — pass (but see the caveat above: it does not exercise this code).
- `tools/preflight.sh --changed` via the pre-push hook — all applicable gates PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)