### PR TITLE
feat(hooks): per-adapter hook-liveness watchdog (#1368)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,20 @@ Before marking a ticket done, run the full suite — every layer must pass:
   the diagnostics bundle's `hooks.json`; note that `--diagnose` runs in a process
   that never served a hook, so that form omits the counts and says so rather than
   publishing zeros (the live counts come from `GET /debug/bundle`).
-  All six contract families pass by construction against a correct adapter, so
+- Hook receipts: `contracttesting.AssertHookReceiptObserved`
+  (`core/internal/contracttesting/hook_receipt.go`) is the #1368 counterpart —
+  the event that never *arrives*, rather than the one that arrives unrecognized.
+  It is the only receiving-side contract whose failure is a false **accusation**
+  instead of a silence: the liveness watchdog demotes a channel that produces no
+  receipts across N turns and releases the holds it placed, so a receiver that
+  forgets `hookjson.ObserveHookReceipt` is reported dead and stops being trusted
+  while working perfectly — and the watchdog cannot tell that apart from a real
+  outage. Four obligations: a recognized event counts exactly one receipt; an
+  *unrecognized* one counts too (alive-but-misunderstood is #1364's diagnosis);
+  a path-confinement rejection counts too (alive-but-misrouted is #1361's); and a
+  consent-denied request counts nothing, because noting that a POST arrived is
+  itself an observation.
+  All seven contract families pass by construction against a correct adapter, so
   their whole value is that they *can* fail: a new or reworked contract
   assertion lands with the deliberate mutation that was seen red for each
   obligation recorded in its PR — the same bar the red-first rule above sets

--- a/core/adapters/inbound/agents/claudecode/hookreceipt_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookreceipt_test.go
@@ -1,0 +1,36 @@
+package claudecode
+
+import (
+	"net/http"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+// TestHookReceiptObserved wires this adapter's hook receiver into the shared
+// issue #1368 contract: a consent-passed request is counted as a receipt for
+// this adapter whatever the receiver then does with it, and a consent-denied
+// one is not.
+//
+// The counter is what tells the liveness watchdog this channel is alive, so a
+// receiver that stops calling it is not merely unmonitored — it is actively
+// reported as dead and demoted to the transcript tier while working.
+func TestHookReceiptObserved(t *testing.T) {
+	contracttesting.AssertHookReceiptObserved(t, contracttesting.HookReceiptReceiver{
+		Adapter:         AdapterName,
+		Root:            claudeProjectsRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandlerWithConfiner(&mockTarget{}, nil, fakeGate(true), log, TranscriptConfiner())
+		},
+		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandlerWithConfiner(&mockTarget{}, nil, fakeGate(false), log, TranscriptConfiner())
+		},
+		PayloadFor:   contractPayload,
+		KnownEvent:   HookPermissionRequest,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -274,6 +274,13 @@ func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGrant
 		return
 	}
 
+	// The channel delivered (issue #1368). Counted here — after the consent
+	// gate, before anything can reject the payload — because the question this
+	// answers is "are hooks arriving at all", and a body we then refuse still
+	// proves they are. See receipt.go for why each rejection below still
+	// counts and why a consent-denied request must not.
+	hookjson.ObserveHookReceipt(AdapterName)
+
 	var payload hookPayload
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)

--- a/core/adapters/inbound/agents/codex/hookreceipt_test.go
+++ b/core/adapters/inbound/agents/codex/hookreceipt_test.go
@@ -1,0 +1,39 @@
+package codex
+
+import (
+	"net/http"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+// TestHookReceiptObserved wires this adapter's hook receiver into the shared
+// issue #1368 contract: a consent-passed request is counted as a receipt for
+// this adapter whatever the receiver then does with it, and a consent-denied
+// one is not.
+//
+// Codex's receiver has two gates, and the receipt is counted against the first.
+// That is deliberate: "transcripts" authorizes READING the transcript, while
+// noting that a POST arrived needs only the "hooks" consent — and a
+// hooks-granted / transcripts-denied install has a channel that plainly works
+// and must not be convicted of silence.
+func TestHookReceiptObserved(t *testing.T) {
+	contracttesting.AssertHookReceiptObserved(t, contracttesting.HookReceiptReceiver{
+		Adapter:         AdapterName,
+		Root:            codexSessionsRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandlerWithConfiner(&mockTarget{},
+				keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, log, TranscriptConfiner())
+		},
+		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandlerWithConfiner(&mockTarget{}, keyedGate{}, log, TranscriptConfiner())
+		},
+		PayloadFor:   contractPayload,
+		KnownEvent:   HookPermissionRequest,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/codex/hooks.go
+++ b/core/adapters/inbound/agents/codex/hooks.go
@@ -136,6 +136,12 @@ func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logge
 		return
 	}
 
+	// The channel delivered (issue #1368). Counted against the "hooks" consent
+	// only — the transcripts gate below authorizes READING the transcript, not
+	// observing that a POST arrived, and a hooks-granted / transcripts-denied
+	// install has a working channel that this counter must not call dead.
+	hookjson.ObserveHookReceipt(AdapterName)
+
 	var payload codexHookPayload
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)

--- a/core/adapters/inbound/agents/hookjson/receipt.go
+++ b/core/adapters/inbound/agents/hookjson/receipt.go
@@ -1,0 +1,130 @@
+// receipt.go counts, per adapter, that the hook channel delivered anything at
+// all (issue #1368).
+//
+// It is the missing half of #1364. That issue made an event we do not
+// UNDERSTAND visible; this one makes an event that never ARRIVES visible. The
+// two failures look identical from every surface a user can see — permission
+// reads `granted`, the config still holds our entries, no error is logged
+// anywhere — and they have opposite fixes, so a single "hooks are unhealthy"
+// signal would be worse than none.
+//
+// What this counter is NOT: a count of hook events successfully handled. It is
+// deliberately incremented at the earliest point the receiver is allowed to
+// observe anything, which is immediately after the consent gate. Three
+// consequences, each chosen:
+//
+//   - A malformed body still counts. A decode failure is a different diagnosis
+//     with a different fix, and it is already answered 400. For the question
+//     this counter answers — "is the channel delivering?" — a 400 is a yes.
+//   - A path-confinement rejection still counts (#1361). Same argument, and
+//     confine.go's own counters say what is actually wrong. A channel that is
+//     alive but 100% rejected must not be reported as silent, or the watchdog
+//     sends its reader to the wrong file.
+//   - A consent-denied request does NOT count. Everything an adapter observes
+//     must be gated behind a declared permission (AGENTS.md), and "a POST
+//     arrived" is an observation. It is also the honest answer: while consent
+//     is withheld the daemon has no business claiming to know whether the
+//     channel works.
+//
+// Unlike unknown.go's table this map needs no bound. Its key is the adapter's
+// own compile-time AdapterName constant, never caller-supplied input, so the key
+// space is closed at the size of the agent registry — the same reason
+// unknown.go's per-adapter DROP counter is unbounded while its per-name table is
+// not.
+package hookjson
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+var (
+	// receiptMu guards slot allocation only. Once an adapter owns a slot every
+	// later receipt goes through its atomic under the read lock — the same
+	// argument unknown.go makes, and it applies harder here: this increments on
+	// EVERY hook, not only on the unrecognized ones, so it sits squarely on the
+	// receiver hot path.
+	receiptMu sync.RWMutex
+	receipts  = make(map[string]*atomic.Uint64)
+)
+
+// ObserveHookReceipt records that adapter's hook receiver was handed a
+// consent-passed request.
+//
+// It takes no logger and writes no response on purpose. There is nothing to
+// report here: a hook arriving is the healthy case, and the interesting event
+// is its ABSENCE, which by definition no call site can observe. The watchdog in
+// the application layer is what notices the absence, by reading HookReceipts
+// against turns it counted independently.
+func ObserveHookReceipt(adapter string) {
+	receiptMu.RLock()
+	counter := receipts[adapter]
+	receiptMu.RUnlock()
+	if counter != nil {
+		counter.Add(1)
+		return
+	}
+
+	receiptMu.Lock()
+	defer receiptMu.Unlock()
+	if counter := receipts[adapter]; counter != nil {
+		// Lost the race to insert; the winner's slot is the live one.
+		counter.Add(1)
+		return
+	}
+	fresh := &atomic.Uint64{}
+	fresh.Add(1)
+	receipts[adapter] = fresh
+}
+
+// HookReceiptsFor reads one adapter's receipt total.
+//
+// The single-key read exists because it is the one the watchdog actually makes:
+// it wants two atomics per classify pass, and reaching them through HookReceipts
+// meant allocating and copying the whole table to index one key — ~19x the cost
+// and 256 bytes of garbage per pass, forever, on a path that scales with session
+// count rather than hook traffic. HookReceipts stays for the readers that really
+// do want every row.
+func HookReceiptsFor(adapter string) uint64 {
+	receiptMu.RLock()
+	counter := receipts[adapter]
+	receiptMu.RUnlock()
+	if counter == nil {
+		return 0
+	}
+	return counter.Load()
+}
+
+// HookReceipts snapshots the per-adapter receipt totals.
+//
+// Zeros are absent by construction — an adapter gets a slot only when it is
+// first counted — which matters to the reader more than it looks. An adapter
+// missing from this map has either never received a hook or has no receiver at
+// all, and those are the same fact as far as the watchdog is concerned: it only
+// arms for adapters whose hook consent is granted and whose install succeeded.
+//
+// Monotonic for the life of the process. The watchdog compares successive
+// readings rather than resetting anything, so nothing here needs to be
+// clearable and two readers can never steal each other's deltas.
+func HookReceipts() map[string]uint64 {
+	receiptMu.RLock()
+	defer receiptMu.RUnlock()
+	out := make(map[string]uint64, len(receipts))
+	for adapter, counter := range receipts {
+		out[adapter] = counter.Load()
+	}
+	return out
+}
+
+// HookReceiptTotal is every hook receipt across every adapter, so the
+// diagnostics bundle can say "this daemon has served N hooks" without a reader
+// summing rows — the same courtesy UnknownEventTotal provides.
+func HookReceiptTotal() uint64 {
+	receiptMu.RLock()
+	defer receiptMu.RUnlock()
+	var total uint64
+	for _, counter := range receipts {
+		total += counter.Load()
+	}
+	return total
+}

--- a/core/adapters/inbound/agents/hookjson/receipt_test.go
+++ b/core/adapters/inbound/agents/hookjson/receipt_test.go
@@ -1,0 +1,97 @@
+package hookjson
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// receiptTestSeq keeps every test's adapter name unique. The counters are
+// process-global and never reset — the same constraint unknown_test.go works
+// under — so a fixed literal would make two tests in one binary share a slot
+// and steal each other's deltas.
+var receiptTestSeq atomic.Uint64
+
+func receiptAdapter(t *testing.T) string {
+	t.Helper()
+	return fmt.Sprintf("irr-receipt-test-%d", receiptTestSeq.Add(1))
+}
+
+func TestObserveHookReceipt_CountsPerAdapter(t *testing.T) {
+	a, b := receiptAdapter(t), receiptAdapter(t)
+
+	for i := 0; i < 3; i++ {
+		ObserveHookReceipt(a)
+	}
+	ObserveHookReceipt(b)
+
+	snap := HookReceipts()
+	if snap[a] != 3 {
+		t.Errorf("adapter %q counted %d, want 3", a, snap[a])
+	}
+	if snap[b] != 1 {
+		t.Errorf("adapter %q counted %d, want 1 — a second adapter must get its own key, or one live channel would vouch for a dead one", b, snap[b])
+	}
+}
+
+// An adapter that has received nothing must be ABSENT rather than present with
+// a zero. The watchdog reads a missing key and a zero identically, but a human
+// reading hooks.json does not: an explicit zero from a counter looks like a
+// measurement, and this counter cannot distinguish "no hooks yet" from "no
+// receiver". The row that carries that judgement is the watchdog's, which knows
+// whether the channel was armed.
+func TestHookReceipts_OmitsAdaptersWithNoTraffic(t *testing.T) {
+	quiet := receiptAdapter(t)
+	if _, ok := HookReceipts()[quiet]; ok {
+		t.Errorf("adapter %q with no receipts appears in the snapshot", quiet)
+	}
+}
+
+func TestHookReceipts_SnapshotDoesNotAliasLiveState(t *testing.T) {
+	a := receiptAdapter(t)
+	ObserveHookReceipt(a)
+
+	snap := HookReceipts()
+	snap[a] = 999
+	if HookReceipts()[a] != 1 {
+		t.Error("mutating a snapshot changed the live counters — the aliasing bug this repo has already paid for once")
+	}
+}
+
+func TestHookReceiptTotal_SumsEveryAdapter(t *testing.T) {
+	a, b := receiptAdapter(t), receiptAdapter(t)
+	before := HookReceiptTotal()
+
+	ObserveHookReceipt(a)
+	ObserveHookReceipt(a)
+	ObserveHookReceipt(b)
+
+	if got := HookReceiptTotal() - before; got != 3 {
+		t.Errorf("total rose by %d, want 3", got)
+	}
+}
+
+// The receiver is an HTTP handler, so concurrent increments are the normal
+// case, and the first ones race to allocate the adapter's slot. Under -race
+// this fails on an unsynchronised map and on a lost-update allocation.
+func TestObserveHookReceipt_IsConcurrencySafe(t *testing.T) {
+	a := receiptAdapter(t)
+	const goroutines, each = 8, 250
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < each; j++ {
+				ObserveHookReceipt(a)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := HookReceipts()[a]; got != goroutines*each {
+		t.Errorf("counted %d, want %d — a lost update makes a busy channel look quieter than it is", got, goroutines*each)
+	}
+}

--- a/core/application/services/diagnostics_service.go
+++ b/core/application/services/diagnostics_service.go
@@ -81,6 +81,19 @@ type HookHealthSnapshot struct {
 	// UnknownEventsTotal is every unrecognized event seen, named or dropped, so
 	// the total is read rather than reconstructed.
 	UnknownEventsTotal uint64
+
+	// Channels is the hook-liveness watchdog's per-adapter view (issue #1368):
+	// which channels are being watched, how many requests each has delivered,
+	// and which are currently treated as dead. It rides in the SAME snapshot as
+	// the unrecognized-event counters, and hooks.json renders both in one
+	// section, because they answer two halves of one question — "are hooks
+	// arriving, and do we understand them" — and because a second nil-meaningful
+	// seam would be a second thing to get wrong in the CLI case.
+	Channels []HookChannelHealth
+
+	// ReceiptsTotal is every consent-passed hook request this process was
+	// handed, across all adapters.
+	ReceiptsTotal uint64
 }
 
 // DiagnosticsServiceDeps bundles NewDiagnosticsService's dependencies.
@@ -443,6 +456,7 @@ func (s *DiagnosticsService) hooksView() any {
 		return struct {
 			CollectedFrom string `json:"collected_from"`
 			Note          string `json:"note"`
+			LivenessNote  string `json:"liveness_note"`
 		}{
 			CollectedFrom: "cli",
 			Note: "Collected by `irrlichd --diagnose`, which runs in a process that never served a hook, " +
@@ -450,6 +464,12 @@ func (s *DiagnosticsService) hooksView() any {
 				"reported as zero. The FIRST sighting of each unrecognized event name is logged at error level, so " +
 				"events.log in this bundle still names them. For live counts, fetch GET /debug/bundle from the " +
 				"running daemon.",
+			LivenessNote: "The per-adapter hook-liveness watchdog (#1368) is omitted here for the same reason and " +
+				"one more: this process served no hooks AND observed no turns, so both sides of the ratio it " +
+				"reports are structurally absent — a channel would read as silent with zero turns behind it, which " +
+				"is an accusation, not a measurement. Its verdicts are logged, so events.log in this bundle still " +
+				"carries any `hook channel for <adapter> looks dead` line. For the live view, fetch " +
+				"GET /debug/bundle from the running daemon.",
 		}
 	}
 
@@ -464,17 +484,55 @@ func (s *DiagnosticsService) hooksView() any {
 		}
 		return events[i].Event < events[j].Event
 	})
+	// Not copied, unlike events above, and not sorted: Snapshot allocates a
+	// fresh slice per call and owes a stable order to its own callers, so there
+	// is nothing here to alias and re-sorting would be a second copy of one
+	// comparator that no test could see go stale.
+	channels := snap.Channels
 	return struct {
-		CollectedFrom            string             `json:"collected_from"`
-		UnknownEventsTotal       uint64             `json:"unknown_events_total"`
-		UnknownEvents            []UnknownHookEvent `json:"unknown_events,omitempty"`
-		UnknownEventNamesDropped map[string]uint64  `json:"unknown_event_names_dropped_by_adapter,omitempty"`
+		CollectedFrom            string              `json:"collected_from"`
+		HookRequestsReceived     uint64              `json:"hook_requests_received"`
+		Channels                 []HookChannelHealth `json:"channels,omitempty"`
+		SilentChannelNote        string              `json:"silent_channel_note,omitempty"`
+		UnknownEventsTotal       uint64              `json:"unknown_events_total"`
+		UnknownEvents            []UnknownHookEvent  `json:"unknown_events,omitempty"`
+		UnknownEventNamesDropped map[string]uint64   `json:"unknown_event_names_dropped_by_adapter,omitempty"`
 	}{
 		CollectedFrom:            "daemon",
+		HookRequestsReceived:     snap.ReceiptsTotal,
+		Channels:                 channels,
+		SilentChannelNote:        silentChannelNote(channels),
 		UnknownEventsTotal:       snap.UnknownEventsTotal,
 		UnknownEvents:            events,
 		UnknownEventNamesDropped: snap.UnknownNamesDropped,
 	}
+}
+
+// silentChannelNote spells out what a `"silent": true` row means, and — just as
+// importantly — what it does not (issue #1368).
+//
+// It is emitted only when a channel is actually silent, so the healthy bundle
+// stays terse. The three-way disambiguation is the point: the same
+// user-visible symptom ("hooks aren't working") has three causes with three
+// different first moves, and a bug reporter pasting this file should not have
+// to know which issue number owns which.
+func silentChannelNote(channels []HookChannelHealth) string {
+	var silent []string
+	for _, c := range channels {
+		if c.Silent {
+			silent = append(silent, c.Adapter)
+		}
+	}
+	if len(silent) == 0 {
+		return ""
+	}
+	return "Hook channel(s) " + strings.Join(silent, ", ") + " delivered nothing across the watchdog's turn " +
+		"threshold while consent was granted and the install reported success, so they were demoted to the " +
+		"transcript tier and any hook-tier holds they had placed were released (#1368). This says entries were " +
+		"WRITTEN and nothing is arriving through them. It does NOT mean the entries are still present — if " +
+		"something removed them since, this is how that looks too (#1372). And it is a different fault from an " +
+		"install that FAILED, which never wrote entries at all and shows up as effect_error on the permission " +
+		"rather than here (#1362). Check the agent's own hook config next, then the daemon's bind port."
 }
 
 func stateView(sessions []*session.SessionState, now time.Time) any {

--- a/core/application/services/diagnostics_service_test.go
+++ b/core/application/services/diagnostics_service_test.go
@@ -358,7 +358,15 @@ func TestHooksBundleOmitsCountsWhenNotCollectedInDaemon(t *testing.T) {
 	}
 	// Not just the list: ANY count from a process that served no hooks is a
 	// number nobody observed, and a zero reads as an all-clear.
-	for _, field := range []string{"unknown_events", "unknown_events_total", "unknown_event_names_dropped_by_adapter"} {
+	// The #1368 fields inherit the same obligation and are listed here, not
+	// only in their own test: the two shapes differ by a handful of fields and
+	// are an obvious candidate for being unified later, and the moment they are
+	// this loop is the only thing standing between that refactor and publishing
+	// `"hook_requests_received": 0` from a process that served none.
+	for _, field := range []string{
+		"unknown_events", "unknown_events_total", "unknown_event_names_dropped_by_adapter",
+		"hook_requests_received", "channels", "silent_channel_note",
+	} {
 		if v, ok := got[field]; ok {
 			t.Errorf("%s is present without a daemon to read it from: %v", field, v)
 		}
@@ -366,6 +374,92 @@ func TestHooksBundleOmitsCountsWhenNotCollectedInDaemon(t *testing.T) {
 	note, _ := got["note"].(string)
 	if !strings.Contains(note, "events.log") || !strings.Contains(note, "/debug/bundle") {
 		t.Errorf("note does not say where the real evidence is: %q", note)
+	}
+}
+
+// TestHooksBundleReportsChannelLiveness covers the #1368 half of hooks.json:
+// which hook channels are being watched, what each has delivered, and which are
+// currently treated as dead.
+func TestHooksBundleReportsChannelLiveness(t *testing.T) {
+	svc := buildTestServiceWithHooks(t, func() HookHealthSnapshot {
+		return HookHealthSnapshot{
+			ReceiptsTotal: 91,
+			Channels: []HookChannelHealth{
+				{Adapter: "claude-code", Armed: true, Receipts: 0, TurnsSinceReceipt: 9, Silent: true},
+				{Adapter: "codex", Armed: true, Receipts: 91, TurnsSinceReceipt: 0},
+				{Adapter: "kiro-cli"},
+			},
+		}
+	})
+
+	got := hooksJSON(t, svc)
+
+	if got["hook_requests_received"] != float64(91) {
+		t.Errorf("hook_requests_received = %v, want 91", got["hook_requests_received"])
+	}
+	channels, _ := got["channels"].([]any)
+	if len(channels) != 3 {
+		t.Fatalf("channels has %d entries, want 3: %v", len(channels), got["channels"])
+	}
+
+	dead, _ := channels[0].(map[string]any)
+	if dead["adapter"] != "claude-code" || dead["silent"] != true || dead["turns_since_receipt"] != float64(9) {
+		t.Errorf("dead channel row = %v, want claude-code silent after 9 turns", dead)
+	}
+	if dead["armed"] != true {
+		t.Errorf("a silent row must also say it was armed: %v — otherwise a reader cannot tell a dead channel from an uninstalled one", dead)
+	}
+	unwatched, _ := channels[2].(map[string]any)
+	if v, ok := unwatched["armed"]; ok && v == true {
+		t.Errorf("an adapter with no consent must not read as armed: %v", unwatched)
+	}
+
+	// The three-way disambiguation is the point of the section. Collapsing this
+	// ticket's diagnosis with #1372's or #1362's is the failure mode the note
+	// exists to prevent, so it is asserted rather than trusted.
+	note, _ := got["silent_channel_note"].(string)
+	if note == "" {
+		t.Fatal("a silent channel must carry an explanation; hooks.json is what a bug reporter pastes")
+	}
+	for _, want := range []string{"claude-code", "#1368", "#1372", "#1362", "effect_error"} {
+		if !strings.Contains(note, want) {
+			t.Errorf("silent_channel_note must mention %q so the reader is not sent to the wrong fix; got:\n%s", want, note)
+		}
+	}
+}
+
+// TestHooksBundleOmitsTheLivenessNoteWhenHealthy keeps the healthy bundle
+// terse: a paragraph of failure prose printed on every bundle would train
+// readers to skip the one that matters.
+func TestHooksBundleOmitsTheLivenessNoteWhenHealthy(t *testing.T) {
+	got := hooksJSON(t, buildTestServiceWithHooks(t, func() HookHealthSnapshot {
+		return HookHealthSnapshot{
+			ReceiptsTotal: 12,
+			Channels:      []HookChannelHealth{{Adapter: "codex", Armed: true, Receipts: 12}},
+		}
+	}))
+	if v, ok := got["silent_channel_note"]; ok {
+		t.Errorf("a healthy bundle carries the silent-channel explanation: %v", v)
+	}
+}
+
+// TestHooksBundleOmitsLivenessWhenNotCollectedInDaemon extends #1364's honesty
+// obligation to this feature, and the obligation is strictly stronger here.
+// `--diagnose` served no hooks AND observed no turns, so BOTH sides of the
+// ratio are structurally absent: a channel published from that process would
+// read as silent with zero turns behind it, which is an accusation rather than
+// a measurement.
+func TestHooksBundleOmitsLivenessWhenNotCollectedInDaemon(t *testing.T) {
+	got := hooksJSON(t, buildTestServiceWithHooks(t, nil))
+
+	for _, field := range []string{"channels", "hook_requests_received", "silent_channel_note"} {
+		if v, ok := got[field]; ok {
+			t.Errorf("%s is present without a daemon to read it from: %v", field, v)
+		}
+	}
+	note, _ := got["liveness_note"].(string)
+	if !strings.Contains(note, "no turns") || !strings.Contains(note, "/debug/bundle") {
+		t.Errorf("liveness_note must say why it is absent and where the real view is: %q", note)
 	}
 }
 

--- a/core/application/services/hook_liveness.go
+++ b/core/application/services/hook_liveness.go
@@ -1,0 +1,388 @@
+// hook_liveness.go implements the per-adapter hook-liveness watchdog (#1368).
+//
+// The failure it catches has three parts that must ALL hold, and the third is
+// the only one anybody could previously see:
+//
+//	permission granted  +  install effect succeeded  +  zero hooks arriving
+//
+// Any two of those without the third is a different diagnosis with a different
+// fix, and this file is careful never to answer for one of them:
+//
+//   - granted but the effect FAILED — the entries were never written. Already
+//     visible as PermissionView.EffectError and a permissions LogError (#1362).
+//     The watchdog stays disarmed for that adapter, so it can never re-report
+//     that failure in weaker words.
+//   - entries written and later REMOVED by something else — #1372, not built.
+//     The watchdog will eventually call such a channel silent, because from in
+//     here it is silent; what it does NOT do is claim to know why. Its log line
+//     and its lifecycle event say "nothing is arriving", never "the entries are
+//     present", and hooks.json names #1372 as the thing that would tell them
+//     apart.
+//   - hooks arriving under names we do not recognize — #1364. Those still count
+//     as receipts, because the channel is demonstrably alive; the unknown-event
+//     counters in the same hooks.json section are what say the names are wrong.
+//
+// Turns, not wall time. A window measured in minutes cannot distinguish a dead
+// channel from a user who went to lunch — which is the exact ambiguity the
+// issue opens with. Measured against completed turns, silence is only ever read
+// when the agent was demonstrably doing something, and "the user had a quiet
+// hour" produces no evidence at all rather than false evidence.
+//
+// The turn signal is deliberately independent of the channel under test: it is
+// a rising edge of transcript-derived IsAgentDone, observed before the hook
+// overlay is applied, so a dead hook channel cannot suppress the very
+// measurement that would convict it.
+package services
+
+import (
+	"sort"
+	"sync"
+
+	"irrlicht/core/domain/session"
+)
+
+// HookLivenessTransition is what one OnActivity pass decided.
+type HookLivenessTransition int
+
+const (
+	// HookLivenessUnchanged is the overwhelmingly common answer: nothing to
+	// report.
+	HookLivenessUnchanged HookLivenessTransition = iota
+	// HookLivenessSilent means the adapter just crossed the threshold. Reported
+	// once per silent episode, not once per turn — a channel that stays dead
+	// must not write a log line per turn forever, the same argument #1364 makes
+	// for reporting an unrecognized name once.
+	HookLivenessSilent
+	// HookLivenessRecovered means a receipt arrived for an adapter that had been
+	// declared silent. This is the event that makes the demotion a health
+	// signal rather than a latch.
+	HookLivenessRecovered
+)
+
+// HookLivenessChange is one transition, carrying everything its log line and
+// lifecycle event need so the caller reads no state back out of the watchdog.
+type HookLivenessChange struct {
+	Transition  HookLivenessTransition
+	Adapter     string
+	SilentTurns int
+	Threshold   int
+	// Receipts is the adapter's lifetime receipt total at the moment of the
+	// verdict. Zero and non-zero are different bugs: zero says this channel has
+	// never once worked in this process (a bad install, a port mismatch, a CLI
+	// that does not run our hooks), non-zero says it worked and then stopped
+	// (an upgrade, a rewritten config, a crashed listener).
+	Receipts uint64
+
+	// Silent is whether the adapter's channel is demoted as of this pass. It
+	// rides along on every transition — including Unchanged — so the caller can
+	// act on the verdict without a second lock acquisition and a second adapter
+	// resolution that could disagree with this one.
+	Silent bool
+}
+
+// HookChannelHealth is one adapter's row in the diagnostics bundle.
+type HookChannelHealth struct {
+	Adapter string `json:"adapter"`
+	// Armed is whether the watchdog is watching this adapter at all: its hook
+	// consent is granted AND its install effect reported success. A disarmed row
+	// is published rather than omitted, because "not watched" and "watched and
+	// healthy" are different answers to the same question and a missing row
+	// would read as the second.
+	Armed bool `json:"armed"`
+	// Receipts is the lifetime count of consent-passed requests this adapter's
+	// receiver was handed.
+	Receipts uint64 `json:"receipts"`
+	// TurnsSinceReceipt is how many consecutive completed turns have been
+	// observed for this adapter with no receipt.
+	TurnsSinceReceipt int `json:"turns_since_receipt"`
+	// Silent is whether the channel is currently demoted to TierTranscript.
+	Silent bool `json:"silent"`
+}
+
+// HookLivenessConfig holds the watchdog's tunables and the static facts it
+// needs about the agent registry.
+type HookLivenessConfig struct {
+	// SilentTurns is the threshold; <= 0 disables the watchdog entirely.
+	SilentTurns int
+	// DefaultAdapter is the adapter a session with an empty Adapter belongs to,
+	// injected for the same reason DiagnosticsService takes one: the
+	// application layer must not import the inbound adapter that owns the
+	// constant.
+	DefaultAdapter string
+	// Receipts reads one adapter's lifetime receipt total. Injected rather than
+	// imported because application/services must not import adapters/inbound —
+	// the same hexagonal seam HookHealthSnapshot crosses, and reusing it is why
+	// this feature adds no second one. Per adapter rather than "hand me the
+	// whole table": the production caller wants one row per pass, and mirroring
+	// the package-level getter's granularity is what would import a whole-map
+	// copy onto the classify path. Nil means no source is wired, which the
+	// watchdog treats as "cannot observe", never as "zero".
+	Receipts func(adapter string) uint64
+
+	// Adapters is every adapter that has a hook receiver. Supplied so the
+	// diagnostics snapshot can report a channel that has produced no traffic at
+	// all — which is the single most interesting row in a bundle from a user
+	// whose hooks never worked, and the one a map built from live counters can
+	// never contain.
+	Adapters []string
+}
+
+// hookChannelState is one adapter's watch state.
+//
+// There is deliberately no `silent bool`: it is exactly silentTurns >= the
+// threshold, and the threshold is fixed at construction, so storing it would be
+// a second field that has to agree with the first forever. The pair going out of
+// step is not a hypothetical — it produces a row reading `"silent": true,
+// "turns_since_receipt": 0`, which hooksView's own note calls an accusation
+// rather than a measurement.
+type hookChannelState struct {
+	// receipts is the total observed at the last pass that saw the counter
+	// move. Successive readings are compared against it rather than anything
+	// being reset, so the adapter-side counter stays monotonic and no two
+	// readers can steal each other's deltas.
+	receipts    uint64
+	silentTurns int
+}
+
+// HookLivenessWatchdog tracks, per adapter, completed turns against hook
+// receipts, and reports the crossing in both directions.
+//
+// Unlike CacheBloatDetector — which it otherwise mirrors, down to the
+// rising-edge turn detection — this one needs a mutex. Its writer is the
+// detector's single event-loop goroutine, but Snapshot is read from the
+// diagnostics HTTP handler on another.
+type HookLivenessWatchdog struct {
+	mu  sync.Mutex
+	cfg HookLivenessConfig
+
+	// readyFn reports whether an adapter's hook channel is EXPECTED to deliver:
+	// consent granted and the install effect not failed. Nil means not wired
+	// yet, which reads as disarmed — the daemon builds the watchdog before the
+	// permission service exists, and no hook can have been served in between.
+	readyFn func(adapter string) bool
+
+	state map[string]*hookChannelState
+	// lastDone is the rising-edge memory for turn detection, keyed by session.
+	lastDone map[string]bool
+}
+
+// NewHookLivenessWatchdog builds a watchdog. It is inert until SetChannelReady
+// has been called — the one collaborator that genuinely cannot be supplied
+// here, because the permission service does not exist yet at this point in
+// startup. Everything else arrives in cfg.
+func NewHookLivenessWatchdog(cfg HookLivenessConfig) *HookLivenessWatchdog {
+	return &HookLivenessWatchdog{
+		cfg:      cfg,
+		state:    map[string]*hookChannelState{},
+		lastDone: map[string]bool{},
+	}
+}
+
+// SetChannelReady wires the "is this channel expected to deliver" predicate.
+// Called after the permission service exists, which is later in startup than
+// the watchdog itself — see readyFn.
+func (w *HookLivenessWatchdog) SetChannelReady(fn func(adapter string) bool) {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.readyFn = fn
+}
+
+// enabled reports whether the watchdog will do anything at all.
+func (w *HookLivenessWatchdog) enabled() bool {
+	return w != nil && w.cfg.SilentTurns > 0
+}
+
+// resolve maps a session's adapter string onto the key this watchdog counts
+// under. Shared by every entry point rather than repeated at each: a
+// disagreement here would silently split one channel's evidence across two
+// keys, which is the failure the empty-adapter case exists to prevent.
+func (w *HookLivenessWatchdog) resolve(adapter string) string {
+	if adapter == "" {
+		return w.cfg.DefaultAdapter
+	}
+	return adapter
+}
+
+// OnActivity is called once per processActivity pass, before the hook overlay
+// is applied. It reports at most one transition.
+//
+// Recovery is checked on EVERY pass; demotion only on a turn boundary. That
+// asymmetry is the point: convicting a channel requires evidence that turns
+// went by, but acquitting it requires only that a hook arrived, and making the
+// user wait for another turn boundary to be believed would be a latch wearing a
+// different hat.
+func (w *HookLivenessWatchdog) OnActivity(state *session.SessionState) HookLivenessChange {
+	if !w.enabled() || state == nil || state.Metrics == nil {
+		return HookLivenessChange{}
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Update the rising-edge memory FIRST and unconditionally. Every early
+	// return below would otherwise leave it stale, and a missed falling edge
+	// makes the next real turn boundary invisible.
+	//
+	// `seen` is what keeps a session's FIRST observation from counting as a
+	// completed turn. An unseeded lookup returns false, so a session whose
+	// transcript is already at a turn boundary the first time it is observed
+	// would otherwise register a rising edge for a turn that finished before
+	// the watchdog was watching — and the daemon re-reads every persisted
+	// working session at startup, so a restart alone could donate one phantom
+	// turn per session and convict a channel that has not been given a single
+	// chance to deliver. This is the same argument the receipts baseline below
+	// makes ("hooks served before we were watching are not evidence of
+	// silence"), applied to the other side of the ratio.
+	done := state.Metrics.IsAgentDone()
+	wasDone, seen := w.lastDone[state.SessionID]
+	w.lastDone[state.SessionID] = done
+	turnBoundary := seen && done && !wasDone
+
+	adapter := w.resolve(state.Adapter)
+	if adapter == "" {
+		return HookLivenessChange{}
+	}
+
+	if w.cfg.Receipts == nil || w.readyFn == nil || !w.readyFn(adapter) {
+		// Disarmed: no consent, a failed install, or not yet wired. Forget any
+		// accumulated silence rather than banking it — consent can be revoked
+		// and re-granted, and turns counted while the channel was legitimately
+		// absent are not evidence against it.
+		//
+		// A demotion in force is cleared here WITHOUT a recovered event. The
+		// channel did not come back; it stopped being watched, and reporting a
+		// recovery for it would put a false all-clear in the trace.
+		delete(w.state, adapter)
+		return HookLivenessChange{}
+	}
+
+	st := w.state[adapter]
+	if st == nil {
+		// First armed pass. Baseline against the counter as it stands rather
+		// than against zero: hooks served before the watchdog started watching
+		// are not evidence of silence, and starting from zero would credit them
+		// as a recovery on the very next pass.
+		st = &hookChannelState{receipts: w.receipts(adapter)}
+		w.state[adapter] = st
+		return HookLivenessChange{}
+	}
+
+	if cur := w.receipts(adapter); cur > st.receipts {
+		wasSilent := w.silentLocked(adapter)
+		st.receipts = cur
+		st.silentTurns = 0
+		if wasSilent {
+			return HookLivenessChange{
+				Transition: HookLivenessRecovered,
+				Adapter:    adapter,
+				Threshold:  w.cfg.SilentTurns,
+				Receipts:   cur,
+			}
+		}
+		return HookLivenessChange{}
+	}
+
+	if !turnBoundary {
+		return HookLivenessChange{Silent: w.silentLocked(adapter)}
+	}
+
+	// The counter keeps climbing past the threshold, so the snapshot can show
+	// how long this has been going on; the verdict is reported only on the
+	// crossing itself, because a channel that stays dead must not write a log
+	// line per turn forever.
+	st.silentTurns++
+	if st.silentTurns != w.cfg.SilentTurns {
+		return HookLivenessChange{Silent: w.silentLocked(adapter)}
+	}
+	return HookLivenessChange{
+		Transition:  HookLivenessSilent,
+		Adapter:     adapter,
+		SilentTurns: st.silentTurns,
+		Threshold:   w.cfg.SilentTurns,
+		Receipts:    st.receipts,
+		Silent:      true,
+	}
+}
+
+// Silent reports whether adapter's hook channel is currently demoted.
+//
+// This is what the detector consults before deciding to release hook-tier
+// holds. It is a pure read of the decision OnActivity made — deliberately not a
+// re-derivation from live counters, so the demotion, the log line, the
+// lifecycle event and every hold released under it all describe the same
+// verdict rather than four near-simultaneous ones that could disagree.
+func (w *HookLivenessWatchdog) Silent(adapter string) bool {
+	if !w.enabled() {
+		return false
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.silentLocked(w.resolve(adapter))
+}
+
+// silentLocked is the one definition of "this channel is currently demoted".
+// Caller holds w.mu.
+func (w *HookLivenessWatchdog) silentLocked(adapter string) bool {
+	st := w.state[adapter]
+	return st != nil && st.silentTurns >= w.cfg.SilentTurns
+}
+
+// Forget drops a session's rising-edge memory when the session goes away, so
+// the map does not grow for the life of the process.
+func (w *HookLivenessWatchdog) Forget(sessionID string) {
+	if w == nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	delete(w.lastDone, sessionID)
+}
+
+// Snapshot returns one row per hook-receiving adapter, sorted by name.
+//
+// Every configured adapter appears, including ones with no state and no
+// traffic. That is the difference between a bundle that says "claude-code:
+// armed, 0 receipts, 9 turns, SILENT" and one that simply has no claude-code
+// row — and the second is indistinguishable from a bundle collected before the
+// feature existed.
+func (w *HookLivenessWatchdog) Snapshot() []HookChannelHealth {
+	if w == nil {
+		return nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	names := make(map[string]struct{}, len(w.cfg.Adapters)+len(w.state))
+	for _, a := range w.cfg.Adapters {
+		names[a] = struct{}{}
+	}
+	for a := range w.state {
+		names[a] = struct{}{}
+	}
+
+	out := make([]HookChannelHealth, 0, len(names))
+	for a := range names {
+		row := HookChannelHealth{Adapter: a, Receipts: w.receipts(a)}
+		if w.readyFn != nil {
+			row.Armed = w.readyFn(a)
+		}
+		if st := w.state[a]; st != nil {
+			row.TurnsSinceReceipt = st.silentTurns
+			row.Silent = w.silentLocked(a)
+		}
+		out = append(out, row)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Adapter < out[j].Adapter })
+	return out
+}
+
+// receipts reads one adapter's counter. Caller holds w.mu.
+func (w *HookLivenessWatchdog) receipts(adapter string) uint64 {
+	if w.cfg.Receipts == nil {
+		return 0
+	}
+	return w.cfg.Receipts(adapter)
+}

--- a/core/application/services/hook_liveness_test.go
+++ b/core/application/services/hook_liveness_test.go
@@ -1,0 +1,449 @@
+package services
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+const (
+	livenessAdapter = "claude-code"
+	livenessOther   = "codex"
+)
+
+// livenessHarness is a watchdog plus the two mutable collaborators the
+// production one reads through: the adapter-side receipt counters and the
+// consent predicate. Both are maps the test writes directly, so a test reads as
+// "grant consent, run turns, deliver a hook" rather than as plumbing.
+type livenessHarness struct {
+	w        *HookLivenessWatchdog
+	receipts map[string]uint64
+	ready    map[string]bool
+}
+
+func newLivenessHarness(threshold int) *livenessHarness {
+	h := &livenessHarness{
+		receipts: map[string]uint64{},
+		ready:    map[string]bool{livenessAdapter: true},
+	}
+	h.w = NewHookLivenessWatchdog(HookLivenessConfig{
+		SilentTurns:    threshold,
+		DefaultAdapter: livenessAdapter,
+		Adapters:       []string{livenessAdapter, livenessOther},
+		Receipts:       func(a string) uint64 { return h.receipts[a] },
+	})
+	h.w.SetChannelReady(func(a string) bool { return h.ready[a] })
+	return h
+}
+
+// turn drives one complete turn: a pass with the agent busy, then a pass with
+// it done. That false→true edge is the same one processActivity produces, and
+// it is deliberately built from transcript-derived fields only — the watchdog
+// must not be able to count a turn using anything the hook channel supplies,
+// or a dead channel would suppress the measurement that convicts it.
+func (h *livenessHarness) turn(sessionID string) HookLivenessChange {
+	h.pass(sessionID, false)
+	return h.pass(sessionID, true)
+}
+
+// pass drives one processActivity pass. done=false is modelled with an open
+// tool call rather than an absent turn_done so the metrics stay a shape the
+// classifier would actually produce.
+func (h *livenessHarness) pass(sessionID string, done bool) HookLivenessChange {
+	return h.passAs(sessionID, livenessAdapter, done)
+}
+
+// passAs is pass for a session belonging to some other adapter. The metrics
+// shape a turn is recognised by lives here alone, so a change to it cannot
+// leave one test asserting against a shape the detector no longer produces.
+func (h *livenessHarness) passAs(sessionID, adapter string, done bool) HookLivenessChange {
+	m := &session.SessionMetrics{LastEventType: "turn_done"}
+	if !done {
+		m.HasOpenToolCall = true
+	}
+	return h.w.OnActivity(&session.SessionState{
+		SessionID: sessionID,
+		Adapter:   adapter,
+		Metrics:   m,
+	})
+}
+
+// turnAs is turn for a session belonging to some other adapter.
+func (h *livenessHarness) turnAs(sessionID, adapter string) HookLivenessChange {
+	h.passAs(sessionID, adapter, false)
+	return h.passAs(sessionID, adapter, true)
+}
+
+// A hook arriving is the only thing that clears silence.
+func (h *livenessHarness) hookArrives() { h.receipts[livenessAdapter]++ }
+
+// TestHookLiveness_DemotesAfterThresholdTurnsWithNoReceipts is the core claim:
+// N completed turns with zero hook requests, on a channel whose consent is
+// granted and whose install succeeded, is a verdict — and it is reached at N,
+// not before.
+func TestHookLiveness_DemotesAfterThresholdTurnsWithNoReceipts(t *testing.T) {
+	h := newLivenessHarness(3)
+
+	for i := 1; i < 3; i++ {
+		if got := h.turn("s"); got.Transition != HookLivenessUnchanged {
+			t.Fatalf("turn %d: transition = %v, want unchanged — convicting early makes the threshold decorative", i, got.Transition)
+		}
+		if h.w.Silent(livenessAdapter) {
+			t.Fatalf("turn %d: channel reported silent before the threshold was reached", i)
+		}
+	}
+
+	got := h.turn("s")
+	if got.Transition != HookLivenessSilent {
+		t.Fatalf("transition on the threshold turn = %v, want HookLivenessSilent", got.Transition)
+	}
+	if got.Adapter != livenessAdapter {
+		t.Errorf("Adapter = %q, want %q — a verdict that names the wrong channel sends its reader to the wrong config file", got.Adapter, livenessAdapter)
+	}
+	if got.SilentTurns != 3 || got.Threshold != 3 {
+		t.Errorf("SilentTurns/Threshold = %d/%d, want 3/3 — both are recorded so a trace stays readable after the threshold is retuned", got.SilentTurns, got.Threshold)
+	}
+	if got.Receipts != 0 {
+		t.Errorf("Receipts = %d, want 0 — zero says this channel never worked, non-zero says it worked and stopped, and those are different bugs", got.Receipts)
+	}
+	if !h.w.Silent(livenessAdapter) {
+		t.Error("Silent() must report the demotion the transition just announced")
+	}
+}
+
+// TestHookLiveness_ReportsTheDemotionOnce is the noise floor. A channel that
+// stays dead stays dead for every turn afterwards; a log line and a lifecycle
+// event per turn would bury the one that mattered — the same argument #1364
+// makes for reporting an unrecognized event name once.
+func TestHookLiveness_ReportsTheDemotionOnce(t *testing.T) {
+	h := newLivenessHarness(2)
+
+	h.turn("s")
+	if got := h.turn("s"); got.Transition != HookLivenessSilent {
+		t.Fatalf("precondition: expected the demotion on turn 2, got %v", got.Transition)
+	}
+	for i := 3; i <= 6; i++ {
+		if got := h.turn("s"); got.Transition != HookLivenessUnchanged {
+			t.Fatalf("turn %d re-reported the demotion (%v); it must be announced once per silent episode", i, got.Transition)
+		}
+	}
+	if !h.w.Silent(livenessAdapter) {
+		t.Error("staying quiet about it must not mean forgetting it")
+	}
+}
+
+// TestHookLiveness_RecoversWhenEventsResume is scope item 3 stated literally:
+// a health signal, not a latch.
+func TestHookLiveness_RecoversWhenEventsResume(t *testing.T) {
+	h := newLivenessHarness(2)
+	h.turn("s")
+	h.turn("s")
+	if !h.w.Silent(livenessAdapter) {
+		t.Fatal("precondition: the channel must be silent before recovery can mean anything")
+	}
+
+	h.hookArrives()
+	got := h.pass("s", true)
+
+	if got.Transition != HookLivenessRecovered {
+		t.Fatalf("transition = %v, want HookLivenessRecovered", got.Transition)
+	}
+	if got.Receipts != 1 {
+		t.Errorf("Receipts = %d, want 1", got.Receipts)
+	}
+	if h.w.Silent(livenessAdapter) {
+		t.Error("a recovered channel must stop being treated as dead without a daemon restart")
+	}
+}
+
+// TestHookLiveness_RecoveryNeedsNoTurnBoundary is the asymmetry, asserted
+// rather than assumed. Convicting a channel requires evidence that turns went
+// by; acquitting it requires only that a hook arrived. Making recovery wait for
+// the next turn boundary would be a latch wearing a different hat — and a user
+// whose next action is the one blocked by the stale hold would never produce
+// that boundary.
+func TestHookLiveness_RecoveryNeedsNoTurnBoundary(t *testing.T) {
+	h := newLivenessHarness(2)
+	h.turn("s")
+	h.turn("s")
+	if !h.w.Silent(livenessAdapter) {
+		t.Fatal("precondition: expected a silent channel")
+	}
+
+	h.hookArrives()
+	// A mid-turn pass: the agent is busy, so there is no rising edge at all.
+	if got := h.pass("s", false); got.Transition != HookLivenessRecovered {
+		t.Fatalf("transition on a non-boundary pass = %v, want HookLivenessRecovered", got.Transition)
+	}
+	if h.w.Silent(livenessAdapter) {
+		t.Error("recovery must take effect on the pass that observed the receipt")
+	}
+}
+
+// TestHookLiveness_CountsResetOnAnyReceipt guards the other direction: a
+// channel that delivers on most turns and misses one must never accumulate its
+// way to a verdict.
+func TestHookLiveness_CountsResetOnAnyReceipt(t *testing.T) {
+	h := newLivenessHarness(3)
+	for i := 0; i < 20; i++ {
+		if i%3 != 2 {
+			h.hookArrives()
+		}
+		if got := h.turn("s"); got.Transition != HookLivenessUnchanged {
+			t.Fatalf("turn %d: a channel delivering two turns in three was reported %v", i, got.Transition)
+		}
+	}
+	if h.w.Silent(livenessAdapter) {
+		t.Error("an intermittently quiet but live channel must not be demoted")
+	}
+}
+
+// TestHookLiveness_DisarmedWhenConsentOrInstallIsNot is the boundary against
+// the two neighbouring diagnoses. A channel nobody granted, and a channel whose
+// install effect FAILED (#1362 — which is what HookChannelReady returning false
+// encodes), must produce no verdict at all: the first because there is nothing
+// to be silent about, the second because that failure is already reported
+// elsewhere with its actual error string, and re-reporting it in weaker words
+// sends the reader to the wrong fix.
+func TestHookLiveness_DisarmedWhenConsentOrInstallIsNot(t *testing.T) {
+	h := newLivenessHarness(2)
+	h.ready[livenessAdapter] = false
+
+	for i := 0; i < 10; i++ {
+		if got := h.turn("s"); got.Transition != HookLivenessUnchanged {
+			t.Fatalf("turn %d on a disarmed channel produced %v", i, got.Transition)
+		}
+	}
+	if h.w.Silent(livenessAdapter) {
+		t.Error("a channel that was never installed cannot be silent — it is absent, which is a different fact")
+	}
+}
+
+// TestHookLiveness_DisarmingClearsSilenceWithoutClaimingRecovery: revoking
+// consent while a channel is demoted must drop the demotion — the watchdog has
+// no business holding a verdict about a channel it no longer watches — but must
+// NOT emit a recovered event, which would put a false all-clear in the trace.
+func TestHookLiveness_DisarmingClearsSilenceWithoutClaimingRecovery(t *testing.T) {
+	h := newLivenessHarness(2)
+	h.turn("s")
+	h.turn("s")
+	if !h.w.Silent(livenessAdapter) {
+		t.Fatal("precondition: expected a silent channel")
+	}
+
+	h.ready[livenessAdapter] = false
+	if got := h.pass("s", true); got.Transition != HookLivenessUnchanged {
+		t.Errorf("revoking consent produced %v; the channel did not come back, it stopped being watched", got.Transition)
+	}
+	if h.w.Silent(livenessAdapter) {
+		t.Error("a channel that is no longer watched must not stay demoted")
+	}
+}
+
+// TestHookLiveness_DoesNotBankTurnsFromBeforeItWasArmed: turns that happened
+// while consent was withheld are not evidence against the channel, so
+// re-granting starts the count over rather than tripping immediately.
+func TestHookLiveness_DoesNotBankTurnsFromBeforeItWasArmed(t *testing.T) {
+	h := newLivenessHarness(3)
+	h.ready[livenessAdapter] = false
+	for i := 0; i < 10; i++ {
+		h.turn("s")
+	}
+
+	h.ready[livenessAdapter] = true
+	for i := 1; i < 3; i++ {
+		if got := h.turn("s"); got.Transition != HookLivenessUnchanged {
+			t.Fatalf("turn %d after re-granting produced %v — turns from the disarmed period were banked", i, got.Transition)
+		}
+	}
+	if got := h.turn("s"); got.Transition != HookLivenessSilent {
+		t.Fatalf("the count should restart, not reset forever: transition = %v, want silent on turn 3", got.Transition)
+	}
+}
+
+// TestHookLiveness_BaselinesAgainstReceiptsAlreadySeen: hooks served before the
+// watchdog started watching an adapter are not a recovery. Starting the
+// baseline at zero would credit them on the very next pass and make the first
+// verdict unreachable.
+func TestHookLiveness_BaselinesAgainstReceiptsAlreadySeen(t *testing.T) {
+	h := newLivenessHarness(2)
+	h.receipts[livenessAdapter] = 500
+
+	h.turn("s")
+	if got := h.turn("s"); got.Transition != HookLivenessSilent {
+		t.Fatalf("transition = %v, want silent — a healthy history must not immunise a channel that has since died", got.Transition)
+	}
+}
+
+// TestHookLiveness_KillSwitch: threshold <= 0 disables everything, matching
+// CacheBloatThreshold's convention.
+func TestHookLiveness_KillSwitch(t *testing.T) {
+	h := newLivenessHarness(0)
+	for i := 0; i < 50; i++ {
+		if got := h.turn("s"); got.Transition != HookLivenessUnchanged {
+			t.Fatalf("the kill switch let a transition through: %v", got.Transition)
+		}
+	}
+	if h.w.enabled() || h.w.Silent(livenessAdapter) {
+		t.Error("SilentTurns <= 0 must disable the watchdog completely")
+	}
+}
+
+// TestHookLiveness_TurnsAreAttributedPerAdapter: one adapter going dark must
+// not convict another. After #1355's rollout there are up to ten channels that
+// can fail independently, which is the whole reason this is keyed by adapter.
+func TestHookLiveness_TurnsAreAttributedPerAdapter(t *testing.T) {
+	h := newLivenessHarness(2)
+	h.ready[livenessOther] = true
+
+	h.hookArrives()
+	h.turn("s")
+	h.hookArrives()
+	h.turn("s")
+
+	h.turnAs("o", livenessOther)
+	if got := h.turnAs("o", livenessOther); got.Transition != HookLivenessSilent || got.Adapter != livenessOther {
+		t.Fatalf("transition/adapter = %v/%q, want silent/%q", got.Transition, got.Adapter, livenessOther)
+	}
+	if h.w.Silent(livenessAdapter) {
+		t.Error("the healthy adapter was demoted alongside the dead one")
+	}
+}
+
+// TestHookLiveness_EmptyAdapterResolvesToTheDefault mirrors
+// DiagnosticsService's handling: a claudecode session may carry an empty
+// Adapter, and attributing its turns to "" would silently split one channel's
+// evidence in two.
+func TestHookLiveness_EmptyAdapterResolvesToTheDefault(t *testing.T) {
+	h := newLivenessHarness(2)
+	h.turnAs("b", "")
+	if got := h.turnAs("b", ""); got.Transition != HookLivenessSilent || got.Adapter != livenessAdapter {
+		t.Fatalf("transition/adapter = %v/%q, want silent/%q", got.Transition, got.Adapter, livenessAdapter)
+	}
+	if !h.w.Silent("") {
+		t.Error("Silent(\"\") must resolve to the default adapter too, or the release path misses these sessions")
+	}
+}
+
+// TestHookLiveness_SnapshotPublishesEveryConfiguredChannel: a channel with no
+// traffic at all is the single most telling row in a bundle from a user whose
+// hooks never worked, and it is exactly the row a map built from live counters
+// cannot contain.
+func TestHookLiveness_SnapshotPublishesEveryConfiguredChannel(t *testing.T) {
+	h := newLivenessHarness(2)
+	h.turn("s")
+	h.turn("s")
+
+	rows := h.w.Snapshot()
+	if len(rows) != 2 {
+		t.Fatalf("Snapshot returned %d rows, want one per configured adapter: %+v", len(rows), rows)
+	}
+	if rows[0].Adapter != livenessAdapter || rows[1].Adapter != livenessOther {
+		t.Fatalf("rows are not sorted by adapter: %+v", rows)
+	}
+	if !rows[0].Armed || !rows[0].Silent || rows[0].Receipts != 0 || rows[0].TurnsSinceReceipt != 2 {
+		t.Errorf("dead channel row = %+v, want armed+silent with 0 receipts and 2 silent turns", rows[0])
+	}
+	if rows[1].Armed || rows[1].Silent {
+		t.Errorf("unwatched channel row = %+v, want neither armed nor silent — publishing it as healthy would be a false all-clear", rows[1])
+	}
+}
+
+// TestHookLiveness_SnapshotIsSafeAlongsideOnActivity pins the one property the
+// CacheBloatDetector it mirrors does not need: its writer is the detector's
+// event loop, but Snapshot is read from the diagnostics HTTP handler. Run under
+// -race, this fails on an unsynchronised implementation.
+func TestHookLiveness_SnapshotIsSafeAlongsideOnActivity(t *testing.T) {
+	h := newLivenessHarness(3)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			h.turn("s")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_ = h.w.Snapshot()
+			_ = h.w.Silent(livenessAdapter)
+		}
+	}()
+	wg.Wait()
+}
+
+// TestHookLiveness_NilWatchdogIsInert: SetHookLivenessWatchdog(nil) is the
+// documented way to disable it, so every entry point must tolerate a nil
+// receiver the way CacheBloatDetector's does.
+func TestHookLiveness_NilWatchdogIsInert(t *testing.T) {
+	var w *HookLivenessWatchdog
+	w.SetChannelReady(nil)
+	w.Forget("s")
+	if w.enabled() || w.Silent("x") || w.Snapshot() != nil {
+		t.Error("a nil watchdog must be completely inert")
+	}
+	if got := w.OnActivity(&session.SessionState{SessionID: "s", Metrics: &session.SessionMetrics{}}); got.Transition != HookLivenessUnchanged {
+		t.Errorf("OnActivity on a nil watchdog returned %v", got.Transition)
+	}
+}
+
+// TestHookLiveness_FirstObservationOfASessionIsNotATurn is the review finding
+// that a daemon restart alone could convict a healthy channel.
+//
+// lastDone starts unset, so without a "have I seen this session before" flag an
+// unseeded lookup reads false and a session whose transcript is ALREADY at a
+// turn boundary registers a rising edge on its very first pass — for a turn
+// that completed before the watchdog existed. refreshStaleSessions re-reads
+// every persisted working session at startup, so N such sessions donate N
+// phantom turns in one tick, with no agent having run and no hook having had a
+// chance to arrive.
+func TestHookLiveness_FirstObservationOfASessionIsNotATurn(t *testing.T) {
+	h := newLivenessHarness(3)
+
+	// Six distinct sessions, each observed exactly once, each already done —
+	// the shape of a startup re-read.
+	for i := 0; i < 6; i++ {
+		sid := fmt.Sprintf("restored-%d", i)
+		got := h.w.OnActivity(&session.SessionState{
+			SessionID: sid,
+			Adapter:   livenessAdapter,
+			Metrics:   &session.SessionMetrics{LastEventType: "turn_done"},
+		})
+		if got.Transition != HookLivenessUnchanged {
+			t.Fatalf("session %s: first observation produced %v — a turn that finished before the watchdog was watching is not evidence of silence", sid, got.Transition)
+		}
+	}
+	if h.w.Silent(livenessAdapter) {
+		t.Fatal("a daemon restart re-reading persisted sessions convicted a channel that was never given a chance to deliver")
+	}
+
+	// And the seeding must not deafen it: real turns on those same sessions
+	// still count.
+	for i := 0; i < 3; i++ {
+		h.turn("restored-0")
+	}
+	if !h.w.Silent(livenessAdapter) {
+		t.Error("seeding the first observation swallowed the real turns that followed")
+	}
+}
+
+// TestHookLiveness_ForgottenSessionDoesNotDonateAPhantomTurn: Forget deletes
+// the rising-edge entry, so a session reaped and later revived is a first
+// observation again and must be seeded, not counted.
+func TestHookLiveness_ForgottenSessionDoesNotDonateAPhantomTurn(t *testing.T) {
+	// Threshold 1, so the single phantom turn this guards against is on its own
+	// enough to convict. At 2 the test passes against the bug.
+	h := newLivenessHarness(1)
+	h.pass("s", false)
+	h.w.Forget("s")
+
+	if got := h.pass("s", true); got.Transition != HookLivenessUnchanged {
+		t.Fatalf("a revived session's first pass produced %v", got.Transition)
+	}
+	if h.w.Silent(livenessAdapter) {
+		t.Error("reap-then-revive donated a phantom turn")
+	}
+}

--- a/core/application/services/permission_hook_channel_test.go
+++ b/core/application/services/permission_hook_channel_test.go
@@ -1,0 +1,123 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/config"
+	"irrlicht/core/domain/permission"
+)
+
+// --- #1368: what "the hook channel is expected to deliver" means ----------
+//
+// HookChannelReady is the predicate that ARMS the liveness watchdog, so every
+// case it gets wrong is a wrong verdict downstream: a false positive convicts a
+// channel that was never installed, and a false negative leaves a genuinely
+// dead one unwatched.
+
+// hookAgentDecl declares an agent whose "hooks" permission is a real hook
+// install, plus a modify permission that is NOT one. The second is the case
+// that separates "this agent has a granted permission" from "this agent's hook
+// channel is installed", and it is the easy one to conflate.
+func hookAgentDecl(f *applyFailure) agent.Agent {
+	return agent.Agent{
+		Identity: agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
+		Process:  agent.Process{Match: agent.ExactName{Name: "testagent"}},
+		Permissions: []agent.Permission{
+			{Key: "hooks", Kind: permission.KindModify, Title: "Install hooks",
+				Hooks: &agent.HookInstall{}, Apply: f.apply, Remove: f.remove},
+			{Key: "statusline", Kind: permission.KindModify, Title: "Install statusline",
+				Apply: func() error { return nil }, Remove: func() error { return nil }},
+		},
+	}
+}
+
+func newHookChannelService(t *testing.T, f *applyFailure) *services.PermissionService {
+	t.Helper()
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:    []agent.Agent{hookAgentDecl(f)},
+		Store:     &mockPermStore{},
+		Push:      &mockPush{},
+		Log:       &mockLogger{},
+		Mode:      config.PermissionModeAsk,
+		Registrar: &mockRegistrar{},
+	})
+	svc.Start(context.Background())
+	return svc
+}
+
+// A permission nobody has answered is not an installed channel.
+func TestHookChannelReady_FalseWhilePending(t *testing.T) {
+	svc := newHookChannelService(t, &applyFailure{})
+	if svc.HookChannelReady("testagent") {
+		t.Error("a pending hook permission must not arm the watchdog — there is nothing installed to be silent")
+	}
+}
+
+// The positive case: granted, and the install closure succeeded.
+func TestHookChannelReady_TrueOnceGrantedAndApplied(t *testing.T) {
+	f := &applyFailure{}
+	svc := newHookChannelService(t, f)
+
+	if err := svc.Answer([]services.PermissionAnswer{
+		{Agent: "testagent", Permission: "hooks", Grant: true},
+	}); err != nil {
+		t.Fatalf("Answer: %v", err)
+	}
+	waitFor(t, "the hook channel to read ready", func() bool { return svc.HookChannelReady("testagent") })
+}
+
+// TestHookChannelReady_FalseWhenTheInstallFailed is the #1362 boundary, and the
+// load-bearing one.
+//
+// A granted permission whose Apply failed means the user said yes and the
+// entries were NOT written. Arming the watchdog there would let it convict the
+// channel for not delivering through entries that never existed — reporting, in
+// vaguer words and against a different issue number, a failure that #1362
+// already reports accurately with its actual error string attached.
+func TestHookChannelReady_FalseWhenTheInstallFailed(t *testing.T) {
+	f := &applyFailure{failApplyFor: -1}
+	svc := newHookChannelService(t, f)
+
+	if err := svc.Answer([]services.PermissionAnswer{
+		{Agent: "testagent", Permission: "hooks", Grant: true},
+	}); err != nil {
+		t.Fatalf("Answer: %v", err)
+	}
+	waitFor(t, "the failing Apply to run", func() bool { applied, _ := f.calls(); return applied > 0 })
+
+	if svc.HookChannelReady("testagent") {
+		t.Error("a granted permission whose Apply failed reads as an installed channel — " +
+			"the watchdog would report 'installed but silent' for entries that were never written")
+	}
+}
+
+// A granted permission that is not a hook install must not vouch for the hook
+// channel. Without the Hooks!=nil term, granting a statusline or a transcripts
+// permission would arm the watchdog against an adapter with no hooks at all.
+func TestHookChannelReady_IgnoresNonHookPermissions(t *testing.T) {
+	svc := newHookChannelService(t, &applyFailure{})
+
+	if err := svc.Answer([]services.PermissionAnswer{
+		{Agent: "testagent", Permission: "statusline", Grant: true},
+	}); err != nil {
+		t.Fatalf("Answer: %v", err)
+	}
+	waitFor(t, "the statusline grant to settle", func() bool {
+		return svc.Granted("testagent", "statusline")
+	})
+
+	if svc.HookChannelReady("testagent") {
+		t.Error("a granted non-hook permission armed the hook watchdog")
+	}
+}
+
+// An adapter the registry does not know cannot have a channel.
+func TestHookChannelReady_FalseForAnUnknownAgent(t *testing.T) {
+	svc := newHookChannelService(t, &applyFailure{})
+	if svc.HookChannelReady("no-such-agent") {
+		t.Error("an unknown agent must not read as ready")
+	}
+}

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -283,6 +283,41 @@ func (s *PermissionService) Granted(agentName, key string) bool {
 	return s.set.Get(agentName, key) == permission.StateGranted
 }
 
+// HookChannelReady reports whether agentName's hook channel is EXPECTED to
+// deliver: it declares at least one hook-install permission that is granted and
+// whose apply effect did not fail (issue #1368).
+//
+// This is the daemon's best knowledge that our entries are in the agent's
+// config, and it is deliberately built from what the daemon DID rather than
+// from re-reading the file. Re-reading would cost a JSON parse per turn on the
+// classify path, and it would answer a different question anyway — #1372's
+// question, "are the entries still there", which is a separate diagnosis with a
+// separate fix.
+//
+// The effect-failure term is load-bearing, not defensive. A granted permission
+// whose Apply failed means the user said yes and the hooks are NOT installed
+// (#1362), so this must read false — see hook_liveness.go's header for why
+// convicting that channel of silence would report a known failure in weaker
+// words and against the wrong issue.
+func (s *PermissionService) HookChannelReady(agentName string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, a := range s.agents {
+		if a.Identity.Name != agentName {
+			continue
+		}
+		for _, p := range a.Permissions {
+			if p.Hooks == nil {
+				continue
+			}
+			if s.set.Get(agentName, p.Key) == permission.StateGranted && !s.effectFailedLocked(agentName, p.Key) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Snapshot returns the full consent state for GET /api/v1/permissions.
 func (s *PermissionService) Snapshot() PermissionsSnapshot {
 	s.mu.Lock()

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -121,6 +121,7 @@ type SessionDetector struct {
 	costTracker    outbound.CostTracker    // optional; nil = disabled
 	historyTracker outbound.HistoryTracker // optional; nil = disabled
 	cacheBloat     *CacheBloatDetector     // optional; nil = disabled (#374)
+	hookLiveness   *HookLivenessWatchdog   // optional; nil = disabled (#1368)
 	metrics        outbound.MetricsCollector
 
 	// projectSessions tracks sessionID → projectDir for pre-session cleanup.
@@ -447,6 +448,14 @@ func (d *SessionDetector) SetHistoryTracker(h outbound.HistoryTracker) {
 // Pass nil to disable.
 func (d *SessionDetector) SetCacheBloatDetector(c *CacheBloatDetector) {
 	d.cacheBloat = c
+}
+
+// SetHookLivenessWatchdog wires the optional per-adapter hook-liveness watchdog
+// (#1368). When set, each processActivity pass drives it so an adapter whose
+// hook channel has stopped delivering is demoted to TierTranscript and its
+// pinned hook-tier holds are released. Pass nil to disable.
+func (d *SessionDetector) SetHookLivenessWatchdog(w *HookLivenessWatchdog) {
+	d.hookLiveness = w
 }
 
 // SetLauncherEnvReader installs a reader that captures terminal/IDE identity

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -812,6 +812,14 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 	// Overlay is what decides whether it has been open long enough to apply.
 	d.armStalledEditTool(state, passStart)
 
+	// Hook-liveness watchdog (#1368), before the overlay on purpose. It counts
+	// turns off transcript-derived IsAgentDone, and Overlay is what writes the
+	// hook-sourced turn-done onto that field — so measuring after it would let
+	// the channel under test contribute to its own alibi. Reading first also
+	// means a demotion decided this pass releases this pass's holds, rather
+	// than leaving the session pinned for one more.
+	releasedHookHolds := d.checkHookLiveness(state, passStart)
+
 	expiries := d.signals.Overlay(state.SessionID, state.Metrics, passStart)
 	d.reportHoldExpiries(state, expiries, passStart)
 
@@ -853,7 +861,17 @@ func (d *SessionDetector) classifyAndTransition(state *session.SessionState, ev 
 	// current state out from under the verdict; a hold ceiling changed the
 	// metrics it read. Folded here rather than passed separately so the gate
 	// keeps one question, and because the last two are also read below.
-	rebased := state.State != stateBeforeSynthesis || len(expiries) > 0
+	// releasedHookHolds is the #1368 sibling of the expiry term, and it has to
+	// be here rather than fall out of expiries: checkHookLiveness deletes the
+	// hold BEFORE Overlay runs, so a watchdog release can never appear in
+	// expiries. admitTransition's argument for exempting a ceiling expiry
+	// applies verbatim — the hold is gone and nothing re-asserts it, so
+	// debouncing the un-pinning only delays it — and with the hook hold dropped
+	// the deciding rule is transcript-tier by construction, so the TierHook arm
+	// below cannot rescue it either. Without this term the watchdog's whole
+	// point (relief in minutes rather than #1360's twelve hours) is handed
+	// straight back to a dwell.
+	rebased := state.State != stateBeforeSynthesis || len(expiries) > 0 || releasedHookHolds > 0
 	authoritative := verdict.Tier == session.TierHook || rebased
 
 	if d.admitTransition(state, newState, authoritative, passStart) {
@@ -1516,6 +1534,110 @@ func (d *SessionDetector) reclassifyFromTranscript(state *session.SessionState, 
 		SessionID:      state.SessionID,
 		TranscriptPath: state.TranscriptPath,
 	})
+}
+
+// checkHookLiveness drives the per-adapter hook-liveness watchdog and acts on
+// its verdict (#1368).
+//
+// # Why a demotion must also release the channel's holds
+//
+// This is the question the issue asks, and the answer is yes: the holds ARE the
+// tier being lowered, so a demotion that left them standing would demote
+// nothing — the session stays pinned at waiting by the very channel just
+// declared dead, and the only observable change is a row in a diagnostics
+// bundle. The rest of the argument — why the evidence already collected covers
+// those holds, and why releasing one cannot invent a state — lives on
+// SignalHolds.ReleaseTier, next to the mechanism, and is deliberately not
+// restated here.
+//
+// What is only true at this altitude: #1360's 12-hour ceilings already drop
+// these holds, so this changes WHEN, not WHETHER, and that is the whole value.
+// Five turns is minutes; twelve hours is a working day of a session stuck at
+// the wrong state. The ceiling remains the backstop for the case the watchdog
+// cannot see — an adapter that produces no further turns at all, where there is
+// no evidence to convict on. Two mechanisms, different evidence, deliberately
+// not merged.
+func (d *SessionDetector) checkHookLiveness(state *session.SessionState, at time.Time) int {
+	// d.signals is guarded for the reason forgetSessionScopedState states: it
+	// is not nil-safe, and struct-literal test detectors reach these paths
+	// without one.
+	if d.hookLiveness == nil || state == nil || d.signals == nil {
+		return 0
+	}
+
+	change := d.hookLiveness.OnActivity(state)
+	switch change.Transition {
+	case HookLivenessSilent:
+		d.log.LogError(logComponentSessionDetector, state.SessionID, fmt.Sprintf(
+			"hook channel for %s looks dead: %d completed turns with zero hook requests received, "+
+				"while its hook consent is granted and its install reported success (%d hook requests seen in total "+
+				"this process). Treating %s as %v tier until a hook arrives; any hook-tier holds it placed are being "+
+				"released. If the entries have since been removed from the agent's config this reports the same way — "+
+				"check them before assuming the receiver is at fault.",
+			change.Adapter, change.SilentTurns, change.Receipts, change.Adapter, session.TierTranscript))
+		d.record(lifecycle.Event{
+			Kind:          lifecycle.KindHookChannelSilent,
+			Timestamp:     at,
+			SessionID:     state.SessionID,
+			Adapter:       change.Adapter,
+			SignalTier:    session.TierTranscript.String(),
+			SilentTurns:   change.SilentTurns,
+			TurnThreshold: change.Threshold,
+			HookReceipts:  change.Receipts,
+		})
+	case HookLivenessRecovered:
+		d.log.LogInfo(logComponentSessionDetector, state.SessionID, fmt.Sprintf(
+			"hook channel for %s is delivering again after being treated as dead; hook-tier signals are authoritative "+
+				"for it once more", change.Adapter))
+		d.record(lifecycle.Event{
+			Kind:          lifecycle.KindHookChannelRecovered,
+			Timestamp:     at,
+			SessionID:     state.SessionID,
+			Adapter:       change.Adapter,
+			SignalTier:    session.TierHook.String(),
+			TurnThreshold: change.Threshold,
+			HookReceipts:  change.Receipts,
+		})
+	case HookLivenessUnchanged:
+		// The common case, and the silent one.
+	}
+
+	if !change.Silent {
+		return 0
+	}
+	// Swept every pass while the adapter is silent, not once at the moment of
+	// demotion. A hold placed just before the verdict, or a session that only
+	// becomes active afterwards, would otherwise stay pinned — and ReleaseTier
+	// is a no-op on a session holding nothing, so the repetition is free.
+	released := d.signals.ReleaseTier(state.SessionID, session.TierHook, at)
+	d.reportSilentChannelReleases(state, released, at)
+	return len(released)
+}
+
+// reportSilentChannelReleases logs and records the hook-tier holds dropped
+// because their channel was declared silent (#1368).
+//
+// Split from reportHoldExpiries rather than folded into it: the two describe
+// different failures — one hold outliving its ceiling versus one channel
+// outliving its usefulness — and a reader who cannot tell them apart from the
+// recorded trace cannot tell which of the two fixes applies.
+func (d *SessionDetector) reportSilentChannelReleases(state *session.SessionState, released []session.SignalRelease, at time.Time) {
+	for _, r := range released {
+		d.log.LogInfo(logComponentSessionDetector, state.SessionID, fmt.Sprintf(
+			"released held signal %q (%v tier) after %v: the %s hook channel that placed it has stopped delivering, "+
+				"so the session is no longer pinned by it",
+			r.Kind, r.Tier, r.HeldFor.Round(time.Second), state.Adapter))
+
+		d.record(lifecycle.Event{
+			Kind:       lifecycle.KindHookHoldReleased,
+			Timestamp:  at,
+			SessionID:  state.SessionID,
+			Adapter:    state.Adapter,
+			SignalKind: string(r.Kind),
+			SignalTier: r.Tier.String(),
+			HeldForMS:  r.HeldFor.Milliseconds(),
+		})
+	}
 }
 
 // reportHoldExpiries surfaces the holds Overlay dropped because their

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -61,6 +61,12 @@ func (d *SessionDetector) forgetSessionScopedState(sessionID string) {
 	}
 	d.dwell.DropSession(sessionID)
 
+	// The hook-liveness watchdog's rising-edge memory (#1368): one bool per
+	// session, kept for the life of the process otherwise, and a recycled
+	// session ID would inherit a stale "was done" and swallow its first turn.
+	// Nil-safe on its own receiver, so it needs no guard like signals above.
+	d.hookLiveness.Forget(sessionID)
+
 	d.idleMu.Lock()
 	delete(d.idleProjectRetryAttempts, sessionID)
 	d.idleMu.Unlock()

--- a/core/application/services/session_detector_hook_liveness_test.go
+++ b/core/application/services/session_detector_hook_liveness_test.go
@@ -1,0 +1,311 @@
+package services
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/session"
+)
+
+// livenessLogger captures every line at both levels. The package's
+// capturingLogger discards LogError, and the watchdog's verdict is deliberately
+// an error-level line — so reusing it would assert the demotion is reported by
+// reading a field that is never written.
+type livenessLogger struct {
+	mu    sync.Mutex
+	info  []string
+	error []string
+}
+
+func (l *livenessLogger) LogInfo(_, _, message string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.info = append(l.info, message)
+}
+
+func (l *livenessLogger) LogError(_, _, message string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.error = append(l.error, message)
+}
+
+func (l *livenessLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (l *livenessLogger) Close() error                                         { return nil }
+
+func (l *livenessLogger) joined() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return strings.Join(append(append([]string{}, l.info...), l.error...), "\n")
+}
+
+// livenessDetector wires the smallest detector that can run checkHookLiveness,
+// plus the watchdog harness driving it. Same shape the #1360 ceiling tests use.
+type livenessDetector struct {
+	d   *SessionDetector
+	h   *livenessHarness
+	lg  *livenessLogger
+	rec *ceilingRecorder
+}
+
+func newLivenessDetector(threshold int) *livenessDetector {
+	lg := &livenessLogger{}
+	rec := &ceilingRecorder{}
+	d := &SessionDetector{log: lg, recorder: rec, signals: session.NewSignalHolds()}
+	h := newLivenessHarness(threshold)
+	d.SetHookLivenessWatchdog(h.w)
+	return &livenessDetector{d: d, h: h, lg: lg, rec: rec}
+}
+
+// pass drives one processActivity-equivalent pass through checkHookLiveness and
+// returns the number of hook-tier holds it released — the value processActivity
+// folds into `rebased`. One definition of "a pass", so a change to the metrics
+// shape a turn is recognised by cannot leave some tests asserting against a
+// shape the detector no longer produces.
+func (ld *livenessDetector) pass(done bool, at time.Time) int {
+	m := &session.SessionMetrics{LastEventType: "turn_done"}
+	if !done {
+		m.HasOpenToolCall = true
+	}
+	return ld.d.checkHookLiveness(
+		&session.SessionState{SessionID: "s", Adapter: livenessAdapter, Metrics: m}, at)
+}
+
+func (ld *livenessDetector) turn(at time.Time) { ld.pass(false, at); ld.pass(true, at) }
+
+func (ld *livenessDetector) kinds(k lifecycle.Kind) []lifecycle.Event {
+	var out []lifecycle.Event
+	for _, ev := range ld.rec.events {
+		if ev.Kind == k {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+var livenessT0 = time.Date(2026, 8, 9, 9, 0, 0, 0, time.UTC)
+
+// TestSessionDetector_SilentHookChannelReleasesItsPinnedHolds is THE defect
+// test for #1368, stated at the altitude the failure is actually felt.
+//
+// The compound failure: a PermissionRequest hook lands and pins the session at
+// waiting with a TierHook hold, then the channel dies. The release POST that
+// would retire the hold travels over the same dead channel, so it never
+// arrives; the hold outranks every lower tier, so nothing may correct it; and
+// #1360's ceiling will not drop it for twelve hours. The session sits at the
+// wrong state for a working day.
+//
+// A watchdog that only logged and only wrote a diagnostics row would leave that
+// entirely intact — which is why the answer to "must the demotion also release
+// the holds" is yes: the holds ARE the tier the demotion claims to be lowering.
+func TestSessionDetector_SilentHookChannelReleasesItsPinnedHolds(t *testing.T) {
+	ld := newLivenessDetector(3)
+	ld.d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, livenessT0)
+
+	at := livenessT0.Add(2 * time.Hour)
+	for i := 0; i < 3; i++ {
+		ld.turn(at)
+	}
+
+	if ld.d.signals.Held("s", session.SignalPermissionPrompt) {
+		t.Fatal("the hold placed by a channel now proven dead is still pinning the session — the demotion demoted nothing")
+	}
+
+	// The altitude claim: with the hold gone, the classifier's inputs are no
+	// longer being rewritten by the dead channel.
+	m := &session.SessionMetrics{LastEventType: "turn_done"}
+	ld.d.signals.Overlay("s", m, at)
+	if m.PermissionPending {
+		t.Error("Overlay still applies the released hold — the session would stay pinned at waiting")
+	}
+
+	released := ld.kinds(lifecycle.KindHookHoldReleased)
+	if len(released) != 1 {
+		t.Fatalf("expected exactly one hook_hold_released event, got %d: %+v", len(released), ld.rec.events)
+	}
+	ev := released[0]
+	if ev.SignalKind != string(session.SignalPermissionPrompt) {
+		t.Errorf("SignalKind = %q, want %q", ev.SignalKind, session.SignalPermissionPrompt)
+	}
+	if ev.SignalTier != session.TierHook.String() {
+		t.Errorf("SignalTier = %q, want %q — the tier is what made the hold consequential", ev.SignalTier, session.TierHook.String())
+	}
+	if ev.HeldForMS != (2 * time.Hour).Milliseconds() {
+		t.Errorf("HeldForMS = %d, want %d", ev.HeldForMS, (2 * time.Hour).Milliseconds())
+	}
+	if ev.CeilingMS != 0 {
+		t.Errorf("CeilingMS = %d, want 0 — a ceiling expiry (#1360) and a dead-channel release (#1368) are different diagnoses and must not be told apart by guesswork", ev.CeilingMS)
+	}
+	if !ev.Timestamp.Equal(at) {
+		t.Errorf("Timestamp = %v, want the pass clock %v — a wall-time stamp would not replay", ev.Timestamp, at)
+	}
+	if !strings.Contains(ld.lg.joined(), "stopped delivering") {
+		t.Errorf("the release must be explained in the log, got:\n%s", ld.lg.joined())
+	}
+}
+
+// TestSessionDetector_SilentVerdictIsLoggedLoudlyAndRecorded is scope item 2's
+// "log loudly" half. Error level, because outbound.Logger has no level between
+// Info and Error and Info is where this class of failure was already hiding —
+// the argument #1364's IgnoreUnknownEvent makes for the same choice.
+func TestSessionDetector_SilentVerdictIsLoggedLoudlyAndRecorded(t *testing.T) {
+	ld := newLivenessDetector(2)
+	at := livenessT0
+	ld.turn(at)
+	ld.turn(at)
+
+	if len(ld.lg.error) != 1 {
+		t.Fatalf("expected exactly one error-level line for the verdict, got %d: %v", len(ld.lg.error), ld.lg.error)
+	}
+	line := ld.lg.error[0]
+	for _, want := range []string{livenessAdapter, "zero hook requests", "granted", "install reported success", "transcript"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("the verdict line must mention %q so a reader can tell this failure from its two neighbours; got:\n%s", want, line)
+		}
+	}
+
+	silent := ld.kinds(lifecycle.KindHookChannelSilent)
+	if len(silent) != 1 {
+		t.Fatalf("expected one hook_channel_silent event, got %d: %+v", len(silent), ld.rec.events)
+	}
+	ev := silent[0]
+	if ev.Adapter != livenessAdapter {
+		t.Errorf("Adapter = %q, want %q", ev.Adapter, livenessAdapter)
+	}
+	if ev.SignalTier != session.TierTranscript.String() {
+		t.Errorf("SignalTier = %q, want %q — the event should say what the adapter was demoted TO", ev.SignalTier, session.TierTranscript.String())
+	}
+	if ev.SilentTurns != 2 || ev.TurnThreshold != 2 {
+		t.Errorf("SilentTurns/TurnThreshold = %d/%d, want 2/2", ev.SilentTurns, ev.TurnThreshold)
+	}
+}
+
+// TestSessionDetector_LiveHookChannelKeepsItsHolds is a LOCK: it pins behaviour
+// that must not change, and it passes by construction on main because nothing
+// released holds there at all. Its job is to fail if the release ever escapes
+// the silent-channel condition and starts dropping holds on a healthy channel —
+// which would break every hook-driven state transition in the product.
+func TestSessionDetector_LiveHookChannelKeepsItsHolds(t *testing.T) {
+	ld := newLivenessDetector(3)
+	ld.d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, livenessT0)
+
+	at := livenessT0.Add(time.Minute)
+	for i := 0; i < 10; i++ {
+		ld.h.hookArrives()
+		ld.turn(at)
+	}
+
+	if !ld.d.signals.Held("s", session.SignalPermissionPrompt) {
+		t.Fatal("a live channel's hold was released — hook-driven waiting detection would stop working")
+	}
+	if len(ld.rec.events) != 0 {
+		t.Errorf("a healthy channel must record nothing, got %+v", ld.rec.events)
+	}
+}
+
+// TestSessionDetector_RecoveredChannelStopsReleasingHolds closes the loop: once
+// hooks resume, a newly placed hold must survive. A released hold is not a
+// tombstone.
+func TestSessionDetector_RecoveredChannelStopsReleasingHolds(t *testing.T) {
+	ld := newLivenessDetector(2)
+	at := livenessT0
+	ld.turn(at)
+	ld.turn(at)
+	if !ld.h.w.Silent(livenessAdapter) {
+		t.Fatal("precondition: expected a silent channel")
+	}
+
+	ld.h.hookArrives()
+	ld.pass(true, at)
+	ld.d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, at)
+	ld.pass(false, at)
+
+	if !ld.d.signals.Held("s", session.SignalPermissionPrompt) {
+		t.Fatal("a hold placed after recovery was released — the demotion behaved as a latch")
+	}
+	if len(ld.kinds(lifecycle.KindHookChannelRecovered)) != 1 {
+		t.Errorf("expected one hook_channel_recovered event, got %+v", ld.rec.events)
+	}
+}
+
+// TestSessionDetector_HookLivenessDisabledDoesNothing: the kill switch, and the
+// nil-watchdog path the detector's other collaborators all honour.
+func TestSessionDetector_HookLivenessDisabledDoesNothing(t *testing.T) {
+	for name, threshold := range map[string]int{"kill_switch": 0, "enabled": 3} {
+		t.Run(name, func(t *testing.T) {
+			ld := newLivenessDetector(threshold)
+			if name == "enabled" {
+				ld.d.SetHookLivenessWatchdog(nil)
+			}
+			ld.d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, livenessT0)
+			for i := 0; i < 20; i++ {
+				ld.turn(livenessT0)
+			}
+			if !ld.d.signals.Held("s", session.SignalPermissionPrompt) {
+				t.Error("a disabled watchdog must not touch holds")
+			}
+			if len(ld.rec.events) != 0 || len(ld.lg.error) != 0 {
+				t.Errorf("a disabled watchdog must be silent, got %+v / %v", ld.rec.events, ld.lg.error)
+			}
+		})
+	}
+}
+
+// TestSessionDetector_CheckHookLivenessReportsWhatItReleased is the review
+// finding that the un-pinning was being handed straight back to #1366's grace
+// timer.
+//
+// checkHookLiveness deletes the hold BEFORE Overlay runs, so a watchdog release
+// can never show up in the `expiries` slice that processActivity folds into
+// `rebased`. Without a separate signal the pass is not authoritative,
+// admitTransition defers to the dwell, and the correction the watchdog exists
+// to deliver in minutes is debounced — while admitTransition's own doc argues
+// the identical ceiling-expiry case must bypass the dwell precisely because the
+// hold is gone and nothing re-asserts it.
+//
+// The count returned here is that signal; processActivity ORs it into `rebased`
+// alongside len(expiries).
+func TestSessionDetector_CheckHookLivenessReportsWhatItReleased(t *testing.T) {
+	// Threshold 1: with the first observation of a session now seeded rather
+	// than counted, the pass below is the seed and the one after it is the
+	// first real turn boundary.
+	ld := newLivenessDetector(1)
+	ld.d.signals.Hold("s", session.SignalPermissionPrompt, session.SignalPayload{}, livenessT0)
+	ld.d.signals.Hold("s", session.SignalIdlePrompt, session.SignalPayload{}, livenessT0)
+
+	at := livenessT0.Add(time.Minute)
+	if got := ld.pass(false, at); got != 0 {
+		t.Fatalf("a pass with no verdict reported %d releases, want 0 — a false positive here makes every pass authoritative and disables the dwell", got)
+	}
+
+	// The first real turn boundary crosses the threshold; both hook-tier holds go.
+	released := ld.pass(true, at)
+	if released != 2 {
+		t.Fatalf("reported %d releases, want 2 — processActivity reads this to decide the pass is authoritative, so a zero here silently re-debounces the un-pinning", released)
+	}
+
+	// And once everything is released, later sweeps report nothing, so a
+	// permanently-dead channel does not permanently disable the dwell.
+	if got := ld.pass(false, at); got != 0 {
+		t.Fatalf("a sweep that released nothing reported %d — a silent channel would make every subsequent pass authoritative", got)
+	}
+}
+
+// TestSessionDetector_HookLivenessToleratesAMissingHoldStore is the review's
+// nil-guard finding: forgetSessionScopedState guards d.signals with an explicit
+// "not nil-safe, struct-literal test detectors reach this without one", and
+// this path must not take the opposite position.
+func TestSessionDetector_HookLivenessToleratesAMissingHoldStore(t *testing.T) {
+	ld := newLivenessDetector(1)
+	ld.d.signals = nil
+
+	// Two passes, so the channel is actually convicted and the sweep — the only
+	// line that touches d.signals — is really reached. One pass returns before
+	// it and would prove nothing.
+	ld.pass(false, livenessT0)
+	if got := ld.pass(true, livenessT0); got != 0 {
+		t.Fatalf("got %d releases from a detector with no hold store", got)
+	}
+}

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -41,9 +41,10 @@ func (d *SessionDetector) onRemoved(ev agent.Event) {
 
 	// Drop every per-session store — a hook that fired without a clearing
 	// partner (e.g. an agent crash mid-overlay), a decided-but-unpublished
-	// #1366 transition, an idle-retry counter. Any of them left behind is
-	// permanent, and a recycled session ID would inherit it. One seam, shared
-	// with the PIDManager reap path; see forgetSessionScopedState.
+	// #1366 transition, an idle-retry counter, the hook-liveness watchdog's
+	// rising-edge memory (#1368). Any of them left behind is permanent, and a
+	// recycled session ID would inherit it. One seam, shared with the
+	// PIDManager reap path; see forgetSessionScopedState.
 	d.forgetSessionScopedState(ev.SessionID)
 
 	state, err := d.repo.Load(ev.SessionID)

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -15,6 +15,7 @@ import (
 	"irrlicht/core/adapters/inbound/agents"
 	"irrlicht/core/adapters/inbound/agents/agentwiring"
 	"irrlicht/core/adapters/inbound/agents/claudecode"
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/adapters/outbound/filesystem"
 	"irrlicht/core/adapters/outbound/git"
 	"irrlicht/core/adapters/outbound/gtbin"
@@ -335,6 +336,19 @@ func runDaemon() {
 		defer pwCleanup()
 	}
 
+	// Hook-liveness watchdog (#1368). Built here because it has two consumers
+	// on opposite sides of startup — the diagnostics bundle registered a few
+	// lines below, and the detector built further down — and neither exists
+	// yet. Its two collaborators are injected as they appear; until both are,
+	// it reports every channel disarmed, which is honest: no hook can have been
+	// served before the receivers are registered either.
+	hookLiveness := services.NewHookLivenessWatchdog(services.HookLivenessConfig{
+		SilentTurns:    cfg.HookSilentTurns,
+		DefaultAdapter: claudecode.AdapterName,
+		Adapters:       hookAdapterNames(allAgents),
+		Receipts:       hookjson.HookReceiptsFor,
+	})
+
 	mux := http.NewServeMux()
 	registerCoreRoutes(mux, registerCoreRoutesDeps{
 		FSRepo:            fsRepo,
@@ -345,6 +359,7 @@ func runDaemon() {
 		Version:           Version,
 		PublishController: rel.publishController,
 		Cfg:               cfg,
+		HookLiveness:      hookLiveness,
 	})
 
 	// Static web UI: served from disk so the dashboard ships as three files
@@ -417,6 +432,13 @@ func runDaemon() {
 		StartGastown:     startGastown,
 		StopGastown:      stopGastown,
 	})
+
+	// The watchdog's second collaborator, available only now: "is this channel
+	// expected to deliver" is a consent question, and answering it before the
+	// permission service exists would arm the watchdog against channels nobody
+	// has agreed to install yet.
+	hookLiveness.SetChannelReady(permService.HookChannelReady)
+	detector.SetHookLivenessWatchdog(hookLiveness)
 
 	backchannelEngine, terminalObserver := setupBackchannel(mux, setupBackchannelDeps{
 		CachedRepo:        cachedRepo,

--- a/core/cmd/irrlichd/paths.go
+++ b/core/cmd/irrlichd/paths.go
@@ -115,21 +115,49 @@ func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Ag
 // diagnostics bundle (issue #1364). Only the daemon wires it: these counters
 // accumulate in whatever process served the hooks, and --diagnose is not that
 // process.
-func liveHookHealth() services.HookHealthSnapshot {
-	rows := hookjson.UnknownEvents()
-	snap := services.HookHealthSnapshot{
-		UnknownEvents:       make([]services.UnknownHookEvent, 0, len(rows)),
-		UnknownNamesDropped: hookjson.UnknownEventNamesDropped(),
-		UnknownEventsTotal:  hookjson.UnknownEventTotal(),
+// watchdog carries the liveness half (#1368) and may be nil, which reads the
+// same way the whole function being absent does: the counters are omitted, not
+// zeroed.
+func liveHookHealth(watchdog *services.HookLivenessWatchdog) func() services.HookHealthSnapshot {
+	return func() services.HookHealthSnapshot {
+		rows := hookjson.UnknownEvents()
+		snap := services.HookHealthSnapshot{
+			UnknownEvents:       make([]services.UnknownHookEvent, 0, len(rows)),
+			UnknownNamesDropped: hookjson.UnknownEventNamesDropped(),
+			UnknownEventsTotal:  hookjson.UnknownEventTotal(),
+			Channels:            watchdog.Snapshot(),
+			ReceiptsTotal:       hookjson.HookReceiptTotal(),
+		}
+		for _, row := range rows {
+			snap.UnknownEvents = append(snap.UnknownEvents, services.UnknownHookEvent{
+				Adapter: row.Adapter,
+				Event:   row.Event,
+				Count:   row.Count,
+			})
+		}
+		return snap
 	}
-	for _, row := range rows {
-		snap.UnknownEvents = append(snap.UnknownEvents, services.UnknownHookEvent{
-			Adapter: row.Adapter,
-			Event:   row.Event,
-			Count:   row.Count,
-		})
+}
+
+// hookAdapterNames lists the adapters that declare a hook install, so the
+// liveness watchdog can publish a row for a channel that has produced no
+// traffic at all — the most telling row in a bundle from a user whose hooks
+// never worked once.
+//
+// Derived from the registry rather than written out, for the reason all.go
+// exists: a hook-receiving adapter added later must not have to remember to
+// appear here.
+func hookAdapterNames(allAgents []agent.Agent) []string {
+	var out []string
+	for _, a := range allAgents {
+		for _, p := range a.Permissions {
+			if p.Hooks != nil {
+				out = append(out, a.Identity.Name)
+				break
+			}
+		}
 	}
-	return snap
+	return out
 }
 
 // runDiagnose writes a diagnostics bundle to the current directory and exits.

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -379,6 +379,10 @@ type registerCoreRoutesDeps struct {
 	Version           string
 	PublishController *relay.PublishController
 	Cfg               config.Config
+	// HookLiveness supplies the per-adapter hook-liveness rows for hooks.json
+	// (#1368). Built before this call because the diagnostics bundle is
+	// registered earlier in startup than the detector that drives it.
+	HookLiveness *services.HookLivenessWatchdog
 }
 
 // registerCoreRoutes wires the always-on API surface: session state, the
@@ -408,7 +412,7 @@ func registerCoreRoutes(mux *http.ServeMux, deps registerCoreRoutesDeps) {
 	// per-PID liveness, trimmed logs, and config for bug reports. Localhost
 	// only — it carries session paths and (pre-redaction) process argv. Reads
 	// fsRepo directly for a fresh, uncached snapshot.
-	diagSvc := buildDiagnostics(deps.FSRepo, deps.AllAgents, deps.Cfg, liveHookHealth)
+	diagSvc := buildDiagnostics(deps.FSRepo, deps.AllAgents, deps.Cfg, liveHookHealth(deps.HookLiveness))
 	mux.HandleFunc("GET /debug/bundle", localhostOnly(handleDiagnosticsBundle(diagSvc)))
 }
 

--- a/core/domain/config/config.go
+++ b/core/domain/config/config.go
@@ -53,6 +53,59 @@ const (
 	defaultCacheBloatMinTurns          = 3
 )
 
+// defaultHookSilentTurns is how many consecutive completed turns an adapter may
+// produce with zero hook receipts before its hook channel is declared silent
+// and the adapter falls back to TierTranscript (issue #1368).
+//
+// The rationale, and why five rather than one or fifty:
+//
+// The expected rate is at least one hook event per completed turn, not per
+// session and not per hour. Both hook-receiving adapters install a Stop hook —
+// claudecode's installedHookEvents includes HookStop, and codex's Stop is the
+// authoritative turn-done push (#1171) — so on a healthy channel every turn
+// boundary the daemon counts should be accompanied by at least one receipt, and
+// a permission-heavy turn produces several. That makes zero-over-N a genuine
+// signal rather than an inference from silence, and it is why the threshold is
+// counted in TURNS: a wall-clock window cannot tell a dead channel from a user
+// at lunch, which is precisely the ambiguity this exists to remove.
+//
+// One turn would already be suspicious and is far too twitchy to act on. The
+// daemon's turn boundary is a rising edge of transcript-derived IsAgentDone,
+// which is deliberately independent of the channel under test, so the two
+// clocks can interleave: a Stop hook can land just after the pass that counted
+// its turn, an install can complete mid-turn, and a session already in flight
+// when consent was granted owes no receipt for the turn it was in. Each of
+// those costs at most one or two turns. Five clears all of them with margin.
+//
+// The upper bound is set by what the demotion is FOR. Its most consequential
+// effect is releasing hook-tier holds that would otherwise pin a session at
+// waiting until #1360's 12-hour ceiling drops them. Five turns is minutes of
+// real use, so the watchdog is the fast path to that same relief; a threshold
+// in the tens would make it slower than the backstop it is meant to beat.
+//
+// The premise is an adapter fact, and it is not currently declarable: the
+// watchdog arms on any adapter declaring a HookInstall, while the "at least one
+// receipt per turn" expectation comes from both current adapters happening to
+// install a Stop hook. A future #1355 adapter that installs only, say, a
+// permission hook would owe no receipt on a quiet turn and be convicted at this
+// threshold. Surfacing the installed event set on agent.HookInstall is the fix
+// when that adapter arrives; until then the env var is the escape hatch.
+//
+// One caveat the count deliberately carries rather than hides: silent turns are
+// aggregated PER ADAPTER, while the excuses above are per session. A session
+// already in flight at the instant consent is granted owes no receipt for the
+// turn it is in, so N such sessions can donate N uncredited turns at once. Two
+// things bound that. The watchdog seeds a session's rising-edge memory on first
+// observation rather than counting it (see hook_liveness.go), which removes the
+// large source — a daemon restart re-reading every persisted working session —
+// entirely; and recovery is immediate on the first receipt with no turn
+// boundary required, so a burst at grant time self-corrects on the next hook
+// rather than latching.
+//
+// 0 (or a negative, which envInt rejects back to this default) disables the
+// watchdog entirely — the kill switch, matching CacheBloatThreshold's.
+const defaultHookSilentTurns = 5
+
 // Config holds daemon-wide runtime configuration.
 type Config struct {
 	MaxSessionAge      time.Duration
@@ -65,6 +118,10 @@ type Config struct {
 	CacheBloatThreshold          float64
 	CacheBloatVersionDeltaTokens int64
 	CacheBloatMinTurns           int
+
+	// HookSilentTurns is the hook-liveness watchdog's threshold (issue #1368),
+	// overridable via IRRLICHT_HOOK_SILENT_TURNS. 0 disables the watchdog.
+	HookSilentTurns int
 }
 
 // Default returns a Config populated with production defaults, with the
@@ -97,6 +154,8 @@ func Default() Config {
 		CacheBloatThreshold:          envFloat("IRRLICHT_CACHE_BLOAT_THRESHOLD", defaultCacheBloatThreshold),
 		CacheBloatVersionDeltaTokens: int64(envInt("IRRLICHT_CACHE_BLOAT_VERSION_DELTA", defaultCacheBloatVersionDeltaToken)),
 		CacheBloatMinTurns:           envInt("IRRLICHT_CACHE_BLOAT_MIN_TURNS", defaultCacheBloatMinTurns),
+
+		HookSilentTurns: envInt("IRRLICHT_HOOK_SILENT_TURNS", defaultHookSilentTurns),
 	}
 }
 

--- a/core/domain/lifecycle/event.go
+++ b/core/domain/lifecycle/event.go
@@ -70,6 +70,35 @@ const (
 	// never did. Rare by construction, and the one event that explains a
 	// session silently ceasing to be pinned at waiting.
 	KindHoldExpired Kind = "hold_expired"
+
+	// Hook-liveness watchdog (issue #1368). Three kinds, kept apart because
+	// they are three different facts and collapsing any two of them would
+	// re-create the ambiguity the watchdog exists to remove.
+	//
+	// KindHookChannelSilent: an adapter whose hook consent is granted and whose
+	// install reported success completed N turns without its receiver being
+	// handed a single request. The channel is treated as dead and the adapter
+	// falls back to TierTranscript. Distinct from the two neighbouring
+	// diagnoses that look identical from the outside: an install whose effect
+	// FAILED never wrote entries at all and is reported as a permission
+	// effect_error (#1362), and entries that were written and later went
+	// missing are #1372's subject. This event says entries were written, the
+	// daemon believes they are there, and nothing is coming.
+	KindHookChannelSilent Kind = "hook_channel_silent"
+
+	// KindHookChannelRecovered: a receipt arrived for an adapter previously
+	// declared silent. The demotion is a health signal, not a latch — this is
+	// the event that proves it, and its absence after a silent event is what
+	// says the channel never came back.
+	KindHookChannelRecovered Kind = "hook_channel_recovered"
+
+	// KindHookHoldReleased: one TierHook hold dropped because the watchdog
+	// declared its channel silent. Deliberately NOT KindHoldExpired: that one
+	// means a single hold outlived its wall-clock ceiling (#1360), which is a
+	// statement about elapsed time on one session. This one means the channel
+	// that placed the hold stopped delivering, which is a statement about the
+	// adapter. Same visible outcome, opposite investigation.
+	KindHookHoldReleased Kind = "hook_hold_released"
 )
 
 // Event is a single recorded lifecycle signal. The Kind field discriminates
@@ -137,6 +166,19 @@ type Event struct {
 	SignalTier string `json:"signal_tier,omitempty"`
 	HeldForMS  int64  `json:"held_for_ms,omitempty"`
 	CeilingMS  int64  `json:"ceiling_ms,omitempty"`
+
+	// Hook-liveness watchdog (KindHookChannelSilent / KindHookChannelRecovered,
+	// issue #1368). SilentTurns is how many consecutive completed turns the
+	// adapter produced with no hook receipt; TurnThreshold is the bound that
+	// was crossed. Both are recorded for the reason CeilingMS is: the threshold
+	// is tunable, so an elapsed count alone cannot say whether a trace from an
+	// older daemon was overdue by the rules that daemon was running.
+	// HookReceipts is the adapter's lifetime receipt total at the moment of the
+	// verdict — zero says the channel never worked, non-zero says it worked and
+	// stopped, and those have different first suspects.
+	SilentTurns   int    `json:"silent_turns,omitempty"`
+	TurnThreshold int    `json:"turn_threshold,omitempty"`
+	HookReceipts  uint64 `json:"hook_receipts,omitempty"`
 
 	// Cache-creation regression (KindCacheBloatDetected, issue #374).
 	Project           string  `json:"project,omitempty"`

--- a/core/domain/session/signal_hold.go
+++ b/core/domain/session/signal_hold.go
@@ -574,6 +574,33 @@ type SignalExpiry struct {
 	Ceiling time.Duration
 }
 
+// SignalRelease reports one hold that ReleaseTier dropped because the channel
+// that asserted it was declared dead, rather than because it went stale, was
+// consumed, or ran out its ceiling (#1368).
+//
+// It is deliberately a different type from SignalExpiry, carrying no Ceiling,
+// because the two answer different questions and a reader must not have to
+// guess which happened. A SignalExpiry says "this hold's release was late past
+// the point of belief" — one hold, one session, wall clock. A SignalRelease
+// says "every hold from this channel is being dropped because the channel
+// itself stopped delivering" — a per-adapter verdict that happens to land on
+// this session. Collapsing them into one type with a zero Ceiling would make
+// the distinction depend on a reader noticing an absent field.
+type SignalRelease struct {
+	// Kind is the signal whose hold was dropped.
+	Kind SignalKind
+
+	// Tier is the authority the hold had been asserting, and the tier the
+	// caller asked to have released. Carried rather than implied so a recorded
+	// trace stands alone.
+	Tier SignalTier
+
+	// HeldFor is how long the hold had stood, measured Now-HeldSince against
+	// the clock the caller injected. Usually long: a hold placed by a channel
+	// that has since gone silent was, by definition, placed before it did.
+	HeldFor time.Duration
+}
+
 // heldSignal is one stored hold: what the signal carried, and when it arrived.
 // The arrival time is what a time-based staleness rule reads through
 // holdContext.HeldSince.
@@ -676,6 +703,98 @@ func (h *SignalHolds) DropSession(sessionID string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	delete(h.held, sessionID)
+}
+
+// ReleaseTier drops every hold on sessionID whose policy declares tier, and
+// reports what it dropped (#1368).
+//
+// This is the mechanism behind "demote the adapter to TierTranscript". Holds
+// are how a tier asserts authority over time — a TierHook hold suppresses every
+// lower tier for as long as it stands — so demoting a channel while leaving its
+// holds in place would demote nothing at all. The session would stay pinned by
+// the very channel just declared dead, and the only thing that changed would be
+// a line in a diagnostics bundle.
+//
+// Why this is sound and not a guess: the caller only reaches here after
+// observing N completed turns for the adapter with zero hook receipts. A hold
+// asserted by that channel is therefore older than those N turns, because
+// nothing from the channel has arrived since. The evidence has already been
+// collected; this is acting on it.
+//
+// Releasing does not force a state. It removes a suppression, and the next
+// classify pass decides from the transcript — which is exactly what
+// TierTranscript means and exactly what the adapter would do if it had no hook
+// channel at all. If the channel comes back, the next hook re-asserts its hold
+// from scratch.
+//
+// Two things this API cannot check and the caller therefore owes it. First, the
+// evidence above is a CALLER invariant — the domain cannot see turns or
+// receipts, so a caller that reaches here without them gets a silent, confident
+// wrong answer. Second, it releases every hold of the tier on this session, and
+// the verdict driving it is per ADAPTER; those coincide only because a session
+// belongs to one adapter and each hook receiver resolves its own transcript
+// roots, so every TierHook hold on a session came from that session's adapter.
+// That holds today and is worth re-checking if a TierHook-authority signal ever
+// arrives on a channel that is not an adapter's own receiver.
+//
+// Dropping the holds rather than suppressing them is deliberate. A
+// Suppress/Unsuppress pair would make recovery symmetric for free, but it
+// leaves stale holds alive indefinitely for a channel that may never return and
+// so needs a reaper of its own; deletion is the simpler end state, and the
+// freshness guard below is the price it pays.
+//
+// Idempotent and cheap on the common path: a session with no holds returns nil
+// without allocating, so the caller may invoke it on every pass while an
+// adapter is silent rather than tracking which sessions it has already swept.
+//
+// now is the pass clock, injected for the same reason Overlay takes one: HeldFor
+// must be measured on the transcript's virtual timeline so a recording replays
+// deterministically.
+func (h *SignalHolds) ReleaseTier(sessionID string, tier SignalTier, now time.Time) []SignalRelease {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	holds := h.held[sessionID]
+	if len(holds) == 0 {
+		return nil
+	}
+
+	var released []SignalRelease
+	// signalPolicies order, not map order: the result reaches a log and a
+	// recorded lifecycle trace, and a nondeterministic order there would make
+	// two identical runs produce different recordings.
+	for _, policy := range signalPolicies {
+		if policy.tier != tier {
+			continue
+		}
+		hs, ok := holds[policy.kind]
+		if !ok {
+			continue
+		}
+		// A hold placed at or after `now` was asserted AFTER the caller took
+		// the verdict it is acting on, so the evidence for that verdict says
+		// nothing about it. The receiver runs on its own goroutine: a hook can
+		// land, dispatch and place a fresh hold in the window between a classify
+		// pass reading the liveness counters and reaching this sweep, and
+		// dropping that hold would discard the first signal from a channel that
+		// has just come back — while the next pass reports it as recovered.
+		// Leaving it stands the hold up against a demotion that predates it,
+		// which is the correct reading of both facts.
+		if hs.heldAt.After(now) {
+			continue
+		}
+		delete(holds, policy.kind)
+		released = append(released, SignalRelease{
+			Kind:    policy.kind,
+			Tier:    policy.tier,
+			HeldFor: now.Sub(hs.heldAt),
+		})
+	}
+
+	if len(holds) == 0 {
+		delete(h.held, sessionID)
+	}
+	return released
 }
 
 // Overlay folds every currently-valid held signal for sessionID onto m, in

--- a/core/domain/session/signal_hold_release_tier_test.go
+++ b/core/domain/session/signal_hold_release_tier_test.go
@@ -1,0 +1,175 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+var releaseT0 = time.Date(2026, 8, 9, 8, 0, 0, 0, time.UTC)
+
+// TestReleaseTier_DropsOnlyTheNamedTier is the core guarantee. The watchdog
+// declares one CHANNEL dead, not one session broken, so a hold sourced from a
+// different tier must survive untouched — otherwise "demote the hook channel"
+// would quietly take out the transcript-based stalled-edit-tool fallback too,
+// which is the very tier the adapter is being demoted TO.
+func TestReleaseTier_DropsOnlyTheNamedTier(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold("s", SignalPermissionPrompt, SignalPayload{}, releaseT0)
+	h.Hold("s", SignalOpenToolStalled, SignalPayload{}, releaseT0)
+
+	released := h.ReleaseTier("s", TierHook, releaseT0.Add(time.Hour))
+
+	if len(released) != 1 {
+		t.Fatalf("released %d holds, want 1: %+v", len(released), released)
+	}
+	if released[0].Kind != SignalPermissionPrompt {
+		t.Errorf("Kind = %q, want %q", released[0].Kind, SignalPermissionPrompt)
+	}
+	if released[0].Tier != TierHook {
+		t.Errorf("Tier = %v, want %v", released[0].Tier, TierHook)
+	}
+	if released[0].HeldFor != time.Hour {
+		t.Errorf("HeldFor = %v, want 1h — measured against the injected pass clock, not wall time", released[0].HeldFor)
+	}
+	if h.Held("s", SignalPermissionPrompt) {
+		t.Error("the hook-tier hold survived the release")
+	}
+	if !h.Held("s", SignalOpenToolStalled) {
+		t.Error("a transcript-tier hold was collateral damage of a hook-channel demotion")
+	}
+}
+
+// TestReleaseTier_DropsEveryHoldOfThatTier: one dead channel can be pinning a
+// session through more than one signal at a time, and leaving any of them
+// standing leaves the session pinned.
+func TestReleaseTier_DropsEveryHoldOfThatTier(t *testing.T) {
+	h := NewSignalHolds()
+	for _, k := range []SignalKind{SignalPermissionPrompt, SignalIdlePrompt, SignalCompactInProgress} {
+		h.Hold("s", k, SignalPayload{}, releaseT0)
+	}
+
+	released := h.ReleaseTier("s", TierHook, releaseT0.Add(time.Minute))
+
+	if len(released) != 3 {
+		t.Fatalf("released %d holds, want all 3 hook-tier holds: %+v", len(released), released)
+	}
+	if h.HasAny("s") {
+		t.Error("the session still holds something after every one of its holds was released")
+	}
+}
+
+// TestReleaseTier_OrderIsThePolicyTableOrder: the result reaches a log and a
+// recorded lifecycle trace, so a map-iteration order would make two identical
+// runs produce different recordings and defeat replay comparison.
+func TestReleaseTier_OrderIsThePolicyTableOrder(t *testing.T) {
+	var want []SignalKind
+	for _, p := range signalPolicies {
+		if p.tier == TierHook {
+			want = append(want, p.kind)
+		}
+	}
+
+	for attempt := 0; attempt < 20; attempt++ {
+		h := NewSignalHolds()
+		for _, k := range want {
+			h.Hold("s", k, SignalPayload{}, releaseT0)
+		}
+		released := h.ReleaseTier("s", TierHook, releaseT0)
+		if len(released) != len(want) {
+			t.Fatalf("released %d, want %d", len(released), len(want))
+		}
+		for i, r := range released {
+			if r.Kind != want[i] {
+				t.Fatalf("attempt %d: order = %v at index %d, want %v — a nondeterministic order breaks recorded traces", attempt, r.Kind, i, want[i])
+			}
+		}
+	}
+}
+
+// TestReleaseTier_IsANoOpWithNothingHeld: the detector calls this on every pass
+// while an adapter is silent rather than tracking which sessions it has already
+// swept, so the empty case must allocate nothing and report nothing.
+func TestReleaseTier_IsANoOpWithNothingHeld(t *testing.T) {
+	h := NewSignalHolds()
+	if got := h.ReleaseTier("never-seen", TierHook, releaseT0); got != nil {
+		t.Errorf("ReleaseTier on an unknown session returned %+v, want nil", got)
+	}
+
+	h.Hold("s", SignalOpenToolStalled, SignalPayload{}, releaseT0)
+	if got := h.ReleaseTier("s", TierHook, releaseT0); got != nil {
+		t.Errorf("ReleaseTier with no matching tier returned %+v, want nil", got)
+	}
+	if !h.Held("s", SignalOpenToolStalled) {
+		t.Error("a no-op release dropped an unrelated hold")
+	}
+}
+
+// TestReleaseTier_IsIdempotent: called repeatedly while the channel stays
+// silent, the second call must report nothing rather than re-announcing holds
+// it already dropped.
+func TestReleaseTier_IsIdempotent(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold("s", SignalPermissionPrompt, SignalPayload{}, releaseT0)
+
+	if got := h.ReleaseTier("s", TierHook, releaseT0); len(got) != 1 {
+		t.Fatalf("first release returned %d, want 1", len(got))
+	}
+	if got := h.ReleaseTier("s", TierHook, releaseT0); got != nil {
+		t.Errorf("second release returned %+v, want nil — a repeated sweep must not re-report", got)
+	}
+}
+
+// TestReleaseTier_DoesNotTouchOtherSessions: the verdict is per adapter, but
+// the release is applied per session as each one is next classified. A release
+// that leaked across sessions would drop holds for sessions the caller never
+// examined, including ones belonging to a different, healthy adapter.
+func TestReleaseTier_DoesNotTouchOtherSessions(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold("a", SignalPermissionPrompt, SignalPayload{}, releaseT0)
+	h.Hold("b", SignalPermissionPrompt, SignalPayload{}, releaseT0)
+
+	h.ReleaseTier("a", TierHook, releaseT0)
+
+	if h.Held("a", SignalPermissionPrompt) {
+		t.Error("the targeted session kept its hold")
+	}
+	if !h.Held("b", SignalPermissionPrompt) {
+		t.Error("an untargeted session lost its hold")
+	}
+}
+
+// TestReleaseTier_KeepsAHoldPlacedAfterTheVerdictClock is the review finding
+// about the window between reading the liveness counters and sweeping the
+// holds.
+//
+// The hook receiver runs on its own goroutine. A channel that has just come
+// back can land a POST, dispatch it and place a fresh hold in that window, and
+// dropping it would throw away the first signal from a recovered channel while
+// the very next pass reports the recovery. A hold asserted after the pass clock
+// is not covered by evidence gathered before it.
+func TestReleaseTier_KeepsAHoldPlacedAfterTheVerdictClock(t *testing.T) {
+	h := NewSignalHolds()
+	passClock := releaseT0.Add(time.Hour)
+
+	h.Hold("s", SignalPermissionPrompt, SignalPayload{}, releaseT0)            // stale: predates the verdict
+	h.Hold("s", SignalIdlePrompt, SignalPayload{}, passClock.Add(time.Second)) // fresh: arrived mid-pass
+
+	released := h.ReleaseTier("s", TierHook, passClock)
+
+	if len(released) != 1 || released[0].Kind != SignalPermissionPrompt {
+		t.Fatalf("released %+v, want only the hold that predates the pass clock", released)
+	}
+	if !h.Held("s", SignalIdlePrompt) {
+		t.Error("a hold placed after the verdict was taken was swept away — the first signal from a recovering channel is discarded")
+	}
+}
+
+// The boundary itself: a hold placed exactly AT the pass clock is covered by
+// the verdict (>= not >), matching the ceiling rule's own inclusive boundary.
+func TestReleaseTier_ReleasesAHoldPlacedExactlyAtTheClock(t *testing.T) {
+	h := NewSignalHolds()
+	h.Hold("s", SignalPermissionPrompt, SignalPayload{}, releaseT0)
+	if got := h.ReleaseTier("s", TierHook, releaseT0); len(got) != 1 {
+		t.Fatalf("released %d holds, want 1 — heldAt == now must still be released", len(got))
+	}
+}

--- a/core/internal/contracttesting/hook_receipt.go
+++ b/core/internal/contracttesting/hook_receipt.go
@@ -1,0 +1,168 @@
+// hook_receipt.go holds the issue #1368 contract every hook-RECEIVING agent
+// adapter must satisfy: a consent-passed request is counted as a receipt for
+// that adapter, whatever the receiver then decides to do with it.
+//
+// It is the fourth receiving-side contract, and unlike the other three the
+// failure it guards against is a FALSE ACCUSATION rather than a silence.
+//
+// The hook-liveness watchdog convicts a channel that produces no receipts
+// across N completed turns and demotes it to the transcript tier, releasing the
+// holds it had placed. That is a real behavioural change to state detection —
+// so a receiver that simply forgets to call hookjson.ObserveHookReceipt does not
+// merely go unreported: it is reported as DEAD while working perfectly, and the
+// product then stops trusting a channel that was fine. The watchdog cannot
+// possibly detect that; a missing call and a missing hook look identical to it,
+// which is precisely why the obligation has to be pinned from outside.
+//
+// The two obligations that are easiest to get subtly wrong are both about
+// counting TOO LITTLE, and both would produce that false accusation on a live
+// channel:
+//
+//   - an unrecognized event name (#1364) still proves the channel delivered.
+//     A receiver that counts only names it handles reports a channel as dead
+//     the moment upstream renames an event — turning a "we don't understand
+//     these" problem into a "these aren't arriving" verdict, which sends the
+//     reader to a different file and a different fix.
+//   - a path-confinement rejection (#1361) still proves the channel delivered.
+//     A receiver that counts only what it dispatches reports a misconfigured
+//     transcript root as a dead channel.
+//
+// And one about counting too much: a request refused by the consent gate must
+// NOT count. Observing that a POST arrived is an observation, and every
+// observation an adapter makes is gated (AGENTS.md). It is also the honest
+// answer — while consent is withheld the daemon has no basis for an opinion
+// about whether the channel works.
+package contracttesting
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/ports/outbound"
+)
+
+// HookReceiptReceiver wires one adapter's hook receiver into
+// AssertHookReceiptObserved. Every field is required.
+type HookReceiptReceiver struct {
+	// Adapter is the name the receipt must be counted under — the same string
+	// the receiver passes to hookjson.ObserveHookReceipt, and the same one the
+	// permission service and the watchdog key on. Asserted, not assumed: a
+	// receipt filed under the wrong name leaves the right channel reading as
+	// dead while a channel nobody is watching looks busy.
+	Adapter string
+
+	// Root relocates the adapter's declared transcript root to a
+	// test-controlled directory — by t.Setenv of whatever env var moves it —
+	// creates it, and returns its absolute path. Called FIRST in every
+	// sub-test, before New.
+	Root func(t *testing.T) string
+
+	// WriteTranscript writes a transcript the adapter will resolve a session id
+	// from into dir, and returns its absolute path.
+	WriteTranscript func(t *testing.T, dir string) string
+
+	// New builds a fresh receiver whose consent gate GRANTS, logging into log.
+	New func(t *testing.T, log outbound.Logger) http.Handler
+
+	// NewDenied builds the same receiver with a consent gate that REFUSES.
+	// Separate from New rather than a parameter on it because the denial case
+	// is the one obligation whose expected count is zero, and a wiring that
+	// silently ignored a "denied" flag would pass it by accident.
+	NewDenied func(t *testing.T, log outbound.Logger) http.Handler
+
+	// PayloadFor renders the adapter's hook JSON body carrying transcriptPath
+	// and event.
+	PayloadFor func(transcriptPath, event string) string
+
+	// KnownEvent is an event name this adapter recognizes and dispatches on.
+	KnownEvent string
+
+	// EndpointPath is the adapter's hook route.
+	EndpointPath string
+}
+
+// AssertHookReceiptObserved runs the issue #1368 contract against r. Four
+// obligations, each independently failable:
+//
+//  1. a recognized event counts exactly one receipt for this adapter — the
+//     positive case, and the one that fails outright on a receiver that never
+//     calls ObserveHookReceipt at all;
+//  2. an unrecognized event counts too. Alive-but-misunderstood is #1364's
+//     diagnosis and must not be reported as this one;
+//  3. a path-confinement rejection counts too. Alive-but-misrouted is #1361's
+//     diagnosis and must not be reported as this one either;
+//  4. a consent-denied request counts nothing, and is still answered 2xx.
+//
+// The counters are process-global and monotonic, so every obligation measures a
+// DELTA around its own request rather than an absolute — two adapters, or two
+// invocations, share a test binary without interfering.
+func AssertHookReceiptObserved(t *testing.T, r HookReceiptReceiver) {
+	t.Helper()
+	t.Run("recognized_event_counts_one", func(t *testing.T) { assertReceiptCounted(t, r, r.KnownEvent) })
+	t.Run("unrecognized_event_counts_too", func(t *testing.T) { assertReceiptCounted(t, r, "IrrReceiptUnknownEvent") })
+	t.Run("confinement_rejected_request_counts_too", func(t *testing.T) { assertReceiptCountedOutOfTree(t, r) })
+	t.Run("consent_denied_request_is_not_counted", func(t *testing.T) { assertDeniedNotCounted(t, r) })
+}
+
+// assertReceiptCounted is obligations 1 and 2: a request the receiver was
+// allowed to see adds exactly one receipt, whether or not it understood it.
+func assertReceiptCounted(t *testing.T, r HookReceiptReceiver, event string) {
+	t.Helper()
+	transcript := receiptTranscript(t, r, "in-tree")
+	handler := r.New(t, &recordingLogger{})
+
+	before := hookjson.HookReceipts()[r.Adapter]
+	rec := postHookBody(t, handler, r.EndpointPath, r.PayloadFor(transcript, event))
+
+	assertHookStatus2xx(t, rec, fmt.Sprintf("event %q", event))
+	if got := hookjson.HookReceipts()[r.Adapter] - before; got != 1 {
+		t.Errorf("event %q added %d receipts for adapter %q, want exactly 1 — a receiver that does not count its own traffic is reported as a DEAD channel by the liveness watchdog and demoted while working perfectly",
+			event, got, r.Adapter)
+	}
+}
+
+// assertReceiptCountedOutOfTree is obligation 3.
+func assertReceiptCountedOutOfTree(t *testing.T, r HookReceiptReceiver) {
+	t.Helper()
+	// Relocate the root first so the receiver is confined to it, then write the
+	// transcript somewhere else entirely — the request is well-formed and the
+	// channel plainly delivered it; only the path is refused.
+	r.Root(t)
+	outside := r.WriteTranscript(t, mkSubdir(t, t.TempDir(), "out-of-tree"))
+	handler := r.New(t, &recordingLogger{})
+
+	before := hookjson.HookReceipts()[r.Adapter]
+	rec := postHookBody(t, handler, r.EndpointPath, r.PayloadFor(outside, r.KnownEvent))
+
+	assertHookStatus2xx(t, rec, "a confinement-rejected request")
+	if got := hookjson.HookReceipts()[r.Adapter] - before; got != 1 {
+		t.Errorf("a path-refused request added %d receipts for adapter %q, want 1 — a misconfigured transcript root (#1361) must not be reported as a channel that stopped delivering (#1368)",
+			got, r.Adapter)
+	}
+}
+
+// assertDeniedNotCounted is obligation 4.
+func assertDeniedNotCounted(t *testing.T, r HookReceiptReceiver) {
+	t.Helper()
+	transcript := receiptTranscript(t, r, "in-tree")
+	handler := r.NewDenied(t, &recordingLogger{})
+
+	before := hookjson.HookReceipts()[r.Adapter]
+	rec := postHookBody(t, handler, r.EndpointPath, r.PayloadFor(transcript, r.KnownEvent))
+
+	assertHookStatus2xx(t, rec, "a consent-denied request")
+	if got := hookjson.HookReceipts()[r.Adapter] - before; got != 0 {
+		t.Errorf("a consent-denied request added %d receipts for adapter %q, want 0 — noting that a POST arrived is an observation, and every observation an adapter makes is gated",
+			got, r.Adapter)
+	}
+}
+
+// receiptTranscript relocates the adapter's root and writes a transcript inside
+// it, so confinement accepts the path and the only thing under test is the
+// counting.
+func receiptTranscript(t *testing.T, r HookReceiptReceiver, name string) string {
+	t.Helper()
+	return r.WriteTranscript(t, mkSubdir(t, r.Root(t), name))
+}

--- a/tools/onboarding-factory/internal/viewer/web/playbackTimeline.js
+++ b/tools/onboarding-factory/internal/viewer/web/playbackTimeline.js
@@ -85,6 +85,18 @@ export function eventStyle(ev) {
     // as bookkeeping.
     case "hold_expired":
       return {color: "#f59e0b", size: 14, opacity: 1, label: "Held signal expired — its release never arrived"};
+    // The hook-liveness watchdog (#1368). A channel going silent is strictly
+    // more of a fault than a single hold expiring, so it is red rather than
+    // amber; the release it causes shares hold_expired's amber because it is
+    // the same visible outcome by a different route. Recovery is green — it is
+    // the event that proves the demotion was a health signal and not a latch,
+    // and its ABSENCE after a silent marker is the thing worth spotting.
+    case "hook_channel_silent":
+      return {color: "#ef4444", size: 14, opacity: 1, label: ev.adapter ? `Hook channel for ${ev.adapter} declared dead — nothing arriving` : "Hook channel declared dead — nothing arriving"};
+    case "hook_channel_recovered":
+      return {color: "#22c55e", size: 14, opacity: 1, label: ev.adapter ? `Hook channel for ${ev.adapter} is delivering again` : "Hook channel is delivering again"};
+    case "hook_hold_released":
+      return {color: "#f59e0b", size: 14, opacity: 1, label: "Held signal released — the channel that placed it went silent"};
     case "file_event":
       return {color: "#94a3b8", size: 7, opacity: 0.6, label: "Filesystem event"};
     default:


### PR DESCRIPTION
Closes #1368

## The failure

`permission granted` **+** `install effect succeeded` **+** zero hook requests arriving across N completed turns. Today that is indistinguishable from "the user just hasn't hit a permission prompt lately", and its only symptom is silently degraded detection.

Three diagnoses are deliberately kept apart, because they have different first moves:

| | what it means | where it shows |
|---|---|---|
| **this PR (#1368)** | entries were written, nothing is arriving | `hooks.json` `channels[].silent` + a loud log line |
| #1372 (not built) | entries were written and later removed | reports *the same way* as above — the note says so explicitly rather than claiming otherwise |
| #1362 (landed) | the install effect failed, entries never written | `effect_error` on the permission; the watchdog **stays disarmed** so it cannot re-report this in weaker words |
| #1364 (landed) | events arrive under names we don't know | still counts as a *receipt* — the channel is alive; the unknown-event counters say the names are wrong |

## Design

- **`hookjson.ObserveHookReceipt`** (`receipt.go`) counts, per adapter, that the channel delivered. Called immediately after the consent gate and *before* any rejection: a malformed body, an unrecognized name (#1364) or a confinement refusal (#1361) all still prove delivery. A consent-*denied* request is not counted — noting that a POST arrived is itself an observation, and every observation is gated.
- **`services.HookLivenessWatchdog`** (`hook_liveness.go`) tracks turns against receipts per adapter. Turns, not wall time: a minutes-based window cannot tell a dead channel from a lunch break, which is the whole ambiguity. The turn signal is transcript-derived `IsAgentDone`, read *before* the hook overlay, so a dead channel cannot suppress the measurement that convicts it.
- **Recovery** is checked on *every* pass; demotion only on a turn boundary. Convicting needs evidence that turns went by; acquitting needs only that a hook arrived. Waiting for the next boundary to believe a recovery would be a latch wearing a different hat.
- **`PermissionService.HookChannelReady`** is the arming predicate: a hook-install permission that is granted *and* whose Apply did not fail. Built from what the daemon did, not from re-reading the config — that would cost a JSON parse per turn and answers #1372's question instead.
- **Diagnostics** extend #1364's *existing* `HookHealthSnapshot` seam rather than adding a second one, and inherit its nil-means-CLI honesty rule.

## The hard question: must the demotion release the channel's holds?

**Yes.** A hold is not a record that a hook fired — it is a live assertion of authority: while a `TierHook` hold stands, nothing below it may correct the session. So the holds *are* the tier the demotion claims to be lowering, and a demotion that left them standing would demote nothing: the session stays pinned at `waiting` by the channel just declared dead, and the only observable change is a row in a bundle.

It acts on evidence already collected, not a guess: conviction requires N turns with zero receipts, so any hold that channel placed necessarily predates all N of them, and the release POST that would retire it is exactly what has been shown not to arrive.

It cannot invent a state — `ReleaseTier` removes a *suppression*; the classifier then decides from the transcript, which is what `TierTranscript` means and what the seven hookless adapters do all the time.

#1360's 12-hour ceilings already drop these holds, so this changes **when**, not **whether** — and that is the value: five turns is minutes, twelve hours is a working day at the wrong state. The ceiling remains the backstop for the case the watchdog cannot see (an adapter producing no further turns, where there is no evidence to convict on). Two mechanisms, different evidence, deliberately not merged — and a distinct `hook_hold_released` kind so a trace never conflates them.

Pinned by `TestSessionDetector_SilentHookChannelReleasesItsPinnedHolds`.

## Tunable

`IRRLICHT_HOOK_SILENT_TURNS`, default **5**, `0` disables. Rationale in `config.go`: both hook adapters install a Stop hook, so a healthy channel owes ≥1 receipt per turn; 1 would be far too twitchy given hook/transcript interleaving, a mid-turn install, and a session already in flight when consent was granted (each costs 1–2 turns); and the upper bound is set by the point of the demotion — a threshold in the tens would be slower than the 12h backstop it exists to beat.

## Red-first evidence

Every behaviour was mutated and seen fail. Verbatim failures are in the thread below.

## Not done deliberately

- No macOS/web UI surface. This is a daemon-internal health signal whose consumer is the diagnostics bundle and events.log; the issue scopes it to `--diagnose`.
- No detection of *why* a channel is silent. That is #1372, and the note says so instead of guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)