### PR TITLE
feat(hooks): re-verify installed hook entries and repair them behind consent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,25 @@ Before marking a ticket done, run the full suite — every layer must pass:
   the diagnostics bundle's `hooks.json`; note that `--diagnose` runs in a process
   that never served a hook, so that form omits the counts and says so rather than
   publishing zeros (the live counts come from `GET /debug/bundle`).
+- Hook entry presence: not a contract family — a registry tripwire,
+  `TestEveryHookInstallDeclaresAVerifier`
+  (`core/adapters/inbound/agents/hookverify_test.go`), riding the same
+  projection as #1365's version-floor tripwire. It exists because the install
+  is not a one-shot fact: an agent whose own settings UI rewrites its config
+  deletes our entries silently, with the permission still reading `granted`
+  and no error anywhere. gemini-cli's writer is sync-by-omission and #1355's
+  Phase C audit verified the deletion live. So a hooks permission declares
+  `Verify` beside `Uninstall` (one line, `hookjson.Verify` does the matching
+  via the adapter's own `hookConfig`), and `services.HookEntryVerifier`
+  re-reads every granted install on a timer, repairing through
+  `PermissionService.RepairGrantedHookInstall` — never through the adapter's
+  `Apply` directly, because the repair is a WRITE and has to pass the same
+  #570 consent the install did. An adapter that omits `Verify` is skipped in
+  silence, which is why the tripwire is the coverage rather than a per-adapter
+  test. Keep the three hook diagnoses distinguishable: entries GONE is this
+  one, entries present but nothing ARRIVING is #1368, and an install that
+  FAILED is #1362's `effect_error` — `hooks.json` prints all three side by
+  side and each note names the other two.
 - Hook receipts: `contracttesting.AssertHookReceiptObserved`
   (`core/internal/contracttesting/hook_receipt.go`) is the #1368 counterpart —
   the event that never *arrives*, rather than the one that arrives unrecognized.

--- a/core/adapters/inbound/agents/claudecode/agent.go
+++ b/core/adapters/inbound/agents/claudecode/agent.go
@@ -96,6 +96,10 @@ func Agent() agent.Agent {
 				Hooks: &agent.HookInstall{
 					ConfigPath: claudeSettingsPath,
 					Uninstall:  UninstallHooks,
+					// Read-only; the repair it feeds runs through
+					// PermissionService, which re-checks consent under its own
+					// lock before writing (#1372).
+					Verify: VerifyHooksInstalled,
 					// Declared, not implemented — PermissionService enforces it
 					// (#1365). Observed reads the version Claude Code stamps on
 					// every transcript line, which is what makes this gate real

--- a/core/adapters/inbound/agents/claudecode/hookinstaller.go
+++ b/core/adapters/inbound/agents/claudecode/hookinstaller.go
@@ -14,6 +14,7 @@ import (
 
 	"irrlicht/core/adapters/inbound/agents/agentpaths"
 	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/pkg/daemonaddr"
 )
 
@@ -215,6 +216,20 @@ func EnsureHooksInstalled() (bool, error) {
 		return false, err
 	}
 	return hookjson.EnsureInstalled(hookConfig(path))
+}
+
+// VerifyHooksInstalled reports which of our entries are missing from, or stale
+// in, ~/.claude/settings.json — without writing anything (issue #1372).
+//
+// Same hookConfig as the installer, so "stale" here means exactly what
+// EnsureHooksInstalled would rewrite, including an entry left pointing at a
+// port this daemon is not listening on.
+func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
+	path, err := claudeSettingsPath()
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	return hookjson.Verify(hookConfig(path))
 }
 
 // UninstallHooks removes irrlicht hook entries from ~/.claude/settings.json.

--- a/core/adapters/inbound/agents/codex/agent.go
+++ b/core/adapters/inbound/agents/codex/agent.go
@@ -79,6 +79,10 @@ func Agent() agent.Agent {
 				Hooks: &agent.HookInstall{
 					ConfigPath: codexHooksPath,
 					Uninstall:  UninstallHooks,
+					// Read-only; the repair it feeds runs through
+					// PermissionService, which re-checks consent under its own
+					// lock before writing (#1372).
+					Verify: VerifyHooksInstalled,
 					// The floor is declared, not implemented: PermissionService
 					// enforces it for every adapter (#1365). Observed reads
 					// cli_version out of the newest session header, so the common

--- a/core/adapters/inbound/agents/codex/hookinstaller.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller.go
@@ -14,6 +14,7 @@ import (
 
 	"irrlicht/core/adapters/inbound/agents/agentpaths"
 	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/pkg/daemonaddr"
 )
 
@@ -140,6 +141,18 @@ func EnsureHooksInstalled() (bool, error) {
 		return false, err
 	}
 	return hookjson.EnsureInstalled(hookConfig(path))
+}
+
+// VerifyHooksInstalled reports which of our entries are missing from, or stale
+// in, ~/.codex/hooks.json — without writing anything (issue #1372). Same
+// hookConfig as the installer, so "stale" means exactly what
+// EnsureHooksInstalled would rewrite.
+func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
+	path, err := codexHooksPath()
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	return hookjson.Verify(hookConfig(path))
 }
 
 // UninstallHooks removes irrlicht hook entries from ~/.codex/hooks.json.

--- a/core/adapters/inbound/agents/hookjson/hookjson.go
+++ b/core/adapters/inbound/agents/hookjson/hookjson.go
@@ -301,7 +301,7 @@ func upgradeGroupEntries(g interface{}, cfg Config) bool {
 		if !ok {
 			continue
 		}
-		if entryIsSentinel(hook, cfg.Sentinel) && !cfg.IsCanonical(hook) {
+		if entryIsStale(hook, cfg) {
 			entries[i] = cfg.Entry()
 			upgraded = true
 		}
@@ -342,18 +342,43 @@ func upgradeStaleMatchers(hooksMap map[string]interface{}, event string, cfg Con
 // reject — permanently, since EnsureInstalled would then report no change and
 // never revisit it.
 func reconcileGroupMatcher(group map[string]interface{}, expected string) bool {
-	if expected == "" {
-		if _, present := group["matcher"]; present {
-			delete(group, "matcher")
-			return true
-		}
+	if !matcherIsStale(group, expected) {
 		return false
 	}
-	if m, _ := group["matcher"].(string); m != expected {
-		group["matcher"] = expected
+	if expected == "" {
+		delete(group, "matcher")
 		return true
 	}
-	return false
+	group["matcher"] = expected
+	return true
+}
+
+// entryIsStale and matcherIsStale are the two definitions of "this install is
+// not what we would write today", and they are functions rather than inline
+// conditions so that EnsureInstalled's repair and Verify's read-only report
+// cannot drift apart (issue #1372).
+//
+// That drift is the whole risk of adding a second reader: a Verify that judged
+// staleness even slightly differently would either repair nothing while
+// reporting damage — a loop that writes forever and never converges — or
+// report health while EnsureInstalled would have rewritten the file. Both are
+// worse than not checking. TestVerifyAgreesWithEnsureInstalled pins the
+// equivalence over the same corpus rather than trusting this comment.
+func entryIsStale(hook map[string]interface{}, cfg Config) bool {
+	return entryIsSentinel(hook, cfg.Sentinel) && !cfg.IsCanonical(hook)
+}
+
+// matcherIsStale reports whether a sentinel-bearing group's matcher differs
+// from the one cfg now expects. Keyed off PRESENCE for the empty-expected case
+// for the reason reconcileGroupMatcher documents: `"matcher": null` in a
+// hand-edited file is a matcher key both upstreams reject.
+func matcherIsStale(group map[string]interface{}, expected string) bool {
+	if expected == "" {
+		_, present := group["matcher"]
+		return present
+	}
+	m, _ := group["matcher"].(string)
+	return m != expected
 }
 
 // addOurHook appends a matcher group holding entry to the event's array. The

--- a/core/adapters/inbound/agents/hookjson/verify.go
+++ b/core/adapters/inbound/agents/hookjson/verify.go
@@ -1,0 +1,122 @@
+// verify.go is the read-only half of the install (issue #1372).
+//
+// EnsureInstalled answers "make it so" and, by design, tells you almost nothing
+// afterwards: a bool saying whether it wrote. That was enough while the install
+// was treated as a one-shot fact — grant once, write once, assume forever. It
+// is not enough once the file can change underneath us.
+//
+// It can. gemini-cli's settings writer is sync-by-omission: applyKeyDiff
+// deletes every key present on disk but absent from the in-memory snapshot the
+// CLI took at startup, recursively, at every nesting level. Live-verified on
+// #1355's Phase C audit — with gemini running, an externally added top-level
+// key AND an externally added hooks.PreCompress entry were both silently
+// deleted by a single /theme change, and one of the write paths that can do it
+// (saveModelChange) is not user-initiated at all. Claude Code and Codex have
+// the same exposure to a hand-edit or a future in-app settings surface; it has
+// simply never been checked.
+//
+// So the question "are our entries still there" needs an answer that does not
+// require writing to find out. Calling EnsureInstalled on a schedule would
+// answer it, but only by performing the write — behind the user's back, on a
+// file whose consent they may have withdrawn since. Verify separates the
+// question from the answer: it reads, reports, and returns. The repair runs
+// through PermissionService, which owns the consent gate.
+package hookjson
+
+import (
+	"irrlicht/core/domain/agent"
+)
+
+// Verify reports which of cfg's events are not installed the way
+// EnsureInstalled would install them right now. It never writes.
+//
+// The verdict is deliberately built from the SAME predicates EnsureInstalled
+// repairs with — entryIsStale, matcherIsStale, HasOurHook — rather than from a
+// second reading of what "installed" means. Two definitions would drift, and
+// both directions of drift are live bugs: stricter than the repair is a loop
+// that writes on every pass and never converges, laxer is a clobbered install
+// that reads healthy in the diagnostics bundle. TestVerifyAgreesWithEnsureInstalled
+// pins the equivalence over a corpus of awkward files.
+//
+// An unreadable or malformed file is an error, not damage and not health.
+// Reporting damage would aim the repair at a file EnsureInstalled also refuses
+// to touch (it errors rather than overwrite content the user meant to keep), so
+// the loop would spin; reporting health would hide a genuinely broken config.
+// A file that does not EXIST is neither — ReadSettings treats it as an empty
+// document, so every event reads as missing, which is exactly right: that is
+// what deleting the settings file looks like, and installing is the fix.
+func Verify(cfg Config) (agent.HookEntryStatus, error) {
+	settings, err := ReadSettings(cfg.Path)
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+
+	hooksMap, _ := settings["hooks"].(map[string]interface{})
+	if hooksMap == nil {
+		// No hooks object at all — the shape a sync-by-omission clobber leaves
+		// behind. Every event is missing; nothing can be stale.
+		return agent.HookEntryStatus{Missing: append([]string(nil), cfg.Events...)}, nil
+	}
+
+	var status agent.HookEntryStatus
+	for _, event := range cfg.Events {
+		if !HasOurHook(hooksMap, event, cfg.Sentinel) {
+			status.Missing = append(status.Missing, event)
+			continue
+		}
+		// Present but possibly wrong. Missing and stale are exclusive per event
+		// on purpose: an event with no entry of ours cannot also have one in the
+		// wrong shape, and reporting it in both buckets would double every count
+		// the diagnostics bundle publishes.
+		if eventHasStaleEntry(hooksMap, event, cfg) || eventHasStaleMatcher(hooksMap, event, cfg) {
+			status.Stale = append(status.Stale, event)
+		}
+	}
+	return status, nil
+}
+
+// eventHasStaleEntry reports whether any sentinel-bearing inner hook of the
+// event is no longer canonical — the read-only twin of upgradeStaleEntries.
+func eventHasStaleEntry(hooksMap map[string]interface{}, event string, cfg Config) bool {
+	arr, ok := eventGroups(hooksMap, event)
+	if !ok {
+		return false
+	}
+	for _, g := range arr {
+		entries, ok := groupEntries(g)
+		if !ok {
+			continue
+		}
+		for _, h := range entries {
+			hook, ok := h.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if entryIsStale(hook, cfg) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// eventHasStaleMatcher reports whether any sentinel-bearing group of the event
+// carries a matcher other than the one cfg now expects — the read-only twin of
+// upgradeStaleMatchers.
+func eventHasStaleMatcher(hooksMap map[string]interface{}, event string, cfg Config) bool {
+	arr, ok := eventGroups(hooksMap, event)
+	if !ok {
+		return false
+	}
+	expected := cfg.MatcherFor(event)
+	for _, g := range arr {
+		group, ok := g.(map[string]interface{})
+		if !ok || !containsSentinel(g, cfg.Sentinel) {
+			continue
+		}
+		if matcherIsStale(group, expected) {
+			return true
+		}
+	}
+	return false
+}

--- a/core/adapters/inbound/agents/hookjson/verify_test.go
+++ b/core/adapters/inbound/agents/hookjson/verify_test.go
@@ -1,0 +1,375 @@
+package hookjson
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Verify is the read-only half of #1372: EnsureInstalled answers "make it so",
+// Verify answers "is it so", and the loop that repairs a clobbered config needs
+// the second before it is allowed to run the first.
+//
+// Every test here runs against both delivery shapes, for the reason
+// hookjson_test.go's header gives: a check that only holds for `type: http`
+// would leave Codex's curl install unverified and nothing would say so.
+
+// clobberedPath seeds path with an install and then deletes it the way
+// gemini-cli's sync-by-omission writer does — by dropping the whole "hooks"
+// key, not by editing our entries. That is the live-verified shape of the
+// defect (see #1372 / the Phase C audit on #1355), so it is the shape the
+// fixture uses.
+func clobberedPath(t *testing.T, mk func(string) Config) (string, Config) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "settings.json")
+	cfg := mk(path)
+	if _, err := EnsureInstalled(cfg); err != nil {
+		t.Fatalf("seed install: %v", err)
+	}
+	seedSettings(t, path, map[string]interface{}{"theme": "dark"})
+	return path, cfg
+}
+
+func TestVerify_IntactInstallReportsNoDamage(t *testing.T) {
+	for name, mk := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			cfg := mk(path)
+			if _, err := EnsureInstalled(cfg); err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			got, err := Verify(cfg)
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if !got.Intact() {
+				t.Errorf("freshly installed config reports damage %q; a verifier that "+
+					"cannot see its own install would repair on every pass forever", got.Damage())
+			}
+		})
+	}
+}
+
+func TestVerify_ExternallyDeletedEntriesAreReported(t *testing.T) {
+	for name, mk := range configs() {
+		t.Run(name, func(t *testing.T) {
+			_, cfg := clobberedPath(t, mk)
+			got, err := Verify(cfg)
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if got.Intact() {
+				t.Fatalf("Verify reports an intact install after the whole `hooks` key was " +
+					"deleted externally — this is the #1372 defect: the permission still reads " +
+					"granted, nothing errors, and waiting detection is silently gone")
+			}
+			if len(got.Missing) != len(cfg.Events) {
+				t.Errorf("Missing = %v, want all %d installed events %v",
+					got.Missing, len(cfg.Events), cfg.Events)
+			}
+			if len(got.Stale) != 0 {
+				t.Errorf("Stale = %v, want empty: nothing of ours is present to BE stale", got.Stale)
+			}
+		})
+	}
+}
+
+func TestVerify_SingleDeletedEventIsReportedAlone(t *testing.T) {
+	for name, mk := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			cfg := mk(path)
+			if _, err := EnsureInstalled(cfg); err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			settings, err := ReadSettings(path)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			hooks := settings["hooks"].(map[string]interface{})
+			delete(hooks, eventNoMatcher)
+			seedSettings(t, path, settings)
+
+			got, err := Verify(cfg)
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if len(got.Missing) != 1 || got.Missing[0] != eventNoMatcher {
+				t.Errorf("Missing = %v, want exactly [%s] — a partial clobber must not be "+
+					"rounded up to a total one, or the log line names events that are fine",
+					got.Missing, eventNoMatcher)
+			}
+		})
+	}
+}
+
+// A stale entry is the #1178 shape: our sentinel is still there, so nothing
+// looks deleted, but the endpoint names a port this daemon is not listening on.
+// It is a different bucket from Missing because a user reading the file sees an
+// irrlicht entry and concludes the install is fine.
+func TestVerify_StaleEndpointIsReportedAsStaleNotMissing(t *testing.T) {
+	for name, mk := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			cfg := mk(path)
+			if _, err := EnsureInstalled(cfg); err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			settings, err := ReadSettings(path)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			// Rewrite every inner entry into a shape that still carries the
+			// sentinel but is not canonical, exactly as a daemon on another port
+			// would have left it.
+			hooks := settings["hooks"].(map[string]interface{})
+			for _, groups := range hooks {
+				for _, g := range groups.([]interface{}) {
+					entries := g.(map[string]interface{})["hooks"].([]interface{})
+					for _, h := range entries {
+						hook := h.(map[string]interface{})
+						hook["timeout"] = 5
+						if _, ok := hook["url"]; ok {
+							hook["url"] = "http://" + cfg.Sentinel + "?stale=1"
+						} else {
+							hook["command"] = "curl http://" + cfg.Sentinel + " # stale"
+						}
+					}
+				}
+			}
+			seedSettings(t, path, settings)
+
+			got, err := Verify(cfg)
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if len(got.Missing) != 0 {
+				t.Errorf("Missing = %v, want empty: our entries are present, just wrong", got.Missing)
+			}
+			if len(got.Stale) != len(cfg.Events) {
+				t.Errorf("Stale = %v, want all %d events %v", got.Stale, len(cfg.Events), cfg.Events)
+			}
+		})
+	}
+}
+
+func TestVerify_StaleMatcherIsReported(t *testing.T) {
+	for name, mk := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			cfg := mk(path)
+			if _, err := EnsureInstalled(cfg); err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			settings, err := ReadSettings(path)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			hooks := settings["hooks"].(map[string]interface{})
+			for _, g := range hooks[eventWithMatcher].([]interface{}) {
+				g.(map[string]interface{})["matcher"] = "SomethingElse"
+			}
+			seedSettings(t, path, settings)
+
+			got, err := Verify(cfg)
+			if err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			if len(got.Stale) != 1 || got.Stale[0] != eventWithMatcher {
+				t.Errorf("Stale = %v, want [%s]: a rewritten matcher is a real divergence "+
+					"— EnsureInstalled reconciles it, so Verify must see it", got.Stale, eventWithMatcher)
+			}
+		})
+	}
+}
+
+// The single most important property: Verify must be a pure read. A verifier
+// that writes is a way to modify a user's config outside the consent gate.
+func TestVerify_NeverWritesAnything(t *testing.T) {
+	for name, mk := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path, cfg := clobberedPath(t, mk)
+			writes := 0
+			cfg.WriteFile = func(string, []byte) error {
+				writes++
+				return nil
+			}
+			before, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read before: %v", err)
+			}
+			if _, err := Verify(cfg); err != nil {
+				t.Fatalf("Verify: %v", err)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read after: %v", err)
+			}
+			if writes != 0 {
+				t.Errorf("Verify called WriteFile %d times; it must be a pure read — the "+
+					"repair is a separate step that runs behind the consent gate (#1372/#570)", writes)
+			}
+			if string(before) != string(after) {
+				t.Errorf("Verify changed the file on disk:\nbefore: %s\nafter:  %s", before, after)
+			}
+		})
+	}
+}
+
+// Malformed JSON must error rather than report an intact install. Reporting
+// intact would leave a genuinely broken config unrepaired and unmentioned;
+// reporting damage would send the repair loop at a file EnsureInstalled also
+// refuses to touch, spinning forever. Erroring is the only answer that lets the
+// caller count it as its own outcome.
+func TestVerify_MalformedJSONErrors(t *testing.T) {
+	for name, mk := range configs() {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			got, err := Verify(mk(path))
+			if err == nil {
+				t.Fatalf("Verify returned no error for malformed JSON (status %+v); "+
+					"EnsureInstalled errors on it too and the two must agree", got)
+			}
+		})
+	}
+}
+
+// A config file that does not exist yet is not an error and not "intact": the
+// entries are genuinely absent, which is precisely what a repair fixes. This is
+// also the shape a user gets by deleting the whole settings file.
+func TestVerify_MissingFileReportsEveryEventMissing(t *testing.T) {
+	for name, mk := range configs() {
+		t.Run(name, func(t *testing.T) {
+			cfg := mk(filepath.Join(t.TempDir(), "nope", "settings.json"))
+			got, err := Verify(cfg)
+			if err != nil {
+				t.Fatalf("Verify on absent file: %v", err)
+			}
+			if len(got.Missing) != len(cfg.Events) {
+				t.Errorf("Missing = %v, want all %d events", got.Missing, len(cfg.Events))
+			}
+		})
+	}
+}
+
+// TestVerifyAgreesWithEnsureInstalled is the equivalence that makes a second
+// reader safe. Verify().Intact() must be true exactly when EnsureInstalled
+// would report "nothing to do" — no more, no less.
+//
+// Disagreement in either direction is a live bug, not a cosmetic one. Verify
+// stricter than EnsureInstalled is a repair loop that reports damage, repairs
+// nothing, and writes forever; Verify laxer is a clobbered install that reads
+// healthy in the diagnostics bundle. The corpus is deliberately the awkward
+// cases: partial clobbers, hand-edited matchers, foreign entries alongside ours.
+func TestVerifyAgreesWithEnsureInstalled(t *testing.T) {
+	mutations := map[string]func(t *testing.T, path string, cfg Config){
+		"untouched": func(*testing.T, string, Config) {},
+		"hooks key deleted": func(t *testing.T, path string, _ Config) {
+			seedSettings(t, path, map[string]interface{}{"theme": "dark"})
+		},
+		"one event deleted": func(t *testing.T, path string, _ Config) {
+			s := mustRead(t, path)
+			delete(s["hooks"].(map[string]interface{}), eventNoMatcher)
+			seedSettings(t, path, s)
+		},
+		"matcher rewritten": func(t *testing.T, path string, _ Config) {
+			s := mustRead(t, path)
+			for _, g := range s["hooks"].(map[string]interface{})[eventWithMatcher].([]interface{}) {
+				g.(map[string]interface{})["matcher"] = "Other"
+			}
+			seedSettings(t, path, s)
+		},
+		"matcher added to turn-end event": func(t *testing.T, path string, _ Config) {
+			s := mustRead(t, path)
+			for _, g := range s["hooks"].(map[string]interface{})[eventNoMatcher].([]interface{}) {
+				g.(map[string]interface{})["matcher"] = "Bash"
+			}
+			seedSettings(t, path, s)
+		},
+		"entry made non-canonical": func(t *testing.T, path string, cfg Config) {
+			s := mustRead(t, path)
+			for _, groups := range s["hooks"].(map[string]interface{}) {
+				for _, g := range groups.([]interface{}) {
+					for _, h := range g.(map[string]interface{})["hooks"].([]interface{}) {
+						hook := h.(map[string]interface{})
+						if _, ok := hook["url"]; ok {
+							hook["url"] = "http://" + cfg.Sentinel + "/other"
+						} else {
+							hook["command"] = "curl http://" + cfg.Sentinel + "/other"
+						}
+					}
+				}
+			}
+			seedSettings(t, path, s)
+		},
+		"foreign group alongside ours": func(t *testing.T, path string, _ Config) {
+			s := mustRead(t, path)
+			hooks := s["hooks"].(map[string]interface{})
+			hooks[eventWithMatcher] = append(hooks[eventWithMatcher].([]interface{}),
+				map[string]interface{}{
+					"matcher": "Bash",
+					"hooks":   []interface{}{map[string]interface{}{"type": "command", "command": "echo mine"}},
+				})
+			seedSettings(t, path, s)
+		},
+		"only a foreign group": func(t *testing.T, path string, _ Config) {
+			seedSettings(t, path, map[string]interface{}{"hooks": map[string]interface{}{
+				eventWithMatcher: []interface{}{map[string]interface{}{
+					"matcher": "Bash",
+					"hooks":   []interface{}{map[string]interface{}{"type": "command", "command": "echo mine"}},
+				}},
+			}})
+		},
+	}
+
+	for shape, mk := range configs() {
+		for name, mutate := range mutations {
+			t.Run(shape+"/"+name, func(t *testing.T) {
+				path := filepath.Join(t.TempDir(), "settings.json")
+				cfg := mk(path)
+				if _, err := EnsureInstalled(cfg); err != nil {
+					t.Fatalf("seed install: %v", err)
+				}
+				mutate(t, path, cfg)
+
+				status, verr := Verify(cfg)
+				if verr != nil {
+					t.Fatalf("Verify: %v", verr)
+				}
+				modified, ierr := EnsureInstalled(cfg)
+				if ierr != nil {
+					t.Fatalf("EnsureInstalled: %v", ierr)
+				}
+				if status.Intact() == modified {
+					t.Errorf("Verify says intact=%v but EnsureInstalled %s the file.\n"+
+						"They must agree: a Verify stricter than the repair writes forever, "+
+						"a Verify laxer leaves a clobbered install reading healthy.\ndamage: %q",
+						status.Intact(), map[bool]string{true: "MODIFIED", false: "did NOT modify"}[modified],
+						status.Damage())
+				}
+				// And after the repair, Verify must be satisfied — otherwise the
+				// loop never converges no matter how the two disagree.
+				after, err := Verify(cfg)
+				if err != nil {
+					t.Fatalf("Verify after repair: %v", err)
+				}
+				if !after.Intact() {
+					t.Errorf("Verify still reports %q immediately after EnsureInstalled repaired "+
+						"the file — the repair loop would never converge", after.Damage())
+				}
+			})
+		}
+	}
+}
+
+func mustRead(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	s, err := ReadSettings(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return s
+}

--- a/core/adapters/inbound/agents/hookverify_test.go
+++ b/core/adapters/inbound/agents/hookverify_test.go
@@ -1,6 +1,8 @@
 package agents
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"irrlicht/core/domain/permission"
@@ -56,29 +58,63 @@ func TestEveryHookInstallDeclaresAVerifier(t *testing.T) {
 	}
 }
 
-// TestHookVerifiersAreReadOnlyOnAnAbsentConfig is the cheapest possible check
-// that a declared Verify is actually a read: called against the real resolved
-// config path it must not create the file, and must not panic or error merely
-// because nothing is installed.
+// TestHookVerifiersDoNotCreateTheConfigFile runs each adapter's PRODUCTION
+// Verify closure against an empty HOME and asserts it left no file behind.
 //
-// It runs the production closures rather than a fixture, so it covers the wiring
-// (right hookConfig, right path resolver) that a package-local test would mock
-// away. It deliberately asserts nothing about the CONTENT of the verdict — this
-// machine may or may not have Claude Code installed, and a test that depended on
-// that would be a flake, not a check.
-func TestHookVerifiersDoNotErrorOnARealPath(t *testing.T) {
+// It exercises the real wiring — the adapter's own path resolver and hookConfig
+// — which a package-local test would mock away, and it is the only mechanical
+// check that a declared Verify is genuinely a read. "Read-only" is the whole
+// reason the repair is a separate step behind the consent gate (#1372/#570); a
+// verifier that quietly created or rewrote the file would move a write outside
+// that gate while every consent test still passed.
+//
+// HOME (and CODEX_HOME) point at a temp dir, so this asserts on a known-empty
+// tree rather than on the developer's real config, which may legitimately hold
+// anything at all.
+func TestHookVerifiersDoNotCreateTheConfigFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir on windows
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	checked := 0
 	for _, a := range All() {
 		for _, p := range a.Permissions {
-			if p.Hooks == nil || p.Hooks.Verify == nil {
+			if p.Hooks == nil || p.Hooks.Verify == nil || p.Hooks.ConfigPath == nil {
 				continue
 			}
-			if _, err := p.Hooks.Verify(); err != nil {
-				// Malformed JSON in a developer's real config is a legitimate
-				// error and not this test's business, so this is only a signal
-				// when it fires in CI, where the home dir is clean.
-				t.Logf("%s/%s Verify returned %v (expected only for a malformed real config)",
+			path, err := p.Hooks.ConfigPath()
+			if err != nil {
+				t.Errorf("%s/%s: ConfigPath failed under a temp HOME: %v", a.Identity.Name, p.Key, err)
+				continue
+			}
+			if _, err := os.Stat(path); err == nil {
+				t.Fatalf("%s/%s: %s already exists under a fresh temp HOME — the fixture is "+
+					"not empty, so the assertion below would prove nothing",
+					a.Identity.Name, p.Key, path)
+			}
+
+			status, err := p.Hooks.Verify()
+			if err != nil {
+				t.Errorf("%s/%s: Verify errored on an absent config: %v — an install that is "+
+					"simply not there is the ordinary answer, not a fault",
 					a.Identity.Name, p.Key, err)
 			}
+			if status.Intact() {
+				t.Errorf("%s/%s: Verify reports an intact install with no config file at all "+
+					"(%+v); nothing is installed, so the loop would never repair it",
+					a.Identity.Name, p.Key, status)
+			}
+			if _, err := os.Stat(path); err == nil {
+				t.Errorf("%s/%s: Verify CREATED %s. It must be a pure read — the repair is a "+
+					"separate step that runs behind the #570 consent gate, and a verifier that "+
+					"writes moves a write outside that gate entirely",
+					a.Identity.Name, p.Key, path)
+			}
+			checked++
 		}
+	}
+	if checked == 0 {
+		t.Fatal("no hook adapter was exercised; this test passed without checking anything")
 	}
 }

--- a/core/adapters/inbound/agents/hookverify_test.go
+++ b/core/adapters/inbound/agents/hookverify_test.go
@@ -1,0 +1,84 @@
+package agents
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/permission"
+)
+
+// TestEveryHookInstallDeclaresAVerifier is the registry-wide tripwire for issue
+// #1372, and the third obligation to ride the projection #1357 added — after
+// #1365's version floor and #1357's own ConfigPath/Uninstall pair.
+//
+// It fails for a NEW adapter that installs hooks into a user config without
+// declaring how to check they are still there, before that adapter has a test
+// of its own. That matters more here than for most declarations, because the
+// omission is invisible in every other way: an adapter with no Verify is simply
+// skipped by the re-verification loop, so its entries can be deleted by the
+// agent's own settings UI and every surface — the permission state, the
+// diagnostics bundle, the wizard — goes on reading green. A missing
+// declaration produces no error, no log line and no empty row. It produces
+// nothing at all, which is the failure mode #1372 exists to end.
+//
+// Declaring it is one line: Verify: VerifyHooksInstalled, next to Uninstall.
+func TestEveryHookInstallDeclaresAVerifier(t *testing.T) {
+	for _, a := range All() {
+		for _, p := range a.Permissions {
+			if p.Hooks == nil {
+				continue
+			}
+			if p.Hooks.Verify == nil {
+				t.Errorf("%s/%s installs hooks into a user config but declares no Verify "+
+					"(#1372), so the re-verification loop skips it silently: the agent's own "+
+					"settings UI can delete our entries and the permission still reads granted "+
+					"with no error anywhere. Add Verify: VerifyHooksInstalled next to Uninstall.",
+					a.Identity.Name, p.Key)
+				continue
+			}
+			// A hooks permission must be modify-kind. The re-verification loop
+			// runs its repair through PermissionService's granted-effect path,
+			// which is the same #570 gate the original install passed; an
+			// observe-kind hooks permission would be a write behind a read
+			// consent, and there would be nothing in the loop to catch it.
+			if p.Kind != permission.KindModify {
+				t.Errorf("%s/%s declares a hook install but is kind %q, not %q — the #1372 "+
+					"repair writes to the user's config and must sit behind modify consent",
+					a.Identity.Name, p.Key, p.Kind, permission.KindModify)
+			}
+			// Apply is what the repair re-runs. A hooks permission without one
+			// could be verified and found damaged forever with no way to fix it.
+			if p.Apply == nil {
+				t.Errorf("%s/%s declares a hook install and a Verify but no Apply, so a "+
+					"damaged install can be detected and never repaired (#1372)",
+					a.Identity.Name, p.Key)
+			}
+		}
+	}
+}
+
+// TestHookVerifiersAreReadOnlyOnAnAbsentConfig is the cheapest possible check
+// that a declared Verify is actually a read: called against the real resolved
+// config path it must not create the file, and must not panic or error merely
+// because nothing is installed.
+//
+// It runs the production closures rather than a fixture, so it covers the wiring
+// (right hookConfig, right path resolver) that a package-local test would mock
+// away. It deliberately asserts nothing about the CONTENT of the verdict — this
+// machine may or may not have Claude Code installed, and a test that depended on
+// that would be a flake, not a check.
+func TestHookVerifiersDoNotErrorOnARealPath(t *testing.T) {
+	for _, a := range All() {
+		for _, p := range a.Permissions {
+			if p.Hooks == nil || p.Hooks.Verify == nil {
+				continue
+			}
+			if _, err := p.Hooks.Verify(); err != nil {
+				// Malformed JSON in a developer's real config is a legitimate
+				// error and not this test's business, so this is only a signal
+				// when it fires in CI, where the home dir is clean.
+				t.Logf("%s/%s Verify returned %v (expected only for a malformed real config)",
+					a.Identity.Name, p.Key, err)
+			}
+		}
+	}
+}

--- a/core/application/services/diagnostics_service.go
+++ b/core/application/services/diagnostics_service.go
@@ -94,6 +94,16 @@ type HookHealthSnapshot struct {
 	// ReceiptsTotal is every consent-passed hook request this process was
 	// handed, across all adapters.
 	ReceiptsTotal uint64
+
+	// EntryReverification is the periodic entry-presence loop's view (#1372):
+	// per hook install, whether our entries are still in the agent's config,
+	// how often they have had to be put back, and whether a repair storm is
+	// being backed off from. It rides in this same snapshot, and renders into
+	// the same hooks.json section, for the reason Channels does — a reader
+	// looking at "hooks aren't working" needs all three diagnoses side by side,
+	// and a fourth nil-meaningful seam would be a fourth thing to get wrong in
+	// the --diagnose case.
+	EntryReverification HookEntryReverifySnapshot
 }
 
 // DiagnosticsServiceDeps bundles NewDiagnosticsService's dependencies.
@@ -454,10 +464,18 @@ func (s *DiagnosticsService) hooksView() any {
 		// process that could not have observed one — the very thing the note
 		// beside it says is not being done.
 		return struct {
-			CollectedFrom string `json:"collected_from"`
-			Note          string `json:"note"`
-			LivenessNote  string `json:"liveness_note"`
+			CollectedFrom     string `json:"collected_from"`
+			Note              string `json:"note"`
+			LivenessNote      string `json:"liveness_note"`
+			EntryReverifyNote string `json:"entry_reverification_note"`
 		}{
+			EntryReverifyNote: "The hook-entry re-verification loop (#1372) is omitted here for the same reason: " +
+				"it runs in the daemon, so this process has performed no passes and its counters are " +
+				"structurally zero — publishing them would report 'entries verified present' from a process " +
+				"that never looked. Its repairs ARE logged, so events.log in this bundle still carries any " +
+				"`hook entries were ... and have been re-installed` line, and a repair that failed is on the " +
+				"permission as effect_error in permissions.json. For the live view, fetch GET /debug/bundle " +
+				"from the running daemon.",
 			CollectedFrom: "cli",
 			Note: "Collected by `irrlichd --diagnose`, which runs in a process that never served a hook, " +
 				"so the receivers' unrecognized-event counters are not readable here and are omitted rather than " +
@@ -489,23 +507,88 @@ func (s *DiagnosticsService) hooksView() any {
 	// is nothing here to alias and re-sorting would be a second copy of one
 	// comparator that no test could see go stale.
 	channels := snap.Channels
+	reverify := snap.EntryReverification
 	return struct {
-		CollectedFrom            string              `json:"collected_from"`
-		HookRequestsReceived     uint64              `json:"hook_requests_received"`
-		Channels                 []HookChannelHealth `json:"channels,omitempty"`
-		SilentChannelNote        string              `json:"silent_channel_note,omitempty"`
-		UnknownEventsTotal       uint64              `json:"unknown_events_total"`
-		UnknownEvents            []UnknownHookEvent  `json:"unknown_events,omitempty"`
-		UnknownEventNamesDropped map[string]uint64   `json:"unknown_event_names_dropped_by_adapter,omitempty"`
+		CollectedFrom            string                     `json:"collected_from"`
+		HookRequestsReceived     uint64                     `json:"hook_requests_received"`
+		Channels                 []HookChannelHealth        `json:"channels,omitempty"`
+		SilentChannelNote        string                     `json:"silent_channel_note,omitempty"`
+		EntryReverification      []HookEntryHealth          `json:"entry_reverification,omitempty"`
+		EntryReverifyOutcomes    map[ReverifyOutcome]uint64 `json:"entry_reverification_outcomes,omitempty"`
+		EntryReverifyNote        string                     `json:"entry_reverification_note,omitempty"`
+		UnknownEventsTotal       uint64                     `json:"unknown_events_total"`
+		UnknownEvents            []UnknownHookEvent         `json:"unknown_events,omitempty"`
+		UnknownEventNamesDropped map[string]uint64          `json:"unknown_event_names_dropped_by_adapter,omitempty"`
 	}{
 		CollectedFrom:            "daemon",
 		HookRequestsReceived:     snap.ReceiptsTotal,
 		Channels:                 channels,
 		SilentChannelNote:        silentChannelNote(channels),
+		EntryReverification:      reverify.Targets,
+		EntryReverifyOutcomes:    reverify.Outcomes,
+		EntryReverifyNote:        entryReverificationNote(reverify.Targets),
 		UnknownEventsTotal:       snap.UnknownEventsTotal,
 		UnknownEvents:            events,
 		UnknownEventNamesDropped: snap.UnknownNamesDropped,
 	}
+}
+
+// entryReverificationNote spells out what the entry_reverification rows mean
+// (issue #1372) — and, like silentChannelNote beside it, what they do not.
+//
+// Emitted only when there is something to say: a repair has happened, or a
+// target is currently damaged, or a config could not be read. A bundle from a
+// healthy machine keeps the terse rows and no essay.
+//
+// The three-way disambiguation is repeated here rather than cross-referenced
+// because the two notes are read independently — a reader lands on whichever
+// one fired — and the whole failure this family of issues is about is that the
+// same symptom has three causes with three different first moves.
+func entryReverificationNote(rows []HookEntryHealth) string {
+	var repaired, damaged, unreadable []string
+	for _, r := range rows {
+		switch {
+		case r.LastOutcome == string(ReverifyUnreadable):
+			unreadable = append(unreadable, r.Adapter)
+		case len(r.Missing) > 0 || len(r.Stale) > 0:
+			damaged = append(damaged, r.Adapter)
+		}
+		if r.Repairs > 0 {
+			repaired = append(repaired, fmt.Sprintf("%s (%d)", r.Adapter, r.Repairs))
+		}
+	}
+	if len(repaired) == 0 && len(damaged) == 0 && len(unreadable) == 0 {
+		return ""
+	}
+
+	note := "irrlicht re-verifies that its hook entries are still present in each agent's own config, " +
+		"on a timer, and re-installs them when they are not (#1372). "
+	if len(repaired) > 0 {
+		note += "Re-installed this session: " + strings.Join(repaired, ", ") + ". " +
+			"A non-zero count means something OUTSIDE irrlicht removed or rewrote those entries after " +
+			"the user granted the permission — an agent whose own settings UI syncs by omission deletes " +
+			"every key it did not know about on any config change, and gemini-cli is confirmed to do " +
+			"exactly that. A count that keeps climbing is that, happening repeatedly; the loop backs off " +
+			"exponentially rather than fighting it, so consecutive_repairs and backoff_seconds are the " +
+			"fields to read. "
+	}
+	if len(damaged) > 0 {
+		note += "Currently damaged: " + strings.Join(damaged, ", ") +
+			" — entries are missing or stale as of the last pass and the repair has not yet succeeded. "
+	}
+	if len(unreadable) > 0 {
+		note += "Unreadable: " + strings.Join(unreadable, ", ") +
+			" — the config could not be parsed, so nothing was written; the installer refuses to " +
+			"overwrite a file it cannot read, and this needs a human. "
+	}
+	note += "This section is about whether the entries EXIST. It is a different question from " +
+		"whether anything is arriving through them, which is the channels/silent_channel_note above " +
+		"(#1368), and from an install that FAILED and never wrote entries at all, which shows up as " +
+		"effect_error on the permission (#1362). A repair that fails is recorded there too, so a " +
+		"repair_failed count here has its reason on the permission. " +
+		"watched:false means the permission is not currently granted, so nothing is read or written " +
+		"for that row at all — not that the entries are gone."
+	return note
 }
 
 // silentChannelNote spells out what a `"silent": true` row means, and — just as
@@ -530,9 +613,11 @@ func silentChannelNote(channels []HookChannelHealth) string {
 		"threshold while consent was granted and the install reported success, so they were demoted to the " +
 		"transcript tier and any hook-tier holds they had placed were released (#1368). This says entries were " +
 		"WRITTEN and nothing is arriving through them. It does NOT mean the entries are still present — if " +
-		"something removed them since, this is how that looks too (#1372). And it is a different fault from an " +
-		"install that FAILED, which never wrote entries at all and shows up as effect_error on the permission " +
-		"rather than here (#1362). Check the agent's own hook config next, then the daemon's bind port."
+		"something removed them since, this is how that looks too, and the entry_reverification rows below are " +
+		"what tell those apart (#1372): a row with repairs:0 and no missing/stale means the entries WERE there " +
+		"at the last pass, so this really is a dead channel and not a clobbered config. And it is a different " +
+		"fault from an install that FAILED, which never wrote entries at all and shows up as effect_error on " +
+		"the permission rather than here (#1362). Check the daemon's bind port next."
 }
 
 func stateView(sessions []*session.SessionState, now time.Time) any {

--- a/core/application/services/diagnostics_service.go
+++ b/core/application/services/diagnostics_service.go
@@ -547,10 +547,16 @@ func (s *DiagnosticsService) hooksView() any {
 func entryReverificationNote(rows []HookEntryHealth) string {
 	var repaired, damaged, unreadable []string
 	for _, r := range rows {
-		switch {
-		case r.LastOutcome == string(ReverifyUnreadable):
+		// Keyed off the OUTCOME, never off the residue. Missing/Stale record
+		// what the last verdict FOUND and survive a successful repair until the
+		// next intact pass clears them — which is at least one back-off window
+		// later — so classifying on their length alone reports every repaired
+		// target as "the repair has not yet succeeded" for up to an hour after
+		// it did.
+		switch r.LastOutcome {
+		case string(ReverifyUnreadable):
 			unreadable = append(unreadable, r.Adapter)
-		case len(r.Missing) > 0 || len(r.Stale) > 0:
+		case string(ReverifyRepairFailed):
 			damaged = append(damaged, r.Adapter)
 		}
 		if r.Repairs > 0 {
@@ -573,8 +579,10 @@ func entryReverificationNote(rows []HookEntryHealth) string {
 			"fields to read. "
 	}
 	if len(damaged) > 0 {
-		note += "Currently damaged: " + strings.Join(damaged, ", ") +
-			" — entries are missing or stale as of the last pass and the repair has not yet succeeded. "
+		note += "Repair FAILED for: " + strings.Join(damaged, ", ") +
+			" — entries are missing or stale and the re-install errored, so they are still not " +
+			"installed. The reason is on the permission as effect_error in permissions.json, and " +
+			"re-granting the permission in the wizard retries it. "
 	}
 	if len(unreadable) > 0 {
 		note += "Unreadable: " + strings.Join(unreadable, ", ") +

--- a/core/application/services/diagnostics_service_test.go
+++ b/core/application/services/diagnostics_service_test.go
@@ -366,6 +366,11 @@ func TestHooksBundleOmitsCountsWhenNotCollectedInDaemon(t *testing.T) {
 	for _, field := range []string{
 		"unknown_events", "unknown_events_total", "unknown_event_names_dropped_by_adapter",
 		"hook_requests_received", "channels", "silent_channel_note",
+		// The #1372 DATA fields, on the same footing. Its note is deliberately
+		// not in this list: like liveness_note, the CLI form publishes an
+		// explanation of the absence, which is the opposite of publishing a
+		// number nobody observed.
+		"entry_reverification", "entry_reverification_outcomes",
 	} {
 		if v, ok := got[field]; ok {
 			t.Errorf("%s is present without a daemon to read it from: %v", field, v)
@@ -479,4 +484,120 @@ func hooksJSON(t *testing.T, svc *DiagnosticsService) map[string]any {
 		t.Fatalf("hooks.json is not valid JSON: %v\n%s", err, raw)
 	}
 	return out
+}
+
+// --- #1372: the entry re-verification half of hooks.json ------------------
+
+// TestHooksBundleReportsEntryReverification covers what a bug reporter needs to
+// see when the agent's own settings UI has been eating our entries: which file,
+// how many times it has been put back, and whether the loop is currently
+// backing off from a fight it is losing.
+func TestHooksBundleReportsEntryReverification(t *testing.T) {
+	svc := buildTestServiceWithHooks(t, func() HookHealthSnapshot {
+		return HookHealthSnapshot{
+			ReceiptsTotal: 4,
+			EntryReverification: HookEntryReverifySnapshot{
+				Outcomes: map[ReverifyOutcome]uint64{
+					ReverifyIntact: 40, ReverifyRepaired: 7, ReverifyBackoff: 12,
+				},
+				Targets: []HookEntryHealth{
+					{
+						Adapter: "claude-code", Permission: "hooks",
+						ConfigPath: "/Users/x/.claude/settings.json", Watched: true,
+						Missing: []string{"Stop"}, Repairs: 7, ConsecutiveRepairs: 5,
+						LastOutcome: string(ReverifyRepaired), BackoffSeconds: 1800,
+					},
+					{Adapter: "codex", Permission: "hooks", Watched: false},
+				},
+			},
+		}
+	})
+
+	got := hooksJSON(t, svc)
+
+	rows, _ := got["entry_reverification"].([]any)
+	if len(rows) != 2 {
+		t.Fatalf("entry_reverification has %d rows, want 2: %v", len(rows), got["entry_reverification"])
+	}
+	damaged, _ := rows[0].(map[string]any)
+	if damaged["adapter"] != "claude-code" || damaged["repairs"] != float64(7) {
+		t.Errorf("damaged row = %v, want claude-code with 7 repairs", damaged)
+	}
+	if damaged["config_path"] == nil || damaged["config_path"] == "" {
+		t.Errorf("row carries no config_path; the reader cannot go look: %v", damaged)
+	}
+	if damaged["backoff_seconds"] != float64(1800) {
+		t.Errorf("backoff_seconds = %v, want 1800 — the deferral in force is how a reader "+
+			"tells a one-off clobber from a repair storm", damaged["backoff_seconds"])
+	}
+	unwatched, _ := rows[1].(map[string]any)
+	if v, ok := unwatched["watched"]; ok && v == true {
+		t.Errorf("a row with no consent must not read as watched: %v", unwatched)
+	}
+
+	outcomes, _ := got["entry_reverification_outcomes"].(map[string]any)
+	if outcomes[string(ReverifyRepaired)] != float64(7) {
+		t.Errorf("outcomes[%s] = %v, want 7", ReverifyRepaired, outcomes[string(ReverifyRepaired)])
+	}
+	if _, present := outcomes[string(ReverifyRepairFailed)]; present {
+		t.Errorf("a zero outcome is published: %v — zeros read as an all-clear", outcomes)
+	}
+
+	// Same obligation the silent-channel note carries, and for the same reason:
+	// three causes, three first moves, and a reader who should not have to know
+	// which issue owns which.
+	note, _ := got["entry_reverification_note"].(string)
+	if note == "" {
+		t.Fatal("repaired entries must carry an explanation; hooks.json is what a bug reporter pastes")
+	}
+	for _, want := range []string{"claude-code", "#1372", "#1368", "#1362", "effect_error", "watched:false"} {
+		if !strings.Contains(note, want) {
+			t.Errorf("entry_reverification_note must mention %q so the reader is not sent to the "+
+				"wrong fix; got:\n%s", want, note)
+		}
+	}
+}
+
+// A healthy machine gets rows and no essay — the same terseness rule the
+// silent-channel note follows.
+func TestHooksBundleOmitsTheReverificationNoteWhenHealthy(t *testing.T) {
+	got := hooksJSON(t, buildTestServiceWithHooks(t, func() HookHealthSnapshot {
+		return HookHealthSnapshot{
+			EntryReverification: HookEntryReverifySnapshot{
+				Outcomes: map[ReverifyOutcome]uint64{ReverifyIntact: 99},
+				Targets: []HookEntryHealth{
+					{Adapter: "codex", Permission: "hooks", Watched: true, LastOutcome: string(ReverifyIntact)},
+				},
+			},
+		}
+	}))
+	if v, ok := got["entry_reverification_note"]; ok {
+		t.Errorf("a healthy bundle carries the re-verification essay: %v", v)
+	}
+	if rows, _ := got["entry_reverification"].([]any); len(rows) != 1 {
+		t.Errorf("the ROWS must still be published when healthy (got %v) — an absent row is "+
+			"indistinguishable from a bundle collected before the feature existed", got["entry_reverification"])
+	}
+}
+
+// The --diagnose process runs no passes, so publishing "entries verified
+// present" from it would be a measurement nobody took. Same honesty obligation
+// as #1364's counters and #1368's channels.
+func TestHooksBundleOmitsReverificationWhenNotCollectedInDaemon(t *testing.T) {
+	got := hooksJSON(t, buildTestServiceWithHooks(t, nil))
+
+	for _, field := range []string{"entry_reverification", "entry_reverification_outcomes"} {
+		if v, ok := got[field]; ok {
+			t.Errorf("%s is present without a daemon to read it from: %v", field, v)
+		}
+	}
+	note, _ := got["entry_reverification_note"].(string)
+	if !strings.Contains(note, "#1372") || !strings.Contains(note, "/debug/bundle") {
+		t.Errorf("entry_reverification_note must say why it is absent and where the real view "+
+			"is: %q", note)
+	}
+	if !strings.Contains(note, "effect_error") {
+		t.Errorf("the CLI note must still point at permissions.json for a failed repair, since "+
+			"that IS readable from this process: %q", note)
+	}
 }

--- a/core/application/services/diagnostics_service_test.go
+++ b/core/application/services/diagnostics_service_test.go
@@ -556,6 +556,40 @@ func TestHooksBundleReportsEntryReverification(t *testing.T) {
 				"wrong fix; got:\n%s", want, note)
 		}
 	}
+	// The fixture row is a SUCCESSFUL repair that still carries Missing:[Stop]
+	// — the residue every repair leaves until the next intact pass clears it,
+	// which is at least one back-off window later. Classifying on that residue
+	// rather than on last_outcome told the reader the repair had failed, in the
+	// same paragraph as "Re-installed this session: claude-code (7)".
+	if strings.Contains(note, "Repair FAILED") || strings.Contains(note, "has not yet succeeded") {
+		t.Errorf("a repaired target is reported as a failed repair; hooks.json is what a bug "+
+			"reporter pastes, and this sends them hunting a failure that did not happen:\n%s", note)
+	}
+}
+
+// The other half of the same rule: a repair that really DID fail must be named,
+// so tightening the classifier above cannot silently swallow the real case.
+func TestHooksBundleReportsAFailedRepairAsFailed(t *testing.T) {
+	got := hooksJSON(t, buildTestServiceWithHooks(t, func() HookHealthSnapshot {
+		return HookHealthSnapshot{
+			EntryReverification: HookEntryReverifySnapshot{
+				Outcomes: map[ReverifyOutcome]uint64{ReverifyRepairFailed: 3},
+				Targets: []HookEntryHealth{{
+					Adapter: "codex", Permission: "hooks", Watched: true,
+					Missing: []string{"Stop"}, Repairs: 3, ConsecutiveRepairs: 3,
+					LastOutcome: string(ReverifyRepairFailed),
+					LastError:   "installed CLI is 0.100.0, which is older than the 0.144.4 required",
+				}},
+			},
+		}
+	}))
+	note, _ := got["entry_reverification_note"].(string)
+	if !strings.Contains(note, "Repair FAILED") || !strings.Contains(note, "codex") {
+		t.Errorf("a genuinely failed repair is not named in the note:\n%s", note)
+	}
+	if !strings.Contains(note, "effect_error") {
+		t.Errorf("the failed-repair sentence must point at where the reason actually is:\n%s", note)
+	}
 }
 
 // A healthy machine gets rows and no essay — the same terseness rule the

--- a/core/application/services/hook_liveness.go
+++ b/core/application/services/hook_liveness.go
@@ -12,12 +12,14 @@
 //     visible as PermissionView.EffectError and a permissions LogError (#1362).
 //     The watchdog stays disarmed for that adapter, so it can never re-report
 //     that failure in weaker words.
-//   - entries written and later REMOVED by something else — #1372, not built.
-//     The watchdog will eventually call such a channel silent, because from in
-//     here it is silent; what it does NOT do is claim to know why. Its log line
-//     and its lifecycle event say "nothing is arriving", never "the entries are
-//     present", and hooks.json names #1372 as the thing that would tell them
-//     apart.
+//   - entries written and later REMOVED by something else — #1372, now built,
+//     and deliberately still a separate diagnosis. The watchdog will call such
+//     a channel silent, because from in here it is silent; what it does NOT do
+//     is claim to know why. Its log line and its lifecycle event say "nothing
+//     is arriving", never "the entries are present". The entry re-verification
+//     loop (hook_reverify.go) is what answers the other half, by re-reading the
+//     file; hooks.json prints both sections so a reader can tell a dead channel
+//     from a clobbered config without knowing which issue owns which.
 //   - hooks arriving under names we do not recognize — #1364. Those still count
 //     as receipts, because the channel is demonstrably alive; the unknown-event
 //     counters in the same hooks.json section are what say the names are wrong.

--- a/core/application/services/hook_reverify.go
+++ b/core/application/services/hook_reverify.go
@@ -132,8 +132,9 @@ type HookEntryHealth struct {
 	// ConfigPath is the file being verified. Without it the finding is not
 	// actionable — the reader cannot go look.
 	ConfigPath string `json:"config_path,omitempty"`
-	// Watched is whether consent was granted at the last pass. A false row is
-	// published, not omitted.
+	// Watched is whether the last pass actually examined this target — i.e.
+	// consent was granted then. False also covers "no pass has run yet", which
+	// LastOutcome distinguishes. A false row is published, not omitted.
 	Watched bool `json:"watched"`
 	// Missing and Stale are the last verdict's detail, empty when intact.
 	Missing []string `json:"missing,omitempty"`
@@ -202,7 +203,6 @@ func (t reverifyTarget) id() string { return t.adapter + "/" + t.permKey }
 
 // reverifyState is one target's episode memory.
 type reverifyState struct {
-	watched            bool
 	missing            []string
 	stale              []string
 	repairs            uint64
@@ -397,7 +397,6 @@ func (v *HookEntryVerifier) checkTarget(t reverifyTarget, now time.Time, granted
 	if granted == nil || !granted(t.adapter, t.permKey) {
 		v.mu.Lock()
 		st := v.state[t.id()]
-		st.watched = false
 		st.reset()
 		st.lastOutcome = ReverifyNoConsent
 		v.mu.Unlock()
@@ -407,7 +406,6 @@ func (v *HookEntryVerifier) checkTarget(t reverifyTarget, now time.Time, granted
 
 	v.mu.Lock()
 	st := v.state[t.id()]
-	st.watched = true
 	deferred := !st.nextEligible.IsZero() && now.Before(st.nextEligible)
 	v.mu.Unlock()
 	if deferred {
@@ -484,7 +482,6 @@ func (v *HookEntryVerifier) repair(t reverifyTarget, status agent.HookEntryStatu
 		// decision.
 		v.mu.Lock()
 		st := v.state[t.id()]
-		st.watched = false
 		st.reset()
 		st.lastOutcome = ReverifyNoConsent
 		v.mu.Unlock()
@@ -632,7 +629,12 @@ func (v *HookEntryVerifier) Snapshot() HookEntryReverifySnapshot {
 			ConfigPath: t.configPath,
 		}
 		if st != nil {
-			row.Watched = st.watched
+			// Derived, never stored. hook_liveness.go's hookChannelState carries
+			// the same rule and the reason: a second field that has to agree with
+			// the first forever eventually does not, and the row it then prints
+			// ("watched": true beside "last_outcome": "skipped_no_consent") is an
+			// assertion no pass ever made.
+			row.Watched = st.lastOutcome != "" && st.lastOutcome != ReverifyNoConsent
 			// An empty lastOutcome means no pass has run yet. Published as its
 			// own word rather than omitted: every other field is then at its
 			// zero value too, and "watched:false, repairs:0, nothing missing"

--- a/core/application/services/hook_reverify.go
+++ b/core/application/services/hook_reverify.go
@@ -81,6 +81,11 @@ const (
 	// different problem from one clobbered once — and it is the one thing the
 	// counters alone would not put in front of a reader of events.log.
 	reverifyStormThreshold = 3
+
+	// reverifyNoPassYet is the last_outcome published for a target the loop has
+	// not yet examined. Not a ReverifyOutcome: nothing counts it, because no
+	// decision was made.
+	reverifyNoPassYet = "no_pass_yet"
 )
 
 // ReverifyOutcome is what one pass decided about one target. The set is closed,
@@ -202,10 +207,16 @@ type reverifyState struct {
 	stale              []string
 	repairs            uint64
 	consecutiveRepairs int
-	lastOutcome        ReverifyOutcome
-	backoff            time.Duration
-	nextEligible       time.Time
-	lastError          string
+	// consecutiveUnreadable escalates the deferral for a config that cannot be
+	// parsed. It is a SEPARATE counter from consecutiveRepairs, which is
+	// published as a repair count: an unreadable config is never repaired, so
+	// borrowing that field to drive the back-off would put a number in the
+	// diagnostics bundle claiming writes that never happened.
+	consecutiveUnreadable int
+	lastOutcome           ReverifyOutcome
+	backoff               time.Duration
+	nextEligible          time.Time
+	lastError             string
 }
 
 // reset returns a target to "nothing is going on", used when consent goes away
@@ -215,6 +226,7 @@ type reverifyState struct {
 func (s *reverifyState) reset() {
 	s.missing, s.stale = nil, nil
 	s.consecutiveRepairs = 0
+	s.consecutiveUnreadable = 0
 	s.backoff = 0
 	s.nextEligible = time.Time{}
 	s.lastError = ""
@@ -278,6 +290,11 @@ func NewHookEntryVerifier(cfg HookEntryReverifyConfig) *HookEntryVerifier {
 	if cfg.BackoffBase <= 0 {
 		cfg.BackoffBase = defaultReverifyBackoffBase
 	}
+	// Two clamps, not a copy-paste. The first supplies the default for an unset
+	// or nonsensical cap; the second catches the case the default cannot serve —
+	// a caller passing a BackoffBase LARGER than the default cap, where leaving
+	// the default in place would make the cap smaller than the base and
+	// backoffFor's guard would return the cap on the very first repair.
 	if cfg.BackoffMax < cfg.BackoffBase {
 		cfg.BackoffMax = defaultReverifyBackoffMax
 	}
@@ -321,6 +338,18 @@ func (v *HookEntryVerifier) Run(ctx context.Context) {
 	if v == nil || len(v.targets) == 0 {
 		return
 	}
+	// One pass immediately, before the first tick. Two reasons: a clobber that
+	// happened while the daemon was down is repaired at once rather than up to
+	// an Interval later, and — the reporting one — a bundle collected in the
+	// first few minutes of uptime would otherwise show every row in its zero
+	// state, which reads as "not granted, nothing wrong" for a permission that
+	// may be granted and an install that may be gone.
+	//
+	// Safe to run here: the caller starts this only after PermissionService.Start
+	// has synchronously re-applied every granted install, so this pass observes
+	// the boot repair rather than racing it.
+	v.pass(v.now())
+
 	ticker := time.NewTicker(v.cfg.Interval)
 	defer ticker.Stop()
 	for {
@@ -388,7 +417,7 @@ func (v *HookEntryVerifier) checkTarget(t reverifyTarget, now time.Time, granted
 
 	status, err := t.verify()
 	if err != nil {
-		v.recordUnreadable(t, err)
+		v.recordUnreadable(t, err, now)
 		return
 	}
 	if status.Intact() {
@@ -398,7 +427,7 @@ func (v *HookEntryVerifier) checkTarget(t reverifyTarget, now time.Time, granted
 	v.repair(t, status, now, repair)
 }
 
-func (v *HookEntryVerifier) recordUnreadable(t reverifyTarget, err error) {
+func (v *HookEntryVerifier) recordUnreadable(t reverifyTarget, err error, now time.Time) {
 	v.mu.Lock()
 	st := v.state[t.id()]
 	first := st.lastOutcome != ReverifyUnreadable
@@ -407,7 +436,13 @@ func (v *HookEntryVerifier) recordUnreadable(t reverifyTarget, err error) {
 	// Defer the next read as well: a config we cannot parse will not become
 	// parseable by being read again in five minutes, and this is the same spin
 	// the storm back-off prevents, arriving by a different route.
-	st.backoff = v.backoffFor(st.consecutiveRepairs + 1)
+	//
+	// nextEligible is what checkTarget actually reads — setting only backoff
+	// would publish a deferral in the diagnostics bundle that does not exist,
+	// which is a worse failure than not deferring at all.
+	st.consecutiveUnreadable++
+	st.backoff = v.backoffFor(st.consecutiveUnreadable)
+	st.nextEligible = now.Add(st.backoff)
 	v.mu.Unlock()
 	v.count(ReverifyUnreadable)
 	if first && v.cfg.Log != nil {
@@ -459,6 +494,12 @@ func (v *HookEntryVerifier) repair(t reverifyTarget, status agent.HookEntryStatu
 
 	v.mu.Lock()
 	st := v.state[t.id()]
+	// Captured before lastOutcome is overwritten: the failure branch below logs
+	// only on the FIRST failure of an episode, the same once-per-episode rule
+	// recordUnreadable and logRepair follow. Without it a permanently failing
+	// repair — the shape a CLI below the #1365 version floor produces — writes
+	// an error line every pass for the life of the daemon.
+	firstFailure := st.lastOutcome != ReverifyRepairFailed
 	st.repairs++
 	st.consecutiveRepairs++
 	st.missing = append([]string(nil), status.Missing...)
@@ -475,7 +516,7 @@ func (v *HookEntryVerifier) repair(t reverifyTarget, status agent.HookEntryStatu
 
 	if err != nil {
 		v.count(ReverifyRepairFailed)
-		if v.cfg.Log != nil {
+		if firstFailure && v.cfg.Log != nil {
 			v.cfg.Log.LogError("hooks", "", fmt.Sprintf(
 				"%s/%s: failed to re-install hook entries in %s (%s): %v (#1372). The permission now "+
 					"carries this as its effect_error (#1362); re-granting it in the wizard retries.",
@@ -592,6 +633,14 @@ func (v *HookEntryVerifier) Snapshot() HookEntryReverifySnapshot {
 		}
 		if st != nil {
 			row.Watched = st.watched
+			// An empty lastOutcome means no pass has run yet. Published as its
+			// own word rather than omitted: every other field is then at its
+			// zero value too, and "watched:false, repairs:0, nothing missing"
+			// is indistinguishable from a healthy unconsented row unless
+			// something says the loop has not looked.
+			if st.lastOutcome == "" {
+				row.LastOutcome = reverifyNoPassYet
+			}
 			row.Missing = append([]string(nil), st.missing...)
 			row.Stale = append([]string(nil), st.stale...)
 			row.Repairs = st.repairs

--- a/core/application/services/hook_reverify.go
+++ b/core/application/services/hook_reverify.go
@@ -1,0 +1,606 @@
+// hook_reverify.go implements the periodic hook-entry re-verification loop
+// (issue #1372).
+//
+// irrlicht's hook model was "install once on consent, then assume it is there".
+// That assumption is false for any agent whose own UI rewrites its config.
+// gemini-cli's settings writer is sync-by-omission — applyKeyDiff deletes every
+// key on disk that is absent from the snapshot the CLI took at startup,
+// recursively — and #1355's Phase C audit verified it live: with gemini
+// running, an externally added top-level key AND an externally added
+// hooks.PreCompress entry were both deleted by a single /theme change. One of
+// the write paths that can do it, saveModelChange, is not user-initiated.
+// Claude Code and Codex have the same exposure to a hand-edit or a future
+// in-app settings surface, and it has never been checked.
+//
+// # The three hook diagnoses, and why this one is separate
+//
+// The user-visible symptom is identical in all three cases — "irrlicht stopped
+// detecting waiting" — so the whole value of these features is that they
+// produce DIFFERENT evidence. Collapsing any two would put the reader back
+// where they started:
+//
+//   - install FAILED — the entries were never written. Surfaced as the
+//     permission's EffectError, retried by re-answering (#1362/#1365). This
+//     loop's repair failures route into that same slot rather than inventing a
+//     second one.
+//   - entries PRESENT, nothing arriving — the channel is dead for some other
+//     reason (a port mismatch the CLI does not report, a CLI that does not run
+//     our hooks). #1368's liveness watchdog demotes it to the transcript tier.
+//     It reads receipts and turns, and deliberately never re-reads the file.
+//   - entries GONE — this file. It re-reads the file and knows nothing about
+//     receipts. #1368's hooks.json note already points here by number, because
+//     "silent" and "removed" look the same from inside the watchdog.
+//
+// # Consent
+//
+// Re-verification READS a user config file, and the repair WRITES one. Both are
+// exactly what the hooks permission's disclosure covers, so both stay behind
+// it. Three independent refusals, deliberately not one:
+//
+//  1. this loop consults Granted before it reads — every pass, never cached, and
+//     before the back-off check, so a target sitting in a long cooling-off
+//     window still notices its consent went away;
+//  2. PermissionService.RepairGrantedHookInstall re-reads the recorded state
+//     before it queues anything; and
+//  3. runEffects re-reads it a third time under effectMu, immediately before
+//     running the closure.
+//
+// The third is what makes revocation authoritative rather than eventually
+// noticed: gates 1 and 2 can only be as fresh as the instant they were asked,
+// and the write that follows may wait on a mutex behind an in-flight wizard
+// answer. A background repair that outlives consent would break #570 more
+// thoroughly than the bug it fixes, so the loop owns no write path of its own —
+// it can only ask the service, and the service can say no. Each of the three
+// has been individually deleted and seen to turn a test red; see
+// hook_reverify_gate_internal_test.go for the one that only a race can reach.
+package services
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/ports/outbound"
+)
+
+// Defaults for the production loop. The cadence is deliberately unhurried: the
+// cost of a late repair is one degraded turn, the cost of a hot loop is writing
+// to a user's config file all day.
+const (
+	defaultReverifyInterval    = 5 * time.Minute
+	defaultReverifyBackoffBase = 5 * time.Minute
+	defaultReverifyBackoffMax  = time.Hour
+
+	// reverifyStormThreshold is the number of consecutive repairs after which
+	// the loop says out loud that it is losing. Repeated repairs are a signal
+	// in their own right — a config being rewritten every few seconds is a
+	// different problem from one clobbered once — and it is the one thing the
+	// counters alone would not put in front of a reader of events.log.
+	reverifyStormThreshold = 3
+)
+
+// ReverifyOutcome is what one pass decided about one target. The set is closed,
+// which is why the counters below can be a fixed array rather than a map: same
+// shape as hookjson's PathConfiner rejection counters (#1361).
+type ReverifyOutcome string
+
+const (
+	// ReverifyIntact: the entries are present and current. The common answer.
+	ReverifyIntact ReverifyOutcome = "intact"
+	// ReverifyRepaired: entries were missing or stale and were re-installed.
+	ReverifyRepaired ReverifyOutcome = "repaired"
+	// ReverifyRepairFailed: the re-install was attempted and errored. Also
+	// recorded as the permission's EffectError (#1362).
+	ReverifyRepairFailed ReverifyOutcome = "repair_failed"
+	// ReverifyNoConsent: the permission is not granted, so nothing was read and
+	// nothing was written. Counted rather than silent, because "not watched"
+	// and "watched and healthy" are different answers to the same question.
+	ReverifyNoConsent ReverifyOutcome = "skipped_no_consent"
+	// ReverifyBackoff: a repair is in force's cooling-off window, so this pass
+	// did not even read the file.
+	ReverifyBackoff ReverifyOutcome = "skipped_backoff"
+	// ReverifyUnreadable: the config could not be parsed. Not damage and not
+	// health — repairing would spin against a file EnsureInstalled also refuses
+	// to overwrite.
+	ReverifyUnreadable ReverifyOutcome = "unreadable"
+)
+
+// reverifyOutcomes is every outcome in a fixed order, so each has a stable
+// counter slot. An array (not a slice) so len() is a constant.
+var reverifyOutcomes = [...]ReverifyOutcome{
+	ReverifyIntact, ReverifyRepaired, ReverifyRepairFailed,
+	ReverifyNoConsent, ReverifyBackoff, ReverifyUnreadable,
+}
+
+// HookEntryHealth is one target's row in the diagnostics bundle.
+//
+// Every declared target gets a row whether or not anything has happened to it,
+// for the reason #1368's Snapshot gives: a missing row is indistinguishable
+// from a bundle collected before the feature existed.
+type HookEntryHealth struct {
+	Adapter    string `json:"adapter"`
+	Permission string `json:"permission"`
+	// ConfigPath is the file being verified. Without it the finding is not
+	// actionable — the reader cannot go look.
+	ConfigPath string `json:"config_path,omitempty"`
+	// Watched is whether consent was granted at the last pass. A false row is
+	// published, not omitted.
+	Watched bool `json:"watched"`
+	// Missing and Stale are the last verdict's detail, empty when intact.
+	Missing []string `json:"missing,omitempty"`
+	Stale   []string `json:"stale,omitempty"`
+	// Repairs is the lifetime count for this target in this process.
+	Repairs uint64 `json:"repairs"`
+	// ConsecutiveRepairs is how many passes in a row have had to repair. A
+	// number climbing here is the "something is fighting us" signal; it resets
+	// on the first intact pass.
+	ConsecutiveRepairs int    `json:"consecutive_repairs"`
+	LastOutcome        string `json:"last_outcome,omitempty"`
+	// BackoffSeconds is the deferral currently in force, not the time left in
+	// it: a remaining-time field would need a clock in Snapshot and would read
+	// as zero whenever the bundle happened to be collected late.
+	BackoffSeconds int `json:"backoff_seconds,omitempty"`
+	// LastError is the reason the last repair or read failed, if it did.
+	LastError string `json:"last_error,omitempty"`
+}
+
+// HookEntryReverifySnapshot is the whole loop's view at one instant.
+type HookEntryReverifySnapshot struct {
+	Targets  []HookEntryHealth
+	Outcomes map[ReverifyOutcome]uint64
+}
+
+// HookEntryReverifyConfig holds the loop's tunables and collaborators.
+type HookEntryReverifyConfig struct {
+	// Interval is the pass cadence. <= 0 takes the default; Run does nothing
+	// when there are no targets.
+	Interval time.Duration
+	// BackoffBase is the deferral after a single repair; it doubles per
+	// consecutive repair up to BackoffMax.
+	BackoffBase time.Duration
+	BackoffMax  time.Duration
+
+	// Agents is the registry projection the targets are derived from, so a new
+	// hook adapter is covered by declaring Verify and nothing else.
+	Agents []agent.Agent
+
+	// Granted is the consent gate, consulted before every read. Nil reads as
+	// "nothing is granted", which disables the loop rather than opening it —
+	// the safe direction for a gate.
+	Granted func(agentName, key string) bool
+
+	// Repair re-runs the install behind the service's own consent re-check. It
+	// reports whether the write was ATTEMPTED and, if so, whether it worked.
+	// Nil disables repair while leaving verification and reporting intact.
+	Repair func(agentName, key string) (bool, error)
+
+	Log outbound.Logger
+	// Now is injectable for tests; nil means time.Now.
+	Now func() time.Time
+}
+
+// reverifyTarget is one hook install to watch. Resolved once at construction:
+// the declaration is static and the config path is HOME-derived, so re-deriving
+// it per pass would buy nothing and could disagree with itself.
+type reverifyTarget struct {
+	adapter    string
+	permKey    string
+	configPath string
+	verify     func() (agent.HookEntryStatus, error)
+}
+
+func (t reverifyTarget) id() string { return t.adapter + "/" + t.permKey }
+
+// reverifyState is one target's episode memory.
+type reverifyState struct {
+	watched            bool
+	missing            []string
+	stale              []string
+	repairs            uint64
+	consecutiveRepairs int
+	lastOutcome        ReverifyOutcome
+	backoff            time.Duration
+	nextEligible       time.Time
+	lastError          string
+}
+
+// reset returns a target to "nothing is going on", used when consent goes away
+// and when an intact pass ends an episode. Accumulated back-off is forgotten
+// rather than banked: turns spent while the channel was legitimately absent are
+// not evidence against it — the same argument #1368's disarm path makes.
+func (s *reverifyState) reset() {
+	s.missing, s.stale = nil, nil
+	s.consecutiveRepairs = 0
+	s.backoff = 0
+	s.nextEligible = time.Time{}
+	s.lastError = ""
+}
+
+// HookEntryVerifier re-verifies installed hook entries on a schedule and
+// repairs them through the permission service.
+//
+// It needs a mutex for the same reason the liveness watchdog does: its writer
+// is the loop goroutine, but Snapshot is read from the diagnostics HTTP
+// handler on another.
+type HookEntryVerifier struct {
+	mu      sync.Mutex
+	cfg     HookEntryReverifyConfig
+	targets []reverifyTarget
+	state   map[string]*reverifyState
+	counts  [len(reverifyOutcomes)]atomic.Uint64
+
+	// grantedFn and repairFn are the permission service's two entry points.
+	// They live outside cfg because the daemon builds this verifier before the
+	// permission service exists — the same startup ordering HookLivenessWatchdog
+	// solves with SetChannelReady — and because they are then read from the loop
+	// goroutine while SetConsent may still be writing them.
+	grantedFn func(agentName, key string) bool
+	repairFn  func(agentName, key string) (bool, error)
+}
+
+// SetConsent wires the permission service's gate and repair entry points. Until
+// it is called the verifier reports every target unwatched and writes nothing,
+// which is the honest reading: before the permission service exists, nothing
+// has been consented to.
+func (v *HookEntryVerifier) SetConsent(granted func(agentName, key string) bool, repair func(agentName, key string) (bool, error)) {
+	if v == nil {
+		return
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.grantedFn, v.repairFn = granted, repair
+}
+
+// consent returns the two collaborators as one atomic read, so a pass cannot
+// use a gate from before SetConsent with a repair from after it.
+func (v *HookEntryVerifier) consent() (func(string, string) bool, func(string, string) (bool, error)) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.grantedFn, v.repairFn
+}
+
+// NewHookEntryVerifier builds the loop and resolves its targets from the agent
+// registry: every modify-kind permission declaring a HookInstall with a Verify.
+//
+// An adapter that declares a hook install but no Verify is SKIPPED rather than
+// faulted here — one adapter's missing declaration must not disable the loop
+// for the others. TestEveryHookInstallDeclaresAVerifier is what stops that
+// omission being permanent, and it fires in the adapter package, before the
+// adapter has a test of its own.
+func NewHookEntryVerifier(cfg HookEntryReverifyConfig) *HookEntryVerifier {
+	if cfg.Interval <= 0 {
+		cfg.Interval = defaultReverifyInterval
+	}
+	if cfg.BackoffBase <= 0 {
+		cfg.BackoffBase = defaultReverifyBackoffBase
+	}
+	if cfg.BackoffMax < cfg.BackoffBase {
+		cfg.BackoffMax = defaultReverifyBackoffMax
+	}
+	if cfg.BackoffMax < cfg.BackoffBase {
+		cfg.BackoffMax = cfg.BackoffBase
+	}
+
+	v := &HookEntryVerifier{
+		cfg:       cfg,
+		state:     map[string]*reverifyState{},
+		grantedFn: cfg.Granted,
+		repairFn:  cfg.Repair,
+	}
+	for _, a := range cfg.Agents {
+		for _, p := range a.Permissions {
+			if p.Hooks == nil || p.Hooks.Verify == nil {
+				continue
+			}
+			t := reverifyTarget{adapter: a.Identity.Name, permKey: p.Key, verify: p.Hooks.Verify}
+			if p.Hooks.ConfigPath != nil {
+				// Best effort: an unresolvable path costs the row its
+				// actionability, not the loop its function.
+				if path, err := p.Hooks.ConfigPath(); err == nil {
+					t.configPath = path
+				}
+			}
+			v.targets = append(v.targets, t)
+			v.state[t.id()] = &reverifyState{}
+		}
+	}
+	sort.Slice(v.targets, func(i, j int) bool { return v.targets[i].id() < v.targets[j].id() })
+	return v
+}
+
+// Run drives one pass per Interval until ctx is cancelled. Its own goroutine
+// and its own ticker — shape (A) of the two periodic-loop shapes in this
+// package (see PIDManager.SweepDeadPIDs) — because it is an independent concern
+// measured in wall time, unlike the liveness watchdog, which rides the
+// detector's event loop because it counts turns.
+func (v *HookEntryVerifier) Run(ctx context.Context) {
+	if v == nil || len(v.targets) == 0 {
+		return
+	}
+	ticker := time.NewTicker(v.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			v.pass(v.now())
+		}
+	}
+}
+
+// RunPassForTest runs exactly one pass synchronously at the given instant. The
+// package convention (RunPIDLivenessSweepForTest, RunStaleSessionRefreshForTest)
+// is a plain synchronous seam onto the same function the ticker calls, rather
+// than a fake clock.
+func (v *HookEntryVerifier) RunPassForTest(now time.Time) { v.pass(now) }
+
+func (v *HookEntryVerifier) now() time.Time {
+	if v.cfg.Now != nil {
+		return v.cfg.Now()
+	}
+	return time.Now()
+}
+
+// pass is THE decision point: the one place a target's outcome is decided, so
+// that every counter, log line and diagnostics row describes the same verdict
+// rather than several near-simultaneous ones that could disagree.
+//
+// The order of the guards is the contract, not an optimization. Consent is
+// asked FIRST, before the back-off check and before the file is opened, so a
+// revoked permission cannot be read even once — and so a target sitting in a
+// long back-off window still notices its consent went away.
+func (v *HookEntryVerifier) pass(now time.Time) {
+	if v == nil {
+		return
+	}
+	granted, repair := v.consent()
+	for _, t := range v.targets {
+		v.checkTarget(t, now, granted, repair)
+	}
+}
+
+func (v *HookEntryVerifier) checkTarget(t reverifyTarget, now time.Time, granted func(string, string) bool, repair func(string, string) (bool, error)) {
+	if granted == nil || !granted(t.adapter, t.permKey) {
+		v.mu.Lock()
+		st := v.state[t.id()]
+		st.watched = false
+		st.reset()
+		st.lastOutcome = ReverifyNoConsent
+		v.mu.Unlock()
+		v.count(ReverifyNoConsent)
+		return
+	}
+
+	v.mu.Lock()
+	st := v.state[t.id()]
+	st.watched = true
+	deferred := !st.nextEligible.IsZero() && now.Before(st.nextEligible)
+	v.mu.Unlock()
+	if deferred {
+		v.count(ReverifyBackoff)
+		return
+	}
+
+	status, err := t.verify()
+	if err != nil {
+		v.recordUnreadable(t, err)
+		return
+	}
+	if status.Intact() {
+		v.recordIntact(t)
+		return
+	}
+	v.repair(t, status, now, repair)
+}
+
+func (v *HookEntryVerifier) recordUnreadable(t reverifyTarget, err error) {
+	v.mu.Lock()
+	st := v.state[t.id()]
+	first := st.lastOutcome != ReverifyUnreadable
+	st.lastOutcome = ReverifyUnreadable
+	st.lastError = err.Error()
+	// Defer the next read as well: a config we cannot parse will not become
+	// parseable by being read again in five minutes, and this is the same spin
+	// the storm back-off prevents, arriving by a different route.
+	st.backoff = v.backoffFor(st.consecutiveRepairs + 1)
+	v.mu.Unlock()
+	v.count(ReverifyUnreadable)
+	if first && v.cfg.Log != nil {
+		v.cfg.Log.LogError("hooks", "", fmt.Sprintf(
+			"%s/%s: cannot re-verify hook entries in %s: %v (#1372). Nothing was written — "+
+				"the installer refuses to overwrite a config it cannot parse, so this needs a human "+
+				"to fix the file.", t.adapter, t.permKey, t.configPath, err))
+	}
+}
+
+func (v *HookEntryVerifier) recordIntact(t reverifyTarget) {
+	v.mu.Lock()
+	st := v.state[t.id()]
+	recovered := st.consecutiveRepairs
+	st.reset()
+	st.lastOutcome = ReverifyIntact
+	v.mu.Unlock()
+	v.count(ReverifyIntact)
+	if recovered > 0 && v.cfg.Log != nil {
+		v.cfg.Log.LogInfo("hooks", "", fmt.Sprintf(
+			"%s/%s: hook entries verified intact after %d repair(s) — back-off cleared (#1372)",
+			t.adapter, t.permKey, recovered))
+	}
+}
+
+// repair asks the permission service to re-install. It never writes itself.
+func (v *HookEntryVerifier) repair(t reverifyTarget, status agent.HookEntryStatus, now time.Time, doRepair func(string, string) (bool, error)) {
+	if doRepair == nil {
+		v.recordDamageWithoutRepair(t, status)
+		return
+	}
+
+	attempted, err := doRepair(t.adapter, t.permKey)
+	if !attempted {
+		// The service declined: consent is no longer granted as of the moment
+		// it took its lock. That is a consent outcome, not a failed repair —
+		// counting it as a failure would put a fabricated error in the bundle,
+		// and backing off from it would be backing off from the user's own
+		// decision.
+		v.mu.Lock()
+		st := v.state[t.id()]
+		st.watched = false
+		st.reset()
+		st.lastOutcome = ReverifyNoConsent
+		v.mu.Unlock()
+		v.count(ReverifyNoConsent)
+		return
+	}
+
+	v.mu.Lock()
+	st := v.state[t.id()]
+	st.repairs++
+	st.consecutiveRepairs++
+	st.missing = append([]string(nil), status.Missing...)
+	st.stale = append([]string(nil), status.Stale...)
+	st.backoff = v.backoffFor(st.consecutiveRepairs)
+	st.nextEligible = now.Add(st.backoff)
+	n, backoff := st.consecutiveRepairs, st.backoff
+	if err != nil {
+		st.lastOutcome, st.lastError = ReverifyRepairFailed, err.Error()
+	} else {
+		st.lastOutcome, st.lastError = ReverifyRepaired, ""
+	}
+	v.mu.Unlock()
+
+	if err != nil {
+		v.count(ReverifyRepairFailed)
+		if v.cfg.Log != nil {
+			v.cfg.Log.LogError("hooks", "", fmt.Sprintf(
+				"%s/%s: failed to re-install hook entries in %s (%s): %v (#1372). The permission now "+
+					"carries this as its effect_error (#1362); re-granting it in the wizard retries.",
+				t.adapter, t.permKey, t.configPath, status.Damage(), err))
+		}
+		return
+	}
+
+	v.count(ReverifyRepaired)
+	v.logRepair(t, status, n, backoff)
+}
+
+// recordDamageWithoutRepair is the wiring-incomplete case: verification is on,
+// repair is not. It reports rather than pretending health, because a row saying
+// "missing: Stop, repairs: 0" is the only thing that would make that visible.
+func (v *HookEntryVerifier) recordDamageWithoutRepair(t reverifyTarget, status agent.HookEntryStatus) {
+	v.mu.Lock()
+	st := v.state[t.id()]
+	st.missing = append([]string(nil), status.Missing...)
+	st.stale = append([]string(nil), status.Stale...)
+	st.lastOutcome = ReverifyRepairFailed
+	st.lastError = "no repair function is wired"
+	v.mu.Unlock()
+	v.count(ReverifyRepairFailed)
+}
+
+// logRepair reports the first repair of an episode and one storm notice, then
+// goes quiet.
+//
+// A channel under sustained attack must not write a log line per pass forever —
+// the same argument #1364 makes for reporting an unrecognized event name once
+// and #1368 for reporting a silent channel once. The counters and the
+// diagnostics row carry the volume; events.log carries the fact and the shape.
+func (v *HookEntryVerifier) logRepair(t reverifyTarget, status agent.HookEntryStatus, n int, backoff time.Duration) {
+	if v.cfg.Log == nil {
+		return
+	}
+	switch n {
+	case 1:
+		v.cfg.Log.LogError("hooks", "", fmt.Sprintf(
+			"%s/%s: irrlicht's hook entries were %s in %s and have been re-installed (#1372). "+
+				"Something outside irrlicht rewrote that file — an agent settings UI that syncs by "+
+				"omission does this on any config change, and the permission stays green throughout.",
+			t.adapter, t.permKey, status.Damage(), t.configPath))
+	case reverifyStormThreshold:
+		v.cfg.Log.LogError("hooks", "", fmt.Sprintf(
+			"%s/%s: hook entries have now been re-installed %d times in a row in %s (#1372) — "+
+				"something is rewriting that file faster than we repair it. Backing off to at most one "+
+				"repair per %s; further repairs are counted in the diagnostics bundle but not logged "+
+				"until the install is found intact.",
+			t.adapter, t.permKey, n, t.configPath, backoff))
+	}
+}
+
+// backoffFor is the deferral after n consecutive repairs: base doubled per
+// repair, capped. Exponential rather than fixed because the two failure shapes
+// need different answers from one rule — a config clobbered once wants the next
+// pass to be soon, a config rewritten every few seconds wants the loop to stop
+// fighting it — and a cap rather than unbounded growth because the back-off is
+// a ceiling, not a latch: an install clobbered once an hour must still be fixed
+// once an hour.
+func (v *HookEntryVerifier) backoffFor(n int) time.Duration {
+	if n <= 0 {
+		return 0
+	}
+	d := v.cfg.BackoffBase
+	for i := 1; i < n; i++ {
+		if d >= v.cfg.BackoffMax/2 {
+			return v.cfg.BackoffMax
+		}
+		d *= 2
+	}
+	if d > v.cfg.BackoffMax {
+		return v.cfg.BackoffMax
+	}
+	return d
+}
+
+// count bumps one outcome's counter. Linear scan over a six-element array, the
+// same shape hookjson.PathConfiner uses — a map would need a lock on the hot
+// path to buy nothing.
+func (v *HookEntryVerifier) count(o ReverifyOutcome) {
+	for i, name := range reverifyOutcomes {
+		if name == o {
+			v.counts[i].Add(1)
+			return
+		}
+	}
+}
+
+// Snapshot returns one row per target plus the outcome counters, with zero
+// counters OMITTED — the idiom #1361 and #1364 established in hookjson. A map
+// full of zeros reads as an all-clear from a loop that may never have run once.
+func (v *HookEntryVerifier) Snapshot() HookEntryReverifySnapshot {
+	if v == nil {
+		return HookEntryReverifySnapshot{}
+	}
+	out := HookEntryReverifySnapshot{Outcomes: map[ReverifyOutcome]uint64{}}
+	for i, name := range reverifyOutcomes {
+		if n := v.counts[i].Load(); n > 0 {
+			out.Outcomes[name] = n
+		}
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	out.Targets = make([]HookEntryHealth, 0, len(v.targets))
+	for _, t := range v.targets {
+		st := v.state[t.id()]
+		row := HookEntryHealth{
+			Adapter:    t.adapter,
+			Permission: t.permKey,
+			ConfigPath: t.configPath,
+		}
+		if st != nil {
+			row.Watched = st.watched
+			row.Missing = append([]string(nil), st.missing...)
+			row.Stale = append([]string(nil), st.stale...)
+			row.Repairs = st.repairs
+			row.ConsecutiveRepairs = st.consecutiveRepairs
+			row.LastOutcome = string(st.lastOutcome)
+			row.BackoffSeconds = int(st.backoff / time.Second)
+			row.LastError = st.lastError
+		}
+		out.Targets = append(out.Targets, row)
+	}
+	return out
+}

--- a/core/application/services/hook_reverify_gate_internal_test.go
+++ b/core/application/services/hook_reverify_gate_internal_test.go
@@ -39,55 +39,14 @@ import (
 // stale-effect skip an interactive superseding answer relies on; #1372 reuses
 // it rather than adding a fourth check that could disagree with it.
 func TestRunEffects_SkipsAGrantEffectWhoseStateIsNoLongerGranted(t *testing.T) {
-	var mu sync.Mutex
-	applies, removes := 0, 0
-
-	perm := agent.Permission{
-		Key:   "hooks",
-		Kind:  permission.KindModify,
-		Title: "Install hooks",
-		Apply: func() error {
-			mu.Lock()
-			applies++
-			mu.Unlock()
-			return nil
-		},
-		Remove: func() error {
-			mu.Lock()
-			removes++
-			mu.Unlock()
-			return nil
-		},
-		Hooks: &agent.HookInstall{
-			ConfigPath: func() (string, error) { return "/tmp/irrelevant", nil },
-			Uninstall:  func() (bool, error) { return false, nil },
-			Verify:     func() (agent.HookEntryStatus, error) { return agent.HookEntryStatus{}, nil },
-		},
-	}
-	decl := agent.Agent{
-		Identity:    agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
-		Process:     agent.Process{Match: agent.ExactName{Name: "testagent"}},
-		Permissions: []agent.Permission{perm},
-	}
-
-	svc := NewPermissionService(PermissionServiceDeps{
-		Agents: []agent.Agent{decl},
-		Store:  &gatePermStore{},
-		Push:   &gatePush{},
-		Log:    &gateLogger{},
-	})
-
 	// The user has revoked. This is the state RepairGrantedHookInstall's own
 	// pre-check would have seen a moment later — but the repair got past it and
 	// is now inside runEffects, holding a granted-target effect.
-	svc.mu.Lock()
-	svc.set.Put("testagent", "hooks", permission.StateDenied)
-	svc.mu.Unlock()
+	f := newGateFixture(permission.StateDenied)
 
-	svc.runEffects([]pendingEffect{{agentName: "testagent", perm: perm, target: permission.StateGranted}})
+	f.svc.runEffects([]pendingEffect{f.grantEffect()})
 
-	mu.Lock()
-	defer mu.Unlock()
+	applies, removes := f.counts()
 	if applies != 0 {
 		t.Errorf("Apply ran %d times for a grant effect whose permission is DENIED. "+
 			"A background repair that wins the race to effectMu and then writes anyway is "+
@@ -104,44 +63,169 @@ func TestRunEffects_SkipsAGrantEffectWhoseStateIsNoLongerGranted(t *testing.T) {
 // pendingEffect built wrong — would satisfy the assertion above while proving
 // nothing at all.
 func TestRunEffects_RunsAGrantEffectWhoseStateIsStillGranted(t *testing.T) {
-	var mu sync.Mutex
-	applies := 0
-	perm := agent.Permission{
-		Key: "hooks", Kind: permission.KindModify, Title: "Install hooks",
+	f := newGateFixture(permission.StateGranted)
+
+	f.svc.runEffects([]pendingEffect{f.grantEffect()})
+
+	if applies, _ := f.counts(); applies != 1 {
+		t.Errorf("Apply ran %d times for a granted effect, want 1 — the refusal test above "+
+			"would pass vacuously against a runEffects that runs nothing", applies)
+	}
+}
+
+// --- review follow-up: a SKIPPED effect must not read as a successful one ---
+
+// runEffects returning "how many did you run" is what lets the out-of-band
+// #1372 repair tell gate 3's refusal apart from a successful re-install.
+//
+// Without it, a skip left effectErrs untouched, RepairGrantedHookInstall's
+// post-call read of that slot returned "" — or, worse, a stale error from an
+// earlier attempt — and the caller banked a repair that never happened: a
+// lifetime counter, an armed back-off, and an error-level log line blaming
+// something outside irrlicht for a deletion that had not occurred.
+func TestRunEffects_ReportsZeroWhenEveryEffectIsSkipped(t *testing.T) {
+	f := newGateFixture(permission.StateDenied)
+
+	if ran := f.svc.runEffects([]pendingEffect{f.grantEffect()}); ran != 0 {
+		t.Errorf("runEffects reported %d effects run while skipping all of them; the caller "+
+			"cannot then tell a refusal from a success", ran)
+	}
+	if applies, _ := f.counts(); applies != 0 {
+		t.Errorf("Apply ran %d times, want 0", applies)
+	}
+
+	// Vacuity guard: it must count the one it DOES run.
+	f.setState(permission.StateGranted)
+	if ran := f.svc.runEffects([]pendingEffect{f.grantEffect()}); ran != 1 {
+		t.Errorf("runEffects reported %d for one executed effect, want 1 — the assertion above "+
+			"would pass against a function that always returns 0", ran)
+	}
+}
+
+// The composite: a repair that passes gates 1 and 2 and is then overtaken by a
+// revoke while it waits on effectMu must report attempted=false, so the loop
+// counts a consent refusal rather than a phantom re-install.
+//
+// The test holds effectMu itself, so a repair that has passed the pre-check is
+// GUARANTEED to be parked exactly where gate 3 catches it. The one thing it
+// cannot pin down is whether the goroutine got that far before the revoke — and
+// it does not need to: if it did not, gate 2 refuses instead and the assertion
+// holds for that reason. Losing the race costs coverage, never a false failure,
+// which is why the deterministic ran==0 test above is the real proof.
+func TestRepairGrantedHookInstall_RevokedWhileWaitingOnTheEffectLockIsNotAttempted(t *testing.T) {
+	f := newGateFixture(permission.StateGranted)
+
+	f.svc.effectMu.Lock() // stand in for an in-flight wizard answer
+
+	type result struct {
+		attempted bool
+		err       error
+	}
+	done := make(chan result, 1)
+	go func() {
+		a, err := f.svc.RepairGrantedHookInstall("testagent", "hooks")
+		done <- result{a, err}
+	}()
+
+	// Give the repair time to clear the pre-check and park on effectMu.
+	time.Sleep(50 * time.Millisecond)
+
+	f.setState(permission.StateDenied)
+	f.svc.effectMu.Unlock()
+
+	select {
+	case got := <-done:
+		if got.attempted {
+			t.Errorf("RepairGrantedHookInstall reported attempted=true (err=%v) for a repair the "+
+				"service refused because consent was withdrawn while it waited on effectMu. The "+
+				"loop then banks a repair that never happened and logs that something outside "+
+				"irrlicht deleted the entries.", got.err)
+		}
+		if got.err != nil {
+			t.Errorf("a refusal returned an error (%v); declining is not failing", got.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RepairGrantedHookInstall did not return; deadlock on effectMu")
+	}
+
+	if applies, _ := f.counts(); applies != 0 {
+		t.Errorf("Apply ran %d times for a revoked permission, want 0", applies)
+	}
+}
+
+// --- fixture ---------------------------------------------------------------
+
+// gateFixture is the one setup every test in this file needs: a single
+// modify-kind hooks permission whose Apply and Remove are counted, wired into a
+// real PermissionService.
+//
+// Factored because four near-identical copies of it is exactly the shape that
+// makes a later change to the declaration land in three of them and get missed
+// in the fourth — and a consent test that silently stops constructing the thing
+// it means to test still passes.
+type gateFixture struct {
+	svc  *PermissionService
+	perm agent.Permission
+
+	mu      sync.Mutex
+	applies int
+	removes int
+}
+
+// newGateFixture builds the service with the permission already in state.
+func newGateFixture(state permission.State) *gateFixture {
+	f := &gateFixture{}
+	f.perm = agent.Permission{
+		Key:   "hooks",
+		Kind:  permission.KindModify,
+		Title: "Install hooks",
 		Apply: func() error {
-			mu.Lock()
-			applies++
-			mu.Unlock()
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			f.applies++
+			return nil
+		},
+		Remove: func() error {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			f.removes++
 			return nil
 		},
 		Hooks: &agent.HookInstall{
 			ConfigPath: func() (string, error) { return "/tmp/irrelevant", nil },
+			Uninstall:  func() (bool, error) { return false, nil },
 			Verify:     func() (agent.HookEntryStatus, error) { return agent.HookEntryStatus{}, nil },
 		},
 	}
-	decl := agent.Agent{
-		Identity:    agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
-		Process:     agent.Process{Match: agent.ExactName{Name: "testagent"}},
-		Permissions: []agent.Permission{perm},
-	}
-	svc := NewPermissionService(PermissionServiceDeps{
-		Agents: []agent.Agent{decl},
-		Store:  &gatePermStore{},
-		Push:   &gatePush{},
-		Log:    &gateLogger{},
+	f.svc = NewPermissionService(PermissionServiceDeps{
+		Agents: []agent.Agent{{
+			Identity:    agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
+			Process:     agent.Process{Match: agent.ExactName{Name: "testagent"}},
+			Permissions: []agent.Permission{f.perm},
+		}},
+		Store: &gatePermStore{}, Push: &gatePush{}, Log: &gateLogger{},
 	})
-	svc.mu.Lock()
-	svc.set.Put("testagent", "hooks", permission.StateGranted)
-	svc.mu.Unlock()
+	f.setState(state)
+	return f
+}
 
-	svc.runEffects([]pendingEffect{{agentName: "testagent", perm: perm, target: permission.StateGranted}})
+// setState records a consent answer directly, standing in for whatever gesture
+// would have produced it.
+func (f *gateFixture) setState(state permission.State) {
+	f.svc.mu.Lock()
+	f.svc.set.Put("testagent", "hooks", state)
+	f.svc.mu.Unlock()
+}
 
-	mu.Lock()
-	defer mu.Unlock()
-	if applies != 1 {
-		t.Errorf("Apply ran %d times for a granted effect, want 1 — the refusal test above "+
-			"would pass vacuously against a runEffects that runs nothing", applies)
-	}
+// grantEffect is the pendingEffect RepairGrantedHookInstall builds.
+func (f *gateFixture) grantEffect() pendingEffect {
+	return pendingEffect{agentName: "testagent", perm: f.perm, target: permission.StateGranted}
+}
+
+func (f *gateFixture) counts() (int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.applies, f.removes
 }
 
 // --- minimal in-package doubles (the services_test ones are in the other
@@ -169,136 +253,3 @@ func (l *gateLogger) LogInfo(_, _, _ string)                                  {}
 func (l *gateLogger) LogError(_, _, _ string)                                 {}
 func (l *gateLogger) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
 func (l *gateLogger) Close() error                                            { return nil }
-
-// --- review follow-up: a SKIPPED effect must not read as a successful one ---
-
-// runEffects returning "how many did you run" is what lets the out-of-band
-// #1372 repair tell gate 3's refusal apart from a successful re-install.
-//
-// Without it, a skip left effectErrs untouched, RepairGrantedHookInstall's
-// post-call read of that slot returned "" — or, worse, a stale error from an
-// earlier attempt — and the caller banked a repair that never happened: a
-// lifetime counter, an armed back-off, and an error-level log line blaming
-// something outside irrlicht for a deletion that had not occurred.
-func TestRunEffects_ReportsZeroWhenEveryEffectIsSkipped(t *testing.T) {
-	var applies int
-	perm := agent.Permission{
-		Key: "hooks", Kind: permission.KindModify, Title: "Install hooks",
-		Apply: func() error { applies++; return nil },
-		Hooks: &agent.HookInstall{
-			ConfigPath: func() (string, error) { return "/tmp/irrelevant", nil },
-			Verify:     func() (agent.HookEntryStatus, error) { return agent.HookEntryStatus{}, nil },
-		},
-	}
-	svc := NewPermissionService(PermissionServiceDeps{
-		Agents: []agent.Agent{{
-			Identity:    agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
-			Process:     agent.Process{Match: agent.ExactName{Name: "testagent"}},
-			Permissions: []agent.Permission{perm},
-		}},
-		Store: &gatePermStore{}, Push: &gatePush{}, Log: &gateLogger{},
-	})
-
-	svc.mu.Lock()
-	svc.set.Put("testagent", "hooks", permission.StateDenied)
-	svc.mu.Unlock()
-
-	ran := svc.runEffects([]pendingEffect{{agentName: "testagent", perm: perm, target: permission.StateGranted}})
-	if ran != 0 {
-		t.Errorf("runEffects reported %d effects run while skipping all of them; the caller "+
-			"cannot then tell a refusal from a success", ran)
-	}
-	if applies != 0 {
-		t.Errorf("Apply ran %d times, want 0", applies)
-	}
-
-	// Vacuity guard: it must count the one it DOES run.
-	svc.mu.Lock()
-	svc.set.Put("testagent", "hooks", permission.StateGranted)
-	svc.mu.Unlock()
-	if ran := svc.runEffects([]pendingEffect{{agentName: "testagent", perm: perm, target: permission.StateGranted}}); ran != 1 {
-		t.Errorf("runEffects reported %d for one executed effect, want 1 — the assertion above "+
-			"would pass against a function that always returns 0", ran)
-	}
-}
-
-// The composite: a repair that passes gates 1 and 2 and is then overtaken by a
-// revoke while it waits on effectMu must report attempted=false, so the loop
-// counts a consent refusal rather than a phantom re-install.
-//
-// The test holds effectMu itself, so a repair that has passed the pre-check is
-// GUARANTEED to be parked exactly where gate 3 catches it. The one thing it
-// cannot pin down is whether the goroutine got that far before the revoke — and
-// it does not need to: if it did not, gate 2 refuses instead and the assertion
-// holds for that reason. Losing the race costs coverage, never a false failure,
-// which is why the deterministic ran==0 test above is the real proof.
-func TestRepairGrantedHookInstall_RevokedWhileWaitingOnTheEffectLockIsNotAttempted(t *testing.T) {
-	var mu sync.Mutex
-	applies := 0
-	perm := agent.Permission{
-		Key: "hooks", Kind: permission.KindModify, Title: "Install hooks",
-		Apply: func() error {
-			mu.Lock()
-			applies++
-			mu.Unlock()
-			return nil
-		},
-		Remove: func() error { return nil },
-		Hooks: &agent.HookInstall{
-			ConfigPath: func() (string, error) { return "/tmp/irrelevant", nil },
-			Verify:     func() (agent.HookEntryStatus, error) { return agent.HookEntryStatus{}, nil },
-		},
-	}
-	svc := NewPermissionService(PermissionServiceDeps{
-		Agents: []agent.Agent{{
-			Identity:    agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
-			Process:     agent.Process{Match: agent.ExactName{Name: "testagent"}},
-			Permissions: []agent.Permission{perm},
-		}},
-		Store: &gatePermStore{}, Push: &gatePush{}, Log: &gateLogger{},
-	})
-	svc.mu.Lock()
-	svc.set.Put("testagent", "hooks", permission.StateGranted)
-	svc.mu.Unlock()
-
-	svc.effectMu.Lock() // stand in for an in-flight wizard answer
-
-	type result struct {
-		attempted bool
-		err       error
-	}
-	done := make(chan result, 1)
-	go func() {
-		a, err := svc.RepairGrantedHookInstall("testagent", "hooks")
-		done <- result{a, err}
-	}()
-
-	// Give the repair time to clear the pre-check and park on effectMu.
-	time.Sleep(50 * time.Millisecond)
-
-	svc.mu.Lock()
-	svc.set.Put("testagent", "hooks", permission.StateDenied)
-	svc.mu.Unlock()
-	svc.effectMu.Unlock()
-
-	select {
-	case got := <-done:
-		if got.attempted {
-			t.Errorf("RepairGrantedHookInstall reported attempted=true (err=%v) for a repair the "+
-				"service refused because consent was withdrawn while it waited on effectMu. The "+
-				"loop then banks a repair that never happened and logs that something outside "+
-				"irrlicht deleted the entries.", got.err)
-		}
-		if got.err != nil {
-			t.Errorf("a refusal returned an error (%v); declining is not failing", got.err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("RepairGrantedHookInstall did not return; deadlock on effectMu")
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if applies != 0 {
-		t.Errorf("Apply ran %d times for a revoked permission, want 0", applies)
-	}
-}

--- a/core/application/services/hook_reverify_gate_internal_test.go
+++ b/core/application/services/hook_reverify_gate_internal_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/permission"
@@ -168,3 +169,136 @@ func (l *gateLogger) LogInfo(_, _, _ string)                                  {}
 func (l *gateLogger) LogError(_, _, _ string)                                 {}
 func (l *gateLogger) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
 func (l *gateLogger) Close() error                                            { return nil }
+
+// --- review follow-up: a SKIPPED effect must not read as a successful one ---
+
+// runEffects returning "how many did you run" is what lets the out-of-band
+// #1372 repair tell gate 3's refusal apart from a successful re-install.
+//
+// Without it, a skip left effectErrs untouched, RepairGrantedHookInstall's
+// post-call read of that slot returned "" — or, worse, a stale error from an
+// earlier attempt — and the caller banked a repair that never happened: a
+// lifetime counter, an armed back-off, and an error-level log line blaming
+// something outside irrlicht for a deletion that had not occurred.
+func TestRunEffects_ReportsZeroWhenEveryEffectIsSkipped(t *testing.T) {
+	var applies int
+	perm := agent.Permission{
+		Key: "hooks", Kind: permission.KindModify, Title: "Install hooks",
+		Apply: func() error { applies++; return nil },
+		Hooks: &agent.HookInstall{
+			ConfigPath: func() (string, error) { return "/tmp/irrelevant", nil },
+			Verify:     func() (agent.HookEntryStatus, error) { return agent.HookEntryStatus{}, nil },
+		},
+	}
+	svc := NewPermissionService(PermissionServiceDeps{
+		Agents: []agent.Agent{{
+			Identity:    agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
+			Process:     agent.Process{Match: agent.ExactName{Name: "testagent"}},
+			Permissions: []agent.Permission{perm},
+		}},
+		Store: &gatePermStore{}, Push: &gatePush{}, Log: &gateLogger{},
+	})
+
+	svc.mu.Lock()
+	svc.set.Put("testagent", "hooks", permission.StateDenied)
+	svc.mu.Unlock()
+
+	ran := svc.runEffects([]pendingEffect{{agentName: "testagent", perm: perm, target: permission.StateGranted}})
+	if ran != 0 {
+		t.Errorf("runEffects reported %d effects run while skipping all of them; the caller "+
+			"cannot then tell a refusal from a success", ran)
+	}
+	if applies != 0 {
+		t.Errorf("Apply ran %d times, want 0", applies)
+	}
+
+	// Vacuity guard: it must count the one it DOES run.
+	svc.mu.Lock()
+	svc.set.Put("testagent", "hooks", permission.StateGranted)
+	svc.mu.Unlock()
+	if ran := svc.runEffects([]pendingEffect{{agentName: "testagent", perm: perm, target: permission.StateGranted}}); ran != 1 {
+		t.Errorf("runEffects reported %d for one executed effect, want 1 — the assertion above "+
+			"would pass against a function that always returns 0", ran)
+	}
+}
+
+// The composite: a repair that passes gates 1 and 2 and is then overtaken by a
+// revoke while it waits on effectMu must report attempted=false, so the loop
+// counts a consent refusal rather than a phantom re-install.
+//
+// The test holds effectMu itself, so a repair that has passed the pre-check is
+// GUARANTEED to be parked exactly where gate 3 catches it. The one thing it
+// cannot pin down is whether the goroutine got that far before the revoke — and
+// it does not need to: if it did not, gate 2 refuses instead and the assertion
+// holds for that reason. Losing the race costs coverage, never a false failure,
+// which is why the deterministic ran==0 test above is the real proof.
+func TestRepairGrantedHookInstall_RevokedWhileWaitingOnTheEffectLockIsNotAttempted(t *testing.T) {
+	var mu sync.Mutex
+	applies := 0
+	perm := agent.Permission{
+		Key: "hooks", Kind: permission.KindModify, Title: "Install hooks",
+		Apply: func() error {
+			mu.Lock()
+			applies++
+			mu.Unlock()
+			return nil
+		},
+		Remove: func() error { return nil },
+		Hooks: &agent.HookInstall{
+			ConfigPath: func() (string, error) { return "/tmp/irrelevant", nil },
+			Verify:     func() (agent.HookEntryStatus, error) { return agent.HookEntryStatus{}, nil },
+		},
+	}
+	svc := NewPermissionService(PermissionServiceDeps{
+		Agents: []agent.Agent{{
+			Identity:    agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
+			Process:     agent.Process{Match: agent.ExactName{Name: "testagent"}},
+			Permissions: []agent.Permission{perm},
+		}},
+		Store: &gatePermStore{}, Push: &gatePush{}, Log: &gateLogger{},
+	})
+	svc.mu.Lock()
+	svc.set.Put("testagent", "hooks", permission.StateGranted)
+	svc.mu.Unlock()
+
+	svc.effectMu.Lock() // stand in for an in-flight wizard answer
+
+	type result struct {
+		attempted bool
+		err       error
+	}
+	done := make(chan result, 1)
+	go func() {
+		a, err := svc.RepairGrantedHookInstall("testagent", "hooks")
+		done <- result{a, err}
+	}()
+
+	// Give the repair time to clear the pre-check and park on effectMu.
+	time.Sleep(50 * time.Millisecond)
+
+	svc.mu.Lock()
+	svc.set.Put("testagent", "hooks", permission.StateDenied)
+	svc.mu.Unlock()
+	svc.effectMu.Unlock()
+
+	select {
+	case got := <-done:
+		if got.attempted {
+			t.Errorf("RepairGrantedHookInstall reported attempted=true (err=%v) for a repair the "+
+				"service refused because consent was withdrawn while it waited on effectMu. The "+
+				"loop then banks a repair that never happened and logs that something outside "+
+				"irrlicht deleted the entries.", got.err)
+		}
+		if got.err != nil {
+			t.Errorf("a refusal returned an error (%v); declining is not failing", got.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RepairGrantedHookInstall did not return; deadlock on effectMu")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if applies != 0 {
+		t.Errorf("Apply ran %d times for a revoked permission, want 0", applies)
+	}
+}

--- a/core/application/services/hook_reverify_gate_internal_test.go
+++ b/core/application/services/hook_reverify_gate_internal_test.go
@@ -1,0 +1,170 @@
+package services
+
+import (
+	"sync"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/ports/outbound"
+)
+
+// The third consent gate on the #1372 repair path, tested where it can actually
+// be reached.
+//
+// RepairGrantedHookInstall has three independent refusals and they cover
+// different windows:
+//
+//  1. the verifier loop asks Granted before it reads the file (proved in
+//     hook_reverify_test.go, and by deleting that check: the revoke test goes
+//     red);
+//  2. RepairGrantedHookInstall re-reads the recorded state before it queues
+//     anything (proved by deleting it: the on-disk test's direct-call arm goes
+//     red);
+//  3. runEffects re-reads the state a THIRD time, under effectMu, immediately
+//     before running the closure.
+//
+// Gate 3 is the one that matters for a real revoke, because gates 1 and 2 can
+// only be as fresh as the instant they were asked: a repair that passes both
+// and then waits on effectMu behind an in-flight wizard answer would otherwise
+// write to a config the user revoked while it waited. It is also the only gate
+// unreachable from outside the package — by construction, gate 2 stops every
+// non-racing caller — so a black-box test of it would either need a scheduling
+// race (flaky, and passes vacuously when it loses) or would not test it at all.
+//
+// So this test does what the race would do, deterministically: it hands
+// runEffects the exact pendingEffect RepairGrantedHookInstall builds, with the
+// state already denied, and asserts the closure never runs. That is the same
+// stale-effect skip an interactive superseding answer relies on; #1372 reuses
+// it rather than adding a fourth check that could disagree with it.
+func TestRunEffects_SkipsAGrantEffectWhoseStateIsNoLongerGranted(t *testing.T) {
+	var mu sync.Mutex
+	applies, removes := 0, 0
+
+	perm := agent.Permission{
+		Key:   "hooks",
+		Kind:  permission.KindModify,
+		Title: "Install hooks",
+		Apply: func() error {
+			mu.Lock()
+			applies++
+			mu.Unlock()
+			return nil
+		},
+		Remove: func() error {
+			mu.Lock()
+			removes++
+			mu.Unlock()
+			return nil
+		},
+		Hooks: &agent.HookInstall{
+			ConfigPath: func() (string, error) { return "/tmp/irrelevant", nil },
+			Uninstall:  func() (bool, error) { return false, nil },
+			Verify:     func() (agent.HookEntryStatus, error) { return agent.HookEntryStatus{}, nil },
+		},
+	}
+	decl := agent.Agent{
+		Identity:    agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
+		Process:     agent.Process{Match: agent.ExactName{Name: "testagent"}},
+		Permissions: []agent.Permission{perm},
+	}
+
+	svc := NewPermissionService(PermissionServiceDeps{
+		Agents: []agent.Agent{decl},
+		Store:  &gatePermStore{},
+		Push:   &gatePush{},
+		Log:    &gateLogger{},
+	})
+
+	// The user has revoked. This is the state RepairGrantedHookInstall's own
+	// pre-check would have seen a moment later — but the repair got past it and
+	// is now inside runEffects, holding a granted-target effect.
+	svc.mu.Lock()
+	svc.set.Put("testagent", "hooks", permission.StateDenied)
+	svc.mu.Unlock()
+
+	svc.runEffects([]pendingEffect{{agentName: "testagent", perm: perm, target: permission.StateGranted}})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if applies != 0 {
+		t.Errorf("Apply ran %d times for a grant effect whose permission is DENIED. "+
+			"A background repair that wins the race to effectMu and then writes anyway is "+
+			"the #570 violation #1372 must not introduce — the user revoked while it waited.",
+			applies)
+	}
+	if removes != 0 {
+		t.Errorf("Remove ran %d times; a skipped effect must run neither closure", removes)
+	}
+}
+
+// Vacuity guard for the test above: the same call with the state still granted
+// MUST run Apply. Without this, a runEffects that skipped everything — or a
+// pendingEffect built wrong — would satisfy the assertion above while proving
+// nothing at all.
+func TestRunEffects_RunsAGrantEffectWhoseStateIsStillGranted(t *testing.T) {
+	var mu sync.Mutex
+	applies := 0
+	perm := agent.Permission{
+		Key: "hooks", Kind: permission.KindModify, Title: "Install hooks",
+		Apply: func() error {
+			mu.Lock()
+			applies++
+			mu.Unlock()
+			return nil
+		},
+		Hooks: &agent.HookInstall{
+			ConfigPath: func() (string, error) { return "/tmp/irrelevant", nil },
+			Verify:     func() (agent.HookEntryStatus, error) { return agent.HookEntryStatus{}, nil },
+		},
+	}
+	decl := agent.Agent{
+		Identity:    agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
+		Process:     agent.Process{Match: agent.ExactName{Name: "testagent"}},
+		Permissions: []agent.Permission{perm},
+	}
+	svc := NewPermissionService(PermissionServiceDeps{
+		Agents: []agent.Agent{decl},
+		Store:  &gatePermStore{},
+		Push:   &gatePush{},
+		Log:    &gateLogger{},
+	})
+	svc.mu.Lock()
+	svc.set.Put("testagent", "hooks", permission.StateGranted)
+	svc.mu.Unlock()
+
+	svc.runEffects([]pendingEffect{{agentName: "testagent", perm: perm, target: permission.StateGranted}})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if applies != 1 {
+		t.Errorf("Apply ran %d times for a granted effect, want 1 — the refusal test above "+
+			"would pass vacuously against a runEffects that runs nothing", applies)
+	}
+}
+
+// --- minimal in-package doubles (the services_test ones are in the other
+// package and cannot be reached from here) ---
+
+type gatePermStore struct{ set permission.Set }
+
+func (s *gatePermStore) Load() (permission.Set, error) {
+	if s.set == nil {
+		return permission.Set{}, nil
+	}
+	return s.set, nil
+}
+func (s *gatePermStore) Save(set permission.Set) error { s.set = set; return nil }
+
+type gatePush struct{}
+
+func (p *gatePush) Broadcast(outbound.PushMessage)        {}
+func (p *gatePush) Subscribe() chan outbound.PushMessage  { return make(chan outbound.PushMessage, 1) }
+func (p *gatePush) Unsubscribe(chan outbound.PushMessage) {}
+
+type gateLogger struct{}
+
+func (l *gateLogger) LogInfo(_, _, _ string)                                  {}
+func (l *gateLogger) LogError(_, _, _ string)                                 {}
+func (l *gateLogger) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
+func (l *gateLogger) Close() error                                            { return nil }

--- a/core/application/services/hook_reverify_test.go
+++ b/core/application/services/hook_reverify_test.go
@@ -1,0 +1,607 @@
+package services_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+)
+
+// --- #1372: installed hook entries are re-verified, and repaired, on a
+// schedule — and the repair stays behind the same consent as the install.
+
+var reverifyEpoch = time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+
+// fakeInstall is a hook install whose on-disk state the test drives directly.
+// It counts verifies and repairs separately, because the two are gated
+// separately and the whole point of scope item 4 is that a revoked permission
+// stops BOTH — a test that only counted repairs would pass against a loop that
+// went on reading the user's config after consent was withdrawn.
+type fakeInstall struct {
+	mu        sync.Mutex
+	status    agent.HookEntryStatus
+	verifyN   int
+	repairN   int
+	verifyErr error
+	repairErr error
+	// attempted is what Repair reports back. false models the permission
+	// service refusing the write because consent is no longer granted at the
+	// moment it took its lock.
+	attempted bool
+}
+
+func newFakeInstall() *fakeInstall {
+	return &fakeInstall{attempted: true}
+}
+
+func (f *fakeInstall) verify() (agent.HookEntryStatus, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.verifyN++
+	if f.verifyErr != nil {
+		return agent.HookEntryStatus{}, f.verifyErr
+	}
+	return f.status, nil
+}
+
+func (f *fakeInstall) repair(string, string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.repairN++
+	if !f.attempted {
+		return false, nil
+	}
+	if f.repairErr != nil {
+		return true, f.repairErr
+	}
+	f.status = agent.HookEntryStatus{}
+	return true, nil
+}
+
+func (f *fakeInstall) damage(missing ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.status = agent.HookEntryStatus{Missing: missing}
+}
+
+func (f *fakeInstall) counts() (int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.verifyN, f.repairN
+}
+
+func reverifyAgent(f *fakeInstall) agent.Agent {
+	return agent.Agent{
+		Identity: agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
+		Process:  agent.Process{Match: agent.ExactName{Name: "testagent"}},
+		Permissions: []agent.Permission{
+			{
+				Key:    "hooks",
+				Kind:   permission.KindModify,
+				Title:  "Install hooks",
+				Apply:  func() error { return nil },
+				Remove: func() error { return nil },
+				Hooks: &agent.HookInstall{
+					ConfigPath: func() (string, error) { return "/tmp/fake/settings.json", nil },
+					Uninstall:  func() (bool, error) { return false, nil },
+					Verify:     f.verify,
+				},
+			},
+		},
+	}
+}
+
+// grantSwitch is a consent gate the test flips at will, standing in for the
+// user revoking the permission mid-run.
+type grantSwitch struct {
+	mu      sync.Mutex
+	granted bool
+	asked   int
+}
+
+func (g *grantSwitch) fn(string, string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.asked++
+	return g.granted
+}
+
+func (g *grantSwitch) set(v bool) {
+	g.mu.Lock()
+	g.granted = v
+	g.mu.Unlock()
+}
+
+func (g *grantSwitch) askCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.asked
+}
+
+func newVerifier(f *fakeInstall, g *grantSwitch, log *mockLogger) *services.HookEntryVerifier {
+	return services.NewHookEntryVerifier(services.HookEntryReverifyConfig{
+		Interval:    5 * time.Minute,
+		BackoffBase: 5 * time.Minute,
+		BackoffMax:  40 * time.Minute,
+		Agents:      []agent.Agent{reverifyAgent(f)},
+		Granted:     g.fn,
+		Repair:      f.repair,
+		Log:         log,
+	})
+}
+
+func outcome(t *testing.T, v *services.HookEntryVerifier, o services.ReverifyOutcome) uint64 {
+	t.Helper()
+	return v.Snapshot().Outcomes[o]
+}
+
+// The defect itself: entries removed by something outside irrlicht are found
+// and put back, with no user gesture.
+func TestReverify_RepairsExternallyDeletedEntries(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	f.damage("Stop", "PermissionRequest")
+	v.RunPassForTest(reverifyEpoch)
+
+	verifies, repairs := f.counts()
+	if verifies != 1 {
+		t.Errorf("verify called %d times, want 1", verifies)
+	}
+	if repairs != 1 {
+		t.Fatalf("repair called %d times, want 1 — entries deleted by the agent's own "+
+			"settings UI must be re-installed without the user noticing (#1372)", repairs)
+	}
+	if got := outcome(t, v, services.ReverifyRepaired); got != 1 {
+		t.Errorf("repaired counter = %d, want 1", got)
+	}
+
+	// And the repair converges: the next pass finds it intact and does nothing.
+	v.RunPassForTest(reverifyEpoch.Add(time.Hour))
+	if _, repairs := f.counts(); repairs != 1 {
+		t.Errorf("repair called %d times after the install was restored, want 1 — a loop "+
+			"that repairs an intact install writes to the user's config forever", repairs)
+	}
+	if got := outcome(t, v, services.ReverifyIntact); got != 1 {
+		t.Errorf("intact counter = %d, want 1", got)
+	}
+}
+
+func TestReverify_IntactInstallIsNeverWritten(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	for i := 0; i < 5; i++ {
+		v.RunPassForTest(reverifyEpoch.Add(time.Duration(i) * time.Hour))
+	}
+	if _, repairs := f.counts(); repairs != 0 {
+		t.Errorf("repair called %d times on an intact install, want 0", repairs)
+	}
+	if got := outcome(t, v, services.ReverifyIntact); got != 5 {
+		t.Errorf("intact counter = %d, want 5", got)
+	}
+}
+
+// --- scope item 4: a revoked permission stops the loop -------------------
+
+// The load-bearing test. A background repair must never become a way to write
+// to a config whose consent the user withdrew — that would break #570 more
+// thoroughly than the bug it fixes.
+//
+// It asserts on the VERIFY count as well as the repair count. Reading the
+// user's settings file is itself one of the things the permission's Touches
+// text discloses, so a loop that keeps reading after a revoke is already
+// outside consent even if it never writes again.
+func TestReverify_RevokedPermissionStopsTheLoop(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	// Establish that the loop is live and would otherwise repair.
+	f.damage("Stop")
+	v.RunPassForTest(reverifyEpoch)
+	if _, repairs := f.counts(); repairs != 1 {
+		t.Fatalf("precondition: granted loop did not repair (repairs=%d) — the revoke "+
+			"assertion below would pass vacuously", repairs)
+	}
+	verifiesAtRevoke, repairsAtRevoke := f.counts()
+
+	g.set(false)
+	f.damage("Stop", "PermissionRequest")
+	for i := 1; i <= 10; i++ {
+		v.RunPassForTest(reverifyEpoch.Add(time.Duration(i) * time.Hour))
+	}
+
+	verifies, repairs := f.counts()
+	if verifies != verifiesAtRevoke {
+		t.Errorf("verify was called %d more times after the permission was revoked "+
+			"(%d -> %d); re-verification READS the user's config, which the revoked "+
+			"permission is exactly what withdrew consent for (#570/#1372)",
+			verifies-verifiesAtRevoke, verifiesAtRevoke, verifies)
+	}
+	if repairs != repairsAtRevoke {
+		t.Errorf("repair was called %d more times after the permission was revoked "+
+			"(%d -> %d); a background repair must never write to a config the user "+
+			"withdrew consent for", repairs-repairsAtRevoke, repairsAtRevoke, repairs)
+	}
+	if got := outcome(t, v, services.ReverifyNoConsent); got != 10 {
+		t.Errorf("skipped_no_consent counter = %d, want 10 — the skip must be COUNTED, "+
+			"not merely silent, or a bundle cannot distinguish 'not watched' from "+
+			"'watched and healthy'", got)
+	}
+	if g.askCount() < 11 {
+		t.Errorf("consent was consulted only %d times across 11 passes; it must be "+
+			"re-read every pass, never cached", g.askCount())
+	}
+}
+
+// The narrower race: consent is granted when the loop reads, and gone by the
+// time the permission service takes its lock to write. The service refuses
+// (attempted=false) and the loop must treat that as a consent refusal, not as a
+// failed repair to be counted, logged and backed off from.
+func TestReverify_RevocationRacingTheWriteIsARefusalNotAFailure(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	f.damage("Stop")
+	f.mu.Lock()
+	f.attempted = false // the service declines: state is no longer granted
+	f.mu.Unlock()
+
+	v.RunPassForTest(reverifyEpoch)
+
+	if got := outcome(t, v, services.ReverifyNoConsent); got != 1 {
+		t.Errorf("skipped_no_consent = %d, want 1: a refused write is a consent outcome", got)
+	}
+	if got := outcome(t, v, services.ReverifyRepaired); got != 0 {
+		t.Errorf("repaired = %d, want 0: nothing was written", got)
+	}
+	if got := outcome(t, v, services.ReverifyRepairFailed); got != 0 {
+		t.Errorf("repair_failed = %d, want 0: declining is not failing, and counting it "+
+			"as a failure would put a fabricated error in the diagnostics bundle", got)
+	}
+	if errs := log.errorSnapshot(); len(errs) != 0 {
+		t.Errorf("a consent refusal logged at error level: %v", errs)
+	}
+}
+
+// End-to-end, through the REAL PermissionService and a REAL file on disk. The
+// fake-based test above proves the loop asks; this proves the thing it asks
+// actually refuses, and that the bytes on disk are untouched.
+//
+// This is the arm that would catch a loop wired to the adapter's Apply closure
+// directly instead of through the service — which would pass every assertion in
+// the fake-based test while writing to a revoked config.
+func TestReverify_RevokedPermissionNeverTouchesTheFileOnDisk(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	cfg := hookjson.Config{
+		Path:       path,
+		Sentinel:   "localhost:7837/api/v1/hooks/testagent",
+		Events:     []string{"Stop"},
+		MatcherFor: func(string) string { return "" },
+		Entry: func() map[string]interface{} {
+			return map[string]interface{}{"type": "http", "url": "http://localhost:7837/api/v1/hooks/testagent"}
+		},
+		IsCanonical: func(h map[string]interface{}) bool {
+			u, _ := h["url"].(string)
+			return u == "http://localhost:7837/api/v1/hooks/testagent"
+		},
+		WriteFile: func(p string, d []byte) error { return os.WriteFile(p, d, 0o600) },
+	}
+
+	decl := agent.Agent{
+		Identity: agent.Identity{Name: "testagent", DisplayName: "Test Agent"},
+		Process:  agent.Process{Match: agent.ExactName{Name: "testagent"}},
+		Permissions: []agent.Permission{{
+			Key:    "hooks",
+			Kind:   permission.KindModify,
+			Title:  "Install hooks",
+			Apply:  func() error { _, err := hookjson.EnsureInstalled(cfg); return err },
+			Remove: func() error { _, err := hookjson.Uninstall(cfg); return err },
+			Hooks: &agent.HookInstall{
+				ConfigPath: func() (string, error) { return path, nil },
+				Uninstall:  func() (bool, error) { return hookjson.Uninstall(cfg) },
+				Verify:     func() (agent.HookEntryStatus, error) { return hookjson.Verify(cfg) },
+			},
+		}},
+	}
+
+	log := &mockLogger{}
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents: []agent.Agent{decl},
+		Store:  &mockPermStore{},
+		Push:   &mockPush{},
+		Log:    log,
+	})
+	if err := svc.Answer([]services.PermissionAnswer{{Agent: "testagent", Permission: "hooks", Grant: true}}); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	v := services.NewHookEntryVerifier(services.HookEntryReverifyConfig{
+		Interval:    time.Minute,
+		BackoffBase: time.Minute,
+		BackoffMax:  time.Minute,
+		Agents:      []agent.Agent{decl},
+		Granted:     svc.Granted,
+		Repair:      svc.RepairGrantedHookInstall,
+		Log:         log,
+	})
+
+	// Granted: an external clobber is repaired.
+	if err := os.WriteFile(path, []byte(`{"theme":"dark"}`), 0o600); err != nil {
+		t.Fatalf("clobber: %v", err)
+	}
+	v.RunPassForTest(reverifyEpoch)
+	restored, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(restored), "hooks/testagent") {
+		t.Fatalf("precondition: granted loop did not restore the entries; file is %s", restored)
+	}
+
+	// Revoked: the same clobber is left exactly as the user's agent left it.
+	if err := svc.Answer([]services.PermissionAnswer{{Agent: "testagent", Permission: "hooks", Grant: false}}); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+	clobbered := `{"theme":"dark","hooks":{}}`
+	if err := os.WriteFile(path, []byte(clobbered), 0o600); err != nil {
+		t.Fatalf("re-clobber: %v", err)
+	}
+	for i := 1; i <= 5; i++ {
+		v.RunPassForTest(reverifyEpoch.Add(time.Duration(i) * time.Hour))
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(after) != clobbered {
+		t.Errorf("the re-verification loop wrote to a config whose permission was REVOKED.\n"+
+			"want (untouched): %s\ngot:              %s\n"+
+			"This is the #570 violation #1372 must not introduce: a background repair "+
+			"that outlives consent is worse than the bug it fixes.", clobbered, after)
+	}
+
+	// Belt and braces: the service's own entry point refuses too, whatever the
+	// loop does with the answer.
+	attempted, err := svc.RepairGrantedHookInstall("testagent", "hooks")
+	if attempted {
+		t.Errorf("RepairGrantedHookInstall attempted a write on a denied permission (err=%v)", err)
+	}
+}
+
+// A permission that was never granted at all must not be read even once. The
+// revoke test above starts from granted; this one starts from pending, which is
+// the state a fresh install sits in and the one #570 is strictest about.
+func TestReverify_PendingPermissionIsNeverRead(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: false}, &mockLogger{}
+	v := newVerifier(f, g, log)
+	f.damage("Stop")
+
+	for i := 0; i < 3; i++ {
+		v.RunPassForTest(reverifyEpoch.Add(time.Duration(i) * time.Minute))
+	}
+	if verifies, repairs := f.counts(); verifies != 0 || repairs != 0 {
+		t.Errorf("verify=%d repair=%d on a never-granted permission, want 0/0", verifies, repairs)
+	}
+}
+
+// --- scope item 3: rate-limit and log ------------------------------------
+
+// A repair loop fighting a live CLI that rewrites the same file every few
+// seconds must back off, not spin. The damage here is never fixed — repair
+// reports success and the next verify finds it broken again, which is exactly
+// what a CLI holding a stale in-memory snapshot does.
+func TestReverify_BacksOffWhenTheRepairKeepsLosing(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	// Re-break the install after every repair.
+	var passes int
+	at := reverifyEpoch
+	// Drive one pass per minute for four hours. Without back-off that is 240
+	// writes to the user's config.
+	for i := 0; i < 240; i++ {
+		f.damage("Stop")
+		v.RunPassForTest(at)
+		at = at.Add(time.Minute)
+		passes++
+	}
+
+	_, repairs := f.counts()
+	if repairs >= 20 {
+		t.Errorf("%d repairs across %d passes — the loop is spinning against a live "+
+			"writer instead of backing off (#1372 scope item 3)", repairs, passes)
+	}
+	if repairs < 4 {
+		t.Errorf("only %d repairs across four hours; the back-off must be a ceiling, "+
+			"not a latch — a config clobbered once an hour still has to be fixed", repairs)
+	}
+	if got := outcome(t, v, services.ReverifyBackoff); got == 0 {
+		t.Errorf("skipped_backoff counter is 0; a deferral that is not counted is " +
+			"indistinguishable from a pass that never ran")
+	}
+}
+
+// Back-off is per-episode, not permanent: once the install is found intact the
+// cadence returns to normal, so the next clobber is caught promptly.
+func TestReverify_BackoffResetsAfterAnIntactPass(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	at := reverifyEpoch
+	for i := 0; i < 3; i++ {
+		f.damage("Stop")
+		v.RunPassForTest(at)
+		at = at.Add(time.Hour) // long enough to clear each deferral
+	}
+	if got := v.Snapshot().Targets[0].ConsecutiveRepairs; got != 3 {
+		t.Fatalf("consecutive repairs = %d, want 3", got)
+	}
+
+	// One clean pass.
+	v.RunPassForTest(at)
+	row := v.Snapshot().Targets[0]
+	if row.ConsecutiveRepairs != 0 {
+		t.Errorf("consecutive repairs = %d after an intact pass, want 0", row.ConsecutiveRepairs)
+	}
+	if row.BackoffSeconds != 0 {
+		t.Errorf("backoff still %ds after an intact pass; the episode is over", row.BackoffSeconds)
+	}
+}
+
+// Repeated repairs are themselves a signal, so the first one of an episode is
+// reported — and only the first, plus one storm line. A channel that stays
+// under attack must not write a log line per pass forever, the same argument
+// #1364 and #1368 make.
+func TestReverify_LogsOncePerEpisodeNotOncePerRepair(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	at := reverifyEpoch
+	for i := 0; i < 12; i++ {
+		f.damage("Stop")
+		v.RunPassForTest(at)
+		at = at.Add(2 * time.Hour) // clear every deferral, so every pass repairs
+	}
+
+	var repaired []string
+	for _, line := range append(log.errorSnapshot(), log.infoSnapshot()...) {
+		if strings.Contains(line, "#1372") {
+			repaired = append(repaired, line)
+		}
+	}
+	if len(repaired) == 0 {
+		t.Fatalf("12 repairs produced no #1372 log line at all; repeated repairs are the " +
+			"signal this feature exists to surface")
+	}
+	if len(repaired) > 3 {
+		t.Errorf("12 repairs produced %d log lines; expected the first of the episode plus "+
+			"at most a storm notice:\n%s", len(repaired), strings.Join(repaired, "\n"))
+	}
+	joined := strings.Join(repaired, "\n")
+	if !strings.Contains(joined, "Stop") {
+		t.Errorf("the log line does not name the affected event; a repair notice with no "+
+			"events in it cannot be acted on:\n%s", joined)
+	}
+}
+
+func TestReverify_RepairFailureIsCountedAndSurfaced(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	f.damage("Stop")
+	f.mu.Lock()
+	f.repairErr = errors.New("settings.json is malformed")
+	f.mu.Unlock()
+
+	v.RunPassForTest(reverifyEpoch)
+
+	if got := outcome(t, v, services.ReverifyRepairFailed); got != 1 {
+		t.Errorf("repair_failed = %d, want 1", got)
+	}
+	row := v.Snapshot().Targets[0]
+	if !strings.Contains(row.LastError, "malformed") {
+		t.Errorf("LastError = %q, want the underlying reason", row.LastError)
+	}
+	// It must also back off: hammering a repair that cannot succeed is the same
+	// spin the live-writer case produces, by a different route.
+	if row.BackoffSeconds == 0 {
+		t.Errorf("no back-off after a failed repair; the loop would retry every pass")
+	}
+}
+
+func TestReverify_UnreadableConfigIsItsOwnOutcomeAndIsNotRepaired(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	f.mu.Lock()
+	f.verifyErr = errors.New("invalid character '}' looking for beginning of object key string")
+	f.mu.Unlock()
+
+	v.RunPassForTest(reverifyEpoch)
+
+	if got := outcome(t, v, services.ReverifyUnreadable); got != 1 {
+		t.Errorf("unreadable = %d, want 1", got)
+	}
+	if _, repairs := f.counts(); repairs != 0 {
+		t.Errorf("repair called %d times on an unreadable config, want 0 — EnsureInstalled "+
+			"refuses to overwrite malformed JSON too, so the loop would spin", repairs)
+	}
+}
+
+// An adapter that declares a hook install but no Verify is skipped rather than
+// crashing the loop for every other adapter. The registry tripwire
+// (TestEveryHookInstallDeclaresAVerifier) is what stops that being permanent.
+func TestReverify_AdapterWithoutAVerifierIsSkipped(t *testing.T) {
+	decl := agent.Agent{
+		Identity: agent.Identity{Name: "noverify", DisplayName: "No Verify"},
+		Process:  agent.Process{Match: agent.ExactName{Name: "noverify"}},
+		Permissions: []agent.Permission{{
+			Key: "hooks", Kind: permission.KindModify, Title: "Install hooks",
+			Apply: func() error { return nil },
+			Hooks: &agent.HookInstall{ConfigPath: func() (string, error) { return "/tmp/x", nil }},
+		}},
+	}
+	f := newFakeInstall()
+	v := services.NewHookEntryVerifier(services.HookEntryReverifyConfig{
+		Agents:  []agent.Agent{decl, reverifyAgent(f)},
+		Granted: func(string, string) bool { return true },
+		Repair:  f.repair,
+		Log:     &mockLogger{},
+	})
+	f.damage("Stop")
+	v.RunPassForTest(reverifyEpoch)
+
+	if got := len(v.Snapshot().Targets); got != 1 {
+		t.Errorf("snapshot has %d targets, want 1 — an adapter with no Verify is not a "+
+			"target, and publishing it as one would report a permanent zero", got)
+	}
+	if _, repairs := f.counts(); repairs != 1 {
+		t.Errorf("the declaring adapter was not repaired (repairs=%d); one adapter's "+
+			"missing declaration must not disable the loop for the rest", repairs)
+	}
+}
+
+// The snapshot omits zero counters, per the package idiom (#1361/#1364): a map
+// full of zeros reads as an all-clear from a loop that may never have run.
+func TestReverify_SnapshotOmitsZeroOutcomes(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+	v.RunPassForTest(reverifyEpoch)
+
+	got := v.Snapshot().Outcomes
+	if _, present := got[services.ReverifyRepaired]; present {
+		t.Errorf("Outcomes carries a zero %q entry: %v", services.ReverifyRepaired, got)
+	}
+	if got[services.ReverifyIntact] != 1 {
+		t.Errorf("Outcomes[%q] = %d, want 1", services.ReverifyIntact, got[services.ReverifyIntact])
+	}
+}
+
+// Every declaring target gets a row whether or not anything happened to it —
+// the same argument #1368's Snapshot makes: a missing row is indistinguishable
+// from a bundle collected before the feature existed.
+func TestReverify_SnapshotPublishesARowPerTargetBeforeAnyPass(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	rows := v.Snapshot().Targets
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows before any pass, want 1", len(rows))
+	}
+	if rows[0].Adapter != "testagent" || rows[0].Permission != "hooks" {
+		t.Errorf("row = %+v, want adapter testagent / permission hooks", rows[0])
+	}
+	if rows[0].ConfigPath == "" {
+		t.Errorf("row carries no config path; the bundle reader has to be told WHICH file " +
+			"is being repaired, or the finding is not actionable")
+	}
+}

--- a/core/application/services/hook_reverify_test.go
+++ b/core/application/services/hook_reverify_test.go
@@ -605,3 +605,108 @@ func TestReverify_SnapshotPublishesARowPerTargetBeforeAnyPass(t *testing.T) {
 			"is being repaired, or the finding is not actionable")
 	}
 }
+
+// --- review follow-up ------------------------------------------------------
+
+// An unreadable config must actually be deferred, not merely reported as
+// deferred. The single-pass test above cannot see the difference: backoff is
+// published from st.backoff, but the skip is decided from st.nextEligible, and
+// setting only the first produces a bundle claiming a cooling-off window that
+// does not exist while the file is re-parsed on every pass forever.
+func TestReverify_UnreadableConfigIsActuallyDeferredNotJustReportedAs(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log) // BackoffBase 5m
+
+	f.mu.Lock()
+	f.verifyErr = errors.New("invalid character '}' looking for beginning of object key string")
+	f.mu.Unlock()
+
+	// Five passes one minute apart — all well inside the first deferral.
+	for i := 0; i < 5; i++ {
+		v.RunPassForTest(reverifyEpoch.Add(time.Duration(i) * time.Minute))
+	}
+
+	verifies, _ := f.counts()
+	if verifies != 1 {
+		t.Errorf("the config was re-parsed %d times across five passes inside the back-off "+
+			"window, want 1 — a file we cannot parse will not become parseable by being read "+
+			"again in a minute", verifies)
+	}
+	if got := outcome(t, v, services.ReverifyBackoff); got != 4 {
+		t.Errorf("skipped_backoff = %d, want 4", got)
+	}
+	row := v.Snapshot().Targets[0]
+	if row.BackoffSeconds == 0 {
+		t.Errorf("backoff_seconds = 0 while deferring; the bundle must not understate it")
+	}
+
+	// And it escalates: a second unreadable pass after the window must defer
+	// for longer, not reset to the base every time.
+	v.RunPassForTest(reverifyEpoch.Add(6 * time.Minute))
+	if got := v.Snapshot().Targets[0].BackoffSeconds; got <= row.BackoffSeconds {
+		t.Errorf("backoff_seconds stayed at %ds after a second unreadable pass (was %ds); "+
+			"a permanently broken config must not be re-read at the base cadence forever",
+			got, row.BackoffSeconds)
+	}
+}
+
+// A permanently failing repair — the shape a CLI below the #1365 version floor
+// produces, where the version gate refuses every time — must not write an
+// error line on every pass for the life of the daemon. Every sibling path in
+// the file has a once-per-episode guard; this one is held to the same rule.
+func TestReverify_RepairFailureLogsOncePerEpisode(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	f.mu.Lock()
+	f.repairErr = errors.New("installed CLI is 2.0.1, which is older than the 2.1.122 required")
+	f.mu.Unlock()
+
+	at := reverifyEpoch
+	for i := 0; i < 12; i++ {
+		f.damage("Stop")
+		v.RunPassForTest(at)
+		at = at.Add(2 * time.Hour) // clear every deferral, so every pass retries
+	}
+
+	var failures []string
+	for _, line := range log.errorSnapshot() {
+		if strings.Contains(line, "failed to re-install") {
+			failures = append(failures, line)
+		}
+	}
+	if len(failures) == 0 {
+		t.Fatalf("12 failed repairs produced no error line at all")
+	}
+	if len(failures) > 1 {
+		t.Errorf("12 failed repairs produced %d error lines; a repair that can never succeed "+
+			"would write one per pass forever, which is the noise the once-per-episode rule "+
+			"exists to prevent (#1364/#1368):\n%s", len(failures), strings.Join(failures, "\n"))
+	}
+	if got := outcome(t, v, services.ReverifyRepairFailed); got != 12 {
+		t.Errorf("repair_failed = %d, want 12 — the COUNTER carries the volume that the log "+
+			"deliberately does not", got)
+	}
+}
+
+// After a successful repair the loop keeps Missing/Stale as the record of what
+// the last verdict found, until an intact pass clears them. The diagnostics
+// note must not read that residue as "the repair has not yet succeeded".
+func TestReverify_ASuccessfulRepairIsNotReportedAsAFailedOne(t *testing.T) {
+	f, g, log := newFakeInstall(), &grantSwitch{granted: true}, &mockLogger{}
+	v := newVerifier(f, g, log)
+
+	f.damage("Stop")
+	v.RunPassForTest(reverifyEpoch)
+
+	row := v.Snapshot().Targets[0]
+	if row.LastOutcome != string(services.ReverifyRepaired) {
+		t.Fatalf("last_outcome = %q, want %q", row.LastOutcome, services.ReverifyRepaired)
+	}
+	if len(row.Missing) == 0 {
+		t.Fatalf("precondition: the row no longer carries the residue this test is about")
+	}
+	if row.LastError != "" {
+		t.Errorf("a successful repair left last_error = %q", row.LastError)
+	}
+}

--- a/core/application/services/hook_reverify_test.go
+++ b/core/application/services/hook_reverify_test.go
@@ -188,6 +188,10 @@ func TestReverify_IntactInstallIsNeverWritten(t *testing.T) {
 	if got := outcome(t, v, services.ReverifyIntact); got != 5 {
 		t.Errorf("intact counter = %d, want 5", got)
 	}
+	if row := v.Snapshot().Targets[0]; !row.Watched {
+		t.Errorf("a granted, healthy target reads watched:false: %+v — the revoke test's "+
+			"watched assertion would pass vacuously against a row that is never true", row)
+	}
 }
 
 // --- scope item 4: a revoked permission stops the loop -------------------
@@ -239,6 +243,21 @@ func TestReverify_RevokedPermissionStopsTheLoop(t *testing.T) {
 	if g.askCount() < 11 {
 		t.Errorf("consent was consulted only %d times across 11 passes; it must be "+
 			"re-read every pass, never cached", g.askCount())
+	}
+	// The published row must follow the consent, not lag it. Watched is derived
+	// from the last outcome rather than stored, so this also pins that
+	// derivation: a row reading watched:true beside last_outcome
+	// "skipped_no_consent" would be an assertion no pass ever made.
+	row := v.Snapshot().Targets[0]
+	if row.Watched {
+		t.Errorf("row still reads watched:true after the permission was revoked: %+v", row)
+	}
+	if row.LastOutcome != string(services.ReverifyNoConsent) {
+		t.Errorf("last_outcome = %q, want %q", row.LastOutcome, services.ReverifyNoConsent)
+	}
+	if row.Repairs != 1 {
+		t.Errorf("repairs = %d, want the 1 from before the revoke — a revoke must not erase "+
+			"the lifetime record of what was already done", row.Repairs)
 	}
 }
 

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -357,7 +357,7 @@ func (s *PermissionService) HookChannelReady(agentName string) bool {
 // read per pass rather than a lock and a log line.
 func (s *PermissionService) RepairGrantedHookInstall(agentName, key string) (bool, error) {
 	s.mu.Lock()
-	perm, found := s.hookPermissionLocked(agentName, key)
+	perm, found := s.hookPermission(agentName, key)
 	granted := found && s.set.Get(agentName, key) == permission.StateGranted
 	s.mu.Unlock()
 	if !granted || perm.Apply == nil {
@@ -388,24 +388,26 @@ func (s *PermissionService) RepairGrantedHookInstall(agentName, key string) (boo
 	return true, nil
 }
 
-// hookPermissionLocked resolves one agent's hook-install permission by key.
-// Caller holds s.mu.
+// hookPermission resolves one agent's HOOK-INSTALL permission by key.
 //
-// Restricted to modify-kind permissions declaring a HookInstall, so this can
-// never be used to re-run an arbitrary effect by name: the re-verification loop
-// is allowed to repair hook installs and nothing else.
-func (s *PermissionService) hookPermissionLocked(agentName, key string) (agent.Permission, bool) {
-	for _, a := range s.agents {
-		if a.Identity.Name != agentName {
-			continue
-		}
-		for _, p := range a.Permissions {
-			if p.Key == key && p.Hooks != nil && p.Kind == permission.KindModify {
-				return p, true
-			}
-		}
+// A thin filter over declared() rather than a second registry walk: two copies
+// of "find the permission named key on the agent named agentName" would be two
+// places to keep in step, and the filter is the only part that is actually
+// specific to this caller.
+//
+// The filter is the point. Restricted to modify-kind permissions declaring a
+// HookInstall, so RepairGrantedHookInstall can never be used to re-run an
+// arbitrary effect by name: the re-verification loop is allowed to repair hook
+// installs and nothing else.
+//
+// Takes no lock and needs none — s.agents is written once at construction and
+// only read after. Named without the Locked suffix for that reason.
+func (s *PermissionService) hookPermission(agentName, key string) (agent.Permission, bool) {
+	p, ok := s.declared(agentName, key)
+	if !ok || p.Hooks == nil || p.Kind != permission.KindModify {
+		return agent.Permission{}, false
 	}
-	return agent.Permission{}, false
+	return p, true
 }
 
 // Snapshot returns the full consent state for GET /api/v1/permissions.

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -364,14 +364,21 @@ func (s *PermissionService) RepairGrantedHookInstall(agentName, key string) (boo
 		return false, nil
 	}
 
-	s.runEffects([]pendingEffect{{agentName: agentName, perm: perm, target: permission.StateGranted}})
+	if ran := s.runEffects([]pendingEffect{{agentName: agentName, perm: perm, target: permission.StateGranted}}); ran == 0 {
+		// Gate 3 fired: consent went away while this repair waited on effectMu,
+		// so nothing was written. Report it as NOT ATTEMPTED, which is what the
+		// caller means by that word — the alternative is worse than cosmetic.
+		// effectErrs is untouched by a skip, so the read below would return ""
+		// (or, worse, a stale error from a previous attempt) and the loop would
+		// bank a repair that never happened: a lifetime counter, a log line
+		// blaming something outside irrlicht for a deletion, and an armed
+		// back-off, all describing a write the service refused to make.
+		return false, nil
+	}
 
 	// Read the outcome out of the same slot the interactive path writes, rather
 	// than having runEffects hand it back: one recorded truth, which is what the
-	// wizard renders and what HookChannelReady reads. A superseding revoke that
-	// caused runEffects to skip leaves the previous value in place, and the next
-	// pass's consent check — which will find the permission denied — is what
-	// stops the loop, not this return.
+	// wizard renders and what HookChannelReady reads.
 	s.mu.Lock()
 	reason := s.effectErrs[effectKey(agentName, key)]
 	s.mu.Unlock()
@@ -544,10 +551,16 @@ func (s *PermissionService) declared(agentName, key string) (agent.Permission, b
 // the permission (surfacing in Snapshot as EffectError), never propagated
 // — the recorded state stands, the user's consent is never rolled back by
 // a failed effect, and effects are re-applied on the next daemon start.
-func (s *PermissionService) runEffects(effects []pendingEffect) {
+// It returns how many effects it actually RAN, which is not len(effects): an
+// effect superseded while the batch waited on effectMu is skipped. Only the
+// out-of-band #1372 repair reads the count, and it needs it — from outside,
+// "skipped because consent went away" and "applied successfully" are otherwise
+// indistinguishable, and the repair loop would bank a phantom re-install.
+func (s *PermissionService) runEffects(effects []pendingEffect) int {
 	if len(effects) == 0 {
-		return
+		return 0
 	}
+	ran := 0
 	s.effectMu.Lock()
 	defer s.effectMu.Unlock()
 	for _, e := range effects {
@@ -565,6 +578,7 @@ func (s *PermissionService) runEffects(effects []pendingEffect) {
 			s.log.LogInfo("permissions", "", fmt.Sprintf("%s/%s: skipping stale %s effect (state is now %s)", e.agentName, e.perm.Key, e.target, current))
 			continue
 		}
+		ran++
 		s.runClosureEffect(e)
 		if e.perm.Kind == permission.KindObserve {
 			if e.target == permission.StateGranted {
@@ -574,6 +588,7 @@ func (s *PermissionService) runEffects(effects []pendingEffect) {
 			}
 		}
 	}
+	return ran
 }
 
 // runClosureEffect runs the effect's Apply/Remove closure, if any, and

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -318,6 +318,89 @@ func (s *PermissionService) HookChannelReady(agentName string) bool {
 	return false
 }
 
+// RepairGrantedHookInstall re-runs one hook permission's install effect out of
+// band, for the periodic entry re-verification loop (issue #1372).
+//
+// It reports whether the effect was ATTEMPTED, and if so whether it succeeded.
+// attempted=false is the consent refusal — the permission is not currently
+// granted, is unknown, or declares no hook install — and it is not an error:
+// declining to write is the correct outcome, not a failure to be retried.
+//
+// There are two consent checks on this path and they cover different windows.
+// The pre-check below is the one that refuses every ordinary revoked caller —
+// it is a real gate, not decoration, and deleting it is visible as a red test.
+// But it can only be as fresh as the instant it was asked, and the write that
+// follows may wait on a mutex first. So the write itself is not performed here:
+// it goes through runEffects, exactly as a wizard answer does, which means the
+// background repair inherits every guarantee the interactive path already had
+// and cannot drift from it:
+//
+//   - runEffects takes effectMu, so a repair cannot race a concurrent Answer
+//     batch into the same installer;
+//   - under effectMu it re-reads the recorded state and SKIPS any effect whose
+//     target no longer matches. That third read is what makes revocation
+//     authoritative rather than eventually noticed: consent withdrawn at any
+//     point before the closure runs means the closure does not run, and the
+//     skip is logged. It is the only one of the three that a user revoking
+//     WHILE a repair waits on the lock can be caught by, and
+//     TestRunEffects_SkipsAGrantEffectWhoseStateIsNoLongerGranted pins it;
+//   - runClosureEffect consults the declared version floor (#1365) before
+//     applying, so a repair cannot install into a CLI too old for the entries;
+//   - the outcome lands in effectErrs, so a repair that FAILS surfaces as the
+//     permission's EffectError and is retried by the user re-answering — the
+//     #1362 mechanism, not a second one. That also drops HookChannelReady to
+//     false, which correctly disarms #1368's liveness watchdog for an adapter
+//     whose install is known broken.
+//
+// The pre-check below also keeps the common case — nothing granted, nothing to
+// do — off effectMu entirely, so an unanswered wizard costs the loop one map
+// read per pass rather than a lock and a log line.
+func (s *PermissionService) RepairGrantedHookInstall(agentName, key string) (bool, error) {
+	s.mu.Lock()
+	perm, found := s.hookPermissionLocked(agentName, key)
+	granted := found && s.set.Get(agentName, key) == permission.StateGranted
+	s.mu.Unlock()
+	if !granted || perm.Apply == nil {
+		return false, nil
+	}
+
+	s.runEffects([]pendingEffect{{agentName: agentName, perm: perm, target: permission.StateGranted}})
+
+	// Read the outcome out of the same slot the interactive path writes, rather
+	// than having runEffects hand it back: one recorded truth, which is what the
+	// wizard renders and what HookChannelReady reads. A superseding revoke that
+	// caused runEffects to skip leaves the previous value in place, and the next
+	// pass's consent check — which will find the permission denied — is what
+	// stops the loop, not this return.
+	s.mu.Lock()
+	reason := s.effectErrs[effectKey(agentName, key)]
+	s.mu.Unlock()
+	if reason != "" {
+		return true, errors.New(reason)
+	}
+	return true, nil
+}
+
+// hookPermissionLocked resolves one agent's hook-install permission by key.
+// Caller holds s.mu.
+//
+// Restricted to modify-kind permissions declaring a HookInstall, so this can
+// never be used to re-run an arbitrary effect by name: the re-verification loop
+// is allowed to repair hook installs and nothing else.
+func (s *PermissionService) hookPermissionLocked(agentName, key string) (agent.Permission, bool) {
+	for _, a := range s.agents {
+		if a.Identity.Name != agentName {
+			continue
+		}
+		for _, p := range a.Permissions {
+			if p.Key == key && p.Hooks != nil && p.Kind == permission.KindModify {
+				return p, true
+			}
+		}
+	}
+	return agent.Permission{}, false
+}
+
 // Snapshot returns the full consent state for GET /api/v1/permissions.
 func (s *PermissionService) Snapshot() PermissionsSnapshot {
 	s.mu.Lock()

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -302,6 +302,14 @@ func (l *mockLogger) infoSnapshot() []string {
 	return out
 }
 
+func (l *mockLogger) errorSnapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.errors))
+	copy(out, l.errors)
+	return out
+}
+
 type mockGit struct{}
 
 func (g *mockGit) GetBranch(dir string) string { return "main" }

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -440,6 +440,21 @@ func runDaemon() {
 		Receipts:       hookjson.HookReceiptsFor,
 	})
 
+	// Hook-entry re-verification loop (#1372). Same construction timing and the
+	// same reason as the watchdog above: the diagnostics bundle registered a few
+	// lines below reads its snapshot, and its consent collaborators do not exist
+	// yet. Until SetConsent runs it reports every target unwatched and writes
+	// nothing — which is honest, since nothing has been consented to either.
+	//
+	// Deliberately a SEPARATE object from the watchdog: that one answers "is
+	// anything arriving" from receipts and turns, this one answers "are the
+	// entries still there" by re-reading the file, and collapsing them would
+	// merge two diagnoses whose whole value is being distinguishable.
+	hookVerifier := services.NewHookEntryVerifier(services.HookEntryReverifyConfig{
+		Agents: allAgents,
+		Log:    logger,
+	})
+
 	mux := http.NewServeMux()
 	registerCoreRoutes(mux, registerCoreRoutesDeps{
 		FSRepo:            fsRepo,
@@ -451,6 +466,7 @@ func runDaemon() {
 		PublishController: rel.publishController,
 		Cfg:               cfg,
 		HookLiveness:      hookLiveness,
+		HookVerifier:      hookVerifier,
 	})
 
 	// Static web UI: served from disk so the dashboard ships as three files
@@ -531,6 +547,11 @@ func runDaemon() {
 	hookLiveness.SetChannelReady(permService.HookChannelReady)
 	detector.SetHookLivenessWatchdog(hookLiveness)
 
+	// The verifier's collaborators, available for the same reason and at the
+	// same moment. Both come from the permission service on purpose: the loop
+	// gets no write path of its own, only the right to ask (#1372/#570).
+	hookVerifier.SetConsent(permService.Granted, permService.RepairGrantedHookInstall)
+
 	backchannelEngine, terminalObserver := setupBackchannel(mux, setupBackchannelDeps{
 		CachedRepo:        cachedRepo,
 		Push:              push,
@@ -568,6 +589,7 @@ func runDaemon() {
 		GitResolver:       gitResolver,
 		TerminalObserver:  terminalObserver,
 		PermService:       permService,
+		HookVerifier:      hookVerifier,
 		Cfg:               cfg,
 		DemoMode:          demoMode,
 		Logger:            logger,

--- a/core/cmd/irrlichd/paths.go
+++ b/core/cmd/irrlichd/paths.go
@@ -115,10 +115,10 @@ func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Ag
 // diagnostics bundle (issue #1364). Only the daemon wires it: these counters
 // accumulate in whatever process served the hooks, and --diagnose is not that
 // process.
-// watchdog carries the liveness half (#1368) and may be nil, which reads the
-// same way the whole function being absent does: the counters are omitted, not
-// zeroed.
-func liveHookHealth(watchdog *services.HookLivenessWatchdog) func() services.HookHealthSnapshot {
+// watchdog carries the liveness half (#1368) and verifier the entry-presence
+// half (#1372); either may be nil, which reads the same way the whole function
+// being absent does — that section is omitted, not zeroed.
+func liveHookHealth(watchdog *services.HookLivenessWatchdog, verifier *services.HookEntryVerifier) func() services.HookHealthSnapshot {
 	return func() services.HookHealthSnapshot {
 		rows := hookjson.UnknownEvents()
 		snap := services.HookHealthSnapshot{
@@ -127,6 +127,7 @@ func liveHookHealth(watchdog *services.HookLivenessWatchdog) func() services.Hoo
 			UnknownEventsTotal:  hookjson.UnknownEventTotal(),
 			Channels:            watchdog.Snapshot(),
 			ReceiptsTotal:       hookjson.HookReceiptTotal(),
+			EntryReverification: verifier.Snapshot(),
 		}
 		for _, row := range rows {
 			snap.UnknownEvents = append(snap.UnknownEvents, services.UnknownHookEvent{

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -383,6 +383,11 @@ type registerCoreRoutesDeps struct {
 	// (#1368). Built before this call because the diagnostics bundle is
 	// registered earlier in startup than the detector that drives it.
 	HookLiveness *services.HookLivenessWatchdog
+	// HookVerifier supplies the entry re-verification rows for hooks.json
+	// (#1372), for the same reason and with the same timing as HookLiveness:
+	// built before this call, its consent collaborators injected after the
+	// permission service exists.
+	HookVerifier *services.HookEntryVerifier
 }
 
 // registerCoreRoutes wires the always-on API surface: session state, the
@@ -412,7 +417,7 @@ func registerCoreRoutes(mux *http.ServeMux, deps registerCoreRoutesDeps) {
 	// per-PID liveness, trimmed logs, and config for bug reports. Localhost
 	// only — it carries session paths and (pre-redaction) process argv. Reads
 	// fsRepo directly for a fresh, uncached snapshot.
-	diagSvc := buildDiagnostics(deps.FSRepo, deps.AllAgents, deps.Cfg, liveHookHealth(deps.HookLiveness))
+	diagSvc := buildDiagnostics(deps.FSRepo, deps.AllAgents, deps.Cfg, liveHookHealth(deps.HookLiveness, deps.HookVerifier))
 	mux.HandleFunc("GET /debug/bundle", localhostOnly(handleDiagnosticsBundle(diagSvc)))
 }
 
@@ -984,6 +989,7 @@ type startBackgroundLoopsDeps struct {
 	GitResolver       *git.Adapter
 	TerminalObserver  *services.TerminalObserver
 	PermService       *services.PermissionService
+	HookVerifier      *services.HookEntryVerifier
 	Cfg               config.Config
 	DemoMode          bool
 	Logger            outbound.Logger
@@ -1014,6 +1020,15 @@ func startBackgroundLoops(deps startBackgroundLoopsDeps) context.CancelFunc {
 
 	if !deps.DemoMode {
 		deps.PermService.Start(detectorCtx)
+		// Hook-entry re-verification (#1372). Started only outside demo mode
+		// and only after PermService.Start, which re-applies every granted
+		// install: starting it earlier would have the loop racing the boot
+		// repair and reporting a clobber the daemon was already fixing.
+		//
+		// It is inert in demo mode by omission rather than by an internal
+		// check — demo mode has no real consent state, so a loop asking
+		// "is this granted" would be asking a fiction.
+		go deps.HookVerifier.Run(detectorCtx)
 		// Hooks are delivered by Claude Code's native `type: http` transport
 		// straight to the daemon (#1161) — no curl, no shell — so there is no
 		// external tool whose absence could silently no-op delivery (the reason

--- a/core/domain/agent/declaration.go
+++ b/core/domain/agent/declaration.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 
 	"irrlicht/core/domain/permission"
 	"irrlicht/core/pkg/cliversion"
@@ -135,12 +136,68 @@ type HookInstall struct {
 	// it modified anything.
 	Uninstall func() (bool, error)
 
+	// Verify reports what our entries look like in that file RIGHT NOW,
+	// without writing anything (issue #1372).
+	//
+	// It exists because the install is not a one-shot fact. An agent whose own
+	// UI rewrites its settings can delete our entries between the grant and
+	// the next hook: gemini-cli's writer is sync-by-omission — it drops every
+	// key absent from the snapshot the CLI took at startup, recursively — and
+	// one of its write paths (saveModelChange) is not even user-initiated. The
+	// symptom is indistinguishable from every other silent hook failure: a
+	// permission still reading `granted`, no error anywhere, and waiting
+	// detection quietly degraded.
+	//
+	// Read-only is the contract, not an implementation detail. The repair is a
+	// separate step run through the permission service, so that the write
+	// stays behind the same consent gate the original install passed, and so
+	// that a verifier can never become a way to write to a config the user
+	// withdrew consent for (#570).
+	Verify func() (HookEntryStatus, error)
+
 	// Version declares the upstream CLI version floor this install requires
 	// (issue #1365). Nil means the adapter declares no floor and installs
 	// unconditionally — which is what Claude Code did for its whole life, and
 	// what a third adapter would inherit by default, so a nil here is a
 	// decision worth stating rather than an omission.
 	Version *VersionGate
+}
+
+// HookEntryStatus is one read-only look at an install (issue #1372): which of
+// the events the adapter installs are no longer represented in the config file
+// the way we would write them today.
+//
+// The two buckets are kept apart because they are different accidents, even
+// though the repair for both is the same call. Missing means nothing carrying
+// our sentinel is in that event's array at all — somebody deleted it, which is
+// the gemini-cli sync-by-omission case. Stale means an entry of ours IS there
+// but no longer canonical — most often pointing at a port this daemon is not
+// listening on (#1178), which a user reading the file would not spot as broken.
+type HookEntryStatus struct {
+	// Missing are event names with no irrlicht entry left in the file.
+	Missing []string
+	// Stale are event names whose irrlicht entry is present but not in the
+	// shape (or at the endpoint) we would install today.
+	Stale []string
+}
+
+// Intact reports whether the install needs nothing done to it.
+func (s HookEntryStatus) Intact() bool {
+	return len(s.Missing) == 0 && len(s.Stale) == 0
+}
+
+// Damage renders the finding for a log line, e.g. "missing: Stop, Notification;
+// stale: PreToolUse". Empty for an intact install, so a caller never logs a
+// verdict with nothing behind it.
+func (s HookEntryStatus) Damage() string {
+	var parts []string
+	if len(s.Missing) > 0 {
+		parts = append(parts, "missing: "+strings.Join(s.Missing, ", "))
+	}
+	if len(s.Stale) > 0 {
+		parts = append(parts, "stale: "+strings.Join(s.Stale, ", "))
+	}
+	return strings.Join(parts, "; ")
 }
 
 // VersionGate is a declared minimum upstream-CLI version for a hook install


### PR DESCRIPTION
Closes #1372.

## The problem

irrlicht installed hook entries once on consent and then assumed they were still there. That is false for any agent whose own UI rewrites its config.

gemini-cli's settings writer is **sync-by-omission**: `applyKeyDiff` deletes any key present on disk but absent from the in-memory snapshot the CLI took at startup, recursively. #1355's Phase C audit verified it live — with gemini running, an externally added top-level key **and** an externally added `hooks.PreCompress` entry were both deleted by a single `/theme` change, and one of the write paths (`saveModelChange`) is not user-initiated. Claude Code and Codex have the same exposure and it had never been checked.

The symptom is the same as every other silent hook failure: "irrlicht stopped detecting waiting", a permission still reading `granted`, and no error anywhere.

## What this adds

| Piece | File |
|---|---|
| `hookjson.Verify` — read-only counterpart to `EnsureInstalled` | `core/adapters/inbound/agents/hookjson/verify.go` |
| Shared staleness predicates so verify and repair cannot drift | `core/adapters/inbound/agents/hookjson/hookjson.go` |
| `agent.HookEntryStatus` + `HookInstall.Verify` | `core/domain/agent/declaration.go` |
| `VerifyHooksInstalled` + declaration, both adapters | `claudecode/`, `codex/` `hookinstaller.go`, `agent.go` |
| Registry tripwire — a new hook adapter must declare `Verify` | `core/adapters/inbound/agents/hookverify_test.go` |
| `HookEntryVerifier` — timed loop, per-reason counters, back-off | `core/application/services/hook_reverify.go` |
| `RepairGrantedHookInstall` — the only write path | `core/application/services/permission_service.go` |
| `entry_reverification` section in `hooks.json` | `core/application/services/diagnostics_service.go` |
| Wiring | `core/cmd/irrlichd/{main,startup,paths}.go` |

**Nothing new was invented where a mechanism existed.** `IsCanonical` already expressed "is this entry ours and current" — this calls it on a schedule. A repair that fails routes into #1362's `EffectError` and is retried by re-answering, not into a new error channel. The version gate (#1365) is consulted because the repair goes through `runEffects`, not around it. The counters follow the #1361/#1364 idiom: closed reason enum, fixed array of atomics, `Snapshot()` that omits zeros.

## Consent — the constraint this ticket said to get right

Re-verification **reads** a user config and the repair **writes** one. Both are what the hooks permission discloses, so both stay behind it. There are **three independent refusals**, each individually deleted and seen to turn a test red:

| # | Where | Deleted → |
|---|---|---|
| 1 | The loop asks `Granted` before it reads — every pass, never cached, and *before* the back-off check | `TestReverify_RevokedPermissionStopsTheLoop` red: *"verify was called 10 more times after the permission was revoked (1 -> 11)"*, plus `TestReverify_PendingPermissionIsNeverRead` red |
| 2 | `RepairGrantedHookInstall` re-reads the recorded state before queueing | with gate 3 also removed, `TestReverify_RevokedPermissionNeverTouchesTheFileOnDisk` red: *"RepairGrantedHookInstall attempted a write on a denied permission"* |
| 3 | `runEffects` re-reads it a third time **under `effectMu`**, immediately before the closure | `TestRunEffects_SkipsAGrantEffectWhoseStateIsNoLongerGranted` red: *"Apply ran 1 times for a grant effect whose permission is DENIED"* |

Gate 3 is the one that matters for a real revoke: gates 1 and 2 can only be as fresh as the instant they were asked, and the write that follows may wait on a mutex behind an in-flight wizard answer. It is unreachable from outside the package by construction — gate 2 stops every non-racing caller — so it is tested in-package by handing `runEffects` the exact `pendingEffect` the repair builds, with the state already denied. That is deterministic where a scheduling race would be flaky and would pass vacuously whenever it lost. It ships with a vacuity guard (`TestRunEffects_RunsAGrantEffectWhoseStateIsStillGranted`) so a `runEffects` that ran nothing could not satisfy it.

**The loop owns no write path of its own.** It cannot call `Apply`; it can only ask the service, and the service can say no. `TestReverify_RevokedPermissionNeverTouchesTheFileOnDisk` runs the real `PermissionService` against a real file and asserts the clobbered bytes are still there, byte for byte, after five passes.

The narrower race — consent granted at the read, gone at the write — is a *consent* outcome, not a failed repair. **The first version of this PR got that wrong and the review caught it**: `runEffects` skipping an effect left `effectErrs` untouched, so `RepairGrantedHookInstall` returned `(true, nil)` and the loop banked a repair that never happened — a lifetime counter, an armed back-off, and an error-level line blaming something outside irrlicht for a deletion that had not occurred. The test that was supposed to pin this drove a *fake* whose `attempted` field the test itself set to `false`, so it never exercised the real service in that window. `runEffects` now reports how many effects it ran, `RepairGrantedHookInstall` returns `(false, nil)` on zero, and there are two tests: a deterministic one on the `ran == 0` accessor, and one that holds `effectMu` itself so a repair past the pre-check is parked exactly where gate 3 catches it.

## Back-off and logging

Per target, on **consecutive** repairs: `base × 2^(n-1)`, capped. Production `base` = 5 min, cap = 1 h. A pass that finds the install **intact** resets the counter and clears the deferral — the back-off is a ceiling, not a latch, so a config clobbered once an hour is still fixed once an hour. A failed repair and an unreadable config defer too, since retrying either every pass is the same spin by a different route.

Measured in `TestReverify_BacksOffWhenTheRepairKeepsLosing`: 240 passes one minute apart against damage that is re-applied every time yields **9** writes instead of 240, and the test fails on both sides (`>= 20` spinning, `< 4` latched).

Logging follows the #1364/#1368 "once per episode" rule — a channel under sustained attack must not write a line per pass forever:

- **first repair of an episode** (error level): `<adapter>/<perm>: irrlicht's hook entries were missing: Stop in ~/.claude/settings.json and have been re-installed (#1372). Something outside irrlicht rewrote that file — an agent settings UI that syncs by omission does this on any config change, and the permission stays green throughout.`
- **3rd consecutive repair**, once (error level): `... have now been re-installed 3 times in a row in <path> (#1372) — something is rewriting that file faster than we repair it. Backing off to at most one repair per 20m0s; further repairs are counted in the diagnostics bundle but not logged until the install is found intact.`
- **recovery** (info): `hook entries verified intact after N repair(s) — back-off cleared (#1372)`
- **repair failed** (error): names the reason and says it is now the permission's `effect_error` and that re-granting retries.
- **unreadable**, once on transition (error): says nothing was written and why.

`TestReverify_LogsOncePerEpisodeNotOncePerRepair` pins it: 12 repairs produce at most 3 lines, at least 1, and the line names the affected event.

## Keeping the three diagnoses apart

This was an explicit requirement, so it is asserted rather than trusted. `hooks.json` now carries `entry_reverification` rows (adapter, permission, **config_path**, watched, missing, stale, repairs, consecutive_repairs, last_outcome, backoff_seconds, last_error) plus zero-omitting `entry_reverification_outcomes`, and a note emitted only when something happened:

> irrlicht re-verifies that its hook entries are still present in each agent's own config, on a timer, and re-installs them when they are not (#1372). Re-installed this session: claude-code (7). A non-zero count means something OUTSIDE irrlicht removed or rewrote those entries after the user granted the permission — an agent whose own settings UI syncs by omission deletes every key it did not know about on any config change, and gemini-cli is confirmed to do exactly that. A count that keeps climbing is that, happening repeatedly; the loop backs off exponentially rather than fighting it, so consecutive_repairs and backoff_seconds are the fields to read. This section is about whether the entries EXIST. It is a different question from whether anything is arriving through them, which is the channels/silent_channel_note above (#1368), and from an install that FAILED and never wrote entries at all, which shows up as effect_error on the permission (#1362). A repair that fails is recorded there too, so a repair_failed count here has its reason on the permission. watched:false means the permission is not currently granted, so nothing is read or written for that row at all — not that the entries are gone.

#1368's `silent_channel_note` previously said the entries question was unanswerable; it now points at the new rows and says what to read:

> ... It does NOT mean the entries are still present — if something removed them since, this is how that looks too, and the entry_reverification rows below are what tell those apart (#1372): a row with repairs:0 and no missing/stale means the entries WERE there at the last pass, so this really is a dead channel and not a clobbered config. ...

`hook_liveness.go`'s header, which said "#1372, not built", is updated in place.

The `--diagnose` CLI omits the **data** and publishes a note saying why, matching how #1364's counters and #1368's channels already behave — that process runs no passes, so "entries verified present" from it would be a measurement nobody took. `TestHooksBundleOmitsReverificationWhenNotCollectedInDaemon` pins it.

## Red-first evidence

`hookjson.Verify` and `HookEntryVerifier` were both written as stubs first and the tests run against them.

`hookjson` (stub returned an always-intact status) — 6 of 8 test funcs red, e.g.:

```
--- FAIL: TestVerify_ExternallyDeletedEntriesAreReported/http
    Verify reports an intact install after the whole `hooks` key was deleted externally
    — this is the #1372 defect: the permission still reads granted, nothing errors, and
    waiting detection is silently gone
--- FAIL: TestVerifyAgreesWithEnsureInstalled/http/one_event_deleted
    Verify says intact=true but EnsureInstalled MODIFIED the file.
```

`HookEntryVerifier` (stub with a no-op `pass`):

```
--- FAIL: TestReverify_RepairsExternallyDeletedEntries
    verify called 0 times, want 1
    repair called 0 times, want 1 — entries deleted by the agent's own settings UI must
    be re-installed without the user noticing (#1372)
--- FAIL: TestReverify_RevokedPermissionStopsTheLoop
    precondition: granted loop did not repair (repairs=0) — the revoke assertion below
    would pass vacuously
--- FAIL: TestReverify_BacksOffWhenTheRepairKeepsLosing
    only 0 repairs across four hours; the back-off must be a ceiling, not a latch
```

Registry tripwire, with codex's declaration deleted:

```
--- FAIL: TestEveryHookInstallDeclaresAVerifier
    codex/hooks installs hooks into a user config but declares no Verify (#1372), so the
    re-verification loop skips it silently
```

**Locks — these pass by construction and are not red-first evidence:**

- `TestVerify_IntactInstallReportsNoDamage` and `TestVerify_NeverWritesAnything` passed against the do-nothing stub. They are worth keeping (the second is the "a verifier must not write" invariant) but they proved nothing at that point.
- `TestReverify_IntactInstallIsNeverWritten`, `TestReverify_PendingPermissionIsNeverRead` and the "never repaired" arms of the unreadable/adapter-without-verify tests likewise pass against a loop that does nothing. Their value is that they can fail now that it does something — which the gate-1 mutation demonstrated for `PendingPermissionIsNeverRead`.
- `TestRunEffects_SkipsAGrantEffectWhoseStateIsNoLongerGranted` is a lock on pre-existing `runEffects` behaviour, not new code. It was still seen red under a deliberate mutation.
- The equivalence test `TestVerifyAgreesWithEnsureInstalled` is a lock in one direction (it pins that `EnsureInstalled` keeps behaving as it does) and a defect test in the other.

## Interaction with #1421 (landed mid-review)

`main` moved under this branch while it was in review; #1421 makes `install.sh --uninstall` sweep hook entries. No file overlap, and the two compose correctly rather than by luck:

- #1421 calls `uninstall_agent_hooks()` from `uninstall_previous()` **after the daemon is stopped**, so this loop is not running when the sweep happens.
- `irrlichd --uninstall-hooks` also persists the hooks permission as `StateDenied` (`denyHooksPermissions`, `core/cmd/irrlichd/main.go:236` — read, not assumed). A daemon started afterwards loads that denial, so gate 1 refuses and this loop cannot undo the sweep.

**One narrow case is genuinely widened, and I am not dismissing it:** running `irrlichd --uninstall-hooks` *by hand while a daemon is live* leaves that daemon's in-memory consent still reading granted, since the denial is written to the store by a separate process. Before this PR the entries stayed gone until the next daemon start (which loads the denial). With this PR the live daemon's loop re-installs them within one interval. The supported path is unaffected because #1421 stops the daemon first; the by-hand path is the one #1421's docs call out. Closing it properly means the service re-reading its store or the CLI signalling the daemon — both beyond this issue, and worth an issue of their own rather than a rushed fix here.

## Review and simplify passes

A `high`-effort review subagent returned **six findings, all confirmed, all fixed**, each seen red first (commit `ecbceba2`): the phantom-repair bug above; a note that called every successfully repaired target *"the repair has not yet succeeded"* for up to an hour, because it classified on the `Missing`/`Stale` residue instead of `last_outcome`; an unreadable-config deferral that was computed and published but never applied, so the file was re-parsed every pass while the bundle advertised a cooling-off window that did not exist; a failed repair logging at error level on every attempt — the one path lacking the once-per-episode guard, which for a CLI below the #1365 version floor meant ~24 identical lines a day forever; a first-pass delay that published every row in its zero state for the first five minutes of uptime; and a read-only test that could not fail.

`/simplify` (4 agents) returned two actionable findings, both applied (`2e5fa53b`): `hookPermissionLocked` was a second copy of `declared()`'s registry walk and is now a thin filter over it; and `reverifyState.watched` was a stored bool three write sites had to keep in lockstep with `lastOutcome` — precisely the redundancy `hook_liveness.go`'s `hookChannelState` documents refusing — now derived in `Snapshot` with both arms pinned. Skipped, with reasons: merging the two staleness *walk* helpers (they are the 1:1 read-only twins of `upgradeStaleEntries`/`upgradeStaleMatchers`, and that pairing is itself the drift protection); dropping `cfg.Agents` from the long-lived verifier (verified not a live leak — `PermissionService` already pins the same slice for daemon life); and splitting `hooksView()`'s now-10-field struct literal (real, but it would drag #1364's and #1368's fields into this diff).

## Deliberately not done

- **No gemini-cli adapter.** gemini-cli is unmaintained as of #1068 and installs no hooks today; this is Phase B infrastructure that the gemini adapter would inherit by declaring one field.
- **No user-visible UI.** The wizard is unchanged. A repair the user never notices is the requirement; a repair *failure* was already visible via #1362.
- **`PathConfiner`'s counters are still unpublished.** `confine.go:254` notes they reach no UI. Adjacent and tempting, out of scope.
- **No config knob for the interval.** Defaults are constants. Adding a `config.Config` field is a wider change and nothing yet needs it.

## Verification

`tools/preflight.sh` run chunked in the foreground, twice — before review and after the fixes: **go** (7 checks incl. `go test ./core/... -race`, replay fixtures, replaydata validate) PASS; **web** (both suites) PASS; **arch** PASS (ARS 7.9498 → 7.9495, not flagged); **tools** PASS; **skills** PASS; **security** PASS. Re-verified after rebasing onto #1421.

Deletion tripwire (`git diff --diff-filter=D --name-only <base>...HEAD`) empty against both the originally recorded base SHA `d6b4ccd1` and the post-rebase `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
