### PR TITLE
fix(claudecode): derive the instructions consent copy from the blocks Apply installs

### DIFF
--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -130,20 +130,20 @@ func Agent() agent.Agent {
 				Remove: func() error { _, err := UninstallStatusline(); return err },
 			},
 			{
-				Key:             PermissionKeyInstructions,
-				Kind:            permission.KindModify,
-				Title:           "Install task-progress rule",
-				FeatureUnlocked: "Task-completion ETA chip + task summary from agent-reported markers",
-				Touches:         "Maintains two managed blocks in ~/.claude/CLAUDE.md",
-				Detail: "Writes two irrlicht-managed blocks (each between BEGIN/END " +
-					"sentinels) to ~/.claude/CLAUDE.md instructing the agent to emit " +
-					"hidden markers: a task-progress marker (which irrlicht reads to " +
-					"project a completion ETA) and a one-line task summary (so a human " +
-					"can tell what a session is about). All surrounding file content " +
-					"is preserved byte-for-byte. Toggling off removes exactly these " +
-					"blocks (also available via the macOS Settings toggle).",
-				Apply:  applyInstructionBlocks,
-				Remove: removeInstructionBlocks,
+				Key:   PermissionKeyInstructions,
+				Kind:  permission.KindModify,
+				Title: "Install task-progress rule",
+				// The block list and count are derived from
+				// installedInstructionBlocks — the same slice Apply iterates —
+				// never restated here. Hand-maintaining this text is how it came
+				// to disclose the task-summary block retired in #1186 while
+				// saying nothing about the task-question block (#759) it has
+				// been writing to the user's CLAUDE.md ever since (#1377).
+				FeatureUnlocked: "Task-completion ETA chip + waiting-question headline from agent-reported markers",
+				Touches:         instructionsTouched(),
+				Detail:          instructionsDetail(),
+				Apply:           applyInstructionBlocks,
+				Remove:          removeInstructionBlocks,
 			},
 			agent.ControlPermission(),
 		},

--- a/core/adapters/inbound/agents/claudecode/instructiondisclosure_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructiondisclosure_test.go
@@ -1,0 +1,159 @@
+// instructiondisclosure_test.go binds the instructions permission's consent
+// copy to what applyInstructionBlocks actually writes into the user's
+// ~/.claude/CLAUDE.md (issue #1377) — the same obligation
+// contracttesting.AssertHookDisclosureMatchesInstalled carries for the hooks
+// permission (#1356), which is keyed on hook events and so structurally cannot
+// see this one.
+//
+// It lives here rather than in contracttesting on purpose: today exactly one
+// adapter installs instruction blocks, and the generalized seam the issue
+// sketches (an inventory on agent.Permission spanning every KindModify
+// permission) is owned by #1383. This file asserts the obligation for the
+// adapter that has it; if a second adapter grows managed instruction blocks,
+// promote it then.
+//
+// Ground truth is the file on disk, not the inventory the renderer reads: the
+// test runs the real Apply effect against a temp HOME and scans the BEGIN
+// sentinels that ended up written. A test comparing the copy against the same
+// variable the copy is rendered from would be comparing a declaration to
+// itself.
+package claudecode
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/permission"
+)
+
+// blockSentinelName pulls a managed block's name out of its BEGIN sentinel:
+// "<!-- BEGIN IRRLICHT MANAGED BLOCK (task-eta) -->" → "task-eta". Applied both
+// to the file the installer wrote and to the package's sentinel constants, so
+// neither side is a hand-kept roster of names.
+var blockSentinelName = regexp.MustCompile(`BEGIN IRRLICHT MANAGED BLOCK \(([a-z0-9-]+)\)`)
+
+// blockCountPattern reads back every block count the consent copy states.
+// "irrlicht-" is optional so the Touches line ("2 managed blocks") and the
+// Detail line ("2 irrlicht-managed blocks") are both recognized, and the
+// singular is accepted so a one-block future is not forced into bad grammar.
+var blockCountPattern = regexp.MustCompile(`(\d+) (?:irrlicht-)?managed blocks?`)
+
+// namePattern matches a block name as prose would carry it: the hyphen in
+// "task-summary" also matches the space in "task summary". That tolerance is
+// load-bearing for the over-promise arm — the copy this test was written
+// against disclosed the retired block as "a one-line task summary", which a
+// strict hyphenated match would have read as absent.
+func namePattern(name string) *regexp.Regexp {
+	return regexp.MustCompile(`\b` + strings.ReplaceAll(regexp.QuoteMeta(name), `-`, `[- ]`) + `\b`)
+}
+
+// declaredBlockNames are the names of every managed block this package knows a
+// sentinel for — installed, or retired and cleaned up. Referencing the
+// constants (not string literals) keeps the list tied to the declarations it
+// polices; a future block whose sentinel is not added here is simply not
+// covered by the over-promise arm, never silently mis-covered.
+func declaredBlockNames(t *testing.T) []string {
+	t.Helper()
+	var names []string
+	for _, sentinel := range []string{
+		taskEtaBeginSentinel,
+		taskSummaryBeginSentinel,
+		taskQuestionBeginSentinel,
+	} {
+		m := blockSentinelName.FindStringSubmatch(sentinel)
+		if m == nil {
+			t.Fatalf("sentinel %q does not carry a parseable block name", sentinel)
+		}
+		names = append(names, m[1])
+	}
+	return names
+}
+
+// installedBlockNames runs the permission's real Apply effect against a temp
+// HOME and returns the block names it actually left in the file.
+func installedBlockNames(t *testing.T) []string {
+	t.Helper()
+	home := withTempHome(t)
+	if err := applyInstructionBlocks(); err != nil {
+		t.Fatalf("applyInstructionBlocks: %v", err)
+	}
+	content := readFileString(t, memoryPathFor(home))
+	var names []string
+	for _, m := range blockSentinelName.FindAllStringSubmatch(content, -1) {
+		names = append(names, m[1])
+	}
+	if len(names) == 0 {
+		t.Fatal("apply wrote no managed block at all — the test cannot see what it discloses")
+	}
+	return names
+}
+
+// TestInstructionsDisclosure_MatchesInstalledBlocks is the issue #1377 defect
+// test. The wizard's Touches/Detail text *is* the #570 consent contract for a
+// modify-kind permission, so it must name every block the install writes, state
+// how many there are, and present no block it does not write.
+func TestInstructionsDisclosure_MatchesInstalledBlocks(t *testing.T) {
+	installed := installedBlockNames(t)
+	perm := findPermission(t, Agent(), PermissionKeyInstructions)
+
+	if perm.Kind != permission.KindModify {
+		t.Errorf("instructions permission is %v, want %v — it writes to the user's CLAUDE.md",
+			perm.Kind, permission.KindModify)
+	}
+
+	// Touches is the wizard row and Detail the (i) expander; which of the two
+	// carries a given fact is presentation, and the user sees both before
+	// granting — so the naming and count arms read them together.
+	disclosure := perm.Touches + "\n" + perm.Detail
+
+	t.Run("names_every_installed_block", func(t *testing.T) {
+		for _, name := range installed {
+			if !namePattern(name).MatchString(disclosure) {
+				t.Errorf("consent copy never names the %q block, but Apply writes it to "+
+					"~/.claude/CLAUDE.md — an undisclosed write to a user-authored file (#570)", name)
+			}
+		}
+	})
+
+	t.Run("states_the_installed_count", func(t *testing.T) {
+		matches := blockCountPattern.FindAllStringSubmatch(disclosure, -1)
+		if len(matches) == 0 {
+			t.Fatalf("consent copy states no block count; want %q",
+				strconv.Itoa(len(installed))+" managed blocks")
+		}
+		for _, m := range matches {
+			stated, err := strconv.Atoi(m[1])
+			if err != nil {
+				t.Fatalf("unparseable block count %q: %v", m[1], err)
+			}
+			if stated != len(installed) {
+				t.Errorf("consent copy declares %d managed blocks, Apply writes %d", stated, len(installed))
+			}
+		}
+	})
+
+	t.Run("names_no_uninstalled_block", func(t *testing.T) {
+		// FeatureUnlocked joins this arm: it is the benefit line the wizard
+		// shows above the row, and naming a retired block there advertises a
+		// capability the install does not deliver. It is deliberately left out
+		// of the two arms above — it sells the feature, it does not enumerate
+		// the writes.
+		overPromise := disclosure + "\n" + perm.FeatureUnlocked
+		written := map[string]bool{}
+		for _, name := range installed {
+			written[name] = true
+		}
+		for _, name := range declaredBlockNames(t) {
+			if written[name] {
+				continue
+			}
+			if namePattern(name).MatchString(overPromise) {
+				t.Errorf("consent copy names the %q block, but Apply does not write it — "+
+					"the disclosure promises something the install never does; install it "+
+					"or drop it from the copy", name)
+			}
+		}
+	})
+}

--- a/core/adapters/inbound/agents/claudecode/instructiondisclosure_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructiondisclosure_test.go
@@ -135,12 +135,14 @@ func TestInstructionsDisclosure_MatchesInstalledBlocks(t *testing.T) {
 	})
 
 	t.Run("names_no_uninstalled_block", func(t *testing.T) {
-		// FeatureUnlocked joins this arm: it is the benefit line the wizard
-		// shows above the row, and naming a retired block there advertises a
-		// capability the install does not deliver. It is deliberately left out
-		// of the two arms above — it sells the feature, it does not enumerate
-		// the writes.
-		overPromise := disclosure + "\n" + perm.FeatureUnlocked
+		// Title and FeatureUnlocked join this arm: they are the wizard's row
+		// label and benefit line, and naming a retired block in either
+		// advertises a capability the install does not deliver. They are
+		// deliberately left out of the two arms above — they sell the feature,
+		// they do not enumerate the writes. Title matters most here because it
+		// is the last hand-written string in this permission, which is exactly
+		// the shape of drift the rest of the change makes unrepresentable.
+		overPromise := strings.Join([]string{disclosure, perm.FeatureUnlocked, perm.Title}, "\n")
 		written := map[string]bool{}
 		for _, name := range installed {
 			written[name] = true

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -365,11 +365,11 @@ func applyInstructionBlocks() error {
 // removeInstructionBlocks removes all managed blocks — the revoke effect of
 // the instructions permission.
 func removeInstructionBlocks() error {
-	_, err := UninstallAllInstructionBlocks()
+	_, err := UninstallInstructionBlocks()
 	return err
 }
 
-// UninstallAllInstructionBlocks removes every managed instruction block —
+// UninstallInstructionBlocks removes every managed instruction block —
 // installed and retired alike — reporting whether ~/.claude/CLAUDE.md changed.
 // It backs both the permission's revoke effect and the `irrlichd
 // --uninstall-task-eta` escape hatch, driven by the same two inventories Apply
@@ -377,7 +377,7 @@ func removeInstructionBlocks() error {
 // the CLI carried its own hand-written pair (task-eta + task-summary) and so
 // left the task-question block #759 installs sitting in the user's file with no
 // way to remove it, while printing "No irrlicht managed blocks found" (#1377).
-func UninstallAllInstructionBlocks() (bool, error) {
+func UninstallInstructionBlocks() (bool, error) {
 	changed := false
 	for _, b := range allInstructionBlocks() {
 		modified, err := uninstallBlock(b.begin, b.end)

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 )
 
 // Sentinels delimiting the managed block. Detection keys on these full
@@ -225,32 +227,21 @@ func uninstallBlock(beginSentinel, endSentinel string) (bool, error) {
 	return true, writeMemoryFile(path, stripped)
 }
 
-// EnsureTaskEtaBlockInstalled writes-or-patches the task-eta managed block.
-func EnsureTaskEtaBlockInstalled() (bool, error) {
+// ensureTaskEtaBlock writes-or-patches the task-eta managed block.
+func ensureTaskEtaBlock() (bool, error) {
 	return ensureBlockInstalled(taskEtaBeginSentinel, taskEtaEndSentinel, managedTaskEtaBlock)
 }
 
-// UninstallTaskEtaBlock removes only the task-eta managed block.
-func UninstallTaskEtaBlock() (bool, error) {
+// uninstallTaskEtaBlock removes only the task-eta managed block.
+func uninstallTaskEtaBlock() (bool, error) {
 	return uninstallBlock(taskEtaBeginSentinel, taskEtaEndSentinel)
 }
 
-// UninstallTaskSummaryBlock removes only the (retired, issue #1186) task-summary
-// managed block — the cleanup path for CLAUDE.md files a prior version wrote.
-func UninstallTaskSummaryBlock() (bool, error) {
-	return uninstallBlock(taskSummaryBeginSentinel, taskSummaryEndSentinel)
-}
-
-// EnsureTaskQuestionBlockInstalled writes-or-patches the task-question managed
-// block (issue #759) — installed alongside the eta/summary blocks under the
-// same instructions permission.
-func EnsureTaskQuestionBlockInstalled() (bool, error) {
+// ensureTaskQuestionBlock writes-or-patches the task-question managed block
+// (issue #759) — installed alongside the task-eta block under the same
+// instructions permission.
+func ensureTaskQuestionBlock() (bool, error) {
 	return ensureBlockInstalled(taskQuestionBeginSentinel, taskQuestionEndSentinel, managedTaskQuestionBlock)
-}
-
-// UninstallTaskQuestionBlock removes only the task-question managed block.
-func UninstallTaskQuestionBlock() (bool, error) {
-	return uninstallBlock(taskQuestionBeginSentinel, taskQuestionEndSentinel)
 }
 
 // managedInstructionBlock is one irrlicht-managed block in ~/.claude/CLAUDE.md:
@@ -312,9 +303,14 @@ func instructionsTouched() string {
 	for _, b := range installedInstructionBlocks {
 		names = append(names, b.name)
 	}
+	// hookjson.EventList is the repo's one prose-list renderer for consent copy.
+	// It is named for its first caller, but the serial comma it fixes is a
+	// property of the copy, not of hooks: both disclosure contracts read names
+	// back out of the rendered text, so a second copy of this switch is a second
+	// place the punctuation can drift.
 	return fmt.Sprintf("Maintains %d managed %s (%s) in %s",
 		len(installedInstructionBlocks), blockNoun(len(installedInstructionBlocks)),
-		joinProse(names), claudeMemoryDisplayPath)
+		hookjson.EventList(names), claudeMemoryDisplayPath)
 }
 
 // instructionsDetail renders the Detail text behind the wizard's (i) expander.
@@ -331,8 +327,8 @@ func instructionsDetail() string {
 			"instructing the agent to emit hidden markers: %s. All surrounding file "+
 			"content is preserved byte-for-byte, and a managed block an earlier "+
 			"irrlicht version wrote but this one no longer uses is removed on the same "+
-			"pass. Toggling off removes exactly these blocks (also available via the "+
-			"macOS Settings toggle).",
+			"pass. Toggling off removes these blocks and any such retired block, and "+
+			"nothing else (also available via the macOS Settings toggle).",
 		len(installedInstructionBlocks), blockNoun(len(installedInstructionBlocks)),
 		claudeMemoryDisplayPath, strings.Join(clauses, "; "))
 }
@@ -344,22 +340,6 @@ func blockNoun(n int) string {
 		return "block"
 	}
 	return "blocks"
-}
-
-// joinProse renders items as "A", "A and B", "A, B, and C". The serial comma is
-// deliberate and matches hookjson.EventList: the disclosure assertions read
-// names back out of the copy, so the punctuation must not be tuned per caller.
-func joinProse(items []string) string {
-	switch len(items) {
-	case 0:
-		return ""
-	case 1:
-		return items[0]
-	case 2:
-		return items[0] + " and " + items[1]
-	default:
-		return strings.Join(items[:len(items)-1], ", ") + ", and " + items[len(items)-1]
-	}
 }
 
 // applyInstructionBlocks installs the managed instruction blocks — the grant
@@ -383,20 +363,39 @@ func applyInstructionBlocks() error {
 }
 
 // removeInstructionBlocks removes all managed blocks — the revoke effect of
-// the instructions permission. Retired blocks are swept here too, so revoking
-// leaves nothing behind whichever version installed it.
+// the instructions permission.
 func removeInstructionBlocks() error {
-	for _, b := range installedInstructionBlocks {
-		if _, err := uninstallBlock(b.begin, b.end); err != nil {
-			return err
+	_, err := UninstallAllInstructionBlocks()
+	return err
+}
+
+// UninstallAllInstructionBlocks removes every managed instruction block —
+// installed and retired alike — reporting whether ~/.claude/CLAUDE.md changed.
+// It backs both the permission's revoke effect and the `irrlichd
+// --uninstall-task-eta` escape hatch, driven by the same two inventories Apply
+// is, so the two cleanup paths cannot come to sweep different sets. They had:
+// the CLI carried its own hand-written pair (task-eta + task-summary) and so
+// left the task-question block #759 installs sitting in the user's file with no
+// way to remove it, while printing "No irrlicht managed blocks found" (#1377).
+func UninstallAllInstructionBlocks() (bool, error) {
+	changed := false
+	for _, b := range allInstructionBlocks() {
+		modified, err := uninstallBlock(b.begin, b.end)
+		if err != nil {
+			return changed, err
 		}
+		changed = changed || modified
 	}
-	for _, b := range retiredInstructionBlocks {
-		if _, err := uninstallBlock(b.begin, b.end); err != nil {
-			return err
-		}
-	}
-	return nil
+	return changed, nil
+}
+
+// allInstructionBlocks is every block this package knows a sentinel for, in a
+// fresh slice — never append-onto-a-package-var, which would write through the
+// inventory's backing array whenever it had spare capacity.
+func allInstructionBlocks() []managedInstructionBlock {
+	all := make([]managedInstructionBlock, 0, len(installedInstructionBlocks)+len(retiredInstructionBlocks))
+	all = append(all, installedInstructionBlocks...)
+	return append(all, retiredInstructionBlocks...)
 }
 
 // patchManagedBlock returns existing with the managed block inserted or

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller.go
@@ -16,6 +16,7 @@
 package claudecode
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -169,6 +170,11 @@ characters, and when clarity and brevity conflict, choose clarity.
 - Bad "Yes or no?" → Good "PR #482 review: 1 blocking finding left — fix now or merge and follow up?"
 ` + taskQuestionEndSentinel
 
+// claudeMemoryDisplayPath is the instruction file as the consent copy shows it
+// — tilde-form, not the resolved absolute path, because the wizard text is read
+// by a human and claudeMemoryPath() expands to whatever $HOME happens to be.
+const claudeMemoryDisplayPath = "~/.claude/CLAUDE.md"
+
 // claudeMemoryPath returns the user-level Claude Code instruction file path.
 func claudeMemoryPath() (string, error) {
 	home, err := os.UserHomeDir()
@@ -247,34 +253,150 @@ func UninstallTaskQuestionBlock() (bool, error) {
 	return uninstallBlock(taskQuestionBeginSentinel, taskQuestionEndSentinel)
 }
 
+// managedInstructionBlock is one irrlicht-managed block in ~/.claude/CLAUDE.md:
+// the sentinels that delimit it, the content written between them, and the
+// clause the consent copy uses to disclose it.
+type managedInstructionBlock struct {
+	// name is the identifier inside the sentinels, e.g. "task-eta" — the same
+	// string a user finds in their own CLAUDE.md, so the copy can name the
+	// block by what they will actually see there.
+	name  string
+	begin string
+	end   string
+	// content is the block written verbatim. Empty for a retired block: it is
+	// removed, never written.
+	content string
+	// discloses says what this block asks the agent to emit, in consent prose.
+	discloses string
+}
+
+// installedInstructionBlocks is the single declaration of what the instructions
+// permission's Apply writes. applyInstructionBlocks iterates it and the consent
+// copy is rendered from it (instructionsTouched/instructionsDetail), so the text
+// the user grants against cannot come to describe a different set of blocks than
+// the installer writes. Issue #1377 was exactly that drift — the hand-written
+// copy named the retired task-summary block and never named task-question —
+// arriving on the permission next door to #1356's, which is why the count and
+// the list are derived here rather than restated there.
+var installedInstructionBlocks = []managedInstructionBlock{
+	{
+		name:      "task-eta",
+		begin:     taskEtaBeginSentinel,
+		end:       taskEtaEndSentinel,
+		content:   managedTaskEtaBlock,
+		discloses: "a task-progress marker, which irrlicht reads to project a completion ETA",
+	},
+	{
+		name:    "task-question",
+		begin:   taskQuestionBeginSentinel,
+		end:     taskQuestionEndSentinel,
+		content: managedTaskQuestionBlock,
+		discloses: "a one-line version of the question it is waiting on, so a human can tell " +
+			"what a session is blocked on",
+	},
+}
+
+// retiredInstructionBlocks are blocks an earlier version installed that this one
+// no longer uses. Apply removes them instead of writing them, which is why they
+// are a separate list and carry no disclosure clause: the copy is rendered from
+// the installed list alone, so a retired block cannot be presented as something
+// irrlicht writes.
+var retiredInstructionBlocks = []managedInstructionBlock{
+	{name: "task-summary", begin: taskSummaryBeginSentinel, end: taskSummaryEndSentinel},
+}
+
+// instructionsTouched renders the Touches line of the instructions permission —
+// the one-line summary the wizard row shows.
+func instructionsTouched() string {
+	var names []string
+	for _, b := range installedInstructionBlocks {
+		names = append(names, b.name)
+	}
+	return fmt.Sprintf("Maintains %d managed %s (%s) in %s",
+		len(installedInstructionBlocks), blockNoun(len(installedInstructionBlocks)),
+		joinProse(names), claudeMemoryDisplayPath)
+}
+
+// instructionsDetail renders the Detail text behind the wizard's (i) expander.
+// The retired-block cleanup is disclosed as a removal without naming the block:
+// what the user needs to know is that Apply may delete an irrlicht block it did
+// not write in this version, not which historical marker it was.
+func instructionsDetail() string {
+	var clauses []string
+	for _, b := range installedInstructionBlocks {
+		clauses = append(clauses, b.name+" — "+b.discloses)
+	}
+	return fmt.Sprintf(
+		"Writes %d irrlicht-managed %s (each between BEGIN/END sentinels) to %s, "+
+			"instructing the agent to emit hidden markers: %s. All surrounding file "+
+			"content is preserved byte-for-byte, and a managed block an earlier "+
+			"irrlicht version wrote but this one no longer uses is removed on the same "+
+			"pass. Toggling off removes exactly these blocks (also available via the "+
+			"macOS Settings toggle).",
+		len(installedInstructionBlocks), blockNoun(len(installedInstructionBlocks)),
+		claudeMemoryDisplayPath, strings.Join(clauses, "; "))
+}
+
+// blockNoun agrees the noun with the count so a future single-block install
+// does not ship broken grammar in the copy the user consents to.
+func blockNoun(n int) string {
+	if n == 1 {
+		return "block"
+	}
+	return "blocks"
+}
+
+// joinProse renders items as "A", "A and B", "A, B, and C". The serial comma is
+// deliberate and matches hookjson.EventList: the disclosure assertions read
+// names back out of the copy, so the punctuation must not be tuned per caller.
+func joinProse(items []string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " and " + items[1]
+	default:
+		return strings.Join(items[:len(items)-1], ", ") + ", and " + items[len(items)-1]
+	}
+}
+
 // applyInstructionBlocks installs the managed instruction blocks — the grant
 // effect of the instructions permission. All are governed by a single toggle
-// so it covers every irrlicht-managed instruction. The retired irrlicht-summary
-// block (issue #1186) is actively uninstalled here rather than installed, so a
-// CLAUDE.md a prior version wrote is cleaned up on the next granted daemon
-// start. Returns on the first error.
+// so it covers every irrlicht-managed instruction. Retired blocks (the
+// irrlicht-summary one, issue #1186) are actively uninstalled here rather than
+// installed, so a CLAUDE.md a prior version wrote is cleaned up on the next
+// granted daemon start. Returns on the first error.
 func applyInstructionBlocks() error {
-	if _, err := EnsureTaskEtaBlockInstalled(); err != nil {
-		return err
+	for _, b := range installedInstructionBlocks {
+		if _, err := ensureBlockInstalled(b.begin, b.end, b.content); err != nil {
+			return err
+		}
 	}
-	if _, err := UninstallTaskSummaryBlock(); err != nil {
-		return err
+	for _, b := range retiredInstructionBlocks {
+		if _, err := uninstallBlock(b.begin, b.end); err != nil {
+			return err
+		}
 	}
-	_, err := EnsureTaskQuestionBlockInstalled()
-	return err
+	return nil
 }
 
 // removeInstructionBlocks removes all managed blocks — the revoke effect of
-// the instructions permission.
+// the instructions permission. Retired blocks are swept here too, so revoking
+// leaves nothing behind whichever version installed it.
 func removeInstructionBlocks() error {
-	if _, err := UninstallTaskEtaBlock(); err != nil {
-		return err
+	for _, b := range installedInstructionBlocks {
+		if _, err := uninstallBlock(b.begin, b.end); err != nil {
+			return err
+		}
 	}
-	if _, err := UninstallTaskSummaryBlock(); err != nil {
-		return err
+	for _, b := range retiredInstructionBlocks {
+		if _, err := uninstallBlock(b.begin, b.end); err != nil {
+			return err
+		}
 	}
-	_, err := UninstallTaskQuestionBlock()
-	return err
+	return nil
 }
 
 // patchManagedBlock returns existing with the managed block inserted or

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -27,7 +27,7 @@ func readFileString(t *testing.T, path string) string {
 
 func TestEnsureTaskEtaBlock_CreatesFileIfAbsent(t *testing.T) {
 	home := withTempHome(t)
-	modified, err := EnsureTaskEtaBlockInstalled()
+	modified, err := ensureTaskEtaBlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,12 +44,12 @@ func TestEnsureTaskEtaBlock_CreatesFileIfAbsent(t *testing.T) {
 
 func TestEnsureTaskEtaBlock_Idempotent(t *testing.T) {
 	home := withTempHome(t)
-	if _, err := EnsureTaskEtaBlockInstalled(); err != nil {
+	if _, err := ensureTaskEtaBlock(); err != nil {
 		t.Fatal(err)
 	}
 	first := readFileString(t, memoryPathFor(home))
 
-	modified, err := EnsureTaskEtaBlockInstalled()
+	modified, err := ensureTaskEtaBlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestEnsureTaskEtaBlock_PreservesSurroundingContent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := EnsureTaskEtaBlockInstalled(); err != nil {
+	if _, err := ensureTaskEtaBlock(); err != nil {
 		t.Fatal(err)
 	}
 	content := readFileString(t, path)
@@ -92,7 +92,7 @@ func TestEnsureTaskEtaBlock_UpgradesStaleBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	modified, err := EnsureTaskEtaBlockInstalled()
+	modified, err := ensureTaskEtaBlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func TestEnsureTaskEtaBlock_UpgradesStaleBlock(t *testing.T) {
 	}
 
 	// And the upgrade itself is idempotent.
-	if again, err := EnsureTaskEtaBlockInstalled(); err != nil || again {
+	if again, err := ensureTaskEtaBlock(); err != nil || again {
 		t.Errorf("re-install after upgrade: modified=%v err=%v, want false,nil", again, err)
 	}
 }
@@ -163,7 +163,7 @@ is how many you've finished. Update every few steps.
 		t.Fatal(err)
 	}
 
-	modified, err := EnsureTaskEtaBlockInstalled()
+	modified, err := ensureTaskEtaBlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +205,7 @@ already making (never to the command itself).
 		t.Fatal(err)
 	}
 
-	modified, err := EnsureTaskEtaBlockInstalled()
+	modified, err := ensureTaskEtaBlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ text when no Bash call is coming.
 		t.Fatal(err)
 	}
 
-	modified, err := EnsureTaskEtaBlockInstalled()
+	modified, err := ensureTaskEtaBlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,10 +304,10 @@ func TestUninstallTaskEtaBlock_RoundTripsToOriginal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := EnsureTaskEtaBlockInstalled(); err != nil {
+	if _, err := ensureTaskEtaBlock(); err != nil {
 		t.Fatal(err)
 	}
-	modified, err := UninstallTaskEtaBlock()
+	modified, err := uninstallTaskEtaBlock()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,7 +330,7 @@ func TestUninstallTaskEtaBlock_PreservesUserContentAroundBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := UninstallTaskEtaBlock(); err != nil {
+	if _, err := uninstallTaskEtaBlock(); err != nil {
 		t.Fatal(err)
 	}
 	got := readFileString(t, path)
@@ -343,7 +343,7 @@ func TestUninstallTaskEtaBlock_Noops(t *testing.T) {
 	home := withTempHome(t)
 
 	// No file at all.
-	modified, err := UninstallTaskEtaBlock()
+	modified, err := uninstallTaskEtaBlock()
 	if err != nil || modified {
 		t.Errorf("no file: modified=%v err=%v, want false,nil", modified, err)
 	}
@@ -359,7 +359,7 @@ func TestUninstallTaskEtaBlock_Noops(t *testing.T) {
 	if err := os.WriteFile(path, []byte("just user stuff\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	modified, err = UninstallTaskEtaBlock()
+	modified, err = uninstallTaskEtaBlock()
 	if err != nil || modified {
 		t.Errorf("no block: modified=%v err=%v, want false,nil", modified, err)
 	}
@@ -397,7 +397,7 @@ func TestPatchManagedBlock_BeginWithoutEndAppendsFresh(t *testing.T) {
 
 func TestEnsureTaskQuestionBlock_CreatesFileIfAbsent(t *testing.T) {
 	home := withTempHome(t)
-	modified, err := EnsureTaskQuestionBlockInstalled()
+	modified, err := ensureTaskQuestionBlock()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -313,19 +313,17 @@ func reportUninstall(w io.Writer, path string, uninstall func() (bool, error)) b
 	return true
 }
 
-// uninstallTaskEtaBlocks removes irrlicht's managed task-eta and
-// task-summary blocks from ~/.claude/CLAUDE.md.
+// uninstallTaskEtaBlocks removes every irrlicht-managed instruction block from
+// ~/.claude/CLAUDE.md. The set is the adapter's, not restated here: this used to
+// name task-eta and task-summary by hand and so silently left the task-question
+// block behind (#1377).
 func uninstallTaskEtaBlocks() {
-	etaModified, err := claudecode.UninstallTaskEtaBlock()
+	modified, err := claudecode.UninstallAllInstructionBlocks()
 	if err != nil {
-		log.Fatalf("failed to uninstall task-eta block: %v", err)
+		log.Fatalf("failed to uninstall irrlicht instruction blocks: %v", err)
 	}
-	summaryModified, err := claudecode.UninstallTaskSummaryBlock()
-	if err != nil {
-		log.Fatalf("failed to uninstall task-summary block: %v", err)
-	}
-	if etaModified || summaryModified {
-		fmt.Println("Removed irrlicht task-eta/task-summary blocks from ~/.claude/CLAUDE.md")
+	if modified {
+		fmt.Println("Removed irrlicht managed blocks from ~/.claude/CLAUDE.md")
 	} else {
 		fmt.Println("No irrlicht managed blocks found in ~/.claude/CLAUDE.md")
 	}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -318,7 +318,7 @@ func reportUninstall(w io.Writer, path string, uninstall func() (bool, error)) b
 // name task-eta and task-summary by hand and so silently left the task-question
 // block behind (#1377).
 func uninstallTaskEtaBlocks() {
-	modified, err := claudecode.UninstallAllInstructionBlocks()
+	modified, err := claudecode.UninstallInstructionBlocks()
 	if err != nil {
 		log.Fatalf("failed to uninstall irrlicht instruction blocks: %v", err)
 	}


### PR DESCRIPTION
Closes #1377.

## What was wrong

The Claude Code `instructions` permission's consent copy described an install
that never happened and hid one that did:

- it named **task-summary**, retired in #1186 — `applyInstructionBlocks` *removes*
  that block, it does not write it;
- it never named **task-question** (#759), which it has been writing into the
  user's `~/.claude/CLAUDE.md` on every grant since;
- `FeatureUnlocked` advertised "task summary from agent-reported markers", a
  capability that no longer exists.

The count ("two managed blocks") was right by luck. Per #570 the `Touches`/`Detail`
text *is* the consent contract for a `modify`-kind permission, so this is the same
violation shape as #1356, one permission over in the same `Agent()` literal.

## What changed

`installedInstructionBlocks` (in `instructioninstaller.go`) is now the single
declaration of what the grant effect writes — name, sentinels, content, and the
clause the copy uses to disclose it. `applyInstructionBlocks` iterates it, and
`instructionsTouched()` / `instructionsDetail()` render the copy from it, so the
count and the list cannot be restated by hand and cannot drift. Retired blocks
live in their own `retiredInstructionBlocks` list: `Apply` sweeps them, and
because the copy is rendered from the *installed* list only, a retired block can
never be presented as a write. The cleanup is still disclosed, as a removal,
without naming a historical marker the user has no reason to care about.

Rendered copy today (captured by *executing* `Agent()` and printing the
fields, not transcribed from the format strings):

> **Touches** — Maintains 2 managed blocks (task-eta and task-question) in ~/.claude/CLAUDE.md
>
> **Detail** — Writes 2 irrlicht-managed blocks (each between BEGIN/END sentinels)
> to ~/.claude/CLAUDE.md, instructing the agent to emit hidden markers: task-eta —
> a task-progress marker, which irrlicht reads to project a completion ETA;
> task-question — a one-line version of the question it is waiting on, so a human
> can tell what a session is blocked on. All surrounding file content is preserved
> byte-for-byte, and a managed block an earlier irrlicht version wrote but this one
> no longer uses is removed on the same pass. Toggling off removes these blocks and
> any such retired block, and nothing else (also available via the macOS Settings
> toggle).
>
> **FeatureUnlocked** — Task-completion ETA chip + waiting-question headline from
> agent-reported markers

**Deliberately not in scope.** The issue's fix step 2 — an `Installs []string`
inventory on `agent.Permission` plus one contract over every `KindModify`
permission — is #1383's, and is not touched here. No field is added to
`agent.Permission`; nothing in `contracttesting` is generalized. The derivation
above is entirely claudecode-internal.

## Defect test, seen red first

`TestInstructionsDisclosure_MatchesInstalledBlocks`
(`core/adapters/inbound/agents/claudecode/instructiondisclosure_test.go`) runs the
real `Apply` effect against a temp `$HOME`, scans the `BEGIN` sentinels that
actually landed in the written `CLAUDE.md`, and asserts the declared copy names
every one of them, states the right count, and names none it does not write.
Ground truth is the file on disk, not the inventory the renderer reads — a test
comparing the copy to the variable it is rendered from would compare a
declaration to itself.

Run against the unfixed copy (test present, `agent.go` untouched):

```
$ go test ./core/adapters/inbound/agents/claudecode/ \
    -run TestInstructionsDisclosure_MatchesInstalledBlocks -race -count=1 -v

=== RUN   TestInstructionsDisclosure_MatchesInstalledBlocks/names_every_installed_block
    instructiondisclosure_test.go:114: consent copy never names the "task-eta" block, but Apply writes it to ~/.claude/CLAUDE.md — an undisclosed write to a user-authored file (#570)
    instructiondisclosure_test.go:114: consent copy never names the "task-question" block, but Apply writes it to ~/.claude/CLAUDE.md — an undisclosed write to a user-authored file (#570)
=== RUN   TestInstructionsDisclosure_MatchesInstalledBlocks/states_the_installed_count
    instructiondisclosure_test.go:123: consent copy states no block count; want "2 managed blocks"
=== RUN   TestInstructionsDisclosure_MatchesInstalledBlocks/names_no_uninstalled_block
    instructiondisclosure_test.go:153: consent copy names the "task-summary" block, but Apply does not write it — the disclosure promises something the install never does; install it or drop it from the copy
--- FAIL: TestInstructionsDisclosure_MatchesInstalledBlocks (0.00s)
FAIL	irrlicht/core/adapters/inbound/agents/claudecode	0.389s
```

All three arms red, one per half of the defect plus the count. Green after the fix.

The `[- ]` tolerance in `namePattern` is load-bearing rather than cosmetic: the
copy this replaces spelled the retired block "a one-line task **summary**", which
a strict hyphenated match would have read as absent — the over-promise arm would
have passed on the very text it exists to catch.

**Locks** (pass by construction, not red-first evidence): the pre-existing
`TestApplyInstructionBlocks_*`, `TestRemoveInstructionBlocks_RoundTripsToOriginal`
and `TestInstructionsPermission_GateContract` are unchanged and pin that looping
`Apply`/`Remove` over the two inventories still installs task-eta + task-question,
still sweeps a legacy task-summary block, still round-trips the file byte-for-byte,
and is still what the permission's gate dispatch drives.

## Verification

`tools/preflight.sh` unscoped — all 13 gates PASS (gofmt, core module tests,
onboarding-factory, replaydata validate, recording-rig smoke, replay fixtures,
starhistory, both web suites, ARS architecture gate, tools/lib, skill-file lint,
security scan).

## Review findings applied

A `medium`-effort review subagent returned five findings; all are applied.

1. **`Title` was the one hand-written string the test did not police.** It is
   wizard copy of the same class as `Touches`/`FeatureUnlocked`, and after this
   change it was the last unpoliced one. Setting `Title: "Install task-summary rule"`
   passed green before the fix. It is now in the over-promise arm — mutation-verified:
   with `Title` scanned, that same mutation fails with
   `consent copy names the "task-summary" block, but Apply does not write it`.
2. **`joinProse` was a verbatim copy of `hookjson.EventList`** in a package that
   already calls it on the adjacent permission. Deleted; the renderer calls
   `hookjson.EventList`.
3. **`irrlichd --uninstall-task-eta` never removed the `task-question` block.**
   Pre-existing, and the same drift class: `uninstallTaskEtaBlocks` carried its own
   hand-written pair (task-eta + task-summary), so a user running the CLI escape
   hatch was told `No irrlicht managed blocks found in ~/.claude/CLAUDE.md` while
   the block #759 installs stayed in their file with no way to remove it.
   `UninstallInstructionBlocks` now sweeps via the same two inventories `Apply`
   uses, and the CLI calls it.
4. **`Detail` understated revoke** — `Remove` sweeps retired blocks too, so
   "removes exactly these blocks" was wrong. Now "removes these blocks and any
   such retired block, and nothing else".
5. **Dead exported wrappers.** The refactor orphaned `UninstallTaskQuestionBlock`
   (zero callers) and left `EnsureTaskEtaBlockInstalled` / `EnsureTaskQuestionBlockInstalled`
   / `UninstallTaskEtaBlock` reachable only from tests. The orphans are gone; the
   test-only ones are unexported.

The reviewer independently verified the ordering change in `applyInstructionBlocks`
is a byte-level no-op (old call order vs new loops compared across 8 seeded
`CLAUDE.md` shapes) and that the new test fails under a second, independent
mutation (`Apply` writes a third, undisclosed block → red on both the naming and
the count arms).

## ⚠️ Overlaps PR #1411 (issue #1383) — three files

#1411 edits `claudecode/agent.go`, `claudecode/instructioninstaller.go` and
`cmd/irrlichd/main.go` too. Whichever lands second must reconcile:

- **Same function, deliberately same name.** #1411 adds
  `UninstallInstructionBlocks() (bool, error)` — the identical operation — and
  wires it as the `agent.ManagedUserFile.Uninstall` of a new `Writes:` field. This
  PR's sweep was renamed to exactly that name and signature so the second merge
  is a de-duplication, not a rename reconciliation. Keep this PR's
  inventory-driven body (#1411's loops over the three per-block wrappers).
- **#1411 calls `UninstallTaskEtaBlock`, `UninstallTaskSummaryBlock` and
  `UninstallTaskQuestionBlock`**, which this PR removes or unexports. Point its
  loop at `UninstallInstructionBlocks` instead — it is the same sweep.
- **Same `agent.go` literal.** #1411 adds `Writes:` to the `instructions`
  permission; this PR replaces its `Touches`/`Detail`/`FeatureUnlocked`. Disjoint
  fields, so both survive — but a textual auto-merge here is the dangerous
  outcome, not the conflicted one. Re-read the whole literal after merging.
- `main.go` conflicts are in different functions (#1411 renames
  `--print-hook-configs`; this PR rewrites `uninstallTaskEtaBlocks`).

No field was added to `agent.Permission` and nothing in `contracttesting` was
generalized by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Rebase onto current `main` + independent re-verification (2026-08-10)

This PR's original checks ran against a base **14 commits stale** — `hook_receipt.go`
(#1368) and `unknown_hook_event.go` (#1364) both postdated it, and #1412 / #1413 /
#1421 / #1422 landed in between. Rebased onto `dba52708` and re-verified from scratch;
none of the evidence below is carried over from the pre-rebase run.

**Rebase.** Clean, no conflicts. Three upstream commits touch files this branch edits,
so the auto-merge was re-read semantically rather than trusted:

- **#1422** → `claudecode/agent.go`: adds `Verify: VerifyHooksInstalled` to the **hooks**
  permission's `Hooks:` block (~line 96). This PR edits the **instructions** permission
  (~line 133). Disjoint fields in different literals; the merged `instructions` literal
  was re-read in full and is intact.
- **#1412 / #1413 / #1422** → `cmd/irrlichd/main.go`: different functions. The merged
  `uninstallTaskEtaBlocks` still calls this PR's `claudecode.UninstallInstructionBlocks()`.

**Deletion tripwire** (#1419 — concurrent agents share one `.git`): `git diff
--diff-filter=D --name-only` is **empty** both against the recorded pre-rebase base
`d82c6ff6` and against `origin/main`. Still exactly the same 5 files.

**Contract-family count.** `grep -c "^func Assert" core/internal/contracttesting/*.go`
→ **7** (`HookEndpointFollowsBindAddr`, `HookReceiptObserved`, `HookDisclosureMatchesInstalled`,
`UnknownHookEventObserved`, `HookVersionGate`, `HookPathConfined`, `PermissionGated`),
plus `userblocking.AssertMatchesCanonical` in the leaf sub-package. `AGENTS.md:241`
says "All seven contract families" — **consistent**. This PR adds no contract family,
so the sentence needs no edit. (Before the rebase the branch carried only 6, which is
the failure mode that sentence is prone to after a rebase.)

**Red-first, re-run on the rebased tree** — pre-fix copy restored into `agent.go`, the
defect test left in place:

```
=== RUN   TestInstructionsDisclosure_MatchesInstalledBlocks/names_every_installed_block
    instructiondisclosure_test.go:114: consent copy never names the "task-eta" block, but Apply writes it to ~/.claude/CLAUDE.md — an undisclosed write to a user-authored file (#570)
    instructiondisclosure_test.go:114: consent copy never names the "task-question" block, but Apply writes it to ~/.claude/CLAUDE.md — an undisclosed write to a user-authored file (#570)
=== RUN   TestInstructionsDisclosure_MatchesInstalledBlocks/states_the_installed_count
    instructiondisclosure_test.go:123: consent copy states no block count; want "2 managed blocks"
=== RUN   TestInstructionsDisclosure_MatchesInstalledBlocks/names_no_uninstalled_block
    instructiondisclosure_test.go:155: consent copy names the "task-summary" block, but Apply does not write it — the disclosure promises something the install never does; install it or drop it from the copy
--- FAIL: TestInstructionsDisclosure_MatchesInstalledBlocks (0.00s)
FAIL	irrlicht/core/adapters/inbound/agents/claudecode	0.337s
```

**Per-obligation mutations, re-run on the rebased tree.** Each reddens only the arm it
targets, which is what makes the arms independently load-bearing:

*Obligation — `Title` is policed by the over-promise arm* (`Title: "Install task-summary rule"`, nothing else changed):

```
    instructiondisclosure_test.go:155: consent copy names the "task-summary" block, but Apply does not write it — the disclosure promises something the install never does; install it or drop it from the copy
    --- PASS: TestInstructionsDisclosure_MatchesInstalledBlocks/names_every_installed_block
    --- PASS: TestInstructionsDisclosure_MatchesInstalledBlocks/states_the_installed_count
    --- FAIL: TestInstructionsDisclosure_MatchesInstalledBlocks/names_no_uninstalled_block
```

*Obligation — an install the copy does not name is caught* (`Apply` writes a third,
undisclosed block):

```
    instructiondisclosure_test.go:114: consent copy never names the "task-summary" block, but Apply writes it to ~/.claude/CLAUDE.md — an undisclosed write to a user-authored file (#570)
    instructiondisclosure_test.go:132: consent copy declares 2 managed blocks, Apply writes 3
    --- FAIL: TestInstructionsDisclosure_MatchesInstalledBlocks/names_every_installed_block
    --- FAIL: TestInstructionsDisclosure_MatchesInstalledBlocks/states_the_installed_count
    --- PASS: TestInstructionsDisclosure_MatchesInstalledBlocks/names_no_uninstalled_block
```

**Locks** (unchanged, pass by construction — not red-first evidence):
`TestApplyInstructionBlocks_*`, `TestRemoveInstructionBlocks_RoundTripsToOriginal`,
`TestInstructionsPermission_GateContract`.

**Corrected in this pass:** the "Rendered copy today" block above quoted `Detail` as
"Toggling off removes exactly these blocks" — the pre-review-finding-4 wording. The
executed output says "removes these blocks and any such retired block, and nothing
else". The body now quotes what the code actually renders, which for a #570 consent
contract is the whole point.

**Preflight**, run chunked in the foreground (#1382), all PASS: `go` (gofmt, core module
tests, onboarding-factory, replaydata validate, recording-rig smoke, replay fixtures,
starhistory), `web` (both suites), `arch` (ARS gate), `tools` (shell-lib), `skills`
(skill-file lint), `security` (govulncheck + gosec + npm audit).
