### PR TITLE
feat(onboarding): add "of status --summary" and "of coverage --hooks"

### DIFF
--- a/.claude/skills/ir:onboarding-factory/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/SKILL.md
@@ -162,6 +162,33 @@ remain before reporting "done". `display_state` ∈ `observed` (terminal),
 `unobservable` / `n.a.` (terminal — documented, no recording), `unknown`
 (→ assess). A sweep is finished only when every cell is terminal.
 
+For "how far along is agent X" — a progress read, not a work-list — use the
+per-agent counts instead of scrolling the dump:
+
+```bash
+of status --summary                   # recorded / pending / blocked / unobservable / n/a / unknown, per agent
+of status --summary --agent <agent>   # one row; composes with --scenario too
+```
+
+Its buckets always sum to the agent's cell total, so nothing is hidden by the
+aggregation. **It is still not a work-list**: `--summary` gives you a count,
+never the cell ids, so deriving the next stage's work from it is the same
+mistake as deriving it from subagent prose. Enumerate from the full dump.
+
+To ask a different question of the same catalog — how much of the recorded
+corpus actually exercises the hook channel — use:
+
+```bash
+of coverage --hooks                   # per adapter: recordings carrying a hook_received event
+```
+
+It joins the catalog to the daemon's adapter registry, so it separates the two
+cases a raw count conflates: an adapter that **declares** a hooks permission and
+has zero hook-bearing recordings (a `GAP` — the regression net does not cover a
+channel the daemon depends on) from one that declares none (fine). Scope is
+catalog cells; the non-catalog `regressions/` tree is excluded and the output
+says so.
+
 ## Parallelism + ordering rules for sweeps
 
 - **`assess` fans out; the PARENT commits.** assess is read-only of the live
@@ -238,9 +265,9 @@ commits).
 or the built `of` binary). The verbs the skill drives:
 
 ```
-of status   [--agent a] [--scenario s] [--runs] [--json]   coverage / run-log
-of validate [--json]                                        schema + referential integrity
-of coverage [--json]                                        derived rollup
+of status   [--agent a] [--scenario s] [--runs] [--summary] [--json]  coverage / run-log
+of validate [--json]                                                  schema + referential integrity
+of coverage [--hooks] [--json]                                        derived rollup, or hook coverage
 of scenario add|update --name n [--id i] [--description d]
                        [--process-file f] [--acceptance-file f]
 of agent add --id i --name n --provider p [--min-version v] [--prereq p]...

--- a/tools/onboarding-factory/cmd/of/coverage.go
+++ b/tools/onboarding-factory/cmd/of/coverage.go
@@ -22,7 +22,7 @@ func runCoverage(args []string, stdout, stderr io.Writer) int {
 	fs := newFlagSet("of coverage")
 	var (
 		hooks    = fs.Bool("hooks", false, "report per-adapter hook_received coverage instead of the rollup")
-		asJSON   = fs.Bool("json", false, "emit JSON (the rollup is JSON either way)")
+		asJSON   = fs.Bool("json", false, "emit JSON (selects JSON vs text under --hooks; the rollup is JSON either way)")
 		repoRoot = fs.String("repo-root", ".", "repository root")
 	)
 	if err := fs.Parse(args); err != nil {
@@ -92,7 +92,7 @@ const hookRowFormat = "%-14s %14s %6d %11d %11d  %s\n"
 
 func printHookCoverageText(stdout io.Writer, rep hookcov.Report) {
 	fmt.Fprintln(stdout, "hook coverage — recordings containing a hook_received event, per adapter")
-	fmt.Fprintln(stdout, "scope: catalog cells only (replaydata/agents/<adapter>/scenarios); the non-catalog regressions/ tree is excluded")
+	fmt.Fprintln(stdout, "scope: cells on disk under replaydata/agents/<adapter>/scenarios; the non-catalog regressions/ tree is excluded")
 	fmt.Fprintln(stdout)
 	fmt.Fprintf(stdout, "%-14s %14s %6s %11s %11s  %s\n",
 		"adapter", "declares-hooks", "cells", "recordings", "with-hooks", "status")
@@ -105,8 +105,10 @@ func printHookCoverageText(stdout io.Writer, rep hookcov.Report) {
 
 	fmt.Fprintln(stdout)
 	if gaps := rep.Gaps(); len(gaps) > 0 {
-		fmt.Fprintf(stdout, "GAP: %d of %d adapters declare hooks but have zero hook-bearing recordings: %s\n",
-			len(gaps), len(rep.Adapters), strings.Join(gaps, ", "))
+		// Denominator is the hooks-declaring adapters, not all of them: "1 of
+		// 11" invites the reading that 11 adapters declare hooks.
+		fmt.Fprintf(stdout, "GAP: %d of %d hooks-declaring adapters have zero hook-bearing recordings: %s\n",
+			len(gaps), rep.Declaring(), strings.Join(gaps, ", "))
 	} else {
 		fmt.Fprintln(stdout, "no gaps: every adapter that declares hooks has at least one hook-bearing recording")
 	}

--- a/tools/onboarding-factory/cmd/of/coverage.go
+++ b/tools/onboarding-factory/cmd/of/coverage.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"irrlicht/tools/onboarding-factory/internal/hookcov"
@@ -28,11 +29,11 @@ func runCoverage(args []string, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
 	}
+	*repoRoot = absRoot(*repoRoot)
 
 	if *hooks {
 		return runCoverageHooks(*repoRoot, *asJSON, stdout, stderr)
 	}
-	_ = asJSON // the rollup is JSON; the flag exists for CLI symmetry
 
 	m, err := matrix.LoadRepo(*repoRoot)
 	if err != nil {
@@ -88,20 +89,21 @@ func hookStatusNote(s hookcov.Status) string {
 	}
 }
 
-const hookRowFormat = "%-14s %14s %6d %11d %11d  %s\n"
+// One column-width spec for the whole table: header, rows and the totals line
+// all format through hookRowFormat with %s cells, so the widths cannot drift
+// between them. printHookRow converts the counts.
+const hookRowFormat = "%-14s %14s %6s %11s %11s  %s\n"
 
 func printHookCoverageText(stdout io.Writer, rep hookcov.Report) {
 	fmt.Fprintln(stdout, "hook coverage — recordings containing a hook_received event, per adapter")
 	fmt.Fprintln(stdout, "scope: cells on disk under replaydata/agents/<adapter>/scenarios; the non-catalog regressions/ tree is excluded")
 	fmt.Fprintln(stdout)
-	fmt.Fprintf(stdout, "%-14s %14s %6s %11s %11s  %s\n",
+	fmt.Fprintf(stdout, hookRowFormat,
 		"adapter", "declares-hooks", "cells", "recordings", "with-hooks", "status")
 	for _, a := range rep.Adapters {
-		fmt.Fprintf(stdout, hookRowFormat,
-			a.Adapter, yesNo(a.DeclaresHooks), a.Cells, a.Recordings, a.WithHooks, hookStatusNote(a.Status))
+		printHookRow(stdout, a.Adapter, yesNo(a.DeclaresHooks), a.Cells, a.Recordings, a.WithHooks, hookStatusNote(a.Status))
 	}
-	fmt.Fprintf(stdout, "%-14s %14s %6d %11d %11d\n",
-		"total", "", rep.Totals.Cells, rep.Totals.Recordings, rep.Totals.WithHooks)
+	printHookRow(stdout, "total", "", rep.Totals.Cells, rep.Totals.Recordings, rep.Totals.WithHooks, "")
 
 	fmt.Fprintln(stdout)
 	if gaps := rep.Gaps(); len(gaps) > 0 {
@@ -112,6 +114,14 @@ func printHookCoverageText(stdout io.Writer, rep hookcov.Report) {
 	} else {
 		fmt.Fprintln(stdout, "no gaps: every adapter that declares hooks has at least one hook-bearing recording")
 	}
+}
+
+// printHookRow renders one table line. Trailing whitespace is trimmed so the
+// totals row — which has no status cell — does not ship padding.
+func printHookRow(stdout io.Writer, adapter, declares string, cells, recordings, withHooks int, status string) {
+	line := fmt.Sprintf(hookRowFormat, adapter, declares,
+		strconv.Itoa(cells), strconv.Itoa(recordings), strconv.Itoa(withHooks), status)
+	fmt.Fprintln(stdout, strings.TrimRight(line, " \n"))
 }
 
 func yesNo(b bool) string {

--- a/tools/onboarding-factory/cmd/of/coverage.go
+++ b/tools/onboarding-factory/cmd/of/coverage.go
@@ -3,22 +3,34 @@ package main
 import (
 	"fmt"
 	"io"
+	"strings"
 
+	"irrlicht/tools/onboarding-factory/internal/hookcov"
 	"irrlicht/tools/onboarding-factory/internal/matrix"
+	"irrlicht/tools/onboarding-factory/internal/shard"
 )
 
 // runCoverage emits the derived coverage rollup. Since the committed
 // agent-scenarios-coverage.json was retired (#524), this is computed in-memory
 // from the assessments every time — there is no file to read or keep in sync.
 // An empty overlay means generated_at falls back to the max assessed_at.
+//
+// --hooks switches to the hook-coverage report (#1363): a different question
+// over the same catalog — not how much is recorded, but how much of what is
+// recorded exercises the hook channel.
 func runCoverage(args []string, stdout, stderr io.Writer) int {
 	fs := newFlagSet("of coverage")
 	var (
+		hooks    = fs.Bool("hooks", false, "report per-adapter hook_received coverage instead of the rollup")
 		asJSON   = fs.Bool("json", false, "emit JSON (the rollup is JSON either way)")
 		repoRoot = fs.String("repo-root", ".", "repository root")
 	)
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
+	}
+
+	if *hooks {
+		return runCoverageHooks(*repoRoot, *asJSON, stdout, stderr)
 	}
 	_ = asJSON // the rollup is JSON; the flag exists for CLI symmetry
 
@@ -35,4 +47,74 @@ func runCoverage(args []string, stdout, stderr io.Writer) int {
 	stdout.Write(b)
 	fmt.Fprintln(stdout)
 	return exitOK
+}
+
+// runCoverageHooks derives and renders the hook-coverage report. Exit stays 0
+// even when there are gaps: this is a report, not a gate. `of validate` is the
+// CI gate, and making a reporting command fail the build would be a policy
+// change nobody asked for.
+func runCoverageHooks(repoRoot string, asJSON bool, stdout, stderr io.Writer) int {
+	catalogAdapters := shard.Agents(repoRoot)
+	if len(catalogAdapters) == 0 {
+		fmt.Fprintf(stderr, "of coverage --hooks: no onboarded adapters in %s\n", shard.File(repoRoot))
+		return exitUsage
+	}
+	rep := hookcov.Coverage(repoRoot, catalogAdapters, hookcov.Declared())
+
+	if asJSON {
+		if err := writeJSON(stdout, rep); err != nil {
+			fmt.Fprintf(stderr, "of coverage --hooks: encode: %v\n", err)
+			return exitUsage
+		}
+		return exitOK
+	}
+	printHookCoverageText(stdout, rep)
+	return exitOK
+}
+
+// hookStatusNote is the human-readable gloss per status. The gap line is
+// deliberately the only one in capitals — it is the one a reader must not skim
+// past.
+func hookStatusNote(s hookcov.Status) string {
+	switch s {
+	case hookcov.StatusOK:
+		return "ok"
+	case hookcov.StatusGap:
+		return "GAP — declares hooks, zero hook-bearing recordings"
+	case hookcov.StatusIncidental:
+		return "incidental — hook events present, adapter declares no hooks"
+	default:
+		return "—"
+	}
+}
+
+const hookRowFormat = "%-14s %14s %6d %11d %11d  %s\n"
+
+func printHookCoverageText(stdout io.Writer, rep hookcov.Report) {
+	fmt.Fprintln(stdout, "hook coverage — recordings containing a hook_received event, per adapter")
+	fmt.Fprintln(stdout, "scope: catalog cells only (replaydata/agents/<adapter>/scenarios); the non-catalog regressions/ tree is excluded")
+	fmt.Fprintln(stdout)
+	fmt.Fprintf(stdout, "%-14s %14s %6s %11s %11s  %s\n",
+		"adapter", "declares-hooks", "cells", "recordings", "with-hooks", "status")
+	for _, a := range rep.Adapters {
+		fmt.Fprintf(stdout, hookRowFormat,
+			a.Adapter, yesNo(a.DeclaresHooks), a.Cells, a.Recordings, a.WithHooks, hookStatusNote(a.Status))
+	}
+	fmt.Fprintf(stdout, "%-14s %14s %6d %11d %11d\n",
+		"total", "", rep.Totals.Cells, rep.Totals.Recordings, rep.Totals.WithHooks)
+
+	fmt.Fprintln(stdout)
+	if gaps := rep.Gaps(); len(gaps) > 0 {
+		fmt.Fprintf(stdout, "GAP: %d of %d adapters declare hooks but have zero hook-bearing recordings: %s\n",
+			len(gaps), len(rep.Adapters), strings.Join(gaps, ", "))
+	} else {
+		fmt.Fprintln(stdout, "no gaps: every adapter that declares hooks has at least one hook-bearing recording")
+	}
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
 }

--- a/tools/onboarding-factory/cmd/of/coverage.go
+++ b/tools/onboarding-factory/cmd/of/coverage.go
@@ -101,9 +101,11 @@ func printHookCoverageText(stdout io.Writer, rep hookcov.Report) {
 	fmt.Fprintf(stdout, hookRowFormat,
 		"adapter", "declares-hooks", "cells", "recordings", "with-hooks", "status")
 	for _, a := range rep.Adapters {
-		printHookRow(stdout, a.Adapter, yesNo(a.DeclaresHooks), a.Cells, a.Recordings, a.WithHooks, hookStatusNote(a.Status))
+		printHookRow(stdout, a.Adapter, yesNo(a.DeclaresHooks),
+			counts{a.Cells, a.Recordings, a.WithHooks}, hookStatusNote(a.Status))
 	}
-	printHookRow(stdout, "total", "", rep.Totals.Cells, rep.Totals.Recordings, rep.Totals.WithHooks, "")
+	printHookRow(stdout, "total", "",
+		counts{rep.Totals.Cells, rep.Totals.Recordings, rep.Totals.WithHooks}, "")
 
 	fmt.Fprintln(stdout)
 	if gaps := rep.Gaps(); len(gaps) > 0 {
@@ -116,11 +118,15 @@ func printHookCoverageText(stdout io.Writer, rep hookcov.Report) {
 	}
 }
 
+// counts is the numeric middle of a hook-coverage row, grouped so the printer
+// takes one value per column group rather than a run of bare ints.
+type counts struct{ cells, recordings, withHooks int }
+
 // printHookRow renders one table line. Trailing whitespace is trimmed so the
 // totals row — which has no status cell — does not ship padding.
-func printHookRow(stdout io.Writer, adapter, declares string, cells, recordings, withHooks int, status string) {
+func printHookRow(stdout io.Writer, adapter, declares string, c counts, status string) {
 	line := fmt.Sprintf(hookRowFormat, adapter, declares,
-		strconv.Itoa(cells), strconv.Itoa(recordings), strconv.Itoa(withHooks), status)
+		strconv.Itoa(c.cells), strconv.Itoa(c.recordings), strconv.Itoa(c.withHooks), status)
 	fmt.Fprintln(stdout, strings.TrimRight(line, " \n"))
 }
 

--- a/tools/onboarding-factory/cmd/of/fixture_test.go
+++ b/tools/onboarding-factory/cmd/of/fixture_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -86,10 +87,8 @@ func cell(t *testing.T, root, agent, folder, supports, daemon, driver string) {
 // scenarioNameOf maps the on-disk folder "<dashed-id>_<name>" to the scenario
 // name the shard loader keys cells by.
 func scenarioNameOf(folder string) string {
-	for i := 0; i < len(folder); i++ {
-		if folder[i] == '_' {
-			return folder[i+1:]
-		}
+	if _, name, ok := strings.Cut(folder, "_"); ok {
+		return name
 	}
 	return folder
 }

--- a/tools/onboarding-factory/cmd/of/fixture_test.go
+++ b/tools/onboarding-factory/cmd/of/fixture_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// richRepo writes a catalog exercising every display state and every
+// hook-coverage status, so `of status --summary` and `of coverage --hooks`
+// are both pinned against ONE fixture whose expected counts are stated here
+// rather than recomputed by the assertions.
+//
+// The adapter slugs are real (claudecode, codex, aider, opencode) because
+// `of coverage --hooks` joins the catalog to the daemon's adapter registry:
+// claudecode and codex declare a "hooks" permission, aider and opencode do
+// not. Inventing a slug would silently drop the row from that join.
+//
+// Cells per agent, and the display state each one derives to:
+//
+//	claudecode  1-1 observed (recorded)   2-1 pending-record   3-1 blocked-driver
+//	            4-1 blocked-daemon        5-1 unobservable     6-1 n.a. (supports=no)
+//	            7-1 unknown (supports=unknown)                        → 7 cells
+//	codex       1-1 observed (recorded)   2-1 pending-record          → 2 cells
+//	aider       1-1 observed (recorded)                               → 1 cell
+//	opencode    1-1 observed (recorded)                               → 1 cell
+//
+// Recordings, and which carry a hook_received event:
+//
+//	claudecode 1-1: r1 (hook_received), r2 (none)  → 2 recordings, 1 with hooks
+//	codex      1-1: r1 (none)                      → 1 recording,  0 with hooks
+//	aider      1-1: r1 (hook_received)             → 1 recording,  1 with hooks
+//	opencode   1-1: r1 (none)                      → 1 recording,  0 with hooks
+func richRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	write(t, filepath.Join(root, "replaydata", "agents", "scenarios.json"), `{
+  "meta": {"min_versions": {"aider": "1.0.0", "claudecode": "2.0.0", "codex": "1.0.0", "opencode": "1.0.0"}},
+  "scenarios": [
+    {"id": "1.1", "name": "one",   "description": "d", "process": "p", "acceptance_criteria": "a"},
+    {"id": "2.1", "name": "two",   "description": "d", "process": "p", "acceptance_criteria": "a"},
+    {"id": "3.1", "name": "three", "description": "d", "process": "p", "acceptance_criteria": "a"},
+    {"id": "4.1", "name": "four",  "description": "d", "process": "p", "acceptance_criteria": "a"},
+    {"id": "5.1", "name": "five",  "description": "d", "process": "p", "acceptance_criteria": "a"},
+    {"id": "6.1", "name": "six",   "description": "d", "process": "p", "acceptance_criteria": "a"},
+    {"id": "7.1", "name": "seven", "description": "d", "process": "p", "acceptance_criteria": "a"}
+  ]
+}`)
+
+	// claudecode: one cell per display state.
+	cell(t, root, "claudecode", "1-1_one", "yes", "full", "ready")
+	cell(t, root, "claudecode", "2-1_two", "yes", "full", "ready")
+	cell(t, root, "claudecode", "3-1_three", "yes", "full", "gap:driver-cannot-interrupt")
+	cell(t, root, "claudecode", "4-1_four", "yes", "bug", "ready")
+	cell(t, root, "claudecode", "5-1_five", "yes", "incapable", "ready")
+	cell(t, root, "claudecode", "6-1_six", "no", "full", "ready")
+	cell(t, root, "claudecode", "7-1_seven", "unknown", "full", "ready")
+	recording(t, root, "claudecode", "1-1_one", "r1", true)
+	recording(t, root, "claudecode", "1-1_one", "r2", false)
+
+	cell(t, root, "codex", "1-1_one", "yes", "full", "ready")
+	cell(t, root, "codex", "2-1_two", "yes", "full", "ready")
+	recording(t, root, "codex", "1-1_one", "r1", false)
+
+	cell(t, root, "aider", "1-1_one", "yes", "full", "ready")
+	recording(t, root, "aider", "1-1_one", "r1", true)
+
+	cell(t, root, "opencode", "1-1_one", "yes", "full", "ready")
+	recording(t, root, "opencode", "1-1_one", "r1", false)
+
+	return root
+}
+
+// cell writes one (agent, scenario) cell with the three assessment axes that
+// drive matrix.DeriveDisplayState.
+func cell(t *testing.T, root, agent, folder, supports, daemon, driver string) {
+	t.Helper()
+	dir := filepath.Join(root, "replaydata", "agents", agent, "scenarios", folder)
+	write(t, filepath.Join(dir, "metadata.json"), `{
+  "scenario_id": "`+scenarioNameOf(folder)+`",
+  "details": {"assessment": {"agent_supports": "`+supports+`", "daemon_capability": "`+daemon+`", "driver_capability": "`+driver+`"}}
+}`)
+	write(t, filepath.Join(dir, "expected.jsonl"), `{"schema_version":1}`+"\n")
+}
+
+// scenarioNameOf maps the on-disk folder "<dashed-id>_<name>" to the scenario
+// name the shard loader keys cells by.
+func scenarioNameOf(folder string) string {
+	for i := 0; i < len(folder); i++ {
+		if folder[i] == '_' {
+			return folder[i+1:]
+		}
+	}
+	return folder
+}
+
+// recording writes one complete recording under a cell. withHook adds a
+// hook_received event, which is what `of coverage --hooks` counts.
+func recording(t *testing.T, root, agent, folder, name string, withHook bool) {
+	t.Helper()
+	rec := filepath.Join(root, "replaydata", "agents", agent, "scenarios", folder, "recordings", name)
+	events := `{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"pid_discovered","session_id":"s"}` + "\n"
+	if withHook {
+		events += `{"seq":2,"ts":"2026-05-01T00:00:01Z","kind":"hook_received","session_id":"s","hook_name":"PostToolUse"}` + "\n"
+	}
+	write(t, filepath.Join(rec, "events.jsonl"), events)
+	write(t, filepath.Join(rec, "manifest.json"), `{}`+"\n")
+	write(t, filepath.Join(rec, "transcript.jsonl"), `{}`+"\n")
+	write(t, filepath.Join(rec, "transcript.jsonl.replay.json.golden"), `{}`+"\n")
+}

--- a/tools/onboarding-factory/cmd/of/hooks_test.go
+++ b/tools/onboarding-factory/cmd/of/hooks_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"irrlicht/tools/onboarding-factory/internal/hookcov"
+)
+
+// TestCoverageHooksCounts pins the per-adapter hook numbers against richRepo.
+// As with --summary the counts are the product, so they are literal here.
+//
+// The `declares` column is NOT fixture data — it is joined at runtime from the
+// daemon's adapter registry, where claudecode and codex declare a "hooks"
+// permission and aider and opencode do not. That join is the part of this
+// command that can rot silently (a renamed permission key, a changed adapter
+// slug), so it is asserted rather than assumed.
+func TestCoverageHooksCounts(t *testing.T) {
+	root := richRepo(t)
+	code, out, errs := runOf("coverage", "--hooks", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d stderr=%s", code, errs)
+	}
+	var rep hookcov.Report
+	if err := json.Unmarshal([]byte(out), &rep); err != nil {
+		t.Fatalf("bad json: %v\n%s", err, out)
+	}
+
+	want := map[string]hookcov.AdapterCoverage{
+		"aider":      {Adapter: "aider", DeclaresHooks: false, Cells: 1, Recordings: 1, WithHooks: 1, Status: hookcov.StatusIncidental},
+		"claudecode": {Adapter: "claudecode", DeclaresHooks: true, Cells: 7, Recordings: 2, WithHooks: 1, Status: hookcov.StatusOK},
+		"codex":      {Adapter: "codex", DeclaresHooks: true, Cells: 2, Recordings: 1, WithHooks: 0, Status: hookcov.StatusGap},
+		"opencode":   {Adapter: "opencode", DeclaresHooks: false, Cells: 1, Recordings: 1, WithHooks: 0, Status: hookcov.StatusNone},
+	}
+	got := map[string]hookcov.AdapterCoverage{}
+	for _, a := range rep.Adapters {
+		got[a.Adapter] = a
+	}
+	for name, w := range want {
+		g, ok := got[name]
+		if !ok {
+			t.Errorf("missing adapter row %q", name)
+			continue
+		}
+		if g != w {
+			t.Errorf("%s: got %+v want %+v", name, g, w)
+		}
+	}
+	if rep.Totals.Cells != 11 || rep.Totals.Recordings != 5 || rep.Totals.WithHooks != 2 {
+		t.Errorf("totals: got %+v want cells=11 recordings=5 with-hooks=2", rep.Totals)
+	}
+}
+
+// TestCoverageHooksDistinguishesGapFromNoHooks is the reason this command
+// exists. "Declares hooks and has zero hook-bearing recordings" (codex) is the
+// loud failure; "declares no hooks" (opencode) is fine. Both have WithHooks==0,
+// so a report keying only on that number would conflate them.
+func TestCoverageHooksDistinguishesGapFromNoHooks(t *testing.T) {
+	root := richRepo(t)
+	code, out, errs := runOf("coverage", "--hooks", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d stderr=%s", code, errs)
+	}
+	var rep hookcov.Report
+	if err := json.Unmarshal([]byte(out), &rep); err != nil {
+		t.Fatalf("bad json: %v\n%s", err, out)
+	}
+	byName := map[string]hookcov.AdapterCoverage{}
+	for _, a := range rep.Adapters {
+		byName[a.Adapter] = a
+	}
+	if byName["codex"].WithHooks != 0 || byName["opencode"].WithHooks != 0 {
+		t.Fatalf("fixture precondition: both codex and opencode should have zero hook-bearing recordings")
+	}
+	if byName["codex"].Status == byName["opencode"].Status {
+		t.Errorf("gap and no-hooks-declared must not share a status; both are %q", byName["codex"].Status)
+	}
+	if byName["codex"].Status != hookcov.StatusGap {
+		t.Errorf("codex declares hooks with zero hook recordings — want %q, got %q", hookcov.StatusGap, byName["codex"].Status)
+	}
+	if rep.Gaps() == nil || rep.Gaps()[0] != "codex" {
+		t.Errorf("codex should be listed as the gap, got %v", rep.Gaps())
+	}
+}
+
+// TestCoverageHooksText checks the loud rendering: the GAP must be legible at
+// a terminal, not only in the JSON.
+func TestCoverageHooksText(t *testing.T) {
+	root := richRepo(t)
+	code, out, errs := runOf("coverage", "--hooks", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d stderr=%s", code, errs)
+	}
+	if !strings.Contains(out, "GAP") {
+		t.Errorf("text output must shout about the gap:\n%s", out)
+	}
+	if !strings.Contains(out, "codex") {
+		t.Errorf("text output must name the gapped adapter:\n%s", out)
+	}
+	// The scope caveat is part of the output, not a code comment: the count is
+	// over catalog cells, and a reader grepping replaydata/ would otherwise get
+	// a different number from the non-catalog regressions/ tree.
+	if !strings.Contains(out, "regressions") {
+		t.Errorf("text output must state which tree is out of scope:\n%s", out)
+	}
+}
+
+// TestCoveragePlainStillRollup locks the pre-existing behavior: `of coverage`
+// with no flag keeps emitting the derived rollup JSON. This one passes on main
+// by construction — it is a lock, not a red-first defect test.
+func TestCoveragePlainStillRollup(t *testing.T) {
+	root := richRepo(t)
+	code, out, errs := runOf("coverage", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d stderr=%s", code, errs)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("plain coverage should still be rollup JSON: %v\n%s", err, out)
+	}
+	if _, ok := doc["agents"]; !ok {
+		t.Errorf("rollup shape lost its agents key: %v", doc)
+	}
+}

--- a/tools/onboarding-factory/cmd/of/main.go
+++ b/tools/onboarding-factory/cmd/of/main.go
@@ -7,9 +7,9 @@
 //
 // Read-side commands (this phase):
 //
-//	of status   [--agent a] [--scenario s] [--runs] [--json]   coverage / run status
-//	of validate [--json]                                        schema + referential integrity
-//	of coverage [--json]                                        derived rollup (in-memory)
+//	of status   [--agent a] [--scenario s] [--runs] [--summary] [--json]  coverage / run status
+//	of validate [--json]                                                  schema + referential integrity
+//	of coverage [--hooks] [--json]                                        derived rollup, or hook coverage
 //
 // Exit codes (matching the sibling cmd tools):
 //
@@ -35,9 +35,9 @@ const (
 )
 
 const usage = `usage:
-  of status   [--agent a] [--scenario s] [--runs] [--json] [--repo-root .]
+  of status   [--agent a] [--scenario s] [--runs] [--summary] [--json] [--repo-root .]
   of validate [--json] [--repo-root .]
-  of coverage [--json] [--repo-root .]
+  of coverage [--hooks] [--json] [--repo-root .]
   of scenario add|update --name n [--id i] [--description d] [--process-file f] [--acceptance-file f]
   of scenario show --name n [--json]
   of agent add    --id i --name n --provider p [--min-version v] [--prereq p]...
@@ -129,6 +129,7 @@ func runStatus(args []string, stdout, stderr io.Writer) int {
 		agent    = fs.String("agent", "", "filter to one agent column")
 		scenario = fs.String("scenario", "", "filter to one scenario (by name or id)")
 		runs     = fs.Bool("runs", false, "show the factory run-log instead of coverage")
+		summary  = fs.Bool("summary", false, "per-agent cell counts instead of the full cell dump")
 		asJSON   = fs.Bool("json", false, "emit JSON")
 		repoRoot = fs.String("repo-root", ".", "repository root")
 	)
@@ -155,6 +156,22 @@ func runStatus(args []string, stdout, stderr io.Writer) int {
 	}
 
 	view := buildStatusView(m, *repoRoot, agents, *scenario)
+
+	// --summary folds the same view into per-agent counts. Folding the view
+	// (rather than re-reading the matrix) is what keeps the two renderings of
+	// `of status` arithmetically consistent.
+	if *summary {
+		sv := buildSummaryView(view)
+		if *asJSON {
+			if err := writeJSON(stdout, sv); err != nil {
+				fmt.Fprintf(stderr, "of status: encode: %v\n", err)
+				return exitUsage
+			}
+			return exitOK
+		}
+		printSummaryText(stdout, sv)
+		return exitOK
+	}
 
 	if *asJSON {
 		if err := writeJSON(stdout, view); err != nil {

--- a/tools/onboarding-factory/cmd/of/main.go
+++ b/tools/onboarding-factory/cmd/of/main.go
@@ -80,6 +80,21 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 }
 
+// emitSummary renders the folded per-agent counts, as JSON or as the text
+// table.
+func emitSummary(view statusView, asJSON bool, stdout, stderr io.Writer) int {
+	sv := buildSummaryView(view)
+	if asJSON {
+		if err := writeJSON(stdout, sv); err != nil {
+			fmt.Fprintf(stderr, "of status: encode: %v\n", err)
+			return exitUsage
+		}
+		return exitOK
+	}
+	printSummaryText(stdout, sv)
+	return exitOK
+}
+
 // absRoot resolves --repo-root to an absolute path. Every filesystem reader
 // under internal/validate and internal/replay refuses a path containing ".."
 // (a CodeQL taint barrier) by returning an EMPTY result rather than an error,
@@ -189,16 +204,7 @@ func runStatus(args []string, stdout, stderr io.Writer) int {
 	// (rather than re-reading the matrix) is what keeps the two renderings of
 	// `of status` arithmetically consistent.
 	if *summary {
-		sv := buildSummaryView(view)
-		if *asJSON {
-			if err := writeJSON(stdout, sv); err != nil {
-				fmt.Fprintf(stderr, "of status: encode: %v\n", err)
-				return exitUsage
-			}
-			return exitOK
-		}
-		printSummaryText(stdout, sv)
-		return exitOK
+		return emitSummary(view, *asJSON, stdout, stderr)
 	}
 
 	if *asJSON {

--- a/tools/onboarding-factory/cmd/of/main.go
+++ b/tools/onboarding-factory/cmd/of/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"irrlicht/tools/onboarding-factory/internal/matrix"
 	"irrlicht/tools/onboarding-factory/internal/shard"
@@ -77,6 +78,21 @@ func run(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, usage)
 		return exitUsage
 	}
+}
+
+// absRoot resolves --repo-root to an absolute path. Every filesystem reader
+// under internal/validate and internal/replay refuses a path containing ".."
+// (a CodeQL taint barrier) by returning an EMPTY result rather than an error,
+// so a relative root like "--repo-root .." silently reports a catalog in which
+// nothing is recorded — exit 0, no warning. `of status --summary` renders that
+// as a full table of zeros, which reads as a finished measurement rather than
+// a misread path. Resolving once at the flag boundary is what makes the guard
+// a no-op for legitimate callers instead of a trap.
+func absRoot(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return p
 }
 
 func writeJSON(w io.Writer, v any) error {
@@ -136,6 +152,7 @@ func runStatus(args []string, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
 	}
+	*repoRoot = absRoot(*repoRoot)
 
 	if *runs {
 		return runStatusRuns(*repoRoot, *asJSON, stdout, stderr)
@@ -154,16 +171,19 @@ func runStatus(args []string, stdout, stderr io.Writer) int {
 		}
 		agents = []string{*agent}
 	}
+	view := buildStatusView(m, *repoRoot, agents, *scenario)
+
 	// Validate --scenario the way --agent is validated. An unmatched filter
 	// used to yield a visibly empty listing; under --summary it yields a full
 	// table of zeros that reads as a completed measurement, so a typo has to
-	// fail loudly instead.
-	if *scenario != "" && !hasScenario(*repoRoot, *scenario) {
+	// fail loudly instead. Checked on the built view rather than by a second
+	// catalog walk, so the guard and the filter are literally the same
+	// predicate — buildStatusView emits a row for every matching shard, so an
+	// empty result means nothing matched.
+	if *scenario != "" && len(view.Scenarios) == 0 {
 		fmt.Fprintf(stderr, "of status: %q is not a scenario (by name or id)\n", *scenario)
 		return exitUsage
 	}
-
-	view := buildStatusView(m, *repoRoot, agents, *scenario)
 
 	// --summary folds the same view into per-agent counts. Folding the view
 	// (rather than re-reading the matrix) is what keeps the two renderings of
@@ -190,18 +210,6 @@ func runStatus(args []string, stdout, stderr io.Writer) int {
 	}
 	printStatusText(stdout, view)
 	return exitOK
-}
-
-// hasScenario reports whether the filter matches a shard by name or by id —
-// the same two spellings buildStatusView accepts, so the guard and the filter
-// can never disagree about what "matches".
-func hasScenario(repoRoot, filter string) bool {
-	for _, sh := range shard.LoadAll(repoRoot) {
-		if sh.Name == filter || sh.ID == filter {
-			return true
-		}
-	}
-	return false
 }
 
 // buildStatusView projects the matrix + catalog shards (optionally filtered

--- a/tools/onboarding-factory/cmd/of/main.go
+++ b/tools/onboarding-factory/cmd/of/main.go
@@ -154,6 +154,14 @@ func runStatus(args []string, stdout, stderr io.Writer) int {
 		}
 		agents = []string{*agent}
 	}
+	// Validate --scenario the way --agent is validated. An unmatched filter
+	// used to yield a visibly empty listing; under --summary it yields a full
+	// table of zeros that reads as a completed measurement, so a typo has to
+	// fail loudly instead.
+	if *scenario != "" && !hasScenario(*repoRoot, *scenario) {
+		fmt.Fprintf(stderr, "of status: %q is not a scenario (by name or id)\n", *scenario)
+		return exitUsage
+	}
 
 	view := buildStatusView(m, *repoRoot, agents, *scenario)
 
@@ -182,6 +190,18 @@ func runStatus(args []string, stdout, stderr io.Writer) int {
 	}
 	printStatusText(stdout, view)
 	return exitOK
+}
+
+// hasScenario reports whether the filter matches a shard by name or by id —
+// the same two spellings buildStatusView accepts, so the guard and the filter
+// can never disagree about what "matches".
+func hasScenario(repoRoot, filter string) bool {
+	for _, sh := range shard.LoadAll(repoRoot) {
+		if sh.Name == filter || sh.ID == filter {
+			return true
+		}
+	}
+	return false
 }
 
 // buildStatusView projects the matrix + catalog shards (optionally filtered

--- a/tools/onboarding-factory/cmd/of/main_test.go
+++ b/tools/onboarding-factory/cmd/of/main_test.go
@@ -32,20 +32,11 @@ func validRepo(t *testing.T) string {
     {"id": "2.1", "name": "basic-turn", "description": "d", "process": "p", "acceptance_criteria": "a"}
   ]
 }`)
-	cell := filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", "1-1_session-start")
-	write(t, filepath.Join(cell, "metadata.json"), `{
-  "scenario_id": "session-start",
-  "details": {"assessment": {"agent_supports": "yes", "daemon_capability": "full", "driver_capability": "ready"}}
-}`)
-	write(t, filepath.Join(cell, "expected.jsonl"), `{"schema_version":1}`+"\n")
-	// "Recorded" is a disk fact, and a recording must be complete: events +
-	// manifest + a transcript + (for a jsonl transcript) its replay golden.
-	rec := filepath.Join(cell, "recordings", "r1")
-	write(t, filepath.Join(rec, "events.jsonl"),
-		`{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"pid_discovered","session_id":"s"}`+"\n")
-	write(t, filepath.Join(rec, "manifest.json"), `{}`+"\n")
-	write(t, filepath.Join(rec, "transcript.jsonl"), `{}`+"\n")
-	write(t, filepath.Join(rec, "transcript.jsonl.replay.json.golden"), `{}`+"\n")
+	// Shares fixture_test.go's cell/recording helpers so "what a complete
+	// recording is" lives in one place — validate.RecordingComplete gaining a
+	// required file must not mean editing two fixtures in this package.
+	cell(t, root, "claudecode", "1-1_session-start", "yes", "full", "ready")
+	recording(t, root, "claudecode", "1-1_session-start", "r1", false)
 	return root
 }
 

--- a/tools/onboarding-factory/cmd/of/status_summary.go
+++ b/tools/onboarding-factory/cmd/of/status_summary.go
@@ -3,14 +3,16 @@ package main
 import (
 	"fmt"
 	"io"
+	"strconv"
 )
 
 // agentSummary is one agent's cell counts, bucketed by the matrix display
 // state. Every value matrix.DeriveDisplayState can return maps to exactly one
-// bucket, so the buckets always sum to Total — see buckets() and the
-// total-preserving test. That property is the point: a summary that quietly
-// drops a state under-reports how much work is left, which is worse than no
-// summary at all.
+// bucket — add()'s default arm guarantees it — so the buckets always sum to
+// Total. That property is the point: a summary that quietly drops a state
+// under-reports how much work is left, which is worse than no summary at all.
+// TestStatusSummaryAgreesWithFullDump is what enforces it, by cross-checking
+// against `of status --json` rather than against this type itself.
 type agentSummary struct {
 	Agent string `json:"agent"`
 	// Recorded ← "observed": assessed recordable AND has a recording. NOT the
@@ -36,12 +38,6 @@ type agentSummary struct {
 	Total   int `json:"total"`
 }
 
-// buckets returns the sum of every bucket. It must equal Total; a mismatch
-// means matrix gained a display state this summary does not know about.
-func (a agentSummary) buckets() int {
-	return a.Recorded + a.Pending + a.Blocked + a.Unobservable + a.NotApplicable + a.Unknown
-}
-
 // add folds one cell's display state into the right bucket.
 func (a *agentSummary) add(displayState string) {
 	a.Total++
@@ -57,10 +53,10 @@ func (a *agentSummary) add(displayState string) {
 	case "n.a.":
 		a.NotApplicable++
 	default:
-		// "unknown" and anything matrix adds later. Counting an unrecognised
-		// state as unknown keeps the buckets total-preserving instead of
-		// silently discarding the cell; the test that sums them then still
-		// passes, and `of status` remains the place to see the raw state.
+		// "unknown", plus any state matrix adds later. Bucketing an
+		// unrecognised state here rather than dropping it is what keeps the
+		// row total honest; `of status` remains the place to see the raw
+		// state, and TestStatusSummaryCounts is what pins the known ones.
 		a.Unknown++
 	}
 }
@@ -97,12 +93,13 @@ func buildSummaryView(view statusView) summaryView {
 	return out
 }
 
-const summaryRowFormat = "%-14s %9d %8d %8d %13d %6d %8d %6d\n"
+// One column-width spec for header and rows alike, so they cannot drift.
+const summaryRowFormat = "%-14s %9s %8s %8s %13s %6s %8s %6s\n"
 
 func printSummaryText(stdout io.Writer, view summaryView) {
 	fmt.Fprintf(stdout, "per-agent cell counts — %s, %d cells\n\n",
 		plural(len(view.Agents), "agent"), view.Total.Total)
-	fmt.Fprintf(stdout, "%-14s %9s %8s %8s %13s %6s %8s %6s\n",
+	fmt.Fprintf(stdout, summaryRowFormat,
 		"agent", "recorded", "pending", "blocked", "unobservable", "n/a", "unknown", "total")
 	for _, a := range view.Agents {
 		printSummaryRow(stdout, a)
@@ -125,6 +122,7 @@ func plural(n int, noun string) string {
 }
 
 func printSummaryRow(stdout io.Writer, a agentSummary) {
-	fmt.Fprintf(stdout, summaryRowFormat,
-		a.Agent, a.Recorded, a.Pending, a.Blocked, a.Unobservable, a.NotApplicable, a.Unknown, a.Total)
+	n := strconv.Itoa
+	fmt.Fprintf(stdout, summaryRowFormat, a.Agent,
+		n(a.Recorded), n(a.Pending), n(a.Blocked), n(a.Unobservable), n(a.NotApplicable), n(a.Unknown), n(a.Total))
 }

--- a/tools/onboarding-factory/cmd/of/status_summary.go
+++ b/tools/onboarding-factory/cmd/of/status_summary.go
@@ -13,7 +13,13 @@ import (
 // summary at all.
 type agentSummary struct {
 	Agent string `json:"agent"`
-	// Recorded ← "observed": the cell has a recording on disk.
+	// Recorded ← "observed": assessed recordable AND has a recording. NOT the
+	// same as "has a recording on disk": DeriveDisplayState consults the
+	// recording only after the daemon/driver switch, so a cell whose daemon
+	// axis is bug/incapable — or whose driver has a gap — is counted under
+	// blocked/unobservable even when a recording exists. 11 cells in the
+	// current corpus are in exactly that state, so "482 − recorded" is not
+	// the number of un-recorded cells.
 	Recorded int `json:"recorded"`
 	// Pending ← "pending-record": assessed recordable, not yet recorded.
 	Pending int `json:"pending"`
@@ -94,13 +100,28 @@ func buildSummaryView(view statusView) summaryView {
 const summaryRowFormat = "%-14s %9d %8d %8d %13d %6d %8d %6d\n"
 
 func printSummaryText(stdout io.Writer, view summaryView) {
-	fmt.Fprintf(stdout, "per-agent cell counts — %d agents, %d cells\n\n", len(view.Agents), view.Total.Total)
+	fmt.Fprintf(stdout, "per-agent cell counts — %s, %d cells\n\n",
+		plural(len(view.Agents), "agent"), view.Total.Total)
 	fmt.Fprintf(stdout, "%-14s %9s %8s %8s %13s %6s %8s %6s\n",
 		"agent", "recorded", "pending", "blocked", "unobservable", "n/a", "unknown", "total")
 	for _, a := range view.Agents {
 		printSummaryRow(stdout, a)
 	}
 	printSummaryRow(stdout, view.Total)
+	// Without this, "recorded" reads as "has a recording" and the complement
+	// reads as the remaining work. It is neither — see agentSummary.Recorded.
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "note: recorded = display state \"observed\". A cell blocked by a daemon bug or driver gap")
+	fmt.Fprintln(stdout, "counts under blocked/unobservable even if it has a recording, so total − recorded is not")
+	fmt.Fprintln(stdout, "the un-recorded count. Use `of status` for per-cell detail.")
+}
+
+// plural renders "1 agent" / "2 agents".
+func plural(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
 }
 
 func printSummaryRow(stdout io.Writer, a agentSummary) {

--- a/tools/onboarding-factory/cmd/of/status_summary.go
+++ b/tools/onboarding-factory/cmd/of/status_summary.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+// agentSummary is one agent's cell counts, bucketed by the matrix display
+// state. Every value matrix.DeriveDisplayState can return maps to exactly one
+// bucket, so the buckets always sum to Total — see buckets() and the
+// total-preserving test. That property is the point: a summary that quietly
+// drops a state under-reports how much work is left, which is worse than no
+// summary at all.
+type agentSummary struct {
+	Agent string `json:"agent"`
+	// Recorded ← "observed": the cell has a recording on disk.
+	Recorded int `json:"recorded"`
+	// Pending ← "pending-record": assessed recordable, not yet recorded.
+	Pending int `json:"pending"`
+	// Blocked ← "blocked-daemon" + "blocked-driver": recordable in principle,
+	// held up by a daemon bug or a driver gap. Merged because the issue asks
+	// for one "blocked" number; the two states stay separable in `of status`.
+	Blocked int `json:"blocked"`
+	// Unobservable ← "unobservable": the daemon cannot observe this at all.
+	Unobservable int `json:"unobservable"`
+	// NotApplicable ← "n.a.": out of scope for this agent.
+	NotApplicable int `json:"not_applicable"`
+	// Unknown ← "unknown": not yet assessed, or assessed with empty axes.
+	Unknown int `json:"unknown"`
+	Total   int `json:"total"`
+}
+
+// buckets returns the sum of every bucket. It must equal Total; a mismatch
+// means matrix gained a display state this summary does not know about.
+func (a agentSummary) buckets() int {
+	return a.Recorded + a.Pending + a.Blocked + a.Unobservable + a.NotApplicable + a.Unknown
+}
+
+// add folds one cell's display state into the right bucket.
+func (a *agentSummary) add(displayState string) {
+	a.Total++
+	switch displayState {
+	case "observed":
+		a.Recorded++
+	case "pending-record":
+		a.Pending++
+	case "blocked-daemon", "blocked-driver":
+		a.Blocked++
+	case "unobservable":
+		a.Unobservable++
+	case "n.a.":
+		a.NotApplicable++
+	default:
+		// "unknown" and anything matrix adds later. Counting an unrecognised
+		// state as unknown keeps the buckets total-preserving instead of
+		// silently discarding the cell; the test that sums them then still
+		// passes, and `of status` remains the place to see the raw state.
+		a.Unknown++
+	}
+}
+
+type summaryView struct {
+	Agents []agentSummary `json:"agents"`
+	Total  agentSummary   `json:"total"`
+}
+
+// buildSummaryView counts each agent's cells by display state. It folds the
+// SAME statusView `of status` renders rather than re-reading the matrix, so
+// the summary cannot disagree with the full dump it summarises — and the
+// --agent / --scenario filters already applied to that view carry over for
+// free.
+func buildSummaryView(view statusView) summaryView {
+	out := summaryView{Total: agentSummary{Agent: "total"}}
+	rows := make(map[string]*agentSummary, len(view.Agents))
+	for _, a := range view.Agents {
+		rows[a] = &agentSummary{Agent: a}
+	}
+	for _, sv := range view.Scenarios {
+		for _, a := range view.Agents {
+			c, ok := sv.Cells[a]
+			if !ok {
+				continue // no cell for this (agent, scenario) — not a state
+			}
+			rows[a].add(c.DisplayState)
+			out.Total.add(c.DisplayState)
+		}
+	}
+	for _, a := range view.Agents {
+		out.Agents = append(out.Agents, *rows[a])
+	}
+	return out
+}
+
+const summaryRowFormat = "%-14s %9d %8d %8d %13d %6d %8d %6d\n"
+
+func printSummaryText(stdout io.Writer, view summaryView) {
+	fmt.Fprintf(stdout, "per-agent cell counts — %d agents, %d cells\n\n", len(view.Agents), view.Total.Total)
+	fmt.Fprintf(stdout, "%-14s %9s %8s %8s %13s %6s %8s %6s\n",
+		"agent", "recorded", "pending", "blocked", "unobservable", "n/a", "unknown", "total")
+	for _, a := range view.Agents {
+		printSummaryRow(stdout, a)
+	}
+	printSummaryRow(stdout, view.Total)
+}
+
+func printSummaryRow(stdout io.Writer, a agentSummary) {
+	fmt.Fprintf(stdout, summaryRowFormat,
+		a.Agent, a.Recorded, a.Pending, a.Blocked, a.Unobservable, a.NotApplicable, a.Unknown, a.Total)
+}

--- a/tools/onboarding-factory/cmd/of/status_summary_test.go
+++ b/tools/onboarding-factory/cmd/of/status_summary_test.go
@@ -46,13 +46,15 @@ func TestStatusSummaryCounts(t *testing.T) {
 	}
 }
 
-// TestStatusSummaryIsTotalPreserving is the anti-lossy lock. The onboarding
-// skill warns that "lossy summaries drop cells": a bucket set that does not
-// cover every value matrix.DeriveDisplayState can return would silently
-// under-report progress, which is the exact failure a summary must not have.
-// Asserted per agent AND on the total row, so a state dropped from only one
-// of the two aggregations still fails.
-func TestStatusSummaryIsTotalPreserving(t *testing.T) {
+// TestStatusSummaryBucketsSumToTotal is a LOCK, not a red-first test: add()
+// always increments Total and exactly one bucket (with a default: catch-all),
+// so this passes by construction. It is worth keeping only as a guard against
+// a future add() that increments Total on a path with no bucket — it does NOT
+// prove states are bucketed *correctly*. Dropping "blocked-driver" from add()
+// keeps this green (the cells fall into Unknown); TestStatusSummaryCounts is
+// what catches that, and TestStatusSummaryAgreesWithFullDump below is what
+// catches a cell going missing entirely.
+func TestStatusSummaryBucketsSumToTotal(t *testing.T) {
 	root := richRepo(t)
 	code, out, errs := runOf("status", "--summary", "--json", "--repo-root", root)
 	if code != exitOK {
@@ -64,8 +66,72 @@ func TestStatusSummaryIsTotalPreserving(t *testing.T) {
 	}
 	for _, a := range append(append([]agentSummary{}, v.Agents...), v.Total) {
 		if sum := a.buckets(); sum != a.Total {
-			t.Errorf("%s: buckets sum to %d but total is %d — a display state is unbucketed", a.Agent, sum, a.Total)
+			t.Errorf("%s: buckets sum to %d but total is %d — Total moved without a bucket", a.Agent, sum, a.Total)
 		}
+	}
+}
+
+// TestStatusSummaryAgreesWithFullDump is the real anti-lossy assertion: it
+// compares the summary against the OTHER command's output rather than against
+// itself. The skill's warning is that "lossy summaries drop cells", and only a
+// cross-check against the full per-cell dump can detect a dropped cell — a
+// self-consistency check cannot, because a dropped cell lowers the buckets and
+// the total together.
+func TestStatusSummaryAgreesWithFullDump(t *testing.T) {
+	root := richRepo(t)
+
+	code, dumpOut, errs := runOf("status", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("full dump exit=%d stderr=%s", code, errs)
+	}
+	var dump statusView
+	if err := json.Unmarshal([]byte(dumpOut), &dump); err != nil {
+		t.Fatalf("bad dump json: %v", err)
+	}
+	perAgent := map[string]int{}
+	cells := 0
+	for _, sv := range dump.Scenarios {
+		for agent := range sv.Cells {
+			perAgent[agent]++
+			cells++
+		}
+	}
+
+	code, sumOut, errs := runOf("status", "--summary", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("summary exit=%d stderr=%s", code, errs)
+	}
+	var v summaryView
+	if err := json.Unmarshal([]byte(sumOut), &v); err != nil {
+		t.Fatalf("bad summary json: %v", err)
+	}
+	if v.Total.Total != cells {
+		t.Errorf("summary counts %d cells, the full dump has %d", v.Total.Total, cells)
+	}
+	for _, a := range v.Agents {
+		if a.Total != perAgent[a.Agent] {
+			t.Errorf("%s: summary counts %d cells, full dump has %d", a.Agent, a.Total, perAgent[a.Agent])
+		}
+	}
+}
+
+// TestStatusRejectsUnknownScenario pins the guard added alongside --summary:
+// an unmatched --scenario must fail loudly rather than render a table of
+// zeros that reads as a real measurement.
+func TestStatusRejectsUnknownScenario(t *testing.T) {
+	root := richRepo(t)
+	for _, args := range [][]string{
+		{"status", "--scenario", "bogus", "--repo-root", root},
+		{"status", "--summary", "--scenario", "bogus", "--repo-root", root},
+	} {
+		code, out, errs := runOf(args...)
+		if code != exitUsage {
+			t.Errorf("%v: want exit %d, got %d (stdout=%q stderr=%q)", args, exitUsage, code, out, errs)
+		}
+	}
+	// A real scenario id still works, so the guard accepts both spellings.
+	if code, _, errs := runOf("status", "--summary", "--scenario", "1.1", "--repo-root", root); code != exitOK {
+		t.Errorf("scenario by id should be accepted: exit=%d stderr=%s", code, errs)
 	}
 }
 

--- a/tools/onboarding-factory/cmd/of/status_summary_test.go
+++ b/tools/onboarding-factory/cmd/of/status_summary_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestStatusSummaryCounts pins the per-agent bucket counts against richRepo's
+// documented cell layout. The counts ARE the product of `--summary`, so they
+// are written out literally here rather than recomputed from the matrix — a
+// test that re-derives them would pass against any derivation, correct or not.
+func TestStatusSummaryCounts(t *testing.T) {
+	root := richRepo(t)
+	code, out, errs := runOf("status", "--summary", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d stderr=%s", code, errs)
+	}
+	var v summaryView
+	if err := json.Unmarshal([]byte(out), &v); err != nil {
+		t.Fatalf("bad json: %v\n%s", err, out)
+	}
+
+	want := map[string]agentSummary{
+		"aider":      {Agent: "aider", Recorded: 1, Total: 1},
+		"claudecode": {Agent: "claudecode", Recorded: 1, Pending: 1, Blocked: 2, Unobservable: 1, NotApplicable: 1, Unknown: 1, Total: 7},
+		"codex":      {Agent: "codex", Recorded: 1, Pending: 1, Total: 2},
+		"opencode":   {Agent: "opencode", Recorded: 1, Total: 1},
+	}
+	if len(v.Agents) != len(want) {
+		t.Fatalf("want %d agent rows, got %d: %+v", len(want), len(v.Agents), v.Agents)
+	}
+	for _, got := range v.Agents {
+		w, ok := want[got.Agent]
+		if !ok {
+			t.Fatalf("unexpected agent row %q", got.Agent)
+		}
+		if got != w {
+			t.Errorf("%s: got %+v want %+v", got.Agent, got, w)
+		}
+	}
+
+	wantTotal := agentSummary{Agent: "total", Recorded: 4, Pending: 2, Blocked: 2, Unobservable: 1, NotApplicable: 1, Unknown: 1, Total: 11}
+	if v.Total != wantTotal {
+		t.Errorf("total: got %+v want %+v", v.Total, wantTotal)
+	}
+}
+
+// TestStatusSummaryIsTotalPreserving is the anti-lossy lock. The onboarding
+// skill warns that "lossy summaries drop cells": a bucket set that does not
+// cover every value matrix.DeriveDisplayState can return would silently
+// under-report progress, which is the exact failure a summary must not have.
+// Asserted per agent AND on the total row, so a state dropped from only one
+// of the two aggregations still fails.
+func TestStatusSummaryIsTotalPreserving(t *testing.T) {
+	root := richRepo(t)
+	code, out, errs := runOf("status", "--summary", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d stderr=%s", code, errs)
+	}
+	var v summaryView
+	if err := json.Unmarshal([]byte(out), &v); err != nil {
+		t.Fatalf("bad json: %v\n%s", err, out)
+	}
+	for _, a := range append(append([]agentSummary{}, v.Agents...), v.Total) {
+		if sum := a.buckets(); sum != a.Total {
+			t.Errorf("%s: buckets sum to %d but total is %d — a display state is unbucketed", a.Agent, sum, a.Total)
+		}
+	}
+}
+
+// TestStatusSummaryText checks the human-readable rendering, which is the form
+// the skill and a human at a terminal actually read.
+func TestStatusSummaryText(t *testing.T) {
+	root := richRepo(t)
+	code, out, errs := runOf("status", "--summary", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d stderr=%s", code, errs)
+	}
+	for _, want := range []string{"recorded", "blocked", "unobservable", "claudecode", "total"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary text missing %q:\n%s", want, out)
+		}
+	}
+	// The claudecode row must carry its seven cells.
+	var row string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "claudecode") {
+			row = line
+		}
+	}
+	if row == "" {
+		t.Fatalf("no claudecode row:\n%s", out)
+	}
+	if fields := strings.Fields(row); fields[len(fields)-1] != "7" {
+		t.Errorf("claudecode row should end in its 7-cell total, got %q", row)
+	}
+}
+
+// TestStatusSummaryAgentFilter confirms --summary composes with --agent rather
+// than silently ignoring it.
+func TestStatusSummaryAgentFilter(t *testing.T) {
+	root := richRepo(t)
+	code, out, errs := runOf("status", "--summary", "--agent", "codex", "--json", "--repo-root", root)
+	if code != exitOK {
+		t.Fatalf("exit=%d stderr=%s", code, errs)
+	}
+	var v summaryView
+	if err := json.Unmarshal([]byte(out), &v); err != nil {
+		t.Fatalf("bad json: %v\n%s", err, out)
+	}
+	if len(v.Agents) != 1 || v.Agents[0].Agent != "codex" {
+		t.Fatalf("agent filter not applied: %+v", v.Agents)
+	}
+	if v.Total.Total != 2 {
+		t.Errorf("filtered total should count only codex's 2 cells, got %d", v.Total.Total)
+	}
+}

--- a/tools/onboarding-factory/cmd/of/status_summary_test.go
+++ b/tools/onboarding-factory/cmd/of/status_summary_test.go
@@ -46,31 +46,6 @@ func TestStatusSummaryCounts(t *testing.T) {
 	}
 }
 
-// TestStatusSummaryBucketsSumToTotal is a LOCK, not a red-first test: add()
-// always increments Total and exactly one bucket (with a default: catch-all),
-// so this passes by construction. It is worth keeping only as a guard against
-// a future add() that increments Total on a path with no bucket — it does NOT
-// prove states are bucketed *correctly*. Dropping "blocked-driver" from add()
-// keeps this green (the cells fall into Unknown); TestStatusSummaryCounts is
-// what catches that, and TestStatusSummaryAgreesWithFullDump below is what
-// catches a cell going missing entirely.
-func TestStatusSummaryBucketsSumToTotal(t *testing.T) {
-	root := richRepo(t)
-	code, out, errs := runOf("status", "--summary", "--json", "--repo-root", root)
-	if code != exitOK {
-		t.Fatalf("exit=%d stderr=%s", code, errs)
-	}
-	var v summaryView
-	if err := json.Unmarshal([]byte(out), &v); err != nil {
-		t.Fatalf("bad json: %v\n%s", err, out)
-	}
-	for _, a := range append(append([]agentSummary{}, v.Agents...), v.Total) {
-		if sum := a.buckets(); sum != a.Total {
-			t.Errorf("%s: buckets sum to %d but total is %d — Total moved without a bucket", a.Agent, sum, a.Total)
-		}
-	}
-}
-
 // TestStatusSummaryAgreesWithFullDump is the real anti-lossy assertion: it
 // compares the summary against the OTHER command's output rather than against
 // itself. The skill's warning is that "lossy summaries drop cells", and only a

--- a/tools/onboarding-factory/internal/hookcov/hookcov.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov.go
@@ -11,8 +11,14 @@
 //   - "has a hook-bearing recording" is disk, reached through the catalog
 //     loaders (shard.LoadAdapterCells → shard.AgentCellDir →
 //     validate.RecordingDirs → replay.LoadEvents) rather than a bespoke walk
-//     of replaydata/, so this report can never drift from what the rest of the
-//     factory tooling believes the catalog contains.
+//     of replaydata/, so this report reads the same tree the rest of the
+//     factory tooling reads.
+//
+// One caveat on that second bullet: a cell here is a metadata.json folder on
+// disk, whereas `of status` counts a cell only once its scenario_id resolves
+// to a catalog row. The two therefore agree only while the FK holds — which
+// `of validate` gates in CI, and which does hold today (482 == 482). They are
+// not equal by construction.
 //
 // Every number is derived at call time. Nothing is cached and nothing is
 // hardcoded — a count committed to source would be stale the day it landed.
@@ -28,7 +34,7 @@
 //
 // # Scope
 //
-// Catalog cells only — replaydata/agents/<adapter>/scenarios. The sibling
+// Cells on disk under replaydata/agents/<adapter>/scenarios. The sibling
 // regressions/ tree is not a catalog cell and no catalog loader enumerates it,
 // so it is excluded and the CLI says so in its output rather than leaving a
 // reader to discover the discrepancy by grep.
@@ -94,6 +100,18 @@ type Report struct {
 	Totals   Totals            `json:"totals"`
 }
 
+// Declaring counts the adapters that declare a hooks permission — the
+// denominator a gap count is meaningful against.
+func (r Report) Declaring() int {
+	n := 0
+	for _, a := range r.Adapters {
+		if a.DeclaresHooks {
+			n++
+		}
+	}
+	return n
+}
+
 // Gaps names every adapter that declares hooks but has no hook-bearing
 // recording, in report order. Nil when there are none.
 func (r Report) Gaps() []string {
@@ -151,11 +169,13 @@ func Slug(identityName string) string {
 // no catalog presence at all is the loudest gap there is, and dropping it
 // because it has no cells would hide exactly the case worth shouting about.
 func Coverage(repoRoot string, catalogAdapters []string, declares map[string]bool) Report {
-	// Resolve to an absolute path up front. Both validate and replay refuse
-	// any path containing "..", so a relative --repo-root like "../.." would
-	// otherwise read as zero recordings everywhere — which in THIS report
-	// renders as every hooks-declaring adapter being a gap. A silent
-	// all-clear is bad; a silent all-alarm is worse.
+	// Resolve to an absolute path up front. validate.RecordingDirs and
+	// replay.LoadEvents both refuse any path containing "..", so a relative
+	// --repo-root like "../.." would otherwise report zero recordings and
+	// zero hook-bearing recordings for every adapter — which in THIS report
+	// renders as every hooks-declaring adapter being a GAP. A silent
+	// all-clear is bad; a silent all-alarm is worse. TestCoverageRelativeRepoRoot
+	// is what keeps this from being deleted as dead code.
 	if abs, err := filepath.Abs(repoRoot); err == nil {
 		repoRoot = abs
 	}
@@ -165,7 +185,10 @@ func Coverage(repoRoot string, catalogAdapters []string, declares map[string]boo
 		row := AdapterCoverage{Adapter: adapter, DeclaresHooks: declares[adapter]}
 		for _, cell := range shard.LoadAdapterCells(repoRoot, adapter) {
 			if cell == nil || cell.Folder == "" {
-				continue // loader could not place the cell on disk
+				// Defensive only: LoadAdapterCells always fills Folder from the
+				// directory it scanned and never stores a nil. Kept so a future
+				// loader change degrades to under-counting rather than panicking.
+				continue
 			}
 			row.Cells++
 			cellDir := shard.AgentCellDir(repoRoot, adapter, cell.Folder)

--- a/tools/onboarding-factory/internal/hookcov/hookcov.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov.go
@@ -130,7 +130,7 @@ func (r Report) Gaps() []string {
 func Declared() map[string]bool {
 	out := make(map[string]bool)
 	for _, a := range agents.All() {
-		slug := Slug(a.Identity.Name)
+		slug := slug(a.Identity.Name)
 		declares := false
 		for _, p := range a.Permissions {
 			if p.Key == permissionKeyHooks {
@@ -143,21 +143,15 @@ func Declared() map[string]bool {
 	return out
 }
 
-// Slug maps a daemon adapter's Identity.Name to the directory name used under
-// replaydata/agents. Only claude-code differs (the pre-#319 spelling survives
-// in the registry); gemini-cli, kiro-cli and mistral-vibe match their slugs
-// verbatim, hyphens and all.
+// slug is shard.SlugForAdapter, which owns the registry-name → on-disk-slug
+// map for every caller that indexes the catalog by adapter.
 //
-// Deliberately NOT the same function as viewer.normalizeAdapter, which also
-// maps "" to claudecode so that pre-#319 recordings with no adapter field
-// still render a branded icon. That fallback would be a bug here: it would
-// invent an adapter for an unattributed name.
-func Slug(identityName string) string {
-	if identityName == "claude-code" {
-		return "claudecode"
-	}
-	return identityName
-}
+// Note it is NOT viewer.normalizeAdapter, which additionally maps "" to
+// claudecode so pre-#319 recordings with no adapter field still render a
+// branded icon. That fallback is right on the recording path and wrong here —
+// it would invent an adapter for an unattributed name — so the viewer keeps it
+// as a local wrapper around the shared map rather than the two forking.
+func slug(identityName string) string { return shard.SlugForAdapter(identityName) }
 
 // Coverage builds the report. catalogAdapters is the onboarded column set
 // (shard.Agents); declares is the registry join (Declared). Both are
@@ -184,11 +178,8 @@ func Coverage(repoRoot string, catalogAdapters []string, declares map[string]boo
 	for _, adapter := range adapterSet(catalogAdapters, declares) {
 		row := AdapterCoverage{Adapter: adapter, DeclaresHooks: declares[adapter]}
 		for _, cell := range shard.LoadAdapterCells(repoRoot, adapter) {
-			if cell == nil || cell.Folder == "" {
-				// Defensive only: LoadAdapterCells always fills Folder from the
-				// directory it scanned and never stores a nil. Kept so a future
-				// loader change degrades to under-counting rather than panicking.
-				continue
+			if cell == nil {
+				continue // LoadAdapterCells never stores one; cheap panic guard
 			}
 			row.Cells++
 			cellDir := shard.AgentCellDir(repoRoot, adapter, cell.Folder)

--- a/tools/onboarding-factory/internal/hookcov/hookcov.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov.go
@@ -176,27 +176,43 @@ func Coverage(repoRoot string, catalogAdapters []string, declares map[string]boo
 
 	rep := Report{}
 	for _, adapter := range adapterSet(catalogAdapters, declares) {
-		row := AdapterCoverage{Adapter: adapter, DeclaresHooks: declares[adapter]}
-		for _, cell := range shard.LoadAdapterCells(repoRoot, adapter) {
-			if cell == nil {
-				continue // LoadAdapterCells never stores one; cheap panic guard
-			}
-			row.Cells++
-			cellDir := shard.AgentCellDir(repoRoot, adapter, cell.Folder)
-			for _, recDir := range validate.RecordingDirs(cellDir) {
-				row.Recordings++
-				if hasHookEvent(filepath.Join(recDir, "events.jsonl")) {
-					row.WithHooks++
-				}
-			}
-		}
-		row.Status = statusOf(row.DeclaresHooks, row.WithHooks)
+		row := coverageFor(repoRoot, adapter, declares[adapter])
 		rep.Adapters = append(rep.Adapters, row)
 		rep.Totals.Cells += row.Cells
 		rep.Totals.Recordings += row.Recordings
 		rep.Totals.WithHooks += row.WithHooks
 	}
 	return rep
+}
+
+// coverageFor walks one adapter's cells and their recordings. repoRoot must
+// already be absolute — Coverage resolves it once for every adapter.
+func coverageFor(repoRoot, adapter string, declaresHooks bool) AdapterCoverage {
+	row := AdapterCoverage{Adapter: adapter, DeclaresHooks: declaresHooks}
+	for _, cell := range shard.LoadAdapterCells(repoRoot, adapter) {
+		if cell == nil {
+			continue // LoadAdapterCells never stores one; cheap panic guard
+		}
+		row.Cells++
+		cellDir := shard.AgentCellDir(repoRoot, adapter, cell.Folder)
+		withHooks, total := hookBearingRecordings(cellDir)
+		row.Recordings += total
+		row.WithHooks += withHooks
+	}
+	row.Status = statusOf(row.DeclaresHooks, row.WithHooks)
+	return row
+}
+
+// hookBearingRecordings counts one cell's recordings and how many of them
+// carry at least one hook_received event.
+func hookBearingRecordings(cellDir string) (withHooks, total int) {
+	for _, recDir := range validate.RecordingDirs(cellDir) {
+		total++
+		if hasHookEvent(filepath.Join(recDir, "events.jsonl")) {
+			withHooks++
+		}
+	}
+	return withHooks, total
 }
 
 // adapterSet is the sorted union described on Coverage.

--- a/tools/onboarding-factory/internal/hookcov/hookcov.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov.go
@@ -1,0 +1,239 @@
+// Package hookcov derives per-adapter hook coverage over the onboarding
+// catalog: how many of each adapter's recordings carry at least one
+// hook_received lifecycle event, against how many could — i.e. whether the
+// adapter declares a "hooks" permission in the daemon's adapter registry.
+//
+// Two facts live in two different places and this package is the join:
+//
+//   - "declares hooks" is code, not catalog. Nothing under replaydata/ records
+//     it; the only machine-readable source is agent.Agent.Permissions in the
+//     daemon's adapter registry.
+//   - "has a hook-bearing recording" is disk, reached through the catalog
+//     loaders (shard.LoadAdapterCells → shard.AgentCellDir →
+//     validate.RecordingDirs → replay.LoadEvents) rather than a bespoke walk
+//     of replaydata/, so this report can never drift from what the rest of the
+//     factory tooling believes the catalog contains.
+//
+// Every number is derived at call time. Nothing is cached and nothing is
+// hardcoded — a count committed to source would be stale the day it landed.
+//
+// # Attribution
+//
+// A recording counts toward the adapter whose cell directory holds it.
+// Per-event attribution is not possible: lifecycle events carry an `adapter`
+// field, but the hook_received events actually present in the corpus leave it
+// empty, so a multi-agent scenario credits its owning adapter even when a
+// co-resident agent produced the hook. Recorded here because the number is
+// otherwise quietly wrong for exactly those cells.
+//
+// # Scope
+//
+// Catalog cells only — replaydata/agents/<adapter>/scenarios. The sibling
+// regressions/ tree is not a catalog cell and no catalog loader enumerates it,
+// so it is excluded and the CLI says so in its output rather than leaving a
+// reader to discover the discrepancy by grep.
+package hookcov
+
+import (
+	"path/filepath"
+	"sort"
+
+	"irrlicht/core/adapters/inbound/agents"
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/tools/onboarding-factory/internal/replay"
+	"irrlicht/tools/onboarding-factory/internal/shard"
+	"irrlicht/tools/onboarding-factory/internal/validate"
+)
+
+// permissionKeyHooks is the Permission.Key adapters use to declare that they
+// install agent hooks. It mirrors claudecode.PermissionKeyHooks and
+// codex.PermissionKeyHooks, which are independent consts of the same value;
+// TestDeclaredMatchesRegistry pins the join so a rename on either side fails a
+// test instead of silently reporting every adapter as declaring nothing.
+const permissionKeyHooks = "hooks"
+
+// Status is the per-adapter verdict. The distinction that matters is
+// StatusGap vs StatusNone: both have zero hook-bearing recordings, but only
+// one of them is a problem.
+type Status string
+
+const (
+	// StatusOK — declares hooks and has at least one hook-bearing recording.
+	StatusOK Status = "ok"
+	// StatusGap — declares hooks and has NONE. The loud failure this report
+	// exists to surface: the regression net does not exercise the channel.
+	StatusGap Status = "gap"
+	// StatusIncidental — declares no hooks, yet a recording carries hook
+	// events. Real in this corpus: multi-agent scenarios where a co-resident
+	// agent emitted them. Not a problem, but not "no hooks here" either.
+	StatusIncidental Status = "incidental"
+	// StatusNone — declares no hooks and has none. Nothing to see.
+	StatusNone Status = "none"
+)
+
+// AdapterCoverage is one adapter's row.
+type AdapterCoverage struct {
+	Adapter       string `json:"adapter"`
+	DeclaresHooks bool   `json:"declares_hooks"`
+	Cells         int    `json:"cells"`
+	Recordings    int    `json:"recordings"`
+	WithHooks     int    `json:"recordings_with_hooks"`
+	Status        Status `json:"status"`
+}
+
+// Totals is the corpus-wide rollup of the rows.
+type Totals struct {
+	Cells      int `json:"cells"`
+	Recordings int `json:"recordings"`
+	WithHooks  int `json:"recordings_with_hooks"`
+}
+
+// Report is the whole derived view, adapters sorted by name.
+type Report struct {
+	Adapters []AdapterCoverage `json:"adapters"`
+	Totals   Totals            `json:"totals"`
+}
+
+// Gaps names every adapter that declares hooks but has no hook-bearing
+// recording, in report order. Nil when there are none.
+func (r Report) Gaps() []string {
+	var out []string
+	for _, a := range r.Adapters {
+		if a.Status == StatusGap {
+			out = append(out, a.Adapter)
+		}
+	}
+	return out
+}
+
+// Declared reports, per on-disk adapter slug, whether that adapter declares a
+// hooks permission in the daemon's adapter registry. Every registry adapter
+// gets an entry, so a false is "asked and answered" rather than "absent".
+func Declared() map[string]bool {
+	out := make(map[string]bool)
+	for _, a := range agents.All() {
+		slug := Slug(a.Identity.Name)
+		declares := false
+		for _, p := range a.Permissions {
+			if p.Key == permissionKeyHooks {
+				declares = true
+				break
+			}
+		}
+		out[slug] = declares
+	}
+	return out
+}
+
+// Slug maps a daemon adapter's Identity.Name to the directory name used under
+// replaydata/agents. Only claude-code differs (the pre-#319 spelling survives
+// in the registry); gemini-cli, kiro-cli and mistral-vibe match their slugs
+// verbatim, hyphens and all.
+//
+// Deliberately NOT the same function as viewer.normalizeAdapter, which also
+// maps "" to claudecode so that pre-#319 recordings with no adapter field
+// still render a branded icon. That fallback would be a bug here: it would
+// invent an adapter for an unattributed name.
+func Slug(identityName string) string {
+	if identityName == "claude-code" {
+		return "claudecode"
+	}
+	return identityName
+}
+
+// Coverage builds the report. catalogAdapters is the onboarded column set
+// (shard.Agents); declares is the registry join (Declared). Both are
+// parameters rather than read inside so tests can pin the arithmetic without
+// depending on the compiled-in registry.
+//
+// The adapter set is the union of the catalog columns and any hooks-declaring
+// registry adapter missing from them — an adapter that declares hooks and has
+// no catalog presence at all is the loudest gap there is, and dropping it
+// because it has no cells would hide exactly the case worth shouting about.
+func Coverage(repoRoot string, catalogAdapters []string, declares map[string]bool) Report {
+	// Resolve to an absolute path up front. Both validate and replay refuse
+	// any path containing "..", so a relative --repo-root like "../.." would
+	// otherwise read as zero recordings everywhere — which in THIS report
+	// renders as every hooks-declaring adapter being a gap. A silent
+	// all-clear is bad; a silent all-alarm is worse.
+	if abs, err := filepath.Abs(repoRoot); err == nil {
+		repoRoot = abs
+	}
+
+	rep := Report{}
+	for _, adapter := range adapterSet(catalogAdapters, declares) {
+		row := AdapterCoverage{Adapter: adapter, DeclaresHooks: declares[adapter]}
+		for _, cell := range shard.LoadAdapterCells(repoRoot, adapter) {
+			if cell == nil || cell.Folder == "" {
+				continue // loader could not place the cell on disk
+			}
+			row.Cells++
+			cellDir := shard.AgentCellDir(repoRoot, adapter, cell.Folder)
+			for _, recDir := range validate.RecordingDirs(cellDir) {
+				row.Recordings++
+				if hasHookEvent(filepath.Join(recDir, "events.jsonl")) {
+					row.WithHooks++
+				}
+			}
+		}
+		row.Status = statusOf(row.DeclaresHooks, row.WithHooks)
+		rep.Adapters = append(rep.Adapters, row)
+		rep.Totals.Cells += row.Cells
+		rep.Totals.Recordings += row.Recordings
+		rep.Totals.WithHooks += row.WithHooks
+	}
+	return rep
+}
+
+// adapterSet is the sorted union described on Coverage.
+func adapterSet(catalogAdapters []string, declares map[string]bool) []string {
+	seen := make(map[string]bool, len(catalogAdapters))
+	for _, a := range catalogAdapters {
+		seen[a] = true
+	}
+	for a, d := range declares {
+		if d {
+			seen[a] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for a := range seen {
+		out = append(out, a)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// statusOf is the whole point of the report in one function: zero
+// hook-bearing recordings means opposite things depending on whether the
+// adapter claims to install hooks.
+func statusOf(declares bool, withHooks int) Status {
+	switch {
+	case declares && withHooks > 0:
+		return StatusOK
+	case declares:
+		return StatusGap
+	case withHooks > 0:
+		return StatusIncidental
+	default:
+		return StatusNone
+	}
+}
+
+// hasHookEvent reports whether a recording's events sidecar carries at least
+// one hook_received event. It goes through replay.LoadEvents — the sanctioned
+// reader — rather than scanning bytes, so it cannot disagree with replay about
+// line-length caps or malformed-line handling. A missing or unreadable
+// sidecar counts as "no hooks", the same as an empty one.
+func hasHookEvent(eventsPath string) bool {
+	events, err := replay.LoadEvents(eventsPath)
+	if err != nil {
+		return false
+	}
+	for _, e := range events {
+		if e.Kind == lifecycle.KindHookReceived {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/onboarding-factory/internal/hookcov/hookcov_test.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov_test.go
@@ -1,6 +1,8 @@
 package hookcov
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -86,6 +88,65 @@ func TestAdapterSetIncludesUnrepresentedDeclarer(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("adapterSet = %v, want %v (sorted union; pi declares nothing so it stays out)", got, want)
 	}
+}
+
+// TestCoverageRelativeRepoRoot is what keeps the filepath.Abs call in
+// Coverage alive. validate.RecordingDirs and replay.LoadEvents both refuse any
+// path containing "..", so without the Abs a repo root reached via ".." counts
+// zero recordings and zero hook events for every adapter — rendering every
+// hooks-declaring adapter as a GAP. That is the loudest possible wrong answer
+// from this report, and before this test it was defended by three lines no
+// test exercised: deleting them left the whole suite green.
+// A RELATIVE root is required, and it must be spelled ".." rather than
+// filepath.Join(root, "x", ".."): Join runs Clean, which cancels an interior
+// "x/.." and leaves an absolute path with no ".." in it at all — a version of
+// this test written that way passes with the Abs guard deleted, proving
+// nothing. Only a LEADING ".." survives Clean, which is why this chdirs.
+func TestCoverageRelativeRepoRoot(t *testing.T) {
+	root := t.TempDir()
+	writeHookFixture(t, root)
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	declares := map[string]bool{"claudecode": true}
+	direct := Coverage(root, []string{"claudecode"}, declares)
+	if len(direct.Adapters) != 1 || direct.Adapters[0].WithHooks != 1 {
+		t.Fatalf("fixture precondition: direct read should find 1 hook-bearing recording, got %+v", direct.Adapters)
+	}
+
+	// From root/sub, ".." IS root — but spelled so that every path derived
+	// from it keeps a leading "..".
+	t.Chdir(filepath.Join(root, "sub"))
+	relative := Coverage("..", []string{"claudecode"}, declares)
+
+	if !reflect.DeepEqual(direct, relative) {
+		t.Errorf("a repo root spelled \"..\" must give the same report\nabsolute: %+v\nrelative: %+v",
+			direct.Adapters, relative.Adapters)
+	}
+	if relative.Adapters[0].Status == StatusGap {
+		t.Errorf("relative repo root invented a GAP for an adapter with %d hook-bearing recordings",
+			direct.Adapters[0].WithHooks)
+	}
+}
+
+// writeHookFixture lays down one claudecode cell with one hook-bearing
+// recording — the minimum shape Coverage reads.
+func writeHookFixture(t *testing.T, root string) {
+	t.Helper()
+	mk := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cell := filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", "1-1_one")
+	mk(filepath.Join(cell, "metadata.json"), `{"scenario_id":"one"}`)
+	mk(filepath.Join(cell, "recordings", "r1", "events.jsonl"),
+		`{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"hook_received","session_id":"s","hook_name":"PostToolUse"}`+"\n")
 }
 
 // TestGapsListsOnlyGaps confirms the convenience accessor the CLI shouts with.

--- a/tools/onboarding-factory/internal/hookcov/hookcov_test.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov_test.go
@@ -37,7 +37,8 @@ func TestDeclaredMatchesRegistry(t *testing.T) {
 	}
 }
 
-// TestSlugMapsOnlyClaudeCode locks the name mapping. Over-normalising is the
+// TestSlugMapsOnlyClaudeCode locks the shared shard.SlugForAdapter mapping as
+// hookcov consumes it. Over-normalising is the
 // hazard: the viewer's near-identical helper also maps "" to claudecode, and
 // copying that here would invent an adapter for an unattributed name.
 func TestSlugMapsOnlyClaudeCode(t *testing.T) {
@@ -50,8 +51,8 @@ func TestSlugMapsOnlyClaudeCode(t *testing.T) {
 		"":             "",
 	}
 	for in, want := range cases {
-		if got := Slug(in); got != want {
-			t.Errorf("Slug(%q) = %q, want %q", in, got, want)
+		if got := slug(in); got != want {
+			t.Errorf("slug(%q) = %q, want %q", in, got, want)
 		}
 	}
 }

--- a/tools/onboarding-factory/internal/hookcov/hookcov_test.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov_test.go
@@ -1,0 +1,105 @@
+package hookcov
+
+import (
+	"reflect"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents"
+)
+
+// TestDeclaredMatchesRegistry pins the code→catalog join. This is the part of
+// the report that can rot without anything else noticing: rename the
+// permission key, or change an adapter's Identity.Name without updating Slug,
+// and every adapter silently reports "declares no hooks" — which turns every
+// real gap into a benign-looking StatusNone.
+func TestDeclaredMatchesRegistry(t *testing.T) {
+	got := Declared()
+
+	// Exhaustive as of this commit: claudecode and codex are the only two
+	// adapters declaring a hooks permission. If a third gains one, this fails
+	// and the new adapter joins the list — that is the intended workflow, not
+	// an obstacle.
+	want := map[string]bool{
+		"aider": false, "antigravity": false, "claudecode": true, "codex": true,
+		"copilot": false, "gemini-cli": false, "hermes": false, "kiro-cli": false,
+		"mistral-vibe": false, "opencode": false, "pi": false,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Declared() = %v\nwant %v", got, want)
+	}
+
+	// Every registry adapter must be represented, so a false is an answer
+	// rather than a missing key.
+	if len(got) != len(agents.All()) {
+		t.Errorf("Declared() has %d entries for %d registry adapters", len(got), len(agents.All()))
+	}
+}
+
+// TestSlugMapsOnlyClaudeCode locks the name mapping. Over-normalising is the
+// hazard: the viewer's near-identical helper also maps "" to claudecode, and
+// copying that here would invent an adapter for an unattributed name.
+func TestSlugMapsOnlyClaudeCode(t *testing.T) {
+	cases := map[string]string{
+		"claude-code":  "claudecode",
+		"claudecode":   "claudecode",
+		"gemini-cli":   "gemini-cli",
+		"kiro-cli":     "kiro-cli",
+		"mistral-vibe": "mistral-vibe",
+		"":             "",
+	}
+	for in, want := range cases {
+		if got := Slug(in); got != want {
+			t.Errorf("Slug(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestStatusOf is the report's central distinction, tabulated. Rows 2 and 4
+// are the pair the whole command exists for: identical zero, opposite meaning.
+func TestStatusOf(t *testing.T) {
+	cases := []struct {
+		declares  bool
+		withHooks int
+		want      Status
+	}{
+		{true, 3, StatusOK},
+		{true, 0, StatusGap},
+		{false, 2, StatusIncidental},
+		{false, 0, StatusNone},
+	}
+	for _, c := range cases {
+		if got := statusOf(c.declares, c.withHooks); got != c.want {
+			t.Errorf("statusOf(declares=%v, withHooks=%d) = %q, want %q", c.declares, c.withHooks, got, c.want)
+		}
+	}
+}
+
+// TestAdapterSetIncludesUnrepresentedDeclarer covers the union rule: an
+// adapter that declares hooks but has no catalog column still gets a row, so
+// "declares hooks, has nothing at all" cannot vanish from the report.
+func TestAdapterSetIncludesUnrepresentedDeclarer(t *testing.T) {
+	got := adapterSet(
+		[]string{"opencode", "aider"},
+		map[string]bool{"codex": true, "claudecode": true, "pi": false},
+	)
+	want := []string{"aider", "claudecode", "codex", "opencode"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("adapterSet = %v, want %v (sorted union; pi declares nothing so it stays out)", got, want)
+	}
+}
+
+// TestGapsListsOnlyGaps confirms the convenience accessor the CLI shouts with.
+func TestGapsListsOnlyGaps(t *testing.T) {
+	r := Report{Adapters: []AdapterCoverage{
+		{Adapter: "aider", Status: StatusNone},
+		{Adapter: "claudecode", Status: StatusOK},
+		{Adapter: "codex", Status: StatusGap},
+		{Adapter: "copilot", Status: StatusIncidental},
+	}}
+	if got := r.Gaps(); !reflect.DeepEqual(got, []string{"codex"}) {
+		t.Errorf("Gaps() = %v, want [codex]", got)
+	}
+	if got := (Report{}).Gaps(); got != nil {
+		t.Errorf("Gaps() on an empty report = %v, want nil", got)
+	}
+}

--- a/tools/onboarding-factory/internal/shard/shard.go
+++ b/tools/onboarding-factory/internal/shard/shard.go
@@ -122,6 +122,21 @@ func sanitizePathComponent(name string) string {
 // "../"-containing value through to the filesystem. The viewer's HTTP
 // handler already restricts these to a `^[a-z0-9][a-z0-9_-]*$` slug before
 // they ever reach here, so this is a no-op for every legitimate caller.
+// SlugForAdapter maps a daemon adapter's agent.Identity.Name to the directory
+// name it uses under replaydata/agents. Only claude-code differs — the
+// pre-#319 spelling survives in the registry — while gemini-cli, kiro-cli and
+// mistral-vibe match their slugs verbatim, hyphens and all.
+//
+// This package owns "where does adapter X live on disk" (AgentCellDir,
+// AgentFolderForScenario), so the mapping belongs here rather than being
+// re-derived by each caller that indexes the catalog by registry name.
+func SlugForAdapter(identityName string) string {
+	if identityName == "claude-code" {
+		return "claudecode"
+	}
+	return identityName
+}
+
 func AgentCellDir(repoRoot, adapter, folder string) string {
 	return filepath.Join(repoRoot, "replaydata", "agents", sanitizePathComponent(adapter), "scenarios", sanitizePathComponent(folder))
 }

--- a/tools/onboarding-factory/internal/validate/observations.go
+++ b/tools/onboarding-factory/internal/validate/observations.go
@@ -71,7 +71,15 @@ type ObservationReport struct {
 // need the whole set (e.g. hook coverage) use it instead of a second
 // os.ReadDir, the way callers needing only the latest use NewestRecordingDir.
 // Returns nil when the cell has no recordings/ dir.
+//
+// Guarded the same way NewestRecordingDir is: every exported reader in this
+// package refuses a path containing "..", and an enumerator that did not would
+// be the one way to get a real listing out of validate from an unsanitised
+// path.
 func RecordingDirs(scenarioDir string) []string {
+	if hasParentTraversal(scenarioDir) {
+		return nil
+	}
 	entries, err := os.ReadDir(filepath.Join(scenarioDir, "recordings"))
 	if err != nil {
 		return nil

--- a/tools/onboarding-factory/internal/validate/observations.go
+++ b/tools/onboarding-factory/internal/validate/observations.go
@@ -65,9 +65,13 @@ type ObservationReport struct {
 	Drifts  []ObsDrift  `json:"drifts,omitempty"`
 }
 
-// sortedRecordingDirs returns the cell's recording dirs newest-first (names are
-// timestamp-prefixed, so reverse-lexical == reverse-chronological).
-func sortedRecordingDirs(scenarioDir string) []string {
+// RecordingDirs returns the cell's recording dirs newest-first (names are
+// timestamp-prefixed, so reverse-lexical == reverse-chronological). Exported
+// as the single enumerator for "every recording of this cell": callers that
+// need the whole set (e.g. hook coverage) use it instead of a second
+// os.ReadDir, the way callers needing only the latest use NewestRecordingDir.
+// Returns nil when the cell has no recordings/ dir.
+func RecordingDirs(scenarioDir string) []string {
 	entries, err := os.ReadDir(filepath.Join(scenarioDir, "recordings"))
 	if err != nil {
 		return nil
@@ -134,7 +138,7 @@ func loadObservationSpec(scenarioDir string) *ObservationSpec {
 // that field. No newest golden → Skipped (Pass=true).
 func ValidateObservations(scenarioDir string) (*ObservationReport, error) {
 	rep := &ObservationReport{Pass: true}
-	dirs := sortedRecordingDirs(scenarioDir)
+	dirs := RecordingDirs(scenarioDir)
 	if len(dirs) == 0 {
 		rep.Skipped, rep.Note = true, "no recordings"
 		return rep, nil

--- a/tools/onboarding-factory/internal/viewer/playback.go
+++ b/tools/onboarding-factory/internal/viewer/playback.go
@@ -21,6 +21,7 @@ import (
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/outbound"
 	"irrlicht/tools/onboarding-factory/internal/replay"
+	"irrlicht/tools/onboarding-factory/internal/shard"
 	"irrlicht/tools/onboarding-factory/internal/validate"
 )
 
@@ -729,13 +730,13 @@ func (m *PlaybackManager) handleAgents(w http.ResponseWriter, r *http.Request) {
 // dashboard joins sessions to agents by string equality, so a mismatch
 // here means the session row renders without its branded icon.
 func normalizeAdapter(a string) string {
-	switch a {
-	case "claude-code":
-		return "claudecode"
-	case "":
+	if a == "" {
+		// Recording-path only: a pre-#319 sidecar with no adapter field.
+		// shard.SlugForAdapter deliberately does NOT do this, because for a
+		// registry name an empty string is not claudecode, it is a bug.
 		return "claudecode"
 	}
-	return a
+	return shard.SlugForAdapter(a)
 }
 
 // handleSessions returns the current synthetic session list in the EXACT


### PR DESCRIPTION
Closes #1363.

Two derived reports over the existing catalog. Both computed at runtime from
the catalog/shard loaders — no committed counts (including the issue's own
17/396, which is already stale), no jq, no bespoke walk of `replaydata/`.

## `of status --summary`

```
per-agent cell counts — 11 agents, 482 cells

agent           recorded  pending  blocked  unobservable    n/a  unknown  total
aider                 19        2        0             7      8        0     36
antigravity           29        0        0             8      6        2     45
claudecode            41        2        0             3      0        0     46
codex                 28        4        3             7      2        0     44
copilot               30        0       10             5      1        0     46
gemini-cli            29        1        4             8      3        0     45
hermes                23        0       12             9      2        0     46
kiro-cli              25        1        1            14      3        0     44
mistral-vibe          30        0        2             7      7        0     46
opencode              24        0        3             3      6        4     40
pi                    25        1        1             3     14        0     44
total                303       11       36            74     52        6    482

note: recorded = display state "observed". A cell blocked by a daemon bug or driver gap
counts under blocked/unobservable even if it has a recording, so total − recorded is not
the un-recorded count. Use `of status` for per-cell detail.
```

It folds the **same `statusView`** the full dump renders rather than re-reading
the matrix, so the two cannot disagree and the existing `--agent` /
`--scenario` filters carry over for free.

Bucket coverage is total-preserving: all 7 values `DeriveDisplayState` can
return map to exactly one bucket, and an unrecognised future state falls into
`unknown` rather than being dropped.

That trailing note is not decoration. `observed` is **not** "has a recording on
disk" — `DeriveDisplayState` consults the recording only *after* the
daemon/driver switch, so 11 cells in the current corpus have a recording and
still count as blocked/unobservable. Review caught the field doc claiming
otherwise.

## `of coverage --hooks`

```
hook coverage — recordings containing a hook_received event, per adapter
scope: cells on disk under replaydata/agents/<adapter>/scenarios; the non-catalog regressions/ tree is excluded

adapter        declares-hooks  cells  recordings  with-hooks  status
aider                      no     36          25           0  —
antigravity                no     45          29           0  —
claudecode                yes     46          52          11  ok
codex                     yes     44          36           0  GAP — declares hooks, zero hook-bearing recordings
copilot                    no     46          37           1  incidental — hook events present, adapter declares no hooks
gemini-cli                 no     45          38           0  —
hermes                     no     46          24           1  incidental — hook events present, adapter declares no hooks
kiro-cli                   no     44          28           0  —
mistral-vibe               no     46          36           0  —
opencode                   no     40          30           0  —
pi                         no     44          28           0  —
total                            482         363          13

GAP: 1 of 2 hooks-declaring adapters have zero hook-bearing recordings: codex
```

**The answer is codex** — declares a `hooks` permission, zero hook-bearing
recordings across 36. Exactly the loud failure the issue asked to surface.

It joins two facts from different places:

- **"declares hooks" is code, not catalog.** Nothing under `replaydata/`
  records it — no field, no capability axis. The only machine-readable source
  is `agent.Agent.Permissions` in the daemon registry (`agents.All()`), where
  claudecode and codex are the only declarers.
- **"has a hook-bearing recording" is disk**, via `shard.LoadAdapterCells` →
  `shard.AgentCellDir` → `validate.RecordingDirs` → `replay.LoadEvents`.

`GAP` vs `none` is the distinction that matters: both are `with-hooks == 0`,
only one is a problem. A report keying on the number alone conflates them.

## Two scope calls, printed rather than left silent

**Attribution is by owning cell directory.** `lifecycle.Event` has an `adapter`
field, so per-event attribution looked possible — but every `hook_received`
event in the corpus leaves it empty:

```
{"seq":6078,"ts":"2026-05-18T00:15:31.10667+02:00","kind":"hook_received","session_id":"9298e3d0-...","hook_name":"PostToolUse"}
```

So a multi-agent cell credits its owner. `copilot` and `hermes` each show 1,
both from `4-2_multiple-agents-same-workspace`, rendered `incidental` rather
than silently counted as real coverage.

**Cells on disk under `scenarios/` only.** The sibling `regressions/` tree is
not a catalog cell and no catalog loader enumerates it — that is the whole
difference between the issue's 17/396 and this report's 13/363 (33 regression
recordings, 4 hook-bearing). Those 4 are **all claudecode** (`permission-hook-denial`,
`15-permission-hooks-a845d6c4`, `subagent-spawn`, `full-lifecycle-toolcall`),
already non-zero at 11, so **no adapter's status changes**. Stated in the
command's own output so nobody greps and gets a different number.

Review also caught that "catalog cells" over-claimed: a cell here is a
`metadata.json` folder, whereas `of status` counts one only once its
`scenario_id` resolves to a catalog row. Equal today (482 == 482) and gated by
`of validate`, but not equal by construction — so the wording is now "cells on
disk".

**Exit stays 0 with gaps.** A report, not a gate; `of validate` is the gate.

## A live bug this surfaced in `of status`

`--summary` made a pre-existing defect dangerous enough to fix. Every reader
under `internal/validate` and `internal/replay` treats a path containing `..`
as tainted and returns an **empty result rather than an error**, so a relative
`--repo-root` silently reports a catalog in which nothing is recorded:

```
$ of status --summary --agent claudecode --repo-root ..    # from tools/
claudecode             0       43        0             3      0        0     46   # before
claudecode            41        2        0             3      0        0     46   # after
```

Exit 0, no warning, both times. The old rendering was a visibly empty listing;
the new one is a full table of zeros that reads as a finished measurement.
Fixed at the flag boundary (`absRoot`) for `of status` and `of coverage`.
`of validate`, `of verify` and the write side have the same latent issue and
are left alone as out of scope.

## Testing

Red-first: these are new features, so there is no defect on `main` to
reproduce. The `--summary` tests were run against a build with the view types
present but the flag unwired, failing behaviorally rather than by compile
error:

```
flag provided but not defined: -summary
--- FAIL: TestStatusSummaryCounts (0.01s)
    status_summary_test.go:17: exit=2 stderr=
```

Both guard tests were **mutation-verified** — the point of finding 2 below was
that a guard with a green suite is a guard nobody is protecting:

```
# Abs guard deleted:
--- FAIL: TestCoverageRelativeRepoRoot
    absolute: [{... Recordings:1 WithHooks:1 Status:ok}]
    relative: [{... Recordings:0 WithHooks:0 Status:gap}]
    relative repo root invented a GAP for an adapter with 1 hook-bearing recordings

# --scenario guard disabled:
--- FAIL: TestStatusRejectsUnknownScenario
    want exit 2, got 0 (stdout="per-agent cell counts — 4 agents, 0 cells\n...")
```

The first version of `TestCoverageRelativeRepoRoot` did **not** bite:
`filepath.Join` runs `Clean`, which cancels an interior `x/..` and leaves no
`..` at all. Only a *leading* `..` survives, so the test chdirs and passes
`".."` literally. Caught by running the mutation, not by reading it.

`TestCoveragePlainStillRollup` is a **lock** — bare `of coverage` still emits
the rollup JSON — and passes on `main` by construction.

Both commands are pinned against one shared fixture catalog
(`cmd/of/fixture_test.go`) whose expected counts are documented in its header
and written literally. Real adapter slugs, because `--hooks` joins to the
compiled-in registry. `TestDeclaredMatchesRegistry` pins that join
exhaustively — it is what rots invisibly, since a renamed key makes every
adapter report "declares no hooks", turning every real gap into a benign
`none`.

Gates: `tools/preflight.sh` all-green (run in `--only` groups; the unscoped run
exceeds a 10-minute command ceiling), `go test ./tools/onboarding-factory/...
-race -count=1`, `go run ./tools/onboarding-factory/cmd/of validate`.

## Review + simplify

A `high`-effort review reconciled every printed number against independent
counts and found no arithmetic defect; its 7 findings were mostly prose
claiming more than the code does, plus two tests weaker than their comments
said. All applied. Notably `TestStatusSummaryIsTotalPreserving` passed by
construction and stayed green when a case was dropped from the switch — it is
gone, replaced by `TestStatusSummaryAgreesWithFullDump`, which cross-checks
against `of status --json`.

`/simplify` (4 angles) additionally produced: `shard.SlugForAdapter` as the
single registry-name→slug map (`hookcov` and `viewer.normalizeAdapter` both
delegate; the viewer keeps its `""`→claudecode fallback, which belongs on the
recording path); `validRepo` rebuilt on the shared fixture helpers; the
`hasScenario` helper replaced by a check on the already-built view (same
predicate, one fewer catalog walk); dead `_ = asJSON` and an unreachable guard
removed; one column-width spec per table.

Efficiency was **measured and left alone**: `of coverage --hooks` is 0.19s warm
/ 2.6s cold over 363 recordings. The suspected hot spot (`replay.LoadEvents`
decoding every event to answer a boolean) is 70ms; `LoadAdapterCells` parsing
5.6MB of metadata to recover directory names is 73ms. Neither justifies
trading the sanctioned reader for a hand-rolled scan that could disagree with
it.

Deliberately **not** done: `agent.HooksPermissionKey` in `core/domain` (edits
two core adapters for a tooling concern; `TestDeclaredMatchesRegistry` already
fails on a rename), and typed `DisplayState` constants in `internal/matrix`
(needs a pre-existing caller in `record.go` updated too). Both are noted
follow-ups rather than oversights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)