### PR TITLE
feat(hooks): irrlichd hook-post beacon that cannot fail a tool call

### DIFF
--- a/core/adapters/inbound/agents/beaconroute_test.go
+++ b/core/adapters/inbound/agents/beaconroute_test.go
@@ -20,9 +20,15 @@ import (
 // symptom at all on the agent's side.
 //
 // Note the segment is NOT AdapterName: claudecode.AdapterName is "claude-code"
-// while its route segment is "claudecode". That mismatch is exactly the kind of
-// thing this test exists to catch when a third receiver is added, so the map keys
-// below are written out literally rather than derived from the adapter constants.
+// while its route segment is "claudecode". That is why the map keys below are
+// written out literally rather than derived from the adapter constants.
+//
+// Scope, stated honestly: this pins the two receivers that exist. It cannot fail
+// for a THIRD receiver registered at a different prefix, because
+// registerHookRoutes (core/cmd/irrlichd/startup.go) is hand-wired with no
+// registry to enumerate and this map is hand-written. Whoever adds the third
+// receiver adds its row here; until then the convention is pinned, not
+// enforced.
 func TestBeaconEndpointPathMatchesTheInstalledReceivers(t *testing.T) {
 	for segment, want := range map[string]string{
 		"claudecode": claudecode.HookEndpointPath,

--- a/core/adapters/inbound/agents/beaconroute_test.go
+++ b/core/adapters/inbound/agents/beaconroute_test.go
@@ -1,0 +1,35 @@
+package agents
+
+import (
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/claudecode"
+	"irrlicht/core/adapters/inbound/agents/codex"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// TestBeaconEndpointPathMatchesTheInstalledReceivers pins the one convention the
+// beacon relies on and cannot see from inside core/pkg: that a hook receiver is
+// registered at /api/v1/hooks/<segment>, where <segment> is the argument an
+// adapter would pass to `irrlichd hook-post`.
+//
+// hookbeacon composes that route from a prefix rather than each adapter
+// exporting a second constant, so this test is what keeps the two from drifting.
+// Without it, a receiver registered somewhere else would leave the beacon POSTing
+// into a 404 — which, because the beacon exits 0 by design, is a failure with no
+// symptom at all on the agent's side.
+//
+// Note the segment is NOT AdapterName: claudecode.AdapterName is "claude-code"
+// while its route segment is "claudecode". That mismatch is exactly the kind of
+// thing this test exists to catch when a third receiver is added, so the map keys
+// below are written out literally rather than derived from the adapter constants.
+func TestBeaconEndpointPathMatchesTheInstalledReceivers(t *testing.T) {
+	for segment, want := range map[string]string{
+		"claudecode": claudecode.HookEndpointPath,
+		"codex":      codex.HookEndpointPath,
+	} {
+		if got := hookbeacon.EndpointPath(segment); got != want {
+			t.Errorf("hookbeacon.EndpointPath(%q) = %q, but the receiver is registered at %q — the beacon would post into a route nothing serves", segment, got, want)
+		}
+	}
+}

--- a/core/cmd/irrlichd/beaconexit_test.go
+++ b/core/cmd/irrlichd/beaconexit_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBeaconSubprocessAlwaysExitsZero runs the REAL binary and asserts the real
+// process exit status.
+//
+// This exists because every other test of the contract asserts hookbeacon.Post's
+// return value, and Post ends in a literal `return 0` — so those assertions
+// cannot fail by construction, however the code around them changes. The thing
+// the ticket actually promises is a property of the *process*: gemini-cli's
+// BeforeTool and Copilot's preToolUse read the exit status, not a Go return
+// value. Only a subprocess can observe a panic (exit 2), a mis-wired main(), an
+// init() that calls log.Fatal, or a dispatch that fell through to runDaemon.
+//
+// Every case runs with no daemon reachable, which is the situation the whole
+// mechanism exists for.
+func TestBeaconSubprocessAlwaysExitsZero(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "irrlichd")
+	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
+		t.Fatalf("build irrlichd: %v\n%s", err, out)
+	}
+
+	// A port nothing is listening on, so the subprocess can never reach a real
+	// daemon on this machine.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	deadAddr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		t.Fatalf("closing the reserved port: %v", err)
+	}
+
+	const payload = `{"hook_event_name":"BeforeTool","transcript_path":"/tmp/x.jsonl"}`
+
+	tests := map[string]struct {
+		args  []string
+		stdin string
+	}{
+		"the form we install, with no daemon running": {[]string{"--version", "hook-post", "gemini-cli"}, payload},
+		"the bare verb form":                          {[]string{"hook-post", "gemini-cli"}, payload},
+		"no stdin at all":                             {[]string{"hook-post", "gemini-cli"}, ""},
+		"malformed stdin":                             {[]string{"hook-post", "gemini-cli"}, "}{not json"},
+		"no adapter argument":                         {[]string{"hook-post"}, payload},
+		"an unsafe adapter argument":                  {[]string{"hook-post", "../../debug/bundle"}, payload},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := exec.Command(bin, tt.args...)
+			cmd.Stdin = strings.NewReader(tt.stdin)
+			cmd.Env = append(os.Environ(),
+				"IRRLICHT_HOME="+t.TempDir(),
+				"IRRLICHT_BIND_ADDR="+deadAddr,
+			)
+			var stdout, stderr strings.Builder
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			start := time.Now()
+			err := cmd.Run()
+			elapsed := time.Since(start)
+
+			if err != nil {
+				t.Errorf("exit status: %v (stderr: %s) — a non-zero exit from a pre-tool hook is decision \"deny\" on gemini-cli and Copilot, which breaks the user's tool call", err, stderr.String())
+			}
+			// Empty stdout is a hard requirement, not tidiness: gemini-cli and
+			// Claude Code parse a JSON decision from a hook's stdout. This also
+			// proves end-to-end that the leading --version guard did NOT reach
+			// the version branch on a current binary.
+			if stdout.Len() != 0 {
+				t.Errorf("stdout = %q, want empty — a hook's stdout is a decision channel", stdout.String())
+			}
+			if elapsed > 10*time.Second {
+				t.Errorf("took %s; the agent awaits this process", elapsed)
+			}
+		})
+	}
+}

--- a/core/cmd/irrlichd/beaconexit_test.go
+++ b/core/cmd/irrlichd/beaconexit_test.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -24,10 +23,7 @@ import (
 // Every case runs with no daemon reachable, which is the situation the whole
 // mechanism exists for.
 func TestBeaconSubprocessAlwaysExitsZero(t *testing.T) {
-	bin := filepath.Join(t.TempDir(), "irrlichd")
-	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
-		t.Fatalf("build irrlichd: %v\n%s", err, out)
-	}
+	bin := buildIrrlichd(t)
 
 	// A port nothing is listening on, so the subprocess can never reach a real
 	// daemon on this machine.

--- a/core/cmd/irrlichd/buildbin_test.go
+++ b/core/cmd/irrlichd/buildbin_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestMain owns the one irrlichd binary the subprocess tests share, so it is
+// removed after the run rather than leaked into the temp dir.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	sharedBin.remove()
+	os.Exit(code)
+}
+
+// daemonBinary is the lazily built irrlichd shared by every test that needs a
+// real process.
+type daemonBinary struct {
+	once sync.Once
+	dir  string
+	path string
+	err  error
+}
+
+var sharedBin daemonBinary
+
+func (b *daemonBinary) remove() {
+	if b.dir != "" {
+		_ = os.RemoveAll(b.dir)
+	}
+}
+
+// buildIrrlichd compiles the daemon once per test binary and returns its path.
+//
+// Built lazily rather than eagerly in TestMain so an unrelated `go test -run …`
+// does not pay for it, and shared rather than per-test because two tests need a
+// real binary — the startup smoke test and the beacon's process-level
+// exit-code test — and compiling the same unchanged package twice costs about
+// 0.8s of a suite that otherwise finishes in a fraction of a second.
+func buildIrrlichd(t *testing.T) string {
+	t.Helper()
+	sharedBin.once.Do(func() {
+		sharedBin.dir, sharedBin.err = os.MkdirTemp("", "irrlichd-build")
+		if sharedBin.err != nil {
+			return
+		}
+		sharedBin.path = filepath.Join(sharedBin.dir, "irrlichd")
+		if out, err := exec.Command("go", "build", "-o", sharedBin.path, ".").CombinedOutput(); err != nil {
+			sharedBin.err = fmt.Errorf("%w\n%s", err, out)
+		}
+	})
+	if sharedBin.err != nil {
+		t.Fatalf("build irrlichd: %v", sharedBin.err)
+	}
+	return sharedBin.path
+}

--- a/core/cmd/irrlichd/daemon_smoke_test.go
+++ b/core/cmd/irrlichd/daemon_smoke_test.go
@@ -40,10 +40,7 @@ import (
 func TestDaemonStartupSmoke(t *testing.T) {
 	// Build the daemon binary once for both boots. Done lazily here (not in
 	// TestMain) so unrelated `go test -run …` invocations don't pay the cost.
-	bin := filepath.Join(t.TempDir(), "irrlichd")
-	if out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput(); err != nil {
-		t.Fatalf("build irrlichd: %v\n%s", err, out)
-	}
+	bin := buildIrrlichd(t)
 
 	t.Run("demo", func(t *testing.T) {
 		d := bootSmokeDaemon(t, bin, "IRRLICHT_DEMO_MODE=1")

--- a/core/cmd/irrlichd/dispatch_test.go
+++ b/core/cmd/irrlichd/dispatch_test.go
@@ -1,0 +1,88 @@
+package main
+
+import "testing"
+
+// TestSelectActionOrder pins irrlichd's argv dispatch, which until #1373 was an
+// unparsed chain of exact-match flag scans falling through to runDaemon().
+//
+// Two rows carry the weight, and both fail silently rather than loudly:
+//
+//   - "the beacon wins over its own guard token". Every installed beacon command
+//     line ends in --version, so that an irrlichd predating this subcommand
+//     no-ops instead of starting a daemon (hookbeacon.LegacyGuardToken). If the
+//     version check were ever moved back in front, every installed beacon would
+//     become a version banner: exit 0, nothing delivered, no error anywhere, and
+//     session state would simply stop arriving.
+//   - "an unknown flag still starts the daemon". That is the behaviour every
+//     irrlichd has had, and the #1373 change deliberately narrows the new
+//     rejection to POSITIONAL tokens so it cannot break an existing invocation.
+//     It is a LOCK: it passes on main by construction and exists so a later
+//     tightening of the parser has to be a deliberate decision.
+func TestSelectActionOrder(t *testing.T) {
+	tests := map[string]struct {
+		args []string
+		want cliAction
+	}{
+		"no arguments starts the daemon":            {nil, actionRunDaemon},
+		"--record starts the daemon":                {[]string{"--record"}, actionRunDaemon},
+		"an unknown flag still starts the daemon":   {[]string{"--not-a-real-flag"}, actionRunDaemon},
+		"--version prints the version":              {[]string{"--version"}, actionVersion},
+		"-v prints the version":                     {[]string{"-v"}, actionVersion},
+		"--uninstall-hooks":                         {[]string{"--uninstall-hooks"}, actionUninstallHooks},
+		"--print-hook-configs":                      {[]string{"--print-hook-configs"}, actionPrintHookConfigs},
+		"--uninstall-task-eta":                      {[]string{"--uninstall-task-eta"}, actionUninstallTaskEta},
+		"--diagnose":                                {[]string{"--diagnose"}, actionDiagnose},
+		"the beacon verb":                           {[]string{"hook-post", "gemini-cli"}, actionBeacon},
+		"the beacon wins over its own guard token":  {[]string{"hook-post", "gemini-cli", "--version"}, actionBeacon},
+		"the beacon verb with no adapter":           {[]string{"hook-post"}, actionBeacon},
+		"the beacon verb with a shell redirect":     {[]string{"hook-post", "gemini-cli", "--version", ">/dev/null"}, actionBeacon},
+		"a positional that is not a subcommand":     {[]string{"start"}, actionUnknownSubcommand},
+		"the beacon verb in a non-leading position": {[]string{"--record", "hook-post"}, actionUnknownSubcommand},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := selectAction(tt.args); got != tt.want {
+				t.Errorf("selectAction(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUnknownSubcommandNeverReachesTheDaemon states the hazard positively: a
+// beacon-shaped invocation on a future irrlichd that renamed the verb must not
+// start a daemon. A stray start is not merely wasteful — setupUnixSocket removes
+// the socket file before listening, so it breaks the live daemon's socket on its
+// way to failing to bind the port.
+func TestUnknownSubcommandNeverReachesTheDaemon(t *testing.T) {
+	for _, args := range [][]string{
+		{"hook-post-v2", "gemini-cli"},
+		{"post-hook", "codex", "--version"},
+		{"gemini-cli"},
+	} {
+		if got := selectAction(args); got == actionRunDaemon {
+			t.Errorf("selectAction(%q) = actionRunDaemon; an unrecognized subcommand must never start a daemon", args)
+		}
+	}
+}
+
+func TestFirstPositional(t *testing.T) {
+	tests := map[string]struct {
+		args []string
+		want string
+		ok   bool
+	}{
+		"only flags":            {[]string{"--record", "-v"}, "", false},
+		"a positional":          {[]string{"--record", "start"}, "start", true},
+		"empty strings skipped": {[]string{"", "start"}, "start", true},
+		"nothing":               {nil, "", false},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, ok := firstPositional(tt.args)
+			if got != tt.want || ok != tt.ok {
+				t.Errorf("firstPositional(%q) = %q, %v; want %q, %v", tt.args, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/core/cmd/irrlichd/dispatch_test.go
+++ b/core/cmd/irrlichd/dispatch_test.go
@@ -7,12 +7,14 @@ import "testing"
 //
 // Two rows carry the weight, and both fail silently rather than loudly:
 //
-//   - "the beacon wins over its own guard token". Every installed beacon command
-//     line ends in --version, so that an irrlichd predating this subcommand
-//     no-ops instead of starting a daemon (hookbeacon.LegacyGuardToken). If the
-//     version check were ever moved back in front, every installed beacon would
-//     become a version banner: exit 0, nothing delivered, no error anywhere, and
-//     session state would simply stop arriving.
+//   - "the guarded form we install". Every installed beacon command line LEADS
+//     with --version, so that an irrlichd predating this subcommand no-ops
+//     instead of starting a daemon — and leads rather than trails because
+//     releases up to v0.3.2 only ever matched os.Args[1]
+//     (hookbeacon.LegacyGuardToken records the git evidence). If the version
+//     check were ever moved back in front of the verb, every installed beacon
+//     would become a version banner: exit 0, nothing delivered, no error
+//     anywhere, and session state would simply stop arriving.
 //   - "an unknown flag still starts the daemon". That is the behaviour every
 //     irrlichd has had, and the #1373 change deliberately narrows the new
 //     rejection to POSITIONAL tokens so it cannot break an existing invocation.
@@ -33,9 +35,11 @@ func TestSelectActionOrder(t *testing.T) {
 		"--uninstall-task-eta":                      {[]string{"--uninstall-task-eta"}, actionUninstallTaskEta},
 		"--diagnose":                                {[]string{"--diagnose"}, actionDiagnose},
 		"the beacon verb":                           {[]string{"hook-post", "gemini-cli"}, actionBeacon},
-		"the beacon wins over its own guard token":  {[]string{"hook-post", "gemini-cli", "--version"}, actionBeacon},
+		"the guarded form we install":               {[]string{"--version", "hook-post", "gemini-cli"}, actionBeacon},
+		"the guarded form beats the version branch": {[]string{"--version", "hook-post", "gemini-cli", ">/dev/null"}, actionBeacon},
+		"a trailing guard token is still the verb":  {[]string{"hook-post", "gemini-cli", "--version"}, actionBeacon},
 		"the beacon verb with no adapter":           {[]string{"hook-post"}, actionBeacon},
-		"the beacon verb with a shell redirect":     {[]string{"hook-post", "gemini-cli", "--version", ">/dev/null"}, actionBeacon},
+		"the beacon verb with a shell redirect":     {[]string{"hook-post", "gemini-cli", ">/dev/null"}, actionBeacon},
 		"a positional that is not a subcommand":     {[]string{"start"}, actionUnknownSubcommand},
 		"the beacon verb in a non-leading position": {[]string{"--record", "hook-post"}, actionUnknownSubcommand},
 	}

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -138,44 +138,50 @@ func firstPositional(args []string) (string, bool) {
 }
 
 func main() {
-	switch selectAction(os.Args[1:]) {
+	args := os.Args[1:]
+	if action := selectAction(args); action != actionRunDaemon {
+		os.Exit(runCLIAction(action, args))
+	}
+	runDaemon()
+}
+
+// runCLIAction performs every action other than starting the daemon and returns
+// the process exit code, so main() stays a two-line dispatch and the actions
+// themselves are one flat switch.
+func runCLIAction(action cliAction, args []string) int {
+	switch action {
 	case actionBeacon:
 		// Post always returns 0 — that contract is the whole of #1373; see the
 		// hookbeacon package doc for what a non-zero exit does to a tool call.
-		os.Exit(hookbeacon.Post(hookbeacon.Options{
-			Args:   hookbeacon.InvocationArgs(os.Args[1:]),
+		return hookbeacon.Post(hookbeacon.Options{
+			Args:   hookbeacon.InvocationArgs(args),
 			Stdin:  os.Stdin,
 			Stderr: os.Stderr,
-		}))
+		})
 	case actionVersion:
 		fmt.Printf("irrlichd version %s\n", Version)
 		fmt.Printf("Built with %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
-		os.Exit(0)
 	case actionUninstallHooks:
 		uninstallHooks()
-		os.Exit(0)
 	case actionPrintHookConfigs:
 		if err := printHookConfigs(os.Stdout); err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return 1
 		}
-		os.Exit(0)
 	case actionUninstallTaskEta:
 		uninstallTaskEtaBlocks()
-		os.Exit(0)
 	case actionDiagnose:
 		runDiagnose()
-		os.Exit(0)
 	case actionUnknownSubcommand:
 		// stderr, never stdout, and the message is the only output: if this is
 		// ever reached by a hook-shaped invocation on a future binary that
 		// renamed the verb, an empty stdout is what keeps a non-zero exit from
 		// reading as a "deny" decision to a fail-closed pre-tool hook.
-		name, _ := firstPositional(os.Args[1:])
+		name, _ := firstPositional(args)
 		fmt.Fprintf(os.Stderr, "irrlichd: unknown subcommand %q\n", name)
-		os.Exit(2)
+		return 2
 	}
-	runDaemon()
+	return 0
 }
 
 // uninstallHooks removes irrlicht's hooks from every agent config file the

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"irrlicht/core/domain/permission"
 	"irrlicht/core/pkg/capacity"
 	"irrlicht/core/pkg/daemonaddr"
+	"irrlicht/core/pkg/hookbeacon"
 	"irrlicht/core/ports/outbound"
 )
 
@@ -57,7 +59,13 @@ func (l lazyControl) Interrupt(id string) error {
 const envUIDir = "IRRLICHT_UI_DIR"
 
 func hasFlag(name string) bool {
-	for _, arg := range os.Args[1:] {
+	return hasFlagIn(os.Args[1:], name)
+}
+
+// hasFlagIn is hasFlag over an explicit argument list, so selectAction is a pure
+// function of argv and its ORDER can be tested without building a binary.
+func hasFlagIn(args []string, name string) bool {
+	for _, arg := range args {
 		if arg == name {
 			return true
 		}
@@ -65,30 +73,106 @@ func hasFlag(name string) bool {
 	return false
 }
 
+// cliAction is what one irrlichd command line selects.
+type cliAction int
+
+const (
+	actionBeacon cliAction = iota
+	actionVersion
+	actionUninstallHooks
+	actionPrintHookConfigs
+	actionUninstallTaskEta
+	actionDiagnose
+	actionUnknownSubcommand
+	actionRunDaemon
+)
+
+// selectAction resolves a command line to the one thing irrlichd will do.
+//
+// The order is part of the contract, not an implementation detail, and two
+// positions in it are load-bearing:
+//
+//   - The beacon is FIRST, ahead of --version. Every installed beacon command
+//     line ends in --version as a guard against an older irrlichd starting a
+//     daemon instead of posting a hook (see hookbeacon.LegacyGuardToken). Moving
+//     the version check back in front would turn every installed beacon into a
+//     version banner — silently, since the beacon is not supposed to say
+//     anything on a healthy path either.
+//   - actionUnknownSubcommand is LAST, and it only fires on a positional token.
+//     Unknown FLAGS still fall through to the daemon, which is the behaviour
+//     every irrlichd has had; narrowing the change to positionals keeps it from
+//     touching any existing invocation while still closing the fall-through that
+//     makes a beacon-shaped command line start a daemon on a future binary that
+//     renames the verb.
+func selectAction(args []string) cliAction {
+	switch {
+	case hookbeacon.IsInvocation(args):
+		return actionBeacon
+	case hasFlagIn(args, "--version"), hasFlagIn(args, "-v"):
+		return actionVersion
+	case hasFlagIn(args, "--uninstall-hooks"):
+		return actionUninstallHooks
+	case hasFlagIn(args, "--print-hook-configs"):
+		return actionPrintHookConfigs
+	case hasFlagIn(args, "--uninstall-task-eta"):
+		return actionUninstallTaskEta
+	case hasFlagIn(args, "--diagnose"):
+		return actionDiagnose
+	}
+	if _, ok := firstPositional(args); ok {
+		return actionUnknownSubcommand
+	}
+	return actionRunDaemon
+}
+
+// firstPositional returns the first argument that is not flag-shaped.
+func firstPositional(args []string) (string, bool) {
+	for _, arg := range args {
+		if arg == "" || strings.HasPrefix(arg, "-") {
+			continue
+		}
+		return arg, true
+	}
+	return "", false
+}
+
 func main() {
-	if hasFlag("--version") || hasFlag("-v") {
+	switch selectAction(os.Args[1:]) {
+	case actionBeacon:
+		// Post always returns 0 — that contract is the whole of #1373; see the
+		// hookbeacon package doc for what a non-zero exit does to a tool call.
+		os.Exit(hookbeacon.Post(hookbeacon.Options{
+			Args:   os.Args[2:],
+			Stdin:  os.Stdin,
+			Stderr: os.Stderr,
+		}))
+	case actionVersion:
 		fmt.Printf("irrlichd version %s\n", Version)
 		fmt.Printf("Built with %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		os.Exit(0)
-	}
-	if hasFlag("--uninstall-hooks") {
+	case actionUninstallHooks:
 		uninstallHooks()
 		os.Exit(0)
-	}
-	if hasFlag("--print-hook-configs") {
+	case actionPrintHookConfigs:
 		if err := printHookConfigs(os.Stdout); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		os.Exit(0)
-	}
-	if hasFlag("--uninstall-task-eta") {
+	case actionUninstallTaskEta:
 		uninstallTaskEtaBlocks()
 		os.Exit(0)
-	}
-	if hasFlag("--diagnose") {
+	case actionDiagnose:
 		runDiagnose()
 		os.Exit(0)
+	case actionUnknownSubcommand:
+		// stderr, never stdout, and the message is the only output: if this is
+		// ever reached by a hook-shaped invocation on a future binary that
+		// renamed the verb, an empty stdout is what keeps a non-zero exit from
+		// reading as a "deny" decision to a fail-closed pre-tool hook.
+		name, _ := firstPositional(os.Args[1:])
+		fmt.Fprintf(os.Stderr, "irrlichd: unknown subcommand %q\n", name)
+		os.Exit(2)
 	}
 	runDaemon()
 }

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -93,11 +93,12 @@ const (
 // positions in it are load-bearing:
 //
 //   - The beacon is FIRST, ahead of --version. Every installed beacon command
-//     line ends in --version as a guard against an older irrlichd starting a
-//     daemon instead of posting a hook (see hookbeacon.LegacyGuardToken). Moving
-//     the version check back in front would turn every installed beacon into a
-//     version banner — silently, since the beacon is not supposed to say
-//     anything on a healthy path either.
+//     line LEADS with --version as a guard against an older irrlichd starting a
+//     daemon instead of posting a hook (see hookbeacon.LegacyGuardToken, which
+//     records why the guard has to lead rather than trail). Moving the version
+//     check back in front would turn every installed beacon into a version
+//     banner — silently, since the beacon is not supposed to say anything on a
+//     healthy path either.
 //   - actionUnknownSubcommand is LAST, and it only fires on a positional token.
 //     Unknown FLAGS still fall through to the daemon, which is the behaviour
 //     every irrlichd has had; narrowing the change to positionals keeps it from
@@ -142,7 +143,7 @@ func main() {
 		// Post always returns 0 — that contract is the whole of #1373; see the
 		// hookbeacon package doc for what a non-zero exit does to a tool call.
 		os.Exit(hookbeacon.Post(hookbeacon.Options{
-			Args:   os.Args[2:],
+			Args:   hookbeacon.InvocationArgs(os.Args[1:]),
 			Stdin:  os.Stdin,
 			Stderr: os.Stderr,
 		}))

--- a/core/pkg/hookbeacon/beacon.go
+++ b/core/pkg/hookbeacon/beacon.go
@@ -1,0 +1,389 @@
+// Package hookbeacon implements `irrlichd hook-post <adapter>` — the hook
+// delivery mechanism for agent CLIs that can run a command but cannot POST to a
+// URL themselves.
+//
+// Claude Code installs `type: "http"` entries and the daemon receives them
+// directly; that is the shape #1161 moved to precisely so delivery stops
+// depending on `curl` being on the agent's PATH. Codex has no HTTP hook type, so
+// it still shells out to `curl`. gemini-cli's HookType is {Command, Runtime} and
+// Runtime is a Go-style function pointer that is not expressible in JSON, so it
+// cannot use HTTP either. This subcommand is what those adapters install instead
+// of a `curl` line: a binary irrlicht ships, invoked by absolute path.
+//
+// # Why exit code 0 is the entire point
+//
+// The hooks that matter fire BEFORE a tool call and they fail CLOSED. The Phase C
+// audit for #1355 live-verified that gemini-cli's BeforeTool and BeforeAgent
+// hooks turn an exit code >= 2 with text on stdout into decision "deny", after
+// which the scheduler kills the tool with ToolErrorType.POLICY_VIOLATION;
+// Copilot's preToolUse has denied on hook error since 1.0.57. A `curl` against a
+// daemon that is not running exits 7.
+//
+// So the naive command does not merely fail to report session state — it breaks
+// the user's tool calls whenever irrlicht is not running, which is strictly worse
+// than installing no monitoring at all. Post therefore returns 0 on every path,
+// by construction rather than by care: daemon down, connection refused, deadline
+// exceeded, malformed stdin, no stdin at all, an adapter argument that is not a
+// safe path segment, a daemon that answers 500. Every one of those is a row in
+// the matrix in beacon_test.go, because "it exits 0" is a claim about the paths
+// nobody exercises, and inspection is not evidence for those.
+//
+// # Why Options has no Stdout
+//
+// A hook's stdout is a control channel: gemini-cli parses a JSON decision from
+// it, and Claude Code reads a JSON decision from it too. The beacon must never
+// write there, and the way to guarantee that is to not hold the handle — the
+// same structural argument hookjson.IgnoreUnknownEvent makes for not taking an
+// http.ResponseWriter. Diagnostics go to stderr, which no CLI reads as a verdict.
+//
+// # Why the daemon address is resolved here and not at install time
+//
+// deliver calls daemonaddr.ClientURL in the beacon process, on the tool call that
+// fired it. An installed entry therefore carries no port at all, which makes the
+// whole #1178 stale-port class impossible rather than fixing it once more: there
+// is no port in the config that can go stale, so a dev daemon on :7838, a
+// restarted daemon on an ephemeral port and a production daemon on :7837 are all
+// reached by the same never-rewritten entry. ClientURL, not LocalURL — the beacon
+// is a separate short-lived process spawned by the agent CLI and inherits none of
+// the daemon's environment, so it must be allowed to read the address file the
+// running daemon published.
+package hookbeacon
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"irrlicht/core/pkg/daemonaddr"
+)
+
+// Subcommand is the argv verb that selects the beacon. It is a positional token
+// rather than a flag so that irrlichd's dispatch can key on os.Args[1] exactly,
+// instead of scanning the whole command line the way hasFlag does — see
+// LegacyGuardToken for why that precision is load-bearing.
+const Subcommand = "hook-post"
+
+// endpointPrefix is the route prefix every hook receiver is registered under.
+// EndpointPath composes it with the adapter segment rather than each adapter
+// exporting a second constant; TestEndpointPathMatchesInstalledReceivers pins it
+// against the two receivers that exist so the convention cannot drift silently.
+const endpointPrefix = "/api/v1/hooks/"
+
+// DefaultTimeout bounds everything the beacon does — reading stdin, dialing,
+// writing the body, reading the response.
+//
+// One second, because every gemini-cli fire site awaits the hook and the config
+// default timeout is 60s: a wedged receiver would stall the user's prompt for a
+// full minute. The Phase C audit measured a hook sleeping 5s delaying the
+// approval dialog by 5.24s, i.e. the cost is paid in full and in the foreground.
+// The daemon is on loopback, so a second is several orders of magnitude more than
+// a healthy POST needs and still imperceptible when it is spent in full.
+//
+// Note for whoever installs this: gemini-cli's config `timeout` is in
+// MILLISECONDS, not seconds. Upstream's own `hooks migrate` command gets this
+// wrong by 1000x, so a value copied from a Claude Code config reads as 5ms rather
+// than 5s and the hook is killed before it can connect.
+const DefaultTimeout = time.Second
+
+// maxPayloadBytes caps what the beacon will read from stdin. An over-cap body is
+// dropped whole rather than truncated: a truncated JSON object is a body the
+// daemon must reject anyway, and sending it would spend the deadline to produce a
+// 400 instead of a counted, named local refusal.
+const maxPayloadBytes = 1 << 20
+
+// Reason names why a delivery did not happen. It never changes the exit code —
+// Post returns 0 for all of these — so it exists to make a refusal observable
+// rather than to influence the caller, which is the same trade hookjson's
+// RejectReason makes.
+type Reason string
+
+const (
+	// ReasonNone is the zero value: the payload was delivered and the daemon
+	// answered 2xx.
+	ReasonNone Reason = ""
+
+	// ReasonMissingAdapter is an invocation with no adapter segment at all.
+	ReasonMissingAdapter Reason = "missing_adapter"
+
+	// ReasonInvalidAdapter is an adapter segment that is not a safe single
+	// path element — it would otherwise be pasted into a URL path.
+	ReasonInvalidAdapter Reason = "invalid_adapter"
+
+	// ReasonUnreadableStdin is a read error on stdin. A partial read counts
+	// here too: half a JSON object is not worth a POST.
+	ReasonUnreadableStdin Reason = "unreadable_stdin"
+
+	// ReasonEmptyPayload is stdin closed with nothing (or only whitespace) on
+	// it, including the case where the CLI attached no stdin at all.
+	ReasonEmptyPayload Reason = "empty_payload"
+
+	// ReasonPayloadTooLarge is a body over maxPayloadBytes.
+	ReasonPayloadTooLarge Reason = "payload_too_large"
+
+	// ReasonDaemonUnreachable is any transport failure: connection refused
+	// because no daemon is running, a dead unix path, DNS, a reset.
+	ReasonDaemonUnreachable Reason = "daemon_unreachable"
+
+	// ReasonDeadlineExceeded is the beacon's own deadline firing, whether the
+	// stall was stdin or the receiver.
+	ReasonDeadlineExceeded Reason = "deadline_exceeded"
+
+	// ReasonDaemonRejected is a non-2xx response. The daemon is up and heard
+	// us, so this is a bug on one side or the other rather than an outage —
+	// which is why it is counted apart from ReasonDaemonUnreachable.
+	ReasonDaemonRejected Reason = "daemon_rejected"
+)
+
+// reasons is every reason in a fixed order, so each has a stable counter slot.
+// ReasonNone is deliberately absent — it is not a refusal.
+var reasons = [...]Reason{
+	ReasonMissingAdapter, ReasonInvalidAdapter, ReasonUnreadableStdin,
+	ReasonEmptyPayload, ReasonPayloadTooLarge, ReasonDaemonUnreachable,
+	ReasonDeadlineExceeded, ReasonDaemonRejected,
+}
+
+// counts holds one counter per reason, indexed by the reasons order — the same
+// fixed array of atomics hookjson.PathConfiner and hookjson's splicer fallbacks
+// use, for the same reason: instrumentation that serializes exactly when
+// refusals arrive together would blunt what it measures.
+//
+// Package scope rather than per-instance because a beacon process delivers
+// exactly once. In that process the counters are barely more than a test seam;
+// they earn their place because Post is also callable in-process, and because a
+// refusal that is only ever written to a stderr the agent may discard is
+// indistinguishable from no refusal.
+var counts [len(reasons)]atomic.Uint64
+
+// adapterSegment is the accepted shape of the adapter argument: a lowercase DNS
+// -style label. It admits every adapter id in the registry (claudecode, codex,
+// gemini-cli, copilot, aider) and admits nothing that changes the meaning of the
+// URL path it is pasted into — no "/", no "..", no "%", no empty string, no
+// control characters, no whitespace.
+var adapterSegment = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$`)
+
+// EndpointPath returns the daemon route a given adapter's hook payloads are
+// POSTed to.
+func EndpointPath(adapter string) string { return endpointPrefix + adapter }
+
+// IsInvocation reports whether args (os.Args[1:]) selects the beacon.
+//
+// It keys on the FIRST token only. irrlichd's own flag dispatch is a permissive
+// whole-command-line scan (hasFlag), and inheriting that here would make any
+// daemon invocation that happened to contain the word "hook-post" deliver a hook
+// instead of starting — the beacon has to be more precise than the chain it is
+// spliced into, not equally loose.
+func IsInvocation(args []string) bool {
+	return len(args) > 0 && args[0] == Subcommand
+}
+
+// Options is one beacon invocation.
+type Options struct {
+	// Args is the argument list AFTER the subcommand verb.
+	Args []string
+
+	// Stdin carries the hook payload. A nil Stdin is a refusal, not a panic:
+	// an agent CLI is free to invoke a hook with no stdin attached.
+	Stdin io.Reader
+
+	// Stderr receives one diagnostic line per refusal. A nil Stderr silences
+	// it — the counter still moves.
+	Stderr io.Writer
+
+	// Timeout overrides DefaultTimeout. Zero or negative means the default.
+	Timeout time.Duration
+}
+
+// Post delivers one hook payload and returns the process exit code.
+//
+// It ALWAYS returns 0. That is not a description of the current implementation,
+// it is the contract this package exists to hold — see the package doc for what
+// a non-zero exit does to a gemini-cli tool call — and it is why this function
+// returns an int at all rather than nothing: an exit code that is a value can be
+// asserted, and beacon_test.go asserts it once per failure mode.
+//
+// Post is the ONE place the exit code and the reporting of a refusal are decided,
+// so deliver can return a plain Reason and no code path anywhere else in the
+// package has to remember the rule. That is the shape hookjson.RejectPath uses
+// for the receiver side of the same problem.
+func Post(opts Options) int {
+	reason, detail := deliver(opts)
+	if reason != ReasonNone {
+		count(reason)
+		report(opts.Stderr, reason, detail)
+	}
+	return 0
+}
+
+// deliver performs the delivery and returns why it did not happen, plus a short
+// human detail for the stderr line. It never decides an exit code.
+func deliver(opts Options) (Reason, string) {
+	adapter, reason := adapterFrom(opts.Args)
+	if reason != ReasonNone {
+		return reason, strings.Join(opts.Args, " ")
+	}
+
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	// One deadline over the whole operation, taken before stdin is touched.
+	// Bounding only the HTTP call would leave the worst stall unbounded: a CLI
+	// that opens the pipe and neither writes nor closes it blocks io.ReadAll
+	// forever, and the agent is awaiting this process.
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	body, reason, detail := readPayload(ctx, opts.Stdin)
+	if reason != ReasonNone {
+		return reason, detail
+	}
+
+	return send(ctx, daemonaddr.ClientURL(EndpointPath(adapter)), body)
+}
+
+// adapterFrom takes the adapter segment out of the post-verb arguments.
+//
+// It skips any token beginning with "-", which is what makes LegacyGuardToken
+// inert on a current binary: the installed command line ends in --version, and
+// the beacon has to read straight past it. Skipping rather than rejecting also
+// means a future flag can be added to the command line without every previously
+// installed entry becoming invalid.
+func adapterFrom(args []string) (string, Reason) {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		if !adapterSegment.MatchString(arg) {
+			return "", ReasonInvalidAdapter
+		}
+		return arg, ReasonNone
+	}
+	return "", ReasonMissingAdapter
+}
+
+// readPayload reads the whole hook body, bounded by both ctx and
+// maxPayloadBytes.
+//
+// The read happens on its own goroutine so that a stdin that never closes loses
+// the race against ctx instead of hanging the process. The goroutine is
+// deliberately left running on the timeout path: this is a one-shot process
+// about to exit, and the alternative — waiting for a reader that by definition
+// is not going to return — is the stall being avoided.
+func readPayload(ctx context.Context, stdin io.Reader) ([]byte, Reason, string) {
+	if stdin == nil {
+		return nil, ReasonEmptyPayload, "no stdin attached"
+	}
+
+	type result struct {
+		body []byte
+		err  error
+	}
+	// Buffered so the goroutine can always finish even after ctx has won.
+	done := make(chan result, 1)
+	go func() {
+		// One byte over the cap, so an over-cap body is DETECTED here rather
+		// than silently truncated into a body the daemon would have to reject.
+		body, err := io.ReadAll(io.LimitReader(stdin, maxPayloadBytes+1))
+		done <- result{body: body, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ReasonDeadlineExceeded, "reading stdin"
+	case res := <-done:
+		switch {
+		case res.err != nil:
+			return nil, ReasonUnreadableStdin, res.err.Error()
+		case len(res.body) > maxPayloadBytes:
+			return nil, ReasonPayloadTooLarge, fmt.Sprintf("%d bytes exceeds the %d byte cap", len(res.body), maxPayloadBytes)
+		case len(bytes.TrimSpace(res.body)) == 0:
+			return nil, ReasonEmptyPayload, "stdin was empty"
+		}
+		return res.body, ReasonNone, ""
+	}
+}
+
+// send POSTs the body verbatim.
+//
+// Verbatim matters: the beacon does not decode, validate or re-encode the
+// payload. The adapter id is stamped by the URL path, so there is nothing to add
+// to the body, and re-serializing a JSON document is how fields the daemon has
+// not been taught about yet get dropped in transit (#1371). A body that is not
+// JSON at all is the daemon's 400 to make, and that 400 is still exit 0 here.
+func send(ctx context.Context, url string, body []byte) (Reason, string) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return ReasonDaemonUnreachable, err.Error()
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return ReasonDeadlineExceeded, err.Error()
+		}
+		return ReasonDaemonUnreachable, err.Error()
+	}
+	defer func() {
+		// Drained and closed so the connection can be reused... by nobody, this
+		// process is exiting. It is here so a receiver that streams a response
+		// does not see a client that vanished mid-write.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxPayloadBytes))
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return ReasonDaemonRejected, fmt.Sprintf("daemon answered %d", resp.StatusCode)
+	}
+	return ReasonNone, ""
+}
+
+// report writes the single stderr line a refusal gets. Never stdout — see the
+// package doc.
+func report(stderr io.Writer, reason Reason, detail string) {
+	if stderr == nil {
+		return
+	}
+	if detail == "" {
+		fmt.Fprintf(stderr, "irrlichd %s: not delivered (%s)\n", Subcommand, reason)
+		return
+	}
+	fmt.Fprintf(stderr, "irrlichd %s: not delivered (%s): %s\n", Subcommand, reason, detail)
+}
+
+// count records a refusal.
+func count(reason Reason) {
+	for i, known := range reasons {
+		if known == reason {
+			counts[i].Add(1)
+			return
+		}
+	}
+}
+
+// Reasons returns a snapshot of the per-reason refusal counts, omitting zeros.
+// The map is a copy; mutating it does not touch the counters.
+func Reasons() map[Reason]uint64 {
+	out := make(map[Reason]uint64, len(reasons))
+	for i, reason := range reasons {
+		if n := counts[i].Load(); n > 0 {
+			out[reason] = n
+		}
+	}
+	return out
+}
+
+// ReasonCount returns the total number of undelivered payloads.
+func ReasonCount() uint64 {
+	var total uint64
+	for i := range counts {
+		total += counts[i].Load()
+	}
+	return total
+}

--- a/core/pkg/hookbeacon/beacon.go
+++ b/core/pkg/hookbeacon/beacon.go
@@ -188,26 +188,29 @@ func EndpointPath(adapter string) string { return endpointPrefix + adapter }
 // deliver a hook instead of starting — the beacon has to be more precise than
 // the chain it is spliced into, not equally loose.
 func IsInvocation(args []string) bool {
-	switch {
-	case len(args) > 0 && args[0] == Subcommand:
-		return true
-	case len(args) > 1 && args[0] == LegacyGuardToken && args[1] == Subcommand:
-		return true
-	}
-	return false
+	_, ok := verbArgs(args)
+	return ok
 }
 
 // InvocationArgs returns the arguments after the verb, for whichever accepted
-// form was used. Pairing it with IsInvocation keeps the two spellings of "where
-// does the verb sit" in one place instead of at the call site in main().
+// form was used.
 func InvocationArgs(args []string) []string {
+	rest, _ := verbArgs(args)
+	return rest
+}
+
+// verbArgs is the single place the accepted verb positions are spelled out, so
+// IsInvocation and InvocationArgs cannot drift into disagreeing about what
+// counts as a beacon invocation — selectAction asks the first and main() asks
+// the second, about the same command line.
+func verbArgs(args []string) ([]string, bool) {
 	if len(args) > 1 && args[0] == LegacyGuardToken && args[1] == Subcommand {
-		return args[2:]
+		return args[2:], true
 	}
 	if len(args) > 0 && args[0] == Subcommand {
-		return args[1:]
+		return args[1:], true
 	}
-	return nil
+	return nil, false
 }
 
 // Options is one beacon invocation.

--- a/core/pkg/hookbeacon/beacon.go
+++ b/core/pkg/hookbeacon/beacon.go
@@ -134,6 +134,10 @@ const (
 	// stall was stdin or the receiver.
 	ReasonDeadlineExceeded Reason = "deadline_exceeded"
 
+	// ReasonPanicked is a panic recovered inside Post. It should never be
+	// seen; it is counted so that if it ever is, it is not silent.
+	ReasonPanicked Reason = "panicked"
+
 	// ReasonDaemonRejected is a non-2xx response. The daemon is up and heard
 	// us, so this is a bug on one side or the other rather than an outage —
 	// which is why it is counted apart from ReasonDaemonUnreachable.
@@ -145,7 +149,7 @@ const (
 var reasons = [...]Reason{
 	ReasonMissingAdapter, ReasonInvalidAdapter, ReasonUnreadableStdin,
 	ReasonEmptyPayload, ReasonPayloadTooLarge, ReasonDaemonUnreachable,
-	ReasonDeadlineExceeded, ReasonDaemonRejected,
+	ReasonDeadlineExceeded, ReasonDaemonRejected, ReasonPanicked,
 }
 
 // counts holds one counter per reason, indexed by the reasons order — the same
@@ -173,13 +177,37 @@ func EndpointPath(adapter string) string { return endpointPrefix + adapter }
 
 // IsInvocation reports whether args (os.Args[1:]) selects the beacon.
 //
-// It keys on the FIRST token only. irrlichd's own flag dispatch is a permissive
-// whole-command-line scan (hasFlag), and inheriting that here would make any
-// daemon invocation that happened to contain the word "hook-post" deliver a hook
-// instead of starting — the beacon has to be more precise than the chain it is
-// spliced into, not equally loose.
+// Two accepted forms, both anchored at a fixed position: the bare verb, and the
+// verb behind LegacyGuardToken — which is the form Command actually installs,
+// because irrlichd releases up to v0.3.2 only ever looked at argv[1] and a
+// trailing guard would miss them (see LegacyGuardToken).
+//
+// Position-anchored rather than scanned. irrlichd's own flag dispatch is a
+// permissive whole-command-line scan (hasFlag), and inheriting that here would
+// make any daemon invocation that happened to contain the word "hook-post"
+// deliver a hook instead of starting — the beacon has to be more precise than
+// the chain it is spliced into, not equally loose.
 func IsInvocation(args []string) bool {
-	return len(args) > 0 && args[0] == Subcommand
+	switch {
+	case len(args) > 0 && args[0] == Subcommand:
+		return true
+	case len(args) > 1 && args[0] == LegacyGuardToken && args[1] == Subcommand:
+		return true
+	}
+	return false
+}
+
+// InvocationArgs returns the arguments after the verb, for whichever accepted
+// form was used. Pairing it with IsInvocation keeps the two spellings of "where
+// does the verb sit" in one place instead of at the call site in main().
+func InvocationArgs(args []string) []string {
+	if len(args) > 1 && args[0] == LegacyGuardToken && args[1] == Subcommand {
+		return args[2:]
+	}
+	if len(args) > 0 && args[0] == Subcommand {
+		return args[1:]
+	}
+	return nil
 }
 
 // Options is one beacon invocation.
@@ -211,7 +239,19 @@ type Options struct {
 // so deliver can return a plain Reason and no code path anywhere else in the
 // package has to remember the rule. That is the shape hookjson.RejectPath uses
 // for the receiver side of the same problem.
-func Post(opts Options) int {
+func Post(opts Options) (exitCode int) {
+	// A panic would exit 2 and read as "deny" to a fail-closed pre-tool hook,
+	// which is the one way "returns 0 by construction" could still fail in
+	// production. Recovering is not defensive clutter here: it is the contract.
+	// The panic is still counted and reported, so it cannot hide.
+	defer func() {
+		if r := recover(); r != nil {
+			count(ReasonPanicked)
+			report(opts.Stderr, ReasonPanicked, fmt.Sprint(r))
+			exitCode = 0
+		}
+	}()
+
 	reason, detail := deliver(opts)
 	if reason != ReasonNone {
 		count(reason)
@@ -223,11 +263,6 @@ func Post(opts Options) int {
 // deliver performs the delivery and returns why it did not happen, plus a short
 // human detail for the stderr line. It never decides an exit code.
 func deliver(opts Options) (Reason, string) {
-	adapter, reason := adapterFrom(opts.Args)
-	if reason != ReasonNone {
-		return reason, strings.Join(opts.Args, " ")
-	}
-
 	timeout := opts.Timeout
 	if timeout <= 0 {
 		timeout = DefaultTimeout
@@ -239,11 +274,27 @@ func deliver(opts Options) (Reason, string) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	adapter, reason := adapterFrom(opts.Args)
+	if reason != ReasonNone {
+		// Drain before giving up. Exiting while the CLI is still writing the
+		// payload hands it EPIPE on the hook's stdin, and a fail-closed
+		// pre-tool hook may read a child-stdin write error as a hook failure —
+		// which would defeat the exit code we were careful about. ASSUMED: not
+		// verified against a live gemini-cli or Copilot. The drain runs under
+		// the same deadline, so it cannot itself become the stall.
+		readPayload(ctx, opts.Stdin)
+		return reason, strings.Join(opts.Args, " ")
+	}
+
 	body, reason, detail := readPayload(ctx, opts.Stdin)
 	if reason != ReasonNone {
 		return reason, detail
 	}
 
+	// Address resolution is deliberately outside ctx: daemonaddr.ClientURL is
+	// an os.Lstat plus a 64-byte bounded read of a local file, with no network
+	// step, so there is nothing here for a deadline to rescue that a hung
+	// filesystem would not also hang the deadline's own goroutine on.
 	return send(ctx, daemonaddr.ClientURL(EndpointPath(adapter)), body)
 }
 
@@ -287,6 +338,14 @@ func readPayload(ctx context.Context, stdin io.Reader) ([]byte, Reason, string) 
 	// Buffered so the goroutine can always finish even after ctx has won.
 	done := make(chan result, 1)
 	go func() {
+		// This goroutine is outside Post's recover: a panic here would take
+		// the process down with exit 2 no matter what Post promises, so it
+		// carries its own and reports the panic as an unreadable stdin.
+		defer func() {
+			if r := recover(); r != nil {
+				done <- result{err: fmt.Errorf("panic while reading stdin: %v", r)}
+			}
+		}()
 		// One byte over the cap, so an over-cap body is DETECTED here rather
 		// than silently truncated into a body the daemon would have to reject.
 		body, err := io.ReadAll(io.LimitReader(stdin, maxPayloadBytes+1))

--- a/core/pkg/hookbeacon/beacon_test.go
+++ b/core/pkg/hookbeacon/beacon_test.go
@@ -130,8 +130,22 @@ func TestPostAlwaysExitsZero(t *testing.T) {
 		{
 			name: "receiver wedged past the deadline",
 			setup: func(t *testing.T) Options {
+				// Wedged until the CLIENT gives up, which is the shape being
+				// tested. Tied to the request context rather than a sleep or a
+				// test-owned channel: httptest registers its own Close cleanup
+				// after this one, cleanups run LIFO, and a handler still
+				// running at Close deadlocks the subtest.
 				serverAt(t, func(w http.ResponseWriter, r *http.Request) {
-					time.Sleep(5 * time.Second)
+					// Draining the body first is load-bearing: net/http only
+					// starts the background read that notices a client hang-up
+					// once the request body has been consumed, so a handler
+					// that skips it never sees its context cancelled and then
+					// deadlocks httptest's Close during cleanup.
+					_, _ = io.Copy(io.Discard, r.Body)
+					select {
+					case <-r.Context().Done():
+					case <-time.After(3 * time.Second):
+					}
 				})
 				return Options{
 					Args: []string{"gemini-cli"}, Stdin: strings.NewReader(validPayload),
@@ -519,7 +533,7 @@ func TestEveryReasonHasACounterSlot(t *testing.T) {
 	all := []Reason{
 		ReasonMissingAdapter, ReasonInvalidAdapter, ReasonUnreadableStdin,
 		ReasonEmptyPayload, ReasonPayloadTooLarge, ReasonDaemonUnreachable,
-		ReasonDeadlineExceeded, ReasonDaemonRejected,
+		ReasonDeadlineExceeded, ReasonDaemonRejected, ReasonPanicked,
 	}
 	if len(all) != len(reasons) {
 		t.Fatalf("this test lists %d reasons but the counter table has %d — add the new one to both", len(all), len(reasons))
@@ -539,6 +553,9 @@ func TestIsInvocation(t *testing.T) {
 		want bool
 	}{
 		"the verb alone":                  {[]string{"hook-post"}, true},
+		"the guarded form we install":     {[]string{"--version", "hook-post", "gemini-cli"}, true},
+		"the guard token alone":           {[]string{"--version"}, false},
+		"the guard token then a flag":     {[]string{"--version", "--record"}, false},
 		"verb and adapter":                {[]string{"hook-post", "gemini-cli"}, true},
 		"verb, adapter and guard token":   {[]string{"hook-post", "gemini-cli", "--version"}, true},
 		"no arguments":                    {nil, false},
@@ -598,4 +615,54 @@ func TestReportNeverPanicsWithoutStderr(t *testing.T) {
 	if n := ReasonCount(); n != 1 {
 		t.Errorf("ReasonCount() = %d, want 1 — the counter must move even when there is nowhere to report", n)
 	}
+}
+
+// panicOnceWriter panics on its first write and behaves after that, so a panic
+// can be injected into Post's own body rather than into a goroutine.
+type panicOnceWriter struct{ panicked bool }
+
+func (p *panicOnceWriter) Write(b []byte) (int, error) {
+	if !p.panicked {
+		p.panicked = true
+		panic("stderr exploded")
+	}
+	return len(b), nil
+}
+
+// panicReader stands in for an io.Reader that panics — the one failure that
+// would otherwise take the process down with exit 2 from inside the read
+// goroutine, where Post's recover cannot reach it.
+type panicReader struct{}
+
+func (panicReader) Read([]byte) (int, error) { panic("stdin exploded") }
+
+// TestPostSurvivesAPanic completes the exit-0 contract. A panic exits 2, and
+// exit 2 with a fail-closed pre-tool hook is a denied tool call — so "returns 0
+// by construction" has to survive one, in both places a panic can originate.
+func TestPostSurvivesAPanic(t *testing.T) {
+	t.Run("in the read goroutine", func(t *testing.T) {
+		resetCounts()
+		t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+		var stderr bytes.Buffer
+		if code := Post(Options{Args: []string{"gemini-cli"}, Stdin: panicReader{}, Stderr: &stderr}); code != 0 {
+			t.Fatalf("Post() = %d, want 0", code)
+		}
+		if Reasons()[ReasonUnreadableStdin] != 1 {
+			t.Errorf("Reasons() = %v, want the panic counted as unreadable stdin", Reasons())
+		}
+	})
+
+	t.Run("in Post's own body", func(t *testing.T) {
+		resetCounts()
+		t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+		if code := Post(Options{
+			Args: []string{"gemini-cli"}, Stdin: strings.NewReader(validPayload),
+			Stderr: &panicOnceWriter{},
+		}); code != 0 {
+			t.Fatalf("Post() = %d, want 0", code)
+		}
+		if Reasons()[ReasonPanicked] != 1 {
+			t.Errorf("Reasons() = %v, want the panic counted as %q", Reasons(), ReasonPanicked)
+		}
+	})
 }

--- a/core/pkg/hookbeacon/beacon_test.go
+++ b/core/pkg/hookbeacon/beacon_test.go
@@ -1,0 +1,601 @@
+package hookbeacon
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"testing/iotest"
+	"time"
+
+	"irrlicht/core/pkg/daemonaddr"
+)
+
+// resetCounts zeroes the package counters between tests. Test-only on purpose:
+// a counter an operator can reset is a counter that can hide the thing it was
+// added to reveal (the same rule hookjson's unknown-event counters keep).
+func resetCounts() {
+	for i := range counts {
+		counts[i].Store(0)
+	}
+}
+
+// closedPort returns an address nothing is listening on, by binding one and
+// releasing it. Every test that must NOT reach a daemon points the beacon here
+// rather than leaving resolution to the default port — a developer machine
+// usually has a real irrlichd on :7837, and a unit test must never post to it.
+func closedPort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	addr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		t.Fatalf("closing the reserved port: %v", err)
+	}
+	return addr
+}
+
+// blockingReader never yields until the test ends. It stands in for an agent CLI
+// that opens the hook's stdin pipe and then neither writes nor closes it.
+type blockingReader struct{ release <-chan struct{} }
+
+func (b blockingReader) Read([]byte) (int, error) {
+	<-b.release
+	return 0, io.EOF
+}
+
+func newBlockingReader(t *testing.T) blockingReader {
+	t.Helper()
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	return blockingReader{release: release}
+}
+
+// serverAt starts a receiver and points the beacon at it via IRRLICHT_BIND_ADDR.
+func serverAt(t *testing.T, h http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	t.Setenv(daemonaddr.EnvBindAddr, strings.TrimPrefix(srv.URL, "http://"))
+	return srv
+}
+
+const validPayload = `{"hook_event_name":"BeforeTool","transcript_path":"/tmp/x.jsonl"}`
+
+// TestPostAlwaysExitsZero is the acceptance criterion of #1373, one row per
+// failure mode.
+//
+// The property under test is not "the happy path works" — it is that a hook
+// command irrlicht installs can never fail the user's tool call. gemini-cli's
+// BeforeTool/BeforeAgent hooks turn a non-zero exit into decision "deny" and the
+// scheduler then kills the tool with POLICY_VIOLATION; Copilot's preToolUse
+// denies on hook error. A `curl` against a down daemon exits 7, which is why the
+// naive command is worse than no monitoring at all. Every row below is a way the
+// beacon can fail, and every row must still exit 0.
+//
+// The last row is the vacuity guard: a Post that returned 0 by doing nothing at
+// all would satisfy every other row, so one row has to actually deliver.
+func TestPostAlwaysExitsZero(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) Options
+		want  Reason
+		// anyOf is for the one row whose outcome legitimately depends on
+		// whether a daemon happens to be running locally.
+		anyOf []Reason
+	}{
+		{
+			name: "daemon down: connection refused",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{Args: []string{"gemini-cli"}, Stdin: strings.NewReader(validPayload)}
+			},
+			want: ReasonDaemonUnreachable,
+		},
+		{
+			name: "daemon down: address comes from the published addr file",
+			setup: func(t *testing.T) Options {
+				home := t.TempDir()
+				t.Setenv("IRRLICHT_HOME", home)
+				t.Setenv(daemonaddr.EnvBindAddr, "")
+				writeAddrFile(t, home, closedPort(t))
+				return Options{Args: []string{"gemini-cli"}, Stdin: strings.NewReader(validPayload)}
+			},
+			want: ReasonDaemonUnreachable,
+		},
+		{
+			name: "addr file is unreadable garbage",
+			setup: func(t *testing.T) Options {
+				home := t.TempDir()
+				t.Setenv("IRRLICHT_HOME", home)
+				t.Setenv(daemonaddr.EnvBindAddr, "")
+				writeAddrFile(t, home, "not-an-address")
+				return Options{Args: []string{"irrlicht-no-such-receiver"}, Stdin: strings.NewReader(validPayload)}
+			},
+			// A garbage addr file falls back to the default port, where a
+			// developer machine may well have a real daemon. Either outcome is
+			// exit 0; the route is one no daemon serves, so the worst case is a
+			// 404 it already answers for any unknown path.
+			anyOf: []Reason{ReasonDaemonUnreachable, ReasonDaemonRejected},
+		},
+		{
+			name: "receiver wedged past the deadline",
+			setup: func(t *testing.T) Options {
+				serverAt(t, func(w http.ResponseWriter, r *http.Request) {
+					time.Sleep(5 * time.Second)
+				})
+				return Options{
+					Args: []string{"gemini-cli"}, Stdin: strings.NewReader(validPayload),
+					Timeout: 150 * time.Millisecond,
+				}
+			},
+			want: ReasonDeadlineExceeded,
+		},
+		{
+			name: "stdin is opened and never closed",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{
+					Args: []string{"gemini-cli"}, Stdin: newBlockingReader(t),
+					Timeout: 150 * time.Millisecond,
+				}
+			},
+			want: ReasonDeadlineExceeded,
+		},
+		{
+			name: "stdin errors mid-read",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{
+					Args:  []string{"gemini-cli"},
+					Stdin: iotest.ErrReader(errors.New("read |0: file already closed")),
+				}
+			},
+			want: ReasonUnreadableStdin,
+		},
+		{
+			name: "stdin returns bytes and then errors: never post a truncated body",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{
+					Args:  []string{"gemini-cli"},
+					Stdin: iotest.TimeoutReader(strings.NewReader(validPayload + validPayload)),
+				}
+			},
+			want: ReasonUnreadableStdin,
+		},
+		{
+			name: "no stdin attached at all",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{Args: []string{"gemini-cli"}, Stdin: nil}
+			},
+			want: ReasonEmptyPayload,
+		},
+		{
+			name: "stdin closes with nothing on it",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{Args: []string{"gemini-cli"}, Stdin: strings.NewReader("")}
+			},
+			want: ReasonEmptyPayload,
+		},
+		{
+			name: "stdin carries only whitespace",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{Args: []string{"gemini-cli"}, Stdin: strings.NewReader("  \n\t ")}
+			},
+			want: ReasonEmptyPayload,
+		},
+		{
+			name: "payload over the size cap",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{
+					Args:  []string{"gemini-cli"},
+					Stdin: strings.NewReader(strings.Repeat("x", maxPayloadBytes+1)),
+				}
+			},
+			want: ReasonPayloadTooLarge,
+		},
+		{
+			name: "malformed stdin: not JSON at all",
+			setup: func(t *testing.T) Options {
+				serverAt(t, func(w http.ResponseWriter, r *http.Request) {
+					http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
+				})
+				return Options{Args: []string{"gemini-cli"}, Stdin: strings.NewReader("}{not json")}
+			},
+			// The beacon does not parse the payload — the daemon's 400 is the
+			// verdict, and it is still exit 0 here.
+			want: ReasonDaemonRejected,
+		},
+		{
+			name: "daemon answers 500",
+			setup: func(t *testing.T) Options {
+				serverAt(t, func(w http.ResponseWriter, r *http.Request) {
+					http.Error(w, "boom", http.StatusInternalServerError)
+				})
+				return Options{Args: []string{"gemini-cli"}, Stdin: strings.NewReader(validPayload)}
+			},
+			want: ReasonDaemonRejected,
+		},
+		{
+			name: "daemon has no route for this adapter",
+			setup: func(t *testing.T) Options {
+				serverAt(t, func(w http.ResponseWriter, r *http.Request) {
+					http.NotFound(w, r)
+				})
+				return Options{Args: []string{"gemini-cli"}, Stdin: strings.NewReader(validPayload)}
+			},
+			want: ReasonDaemonRejected,
+		},
+		{
+			name: "daemon hangs up mid-response",
+			setup: func(t *testing.T) Options {
+				serverAt(t, func(w http.ResponseWriter, r *http.Request) {
+					conn, _, err := http.NewResponseController(w).Hijack()
+					if err != nil {
+						t.Errorf("hijack: %v", err)
+						return
+					}
+					_ = conn.Close()
+				})
+				return Options{Args: []string{"gemini-cli"}, Stdin: strings.NewReader(validPayload)}
+			},
+			want: ReasonDaemonUnreachable,
+		},
+		{
+			name: "no adapter argument",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{Args: nil, Stdin: strings.NewReader(validPayload)}
+			},
+			want: ReasonMissingAdapter,
+		},
+		{
+			name: "only the guard token, no adapter",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{Args: []string{LegacyGuardToken}, Stdin: strings.NewReader(validPayload)}
+			},
+			want: ReasonMissingAdapter,
+		},
+		{
+			name: "adapter argument is a path traversal",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{Args: []string{"../../../debug/bundle"}, Stdin: strings.NewReader(validPayload)}
+			},
+			want: ReasonInvalidAdapter,
+		},
+		{
+			name: "adapter argument is empty",
+			setup: func(t *testing.T) Options {
+				t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+				return Options{Args: []string{""}, Stdin: strings.NewReader(validPayload)}
+			},
+			want: ReasonInvalidAdapter,
+		},
+		{
+			// Vacuity guard: without this row, a Post that always refused would
+			// pass every other row above.
+			name: "delivered: the daemon is up and answers 200",
+			setup: func(t *testing.T) Options {
+				serverAt(t, func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				})
+				return Options{Args: []string{"gemini-cli"}, Stdin: strings.NewReader(validPayload)}
+			},
+			want: ReasonNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetCounts()
+			opts := tt.setup(t)
+			var stderr bytes.Buffer
+			opts.Stderr = &stderr
+
+			start := time.Now()
+			code := Post(opts)
+			elapsed := time.Since(start)
+
+			if code != 0 {
+				t.Errorf("Post() = %d, want 0 — a non-zero exit from a pre-tool hook is decision \"deny\" on gemini-cli and Copilot, which breaks the user's tool call", code)
+			}
+			// Bounded, unconditionally: the agent awaits this process, so a row
+			// that exits 0 after 60s has still stalled the user's prompt.
+			if elapsed > 2*time.Second {
+				t.Errorf("Post() took %s, want well under the 2s ceiling — every gemini-cli fire site awaits the hook", elapsed)
+			}
+			assertReason(t, tt.want, tt.anyOf, &stderr)
+		})
+	}
+}
+
+// assertReason checks the refusal was named, counted and reported — an
+// uncounted refusal is indistinguishable from no refusal.
+func assertReason(t *testing.T, want Reason, anyOf []Reason, stderr *bytes.Buffer) {
+	t.Helper()
+	got := Reasons()
+
+	if len(anyOf) > 0 {
+		for _, candidate := range anyOf {
+			if got[candidate] == 1 {
+				return
+			}
+		}
+		t.Errorf("Reasons() = %v, want exactly one of %v", got, anyOf)
+		return
+	}
+
+	if want == ReasonNone {
+		if n := ReasonCount(); n != 0 {
+			t.Errorf("ReasonCount() = %d after a delivered payload, want 0 (reasons: %v)", n, got)
+		}
+		if stderr.Len() != 0 {
+			t.Errorf("stderr = %q after a delivered payload, want silence", stderr.String())
+		}
+		return
+	}
+
+	if got[want] != 1 {
+		t.Errorf("Reasons()[%q] = %d, want 1 (full snapshot: %v)", want, got[want], got)
+	}
+	if n := ReasonCount(); n != 1 {
+		t.Errorf("ReasonCount() = %d, want exactly 1", n)
+	}
+	if !strings.Contains(stderr.String(), string(want)) {
+		t.Errorf("stderr = %q, want it to name the reason %q", stderr.String(), want)
+	}
+}
+
+func writeAddrFile(t *testing.T, home, addr string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(home, "irrlichd.addr"), []byte(addr+"\n"), 0o600); err != nil {
+		t.Fatalf("writing addr file: %v", err)
+	}
+}
+
+// TestPostResolvesTheDaemonAddressAtFireTime is requirement 4 of #1373: the
+// address is read when the hook fires, not when the entry was installed.
+//
+// The test proves it the only way that distinguishes the two — the daemon does
+// not exist yet when the Options are built, and publishes its address afterwards.
+// An implementation that captured the address earlier cannot pass this, and an
+// installed entry that carried a port could not either, which is the whole
+// structural argument: the #1178 stale-port class stops being expressible.
+func TestPostResolvesTheDaemonAddressAtFireTime(t *testing.T) {
+	resetCounts()
+	home := t.TempDir()
+	t.Setenv("IRRLICHT_HOME", home)
+	t.Setenv(daemonaddr.EnvBindAddr, "")
+
+	opts := Options{Args: []string{"gemini-cli"}, Stdin: strings.NewReader(validPayload)}
+
+	// Only now does a daemon come up and publish where it landed.
+	got := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got <- r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	writeAddrFile(t, home, strings.TrimPrefix(srv.URL, "http://"))
+
+	if code := Post(opts); code != 0 {
+		t.Fatalf("Post() = %d, want 0", code)
+	}
+	select {
+	case path := <-got:
+		if path != EndpointPath("gemini-cli") {
+			t.Errorf("posted to %q, want %q", path, EndpointPath("gemini-cli"))
+		}
+	default:
+		t.Fatalf("the daemon that published its address after the beacon was built never received the payload (reasons: %v)", Reasons())
+	}
+}
+
+// TestEnvBeatsTheAddrFile locks daemonaddr's documented precedence through the
+// beacon: an explicit IRRLICHT_BIND_ADDR is the caller naming the daemon it
+// means, and the addr file can outlive a SIGKILLed daemon. This is a LOCK on
+// existing daemonaddr behaviour, not a regression test — it passes on main by
+// construction and is here so a future "just read the file" simplification of
+// the beacon fails loudly.
+func TestEnvBeatsTheAddrFile(t *testing.T) {
+	resetCounts()
+	home := t.TempDir()
+	t.Setenv("IRRLICHT_HOME", home)
+	writeAddrFile(t, home, closedPort(t))
+
+	hit := make(chan struct{}, 1)
+	serverAt(t, func(w http.ResponseWriter, r *http.Request) {
+		hit <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	if code := Post(Options{Args: []string{"codex"}, Stdin: strings.NewReader(validPayload)}); code != 0 {
+		t.Fatalf("Post() = %d, want 0", code)
+	}
+	select {
+	case <-hit:
+	default:
+		t.Errorf("the env-named daemon was not reached; the addr file won (reasons: %v)", Reasons())
+	}
+}
+
+// TestPostSendsTheBodyVerbatim pins that the beacon is a pipe, not a parser. It
+// stamps the adapter through the URL path and forwards the bytes untouched, so a
+// field the daemon has not been taught about yet cannot be dropped in transit by
+// a decode/re-encode round trip (#1371).
+func TestPostSendsTheBodyVerbatim(t *testing.T) {
+	resetCounts()
+	type received struct {
+		method, path, contentType, body string
+	}
+	seen := make(chan received, 1)
+	serverAt(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		seen <- received{r.Method, r.URL.Path, r.Header.Get("Content-Type"), string(body)}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	const payload = `{"hook_event_name":"BeforeTool","an_unknown_future_field":{"a":[1,2,3]}}`
+	if code := Post(Options{Args: []string{"gemini-cli", LegacyGuardToken}, Stdin: strings.NewReader(payload)}); code != 0 {
+		t.Fatalf("Post() = %d, want 0", code)
+	}
+
+	r := <-seen
+	if r.method != http.MethodPost {
+		t.Errorf("method = %q, want POST", r.method)
+	}
+	if r.path != "/api/v1/hooks/gemini-cli" {
+		t.Errorf("path = %q, want /api/v1/hooks/gemini-cli", r.path)
+	}
+	if r.contentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", r.contentType)
+	}
+	if r.body != payload {
+		t.Errorf("body = %q, want it byte-identical to stdin %q", r.body, payload)
+	}
+}
+
+// TestOptionsHasNoStdout is a structural lock, not a behavioural test: a hook's
+// stdout is a decision channel (gemini-cli and Claude Code both parse JSON from
+// it), and the guarantee that the beacon never writes there is that it does not
+// hold the handle. Adding a Stdout field would quietly reopen that.
+func TestOptionsHasNoStdout(t *testing.T) {
+	if _, found := reflect.TypeOf(Options{}).FieldByName("Stdout"); found {
+		t.Error("Options grew a Stdout field — a hook's stdout is a decision channel the beacon must never write to; see the package doc")
+	}
+}
+
+// TestReasonsSnapshotIsACopy — handing out the live counters lets a reader
+// corrupt them.
+func TestReasonsSnapshotIsACopy(t *testing.T) {
+	resetCounts()
+	count(ReasonDaemonUnreachable)
+	count(ReasonDaemonUnreachable)
+
+	snap := Reasons()
+	if snap[ReasonDaemonUnreachable] != 2 {
+		t.Fatalf("Reasons()[daemon_unreachable] = %d, want 2", snap[ReasonDaemonUnreachable])
+	}
+	snap[ReasonDaemonUnreachable] = 99
+	if Reasons()[ReasonDaemonUnreachable] != 2 {
+		t.Error("Reasons() handed out the live counters")
+	}
+	if n := ReasonCount(); n != 2 {
+		t.Errorf("ReasonCount() = %d, want 2", n)
+	}
+}
+
+// TestReasonsOmitsZeros mirrors hookjson's accessors: an absent key means it
+// never happened, so a snapshot full of zeros cannot be mistaken for evidence.
+func TestReasonsOmitsZeros(t *testing.T) {
+	resetCounts()
+	count(ReasonEmptyPayload)
+	if snap := Reasons(); len(snap) != 1 {
+		t.Errorf("Reasons() = %v, want exactly one non-zero entry", snap)
+	}
+}
+
+// TestEveryReasonHasACounterSlot guards the one way this idiom breaks silently:
+// a reason added to the constant block but not to the reasons array is counted
+// by nobody, and its refusal becomes invisible.
+func TestEveryReasonHasACounterSlot(t *testing.T) {
+	resetCounts()
+	all := []Reason{
+		ReasonMissingAdapter, ReasonInvalidAdapter, ReasonUnreadableStdin,
+		ReasonEmptyPayload, ReasonPayloadTooLarge, ReasonDaemonUnreachable,
+		ReasonDeadlineExceeded, ReasonDaemonRejected,
+	}
+	if len(all) != len(reasons) {
+		t.Fatalf("this test lists %d reasons but the counter table has %d — add the new one to both", len(all), len(reasons))
+	}
+	for _, r := range all {
+		resetCounts()
+		count(r)
+		if got := Reasons()[r]; got != 1 {
+			t.Errorf("count(%q) did not land in a counter slot", r)
+		}
+	}
+}
+
+func TestIsInvocation(t *testing.T) {
+	tests := map[string]struct {
+		args []string
+		want bool
+	}{
+		"the verb alone":                  {[]string{"hook-post"}, true},
+		"verb and adapter":                {[]string{"hook-post", "gemini-cli"}, true},
+		"verb, adapter and guard token":   {[]string{"hook-post", "gemini-cli", "--version"}, true},
+		"no arguments":                    {nil, false},
+		"a flag":                          {[]string{"--record"}, false},
+		"the verb in a later position":    {[]string{"--record", "hook-post"}, false},
+		"a value that merely contains it": {[]string{"--watch=hook-post"}, false},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := IsInvocation(tt.args); got != tt.want {
+				t.Errorf("IsInvocation(%q) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEndpointPath(t *testing.T) {
+	if got := EndpointPath("gemini-cli"); got != "/api/v1/hooks/gemini-cli" {
+		t.Errorf("EndpointPath = %q, want /api/v1/hooks/gemini-cli", got)
+	}
+}
+
+// TestDefaultTimeoutIsShort pins the ceiling rather than the exact value. Every
+// gemini-cli fire site awaits the hook and its config default is 60s; the Phase C
+// audit measured a 5s hook delaying the approval dialog by 5.24s, so the cost of
+// a large value here is paid in full, in the foreground, on the user's prompt.
+func TestDefaultTimeoutIsShort(t *testing.T) {
+	if DefaultTimeout > 2*time.Second {
+		t.Errorf("DefaultTimeout = %s; a hook the agent awaits must not be able to stall a prompt this long", DefaultTimeout)
+	}
+}
+
+func TestAdapterSegmentRejectsUnsafeValues(t *testing.T) {
+	bad := []string{
+		"", "..", "../codex", "code x", "Codex", "codex/", "/codex", "codex?x=1",
+		"codex#f", "codex%2e", "-codex", "codex-", "co\nex", strings.Repeat("a", 65),
+	}
+	for _, s := range bad {
+		if adapterSegment.MatchString(s) {
+			t.Errorf("adapter segment %q was accepted; it must not be pasted into a URL path", s)
+		}
+	}
+	for _, s := range []string{"codex", "claudecode", "gemini-cli", "copilot", "aider", "kiro-cli", "a", "a1"} {
+		if !adapterSegment.MatchString(s) {
+			t.Errorf("adapter segment %q was rejected; it is a real adapter id", s)
+		}
+	}
+}
+
+// TestReportNeverPanicsWithoutStderr — a CLI is free to give the hook no stderr.
+func TestReportNeverPanicsWithoutStderr(t *testing.T) {
+	resetCounts()
+	t.Setenv(daemonaddr.EnvBindAddr, closedPort(t))
+	if code := Post(Options{Args: []string{"gemini-cli"}, Stdin: strings.NewReader(validPayload), Stderr: nil}); code != 0 {
+		t.Fatalf("Post() = %d, want 0", code)
+	}
+	if n := ReasonCount(); n != 1 {
+		t.Errorf("ReasonCount() = %d, want 1 — the counter must move even when there is nowhere to report", n)
+	}
+}

--- a/core/pkg/hookbeacon/install.go
+++ b/core/pkg/hookbeacon/install.go
@@ -323,14 +323,20 @@ func binaryPathOf(command, adapter string) (string, bool) {
 // that quote and then read as a missing binary.
 func leadingArg(command string) (string, bool) {
 	s := strings.TrimLeft(command, " ")
-	if !strings.HasPrefix(s, "'") {
-		fields := strings.Fields(s)
-		if len(fields) == 0 {
-			return "", false
-		}
-		return fields[0], true
+	if strings.HasPrefix(s, "'") {
+		return unquoteLeading(s)
 	}
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return "", false
+	}
+	return fields[0], true
+}
 
+// unquoteLeading reads one single-quoted shell word from the front of s,
+// undoing shellQuote's '\” escape. It reports false on an unterminated quote,
+// which is not a line we rendered.
+func unquoteLeading(s string) (string, bool) {
 	var out strings.Builder
 	for i := 1; i < len(s); {
 		if s[i] != '\'' {
@@ -346,7 +352,7 @@ func leadingArg(command string) (string, bool) {
 		}
 		return out.String(), true
 	}
-	return "", false // unterminated quote: not a line we rendered
+	return "", false
 }
 
 // isExecutableFile reports whether path is a regular file with an execute bit.

--- a/core/pkg/hookbeacon/install.go
+++ b/core/pkg/hookbeacon/install.go
@@ -1,0 +1,248 @@
+// install.go is the install-side half of the beacon: rendering the command an
+// adapter writes into an agent's config, and deciding when an already-installed
+// one has gone stale.
+//
+// Nothing installs it yet — #1373 builds the mechanism and each adapter adopts it
+// separately — so this file is written to be wired into hookjson.Config without
+// modification:
+//
+//	hookjson.Config{
+//	    Sentinel:    hookbeacon.Sentinel(segment),
+//	    Entry:       func() map[string]interface{} { ... "command": cmd ... },
+//	    IsCanonical: func(h map[string]interface{}) bool {
+//	        c, _ := h["command"].(string)
+//	        return hookbeacon.IsCanonical(c, segment)
+//	    },
+//	}
+package hookbeacon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LegacyGuardToken is appended to every installed beacon command line, and it is
+// the reason this file exists rather than a one-line fmt.Sprintf.
+//
+// irrlichd does not parse its arguments. main() is a chain of exact-match
+// hasFlag scans over os.Args that falls through to runDaemon() on anything it
+// does not recognize, so an irrlichd predating this subcommand, handed
+// `hook-post gemini-cli`, does not error — it STARTS A DAEMON. On every tool
+// call. And that is not merely wasteful: the startup path calls os.Remove on the
+// unix socket before listening, so a rogue start actively breaks the live
+// daemon's socket before failing to bind the TCP port.
+//
+// That hazard cannot be fixed in the old binary, so it is fixed in the command
+// line the new one installs. --version is the guard because it is the FIRST
+// branch of that chain and has been present since the commit that first named
+// the binary irrlichd (04fc6265, the irrlichtd rename) — so every irrlichd that
+// has ever existed handles it by printing two lines and exiting 0. An old binary
+// invoked as a beacon therefore no-ops instead of starting a daemon.
+//
+// It is inert on a current binary because irrlichd dispatches the subcommand on
+// os.Args[1] BEFORE any flag check (see selectAction in core/cmd/irrlichd), and
+// because adapterFrom reads past any "-" token. Both halves are locked by tests;
+// reordering the dispatch so --version wins would silently turn every installed
+// beacon into a version banner.
+const LegacyGuardToken = "--version"
+
+// stdoutRedirect keeps the guard token's own output off the hook's stdout, which
+// gemini-cli and Claude Code both read as a decision channel. It only takes
+// effect when the entry is run through a shell — which is how `type: "command"`
+// hooks are run today (Codex's installed entry is `curl ... || true`, which is
+// shell syntax). If some adapter ever execs the command directly the redirect
+// becomes an inert extra argument that adapterFrom skips over, and the residual
+// cost is two lines of stdout from an out-of-date binary. That is the intended
+// failure ordering: the redirect is defence in depth for the guard, not the
+// guard.
+const stdoutRedirect = ">/dev/null"
+
+// Command renders the shell command an adapter installs for one hook event.
+//
+// binaryPath must be absolute — the daemon runs under launchd with a minimal
+// PATH (/usr/bin:/bin:/usr/sbin:/sbin) and the agent CLIs inherit no better, so
+// a bare "irrlichd" is the silent no-op #1161 removed, wearing a new hat. Callers
+// get it from BinaryPath.
+//
+// The rendered line carries no port and no host. That is the beacon's structural
+// payoff over a curl entry: there is nothing address-shaped in the user's config
+// that can go stale, so the entire #1178 class stops being a thing that has to be
+// re-fixed per adapter rather than being fixed once more.
+func Command(binaryPath, adapter string) string {
+	return strings.Join([]string{
+		shellQuote(binaryPath), Subcommand, adapter, LegacyGuardToken, stdoutRedirect,
+	}, " ")
+}
+
+// Sentinel is the substring hookjson uses to recognize an installed entry as
+// ours across every shape we have ever written for this adapter.
+//
+// It deliberately excludes the binary path and the guard token, the two parts of
+// the command that are allowed to change: an entry naming a binary that has since
+// moved must still be recognized as ours, because recognizing it is the
+// precondition for rewriting it in place instead of appending a duplicate beside
+// it. It is the same role HookEndpointPath plays for the curl and http shapes —
+// identity is the part that does not vary.
+//
+// A caveat for the first adapter that migrates an EXISTING install to the beacon:
+// hookjson's sentinel has to match every shape ever installed for that adapter,
+// and this one does not appear in a curl line. Such an adapter must keep its
+// endpoint-path sentinel, not adopt this one, or its old entries are orphaned and
+// `irrlichd --uninstall-hooks` stops finding them. No adapter is in that position
+// today — claudecode and codex are the only installers and neither is in scope
+// for #1373.
+func Sentinel(adapter string) string {
+	return Subcommand + " " + adapter
+}
+
+// BinaryPath returns the absolute path of the running irrlichd, for embedding in
+// an installed entry.
+//
+// No symlink resolution: the invoked path is what the user's installation
+// intends, and resolving it would bake a version-specific real path into the
+// config for any install laid out like Claude Code's versions/<ver> tree, so
+// every upgrade would look like drift. (On Linux os.Executable reads
+// /proc/self/exe and is symlink-resolved by the kernel regardless. That
+// asymmetry is tolerable precisely because Inspect treats a changed path as
+// ordinary drift and EnsureInstalled rewrites it in place on the next daemon
+// start — a wrong-but-detected path self-heals, which is the property #1161
+// lacked.)
+func BinaryPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(exe)
+}
+
+// Drift names why an installed entry is not the one we would write now. It is
+// the beacon's equivalent of the port comparison inside claudecode's
+// hookEntryIsCanonical, generalized to the failure this mechanism newly admits:
+// the binary path.
+type Drift string
+
+const (
+	// DriftNone means the entry is current and its binary is present.
+	DriftNone Drift = ""
+
+	// DriftShape is an entry that is ours by sentinel but not in the current
+	// command form — a flag added, the guard token dropped, an older
+	// rendering.
+	DriftShape Drift = "shape"
+
+	// DriftBinaryPath is an entry naming a DIFFERENT irrlichd than the one
+	// running. A second install, a move out of /Applications, a dev binary
+	// that installed and then a release binary that took over.
+	DriftBinaryPath Drift = "binary_path"
+
+	// DriftBinaryMissing is an entry naming a path that is no longer there at
+	// all. This is the trap #1373 names: the beacon trades curl's PATH
+	// dependency for an absolute-path dependency, and an absolute path that
+	// stops existing fails exactly as quietly as a curl that was never on
+	// PATH — the agent runs it, the exec fails, no state is ever reported and
+	// nothing anywhere says why.
+	DriftBinaryMissing Drift = "binary_missing"
+
+	// DriftUnresolvable means we could not determine our own path, so we
+	// cannot judge the entry and must not rewrite it. Reported rather than
+	// swallowed: silently leaving an install alone is how the previous entry
+	// in this list stays invisible.
+	DriftUnresolvable Drift = "unresolvable"
+)
+
+// Inspect is the ONE decision point for whether an installed beacon command is
+// current, and it returns WHY rather than a boolean so the installer can log the
+// reason. IsCanonical is the boolean hookjson.Config wants.
+//
+// Unlike the delivery reasons above there is no counter here, and the difference
+// is not an oversight: delivery runs in a one-shot process where a stderr line
+// can be discarded by the CLI, while reconciliation runs inside the daemon on
+// every start, where a log line is read by the same operator reading everything
+// else. Detection is the requirement; a counter would be a second surface for a
+// fact already on the first.
+func Inspect(command, adapter string) Drift {
+	live, err := BinaryPath()
+	if err != nil {
+		return DriftUnresolvable
+	}
+	if command != Command(live, adapter) {
+		return driftOfOtherEntry(command, adapter, live)
+	}
+	if !isExecutableFile(live) {
+		return DriftBinaryMissing
+	}
+	return DriftNone
+}
+
+// driftOfOtherEntry classifies an entry that is not the line we would write now.
+//
+// The order is the point. A missing binary is checked before a differing one
+// because it is the drift that is otherwise undetectable from the config alone —
+// a path that merely differs still runs, while a path that is gone fails exactly
+// as quietly as the un-PATHed curl #1161 removed. And an entry naming the binary
+// we are actually running is shape drift, not path drift, or every rendering
+// change would be misreported as a move.
+func driftOfOtherEntry(command, adapter, live string) Drift {
+	path, ok := binaryPathOf(command, adapter)
+	if !ok {
+		return DriftShape
+	}
+	if !isExecutableFile(path) {
+		return DriftBinaryMissing
+	}
+	if path != live {
+		return DriftBinaryPath
+	}
+	return DriftShape
+}
+
+// IsCanonical reports whether an installed command needs no rewrite. It is the
+// hookjson.Config.IsCanonical for a beacon entry.
+//
+// A false here is what makes hookjson rewrite the entry IN PLACE — replacing the
+// element rather than appending a group beside it — so a moved or deleted binary
+// is repaired on the next daemon start rather than failing quietly forever.
+func IsCanonical(command, adapter string) bool {
+	return Inspect(command, adapter) == DriftNone
+}
+
+// binaryPathOf recovers the binary path from an installed beacon command, so a
+// stale entry can be described ("was /old/irrlichd") and not merely replaced.
+// Returns false when the command is not a beacon line for this adapter.
+func binaryPathOf(command, adapter string) (string, bool) {
+	idx := strings.Index(command, " "+Sentinel(adapter))
+	if idx <= 0 {
+		return "", false
+	}
+	return shellUnquote(strings.TrimSpace(command[:idx])), true
+}
+
+// isExecutableFile reports whether path is a regular file with an execute bit.
+// A directory or a mode-0644 leftover is as unrunnable as an absent file, and
+// all three have to read the same way here or the drift they cause is the
+// invisible one.
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
+
+// shellQuote wraps s in single quotes so a path containing a space, a $ or a
+// semicolon is one argument and not several. The embedded-quote form
+// ('\”) is the portable one — it closes the literal, escapes a bare quote and
+// reopens — and it is what every POSIX shell accepts.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// shellUnquote is shellQuote's inverse, for reading a path back out of an
+// installed entry.
+func shellUnquote(s string) string {
+	if len(s) < 2 || !strings.HasPrefix(s, "'") || !strings.HasSuffix(s, "'") {
+		return s
+	}
+	return strings.ReplaceAll(s[1:len(s)-1], `'\''`, "'")
+}

--- a/core/pkg/hookbeacon/install.go
+++ b/core/pkg/hookbeacon/install.go
@@ -17,62 +17,98 @@
 package hookbeacon
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
-// LegacyGuardToken is appended to every installed beacon command line, and it is
-// the reason this file exists rather than a one-line fmt.Sprintf.
+// LegacyGuardToken leads every installed beacon command line, and it is the
+// reason this file exists rather than a one-line fmt.Sprintf.
 //
-// irrlichd does not parse its arguments. main() is a chain of exact-match
-// hasFlag scans over os.Args that falls through to runDaemon() on anything it
-// does not recognize, so an irrlichd predating this subcommand, handed
-// `hook-post gemini-cli`, does not error — it STARTS A DAEMON. On every tool
-// call. And that is not merely wasteful: the startup path calls os.Remove on the
-// unix socket before listening, so a rogue start actively breaks the live
-// daemon's socket before failing to bind the TCP port.
+// irrlichd does not parse its arguments, and never has. An irrlichd predating
+// this subcommand, handed `hook-post gemini-cli`, does not error — it STARTS A
+// DAEMON. On every tool call. And that is not merely wasteful: the startup path
+// calls os.Remove on the unix socket before listening (setupUnixSocket), so a
+// rogue start actively breaks the live daemon's socket before failing to bind
+// the TCP port.
 //
 // That hazard cannot be fixed in the old binary, so it is fixed in the command
-// line the new one installs. --version is the guard because it is the FIRST
-// branch of that chain and has been present since the commit that first named
-// the binary irrlichd (04fc6265, the irrlichtd rename) — so every irrlichd that
-// has ever existed handles it by printing two lines and exiting 0. An old binary
-// invoked as a beacon therefore no-ops instead of starting a daemon.
+// line the new one installs: --version is a token every irrlichd exits 0 on
+// without side effects, and it is placed FIRST because irrlichd has had two
+// different dispatch shapes and only the leading position satisfies both.
+// Verified with `git show <tag>:core/cmd/irrlichd/main.go`:
 //
-// It is inert on a current binary because irrlichd dispatches the subcommand on
-// os.Args[1] BEFORE any flag check (see selectAction in core/cmd/irrlichd), and
-// because adapterFrom reads past any "-" token. Both halves are locked by tests;
-// reordering the dispatch so --version wins would silently turn every installed
-// beacon into a version banner.
+//   - v0.2.0 through v0.3.2 dispatch POSITIONALLY:
+//     `if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v")`.
+//     These match only in argv[1]. A trailing guard token would miss them
+//     entirely and they would start a daemon — so "every irrlichd handles
+//     --version anywhere in argv" is false, and an earlier draft of this file
+//     said exactly that.
+//   - Later versions scan the whole command line (hasFlag), and match a guard
+//     in any position.
+//
+// Leading satisfies both, so the guard covers every irrlichd ever released.
+//
+// It is inert on a current binary because IsInvocation accepts the guarded form
+// explicitly and irrlichd dispatches the subcommand BEFORE any flag check (see
+// selectAction in core/cmd/irrlichd), and because adapterFrom reads past any
+// "-" token. Both halves are locked by tests; reordering the dispatch so
+// --version wins would silently turn every installed beacon into a version
+// banner.
 const LegacyGuardToken = "--version"
 
-// stdoutRedirect keeps the guard token's own output off the hook's stdout, which
-// gemini-cli and Claude Code both read as a decision channel. It only takes
-// effect when the entry is run through a shell — which is how `type: "command"`
-// hooks are run today (Codex's installed entry is `curl ... || true`, which is
-// shell syntax). If some adapter ever execs the command directly the redirect
-// becomes an inert extra argument that adapterFrom skips over, and the residual
-// cost is two lines of stdout from an out-of-date binary. That is the intended
-// failure ordering: the redirect is defence in depth for the guard, not the
-// guard.
+// failOpenSuffix keeps the SHELL's exit code at 0 when the command itself never
+// runs, which is the one failure the beacon newly introduces and the one its
+// own exit-0 contract cannot reach: an absolute path that has stopped existing
+// exits 127, and a path that lost its execute bit exits 126, both from the
+// shell, before any Go code runs. Measured:
+//
+//	$ sh -c "'/gone/irrlichd' hook-post x --version >/dev/null"; echo $?   -> 127
+//	$ sh -c "'/gone/irrlichd' hook-post x --version >/dev/null || true"    -> 0
+//
+// A fail-closed pre-tool hook turns that 127 into a denied tool call, which is
+// precisely what this package exists to prevent — so the guarantee has to hold
+// even when irrlicht has been uninstalled and no daemon is left to reconcile the
+// stale entry. Codex's installed curl line carries the same `|| true` for the
+// same reason (codex/hookinstaller.go).
+const failOpenSuffix = "|| true"
+
 const stdoutRedirect = ">/dev/null"
 
 // Command renders the shell command an adapter installs for one hook event.
 //
+// The token order is load-bearing and is documented on LegacyGuardToken and
+// failOpenSuffix: guard first so every irrlichd release exits 0 rather than
+// starting a daemon, `|| true` last so the shell exits 0 even when the binary
+// is gone.
+//
 // binaryPath must be absolute — the daemon runs under launchd with a minimal
 // PATH (/usr/bin:/bin:/usr/sbin:/sbin) and the agent CLIs inherit no better, so
-// a bare "irrlichd" is the silent no-op #1161 removed, wearing a new hat. Callers
-// get it from BinaryPath.
+// a bare "irrlichd" is the silent no-op #1161 removed, wearing a new hat.
+// Callers get it from BinaryPath.
 //
 // The rendered line carries no port and no host. That is the beacon's structural
 // payoff over a curl entry: there is nothing address-shaped in the user's config
 // that can go stale, so the entire #1178 class stops being a thing that has to be
 // re-fixed per adapter rather than being fixed once more.
-func Command(binaryPath, adapter string) string {
+//
+// It returns an error rather than panicking on a bad argument because this text
+// is written into a user's config file and executed by a shell: the read side
+// (adapterFrom) already refuses an adapter that is not a safe path segment, and
+// a write side that did not would be the asymmetry that stops holding the day a
+// segment becomes config-derived rather than a compile-time literal.
+func Command(binaryPath, adapter string) (string, error) {
+	if !filepath.IsAbs(binaryPath) {
+		return "", fmt.Errorf("hookbeacon: binary path %q is not absolute; a relative path is the un-PATHed no-op #1161 removed", binaryPath)
+	}
+	if !adapterSegment.MatchString(adapter) {
+		return "", fmt.Errorf("hookbeacon: %q is not a valid adapter segment", adapter)
+	}
 	return strings.Join([]string{
-		shellQuote(binaryPath), Subcommand, adapter, LegacyGuardToken, stdoutRedirect,
-	}, " ")
+		shellQuote(binaryPath), LegacyGuardToken, Subcommand, adapter,
+		stdoutRedirect, failOpenSuffix,
+	}, " "), nil
 }
 
 // Sentinel is the substring hookjson uses to recognize an installed entry as
@@ -92,8 +128,16 @@ func Command(binaryPath, adapter string) string {
 // `irrlichd --uninstall-hooks` stops finding them. No adapter is in that position
 // today — claudecode and codex are the only installers and neither is in scope
 // for #1373.
+//
+// The trailing space is not cosmetic. hookjson matches a sentinel with
+// strings.Contains, so an unterminated "hook-post gemini" would also match an
+// installed "hook-post gemini-cli" entry: one adapter's EnsureInstalled would
+// claim the other's entry and rewrite it, and its Uninstall would delete it. No
+// current segment is a prefix of another, so this is latent rather than live —
+// which is exactly the kind of thing that stops being latent when a segment is
+// added.
 func Sentinel(adapter string) string {
-	return Subcommand + " " + adapter
+	return Subcommand + " " + adapter + " "
 }
 
 // BinaryPath returns the absolute path of the running irrlichd, for embedding in
@@ -166,23 +210,34 @@ func Inspect(command, adapter string) Drift {
 	if err != nil {
 		return DriftUnresolvable
 	}
-	if command != Command(live, adapter) {
-		return driftOfOtherEntry(command, adapter, live)
+	return inspectAgainst(command, adapter, live)
+}
+
+// inspectAgainst is Inspect with the running binary's path injected, so the
+// cases that depend on OUR binary being absent are testable without arranging
+// for os.Executable to fail.
+func inspectAgainst(command, adapter, live string) Drift {
+	want, err := Command(live, adapter)
+	if err != nil {
+		return DriftUnresolvable
 	}
-	if !isExecutableFile(live) {
-		return DriftBinaryMissing
+	if command == want {
+		if !isExecutableFile(live) {
+			return DriftBinaryMissing
+		}
+		return DriftNone
 	}
-	return DriftNone
+	return driftOfOtherEntry(command, adapter, live)
 }
 
 // driftOfOtherEntry classifies an entry that is not the line we would write now.
 //
 // The order is the point. A missing binary is checked before a differing one
 // because it is the drift that is otherwise undetectable from the config alone —
-// a path that merely differs still runs, while a path that is gone fails exactly
-// as quietly as the un-PATHed curl #1161 removed. And an entry naming the binary
-// we are actually running is shape drift, not path drift, or every rendering
-// change would be misreported as a move.
+// a path that merely differs still runs, while a path that is gone makes the
+// SHELL exit 127 before any of our code runs (which is what failOpenSuffix is
+// for). And an entry naming the binary we are actually running is shape drift,
+// not path drift, or every rendering change would be misreported as a move.
 func driftOfOtherEntry(command, adapter, live string) Drift {
 	path, ok := binaryPathOf(command, adapter)
 	if !ok {
@@ -197,25 +252,88 @@ func driftOfOtherEntry(command, adapter, live string) Drift {
 	return DriftShape
 }
 
-// IsCanonical reports whether an installed command needs no rewrite. It is the
-// hookjson.Config.IsCanonical for a beacon entry.
+// IsCanonical reports whether an installed command should be left alone. It is
+// the hookjson.Config.IsCanonical for a beacon entry.
 //
-// A false here is what makes hookjson rewrite the entry IN PLACE — replacing the
-// element rather than appending a group beside it — so a moved or deleted binary
-// is repaired on the next daemon start rather than failing quietly forever.
+// It is deliberately NOT `Inspect(...) == DriftNone`. False is what makes
+// hookjson replace the entry and mark the settings file modified, and hookjson
+// has no "the bytes did not change, skip the write" branch — so reporting a
+// drift that a rewrite cannot repair means rewriting the user's config on every
+// daemon start, forever, without ever converging. Two such drifts exist:
+//
+//   - DriftUnresolvable: we could not work out what we would write, so we have
+//     no replacement to offer. Its own doc says "must not rewrite it", and
+//     returning false here would do exactly that.
+//   - A dead binary that the rewrite would name again — either the entry is
+//     already byte-identical to what we would write, or our own binary is gone
+//     so every candidate line is equally dead.
+//
+// Both are still reported by Inspect, which is where the installer logs them.
+// Detection and repair are separate questions, and only repair belongs here.
 func IsCanonical(command, adapter string) bool {
-	return Inspect(command, adapter) == DriftNone
+	live, err := BinaryPath()
+	if err != nil {
+		return true
+	}
+	return canonicalAgainst(command, adapter, live)
+}
+
+func canonicalAgainst(command, adapter, live string) bool {
+	switch inspectAgainst(command, adapter, live) {
+	case DriftNone, DriftUnresolvable:
+		return true
+	}
+	want, err := Command(live, adapter)
+	if err != nil {
+		return true
+	}
+	// A rewrite repairs the entry only if it would actually change the line AND
+	// the binary it would name can be run.
+	return command == want || !isExecutableFile(live)
 }
 
 // binaryPathOf recovers the binary path from an installed beacon command, so a
 // stale entry can be described ("was /old/irrlichd") and not merely replaced.
 // Returns false when the command is not a beacon line for this adapter.
 func binaryPathOf(command, adapter string) (string, bool) {
-	idx := strings.Index(command, " "+Sentinel(adapter))
-	if idx <= 0 {
+	if !strings.Contains(command, Sentinel(adapter)) {
 		return "", false
 	}
-	return shellUnquote(strings.TrimSpace(command[:idx])), true
+	return leadingArg(command)
+}
+
+// leadingArg extracts the first shell word of a command line, undoing
+// shellQuote. It is the inverse of the rendering in Command, and it has to
+// understand the '\” escape or a path containing a quote would be truncated at
+// that quote and then read as a missing binary.
+func leadingArg(command string) (string, bool) {
+	s := strings.TrimLeft(command, " ")
+	if !strings.HasPrefix(s, "'") {
+		if i := strings.IndexByte(s, ' '); i > 0 {
+			return s[:i], true
+		}
+		if s == "" {
+			return "", false
+		}
+		return s, true
+	}
+
+	var out strings.Builder
+	for i := 1; i < len(s); {
+		if s[i] != '\'' {
+			out.WriteByte(s[i])
+			i++
+			continue
+		}
+		// A quote is either the '\'' escape sequence or the terminator.
+		if strings.HasPrefix(s[i:], `'\''`) {
+			out.WriteByte('\'')
+			i += 4
+			continue
+		}
+		return out.String(), true
+	}
+	return "", false // unterminated quote: not a line we rendered
 }
 
 // isExecutableFile reports whether path is a regular file with an execute bit.
@@ -236,13 +354,4 @@ func isExecutableFile(path string) bool {
 // reopens — and it is what every POSIX shell accepts.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
-}
-
-// shellUnquote is shellQuote's inverse, for reading a path back out of an
-// installed entry.
-func shellUnquote(s string) string {
-	if len(s) < 2 || !strings.HasPrefix(s, "'") || !strings.HasSuffix(s, "'") {
-		return s
-	}
-	return strings.ReplaceAll(s[1:len(s)-1], `'\''`, "'")
 }

--- a/core/pkg/hookbeacon/install.go
+++ b/core/pkg/hookbeacon/install.go
@@ -14,6 +14,15 @@
 //	        return hookbeacon.IsCanonical(c, segment)
 //	    },
 //	}
+//
+// One thing the adopting adapter owes: `segment` is typed in three independent
+// places — the value it passes here, the route registerHookRoutes registers
+// (core/cmd/irrlichd/startup.go), and the row in beaconroute_test.go that pins
+// the two against each other. Export it as ONE constant from the adapter and
+// reference that constant from all three, the way claudecode and codex already
+// share a single HookEndpointPath between their route and their installer. A
+// mismatch is a permanent silent 404: the beacon exits 0 by design, so nothing
+// anywhere reports it.
 package hookbeacon
 
 import (
@@ -221,6 +230,12 @@ func inspectAgainst(command, adapter, live string) Drift {
 	if err != nil {
 		return DriftUnresolvable
 	}
+	return driftAgainst(command, adapter, live, want)
+}
+
+// driftAgainst takes the line we would write as a parameter so a caller that
+// has already rendered it does not render it again.
+func driftAgainst(command, adapter, live, want string) Drift {
 	if command == want {
 		if !isExecutableFile(live) {
 			return DriftBinaryMissing
@@ -279,12 +294,12 @@ func IsCanonical(command, adapter string) bool {
 }
 
 func canonicalAgainst(command, adapter, live string) bool {
-	switch inspectAgainst(command, adapter, live) {
-	case DriftNone, DriftUnresolvable:
-		return true
-	}
 	want, err := Command(live, adapter)
 	if err != nil {
+		return true
+	}
+	switch driftAgainst(command, adapter, live, want) {
+	case DriftNone, DriftUnresolvable:
 		return true
 	}
 	// A rewrite repairs the entry only if it would actually change the line AND
@@ -309,13 +324,11 @@ func binaryPathOf(command, adapter string) (string, bool) {
 func leadingArg(command string) (string, bool) {
 	s := strings.TrimLeft(command, " ")
 	if !strings.HasPrefix(s, "'") {
-		if i := strings.IndexByte(s, ' '); i > 0 {
-			return s[:i], true
-		}
-		if s == "" {
+		fields := strings.Fields(s)
+		if len(fields) == 0 {
 			return "", false
 		}
-		return s, true
+		return fields[0], true
 	}
 
 	var out strings.Builder

--- a/core/pkg/hookbeacon/install_test.go
+++ b/core/pkg/hookbeacon/install_test.go
@@ -1,0 +1,204 @@
+package hookbeacon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func liveBinary(t *testing.T) string {
+	t.Helper()
+	path, err := BinaryPath()
+	if err != nil {
+		t.Fatalf("BinaryPath(): %v", err)
+	}
+	if !filepath.IsAbs(path) {
+		t.Fatalf("BinaryPath() = %q, want an absolute path — a relative one is the un-PATHed no-op #1161 removed", path)
+	}
+	return path
+}
+
+// executableAt creates a runnable stand-in binary and returns its path.
+func executableAt(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	return path
+}
+
+// TestCommandCarriesNoAddress is requirement 4 of #1373 stated as a property of
+// the installed text: there is nothing address-shaped in it to go stale.
+//
+// This is what makes the beacon a structural fix rather than another instance of
+// the #1178 repair. A curl entry embeds a port at install time, so every daemon
+// that binds elsewhere has to detect and rewrite it; a beacon entry has no port
+// to be wrong about, because the address is resolved in the beacon process on the
+// tool call that fires it.
+func TestCommandCarriesNoAddress(t *testing.T) {
+	cmd := Command("/Applications/Irrlicht.app/Contents/MacOS/irrlichd", "gemini-cli")
+	for _, forbidden := range []string{"7837", "7838", "http://", "https://", "localhost", "127.0.0.1", "/api/v1/"} {
+		if strings.Contains(cmd, forbidden) {
+			t.Errorf("Command() = %q contains %q — an installed entry must carry no address, or the #1178 stale-port class is back", cmd, forbidden)
+		}
+	}
+}
+
+// TestCommandEndsWithTheGuardToken locks the defence against an older irrlichd
+// being invoked as a beacon and starting a daemon instead. See
+// LegacyGuardToken's doc for why --version specifically.
+func TestCommandEndsWithTheGuardToken(t *testing.T) {
+	cmd := Command("/usr/local/bin/irrlichd", "gemini-cli")
+	if !strings.Contains(cmd, " "+LegacyGuardToken) {
+		t.Fatalf("Command() = %q, want it to carry the %q guard token — without it an irrlichd predating this subcommand starts a daemon on every tool call", cmd, LegacyGuardToken)
+	}
+	// The guard must come after the adapter, so a current binary reads the
+	// adapter first and a stale one still finds the flag anywhere in argv.
+	if strings.Index(cmd, LegacyGuardToken) < strings.Index(cmd, "gemini-cli") {
+		t.Errorf("Command() = %q puts the guard token before the adapter", cmd)
+	}
+	if !strings.Contains(cmd, stdoutRedirect) {
+		t.Errorf("Command() = %q, want stdout redirected — the guard token's own banner must not reach a hook's decision channel", cmd)
+	}
+}
+
+// TestCommandQuotesThePath — this repo tracks a path with a space in it, and a
+// user is free to install into one.
+func TestCommandQuotesThePath(t *testing.T) {
+	cmd := Command("/Users/a b/Irrlicht.app/Contents/MacOS/irrlichd", "codex")
+	if !strings.Contains(cmd, `'/Users/a b/Irrlicht.app/Contents/MacOS/irrlichd'`) {
+		t.Errorf("Command() = %q, want the binary path quoted as one argument", cmd)
+	}
+	awkward := "/tmp/it's here/irrlichd"
+	if got := shellUnquote(shellQuote(awkward)); got != awkward {
+		t.Errorf("shellQuote/shellUnquote round trip = %q, want %q", got, awkward)
+	}
+}
+
+// TestSentinelIsPathIndependent — identity has to be the part that does not
+// vary, or a moved binary reads as somebody else's entry and gets a duplicate
+// appended beside it instead of being rewritten in place.
+func TestSentinelIsPathIndependent(t *testing.T) {
+	a := Command("/one/irrlichd", "gemini-cli")
+	b := Command("/two/somewhere/else/irrlichd", "gemini-cli")
+	sentinel := Sentinel("gemini-cli")
+
+	if !strings.Contains(a, sentinel) || !strings.Contains(b, sentinel) {
+		t.Fatalf("sentinel %q does not appear in both %q and %q", sentinel, a, b)
+	}
+	if Sentinel("gemini-cli") == Sentinel("codex") {
+		t.Error("the sentinel does not distinguish adapters; one adapter's uninstall would take another's entries")
+	}
+}
+
+// TestIsCanonicalAcceptsTheLiveCommand is the vacuity guard for the drift table
+// below: a reconciliation rule that called everything stale would rewrite the
+// user's config on every daemon start and still pass every negative case.
+func TestIsCanonicalAcceptsTheLiveCommand(t *testing.T) {
+	live := liveBinary(t)
+	cmd := Command(live, "gemini-cli")
+	if drift := Inspect(cmd, "gemini-cli"); drift != DriftNone {
+		t.Errorf("Inspect(the command we would write now) = %q, want DriftNone", drift)
+	}
+	if !IsCanonical(cmd, "gemini-cli") {
+		t.Error("IsCanonical rejected the command it just rendered")
+	}
+}
+
+// TestInspectDetectsEveryDrift covers requirement 5 of #1373: an installed entry
+// pointing at a binary path that no longer exists must be DETECTED and rewritten,
+// not left to fail quietly.
+func TestInspectDetectsEveryDrift(t *testing.T) {
+	live := liveBinary(t)
+	const adapter = "gemini-cli"
+
+	tests := map[string]struct {
+		command string
+		want    Drift
+	}{
+		"an entry naming a different, still-present irrlichd": {
+			command: Command(executableAt(t, "irrlichd"), adapter),
+			want:    DriftBinaryPath,
+		},
+		"an entry naming a binary that no longer exists": {
+			command: Command(filepath.Join(t.TempDir(), "gone", "irrlichd"), adapter),
+			want:    DriftBinaryMissing,
+		},
+		"an entry naming a path that is a directory": {
+			command: Command(t.TempDir(), adapter),
+			want:    DriftBinaryMissing,
+		},
+		"an entry naming a file with no execute bit": {
+			command: Command(nonExecutableAt(t), adapter),
+			want:    DriftBinaryMissing,
+		},
+		"our binary, but an older command shape without the guard token": {
+			command: shellQuote(live) + " " + Subcommand + " " + adapter,
+			want:    DriftShape,
+		},
+		"a curl entry from before the beacon existed": {
+			command: "curl -fsS --max-time 1 -X POST --data-binary @- http://localhost:7837/api/v1/hooks/gemini-cli || true",
+			want:    DriftShape,
+		},
+		"an entry for a different adapter entirely": {
+			command: Command(live, "codex"),
+			want:    DriftShape,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := Inspect(tt.command, adapter); got != tt.want {
+				t.Errorf("Inspect(%q) = %q, want %q", tt.command, got, tt.want)
+			}
+			if IsCanonical(tt.command, adapter) {
+				t.Errorf("IsCanonical(%q) = true — a drifted entry that reads as canonical is never rewritten, and fails silently forever", tt.command)
+			}
+		})
+	}
+}
+
+func nonExecutableAt(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "irrlichd")
+	if err := os.WriteFile(path, []byte("not runnable"), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	return path
+}
+
+// TestBinaryPathOfRecoversTheInstalledPath — a reconciliation that can only say
+// "stale" cannot tell the user what it changed away from.
+func TestBinaryPathOfRecoversTheInstalledPath(t *testing.T) {
+	const want = "/Users/a b/Irrlicht.app/Contents/MacOS/irrlichd"
+	got, ok := binaryPathOf(Command(want, "codex"), "codex")
+	if !ok {
+		t.Fatalf("binaryPathOf did not recognize the command it rendered")
+	}
+	if got != want {
+		t.Errorf("binaryPathOf = %q, want %q", got, want)
+	}
+	if _, ok := binaryPathOf("something else entirely", "codex"); ok {
+		t.Error("binaryPathOf claimed a non-beacon command as ours")
+	}
+}
+
+// TestIsExecutableFile pins the three shapes that must all read the same way —
+// absent, directory, and present-but-not-runnable are equally unrunnable, and a
+// rule that distinguished them would let two of the three drift invisibly.
+func TestIsExecutableFile(t *testing.T) {
+	if isExecutableFile(filepath.Join(t.TempDir(), "nope")) {
+		t.Error("an absent path read as executable")
+	}
+	if isExecutableFile(t.TempDir()) {
+		t.Error("a directory read as executable")
+	}
+	if isExecutableFile(nonExecutableAt(t)) {
+		t.Error("a mode-0644 file read as executable")
+	}
+	if !isExecutableFile(executableAt(t, "irrlichd")) {
+		t.Error("a mode-0755 regular file did not read as executable")
+	}
+}

--- a/core/pkg/hookbeacon/install_test.go
+++ b/core/pkg/hookbeacon/install_test.go
@@ -7,6 +7,18 @@ import (
 	"testing"
 )
 
+// mustCommand renders a command and fails the test if the arguments are
+// rejected. Command returns an error because its output is written into a
+// user's config and executed by a shell.
+func mustCommand(t *testing.T, binaryPath, adapter string) string {
+	t.Helper()
+	cmd, err := Command(binaryPath, adapter)
+	if err != nil {
+		t.Fatalf("Command(%q, %q): %v", binaryPath, adapter, err)
+	}
+	return cmd
+}
+
 func liveBinary(t *testing.T) string {
 	t.Helper()
 	path, err := BinaryPath()
@@ -38,7 +50,7 @@ func executableAt(t *testing.T, name string) string {
 // to be wrong about, because the address is resolved in the beacon process on the
 // tool call that fires it.
 func TestCommandCarriesNoAddress(t *testing.T) {
-	cmd := Command("/Applications/Irrlicht.app/Contents/MacOS/irrlichd", "gemini-cli")
+	cmd := mustCommand(t, "/Applications/Irrlicht.app/Contents/MacOS/irrlichd", "gemini-cli")
 	for _, forbidden := range []string{"7837", "7838", "http://", "https://", "localhost", "127.0.0.1", "/api/v1/"} {
 		if strings.Contains(cmd, forbidden) {
 			t.Errorf("Command() = %q contains %q — an installed entry must carry no address, or the #1178 stale-port class is back", cmd, forbidden)
@@ -50,14 +62,19 @@ func TestCommandCarriesNoAddress(t *testing.T) {
 // being invoked as a beacon and starting a daemon instead. See
 // LegacyGuardToken's doc for why --version specifically.
 func TestCommandEndsWithTheGuardToken(t *testing.T) {
-	cmd := Command("/usr/local/bin/irrlichd", "gemini-cli")
+	cmd := mustCommand(t, "/usr/local/bin/irrlichd", "gemini-cli")
 	if !strings.Contains(cmd, " "+LegacyGuardToken) {
 		t.Fatalf("Command() = %q, want it to carry the %q guard token — without it an irrlichd predating this subcommand starts a daemon on every tool call", cmd, LegacyGuardToken)
 	}
-	// The guard must come after the adapter, so a current binary reads the
-	// adapter first and a stale one still finds the flag anywhere in argv.
-	if strings.Index(cmd, LegacyGuardToken) < strings.Index(cmd, "gemini-cli") {
-		t.Errorf("Command() = %q puts the guard token before the adapter", cmd)
+	// The guard must LEAD. irrlichd v0.2.0-v0.3.2 dispatch on os.Args[1] only
+	// (verified with git show <tag>:core/cmd/irrlichd/main.go), so a trailing
+	// guard misses them and they start a daemon — the exact hazard it exists
+	// to prevent.
+	if strings.Index(cmd, LegacyGuardToken) > strings.Index(cmd, Subcommand) {
+		t.Errorf("Command() = %q puts the guard token after the verb; releases up to v0.3.2 only match argv[1]", cmd)
+	}
+	if !strings.HasSuffix(cmd, failOpenSuffix) {
+		t.Errorf("Command() = %q, want it to end in %q — a binary that has stopped existing makes the SHELL exit 127 before any of our code runs", cmd, failOpenSuffix)
 	}
 	if !strings.Contains(cmd, stdoutRedirect) {
 		t.Errorf("Command() = %q, want stdout redirected — the guard token's own banner must not reach a hook's decision channel", cmd)
@@ -67,13 +84,20 @@ func TestCommandEndsWithTheGuardToken(t *testing.T) {
 // TestCommandQuotesThePath — this repo tracks a path with a space in it, and a
 // user is free to install into one.
 func TestCommandQuotesThePath(t *testing.T) {
-	cmd := Command("/Users/a b/Irrlicht.app/Contents/MacOS/irrlichd", "codex")
+	cmd := mustCommand(t, "/Users/a b/Irrlicht.app/Contents/MacOS/irrlichd", "codex")
 	if !strings.Contains(cmd, `'/Users/a b/Irrlicht.app/Contents/MacOS/irrlichd'`) {
 		t.Errorf("Command() = %q, want the binary path quoted as one argument", cmd)
 	}
-	awkward := "/tmp/it's here/irrlichd"
-	if got := shellUnquote(shellQuote(awkward)); got != awkward {
-		t.Errorf("shellQuote/shellUnquote round trip = %q, want %q", got, awkward)
+	for _, awkward := range []string{
+		"/tmp/it's here/irrlichd",
+		"/tmp/'/irrlichd",
+		"/tmp/a'b'c/irrlichd",
+		"/tmp/trailing'/irrlichd",
+	} {
+		got, ok := leadingArg(shellQuote(awkward) + " " + LegacyGuardToken)
+		if !ok || got != awkward {
+			t.Errorf("leadingArg(shellQuote(%q)) = %q, %v; want %q, true", awkward, got, ok, awkward)
+		}
 	}
 }
 
@@ -81,8 +105,8 @@ func TestCommandQuotesThePath(t *testing.T) {
 // vary, or a moved binary reads as somebody else's entry and gets a duplicate
 // appended beside it instead of being rewritten in place.
 func TestSentinelIsPathIndependent(t *testing.T) {
-	a := Command("/one/irrlichd", "gemini-cli")
-	b := Command("/two/somewhere/else/irrlichd", "gemini-cli")
+	a := mustCommand(t, "/one/irrlichd", "gemini-cli")
+	b := mustCommand(t, "/two/somewhere/else/irrlichd", "gemini-cli")
 	sentinel := Sentinel("gemini-cli")
 
 	if !strings.Contains(a, sentinel) || !strings.Contains(b, sentinel) {
@@ -98,7 +122,7 @@ func TestSentinelIsPathIndependent(t *testing.T) {
 // user's config on every daemon start and still pass every negative case.
 func TestIsCanonicalAcceptsTheLiveCommand(t *testing.T) {
 	live := liveBinary(t)
-	cmd := Command(live, "gemini-cli")
+	cmd := mustCommand(t, live, "gemini-cli")
 	if drift := Inspect(cmd, "gemini-cli"); drift != DriftNone {
 		t.Errorf("Inspect(the command we would write now) = %q, want DriftNone", drift)
 	}
@@ -119,19 +143,19 @@ func TestInspectDetectsEveryDrift(t *testing.T) {
 		want    Drift
 	}{
 		"an entry naming a different, still-present irrlichd": {
-			command: Command(executableAt(t, "irrlichd"), adapter),
+			command: mustCommand(t, executableAt(t, "irrlichd"), adapter),
 			want:    DriftBinaryPath,
 		},
 		"an entry naming a binary that no longer exists": {
-			command: Command(filepath.Join(t.TempDir(), "gone", "irrlichd"), adapter),
+			command: mustCommand(t, filepath.Join(t.TempDir(), "gone", "irrlichd"), adapter),
 			want:    DriftBinaryMissing,
 		},
 		"an entry naming a path that is a directory": {
-			command: Command(t.TempDir(), adapter),
+			command: mustCommand(t, t.TempDir(), adapter),
 			want:    DriftBinaryMissing,
 		},
 		"an entry naming a file with no execute bit": {
-			command: Command(nonExecutableAt(t), adapter),
+			command: mustCommand(t, nonExecutableAt(t), adapter),
 			want:    DriftBinaryMissing,
 		},
 		"our binary, but an older command shape without the guard token": {
@@ -143,7 +167,7 @@ func TestInspectDetectsEveryDrift(t *testing.T) {
 			want:    DriftShape,
 		},
 		"an entry for a different adapter entirely": {
-			command: Command(live, "codex"),
+			command: mustCommand(t, live, "codex"),
 			want:    DriftShape,
 		},
 	}
@@ -173,7 +197,7 @@ func nonExecutableAt(t *testing.T) string {
 // "stale" cannot tell the user what it changed away from.
 func TestBinaryPathOfRecoversTheInstalledPath(t *testing.T) {
 	const want = "/Users/a b/Irrlicht.app/Contents/MacOS/irrlichd"
-	got, ok := binaryPathOf(Command(want, "codex"), "codex")
+	got, ok := binaryPathOf(mustCommand(t, want, "codex"), "codex")
 	if !ok {
 		t.Fatalf("binaryPathOf did not recognize the command it rendered")
 	}
@@ -200,5 +224,77 @@ func TestIsExecutableFile(t *testing.T) {
 	}
 	if !isExecutableFile(executableAt(t, "irrlichd")) {
 		t.Error("a mode-0755 regular file did not read as executable")
+	}
+}
+
+// TestCommandRejectsUnsafeArguments — Command's output is written into a user's
+// config file and run by a shell, so the write side owes the same validation
+// the read side (adapterFrom) already does. Unvalidated, `Command(exe, "x; rm
+// -rf /tmp/pwn #")` renders a shell line that runs the injected command.
+func TestCommandRejectsUnsafeArguments(t *testing.T) {
+	for _, tt := range []struct{ path, adapter, why string }{
+		{"irrlichd", "codex", "a relative binary path"},
+		{"./bin/irrlichd", "codex", "a relative binary path"},
+		{"/usr/bin/irrlichd", "x; rm -rf /tmp/pwn #", "a shell metacharacter in the adapter"},
+		{"/usr/bin/irrlichd", "../../debug/bundle", "a path traversal in the adapter"},
+		{"/usr/bin/irrlichd", "", "an empty adapter"},
+	} {
+		if got, err := Command(tt.path, tt.adapter); err == nil {
+			t.Errorf("Command(%q, %q) = %q with no error, want a refusal (%s)", tt.path, tt.adapter, got, tt.why)
+		}
+	}
+}
+
+// TestIsCanonicalLeavesUnrepairableDriftAlone is the counterpart to
+// TestInspectDetectsEveryDrift: detection and repair are separate questions.
+//
+// hookjson has no "the bytes did not change, skip the write" branch, so a drift
+// reported as non-canonical that a rewrite cannot actually repair rewrites the
+// user's settings file on every daemon start, forever, without converging.
+func TestIsCanonicalLeavesUnrepairableDriftAlone(t *testing.T) {
+	live := liveBinary(t)
+
+	t.Run("we cannot work out what we would write", func(t *testing.T) {
+		// An adapter Command refuses makes the drift unresolvable: there is no
+		// replacement line to offer, so the entry must be left alone.
+		if !IsCanonical("anything at all", "Not A Valid Segment") {
+			t.Error("an unresolvable entry read as needing a rewrite; there is nothing to rewrite it to")
+		}
+		if got := Inspect("anything at all", "Not A Valid Segment"); got != DriftUnresolvable {
+			t.Errorf("Inspect = %q, want %q — it must still be REPORTED, only not repaired", got, DriftUnresolvable)
+		}
+	})
+
+	t.Run("our own binary is gone, so every candidate line is equally dead", func(t *testing.T) {
+		gone := filepath.Join(t.TempDir(), "irrlichd")
+		cmd := mustCommand(t, gone, "gemini-cli")
+		if got := inspectAgainst(cmd, "gemini-cli", gone); got != DriftBinaryMissing {
+			t.Errorf("Inspect = %q, want %q", got, DriftBinaryMissing)
+		}
+		if !canonicalAgainst(cmd, "gemini-cli", gone) {
+			t.Error("an entry already identical to what we would write read as needing a rewrite — that rewrite changes nothing and repeats on every daemon start")
+		}
+	})
+
+	t.Run("a repairable drift is still repaired", func(t *testing.T) {
+		// The vacuity guard for this test: the leniency above must not swallow
+		// the case the reconciliation exists for.
+		stale := mustCommand(t, filepath.Join(t.TempDir(), "old", "irrlichd"), "gemini-cli")
+		if canonicalAgainst(stale, "gemini-cli", live) {
+			t.Error("a dead entry that a rewrite WOULD repair read as canonical")
+		}
+	})
+}
+
+// TestSentinelIsNotAPrefixOfAnother — hookjson matches a sentinel with
+// strings.Contains, so an unterminated sentinel lets one adapter claim, rewrite
+// and uninstall another adapter's entries whenever one id prefixes another.
+func TestSentinelIsNotAPrefixOfAnother(t *testing.T) {
+	full := mustCommand(t, "/usr/bin/irrlichd", "gemini-cli")
+	if strings.Contains(full, Sentinel("gemini")) {
+		t.Errorf("Sentinel(%q) matches an entry belonging to %q; one adapter would rewrite and uninstall the other's entries", "gemini", "gemini-cli")
+	}
+	if !strings.Contains(full, Sentinel("gemini-cli")) {
+		t.Error("the sentinel no longer matches its own rendered command")
 	}
 }

--- a/tools/linux-parity-check.sh
+++ b/tools/linux-parity-check.sh
@@ -25,7 +25,7 @@
 #      nothing and events.jsonl comes out empty:
 #        tools/build-dev.sh && IRRLICHT_HOME=$(mktemp -d) \
 #          IRRLICHT_PERMISSION_MODE=grant-all \
-#          IRRLICHT_DAEMON_PORT=7838 core/bin/irrlichd --record /tmp/rec &
+#          IRRLICHT_DAEMON_PORT=7838 core/bin/irrlichd --record &
 #   2. Drive the cell's recipe (tmux send-keys; never human-in-loop) so the
 #      live Linux sensor emits the event stream into /tmp/rec/.../events.jsonl.
 #   3. Run this script: macOS golden vs the fresh Linux events.jsonl.


### PR DESCRIPTION
Closes #1373. Parent: #1355.

## Why

gemini-cli's `HookType` is `{Command, Runtime}` and `Runtime` is a function pointer that is not expressible in JSON, so it has **no native HTTP delivery** — its installer must shell out, reintroducing the `$PATH` dependency #1161 removed. Worse, the Phase C audit live-verified that its `BeforeTool`/`BeforeAgent` hooks **fail closed**: exit code >= 2 with text on stdout yields `decision: "deny"` and the scheduler kills the tool with `POLICY_VIOLATION`. Copilot's `preToolUse` has denied on hook error since 1.0.57. **A `curl` against a down daemon exits 7.**

So the naive command does not merely fail to report state — it breaks the user's tool calls whenever irrlicht is not running. That is strictly worse than no monitoring at all, and guaranteeing it cannot happen is the whole of this ticket.

**No adapter installs the beacon here.** This builds the mechanism; adoption is a separate change per adapter.

## What

New package `core/pkg/hookbeacon`, plus the dispatch to reach it.

### 1. Exit 0 on every path — proven per failure mode

`Post` is the one place the exit code is decided (the shape `hookjson.RejectPath` uses for the receiver side) and it returns 0 unconditionally. `deliver` returns a `Reason`, counted into a fixed array of atomics with a `Reasons()`/`ReasonCount()` snapshot pair — the `PathConfiner` idiom, because an uncounted refusal is indistinguishable from no refusal.

Exit-0 is guaranteed in three layers, because the Go return value is only one of the ways the *process* can exit non-zero:

| Layer | Covers | Test |
|---|---|---|
| `Post` returns 0 on every `deliver` outcome | 19 failure modes | `TestPostAlwaysExitsZero` |
| `recover()` in `Post` **and** in the stdin-read goroutine | a panic (exit 2) | `TestPostSurvivesAPanic` |
| `\|\| true` in the installed line | the binary never runs: exit **127** (gone) / **126** (not executable), from the *shell* | `TestCommandEndsWithTheGuardToken` |

The exit-0 matrix, one row per failure mode, each asserting exit 0 **and** completion under a 2 s ceiling: connection refused; addr-file-resolved daemon down; garbage addr file; wedged receiver; stdin opened and never closed; stdin errors; stdin errors after partial data; no stdin at all; empty stdin; whitespace-only stdin; over-cap payload; non-JSON stdin (400); daemon 500; daemon 404; daemon hangs up mid-response; no adapter argument; guard token only; path-traversal adapter; empty adapter. A 20th row is the vacuity guard — a `Post` that refused everything would pass all the others.

`TestBeaconSubprocessAlwaysExitsZero` runs the **real binary** and asserts the real process exit status plus an empty stdout. Every other assertion is on `Post`'s return value, and `Post` ends in a literal `return 0`, so those cannot fail by construction; only a subprocess observes a panic, a mis-wired `main()`, or a dispatch that fell through to `runDaemon`.

`Options` deliberately has no `Stdout` field, locked by a reflection test: a hook's stdout is a decision channel, and the way to guarantee the beacon never writes there is not to hold the handle.

### 2. Fast and bounded

One deadline over the whole operation, taken **before stdin is touched** — bounding only the HTTP call leaves the worst stall unbounded, since a CLI that opens the pipe and neither writes nor closes it blocks `io.ReadAll` forever while the agent awaits the process. Default 1 s. gemini's config `timeout` is **milliseconds** (upstream's own `hooks migrate` is wrong by 1000x) and is recorded as such in the `DefaultTimeout` doc for whoever installs this.

### 3. The daemon address is read at fire time

`daemonaddr.ClientURL` — not `LocalURL`, which is locked against reading the addr file — is called in the beacon process, on the tool call that fired it. **An installed entry therefore carries no port at all**, so the #1178 stale-port class stops being expressible rather than being fixed once more. `TestPostResolvesTheDaemonAddressAtFireTime` proves it the only way that distinguishes the two: the daemon does not exist when the `Options` are built and publishes its address afterwards.

### 4. Path drift

`Inspect` returns *why* an entry is stale — `shape`, `binary_path`, `binary_missing`, `unresolvable`. Absent path, directory, and present-but-not-executable all read as `binary_missing`, because a rule that distinguished them would let two of the three drift invisibly.

`IsCanonical` is deliberately **not** `Inspect(...) == DriftNone`. False is what makes hookjson replace the entry and mark the file modified, and hookjson has no "bytes unchanged, skip the write" branch — so reporting a drift a rewrite *cannot repair* rewrites the user's config on every daemon start, forever, without converging. Detection and repair are separate questions: `Inspect` reports, `IsCanonical` only asks whether a rewrite would help.

### 5. An older irrlichd invoked as a beacon must not start a daemon

`irrlichd` does not parse argv — `main()` was a chain of exact-match `hasFlag` scans falling through to `runDaemon()`. An irrlichd predating this subcommand, handed `hook-post gemini-cli`, **starts a daemon**, and `setupUnixSocket` `os.Remove`s the live socket before listening, so a stray start actively breaks the running daemon.

That cannot be fixed in the old binary, so it is fixed in the line the new one installs. Every rendered command **leads** with `--version`, and leads rather than trails because irrlichd has had two dispatch shapes — verified with `git show <tag>:core/cmd/irrlichd/main.go`:

- **v0.2.0 through v0.3.2** dispatch positionally: `if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v")`. These match **only** argv[1], so a trailing guard misses them entirely and they start a daemon.
- Later versions scan the whole command line (`hasFlag`) and match a guard anywhere.

Leading satisfies both, so the guard covers every irrlichd ever released. A `>/dev/null` keeps the banner off the hook's decision channel. The token is inert on a current binary because `IsInvocation` accepts the guarded form explicitly and the dispatch matches the verb **before** any flag check.

The flag chain is now `selectAction`, a pure function of argv, so **order** is testable. `actionUnknownSubcommand` additionally exits 2 on an unrecognized **positional**; unknown *flags* still fall through to the daemon, a deliberate lock keeping the change from touching any existing invocation. (Swept every invocation site — LaunchAgent plist, systemd unit, `DaemonManager`, both Docker entrypoints, `spawn-record-daemon.sh`, `hook-config-snapshot.sh`, `ir:test-mac`: not one passes a positional.)

## Red-first evidence

New mechanism, so per AGENTS.md's bar for new contract assertions it lands with **one deliberate mutation seen red per obligation — 18 in total**, all applied, run, and reverted.

| # | Mutation | Caught by |
|---|---|---|
| 1 | refusal returns exit 1 (the `irrlicht-focus` shape) | `TestPostAlwaysExitsZero`, 19 rows |
| 2 | deadline does not cover the HTTP call | `receiver_wedged...`: took 5.005 s, want < 2 s |
| 3 | deadline does not cover reading stdin | `panic: test timed out after 20s` |
| 4 | payload cap truncates instead of detecting | `payload_over_the_size_cap` |
| 5 | `LocalURL` instead of `ClientURL` | `TestPostResolvesTheDaemonAddressAtFireTime` |
| 6 | refusals reported but not counted | `Reasons()[daemon_unreachable] = 0, want 1` |
| 7 | reconciliation matches the sentinel only | `TestInspectDetectsEveryDrift`, 5 rows |
| 8 | missing binary not distinguished from moved | `= "binary_path", want "binary_missing"` |
| 9 | `--version` dispatched before the beacon verb | `the_guarded_form_we_install` |
| 10 | unknown positional falls through to `runDaemon` | `TestUnknownSubcommandNeverReachesTheDaemon` |
| 11 | installed line has no `\|\| true` | `want it to end in "\|\| true"` |
| 12 | guard token trails the verb | `puts the guard token after the verb` |
| 13 | `IsCanonical` is the naive `Inspect()==DriftNone` | `TestIsCanonicalLeavesUnrepairableDriftAlone` |
| 14 | sentinel not terminated (prefix cross-claim) | `TestSentinelIsNotAPrefixOfAnother` |
| 15 | `Command` skips argument validation | `TestCommandRejectsUnsafeArguments` |
| 16 | read goroutine has no `recover` | `panic: stdin exploded` |
| 17 | `Post` has no `recover` | `panic: stderr exploded [recovered, repanicked]` |
| 18 | subprocess: refusal exits 1 | `TestBeaconSubprocessAlwaysExitsZero` |

Mutation 5 is worth calling out: with `LocalURL` the beacon reached the **real daemon on :7837** and got a 404, rather than the daemon that had published its address. That is the #1178 failure, reproduced.

**Locks** (pass on `main` by construction — not red-first proofs): `TestEnvBeatsTheAddrFile` pins existing `daemonaddr` precedence; `TestSelectActionOrder`'s "an unknown flag still starts the daemon" row pins the pre-existing fall-through the change deliberately does not touch; `TestOptionsHasNoStdout` is structural.

## Review round

A `high`-effort review subagent returned 9 findings; the first three were real and are fixed in `8f860db5`:

- **HIGH** — the installed line had no `|| true`, so the one failure the beacon *newly introduces* (an absolute path that stops existing) exited 127 from the shell before any Go code ran. `site/install.sh --uninstall` removes the binary without calling `--uninstall-hooks`, so the stale entry outlives every daemon that could reconcile it.
- **MEDIUM** — the guard token's justification was false: "every irrlichd handles `--version`" is contradicted by v0.2.0–v0.3.2's positional dispatch. Guard now leads (see above).
- **MEDIUM** — `IsCanonical` reported unrepairable drift as needing a rewrite, producing a non-converging config rewrite on every daemon start.

Plus: panic recovery in both places a panic can originate, `Command` argument validation, a terminated sentinel, an stdin drain on adapter refusal, and the real-process exit-code test.

A `/simplify` pass (`c9d4b0a`-equivalent, commit 3) shared the duplicated `go build` between the two subprocess tests (core/cmd/irrlichd tests 5.6s -> 3.3s), deduplicated the verb-position logic, and rendered the command once per reconciliation decision.

## Verification

`tools/preflight.sh` run chunked in the foreground, all PASS on the final tree: `go` (gofmt, core module tests, onboarding-factory, replaydata validate, recording-rig smoke, replay fixtures, starhistory), `web` (both trees), `arch` (ARS composite 7.9503 -> 7.9517, no category regressions), `tools`, `skills`, `security`.

## Deliberately not done

aider's `--notifications-command` is not wired. The beacon is installed into no adapter. `AGENTS.md` is untouched — no new contract-testing family is added, so its count of contract families is unaffected.

**Marked assumed** (not verified against a live CLI): that a fail-closed pre-tool hook treats a child-stdin `EPIPE` as a hook failure — the stdin drain on adapter refusal is insurance against it, not a fix for an observed behaviour. Likewise, that gemini-cli denies on exit 127 with empty stdout follows from the audit's exit-code rule but was not separately probed. A live probe against real gemini-cli and Copilot with a deliberately broken hook command is the highest-value thing that could still be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)