### PR TITLE
fix(hookjson): preserve comments, key order and `&&` across a hook install

### DIFF
--- a/core/adapters/inbound/agents/hookjson/fallback.go
+++ b/core/adapters/inbound/agents/hookjson/fallback.go
@@ -1,0 +1,115 @@
+package hookjson
+
+// Observability for the splicer's degradations (issue #1371).
+//
+// jsonc.go rewrites the user's agent config by hand-computed byte arithmetic,
+// and it protects itself two ways: an edit it cannot make safely falls back to
+// re-encoding the whole document, and an edit it did make is re-decoded and
+// compared against the document it claims to represent before being returned.
+// Both are the right mitigation. Both are also silent — the file stays valid,
+// the install succeeds, and the only thing the user loses is the comments and
+// key order this package exists to preserve.
+//
+// A mitigation nobody can see is a mitigation nobody learns from. Review of
+// PR #1381 found four separate ways the arithmetic could corrupt a config, one
+// of them firing on ~11% of randomly shaped documents and reachable by an
+// ordinary permission toggle; every one was found by a test, because there was
+// nothing in the field to find it with. So each degradation is counted.
+//
+// FallbackVerifyFailed is the one that matters. The other three are designed
+// paths — shapes the splicer knowingly declines. A non-zero verify_failed means
+// the splicer produced output its own verifier rejected: a bug in jsonc.go, not
+// a quirk of the user's file.
+//
+// This mirrors PathConfiner's rejection counters in confine.go deliberately —
+// same package, same problem, same shape: make a refusal countable rather than
+// merely returned.
+
+import "sync/atomic"
+
+// FallbackReason names why a document was re-encoded whole instead of spliced.
+type FallbackReason string
+
+const (
+	// FallbackNone is the zero value: the splice was used.
+	FallbackNone FallbackReason = ""
+	// FallbackUnsupportedShape — the document, or a container in it, has no
+	// in-place edit this package knows how to make.
+	FallbackUnsupportedShape FallbackReason = "unsupported_shape"
+	// FallbackOverlappingEdits — two edits claimed the same bytes, which means
+	// the separator arithmetic disagrees with itself.
+	FallbackOverlappingEdits FallbackReason = "overlapping_edits"
+	// FallbackVerifyFailed — the spliced bytes did not decode back to the
+	// document they were built from. The splice was discarded. This one is a
+	// defect in jsonc.go; the others are not.
+	FallbackVerifyFailed FallbackReason = "verify_failed"
+	// FallbackArrayRewrite — one array was re-encoded rather than edited,
+	// because a new element belongs somewhere other than its tail or the array
+	// is too large to align. Scoped to that array; the rest of the document is
+	// still spliced.
+	FallbackArrayRewrite FallbackReason = "array_rewrite"
+)
+
+// fallbackReasons is every reason in a fixed order, so each has a stable
+// counter slot. FallbackNone is deliberately absent — it is not a fallback.
+var fallbackReasons = [...]FallbackReason{
+	FallbackUnsupportedShape,
+	FallbackOverlappingEdits,
+	FallbackVerifyFailed,
+	FallbackArrayRewrite,
+}
+
+// fallbackCounts holds one counter per reason, indexed by fallbackReasons
+// order. Package-level rather than per-instance because the splicer is reached
+// through package functions (ReadSettings/WriteSettings are what the adapters
+// and the statusline installer share), and atomics rather than a mutex-guarded
+// map for the same reason confine.go gives: these exist to observe a burst, so
+// instrumentation that serializes exactly when events arrive together would
+// blunt what it measures.
+var fallbackCounts [len(fallbackReasons)]atomic.Uint64
+
+// countFallback records one degradation and returns the reason, so a call site
+// can both count and report in one expression.
+func countFallback(reason FallbackReason) FallbackReason {
+	for i, r := range fallbackReasons {
+		if r == reason {
+			fallbackCounts[i].Add(1)
+			return reason
+		}
+	}
+	return reason
+}
+
+// noSafeSplice counts a whole-document fallback and returns the sentinel that
+// routes the caller to encodeDocument.
+func noSafeSplice(reason FallbackReason) error {
+	countFallback(reason)
+	return errNoSafeSplice
+}
+
+// Fallbacks returns a snapshot of the per-reason counts, omitting zeros.
+// Nothing surfaces these to a UI yet — there is no daemon-wide counter registry
+// to publish into — but they make "degraded and counted" an observable fact
+// rather than a claim, which is what this package's tests check.
+//
+// A non-zero FallbackVerifyFailed is the signal worth acting on: it says this
+// package built bytes that failed its own verification, and the user silently
+// lost the comments and key order the splice existed to keep.
+func Fallbacks() map[FallbackReason]uint64 {
+	out := make(map[FallbackReason]uint64, len(fallbackReasons))
+	for i, reason := range fallbackReasons {
+		if n := fallbackCounts[i].Load(); n > 0 {
+			out[reason] = n
+		}
+	}
+	return out
+}
+
+// FallbackCount is the total across every reason.
+func FallbackCount() uint64 {
+	var total uint64
+	for i := range fallbackReasons {
+		total += fallbackCounts[i].Load()
+	}
+	return total
+}

--- a/core/adapters/inbound/agents/hookjson/hookjson.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson.go
@@ -149,12 +149,20 @@ func Uninstall(cfg Config) (bool, error) {
 // Exported because claudecode's statusline installer merges into the same
 // settings.json and must read it exactly the same way.
 //
-// Comments are tolerated (issue #1371). gemini-cli's ~/.gemini/settings.json is
-// JSONC by design, and a `//` in a config that documents itself is not
-// malformed input — before this, an install into such a file failed the parse
-// and merged nothing at all. Comments are blanked to spaces rather than
-// stripped, so any error the decoder does report still points at the byte the
-// user has to go fix.
+// Comments are tolerated (issue #1371), for every caller rather than per
+// adapter. The file this is for is gemini-cli's ~/.gemini/settings.json, which
+// is JSONC by design — no caller reads it yet, and this is the prerequisite for
+// the one that will (#1355 Phase D). Tolerating them everywhere rather than
+// behind a Config flag is deliberate: the two files read today are strict JSON,
+// so a comment in one means the user's own agent cannot load it either, and
+// erroring here neither tells them that nor fixes it. Comments are blanked to
+// spaces rather than stripped, so any error the decoder does report still
+// points at the byte the user has to go fix.
+//
+// Not established: whether Claude Code and Codex themselves accept comments in
+// those files. If they do not, an install into a commented one now reports
+// success where it used to report a parse error — for a config their agent was
+// already failing to load.
 //
 // What has NOT changed is the treatment of genuinely broken JSON: it still
 // errors, and the file is still never overwritten. Issue #1362 is making that

--- a/core/adapters/inbound/agents/hookjson/hookjson.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson.go
@@ -224,7 +224,7 @@ func renderSettings(original []byte, settings map[string]interface{}) ([]byte, e
 		return encodeDocument(settings)
 	}
 	data, err := spliceSettings(original, settings)
-	if errors.Is(err, errUnsupportedShape) {
+	if errors.Is(err, errNoSafeSplice) {
 		return encodeDocument(settings)
 	}
 	if err != nil {

--- a/core/adapters/inbound/agents/hookjson/hookjson.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson.go
@@ -22,6 +22,7 @@ package hookjson
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 )
@@ -128,6 +129,16 @@ func Uninstall(cfg Config) (bool, error) {
 		return false, nil
 	}
 
+	// Our removals emptied the "hooks" object, so drop it: on a config that had
+	// no hooks before we installed, leaving `"hooks": {}` behind means revoking
+	// consent does not give the user their file back (issue #1371). Gated on
+	// having actually removed something, so a user's own pre-existing empty
+	// object — which never reaches here, because modified stays false — is not
+	// touched. A user hook in any event keeps the object non-empty and it stays.
+	if len(hooksMap) == 0 {
+		delete(settings, "hooks")
+	}
+
 	return true, WriteSettings(cfg.Path, settings, cfg.WriteFile)
 }
 
@@ -137,6 +148,19 @@ func Uninstall(cfg Config) (bool, error) {
 // JSON does error: overwriting it would destroy content the user meant to keep.
 // Exported because claudecode's statusline installer merges into the same
 // settings.json and must read it exactly the same way.
+//
+// Comments are tolerated (issue #1371). gemini-cli's ~/.gemini/settings.json is
+// JSONC by design, and a `//` in a config that documents itself is not
+// malformed input — before this, an install into such a file failed the parse
+// and merged nothing at all. Comments are blanked to spaces rather than
+// stripped, so any error the decoder does report still points at the byte the
+// user has to go fix.
+//
+// What has NOT changed is the treatment of genuinely broken JSON: it still
+// errors, and the file is still never overwritten. Issue #1362 is making that
+// error visible rather than swallowed by the callers; it is the correct
+// behavior, and TestReadSettings_MalformedJSONErrors plus
+// TestMalformedInput_IsNeverOverwritten pin it.
 //
 // A file holding a bare `null` decodes to a nil map with no error, which every
 // later write would panic on ("assignment to entry in nil map"), so it is
@@ -154,7 +178,7 @@ func ReadSettings(path string) (map[string]interface{}, error) {
 		return map[string]interface{}{}, nil
 	}
 	var settings map[string]interface{}
-	if err := json.Unmarshal(data, &settings); err != nil {
+	if err := json.Unmarshal(blankComments(data), &settings); err != nil {
 		return nil, err
 	}
 	if settings == nil {
@@ -163,16 +187,50 @@ func ReadSettings(path string) (map[string]interface{}, error) {
 	return settings, nil
 }
 
-// WriteSettings re-serializes settings (2-space indented, trailing newline —
-// the shape a hand-edited config file expects) and hands the bytes to writeFile.
+// WriteSettings persists settings to path and hands the bytes to writeFile.
 // Exported alongside ReadSettings for the same statusline caller.
+//
+// It re-reads the file it is about to replace so it can change as little of it
+// as possible: the wanted document is compared against the one on disk and only
+// the byte ranges that actually differ are rewritten (issue #1371). That is what
+// keeps a hand-maintained config intact — comments, key order, blank lines and
+// an unescaped `&&` all survive because those bytes are copied, not
+// re-serialized. See jsonc.go for how.
+//
+// Only when there is nothing to preserve — no file, or an empty one — is the
+// document encoded from scratch, 2-space indented with a trailing newline,
+// which is the shape a hand-edited config expects.
+//
+// The re-read cannot resurrect content the caller already dropped: callers
+// obtain settings from ReadSettings on the same path moments earlier, so the
+// bytes read here are the bytes that decoded into what they mutated.
 func WriteSettings(path string, settings map[string]interface{}, writeFile func(path string, data []byte) error) error {
-	data, err := json.MarshalIndent(settings, "", "  ")
+	original, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	data, err := renderSettings(original, settings)
 	if err != nil {
 		return err
 	}
-	data = append(data, '\n')
 	return writeFile(path, data)
+}
+
+// renderSettings produces the bytes to write: a minimal splice of the original
+// when there is one, a fresh encode when there is not.
+func renderSettings(original []byte, settings map[string]interface{}) ([]byte, error) {
+	if len(bytes.TrimSpace(original)) == 0 {
+		return encodeDocument(settings)
+	}
+	data, err := spliceSettings(original, settings)
+	if errors.Is(err, errUnsupportedShape) {
+		return encodeDocument(settings)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
 }
 
 // HasOurHook reports whether any matcher group carrying sentinel already exists

--- a/core/adapters/inbound/agents/hookjson/jsonc.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc.go
@@ -418,14 +418,17 @@ func spliceSettings(original []byte, want map[string]interface{}) ([]byte, error
 
 	out, ok := applyEdits(original, edits)
 	if !ok {
-		return nil, errNoSafeSplice
+		return nil, noSafeSplice(FallbackOverlappingEdits)
 	}
 	if !decodesTo(out, normalized) {
 		// The edit arithmetic produced something that is not the document we
 		// were asked for. Never write it: a corrupted settings.json breaks the
 		// agent and every later install, whereas re-encoding merely costs the
 		// comments this package exists to protect.
-		return nil, errNoSafeSplice
+		//
+		// Counted, and the only reason that means a defect here rather than a
+		// shape we declined — see fallback.go.
+		return nil, noSafeSplice(FallbackVerifyFailed)
 	}
 	return out, nil
 }
@@ -756,8 +759,11 @@ func (s *splicer) diffArray(n *jsonNode, want []interface{}, depth int, edits *[
 	plan, ok := alignArray(have, want)
 	if !ok {
 		// An insertion somewhere other than the tail has no separator we can
-		// hang an edit off without guessing. Rewriting the array wholesale
-		// costs only the comments inside this one array, and never corrupts.
+		// hang an edit off without guessing, and an oversized array is not
+		// worth a quadratic table. Rewriting the array wholesale costs only the
+		// comments inside this one array, and never corrupts — but it is still
+		// a silent loss, so it is counted (fallback.go).
+		countFallback(FallbackArrayRewrite)
 		return s.replaceNode(n, want, depth, edits)
 	}
 
@@ -805,7 +811,7 @@ func (s *splicer) applyContainerEdits(n *jsonNode, items []itemSpan, removed []i
 	if tail := trailingRun(len(items), removed); tail >= 0 && len(body) > 0 {
 		comma := s.nextComma(items[tail-1].end)
 		if comma < 0 {
-			return errNoSafeSplice
+			return noSafeSplice(FallbackUnsupportedShape)
 		}
 		*edits = append(*edits, edit{
 			start: s.trailerEnd(comma + 1),
@@ -814,13 +820,13 @@ func (s *splicer) applyContainerEdits(n *jsonNode, items []itemSpan, removed []i
 		})
 		earlier := removed[:len(removed)-(len(items)-tail)]
 		if len(earlier) > 0 && !s.removeItems(items, earlier, edits) {
-			return errNoSafeSplice
+			return noSafeSplice(FallbackUnsupportedShape)
 		}
 		return nil
 	}
 
 	if len(removed) > 0 && !s.removeItems(items, removed, edits) {
-		return errNoSafeSplice
+		return noSafeSplice(FallbackUnsupportedShape)
 	}
 	if len(body) > 0 {
 		s.appendItems(items[len(items)-1], body, itemIndent, edits)

--- a/core/adapters/inbound/agents/hookjson/jsonc.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc.go
@@ -1,0 +1,799 @@
+package hookjson
+
+// Lossless read-modify-write for hand-maintained JSON(C) settings files
+// (issue #1371).
+//
+// The problem this file solves is that the merge logic in hookjson.go works on
+// a generic map[string]interface{} — which is the right shape for the merge,
+// and the wrong shape for a file the user edits by hand. A map has no comments,
+// no key order and no formatting, so re-serializing one with
+// json.MarshalIndent destroys all three at once:
+//
+//   - comments vanish. gemini-cli's ~/.gemini/settings.json is JSONC: the CLI
+//     reads it through stripJsonComments and writes it back through the
+//     comment-json package precisely to keep them. Today they don't even
+//     survive the *read* — encoding/json rejects the file outright, so an
+//     install into a commented config fails rather than merging;
+//   - key order becomes alphabetical, silently reshuffling a file the user
+//     organized deliberately;
+//   - `<`, `>` and `&` are HTML-escaped into their six-character \u00xx
+//     escapes, so a perfectly ordinary `npm run build && npm run list-tools`
+//     comes back with each ampersand replaced by a backslash-u-0026.
+//
+// The strategy is to never re-serialize what we did not change. Writing works
+// on byte ranges of the original file: the wanted document is structurally
+// compared against the original, and only the ranges that actually differ are
+// replaced. Everything else — every comment, every blank line, the user's key
+// order, their indentation, and their unescaped `&&` — is passed through as the
+// original bytes, because it literally is the original bytes.
+//
+// Two pieces make that possible:
+//
+//   - blankComments overwrites each comment with spaces *in place*. The result
+//     is valid JSON that encoding/json can parse, and because blanking
+//     preserves length, every byte offset in it still indexes the same byte of
+//     the original. That is what lets a parser that has never heard of comments
+//     hand back offsets usable against a file full of them.
+//   - parseSpans records, for every value in the document, the byte range it
+//     occupies. It uses encoding/json's own Decoder token stream rather than a
+//     hand-written JSON parser, so the only bespoke lexing in this file is the
+//     comment blanker.
+//
+// Deliberately NOT changed here: what happens on genuinely malformed input.
+// A file that is not valid JSON once its comments are blanked still errors, and
+// is never overwritten — see ReadSettings. Issue #1362 is making that error
+// visible to the user rather than swallowed; it is correct behavior, not a
+// defect, and there is a test pinning it.
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// errUnsupportedShape marks a document whose top level is something we have no
+// safe in-place edit for. The caller falls back to a whole-document encode.
+var errUnsupportedShape = errors.New("hookjson: unsupported document shape")
+
+// --- comment blanking ---
+
+// blankComments returns a copy of src with every JSONC comment overwritten by
+// spaces. Newlines inside block comments are kept so line numbers — and, more
+// importantly, byte offsets — are identical to src. The result is what gets
+// parsed; the original is what gets copied from.
+func blankComments(src []byte) []byte {
+	out := make([]byte, len(src))
+	copy(out, src)
+
+	inString := false
+	for i := 0; i < len(src); i++ {
+		c := src[i]
+		if inString {
+			switch c {
+			case '\\':
+				i++ // an escaped byte can never close the string
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch {
+		case c == '"':
+			inString = true
+		case c == '/' && i+1 < len(src) && src[i+1] == '/':
+			i = blankLineComment(src, out, i) - 1
+		case c == '/' && i+1 < len(src) && src[i+1] == '*':
+			i = blankBlockComment(src, out, i) - 1
+		}
+	}
+	return out
+}
+
+// blankLineComment blanks from i up to (not including) the next newline and
+// returns the index it stopped at.
+func blankLineComment(src, out []byte, i int) int {
+	for i < len(src) && src[i] != '\n' {
+		out[i] = ' '
+		i++
+	}
+	return i
+}
+
+// blankBlockComment blanks from i through the closing `*/` (or to end of input
+// when unterminated, which then fails the parse) and returns the index just
+// past it. Newlines survive so offsets and line structure are unchanged.
+func blankBlockComment(src, out []byte, i int) int {
+	for i < len(src) {
+		if src[i] == '*' && i+1 < len(src) && src[i+1] == '/' {
+			out[i], out[i+1] = ' ', ' '
+			return i + 2
+		}
+		if src[i] != '\n' {
+			out[i] = ' '
+		}
+		i++
+	}
+	return i
+}
+
+// --- span-recording parse ---
+
+// jsonNode is one value in the document plus the byte range it occupies.
+// Offsets index the blanked text, which by construction indexes the original.
+type jsonNode struct {
+	kind    byte // '{', '[', or 's' for any scalar
+	start   int
+	end     int
+	members []jsonMember // kind '{', in document order
+	elems   []*jsonNode  // kind '[', in document order
+}
+
+type jsonMember struct {
+	key      string
+	keyStart int // offset of the opening quote of the key
+	value    *jsonNode
+}
+
+// parseSpans decodes blanked (valid JSON) recording every value's byte range.
+func parseSpans(blanked []byte) (*jsonNode, error) {
+	dec := json.NewDecoder(bytes.NewReader(blanked))
+	dec.UseNumber()
+	n, err := parseNode(dec, blanked)
+	if err != nil {
+		return nil, err
+	}
+	return n, nil
+}
+
+// tokenStart returns the offset of the next token, given the offset just past
+// the previous one. Only whitespace and structural punctuation can sit between
+// two tokens, and no value ever begins with those — so skipping them lands
+// exactly on the token. Blanked comments are spaces here, so they skip too.
+func tokenStart(src []byte, from int) int {
+	for from < len(src) {
+		switch src[from] {
+		case ' ', '\t', '\r', '\n', ',', ':':
+			from++
+		default:
+			return from
+		}
+	}
+	return from
+}
+
+func parseNode(dec *json.Decoder, src []byte) (*jsonNode, error) {
+	start := tokenStart(src, int(dec.InputOffset()))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	delim, isDelim := tok.(json.Delim)
+	if !isDelim {
+		return &jsonNode{kind: 's', start: start, end: int(dec.InputOffset())}, nil
+	}
+
+	switch delim {
+	case '{':
+		return parseObject(dec, src, start)
+	case '[':
+		return parseArray(dec, src, start)
+	}
+	return nil, errUnsupportedShape
+}
+
+func parseObject(dec *json.Decoder, src []byte, start int) (*jsonNode, error) {
+	n := &jsonNode{kind: '{', start: start}
+	for dec.More() {
+		keyStart := tokenStart(src, int(dec.InputOffset()))
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, errUnsupportedShape
+		}
+		value, err := parseNode(dec, src)
+		if err != nil {
+			return nil, err
+		}
+		n.members = append(n.members, jsonMember{key: key, keyStart: keyStart, value: value})
+	}
+	if _, err := dec.Token(); err != nil { // the closing '}'
+		return nil, err
+	}
+	n.end = int(dec.InputOffset())
+	return n, nil
+}
+
+func parseArray(dec *json.Decoder, src []byte, start int) (*jsonNode, error) {
+	n := &jsonNode{kind: '[', start: start}
+	for dec.More() {
+		elem, err := parseNode(dec, src)
+		if err != nil {
+			return nil, err
+		}
+		n.elems = append(n.elems, elem)
+	}
+	if _, err := dec.Token(); err != nil { // the closing ']'
+		return nil, err
+	}
+	n.end = int(dec.InputOffset())
+	return n, nil
+}
+
+// --- layout ---
+
+// layout is the formatting of the file we are editing, so inserted text looks
+// like the user wrote it rather than like a serializer emitted it.
+type layout struct {
+	newline string
+	indent  string // one indentation unit
+}
+
+func detectLayout(orig, blanked []byte) layout {
+	lay := layout{newline: "\n", indent: "  "}
+	if bytes.Contains(orig, []byte("\r\n")) {
+		lay.newline = "\r\n"
+	}
+	// The first line that is indented and carries content gives the unit: at
+	// that point we are exactly one level deep. Comment lines are all-spaces in
+	// the blanked text and skip themselves.
+	for _, line := range bytes.Split(blanked, []byte("\n")) {
+		line = bytes.TrimRight(line, "\r")
+		body := bytes.TrimLeft(line, " \t")
+		if len(body) == 0 || len(body) == len(line) {
+			continue
+		}
+		lay.indent = string(line[:len(line)-len(body)])
+		break
+	}
+	return lay
+}
+
+func lineStart(src []byte, pos int) int {
+	if i := bytes.LastIndexByte(src[:pos], '\n'); i >= 0 {
+		return i + 1
+	}
+	return 0
+}
+
+// indentOfLine returns the whitespace a value is indented by, and false when
+// the value does not start its own line (so there is no indent to copy).
+func indentOfLine(src []byte, pos int) (string, bool) {
+	ls := lineStart(src, pos)
+	i := ls
+	for i < pos && (src[i] == ' ' || src[i] == '\t') {
+		i++
+	}
+	if i != pos {
+		return "", false
+	}
+	return string(src[ls:pos]), true
+}
+
+// containerIndents returns the indent for a container's items and for its
+// closing bracket. Observed indentation wins over a computed one, so an
+// irregularly formatted file keeps its own shape.
+func containerIndents(blanked []byte, n *jsonNode, depth int, lay layout) (item string, closing string) {
+	closing = strings.Repeat(lay.indent, depth)
+	if observed, ok := indentOfLine(blanked, n.start); ok {
+		closing = observed
+	}
+	item = closing + lay.indent
+	if len(n.members) > 0 {
+		if observed, ok := indentOfLine(blanked, n.members[0].keyStart); ok {
+			item = observed
+		}
+	} else if len(n.elems) > 0 {
+		if observed, ok := indentOfLine(blanked, n.elems[0].start); ok {
+			item = observed
+		}
+	}
+	return item, closing
+}
+
+// --- edits ---
+
+type edit struct {
+	start, end int
+	text       []byte
+}
+
+// applyEdits splices edits into orig. Insertions share a position with the edit
+// they follow, so the sort must be stable to keep them in the order emitted.
+func applyEdits(orig []byte, edits []edit) []byte {
+	sort.SliceStable(edits, func(i, j int) bool { return edits[i].start < edits[j].start })
+	var out bytes.Buffer
+	prev := 0
+	for _, e := range edits {
+		if e.start < prev {
+			continue // defensive: overlapping edits, keep the earlier one
+		}
+		out.Write(orig[prev:e.start])
+		out.Write(e.text)
+		prev = e.end
+	}
+	out.Write(orig[prev:])
+	return out.Bytes()
+}
+
+// --- encoding ---
+
+// encodeValue renders v the way this package writes JSON: two-space-style
+// indentation taken from the file, and no HTML escaping, so `&&` stays `&&`.
+// prefix is the indentation of the line the value starts on; the first line
+// carries none because it follows a `"key": `.
+func encodeValue(v interface{}, prefix string, lay layout) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent(prefix, lay.indent)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	out := bytes.TrimRight(buf.Bytes(), "\n")
+	if lay.newline != "\n" {
+		out = bytes.ReplaceAll(out, []byte("\n"), []byte(lay.newline))
+	}
+	return out, nil
+}
+
+// encodeDocument renders a whole settings document from scratch — the path
+// taken when there is no original file to preserve. The two-space indent and
+// trailing newline are the shape a hand-edited config expects, and are pinned
+// by TestWriteSettings_ShapeAndDelegation.
+func encodeDocument(settings map[string]interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(settings); err != nil { // Encode appends the newline
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func encodeKey(key string) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(key); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// renderMembers renders `"k": v` pairs joined by a comma and a newline, each
+// continuation line indented by indent.
+func renderMembers(keys []string, want map[string]interface{}, indent string, lay layout) ([]byte, error) {
+	var buf bytes.Buffer
+	for i, k := range keys {
+		if i > 0 {
+			buf.WriteString("," + lay.newline + indent)
+		}
+		key, err := encodeKey(k)
+		if err != nil {
+			return nil, err
+		}
+		value, err := encodeValue(want[k], indent, lay)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(key)
+		buf.WriteString(": ")
+		buf.Write(value)
+	}
+	return buf.Bytes(), nil
+}
+
+func renderElems(values []interface{}, indent string, lay layout) ([]byte, error) {
+	var buf bytes.Buffer
+	for i, v := range values {
+		if i > 0 {
+			buf.WriteString("," + lay.newline + indent)
+		}
+		value, err := encodeValue(v, indent, lay)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(value)
+	}
+	return buf.Bytes(), nil
+}
+
+// --- separator arithmetic ---
+//
+// Insertion and removal are written as exact inverses of each other, which is
+// what makes install-then-uninstall byte-identical. Appending an item emits a
+// comma at the end of the previous item's value and the item itself after any
+// trailing same-line comment; removing the tail deletes exactly those two
+// ranges. The comma has to go before the comment and the content after it —
+// putting the comma after would bury it inside a `//` comment and produce a
+// file that no longer parses.
+
+// nextComma returns the offset of the separating comma at or after from, or -1.
+// Blanked comments read as spaces, so a comment sitting between a value and its
+// comma is skipped like whitespace.
+func nextComma(blanked []byte, from int) int {
+	for i := from; i < len(blanked); i++ {
+		switch blanked[i] {
+		case ',':
+			return i
+		case ' ', '\t', '\r', '\n':
+			continue
+		default:
+			return -1
+		}
+	}
+	return -1
+}
+
+// endOfSameLineTrailer returns the offset just past a comment trailing on the
+// same line as from, or from itself when there is none. Comment bytes are the
+// ones where the blanked copy differs from the original.
+func endOfSameLineTrailer(orig, blanked []byte, from int) int {
+	last := from
+	for i := from; i < len(orig) && orig[i] != '\n'; i++ {
+		if blanked[i] != orig[i] {
+			last = i + 1
+			continue
+		}
+		if orig[i] == ' ' || orig[i] == '\t' || orig[i] == '\r' {
+			continue
+		}
+		break
+	}
+	return last
+}
+
+// itemSpan is one member or element of a container, reduced to the two offsets
+// the separator arithmetic needs.
+type itemSpan struct{ start, end int }
+
+// removeItems emits the edits that delete idx (ascending) from a container.
+// Consecutive removals are handled as one run so their spans cannot overlap.
+func removeItems(orig, blanked []byte, items []itemSpan, idx []int, edits *[]edit) bool {
+	for run := 0; run < len(idx); {
+		i := idx[run]
+		j := i
+		for run+1 < len(idx) && idx[run+1] == j+1 {
+			run++
+			j = idx[run]
+		}
+		run++
+		if !removeRun(orig, blanked, items, i, j, edits) {
+			return false
+		}
+	}
+	return true
+}
+
+// removeRun deletes items[i..j], keeping the container's remaining separators
+// valid. Which side the comma comes from depends on whether anything survives
+// before or after the run.
+func removeRun(orig, blanked []byte, items []itemSpan, i, j int, edits *[]edit) bool {
+	if i > 0 {
+		// Take the comma that precedes the run, and everything after it up to
+		// the end of the run — leaving a same-line comment on the previous
+		// item's line where the user put it.
+		comma := nextComma(blanked, items[i-1].end)
+		if comma < 0 {
+			return false
+		}
+		*edits = append(*edits, edit{start: endOfSameLineTrailer(orig, blanked, comma+1), end: items[j].end})
+		if j == len(items)-1 {
+			*edits = append(*edits, edit{start: comma, end: comma + 1})
+		}
+		return true
+	}
+	// Nothing survives before the run, so take the comma that follows it.
+	comma := nextComma(blanked, items[j].end)
+	if comma < 0 {
+		return false
+	}
+	*edits = append(*edits, edit{start: items[0].start, end: endOfSameLineTrailer(orig, blanked, comma+1)})
+	return true
+}
+
+// appendItems emits the edits that add body after the last item of a container.
+func appendItems(orig, blanked []byte, last itemSpan, body []byte, indent string, lay layout, edits *[]edit) {
+	*edits = append(*edits, edit{start: last.end, end: last.end, text: []byte(",")})
+	at := endOfSameLineTrailer(orig, blanked, last.end)
+	*edits = append(*edits, edit{start: at, end: at, text: []byte(lay.newline + indent + string(body))})
+}
+
+// fillEmptyContainer replaces a container's whole interior, used when it had no
+// items to hang a separator off. Emptying it again restores the original `{}`.
+func fillEmptyContainer(n *jsonNode, body []byte, itemIndent, closeIndent string, lay layout, edits *[]edit) {
+	text := ""
+	if len(body) > 0 {
+		text = lay.newline + itemIndent + string(body) + lay.newline + closeIndent
+	}
+	*edits = append(*edits, edit{start: n.start + 1, end: n.end - 1, text: []byte(text)})
+}
+
+// --- structural diff ---
+
+// spliceSettings rewrites original so that it decodes to want, changing as few
+// bytes as it can. Everything it does not have to touch stays byte-for-byte.
+func spliceSettings(original []byte, want map[string]interface{}) ([]byte, error) {
+	blanked := blankComments(original)
+	root, err := parseSpans(blanked)
+	if err != nil {
+		return nil, err
+	}
+
+	normalized, err := normalize(want)
+	if err != nil {
+		return nil, err
+	}
+
+	lay := detectLayout(original, blanked)
+	var edits []edit
+	if err := diffValue(original, blanked, root, normalized, 0, lay, &edits); err != nil {
+		return nil, err
+	}
+	return applyEdits(original, edits), nil
+}
+
+// normalize round-trips a value through the decoder so it compares like-for-like
+// against values decoded out of the file: an int the merge code wrote as 5 and a
+// 5 read off disk must not look like a change. UseNumber keeps integer literals
+// exact rather than routing them through float64.
+func normalize(v interface{}) (interface{}, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return decodeBytes(data)
+}
+
+func decodeBytes(data []byte) (interface{}, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var out interface{}
+	if err := dec.Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func decodeNode(blanked []byte, n *jsonNode) (interface{}, error) {
+	return decodeBytes(blanked[n.start:n.end])
+}
+
+// diffValue emits the edits that turn the value at n into want. A subtree that
+// already matches produces no edits at all, which is the whole mechanism by
+// which comments, ordering and escaping survive: untouched bytes are never
+// rewritten, so there is nothing for a serializer to get wrong.
+func diffValue(orig, blanked []byte, n *jsonNode, want interface{}, depth int, lay layout, edits *[]edit) error {
+	have, err := decodeNode(blanked, n)
+	if err != nil {
+		return err
+	}
+	if reflect.DeepEqual(have, want) {
+		return nil
+	}
+
+	switch n.kind {
+	case '{':
+		if m, ok := want.(map[string]interface{}); ok {
+			return diffObject(orig, blanked, n, m, depth, lay, edits)
+		}
+	case '[':
+		if s, ok := want.([]interface{}); ok {
+			return diffArray(orig, blanked, n, s, depth, lay, edits)
+		}
+	}
+	return replaceNode(blanked, n, want, depth, lay, edits)
+}
+
+// replaceNode rewrites a value wholesale — a scalar that changed, or a value
+// whose type changed out from under the original shape.
+func replaceNode(blanked []byte, n *jsonNode, want interface{}, depth int, lay layout, edits *[]edit) error {
+	prefix := strings.Repeat(lay.indent, depth)
+	if observed, ok := indentOfLine(blanked, n.start); ok {
+		prefix = observed
+	}
+	text, err := encodeValue(want, prefix, lay)
+	if err != nil {
+		return err
+	}
+	*edits = append(*edits, edit{start: n.start, end: n.end, text: text})
+	return nil
+}
+
+func diffObject(orig, blanked []byte, n *jsonNode, want map[string]interface{}, depth int, lay layout, edits *[]edit) error {
+	itemIndent, closeIndent := containerIndents(blanked, n, depth, lay)
+
+	kept := make(map[string]bool, len(n.members))
+	var removed []int
+	for i, m := range n.members {
+		value, ok := want[m.key]
+		if !ok {
+			removed = append(removed, i)
+			continue
+		}
+		kept[m.key] = true
+		if err := diffValue(orig, blanked, m.value, value, depth+1, lay, edits); err != nil {
+			return err
+		}
+	}
+
+	added := make([]string, 0, len(want))
+	for k := range want {
+		if !kept[k] {
+			added = append(added, k)
+		}
+	}
+	sort.Strings(added) // map iteration is random; the file must not be
+
+	body, err := renderMembers(added, want, itemIndent, lay)
+	if err != nil {
+		return err
+	}
+
+	items := make([]itemSpan, len(n.members))
+	for i, m := range n.members {
+		items[i] = itemSpan{start: m.keyStart, end: m.value.end}
+	}
+	return applyContainerEdits(orig, blanked, n, items, removed, len(added), body, itemIndent, closeIndent, lay, edits)
+}
+
+func diffArray(orig, blanked []byte, n *jsonNode, want []interface{}, depth int, lay layout, edits *[]edit) error {
+	itemIndent, closeIndent := containerIndents(blanked, n, depth, lay)
+
+	have := make([]interface{}, len(n.elems))
+	for i, e := range n.elems {
+		v, err := decodeNode(blanked, e)
+		if err != nil {
+			return err
+		}
+		have[i] = v
+	}
+
+	plan, ok := alignArray(have, want)
+	if !ok {
+		// An insertion somewhere other than the tail has no separator we can
+		// hang an edit off without guessing. Rewriting the array wholesale
+		// costs only the comments inside this one array, and never corrupts.
+		return replaceNode(blanked, n, want, depth, lay, edits)
+	}
+
+	for _, p := range plan.paired {
+		if err := diffValue(orig, blanked, n.elems[p.have], want[p.want], depth+1, lay, edits); err != nil {
+			return err
+		}
+	}
+
+	body, err := renderElems(plan.appended, itemIndent, lay)
+	if err != nil {
+		return err
+	}
+
+	items := make([]itemSpan, len(n.elems))
+	for i, e := range n.elems {
+		items[i] = itemSpan{start: e.start, end: e.end}
+	}
+	return applyContainerEdits(orig, blanked, n, items, plan.removed, len(plan.appended), body, itemIndent, closeIndent, lay, edits)
+}
+
+// applyContainerEdits is the shared tail of diffObject and diffArray: given
+// which items go away and what text gets appended, emit the edits. The branches
+// exist because a container with nothing left in it has no separator to attach
+// to, so its interior is rewritten instead.
+func applyContainerEdits(orig, blanked []byte, n *jsonNode, items []itemSpan, removed []int, addedCount int, body []byte, itemIndent, closeIndent string, lay layout, edits *[]edit) error {
+	emptied := len(removed) == len(items)
+
+	if emptied {
+		fillEmptyContainer(n, body, itemIndent, closeIndent, lay, edits)
+		return nil
+	}
+	if len(removed) > 0 {
+		if !removeItems(orig, blanked, items, removed, edits) {
+			return errUnsupportedShape
+		}
+	}
+	if addedCount > 0 {
+		appendItems(orig, blanked, items[len(items)-1], body, itemIndent, lay, edits)
+	}
+	return nil
+}
+
+// --- array alignment ---
+
+type arrayPair struct{ have, want int }
+
+type arrayPlan struct {
+	paired   []arrayPair   // same position, different content: recurse
+	removed  []int         // indices of have that go away
+	appended []interface{} // new values, all at the tail
+}
+
+// alignArray works out how have became want. It matches equal elements with a
+// longest-common-subsequence, pairs up what is left position-wise so an element
+// edited in place is recursed into rather than replaced (which would drop any
+// comments inside it), and reports the rest as removals plus tail appends.
+//
+// It returns false when a new element belongs anywhere but the tail. That never
+// arises from this package's own merges — hook groups are appended and removed,
+// never spliced into the middle — and the caller falls back to rewriting the
+// array rather than guessing at a separator.
+func alignArray(have, want []interface{}) (arrayPlan, bool) {
+	matches := longestCommonSubsequence(have, want)
+
+	var plan arrayPlan
+	ai, bi := 0, 0
+	advance := func(ma, mb int) bool {
+		da, db := ma-ai, mb-bi
+		paired := da
+		if db < paired {
+			paired = db
+		}
+		for k := 0; k < paired; k++ {
+			plan.paired = append(plan.paired, arrayPair{have: ai + k, want: bi + k})
+		}
+		for k := paired; k < da; k++ {
+			plan.removed = append(plan.removed, ai+k)
+		}
+		if db > paired && ma != len(have) {
+			return false // an insertion that is not at the tail
+		}
+		for k := paired; k < db; k++ {
+			plan.appended = append(plan.appended, want[bi+k])
+		}
+		return true
+	}
+
+	for _, m := range matches {
+		if !advance(m.have, m.want) {
+			return arrayPlan{}, false
+		}
+		ai, bi = m.have+1, m.want+1
+	}
+	if !advance(len(have), len(want)) {
+		return arrayPlan{}, false
+	}
+	return plan, true
+}
+
+// longestCommonSubsequence returns the matched index pairs of the longest run of
+// deep-equal elements common to a and b, in order. Arrays here hold a handful of
+// hook groups, so the quadratic table is free.
+func longestCommonSubsequence(a, b []interface{}) []arrayPair {
+	table := make([][]int, len(a)+1)
+	for i := range table {
+		table[i] = make([]int, len(b)+1)
+	}
+	for i := len(a) - 1; i >= 0; i-- {
+		for j := len(b) - 1; j >= 0; j-- {
+			if reflect.DeepEqual(a[i], b[j]) {
+				table[i][j] = table[i+1][j+1] + 1
+				continue
+			}
+			table[i][j] = table[i+1][j]
+			if table[i][j+1] > table[i][j] {
+				table[i][j] = table[i][j+1]
+			}
+		}
+	}
+
+	var out []arrayPair
+	for i, j := 0, 0; i < len(a) && j < len(b); {
+		switch {
+		case reflect.DeepEqual(a[i], b[j]):
+			out = append(out, arrayPair{have: i, want: j})
+			i, j = i+1, j+1
+		case table[i+1][j] >= table[i][j+1]:
+			i++
+		default:
+			j++
+		}
+	}
+	return out
+}

--- a/core/adapters/inbound/agents/hookjson/jsonc.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc.go
@@ -9,16 +9,24 @@ package hookjson
 // no key order and no formatting, so re-serializing one with
 // json.MarshalIndent destroys all three at once:
 //
-//   - comments vanish. gemini-cli's ~/.gemini/settings.json is JSONC: the CLI
-//     reads it through stripJsonComments and writes it back through the
-//     comment-json package precisely to keep them. Before this, they did not
-//     even survive the *read* — encoding/json rejects the file outright, so an
-//     install into a commented config failed rather than merging;
 //   - key order becomes alphabetical, silently reshuffling a file the user
 //     organized deliberately;
 //   - `<`, `>` and `&` are HTML-escaped into their six-character \u00xx
 //     escapes, so a perfectly ordinary `npm run build && npm run list-tools`
-//     comes back with each ampersand replaced by a backslash-u-0026.
+//     comes back with each ampersand replaced by a backslash-u-0026 — which
+//     ~/.claude/settings.json gets today, since the statusline command this
+//     package also writes ends in `>/dev/null 2>&1`;
+//   - comments do not survive, and in fact did not survive the *read* either:
+//     encoding/json rejects them outright, so an install into a commented
+//     config failed and merged nothing.
+//
+// The first two bite the files this package writes today —
+// ~/.claude/settings.json and ~/.codex/hooks.json, both strict JSON. The third
+// is why the work happened now: it is a prerequisite for installing hooks into
+// gemini-cli's ~/.gemini/settings.json (#1355 Phase D), which is JSONC by
+// design — the CLI reads it through stripJsonComments and writes it back
+// through the comment-json package specifically to keep comments. No caller
+// reads that file yet; this package is being made ready for the one that will.
 //
 // The strategy is to never re-serialize what we did not change. Writing works
 // on byte ranges of the original file: the wanted document is structurally
@@ -342,6 +350,11 @@ func applyEdits(orig []byte, edits []edit) ([]byte, bool) {
 // from the file, and no HTML escaping, so `&&` stays `&&`. prefix is the
 // indentation of the line the value starts on; the first line carries none
 // because it follows a `"key": `.
+//
+// Every byte of JSON this package emits goes through here, so
+// SetEscapeHTML(false) — the one flag this whole change exists to set — is
+// written in exactly one place. A second encoder configured somewhere else is
+// how the escaping comes back.
 func encodeValue(v interface{}, prefix string, lay layout) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
@@ -363,24 +376,11 @@ func encodeValue(v interface{}, prefix string, lay layout) ([]byte, error) {
 // newline are the shape a hand-edited config expects, and are pinned by
 // TestWriteSettings_ShapeAndDelegation.
 func encodeDocument(settings map[string]interface{}) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(settings); err != nil { // Encode appends the newline
+	out, err := encodeValue(settings, "", layout{newline: "\n", indent: "  "})
+	if err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
-}
-
-func encodeKey(key string) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(key); err != nil {
-		return nil, err
-	}
-	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+	return append(out, '\n'), nil
 }
 
 // --- the splicer ---
@@ -521,6 +521,24 @@ func (s *splicer) trailerEnd(from int) int {
 // the separator arithmetic needs.
 type itemSpan struct{ start, end int }
 
+// itemSpans reduces a container's members or elements to those offsets. An
+// object's item starts at its key, an array's at the value itself; both end at
+// the end of the value.
+func (n *jsonNode) itemSpans() []itemSpan {
+	if n.kind == '{' {
+		items := make([]itemSpan, len(n.members))
+		for i, m := range n.members {
+			items[i] = itemSpan{start: m.keyStart, end: m.value.end}
+		}
+		return items
+	}
+	items := make([]itemSpan, len(n.elems))
+	for i, e := range n.elems {
+		items[i] = itemSpan{start: e.start, end: e.end}
+	}
+	return items
+}
+
 // removeItems emits the edits that delete idx (ascending) from a container.
 // Consecutive removals are handled as one run so their spans cannot overlap.
 func (s *splicer) removeItems(items []itemSpan, idx []int, edits *[]edit) bool {
@@ -555,16 +573,19 @@ func (s *splicer) removeRun(items []itemSpan, i, j int, edits *[]edit) bool {
 			return false
 		}
 		start := s.trailerEnd(comma + 1)
-		// Start from the end of the line above the run rather than from the
-		// previous item's comma, so a standalone comment the user wrote between
-		// the two is left where it is instead of being swallowed. In the common
-		// case the two positions are the same byte, which is what keeps this the
-		// exact inverse of an append.
+
 		// Anything trailing the removed value goes with it. Leaving it behind
 		// would splice it onto the line above, and a `/* … */` landing after a
 		// `//` on that line is no longer a block comment — its closing `*/`
 		// becomes stray text and the file stops parsing.
 		end := s.trailerEnd(items[j].end)
+
+		// Start from the end of the line above the run rather than from the
+		// previous item's comma, so a standalone comment the user wrote between
+		// the two is left where it is instead of being swallowed. In the common
+		// case the two positions are the same byte, which is what keeps this the
+		// exact inverse of an append.
+		//
 		// items[i], not items[j]: the run begins at i, and anchoring on the last
 		// item of a multi-item run would delete only that one and leave the rest
 		// of the run in the file.
@@ -704,7 +725,7 @@ func (s *splicer) diffObject(n *jsonNode, want map[string]interface{}, depth int
 		if i > 0 {
 			buf.WriteString("," + s.lay.newline + itemIndent)
 		}
-		key, err := encodeKey(k)
+		key, err := encodeValue(k, itemIndent, s.lay)
 		if err != nil {
 			return err
 		}
@@ -717,11 +738,7 @@ func (s *splicer) diffObject(n *jsonNode, want map[string]interface{}, depth int
 		buf.Write(value)
 	}
 
-	items := make([]itemSpan, len(n.members))
-	for i, m := range n.members {
-		items[i] = itemSpan{start: m.keyStart, end: m.value.end}
-	}
-	return s.applyContainerEdits(n, items, removed, len(added), buf.Bytes(), itemIndent, closeIndent, edits)
+	return s.applyContainerEdits(n, n.itemSpans(), removed, buf.Bytes(), itemIndent, closeIndent, edits)
 }
 
 func (s *splicer) diffArray(n *jsonNode, want []interface{}, depth int, edits *[]edit) error {
@@ -762,17 +779,17 @@ func (s *splicer) diffArray(n *jsonNode, want []interface{}, depth int, edits *[
 		buf.Write(value)
 	}
 
-	items := make([]itemSpan, len(n.elems))
-	for i, e := range n.elems {
-		items[i] = itemSpan{start: e.start, end: e.end}
-	}
-	return s.applyContainerEdits(n, items, plan.removed, len(plan.appended), buf.Bytes(), itemIndent, closeIndent, edits)
+	return s.applyContainerEdits(n, n.itemSpans(), plan.removed, buf.Bytes(), itemIndent, closeIndent, edits)
 }
 
 // applyContainerEdits is the shared tail of diffObject and diffArray: given
 // which items go away and what text gets appended, emit the edits.
-func (s *splicer) applyContainerEdits(n *jsonNode, items []itemSpan, removed []int, addedCount int, body []byte, itemIndent, closeIndent string, edits *[]edit) error {
-	if lastSurviving(len(items), removed) < 0 {
+func (s *splicer) applyContainerEdits(n *jsonNode, items []itemSpan, removed []int, body []byte, itemIndent, closeIndent string, edits *[]edit) error {
+	// removed is always ascending, distinct and in range — diffObject appends
+	// while ranging over members, alignArray appends monotonically — so "nothing
+	// survives" is a count rather than a search. body is non-empty exactly when
+	// something is being added, since every encoded item is at least one byte.
+	if len(removed) == len(items) {
 		// Nothing survives, so there is no separator to attach to: the
 		// container's whole interior is rewritten instead.
 		s.fillEmptyContainer(n, body, itemIndent, closeIndent, edits)
@@ -785,7 +802,7 @@ func (s *splicer) applyContainerEdits(n *jsonNode, items []itemSpan, removed []i
 	// the tail and then re-adding it for the append means two edits at one
 	// offset, which is an overlap, and anchoring the append on the removed item
 	// puts the comma at an offset the deletion splices away.
-	if tail := trailingRun(len(items), removed); tail >= 0 && addedCount > 0 {
+	if tail := trailingRun(len(items), removed); tail >= 0 && len(body) > 0 {
 		comma := s.nextComma(items[tail-1].end)
 		if comma < 0 {
 			return errNoSafeSplice
@@ -805,25 +822,10 @@ func (s *splicer) applyContainerEdits(n *jsonNode, items []itemSpan, removed []i
 	if len(removed) > 0 && !s.removeItems(items, removed, edits) {
 		return errNoSafeSplice
 	}
-	if addedCount > 0 {
+	if len(body) > 0 {
 		s.appendItems(items[len(items)-1], body, itemIndent, edits)
 	}
 	return nil
-}
-
-// lastSurviving returns the highest index in [0,count) that is not in removed,
-// or -1 when every item is going away.
-func lastSurviving(count int, removed []int) int {
-	gone := make(map[int]bool, len(removed))
-	for _, i := range removed {
-		gone[i] = true
-	}
-	for i := count - 1; i >= 0; i-- {
-		if !gone[i] {
-			return i
-		}
-	}
-	return -1
 }
 
 // trailingRun returns the first index of the run of removed items that reaches

--- a/core/adapters/inbound/agents/hookjson/jsonc.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc.go
@@ -862,6 +862,10 @@ type arrayPlan struct {
 // never spliced into the middle — and the caller falls back to rewriting the
 // array rather than guessing at a separator.
 func alignArray(have, want []interface{}) (arrayPlan, bool) {
+	if len(have) > maxAlignedArray || len(want) > maxAlignedArray {
+		return arrayPlan{}, false
+	}
+
 	var plan arrayPlan
 	ai, bi := 0, 0
 	advance := func(ma, mb int) bool {
@@ -897,9 +901,19 @@ func alignArray(have, want []interface{}) (arrayPlan, bool) {
 	return plan, true
 }
 
+// maxAlignedArray bounds the quadratic alignment table below. A hook event
+// array holds single-digit matcher groups, so this is far above anything a
+// hand-maintained config produces — but the table costs len(a)·len(b) ints, and
+// the lengths come from a file we do not control. A settings.json carrying a
+// couple of megabytes of `[0,0,0,…]` would ask for tens of gigabytes and take
+// the daemon down with it, so past this size the alignment is skipped and the
+// array is rewritten instead: the same safe fallback a mid-array insertion
+// takes, costing that array's comments and nothing else.
+const maxAlignedArray = 512
+
 // longestCommonSubsequence returns the matched index pairs of the longest run of
-// deep-equal elements common to a and b, in order. Arrays here hold a handful of
-// hook groups, so the quadratic table is free.
+// deep-equal elements common to a and b, in order. Callers bound the inputs by
+// maxAlignedArray, so the quadratic table is free.
 func longestCommonSubsequence(a, b []interface{}) []arrayPair {
 	table := make([][]int, len(a)+1)
 	for i := range table {

--- a/core/adapters/inbound/agents/hookjson/jsonc.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc.go
@@ -11,9 +11,9 @@ package hookjson
 //
 //   - comments vanish. gemini-cli's ~/.gemini/settings.json is JSONC: the CLI
 //     reads it through stripJsonComments and writes it back through the
-//     comment-json package precisely to keep them. Today they don't even
-//     survive the *read* — encoding/json rejects the file outright, so an
-//     install into a commented config fails rather than merging;
+//     comment-json package precisely to keep them. Before this, they did not
+//     even survive the *read* — encoding/json rejects the file outright, so an
+//     install into a commented config failed rather than merging;
 //   - key order becomes alphabetical, silently reshuffling a file the user
 //     organized deliberately;
 //   - `<`, `>` and `&` are HTML-escaped into their six-character \u00xx
@@ -27,23 +27,32 @@ package hookjson
 // order, their indentation, and their unescaped `&&` — is passed through as the
 // original bytes, because it literally is the original bytes.
 //
-// Two pieces make that possible:
+// Three pieces make that possible:
 //
-//   - blankComments overwrites each comment with spaces *in place*. The result
-//     is valid JSON that encoding/json can parse, and because blanking
-//     preserves length, every byte offset in it still indexes the same byte of
-//     the original. That is what lets a parser that has never heard of comments
-//     hand back offsets usable against a file full of them.
+//   - blankComments overwrites each comment with spaces *in place*, and records
+//     which bytes were comment. The blanked text is valid JSON that
+//     encoding/json can parse, and because blanking preserves length, every byte
+//     offset in it still indexes the original. That is what lets a parser which
+//     has never heard of comments hand back offsets usable against a file full
+//     of them.
 //   - parseSpans records, for every value in the document, the byte range it
 //     occupies. It uses encoding/json's own Decoder token stream rather than a
-//     hand-written JSON parser, so the only bespoke lexing in this file is the
-//     comment blanker.
+//     hand-written JSON parser, so the only bespoke lexing here is the blanker.
+//   - the splicer diffs wanted-against-original and emits byte edits.
+//
+// Because that last part is hand-rolled arithmetic over a file the user cares
+// about, the result is verified before it is returned: the spliced bytes are
+// re-decoded and compared against the document they are supposed to represent,
+// and any mismatch falls back to a whole-document encode. That trades the
+// user's comments for their data, which is the right way round — an
+// unparseable ~/.claude/settings.json breaks the agent and every subsequent
+// install, and the error is currently swallowed on the way out (#1362).
 //
 // Deliberately NOT changed here: what happens on genuinely malformed input.
 // A file that is not valid JSON once its comments are blanked still errors, and
 // is never overwritten — see ReadSettings. Issue #1362 is making that error
 // visible to the user rather than swallowed; it is correct behavior, not a
-// defect, and there is a test pinning it.
+// defect, and there are tests pinning it.
 
 import (
 	"bytes"
@@ -54,19 +63,29 @@ import (
 	"strings"
 )
 
-// errUnsupportedShape marks a document whose top level is something we have no
-// safe in-place edit for. The caller falls back to a whole-document encode.
-var errUnsupportedShape = errors.New("hookjson: unsupported document shape")
+// errNoSafeSplice means this document cannot be edited in place with confidence
+// — an unexpected top-level shape, overlapping edits, or a spliced result that
+// failed its own verification. The caller re-encodes the whole document
+// instead, losing comments but never content.
+var errNoSafeSplice = errors.New("hookjson: cannot splice safely")
 
 // --- comment blanking ---
 
 // blankComments returns a copy of src with every JSONC comment overwritten by
-// spaces. Newlines inside block comments are kept so line numbers — and, more
-// importantly, byte offsets — are identical to src. The result is what gets
-// parsed; the original is what gets copied from.
+// spaces.
 func blankComments(src []byte) []byte {
+	blanked, _ := blankCommentsMask(src)
+	return blanked
+}
+
+// blankCommentsMask also reports which bytes belonged to a comment. Newlines
+// inside a block comment are left as newlines in the blanked text — so line
+// structure and byte offsets are identical to src — but they are still marked,
+// which is how the separator arithmetic knows a comment spans lines.
+func blankCommentsMask(src []byte) ([]byte, []bool) {
 	out := make([]byte, len(src))
 	copy(out, src)
+	mask := make([]bool, len(src))
 
 	inString := false
 	for i := 0; i < len(src); i++ {
@@ -84,19 +103,20 @@ func blankComments(src []byte) []byte {
 		case c == '"':
 			inString = true
 		case c == '/' && i+1 < len(src) && src[i+1] == '/':
-			i = blankLineComment(src, out, i) - 1
+			i = blankLineComment(src, out, mask, i) - 1
 		case c == '/' && i+1 < len(src) && src[i+1] == '*':
-			i = blankBlockComment(src, out, i) - 1
+			i = blankBlockComment(src, out, mask, i) - 1
 		}
 	}
-	return out
+	return out, mask
 }
 
 // blankLineComment blanks from i up to (not including) the next newline and
 // returns the index it stopped at.
-func blankLineComment(src, out []byte, i int) int {
+func blankLineComment(src, out []byte, mask []bool, i int) int {
 	for i < len(src) && src[i] != '\n' {
 		out[i] = ' '
+		mask[i] = true
 		i++
 	}
 	return i
@@ -104,11 +124,13 @@ func blankLineComment(src, out []byte, i int) int {
 
 // blankBlockComment blanks from i through the closing `*/` (or to end of input
 // when unterminated, which then fails the parse) and returns the index just
-// past it. Newlines survive so offsets and line structure are unchanged.
-func blankBlockComment(src, out []byte, i int) int {
+// past it.
+func blankBlockComment(src, out []byte, mask []bool, i int) int {
 	for i < len(src) {
+		mask[i] = true
 		if src[i] == '*' && i+1 < len(src) && src[i+1] == '/' {
 			out[i], out[i+1] = ' ', ' '
+			mask[i+1] = true
 			return i + 2
 		}
 		if src[i] != '\n' {
@@ -141,11 +163,7 @@ type jsonMember struct {
 func parseSpans(blanked []byte) (*jsonNode, error) {
 	dec := json.NewDecoder(bytes.NewReader(blanked))
 	dec.UseNumber()
-	n, err := parseNode(dec, blanked)
-	if err != nil {
-		return nil, err
-	}
-	return n, nil
+	return parseNode(dec, blanked)
 }
 
 // tokenStart returns the offset of the next token, given the offset just past
@@ -182,7 +200,7 @@ func parseNode(dec *json.Decoder, src []byte) (*jsonNode, error) {
 	case '[':
 		return parseArray(dec, src, start)
 	}
-	return nil, errUnsupportedShape
+	return nil, errNoSafeSplice
 }
 
 func parseObject(dec *json.Decoder, src []byte, start int) (*jsonNode, error) {
@@ -195,7 +213,7 @@ func parseObject(dec *json.Decoder, src []byte, start int) (*jsonNode, error) {
 		}
 		key, ok := keyTok.(string)
 		if !ok {
-			return nil, errUnsupportedShape
+			return nil, errNoSafeSplice
 		}
 		value, err := parseNode(dec, src)
 		if err != nil {
@@ -276,25 +294,18 @@ func indentOfLine(src []byte, pos int) (string, bool) {
 	return string(src[ls:pos]), true
 }
 
-// containerIndents returns the indent for a container's items and for its
-// closing bracket. Observed indentation wins over a computed one, so an
-// irregularly formatted file keeps its own shape.
-func containerIndents(blanked []byte, n *jsonNode, depth int, lay layout) (item string, closing string) {
-	closing = strings.Repeat(lay.indent, depth)
-	if observed, ok := indentOfLine(blanked, n.start); ok {
-		closing = observed
+// throughLineEnd extends pos past the rest of its line when only whitespace
+// remains on it, so removing an item takes its line with it instead of leaving
+// a blank one behind. Returns pos unchanged when something else is on the line.
+func throughLineEnd(orig []byte, pos int) int {
+	i := pos
+	for i < len(orig) && (orig[i] == ' ' || orig[i] == '\t' || orig[i] == '\r') {
+		i++
 	}
-	item = closing + lay.indent
-	if len(n.members) > 0 {
-		if observed, ok := indentOfLine(blanked, n.members[0].keyStart); ok {
-			item = observed
-		}
-	} else if len(n.elems) > 0 {
-		if observed, ok := indentOfLine(blanked, n.elems[0].start); ok {
-			item = observed
-		}
+	if i < len(orig) && orig[i] == '\n' {
+		return i + 1
 	}
-	return item, closing
+	return pos
 }
 
 // --- edits ---
@@ -306,28 +317,31 @@ type edit struct {
 
 // applyEdits splices edits into orig. Insertions share a position with the edit
 // they follow, so the sort must be stable to keep them in the order emitted.
-func applyEdits(orig []byte, edits []edit) []byte {
+// Overlapping edits mean the arithmetic that produced them is wrong; rather
+// than silently dropping one and writing a plausible-looking file, it reports
+// failure so the caller can fall back to a whole-document encode.
+func applyEdits(orig []byte, edits []edit) ([]byte, bool) {
 	sort.SliceStable(edits, func(i, j int) bool { return edits[i].start < edits[j].start })
 	var out bytes.Buffer
 	prev := 0
 	for _, e := range edits {
 		if e.start < prev {
-			continue // defensive: overlapping edits, keep the earlier one
+			return nil, false
 		}
 		out.Write(orig[prev:e.start])
 		out.Write(e.text)
 		prev = e.end
 	}
 	out.Write(orig[prev:])
-	return out.Bytes()
+	return out.Bytes(), true
 }
 
 // --- encoding ---
 
-// encodeValue renders v the way this package writes JSON: two-space-style
-// indentation taken from the file, and no HTML escaping, so `&&` stays `&&`.
-// prefix is the indentation of the line the value starts on; the first line
-// carries none because it follows a `"key": `.
+// encodeValue renders v the way this package writes JSON: indentation taken
+// from the file, and no HTML escaping, so `&&` stays `&&`. prefix is the
+// indentation of the line the value starts on; the first line carries none
+// because it follows a `"key": `.
 func encodeValue(v interface{}, prefix string, lay layout) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
@@ -344,9 +358,10 @@ func encodeValue(v interface{}, prefix string, lay layout) ([]byte, error) {
 }
 
 // encodeDocument renders a whole settings document from scratch — the path
-// taken when there is no original file to preserve. The two-space indent and
-// trailing newline are the shape a hand-edited config expects, and are pinned
-// by TestWriteSettings_ShapeAndDelegation.
+// taken when there is no original file to preserve, and the fallback when an
+// in-place edit cannot be made safely. The two-space indent and trailing
+// newline are the shape a hand-edited config expects, and are pinned by
+// TestWriteSettings_ShapeAndDelegation.
 func encodeDocument(settings map[string]interface{}) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
@@ -368,161 +383,23 @@ func encodeKey(key string) ([]byte, error) {
 	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }
 
-// renderMembers renders `"k": v` pairs joined by a comma and a newline, each
-// continuation line indented by indent.
-func renderMembers(keys []string, want map[string]interface{}, indent string, lay layout) ([]byte, error) {
-	var buf bytes.Buffer
-	for i, k := range keys {
-		if i > 0 {
-			buf.WriteString("," + lay.newline + indent)
-		}
-		key, err := encodeKey(k)
-		if err != nil {
-			return nil, err
-		}
-		value, err := encodeValue(want[k], indent, lay)
-		if err != nil {
-			return nil, err
-		}
-		buf.Write(key)
-		buf.WriteString(": ")
-		buf.Write(value)
-	}
-	return buf.Bytes(), nil
+// --- the splicer ---
+
+// splicer carries the document being edited: the original bytes that get
+// copied, the blanked copy that gets parsed, the comment mask the separator
+// arithmetic consults, and the formatting to match when inserting.
+type splicer struct {
+	orig    []byte
+	blanked []byte
+	mask    []bool
+	lay     layout
 }
-
-func renderElems(values []interface{}, indent string, lay layout) ([]byte, error) {
-	var buf bytes.Buffer
-	for i, v := range values {
-		if i > 0 {
-			buf.WriteString("," + lay.newline + indent)
-		}
-		value, err := encodeValue(v, indent, lay)
-		if err != nil {
-			return nil, err
-		}
-		buf.Write(value)
-	}
-	return buf.Bytes(), nil
-}
-
-// --- separator arithmetic ---
-//
-// Insertion and removal are written as exact inverses of each other, which is
-// what makes install-then-uninstall byte-identical. Appending an item emits a
-// comma at the end of the previous item's value and the item itself after any
-// trailing same-line comment; removing the tail deletes exactly those two
-// ranges. The comma has to go before the comment and the content after it —
-// putting the comma after would bury it inside a `//` comment and produce a
-// file that no longer parses.
-
-// nextComma returns the offset of the separating comma at or after from, or -1.
-// Blanked comments read as spaces, so a comment sitting between a value and its
-// comma is skipped like whitespace.
-func nextComma(blanked []byte, from int) int {
-	for i := from; i < len(blanked); i++ {
-		switch blanked[i] {
-		case ',':
-			return i
-		case ' ', '\t', '\r', '\n':
-			continue
-		default:
-			return -1
-		}
-	}
-	return -1
-}
-
-// endOfSameLineTrailer returns the offset just past a comment trailing on the
-// same line as from, or from itself when there is none. Comment bytes are the
-// ones where the blanked copy differs from the original.
-func endOfSameLineTrailer(orig, blanked []byte, from int) int {
-	last := from
-	for i := from; i < len(orig) && orig[i] != '\n'; i++ {
-		if blanked[i] != orig[i] {
-			last = i + 1
-			continue
-		}
-		if orig[i] == ' ' || orig[i] == '\t' || orig[i] == '\r' {
-			continue
-		}
-		break
-	}
-	return last
-}
-
-// itemSpan is one member or element of a container, reduced to the two offsets
-// the separator arithmetic needs.
-type itemSpan struct{ start, end int }
-
-// removeItems emits the edits that delete idx (ascending) from a container.
-// Consecutive removals are handled as one run so their spans cannot overlap.
-func removeItems(orig, blanked []byte, items []itemSpan, idx []int, edits *[]edit) bool {
-	for run := 0; run < len(idx); {
-		i := idx[run]
-		j := i
-		for run+1 < len(idx) && idx[run+1] == j+1 {
-			run++
-			j = idx[run]
-		}
-		run++
-		if !removeRun(orig, blanked, items, i, j, edits) {
-			return false
-		}
-	}
-	return true
-}
-
-// removeRun deletes items[i..j], keeping the container's remaining separators
-// valid. Which side the comma comes from depends on whether anything survives
-// before or after the run.
-func removeRun(orig, blanked []byte, items []itemSpan, i, j int, edits *[]edit) bool {
-	if i > 0 {
-		// Take the comma that precedes the run, and everything after it up to
-		// the end of the run — leaving a same-line comment on the previous
-		// item's line where the user put it.
-		comma := nextComma(blanked, items[i-1].end)
-		if comma < 0 {
-			return false
-		}
-		*edits = append(*edits, edit{start: endOfSameLineTrailer(orig, blanked, comma+1), end: items[j].end})
-		if j == len(items)-1 {
-			*edits = append(*edits, edit{start: comma, end: comma + 1})
-		}
-		return true
-	}
-	// Nothing survives before the run, so take the comma that follows it.
-	comma := nextComma(blanked, items[j].end)
-	if comma < 0 {
-		return false
-	}
-	*edits = append(*edits, edit{start: items[0].start, end: endOfSameLineTrailer(orig, blanked, comma+1)})
-	return true
-}
-
-// appendItems emits the edits that add body after the last item of a container.
-func appendItems(orig, blanked []byte, last itemSpan, body []byte, indent string, lay layout, edits *[]edit) {
-	*edits = append(*edits, edit{start: last.end, end: last.end, text: []byte(",")})
-	at := endOfSameLineTrailer(orig, blanked, last.end)
-	*edits = append(*edits, edit{start: at, end: at, text: []byte(lay.newline + indent + string(body))})
-}
-
-// fillEmptyContainer replaces a container's whole interior, used when it had no
-// items to hang a separator off. Emptying it again restores the original `{}`.
-func fillEmptyContainer(n *jsonNode, body []byte, itemIndent, closeIndent string, lay layout, edits *[]edit) {
-	text := ""
-	if len(body) > 0 {
-		text = lay.newline + itemIndent + string(body) + lay.newline + closeIndent
-	}
-	*edits = append(*edits, edit{start: n.start + 1, end: n.end - 1, text: []byte(text)})
-}
-
-// --- structural diff ---
 
 // spliceSettings rewrites original so that it decodes to want, changing as few
 // bytes as it can. Everything it does not have to touch stays byte-for-byte.
+// Returns errNoSafeSplice when it cannot do that with confidence.
 func spliceSettings(original []byte, want map[string]interface{}) ([]byte, error) {
-	blanked := blankComments(original)
+	blanked, mask := blankCommentsMask(original)
 	root, err := parseSpans(blanked)
 	if err != nil {
 		return nil, err
@@ -533,12 +410,33 @@ func spliceSettings(original []byte, want map[string]interface{}) ([]byte, error
 		return nil, err
 	}
 
-	lay := detectLayout(original, blanked)
+	s := &splicer{orig: original, blanked: blanked, mask: mask, lay: detectLayout(original, blanked)}
 	var edits []edit
-	if err := diffValue(original, blanked, root, normalized, 0, lay, &edits); err != nil {
+	if err := s.diffValue(root, normalized, 0, &edits); err != nil {
 		return nil, err
 	}
-	return applyEdits(original, edits), nil
+
+	out, ok := applyEdits(original, edits)
+	if !ok {
+		return nil, errNoSafeSplice
+	}
+	if !decodesTo(out, normalized) {
+		// The edit arithmetic produced something that is not the document we
+		// were asked for. Never write it: a corrupted settings.json breaks the
+		// agent and every later install, whereas re-encoding merely costs the
+		// comments this package exists to protect.
+		return nil, errNoSafeSplice
+	}
+	return out, nil
+}
+
+// decodesTo reports whether spliced bytes really represent want.
+func decodesTo(spliced []byte, want interface{}) bool {
+	got, err := decodeBytes(blankComments(spliced))
+	if err != nil {
+		return false
+	}
+	return reflect.DeepEqual(got, want)
 }
 
 // normalize round-trips a value through the decoder so it compares like-for-like
@@ -563,16 +461,184 @@ func decodeBytes(data []byte) (interface{}, error) {
 	return out, nil
 }
 
-func decodeNode(blanked []byte, n *jsonNode) (interface{}, error) {
-	return decodeBytes(blanked[n.start:n.end])
+func (s *splicer) decodeNode(n *jsonNode) (interface{}, error) {
+	return decodeBytes(s.blanked[n.start:n.end])
 }
+
+// --- separator arithmetic ---
+//
+// Appending an item emits a comma at the end of the last surviving item's value
+// and the item itself after any comment trailing that value; removing the tail
+// deletes exactly those two ranges, which is what makes install-then-uninstall
+// byte-identical. The comma has to go before the comment and the content after
+// it — putting the comma after would bury it inside a `//` comment and produce
+// a file that no longer parses.
+
+// nextComma returns the offset of the separating comma at or after from, or -1.
+// Blanked comments read as whitespace, so a comment sitting between a value and
+// its comma is skipped like whitespace.
+func (s *splicer) nextComma(from int) int {
+	for i := from; i < len(s.blanked); i++ {
+		switch s.blanked[i] {
+		case ',':
+			return i
+		case ' ', '\t', '\r', '\n':
+			continue
+		default:
+			return -1
+		}
+	}
+	return -1
+}
+
+// trailerEnd returns the offset just past any comments trailing on the same
+// line as from, or from itself when there are none.
+//
+// A block comment is consumed whole even when it spans lines. Stopping at the
+// first newline would return an offset *inside* the comment, and splicing there
+// either buries the inserted member in the comment or deletes its closing `*/`
+// and swallows the rest of the file.
+func (s *splicer) trailerEnd(from int) int {
+	last := from
+	for i := from; i < len(s.orig); {
+		if s.mask[i] {
+			for i < len(s.orig) && s.mask[i] {
+				i++
+			}
+			last = i
+			continue
+		}
+		if s.orig[i] == ' ' || s.orig[i] == '\t' || s.orig[i] == '\r' {
+			i++
+			continue
+		}
+		break // a newline, or real content, ends the trailer
+	}
+	return last
+}
+
+// itemSpan is one member or element of a container, reduced to the two offsets
+// the separator arithmetic needs.
+type itemSpan struct{ start, end int }
+
+// removeItems emits the edits that delete idx (ascending) from a container.
+// Consecutive removals are handled as one run so their spans cannot overlap.
+func (s *splicer) removeItems(items []itemSpan, idx []int, edits *[]edit) bool {
+	for run := 0; run < len(idx); {
+		i := idx[run]
+		j := i
+		for run+1 < len(idx) && idx[run+1] == j+1 {
+			run++
+			j = idx[run]
+		}
+		run++
+		if !s.removeRun(items, i, j, edits) {
+			return false
+		}
+	}
+	return true
+}
+
+// removeRun deletes items[i..j], leaving exactly one comma between every pair
+// of survivors.
+//
+// Which comma goes with the run depends on what survives around it. When
+// nothing survives after the run, the comma *before* it must go or the last
+// survivor is left with a trailing comma. When something does survive after the
+// run, that same comma is what separates the survivors on either side, so the
+// comma *after* the run goes instead — taking both would leave the survivors
+// unseparated, and taking neither writes `,,` into the user's file.
+func (s *splicer) removeRun(items []itemSpan, i, j int, edits *[]edit) bool {
+	if j == len(items)-1 && i > 0 {
+		comma := s.nextComma(items[i-1].end)
+		if comma < 0 {
+			return false
+		}
+		start := s.trailerEnd(comma + 1)
+		// Start from the end of the line above the run rather than from the
+		// previous item's comma, so a standalone comment the user wrote between
+		// the two is left where it is instead of being swallowed. In the common
+		// case the two positions are the same byte, which is what keeps this the
+		// exact inverse of an append.
+		// Anything trailing the removed value goes with it. Leaving it behind
+		// would splice it onto the line above, and a `/* … */` landing after a
+		// `//` on that line is no longer a block comment — its closing `*/`
+		// becomes stray text and the file stops parsing.
+		end := s.trailerEnd(items[j].end)
+		// items[i], not items[j]: the run begins at i, and anchoring on the last
+		// item of a multi-item run would delete only that one and leave the rest
+		// of the run in the file.
+		if _, ownLine := indentOfLine(s.blanked, items[i].start); ownLine {
+			if ls := lineStart(s.blanked, items[i].start); ls > start {
+				start = ls - 1
+			}
+		}
+		*edits = append(*edits, edit{start: start, end: end})
+		*edits = append(*edits, edit{start: comma, end: comma + 1})
+		return true
+	}
+
+	comma := s.nextComma(items[j].end)
+	if comma < 0 {
+		return false
+	}
+	start, end := items[i].start, s.trailerEnd(comma+1)
+	// When the run owns its lines outright, take the lines rather than the
+	// values, so nothing is left behind but correctly indented survivors.
+	if indent, ok := indentOfLine(s.blanked, start); ok {
+		start -= len(indent)
+		end = throughLineEnd(s.orig, end)
+	}
+	*edits = append(*edits, edit{start: start, end: end})
+	return true
+}
+
+// appendItems emits the edits that add body after the last surviving item.
+func (s *splicer) appendItems(last itemSpan, body []byte, indent string, edits *[]edit) {
+	*edits = append(*edits, edit{start: last.end, end: last.end, text: []byte(",")})
+	at := s.trailerEnd(last.end)
+	*edits = append(*edits, edit{start: at, end: at, text: []byte(s.lay.newline + indent + string(body))})
+}
+
+// fillEmptyContainer replaces a container's whole interior, used when it has no
+// surviving item to hang a separator off. Emptying it again restores `{}`.
+func (s *splicer) fillEmptyContainer(n *jsonNode, body []byte, itemIndent, closeIndent string, edits *[]edit) {
+	text := ""
+	if len(body) > 0 {
+		text = s.lay.newline + itemIndent + string(body) + s.lay.newline + closeIndent
+	}
+	*edits = append(*edits, edit{start: n.start + 1, end: n.end - 1, text: []byte(text)})
+}
+
+// containerIndents returns the indent for a container's items and for its
+// closing bracket. Observed indentation wins over a computed one, so an
+// irregularly formatted file keeps its own shape.
+func (s *splicer) containerIndents(n *jsonNode, depth int) (item string, closing string) {
+	closing = strings.Repeat(s.lay.indent, depth)
+	if observed, ok := indentOfLine(s.blanked, n.start); ok {
+		closing = observed
+	}
+	item = closing + s.lay.indent
+	if len(n.members) > 0 {
+		if observed, ok := indentOfLine(s.blanked, n.members[0].keyStart); ok {
+			item = observed
+		}
+	} else if len(n.elems) > 0 {
+		if observed, ok := indentOfLine(s.blanked, n.elems[0].start); ok {
+			item = observed
+		}
+	}
+	return item, closing
+}
+
+// --- structural diff ---
 
 // diffValue emits the edits that turn the value at n into want. A subtree that
 // already matches produces no edits at all, which is the whole mechanism by
 // which comments, ordering and escaping survive: untouched bytes are never
 // rewritten, so there is nothing for a serializer to get wrong.
-func diffValue(orig, blanked []byte, n *jsonNode, want interface{}, depth int, lay layout, edits *[]edit) error {
-	have, err := decodeNode(blanked, n)
+func (s *splicer) diffValue(n *jsonNode, want interface{}, depth int, edits *[]edit) error {
+	have, err := s.decodeNode(n)
 	if err != nil {
 		return err
 	}
@@ -583,24 +649,24 @@ func diffValue(orig, blanked []byte, n *jsonNode, want interface{}, depth int, l
 	switch n.kind {
 	case '{':
 		if m, ok := want.(map[string]interface{}); ok {
-			return diffObject(orig, blanked, n, m, depth, lay, edits)
+			return s.diffObject(n, m, depth, edits)
 		}
 	case '[':
-		if s, ok := want.([]interface{}); ok {
-			return diffArray(orig, blanked, n, s, depth, lay, edits)
+		if a, ok := want.([]interface{}); ok {
+			return s.diffArray(n, a, depth, edits)
 		}
 	}
-	return replaceNode(blanked, n, want, depth, lay, edits)
+	return s.replaceNode(n, want, depth, edits)
 }
 
 // replaceNode rewrites a value wholesale — a scalar that changed, or a value
 // whose type changed out from under the original shape.
-func replaceNode(blanked []byte, n *jsonNode, want interface{}, depth int, lay layout, edits *[]edit) error {
-	prefix := strings.Repeat(lay.indent, depth)
-	if observed, ok := indentOfLine(blanked, n.start); ok {
+func (s *splicer) replaceNode(n *jsonNode, want interface{}, depth int, edits *[]edit) error {
+	prefix := strings.Repeat(s.lay.indent, depth)
+	if observed, ok := indentOfLine(s.blanked, n.start); ok {
 		prefix = observed
 	}
-	text, err := encodeValue(want, prefix, lay)
+	text, err := encodeValue(want, prefix, s.lay)
 	if err != nil {
 		return err
 	}
@@ -608,8 +674,8 @@ func replaceNode(blanked []byte, n *jsonNode, want interface{}, depth int, lay l
 	return nil
 }
 
-func diffObject(orig, blanked []byte, n *jsonNode, want map[string]interface{}, depth int, lay layout, edits *[]edit) error {
-	itemIndent, closeIndent := containerIndents(blanked, n, depth, lay)
+func (s *splicer) diffObject(n *jsonNode, want map[string]interface{}, depth int, edits *[]edit) error {
+	itemIndent, closeIndent := s.containerIndents(n, depth)
 
 	kept := make(map[string]bool, len(n.members))
 	var removed []int
@@ -620,7 +686,7 @@ func diffObject(orig, blanked []byte, n *jsonNode, want map[string]interface{}, 
 			continue
 		}
 		kept[m.key] = true
-		if err := diffValue(orig, blanked, m.value, value, depth+1, lay, edits); err != nil {
+		if err := s.diffValue(m.value, value, depth+1, edits); err != nil {
 			return err
 		}
 	}
@@ -633,24 +699,37 @@ func diffObject(orig, blanked []byte, n *jsonNode, want map[string]interface{}, 
 	}
 	sort.Strings(added) // map iteration is random; the file must not be
 
-	body, err := renderMembers(added, want, itemIndent, lay)
-	if err != nil {
-		return err
+	var buf bytes.Buffer
+	for i, k := range added {
+		if i > 0 {
+			buf.WriteString("," + s.lay.newline + itemIndent)
+		}
+		key, err := encodeKey(k)
+		if err != nil {
+			return err
+		}
+		value, err := encodeValue(want[k], itemIndent, s.lay)
+		if err != nil {
+			return err
+		}
+		buf.Write(key)
+		buf.WriteString(": ")
+		buf.Write(value)
 	}
 
 	items := make([]itemSpan, len(n.members))
 	for i, m := range n.members {
 		items[i] = itemSpan{start: m.keyStart, end: m.value.end}
 	}
-	return applyContainerEdits(orig, blanked, n, items, removed, len(added), body, itemIndent, closeIndent, lay, edits)
+	return s.applyContainerEdits(n, items, removed, len(added), buf.Bytes(), itemIndent, closeIndent, edits)
 }
 
-func diffArray(orig, blanked []byte, n *jsonNode, want []interface{}, depth int, lay layout, edits *[]edit) error {
-	itemIndent, closeIndent := containerIndents(blanked, n, depth, lay)
+func (s *splicer) diffArray(n *jsonNode, want []interface{}, depth int, edits *[]edit) error {
+	itemIndent, closeIndent := s.containerIndents(n, depth)
 
 	have := make([]interface{}, len(n.elems))
 	for i, e := range n.elems {
-		v, err := decodeNode(blanked, e)
+		v, err := s.decodeNode(e)
 		if err != nil {
 			return err
 		}
@@ -662,47 +741,103 @@ func diffArray(orig, blanked []byte, n *jsonNode, want []interface{}, depth int,
 		// An insertion somewhere other than the tail has no separator we can
 		// hang an edit off without guessing. Rewriting the array wholesale
 		// costs only the comments inside this one array, and never corrupts.
-		return replaceNode(blanked, n, want, depth, lay, edits)
+		return s.replaceNode(n, want, depth, edits)
 	}
 
 	for _, p := range plan.paired {
-		if err := diffValue(orig, blanked, n.elems[p.have], want[p.want], depth+1, lay, edits); err != nil {
+		if err := s.diffValue(n.elems[p.have], want[p.want], depth+1, edits); err != nil {
 			return err
 		}
 	}
 
-	body, err := renderElems(plan.appended, itemIndent, lay)
-	if err != nil {
-		return err
+	var buf bytes.Buffer
+	for i, v := range plan.appended {
+		if i > 0 {
+			buf.WriteString("," + s.lay.newline + itemIndent)
+		}
+		value, err := encodeValue(v, itemIndent, s.lay)
+		if err != nil {
+			return err
+		}
+		buf.Write(value)
 	}
 
 	items := make([]itemSpan, len(n.elems))
 	for i, e := range n.elems {
 		items[i] = itemSpan{start: e.start, end: e.end}
 	}
-	return applyContainerEdits(orig, blanked, n, items, plan.removed, len(plan.appended), body, itemIndent, closeIndent, lay, edits)
+	return s.applyContainerEdits(n, items, plan.removed, len(plan.appended), buf.Bytes(), itemIndent, closeIndent, edits)
 }
 
 // applyContainerEdits is the shared tail of diffObject and diffArray: given
-// which items go away and what text gets appended, emit the edits. The branches
-// exist because a container with nothing left in it has no separator to attach
-// to, so its interior is rewritten instead.
-func applyContainerEdits(orig, blanked []byte, n *jsonNode, items []itemSpan, removed []int, addedCount int, body []byte, itemIndent, closeIndent string, lay layout, edits *[]edit) error {
-	emptied := len(removed) == len(items)
-
-	if emptied {
-		fillEmptyContainer(n, body, itemIndent, closeIndent, lay, edits)
+// which items go away and what text gets appended, emit the edits.
+func (s *splicer) applyContainerEdits(n *jsonNode, items []itemSpan, removed []int, addedCount int, body []byte, itemIndent, closeIndent string, edits *[]edit) error {
+	if lastSurviving(len(items), removed) < 0 {
+		// Nothing survives, so there is no separator to attach to: the
+		// container's whole interior is rewritten instead.
+		s.fillEmptyContainer(n, body, itemIndent, closeIndent, edits)
 		return nil
 	}
-	if len(removed) > 0 {
-		if !removeItems(orig, blanked, items, removed, edits) {
-			return errUnsupportedShape
+
+	// When the tail is being removed and new items are arriving in the same
+	// pass, the new items simply take the tail's place. The comma that already
+	// separates the last survivor stays exactly where it is — deleting it with
+	// the tail and then re-adding it for the append means two edits at one
+	// offset, which is an overlap, and anchoring the append on the removed item
+	// puts the comma at an offset the deletion splices away.
+	if tail := trailingRun(len(items), removed); tail >= 0 && addedCount > 0 {
+		comma := s.nextComma(items[tail-1].end)
+		if comma < 0 {
+			return errNoSafeSplice
 		}
+		*edits = append(*edits, edit{
+			start: s.trailerEnd(comma + 1),
+			end:   items[len(items)-1].end,
+			text:  []byte(s.lay.newline + itemIndent + string(body)),
+		})
+		earlier := removed[:len(removed)-(len(items)-tail)]
+		if len(earlier) > 0 && !s.removeItems(items, earlier, edits) {
+			return errNoSafeSplice
+		}
+		return nil
+	}
+
+	if len(removed) > 0 && !s.removeItems(items, removed, edits) {
+		return errNoSafeSplice
 	}
 	if addedCount > 0 {
-		appendItems(orig, blanked, items[len(items)-1], body, itemIndent, lay, edits)
+		s.appendItems(items[len(items)-1], body, itemIndent, edits)
 	}
 	return nil
+}
+
+// lastSurviving returns the highest index in [0,count) that is not in removed,
+// or -1 when every item is going away.
+func lastSurviving(count int, removed []int) int {
+	gone := make(map[int]bool, len(removed))
+	for _, i := range removed {
+		gone[i] = true
+	}
+	for i := count - 1; i >= 0; i-- {
+		if !gone[i] {
+			return i
+		}
+	}
+	return -1
+}
+
+// trailingRun returns the first index of the run of removed items that reaches
+// the last item, or -1 when the last item survives. Callers reach it only when
+// something survives, so the returned index is always >= 1.
+func trailingRun(count int, removed []int) int {
+	if len(removed) == 0 || removed[len(removed)-1] != count-1 {
+		return -1
+	}
+	start := count - 1
+	for k := len(removed) - 2; k >= 0 && removed[k] == start-1; k-- {
+		start--
+	}
+	return start
 }
 
 // --- array alignment ---
@@ -725,8 +860,6 @@ type arrayPlan struct {
 // never spliced into the middle — and the caller falls back to rewriting the
 // array rather than guessing at a separator.
 func alignArray(have, want []interface{}) (arrayPlan, bool) {
-	matches := longestCommonSubsequence(have, want)
-
 	var plan arrayPlan
 	ai, bi := 0, 0
 	advance := func(ma, mb int) bool {
@@ -750,7 +883,7 @@ func alignArray(have, want []interface{}) (arrayPlan, bool) {
 		return true
 	}
 
-	for _, m := range matches {
+	for _, m := range longestCommonSubsequence(have, want) {
 		if !advance(m.have, m.want) {
 			return arrayPlan{}, false
 		}

--- a/core/adapters/inbound/agents/hookjson/jsonc_test.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc_test.go
@@ -2,7 +2,10 @@ package hookjson
 
 import (
 	"encoding/json"
+	"math/rand"
 	"os"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -249,4 +252,299 @@ func TestWriteSettings_FreshFileIsPlainEncode(t *testing.T) {
 	if want := "{\n  \"cmd\": \"a && b\"\n}\n"; got != want {
 		t.Errorf("fresh encode = %q, want %q", got, want)
 	}
+}
+
+// --- regressions from the review of PR #1381 ---
+//
+// Every test in this section was seen red against the first version of the
+// splicer. They cover the separator arithmetic in positions the original suite
+// never exercised: it only ever removed the *tail* of a container, which is the
+// one position where the arithmetic happened to be right.
+
+// TestSplice_RemoveMiddleMember: removing an item with survivors on both sides
+// must consume exactly one of the two commas around it. Keeping both wrote
+// `"a": 1,,` — an unparseable settings.json — and it fired on ~11% of randomly
+// shaped documents.
+func TestSplice_RemoveMiddleMember(t *testing.T) {
+	const src = "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}\n"
+	got := spliceTo(t, src, func(s map[string]interface{}) { delete(s, "b") })
+	if want := "{\n  \"a\": 1,\n  \"c\": 3\n}\n"; got != want {
+		t.Errorf("middle removal\n--- want ---\n%q\n--- got ---\n%q", want, got)
+	}
+}
+
+func TestSplice_RemoveMiddleArrayElement(t *testing.T) {
+	const src = "{\n  \"list\": [\n    1,\n    2,\n    3\n  ]\n}\n"
+	got := spliceTo(t, src, func(s map[string]interface{}) {
+		list := s["list"].([]interface{})
+		s["list"] = []interface{}{list[0], list[2]}
+	})
+	if want := "{\n  \"list\": [\n    1,\n    3\n  ]\n}\n"; got != want {
+		t.Errorf("middle element removal\n--- want ---\n%q\n--- got ---\n%q", want, got)
+	}
+}
+
+// TestSplice_RemoveHeadMember: the head has no preceding comma, so the trailing
+// one goes instead — and the item's whole line goes with it rather than leaving
+// a blank, wrongly-indented line behind.
+func TestSplice_RemoveHeadMember(t *testing.T) {
+	const src = "{\n  \"a\": 1,\n  \"b\": 2\n}\n"
+	got := spliceTo(t, src, func(s map[string]interface{}) { delete(s, "a") })
+	if want := "{\n  \"b\": 2\n}\n"; got != want {
+		t.Errorf("head removal\n--- want ---\n%q\n--- got ---\n%q", want, got)
+	}
+}
+
+// TestSplice_AppendAnchorsOnLastSurvivor: when the last item is removed in the
+// same pass that adds one, the new comma must be emitted at the last *surviving*
+// item. Anchoring on the removed one put the comma at an offset the deletion
+// splices away, landing it inside the previous item's `//` trailer — which
+// comments out the separator and breaks the file.
+func TestSplice_AppendAnchorsOnLastSurvivor(t *testing.T) {
+	const src = "{\n  \"a\": 1, // trail\n  \"b\": 2\n}\n"
+	got := spliceTo(t, src, func(s map[string]interface{}) {
+		delete(s, "b")
+		s["z"] = 9
+	})
+	if !strings.Contains(got, "// trail") {
+		t.Errorf("trailing comment lost\n%s", got)
+	}
+	if strings.Contains(got, "// trail,") {
+		t.Errorf("separator was buried inside the comment\n%s", got)
+	}
+	if !strings.Contains(got, `"z": 9`) {
+		t.Errorf("new member missing\n%s", got)
+	}
+}
+
+// TestSplice_MultiLineBlockCommentTrailer: a `/* … */` opening on a value's line
+// and closing on a later one must be treated as one unit. Stopping the trailer
+// scan at the first newline returned an offset inside the comment, which either
+// swallowed the inserted member or deleted the closing `*/` and with it the rest
+// of the document.
+func TestSplice_MultiLineBlockCommentTrailer(t *testing.T) {
+	t.Run("insert after it", func(t *testing.T) {
+		const src = "{\n  \"a\": 1 /* multi\n     line */\n}\n"
+		got := spliceTo(t, src, func(s map[string]interface{}) { s["b"] = 2 })
+		if !strings.Contains(got, "/* multi") || !strings.Contains(got, "line */") {
+			t.Errorf("block comment damaged\n%s", got)
+		}
+		if !strings.Contains(got, `"b": 2`) {
+			t.Errorf("new member missing or swallowed by the comment\n%s", got)
+		}
+	})
+
+	t.Run("remove past it", func(t *testing.T) {
+		const src = "{\n  \"a\": 1, /* multi\n     line */\n  \"b\": 2\n}\n"
+		got := spliceTo(t, src, func(s map[string]interface{}) { delete(s, "b") })
+		if !strings.Contains(got, "/* multi") || !strings.Contains(got, "line */") {
+			t.Errorf("block comment damaged\n%s", got)
+		}
+		if strings.Contains(got, `"b"`) {
+			t.Errorf("member not removed\n%s", got)
+		}
+	})
+}
+
+// --- property test ---
+
+// TestSplice_PropertyRandomMutations is the test that earns its keep. Seven
+// hand-written round-trip cases all passed while the splicer was writing `,,`
+// into 11% of documents, because every one of them removed the *tail* of a
+// container — the single position where the arithmetic happened to be correct.
+// A generator does not share the author's blind spot.
+//
+// The property: for a random JSONC document and a random mutation of it, the
+// splice must succeed (not fall back), must decode to exactly the wanted
+// document, and must still contain every comment it started with. Falling back
+// is safe but lossy, so "no fallbacks" is the assertion that keeps the codec
+// honest — a wrong edit trips spliceSettings' own verification and shows up
+// here as a fallback rather than as silent corruption.
+//
+// The seed is fixed so a failure is reproducible; the failure message prints
+// the document and the mutation needed to reproduce it by hand.
+func TestSplice_PropertyRandomMutations(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260809))
+	const iterations = 2000
+
+	for i := 0; i < iterations; i++ {
+		doc := randomDocument(rng)
+		original := renderJSONC(rng, doc)
+
+		want, err := decodeBytes(blankComments([]byte(original)))
+		if err != nil {
+			t.Fatalf("iteration %d: generated document does not parse: %v\n%s", i, err, original)
+		}
+		wantMap, ok := want.(map[string]interface{})
+		if !ok {
+			t.Fatalf("iteration %d: generated document is not an object\n%s", i, original)
+		}
+		// More than one mutation per document on purpose: a single edit can never
+		// produce a removal run longer than one item, and "delete several
+		// adjacent members at once" is exactly what uninstalling does — the
+		// claudecode adapter removes seven hook events in one pass.
+		mutation, keepsComments := "", true
+		for m, n := 0, 1+rng.Intn(3); m < n; m++ {
+			desc, keeps := mutateDocument(rng, wantMap)
+			mutation += desc + "; "
+			keepsComments = keepsComments && keeps
+		}
+
+		out, err := spliceSettings([]byte(original), wantMap)
+		if err != nil {
+			t.Fatalf("iteration %d: splice fell back (%v) after %s\n--- original ---\n%s", i, err, mutation, original)
+		}
+
+		got, err := decodeBytes(blankComments(out))
+		if err != nil {
+			t.Fatalf("iteration %d: output does not parse: %v after %s\n--- original ---\n%s\n--- got ---\n%s", i, err, mutation, original, out)
+		}
+		// Compare against the normalized form: values the mutation introduced are
+		// plain Go types, while everything decoded from a file is a json.Number,
+		// and that difference is a property of the harness, not of the splice.
+		normalizedWant, err := normalize(wantMap)
+		if err != nil {
+			t.Fatalf("iteration %d: normalize: %v", i, err)
+		}
+		if !reflect.DeepEqual(got, normalizedWant) {
+			t.Fatalf("iteration %d: output is not the wanted document after %s\n--- original ---\n%s\n--- got ---\n%s", i, mutation, original, out)
+		}
+		// A mutation that deletes or replaces a whole subtree legitimately takes
+		// that subtree's comments with it, so comment survival is only asserted
+		// for the mutations that cannot destroy one.
+		if keepsComments {
+			if before, after := strings.Count(original, commentMark), strings.Count(string(out), commentMark); before != after {
+				t.Fatalf("iteration %d: %d of %d comments lost after %s\n--- original ---\n%s\n--- got ---\n%s",
+					i, before-after, before, mutation, original, out)
+			}
+		}
+	}
+}
+
+// commentMark appears in every generated comment, so comment survival is a
+// count rather than a parse.
+const commentMark = "zc"
+
+// randomDocument builds a small object tree: scalars of every JSON type, nested
+// objects and arrays, with enough keys that middle positions come up often.
+func randomDocument(rng *rand.Rand) map[string]interface{} {
+	return randomObject(rng, 0)
+}
+
+func randomObject(rng *rand.Rand, depth int) map[string]interface{} {
+	out := map[string]interface{}{}
+	for i, n := 0, 1+rng.Intn(4); i < n; i++ {
+		out[randomKey(rng, i)] = randomValue(rng, depth)
+	}
+	return out
+}
+
+func randomKey(rng *rand.Rand, i int) string {
+	return string(rune('a'+rng.Intn(6))) + string(rune('0'+i))
+}
+
+func randomValue(rng *rand.Rand, depth int) interface{} {
+	kinds := 5
+	if depth >= 2 {
+		kinds = 3 // stop nesting
+	}
+	switch rng.Intn(kinds) {
+	case 0:
+		return float64(rng.Intn(100))
+	case 1:
+		// Strings deliberately carry the characters the old writer escaped and
+		// the sequences the blanker must not mistake for comments.
+		return []string{"a && b", "x >/dev/null 2>&1", "http://e.com/p", "/* no */", "// no", "plain"}[rng.Intn(6)]
+	case 2:
+		return rng.Intn(2) == 0
+	case 3:
+		return randomObject(rng, depth+1)
+	default:
+		var arr []interface{}
+		for i, n := 0, rng.Intn(4); i < n; i++ {
+			arr = append(arr, randomValue(rng, depth+1))
+		}
+		return arr
+	}
+}
+
+// renderJSONC marshals doc and then sprinkles comments through it — full-line,
+// trailing, and multi-line block — which is what makes the offset arithmetic
+// and the trailer scan interesting.
+func renderJSONC(rng *rand.Rand, doc map[string]interface{}) string {
+	plain, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	var out strings.Builder
+	for _, line := range strings.Split(string(plain), "\n") {
+		indent := line[:len(line)-len(strings.TrimLeft(line, " "))]
+		switch rng.Intn(6) {
+		case 0:
+			out.WriteString(indent + "// " + commentMark + " leading\n")
+		case 1:
+			out.WriteString(indent + "/* " + commentMark + " block\n" + indent + "   continues */\n")
+		case 2:
+			out.WriteString("\n") // a blank line the splice must also preserve
+		}
+		out.WriteString(line)
+		// A trailing comment is only safe on a line that ends a token; every
+		// MarshalIndent line does, so the only rule is not to append twice.
+		if rng.Intn(4) == 0 {
+			out.WriteString(" // " + commentMark + " trailing")
+		} else if rng.Intn(8) == 0 {
+			out.WriteString(" /* " + commentMark + " multi\n   line */")
+		}
+		out.WriteString("\n")
+	}
+	return out.String()
+}
+
+// mutateDocument applies one random edit in place. It returns a description, so
+// a failure names the operation that produced it, and whether that operation is
+// one after which every comment in the document must still be present.
+func mutateDocument(rng *rand.Rand, doc map[string]interface{}) (string, bool) {
+	obj, path := randomContainer(rng, doc, "$")
+	keys := sortedKeys(obj)
+
+	if len(keys) == 0 || rng.Intn(3) == 0 {
+		key := "new" + string(rune('a'+rng.Intn(4)))
+		obj[key] = randomValue(rng, 2)
+		return "add " + path + "." + key, true
+	}
+	key := keys[rng.Intn(len(keys))]
+	_, wasScalar := obj[key].(map[string]interface{})
+	_, wasArray := obj[key].([]interface{})
+	scalar := !wasScalar && !wasArray
+
+	if rng.Intn(2) == 0 {
+		delete(obj, key)
+		// Removing a member also removes any comment attached to it, which is
+		// the right thing to do and impossible to distinguish here from a
+		// comment that should have survived.
+		return "delete " + path + "." + key, false
+	}
+	obj[key] = randomValue(rng, 2)
+	return "replace " + path + "." + key, scalar
+}
+
+// randomContainer descends into a random nested object so mutations land at
+// every depth, not only the top level.
+func randomContainer(rng *rand.Rand, obj map[string]interface{}, path string) (map[string]interface{}, string) {
+	for _, k := range sortedKeys(obj) {
+		child, ok := obj[k].(map[string]interface{})
+		if ok && rng.Intn(3) == 0 {
+			return randomContainer(rng, child, path+"."+k)
+		}
+	}
+	return obj, path
+}
+
+func sortedKeys(obj map[string]interface{}) []string {
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/core/adapters/inbound/agents/hookjson/jsonc_test.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc_test.go
@@ -1,0 +1,252 @@
+package hookjson
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// --- comment blanking ---
+
+// TestBlankComments_PreservesOffsets is the property the whole splicer rests on:
+// a byte offset taken from the blanked text indexes the same byte of the
+// original. If blanking ever changed length, every span in this package would
+// silently point somewhere else.
+func TestBlankComments_PreservesOffsets(t *testing.T) {
+	cases := map[string]string{
+		"line comment":            "{\n  // note\n  \"a\": 1\n}\n",
+		"block comment":           "{\n  /* note */\n  \"a\": 1\n}\n",
+		"multiline block":         "{\n  /* one\n     two */\n  \"a\": 1\n}\n",
+		"trailing line comment":   "{\n  \"a\": 1 // note\n}\n",
+		"comment-looking string":  "{\n  \"a\": \"// not a comment\"\n}\n",
+		"block-looking string":    "{\n  \"a\": \"/* not a comment */\"\n}\n",
+		"escaped quote in string": "{\n  \"a\": \"he said \\\" // no\"\n}\n",
+		"url in string":           "{\n  \"a\": \"http://example.com\"\n}\n",
+		"no comments at all":      "{\n  \"a\": 1\n}\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			blanked := blankComments([]byte(src))
+			if len(blanked) != len(src) {
+				t.Fatalf("length changed: got %d, want %d", len(blanked), len(src))
+			}
+			if strings.Count(string(blanked), "\n") != strings.Count(src, "\n") {
+				t.Errorf("newline count changed\nsrc:     %q\nblanked: %q", src, blanked)
+			}
+			var v interface{}
+			if err := json.Unmarshal(blanked, &v); err != nil {
+				t.Errorf("blanked text is not valid JSON: %v\nblanked: %q", err, blanked)
+			}
+		})
+	}
+}
+
+// TestBlankComments_LeavesStringContentAlone guards the one way a comment
+// blanker can destroy data: mistaking a `//` inside a string for a comment.
+func TestBlankComments_LeavesStringContentAlone(t *testing.T) {
+	src := `{"url": "http://example.com/a", "glob": "/*.go", "cmd": "a && b"}`
+	blanked := string(blankComments([]byte(src)))
+	if blanked != src {
+		t.Errorf("a document with no comments was modified\nsrc:     %q\nblanked: %q", src, blanked)
+	}
+}
+
+// --- splicing ---
+
+// spliceTo is the codec under test end to end: decode a document, apply a
+// mutation to the decoded map, and splice the result back.
+func spliceTo(t *testing.T, original string, mutate func(map[string]interface{})) string {
+	t.Helper()
+	var settings map[string]interface{}
+	if err := json.Unmarshal(blankComments([]byte(original)), &settings); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	mutate(settings)
+	out, err := spliceSettings([]byte(original), settings)
+	if err != nil {
+		t.Fatalf("spliceSettings: %v", err)
+	}
+	if err := json.Unmarshal(blankComments(out), new(interface{})); err != nil {
+		t.Fatalf("spliced output is not parseable: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+func TestSplice_NoChangeIsByteIdentical(t *testing.T) {
+	got := spliceTo(t, jsoncSettings, func(map[string]interface{}) {})
+	if got != jsoncSettings {
+		t.Errorf("an unchanged document was rewritten\n--- want ---\n%s\n--- got ---\n%s", jsoncSettings, got)
+	}
+}
+
+func TestSplice_ScalarChangeTouchesOnlyThatValue(t *testing.T) {
+	got := spliceTo(t, jsoncSettings, func(s map[string]interface{}) {
+		s["theme"] = "Dracula"
+	})
+	if !strings.Contains(got, `"theme": "Dracula"`) {
+		t.Errorf("theme not updated\n%s", got)
+	}
+	if !strings.Contains(got, `"npm run build && npm run list-tools"`) {
+		t.Errorf("an untouched value was re-serialized\n%s", got)
+	}
+	if !strings.Contains(got, "/* Appearance first") {
+		t.Errorf("a comment was lost\n%s", got)
+	}
+	assertKeyOrder(t, got, []string{"theme", "selectedAuthType", "sandbox", "autoAccept"})
+}
+
+// TestSplice_TrailingCommentOnLastMember covers the case where the naive
+// "append a comma after the last value" rule produces a file that no longer
+// parses: the comma would land inside a `//` comment. The comma has to go
+// before the comment and the new member after it.
+func TestSplice_TrailingCommentOnLastMember(t *testing.T) {
+	const src = "{\n  \"a\": 1  // keep me\n}\n"
+	got := spliceTo(t, src, func(s map[string]interface{}) {
+		s["b"] = 2
+	})
+	if !strings.Contains(got, "// keep me") {
+		t.Errorf("trailing comment lost\n%s", got)
+	}
+	if strings.Contains(got, "// keep me,") {
+		t.Errorf("comma was buried inside the comment\n%s", got)
+	}
+}
+
+// TestSplice_RoundTripOfAddThenRemove is the invertibility property that makes
+// install-then-uninstall lossless, exercised directly on the codec across the
+// formatting shapes the separator arithmetic branches on.
+func TestSplice_RoundTripOfAddThenRemove(t *testing.T) {
+	cases := map[string]string{
+		"multiline":                jsoncSettings,
+		"trailing comment":         "{\n  \"a\": 1  // keep me\n}\n",
+		"empty object":             "{}\n",
+		"single line":              `{"a": 1}`,
+		"tab indented":             "{\n\t\"a\": 1\n}\n",
+		"comment before close":     "{\n  \"a\": 1\n  // dangling\n}\n",
+		"blank lines between keys": "{\n  \"a\": 1,\n\n  \"b\": 2\n}\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			added := spliceTo(t, src, func(s map[string]interface{}) {
+				s["hooks"] = map[string]interface{}{"Stop": []interface{}{"x"}}
+			})
+			if !strings.Contains(added, `"hooks"`) {
+				t.Fatalf("hooks not added\n%s", added)
+			}
+			back := spliceTo(t, added, func(s map[string]interface{}) {
+				delete(s, "hooks")
+			})
+			if back != src {
+				t.Errorf("add+remove was not lossless\n--- want ---\n%q\n--- got ---\n%q\n--- intermediate ---\n%s", src, back, added)
+			}
+		})
+	}
+}
+
+// TestSplice_ArrayAppendAndRemove covers the same invertibility one level down,
+// where hook matcher groups actually live.
+func TestSplice_ArrayAppendAndRemove(t *testing.T) {
+	const src = "{\n  \"hooks\": {\n    \"Stop\": [\n      { \"mine\": true }\n    ]\n  }\n}\n"
+
+	added := spliceTo(t, src, func(s map[string]interface{}) {
+		hooks := s["hooks"].(map[string]interface{})
+		stop := hooks["Stop"].([]interface{})
+		hooks["Stop"] = append(stop, map[string]interface{}{"ours": true})
+	})
+	if !strings.Contains(added, `"ours"`) {
+		t.Fatalf("group not appended\n%s", added)
+	}
+	if !strings.Contains(added, `{ "mine": true }`) {
+		t.Errorf("the user's existing group was re-serialized rather than left alone\n%s", added)
+	}
+
+	back := spliceTo(t, added, func(s map[string]interface{}) {
+		hooks := s["hooks"].(map[string]interface{})
+		stop := hooks["Stop"].([]interface{})
+		hooks["Stop"] = stop[:len(stop)-1]
+	})
+	if back != src {
+		t.Errorf("append+remove was not lossless\n--- want ---\n%q\n--- got ---\n%q", src, back)
+	}
+}
+
+// TestSplice_EditInsideArrayElementKeepsSiblings pins that an in-place upgrade
+// of one hook entry does not rewrite the entries around it.
+func TestSplice_EditInsideArrayElementKeepsSiblings(t *testing.T) {
+	const src = "{\n  \"list\": [\n    { \"keep\": \"a && b\" },\n    { \"change\": 1 }\n  ]\n}\n"
+	got := spliceTo(t, src, func(s map[string]interface{}) {
+		list := s["list"].([]interface{})
+		list[1].(map[string]interface{})["change"] = 2
+	})
+	if !strings.Contains(got, `{ "keep": "a && b" }`) {
+		t.Errorf("sibling element was reformatted\n%s", got)
+	}
+	if !strings.Contains(got, `"change": 2`) {
+		t.Errorf("target not updated\n%s", got)
+	}
+}
+
+func TestSplice_CRLFDocumentKeepsCRLF(t *testing.T) {
+	const src = "{\r\n  \"a\": 1\r\n}\r\n"
+	got := spliceTo(t, src, func(s map[string]interface{}) { s["b"] = 2 })
+	if strings.Contains(strings.ReplaceAll(got, "\r\n", ""), "\n") {
+		t.Errorf("a bare LF was introduced into a CRLF document\n%q", got)
+	}
+}
+
+// --- locks: behavior that must NOT change (issue #1371 scope note 4) ---
+//
+// These pass on main by construction. They are here so that the leniency added
+// for comments cannot quietly grow into leniency for broken files, which is a
+// separate decision belonging to issue #1362.
+
+func TestMalformedInput_StillErrors(t *testing.T) {
+	cases := map[string]string{
+		"truncated":        `{"hooks":`,
+		"trailing comma":   "{\n  \"a\": 1,\n}\n",
+		"single quotes":    `{'a': 1}`,
+		"unterminated str": `{"a": "oops}`,
+		"unclosed comment": "{\n  /* never closed\n  \"a\": 1\n}\n",
+		"bare word":        `{a: 1}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := ReadSettings(seedRaw(t, "bad.json", body)); err == nil {
+				t.Errorf("ReadSettings(%q): got nil error, want a decode error", body)
+			}
+		})
+	}
+}
+
+// TestMalformedInput_IsNeverOverwritten is the consequence that actually matters
+// to a user: a config we cannot parse is left exactly as they wrote it.
+func TestMalformedInput_IsNeverOverwritten(t *testing.T) {
+	const broken = "{\n  \"hooks\": [[[\n"
+	path := seedRaw(t, "broken.json", broken)
+
+	if _, err := EnsureInstalled(httpConfig(path)); err == nil {
+		t.Error("EnsureInstalled on a malformed file: got nil error, want a decode error")
+	}
+	if got := readRawFile(t, path); got != broken {
+		t.Errorf("malformed file was rewritten\n--- want ---\n%q\n--- got ---\n%q", broken, got)
+	}
+}
+
+// TestWriteSettings_FreshFileIsPlainEncode pins the no-original path, which is
+// the one the existing shape lock covers and the one every brand-new install
+// takes.
+func TestWriteSettings_FreshFileIsPlainEncode(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/new.json"
+	err := WriteSettings(path, map[string]interface{}{"cmd": "a && b"}, func(_ string, data []byte) error {
+		return os.WriteFile(path, data, 0o600)
+	})
+	if err != nil {
+		t.Fatalf("WriteSettings: %v", err)
+	}
+	got := readRawFile(t, path)
+	if want := "{\n  \"cmd\": \"a && b\"\n}\n"; got != want {
+		t.Errorf("fresh encode = %q, want %q", got, want)
+	}
+}

--- a/core/adapters/inbound/agents/hookjson/jsonc_test.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc_test.go
@@ -637,3 +637,40 @@ func TestSplice_MidArrayInsertRewritesOnlyThatArray(t *testing.T) {
 			"the alignment learned mid-array insertion and this test should assert preservation\n%s", got)
 	}
 }
+
+// TestSplice_HugeArrayDoesNotAllocateQuadratically pins the bound on the
+// alignment table. The lengths feeding it come from the user's settings file,
+// and the table costs len(a)·len(b) ints — CodeQL flagged the unbounded make()
+// as a high-severity allocation-size overflow (PR #1381). Past the bound the
+// array is rewritten rather than aligned, which is correct but lossy for that
+// array's comments, so this asserts the document still comes out right.
+func TestSplice_HugeArrayDoesNotAllocateQuadratically(t *testing.T) {
+	big := make([]interface{}, maxAlignedArray+1)
+	for i := range big {
+		big[i] = json.Number("0")
+	}
+	if _, ok := alignArray(big, append(slices.Clone(big), json.Number("1"))); ok {
+		t.Fatalf("alignArray accepted %d elements; the quadratic table must be bounded", len(big))
+	}
+
+	// End to end: an oversized array still splices to the right document.
+	var src strings.Builder
+	src.WriteString("{\n  // keep me\n  \"list\": [")
+	for i := range big {
+		if i > 0 {
+			src.WriteString(", ")
+		}
+		src.WriteString("0")
+	}
+	src.WriteString("]\n}\n")
+
+	got := spliceTo(t, src.String(), func(s map[string]interface{}) {
+		s["list"] = append(s["list"].([]interface{}), json.Number("1"))
+	})
+	if !strings.Contains(got, "// keep me") {
+		t.Errorf("the fallback reformatted more than the oversized array\n%.200s", got)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(got), "]\n}") {
+		t.Errorf("unexpected shape after the oversized-array fallback\n%.200s", got)
+	}
+}

--- a/core/adapters/inbound/agents/hookjson/jsonc_test.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc_test.go
@@ -2,6 +2,7 @@ package hookjson
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"math/rand"
@@ -672,5 +673,96 @@ func TestSplice_HugeArrayDoesNotAllocateQuadratically(t *testing.T) {
 	}
 	if !strings.HasSuffix(strings.TrimSpace(got), "]\n}") {
 		t.Errorf("unexpected shape after the oversized-array fallback\n%.200s", got)
+	}
+}
+
+// --- fallback observability (issue #1371) ---
+
+// countsDelta runs fn and reports how many fallbacks of each reason it caused.
+// Deltas rather than absolutes because the counters are package-level and every
+// other test in this file contributes to them.
+func countsDelta(fn func()) map[FallbackReason]uint64 {
+	before := Fallbacks()
+	fn()
+	after := Fallbacks()
+
+	delta := map[FallbackReason]uint64{}
+	for reason, n := range after {
+		if d := n - before[reason]; d > 0 {
+			delta[reason] = d
+		}
+	}
+	return delta
+}
+
+// TestFallback_ArrayRewriteIsCounted is the reachable end of the contract: a
+// degradation the user can actually trigger must show up in the counters, not
+// just in the output. Without this the array rewrite is exactly the kind of
+// silent loss that made four separate corruption bugs in this file invisible
+// until someone wrote a property test.
+func TestFallback_ArrayRewriteIsCounted(t *testing.T) {
+	const src = "{\n  \"list\": [\n    1, // inner\n    3\n  ]\n}\n"
+
+	delta := countsDelta(func() {
+		spliceTo(t, src, func(s map[string]interface{}) {
+			list := s["list"].([]interface{})
+			s["list"] = []interface{}{list[0], json.Number("2"), list[1]}
+		})
+	})
+
+	if delta[FallbackArrayRewrite] != 1 {
+		t.Errorf("array rewrite not counted: got %v, want one %s", delta, FallbackArrayRewrite)
+	}
+	if delta[FallbackVerifyFailed] != 0 {
+		t.Errorf("a scoped array rewrite must not register as a verifier failure: %v", delta)
+	}
+}
+
+// TestFallback_CleanSpliceCountsNothing is the other half — a counter that only
+// ever goes up is not evidence of anything.
+func TestFallback_CleanSpliceCountsNothing(t *testing.T) {
+	delta := countsDelta(func() {
+		spliceTo(t, jsoncSettings, func(s map[string]interface{}) { s["theme"] = "Dracula" })
+	})
+	if len(delta) != 0 {
+		t.Errorf("a clean splice registered a fallback: %v", delta)
+	}
+}
+
+// TestFallback_WholeDocumentReasonsAreWired covers the three whole-document
+// reasons. They are unreachable from outside this package by construction —
+// which is the entire reason they are counted: if one ever fires in the field
+// it is a defect in jsonc.go, and FallbackVerifyFailed says so specifically.
+// The assertion is that each reason has a live counter slot and that
+// noSafeSplice routes to the sentinel renderSettings falls back on.
+func TestFallback_WholeDocumentReasonsAreWired(t *testing.T) {
+	for _, reason := range []FallbackReason{
+		FallbackUnsupportedShape, FallbackOverlappingEdits, FallbackVerifyFailed,
+	} {
+		t.Run(string(reason), func(t *testing.T) {
+			var err error
+			delta := countsDelta(func() { err = noSafeSplice(reason) })
+
+			if !errors.Is(err, errNoSafeSplice) {
+				t.Errorf("noSafeSplice(%s) = %v, want the errNoSafeSplice sentinel renderSettings falls back on", reason, err)
+			}
+			if delta[reason] != 1 {
+				t.Errorf("noSafeSplice(%s) counted %v, want one", reason, delta)
+			}
+		})
+	}
+}
+
+// TestFallback_RenderSettingsFallsBackOnSentinel pins what the counter is
+// counting: an errNoSafeSplice becomes a whole-document encode rather than a
+// failed write, so the user keeps a valid file and loses only formatting.
+func TestFallback_RenderSettingsFallsBackOnSentinel(t *testing.T) {
+	// A document whose top level is not an object cannot be spliced onto a map.
+	got, err := renderSettings([]byte("[1, 2]\n"), map[string]interface{}{"cmd": "a && b"})
+	if err != nil {
+		t.Fatalf("renderSettings: %v", err)
+	}
+	if want := "{\n  \"cmd\": \"a && b\"\n}\n"; string(got) != want {
+		t.Errorf("fallback encode = %q, want %q", got, want)
 	}
 }

--- a/core/adapters/inbound/agents/hookjson/jsonc_test.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc_test.go
@@ -2,10 +2,12 @@ package hookjson
 
 import (
 	"encoding/json"
+	"fmt"
+	"maps"
 	"math/rand"
 	"os"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -204,9 +206,10 @@ func TestSplice_CRLFDocumentKeepsCRLF(t *testing.T) {
 // for comments cannot quietly grow into leniency for broken files, which is a
 // separate decision belonging to issue #1362.
 
+// The plain-truncated case lives in TestReadSettings_MalformedJSONErrors; these
+// are the shapes a JSONC-tolerant reader might newly be tempted to accept.
 func TestMalformedInput_StillErrors(t *testing.T) {
 	cases := map[string]string{
-		"truncated":        `{"hooks":`,
 		"trailing comma":   "{\n  \"a\": 1,\n}\n",
 		"single quotes":    `{'a': 1}`,
 		"unterminated str": `{"a": "oops}`,
@@ -236,9 +239,11 @@ func TestMalformedInput_IsNeverOverwritten(t *testing.T) {
 	}
 }
 
-// TestWriteSettings_FreshFileIsPlainEncode pins the no-original path, which is
-// the one the existing shape lock covers and the one every brand-new install
-// takes.
+// TestWriteSettings_FreshFileIsPlainEncode complements
+// TestWriteSettings_ShapeAndDelegation rather than repeating it: that one pins
+// the shape through a fake writer, this one goes through a real file on disk
+// (the no-original branch of WriteSettings' own re-read) and adds the assertion
+// that a fresh encode does not HTML-escape either.
 func TestWriteSettings_FreshFileIsPlainEncode(t *testing.T) {
 	dir := t.TempDir()
 	path := dir + "/new.json"
@@ -504,6 +509,16 @@ func renderJSONC(rng *rand.Rand, doc map[string]interface{}) string {
 // a failure names the operation that produced it, and whether that operation is
 // one after which every comment in the document must still be present.
 func mutateDocument(rng *rand.Rand, doc map[string]interface{}) (string, bool) {
+	// Arrays get their own mutations rather than only ever being replaced
+	// wholesale as an object member. Arrays are what the hook machinery actually
+	// edits — `hooks[event]` is an array of matcher groups, appended to on
+	// install and filtered on uninstall — so a generator that only mutates
+	// object members would inherit the very blind spot this test exists to
+	// escape.
+	if sites := arraySites(doc, "$"); len(sites) > 0 && rng.Intn(3) == 0 {
+		return mutateArray(rng, sites[rng.Intn(len(sites))])
+	}
+
 	obj, path := randomContainer(rng, doc, "$")
 	keys := sortedKeys(obj)
 
@@ -540,11 +555,85 @@ func randomContainer(rng *rand.Rand, obj map[string]interface{}, path string) (m
 	return obj, path
 }
 
-func sortedKeys(obj map[string]interface{}) []string {
-	keys := make([]string, 0, len(obj))
-	for k := range obj {
-		keys = append(keys, k)
+// arraySite is one array reachable from the document, addressed through the
+// object that holds it so the mutation can write a new slice back.
+type arraySite struct {
+	parent map[string]interface{}
+	key    string
+	path   string
+}
+
+func arraySites(obj map[string]interface{}, path string) []arraySite {
+	var out []arraySite
+	for _, k := range sortedKeys(obj) {
+		switch v := obj[k].(type) {
+		case []interface{}:
+			out = append(out, arraySite{parent: obj, key: k, path: path + "." + k})
+			for i, e := range v {
+				if child, ok := e.(map[string]interface{}); ok {
+					out = append(out, arraySites(child, fmt.Sprintf("%s.%s[%d]", path, k, i))...)
+				}
+			}
+		case map[string]interface{}:
+			out = append(out, arraySites(v, path+"."+k)...)
+		}
 	}
-	sort.Strings(keys)
-	return keys
+	return out
+}
+
+// mutateArray appends to, removes from, or edits one element of an array. The
+// remove branch is what produces multi-element removal runs, which is where the
+// separator arithmetic is hardest.
+func mutateArray(rng *rand.Rand, site arraySite) (string, bool) {
+	arr := site.parent[site.key].([]interface{})
+
+	if len(arr) == 0 || rng.Intn(3) == 0 {
+		site.parent[site.key] = append(slices.Clone(arr), randomValue(rng, 2))
+		return "array-append " + site.path, true
+	}
+	at := rng.Intn(len(arr))
+	if rng.Intn(2) == 0 {
+		site.parent[site.key] = slices.Delete(slices.Clone(arr), at, at+1)
+		return fmt.Sprintf("array-remove %s[%d]", site.path, at), false
+	}
+	next := slices.Clone(arr)
+	next[at] = randomValue(rng, 2)
+	site.parent[site.key] = next
+	// Not comment-preserving, even when the old element was a scalar: if the
+	// new value happens to equal another element, the alignment reads the change
+	// as a removal plus a mid-array insertion, and a mid-array insertion is the
+	// documented case where the whole array is rewritten
+	// (TestSplice_MidArrayInsertRewritesOnlyThatArray).
+	return fmt.Sprintf("array-replace %s[%d]", site.path, at), false
+}
+
+func sortedKeys(obj map[string]interface{}) []string {
+	return slices.Sorted(maps.Keys(obj))
+}
+
+// TestSplice_MidArrayInsertRewritesOnlyThatArray exercises the alignment's
+// deliberate safety valve. A new element anywhere but the tail has no separator
+// to hang an edit off without guessing, so the array is re-encoded whole —
+// costing that array's comments and nothing else. The branch is unreachable
+// from this package's own merges (hook groups are appended and removed, never
+// spliced into the middle), which is exactly why it needs a test of its own:
+// nothing else would ever run it.
+func TestSplice_MidArrayInsertRewritesOnlyThatArray(t *testing.T) {
+	const src = "{\n  // keep me\n  \"list\": [\n    1, // inner comment\n    3\n  ],\n  \"other\": \"a && b\" // also keep me\n}\n"
+
+	got := spliceTo(t, src, func(s map[string]interface{}) {
+		list := s["list"].([]interface{})
+		s["list"] = []interface{}{list[0], json.Number("2"), list[1]}
+	})
+
+	if !strings.Contains(got, "// keep me") || !strings.Contains(got, "// also keep me") {
+		t.Errorf("the fallback reformatted more than the one array\n%s", got)
+	}
+	if !strings.Contains(got, `"a && b"`) {
+		t.Errorf("an untouched value outside the array was re-serialized\n%s", got)
+	}
+	if strings.Contains(got, "// inner comment") {
+		t.Errorf("expected the rewritten array to lose its own comment; if this now passes,\n"+
+			"the alignment learned mid-array insertion and this test should assert preservation\n%s", got)
+	}
 }

--- a/core/adapters/inbound/agents/hookjson/roundtrip_test.go
+++ b/core/adapters/inbound/agents/hookjson/roundtrip_test.go
@@ -1,0 +1,211 @@
+package hookjson
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// jsoncSettings is the fixture issue #1371 is about: a realistic hand-maintained
+// agent config that a naive read-modify-write destroys three different ways at
+// once. Every property below is deliberate and is asserted on somewhere in this
+// file.
+//
+//   - Comments, both line and block. gemini-cli's ~/.gemini/settings.json is
+//     JSONC: it reads the file through stripJsonComments and writes it back
+//     through the comment-json package specifically so these survive.
+//   - A deliberately NON-alphabetical key order ("theme" first, "autoAccept"
+//     last). json.MarshalIndent over a map sorts keys, so a writer that
+//     re-serializes the whole document reorders a file the user hand-organized.
+//   - An `&&` inside a command string, plus `>` and `|`. encoding/json rewrites
+//     `<`, `>` and `&` into their six-character backslash-u escapes unless
+//     SetEscapeHTML(false) is set, so `npm run build && npm run list-tools`
+//     comes back mangled. assertNoHTMLEscapes below spells those escapes out.
+//
+// It is a const rather than a testdata file so the exact bytes being asserted on
+// are visible next to the assertion.
+const jsoncSettings = `// ~/.gemini/settings.json — hand-maintained. Comments are legal in this file
+// and the CLI preserves them, so anything else that rewrites it must too.
+{
+  /* Appearance first, on purpose: it is what gets changed most often. */
+  "theme": "GitHub",
+  "selectedAuthType": "oauth-personal",
+
+  // Sandboxing is off because the build script shells out to docker.
+  "sandbox": false,
+
+  // The && below is load-bearing: it must not come back HTML-escaped.
+  "toolDiscoveryCommand": "npm run build && npm run list-tools",
+  "toolCallCommand": "node ./tools/call.js 2>/dev/null || true",
+
+  "excludeTools": ["ShellTool(rm -rf)"],
+  "contextFileName": "GEMINI.md",
+
+  // Deliberately last, and deliberately not in alphabetical order.
+  "autoAccept": false
+}
+`
+
+// seedRawFile writes raw bytes as the settings file, bypassing the Go-map
+// seeders the rest of this package's tests use. A map seeder cannot express a
+// comment or a key order, which is exactly what these tests are about.
+func seedRawFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("seed %s: %v", path, err)
+	}
+	return path
+}
+
+func readRawFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// TestRoundTrip_JSONCSettingsSurviveInstallThenUninstall is the deliverable of
+// issue #1371: grant, then revoke, and the user gets their file back exactly as
+// they wrote it. Byte-identical is the assertion because every weaker one —
+// "still parses", "keys still present" — passes on a file whose comments have
+// been deleted and whose keys have been reshuffled.
+func TestRoundTrip_JSONCSettingsSurviveInstallThenUninstall(t *testing.T) {
+	for name, build := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := seedRawFile(t, t.TempDir(), "settings.json", jsoncSettings)
+			cfg := build(path)
+
+			installed, err := EnsureInstalled(cfg)
+			if err != nil {
+				t.Fatalf("EnsureInstalled: %v", err)
+			}
+			if !installed {
+				t.Fatal("EnsureInstalled reported no change; expected a fresh install")
+			}
+
+			removed, err := Uninstall(cfg)
+			if err != nil {
+				t.Fatalf("Uninstall: %v", err)
+			}
+			if !removed {
+				t.Fatal("Uninstall reported no change; expected our hooks to be removed")
+			}
+
+			if got := readRawFile(t, path); got != jsoncSettings {
+				t.Errorf("install+uninstall was not lossless\n--- want (original) ---\n%s\n--- got ---\n%s", jsoncSettings, got)
+			}
+		})
+	}
+}
+
+// TestEnsureInstalled_PreservesCommentsOrderAndAmpersands pins the intermediate
+// state, so a writer that destroys the file on install and happens to restore it
+// on uninstall cannot pass the round-trip test above by cancelling its own
+// damage out.
+func TestEnsureInstalled_PreservesCommentsOrderAndAmpersands(t *testing.T) {
+	for name, build := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := seedRawFile(t, t.TempDir(), "settings.json", jsoncSettings)
+
+			if _, err := EnsureInstalled(build(path)); err != nil {
+				t.Fatalf("EnsureInstalled: %v", err)
+			}
+			got := readRawFile(t, path)
+
+			for _, comment := range []string{
+				"// ~/.gemini/settings.json — hand-maintained.",
+				"/* Appearance first, on purpose: it is what gets changed most often. */",
+				"// Sandboxing is off because the build script shells out to docker.",
+				"// Deliberately last, and deliberately not in alphabetical order.",
+			} {
+				if !strings.Contains(got, comment) {
+					t.Errorf("comment deleted by install: %q\n--- got ---\n%s", comment, got)
+				}
+			}
+
+			if !strings.Contains(got, `"npm run build && npm run list-tools"`) {
+				t.Errorf("`&&` was HTML-escaped or otherwise mangled\n--- got ---\n%s", got)
+			}
+			assertNoHTMLEscapes(t, got)
+
+			assertKeyOrder(t, got, []string{
+				"theme", "selectedAuthType", "sandbox", "toolDiscoveryCommand",
+				"toolCallCommand", "excludeTools", "contextFileName", "autoAccept",
+			})
+		})
+	}
+}
+
+// TestEnsureInstalled_PlainJSONKeepsOrderAndEscaping is the claudecode half of
+// the issue: ~/.claude/settings.json carries no comments, so the parse never
+// fails and the corruption is entirely silent — the file simply comes back
+// alphabetized with its `&&` escaped.
+func TestEnsureInstalled_PlainJSONKeepsOrderAndEscaping(t *testing.T) {
+	const plain = `{
+  "theme": "dark",
+  "statusLine": {
+    "type": "command",
+    "command": "date && whoami >/dev/null 2>&1 || true"
+  },
+  "autoAccept": false
+}
+`
+	for name, build := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := seedRawFile(t, t.TempDir(), "settings.json", plain)
+
+			if _, err := EnsureInstalled(build(path)); err != nil {
+				t.Fatalf("EnsureInstalled: %v", err)
+			}
+			got := readRawFile(t, path)
+
+			if !strings.Contains(got, `"date && whoami >/dev/null 2>&1 || true"`) {
+				t.Errorf("user command was HTML-escaped\n--- got ---\n%s", got)
+			}
+			assertNoHTMLEscapes(t, got)
+			assertKeyOrder(t, got, []string{"theme", "statusLine", "autoAccept"})
+		})
+	}
+}
+
+// assertNoHTMLEscapes fails if the document carries any of the three escapes
+// encoding/json emits unless SetEscapeHTML(false) is set. The needles are built
+// by concatenation rather than written literally so that nothing along the way
+// can quietly turn the six characters back into the one they denote — which
+// would leave the assertion searching for `&` in a file that legitimately
+// contains `&&`, and passing for the wrong reason.
+func assertNoHTMLEscapes(t *testing.T, doc string) {
+	t.Helper()
+	for _, hex := range []string{"0026", "003c", "003e", "003C", "003E"} {
+		needle := "\\u" + hex
+		if strings.Contains(doc, needle) {
+			t.Errorf("output contains the HTML escape %s\n--- got ---\n%s", needle, doc)
+		}
+	}
+}
+
+// assertKeyOrder checks that the given top-level-ish keys appear in the file in
+// the order listed. It works on the raw text rather than a decoded map because a
+// decoded map has no order to assert on — which is precisely how this class of
+// bug stayed invisible to every existing test in this package.
+func assertKeyOrder(t *testing.T, doc string, keys []string) {
+	t.Helper()
+	prev := -1
+	prevKey := ""
+	for _, k := range keys {
+		at := strings.Index(doc, `"`+k+`"`)
+		if at < 0 {
+			t.Errorf("key %q missing from output\n--- got ---\n%s", k, doc)
+			return
+		}
+		if at < prev {
+			t.Errorf("key order not preserved: %q now precedes %q\n--- got ---\n%s", k, prevKey, doc)
+			return
+		}
+		prev, prevKey = at, k
+	}
+}

--- a/core/adapters/inbound/agents/hookjson/roundtrip_test.go
+++ b/core/adapters/inbound/agents/hookjson/roundtrip_test.go
@@ -2,7 +2,6 @@ package hookjson
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -47,18 +46,6 @@ const jsoncSettings = `// ~/.gemini/settings.json — hand-maintained. Comments 
 }
 `
 
-// seedRawFile writes raw bytes as the settings file, bypassing the Go-map
-// seeders the rest of this package's tests use. A map seeder cannot express a
-// comment or a key order, which is exactly what these tests are about.
-func seedRawFile(t *testing.T, dir, name, content string) string {
-	t.Helper()
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatalf("seed %s: %v", path, err)
-	}
-	return path
-}
-
 func readRawFile(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)
@@ -76,7 +63,7 @@ func readRawFile(t *testing.T, path string) string {
 func TestRoundTrip_JSONCSettingsSurviveInstallThenUninstall(t *testing.T) {
 	for name, build := range configs() {
 		t.Run(name, func(t *testing.T) {
-			path := seedRawFile(t, t.TempDir(), "settings.json", jsoncSettings)
+			path := seedRaw(t, "settings.json", jsoncSettings)
 			cfg := build(path)
 
 			installed, err := EnsureInstalled(cfg)
@@ -109,7 +96,7 @@ func TestRoundTrip_JSONCSettingsSurviveInstallThenUninstall(t *testing.T) {
 func TestEnsureInstalled_PreservesCommentsOrderAndAmpersands(t *testing.T) {
 	for name, build := range configs() {
 		t.Run(name, func(t *testing.T) {
-			path := seedRawFile(t, t.TempDir(), "settings.json", jsoncSettings)
+			path := seedRaw(t, "settings.json", jsoncSettings)
 
 			if _, err := EnsureInstalled(build(path)); err != nil {
 				t.Fatalf("EnsureInstalled: %v", err)
@@ -156,7 +143,7 @@ func TestEnsureInstalled_PlainJSONKeepsOrderAndEscaping(t *testing.T) {
 `
 	for name, build := range configs() {
 		t.Run(name, func(t *testing.T) {
-			path := seedRawFile(t, t.TempDir(), "settings.json", plain)
+			path := seedRaw(t, "settings.json", plain)
 
 			if _, err := EnsureInstalled(build(path)); err != nil {
 				t.Fatalf("EnsureInstalled: %v", err)
@@ -224,7 +211,7 @@ func TestUninstall_EmptiedHooksObjectIsRemoved(t *testing.T) {
 	const src = "{\n  \"theme\": \"dark\"\n}\n"
 	for name, build := range configs() {
 		t.Run(name, func(t *testing.T) {
-			path := seedRawFile(t, t.TempDir(), "settings.json", src)
+			path := seedRaw(t, "settings.json", src)
 			cfg := build(path)
 			mustEnsure(t, cfg, "install", true)
 			mustUninstall(t, cfg, "uninstall", true)
@@ -242,7 +229,7 @@ func TestUninstall_UserHooksKeepTheObject(t *testing.T) {
 	const src = "{\n  \"hooks\": {\n    \"PreToolUse\": [\n      {\n        \"hooks\": [\n          { \"type\": \"command\", \"command\": \"echo mine && true\" }\n        ]\n      }\n    ]\n  }\n}\n"
 	for name, build := range configs() {
 		t.Run(name, func(t *testing.T) {
-			path := seedRawFile(t, t.TempDir(), "settings.json", src)
+			path := seedRaw(t, "settings.json", src)
 			cfg := build(path)
 			mustEnsure(t, cfg, "install", true)
 			mustUninstall(t, cfg, "uninstall", true)

--- a/core/adapters/inbound/agents/hookjson/roundtrip_test.go
+++ b/core/adapters/inbound/agents/hookjson/roundtrip_test.go
@@ -209,3 +209,46 @@ func assertKeyOrder(t *testing.T, doc string, keys []string) {
 		prev, prevKey = at, k
 	}
 }
+
+// TestUninstall_EmptiedHooksObjectIsRemoved pins the one behavior change this
+// work makes beyond the three lossy ones: an emptied "hooks" object goes away,
+// so revoking consent on a config that had no hooks gives the file back rather
+// than leaving `"hooks": {}` litter behind.
+//
+// The narrow case it does NOT cover is a user who wrote `"hooks": {"Stop": []}`
+// themselves. Their "Stop" key is already deleted by removeOurHook on main —
+// that `delete(hooksMap, event)` predates this change and is untouched by it —
+// so all this adds is removal of the empty object that deletion leaves. The
+// user content was lost before; only the wrapper is new.
+func TestUninstall_EmptiedHooksObjectIsRemoved(t *testing.T) {
+	const src = "{\n  \"theme\": \"dark\"\n}\n"
+	for name, build := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := seedRawFile(t, t.TempDir(), "settings.json", src)
+			cfg := build(path)
+			mustEnsure(t, cfg, "install", true)
+			mustUninstall(t, cfg, "uninstall", true)
+			if got := readRawFile(t, path); got != src {
+				t.Errorf("uninstall left something behind\n--- want ---\n%q\n--- got ---\n%q", src, got)
+			}
+		})
+	}
+}
+
+// TestUninstall_UserHooksKeepTheObject is the other side of it: any surviving
+// user-authored hook keeps "hooks" alive, so the cleanup can never take a
+// populated object with it.
+func TestUninstall_UserHooksKeepTheObject(t *testing.T) {
+	const src = "{\n  \"hooks\": {\n    \"PreToolUse\": [\n      {\n        \"hooks\": [\n          { \"type\": \"command\", \"command\": \"echo mine && true\" }\n        ]\n      }\n    ]\n  }\n}\n"
+	for name, build := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := seedRawFile(t, t.TempDir(), "settings.json", src)
+			cfg := build(path)
+			mustEnsure(t, cfg, "install", true)
+			mustUninstall(t, cfg, "uninstall", true)
+			if got := readRawFile(t, path); got != src {
+				t.Errorf("the user's own hook was not restored exactly\n--- want ---\n%q\n--- got ---\n%q", src, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1371.

## This fixes a corruption that is shipping today

Every claudecode user who has hooks or a statusline enabled has already had `~/.claude/settings.json` rewritten with their keys alphabetised and their shell operators mangled. `json.MarshalIndent` sorts map keys and HTML-escapes `<`, `>` and `&`, and the statusline command this package writes ends in `>/dev/null 2>&1` — so it is stored as `\u003e/dev/null 2\u003e\u00261`. That happens on every install, silently, and it also rewrites any `&&` the user put in a command of their own.

That is the part of this PR with a user waiting on it, and it is not contingent on anything.

**Separately**, the same fix makes JSONC readable, which unblocks installing hooks into a comment-bearing config for whichever adapter needs it first. (#1355's Phase D has since moved from gemini-cli to copilot, so this is no longer a blocker for that rollout slice — the claudecode fix above stands on its own.)

### Correcting the issue's premise

#1371 says our first install into a commented config "would silently delete every comment". It would not: `encoding/json` **rejects** comments, so `ReadSettings` errored, `EnsureInstalled` returned before writing, and the file was untouched. Combined with #1362 swallowing that error, the symptom would have been *"hooks never install, no message"* — a hard failure hidden, not a silent corruption. The silent corruption is the key-order and escaping half, on strict-JSON files, today. Noted on the issue as well.

## What was wrong, in full

| | Symptom | Bites today? |
|---|---|---|
| **Key order** | `MarshalIndent` sorts map keys, alphabetising a hand-organised file on first install. | **Yes** — `~/.claude/settings.json`, `~/.codex/hooks.json` |
| **HTML escaping** | `<`, `>`, `&` became `\u003c` / `\u003e` / `\u0026`. | **Yes** — the statusline command ends in `>/dev/null 2>&1` |
| **Comments** | Not deleted — *rejected*, so the install errored and merged nothing. | Not yet; this is the JSONC unblock |

## The fix

Stop re-serializing what we did not change.

- **`ReadSettings`** blanks comments to spaces **in place**. Length is preserved, so every byte offset in the blanked text still indexes the same byte of the original — that is what lets `encoding/json`, which has never heard of comments, hand back offsets usable against a JSONC file. Decoder error offsets stay meaningful too (relevant to #1362).
- **`WriteSettings`** re-reads the file it is about to replace, structurally diffs the wanted document against it, and splices **only the byte ranges that differ**. A subtree that already matches emits no edits at all, so comments, ordering, blank lines, indentation style, CRLF and unescaped `&&` survive because those bytes are copied, not regenerated.
- Insertion and removal are written as **exact inverses**, which is what makes install-then-uninstall byte-identical.
- Every byte of JSON this package emits goes through one encoder with `SetEscapeHTML(false)`, so the flag this PR exists to set is written in exactly one place.
- **The splicer verifies its own output**: the spliced bytes are re-decoded and compared against the document they claim to represent, falling back to a whole-document encode on mismatch. Hand-rolled byte arithmetic over the user's real config should fail toward losing comments, never toward losing data.

`ReadSettings`/`WriteSettings` keep their exact signatures, so `contracttesting`, both adapters and the statusline installer needed no changes — and the statusline path (the third writer of `~/.claude/settings.json`) gets the fix for free.

## Dependency decision: none added

The obvious candidate is **`github.com/tailscale/hujson`** (JWCC parser, BSD-3-Clause, Tailscale-maintained, last commit 2026-07-27, no runtime transitive deps). Rejected:

1. **It forces a repo-wide Go bump.** Verified, not assumed:
   ```
   $ go get github.com/tailscale/hujson
   go: github.com/tailscale/hujson@v0.0.0-20260727124030-b80ff77dac4f requires go >= 1.26; switching to go1.26.5
   go: upgraded go 1.25.12 => 1.26
   ```
   `core/go.mod` pins `go 1.25.12` and `linux.yml` feeds CI from it via `go-version-file`. A Go language-version bump riding along in a hook-config bugfix is the unrelated churn AGENTS.md warns about for lockfiles.
2. **It solves less than half the problem.** hujson gives a JSONC *parser*. It has no "merge this map into that AST" operation, and its `Format()` reformats the whole document — destructive to the very formatting we are protecting. The diff/splice walk is still hand-written either way.
3. **Untagged** — pseudo-versions only, so we would pin a commit.

So the only bespoke lexing is a ~40-line comment blanker; structure and byte offsets come from `encoding/json`'s own `Decoder`. **Assumed, not verified:** hujson's licence and maintenance activity are read off public repo metadata, not audited.

## Red-first evidence

Final tests, run against `origin/main`'s `hookjson.go` with `jsonc.go` removed:

```
--- FAIL: TestRoundTrip_JSONCSettingsSurviveInstallThenUninstall/command
    roundtrip_test.go:84: EnsureInstalled: invalid character '/' looking for beginning of value
--- FAIL: TestRoundTrip_JSONCSettingsSurviveInstallThenUninstall/http
    roundtrip_test.go:84: EnsureInstalled: invalid character '/' looking for beginning of value
--- FAIL: TestEnsureInstalled_PreservesCommentsOrderAndAmpersands/http
    roundtrip_test.go:115: EnsureInstalled: invalid character '/' looking for beginning of value
--- FAIL: TestEnsureInstalled_PlainJSONKeepsOrderAndEscaping/command
    roundtrip_test.go:167: user command was HTML-escaped
    roundtrip_test.go:169: output contains the HTML escape \u0026
    roundtrip_test.go:169: output contains the HTML escape \u003e
    roundtrip_test.go:170: key order not preserved: "statusLine" now precedes "theme"
```

All three lossy behaviours covered: parse failure on comments, escaping, reordering.

The six regression tests added after review were likewise seen red against this PR's own first commit (`6baefc05`) — `TestSplice_RemoveMiddleMember`, `TestSplice_RemoveMiddleArrayElement`, `TestSplice_RemoveHeadMember`, `TestSplice_AppendAnchorsOnLastSurvivor`, `TestSplice_MultiLineBlockCommentTrailer`, `TestSplice_PropertyRandomMutations`, all FAIL.

### Locks (pass by construction — not red-first proofs)

- `TestReadSettings_MalformedJSONErrors` (pre-existing), `TestMalformedInput_StillErrors`, `TestMalformedInput_IsNeverOverwritten` — scope note 4: genuinely malformed input still errors and the file is still never overwritten. Leniency was added for *comments only*; these exist so it cannot quietly grow into leniency for broken files.
- `TestWriteSettings_ShapeAndDelegation` (pre-existing) — the 2-space / trailing-newline on-disk shape, unchanged.

## Losslessness, demonstrated

Install then uninstall on the JSONC fixture; the third state is byte-identical to the first (asserted, not eyeballed).

<details><summary>before → after install → after uninstall</summary>

```jsonc
// ~/.gemini/settings.json — hand-maintained. Comments are legal in this file
// and the CLI preserves them, so anything else that rewrites it must too.
{
  /* Appearance first, on purpose: it is what gets changed most often. */
  "theme": "GitHub",
  "selectedAuthType": "oauth-personal",

  // Sandboxing is off because the build script shells out to docker.
  "sandbox": false,

  // The && below is load-bearing: it must not come back HTML-escaped.
  "toolDiscoveryCommand": "npm run build && npm run list-tools",
  "toolCallCommand": "node ./tools/call.js 2>/dev/null || true",

  "excludeTools": ["ShellTool(rm -rf)"],
  "contextFileName": "GEMINI.md",

  // Deliberately last, and deliberately not in alphabetical order.
  "autoAccept": false
}
```

After install — every comment, the non-alphabetical order, the `&&` and the `2>/dev/null` untouched; the hook block appended:

```jsonc
  // Deliberately last, and deliberately not in alphabetical order.
  "autoAccept": false,
  "hooks": {
    "PermissionRequest": [
      {
        "hooks": [
          {
            "command": "curl -fsS -X POST --data-binary @- http://localhost:7837/api/v1/hooks/cmdagent || true",
            "timeout": 5,
            "type": "command"
          }
        ],
        "matcher": "Bash|Write"
      }
    ],
    "Stop": [ ... ]
  }
}
```

After uninstall: byte-identical to the original.

</details>

## Review found three ways to corrupt a config — all fixed

A `high`-effort review subagent reproduced three defects in the first commit, every one of them in a position the original tests never reached (they only ever removed the **tail** of a container, the single place the arithmetic was right):

1. **`,,` — critical.** Removing an item with survivors on both sides kept both surrounding commas. Reachable by a plain permission toggle: statusline and hooks are independent permissions writing the same `~/.claude/settings.json`, and revoking statusline is a middle removal. Fired on ~11% of randomly shaped documents.
2. Appending while removing the tail anchored the new comma on the removed item, burying it in the previous item's `//` trailer.
3. The trailer scan stopped at the first newline, so a `/* … */` spanning lines was spliced into — swallowing an inserted member, or deleting its closing `*/` and with it the rest of the file.

A fourth was then found by the new property test: a removal run of two or more adjacent members deleted only the last of them — which is the ordinary uninstall path whenever a user's own hook keeps the `hooks` object alive (claudecode removes seven events at once).

**`TestSplice_PropertyRandomMutations`** is the instrument that found the last two and is the most valuable thing here: random JSONC documents, 1–3 random mutations, asserting the splice does not fall back, decodes to exactly the wanted document, and keeps every comment. Seven hand-written round-trip cases had all passed. 150k iterations across six seeds are clean; the committed run is 2000 on a fixed seed (~0.1s).

## CodeQL

`go/allocation-size-overflow` (high) on the alignment table — real, and fixed in `6bee2516`: the table costs `len(have)·len(want)` ints and both lengths come from the user's file, so a settings.json holding megabytes of `[0,0,0,…]` would ask for tens of gigabytes. Arrays past 512 elements now skip alignment and take the existing safe array-rewrite path. **Not verifiable pre-merge:** a PR-head CodeQL rescan always reports 0 results; only main's post-merge scan flips the alert to `fixed`.

## Degradations are counted, not merely handled

The self-verify-and-fall-back design means a bad splice costs the user their comments rather than their data — but it fired invisibly, so we would never learn the splicer was wrong in the field. That is the failure mode #1364 and #1368 exist to remove for the hook channel, and it had no business being in the riskiest writer in this package.

`fallback.go` counts every degradation, in the shape #1361 established for `PathConfiner` in this same package: a fixed array of `atomic.Uint64` indexed by a reason enum, plus a `Fallbacks()` snapshot accessor. No logger needed.

| Reason | Meaning |
|---|---|
| `array_rewrite` | One array re-encoded rather than edited (non-tail insert, or oversized). Scoped, designed. |
| `unsupported_shape` | No in-place edit exists for this document. Designed. |
| `overlapping_edits` | Two edits claimed the same bytes — the arithmetic disagrees with itself. |
| **`verify_failed`** | **The splice did not decode back to the wanted document. This one means a bug in `jsonc.go`, not a quirk of the user's config** — and the accessor's doc comment says so. |

**Coverage, stated precisely:** `array_rewrite` is the only degradation reachable from outside the package, and its counting was seen red by deleting the `countFallback` call. The other three call sites are unreachable by construction — which is exactly why they are counted — so only their counting mechanism is asserted, not their call sites. `TestFallback_CleanSpliceCountsNothing` pins the other direction, since a counter that only goes up proves nothing.

## Behaviour changes beyond the three lossy ones

**`Uninstall` deletes a `hooks` object its own removals emptied.** Without it, revoking consent on a config that had no hooks leaves `"hooks": {}` and "the user gets their file back" is false (scope note 5). Gated on having actually removed something, so a pre-existing empty object never reaches the branch (`modified` stays false, nothing is written), and any surviving user hook keeps the object non-empty. The narrow case it does not help: a user who wrote `"hooks": {"Stop": []}` themselves loses that key — but `removeOurHook`'s `delete(hooksMap, event)` already does that on `main` and is untouched by this PR (verified: the diff contains no change to `removeOurHook` or `addOurHook`), so all this adds is removal of the empty wrapper that deletion leaves behind.

**JSONC tolerance applies to every caller**, not per adapter. The two files read today are strict JSON, so a comment in one means the user's own agent cannot load it either, and erroring here neither tells them that nor fixes it. **Not established:** whether Claude Code and Codex themselves accept comments. If they do not, an install into a commented file now reports success where it used to report a parse error — for a config their agent was already failing to load. Recorded in the `ReadSettings` doc comment rather than assumed away.

## Deliberately not done

- **No `core/pkg/jsonc` extraction.** The blanker has an identified second consumer (`core/pkg/tailer`'s `getClaudeModel`, which reads the same file with a plain `json.Unmarshal`), but making `tailer` JSONC-tolerant is a behaviour change outside this ticket and `pkg → adapters` would be the repo's first such import. **Filed as #1391** — this PR creates that divergence without touching the code involved.
- **~~The splice fallback is silent.~~** Addressed — see the section above. Every degradation is now counted.
- **`WriteSettings`' re-read** creates a small TOCTOU seam and an unenforced precondition (the map must have come from `ReadSettings` of the same path). Removing it means changing exported signatures the statusline installer depends on. Documented in the doc comment.
- **CodeScene** reports `jsonc.go` at 7.84 code health (Bumpy Road, Complex Method on the blanker). Advisory per AGENTS.md, and the blanker is a lexer whose shape is a switch; not contorted to chase the number.

## Files

| File | Why |
|---|---|
| `core/adapters/inbound/agents/hookjson/fallback.go` | New. Per-reason counters for every silent degradation, in `confine.go`'s shape (#1361). |
| `core/adapters/inbound/agents/hookjson/jsonc.go` | New. Comment blanker + mask, span-recording parse over `json.Decoder`, structural diff, edit splicer, output verification, layout detection. |
| `core/adapters/inbound/agents/hookjson/hookjson.go` | `ReadSettings` tolerates comments; `WriteSettings` splices instead of re-marshalling; `Uninstall` drops an emptied `hooks`. |
| `core/adapters/inbound/agents/hookjson/roundtrip_test.go` | New. The deliverable JSONC round-trip fixture, intermediate-state assertions, uninstall-cleanup tests. |
| `core/adapters/inbound/agents/hookjson/jsonc_test.go` | New. Codec unit tests, the review regressions, the property test, and the malformed-input locks. |

No dependency, no `go.mod` change, no changes outside this one package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
