### PR TITLE
feat(launcher): herdr click-to-focus via the attached client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ beyond), see the [Roadmap](https://irrlicht.io/docs/roadmap.html).
 
 ## [Unreleased]
 
+### Added
+- **Click-to-focus works for sessions running in a [herdr](https://herdr.dev/) pane.** Clicking such a session used to do nothing: herdr's server owns every pane's pty, outlives any attached client and is reparented to init, so the pane's own process tree leads to no window and #1349 deliberately refused to guess one. The window belongs to the herdr *client*, so the daemon now finds the client attached to that pane's session and reads the host identity from it — the same whitelisted env plus ancestry walk used for a directly-hosted agent — and the macOS app selects the pane with `herdr agent focus` before raising that window. A session nobody has attached still resolves to no window, which is the honest answer rather than a wrong one; with more than one client attached, the most recent attach wins. Verified against herdr 0.8.0. macOS only — the web dashboard reads no launcher fields. (#1350)
+
 ## [0.5.10] — 2026-08-09
 
 ### Two more agents monitored — GitHub Copilot CLI and Hermes — herdr joins tmux and kitty as a controllable terminal, and live state now comes from the agent's own hooks instead of prose heuristics

--- a/core/adapters/inbound/agents/processlifecycle/launcher_permission.go
+++ b/core/adapters/inbound/agents/processlifecycle/launcher_permission.go
@@ -30,13 +30,17 @@ func LauncherPermissionDeclaration() agent.Agent {
 			Kind:            permission.KindObserve,
 			Title:           "Capture terminal identity",
 			FeatureUnlocked: "Click-to-focus: jump from a session row or notification straight to the terminal window that runs it",
-			Touches:         "Reads a fixed whitelist of environment variables from detected agent processes (TERM_PROGRAM, KITTY_*, TMUX, HERDR_*, …)",
+			Touches:         "Reads a fixed whitelist of environment variables from detected agent processes (TERM_PROGRAM, KITTY_*, TMUX, HERDR_*, …), and for a herdr pane from the herdr client displaying it",
 			Detail: "When a session is linked to its process, irrlicht reads only " +
 				"these variables from that process's environment: TERM_PROGRAM, " +
 				"ITERM_SESSION_ID, TERM_SESSION_ID, TMUX, TMUX_PANE, VSCODE_PID, " +
 				"TERMINAL_EMULATOR, KITTY_PID, KITTY_LISTEN_ON, KITTY_WINDOW_ID, " +
 				"HERDR_PANE_ID, HERDR_SOCKET_PATH — " +
-				"never the full environment. Focusing itself only happens when you " +
+				"never the full environment. A session running in a herdr pane is " +
+				"displayed by a separate herdr client process, so for those the same " +
+				"whitelist is also read from that client (found via the session's own " +
+				"socket path) — without it there is no window to jump to. Focusing " +
+				"itself only happens when you " +
 				"click a session (kitty remote control / AppleScript, additionally " +
 				"gated by macOS automation prompts). Toggling off stops the capture " +
 				"immediately; without it, click-to-focus falls back to app-level " +

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -76,6 +76,34 @@ func ReadLauncherEnv(pid int) *session.Launcher {
 	if pid <= 0 {
 		return nil
 	}
+	l := hostIdentity(pid)
+
+	// A herdr pane's window belongs to the attached client, so its host
+	// identity is resolved from that process instead — one indirection past
+	// the ancestry walk hostIdentity skipped (#1350). Runs after the TTY
+	// capture so the pane keeps its own pty when nothing is attached, and is
+	// overridden by the client's when something is: AdoptHostIdentity owns
+	// that rule.
+	if l.HerdrPaneID != "" {
+		l.AdoptHostIdentity(herdrClientLauncher(l.HerdrSocketPath))
+	}
+
+	if l.IsEmpty() {
+		return nil
+	}
+	return l
+}
+
+// hostIdentity resolves the window-owning identity of pid: its whitelisted
+// env, the ancestry fallbacks, and its controlling TTY. This is the sequence
+// that answers "which window is this process displayed in", and it is applied
+// twice — once to the agent, and once to a herdr client standing in for it
+// (osutil_darwin.go). Keeping it in one function is what stops the two from
+// drifting when a step is added.
+//
+// The ordering is load-bearing: ancestry before TTY, and both before any
+// adoption by the caller.
+func hostIdentity(pid int) *session.Launcher {
 	// Env may be empty — hardened-runtime processes hide it from sysctl.
 	// Don't bail here: the ancestry fallback below is the only signal we
 	// have in that case.
@@ -94,8 +122,8 @@ func ReadLauncherEnv(pid int) *session.Launcher {
 	// The ancestry walk is cached because three guarded blocks may all need it
 	// (kitty TermProgram override, hardened-runtime TermProgram fallback,
 	// kitty field back-fill). Walking the ppid chain once instead of up to
-	// three times keeps ReadLauncherEnv bounded — each readProcInfo is a `ps`
-	// shellout with a 2s ceiling.
+	// three times keeps this bounded — each readProcInfo is a `ps` shellout
+	// with a 2s ceiling.
 	if l.HerdrPaneID == "" {
 		applyAncestryFallbacks(l, pid, memoizedAncestry(pid))
 	}
@@ -104,18 +132,6 @@ func ReadLauncherEnv(pid int) *session.Launcher {
 	// can target the exact tab — Terminal.app's AppleScript dictionary
 	// matches tabs by `tty` but has no session-UUID analog.
 	l.TTY = processTTY(pid)
-
-	// A herdr pane's window belongs to the attached client, so its host
-	// identity is resolved from that process instead — one indirection past
-	// the ancestry walk skipped above (#1350). Runs after the TTY capture so
-	// the pane keeps its own pty when nothing is attached, and is overridden
-	// by the client's when something is: AdoptHostIdentity owns that rule.
-	if l.HerdrPaneID != "" {
-		l.AdoptHostIdentity(herdrClientLauncher(l.HerdrSocketPath))
-	}
-	if l.IsEmpty() {
-		return nil
-	}
 	return l
 }
 

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -10,6 +10,7 @@ package processlifecycle
 
 import (
 	"encoding/binary"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -40,6 +41,28 @@ var launcherEnvKeys = map[string]struct{}{
 	"KITTY_PID":         {}, // kitty.app PID; lets the macOS activator target this specific kitty instance
 	"HERDR_PANE_ID":     {}, // herdr pane address (e.g. "w1:p2") — injected per pane, so unlike the vars above it always describes *this* pane
 	"HERDR_SOCKET_PATH": {}, // herdr server socket; the complete addressing key for that server
+}
+
+// herdrClientLogName is the per-session file every attached herdr client holds
+// open for writing, in the same directory as the server socket. It is what
+// makes $HERDR_SOCKET_PATH — which the daemon already captures — a complete
+// key for finding the client, with no need to also capture $HERDR_SESSION or
+// to parse a client's argv (which differs between `herdr --session <name>`,
+// a bare `herdr` on the default session, and `herdr session attach <name>`).
+// Verified against herdr 0.8.0: the layout is identical for the default
+// session (<config>/herdr.sock) and named ones
+// (<config>/sessions/<name>/herdr.sock), and a session with no client attached
+// has no writer on this file at all.
+const herdrClientLogName = "herdr-client.log"
+
+// herdrClientLogPath maps a captured $HERDR_SOCKET_PATH to the client log
+// beside it. Returns "" for an empty socket path so callers inherit the
+// "no address, no client" answer instead of probing a bare directory.
+func herdrClientLogPath(socketPath string) string {
+	if socketPath == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(socketPath), herdrClientLogName)
 }
 
 // ReadLauncherEnv returns the launcher identity captured from the process env
@@ -81,6 +104,15 @@ func ReadLauncherEnv(pid int) *session.Launcher {
 	// can target the exact tab — Terminal.app's AppleScript dictionary
 	// matches tabs by `tty` but has no session-UUID analog.
 	l.TTY = processTTY(pid)
+
+	// A herdr pane's window belongs to the attached client, so its host
+	// identity is resolved from that process instead — one indirection past
+	// the ancestry walk skipped above (#1350). Runs after the TTY capture so
+	// the pane keeps its own pty when nothing is attached, and is overridden
+	// by the client's when something is: AdoptHostIdentity owns that rule.
+	if l.HerdrPaneID != "" {
+		l.AdoptHostIdentity(herdrClientLauncher(l.HerdrSocketPath))
+	}
 	if l.IsEmpty() {
 		return nil
 	}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -383,13 +383,11 @@ func readProcInfo(pid int) (ppid int, cmd string, err error) {
 // client has no writer on its client log, and one with two clients attached
 // (herdr supports attaching from more than one place) has two.
 //
-// Only *writers* count. "Holds the log open" is not the predicate: `lsof -t`
-// discards the FD column, so it cannot tell a client's `3w` from a
-// `tail -f` reader's `3r` — and a reader is not a client. Left unfiltered, a
-// developer tailing the log to debug herdr would have their own terminal
-// adopted as the host of every session on that server (and, being newer, would
-// sort first), which is precisely the #1348 misroute. Parsing the FD column is
-// the same thing darwinObserver.WriterOf does for the same reason.
+// Only writers count. "Holds the log open" is not the predicate: a `tail -f`
+// reader is not a client, and adopting its terminal as the host of every
+// session on that server would be the #1348 misroute with a new cause — and,
+// being the newer process, it would sort first. Hence the FD-column filter,
+// which is also why this cannot use `lsof -t` (that form drops the column).
 //
 // Ordering answers open question 3 of #1350: the most recently attached client
 // is the window the user most recently chose to view the session in, and PIDs
@@ -403,38 +401,26 @@ func herdrClientPIDs(socketPath string) []int {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	// Default table output, not -t: the FD column is the whole point.
 	// A non-zero exit means no process holds the file open — the detached
 	// case, not an error.
 	out, err := exec.CommandContext(ctx, lsofPath, logPath).Output()
 	if err != nil {
 		return nil
 	}
-	pids := parseHerdrClientWriters(string(out), os.Getpid())
+	pids := herdrClientWriters(string(out), os.Getpid())
 	sort.Sort(sort.Reverse(sort.IntSlice(pids)))
 	return pids
 }
 
-// parseHerdrClientWriters extracts the writer PIDs from lsof's default table,
-// skipping the header, the daemon itself, and every read-only holder. Split out
-// of herdrClientPIDs so the FD-column rule is testable without a live herdr.
-func parseHerdrClientWriters(out string, self int) []int {
+// herdrClientWriters selects the client PIDs from an lsof table. 'u' counts
+// alongside 'w': it is read/write, which a client's log handle may legitimately
+// be, whereas a plain 'r' reader never is. Split out so the rule is testable
+// without a live herdr.
+func herdrClientWriters(out string, self int) []int {
 	var pids []int
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) < 4 || fields[0] == "COMMAND" {
-			continue
-		}
-		pid, err := strconv.Atoi(fields[1])
-		if err != nil || pid <= 0 || pid == self {
-			continue
-		}
-		// e.g. "3w", "9u" — a client opens the log for writing. "u" is
-		// read/write, which also qualifies; "3r" does not.
-		if fd := fields[3]; fd != "" {
-			if mode := fd[len(fd)-1]; mode == 'w' || mode == 'u' {
-				pids = append(pids, pid)
-			}
+	for _, e := range parseLsofFDs(out, self) {
+		if mode := e.Mode(); mode == 'w' || mode == 'u' {
+			pids = append(pids, e.PID)
 		}
 	}
 	return pids
@@ -442,18 +428,16 @@ func parseHerdrClientWriters(out string, self int) []int {
 
 // maxHerdrClientCandidates bounds how many attached clients are probed for a
 // resolvable host. Each candidate costs an env read plus an ancestry walk, and
-// ReadLauncherEnv documents a two-second ceiling; attaching more than a handful
-// of clients to one session is not a real workflow, so the cap keeps the
-// contract enforceable rather than aspirational.
+// attaching more than a handful of clients to one session is not a real
+// workflow, so the cap keeps that work proportionate.
 const maxHerdrClientCandidates = 4
 
 // herdrClientLauncher resolves the host-window identity of the herdr session
-// addressed by socketPath, by reading it from the attached client the same way
-// it would be read from any directly-hosted agent: the whitelisted env of that
-// process plus the ancestry fallbacks. Returns nil when nothing is attached, or
-// when no attached client resolves to a local GUI host — an SSH client has a
-// real tty but no local window, and reporting one anyway is the misroute #1348
-// removed.
+// addressed by socketPath, by reading it from the attached client exactly the
+// way it would be read from any directly-hosted agent (hostIdentity). Returns
+// nil when nothing is attached, or when no attached client resolves to a local
+// GUI host — an SSH client has a real tty but no local window, and reporting
+// one anyway is the misroute #1348 removed.
 //
 // Only ever called with a socket path the daemon captured from the pane's own
 // $HERDR_SOCKET_PATH, so a resolved identity always accompanies a complete
@@ -483,15 +467,12 @@ func resolveHerdrClientLauncher(socketPath string) *session.Launcher {
 		pids = pids[:maxHerdrClientCandidates]
 	}
 	for _, pid := range pids {
-		env, _ := osProc.EnvOf(pid)
-		host := launcherFromEnv(env)
+		host := hostIdentity(pid)
 		if host.HerdrPaneID != "" {
 			// herdr nested in herdr: this client's own window is another
 			// indirection away. Don't recurse — try the next candidate.
 			continue
 		}
-		applyAncestryFallbacks(host, pid, memoizedAncestry(pid))
-		host.TTY = processTTY(pid)
 		if host.TermProgram == "" && host.HostBundleID == "" {
 			continue
 		}
@@ -510,30 +491,31 @@ type herdrClientCacheEntry struct {
 	at       time.Time
 }
 
-var herdrClientCache = struct {
-	sync.Mutex
-	entries map[string]herdrClientCacheEntry
-}{entries: map[string]herdrClientCacheEntry{}}
+var (
+	herdrClientCacheMu sync.Mutex
+	herdrClientCache   = map[string]herdrClientCacheEntry{}
+)
 
-// herdrClientCacheGet returns a copy of the cached identity for socketPath, so
-// a caller mutating what it gets back cannot corrupt the entry for the next
-// pane of the same server. ok is false once the entry has aged out.
+// herdrClientCacheGet reports the cached identity for socketPath. A cached
+// "nothing attached" is a real answer and returns (nil, true); ok is false only
+// when there is no live entry. Expired entries are dropped on the way past, so
+// sockets that stop being used don't accumulate.
 func herdrClientCacheGet(socketPath string) (*session.Launcher, bool) {
-	herdrClientCache.Lock()
-	defer herdrClientCache.Unlock()
-	entry, ok := herdrClientCache.entries[socketPath]
-	if !ok || time.Since(entry.at) > herdrClientCacheTTL {
+	herdrClientCacheMu.Lock()
+	defer herdrClientCacheMu.Unlock()
+	entry, ok := herdrClientCache[socketPath]
+	if !ok {
 		return nil, false
 	}
-	if entry.launcher == nil {
-		return nil, true
+	if time.Since(entry.at) > herdrClientCacheTTL {
+		delete(herdrClientCache, socketPath)
+		return nil, false
 	}
-	clone := *entry.launcher
-	return &clone, true
+	return entry.launcher, true
 }
 
 func herdrClientCachePut(socketPath string, l *session.Launcher) {
-	herdrClientCache.Lock()
-	defer herdrClientCache.Unlock()
-	herdrClientCache.entries[socketPath] = herdrClientCacheEntry{launcher: l, at: time.Now()}
+	herdrClientCacheMu.Lock()
+	defer herdrClientCacheMu.Unlock()
+	herdrClientCache[socketPath] = herdrClientCacheEntry{launcher: l, at: time.Now()}
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -15,6 +16,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/pathutil"
 )
 
@@ -372,4 +374,73 @@ func readProcInfo(pid int) (ppid int, cmd string, err error) {
 	}
 	cmd = strings.TrimSpace(line[space:])
 	return ppid, cmd, nil
+}
+
+// herdrClientPIDs returns the PIDs of every herdr client currently attached to
+// the session addressed by socketPath, newest attach first. A detached session
+// yields nil — verified live against herdr 0.8.0, where a session with no
+// client has no writer on its client log, and one with two clients attached
+// (herdr supports attaching from more than one place) has two.
+//
+// Ordering answers open question 3 of #1350: the most recently attached client
+// is the window the user most recently chose to view the session in, and PIDs
+// are allocated ascending, so descending PID is "newest first". lsof matches
+// by device and inode rather than by string, so a symlinked path (a macOS
+// t.TempDir() lives under /var -> /private/var) needs no canonicalisation here.
+func herdrClientPIDs(socketPath string) []int {
+	logPath := herdrClientLogPath(socketPath)
+	if logPath == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	// -t prints bare PIDs, one per line, and exits non-zero when no process
+	// holds the file open — the detached case, not an error.
+	out, err := exec.CommandContext(ctx, lsofPath, "-t", logPath).Output()
+	if err != nil {
+		return nil
+	}
+	self := os.Getpid()
+	var pids []int
+	for _, line := range strings.Fields(string(out)) {
+		pid, convErr := strconv.Atoi(line)
+		if convErr != nil || pid <= 0 || pid == self {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(pids)))
+	return pids
+}
+
+// herdrClientLauncher resolves the host-window identity of the herdr session
+// addressed by socketPath, by reading it from the attached client the same way
+// it would be read from any directly-hosted agent: the whitelisted env of that
+// process plus the ancestry fallbacks. Returns nil when nothing is attached, or
+// when no attached client resolves to a local GUI host — an SSH client has a
+// real tty but no local window, and reporting one anyway is the misroute #1348
+// removed.
+//
+// Only ever called with a socket path the daemon captured from the pane's own
+// $HERDR_SOCKET_PATH, so a resolved identity always accompanies a complete
+// herdr address; control keeps routing to herdr (resolveBackend requires both
+// Herdr fields and tests them first) rather than to any tmux/kitty identity
+// adopted from the client.
+func herdrClientLauncher(socketPath string) *session.Launcher {
+	for _, pid := range herdrClientPIDs(socketPath) {
+		env, _ := osProc.EnvOf(pid)
+		host := launcherFromEnv(env)
+		if host.HerdrPaneID != "" {
+			// herdr nested in herdr: this client's own window is another
+			// indirection away. Don't recurse — try the next candidate.
+			continue
+		}
+		applyAncestryFallbacks(host, pid, memoizedAncestry(pid))
+		host.TTY = processTTY(pid)
+		if host.TermProgram == "" && host.HostBundleID == "" {
+			continue
+		}
+		return host
+	}
+	return nil
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -382,6 +383,14 @@ func readProcInfo(pid int) (ppid int, cmd string, err error) {
 // client has no writer on its client log, and one with two clients attached
 // (herdr supports attaching from more than one place) has two.
 //
+// Only *writers* count. "Holds the log open" is not the predicate: `lsof -t`
+// discards the FD column, so it cannot tell a client's `3w` from a
+// `tail -f` reader's `3r` — and a reader is not a client. Left unfiltered, a
+// developer tailing the log to debug herdr would have their own terminal
+// adopted as the host of every session on that server (and, being newer, would
+// sort first), which is precisely the #1348 misroute. Parsing the FD column is
+// the same thing darwinObserver.WriterOf does for the same reason.
+//
 // Ordering answers open question 3 of #1350: the most recently attached client
 // is the window the user most recently chose to view the session in, and PIDs
 // are allocated ascending, so descending PID is "newest first". lsof matches
@@ -394,24 +403,49 @@ func herdrClientPIDs(socketPath string) []int {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	// -t prints bare PIDs, one per line, and exits non-zero when no process
-	// holds the file open — the detached case, not an error.
-	out, err := exec.CommandContext(ctx, lsofPath, "-t", logPath).Output()
+	// Default table output, not -t: the FD column is the whole point.
+	// A non-zero exit means no process holds the file open — the detached
+	// case, not an error.
+	out, err := exec.CommandContext(ctx, lsofPath, logPath).Output()
 	if err != nil {
 		return nil
 	}
-	self := os.Getpid()
-	var pids []int
-	for _, line := range strings.Fields(string(out)) {
-		pid, convErr := strconv.Atoi(line)
-		if convErr != nil || pid <= 0 || pid == self {
-			continue
-		}
-		pids = append(pids, pid)
-	}
+	pids := parseHerdrClientWriters(string(out), os.Getpid())
 	sort.Sort(sort.Reverse(sort.IntSlice(pids)))
 	return pids
 }
+
+// parseHerdrClientWriters extracts the writer PIDs from lsof's default table,
+// skipping the header, the daemon itself, and every read-only holder. Split out
+// of herdrClientPIDs so the FD-column rule is testable without a live herdr.
+func parseHerdrClientWriters(out string, self int) []int {
+	var pids []int
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 || fields[0] == "COMMAND" {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[1])
+		if err != nil || pid <= 0 || pid == self {
+			continue
+		}
+		// e.g. "3w", "9u" — a client opens the log for writing. "u" is
+		// read/write, which also qualifies; "3r" does not.
+		if fd := fields[3]; fd != "" {
+			if mode := fd[len(fd)-1]; mode == 'w' || mode == 'u' {
+				pids = append(pids, pid)
+			}
+		}
+	}
+	return pids
+}
+
+// maxHerdrClientCandidates bounds how many attached clients are probed for a
+// resolvable host. Each candidate costs an env read plus an ancestry walk, and
+// ReadLauncherEnv documents a two-second ceiling; attaching more than a handful
+// of clients to one session is not a real workflow, so the cap keeps the
+// contract enforceable rather than aspirational.
+const maxHerdrClientCandidates = 4
 
 // herdrClientLauncher resolves the host-window identity of the herdr session
 // addressed by socketPath, by reading it from the attached client the same way
@@ -426,8 +460,29 @@ func herdrClientPIDs(socketPath string) []int {
 // herdr address; control keeps routing to herdr (resolveBackend requires both
 // Herdr fields and tests them first) rather than to any tmux/kitty identity
 // adopted from the client.
+//
+// Results are memoized briefly because every pane of one herdr server shares a
+// socket, and the startup seed resolves them back to back, synchronously: an
+// lsof scan costs ~0.3s on a quiet machine, so eight panes would otherwise pay
+// eight identical scans before the daemon starts serving.
 func herdrClientLauncher(socketPath string) *session.Launcher {
-	for _, pid := range herdrClientPIDs(socketPath) {
+	if socketPath == "" {
+		return nil
+	}
+	if cached, ok := herdrClientCacheGet(socketPath); ok {
+		return cached
+	}
+	resolved := resolveHerdrClientLauncher(socketPath)
+	herdrClientCachePut(socketPath, resolved)
+	return resolved
+}
+
+func resolveHerdrClientLauncher(socketPath string) *session.Launcher {
+	pids := herdrClientPIDs(socketPath)
+	if len(pids) > maxHerdrClientCandidates {
+		pids = pids[:maxHerdrClientCandidates]
+	}
+	for _, pid := range pids {
 		env, _ := osProc.EnvOf(pid)
 		host := launcherFromEnv(env)
 		if host.HerdrPaneID != "" {
@@ -443,4 +498,42 @@ func herdrClientLauncher(socketPath string) *session.Launcher {
 		return host
 	}
 	return nil
+}
+
+// herdrClientCacheTTL is short enough that attaching a client is picked up by
+// the next session bound after it, and long enough to collapse one startup
+// seed's worth of repeats into a single scan.
+const herdrClientCacheTTL = 5 * time.Second
+
+type herdrClientCacheEntry struct {
+	launcher *session.Launcher
+	at       time.Time
+}
+
+var herdrClientCache = struct {
+	sync.Mutex
+	entries map[string]herdrClientCacheEntry
+}{entries: map[string]herdrClientCacheEntry{}}
+
+// herdrClientCacheGet returns a copy of the cached identity for socketPath, so
+// a caller mutating what it gets back cannot corrupt the entry for the next
+// pane of the same server. ok is false once the entry has aged out.
+func herdrClientCacheGet(socketPath string) (*session.Launcher, bool) {
+	herdrClientCache.Lock()
+	defer herdrClientCache.Unlock()
+	entry, ok := herdrClientCache.entries[socketPath]
+	if !ok || time.Since(entry.at) > herdrClientCacheTTL {
+		return nil, false
+	}
+	if entry.launcher == nil {
+		return nil, true
+	}
+	clone := *entry.launcher
+	return &clone, true
+}
+
+func herdrClientCachePut(socketPath string, l *session.Launcher) {
+	herdrClientCache.Lock()
+	defer herdrClientCache.Unlock()
+	herdrClientCache.entries[socketPath] = herdrClientCacheEntry{launcher: l, at: time.Now()}
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func TestKittyAncestryPID_Self(t *testing.T) {
@@ -353,4 +354,158 @@ func reverseLookup(termProgram string) string {
 		}
 	}
 	return ""
+}
+
+// --- herdr client discovery (#1350) -----------------------------------------
+//
+// Darwin-only because client discovery is: it walks lsof's FD table and then
+// the process ancestry, neither of which the linux/other builds implement.
+
+// spawnHerdrClient starts a sleeper that stands in for an attached herdr
+// client: it holds the session's client log open for writing (which is what
+// identifies a client) and carries the host terminal's identity in its own env.
+// Waits until the open fd is actually visible to the discovery helper so the
+// caller isn't racing the child's OpenFile.
+func spawnHerdrClient(t *testing.T, socketPath string, env ...string) int {
+	t.Helper()
+	pid := spawnSleeperWithEnv(t, append([]string{
+		"PATH=/usr/bin:/bin",
+		"GO_WANT_LAUNCHER_HELPER_HOLD=" + herdrClientLogPath(socketPath),
+	}, env...))
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, got := range herdrClientPIDs(socketPath) {
+			if got == pid {
+				return pid
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("client pid %d never became visible as a writer of the client log", pid)
+	return 0
+}
+
+// TestReadLauncherEnv_Herdr_ResolvesHostFromAttachedClient pins the defect in
+// #1350: a herdr pane reached the macOS app with no term_program and no
+// host_bundle_id, so resolveActivator returned nil and a click did nothing.
+// The window belongs to the attached *client*, so the host identity has to be
+// read from that process — one indirection past the pane's own env, which
+// describes the (detached, reparented) server and is deliberately suppressed.
+func TestReadLauncherEnv_Herdr_ResolvesHostFromAttachedClient(t *testing.T) {
+	socketPath := newHerdrSessionDir(t)
+	spawnHerdrClient(t, socketPath,
+		"TERM_PROGRAM=iTerm.app",
+		"ITERM_SESSION_ID=w0t0p0-CLIENT",
+	)
+	agentPID := spawnSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"HERDR_PANE_ID=w1:p2",
+		"HERDR_SOCKET_PATH=" + socketPath,
+		// The stale, inherited identity a real pane carries — it describes the
+		// server's launch environment and must stay suppressed (#1348).
+		"TERM_PROGRAM=tmux",
+		"TMUX=/tmp/foreign-tmux,95058,0",
+		"TMUX_PANE=%0",
+	})
+
+	l := ReadLauncherEnv(agentPID)
+	if l == nil {
+		t.Fatal("expected non-nil launcher")
+	}
+	if l.TermProgram != "iTerm.app" {
+		t.Errorf("TermProgram: want the attached client's iTerm.app, got %q", l.TermProgram)
+	}
+	if l.ITermSessionID != "w0t0p0-CLIENT" {
+		t.Errorf("ITermSessionID: want the client's window selector, got %q", l.ITermSessionID)
+	}
+	// The pane address must survive the merge — it is what the activator
+	// focuses, and what resolveBackend keys the control path on.
+	if l.HerdrPaneID != "w1:p2" || l.HerdrSocketPath != socketPath {
+		t.Errorf("herdr address lost: pane=%q socket=%q", l.HerdrPaneID, l.HerdrSocketPath)
+	}
+	// The client's env carried no tmux, so the pane's inherited tmux identity
+	// must not reappear by this route — resolveBackend requires both herdr
+	// fields, and a surviving TmuxPane is the #1348 misroute.
+	if l.TmuxPane != "" || l.TmuxSocket != "" {
+		t.Errorf("inherited tmux identity survived: pane=%q socket=%q", l.TmuxPane, l.TmuxSocket)
+	}
+}
+
+// TestHerdrClientPIDs_MultipleClientsAreOrderedNewestFirst covers open question
+// 3 of #1350. herdr supports attaching from more than one place at once;
+// verified live (two clients on one session → two writers on the client log).
+// The newest attach is the window the user most recently chose, so the
+// discovery helper reports descending PID and the resolver takes the first
+// candidate that yields a host.
+func TestHerdrClientPIDs_MultipleClientsAreOrderedNewestFirst(t *testing.T) {
+	socketPath := newHerdrSessionDir(t)
+	first := spawnHerdrClient(t, socketPath)
+	second := spawnHerdrClient(t, socketPath)
+
+	pids := herdrClientPIDs(socketPath)
+	if len(pids) < 2 {
+		t.Fatalf("want both attached clients, got %v (first=%d second=%d)", pids, first, second)
+	}
+	for i := 1; i < len(pids); i++ {
+		if pids[i-1] < pids[i] {
+			t.Errorf("want descending pids (newest attach first), got %v", pids)
+			break
+		}
+	}
+	if pids[0] != max(first, second) {
+		t.Errorf("newest client must win: got %d, want %d", pids[0], max(first, second))
+	}
+}
+
+// TestHerdrClientWriters covers the FD-column rule: "holds the client log open"
+// is not the predicate, "holds it open for writing" is. A read-only holder — a
+// developer running `tail -f` on the log to debug herdr — is not a client, and
+// adopting its terminal as the herdr host would be the #1348 misroute with a
+// new cause. The reader is deliberately given the higher PID here, because the
+// caller sorts descending and would otherwise prefer it.
+func TestHerdrClientWriters(t *testing.T) {
+	const out = `COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME
+herdr     26932 ingo    3w   REG   1,18      372 136170 /cfg/herdr/herdr-client.log
+tail      99999 ingo    3r   REG   1,18      372 136170 /cfg/herdr/herdr-client.log
+herdr     26940 ingo    9u   REG   1,18      372 136170 /cfg/herdr/herdr-client.log
+herdr     26941 ingo    5uW  REG   1,18      372 136170 /cfg/herdr/herdr-client.log
+irrlichd    777 ingo    4w   REG   1,18      372 136170 /cfg/herdr/herdr-client.log`
+
+	got := herdrClientWriters(out, 777)
+	want := map[int]bool{26932: true, 26940: true, 26941: true}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want exactly the writers %v", got, want)
+	}
+	for _, pid := range got {
+		if !want[pid] {
+			t.Errorf("pid %d must not be reported: readers are not clients, and the daemon is not its own client", pid)
+		}
+	}
+}
+
+// TestHerdrClientWriters_NoHolders is the detached case as lsof reports it —
+// header only, or nothing at all.
+func TestHerdrClientWriters_NoHolders(t *testing.T) {
+	for name, out := range map[string]string{
+		"empty":       "",
+		"header only": "COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME",
+	} {
+		if got := herdrClientWriters(out, 1); len(got) != 0 {
+			t.Errorf("%s: want no clients, got %v", name, got)
+		}
+	}
+}
+
+// TestLsofFDMode pins the mode parse, including the lock-character case: lsof
+// appends a lock flag *after* the mode, so "5uW" is a read/write handle with a
+// write lock — reading the last byte would call its mode 'W' and miss it.
+func TestLsofFDMode(t *testing.T) {
+	cases := map[string]byte{
+		"14w": 'w', "8299r": 'r', "9u": 'u', "5uW": 'u', "3wR": 'w', "cwd": 'c', "12": 0,
+	}
+	for fd, want := range cases {
+		if got := (lsofFD{FD: fd}).Mode(); got != want {
+			t.Errorf("lsofFD{FD: %q}.Mode() = %q, want %q", fd, got, want)
+		}
+	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"irrlicht/core/domain/session"
 )
 
 // readProcessEnv reads /proc/<pid>/environ and returns the whitelisted
@@ -53,3 +55,10 @@ func kittyWindowIDForPID(socket string, sessionPID int) string { return "" }
 // process, issue #784) only exists on macOS, so failing closed here would
 // reject every antigravity CLI session on this platform instead.
 func IsKnownInteractiveHost(pid int) bool { return true }
+
+// herdrClientPIDs / herdrClientLauncher resolve a herdr pane's window through
+// the attached client (#1350). Darwin-only: the identity they produce is only
+// consumed by the macOS click-to-focus path, and resolving it needs the same
+// ancestry walk the stubs above already decline to do.
+func herdrClientPIDs(socketPath string) []int                 { return nil }
+func herdrClientLauncher(socketPath string) *session.Launcher { return nil }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -56,9 +56,8 @@ func kittyWindowIDForPID(socket string, sessionPID int) string { return "" }
 // reject every antigravity CLI session on this platform instead.
 func IsKnownInteractiveHost(pid int) bool { return true }
 
-// herdrClientPIDs / herdrClientLauncher resolve a herdr pane's window through
-// the attached client (#1350). Darwin-only: the identity they produce is only
-// consumed by the macOS click-to-focus path, and resolving it needs the same
-// ancestry walk the stubs above already decline to do.
-func herdrClientPIDs(socketPath string) []int                 { return nil }
+// herdrClientLauncher resolves a herdr pane's window through the attached
+// client (#1350). Darwin-only: the identity it produces is only consumed by the
+// macOS click-to-focus path, and resolving it needs the same ancestry walk the
+// stubs above already decline to do.
 func herdrClientLauncher(socketPath string) *session.Launcher { return nil }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -30,9 +30,8 @@ func kittyWindowIDForPID(socket string, sessionPID int) string { return "" }
 // reject every antigravity CLI session on this platform instead.
 func IsKnownInteractiveHost(pid int) bool { return true }
 
-// herdrClientPIDs / herdrClientLauncher resolve a herdr pane's window through
-// the attached client (#1350). Darwin-only: the identity they produce is only
-// consumed by the macOS click-to-focus path, and resolving it needs the same
-// ancestry walk the stubs above already decline to do.
-func herdrClientPIDs(socketPath string) []int                 { return nil }
+// herdrClientLauncher resolves a herdr pane's window through the attached
+// client (#1350). Darwin-only: the identity it produces is only consumed by the
+// macOS click-to-focus path, and resolving it needs the same ancestry walk the
+// stubs above already decline to do.
 func herdrClientLauncher(socketPath string) *session.Launcher { return nil }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -2,6 +2,8 @@
 
 package processlifecycle
 
+import "irrlicht/core/domain/session"
+
 // readProcessEnv is not implemented on this platform — launcher capture
 // is disabled and the menu-bar app falls back to Finder-reveal of cwd.
 func readProcessEnv(pid int) (map[string]string, error) {
@@ -27,3 +29,10 @@ func kittyWindowIDForPID(socket string, sessionPID int) string { return "" }
 // process, issue #784) only exists on macOS, so failing closed here would
 // reject every antigravity CLI session on this platform instead.
 func IsKnownInteractiveHost(pid int) bool { return true }
+
+// herdrClientPIDs / herdrClientLauncher resolve a herdr pane's window through
+// the attached client (#1350). Darwin-only: the identity they produce is only
+// consumed by the macOS click-to-focus path, and resolving it needs the same
+// ancestry walk the stubs above already decline to do.
+func herdrClientPIDs(socketPath string) []int                 { return nil }
+func herdrClientLauncher(socketPath string) *session.Launcher { return nil }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -631,3 +631,41 @@ func TestHerdrClientLogPath(t *testing.T) {
 		}
 	}
 }
+
+// TestParseHerdrClientWriters covers the FD-column rule: "holds the client log
+// open" is not the predicate, "holds it open for writing" is. A read-only
+// holder — a developer running `tail -f` on the log to debug herdr — is not a
+// client, and adopting its terminal as the herdr host would be the #1348
+// misroute with a new cause. The reader is deliberately given the higher PID
+// here, because the caller sorts descending and would otherwise prefer it.
+func TestParseHerdrClientWriters(t *testing.T) {
+	const out = `COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME
+herdr     26932 ingo    3w   REG   1,18      372 136170 /cfg/herdr/herdr-client.log
+tail      99999 ingo    3r   REG   1,18      372 136170 /cfg/herdr/herdr-client.log
+herdr     26940 ingo    9u   REG   1,18      372 136170 /cfg/herdr/herdr-client.log
+irrlichd    777 ingo    4w   REG   1,18      372 136170 /cfg/herdr/herdr-client.log`
+
+	got := parseHerdrClientWriters(out, 777)
+	want := map[int]bool{26932: true, 26940: true}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want exactly the writers %v", got, want)
+	}
+	for _, pid := range got {
+		if !want[pid] {
+			t.Errorf("pid %d must not be reported: readers are not clients, and the daemon is not its own client", pid)
+		}
+	}
+}
+
+// TestParseHerdrClientWriters_NoHolders is the detached case as lsof reports
+// it — header only, or nothing at all.
+func TestParseHerdrClientWriters_NoHolders(t *testing.T) {
+	for name, out := range map[string]string{
+		"empty":       "",
+		"header only": "COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME",
+	} {
+		if got := parseHerdrClientWriters(out, 1); len(got) != 0 {
+			t.Errorf("%s: want no clients, got %v", name, got)
+		}
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -3,6 +3,7 @@ package processlifecycle
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
@@ -16,6 +17,21 @@ import (
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_LAUNCHER_HELPER") != "1" {
 		return
+	}
+	// GO_WANT_LAUNCHER_HELPER_HOLD makes the sleeper stand in for an attached
+	// herdr client: it holds the named file open for writing, which is the
+	// signal herdrClientPIDs matches on. Held for longer than the plain
+	// sleeper because the herdr tests poll for the open fd to become visible
+	// to lsof; every caller kills it via t.Cleanup, so the longer sleep costs
+	// nothing.
+	if hold := os.Getenv("GO_WANT_LAUNCHER_HELPER_HOLD"); hold != "" {
+		f, err := os.OpenFile(hold, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+		if err != nil {
+			os.Exit(1)
+		}
+		defer f.Close()
+		time.Sleep(30 * time.Second)
+		os.Exit(0)
 	}
 	time.Sleep(3 * time.Second)
 	os.Exit(0)
@@ -447,5 +463,171 @@ func TestReadLauncherEnv_Subprocess_JetBrainsImpliesTermProgram(t *testing.T) {
 	}
 	if l.TermProgram != "jetbrains" {
 		t.Errorf("TermProgram: expected implicit 'jetbrains', got %q", l.TermProgram)
+	}
+}
+
+// --- herdr click-to-focus (#1350) -------------------------------------------
+
+// newHerdrSessionDir returns a stand-in for a herdr session directory: the
+// socket path the pane's $HERDR_SOCKET_PATH points at, and the client log
+// that sits beside it. Mirrors the real layout, which is identical for the
+// default session (<config>/herdr.sock) and a named one
+// (<config>/sessions/<name>/herdr.sock) — verified against herdr 0.8.0.
+func newHerdrSessionDir(t *testing.T) (socketPath, clientLog string) {
+	t.Helper()
+	dir := t.TempDir()
+	return filepath.Join(dir, "herdr.sock"), filepath.Join(dir, "herdr-client.log")
+}
+
+// spawnHerdrClient starts a sleeper that stands in for an attached herdr
+// client: it holds clientLog open for writing and carries the host terminal's
+// identity in its own env. Waits until the open fd is actually visible to the
+// discovery helper so the caller isn't racing the child's OpenFile.
+func spawnHerdrClient(t *testing.T, socketPath, clientLog string, env ...string) int {
+	t.Helper()
+	pid := spawnSleeperWithEnv(t, append([]string{
+		"PATH=/usr/bin:/bin",
+		"GO_WANT_LAUNCHER_HELPER_HOLD=" + clientLog,
+	}, env...))
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, got := range herdrClientPIDs(socketPath) {
+			if got == pid {
+				return pid
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("client pid %d never became visible as a writer of %s", pid, clientLog)
+	return 0
+}
+
+// TestReadLauncherEnv_Herdr_ResolvesHostFromAttachedClient pins the defect in
+// #1350: a herdr pane reached the macOS app with no term_program and no
+// host_bundle_id, so resolveActivator returned nil and a click did nothing.
+// The window belongs to the attached *client*, so the host identity has to be
+// read from that process — one indirection past the pane's own env, which
+// describes the (detached, reparented) server and is deliberately suppressed.
+func TestReadLauncherEnv_Herdr_ResolvesHostFromAttachedClient(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("herdr client resolution is darwin-only (lsof + ancestry)")
+	}
+	socketPath, clientLog := newHerdrSessionDir(t)
+	spawnHerdrClient(t, socketPath, clientLog,
+		"TERM_PROGRAM=iTerm.app",
+		"ITERM_SESSION_ID=w0t0p0-CLIENT",
+	)
+	agentPID := spawnSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"HERDR_PANE_ID=w1:p2",
+		"HERDR_SOCKET_PATH=" + socketPath,
+		// The stale, inherited identity a real pane carries — it describes the
+		// server's launch environment and must stay suppressed (#1348).
+		"TERM_PROGRAM=tmux",
+		"TMUX=/tmp/foreign-tmux,95058,0",
+		"TMUX_PANE=%0",
+	})
+
+	l := ReadLauncherEnv(agentPID)
+	if l == nil {
+		t.Fatal("expected non-nil launcher")
+	}
+	if l.TermProgram != "iTerm.app" {
+		t.Errorf("TermProgram: want the attached client's iTerm.app, got %q", l.TermProgram)
+	}
+	if l.ITermSessionID != "w0t0p0-CLIENT" {
+		t.Errorf("ITermSessionID: want the client's window selector, got %q", l.ITermSessionID)
+	}
+	// The pane address must survive the merge — it is what the activator
+	// focuses, and what resolveBackend keys the control path on.
+	if l.HerdrPaneID != "w1:p2" || l.HerdrSocketPath != socketPath {
+		t.Errorf("herdr address lost: pane=%q socket=%q", l.HerdrPaneID, l.HerdrSocketPath)
+	}
+	// The client's env carried no tmux, so the pane's inherited tmux identity
+	// must not reappear by this route — resolveBackend requires both herdr
+	// fields, and a surviving TmuxPane is the #1348 misroute.
+	if l.TmuxPane != "" || l.TmuxSocket != "" {
+		t.Errorf("inherited tmux identity survived: pane=%q socket=%q", l.TmuxPane, l.TmuxSocket)
+	}
+}
+
+// TestReadLauncherEnv_Herdr_DetachedSessionResolvesNoHost is the honest-failure
+// half: a herdr session with no attached client has no window anywhere, so the
+// launcher must stay herdr-only rather than guess. Verified live against herdr
+// 0.8.0 — a detached session's client log has no writer at all.
+func TestReadLauncherEnv_Herdr_DetachedSessionResolvesNoHost(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip()
+	}
+	socketPath, clientLog := newHerdrSessionDir(t)
+	// The log exists (the session ran once) but nobody holds it open.
+	if err := os.WriteFile(clientLog, []byte("detached\n"), 0o600); err != nil {
+		t.Fatalf("seed client log: %v", err)
+	}
+	agentPID := spawnSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"HERDR_PANE_ID=w1:p1",
+		"HERDR_SOCKET_PATH=" + socketPath,
+		"TERM_PROGRAM=kitty",
+		"KITTY_WINDOW_ID=42",
+	})
+	l := ReadLauncherEnv(agentPID)
+	if l == nil {
+		t.Fatal("expected non-nil launcher (the herdr address is still identity)")
+	}
+	if l.TermProgram != "" || l.HostBundleID != "" {
+		t.Errorf("no client is attached, so no host may be reported: %+v", l)
+	}
+	if l.KittyWindowID != "" || l.KittyListenOn != "" {
+		t.Errorf("inherited kitty identity must stay suppressed: %+v", l)
+	}
+	if l.HerdrPaneID != "w1:p1" {
+		t.Errorf("HerdrPaneID: got %q", l.HerdrPaneID)
+	}
+}
+
+// TestHerdrClientPIDs_MultipleClientsAreOrderedNewestFirst covers open question
+// 3 of #1350. herdr supports attaching from more than one place at once;
+// verified live (two clients on one session → two writers on the client log).
+// The newest attach is the window the user most recently chose, so the
+// discovery helper reports descending PID and the resolver takes the first
+// candidate that yields a host.
+func TestHerdrClientPIDs_MultipleClientsAreOrderedNewestFirst(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("herdr client resolution is darwin-only (lsof + ancestry)")
+	}
+	socketPath, clientLog := newHerdrSessionDir(t)
+	first := spawnHerdrClient(t, socketPath, clientLog)
+	second := spawnHerdrClient(t, socketPath, clientLog)
+
+	pids := herdrClientPIDs(socketPath)
+	if len(pids) < 2 {
+		t.Fatalf("want both attached clients, got %v (first=%d second=%d)", pids, first, second)
+	}
+	for i := 1; i < len(pids); i++ {
+		if pids[i-1] < pids[i] {
+			t.Errorf("want descending pids (newest attach first), got %v", pids)
+			break
+		}
+	}
+	if pids[0] != max(first, second) {
+		t.Errorf("newest client must win: got %d, want %d", pids[0], max(first, second))
+	}
+}
+
+// TestHerdrClientLogPath pins the addressing derivation: the client log sits
+// beside the socket, so the socket path the daemon already captures is a
+// complete key — no $HERDR_SESSION capture and no argv parsing needed
+// (open question 1 of #1350).
+func TestHerdrClientLogPath(t *testing.T) {
+	cases := map[string]string{
+		"/Users/t/.config/herdr/herdr.sock":                "/Users/t/.config/herdr/herdr-client.log",
+		"/Users/t/.config/herdr/sessions/probe/herdr.sock": "/Users/t/.config/herdr/sessions/probe/herdr-client.log",
+		"": "",
+	}
+	for socket, want := range cases {
+		if got := herdrClientLogPath(socket); got != want {
+			t.Errorf("herdrClientLogPath(%q) = %q, want %q", socket, got, want)
+		}
 	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -469,99 +469,28 @@ func TestReadLauncherEnv_Subprocess_JetBrainsImpliesTermProgram(t *testing.T) {
 // --- herdr click-to-focus (#1350) -------------------------------------------
 
 // newHerdrSessionDir returns a stand-in for a herdr session directory: the
-// socket path the pane's $HERDR_SOCKET_PATH points at, and the client log
-// that sits beside it. Mirrors the real layout, which is identical for the
-// default session (<config>/herdr.sock) and a named one
+// socket path the pane's $HERDR_SOCKET_PATH points at. The client log that
+// identifies an attached client sits beside it and is derived, never spelled
+// out again, so the layout has one definition (herdrClientLogPath). Mirrors the
+// real thing, which is identical for the default session
+// (<config>/herdr.sock) and a named one
 // (<config>/sessions/<name>/herdr.sock) — verified against herdr 0.8.0.
-func newHerdrSessionDir(t *testing.T) (socketPath, clientLog string) {
+func newHerdrSessionDir(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	return filepath.Join(dir, "herdr.sock"), filepath.Join(dir, "herdr-client.log")
-}
-
-// spawnHerdrClient starts a sleeper that stands in for an attached herdr
-// client: it holds clientLog open for writing and carries the host terminal's
-// identity in its own env. Waits until the open fd is actually visible to the
-// discovery helper so the caller isn't racing the child's OpenFile.
-func spawnHerdrClient(t *testing.T, socketPath, clientLog string, env ...string) int {
-	t.Helper()
-	pid := spawnSleeperWithEnv(t, append([]string{
-		"PATH=/usr/bin:/bin",
-		"GO_WANT_LAUNCHER_HELPER_HOLD=" + clientLog,
-	}, env...))
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		for _, got := range herdrClientPIDs(socketPath) {
-			if got == pid {
-				return pid
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	t.Fatalf("client pid %d never became visible as a writer of %s", pid, clientLog)
-	return 0
-}
-
-// TestReadLauncherEnv_Herdr_ResolvesHostFromAttachedClient pins the defect in
-// #1350: a herdr pane reached the macOS app with no term_program and no
-// host_bundle_id, so resolveActivator returned nil and a click did nothing.
-// The window belongs to the attached *client*, so the host identity has to be
-// read from that process — one indirection past the pane's own env, which
-// describes the (detached, reparented) server and is deliberately suppressed.
-func TestReadLauncherEnv_Herdr_ResolvesHostFromAttachedClient(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("herdr client resolution is darwin-only (lsof + ancestry)")
-	}
-	socketPath, clientLog := newHerdrSessionDir(t)
-	spawnHerdrClient(t, socketPath, clientLog,
-		"TERM_PROGRAM=iTerm.app",
-		"ITERM_SESSION_ID=w0t0p0-CLIENT",
-	)
-	agentPID := spawnSleeperWithEnv(t, []string{
-		"PATH=/usr/bin:/bin",
-		"HERDR_PANE_ID=w1:p2",
-		"HERDR_SOCKET_PATH=" + socketPath,
-		// The stale, inherited identity a real pane carries — it describes the
-		// server's launch environment and must stay suppressed (#1348).
-		"TERM_PROGRAM=tmux",
-		"TMUX=/tmp/foreign-tmux,95058,0",
-		"TMUX_PANE=%0",
-	})
-
-	l := ReadLauncherEnv(agentPID)
-	if l == nil {
-		t.Fatal("expected non-nil launcher")
-	}
-	if l.TermProgram != "iTerm.app" {
-		t.Errorf("TermProgram: want the attached client's iTerm.app, got %q", l.TermProgram)
-	}
-	if l.ITermSessionID != "w0t0p0-CLIENT" {
-		t.Errorf("ITermSessionID: want the client's window selector, got %q", l.ITermSessionID)
-	}
-	// The pane address must survive the merge — it is what the activator
-	// focuses, and what resolveBackend keys the control path on.
-	if l.HerdrPaneID != "w1:p2" || l.HerdrSocketPath != socketPath {
-		t.Errorf("herdr address lost: pane=%q socket=%q", l.HerdrPaneID, l.HerdrSocketPath)
-	}
-	// The client's env carried no tmux, so the pane's inherited tmux identity
-	// must not reappear by this route — resolveBackend requires both herdr
-	// fields, and a surviving TmuxPane is the #1348 misroute.
-	if l.TmuxPane != "" || l.TmuxSocket != "" {
-		t.Errorf("inherited tmux identity survived: pane=%q socket=%q", l.TmuxPane, l.TmuxSocket)
-	}
+	return filepath.Join(t.TempDir(), "herdr.sock")
 }
 
 // TestReadLauncherEnv_Herdr_DetachedSessionResolvesNoHost is the honest-failure
-// half: a herdr session with no attached client has no window anywhere, so the
-// launcher must stay herdr-only rather than guess. Verified live against herdr
-// 0.8.0 — a detached session's client log has no writer at all.
+// half of #1350: a herdr session with no attached client has no window
+// anywhere, so the launcher must stay herdr-only rather than guess. Verified
+// live against herdr 0.8.0 — a detached session's client log has no writer.
 func TestReadLauncherEnv_Herdr_DetachedSessionResolvesNoHost(t *testing.T) {
 	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
 		t.Skip()
 	}
-	socketPath, clientLog := newHerdrSessionDir(t)
+	socketPath := newHerdrSessionDir(t)
 	// The log exists (the session ran once) but nobody holds it open.
-	if err := os.WriteFile(clientLog, []byte("detached\n"), 0o600); err != nil {
+	if err := os.WriteFile(herdrClientLogPath(socketPath), []byte("detached\n"), 0o600); err != nil {
 		t.Fatalf("seed client log: %v", err)
 	}
 	agentPID := spawnSleeperWithEnv(t, []string{
@@ -586,35 +515,6 @@ func TestReadLauncherEnv_Herdr_DetachedSessionResolvesNoHost(t *testing.T) {
 	}
 }
 
-// TestHerdrClientPIDs_MultipleClientsAreOrderedNewestFirst covers open question
-// 3 of #1350. herdr supports attaching from more than one place at once;
-// verified live (two clients on one session → two writers on the client log).
-// The newest attach is the window the user most recently chose, so the
-// discovery helper reports descending PID and the resolver takes the first
-// candidate that yields a host.
-func TestHerdrClientPIDs_MultipleClientsAreOrderedNewestFirst(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("herdr client resolution is darwin-only (lsof + ancestry)")
-	}
-	socketPath, clientLog := newHerdrSessionDir(t)
-	first := spawnHerdrClient(t, socketPath, clientLog)
-	second := spawnHerdrClient(t, socketPath, clientLog)
-
-	pids := herdrClientPIDs(socketPath)
-	if len(pids) < 2 {
-		t.Fatalf("want both attached clients, got %v (first=%d second=%d)", pids, first, second)
-	}
-	for i := 1; i < len(pids); i++ {
-		if pids[i-1] < pids[i] {
-			t.Errorf("want descending pids (newest attach first), got %v", pids)
-			break
-		}
-	}
-	if pids[0] != max(first, second) {
-		t.Errorf("newest client must win: got %d, want %d", pids[0], max(first, second))
-	}
-}
-
 // TestHerdrClientLogPath pins the addressing derivation: the client log sits
 // beside the socket, so the socket path the daemon already captures is a
 // complete key — no $HERDR_SESSION capture and no argv parsing needed
@@ -628,44 +528,6 @@ func TestHerdrClientLogPath(t *testing.T) {
 	for socket, want := range cases {
 		if got := herdrClientLogPath(socket); got != want {
 			t.Errorf("herdrClientLogPath(%q) = %q, want %q", socket, got, want)
-		}
-	}
-}
-
-// TestParseHerdrClientWriters covers the FD-column rule: "holds the client log
-// open" is not the predicate, "holds it open for writing" is. A read-only
-// holder — a developer running `tail -f` on the log to debug herdr — is not a
-// client, and adopting its terminal as the herdr host would be the #1348
-// misroute with a new cause. The reader is deliberately given the higher PID
-// here, because the caller sorts descending and would otherwise prefer it.
-func TestParseHerdrClientWriters(t *testing.T) {
-	const out = `COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME
-herdr     26932 ingo    3w   REG   1,18      372 136170 /cfg/herdr/herdr-client.log
-tail      99999 ingo    3r   REG   1,18      372 136170 /cfg/herdr/herdr-client.log
-herdr     26940 ingo    9u   REG   1,18      372 136170 /cfg/herdr/herdr-client.log
-irrlichd    777 ingo    4w   REG   1,18      372 136170 /cfg/herdr/herdr-client.log`
-
-	got := parseHerdrClientWriters(out, 777)
-	want := map[int]bool{26932: true, 26940: true}
-	if len(got) != len(want) {
-		t.Fatalf("got %v, want exactly the writers %v", got, want)
-	}
-	for _, pid := range got {
-		if !want[pid] {
-			t.Errorf("pid %d must not be reported: readers are not clients, and the daemon is not its own client", pid)
-		}
-	}
-}
-
-// TestParseHerdrClientWriters_NoHolders is the detached case as lsof reports
-// it — header only, or nothing at all.
-func TestParseHerdrClientWriters_NoHolders(t *testing.T) {
-	for name, out := range map[string]string{
-		"empty":       "",
-		"header only": "COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME",
-	} {
-		if got := parseHerdrClientWriters(out, 1); len(got) != 0 {
-			t.Errorf("%s: want no clients, got %v", name, got)
 		}
 	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/process_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/process_darwin.go
@@ -117,25 +117,57 @@ func (darwinObserver) WriterOf(path string) (int, error) {
 		return 0, nil // file not open by any process
 	}
 
-	myPID := os.Getpid()
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) < 4 {
-			continue
-		}
-		if fields[0] == "COMMAND" { // header row
-			continue
-		}
-		pid, err := strconv.Atoi(fields[1])
-		if err != nil || pid <= 0 || pid == myPID {
-			continue
-		}
-		fd := fields[3] // e.g. "14w", "8299r" — writer ends with 'w'
-		if len(fd) > 0 && fd[len(fd)-1] == 'w' {
-			return pid, nil
+	for _, e := range parseLsofFDs(string(out), os.Getpid()) {
+		// e.g. "14w", "8299r" — this caller wants write mode only.
+		if e.FD[len(e.FD)-1] == 'w' {
+			return e.PID, nil
 		}
 	}
 	return 0, nil
+}
+
+// lsofFD is one open-file row of lsof's default table: the process holding the
+// file and its raw FD column (e.g. "14w", "3r", "9u", "5uW").
+type lsofFD struct {
+	PID int
+	FD  string
+}
+
+// Mode returns the access mode letter of the FD column — 'r', 'w' or 'u'
+// (read/write) — or 0 when the column has none.
+//
+// It reads the first non-digit rather than the last byte, because lsof may
+// append a lock character after the mode: a file locked for writing shows
+// "5uW", whose last byte is the lock, not the mode. Callers that only ever see
+// unlocked files are unaffected either way.
+func (e lsofFD) Mode() byte {
+	for i := 0; i < len(e.FD); i++ {
+		if e.FD[i] < '0' || e.FD[i] > '9' {
+			return e.FD[i]
+		}
+	}
+	return 0
+}
+
+// parseLsofFDs tokenizes lsof's default table, dropping the header row, rows
+// too short to carry an FD column, and self. It deliberately applies no mode
+// filter: WriterOf wants the first pure writer, while herdr client discovery
+// (osutil_darwin.go) also counts read/write handles, and keeping the predicate
+// at the call site is what stops those two rules from being confused for one.
+func parseLsofFDs(out string, self int) []lsofFD {
+	var entries []lsofFD
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 4 || fields[0] == "COMMAND" {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[1])
+		if err != nil || pid <= 0 || pid == self || fields[3] == "" {
+			continue
+		}
+		entries = append(entries, lsofFD{PID: pid, FD: fields[3]})
+	}
+	return entries
 }
 
 // EnvOf returns the whitelisted launcher env of pid via KERN_PROCARGS2 sysctl

--- a/core/adapters/inbound/agents/processlifecycle/process_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/process_darwin.go
@@ -158,11 +158,14 @@ func parseLsofFDs(out string, self int) []lsofFD {
 	var entries []lsofFD
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		fields := strings.Fields(line)
-		if len(fields) < 4 || fields[0] == "COMMAND" {
+		if len(fields) < 4 || fields[0] == "COMMAND" { // short row, or the header
 			continue
 		}
 		pid, err := strconv.Atoi(fields[1])
-		if err != nil || pid <= 0 || pid == self || fields[3] == "" {
+		if err != nil || pid <= 0 {
+			continue
+		}
+		if pid == self {
 			continue
 		}
 		entries = append(entries, lsofFD{PID: pid, FD: fields[3]})

--- a/core/adapters/outbound/control/controller.go
+++ b/core/adapters/outbound/control/controller.go
@@ -191,10 +191,16 @@ var cliBackends = map[backend]cliBackend{
 // which the daemon delegates to the macOS app. A session in tmux *inside*
 // iTerm resolves to tmux, because tmux owns the pty.
 //
-// herdr is checked before tmux despite that innermost-owns-the-pty rule: the
-// fields are mutually exclusive by construction, since ReadLauncherEnv gives a
-// herdr pane no other identity, so the order only matters as a safe default if
-// some future capture path populates both (#1348).
+// herdr is checked before tmux despite that innermost-owns-the-pty rule, and
+// that ordering is now load-bearing rather than merely a safe default. It used
+// to be unreachable — ReadLauncherEnv gave a herdr pane no other identity at
+// all — but since #1350 a herdr launcher carries the *client's* host identity,
+// and a client running inside tmux contributes real TmuxPane/TmuxSocket
+// fields. Those describe the window displaying the pane, not the pane, so
+// scripting them would type into the herdr TUI instead of the agent: exactly
+// the #1348 misroute, arriving by a different route. Reordering these two
+// checks reintroduces it. TestResolveBackend_HerdrWinsOverClientTmux is the
+// lock.
 func resolveBackend(l *session.Launcher) backend {
 	if l == nil {
 		return backendNone

--- a/core/adapters/outbound/control/controller_test.go
+++ b/core/adapters/outbound/control/controller_test.go
@@ -66,6 +66,37 @@ func TestResolveBackend(t *testing.T) {
 	}
 }
 
+// TestResolveBackend_HerdrWinsOverClientTmux locks the ordering resolveBackend's
+// doc comment now depends on. Since #1350 a herdr launcher legitimately carries
+// tmux/kitty fields — they come from the attached herdr *client*, and describe
+// the window displaying the pane rather than the pane itself. Scripting them
+// would type into the herdr TUI instead of the agent, so herdr must keep
+// winning; the case is no longer unreachable, and the "mutually exclusive by
+// construction" argument that used to make this ordering moot is gone.
+func TestResolveBackend_HerdrWinsOverClientTmux(t *testing.T) {
+	clientInTmux := &session.Launcher{
+		HerdrPaneID:     "w1:p2",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		// Real, correct, and the client's own — not inherited junk.
+		TermProgram: "ghostty",
+		TmuxPane:    "%3",
+		TmuxSocket:  "/tmp/tmux-501/default",
+	}
+	if got := resolveBackend(clientInTmux); got != backendHerdr {
+		t.Errorf("resolveBackend = %v, want backendHerdr", got)
+	}
+
+	clientInKitty := &session.Launcher{
+		HerdrPaneID:     "w1:p2",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		KittyListenOn:   "unix:/tmp/mykitty",
+		KittyWindowID:   "12",
+	}
+	if got := resolveBackend(clientInKitty); got != backendHerdr {
+		t.Errorf("resolveBackend = %v, want backendHerdr", got)
+	}
+}
+
 func TestCommandBuilders(t *testing.T) {
 	tmuxL := &session.Launcher{TmuxPane: "%3", TmuxSocket: "/tmp/tmux-501/default"}
 	tmuxNoSock := &session.Launcher{TmuxPane: "%7"}

--- a/core/application/services/launcher_backfill_internal_test.go
+++ b/core/application/services/launcher_backfill_internal_test.go
@@ -1,0 +1,79 @@
+package services
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestLauncherBackfillNeedsFor_HerdrHost covers the gap #1350 leaves open at
+// capture time: a herdr session whose PID was bound while nothing was attached
+// has no host to record, so the seed-time backfill has to be the path that
+// picks up a client attached since then.
+func TestLauncherBackfillNeedsFor_HerdrHost(t *testing.T) {
+	tests := map[string]struct {
+		launcher *session.Launcher
+		want     bool
+	}{
+		"herdr pane with no host": {
+			launcher: &session.Launcher{HerdrPaneID: "w1:p1", TTY: "/dev/ttys900"},
+			want:     true,
+		},
+		"herdr pane whose client already resolved": {
+			launcher: &session.Launcher{HerdrPaneID: "w1:p1", TermProgram: "ghostty"},
+			want:     false,
+		},
+		"herdr pane resolved only to a bundle id": {
+			launcher: &session.Launcher{HerdrPaneID: "w1:p1", HostBundleID: "md.obsidian"},
+			want:     false,
+		},
+		"a non-herdr session is never eligible": {
+			launcher: &session.Launcher{TTY: "/dev/ttys012"},
+			want:     false,
+		},
+	}
+	for name, tc := range tests {
+		if got := launcherBackfillNeedsFor(tc.launcher).herdrHost; got != tc.want {
+			t.Errorf("%s: herdrHost = %v, want %v", name, got, tc.want)
+		}
+	}
+}
+
+// TestApplyLauncherBackfill_HerdrHost pins that the backfill adopts the freshly
+// resolved client identity, and reports no change when the session is still
+// detached — writing empties over empties would churn UpdatedAt on every seed.
+func TestApplyLauncherBackfill_HerdrHost(t *testing.T) {
+	stored := &session.Launcher{
+		HerdrPaneID:     "w1:p1",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		TTY:             "/dev/ttys900",
+	}
+	needs := launcherBackfillNeedsFor(stored)
+
+	// Still detached: the re-read carries the herdr address and nothing else.
+	stillDetached := &session.Launcher{HerdrPaneID: "w1:p1", HerdrSocketPath: "/cfg/herdr/herdr.sock"}
+	if applyLauncherBackfill(stored, needs, stillDetached) {
+		t.Error("a still-detached session must report no update")
+	}
+	if stored.TermProgram != "" {
+		t.Errorf("no host may be invented: %+v", stored)
+	}
+
+	// A client attached since capture.
+	fresh := &session.Launcher{
+		HerdrPaneID:     "w1:p1",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		TermProgram:     "iTerm.app",
+		ITermSessionID:  "w0t0p0-CLIENT",
+		TTY:             "/dev/ttys012",
+	}
+	if !applyLauncherBackfill(stored, needs, fresh) {
+		t.Fatal("a newly attached client must report an update")
+	}
+	if stored.TermProgram != "iTerm.app" || stored.ITermSessionID != "w0t0p0-CLIENT" {
+		t.Errorf("host identity not adopted: %+v", stored)
+	}
+	if stored.HerdrPaneID != "w1:p1" {
+		t.Errorf("the pane address must survive: %+v", stored)
+	}
+}

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1226,9 +1226,14 @@ func (pm *PIDManager) handleAlivePIDState(state *session.SessionState) bool {
 //   - The host identity of a herdr pane (issue #1350), which is resolved from
 //     the attached herdr client rather than from the pane itself. A session
 //     that was detached when its PID was bound has no host to record, so this
-//     is the path by which one attached since then is picked up. Capture is
-//     still once-per-PID-bind and this runs at seed, so re-attaching a session
-//     to a *different* terminal is not noticed until the daemon restarts.
+//     is the path by which one attached since then is picked up. Two limits
+//     follow from where this runs, and both are deliberate for now: capture is
+//     once-per-PID-bind and this runs only at seed, so re-attaching a session
+//     to a *different* terminal is not noticed until the daemon restarts; and
+//     because the need is gated on *no* host being recorded, a host that did
+//     resolve is never re-checked afterwards. Refreshing it from the periodic
+//     liveness sweep instead would fix both — the daemon pushes launcher
+//     updates to clients, so nothing on the click path would have to change.
 func (pm *PIDManager) backfillLauncher(state *session.SessionState) {
 	if state.Launcher == nil {
 		pm.captureLauncher(state, state.PID)
@@ -1266,8 +1271,11 @@ type launcherBackfillNeeds struct {
 	tty, kittyPID, kittyListen, kittyWindow, herdrHost bool
 }
 
+// any reports whether anything needs refreshing. Compares against the zero
+// value rather than or-ing the fields, so a need added to the struct is covered
+// without a second edit here.
 func (n launcherBackfillNeeds) any() bool {
-	return n.tty || n.kittyPID || n.kittyListen || n.kittyWindow || n.herdrHost
+	return n != launcherBackfillNeeds{}
 }
 
 // launcherBackfillNeedsFor computes which fields of l are missing and

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1303,6 +1303,23 @@ func applyLauncherBackfill(l *session.Launcher, needs launcherBackfillNeeds, fre
 		l.TTY = fresh.TTY
 		updated = true
 	}
+	if applyKittyLauncherBackfill(l, needs, fresh) {
+		updated = true
+	}
+	// fresh was produced by the same reader, so its host fields are already
+	// the attached client's. A still-detached session yields none and this
+	// reports no change rather than writing empties over empties.
+	if needs.herdrHost && l.AdoptHostIdentity(fresh) {
+		updated = true
+	}
+	return updated
+}
+
+// applyKittyLauncherBackfill copies the three kitty fields fresh has that l is
+// missing per needs. Split out of applyLauncherBackfill so that function stays
+// one branch per *kind* of backfill rather than one per field.
+func applyKittyLauncherBackfill(l *session.Launcher, needs launcherBackfillNeeds, fresh *session.Launcher) bool {
+	updated := false
 	if needs.kittyPID && fresh.KittyPID != 0 {
 		l.KittyPID = fresh.KittyPID
 		updated = true
@@ -1313,12 +1330,6 @@ func applyLauncherBackfill(l *session.Launcher, needs launcherBackfillNeeds, fre
 	}
 	if needs.kittyWindow && fresh.KittyWindowID != "" {
 		l.KittyWindowID = fresh.KittyWindowID
-		updated = true
-	}
-	// fresh was produced by the same reader, so its host fields are already
-	// the attached client's. A still-detached session yields none and this
-	// reports no change rather than writing empties over empties.
-	if needs.herdrHost && l.AdoptHostIdentity(fresh) {
 		updated = true
 	}
 	return updated

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1223,6 +1223,12 @@ func (pm *PIDManager) handleAlivePIDState(state *session.SessionState) bool {
 //   - KittyPID: shipped to support per-process kitty activation (issue #326).
 //     Without it, KittyActivator on macOS falls back to bundle-level activation
 //     which can pick the wrong kitty when multiple kitty.app instances run.
+//   - The host identity of a herdr pane (issue #1350), which is resolved from
+//     the attached herdr client rather than from the pane itself. A session
+//     that was detached when its PID was bound has no host to record, so this
+//     is the path by which one attached since then is picked up. Capture is
+//     still once-per-PID-bind and this runs at seed, so re-attaching a session
+//     to a *different* terminal is not noticed until the daemon restarts.
 func (pm *PIDManager) backfillLauncher(state *session.SessionState) {
 	if state.Launcher == nil {
 		pm.captureLauncher(state, state.PID)
@@ -1257,11 +1263,11 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 // launcherBackfillNeeds tracks which Launcher fields are missing and should
 // be refreshed from a fresh env read.
 type launcherBackfillNeeds struct {
-	tty, kittyPID, kittyListen, kittyWindow bool
+	tty, kittyPID, kittyListen, kittyWindow, herdrHost bool
 }
 
 func (n launcherBackfillNeeds) any() bool {
-	return n.tty || n.kittyPID || n.kittyListen || n.kittyWindow
+	return n.tty || n.kittyPID || n.kittyListen || n.kittyWindow || n.herdrHost
 }
 
 // launcherBackfillNeedsFor computes which fields of l are missing and
@@ -1274,6 +1280,10 @@ func launcherBackfillNeedsFor(l *session.Launcher) launcherBackfillNeeds {
 		kittyPID:    isKitty && l.KittyPID == 0,
 		kittyListen: isKitty && l.KittyListenOn == "",
 		kittyWindow: isKitty && l.KittyWindowID == "",
+		// A herdr pane with no host recorded had no client attached when it
+		// was captured. Mutually exclusive with the kitty needs above, which
+		// all require TermProgram == "kitty".
+		herdrHost: l.HerdrPaneID != "" && l.TermProgram == "" && l.HostBundleID == "",
 	}
 }
 
@@ -1295,6 +1305,12 @@ func applyLauncherBackfill(l *session.Launcher, needs launcherBackfillNeeds, fre
 	}
 	if needs.kittyWindow && fresh.KittyWindowID != "" {
 		l.KittyWindowID = fresh.KittyWindowID
+		updated = true
+	}
+	// fresh was produced by the same reader, so its host fields are already
+	// the attached client's. A still-detached session yields none and this
+	// reports no change rather than writing empties over empties.
+	if needs.herdrHost && l.AdoptHostIdentity(fresh) {
 		updated = true
 	}
 	return updated

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -148,18 +148,15 @@ func (l *Launcher) AdoptHostIdentity(from *Launcher) bool {
 	if l == nil || from.IsEmpty() {
 		return false
 	}
-	before := *l
-	l.TermProgram = from.TermProgram
-	l.ITermSessionID = from.ITermSessionID
-	l.TermSessionID = from.TermSessionID
-	l.TmuxPane = from.TmuxPane
-	l.TmuxSocket = from.TmuxSocket
-	l.VSCodePID = from.VSCodePID
-	l.KittyListenOn = from.KittyListenOn
-	l.KittyWindowID = from.KittyWindowID
-	l.KittyPID = from.KittyPID
-	l.HostBundleID = from.HostBundleID
-	// Both sides must have one, and the guard is symmetric on purpose:
+	// Copy wholesale and put back the two fields that are the *pane's*, rather
+	// than listing the host fields one by one. The host set grows (it has
+	// eleven members and gains one per terminal integration) while the herdr
+	// address is closed at two, so enumerating the closed set is what keeps a
+	// newly added host field from being silently left behind here.
+	merged := *from
+	merged.HerdrPaneID = l.HerdrPaneID
+	merged.HerdrSocketPath = l.HerdrSocketPath
+	// TTY needs both sides, and the guard is symmetric on purpose:
 	// BackgroundAgent.Detached is computed from this field (#744), so a client
 	// resolved without a controlling tty must not erase the pane's own — and,
 	// in the other direction, an agent that genuinely has no controlling
@@ -167,10 +164,14 @@ func (l *Launcher) AdoptHostIdentity(from *Launcher) bool {
 	// pane's herdr env) must not be handed the client's tty and stop looking
 	// detached. The client's tty describes the client's window, not a terminal
 	// this process has.
-	if l.TTY != "" && from.TTY != "" {
-		l.TTY = from.TTY
+	if l.TTY == "" || from.TTY == "" {
+		merged.TTY = l.TTY
 	}
-	return *l != before
+	if merged == *l {
+		return false
+	}
+	*l = merged
+	return true
 }
 
 // SessionState represents the current state of a Claude Code or Copilot session.

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -74,9 +74,9 @@ func (s *subagentSummary) Equal(o *subagentSummary) bool {
 // and carries it here.
 //
 // The Herdr* fields are the one case where the other fields are not merely
-// best-effort but actively wrong, so a herdr pane is captured with those two
-// alone and every other field left zero. herdr's server owns each pane's pty,
-// outlives any attached client and is reparented to init, so every
+// best-effort but actively wrong *when read from the pane*, so a herdr pane
+// never keeps what its own environment claims. herdr's server owns each pane's
+// pty, outlives any attached client and is reparented to init, so every
 // terminal-identity var a pane inherits — $TERM_PROGRAM, $TMUX, $TMUX_PANE,
 // $KITTY_*, $VSCODE_PID — describes whatever environment the *server* was
 // started in, frozen at that moment and handed to every pane it will ever
@@ -84,6 +84,14 @@ func (s *subagentSummary) Equal(o *subagentSummary) bool {
 // application, and, for a server started inside tmux, made the backchannel
 // resolve to tmux and type into a foreign pane in a different window. This is
 // the rationale the capture and control paths refer back to (#1348).
+//
+// The host fields on a herdr launcher are therefore populated from a different
+// process: the attached herdr *client*, which is what actually owns a window
+// (#1350). Provenance is the whole distinction — the same TmuxPane that is a
+// misroute when inherited by a pane is the correct selector when it is the
+// client's own, because then the client really is running in that tmux pane.
+// A session with no attached client keeps the two Herdr* fields alone, which
+// is the honest answer: nothing is displaying it anywhere.
 type Launcher struct {
 	TermProgram    string `json:"term_program,omitempty"`     // $TERM_PROGRAM (e.g. iTerm.app, Apple_Terminal, vscode, cursor, ghostty, WezTerm, Hyper)
 	ITermSessionID string `json:"iterm_session_id,omitempty"` // $ITERM_SESSION_ID
@@ -125,6 +133,39 @@ func (l *Launcher) IsEmpty() bool {
 		l.TmuxSocket == "" && l.VSCodePID == 0 && l.TTY == "" &&
 		l.KittyListenOn == "" && l.KittyWindowID == "" && l.KittyPID == 0 &&
 		l.HostBundleID == "" && l.HerdrPaneID == "" && l.HerdrSocketPath == "")
+}
+
+// AdoptHostIdentity copies every host-window field of from onto l, leaving
+// l's own herdr address untouched, and reports whether anything changed. It is
+// how a herdr pane acquires the identity of the client that displays it: the
+// pane supplies the address to focus, the client supplies the window to raise.
+//
+// A nil or empty from is a no-op, so "no client attached" degrades to the
+// herdr-only launcher rather than to a half-populated one. Callers must only
+// pass a launcher they resolved from the attached client — the point of #1348
+// is that the pane's own environment is not that.
+func (l *Launcher) AdoptHostIdentity(from *Launcher) bool {
+	if l == nil || from.IsEmpty() {
+		return false
+	}
+	before := *l
+	l.TermProgram = from.TermProgram
+	l.ITermSessionID = from.ITermSessionID
+	l.TermSessionID = from.TermSessionID
+	l.TmuxPane = from.TmuxPane
+	l.TmuxSocket = from.TmuxSocket
+	l.VSCodePID = from.VSCodePID
+	l.KittyListenOn = from.KittyListenOn
+	l.KittyWindowID = from.KittyWindowID
+	l.KittyPID = from.KittyPID
+	l.HostBundleID = from.HostBundleID
+	// Only when the client actually has one: a client resolved without a
+	// controlling tty must not erase the pane's own, which is what
+	// BackgroundAgent.Detached is computed from (#744).
+	if from.TTY != "" {
+		l.TTY = from.TTY
+	}
+	return *l != before
 }
 
 // SessionState represents the current state of a Claude Code or Copilot session.

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -99,7 +99,7 @@ type Launcher struct {
 	TmuxPane       string `json:"tmux_pane,omitempty"`        // $TMUX_PANE
 	TmuxSocket     string `json:"tmux_socket,omitempty"`      // first `,`-field of $TMUX
 	VSCodePID      int    `json:"vscode_pid,omitempty"`       // $VSCODE_PID (vscode/cursor/windsurf)
-	TTY            string `json:"tty,omitempty"`              // controlling TTY of the agent process, e.g. "/dev/ttys021" — Terminal.app AppleScript matches tabs by this
+	TTY            string `json:"tty,omitempty"`              // controlling TTY, e.g. "/dev/ttys021" — Terminal.app AppleScript matches tabs by this. The agent process's own, except on a herdr session with a client attached, where it is the client's: that is the tab actually displaying the pane (#1350)
 	KittyListenOn  string `json:"kitty_listen_on,omitempty"`  // $KITTY_LISTEN_ON — kitty remote-control socket path
 	KittyWindowID  string `json:"kitty_window_id,omitempty"`  // $KITTY_WINDOW_ID — kitty window identifier
 	KittyPID       int    `json:"kitty_pid,omitempty"`        // $KITTY_PID — kitty.app process id (lets the activator target this specific instance when multiple kitties run)
@@ -159,10 +159,15 @@ func (l *Launcher) AdoptHostIdentity(from *Launcher) bool {
 	l.KittyWindowID = from.KittyWindowID
 	l.KittyPID = from.KittyPID
 	l.HostBundleID = from.HostBundleID
-	// Only when the client actually has one: a client resolved without a
-	// controlling tty must not erase the pane's own, which is what
-	// BackgroundAgent.Detached is computed from (#744).
-	if from.TTY != "" {
+	// Both sides must have one, and the guard is symmetric on purpose:
+	// BackgroundAgent.Detached is computed from this field (#744), so a client
+	// resolved without a controlling tty must not erase the pane's own — and,
+	// in the other direction, an agent that genuinely has no controlling
+	// terminal (a background agent detached into a pool, which inherits the
+	// pane's herdr env) must not be handed the client's tty and stop looking
+	// detached. The client's tty describes the client's window, not a terminal
+	// this process has.
+	if l.TTY != "" && from.TTY != "" {
 		l.TTY = from.TTY
 	}
 	return *l != before

--- a/core/domain/session/session_test.go
+++ b/core/domain/session/session_test.go
@@ -106,3 +106,65 @@ func TestSessionState_LauncherJSONRoundTrip(t *testing.T) {
 		t.Errorf("legacy session should have nil Launcher, got %+v", legacyOut.Launcher)
 	}
 }
+
+// TestLauncher_AdoptHostIdentity covers how a herdr pane acquires the window
+// it is displayed in (#1350): the pane keeps its own address, and every
+// host-window field comes from the attached client.
+func TestLauncher_AdoptHostIdentity(t *testing.T) {
+	pane := &Launcher{
+		HerdrPaneID:     "w1:p2",
+		HerdrSocketPath: "/cfg/herdr/sessions/probe/herdr.sock",
+		TTY:             "/dev/ttys900", // the pane's own pty, captured first
+	}
+	client := &Launcher{
+		TermProgram:    "iTerm.app",
+		ITermSessionID: "w0t0p0-CLIENT",
+		TTY:            "/dev/ttys012",
+		HostBundleID:   "com.googlecode.iterm2",
+	}
+	if !pane.AdoptHostIdentity(client) {
+		t.Fatal("adopting a populated client identity must report a change")
+	}
+	if pane.TermProgram != "iTerm.app" || pane.ITermSessionID != "w0t0p0-CLIENT" {
+		t.Errorf("host identity not adopted: %+v", pane)
+	}
+	if pane.TTY != "/dev/ttys012" {
+		t.Errorf("TTY: want the client's tab, got %q", pane.TTY)
+	}
+	if pane.HerdrPaneID != "w1:p2" || pane.HerdrSocketPath != "/cfg/herdr/sessions/probe/herdr.sock" {
+		t.Errorf("the pane's own address must survive: %+v", pane)
+	}
+}
+
+// TestLauncher_AdoptHostIdentity_NoClientIsNoOp is the honest-failure lock: a
+// detached herdr session has no window anywhere, and must keep its pane-only
+// launcher rather than end up half-populated.
+func TestLauncher_AdoptHostIdentity_NoClientIsNoOp(t *testing.T) {
+	for name, from := range map[string]*Launcher{
+		"nil":   nil,
+		"empty": {},
+	} {
+		pane := &Launcher{HerdrPaneID: "w1:p1", TTY: "/dev/ttys900"}
+		if pane.AdoptHostIdentity(from) {
+			t.Errorf("%s: must report no change", name)
+		}
+		if pane.TTY != "/dev/ttys900" || pane.HerdrPaneID != "w1:p1" {
+			t.Errorf("%s: launcher was mutated: %+v", name, pane)
+		}
+	}
+}
+
+// TestLauncher_AdoptHostIdentity_KeepsOwnTTYWhenClientHasNone pins the reason
+// the TTY copy is guarded: BackgroundAgent.Detached is computed from this
+// field (#744), so a client resolved without a controlling terminal must not
+// erase the pane's own pty and make a live session look detached.
+func TestLauncher_AdoptHostIdentity_KeepsOwnTTYWhenClientHasNone(t *testing.T) {
+	pane := &Launcher{HerdrPaneID: "w1:p1", TTY: "/dev/ttys900"}
+	pane.AdoptHostIdentity(&Launcher{TermProgram: "ghostty"})
+	if pane.TTY != "/dev/ttys900" {
+		t.Errorf("TTY: want the pane's own pty preserved, got %q", pane.TTY)
+	}
+	if pane.TermProgram != "ghostty" {
+		t.Errorf("TermProgram: want ghostty, got %q", pane.TermProgram)
+	}
+}

--- a/core/domain/session/session_test.go
+++ b/core/domain/session/session_test.go
@@ -168,3 +168,22 @@ func TestLauncher_AdoptHostIdentity_KeepsOwnTTYWhenClientHasNone(t *testing.T) {
 		t.Errorf("TermProgram: want ghostty, got %q", pane.TermProgram)
 	}
 }
+
+// TestLauncher_AdoptHostIdentity_TTYlessAgentStaysTTYless is the other half of
+// the TTY guard, and the one the first cut of #1350 got wrong: a background
+// agent detached into a pool inherits the pane's herdr env but genuinely has no
+// controlling terminal. Handing it the client's tty would make
+// BackgroundAgent.Detached compute false and hide the "detached" badge #744
+// exists to show — for an agent with no window the user can ever reach.
+func TestLauncher_AdoptHostIdentity_TTYlessAgentStaysTTYless(t *testing.T) {
+	detachedAgent := &Launcher{HerdrPaneID: "w1:p1", HerdrSocketPath: "/cfg/herdr/herdr.sock"}
+	detachedAgent.AdoptHostIdentity(&Launcher{TermProgram: "iTerm.app", TTY: "/dev/ttys012"})
+	if detachedAgent.TTY != "" {
+		t.Errorf("an agent with no controlling terminal must not adopt the client's: got %q", detachedAgent.TTY)
+	}
+	// The rest of the host identity is still adopted — the window exists even
+	// though this process has no terminal of its own.
+	if detachedAgent.TermProgram != "iTerm.app" {
+		t.Errorf("TermProgram: want iTerm.app, got %q", detachedAgent.TermProgram)
+	}
+}

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/HerdrActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/HerdrActivator.swift
@@ -46,6 +46,14 @@ struct HerdrActivator: HostActivator {
         // ordering it second costs a redraw, not a wrong window. This is the
         // one place this activator deliberately differs from TmuxActivator,
         // which runs its selection before delegating.
+        //
+        // The guarantee is only as synchronous as `inner`. When the herdr
+        // client is itself inside tmux, `inner` is TmuxActivator, which returns
+        // immediately and does its own raise on a background queue — so that
+        // composed path inherits tmux's existing async raise and this ordering
+        // buys nothing. Fixing it means changing TmuxActivator's ordering for
+        // every tmux user, which is out of scope here; herdr-in-tmux is the
+        // rare nesting, and the plain path is the one this protects.
         let activated = inner.activate(session)
 
         DispatchQueue.global(qos: .userInitiated).async {

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/HerdrActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/HerdrActivator.swift
@@ -1,0 +1,94 @@
+import Foundation
+import OSLog
+
+/// Decorator that selects the session's herdr pane, then delegates to the
+/// activator for the terminal that displays it.
+///
+/// herdr is a persistent multiplexer: its server owns every pane's pty,
+/// outlives any attached client and is reparented to init. So the window a
+/// pane is shown in belongs to a *client* process, not to the pane's own
+/// process tree — the daemon resolves that client and reports its identity in
+/// the launcher's ordinary host fields, which is what `inner` was built from
+/// (issue #1350). A session with no attached client resolves to no host at all
+/// and never reaches this type: there is genuinely no window to raise.
+///
+/// `SessionLauncher.resolveActivator` wraps the resolved inner activator with
+/// this type when `session.launcher?.herdrPaneID` is set. `HerdrActivator` is
+/// never stored in the registry directly.
+struct HerdrActivator: HostActivator {
+    private static let logger = Logger(subsystem: "io.irrlicht.app", category: "HerdrActivator")
+
+    // Forwarded from the wrapped activator so bundleID(for:) and logging
+    // continue to work after wrapping.
+    var termProgram: String { inner.termProgram }
+    var bundleID: String    { inner.bundleID }
+
+    let inner: HostActivator
+
+    func activate(_ session: SessionState) -> Bool {
+        guard let pane = session.launcher?.herdrPaneID,
+              let socket = session.launcher?.herdrSocketPath,
+              !pane.isEmpty, !socket.isEmpty
+        else {
+            // Both halves are required: a pane address like "w1:p1" exists on
+            // every running herdr server, so without the socket the focus
+            // could land in an unrelated session. Mirrors the daemon's
+            // resolveBackend guard.
+            Self.logger.info("herdr: missing pane or socket — delegating directly")
+            return inner.activate(session)
+        }
+
+        // Raise the window FIRST, synchronously, inside the click handler's
+        // user-attention window: macOS denies a cross-app activation issued
+        // after async work and lets the previous frontmost app reclaim focus
+        // (the "raise then drop back" symptom documented on KittyActivator).
+        // Pane selection follows async — herdr redraws the pane in place, so
+        // ordering it second costs a redraw, not a wrong window. This is the
+        // one place this activator deliberately differs from TmuxActivator,
+        // which runs its selection before delegating.
+        let activated = inner.activate(session)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            Self.focusPane(pane: pane, socket: socket)
+        }
+        return activated
+    }
+
+    /// Runs `herdr agent focus <pane>` against the server at `socket`.
+    ///
+    /// Note the verb: `herdr pane focus` is *directional* ("focus a
+    /// neighbouring pane") and would move the user somewhere else entirely.
+    /// Addressing rides in the environment because herdr's CLI has no socket
+    /// flag. Exit status is meaningful — an unknown pane exits 1 (verified
+    /// against herdr 0.8.0).
+    private static func focusPane(pane: String, socket: String) {
+        guard let herdr = herdrPath else {
+            logger.info("herdr binary not found; pane will not be selected")
+            return
+        }
+        let result = ProcessRunner.run(
+            herdr,
+            args: ["agent", "focus", pane],
+            env: ["HERDR_SOCKET_PATH": socket],
+            timeout: 3.0
+        )
+        if result.status != 0 {
+            logger.info("herdr agent focus failed (status \(result.status)): \(result.stderr, privacy: .public)")
+        }
+    }
+
+    /// Absolute path to the `herdr` binary, or nil when it isn't installed.
+    /// Resolved from a candidate list rather than via `/usr/bin/env` because a
+    /// GUI app's PATH is LaunchServices', not the user's login shell's — and
+    /// herdr's own installer puts it in ~/.local/bin. Same approach as
+    /// `KittyActivator.kittenPath`.
+    private static let herdrPath: String? = {
+        let home = ProcessInfo.processInfo.environment["HOME"] ?? ""
+        let candidates = [
+            home + "/.local/bin/herdr",  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
+            "/opt/homebrew/bin/herdr",  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
+            "/usr/local/bin/herdr",  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
+        ]
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }()
+}

--- a/platforms/macos/Irrlicht/Managers/Launcher/ProcessRunner.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/ProcessRunner.swift
@@ -15,11 +15,24 @@ enum ProcessRunner {
     /// Launches `launchPath` with `args` and blocks until the process exits or
     /// `timeout` expires. On timeout the process is terminated and `status` is
     /// set to -1.
+    ///
+    /// `env` is layered onto the current environment rather than replacing it,
+    /// so a CLI that still needs $HOME or $PATH keeps them. It exists for tools
+    /// that take their target out of the environment instead of argv — herdr
+    /// addresses its server through $HERDR_SOCKET_PATH and has no socket flag.
     @discardableResult
-    static func run(_ launchPath: String, args: [String], timeout: TimeInterval = 3.0) -> Result {
+    static func run(
+        _ launchPath: String,
+        args: [String],
+        env: [String: String]? = nil,
+        timeout: TimeInterval = 3.0
+    ) -> Result {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: launchPath)
         proc.arguments = args
+        if let env, !env.isEmpty {
+            proc.environment = ProcessInfo.processInfo.environment.merging(env) { _, new in new }
+        }
 
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -51,8 +51,16 @@ enum SessionLauncher {
             // A herdr pane with no host is the expected "nothing is displaying
             // this session" case rather than a capture failure, so name it:
             // otherwise a detached multiplexer session is indistinguishable
-            // from a launcher we simply failed to read (#1350).
-            let herdr = session.launcher?.herdrPaneID.map { "herdr_pane=\($0), no attached client" } ?? "herdr_pane=nil"
+            // from a launcher we simply failed to read (#1350). Only claim
+            // "no attached client" when the host fields really are empty —
+            // a resolved client whose terminal has no registry entry also
+            // lands here, and pointing that at a missing client would send
+            // whoever debugs it looking for the wrong thing.
+            let herdr = session.launcher?.herdrPaneID.map { pane in
+                let unresolved = (session.launcher?.termProgram ?? "").isEmpty
+                    && (session.launcher?.hostBundleID ?? "").isEmpty
+                return "herdr_pane=\(pane), \(unresolved ? "no attached client" : "client resolved but its host has no activator")"
+            } ?? "herdr_pane=nil"
             logger.info("no activator for session \(session.id, privacy: .public) (term_program=\(tp, privacy: .public), host_bundle_id=\(bid, privacy: .public), \(herdr, privacy: .public))")
             return
         }

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -48,23 +48,29 @@ enum SessionLauncher {
         guard let activator = resolveActivator(for: session.launcher) else {
             let tp = session.launcher?.termProgram ?? "nil"
             let bid = session.launcher?.hostBundleID ?? "nil"
-            // A herdr pane with no host is the expected "nothing is displaying
-            // this session" case rather than a capture failure, so name it:
-            // otherwise a detached multiplexer session is indistinguishable
-            // from a launcher we simply failed to read (#1350). Only claim
-            // "no attached client" when the host fields really are empty —
-            // a resolved client whose terminal has no registry entry also
-            // lands here, and pointing that at a missing client would send
-            // whoever debugs it looking for the wrong thing.
-            let herdr = session.launcher?.herdrPaneID.map { pane in
-                let unresolved = (session.launcher?.termProgram ?? "").isEmpty
-                    && (session.launcher?.hostBundleID ?? "").isEmpty
-                return "herdr_pane=\(pane), \(unresolved ? "no attached client" : "client resolved but its host has no activator")"
-            } ?? "herdr_pane=nil"
+            let herdr = herdrDiagnostic(for: session.launcher)
             logger.info("no activator for session \(session.id, privacy: .public) (term_program=\(tp, privacy: .public), host_bundle_id=\(bid, privacy: .public), \(herdr, privacy: .public))")
             return
         }
         _ = activator.activate(session)
+    }
+
+    /// Explains, for the "no activator" log, why a herdr session produced no
+    /// window. A pane with no host at all is the expected "nothing is
+    /// displaying this session" case rather than a capture failure, and saying
+    /// so is what makes a detached multiplexer session distinguishable from a
+    /// launcher we simply failed to read (#1350). It only claims that when the
+    /// host fields really are empty: a client that *was* resolved, whose
+    /// terminal has no registry entry, lands here too, and pointing that at a
+    /// missing client would send whoever debugs it looking for the wrong thing.
+    ///
+    /// Exposed for tests, which is the only way either wording is checked.
+    static func herdrDiagnostic(for launcher: Launcher?) -> String {
+        guard let pane = launcher?.herdrPaneID else { return "herdr_pane=nil" }
+        let unresolved = (launcher?.termProgram ?? "").isEmpty
+            && (launcher?.hostBundleID ?? "").isEmpty
+        let why = unresolved ? "no attached client" : "client resolved but its host has no activator"
+        return "herdr_pane=\(pane), \(why)"
     }
 
     /// Selects the activator for a launcher without performing activation
@@ -91,8 +97,7 @@ enum SessionLauncher {
         if base == nil, let bundleID = launcher?.hostBundleID, !bundleID.isEmpty {
             base = AXTitleMatchActivator(termProgram: launcher?.termProgram ?? "", bundleID: bundleID)
         }
-        guard let base = base else { return nil }
-        var activator: HostActivator = base
+        guard var activator: HostActivator = base else { return nil }
         if launcher?.tmuxPane != nil {
             activator = TmuxActivator(inner: activator)
         }

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -48,7 +48,12 @@ enum SessionLauncher {
         guard let activator = resolveActivator(for: session.launcher) else {
             let tp = session.launcher?.termProgram ?? "nil"
             let bid = session.launcher?.hostBundleID ?? "nil"
-            logger.info("no activator for session \(session.id, privacy: .public) (term_program=\(tp, privacy: .public), host_bundle_id=\(bid, privacy: .public))")
+            // A herdr pane with no host is the expected "nothing is displaying
+            // this session" case rather than a capture failure, so name it:
+            // otherwise a detached multiplexer session is indistinguishable
+            // from a launcher we simply failed to read (#1350).
+            let herdr = session.launcher?.herdrPaneID.map { "herdr_pane=\($0), no attached client" } ?? "herdr_pane=nil"
+            logger.info("no activator for session \(session.id, privacy: .public) (term_program=\(tp, privacy: .public), host_bundle_id=\(bid, privacy: .public), \(herdr, privacy: .public))")
             return
         }
         _ = activator.activate(session)
@@ -61,7 +66,15 @@ enum SessionLauncher {
     /// have no registry entry (e.g. a terminal inside Obsidian) — bringing the
     /// host app/window to the front, not a specific pane. The result is wrapped
     /// in `TmuxActivator` when the session lives in a tmux pane so the correct
-    /// pane is selected before the host window is raised.
+    /// pane is selected before the host window is raised, and in
+    /// `HerdrActivator` when it lives in a herdr pane. The two compose: a herdr
+    /// client can itself be running inside tmux, in which case both selections
+    /// are needed and neither substitutes for the other.
+    ///
+    /// For a herdr session the host fields were resolved from the attached
+    /// herdr client, not from the agent's own process tree (#1350) — so a
+    /// detached session has no host, falls through to nil, and honestly does
+    /// nothing rather than raising some other window.
     static func resolveActivator(for launcher: Launcher?) -> HostActivator? {
         var base: HostActivator?
         if let tp = launcher?.termProgram {
@@ -71,7 +84,14 @@ enum SessionLauncher {
             base = AXTitleMatchActivator(termProgram: launcher?.termProgram ?? "", bundleID: bundleID)
         }
         guard let base = base else { return nil }
-        return launcher?.tmuxPane != nil ? TmuxActivator(inner: base) : base
+        var activator: HostActivator = base
+        if launcher?.tmuxPane != nil {
+            activator = TmuxActivator(inner: activator)
+        }
+        if launcher?.herdrPaneID != nil {
+            activator = HerdrActivator(inner: activator)
+        }
+        return activator
     }
 
     /// Returns the macOS bundle ID for a `$TERM_PROGRAM` value, or nil

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -720,6 +720,16 @@ struct Launcher: Codable, Hashable {
     /// terminal embedded in Obsidian). Lets `SessionLauncher` build a generic
     /// title-match activator for hosts that have no registry entry.
     let hostBundleID: String?
+    /// $HERDR_PANE_ID — the pane address to focus inside the herdr session
+    /// (e.g. "w1:p2"). Present only for a session running in a herdr pane; the
+    /// host fields above then describe the herdr *client* displaying it, which
+    /// is a different process from the agent (see the daemon's session.Launcher).
+    let herdrPaneID: String?
+    /// $HERDR_SOCKET_PATH — addresses the herdr server that owns the pane.
+    /// Required alongside the pane id: a bare pane address like "w1:p1" exists
+    /// on every running server, so focusing without the socket could target a
+    /// pane in an unrelated session.
+    let herdrSocketPath: String?
 
     enum CodingKeys: String, CodingKey {
         case termProgram    = "term_program"
@@ -732,6 +742,8 @@ struct Launcher: Codable, Hashable {
         case kittyWindowID  = "kitty_window_id"
         case kittyPID       = "kitty_pid"
         case hostBundleID   = "host_bundle_id"
+        case herdrPaneID    = "herdr_pane_id"
+        case herdrSocketPath = "herdr_socket_path"
     }
 }
 

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -474,6 +474,27 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertEqual(result.stdout, "has-home")
     }
 
+    // Both wordings of the "no activator" diagnostic (#1350). The distinction
+    // is the whole reason the line exists: "no attached client" is a real,
+    // expected state, while a resolved client whose terminal has no registry
+    // entry is a gap in the registry — and sending someone to look for a
+    // missing client in that case wastes the debugging session the log was
+    // added to shorten.
+    func testHerdrDiagnosticDistinguishesDetachedFromUnregisteredHost() throws {
+        func launcher(_ json: String) throws -> Launcher {
+            try JSONDecoder().decode(Launcher.self, from: Data(json.utf8))
+        }
+        let detached = try launcher(#"{"herdr_pane_id":"w1:p1"}"#)
+        XCTAssertEqual(SessionLauncher.herdrDiagnostic(for: detached),
+                       "herdr_pane=w1:p1, no attached client")
+
+        let unregisteredHost = try launcher(#"{"herdr_pane_id":"w1:p1","term_program":"foot"}"#)
+        XCTAssertEqual(SessionLauncher.herdrDiagnostic(for: unregisteredHost),
+                       "herdr_pane=w1:p1, client resolved but its host has no activator")
+
+        XCTAssertEqual(SessionLauncher.herdrDiagnostic(for: nil), "herdr_pane=nil")
+    }
+
     func testResolveActivatorHerdrComposesWithTmux() throws {
         let nested = try JSONDecoder().decode(Launcher.self, from: Data(#"""
         {"term_program":"ghostty","tmux_pane":"%3","tmux_socket":"/tmp/tmux-501/default",

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -378,6 +378,9 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertEqual(SessionLauncher.bundleID(for: "cmux"),      "com.cmuxterm.app")
         // tmux is a decorator, not a standalone term_program — no registry entry.
         XCTAssertNil(SessionLauncher.bundleID(for: "tmux"))
+        // herdr likewise: the host comes from the attached client, so herdr
+        // never names a bundle of its own (#1350).
+        XCTAssertNil(SessionLauncher.bundleID(for: "herdr"))
         XCTAssertNil(SessionLauncher.bundleID(for: nil))
         XCTAssertNil(SessionLauncher.bundleID(for: "unknown-terminal"))
     }
@@ -408,6 +411,78 @@ final class SessionManagerTests: XCTestCase {
         // Nothing identifying → no activator (silent no-op, as before).
         XCTAssertNil(SessionLauncher.resolveActivator(for: try launcher("{}")))
         XCTAssertNil(SessionLauncher.resolveActivator(for: nil))
+    }
+
+    // A session running in a herdr pane (#1350). herdr's server owns the pane's
+    // pty and outlives any attached client, so the window belongs to the client
+    // — the daemon resolves that client and reports its identity in the ordinary
+    // host fields, which is what makes an activator resolvable at all here. The
+    // pane address then rides along so the right pane is selected inside it.
+    func testResolveActivatorHerdrPaneWrapsHostActivator() throws {
+        let attached = try JSONDecoder().decode(Launcher.self, from: Data(#"""
+        {"term_program":"iTerm.app","iterm_session_id":"w0t0p0-CLIENT",
+         "herdr_pane_id":"w1:p2","herdr_socket_path":"/cfg/herdr/sessions/probe/herdr.sock"}
+        """#.utf8))
+
+        // Wire contract: both herdr keys decode.
+        XCTAssertEqual(attached.herdrPaneID, "w1:p2")
+        XCTAssertEqual(attached.herdrSocketPath, "/cfg/herdr/sessions/probe/herdr.sock")
+
+        // The host activator is wrapped, and still reports the inner host so
+        // the window that actually gets raised is the client's.
+        let resolved = SessionLauncher.resolveActivator(for: attached)
+        XCTAssertTrue(resolved is HerdrActivator)
+        XCTAssertEqual(resolved?.bundleID, "com.googlecode.iterm2")
+        XCTAssertEqual(resolved?.termProgram, "iTerm.app")
+    }
+
+    // The honest-failure half: a herdr session with no attached client has no
+    // host anywhere, so it must resolve to nothing rather than raise whatever
+    // application happens to be nearby — the misroute #1348 removed.
+    func testResolveActivatorHerdrDetachedResolvesToNil() throws {
+        let detached = try JSONDecoder().decode(Launcher.self, from: Data(#"""
+        {"herdr_pane_id":"w1:p1","herdr_socket_path":"/cfg/herdr/herdr.sock"}
+        """#.utf8))
+        XCTAssertEqual(detached.herdrPaneID, "w1:p1")
+        XCTAssertNil(detached.termProgram)
+        XCTAssertNil(SessionLauncher.resolveActivator(for: detached))
+    }
+
+    // herdr and tmux compose: a herdr client can itself be running in a tmux
+    // pane, and both selections are needed to land in the right window. Pins
+    // that adding the herdr decorator did not replace the tmux one.
+    // ProcessRunner gained an `env:` parameter for herdr, which addresses its
+    // server through $HERDR_SOCKET_PATH because its CLI has no socket flag
+    // (#1350). Layering, not replacing, is the contract: a CLI that still needs
+    // $HOME or $PATH must keep them.
+    func testProcessRunnerLayersEnvOntoCurrentEnvironment() throws {
+        let result = ProcessRunner.run("/bin/sh",  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
+                                       args: ["-c", "printf '%s|%s' \"$HERDR_SOCKET_PATH\" \"${HOME:+has-home}\""],
+                                       env: ["HERDR_SOCKET_PATH": "/cfg/herdr/herdr.sock"],
+                                       timeout: 5.0)
+        XCTAssertEqual(result.status, 0, "stderr: \(result.stderr)")
+        XCTAssertEqual(result.stdout, "/cfg/herdr/herdr.sock|has-home")
+    }
+
+    // Omitting `env:` must leave the child on the inherited environment — the
+    // path every existing activator (tmux, kitty) still takes.
+    func testProcessRunnerWithoutEnvInheritsEnvironment() throws {
+        let result = ProcessRunner.run("/bin/sh",  // NOSONAR (swift:S1075) — local filesystem/binary path, not a network endpoint
+                                       args: ["-c", "printf '%s' \"${HOME:+has-home}\""],
+                                       timeout: 5.0)
+        XCTAssertEqual(result.status, 0, "stderr: \(result.stderr)")
+        XCTAssertEqual(result.stdout, "has-home")
+    }
+
+    func testResolveActivatorHerdrComposesWithTmux() throws {
+        let nested = try JSONDecoder().decode(Launcher.self, from: Data(#"""
+        {"term_program":"ghostty","tmux_pane":"%3","tmux_socket":"/tmp/tmux-501/default",
+         "herdr_pane_id":"w1:p2","herdr_socket_path":"/cfg/herdr/herdr.sock"}
+        """#.utf8))
+        let resolved = SessionLauncher.resolveActivator(for: nested)
+        let herdr = try XCTUnwrap(resolved as? HerdrActivator)
+        XCTAssertTrue(herdr.inner is TmuxActivator)
+        XCTAssertEqual(herdr.bundleID, "com.mitchellh.ghostty")
     }
 
     func testJetBrainsActivatorRunningBundleIDIsNilOrKnown() {


### PR DESCRIPTION
Closes #1350 — Phase 3 of #1348.

## The problem

#1349 removed the *misroute*: a herdr pane no longer inherits a stranger's
`term_program`, so the macOS app stopped raising an unrelated application. It
could not supply the *right* one — the pane's own process tree leads to the
herdr server, which is detached, reparented to init, and often has no terminal
at all. So `resolveActivator` got nothing, logged "no activator", and a click
did nothing.

## The answer to each open question, from live herdr 0.8.0

The issue left three design questions open. All three were settled by probing a
running herdr rather than by picking a default.

**1 — Matching client → session.** The client log sits beside the server socket,
so `$HERDR_SOCKET_PATH` (already captured, #1349) is a *complete* key. No
`$HERDR_SESSION` capture, and no argv parsing — which matters because argv
differs between `herdr --session <name>`, a bare `herdr` on the default session,
and `herdr session attach <name>`. The directory layout is identical for the
default session (`<config>/herdr.sock`) and named ones
(`<config>/sessions/<name>/herdr.sock`).

**2 — No attached client.** Report honestly. Verified: a detached session has no
writer on that file at all, so it resolves to no host, and the app logs a
"no attached client" reason instead of raising something arbitrary.

```
$ lsof .../sessions/irrlicht/herdr-client.log   # attached
herdr  26932 ingo 3w REG ... /Users/ingo/.config/herdr/sessions/irrlicht/herdr-client.log
$ lsof .../sessions/factory/herdr-client.log    # detached
$                                               # (nothing, exit 1)
```

**3 — Multiple clients.** Real and detectable — two clients attached to one
session produce two writers (verified by driving two clients through tmux). The
most recent attach wins: it is the window the user most recently chose, and PIDs
ascend, so discovery reports descending PID. A client that resolves to no local
GUI host — an SSH client — is skipped rather than reported.

**4 — Remote sessions** remain out of scope, as the issue states.

## What changed

**Daemon.** For a herdr pane, `ReadLauncherEnv` resolves the attached client and
reads the host identity from *that* process, through the same `hostIdentity`
sequence (whitelisted env → ancestry fallbacks → controlling tty) used for a
directly-hosted agent. The result is merged by
`session.Launcher.AdoptHostIdentity`, which leaves the pane's own herdr address
untouched.

Only *writers* of the client log count. "Holds it open" would also match a
`tail -f` reader debugging herdr — which, being newer, would sort first and have
its terminal adopted as the host of every session on that server.

Provenance is the whole distinction from #1348: the same `TmuxPane` that is a
misroute when *inherited by a pane* is the correct selector when it is the
*client's own*, because then the client really is running in that tmux pane.
Control is unaffected — `resolveBackend` requires both Herdr fields and tests
them first. That ordering used to be moot ("mutually exclusive by construction")
and is now load-bearing, so the comment saying otherwise is corrected and
`TestResolveBackend_HerdrWinsOverClientTmux` locks it.

**macOS.** `Launcher` decodes the two herdr keys; a new `HerdrActivator`
decorator runs `herdr agent focus <pane>` (note: `herdr pane focus` is
*directional* and is not the verb wanted) against the session's socket, and
`resolveActivator` chains it with `TmuxActivator` rather than replacing it, so a
herdr client running inside tmux still gets both selections.

`HerdrActivator` raises the window synchronously *before* selecting the pane —
the ordering `KittyActivator` documents, because macOS denies a cross-app
activation issued after async work. That guarantee is only as synchronous as its
inner activator, so the herdr-in-tmux composition inherits `TmuxActivator`'s
existing async raise; noted in the code rather than silently claimed.

## Red-first

**Go** — `TestReadLauncherEnv_Herdr_ResolvesHostFromAttachedClient`, wiring disabled:

```
--- FAIL: TestReadLauncherEnv_Herdr_ResolvesHostFromAttachedClient (0.38s)
    osutil_darwin_test.go:416: TermProgram: want the attached client's iTerm.app, got ""
    osutil_darwin_test.go:419: ITermSessionID: want the client's window selector, got ""
```

**Go** — `TestLauncher_AdoptHostIdentity_TTYlessAgentStaysTTYless`, against the
one-directional TTY guard the first cut shipped:

```
--- FAIL: TestLauncher_AdoptHostIdentity_TTYlessAgentStaysTTYless (0.00s)
    session_test.go:182: an agent with no controlling terminal must not adopt the client's: got "/dev/ttys012"
```

**Swift** — with the decorator wrapping disabled:

```
error: testResolveActivatorHerdrPaneWrapsHostActivator : XCTAssertTrue failed
error: testResolveActivatorHerdrComposesWithTmux : XCTUnwrap failed: expected non-nil value of type "HerdrActivator"
```

**Locks** — pass by construction, stated so their green is not read as a
red-first proof: the three #1348 suppression tests
(`TestLauncherFromEnv_HerdrSuppressesInheritedIdentity`,
`...SuppressionIsScoped`, `TestReadLauncherEnv_Subprocess_Herdr`),
`TestReadLauncherEnv_Herdr_DetachedSessionResolvesNoHost`,
`testResolveActivatorHerdrDetachedResolvesToNil`, and
`TestResolveBackend_HerdrWinsOverClientTmux`.

## Live verification

Resolved against the real herdr client hosting this very session
(`herdr --session irrlicht`, PID 26932, running in VS Code's integrated
terminal):

```
HERDR pane="w1:p1" socket="/Users/ingo/.config/herdr/sessions/irrlicht/herdr.sock"
HOST  term_program="vscode"
client pids for socket: [26932]
```

Before this change both host fields were empty. Also verified live that a
competing `tail -f` on the same client log (holding it `3r`) is excluded, and
that a `herdr` CLI invocation does not open that log at all.

**What is *not* live-verified:** the tty adoption. The probe harness has no
controlling terminal of its own, and the symmetric guard correctly declines to
adopt in that case, so this path is covered by unit test
(`TestLauncher_AdoptHostIdentity`) rather than by the live probe. The end-to-end
click itself was not exercised against a running macOS app — the daemon half and
the `herdr agent focus` verb were each verified live, and the Swift half by unit
test, but nobody has clicked the row. Worth one manual smoke test before merge.

## Review and cleanup

A `high`-effort review pass raised six findings, all addressed: reader-vs-writer
FD filtering (above), the one-directional TTY guard (above), the stale
`resolveBackend` invariant (above), repeated `lsof` scans at synchronous startup
(now memoized per socket — measured ~0.3s per scan, and every pane of one server
shares a socket), a log line that asserted "no attached client" for causes it
had not established, and the composed-activator caveat.

A cleanup pass then caught a **real CI breaker the review missed**: `osutil_test.go`
carries no build tag but referenced a darwin-only symbol, so
`GOOS=linux go vet ./core/...` failed and linux.yml would have gone red. Fixed
by moving the darwin-only helpers into `osutil_darwin_test.go`. It also merged
this change's duplicate `lsof` exec+parse into `WriterOf`'s (`parseLsofFDs`), and
fixed mode parsing to read the first non-digit rather than the last byte, since
lsof appends a lock character after the mode (`5uW` is a `u` handle).

## Known limitation → #1405

Capture is once-per-PID-bind, and the seed-time backfill only fires when *no*
host was ever recorded. So a session captured while detached heals at the next
daemon restart, and one whose host did resolve is never re-checked — re-attaching
to a different terminal points the click at the old window until restart. #1405
tracks refreshing it from the periodic liveness sweep, which needs no click-path
change.

## Scope

macOS only, per the issue: the web dashboard reads no launcher fields
(`git grep -in launcher HEAD -- platforms/web` → 0 hits).

## Testing

- `go test ./core/... -race -count=1` — 0 failures.
- `GOOS=linux go build ./core/... && GOOS=linux go vet ./core/...` — clean.
- `cd platforms/macos && swift test` — 302 tests, 5 skipped, 0 failures.
  The Swift suite is **not CI-gated** anywhere, so this was run locally.
- `tools/preflight.sh --changed` — all gates PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)