### PR TITLE
feat(state): grace-timer hysteresis on the one edge that withdraws the cue

### DIFF
--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -384,9 +384,22 @@ func (d *SessionDetector) nowFn() time.Time {
 }
 
 // SetClockForTest replaces the detector's clock. Exported for tests outside
-// this package that need to advance the #1366 dwell without sleeping.
+// this package that need to drive the #1360 ceilings and the #1366 dwell
+// without sleeping.
+//
+// MUST be called before Run. The write is unsynchronised, while nowFn is read
+// from the event-loop goroutine — setting it on a started detector is a data
+// race, not a supported reconfiguration.
 func (d *SessionDetector) SetClockForTest(now func() time.Time) {
 	d.now = now
+}
+
+// StartDwellForTest records a decided-but-unpublished state change (#1366)
+// with an explicit start time. Exported only so tests outside this package can
+// set up a dwell the ticker then has to notice; production starts one solely
+// from inside the classify pass, via admitTransition.
+func (d *SessionDetector) StartDwellForTest(sessionID, current, candidate string, at time.Time) {
+	d.dwell.Admit(sessionID, current, candidate, at)
 }
 
 // HoldSignalForTest places an out-of-band signal hold with an explicit
@@ -715,7 +728,7 @@ func (d *SessionDetector) handleTerminalUISignal(sig terminalUISignal) {
 			Adapter: state.Adapter, UIKind: string(sig.ui), Reason: uiReason,
 		})
 
-		now := time.Now().Unix()
+		now := d.nowFn().Unix()
 		d.record(lifecycle.Event{
 			Kind: lifecycle.KindStateTransition, SessionID: sig.sessionID,
 			PrevState: state.State, NewState: newState, Reason: reason,

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -372,26 +372,29 @@ func (d *SessionDetector) RunStaleSessionRefreshForTest() {
 }
 
 // nowFn reads this detector's clock. The indirection is what lets a test drive
-// the ceiling and dwell timers on a virtual timeline; production leaves the
-// field nil and gets time.Now. Every elapsed-time decision in the classify
-// pipeline must come through here — a bare time.Now() alongside it would make
-// two mechanisms that are supposed to share one instant disagree.
+// the #1360 ceilings and the #1366 dwell on a virtual timeline; production
+// leaves the field nil and gets time.Now.
+//
+// WHAT MUST COME THROUGH HERE: every instant that is later compared against
+// another instant by the classify pipeline. Concretely that is the pass clock
+// (holdContext.Now and the dwell), every SignalHolds placement (HeldSince is
+// measured against the pass clock by both ceiling and ripe), and every
+// SessionState.UpdatedAt write (reclassifyFromTranscript measures the refresh
+// interval against it). Mixing a bare time.Now() into any of those makes two
+// stamps that are supposed to share one timeline disagree, and the symptom is
+// a guard silently short-circuiting rather than anything failing loudly.
+//
+// DELIBERATELY EXEMPT, because they are self-consistent wall-clock pairs that
+// no pipeline guard reads: the deletedSessions tombstone and its prune
+// threshold (session_detector_helpers.go / session_detector_lifecycle.go), and
+// historyTracker timestamps, which pair with record()'s own event stamping.
+// Naming them is the point — otherwise a reader cannot tell "deliberately wall
+// clock" from "missed in the sweep".
 func (d *SessionDetector) nowFn() time.Time {
 	if d.now != nil {
 		return d.now()
 	}
 	return time.Now()
-}
-
-// SetClockForTest replaces the detector's clock. Exported for tests outside
-// this package that need to drive the #1360 ceilings and the #1366 dwell
-// without sleeping.
-//
-// MUST be called before Run. The write is unsynchronised, while nowFn is read
-// from the event-loop goroutine — setting it on a started detector is a data
-// race, not a supported reconfiguration.
-func (d *SessionDetector) SetClockForTest(now func() time.Time) {
-	d.now = now
 }
 
 // StartDwellForTest records a decided-but-unpublished state change (#1366)

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -182,6 +182,19 @@ type SessionDetector struct {
 	// event loop classifies), so it is deliberately NOT guarded by idleMu.
 	signals *session.SignalHolds
 
+	// dwell is the grace timer state changes serve before they are published
+	// (#1366). Like signals it carries its own lock and takes the pass clock
+	// as an argument, so it is deliberately NOT guarded by mu. A nil value
+	// disables hysteresis; see session.StateDwell.
+	dwell *session.StateDwell
+
+	// now is this detector's clock, read once per classify pass and threaded
+	// into everything that reasons about elapsed time — the signal holds'
+	// ceilings and ripeness rules (holdContext.Now) and the #1366 dwell. nil
+	// means time.Now; tests replace it to drive both mechanisms on a virtual
+	// timeline instead of sleeping. Read through nowFn, never directly.
+	now func() time.Time
+
 	// idleMu guards idleProjectRetryAttempts below. Written from HTTP handler
 	// goroutines, read by processActivity (event-loop goroutine).
 	idleMu sync.Mutex
@@ -286,6 +299,7 @@ func NewSessionDetector(watchers []inbound.Watcher, deps SessionDetectorDeps) *S
 		debouncedEvents:          make(chan agent.Event, 64),
 		deletedCooldown:          10 * time.Second,
 		signals:                  session.NewSignalHolds(),
+		dwell:                    session.NewStateDwell(),
 		idleProjectRetryAttempts: make(map[string]int),
 		bgLiveProbe:              anyLiveOutputWriter,
 		bgPIDProbe:               anyLivePID,
@@ -355,6 +369,24 @@ func (d *SessionDetector) RunPIDLivenessSweepForTest() {
 // staleWorkingRefreshInterval ticker.
 func (d *SessionDetector) RunStaleSessionRefreshForTest() {
 	d.refreshStaleSessions()
+}
+
+// nowFn reads this detector's clock. The indirection is what lets a test drive
+// the ceiling and dwell timers on a virtual timeline; production leaves the
+// field nil and gets time.Now. Every elapsed-time decision in the classify
+// pipeline must come through here — a bare time.Now() alongside it would make
+// two mechanisms that are supposed to share one instant disagree.
+func (d *SessionDetector) nowFn() time.Time {
+	if d.now != nil {
+		return d.now()
+	}
+	return time.Now()
+}
+
+// SetClockForTest replaces the detector's clock. Exported for tests outside
+// this package that need to advance the #1366 dwell without sleeping.
+func (d *SessionDetector) SetClockForTest(now func() time.Time) {
+	d.now = now
 }
 
 // HoldSignalForTest places an out-of-band signal hold with an explicit

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -805,14 +805,15 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 	// stamp below must agree about when "now" was, and a held signal whose
 	// staleness is time-based (session.holdContext) is only meaningful against
 	// a single instant.
-	passStart := time.Now()
+	passStart := d.nowFn()
 
 	// Arm the transcript-based stalled-edit-tool fallback (#488) before the
 	// overlay, not after: it is a held signal like the rest now (#1319), and
 	// Overlay is what decides whether it has been open long enough to apply.
 	d.armStalledEditTool(state, passStart)
 
-	d.reportHoldExpiries(state, d.signals.Overlay(state.SessionID, state.Metrics, passStart), passStart)
+	expiries := d.signals.Overlay(state.SessionID, state.Metrics, passStart)
+	d.reportHoldExpiries(state, expiries, passStart)
 
 	// Content-based state detection. The tiered form is used here (and only
 	// here) so the deciding rule and its authority tier reach the recorded
@@ -841,7 +842,7 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 		ParentHeldWorking: parentHeldWorking,
 	})
 
-	if newState != state.State {
+	if d.admitTransition(state, newState, stateBeforeSynthesis, expiries, passStart) {
 		applied := stateTransitionUpdate{NewState: newState, Reason: reason, Now: now}
 		switch {
 		case parentHeldWorking:
@@ -866,6 +867,49 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 	if d.cacheBloat != nil {
 		d.cacheBloat.OnActivity(state)
 	}
+}
+
+// admitTransition is the #1366 grace-timer gate: the single place that decides
+// whether this pass's classified state change is published or held back.
+//
+// It replaces a bare `newState != state.State`, and it is called on every pass
+// rather than only on the passes that produce a change — session.StateDwell
+// learns that a proposal was reversed by being told the classifier now agrees
+// with the current state, and never learns it otherwise.
+//
+// Two classes of change skip the dwell outright. Both are cases where delaying
+// publication could only lose information, never smooth it:
+//
+//   - A HOLD CEILING FIRED this pass (#1360). An expiry is not a flap and
+//     cannot become one: the hold is deleted, nothing re-asserts it, and the
+//     ceiling only fires after hours of wall clock. Debouncing it would at
+//     best delay the unpinning by a dwell, and at worst lose it entirely — the
+//     hold that kept SignalHolds.HasAny true is the very thing that just went
+//     away, so refreshStaleSessions' held-session arm stops selecting this
+//     session on the same pass that starts the dwell. That is a real hole and
+//     it is closed twice over, here and by the Pending arm in
+//     refreshStaleSessions, because #1360 exists precisely to guarantee a
+//     pinned session eventually unpins and a grace timer must not be able to
+//     take that back. TestClassify_CeilingExpiryIsNotSwallowedByTheDwell.
+//   - A SYNTHESIZER RE-BASED the current state this pass. The collapsed-waiting
+//     and collapsed-turn-boundary synthesizers author a *pair* of transitions
+//     to reconstruct edges the daemon observed collapsed into one pass; the
+//     second half is the classifier's verdict about a state the synthesizer
+//     has already declared over. Holding it back would strand the session in a
+//     synthetic waiting the pass itself knows has ended — inventing a stall
+//     rather than suppressing a flap.
+func (d *SessionDetector) admitTransition(
+	state *session.SessionState,
+	newState string,
+	stateBeforeSynthesis string,
+	expiries []session.SignalExpiry,
+	now time.Time,
+) bool {
+	if len(expiries) > 0 || state.State != stateBeforeSynthesis {
+		d.dwell.DropSession(state.SessionID)
+		return newState != state.State
+	}
+	return d.dwell.Admit(state.SessionID, state.State, newState, now)
 }
 
 // forceReadyToWorkingIfActive bounces a ready session straight to working
@@ -1470,7 +1514,7 @@ func (d *SessionDetector) refreshStaleSessions() {
 	if err != nil {
 		return
 	}
-	now := time.Now()
+	now := d.nowFn()
 	for _, state := range sessions {
 		switch state.State {
 		case session.StateWorking:
@@ -1478,28 +1522,48 @@ func (d *SessionDetector) refreshStaleSessions() {
 		case session.StateWaiting, session.StateReady:
 			d.retryIdleProjectResolution(state, now)
 
-			// A held signal is the one reason to revisit a non-working
-			// session, and without this the ceilings added in #1360 could
-			// never fire. A ceiling is only evaluated inside
-			// SignalHolds.Overlay, Overlay is only reached from the classify
-			// pipeline, and this loop ran that pipeline for StateWorking
-			// alone — while both hook holds that have a ceiling pin the
-			// session at *waiting*. The pinned session was precisely the one
-			// being skipped, so a lost release stayed lost for the life of
-			// the process. (That asymmetry is also why compactHoldTimeout
-			// appeared to prove the mechanism worked: it pins at working, the
-			// state already being re-read.)
-			//
-			// Scoped to sessions that actually hold something, deliberately:
-			// not re-reading idle transcripts is long-standing behaviour with
-			// a real cost attached — one stat and parse per idle session per
-			// tick, on a machine that may be tracking dozens — and a hold is
-			// both rare and the only thing such a pass could newly decide.
-			if d.signals != nil && d.signals.HasAny(state.SessionID) {
+			// Only when something outstanding could make a full pass decide
+			// anything new — see shouldRevisitIdleSession for both reasons and
+			// why the scoping is deliberate.
+			if d.shouldRevisitIdleSession(state.SessionID) {
 				d.reclassifyFromTranscript(state, now)
 			}
 		}
 	}
+}
+
+// shouldRevisitIdleSession reports whether the ticker has a reason to run a
+// full classify pass for a session that is not working. Both disjuncts are
+// liveness guarantees for a wall-clock timer that only ever advances inside
+// the classify pipeline, and neither implies the other.
+//
+//   - A HELD SIGNAL (#1360). A ceiling is only evaluated inside
+//     SignalHolds.Overlay, Overlay is only reached from the classify pipeline,
+//     and both hook holds that declare a ceiling pin the session at *waiting*
+//     — the state this loop used to skip. Without this the pinned session was
+//     precisely the one never revisited, so a lost release stayed lost for the
+//     life of the process. (That asymmetry is also why compactHoldTimeout
+//     appeared to prove the mechanism worked: it pins at working, the state
+//     already being re-read.)
+//   - A DWELL OUTSTANDING (#1366). The same argument one turn deeper: a grace
+//     timer is a *delay* only if a later pass arrives to end it, and on a
+//     session nothing else revisits it silently becomes a drop. The case that
+//     forces it is a ceiling expiry — dropping the hold is what makes HasAny
+//     false, so the first disjunct stops selecting the session on the very
+//     pass that needs a follow-up. admitTransition also exempts expiries from
+//     the dwell outright; this is the belt to that pair of braces, bounding
+//     every dwell whatever started it.
+//
+// Deliberately not "every non-working session": not re-reading idle
+// transcripts is long-standing behaviour with a real cost attached — one stat
+// and parse per idle session per tick, on a machine that may be tracking
+// dozens — and these two conditions are both rare and the only things such a
+// pass could newly decide.
+func (d *SessionDetector) shouldRevisitIdleSession(sessionID string) bool {
+	if d.signals != nil && d.signals.HasAny(sessionID) {
+		return true
+	}
+	return d.dwell.Pending(sessionID)
 }
 
 // retryIdleProjectResolution re-attempts CWD/project/branch backfill for an

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -842,7 +842,14 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 		ParentHeldWorking: parentHeldWorking,
 	})
 
-	if d.admitTransition(state, newState, stateBeforeSynthesis, expiries, passStart) {
+	// Did this pass re-base what the classifier was reading, rather than merely
+	// read it? Two things can: a synthesizer moved the session's current state
+	// out from under the verdict, or a hold ceiling expired and changed the
+	// metrics. Both matter twice below — to the dwell gate and to the
+	// provenance stamp — so the question is asked once, here.
+	rebased := state.State != stateBeforeSynthesis || len(expiries) > 0
+
+	if d.admitTransition(state, newState, verdict.Tier, rebased, passStart) {
 		applied := stateTransitionUpdate{NewState: newState, Reason: reason, Now: now}
 		switch {
 		case parentHeldWorking:
@@ -878,7 +885,23 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 // with the current state, and never learns it otherwise.
 //
 // Two classes of change skip the dwell outright. Both are cases where delaying
-// publication could only lose information, never smooth it:
+// publication could only lose information, never smooth it.
+//
+// FIRST: a HOOK-TIER VERDICT. The dwell exists to absorb a lower-tier guess
+// being corrected; a TierHook verdict IS the correction, delivered out of band
+// by the agent itself, and nothing below it is allowed to retire it anyway. The
+// edge that makes this concrete is compact_in_progress — a TierHook rule that
+// decides *working* (state_classifier.go). A manual /compact issued while the
+// session reads waiting would otherwise serve the full dwell plus a ticker
+// interval, directly contradicting that hook handler's own reason for existing:
+// "there is no transcript flush coming during the compaction window". Note this
+// does NOT subsume the two bypasses below — after a ceiling expiry, and after
+// the collapsed-waiting synthesizer re-bases, the deciding rule is
+// transcript_activity, at TierTranscript.
+// TestClassify_AHookTierVerdictIsNotDebounced.
+//
+// SECOND: THIS PASS RE-BASED WHAT THE CLASSIFIER READ (the `rebased` argument),
+// which is true in either of two ways:
 //
 //   - A HOLD CEILING FIRED this pass (#1360). An expiry is not a flap and
 //     cannot become one: the hold is deleted, nothing re-asserts it, and the
@@ -906,11 +929,11 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 func (d *SessionDetector) admitTransition(
 	state *session.SessionState,
 	newState string,
-	stateBeforeSynthesis string,
-	expiries []session.SignalExpiry,
+	tier session.SignalTier,
+	rebased bool,
 	now time.Time,
 ) bool {
-	if len(expiries) > 0 || state.State != stateBeforeSynthesis {
+	if tier == session.TierHook || rebased {
 		d.dwell.DropSession(state.SessionID)
 		return newState != state.State
 	}
@@ -1452,15 +1475,27 @@ func (d *SessionDetector) armStalledEditTool(state *session.SessionState, now ti
 // See refreshStaleSessions' non-working branch for why an idle session is ever
 // put through this.
 func (d *SessionDetector) reclassifyFromTranscript(state *session.SessionState, now time.Time) {
-	// Direction-safe on purpose. UpdatedAt is written by this detector through
-	// the same nowFn clock, so elapsed is normally non-negative — but a
-	// session persisted by an earlier daemon run carries a wall-clock stamp
-	// this process's clock need not be ahead of, and under a test clock the
-	// gap can be hours of NEGATIVE elapsed time. Comparing that against the
-	// interval short-circuits and the re-read silently does nothing, which is
-	// the worst possible failure for the one path that ends a #1366 dwell or
-	// fires a #1360 ceiling. When the two stamps cannot be reconciled the
-	// guard degrades toward doing MORE work, never less.
+	// Direction-safe on purpose, and the cost is known and accepted.
+	//
+	// UpdatedAt is written by this detector through the same nowFn clock, so
+	// elapsed is normally non-negative. It can still go negative in
+	// production: a session persisted by an earlier daemon run carries a stamp
+	// this process's clock need not be ahead of, and a backwards NTP step does
+	// the same to live ones. A bare `elapsed < interval` treats that as "just
+	// updated" and short-circuits EVERY tick for as long as the skew lasts —
+	// so the session's #1360 ceiling can never fire and its #1366 dwell can
+	// never resolve, which is precisely the permanently-pinned failure both
+	// mechanisms exist to prevent, arriving silently.
+	//
+	// The accepted cost of the `>= 0` clause is the mirror image: a
+	// future-stamped session is re-read once per tick until the clock catches
+	// up, and nothing on a no-op pass rewrites the stamp to end that early.
+	// Correctness wins — a pinned session is unbounded and invisible, extra
+	// stats are bounded and cheap — but the asymmetry is real and a dirty-check
+	// in finalizeActivityPass would remove it.
+	//
+	// The rule: when the two stamps cannot be reconciled, degrade toward doing
+	// MORE work, never less.
 	if elapsed := now.Sub(time.Unix(state.UpdatedAt, 0)); elapsed >= 0 && elapsed < staleWorkingRefreshInterval {
 		return
 	}

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -847,9 +847,16 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 	// out from under the verdict, or a hold ceiling expired and changed the
 	// metrics. Both matter twice below — to the dwell gate and to the
 	// provenance stamp — so the question is asked once, here.
+	// Three things make this pass's verdict authoritative rather than a guess
+	// the dwell should sit on; admitTransition's doc argues each. A hook-tier
+	// verdict IS the correction the dwell waits for; a synthesizer moved the
+	// current state out from under the verdict; a hold ceiling changed the
+	// metrics it read. Folded here rather than passed separately so the gate
+	// keeps one question, and because the last two are also read below.
 	rebased := state.State != stateBeforeSynthesis || len(expiries) > 0
+	authoritative := verdict.Tier == session.TierHook || rebased
 
-	if d.admitTransition(state, newState, verdict.Tier, rebased, passStart) {
+	if d.admitTransition(state, newState, authoritative, passStart) {
 		applied := stateTransitionUpdate{NewState: newState, Reason: reason, Now: now}
 		switch {
 		case parentHeldWorking:
@@ -929,11 +936,10 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 func (d *SessionDetector) admitTransition(
 	state *session.SessionState,
 	newState string,
-	tier session.SignalTier,
-	rebased bool,
+	authoritative bool,
 	now time.Time,
 ) bool {
-	if tier == session.TierHook || rebased {
+	if authoritative {
 		d.dwell.DropSession(state.SessionID)
 		return newState != state.State
 	}

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -60,7 +60,7 @@ func (d *SessionDetector) onNewSession(id agent.Identity, ev agent.Event) {
 	existing, _ := d.repo.Load(ev.SessionID)
 	isNew := existing == nil
 
-	now := time.Now().Unix()
+	now := d.nowFn().Unix()
 
 	if isNew {
 		if !d.admitNewSession(id, &ev) {
@@ -647,7 +647,7 @@ func (d *SessionDetector) finalizeActivityPass(state *session.SessionState, ev a
 	// transition still bumps UpdatedAt via the write inside the classify block
 	// above, so #445's process-exit settle is unaffected.
 	if transcriptGrew {
-		state.UpdatedAt = time.Now().Unix()
+		state.UpdatedAt = d.nowFn().Unix()
 		state.EventCount++
 		state.LastEvent = "transcript_activity"
 	}
@@ -891,13 +891,18 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 //     refreshStaleSessions, because #1360 exists precisely to guarantee a
 //     pinned session eventually unpins and a grace timer must not be able to
 //     take that back. TestClassify_CeilingExpiryIsNotSwallowedByTheDwell.
-//   - A SYNTHESIZER RE-BASED the current state this pass. The collapsed-waiting
-//     and collapsed-turn-boundary synthesizers author a *pair* of transitions
-//     to reconstruct edges the daemon observed collapsed into one pass; the
-//     second half is the classifier's verdict about a state the synthesizer
-//     has already declared over. Holding it back would strand the session in a
-//     synthetic waiting the pass itself knows has ended — inventing a stall
-//     rather than suppressing a flap.
+//   - A SYNTHESIZER RE-BASED the current state this pass. In practice that is
+//     synthesizeCollapsedWaitingIfNeeded and only it: the collapsed-turn-
+//     boundary synthesizer fires from working and re-bases back to working, so
+//     it can never make this condition true. The collapsed-waiting synthesizer
+//     authors a *pair* of transitions to reconstruct an edge the daemon
+//     observed collapsed into one pass — a synthetic working→waiting, then the
+//     classifier's verdict from that new base, which for a just-closed
+//     user-blocking tool is ordinarily working. That second half is the
+//     debounced edge, and holding it back would strand the session in a
+//     synthetic waiting the same pass already knows has ended: inventing a
+//     stall rather than suppressing a flap.
+//     TestClassify_ASynthesizedWaitingIsNotLeftStranded.
 func (d *SessionDetector) admitTransition(
 	state *session.SessionState,
 	newState string,
@@ -1447,7 +1452,16 @@ func (d *SessionDetector) armStalledEditTool(state *session.SessionState, now ti
 // See refreshStaleSessions' non-working branch for why an idle session is ever
 // put through this.
 func (d *SessionDetector) reclassifyFromTranscript(state *session.SessionState, now time.Time) {
-	if now.Sub(time.Unix(state.UpdatedAt, 0)) < staleWorkingRefreshInterval {
+	// Direction-safe on purpose. UpdatedAt is written by this detector through
+	// the same nowFn clock, so elapsed is normally non-negative — but a
+	// session persisted by an earlier daemon run carries a wall-clock stamp
+	// this process's clock need not be ahead of, and under a test clock the
+	// gap can be hours of NEGATIVE elapsed time. Comparing that against the
+	// interval short-circuits and the re-read silently does nothing, which is
+	// the worst possible failure for the one path that ends a #1366 dwell or
+	// fires a #1360 ceiling. When the two stamps cannot be reconciled the
+	// guard degrades toward doing MORE work, never less.
+	if elapsed := now.Sub(time.Unix(state.UpdatedAt, 0)); elapsed >= 0 && elapsed < staleWorkingRefreshInterval {
 		return
 	}
 	if state.TranscriptPath == "" {

--- a/core/application/services/session_detector_dwell_test.go
+++ b/core/application/services/session_detector_dwell_test.go
@@ -1,0 +1,65 @@
+package services_test
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestSessionDetector_StaleRefreshFinishesAnOutstandingDwell is the #1366
+// liveness guarantee end to end, and it is the test a review found missing:
+// everything else pinned the PREDICATE (shouldRevisitIdleSession returns true)
+// rather than the CONSEQUENCE (the ticker then actually runs a classify pass).
+//
+// That gap matters more than it looks. The entire safety argument for the
+// grace timer is that a deferred waiting→working is DELAYED and never DROPPED,
+// and on a session receiving no further transcript events the only thing that
+// makes that true is this chain: refreshStaleSessions →
+// shouldRevisitIdleSession → reclassifyFromTranscript → a real pass. That last
+// hop has three preconditions of its own (the 5s interval, a non-empty
+// transcript path, and the #570 consent gate), none of which the predicate
+// test exercises. If any silently blocks, the session advertises "needs a
+// human" for the life of the process — the expensive, silent error graceFor
+// exists to prevent, arriving by the back door.
+//
+// The observable is UpdatedAt moving, which is the same signal its counterpart
+// TestSessionDetector_StaleRefreshLeavesAnUnheldIdleSessionAlone asserts must
+// NOT move; that test is the LOCK on the scoping, this one is the fix. A state
+// assertion is not available here because this harness's metrics collector
+// leaves state.Metrics nil, so the classifier has nothing to re-decide from —
+// see TestSessionDetector_StaleRefreshExpiresAHookHoldOnAWaitingSession for
+// the same reasoning applied to the #1360 ceiling.
+func TestSessionDetector_StaleRefreshFinishesAnOutstandingDwell(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	det := newDetector(tw, pw, repo)
+
+	// Same fixture as the #1360 tests: waiting, quiet transcript, stale
+	// UpdatedAt, project already resolved so the idle-retry path cannot be
+	// mistaken for the thing that woke the session.
+	newHeldWaitingSession(t, repo, "dwell1")
+
+	before, err := repo.Load("dwell1")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	// No hold is placed, deliberately: the #1360 arm of the predicate must not
+	// be what selects this session, or the test would pass without the #1366
+	// arm existing at all.
+	det.StartDwellForTest("dwell1", session.StateWaiting, session.StateWorking, time.Now())
+
+	det.RunStaleSessionRefreshForTest()
+
+	after, err := repo.Load("dwell1")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if after.UpdatedAt == before.UpdatedAt {
+		t.Fatalf("the ticker never ran a classify pass for a session with a dwell outstanding "+
+			"(UpdatedAt still %d) — nothing else revisits a quiet non-working session, so the "+
+			"deferred transition is dropped rather than delayed", before.UpdatedAt)
+	}
+}

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -26,6 +26,22 @@ func (d *SessionDetector) removeFromProjectSessions(sessionID string) {
 	if d.historyTracker != nil {
 		d.historyTracker.Remove(sessionID)
 	}
+	// Drop the out-of-band signal holds and any outstanding #1366 dwell.
+	//
+	// onRemoved does this too, but onRemoved fires on the TRANSCRIPT FILE
+	// disappearing — and a process dying does not delete its transcript. Every
+	// PIDManager-driven deletion (dead process, duplicate-PID dedup, ready-TTL
+	// age-out, parent cleanup, pre-session supersession) reaches teardown
+	// through here instead, and reached neither map: nothing else ever revisits
+	// a deleted session, so an entry left behind is permanent for the life of
+	// the process and a recycled session ID inherits it. Both calls are
+	// idempotent, which is why onRemoved keeps its own.
+	// (SignalHolds, unlike StateDwell, is not nil-safe; struct-literal test
+	// detectors can reach this path without one.)
+	if d.signals != nil {
+		d.signals.DropSession(sessionID)
+	}
+	d.dwell.DropSession(sessionID)
 }
 
 // broadcast sends a push notification if a broadcaster is configured. For

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -26,22 +26,44 @@ func (d *SessionDetector) removeFromProjectSessions(sessionID string) {
 	if d.historyTracker != nil {
 		d.historyTracker.Remove(sessionID)
 	}
-	// Drop the out-of-band signal holds and any outstanding #1366 dwell.
-	//
-	// onRemoved does this too, but onRemoved fires on the TRANSCRIPT FILE
-	// disappearing — and a process dying does not delete its transcript. Every
-	// PIDManager-driven deletion (dead process, duplicate-PID dedup, ready-TTL
-	// age-out, parent cleanup, pre-session supersession) reaches teardown
-	// through here instead, and reached neither map: nothing else ever revisits
-	// a deleted session, so an entry left behind is permanent for the life of
-	// the process and a recycled session ID inherits it. Both calls are
-	// idempotent, which is why onRemoved keeps its own.
-	// (SignalHolds, unlike StateDwell, is not nil-safe; struct-literal test
-	// detectors can reach this path without one.)
+	d.forgetSessionScopedState(sessionID)
+}
+
+// forgetSessionScopedState drops the per-session bookkeeping that only the
+// session itself gives meaning to. It exists because there are TWO teardown
+// paths and they are not the same one:
+//
+//   - onRemoved, which fires on the TRANSCRIPT FILE disappearing;
+//   - removeFromProjectSessions, reached from the PIDManager's
+//     OnSessionDeleted callback — dead process, duplicate-PID dedup, ready-TTL
+//     age-out, parent cleanup, pre-session supersession.
+//
+// A dying process does not delete its transcript, so the second path is how
+// most sessions actually end, and it was clearing neither the signal holds nor
+// the #1366 dwell. Nothing revisits a deleted session, so an entry left behind
+// is permanent for the life of the process and a recycled session ID inherits
+// it. That drift is not hypothetical: this function was extracted after the
+// second map was added to the first list and missed on the second, which is
+// exactly how the first one was missed before it.
+//
+// Every store here is idempotent, so both callers may call it unconditionally.
+// The rule for the next per-session map: add it HERE, not to a call site.
+//
+// Not everything per-session belongs in this set. deletedSessions is a
+// deliberate tombstone written BY this path and aged out on its own schedule,
+// and the background-liveness caches are cleared inline above with their own
+// reasoning (#445).
+func (d *SessionDetector) forgetSessionScopedState(sessionID string) {
+	// SignalHolds, unlike StateDwell, is not nil-safe; struct-literal test
+	// detectors reach this path without one.
 	if d.signals != nil {
 		d.signals.DropSession(sessionID)
 	}
 	d.dwell.DropSession(sessionID)
+
+	d.idleMu.Lock()
+	delete(d.idleProjectRetryAttempts, sessionID)
+	d.idleMu.Unlock()
 }
 
 // broadcast sends a push notification if a broadcaster is configured. For

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -100,7 +100,7 @@ func (d *SessionDetector) onRelocated(ev agent.Event, newPath string) {
 		// cumulative metrics are rebuilt intact.
 		d.enricher.PruneMetrics(state.TranscriptPath)
 		state.TranscriptPath = newPath
-		state.UpdatedAt = time.Now().Unix()
+		state.UpdatedAt = d.nowFn().Unix()
 		if err := d.repo.Save(state); err != nil {
 			d.log.LogError(logComponentSessionDetector, ev.SessionID,
 				fmt.Sprintf("failed to save relocated transcript path: %v", err))
@@ -187,7 +187,7 @@ func (d *SessionDetector) onRemovedLocked(state *session.SessionState, ev agent.
 
 	prevState := state.State
 	state.State = session.StateReady
-	state.UpdatedAt = time.Now().Unix()
+	state.UpdatedAt = d.nowFn().Unix()
 	state.Confidence = "high"
 	state.LastEvent = "transcript_removed"
 
@@ -255,7 +255,7 @@ func (d *SessionDetector) ReconcilePreSessionBackchannel(oldID, newID string) {
 		prevState := newState.State
 		newState.State = session.StateWaiting
 		newState.WaitingStartTime = old.WaitingStartTime
-		newState.UpdatedAt = time.Now().Unix()
+		newState.UpdatedAt = d.nowFn().Unix()
 		if err := d.repo.Save(newState); err != nil {
 			d.log.LogError(logComponentSessionDetector, newID,
 				fmt.Sprintf("failed to carry forward waiting state from presession %s: %v", oldID, err))
@@ -287,7 +287,7 @@ func (d *SessionDetector) HandlePermissionHook(sessionID, transcriptPath, hookEv
 	// by the replay harness's applyHookEvent. It used to be a switch here and a
 	// second switch there, and they had drifted (issue #1320).
 	if effect, ok := session.HookSignal(hookEventName); ok {
-		d.signals.ApplyHook(sessionID, effect, time.Now())
+		d.signals.ApplyHook(sessionID, effect, d.nowFn())
 	}
 
 	// processActivity overlays PermissionPending onto the metrics before
@@ -340,7 +340,7 @@ func (d *SessionDetector) HandleStopHook(sessionID, transcriptPath, lastAssistan
 	d.signals.Hold(sessionID, session.SignalTurnDone, session.SignalPayload{
 		LastAssistantText: lastAssistantText,
 		WaitingCue:        waitingCue,
-	}, time.Now())
+	}, d.nowFn())
 
 	// classifyAndTransition overlays HookTurnDone onto the metrics before
 	// calling ClassifyState. The Stop hook fires at true turn end (after the
@@ -368,7 +368,7 @@ func (d *SessionDetector) HandleStopHook(sessionID, transcriptPath, lastAssistan
 //
 // Safe to call from any goroutine (e.g. the HTTP handler).
 func (d *SessionDetector) HandleIdlePromptHook(sessionID, transcriptPath string) {
-	d.signals.Hold(sessionID, session.SignalIdlePrompt, session.SignalPayload{}, time.Now())
+	d.signals.Hold(sessionID, session.SignalIdlePrompt, session.SignalPayload{}, d.nowFn())
 
 	d.dispatchHookActivity(sessionID, transcriptPath, session.HookNotification)
 }
@@ -391,7 +391,7 @@ func (d *SessionDetector) HandleCompactHook(sessionID, transcriptPath, trigger s
 		return
 	}
 
-	d.signals.Hold(sessionID, session.SignalCompactInProgress, session.SignalPayload{}, time.Now())
+	d.signals.Hold(sessionID, session.SignalCompactInProgress, session.SignalPayload{}, d.nowFn())
 
 	// Flip the session to working immediately — there is no transcript flush
 	// coming during the compaction window to trigger a natural re-evaluation.
@@ -499,7 +499,7 @@ func (d *SessionDetector) seedBackfillMetadata(states []*session.SessionState) {
 		}
 	}
 	for _, state := range d.enricher.BackfillMetadata(allowed) {
-		state.UpdatedAt = time.Now().Unix()
+		state.UpdatedAt = d.nowFn().Unix()
 		if err := d.repo.Save(state); err != nil {
 			d.log.LogError(logComponentSessionDetectorSeed, state.SessionID,
 				fmt.Sprintf("failed to backfill metadata: %v", err))

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -44,6 +44,11 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	// forever, and a recycled session ID would inherit it.
 	d.signals.DropSession(ev.SessionID)
 
+	// Same reasoning for the #1366 grace timer: a decided-but-unpublished
+	// change belongs to a session that no longer exists, and leaving it would
+	// hand a recycled session ID a transition proposed for its predecessor.
+	d.dwell.DropSession(ev.SessionID)
+
 	d.idleMu.Lock()
 	delete(d.idleProjectRetryAttempts, ev.SessionID)
 	d.idleMu.Unlock()

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -39,19 +39,12 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 	delete(d.projectSessions, ev.SessionID)
 	d.mu.Unlock()
 
-	// Drop any leftover held signal — otherwise a hook that fired without a
-	// clearing partner (e.g. agent crash mid-overlay) would keep the entry
-	// forever, and a recycled session ID would inherit it.
-	d.signals.DropSession(ev.SessionID)
-
-	// Same reasoning for the #1366 grace timer: a decided-but-unpublished
-	// change belongs to a session that no longer exists, and leaving it would
-	// hand a recycled session ID a transition proposed for its predecessor.
-	d.dwell.DropSession(ev.SessionID)
-
-	d.idleMu.Lock()
-	delete(d.idleProjectRetryAttempts, ev.SessionID)
-	d.idleMu.Unlock()
+	// Drop every per-session store — a hook that fired without a clearing
+	// partner (e.g. an agent crash mid-overlay), a decided-but-unpublished
+	// #1366 transition, an idle-retry counter. Any of them left behind is
+	// permanent, and a recycled session ID would inherit it. One seam, shared
+	// with the PIDManager reap path; see forgetSessionScopedState.
+	d.forgetSessionScopedState(ev.SessionID)
 
 	state, err := d.repo.Load(ev.SessionID)
 	if err != nil || state == nil {

--- a/core/application/services/session_detector_subagent.go
+++ b/core/application/services/session_detector_subagent.go
@@ -20,7 +20,7 @@ func (d *SessionDetector) refreshSubagentSummary(state *session.SessionState) {
 		children = nil
 	}
 	state.Subagents = session.ComputeSubagentSummary(state, children)
-	session.ApplySubagentTaskEstimate(state, children, time.Now())
+	session.ApplySubagentTaskEstimate(state, children, d.nowFn())
 }
 
 // finishOrphanedChildren walks the child sessions of parentID and promotes
@@ -44,7 +44,7 @@ func (d *SessionDetector) finishOrphanedChildren(parentID string) {
 	if err != nil {
 		return
 	}
-	now := time.Now().Unix()
+	now := d.nowFn().Unix()
 	for _, s := range states {
 		if !d.isOrphanedChild(s, parentID) {
 			continue
@@ -148,7 +148,7 @@ func (d *SessionDetector) applySubagentCompletions(parentID string, completions 
 	if err != nil {
 		return
 	}
-	now := time.Now().Unix()
+	now := d.nowFn().Unix()
 	for _, c := range completions {
 		if c.AgentID == "" {
 			continue
@@ -262,7 +262,7 @@ func (d *SessionDetector) holdParentWorkingForNewChild(parentID string) {
 		}
 		d.record(lifecycle.Event{Kind: lifecycle.KindStateTransition, SessionID: parentID, PrevState: parent.State, NewState: session.StateWorking, Reason: "new child discovered while ready — holding working"})
 		parent.State = session.StateWorking
-		parent.UpdatedAt = time.Now().Unix()
+		parent.UpdatedAt = d.nowFn().Unix()
 		d.refreshSubagentSummary(parent)
 		if err := d.repo.Save(parent); err != nil {
 			d.log.LogError(logComponentSessionDetector, parentID,
@@ -361,7 +361,7 @@ func (d *SessionDetector) transitionParentAfterChildrenDone(parent *session.Sess
 		return
 	}
 
-	now := time.Now().Unix()
+	now := d.nowFn().Unix()
 	if reason != "" {
 		d.log.LogInfo(logComponentSessionDetector, parentID,
 			fmt.Sprintf("children done, parent re-evaluated: %s", reason))

--- a/core/application/services/state_dwell_test.go
+++ b/core/application/services/state_dwell_test.go
@@ -321,6 +321,94 @@ func TestClassify_ADwellOutstandingKeepsTheTickerComing(t *testing.T) {
 	})
 }
 
+// TestClassify_ASynthesizedWaitingIsNotLeftStranded pins the second bypass in
+// admitTransition, which a review found was load-bearing, reachable, and held
+// up by nothing but a comment: deleting the `state.State != stateBeforeSynthesis`
+// disjunct left the whole package green.
+//
+// The collapsed-waiting synthesizer (#150) reconstructs a waiting episode the
+// fswatcher coalesced away, by emitting a synthetic working→waiting and then
+// re-classifying from that new base. For a just-closed user-blocking tool the
+// re-classification is working — which is the one edge the dwell debounces. So
+// without the bypass the pass emits a waiting it has itself already concluded
+// is over, and then withholds the exit: a fabricated "needs a human" badge, on
+// a session demonstrably not blocked, for a dwell plus a ticker interval.
+func TestClassify_ASynthesizedWaitingIsNotLeftStranded(t *testing.T) {
+	clock := holdT0
+	d, rec := dwellDetector(&clock)
+
+	m := workingMetrics()
+	m.SawUserBlockingToolClosedThisPass = true
+
+	state := &session.SessionState{
+		SessionID:       "s",
+		Adapter:         "claudecode",
+		State:           session.StateWorking,
+		ParentSessionID: "p",
+		Metrics:         m,
+	}
+
+	d.classifyAndTransition(state, agent.Event{SessionID: "s"})
+
+	got := transitions(rec)
+	if len(got) != 2 {
+		t.Fatalf("expected the synthesized pair (working→waiting, waiting→working), got %d: %+v",
+			len(got), got)
+	}
+	if got[0].PrevState != session.StateWorking || got[0].NewState != session.StateWaiting {
+		t.Errorf("first transition %q→%q, want working→waiting", got[0].PrevState, got[0].NewState)
+	}
+	if got[1].PrevState != session.StateWaiting || got[1].NewState != session.StateWorking {
+		t.Errorf("second transition %q→%q, want waiting→working — the dwell must not "+
+			"strand the session in a waiting this same pass already ended",
+			got[1].PrevState, got[1].NewState)
+	}
+	if state.State != session.StateWorking {
+		t.Errorf("session state = %q, want working", state.State)
+	}
+}
+
+// TestSessionDetector_ReapingASessionEvictsItsDwellAndHolds covers the
+// teardown path a review found uncovered.
+//
+// onRemoved drops both maps, but onRemoved fires on the TRANSCRIPT FILE
+// disappearing — and a process dying does not delete its transcript. Every
+// PIDManager-driven deletion (dead process, duplicate-PID dedup, ready-TTL
+// age-out, parent cleanup, pre-session supersession) tears down through
+// removeFromProjectSessions instead, whose own doc comment already says
+// "Every PIDManager session removal must route through here so no path leaks
+// history again" — and which dropped neither the signal holds nor the dwell.
+//
+// Nothing revisits a deleted session, so an entry left behind is permanent for
+// the life of the process, and a recycled session ID inherits a transition
+// proposed for its predecessor.
+func TestSessionDetector_ReapingASessionEvictsItsDwellAndHolds(t *testing.T) {
+	d := &SessionDetector{
+		dwell:           session.NewStateDwell(),
+		signals:         session.NewSignalHolds(),
+		projectSessions: map[string]string{"s": "proj"},
+		deletedSessions: map[string]int64{},
+		bgLive:          map[string]bool{},
+		bgProbing:       map[string]bool{},
+	}
+
+	d.dwell.Admit("s", session.StateWaiting, session.StateWorking, holdT0)
+	d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, holdT0)
+	if !d.dwell.Pending("s") || !d.signals.HasAny("s") {
+		t.Fatal("precondition: both a dwell and a hold must be outstanding")
+	}
+
+	// The reap path — not onRemoved.
+	d.removeFromProjectSessions("s")
+
+	if d.dwell.Pending("s") {
+		t.Error("a reaped session must not leave a pending transition behind")
+	}
+	if d.signals.HasAny("s") {
+		t.Error("a reaped session must not leave a signal hold behind")
+	}
+}
+
 // TestSessionDetector_WiresAStateDwell exists because a nil *StateDwell is
 // deliberately usable and silently disables hysteresis — which is right for
 // the test suite's many struct literals and catastrophic in production.

--- a/core/application/services/state_dwell_test.go
+++ b/core/application/services/state_dwell_test.go
@@ -1,0 +1,344 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+)
+
+// dwellDetector builds a detector wired for the classify pipeline and nothing
+// else, driving both the signal holds and the #1366 dwell off one virtual
+// clock the test advances by hand.
+//
+// The clock is a pointer the caller moves, not a fixed value, because a dwell
+// is only observable across passes: the whole mechanism is "what the second
+// pass decides about what the first pass proposed".
+func dwellDetector(clock *time.Time) (*SessionDetector, *ceilingRecorder) {
+	rec := &ceilingRecorder{}
+	d := &SessionDetector{
+		log:      &capturingLogger{},
+		recorder: rec,
+		signals:  session.NewSignalHolds(),
+		dwell:    session.NewStateDwell(),
+		now:      func() time.Time { return *clock },
+	}
+	return d, rec
+}
+
+// workingMetrics is a transcript shape the classifier resolves to working via
+// the transcript_activity default: a tool call is open (so IsAgentDone is
+// false), the tool is neither user-blocking nor permission-gated (so neither
+// the user_blocking_tool rule nor the #488 stalled-edit arming reaches it).
+func workingMetrics() *session.SessionMetrics {
+	return &session.SessionMetrics{
+		LastEventType:     "assistant",
+		HasOpenToolCall:   true,
+		LastOpenToolNames: []string{"Bash"},
+	}
+}
+
+// transitions extracts the published state changes, which is the observable
+// #1366 is actually about — what reached the UI, not what the classifier
+// privately decided.
+func transitions(rec *ceilingRecorder) []lifecycle.Event {
+	var out []lifecycle.Event
+	for _, ev := range rec.events {
+		if ev.Kind == lifecycle.KindStateTransition {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// TestClassify_AReversedWaitingExitNeverReachesTheUI is #1366's defect test,
+// at the altitude the issue states it: not "a map entry was cleared" but "the
+// badge never flickered".
+//
+// The sequence is the one #1355 multiplies by eight. A session is pinned at
+// waiting by a permission-prompt hook. One pass sees a transcript that no
+// longer looks blocked — the hook's release has landed but the authoritative
+// re-assertion has not, which is #1141's ~6s Notification lag — and the
+// classifier says working. Two seconds later the prompt is visibly open again
+// and the classifier says waiting.
+//
+// Pre-#1366 both of those reached applyStateTransition, so the user saw
+// waiting→working→waiting: a badge that flapped to "no attention needed" and
+// back on a session that never stopped needing a human.
+func TestClassify_AReversedWaitingExitNeverReachesTheUI(t *testing.T) {
+	clock := holdT0
+	d, rec := dwellDetector(&clock)
+
+	state := &session.SessionState{
+		SessionID:       "s",
+		Adapter:         "claudecode",
+		State:           session.StateWaiting,
+		ParentSessionID: "p", // no parent-hold path; this session is a child
+		Metrics:         workingMetrics(),
+	}
+	ev := agent.Event{SessionID: "s"}
+
+	// Pass 1: the transcript momentarily reads as working.
+	d.classifyAndTransition(state, ev)
+
+	// Pass 2, two seconds later and well inside the dwell: the prompt is open
+	// again, so the classifier is back to waiting.
+	clock = clock.Add(2 * time.Second)
+	state.Metrics = workingMetrics()
+	d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, clock)
+	d.classifyAndTransition(state, ev)
+
+	if got := transitions(rec); len(got) != 0 {
+		t.Fatalf("a waiting exit reversed inside the dwell must never be published, got %d transition(s): %+v",
+			len(got), got)
+	}
+	if state.State != session.StateWaiting {
+		t.Errorf("the session must still read waiting, got %q", state.State)
+	}
+}
+
+// TestClassify_AWaitingExitThatHoldsIsPublished is the other half, and the
+// reason the test above is not satisfied by simply never publishing anything.
+// A grace timer that defers is correct; one that drops is the failure
+// graceFor's asymmetry argues against in the opposite direction.
+func TestClassify_AWaitingExitThatHoldsIsPublished(t *testing.T) {
+	clock := holdT0
+	d, rec := dwellDetector(&clock)
+
+	state := &session.SessionState{
+		SessionID:       "s",
+		Adapter:         "claudecode",
+		State:           session.StateWaiting,
+		ParentSessionID: "p",
+		Metrics:         workingMetrics(),
+	}
+	ev := agent.Event{SessionID: "s"}
+
+	d.classifyAndTransition(state, ev)
+	if state.State != session.StateWaiting {
+		t.Fatalf("precondition: the first pass must not publish, got %q", state.State)
+	}
+
+	// Far enough past the dwell that retuning waitingExitDwell downward cannot
+	// make this test lie; the constant is unexported in core/domain/session.
+	clock = clock.Add(time.Minute)
+	state.Metrics = workingMetrics()
+	d.classifyAndTransition(state, ev)
+
+	got := transitions(rec)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one published transition, got %d: %+v", len(got), got)
+	}
+	if got[0].PrevState != session.StateWaiting || got[0].NewState != session.StateWorking {
+		t.Errorf("published %q→%q, want waiting→working", got[0].PrevState, got[0].NewState)
+	}
+	if state.State != session.StateWorking {
+		t.Errorf("session state = %q, want working", state.State)
+	}
+}
+
+// TestClassify_EnteringWaitingIsNotDelayed is a LOCK, and the one that matters
+// most: it passes on main by construction and must keep passing. #1366 buys
+// flap suppression by spending latency, and the entire argument in graceFor is
+// that none of that latency may be spent on the edge that tells a human they
+// are needed.
+func TestClassify_EnteringWaitingIsNotDelayed(t *testing.T) {
+	clock := holdT0
+	d, rec := dwellDetector(&clock)
+
+	state := &session.SessionState{
+		SessionID:       "s",
+		Adapter:         "claudecode",
+		State:           session.StateWorking,
+		ParentSessionID: "p",
+		Metrics:         workingMetrics(),
+	}
+
+	d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, clock)
+	d.classifyAndTransition(state, agent.Event{SessionID: "s"})
+
+	if state.State != session.StateWaiting {
+		t.Fatalf("working→waiting must publish on the pass that decides it, got %q", state.State)
+	}
+	got := transitions(rec)
+	if len(got) != 1 || got[0].NewState != session.StateWaiting {
+		t.Fatalf("expected one working→waiting transition, got %+v", got)
+	}
+}
+
+// TestClassify_FirstClassificationIsNotDelayed is #1366's scope note 3.
+//
+// A session's first classification has no previously published waiting to be
+// leaving, so no dwell can attach to it. Asserted from the empty current state
+// a freshly constructed session carries before buildNewSessionState stamps
+// one, and for the waiting target specifically, since that is the case a dwell
+// would be most damaging to. LOCK: passes on main.
+func TestClassify_FirstClassificationIsNotDelayed(t *testing.T) {
+	clock := holdT0
+	d, _ := dwellDetector(&clock)
+
+	state := &session.SessionState{
+		SessionID:       "s",
+		Adapter:         "claudecode",
+		State:           "", // never classified before
+		ParentSessionID: "p",
+		Metrics:         workingMetrics(),
+	}
+
+	d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, clock)
+	d.classifyAndTransition(state, agent.Event{SessionID: "s"})
+
+	if state.State != session.StateWaiting {
+		t.Fatalf("a session's first classification must publish immediately, got %q", state.State)
+	}
+}
+
+// TestClassify_CeilingExpiryIsNotSwallowedByTheDwell is the interaction test
+// between #1366 and #1360, and it is the sharpest test in this change because
+// the two features pull in opposite directions on the same edge.
+//
+// #1360 bounds a hook-asserted hold at twelve hours so a lost release cannot
+// pin a session at waiting forever. The unpinning it produces is, by
+// construction, a waiting exit — the exact edge #1366 debounces. So the naive
+// composition is: the ceiling fires, the classifier finally says working, and
+// the dwell holds it back.
+//
+// That is not merely a delay, it is a permanent loss, and the mechanism is
+// worth stating because it is invisible from either feature's own tests.
+// refreshStaleSessions is the only thing that revisits a session no transcript
+// event is arriving for, and its non-working arm selects sessions where
+// SignalHolds.HasAny is true. The ceiling firing is what DELETES the hold — so
+// the same pass that starts the dwell is the pass that stops the ticker from
+// ever coming back. The session stays pinned at waiting for the life of the
+// process, which is precisely the defect #1360 was opened to remove.
+//
+// This test FAILED against the first version of this branch — a dwell with no
+// expiry exemption. It asserts the fix at the altitude that matters: the
+// unpinning is published on the pass the ceiling fires, not one dwell later
+// and not never.
+func TestClassify_CeilingExpiryIsNotSwallowedByTheDwell(t *testing.T) {
+	// Past every ceiling any TierHook persistent row declares, framed as an
+	// absurd elapsed time rather than the (unexported) constant so retuning a
+	// ceiling cannot make this test lie in either direction.
+	const beyondAnyHookCeiling = 48 * time.Hour
+
+	clock := holdT0
+	d, rec := dwellDetector(&clock)
+
+	state := &session.SessionState{
+		SessionID:       "s",
+		Adapter:         "claudecode",
+		State:           session.StateWaiting,
+		ParentSessionID: "p",
+		Metrics:         workingMetrics(),
+	}
+
+	// The PermissionRequest hook landed and pinned the session. PostToolUse
+	// never came: nothing releases this hold but its ceiling.
+	d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, clock)
+
+	clock = clock.Add(beyondAnyHookCeiling)
+	d.classifyAndTransition(state, agent.Event{SessionID: "s"})
+
+	if state.State != session.StateWorking {
+		t.Fatalf("the ceiling expiry must unpin the session on the pass it fires, got %q — "+
+			"a dwell that defers this can never be satisfied, because dropping the hold is "+
+			"what stops refreshStaleSessions from revisiting the session at all", state.State)
+	}
+
+	var sawExpiry, sawTransition bool
+	for _, ev := range rec.events {
+		switch ev.Kind {
+		case lifecycle.KindHoldExpired:
+			sawExpiry = true
+		case lifecycle.KindStateTransition:
+			sawTransition = true
+			if ev.PrevState != session.StateWaiting || ev.NewState != session.StateWorking {
+				t.Errorf("published %q→%q, want waiting→working", ev.PrevState, ev.NewState)
+			}
+		}
+	}
+	if !sawExpiry {
+		t.Error("precondition: no hold_expired event — the ceiling did not fire and this test proves nothing")
+	}
+	if !sawTransition {
+		t.Error("the unpinning must be published, not merely applied in memory")
+	}
+}
+
+// TestClassify_ADwellOutstandingKeepsTheTickerComing is the second, general
+// half of the same liveness argument, and it is deliberately not satisfied by
+// the expiry exemption above.
+//
+// Any dwell, whatever started it, needs a later pass to end it. On a session
+// with no holds outstanding, refreshStaleSessions' non-working arm would skip
+// it — so a dwell started on the last pass a session ever receives would be a
+// drop rather than a delay. Pending() is what closes that.
+func TestClassify_ADwellOutstandingKeepsTheTickerComing(t *testing.T) {
+	newDet := func() *SessionDetector {
+		return &SessionDetector{dwell: session.NewStateDwell(), signals: session.NewSignalHolds()}
+	}
+
+	t.Run("nothing outstanding is still left alone", func(t *testing.T) {
+		// LOCK on the scoping #1376 introduced: widening this to every idle
+		// session is a per-tick transcript re-read of the whole machine.
+		if newDet().shouldRevisitIdleSession("s") {
+			t.Error("a session with neither a hold nor a dwell must not be revisited")
+		}
+	})
+
+	t.Run("a hold alone selects the session", func(t *testing.T) {
+		d := newDet()
+		d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, holdT0)
+		if !d.shouldRevisitIdleSession("s") {
+			t.Error("the #1360 arm must still select a held session")
+		}
+	})
+
+	t.Run("a dwell alone selects the session", func(t *testing.T) {
+		d := newDet()
+		d.dwell.Admit("s", session.StateWaiting, session.StateWorking, holdT0)
+
+		if d.signals.HasAny("s") {
+			t.Fatal("precondition: no holds — the #1360 arm must not be what selects this session")
+		}
+		if !d.shouldRevisitIdleSession("s") {
+			t.Error("a deferred waiting exit must keep the ticker coming, " +
+				"or the grace timer is a dropper and not a delay")
+		}
+	})
+
+	t.Run("publishing the dwell stops the extra work", func(t *testing.T) {
+		d := newDet()
+		d.dwell.Admit("s", session.StateWaiting, session.StateWorking, holdT0)
+		d.dwell.Admit("s", session.StateWaiting, session.StateWorking, holdT0.Add(time.Minute))
+
+		if d.shouldRevisitIdleSession("s") {
+			t.Error("once the dwell has published, the session goes back to being left alone")
+		}
+	})
+}
+
+// TestSessionDetector_WiresAStateDwell exists because a nil *StateDwell is
+// deliberately usable and silently disables hysteresis — which is right for
+// the test suite's many struct literals and catastrophic in production.
+// Nothing else in the suite would notice the constructor dropping it.
+func TestSessionDetector_WiresAStateDwell(t *testing.T) {
+	bare := &SessionDetector{}
+	if bare.dwell != nil {
+		t.Fatal("precondition: a bare struct literal has no dwell")
+	}
+	// The nil path must be transparent rather than panicking — that is what
+	// keeps the suite's struct literals meaningful.
+	if !bare.dwell.Admit("s", session.StateWaiting, session.StateWorking, holdT0) {
+		t.Error("a nil dwell must publish immediately (pre-#1366 behaviour)")
+	}
+
+	// …and the real constructor must not leave production on that path.
+	det := NewSessionDetector(nil, SessionDetectorDeps{})
+	if det.dwell == nil {
+		t.Fatal("NewSessionDetector must wire a StateDwell, or hysteresis is silently off in the daemon")
+	}
+}

--- a/core/application/services/state_dwell_test.go
+++ b/core/application/services/state_dwell_test.go
@@ -40,6 +40,20 @@ func workingMetrics() *session.SessionMetrics {
 	}
 }
 
+// dwellSession is the fixture every test here varies by one field. Note
+// ParentSessionID: it short-circuits holdParentForActiveChildren, keeping these
+// tests on the classify/publish path they are about rather than the
+// parent-child rule.
+func dwellSession(state string, m *session.SessionMetrics) *session.SessionState {
+	return &session.SessionState{
+		SessionID:       "s",
+		Adapter:         "claudecode",
+		State:           state,
+		ParentSessionID: "p",
+		Metrics:         m,
+	}
+}
+
 // transitions extracts the published state changes, which is the observable
 // #1366 is actually about — what reached the UI, not what the classifier
 // privately decided.
@@ -71,13 +85,7 @@ func TestClassify_AReversedWaitingExitNeverReachesTheUI(t *testing.T) {
 	clock := holdT0
 	d, rec := dwellDetector(&clock)
 
-	state := &session.SessionState{
-		SessionID:       "s",
-		Adapter:         "claudecode",
-		State:           session.StateWaiting,
-		ParentSessionID: "p", // no parent-hold path; this session is a child
-		Metrics:         workingMetrics(),
-	}
+	state := dwellSession(session.StateWaiting, workingMetrics())
 	ev := agent.Event{SessionID: "s"}
 
 	// Pass 1: the transcript momentarily reads as working.
@@ -107,13 +115,7 @@ func TestClassify_AWaitingExitThatHoldsIsPublished(t *testing.T) {
 	clock := holdT0
 	d, rec := dwellDetector(&clock)
 
-	state := &session.SessionState{
-		SessionID:       "s",
-		Adapter:         "claudecode",
-		State:           session.StateWaiting,
-		ParentSessionID: "p",
-		Metrics:         workingMetrics(),
-	}
+	state := dwellSession(session.StateWaiting, workingMetrics())
 	ev := agent.Event{SessionID: "s"}
 
 	d.classifyAndTransition(state, ev)
@@ -148,13 +150,7 @@ func TestClassify_EnteringWaitingIsNotDelayed(t *testing.T) {
 	clock := holdT0
 	d, rec := dwellDetector(&clock)
 
-	state := &session.SessionState{
-		SessionID:       "s",
-		Adapter:         "claudecode",
-		State:           session.StateWorking,
-		ParentSessionID: "p",
-		Metrics:         workingMetrics(),
-	}
+	state := dwellSession(session.StateWorking, workingMetrics())
 
 	d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, clock)
 	d.classifyAndTransition(state, agent.Event{SessionID: "s"})
@@ -179,13 +175,7 @@ func TestClassify_FirstClassificationIsNotDelayed(t *testing.T) {
 	clock := holdT0
 	d, _ := dwellDetector(&clock)
 
-	state := &session.SessionState{
-		SessionID:       "s",
-		Adapter:         "claudecode",
-		State:           "", // never classified before
-		ParentSessionID: "p",
-		Metrics:         workingMetrics(),
-	}
+	state := dwellSession("", workingMetrics()) // "" — never classified before
 
 	d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, clock)
 	d.classifyAndTransition(state, agent.Event{SessionID: "s"})
@@ -227,13 +217,7 @@ func TestClassify_CeilingExpiryIsNotSwallowedByTheDwell(t *testing.T) {
 	clock := holdT0
 	d, rec := dwellDetector(&clock)
 
-	state := &session.SessionState{
-		SessionID:       "s",
-		Adapter:         "claudecode",
-		State:           session.StateWaiting,
-		ParentSessionID: "p",
-		Metrics:         workingMetrics(),
-	}
+	state := dwellSession(session.StateWaiting, workingMetrics())
 
 	// The PermissionRequest hook landed and pinned the session. PostToolUse
 	// never came: nothing releases this hold but its ceiling.
@@ -340,13 +324,7 @@ func TestClassify_ASynthesizedWaitingIsNotLeftStranded(t *testing.T) {
 	m := workingMetrics()
 	m.SawUserBlockingToolClosedThisPass = true
 
-	state := &session.SessionState{
-		SessionID:       "s",
-		Adapter:         "claudecode",
-		State:           session.StateWorking,
-		ParentSessionID: "p",
-		Metrics:         m,
-	}
+	state := dwellSession(session.StateWorking, m)
 
 	d.classifyAndTransition(state, agent.Event{SessionID: "s"})
 
@@ -365,6 +343,34 @@ func TestClassify_ASynthesizedWaitingIsNotLeftStranded(t *testing.T) {
 	}
 	if state.State != session.StateWorking {
 		t.Errorf("session state = %q, want working", state.State)
+	}
+}
+
+// TestClassify_AHookTierVerdictIsNotDebounced covers the third bypass, found
+// by review: the dwell absorbs a lower-tier guess being corrected, and a
+// TierHook verdict *is* the correction.
+//
+// The concrete edge is compact_in_progress — the one TierHook rule that
+// decides working. A manual /compact issued while the session reads waiting
+// would otherwise serve the full dwell plus a ticker interval, contradicting
+// that hook handler's own stated reason for existing ("there is no transcript
+// flush coming during the compaction window").
+func TestClassify_AHookTierVerdictIsNotDebounced(t *testing.T) {
+	clock := holdT0
+	d, rec := dwellDetector(&clock)
+
+	state := dwellSession(session.StateWaiting, workingMetrics())
+
+	// The PreCompact hook fires while the session is pinned at waiting.
+	d.signals.Hold("s", session.SignalCompactInProgress, session.SignalPayload{}, clock)
+	d.classifyAndTransition(state, agent.Event{SessionID: "s"})
+
+	if state.State != session.StateWorking {
+		t.Fatalf("a hook-tier verdict must publish on the pass that decides it, got %q", state.State)
+	}
+	got := transitions(rec)
+	if len(got) != 1 || got[0].NewState != session.StateWorking {
+		t.Fatalf("expected one waiting→working transition, got %+v", got)
 	}
 }
 

--- a/core/domain/session/state_dwell.go
+++ b/core/domain/session/state_dwell.go
@@ -105,11 +105,18 @@ type StateDwell struct {
 	pending map[string]pendingExit
 }
 
-// pendingExit is one decided-but-unpublished state change. from is recorded
-// alongside to because a dwell is only continuous while BOTH ends hold still:
-// if the session's published state moved underneath the proposal (a terminal
-// UI signal forcing waiting, say), the elapsed time measured so far describes
-// a transition nobody is proposing any more.
+// pendingExit is one decided-but-unpublished state change.
+//
+// from and to are DEFENCE IN DEPTH, not a live invariant, and it is worth
+// being exact about that rather than letting a reader assume either. Today
+// graceFor returns non-zero for exactly one pair, so any entry that exists is
+// necessarily waiting→working and the shape check in Admit cannot fail — a
+// mutation replacing it with a bare presence test keeps the whole suite green.
+// They are kept because they are what makes a future second debounced edge
+// safe by construction instead of by remembering: the moment graceFor grows a
+// row, "the elapsed time on file describes the edge being proposed" stops
+// being free, and publishing a stale edge is the one error class this whole
+// mechanism must not commit.
 type pendingExit struct {
 	from  string
 	to    string

--- a/core/domain/session/state_dwell.go
+++ b/core/domain/session/state_dwell.go
@@ -123,6 +123,12 @@ type pendingExit struct {
 	since time.Time
 }
 
+// describes reports whether this entry is the proposal being made now — both
+// ends, not just the destination. See the type's comment for why both.
+func (p pendingExit) describes(current, candidate string) bool {
+	return p.from == current && p.to == candidate
+}
+
 // NewStateDwell returns an empty grace-timer store.
 func NewStateDwell() *StateDwell {
 	return &StateDwell{pending: make(map[string]pendingExit)}
@@ -163,7 +169,7 @@ func (d *StateDwell) Admit(sessionID, current, candidate string, now time.Time) 
 	}
 
 	p, ok := d.pending[sessionID]
-	if !ok || p.from != current || p.to != candidate {
+	if !ok || !p.describes(current, candidate) {
 		// First sighting of this proposal, or the proposal changed shape. The
 		// clock restarts rather than carrying over, which errs toward staying
 		// in waiting — the cheap side of graceFor's asymmetry.

--- a/core/domain/session/state_dwell.go
+++ b/core/domain/session/state_dwell.go
@@ -1,0 +1,203 @@
+package session
+
+import (
+	"sync"
+	"time"
+)
+
+// waitingExitDwell is how long a proposal to LEAVE StateWaiting must survive
+// before it is published (#1366).
+//
+// WHY SIX SECONDS. The dwell only earns its cost if it outlasts the correction
+// it exists to absorb. The slowest authoritative signal that can re-assert
+// waiting after a lower tier has already concluded the session moved on is
+// claudecode's Notification/idle_prompt hook, measured at roughly six seconds
+// late in #1141 — that lag is the whole reason #1366 was opened, since #1355
+// multiplies the number of adapters delivering signals on that schedule.
+// Below six seconds the dwell cannot absorb the flap it was built for; far
+// above it, a session the user has just unblocked reads as stuck for long
+// enough to look like a bug of its own. Six is the measured number plus
+// nothing, deliberately: the residual risk of being slightly short is a flap
+// that reaches the UI, which is exactly the pre-#1366 behaviour and therefore
+// no regression, while the risk of being long is a *new* failure mode.
+//
+// On the ticker-driven path the observed latency is up to this value plus one
+// staleWorkingRefreshInterval (5s), because a pass has to actually run for the
+// dwell to be re-examined. That is accounted for and accepted; see the
+// direction argument below for why erring long here is the cheap side.
+const waitingExitDwell = 6 * time.Second
+
+// graceFor is the asymmetry of #1366, in one function: which direction gets a
+// grace period, and — just as load-bearing — which does not.
+//
+// EXACTLY ONE EDGE IS DEBOUNCED: waiting→working. Everything else, entering
+// waiting most of all, publishes on the pass that decides it.
+//
+// The direction comes from the same argument that set
+// permissionPromptHoldTimeout to twelve hours. The two errors are not mirror
+// images:
+//
+//   - A PHANTOM waiting is self-limiting. The session claims it needs a human,
+//     the human looks, and looking is what corrects it. The cost is one glance.
+//   - A DROPPED OR LATE waiting is silent. The session has stopped advertising
+//     that it needs a human and there is no cue to go and check — nothing
+//     prompts the look that would reveal the error. An agent that went quiet
+//     behind an unanswered prompt at 22:00 is still unanswered at 08:00, and
+//     the only thing that was ever going to fix that is the badge.
+//
+// So the grace is spent entirely on staying in waiting a moment too long, and
+// never on getting there a moment too late. A symmetric dwell would buy flap
+// suppression on the working→waiting edge at the price of delaying every real
+// prompt, which trades the cheap error for the expensive one.
+//
+// WHY waiting→ready IS *NOT* DEBOUNCED, though it is also a waiting exit. What
+// the grace protects is not the literal string "waiting" but the ADVERTISEMENT
+// THAT A HUMAN IS NEEDED. waiting and ready both carry that advertisement;
+// working is the only state that withdraws it. waiting→ready therefore cannot
+// commit the silent error above — the cue stays up, only its wording changes —
+// so debouncing it buys nothing and costs real accuracy. Two existing
+// behaviours prove the cost is not hypothetical: ESC-cancelling a permission
+// prompt resolves waiting→ready (TestSessionDetector_Activity_Cancellation
+// FromWaiting_TransitionsToReady) and #1173's idle-prompt reconciliation
+// requires that a completed next turn reads ready rather than leaking the
+// stale waiting (TestSessionDetector_IdlePromptHook_ReconcilesReadyToWaiting).
+// Both are a user action or an authoritative signal, not a flap, and both
+// failed against a version of this function that debounced every waiting exit.
+//
+// ALSO NOT DEBOUNCED, and not an oversight:
+//
+//   - working→ready. Raising the come-look cue, so delaying it spends the
+//     grace in the expensive direction. It is also the ordinary end of every
+//     turn — the most common transition in the system.
+//   - ready→working. Reversing it wrongly would hide a finished turn, which is
+//     the same silent class of error as a dropped waiting.
+//
+// The residual, stated plainly rather than left to be discovered: the
+// working→ready→waiting sequence a late idle_prompt produces still reaches the
+// UI as two transitions. #1366 does not claim to remove it.
+func graceFor(current, candidate string) time.Duration {
+	if current == StateWaiting && candidate == StateWorking {
+		return waitingExitDwell
+	}
+	return 0
+}
+
+// StateDwell is the classifier's grace timer (#1366): the record of state
+// changes that have been decided but not yet published, so a decision that is
+// reversed before its dwell elapses never reaches the UI at all.
+//
+// It is shaped after SignalHolds on purpose — per-session map, its own mutex
+// because holds and hooks arrive on HTTP handler goroutines while the event
+// loop classifies, and a clock passed IN on every call rather than read here.
+// A time.Now() inside this type would make the offline replay harness
+// non-deterministic in the same way it would inside a signalPolicy: the
+// caller's pass clock is wall time in the daemon and the transcript's virtual
+// time under replay, and only the caller knows which.
+//
+// The zero value is not usable; call NewStateDwell. A nil *StateDwell is
+// usable and disables hysteresis entirely — every proposed change publishes
+// immediately, i.e. exactly the pre-#1366 behaviour. That is what keeps the
+// many SessionDetector struct literals in the test suite meaningful rather
+// than panicking, and it is why TestSessionDetector_WiresAStateDwell exists:
+// nothing else would notice production forgetting to construct one.
+type StateDwell struct {
+	mu      sync.Mutex
+	pending map[string]pendingExit
+}
+
+// pendingExit is one decided-but-unpublished state change. from is recorded
+// alongside to because a dwell is only continuous while BOTH ends hold still:
+// if the session's published state moved underneath the proposal (a terminal
+// UI signal forcing waiting, say), the elapsed time measured so far describes
+// a transition nobody is proposing any more.
+type pendingExit struct {
+	from  string
+	to    string
+	since time.Time
+}
+
+// NewStateDwell returns an empty grace-timer store.
+func NewStateDwell() *StateDwell {
+	return &StateDwell{pending: make(map[string]pendingExit)}
+}
+
+// Admit decides whether a classified state change may be published now, and is
+// the only method that advances a dwell. It must be called on EVERY classify
+// pass, including the passes where the classifier re-decides the state the
+// session already has — that is how a reversal is observed. Calling it only
+// when current != candidate would leave a reversed proposal on the books and
+// publish it later, which is the precise opposite of the intent.
+//
+// now is this pass's clock, on the same timeline as holdContext.Now.
+//
+// It reports true when the caller should apply the transition to candidate.
+// False means either that there is nothing to publish (candidate == current)
+// or that the change is still serving its dwell.
+func (d *StateDwell) Admit(sessionID, current, candidate string, now time.Time) bool {
+	if d == nil {
+		return candidate != current
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// The proposal was reversed — or never existed. Either way the session is
+	// where it should be, and anything outstanding is void: it described a
+	// change the classifier no longer wants.
+	if candidate == current {
+		delete(d.pending, sessionID)
+		return false
+	}
+
+	grace := graceFor(current, candidate)
+	if grace == 0 {
+		delete(d.pending, sessionID)
+		return true
+	}
+
+	p, ok := d.pending[sessionID]
+	if !ok || p.from != current || p.to != candidate {
+		// First sighting of this proposal, or the proposal changed shape. The
+		// clock restarts rather than carrying over, which errs toward staying
+		// in waiting — the cheap side of graceFor's asymmetry.
+		d.pending[sessionID] = pendingExit{from: current, to: candidate, since: now}
+		return false
+	}
+	if now.Sub(p.since) < grace {
+		return false
+	}
+	delete(d.pending, sessionID)
+	return true
+}
+
+// Pending reports whether a session has a decided-but-unpublished change
+// outstanding.
+//
+// This exists for scheduling, not for reading state: a dwell can only be
+// resolved by a later classify pass, and the ticker that drives those passes
+// skips non-working sessions unless something says otherwise. Without this,
+// a dwell started on the last pass a session ever receives would never be
+// re-examined and the change would be lost rather than delayed — which would
+// make the grace timer a dropper, exactly the failure graceFor argues against.
+// See refreshStaleSessions.
+func (d *StateDwell) Pending(sessionID string) bool {
+	if d == nil {
+		return false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_, ok := d.pending[sessionID]
+	return ok
+}
+
+// DropSession forgets any outstanding proposal for a session — because the
+// session went away, or because something authoritative happened that must not
+// be debounced. Both callers are deliberate; see admitTransition.
+func (d *StateDwell) DropSession(sessionID string) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.pending, sessionID)
+}

--- a/core/domain/session/state_dwell_test.go
+++ b/core/domain/session/state_dwell_test.go
@@ -1,0 +1,232 @@
+package session
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// dwellT0 is a fixed virtual instant far from any real clock, deliberately.
+// Every elapsed-time assertion below is measured from it, so a StateDwell that
+// secretly consulted time.Now would compute an elapsed time of decades and
+// publish everything immediately — see
+// TestStateDwell_MeasuresTheInjectedClockNotTheWallClock, which is the whole
+// point of anchoring here rather than at time.Now().
+var dwellT0 = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// TestStateDwell_LeavingWaitingServesTheDwell is the mechanism in one line: a
+// proposal to leave waiting is not published on the pass that decides it, and
+// is published once it has survived waitingExitDwell.
+func TestStateDwell_LeavingWaitingServesTheDwell(t *testing.T) {
+	d := NewStateDwell()
+
+	if d.Admit("s", StateWaiting, StateWorking, dwellT0) {
+		t.Fatal("the pass that first decides a waiting exit must not publish it")
+	}
+	if d.Admit("s", StateWaiting, StateWorking, dwellT0.Add(waitingExitDwell-time.Nanosecond)) {
+		t.Error("one nanosecond short of the dwell is still short")
+	}
+	if !d.Admit("s", StateWaiting, StateWorking, dwellT0.Add(waitingExitDwell)) {
+		t.Error("a waiting exit that survived the full dwell must publish")
+	}
+	if d.Pending("s") {
+		t.Error("publishing must clear the proposal, or the next pass would re-publish it")
+	}
+}
+
+// TestStateDwell_AReversedExitNeverPublishes is the defect #1366 names: a
+// transition that is immediately reversed must never reach the UI. The
+// reversal is observed as the classifier agreeing with the current state
+// again, which is why Admit has to be called on every pass and not only on
+// the passes that produce a change.
+func TestStateDwell_AReversedExitNeverPublishes(t *testing.T) {
+	d := NewStateDwell()
+
+	d.Admit("s", StateWaiting, StateWorking, dwellT0)                  // decided
+	d.Admit("s", StateWaiting, StateWaiting, dwellT0.Add(time.Second)) // reversed
+
+	if d.Pending("s") {
+		t.Fatal("a reversed proposal must be forgotten, not left to mature")
+	}
+	// Long past the original proposal's dwell. If the reversal had not voided
+	// it, this pass would publish a change decided — and abandoned — 10s ago.
+	if d.Admit("s", StateWaiting, StateWorking, dwellT0.Add(10*time.Second)) {
+		t.Error("the clock must restart after a reversal, not resume")
+	}
+}
+
+// TestStateDwell_EnteringWaitingIsNeverDelayed is the asymmetry, asserted
+// rather than left to the comment on graceFor. It is the half of #1366 that
+// must NOT happen: a session that needs a human says so on the pass that
+// works it out, from every state, with no grace at all.
+func TestStateDwell_EnteringWaitingIsNeverDelayed(t *testing.T) {
+	for _, from := range []string{StateWorking, StateReady, ""} {
+		d := NewStateDwell()
+		if !d.Admit("s", from, StateWaiting, dwellT0) {
+			t.Errorf("%q→waiting must publish immediately; delaying a waiting is the expensive error", from)
+		}
+		if d.Pending("s") {
+			t.Errorf("%q→waiting must leave nothing outstanding", from)
+		}
+	}
+}
+
+// TestStateDwell_OnlyWaitingToWorkingIsDebounced pins the scope of the grace
+// to the single edge that withdraws the come-look cue. Every other edge — the
+// other waiting exit included — publishes on the pass that decides it. See
+// graceFor for the reasoning; widening this is a decision, not a refactor, and
+// this test is what makes it one.
+func TestStateDwell_OnlyWaitingToWorkingIsDebounced(t *testing.T) {
+	undebounced := [][2]string{
+		{StateWorking, StateReady},
+		{StateReady, StateWorking},
+		{StateWorking, StateWaiting},
+		{StateReady, StateWaiting},
+		// The other waiting exit. ready still advertises that a human is
+		// needed, so this edge cannot commit the silent error the grace exists
+		// to prevent — and debouncing it broke ESC-cancel and #1173's
+		// idle-prompt reconciliation.
+		{StateWaiting, StateReady},
+	}
+	for _, edge := range undebounced {
+		d := NewStateDwell()
+		if !d.Admit("s", edge[0], edge[1], dwellT0) {
+			t.Errorf("%s→%s must not be debounced", edge[0], edge[1])
+		}
+	}
+
+	d := NewStateDwell()
+	if d.Admit("s", StateWaiting, StateWorking, dwellT0) {
+		t.Error("waiting→working must serve the dwell — it is the only edge that withdraws the cue")
+	}
+}
+
+// TestStateDwell_MeasuresTheInjectedClockNotTheWallClock is the replay
+// constraint from #1366's scope note 4, made mechanical. The virtual timeline
+// here sits in the year 2000; a time.Now() anywhere inside StateDwell would
+// read decades of elapsed time and publish on the second pass.
+func TestStateDwell_MeasuresTheInjectedClockNotTheWallClock(t *testing.T) {
+	d := NewStateDwell()
+
+	if d.Admit("s", StateWaiting, StateWorking, dwellT0) {
+		t.Fatal("first pass must not publish")
+	}
+	if d.Admit("s", StateWaiting, StateWorking, dwellT0.Add(time.Second)) {
+		t.Fatal("one virtual second in, the dwell is unmet — a wall clock would say decades")
+	}
+	if !d.Admit("s", StateWaiting, StateWorking, dwellT0.Add(waitingExitDwell)) {
+		t.Error("the dwell must be measured on the timeline it was handed")
+	}
+}
+
+// TestStateDwell_AChangedTargetVoidsTheProposal covers the classifier changing
+// its mind about where the session is going while still agreeing it is leaving
+// waiting. The new target is judged on its own terms — waiting→ready is not
+// debounced at all — and must not inherit elapsed time measured for a
+// different edge.
+func TestStateDwell_AChangedTargetVoidsTheProposal(t *testing.T) {
+	d := NewStateDwell()
+
+	d.Admit("s", StateWaiting, StateWorking, dwellT0)
+	if !d.Admit("s", StateWaiting, StateReady, dwellT0.Add(time.Second)) {
+		t.Fatal("waiting→ready is undebounced and must publish on its own terms")
+	}
+	if d.Pending("s") {
+		t.Error("publishing an undebounced edge must clear the outstanding proposal")
+	}
+}
+
+// TestStateDwell_APublishedStateMovingUnderneathRestartsTheClock covers the
+// other half of pendingExit recording `from`: something outside the classifier
+// (a terminal UI signal, a synthesizer) moved the session's published state
+// while a proposal was outstanding. The elapsed time measured so far describes
+// an edge nobody is proposing any more.
+func TestStateDwell_APublishedStateMovingUnderneathRestartsTheClock(t *testing.T) {
+	d := NewStateDwell()
+
+	d.Admit("s", StateWaiting, StateWorking, dwellT0)
+	// The session is now published as ready; ready→working is not debounced
+	// at all, so it publishes — and must not be treated as the maturing of
+	// the waiting→working proposal.
+	if !d.Admit("s", StateReady, StateWorking, dwellT0.Add(time.Second)) {
+		t.Fatal("ready→working is undebounced and must publish")
+	}
+	if d.Pending("s") {
+		t.Error("an undebounced publish must clear whatever was outstanding")
+	}
+}
+
+// TestStateDwell_SessionsAreIsolated guards the obvious sharing bug: one
+// session's dwell must not satisfy another's.
+func TestStateDwell_SessionsAreIsolated(t *testing.T) {
+	d := NewStateDwell()
+
+	d.Admit("a", StateWaiting, StateWorking, dwellT0)
+	if d.Admit("b", StateWaiting, StateWorking, dwellT0.Add(waitingExitDwell)) {
+		t.Error("session b's first sighting must not inherit session a's elapsed time")
+	}
+	if !d.Admit("a", StateWaiting, StateWorking, dwellT0.Add(waitingExitDwell)) {
+		t.Error("session a's own dwell must still complete")
+	}
+}
+
+// TestStateDwell_DropSessionForgets covers both callers: session teardown, and
+// the authoritative-event bypass in admitTransition.
+func TestStateDwell_DropSessionForgets(t *testing.T) {
+	d := NewStateDwell()
+
+	d.Admit("s", StateWaiting, StateWorking, dwellT0)
+	if !d.Pending("s") {
+		t.Fatal("precondition: the proposal must be outstanding")
+	}
+	d.DropSession("s")
+	if d.Pending("s") {
+		t.Fatal("DropSession must forget the proposal")
+	}
+	if d.Admit("s", StateWaiting, StateWorking, dwellT0.Add(waitingExitDwell)) {
+		t.Error("after DropSession the next sighting is a first sighting")
+	}
+}
+
+// TestStateDwell_NilDisablesHysteresis pins the nil behaviour the many
+// SessionDetector struct literals in the test suite rely on: no grace, and no
+// panic. A nil dwell must behave exactly as the code did before #1366.
+func TestStateDwell_NilDisablesHysteresis(t *testing.T) {
+	var d *StateDwell
+
+	if !d.Admit("s", StateWaiting, StateWorking, dwellT0) {
+		t.Error("a nil dwell must publish a real change immediately")
+	}
+	if d.Admit("s", StateWaiting, StateWaiting, dwellT0) {
+		t.Error("a nil dwell must still report 'nothing to publish' when nothing changed")
+	}
+	if d.Pending("s") {
+		t.Error("a nil dwell never has anything outstanding")
+	}
+	d.DropSession("s") // must not panic
+}
+
+// TestStateDwell_ConcurrentAccess is a -race guard. Hooks arrive on HTTP
+// handler goroutines while the event loop classifies, which is why StateDwell
+// carries its own lock rather than borrowing the detector's.
+func TestStateDwell_ConcurrentAccess(t *testing.T) {
+	d := NewStateDwell()
+	var wg sync.WaitGroup
+
+	for i := range 8 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sid := string(rune('a' + i))
+			for n := range 200 {
+				at := dwellT0.Add(time.Duration(n) * time.Second)
+				d.Admit(sid, StateWaiting, StateWorking, at)
+				d.Pending(sid)
+				if n%17 == 0 {
+					d.DropSession(sid)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/core/domain/session/state_dwell_test.go
+++ b/core/domain/session/state_dwell_test.go
@@ -124,6 +124,11 @@ func TestStateDwell_MeasuresTheInjectedClockNotTheWallClock(t *testing.T) {
 // waiting. The new target is judged on its own terms — waiting→ready is not
 // debounced at all — and must not inherit elapsed time measured for a
 // different edge.
+//
+// Note what this does and does not reach: it exits at Admit's `grace == 0`
+// branch, so it pins the DELETE on an undebounced publish, not pendingExit's
+// from/to shape check. That check is unreachable while graceFor debounces a
+// single edge; see its comment.
 func TestStateDwell_AChangedTargetVoidsTheProposal(t *testing.T) {
 	d := NewStateDwell()
 
@@ -136,11 +141,11 @@ func TestStateDwell_AChangedTargetVoidsTheProposal(t *testing.T) {
 	}
 }
 
-// TestStateDwell_APublishedStateMovingUnderneathRestartsTheClock covers the
-// other half of pendingExit recording `from`: something outside the classifier
-// (a terminal UI signal, a synthesizer) moved the session's published state
-// while a proposal was outstanding. The elapsed time measured so far describes
-// an edge nobody is proposing any more.
+// TestStateDwell_APublishedStateMovingUnderneathRestartsTheClock covers
+// something outside the classifier (a terminal UI signal, a synthesizer)
+// moving the session's published state while a proposal was outstanding: the
+// outstanding entry must not survive it. Same caveat as above — this exits at
+// the `grace == 0` branch and asserts the delete, not the shape check.
 func TestStateDwell_APublishedStateMovingUnderneathRestartsTheClock(t *testing.T) {
 	d := NewStateDwell()
 

--- a/tools/onboarding-factory/cmd/replay/replay_sidecar.go
+++ b/tools/onboarding-factory/cmd/replay/replay_sidecar.go
@@ -504,6 +504,25 @@ func (r *sidecarReplayer) applyParentHoldAndSynthesizedWaiting(newState, reason 
 		r.state = session.StateWaiting
 		newState, reason = services.ClassifyState(r.state, domainMetrics)
 	}
+	// Deliberately NOT mirroring the #1366 grace timer here, for the same
+	// reason #988 kept ShouldSynthesizeCollapsedTurnBoundary out of the
+	// transcript engine: only the live path has real timing to gate on.
+	//
+	// The dwell is a *publication* policy — it decides what reaches the UI,
+	// and SessionDetector.applyStateTransition is the thing it sits in front
+	// of. This replayer has no UI; its output model is the transition stream
+	// emit() builds, and runExtendedCheck diffs state_transition events only.
+	// So the goldens are a regression net for the parsers, the tailer and the
+	// classifier, and debouncing that net lowers its resolution: a correctly
+	// derived waiting→working with no later event behind it would simply stop
+	// appearing, and a future regression that stopped deriving it would then
+	// be invisible. Measured blast radius at the time of writing, so the
+	// trade-off is a number rather than a hunch: 41 such transitions across 15
+	// goldens in 4 adapters (claudecode 9, codex 3, hermes 2, pi 1).
+	//
+	// The classifier is untouched by #1366 — ClassifyStateTiered is byte for
+	// byte what it was — so this file keeps measuring exactly what it measured
+	// before, and no golden moves.
 	if newState != r.state {
 		r.emit(transitionFromMetrics(ctx.eventIdx, ctx.virtTime, ctx.cause,
 			r.state, newState, reason, domainMetrics))


### PR DESCRIPTION
Closes #1366.

A classified state change was published the instant the classifier decided it, so a transition reversed one pass later still reached the UI. #1355 adds hook-tier signals to up to eight more adapters and `Notification`/`idle_prompt` is ~6s late (#1141) — eight new ways to flap the badge.

## What this adds

`session.StateDwell` (`core/domain/session/state_dwell.go`): a per-session record of state changes decided but not yet published. Shaped after `SignalHolds` — own mutex, and **the clock passed in on every call**, never read inside. `SessionDetector.admitTransition` replaces the bare `newState != state.State` at the single publication point in `classifyAndTransition`.

No `time.Now()` enters the classifier. The pass clock now comes from `SessionDetector.nowFn()` — the same instant `holdContext.Now` already receives — so the dwell runs on the transcript's virtual timeline under replay. `TestStateDwell_MeasuresTheInjectedClockNotTheWallClock` anchors its virtual timeline in the year 2000, so a `time.Now()` anywhere inside would read decades of elapsed time and publish immediately.

## Which direction gets the grace

**Exactly one edge is debounced: `waiting→working`.** Entering `waiting` is never delayed, from any state.

The reasoning is in `graceFor`'s doc comment. A phantom `waiting` is self-limiting — the session claims it needs a human, the human looks, and looking is what corrects it. A dropped or late `waiting` is silent: nothing prompts the look that would reveal the error. So the grace is spent entirely on staying in `waiting` a moment too long, never on getting there a moment too late.

It is narrower than "leaving waiting", and that narrowing was **forced by evidence, not chosen**. What the grace protects is not the string `waiting` but *the advertisement that a human is needed* — and `ready` carries that advertisement too. `working` is the only state that withdraws it. A first version that debounced every waiting exit broke two existing behaviours:

- `TestSessionDetector_Activity_CancellationFromWaiting_TransitionsToReady` — `state: got "waiting", want ready (ESC from permission prompt)`
- `TestSessionDetector_IdlePromptHook_ReconcilesReadyToWaiting` — `next turn completed: state = "waiting", want ready (idle signal must not leak into the next turn)`

Both are a user action or an authoritative signal, not a flap. `waiting→ready` now publishes immediately and both pass.

Dwell value: **6s**, calibrated to #1141's measured `Notification` lag rather than picked symmetric — see the constant's comment.

## Can a dwell swallow a `hold_expired`-driven transition?

**Yes — and it did.** A #1360 ceiling expiry unpins a session, which is a `waiting→working` edge: exactly the debounced one. It is not merely delayed, it is lost, and the mechanism is invisible from either feature's own tests: `refreshStaleSessions` selects non-working sessions on `SignalHolds.HasAny`, and *dropping the hold is what makes `HasAny` false*. The same pass that starts the dwell is the pass that stops the ticker ever coming back. The session stays pinned at `waiting` for the life of the process — the defect #1360 was opened to remove.

Seen red against a naive dwell (gate on, exemption off):

```
--- FAIL: TestClassify_CeilingExpiryIsNotSwallowedByTheDwell (0.00s)
    state_dwell_test.go:246: the ceiling expiry must unpin the session on the
    pass it fires, got "waiting" — a dwell that defers this can never be
    satisfied, because dropping the hold is what stops refreshStaleSessions
    from revisiting the session at all
--- FAIL: TestClassify_ADwellOutstandingKeepsTheTickerComing/a_dwell_alone_selects_the_session
    state_dwell_test.go:308: a deferred waiting exit must keep the ticker
    coming, or the grace timer is a dropper and not a delay
```

Closed twice over, deliberately:

1. `admitTransition` **bypasses the dwell entirely** when `Overlay` reported an expiry this pass. An expiry is not a flap and cannot become one — the hold is deleted, nothing re-asserts it, and it only fires after hours of wall clock.
2. `shouldRevisitIdleSession` also selects on `StateDwell.Pending`, bounding *every* dwell whatever started it, so the timer is always a delay and never a drop.

A synthesizer that re-based the current state this pass is exempt for the same class of reason: it authors a *pair* of transitions, and holding the second half back would strand the session in a synthetic `waiting` the pass itself knows has ended.

## Red-first evidence

Both captures taken against the final code by reverting only the gate (`git commit -m wip` checkpoint, never `git stash`).

**No hysteresis (pre-#1366 publication rule):**
```
state_dwell_test.go:94: a waiting exit reversed inside the dwell must never be
published, got 2 transition(s): [... PrevState:waiting NewState:working ...
PrevState:working NewState:waiting ...]
--- FAIL: TestClassify_AReversedWaitingExitNeverReachesTheUI (0.00s)
state_dwell_test.go:121: precondition: the first pass must not publish, got "working"
--- FAIL: TestClassify_AWaitingExitThatHoldsIsPublished (0.00s)
```

**LOCKS** — pass on `main` by construction, and say so: `TestClassify_EnteringWaitingIsNotDelayed`, `TestClassify_FirstClassificationIsNotDelayed`, `TestClassify_ADwellOutstandingKeepsTheTickerComing/{nothing_outstanding_is_still_left_alone, a_hold_alone_selects_the_session}`, `TestStateDwell_OnlyWaitingToWorkingIsDebounced`'s undebounced arm.

## Replay goldens: none moved

`tools/preflight.sh --only go`'s `replay fixtures` gate is **PASS**, unmodified. The harness deliberately does not mirror the dwell, documented at the call site in `replay_sidecar.go` with the measurement rather than a hunch:

- The dwell is a *publication* policy; this replayer has no UI, and `runExtendedCheck` diffs `state_transition` events only. The goldens are a regression net for the parsers, tailer and classifier — debouncing that net lowers its resolution, since a correctly derived `waiting→working` with no later event behind it would stop appearing and a future regression that stopped deriving it would be invisible.
- Measured blast radius had it been mirrored: **41 transitions across 15 goldens in 4 adapters** (claudecode 9, codex 3, hermes 2, pi 1).
- Precedent for deliberate daemon/harness divergence on timing-derived behaviour: #988 keeps `ShouldSynthesizeCollapsedTurnBoundary` out of the replay engine ("only the live path has real timing to gate this on"), and #1360 discards `Overlay`'s `[]SignalExpiry` at all three sidecar call sites.
- `ClassifyStateTiered` is byte-for-byte unchanged, so the harness measures exactly what it measured before.

## Verification

Chunked foreground `tools/preflight.sh`, all green: `go` (gofmt, core module tests, onboarding-factory, replaydata validate, recording-rig smoke, **replay fixtures**, starhistory), `web` (both trees), `arch` (ARS), `tools`, `skills`, `security`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
