### PR TITLE
fix(hooks): declare a minimum upstream CLI version per hook adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,12 @@ Before marking a ticket done, run the full suite — every layer must pass:
   "--version"}}` and nothing else. `TestEveryHookInstallDeclaresAVersionFloor`
   (`core/adapters/inbound/agents/hookversion_test.go`) walks the registry
   projection so a new hook adapter is covered by existing rather than by
-  remembering to wire the contract. Note the direction: an unknown or
+  remembering to wire the contract. A refusal is an ordinary effect error, not
+  a separate "skipped" concept, so #1362's surfacing carries it for free — the
+  wizard shows "granted but NOT applied, because <the CLI is too old>", and
+  because a re-answer re-runs an effect that previously failed, the refusal's
+  own advice (upgrade the CLI and grant again) is the gesture that retries it.
+  Note the direction: an unknown or
   unparseable version fails **open** (`core/pkg/cliversion`) — the daemon runs
   under launchd with a minimal PATH and routinely cannot see the user's CLI, so
   only a version successfully read AND parsed AND found below the floor blocks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,28 @@ Before marking a ticket done, run the full suite — every layer must pass:
   contract asserts the 2xx so a new receiver inherits the rule instead of
   re-deciding it (#1361, #1364). `hookjson.RejectPath` is the single place it
   is implemented, and its doc comment records what was and was not observed.
-  All four contract families pass by construction against a correct adapter, so
+- Hook version floors: `contracttesting.AssertHookVersionGate`
+  (`core/internal/contracttesting/hook_version.go`) is the static half of
+  #1365 — a hooks permission declares the minimum upstream CLI version its
+  install requires (`agent.HookInstall.Version`), that floor is at or above
+  every installed event's own `Since` entry, and it actually refuses one patch
+  below itself with a reason naming both versions. The runtime half — that
+  `PermissionService.runClosureEffect` consults the declaration before running
+  `Apply` — is `core/application/services/permission_version_gate_test.go`, the
+  same split `AssertPermissionGated` draws. It exists because Codex carried a
+  private `codexSupportsHooks` with its own parser and floor constants while
+  Claude Code carried nothing and wrote seven entries into the user's
+  `settings.json` at any version; a third adapter joins by declaring
+  `Version: &agent.VersionGate{Min: "x.y.z", Probe: []string{"<cli>",
+  "--version"}}` and nothing else. `TestEveryHookInstallDeclaresAVersionFloor`
+  (`core/adapters/inbound/agents/hookversion_test.go`) walks the registry
+  projection so a new hook adapter is covered by existing rather than by
+  remembering to wire the contract. Note the direction: an unknown or
+  unparseable version fails **open** (`core/pkg/cliversion`) — the daemon runs
+  under launchd with a minimal PATH and routinely cannot see the user's CLI, so
+  only a version successfully read AND parsed AND found below the floor blocks
+  an install.
+  All five contract families pass by construction against a correct adapter, so
   their whole value is that they *can* fail: a new or reworked contract
   assertion lands with the deliberate mutation that was seen red for each
   obligation recorded in its PR — the same bar the red-first rule above sets

--- a/core/adapters/inbound/agents/agentpaths/agentpaths.go
+++ b/core/adapters/inbound/agents/agentpaths/agentpaths.go
@@ -10,6 +10,7 @@ package agentpaths
 
 import (
 	"errors"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -95,4 +96,42 @@ func AbsRoot(dir string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, dir), nil
+}
+
+// NewestFileWithSuffix returns the path of the most recently modified file
+// under root (recursively) whose name ends in suffix, or "" if there is none.
+//
+// Both hook-capable adapters need the same thing for the same reason: the
+// newest transcript is the closest proxy on disk for "the version of this
+// agent the user is running now" (#1365). Codex reads a cli_version out of its
+// session header, Claude Code reads a version stamp off any transcript line —
+// different files, different fields, identical walk. Keeping the walk here
+// means a third adapter supplies only its own field extraction, and a fix to
+// the traversal (symlinks, unreadable dirs, tie-breaking) lands once.
+//
+// Callers pass a root already resolved through AbsRoot. Handing this a
+// $HOME-relative default instead walks the daemon's CWD and returns "" — no
+// error, no empty-directory signal, just an answer that reads as "this agent
+// has no sessions".
+//
+// Walk errors are ignored per entry rather than aborting: an unreadable
+// subdirectory should cost that subtree, not the whole answer.
+func NewestFileWithSuffix(root, suffix string) string {
+	var newestPath string
+	var newestMod int64
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, suffix) {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if mod := info.ModTime().UnixNano(); mod > newestMod {
+			newestMod = mod
+			newestPath = path
+		}
+		return nil
+	})
+	return newestPath
 }

--- a/core/adapters/inbound/agents/agentpaths/newest_test.go
+++ b/core/adapters/inbound/agents/agentpaths/newest_test.go
@@ -1,0 +1,67 @@
+package agentpaths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAbsRootResolvesRelativeDefaults(t *testing.T) {
+	if got, err := AbsRoot("/already/absolute"); err != nil || got != "/already/absolute" {
+		t.Errorf("AbsRoot(absolute) = %q, %v; want the path unchanged", got, err)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home directory")
+	}
+	// The trap this exists to close: a $HOME-relative default (what FromEnv
+	// returns when the override is unset) must not be walked as-is, or the
+	// walk runs against the daemon's CWD and reports "nothing here".
+	got, err := AbsRoot(".claude/projects")
+	if err != nil {
+		t.Fatalf("AbsRoot: %v", err)
+	}
+	if want := filepath.Join(home, ".claude/projects"); got != want {
+		t.Errorf("AbsRoot(relative) = %q, want %q", got, want)
+	}
+}
+
+func TestNewestFileWithSuffix(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	write := func(path string, age time.Duration) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+		when := time.Now().Add(-age)
+		if err := os.Chtimes(path, when, when); err != nil {
+			t.Fatalf("chtimes %s: %v", path, err)
+		}
+	}
+	write(filepath.Join(root, "old.jsonl"), 2*time.Hour)
+	write(filepath.Join(nested, "new.jsonl"), time.Minute)
+	// A newer file of another type must not win — the suffix is the filter.
+	write(filepath.Join(nested, "newest.txt"), 0)
+
+	got := NewestFileWithSuffix(root, ".jsonl")
+	if want := filepath.Join(nested, "new.jsonl"); got != want {
+		t.Errorf("NewestFileWithSuffix = %q, want %q", got, want)
+	}
+}
+
+func TestNewestFileWithSuffix_NoMatchIsEmpty(t *testing.T) {
+	if got := NewestFileWithSuffix(t.TempDir(), ".jsonl"); got != "" {
+		t.Errorf("got %q for an empty tree, want empty", got)
+	}
+	// A root that does not exist is the fresh-install case, and must read as
+	// "nothing to report" rather than panicking or erroring out.
+	if got := NewestFileWithSuffix(filepath.Join(t.TempDir(), "absent"), ".jsonl"); got != "" {
+		t.Errorf("got %q for a missing root, want empty", got)
+	}
+}

--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -93,15 +93,17 @@ func Agent() agent.Agent {
 					ConfigPath: claudeSettingsPath,
 					Uninstall:  UninstallHooks,
 					// Declared, not implemented — PermissionService enforces it
-					// (#1365). No Observed source: Claude Code records its version
-					// per transcript entry, but reading it would mean walking
-					// ~/.claude/projects at grant time, and unlike Codex's single
-					// session header there is no cheap newest-session read. The
-					// probe is honest and bounded; if it cannot run, the install
-					// proceeds (an unreadable version is not an old one).
+					// (#1365). Observed reads the version Claude Code stamps on
+					// every transcript line, which is what makes this gate real
+					// rather than decorative: the production daemon inherits a
+					// LaunchServices PATH that does not include ~/.local/bin, so
+					// the probe alone would miss and every install would take the
+					// fail-open branch. The probe stays as the fallback and as the
+					// authority whenever the passive reading says "too old".
 					Version: &agent.VersionGate{
-						Min:   minCLIVersion,
-						Probe: []string{"claude", "--version"},
+						Min:      minCLIVersion,
+						Probe:    []string{"claude", "--version"},
+						Observed: newestObservedCLIVersion,
 					},
 				},
 			},

--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -34,10 +34,14 @@ const iconSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" 
 
 // Agent returns the Claude Code adapter registration.
 func Agent() agent.Agent {
+	// One name, used both as the wizard's label and in the hooks permission's
+	// version disclosure below, so the copy cannot come to call the CLI
+	// something the rest of the UI doesn't.
+	const displayName = "Claude Code"
 	return agent.Agent{
 		Identity: agent.Identity{
 			Name:         AdapterName,
-			DisplayName:  "Claude Code",
+			DisplayName:  displayName,
 			IconSVGLight: iconSVG,
 			IconSVGDark:  iconSVG,
 		},
@@ -84,7 +88,7 @@ func Agent() agent.Agent {
 					" hook entries that POST " +
 					"the hook payload to the local daemon at " + hookEndpointURL() +
 					" via Claude Code's native http hook (no shell/curl). " +
-					hookjson.RequiresVersion("Claude Code", minCLIVersion) +
+					hookjson.RequiresVersion(displayName, minCLIVersion) +
 					" Toggling off removes exactly these entries (also available via " +
 					"`irrlichd --uninstall-hooks`).",
 				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },

--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -83,14 +83,26 @@ func Agent() agent.Agent {
 				Detail: "Adds " + hookjson.EventList(installedHookEvents) +
 					" hook entries that POST " +
 					"the hook payload to the local daemon at " + hookEndpointURL() +
-					" via Claude Code's native http hook (no shell/curl). Toggling " +
-					"off removes exactly these entries (also available via " +
+					" via Claude Code's native http hook (no shell/curl). " +
+					hookjson.RequiresVersion("Claude Code", minCLIVersion) +
+					" Toggling off removes exactly these entries (also available via " +
 					"`irrlichd --uninstall-hooks`).",
 				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
 				Remove: func() error { _, err := UninstallHooks(); return err },
 				Hooks: &agent.HookInstall{
 					ConfigPath: claudeSettingsPath,
 					Uninstall:  UninstallHooks,
+					// Declared, not implemented — PermissionService enforces it
+					// (#1365). No Observed source: Claude Code records its version
+					// per transcript entry, but reading it would mean walking
+					// ~/.claude/projects at grant time, and unlike Codex's single
+					// session header there is no cheap newest-session read. The
+					// probe is honest and bounded; if it cannot run, the install
+					// proceeds (an unreadable version is not an old one).
+					Version: &agent.VersionGate{
+						Min:   minCLIVersion,
+						Probe: []string{"claude", "--version"},
+					},
 				},
 			},
 			{

--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -85,6 +85,61 @@ const hookMatcherPreCompact = "manual"
 // blocking PermissionRequest hook, and the other types don't affect state.
 const hookMatcherNotification = "idle_prompt"
 
+// minCLIVersion is the lowest Claude Code version this install may be written
+// into (issue #1365). Declared here, enforced generically by PermissionService
+// via agent.HookInstall.Version — before #1365 this adapter had no gate at all
+// and wrote all seven entries into ~/.claude/settings.json whatever version was
+// installed.
+//
+// 2.1.122 rather than the 2.1.63 that the `type: "http"` entry alone would
+// require, because below 2.1.122 a hook entry Claude Code cannot make sense of
+// does not degrade to "that hook doesn't fire" — it takes the user's whole
+// settings.json with it. Both fixes are named in the upstream changelog:
+//
+//	2.1.101 — "an unrecognized hook event name in settings.json no longer
+//	           causes the entire file to be ignored"
+//	2.1.122 — "Fixed a malformed hooks entry in settings.json no longer
+//	           invalidating the entire file"
+//
+// That is what decides the direction of this gate. Installing into a too-old
+// Claude Code is not inert-and-slightly-untidy; it can silently disable every
+// other setting the user has — other hooks, permissions, model choice. A floor
+// high enough that a mistake degrades to one dead hook is worth more than the
+// handful of versions of reach it costs.
+const minCLIVersion = "2.1.122"
+
+// hookEventSince records, per installed event, the Claude Code version at
+// which that event is PROVEN to exist — not necessarily the version that
+// introduced it. minCLIVersion must be >= every value (AssertHookVersionGate
+// enforces it), which is what makes "do not write an entry the installed CLI
+// does not know" (#1365 scope item 2) mechanical rather than aspirational.
+//
+// Provenance, all from the upstream changelog cached at
+// ~/.claude/cache/changelog.md and re-checkable there:
+//
+//   - 1.0.38 "Released hooks" — the four original events.
+//   - 2.0.45 "Added PermissionRequest hook to automatically approve or deny
+//     tool permission requests with custom logic".
+//   - 2.1.119 "Hooks: PostToolUse and PostToolUseFailure hook inputs now
+//     include duration_ms" — an enhancement, so PostToolUseFailure existed BY
+//     2.1.119. Its introducing version is not stated anywhere in the changelog;
+//     2.1.119 is recorded here as the proven upper bound, which is the
+//     conservative direction (it can only push the floor up, never down).
+//
+// The `type: "http"` delivery all seven entries use arrived in 2.1.63 ("Added
+// HTTP hooks, which can POST JSON to a URL and receive JSON instead of running
+// a shell command") — a property of the entry rather than of any one event, so
+// it constrains minCLIVersion directly rather than appearing in this map.
+var hookEventSince = map[string]string{
+	HookPermissionRequest:  "2.0.45",
+	HookPreToolUse:         "1.0.38",
+	HookPostToolUse:        "1.0.38",
+	HookPostToolUseFailure: "2.1.119",
+	HookPreCompact:         "1.0.38",
+	HookStop:               "1.0.38",
+	HookNotification:       "1.0.38",
+}
+
 // installedHookEvents are the Claude Code hook events we install handlers for.
 var installedHookEvents = []string{
 	HookPermissionRequest,

--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -6,8 +6,12 @@
 package claudecode
 
 import (
+	"bufio"
+	"encoding/json"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/pkg/daemonaddr"
@@ -260,4 +264,106 @@ func hookEntryIsCanonical(hook map[string]interface{}) bool {
 	t, _ := hook["type"].(string)
 	u, _ := hook["url"].(string)
 	return t == "http" && u == hookEndpointURL()
+}
+
+// maxVersionScanLines bounds how far into a transcript newestObservedCLIVersion
+// reads looking for the version stamp. Claude Code puts it on every user and
+// assistant line, so it is found within the first few; the cap is there so a
+// multi-megabyte transcript cannot turn a consent click into a long read.
+const maxVersionScanLines = 200
+
+// newestObservedCLIVersion returns the Claude Code version stamped on the most
+// recently modified transcript, or "" if none can be read.
+//
+// This is the passive half of the #1365 gate, and without it the gate would be
+// decorative for this adapter. The declared fallback is `claude --version`, but
+// the production daemon is launched by Irrlicht.app and inherits a LaunchServices
+// PATH of /usr/bin:/bin:/usr/sbin:/sbin, while the official installer puts the
+// binary in ~/.local/bin — so the probe misses, the version reads as unknown,
+// and unknown fails open. Every install would take the fail-open branch and no
+// version would ever actually be checked. The transcripts are already on disk
+// and already parsed for this exact field (parser.go reads raw["version"] into
+// AgentVersion), so reading it here costs no process and no PATH.
+//
+// It resolves the ABSOLUTE transcripts dir rather than using transcriptsDir()
+// directly: that returns a $HOME-relative path when CLAUDE_CONFIG_DIR is unset
+// (expansion happens downstream in fswatcher), which would make this walk run
+// against the daemon's CWD and always find nothing — the same trap codex's
+// newestObservedCLIVersion documents.
+//
+// A stale answer is tolerable by construction: the version is the one that
+// wrote the newest transcript, so it can only lag the installed CLI downward,
+// and PermissionService re-confirms with the probe before acting on any
+// "too old" reading (shouldConfirmByProbe). So a stale value costs at most one
+// process, never a false refusal.
+func newestObservedCLIVersion() string {
+	dir, err := absTranscriptsDir()
+	if err != nil {
+		return ""
+	}
+	var newestPath string
+	var newestMod int64
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if mod := info.ModTime().UnixNano(); mod > newestMod {
+			newestMod = mod
+			newestPath = path
+		}
+		return nil
+	})
+	if newestPath == "" {
+		return ""
+	}
+	return versionInTranscript(newestPath)
+}
+
+// versionInTranscript returns the first "version" string found in the file.
+func versionInTranscript(path string) string {
+	// Plain ".." check: the path is built by WalkDir from a root this package
+	// resolved itself, but this is the spelling CodeQL's go/path-injection
+	// query recognizes as a sanitizer (same reasoning as codex's
+	// sessionMetaPayload).
+	if strings.Contains(path, "..") {
+		return ""
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	// Transcript lines carry whole tool results and routinely exceed
+	// Scanner's small default token limit.
+	scanner.Buffer(make([]byte, 64*1024), 2*1024*1024)
+	for i := 0; i < maxVersionScanLines && scanner.Scan(); i++ {
+		var record map[string]interface{}
+		if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
+			continue
+		}
+		if v, ok := record["version"].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// absTranscriptsDir resolves the transcripts directory to an absolute path,
+// honoring the same CLAUDE_CONFIG_DIR override the watcher honors.
+func absTranscriptsDir() (string, error) {
+	dir := transcriptsDir()
+	if filepath.IsAbs(dir) {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, dir), nil
 }

--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -8,11 +8,11 @@ package claudecode
 import (
 	"bufio"
 	"encoding/json"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
 	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/pkg/daemonaddr"
 )
@@ -285,11 +285,10 @@ const maxVersionScanLines = 200
 // and already parsed for this exact field (parser.go reads raw["version"] into
 // AgentVersion), so reading it here costs no process and no PATH.
 //
-// It resolves the ABSOLUTE transcripts dir rather than using transcriptsDir()
-// directly: that returns a $HOME-relative path when CLAUDE_CONFIG_DIR is unset
+// transcriptsDir() is resolved through agentpaths.Abs rather than used
+// directly: it returns a $HOME-relative path when CLAUDE_CONFIG_DIR is unset
 // (expansion happens downstream in fswatcher), which would make this walk run
-// against the daemon's CWD and always find nothing — the same trap codex's
-// newestObservedCLIVersion documents.
+// against the daemon's CWD and always find nothing.
 //
 // A stale answer is tolerable by construction: the version is the one that
 // wrote the newest transcript, so it can only lag the installed CLI downward,
@@ -297,26 +296,11 @@ const maxVersionScanLines = 200
 // "too old" reading (shouldConfirmByProbe). So a stale value costs at most one
 // process, never a false refusal.
 func newestObservedCLIVersion() string {
-	dir, err := absTranscriptsDir()
+	dir, err := agentpaths.AbsRoot(transcriptsDir())
 	if err != nil {
 		return ""
 	}
-	var newestPath string
-	var newestMod int64
-	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
-			return nil
-		}
-		info, err := d.Info()
-		if err != nil {
-			return nil
-		}
-		if mod := info.ModTime().UnixNano(); mod > newestMod {
-			newestMod = mod
-			newestPath = path
-		}
-		return nil
-	})
+	newestPath := agentpaths.NewestFileWithSuffix(dir, ".jsonl")
 	if newestPath == "" {
 		return ""
 	}
@@ -352,18 +336,4 @@ func versionInTranscript(path string) string {
 		}
 	}
 	return ""
-}
-
-// absTranscriptsDir resolves the transcripts directory to an absolute path,
-// honoring the same CLAUDE_CONFIG_DIR override the watcher honors.
-func absTranscriptsDir() (string, error) {
-	dir := transcriptsDir()
-	if filepath.IsAbs(dir) {
-		return dir, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, dir), nil
 }

--- a/core/adapters/inbound/agents/claudecode/hookversion_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookversion_test.go
@@ -1,0 +1,82 @@
+package claudecode
+
+import (
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/internal/contracttesting"
+)
+
+// TestHooksPermission_DeclaresVersionGate is the issue #1365 defect test for
+// this adapter. Claude Code installed seven hook entries into the user's
+// ~/.claude/settings.json at ANY version — no floor, no check, nothing to
+// declare — which is what the issue is about. Against that code this fails at
+// the "declares no minimum CLI version" fatal.
+func TestHooksPermission_DeclaresVersionGate(t *testing.T) {
+	contracttesting.AssertHookVersionGate(t, contracttesting.HookVersionGate{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		Since:         hookEventSince,
+	})
+}
+
+func hooksVersionGate(t *testing.T) *agent.VersionGate {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			if p.Hooks == nil || p.Hooks.Version == nil {
+				t.Fatal("hooks permission declares no version gate")
+			}
+			return p.Hooks.Version
+		}
+	}
+	t.Fatal("no hooks permission")
+	return nil
+}
+
+// TestHooksGate_RefusesTooOldClaudeCode pins the boundary in real terms. 2.1.121
+// is the version one patch below the floor, and the reason it is refused is not
+// tidiness: below 2.1.122 a hooks entry Claude Code cannot parse invalidates the
+// user's whole settings.json (upstream changelog 2.1.122, "Fixed a malformed
+// hooks entry in settings.json no longer invalidating the entire file"), and
+// below 2.1.101 an unrecognized event name does the same.
+func TestHooksGate_RefusesTooOldClaudeCode(t *testing.T) {
+	gate := hooksVersionGate(t)
+
+	allowed, why := gate.Permits("2.1.121 (Claude Code)")
+	if allowed {
+		t.Fatalf("gate permits Claude Code 2.1.121, below the %s floor", minCLIVersion)
+	}
+	if !strings.Contains(why, minCLIVersion) {
+		t.Errorf("refusal %q never names the required version", why)
+	}
+}
+
+// TestHooksGate_AllowsCurrentClaudeCode is a LOCK against the floor being set
+// so high that ordinary users stop getting hooks. The banner form is the one
+// `claude --version` actually prints, so this also pins that the parser copes
+// with the suffix.
+func TestHooksGate_AllowsCurrentClaudeCode(t *testing.T) {
+	gate := hooksVersionGate(t)
+	for _, v := range []string{minCLIVersion, "2.1.122 (Claude Code)", "2.1.226 (Claude Code)", "3.0.0"} {
+		if allowed, why := gate.Permits(v); !allowed {
+			t.Errorf("gate refuses Claude Code %q: %s", v, why)
+		}
+	}
+}
+
+// TestHooksGate_ProbesTheBinary pins the declared probe. Claude Code has no
+// cheap Observed source (unlike Codex's single session header), so the probe is
+// the only way this gate ever learns a version — an empty Probe would make the
+// floor decorative.
+func TestHooksGate_ProbesTheBinary(t *testing.T) {
+	gate := hooksVersionGate(t)
+	if len(gate.Probe) == 0 {
+		t.Fatal("no probe declared, and no Observed source either — the gate can never refuse")
+	}
+	if gate.Probe[0] != "claude" {
+		t.Errorf("probe runs %q, want the claude binary", gate.Probe[0])
+	}
+}

--- a/core/adapters/inbound/agents/claudecode/hookversion_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookversion_test.go
@@ -1,8 +1,11 @@
 package claudecode
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/internal/contracttesting"
@@ -67,16 +70,113 @@ func TestHooksGate_AllowsCurrentClaudeCode(t *testing.T) {
 	}
 }
 
-// TestHooksGate_ProbesTheBinary pins the declared probe. Claude Code has no
-// cheap Observed source (unlike Codex's single session header), so the probe is
-// the only way this gate ever learns a version — an empty Probe would make the
-// floor decorative.
-func TestHooksGate_ProbesTheBinary(t *testing.T) {
+// TestHooksGate_DeclaresBothVersionSources is the regression guard for the
+// review finding that nearly shipped: with only a Probe declared, this gate is
+// decorative in the deployment that matters. The production daemon is launched
+// by Irrlicht.app and inherits a LaunchServices PATH of
+// /usr/bin:/bin:/usr/sbin:/sbin, while the official installer puts `claude` in
+// ~/.local/bin — so the probe misses, the version reads as unknown, unknown
+// fails open, and every install takes the fail-open branch. A user on 2.1.90
+// would still get all seven entries written into a settings.json that version
+// can be broken by.
+//
+// Observed closes that: the transcripts are already on disk and already carry
+// the version stamp. The probe stays as the fallback and as the authority when
+// the passive reading looks too old.
+func TestHooksGate_DeclaresBothVersionSources(t *testing.T) {
 	gate := hooksVersionGate(t)
+	if gate.Observed == nil {
+		t.Error("no Observed source — under the production daemon's PATH the probe " +
+			"cannot find `claude`, so the gate would only ever fail open")
+	}
 	if len(gate.Probe) == 0 {
-		t.Fatal("no probe declared, and no Observed source either — the gate can never refuse")
+		t.Fatal("no probe declared")
 	}
 	if gate.Probe[0] != "claude" {
 		t.Errorf("probe runs %q, want the claude binary", gate.Probe[0])
+	}
+}
+
+// writeVersionTranscript lays down a transcript under a temp CLAUDE_CONFIG_DIR and
+// returns the config root.
+func writeVersionTranscript(t *testing.T, name, line string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "projects", "-Users-someone-repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(line), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", root)
+	return root
+}
+
+// TestNewestObservedCLIVersion_ReadsTheVersionStamp covers the passive source
+// that keeps this gate from being decorative under launchd's PATH.
+func TestNewestObservedCLIVersion_ReadsTheVersionStamp(t *testing.T) {
+	writeVersionTranscript(t, "s1.jsonl",
+		`{"type":"user","version":"2.1.90","message":{"role":"user"}}`+"\n")
+
+	if got := newestObservedCLIVersion(); got != "2.1.90" {
+		t.Errorf("newestObservedCLIVersion() = %q, want 2.1.90", got)
+	}
+}
+
+// TestNewestObservedCLIVersion_SkipsLinesWithoutAVersion pins that the scan
+// does not stop at the first line: Claude Code's transcripts routinely open
+// with a summary record carrying no version stamp.
+func TestNewestObservedCLIVersion_SkipsLinesWithoutAVersion(t *testing.T) {
+	writeVersionTranscript(t, "s1.jsonl",
+		`{"type":"summary","summary":"a thing"}`+"\n"+
+			`{"type":"user","version":"2.1.130","message":{"role":"user"}}`+"\n")
+
+	if got := newestObservedCLIVersion(); got != "2.1.130" {
+		t.Errorf("newestObservedCLIVersion() = %q, want 2.1.130", got)
+	}
+}
+
+// TestNewestObservedCLIVersion_UnreadableIsEmpty pins that every "cannot tell"
+// path resolves to unknown rather than to something that compares. Unknown
+// reaches the probe and ultimately fails open; a zero value would refuse.
+func TestNewestObservedCLIVersion_UnreadableIsEmpty(t *testing.T) {
+	t.Run("no transcripts at all", func(t *testing.T) {
+		t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+		if got := newestObservedCLIVersion(); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("transcript carries no version", func(t *testing.T) {
+		writeVersionTranscript(t, "s1.jsonl", `{"type":"summary","summary":"no version here"}`+"\n")
+		if got := newestObservedCLIVersion(); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+	t.Run("transcript is not json", func(t *testing.T) {
+		writeVersionTranscript(t, "s1.jsonl", "this is not jsonl at all\n")
+		if got := newestObservedCLIVersion(); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+// TestNewestObservedCLIVersion_PicksTheNewestFile pins that the answer tracks
+// the most recently written session, which is the closest proxy on disk for
+// "the Claude Code the user is running now".
+func TestNewestObservedCLIVersion_PicksTheNewestFile(t *testing.T) {
+	root := writeVersionTranscript(t, "old.jsonl", `{"type":"user","version":"2.1.90"}`+"\n")
+	dir := filepath.Join(root, "projects", "-Users-someone-repo")
+	newer := filepath.Join(dir, "new.jsonl")
+	if err := os.WriteFile(newer, []byte(`{"type":"user","version":"2.1.200"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	older := filepath.Join(dir, "old.jsonl")
+	if err := os.Chtimes(older, time.Now().Add(-time.Hour), time.Now().Add(-time.Hour)); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	if got := newestObservedCLIVersion(); got != "2.1.200" {
+		t.Errorf("newestObservedCLIVersion() = %q, want 2.1.200 (the newest file)", got)
 	}
 }

--- a/core/adapters/inbound/agents/codex/agent.go
+++ b/core/adapters/inbound/agents/codex/agent.go
@@ -69,13 +69,23 @@ func Agent() agent.Agent {
 					"POST the hook payload to the local daemon at " + hookEndpointURL() +
 					" via curl. PermissionRequest drives a live waiting transition " +
 					"the moment an approval prompt appears; Stop carries the final " +
-					"assistant message for turn-end. Install is version-gated on the " +
-					"running Codex's cli_version. Toggling off removes the entries.",
-				Apply:  func() error { return applyCodexHooks() },
+					"assistant message for turn-end. " + hookjson.RequiresVersion("Codex", minCLIVersion) +
+					" Toggling off removes the entries.",
+				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
 				Remove: func() error { _, err := UninstallHooks(); return err },
 				Hooks: &agent.HookInstall{
 					ConfigPath: codexHooksPath,
 					Uninstall:  UninstallHooks,
+					// The floor is declared, not implemented: PermissionService
+					// enforces it for every adapter (#1365). Observed reads
+					// cli_version out of the newest session header, so the common
+					// case costs no process at all and works even when the binary
+					// is not on the daemon's PATH; Probe is the fallback.
+					Version: &agent.VersionGate{
+						Min:      minCLIVersion,
+						Probe:    []string{"codex", "--version"},
+						Observed: newestObservedCLIVersion,
+					},
 				},
 			},
 		},

--- a/core/adapters/inbound/agents/codex/agent.go
+++ b/core/adapters/inbound/agents/codex/agent.go
@@ -29,10 +29,13 @@ const iconSVGDark = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="
 
 // Agent returns the Codex adapter registration.
 func Agent() agent.Agent {
+	// See claudecode's Agent(): one name for the wizard label and the version
+	// disclosure, so the two cannot drift.
+	const displayName = "Codex"
 	return agent.Agent{
 		Identity: agent.Identity{
 			Name:         AdapterName,
-			DisplayName:  "Codex",
+			DisplayName:  displayName,
 			IconSVGLight: iconSVGLight,
 			IconSVGDark:  iconSVGDark,
 		},
@@ -69,7 +72,7 @@ func Agent() agent.Agent {
 					"POST the hook payload to the local daemon at " + hookEndpointURL() +
 					" via curl. PermissionRequest drives a live waiting transition " +
 					"the moment an approval prompt appears; Stop carries the final " +
-					"assistant message for turn-end. " + hookjson.RequiresVersion("Codex", minCLIVersion) +
+					"assistant message for turn-end. " + hookjson.RequiresVersion(displayName, minCLIVersion) +
 					" Toggling off removes the entries.",
 				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
 				Remove: func() error { _, err := UninstallHooks(); return err },

--- a/core/adapters/inbound/agents/codex/hookinstaller.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller.go
@@ -9,15 +9,12 @@
 package codex
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"irrlicht/core/adapters/inbound/agents/hookjson"
-	"irrlicht/core/pkg/daemonaddr"
 
 	"irrlicht/core/adapters/inbound/agents/agentpaths"
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/pkg/daemonaddr"
 )
 
 // HookEndpointPath is the daemon's Codex hook path. Host and port are resolved
@@ -171,22 +168,7 @@ func newestObservedCLIVersion() string {
 	if err != nil {
 		return ""
 	}
-	var newestPath string
-	var newestMod int64
-	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
-			return nil
-		}
-		info, err := d.Info()
-		if err != nil {
-			return nil
-		}
-		if mod := info.ModTime().UnixNano(); mod > newestMod {
-			newestMod = mod
-			newestPath = path
-		}
-		return nil
-	})
+	newestPath := agentpaths.NewestFileWithSuffix(dir, ".jsonl")
 	if newestPath == "" {
 		return ""
 	}

--- a/core/adapters/inbound/agents/codex/hookinstaller.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller.go
@@ -12,7 +12,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
@@ -63,14 +62,29 @@ const hookTimeoutSeconds = 5
 // permission-pending overlay is always cleared once an approved tool runs.
 const hookMatcher = ".*"
 
-// minHookMajor/Minor/Patch is the lowest Codex version whose hook event set
-// includes the events we install (PermissionRequest/PostToolUse/Stop). Hooks
-// were introduced experimental in rust-v0.114.0 (~March 2026, issue #1171).
-const (
-	minHookMajor = 0
-	minHookMinor = 114
-	minHookPatch = 0
-)
+// minCLIVersion is the lowest Codex version whose hook event set includes
+// every event we install. Declared here and enforced generically by
+// PermissionService via agent.HookInstall.Version (issue #1365), replacing the
+// adapter-private codexSupportsHooks/parseCodexVersion pair this file used to
+// carry — the thing a third adapter would otherwise have copied.
+const minCLIVersion = "0.114.0"
+
+// hookEventSince records the Codex version each event we install arrived in.
+// It is the machine-checkable form of "do not write an entry the installed CLI
+// does not know" (#1365 scope item 2): minCLIVersion must be >= every value
+// here, which AssertHookVersionGate enforces, so at any version where we
+// install at all, every event we write is one the CLI understands. Adding an
+// event that landed later than minCLIVersion fails that test rather than
+// shipping an entry an in-range CLI would reject.
+//
+// All three arrived together with the experimental hooks feature in
+// rust-v0.114.0 (~March 2026, issue #1171); Codex has no separately-dated hook
+// events yet.
+var hookEventSince = map[string]string{
+	HookPermissionRequest: "0.114.0",
+	HookPostToolUse:       "0.114.0",
+	HookStop:              "0.114.0",
+}
 
 // installedHookEvents are the Codex hook events we install handlers for. Codex
 // has no PostToolUseFailure event, so PostToolUse is the sole pending-clear
@@ -139,67 +153,6 @@ func UninstallHooks() (bool, error) {
 		return false, err
 	}
 	return hookjson.Uninstall(hookConfig(path))
-}
-
-// applyCodexHooks is the Apply closure for the "hooks" permission: it
-// version-gates the install on the running Codex's cli_version (issue #1171).
-// A Codex older than the hooks feature is skipped rather than cluttered with a
-// config it ignores; an unknown/unparseable version fails open and installs,
-// since a dedicated hooks.json is harmless to an old Codex regardless.
-func applyCodexHooks() error {
-	if v := newestObservedCLIVersion(); v != "" && !codexSupportsHooks(v) {
-		return nil
-	}
-	_, err := EnsureHooksInstalled()
-	return err
-}
-
-// codexSupportsHooks reports whether a Codex cli_version string is new enough
-// to fire the hook events we install. Accepts bare semver ("0.114.0") and the
-// release-tag form ("rust-v0.114.0" / "v0.114.0"); an empty or unparseable
-// version fails open (returns true) — see applyCodexHooks.
-func codexSupportsHooks(version string) bool {
-	major, minor, patch, ok := parseCodexVersion(version)
-	if !ok {
-		return true
-	}
-	if major != minHookMajor {
-		return major > minHookMajor
-	}
-	if minor != minHookMinor {
-		return minor > minHookMinor
-	}
-	return patch >= minHookPatch
-}
-
-// parseCodexVersion extracts major.minor.patch from a Codex version string,
-// stripping a leading "rust-v" or "v" tag prefix. Reports ok=false when the
-// first three dot groups don't parse as integers.
-func parseCodexVersion(version string) (major, minor, patch int, ok bool) {
-	v := strings.TrimSpace(version)
-	v = strings.TrimPrefix(v, "rust-")
-	v = strings.TrimPrefix(v, "v")
-	if v == "" {
-		return 0, 0, 0, false
-	}
-	fields := strings.SplitN(v, ".", 4)
-	nums := make([]int, 3)
-	for i := 0; i < 3; i++ {
-		if i >= len(fields) {
-			return 0, 0, 0, false
-		}
-		// Trim any pre-release/build suffix off the patch field ("0-rc1").
-		field := fields[i]
-		if j := strings.IndexAny(field, "-+"); j >= 0 {
-			field = field[:j]
-		}
-		n, err := strconv.Atoi(field)
-		if err != nil {
-			return 0, 0, 0, false
-		}
-		nums[i] = n
-	}
-	return nums[0], nums[1], nums[2], true
 }
 
 // newestObservedCLIVersion returns the cli_version recorded in the most

--- a/core/adapters/inbound/agents/codex/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller_test.go
@@ -12,32 +12,6 @@ import (
 	"irrlicht/core/internal/contracttesting"
 )
 
-func TestCodexSupportsHooks(t *testing.T) {
-	cases := []struct {
-		version string
-		want    bool
-	}{
-		{"0.114.0", true},       // exactly the floor
-		{"0.114.1", true},       // above the floor patch
-		{"0.115.0", true},       // above the floor minor
-		{"0.113.9", false},      // just below the floor minor
-		{"0.100.0", false},      // well below
-		{"1.0.0", true},         // above the floor major
-		{"rust-v0.114.0", true}, // release-tag prefix stripped
-		{"v0.113.0", false},     // v-prefix stripped, still too old
-		{"0.114.0-rc1", true},   // pre-release suffix trimmed off patch
-		{"0.144.2", true},       // a later shipped version
-		{"", true},              // unknown → fail open (install anyway)
-		{"garbage", true},       // unparseable → fail open
-		{"0.114", true},         // incomplete (2 fields) → fail open
-	}
-	for _, tc := range cases {
-		if got := codexSupportsHooks(tc.version); got != tc.want {
-			t.Errorf("codexSupportsHooks(%q): got %v, want %v", tc.version, got, tc.want)
-		}
-	}
-}
-
 // readHooks reads the installed hooks.json under home and returns the "hooks"
 // map (or nil if absent).
 func readHooks(t *testing.T, home string) map[string]interface{} {
@@ -190,49 +164,6 @@ func TestEnsurePreservesUnrelatedContent(t *testing.T) {
 	}
 }
 
-// seedSession writes a Codex session file with the given cli_version under
-// home/sessions so newestObservedCLIVersion can read it.
-func seedSession(t *testing.T, home, cliVersion string) {
-	t.Helper()
-	dir := filepath.Join(home, "sessions", "2026", "07", "18")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir sessions: %v", err)
-	}
-	meta := `{"type":"session_meta","payload":{"id":"s","cli_version":"` + cliVersion + `"}}` + "\n"
-	f := filepath.Join(dir, "rollout-2026-07-18T00-00-00-abcdefabcdef.jsonl")
-	if err := os.WriteFile(f, []byte(meta), 0o600); err != nil {
-		t.Fatalf("write session: %v", err)
-	}
-}
-
-func TestApplyCodexHooks_VersionGate(t *testing.T) {
-	t.Run("too_old_skips_install", func(t *testing.T) {
-		home := t.TempDir()
-		t.Setenv(codexHomeEnvVar, home)
-		seedSession(t, home, "0.100.0") // predates hooks
-
-		if err := applyCodexHooks(); err != nil {
-			t.Fatalf("applyCodexHooks: %v", err)
-		}
-		if eventHasSentinel(readHooks(t, home), HookStop) {
-			t.Error("hooks installed despite a too-old Codex version")
-		}
-	})
-
-	t.Run("supported_installs", func(t *testing.T) {
-		home := t.TempDir()
-		t.Setenv(codexHomeEnvVar, home)
-		seedSession(t, home, "0.144.0") // supports hooks
-
-		if err := applyCodexHooks(); err != nil {
-			t.Fatalf("applyCodexHooks: %v", err)
-		}
-		if !eventHasSentinel(readHooks(t, home), HookStop) {
-			t.Error("hooks not installed for a supported Codex version")
-		}
-	})
-}
-
 // TestHooksPermission_InstallGateContract exercises the install-type gate: the
 // hooks permission's effect (entries on disk) must appear only while granted
 // and be undone on revoke, driven through the real Apply/Remove closures.
@@ -244,7 +175,7 @@ func TestHooksPermission_InstallGateContract(t *testing.T) {
 		SetState: func(state permission.State) {
 			var err error
 			if state == permission.StateGranted {
-				err = applyCodexHooks()
+				_, err = EnsureHooksInstalled()
 			} else {
 				_, err = UninstallHooks()
 			}

--- a/core/adapters/inbound/agents/codex/hookversion_test.go
+++ b/core/adapters/inbound/agents/codex/hookversion_test.go
@@ -62,8 +62,8 @@ func hooksVersionGate(t *testing.T) *agent.VersionGate {
 // that can never fire and nothing anywhere said why.
 //
 // The reason is now carried by the refusal itself, which PermissionService
-// routes into the failed-effect log and which #1362's consent-effect surfacing
-// (PR #1379) will carry to the wizard unchanged once it lands.
+// records as the permission's EffectError, so #1362's consent-effect surfacing
+// renders it in both wizards.
 func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
 	writeCodexSessionWithVersion(t, "0.100.0")
 	gate := hooksVersionGate(t)

--- a/core/adapters/inbound/agents/codex/hookversion_test.go
+++ b/core/adapters/inbound/agents/codex/hookversion_test.go
@@ -1,0 +1,120 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DeclaresVersionGate(t *testing.T) {
+	contracttesting.AssertHookVersionGate(t, contracttesting.HookVersionGate{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		Since:         hookEventSince,
+	})
+}
+
+// writeCodexSessionWithVersion lays down a $CODEX_HOME/sessions tree holding a
+// single transcript whose session_meta header declares cliVersion, which is
+// what the adapter uses as its install-time proxy for "the Codex the user is
+// running now".
+func writeCodexSessionWithVersion(t *testing.T, cliVersion string) string {
+	t.Helper()
+	home := t.TempDir()
+	sessions := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	line := `{"type":"session_meta","payload":{"id":"s1","cli_version":"` + cliVersion + `"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(sessions, "s1.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+	t.Setenv(codexHomeEnvVar, home)
+	return home
+}
+
+// hooksVersionGate returns the declared gate for the hooks permission, read
+// off the real registration the daemon consumes.
+func hooksVersionGate(t *testing.T) *agent.VersionGate {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			if p.Hooks == nil || p.Hooks.Version == nil {
+				t.Fatal("hooks permission declares no version gate")
+			}
+			return p.Hooks.Version
+		}
+	}
+	t.Fatal("no hooks permission")
+	return nil
+}
+
+// TestHooksGate_BelowFloorSaysWhy is the issue #1365 defect test for the "say
+// why" half of scope item 3, resolved through the adapter's real version
+// source. A Codex older than the hooks feature was already skipped before
+// #1365 — but silently: applyCodexHooks returned nil, indistinguishable from a
+// successful install, so the user saw the permission go green with a channel
+// that can never fire and nothing anywhere said why.
+//
+// The reason is now carried by the refusal itself, which PermissionService
+// routes into the failed-effect log and which #1362's consent-effect surfacing
+// (PR #1379) will carry to the wizard unchanged once it lands.
+func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
+	writeCodexSessionWithVersion(t, "0.100.0")
+	gate := hooksVersionGate(t)
+	observed := gate.Observed
+
+	if observed == nil {
+		t.Fatal("codex declares no Observed version source; it reads cli_version from the " +
+			"session header it already tails, and losing that means probing the binary")
+	}
+	if got := observed(); got != "0.100.0" {
+		t.Fatalf("Observed() = %q, want the cli_version from the newest session header", got)
+	}
+
+	allowed, why := gate.Permits(observed())
+
+	if allowed {
+		t.Fatal("gate permits installing into Codex 0.100.0, below the declared floor")
+	}
+	if !strings.Contains(why, "0.100.0") || !strings.Contains(why, minCLIVersion) {
+		t.Errorf("refusal %q does not name both the installed version and the required "+
+			"one; the reason has to be actionable enough for a user to know what to "+
+			"upgrade", why)
+	}
+}
+
+// TestHooksGate_AtOrAboveFloorInstalls is a LOCK: it pins that the gate does
+// not become a blanket refusal. It passes by construction and is here because
+// a floor that rejects everything looks identical, from the log, to a floor
+// that works.
+func TestHooksGate_AtOrAboveFloorInstalls(t *testing.T) {
+	for _, v := range []string{minCLIVersion, "0.146.1", "rust-v0.120.3"} {
+		writeCodexSessionWithVersion(t, v)
+		gate := hooksVersionGate(t)
+		if allowed, why := gate.Permits(gate.Observed()); !allowed {
+			t.Errorf("gate refuses Codex %s, at or above the %s floor: %s", v, minCLIVersion, why)
+		}
+	}
+}
+
+// TestHooksGate_NoTranscriptFallsThroughToProbe pins that a machine with no
+// Codex sessions yet does not resolve to "version 0" — Observed returns "",
+// which must mean unknown and reach the probe, not a refusal.
+func TestHooksGate_NoTranscriptFallsThroughToProbe(t *testing.T) {
+	t.Setenv(codexHomeEnvVar, t.TempDir())
+	gate := hooksVersionGate(t)
+
+	if got := gate.Observed(); got != "" {
+		t.Fatalf("Observed() = %q with no sessions on disk, want empty", got)
+	}
+	if allowed, why := gate.Permits(""); !allowed {
+		t.Errorf("gate refuses on an unknown version: %s — an unread version is not an "+
+			"old one, and refusing here disables hooks on a fresh install", why)
+	}
+}

--- a/core/adapters/inbound/agents/hookjson/disclosure.go
+++ b/core/adapters/inbound/agents/hookjson/disclosure.go
@@ -40,3 +40,26 @@ func EventList(events []string) string {
 		return strings.Join(events[:len(events)-1], ", ") + ", and " + events[len(events)-1]
 	}
 }
+
+// RequiresVersion renders the sentence disclosing a hook install's declared
+// minimum upstream CLI version (issue #1365).
+//
+// The floor belongs in the consent copy for the same reason the event list
+// does. #1356's rule is that the text names what the installer writes; a
+// version gate makes *whether* it writes conditional, so copy that describes
+// the install without naming the condition is describing something that may
+// not happen. Rendering it from the same string the gate compares against
+// keeps the two from drifting — the failure #1356 exists to prevent, arriving
+// on a new axis.
+//
+// The wording deliberately avoids CamelCase and any "N hook entries" phrasing:
+// the disclosure contract scans the copy for event-shaped tokens and for entry
+// counts, and a version sentence must not trip either.
+func RequiresVersion(cliName, minVersion string) string {
+	if minVersion == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Requires %s %s or newer; on an older version nothing is written and the daemon reports why.",
+		cliName, minVersion)
+}

--- a/core/adapters/inbound/agents/hookjson/disclosure_test.go
+++ b/core/adapters/inbound/agents/hookjson/disclosure_test.go
@@ -1,6 +1,10 @@
 package hookjson
 
-import "testing"
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
 
 func TestEventList(t *testing.T) {
 	tests := []struct {
@@ -21,5 +25,37 @@ func TestEventList(t *testing.T) {
 				t.Errorf("EventList(%v) = %q, want %q", tt.events, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRequiresVersion(t *testing.T) {
+	got := RequiresVersion("Claude Code", "2.1.122")
+	for _, want := range []string{"Claude Code", "2.1.122", "nothing is written"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("RequiresVersion() = %q, missing %q", got, want)
+		}
+	}
+	if RequiresVersion("Claude Code", "") != "" {
+		t.Error("RequiresVersion rendered a sentence for an undeclared floor")
+	}
+}
+
+// TestRequiresVersion_DoesNotTripTheDisclosureContract guards a real collision
+// between the two #1356/#1365 mechanisms. AssertHookDisclosureMatchesInstalled
+// scans the same copy for CamelCase event-shaped tokens and for "N hook
+// entries" counts, so a version sentence worded slightly differently — "Adds 1
+// hook entry on ClaudeCode 2.1.122+" — would fail an adapter's disclosure test
+// for a reason having nothing to do with its install.
+func TestRequiresVersion_DoesNotTripTheDisclosureContract(t *testing.T) {
+	s := RequiresVersion("Claude Code", "2.1.122")
+	if regexp.MustCompile(`(\d+) hook entr(?:y|ies)`).MatchString(s) {
+		t.Errorf("version sentence %q states a hook-entry count; it would be read as the "+
+			"install's count and contradict the real one", s)
+	}
+	for _, w := range regexp.MustCompile(`[A-Za-z][A-Za-z0-9_]*`).FindAllString(s, -1) {
+		if regexp.MustCompile(`^[A-Z][a-z]+(?:[A-Z][a-z]+)+$`).MatchString(w) {
+			t.Errorf("version sentence contains %q, which reads as a hook event name and "+
+				"would be reported as an undisclosed over-promise", w)
+		}
 	}
 }

--- a/core/adapters/inbound/agents/hookversion_test.go
+++ b/core/adapters/inbound/agents/hookversion_test.go
@@ -1,0 +1,51 @@
+package agents
+
+import (
+	"testing"
+
+	"irrlicht/core/pkg/cliversion"
+)
+
+// TestEveryHookInstallDeclaresAVersionFloor is the registry-wide tripwire for
+// issue #1365, and the reason scope item 4 says "declaring a version string,
+// not copying a function": it fails for a NEW adapter that installs hooks
+// without declaring a floor, before that adapter has any test of its own.
+//
+// The per-adapter contract (contracttesting.AssertHookVersionGate) is stronger
+// but has to be wired; this one cannot be forgotten, because it walks the same
+// registry projection --uninstall-hooks and the recorder read. #1357 added that
+// projection precisely so a third hook adapter is covered by existing rather
+// than by remembering, and the version floor is the second obligation to ride
+// it.
+//
+// Phase C of #1355 has already established the floors the next two adapters
+// will declare: copilot >= 1.0.26, kiro-cli >= 1.29.8. Each joins by adding a
+// Version block to its HookInstall — no new function, nothing here to change.
+func TestEveryHookInstallDeclaresAVersionFloor(t *testing.T) {
+	for _, a := range All() {
+		for _, p := range a.Permissions {
+			if p.Hooks == nil {
+				continue
+			}
+			if p.Hooks.Version == nil || p.Hooks.Version.Min == "" {
+				t.Errorf("%s/%s installs hooks into the user's config but declares no "+
+					"minimum CLI version (#1365) — an older CLI is written entries it may "+
+					"reject or ignore, and the user sees a granted permission whose channel "+
+					"never fires. Add Version: &agent.VersionGate{Min: \"x.y.z\", Probe: "+
+					"[]string{\"<cli>\", \"--version\"}}",
+					a.Identity.Name, p.Key)
+				continue
+			}
+			if _, ok := cliversion.Parse(p.Hooks.Version.Min); !ok {
+				t.Errorf("%s/%s declares minimum version %q, which is not a "+
+					"major.minor.patch triple; an unparseable floor permits every version",
+					a.Identity.Name, p.Key, p.Hooks.Version.Min)
+			}
+			if p.Hooks.Version.Observed == nil && len(p.Hooks.Version.Probe) == 0 {
+				t.Errorf("%s/%s declares a floor but no version source (neither Observed "+
+					"nor Probe), so the gate can never refuse anything",
+					a.Identity.Name, p.Key)
+			}
+		}
+	}
+}

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -17,6 +17,7 @@ import (
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/config"
 	"irrlicht/core/domain/permission"
+	"irrlicht/core/pkg/cliversion"
 	"irrlicht/core/ports/inbound"
 	"irrlicht/core/ports/outbound"
 )
@@ -461,6 +462,16 @@ func (s *PermissionService) runEffects(effects []pendingEffect) {
 // but NOT applied, because <reason>" instead of a bare "granted" (#1362).
 // The error is still logged and still not propagated — the recorded
 // consent stands either way — but it is no longer the only trace.
+//
+// A declared upstream-version floor (agent.HookInstall.Version, issue #1365)
+// is checked here rather than inside each adapter's Apply closure, so an
+// adapter joins the scheme by declaring a version string instead of by copying
+// a function. It deliberately produces an ordinary effect error rather than a
+// separate "skipped" concept, so #1362's surfacing carries it for free: the
+// wizard renders "granted but NOT applied, because <the CLI is too old>", and
+// because planAnswerLocked re-runs the effect when a re-answer finds a
+// recorded failure, the refusal's own advice — upgrade the CLI and grant again
+// — is literally the gesture that retries it.
 func (s *PermissionService) runClosureEffect(e pendingEffect) {
 	effect, verb := e.perm.Apply, "apply"
 	if e.target != permission.StateGranted {
@@ -470,7 +481,17 @@ func (s *PermissionService) runClosureEffect(e pendingEffect) {
 	// left over from the opposite verb is stale.
 	var reason string
 	if effect != nil {
-		if err := effect(); err != nil {
+		// Only granting is gated. Removing our entries from a config file is
+		// always safe and always wanted, including on a CLI too old to have
+		// understood them in the first place.
+		err := error(nil)
+		if e.target == permission.StateGranted {
+			err = s.hookVersionRefusal(e.perm)
+		}
+		if err == nil {
+			err = effect()
+		}
+		if err != nil {
 			reason = err.Error()
 			s.log.LogError("permissions", "", fmt.Sprintf("failed to %s %s/%s: %v", verb, e.agentName, e.perm.Key, err))
 		} else {
@@ -495,6 +516,45 @@ func (s *PermissionService) recordEffectResult(e pendingEffect, reason string) {
 // Caller holds s.mu.
 func (s *PermissionService) effectFailedLocked(agentName, permKey string) bool {
 	return s.effectErrs[effectKey(agentName, permKey)] != ""
+}
+
+// hookVersionRefusal resolves the installed upstream CLI version for a
+// permission that declares a floor and returns a non-nil error when the
+// install must not proceed. It returns nil for every permission that declares
+// no floor, which is every non-hook permission and any hook adapter that has
+// not opted in.
+//
+// Resolution prefers the adapter's own passive signal over running anything:
+// Codex reads cli_version out of the transcript it is already tailing, which
+// costs nothing and works when the binary is not on the daemon's PATH. The
+// probe is the fallback for adapters with no such signal.
+func (s *PermissionService) hookVersionRefusal(p agent.Permission) error {
+	if p.Hooks == nil || p.Hooks.Version == nil || p.Hooks.Version.Min == "" {
+		return nil
+	}
+	gate := p.Hooks.Version
+
+	installed := ""
+	if gate.Observed != nil {
+		installed = gate.Observed()
+	}
+	if installed == "" && len(gate.Probe) > 0 {
+		probed, err := cliversion.Probe(context.Background(), gate.Probe)
+		if err != nil {
+			// Unknown version: fail open, but say so. A probe that cannot run
+			// is the state most likely to be misread later as "the gate
+			// checked and approved".
+			s.log.LogInfo("permissions", "", fmt.Sprintf(
+				"%s: version probe failed (%v); installing anyway — an unreadable version is not an old one", p.Key, err))
+			return nil
+		}
+		installed = probed
+	}
+
+	if allowed, why := gate.Permits(installed); !allowed {
+		return errors.New(why)
+	}
+	return nil
 }
 
 // startWatching constructs the agent's watchers fresh, registers their

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -17,6 +17,7 @@ import (
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/config"
 	"irrlicht/core/domain/permission"
+	"irrlicht/core/pkg/cliprobe"
 	"irrlicht/core/pkg/cliversion"
 	"irrlicht/core/ports/inbound"
 	"irrlicht/core/ports/outbound"
@@ -538,23 +539,70 @@ func (s *PermissionService) hookVersionRefusal(p agent.Permission) error {
 	if gate.Observed != nil {
 		installed = gate.Observed()
 	}
-	if installed == "" && len(gate.Probe) > 0 {
-		probed, err := cliversion.Probe(context.Background(), gate.Probe)
+	if s.shouldConfirmByProbe(gate, installed) {
+		probed, err := cliprobe.Probe(s.effectContext(), gate.Probe)
 		if err != nil {
-			// Unknown version: fail open, but say so. A probe that cannot run
-			// is the state most likely to be misread later as "the gate
+			// Unknown version: fail open, but say so. A probe that could not
+			// run is the state most likely to be misread later as "the gate
 			// checked and approved".
 			s.log.LogInfo("permissions", "", fmt.Sprintf(
 				"%s: version probe failed (%v); installing anyway — an unreadable version is not an old one", p.Key, err))
-			return nil
+		} else {
+			installed = probed
 		}
-		installed = probed
 	}
 
 	if allowed, why := gate.Permits(installed); !allowed {
 		return errors.New(why)
 	}
 	return nil
+}
+
+// shouldConfirmByProbe decides whether to spend a process on confirming the
+// version. It returns false only for the case that needs no help: a passive
+// signal that parses and already clears the floor.
+//
+// The two cases it does probe are the ones where the passive answer cannot be
+// relied on:
+//
+//   - It is unknown or unparseable. An adapter with no Observed source at all
+//     (Claude Code) is always here, and so is one whose source returned
+//     something it could not read — falling open without asking the binary
+//     that could have answered would make the gate decorative.
+//   - It parses and says "too old". A passive signal is the LAST-RUN version,
+//     not the installed one, so it can only be stale downward: a user who
+//     upgrades and grants before starting a new session would otherwise be
+//     refused on a version they no longer run, with nothing installed and the
+//     permission still showing green. A false refusal is the one direction
+//     this gate must never produce quietly, so it is worth a process to be
+//     sure.
+func (s *PermissionService) shouldConfirmByProbe(gate *agent.VersionGate, installed string) bool {
+	if len(gate.Probe) == 0 {
+		return false
+	}
+	if _, parsed := cliversion.Parse(installed); !parsed {
+		return true
+	}
+	allowed, _ := gate.Permits(installed)
+	return !allowed
+}
+
+// effectContext is the daemon-lifetime context effects run under, so a
+// shutdown mid-probe cancels it rather than leaving a process to time out.
+// Start sets parent; a service constructed without one (tests) falls back to
+// Background.
+//
+// Takes s.mu because Start writes parent under it. Callers hold effectMu,
+// never mu, so this respects the documented lock order (effectMu before mu)
+// — and it is released before the probe runs, so no exec ever happens with
+// the hot Granted() gate's mutex held.
+func (s *PermissionService) effectContext() context.Context {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.parent != nil {
+		return s.parent
+	}
+	return context.Background()
 }
 
 // startWatching constructs the agent's watchers fresh, registers their

--- a/core/application/services/permission_version_gate_test.go
+++ b/core/application/services/permission_version_gate_test.go
@@ -1,10 +1,18 @@
 package services
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 
+	// Importing an adapter from the services package is confined to this test
+	// file and is the point of the composition test below: it is the only place
+	// the real declaration and the real enforcement meet. Test-only, so it does
+	// not affect the hexagonal import direction core/architecture_test.go
+	// enforces (that walks non-test package imports).
+	"irrlicht/core/adapters/inbound/agents/codex"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/permission"
 )
@@ -198,5 +206,58 @@ func TestHookVersionGate_ProbeFailureInstallsAndSaysSo(t *testing.T) {
 	if len(log.infos) == 0 {
 		t.Error("a probe that could not run left no trace; an unchecked gate must not be " +
 			"indistinguishable from a passed one")
+	}
+}
+
+// TestHookVersionGate_RealCodexDeclarationRefusesOldCLI is the composition
+// test: the REAL adapter declaration driven through the REAL service, asserting
+// nothing lands on disk. Every other test here mocks one side or the other —
+// the adapter tests call gate.Permits directly, and the tests above use a
+// synthetic permission — so without this, a wiring regression between the two
+// (the service reading the wrong field, an adapter dropping its Version block)
+// would leave every test green.
+//
+// It replaces the end-to-end coverage that codex's TestApplyCodexHooks_VersionGate
+// had before #1365 moved the gate out of the adapter.
+func TestHookVersionGate_RealCodexDeclarationRefusesOldCLI(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+	sessions := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	meta := `{"type":"session_meta","payload":{"id":"s1","cli_version":"0.100.0"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(sessions, "s1.jsonl"), []byte(meta), 0o600); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+
+	var hooks agent.Permission
+	for _, p := range codex.Agent().Permissions {
+		if p.Hooks != nil {
+			hooks = p
+		}
+	}
+	if hooks.Key == "" {
+		t.Fatal("codex declares no hooks permission")
+	}
+	if len(hooks.Hooks.Version.Probe) == 0 {
+		t.Fatal("codex declares no probe; the line below would be hiding its absence")
+	}
+	// Pin the version to the passive source. Left alone, the stale-transcript
+	// path would confirm against the real `codex` on the developer's machine
+	// (shouldConfirmByProbe, and correctly so — it is newer than 0.100.0), which
+	// makes the outcome depend on what happens to be installed. Everything else
+	// here is the real declaration: floor, Observed, ConfigPath, Apply.
+	hooks.Hooks.Version.Probe = nil
+
+	svc, log := newGateService()
+	svc.runClosureEffect(pendingEffect{"codex", hooks, permission.StateGranted})
+
+	if _, err := os.Stat(filepath.Join(home, "hooks.json")); !os.IsNotExist(err) {
+		t.Errorf("hooks.json was written under %s for a Codex reporting 0.100.0 — "+
+			"the real declaration and the real service did not compose into a refusal", home)
+	}
+	if !log.errorMentioning("0.100.0") {
+		t.Errorf("no logged reason naming the installed version; errors were %v", log.errors)
 	}
 }

--- a/core/application/services/permission_version_gate_test.go
+++ b/core/application/services/permission_version_gate_test.go
@@ -26,8 +26,8 @@ import (
 // from no declaration at all.
 
 // gateLog captures what the service reported. The log line is not incidental
-// here: it is the entire user-visible output of a refusal today, and the thing
-// #1362's consent-effect surfacing (PR #1379) will lift into the wizard.
+// here: the same string is recorded as the permission's EffectError, which is
+// what #1362's consent-effect surfacing renders in both wizards.
 type gateLog struct {
 	mu     sync.Mutex
 	infos  []string
@@ -90,7 +90,9 @@ func gatedHooksPermission(min, observed string, applied *bool) agent.Permission 
 
 func newGateService() (*PermissionService, *gateLog) {
 	log := &gateLog{}
-	return &PermissionService{log: log}, log
+	// effectErrs must exist: runClosureEffect records every outcome there
+	// (#1362), so a bare struct panics on the first effect.
+	return &PermissionService{log: log, effectErrs: map[string]string{}}, log
 }
 
 func grant(svc *PermissionService, p agent.Permission) {
@@ -259,5 +261,58 @@ func TestHookVersionGate_RealCodexDeclarationRefusesOldCLI(t *testing.T) {
 	}
 	if !log.errorMentioning("0.100.0") {
 		t.Errorf("no logged reason naming the installed version; errors were %v", log.errors)
+	}
+}
+
+// TestHookVersionGate_RefusalIsRecordedAsAnEffectError is the #1365 x #1362
+// join. The gate deliberately produces an ordinary effect error rather than a
+// separate "skipped" concept, so the refusal rides the mechanism #1379 landed:
+// it is stored in effectErrs, which Snapshot exposes as EffectError and both
+// wizards render as "granted but NOT applied, because <reason>".
+//
+// Without this the two features are only adjacent — the gate could refuse into
+// the log while the wizard still showed a clean "granted", which is the exact
+// state #1365 was filed about.
+func TestHookVersionGate_RefusalIsRecordedAsAnEffectError(t *testing.T) {
+	applied := false
+	svc, _ := newGateService()
+	p := gatedHooksPermission("2.1.122", "2.1.121", &applied)
+
+	grant(svc, p)
+
+	got := svc.effectErrs[effectKey("test-agent", "hooks")]
+	if got == "" {
+		t.Fatal("refusal was not recorded as an EffectError — the wizard would render a " +
+			"clean \"granted\" for a permission that installed nothing (#1362/#1365)")
+	}
+	if !strings.Contains(got, "2.1.121") || !strings.Contains(got, "2.1.122") {
+		t.Errorf("recorded EffectError %q does not name both versions", got)
+	}
+	// The recorded failure is also what makes the refusal's advice actionable:
+	// planAnswerLocked re-runs the effect when a re-answer finds one.
+	svc.mu.Lock()
+	retries := svc.effectFailedLocked("test-agent", "hooks")
+	svc.mu.Unlock()
+	if !retries {
+		t.Error("a recorded refusal does not mark the permission for retry, so " +
+			"\"upgrade the CLI and grant again\" would not actually re-run the install")
+	}
+}
+
+// TestHookVersionGate_SuccessClearsAnEarlierRefusal pins the other half: after
+// the user upgrades and re-grants, the stale "too old" reason must not linger
+// on a permission that is now installed.
+func TestHookVersionGate_SuccessClearsAnEarlierRefusal(t *testing.T) {
+	applied := false
+	svc, _ := newGateService()
+
+	grant(svc, gatedHooksPermission("2.1.122", "2.1.121", &applied)) // too old
+	grant(svc, gatedHooksPermission("2.1.122", "2.1.226", &applied)) // upgraded
+
+	if !applied {
+		t.Fatal("install did not run after the CLI was upgraded")
+	}
+	if got := svc.effectErrs[effectKey("test-agent", "hooks")]; got != "" {
+		t.Errorf("stale refusal %q survived a successful install", got)
 	}
 }

--- a/core/application/services/permission_version_gate_test.go
+++ b/core/application/services/permission_version_gate_test.go
@@ -1,0 +1,202 @@
+package services
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+)
+
+// This file covers the RUNTIME half of the issue #1365 obligation: that
+// PermissionService actually consults a declared version floor before running
+// an Apply closure. The static half — that each adapter declares a sane floor
+// covering every event it installs — is contracttesting.AssertHookVersionGate,
+// wired from the adapter packages. The split is the one AssertPermissionGated
+// draws, and it exists because a declaration nobody reads is indistinguishable
+// from no declaration at all.
+
+// gateLog captures what the service reported. The log line is not incidental
+// here: it is the entire user-visible output of a refusal today, and the thing
+// #1362's consent-effect surfacing (PR #1379) will lift into the wizard.
+type gateLog struct {
+	mu     sync.Mutex
+	infos  []string
+	errors []string
+}
+
+func (l *gateLog) LogInfo(_, _, msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.infos = append(l.infos, msg)
+}
+
+func (l *gateLog) LogError(_, _, msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.errors = append(l.errors, msg)
+}
+
+func (l *gateLog) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
+func (l *gateLog) Close() error                                            { return nil }
+
+func (l *gateLog) errorMentioning(needles ...string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, e := range l.errors {
+		all := true
+		for _, n := range needles {
+			if !strings.Contains(e, n) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
+}
+
+// gatedHooksPermission builds a hooks permission whose Apply records whether it
+// ran, so a test can tell "refused" from "installed" the way the filesystem
+// would. min is the declared floor; observed is what the machine reports.
+func gatedHooksPermission(min, observed string, applied *bool) agent.Permission {
+	return agent.Permission{
+		Key:    "hooks",
+		Kind:   permission.KindModify,
+		Title:  "Install status hooks",
+		Apply:  func() error { *applied = true; return nil },
+		Remove: func() error { *applied = false; return nil },
+		Hooks: &agent.HookInstall{
+			ConfigPath: func() (string, error) { return "/tmp/irrlicht-1365-test.json", nil },
+			Uninstall:  func() (bool, error) { return false, nil },
+			Version: &agent.VersionGate{
+				Min:      min,
+				Observed: func() string { return observed },
+			},
+		},
+	}
+}
+
+func newGateService() (*PermissionService, *gateLog) {
+	log := &gateLog{}
+	return &PermissionService{log: log}, log
+}
+
+func grant(svc *PermissionService, p agent.Permission) {
+	svc.runClosureEffect(pendingEffect{"test-agent", p, permission.StateGranted})
+}
+
+func TestHookVersionGate_RefusesBelowFloorAndSaysWhy(t *testing.T) {
+	applied := false
+	svc, log := newGateService()
+
+	grant(svc, gatedHooksPermission("2.1.122", "2.1.121", &applied))
+
+	if applied {
+		t.Error("Apply ran although the installed CLI is below the declared floor — " +
+			"refusing means nothing is written, not that a half-install is tidied up after")
+	}
+	if !log.errorMentioning("2.1.121", "2.1.122") {
+		t.Errorf("no logged failure naming both the installed and the required version; "+
+			"errors were %v — the refusal is the only thing the user ever sees", log.errors)
+	}
+}
+
+func TestHookVersionGate_InstallsAtOrAboveFloor(t *testing.T) {
+	for _, v := range []string{"2.1.122", "2.1.226", "3.0.0"} {
+		applied := false
+		svc, _ := newGateService()
+
+		grant(svc, gatedHooksPermission("2.1.122", v, &applied))
+
+		if !applied {
+			t.Errorf("Apply did not run at CLI version %s, at or above the floor", v)
+		}
+	}
+}
+
+// TestHookVersionGate_UnknownVersionInstalls is a LOCK on the fail-open
+// direction, not a defect test. A daemon started by launchd routinely cannot
+// see the user's CLI at all — minimal PATH, binary in ~/.local/bin — and
+// refusing there would produce the exact "granted, but the channel never fires"
+// outcome #1365 is about, reached from the other side.
+func TestHookVersionGate_UnknownVersionInstalls(t *testing.T) {
+	for _, unreadable := range []string{"", "garbage", "2.1"} {
+		applied := false
+		svc, _ := newGateService()
+		p := gatedHooksPermission("2.1.122", unreadable, &applied)
+		p.Hooks.Version.Probe = nil // nothing left to learn the version from
+
+		grant(svc, p)
+
+		if !applied {
+			t.Errorf("Apply was skipped on unreadable version %q — unknown is not old", unreadable)
+		}
+	}
+}
+
+// TestHookVersionGate_RevokeIsNeverGated pins that taking our entries back out
+// works at any version. A user on an old CLI that somehow has entries installed
+// must still be able to remove them; gating Remove would strand them.
+func TestHookVersionGate_RevokeIsNeverGated(t *testing.T) {
+	applied := true
+	svc, _ := newGateService()
+	p := gatedHooksPermission("2.1.122", "1.0.0", &applied)
+
+	svc.runClosureEffect(pendingEffect{"test-agent", p, permission.StateDenied})
+
+	if applied {
+		t.Error("Remove was gated on the CLI version; uninstall must always be possible")
+	}
+}
+
+// TestHookVersionGate_NoFloorDeclaredInstalls pins that the gate is opt-in, so
+// every non-hook permission — and any hook adapter that has not declared a
+// floor — behaves exactly as before.
+func TestHookVersionGate_NoFloorDeclaredInstalls(t *testing.T) {
+	applied := false
+	svc, _ := newGateService()
+
+	grant(svc, gatedHooksPermission("", "1.0.0", &applied))
+
+	if !applied {
+		t.Error("Apply was skipped for a permission declaring no floor")
+	}
+
+	applied = false
+	svc2, _ := newGateService()
+	svc2.runClosureEffect(pendingEffect{"test-agent", agent.Permission{
+		Key:   "statusline",
+		Kind:  permission.KindModify,
+		Apply: func() error { applied = true; return nil },
+	}, permission.StateGranted})
+
+	if !applied {
+		t.Error("Apply was skipped for a permission with no HookInstall at all")
+	}
+}
+
+// TestHookVersionGate_ProbeFailureInstallsAndSaysSo pins both halves of the
+// missing/hung/unparseable-probe case: the install proceeds (fail open), and
+// the fact that the gate could not check is recorded rather than passing
+// silently as "checked and approved".
+func TestHookVersionGate_ProbeFailureInstallsAndSaysSo(t *testing.T) {
+	applied := false
+	svc, log := newGateService()
+	p := gatedHooksPermission("2.1.122", "", &applied)
+	p.Hooks.Version.Probe = []string{"irrlicht-no-such-binary-1365"}
+
+	grant(svc, p)
+
+	if !applied {
+		t.Error("Apply was skipped because the version probe could not run; a binary the " +
+			"daemon cannot see is not an old binary")
+	}
+	if len(log.infos) == 0 {
+		t.Error("a probe that could not run left no trace; an unchecked gate must not be " +
+			"indistinguishable from a passed one")
+	}
+}

--- a/core/domain/agent/declaration.go
+++ b/core/domain/agent/declaration.go
@@ -185,8 +185,11 @@ func (g *VersionGate) Permits(installed string) (bool, string) {
 	if g == nil || g.Min == "" {
 		return true, ""
 	}
-	ok, known := cliversion.AtLeast(installed, g.Min)
-	if ok || !known {
+	// The unknown-fails-open decision is AtLeast's and is encoded there once:
+	// it already reports ok=true for anything it could not read. Re-deriving it
+	// here from `known` would mean two places decide the direction and the
+	// contract arm that claims to pin it would only be pinning this copy.
+	if ok, _ := cliversion.AtLeast(installed, g.Min); ok {
 		return true, ""
 	}
 	return false, fmt.Sprintf(

--- a/core/domain/agent/declaration.go
+++ b/core/domain/agent/declaration.go
@@ -1,6 +1,11 @@
 package agent
 
-import "irrlicht/core/domain/permission"
+import (
+	"fmt"
+
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/pkg/cliversion"
+)
 
 // Agent is the registration record each inbound agent adapter exports.
 // It collapses identity, process recognition, session source, write-back
@@ -129,6 +134,65 @@ type HookInstall struct {
 	// Uninstall removes irrlicht's entries from that file, reporting whether
 	// it modified anything.
 	Uninstall func() (bool, error)
+
+	// Version declares the upstream CLI version floor this install requires
+	// (issue #1365). Nil means the adapter declares no floor and installs
+	// unconditionally — which is what Claude Code did for its whole life, and
+	// what a third adapter would inherit by default, so a nil here is a
+	// decision worth stating rather than an omission.
+	Version *VersionGate
+}
+
+// VersionGate is a declared minimum upstream-CLI version for a hook install
+// (issue #1365).
+//
+// It is data, not behaviour, and that is the whole point. Codex used to carry
+// a private codexSupportsHooks/parseCodexVersion pair and its own
+// minHookMajor/Minor/Patch constants; Claude Code carried nothing and wrote
+// seven hook entries into ~/.claude/settings.json whatever version was
+// installed. A third adapter joins the scheme by declaring two literals here —
+// a version string and the argv that prints one — and PermissionService
+// enforces it for every adapter identically.
+type VersionGate struct {
+	// Min is the lowest upstream CLI version at which EVERY event this
+	// permission installs is known to the CLI. It is a whole-install floor,
+	// not a per-event one: see the package comment on why the installed event
+	// set must not vary with the version.
+	Min string
+
+	// Probe is the argv that asks the installed CLI its version, e.g.
+	// {"claude", "--version"}. Used when Observed is nil or yields nothing.
+	// Must be a compile-time literal — it is executed.
+	Probe []string
+
+	// Observed, when non-nil, supplies the installed version WITHOUT running
+	// anything. Codex sets it: the adapter already captures cli_version from
+	// every session header, so the newest transcript answers the question for
+	// free and works even when the binary is not on the daemon's PATH. It is
+	// consulted first; an empty return falls through to Probe. An adapter with
+	// no such signal leaves it nil and gets the probe.
+	Observed func() string
+}
+
+// Permits reports whether an install may proceed at the given installed
+// version, and when it may not, why.
+//
+// Pure comparison — resolving `installed` (reading a transcript, running a
+// binary) belongs to the caller, which keeps process execution out of the
+// domain. An unknown or unparseable version permits the install: see
+// cliversion.AtLeast for why unknown fails open rather than closed.
+func (g *VersionGate) Permits(installed string) (bool, string) {
+	if g == nil || g.Min == "" {
+		return true, ""
+	}
+	ok, known := cliversion.AtLeast(installed, g.Min)
+	if ok || !known {
+		return true, ""
+	}
+	return false, fmt.Sprintf(
+		"installed CLI is %s, which is older than the %s required by the hook events this installs; "+
+			"nothing was written — upgrade the CLI and grant again",
+		installed, g.Min)
 }
 
 // Identity is the always-required adapter metadata served via

--- a/core/internal/contracttesting/hook_disclosure.go
+++ b/core/internal/contracttesting/hook_disclosure.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 
 	"irrlicht/core/domain/agent"
@@ -126,6 +127,38 @@ func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
 	t.Run("names_no_uninstalled_event", func(t *testing.T) {
 		assertNamesNoUninstalledEvent(t, d, named)
 	})
+	t.Run("states_the_version_floor", func(t *testing.T) {
+		assertStatesVersionFloor(t, perm, disclosure)
+	})
+}
+
+// assertStatesVersionFloor extends the #1356 contract along the axis #1365
+// added. The other three arms bind the copy to WHICH entries get written; a
+// declared minimum upstream version makes it conditional whether ANY of them
+// do, and copy that describes an install without naming its precondition
+// describes something that may not happen on the user's machine.
+//
+// This arm reads the floor off the declaration rather than taking it as a
+// field, so every adapter that declares one is covered without changing its
+// call site, and an adapter that declares none is unaffected.
+//
+// Note what does NOT need saying here: the disclosed event set is the same at
+// every version the adapter installs at. The gate is whole-install — below the
+// floor nothing is written, at or above it everything is — precisely so that
+// Touches/Detail can keep stating one exact count and one exact list. A gate
+// that filtered events per version would make the count a range, which is the
+// hand-waving #1356 abolished.
+func assertStatesVersionFloor(t *testing.T, perm agent.Permission, disclosure string) {
+	t.Helper()
+	if perm.Hooks == nil || perm.Hooks.Version == nil || perm.Hooks.Version.Min == "" {
+		return
+	}
+	if !strings.Contains(disclosure, perm.Hooks.Version.Min) {
+		t.Errorf("consent copy never states the %s minimum CLI version the install is gated "+
+			"on — the user reads this text and grants, then nothing is written and the copy "+
+			"gave no hint why (#1365); render it with hookjson.RequiresVersion so it cannot "+
+			"drift from the gate", perm.Hooks.Version.Min)
+	}
 }
 
 // assertNamesEveryInstalledEvent is the consent-critical arm: an installed

--- a/core/internal/contracttesting/hook_version.go
+++ b/core/internal/contracttesting/hook_version.go
@@ -161,9 +161,10 @@ func assertFloorRefusesOlder(t *testing.T, gate *agent.VersionGate) {
 			t.Errorf("gate permits %s, below the declared floor %s", older, gate.Min)
 			continue
 		}
-		// The refusal is the only thing the user ever sees about it (the daemon
-		// log today, #1362's wizard surfacing once PR #1379 lands), so an empty
-		// or version-free reason is a silent skip wearing an error's clothes —
+		// The refusal string IS the user-visible text: PermissionService
+		// records it as the permission's EffectError and both wizards render
+		// "granted but NOT applied, because <reason>" (#1362). An empty or
+		// version-free reason is a silent skip wearing an error's clothes —
 		// the exact behaviour #1365 filed against Codex.
 		if why == "" {
 			t.Errorf("gate refuses %s without a reason; the refusal is what the user is shown", older)

--- a/core/internal/contracttesting/hook_version.go
+++ b/core/internal/contracttesting/hook_version.go
@@ -104,28 +104,36 @@ func assertFloorCoversEveryEvent(t *testing.T, min string, installed []string, s
 		t.Fatal("HookVersionGate.Installed is empty — pass the installer's event list")
 	}
 	for _, event := range installed {
-		got, ok := since[event]
-		if !ok {
-			t.Errorf("no Since entry for installed event %q — every event written into the "+
-				"user's config needs a stated version it is known to exist at, or the floor "+
-				"cannot be shown to cover it", event)
-			continue
-		}
-		if _, parsed := cliversion.Parse(got); !parsed {
-			t.Errorf("Since[%q] = %q is not a major.minor.patch triple", event, got)
-			continue
-		}
-		if ok, known := cliversion.AtLeast(min, got); known && !ok {
-			t.Errorf("declared floor %s is below %s, the version %q is known at — at a CLI "+
-				"between the two the install writes an entry naming an event that CLI does "+
-				"not have; raise the floor to at least %s", min, got, event, got)
-		}
+		assertFloorCoversEvent(t, min, event, since[event])
 	}
 	for event := range since {
 		if !slices.Contains(installed, event) {
 			t.Errorf("Since names %q, which is not installed — a stale provenance entry "+
 				"makes the floor look better justified than it is", event)
 		}
+	}
+}
+
+// assertFloorCoversEvent checks one event's provenance against the floor.
+// A missing or unparseable Since is reported rather than skipped: an event
+// with no stated version is one nobody checked, which is the position
+// claudecode's seven-event install was in before #1365.
+func assertFloorCoversEvent(t *testing.T, min, event, since string) {
+	t.Helper()
+	if since == "" {
+		t.Errorf("no Since entry for installed event %q — every event written into the "+
+			"user's config needs a stated version it is known to exist at, or the floor "+
+			"cannot be shown to cover it", event)
+		return
+	}
+	if _, parsed := cliversion.Parse(since); !parsed {
+		t.Errorf("Since[%q] = %q is not a major.minor.patch triple", event, since)
+		return
+	}
+	if ok, known := cliversion.AtLeast(min, since); known && !ok {
+		t.Errorf("declared floor %s is below %s, the version %q is known at — at a CLI "+
+			"between the two the install writes an entry naming an event that CLI does "+
+			"not have; raise the floor to at least %s", min, since, event, since)
 	}
 }
 

--- a/core/internal/contracttesting/hook_version.go
+++ b/core/internal/contracttesting/hook_version.go
@@ -142,26 +142,47 @@ func assertFloorRefusesOlder(t *testing.T, gate *agent.VersionGate) {
 		t.Errorf("gate refuses its own floor %s — the comparison is exclusive where it "+
 			"should be inclusive", gate.Min)
 	}
-	older := justBelow(floor)
-	if older == floor {
-		return // a 0.0.0 floor has no predecessor to refuse
+	// Each field decremented independently rather than one synthetic
+	// predecessor: a single "just below" value like 0.99.99 exercises only the
+	// borrow path, so a comparison that is correct there and off by one at the
+	// major boundary would still pass. These are the three boundaries a
+	// field-wise comparison can get wrong.
+	for _, older := range predecessors(floor) {
+		allowed, why := gate.Permits(older.String())
+		if allowed {
+			t.Errorf("gate permits %s, below the declared floor %s", older, gate.Min)
+			continue
+		}
+		// The refusal is the only thing the user ever sees about it (the daemon
+		// log today, #1362's wizard surfacing once PR #1379 lands), so an empty
+		// or version-free reason is a silent skip wearing an error's clothes —
+		// the exact behaviour #1365 filed against Codex.
+		if why == "" {
+			t.Errorf("gate refuses %s without a reason; the refusal is what the user is shown", older)
+			continue
+		}
+		if !strings.Contains(why, older.String()) || !strings.Contains(why, gate.Min) {
+			t.Errorf("refusal %q names neither the installed version %s nor the required %s; "+
+				"a user cannot act on it", why, older, gate.Min)
+		}
 	}
-	allowed, why := gate.Permits(older.String())
-	if allowed {
-		t.Errorf("gate permits %s, below the declared floor %s", older, gate.Min)
-		return
+}
+
+// predecessors returns every version reachable by decrementing exactly one
+// field of v, skipping fields already at zero (which have no predecessor at
+// that position).
+func predecessors(v cliversion.Version) []cliversion.Version {
+	var out []cliversion.Version
+	if v.Patch > 0 {
+		out = append(out, cliversion.Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch - 1})
 	}
-	// The refusal is the only thing the user ever sees about it (via the
-	// daemon log today, #1362's wizard surfacing once PR #1379 lands), so an
-	// empty or version-free reason is a silent skip wearing an error's clothes
-	// — the exact behaviour #1365 filed against Codex.
-	if why == "" {
-		t.Error("gate refuses without a reason; the refusal is what the user is shown")
+	if v.Minor > 0 {
+		out = append(out, cliversion.Version{Major: v.Major, Minor: v.Minor - 1, Patch: v.Patch})
 	}
-	if !strings.Contains(why, older.String()) || !strings.Contains(why, gate.Min) {
-		t.Errorf("refusal %q names neither the installed version %s nor the required %s; "+
-			"a user cannot act on it", why, older, gate.Min)
+	if v.Major > 0 {
+		out = append(out, cliversion.Version{Major: v.Major - 1, Minor: v.Minor, Patch: v.Patch})
 	}
+	return out
 }
 
 // assertUnknownFailsOpen pins the direction chosen in cliversion.AtLeast. It is
@@ -177,20 +198,5 @@ func assertUnknownFailsOpen(t *testing.T, gate *agent.VersionGate) {
 				"not an old one, and failing closed here disables hooks for anyone whose "+
 				"CLI the daemon cannot probe", unknown, why)
 		}
-	}
-}
-
-// justBelow returns the version one patch level below v, borrowing across
-// minor and major so a floor of x.y.0 still has a representable predecessor.
-func justBelow(v cliversion.Version) cliversion.Version {
-	switch {
-	case v.Patch > 0:
-		return cliversion.Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch - 1}
-	case v.Minor > 0:
-		return cliversion.Version{Major: v.Major, Minor: v.Minor - 1, Patch: 99}
-	case v.Major > 0:
-		return cliversion.Version{Major: v.Major - 1, Minor: 99, Patch: 99}
-	default:
-		return v // 0.0.0 has no predecessor; assertFloorRefusesOlder tolerates it
 	}
 }

--- a/core/internal/contracttesting/hook_version.go
+++ b/core/internal/contracttesting/hook_version.go
@@ -1,0 +1,196 @@
+// hook_version.go holds the issue #1365 contract every hook-installing agent
+// adapter must satisfy: it declares the minimum upstream CLI version its
+// install requires, that floor is high enough that every event it writes
+// exists at it, and the floor actually refuses an older CLI.
+//
+// It is the static half of the obligation. The runtime half — that
+// PermissionService consults the declaration before running the Apply closure
+// — cannot be checked from a declaration and lives in the services package's
+// own tests, the same split AssertPermissionGated draws.
+//
+// The family exists for the reason #1365 was filed: Codex grew a private
+// codexSupportsHooks with its own parser and floor constants, Claude Code grew
+// nothing and wrote seven entries into the user's settings.json at any version,
+// and the third adapter was going to copy one of those two. What an adapter
+// declares can be checked; what it remembers to implement cannot.
+package contracttesting
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/pkg/cliversion"
+)
+
+// HookVersionGate wires one adapter's hooks permission into
+// AssertHookVersionGate.
+type HookVersionGate struct {
+	// Agent is the adapter's registration, exactly as the daemon consumes it.
+	Agent agent.Agent
+	// PermissionKey is the hooks permission's key within that registration.
+	PermissionKey string
+	// Installed is the installer's event list — pass the same variable handed
+	// to hookjson.Config.Events, never a copy, for the reason spelled out on
+	// HookDisclosure.Installed.
+	Installed []string
+	// Since maps each installed event to the upstream CLI version at which it
+	// is proven to exist. Every entry in Installed needs one: an event with no
+	// stated provenance is an event nobody checked, which is exactly the
+	// position claudecode's seven-event install was in.
+	Since map[string]string
+}
+
+// AssertHookVersionGate runs the issue #1365 contract against g.
+func AssertHookVersionGate(t *testing.T, g HookVersionGate) {
+	t.Helper()
+
+	perm, ok := findPermission(g.Agent, g.PermissionKey)
+	if !ok {
+		t.Fatalf("agent %q declares no permission with key %q", g.Agent.Identity.Name, g.PermissionKey)
+	}
+	if perm.Hooks == nil {
+		t.Fatalf("permission %q declares no HookInstall — a hooks permission must, "+
+			"so that --uninstall-hooks and the version gate can both see it", g.PermissionKey)
+	}
+	if perm.Hooks.Version == nil || perm.Hooks.Version.Min == "" {
+		t.Fatalf("hooks permission %q declares no minimum CLI version (#1365) — an adapter "+
+			"that installs into an agent's config at any version writes entries an older CLI "+
+			"may reject, and the user sees a granted permission whose channel never fires",
+			g.PermissionKey)
+	}
+	gate := perm.Hooks.Version
+
+	t.Run("floor_is_parseable", func(t *testing.T) {
+		assertFloorParses(t, gate.Min)
+	})
+	t.Run("floor_covers_every_installed_event", func(t *testing.T) {
+		assertFloorCoversEveryEvent(t, gate.Min, g.Installed, g.Since)
+	})
+	t.Run("floor_refuses_an_older_cli", func(t *testing.T) {
+		assertFloorRefusesOlder(t, gate)
+	})
+	t.Run("unknown_version_fails_open", func(t *testing.T) {
+		assertUnknownFailsOpen(t, gate)
+	})
+	t.Run("version_source_is_declared", func(t *testing.T) {
+		if gate.Observed == nil && len(gate.Probe) == 0 {
+			t.Errorf("hooks permission %q declares a floor of %q but no way to learn the "+
+				"installed version — neither Observed nor Probe — so the gate can never "+
+				"refuse anything and reads as protection that isn't there",
+				g.PermissionKey, gate.Min)
+		}
+	})
+}
+
+// assertFloorParses rejects a floor the comparison cannot read. An unparseable
+// floor fails open on every comparison, so the declaration would look like a
+// gate while gating nothing — the failure mode this whole family is about.
+func assertFloorParses(t *testing.T, min string) {
+	t.Helper()
+	if _, ok := cliversion.Parse(min); !ok {
+		t.Errorf("declared minimum version %q is not a major.minor.patch triple; "+
+			"an unparseable floor silently permits every version", min)
+	}
+}
+
+// assertFloorCoversEveryEvent is the scope-item-2 arm: the floor must dominate
+// every installed event's own introduction, so that at any version where the
+// adapter installs at all, every entry it writes names an event the CLI knows.
+func assertFloorCoversEveryEvent(t *testing.T, min string, installed []string, since map[string]string) {
+	t.Helper()
+	if len(installed) == 0 {
+		t.Fatal("HookVersionGate.Installed is empty — pass the installer's event list")
+	}
+	for _, event := range installed {
+		got, ok := since[event]
+		if !ok {
+			t.Errorf("no Since entry for installed event %q — every event written into the "+
+				"user's config needs a stated version it is known to exist at, or the floor "+
+				"cannot be shown to cover it", event)
+			continue
+		}
+		if _, parsed := cliversion.Parse(got); !parsed {
+			t.Errorf("Since[%q] = %q is not a major.minor.patch triple", event, got)
+			continue
+		}
+		if ok, known := cliversion.AtLeast(min, got); known && !ok {
+			t.Errorf("declared floor %s is below %s, the version %q is known at — at a CLI "+
+				"between the two the install writes an entry naming an event that CLI does "+
+				"not have; raise the floor to at least %s", min, got, event, got)
+		}
+	}
+	for event := range since {
+		if !slices.Contains(installed, event) {
+			t.Errorf("Since names %q, which is not installed — a stale provenance entry "+
+				"makes the floor look better justified than it is", event)
+		}
+	}
+}
+
+// assertFloorRefusesOlder proves the declaration actually blocks, rather than
+// merely being present. It walks one patch level below the floor, which is the
+// boundary an off-by-one in a comparison shows up at.
+func assertFloorRefusesOlder(t *testing.T, gate *agent.VersionGate) {
+	t.Helper()
+	floor, ok := cliversion.Parse(gate.Min)
+	if !ok {
+		return // already reported by assertFloorParses
+	}
+	if allowed, _ := gate.Permits(gate.Min); !allowed {
+		t.Errorf("gate refuses its own floor %s — the comparison is exclusive where it "+
+			"should be inclusive", gate.Min)
+	}
+	older := justBelow(floor)
+	if older == floor {
+		return // a 0.0.0 floor has no predecessor to refuse
+	}
+	allowed, why := gate.Permits(older.String())
+	if allowed {
+		t.Errorf("gate permits %s, below the declared floor %s", older, gate.Min)
+		return
+	}
+	// The refusal is the only thing the user ever sees about it (via the
+	// daemon log today, #1362's wizard surfacing once PR #1379 lands), so an
+	// empty or version-free reason is a silent skip wearing an error's clothes
+	// — the exact behaviour #1365 filed against Codex.
+	if why == "" {
+		t.Error("gate refuses without a reason; the refusal is what the user is shown")
+	}
+	if !strings.Contains(why, older.String()) || !strings.Contains(why, gate.Min) {
+		t.Errorf("refusal %q names neither the installed version %s nor the required %s; "+
+			"a user cannot act on it", why, older, gate.Min)
+	}
+}
+
+// assertUnknownFailsOpen pins the direction chosen in cliversion.AtLeast. It is
+// a LOCK, not a defect test: it passes by construction and exists so that
+// flipping the default to fail-closed — which would silently disable hooks for
+// every user whose binary the daemon's PATH cannot reach — cannot happen
+// quietly.
+func assertUnknownFailsOpen(t *testing.T, gate *agent.VersionGate) {
+	t.Helper()
+	for _, unknown := range []string{"", "not a version", "2.1"} {
+		if allowed, why := gate.Permits(unknown); !allowed {
+			t.Errorf("gate refuses on unreadable version %q (%s) — an unknown version is "+
+				"not an old one, and failing closed here disables hooks for anyone whose "+
+				"CLI the daemon cannot probe", unknown, why)
+		}
+	}
+}
+
+// justBelow returns the version one patch level below v, borrowing across
+// minor and major so a floor of x.y.0 still has a representable predecessor.
+func justBelow(v cliversion.Version) cliversion.Version {
+	switch {
+	case v.Patch > 0:
+		return cliversion.Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch - 1}
+	case v.Minor > 0:
+		return cliversion.Version{Major: v.Major, Minor: v.Minor - 1, Patch: 99}
+	case v.Major > 0:
+		return cliversion.Version{Major: v.Major - 1, Minor: 99, Patch: 99}
+	default:
+		return v // 0.0.0 has no predecessor; assertFloorRefusesOlder tolerates it
+	}
+}

--- a/core/pkg/cliprobe/cliprobe.go
+++ b/core/pkg/cliprobe/cliprobe.go
@@ -77,18 +77,18 @@ func Probe(ctx context.Context, argv []string) (string, error) {
 
 	runErr := cmd.Run()
 
-	version, ok := cliversion.Parse(out.String())
-	if !ok {
-		if runErr != nil {
-			return "", fmt.Errorf("cliprobe: probing %q: %w", strings.Join(argv, " "), runErr)
-		}
-		return "", fmt.Errorf("cliprobe: %q printed no recognizable version", strings.Join(argv, " "))
-	}
-	// A CLI that printed a usable version and then failed has still answered
-	// the only question asked, but a non-zero exit is the stronger signal that
-	// something is wrong with the install — prefer it.
+	// A run that did not complete cleanly is not trusted for its output, even
+	// when that output parses: a version-shaped fragment in an error message
+	// ("config schema 1.0.0 unsupported") would otherwise be read as the CLI's
+	// version and could produce a FALSE REFUSAL — the one direction this gate
+	// must never take quietly. Reporting unknown instead fails open, which is
+	// recoverable.
 	if runErr != nil {
 		return "", fmt.Errorf("cliprobe: probing %q: %w", strings.Join(argv, " "), runErr)
+	}
+	version, ok := cliversion.Parse(out.String())
+	if !ok {
+		return "", fmt.Errorf("cliprobe: %q printed no recognizable version", strings.Join(argv, " "))
 	}
 	return version.String(), nil
 }

--- a/core/pkg/cliprobe/cliprobe.go
+++ b/core/pkg/cliprobe/cliprobe.go
@@ -1,0 +1,116 @@
+// Package cliprobe asks an installed agent CLI what version it is, by running
+// it (issue #1365).
+//
+// It is split from core/pkg/cliversion — which only parses and compares — so
+// that core/domain/agent can import the comparison without dragging os/exec
+// into the domain's dependency graph. Deciding whether a version is new enough
+// is domain logic; going and finding out what version is installed is not.
+package cliprobe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"irrlicht/core/pkg/cliversion"
+	"irrlicht/core/pkg/pathutil"
+)
+
+// Timeout bounds how long a version probe may take. A version check runs on
+// the consent path — the user has just clicked "grant" and is watching — so a
+// CLI that hangs must lose quickly rather than wedge the grant.
+const Timeout = 2 * time.Second
+
+// waitDelay bounds the extra time Probe waits for the child's output pipes to
+// close after its context expires. Killing the process is not enough on its
+// own: exec waits for stdout to reach EOF, and a grandchild that inherited the
+// pipe holds it open after its parent dies, so a plain CommandContext kill can
+// still block indefinitely. This is the difference between "fails fast" as an
+// intention and as a guarantee.
+const waitDelay = 500 * time.Millisecond
+
+// maxOutput caps how much of the child's stdout is read. Timeout bounds how
+// long a misbehaving CLI gets, not how much it can write in that time — a
+// process streaming to a pipe moves gigabytes in two seconds, and this runs
+// inside a long-lived daemon. A version banner is a few hundred bytes.
+const maxOutput = 64 << 10
+
+// Probe runs argv and returns the first version triple it prints on stdout.
+//
+// Every way an external binary can fail to answer — missing, hung, flooding,
+// unintelligible, non-zero exit — collapses to an error, which callers turn
+// into "unknown", which cliversion.AtLeast fails open on.
+//
+//   - Missing binary: the lookup fails before anything is spawned, so this
+//     returns immediately rather than after Timeout.
+//   - Hung binary: bounded by Timeout, and by waitDelay against a grandchild
+//     holding the output pipe open past the kill.
+//   - Flooding binary: bounded by maxOutput.
+//   - Unintelligible output: reported as an error here, unknown by Parse.
+//
+// argv[0] is resolved through pathutil rather than the inherited PATH, so a
+// directory an unprivileged local attacker prepended to PATH cannot decide
+// which binary the daemon executes (SonarQube go:S4036); pathutil falls back
+// to a plain PATH lookup when the trusted directories don't have it, which is
+// the common case for an agent CLI installed under the user's home. argv
+// itself is a compile-time literal in an adapter's declaration and is passed
+// as separate arguments with no shell in between.
+func Probe(ctx context.Context, argv []string) (string, error) {
+	if len(argv) == 0 {
+		return "", errors.New("cliprobe: no probe command declared")
+	}
+	ctx, cancel := context.WithTimeout(ctx, Timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, pathutil.MustResolve(argv[0]), argv[1:]...)
+	cmd.WaitDelay = waitDelay
+	// A version probe must never block on a prompt or inherit the daemon's
+	// stdin, and stderr is discarded so a chatty CLI cannot buffer through it.
+	cmd.Stdin = nil
+
+	var out cappedWriter
+	out.limit = maxOutput
+	cmd.Stdout = &out
+
+	runErr := cmd.Run()
+
+	version, ok := cliversion.Parse(out.String())
+	if !ok {
+		if runErr != nil {
+			return "", fmt.Errorf("cliprobe: probing %q: %w", strings.Join(argv, " "), runErr)
+		}
+		return "", fmt.Errorf("cliprobe: %q printed no recognizable version", strings.Join(argv, " "))
+	}
+	// A CLI that printed a usable version and then failed has still answered
+	// the only question asked, but a non-zero exit is the stronger signal that
+	// something is wrong with the install — prefer it.
+	if runErr != nil {
+		return "", fmt.Errorf("cliprobe: probing %q: %w", strings.Join(argv, " "), runErr)
+	}
+	return version.String(), nil
+}
+
+// cappedWriter keeps at most limit bytes and silently discards the rest. It
+// never returns an error: exec's output-copying goroutine treats a write error
+// as fatal to the command, and a CLI whose banner happens to be followed by
+// noise has still told us its version. Bounding memory is the whole job here —
+// the process itself is bounded by Timeout.
+type cappedWriter struct {
+	limit int
+	buf   []byte
+}
+
+func (w *cappedWriter) Write(p []byte) (int, error) {
+	if room := w.limit - len(w.buf); room > 0 {
+		if len(p) < room {
+			room = len(p)
+		}
+		w.buf = append(w.buf, p[:room]...)
+	}
+	return len(p), nil
+}
+
+func (w *cappedWriter) String() string { return string(w.buf) }

--- a/core/pkg/cliprobe/cliprobe_test.go
+++ b/core/pkg/cliprobe/cliprobe_test.go
@@ -1,0 +1,152 @@
+package cliprobe
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestProbe_ReadsVersionFromStdout(t *testing.T) {
+	got, err := Probe(context.Background(), []string{"sh", "-c", `echo "2.1.226 (Claude Code)"`})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if got != "2.1.226" {
+		t.Errorf("Probe = %q, want %q", got, "2.1.226")
+	}
+}
+
+// TestProbe_MissingBinaryFailsImmediately pins the most common real-world
+// case, not an exotic one: the daemon runs under launchd with a minimal PATH,
+// so an agent CLI installed in ~/.local/bin is simply not findable. That must
+// cost nothing and must not wait out Timeout.
+func TestProbe_MissingBinaryFailsImmediately(t *testing.T) {
+	start := time.Now()
+	_, err := Probe(context.Background(), []string{"irrlicht-no-such-binary-1365"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Probe of a nonexistent binary returned no error")
+	}
+	if elapsed > Timeout/2 {
+		t.Errorf("Probe took %v for a missing binary; PATH lookup should fail before "+
+			"anything is spawned, well inside the %v budget", elapsed, Timeout)
+	}
+}
+
+func TestProbe_HungBinaryIsBounded(t *testing.T) {
+	start := time.Now()
+	_, err := Probe(context.Background(), []string{"sh", "-c", "sleep 30"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Probe of a hung binary returned no error")
+	}
+	if elapsed > 3*Timeout {
+		t.Errorf("Probe took %v to give up on a hung binary; the consent path cannot "+
+			"wait that long", elapsed)
+	}
+}
+
+// TestProbe_OrphanHoldingStdoutIsBounded is the failure mode Timeout alone
+// does not cover: the CLI exits promptly but leaves a background child holding
+// the stdout pipe, so exec waits for EOF that never comes. Without
+// cmd.WaitDelay this test hangs for 30s rather than failing.
+func TestProbe_OrphanHoldingStdoutIsBounded(t *testing.T) {
+	start := time.Now()
+	_, err := Probe(context.Background(), []string{"sh", "-c", "sleep 30 & echo no-version-here"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Probe returned no error for output carrying no version")
+	}
+	if elapsed > 3*Timeout {
+		t.Errorf("Probe took %v when a grandchild held stdout open; WaitDelay is supposed "+
+			"to bound exactly this", elapsed)
+	}
+}
+
+func TestProbe_UnparseableOutputIsAnError(t *testing.T) {
+	if _, err := Probe(context.Background(), []string{"sh", "-c", "echo hello there"}); err == nil {
+		t.Error("Probe accepted output containing no version")
+	}
+}
+
+func TestProbe_NonZeroExitIsAnError(t *testing.T) {
+	if _, err := Probe(context.Background(), []string{"sh", "-c", "echo 1.2.3; exit 3"}); err == nil {
+		t.Error("Probe ignored a non-zero exit status; a CLI that failed is not a CLI " +
+			"whose version we read")
+	}
+}
+
+func TestProbe_EmptyArgv(t *testing.T) {
+	if _, err := Probe(context.Background(), nil); err == nil {
+		t.Error("Probe accepted an empty command")
+	}
+}
+
+// TestProbe_FloodingBinaryIsBounded pins the volume ceiling. Timeout bounds how
+// long a misbehaving CLI runs, not how much it writes in that time — a process
+// streaming to a pipe moves gigabytes in two seconds, and this runs inside a
+// long-lived daemon. Without maxOutput the read below accumulates all of it.
+func TestProbe_FloodingBinaryIsBounded(t *testing.T) {
+	start := time.Now()
+	_, err := Probe(context.Background(), []string{"sh", "-c", "yes flooding-with-no-version"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Probe accepted an endless stream carrying no version")
+	}
+	if elapsed > 3*Timeout {
+		t.Errorf("Probe took %v against a flooding binary", elapsed)
+	}
+}
+
+// TestProbe_CapTruncatesRatherThanBlinds pins that maxOutput drops the tail
+// rather than the answer: a CLI that prints its version and then far more than
+// the cap, but exits cleanly, is still read correctly.
+func TestProbe_CapTruncatesRatherThanBlinds(t *testing.T) {
+	got, err := Probe(context.Background(), []string{"sh", "-c", "echo 1.2.3; head -c 200000 /dev/zero"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if got != "1.2.3" {
+		t.Errorf("Probe = %q, want 1.2.3", got)
+	}
+}
+
+// TestProbe_ResolvesThroughTrustedDirs pins that argv[0] is not resolved from
+// the inherited PATH: a hostile "sh" earlier on PATH must not be what runs.
+func TestProbe_ResolvesThroughTrustedDirs(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "sh"), []byte("#!/bin/sh\necho 9.9.9\n"), 0o755); err != nil {
+		t.Fatalf("write decoy: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	got, err := Probe(context.Background(), []string{"sh", "-c", "echo 1.2.3"})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if got == "9.9.9" {
+		t.Error("Probe ran the decoy sh from a PATH-prepended writable directory; " +
+			"argv[0] must resolve through pathutil's trusted dirs (go:S4036)")
+	}
+	if got != "1.2.3" {
+		t.Errorf("Probe = %q, want 1.2.3", got)
+	}
+}
+
+// TestProbe_VersionFromAnUncleanRunIsNotTrusted pins the direction chosen when
+// a CLI prints something version-shaped and then fails. The output is NOT
+// trusted: a version-shaped fragment in an error message ("config schema 1.0.0
+// unsupported") would otherwise be read as the CLI's version and could produce
+// a FALSE REFUSAL — the one direction #1365's design says must never happen
+// quietly. Reporting unknown instead fails open, which is recoverable.
+func TestProbe_VersionFromAnUncleanRunIsNotTrusted(t *testing.T) {
+	if _, err := Probe(context.Background(), []string{"sh", "-c", "echo 1.0.0; exit 3"}); err == nil {
+		t.Error("Probe trusted a version printed by a run that then failed")
+	}
+}

--- a/core/pkg/cliversion/cliversion.go
+++ b/core/pkg/cliversion/cliversion.go
@@ -1,6 +1,7 @@
-// Package cliversion parses, compares and probes upstream agent-CLI version
-// strings — the shared half of issue #1365's declared minimum version per
-// hook-capable adapter.
+// Package cliversion parses and compares upstream agent-CLI version strings —
+// the shared half of issue #1365's declared minimum version per hook-capable
+// adapter. It is deliberately free of process execution so the domain can
+// import it; running a CLI to ask its version lives in core/pkg/cliprobe.
 //
 // It exists because the alternative is the thing #1365 is about: Codex grew a
 // bespoke parseCodexVersion/codexSupportsHooks pair inside its own adapter,
@@ -16,28 +17,10 @@
 package cliversion
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"strconv"
-	"strings"
-	"time"
 )
-
-// ProbeTimeout bounds how long a version probe may take. A version check runs
-// on the consent path — the user has just clicked "grant" and is watching —
-// so a CLI that hangs must lose quickly rather than wedge the grant.
-const ProbeTimeout = 2 * time.Second
-
-// probeWaitDelay bounds the extra time Probe waits for the child's output
-// pipes to close after its context expires. Killing the process is not enough
-// on its own: exec waits for stdout to reach EOF, and a grandchild that
-// inherited the pipe holds it open after its parent dies, so a plain
-// CommandContext kill can still block indefinitely. This is the difference
-// between "fails fast" as an intention and as a guarantee.
-const probeWaitDelay = 500 * time.Millisecond
 
 // versionTriple matches a bare major.minor.patch run of digits anywhere in a
 // version banner. Requiring all three fields is deliberate: every agent CLI in
@@ -122,43 +105,4 @@ func AtLeast(installed, minimum string) (ok, known bool) {
 		return true, false
 	}
 	return got.Compare(floor) >= 0, true
-}
-
-// Probe runs argv and returns the first version triple it prints on stdout.
-//
-// All three failure modes an external binary can present — missing, hung,
-// unintelligible — collapse to the same result: an error, which callers turn
-// into "unknown", which AtLeast fails open on.
-//
-//   - Missing binary: exec's PATH lookup fails before anything is spawned, so
-//     this returns immediately rather than after the timeout.
-//   - Hung binary: bounded by ProbeTimeout, and by probeWaitDelay against a
-//     grandchild holding the output pipe open past the kill.
-//   - Unintelligible output: reported as an error here and as unknown by Parse.
-//
-// argv comes from an adapter's compile-time declaration, never from a session,
-// a config file, or anything else an attacker could reach; it is passed to
-// exec as separate arguments with no shell in between.
-func Probe(ctx context.Context, argv []string) (string, error) {
-	if len(argv) == 0 {
-		return "", errors.New("cliversion: no probe command declared")
-	}
-	ctx, cancel := context.WithTimeout(ctx, ProbeTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
-	cmd.WaitDelay = probeWaitDelay
-	// A version probe must never block on a prompt, and must never inherit the
-	// daemon's stdin.
-	cmd.Stdin = nil
-
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("cliversion: probing %q: %w", strings.Join(argv, " "), err)
-	}
-	version, ok := Parse(string(out))
-	if !ok {
-		return "", fmt.Errorf("cliversion: %q printed no recognizable version", strings.Join(argv, " "))
-	}
-	return version.String(), nil
 }

--- a/core/pkg/cliversion/cliversion.go
+++ b/core/pkg/cliversion/cliversion.go
@@ -1,0 +1,164 @@
+// Package cliversion parses, compares and probes upstream agent-CLI version
+// strings — the shared half of issue #1365's declared minimum version per
+// hook-capable adapter.
+//
+// It exists because the alternative is the thing #1365 is about: Codex grew a
+// bespoke parseCodexVersion/codexSupportsHooks pair inside its own adapter,
+// Claude Code grew nothing at all, and a third adapter would have copied one or
+// the other. The comparison is the same arithmetic for every CLI; only the
+// version *string* differs, so only the version string is declared.
+//
+// Every agent CLI decorates its version differently and none of them are
+// promising not to change it — "2.1.226 (Claude Code)", "codex-cli 0.146.1",
+// "rust-v0.114.0", "1.29.8". Parse therefore looks for the first bare
+// major.minor.patch triple anywhere in the string rather than trying to model
+// each CLI's banner.
+package cliversion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ProbeTimeout bounds how long a version probe may take. A version check runs
+// on the consent path — the user has just clicked "grant" and is watching —
+// so a CLI that hangs must lose quickly rather than wedge the grant.
+const ProbeTimeout = 2 * time.Second
+
+// probeWaitDelay bounds the extra time Probe waits for the child's output
+// pipes to close after its context expires. Killing the process is not enough
+// on its own: exec waits for stdout to reach EOF, and a grandchild that
+// inherited the pipe holds it open after its parent dies, so a plain
+// CommandContext kill can still block indefinitely. This is the difference
+// between "fails fast" as an intention and as a guarantee.
+const probeWaitDelay = 500 * time.Millisecond
+
+// versionTriple matches a bare major.minor.patch run of digits anywhere in a
+// version banner. Requiring all three fields is deliberate: every agent CLI in
+// play ships three (2.1.226, 0.146.1, 1.0.26, 1.29.8), and treating a
+// two-field string as a version would invent a patch level nobody stated.
+// Unparseable input is not an error condition here — it resolves to "unknown",
+// which fails open (see AtLeast).
+var versionTriple = regexp.MustCompile(`(\d+)\.(\d+)\.(\d+)`)
+
+// Version is a parsed semantic-ish version. Pre-release and build suffixes are
+// discarded: no agent CLI gates a hook event on an -rc tag, and comparing them
+// would mean picking a precedence rule none of these CLIs document.
+type Version struct {
+	Major, Minor, Patch int
+}
+
+// Parse extracts the first major.minor.patch triple from s. ok is false when s
+// contains no such triple, which callers must treat as "unknown version", not
+// as "version zero".
+func Parse(s string) (Version, bool) {
+	m := versionTriple.FindStringSubmatch(s)
+	if m == nil {
+		return Version{}, false
+	}
+	// Each group is \d+ and so parses, but a version long enough to overflow
+	// an int is not a version — fall back to unknown rather than to a
+	// wrapped-around number that would compare wrong.
+	major, err1 := strconv.Atoi(m[1])
+	minor, err2 := strconv.Atoi(m[2])
+	patch, err3 := strconv.Atoi(m[3])
+	if err1 != nil || err2 != nil || err3 != nil {
+		return Version{}, false
+	}
+	return Version{Major: major, Minor: minor, Patch: patch}, true
+}
+
+// String renders the version in bare major.minor.patch form.
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// Compare returns -1, 0 or +1 as v sorts before, equal to, or after o.
+func (v Version) Compare(o Version) int {
+	switch {
+	case v.Major != o.Major:
+		return sign(v.Major - o.Major)
+	case v.Minor != o.Minor:
+		return sign(v.Minor - o.Minor)
+	default:
+		return sign(v.Patch - o.Patch)
+	}
+}
+
+func sign(n int) int {
+	switch {
+	case n < 0:
+		return -1
+	case n > 0:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// AtLeast reports whether installed is at or above minimum.
+//
+// known is false when either string is missing or unparseable, and in that
+// case ok is reported as true — unknown fails OPEN. That direction is chosen,
+// not inherited: the harm this gate prevents is writing config into a CLI too
+// old to understand it, and "I could not read a version" is not evidence that
+// the CLI is old. Failing closed on unknown would silently disable hooks for
+// every user whose binary is installed somewhere the daemon's PATH does not
+// reach — the daemon runs under launchd with a minimal PATH, while `claude`
+// commonly lives in ~/.local/bin — which is the same "granted, but the channel
+// never fires" outcome the gate exists to abolish, just arrived at from the
+// other side. Only a version we successfully read AND successfully parsed AND
+// found to be below the floor is allowed to block an install.
+func AtLeast(installed, minimum string) (ok, known bool) {
+	got, gotOK := Parse(installed)
+	floor, floorOK := Parse(minimum)
+	if !gotOK || !floorOK {
+		return true, false
+	}
+	return got.Compare(floor) >= 0, true
+}
+
+// Probe runs argv and returns the first version triple it prints on stdout.
+//
+// All three failure modes an external binary can present — missing, hung,
+// unintelligible — collapse to the same result: an error, which callers turn
+// into "unknown", which AtLeast fails open on.
+//
+//   - Missing binary: exec's PATH lookup fails before anything is spawned, so
+//     this returns immediately rather than after the timeout.
+//   - Hung binary: bounded by ProbeTimeout, and by probeWaitDelay against a
+//     grandchild holding the output pipe open past the kill.
+//   - Unintelligible output: reported as an error here and as unknown by Parse.
+//
+// argv comes from an adapter's compile-time declaration, never from a session,
+// a config file, or anything else an attacker could reach; it is passed to
+// exec as separate arguments with no shell in between.
+func Probe(ctx context.Context, argv []string) (string, error) {
+	if len(argv) == 0 {
+		return "", errors.New("cliversion: no probe command declared")
+	}
+	ctx, cancel := context.WithTimeout(ctx, ProbeTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.WaitDelay = probeWaitDelay
+	// A version probe must never block on a prompt, and must never inherit the
+	// daemon's stdin.
+	cmd.Stdin = nil
+
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("cliversion: probing %q: %w", strings.Join(argv, " "), err)
+	}
+	version, ok := Parse(string(out))
+	if !ok {
+		return "", fmt.Errorf("cliversion: %q printed no recognizable version", strings.Join(argv, " "))
+	}
+	return version.String(), nil
+}

--- a/core/pkg/cliversion/cliversion_test.go
+++ b/core/pkg/cliversion/cliversion_test.go
@@ -1,0 +1,177 @@
+package cliversion
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		// The four CLIs in play, exactly as they print today.
+		{"2.1.226 (Claude Code)", "2.1.226", true}, // claude --version
+		{"codex-cli 0.146.1", "0.146.1", true},     // codex --version
+		{"1.0.26", "1.0.26", true},                 // copilot (#1355 Phase C)
+		{"1.29.8", "1.29.8", true},                 // kiro-cli (#1355 Phase C)
+		// Codex's transcript cli_version field and its release-tag spellings —
+		// these came from the deleted parseCodexVersion's own table, so the
+		// shared parser is held to everything the bespoke one handled.
+		{"0.114.0", "0.114.0", true},
+		{"rust-v0.114.0", "0.114.0", true},
+		{"v0.113.0", "0.113.0", true},
+		{"0.114.0-rc1", "0.114.0", true}, // pre-release suffix discarded
+		{"0.114.0+build7", "0.114.0", true},
+		// Unknown — every one of these must be reported as unparseable rather
+		// than coerced to a number, because a wrong number compares.
+		{"", "", false},
+		{"garbage", "", false},
+		{"0.114", "", false}, // two fields is not a version we will invent a patch for
+		{"v", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := Parse(tc.in)
+		if ok != tc.ok {
+			t.Errorf("Parse(%q): ok=%v, want %v", tc.in, ok, tc.ok)
+			continue
+		}
+		if ok && got.String() != tc.want {
+			t.Errorf("Parse(%q) = %s, want %s", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCompare(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"1.0.1", "1.0.0", 1},
+		{"1.0.0", "1.0.1", -1},
+		{"1.1.0", "1.0.9", 1},
+		{"2.0.0", "1.99.99", 1},
+		{"0.113.9", "0.114.0", -1},
+		// Field-wise, not lexicographic: "2.1.99" must not outrank "2.1.226".
+		{"2.1.226", "2.1.99", 1},
+	}
+	for _, tc := range cases {
+		a, _ := Parse(tc.a)
+		b, _ := Parse(tc.b)
+		if got := a.Compare(b); got != tc.want {
+			t.Errorf("Parse(%q).Compare(%q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestAtLeast(t *testing.T) {
+	cases := []struct {
+		installed, minimum string
+		wantOK, wantKnown  bool
+	}{
+		{"0.114.0", "0.114.0", true, true},  // exactly the floor is allowed
+		{"0.114.1", "0.114.0", true, true},  // above by patch
+		{"0.115.0", "0.114.0", true, true},  // above by minor
+		{"1.0.0", "0.114.0", true, true},    // above by major
+		{"0.113.9", "0.114.0", false, true}, // below by minor — the only refusing shape
+		{"0.100.0", "0.114.0", false, true},
+		{"2.1.121", "2.1.122", false, true},
+		{"2.1.226", "2.1.122", true, true},
+		// Unknown fails OPEN, in both directions. Each of these would silently
+		// disable hooks for a real user if it flipped to closed.
+		{"", "0.114.0", true, false},
+		{"garbage", "0.114.0", true, false},
+		{"0.114", "0.114.0", true, false},
+		{"0.114.0", "", true, false},
+		{"0.114.0", "not a version", true, false},
+	}
+	for _, tc := range cases {
+		ok, known := AtLeast(tc.installed, tc.minimum)
+		if ok != tc.wantOK || known != tc.wantKnown {
+			t.Errorf("AtLeast(%q, %q) = (ok=%v, known=%v), want (ok=%v, known=%v)",
+				tc.installed, tc.minimum, ok, known, tc.wantOK, tc.wantKnown)
+		}
+	}
+}
+
+func TestProbe_ReadsVersionFromStdout(t *testing.T) {
+	got, err := Probe(context.Background(), []string{"sh", "-c", `echo "2.1.226 (Claude Code)"`})
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if got != "2.1.226" {
+		t.Errorf("Probe = %q, want %q", got, "2.1.226")
+	}
+}
+
+// TestProbe_MissingBinaryFailsImmediately pins the most common real-world
+// case, not an exotic one: the daemon runs under launchd with a minimal PATH,
+// so an agent CLI installed in ~/.local/bin is simply not findable. That must
+// cost nothing and must not wait out ProbeTimeout.
+func TestProbe_MissingBinaryFailsImmediately(t *testing.T) {
+	start := time.Now()
+	_, err := Probe(context.Background(), []string{"irrlicht-no-such-binary-1365"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Probe of a nonexistent binary returned no error")
+	}
+	if elapsed > ProbeTimeout/2 {
+		t.Errorf("Probe took %v for a missing binary; PATH lookup should fail before "+
+			"anything is spawned, well inside the %v budget", elapsed, ProbeTimeout)
+	}
+}
+
+func TestProbe_HungBinaryIsBounded(t *testing.T) {
+	start := time.Now()
+	_, err := Probe(context.Background(), []string{"sh", "-c", "sleep 30"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Probe of a hung binary returned no error")
+	}
+	if elapsed > 3*ProbeTimeout {
+		t.Errorf("Probe took %v to give up on a hung binary; the consent path cannot "+
+			"wait that long", elapsed)
+	}
+}
+
+// TestProbe_OrphanHoldingStdoutIsBounded is the failure mode ProbeTimeout alone
+// does not cover: the CLI exits promptly but leaves a background child holding
+// the stdout pipe, so exec waits for EOF that never comes. Without
+// cmd.WaitDelay this test hangs for 30s rather than failing.
+func TestProbe_OrphanHoldingStdoutIsBounded(t *testing.T) {
+	start := time.Now()
+	_, err := Probe(context.Background(), []string{"sh", "-c", "sleep 30 & echo no-version-here"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Probe returned no error for output carrying no version")
+	}
+	if elapsed > 3*ProbeTimeout {
+		t.Errorf("Probe took %v when a grandchild held stdout open; WaitDelay is supposed "+
+			"to bound exactly this", elapsed)
+	}
+}
+
+func TestProbe_UnparseableOutputIsAnError(t *testing.T) {
+	if _, err := Probe(context.Background(), []string{"sh", "-c", "echo hello there"}); err == nil {
+		t.Error("Probe accepted output containing no version")
+	}
+}
+
+func TestProbe_NonZeroExitIsAnError(t *testing.T) {
+	if _, err := Probe(context.Background(), []string{"sh", "-c", "echo 1.2.3; exit 3"}); err == nil {
+		t.Error("Probe ignored a non-zero exit status; a CLI that failed is not a CLI " +
+			"whose version we read")
+	}
+}
+
+func TestProbe_EmptyArgv(t *testing.T) {
+	if _, err := Probe(context.Background(), nil); err == nil {
+		t.Error("Probe accepted an empty command")
+	}
+}

--- a/core/pkg/cliversion/cliversion_test.go
+++ b/core/pkg/cliversion/cliversion_test.go
@@ -1,10 +1,6 @@
 package cliversion
 
-import (
-	"context"
-	"testing"
-	"time"
-)
+import "testing"
 
 func TestParse(t *testing.T) {
 	cases := []struct {
@@ -94,84 +90,5 @@ func TestAtLeast(t *testing.T) {
 			t.Errorf("AtLeast(%q, %q) = (ok=%v, known=%v), want (ok=%v, known=%v)",
 				tc.installed, tc.minimum, ok, known, tc.wantOK, tc.wantKnown)
 		}
-	}
-}
-
-func TestProbe_ReadsVersionFromStdout(t *testing.T) {
-	got, err := Probe(context.Background(), []string{"sh", "-c", `echo "2.1.226 (Claude Code)"`})
-	if err != nil {
-		t.Fatalf("Probe: %v", err)
-	}
-	if got != "2.1.226" {
-		t.Errorf("Probe = %q, want %q", got, "2.1.226")
-	}
-}
-
-// TestProbe_MissingBinaryFailsImmediately pins the most common real-world
-// case, not an exotic one: the daemon runs under launchd with a minimal PATH,
-// so an agent CLI installed in ~/.local/bin is simply not findable. That must
-// cost nothing and must not wait out ProbeTimeout.
-func TestProbe_MissingBinaryFailsImmediately(t *testing.T) {
-	start := time.Now()
-	_, err := Probe(context.Background(), []string{"irrlicht-no-such-binary-1365"})
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("Probe of a nonexistent binary returned no error")
-	}
-	if elapsed > ProbeTimeout/2 {
-		t.Errorf("Probe took %v for a missing binary; PATH lookup should fail before "+
-			"anything is spawned, well inside the %v budget", elapsed, ProbeTimeout)
-	}
-}
-
-func TestProbe_HungBinaryIsBounded(t *testing.T) {
-	start := time.Now()
-	_, err := Probe(context.Background(), []string{"sh", "-c", "sleep 30"})
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("Probe of a hung binary returned no error")
-	}
-	if elapsed > 3*ProbeTimeout {
-		t.Errorf("Probe took %v to give up on a hung binary; the consent path cannot "+
-			"wait that long", elapsed)
-	}
-}
-
-// TestProbe_OrphanHoldingStdoutIsBounded is the failure mode ProbeTimeout alone
-// does not cover: the CLI exits promptly but leaves a background child holding
-// the stdout pipe, so exec waits for EOF that never comes. Without
-// cmd.WaitDelay this test hangs for 30s rather than failing.
-func TestProbe_OrphanHoldingStdoutIsBounded(t *testing.T) {
-	start := time.Now()
-	_, err := Probe(context.Background(), []string{"sh", "-c", "sleep 30 & echo no-version-here"})
-	elapsed := time.Since(start)
-
-	if err == nil {
-		t.Fatal("Probe returned no error for output carrying no version")
-	}
-	if elapsed > 3*ProbeTimeout {
-		t.Errorf("Probe took %v when a grandchild held stdout open; WaitDelay is supposed "+
-			"to bound exactly this", elapsed)
-	}
-}
-
-func TestProbe_UnparseableOutputIsAnError(t *testing.T) {
-	if _, err := Probe(context.Background(), []string{"sh", "-c", "echo hello there"}); err == nil {
-		t.Error("Probe accepted output containing no version")
-	}
-}
-
-func TestProbe_NonZeroExitIsAnError(t *testing.T) {
-	if _, err := Probe(context.Background(), []string{"sh", "-c", "echo 1.2.3; exit 3"}); err == nil {
-		t.Error("Probe ignored a non-zero exit status; a CLI that failed is not a CLI " +
-			"whose version we read")
-	}
-}
-
-func TestProbe_EmptyArgv(t *testing.T) {
-	if _, err := Probe(context.Background(), nil); err == nil {
-		t.Error("Probe accepted an empty command")
 	}
 }


### PR DESCRIPTION
Closes #1365. Parent: #1355 Phase B, work item 3. Builds on #1356 (merged, `47fe60fe`).

## Premise check (scope note 1) — both confirmed against the code

**codex gates.** `core/adapters/inbound/agents/codex/hookinstaller.go` (pre-change):

```go
func applyCodexHooks() error {
	if v := newestObservedCLIVersion(); v != "" && !codexSupportsHooks(v) {
		return nil
	}
	_, err := EnsureHooksInstalled()
	return err
}
```

**claudecode does not.** `core/adapters/inbound/agents/claudecode/agent.go` (pre-change):

```go
Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
Remove: func() error { _, err := UninstallHooks(); return err },
```

No version check anywhere in the adapter — confirmed by reading `hookinstaller.go` in full.

Two corrections to how the issue frames it, both material:

1. Codex's gate is not a *probe* — `newestObservedCLIVersion` reads `cli_version` out of the newest session transcript. There is **no** `exec`-a-CLI version probe anywhere in `core/` today; that part is greenfield.
2. Codex's skip is **silent** (`return nil`). So "the user sees granted with a channel that never fires" was already true for codex too, by a different route — not only for the ungated adapter.

## Design

The floor is **data on the declaration**, enforced **once** in the shared layer.

```go
// core/domain/agent/declaration.go
type VersionGate struct {
	Min      string        // "2.1.122"
	Probe    []string      // {"claude", "--version"}
	Observed func() string // optional: a free, passive source
}
```

`PermissionService.runClosureEffect` resolves the version and calls `VersionGate.Permits` before running `Apply`.

### Two version sources, and why both

`Observed` is a passive read of a version already on disk; `Probe` runs the binary. Resolution uses `Observed` first and consults `Probe` only when the passive answer is **unparseable** or says **"too old"**.

That is not an optimization, it is what makes the gate real. **A probe-only gate would be decorative in the shipped deployment**: the daemon is launched by `Irrlicht.app` and inherits a LaunchServices PATH of `/usr/bin:/bin:/usr/sbin:/sbin`, while the official installer puts `claude` in `~/.local/bin`. The probe would always miss, the version would always read unknown, unknown fails open — every install takes the fail-open branch and no version is ever checked. So claudecode reads the version stamp Claude Code writes on every transcript line (the field `parser.go` already extracts), and codex reads `cli_version` from its session header.

Conversely a passive-only gate would produce **false refusals**: the transcript records the LAST-RUN version, so it can only be stale downward, and a user who upgrades and grants before starting a new session would be refused on a version they no longer run. Hence the probe is consulted before acting on any "too old" reading. A false refusal is the one direction this gate must never take quietly. Codex's `applyCodexHooks`, `codexSupportsHooks`, `parseCodexVersion` and `minHookMajor/Minor/Patch` are **deleted** — that bespoke pair is exactly what scope item 4 says adapter #3 must not copy.

**Adapter #3 writes this and nothing else** (scope item 4):

```go
Hooks: &agent.HookInstall{
	ConfigPath: copilotConfigPath,
	Uninstall:  UninstallHooks,
	Version: &agent.VersionGate{
		Min:   "1.0.26",                          // #1355 Phase C
		Probe: []string{"copilot", "--version"},
		// Optional: a passive source, if the adapter already reads a version
		// off disk. Both current adapters set one — see "Two version sources".
		// Observed: newestObservedCLIVersion,
	},
},
```

No function, no parser, no constants. `TestEveryHookInstallDeclaresAVersionFloor` walks the `#1357` registry projection, so an adapter that forgets fails **before** it has a test of its own.

## Floors, with evidence

| Adapter | Floor | Why |
|---|---|---|
| codex | `0.114.0` | unchanged; hooks introduced in `rust-v0.114.0` (#1171) |
| claudecode | `2.1.122` | see below |

Claude Code's floor is the max of four cited constraints (upstream changelog, cached at `~/.claude/cache/changelog.md`, each line read directly rather than via a summarizer):

- **2.1.63** — *"Added HTTP hooks, which can POST JSON to a URL…"*. All seven entries use `"type": "http"`.
- **2.0.45** — *"Added `PermissionRequest` hook…"*.
- **2.1.119** — *"Hooks: `PostToolUse` and `PostToolUseFailure` hook inputs now include `duration_ms`"*. An enhancement, so `PostToolUseFailure` **existed by** 2.1.119; its introducing version is not stated anywhere in the changelog. Recorded as a proven upper bound, which only pushes the floor up.
- **2.1.101 / 2.1.122** — *"an unrecognized hook event name in `settings.json` no longer causes the entire file to be ignored"* / *"Fixed a malformed hooks entry in `settings.json` no longer invalidating the entire file"*.

That last pair is what decides the **direction** of this gate. Below 2.1.122, an entry Claude Code cannot parse does **not** degrade to "that hook doesn't fire" — it takes the user's whole `settings.json` with it, silently disabling every other setting they have. That is a materially worse failure than a dead hook, and it justifies a floor higher than any single event needs.

Reality check: `claude --version` here is `2.1.226` and `codex --version` is `0.146.1`. Both clear their floors — no current user is blocked.

## Scope item 2, made mechanical

Each adapter declares per-event provenance (`hookEventSince`), and `AssertHookVersionGate` requires the floor to dominate every entry. So at any version where we install at all, every event we write is one the CLI knows — and adding a newer event fails the test rather than shipping an entry an in-range CLI would reject.

## Interaction with #1356's disclosure contract

**The gate is whole-install, not per-event, and that is the load-bearing choice.** If the installed set varied by version, `Touches`/`Detail` — static strings built at declaration time — could not state one exact count or one exact list. The copy would have to say "between four and seven entries", which is precisely the hand-waving #1356 abolished. Keeping the gate all-or-nothing means all three original arms hold **unchanged**.

So the contract is **extended, not weakened**. A fourth arm, `states_the_version_floor`, requires the copy to name the floor: #1356's rule is that the text describes what the installer writes, and a version gate makes it conditional *whether* it writes at all, so copy silent on the precondition describes something that may not happen. It reads the floor off the declaration, so adapters that declare none are unaffected and no call site changed.

The sentence is rendered by `hookjson.RequiresVersion` from the same string the gate compares against — derived, never hand-written, same principle as `EventList`. Its wording is constrained by the contract itself: the disclosure scan looks for CamelCase event-shaped tokens and for `N hook entr(y|ies)`, so a version sentence phrased "Adds 1 hook entry on ClaudeCode 2.1.122+" would fail an adapter's disclosure test for reasons unrelated to its install. `TestRequiresVersion_DoesNotTripTheDisclosureContract` pins that against both regexes.

## Missing / hung / unparseable probe — "safe" points at **install**

All three collapse to *unknown*, and unknown **fails open**. Only a version successfully read **and** parsed **and** found below the floor blocks an install.

This is chosen, not inherited. The harm the gate prevents is writing config into a CLI too old to understand it; *"I could not read a version"* is not evidence the CLI is old. The daemon runs under launchd with a minimal `PATH` while `claude` commonly lives in `~/.local/bin` — failing closed there would silently disable hooks for a large set of perfectly current users, producing the very "granted, but the channel never fires" outcome #1365 exists to abolish, reached from the other side.

Fast, and bounded three ways:

- **Missing** — `exec`'s PATH lookup fails before anything spawns; returns immediately, not after the timeout.
- **Hung** — `ProbeTimeout` = 2s on the consent path (the user is watching).
- **Orphan holding stdout** — `cmd.WaitDelay` = 500ms. Killing the process is not enough: `exec` waits for stdout EOF, and a grandchild that inherited the pipe holds it open past the kill. Without this, `Probe` hangs for the full 30s in `TestProbe_OrphanHoldingStdoutIsBounded`.
- **Flooding** — stdout capped at 64 KiB. Timeout bounds how long a bad CLI runs, not how much it writes; a process streaming to a pipe moves ~6 GB in two seconds and this is a long-lived daemon.
- **Unparseable, or any unclean exit** — an error, then unknown. Output from a run that did not complete cleanly is not trusted even when it parses: a version-shaped fragment in an error message ("config schema 1.0.0 unsupported") would otherwise read as the version and could cause a false refusal.

A probe that could not run is logged, so an *unchecked* gate is never mistaken for a *passed* one.

`argv` is a compile-time literal in the adapter declaration, passed to `exec` as separate arguments with no shell — and `argv[0]` resolves through `pathutil`'s trusted directories rather than the inherited PATH (go:S4036), matching every other fixed-literal exec in `core/`.

## Below the floor: no install, and the reason is available (scope item 3)

Nothing is written — not a partial install. The refusal is returned as an `error` from the gate and travels the **existing** failed-effect path in `runClosureEffect`, so it reaches the daemon log today and will ride #1362's consent-effect surfacing into the wizard **unchanged** once PR #1379 lands. #1379 is still open as of this PR, so no competing mechanism was built. Expect a small conflict in `permission_service.go` between the two; the resolution is to keep both.

Revoke is deliberately **never** gated — a user on an old CLI with entries installed must still be able to remove them.

## Red-first evidence

Full verbatim output in the thread. Summary:

| Test | Pre-fix failure |
|---|---|
| `codex TestCodexHooksApply_BelowFloorSaysWhy` (against untouched `main`) | `applyCodexHooks() on Codex 0.100.0 … returned nil — the skip is silent` |
| `claudecode TestHooksPermission_DeclaresVersionGate` | `hooks permission "hooks" declares no minimum CLI version (#1365)` |
| `agents TestEveryHookInstallDeclaresAVersionFloor` | fails for **both** `claude-code/hooks` and `codex/hooks` |
| `services TestHookVersionGate_RefusesBelowFloorAndSaysWhy` | `Apply ran although the installed CLI is below the declared floor` |
| `claudecode` #1356 `states_the_version_floor` | `consent copy never states the 2.1.122 minimum CLI version` |

The first ran against a tree containing **only** the new test file — no production change at all. The rest need the declaration field to compile, so they were run with the fix reverted from a `wip` checkpoint per AGENTS.md 11a (never `git stash`). During the #1356 run the other three arms stayed green, which is the direct evidence that the version gate does not disturb the existing disclosure contract.

**Locks** (pass by construction, called out so their green is not read as a red-first proof): `TestHookVersionGate_UnknownVersionInstalls`, `TestHooksGate_AtOrAboveFloorInstalls`, `TestHooksGate_AllowsCurrentClaudeCode`, `TestHookVersionGate_RevokeIsNeverGated`, `TestHookVersionGate_NoFloorDeclaredInstalls`, `assertUnknownFailsOpen`.

## Verification

`tools/preflight.sh` run chunked in the foreground (unscoped runs blow an automated caller's timeout — #1382). Every gate PASS: `go` (7 gates incl. replay fixtures), `web` (both trees), `arch` (ARS composite 7.9560 → 7.9580, no regression), `tools`, `skills`, `security`.

## Assumed, not verified

- The `idle_prompt` **matcher value** for `Notification`. Notification matchers arrived in 2.0.37 (cited) and `idle_prompt` is valid at 2.1.226 (docs), but no changelog line dates the value itself. Low risk: an unknown matcher never matches, it is not a malformed entry.
- `PostToolUseFailure`'s introducing version. Bounded above by 2.1.119 (cited), which is what the floor uses; the true value may be earlier, which would only mean the floor is conservative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review and simplify rounds (both applied, in commits 2-4)

A `high`-effort review returned **8 findings**, four confirmed by deliberate mutation. All are addressed; the two that changed the design materially:

- **The claudecode gate was decorative.** Probe-only + launchd PATH = permanent fail-open. Fixed by adding the passive `Observed` source described above. This was the single most valuable thing the review found — the gate would have shipped looking correct and checking nothing.
- **`assertUnknownFailsOpen` did not pin what it claimed.** The fail-open direction was encoded twice (in `AtLeast` and again in `Permits`' `|| !known`), so the reviewer's mutation — `AtLeast` failing closed — passed every test. `Permits` now trusts `AtLeast`'s `ok`. Re-run after the change: the arm goes red in both adapters.

Others: `Probe` split into `core/pkg/cliprobe` so `core/domain/agent` no longer pulls `os/exec` into its dependency graph; `pathutil` resolution; the 64 KiB output cap; a real-declaration-through-real-service composition test replacing the coverage lost with codex's deleted wrapper; probe runs under the daemon-lifetime context; the boundary arm decrements each version field independently instead of testing one synthetic predecessor.

`/simplify` then found the newest-transcript walk had been **copied** from codex into claudecode; both now call `agentpaths.NewestFileWithSuffix` / `agentpaths.Abs`, so adapter #3 supplies only its own field extraction. Two findings were skipped with reasons recorded in the commit message (backgrounding `Start`'s effects would break the recording rig, which relies on them being synchronous; moving `VersionGate` up to `Permission` generalizes on speculation with no caller).

## CI

All six `tools/preflight.sh` gates PASS locally (run chunked in the foreground — unscoped blows an automated caller's timeout, #1382).

CodeScene reports one critical finding, now fixed (Bumpy Road in `assertFloorCoversEveryEvent`, flattened; re-verified still red-first). Its remaining findings are advisory and deliberately not chased, per AGENTS.md — "a prompt to look closer, not something to chase to green". Two files improve: `codex/hookinstaller.go` 9.39 → 10.00 and its test 9.03 → 9.61, from deleting the bespoke gate.

---

## Rebased onto Wave 1 (`origin/main` @ `655249fe`+)

Three textual conflicts, plus one the merge could not flag.

**`permission_service.go` vs #1379 — kept both, and the join is better than "coexisting".** The gate already produced an ordinary `error` rather than a separate "skipped" concept, specifically so it would ride whatever #1362 landed. It now does: the refusal becomes the permission's `EffectError`, so both wizards render *"granted but NOT applied, because &lt;the CLI is too old&gt;"*. And because `planAnswerLocked` re-runs an effect when a re-answer finds a recorded failure, the refusal's own advice — *upgrade the CLI and grant again* — is literally the gesture that retries the install. Two new tests pin it (`_RefusalIsRecordedAsAnEffectError`, `_SuccessClearsAnEarlierRefusal`).

**`agentpaths` vs #1380 — collapsed, not merged.** #1380's `AbsRoot` and my `Abs` were two spellings of one rule, and `AbsRoot` is strictly better: it `Clean`s, and it rejects an empty root instead of silently answering `$HOME`. `Abs` is deleted; its caller and test moved to `AbsRoot`. Keeping both would have been precisely the drift #1380 was fixing. `NewestFileWithSuffix` is genuinely new and stays.

**`hookjson/disclosure.go`** — `RequiresVersion` re-applied on top of #1370's version.

**`AGENTS.md` — the trap, and it was real.** Both sides were individually correct so git flagged nothing: main's summary said *"All four contract families"* (`hook_disclosure`, `hook_endpoint`, `hook_path_confinement`, `permission_gate`) and this branch adds `hook_version` as the fifth. Verified against `git ls-tree --name-only origin/main core/internal/contracttesting/` rather than counted — `fixtures.go` exports no `Assert*` entrypoint, so four is right for main and five for the merged result. Also dropped three now-stale *"once PR #1379 lands"* comments.

### Re-verified on the rebased tree

Red-first and all four mutations re-run post-rebase; every one still red, and the four upstream contract families (`TestHookPathConfined`, `TestStatuslinePathConfined`, `TestHookEndpointFollowsBindAddr`, disclosure's original three arms) still pass. All six preflight gates PASS. Required checks confirmed **present** on head `acd3bbe9`, not merely not-red: `go-test` success, `build-test` success, `ars-gate` success.
