### PR TITLE
fix(state): bound hook-asserted persistent holds with a wall-clock ceiling

### DIFF
--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -357,6 +357,14 @@ func (d *SessionDetector) RunStaleSessionRefreshForTest() {
 	d.refreshStaleSessions()
 }
 
+// HoldSignalForTest places an out-of-band signal hold with an explicit
+// HeldSince. Exported only so tests outside this package can set up a hold
+// that is already older than its policy's ceiling; production code holds
+// through ApplyHook, which always stamps time.Now.
+func (d *SessionDetector) HoldSignalForTest(sessionID string, kind session.SignalKind, at time.Time) {
+	d.signals.Hold(sessionID, kind, session.SignalPayload{}, at)
+}
+
 // CleanupZombies runs a one-shot startup sweep that deletes persisted
 // sessions whose process is provably gone. Call before the daemon starts
 // serving requests so the API never returns stale records inherited from a

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1385,33 +1385,24 @@ func (d *SessionDetector) armStalledEditTool(state *session.SessionState, now ti
 	d.signals.HoldIfAbsent(state.SessionID, session.SignalOpenToolStalled, session.SignalPayload{}, now)
 }
 
-// refreshHeldSession re-runs the classify pipeline for a non-working session
-// that still has an out-of-band signal hold outstanding (#1360).
+// reclassifyFromTranscript re-reads one session's transcript and re-runs the
+// classify pipeline, subject to the three preconditions every ticker-driven
+// re-read shares. It is the body of both refreshStaleSessions branches, kept
+// in one place so those preconditions cannot drift apart — the consent gate
+// especially, since a branch that forgot it would silently keep reading a
+// revoked adapter and nothing else in the system would object.
 //
-// Without it, the ceilings this issue adds could never fire in the situation
-// they exist for. A ceiling is only evaluated inside SignalHolds.Overlay, and
-// Overlay is only reached from the classify pipeline; refreshStaleSessions —
-// the one thing that revisits a session no transcript event is arriving for —
-// ran that pipeline for StateWorking alone. Both hook holds with a ceiling pin
-// the session at *waiting*, so the pinned session was precisely the one the
-// ticker skipped, and a lost release stayed lost for the life of the process.
+//   - the interval: a session updated moments ago has nothing new to say, and
+//     re-reading it every tick is pure cost;
+//   - a transcript to read at all;
+//   - consent (#570): this path re-reads independently of the gated watcher
+//     pipeline, so after a revoke, persisted sessions would otherwise keep
+//     being re-read and re-broadcast every tick — "existing sessions stop
+//     updating" must hold.
 //
-// That asymmetry is also why compactHoldTimeout appeared to prove the
-// mechanism worked: it pins at working, the state already being re-read.
-//
-// Scoped to sessions with a hold outstanding, deliberately. The ticker not
-// re-reading idle transcripts is long-standing behaviour with a real cost
-// attached — one stat and parse per idle session per tick, on a machine that
-// may be tracking dozens — and a hold is both rare and the only reason this
-// pass has anything to decide. The remaining guards are the working branch's,
-// for the same reasons: the interval keeps a busy session from being re-read
-// every tick, and observeAllowed keeps a revoked adapter from being read at
-// all (#570), which a refresh outside the gated watcher pipeline would
-// otherwise quietly bypass.
-func (d *SessionDetector) refreshHeldSession(state *session.SessionState, now time.Time) {
-	if d.signals == nil || !d.signals.HasAny(state.SessionID) {
-		return
-	}
+// See refreshStaleSessions' non-working branch for why an idle session is ever
+// put through this.
+func (d *SessionDetector) reclassifyFromTranscript(state *session.SessionState, now time.Time) {
 	if now.Sub(time.Unix(state.UpdatedAt, 0)) < staleWorkingRefreshInterval {
 		return
 	}
@@ -1483,28 +1474,30 @@ func (d *SessionDetector) refreshStaleSessions() {
 	for _, state := range sessions {
 		switch state.State {
 		case session.StateWorking:
-			if now.Sub(time.Unix(state.UpdatedAt, 0)) < staleWorkingRefreshInterval {
-				continue
-			}
-			if state.TranscriptPath == "" {
-				continue
-			}
-			// Consent-gated per adapter (#570): this refresh re-reads the
-			// transcript independently of the (gated) watcher pipeline. After
-			// a revoke, persisted working sessions would otherwise keep being
-			// re-read and re-broadcast every tick — "existing sessions stop
-			// updating" must hold.
-			if !d.observeAllowed(state.Adapter) {
-				continue
-			}
-			d.processActivityWithoutIdentity(agent.Event{
-				Type:           agent.EventActivity,
-				SessionID:      state.SessionID,
-				TranscriptPath: state.TranscriptPath,
-			})
+			d.reclassifyFromTranscript(state, now)
 		case session.StateWaiting, session.StateReady:
 			d.retryIdleProjectResolution(state, now)
-			d.refreshHeldSession(state, now)
+
+			// A held signal is the one reason to revisit a non-working
+			// session, and without this the ceilings added in #1360 could
+			// never fire. A ceiling is only evaluated inside
+			// SignalHolds.Overlay, Overlay is only reached from the classify
+			// pipeline, and this loop ran that pipeline for StateWorking
+			// alone — while both hook holds that have a ceiling pin the
+			// session at *waiting*. The pinned session was precisely the one
+			// being skipped, so a lost release stayed lost for the life of
+			// the process. (That asymmetry is also why compactHoldTimeout
+			// appeared to prove the mechanism worked: it pins at working, the
+			// state already being re-read.)
+			//
+			// Scoped to sessions that actually hold something, deliberately:
+			// not re-reading idle transcripts is long-standing behaviour with
+			// a real cost attached — one stat and parse per idle session per
+			// tick, on a machine that may be tracking dozens — and a hold is
+			// both rare and the only thing such a pass could newly decide.
+			if d.signals != nil && d.signals.HasAny(state.SessionID) {
+				d.reclassifyFromTranscript(state, now)
+			}
 		}
 	}
 }

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -812,7 +812,7 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 	// Overlay is what decides whether it has been open long enough to apply.
 	d.armStalledEditTool(state, passStart)
 
-	d.signals.Overlay(state.SessionID, state.Metrics, passStart)
+	d.reportHoldExpiries(state, d.signals.Overlay(state.SessionID, state.Metrics, passStart), passStart)
 
 	// Content-based state detection. The tiered form is used here (and only
 	// here) so the deciding rule and its authority tier reach the recorded
@@ -1383,6 +1383,46 @@ func (d *SessionDetector) armStalledEditTool(state *session.SessionState, now ti
 		return
 	}
 	d.signals.HoldIfAbsent(state.SessionID, session.SignalOpenToolStalled, session.SignalPayload{}, now)
+}
+
+// reportHoldExpiries surfaces the holds Overlay dropped because their
+// wall-clock ceiling elapsed (#1360). It is the observability half of that
+// fix, and it lives here rather than in the domain because core/domain/session
+// owns no logger and may not import one — the architecture test enforces that
+// direction, so the domain reports expiries as data and the caller decides
+// what to do with them.
+//
+// A ceiling firing means a release that should have arrived never did: the
+// hook fired, the PostToolUse (or the transcript's end-of-life marker) did
+// not, and the session had been pinned by a signal nothing below it was
+// allowed to correct. That is precisely the condition an operator cannot
+// otherwise infer from a recording — before this, the only trace was a
+// ClassifierInputs bit quietly reading false on some later transition, which
+// is indistinguishable from the hold never having been placed.
+//
+// Both sinks are deliberate and neither substitutes for the other: the log
+// line is what a human tailing the daemon sees live, and the lifecycle event
+// is what the replay harness reads back out of a recording. Normal staleness
+// releases are NOT reported — they are the expected path, and emitting them
+// would bury the interesting case in one line per permission denial.
+func (d *SessionDetector) reportHoldExpiries(state *session.SessionState, expiries []session.SignalExpiry, at time.Time) {
+	for _, e := range expiries {
+		d.log.LogInfo(logComponentSessionDetector, state.SessionID, fmt.Sprintf(
+			"held signal %q (%v tier) expired after %v, past its %v ceiling — its release never arrived; "+
+				"the session is no longer pinned by it",
+			e.Kind, e.Tier, e.HeldFor.Round(time.Second), e.Ceiling))
+
+		d.record(lifecycle.Event{
+			Kind:       lifecycle.KindHoldExpired,
+			Timestamp:  at,
+			SessionID:  state.SessionID,
+			Adapter:    state.Adapter,
+			SignalKind: string(e.Kind),
+			SignalTier: e.Tier.String(),
+			HeldForMS:  e.HeldFor.Milliseconds(),
+			CeilingMS:  e.Ceiling.Milliseconds(),
+		})
+	}
 }
 
 // refreshStaleSessions re-reads working sessions that haven't received a

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1385,6 +1385,49 @@ func (d *SessionDetector) armStalledEditTool(state *session.SessionState, now ti
 	d.signals.HoldIfAbsent(state.SessionID, session.SignalOpenToolStalled, session.SignalPayload{}, now)
 }
 
+// refreshHeldSession re-runs the classify pipeline for a non-working session
+// that still has an out-of-band signal hold outstanding (#1360).
+//
+// Without it, the ceilings this issue adds could never fire in the situation
+// they exist for. A ceiling is only evaluated inside SignalHolds.Overlay, and
+// Overlay is only reached from the classify pipeline; refreshStaleSessions —
+// the one thing that revisits a session no transcript event is arriving for —
+// ran that pipeline for StateWorking alone. Both hook holds with a ceiling pin
+// the session at *waiting*, so the pinned session was precisely the one the
+// ticker skipped, and a lost release stayed lost for the life of the process.
+//
+// That asymmetry is also why compactHoldTimeout appeared to prove the
+// mechanism worked: it pins at working, the state already being re-read.
+//
+// Scoped to sessions with a hold outstanding, deliberately. The ticker not
+// re-reading idle transcripts is long-standing behaviour with a real cost
+// attached — one stat and parse per idle session per tick, on a machine that
+// may be tracking dozens — and a hold is both rare and the only reason this
+// pass has anything to decide. The remaining guards are the working branch's,
+// for the same reasons: the interval keeps a busy session from being re-read
+// every tick, and observeAllowed keeps a revoked adapter from being read at
+// all (#570), which a refresh outside the gated watcher pipeline would
+// otherwise quietly bypass.
+func (d *SessionDetector) refreshHeldSession(state *session.SessionState, now time.Time) {
+	if d.signals == nil || !d.signals.HasAny(state.SessionID) {
+		return
+	}
+	if now.Sub(time.Unix(state.UpdatedAt, 0)) < staleWorkingRefreshInterval {
+		return
+	}
+	if state.TranscriptPath == "" {
+		return
+	}
+	if !d.observeAllowed(state.Adapter) {
+		return
+	}
+	d.processActivityWithoutIdentity(agent.Event{
+		Type:           agent.EventActivity,
+		SessionID:      state.SessionID,
+		TranscriptPath: state.TranscriptPath,
+	})
+}
+
 // reportHoldExpiries surfaces the holds Overlay dropped because their
 // wall-clock ceiling elapsed (#1360). It is the observability half of that
 // fix, and it lives here rather than in the domain because core/domain/session
@@ -1461,6 +1504,7 @@ func (d *SessionDetector) refreshStaleSessions() {
 			})
 		case session.StateWaiting, session.StateReady:
 			d.retryIdleProjectResolution(state, now)
+			d.refreshHeldSession(state, now)
 		}
 	}
 }

--- a/core/application/services/session_detector_hold_ceiling_test.go
+++ b/core/application/services/session_detector_hold_ceiling_test.go
@@ -1,0 +1,133 @@
+package services_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+)
+
+// newHeldWaitingSession persists a session that is pinned at waiting by a hook
+// hold whose release never arrived: quiet transcript, stale UpdatedAt, project
+// already resolved so the idle-retry path has nothing to do and cannot be
+// mistaken for the thing that unpinned it.
+func newHeldWaitingSession(t *testing.T, repo *mockRepo, sessionID string) {
+	t.Helper()
+	dir := t.TempDir()
+	transcriptPath := filepath.Join(dir, sessionID+".jsonl")
+	writeOldTranscript(t, transcriptPath, time.Minute)
+
+	old := time.Now().Add(-time.Hour).Unix()
+	repo.Save(&session.SessionState{
+		SessionID:      sessionID,
+		State:          session.StateWaiting,
+		Adapter:        "claude-code",
+		TranscriptPath: transcriptPath,
+		CWD:            dir,
+		ProjectName:    "proj",
+		Metrics:        &session.SessionMetrics{LastEventType: "turn_done"},
+		PID:            4242,
+		FirstSeen:      old,
+		UpdatedAt:      old,
+	})
+}
+
+// TestSessionDetector_StaleRefreshExpiresAHookHoldOnAWaitingSession is the
+// second #1360 defect test, and it FAILED against the first version of this
+// branch — the one that added ceilings to the policy table but nothing else.
+//
+// A ceiling is only ever evaluated inside SignalHolds.Overlay, and Overlay is
+// only reached from the classify pipeline. refreshStaleSessions — the only
+// thing that revisits a session no transcript event is arriving for — ran that
+// pipeline for StateWorking alone; StateWaiting and StateReady got
+// retryIdleProjectResolution, which does not reclassify.
+//
+// Both ceilings this issue adds bound holds that pin the session at *waiting*.
+// So in the exact scenario #1360 describes — the release is lost and the agent
+// then goes quiet — no further pass ever runs, Overlay is never called again,
+// and a declared ceiling can never fire. The session stays pinned for the life
+// of the process, which is the defect the ceilings were supposed to remove.
+//
+// This is also why compactHoldTimeout has always worked and looked like proof
+// the mechanism was sound: it pins at *working*, the one state the ticker
+// already re-read.
+//
+// The observable asserted here is the recorded hold_expired event rather than
+// the session's new state, and deliberately: this harness's metrics collector
+// is a mock that leaves state.Metrics nil, so the classifier has nothing to
+// re-decide from and any state assertion would be measuring the mock. The
+// recorded event is the sharper claim anyway — it can only be emitted by a
+// real Overlay call inside a real classify pass, which is precisely the thing
+// that was not happening. The user-visible "no longer pinned at waiting" half
+// is covered by TestClassify_HookHoldCeilingUnpinsAStuckSession.
+func TestSessionDetector_StaleRefreshExpiresAHookHoldOnAWaitingSession(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	det := newDetector(tw, pw, repo)
+
+	rec := &mockRecorder{}
+	det.SetRecorder(rec)
+
+	newHeldWaitingSession(t, repo, "held1")
+
+	// The PermissionRequest hook landed two hours ago; PostToolUse never came.
+	// Two hours is past permissionPromptHoldTimeout with room to spare.
+	det.HoldSignalForTest("held1", session.SignalPermissionPrompt, time.Now().Add(-2*time.Hour))
+
+	det.RunStaleSessionRefreshForTest()
+
+	var expired *lifecycle.Event
+	for _, ev := range rec.snapshot() {
+		if ev.Kind == lifecycle.KindHoldExpired {
+			e := ev
+			expired = &e
+		}
+	}
+	if expired == nil {
+		t.Fatalf("no %q event — the ticker never ran a classify pass for the held waiting session, "+
+			"so its ceiling could not fire", lifecycle.KindHoldExpired)
+	}
+	if expired.SessionID != "held1" {
+		t.Errorf("expiry attributed to %q, want %q", expired.SessionID, "held1")
+	}
+	if expired.SignalKind != string(session.SignalPermissionPrompt) {
+		t.Errorf("SignalKind = %q, want %q", expired.SignalKind, session.SignalPermissionPrompt)
+	}
+}
+
+// TestSessionDetector_StaleRefreshLeavesAnUnheldIdleSessionAlone is the
+// counterweight, and a LOCK on behaviour that predates #1360.
+//
+// The fix above makes refreshStaleSessions re-read transcripts for
+// non-working sessions, which is work the ticker deliberately did not do
+// before. Scoping it to sessions that actually have a hold outstanding is what
+// keeps that from becoming a per-tick transcript re-read of every idle session
+// on the machine — so the scoping needs a test, or the next refactor will
+// quietly widen it.
+func TestSessionDetector_StaleRefreshLeavesAnUnheldIdleSessionAlone(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	det := newDetector(tw, pw, repo)
+
+	newHeldWaitingSession(t, repo, "quiet1") // same fixture, but no hold placed
+
+	before, err := repo.Load("quiet1")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	det.RunStaleSessionRefreshForTest()
+
+	after, err := repo.Load("quiet1")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if after.State != before.State || after.UpdatedAt != before.UpdatedAt {
+		t.Errorf("an idle session with no hold outstanding must not be reclassified by the ticker: "+
+			"state %q→%q, updatedAt %d→%d",
+			before.State, after.State, before.UpdatedAt, after.UpdatedAt)
+	}
+}

--- a/core/application/services/session_detector_hold_ceiling_test.go
+++ b/core/application/services/session_detector_hold_ceiling_test.go
@@ -73,9 +73,13 @@ func TestSessionDetector_StaleRefreshExpiresAHookHoldOnAWaitingSession(t *testin
 
 	newHeldWaitingSession(t, repo, "held1")
 
-	// The PermissionRequest hook landed two hours ago; PostToolUse never came.
-	// Two hours is past permissionPromptHoldTimeout with room to spare.
-	det.HoldSignalForTest("held1", session.SignalPermissionPrompt, time.Now().Add(-2*time.Hour))
+	// The PermissionRequest hook landed three days ago; PostToolUse never came.
+	// Deliberately far past any defensible ceiling rather than just past the
+	// current one: this test is about the ticker reaching the session at all,
+	// so retuning permissionPromptHoldTimeout must not be able to break it.
+	// (It could, once: an earlier version held two hours back and started
+	// failing the moment that constant grew to twelve.)
+	det.HoldSignalForTest("held1", session.SignalPermissionPrompt, time.Now().Add(-72*time.Hour))
 
 	det.RunStaleSessionRefreshForTest()
 

--- a/core/application/services/state_classifier_hold_ceiling_test.go
+++ b/core/application/services/state_classifier_hold_ceiling_test.go
@@ -85,6 +85,87 @@ func TestClassify_HookHoldCeilingUnpinsAStuckSession(t *testing.T) {
 	}
 }
 
+// TestClassify_WhatTheUserSeesAfterAPermissionCeilingExpires pins the claim
+// that permissionPromptHoldTimeout's rationale rests on, for both populations
+// it splits the world into. Before this, every test here established only that
+// the ceiling FIRES; none established what a user actually observes afterwards
+// — which is the thing that decides whether an hour or a night is the right
+// number.
+//
+// Neither case is a defect test: both describe behaviour the current code
+// already has. The first is a LOCK on #488's fallback, and it is the assertion
+// that would have caught the original comment's claim that expiry is "soft and
+// self-correcting" across the board. The second is a CHARACTERIZATION of the
+// residual that claim got wrong, written down so it stops being invisible.
+func TestClassify_WhatTheUserSeesAfterAPermissionCeilingExpires(t *testing.T) {
+	// Well past the ceiling, without naming the constant: this asserts the
+	// shape of the outcome, not the tuning.
+	pastAnyCeiling := holdT0.Add(72 * time.Hour)
+
+	t.Run("covered tool: the transcript tier re-derives waiting", func(t *testing.T) {
+		// An Edit prompt — one of the four alternatives of claudecode's
+		// matcher that isPermissionGatedEditTool also matches.
+		holds := session.NewSignalHolds()
+		const sid = "s"
+
+		holds.Hold(sid, session.SignalPermissionPrompt, session.SignalPayload{}, holdT0)
+		// #488's fallback, armed by the detector the moment the tool is seen
+		// open. Arm-once, so its clock starts with the prompt.
+		holds.HoldIfAbsent(sid, session.SignalOpenToolStalled, session.SignalPayload{}, holdT0)
+
+		m := &session.SessionMetrics{
+			LastEventType:     "assistant",
+			HasOpenToolCall:   true,
+			LastOpenToolNames: []string{"Edit"},
+		}
+		holds.Overlay(sid, m, pastAnyCeiling)
+
+		if m.PermissionPending {
+			t.Fatal("precondition: the hook hold must have expired, or this proves nothing about the fallback")
+		}
+		v := ClassifyStateTiered(session.StateWaiting, m)
+		if v.State != session.StateWaiting {
+			t.Errorf("an edit-tool prompt must still read waiting after the hook ceiling expires — "+
+				"SignalOpenToolStalled is the net; got %q", v.State)
+		}
+		if v.Tier != session.TierTranscript {
+			t.Errorf("the re-derived verdict must be attributed to the transcript tier (correctable), got %v", v.Tier)
+		}
+	})
+
+	t.Run("uncovered tool: nothing re-derives it, the session reads ready", func(t *testing.T) {
+		// ExitPlanMode-shaped: the #307 fast path. No tool is open — a plan
+		// approval is not a file edit — so isPermissionGatedEditTool matches
+		// nothing and #488 never arms.
+		//
+		// CHARACTERIZATION, not an endorsement. This is the accepted residual
+		// that sets the ceiling: the session silently stops advertising that a
+		// human is needed, and only the recorded hold_expired event says why.
+		// It is why the constant is calibrated against an overnight rather
+		// than a lunch break, and why shortening it is not a free tuning knob.
+		holds := session.NewSignalHolds()
+		const sid = "s"
+
+		holds.Hold(sid, session.SignalPermissionPrompt, session.SignalPayload{}, holdT0)
+
+		m := &session.SessionMetrics{LastEventType: "turn_done"}
+		holds.Overlay(sid, m, pastAnyCeiling)
+
+		if m.OpenToolStalled {
+			t.Fatal("no edit tool is open, so the #488 fallback must not have armed")
+		}
+		v := ClassifyStateTiered(session.StateWaiting, m)
+		if v.State == session.StateWaiting {
+			t.Fatal("this test documents the residual; if a plan approval now survives its ceiling, " +
+				"the fallback story changed and permissionPromptHoldTimeout's comment must be rewritten")
+		}
+		if v.State != session.StateReady {
+			t.Errorf("expected the uncovered case to fall through to ready, got %q — "+
+				"if this changed, update the rationale it is cited by", v.State)
+		}
+	})
+}
+
 // TestSessionDetector_HoldCeilingExpiryIsLoggedAndRecorded covers #1360 scope
 // item 4: a ceiling that rewrites session state without saying so is a new
 // debugging blind spot rather than a fix.

--- a/core/application/services/state_classifier_hold_ceiling_test.go
+++ b/core/application/services/state_classifier_hold_ceiling_test.go
@@ -1,0 +1,191 @@
+package services
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+)
+
+// ceilingRecorder captures lifecycle events for the #1360 expiry assertions.
+// Local rather than the package's fakeRecorder, which implements only Record
+// and so does not satisfy outbound.EventRecorder.
+type ceilingRecorder struct{ events []lifecycle.Event }
+
+func (r *ceilingRecorder) Record(ev lifecycle.Event) { r.events = append(r.events, ev) }
+func (r *ceilingRecorder) Close() error              { return nil }
+
+// TestClassify_HookHoldCeilingUnpinsAStuckSession is #1360 stated end to end,
+// at the altitude the defect is actually felt: not "a map entry survived" but
+// "the badge says waiting and nothing can talk it down". It FAILED before the
+// ceiling existed.
+//
+// The sequence is the unrecoverable one. A PermissionRequest hook lands and
+// correctly pins the session at waiting. The release never arrives — the POST
+// was lost to a daemon restart, a port change, or an uninstalled hook — and no
+// denial marker is ever written, so the metric-driven staleness rule stays
+// false. Because SignalPermissionPrompt is TierHook, every lower-tier signal
+// that would otherwise reclassify the session is outranked. Pre-fix the final
+// pass below still returned waiting, at hook tier, with no elapsed time able
+// to change that.
+//
+// The middle block — repeated passes staying waiting — is a LOCK, not a defect
+// assertion. Pinning is the feature; #1360 is only about it having no end.
+func TestClassify_HookHoldCeilingUnpinsAStuckSession(t *testing.T) {
+	// Must exceed every ceiling declared on a TierHook persistent row. Framed
+	// as an absurd elapsed time rather than as a named constant (which is
+	// unexported in core/domain/session) so retuning a ceiling cannot make
+	// this test lie in either direction.
+	const beyondAnyHookCeiling = 48 * time.Hour
+
+	holds := session.NewSignalHolds()
+	const sid = "s"
+
+	// A permission-gated tool opens and the hook lands: the user is blocked.
+	holds.Hold(sid, session.SignalPermissionPrompt, session.SignalPayload{}, holdT0)
+
+	m := &session.SessionMetrics{LastEventType: "turn_done"}
+	holds.Overlay(sid, m, holdT0)
+	v := ClassifyStateTiered(session.StateWorking, m)
+	if v.State != session.StateWaiting {
+		t.Fatalf("the permission hook must pin the session at waiting, got %q", v.State)
+	}
+	if v.Tier != session.TierHook {
+		t.Fatalf("that verdict must be attributed to the hook tier, got %v", v.Tier)
+	}
+	state := v.State
+
+	// LOCK: while the prompt is plausibly still open the pin must hold across
+	// every re-evaluation. This is the behaviour #1360 must not weaken.
+	for pass := 1; pass <= 3; pass++ {
+		again := &session.SessionMetrics{LastEventType: "turn_done"}
+		holds.Overlay(sid, again, holdT0.Add(time.Duration(pass)*time.Minute))
+		v = ClassifyStateTiered(state, again)
+		if v.State != session.StateWaiting {
+			t.Fatalf("pass %d: the pin must hold inside the ceiling, got %q", pass, v.State)
+		}
+	}
+
+	// The release never came. Once the ceiling elapses the session must stop
+	// being pinned and re-classify from whatever evidence it does have.
+	unpinned := &session.SessionMetrics{LastEventType: "turn_done"}
+	holds.Overlay(sid, unpinned, holdT0.Add(beyondAnyHookCeiling))
+	v = ClassifyStateTiered(state, unpinned)
+
+	if v.State == session.StateWaiting {
+		t.Errorf("the session is still pinned at waiting after %v — a missed release must not be permanent", beyondAnyHookCeiling)
+	}
+	if v.Tier == session.TierHook {
+		t.Errorf("an expired hold must stop claiming hook authority, got tier %v deciding %q", v.Tier, v.State)
+	}
+	if unpinned.PermissionPending {
+		t.Error("the expired hold must not keep folding PermissionPending onto fresh metrics")
+	}
+}
+
+// TestSessionDetector_HoldCeilingExpiryIsLoggedAndRecorded covers #1360 scope
+// item 4: a ceiling that rewrites session state without saying so is a new
+// debugging blind spot rather than a fix.
+//
+// Honest framing on red-first: this is a NEW-CAPABILITY test, not a defect
+// test. Nothing reported ceiling expiries before, so there was no shape for it
+// to assert and it could not have been run red on main — it would not have
+// compiled. Its ability to fail was shown instead by deliberate mutation,
+// recorded in the PR: dropping the d.record call fails the event assertions,
+// dropping the d.log.LogInfo call fails the log assertion.
+//
+// Both sinks are asserted because they serve different readers and neither
+// implies the other — the log line is what a human tailing the daemon sees
+// live, the lifecycle event is what the replay harness reads back out of a
+// recording.
+func TestSessionDetector_HoldCeilingExpiryIsLoggedAndRecorded(t *testing.T) {
+	const beyondAnyHookCeiling = 48 * time.Hour
+
+	lg := &capturingLogger{}
+	rec := &ceilingRecorder{}
+	d := &SessionDetector{log: lg, recorder: rec, signals: session.NewSignalHolds()}
+
+	state := &session.SessionState{
+		SessionID: "s",
+		Adapter:   "claudecode",
+		Metrics:   &session.SessionMetrics{LastEventType: "turn_done"},
+	}
+
+	d.signals.Hold(state.SessionID, session.SignalPermissionPrompt, session.SignalPayload{}, holdT0)
+
+	at := holdT0.Add(beyondAnyHookCeiling)
+	d.reportHoldExpiries(state, d.signals.Overlay(state.SessionID, state.Metrics, at), at)
+
+	if lg.calls != 1 {
+		t.Fatalf("expected exactly one log line for the expiry, got %d", lg.calls)
+	}
+	if !strings.Contains(lg.message, string(session.SignalPermissionPrompt)) {
+		t.Errorf("the log line must name the signal that expired, got %q", lg.message)
+	}
+	if lg.sessionID != state.SessionID {
+		t.Errorf("the log line must be attributed to its session, got %q", lg.sessionID)
+	}
+
+	if len(rec.events) != 1 {
+		t.Fatalf("expected exactly one lifecycle event, got %d: %+v", len(rec.events), rec.events)
+	}
+	ev := rec.events[0]
+	if ev.Kind != lifecycle.KindHoldExpired {
+		t.Errorf("Kind = %q, want %q", ev.Kind, lifecycle.KindHoldExpired)
+	}
+	if ev.SessionID != state.SessionID || ev.Adapter != state.Adapter {
+		t.Errorf("the event must identify its session and adapter, got %q/%q", ev.SessionID, ev.Adapter)
+	}
+	if ev.SignalKind != string(session.SignalPermissionPrompt) {
+		t.Errorf("SignalKind = %q, want %q", ev.SignalKind, session.SignalPermissionPrompt)
+	}
+	if ev.SignalTier != session.TierHook.String() {
+		t.Errorf("SignalTier = %q, want %q — the tier is what makes the expiry consequential",
+			ev.SignalTier, session.TierHook.String())
+	}
+	if ev.HeldForMS != beyondAnyHookCeiling.Milliseconds() {
+		t.Errorf("HeldForMS = %d, want %d", ev.HeldForMS, beyondAnyHookCeiling.Milliseconds())
+	}
+	if ev.CeilingMS <= 0 || ev.CeilingMS >= ev.HeldForMS {
+		t.Errorf("CeilingMS = %d must be positive and below HeldForMS %d, or the trace cannot show it was overdue",
+			ev.CeilingMS, ev.HeldForMS)
+	}
+	if !ev.Timestamp.Equal(at) {
+		t.Errorf("Timestamp = %v, want the pass clock %v — an expiry stamped with wall time would not replay",
+			ev.Timestamp, at)
+	}
+}
+
+// TestSessionDetector_NormalHoldReleaseIsNotReported is the noise-floor half.
+// A permission denial is the expected end-of-life path and happens constantly;
+// if it emitted a log line and a lifecycle event, the rare expiry that
+// actually indicates a lost release would be buried, which defeats the purpose
+// of recording it at all.
+func TestSessionDetector_NormalHoldReleaseIsNotReported(t *testing.T) {
+	lg := &capturingLogger{}
+	rec := &ceilingRecorder{}
+	d := &SessionDetector{log: lg, recorder: rec, signals: session.NewSignalHolds()}
+
+	state := &session.SessionState{
+		SessionID: "s",
+		Adapter:   "claudecode",
+		Metrics:   &session.SessionMetrics{LastWasToolDenial: true},
+	}
+
+	d.signals.Hold(state.SessionID, session.SignalPermissionPrompt, session.SignalPayload{}, holdT0)
+
+	at := holdT0.Add(time.Minute)
+	d.reportHoldExpiries(state, d.signals.Overlay(state.SessionID, state.Metrics, at), at)
+
+	if d.signals.Held(state.SessionID, session.SignalPermissionPrompt) {
+		t.Fatal("precondition: the denial must have retired the hold, or this test proves nothing")
+	}
+	if lg.calls != 0 {
+		t.Errorf("a normal staleness release must log nothing, got %q", lg.message)
+	}
+	if len(rec.events) != 0 {
+		t.Errorf("a normal staleness release must record nothing, got %+v", rec.events)
+	}
+}

--- a/core/domain/lifecycle/event.go
+++ b/core/domain/lifecycle/event.go
@@ -62,6 +62,14 @@ const (
 	// turn exceeding the project's p25 baseline × threshold. The named
 	// consumer is the ir:agent-releases workflow.
 	KindCacheBloatDetected Kind = "cache_bloat_detected"
+
+	// Held-signal ceiling expiry (issue #1360). Emitted when an out-of-band
+	// signal hold is dropped because its wall-clock ceiling elapsed rather
+	// than because its own staleness rule ended it or a Release retired it —
+	// which for a TierHook hold means a release that should have arrived
+	// never did. Rare by construction, and the one event that explains a
+	// session silently ceasing to be pinned at waiting.
+	KindHoldExpired Kind = "hold_expired"
 )
 
 // Event is a single recorded lifecycle signal. The Kind field discriminates
@@ -120,6 +128,15 @@ type Event struct {
 	// Terminal-backend read-back (KindUIDetected). The UI state read off the
 	// rendered terminal screen, e.g. "trust_dialog". Empty on the clearing edge.
 	UIKind string `json:"ui_kind,omitempty"`
+
+	// Held-signal ceiling expiry (KindHoldExpired, issue #1360). HeldForMS is
+	// how long the hold actually stood; CeilingMS is the bound it exceeded.
+	// Both are carried so a recorded trace stays interpretable after a ceiling
+	// is retuned — the elapsed time alone cannot say whether it was overdue.
+	SignalKind string `json:"signal_kind,omitempty"`
+	SignalTier string `json:"signal_tier,omitempty"`
+	HeldForMS  int64  `json:"held_for_ms,omitempty"`
+	CeilingMS  int64  `json:"ceiling_ms,omitempty"`
 
 	// Cache-creation regression (KindCacheBloatDetected, issue #374).
 	Project           string  `json:"project,omitempty"`

--- a/core/domain/session/signal_hold.go
+++ b/core/domain/session/signal_hold.go
@@ -66,6 +66,49 @@ const (
 // session re-classifies normally.
 const compactHoldTimeout = 5 * time.Minute
 
+// permissionPromptHoldTimeout bounds the SignalPermissionPrompt hold (#1360).
+//
+// Calibrated against a human, not a machine. Answering a permission prompt
+// takes seconds to a couple of minutes, and the long tail is not deliberation
+// but absence — the user stepped away from the desk. One hour clears a lunch
+// break or an ordinary meeting with room to spare. Past that, "the release was
+// missed" is a better explanation of a still-open prompt than "somebody has
+// been reading this dialog for over an hour".
+//
+// Cutting a genuinely-open prompt short is the lesser error because it is soft
+// and self-correcting from both directions. The session merely stops being
+// pinned and re-classifies from the transcript — where, for the edit-tool
+// case, #488's SignalOpenToolStalled re-derives the very same waiting, because
+// its ripe rule unblocks the moment PermissionPending stops being set. And if
+// the user does eventually answer, the resulting PostToolUse reaches a hold
+// that is already gone, which Release handles as a no-op. The failure being
+// replaced is neither soft nor self-correcting: TierHook forbids every lower
+// tier from retiring this hold, so one missed release pins the session at
+// waiting until the daemon restarts.
+const permissionPromptHoldTimeout = time.Hour
+
+// idlePromptHoldTimeout bounds the SignalIdlePrompt hold (#1360).
+//
+// Deliberately four times the permission ceiling, because the two conditions
+// have different natural lifetimes. A permission prompt is a modal question
+// somebody is expected to answer now; an idle prompt is a session left sitting
+// at the prompt, and leaving one open across an afternoon is ordinary use
+// rather than a fault. Four hours is past any plausible stepped-away window
+// while still being bounded, so a session abandoned at the end of a day has
+// stopped advertising itself as waiting on its user by the next morning.
+//
+// It is the more generous of the two precisely because it has no fallback to
+// degrade onto: an expired permission prompt hands off to #488's
+// transcript-tier SignalOpenToolStalled, whereas an expired idle prompt simply
+// returns the session to whatever the transcript says — ready, for a finished
+// turn. Cutting a real idle window short therefore costs a genuine
+// waiting → ready downgrade: a session that did want an answer stops asking
+// for one. That is still the lesser error, because it is one badge reading the
+// user corrects by looking, and any later hook for that session re-holds and
+// restores it. The unbounded hold it replaces is correctable by nothing the
+// system can produce.
+const idlePromptHoldTimeout = 4 * time.Hour
+
 // stalledEditToolThreshold is how long a permission-gated file-edit tool
 // (Edit/Write/MultiEdit/NotebookEdit) may stay open before it is read as a held
 // permission prompt and SignalOpenToolStalled applies — the transcript-based
@@ -139,6 +182,13 @@ type SignalPayload struct {
 // today needs it, and guessing its shape from one hypothetical caller is how
 // the wrong abstraction gets frozen in.
 //
+// #1360 then moved the expiry half back *out* of stale, into the declared
+// signalPolicy.ceiling — see that field for why a duration a test can read
+// beats a clock term only a closure can see. Now stays here regardless: ripe
+// reads it, and Overlay measures every ceiling against this same injected
+// instant, so an expiry replays on the transcript's timeline like everything
+// else.
+//
 // Now is injected by the caller rather than read from time.Now here, so
 // staleness stays testable and — for the offline replay harness, which runs on
 // the transcript's virtual timeline — deterministic.
@@ -192,9 +242,34 @@ type signalPolicy struct {
 	consumeOnce bool
 
 	// stale reports that the held signal has stopped describing reality and
-	// must be dropped *without* being applied. Nil means "only consumeOnce
-	// or an explicit Release ends this hold".
+	// must be dropped *without* being applied. Nil means "only consumeOnce,
+	// an explicit Release, or the ceiling below ends this hold".
 	stale func(c holdContext) bool
+
+	// ceiling bounds how long this hold may survive on the wall clock,
+	// measured from HeldSince. Zero means unbounded, which is only defensible
+	// for a row a lower tier can still correct — see
+	// TestSignalPolicies_HookPersistentHoldsDeclareACeiling for the rows where
+	// it is not, and permissionPromptHoldTimeout for how one is calibrated.
+	//
+	// Declared as data rather than folded into stale as another clock term
+	// (#1360), for two reasons the merged form cannot serve:
+	//
+	//   - Observability. Overlay reports a ceiling expiry back to its caller,
+	//     which logs it and records a KindHoldExpired lifecycle event. A stale
+	//     closure returns one bool and so cannot say which of its terms fired;
+	//     a ceiling hidden inside it would rewrite session state silently,
+	//     which is a new debugging blind spot rather than a fix.
+	//   - Enforceability. A structural test can read this field. It cannot
+	//     read intent out of a closure, and the alternative — probing stale
+	//     with a synthetic clock — needs a hand-written "not yet stale"
+	//     metrics fixture per row, which is one more table for the author of
+	//     the next row to forget to update.
+	//
+	// A ceiling is a backstop, not an end-of-life rule. stale is evaluated
+	// first, so a hold that ended for its own declared reason is not reported
+	// as an expiry and only a hold that genuinely ran out of time is.
+	ceiling time.Duration
 
 	// ripe reports that the held signal is ready to be applied. Nil means
 	// "ripe on arrival", which is every hook signal: a hook fires because the
@@ -270,8 +345,17 @@ var signalPolicies = []signalPolicy{
 		// retiring a higher one reads backwards, but it is sound here — this
 		// is not the transcript overruling the hook's verdict, it is the
 		// transcript supplying the end-of-life notice the hook never sends.
-		stale: func(c holdContext) bool { return c.Metrics.LastWasToolDenial },
-		apply: func(c holdContext) { c.Metrics.PermissionPending = true },
+		//
+		// Both of those paths are things that must *happen*. Neither fires if
+		// the daemon never sees the POST — a crash, a restart, a port change,
+		// an uninstalled hook — or if the adapter stops writing the denial
+		// marker in the shape LastWasToolDenial matches. This row sits at the
+		// top of the authority ladder, so no lower-tier signal may correct it,
+		// and without the ceiling below a session pinned that way stayed
+		// pinned for the life of the process (#1360).
+		stale:   func(c holdContext) bool { return c.Metrics.LastWasToolDenial },
+		ceiling: permissionPromptHoldTimeout,
+		apply:   func(c holdContext) { c.Metrics.PermissionPending = true },
 	},
 
 	{
@@ -304,8 +388,15 @@ var signalPolicies = []signalPolicy{
 		// thing that happened. IsAgentDone going false means either the user
 		// replied or a tool opened — either way the idle window is over and
 		// the rules that own those cases take it from here.
-		stale: func(c holdContext) bool { return !c.Metrics.IsAgentDone() },
-		apply: func(c holdContext) { c.Metrics.IdlePromptPending = true },
+		//
+		// That is a transcript observation, so the rule is exactly as good as
+		// the parse: a transcript that stops being read, a rotated file, or an
+		// adapter whose turn-done marker changes shape all leave IsAgentDone
+		// stuck true and this TierHook hold uncorrectable from below. Hence
+		// the ceiling (#1360).
+		stale:   func(c holdContext) bool { return !c.Metrics.IsAgentDone() },
+		ceiling: idlePromptHoldTimeout,
+		apply:   func(c holdContext) { c.Metrics.IdlePromptPending = true },
 	},
 
 	{
@@ -316,13 +407,19 @@ var signalPolicies = []signalPolicy{
 		// re-evaluation in that window or the stale pre-compact turn_done
 		// leaks the session back to ready (#657).
 		//
-		// The first row whose staleness reads the clock, and the reason
-		// holdContext exists. It clears on the first of:
+		// The first row to be bounded by the clock, and the reason holdContext
+		// exists. It clears on the first of:
 		//
 		//   - the manual compact_boundary landing: the normal path —
 		//     compaction finished, release working → ready (#656);
 		//   - compactHoldTimeout elapsing — see that constant for why the
 		//     ceiling is there and why five minutes.
+		//
+		// Those two were one merged stale predicate until #1360, which split
+		// the clock term out into the declared ceiling below. Behaviour is
+		// unchanged — Overlay still drops the hold at >= compactHoldTimeout
+		// measured from HeldSince — but the expiry is now reported rather than
+		// silent, and this row stopped being the one place the pattern lived.
 		//
 		// Position-independent: its staleness reads only transcript-derived
 		// state and the clock, and the field it applies is read by no other
@@ -331,10 +428,9 @@ var signalPolicies = []signalPolicy{
 		// SignalOpenToolStalled after it, which is fine precisely because
 		// nothing here depends on being last. The row that genuinely does is
 		// SignalOpenToolStalled; see TestSignalPolicies_OrderIsPinned.
-		stale: func(c holdContext) bool {
-			return c.Metrics.SawManualCompactBoundary || c.Now.Sub(c.HeldSince) >= compactHoldTimeout
-		},
-		apply: func(c holdContext) { c.Metrics.CompactInProgress = true },
+		stale:   func(c holdContext) bool { return c.Metrics.SawManualCompactBoundary },
+		ceiling: compactHoldTimeout,
+		apply:   func(c holdContext) { c.Metrics.CompactInProgress = true },
 	},
 
 	{
@@ -403,6 +499,34 @@ func TierOf(kind SignalKind) SignalTier {
 type SignalHolds struct {
 	mu   sync.Mutex
 	held map[string]map[SignalKind]heldSignal
+}
+
+// SignalExpiry reports one hold that Overlay dropped because its wall-clock
+// ceiling elapsed, rather than because its own staleness rule ended it or a
+// Release retired it (#1360).
+//
+// Overlay returns these so its caller can log the expiry and record it in the
+// lifecycle trace. That indirection is the price of the domain layer owning no
+// logger: a ceiling that rewrites a session's state without saying so anywhere
+// is a debugging blind spot, and the whole failure mode being fixed here is one
+// nobody could see from the outside.
+type SignalExpiry struct {
+	// Kind is the signal whose hold ran out of time.
+	Kind SignalKind
+
+	// Tier is the authority that hold had been asserting. A TierHook expiry is
+	// the consequential one: while it stood, nothing below it was permitted to
+	// correct the session.
+	Tier SignalTier
+
+	// HeldFor is how long the hold stood before the ceiling dropped it,
+	// measured Now-HeldSince against the clock the caller injected.
+	HeldFor time.Duration
+
+	// Ceiling is the bound that was exceeded. Carried alongside HeldFor so a
+	// recorded trace stays readable after the constant is retuned — otherwise
+	// an old event and a new one are indistinguishable.
+	Ceiling time.Duration
 }
 
 // heldSignal is one stored hold: what the signal carried, and when it arrived.
@@ -507,18 +631,25 @@ func (h *SignalHolds) DropSession(sessionID string) {
 // policy (SignalCompactInProgress today; the Phase 5/6 grace timers next) stays
 // testable and replays deterministically on the transcript's virtual timeline.
 //
-// Each hold runs the same three-way gate: stale drops it unapplied, an unripe
-// ripe leaves it untouched for a later pass, and otherwise it is applied (and
-// consumed, if consume-once).
+// Each hold runs the same four-way gate: stale drops it unapplied, an elapsed
+// ceiling drops it unapplied *and* reports it, an unripe ripe leaves it
+// untouched for a later pass, and otherwise it is applied (and consumed, if
+// consume-once).
+//
+// Returns the holds dropped by their ceiling, in table order — normally none.
+// Callers that ignore the result still get the expiry; what they give up is
+// being able to say it happened, which for a TierHook row is the difference
+// between a fix and a silent state rewrite (#1360). The daemon's caller logs
+// each one and records a lifecycle.KindHoldExpired event.
 //
 // Note that staleness is evaluated before apply on every pass, including the
 // first: a signal that is already contradicted when it arrives is discarded
 // rather than applied once. That matters for a late signal (the ~6s
 // idle_prompt, or a retrospective OTel span) that lands after the condition it
 // describes has already ended.
-func (h *SignalHolds) Overlay(sessionID string, m *SessionMetrics, now time.Time) {
+func (h *SignalHolds) Overlay(sessionID string, m *SessionMetrics, now time.Time) []SignalExpiry {
 	if m == nil {
-		return
+		return nil
 	}
 
 	h.mu.Lock()
@@ -526,8 +657,10 @@ func (h *SignalHolds) Overlay(sessionID string, m *SessionMetrics, now time.Time
 
 	holds := h.held[sessionID]
 	if len(holds) == 0 {
-		return
+		return nil
 	}
+
+	var expired []SignalExpiry
 
 	for _, policy := range signalPolicies {
 		hs, ok := holds[policy.kind]
@@ -539,6 +672,21 @@ func (h *SignalHolds) Overlay(sessionID string, m *SessionMetrics, now time.Time
 
 		if policy.stale != nil && policy.stale(c) {
 			delete(holds, policy.kind)
+			continue
+		}
+
+		// The backstop, checked after stale so a hold that ended for its own
+		// declared reason is never mis-reported as having run out of time.
+		// >= rather than >: the deadline itself is outside the window, which
+		// is what the compact row's tests have pinned since #657.
+		if heldFor := c.Now.Sub(c.HeldSince); policy.ceiling > 0 && heldFor >= policy.ceiling {
+			delete(holds, policy.kind)
+			expired = append(expired, SignalExpiry{
+				Kind:    policy.kind,
+				Tier:    policy.tier,
+				HeldFor: heldFor,
+				Ceiling: policy.ceiling,
+			})
 			continue
 		}
 
@@ -560,4 +708,6 @@ func (h *SignalHolds) Overlay(sessionID string, m *SessionMetrics, now time.Time
 	if len(holds) == 0 {
 		delete(h.held, sessionID)
 	}
+
+	return expired
 }

--- a/core/domain/session/signal_hold.go
+++ b/core/domain/session/signal_hold.go
@@ -269,6 +269,16 @@ type signalPolicy struct {
 	// A ceiling is a backstop, not an end-of-life rule. stale is evaluated
 	// first, so a hold that ended for its own declared reason is not reported
 	// as an expiry and only a hold that genuinely ran out of time is.
+	//
+	// CONSTRAINT for a row that also declares ripe: the ceiling must leave the
+	// row a window in which it can actually fire, i.e. it must exceed whatever
+	// elapsed threshold ripe measures. Overlay checks ceiling *before* ripe —
+	// an expiry beats a pending arm, because "never came due and no longer
+	// describes reality" is an expiry — so a ceiling shorter than the ripen
+	// threshold would drop the hold before it ever applied and report it as a
+	// lost release, which is a lie in the trace rather than a missing signal.
+	// No row combines the two today; TestSignalPolicies_HookPersistentHoldsDeclareACeiling
+	// enforces it for the first one that does.
 	ceiling time.Duration
 
 	// ripe reports that the held signal is ready to be applied. Nil means
@@ -422,8 +432,8 @@ var signalPolicies = []signalPolicy{
 		// silent, and this row stopped being the one place the pattern lived.
 		//
 		// Position-independent: its staleness reads only transcript-derived
-		// state and the clock, and the field it applies is read by no other
-		// policy. It was last in the table when #1297 added it — where the
+		// state, its ceiling is time-only, and the field it applies is read by
+		// no other policy. It was last in the table when #1297 added it — where the
 		// hand-rolled overlay it replaced ran — and #1319 appended
 		// SignalOpenToolStalled after it, which is fine precisely because
 		// nothing here depends on being last. The row that genuinely does is
@@ -609,6 +619,20 @@ func (h *SignalHolds) Held(sessionID string, kind SignalKind) bool {
 	defer h.mu.Unlock()
 	_, ok := h.held[sessionID][kind]
 	return ok
+}
+
+// HasAny reports whether any signal at all is currently held for sessionID.
+//
+// It exists for scheduling, not classification (#1360). A ceiling can only be
+// evaluated by a classify pass, and the daemon's periodic refresh skips
+// sessions that are not working — which is every session a hook hold has
+// pinned at waiting. The refresh asks this to find the few sessions it must
+// revisit anyway, without re-reading the transcript of every idle session on
+// the machine.
+func (h *SignalHolds) HasAny(sessionID string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.held[sessionID]) > 0
 }
 
 // DropSession forgets every hold for a session, for when the session itself

--- a/core/domain/session/signal_hold.go
+++ b/core/domain/session/signal_hold.go
@@ -68,46 +68,81 @@ const compactHoldTimeout = 5 * time.Minute
 
 // permissionPromptHoldTimeout bounds the SignalPermissionPrompt hold (#1360).
 //
-// Calibrated against a human, not a machine. Answering a permission prompt
-// takes seconds to a couple of minutes, and the long tail is not deliberation
-// but absence — the user stepped away from the desk. One hour clears a lunch
-// break or an ordinary meeting with room to spare. Past that, "the release was
-// missed" is a better explanation of a still-open prompt than "somebody has
-// been reading this dialog for over an hour".
+// WHICH PROMPTS HAVE A SAFETY NET, AND WHICH DO NOT. This matters more than
+// the number, because expiry means something different for each group. The
+// only transcript-tier signal that can re-derive "a prompt is open" is #488's
+// SignalOpenToolStalled, and it fires solely for the five names
+// isPermissionGatedEditTool matches (edit/write/multiedit/notebookedit/
+// write_file). Against claudecode's installed matcher —
+// "Bash|Write|Edit|MultiEdit|NotebookEdit|WebFetch|mcp__.*|AskUserQuestion|ExitPlanMode"
+// (hookinstaller.go, hookMatcher) — that covers four of nine alternatives:
 //
-// Cutting a genuinely-open prompt short is the lesser error because it is soft
-// and self-correcting from both directions. The session merely stops being
-// pinned and re-classifies from the transcript — where, for the edit-tool
-// case, #488's SignalOpenToolStalled re-derives the very same waiting, because
-// its ripe rule unblocks the moment PermissionPending stops being set. And if
-// the user does eventually answer, the resulting PostToolUse reaches a hold
-// that is already gone, which Release handles as a no-op. The failure being
-// replaced is neither soft nor self-correcting: TierHook forbids every lower
-// tier from retiring this hold, so one missed release pins the session at
-// waiting until the daemon restarts.
-const permissionPromptHoldTimeout = time.Hour
+//   - COVERED (expiry is soft): Write, Edit, MultiEdit, NotebookEdit. If the
+//     tool is still open, SignalOpenToolStalled ripens the moment
+//     PermissionPending stops being set and re-derives the same waiting, one
+//     tier down where anything can still correct it.
+//   - NOT COVERED (expiry is silent): Bash, WebFetch, mcp__.*, AskUserQuestion,
+//     ExitPlanMode. Nothing re-derives the prompt. The session simply stops
+//     reading waiting.
+//
+// The uncovered group is not the marginal one. hookMatcherPreToolUse is
+// exactly "AskUserQuestion|ExitPlanMode" — the #307 fast path, whose entire
+// reason to exist is flipping working→waiting without transcript-flush
+// latency — so the one prompt class with no fallback at all is also the one
+// the fast path was built for. A plan approval and a Bash approval are
+// ordinary, not edge cases.
+//
+// WHY TWELVE HOURS. The ceiling is therefore calibrated against the uncovered
+// group, where being wrong is expensive and invisible: a phantom waiting is
+// visible and the user clears it by looking, but a dropped waiting means the
+// session has stopped advertising that it needs a human and there is no cue to
+// go and check — the precise failure this project exists to prevent. The
+// governing workflow is an agent left running overnight and reviewed the next
+// morning: a session that hits ExitPlanMode at 22:00 must still read waiting
+// at 08:00. Twelve hours spans that with margin while still bounding the pin
+// inside a single day, so a stuck session heals before the following night
+// rather than persisting across two.
+//
+// An hour was the first cut here and it was wrong — justified by the fallback
+// above without checking how far the fallback reaches.
+//
+// The residual is a weekend: a prompt opened Friday night expires before
+// Monday. No finite ceiling covers that, and an effectively infinite one would
+// restore the bug. The hold_expired event this drops (see SignalExpiry) is how
+// that case is told apart from a session that was never pinned.
+//
+// Cutting a real wait short remains the lesser error overall, because it is
+// bounded and diagnosable, whereas the failure being replaced is neither:
+// TierHook forbids every lower tier from retiring this hold, so one missed
+// release pins the session at waiting until the daemon restarts. A late
+// PostToolUse reaching an already-expired hold is a no-op in Release.
+const permissionPromptHoldTimeout = 12 * time.Hour
 
 // idlePromptHoldTimeout bounds the SignalIdlePrompt hold (#1360).
 //
-// Deliberately four times the permission ceiling, because the two conditions
-// have different natural lifetimes. A permission prompt is a modal question
-// somebody is expected to answer now; an idle prompt is a session left sitting
-// at the prompt, and leaving one open across an afternoon is ordinary use
-// rather than a fault. Four hours is past any plausible stepped-away window
-// while still being bounded, so a session abandoned at the end of a day has
-// stopped advertising itself as waiting on its user by the next morning.
+// This row has NO transcript-tier fallback at all — not the partial coverage
+// permissionPromptHoldTimeout describes, none. #488's SignalOpenToolStalled
+// keys off an open edit tool, and an idle prompt is by definition a session
+// with no tool open. So every expiry here is the silent kind: the session
+// stops reading waiting and nothing re-derives it.
 //
-// It is the more generous of the two precisely because it has no fallback to
-// degrade onto: an expired permission prompt hands off to #488's
-// transcript-tier SignalOpenToolStalled, whereas an expired idle prompt simply
-// returns the session to whatever the transcript says — ready, for a finished
-// turn. Cutting a real idle window short therefore costs a genuine
-// waiting → ready downgrade: a session that did want an answer stops asking
-// for one. That is still the lesser error, because it is one badge reading the
-// user corrects by looking, and any later hook for that session re-holds and
-// restores it. The unbounded hold it replaces is correctable by nothing the
-// system can produce.
-const idlePromptHoldTimeout = 4 * time.Hour
+// It therefore takes the same value as the permission ceiling, and for the
+// same governing reason — an agent left overnight must still read waiting when
+// its user looks in the morning. The two constants stay separate rather than
+// collapsing into one because their coverage stories differ (that row is
+// four-ninths covered, this one is not at all), so a future change to either
+// calibration must not silently move the other.
+//
+// Four hours was the first cut and it was too short: an idle prompt reached at
+// 22:00 expired at 02:00 and read ready by breakfast, which is exactly the
+// invisible failure the ceiling is supposed to be worth its cost against.
+//
+// The upside is that this ceiling is rarely the thing that ends the hold. Its
+// staleness rule — IsAgentDone going false — fires on any user reply or tool
+// open, which is a far more reliable release than the permission row's
+// PostToolUse round-trip. The ceiling is a backstop for a transcript that
+// stopped being parsed, not the expected path.
+const idlePromptHoldTimeout = 12 * time.Hour
 
 // stalledEditToolThreshold is how long a permission-gated file-edit tool
 // (Edit/Write/MultiEdit/NotebookEdit) may stay open before it is read as a held

--- a/core/domain/session/signal_hold_ceiling_test.go
+++ b/core/domain/session/signal_hold_ceiling_test.go
@@ -91,71 +91,93 @@ func TestSignalPolicies_HookPersistentHoldsDeclareACeiling(t *testing.T) {
 		if p.tier != TierHook || p.consumeOnce {
 			continue
 		}
+		t.Run(string(p.kind), func(t *testing.T) {
+			assertCeilingIsDeclaredAndSane(t, p)
+			assertCeilingIsEnforcedAndReported(t, p)
+			assertCeilingLeavesRipeAWindow(t, p)
+		})
+	}
+}
 
-		if p.ceiling <= 0 {
-			t.Errorf("policy %q is TierHook and persistent but declares no ceiling — "+
-				"a missed release pins the session at waiting forever, and no lower tier may correct it (#1360). "+
-				"Add a `ceiling:` with a comment stating the real-world duration it is calibrated against; "+
-				"see permissionPromptHoldTimeout for the shape",
-				p.kind)
-			continue
-		}
-		if p.ceiling < minDefensibleHookCeiling {
-			t.Errorf("policy %q declares ceiling %v, below the %v floor — a duration literal without a unit? "+
-				"A ceiling this short expires the hold on the pass that placed it",
-				p.kind, p.ceiling, minDefensibleHookCeiling)
-		}
-		if p.ceiling > maxDefensibleHookCeiling {
-			t.Errorf("policy %q declares ceiling %v, above the %v cap — that is a ceiling in name only; "+
-				"the session stays pinned longer than the daemon is likely to run",
-				p.kind, p.ceiling, maxDefensibleHookCeiling)
-		}
+// assertCeilingIsDeclaredAndSane is the forgetting check — the one that fails
+// on a new row whose author did not think about the clock. Fatal, because the
+// two assertions after it have nothing to measure without a ceiling.
+func assertCeilingIsDeclaredAndSane(t *testing.T, p signalPolicy) {
+	t.Helper()
 
-		// A declared ceiling that Overlay does not act on would satisfy every
-		// check above and fix nothing, so exercise it end to end: find a
-		// metric state under which this row is not already stale, then assert
-		// Overlay both drops the hold at the deadline and *reports* the
-		// expiry. Reporting is the discriminating half — stale drops a hold
-		// too, but only a ceiling returns a SignalExpiry, so this cannot pass
-		// by accident on a row whose staleness rule fired instead.
-		live := liveFixtureFor(p)
-		if live == nil {
-			t.Errorf("policy %q is stale under every fixture in ceilingProbeFixtures, so its ceiling cannot be "+
-				"exercised — add a metric state to that helper under which this row is still live at t0",
-				p.kind)
-			continue
-		}
+	if p.ceiling <= 0 {
+		t.Fatalf("policy %q is TierHook and persistent but declares no ceiling — "+
+			"a missed release pins the session at waiting forever, and no lower tier may correct it (#1360). "+
+			"Add a `ceiling:` with a comment stating the real-world duration it is calibrated against; "+
+			"see permissionPromptHoldTimeout for the shape",
+			p.kind)
+	}
+	if p.ceiling < minDefensibleHookCeiling {
+		t.Errorf("policy %q declares ceiling %v, below the %v floor — a duration literal without a unit? "+
+			"A ceiling this short expires the hold on the pass that placed it",
+			p.kind, p.ceiling, minDefensibleHookCeiling)
+	}
+	if p.ceiling > maxDefensibleHookCeiling {
+		t.Errorf("policy %q declares ceiling %v, above the %v cap — that is a ceiling in name only; "+
+			"the session stays pinned longer than the daemon is likely to run",
+			p.kind, p.ceiling, maxDefensibleHookCeiling)
+	}
+}
 
-		h := NewSignalHolds()
-		h.Hold(holdSID, p.kind, SignalPayload{}, holdT0)
-		expiries := h.Overlay(holdSID, live, holdT0.Add(p.ceiling))
+// assertCeilingIsEnforcedAndReported exercises the declared ceiling end to
+// end, because a field Overlay does not act on would satisfy every static
+// check and fix nothing.
+//
+// Reporting is the discriminating half: stale drops a hold too, but only a
+// ceiling returns a SignalExpiry — so this cannot pass by accident on a row
+// whose staleness rule fired instead.
+func assertCeilingIsEnforcedAndReported(t *testing.T, p signalPolicy) {
+	t.Helper()
 
-		if h.Held(holdSID, p.kind) {
-			t.Errorf("policy %q declares ceiling %v but the hold survived it — the field is not being enforced",
-				p.kind, p.ceiling)
-		}
-		if !reportsExpiryFor(expiries, p.kind) {
-			t.Errorf("policy %q expired at %v without reporting a SignalExpiry — an unobservable ceiling is a "+
-				"debugging blind spot, not a fix (#1360 scope item 4)",
-				p.kind, p.ceiling)
-		}
+	live := liveFixtureFor(p)
+	if live == nil {
+		t.Fatalf("policy %q is stale under every fixture in ceilingProbeFixtures, so its ceiling cannot be "+
+			"exercised — add a metric state to that helper under which this row is still live at t0",
+			p.kind)
+	}
 
-		// An arm-then-fire row needs a window in which it can actually fire.
-		// Overlay checks ceiling before ripe, so a ceiling at or below the
-		// ripen threshold drops the hold before it ever applies AND reports it
-		// as a lost release — a false entry in the trace, which is worse than
-		// a missing one. No row combines ceiling and ripe today, so this arm
-		// is dormant by construction; it exists so the first one that does
-		// cannot land silently.
-		if p.ripe != nil {
-			justBefore := holdContext{Metrics: live, HeldSince: holdT0, Now: holdT0.Add(p.ceiling - time.Nanosecond)}
-			if !p.ripe(justBefore) {
-				t.Errorf("policy %q is not ripe one nanosecond before its %v ceiling — it would be expired and "+
-					"reported as a lost release without ever having applied; the ceiling must exceed whatever "+
-					"elapsed threshold ripe measures",
-					p.kind, p.ceiling)
-			}
-		}
+	h := NewSignalHolds()
+	h.Hold(holdSID, p.kind, SignalPayload{}, holdT0)
+	expiries := h.Overlay(holdSID, live, holdT0.Add(p.ceiling))
+
+	if h.Held(holdSID, p.kind) {
+		t.Errorf("policy %q declares ceiling %v but the hold survived it — the field is not being enforced",
+			p.kind, p.ceiling)
+	}
+	if !reportsExpiryFor(expiries, p.kind) {
+		t.Errorf("policy %q expired at %v without reporting a SignalExpiry — an unobservable ceiling is a "+
+			"debugging blind spot, not a fix (#1360 scope item 4)",
+			p.kind, p.ceiling)
+	}
+}
+
+// assertCeilingLeavesRipeAWindow guards the combination no row has yet: an
+// arm-then-fire row needs an interval in which it can actually fire. Overlay
+// checks ceiling before ripe, so a ceiling at or below the ripen threshold
+// drops the hold before it ever applies AND reports it as a lost release — a
+// false entry in the trace, which is worse than a missing one.
+//
+// Dormant by construction today; it exists so the first row that combines the
+// two cannot land silently.
+func assertCeilingLeavesRipeAWindow(t *testing.T, p signalPolicy) {
+	t.Helper()
+
+	live := liveFixtureFor(p)
+	if p.ripe == nil || live == nil {
+		return
+	}
+
+	justBefore := holdContext{Metrics: live, HeldSince: holdT0, Now: holdT0.Add(p.ceiling - time.Nanosecond)}
+	if !p.ripe(justBefore) {
+		t.Errorf("policy %q is not ripe one nanosecond before its %v ceiling — it would be expired and "+
+			"reported as a lost release without ever having applied; the ceiling must exceed whatever "+
+			"elapsed threshold ripe measures",
+			p.kind, p.ceiling)
 	}
 }
 

--- a/core/domain/session/signal_hold_ceiling_test.go
+++ b/core/domain/session/signal_hold_ceiling_test.go
@@ -1,0 +1,332 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// beyondAnyHookCeiling is an elapsed time that must exceed every ceiling
+// declared on a TierHook persistent row. Deliberately framed as "absurdly
+// long" rather than as any particular constant: these tests assert that a
+// ceiling *exists*, not what it is tuned to, so retuning a ceiling must not be
+// able to make them lie. A row whose ceiling approached this value would be a
+// ceiling in name only, which is what
+// TestSignalPolicies_HookPersistentHoldsDeclareACeiling exists to catch.
+const beyondAnyHookCeiling = 48 * time.Hour
+
+// maxDefensibleHookCeiling and minDefensibleHookCeiling bracket the range a
+// hook ceiling may sit in. They are not tuning — they are typo detection at
+// both ends. Below the floor, an unsuffixed literal (ceiling: 5, which Go
+// reads as five nanoseconds) would expire every hold on the pass that placed
+// it, turning the fix into a worse bug than the one it replaces. Above the
+// cap, a ceiling is one in name only and the session is pinned for longer than
+// any daemon process realistically lives, which is the #1360 defect wearing a
+// number.
+const (
+	minDefensibleHookCeiling = time.Minute
+	maxDefensibleHookCeiling = 24 * time.Hour
+)
+
+// ceilingProbeFixtures are metric states used to find one under which a given
+// row is *not* already stale, so its ceiling can be exercised for real rather
+// than vacuously. Ordered cheapest-first; the first match wins.
+//
+// This is not a per-row table and deliberately so — nothing here has to be
+// updated when a row is added, unless none of these states happens to leave
+// the new row live, in which case the structural test says exactly that and
+// asks for one more entry.
+func ceilingProbeFixtures() []*SessionMetrics {
+	return []*SessionMetrics{
+		{},
+		{LastEventType: "turn_done"},
+		{LastEventType: "turn_done", HookTurnDone: true},
+		{LastEventType: "assistant"},
+		{HasOpenToolCall: true, LastOpenToolNames: []string{"Edit"}},
+	}
+}
+
+// TestSignalPolicies_HookPersistentHoldsDeclareACeiling is the structural
+// invariant #1360 exists to install, and the part of it that outlives the two
+// rows fixed here.
+//
+// The rule it enforces: a hold that is TierHook and persistent MUST declare a
+// wall-clock ceiling. Those two properties together are what make a missed
+// release unrecoverable — TierHook means no lower-tier signal may retire the
+// hold, and persistent means it re-applies on every pass until something does.
+// A row with both and no ceiling can pin a session at waiting for the life of
+// the daemon process, and nothing in the system can talk it down. That is not
+// a tuning question; it is a correctness property of the tier ladder, and the
+// author of the next hook adapter should not have to know the history to get
+// it right.
+//
+// consumeOnce rows are exempt because they cannot pin anything: the hold is
+// dropped by the pass that applies it. Non-TierHook rows are exempt because a
+// lower tier can still correct them — SignalOpenToolStalled is TierTranscript,
+// and its staleness reads freshly-rebuilt transcript metrics, so the parse
+// failing retires it rather than freezing it.
+//
+// This is a structural test, so it passes by construction against a correct
+// table and its whole value is that it CAN fail. Demonstrated by mutating the
+// table three ways:
+//
+//   - deleting `ceiling: permissionPromptHoldTimeout` from the
+//     SignalPermissionPrompt row: "declares a wall-clock ceiling" fails,
+//     naming that row — this is the exact regression the test exists for, and
+//     the state main was in before #1360;
+//   - `ceiling: 5` on that row (the unsuffixed-literal typo): the floor check
+//     fails at 5ns;
+//   - `ceiling: 30 * 24 * time.Hour`: the cap check fails at 720h.
+//
+// The first catches a forgotten ceiling, the other two catch a ceiling that is
+// present but does not bound anything useful.
+func TestSignalPolicies_HookPersistentHoldsDeclareACeiling(t *testing.T) {
+	for _, p := range signalPolicies {
+		if p.tier != TierHook || p.consumeOnce {
+			continue
+		}
+
+		if p.ceiling <= 0 {
+			t.Errorf("policy %q is TierHook and persistent but declares no ceiling — "+
+				"a missed release pins the session at waiting forever, and no lower tier may correct it (#1360). "+
+				"Add a `ceiling:` with a comment stating the real-world duration it is calibrated against; "+
+				"see permissionPromptHoldTimeout for the shape",
+				p.kind)
+			continue
+		}
+		if p.ceiling < minDefensibleHookCeiling {
+			t.Errorf("policy %q declares ceiling %v, below the %v floor — a duration literal without a unit? "+
+				"A ceiling this short expires the hold on the pass that placed it",
+				p.kind, p.ceiling, minDefensibleHookCeiling)
+		}
+		if p.ceiling > maxDefensibleHookCeiling {
+			t.Errorf("policy %q declares ceiling %v, above the %v cap — that is a ceiling in name only; "+
+				"the session stays pinned longer than the daemon is likely to run",
+				p.kind, p.ceiling, maxDefensibleHookCeiling)
+		}
+
+		// A declared ceiling that Overlay does not act on would satisfy every
+		// check above and fix nothing, so exercise it end to end: find a
+		// metric state under which this row is not already stale, then assert
+		// Overlay both drops the hold at the deadline and *reports* the
+		// expiry. Reporting is the discriminating half — stale drops a hold
+		// too, but only a ceiling returns a SignalExpiry, so this cannot pass
+		// by accident on a row whose staleness rule fired instead.
+		live := liveFixtureFor(p)
+		if live == nil {
+			t.Errorf("policy %q is stale under every fixture in ceilingProbeFixtures, so its ceiling cannot be "+
+				"exercised — add a metric state to that helper under which this row is still live at t0",
+				p.kind)
+			continue
+		}
+
+		h := NewSignalHolds()
+		h.Hold(holdSID, p.kind, SignalPayload{}, holdT0)
+		expiries := h.Overlay(holdSID, live, holdT0.Add(p.ceiling))
+
+		if h.Held(holdSID, p.kind) {
+			t.Errorf("policy %q declares ceiling %v but the hold survived it — the field is not being enforced",
+				p.kind, p.ceiling)
+		}
+		if !reportsExpiryFor(expiries, p.kind) {
+			t.Errorf("policy %q expired at %v without reporting a SignalExpiry — an unobservable ceiling is a "+
+				"debugging blind spot, not a fix (#1360 scope item 4)",
+				p.kind, p.ceiling)
+		}
+	}
+}
+
+// liveFixtureFor returns the first probe fixture under which p is not already
+// stale at holdT0, or nil if every one of them retires it immediately.
+func liveFixtureFor(p signalPolicy) *SessionMetrics {
+	for _, m := range ceilingProbeFixtures() {
+		c := holdContext{Metrics: m, HeldSince: holdT0, Now: holdT0}
+		if p.stale == nil || !p.stale(c) {
+			return m
+		}
+	}
+	return nil
+}
+
+func reportsExpiryFor(expiries []SignalExpiry, kind SignalKind) bool {
+	for _, e := range expiries {
+		if e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSignalHolds_CeilingExpiryIsReported pins the payload of the expiry
+// report itself — the data the detector turns into a log line and a
+// KindHoldExpired lifecycle event. Without this, SignalExpiry could be
+// returned with zero-valued fields and every other test in this file would
+// still pass.
+//
+// A defect test for #1360 scope item 4: nothing reported ceiling expiries
+// before, so there was no shape to assert.
+func TestSignalHolds_CeilingExpiryIsReported(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold(holdSID, SignalPermissionPrompt, SignalPayload{}, holdT0)
+
+	overdue := permissionPromptHoldTimeout + 7*time.Minute
+	expiries := h.Overlay(holdSID, &SessionMetrics{LastEventType: "turn_done"}, holdT0.Add(overdue))
+
+	if len(expiries) != 1 {
+		t.Fatalf("expected exactly one reported expiry, got %d: %+v", len(expiries), expiries)
+	}
+	e := expiries[0]
+	if e.Kind != SignalPermissionPrompt {
+		t.Errorf("Kind = %q, want %q", e.Kind, SignalPermissionPrompt)
+	}
+	if e.Tier != TierHook {
+		t.Errorf("Tier = %v, want %v — the tier is what makes the expiry consequential", e.Tier, TierHook)
+	}
+	if e.HeldFor != overdue {
+		t.Errorf("HeldFor = %v, want %v — the trace must say how long the session was pinned", e.HeldFor, overdue)
+	}
+	if e.Ceiling != permissionPromptHoldTimeout {
+		t.Errorf("Ceiling = %v, want %v — carried so a recorded event stays readable after retuning",
+			e.Ceiling, permissionPromptHoldTimeout)
+	}
+}
+
+// TestSignalHolds_NormalStalenessIsNotReportedAsAnExpiry is the other half of
+// the discrimination: a hold that ended for its own declared reason must not
+// be reported as having run out of time. If it were, the new log line and
+// lifecycle event would fire on every ordinary permission denial and the
+// signal-to-noise of the trace — the entire point of scope item 4 — would be
+// gone.
+func TestSignalHolds_NormalStalenessIsNotReportedAsAnExpiry(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold(holdSID, SignalPermissionPrompt, SignalPayload{}, holdT0)
+
+	// The user rejected the prompt: the transcript marker is the end-of-life
+	// notice, well inside the ceiling.
+	denied := &SessionMetrics{LastWasToolDenial: true}
+	expiries := h.Overlay(holdSID, denied, holdT0.Add(time.Minute))
+
+	if h.Held(holdSID, SignalPermissionPrompt) {
+		t.Fatal("a denial must still retire the hold — #1360 must not weaken release semantics")
+	}
+	if len(expiries) != 0 {
+		t.Errorf("a normal staleness release must not be reported as a ceiling expiry, got %+v", expiries)
+	}
+}
+
+// TestSignalHolds_PermissionPrompt_MissedReleaseDoesNotPinForever is the #1360
+// defect test, and it FAILED before the ceiling existed.
+//
+// SignalPermissionPrompt is TierHook and persistent, so it outranks every
+// transcript-tier signal by design — that is what makes the correction stick,
+// and also what makes a missed release unrecoverable. Its normal end-of-life
+// is PostToolUse/PostToolUseFailure calling Release; its only staleness rule
+// was LastWasToolDenial, one claudecode-shaped transcript marker. If the
+// adapter renames that event, or the daemon never sees the POST (crash,
+// restart, port change, uninstalled hook), neither path fires and no lower
+// tier is permitted to retire the hold — the session reads waiting forever.
+//
+// The scenario below is exactly that: hold the prompt, never release it, never
+// produce a denial marker, and let the clock run. Pre-fix the hold survived
+// arbitrary elapsed time and kept re-applying PermissionPending on every pass.
+func TestSignalHolds_PermissionPrompt_MissedReleaseDoesNotPinForever(t *testing.T) {
+	// missedRelease is what the metrics look like when the release was lost:
+	// nothing in the transcript contradicts the prompt, so the metric-driven
+	// staleness rule stays false forever.
+	missedRelease := func() *SessionMetrics {
+		return &SessionMetrics{LastEventType: "turn_done"}
+	}
+
+	t.Run("a fresh hold still applies", func(t *testing.T) {
+		// A LOCK, not a defect assertion: it passed before the ceiling too.
+		// It is here so a ceiling that fired immediately — the opposite
+		// failure — could not pass this file.
+		h := NewSignalHolds()
+		h.Hold(holdSID, SignalPermissionPrompt, SignalPayload{}, holdT0)
+
+		m := missedRelease()
+		h.Overlay(holdSID, m, holdT0.Add(time.Second))
+		if !m.PermissionPending {
+			t.Fatal("a prompt that just opened must still apply — the ceiling must not fire on arrival")
+		}
+		if !h.Held(holdSID, SignalPermissionPrompt) {
+			t.Fatal("a fresh prompt hold must survive the pass that applied it")
+		}
+	})
+
+	t.Run("an unreleased hold is dropped once its ceiling elapses", func(t *testing.T) {
+		h := NewSignalHolds()
+		h.Hold(holdSID, SignalPermissionPrompt, SignalPayload{}, holdT0)
+
+		m := missedRelease()
+		h.Overlay(holdSID, m, holdT0.Add(beyondAnyHookCeiling))
+
+		if m.PermissionPending {
+			t.Error("PermissionPending must NOT be re-applied past the ceiling — this is what pins the session at waiting")
+		}
+		if h.Held(holdSID, SignalPermissionPrompt) {
+			t.Error("the expired hold must be dropped, or it re-applies on every subsequent pass")
+		}
+	})
+
+	t.Run("the drop is permanent, not one skipped pass", func(t *testing.T) {
+		h := NewSignalHolds()
+		h.Hold(holdSID, SignalPermissionPrompt, SignalPayload{}, holdT0)
+		h.Overlay(holdSID, missedRelease(), holdT0.Add(beyondAnyHookCeiling))
+
+		later := missedRelease()
+		h.Overlay(holdSID, later, holdT0.Add(beyondAnyHookCeiling+time.Minute))
+		if later.PermissionPending {
+			t.Error("a hold dropped by its ceiling must stay dropped")
+		}
+	})
+}
+
+// TestSignalHolds_IdlePrompt_MissedReleaseDoesNotPinForever is the #1360
+// defect test for the second in-scope row, and it FAILED before the ceiling
+// existed.
+//
+// SignalIdlePrompt's staleness rule is !IsAgentDone(), which retires the hold
+// the moment the user replies or a tool opens. Both of those are transcript
+// observations, so the rule is only as good as the parse: a transcript that
+// stops being read, an adapter whose turn-done marker changes shape, or a
+// session whose transcript is rotated away all leave IsAgentDone stuck true.
+// TierHook then forbids any lower tier from correcting it.
+//
+// Note this row's ceiling is calibrated much longer than the permission
+// prompt's — an idle prompt is genuinely long-lived — so this test's absurd
+// elapsed time is doing real work.
+func TestSignalHolds_IdlePrompt_MissedReleaseDoesNotPinForever(t *testing.T) {
+	// stillIdle keeps IsAgentDone true, which is the honest reading of a
+	// session sitting at the prompt — and, when the release is missed, is
+	// also indistinguishable from one whose transcript stopped moving.
+	stillIdle := func() *SessionMetrics {
+		return &SessionMetrics{LastEventType: "turn_done"}
+	}
+
+	t.Run("a fresh hold still applies", func(t *testing.T) {
+		// LOCK — passed before the ceiling; guards the opposite failure.
+		h := NewSignalHolds()
+		h.Hold(holdSID, SignalIdlePrompt, SignalPayload{}, holdT0)
+
+		m := stillIdle()
+		h.Overlay(holdSID, m, holdT0.Add(time.Second))
+		if !m.IdlePromptPending {
+			t.Fatal("the ~6s-late correction must still land — the ceiling must not fire on arrival")
+		}
+	})
+
+	t.Run("an unreleased hold is dropped once its ceiling elapses", func(t *testing.T) {
+		h := NewSignalHolds()
+		h.Hold(holdSID, SignalIdlePrompt, SignalPayload{}, holdT0)
+
+		m := stillIdle()
+		h.Overlay(holdSID, m, holdT0.Add(beyondAnyHookCeiling))
+
+		if m.IdlePromptPending {
+			t.Error("IdlePromptPending must NOT be re-applied past the ceiling")
+		}
+		if h.Held(holdSID, SignalIdlePrompt) {
+			t.Error("the expired hold must be dropped, or it re-applies on every subsequent pass")
+		}
+	})
+}

--- a/core/domain/session/signal_hold_ceiling_test.go
+++ b/core/domain/session/signal_hold_ceiling_test.go
@@ -259,6 +259,66 @@ func TestSignalHolds_NormalStalenessIsNotReportedAsAnExpiry(t *testing.T) {
 	}
 }
 
+// TestSignalHolds_HookCeilingsSurviveAnOvernight is a defect test for the
+// ceiling VALUES, and it FAILED at the first cut of them (1h permission,
+// 4h idle).
+//
+// The governing workflow for this repo is an agent left running overnight and
+// reviewed the next morning. A prompt reached at 22:00 must still be
+// advertising itself as waiting when its user looks at 08:00 — ten hours later
+// — because the two hook rows with a ceiling are the ones that say "a human is
+// needed here", and for most of the tools they cover nothing re-derives that
+// once the hold is gone (see permissionPromptHoldTimeout for exactly which).
+//
+// Deliberately expressed as clock times rather than as `< ceiling`: the point
+// is a real interval a real user leaves, not a tautology about the constant.
+// A ceiling retuned below ten hours must break this test, which is the whole
+// reason it does not reference the constants.
+func TestSignalHolds_HookCeilingsSurviveAnOvernight(t *testing.T) {
+	promptAt := time.Date(2026, 8, 2, 22, 0, 0, 0, time.UTC)  // agent blocks at 22:00
+	reviewedAt := time.Date(2026, 8, 3, 8, 0, 0, 0, time.UTC) // user looks at 08:00
+
+	cases := []struct {
+		kind    SignalKind
+		metrics func() *SessionMetrics
+		applied func(*SessionMetrics) bool
+	}{
+		{
+			// ExitPlanMode-shaped: a plan approval, the #307 fast path, which
+			// has no transcript-tier fallback whatsoever.
+			kind:    SignalPermissionPrompt,
+			metrics: func() *SessionMetrics { return &SessionMetrics{LastEventType: "turn_done"} },
+			applied: func(m *SessionMetrics) bool { return m.PermissionPending },
+		},
+		{
+			kind:    SignalIdlePrompt,
+			metrics: func() *SessionMetrics { return &SessionMetrics{LastEventType: "turn_done"} },
+			applied: func(m *SessionMetrics) bool { return m.IdlePromptPending },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			h := NewSignalHolds()
+			h.Hold(holdSID, tc.kind, SignalPayload{}, promptAt)
+
+			m := tc.metrics()
+			h.Overlay(holdSID, m, reviewedAt)
+
+			if !tc.applied(m) {
+				t.Errorf("%q stopped applying somewhere in the %v overnight gap — the session had quietly "+
+					"stopped asking for a human by the time one looked",
+					tc.kind, reviewedAt.Sub(promptAt))
+			}
+			if !h.Held(holdSID, tc.kind) {
+				t.Errorf("%q was dropped during the overnight gap; a ceiling shorter than a night un-flags "+
+					"the session invisibly, which is worse than the pin it replaces",
+					tc.kind)
+			}
+		})
+	}
+}
+
 // TestSignalHolds_PermissionPrompt_MissedReleaseDoesNotPinForever is the #1360
 // defect test, and it FAILED before the ceiling existed.
 //

--- a/core/domain/session/signal_hold_ceiling_test.go
+++ b/core/domain/session/signal_hold_ceiling_test.go
@@ -79,6 +79,13 @@ func ceilingProbeFixtures() []*SessionMetrics {
 //
 // The first catches a forgotten ceiling, the other two catch a ceiling that is
 // present but does not bound anything useful.
+//
+// The ripe-window arm at the end is dormant by construction — no row today is
+// both TierHook-persistent and arm-then-fire — so it was not mutation-tested
+// against a real row. It exists because Overlay checks ceiling before ripe, so
+// the first row that combines them would otherwise expire before it ever
+// applied and be reported as a lost release, which is a false entry in the
+// trace rather than a missing one.
 func TestSignalPolicies_HookPersistentHoldsDeclareACeiling(t *testing.T) {
 	for _, p := range signalPolicies {
 		if p.tier != TierHook || p.consumeOnce {
@@ -131,6 +138,23 @@ func TestSignalPolicies_HookPersistentHoldsDeclareACeiling(t *testing.T) {
 			t.Errorf("policy %q expired at %v without reporting a SignalExpiry — an unobservable ceiling is a "+
 				"debugging blind spot, not a fix (#1360 scope item 4)",
 				p.kind, p.ceiling)
+		}
+
+		// An arm-then-fire row needs a window in which it can actually fire.
+		// Overlay checks ceiling before ripe, so a ceiling at or below the
+		// ripen threshold drops the hold before it ever applies AND reports it
+		// as a lost release — a false entry in the trace, which is worse than
+		// a missing one. No row combines ceiling and ripe today, so this arm
+		// is dormant by construction; it exists so the first one that does
+		// cannot land silently.
+		if p.ripe != nil {
+			justBefore := holdContext{Metrics: live, HeldSince: holdT0, Now: holdT0.Add(p.ceiling - time.Nanosecond)}
+			if !p.ripe(justBefore) {
+				t.Errorf("policy %q is not ripe one nanosecond before its %v ceiling — it would be expired and "+
+					"reported as a lost release without ever having applied; the ceiling must exceed whatever "+
+					"elapsed threshold ripe measures",
+					p.kind, p.ceiling)
+			}
 		}
 	}
 }

--- a/tools/onboarding-factory/cmd/replay/replay_sidecar.go
+++ b/tools/onboarding-factory/cmd/replay/replay_sidecar.go
@@ -534,6 +534,16 @@ func (r *sidecarReplayer) classifyAt(fileSize int64, ctx transitionCtx) error {
 	// from the transcript's own timeline, or the same recording would replay
 	// differently on a slow machine and the goldens would stop being a
 	// regression net.
+	//
+	// Overlay's []SignalExpiry return is deliberately discarded here and at
+	// the other two call sites in this file (#1360). The daemon turns an
+	// expiry into a log line and a lifecycle.KindHoldExpired event; this
+	// replayer has no event sink to write one to — its output model is the
+	// transition stream that emit() builds — so surfacing expiries would mean
+	// adding an event kind to the golden format for every adapter at once.
+	// The *effect* of a ceiling still replays faithfully, because the hold is
+	// dropped either way and the resulting transition is what the goldens
+	// compare (runExtendedCheck diffs state_transition events only).
 	r.signals.Overlay(replaySessionKey, domainMetrics, ctx.virtTime)
 	r.runClassifier(domainMetrics, ctx, grew)
 	return nil

--- a/tools/onboarding-factory/internal/viewer/web/playbackTimeline.js
+++ b/tools/onboarding-factory/internal/viewer/web/playbackTimeline.js
@@ -79,6 +79,12 @@ export function eventStyle(ev) {
       return {color: "#94a3b8", size: 7, opacity: 0.6, label: "Bookkeeping — multiple updates coalesced"};
     case "hook_received":
       return {color: "#94a3b8", size: 8, opacity: 0.7, label: "Hook event received"};
+    // Rare and worth finding in playback: a held hook signal hit its
+    // wall-clock ceiling, meaning the release that should have retired it
+    // never arrived (#1360). Amber and full-size so it reads as a fault, not
+    // as bookkeeping.
+    case "hold_expired":
+      return {color: "#f59e0b", size: 14, opacity: 1, label: "Held signal expired — its release never arrived"};
     case "file_event":
       return {color: "#94a3b8", size: 7, opacity: 0.6, label: "Filesystem event"};
     default:


### PR DESCRIPTION
Closes #1360

## The defect

A `TierHook` **persistent** hold sits at the top of the authority ladder, so by
design no lower-tier signal may retire it. Two such rows had metric-driven
staleness rules and no clock:

- `SignalPermissionPrompt` — released by `PostToolUse`/`PostToolUseFailure`, or
  by the single claudecode-shaped `LastWasToolDenial` transcript marker;
- `SignalIdlePrompt` — released when `IsAgentDone()` goes false.

Every one of those release paths is something that has to *happen*. If the
daemon never sees the POST (crash, restart, port change, uninstalled hook), or
the adapter stops writing the marker in the shape the rule matches, the hold
never ends and the session reads `waiting` for the life of the process. The
transcript path degrades *down* the ladder and self-corrects; the hook path
**pins**.

## Rows in scope — enumerated from the code

Issue scope item 2 asked not to assume the list. Walking `signalPolicies`:

| Row | Tier | Persistent? | Clock before | Verdict |
|---|---|---|---|---|
| `SignalPermissionPrompt` (:259) | `TierHook` | yes | **none** | **fixed** — ceiling added |
| `SignalIdlePrompt` (:295) | `TierHook` | yes | **none** | **fixed** — ceiling added |
| `SignalCompactInProgress` (:311) | `TierHook` | yes | `compactHoldTimeout` | already bounded; migrated to the new field |
| `SignalTurnDone` (:277) | `TierHook` | no — `consumeOnce` | n/a | out of scope: dropped by the pass that applies it, cannot pin |
| `SignalOpenToolStalled` (:340) | `TierTranscript` | yes | none | out of scope: not `TierHook`, so a lower tier can still correct it. Its `stale` reads freshly-rebuilt transcript metrics (`!HasOpenEditPermissionTool()`), so a parse that stops producing an open tool retires the hold rather than freezing it |

So the issue's guess was right about which two rows are broken, and the third
`TierHook` persistent row turned out to already be compliant.

## Design deviation, stated plainly

The issue suggested "this is a `stale` predicate, not new machinery — copy the
shape of the `SignalCompactInProgress` row". **This PR instead declares the
ceiling as a `ceiling time.Duration` field on `signalPolicy`.** Scope item 4
forces it: a `stale` closure returns one bool and cannot say *which* of its
terms fired, so a ceiling merged into it rewrites session state silently — the
new debugging blind spot the issue explicitly rules out. The declared field
also makes scope item 5's structural test exact, instead of a closure probe
that would need a hand-written "not yet stale" metrics fixture per row (i.e.
one more table for the next author to forget).

`SignalCompactInProgress`'s clock term migrates to the same field.
Behaviour is unchanged — still `>= compactHoldTimeout` measured from
`HeldSince` — and its existing tests pass untouched.

## Ceilings (scope item 3): per-row constants, each with a rationale

- `permissionPromptHoldTimeout = 1h` — calibrated against a human, not a
  machine. Answering takes seconds to minutes; the long tail is absence, not
  deliberation. An hour clears a lunch break or a meeting. Cutting a real wait
  short is the lesser error because it is soft and self-correcting: the session
  re-classifies from the transcript, where #488's `SignalOpenToolStalled`
  re-derives the same `waiting` for the edit-tool case (its `ripe` rule unblocks
  the moment `PermissionPending` stops being set), and a late `PostToolUse`
  reaches an already-gone hold, which `Release` handles as a no-op.
- `idlePromptHoldTimeout = 4h` — deliberately more generous, because an idle
  prompt is genuinely long-lived and, unlike the permission prompt, has **no
  fallback to degrade onto**. Four hours is past any plausible stepped-away
  window while still bounded, so a session abandoned at end of day stops
  advertising itself as waiting by morning.

## Observability (scope item 4)

`core/domain/session` owns no logger and may not import one (the architecture
test enforces the direction), so `Overlay` now **returns** the holds it dropped
on their ceiling and the caller decides what to do with them:

- `SessionDetector.reportHoldExpiries` logs one line per expiry, and
- records a new `lifecycle.KindHoldExpired` event carrying
  `signal_kind`, `signal_tier`, `held_for_ms`, `ceiling_ms`.

Both sinks are asserted, because they serve different readers: the log is what
a human tailing the daemon sees live, the event is what the replay harness
reads out of a recording. **Normal staleness releases are deliberately not
reported** — a permission denial is the expected path and happens constantly;
emitting it would bury the rare expiry that actually indicates a lost release.

## Red-first evidence (AGENTS.md)

Run on the unmodified tree at `ef00c4f3`, before any fix existed:

```
$ go test ./core/domain/session/ -run 'TestSignalHolds_(PermissionPrompt|IdlePrompt)_MissedReleaseDoesNotPinForever' -count=1 -v
    signal_hold_ceiling_test.go:65: PermissionPending must NOT be re-applied past the ceiling — this is what pins the session at waiting
    signal_hold_ceiling_test.go:68: the expired hold must be dropped, or it re-applies on every subsequent pass
    signal_hold_ceiling_test.go:80: a hold dropped by its ceiling must stay dropped
--- FAIL: TestSignalHolds_PermissionPrompt_MissedReleaseDoesNotPinForever (0.00s)
    --- PASS: .../a_fresh_hold_still_applies
    --- FAIL: .../an_unreleased_hold_is_dropped_once_its_ceiling_elapses
    --- FAIL: .../the_drop_is_permanent,_not_one_skipped_pass
    signal_hold_ceiling_test.go:127: IdlePromptPending must NOT be re-applied past the ceiling
    signal_hold_ceiling_test.go:130: the expired hold must be dropped, or it re-applies on every subsequent pass
--- FAIL: TestSignalHolds_IdlePrompt_MissedReleaseDoesNotPinForever (0.00s)
FAIL	irrlicht/core/domain/session	0.887s

$ go test ./core/application/services/ -run 'TestClassify_HookHoldCeilingUnpinsAStuckSession' -count=1 -v
    state_classifier_hold_ceiling_test.go:68: the session is still pinned at waiting after 48h0m0s — a missed release must not be permanent
    state_classifier_hold_ceiling_test.go:71: an expired hold must stop claiming hook authority, got tier hook deciding "waiting"
    state_classifier_hold_ceiling_test.go:74: the expired hold must not keep folding PermissionPending onto fresh metrics
--- FAIL: TestClassify_HookHoldCeilingUnpinsAStuckSession (0.00s)
FAIL	irrlicht/core/application/services	0.371s
```

The `a fresh hold still applies` subtests are **LOCKs** — they pass on `main` by
construction and guard the opposite failure (a ceiling that fires on arrival).
The middle block of `TestClassify_HookHoldCeilingUnpinsAStuckSession` is also a
LOCK: pinning is the feature, #1360 is only about it having no end.

## The structural test (scope item 5) and its mutations

`TestSignalPolicies_HookPersistentHoldsDeclareACeiling` enforces: a row that is
`TierHook` and persistent MUST declare a ceiling, inside a sane range, and
`Overlay` must actually enforce **and report** it. The reporting half is the
discriminating one — `stale` also drops a hold, but only a ceiling returns a
`SignalExpiry`, so the check cannot pass by accident on a row whose staleness
fired instead.

Structural tests pass by construction, so their value is that they *can* fail.
Seen red by deliberate mutation:

```
MUTATION: ceiling line deleted from SignalPermissionPrompt (== main's state)
    policy "permission_prompt" is TierHook and persistent but declares no ceiling — a missed release
    pins the session at waiting forever, and no lower tier may correct it (#1360). Add a `ceiling:` ...

MUTATION: ceiling: 5 (unsuffixed literal = 5ns)
    policy "permission_prompt" declares ceiling 5ns, below the 1m0s floor — a duration literal without
    a unit? A ceiling this short expires the hold on the pass that placed it

MUTATION: ceiling: 30 * 24 * time.Hour
    policy "permission_prompt" declares ceiling 720h0m0s, above the 24h0m0s cap — that is a ceiling in
    name only; the session stays pinned longer than the daemon is likely to run
```

`TestSessionDetector_HoldCeilingExpiryIsLoggedAndRecorded` is a
**new-capability test, not a defect test** — nothing reported expiries before,
so it could not have been compiled, let alone run red, on `main`. Its ability
to fail was shown the same way:

```
MUTATION: d.record(lifecycle.Event{...}) block deleted
    expected exactly one lifecycle event, got 0: []

MUTATION: d.log.LogInfo(...) removed
    expected exactly one log line for the expiry, got 0
```

## Verification

`tools/preflight.sh` (full, unscoped) — all 13 gates PASS, including
`replay fixtures`, which is the evidence that the new ceilings caused **no
golden drift** in any recording.

## Out of scope, respected

Release semantics unchanged, `LastWasToolDenial` untouched, tier ladder order
untouched (`TestSignalPolicies_OrderIsPinned` passes unmodified).

---

## Review round (subagent, `high` effort) — one finding changed the shape of the fix

**The ceilings could never fire in the scenario #1360 describes.** A ceiling is
only evaluated inside `SignalHolds.Overlay`, and `Overlay` is only reached from
the classify pipeline. `refreshStaleSessions` — the one thing that revisits a
session no transcript event is arriving for — ran that pipeline for
`StateWorking` **alone**; `StateWaiting`/`StateReady` got only
`retryIdleProjectResolution`, which does not reclassify.

Both ceilings bound holds that pin the session at *waiting*. So the pinned
session was exactly the one the ticker skipped, and the first commit fixed
nothing in the quiet-agent case. **That asymmetry is also why
`compactHoldTimeout` looked like proof the mechanism was sound: it pins at
*working*, the one state already being re-read.**

Fixed in `6fddd2f0`: the non-working branch now re-runs the pipeline when the
session still holds something, scoped by a new `SignalHolds.HasAny` so the
ticker does not start re-reading every idle transcript on the machine.

### Red-first for that second defect

```
$ go test ./core/application/services/ -run TestSessionDetector_StaleRefresh -count=1 -v
    session_detector_hold_ceiling_test.go:90: no "hold_expired" event — the ticker never ran a
    classify pass for the held waiting session, so its ceiling could not fire
--- FAIL: TestSessionDetector_StaleRefreshExpiresAHookHoldOnAWaitingSession (0.00s)
--- PASS: TestSessionDetector_StaleRefreshLeavesAnUnheldIdleSessionAlone (0.00s)
```

The PASS is the scoping LOCK: an idle session with no hold must still not be
touched by the ticker. Re-confirmed red after the `f131fcf5` refactor too.

### Other findings applied

- ceiling-vs-`ripe` constraint stated on the field and enforced in the
  structural test (dormant — no row combines the two yet, so that arm was not
  mutation-tested against a real row);
- `SignalCompactInProgress`s "position-independent … and the clock" comment
  corrected — the clock term had moved out from under it;
- `hold_expired` given a label in the onboarding viewer timeline instead of
  rendering as a raw event kind;
- recorded why the replay harness discards `Overlay`s expiries (its output
  model is the transition stream; there is no event sink to write one to).

### Simplify pass

Both `refreshStaleSessions` branches now share `reclassifyFromTranscript`
rather than each spelling out the interval / transcript-path / consent guards.
The consent gate is the one that mattered — a branch that forgot it would keep
reading a revoked adapter every tick (#570).

## Final verification

`tools/preflight.sh` (full, unscoped) at `f131fcf5`:

```
  gofmt                                                      PASS
  core module tests                                          PASS
  onboarding-factory tests                                   PASS
  replaydata validate                                        PASS
  recording-rig smoke test                                   PASS
  replay fixtures                                            PASS
  starhistory tests                                          PASS
  web: platforms/web                                         PASS
  web: onboarding-factory viewer                             PASS
  ARS architecture gate                                      PASS
  tools/lib shell-lib tests                                  PASS
  skill-file lint                                            PASS
  security scan (govulncheck + gosec + npm audit)            PASS
```

---

## QA round — the ceiling rationale was wrong, and the number followed from it

The first version justified `permissionPromptHoldTimeout = 1h` by claiming
expiry is "soft and self-correcting" because #488's `SignalOpenToolStalled`
re-derives the same `waiting`. **That claim is false for most of the prompts
this hold covers**, and it was load-bearing for the number.

`isPermissionGatedEditTool` (`core/domain/session/metrics.go`) matches exactly
five names. Against claudecode's installed matcher (`hookinstaller.go:65`):

| Matcher alternative | Transcript-tier fallback? |
|---|---|
| `Write`, `Edit`, `MultiEdit`, `NotebookEdit` | **yes** — 4 of 9 |
| `Bash`, `WebFetch`, `mcp__.*`, `AskUserQuestion`, `ExitPlanMode` | **no** — 5 of 9 |

And `hookMatcherPreToolUse` (`hookinstaller.go:70`) is exactly
`AskUserQuestion|ExitPlanMode` — the #307 fast path, whose whole purpose is
flipping working→waiting without transcript-flush latency. `HookPreToolUse`
asserts `SignalPermissionPrompt` (`hook_signal.go:80`). So **the prompt class
with no fallback at all is the one the fast path was built for.**

### Why the direction of error matters

A phantom `waiting` is visible and the user clears it by looking. A dropped
`waiting` is invisible: the session stops advertising that it needs a human and
there is no cue to go and check — the failure this project exists to prevent.
For the uncovered tools, a short ceiling produces the second.

### What changed

- `permissionPromptHoldTimeout` **1h → 12h**, recalibrated against the
  *uncovered* group and the workflow that governs it: an agent left running
  overnight and reviewed next morning (`ExitPlanMode` at 22:00 must still read
  `waiting` at 08:00). 12h spans that with margin while still bounding the pin
  inside a single day.
- `idlePromptHoldTimeout` **4h → 12h**. Same reason, more strongly: this row
  has *no* fallback at all, so leaving it shorter than the partially-covered
  permission row was incoherent. At 4h an idle prompt reached at 22:00 read
  `ready` by breakfast. The constants stay separate because their coverage
  stories differ.
- The comment now enumerates which tools have the net and which do not.

Known residual, stated in the code: a prompt opened Friday night expires before
Monday. No finite ceiling covers that; the recorded `hold_expired` event is how
that case is distinguished from a session that was never pinned.

### Red-first for the values

```
$ go test ./core/domain/session/ -run TestSignalHolds_HookCeilingsSurviveAnOvernight -count=1 -v
=== RUN   TestSignalHolds_HookCeilingsSurviveAnOvernight/permission_prompt
=== RUN   TestSignalHolds_HookCeilingsSurviveAnOvernight/idle_prompt
--- FAIL: TestSignalHolds_HookCeilingsSurviveAnOvernight (0.00s)
    --- FAIL: TestSignalHolds_HookCeilingsSurviveAnOvernight/permission_prompt (0.00s)
    --- FAIL: TestSignalHolds_HookCeilingsSurviveAnOvernight/idle_prompt (0.00s)
FAIL	irrlicht/core/domain/session	0.338s
```
(at 1h / 4h; green at 12h). It asserts a real 22:00→08:00 interval in clock
times rather than referencing the constants, so a future retune below ten hours
breaks it.

### Post-expiry observable, both populations

`TestClassify_WhatTheUserSeesAfterAPermissionCeilingExpires` — **neither
subtest is a defect test**:

- *covered tool* — **LOCK**: with an `Edit` tool open, the session still reads
  `waiting` after the hook ceiling expires, re-derived at `TierTranscript`.
  This is the assertion that would have caught the original false claim. Shown
  to bite by removing `"edit"` from `isPermissionGatedEditTool` → the covered
  subtest fails, the uncovered one is unaffected.
- *uncovered tool* — **CHARACTERIZATION**: an `ExitPlanMode`-shaped hold with
  no open tool falls through to `ready`. Written down so the accepted residual
  stops being invisible, and it fails loudly if the fallback story ever changes.

### Also

- The `compactHoldTimeout`-was-unreachable finding is now its own issue,
  **#1387**, so it survives this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
