### PR TITLE
fix(claudecode): derive hook consent copy from installedHookEvents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,21 @@ Before marking a ticket done, run the full suite — every layer must pass:
   on another port is rewritten in place rather than duplicated, and uninstall
   is not port-scoped (#1178). A new hook-installing adapter wires one call
   (see `claudecode`/`codex` `hookport_test.go`) instead of porting a test file.
-  Both contract families pass by construction against a correct adapter, so
+- Hook disclosure: `contracttesting.AssertHookDisclosureMatchesInstalled`
+  (`core/internal/contracttesting/hook_disclosure.go`) binds a hooks
+  permission's consent copy to what the installer actually writes — the
+  `Touches`/`Detail` text names every event in `installedHookEvents`, states
+  the right entry count, and names no event the adapter doesn't install
+  (#1356). It exists because that text *is* the #570 consent contract and it
+  was hand-maintained: Claude Code's copy declared six entries for the whole
+  of #1173's seven-event install, so the Notification hook was written to the
+  user's `settings.json` undisclosed. Adapters now derive both the count and
+  the list from `installedHookEvents` via `hookjson.EventList`, and wire one
+  call (see `claudecode`/`codex` `hookdisclosure_test.go`). The "names no
+  uninstalled event" arm checks against `session.AllHookEvents`, itself kept
+  honest by `TestAllHookEvents_CoversEveryConstant`, which scans
+  `hook_signal.go`'s source rather than trusting a second hand-kept list.
+  All three contract families pass by construction against a correct adapter, so
   their whole value is that they *can* fail: a new or reworked contract
   assertion lands with the deliberate mutation that was seen red for each
   obligation recorded in its PR — the same bar the red-first rule above sets

--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -1,8 +1,6 @@
 package claudecode
 
 import (
-	"fmt"
-
 	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/backchannel"
@@ -86,8 +84,7 @@ func Agent() agent.Agent {
 				// restated: this copy is the consent contract, and hand-maintaining
 				// it is how it came to promise six entries against a seven-event
 				// install (#1173's Notification hook, undisclosed until #1356).
-				Touches: fmt.Sprintf("Writes %d hook entries to ~/.claude/settings.json",
-					len(installedHookEvents)),
+				Touches: hookjson.EntriesTouched("~/.claude/settings.json", installedHookEvents),
 				Detail: "Adds " + hookjson.EventList(installedHookEvents) +
 					" hook entries that POST " +
 					"the hook payload to the local daemon at " + hookEndpointURL() +

--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -1,6 +1,9 @@
 package claudecode
 
 import (
+	"fmt"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/backchannel"
 	"irrlicht/core/domain/permission"
@@ -79,9 +82,14 @@ func Agent() agent.Agent {
 				Kind:            permission.KindModify,
 				Title:           "Install status hooks",
 				FeatureUnlocked: "Instant waiting-state detection (permission prompts, plan approval, questions)",
-				Touches:         "Writes 6 hook entries to ~/.claude/settings.json",
-				Detail: "Adds PermissionRequest, PreToolUse, PostToolUse, " +
-					"PostToolUseFailure, PreCompact, and Stop hook entries that POST " +
+				// Count and event list are derived from installedHookEvents, never
+				// restated: this copy is the consent contract, and hand-maintaining
+				// it is how it came to promise six entries against a seven-event
+				// install (#1173's Notification hook, undisclosed until #1356).
+				Touches: fmt.Sprintf("Writes %d hook entries to ~/.claude/settings.json",
+					len(installedHookEvents)),
+				Detail: "Adds " + hookjson.EventList(installedHookEvents) +
+					" hook entries that POST " +
 					"the hook payload to the local daemon at " + hookEndpointURL() +
 					" via Claude Code's native http hook (no shell/curl). Toggling " +
 					"off removes exactly these entries (also available via " +

--- a/core/adapters/inbound/agents/claudecode/hookdisclosure_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookdisclosure_test.go
@@ -1,0 +1,20 @@
+// hookdisclosure_test.go wires the Claude Code hooks permission into the
+// shared issue #1356 contract: the consent copy the user reads before granting
+// names every event installedHookEvents installs, and no event it doesn't.
+// This adapter is where the contract was found failing — the copy declared six
+// entries against a seven-event install (#1173's Notification hook).
+package claudecode
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DisclosureMatchesInstalled(t *testing.T) {
+	contracttesting.AssertHookDisclosureMatchesInstalled(t, contracttesting.HookDisclosure{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+	})
+}

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -1,7 +1,9 @@
 // hooks.go provides the HTTP handler for receiving Claude Code hook events.
-// Claude Code fires hooks on PermissionRequest, PreToolUse, PostToolUse,
-// PostToolUseFailure, PreCompact and Stop — the daemon uses these to surface
-// user-blocking and turn-done state in the classifier. PermissionRequest covers
+// The events we install are listed once, in installedHookEvents
+// (hookinstaller.go); this comment deliberately does not restate them, because
+// the copy that did drifted to six for the whole of #1173's seven-event install
+// (#1356). The daemon uses them to surface user-blocking and turn-done state in
+// the classifier. The roles worth calling out: PermissionRequest covers
 // permission gates (issue #108); PreToolUse on AskUserQuestion / ExitPlanMode
 // covers user-input overlays that block the agent before the transcript is
 // flushed (issue #307); Stop is the authoritative per-turn done signal

--- a/core/adapters/inbound/agents/codex/agent.go
+++ b/core/adapters/inbound/agents/codex/agent.go
@@ -1,8 +1,6 @@
 package codex
 
 import (
-	"fmt"
-
 	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/permission"
@@ -72,8 +70,7 @@ func Agent() agent.Agent {
 				// Derived from installedHookEvents rather than restated — see the
 				// same note on claudecode's hooks permission (#1356). Codex's copy
 				// happened to be accurate; the contract is what keeps it so.
-				Touches: fmt.Sprintf("Writes %d hook entries to ~/.codex/hooks.json",
-					len(installedHookEvents)),
+				Touches: hookjson.EntriesTouched("~/.codex/hooks.json", installedHookEvents),
 				Detail: "Adds " + hookjson.EventList(installedHookEvents) + " hooks to " +
 					"~/.codex/hooks.json (a dedicated file, never config.toml) that " +
 					"POST the hook payload to the local daemon at " + hookEndpointURL() +

--- a/core/adapters/inbound/agents/codex/agent.go
+++ b/core/adapters/inbound/agents/codex/agent.go
@@ -1,6 +1,9 @@
 package codex
 
 import (
+	"fmt"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/permission"
 )
@@ -66,8 +69,12 @@ func Agent() agent.Agent {
 				Kind:            permission.KindModify,
 				Title:           "Install Codex hooks",
 				FeatureUnlocked: "Instant waiting/ready detection (approval prompts, turn end)",
-				Touches:         "Writes hook entries to ~/.codex/hooks.json",
-				Detail: "Adds PermissionRequest, PostToolUse and Stop hooks to " +
+				// Derived from installedHookEvents rather than restated — see the
+				// same note on claudecode's hooks permission (#1356). Codex's copy
+				// happened to be accurate; the contract is what keeps it so.
+				Touches: fmt.Sprintf("Writes %d hook entries to ~/.codex/hooks.json",
+					len(installedHookEvents)),
+				Detail: "Adds " + hookjson.EventList(installedHookEvents) + " hooks to " +
 					"~/.codex/hooks.json (a dedicated file, never config.toml) that " +
 					"POST the hook payload to the local daemon at " + hookEndpointURL() +
 					" via curl. PermissionRequest drives a live waiting transition " +

--- a/core/adapters/inbound/agents/codex/hookdisclosure_test.go
+++ b/core/adapters/inbound/agents/codex/hookdisclosure_test.go
@@ -1,0 +1,20 @@
+// hookdisclosure_test.go wires the Codex hooks permission into the shared
+// issue #1356 contract. Codex's copy was already accurate when the contract
+// landed, so this is a lock rather than a defect test — it is here because the
+// contract's value is being wired by every hook-installing adapter, not only
+// the one that was caught drifting.
+package codex
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DisclosureMatchesInstalled(t *testing.T) {
+	contracttesting.AssertHookDisclosureMatchesInstalled(t, contracttesting.HookDisclosure{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+	})
+}

--- a/core/adapters/inbound/agents/hookjson/disclosure.go
+++ b/core/adapters/inbound/agents/hookjson/disclosure.go
@@ -1,0 +1,30 @@
+// disclosure.go renders the event list an adapter's consent copy shows the
+// user (issue #1356). The wizard's Touches/Detail text is the consent contract
+// for a modify-kind permission — it is what the user reads before granting —
+// so it has to name what the installer actually writes. Restating the list by
+// hand is what let Claude Code's copy sit at six events for the whole of
+// #1173's seven-event install; deriving it from the same slice the installer
+// consumes makes that drift unrepresentable rather than merely tested for.
+package hookjson
+
+import "strings"
+
+// EventList renders events as prose for consent copy: "A", "A and B",
+// "A, B, and C". Callers pass the same slice they put in Config.Events, so the
+// sentence and the install cannot disagree.
+//
+// The serial comma is deliberate and uniform across adapters: the contract
+// assertion checks that every installed event is named, and a caller that
+// hand-tuned the punctuation per adapter would be back to maintaining prose.
+func EventList(events []string) string {
+	switch len(events) {
+	case 0:
+		return ""
+	case 1:
+		return events[0]
+	case 2:
+		return events[0] + " and " + events[1]
+	default:
+		return strings.Join(events[:len(events)-1], ", ") + ", and " + events[len(events)-1]
+	}
+}

--- a/core/adapters/inbound/agents/hookjson/disclosure.go
+++ b/core/adapters/inbound/agents/hookjson/disclosure.go
@@ -7,7 +7,19 @@
 // consumes makes that drift unrepresentable rather than merely tested for.
 package hookjson
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+// EntriesTouched renders the Touches line of a hooks permission: "Writes N
+// hook entries to <path>". Both the number and the noun live here rather than
+// in each adapter, so a third adapter cannot state a count that disagrees with
+// its install, and cannot word the sentence in a way the contract assertion
+// (which reads the count back out of the copy) fails to recognize.
+func EntriesTouched(path string, events []string) string {
+	return fmt.Sprintf("Writes %d hook entries to %s", len(events), path)
+}
 
 // EventList renders events as prose for consent copy: "A", "A and B",
 // "A, B, and C". Callers pass the same slice they put in Config.Events, so the

--- a/core/adapters/inbound/agents/hookjson/disclosure_test.go
+++ b/core/adapters/inbound/agents/hookjson/disclosure_test.go
@@ -1,0 +1,25 @@
+package hookjson
+
+import "testing"
+
+func TestEventList(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []string
+		want   string
+	}{
+		{"empty", nil, ""},
+		{"one", []string{"Stop"}, "Stop"},
+		{"two", []string{"PostToolUse", "Stop"}, "PostToolUse and Stop"},
+		{"three", []string{"PermissionRequest", "PostToolUse", "Stop"},
+			"PermissionRequest, PostToolUse, and Stop"},
+		{"many", []string{"A", "B", "C", "D"}, "A, B, C, and D"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EventList(tt.events); got != tt.want {
+				t.Errorf("EventList(%v) = %q, want %q", tt.events, got, tt.want)
+			}
+		})
+	}
+}

--- a/core/domain/session/hook_events_test.go
+++ b/core/domain/session/hook_events_test.go
@@ -73,23 +73,27 @@ func hookEventConstants(t *testing.T) map[string]string {
 		if err != nil {
 			t.Fatalf("parse %s: %v", name, err)
 		}
-		// Top-level const declarations only: a ValueSpec inside a function body
-		// is a local, and a var is not part of the event vocabulary.
-		for _, decl := range file.Decls {
-			gen, ok := decl.(*ast.GenDecl)
-			if !ok || gen.Tok != token.CONST {
-				continue
-			}
-			for _, spec := range gen.Specs {
-				value, ok := spec.(*ast.ValueSpec)
-				if !ok {
-					continue
-				}
+		collectFileConstants(t, name, file, found)
+	}
+	return found
+}
+
+// collectFileConstants adds one file's top-level Hook* string constants to
+// found. Top-level const declarations only: a ValueSpec inside a function body
+// is a local, and a var is not part of the package's event vocabulary.
+func collectFileConstants(t *testing.T, name string, file *ast.File, found map[string]string) {
+	t.Helper()
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			if value, ok := spec.(*ast.ValueSpec); ok {
 				collectHookConstants(t, name, value, found)
 			}
 		}
 	}
-	return found
 }
 
 // collectHookConstants adds spec's Hook* string constants to found. A Hook*

--- a/core/domain/session/hook_events_test.go
+++ b/core/domain/session/hook_events_test.go
@@ -1,0 +1,51 @@
+package session
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+// hookConstPattern matches one tab-indented `HookXxx = "Value"` const
+// declaration in hook_signal.go. It deliberately does not match the
+// AllHookEvents var's entries (no `=`, no string literal) nor AllHookEvents
+// itself (no word boundary before "Hook" in "AllHookEvents").
+var hookConstPattern = regexp.MustCompile(`(?m)^\tHook\w* += +"([^"]+)"`)
+
+// TestAllHookEvents_CoversEveryConstant is the guard that keeps AllHookEvents
+// from becoming the very thing issue #1356 was about: a hand-maintained
+// restatement of a list, drifting silently from it. AllHookEvents is the
+// universe contracttesting.AssertHookDisclosureMatchesInstalled checks an
+// adapter's consent copy against, so a constant missing from it weakens that
+// contract rather than breaking anything loudly.
+//
+// Reading the package's own source is the only mechanical route: constants are
+// erased at compile time, so there is nothing to reflect over.
+func TestAllHookEvents_CoversEveryConstant(t *testing.T) {
+	src, err := os.ReadFile("hook_signal.go")
+	if err != nil {
+		t.Fatalf("read hook_signal.go: %v", err)
+	}
+	matches := hookConstPattern.FindAllStringSubmatch(string(src), -1)
+	if len(matches) == 0 {
+		t.Fatal("no Hook* constants found in hook_signal.go — the scan pattern has drifted from the source")
+	}
+
+	listed := make(map[string]bool, len(AllHookEvents))
+	for _, e := range AllHookEvents {
+		listed[e] = true
+	}
+
+	declared := make(map[string]bool, len(matches))
+	for _, m := range matches {
+		declared[m[1]] = true
+		if !listed[m[1]] {
+			t.Errorf("hook event %q is declared as a constant but missing from AllHookEvents", m[1])
+		}
+	}
+	for _, e := range AllHookEvents {
+		if !declared[e] {
+			t.Errorf("AllHookEvents lists %q, which no Hook* constant declares", e)
+		}
+	}
+}

--- a/core/domain/session/hook_events_test.go
+++ b/core/domain/session/hook_events_test.go
@@ -1,51 +1,99 @@
 package session
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
-	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 )
-
-// hookConstPattern matches one tab-indented `HookXxx = "Value"` const
-// declaration in hook_signal.go. It deliberately does not match the
-// AllHookEvents var's entries (no `=`, no string literal) nor AllHookEvents
-// itself (no word boundary before "Hook" in "AllHookEvents").
-var hookConstPattern = regexp.MustCompile(`(?m)^\tHook\w* += +"([^"]+)"`)
 
 // TestAllHookEvents_CoversEveryConstant is the guard that keeps AllHookEvents
 // from becoming the very thing issue #1356 was about: a hand-maintained
 // restatement of a list, drifting silently from it. AllHookEvents is the
 // universe contracttesting.AssertHookDisclosureMatchesInstalled checks an
 // adapter's consent copy against, so a constant missing from it weakens that
-// contract rather than breaking anything loudly.
+// contract silently rather than breaking anything loudly.
 //
-// Reading the package's own source is the only mechanical route: constants are
-// erased at compile time, so there is nothing to reflect over.
+// It parses the package's source rather than scanning it with a regexp:
+// constants are erased at compile time so there is nothing to reflect over, and
+// a pattern tight enough to read one file's current formatting fails *open* on
+// every other legal spelling — a typed const (`HookX string = "x"`), an
+// ungrouped `const HookX = "x"` (live style elsewhere in this repo), or a
+// constant added in another file of the package. Failing open is the one
+// failure mode a drift guard cannot have.
 func TestAllHookEvents_CoversEveryConstant(t *testing.T) {
-	src, err := os.ReadFile("hook_signal.go")
-	if err != nil {
-		t.Fatalf("read hook_signal.go: %v", err)
-	}
-	matches := hookConstPattern.FindAllStringSubmatch(string(src), -1)
-	if len(matches) == 0 {
-		t.Fatal("no Hook* constants found in hook_signal.go — the scan pattern has drifted from the source")
+	declared := hookEventConstants(t)
+	if len(declared) == 0 {
+		t.Fatal("no Hook* string constants found in package session — the scan has stopped finding what it checks")
 	}
 
 	listed := make(map[string]bool, len(AllHookEvents))
 	for _, e := range AllHookEvents {
 		listed[e] = true
 	}
-
-	declared := make(map[string]bool, len(matches))
-	for _, m := range matches {
-		declared[m[1]] = true
-		if !listed[m[1]] {
-			t.Errorf("hook event %q is declared as a constant but missing from AllHookEvents", m[1])
+	for name, value := range declared {
+		if !listed[value] {
+			t.Errorf("hook event %q (%s) is declared but missing from AllHookEvents", value, name)
 		}
 	}
+
+	values := make(map[string]bool, len(declared))
+	for _, value := range declared {
+		values[value] = true
+	}
 	for _, e := range AllHookEvents {
-		if !declared[e] {
+		if !values[e] {
 			t.Errorf("AllHookEvents lists %q, which no Hook* constant declares", e)
 		}
 	}
+}
+
+// hookEventConstants returns every package-level `Hook*` identifier bound to a
+// string literal, as name → value. go test runs with the package directory as
+// its working directory, so "." is the package under test; a parse failure is
+// fatal rather than an empty result.
+func hookEventConstants(t *testing.T) map[string]string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	found := map[string]string{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			spec, ok := n.(*ast.ValueSpec)
+			if !ok {
+				return true
+			}
+			for i, ident := range spec.Names {
+				if !strings.HasPrefix(ident.Name, "Hook") || i >= len(spec.Values) {
+					continue
+				}
+				lit, ok := spec.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				value, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					t.Fatalf("unquote %s = %s: %v", ident.Name, lit.Value, err)
+				}
+				found[ident.Name] = value
+			}
+			return true
+		})
+	}
+	return found
 }

--- a/core/domain/session/hook_events_test.go
+++ b/core/domain/session/hook_events_test.go
@@ -73,27 +73,47 @@ func hookEventConstants(t *testing.T) map[string]string {
 		if err != nil {
 			t.Fatalf("parse %s: %v", name, err)
 		}
-		ast.Inspect(file, func(n ast.Node) bool {
-			spec, ok := n.(*ast.ValueSpec)
-			if !ok {
-				return true
+		// Top-level const declarations only: a ValueSpec inside a function body
+		// is a local, and a var is not part of the event vocabulary.
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
 			}
-			for i, ident := range spec.Names {
-				if !strings.HasPrefix(ident.Name, "Hook") || i >= len(spec.Values) {
+			for _, spec := range gen.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok {
 					continue
 				}
-				lit, ok := spec.Values[i].(*ast.BasicLit)
-				if !ok || lit.Kind != token.STRING {
-					continue
-				}
-				value, err := strconv.Unquote(lit.Value)
-				if err != nil {
-					t.Fatalf("unquote %s = %s: %v", ident.Name, lit.Value, err)
-				}
-				found[ident.Name] = value
+				collectHookConstants(t, name, value, found)
 			}
-			return true
-		})
+		}
 	}
 	return found
+}
+
+// collectHookConstants adds spec's Hook* string constants to found. A Hook*
+// constant whose value is not a plain string literal — a concatenation, an
+// alias of another constant — is a hard failure rather than a skip: this guard
+// exists because failing open is the one thing a drift guard must not do, and
+// "I could not evaluate that one" is indistinguishable from "there was nothing
+// there" to everyone downstream.
+func collectHookConstants(t *testing.T, file string, spec *ast.ValueSpec, found map[string]string) {
+	t.Helper()
+	for i, ident := range spec.Names {
+		if !strings.HasPrefix(ident.Name, "Hook") || i >= len(spec.Values) {
+			continue
+		}
+		lit, ok := spec.Values[i].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			t.Fatalf("%s: %s is not bound to a plain string literal, so this guard cannot check "+
+				"it against AllHookEvents — spell it as a literal, or give the event constants a "+
+				"distinct type and filter on that rather than on the name prefix", file, ident.Name)
+		}
+		value, err := strconv.Unquote(lit.Value)
+		if err != nil {
+			t.Fatalf("%s: unquote %s = %s: %v", file, ident.Name, lit.Value, err)
+		}
+		found[ident.Name] = value
+	}
 }

--- a/core/domain/session/hook_signal.go
+++ b/core/domain/session/hook_signal.go
@@ -32,6 +32,27 @@ const (
 	HookNotification = "Notification"
 )
 
+// AllHookEvents is every hook event name the constants above define, in
+// declaration order. It is the universe an adapter's consent copy is checked
+// against by contracttesting.AssertHookDisclosureMatchesInstalled (issue
+// #1356): a name in here that the adapter's disclosure text mentions but does
+// not install is a promise it doesn't keep, in the opposite direction from the
+// #1173 drift that motivated the contract.
+//
+// Every constant above must appear here. That obligation is not left to
+// discipline — it is exactly the kind of hand-maintained restatement #1356 was
+// about — so TestAllHookEvents_CoversEveryConstant reads this file's own source
+// and fails on a constant that was never added.
+var AllHookEvents = []string{
+	HookPermissionRequest,
+	HookPreToolUse,
+	HookPostToolUse,
+	HookPostToolUseFailure,
+	HookPreCompact,
+	HookStop,
+	HookNotification,
+}
+
 // HookSignalEffect is what one hook event name does to a session's signal
 // holds. Release distinguishes the two directions: a hook either asserts a
 // signal (Release false) or retracts one (Release true).

--- a/core/internal/contracttesting/hook_disclosure.go
+++ b/core/internal/contracttesting/hook_disclosure.go
@@ -118,55 +118,72 @@ func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
 	named := wordsIn(disclosure)
 
 	t.Run("names_every_installed_event", func(t *testing.T) {
-		for _, event := range d.Installed {
-			if !named[event] {
-				t.Errorf("consent copy never names the %q hook, but the installer writes it — "+
-					"an undisclosed write to the user's config (#570)", event)
-			}
-		}
+		assertNamesEveryInstalledEvent(t, d.Installed, named)
 	})
-
 	t.Run("states_the_installed_count", func(t *testing.T) {
-		matches := entryCountPattern.FindAllStringSubmatch(disclosure, -1)
-		if len(matches) == 0 {
-			t.Fatalf("consent copy states no entry count; want %q", strconv.Itoa(len(d.Installed))+" hook entries")
-		}
-		for _, m := range matches {
-			stated, err := strconv.Atoi(m[1])
-			if err != nil {
-				t.Fatalf("unparseable entry count %q: %v", m[1], err)
-			}
-			if stated != len(d.Installed) {
-				t.Errorf("consent copy declares %d hook entries, installer writes %d",
-					stated, len(d.Installed))
-			}
-		}
+		assertStatesInstalledCount(t, d.Installed, disclosure)
 	})
-
 	t.Run("names_no_uninstalled_event", func(t *testing.T) {
-		installed := make(map[string]bool, len(d.Installed))
-		for _, event := range d.Installed {
-			installed[event] = true
-		}
-		allowed := make(map[string]bool, len(d.NonEventTerms))
-		for _, term := range d.NonEventTerms {
-			allowed[term] = true
-		}
-		// The two candidate sources overlap (every multi-word modelled name is
-		// in both), so they are merged before reporting: one over-promise in
-		// the copy should produce one failure line, not two. The contract's
-		// whole value is the message someone reads at 2am.
-		reported := map[string]bool{}
-		for _, name := range append(uninstalledNamesIn(named), eventShapedNamesIn(named)...) {
-			if installed[name] || allowed[name] || reported[name] {
-				continue
-			}
-			reported[name] = true
-			t.Errorf("consent copy names %q, which reads as a hook event but the installer "+
-				"does not write it — the disclosure promises more than it does; install it, "+
-				"reword the copy, or list it in NonEventTerms", name)
-		}
+		assertNamesNoUninstalledEvent(t, d, named)
 	})
+}
+
+// assertNamesEveryInstalledEvent is the consent-critical arm: an installed
+// event the copy never names is a write the user was not told about.
+func assertNamesEveryInstalledEvent(t *testing.T, installed []string, named map[string]bool) {
+	t.Helper()
+	for _, event := range installed {
+		if !named[event] {
+			t.Errorf("consent copy never names the %q hook, but the installer writes it — "+
+				"an undisclosed write to the user's config (#570)", event)
+		}
+	}
+}
+
+// assertStatesInstalledCount checks every count the copy states, not just the
+// first: a permission that mentions its entry count twice must not have them
+// disagree.
+func assertStatesInstalledCount(t *testing.T, installed []string, disclosure string) {
+	t.Helper()
+	matches := entryCountPattern.FindAllStringSubmatch(disclosure, -1)
+	if len(matches) == 0 {
+		t.Fatalf("consent copy states no entry count; want %q",
+			strconv.Itoa(len(installed))+" hook entries")
+	}
+	for _, m := range matches {
+		stated, err := strconv.Atoi(m[1])
+		if err != nil {
+			t.Fatalf("unparseable entry count %q: %v", m[1], err)
+		}
+		if stated != len(installed) {
+			t.Errorf("consent copy declares %d hook entries, installer writes %d",
+				stated, len(installed))
+		}
+	}
+}
+
+// assertNamesNoUninstalledEvent is the over-promise arm. Its two candidate
+// sources overlap (every multi-word modelled name is in both), so they are
+// merged before reporting: one wrong name should produce one failure line, not
+// two. The contract's whole value is the message someone reads at 2am.
+func assertNamesNoUninstalledEvent(t *testing.T, d HookDisclosure, named map[string]bool) {
+	t.Helper()
+	exempt := make(map[string]bool, len(d.Installed)+len(d.NonEventTerms))
+	for _, event := range d.Installed {
+		exempt[event] = true
+	}
+	for _, term := range d.NonEventTerms {
+		exempt[term] = true
+	}
+	for _, name := range append(uninstalledNamesIn(named), eventShapedNamesIn(named)...) {
+		if exempt[name] {
+			continue
+		}
+		exempt[name] = true // reported once
+		t.Errorf("consent copy names %q, which reads as a hook event but the installer "+
+			"does not write it — the disclosure promises more than it does; install it, "+
+			"reword the copy, or list it in NonEventTerms", name)
+	}
 }
 
 // findPermission returns the declared permission with the given key.

--- a/core/internal/contracttesting/hook_disclosure.go
+++ b/core/internal/contracttesting/hook_disclosure.go
@@ -1,0 +1,132 @@
+// hook_disclosure.go holds the issue #1356 contract every hook-installing
+// agent adapter must satisfy: the consent copy the user reads before granting
+// the hooks permission names exactly the hook events the installer writes, and
+// states how many of them there are.
+//
+// Like AssertPermissionGated and AssertHookEndpointFollowsBindAddr it exists
+// because the obligation is one an adapter opts into rather than one the
+// compiler can see. Claude Code's copy said "6 hook entries" and named six
+// events for the whole of #1173's seven-event install: the Notification hook
+// was written to the user's settings.json without ever being disclosed. That is
+// a #570 consent violation, not a docs typo — the wizard's Touches/Detail text
+// *is* what the user consents to — and nothing bound the prose to the list, so
+// it drifted silently at N=2 adapters with one added event.
+package contracttesting
+
+import (
+	"regexp"
+	"strconv"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/domain/session"
+)
+
+// entryCountPattern extracts the entry count an adapter's consent copy states
+// ("Writes 7 hook entries to ~/.claude/settings.json"). Both singular and
+// plural are accepted so a one-event adapter is not forced into bad grammar.
+var entryCountPattern = regexp.MustCompile(`(\d+) hook entr(?:y|ies)`)
+
+// HookDisclosure wires one adapter's hooks permission into
+// AssertHookDisclosureMatchesInstalled. Installed is the same slice the
+// adapter hands to hookjson.Config.Events — pass the variable, never a
+// hand-written copy of it, or the contract checks the declaration against
+// another declaration instead of against the install.
+type HookDisclosure struct {
+	// Agent is the adapter's registration, exactly as the daemon consumes it.
+	Agent agent.Agent
+	// PermissionKey is the hooks permission's key within that registration.
+	PermissionKey string
+	// Installed is the installer's event list.
+	Installed []string
+}
+
+// AssertHookDisclosureMatchesInstalled runs the issue #1356 contract against d:
+// the declared permission is modify-kind, its Touches/Detail text names every
+// installed event, states the right number of entries, and names no hook event
+// the adapter does not install.
+//
+// All three obligations read Touches and Detail together, because which of the
+// two carries a given fact is a presentation choice — the wizard row shows
+// Touches and the (i) expander shows Detail, and the user sees both before
+// granting.
+//
+// The third obligation is checked against session.AllHookEvents, the universe
+// of names the domain defines; TestAllHookEvents_CoversEveryConstant keeps that
+// universe from drifting from the constants themselves.
+func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
+	t.Helper()
+
+	perm, ok := findPermission(d.Agent, d.PermissionKey)
+	if !ok {
+		t.Fatalf("agent %q declares no permission with key %q", d.Agent.Identity.Name, d.PermissionKey)
+	}
+	if perm.Kind != permission.KindModify {
+		t.Errorf("hooks permission %q is %v, want %v — installing hooks writes to the user's config",
+			d.PermissionKey, perm.Kind, permission.KindModify)
+	}
+	if len(d.Installed) == 0 {
+		t.Fatal("HookDisclosure.Installed is empty — pass the installer's event list")
+	}
+	disclosure := perm.Touches + "\n" + perm.Detail
+
+	t.Run("names_every_installed_event", func(t *testing.T) {
+		for _, event := range d.Installed {
+			if !mentions(disclosure, event) {
+				t.Errorf("consent copy never names the %q hook, but the installer writes it — "+
+					"an undisclosed write to the user's config (#570)", event)
+			}
+		}
+	})
+
+	t.Run("states_the_installed_count", func(t *testing.T) {
+		matches := entryCountPattern.FindAllStringSubmatch(disclosure, -1)
+		if len(matches) == 0 {
+			t.Fatalf("consent copy states no entry count; want %q", strconv.Itoa(len(d.Installed))+" hook entries")
+		}
+		for _, m := range matches {
+			stated, err := strconv.Atoi(m[1])
+			if err != nil {
+				t.Fatalf("unparseable entry count %q: %v", m[1], err)
+			}
+			if stated != len(d.Installed) {
+				t.Errorf("consent copy declares %d hook entries, installer writes %d",
+					stated, len(d.Installed))
+			}
+		}
+	})
+
+	t.Run("names_no_uninstalled_event", func(t *testing.T) {
+		installed := make(map[string]bool, len(d.Installed))
+		for _, event := range d.Installed {
+			installed[event] = true
+		}
+		for _, event := range session.AllHookEvents {
+			if installed[event] {
+				continue
+			}
+			if mentions(disclosure, event) {
+				t.Errorf("consent copy names the %q hook, which the installer does not write — "+
+					"the disclosure promises more than it does", event)
+			}
+		}
+	})
+}
+
+// findPermission returns the declared permission with the given key.
+func findPermission(a agent.Agent, key string) (agent.Permission, bool) {
+	for _, p := range a.Permissions {
+		if p.Key == key {
+			return p, true
+		}
+	}
+	return agent.Permission{}, false
+}
+
+// mentions reports whether text names event as a whole word. Substring
+// matching would not do: "PostToolUse" occurs inside "PostToolUseFailure", so
+// copy that named only the latter would read as disclosing both.
+func mentions(text, event string) bool {
+	return regexp.MustCompile(`\b` + regexp.QuoteMeta(event) + `\b`).MatchString(text)
+}

--- a/core/internal/contracttesting/hook_disclosure.go
+++ b/core/internal/contracttesting/hook_disclosure.go
@@ -28,11 +28,34 @@ import (
 // plural are accepted so a one-event adapter is not forced into bad grammar.
 var entryCountPattern = regexp.MustCompile(`(\d+) hook entr(?:y|ies)`)
 
+// eventShapedToken matches a CamelCase identifier of two or more words —
+// "SessionStart", "UserPromptSubmit", "PostToolUseFailure". Every agent CLI
+// names its hook events this way, and an agent fires far more of them than
+// irrlicht models, so session.AllHookEvents alone cannot see copy that promises
+// a SessionStart hook nobody installs. Matching the *shape* rather than a
+// second hand-kept roster of upstream names is deliberate: a roster is the kind
+// of list #1356 is about.
+//
+// Single-word event names ("Stop", "Notification") are outside this shape and
+// are covered by the session.AllHookEvents arm instead. The two overlap, and
+// between them they cover every name either source knows.
+var eventShapedToken = regexp.MustCompile(`\b[A-Z][a-z]+(?:[A-Z][a-z]+)+\b`)
+
 // HookDisclosure wires one adapter's hooks permission into
 // AssertHookDisclosureMatchesInstalled. Installed is the same slice the
 // adapter hands to hookjson.Config.Events — pass the variable, never a
 // hand-written copy of it, or the contract checks the declaration against
 // another declaration instead of against the install.
+//
+// That instruction is not enforced here, which bounds what the count
+// obligation proves: it is len(the slice the test passed), not a count read
+// back off a written config file. For today's two adapters the gap is closed
+// elsewhere — both pass the same installedHookEvents variable to
+// AssertHookEndpointFollowsBindAddr, which does run a real install into a temp
+// home and reads every event's entry back, and hookjson.EnsureInstalled writes
+// exactly one matcher group per event. A third adapter that wires this contract
+// with a literal slice and skips that one would get a weaker check than it
+// looks like.
 type HookDisclosure struct {
 	// Agent is the adapter's registration, exactly as the daemon consumes it.
 	Agent agent.Agent
@@ -40,6 +63,11 @@ type HookDisclosure struct {
 	PermissionKey string
 	// Installed is the installer's event list.
 	Installed []string
+	// NonEventTerms are CamelCase terms the copy legitimately mentions that
+	// are not hook events — a tool name in a matcher, a type name. Usually
+	// empty. Every entry is a name the over-promise arm stops policing, so
+	// keep the list short and say in a comment why each one is there.
+	NonEventTerms []string
 }
 
 // AssertHookDisclosureMatchesInstalled runs the issue #1356 contract against d:
@@ -52,9 +80,13 @@ type HookDisclosure struct {
 // Touches and the (i) expander shows Detail, and the user sees both before
 // granting.
 //
-// The third obligation is checked against session.AllHookEvents, the universe
-// of names the domain defines; TestAllHookEvents_CoversEveryConstant keeps that
-// universe from drifting from the constants themselves.
+// The third obligation draws candidate names from two overlapping sources:
+// session.AllHookEvents (the universe the domain models, kept complete by
+// TestAllHookEvents_CoversEveryConstant) and every event-shaped CamelCase token
+// in the copy itself, which reaches upstream events irrlicht has no constant
+// for. Neither direction is the consent-critical one — an over-promise doesn't
+// hide a write from the user — but a disclosure that names hooks the daemon
+// never installs is still not the contract the user agreed to.
 func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
 	t.Helper()
 
@@ -102,14 +134,27 @@ func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
 		for _, event := range d.Installed {
 			installed[event] = true
 		}
+		allowed := make(map[string]bool, len(d.NonEventTerms))
+		for _, term := range d.NonEventTerms {
+			allowed[term] = true
+		}
+		// Two candidate sources, deliberately overlapping: the names the
+		// domain models (which includes single-word ones), and every
+		// event-shaped token actually present in the copy (which reaches
+		// upstream events irrlicht has no constant for).
 		for _, event := range session.AllHookEvents {
-			if installed[event] {
+			if installed[event] || allowed[event] || !mentions(disclosure, event) {
 				continue
 			}
-			if mentions(disclosure, event) {
-				t.Errorf("consent copy names the %q hook, which the installer does not write — "+
-					"the disclosure promises more than it does", event)
+			t.Errorf("consent copy names the %q hook, which the installer does not write — "+
+				"the disclosure promises more than it does", event)
+		}
+		for _, token := range eventShapedToken.FindAllString(disclosure, -1) {
+			if installed[token] || allowed[token] {
+				continue
 			}
+			t.Errorf("consent copy names %q, which reads as a hook event but the installer "+
+				"does not write it — install it, reword the copy, or list it in NonEventTerms", token)
 		}
 	})
 }

--- a/core/internal/contracttesting/hook_disclosure.go
+++ b/core/internal/contracttesting/hook_disclosure.go
@@ -15,6 +15,7 @@ package contracttesting
 
 import (
 	"regexp"
+	"sort"
 	"strconv"
 	"testing"
 
@@ -39,7 +40,14 @@ var entryCountPattern = regexp.MustCompile(`(\d+) hook entr(?:y|ies)`)
 // Single-word event names ("Stop", "Notification") are outside this shape and
 // are covered by the session.AllHookEvents arm instead. The two overlap, and
 // between them they cover every name either source knows.
-var eventShapedToken = regexp.MustCompile(`\b[A-Z][a-z]+(?:[A-Z][a-z]+)+\b`)
+//
+// Anchored because it is applied to whole words, not scanned across prose.
+var eventShapedToken = regexp.MustCompile(`^[A-Z][a-z]+(?:[A-Z][a-z]+)+$`)
+
+// wordPattern splits consent copy into identifier-shaped words. Deliberately
+// includes digits and underscores so "cli_version" is one word rather than two,
+// which keeps a fragment from being mistaken for an event name.
+var wordPattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9_]*`)
 
 // HookDisclosure wires one adapter's hooks permission into
 // AssertHookDisclosureMatchesInstalled. Installed is the same slice the
@@ -102,10 +110,16 @@ func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
 		t.Fatal("HookDisclosure.Installed is empty — pass the installer's event list")
 	}
 	disclosure := perm.Touches + "\n" + perm.Detail
+	// One tokenization serves both the "is this name present" and the "what
+	// event-shaped names are present" questions. Whole-word matching is what
+	// makes the first safe: "PostToolUse" occurs inside "PostToolUseFailure",
+	// so a substring test on copy naming only the latter would read as
+	// disclosing both.
+	named := wordsIn(disclosure)
 
 	t.Run("names_every_installed_event", func(t *testing.T) {
 		for _, event := range d.Installed {
-			if !mentions(disclosure, event) {
+			if !named[event] {
 				t.Errorf("consent copy never names the %q hook, but the installer writes it — "+
 					"an undisclosed write to the user's config (#570)", event)
 			}
@@ -138,23 +152,19 @@ func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
 		for _, term := range d.NonEventTerms {
 			allowed[term] = true
 		}
-		// Two candidate sources, deliberately overlapping: the names the
-		// domain models (which includes single-word ones), and every
-		// event-shaped token actually present in the copy (which reaches
-		// upstream events irrlicht has no constant for).
-		for _, event := range session.AllHookEvents {
-			if installed[event] || allowed[event] || !mentions(disclosure, event) {
+		// The two candidate sources overlap (every multi-word modelled name is
+		// in both), so they are merged before reporting: one over-promise in
+		// the copy should produce one failure line, not two. The contract's
+		// whole value is the message someone reads at 2am.
+		reported := map[string]bool{}
+		for _, name := range append(uninstalledNamesIn(named), eventShapedNamesIn(named)...) {
+			if installed[name] || allowed[name] || reported[name] {
 				continue
 			}
-			t.Errorf("consent copy names the %q hook, which the installer does not write — "+
-				"the disclosure promises more than it does", event)
-		}
-		for _, token := range eventShapedToken.FindAllString(disclosure, -1) {
-			if installed[token] || allowed[token] {
-				continue
-			}
+			reported[name] = true
 			t.Errorf("consent copy names %q, which reads as a hook event but the installer "+
-				"does not write it — install it, reword the copy, or list it in NonEventTerms", token)
+				"does not write it — the disclosure promises more than it does; install it, "+
+				"reword the copy, or list it in NonEventTerms", name)
 		}
 	})
 }
@@ -169,9 +179,38 @@ func findPermission(a agent.Agent, key string) (agent.Permission, bool) {
 	return agent.Permission{}, false
 }
 
-// mentions reports whether text names event as a whole word. Substring
-// matching would not do: "PostToolUse" occurs inside "PostToolUseFailure", so
-// copy that named only the latter would read as disclosing both.
-func mentions(text, event string) bool {
-	return regexp.MustCompile(`\b` + regexp.QuoteMeta(event) + `\b`).MatchString(text)
+// wordsIn returns the set of whole words in text. Hook event names are single
+// identifiers, so set membership is exactly whole-word matching — and one scan
+// serves every arm instead of a regexp compiled per candidate name.
+func wordsIn(text string) map[string]bool {
+	words := map[string]bool{}
+	for _, w := range wordPattern.FindAllString(text, -1) {
+		words[w] = true
+	}
+	return words
+}
+
+// uninstalledNamesIn returns the modelled hook event names present in words, in
+// the domain's declaration order so failures are deterministic.
+func uninstalledNamesIn(words map[string]bool) []string {
+	var found []string
+	for _, event := range session.AllHookEvents {
+		if words[event] {
+			found = append(found, event)
+		}
+	}
+	return found
+}
+
+// eventShapedNamesIn returns the words that read as hook event names without
+// the domain necessarily modelling them, sorted so failures are deterministic.
+func eventShapedNamesIn(words map[string]bool) []string {
+	var found []string
+	for word := range words {
+		if eventShapedToken.MatchString(word) {
+			found = append(found, word)
+		}
+	}
+	sort.Strings(found)
+	return found
 }


### PR DESCRIPTION
Closes #1356

## What

The Claude Code `hooks` permission told the user it writes **6** hook entries and named six events. The installer has written **seven** since #1173 added `HookNotification`. The wizard's `Touches`/`Detail` text *is* the #570 consent contract — it is what the user reads before granting — so an entry it does not name is an undisclosed write to `~/.claude/settings.json`, not a docs typo.

- **Corrected the copy**, and — the actual fix — **derived it**: both hook-installing adapters now build the count and the event enumeration from `installedHookEvents` via a new shared `hookjson.EventList`, so the sentence and the install cannot disagree. Codex's copy was already accurate; it is derived too, so it stays that way.
- **New contract family** `contracttesting.AssertHookDisclosureMatchesInstalled` (`core/internal/contracttesting/hook_disclosure.go`), wired by `claudecode` and `codex` in one call each. Three obligations: the copy names every installed event, states the right entry count, and names no hook event the adapter does not install.
- The third obligation needs a universe of event names, so `session.AllHookEvents` was added next to the constants — and, since a hand-kept restatement is exactly what this issue is about, `TestAllHookEvents_CoversEveryConstant` scans `hook_signal.go`'s own source rather than trusting discipline.

## Defect test, seen RED first

Written and run **before** any change to `agent.go`:

```
$ go test ./core/adapters/inbound/agents/claudecode/ -run TestHooksPermission_DisclosureMatchesInstalled -count=1 -v
=== RUN   TestHooksPermission_DisclosureMatchesInstalled
    hook_disclosure.go:77: consent copy never names the "Notification" hook, but the installer writes it — an undisclosed write to the user's config (#570)
    hook_disclosure.go:94: consent copy declares 6 hook entries, installer writes 7
--- FAIL: TestHooksPermission_DisclosureMatchesInstalled/names_every_installed_event
--- FAIL: TestHooksPermission_DisclosureMatchesInstalled/states_the_installed_count
--- PASS: TestHooksPermission_DisclosureMatchesInstalled/names_no_uninstalled_event
FAIL	irrlicht/core/adapters/inbound/agents/claudecode	0.350s
```

Both failing arms are the real defect (7 installed vs 6 declared, `Notification` unnamed). Green after the fix.

## Deliberate mutations, one per obligation

A contract assertion passes by construction against a correct adapter, so each arm was made to fail on purpose and reverted (AGENTS.md):

| # | Mutation | Observed failure |
|---|---|---|
| M1 | claudecode `Touches` count hand-restated as `6` | `hook_disclosure.go:94: consent copy declares 6 hook entries, installer writes 7` |
| M2 | claudecode `Detail` rendered from `installedHookEvents[:len-1]` | `hook_disclosure.go:77: consent copy never names the "Notification" hook, but the installer writes it` |
| M3 | codex `Detail` also names `PreCompact`, which codex never installs | `hook_disclosure.go:110: consent copy names the "PreCompact" hook, which the installer does not write` |
| M4 | `HookNotification` dropped from `session.AllHookEvents` | `hook_events_test.go:43: hook event "Notification" is declared as a constant but missing from AllHookEvents` |

Codex's `TestHooksPermission_DisclosureMatchesInstalled` is a **lock**, not a defect test — codex's copy was already accurate, so it passes on `main` by construction. M3 is what proves it can fail.

## Verification

- `go test ./core/... -race -count=1` — green.
- `tools/preflight.sh` (unscoped) — **all 13 gates PASS**, including replay fixtures, both web suites, the ARS architecture gate, skill-file lint and the security scan.
- No frontend change needed: a repo-wide grep found the consent strings only in the two `agent.go` files, so the macOS app and the web dashboard both render them from the daemon's API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round (Phase 5)

A `medium`-effort review subagent returned 4 findings; 2 were confirmed holes in the **new contract itself** and are fixed in `7c04924e`, each with the reviewer's own mutation re-run and seen red:

| Finding | Was | Now |
|---|---|---|
| The `AllHookEvents` guard scanned source with a regexp tuned to one const spelling — a typed const, an ungrouped const, or a constant in another file of the package **passed silently** (a drift guard failing open) | `HookTyped string = "Typed"` omitted from `AllHookEvents` → **passed** | parses the package source; both probes now fail: `hook event "Typed" (HookTyped) is declared but missing from AllHookEvents`, and the same for an ungrouped const in another file |
| The over-promise arm only knew names the *domain* models, so copy claiming a `SessionStart`/`UserPromptSubmit` hook nobody installs was invisible | that exact mutation → **passed clean** | `consent copy names "SessionStart", which reads as a hook event but the installer does not write it` (and the same for `UserPromptSubmit`) |

Two findings were **not** fixed and are recorded rather than argued away:
- The count obligation compares `len(the slice the test passed)`, not entries read back off a written file. Bounded and documented in `HookDisclosure`'s doc comment, with the evidence for why today's two adapters are covered anyway (both pass the same `installedHookEvents` to `AssertHookEndpointFollowsBindAddr`, which *does* install into a temp home and read every entry back; `hookjson.EnsureInstalled` writes exactly one matcher group per event).
- Consolidating the two pre-existing `findPermission` copies in other test files — out of scope for this PR.

## /simplify pass (`702a967b`)

Tokenize the copy once instead of compiling a regexp per candidate name; merge the two candidate sources so one wrong name produces one failure line instead of two; move the `"Writes N hook entries to <path>"` sentence both adapters were building independently into `hookjson.EntriesTouched`, so the phrasing the contract reads back lives in one place; restrict the AST guard to top-level const declarations and make an unevaluatable `Hook*` constant a hard failure rather than a skip. All four mutations above were re-run after the refactor and are still red.

## Found while here — filed, not fixed: #1377

The `instructions` permission one entry below in the same `Agent()` literal has the **same defect**: its copy names the retired task-summary block (removed on apply since #1186) and never names the task-question block that *is* written. Verified by reading `applyInstructionBlocks` against the declared copy. Kept out of this PR to keep it scoped to hooks; #1377 also records the deeper seam a reviewer proposed (an `Installs []string` inventory on `agent.Permission` plus one contract over every `KindModify` permission), which would subsume this contract.

## CI status

All required checks green (`go-test`, `build-test`, `ars-gate`, both web suites, CodeQL, SonarCloud). `tools/preflight.sh` unscoped: **13/13 PASS**.

**CodeScene is red and deliberately left that way** — it is advisory, not a merge gate (AGENTS.md). It flagged Bumpy Road / deep nesting in the two new functions; `651b9930` addressed that by giving each obligation its own named function (the idiom `hook_endpoint.go` already uses), taking the delta from 2 files / 5 violations to 1 file / 2 and the code-health score from 8.68 to **9.54**. What remains is the two comparison loops inside a 25-line test; splitting those further would fragment the test for the linter's benefit rather than the reader's. Flagging it rather than chasing it, per AGENTS.md's guidance on advisory checks.
