### PR TITLE
fix(hooks): confine caller-supplied transcript_path on every hook receiver

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,20 @@ Before marking a ticket done, run the full suite — every layer must pass:
   uninstalled event" arm checks against `session.AllHookEvents`, itself kept
   honest by `TestAllHookEvents_CoversEveryConstant`, which scans
   `hook_signal.go`'s source rather than trusting a second hand-kept list.
+- Hook path confinement: `contracttesting.AssertHookPathConfined`
+  (`core/internal/contracttesting/hook_path_confinement.go`) is the
+  receiving-side counterpart to the two above — the `transcript_path` in an
+  inbound hook body is caller-supplied on a local, unauthenticated endpoint, so
+  a receiver confines it to the adapter's own declared transcript roots
+  (`agent.Source`'s `FilesUnderRoot.AllRootsFor`, never a second list that can
+  drift) before anything downstream opens it. Four obligations: an in-tree path
+  is still accepted (the vacuity guard), and an out-of-tree path, a `..`
+  traversal and a symlink planted inside the root are each refused with a 4xx
+  and a counted reason. The symlink one is the load-bearing case — **symlinks
+  are resolved BEFORE the containment check**, and a guard with that order
+  reversed passes the first three and confines nothing (#1361, where claudecode
+  forwarded the raw path while codex confined). A new hook-receiving adapter
+  wires one call (see `claudecode`/`codex` `hookpath_test.go`).
   All three contract families pass by construction against a correct adapter, so
   their whole value is that they *can* fail: a new or reworked contract
   assertion lands with the deliberate mutation that was seen red for each

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,8 +137,8 @@ Before marking a ticket done, run the full suite — every layer must pass:
   drift) before anything downstream opens it. Six obligations: an in-tree path
   is still accepted (the vacuity guard); an out-of-tree path, a `..` traversal,
   a symlink planted inside the root and a *dangling* symlink inside the root
-  are each refused with a 4xx and a counted reason; and the adapter's
-  production constructor confines, not merely the handler the test assembled.
+  are each refused, logged and counted; and the adapter's production
+  constructor confines, not merely the handler the test assembled.
   Two are load-bearing and neither is obvious. **Symlinks are resolved BEFORE
   the containment check** — a guard with that order reversed passes every
   lexical traversal test and confines nothing (#1361, where claudecode
@@ -150,7 +150,17 @@ Before marking a ticket done, run the full suite — every layer must pass:
   hook-receiving adapter wires one call (see `claudecode`/`codex`
   `hookpath_test.go`; claudecode wires it twice, because its statusline
   endpoint is a receiver too and was the one the original fix forgot).
-  All three contract families pass by construction against a correct adapter, so
+  **A confinement refusal answers 2xx** — it is reported by the log and the
+  counter, never by a status code on the user's critical path. The path is
+  already contained by not being forwarded, so the status buys no security,
+  while a non-2xx is an untested interaction with the agent CLI: Claude Code
+  documents that a non-2xx from a `type: http` hook "can't block actions" but
+  not whether it surfaces an error, and gemini-cli's pre-tool hooks and
+  Copilot's `preToolUse` are known to fail CLOSED on an error result. The
+  contract asserts the 2xx so a new receiver inherits the rule instead of
+  re-deciding it (#1361, #1364). `hookjson.RejectPath` is the single place it
+  is implemented, and its doc comment records what was and was not observed.
+  All four contract families pass by construction against a correct adapter, so
   their whole value is that they *can* fail: a new or reworked contract
   assertion lands with the deliberate mutation that was seen red for each
   obligation recorded in its PR — the same bar the red-first rule above sets

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,14 +134,22 @@ Before marking a ticket done, run the full suite — every layer must pass:
   inbound hook body is caller-supplied on a local, unauthenticated endpoint, so
   a receiver confines it to the adapter's own declared transcript roots
   (`agent.Source`'s `FilesUnderRoot.AllRootsFor`, never a second list that can
-  drift) before anything downstream opens it. Four obligations: an in-tree path
-  is still accepted (the vacuity guard), and an out-of-tree path, a `..`
-  traversal and a symlink planted inside the root are each refused with a 4xx
-  and a counted reason. The symlink one is the load-bearing case — **symlinks
-  are resolved BEFORE the containment check**, and a guard with that order
-  reversed passes the first three and confines nothing (#1361, where claudecode
-  forwarded the raw path while codex confined). A new hook-receiving adapter
-  wires one call (see `claudecode`/`codex` `hookpath_test.go`).
+  drift) before anything downstream opens it. Six obligations: an in-tree path
+  is still accepted (the vacuity guard); an out-of-tree path, a `..` traversal,
+  a symlink planted inside the root and a *dangling* symlink inside the root
+  are each refused with a 4xx and a counted reason; and the adapter's
+  production constructor confines, not merely the handler the test assembled.
+  Two are load-bearing and neither is obvious. **Symlinks are resolved BEFORE
+  the containment check** — a guard with that order reversed passes every
+  lexical traversal test and confines nothing (#1361, where claudecode
+  forwarded the raw path while codex confined). And **"unresolvable" is not
+  "not written yet"**: resolution reports the same error for a broken link as
+  for an absent file, so a receiver that waves through an unresolvable leaf
+  (a reasonable allowance — the hook fires around the write) lets an attacker
+  plant a broken link, have it accepted, then create the target. A new
+  hook-receiving adapter wires one call (see `claudecode`/`codex`
+  `hookpath_test.go`; claudecode wires it twice, because its statusline
+  endpoint is a receiver too and was the one the original fix forgot).
   All three contract families pass by construction against a correct adapter, so
   their whole value is that they *can* fail: a new or reworked contract
   assertion lands with the deliberate mutation that was seen red for each

--- a/core/adapters/inbound/agents/agentpaths/agentpaths.go
+++ b/core/adapters/inbound/agents/agentpaths/agentpaths.go
@@ -38,3 +38,28 @@ func FromEnv(adapter, envVar, defaultDir string, subdir ...string) string {
 	}
 	return defaultDir
 }
+
+// AbsRoot resolves a declared transcript root to an absolute path: used as-is
+// when already absolute, otherwise joined under the user's home directory.
+//
+// This is the other half of the rule FromEnv starts. A root reaching the
+// runtime is either an absolute path (an env override was honored) or a
+// $HOME-relative default like ".claude/projects", and every consumer has to
+// close that gap the same way — the fswatcher that watches the tree and the
+// hook receiver that confines caller-supplied paths to it must agree on where
+// the tree is, or confinement guards a different directory than the one being
+// watched (issue #1361). Exported here, next to FromEnv, so there is one
+// implementation rather than one per consumer.
+//
+// It is purely lexical: nothing is created, statted, or symlink-resolved.
+// Callers that need a real on-disk identity resolve symlinks themselves.
+func AbsRoot(dir string) (string, error) {
+	if filepath.IsAbs(dir) {
+		return filepath.Clean(dir), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, dir), nil
+}

--- a/core/adapters/inbound/agents/agentpaths/agentpaths.go
+++ b/core/adapters/inbound/agents/agentpaths/agentpaths.go
@@ -9,9 +9,12 @@
 package agentpaths
 
 import (
+	"errors"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 )
 
 // FromEnv returns the directory the named adapter should watch.
@@ -34,10 +37,32 @@ func FromEnv(adapter, envVar, defaultDir string, subdir ...string) string {
 		if filepath.IsAbs(cleaned) {
 			return filepath.Join(append([]string{cleaned}, subdir...)...)
 		}
-		log.Printf("%s: ignoring %s=%q — must be an absolute path (no shell expansion)", adapter, envVar, v)
+		warnOnce(adapter+"\x00"+envVar, func() {
+			log.Printf("%s: ignoring %s=%q — must be an absolute path (no shell expansion)", adapter, envVar, v)
+		})
 	}
 	return defaultDir
 }
+
+// warned tracks which (adapter, envVar) pairs have already logged a rejected
+// override, so the warning is emitted once per process rather than once per
+// call. FromEnv used to be reached only when the daemon built its watchers; it
+// is now also on the hook receiver's per-request path (issue #1361), and that
+// endpoint is local and unauthenticated — an un-deduped log would let any local
+// process drive unbounded log volume by POSTing in a loop while a misconfigured
+// override is set.
+var warned sync.Map
+
+func warnOnce(key string, emit func()) {
+	if _, seen := warned.LoadOrStore(key, struct{}{}); !seen {
+		emit()
+	}
+}
+
+// resetWarnOnce clears the dedupe. Tests that assert on the warning must call
+// it first, or they pass or fail depending on whether an earlier test in the
+// package happened to warn for the same adapter and env var.
+func resetWarnOnce() { warned = sync.Map{} }
 
 // AbsRoot resolves a declared transcript root to an absolute path: used as-is
 // when already absolute, otherwise joined under the user's home directory.
@@ -53,7 +78,15 @@ func FromEnv(adapter, envVar, defaultDir string, subdir ...string) string {
 //
 // It is purely lexical: nothing is created, statted, or symlink-resolved.
 // Callers that need a real on-disk identity resolve symlinks themselves.
+//
+// An empty dir is an error, not $HOME. Joining "" under the home directory
+// would silently answer "the user's entire home directory" for what is really
+// an adapter that failed to resolve its root — and for the confinement caller
+// that is a fail-open, which is the one direction this must never take.
 func AbsRoot(dir string) (string, error) {
+	if strings.TrimSpace(dir) == "" {
+		return "", errors.New("agentpaths: empty transcript root")
+	}
 	if filepath.IsAbs(dir) {
 		return filepath.Clean(dir), nil
 	}

--- a/core/adapters/inbound/agents/agentpaths/agentpaths_test.go
+++ b/core/adapters/inbound/agents/agentpaths/agentpaths_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -54,6 +55,7 @@ func TestFromEnv(t *testing.T) {
 // a rejected override must name the adapter and the offending value, so the
 // misconfiguration is greppable rather than silent.
 func TestFromEnvLogsRejectionUnderAdapterName(t *testing.T) {
+	resetWarnOnce()
 	buf := captureLog(t)
 
 	t.Setenv(testEnvVar, "~/custom")
@@ -69,6 +71,7 @@ func TestFromEnvLogsRejectionUnderAdapterName(t *testing.T) {
 // TestFromEnvDoesNotLogOnAcceptedOverride guards against noise: a valid
 // absolute override is the supported path, not something to warn about.
 func TestFromEnvDoesNotLogOnAcceptedOverride(t *testing.T) {
+	resetWarnOnce()
 	buf := captureLog(t)
 
 	t.Setenv(testEnvVar, "/tmp/home")
@@ -76,5 +79,64 @@ func TestFromEnvDoesNotLogOnAcceptedOverride(t *testing.T) {
 
 	if buf.Len() != 0 {
 		t.Errorf("accepted override logged %q, want no output", buf.String())
+	}
+}
+
+// TestAbsRoot pins the absolute-or-$HOME-relative rule. AbsRoot is the single
+// shared implementation two independent consumers rely on to agree — the
+// fswatcher that watches a tree and the hook receiver that confines paths to it
+// (issue #1361) — so the contract belongs at the layer that owns it.
+func TestAbsRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tests := map[string]struct {
+		dir     string
+		want    string
+		wantErr bool
+	}{
+		"$HOME-relative default": {".claude/projects", filepath.Join(home, ".claude/projects"), false},
+		"absolute used as-is":    {"/opt/agent/sessions", "/opt/agent/sessions", false},
+		"absolute is cleaned":    {"/opt/agent/./sessions/", "/opt/agent/sessions", false},
+		// An empty root is the absence of a root, never $HOME: for the
+		// confinement caller, answering "$HOME" would be a fail-open over the
+		// user's entire home directory.
+		"empty is an error":      {"", "", true},
+		"whitespace is an error": {"   ", "", true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := AbsRoot(tt.dir)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("AbsRoot(%q) = %q, want an error", tt.dir, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AbsRoot(%q): %v", tt.dir, err)
+			}
+			if got != tt.want {
+				t.Errorf("AbsRoot(%q) = %q, want %q", tt.dir, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFromEnvWarnsOncePerAdapterAndVar pins the dedupe. FromEnv is now on the
+// hook receiver's per-request path (issue #1361), and that endpoint is local
+// and unauthenticated — without this, any local process could drive unbounded
+// log volume by POSTing in a loop while a bad override is set.
+func TestFromEnvWarnsOncePerAdapterAndVar(t *testing.T) {
+	resetWarnOnce()
+	t.Setenv("IRR_TEST_ROOT", "relative/nope")
+
+	buf := captureLog(t)
+	for i := 0; i < 5; i++ {
+		FromEnv("testadapter", "IRR_TEST_ROOT", ".default")
+	}
+	if got := strings.Count(buf.String(), "IRR_TEST_ROOT"); got != 1 {
+		t.Errorf("logged %d times across 5 calls, want exactly 1:\n%s", got, buf.String())
 	}
 }

--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -46,12 +46,7 @@ func Agent() agent.Agent {
 			PIDForSession: DiscoverPID,
 			ExcludeArgv:   IsInfraArgv,
 		},
-		Source: agent.FilesUnderRoot{
-			Dir: transcriptsDir(),
-			Parser: agent.JSONLineParser{
-				NewParser: func() agent.LineParser { return &Parser{} },
-			},
-		},
+		Source: Source(),
 		Control: agent.Control{
 			SupportsInput: true,
 			Interrupt:     agent.InterruptCtrlC,
@@ -139,4 +134,22 @@ func Agent() agent.Agent {
 // function of SessionMetrics and lives in CountOpenSubagents.
 func (p *Parser) OpenSubagents(m *tailer.SessionMetrics) int {
 	return CountOpenSubagents(m)
+}
+
+// Source is this adapter's transcript-source declaration, split out of Agent so
+// callers that need only the roots do not rebuild the whole declaration.
+//
+// Claude Code transcripts live one file per session under
+// $CLAUDE_CONFIG_DIR/projects (default ~/.claude/projects).
+//
+// The hook receiver's path confiner reads it per request (issue #1361), and
+// Agent() below is its only other caller — one declaration, so the tree the
+// daemon watches and the tree the receiver confines to cannot drift apart.
+func Source() agent.Source {
+	return agent.FilesUnderRoot{
+		Dir: transcriptsDir(),
+		Parser: agent.JSONLineParser{
+			NewParser: func() agent.LineParser { return &Parser{} },
+		},
+	}
 }

--- a/core/adapters/inbound/agents/claudecode/hookconfine_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookconfine_test.go
@@ -72,8 +72,11 @@ func inTreeTranscript(t *testing.T, stem string) string {
 // TestHookHandler_OutOfTreeTranscriptRejected is the issue #1361 defect test.
 // The hook endpoint is local and unauthenticated, so transcript_path is
 // attacker-controlled; a path outside the adapter's declared transcript root
-// must be refused loudly (400) and must never reach the detector, which opens
-// it.
+// must never reach the detector, which opens it.
+//
+// The status stays 200 — a refusal is reported by the log and the counter, not
+// on the wire (hookjson.RejectPath explains why). So the dispatch assertion,
+// not the status, is what carries this test.
 func TestHookHandler_OutOfTreeTranscriptRejected(t *testing.T) {
 	confineTestHome(t)
 	outside := writeTranscriptFile(t, t.TempDir(), transcriptStem)
@@ -85,8 +88,8 @@ func TestHookHandler_OutOfTreeTranscriptRejected(t *testing.T) {
 		ToolName:       "Bash",
 	})
 
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("status: got %d, want 400 — an out-of-tree transcript_path must be rejected, not silently accepted", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200 — a confinement refusal fails open on the wire (see hookjson.RejectPath)", rec.Code)
 	}
 	if calls := target.getCalls(); len(calls) != 0 {
 		t.Errorf("handler forwarded an out-of-tree transcript_path to the detector: %+v", calls)
@@ -110,8 +113,8 @@ func TestHookHandler_ParentTraversalTranscriptRejected(t *testing.T) {
 		ToolName:       "Bash",
 	})
 
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("status: got %d, want 400 — a parent-traversal transcript_path must be rejected", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200 — a confinement refusal fails open on the wire (see hookjson.RejectPath)", rec.Code)
 	}
 	if calls := target.getCalls(); len(calls) != 0 {
 		t.Errorf("handler forwarded a parent-traversal transcript_path to the detector: %+v", calls)
@@ -137,8 +140,8 @@ func TestHookHandler_SymlinkEscapeTranscriptRejected(t *testing.T) {
 		ToolName:       "Bash",
 	})
 
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("status: got %d, want 400 — a symlink inside the root pointing out of it must be rejected", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200 — a confinement refusal fails open on the wire (see hookjson.RejectPath)", rec.Code)
 	}
 	if calls := target.getCalls(); len(calls) != 0 {
 		t.Errorf("handler followed a symlink out of the declared root: %+v", calls)

--- a/core/adapters/inbound/agents/claudecode/hookconfine_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookconfine_test.go
@@ -1,0 +1,178 @@
+package claudecode
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// transcriptStem is a plausible Claude Code transcript filename stem. The
+// handler derives the session id from it, so it has to look like one for the
+// dispatch path to be reached at all — otherwise a rejection could not be told
+// apart from "the id came out empty".
+const transcriptStem = "11111111-2222-3333-4444-555555555555"
+
+// confineTestHome relocates $HOME to a temp dir and returns that dir plus an
+// existing project directory inside the adapter's declared transcript root
+// ($HOME/.claude/projects). Both are absolute.
+func confineTestHome(t *testing.T) (home, projectDir string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	projectDir = filepath.Join(home, defaultProjectsDir, "-Users-someone-repo")
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatalf("create project dir: %v", err)
+	}
+	return home, projectDir
+}
+
+// writeTranscriptFile writes a minimal transcript at dir/<stem>.jsonl and
+// returns its path.
+func writeTranscriptFile(t *testing.T, dir, stem string) string {
+	t.Helper()
+	path := filepath.Join(dir, stem+".jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// hookTestHomeMarker is created inside the temp $HOME hookTestHome installs.
+// Its presence is how a second call within the same test knows the relocation
+// already happened and reuses that root — replacing it would invalidate the
+// path an earlier call already returned.
+const hookTestHomeMarker = ".irrlicht-hook-test"
+
+// hookTestHome relocates $HOME to a temp directory for the duration of the
+// test, once, and returns it.
+func hookTestHome(t *testing.T) string {
+	t.Helper()
+	if home := os.Getenv("HOME"); home != "" {
+		if st, err := os.Stat(filepath.Join(home, hookTestHomeMarker)); err == nil && st.IsDir() {
+			return home
+		}
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, hookTestHomeMarker), 0o700); err != nil {
+		t.Fatalf("mark test home: %v", err)
+	}
+	return home
+}
+
+// inTreeTranscript materializes <stem>.jsonl inside the adapter's declared
+// transcript root and returns its absolute path. Hook tests need a real
+// in-tree file because the receiver confines every caller-supplied path to
+// that root (issue #1361) — a fabricated literal is now, correctly, refused.
+func inTreeTranscript(t *testing.T, stem string) string {
+	t.Helper()
+	dir := filepath.Join(hookTestHome(t), defaultProjectsDir, "p")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("create project dir: %v", err)
+	}
+	return writeTranscriptFile(t, dir, stem)
+}
+
+// TestHookHandler_OutOfTreeTranscriptRejected is the issue #1361 defect test.
+// The hook endpoint is local and unauthenticated, so transcript_path is
+// attacker-controlled; a path outside the adapter's declared transcript root
+// must be refused loudly (400) and must never reach the detector, which opens
+// it.
+func TestHookHandler_OutOfTreeTranscriptRejected(t *testing.T) {
+	confineTestHome(t)
+	outside := writeTranscriptFile(t, t.TempDir(), transcriptStem)
+
+	target := &mockTarget{}
+	rec := postHook(t, NewHookHandler(target, nil, nil, mockLogger{}), hookPayload{
+		TranscriptPath: outside,
+		HookEventName:  HookPermissionRequest,
+		ToolName:       "Bash",
+	})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400 — an out-of-tree transcript_path must be rejected, not silently accepted", rec.Code)
+	}
+	if calls := target.getCalls(); len(calls) != 0 {
+		t.Errorf("handler forwarded an out-of-tree transcript_path to the detector: %+v", calls)
+	}
+}
+
+// TestHookHandler_ParentTraversalTranscriptRejected covers the lexical escape:
+// a path that starts inside the declared root and climbs out of it.
+func TestHookHandler_ParentTraversalTranscriptRejected(t *testing.T) {
+	_, projectDir := confineTestHome(t)
+	outside := writeTranscriptFile(t, t.TempDir(), transcriptStem)
+	// Built by concatenation, not filepath.Join, because Join cleans: the
+	// point is a path whose LEXICAL prefix is the declared root and which
+	// climbs out of it. Enough ".." to bottom out at "/", where they stop.
+	traversal := projectDir + strings.Repeat("/..", 24) + outside
+
+	target := &mockTarget{}
+	rec := postHook(t, NewHookHandler(target, nil, nil, mockLogger{}), hookPayload{
+		TranscriptPath: traversal,
+		HookEventName:  HookPermissionRequest,
+		ToolName:       "Bash",
+	})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400 — a parent-traversal transcript_path must be rejected", rec.Code)
+	}
+	if calls := target.getCalls(); len(calls) != 0 {
+		t.Errorf("handler forwarded a parent-traversal transcript_path to the detector: %+v", calls)
+	}
+}
+
+// TestHookHandler_SymlinkEscapeTranscriptRejected is the ordering test: the
+// path is lexically inside the declared root and only leaves it once symlinks
+// are resolved. A containment check that runs BEFORE symlink resolution passes
+// the two tests above and fails this one.
+func TestHookHandler_SymlinkEscapeTranscriptRejected(t *testing.T) {
+	_, projectDir := confineTestHome(t)
+	outside := writeTranscriptFile(t, t.TempDir(), "secret")
+	link := filepath.Join(projectDir, transcriptStem+".jsonl")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	target := &mockTarget{}
+	rec := postHook(t, NewHookHandler(target, nil, nil, mockLogger{}), hookPayload{
+		TranscriptPath: link,
+		HookEventName:  HookPermissionRequest,
+		ToolName:       "Bash",
+	})
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400 — a symlink inside the root pointing out of it must be rejected", rec.Code)
+	}
+	if calls := target.getCalls(); len(calls) != 0 {
+		t.Errorf("handler followed a symlink out of the declared root: %+v", calls)
+	}
+}
+
+// TestHookHandler_InTreeTranscriptStillAccepted is a LOCK, not a defect test:
+// it pins the behaviour confinement must not break, and passes on main by
+// construction.
+func TestHookHandler_InTreeTranscriptStillAccepted(t *testing.T) {
+	_, projectDir := confineTestHome(t)
+	inTree := writeTranscriptFile(t, projectDir, transcriptStem)
+
+	target := &mockTarget{}
+	rec := postHook(t, NewHookHandler(target, nil, nil, mockLogger{}), hookPayload{
+		TranscriptPath: inTree,
+		HookEventName:  HookPermissionRequest,
+		ToolName:       "Bash",
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 for a transcript inside the declared root", rec.Code)
+	}
+	calls := target.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 dispatch for an in-tree transcript, got %d", len(calls))
+	}
+	if calls[0].sessionID != transcriptStem {
+		t.Errorf("sessionID: got %q, want %q", calls[0].sessionID, transcriptStem)
+	}
+}

--- a/core/adapters/inbound/agents/claudecode/hookconfine_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookconfine_test.go
@@ -19,13 +19,10 @@ const transcriptStem = "11111111-2222-3333-4444-555555555555"
 // ($HOME/.claude/projects). Both are absolute.
 func confineTestHome(t *testing.T) (home, projectDir string) {
 	t.Helper()
-	home = t.TempDir()
-	t.Setenv("HOME", home)
-	projectDir = filepath.Join(home, defaultProjectsDir, "-Users-someone-repo")
-	if err := os.MkdirAll(projectDir, 0o700); err != nil {
-		t.Fatalf("create project dir: %v", err)
-	}
-	return home, projectDir
+	// Delegates rather than relocating again: two relocations in one test
+	// would leave a path handed out by the first no longer inside the root.
+	home = hookTestHome(t)
+	return home, mkdirAllOrFail(t, filepath.Join(home, defaultProjectsDir, "-Users-someone-repo"))
 }
 
 // writeTranscriptFile writes a minimal transcript at dir/<stem>.jsonl and
@@ -68,10 +65,7 @@ func hookTestHome(t *testing.T) string {
 // that root (issue #1361) — a fabricated literal is now, correctly, refused.
 func inTreeTranscript(t *testing.T, stem string) string {
 	t.Helper()
-	dir := filepath.Join(hookTestHome(t), defaultProjectsDir, "p")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatalf("create project dir: %v", err)
-	}
+	dir := mkdirAllOrFail(t, filepath.Join(hookTestHome(t), defaultProjectsDir, "p"))
 	return writeTranscriptFile(t, dir, stem)
 }
 
@@ -175,4 +169,13 @@ func TestHookHandler_InTreeTranscriptStillAccepted(t *testing.T) {
 	if calls[0].sessionID != transcriptStem {
 		t.Errorf("sessionID: got %q, want %q", calls[0].sessionID, transcriptStem)
 	}
+}
+
+// mkdirAllOrFail creates dir (and parents) and returns it.
+func mkdirAllOrFail(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("create %s: %v", dir, err)
+	}
+	return dir
 }

--- a/core/adapters/inbound/agents/claudecode/hookpath_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookpath_test.go
@@ -2,12 +2,28 @@ package claudecode
 
 import (
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"irrlicht/core/internal/contracttesting"
 )
+
+// claudeProjectsRoot relocates the config root to a temp dir and returns the
+// declared transcript root inside it — CLAUDE_CONFIG_DIR moves the config root,
+// and transcripts live in its projects/ subdirectory.
+func claudeProjectsRoot(t *testing.T) string {
+	t.Helper()
+	cfg := t.TempDir()
+	t.Setenv(configDirEnvVar, cfg)
+	return mkdirAllOrFail(t, filepath.Join(cfg, "projects"))
+}
+
+// writeContractTranscript writes a transcript the receiver will dispatch on.
+// The session id is the filename stem, so the name has to look like one.
+func writeContractTranscript(t *testing.T, dir string) string {
+	t.Helper()
+	return writeTranscriptFile(t, dir, transcriptStem)
+}
 
 // TestHookPathConfined wires this adapter's hook receiver into the shared issue
 // #1361 contract: a caller-supplied transcript_path is confined to the
@@ -15,18 +31,9 @@ import (
 // anything outside is refused loudly and counted.
 func TestHookPathConfined(t *testing.T) {
 	contracttesting.AssertHookPathConfined(t, contracttesting.HookReceiver{
-		Root: func(t *testing.T) string {
-			t.Helper()
-			// CLAUDE_CONFIG_DIR relocates the config root; transcripts live in
-			// its projects/ subdirectory, which is the declared root.
-			cfg := t.TempDir()
-			t.Setenv(configDirEnvVar, cfg)
-			root := filepath.Join(cfg, "projects")
-			if err := os.MkdirAll(root, 0o700); err != nil {
-				t.Fatalf("create projects dir: %v", err)
-			}
-			return root
-		},
+		Root:            claudeProjectsRoot,
+		WriteTranscript: writeContractTranscript,
+		TranscriptExt:   transcriptExt,
 		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
 			t.Helper()
 			target := &mockTarget{}
@@ -45,16 +52,6 @@ func TestHookPathConfined(t *testing.T) {
 				Observed: func() bool { return len(target.getCalls()) > 0 },
 			}
 		},
-		// The session id is the filename stem, so the name has to look like a
-		// session id for a dispatch to happen at all.
-		WriteTranscript: func(t *testing.T, dir string) string {
-			t.Helper()
-			path := filepath.Join(dir, transcriptStem+transcriptExt)
-			if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
-				t.Fatalf("write transcript: %v", err)
-			}
-			return path
-		},
 		PayloadFor: func(transcriptPath string) string {
 			body, err := json.Marshal(hookPayload{
 				TranscriptPath: transcriptPath,
@@ -67,5 +64,42 @@ func TestHookPathConfined(t *testing.T) {
 			return string(body)
 		},
 		EndpointPath: HookEndpointPath,
+	})
+}
+
+// TestStatuslinePathConfined runs the same #1361 contract against the
+// statusline receiver. It sits on the same local, unauthenticated mux and takes
+// the same caller-supplied path, and it is the receiver the first cut of this
+// change forgot — which is the argument for a contract rather than a habit.
+func TestStatuslinePathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, contracttesting.HookReceiver{
+		Root:            claudeProjectsRoot,
+		WriteTranscript: writeContractTranscript,
+		TranscriptExt:   transcriptExt,
+		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &fakeRateLimitIngester{}
+			confiner := TranscriptConfiner()
+			return contracttesting.HookReceiverUnderTest{
+				Handler:    NewStatuslineHandlerWithConfiner(target, nil, silentLogger{}, confiner),
+				Observed:   func() bool { return len(target.calls) > 0 },
+				Rejections: confiner.RejectionCount,
+			}
+		},
+		NewProduction: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &fakeRateLimitIngester{}
+			return contracttesting.HookReceiverUnderTest{
+				Handler:  NewStatuslineHandler(target, nil, silentLogger{}),
+				Observed: func() bool { return len(target.calls) > 0 },
+			}
+		},
+		// A rate_limits block is required or the handler acks and returns
+		// before the ingest — the observation the contract keys on.
+		PayloadFor: func(transcriptPath string) string {
+			return `{"session_id":"abc","transcript_path":"` + transcriptPath +
+				`","rate_limits":{"five_hour":{"used_percentage":47,"resets_at":1778761800}}}`
+		},
+		EndpointPath: StatuslineEndpointPath,
 	})
 }

--- a/core/adapters/inbound/agents/claudecode/hookpath_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookpath_test.go
@@ -1,0 +1,63 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+// TestHookPathConfined wires this adapter's hook receiver into the shared issue
+// #1361 contract: a caller-supplied transcript_path is confined to the
+// adapter's declared transcript roots, with symlinks resolved first, and
+// anything outside is refused loudly and counted.
+func TestHookPathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, contracttesting.HookReceiver{
+		Root: func(t *testing.T) string {
+			t.Helper()
+			// CLAUDE_CONFIG_DIR relocates the config root; transcripts live in
+			// its projects/ subdirectory, which is the declared root.
+			cfg := t.TempDir()
+			t.Setenv(configDirEnvVar, cfg)
+			root := filepath.Join(cfg, "projects")
+			if err := os.MkdirAll(root, 0o700); err != nil {
+				t.Fatalf("create projects dir: %v", err)
+			}
+			return root
+		},
+		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			confiner := TranscriptConfiner()
+			return contracttesting.HookReceiverUnderTest{
+				Handler:    NewHookHandlerWithConfiner(target, nil, nil, mockLogger{}, confiner),
+				Observed:   func() bool { return len(target.getCalls()) > 0 },
+				Rejections: confiner.RejectionCount,
+			}
+		},
+		// The session id is the filename stem, so the name has to look like a
+		// session id for a dispatch to happen at all.
+		WriteTranscript: func(t *testing.T, dir string) string {
+			t.Helper()
+			path := filepath.Join(dir, transcriptStem+transcriptExt)
+			if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+				t.Fatalf("write transcript: %v", err)
+			}
+			return path
+		},
+		PayloadFor: func(transcriptPath string) string {
+			body, err := json.Marshal(hookPayload{
+				TranscriptPath: transcriptPath,
+				HookEventName:  HookPermissionRequest,
+				ToolName:       "Bash",
+			})
+			if err != nil {
+				panic(err)
+			}
+			return string(body)
+		},
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/claudecode/hookpath_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookpath_test.go
@@ -37,6 +37,14 @@ func TestHookPathConfined(t *testing.T) {
 				Rejections: confiner.RejectionCount,
 			}
 		},
+		NewProduction: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.HookReceiverUnderTest{
+				Handler:  NewHookHandler(target, nil, nil, mockLogger{}),
+				Observed: func() bool { return len(target.getCalls()) > 0 },
+			}
+		},
 		// The session id is the filename stem, so the name has to look like a
 		// session id for a dispatch to happen at all.
 		WriteTranscript: func(t *testing.T, dir string) string {

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -17,10 +17,12 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/ports/outbound"
@@ -65,6 +67,11 @@ const compactTriggerManual = "manual"
 // logComponentHookReceiver is the Logger component tag for every log line
 // emitted by the hook HTTP handler below.
 const logComponentHookReceiver = "hook-receiver"
+
+// transcriptExt is the file extension of a Claude Code transcript. The hook
+// receiver confines caller-supplied paths to this extension, and the session id
+// is the filename stem once it is stripped.
+const transcriptExt = ".jsonl"
 
 // Tool names that suspend the agent waiting for user input. PreToolUse hooks
 // must match one of these — anything else is rejected by the handler, even
@@ -212,7 +219,7 @@ func sessionIDFromTranscriptPath(p string) string {
 	if p == "" {
 		return ""
 	}
-	return strings.TrimSuffix(filepath.Base(p), ".jsonl")
+	return strings.TrimSuffix(filepath.Base(p), transcriptExt)
 }
 
 // NewHookHandler returns an http.HandlerFunc that receives Claude Code
@@ -233,8 +240,23 @@ func sessionIDFromTranscriptPath(p string) string {
 // the payload is dropped with 200 (so the curl hook stays quiet). A nil
 // gate means no gating — used by tests.
 func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGranter, log outbound.Logger) http.HandlerFunc {
+	return NewHookHandlerWithConfiner(target, markers, gate, log, TranscriptConfiner())
+}
+
+// TranscriptConfiner returns the confiner this adapter's hook receiver guards
+// caller-supplied transcript paths with, rooted in the adapter's own
+// agent.Source declaration so it cannot drift from the tree the daemon watches
+// (issue #1361).
+func TranscriptConfiner() *hookjson.PathConfiner {
+	return hookjson.ConfinerForSource(func() agent.Source { return Agent().Source }, runtime.GOOS, transcriptExt)
+}
+
+// NewHookHandlerWithConfiner is NewHookHandler with an explicit confiner, for
+// tests that need to drive a receiver rooted somewhere other than the real
+// transcript tree and to read back what it refused.
+func NewHookHandlerWithConfiner(target HookTarget, markers MarkerTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveHookRequest(target, markers, gate, log, w, r)
+		serveHookRequest(target, markers, gate, log, confiner, w, r)
 	}
 }
 
@@ -242,7 +264,7 @@ func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGranter
 // returned closure so its branching isn't counted at the closure's extra
 // nesting depth (go:S3776 — this dropped the reported complexity from 31 to
 // within the 15-point budget without changing any behavior).
-func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGranter, log outbound.Logger, w http.ResponseWriter, r *http.Request) {
+func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -259,7 +281,19 @@ func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGrant
 		return
 	}
 
-	sessionID := sessionIDFromTranscriptPath(payload.TranscriptPath)
+	// transcript_path arrives in an HTTP body on a local, unauthenticated
+	// endpoint, so it is untrusted: every dispatch below hands it to the
+	// detector, which opens it. Confine it to the adapter's declared transcript
+	// roots before anything downstream sees it, and carry the confined path —
+	// not the caller's string — onward (issue #1361).
+	transcriptPath, reason := confiner.Confine(payload.TranscriptPath)
+	if reason != hookjson.RejectNone {
+		hookjson.RejectPath(w, log, logComponentHookReceiver, payload.TranscriptPath, reason)
+		return
+	}
+	payload.TranscriptPath = transcriptPath
+
+	sessionID := sessionIDFromTranscriptPath(transcriptPath)
 	if sessionID == "" {
 		http.Error(w, "bad request: missing transcript_path", http.StatusBadRequest)
 		return

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
-	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/ports/outbound"
@@ -248,7 +247,7 @@ func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGranter
 // agent.Source declaration so it cannot drift from the tree the daemon watches
 // (issue #1361).
 func TranscriptConfiner() *hookjson.PathConfiner {
-	return hookjson.ConfinerForSource(func() agent.Source { return Agent().Source }, runtime.GOOS, transcriptExt)
+	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
 }
 
 // NewHookHandlerWithConfiner is NewHookHandler with an explicit confiner, for
@@ -293,9 +292,12 @@ func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGrant
 	}
 	payload.TranscriptPath = transcriptPath
 
+	// Confinement already rejected an empty or non-.jsonl path, so the only
+	// input still reaching this is a basename that is bare ".jsonl" — an empty
+	// session id, which nothing downstream can key on.
 	sessionID := sessionIDFromTranscriptPath(transcriptPath)
 	if sessionID == "" {
-		http.Error(w, "bad request: missing transcript_path", http.StatusBadRequest)
+		http.Error(w, "bad request: transcript_path has no session id", http.StatusBadRequest)
 		return
 	}
 

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -128,7 +128,7 @@ func TestHookHandler_PermissionRequest(t *testing.T) {
 	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-123.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-123"),
 		HookEventName:  "PermissionRequest",
 		ToolName:       "Bash",
 	}
@@ -159,7 +159,7 @@ func TestHookHandler_PostToolUse(t *testing.T) {
 	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-456.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-456"),
 		HookEventName:  "PostToolUse",
 		ToolName:       "Write",
 		ToolUseID:      "toolu_abc",
@@ -184,7 +184,7 @@ func TestHookHandler_PreToolUse(t *testing.T) {
 	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-pre.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-pre"),
 		HookEventName:  "PreToolUse",
 		ToolName:       "AskUserQuestion",
 		ToolUseID:      "toolu_pre",
@@ -219,7 +219,7 @@ func TestHookHandler_PreToolUse_RejectsUnexpectedTool(t *testing.T) {
 	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-x.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-x"),
 		HookEventName:  "PreToolUse",
 		ToolName:       "Bash",
 		ToolUseID:      "toolu_bash",
@@ -246,7 +246,7 @@ func TestHookHandler_PreCompactManual(t *testing.T) {
 	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-comp.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-comp"),
 		HookEventName:  "PreCompact",
 		Trigger:        "manual",
 	}
@@ -282,7 +282,7 @@ func TestHookHandler_PreCompactAuto(t *testing.T) {
 	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-auto.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-auto"),
 		HookEventName:  "PreCompact",
 		Trigger:        "auto",
 	}
@@ -309,7 +309,7 @@ func TestHookHandler_Stop(t *testing.T) {
 	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath:       "/Users/u/.claude/projects/p/sess-stop.jsonl",
+		TranscriptPath:       inTreeTranscript(t, "sess-stop"),
 		HookEventName:        "Stop",
 		LastAssistantMessage: "All tests pass. The refactor is complete.",
 	}
@@ -349,7 +349,7 @@ func TestHookHandler_StopEndingInQuestion(t *testing.T) {
 	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath:       "/Users/u/.claude/projects/p/sess-q.jsonl",
+		TranscriptPath:       inTreeTranscript(t, "sess-q"),
 		HookEventName:        "Stop",
 		LastAssistantMessage: "I can take either approach. Which option do you prefer?",
 	}
@@ -374,9 +374,10 @@ func TestHookHandler_StopEndingInQuestion(t *testing.T) {
 func TestHookHandler_NotificationIdlePrompt(t *testing.T) {
 	target := &mockTarget{}
 	handler := NewHookHandler(target, nil, nil, mockLogger{})
+	idlePath := inTreeTranscript(t, "sess-idle")
 
 	rec := postHook(t, handler, hookPayload{
-		TranscriptPath:   "/Users/u/.claude/projects/p/sess-idle.jsonl",
+		TranscriptPath:   idlePath,
 		HookEventName:    "Notification",
 		NotificationType: "idle_prompt",
 	})
@@ -394,7 +395,7 @@ func TestHookHandler_NotificationIdlePrompt(t *testing.T) {
 	if idles[0].sessionID != "sess-idle" {
 		t.Errorf("sessionID = %q, want %q", idles[0].sessionID, "sess-idle")
 	}
-	if idles[0].transcriptPath != "/Users/u/.claude/projects/p/sess-idle.jsonl" {
+	if idles[0].transcriptPath != idlePath {
 		t.Errorf("transcriptPath = %q, want the payload path", idles[0].transcriptPath)
 	}
 }
@@ -408,7 +409,7 @@ func TestHookHandler_NotificationNonIdleType(t *testing.T) {
 		handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 		rec := postHook(t, handler, hookPayload{
-			TranscriptPath:   "/Users/u/.claude/projects/p/sess-n.jsonl",
+			TranscriptPath:   inTreeTranscript(t, "sess-n"),
 			HookEventName:    "Notification",
 			NotificationType: ntype,
 		})
@@ -430,7 +431,7 @@ func TestHookHandler_NotificationConsentGated(t *testing.T) {
 	handler := NewHookHandler(target, nil, fakeGate(false), mockLogger{})
 
 	rec := postHook(t, handler, hookPayload{
-		TranscriptPath:   "/Users/u/.claude/projects/p/sess-gated.jsonl",
+		TranscriptPath:   inTreeTranscript(t, "sess-gated"),
 		HookEventName:    "Notification",
 		NotificationType: "idle_prompt",
 	})
@@ -448,7 +449,7 @@ func TestHookHandler_PostToolUseFailure(t *testing.T) {
 	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-789.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-789"),
 		HookEventName:  "PostToolUseFailure",
 		ToolName:       "Bash",
 		IsInterrupt:    true,
@@ -473,7 +474,7 @@ func TestHookHandler_UnrecognizedEvent(t *testing.T) {
 	handler := NewHookHandler(target, nil, nil, mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess"),
 		HookEventName:  "SessionStart",
 		ToolName:       "",
 	}
@@ -566,7 +567,7 @@ func TestHookHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 	handler := NewHookHandler(target, nil, fakeGate(false), mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-123.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-123"),
 		HookEventName:  "PermissionRequest",
 		ToolName:       "Bash",
 	}
@@ -589,7 +590,7 @@ func TestHookHandler_ConsentGatePassesWhenGranted(t *testing.T) {
 	handler := NewHookHandler(target, nil, fakeGate(true), mockLogger{})
 
 	payload := hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-123.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-123"),
 		HookEventName:  "PermissionRequest",
 		ToolName:       "Bash",
 	}
@@ -665,9 +666,10 @@ func TestHookHandler_PreToolUse_MarkerInBashDescription(t *testing.T) {
 	target := &mockTarget{}
 	markers := &mockMarkerTarget{}
 	handler := NewHookHandler(target, markers, nil, mockLogger{})
+	etaPath := inTreeTranscript(t, "sess-eta")
 
 	rec := postHook(t, handler, hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-eta.jsonl",
+		TranscriptPath: etaPath,
 		HookEventName:  "PreToolUse",
 		ToolName:       "Bash",
 		ToolInput:      json.RawMessage(`{"command":"go test ./...","description":"Run tests <!-- {\"marker\":\"irrlicht-eta\",\"total_rounds\":7,\"completed_rounds\":3} -->"}`),
@@ -679,7 +681,7 @@ func TestHookHandler_PreToolUse_MarkerInBashDescription(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("got %d IngestTaskEstimate calls, want 1", len(calls))
 	}
-	if calls[0].transcriptPath != "/Users/u/.claude/projects/p/sess-eta.jsonl" {
+	if calls[0].transcriptPath != etaPath {
 		t.Errorf("transcriptPath = %q", calls[0].transcriptPath)
 	}
 	if calls[0].est.TotalRounds != 7 || calls[0].est.CompletedRounds != 3 {
@@ -701,9 +703,10 @@ func TestHookHandler_PreToolUse_SummaryInBashDescription(t *testing.T) {
 	target := &mockTarget{}
 	markers := &mockMarkerTarget{}
 	handler := NewHookHandler(target, markers, nil, mockLogger{})
+	sumPath := inTreeTranscript(t, "sess-sum")
 
 	rec := postHook(t, handler, hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-sum.jsonl",
+		TranscriptPath: sumPath,
 		HookEventName:  "PreToolUse",
 		ToolName:       "Bash",
 		ToolInput:      json.RawMessage(`{"command":"go build ./...","description":"Build core <!-- {\"marker\":\"irrlicht-summary\",\"summary\":\"add the logout button\"} -->"}`),
@@ -715,7 +718,7 @@ func TestHookHandler_PreToolUse_SummaryInBashDescription(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("got %d IngestTaskSummary calls, want 1", len(got))
 	}
-	if got[0].transcriptPath != "/Users/u/.claude/projects/p/sess-sum.jsonl" {
+	if got[0].transcriptPath != sumPath {
 		t.Errorf("transcriptPath = %q", got[0].transcriptPath)
 	}
 	if got[0].text != "add the logout button" {
@@ -734,14 +737,14 @@ func TestHookHandler_PreToolUse_NoMarkerNoIngest(t *testing.T) {
 	handler := NewHookHandler(&mockTarget{}, markers, nil, mockLogger{})
 
 	postHook(t, handler, hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-1.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-1"),
 		HookEventName:  "PreToolUse",
 		ToolName:       "Bash",
 		ToolInput:      json.RawMessage(`{"command":"ls","description":"List files"}`),
 	})
 	// A plain HTML comment without the marker key must not ingest either.
 	postHook(t, handler, hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-1.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-1"),
 		HookEventName:  "PreToolUse",
 		ToolName:       "Write",
 		ToolInput:      json.RawMessage(`{"file_path":"/tmp/x.html","content":"<!-- a comment -->"}`),
@@ -762,7 +765,7 @@ func TestHookHandler_PreToolUse_UserInputToolStillDispatchesWithMarkerScan(t *te
 	handler := NewHookHandler(target, markers, nil, mockLogger{})
 
 	postHook(t, handler, hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-q.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-q"),
 		HookEventName:  "PreToolUse",
 		ToolName:       "AskUserQuestion",
 		ToolInput:      json.RawMessage(`{"questions":[{"question":"Proceed? <!-- {\"marker\":\"irrlicht-eta\",\"total_rounds\":4,\"completed_rounds\":2} -->"}]}`),
@@ -787,7 +790,7 @@ func TestHookHandler_PermissionGateContract(t *testing.T) {
 	gate := &mutableGate{}
 	handler := NewHookHandler(target, nil, gate, mockLogger{})
 	payload := hookPayload{
-		TranscriptPath: "/Users/u/.claude/projects/p/sess-gate.jsonl",
+		TranscriptPath: inTreeTranscript(t, "sess-gate"),
 		HookEventName:  "PermissionRequest",
 		ToolName:       "Bash",
 	}

--- a/core/adapters/inbound/agents/claudecode/statusline.go
+++ b/core/adapters/inbound/agents/claudecode/statusline.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"time"
 
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/outbound"
 )
@@ -62,6 +63,10 @@ type RateLimitIngester interface {
 	IngestRateLimit(transcriptPath string, snap *session.RateLimitSnapshot)
 }
 
+// logComponentStatuslineReceiver is the Logger component tag for the
+// statusline HTTP handler below.
+const logComponentStatuslineReceiver = "statusline-receiver"
+
 // NewStatuslineHandler returns the HTTP handler for
 // POST /api/v1/hooks/claudecode/statusline. The handler returns 200 with an
 // empty body on success; on bad input or missing transcript_path it returns
@@ -72,6 +77,12 @@ type RateLimitIngester interface {
 // granted the payload is dropped with 200. A nil gate means no gating —
 // used by tests.
 func NewStatuslineHandler(target RateLimitIngester, gate ConsentGranter, log outbound.Logger) http.HandlerFunc {
+	return NewStatuslineHandlerWithConfiner(target, gate, log, TranscriptConfiner())
+}
+
+// NewStatuslineHandlerWithConfiner is NewStatuslineHandler with an explicit
+// confiner, for tests that drive the receiver against a temp root.
+func NewStatuslineHandlerWithConfiner(target RateLimitIngester, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -89,22 +100,31 @@ func NewStatuslineHandler(target RateLimitIngester, gate ConsentGranter, log out
 			return
 		}
 
-		if payload.TranscriptPath == "" {
-			http.Error(w, "bad request: missing transcript_path", http.StatusBadRequest)
+		// The statusline endpoint sits on the same local, unauthenticated mux
+		// as the hook receivers and takes the same caller-supplied path, so it
+		// is confined by the same rule (issue #1361). Its sink is a map lookup
+		// rather than an open, so this is not an arbitrary-read guard — it is
+		// what keeps this receiver keying the tailer map with the SAME spelling
+		// the hook receiver now uses. Two spellings of one file are two
+		// sessions, and the rate-limit snapshot would land on neither.
+		transcriptPath, reason := confiner.Confine(payload.TranscriptPath)
+		if reason != hookjson.RejectNone {
+			hookjson.RejectPath(w, log, logComponentStatuslineReceiver, payload.TranscriptPath, reason)
 			return
 		}
+		payload.TranscriptPath = transcriptPath
 
-		sessionID := sessionIDFromTranscriptPath(payload.TranscriptPath)
+		sessionID := sessionIDFromTranscriptPath(transcriptPath)
 		snap := statuslineToSnapshot(payload.RateLimits)
 		if snap == nil {
 			// API-key / Bedrock / Vertex users — nothing to record. Ack and move on.
-			log.LogInfo("statusline-receiver", sessionID, "received statusline tick with no rate_limits block")
+			log.LogInfo(logComponentStatuslineReceiver, sessionID, "received statusline tick with no rate_limits block")
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 
 		target.IngestRateLimit(payload.TranscriptPath, snap)
-		log.LogInfo("statusline-receiver", sessionID, "ingested rate-limit snapshot")
+		log.LogInfo(logComponentStatuslineReceiver, sessionID, "ingested rate-limit snapshot")
 		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -41,10 +41,11 @@ func (silentLogger) Close() error                                         { retu
 func TestStatuslineHandler_IngestsRateLimits(t *testing.T) {
 	target := &fakeRateLimitIngester{}
 	h := NewStatuslineHandler(target, nil, silentLogger{})
+	transcript := inTreeTranscript(t, "abc")
 
 	body := `{
 		"session_id": "abc",
-		"transcript_path": "/tmp/sessions/abc.jsonl",
+		"transcript_path": "` + transcript + `",
 		"rate_limits": {
 			"five_hour": {"used_percentage": 47, "resets_at": 1778761800},
 			"seven_day": {"used_percentage": 14.0, "resets_at": 1779188400}
@@ -61,8 +62,8 @@ func TestStatuslineHandler_IngestsRateLimits(t *testing.T) {
 		t.Fatalf("expected one IngestRateLimit call, got %d", len(target.calls))
 	}
 	call := target.calls[0]
-	if call.path != "/tmp/sessions/abc.jsonl" {
-		t.Errorf("wrong path: %s", call.path)
+	if call.path != transcript {
+		t.Errorf("wrong path: got %s, want the confined transcript %s", call.path, transcript)
 	}
 	if len(call.snap.Windows) != 2 {
 		t.Fatalf("expected 2 windows, got %d", len(call.snap.Windows))
@@ -79,7 +80,7 @@ func TestStatuslineHandler_NoRateLimitsBlockIsOk(t *testing.T) {
 	target := &fakeRateLimitIngester{}
 	h := NewStatuslineHandler(target, nil, silentLogger{})
 
-	body := `{"session_id":"abc","transcript_path":"/tmp/abc.jsonl"}`
+	body := `{"session_id":"abc","transcript_path":"` + inTreeTranscript(t, "abc") + `"}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", bytes.NewBufferString(body))
 	rr := httptest.NewRecorder()
 	h(rr, req)
@@ -121,7 +122,7 @@ func TestStatuslineHandler_SampledAtUsesClock(t *testing.T) {
 
 	target := &fakeRateLimitIngester{}
 	h := NewStatuslineHandler(target, nil, silentLogger{})
-	body := `{"transcript_path":"/tmp/x.jsonl","rate_limits":{"five_hour":{"used_percentage":1,"resets_at":2}}}`
+	body := `{"transcript_path":"` + inTreeTranscript(t, "x") + `","rate_limits":{"five_hour":{"used_percentage":1,"resets_at":2}}}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", bytes.NewBufferString(body))
 	rr := httptest.NewRecorder()
 	h(rr, req)
@@ -271,7 +272,7 @@ func TestStatuslineHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 
 	body := `{
 		"session_id": "abc",
-		"transcript_path": "/tmp/sessions/abc.jsonl",
+		"transcript_path": "` + inTreeTranscript(t, "abc") + `",
 		"rate_limits": {
 			"five_hour": {"used_percentage": 47, "resets_at": 1778761800}
 		}
@@ -299,7 +300,7 @@ func TestStatuslineHandler_PermissionGateContract(t *testing.T) {
 	h := NewStatuslineHandler(target, gate, silentLogger{})
 	body := `{
 		"session_id": "abc",
-		"transcript_path": "/tmp/sessions/abc.jsonl",
+		"transcript_path": "` + inTreeTranscript(t, "abc") + `",
 		"rate_limits": {
 			"five_hour": {"used_percentage": 47, "resets_at": 1778761800}
 		}

--- a/core/adapters/inbound/agents/codex/agent.go
+++ b/core/adapters/inbound/agents/codex/agent.go
@@ -40,14 +40,7 @@ func Agent() agent.Agent {
 			Match:         agent.ExactName{Name: ProcessName},
 			PIDForSession: DiscoverPID,
 		},
-		Source: agent.FilesUnderRoot{
-			Dir:                     sessionsDir(),
-			SessionIDFromPath:       sessionIDFromPath,
-			ParentSessionIDFromPath: parentSessionIDFromPath,
-			Parser: agent.JSONLineParser{
-				NewParser: func() agent.LineParser { return &Parser{} },
-			},
-		},
+		Source:  Source(),
 		Control: agent.Control{SupportsInput: true, Interrupt: agent.InterruptCtrlC},
 		Permissions: []agent.Permission{
 			agent.ControlPermission(),
@@ -85,6 +78,26 @@ func Agent() agent.Agent {
 					Uninstall:  UninstallHooks,
 				},
 			},
+		},
+	}
+}
+
+// Source is this adapter's transcript-source declaration, split out of Agent so
+// callers that need only the roots do not rebuild the whole declaration.
+//
+// Codex rollouts live under $CODEX_HOME/sessions (default
+// ~/.codex/sessions), nested sessions/YYYY/MM/DD/*.jsonl.
+//
+// The hook receiver's path confiner reads it per request (issue #1361), and
+// Agent() below is its only other caller — one declaration, so the tree the
+// daemon watches and the tree the receiver confines to cannot drift apart.
+func Source() agent.Source {
+	return agent.FilesUnderRoot{
+		Dir:                     sessionsDir(),
+		SessionIDFromPath:       sessionIDFromPath,
+		ParentSessionIDFromPath: parentSessionIDFromPath,
+		Parser: agent.JSONLineParser{
+			NewParser: func() agent.LineParser { return &Parser{} },
 		},
 	}
 }

--- a/core/adapters/inbound/agents/codex/hookinstaller.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller.go
@@ -17,6 +17,8 @@ import (
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/pkg/daemonaddr"
+
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
 )
 
 // HookEndpointPath is the daemon's Codex hook path. Host and port are resolved
@@ -265,11 +267,15 @@ func codexHome() (string, error) {
 // It reports an error when the tree does not exist, which is the honest answer
 // for both callers: nothing to walk, and nothing a transcript could sit inside.
 func codexSessionsDir() (string, error) {
-	home, err := codexHome()
+	// Derived from the adapter's own declared root, not re-assembled from
+	// ".codex" + "sessions": that second derivation is exactly what issue #1361
+	// removed from the hook receiver, and leaving a copy here would let the
+	// tree the installer walks drift from the one the daemon watches.
+	root, err := agentpaths.AbsRoot(sessionsDir())
 	if err != nil {
 		return "", err
 	}
-	return filepath.EvalSymlinks(filepath.Join(home, "sessions"))
+	return filepath.EvalSymlinks(root)
 }
 
 func codexHooksPath() (string, error) {

--- a/core/adapters/inbound/agents/codex/hookpath_test.go
+++ b/core/adapters/inbound/agents/codex/hookpath_test.go
@@ -50,13 +50,9 @@ func TestHookPathConfined(t *testing.T) {
 		// keeping it from dispatching is confinement, not an unreadable file.
 		WriteTranscript: func(t *testing.T, dir string) string {
 			t.Helper()
-			path := filepath.Join(dir, "rollout-2026-07-18T00-00-00-abcdefabcdef"+transcriptExt)
-			meta := `{"type":"session_meta","payload":{"id":"sess-confine"}}` + "\n"
-			if err := os.WriteFile(path, []byte(meta), 0o600); err != nil {
-				t.Fatalf("write transcript: %v", err)
-			}
-			return path
+			return writeRolloutInto(t, dir, "sess-confine")
 		},
+		TranscriptExt: transcriptExt,
 		PayloadFor: func(transcriptPath string) string {
 			body, err := json.Marshal(codexHookPayload{
 				TranscriptPath: transcriptPath,

--- a/core/adapters/inbound/agents/codex/hookpath_test.go
+++ b/core/adapters/inbound/agents/codex/hookpath_test.go
@@ -1,0 +1,65 @@
+package codex
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+// TestHookPathConfined wires this adapter's hook receiver into the shared issue
+// #1361 contract: a caller-supplied transcript_path is confined to the
+// adapter's declared transcript roots, with symlinks resolved first, and
+// anything outside is refused loudly and counted.
+func TestHookPathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, contracttesting.HookReceiver{
+		Root: func(t *testing.T) string {
+			t.Helper()
+			// CODEX_HOME relocates the agent home; rollouts live in its
+			// sessions/ subdirectory, which is the declared root.
+			home := t.TempDir()
+			t.Setenv(codexHomeEnvVar, home)
+			root := filepath.Join(home, "sessions")
+			if err := os.MkdirAll(root, 0o700); err != nil {
+				t.Fatalf("create sessions dir: %v", err)
+			}
+			return root
+		},
+		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			confiner := TranscriptConfiner()
+			return contracttesting.HookReceiverUnderTest{
+				Handler:    NewHookHandlerWithConfiner(target, nil, mockLogger{}, confiner),
+				Observed:   func() bool { return target.totalCalls() > 0 },
+				Rejections: confiner.RejectionCount,
+			}
+		},
+		// Codex resolves the session id from the rollout's session_meta header,
+		// so the decoy outside the tree carries one too — the only thing
+		// keeping it from dispatching is confinement, not an unreadable file.
+		WriteTranscript: func(t *testing.T, dir string) string {
+			t.Helper()
+			path := filepath.Join(dir, "rollout-2026-07-18T00-00-00-abcdefabcdef"+transcriptExt)
+			meta := `{"type":"session_meta","payload":{"id":"sess-confine"}}` + "\n"
+			if err := os.WriteFile(path, []byte(meta), 0o600); err != nil {
+				t.Fatalf("write transcript: %v", err)
+			}
+			return path
+		},
+		PayloadFor: func(transcriptPath string) string {
+			body, err := json.Marshal(codexHookPayload{
+				TranscriptPath: transcriptPath,
+				HookEventName:  HookPermissionRequest,
+				ToolName:       "shell",
+			})
+			if err != nil {
+				panic(err)
+			}
+			return string(body)
+		},
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/codex/hookpath_test.go
+++ b/core/adapters/inbound/agents/codex/hookpath_test.go
@@ -37,6 +37,14 @@ func TestHookPathConfined(t *testing.T) {
 				Rejections: confiner.RejectionCount,
 			}
 		},
+		NewProduction: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.HookReceiverUnderTest{
+				Handler:  NewHookHandler(target, nil, mockLogger{}),
+				Observed: func() bool { return target.totalCalls() > 0 },
+			}
+		},
 		// Codex resolves the session id from the rollout's session_meta header,
 		// so the decoy outside the tree carries one too — the only thing
 		// keeping it from dispatching is confinement, not an unreadable file.

--- a/core/adapters/inbound/agents/codex/hooks.go
+++ b/core/adapters/inbound/agents/codex/hooks.go
@@ -27,10 +27,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"path/filepath"
-	"strings"
+	"runtime"
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/ports/outbound"
@@ -54,6 +54,10 @@ const (
 // logComponentHookReceiver is the Logger component tag for every log line
 // emitted by the hook HTTP handler below.
 const logComponentHookReceiver = "codex-hook-receiver"
+
+// transcriptExt is the file extension of a Codex rollout. The hook receiver
+// confines caller-supplied paths to this extension.
+const transcriptExt = ".jsonl"
 
 // codexHookPayload is the JSON body Codex sends on a hook event (stdin →
 // POSTed to the daemon by the installed curl command). Only the fields the
@@ -98,15 +102,31 @@ type ConsentGranter = hookjson.ConsentGranter
 // behind the "transcripts" permission. A nil gate means no gating — used by
 // tests.
 func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) http.HandlerFunc {
+	return NewHookHandlerWithConfiner(target, gate, log, TranscriptConfiner())
+}
+
+// TranscriptConfiner returns the confiner this adapter's hook receiver guards
+// caller-supplied transcript paths with, rooted in the adapter's own
+// agent.Source declaration (issue #1361). It replaces the adapter-local
+// confineToSessionsDir, which re-derived $CODEX_HOME/sessions from its own
+// constants and so could guard a different tree than the one being watched.
+func TranscriptConfiner() *hookjson.PathConfiner {
+	return hookjson.ConfinerForSource(func() agent.Source { return Agent().Source }, runtime.GOOS, transcriptExt)
+}
+
+// NewHookHandlerWithConfiner is NewHookHandler with an explicit confiner, for
+// tests that need to drive a receiver rooted somewhere other than the real
+// sessions tree and to read back what it refused.
+func NewHookHandlerWithConfiner(target HookTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		serveHookRequest(target, gate, log, w, r)
+		serveHookRequest(target, gate, log, confiner, w, r)
 	}
 }
 
 // serveHookRequest is NewHookHandler's request logic, pulled out of the
 // returned closure so its branching isn't counted at the closure's extra
 // nesting depth.
-func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logger, w http.ResponseWriter, r *http.Request) {
+func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -122,29 +142,29 @@ func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logge
 		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
 		return
 	}
-	if payload.TranscriptPath == "" {
-		http.Error(w, "bad request: missing transcript_path", http.StatusBadRequest)
-		return
-	}
 
 	// Resolving the session id opens and parses the Codex transcript file — a
 	// transcript read, so it must be gated behind the "transcripts" consent,
 	// not merely the "hooks" write consent (issue #1174). A hooks-granted /
 	// transcripts-denied session is not monitored anyway, so dropping the hook
 	// here is both consent-correct and behaviourally harmless.
+	//
+	// The consent check comes BEFORE confinement so a denied session still
+	// yields a quiet 200: a user who has not granted transcript access should
+	// not have hooks failing at them, and the path is never resolved on that
+	// branch anyway.
 	if gate != nil && !gate.Granted(AdapterName, PermissionKeyTranscripts) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	// transcript_path arrives in an HTTP body, so it is untrusted: any local
-	// process able to reach the hook port could otherwise steer the daemon into
-	// opening a file of its choosing. Confine it to the sessions tree before any
-	// read, and carry the confined path downstream so the target reads it too.
-	transcriptPath, ok := confineToSessionsDir(payload.TranscriptPath)
-	if !ok {
-		// Not a rollout inside ~/.codex/sessions — drop it. The "transcripts"
-		// consent covers exactly that tree and nothing outside it.
-		w.WriteHeader(http.StatusOK)
+	// transcript_path arrives in an HTTP body on a local, unauthenticated
+	// endpoint, so it is untrusted: any local process could otherwise steer the
+	// daemon into opening a file of its choosing. Confine it to the declared
+	// sessions tree before any read, and carry the confined path downstream so
+	// the target reads that and not the caller's string (issue #1361).
+	transcriptPath, reason := confiner.Confine(payload.TranscriptPath)
+	if reason != hookjson.RejectNone {
+		hookjson.RejectPath(w, log, logComponentHookReceiver, payload.TranscriptPath, reason)
 		return
 	}
 	payload.TranscriptPath = transcriptPath
@@ -159,35 +179,6 @@ func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logge
 
 	dispatchHookEvent(target, log, sessionID, payload)
 	w.WriteHeader(http.StatusOK)
-}
-
-// confineToSessionsDir validates a hook-supplied transcript path and returns
-// the file the daemon may open, rebuilt from the trusted sessions root so no
-// caller-controlled string reaches os.Open (SonarQube gosecurity:S2083).
-//
-// Two conditions bound it: the file must be a .jsonl rollout, and it must
-// resolve inside $CODEX_HOME/sessions — the tree agent.go's "transcripts"
-// permission scopes the user's consent to. Symlinks are resolved before the
-// containment check, so a link planted inside the tree cannot point out of it;
-// that resolution also means a path that does not exist is rejected here rather
-// than failing later at the open, which the caller already treats as a drop.
-func confineToSessionsDir(raw string) (string, bool) {
-	if filepath.Ext(raw) != ".jsonl" {
-		return "", false
-	}
-	root, err := codexSessionsDir()
-	if err != nil {
-		return "", false
-	}
-	resolved, err := filepath.EvalSymlinks(raw)
-	if err != nil {
-		return "", false
-	}
-	rel, err := filepath.Rel(root, resolved)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", false
-	}
-	return filepath.Join(root, rel), true
 }
 
 // dispatchHookEvent routes a decoded, consent-passed, session-resolved payload

--- a/core/adapters/inbound/agents/codex/hooks.go
+++ b/core/adapters/inbound/agents/codex/hooks.go
@@ -30,7 +30,6 @@ import (
 	"runtime"
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
-	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/ports/outbound"
@@ -111,7 +110,7 @@ func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger)
 // confineToSessionsDir, which re-derived $CODEX_HOME/sessions from its own
 // constants and so could guard a different tree than the one being watched.
 func TranscriptConfiner() *hookjson.PathConfiner {
-	return hookjson.ConfinerForSource(func() agent.Source { return Agent().Source }, runtime.GOOS, transcriptExt)
+	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
 }
 
 // NewHookHandlerWithConfiner is NewHookHandler with an explicit confiner, for

--- a/core/adapters/inbound/agents/codex/hooks_test.go
+++ b/core/adapters/inbound/agents/codex/hooks_test.go
@@ -110,13 +110,28 @@ func (mockLogger) Close() error                                         { return
 // be dropped as out-of-tree before the id is ever resolved.
 func writeSessionTranscript(t *testing.T, id string) string {
 	t.Helper()
+	return writeRolloutInto(t, sessionsTreeDir(t), id)
+}
+
+// sessionsTreeDir relocates $CODEX_HOME to a temp dir and returns a dated
+// rollout directory inside the declared sessions tree.
+func sessionsTreeDir(t *testing.T) string {
+	t.Helper()
 	home := t.TempDir()
 	t.Setenv(codexHomeEnvVar, home)
 	dir := filepath.Join(home, "sessions", "2026", "07", "18")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("create sessions dir: %v", err)
 	}
-	path := filepath.Join(dir, "rollout-2026-07-18T00-00-00-abcdefabcdef.jsonl")
+	return dir
+}
+
+// writeRolloutInto writes a rollout whose session_meta header carries id, so
+// sessionIDFromPath (and thus the handler) resolves to it. One writer, so the
+// rollout naming and header shape have a single owner.
+func writeRolloutInto(t *testing.T, dir, id string) string {
+	t.Helper()
+	path := filepath.Join(dir, "rollout-2026-07-18T00-00-00-abcdefabcdef"+transcriptExt)
 	meta := `{"type":"session_meta","payload":{"id":"` + id + `"}}` + "\n"
 	if err := os.WriteFile(path, []byte(meta), 0o600); err != nil {
 		t.Fatalf("write transcript: %v", err)
@@ -285,17 +300,12 @@ func TestHookHandler_UnresolvableTranscriptDropped(t *testing.T) {
 	// guessed session id — and, importantly, is not confused with an escape:
 	// the hook fires around the write, so a 400 here would fail a legitimate
 	// hook on a race (issue #1361).
-	home := t.TempDir()
-	t.Setenv(codexHomeEnvVar, home)
-	dir := filepath.Join(home, "sessions", "2026", "07", "18")
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatalf("create sessions dir: %v", err)
-	}
+	dir := sessionsTreeDir(t)
 
 	target := &mockTarget{}
 	handler := NewHookHandler(target, nil, mockLogger{})
 	rec := postHook(t, handler, codexHookPayload{
-		TranscriptPath: filepath.Join(dir, "does-not-exist.jsonl"),
+		TranscriptPath: filepath.Join(dir, "does-not-exist"+transcriptExt),
 		HookEventName:  HookPermissionRequest,
 	})
 	if rec.Code != http.StatusOK {

--- a/core/adapters/inbound/agents/codex/hooks_test.go
+++ b/core/adapters/inbound/agents/codex/hooks_test.go
@@ -320,8 +320,9 @@ func TestHookHandler_OutOfTreeTranscriptRejected(t *testing.T) {
 	// transcript_path is attacker-controllable — it comes straight out of an
 	// HTTP body — so a readable file outside $CODEX_HOME/sessions must never be
 	// opened, however well-formed its session_meta header is. Both a plain
-	// out-of-tree path and one traversing back out of the tree are rejected
-	// with a 400 — loudly and counted, never a silent 200 (issue #1361).
+	// out-of-tree path and one traversing back out of the tree are dropped.
+	// The drop is logged and counted rather than signalled on the wire, so the
+	// status stays 200 — unchanged from before #1361; see hookjson.RejectPath.
 	outside := t.TempDir()
 	path := filepath.Join(outside, "rollout-2026-07-18T00-00-00-abcdefabcdef.jsonl")
 	meta := `{"type":"session_meta","payload":{"id":"sess-escape"}}` + "\n"
@@ -345,8 +346,8 @@ func TestHookHandler_OutOfTreeTranscriptRejected(t *testing.T) {
 				TranscriptPath: transcript,
 				HookEventName:  HookPermissionRequest,
 			})
-			if rec.Code != http.StatusBadRequest {
-				t.Errorf("status: got %d, want 400 (an out-of-tree transcript is refused, not silently dropped)", rec.Code)
+			if rec.Code != http.StatusOK {
+				t.Errorf("status: got %d, want 200 (an out-of-tree transcript is dropped, logged and counted — not signalled on the wire)", rec.Code)
 			}
 			if target.totalCalls() != 0 {
 				t.Error("handler read a transcript outside the declared sessions tree")

--- a/core/adapters/inbound/agents/codex/hooks_test.go
+++ b/core/adapters/inbound/agents/codex/hooks_test.go
@@ -280,12 +280,22 @@ func TestHookHandler_MissingTranscriptPath(t *testing.T) {
 }
 
 func TestHookHandler_UnresolvableTranscriptDropped(t *testing.T) {
-	// A transcript_path that can't be read (no header yet / gone) is dropped
-	// with 200 rather than mis-keyed onto a guessed session id.
+	// A transcript_path INSIDE the declared tree that can't be read (not
+	// flushed yet / gone) is dropped with 200 rather than mis-keyed onto a
+	// guessed session id — and, importantly, is not confused with an escape:
+	// the hook fires around the write, so a 400 here would fail a legitimate
+	// hook on a race (issue #1361).
+	home := t.TempDir()
+	t.Setenv(codexHomeEnvVar, home)
+	dir := filepath.Join(home, "sessions", "2026", "07", "18")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("create sessions dir: %v", err)
+	}
+
 	target := &mockTarget{}
 	handler := NewHookHandler(target, nil, mockLogger{})
 	rec := postHook(t, handler, codexHookPayload{
-		TranscriptPath: filepath.Join(t.TempDir(), "does-not-exist.jsonl"),
+		TranscriptPath: filepath.Join(dir, "does-not-exist.jsonl"),
 		HookEventName:  HookPermissionRequest,
 	})
 	if rec.Code != http.StatusOK {
@@ -296,11 +306,12 @@ func TestHookHandler_UnresolvableTranscriptDropped(t *testing.T) {
 	}
 }
 
-func TestHookHandler_OutOfTreeTranscriptDropped(t *testing.T) {
+func TestHookHandler_OutOfTreeTranscriptRejected(t *testing.T) {
 	// transcript_path is attacker-controllable — it comes straight out of an
 	// HTTP body — so a readable file outside $CODEX_HOME/sessions must never be
 	// opened, however well-formed its session_meta header is. Both a plain
-	// out-of-tree path and one traversing back out of the tree are dropped.
+	// out-of-tree path and one traversing back out of the tree are rejected
+	// with a 400 — loudly and counted, never a silent 200 (issue #1361).
 	outside := t.TempDir()
 	path := filepath.Join(outside, "rollout-2026-07-18T00-00-00-abcdefabcdef.jsonl")
 	meta := `{"type":"session_meta","payload":{"id":"sess-escape"}}` + "\n"
@@ -324,8 +335,8 @@ func TestHookHandler_OutOfTreeTranscriptDropped(t *testing.T) {
 				TranscriptPath: transcript,
 				HookEventName:  HookPermissionRequest,
 			})
-			if rec.Code != http.StatusOK {
-				t.Errorf("status: got %d, want 200 (out-of-tree transcript is dropped, not an error)", rec.Code)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status: got %d, want 400 (an out-of-tree transcript is refused, not silently dropped)", rec.Code)
 			}
 			if target.totalCalls() != 0 {
 				t.Error("handler read a transcript outside the declared sessions tree")

--- a/core/adapters/inbound/agents/codex/session_meta.go
+++ b/core/adapters/inbound/agents/codex/session_meta.go
@@ -49,11 +49,11 @@ func parentSessionIDFromPath(path string) string {
 
 func sessionMetaPayload(path string) map[string]interface{} {
 	// Sink-local traversal guard. Every real caller already hands over a
-	// confined path — hooks.go rebuilds it from the trusted sessions root, and
-	// hookinstaller walks that root itself — but the plain ".." check is the
-	// form CodeQL's go/path-injection query recognizes as a sanitizer, which
-	// the Rel-based confinement in confineToSessionsDir is not (same lesson as
-	// store.go's underRoot in #910). A rejected path falls through to the same
+	// confined path — hooks.go rebuilds it from the trusted sessions root via
+	// hookjson.PathConfiner, and hookinstaller walks that root itself — but the
+	// plain ".." check is the form CodeQL's go/path-injection query recognizes
+	// as a sanitizer, which the confiner's Rel-based containment is not (same
+	// lesson as store.go's underRoot in #910). A rejected path falls through to the same
 	// "no metadata" result an unreadable file already produces.
 	if strings.Contains(path, "..") {
 		return nil

--- a/core/adapters/inbound/agents/fswatcher/watcher.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/ports/outbound"
 )
@@ -260,18 +261,15 @@ func (w *Watcher) eventFor(typ agent.EventType, sessionID, projectDir, path stri
 // maxAge controls the maximum file age — transcript files not modified within
 // this window are silently ignored. A zero value disables the filter.
 func New(dir, adapter string, maxAge time.Duration) *Watcher {
-	if filepath.IsAbs(dir) {
-		return &Watcher{root: filepath.Clean(dir), adapter: adapter, maxAge: maxAge}
-	}
-	home, err := os.UserHomeDir()
+	// agentpaths.AbsRoot owns the absolute-or-$HOME-relative rule. The hook
+	// receivers confine caller-supplied paths against the same declared roots
+	// (issue #1361), and a second copy of this resolution here would let the
+	// guarded tree drift from the watched one.
+	root, err := agentpaths.AbsRoot(dir)
 	if err != nil {
 		return &Watcher{adapter: adapter, maxAge: maxAge}
 	}
-	return &Watcher{
-		root:    filepath.Join(home, dir),
-		adapter: adapter,
-		maxAge:  maxAge,
-	}
+	return &Watcher{root: root, adapter: adapter, maxAge: maxAge}
 }
 
 // NewWithRoot creates a Watcher targeting a custom absolute root, bypassing

--- a/core/adapters/inbound/agents/hookjson/confine.go
+++ b/core/adapters/inbound/agents/hookjson/confine.go
@@ -290,7 +290,17 @@ func resolvePath(path string) (string, error) {
 	if err == nil {
 		return resolved, nil
 	}
-	if !errors.Is(err, fs.ErrNotExist) || hasParentRef(path) {
+	// The ".." test is written inline, as a plain strings.Contains, rather than
+	// through a helper: it is a real guard (a parent reference cannot be
+	// resolved without the filesystem, and resolving it lexically is the very
+	// bypass this function exists to prevent) AND it is the form CodeQL's
+	// go/path-injection query recognizes as a sanitizer for the Lstat below —
+	// an interprocedural predicate is not (same lesson as session_meta.go's
+	// guard and store.go's underRoot in #910). Contains is stricter than a
+	// component-wise check, which is the right direction here: it also refuses
+	// a not-yet-written leaf whose own name embeds "..", and no agent names a
+	// transcript that way.
+	if !errors.Is(err, fs.ErrNotExist) || strings.Contains(path, "..") {
 		return "", err
 	}
 	if _, lerr := os.Lstat(path); !errors.Is(lerr, fs.ErrNotExist) {
@@ -309,19 +319,4 @@ func resolvePath(path string) (string, error) {
 		return "", dirErr
 	}
 	return filepath.Join(resolvedDir, base), nil
-}
-
-// hasParentRef reports whether path contains a ".." component.
-func hasParentRef(path string) bool {
-	// Allocation-free reject for the overwhelmingly common case; the split
-	// below only runs for a path that contains ".." as a substring.
-	if !strings.Contains(path, "..") {
-		return false
-	}
-	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
-		if part == ".." {
-			return true
-		}
-	}
-	return false
 }

--- a/core/adapters/inbound/agents/hookjson/confine.go
+++ b/core/adapters/inbound/agents/hookjson/confine.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -110,7 +111,20 @@ func ConfinerForSource(src func() agent.Source, goos, suffix string) *PathConfin
 		if !ok {
 			return nil
 		}
-		return files.AllRootsFor(goos)
+		// Drop empty entries rather than resolving them. AllRootsFor always
+		// returns at least one element — RootDirFor is prepended
+		// unconditionally — so an adapter whose DirFunc failed and returned ""
+		// would otherwise present a root that resolves to $HOME, turning the
+		// fail-closed branch below into confinement over the entire home
+		// directory. An empty root is the absence of a root.
+		roots := files.AllRootsFor(goos)
+		kept := make([]string, 0, len(roots))
+		for _, root := range roots {
+			if strings.TrimSpace(root) != "" {
+				kept = append(kept, root)
+			}
+		}
+		return kept
 	}, suffix)
 }
 
@@ -126,10 +140,19 @@ func ConfinerForSource(src func() agent.Source, goos, suffix string) *PathConfin
 // The accepted path is rebuilt as declared-root + the resolved relative
 // component, never returned as the caller's own string, so no caller-controlled
 // path reaches os.Open (SonarQube gosecurity:S2083). It is rebuilt on the
-// DECLARED root rather than the symlink-resolved one so the result stays in the
-// same namespace as the fswatcher's paths, which are not symlink-resolved —
-// downstream state is keyed by transcript path, and two spellings of one file
-// are two sessions.
+// DECLARED root rather than the symlink-resolved one so the ROOT PREFIX stays
+// in the namespace the fswatcher emits paths in — that side is not
+// symlink-resolved, downstream state is keyed by transcript path, and two
+// spellings of one file are two sessions. On a machine whose $HOME or temp dir
+// sits behind a symlink (/var → /private/var on macOS) this is what keeps the
+// hook's key and the watcher's key equal.
+//
+// The relative component is a resolved one, so the guarantee stops at the
+// prefix: a symlink INSIDE the tree is collapsed here while the watcher reports
+// the link name. No shipped adapter layout has one, and the failure is quiet
+// and partial rather than wrong — hook-delivered rate limits, task estimates
+// and summaries miss their tailer and are dropped, while state classification,
+// which is keyed by session id, is unaffected.
 func (c *PathConfiner) Confine(raw string) (string, RejectReason) {
 	if raw == "" {
 		return "", c.count(RejectEmptyPath)
@@ -147,6 +170,13 @@ func (c *PathConfiner) Confine(raw string) (string, RejectReason) {
 	resolved, err := resolvePath(raw)
 	if err != nil {
 		return "", c.count(RejectUnresolvable)
+	}
+	// Re-assert the extension on the RESOLVED path. The pre-check above reads
+	// the caller's string, which an in-tree symlink can spell ".jsonl" while
+	// pointing at something else entirely — the daemon would then tail a
+	// non-transcript file and derive a session id from its name.
+	if c.suffix != "" && filepath.Ext(resolved) != c.suffix {
+		return "", c.count(RejectWrongSuffix)
 	}
 	for _, declared := range roots {
 		if confined, ok := containedIn(declared, resolved); ok {
@@ -236,12 +266,25 @@ func containedIn(declared, resolved string) (string, bool) {
 // and only when the path carries no ".." — a parent reference cannot be
 // resolved without the filesystem, and resolving it lexically is precisely the
 // bypass this function exists to prevent.
+//
+// "Missing" has to mean absent from the directory, not merely unresolvable.
+// EvalSymlinks reports fs.ErrNotExist for a DANGLING symlink exactly as it does
+// for a file that was never created, and the two are not equivalent here: an
+// attacker who plants a broken link inside the tree, has it accepted, and only
+// then creates the target has escaped the root without ever needing a race.
+// Lstat is what tells them apart — it succeeds on a symlink whatever its target
+// — so an existing leaf is a resolution failure, never an unflushed write.
 func resolvePath(path string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(path)
 	if err == nil {
 		return resolved, nil
 	}
 	if !errors.Is(err, fs.ErrNotExist) || hasParentRef(path) {
+		return "", err
+	}
+	if _, lerr := os.Lstat(path); lerr == nil || !errors.Is(lerr, fs.ErrNotExist) {
+		// The leaf is there (a dangling symlink, most likely) or its status
+		// cannot be established. Either way this is not the write race.
 		return "", err
 	}
 	dir, base := filepath.Split(path)

--- a/core/adapters/inbound/agents/hookjson/confine.go
+++ b/core/adapters/inbound/agents/hookjson/confine.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
+	"sync/atomic"
 
 	"irrlicht/core/adapters/inbound/agents/agentpaths"
 	"irrlicht/core/domain/agent"
@@ -67,8 +67,22 @@ type PathConfiner struct {
 	roots  func() []string
 	suffix string
 
-	mu     sync.Mutex
-	counts map[RejectReason]uint64
+	// One counter per reason, indexed by rejectReasons order. A fixed array of
+	// atomics rather than a mutex-guarded map: the counters exist to observe a
+	// rejection BURST, so instrumentation that serializes exactly when
+	// rejections arrive together would blunt the thing it measures.
+	counts [len(rejectReasons)]atomic.Uint64
+}
+
+// rejectReasons is every reason in a fixed order, so each has a stable counter
+// slot. RejectNone is deliberately absent — it is not a rejection.
+var rejectReasons = [...]RejectReason{
+	RejectEmptyPath,
+	RejectRelativePath,
+	RejectWrongSuffix,
+	RejectNoRoots,
+	RejectUnresolvable,
+	RejectEscapesRoot,
 }
 
 // NewPathConfiner builds a confiner over roots, accepting only files whose
@@ -79,11 +93,7 @@ type PathConfiner struct {
 // evaluated lazily. Each returned element is either absolute or $HOME-relative,
 // exactly as agent.FilesUnderRoot documents; agentpaths.AbsRoot closes that gap.
 func NewPathConfiner(roots func() []string, suffix string) *PathConfiner {
-	return &PathConfiner{
-		roots:  roots,
-		suffix: suffix,
-		counts: make(map[RejectReason]uint64),
-	}
+	return &PathConfiner{roots: roots, suffix: suffix}
 }
 
 // ConfinerForSource builds a confiner from an adapter's own agent.Source
@@ -205,22 +215,20 @@ func RejectPath(w http.ResponseWriter, log outbound.Logger, component, raw strin
 // publish into — but they make "rejected and counted" an observable fact
 // rather than a claim, which is what the contract assertion checks.
 func (c *PathConfiner) Rejections() map[RejectReason]uint64 {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	out := make(map[RejectReason]uint64, len(c.counts))
-	for reason, n := range c.counts {
-		out[reason] = n
+	out := make(map[RejectReason]uint64, len(rejectReasons))
+	for i, reason := range rejectReasons {
+		if n := c.counts[i].Load(); n > 0 {
+			out[reason] = n
+		}
 	}
 	return out
 }
 
 // RejectionCount returns the total number of paths this confiner has refused.
 func (c *PathConfiner) RejectionCount() uint64 {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	var total uint64
-	for _, n := range c.counts {
-		total += n
+	for i := range c.counts {
+		total += c.counts[i].Load()
 	}
 	return total
 }
@@ -228,9 +236,12 @@ func (c *PathConfiner) RejectionCount() uint64 {
 // count records a rejection and returns the reason, so call sites read as
 // `return "", c.count(reason)`.
 func (c *PathConfiner) count(reason RejectReason) RejectReason {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.counts[reason]++
+	for i, known := range rejectReasons {
+		if known == reason {
+			c.counts[i].Add(1)
+			break
+		}
+	}
 	return reason
 }
 
@@ -282,13 +293,15 @@ func resolvePath(path string) (string, error) {
 	if !errors.Is(err, fs.ErrNotExist) || hasParentRef(path) {
 		return "", err
 	}
-	if _, lerr := os.Lstat(path); lerr == nil || !errors.Is(lerr, fs.ErrNotExist) {
+	if _, lerr := os.Lstat(path); !errors.Is(lerr, fs.ErrNotExist) {
 		// The leaf is there (a dangling symlink, most likely) or its status
 		// cannot be established. Either way this is not the write race.
 		return "", err
 	}
+	// path is absolute (Confine checked) and free of "..", so Split always
+	// yields a non-empty dir and base is neither "" nor "..".
 	dir, base := filepath.Split(path)
-	if dir == "" || base == "" || base == "." || base == ".." {
+	if base == "." {
 		return "", err
 	}
 	resolvedDir, dirErr := filepath.EvalSymlinks(filepath.Clean(dir))
@@ -300,6 +313,11 @@ func resolvePath(path string) (string, error) {
 
 // hasParentRef reports whether path contains a ".." component.
 func hasParentRef(path string) bool {
+	// Allocation-free reject for the overwhelmingly common case; the split
+	// below only runs for a path that contains ".." as a substring.
+	if !strings.Contains(path, "..") {
+		return false
+	}
 	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
 		if part == ".." {
 			return true

--- a/core/adapters/inbound/agents/hookjson/confine.go
+++ b/core/adapters/inbound/agents/hookjson/confine.go
@@ -1,0 +1,266 @@
+// confine.go holds the receiver-side path guard every JSON-hook adapter shares
+// (issue #1361).
+//
+// The daemon's hook endpoints are local and unauthenticated: any process on the
+// machine can POST to them, and the transcript_path in that body is opened by
+// whatever the receiver hands it to. Confinement therefore is not an
+// adapter-specific nicety but a property of the receiver path itself, and it
+// lives here — beside ConsentGranter, for the same reason — so a new
+// hook-receiving adapter inherits it instead of remembering it. Codex had this
+// logic inline and Claude Code did not, which is exactly the drift a shared
+// helper removes.
+//
+// The roots come from the adapter's own agent.Source declaration rather than a
+// second list: a confinement root that can disagree with the watched root is a
+// guard on the wrong directory.
+package hookjson
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/ports/outbound"
+)
+
+// RejectReason names why a caller-supplied path was refused. It is a stable,
+// low-cardinality token so a rejection can be logged and counted rather than
+// dropped — the endpoint is unauthenticated, so a burst of rejections is the
+// signal that something local is probing it.
+type RejectReason string
+
+const (
+	// RejectNone is the zero value: the path was accepted.
+	RejectNone RejectReason = ""
+	// RejectEmptyPath — no transcript_path in the payload.
+	RejectEmptyPath RejectReason = "empty_path"
+	// RejectRelativePath — a relative path, which would resolve against the
+	// daemon's working directory rather than the agent's transcript tree.
+	RejectRelativePath RejectReason = "relative_path"
+	// RejectWrongSuffix — not the file extension the adapter's transcripts use.
+	RejectWrongSuffix RejectReason = "wrong_suffix"
+	// RejectNoRoots — the adapter declared no transcript root, so nothing can
+	// be confined. Fail closed: a missing root is not an empty guard.
+	RejectNoRoots RejectReason = "no_roots"
+	// RejectUnresolvable — the path (or its parent directory) could not be
+	// resolved on disk, so its real identity is unknown.
+	RejectUnresolvable RejectReason = "unresolvable"
+	// RejectEscapesRoot — the resolved path lies outside every declared root.
+	// Covers plain out-of-tree paths, parent traversal, and symlinks planted
+	// inside the tree that point out of it.
+	RejectEscapesRoot RejectReason = "escapes_root"
+)
+
+// PathConfiner confines a caller-supplied path to an adapter's declared
+// transcript roots, and counts what it refuses.
+//
+// Safe for concurrent use: hook receivers are HTTP handlers, so Confine runs on
+// many goroutines at once.
+type PathConfiner struct {
+	roots  func() []string
+	suffix string
+
+	mu     sync.Mutex
+	counts map[RejectReason]uint64
+}
+
+// NewPathConfiner builds a confiner over roots, accepting only files whose
+// extension is suffix (e.g. ".jsonl"; empty means any).
+//
+// roots is a func, not a slice, because a root is env-dependent
+// (CLAUDE_CONFIG_DIR, CODEX_HOME) and the declaration that produced it is
+// evaluated lazily. Each returned element is either absolute or $HOME-relative,
+// exactly as agent.FilesUnderRoot documents; agentpaths.AbsRoot closes that gap.
+func NewPathConfiner(roots func() []string, suffix string) *PathConfiner {
+	return &PathConfiner{
+		roots:  roots,
+		suffix: suffix,
+		counts: make(map[RejectReason]uint64),
+	}
+}
+
+// ConfinerForSource builds a confiner from an adapter's own agent.Source
+// declaration — the same roots the daemon builds its fswatchers from
+// (wiring.go's AllRootsFor loop), so the guarded tree and the watched tree
+// cannot drift apart.
+//
+// src is re-read on every Confine rather than captured once. A root is
+// env-dependent (CLAUDE_CONFIG_DIR, CODEX_HOME) and an adapter's Dir is
+// evaluated when it declares itself, so a confiner built at daemon start and
+// frozen would guard wherever the environment pointed at that instant. Nothing
+// relocates a root mid-run in production, but a handler constructed before its
+// root is known guards the wrong tree — and that is the ordinary shape of a
+// test, which makes it the shape a bug hides in.
+//
+// A Source that is not FilesUnderRoot declares no directory tree to confine to
+// (FilesUnderCWD is per-process, ProcessOwnedStore is a database), so the
+// resulting confiner refuses everything with RejectNoRoots rather than waving
+// paths through. If such an adapter ever grows a hook receiver, that failure is
+// the prompt to give it a real root — not something to be discovered later by
+// an unauthenticated caller.
+func ConfinerForSource(src func() agent.Source, goos, suffix string) *PathConfiner {
+	return NewPathConfiner(func() []string {
+		files, ok := src().(agent.FilesUnderRoot)
+		if !ok {
+			return nil
+		}
+		return files.AllRootsFor(goos)
+	}, suffix)
+}
+
+// Confine resolves raw and returns the path the daemon may open, or the reason
+// it was refused. A non-empty reason means the caller must reject the request;
+// the returned path is empty in that case.
+//
+// Symlinks are resolved BEFORE the containment check. That ordering is the
+// whole guard: a link planted inside the declared tree that points out of it is
+// lexically contained and really is not, so a check that runs first passes a
+// naive traversal test and confines nothing.
+//
+// The accepted path is rebuilt as declared-root + the resolved relative
+// component, never returned as the caller's own string, so no caller-controlled
+// path reaches os.Open (SonarQube gosecurity:S2083). It is rebuilt on the
+// DECLARED root rather than the symlink-resolved one so the result stays in the
+// same namespace as the fswatcher's paths, which are not symlink-resolved —
+// downstream state is keyed by transcript path, and two spellings of one file
+// are two sessions.
+func (c *PathConfiner) Confine(raw string) (string, RejectReason) {
+	if raw == "" {
+		return "", c.count(RejectEmptyPath)
+	}
+	if !filepath.IsAbs(raw) {
+		return "", c.count(RejectRelativePath)
+	}
+	if c.suffix != "" && filepath.Ext(raw) != c.suffix {
+		return "", c.count(RejectWrongSuffix)
+	}
+	roots := c.roots()
+	if len(roots) == 0 {
+		return "", c.count(RejectNoRoots)
+	}
+	resolved, err := resolvePath(raw)
+	if err != nil {
+		return "", c.count(RejectUnresolvable)
+	}
+	for _, declared := range roots {
+		if confined, ok := containedIn(declared, resolved); ok {
+			return confined, RejectNone
+		}
+	}
+	return "", c.count(RejectEscapesRoot)
+}
+
+// RejectPath writes the uniform refusal every hook receiver owes a confinement
+// failure: a 400 naming the reason, and an error-level log line carrying the
+// offending path. Never a silent 200 — the endpoint is unauthenticated, so a
+// refused path is either a misconfigured agent or a local process probing the
+// daemon, and both deserve to be visible. The path is logged with %q so an
+// embedded newline cannot forge a log record.
+//
+// component is the caller's Logger component tag; sessionID is empty because
+// confinement runs before an id can be derived from the path.
+func RejectPath(w http.ResponseWriter, log outbound.Logger, component, raw string, reason RejectReason) {
+	log.LogError(component, "", fmt.Sprintf("rejected hook transcript_path %q: %s", raw, reason))
+	http.Error(w, "bad request: transcript_path "+string(reason), http.StatusBadRequest)
+}
+
+// Rejections returns a snapshot of the per-reason rejection counts. Nothing
+// surfaces these to a UI yet — there is no daemon-wide counter registry to
+// publish into — but they make "rejected and counted" an observable fact
+// rather than a claim, which is what the contract assertion checks.
+func (c *PathConfiner) Rejections() map[RejectReason]uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[RejectReason]uint64, len(c.counts))
+	for reason, n := range c.counts {
+		out[reason] = n
+	}
+	return out
+}
+
+// RejectionCount returns the total number of paths this confiner has refused.
+func (c *PathConfiner) RejectionCount() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var total uint64
+	for _, n := range c.counts {
+		total += n
+	}
+	return total
+}
+
+// count records a rejection and returns the reason, so call sites read as
+// `return "", c.count(reason)`.
+func (c *PathConfiner) count(reason RejectReason) RejectReason {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.counts[reason]++
+	return reason
+}
+
+// containedIn reports whether resolved (already symlink-resolved and absolute)
+// lies strictly inside the declared root, and if so returns the path rebuilt on
+// that declared root.
+func containedIn(declared, resolved string) (string, bool) {
+	absRoot, err := agentpaths.AbsRoot(declared)
+	if err != nil {
+		return "", false
+	}
+	// The root is resolved too: on macOS a temp or home directory routinely
+	// sits behind a symlink (/var → /private/var), and comparing a resolved
+	// file against an unresolved root reports every real transcript as an
+	// escape.
+	resolvedRoot, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		// The declared root is not on disk. Nothing can be inside it.
+		return "", false
+	}
+	rel, err := filepath.Rel(resolvedRoot, resolved)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.Join(absRoot, rel), true
+}
+
+// resolvePath resolves every symlink in path.
+//
+// A transcript that is not on disk yet is resolved one level up instead: the
+// hook fires around the write, so refusing an unflushed file would turn a
+// benign race into a 400 on a legitimate hook. Only the leaf may be missing,
+// and only when the path carries no ".." — a parent reference cannot be
+// resolved without the filesystem, and resolving it lexically is precisely the
+// bypass this function exists to prevent.
+func resolvePath(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved, nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) || hasParentRef(path) {
+		return "", err
+	}
+	dir, base := filepath.Split(path)
+	if dir == "" || base == "" || base == "." || base == ".." {
+		return "", err
+	}
+	resolvedDir, dirErr := filepath.EvalSymlinks(filepath.Clean(dir))
+	if dirErr != nil {
+		return "", dirErr
+	}
+	return filepath.Join(resolvedDir, base), nil
+}
+
+// hasParentRef reports whether path contains a ".." component.
+func hasParentRef(path string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/core/adapters/inbound/agents/hookjson/confine.go
+++ b/core/adapters/inbound/agents/hookjson/confine.go
@@ -197,17 +197,58 @@ func (c *PathConfiner) Confine(raw string) (string, RejectReason) {
 }
 
 // RejectPath writes the uniform refusal every hook receiver owes a confinement
-// failure: a 400 naming the reason, and an error-level log line carrying the
-// offending path. Never a silent 200 — the endpoint is unauthenticated, so a
-// refused path is either a misconfigured agent or a local process probing the
-// daemon, and both deserve to be visible. The path is logged with %q so an
-// embedded newline cannot forge a log record.
+// failure. It is the ONE place the wire behaviour of a refusal is decided, so
+// every receiver — present and future — inherits it instead of choosing.
+//
+// The refusal is loud in the daemon and silent on the wire: an error-level log
+// line naming the reason and the offending path, the confiner's counter
+// incremented, and a 200 with an empty body. The path is never forwarded and
+// nothing is opened, so the security property does not depend on the status
+// code at all.
+//
+// Why 2xx rather than 400, recorded because the next reader will otherwise flip
+// it on aesthetics (issue #1361 item 4 asked for a 400; issue #1364 asks for
+// 200, and this is the reconciliation):
+//
+//   - OBSERVED, from the Claude Code hooks guide: "HTTP status codes alone
+//     can't block actions." A non-2xx from a `type: http` hook is documented as
+//     a non-blocking error; to block or deny you must return 2xx with a JSON
+//     decision body. So a 400 here cannot deny a tool call or stall a turn.
+//   - OBSERVED, from the claude 2.1.226 binary: the HTTP hook client sets
+//     `validateStatus: () => true` and returns `{ok: status>=200 && status<300,
+//     statusCode, body}` — a 400 is simply `ok:false`, not an exception.
+//   - NOT OBSERVED: whether `ok:false` surfaces an error to the user, is
+//     retried, or is merely logged. The docs do not say and I did not run a
+//     live probe. That unknown sits on the user's critical path.
+//   - NOT OBSERVED for the other CLIs at all. Codex delivers via `curl ... ||
+//     true`, so its exit code is already swallowed — but gemini-cli's pre-tool
+//     hooks fail CLOSED (a non-zero result yields decision "deny" and the tool
+//     is skipped) and Copilot's preToolUse denies on error. A receiver added
+//     for one of those adapters would inherit whatever this function does, and
+//     for them a non-2xx is known to be dangerous.
+//
+// An empty-bodied 200 is the response this handler already returns on its
+// success path, so it is the one interaction with the CLI that is continuously
+// exercised. Choosing it trades nothing: "never silently drop" is satisfied by
+// the log and the counter, which is where an operator looks, and not by a
+// status code the agent may or may not show anyone.
+//
+// The one exception is a MISSING transcript_path, which stays a 400. That is a
+// malformed body rather than a verdict about a path — the field the receiver
+// keys everything on is simply absent — and both receivers already answered 400
+// for it before this change, so it is the status the CLIs have been given all
+// along. Keeping it preserves that, and confines this function's new opinion to
+// the cases that are genuinely new.
 //
 // component is the caller's Logger component tag; sessionID is empty because
 // confinement runs before an id can be derived from the path.
 func RejectPath(w http.ResponseWriter, log outbound.Logger, component, raw string, reason RejectReason) {
 	log.LogError(component, "", fmt.Sprintf("rejected hook transcript_path %q: %s", raw, reason))
-	http.Error(w, "bad request: transcript_path "+string(reason), http.StatusBadRequest)
+	if reason == RejectEmptyPath {
+		http.Error(w, "bad request: missing transcript_path", http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 // Rejections returns a snapshot of the per-reason rejection counts. Nothing

--- a/core/adapters/inbound/agents/hookjson/confine_test.go
+++ b/core/adapters/inbound/agents/hookjson/confine_test.go
@@ -1,0 +1,177 @@
+package hookjson
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+)
+
+// staticRoots is a PathConfiner over one fixed absolute root.
+func staticRoots(root string) *PathConfiner {
+	return NewPathConfiner(func() []string { return []string{root} }, ".jsonl")
+}
+
+func writeFile(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path
+}
+
+// TestConfine_RejectionReasons pins the reason taxonomy. The reasons are what
+// gets logged and counted, so a path refused for the wrong stated reason is a
+// misleading operator signal even though the security outcome is the same.
+func TestConfine_RejectionReasons(t *testing.T) {
+	root := t.TempDir()
+	inTree := writeFile(t, filepath.Join(root, "sub", "a.jsonl"))
+	outside := writeFile(t, filepath.Join(t.TempDir(), "b.jsonl"))
+
+	tests := map[string]struct {
+		confiner *PathConfiner
+		path     string
+		want     RejectReason
+	}{
+		"in tree accepted":          {staticRoots(root), inTree, RejectNone},
+		"empty path":                {staticRoots(root), "", RejectEmptyPath},
+		"relative path":             {staticRoots(root), "sub/a.jsonl", RejectRelativePath},
+		"wrong suffix":              {staticRoots(root), filepath.Join(root, "sub", "a.txt"), RejectWrongSuffix},
+		"no declared roots":         {NewPathConfiner(func() []string { return nil }, ".jsonl"), inTree, RejectNoRoots},
+		"outside every root":        {staticRoots(root), outside, RejectEscapesRoot},
+		"missing parent directory":  {staticRoots(root), filepath.Join(root, "nope", "c.jsonl"), RejectUnresolvable},
+		"missing leaf inside tree":  {staticRoots(root), filepath.Join(root, "sub", "later.jsonl"), RejectNone},
+		"root itself is not a file": {staticRoots(root), root, RejectWrongSuffix},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, reason := tt.confiner.Confine(tt.path)
+			if reason != tt.want {
+				t.Fatalf("Confine(%q) reason = %q, want %q", tt.path, reason, tt.want)
+			}
+			if reason == RejectNone && got == "" {
+				t.Error("accepted path came back empty")
+			}
+			if reason != RejectNone && got != "" {
+				t.Errorf("rejected path returned %q, want empty", got)
+			}
+		})
+	}
+}
+
+// TestConfine_MissingLeafIsAcceptedNotAnEscape is the race the "resolve one
+// level up" rule exists for: the hook fires around the transcript write, so a
+// file that is not on disk yet must be accepted when its directory is in the
+// tree — refusing it would 400 a legitimate hook.
+func TestConfine_MissingLeafIsAcceptedNotAnEscape(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	unflushed := filepath.Join(root, "sub", "not-yet.jsonl")
+
+	got, reason := staticRoots(root).Confine(unflushed)
+	if reason != RejectNone {
+		t.Fatalf("Confine(%q) = %q, want it accepted", unflushed, reason)
+	}
+	if got != unflushed {
+		t.Errorf("confined path = %q, want %q", got, unflushed)
+	}
+}
+
+// TestConfine_MissingLeafCannotSmuggleParentRefs guards the one case the
+// missing-leaf allowance could have opened: ".." cannot be resolved without the
+// filesystem, so a non-existent path carrying one is refused rather than
+// collapsed lexically.
+func TestConfine_MissingLeafCannotSmuggleParentRefs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	smuggled := filepath.Join(root, "sub") + "/../../escaped.jsonl"
+
+	if got, reason := staticRoots(root).Confine(smuggled); reason == RejectNone {
+		t.Errorf("Confine(%q) accepted it as %q — a missing path with %q must not be resolved lexically", smuggled, got, "..")
+	}
+}
+
+// TestConfine_SymlinkEscapeResolvedBeforeContainment is the ordering property
+// at the unit level: lexically inside, really outside.
+func TestConfine_SymlinkEscapeResolvedBeforeContainment(t *testing.T) {
+	root := t.TempDir()
+	outside := writeFile(t, filepath.Join(t.TempDir(), "secret.jsonl"))
+	link := filepath.Join(root, "sub", "innocent.jsonl")
+	if err := os.MkdirAll(filepath.Dir(link), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if got, reason := staticRoots(root).Confine(link); reason != RejectEscapesRoot {
+		t.Errorf("Confine(%q) = (%q, %q), want %q", link, got, reason, RejectEscapesRoot)
+	}
+}
+
+// TestConfine_CountsEveryRejectionByReason checks the counters the receivers
+// report. Nothing publishes them yet, which is exactly why they need a test:
+// an uncounted rejection is indistinguishable from no rejection.
+func TestConfine_CountsEveryRejectionByReason(t *testing.T) {
+	c := staticRoots(t.TempDir())
+	c.Confine("")
+	c.Confine("")
+	c.Confine("relative.jsonl")
+
+	if n := c.RejectionCount(); n != 3 {
+		t.Errorf("RejectionCount = %d, want 3", n)
+	}
+	counts := c.Rejections()
+	if counts[RejectEmptyPath] != 2 {
+		t.Errorf("empty_path count = %d, want 2", counts[RejectEmptyPath])
+	}
+	if counts[RejectRelativePath] != 1 {
+		t.Errorf("relative_path count = %d, want 1", counts[RejectRelativePath])
+	}
+	// The snapshot must be a copy, not the live map.
+	counts[RejectEmptyPath] = 99
+	if c.Rejections()[RejectEmptyPath] != 2 {
+		t.Error("Rejections() handed out the live map")
+	}
+}
+
+// TestConfinerForSource_NonFileSourceConfinesNothing pins the fail-closed
+// choice: an adapter whose Source declares no directory tree gets a confiner
+// that refuses everything, not one that waves paths through.
+func TestConfinerForSource_NonFileSourceConfinesNothing(t *testing.T) {
+	c := ConfinerForSource(func() agent.Source { return agent.FilesUnderCWD{Filename: "x.md"} }, "darwin", ".jsonl")
+
+	if _, reason := c.Confine(writeFile(t, filepath.Join(t.TempDir(), "a.jsonl"))); reason != RejectNoRoots {
+		t.Errorf("reason = %q, want %q", reason, RejectNoRoots)
+	}
+}
+
+// TestConfinerForSource_UsesDeclaredRoots checks the roots really come from the
+// adapter's own declaration, including ExtraDirs — the point of deriving them
+// from agent.Source rather than a second hardcoded list.
+func TestConfinerForSource_UsesDeclaredRoots(t *testing.T) {
+	primary := t.TempDir()
+	extra := t.TempDir()
+	src := agent.FilesUnderRoot{Dir: primary, ExtraDirs: []string{extra}}
+	c := ConfinerForSource(func() agent.Source { return src }, "darwin", ".jsonl")
+
+	for _, root := range []string{primary, extra} {
+		path := writeFile(t, filepath.Join(root, "sub", "a.jsonl"))
+		if _, reason := c.Confine(path); reason != RejectNone {
+			t.Errorf("declared root %s: Confine(%q) = %q, want accepted", root, path, reason)
+		}
+	}
+	outside := writeFile(t, filepath.Join(t.TempDir(), "a.jsonl"))
+	if _, reason := c.Confine(outside); reason != RejectEscapesRoot {
+		t.Errorf("undeclared root: reason = %q, want %q", reason, RejectEscapesRoot)
+	}
+}

--- a/core/adapters/inbound/agents/hookjson/confine_test.go
+++ b/core/adapters/inbound/agents/hookjson/confine_test.go
@@ -118,6 +118,66 @@ func TestConfine_SymlinkEscapeResolvedBeforeContainment(t *testing.T) {
 	}
 }
 
+// TestConfine_DanglingSymlinkIsNotAnUnflushedWrite guards the missing-leaf
+// allowance's one sharp edge. EvalSymlinks reports fs.ErrNotExist for a broken
+// symlink exactly as it does for a file that was never written, so treating
+// "unresolvable" as "not flushed yet" would let an attacker plant a broken link
+// inside the tree, have the path accepted, and only then create the target —
+// an escape with no race in it.
+func TestConfine_DanglingSymlinkIsNotAnUnflushedWrite(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(t.TempDir(), "planted-later.jsonl") // deliberately absent
+	link := filepath.Join(root, "sub", "innocent.jsonl")
+	if err := os.MkdirAll(filepath.Dir(link), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	got, reason := staticRoots(root).Confine(link)
+	if reason == RejectNone {
+		t.Fatalf("Confine(%q) accepted a dangling in-tree symlink as %q", link, got)
+	}
+	// Once the attacker creates the target, the same path must still be refused.
+	if err := os.WriteFile(target, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if got, reason := staticRoots(root).Confine(link); reason != RejectEscapesRoot {
+		t.Errorf("with the target created, Confine(%q) = (%q, %q), want %q", link, got, reason, RejectEscapesRoot)
+	}
+}
+
+// TestConfine_SuffixIsRecheckedAfterResolution pins the second half of the
+// extension guard: the pre-check reads the caller's string, which an in-tree
+// symlink can spell ".jsonl" while pointing at something else.
+func TestConfine_SuffixIsRecheckedAfterResolution(t *testing.T) {
+	root := t.TempDir()
+	real := writeFile(t, filepath.Join(root, "sub", "store.db"))
+	link := filepath.Join(root, "sub", "looks-like.jsonl")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if got, reason := staticRoots(root).Confine(link); reason != RejectWrongSuffix {
+		t.Errorf("Confine(%q) = (%q, %q), want %q — the extension must be re-asserted on the resolved path", link, got, reason, RejectWrongSuffix)
+	}
+}
+
+// TestConfinerForSource_EmptyRootIsNotHome is the fail-open this guards. A root
+// of "" resolves under $HOME, so an adapter whose DirFunc failed would confine
+// to the entire home directory instead of to nothing.
+func TestConfinerForSource_EmptyRootIsNotHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	victim := writeFile(t, filepath.Join(home, ".ssh", "id_rsa.jsonl"))
+
+	c := ConfinerForSource(func() agent.Source { return agent.FilesUnderRoot{Dir: ""} }, "darwin", ".jsonl")
+	if got, reason := c.Confine(victim); reason != RejectNoRoots {
+		t.Errorf("Confine(%q) = (%q, %q), want %q — an empty declared root must not resolve to $HOME", victim, got, reason, RejectNoRoots)
+	}
+}
+
 // TestConfine_CountsEveryRejectionByReason checks the counters the receivers
 // report. Nothing publishes them yet, which is exactly why they need a test:
 // an uncounted rejection is indistinguishable from no rejection.

--- a/core/domain/agent/source.go
+++ b/core/domain/agent/source.go
@@ -23,7 +23,12 @@ type Source interface {
 // collapse the lot into one resolver (`Roots func(goos string) []string`, with
 // constructors for the static cases) rather than extending the ladder.
 type FilesUnderRoot struct {
-	Dir    string // path relative to $HOME, e.g. ".claude/projects"
+	// Dir is the root, either absolute or relative to $HOME (e.g.
+	// ".claude/projects"). Resolving that choice is a runtime concern, so it
+	// lives outside the domain: adapters/inbound/agents/agentpaths.AbsRoot is
+	// the single implementation, shared by the fswatcher that watches the tree
+	// and the hook receiver that confines caller-supplied paths to it.
+	Dir    string
 	Parser FileParser
 
 	// DirFunc optionally replaces Dir with a resolver, for an adapter whose

--- a/core/internal/contracttesting/hook_path_confinement.go
+++ b/core/internal/contracttesting/hook_path_confinement.go
@@ -1,0 +1,196 @@
+// hook_path_confinement.go holds the issue #1361 contract every hook-RECEIVING
+// agent adapter must satisfy: the transcript_path in an inbound hook body is
+// confined to the adapter's own declared transcript roots before anything
+// downstream opens it.
+//
+// It is the receiving-side sibling of AssertHookEndpointFollowsBindAddr, and
+// exists for the same reason: the obligation is a runtime choice a handler has
+// to make, invisible to a static check, and the alternative is each new adapter
+// remembering it. Two adapters received hooks when this was written and only
+// one confined — claudecode derived a session id from the basename and handed
+// the caller's raw string to the detector, which opened it, on a local
+// unauthenticated endpoint. That is the failure this contract makes impossible
+// to ship quietly at receiver three through ten.
+//
+// The ordering obligation is the one worth stating twice: symlinks must be
+// resolved BEFORE containment is checked. A guard that checks first accepts a
+// link planted inside the tree that points anywhere on the filesystem, while
+// passing every lexical traversal test — it looks correct and confines nothing.
+package contracttesting
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// HookReceiverUnderTest is one freshly built hook receiver plus the two things
+// the contract must be able to see from outside it: whether a payload was
+// dispatched, and what the receiver refused.
+type HookReceiverUnderTest struct {
+	// Handler is the adapter's hook HTTP handler.
+	Handler http.Handler
+
+	// Observed reports whether the receiver dispatched anything downstream —
+	// i.e. whether the supplied transcript_path escaped the receiver. This is
+	// the assertion that actually matters; the status code is how the refusal
+	// is reported, but a 400 alongside a dispatch would still be a breach.
+	Observed func() bool
+
+	// Rejections is the receiver's confinement rejection count, so "rejected
+	// and counted" is checked rather than assumed. A receiver that returns 400
+	// without counting fails here.
+	Rejections func() uint64
+}
+
+// HookReceiver wires one adapter's hook receiver into AssertHookPathConfined.
+// Every field is required.
+type HookReceiver struct {
+	// Root relocates the adapter's declared transcript root to a
+	// test-controlled directory — by t.Setenv of whatever env var moves it
+	// ($HOME, $CODEX_HOME) — creates it, and returns its absolute path. Called
+	// FIRST in every sub-test, before New.
+	Root func(t *testing.T) string
+
+	// New builds a fresh receiver, after Root has run. Fresh per sub-test so
+	// the rejection count starts at zero and Observed cannot carry over.
+	New func(t *testing.T) HookReceiverUnderTest
+
+	// WriteTranscript writes a transcript the adapter would dispatch on into
+	// dir, and returns its absolute path. The contract uses it for the in-tree
+	// fixture AND for the out-of-tree decoy, so a refusal can never be confused
+	// with "the file was unreadable" — the decoy is exactly as well-formed as
+	// the fixture, and the only thing standing between it and a dispatch is
+	// confinement.
+	WriteTranscript func(t *testing.T, dir string) string
+
+	// PayloadFor renders the adapter's hook JSON body carrying transcriptPath,
+	// on an event the adapter dispatches.
+	PayloadFor func(transcriptPath string) string
+
+	// EndpointPath is the adapter's hook route, used to build the request.
+	EndpointPath string
+}
+
+// AssertHookPathConfined runs the issue #1361 contract against r. Four
+// obligations, each independently failable:
+//
+//  1. a transcript inside the declared root is still ACCEPTED — the vacuity
+//     guard, without which a receiver that refuses everything passes 2–4 for
+//     entirely the wrong reason;
+//  2. a well-formed transcript outside every declared root is refused;
+//  3. a path whose lexical prefix IS the declared root but which climbs out of
+//     it with ".." is refused;
+//  4. a symlink INSIDE the declared root pointing at a file outside it is
+//     refused — the ordering obligation, and the only one a
+//     containment-before-resolution guard fails.
+//
+// Obligations 2–4 additionally require the refusal to be loud (a 4xx, never a
+// silent 200) and counted.
+func AssertHookPathConfined(t *testing.T, r HookReceiver) {
+	t.Helper()
+	t.Run("in_tree_path_accepted", func(t *testing.T) { assertInTreeAccepted(t, r) })
+	t.Run("out_of_tree_path_rejected", func(t *testing.T) { assertOutOfTreeRejected(t, r) })
+	t.Run("parent_traversal_rejected", func(t *testing.T) { assertTraversalRejected(t, r) })
+	t.Run("symlink_escape_rejected", func(t *testing.T) { assertSymlinkEscapeRejected(t, r) })
+}
+
+// assertInTreeAccepted is obligation 1. It runs first because every assertion
+// below it is a negative one, and a receiver that has stopped working at all
+// satisfies negative assertions perfectly.
+func assertInTreeAccepted(t *testing.T, r HookReceiver) {
+	t.Helper()
+	root := r.Root(t)
+	inTree := r.WriteTranscript(t, mkSubdir(t, root, "in-tree"))
+	rut := r.New(t)
+
+	rec := postHookPath(t, r, rut, inTree)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("in-tree transcript %s: status = %d, want 200 — confinement is refusing the adapter's own tree", inTree, rec.Code)
+	}
+	if !rut.Observed() {
+		t.Fatal("in-tree transcript was not dispatched — the rejection assertions below would pass vacuously")
+	}
+	if n := rut.Rejections(); n != 0 {
+		t.Errorf("in-tree transcript counted %d rejection(s), want 0", n)
+	}
+}
+
+// assertOutOfTreeRejected is obligation 2: a plain absolute path elsewhere.
+func assertOutOfTreeRejected(t *testing.T, r HookReceiver) {
+	t.Helper()
+	r.Root(t)
+	outside := r.WriteTranscript(t, t.TempDir())
+	assertRefused(t, r, outside, "a well-formed transcript outside every declared root")
+}
+
+// assertTraversalRejected is obligation 3: lexically inside, really outside.
+func assertTraversalRejected(t *testing.T, r HookReceiver) {
+	t.Helper()
+	root := r.Root(t)
+	outside := r.WriteTranscript(t, t.TempDir())
+	// Concatenated, not filepath.Join'd: Join cleans, and an already-cleaned
+	// path is not the input under test. Enough ".." to bottom out at "/",
+	// where further ones are absorbed.
+	traversal := root + strings.Repeat("/..", 32) + outside
+	assertRefused(t, r, traversal, "a path rooted in the declared tree that climbs out of it")
+}
+
+// assertSymlinkEscapeRejected is obligation 4 — the ordering obligation. The
+// submitted path is lexically inside the declared root and passes any
+// containment check applied to the raw string; only resolving it first reveals
+// that it leaves the tree.
+func assertSymlinkEscapeRejected(t *testing.T, r HookReceiver) {
+	t.Helper()
+	root := r.Root(t)
+	outside := r.WriteTranscript(t, t.TempDir())
+	link := filepath.Join(mkSubdir(t, root, "linked"), filepath.Base(outside))
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("symlink %s -> %s: %v", link, outside, err)
+	}
+	assertRefused(t, r, link, "a symlink inside the declared root pointing out of it (symlinks must be resolved BEFORE the containment check)")
+}
+
+// --- helpers ---
+
+// assertRefused drives one escape attempt against a fresh receiver and checks
+// all three properties a refusal owes: nothing dispatched, a loud status, and a
+// counted reason.
+func assertRefused(t *testing.T, r HookReceiver, path, what string) {
+	t.Helper()
+	rut := r.New(t)
+
+	rec := postHookPath(t, r, rut, path)
+	if rut.Observed() {
+		t.Errorf("%s was dispatched downstream: %s", what, path)
+	}
+	if rec.Code < 400 || rec.Code > 499 {
+		t.Errorf("%s: status = %d, want a 4xx — a refused path must not be answered with a success", what, rec.Code)
+	}
+	if n := rut.Rejections(); n != 1 {
+		t.Errorf("%s: counted %d rejection(s), want 1 — a refusal has to be countable, not just returned", what, n)
+	}
+}
+
+// postHookPath POSTs the adapter's hook body for path and returns the response.
+func postHookPath(t *testing.T, r HookReceiver, rut HookReceiverUnderTest, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, r.EndpointPath, strings.NewReader(r.PayloadFor(path)))
+	rec := httptest.NewRecorder()
+	rut.Handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// mkSubdir creates and returns root/name. Transcripts sit some levels below the
+// root in every real layout, so the fixtures do too.
+func mkSubdir(t *testing.T, root, name string) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("create %s: %v", dir, err)
+	}
+	return dir
+}

--- a/core/internal/contracttesting/hook_path_confinement.go
+++ b/core/internal/contracttesting/hook_path_confinement.go
@@ -112,8 +112,17 @@ type HookReceiver struct {
 //  6. the adapter's PRODUCTION constructor confines too, not merely whatever
 //     handler the test assembled.
 //
-// Obligations 2–5 additionally require the refusal to be loud (a 4xx, never a
-// silent 200) and counted.
+// Obligations 2–5 additionally require the refusal to be VISIBLE — counted by
+// the confiner, so an operator can see it — and to answer 2xx.
+//
+// The 2xx is asserted, not merely tolerated. A refused path is already fully
+// contained by not being forwarded, so the status code buys no security; what
+// it does buy is an untested interaction on the user's critical path. Claude
+// Code documents that a non-2xx from a `type: http` hook "can't block actions",
+// but not whether it surfaces an error; gemini-cli's pre-tool hooks and
+// Copilot's preToolUse are known to fail CLOSED on an error result. A receiver
+// added for one of those adapters must not answer 4xx, so the contract pins the
+// rule rather than leaving each adapter to rediscover it (issues #1361, #1364).
 func AssertHookPathConfined(t *testing.T, r HookReceiver) {
 	t.Helper()
 	t.Run("in_tree_path_accepted", func(t *testing.T) { assertInTreeAccepted(t, r) })
@@ -227,8 +236,8 @@ func assertRefusedBy(t *testing.T, r HookReceiver, rut HookReceiverUnderTest, pa
 	if rut.Observed() {
 		t.Errorf("%s was dispatched downstream: %s", what, path)
 	}
-	if rec.Code < 400 || rec.Code > 499 {
-		t.Errorf("%s: status = %d, want a 4xx — a refused path must not be answered with a success", what, rec.Code)
+	if rec.Code < 200 || rec.Code > 299 {
+		t.Errorf("%s: status = %d, want 2xx — a confinement refusal is reported by the log and the counter, never by a status code on the user's critical path", what, rec.Code)
 	}
 	if rut.Rejections == nil {
 		return

--- a/core/internal/contracttesting/hook_path_confinement.go
+++ b/core/internal/contracttesting/hook_path_confinement.go
@@ -78,6 +78,11 @@ type HookReceiver struct {
 	// confinement.
 	WriteTranscript func(t *testing.T, dir string) string
 
+	// TranscriptExt is the transcript file extension (e.g. ".jsonl"). Used to
+	// name a decoy that must NOT exist, which is why it is declared rather
+	// than read back off a throwaway WriteTranscript call.
+	TranscriptExt string
+
 	// PayloadFor renders the adapter's hook JSON body carrying transcriptPath,
 	// on an event the adapter dispatches.
 	PayloadFor func(transcriptPath string) string
@@ -183,7 +188,7 @@ func assertDanglingSymlinkRejected(t *testing.T, r HookReceiver) {
 	root := r.Root(t)
 	// A path in a directory the receiver has no claim on. Deliberately NOT
 	// created: the whole point is that it does not exist at confinement time.
-	target := filepath.Join(t.TempDir(), "planted"+filepath.Ext(r.WriteTranscript(t, t.TempDir())))
+	target := filepath.Join(t.TempDir(), "planted"+r.TranscriptExt)
 	link := filepath.Join(mkSubdir(t, root, "dangling"), filepath.Base(target))
 	if err := os.Symlink(target, link); err != nil {
 		t.Fatalf("symlink %s -> %s: %v", link, target, err)
@@ -199,13 +204,8 @@ func assertProductionConfines(t *testing.T, r HookReceiver) {
 	outside := r.WriteTranscript(t, t.TempDir())
 	rut := r.NewProduction(t)
 
-	rec := postHookPath(t, r, rut, outside)
-	if rut.Observed() {
-		t.Errorf("the adapter's production constructor dispatched an out-of-tree transcript: %s", outside)
-	}
-	if rec.Code < 400 || rec.Code > 499 {
-		t.Errorf("production constructor: status = %d, want a 4xx — confinement is not wired into the handler the daemon builds", rec.Code)
-	}
+	assertRefusedBy(t, r, rut, outside,
+		"an out-of-tree transcript at the adapter's PRODUCTION constructor (confinement must be wired into the handler the daemon builds, not only the one the test assembles)")
 }
 
 // --- helpers ---
@@ -215,14 +215,23 @@ func assertProductionConfines(t *testing.T, r HookReceiver) {
 // counted reason.
 func assertRefused(t *testing.T, r HookReceiver, path, what string) {
 	t.Helper()
-	rut := r.New(t)
+	assertRefusedBy(t, r, r.New(t), path, what)
+}
 
+// assertRefusedBy is assertRefused against an already-built receiver. The count
+// check is skipped when Rejections is nil, which is how NewProduction is
+// allowed to supply a receiver with no handle on the confiner.
+func assertRefusedBy(t *testing.T, r HookReceiver, rut HookReceiverUnderTest, path, what string) {
+	t.Helper()
 	rec := postHookPath(t, r, rut, path)
 	if rut.Observed() {
 		t.Errorf("%s was dispatched downstream: %s", what, path)
 	}
 	if rec.Code < 400 || rec.Code > 499 {
 		t.Errorf("%s: status = %d, want a 4xx — a refused path must not be answered with a success", what, rec.Code)
+	}
+	if rut.Rejections == nil {
+		return
 	}
 	if n := rut.Rejections(); n != 1 {
 		t.Errorf("%s: counted %d rejection(s), want 1 — a refusal has to be countable, not just returned", what, n)

--- a/core/internal/contracttesting/hook_path_confinement.go
+++ b/core/internal/contracttesting/hook_path_confinement.go
@@ -59,6 +59,17 @@ type HookReceiver struct {
 	// the rejection count starts at zero and Observed cannot carry over.
 	New func(t *testing.T) HookReceiverUnderTest
 
+	// NewProduction builds the receiver through the adapter's DEFAULT exported
+	// constructor — the one the daemon actually calls — rather than any
+	// test-only variant New may use to reach the rejection counter.
+	//
+	// Without it the contract only ever inspects a handler the test assembled,
+	// so an adapter could satisfy every obligation with a correctly wired test
+	// handler while its real constructor confines nothing: the #1361 hole,
+	// shipped past a green contract. Rejections may be nil here; the
+	// obligation this field serves is about reachability, not counting.
+	NewProduction func(t *testing.T) HookReceiverUnderTest
+
 	// WriteTranscript writes a transcript the adapter would dispatch on into
 	// dir, and returns its absolute path. The contract uses it for the in-tree
 	// fixture AND for the out-of-tree decoy, so a refusal can never be confused
@@ -86,9 +97,17 @@ type HookReceiver struct {
 //     it with ".." is refused;
 //  4. a symlink INSIDE the declared root pointing at a file outside it is
 //     refused — the ordering obligation, and the only one a
-//     containment-before-resolution guard fails.
+//     containment-before-resolution guard fails;
+//  5. a DANGLING symlink inside the declared root is refused. Resolution
+//     reports "does not exist" for a broken link exactly as it does for a file
+//     that has not been written yet, so a receiver that waves through an
+//     unresolvable leaf (a reasonable allowance — the hook fires around the
+//     write) hands the attacker an escape needing no race at all: plant the
+//     broken link, get the path accepted, then create the target;
+//  6. the adapter's PRODUCTION constructor confines too, not merely whatever
+//     handler the test assembled.
 //
-// Obligations 2–4 additionally require the refusal to be loud (a 4xx, never a
+// Obligations 2–5 additionally require the refusal to be loud (a 4xx, never a
 // silent 200) and counted.
 func AssertHookPathConfined(t *testing.T, r HookReceiver) {
 	t.Helper()
@@ -96,6 +115,8 @@ func AssertHookPathConfined(t *testing.T, r HookReceiver) {
 	t.Run("out_of_tree_path_rejected", func(t *testing.T) { assertOutOfTreeRejected(t, r) })
 	t.Run("parent_traversal_rejected", func(t *testing.T) { assertTraversalRejected(t, r) })
 	t.Run("symlink_escape_rejected", func(t *testing.T) { assertSymlinkEscapeRejected(t, r) })
+	t.Run("dangling_symlink_rejected", func(t *testing.T) { assertDanglingSymlinkRejected(t, r) })
+	t.Run("production_constructor_confines", func(t *testing.T) { assertProductionConfines(t, r) })
 }
 
 // assertInTreeAccepted is obligation 1. It runs first because every assertion
@@ -152,6 +173,39 @@ func assertSymlinkEscapeRejected(t *testing.T, r HookReceiver) {
 		t.Fatalf("symlink %s -> %s: %v", link, outside, err)
 	}
 	assertRefused(t, r, link, "a symlink inside the declared root pointing out of it (symlinks must be resolved BEFORE the containment check)")
+}
+
+// assertDanglingSymlinkRejected is obligation 5. The link is inside the root
+// and its target does not exist yet, so a guard that treats "cannot resolve" as
+// "not written yet" accepts it — and the attacker then creates the target.
+func assertDanglingSymlinkRejected(t *testing.T, r HookReceiver) {
+	t.Helper()
+	root := r.Root(t)
+	// A path in a directory the receiver has no claim on. Deliberately NOT
+	// created: the whole point is that it does not exist at confinement time.
+	target := filepath.Join(t.TempDir(), "planted"+filepath.Ext(r.WriteTranscript(t, t.TempDir())))
+	link := filepath.Join(mkSubdir(t, root, "dangling"), filepath.Base(target))
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink %s -> %s: %v", link, target, err)
+	}
+	assertRefused(t, r, link, "a dangling symlink inside the declared root (an unresolvable leaf must not be assumed to be an unflushed write)")
+}
+
+// assertProductionConfines is obligation 6: the confinement is reachable
+// through the constructor the daemon calls, not only the one the test wires.
+func assertProductionConfines(t *testing.T, r HookReceiver) {
+	t.Helper()
+	r.Root(t)
+	outside := r.WriteTranscript(t, t.TempDir())
+	rut := r.NewProduction(t)
+
+	rec := postHookPath(t, r, rut, outside)
+	if rut.Observed() {
+		t.Errorf("the adapter's production constructor dispatched an out-of-tree transcript: %s", outside)
+	}
+	if rec.Code < 400 || rec.Code > 499 {
+		t.Errorf("production constructor: status = %d, want a 4xx — confinement is not wired into the handler the daemon builds", rec.Code)
+	}
 }
 
 // --- helpers ---


### PR DESCRIPTION
Closes #1361

## Premise verified first

The issue asked for both statements to be checked against the code before anything was written. Both hold.

**`core/adapters/inbound/agents/codex/hooks.go:139-150` (before) — confines:**
```go
// transcript_path arrives in an HTTP body, so it is untrusted: any local
// process able to reach the hook port could otherwise steer the daemon into
// opening a file of its choosing. Confine it to the sessions tree before any
// read, and carry the confined path downstream so the target reads it too.
transcriptPath, ok := confineToSessionsDir(payload.TranscriptPath)
if !ok {
    w.WriteHeader(http.StatusOK)
    return
}
payload.TranscriptPath = transcriptPath
```

**`core/adapters/inbound/agents/claudecode/hooks.go:260-269` (before) — does not:**
```go
sessionID := sessionIDFromTranscriptPath(payload.TranscriptPath)
if sessionID == "" {
    http.Error(w, "bad request: missing transcript_path", http.StatusBadRequest)
    return
}

dispatch := func() {
    log.LogInfo(logComponentHookReceiver, sessionID,
        fmt.Sprintf("received %s (tool=%s)", payload.HookEventName, payload.ToolName))
    target.HandlePermissionHook(sessionID, payload.TranscriptPath, payload.HookEventName)
}
```

`sessionIDFromTranscriptPath` is `strings.TrimSuffix(filepath.Base(p), ".jsonl")` — a basename read, not a guard. The raw caller string then reached six downstream sinks: `HandlePermissionHook` (:269), `HandleCompactHook` (:304), `HandleStopHook` (:326), `HandleIdlePromptHook` (:347), `IngestTaskEstimate` (:382), `IngestTaskSummary` (:393).

## What changed

| File | Why |
|---|---|
| `core/adapters/inbound/agents/hookjson/confine.go` **(new)** | The shared `PathConfiner`: roots from `agent.Source`, symlinks resolved before containment, six named reject reasons, per-reason counters, and `RejectPath` (the uniform 400 + error log). |
| `core/adapters/inbound/agents/hookjson/confine_test.go` **(new)** | Unit coverage for the reason taxonomy, the counters, the missing-leaf allowance and its `..` guard. |
| `core/internal/contracttesting/hook_path_confinement.go` **(new)** | `AssertHookPathConfined` — four obligations so receivers 3–10 cannot skip confinement. |
| `core/adapters/inbound/agents/claudecode/hooks.go` | Confines before deriving the session id; forwards the confined path. `NewHookHandlerWithConfiner` + `TranscriptConfiner` added. |
| `core/adapters/inbound/agents/codex/hooks.go` | Same shared confiner replaces the adapter-local `confineToSessionsDir`; rejection is now 400, not a silent 200. |
| `core/adapters/inbound/agents/agentpaths/agentpaths.go` | `AbsRoot` — the absolute-or-`$HOME`-relative rule, exported once. |
| `core/adapters/inbound/agents/fswatcher/watcher.go` | `New` calls `AbsRoot` instead of carrying its own copy, so the guarded tree cannot drift from the watched one. |
| `core/adapters/inbound/agents/codex/session_meta.go` | Comment referenced the deleted `confineToSessionsDir`. |
| `core/adapters/inbound/agents/claudecode/hookconfine_test.go` **(new)** | The three defect tests + one lock + the in-tree fixture helpers. |
| `core/adapters/inbound/agents/{claudecode,codex}/hookpath_test.go` **(new)** | One-call contract wiring per adapter. |
| `core/adapters/inbound/agents/claudecode/hooks_test.go` | 21 fabricated `/Users/u/.claude/projects/p/*.jsonl` literals became real in-tree fixtures — they are now, correctly, refused. |
| `core/adapters/inbound/agents/codex/hooks_test.go` | Out-of-tree drop is now a 400; the unresolvable-id test moved inside the tree so it still covers what it meant to. |
| `AGENTS.md` | Documents the third contract family beside the other two. |

## Red-first evidence — the defect tests

Run on the pre-fix tree (`core/adapters/inbound/agents/claudecode/hookconfine_test.go`, fix not yet written):

```
=== RUN   TestHookHandler_OutOfTreeTranscriptRejected
    hookconfine_test.go:73: status: got 200, want 400 — an out-of-tree transcript_path must be rejected, not silently accepted
    hookconfine_test.go:76: handler forwarded an out-of-tree transcript_path to the detector: [{sessionID:11111111-2222-3333-4444-555555555555 transcriptPath:/var/folders/7l/.../002/11111111-2222-3333-4444-555555555555.jsonl hookEventName:PermissionRequest}]
--- FAIL: TestHookHandler_OutOfTreeTranscriptRejected (0.00s)
=== RUN   TestHookHandler_ParentTraversalTranscriptRejected
    hookconfine_test.go:99: status: got 200, want 400 — a parent-traversal transcript_path must be rejected
    hookconfine_test.go:102: handler forwarded a parent-traversal transcript_path to the detector: [{sessionID:11111111-2222-3333-4444-555555555555 transcriptPath:/var/folders/7l/.../001/.claude/projects/-Users-someone-repo/../../../../../../../../../../../../../../../../../../../../../../../../var/folders/7l/.../002/11111111-2222-3333-4444-555555555555.jsonl hookEventName:PermissionRequest}]
--- FAIL: TestHookHandler_ParentTraversalTranscriptRejected (0.00s)
=== RUN   TestHookHandler_SymlinkEscapeTranscriptRejected
    hookconfine_test.go:124: status: got 200, want 400 — a symlink inside the root pointing out of it must be rejected
    hookconfine_test.go:127: handler followed a symlink out of the declared root: [{sessionID:11111111-2222-3333-4444-555555555555 transcriptPath:/var/folders/7l/.../001/.claude/projects/-Users-someone-repo/11111111-2222-3333-4444-555555555555.jsonl hookEventName:PermissionRequest}]
--- FAIL: TestHookHandler_SymlinkEscapeTranscriptRejected (0.00s)
=== RUN   TestHookHandler_InTreeTranscriptStillAccepted
--- PASS: TestHookHandler_InTreeTranscriptStillAccepted (0.00s)
FAIL	irrlicht/core/adapters/inbound/agents/claudecode	0.284s
```

`TestHookHandler_InTreeTranscriptStillAccepted` is a **lock**, not a defect test — it pins the behaviour confinement must not break and passes on `main` by construction. The other three are the defect.

## Status code: fails open on the wire, loud in the log (resolves #1361 vs #1364)

Item 4 of this issue asked for a **400**; **#1364** tells the next agent that a hook receiver must keep answering **2xx** because a non-2xx can block or slow the user's turn. Those contradict, and the 400 was the only part of this change touching the user's critical path with an interaction nobody had observed.

**What I established.** Claude Code's hooks guide states, of `type: http` hooks: *"HTTP status codes alone can't block actions."* A non-2xx is a documented **non-blocking error**; blocking or denying requires **2xx plus a JSON decision body**. The claude `2.1.226` binary agrees — its HTTP hook client sets `validateStatus: () => true` and returns `{ok: status>=200 && status<300, statusCode, body}`, so a 400 is `ok:false`, not an exception. Documented timeout for `command`/`http`/`mcp_tool` is 10 minutes.

**What I could NOT establish — stated plainly, not inferred.** Whether `ok:false` surfaces an error to the user, is retried, or is only logged. The docs do not say, and **I did not run a live probe.** It is unknown.

**Decision: 2xx**, uniform across all three receivers, decided in exactly one place (`hookjson.RejectPath`), whose doc comment records the evidence and the gap. Rationale: the security property does not involve the status code at all — the path is not forwarded and nothing is opened either way — so a non-2xx buys nothing and spends an unknown on the critical path. "Never silently drop" is satisfied by the error log (reason + path) and the confiner's counter, which is where an operator looks. And the empty-bodied 200 is the response the success path already returns, i.e. the one interaction that is continuously exercised.

The contract now **asserts** the 2xx, so this is inherited rather than re-decided — which matters most for the adapters that do not exist yet: gemini-cli's pre-tool hooks fail **closed** (non-zero → `decision: "deny"`, tool skipped) and Copilot's `preToolUse` denies on error, so a receiver for either must not answer 4xx.

Two consequences worth noting: **codex now has no behaviour change at all** (this restores the 200 it returned before), and a **missing** `transcript_path` deliberately stays 400 — that is a malformed body rather than a verdict about a path, and both receivers already answered 400 for it on `main`.

**@ticket-owner: #1364 is the one that is right; #1361 item 4 is the one to correct.**

## Rebased onto main (2026-08-09)

`main` moved 4 commits mid-run, two of them into files this branch touches: **#1370** (`derive hook consent copy from installedHookEvents`) and **#1375** (`drive uninstall + recording-rig config lists off the agent registry`). Rebased; one real conflict in `AGENTS.md`, where #1356's new **Hook disclosure** contract bullet landed in the same list position as this PR's **Hook path confinement** bullet. Both are additive and both were kept.

The semantic re-read a clean textual merge would have missed: that list's closing sentence said *"All three contract families pass by construction"* on both sides — correct for main's three, correct for my count before #1356 landed, and **wrong for the merged four**. Corrected to "All four". Nothing else in the merged region contradicts itself; `go test ./core/... -race` and all 13 preflight gates were re-run green after the rebase.

Worth recording because it explains a CI mystery: while the PR was `CONFLICTING`, GitHub silently **stopped dispatching every `pull_request`-triggered workflow** (`Tests`, `Linux`, `ARS Architecture Gate`) — only push-triggered `web-test` kept running, so the checks list *looked* healthy while the Go gate had not run for two commits. A conflicting PR cannot have its merge ref computed, and the workflows that run against it just do not appear. `gh pr view --json mergeable` is the thing to check when a required check goes missing rather than red.

## Post-review changes

The review subagent (`high` effort) found a **real bypass of the guard's headline obligation**, plus six smaller issues; the `/simplify` pass then found a seventh receiver-level gap. Both are fixed in follow-up commits on this branch.

**The bypass — a dangling symlink defeated confinement.** `filepath.EvalSymlinks` returns an `fs.ErrNotExist`-wrapping error for a *broken* symlink exactly as it does for a file that was never written. My missing-leaf allowance (added so the write/hook race would not 400 a legitimate hook) could not tell them apart, so it resolved only the parent and returned the link itself unresolved. No race needed: plant `~/.claude/projects/p/<uuid>.jsonl → /tmp/evil.jsonl` while the target does not exist, get the path accepted, then create the target. `os.Lstat` now separates "absent from the directory" from "unresolvable", and the case is contract obligation 5.

**The seventh receiver.** `/api/v1/hooks/claudecode/statusline` sits on the same local unauthenticated mux, three lines away in `registerHookRoutes`, and was not confined. Its sink is a map lookup, not an open — so it was never an arbitrary-read hole, and the original PR body said so correctly. But once the *hook* receiver started forwarding the rebuilt confined path, the two receivers keyed `metrics.Adapter`'s tailer map with two different spellings of the same file. That divergence was introduced by this PR. It is now confined and wired into the contract. This PR arguing "confinement is a property of the receiver path, not a thing each adapter remembers" and then forgetting the third receiver is the clearest possible argument for the contract existing.

Also fixed: an empty declared root resolved to `$HOME` (fail-open, since `AllRootsFor` always returns at least one element); the extension guard read only the caller's string, so an in-tree symlink spelled `.jsonl` could launder a different target past it; the contract only ever exercised a handler the test assembled (obligation 6 now binds the production constructor); `FromEnv`'s rejected-override warning became per-request on an unauthenticated endpoint and is now deduped; `codexSessionsDir` was still deriving the sessions root from its own constants — the very drift this issue removed from the receiver, left behind in the installer; and per-request rebuilding of the whole `agent.Agent` to read one field (~1.7µs / 2KB per hook) is now a `Source()` call (~80ns / 16B).

## Deliberate-mutation evidence — the contract assertion

`AssertHookPathConfined` passes by construction against both adapters, so per AGENTS.md each obligation was seen red under a deliberate mutation of `hookjson/confine.go`. All five were applied, run against **both** adapters, and reverted.

**Mutation 1 — confiner rejects everything** (`if ... ok && false`). Catches a vacuous pass:
```
--- FAIL: TestHookPathConfined/in_tree_path_accepted
    hook_path_confinement.go:95: in-tree transcript .../projects/in-tree/11111111-....jsonl: status = 400, want 200 — confinement is refusing the adapter's own tree
```

**Mutation 2 — confiner accepts everything** (`return raw, RejectNone` at the top of `Confine`):
```
--- FAIL: TestHookPathConfined/out_of_tree_path_rejected
    a well-formed transcript outside every declared root was dispatched downstream: .../002/11111111-....jsonl
    ...: status = 200, want a 4xx — a refused path must not be answered with a success
    ...: counted 0 rejection(s), want 1 — a refusal has to be countable, not just returned
--- FAIL: TestHookPathConfined/parent_traversal_rejected      (same three)
--- FAIL: TestHookPathConfined/symlink_escape_rejected        (same three)
```

**Mutation 3 — drop the `..` guard in `containedIn`:**
```
--- FAIL: TestHookPathConfined/out_of_tree_path_rejected
--- FAIL: TestHookPathConfined/parent_traversal_rejected
--- FAIL: TestHookPathConfined/symlink_escape_rejected
```

**Mutation 4 — purely LEXICAL containment: no `EvalSymlinks` on the path or the root.** This is the ordering inversion the issue singled out, and the decisive result — it passes the in-tree, out-of-tree **and** traversal obligations and fails only the symlink one:
```
--- FAIL: TestHookPathConfined (0.00s)
    --- FAIL: TestHookPathConfined/symlink_escape_rejected (0.00s)
        hook_path_confinement.go:98: a symlink inside the declared root pointing out of it (symlinks must be resolved BEFORE the containment check) was dispatched downstream: .../001/projects/linked/11111111-2222-3333-4444-555555555555.jsonl
        hook_path_confinement.go:98: ...: status = 200, want a 4xx — a refused path must not be answered with a success
        hook_path_confinement.go:98: ...: counted 0 rejection(s), want 1 — a refusal has to be countable, not just returned
FAIL	irrlicht/core/adapters/inbound/agents/claudecode	0.393s
FAIL	irrlicht/core/adapters/inbound/agents/codex	0.777s
```
That is the issue's warning ("getting that order backwards passes a naive test and fixes nothing") reproduced as a failing assertion.

An earlier attempt at mutation 4 — containment on the raw path but with the root still `EvalSymlinks`-resolved — is recorded as **rejected**: on macOS `/var → /private/var`, so it broke the in-tree case too and did not isolate the ordering obligation. The lexical version is the faithful naive implementation.

**Mutation 5 — reason returned but not counted** (the counter increment neutered). Isolates the "counted" half:
```
--- FAIL: TestHookPathConfined/out_of_tree_path_rejected
--- FAIL: TestHookPathConfined/parent_traversal_rejected
--- FAIL: TestHookPathConfined/symlink_escape_rejected
--- FAIL: TestHookPathConfined/dangling_symlink_rejected
--- FAIL: TestStatuslinePathConfined/... (same four)
```

**Mutation 6 — the dangling-link guard disabled** (`os.Lstat` consulted but ignored). Isolates obligation 5, and nothing else:
```
--- FAIL: TestHookPathConfined/dangling_symlink_rejected
--- FAIL: TestStatuslinePathConfined/dangling_symlink_rejected
FAIL	irrlicht/core/adapters/inbound/agents/claudecode	0.512s
FAIL	irrlicht/core/adapters/inbound/agents/codex	0.876s
```

**Mutation 7 — the production constructor built without confinement** (`NewHookHandler` handed a permissive confiner). Isolates obligation 6, and nothing else:
```
--- FAIL: TestHookPathConfined/production_constructor_confines
    hook_path_confinement.go:119: the adapter's production constructor dispatched an out-of-tree transcript: .../002/11111111-....jsonl
    hook_path_confinement.go:119: production constructor: status = 200, want a 4xx — confinement is not wired into the handler the daemon builds
```

All seven were re-run against the final (post-review, post-simplify) code, since both passes changed `resolvePath` and the counter representation. Mutation 4 now fails obligations 4 *and* 5 — a dangling link also survives purely lexical containment — which is a strictly stronger result than the original.

## Behaviour changes worth a reviewer's attention

1. **codex out-of-tree: 200 → 400.** Issue item 4 ("never silently drop") mandates this. It is the only intentional response-code regression.
2. **A transcript not yet on disk is accepted** when its directory is inside the tree. The hook fires around the write, so refusing an unflushed file would 400 a legitimate hook. Only the leaf may be missing, and only when the path carries no `..` — a `..` cannot be resolved without the filesystem, and resolving it lexically is the bypass itself (`TestConfine_MissingLeafCannotSmuggleParentRefs`).
3. **The accepted path is rebuilt on the DECLARED root, not the symlink-resolved one.** Downstream state is keyed by transcript path (`metrics.Adapter.tailers[transcriptPath]`), and fswatcher's paths are not symlink-resolved — returning the resolved spelling would key a second, phantom session on machines whose `$HOME` sits behind a symlink.

## Verification

`tools/preflight.sh` (full, unscoped) — all 13 gates:
```
  gofmt                                                      PASS
  core module tests                                          PASS
  onboarding-factory tests                                   PASS
  replaydata validate                                        PASS
  recording-rig smoke test                                   PASS
  replay fixtures                                            PASS
  starhistory tests                                          PASS
  web: platforms/web                                         PASS
  web: onboarding-factory viewer                             PASS
  ARS architecture gate                                      PASS
  tools/lib shell-lib tests                                  PASS
  skill-file lint                                            PASS
  security scan (govulncheck + gosec + npm audit)            PASS
```
Plus `go test ./core/... -race -count=1` — clean.

## Deliberately not done

- **A mux-level middleware** that confines before any handler runs. Considered and rejected: it would have to key on a top-level `"transcript_path"` JSON field (true of all three payloads today) and would **fail open** for any future payload that nests or renames it — finding nothing, confining nothing, while `registerHookRoutes` still looks guarded. That is strictly worse than an explicit per-receiver call, which fails closed. The better deep fix is a shared `hookjson.DecodeConfined` at the one step no receiver can skip (the body decode), plus an `architecture_test.go` rule that no hook-receiving file calls `json.NewDecoder(r.Body)` directly — that would make confinement a *build* failure rather than a contract a new adapter must remember to wire. Filed as **#1389**.
- **Collapsing the two constructors per adapter** — now filed as #1390. `NewHookHandlerWithConfiner` exists so the contract can read the rejection counter, and obligation 6 exists to police that split. Returning a small `HookHandler{http.HandlerFunc; Confiner}` from `NewHookHandler` would delete both — but it changes the return type at ~25 existing test call sites plus `startup.go`, which is a design call for the maintainer rather than an autonomous refactor at the end of a run. Filed as **#1390**.
- **Caching the resolved roots.** `containedIn` re-runs `AbsRoot` + `EvalSymlinks` per declared root per request (~11µs, ~4 `lstat`, 42% of a `Confine` call), and the rejection path resolves every root before refusing. A cache keyed on the declared-roots slice would be exact — but it adds invalidation state to save microseconds on a low-rate path, which is the wrong trade for a guard. Not done, deliberately.
- **Deleting the three hand-rolled claudecode defect tests** that the contract now subsumes. They are the red-first record AGENTS.md requires; the contract is not a substitute for evidence that the bug was real.
- **No counter is published anywhere.** The daemon has no counter registry (no expvar, no Prometheus, no stats endpoint), so "counted" is a per-receiver counter with an accessor, which the contract asserts on. Wiring it to an operator-visible surface is out of scope.
- **No grace-timer / hysteresis work** — that is the separate residual #1355 names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
