### PR TITLE
fix(hooks): count and report unrecognized hook events (#1364)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,27 @@ Before marking a ticket done, run the full suite — every layer must pass:
   under launchd with a minimal PATH and routinely cannot see the user's CLI, so
   only a version successfully read AND parsed AND found below the floor blocks
   an install.
-  All five contract families pass by construction against a correct adapter, so
+- Unrecognized hook events: `contracttesting.AssertUnknownHookEventObserved`
+  (`core/internal/contracttesting/unknown_hook_event.go`) covers the other end of
+  the same receiver — the event name it does *not* know. Before #1364 both
+  receivers ended their switch with an Info log and a 200, which is
+  indistinguishable from health: an upstream event rename would leave the
+  permission reading `granted`, the config still holding our entries, and state
+  detection quietly degrading, with nothing anywhere to look at. Four
+  obligations: a recognized event still dispatches and is counted by nobody (the
+  vacuity guard — a receiver that counts *everything* otherwise looks identical
+  to one that counts correctly); an unrecognized event is answered 2xx and
+  dispatched nowhere; it is counted per **(adapter, event name)**, because a
+  rename fires on every tool call forever while a stray POST fires once and a
+  single scalar cannot tell those apart; and it is reported **exactly once per
+  distinct name**, since a line per tool call buries the evidence it exists to
+  surface. `hookjson.IgnoreUnknownEvent` is the single place it is implemented —
+  the sibling of `RejectPath`, and it deliberately takes no `http.ResponseWriter`
+  so it cannot grow an opinion about the status code. Its counters are read into
+  the diagnostics bundle's `hooks.json`; note that `--diagnose` runs in a process
+  that never served a hook, so that form omits the counts and says so rather than
+  publishing zeros (the live counts come from `GET /debug/bundle`).
+  All six contract families pass by construction against a correct adapter, so
   their whole value is that they *can* fail: a new or reworked contract
   assertion lands with the deliberate mutation that was seen red for each
   obligation recorded in its PR — the same bar the red-first rule above sets

--- a/core/adapters/inbound/agents/claudecode/hookpath_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookpath_test.go
@@ -25,6 +25,19 @@ func writeContractTranscript(t *testing.T, dir string) string {
 	return writeTranscriptFile(t, dir, transcriptStem)
 }
 
+// contractPayload renders this adapter's hook body for one event.
+func contractPayload(transcriptPath, event string) string {
+	body, err := json.Marshal(hookPayload{
+		TranscriptPath: transcriptPath,
+		HookEventName:  event,
+		ToolName:       "Bash",
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
 // TestHookPathConfined wires this adapter's hook receiver into the shared issue
 // #1361 contract: a caller-supplied transcript_path is confined to the
 // adapter's declared transcript roots, with symlinks resolved first, and

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -319,9 +319,10 @@ func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGrant
 	case HookNotification:
 		handleNotificationHook(target, log, sessionID, payload)
 	default:
-		// Unrecognized hook event — accept but ignore.
-		log.LogInfo(logComponentHookReceiver, sessionID,
-			fmt.Sprintf("ignored unrecognized hook event %q", payload.HookEventName))
+		// Unrecognized hook event — accept but ignore, counted per name and
+		// reported once, in the one place that behaviour is decided for every
+		// receiver (issue #1364). The 200 below is unaffected.
+		hookjson.IgnoreUnknownEvent(log, logComponentHookReceiver, AdapterName, sessionID, payload.HookEventName)
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/core/adapters/inbound/agents/claudecode/hookunknown_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookunknown_test.go
@@ -1,0 +1,42 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+// TestUnknownHookEventObserved wires this adapter's hook receiver into the
+// shared issue #1364 contract: an event name the receiver does not recognize is
+// counted per (adapter, name), reported once per distinct name, and still
+// answered 2xx.
+func TestUnknownHookEventObserved(t *testing.T) {
+	contracttesting.AssertUnknownHookEventObserved(t, contracttesting.UnknownEventReceiver{
+		Adapter:         AdapterName,
+		Root:            claudeProjectsRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) contracttesting.UnknownEventReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.UnknownEventReceiverUnderTest{
+				Handler:  NewHookHandlerWithConfiner(target, nil, nil, log, TranscriptConfiner()),
+				Observed: func() bool { return len(target.getCalls()) > 0 },
+			}
+		},
+		PayloadFor: func(transcriptPath, event string) string {
+			body, err := json.Marshal(hookPayload{
+				TranscriptPath: transcriptPath,
+				HookEventName:  event,
+				ToolName:       "Bash",
+			})
+			if err != nil {
+				panic(err)
+			}
+			return string(body)
+		},
+		KnownEvent:   HookPermissionRequest,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/claudecode/hookunknown_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookunknown_test.go
@@ -1,7 +1,6 @@
 package claudecode
 
 import (
-	"encoding/json"
 	"testing"
 
 	"irrlicht/core/internal/contracttesting"
@@ -25,17 +24,7 @@ func TestUnknownHookEventObserved(t *testing.T) {
 				Observed: func() bool { return len(target.getCalls()) > 0 },
 			}
 		},
-		PayloadFor: func(transcriptPath, event string) string {
-			body, err := json.Marshal(hookPayload{
-				TranscriptPath: transcriptPath,
-				HookEventName:  event,
-				ToolName:       "Bash",
-			})
-			if err != nil {
-				panic(err)
-			}
-			return string(body)
-		},
+		PayloadFor:   contractPayload,
 		KnownEvent:   HookPermissionRequest,
 		EndpointPath: HookEndpointPath,
 	})

--- a/core/adapters/inbound/agents/codex/hookpath_test.go
+++ b/core/adapters/inbound/agents/codex/hookpath_test.go
@@ -9,24 +9,50 @@ import (
 	"irrlicht/core/internal/contracttesting"
 )
 
+// codexSessionsRoot relocates the agent home to a temp dir and returns the
+// declared transcript root inside it — CODEX_HOME moves the home, and rollouts
+// live in its sessions/ subdirectory. Shared by both receiving-side contracts
+// so the layout is written down once.
+func codexSessionsRoot(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv(codexHomeEnvVar, home)
+	root := filepath.Join(home, "sessions")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("create sessions dir: %v", err)
+	}
+	return root
+}
+
+// writeContractTranscript writes a rollout the receiver will resolve a session
+// id from. Codex reads that id out of the session_meta header, so the decoy
+// outside the tree carries one too — the only thing keeping it from dispatching
+// is confinement, not an unreadable file.
+func writeContractTranscript(t *testing.T, dir string) string {
+	t.Helper()
+	return writeRolloutInto(t, dir, "sess-contract")
+}
+
+// contractPayload renders this adapter's hook body for one event.
+func contractPayload(transcriptPath, event string) string {
+	body, err := json.Marshal(codexHookPayload{
+		TranscriptPath: transcriptPath,
+		HookEventName:  event,
+		ToolName:       "shell",
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
 // TestHookPathConfined wires this adapter's hook receiver into the shared issue
 // #1361 contract: a caller-supplied transcript_path is confined to the
 // adapter's declared transcript roots, with symlinks resolved first, and
 // anything outside is refused loudly and counted.
 func TestHookPathConfined(t *testing.T) {
 	contracttesting.AssertHookPathConfined(t, contracttesting.HookReceiver{
-		Root: func(t *testing.T) string {
-			t.Helper()
-			// CODEX_HOME relocates the agent home; rollouts live in its
-			// sessions/ subdirectory, which is the declared root.
-			home := t.TempDir()
-			t.Setenv(codexHomeEnvVar, home)
-			root := filepath.Join(home, "sessions")
-			if err := os.MkdirAll(root, 0o700); err != nil {
-				t.Fatalf("create sessions dir: %v", err)
-			}
-			return root
-		},
+		Root: codexSessionsRoot,
 		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
 			t.Helper()
 			target := &mockTarget{}
@@ -45,24 +71,10 @@ func TestHookPathConfined(t *testing.T) {
 				Observed: func() bool { return target.totalCalls() > 0 },
 			}
 		},
-		// Codex resolves the session id from the rollout's session_meta header,
-		// so the decoy outside the tree carries one too — the only thing
-		// keeping it from dispatching is confinement, not an unreadable file.
-		WriteTranscript: func(t *testing.T, dir string) string {
-			t.Helper()
-			return writeRolloutInto(t, dir, "sess-confine")
-		},
-		TranscriptExt: transcriptExt,
+		WriteTranscript: writeContractTranscript,
+		TranscriptExt:   transcriptExt,
 		PayloadFor: func(transcriptPath string) string {
-			body, err := json.Marshal(codexHookPayload{
-				TranscriptPath: transcriptPath,
-				HookEventName:  HookPermissionRequest,
-				ToolName:       "shell",
-			})
-			if err != nil {
-				panic(err)
-			}
-			return string(body)
+			return contractPayload(transcriptPath, HookPermissionRequest)
 		},
 		EndpointPath: HookEndpointPath,
 	})

--- a/core/adapters/inbound/agents/codex/hooks.go
+++ b/core/adapters/inbound/agents/codex/hooks.go
@@ -191,9 +191,10 @@ func dispatchHookEvent(target HookTarget, log outbound.Logger, sessionID string,
 	case HookStop:
 		handleStopHook(target, log, sessionID, payload)
 	default:
-		// Unrecognized hook event — accept but ignore.
-		log.LogInfo(logComponentHookReceiver, sessionID,
-			fmt.Sprintf("ignored unrecognized hook event %q", payload.HookEventName))
+		// Unrecognized hook event — accept but ignore, counted per name and
+		// reported once, in the one place that behaviour is decided for every
+		// receiver (issue #1364). serveHookRequest's 200 is unaffected.
+		hookjson.IgnoreUnknownEvent(log, logComponentHookReceiver, AdapterName, sessionID, payload.HookEventName)
 	}
 }
 

--- a/core/adapters/inbound/agents/codex/hookunknown_test.go
+++ b/core/adapters/inbound/agents/codex/hookunknown_test.go
@@ -1,0 +1,56 @@
+package codex
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+// TestUnknownHookEventObserved wires this adapter's hook receiver into the
+// shared issue #1364 contract: an event name the receiver does not recognize is
+// counted per (adapter, name), reported once per distinct name, and still
+// answered 2xx.
+func TestUnknownHookEventObserved(t *testing.T) {
+	contracttesting.AssertUnknownHookEventObserved(t, contracttesting.UnknownEventReceiver{
+		Adapter: AdapterName,
+		Root: func(t *testing.T) string {
+			t.Helper()
+			home := t.TempDir()
+			t.Setenv(codexHomeEnvVar, home)
+			root := filepath.Join(home, "sessions")
+			if err := os.MkdirAll(root, 0o700); err != nil {
+				t.Fatalf("create sessions dir: %v", err)
+			}
+			return root
+		},
+		WriteTranscript: func(t *testing.T, dir string) string {
+			t.Helper()
+			return writeRolloutInto(t, dir, "sess-unknown-event")
+		},
+		New: func(t *testing.T, log outbound.Logger) contracttesting.UnknownEventReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.UnknownEventReceiverUnderTest{
+				Handler:  NewHookHandlerWithConfiner(target, nil, log, TranscriptConfiner()),
+				Observed: func() bool { return target.totalCalls() > 0 },
+			}
+		},
+		PayloadFor: func(transcriptPath, event string) string {
+			body, err := json.Marshal(codexHookPayload{
+				TranscriptPath: transcriptPath,
+				HookEventName:  event,
+				ToolName:       "shell",
+			})
+			if err != nil {
+				panic(err)
+			}
+			return string(body)
+		},
+		KnownEvent:   HookPermissionRequest,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/codex/hookunknown_test.go
+++ b/core/adapters/inbound/agents/codex/hookunknown_test.go
@@ -1,9 +1,6 @@
 package codex
 
 import (
-	"encoding/json"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"irrlicht/core/internal/contracttesting"
@@ -16,21 +13,9 @@ import (
 // answered 2xx.
 func TestUnknownHookEventObserved(t *testing.T) {
 	contracttesting.AssertUnknownHookEventObserved(t, contracttesting.UnknownEventReceiver{
-		Adapter: AdapterName,
-		Root: func(t *testing.T) string {
-			t.Helper()
-			home := t.TempDir()
-			t.Setenv(codexHomeEnvVar, home)
-			root := filepath.Join(home, "sessions")
-			if err := os.MkdirAll(root, 0o700); err != nil {
-				t.Fatalf("create sessions dir: %v", err)
-			}
-			return root
-		},
-		WriteTranscript: func(t *testing.T, dir string) string {
-			t.Helper()
-			return writeRolloutInto(t, dir, "sess-unknown-event")
-		},
+		Adapter:         AdapterName,
+		Root:            codexSessionsRoot,
+		WriteTranscript: writeContractTranscript,
 		New: func(t *testing.T, log outbound.Logger) contracttesting.UnknownEventReceiverUnderTest {
 			t.Helper()
 			target := &mockTarget{}
@@ -39,17 +24,7 @@ func TestUnknownHookEventObserved(t *testing.T) {
 				Observed: func() bool { return target.totalCalls() > 0 },
 			}
 		},
-		PayloadFor: func(transcriptPath, event string) string {
-			body, err := json.Marshal(codexHookPayload{
-				TranscriptPath: transcriptPath,
-				HookEventName:  event,
-				ToolName:       "shell",
-			})
-			if err != nil {
-				panic(err)
-			}
-			return string(body)
-		},
+		PayloadFor:   contractPayload,
 		KnownEvent:   HookPermissionRequest,
 		EndpointPath: HookEndpointPath,
 	})

--- a/core/adapters/inbound/agents/hookjson/unknown.go
+++ b/core/adapters/inbound/agents/hookjson/unknown.go
@@ -36,7 +36,6 @@ package hookjson
 
 import (
 	"fmt"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"unicode/utf8"
@@ -44,21 +43,16 @@ import (
 	"irrlicht/core/ports/outbound"
 )
 
+// Both bounds exist for the threat model in the file header: the name is
+// caller-supplied on an unauthenticated endpoint and is retained for the life
+// of the process. Real event names are short PascalCase identifiers, so both
+// are far past anything an upstream rename produces.
 const (
-	// MaxUnknownEventNames bounds how many distinct (adapter, event) pairs are
-	// retained. The hook endpoints are local and unauthenticated — confine.go
-	// says so in its first paragraph, and it is the reason that file exists —
-	// so any process on the machine can POST an event name of its choosing. An
-	// unbounded map keyed by that string is a memory-growth primitive handed to
-	// an unauthenticated caller. Real adapters recognize a handful of events
-	// each, so a table this size is far past anything an upstream rename can
-	// produce and far short of anything that matters for memory.
-	MaxUnknownEventNames = 64
+	// maxUnknownEventNames bounds how many distinct (adapter, event) pairs are
+	// retained.
+	maxUnknownEventNames = 64
 
-	// maxUnknownEventNameLen bounds the retained length of a single name, for
-	// the same reason: the pair is held for the life of the process, so a
-	// multi-megabyte "event name" must not be what is held. Every real event
-	// name is a short PascalCase identifier.
+	// maxUnknownEventNameLen bounds the retained length of one name, in bytes.
 	maxUnknownEventNameLen = 64
 )
 
@@ -116,13 +110,6 @@ var (
 	// table is full; that residual is the price of the bound, and the
 	// first-drop log line at least names the first one.
 	unknownDropped = make(map[string]*atomic.Uint64)
-
-	// unknownSaturated is a lock-free fast path for the post-saturation case.
-	// Without it every dropped sighting takes the exclusive lock just to re-read
-	// len(unknownCounts) — a process-wide write lock on the hook-receive path of
-	// every adapter, engaged during precisely the flood the design refuses to
-	// serialize.
-	unknownSaturated atomic.Bool
 )
 
 // IgnoreUnknownEvent is the uniform handling every hook receiver owes an event
@@ -141,15 +128,16 @@ var (
 // the count is keyed by; sessionID is the resolved session the event arrived
 // for, purely so the log line joins up with the rest of that session's trail.
 func IgnoreUnknownEvent(log outbound.Logger, component, adapter, sessionID, event string) {
-	switch observeUnknownEvent(adapter, event) {
+	outcome, name := observeUnknownEvent(adapter, event)
+	switch outcome {
 	case unknownFirstSighting:
 		log.LogError(component, sessionID, fmt.Sprintf(
 			"unrecognized hook event %q from %s: ignored, answered 2xx. Further occurrences of this name are counted, not logged — an upstream event rename looks exactly like this, so check the count in the diagnostics bundle's hooks.json before dismissing it.",
-			truncateEventName(event), adapter))
+			name, adapter))
 	case unknownTableFullFirst:
 		log.LogError(component, sessionID, fmt.Sprintf(
 			"unrecognized hook event %q from %s: ignored, and NOT counted by name — the distinct-name table is full at %d entries, so no further name from this adapter can be attributed. Later sightings are totalled per adapter in hooks.json's unknown_event_names_dropped_by_adapter.",
-			truncateEventName(event), adapter, MaxUnknownEventNames))
+			name, adapter, maxUnknownEventNames))
 	case unknownRepeat, unknownTableFullRepeat:
 		// Counted. Deliberately silent: these are the flooding cases.
 	}
@@ -164,23 +152,26 @@ func IgnoreUnknownEvent(log outbound.Logger, component, adapter, sessionID, even
 // what makes "reported once" true rather than approximately true. Both
 // decisions are made under the same lock as the state they consult, so there is
 // no piece of this state living outside the mutex's protection domain.
-func observeUnknownEvent(adapter, event string) unknownOutcome {
+func observeUnknownEvent(adapter, event string) (unknownOutcome, string) {
 	key := UnknownEvent{Adapter: adapter, Event: truncateEventName(event)}
 
 	unknownMu.RLock()
 	counter := unknownCounts[key]
 	var dropped *atomic.Uint64
-	if counter == nil && unknownSaturated.Load() {
+	if counter == nil && len(unknownCounts) >= maxUnknownEventNames {
+		// Post-saturation fast path: read the adapter's drop counter under the
+		// SAME read lock the map lookup above already needs, so a flood of
+		// unretainable names never reaches the exclusive lock.
 		dropped = unknownDropped[adapter]
 	}
 	unknownMu.RUnlock()
 	if counter != nil {
 		counter.Add(1)
-		return unknownRepeat
+		return unknownRepeat, key.Event
 	}
 	if dropped != nil {
 		dropped.Add(1)
-		return unknownTableFullRepeat
+		return unknownTableFullRepeat, key.Event
 	}
 
 	unknownMu.Lock()
@@ -188,45 +179,40 @@ func observeUnknownEvent(adapter, event string) unknownOutcome {
 	if counter := unknownCounts[key]; counter != nil {
 		// Lost the race to insert. The winner reports; this one only counts.
 		counter.Add(1)
-		return unknownRepeat
+		return unknownRepeat, key.Event
 	}
-	if len(unknownCounts) >= MaxUnknownEventNames {
-		unknownSaturated.Store(true)
+	if len(unknownCounts) >= maxUnknownEventNames {
 		if dropped := unknownDropped[adapter]; dropped != nil {
 			dropped.Add(1)
-			return unknownTableFullRepeat
+			return unknownTableFullRepeat, key.Event
 		}
 		dropped := &atomic.Uint64{}
 		dropped.Add(1)
 		unknownDropped[adapter] = dropped
-		return unknownTableFullFirst
+		return unknownTableFullFirst, key.Event
 	}
 	fresh := &atomic.Uint64{}
 	fresh.Add(1)
 	unknownCounts[key] = fresh
-	return unknownFirstSighting
+	return unknownFirstSighting, key.Event
 }
 
 // UnknownEvents returns a snapshot of the per-(adapter, name) sighting counts,
-// sorted by adapter then name so a bundle diffs cleanly between two captures.
+// in unspecified order — ordering is a presentation guarantee and belongs to
+// the one place that owes it, the diagnostics bundle's hooksView. Sorting here
+// too would mean the same comparator in two files, agreeing forever, with no
+// test able to see the other go stale.
 //
 // No entry is ever zero — a pair only gets a slot when it is first counted — so
 // unlike Fallbacks and Rejections there is nothing to omit; the property those
 // promise ("zeros are absent") holds here by construction.
 func UnknownEvents() []UnknownEventCount {
 	unknownMu.RLock()
+	defer unknownMu.RUnlock()
 	out := make([]UnknownEventCount, 0, len(unknownCounts))
 	for key, counter := range unknownCounts {
 		out = append(out, UnknownEventCount{UnknownEvent: key, Count: counter.Load()})
 	}
-	unknownMu.RUnlock()
-
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Adapter != out[j].Adapter {
-			return out[i].Adapter < out[j].Adapter
-		}
-		return out[i].Event < out[j].Event
-	})
 	return out
 }
 
@@ -270,31 +256,6 @@ func UnknownEventNamesDropped() map[string]uint64 {
 	return out
 }
 
-// UnknownEventNamesDroppedTotal is the drop count across every adapter.
-func UnknownEventNamesDroppedTotal() uint64 {
-	var total uint64
-	unknownMu.RLock()
-	defer unknownMu.RUnlock()
-	for _, dropped := range unknownDropped {
-		total += dropped.Load()
-	}
-	return total
-}
-
-// resetUnknownEvents clears the table. Test-only, and unexported so it cannot
-// become a production reset: one test in this package deliberately saturates the
-// table, and a saturated table makes every test after it fail for a reason that
-// has nothing to do with that test. Nothing in the daemon resets these — a
-// counter an operator can zero is a counter that can hide the thing it was added
-// to reveal.
-func resetUnknownEvents() {
-	unknownMu.Lock()
-	defer unknownMu.Unlock()
-	unknownCounts = make(map[UnknownEvent]*atomic.Uint64)
-	unknownDropped = make(map[string]*atomic.Uint64)
-	unknownSaturated.Store(false)
-}
-
 // truncateEventName bounds a retained name at a rune boundary. Cutting mid-rune
 // would store invalid UTF-8, which then has to survive JSON encoding into a
 // diagnostics bundle.
@@ -303,6 +264,13 @@ func resetUnknownEvents() {
 // RETAINED name": two names sharing a 64-byte prefix collapse to one key. No
 // real event name comes close, and the alternative is retaining whatever a local
 // caller sends.
+//
+// Not session.CapRunes, which is the repo's canonical headline truncator: it
+// bounds by RUNE count, and to do that it runs utf8.RuneCountInString over the
+// whole string and then materializes []rune(s). On the input this bound exists
+// for — a multi-megabyte name from a local caller — that is a full scan plus a
+// 4x allocation of the very string we are refusing to keep. A byte bound reads
+// at most 64 bytes.
 func truncateEventName(name string) string {
 	if len(name) <= maxUnknownEventNameLen {
 		return name

--- a/core/adapters/inbound/agents/hookjson/unknown.go
+++ b/core/adapters/inbound/agents/hookjson/unknown.go
@@ -1,0 +1,248 @@
+// unknown.go makes an unrecognized hook event visible (issue #1364).
+//
+// Before this, both receivers ended their event switch the same way: an Info
+// log line, an HTTP 200, and nothing else. That is indistinguishable from
+// health. The failure it hides is not exotic — an upstream CLI renames the
+// event we key permission detection on, every POST lands in the default branch,
+// the permission still reads `granted`, the installed config still contains our
+// entries, and state detection just quietly gets worse. Hook schemas are young
+// enough that this is a when.
+//
+// Three properties, and each one is a deliberate choice against an obvious
+// alternative:
+//
+//   - COUNTED PER (adapter, event name), not per adapter and not globally. A
+//     rename fires on every single tool call, forever; a stray event from some
+//     local process fires once. A single scalar cannot tell those apart, and
+//     telling them apart is the entire diagnostic value.
+//   - LOGGED ONCE PER DISTINCT NAME, at error level. A rename would otherwise
+//     write a log line per tool call — the log stops being readable exactly when
+//     someone needs to read it. The counter carries the volume; the log carries
+//     the name. Error rather than Info because Info is where this was already
+//     hiding, and because outbound.Logger has no level in between.
+//   - STILL ANSWERED 2xx. Not a preference — see RejectPath's doc comment in
+//     confine.go for the evidence, and the contract assertion that pins it. This
+//     function deliberately takes no http.ResponseWriter so it cannot acquire an
+//     opinion about the status code later; the caller's existing 200 stands.
+//
+// The counter shape mirrors PathConfiner's rejection counters (confine.go) and
+// the splicer's fallback counters (fallback.go) on purpose — same package, same
+// problem, same accessors: a snapshot map that omits zeros, plus a total. The
+// one place it cannot mirror them is the storage: those index a fixed array by
+// a closed enum of reasons, and an event NAME is caller-supplied on a local,
+// unauthenticated endpoint, so the key space is open. That is what the bounded
+// table below is for.
+package hookjson
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"unicode/utf8"
+
+	"irrlicht/core/ports/outbound"
+)
+
+const (
+	// MaxUnknownEventNames bounds how many distinct (adapter, event) pairs are
+	// retained. The hook endpoints are local and unauthenticated — confine.go
+	// says so in its first paragraph, and it is the reason that file exists —
+	// so any process on the machine can POST an event name of its choosing. An
+	// unbounded map keyed by that string is a memory-growth primitive handed to
+	// an unauthenticated caller. Real adapters recognize a handful of events
+	// each, so a table this size is far past anything an upstream rename can
+	// produce and far short of anything that matters for memory.
+	MaxUnknownEventNames = 64
+
+	// maxUnknownEventNameLen bounds the retained length of a single name, for
+	// the same reason: the pair is held for the life of the process, so a
+	// multi-megabyte "event name" must not be what is held. Every real event
+	// name is a short PascalCase identifier.
+	maxUnknownEventNameLen = 64
+)
+
+// UnknownEvent identifies one unrecognized hook event: which adapter's receiver
+// saw it, and the name the CLI sent. Both halves are the key — an event named
+// "Stop" arriving at an adapter that does not implement Stop is a different fact
+// from the same name arriving at one that does.
+type UnknownEvent struct {
+	Adapter string
+	Event   string
+}
+
+// unknownOutcome is what observeUnknownEvent decided, so IgnoreUnknownEvent can
+// log the two noteworthy transitions and stay silent on the common one.
+type unknownOutcome int
+
+const (
+	// unknownRepeat — this name has been seen before in this process. Counted,
+	// not logged; this is the case that would flood.
+	unknownRepeat unknownOutcome = iota
+	// unknownFirstSighting — a name not seen before. Counted and logged.
+	unknownFirstSighting
+	// unknownTableFull — the bounded table is saturated, so this name is not
+	// retained. Counted only in unknownNamesDropped.
+	unknownTableFull
+)
+
+var (
+	// unknownMu guards insertion into unknownCounts only. Once a pair has a
+	// slot, further sightings go through its atomic without taking the write
+	// lock — which matters because the thing these counters exist to observe is
+	// a BURST, and a burst is by definition the same name arriving repeatedly.
+	// Serializing exactly then would blunt what is being measured, the same
+	// argument confine.go makes for its fixed array of atomics.
+	unknownMu     sync.RWMutex
+	unknownCounts = make(map[UnknownEvent]*atomic.Uint64)
+
+	// unknownNamesDropped counts sightings refused a slot because the table was
+	// full. Surfaced beside the table so a saturated table is never mistaken for
+	// a complete one.
+	unknownNamesDropped atomic.Uint64
+
+	// unknownSaturationOnce makes the table-full report a single log line rather
+	// than one per event, for the same reason first-sighting logging exists.
+	unknownSaturationOnce sync.Once
+)
+
+// IgnoreUnknownEvent is the uniform handling every hook receiver owes an event
+// name it does not recognize. It is the ONE place that behaviour is decided —
+// the sibling of RejectPath, and for the same reason: two receivers had already
+// written the identical default branch by hand, and the third would have had to
+// remember to.
+//
+// It counts the sighting, logs the first occurrence of each distinct name, and
+// returns. It writes NO response: the caller has already committed to answering
+// 2xx on this path, and that rule is asserted by
+// contracttesting.AssertUnknownHookEventObserved rather than left to each
+// receiver.
+//
+// component is the caller's Logger component tag; adapter is the adapter name
+// the count is keyed by; sessionID is the resolved session the event arrived
+// for, purely so the log line joins up with the rest of that session's trail.
+func IgnoreUnknownEvent(log outbound.Logger, component, adapter, sessionID, event string) {
+	switch observeUnknownEvent(adapter, event) {
+	case unknownFirstSighting:
+		log.LogError(component, sessionID, fmt.Sprintf(
+			"unrecognized hook event %q from %s: ignored, answered 2xx. Further occurrences of this name are counted, not logged — an upstream event rename looks exactly like this, so check the count in the diagnostics bundle's hooks.json before dismissing it.",
+			truncateEventName(event), adapter))
+	case unknownTableFull:
+		unknownSaturationOnce.Do(func() {
+			log.LogError(component, sessionID, fmt.Sprintf(
+				"unrecognized hook event %q from %s: ignored, and NOT counted — the distinct-name table is full at %d entries. Later names are totalled in unknown_event_names_dropped only.",
+				truncateEventName(event), adapter, MaxUnknownEventNames))
+		})
+	case unknownRepeat:
+		// Counted. Deliberately silent: this is the flooding case.
+	}
+}
+
+// observeUnknownEvent records one sighting and reports what kind it was.
+//
+// The double-checked shape is not premature optimization: the fast path is the
+// repeat, and the write lock is taken only on the transition that also produces
+// the log line — so "first sighting" is decided by exactly one goroutine even
+// when two arrive together, which is what makes "logged once" true rather than
+// approximately true.
+func observeUnknownEvent(adapter, event string) unknownOutcome {
+	key := UnknownEvent{Adapter: adapter, Event: truncateEventName(event)}
+
+	unknownMu.RLock()
+	c := unknownCounts[key]
+	unknownMu.RUnlock()
+	if c != nil {
+		c.Add(1)
+		return unknownRepeat
+	}
+
+	unknownMu.Lock()
+	defer unknownMu.Unlock()
+	if c := unknownCounts[key]; c != nil {
+		// Lost the race to insert. The winner logs; this one only counts.
+		c.Add(1)
+		return unknownRepeat
+	}
+	if len(unknownCounts) >= MaxUnknownEventNames {
+		unknownNamesDropped.Add(1)
+		return unknownTableFull
+	}
+	counter := &atomic.Uint64{}
+	counter.Add(1)
+	unknownCounts[key] = counter
+	return unknownFirstSighting
+}
+
+// UnknownEvents returns a snapshot of the per-(adapter, name) sighting counts,
+// sorted by adapter then name so a bundle diffs cleanly between two captures.
+//
+// No entry is ever zero — a pair only gets a slot when it is first counted — so
+// unlike Fallbacks and Rejections there is nothing to omit; the property those
+// promise ("zeros are absent") holds here by construction.
+func UnknownEvents() []UnknownEventCount {
+	unknownMu.RLock()
+	out := make([]UnknownEventCount, 0, len(unknownCounts))
+	for key, counter := range unknownCounts {
+		out = append(out, UnknownEventCount{UnknownEvent: key, Count: counter.Load()})
+	}
+	unknownMu.RUnlock()
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Adapter != out[j].Adapter {
+			return out[i].Adapter < out[j].Adapter
+		}
+		return out[i].Event < out[j].Event
+	})
+	return out
+}
+
+// UnknownEventCount is one row of the UnknownEvents snapshot.
+type UnknownEventCount struct {
+	UnknownEvent
+	Count uint64
+}
+
+// UnknownEventTotal is the total number of unrecognized events seen, across
+// every name — including the ones the table had no room to name.
+func UnknownEventTotal() uint64 {
+	total := UnknownEventNamesDropped()
+	unknownMu.RLock()
+	defer unknownMu.RUnlock()
+	for _, counter := range unknownCounts {
+		total += counter.Load()
+	}
+	return total
+}
+
+// UnknownEventNamesDropped is how many sightings arrived after the distinct-name
+// table saturated. Non-zero means UnknownEvents is incomplete, which is exactly
+// the thing a reader must not have to infer.
+func UnknownEventNamesDropped() uint64 { return unknownNamesDropped.Load() }
+
+// resetUnknownEvents clears the table. Test-only, and unexported so it cannot
+// become a production reset: one test in this package deliberately saturates the
+// table, and a saturated table makes every test after it fail for a reason that
+// has nothing to do with that test. Nothing in the daemon resets these — a
+// counter an operator can zero is a counter that can hide the thing it was added
+// to reveal.
+func resetUnknownEvents() {
+	unknownMu.Lock()
+	defer unknownMu.Unlock()
+	unknownCounts = make(map[UnknownEvent]*atomic.Uint64)
+	unknownNamesDropped.Store(0)
+	unknownSaturationOnce = sync.Once{}
+}
+
+// truncateEventName bounds a retained name at a rune boundary. Cutting mid-rune
+// would store invalid UTF-8, which then has to survive JSON encoding into a
+// diagnostics bundle.
+func truncateEventName(name string) string {
+	if len(name) <= maxUnknownEventNameLen {
+		return name
+	}
+	cut := maxUnknownEventNameLen
+	for cut > 0 && !utf8.RuneStart(name[cut]) {
+		cut--
+	}
+	return name[:cut] + "…"
+}

--- a/core/adapters/inbound/agents/hookjson/unknown.go
+++ b/core/adapters/inbound/agents/hookjson/unknown.go
@@ -71,8 +71,9 @@ type UnknownEvent struct {
 	Event   string
 }
 
-// unknownOutcome is what observeUnknownEvent decided, so IgnoreUnknownEvent can
-// log the two noteworthy transitions and stay silent on the common one.
+// unknownOutcome is what observeUnknownEvent decided, so IgnoreUnknownEvent
+// reports the transitions worth a log line and stays silent on the two that
+// would flood.
 type unknownOutcome int
 
 const (
@@ -81,29 +82,47 @@ const (
 	unknownRepeat unknownOutcome = iota
 	// unknownFirstSighting — a name not seen before. Counted and logged.
 	unknownFirstSighting
-	// unknownTableFull — the bounded table is saturated, so this name is not
-	// retained. Counted only in unknownNamesDropped.
-	unknownTableFull
+	// unknownTableFullFirst — the bounded table is saturated and this is the
+	// FIRST sighting dropped for this adapter. Logged, so saturation is
+	// announced once per adapter rather than once per process: a table filled by
+	// junk aimed at one adapter must not silence the announcement for a real
+	// rename arriving at another.
+	unknownTableFullFirst
+	// unknownTableFullRepeat — saturated, and this adapter has already
+	// announced it. Totalled in its drop counter only.
+	unknownTableFullRepeat
 )
 
 var (
-	// unknownMu guards insertion into unknownCounts only. Once a pair has a
-	// slot, further sightings go through its atomic without taking the write
-	// lock — which matters because the thing these counters exist to observe is
-	// a BURST, and a burst is by definition the same name arriving repeatedly.
-	// Serializing exactly then would blunt what is being measured, the same
-	// argument confine.go makes for its fixed array of atomics.
+	// unknownMu guards the two maps below. Once a pair has a slot, further
+	// sightings go through its atomic without taking any write lock — which
+	// matters because the thing these counters exist to observe is a BURST, and
+	// a burst is by definition the same name arriving repeatedly. Serializing
+	// exactly then would blunt what is being measured, the same argument
+	// confine.go makes for its fixed array of atomics.
 	unknownMu     sync.RWMutex
 	unknownCounts = make(map[UnknownEvent]*atomic.Uint64)
 
-	// unknownNamesDropped counts sightings refused a slot because the table was
-	// full. Surfaced beside the table so a saturated table is never mistaken for
-	// a complete one.
-	unknownNamesDropped atomic.Uint64
+	// unknownDropped counts, PER ADAPTER, the sightings refused a slot because
+	// the table was full.
+	//
+	// Per adapter rather than one global scalar, because the table is shared and
+	// its cap is a process-wide resource: a local process can fill all 64 slots
+	// with junk — the endpoint is unauthenticated — and every genuine rename
+	// after that is refused a row. A single scalar climbing into the thousands
+	// says only "something", which is the exact "a single scalar cannot tell
+	// those apart" failure this file exists to prevent. Keyed by adapter, it
+	// still says WHICH CLI is flooding. The name is not recoverable once the
+	// table is full; that residual is the price of the bound, and the
+	// first-drop log line at least names the first one.
+	unknownDropped = make(map[string]*atomic.Uint64)
 
-	// unknownSaturationOnce makes the table-full report a single log line rather
-	// than one per event, for the same reason first-sighting logging exists.
-	unknownSaturationOnce sync.Once
+	// unknownSaturated is a lock-free fast path for the post-saturation case.
+	// Without it every dropped sighting takes the exclusive lock just to re-read
+	// len(unknownCounts) — a process-wide write lock on the hook-receive path of
+	// every adapter, engaged during precisely the flood the design refuses to
+	// serialize.
+	unknownSaturated atomic.Bool
 )
 
 // IgnoreUnknownEvent is the uniform handling every hook receiver owes an event
@@ -112,9 +131,9 @@ var (
 // written the identical default branch by hand, and the third would have had to
 // remember to.
 //
-// It counts the sighting, logs the first occurrence of each distinct name, and
-// returns. It writes NO response: the caller has already committed to answering
-// 2xx on this path, and that rule is asserted by
+// It counts the sighting, reports the first occurrence of each distinct name,
+// and returns. It writes NO response: the caller has already committed to
+// answering 2xx on this path, and that rule is asserted by
 // contracttesting.AssertUnknownHookEventObserved rather than left to each
 // receiver.
 //
@@ -127,49 +146,64 @@ func IgnoreUnknownEvent(log outbound.Logger, component, adapter, sessionID, even
 		log.LogError(component, sessionID, fmt.Sprintf(
 			"unrecognized hook event %q from %s: ignored, answered 2xx. Further occurrences of this name are counted, not logged — an upstream event rename looks exactly like this, so check the count in the diagnostics bundle's hooks.json before dismissing it.",
 			truncateEventName(event), adapter))
-	case unknownTableFull:
-		unknownSaturationOnce.Do(func() {
-			log.LogError(component, sessionID, fmt.Sprintf(
-				"unrecognized hook event %q from %s: ignored, and NOT counted — the distinct-name table is full at %d entries. Later names are totalled in unknown_event_names_dropped only.",
-				truncateEventName(event), adapter, MaxUnknownEventNames))
-		})
-	case unknownRepeat:
-		// Counted. Deliberately silent: this is the flooding case.
+	case unknownTableFullFirst:
+		log.LogError(component, sessionID, fmt.Sprintf(
+			"unrecognized hook event %q from %s: ignored, and NOT counted by name — the distinct-name table is full at %d entries, so no further name from this adapter can be attributed. Later sightings are totalled per adapter in hooks.json's unknown_event_names_dropped_by_adapter.",
+			truncateEventName(event), adapter, MaxUnknownEventNames))
+	case unknownRepeat, unknownTableFullRepeat:
+		// Counted. Deliberately silent: these are the flooding cases.
 	}
 }
 
 // observeUnknownEvent records one sighting and reports what kind it was.
 //
 // The double-checked shape is not premature optimization: the fast path is the
-// repeat, and the write lock is taken only on the transition that also produces
-// the log line — so "first sighting" is decided by exactly one goroutine even
-// when two arrive together, which is what makes "logged once" true rather than
-// approximately true.
+// repeat, and the write lock is taken only on a transition that also produces a
+// log line — so "first sighting" and "first drop for this adapter" are each
+// decided by exactly one goroutine even when several arrive together, which is
+// what makes "reported once" true rather than approximately true. Both
+// decisions are made under the same lock as the state they consult, so there is
+// no piece of this state living outside the mutex's protection domain.
 func observeUnknownEvent(adapter, event string) unknownOutcome {
 	key := UnknownEvent{Adapter: adapter, Event: truncateEventName(event)}
 
 	unknownMu.RLock()
-	c := unknownCounts[key]
+	counter := unknownCounts[key]
+	var dropped *atomic.Uint64
+	if counter == nil && unknownSaturated.Load() {
+		dropped = unknownDropped[adapter]
+	}
 	unknownMu.RUnlock()
-	if c != nil {
-		c.Add(1)
+	if counter != nil {
+		counter.Add(1)
 		return unknownRepeat
+	}
+	if dropped != nil {
+		dropped.Add(1)
+		return unknownTableFullRepeat
 	}
 
 	unknownMu.Lock()
 	defer unknownMu.Unlock()
-	if c := unknownCounts[key]; c != nil {
-		// Lost the race to insert. The winner logs; this one only counts.
-		c.Add(1)
+	if counter := unknownCounts[key]; counter != nil {
+		// Lost the race to insert. The winner reports; this one only counts.
+		counter.Add(1)
 		return unknownRepeat
 	}
 	if len(unknownCounts) >= MaxUnknownEventNames {
-		unknownNamesDropped.Add(1)
-		return unknownTableFull
+		unknownSaturated.Store(true)
+		if dropped := unknownDropped[adapter]; dropped != nil {
+			dropped.Add(1)
+			return unknownTableFullRepeat
+		}
+		dropped := &atomic.Uint64{}
+		dropped.Add(1)
+		unknownDropped[adapter] = dropped
+		return unknownTableFullFirst
 	}
-	counter := &atomic.Uint64{}
-	counter.Add(1)
-	unknownCounts[key] = counter
+	fresh := &atomic.Uint64{}
+	fresh.Add(1)
+	unknownCounts[key] = fresh
 	return unknownFirstSighting
 }
 
@@ -203,21 +237,49 @@ type UnknownEventCount struct {
 }
 
 // UnknownEventTotal is the total number of unrecognized events seen, across
-// every name — including the ones the table had no room to name.
+// every name — including the ones the table had no room to name. It is
+// published in the diagnostics bundle rather than left for a reader to
+// reconstruct by summing rows and remembering to add the drops.
 func UnknownEventTotal() uint64 {
-	total := UnknownEventNamesDropped()
 	unknownMu.RLock()
 	defer unknownMu.RUnlock()
+	var total uint64
 	for _, counter := range unknownCounts {
 		total += counter.Load()
+	}
+	for _, dropped := range unknownDropped {
+		total += dropped.Load()
 	}
 	return total
 }
 
-// UnknownEventNamesDropped is how many sightings arrived after the distinct-name
-// table saturated. Non-zero means UnknownEvents is incomplete, which is exactly
-// the thing a reader must not have to infer.
-func UnknownEventNamesDropped() uint64 { return unknownNamesDropped.Load() }
+// UnknownEventNamesDropped is how many sightings arrived, per adapter, after
+// the distinct-name table saturated. A non-empty result means UnknownEvents is
+// incomplete FOR THOSE ADAPTERS, which is exactly the thing a reader must not
+// have to infer — and keyed by adapter it still says which CLI is producing
+// them once the names themselves are no longer recoverable.
+func UnknownEventNamesDropped() map[string]uint64 {
+	unknownMu.RLock()
+	defer unknownMu.RUnlock()
+	out := make(map[string]uint64, len(unknownDropped))
+	for adapter, dropped := range unknownDropped {
+		if n := dropped.Load(); n > 0 {
+			out[adapter] = n
+		}
+	}
+	return out
+}
+
+// UnknownEventNamesDroppedTotal is the drop count across every adapter.
+func UnknownEventNamesDroppedTotal() uint64 {
+	var total uint64
+	unknownMu.RLock()
+	defer unknownMu.RUnlock()
+	for _, dropped := range unknownDropped {
+		total += dropped.Load()
+	}
+	return total
+}
 
 // resetUnknownEvents clears the table. Test-only, and unexported so it cannot
 // become a production reset: one test in this package deliberately saturates the
@@ -229,13 +291,18 @@ func resetUnknownEvents() {
 	unknownMu.Lock()
 	defer unknownMu.Unlock()
 	unknownCounts = make(map[UnknownEvent]*atomic.Uint64)
-	unknownNamesDropped.Store(0)
-	unknownSaturationOnce = sync.Once{}
+	unknownDropped = make(map[string]*atomic.Uint64)
+	unknownSaturated.Store(false)
 }
 
 // truncateEventName bounds a retained name at a rune boundary. Cutting mid-rune
 // would store invalid UTF-8, which then has to survive JSON encoding into a
 // diagnostics bundle.
+//
+// The bound means "once per distinct name" is really "once per distinct
+// RETAINED name": two names sharing a 64-byte prefix collapse to one key. No
+// real event name comes close, and the alternative is retaining whatever a local
+// caller sends.
 func truncateEventName(name string) string {
 	if len(name) <= maxUnknownEventNameLen {
 		return name

--- a/core/adapters/inbound/agents/hookjson/unknown_test.go
+++ b/core/adapters/inbound/agents/hookjson/unknown_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"unicode/utf8"
 )
@@ -36,6 +37,28 @@ func (l *countingLogger) mentioning(substr string) int {
 		}
 	}
 	return n
+}
+
+// resetUnknownEvents clears the table. It lives in the test file, not beside
+// the counters, so the production binary carries no way to zero them: a counter
+// an operator can reset is a counter that can hide the thing it was added to
+// reveal. Tests need it because one of them deliberately saturates the shared
+// table, which would otherwise make every test after it fail for a reason that
+// has nothing to do with that test.
+func resetUnknownEvents() {
+	unknownMu.Lock()
+	defer unknownMu.Unlock()
+	unknownCounts = make(map[UnknownEvent]*atomic.Uint64)
+	unknownDropped = make(map[string]*atomic.Uint64)
+}
+
+// droppedTotal sums the per-adapter drop counters.
+func droppedTotal() uint64 {
+	var total uint64
+	for _, n := range UnknownEventNamesDropped() {
+		total += n
+	}
+	return total
 }
 
 // countFor reads one (adapter, event) counter out of the snapshot.
@@ -79,7 +102,7 @@ func TestUnknownEventsAreKeyedPerAdapter(t *testing.T) {
 func TestUnknownEventTotalIncludesDropped(t *testing.T) {
 	resetUnknownEvents()
 	log := &countingLogger{}
-	before, beforeDropped := UnknownEventTotal(), UnknownEventNamesDroppedTotal()
+	before, beforeDropped := UnknownEventTotal(), droppedTotal()
 
 	IgnoreUnknownEvent(log, "comp", "adapter-total", "sess", "TotalledEvent")
 	IgnoreUnknownEvent(log, "comp", "adapter-total", "sess", "TotalledEvent")
@@ -87,7 +110,7 @@ func TestUnknownEventTotalIncludesDropped(t *testing.T) {
 	if got := UnknownEventTotal() - before; got != 2 {
 		t.Errorf("total delta = %d, want 2", got)
 	}
-	if got := UnknownEventNamesDroppedTotal() - beforeDropped; got != 0 {
+	if got := droppedTotal() - beforeDropped; got != 0 {
 		t.Errorf("dropped delta = %d, want 0 — the table was nowhere near full", got)
 	}
 }
@@ -139,15 +162,15 @@ func TestUnknownEventTableSaturates(t *testing.T) {
 	log := &countingLogger{}
 
 	// Fill the table with junk aimed at one adapter.
-	for i := 0; i < MaxUnknownEventNames+8; i++ {
+	for i := 0; i < maxUnknownEventNames+8; i++ {
 		IgnoreUnknownEvent(log, "comp", "adapter-junk", "sess", fmt.Sprintf("Sat%03d", i))
 	}
-	if n := len(UnknownEvents()); n > MaxUnknownEventNames {
-		t.Errorf("retained %d distinct names, want at most %d", n, MaxUnknownEventNames)
+	if n := len(UnknownEvents()); n > maxUnknownEventNames {
+		t.Errorf("retained %d distinct names, want at most %d", n, maxUnknownEventNames)
 	}
-	if UnknownEventNamesDroppedTotal() == 0 {
+	if droppedTotal() == 0 {
 		t.Fatalf("posting %d distinct names past a cap of %d dropped none — the table is unbounded",
-			MaxUnknownEventNames+8, MaxUnknownEventNames)
+			maxUnknownEventNames+8, maxUnknownEventNames)
 	}
 
 	// Now a real rename at a DIFFERENT adapter, arriving on every tool call.
@@ -167,8 +190,8 @@ func TestUnknownEventTableSaturates(t *testing.T) {
 		t.Errorf("saturation was announced %d time(s), want exactly 2 — once per adapter, so a second adapter's rename is not silenced by the first adapter's junk, and not once per event either", n)
 	}
 	// The total still accounts for every event that arrived, named or not.
-	if total := UnknownEventTotal(); total < 500+uint64(MaxUnknownEventNames) {
-		t.Errorf("total = %d, want at least %d — dropped sightings must still be totalled", total, 500+MaxUnknownEventNames)
+	if total := UnknownEventTotal(); total < 500+uint64(maxUnknownEventNames) {
+		t.Errorf("total = %d, want at least %d — dropped sightings must still be totalled", total, 500+maxUnknownEventNames)
 	}
 }
 

--- a/core/adapters/inbound/agents/hookjson/unknown_test.go
+++ b/core/adapters/inbound/agents/hookjson/unknown_test.go
@@ -79,7 +79,7 @@ func TestUnknownEventsAreKeyedPerAdapter(t *testing.T) {
 func TestUnknownEventTotalIncludesDropped(t *testing.T) {
 	resetUnknownEvents()
 	log := &countingLogger{}
-	before, beforeDropped := UnknownEventTotal(), UnknownEventNamesDropped()
+	before, beforeDropped := UnknownEventTotal(), UnknownEventNamesDroppedTotal()
 
 	IgnoreUnknownEvent(log, "comp", "adapter-total", "sess", "TotalledEvent")
 	IgnoreUnknownEvent(log, "comp", "adapter-total", "sess", "TotalledEvent")
@@ -87,7 +87,7 @@ func TestUnknownEventTotalIncludesDropped(t *testing.T) {
 	if got := UnknownEventTotal() - before; got != 2 {
 		t.Errorf("total delta = %d, want 2", got)
 	}
-	if got := UnknownEventNamesDropped() - beforeDropped; got != 0 {
+	if got := UnknownEventNamesDroppedTotal() - beforeDropped; got != 0 {
 		t.Errorf("dropped delta = %d, want 0 — the table was nowhere near full", got)
 	}
 }
@@ -99,8 +99,11 @@ func TestUnknownEventTotalIncludesDropped(t *testing.T) {
 func TestUnknownEventNameIsTruncatedAtRuneBoundary(t *testing.T) {
 	resetUnknownEvents()
 	log := &countingLogger{}
-	// Multi-byte runes, so a naive byte cut lands mid-rune.
-	long := strings.Repeat("ü", maxUnknownEventNameLen)
+	// 3-byte runes, chosen so byte index maxUnknownEventNameLen (64) is a
+	// CONTINUATION byte: 64 % 3 == 1. A 2-byte rune would leave index 64 on a
+	// rune start, and a naive `name[:64] + "…"` would satisfy every assertion
+	// below — the fixture has to be able to fail before it is evidence.
+	long := strings.Repeat("日", maxUnknownEventNameLen)
 
 	IgnoreUnknownEvent(log, "comp", "adapter-trunc", "sess", long)
 
@@ -124,29 +127,48 @@ func TestUnknownEventNameIsTruncatedAtRuneBoundary(t *testing.T) {
 	}
 }
 
-// TestUnknownEventTableSaturates pins the bound itself: past the cap, sightings
-// are still totalled and the incompleteness is reported, rather than the table
-// growing without limit on an unauthenticated endpoint.
+// TestUnknownEventTableSaturates pins the bound and, more importantly, what
+// survives it. The table is process-global and shared by every adapter, so a
+// local process can fill all of it — the endpoint is unauthenticated. What must
+// NOT happen is that a genuine rename arriving at some other adapter afterwards
+// becomes invisible: the name is unrecoverable, but the adapter and the volume
+// are not, and saturation is announced once per adapter rather than once per
+// process.
 func TestUnknownEventTableSaturates(t *testing.T) {
 	resetUnknownEvents()
 	log := &countingLogger{}
-	beforeDropped := UnknownEventNamesDropped()
 
-	// Overshoot the cap outright — other tests in this package share the table,
-	// so filling it exactly is not something a single test can arrange.
+	// Fill the table with junk aimed at one adapter.
 	for i := 0; i < MaxUnknownEventNames+8; i++ {
-		IgnoreUnknownEvent(log, "comp", "adapter-sat", "sess", fmt.Sprintf("Sat%03d", i))
-	}
-
-	if got := UnknownEventNamesDropped() - beforeDropped; got == 0 {
-		t.Fatalf("posting %d distinct names past a cap of %d dropped none — the table is unbounded",
-			MaxUnknownEventNames+8, MaxUnknownEventNames)
+		IgnoreUnknownEvent(log, "comp", "adapter-junk", "sess", fmt.Sprintf("Sat%03d", i))
 	}
 	if n := len(UnknownEvents()); n > MaxUnknownEventNames {
 		t.Errorf("retained %d distinct names, want at most %d", n, MaxUnknownEventNames)
 	}
-	if n := log.mentioning("distinct-name table is full"); n != 1 {
-		t.Errorf("table saturation was reported %d time(s), want exactly 1 — the report must not itself become the flood", n)
+	if UnknownEventNamesDroppedTotal() == 0 {
+		t.Fatalf("posting %d distinct names past a cap of %d dropped none — the table is unbounded",
+			MaxUnknownEventNames+8, MaxUnknownEventNames)
+	}
+
+	// Now a real rename at a DIFFERENT adapter, arriving on every tool call.
+	for i := 0; i < 500; i++ {
+		IgnoreUnknownEvent(log, "comp", "adapter-victim", "sess", "RenamedAssert")
+	}
+
+	dropped := UnknownEventNamesDropped()
+	if dropped["adapter-victim"] != 500 {
+		t.Errorf("victim adapter dropped %d, want 500 — a table filled by one adapter must not make another adapter's flood unattributable",
+			dropped["adapter-victim"])
+	}
+	if dropped["adapter-junk"] == 0 {
+		t.Error("junk adapter's drops were not attributed to it")
+	}
+	if n := log.mentioning("distinct-name table is full"); n != 2 {
+		t.Errorf("saturation was announced %d time(s), want exactly 2 — once per adapter, so a second adapter's rename is not silenced by the first adapter's junk, and not once per event either", n)
+	}
+	// The total still accounts for every event that arrived, named or not.
+	if total := UnknownEventTotal(); total < 500+uint64(MaxUnknownEventNames) {
+		t.Errorf("total = %d, want at least %d — dropped sightings must still be totalled", total, 500+MaxUnknownEventNames)
 	}
 }
 

--- a/core/adapters/inbound/agents/hookjson/unknown_test.go
+++ b/core/adapters/inbound/agents/hookjson/unknown_test.go
@@ -1,0 +1,181 @@
+package hookjson
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"unicode/utf8"
+)
+
+// countingLogger records the lines IgnoreUnknownEvent emits.
+type countingLogger struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *countingLogger) LogInfo(_, _, msg string)  { l.add(msg) }
+func (l *countingLogger) LogError(_, _, msg string) { l.add(msg) }
+func (l *countingLogger) LogProcessingTime(string, string, int64, int, string) {
+}
+func (l *countingLogger) Close() error { return nil }
+
+func (l *countingLogger) add(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, msg)
+}
+
+func (l *countingLogger) mentioning(substr string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var n int
+	for _, line := range l.lines {
+		if strings.Contains(line, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// countFor reads one (adapter, event) counter out of the snapshot.
+func countFor(adapter, event string) uint64 {
+	for _, row := range UnknownEvents() {
+		if row.Adapter == adapter && row.Event == event {
+			return row.Count
+		}
+	}
+	return 0
+}
+
+// TestUnknownEventsAreKeyedPerAdapter pins the half of the key that is easiest
+// to drop: the same event name arriving at two adapters must not merge into one
+// row. A merged count attributes a rename to a CLI that never sent it.
+func TestUnknownEventsAreKeyedPerAdapter(t *testing.T) {
+	resetUnknownEvents()
+	log := &countingLogger{}
+	const event = "SharedNameKeyedPerAdapter"
+
+	IgnoreUnknownEvent(log, "comp", "adapter-a", "sess", event)
+	IgnoreUnknownEvent(log, "comp", "adapter-a", "sess", event)
+	IgnoreUnknownEvent(log, "comp", "adapter-b", "sess", event)
+
+	if got := countFor("adapter-a", event); got != 2 {
+		t.Errorf("adapter-a count = %d, want 2", got)
+	}
+	if got := countFor("adapter-b", event); got != 1 {
+		t.Errorf("adapter-b count = %d, want 1", got)
+	}
+	// One line per (adapter, name), not one per name: two adapters seeing the
+	// same rename are two facts, and an operator has to see both.
+	if n := log.mentioning(event); n != 2 {
+		t.Errorf("logged %d line(s) for %q across two adapters, want 2", n, event)
+	}
+}
+
+// TestUnknownEventTotalIncludesDropped is the arithmetic a reader relies on:
+// the total is the number of unrecognized events that ARRIVED, not the number
+// the name table had room for.
+func TestUnknownEventTotalIncludesDropped(t *testing.T) {
+	resetUnknownEvents()
+	log := &countingLogger{}
+	before, beforeDropped := UnknownEventTotal(), UnknownEventNamesDropped()
+
+	IgnoreUnknownEvent(log, "comp", "adapter-total", "sess", "TotalledEvent")
+	IgnoreUnknownEvent(log, "comp", "adapter-total", "sess", "TotalledEvent")
+
+	if got := UnknownEventTotal() - before; got != 2 {
+		t.Errorf("total delta = %d, want 2", got)
+	}
+	if got := UnknownEventNamesDropped() - beforeDropped; got != 0 {
+		t.Errorf("dropped delta = %d, want 0 — the table was nowhere near full", got)
+	}
+}
+
+// TestUnknownEventNameIsTruncatedAtRuneBoundary covers the retention bound. The
+// endpoint is unauthenticated, so the name is caller-supplied and held for the
+// life of the process; what must never happen is that the retained bytes are
+// invalid UTF-8 and blow up JSON encoding of the diagnostics bundle.
+func TestUnknownEventNameIsTruncatedAtRuneBoundary(t *testing.T) {
+	resetUnknownEvents()
+	log := &countingLogger{}
+	// Multi-byte runes, so a naive byte cut lands mid-rune.
+	long := strings.Repeat("ü", maxUnknownEventNameLen)
+
+	IgnoreUnknownEvent(log, "comp", "adapter-trunc", "sess", long)
+
+	var retained string
+	for _, row := range UnknownEvents() {
+		if row.Adapter == "adapter-trunc" {
+			retained = row.Event
+		}
+	}
+	if retained == "" {
+		t.Fatal("no row retained for adapter-trunc")
+	}
+	if retained == long {
+		t.Fatalf("name of %d bytes was retained whole; want it bounded", len(long))
+	}
+	if !utf8.ValidString(retained) {
+		t.Errorf("retained name is not valid UTF-8: %q", retained)
+	}
+	if !strings.HasSuffix(retained, "…") {
+		t.Errorf("retained name %q does not mark that it was truncated", retained)
+	}
+}
+
+// TestUnknownEventTableSaturates pins the bound itself: past the cap, sightings
+// are still totalled and the incompleteness is reported, rather than the table
+// growing without limit on an unauthenticated endpoint.
+func TestUnknownEventTableSaturates(t *testing.T) {
+	resetUnknownEvents()
+	log := &countingLogger{}
+	beforeDropped := UnknownEventNamesDropped()
+
+	// Overshoot the cap outright — other tests in this package share the table,
+	// so filling it exactly is not something a single test can arrange.
+	for i := 0; i < MaxUnknownEventNames+8; i++ {
+		IgnoreUnknownEvent(log, "comp", "adapter-sat", "sess", fmt.Sprintf("Sat%03d", i))
+	}
+
+	if got := UnknownEventNamesDropped() - beforeDropped; got == 0 {
+		t.Fatalf("posting %d distinct names past a cap of %d dropped none — the table is unbounded",
+			MaxUnknownEventNames+8, MaxUnknownEventNames)
+	}
+	if n := len(UnknownEvents()); n > MaxUnknownEventNames {
+		t.Errorf("retained %d distinct names, want at most %d", n, MaxUnknownEventNames)
+	}
+	if n := log.mentioning("distinct-name table is full"); n != 1 {
+		t.Errorf("table saturation was reported %d time(s), want exactly 1 — the report must not itself become the flood", n)
+	}
+}
+
+// TestUnknownEventFirstSightingIsLoggedOnceUnderConcurrency is the property the
+// double-checked insert exists for: two goroutines racing on a name neither has
+// seen must produce exactly one line, not two. Run with -race.
+func TestUnknownEventFirstSightingIsLoggedOnceUnderConcurrency(t *testing.T) {
+	resetUnknownEvents()
+	log := &countingLogger{}
+	const event = "ConcurrentFirstSighting"
+	const goroutines = 32
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			IgnoreUnknownEvent(log, "comp", "adapter-race", "sess", event)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := countFor("adapter-race", event); got != goroutines {
+		t.Errorf("count = %d, want %d — a sighting was lost", got, goroutines)
+	}
+	if n := log.mentioning(event); n != 1 {
+		t.Errorf("logged %d line(s), want exactly 1", n)
+	}
+}

--- a/core/application/services/diagnostics_service.go
+++ b/core/application/services/diagnostics_service.go
@@ -73,10 +73,14 @@ type UnknownHookEvent struct {
 type HookHealthSnapshot struct {
 	// UnknownEvents is every retained (adapter, name) pair with its count.
 	UnknownEvents []UnknownHookEvent
-	// UnknownNamesDropped is how many sightings arrived after the receivers'
-	// bounded name table saturated. Non-zero means UnknownEvents is incomplete
-	// — reported so a reader never has to infer that.
-	UnknownNamesDropped uint64
+	// UnknownNamesDropped is how many sightings arrived, PER ADAPTER, after the
+	// receivers' bounded name table saturated. A non-empty map means
+	// UnknownEvents is incomplete for those adapters — reported, and attributed,
+	// so a reader never has to infer either fact.
+	UnknownNamesDropped map[string]uint64
+	// UnknownEventsTotal is every unrecognized event seen, named or dropped, so
+	// the total is read rather than reconstructed.
+	UnknownEventsTotal uint64
 }
 
 // DiagnosticsServiceDeps bundles NewDiagnosticsService's dependencies.
@@ -431,33 +435,46 @@ func (s *DiagnosticsService) configView() any {
 // distinct name is written at error level, and events.log IS in this bundle, so
 // even the CLI-collected form carries the names — just not the volumes.
 func (s *DiagnosticsService) hooksView() any {
-	view := struct {
-		CollectedFrom            string             `json:"collected_from"`
-		Note                     string             `json:"note,omitempty"`
-		UnknownEvents            []UnknownHookEvent `json:"unknown_events,omitempty"`
-		UnknownEventNamesDropped uint64             `json:"unknown_event_names_dropped"`
-	}{CollectedFrom: "daemon"}
-
 	if s.hookHealth == nil {
-		view.CollectedFrom = "cli"
-		view.Note = "Collected by `irrlichd --diagnose`, which runs in a process that never served a hook, " +
-			"so the receivers' unrecognized-event counters are not readable here and are omitted rather than " +
-			"reported as zero. The FIRST sighting of each unrecognized event name is logged at error level, so " +
-			"events.log in this bundle still names them. For live counts, fetch GET /debug/bundle from the " +
-			"running daemon."
-		return view
+		// A DIFFERENT shape, not the daemon shape with zeros in it. Emitting
+		// `"unknown_event_names_dropped": 0` here would publish a count from a
+		// process that could not have observed one — the very thing the note
+		// beside it says is not being done.
+		return struct {
+			CollectedFrom string `json:"collected_from"`
+			Note          string `json:"note"`
+		}{
+			CollectedFrom: "cli",
+			Note: "Collected by `irrlichd --diagnose`, which runs in a process that never served a hook, " +
+				"so the receivers' unrecognized-event counters are not readable here and are omitted rather than " +
+				"reported as zero. The FIRST sighting of each unrecognized event name is logged at error level, so " +
+				"events.log in this bundle still names them. For live counts, fetch GET /debug/bundle from the " +
+				"running daemon.",
+		}
 	}
 
 	snap := s.hookHealth()
-	view.UnknownEvents = snap.UnknownEvents
-	view.UnknownEventNamesDropped = snap.UnknownNamesDropped
-	sort.Slice(view.UnknownEvents, func(i, j int) bool {
-		if view.UnknownEvents[i].Adapter != view.UnknownEvents[j].Adapter {
-			return view.UnknownEvents[i].Adapter < view.UnknownEvents[j].Adapter
+	// Copied before sorting: the slice belongs to the injected snapshot source,
+	// not to this service, and reordering a caller's slice in place is the
+	// aliasing bug this repo has already paid for once (#965/#967/#975).
+	events := append([]UnknownHookEvent(nil), snap.UnknownEvents...)
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].Adapter != events[j].Adapter {
+			return events[i].Adapter < events[j].Adapter
 		}
-		return view.UnknownEvents[i].Event < view.UnknownEvents[j].Event
+		return events[i].Event < events[j].Event
 	})
-	return view
+	return struct {
+		CollectedFrom            string             `json:"collected_from"`
+		UnknownEventsTotal       uint64             `json:"unknown_events_total"`
+		UnknownEvents            []UnknownHookEvent `json:"unknown_events,omitempty"`
+		UnknownEventNamesDropped map[string]uint64  `json:"unknown_event_names_dropped_by_adapter,omitempty"`
+	}{
+		CollectedFrom:            "daemon",
+		UnknownEventsTotal:       snap.UnknownEventsTotal,
+		UnknownEvents:            events,
+		UnknownEventNamesDropped: snap.UnknownNamesDropped,
+	}
 }
 
 func stateView(sessions []*session.SessionState, now time.Time) any {

--- a/core/application/services/diagnostics_service.go
+++ b/core/application/services/diagnostics_service.go
@@ -50,6 +50,33 @@ type DiagnosticsService struct {
 	cfg            config.Config
 	version        string
 	paths          DiagnosticsPaths
+	hookHealth     func() HookHealthSnapshot
+}
+
+// UnknownHookEvent is one (adapter, event name) pair a hook receiver was sent
+// and did not recognize, with how many times it arrived (issue #1364). The name
+// is half the key on purpose: an upstream rename arrives on every tool call
+// forever, a stray local POST arrives once, and a count that cannot separate
+// those says nothing.
+type UnknownHookEvent struct {
+	Adapter string `json:"adapter"`
+	Event   string `json:"event"`
+	Count   uint64 `json:"count"`
+}
+
+// HookHealthSnapshot is the receiver-side hook counters at one instant.
+//
+// It is a plain value handed in by the composition root rather than read from
+// the adapter package, because application/services must not import
+// adapters/inbound — the hexagonal rule core/architecture_test.go enforces. The
+// daemon converts hookjson's snapshot into this; --diagnose supplies nothing.
+type HookHealthSnapshot struct {
+	// UnknownEvents is every retained (adapter, name) pair with its count.
+	UnknownEvents []UnknownHookEvent
+	// UnknownNamesDropped is how many sightings arrived after the receivers'
+	// bounded name table saturated. Non-zero means UnknownEvents is incomplete
+	// — reported so a reader never has to infer that.
+	UnknownNamesDropped uint64
 }
 
 // DiagnosticsServiceDeps bundles NewDiagnosticsService's dependencies.
@@ -65,6 +92,11 @@ type DiagnosticsServiceDeps struct {
 	Cfg            config.Config
 	Version        string
 	Paths          DiagnosticsPaths
+	// HookHealth snapshots the live hook-receiver counters. NIL IS MEANINGFUL:
+	// it says this process never served a hook (the --diagnose CLI), and
+	// hooks.json then omits the counts and says where the real ones are, rather
+	// than publishing zeros that look like an all-clear.
+	HookHealth func() HookHealthSnapshot
 }
 
 // NewDiagnosticsService wires the service.
@@ -78,6 +110,7 @@ func NewDiagnosticsService(deps DiagnosticsServiceDeps) *DiagnosticsService {
 		cfg:            deps.Cfg,
 		version:        deps.Version,
 		paths:          deps.Paths,
+		hookHealth:     deps.HookHealth,
 	}
 }
 
@@ -106,6 +139,7 @@ func (s *DiagnosticsService) WriteBundle(w io.Writer) error {
 	s.addLedgers(b)
 	b.addJSON("liveness.json", s.liveness(sessions, b.red))
 	b.addJSON("processes.json", s.processes(b.red))
+	b.addJSON("hooks.json", s.hooksView())
 	s.addLogs(b)
 
 	if errs := b.errs; len(errs) > 0 {
@@ -379,6 +413,51 @@ func (s *DiagnosticsService) configView() any {
 		ReadySessionTTL: s.cfg.ReadySessionTTL.String(),
 		PermissionMode:  s.cfg.PermissionMode,
 	}
+}
+
+// hooksView renders hooks.json: what the daemon's hook receivers were sent and
+// did not recognize (issue #1364).
+//
+// The honesty problem this section has to solve is structural, not cosmetic.
+// The counters live in the daemon process, and `irrlichd --diagnose` builds its
+// bundle in a SEPARATE, freshly launched process that resolves the same stores
+// off disk and never serves a hook (see runDiagnose's doc comment). Reporting
+// its zeros as counts would tell a bug reporter "no unrecognized events" using
+// numbers from a process that could not have seen one — the exact silence #1364
+// is about, re-created inside the fix for it. So when no snapshot source is
+// wired the counts are OMITTED and the section says where the real ones are.
+//
+// The log line is what covers that gap in practice: the first sighting of each
+// distinct name is written at error level, and events.log IS in this bundle, so
+// even the CLI-collected form carries the names — just not the volumes.
+func (s *DiagnosticsService) hooksView() any {
+	view := struct {
+		CollectedFrom            string             `json:"collected_from"`
+		Note                     string             `json:"note,omitempty"`
+		UnknownEvents            []UnknownHookEvent `json:"unknown_events,omitempty"`
+		UnknownEventNamesDropped uint64             `json:"unknown_event_names_dropped"`
+	}{CollectedFrom: "daemon"}
+
+	if s.hookHealth == nil {
+		view.CollectedFrom = "cli"
+		view.Note = "Collected by `irrlichd --diagnose`, which runs in a process that never served a hook, " +
+			"so the receivers' unrecognized-event counters are not readable here and are omitted rather than " +
+			"reported as zero. The FIRST sighting of each unrecognized event name is logged at error level, so " +
+			"events.log in this bundle still names them. For live counts, fetch GET /debug/bundle from the " +
+			"running daemon."
+		return view
+	}
+
+	snap := s.hookHealth()
+	view.UnknownEvents = snap.UnknownEvents
+	view.UnknownEventNamesDropped = snap.UnknownNamesDropped
+	sort.Slice(view.UnknownEvents, func(i, j int) bool {
+		if view.UnknownEvents[i].Adapter != view.UnknownEvents[j].Adapter {
+			return view.UnknownEvents[i].Adapter < view.UnknownEvents[j].Adapter
+		}
+		return view.UnknownEvents[i].Event < view.UnknownEvents[j].Event
+	})
+	return view
 }
 
 func stateView(sessions []*session.SessionState, now time.Time) any {

--- a/core/application/services/diagnostics_service_test.go
+++ b/core/application/services/diagnostics_service_test.go
@@ -80,6 +80,14 @@ func untar(t *testing.T, b []byte) map[string][]byte {
 // home path and a token to prove redaction is applied.
 func buildTestService(t *testing.T) *DiagnosticsService {
 	t.Helper()
+	return buildTestServiceWithHooks(t, nil)
+}
+
+// buildTestServiceWithHooks is buildTestService with an explicit hook-health
+// source, so a test can drive hooks.json's two collection modes: nil is the
+// --diagnose CLI (a process that served no hooks), non-nil is the daemon.
+func buildTestServiceWithHooks(t *testing.T, hookHealth func() HookHealthSnapshot) *DiagnosticsService {
+	t.Helper()
 	home := "/Users/test"
 	dir := t.TempDir()
 	instancesDir := filepath.Join(dir, "instances")
@@ -131,6 +139,7 @@ func buildTestService(t *testing.T) *DiagnosticsService {
 		DefaultAdapter: "claude-code",
 		Cfg:            cfg,
 		Version:        "9.9.9+test",
+		HookHealth:     hookHealth,
 		Paths: DiagnosticsPaths{
 			Home:            home,
 			InstancesDir:    instancesDir,
@@ -151,7 +160,7 @@ func TestWriteBundleContents(t *testing.T) {
 	for _, want := range []string{
 		"version.txt", "system.txt", "config.json", "permissions.json",
 		"state.json", "sessions.json", "liveness.json", "processes.json",
-		"events.log", "instances/sess-a.json", "ledgers/abc.ledger.json",
+		"hooks.json", "events.log", "instances/sess-a.json", "ledgers/abc.ledger.json",
 	} {
 		if _, ok := files[want]; !ok {
 			t.Errorf("bundle missing %s (have %v)", want, keys(files))
@@ -290,6 +299,81 @@ func keys(m map[string][]byte) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {
 		out = append(out, k)
+	}
+	return out
+}
+
+// TestHooksBundleReportsUnknownEvents covers the daemon-collected form of
+// hooks.json (issue #1364): the per-(adapter, name) counts a hook receiver
+// accumulated, plus the saturation total, are in the bundle a bug report
+// carries.
+func TestHooksBundleReportsUnknownEvents(t *testing.T) {
+	svc := buildTestServiceWithHooks(t, func() HookHealthSnapshot {
+		return HookHealthSnapshot{
+			// Deliberately out of order: the view sorts, so two captures of the
+			// same daemon diff cleanly instead of churning on map iteration.
+			UnknownEvents: []UnknownHookEvent{
+				{Adapter: "codex", Event: "TurnComplete", Count: 1},
+				{Adapter: "claude-code", Event: "PostToolUseV2", Count: 412},
+			},
+			UnknownNamesDropped: 7,
+		}
+	})
+
+	got := hooksJSON(t, svc)
+
+	if got["collected_from"] != "daemon" {
+		t.Errorf("collected_from = %v, want \"daemon\"", got["collected_from"])
+	}
+	if _, ok := got["note"]; ok {
+		t.Errorf("daemon-collected hooks.json carries a note it does not need: %v", got["note"])
+	}
+	if got["unknown_event_names_dropped"] != float64(7) {
+		t.Errorf("unknown_event_names_dropped = %v, want 7 — a saturated name table must not read as a complete one", got["unknown_event_names_dropped"])
+	}
+	events, _ := got["unknown_events"].([]any)
+	if len(events) != 2 {
+		t.Fatalf("unknown_events has %d entries, want 2: %v", len(events), got["unknown_events"])
+	}
+	first, _ := events[0].(map[string]any)
+	if first["adapter"] != "claude-code" || first["event"] != "PostToolUseV2" || first["count"] != float64(412) {
+		t.Errorf("first row = %v, want claude-code/PostToolUseV2/412 (sorted by adapter then event)", first)
+	}
+}
+
+// TestHooksBundleOmitsCountsWhenNotCollectedInDaemon is the honesty obligation.
+// `irrlichd --diagnose` builds its bundle in a process that never served a hook,
+// so its counters are structurally zero; publishing them as counts would tell a
+// bug reporter "no unrecognized events" on evidence that could not exist.
+func TestHooksBundleOmitsCountsWhenNotCollectedInDaemon(t *testing.T) {
+	got := hooksJSON(t, buildTestServiceWithHooks(t, nil))
+
+	if got["collected_from"] != "cli" {
+		t.Errorf("collected_from = %v, want \"cli\"", got["collected_from"])
+	}
+	if _, ok := got["unknown_events"]; ok {
+		t.Errorf("unknown_events is present without a daemon to read it from: %v — an empty list here reads as an all-clear", got["unknown_events"])
+	}
+	note, _ := got["note"].(string)
+	if !strings.Contains(note, "events.log") || !strings.Contains(note, "/debug/bundle") {
+		t.Errorf("note does not say where the real evidence is: %q", note)
+	}
+}
+
+// hooksJSON pulls hooks.json out of a freshly written bundle.
+func hooksJSON(t *testing.T, svc *DiagnosticsService) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := svc.WriteBundle(&buf); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	raw, ok := untar(t, buf.Bytes())["hooks.json"]
+	if !ok {
+		t.Fatal("bundle has no hooks.json")
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("hooks.json is not valid JSON: %v\n%s", err, raw)
 	}
 	return out
 }

--- a/core/application/services/diagnostics_service_test.go
+++ b/core/application/services/diagnostics_service_test.go
@@ -316,7 +316,8 @@ func TestHooksBundleReportsUnknownEvents(t *testing.T) {
 				{Adapter: "codex", Event: "TurnComplete", Count: 1},
 				{Adapter: "claude-code", Event: "PostToolUseV2", Count: 412},
 			},
-			UnknownNamesDropped: 7,
+			UnknownNamesDropped: map[string]uint64{"kiro-cli": 7},
+			UnknownEventsTotal:  420,
 		}
 	})
 
@@ -328,8 +329,12 @@ func TestHooksBundleReportsUnknownEvents(t *testing.T) {
 	if _, ok := got["note"]; ok {
 		t.Errorf("daemon-collected hooks.json carries a note it does not need: %v", got["note"])
 	}
-	if got["unknown_event_names_dropped"] != float64(7) {
-		t.Errorf("unknown_event_names_dropped = %v, want 7 — a saturated name table must not read as a complete one", got["unknown_event_names_dropped"])
+	dropped, _ := got["unknown_event_names_dropped_by_adapter"].(map[string]any)
+	if dropped["kiro-cli"] != float64(7) {
+		t.Errorf("unknown_event_names_dropped_by_adapter = %v, want kiro-cli:7 — a saturated name table must not read as a complete one, and the drops must still name the adapter", got["unknown_event_names_dropped_by_adapter"])
+	}
+	if got["unknown_events_total"] != float64(420) {
+		t.Errorf("unknown_events_total = %v, want 420 — the total is published, not left for a reader to reconstruct", got["unknown_events_total"])
 	}
 	events, _ := got["unknown_events"].([]any)
 	if len(events) != 2 {
@@ -351,8 +356,12 @@ func TestHooksBundleOmitsCountsWhenNotCollectedInDaemon(t *testing.T) {
 	if got["collected_from"] != "cli" {
 		t.Errorf("collected_from = %v, want \"cli\"", got["collected_from"])
 	}
-	if _, ok := got["unknown_events"]; ok {
-		t.Errorf("unknown_events is present without a daemon to read it from: %v — an empty list here reads as an all-clear", got["unknown_events"])
+	// Not just the list: ANY count from a process that served no hooks is a
+	// number nobody observed, and a zero reads as an all-clear.
+	for _, field := range []string{"unknown_events", "unknown_events_total", "unknown_event_names_dropped_by_adapter"} {
+		if v, ok := got[field]; ok {
+			t.Errorf("%s is present without a daemon to read it from: %v", field, v)
+		}
 	}
 	note, _ := got["note"].(string)
 	if !strings.Contains(note, "events.log") || !strings.Contains(note, "/debug/bundle") {

--- a/core/cmd/irrlichd/daemon_smoke_test.go
+++ b/core/cmd/irrlichd/daemon_smoke_test.go
@@ -250,6 +250,7 @@ func assertBundleEndpoint(t *testing.T, client *http.Client, url string) {
 	}
 	tr := tar.NewReader(gz)
 	var hasVersion bool
+	var hooks []byte
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -258,12 +259,42 @@ func assertBundleEndpoint(t *testing.T, client *http.Client, url string) {
 		if err != nil {
 			t.Fatalf("bundle is not a valid tar: %v", err)
 		}
-		if hdr.Name == "version.txt" {
+		switch hdr.Name {
+		case "version.txt":
 			hasVersion = true
+		case "hooks.json":
+			if hooks, err = io.ReadAll(tr); err != nil {
+				t.Fatalf("read hooks.json: %v", err)
+			}
 		}
 	}
 	if !hasVersion {
 		t.Errorf("bundle from %s missing version.txt", url)
+	}
+	assertHooksCollectedInDaemon(t, url, hooks)
+}
+
+// assertHooksCollectedInDaemon checks that the LIVE daemon's bundle reports its
+// hook counters as daemon-collected (issue #1364).
+//
+// This is the only thing that proves startup.go passes liveHookHealth. Every
+// other test of hooks.json builds the service itself, and the service's
+// nil-HookHealth branch is a perfectly valid, perfectly quiet output — so a
+// daemon that forgot to wire the snapshot would emit the CLI form here and no
+// unit test anywhere would notice.
+func assertHooksCollectedInDaemon(t *testing.T, url string, raw []byte) {
+	t.Helper()
+	if len(raw) == 0 {
+		t.Fatalf("bundle from %s missing hooks.json", url)
+	}
+	var hooks struct {
+		CollectedFrom string `json:"collected_from"`
+	}
+	if err := json.Unmarshal(raw, &hooks); err != nil {
+		t.Fatalf("hooks.json is not valid JSON: %v\n%s", err, raw)
+	}
+	if hooks.CollectedFrom != "daemon" {
+		t.Errorf("hooks.json collected_from = %q, want \"daemon\" — the running daemon did not wire its hook counters into the bundle", hooks.CollectedFrom)
 	}
 }
 

--- a/core/cmd/irrlichd/daemon_smoke_test.go
+++ b/core/cmd/irrlichd/daemon_smoke_test.go
@@ -244,34 +244,36 @@ func assertBundleEndpoint(t *testing.T, client *http.Client, url string) {
 	if err != nil {
 		t.Fatalf("read %s: %v", url, err)
 	}
+	entries := readBundleEntries(t, body)
+	if _, ok := entries["version.txt"]; !ok {
+		t.Errorf("bundle from %s missing version.txt", url)
+	}
+	assertHooksCollectedInDaemon(t, url, entries["hooks.json"])
+}
+
+// readBundleEntries decodes the gzip+tar bundle into name → contents.
+func readBundleEntries(t *testing.T, body []byte) map[string][]byte {
+	t.Helper()
 	gz, err := gzip.NewReader(bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("bundle is not valid gzip: %v", err)
 	}
+	entries := map[string][]byte{}
 	tr := tar.NewReader(gz)
-	var hasVersion bool
-	var hooks []byte
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
-			break
+			return entries
 		}
 		if err != nil {
 			t.Fatalf("bundle is not a valid tar: %v", err)
 		}
-		switch hdr.Name {
-		case "version.txt":
-			hasVersion = true
-		case "hooks.json":
-			if hooks, err = io.ReadAll(tr); err != nil {
-				t.Fatalf("read hooks.json: %v", err)
-			}
+		data, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("read %s from bundle: %v", hdr.Name, err)
 		}
+		entries[hdr.Name] = data
 	}
-	if !hasVersion {
-		t.Errorf("bundle from %s missing version.txt", url)
-	}
-	assertHooksCollectedInDaemon(t, url, hooks)
 }
 
 // assertHooksCollectedInDaemon checks that the LIVE daemon's bundle reports its

--- a/core/cmd/irrlichd/paths.go
+++ b/core/cmd/irrlichd/paths.go
@@ -116,7 +116,10 @@ func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Ag
 // accumulate in whatever process served the hooks, and --diagnose is not that
 // process.
 func liveHookHealth() services.HookHealthSnapshot {
-	snap := services.HookHealthSnapshot{UnknownNamesDropped: hookjson.UnknownEventNamesDropped()}
+	snap := services.HookHealthSnapshot{
+		UnknownNamesDropped: hookjson.UnknownEventNamesDropped(),
+		UnknownEventsTotal:  hookjson.UnknownEventTotal(),
+	}
 	for _, row := range hookjson.UnknownEvents() {
 		snap.UnknownEvents = append(snap.UnknownEvents, services.UnknownHookEvent{
 			Adapter: row.Adapter,

--- a/core/cmd/irrlichd/paths.go
+++ b/core/cmd/irrlichd/paths.go
@@ -9,6 +9,7 @@ import (
 
 	"irrlicht/core/adapters/inbound/agents"
 	"irrlicht/core/adapters/inbound/agents/claudecode"
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	"irrlicht/core/adapters/outbound/filesystem"
 	"irrlicht/core/adapters/outbound/logging"
@@ -85,7 +86,9 @@ func resolveSessionRepo() (*filesystem.SessionRepository, error) {
 // --diagnose CLI so both snapshot the exact same locations. fsRepo supplies both
 // the (uncached) session list and the instances dir; ledger and log dirs honor
 // IRRLICHT_HOME via the same accessors the daemon writes through.
-func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Agent, cfg config.Config) *services.DiagnosticsService {
+// hookHealth is nil-meaningful: the daemon passes liveHookHealth, --diagnose
+// passes nil, and hooks.json reports which it got. See hooksView.
+func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Agent, cfg config.Config, hookHealth func() services.HookHealthSnapshot) *services.DiagnosticsService {
 	home, _ := os.UserHomeDir()
 	ledgerDir, _ := metrics.LedgerDir()
 	logsDir, _ := logging.LogDir()
@@ -97,6 +100,7 @@ func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Ag
 		DefaultAdapter: claudecode.AdapterName,
 		Cfg:            cfg,
 		Version:        Version,
+		HookHealth:     hookHealth,
 		Paths: services.DiagnosticsPaths{
 			Home:            home,
 			InstancesDir:    fsRepo.InstancesDir(),
@@ -105,6 +109,22 @@ func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Ag
 			PermissionsFile: filepath.Join(dataDir(home), "permissions.json"),
 		},
 	})
+}
+
+// liveHookHealth snapshots the in-process hook-receiver counters for the
+// diagnostics bundle (issue #1364). Only the daemon wires it: these counters
+// accumulate in whatever process served the hooks, and --diagnose is not that
+// process.
+func liveHookHealth() services.HookHealthSnapshot {
+	snap := services.HookHealthSnapshot{UnknownNamesDropped: hookjson.UnknownEventNamesDropped()}
+	for _, row := range hookjson.UnknownEvents() {
+		snap.UnknownEvents = append(snap.UnknownEvents, services.UnknownHookEvent{
+			Adapter: row.Adapter,
+			Event:   row.Event,
+			Count:   row.Count,
+		})
+	}
+	return snap
 }
 
 // runDiagnose writes a diagnostics bundle to the current directory and exits.
@@ -128,7 +148,10 @@ func runDiagnose() {
 		log.Fatalf("diagnose: create %s: %v", out, err)
 	}
 	defer f.Close()
-	if err := buildDiagnostics(fsRepo, agents.All(), cfg).WriteBundle(f); err != nil {
+	// nil hook health on purpose: this process has served no hooks, so its
+	// counters are structurally zero and publishing them would read as an
+	// all-clear. hooks.json says so and points at GET /debug/bundle.
+	if err := buildDiagnostics(fsRepo, agents.All(), cfg, nil).WriteBundle(f); err != nil {
 		log.Fatalf("diagnose: write bundle: %v", err)
 	}
 	abs, _ := filepath.Abs(out)

--- a/core/cmd/irrlichd/paths.go
+++ b/core/cmd/irrlichd/paths.go
@@ -116,11 +116,13 @@ func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Ag
 // accumulate in whatever process served the hooks, and --diagnose is not that
 // process.
 func liveHookHealth() services.HookHealthSnapshot {
+	rows := hookjson.UnknownEvents()
 	snap := services.HookHealthSnapshot{
+		UnknownEvents:       make([]services.UnknownHookEvent, 0, len(rows)),
 		UnknownNamesDropped: hookjson.UnknownEventNamesDropped(),
 		UnknownEventsTotal:  hookjson.UnknownEventTotal(),
 	}
-	for _, row := range hookjson.UnknownEvents() {
+	for _, row := range rows {
 		snap.UnknownEvents = append(snap.UnknownEvents, services.UnknownHookEvent{
 			Adapter: row.Adapter,
 			Event:   row.Event,

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -408,7 +408,7 @@ func registerCoreRoutes(mux *http.ServeMux, deps registerCoreRoutesDeps) {
 	// per-PID liveness, trimmed logs, and config for bug reports. Localhost
 	// only — it carries session paths and (pre-redaction) process argv. Reads
 	// fsRepo directly for a fresh, uncached snapshot.
-	diagSvc := buildDiagnostics(deps.FSRepo, deps.AllAgents, deps.Cfg)
+	diagSvc := buildDiagnostics(deps.FSRepo, deps.AllAgents, deps.Cfg, liveHookHealth)
 	mux.HandleFunc("GET /debug/bundle", localhostOnly(handleDiagnosticsBundle(diagSvc)))
 }
 

--- a/core/internal/contracttesting/hook_path_confinement.go
+++ b/core/internal/contracttesting/hook_path_confinement.go
@@ -236,9 +236,7 @@ func assertRefusedBy(t *testing.T, r HookReceiver, rut HookReceiverUnderTest, pa
 	if rut.Observed() {
 		t.Errorf("%s was dispatched downstream: %s", what, path)
 	}
-	if rec.Code < 200 || rec.Code > 299 {
-		t.Errorf("%s: status = %d, want 2xx — a confinement refusal is reported by the log and the counter, never by a status code on the user's critical path", what, rec.Code)
-	}
+	assertHookStatus2xx(t, rec, what)
 	if rut.Rejections == nil {
 		return
 	}
@@ -250,19 +248,5 @@ func assertRefusedBy(t *testing.T, r HookReceiver, rut HookReceiverUnderTest, pa
 // postHookPath POSTs the adapter's hook body for path and returns the response.
 func postHookPath(t *testing.T, r HookReceiver, rut HookReceiverUnderTest, path string) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, r.EndpointPath, strings.NewReader(r.PayloadFor(path)))
-	rec := httptest.NewRecorder()
-	rut.Handler.ServeHTTP(rec, req)
-	return rec
-}
-
-// mkSubdir creates and returns root/name. Transcripts sit some levels below the
-// root in every real layout, so the fixtures do too.
-func mkSubdir(t *testing.T, root, name string) string {
-	t.Helper()
-	dir := filepath.Join(root, name)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		t.Fatalf("create %s: %v", dir, err)
-	}
-	return dir
+	return postHookBody(t, rut.Handler, r.EndpointPath, r.PayloadFor(path))
 }

--- a/core/internal/contracttesting/hook_receiver.go
+++ b/core/internal/contracttesting/hook_receiver.go
@@ -1,0 +1,48 @@
+// hook_receiver.go holds the primitives every RECEIVING-side hook contract
+// shares, so contract number four is a set of obligations rather than another
+// copy of the request plumbing.
+//
+// The 2xx assertion in particular is here rather than in either contract: "a
+// hook receiver reports a refusal through the log and the counter, never
+// through a status code on the user's critical path" is one rule (#1361,
+// #1364), and a rule stated in three places is a rule that can disagree with
+// itself.
+package contracttesting
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// postHookBody POSTs body to handler at endpoint and returns the response.
+func postHookBody(t *testing.T, handler http.Handler, endpoint, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, endpoint, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// assertHookStatus2xx checks the one status rule every hook receiver owes.
+// what names the input, so the failure says which case broke it.
+func assertHookStatus2xx(t *testing.T, rec *httptest.ResponseRecorder, what string) {
+	t.Helper()
+	if rec.Code < 200 || rec.Code > 299 {
+		t.Errorf("%s: status = %d, want 2xx — a hook receiver reports a refusal through its log and its counters, never through a status code on the user's critical path", what, rec.Code)
+	}
+}
+
+// mkSubdir creates and returns root/name. Transcripts sit some levels below the
+// root in every real layout, so the fixtures do too.
+func mkSubdir(t *testing.T, root, name string) string {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("create %s: %v", dir, err)
+	}
+	return dir
+}

--- a/core/internal/contracttesting/unknown_hook_event.go
+++ b/core/internal/contracttesting/unknown_hook_event.go
@@ -121,15 +121,13 @@ func AssertUnknownHookEventObserved(t *testing.T, r UnknownEventReceiver) {
 func assertKnownEventUncounted(t *testing.T, r UnknownEventReceiver) {
 	t.Helper()
 	transcript := unknownEventTranscript(t, r)
-	log := &RecordingLogger{}
+	log := &recordingLogger{}
 	rut := r.New(t, log)
 
 	before := unknownTotalFor(r.Adapter)
 	rec := postUnknownEvent(t, r, rut, transcript, r.KnownEvent)
 
-	if rec.Code < 200 || rec.Code > 299 {
-		t.Fatalf("recognized event %q: status = %d, want 2xx", r.KnownEvent, rec.Code)
-	}
+	assertHookStatus2xx(t, rec, fmt.Sprintf("recognized event %q", r.KnownEvent))
 	if !rut.Observed() {
 		t.Fatalf("recognized event %q was not dispatched — every obligation below it would pass vacuously", r.KnownEvent)
 	}
@@ -145,14 +143,12 @@ func assertKnownEventUncounted(t *testing.T, r UnknownEventReceiver) {
 func assertUnknownIgnored(t *testing.T, r UnknownEventReceiver) {
 	t.Helper()
 	transcript := unknownEventTranscript(t, r)
-	rut := r.New(t, &RecordingLogger{})
+	rut := r.New(t, &recordingLogger{})
 
 	event := unknownEventName(t)
 	rec := postUnknownEvent(t, r, rut, transcript, event)
 
-	if rec.Code < 200 || rec.Code > 299 {
-		t.Errorf("unrecognized event %q: status = %d, want 2xx — an unrecognized event is reported by the log and the counter, never by a status code on the user's critical path", event, rec.Code)
-	}
+	assertHookStatus2xx(t, rec, fmt.Sprintf("unrecognized event %q", event))
 	if rut.Observed() {
 		t.Errorf("unrecognized event %q was dispatched downstream — an unfamiliar name must not be guessed into a handler", event)
 	}
@@ -162,7 +158,7 @@ func assertUnknownIgnored(t *testing.T, r UnknownEventReceiver) {
 func assertUnknownCounted(t *testing.T, r UnknownEventReceiver) {
 	t.Helper()
 	transcript := unknownEventTranscript(t, r)
-	rut := r.New(t, &RecordingLogger{})
+	rut := r.New(t, &recordingLogger{})
 
 	renamed, stray := unknownEventName(t)+"Renamed", unknownEventName(t)+"Stray"
 	beforeRenamed, beforeStray := unknownCountFor(r.Adapter, renamed), unknownCountFor(r.Adapter, stray)
@@ -186,7 +182,7 @@ func assertUnknownCounted(t *testing.T, r UnknownEventReceiver) {
 func assertUnknownReportedOnce(t *testing.T, r UnknownEventReceiver) {
 	t.Helper()
 	transcript := unknownEventTranscript(t, r)
-	log := &RecordingLogger{}
+	log := &recordingLogger{}
 	rut := r.New(t, log)
 
 	flooding, second := unknownEventName(t)+"Flood", unknownEventName(t)+"Second"
@@ -221,7 +217,7 @@ func unknownEventTranscript(t *testing.T, r UnknownEventReceiver) string {
 // silently share a key and a first-sighting.
 //
 // It hashes t.Name() rather than embedding it. Retained names are bounded
-// (hookjson.MaxUnknownEventNames' sibling cap), and a Go sub-test path is long
+// (hookjson bounds a retained name in bytes), and a Go sub-test path is long
 // enough to cross that bound — which would make the contract assert against a
 // truncated key and fail for a reason that has nothing to do with the adapter.
 // Real event names are short identifiers, so a short name is also the honest
@@ -270,47 +266,44 @@ func unknownTotalFor(adapter string) uint64 {
 // response.
 func postUnknownEvent(t *testing.T, r UnknownEventReceiver, rut UnknownEventReceiverUnderTest, transcriptPath, event string) *httptest.ResponseRecorder {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, r.EndpointPath, strings.NewReader(r.PayloadFor(transcriptPath, event)))
-	rec := httptest.NewRecorder()
-	rut.Handler.ServeHTTP(rec, req)
-	return rec
+	return postHookBody(t, rut.Handler, r.EndpointPath, r.PayloadFor(transcriptPath, event))
 }
 
-// RecordingLogger is an outbound.Logger that keeps every line, so a contract can
+// recordingLogger is an outbound.Logger that keeps every line, so a contract can
 // assert on what was reported rather than only on what was returned. Safe for
 // concurrent use: hook receivers are HTTP handlers.
-type RecordingLogger struct {
+type recordingLogger struct {
 	mu    sync.Mutex
 	lines []string
 }
 
-func (l *RecordingLogger) LogInfo(eventType, sessionID, message string) {
+func (l *recordingLogger) LogInfo(eventType, sessionID, message string) {
 	l.append("info", eventType, sessionID, message)
 }
 
-func (l *RecordingLogger) LogError(eventType, sessionID, errorMsg string) {
+func (l *recordingLogger) LogError(eventType, sessionID, errorMsg string) {
 	l.append("error", eventType, sessionID, errorMsg)
 }
 
-func (l *RecordingLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (l *recordingLogger) LogProcessingTime(string, string, int64, int, string) {}
 
-func (l *RecordingLogger) Close() error { return nil }
+func (l *recordingLogger) Close() error { return nil }
 
-func (l *RecordingLogger) append(level, eventType, sessionID, message string) {
+func (l *recordingLogger) append(level, eventType, sessionID, message string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.lines = append(l.lines, fmt.Sprintf("[%s] %s %s: %s", level, eventType, sessionID, message))
 }
 
 // Lines returns a copy of everything logged so far.
-func (l *RecordingLogger) Lines() []string {
+func (l *recordingLogger) Lines() []string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return append([]string(nil), l.lines...)
 }
 
 // CountMentioning counts the lines containing substr.
-func (l *RecordingLogger) CountMentioning(substr string) int {
+func (l *recordingLogger) CountMentioning(substr string) int {
 	var n int
 	for _, line := range l.Lines() {
 		if strings.Contains(line, substr) {
@@ -321,7 +314,7 @@ func (l *RecordingLogger) CountMentioning(substr string) int {
 }
 
 // FirstMentioning returns the first line containing every one of substrs.
-func (l *RecordingLogger) FirstMentioning(substrs ...string) (string, bool) {
+func (l *recordingLogger) FirstMentioning(substrs ...string) (string, bool) {
 	for _, line := range l.Lines() {
 		all := true
 		for _, s := range substrs {

--- a/core/internal/contracttesting/unknown_hook_event.go
+++ b/core/internal/contracttesting/unknown_hook_event.go
@@ -26,6 +26,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
@@ -225,12 +226,22 @@ func unknownEventTranscript(t *testing.T, r UnknownEventReceiver) string {
 // truncated key and fail for a reason that has nothing to do with the adapter.
 // Real event names are short identifiers, so a short name is also the honest
 // input.
+//
+// The sequence number is what makes the DELTA claim above true rather than
+// nearly true. "First sighting" is process-global state that no reset clears,
+// so a name derived from t.Name() alone repeats whenever the same test function
+// runs twice in one binary — `-count=2`, or one adapter wiring the contract
+// twice — and the second run sees zero log lines and blames the adapter. The
+// hash keeps failures traceable to a test; the counter keeps them independent.
 func unknownEventName(t *testing.T) string {
 	t.Helper()
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(t.Name()))
-	return fmt.Sprintf("IrrUnk%08x", h.Sum32())
+	return fmt.Sprintf("IrrUnk%08x%02d", h.Sum32(), unknownEventSeq.Add(1))
 }
+
+// unknownEventSeq makes every unknownEventName call unique within the process.
+var unknownEventSeq atomic.Uint64
 
 // unknownCountFor reads one (adapter, event) counter out of the snapshot.
 func unknownCountFor(adapter, event string) uint64 {

--- a/core/internal/contracttesting/unknown_hook_event.go
+++ b/core/internal/contracttesting/unknown_hook_event.go
@@ -1,0 +1,327 @@
+// unknown_hook_event.go holds the issue #1364 contract every hook-RECEIVING
+// agent adapter must satisfy: an event name the receiver does not recognize is
+// counted per (adapter, name), reported once per distinct name, and still
+// answered 2xx.
+//
+// It is the third receiving-side contract in this package, and it exists for
+// the reason the other two do — the obligation is a runtime choice, invisible
+// to a static check. What makes this one worth pinning is that the failure it
+// guards against is silent on BOTH sides. Before #1364 the default branch of
+// both receivers logged at Info and returned 200, so an upstream event rename
+// produced: no error, no counter, a permission still reading `granted`, a config
+// still holding our entries, and state detection quietly degrading. Nothing in
+// the daemon, and nothing a user would look at, said anything at all.
+//
+// The obligation that is easiest to get subtly wrong is "once per distinct
+// name". A receiver that logs every unrecognized event satisfies "it is
+// reported" and fails this contract on purpose: a rename fires on every tool
+// call, and a log line per tool call is how the evidence gets buried rather
+// than surfaced. The counter carries volume, the log carries the name.
+package contracttesting
+
+import (
+	"fmt"
+	"hash/fnv"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/ports/outbound"
+)
+
+// UnknownEventReceiverUnderTest is one freshly built hook receiver plus the one
+// thing the contract must see from outside it: whether the payload reached
+// anything downstream.
+type UnknownEventReceiverUnderTest struct {
+	// Handler is the adapter's hook HTTP handler.
+	Handler http.Handler
+
+	// Observed reports whether the receiver dispatched anything downstream. An
+	// unrecognized event must dispatch NOTHING — a receiver that guesses a
+	// handler for an unfamiliar name is worse than one that ignores it — while a
+	// recognized event must still dispatch, which is what keeps the negative
+	// assertions from passing vacuously.
+	Observed func() bool
+}
+
+// UnknownEventReceiver wires one adapter's hook receiver into
+// AssertUnknownHookEventObserved. Every field is required.
+type UnknownEventReceiver struct {
+	// Adapter is the adapter name the counter is keyed by — the same string the
+	// receiver passes to hookjson.IgnoreUnknownEvent. Asserted, not assumed: a
+	// receiver that counts under the wrong name makes every count in the
+	// diagnostics bundle attribute to the wrong CLI.
+	Adapter string
+
+	// Root relocates the adapter's declared transcript root to a
+	// test-controlled directory — by t.Setenv of whatever env var moves it
+	// ($HOME, $CODEX_HOME) — creates it, and returns its absolute path. Called
+	// FIRST in every sub-test, before New.
+	Root func(t *testing.T) string
+
+	// WriteTranscript writes a transcript the adapter will resolve a session id
+	// from into dir, and returns its absolute path. The path must survive
+	// confinement, so every refusal the contract sees is about the EVENT NAME
+	// and never about the path.
+	WriteTranscript func(t *testing.T, dir string) string
+
+	// New builds a fresh receiver logging into log. Fresh per sub-test so
+	// Observed cannot carry over between obligations.
+	New func(t *testing.T, log outbound.Logger) UnknownEventReceiverUnderTest
+
+	// PayloadFor renders the adapter's hook JSON body carrying transcriptPath
+	// and event.
+	PayloadFor func(transcriptPath, event string) string
+
+	// KnownEvent is an event name this adapter DOES recognize and dispatch on —
+	// the vacuity guard's input.
+	KnownEvent string
+
+	// EndpointPath is the adapter's hook route, used to build the request.
+	EndpointPath string
+}
+
+// AssertUnknownHookEventObserved runs the issue #1364 contract against r. Four
+// obligations, each independently failable:
+//
+//  1. a RECOGNIZED event still dispatches, and is counted as unknown by nobody
+//     — the vacuity guard. Without it a receiver that treats every event as
+//     unrecognized passes 2–4 for entirely the wrong reason, and a receiver
+//     that counts everything looks identical to one that counts correctly;
+//  2. an unrecognized event is answered 2xx and dispatches nothing. The 2xx is
+//     asserted rather than tolerated, for the reason RejectPath's doc comment
+//     records: Claude Code documents that a non-2xx from a `type: http` hook
+//     "can't block actions" but not whether it surfaces an error to the user,
+//     and gemini-cli's pre-tool hooks and Copilot's preToolUse are known to
+//     fail CLOSED on an error result. A receiver added for one of those must
+//     not answer 4xx here (#1361, #1364);
+//  3. it is counted per (adapter, event name) — repeats accumulate on their own
+//     key and a second name gets its own. A single scalar cannot distinguish an
+//     upstream rename, which fires on every tool call forever, from one stray
+//     event, and distinguishing them is the whole diagnostic value;
+//  4. it is reported exactly ONCE per distinct name, however many times that
+//     name arrives. A rename would otherwise write a log line per tool call.
+//
+// The counters it reads are process-global, so every obligation measures a
+// DELTA around its own uniquely-named events rather than an absolute — two
+// adapters, or two invocations, can share a test binary without interfering.
+func AssertUnknownHookEventObserved(t *testing.T, r UnknownEventReceiver) {
+	t.Helper()
+	t.Run("known_event_still_dispatched", func(t *testing.T) { assertKnownEventUncounted(t, r) })
+	t.Run("unknown_event_answered_2xx_not_dispatched", func(t *testing.T) { assertUnknownIgnored(t, r) })
+	t.Run("counted_per_adapter_and_name", func(t *testing.T) { assertUnknownCounted(t, r) })
+	t.Run("reported_once_per_distinct_name", func(t *testing.T) { assertUnknownReportedOnce(t, r) })
+}
+
+// assertKnownEventUncounted is obligation 1.
+func assertKnownEventUncounted(t *testing.T, r UnknownEventReceiver) {
+	t.Helper()
+	transcript := unknownEventTranscript(t, r)
+	log := &RecordingLogger{}
+	rut := r.New(t, log)
+
+	before := unknownTotalFor(r.Adapter)
+	rec := postUnknownEvent(t, r, rut, transcript, r.KnownEvent)
+
+	if rec.Code < 200 || rec.Code > 299 {
+		t.Fatalf("recognized event %q: status = %d, want 2xx", r.KnownEvent, rec.Code)
+	}
+	if !rut.Observed() {
+		t.Fatalf("recognized event %q was not dispatched — every obligation below it would pass vacuously", r.KnownEvent)
+	}
+	if got := unknownTotalFor(r.Adapter) - before; got != 0 {
+		t.Errorf("recognized event %q added %d to the unrecognized-event counters, want 0 — a receiver that counts everything reports a rename that never happened", r.KnownEvent, got)
+	}
+	if line, ok := log.FirstMentioning(r.KnownEvent, "unrecognized"); ok {
+		t.Errorf("recognized event %q was reported as unrecognized: %s", r.KnownEvent, line)
+	}
+}
+
+// assertUnknownIgnored is obligation 2.
+func assertUnknownIgnored(t *testing.T, r UnknownEventReceiver) {
+	t.Helper()
+	transcript := unknownEventTranscript(t, r)
+	rut := r.New(t, &RecordingLogger{})
+
+	event := unknownEventName(t)
+	rec := postUnknownEvent(t, r, rut, transcript, event)
+
+	if rec.Code < 200 || rec.Code > 299 {
+		t.Errorf("unrecognized event %q: status = %d, want 2xx — an unrecognized event is reported by the log and the counter, never by a status code on the user's critical path", event, rec.Code)
+	}
+	if rut.Observed() {
+		t.Errorf("unrecognized event %q was dispatched downstream — an unfamiliar name must not be guessed into a handler", event)
+	}
+}
+
+// assertUnknownCounted is obligation 3: the count is keyed by adapter AND name.
+func assertUnknownCounted(t *testing.T, r UnknownEventReceiver) {
+	t.Helper()
+	transcript := unknownEventTranscript(t, r)
+	rut := r.New(t, &RecordingLogger{})
+
+	renamed, stray := unknownEventName(t)+"Renamed", unknownEventName(t)+"Stray"
+	beforeRenamed, beforeStray := unknownCountFor(r.Adapter, renamed), unknownCountFor(r.Adapter, stray)
+
+	for i := 0; i < 3; i++ {
+		postUnknownEvent(t, r, rut, transcript, renamed)
+	}
+	postUnknownEvent(t, r, rut, transcript, stray)
+
+	if got := unknownCountFor(r.Adapter, renamed) - beforeRenamed; got != 3 {
+		t.Errorf("event %q arrived 3 times, counted %d for adapter %q — an event that keeps arriving is the signature of an upstream rename and has to be countable as such",
+			renamed, got, r.Adapter)
+	}
+	if got := unknownCountFor(r.Adapter, stray) - beforeStray; got != 1 {
+		t.Errorf("event %q arrived once, counted %d for adapter %q — a second name must get its own key, or a rename is indistinguishable from a stray event",
+			stray, got, r.Adapter)
+	}
+}
+
+// assertUnknownReportedOnce is obligation 4.
+func assertUnknownReportedOnce(t *testing.T, r UnknownEventReceiver) {
+	t.Helper()
+	transcript := unknownEventTranscript(t, r)
+	log := &RecordingLogger{}
+	rut := r.New(t, log)
+
+	flooding, second := unknownEventName(t)+"Flood", unknownEventName(t)+"Second"
+	for i := 0; i < 5; i++ {
+		postUnknownEvent(t, r, rut, transcript, flooding)
+	}
+	postUnknownEvent(t, r, rut, transcript, second)
+
+	if n := log.CountMentioning(flooding); n != 1 {
+		t.Errorf("event %q arrived 5 times and produced %d log line(s), want exactly 1 — a renamed event fires on every tool call, and one line per call buries the evidence it is meant to surface\nlines:\n%s",
+			flooding, n, strings.Join(log.Lines(), "\n"))
+	}
+	if n := log.CountMentioning(second); n != 1 {
+		t.Errorf("event %q arrived once and produced %d log line(s), want exactly 1 — every distinct name is reported, not only the first one ever seen\nlines:\n%s",
+			second, n, strings.Join(log.Lines(), "\n"))
+	}
+}
+
+// --- helpers ---
+
+// unknownEventTranscript relocates the adapter's root and writes a transcript
+// inside it, so confinement accepts the path and the only thing under test is
+// the event name.
+func unknownEventTranscript(t *testing.T, r UnknownEventReceiver) string {
+	t.Helper()
+	return r.WriteTranscript(t, mkSubdir(t, r.Root(t), "in-tree"))
+}
+
+// unknownEventName derives a name unique to the running sub-test. The counters
+// are process-global and never reset, so a fixed literal would make two
+// invocations in one test binary — two adapters, or a receiver wired twice —
+// silently share a key and a first-sighting.
+//
+// It hashes t.Name() rather than embedding it. Retained names are bounded
+// (hookjson.MaxUnknownEventNames' sibling cap), and a Go sub-test path is long
+// enough to cross that bound — which would make the contract assert against a
+// truncated key and fail for a reason that has nothing to do with the adapter.
+// Real event names are short identifiers, so a short name is also the honest
+// input.
+func unknownEventName(t *testing.T) string {
+	t.Helper()
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(t.Name()))
+	return fmt.Sprintf("IrrUnk%08x", h.Sum32())
+}
+
+// unknownCountFor reads one (adapter, event) counter out of the snapshot.
+func unknownCountFor(adapter, event string) uint64 {
+	for _, row := range hookjson.UnknownEvents() {
+		if row.Adapter == adapter && row.Event == event {
+			return row.Count
+		}
+	}
+	return 0
+}
+
+// unknownTotalFor sums every counter belonging to one adapter, so the vacuity
+// guard can assert "nothing at all was counted" without knowing which name a
+// miscounting receiver would have used.
+func unknownTotalFor(adapter string) uint64 {
+	var total uint64
+	for _, row := range hookjson.UnknownEvents() {
+		if row.Adapter == adapter {
+			total += row.Count
+		}
+	}
+	return total
+}
+
+// postUnknownEvent POSTs the adapter's hook body for event and returns the
+// response.
+func postUnknownEvent(t *testing.T, r UnknownEventReceiver, rut UnknownEventReceiverUnderTest, transcriptPath, event string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, r.EndpointPath, strings.NewReader(r.PayloadFor(transcriptPath, event)))
+	rec := httptest.NewRecorder()
+	rut.Handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// RecordingLogger is an outbound.Logger that keeps every line, so a contract can
+// assert on what was reported rather than only on what was returned. Safe for
+// concurrent use: hook receivers are HTTP handlers.
+type RecordingLogger struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *RecordingLogger) LogInfo(eventType, sessionID, message string) {
+	l.append("info", eventType, sessionID, message)
+}
+
+func (l *RecordingLogger) LogError(eventType, sessionID, errorMsg string) {
+	l.append("error", eventType, sessionID, errorMsg)
+}
+
+func (l *RecordingLogger) LogProcessingTime(string, string, int64, int, string) {}
+
+func (l *RecordingLogger) Close() error { return nil }
+
+func (l *RecordingLogger) append(level, eventType, sessionID, message string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, fmt.Sprintf("[%s] %s %s: %s", level, eventType, sessionID, message))
+}
+
+// Lines returns a copy of everything logged so far.
+func (l *RecordingLogger) Lines() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.lines...)
+}
+
+// CountMentioning counts the lines containing substr.
+func (l *RecordingLogger) CountMentioning(substr string) int {
+	var n int
+	for _, line := range l.Lines() {
+		if strings.Contains(line, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+// FirstMentioning returns the first line containing every one of substrs.
+func (l *RecordingLogger) FirstMentioning(substrs ...string) (string, bool) {
+	for _, line := range l.Lines() {
+		all := true
+		for _, s := range substrs {
+			if !strings.Contains(line, s) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return line, true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
Closes #1364

## The premise, verified against current main (not as the issue describes it)

Both receivers were rewritten by #1380, so I re-read both. The defect is exactly as stated, in both:

`core/adapters/inbound/agents/claudecode/hooks.go:321-327`
```go
	default:
		// Unrecognized hook event — accept but ignore.
		log.LogInfo(logComponentHookReceiver, sessionID,
			fmt.Sprintf("ignored unrecognized hook event %q", payload.HookEventName))
	}

	w.WriteHeader(http.StatusOK)
```

`core/adapters/inbound/agents/codex/hooks.go:193-197` (inside `dispatchHookEvent`; `serveHookRequest:180` writes the 200)
```go
	default:
		// Unrecognized hook event — accept but ignore.
		log.LogInfo(logComponentHookReceiver, sessionID,
			fmt.Sprintf("ignored unrecognized hook event %q", payload.HookEventName))
	}
```

Info + 200 + no counter. `grep -rn "hookjson" core/application/ core/cmd/` returned no non-comment hits, so nothing from that package reached `--diagnose` either.

## What changed

`hookjson.IgnoreUnknownEvent` is now the one place the behaviour is decided — the sibling of `RejectPath`, which #1380 established for the confinement refusal. Both receivers call it.

- **Counted per `(adapter, event name)`.** An upstream rename fires on every tool call forever; a stray local POST fires once. A single scalar cannot separate those, and separating them is the whole diagnostic value.
- **Reported once per distinct name**, at error level (`outbound.Logger` has no level between Info and Error, and Info is where this was already hiding). A line per tool call buries the evidence it exists to surface.
- **Still 2xx.** `IgnoreUnknownEvent` deliberately takes no `http.ResponseWriter`, so it cannot acquire an opinion about the status code later; the caller's existing 200 stands.
- **Bounded, and attributable past the bound.** The endpoint is local and unauthenticated (confine.go's opening paragraph), so a map keyed by a caller-supplied string is a memory-growth primitive handed to an unauthenticated caller. 64 distinct pairs; names bounded at 64 bytes on a rune boundary. Past the bound, sightings are counted **per adapter** and saturation is announced **once per adapter** — so a table filled with junk aimed at one adapter cannot silence a genuine rename arriving at another. (That hole was real and was found by the review pass, which reproduced it with a probe: filling the table then delivering a rename 500 times produced count=0, log lines=0.)

### Counter shape: reused, not reinvented

Third counting site in this package, following the two that exist rather than adding a fourth spelling: package-level counters, a snapshot accessor, a total — `UnknownEvents()` / `UnknownEventTotal()` / `UnknownEventNamesDropped()` alongside `Rejections()`/`RejectionCount()` (confine.go) and `Fallbacks()`/`FallbackCount()` (fallback.go). The one place it *cannot* mirror them is storage: those index a fixed `[N]atomic.Uint64` by a closed enum, and an event **name** is an open, caller-supplied key. The bounded map keeps the property that matters — a per-slot atomic, so a burst of the same name never serializes; the write lock is taken only on a transition that also emits a log line, which is what makes "reported once" exact rather than approximate under concurrency (`TestUnknownEventFirstSightingIsLoggedOnceUnderConcurrency`, 32 goroutines, `-race`). The deviation is stated in the file's doc comment.

### Surfaced in the bundle

New `hooks.json` entry. `--diagnose` builds its bundle in a **separate process that never served a hook** (`runDiagnose`'s own doc comment: it resolves the stores "without starting the daemon"), so its counters are structurally zero. Publishing them as counts would re-create the exact silence this issue is about, inside the fix for it — so that form is a *different shape* carrying no counts at all, and says where the real ones are. `HookHealth` is nil-meaningful; the daemon passes `liveHookHealth`, the CLI passes nil. The counters are read in from `cmd/irrlichd` rather than by the service, because `application/services` may not import `adapters/inbound` (enforced by `core/architecture_test.go`).

`assertHooksCollectedInDaemon` in the daemon smoke test is the only thing proving `startup.go` wires the snapshot at all — the nil branch is a valid, quiet output, so a daemon that forgot would look fine to every unit test.

## Red-first evidence

The contract and both adapter wirings were written first, with the two `default:` branches untouched. Command:

```
go test ./core/adapters/inbound/agents/claudecode/... ./core/adapters/inbound/agents/codex/... -run 'TestUnknownHookEventObserved' -count=1
```

Verbatim, pre-fix:

```
--- FAIL: TestUnknownHookEventObserved (0.01s)
    --- FAIL: TestUnknownHookEventObserved/counted_per_adapter_and_name (0.00s)
        unknown_hook_event.go:114: event "...Renamed" arrived 3 times, counted 0 for adapter "claude-code" — an event that keeps arriving is the signature of an upstream rename and has to be countable as such
        unknown_hook_event.go:114: event "...Stray" arrived once, counted 0 for adapter "claude-code" — a second name must get its own key, or a rename is indistinguishable from a stray event
    --- FAIL: TestUnknownHookEventObserved/reported_once_per_distinct_name (0.00s)
        unknown_hook_event.go:115: event "...Flood" arrived 5 times and produced 5 log line(s), want exactly 1 — a renamed event fires on every tool call, and one line per call buries the evidence it is meant to surface
            lines:
            [info] hook-receiver 1111...: ignored unrecognized hook event "...Flood"
            [info] hook-receiver 1111...: ignored unrecognized hook event "...Flood"
            [info] hook-receiver 1111...: ignored unrecognized hook event "...Flood"
            [info] hook-receiver 1111...: ignored unrecognized hook event "...Flood"
            [info] hook-receiver 1111...: ignored unrecognized hook event "...Flood"
FAIL	irrlicht/core/adapters/inbound/agents/claudecode	0.975s
```

Identical failure for `codex` (`counted 0 for adapter "codex"`, 5 log lines).

**Obligations 1 and 2 passed pre-fix and are LOCKS, not proofs** — "a recognized event still dispatches" and "an unrecognized event is answered 2xx and dispatched nowhere" were already true and must stay true; they are the vacuity guard and the fail-open rule, and their green says nothing about the defect.

**Second mutation, for the truncation fixture.** Review found the original rune-boundary test vacuous (64 two-byte runes leave byte 64 on a rune start, so a naive cut passes). Switched to three-byte runes and re-ran against a deliberately naive `truncateEventName`:

```
--- FAIL: TestUnknownEventNameIsTruncatedAtRuneBoundary
    unknown_test.go:123: retained name is not valid UTF-8: "日日日日日日日日日日日日日日日日日日日日日\xe6…"
```

## Live end-to-end check

Real `irrlichd`, `IRRLICHT_PERMISSION_MODE=grant-all`, a transcript inside a temp `CLAUDE_CONFIG_DIR`. Three POSTs of `PostToolUseV2`, one of `SessionEnd`, all answered `HTTP 200`. `GET /debug/bundle` → `hooks.json`:

```json
{
  "collected_from": "daemon",
  "unknown_events_total": 4,
  "unknown_events": [
    { "adapter": "claude-code", "event": "PostToolUseV2", "count": 3 },
    { "adapter": "claude-code", "event": "SessionEnd", "count": 1 }
  ]
}
```

Separately, 5 POSTs of one freshly-named event produced **exactly 1** line in `events.log`.

And `irrlichd --diagnose` in a fresh `IRRLICHT_HOME`:

```json
{
  "collected_from": "cli",
  "note": "Collected by `irrlichd --diagnose`, which runs in a process that never served a hook, so the receivers' unrecognized-event counters are not readable here and are omitted rather than reported as zero. The FIRST sighting of each unrecognized event name is logged at error level, so events.log in this bundle still names them. For live counts, fetch GET /debug/bundle from the running daemon."
}
```

## Review and simplify

A `high`-effort review subagent returned 8 findings; all 8 applied (see commit `ad27bfcd`). A 4-agent `/simplify` pass followed (commit `d309ef3f`) — notably it deduped the 2xx assertion, which was written three times in three wordings, into one `contracttesting/hook_receiver.go` helper both receiving-side contracts now use.

`session.CapRunes`, the repo's canonical truncator, is deliberately **not** reused: it bounds by rune count, so it runs `RuneCountInString` over the whole string then materializes `[]rune(s)` — on the multi-megabyte name this bound exists for, a full scan plus a 4x allocation of the string we are refusing to keep. Recorded in `truncateEventName`'s comment so the next reader doesn't "fix" it.

## Preflight

Run chunked in the foreground (#1382): `go`, `web`, `arch`, `tools`, `skills`, `security` — every gate PASS, none skipped. Re-run in full after the rebase onto #1393.

## Deliberately not done

- **No persistence of the counters to disk.** It would make `--diagnose` show live numbers, but it means a write path driven by an unauthenticated endpoint plus a file format plus cross-daemon concurrency — far past this ticket. The log line already crosses the process boundary, and `hooks.json` says so.
- **`hookjson.Fallbacks()` (#1371) is still not surfaced.** Same "no registry to publish into" gap, different ticket. The altitude pass called this diff a bandaid around a missing daemon-wide counter registry; that is a fair reading, and building the registry is out of scope here.
- **No split between "upstream sent a name we never installed" and "we install this event and our own switch stopped handling it".** The review pass is right that the counter currently merges them, and that `installedHookEvents` is reachable from `hookjson` — but that is a new behaviour, not this defect.
- **No installer-side assertion** for the mirror-image failure noted on #1355 (kiro-cli silently ignores unknown hook config *keys* and still passes its own `agent validate`, so we could write something the CLI never parses and no receiver-side counter would ever fire). Real gap, orthogonal to this one — it wants a post-install read-back, not a counter. Noted, not built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)