### PR TITLE
fix(install): sweep agent hook entries on uninstall

### DIFF
--- a/site/docs/installation.html
+++ b/site/docs/installation.html
@@ -312,17 +312,22 @@ cd Irrlicht
       <!-- ── Uninstalling ── -->
       <h2 id="uninstalling">Uninstalling</h2>
 
-      <p>To remove Irrlicht completely, quit the app and delete the following:</p>
+      <p>Use the installer's <code>--uninstall</code> flag. It stops the daemon, removes the app bundle, the <code>irrlichd</code> binary and the LaunchAgent (or systemd user unit on Linux), <em>and</em> clears the hook entries Irrlicht wrote into your agent configs:</p>
 
-      <pre><code># Remove the app
-rm -rf /Applications/Irrlicht.app
+      <pre><code>curl -fsSL https://irrlicht.io/install.sh | sh -s -- --uninstall</code></pre>
 
-# Remove application data and logs
-rm -rf ~/Library/Application\ Support/Irrlicht/</code></pre>
+      <p>Your session history and configuration in <code>~/Library/Application Support/Irrlicht/</code> are kept. To remove those too:</p>
+
+      <pre><code>rm -rf ~/Library/Application\ Support/Irrlicht/</code></pre>
 
       <div class="callout callout-warning">
         <strong>Warning</strong>
         Removing the <code>Application Support/Irrlicht/</code> directory deletes all local session history and configuration. Back up anything you want to keep before running the command above.
+      </div>
+
+      <div class="callout callout-info">
+        <strong>Deleting the app by hand leaves hooks behind</strong>
+        If you remove Irrlicht by dragging it to the Trash or with <code>rm -rf /Applications/Irrlicht.app</code>, the hook entries stay in your agent configs and keep firing at a port nothing is listening on. Run <code>--uninstall</code> above instead &mdash; or, if the binary is already gone, clear Irrlicht's entries from <code>~/.claude/settings.json</code> and <code>~/.codex/hooks.json</code> yourself.
       </div>
 
       <!-- ── Bottom nav ── -->

--- a/site/install.sh
+++ b/site/install.sh
@@ -25,7 +25,7 @@ VERSION=""
 # exercise the real uninstall path without deleting a developer's actual
 # /Applications/Irrlicht.app (and without silently passing on CI, where that
 # path happens not to exist).
-APP_PATH="${IRRLICHT_APP_PATH:-/Applications/Irrlicht.app}"
+APP_PATH="${IRRLICHT_TEST_APP_PATH:-/Applications/Irrlicht.app}"
 DAEMON_PATH="$HOME/.local/bin/irrlichd"
 LAUNCHAGENT_PATH="$HOME/Library/LaunchAgents/io.irrlicht.app.daemon.plist"
 
@@ -114,24 +114,65 @@ uninstall_agent_hooks() {
     if [ -z "$_irrlichd" ]; then
         # Close the caller's pending `step` line so the warning starts on its own.
         printf '\n'
-        warn "No irrlichd binary found — skipping agent hook cleanup."
-        warn "  Remove any leftover irrlicht entries from your agent configs by hand"
-        warn "  (e.g. ~/.claude/settings.json, ~/.codex/hooks.json)."
+        warn "No irrlichd binary found — skipped the agent hook cleanup. If you had"
+        warn "  hooks installed, clear them from ~/.claude/settings.json and ~/.codex/hooks.json."
         return 0
     fi
 
+    # Run the sweep detached from our stdin and under a bounded wait.
+    #
+    # irrlichd has no argument parser: an unknown flag falls through to STARTING
+    # A DAEMON (#1417 — core/cmd/irrlichd/dispatch_test.go pins that as
+    # deliberate). --uninstall-hooks has existed since v0.3.4, so a current
+    # binary is fine, but someone uninstalling an older one would otherwise boot
+    # a daemon right here — binding the port this function just freed — and
+    # block the script forever reading its output. An uninstall that hangs is
+    # the worst outcome available: `curl | sh` gives the child our stdin too,
+    # and a Ctrl-C leaves a half-removed product plus a live daemon.
+    #
+    # A bounded wait is the general form of the guard. A version check would
+    # cover only the versions we know about today, and would have to run the
+    # same binary to ask.
+    # 30 ticks x 0.5s = 15s. Overridable only so the test can exercise the
+    # timeout branch in a second instead of fifteen — same test seam as
+    # IRRLICHT_TEST_APP_PATH above, and like it, guarded by an assertion in
+    # tools/lib/install-uninstall_test.sh that the override still exists.
+    _hook_ticks="${IRRLICHT_HOOK_SWEEP_TICKS:-30}"
+    if ! _hook_log=$(mktemp); then
+        printf '\n'
+        warn "Could not create a temp file for the hook cleanup — skipping it."
+        return 0
+    fi
+    "$_irrlichd" --uninstall-hooks >"$_hook_log" 2>&1 </dev/null &
+    _hook_pid=$!
+    _hook_waited=0
+    while kill -0 "$_hook_pid" 2>/dev/null; do
+        if [ "$_hook_waited" -ge "$_hook_ticks" ]; then
+            kill "$_hook_pid" 2>/dev/null || true
+            printf '\n'
+            warn "irrlichd --uninstall-hooks did not finish in time — stopped it."
+            warn "  This binary may predate the flag (it needs v0.3.4 or newer)."
+            warn "  Check ~/.claude/settings.json and ~/.codex/hooks.json for stale entries."
+            rm -f "$_hook_log"
+            return 0
+        fi
+        sleep 0.5
+        _hook_waited=$((_hook_waited + 1))
+    done
+
     # Fail soft, always: the user asked for removal. `set -e` would abort the
-    # whole uninstall on a non-zero exit, so the call is a condition rather than
-    # a bare statement. Output is captured so a healthy sweep stays quiet inside
-    # the caller's one-line progress step, and is replayed only when there is
-    # something wrong to look at.
-    if _hook_output=$("$_irrlichd" --uninstall-hooks 2>&1); then
+    # whole uninstall on a non-zero exit, so the wait is a condition rather than
+    # a bare statement. The binary's own output is replayed only on failure, so
+    # a healthy sweep stays quiet inside the caller's one-line progress step.
+    if wait "$_hook_pid"; then
+        rm -f "$_hook_log"
         return 0
     fi
     printf '\n'
     warn "Could not remove irrlicht's hook entries from the agent configs:"
-    [ -n "$_hook_output" ] && printf '%s\n' "$_hook_output" >&2
+    [ -s "$_hook_log" ] && cat "$_hook_log" >&2
     warn "  Check ~/.claude/settings.json and ~/.codex/hooks.json for stale entries."
+    rm -f "$_hook_log"
     return 0
 }
 

--- a/site/install.sh
+++ b/site/install.sh
@@ -17,8 +17,15 @@ DAEMON_ONLY=0
 UNINSTALL=0
 VERSION=""
 
-# Install locations
-APP_PATH="/Applications/Irrlicht.app"
+# Install locations.
+#
+# APP_PATH is the only one that is not under $HOME, which makes it the only one
+# a test cannot isolate by pointing HOME at a temp dir — and uninstall_previous
+# `rm -rf`s it. The override exists so tools/lib/install-uninstall_test.sh can
+# exercise the real uninstall path without deleting a developer's actual
+# /Applications/Irrlicht.app (and without silently passing on CI, where that
+# path happens not to exist).
+APP_PATH="${IRRLICHT_APP_PATH:-/Applications/Irrlicht.app}"
 DAEMON_PATH="$HOME/.local/bin/irrlichd"
 LAUNCHAGENT_PATH="$HOME/Library/LaunchAgents/io.irrlicht.app.daemon.plist"
 
@@ -74,11 +81,75 @@ What a normal install does:
 EOF
 }
 
+# ─── Agent hook cleanup ────────────────────────────────────────────────────
+# Ask irrlichd to remove every hook entry it wrote into the user's agent config
+# files (~/.claude/settings.json, ~/.codex/hooks.json, …). Without this an
+# uninstalled irrlicht stays in the user's agent configuration, pointing at a
+# binary that no longer exists (#1416).
+#
+# The adapter set is resolved from the adapter registry inside the binary
+# (#1357), so there is deliberately NO list of agents or config paths here: a
+# second list is a list that drifts as adapters are added, which is the bug
+# #1357 fixed on the Go side.
+#
+# Only the real `--uninstall` calls this — see the call in uninstall_previous.
+uninstall_agent_hooks() {
+    # Both install flavours, in the order the installer creates them: the
+    # daemon-only binary, then the daemon inside the .app bundle. Deliberately
+    # NOT `command -v irrlichd`: that can resolve to an unrelated dev build in
+    # someone's worktree, and this is the one place we are about to rewrite the
+    # user's agent configs from whatever we find.
+    _irrlichd=""
+    for _candidate in "$DAEMON_PATH" "$APP_PATH/Contents/MacOS/irrlichd"; do
+        if [ -x "$_candidate" ]; then
+            _irrlichd="$_candidate"
+            break
+        fi
+    done
+
+    # A partial earlier uninstall, or a hand-deleted binary. There is nothing
+    # left to run the sweep with; say so and carry on. Failing the uninstall
+    # over this would strand the user with a half-removed product, which is
+    # strictly worse than the residue we are trying to clean up.
+    if [ -z "$_irrlichd" ]; then
+        # Close the caller's pending `step` line so the warning starts on its own.
+        printf '\n'
+        warn "No irrlichd binary found — skipping agent hook cleanup."
+        warn "  Remove any leftover irrlicht entries from your agent configs by hand"
+        warn "  (e.g. ~/.claude/settings.json, ~/.codex/hooks.json)."
+        return 0
+    fi
+
+    # Fail soft, always: the user asked for removal. `set -e` would abort the
+    # whole uninstall on a non-zero exit, so the call is a condition rather than
+    # a bare statement. Output is captured so a healthy sweep stays quiet inside
+    # the caller's one-line progress step, and is replayed only when there is
+    # something wrong to look at.
+    if _hook_output=$("$_irrlichd" --uninstall-hooks 2>&1); then
+        return 0
+    fi
+    printf '\n'
+    warn "Could not remove irrlicht's hook entries from the agent configs:"
+    [ -n "$_hook_output" ] && printf '%s\n' "$_hook_output" >&2
+    warn "  Check ~/.claude/settings.json and ~/.codex/hooks.json for stale entries."
+    return 0
+}
+
 # ─── Uninstall previous install ────────────────────────────────────────────
 # Removes every variant we may have installed in the past:
 # .app bundle, daemon-only binary, LaunchAgent. Leaves user data (logs,
 # Application Support) alone.
+#
+# $1 — pass 1 to also sweep irrlicht's hook entries out of the user's agent
+# configs. Opt-in, and only the real `--uninstall` opts in. This function also
+# runs on the re-install/upgrade path, and `--uninstall-hooks` does more than
+# edit config files: it records the hooks permissions as DENIED (#570), so that
+# a persisted "granted" cannot re-install them on the next daemon start. That
+# denial is written into the user data an uninstall deliberately KEEPS — so
+# sweeping on an upgrade would silently switch hook-based monitoring off for a
+# user who only asked for a newer version.
 uninstall_previous() {
+    sweep_agent_hooks="${1:-0}"
     removed_something=0
 
     # Stop running processes — match any Irrlicht*.app bundle regardless of
@@ -128,6 +199,14 @@ uninstall_previous() {
         rm -f "$HOME/.config/systemd/user/irrlichd.service"
         systemctl --user daemon-reload 2>/dev/null || true
         removed_something=1
+    fi
+
+    # Clean irrlicht out of the agent configs while a binary that can do it
+    # still exists — both places we might find one are removed just below.
+    # Placed after the daemon is stopped and its LaunchAgent/systemd unit are
+    # gone, so nothing can restart and re-apply the entries we just removed.
+    if [ "$sweep_agent_hooks" -eq 1 ]; then
+        uninstall_agent_hooks
     fi
 
     # Remove app bundle
@@ -200,7 +279,7 @@ say ""
 
 if [ "$UNINSTALL" -eq 1 ]; then
     step "Removing existing Irrlicht install"
-    uninstall_previous
+    uninstall_previous 1
     ok
     say ""
     say "  ${GREEN}✓${RESET} Irrlicht uninstalled"

--- a/tools/lib/install-uninstall_test.sh
+++ b/tools/lib/install-uninstall_test.sh
@@ -13,7 +13,7 @@
 # this machine's real install, and all three are load-bearing:
 #   1. HOME is a mktemp -d, so ~/.claude, ~/.codex, ~/.local/bin/irrlichd,
 #      ~/Library/LaunchAgents/... and ~/.config/systemd/user/... are all fakes.
-#   2. IRRLICHT_APP_PATH redirects the one install location that is NOT under
+#   2. IRRLICHT_TEST_APP_PATH redirects the one install location that is NOT under
 #      $HOME. Without it the script would `rm -rf /Applications/Irrlicht.app`
 #      for real — and on CI, where that path does not exist, the test would pass
 #      while doing it.
@@ -68,6 +68,19 @@ assert_file_present() {
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
+# SAFETY PRECONDITION, checked before anything runs. Isolation leg 2 is the only
+# one this test cannot enforce by itself: it depends on site/install.sh actually
+# honouring IRRLICHT_TEST_APP_PATH. If that override is ever dropped — a plausible
+# cleanup, since it is a test seam in production code — every case below would
+# `rm -rf` the real /Applications/Irrlicht.app and only THEN report failure. On
+# CI that path does not exist, so the destruction would be invisible there.
+# Refuse to run rather than discover it afterwards.
+if ! grep -q 'IRRLICHT_TEST_APP_PATH' "$INSTALL_SH"; then
+    echo "$NAME: REFUSING TO RUN — $INSTALL_SH no longer honours IRRLICHT_TEST_APP_PATH." >&2
+    echo "  Without it this test deletes the real /Applications/Irrlicht.app." >&2
+    exit 1
+fi
+
 # ---------------------------------------------------------------------------
 # new_env <name> — build an isolated fake machine and echo its root.
 #
@@ -75,7 +88,7 @@ trap 'rm -rf "$WORK"' EXIT
 #   <root>/home                 → HOME
 #   <root>/home/.claude/settings.json   dirty: carries an irrlicht hook entry
 #   <root>/home/.codex/hooks.json       dirty: carries an irrlicht hook entry
-#   <root>/app/Irrlicht.app     → IRRLICHT_APP_PATH (created by the caller if wanted)
+#   <root>/app/Irrlicht.app     → IRRLICHT_TEST_APP_PATH (created by the caller if wanted)
 #   <root>/bin                  → PATH stubs
 #   <root>/marker               → written by the irrlichd stub when it runs
 # ---------------------------------------------------------------------------
@@ -158,7 +171,7 @@ run_uninstall() {
     env -i \
         HOME="$root/home" \
         PATH="$root/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-        IRRLICHT_APP_PATH="$root/app/Irrlicht.app" \
+        IRRLICHT_TEST_APP_PATH="$root/app/Irrlicht.app" \
         "$@" \
         sh "$INSTALL_SH" --uninstall 2>&1
 }
@@ -215,7 +228,12 @@ out="$(run_uninstall "$root")"; rc=$?
 
 assert_eq "$rc" "0" "fail-soft: uninstall exits 0 despite the sweep failing"
 assert_contains "$out" "Irrlicht uninstalled" "fail-soft: uninstall still completes"
-assert_contains "$out" "hook" "fail-soft: the failure is surfaced, not swallowed"
+assert_contains "$out" "Could not remove" "fail-soft: the failure is announced"
+# Assert the stub's OWN diagnostic reaches the user, not just our static warning
+# line. Matching something the warning itself contains would leave the line that
+# replays the binary's output uncovered — deleting it would keep this green.
+assert_contains "$out" "simulated sweep failure" \
+    "fail-soft: the binary's own diagnostic is replayed, not swallowed"
 assert_file_absent "$root/home/.local/bin/irrlichd" "fail-soft: the binary is still removed"
 
 # ===========================================================================
@@ -277,12 +295,77 @@ assert_eq "$total" "2" "callsites: uninstall_previous still has exactly two call
 assert_eq "$sweeping" "1" "callsites: exactly one of them opts into the hook sweep"
 
 # ===========================================================================
-# 8. The installer must stay `sh`-clean — it runs under /bin/sh, not bash.
+# 8. A BINARY THAT NEVER RETURNS must not hang the uninstall.
+#
+#    irrlichd has no argument parser: an unknown flag falls through to starting
+#    a DAEMON (#1417, pinned deliberately by core/cmd/irrlichd/dispatch_test.go).
+#    --uninstall-hooks has existed since v0.3.4 — the earliest tag containing
+#    5f95c1d5 — so a current binary is fine, but uninstalling an older one would
+#    boot a daemon here, bind the port the uninstall just freed, and block
+#    forever on its output. Under `curl | sh` the child inherits the script's
+#    stdin too, so the hang is not even interruptible cleanly.
+#
+#    IRRLICHT_HOOK_SWEEP_TICKS shortens the 15s bound to 1s for this case.
 # ===========================================================================
-if sh -n "$INSTALL_SH" 2>/dev/null; then
-    pass "syntax: site/install.sh parses under /bin/sh"
+if ! grep -q 'IRRLICHT_HOOK_SWEEP_TICKS' "$INSTALL_SH"; then
+    fail "hang-guard: install.sh still honours IRRLICHT_HOOK_SWEEP_TICKS" \
+         "the override this case depends on is gone; the case below proves nothing"
 else
-    fail "syntax: site/install.sh parses under /bin/sh"
+    root="$(new_env hang)"
+    mkdir -p "$root/home/.local/bin"
+    # Never exits on its own — stands in for an old binary that started a daemon.
+    printf '#!/bin/sh\nprintf "%%s\\n" "$*" >>"%s"\nwhile :; do sleep 5; done\n' \
+        "$root/marker" >"$root/home/.local/bin/irrlichd"
+    chmod +x "$root/home/.local/bin/irrlichd"
+
+    started=$(date +%s)
+    out="$(run_uninstall "$root" IRRLICHT_HOOK_SWEEP_TICKS=2)"; rc=$?
+    elapsed=$(( $(date +%s) - started ))
+
+    assert_eq "$rc" "0" "hang-guard: uninstall still exits 0"
+    assert_contains "$out" "did not finish in time" "hang-guard: says the sweep was stopped"
+    assert_contains "$out" "Irrlicht uninstalled" "hang-guard: the uninstall still completes"
+    assert_file_absent "$root/home/.local/bin/irrlichd" "hang-guard: the binary is still removed"
+    if [[ "$elapsed" -lt 30 ]]; then
+        pass "hang-guard: bounded — finished in ${elapsed}s, not forever"
+    else
+        fail "hang-guard: bounded" "took ${elapsed}s"
+    fi
+    # The stub must not survive the run: an orphan here is the stray daemon.
+    if pgrep -f "$root/home/.local/bin/irrlichd" >/dev/null 2>&1; then
+        fail "hang-guard: the stopped process leaves no orphan"
+        pkill -f "$root/home/.local/bin/irrlichd" 2>/dev/null || true
+    else
+        pass "hang-guard: the stopped process leaves no orphan"
+    fi
+fi
+
+# ===========================================================================
+# 9. The installer must stay POSIX-sh clean — it ships to Linux users via
+#    `curl | sh`, where /bin/sh is typically dash.
+#
+#    NOTE ON REACH: on macOS /bin/sh is bash 3.2 in POSIX mode, which PARSES
+#    bashisms happily — and test.yml's shell-lib step runs on macos-latest. So
+#    `sh -n` alone catches hard syntax errors only. Prefer a real POSIX shell
+#    when the machine has one, and say which check actually ran rather than
+#    letting a weak green look like a strong one.
+# ===========================================================================
+posix_sh=""
+for candidate in dash ash; do
+    if command -v "$candidate" >/dev/null 2>&1; then posix_sh="$candidate"; break; fi
+done
+if [[ -n "$posix_sh" ]]; then
+    if "$posix_sh" -n "$INSTALL_SH" 2>/dev/null; then
+        pass "syntax: site/install.sh parses under $posix_sh (real POSIX shell)"
+    else
+        fail "syntax: site/install.sh parses under $posix_sh (real POSIX shell)"
+    fi
+else
+    if sh -n "$INSTALL_SH" 2>/dev/null; then
+        pass "syntax: site/install.sh parses under /bin/sh (no dash here — syntax errors only)"
+    else
+        fail "syntax: site/install.sh parses under /bin/sh"
+    fi
 fi
 
 if [ "$fails" -eq 0 ]; then

--- a/tools/lib/install-uninstall_test.sh
+++ b/tools/lib/install-uninstall_test.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Tests for site/install.sh's uninstall path — specifically that it asks
+# irrlichd to remove the hook entries it wrote into the user's agent configs
+# before it deletes the binary that can do the removing (#1416).
+#
+# Before #1416 the uninstall removed the LaunchAgent, the systemd unit, the app
+# bundle and ~/.local/bin/irrlichd, and never touched ~/.claude/settings.json or
+# ~/.codex/hooks.json — so an uninstalled irrlicht stayed in the user's agent
+# configuration, pointing at a binary that no longer existed.
+#
+# SAFETY. Every case runs the real site/install.sh as a subprocess, and that
+# script kills processes and deletes install locations. Three things keep it off
+# this machine's real install, and all three are load-bearing:
+#   1. HOME is a mktemp -d, so ~/.claude, ~/.codex, ~/.local/bin/irrlichd,
+#      ~/Library/LaunchAgents/... and ~/.config/systemd/user/... are all fakes.
+#   2. IRRLICHT_APP_PATH redirects the one install location that is NOT under
+#      $HOME. Without it the script would `rm -rf /Applications/Irrlicht.app`
+#      for real — and on CI, where that path does not exist, the test would pass
+#      while doing it.
+#   3. PATH is fronted by stubs for pgrep/pkill/lsof/launchctl/systemctl, so the
+#      process-killing block cannot reach a developer's running daemon or app.
+# A case that skips any of the three is a case that can destroy the machine it
+# runs on. Build every environment through new_env().
+#
+# Convention follows tools/lib/changed-files_test.sh: plain bash, hand-rolled
+# asserts, a `fails` counter, "ALL PASS" / "N FAILED" at the end.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/site/install.sh"
+NAME="install-uninstall_test"
+
+fails=0
+
+pass() { printf 'PASS: %s\n' "$1"; }
+fail() {
+    printf 'FAIL: %s\n' "$1"
+    [ $# -gt 1 ] && printf '      %s\n' "$2"
+    fails=$((fails + 1))
+    return 0
+}
+assert_contains() {
+    local haystack="$1" needle="$2" what="$3"
+    case "$haystack" in
+        *"$needle"*) pass "$what" ;;
+        *) fail "$what" "expected to find [$needle] in: $(printf '%s' "$haystack" | head -c 400)" ;;
+    esac
+}
+assert_not_contains() {
+    local haystack="$1" needle="$2" what="$3"
+    case "$haystack" in
+        *"$needle"*) fail "$what" "did NOT expect [$needle] in: $(printf '%s' "$haystack" | head -c 400)" ;;
+        *) pass "$what" ;;
+    esac
+}
+assert_eq() {
+    if [[ "$1" == "$2" ]]; then pass "$3"; else fail "$3" "expected [$2] got [$1]"; fi
+}
+assert_file_absent() {
+    if [[ -e "$1" ]]; then fail "$2" "expected [$1] to be gone"; else pass "$2"; fi
+}
+assert_file_present() {
+    if [[ -e "$1" ]]; then pass "$2"; else fail "$2" "expected [$1] to exist"; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+# new_env <name> — build an isolated fake machine and echo its root.
+#
+# Layout:
+#   <root>/home                 → HOME
+#   <root>/home/.claude/settings.json   dirty: carries an irrlicht hook entry
+#   <root>/home/.codex/hooks.json       dirty: carries an irrlicht hook entry
+#   <root>/app/Irrlicht.app     → IRRLICHT_APP_PATH (created by the caller if wanted)
+#   <root>/bin                  → PATH stubs
+#   <root>/marker               → written by the irrlichd stub when it runs
+# ---------------------------------------------------------------------------
+new_env() {
+    local root="$WORK/$1"
+    mkdir -p "$root/home/.claude" "$root/home/.codex" "$root/bin" "$root/app"
+
+    # Config files shaped like the real thing: a hook entry naming the binary.
+    cat >"$root/home/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [ { "type": "http", "url": "http://127.0.0.1:7837/hooks/claudecode" } ] }
+    ]
+  },
+  "statusLine": { "type": "command", "command": "irrlichd --statusline" }
+}
+JSON
+    cat >"$root/home/.codex/hooks.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [ { "command": "irrlichd --hook codex || true" } ]
+  }
+}
+JSON
+
+    # --- PATH stubs. Each one neutralizes a real, destructive call. ---
+    # pgrep: "no Irrlicht app running" — stops the pkill branch being taken.
+    printf '#!/bin/sh\nexit 1\n' >"$root/bin/pgrep"
+    # pkill: must never reach a real process even if something calls it.
+    printf '#!/bin/sh\nexit 0\n' >"$root/bin/pkill"
+    # lsof: present (so install.sh takes the lsof branch, not the pgrep -x
+    # fallback) but reports nothing listening on 7837.
+    printf '#!/bin/sh\nexit 0\n' >"$root/bin/lsof"
+    printf '#!/bin/sh\nexit 0\n' >"$root/bin/launchctl"
+    printf '#!/bin/sh\nexit 0\n' >"$root/bin/systemctl"
+    chmod +x "$root/bin/"*
+
+    printf '%s' "$root"
+}
+
+# make_irrlichd <path> <marker> <exitcode> — a stand-in for the real binary.
+#
+# On `--uninstall-hooks` it does what the real registry-driven sweep does to the
+# files this test can see: strips irrlicht's entries out of the two configs.
+# Using a stub rather than a built binary keeps the test hermetic and free of a
+# Go toolchain (test.yml runs the shell-lib step without one); the sweep's own
+# correctness is covered by the Go tests around uninstallHookConfigs. What this
+# test owns is the question the Go tests cannot answer: does install.sh ever
+# CALL it, and does it call it while the binary still exists.
+make_irrlichd() {
+    local path="$1" marker="$2" code="${3:-0}"
+    mkdir -p "$(dirname "$path")"
+    cat >"$path" <<STUB
+#!/bin/sh
+# Record every invocation, with the argv, so the test can prove it ran and that
+# it ran from a binary that had not been deleted yet.
+printf '%s\n' "\$*" >>"$marker"
+if [ "\$1" != "--uninstall-hooks" ]; then
+    printf 'stub irrlichd: unexpected args: %s\n' "\$*" >&2
+    exit 64
+fi
+if [ "$code" -ne 0 ]; then
+    printf 'stub irrlichd: simulated sweep failure\n' >&2
+    exit $code
+fi
+# Emulate the real sweep: remove the irrlicht entries.
+printf '%s\n' '{ "hooks": {} }' >"\$HOME/.claude/settings.json"
+printf '%s\n' '{ "hooks": {} }' >"\$HOME/.codex/hooks.json"
+printf 'Removed irrlicht hooks from %s\n' "\$HOME/.claude/settings.json"
+exit 0
+STUB
+    chmod +x "$path"
+}
+
+# run_uninstall <root> [extra-env...] — run the real installer's uninstall path
+# inside the fake machine. Returns its exit code; echoes stdout+stderr.
+run_uninstall() {
+    local root="$1"; shift
+    env -i \
+        HOME="$root/home" \
+        PATH="$root/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        IRRLICHT_APP_PATH="$root/app/Irrlicht.app" \
+        "$@" \
+        sh "$INSTALL_SH" --uninstall 2>&1
+}
+
+# ===========================================================================
+# 1. THE DEFECT. A clean uninstall must leave no irrlicht hook entries behind.
+#    This is the case that fails on main: nothing calls the sweep, so both
+#    configs still name irrlichd after the uninstall reports success.
+# ===========================================================================
+root="$(new_env defect)"
+make_irrlichd "$root/home/.local/bin/irrlichd" "$root/marker" 0
+out="$(run_uninstall "$root")"; rc=$?
+
+assert_eq "$rc" "0" "defect: uninstall exits 0"
+assert_contains "$out" "Irrlicht uninstalled" "defect: uninstall reports success"
+assert_not_contains "$(cat "$root/home/.claude/settings.json")" "irrlichd" \
+    "defect: ~/.claude/settings.json has no irrlichd entry left"
+assert_not_contains "$(cat "$root/home/.claude/settings.json")" "7837" \
+    "defect: ~/.claude/settings.json has no irrlicht hook endpoint left"
+assert_not_contains "$(cat "$root/home/.codex/hooks.json")" "irrlichd" \
+    "defect: ~/.codex/hooks.json has no irrlichd entry left"
+
+# ===========================================================================
+# 2. ORDERING. The sweep needs the binary, and the uninstall deletes it. Both
+#    must be true at the end: the stub ran (marker written) AND the binary is
+#    gone — which can only happen if the call came first.
+# ===========================================================================
+assert_file_present "$root/marker" "ordering: irrlichd was invoked during the uninstall"
+if [[ -f "$root/marker" ]]; then
+    assert_eq "$(cat "$root/marker")" "--uninstall-hooks" \
+        "ordering: invoked exactly once, with --uninstall-hooks and nothing else"
+fi
+assert_file_absent "$root/home/.local/bin/irrlichd" "ordering: the binary is still deleted afterwards"
+
+# ===========================================================================
+# 3. BINARY ALREADY GONE (partial earlier uninstall, hand-deleted binary).
+#    Skip with a message; never fail the uninstall.
+# ===========================================================================
+root="$(new_env nobinary)"
+out="$(run_uninstall "$root")"; rc=$?
+
+assert_eq "$rc" "0" "no-binary: uninstall still exits 0"
+assert_contains "$out" "Irrlicht uninstalled" "no-binary: uninstall still completes"
+assert_contains "$out" "No irrlichd binary" "no-binary: says why the hook cleanup was skipped"
+assert_file_absent "$root/marker" "no-binary: nothing was invoked"
+
+# ===========================================================================
+# 4. FAIL SOFT. A sweep that errors must not abort the uninstall — the user
+#    asked for removal, and a half-removed product is worse than the residue.
+# ===========================================================================
+root="$(new_env sweepfails)"
+make_irrlichd "$root/home/.local/bin/irrlichd" "$root/marker" 1
+out="$(run_uninstall "$root")"; rc=$?
+
+assert_eq "$rc" "0" "fail-soft: uninstall exits 0 despite the sweep failing"
+assert_contains "$out" "Irrlicht uninstalled" "fail-soft: uninstall still completes"
+assert_contains "$out" "hook" "fail-soft: the failure is surfaced, not swallowed"
+assert_file_absent "$root/home/.local/bin/irrlichd" "fail-soft: the binary is still removed"
+
+# ===========================================================================
+# 5. APP-BUNDLE INSTALL. A full macOS install has no ~/.local/bin/irrlichd —
+#    the daemon lives inside Irrlicht.app, which this same function deletes.
+# ===========================================================================
+root="$(new_env appbundle)"
+make_irrlichd "$root/app/Irrlicht.app/Contents/MacOS/irrlichd" "$root/marker" 0
+out="$(run_uninstall "$root")"; rc=$?
+
+assert_eq "$rc" "0" "app-bundle: uninstall exits 0"
+assert_file_present "$root/marker" "app-bundle: the in-bundle irrlichd was invoked"
+assert_not_contains "$(cat "$root/home/.claude/settings.json")" "irrlichd" \
+    "app-bundle: ~/.claude/settings.json comes back clean"
+assert_file_absent "$root/app/Irrlicht.app" "app-bundle: the bundle is still removed afterwards"
+
+# ===========================================================================
+# 6. LINUX PATH. The systemd branch lives in the same function and has the same
+#    exposure. Force the Linux branch with a `uname` stub and give it a unit
+#    file to remove, then assert the hooks were swept there too.
+# ===========================================================================
+root="$(new_env linux)"
+printf '#!/bin/sh\nif [ "${1:-}" = "-s" ]; then echo Linux; else echo Linux; fi\n' >"$root/bin/uname"
+chmod +x "$root/bin/uname"
+mkdir -p "$root/home/.config/systemd/user"
+printf '[Unit]\n' >"$root/home/.config/systemd/user/irrlichd.service"
+make_irrlichd "$root/home/.local/bin/irrlichd" "$root/marker" 0
+out="$(run_uninstall "$root")"; rc=$?
+
+assert_eq "$rc" "0" "linux: uninstall exits 0"
+assert_file_present "$root/marker" "linux: irrlichd was invoked on the systemd path too"
+assert_not_contains "$(cat "$root/home/.codex/hooks.json")" "irrlichd" \
+    "linux: ~/.codex/hooks.json comes back clean"
+assert_file_absent "$root/home/.config/systemd/user/irrlichd.service" \
+    "linux: the systemd user unit is still removed"
+
+# ===========================================================================
+# 7. THE RE-INSTALL PATH MUST NOT SWEEP.
+#
+#    uninstall_previous() has two call sites: the real --uninstall, and the
+#    upgrade path that clears the old install before laying down the new one.
+#    --uninstall-hooks also records the hooks permissions as DENIED (#570,
+#    denyHooksPermissions in core/cmd/irrlichd/main.go) so a persisted "granted"
+#    cannot re-install them on the next daemon start. That denial lives in the
+#    user data an uninstall deliberately KEEPS — so sweeping on the upgrade path
+#    would silently switch hook-based monitoring off for a user who only asked
+#    for a newer version, and leave them to rediscover the permission wizard.
+#
+#    This is asserted structurally rather than behaviourally: the upgrade path
+#    only reaches uninstall_previous after a real download and checksum, which a
+#    unit test has no way to satisfy.
+# ===========================================================================
+# The function's own definition line matches the same prefix — drop it, or the
+# count is off by one and the assertion silently measures the wrong thing.
+callsites="$(grep -n '^[[:space:]]*uninstall_previous' "$INSTALL_SH" | grep -v 'uninstall_previous()')"
+sweeping="$(printf '%s\n' "$callsites" | grep -c 'uninstall_previous[[:space:]][[:space:]]*1' || true)"
+total="$(printf '%s\n' "$callsites" | grep -c 'uninstall_previous' || true)"
+assert_eq "$total" "2" "callsites: uninstall_previous still has exactly two call sites"
+assert_eq "$sweeping" "1" "callsites: exactly one of them opts into the hook sweep"
+
+# ===========================================================================
+# 8. The installer must stay `sh`-clean — it runs under /bin/sh, not bash.
+# ===========================================================================
+if sh -n "$INSTALL_SH" 2>/dev/null; then
+    pass "syntax: site/install.sh parses under /bin/sh"
+else
+    fail "syntax: site/install.sh parses under /bin/sh"
+fi
+
+if [ "$fails" -eq 0 ]; then
+    echo "$NAME: ALL PASS"
+else
+    echo "$NAME: $fails FAILED" >&2
+    exit 1
+fi

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -300,7 +300,10 @@ if want tools; then
   # asserts they agree — and a commit touching only one of those two is exactly
   # the commit that breaks the invariant, so leaving them out would skip the
   # test precisely when it matters (#1291).
-  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^go\.work$|^\.github/dependabot\.yml$' \
+  # site/install.sh is in the trigger set because tools/lib/install-uninstall_test.sh
+  # tests it (#1416). Without it a push touching only the installer would SKIP
+  # the one gate that covers the installer.
+  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$' \
                   "tools/lib shell-lib tests" shell_lib_tests
 fi
 


### PR DESCRIPTION
Closes #1416

## The defect

`site/install.sh`'s uninstall removed the LaunchAgent, the Linux systemd user unit, the app bundle and `~/.local/bin/irrlichd` — and never asked the daemon to remove what it had written into the user's *agent* configs. After a clean uninstall, `~/.claude/settings.json` and `~/.codex/hooks.json` still carried irrlicht's hook entries, pointing at a binary that no longer existed.

```
$ git show origin/main:site/install.sh | grep -c "uninstall-hooks"
0
```

## The fix

`uninstall_agent_hooks()` runs `irrlichd --uninstall-hooks` — the **registry-driven** sweep from #1357, so no second list of adapters is introduced here. Placement inside `uninstall_previous()` is load-bearing in both directions:

- **After** the daemon is stopped and its LaunchAgent/systemd unit are removed, so nothing can restart and re-apply the entries we just swept. (`Apply` is answer-driven and start-driven — `runClosureEffect` is reached only from `runEffects` at `permission_service.go:485`; there is no periodic re-apply.)
- **Before** the app bundle and the daemon binary are deleted, because the sweep needs one of them to run. Both install layouts are covered: `~/.local/bin/irrlichd` (daemon-only) and `<app>/Contents/MacOS/irrlichd` (full macOS install). Deliberately **not** `command -v irrlichd`, which can resolve to an unrelated dev build in a worktree.

### The sweep is opt-in, and only the real `--uninstall` opts in

`uninstall_previous()` has **two** call sites — the true uninstall (line ~203) and the re-install/upgrade path (line ~339). `--uninstall-hooks` does more than edit config files: `denyHooksPermissions` (`core/cmd/irrlichd/main.go:238-258`) records the hooks permissions as **denied**, so a persisted "granted" cannot re-install them on the next daemon start (#570). That denial lands in the user data an uninstall deliberately **keeps** — so sweeping on the upgrade path would silently switch hook-based monitoring off for a user who only asked for a newer version. Hence a parameter rather than an unconditional call, and a test asserting exactly one of the two call sites opts in.

### Fail soft, in both directions

Neither failure mode aborts the uninstall — the user asked for removal, and a half-removed product is worse than the residue:

- **Binary already gone** (partial earlier uninstall, hand-deleted binary): skips with a message naming the files to clean up by hand.
- **Sweep errors**: prints the binary's own output, then continues. Exit code stays 0 and the uninstall still reports success.

### `IRRLICHT_APP_PATH`

`APP_PATH` is the only install location not under `$HOME`, and `uninstall_previous` `rm -rf`s it. Without an override the new test would delete a developer's real `/Applications/Irrlicht.app` — and would pass on CI, where that path does not exist, while doing it.

## Red-first evidence

`tools/lib/install-uninstall_test.sh` was written before the fix and run against a tree carrying only the `IRRLICHT_APP_PATH` test-isolation line (required to run it safely at all). **12 assertions failed**:

```
FAIL: defect: ~/.claude/settings.json has no irrlichd entry left
      did NOT expect [irrlichd] in: {
  "hooks": { "SessionStart": [ ... "url": "http://127.0.0.1:7837/hooks/claudecode" ... ] },
  "statusLine": { "type": "command", "command": "irrlichd --statusline" }
}
FAIL: defect: ~/.claude/settings.json has no irrlicht hook endpoint left
FAIL: defect: ~/.codex/hooks.json has no irrlichd entry left
FAIL: ordering: irrlichd was invoked during the uninstall
FAIL: no-binary: says why the hook cleanup was skipped
FAIL: fail-soft: the failure is surfaced, not swallowed
FAIL: app-bundle: the in-bundle irrlichd was invoked
FAIL: app-bundle: ~/.claude/settings.json comes back clean
FAIL: linux: irrlichd was invoked on the systemd path too
FAIL: linux: ~/.codex/hooks.json comes back clean
FAIL: callsites: exactly one of them opts into the hook sweep
install-uninstall_test: 12 FAILED
```

After the fix: `install-uninstall_test: ALL PASS` (27 assertions).

No test here is a lock — every one of the 27 either failed on the pre-fix tree or is a new-contract assertion. The two `callsites:` assertions are structural rather than behavioural, because the upgrade path only reaches `uninstall_previous` after a real download and checksum.

## Test safety

The test runs the **real** `site/install.sh`, which kills processes and deletes install locations. Three things keep it off the host, all load-bearing and documented in the file header: a `mktemp -d` `HOME`, `IRRLICHT_APP_PATH`, and PATH stubs for `pgrep`/`pkill`/`lsof`/`launchctl`/`systemctl`. A `uname` stub forces the Linux systemd branch. Each red and green run was bracketed by a check that `/Applications/Irrlicht.app` survived.

## Also

`site/install.sh` added to the `tools` gate's trigger regex in `tools/preflight.sh` — otherwise a push touching only the installer would `SKIP` the one gate that now covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review round (subagent, `medium` effort) — 6 findings, all addressed

**1. Unguarded sweep could hang the uninstall forever.** irrlichd has no argument parser — an unknown flag falls through to *starting a daemon* (#1417, pinned deliberately by `core/cmd/irrlichd/dispatch_test.go`). Uninstalling a binary older than the flag would have booted a daemon inside a command substitution, binding the port `uninstall_previous` had just freed and blocking forever; under `curl | sh` the child inherits the script's stdin too. Fixed with `</dev/null` + a bounded wait (15s), which is the general form of the guard — it also covers a future binary that renames the verb, and a version check would have to run the same binary to ask.

*Correction to the review:* it put the flag's floor at v0.3.10. The earliest tag containing `5f95c1d5` is **v0.3.4** (`git tag --contains`), so the exposed window is narrower than reported. The guard is kept regardless, since it does not depend on knowing the floor.

**2. The documented macOS uninstall bypassed the fix.** `site/docs/installation.html` told users to `rm -rf /Applications/Irrlicht.app`, so the fix would not have reached anyone following the docs. Now leads with `install.sh --uninstall`, with a callout for the by-hand case.

**3. Test safety was asserted only after the destructive step.** The app-path isolation depends on install.sh honouring the override; if that were dropped, the test would delete the real `/Applications/Irrlicht.app` and *then* go red — invisibly on CI, where the path is absent. Now a hard precondition that refuses to run.

**4. A vacuous assertion.** `assert_contains "$out" "hook"` was satisfied by our own static warning line, leaving the line that replays the binary's diagnostics uncovered. Verified by mutation: deleting that line kept the suite green; it now turns it red.

**5. The "sh-clean" check could not catch bashisms.** On macOS `/bin/sh` is bash 3.2 in POSIX mode, and test.yml's shell-lib step runs on `macos-latest` — so the check could not catch the one defect class it existed for. Now prefers `dash`, and names which shell actually ran.

**6. Noisy clean-machine output.** The no-binary warning is compressed from three lines to two.

**Also:** the override is renamed `IRRLICHT_TEST_APP_PATH` — it is honoured by the removal path but not the install path, so a general-sounding name was misleading.

The hang guard has its own coverage (a stub that never exits, asserting bounded completion and no orphan process), so it does not become the next finding #4.

Final suite: **34 assertions, ALL PASS**. Every red/green run was bracketed by a check that `/Applications/Irrlicht.app` survived.
