### PR TITLE
fix(hooks): drive --uninstall-hooks and the recording rig off the agent registry

### DIFF
--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -88,6 +88,10 @@ func Agent() agent.Agent {
 					"`irrlichd --uninstall-hooks`).",
 				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
 				Remove: func() error { _, err := UninstallHooks(); return err },
+				Hooks: &agent.HookInstall{
+					ConfigPath: claudeSettingsPath,
+					Uninstall:  UninstallHooks,
+				},
 			},
 			{
 				Key:             PermissionKeyStatusline,

--- a/core/adapters/inbound/agents/codex/agent.go
+++ b/core/adapters/inbound/agents/codex/agent.go
@@ -76,6 +76,10 @@ func Agent() agent.Agent {
 					"running Codex's cli_version. Toggling off removes the entries.",
 				Apply:  func() error { return applyCodexHooks() },
 				Remove: func() error { _, err := UninstallHooks(); return err },
+				Hooks: &agent.HookInstall{
+					ConfigPath: codexHooksPath,
+					Uninstall:  UninstallHooks,
+				},
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/hookconfigs.go
+++ b/core/adapters/inbound/agents/hookconfigs.go
@@ -1,0 +1,71 @@
+package agents
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"irrlicht/core/domain/agent"
+)
+
+// HookConfig is one adapter's declared hook config file, resolved.
+type HookConfig struct {
+	// Adapter is the adapter label (agent.Identity.Name) — the key the
+	// consent store records permissions under.
+	Adapter string
+	// Key is the permission key the hooks are declared under.
+	Key string
+	// Path is the resolved, absolute config file the hooks live in.
+	Path string
+	// Uninstall removes irrlicht's entries from Path, reporting whether it
+	// modified anything.
+	Uninstall func() (bool, error)
+}
+
+// HookConfigs projects the adapter registry onto the set of agent config files
+// irrlicht installs hooks into — the single source both `irrlichd
+// --uninstall-hooks` and the onboarding recorder's config snapshot read (#1357).
+//
+// Before this existed each of them carried its own two-element literal list.
+// Both were correct, and both would have been silently wrong the first time a
+// third hook adapter landed: uninstall would leave that agent's entries in the
+// user's real config pointing at a dead port forever, and a recording would
+// repoint the same file at a dead recorder port and never hand it back.
+//
+// A declaration that is present but unusable is an error rather than a skip.
+// Dropping it would reproduce exactly the failure this function exists to
+// remove — a hook-installing adapter absent from both lists — only harder to
+// notice, because nothing would say so.
+//
+// It takes the adapter slice rather than calling All() itself, matching the
+// other registry projections in maps.go. Note the daemon's consent catalog is
+// All() PLUS three non-agent declarations appended in startup.go (gastown,
+// launcher, kitty) — those are not projected here, and the tripwire holding
+// them to that is TestNonAgentPermissionDeclarationsDeclareNoHooks in
+// core/cmd/irrlichd.
+func HookConfigs(all []agent.Agent) ([]HookConfig, error) {
+	var out []HookConfig
+	for _, a := range all {
+		for _, p := range a.Permissions {
+			if p.Hooks == nil {
+				continue
+			}
+			if p.Hooks.ConfigPath == nil || p.Hooks.Uninstall == nil {
+				return nil, fmt.Errorf("adapter %q permission %q: HookInstall needs both ConfigPath and Uninstall", a.Identity.Name, p.Key)
+			}
+			path, err := p.Hooks.ConfigPath()
+			if err != nil {
+				return nil, fmt.Errorf("adapter %q permission %q: resolve hook config path: %w", a.Identity.Name, p.Key, err)
+			}
+			if !filepath.IsAbs(path) {
+				return nil, fmt.Errorf("adapter %q permission %q: hook config path %q is not absolute", a.Identity.Name, p.Key, path)
+			}
+			out = append(out, HookConfig{
+				Adapter:   a.Identity.Name,
+				Key:       p.Key,
+				Path:      path,
+				Uninstall: p.Hooks.Uninstall,
+			})
+		}
+	}
+	return out, nil
+}

--- a/core/adapters/inbound/agents/hookconfigs_test.go
+++ b/core/adapters/inbound/agents/hookconfigs_test.go
@@ -1,0 +1,144 @@
+package agents
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+)
+
+// TestEveryHooksPermissionIsCoveredByHookConfigs is the coverage check #1357
+// asks for: an adapter that declares a hooks permission must also declare WHERE
+// those hooks go, so both of the places that have to enumerate agent config
+// files — `irrlichd --uninstall-hooks` and the onboarding recorder's snapshot —
+// see it without anyone remembering to add it twice.
+//
+// Contract test, not a defect test: it passes by construction against a correct
+// adapter set, and its whole value is that it CAN fail. It was seen red by
+// dropping codex's Hooks declaration (see the PR body).
+//
+// The key match is a substring rather than an equality on "hooks" so an adapter
+// that spells its permission key differently is still held to the contract.
+func TestEveryHooksPermissionIsCoveredByHookConfigs(t *testing.T) {
+	configs, err := HookConfigs(All())
+	if err != nil {
+		t.Fatalf("HookConfigs(): %v", err)
+	}
+
+	covered := make(map[string]bool, len(configs))
+	for _, c := range configs {
+		id := c.Adapter + "/" + c.Key
+		if covered[id] {
+			t.Errorf("%s is listed twice by HookConfigs()", id)
+		}
+		covered[id] = true
+		if !filepath.IsAbs(c.Path) {
+			t.Errorf("%s: hook config path %q is not absolute — the recorder backs up and restores exactly this path", id, c.Path)
+		}
+		if c.Uninstall == nil {
+			t.Errorf("%s: HookConfigs() returned a nil Uninstall", id)
+		}
+	}
+
+	declared := 0
+	for _, a := range All() {
+		for _, p := range a.Permissions {
+			if !strings.Contains(strings.ToLower(p.Key), "hook") {
+				continue
+			}
+			declared++
+			id := a.Identity.Name + "/" + p.Key
+			if p.Hooks == nil {
+				t.Errorf("%s declares a hooks permission but no agent.HookInstall: "+
+					"`irrlichd --uninstall-hooks` would leave its entries in the user's real "+
+					"config permanently, and a recording would repoint that file at a dead "+
+					"recorder port and never hand it back (#1357)", id)
+				continue
+			}
+			if !covered[id] {
+				t.Errorf("%s declares an agent.HookInstall that HookConfigs() does not list", id)
+			}
+		}
+	}
+
+	if declared == 0 {
+		t.Fatal("no adapter declares a hooks permission — this check would pass vacuously")
+	}
+	if len(configs) != declared {
+		t.Errorf("HookConfigs() returned %d entries for %d declared hooks permissions", len(configs), declared)
+	}
+}
+
+// hookAdapter builds a one-permission adapter carrying the given HookInstall.
+func hookAdapter(name string, h *agent.HookInstall) agent.Agent {
+	return agent.Agent{
+		Identity:    agent.Identity{Name: name},
+		Permissions: []agent.Permission{{Key: "hooks", Kind: permission.KindModify, Hooks: h}},
+	}
+}
+
+// TestHookConfigsRejectsUnusableDeclarations covers the branches that become
+// log.Fatalf in `irrlichd --uninstall-hooks`. A half-declared HookInstall must
+// be an error rather than a silent skip: skipping would reproduce exactly the
+// failure HookConfigs exists to remove — a hook-installing adapter absent from
+// both lists — only harder to notice, because nothing would say so.
+func TestHookConfigsRejectsUnusableDeclarations(t *testing.T) {
+	ok := func() (string, error) { return "/tmp/x/settings.json", nil }
+	uninstall := func() (bool, error) { return false, nil }
+
+	cases := []struct {
+		name    string
+		install *agent.HookInstall
+		want    string
+	}{
+		{"nil ConfigPath", &agent.HookInstall{Uninstall: uninstall}, "ConfigPath"},
+		{"nil Uninstall", &agent.HookInstall{ConfigPath: ok}, "Uninstall"},
+		{"resolve fails", &agent.HookInstall{
+			ConfigPath: func() (string, error) { return "", errors.New("no home dir") },
+			Uninstall:  uninstall,
+		}, "no home dir"},
+		{"relative path", &agent.HookInstall{
+			ConfigPath: func() (string, error) { return "settings.json", nil },
+			Uninstall:  uninstall,
+		}, "not absolute"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := HookConfigs([]agent.Agent{hookAdapter("alpha", tc.install)})
+			if err == nil {
+				t.Fatalf("HookConfigs() = %v, want an error naming %q", got, tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not name %q", err, tc.want)
+			}
+			if !strings.Contains(err.Error(), "alpha") {
+				t.Errorf("error %q does not name the offending adapter", err)
+			}
+		})
+	}
+}
+
+// TestHookConfigsIgnoresPermissionsWithoutHooks is a lock: only the permission
+// that actually installs hooks contributes a config file. A transcripts or
+// statusline permission must not be swept in — the recorder would back up a
+// file nobody writes hooks into, and uninstall would report on it.
+func TestHookConfigsIgnoresPermissionsWithoutHooks(t *testing.T) {
+	a := agent.Agent{
+		Identity: agent.Identity{Name: "alpha"},
+		Permissions: []agent.Permission{
+			{Key: "transcripts", Kind: permission.KindObserve},
+			{Key: "statusline", Kind: permission.KindModify, Apply: func() error { return nil }},
+		},
+	}
+	got, err := HookConfigs([]agent.Agent{a})
+	if err != nil {
+		t.Fatalf("HookConfigs(): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("HookConfigs() = %v, want none", got)
+	}
+}

--- a/core/cmd/irrlichd/hookconfigs_test.go
+++ b/core/cmd/irrlichd/hookconfigs_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents"
+	"irrlicht/core/adapters/inbound/agents/processlifecycle"
+	gastownadapter "irrlicht/core/adapters/inbound/orchestrators/gastown"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+)
+
+// TestPrintHookConfigsListsEveryDeclaredConfigFile pins the second half of
+// #1357's coverage requirement: the recording rig reads its protected file set
+// from `irrlichd --print-hook-configs`, so anything the registry declares and
+// this output omits is a file a grant-all recording daemon would rewrite in the
+// user's real $HOME and never hand back.
+//
+// Contract test — it passes by construction; it was seen red by making
+// printHookConfigs emit only the first config (see the PR body).
+func TestPrintHookConfigsListsEveryDeclaredConfigFile(t *testing.T) {
+	configs, err := agents.HookConfigs(agents.All())
+	if err != nil {
+		t.Fatalf("agents.HookConfigs(agents.All()): %v", err)
+	}
+	if len(configs) == 0 {
+		t.Fatal("no adapter declares a hooks permission — this check would pass vacuously")
+	}
+
+	var buf bytes.Buffer
+	if err := printHookConfigs(&buf); err != nil {
+		t.Fatalf("printHookConfigs: %v", err)
+	}
+
+	printed := linesOf(t, buf.String())
+
+	want := map[string]bool{}
+	for _, c := range configs {
+		want[c.Path] = true
+		if !printed[c.Path] {
+			t.Errorf("%s/%s declares %q, which --print-hook-configs does not list: "+
+				"a recording would repoint that file and never restore it (#1357)", c.Adapter, c.Key, c.Path)
+		}
+	}
+	for p := range printed {
+		if !want[p] {
+			t.Errorf("--print-hook-configs listed %q, which no adapter declares", p)
+		}
+	}
+}
+
+// linesOf splits the flag's output into a set, failing on a repeated line: the
+// rig keys its backups by line index, so one file listed twice would be backed
+// up under two indices and restored twice.
+func linesOf(t *testing.T, out string) map[string]bool {
+	t.Helper()
+	got := map[string]bool{}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		if got[line] {
+			t.Errorf("printed %q twice", line)
+		}
+		got[line] = true
+	}
+	return got
+}
+
+// fakePermissionStore is an in-memory consent store, so the coverage check
+// never reads or writes the developer's real permissions.json.
+type fakePermissionStore struct {
+	set   permission.Set
+	saved permission.Set
+}
+
+func (f *fakePermissionStore) Load() (permission.Set, error) { return f.set, nil }
+func (f *fakePermissionStore) Save(s permission.Set) error   { f.saved = s.Clone(); return nil }
+
+// TestUninstallHookConfigsCoversEveryConfig pins the first half: --uninstall-hooks
+// must run EVERY declared uninstaller and record EVERY matching permission as
+// denied. Missing one leaves that agent's hook entries in the user's real config
+// permanently, firing on every turn at a dead port; and a hooks permission left
+// "granted" reinstalls them on the next daemon start via the Apply closure,
+// silently reverting the uninstall (#570).
+//
+// Contract test — driven by synthetic configs so it stays true of an adapter set
+// that has not been written yet. Seen red by truncating the loop to the first
+// config (see the PR body).
+func TestUninstallHookConfigsCoversEveryConfig(t *testing.T) {
+	var called []string
+	configs := []agents.HookConfig{
+		{Adapter: "alpha", Key: "hooks", Path: "/tmp/alpha/settings.json",
+			Uninstall: func() (bool, error) { called = append(called, "alpha"); return true, nil }},
+		{Adapter: "beta", Key: "hooks", Path: "/tmp/beta/hooks.json",
+			Uninstall: func() (bool, error) { called = append(called, "beta"); return false, nil }},
+		{Adapter: "gamma", Key: "hooks", Path: "/tmp/gamma/settings.json",
+			Uninstall: func() (bool, error) { called = append(called, "gamma"); return true, nil }},
+	}
+
+	store := &fakePermissionStore{set: permission.Set{}}
+	for _, c := range configs {
+		store.set.Put(c.Adapter, c.Key, permission.StateGranted)
+	}
+
+	var out bytes.Buffer
+	uninstallHookConfigs(&out, configs, store)
+
+	sort.Strings(called)
+	if got, want := strings.Join(called, ","), "alpha,beta,gamma"; got != want {
+		t.Errorf("uninstalled %q, want %q — an adapter whose uninstaller never runs keeps its hook entries forever (#1357)", got, want)
+	}
+
+	if store.saved == nil {
+		t.Fatal("granted hooks permissions were never persisted as denied")
+	}
+	for _, c := range configs {
+		if st := store.saved.Get(c.Adapter, c.Key); st != permission.StateDenied {
+			t.Errorf("%s/%s is %q after uninstall, want %q — a still-granted hooks permission reinstalls on the next start", c.Adapter, c.Key, st, permission.StateDenied)
+		}
+	}
+
+	// Each file is named in the report, so a CODEX_HOME user is told which
+	// file was actually cleaned rather than the default one.
+	for _, c := range configs {
+		if !strings.Contains(out.String(), c.Path) {
+			t.Errorf("the uninstall report never mentions %q:\n%s", c.Path, out.String())
+		}
+	}
+}
+
+// TestUninstallHookConfigsLeavesUngrantedPermissionsAlone is a lock: uninstall
+// records an opt-out only where consent had actually been given, so a pending
+// permission is not silently turned into a denial the wizard will stop asking
+// about.
+func TestUninstallHookConfigsLeavesUngrantedPermissionsAlone(t *testing.T) {
+	configs := []agents.HookConfig{
+		{Adapter: "alpha", Key: "hooks", Path: "/tmp/alpha/settings.json",
+			Uninstall: func() (bool, error) { return false, nil }},
+	}
+	store := &fakePermissionStore{set: permission.Set{}}
+
+	uninstallHookConfigs(&bytes.Buffer{}, configs, store)
+
+	if store.saved != nil {
+		t.Errorf("persisted %v for a permission that was never granted", store.saved)
+	}
+}
+
+// TestWriteHookConfigPathsDeduplicates pins the dedup the rig depends on: it
+// keys its backups by line index, so one file listed twice would be backed up
+// under two indices and restored twice. Two adapters sharing a config file is
+// the case that produces it (claudecode's hooks and statusline already share
+// ~/.claude/settings.json), so this cannot be exercised through the shipped
+// registry — it is driven directly.
+func TestWriteHookConfigPathsDeduplicates(t *testing.T) {
+	var buf bytes.Buffer
+	writeHookConfigPaths(&buf, []agents.HookConfig{
+		{Adapter: "alpha", Key: "hooks", Path: "/tmp/shared/settings.json"},
+		{Adapter: "beta", Key: "hooks", Path: "/tmp/shared/settings.json"},
+		{Adapter: "gamma", Key: "hooks", Path: "/tmp/gamma/hooks.json"},
+	})
+	got := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	want := []string{"/tmp/shared/settings.json", "/tmp/gamma/hooks.json"}
+	if len(got) != len(want) {
+		t.Fatalf("printed %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestUninstallHookConfigsSurvivesOneFailingAdapter pins the fix for a failure
+// that used to end the whole command: hookjson refuses to rewrite a config it
+// cannot parse, so a single hand-edited ~/.claude/settings.json aborted the
+// process before any later adapter was cleaned and before ANY hooks permission
+// was recorded denied — leaving them granted, which re-installs on the next
+// daemon start via the Apply closure (#570).
+func TestUninstallHookConfigsSurvivesOneFailingAdapter(t *testing.T) {
+	var called []string
+	configs := []agents.HookConfig{
+		{Adapter: "alpha", Key: "hooks", Path: "/tmp/alpha/settings.json",
+			Uninstall: func() (bool, error) {
+				called = append(called, "alpha")
+				return false, errors.New("invalid character '}' looking for beginning of object key string")
+			}},
+		{Adapter: "beta", Key: "hooks", Path: "/tmp/beta/hooks.json",
+			Uninstall: func() (bool, error) { called = append(called, "beta"); return true, nil }},
+	}
+	store := &fakePermissionStore{set: permission.Set{}}
+	for _, c := range configs {
+		store.set.Put(c.Adapter, c.Key, permission.StateGranted)
+	}
+
+	var out bytes.Buffer
+	failed := uninstallHookConfigs(&out, configs, store)
+
+	if failed != 1 {
+		t.Errorf("failed = %d, want 1 — the caller needs a non-zero exit", failed)
+	}
+	if strings.Join(called, ",") != "alpha,beta" {
+		t.Errorf("uninstalled %q, want %q — a failing adapter must not stop the ones after it", called, "alpha,beta")
+	}
+	if store.saved == nil {
+		t.Fatal("no permission was recorded denied — the still-granted hooks reinstall on the next start")
+	}
+	if st := store.saved.Get("beta", "hooks"); st != permission.StateDenied {
+		t.Errorf("beta/hooks = %q, want %q", st, permission.StateDenied)
+	}
+	if !strings.Contains(out.String(), "warning: failed to uninstall hooks from /tmp/alpha/settings.json") {
+		t.Errorf("the failure is not reported to the user:\n%s", out.String())
+	}
+}
+
+// TestNonAgentPermissionDeclarationsDeclareNoHooks closes the one gap in the
+// registry projection. The daemon's consent catalog is agents.All() PLUS three
+// daemon-wide declarations appended in startup.go — gastown, launcher identity,
+// and the kitty remote-control config patch. agents.HookConfigs projects only
+// the adapter slice, so a hooks declaration landing on one of those would be
+// invisible to `--uninstall-hooks`, invisible to `--print-hook-configs`, and
+// invisible to the agents-package contract test as well — the exact shape of
+// #1357, one declaration later.
+//
+// This is where the tripwire has to live: package agents cannot import
+// processlifecycle (which imports it back), while package main already wires
+// all four. If this ever fires, route the declaration through
+// agents.HookConfigs rather than deleting the assertion.
+func TestNonAgentPermissionDeclarationsDeclareNoHooks(t *testing.T) {
+	noop := func() error { return nil }
+	catalog := []agent.Agent{
+		gastownadapter.PermissionDeclaration(noop, noop),
+		processlifecycle.LauncherPermissionDeclaration(),
+		processlifecycle.KittyPermissionDeclaration(),
+	}
+	for _, a := range catalog {
+		for _, p := range a.Permissions {
+			if p.Hooks != nil {
+				t.Errorf("%s/%s declares agent.HookInstall, but non-agent declarations are not projected by agents.HookConfigs — both hook config lists would miss it (#1357)", a.Identity.Name, p.Key)
+			}
+		}
+	}
+}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"irrlicht/core/adapters/inbound/agents"
 	"irrlicht/core/adapters/inbound/agents/agentwiring"
 	"irrlicht/core/adapters/inbound/agents/claudecode"
-	"irrlicht/core/adapters/inbound/agents/codex"
 	"irrlicht/core/adapters/outbound/filesystem"
 	"irrlicht/core/adapters/outbound/git"
 	"irrlicht/core/adapters/outbound/gtbin"
@@ -75,6 +75,13 @@ func main() {
 		uninstallHooks()
 		os.Exit(0)
 	}
+	if hasFlag("--print-hook-configs") {
+		if err := printHookConfigs(os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
 	if hasFlag("--uninstall-task-eta") {
 		uninstallTaskEtaBlocks()
 		os.Exit(0)
@@ -86,54 +93,132 @@ func main() {
 	runDaemon()
 }
 
-// uninstallHooks removes irrlicht's hooks from both Claude Code
-// (~/.claude/settings.json) and Codex (~/.codex/hooks.json) and, for each
-// adapter whose hooks permission was previously granted, records the explicit
-// opt-out in the consent store (#570) — a persisted "granted" would otherwise
-// re-install the hooks on the next daemon start (via the Apply closure),
-// silently reverting this decision.
+// uninstallHooks removes irrlicht's hooks from every agent config file the
+// adapter registry declares and, for each adapter whose hooks permission was
+// previously granted, records the explicit opt-out in the consent store (#570)
+// — a persisted "granted" would otherwise re-install the hooks on the next
+// daemon start (via the Apply closure), silently reverting this decision.
+//
+// The set comes from agents.HookConfigs rather than a literal list: an adapter
+// missing from that list would keep its entries in the user's real config
+// permanently after an uninstall, firing on every turn at a dead port, with
+// nothing to tell the user where they came from (#1357).
 func uninstallHooks() {
-	reportUninstall("~/.claude/settings.json", claudecode.UninstallHooks)
-	reportUninstall("~/.codex/hooks.json", codex.UninstallHooks)
-
+	configs, err := agents.HookConfigs(agents.All())
+	if err != nil {
+		log.Fatalf("failed to resolve the agent config files to uninstall from: %v", err)
+	}
 	home, _ := os.UserHomeDir()
-	store := filesystem.NewPermissionStore(dataDir(home))
+	if failed := uninstallHookConfigs(os.Stdout, configs, filesystem.NewPermissionStore(dataDir(home))); failed > 0 {
+		os.Exit(1)
+	}
+}
+
+// uninstallHookConfigs runs every declared uninstaller and then records the
+// matching hooks permissions as denied. It returns how many uninstallers
+// failed.
+//
+// One adapter's failure must not end the run. `hookjson` deliberately refuses
+// to rewrite a config file it cannot parse, so a single hand-edited
+// ~/.claude/settings.json used to abort the whole command — leaving every LATER
+// adapter's entries firing at a dead port, and (because the consent block never
+// ran) leaving their hooks permissions still granted, so the next daemon start
+// re-installed them via the Apply closure. That is precisely the #570
+// regression this function exists to prevent, and the registry projection only
+// widens the window as adapters are added.
+func uninstallHookConfigs(w io.Writer, configs []agents.HookConfig, store outbound.PermissionStore) int {
+	failed := 0
+	for _, c := range configs {
+		if !reportUninstall(w, c.Path, c.Uninstall) {
+			failed++
+		}
+	}
+
+	denyHooksPermissions(w, configs, store)
+	return failed
+}
+
+// denyHooksPermissions records every hooks permission that had been granted as
+// explicitly denied. Without it a persisted "granted" re-installs the hooks on
+// the next daemon start via the Apply closure, silently undoing the uninstall
+// (#570). A permission that was never granted is left alone — turning a pending
+// answer into a denial would stop the wizard ever asking about it.
+func denyHooksPermissions(w io.Writer, configs []agents.HookConfig, store outbound.PermissionStore) {
 	set, err := store.Load()
 	if err != nil {
 		return
 	}
-
 	denied := false
-	if set.Get(claudecode.AdapterName, claudecode.PermissionKeyHooks) == permission.StateGranted {
-		set.Put(claudecode.AdapterName, claudecode.PermissionKeyHooks, permission.StateDenied)
-		denied = true
-	}
-	if set.Get(codex.AdapterName, codex.PermissionKeyHooks) == permission.StateGranted {
-		set.Put(codex.AdapterName, codex.PermissionKeyHooks, permission.StateDenied)
-		denied = true
+	for _, c := range configs {
+		if set.Get(c.Adapter, c.Key) == permission.StateGranted {
+			set.Put(c.Adapter, c.Key, permission.StateDenied)
+			denied = true
+		}
 	}
 	if !denied {
 		return
 	}
 	if err := store.Save(set); err != nil {
-		fmt.Printf("warning: failed to record hooks permission(s) as denied: %v\n", err)
+		fmt.Fprintf(w, "warning: failed to record hooks permission(s) as denied: %v\n", err)
 		return
 	}
-	fmt.Println("Recorded the hooks permission(s) as denied (re-grant via the permission wizard)")
+	fmt.Fprintln(w, "Recorded the hooks permission(s) as denied (re-grant via the permission wizard)")
+}
+
+// printHookConfigs writes the resolved absolute path of every agent config file
+// irrlicht installs hooks into, one per line.
+//
+// It exists for the onboarding recording rig (#1357): a recording daemon runs
+// grant-all and installs its hooks into the user's REAL config, so the rig has
+// to back those files up before spawning it — and asking the daemon is the only
+// way that list cannot drift from the adapters that actually write them. An
+// empty result is an error, not an empty list: the rig would read "nothing to
+// protect" as success and record over the user's config unprotected.
+func printHookConfigs(w io.Writer) error {
+	configs, err := agents.HookConfigs(agents.All())
+	if err != nil {
+		return fmt.Errorf("failed to resolve the agent config files irrlicht installs hooks into: %w", err)
+	}
+	if len(configs) == 0 {
+		return fmt.Errorf("no adapter declares a hooks permission")
+	}
+	writeHookConfigPaths(w, configs)
+	return nil
+}
+
+// writeHookConfigPaths prints each distinct config path once. The dedup is
+// load-bearing rather than cosmetic: the rig keys its backups by line index, so
+// a path listed twice would be backed up under two indices and restored twice.
+func writeHookConfigPaths(w io.Writer, configs []agents.HookConfig) {
+	seen := make(map[string]bool, len(configs))
+	for _, c := range configs {
+		if seen[c.Path] {
+			continue
+		}
+		seen[c.Path] = true
+		fmt.Fprintln(w, c.Path)
+	}
 }
 
 // reportUninstall runs one adapter's hook uninstaller and prints whether it
-// removed anything.
-func reportUninstall(path string, uninstall func() (bool, error)) {
+// removed anything. path is the file the adapter itself resolved, so a
+// CODEX_HOME user is told which file was actually cleaned rather than the
+// default one.
+//
+// It reports whether the uninstall succeeded; a failure is printed and returned
+// rather than fatal, so the caller can still clean up every other adapter.
+func reportUninstall(w io.Writer, path string, uninstall func() (bool, error)) bool {
 	modified, err := uninstall()
 	if err != nil {
-		log.Fatalf("failed to uninstall hooks from %s: %v", path, err)
+		fmt.Fprintf(w, "warning: failed to uninstall hooks from %s: %v\n", path, err)
+		return false
 	}
 	if modified {
-		fmt.Printf("Removed irrlicht hooks from %s\n", path)
+		fmt.Fprintf(w, "Removed irrlicht hooks from %s\n", path)
 	} else {
-		fmt.Printf("No irrlicht hooks found in %s\n", path)
+		fmt.Fprintf(w, "No irrlicht hooks found in %s\n", path)
 	}
+	return true
 }
 
 // uninstallTaskEtaBlocks removes irrlicht's managed task-eta and

--- a/core/domain/agent/declaration.go
+++ b/core/domain/agent/declaration.go
@@ -102,6 +102,33 @@ type Permission struct {
 	// and stopping the agent's watchers) is owned by the daemon wiring.
 	Apply  func() error
 	Remove func() error
+
+	// Hooks is non-nil exactly for the permission that installs irrlicht's
+	// hooks into an agent-owned config file. It carries what callers OUTSIDE
+	// the adapter need — which file, and how to take our entries back out.
+	Hooks *HookInstall
+}
+
+// HookInstall is the outside-the-adapter half of a hooks permission (#1357).
+//
+// Two places have to enumerate every agent config file irrlicht installs hooks
+// into: the daemon's `--uninstall-hooks`, which must leave nothing behind
+// pointing at a dead port, and the onboarding recorder, which backs those files
+// up before running a grant-all daemon against the user's real $HOME. Both used
+// to carry a hand-maintained two-element literal list, correct only for as long
+// as there were exactly two hook adapters. Declaring the file here — next to the
+// Apply/Remove closures that write it — makes both lists a projection of the
+// registry, so a third adapter is covered by existing over being remembered.
+type HookInstall struct {
+	// ConfigPath resolves the ABSOLUTE path of the agent config file the
+	// hooks are written into, honoring the same env overrides the adapter's
+	// own installer honors (e.g. CODEX_HOME). It must resolve the real path
+	// rather than a display string: the recorder backs up and restores
+	// exactly what it returns.
+	ConfigPath func() (string, error)
+	// Uninstall removes irrlicht's entries from that file, reporting whether
+	// it modified anything.
+	Uninstall func() (bool, error)
 }
 
 // Identity is the always-required adapter metadata served via

--- a/site/docs/cli-tools.html
+++ b/site/docs/cli-tools.html
@@ -103,7 +103,8 @@
       <ul>
         <li><code>--version</code>, <code>-v</code> &mdash; Print version and exit</li>
         <li><code>--diagnose</code> &mdash; Write a redacted diagnostics bundle (<code>irrlicht-diag.tar.gz</code>) to the current directory and exit, without starting the daemon. For headless installs that can't reach the <code>GET /debug/bundle</code> endpoint. Honors <code>IRRLICHT_HOME</code></li>
-        <li><code>--uninstall-hooks</code> &mdash; Remove irrlicht's Claude Code hooks from <code>~/.claude/settings.json</code>, record the hooks permission as denied if it was previously granted (so it isn't silently re-installed on next start), and exit without starting the daemon</li>
+        <li><code>--uninstall-hooks</code> &mdash; Remove irrlicht's hooks from every agent config file it installs into (today <code>~/.claude/settings.json</code> and <code>$CODEX_HOME/hooks.json</code>, enumerated from the adapter registry so a newly added agent is covered automatically), record each hooks permission as denied if it was previously granted (so it isn't silently re-installed on next start), and exit without starting the daemon</li>
+        <li><code>--print-hook-configs</code> &mdash; Print the resolved absolute path of every agent config file irrlicht installs hooks into, one per line, and exit. Used by the onboarding recording rig to back those files up before running a <code>grant-all</code> recording daemon against your real home directory</li>
         <li><code>--uninstall-task-eta</code> &mdash; Remove irrlicht's managed task-eta and task-summary blocks from <code>~/.claude/CLAUDE.md</code> and exit without starting the daemon</li>
         <li><code>--record</code> &mdash; Enable lifecycle recording of session events to <code>&lt;dataDir&gt;/recordings</code> (equivalent to <code>IRRLICHT_RECORD=1</code>); the daemon starts normally otherwise</li>
       </ul>

--- a/tools/onboarding-factory/scripts/lib/hook-config-snapshot.sh
+++ b/tools/onboarding-factory/scripts/lib/hook-config-snapshot.sh
@@ -3,54 +3,229 @@
 # daemon rewrites, so a recording never outlives its own edits.
 #
 # A recording daemon runs with IRRLICHT_PERMISSION_MODE=grant-all and installs
-# its hooks into the user's REAL agent config — ~/.claude/settings.json and
-# $CODEX_HOME/hooks.json follow $HOME, not IRRLICHT_HOME, so
-# IRRLICHT_ONBOARD_HOME does not isolate them. Since #1178 the endpoint written
-# there carries the daemon's own bind port, so a coexist recording on :7838
-# repoints a running production daemon's hooks at the recorder and leaves them
-# that way. grant-all can also install entries the user had explicitly denied.
+# its hooks into the user's REAL agent config — those paths follow $HOME, not
+# IRRLICHT_HOME, so IRRLICHT_ONBOARD_HOME does not isolate them. Since #1178 the
+# endpoint written there carries the daemon's own bind port, so a coexist
+# recording on :7838 repoints a running production daemon's hooks at the
+# recorder and leaves them that way. grant-all can also install entries the user
+# had explicitly denied.
+#
+# WHICH files those are is asked of the daemon binary itself
+# (`irrlichd --print-hook-configs`), which resolves them from the adapter
+# registry — the same declarations its own `--uninstall-hooks` reads (#1357).
+# A literal list here would be correct only for as long as the adapter set
+# stayed frozen: recording a hook-installing adapter this file had never heard
+# of would repoint that agent's real config at a dead recorder port and leave it
+# there, which is #1214 one adapter later. There is deliberately no fallback
+# list — a daemon that cannot answer fails the snapshot instead.
 #
 # Usage — call the first before spawning the daemon, the second from cleanup:
 #   source "$SCRIPT_DIR/lib/hook-config-snapshot.sh"
-#   snapshot_hook_configs "$STAGING/hook-config-backup"
+#   snapshot_hook_configs "$STAGING/hook-config-backup" "$DAEMON" || exit 1
 #   ... spawn daemon, drive agent ...
 #   restore_hook_configs
 #
-# Both are no-ops if the snapshot never ran, so restore is safe to call
-# unconditionally from an EXIT trap.
+# restore_hook_configs is a no-op unless a snapshot completed, so it is safe to
+# call unconditionally from an EXIT trap.
 
-# HOOK_CONFIG_FILES is the set of shared agent config files a recording daemon
-# may rewrite. Set by snapshot_hook_configs and read by restore_hook_configs.
-HOOK_CONFIG_FILES=()
+# HOOK_CONFIG_BACKUP_DIR is the only state the pair shares, and it is set ONLY
+# by a snapshot that ran to completion. Everything restore does comes out of the
+# manifest inside it — there is deliberately no published file list, because two
+# things that can disagree about which files are protected is the defect this
+# lib is fixing, not a shape to reproduce in miniature.
 HOOK_CONFIG_BACKUP_DIR=""
 
-# snapshot_hook_configs <backup-dir> copies each shared agent config aside.
-# A file that does not exist is recorded as absent (no backup written), so
-# restore removes one the daemon created from nothing.
+# hook_config_paths <daemon-bin> prints one absolute agent config path per line,
+# as declared by the daemon's adapter registry.
+#
+# Two deliberate details. It writes to a caller-supplied FILE rather than to
+# stdout, so it is never run in a command substitution — that pipe is not closed
+# until every process holding it exits, which a backgrounded watchdog inherits.
+# And stderr is captured separately rather than merged: a diagnostic line that
+# happened to look like a path would otherwise be adopted as a file to manage,
+# and at restore anything sitting there would be moved out of the user's
+# filesystem.
+#
+# The bound exists because an irrlichd predating the flag does not reject it —
+# `hasFlag` dispatch ignores what it does not recognize and falls through to
+# starting a full production daemon, which would otherwise block here forever.
+# Defense in depth rather than the primary guarantee: precheck.sh rebuilds the
+# daemon from the current worktree before every run-cell.sh / run-cell-multi.sh
+# run, so the two production callers cannot reach a stale binary.
+hook_config_paths() {
+  local daemon_bin="$1" outf="$2" secs="${HOOK_CONFIG_PROBE_TIMEOUT_S:-20}"
+  local errf rc pid watchdog
+  errf="$outf.err"
+
+  "$daemon_bin" --print-hook-configs >"$outf" 2>"$errf" &
+  pid=$!
+  { sleep "$secs"; kill -KILL "$pid" 2>/dev/null; } >/dev/null 2>&1 &
+  watchdog=$!
+  wait "$pid"; rc=$?
+  kill "$watchdog" 2>/dev/null
+  wait "$watchdog" 2>/dev/null
+
+  if [[ "$rc" -ne 0 ]]; then
+    echo "hook-config-snapshot: '$daemon_bin --print-hook-configs' failed (exit $rc): $(head -c 500 "$errf")" >&2
+    echo "hook-config-snapshot: an irrlichd predating the flag starts a daemon instead of answering; refusing to guess the file list" >&2
+    rm -f "$errf"
+    return 1
+  fi
+  if [[ ! -s "$outf" ]]; then
+    echo "hook-config-snapshot: '$daemon_bin --print-hook-configs' printed nothing" >&2
+    rm -f "$errf"
+    return 1
+  fi
+  rm -f "$errf"
+  return 0
+}
+
+# snapshot_hook_configs <backup-dir> <daemon-bin> copies each declared agent
+# config aside and records, per file, whether it existed. Returns non-zero
+# without publishing any state if the daemon cannot be asked, if a path looks
+# wrong, or if any backup fails to land — the caller must not spawn a recording
+# daemon it cannot undo.
 snapshot_hook_configs() {
-  HOOK_CONFIG_BACKUP_DIR="$1"
-  HOOK_CONFIG_FILES=("$HOME/.claude/settings.json" "${CODEX_HOME:-$HOME/.codex}/hooks.json")
-  mkdir -p "$HOOK_CONFIG_BACKUP_DIR"
-  local i
-  for i in "${!HOOK_CONFIG_FILES[@]}"; do
-    if [[ -f "${HOOK_CONFIG_FILES[$i]}" ]]; then
-      cp "${HOOK_CONFIG_FILES[$i]}" "$HOOK_CONFIG_BACKUP_DIR/$i"
+  local backup_dir="${1:-}" daemon_bin="${2:-}"
+
+  if [[ -z "$backup_dir" || -z "$daemon_bin" ]]; then
+    echo "hook-config-snapshot: usage: snapshot_hook_configs <backup-dir> <daemon-bin>" >&2
+    return 1
+  fi
+  # Nothing here clears HOOK_CONFIG_BACKUP_DIR on the way IN, and a second
+  # snapshot over a live one is refused rather than allowed to replace it. A
+  # failing re-snapshot that had already cleared it would silently disarm
+  # restore for the snapshot that DID succeed, while the EXIT trap that calls it
+  # stayed armed and did nothing. A caller that genuinely wants to start over
+  # clears HOOK_CONFIG_BACKUP_DIR itself.
+  if [[ -n "$HOOK_CONFIG_BACKUP_DIR" ]]; then
+    echo "hook-config-snapshot: a snapshot is already active at $HOOK_CONFIG_BACKUP_DIR; restore it before taking another" >&2
+    return 1
+  fi
+
+  if ! mkdir -p "$backup_dir"; then
+    echo "hook-config-snapshot: cannot create the backup dir: $backup_dir" >&2
+    return 1
+  fi
+
+  local listing="$backup_dir/declared"
+  hook_config_paths "$daemon_bin" "$listing" || { rm -f "$listing"; return 1; }
+
+  local paths=() p
+  while IFS= read -r p; do
+    [[ -n "$p" ]] || continue
+    if [[ "$p" != /* ]]; then
+      echo "hook-config-snapshot: refusing a non-absolute config path: $p" >&2
+      return 1
     fi
+    # The manifest is tab-separated and line-oriented; a path carrying either
+    # would be silently mis-parsed on the way back out.
+    if [[ "$p" == *$'\t'* ]]; then
+      echo "hook-config-snapshot: refusing a config path containing a tab: $p" >&2
+      return 1
+    fi
+    paths+=("$p")
+  done < "$listing"
+
+  if [[ "${#paths[@]}" -eq 0 ]]; then
+    echo "hook-config-snapshot: '$daemon_bin --print-hook-configs' listed no paths" >&2
+    return 1
+  fi
+
+  local manifest_tmp="$backup_dir/manifest.tmp"
+  rm -f "$backup_dir/manifest" "$manifest_tmp"
+  if ! : > "$manifest_tmp"; then
+    echo "hook-config-snapshot: cannot write $manifest_tmp" >&2
+    return 1
+  fi
+
+  local i=0
+  for p in "${paths[@]}"; do
+    if [[ -f "$p" ]]; then
+      # Both halves matter: cp can fail outright (unwritable dir), and it can
+      # "succeed" while landing somewhere else (a directory already sitting on
+      # the backup path swallows the file as dir/<basename>). Either way the
+      # backup is not where restore will look for it, and the pre-#1357 code
+      # read that as "the file never existed" and deleted the user's config.
+      if ! cp "$p" "$backup_dir/$i" || [[ ! -f "$backup_dir/$i" ]]; then
+        echo "hook-config-snapshot: cannot back up $p to $backup_dir/$i" >&2
+        rm -f "$manifest_tmp"
+        return 1
+      fi
+      printf 'saved\t%s\t%s\n' "$i" "$p" >> "$manifest_tmp"
+    else
+      printf 'absent\t%s\t%s\n' "$i" "$p" >> "$manifest_tmp"
+    fi
+    i=$((i + 1))
   done
+
+  if ! mv "$manifest_tmp" "$backup_dir/manifest"; then
+    echo "hook-config-snapshot: cannot finalize $backup_dir/manifest" >&2
+    rm -f "$manifest_tmp"
+    return 1
+  fi
+
+  HOOK_CONFIG_BACKUP_DIR="$backup_dir"
   return 0
 }
 
 # restore_hook_configs puts each snapshotted file back exactly as it was.
-# No backup for an index means the file did not exist when we snapshotted, so
-# whatever is there now is ours to remove.
+# Every action is driven by the manifest the snapshot wrote: "saved" means copy
+# the backup back, "absent" means the file did not exist before the run. A file
+# is never removed on the strength of a MISSING record — that inference is what
+# made widening the file list dangerous, because a config the snapshot failed to
+# save reads identically to one that was never there (#1357).
 restore_hook_configs() {
   [[ -n "$HOOK_CONFIG_BACKUP_DIR" ]] || return 0
-  local i
-  for i in "${!HOOK_CONFIG_FILES[@]}"; do
-    if [[ -f "$HOOK_CONFIG_BACKUP_DIR/$i" ]]; then
-      cp "$HOOK_CONFIG_BACKUP_DIR/$i" "${HOOK_CONFIG_FILES[$i]}"
-    else
-      rm -f "${HOOK_CONFIG_FILES[$i]}"
+  local manifest="$HOOK_CONFIG_BACKUP_DIR/manifest"
+  if [[ ! -f "$manifest" ]]; then
+    echo "hook-config-snapshot: no manifest at $manifest — leaving every agent config alone" >&2
+    return 0
+  fi
+
+  local created_dir="$HOOK_CONFIG_BACKUP_DIR/created"
+  local state slot path
+  while IFS=$'\t' read -r state slot path; do
+    if [[ -n "$path" ]]; then
+      case "$state" in
+        saved)
+          if [[ -f "$HOOK_CONFIG_BACKUP_DIR/$slot" ]]; then
+            cp "$HOOK_CONFIG_BACKUP_DIR/$slot" "$path" ||
+              echo "hook-config-snapshot: could not restore $path" >&2
+          else
+            echo "hook-config-snapshot: backup for $path is gone — leaving the file as it is" >&2
+          fi
+          ;;
+        absent)
+          # Removing it restores the pre-run state, but the file may be a
+          # multi-purpose config the AGENT (not the daemon) created during the
+          # run, so move it aside rather than destroying it. The path ends up
+          # absent either way; the contents stay recoverable.
+          #
+          # -f, symmetric with the snapshot's own test, NOT -e: the snapshot
+          # records anything that is not a regular file as "absent", so an -e
+          # here would relocate a whole DIRECTORY a user happens to keep at a
+          # declared config path — worse than the rm -f this replaced, which
+          # refuses a directory outright.
+          if [[ -e "$path" && ! -f "$path" ]]; then
+            echo "hook-config-snapshot: $path is not a regular file; leaving it alone" >&2
+          elif [[ -f "$path" ]]; then
+            if mkdir -p "$created_dir" && mv "$path" "$created_dir/$slot"; then
+              echo "hook-config-snapshot: $path did not exist before the run; moved to $created_dir/$slot" >&2
+            else
+              echo "hook-config-snapshot: could not move $path aside" >&2
+            fi
+          fi
+          ;;
+        *)
+          echo "hook-config-snapshot: unrecognized manifest state '$state' for $path — leaving it alone" >&2
+          ;;
+      esac
     fi
-  done
+  done < "$manifest"
+
+  # The snapshot is spent: clear the shared state so a second restore is a
+  # no-op and a caller that legitimately records again can take a fresh one.
+  HOOK_CONFIG_BACKUP_DIR=""
+  return 0
 }

--- a/tools/onboarding-factory/scripts/lib/hook-config-snapshot_test.sh
+++ b/tools/onboarding-factory/scripts/lib/hook-config-snapshot_test.sh
@@ -7,6 +7,12 @@
 # recording daemon's edits to the user's shared agent config never survive the
 # run — including the case where the daemon created a config file that was not
 # there before (#1178).
+#
+# The second half of the file is #1357: the protected set is whatever the
+# daemon binary declares (`irrlichd --print-hook-configs`), not a literal pair
+# of paths this file and the daemon have to agree on by convention; and a file
+# is only ever removed on the strength of an explicit "was absent" record, so
+# widening that set can never delete a config the snapshot failed to save.
 
 set -uo pipefail   # NOT -e: assertions capture non-zero return codes
 
@@ -43,17 +49,52 @@ assert_eq() {
   return 0
 }
 
-# fresh_env points $HOME and $CODEX_HOME at a clean subdir, sets $ROOT, and
-# clears the lib's state so each case starts from nothing. It must NOT be
-# called in a command substitution — the env assignments have to land in this
-# shell, not a subshell.
+# assert_snapshot_refused <rc> is the tail every "the snapshot must not proceed"
+# case shares: it reported failure, and the user's config is untouched.
+assert_snapshot_refused() {
+  assert_eq "snapshot reports failure" "1" "$1"
+  assert_eq "the user's config survives" "user config" \
+    "$(cat "$HOME/.claude/settings.json" 2>/dev/null)"
+  return 0
+}
+
+# fake_hook_config_daemon writes an executable that answers
+# --print-hook-configs with the paths given, standing in for the real irrlichd.
+# Every case declares its own set, so what the lib protects is visible in the
+# case rather than inherited from the adapter set compiled in today. (Named in
+# full because spawn-record-daemon_test.sh has a `fake_daemon` that models the
+# opposite thing — a process surviving the shutdown ladder — and the two libs
+# are sourced together in production.)
+fake_hook_config_daemon() {
+  local bin="$1"; shift
+  printf '%s\n' "$@" > "$bin.paths"
+  cat > "$bin" <<EOF
+#!/usr/bin/env bash
+[[ "\${1:-}" == "--print-hook-configs" ]] || { echo "unexpected args: \$*" >&2; exit 2; }
+cat "$bin.paths"
+EOF
+  chmod +x "$bin"
+  return 0
+}
+
+# fresh_env points $HOME and $CODEX_HOME at a clean subdir, sets $ROOT, rewrites
+# $DAEMON to declare the two config files the shipped adapters install into, and
+# clears the lib's state so each case starts from nothing. It must NOT be called
+# in a command substitution — the env assignments have to land in this shell,
+# not a subshell.
+#
+# $DAEMON is one shared path rewritten per case rather than a new file each
+# time: every case still execs a real subprocess, but macOS charges ~0.3s to
+# first-exec a newly created executable, which was most of this file's runtime.
+DAEMON="$TMP/irrlichd"
 fresh_env() {
   local name="$1"
   ROOT="$TMP/$name"
   mkdir -p "$ROOT/home/.claude" "$ROOT/codex"
   HOME="$ROOT/home"
   CODEX_HOME="$ROOT/codex"
-  HOOK_CONFIG_FILES=()
+  fake_hook_config_daemon "$DAEMON" "$HOME/.claude/settings.json" "$CODEX_HOME/hooks.json"
+  # shellcheck disable=SC2034  # read by the sourced lib's restore_hook_configs
   HOOK_CONFIG_BACKUP_DIR=""
   return 0
 }
@@ -61,14 +102,14 @@ fresh_env() {
 echo "== an existing config is restored byte-for-byte =="
 fresh_env existing
 printf '{"hooks":{"Stop":"localhost:7837"}}\n' > "$HOME/.claude/settings.json"
-snapshot_hook_configs "$ROOT/backup"
+snapshot_hook_configs "$ROOT/backup" "$DAEMON"
 printf '{"hooks":{"Stop":"localhost:7838"}}\n' > "$HOME/.claude/settings.json"   # daemon repoints it
 restore_hook_configs
 assert_eq "settings.json restored" '{"hooks":{"Stop":"localhost:7837"}}' "$(cat "$HOME/.claude/settings.json")"
 
 echo "== a config the daemon created from nothing is removed =="
 fresh_env created
-snapshot_hook_configs "$ROOT/backup"
+snapshot_hook_configs "$ROOT/backup" "$DAEMON"
 printf '{"hooks":{}}\n' > "$CODEX_HOME/hooks.json"                               # daemon creates it
 restore_hook_configs
 [[ -e "$CODEX_HOME/hooks.json" ]] && got=present || got=absent
@@ -77,7 +118,7 @@ assert_eq "hooks.json removed" "absent" "$got"
 echo "== an untouched config survives a restore unchanged =="
 fresh_env untouched
 printf 'original\n' > "$CODEX_HOME/hooks.json"
-snapshot_hook_configs "$ROOT/backup"
+snapshot_hook_configs "$ROOT/backup" "$DAEMON"
 restore_hook_configs
 assert_eq "hooks.json unchanged" "original" "$(cat "$CODEX_HOME/hooks.json")"
 
@@ -88,6 +129,143 @@ restore_hook_configs
 rc=$?
 assert_eq "restore returns 0" "0" "$rc"
 assert_eq "file left alone" "untouched" "$(cat "$HOME/.claude/settings.json")"
+
+echo "== the protected set is whatever the daemon declares (#1357) =="
+# A third hook adapter is a config path this file has never heard of. The rig
+# must protect it because the daemon named it, not because someone remembered
+# to add a literal here — that is the whole defect: the two lists were correct
+# for exactly as long as there were exactly two adapters.
+fresh_env registry
+mkdir -p "$HOME/.gemini"
+printf 'user gemini config\n' > "$HOME/.gemini/settings.json"
+fake_hook_config_daemon "$DAEMON" "$HOME/.claude/settings.json" "$CODEX_HOME/hooks.json" "$HOME/.gemini/settings.json"
+snapshot_hook_configs "$ROOT/backup" "$DAEMON"
+printf 'repointed at a dead recorder port\n' > "$HOME/.gemini/settings.json"      # daemon rewrites it
+restore_hook_configs
+assert_eq "the third adapter's config is restored too" "user gemini config" \
+  "$(cat "$HOME/.gemini/settings.json" 2>/dev/null)"
+
+echo "== a backup that did not land aborts the snapshot instead of arming a delete (#1357) =="
+# "No backup for this file" used to mean "the daemon created it, remove it", so
+# a snapshot that failed to copy an EXISTING file armed its deletion. Deletion
+# must require a positive record that the file was absent — never the absence
+# of a record.
+fresh_env cpfail
+printf 'user config\n' > "$HOME/.claude/settings.json"
+mkdir -p "$ROOT/backup/0"        # a DIRECTORY where the backup file must go
+snapshot_hook_configs "$ROOT/backup" "$DAEMON"
+rc=$?
+restore_hook_configs
+assert_snapshot_refused "$rc"
+
+echo "== an unwritable backup dir aborts the snapshot too (#1357) =="
+fresh_env unwritable
+printf 'user config\n' > "$HOME/.claude/settings.json"
+mkdir -p "$ROOT/backup"
+chmod 500 "$ROOT/backup"
+if [[ -w "$ROOT/backup" ]]; then
+  echo "  SKIP: running with write access to a 0500 dir (root?)"
+else
+  snapshot_hook_configs "$ROOT/backup" "$DAEMON"
+  rc=$?
+  restore_hook_configs
+  assert_snapshot_refused "$rc"
+fi
+chmod 700 "$ROOT/backup" 2>/dev/null || true
+
+echo "== restore acts only on paths the manifest records (#1357) =="
+# LOCK, not a regression test: it passes on the pre-#1357 lib too. It pins the
+# property the manifest exists to guarantee — restore reads the snapshot's own
+# record of what it saved, so nothing else on disk is in scope. The published
+# file list that used to sit beside the backups, coupled to them only by array
+# index, is gone precisely so there is no second answer to "which files?".
+fresh_env unrecorded
+printf 'user config\n' > "$HOME/.claude/settings.json"
+snapshot_hook_configs "$ROOT/backup" "$DAEMON"
+mkdir -p "$HOME/.gemini"
+printf 'user gemini config\n' > "$HOME/.gemini/settings.json"   # never declared
+restore_hook_configs
+assert_eq "the unrecorded file survives" "user gemini config" \
+  "$(cat "$HOME/.gemini/settings.json" 2>/dev/null)"
+
+echo "== a daemon that cannot list its config files fails the snapshot loudly (#1357) =="
+# Falling back to a literal list here would reinstate the defect at the one
+# moment it matters, so there is no fallback: the run stops instead.
+fresh_env nolist
+printf 'user config\n' > "$HOME/.claude/settings.json"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$DAEMON"
+chmod +x "$DAEMON"
+err="$(snapshot_hook_configs "$ROOT/backup" "$DAEMON" 2>&1)"
+rc=$?
+restore_hook_configs
+assert_snapshot_refused "$rc"
+[[ "$err" == *"--print-hook-configs"* ]] && got=yes || got=no
+assert_eq "says which command failed" "yes" "$got"
+
+echo "== a directory at a declared config path is left alone, not relocated (#1357) =="
+# The snapshot records anything that is not a regular file as "absent". Restore
+# must not read that as licence to move a whole directory a user keeps there —
+# the rm -f this replaced refused a directory outright, so an asymmetric test
+# would have made the safety fix MORE destructive than the bug.
+fresh_env notafile
+mkdir -p "$CODEX_HOME/hooks.json/precious"
+printf 'keep me\n' > "$CODEX_HOME/hooks.json/precious/keep.txt"
+snapshot_hook_configs "$ROOT/backup" "$DAEMON"
+restore_hook_configs
+assert_eq "the directory survives" "keep me" \
+  "$(cat "$CODEX_HOME/hooks.json/precious/keep.txt" 2>/dev/null)"
+
+echo "== a daemon that hangs instead of answering is not waited on forever (#1357) =="
+# An irrlichd predating the flag does not reject it: hasFlag dispatch ignores
+# what it does not recognize and starts a full production daemon, which would
+# otherwise hang the capture with a real daemon running and no backup taken.
+fresh_env hang
+printf 'user config\n' > "$HOME/.claude/settings.json"
+printf '#!/usr/bin/env bash\nsleep 120\n' > "$DAEMON"
+chmod +x "$DAEMON"
+# shellcheck disable=SC2034  # read by the sourced lib's hook_config_paths
+HOOK_CONFIG_PROBE_TIMEOUT_S=0.2
+snapshot_hook_configs "$ROOT/backup" "$DAEMON" 2>/dev/null
+rc=$?
+unset HOOK_CONFIG_PROBE_TIMEOUT_S
+restore_hook_configs
+assert_snapshot_refused "$rc"
+
+echo "== a diagnostic on stderr is never adopted as a config path (#1357) =="
+fresh_env noisy
+cat > "$DAEMON" <<EOF
+#!/usr/bin/env bash
+echo "/tmp/not-a-config-warning" >&2
+printf '%s\n' "$HOME/.claude/settings.json"
+EOF
+chmod +x "$DAEMON"
+snapshot_hook_configs "$ROOT/backup" "$DAEMON"
+assert_eq "only the stdout path is managed" "$HOME/.claude/settings.json" \
+  "$(cut -f3 "$ROOT/backup/manifest")"
+
+echo "== a failing re-snapshot does not disarm the one that succeeded (#1357) =="
+# HOOK_CONFIG_BACKUP_DIR used to be cleared on the way in, so a second snapshot
+# that failed left restore a silent no-op while the EXIT trap that calls it
+# stayed armed.
+fresh_env resnapshot
+printf 'user config\n' > "$HOME/.claude/settings.json"
+snapshot_hook_configs "$ROOT/backup" "$DAEMON"
+printf 'repointed\n' > "$HOME/.claude/settings.json"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$DAEMON"
+chmod +x "$DAEMON"
+snapshot_hook_configs "$ROOT/backup2" "$DAEMON" 2>/dev/null
+rc=$?
+restore_hook_configs
+assert_eq "the second snapshot is refused" "1" "$rc"
+assert_eq "the first snapshot still restores" "user config" \
+  "$(cat "$HOME/.claude/settings.json" 2>/dev/null)"
+
+echo "== the lib names no agent config path of its own (#1357) =="
+# The literal list is the defect. A path spelled out here is one the daemon
+# does not have to agree with, which is how the two drifted in the first place.
+LITERAL_RE='\.(claude|codex|gemini)/'
+assert_eq "no agent config literals in the lib" "0" \
+  "$(grep -cE "$LITERAL_RE" "$DIR/hook-config-snapshot.sh" | tr -d ' ')"
 
 echo ""
 if [[ "$fails" -eq 0 ]]; then

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
@@ -94,15 +94,16 @@ spawn_record_daemon() {
   RECORD_DAEMON_SOCK="$(record_daemon_sock "$home")"
 
   # Save the shared agent config the daemon is about to rewrite (see
-  # lib/hook-config-snapshot.sh); the shutdown hands it back. Refuse to start if
-  # the backup dir can't be created: restore_hook_configs reads "no backup for
-  # this file" as "the daemon created it", so an unwritable snapshot would end
-  # the run by DELETING the user's real ~/.claude/settings.json.
-  if ! mkdir -p "$staging/hook-config-backup"; then
-    echo "cannot create the hook-config backup dir: $staging/hook-config-backup" >&2
+  # lib/hook-config-snapshot.sh); the shutdown hands it back. WHICH files those
+  # are is asked of the daemon binary itself, so the set follows the adapters
+  # that actually install hooks (#1357). Refuse to start if the backup dir can't
+  # be created. The snapshot owns that directory — it creates it and reports its
+  # own failure — so there is one gate here, not two: a recording daemon we
+  # cannot undo must never be spawned in the first place.
+  if ! snapshot_hook_configs "$staging/hook-config-backup" "$daemon_bin"; then
+    echo "cannot snapshot the shared agent config; refusing to spawn the recording daemon" >&2
     return 1
   fi
-  snapshot_hook_configs "$staging/hook-config-backup"
 
   # Read the env into an array so a value containing spaces (e.g. an
   # IRRLICHT_HOME path with a space) stays one word — an unquoted

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
@@ -165,7 +165,13 @@ HOME="$TMP/restore-home"
 CODEX_HOME="$TMP/restore-codex"
 mkdir -p "$CODEX_HOME"
 printf '{"hooks":{"Stop":"localhost:7837"}}\n' > "$HOME/.claude/settings.json"
-snapshot_hook_configs "$STAGING/hook-config-backup"
+# The snapshot asks the daemon binary which files to protect (#1357), so stand
+# one in that declares the shipped pair.
+FAKE_DAEMON="$STAGING/irrlichd"
+printf '%s\n%s\n' "$HOME/.claude/settings.json" "$CODEX_HOME/hooks.json" > "$STAGING/hook-configs"
+printf '#!/usr/bin/env bash\ncat %q\n' "$STAGING/hook-configs" > "$FAKE_DAEMON"
+chmod +x "$FAKE_DAEMON"
+snapshot_hook_configs "$STAGING/hook-config-backup" "$FAKE_DAEMON"
 printf '{"hooks":{"Stop":"localhost:7838"}}\n' > "$HOME/.claude/settings.json"   # daemon repoints it
 stop_record_daemon
 assert_eq "settings.json restored" '{"hooks":{"Stop":"localhost:7837"}}' "$(cat "$HOME/.claude/settings.json")"
@@ -177,17 +183,35 @@ trap 'rm -rf "$TMP"' EXIT
 HOME="$TMP/nohome"
 
 echo "== an unwritable backup dir refuses to start the daemon =="
-# restore_hook_configs reads "no backup for this file" as "the daemon created
-# it, remove it" — so a snapshot that silently did nothing would end the run by
-# deleting the user's real config. Refuse before anything is spawned.
+# A snapshot that cannot save the user's config must stop the run before the
+# grant-all daemon has rewritten anything — there would be nothing to hand back.
 fresh_staging unwritable
+HOOK_CONFIG_BACKUP_DIR=""   # the case above left a spent snapshot behind
 : > "$TMP/unwritable/hook-config-backup"   # a FILE where the dir must go
 err="$(spawn_record_daemon /nonexistent/irrlichd "$TMP/unwritable" 127.0.0.1:7838 "" 2>&1)"
 rc=$?
 assert_eq "returns non-zero" "1" "$rc"
-[[ "$err" == *"cannot create the hook-config backup dir"* ]] && got=yes || got=no
+[[ "$err" == *"cannot create the backup dir"* ]] && got=yes || got=no
 assert_eq "says why" "yes" "$got"
 [[ -f "$TMP/unwritable/daemon.log" ]] && got=spawned || got=none
+assert_eq "nothing was spawned" "none" "$got"
+
+echo "== a snapshot that cannot complete refuses to start the daemon =="
+# The rung ABOVE this one (an uncreatable backup dir) exits at the mkdir gate
+# and never reaches the snapshot, so without this case nothing distinguishes the
+# two: deleting the snapshot guard entirely left the whole suite green. Give it
+# a perfectly writable staging dir and a daemon that cannot answer
+# --print-hook-configs, and nothing may be spawned.
+fresh_staging nosnapshot
+BAD_DAEMON="$STAGING/irrlichd"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$BAD_DAEMON"
+chmod +x "$BAD_DAEMON"
+err="$(spawn_record_daemon "$BAD_DAEMON" "$STAGING" 127.0.0.1:7838 "" 2>&1)"
+rc=$?
+assert_eq "returns non-zero" "1" "$rc"
+[[ "$err" == *"refusing to spawn the recording daemon"* ]] && got=yes || got=no
+assert_eq "says why" "yes" "$got"
+[[ -f "$STAGING/daemon.log" ]] && got=spawned || got=none
 assert_eq "nothing was spawned" "none" "$got"
 
 echo "== waiting on a socket that never appears fails loudly =="


### PR DESCRIPTION
Closes #1357.

## What

Two independent places enumerated "the agent config files irrlicht writes hooks into" as a hardcoded two-element list. Both were correct for exactly as long as there were exactly two hook adapters. Both are now projections of the adapter registry.

- **`agent.Permission` gained `Hooks *HookInstall`** (`ConfigPath` + `Uninstall`), declared next to the Apply/Remove closures that actually write the file. `claudecode` and `codex` fill it in via a new exported `HookConfigPath()`.
- **`agents.HookConfigs()`** projects `All()` onto that declaration. A declaration that is present but unusable (nil closure, relative path) is an error, not a skip — dropping it would reproduce the exact failure this replaces, only harder to notice.
- **`irrlichd --uninstall-hooks`** loops that list instead of naming two adapters twice (uninstall + consent-revoke). Side effect: it now reports the *resolved* path, so a `CODEX_HOME` user is told which file was actually cleaned rather than `~/.codex/hooks.json` regardless.
- **`irrlichd --print-hook-configs`** (new) prints those resolved paths, one per line.
- **The recording rig** asks the daemon binary for its list instead of hardcoding one. There is deliberately **no fallback list** — a daemon that cannot answer fails the snapshot, and `spawn_record_daemon` refuses to spawn a recording daemon it cannot undo.

## The dangerous half, fixed first

The issue warns that widening the list on top of the old restore logic would *delete the user's file*. `restore_hook_configs` inferred "the daemon created this, remove it" from a **missing backup** — which is also what an unwritable backup dir, a failed `cp`, and a list that changed between snapshot and restore all look like.

Deletion now requires a **positive** record. `snapshot_hook_configs` writes a manifest (`saved` / `absent` per path) next to the backups and aborts the whole snapshot if any backup fails to land; `restore_hook_configs` drives every action from that manifest rather than from the published array, so an unrecorded path can never become a delete. A file recorded `absent` is moved into `<backup>/created/` rather than `rm -f`'d — the path ends up absent either way, but a multi-purpose config the *agent* created mid-run stays recoverable.

Scope note: this does **not** build the `HookSpec` seam from #1355 Phase F, and does not wait for it.

## Review + simplify pass (applied)

A `high`-effort review subagent returned 7 findings; all were applied. Notably: `--uninstall-hooks` no longer `log.Fatalf`s on the first adapter (one malformed `~/.claude/settings.json` used to abort the command before any later adapter was cleaned *and* before any permission was recorded denied — the #570 regression); restore now tests `-f` symmetrically with the snapshot so a *directory* at a declared path is left alone rather than relocated; the daemon probe captures stderr separately and is time-bounded; and a failing re-snapshot can no longer disarm a live one. The `/simplify` pass then removed the write-only `HOOK_CONFIG_FILES` global, the duplicate `mkdir` gate, the two pure-alias `HookConfigPath` wrappers, and a local `permissionStore` interface that duplicated `outbound.PermissionStore`; `HookConfigs` now takes the adapter slice, matching the other projections in `maps.go`.

## Defect tests, seen RED first

`bash tools/onboarding-factory/scripts/lib/hook-config-snapshot_test.sh` against the **unfixed** lib. Note the two `got []` lines — that is the user's config having been **deleted** by restore:

Re-run at the end of the branch, with the **final** test file against `origin/main`'s **unmodified** `hook-config-snapshot.sh`:

```
== the protected set is whatever the daemon declares (#1357) ==
  FAIL: the third adapter's config is restored too — expected [user gemini config] got [repointed at a dead recorder port]
== a backup that did not land aborts the snapshot instead of arming a delete (#1357) ==
  FAIL: snapshot reports failure — expected [1] got [0]
  FAIL: the user's config survives — expected [user config] got []
== an unwritable backup dir aborts the snapshot too (#1357) ==
  FAIL: snapshot reports failure — expected [1] got [0]
  FAIL: the user's config survives — expected [user config] got []
== a daemon that cannot list its config files fails the snapshot loudly (#1357) ==
  FAIL: snapshot reports failure — expected [1] got [0]
  FAIL: says which command failed — expected [yes] got [no]
== a daemon that hangs instead of answering is not waited on forever (#1357) ==
  FAIL: snapshot reports failure — expected [1] got [0]
== a diagnostic on stderr is never adopted as a config path (#1357) ==
  FAIL: only the stdout path is managed — expected [.../noisy/home/.claude/settings.json] got []
== a failing re-snapshot does not disarm the one that succeeded (#1357) ==
  FAIL: the second snapshot is refused — expected [1] got [0]
  FAIL: the first snapshot still restores — expected [user config] got [repointed]
== the lib names no agent config path of its own (#1357) ==
  FAIL: no agent config literals in the lib — expected [0] got [2]

hook-config-snapshot_test: 12 FAILURE(S)
```

The two `the user's config survives — got []` lines are the destructive bug reproduced: `restore_hook_configs` **deleted** the user's config because the snapshot had silently failed to back it up. All 12 green after the fix.

## Contract tests, with the mutation each was seen red under

These pass by construction against a correct adapter set, so each lands with its deliberate mutation (AGENTS.md).

**1. `TestEveryHooksPermissionIsCoveredByHookConfigs`** — mutation: delete codex's `Hooks:` declaration.
```
--- FAIL: TestEveryHooksPermissionIsCoveredByHookConfigs (0.00s)
    hookconfigs_test.go:51: codex/hooks declares a hooks permission but no agent.HookInstall: `irrlichd --uninstall-hooks` would leave its entries in the user's real config permanently, and a recording would repoint that file at a dead recorder port and never hand it back (#1357)
    hookconfigs_test.go:67: HookConfigs() returned 1 entries for 2 declared hooks permissions
```

**2. `TestPrintHookConfigsListsEveryDeclaredConfigFile`** — mutation: `for _, c := range configs[:1]` in `printHookConfigs`.
```
--- FAIL: TestPrintHookConfigsListsEveryDeclaredConfigFile (0.00s)
    hookconfigs_test.go:50: codex/hooks declares "/Users/ingo/.codex/hooks.json", which --print-hook-configs does not list: a recording would repoint that file and never restore it (#1357)
```

**3. `TestUninstallHookConfigsCoversEveryConfig`** — mutation: `for _, c := range configs[:1]` in `uninstallHookConfigs`.
```
--- FAIL: TestUninstallHookConfigsCoversEveryConfig (0.00s)
    hookconfigs_test.go:102: uninstalled "alpha", want "alpha,beta,gamma" — an adapter whose uninstaller never runs keeps its hook entries forever (#1357)
    hookconfigs_test.go:118: the uninstall report never mentions "/tmp/beta/hooks.json":
```

**4. `spawn-record-daemon_test.sh` "a snapshot that cannot complete refuses to start the daemon"** — mutation: drop the `if !` guard in `spawn_record_daemon`. This one is the reviewer's finding #1: the guard had no test at all, and the nearest existing case exits one rung earlier.
```
== a snapshot that cannot complete refuses to start the daemon ==
  PASS: returns non-zero
  FAIL: says why — expected [yes] got [no]
  FAIL: nothing was spawned — expected [none] got [spawned]
```

**5. `hook-config-snapshot_test.sh` "a directory at a declared config path is left alone"** — mutation: restore tests `-e` instead of `-f`.
```
  FAIL: the directory survives — expected [keep me] got []
```
(This case passes against `origin/main`, whose `rm -f` refuses a directory — it is a lock relative to `main` and a regression test relative to the intermediate implementation, which was briefly *more* destructive than the bug.)

## Locks (pass by construction, not red-first evidence)

- The four pre-existing `hook-config-snapshot_test.sh` cases (restore byte-for-byte, created-file removed, untouched config unchanged, restore-without-snapshot no-op) — carried forward unchanged except for the new daemon argument.
- `hook-config-snapshot_test.sh` "restore acts only on paths the manifest records" — labelled a lock in the file itself; it passes on `main` too.
- `hook-config-snapshot_test.sh` "a directory at a declared config path is left alone" — a lock vs `main` (see mutation 5 above).
- All the pre-existing `spawn-record-daemon_test.sh` cases, including the `#1214` single-owner assertions.
- `TestUninstallHookConfigsLeavesUngrantedPermissionsAlone` — a pending permission must not be silently turned into a denial.
- `TestHookConfigsIgnoresPermissionsWithoutHooks` — only the hooks permission contributes a config file.
- `TestNonAgentPermissionDeclarationsDeclareNoHooks` — a tripwire on gastown/launcher/kitty, which are appended to the consent catalog in `startup.go` and are NOT projected by `agents.HookConfigs`.

Every test in this PR runs against a fake `$HOME`/`$CODEX_HOME` or synthetic configs. Nothing exercises deletion against a real `~/.claude`, `~/.codex` or `~/.gemini`.

## Gates

`tools/preflight.sh` (unscoped, re-run after the review + simplify passes) — **13/13 PASS**: gofmt, core module tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, replay fixtures, starhistory tests, both web suites, ARS architecture gate, tools/lib shell-lib tests, skill-file lint, security scan.

`bash tools/onboarding-factory/scripts/smoke-test.sh` — **PASS**.

Manual check of the new flag on a real build:
```
$ irrlichd --print-hook-configs
/Users/ingo/.claude/settings.json
/Users/ingo/.codex/hooks.json
$ CODEX_HOME=/tmp/altcodex irrlichd --print-hook-configs
/Users/ingo/.claude/settings.json
/tmp/altcodex/hooks.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Known gaps / deliberate non-goals

- **Only *hooks* permissions are protected — tracked as #1383.** `claudecode/instructions` (`~/.claude/CLAUDE.md`) and `processlifecycle` kitty `remote-control` (`~/.config/kitty/kitty.conf`) are also shared user files a grant-all recording daemon can write, and the rig still does not back them up. Widening the mechanism to "any shared user file a permission writes" was judged scope creep for this issue: those blocks are sentinel-delimited, idempotent and port-free (all three verified by reading the code — see #1383 for the file:line evidence and for what would flip them into the hooks severity class). A leftover is a consent violation rather than the broken-state hazard a stale hook endpoint is.
- **`ConfigPath` is singular.** #1355 Phase E adds adapters with a per-file-in-a-directory hook config. The rest of the pipeline is already plural (one path per line, a list in the manifest), so that migration is a one-field change when it lands.
- **`--print-hook-configs` has exactly one consumer** (the recording rig). It is documented in `site/docs/cli-tools.html` as such rather than as a general-purpose flag.
