### PR TITLE
fix(ci): gate #!/bin/sh scripts against a real POSIX shell and a bashism linter

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,6 +28,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      # POSIX-sh gate (#1423). This job is the host because ubuntu is the only
+      # runner where the property can actually be tested: `/bin/sh` here is
+      # dash, and the image ships shellcheck (0.9.0). test.yml's `go-test` job
+      # cannot host it — that job is pinned to macos-latest for the macOS
+      # runtime paths in `go test ./core/...` (kqueue exit-watch, pgrep/lsof
+      # discovery), and the macos image ships no shellcheck at all, so the
+      # gate would have to `brew install` a linter on every PR to check two
+      # files. Runs before setup-go: it needs no toolchain, takes well under a
+      # second, and behind the Go steps a compile error would abort the job
+      # and leave an installer-only PR with no installer feedback.
+      #
+      # site/install.sh reaches users as `curl … | sh`, which on Debian and
+      # Ubuntu is dash — so a bashism here lands on a new user's first
+      # command, before anything is installed that could report it.
+      - name: Lint POSIX sh scripts
+        run: tools/posix-lint.sh
+
       - name: Set up Go
         uses: actions/setup-go@v7
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -45,6 +45,15 @@ jobs:
       - name: Lint POSIX sh scripts
         run: tools/posix-lint.sh
 
+      # The gate's own unit tests, over the deliberately-broken corpus under
+      # tools/lib/testdata/posix-lint/. They live here rather than in test.yml's
+      # `tools/lib/*_test.sh` loop for the same reason the gate does: they need
+      # a static bashism linter, and the macos image ships none. A gate that
+      # passes by construction is what #1423 is about, so the mutation corpus
+      # has to run somewhere — this is where it can.
+      - name: Test the POSIX-sh gate
+        run: bash tools/lib/posix-lint_test.sh
+
       - name: Set up Go
         uses: actions/setup-go@v7
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,15 @@ jobs:
       - name: Test the shared shell libs
         run: |
           for t in tools/lib/*_test.sh; do
+            # posix-lint_test.sh drives tools/posix-lint.sh, which REQUIRES a
+            # static bashism linter and refuses to pass without one (#1423 is
+            # about a gate that passed having checked nothing, so it fails
+            # rather than skipping). This runner is macos-latest, whose image
+            # ships neither shellcheck nor checkbashisms — which is the same
+            # reason the gate itself lives in linux.yml. Both run there.
+            # Installing a linter here would cost every PR 20-40s to re-test
+            # what linux.yml already tested.
+            case "$t" in */posix-lint_test.sh) continue ;; esac
             echo "== $t =="
             bash "$t"
           done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,14 +271,21 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `tools/lib/install-uninstall_test.sh` is a bash file that writes `#!/bin/sh`
   stubs inside a heredoc, and a content grep would try to lint it as POSIX sh.
   It runs two different kinds of check on each file: a real POSIX shell's
-  parser (`dash -n`) and a static bashism linter (`checkbashisms`, else
-  `shellcheck --shell=sh` filtered to its POSIX-compatibility codes —
-  `SC3xxx`, plus `SC2039` and `SC2112`, so general style debt stays out of
-  scope). Both, because the parser alone is far weaker than it looks:
-  measured one bashism per file, `dash -n` catches **3 of 8** — it flags
-  arrays, process substitution and the `function` keyword, and accepts
-  `[[ ]]`, `${v,,}`, `+=`, `echo -e` and `source`. Either static linter
-  catches 8 of 8. That gap is #1423: `site/install.sh` reaches users as
+  parser (`dash -n`) and **every** static bashism linter installed —
+  `shellcheck --shell=sh` filtered to its POSIX-compatibility codes
+  (`SC3xxx`, plus `SC2039` and `SC2112`/`SC2113`, so general style debt stays
+  out of scope) and `checkbashisms`. Both kinds, because the parser alone is
+  far weaker than it looks: measured one bashism per file, `dash -n` catches
+  **3 of 8** — it flags arrays, process substitution and the `function`
+  keyword, and accepts `[[ ]]`, `${v,,}`, `+=`, `echo -e` and `source`, where
+  either static linter catches all eight of those. *Every* installed linter
+  rather than the first one found, because the two disagree beyond that
+  sample: `checkbashisms` accepts `local`, `set -o pipefail` and `echo -n`,
+  which `shellcheck` rejects (SC3043/SC3040/SC3037) and which an installer
+  accretes. CI has shellcheck and not checkbashisms, so preferring the other
+  one locally would let a developer's preflight pass a diff CI rejects —
+  running both is monotone, and a run without shellcheck says out loud that
+  it is weaker than CI. That gap is #1423: `site/install.sh` reaches users as
   `curl … | sh`, which on Debian and Ubuntu is dash, so a bashism lands on a
   new user's first command before anything is installed that could report it.
   The gate lives in **`linux.yml`**, not test.yml, and the placement is the
@@ -292,8 +299,12 @@ Before marking a ticket done, run the full suite — every layer must pass:
   remove. Its tests are `tools/lib/posix-lint_test.sh` over the corpus under
   `tools/lib/testdata/posix-lint/`: one deliberately-broken fixture per
   bashism class, committed rather than improvised so the mutation evidence
-  outlives the PR, plus a clean `good-clean.sh` as the vacuity guard and two
-  cases pinning the refusals. One of those cases exists because the first
+  outlives the PR, plus a clean `good-clean.sh` as the vacuity guard,
+  `noisy-but-posix.sh` (POSIX-clean but SC2086-noisy) pinning the severity
+  filter in the one direction the `bad-*` files cannot reach, and two cases
+  pinning the refusals. That suite runs in `linux.yml`, **not** in test.yml's
+  `tools/lib/*_test.sh` loop — it needs a linter the macOS image lacks, and
+  the loop skips it by name for that reason. One of those cases exists because the first
   draft of the linter reproduced #1423 inside itself — it piped into `grep`
   and tested the capture for emptiness, so a linter that failed to run came
   back empty, empty read as clean, and it printed `ALL PASS` over an installer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,43 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `tools/lib/testdata/skill-lint/` — so the assertions never move when a real
   skill file is edited, and `testdata/` is excluded from the gate's own walk
   because those fixtures are deliberately corrupt.
+- POSIX shell scripts: `tools/posix-lint.sh` checks every tracked file whose
+  **first line** is a `#!/bin/sh` shebang — today `site/install.sh` and
+  `tools/linux-replay-entrypoint.sh`. Line 1 only, because
+  `tools/lib/install-uninstall_test.sh` is a bash file that writes `#!/bin/sh`
+  stubs inside a heredoc, and a content grep would try to lint it as POSIX sh.
+  It runs two different kinds of check on each file: a real POSIX shell's
+  parser (`dash -n`) and a static bashism linter (`checkbashisms`, else
+  `shellcheck --shell=sh` filtered to its POSIX-compatibility codes —
+  `SC3xxx`, plus `SC2039` and `SC2112`, so general style debt stays out of
+  scope). Both, because the parser alone is far weaker than it looks:
+  measured one bashism per file, `dash -n` catches **3 of 8** — it flags
+  arrays, process substitution and the `function` keyword, and accepts
+  `[[ ]]`, `${v,,}`, `+=`, `echo -e` and `source`. Either static linter
+  catches 8 of 8. That gap is #1423: `site/install.sh` reaches users as
+  `curl … | sh`, which on Debian and Ubuntu is dash, so a bashism lands on a
+  new user's first command before anything is installed that could report it.
+  The gate lives in **`linux.yml`**, not test.yml, and the placement is the
+  decision rather than an accident — ubuntu-latest is the only runner where
+  `/bin/sh` is genuinely dash *and* the image ships shellcheck (0.9.0); the
+  macos image ships none, and test.yml's `go-test` job is pinned to macOS for
+  the runtime paths in `go test ./core/...`. Mirrored locally by
+  `tools/preflight.sh --only posix`. **Three ways out are hard failures, not
+  skips** — no POSIX shell, no static linter, and an empty file set — because
+  a gate whose absence reads as a pass is the exact defect it was built to
+  remove. Its tests are `tools/lib/posix-lint_test.sh` over the corpus under
+  `tools/lib/testdata/posix-lint/`: one deliberately-broken fixture per
+  bashism class, committed rather than improvised so the mutation evidence
+  outlives the PR, plus a clean `good-clean.sh` as the vacuity guard and two
+  cases pinning the refusals. One of those cases exists because the first
+  draft of the linter reproduced #1423 inside itself — it piped into `grep`
+  and tested the capture for emptiness, so a linter that failed to run came
+  back empty, empty read as clean, and it printed `ALL PASS` over an installer
+  carrying a deliberate `[[ ]]`. `testdata/` is excluded from the gate's own
+  walk, the same split `skill-lint.sh` draws. Separately,
+  `install-uninstall_test.sh` now *executes* the installer under `dash` rather
+  than `sh` (macOS ships `/bin/dash`), which is the runtime half — it reaches
+  only the lines a case runs, where the linter reads every line.
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh` — gated in CI by linux.yml, and run
   natively as `tools/preflight.sh`'s `replay fixtures` gate, so golden drift

--- a/tools/lib/install-uninstall_test.sh
+++ b/tools/lib/install-uninstall_test.sh
@@ -32,6 +32,34 @@ REPO_ROOT="$(cd "$DIR/../.." && pwd)"
 INSTALL_SH="$REPO_ROOT/site/install.sh"
 NAME="install-uninstall_test"
 
+# The shell the installer is EXECUTED under, resolved once and shared by
+# run_uninstall and by check 9's parse test at the bottom.
+#
+# Not plain `sh` (#1423). Users get this script as `curl … | sh`, and on
+# Debian and Ubuntu that is dash — but on macOS, where these tests run in CI,
+# `/bin/sh` is bash 3.2 in POSIX mode, which accepts a great deal of bash that
+# dash rejects. Running the real thing under a real POSIX shell is the only
+# part of that gap a *runtime* test can close, and macOS does ship one:
+# /bin/dash is an Apple system binary (com.apple.dash), so this upgrade costs
+# nothing and needs no new runner.
+#
+# It closes only part of the gap, and deliberately so: a runtime check reaches
+# only the lines a case actually executes. The static half — every line of
+# every #!/bin/sh script, whether or not a test runs it — is tools/posix-lint.sh.
+#
+# Absolute path because run_uninstall runs under `env -i` with its own PATH.
+POSIX_SH=""
+for candidate in dash ash; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        POSIX_SH="$(command -v "$candidate")"
+        break
+    fi
+done
+# Fall back to `sh` rather than failing: a developer machine without dash
+# should still be able to run this suite. Check 9 reports which one ran, so a
+# weaker green never looks like a stronger one.
+INSTALL_RUNNER="${POSIX_SH:-sh}"
+
 fails=0
 
 pass() { printf 'PASS: %s\n' "$1"; }
@@ -173,7 +201,7 @@ run_uninstall() {
         PATH="$root/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
         IRRLICHT_TEST_APP_PATH="$root/app/Irrlicht.app" \
         "$@" \
-        sh "$INSTALL_SH" --uninstall 2>&1
+        "$INSTALL_RUNNER" "$INSTALL_SH" --uninstall 2>&1
 }
 
 # ===========================================================================
@@ -344,25 +372,30 @@ fi
 # 9. The installer must stay POSIX-sh clean — it ships to Linux users via
 #    `curl | sh`, where /bin/sh is typically dash.
 #
-#    NOTE ON REACH: on macOS /bin/sh is bash 3.2 in POSIX mode, which PARSES
-#    bashisms happily — and test.yml's shell-lib step runs on macos-latest. So
-#    `sh -n` alone catches hard syntax errors only. Prefer a real POSIX shell
-#    when the machine has one, and say which check actually ran rather than
-#    letting a weak green look like a strong one.
+#    NOTE ON REACH, and it is narrow (#1423). This is a PARSER check, and a
+#    parser accepts most bashisms as ordinary commands. Measured, one bashism
+#    per file, `dash -n` catches 3 of 8: it flags arrays, process substitution
+#    and the `function` keyword, and waves through `[[ ]]`, `${v,,}`, `+=`,
+#    `echo -e` and `source`. So this case is a floor, not the gate.
+#
+#    The real gate is tools/posix-lint.sh, which adds a static bashism linter
+#    (checkbashisms, or shellcheck filtered to its POSIX-compatibility codes)
+#    over every tracked #!/bin/sh script and catches 8 of 8. It runs in
+#    linux.yml, on the one runner where /bin/sh is genuinely dash. This case
+#    stays because it is free and it fails in a different way: it is the check
+#    that still works when no linter is installed.
 # ===========================================================================
-posix_sh=""
-for candidate in dash ash; do
-    if command -v "$candidate" >/dev/null 2>&1; then posix_sh="$candidate"; break; fi
-done
-if [[ -n "$posix_sh" ]]; then
-    if "$posix_sh" -n "$INSTALL_SH" 2>/dev/null; then
-        pass "syntax: site/install.sh parses under $posix_sh (real POSIX shell)"
+if [[ -n "$POSIX_SH" ]]; then
+    if "$POSIX_SH" -n "$INSTALL_SH" 2>/dev/null; then
+        pass "syntax: site/install.sh parses under $POSIX_SH (real POSIX shell; also ran it)"
     else
-        fail "syntax: site/install.sh parses under $posix_sh (real POSIX shell)"
+        fail "syntax: site/install.sh parses under $POSIX_SH (real POSIX shell)"
     fi
 else
+    # Say plainly that the cases above executed the installer under bash-as-sh,
+    # so a weak green never reads as a strong one.
     if sh -n "$INSTALL_SH" 2>/dev/null; then
-        pass "syntax: site/install.sh parses under /bin/sh (no dash here — syntax errors only)"
+        pass "syntax: site/install.sh parses under /bin/sh (NO dash here — syntax errors only, and the runtime cases used bash-as-sh)"
     else
         fail "syntax: site/install.sh parses under /bin/sh"
     fi

--- a/tools/lib/posix-lint_test.sh
+++ b/tools/lib/posix-lint_test.sh
@@ -111,21 +111,29 @@ rc=$?
 assert_eq "vacuity: good-clean.sh passes (exit 0)" "0" "$rc"
 assert_contains "vacuity: good-clean.sh reports ALL PASS" "ALL PASS" "$out"
 
+# 9a. The severity filter, in the only direction the bad-* fixtures cannot
+#     reach. They all trip an SC3xxx, so they exercise the MATCH arm; this one
+#     makes shellcheck exit 1 carrying ONLY SC2086, which the gate must
+#     discard. Without it, deleting the code test (accepting every shellcheck
+#     line) leaves the whole suite green while site/install.sh starts failing
+#     the gate on ordinary style debt.
+out=$("$LINT" "$FIXTURES/noisy-but-posix.sh" 2>&1)
+rc=$?
+assert_eq "filter: shellcheck-noisy but POSIX-clean still passes" "0" "$rc"
+
 # ===========================================================================
 # 9b. CI PARITY: the same corpus, through the shellcheck path specifically.
 #
-#     The two linters are not interchangeable in practice, because which one
-#     runs depends on the host: this repo's CI gate runs on ubuntu-latest,
-#     whose image ships shellcheck (0.9.0) and does NOT ship checkbashisms —
-#     so shellcheck is the branch that actually guards `main`, while a
-#     developer with `brew install checkbashisms` exercises the other one and
-#     never sees it. Asserting only the preferred branch would leave the CI
-#     branch untested by construction.
+#     The gate runs every linter that is installed, so on this machine the
+#     cases above may have been satisfied by checkbashisms. CI is not that
+#     machine: the ubuntu image ships shellcheck (0.9.0) and NOT
+#     checkbashisms, so shellcheck alone is what guards `main`. Pinning a
+#     shellcheck-only PATH is the only way that configuration is ever
+#     exercised from a developer box that has both.
 #
-#     This case also pins the bash-side severity filter: shellcheck reports
-#     general style debt (SC2086 and friends) that this gate deliberately
-#     ignores, so "shellcheck found something" is not the same as "found a
-#     bashism", and the filter is what makes those different.
+#     The two are genuinely not interchangeable — checkbashisms accepts
+#     `local`, `set -o pipefail` and `echo -n`, all of which shellcheck
+#     rejects — which is why the gate runs both rather than preferring one.
 # ===========================================================================
 if command -v shellcheck >/dev/null 2>&1; then
   sc_stub="$(mktemp -d)"
@@ -142,6 +150,10 @@ if command -v shellcheck >/dev/null 2>&1; then
   rc=$?
   assert_eq "shellcheck path: good-clean.sh still passes" "0" "$rc"
   assert_contains "shellcheck path: reports which linter ran" "bashisms=shellcheck" "$out"
+  # The filter, exercised through the branch that actually guards main.
+  out=$(PATH="$sc_stub" "$LINT" "$FIXTURES/noisy-but-posix.sh" 2>&1)
+  rc=$?
+  assert_eq "shellcheck path: SC2086-only noise is not a bashism" "0" "$rc"
   rm -rf "$sc_stub"
 else
   echo "  FAIL: shellcheck absent — the branch that guards CI cannot be tested here" >&2

--- a/tools/lib/posix-lint_test.sh
+++ b/tools/lib/posix-lint_test.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# posix-lint_test.sh — unit tests for tools/posix-lint.sh. Plain bash (no
+# framework), matching the style of lib/skill-lint_test.sh. Run directly, or
+# via tools/preflight.sh's `tools` gate and test.yml's "Test the shared shell
+# libs" step. Exits non-zero on any failed assertion.
+#
+# Covers issue #1423. `site/install.sh` is a POSIX sh script shipped to users
+# as `curl … | sh`, where on Debian/Ubuntu `sh` is dash. The only check it had
+# was `dash -n`, a PARSER check, which accepts most bashisms as ordinary
+# commands: 3 of the 8 classes below, measured. So the gate that existed
+# reported success without testing the property it exists to test.
+#
+# THE POINT OF THIS FILE is that the new gate can be shown RED. Per AGENTS.md's
+# rule for gates that pass by construction, the deliberate mutation is the
+# evidence — so rather than a one-off scratch mutation that disappears with the
+# PR, the mutation corpus is committed under testdata/posix-lint/ and asserted
+# here, one bashism class per fixture. If a future change weakens the linter,
+# these go red.
+#
+# `good-clean.sh` carries as much weight as the eight broken fixtures: it is
+# the vacuity guard. A linter that simply failed everything would satisfy all
+# eight `bad-*` assertions and be worthless, and only the clean fixture can
+# tell those two apart.
+#
+# The last two cases assert the gate's REFUSALS rather than its findings —
+# that a missing POSIX shell and a missing bashism linter each exit 2 instead
+# of passing. Those are the paths by which this gate could itself become the
+# thing it was built to remove: a green check that ran nothing.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+NAME="posix-lint_test"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+LINT="$ROOT/tools/posix-lint.sh"
+FIXTURES="$DIR/testdata/posix-lint"
+
+fails=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() {
+  echo "  FAIL: $1 — expected [$2] got [$3]"
+  fails=$((fails + 1))
+  return 0
+}
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  [[ "$expected" == "$actual" ]] && pass "$label" || fail "$label" "$expected" "$actual"
+  return 0
+}
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  [[ "$haystack" == *"$needle"* ]] && pass "$label" \
+    || fail "$label" "contains '$needle'" "${haystack:0:200}"
+  return 0
+}
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  [[ "$haystack" != *"$needle"* ]] && pass "$label" \
+    || fail "$label" "does NOT contain '$needle'" "${haystack:0:200}"
+  return 0
+}
+
+# ===========================================================================
+# 0. The gate needs its two tools. Without them every assertion below would be
+#    testing the refusal path instead of the detection path, and a suite that
+#    quietly stopped checking detection is this issue wearing a new mask. So
+#    say plainly which tools are in play, and let cases 9-10 (which REMOVE the
+#    tools on purpose) be the only ones that run toolless.
+# ===========================================================================
+echo "== $NAME =="
+have_posix_sh=0
+for c in dash ash; do command -v "$c" >/dev/null 2>&1 && have_posix_sh=1 && break; done
+have_linter=0
+for c in checkbashisms shellcheck; do command -v "$c" >/dev/null 2>&1 && have_linter=1 && break; done
+
+if [[ "$have_posix_sh" -ne 1 || "$have_linter" -ne 1 ]]; then
+  # Not a skip-to-green. This is reported as a failure of the ENVIRONMENT so
+  # it cannot be mistaken for the corpus passing. CI runs this on
+  # ubuntu-latest, which ships both dash (as /bin/sh) and shellcheck 0.9.0.
+  echo "  FAIL: environment — posix shell present=$have_posix_sh, bashism linter present=$have_linter" >&2
+  echo "        install: brew install dash checkbashisms  |  apt-get install -y dash shellcheck" >&2
+  echo "$NAME: 1 FAILED" >&2
+  exit 1
+fi
+
+# ===========================================================================
+# 1-8. Every bashism class must be CAUGHT. One fixture per class; the class is
+#      in the filename so a red run names the construct, not just a path.
+#
+#      These are the mutations. On the pre-#1423 gate (`dash -n` alone) five of
+#      the eight PASS — [[ ]], ${v,,}, +=, echo -e and source — which is the
+#      measurement that motivated the static linter.
+# ===========================================================================
+for fixture in "$FIXTURES"/bad-*.sh; do
+  base="$(basename "$fixture")"
+  out=$("$LINT" "$fixture" 2>&1)
+  rc=$?
+  assert_eq "detect: $base is rejected (exit 1)" "1" "$rc"
+  # Exit status alone is satisfied by the gate erroring for an unrelated
+  # reason (a missing tool exits 2, but a future refactor could exit 1). Pin
+  # the file's own name on a FAIL line so the rejection is about THIS file.
+  assert_contains "detect: $base is named in the failure" "$base" "$out"
+done
+
+# ===========================================================================
+# 9. The vacuity guard: clean POSIX sh must PASS. Without this, a linter that
+#    rejected every input would satisfy all eight assertions above.
+# ===========================================================================
+out=$("$LINT" "$FIXTURES/good-clean.sh" 2>&1)
+rc=$?
+assert_eq "vacuity: good-clean.sh passes (exit 0)" "0" "$rc"
+assert_contains "vacuity: good-clean.sh reports ALL PASS" "ALL PASS" "$out"
+
+# ===========================================================================
+# 9b. CI PARITY: the same corpus, through the shellcheck path specifically.
+#
+#     The two linters are not interchangeable in practice, because which one
+#     runs depends on the host: this repo's CI gate runs on ubuntu-latest,
+#     whose image ships shellcheck (0.9.0) and does NOT ship checkbashisms —
+#     so shellcheck is the branch that actually guards `main`, while a
+#     developer with `brew install checkbashisms` exercises the other one and
+#     never sees it. Asserting only the preferred branch would leave the CI
+#     branch untested by construction.
+#
+#     This case also pins the bash-side severity filter: shellcheck reports
+#     general style debt (SC2086 and friends) that this gate deliberately
+#     ignores, so "shellcheck found something" is not the same as "found a
+#     bashism", and the filter is what makes those different.
+# ===========================================================================
+if command -v shellcheck >/dev/null 2>&1; then
+  sc_stub="$(mktemp -d)"
+  for t in sh bash git awk sed basename dirname sort cat mktemp dash ash shellcheck; do
+    real="$(command -v "$t" 2>/dev/null)" && ln -sf "$real" "$sc_stub/$t"
+  done
+  for fixture in "$FIXTURES"/bad-*.sh; do
+    base="$(basename "$fixture")"
+    out=$(PATH="$sc_stub" "$LINT" "$fixture" 2>&1)
+    rc=$?
+    assert_eq "shellcheck path: $base is rejected (exit 1)" "1" "$rc"
+  done
+  out=$(PATH="$sc_stub" "$LINT" "$FIXTURES/good-clean.sh" 2>&1)
+  rc=$?
+  assert_eq "shellcheck path: good-clean.sh still passes" "0" "$rc"
+  assert_contains "shellcheck path: reports which linter ran" "bashisms=shellcheck" "$out"
+  rm -rf "$sc_stub"
+else
+  echo "  FAIL: shellcheck absent — the branch that guards CI cannot be tested here" >&2
+  fails=$((fails + 1))
+fi
+
+# ===========================================================================
+# 9c. A LINTER THAT CANNOT RUN MUST NOT READ AS CLEAN.
+#
+#     This is #1423 reproduced inside the gate built to fix it, and it is not
+#     hypothetical: the first draft piped the linter into `grep` and tested
+#     the captured string for emptiness, so when the filter failed to execute
+#     the capture came back empty, empty read as clean, and the gate printed
+#     `ALL PASS` over an installer carrying a deliberate `[[ ]]`.
+#
+#     The stub here is a linter that exits 2 (the "could not check" status)
+#     while printing nothing at all — the exact shape that a naive
+#     empty-output test waves through.
+# ===========================================================================
+broken="$(mktemp -d)"
+for t in sh bash git awk sed basename dirname sort cat mktemp dash ash; do
+  real="$(command -v "$t" 2>/dev/null)" && ln -sf "$real" "$broken/$t"
+done
+printf '#!/bin/sh\nexit 2\n' > "$broken/shellcheck"
+chmod +x "$broken/shellcheck"
+out=$(PATH="$broken" "$LINT" "$FIXTURES/good-clean.sh" 2>&1)
+rc=$?
+assert_eq "broken linter: silent exit-2 is a FAILURE, not a clean file" "1" "$rc"
+assert_contains "broken linter: says it could not check" "could not check" "$out"
+rm -rf "$broken"
+
+# ===========================================================================
+# 10. Discovery. The gate must find the real installer and must NOT walk its
+#     own deliberately-broken corpus — if it did, CI would be permanently red
+#     and the corpus would have to be deleted, taking the evidence with it.
+# ===========================================================================
+out=$("$LINT" 2>&1)
+rc=$?
+assert_eq "discovery: the repo's real #!/bin/sh scripts pass (exit 0)" "0" "$rc"
+assert_contains "discovery: site/install.sh is in scope" "site/install.sh" "$out"
+assert_not_contains "discovery: testdata fixtures are excluded" "testdata/posix-lint" "$out"
+
+# ===========================================================================
+# 11. Refusal: no POSIX shell. A PATH without dash/ash must exit 2, not 0.
+#     `sh` is deliberately still reachable — the wrong outcome here is the gate
+#     falling back to bash-as-sh and calling that a POSIX check, which is
+#     precisely the #1423 defect.
+# ===========================================================================
+stub="$(mktemp -d)"
+trap 'rm -rf "$stub"' EXIT
+for t in sh bash git grep awk sed basename dirname sort cat mktemp; do
+  real="$(command -v "$t" 2>/dev/null)" && ln -sf "$real" "$stub/$t"
+done
+# checkbashisms/shellcheck are linked in so this case isolates the SHELL.
+for t in checkbashisms shellcheck; do
+  real="$(command -v "$t" 2>/dev/null)" && ln -sf "$real" "$stub/$t"
+done
+out=$(PATH="$stub" "$LINT" "$FIXTURES/good-clean.sh" 2>&1)
+rc=$?
+assert_eq "refusal: no dash/ash exits 2 (not a silent pass)" "2" "$rc"
+assert_contains "refusal: says which shells it looked for" "dash" "$out"
+
+# ===========================================================================
+# 12. Refusal: no bashism linter. A PATH with a POSIX shell but no
+#     checkbashisms/shellcheck must exit 2. This is the one that matters most:
+#     `dash -n` alone SUCCEEDS on five of the eight fixtures, so a gate that
+#     degraded to parser-only here would go green while missing most bashisms.
+# ===========================================================================
+rm -f "$stub/checkbashisms" "$stub/shellcheck"
+for t in dash ash; do
+  real="$(command -v "$t" 2>/dev/null)" && ln -sf "$real" "$stub/$t"
+done
+out=$(PATH="$stub" "$LINT" "$FIXTURES/good-clean.sh" 2>&1)
+rc=$?
+assert_eq "refusal: no bashism linter exits 2 (not parser-only green)" "2" "$rc"
+assert_contains "refusal: names an installable linter" "checkbashisms" "$out"
+
+if [ "$fails" -eq 0 ]; then
+  echo "$NAME: ALL PASS"
+else
+  echo "$NAME: $fails FAILED" >&2
+  exit 1
+fi

--- a/tools/lib/posix-lint_test.sh
+++ b/tools/lib/posix-lint_test.sh
@@ -128,7 +128,7 @@ assert_eq "filter: shellcheck-noisy but POSIX-clean still passes" "0" "$rc"
 #     cases above may have been satisfied by checkbashisms. CI is not that
 #     machine: the ubuntu image ships shellcheck (0.9.0) and NOT
 #     checkbashisms, so shellcheck alone is what guards `main`. Pinning a
-#     shellcheck-only PATH is the only way that configuration is ever
+#     a shellcheck-only PATH is the only way that configuration is ever
 #     exercised from a developer box that has both.
 #
 #     The two are genuinely not interchangeable — checkbashisms accepts

--- a/tools/lib/testdata/posix-lint/README.md
+++ b/tools/lib/testdata/posix-lint/README.md
@@ -1,0 +1,12 @@
+# posix-lint fixture corpus
+
+Deliberately-broken `#!/bin/sh` scripts, one bashism class per file, plus a
+clean control. They exist so `tools/posix-lint.sh` can be shown *capable of
+failing* — a gate that passes by construction is exactly the defect #1423 was
+filed about.
+
+`tools/lib/posix-lint_test.sh` drives this directory. The gate itself excludes
+`*/testdata/*` from its own walk, so these files never fail CI — the same
+split `tools/skill-lint.sh` draws for its corpus under `testdata/skill-lint/`.
+
+Do not "fix" the bashisms in `bad-*.sh`. They are the assertions.

--- a/tools/lib/testdata/posix-lint/bad-array.sh
+++ b/tools/lib/testdata/posix-lint/bad-array.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# BASHISM: array assignment + subscript
+arr=(a b c)
+echo "${arr[0]}"

--- a/tools/lib/testdata/posix-lint/bad-case-conversion.sh
+++ b/tools/lib/testdata/posix-lint/bad-case-conversion.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# BASHISM: ${var,,} case conversion
+v=ABC
+echo "${v,,}"

--- a/tools/lib/testdata/posix-lint/bad-double-bracket.sh
+++ b/tools/lib/testdata/posix-lint/bad-double-bracket.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# BASHISM: [[ ]] test
+x=1
+if [[ "$x" == 1 ]]; then echo hi; fi

--- a/tools/lib/testdata/posix-lint/bad-echo-e.sh
+++ b/tools/lib/testdata/posix-lint/bad-echo-e.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# BASHISM: echo -e
+echo -e "a\tb"

--- a/tools/lib/testdata/posix-lint/bad-function-keyword.sh
+++ b/tools/lib/testdata/posix-lint/bad-function-keyword.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# BASHISM: function keyword
+function greet() { echo hi; }
+greet

--- a/tools/lib/testdata/posix-lint/bad-plus-equals.sh
+++ b/tools/lib/testdata/posix-lint/bad-plus-equals.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# BASHISM: += append
+s=a
+s+=b
+echo "$s"

--- a/tools/lib/testdata/posix-lint/bad-process-substitution.sh
+++ b/tools/lib/testdata/posix-lint/bad-process-substitution.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# BASHISM: process substitution
+while read -r l; do echo "$l"; done < <(ls)

--- a/tools/lib/testdata/posix-lint/bad-source.sh
+++ b/tools/lib/testdata/posix-lint/bad-source.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# BASHISM: source builtin
+source ./other.sh

--- a/tools/lib/testdata/posix-lint/good-clean.sh
+++ b/tools/lib/testdata/posix-lint/good-clean.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Clean POSIX sh. Must PASS — the vacuity guard for the bad-* fixtures: a
+# linter that failed everything would satisfy all of them and still be useless.
+set -eu
+
+greet() {
+    printf '%s\n' "hello $1"
+}
+
+s="a"
+s="${s}b"
+v="ABC"
+if [ "$s" = "ab" ]; then
+    greet "$v"
+fi
+
+for f in one two; do
+    printf '%s\n' "$f"
+done

--- a/tools/lib/testdata/posix-lint/noisy-but-posix.sh
+++ b/tools/lib/testdata/posix-lint/noisy-but-posix.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# POSIX-clean, but shellcheck-NOISY: the unquoted expansions below trip
+# SC2086 and friends, which are general style debt and deliberately OUT of
+# this gate's scope.
+#
+# This fixture is what pins the severity filter. Every bad-* fixture exercises
+# the MATCH direction (an SC3xxx is found and reported); without a file that
+# makes shellcheck exit 1 carrying only non-POSIX-class codes, the filter
+# itself is untested — deleting the code test and accepting every line would
+# leave the whole suite green, while site/install.sh would start failing this
+# gate on any SC2086.
+#
+# Must PASS.
+x=$1
+echo $x
+
+d=$2
+cd $d || exit 1

--- a/tools/posix-lint.sh
+++ b/tools/posix-lint.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# posix-lint.sh — prove every `#!/bin/sh` script in this repo is really POSIX sh.
+#
+# WHY THIS EXISTS (#1423). `site/install.sh` is what installs and uninstalls
+# irrlicht on users' machines, via `curl -fsSL https://irrlicht.io/install.sh | sh`.
+# On Debian and Ubuntu that `sh` is **dash**. A bashism in it fails on a new
+# user's first command, before anything is installed that could report it.
+#
+# The coverage that existed before this gate was `dash -n` (tools/lib/
+# install-uninstall_test.sh check 9). That is a *parser* check, and a parser
+# accepts most bashisms as ordinary commands — measured, one bashism per file:
+#
+#     bashism                     dash -n   checkbashisms   shellcheck --shell=sh
+#     [[ "$x" == 1 ]]             pass      CATCH           CATCH   (SC3010/SC3014)
+#     arr=(a b c)                 CATCH     CATCH           CATCH   (SC3030/SC3054)
+#     ${v,,}                      pass      CATCH           CATCH   (SC3059)
+#     s+=b                        pass      CATCH           CATCH   (SC3024)
+#     <(cmd)                      CATCH     CATCH           CATCH   (SC3001)
+#     echo -e                     pass      CATCH           CATCH   (SC3037)
+#     function greet() {}         CATCH     CATCH           CATCH   (SC2112)
+#     source ./other.sh           pass      CATCH           CATCH   (SC3046)
+#                                 ---------------------------------------------
+#                                 3 of 8    8 of 8          8 of 8
+#
+# So a parser check alone misses `[[ ]]`, `${v,,}`, `+=`, `echo -e` and
+# `source` — five of the most common bashisms, including the one the issue
+# named first. This gate therefore runs BOTH kinds of check on every file:
+#
+#   1. a real POSIX shell's parser (`dash -n`, or `ash -n`), and
+#   2. a static bashism linter that NAMES the violation
+#      (`checkbashisms` preferred; `shellcheck --shell=sh` otherwise).
+#
+# WHERE IT RUNS. `.github/workflows/linux.yml`'s `build-test` job, on
+# ubuntu-latest — the only runner where `/bin/sh` is genuinely dash and where
+# shellcheck is preinstalled (ubuntu-24.04 image ships shellcheck 0.9.0;
+# the macos-15 image ships none, which is why test.yml's macOS `go-test` job
+# is deliberately NOT the host for this). Mirrored locally by
+# `tools/preflight.sh --only posix`.
+#
+# NEVER SILENTLY PASSES. This gate exists because a green check that tested
+# nothing is worse than no check. Three ways out are therefore hard failures,
+# not skips: no POSIX shell available, no static linter available, and an
+# empty file set. Each exits 2 with a message saying what to install.
+#
+# Scope: every tracked file whose FIRST LINE is a POSIX-sh shebang
+# (`#!/bin/sh`, `#!/usr/bin/env sh`, with or without flags). Matching line 1
+# only is deliberate — `tools/lib/install-uninstall_test.sh` is a bash file
+# that writes `#!/bin/sh` stubs inside a heredoc, and a content grep would try
+# to lint it as POSIX sh. `testdata/` is excluded because that fixture corpus
+# is deliberately full of bashisms and is driven by the unit test, not by the
+# gate — the same split `tools/skill-lint.sh` draws for its own corpus.
+#
+# Usage:
+#   tools/posix-lint.sh              # lint every tracked #!/bin/sh script
+#   tools/posix-lint.sh FILE...      # lint just these files (used by tests)
+set -uo pipefail
+
+FILES=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    # Print the whole leading comment block, the same self-documenting idiom
+    # tools/skill-lint.sh and tools/preflight.sh use, so --help can't drift.
+    -h|--help) awk 'NR>1 && /^#/ {print; next} NR>1 {exit}' "$0"; exit 0 ;;
+    --) shift; FILES+=("$@"); break ;;
+    -*) echo "unknown arg: $1" >&2; exit 2 ;;
+    *) FILES+=("$1"); shift ;;
+  esac
+done
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# is_posix_shebang <file> — true when line 1 selects a POSIX sh interpreter.
+# Reads one line rather than slurping the file: some tracked "scripts" are
+# large, and only the first line can carry a shebang anyway.
+is_posix_shebang() {
+  local first
+  IFS= read -r first < "$1" 2>/dev/null || return 1
+  case "$first" in
+    '#!'*/sh|'#!'*/sh\ *|'#!'*env\ sh|'#!'*env\ sh\ *) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  cd "$ROOT_DIR" || exit 2
+  # `git ls-files`, not `find`: `find .` descends into `.claude/worktrees/`,
+  # which holds entire checkouts of this repo, and would lint every other
+  # branch's scripts as if they were this one's. Staged files are index
+  # entries, so a newly added script is covered on the push that adds it.
+  while IFS= read -r f; do
+    [[ "$f" == */testdata/* ]] && continue
+    [[ -f "$f" ]] || continue
+    is_posix_shebang "$f" && FILES+=("$f")
+  done < <(git ls-files | LC_ALL=C sort -u)
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  # Not a pass. An empty set means the discovery and the repo disagree about
+  # where POSIX scripts live — the same silent-green shape this gate is for.
+  echo "posix-lint: no #!/bin/sh scripts found — nothing was checked" >&2
+  exit 2
+fi
+
+# ─── Tool discovery ─────────────────────────────────────────────────────────
+# Both kinds are mandatory. A missing tool is a hard failure with an install
+# hint, never a skip: "the linter wasn't there" must not read as "the code is
+# clean". This is the exact failure mode #1423 is about.
+
+POSIX_SH=""
+for candidate in dash ash; do
+  if command -v "$candidate" >/dev/null 2>&1; then POSIX_SH="$candidate"; break; fi
+done
+if [[ -z "$POSIX_SH" ]]; then
+  echo "posix-lint: no real POSIX shell found (looked for: dash, ash)." >&2
+  echo "  Install one:  brew install dash   |   apt-get install -y dash" >&2
+  echo "  Refusing to pass a run that could only have used bash-as-sh." >&2
+  exit 2
+fi
+
+# checkbashisms is preferred over shellcheck because it reports bashisms and
+# nothing else, so the gate's scope is fixed by the tool rather than by a
+# filter this script would have to keep in sync. shellcheck is the fallback
+# because it is preinstalled on GitHub's ubuntu runners, which makes the CI
+# path free; there its output is filtered to the POSIX-compatibility codes so
+# the gate cannot drag in unrelated style debt from scripts nobody has linted
+# before. SC3xxx is the "In POSIX sh, X is undefined" family; SC2039 is the
+# pre-0.7.2 catch-all that older shellchecks emit instead; SC2112 is the
+# `function` keyword, which lives outside the SC3xxx range.
+BASHISM_LINTER=""
+if command -v checkbashisms >/dev/null 2>&1; then
+  BASHISM_LINTER="checkbashisms"
+elif command -v shellcheck >/dev/null 2>&1; then
+  BASHISM_LINTER="shellcheck"
+else
+  echo "posix-lint: no static bashism linter found (looked for: checkbashisms, shellcheck)." >&2
+  echo "  Install one:  brew install checkbashisms   |   apt-get install -y devscripts" >&2
+  echo "                brew install shellcheck      |   apt-get install -y shellcheck" >&2
+  echo "  A parser check alone misses [[ ]], \${v,,}, +=, echo -e and source" >&2
+  echo "  (3 of 8 in the matrix at the top of this file), so refusing to pass." >&2
+  exit 2
+fi
+
+POSIX_CODES='\[SC(3[0-9]{3}|2039|2112)\]'
+
+# lint_bashisms <file> — print findings to stdout, return 1 when any were
+# found (or when the linter could not be trusted to have looked).
+#
+# EVERY BRANCH DISTINGUISHES "clean" FROM "did not run". Writing this the
+# obvious way — `out=$(linter "$f" | grep -E "$CODES")` and then testing
+# `-z "$out"` — reproduces #1423 inside the gate built to fix it: if the
+# linter or the filter fails to execute, the capture is empty, empty reads as
+# clean, and the file is reported `ok`. That was not hypothetical; the first
+# draft of this script did exactly that and printed `ALL PASS` over an
+# installer carrying a deliberate `[[ ]]`. So the exit status of each tool is
+# checked explicitly, and the filtering is done in bash rather than by piping
+# into grep, which removes the second process that could fail unnoticed.
+lint_bashisms() {
+  local f="$1" raw rc line out=""
+
+  if [[ "$BASHISM_LINTER" == "checkbashisms" ]]; then
+    # -f forces the check regardless of what checkbashisms makes of the
+    # shebang. It changes nothing for a plain `#!/bin/sh` (verified: those are
+    # checked either way) — it is here so that THIS script's line-1 discovery
+    # is the single thing deciding the gate's scope, rather than two
+    # heuristics that can disagree about an unusual interpreter line.
+    raw=$(checkbashisms -f "$f" 2>&1); rc=$?
+    # 0 = clean, 1 = bashisms found. Anything else is checkbashisms failing.
+    if [[ "$rc" -gt 1 ]]; then
+      printf 'checkbashisms could not check this file (exit %s):\n%s\n' "$rc" "$raw"
+      return 1
+    fi
+    [[ "$rc" -eq 0 ]] && return 0
+    printf '%s\n' "$raw"
+    return 1
+  fi
+
+  raw=$(shellcheck --shell=sh --format=gcc "$f" 2>&1); rc=$?
+  # shellcheck: 0 = clean, 1 = findings. 2+ means it could not parse or run,
+  # which must never be reported as a clean file.
+  if [[ "$rc" -gt 1 ]]; then
+    printf 'shellcheck could not check this file (exit %s):\n%s\n' "$rc" "$raw"
+    return 1
+  fi
+  [[ "$rc" -eq 0 ]] && return 0
+  # Filter to the POSIX-compatibility findings in bash — no pipe, so there is
+  # no second process whose failure could look like "nothing matched".
+  while IFS= read -r line; do
+    [[ "$line" =~ $POSIX_CODES ]] && out+="$line"$'\n'
+  done <<< "$raw"
+  # rc was 1, so shellcheck DID find something; if none of it was a POSIX
+  # violation the file is clean for this gate's purposes (general style debt
+  # is deliberately out of scope — see the note on POSIX_CODES above).
+  [[ -z "$out" ]] && return 0
+  printf '%s' "$out"
+  return 1
+}
+
+# ─── Run ────────────────────────────────────────────────────────────────────
+
+echo "posix-lint: ${#FILES[@]} file(s); parser=$POSIX_SH, bashisms=$BASHISM_LINTER"
+
+rc=0
+for f in "${FILES[@]}"; do
+  file_rc=0
+
+  if ! parse_out=$("$POSIX_SH" -n "$f" 2>&1); then
+    echo "FAIL [$POSIX_SH -n] $f" >&2
+    printf '%s\n' "$parse_out" >&2
+    file_rc=1
+  fi
+
+  if ! bashism_out=$(lint_bashisms "$f"); then
+    echo "FAIL [$BASHISM_LINTER] $f" >&2
+    printf '%s\n' "$bashism_out" >&2
+    file_rc=1
+  fi
+
+  if [[ "$file_rc" -eq 0 ]]; then
+    echo "  ok  $f"
+  else
+    rc=1
+  fi
+done
+
+if [[ "$rc" -ne 0 ]]; then
+  echo >&2
+  echo "posix-lint: FAILED — the above are bashisms in a #!/bin/sh script." >&2
+  echo "  These ship to users running dash (Debian/Ubuntu /bin/sh)." >&2
+  exit 1
+fi
+
+echo "posix-lint: ALL PASS"

--- a/tools/posix-lint.sh
+++ b/tools/posix-lint.sh
@@ -28,7 +28,11 @@
 #
 #   1. a real POSIX shell's parser (`dash -n`, or `ash -n`), and
 #   2. a static bashism linter that NAMES the violation
-#      (`checkbashisms` preferred; `shellcheck --shell=sh` otherwise).
+#      — EVERY one that is installed, not the first one found, because the two
+#      do not agree: checkbashisms accepts `local`, `set -o pipefail` and
+#      `echo -n`, which shellcheck rejects (SC3043/SC3040/SC3037). CI has
+#      shellcheck only, so preferring the other one locally would let a
+#      developer's preflight pass a diff that CI rejects.
 #
 # WHERE IT RUNS. `.github/workflows/linux.yml`'s `build-test` job, on
 # ubuntu-latest — the only runner where `/bin/sh` is genuinely dash and where
@@ -87,11 +91,26 @@ if [[ ${#FILES[@]} -eq 0 ]]; then
   # which holds entire checkouts of this repo, and would lint every other
   # branch's scripts as if they were this one's. Staged files are index
   # entries, so a newly added script is covered on the push that adds it.
-  while IFS= read -r f; do
+  #
+  # `-z` with `core.quotePath=off`, not a plain line read: under the default
+  # `core.quotePath=true` git C-quotes any path with a non-ASCII byte, so
+  # `inställ.sh` is listed as `"inst\303\244ll.sh"` — a string that is not a
+  # real path. `[[ -f ]]` then rejects it and the file is dropped from the
+  # walk with no message, which is a bashism-carrying script reported as
+  # `ALL PASS`. The empty-set guard below cannot catch that, because it only
+  # fires when EVERY file is missed. NUL delimiting also survives newlines and
+  # spaces in paths (this repo tracks one with a space).
+  while IFS= read -r -d '' f; do
     [[ "$f" == */testdata/* ]] && continue
-    [[ -f "$f" ]] || continue
+    if [[ ! -f "$f" ]]; then
+      # Loud, not silent: a tracked path the walk cannot open is exactly the
+      # blind spot above, and the whole point of this gate is that "not
+      # looked at" must never render as "clean".
+      echo "posix-lint: skipping $f (tracked but not a regular file)" >&2
+      continue
+    fi
     is_posix_shebang "$f" && FILES+=("$f")
-  done < <(git ls-files | LC_ALL=C sort -u)
+  done < <(git -c core.quotePath=off ls-files -z | LC_ALL=C sort -z -u)
 fi
 
 if [[ ${#FILES[@]} -eq 0 ]]; then
@@ -117,21 +136,28 @@ if [[ -z "$POSIX_SH" ]]; then
   exit 2
 fi
 
-# checkbashisms is preferred over shellcheck because it reports bashisms and
-# nothing else, so the gate's scope is fixed by the tool rather than by a
-# filter this script would have to keep in sync. shellcheck is the fallback
-# because it is preinstalled on GitHub's ubuntu runners, which makes the CI
-# path free; there its output is filtered to the POSIX-compatibility codes so
-# the gate cannot drag in unrelated style debt from scripts nobody has linted
-# before. SC3xxx is the "In POSIX sh, X is undefined" family; SC2039 is the
-# pre-0.7.2 catch-all that older shellchecks emit instead; SC2112 is the
-# `function` keyword, which lives outside the SC3xxx range.
-BASHISM_LINTER=""
-if command -v checkbashisms >/dev/null 2>&1; then
-  BASHISM_LINTER="checkbashisms"
-elif command -v shellcheck >/dev/null 2>&1; then
-  BASHISM_LINTER="shellcheck"
-else
+# EVERY available linter runs, rather than the first one found.
+#
+# The tempting design — prefer one, fall back to the other — makes the gate's
+# strength depend on which machine it is running on, and the two tools do NOT
+# agree. checkbashisms accepts `local x=1`, `set -o pipefail` and `echo -n`,
+# all of which shellcheck rejects (SC3043 / SC3040 / SC3037) and all of which
+# an installer accretes. CI has shellcheck and not checkbashisms; a developer
+# who has installed checkbashisms would then have had the weaker checker
+# silently preferred, `tools/preflight.sh --only posix` would pass, and
+# linux.yml would go red on the push — the round-trip preflight exists to
+# prevent. Running both is monotone: the local result can be stricter than
+# CI's, never weaker.
+#
+# shellcheck's output is filtered to the POSIX-compatibility codes so the gate
+# cannot drag in unrelated style debt from scripts nobody has linted before.
+# SC3xxx is the "In POSIX sh, X is undefined" family; SC2039 is the pre-0.7.2
+# catch-all that older shellchecks emit instead; SC2112/SC2113 are the two
+# `function` keyword spellings, which live outside the SC3xxx range.
+BASHISM_LINTERS=()
+command -v shellcheck    >/dev/null 2>&1 && BASHISM_LINTERS+=("shellcheck")
+command -v checkbashisms >/dev/null 2>&1 && BASHISM_LINTERS+=("checkbashisms")
+if [[ ${#BASHISM_LINTERS[@]} -eq 0 ]]; then
   echo "posix-lint: no static bashism linter found (looked for: checkbashisms, shellcheck)." >&2
   echo "  Install one:  brew install checkbashisms   |   apt-get install -y devscripts" >&2
   echo "                brew install shellcheck      |   apt-get install -y shellcheck" >&2
@@ -140,7 +166,14 @@ else
   exit 2
 fi
 
-POSIX_CODES='\[SC(3[0-9]{3}|2039|2112)\]'
+POSIX_CODES='\[SC(3[0-9]{3}|2039|211[23])\]'
+# SC1xxx is shellcheck's parse/IO family. SC1072/SC1073/SC1088 make it ABANDON
+# analysis of the file, so it can exit 1 having emitted nothing but SC1xxx —
+# and a filter that keeps only POSIX codes would then see an empty result and
+# call the file clean. That is "the tool didn't look" wearing "the code is
+# fine", the shape this whole gate exists to remove, so it is treated as a
+# failure to check rather than filtered away.
+PARSE_ABORT_CODES='\[SC1[0-9]{3}\]'
 
 # lint_bashisms <file> — print findings to stdout, return 1 when any were
 # found (or when the linter could not be trusted to have looked).
@@ -155,9 +188,18 @@ POSIX_CODES='\[SC(3[0-9]{3}|2039|2112)\]'
 # checked explicitly, and the filtering is done in bash rather than by piping
 # into grep, which removes the second process that could fail unnoticed.
 lint_bashisms() {
-  local f="$1" raw rc line out=""
+  local f="$1" linter rc=0
+  for linter in "${BASHISM_LINTERS[@]}"; do
+    lint_with "$linter" "$f" || rc=1
+  done
+  return "$rc"
+}
 
-  if [[ "$BASHISM_LINTER" == "checkbashisms" ]]; then
+# lint_with <linter> <file> — one linter's verdict on one file.
+lint_with() {
+  local linter="$1" f="$2" raw rc line out=""
+
+  if [[ "$linter" == "checkbashisms" ]]; then
     # -f forces the check regardless of what checkbashisms makes of the
     # shebang. It changes nothing for a plain `#!/bin/sh` (verified: those are
     # checked either way) — it is here so that THIS script's line-1 discovery
@@ -182,6 +224,11 @@ lint_bashisms() {
     return 1
   fi
   [[ "$rc" -eq 0 ]] && return 0
+  # A parse abort must not be filtered into silence — see PARSE_ABORT_CODES.
+  if [[ "$raw" =~ $PARSE_ABORT_CODES ]]; then
+    printf 'shellcheck could not check this file (parse error; analysis abandoned):\n%s\n' "$raw"
+    return 1
+  fi
   # Filter to the POSIX-compatibility findings in bash — no pipe, so there is
   # no second process whose failure could look like "nothing matched".
   while IFS= read -r line; do
@@ -197,7 +244,19 @@ lint_bashisms() {
 
 # ─── Run ────────────────────────────────────────────────────────────────────
 
-echo "posix-lint: ${#FILES[@]} file(s); parser=$POSIX_SH, bashisms=$BASHISM_LINTER"
+# Name every checker that ran. Which ones are present varies by host — CI has
+# shellcheck only — so a run that cannot be read back to "what actually
+# looked at this" is a run whose green means nothing in particular.
+echo "posix-lint: ${#FILES[@]} file(s); parser=$POSIX_SH, bashisms=${BASHISM_LINTERS[*]}"
+if [[ " ${BASHISM_LINTERS[*]} " != *" shellcheck "* ]]; then
+  # Not a failure — checkbashisms alone is still far stronger than the parser
+  # check that preceded this gate. But it is weaker than CI's checker, and a
+  # local green that CI will contradict should say so at the time, not on the
+  # push.
+  echo "posix-lint: NOTE — shellcheck is absent, so this run is WEAKER than CI's." >&2
+  echo "  checkbashisms accepts 'local', 'set -o pipefail' and 'echo -n'; shellcheck rejects all three." >&2
+  echo "  Install it to match the gate that guards main:  brew install shellcheck" >&2
+fi
 
 rc=0
 for f in "${FILES[@]}"; do
@@ -210,7 +269,7 @@ for f in "${FILES[@]}"; do
   fi
 
   if ! bashism_out=$(lint_bashisms "$f"); then
-    echo "FAIL [$BASHISM_LINTER] $f" >&2
+    echo "FAIL [bashisms] $f" >&2
     printf '%s\n' "$bashism_out" >&2
     file_rc=1
   fi

--- a/tools/posix-lint.sh
+++ b/tools/posix-lint.sh
@@ -31,12 +31,12 @@
 #      — EVERY one that is installed, not the first one found, because the two
 #      do not agree: checkbashisms accepts `local`, `set -o pipefail` and
 #      `echo -n`, which shellcheck rejects (SC3043/SC3040/SC3037). CI has
-#      shellcheck only, so preferring the other one locally would let a
+#      only shellcheck, so preferring the other one locally would let a
 #      developer's preflight pass a diff that CI rejects.
 #
 # WHERE IT RUNS. `.github/workflows/linux.yml`'s `build-test` job, on
 # ubuntu-latest — the only runner where `/bin/sh` is genuinely dash and where
-# shellcheck is preinstalled (ubuntu-24.04 image ships shellcheck 0.9.0;
+# a preinstalled shellcheck (ubuntu-24.04 ships shellcheck 0.9.0;
 # the macos-15 image ships none, which is why test.yml's macOS `go-test` job
 # is deliberately NOT the host for this). Mirrored locally by
 # `tools/preflight.sh --only posix`.
@@ -149,7 +149,7 @@ fi
 # prevent. Running both is monotone: the local result can be stricter than
 # CI's, never weaker.
 #
-# shellcheck's output is filtered to the POSIX-compatibility codes so the gate
+# Output from shellcheck is filtered to the POSIX-compatibility codes so the gate
 # cannot drag in unrelated style debt from scripts nobody has linted before.
 # SC3xxx is the "In POSIX sh, X is undefined" family; SC2039 is the pre-0.7.2
 # catch-all that older shellchecks emit instead; SC2112/SC2113 are the two
@@ -217,7 +217,7 @@ lint_with() {
   fi
 
   raw=$(shellcheck --shell=sh --format=gcc "$f" 2>&1); rc=$?
-  # shellcheck: 0 = clean, 1 = findings. 2+ means it could not parse or run,
+  # Exit codes: 0 = clean, 1 = findings. 2+ means it could not parse or run,
   # which must never be reported as a clean file.
   if [[ "$rc" -gt 1 ]]; then
     printf 'shellcheck could not check this file (exit %s):\n%s\n' "$rc" "$raw"
@@ -245,7 +245,7 @@ lint_with() {
 # ─── Run ────────────────────────────────────────────────────────────────────
 
 # Name every checker that ran. Which ones are present varies by host — CI has
-# shellcheck only — so a run that cannot be read back to "what actually
+# only shellcheck — so a run that cannot be read back to "what actually
 # looked at this" is a run whose green means nothing in particular.
 echo "posix-lint: ${#FILES[@]} file(s); parser=$POSIX_SH, bashisms=${BASHISM_LINTERS[*]}"
 if [[ " ${BASHISM_LINTERS[*]} " != *" shellcheck "* ]]; then

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -336,8 +336,13 @@ fi
 # than skipping in that case — the script says what to `brew install`. A gate
 # whose absence looks like a pass is the defect #1423 was filed about, and
 # preflight is not the place to reintroduce it.
+#
+# The extensionless alternatives are not decoration: `tools/git-hooks/pre-push`
+# is already a tracked script with no suffix, and a `#!/bin/sh` file called
+# `site/install` would match nothing in a `\.sh$`-only trigger — skipping the
+# gate on precisely the push that introduces the script it exists to check.
 if want posix; then
-  run_gate_scoped '\.sh$|^tools/posix-lint\.sh$|^tools/lib/testdata/posix-lint/' \
+  run_gate_scoped '\.sh$|^(tools|site)/[^/]*$|^tools/git-hooks/|^tools/lib/testdata/posix-lint/' \
                   "POSIX sh lint (#!/bin/sh bashisms)" tools/posix-lint.sh
 fi
 

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -57,6 +57,7 @@
 #   tools/preflight.sh --only security # just govulncheck + gosec + npm audit
 #   tools/preflight.sh --only tools    # just the tools/lib shell-lib unit tests
 #   tools/preflight.sh --only skills   # just the .claude/skills/**/*.md linter
+#   tools/preflight.sh --only posix    # just the #!/bin/sh POSIX/bashism lint
 #   tools/preflight.sh --only linux    # just the Linux Docker gate
 #   tools/preflight.sh --changed       # scope every gate to the packages/trees
 #                                        this branch changes vs origin/main —
@@ -100,7 +101,7 @@ done
 # Not `GROUPS` — that is a bash built-in holding the caller's supplementary
 # group IDs, and assigning to it silently does nothing, so the check would
 # compare against a list of numeric gids and reject every real group name.
-VALID_GROUPS=(go web arch tools skills security linux)
+VALID_GROUPS=(go web arch tools skills posix security linux)
 if [[ -n "$ONLY" ]]; then
   known=0
   for g in "${VALID_GROUPS[@]}"; do [[ "$ONLY" == "$g" ]] && known=1; done
@@ -318,6 +319,26 @@ fi
 if want skills; then
   run_gate_scoped '^\.claude/skills/.*\.md$|(^|/)SKILL\.md$|^tools/skill-lint\.sh$' \
                   "skill-file lint" tools/skill-lint.sh
+fi
+
+# ---- posix group (mirrors linux.yml's "Lint POSIX sh scripts" step) --------
+# The #!/bin/sh corpus is two files today (site/install.sh and
+# tools/linux-replay-entrypoint.sh) and the gate re-lints all of them whenever
+# it fires — it is a fraction of a second, and the trigger cannot enumerate
+# them anyway, because a NEW POSIX script is exactly the file the gate most
+# needs to see on the push that adds it. So the regex is deliberately loose:
+# any *.sh, any extensionless file under tools/ or site/, plus the linter and
+# its own corpus. Over-firing costs milliseconds; under-firing is #1209's
+# silent-skip shape again.
+#
+# Unlike the CI step this gate can legitimately be unrunnable on a developer
+# machine that has neither checkbashisms nor shellcheck. It still FAILS rather
+# than skipping in that case — the script says what to `brew install`. A gate
+# whose absence looks like a pass is the defect #1423 was filed about, and
+# preflight is not the place to reintroduce it.
+if want posix; then
+  run_gate_scoped '\.sh$|^tools/posix-lint\.sh$|^tools/lib/testdata/posix-lint/' \
+                  "POSIX sh lint (#!/bin/sh bashisms)" tools/posix-lint.sh
 fi
 
 # ---- security group (mirrors tools/security-scan.sh's local mode; the same


### PR DESCRIPTION
Closes #1423

## The defect

`site/install.sh` reaches users as `curl -fsSL https://irrlicht.io/install.sh | sh`. On Debian and Ubuntu that `sh` is **dash**. A bashism there lands on a new user's first command, before anything is installed that could report it. #1416 (PR #1421) widened the surface — the uninstall path now invokes the daemon binary, redirects stdin and applies a bounded wait.

The issue's framing was that no runner can catch such a violation. That turned out to be **half right, and the other half is worse**. `tools/lib/install-uninstall_test.sh` check 9 (added by #1416) already prefers a real POSIX shell, and macOS ships one — `/bin/dash` is an Apple system binary (`com.apple.dash`) — so `dash -n` *was* running on `macos-latest`. The real gap is that `dash -n` is a **parser** check, and a parser accepts most bashisms as ordinary commands.

Measured, one bashism per file:

| bashism | `dash -n` | `checkbashisms` | `shellcheck --shell=sh` |
|---|---|---|---|
| `[[ "$x" == 1 ]]` | **pass** | CATCH | CATCH (SC3010/SC3014) |
| `arr=(a b c)` | CATCH | CATCH | CATCH (SC3030/SC3054) |
| `${v,,}` | **pass** | CATCH | CATCH (SC3059) |
| `s+=b` | **pass** | CATCH | CATCH (SC3024) |
| `<(cmd)` | CATCH | CATCH | CATCH (SC3001) |
| `echo -e` | **pass** | CATCH | CATCH (SC3037) |
| `function greet() {}` | CATCH | CATCH | CATCH (SC2112) |
| `source ./other.sh` | **pass** | CATCH | CATCH (SC3046) |
| | **3 of 8** | **8 of 8** | **8 of 8** |

So the gate missed five of the most common bashisms, including the one the issue named first.

## What the gate finds today: nothing

Run over both tracked `#!/bin/sh` scripts — `site/install.sh` and `tools/linux-replay-entrypoint.sh` — `checkbashisms`, `shellcheck --shell=sh` and `dash -n` all come back **clean**. Reported as the issue asked: the gate was **redundant, not hiding breakage**. No pre-existing user-facing bugs to split out.

## Route taken: both, neither by moving the job

- **Static** (`tools/posix-lint.sh`): every tracked file whose **first line** is a `#!/bin/sh` shebang gets a real POSIX parser *and* a static bashism linter. Line 1 only — `install-uninstall_test.sh` is a bash file that writes `#!/bin/sh` stubs inside a heredoc, and a content grep would lint it as POSIX sh.
- **Runtime**: `install-uninstall_test.sh` now *executes* the installer under `dash` instead of `sh`. That is the issue's "dash proves the script runs", obtained without a new runner.

**Placement — the decision, not an accident.** The gate is hosted in `linux.yml`'s `build-test`, not `test.yml`. Checked first, as the issue instructed: `test.yml`'s `go-test` is a single job pinned to `macos-latest` for the macOS runtime paths in `go test ./core/...` (kqueue exit-watch, pgrep/lsof discovery), so the whole job cannot move — and the `macos-15` image ships **no shellcheck**, so hosting it there means `brew install`ing a linter on every PR to check two files. `ubuntu-latest` is the only runner where `/bin/sh` is genuinely dash **and** the image ships shellcheck (`Ubuntu2404-Readme.md` lists 0.9.0). The step is split out rather than the job moved.

`checkbashisms` is preferred when present (it reports bashisms and nothing else, so the tool fixes the scope); `shellcheck` is the fallback because it is free on the CI runner, filtered to `SC3xxx`/`SC2039`/`SC2112` so the gate cannot drag in unrelated style debt from scripts nobody has linted before.

## The gate is shown capable of failing

Deliberate `[[ ]]` injected into the real `site/install.sh`:

```
=== OLD gate (dash -n) on the mutated installer ===
>>> dash -n: PASS — the pre-#1423 gate does NOT catch it <<<

=== NEW gate on the mutated installer ===
posix-lint: 2 file(s); parser=dash, bashisms=checkbashisms
FAIL [checkbashisms] site/install.sh
possible bashism in site/install.sh line 299 (alternative test command ([[ foo ]] should be [ foo ])):
if [[ -z "${VERSION}" ]]; then :; fi
  ok  tools/linux-replay-entrypoint.sh

posix-lint: FAILED — the above are bashisms in a #!/bin/sh script.
  These ship to users running dash (Debian/Ubuntu /bin/sh).
>>> new gate exit: 1 <<<
```

The mutation was then reverted (`git diff --stat site/install.sh` empty). Rather than leave that as a one-off, the corpus is **committed** under `tools/lib/testdata/posix-lint/` — one deliberately-broken fixture per bashism class, driven by `tools/lib/posix-lint_test.sh`, so the evidence outlives this PR. `good-clean.sh` is the vacuity guard: without a clean fixture that must pass, a linter that rejected everything would satisfy all eight.

## A real defect this found — in the gate itself

The first draft of `lint_bashisms` reproduced #1423 **inside the gate built to fix it**: it piped the linter into `grep` and tested the captured string for emptiness, so when the filter failed to execute the capture came back empty, empty read as clean, and it printed `ALL PASS` over the installer *while the deliberate `[[ ]]` was still in it*. Every branch now checks the tool's own exit status and filters in bash rather than through a second process. Test case 9c pins it, seen red against the naive version:

```
FAIL: broken linter: silent exit-2 is a FAILURE, not a clean file — expected [1] got [0]
FAIL: broken linter: says it could not check — expected [contains 'could not check'] ...
posix-lint_test: 7 FAILED
```

More generally: **no POSIX shell, no static linter, and an empty file set are hard failures, never skips.** A gate whose absence reads as a pass is the defect being fixed.

## Red-first / locks

- **Seen red:** case 9c above (naive pipeline → `expected [1] got [0]`), and all eight `bad-*` fixtures, which the pre-#1423 gate passes on five of.
- **Locks** (pass by construction, pinning behaviour that must not change): `good-clean.sh` vacuity, the discovery cases, and the existing `install-uninstall_test.sh` suite, which stays green now that the installer executes under `dash`.

## Verification

`tools/preflight.sh` chunked in the foreground — `go`, `web`, `arch`, `tools`, `skills`, `security`, `posix`: **all PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)