### PR TITLE
test(state): pin the compact hold's ceiling against the ticker gap (#1387)

### DIFF
--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1716,15 +1716,16 @@ func (d *SessionDetector) refreshStaleSessions() {
 //
 //   - A HELD SIGNAL (#1360). A ceiling is only evaluated inside
 //     SignalHolds.Overlay, Overlay is only reached from the classify pipeline,
-//     and both hook holds that declare a ceiling pin the session at *waiting*
+//     and both of the hook holds #1360 bounds pin the session at *waiting*
 //     — the state this loop used to skip. Without this the pinned session was
 //     precisely the one never revisited, so a lost release stayed lost for the
 //     life of the process. (That asymmetry is also why compactHoldTimeout
 //     appeared to prove the mechanism worked: it pins at working, the state
 //     already being re-read. #1387 records that older defect and is pinned by
 //     TestSessionDetector_StaleRefreshExpiresAnOrphanedCompactHoldOnAnIdleSession,
-//     since a compact hold does reach a non-working session whenever
-//     HandleCompactHook's working-flip dispatch is dropped.)
+//     since a compact hold does reach a non-working session when
+//     HandleCompactHook's working-flip dispatch is dropped while the session is
+//     not already working.)
 //   - A DWELL OUTSTANDING (#1366). The same argument one turn deeper: a grace
 //     timer is a *delay* only if a later pass arrives to end it, and on a
 //     session nothing else revisits it silently becomes a drop. The case that

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1721,7 +1721,10 @@ func (d *SessionDetector) refreshStaleSessions() {
 //     precisely the one never revisited, so a lost release stayed lost for the
 //     life of the process. (That asymmetry is also why compactHoldTimeout
 //     appeared to prove the mechanism worked: it pins at working, the state
-//     already being re-read.)
+//     already being re-read. #1387 records that older defect and is pinned by
+//     TestSessionDetector_StaleRefreshExpiresAnOrphanedCompactHoldOnAnIdleSession,
+//     since a compact hold does reach a non-working session whenever
+//     HandleCompactHook's working-flip dispatch is dropped.)
 //   - A DWELL OUTSTANDING (#1366). The same argument one turn deeper: a grace
 //     timer is a *delay* only if a later pass arrives to end it, and on a
 //     session nothing else revisits it silently becomes a drop. The case that

--- a/core/application/services/session_detector_hold_ceiling_test.go
+++ b/core/application/services/session_detector_hold_ceiling_test.go
@@ -56,8 +56,13 @@ func newHeldWaitingSession(t *testing.T, repo *mockRepo, sessionID string) {
 //
 // The observable asserted here is the recorded hold_expired event rather than
 // the session's new state, and deliberately: this harness's metrics collector
-// is a mock that leaves state.Metrics nil, so the classifier has nothing to
-// re-decide from and any state assertion would be measuring the mock. The
+// returns nothing (mockMetrics.ComputeMetrics gives (nil, nil), and
+// RefreshOnActivity skips a nil result), so state.Metrics stays frozen at the
+// value newHeldWaitingSession seeded and a state assertion would be re-reading
+// that fixture rather than anything the classifier decided. (This sentence
+// used to say the mock leaves state.Metrics *nil*, corrected in #1387: that
+// was self-refuting, since Overlay returns early on nil metrics and the test
+// could never have passed.) The
 // recorded event is the sharper claim anyway — it can only be emitted by a
 // real Overlay call inside a real classify pass, which is precisely the thing
 // that was not happening. The user-visible "no longer pinned at waiting" half
@@ -105,6 +110,15 @@ func TestSessionDetector_StaleRefreshExpiresAHookHoldOnAWaitingSession(t *testin
 // TestSessionDetector_StaleRefreshExpiresAnOrphanedCompactHoldOnAnIdleSession
 // is #1387, and it pins the one row the test above does not reach.
 //
+// A LOCK on current main, not a defect test: #1376 had already closed the gap
+// by the time it was written, so it passes by construction here. It was seen
+// red only under a deliberate mutation — pre-#1376's idle arm restored verbatim
+// — and independently under a sharper one, deleting `ceiling: compactHoldTimeout`
+// from the policy row, where it is the only test in the repo that fails. Both
+// are recorded in PR #1434. Saying which category it belongs to matters because
+// the name reads like a defect test, and the next reader applying the red-first
+// rule would otherwise go looking for a fix this PR does not contain.
+//
 // compactHoldTimeout has bounded SignalCompactInProgress since #657 and was,
 // until #1360, the only ceiling in the table — so it reads as the proof that
 // the mechanism worked. It was not. A ceiling is only evaluated inside
@@ -130,12 +144,25 @@ func TestSessionDetector_StaleRefreshExpiresAHookHoldOnAWaitingSession(t *testin
 // ceiling could not be evaluated from. Absorbing a dropped dispatch is what
 // refreshStaleSessions is for; see its doc comment.
 //
+// Scope the pre-#1376 harm honestly, because overstating it invites a fix for
+// a symptom nobody had: this row's orphaned hold was *inert*, not visibly
+// stuck. Overlay evaluates stale and then the ceiling BEFORE apply, so a hold
+// on a non-working session pins nothing until some pass arrives, and the first
+// one that does expires it rather than applying it. That is unlike #1360's
+// permission_prompt row, which held a session visibly at waiting for the life
+// of the process. What was unbounded here was the map entry and the ticker's
+// blindness to it — which is precisely why the defect stayed invisible, and
+// why it is worth a lock now rather than a fix.
+//
 // Observable and clock follow the sibling above: the recorded hold_expired
-// event, because this harness's mock metrics collector leaves state.Metrics
-// nil so any state assertion would be measuring the mock; and a hold backdated
-// far past any defensible ceiling rather than just past the current five
-// minutes, so retuning compactHoldTimeout cannot break a test that is about
-// the ticker reaching the session at all.
+// event, because this harness's metrics collector returns nothing
+// (mockMetrics.ComputeMetrics gives (nil, nil), and RefreshOnActivity skips a
+// nil result), so state.Metrics stays frozen at the value the fixture seeded
+// and a state assertion would be re-reading that fixture rather than anything
+// the classifier decided; and a hold backdated far past any defensible ceiling
+// rather than just past the current five minutes, so retuning
+// compactHoldTimeout cannot break a test that is about the ticker reaching the
+// session at all.
 func TestSessionDetector_StaleRefreshExpiresAnOrphanedCompactHoldOnAnIdleSession(t *testing.T) {
 	tw := newMockAgentWatcher()
 	pw := newMockProcessWatcher()
@@ -163,7 +190,9 @@ func TestSessionDetector_StaleRefreshExpiresAnOrphanedCompactHoldOnAnIdleSession
 	}
 	if expired == nil {
 		t.Fatalf("no %q event — the ticker never ran a classify pass for the idle session holding "+
-			"compact_in_progress, so compactHoldTimeout could not fire and the orphaned hold is unbounded",
+			"compact_in_progress, so compactHoldTimeout could not fire and the orphaned hold is "+
+			"unbounded in the ticker (inert until some other pass arrives, unlike #1360's row, "+
+			"which pinned the badge)",
 			lifecycle.KindHoldExpired)
 	}
 	if expired.SessionID != "compact1" {

--- a/core/application/services/session_detector_hold_ceiling_test.go
+++ b/core/application/services/session_detector_hold_ceiling_test.go
@@ -102,6 +102,78 @@ func TestSessionDetector_StaleRefreshExpiresAHookHoldOnAWaitingSession(t *testin
 	}
 }
 
+// TestSessionDetector_StaleRefreshExpiresAnOrphanedCompactHoldOnAnIdleSession
+// is #1387, and it pins the one row the test above does not reach.
+//
+// compactHoldTimeout has bounded SignalCompactInProgress since #657 and was,
+// until #1360, the only ceiling in the table — so it reads as the proof that
+// the mechanism worked. It was not. A ceiling is only evaluated inside
+// SignalHolds.Overlay, Overlay is only reached from the classify pipeline, and
+// before #1376 refreshStaleSessions ran that pipeline for StateWorking alone.
+// The compact ceiling fired only because the hold it bounds pins the session at
+// *working* — an accident of which state this one row happens to apply, not a
+// property of the mechanism. #1376 closed the scheduling gap for every row at
+// once (shouldRevisitIdleSession), incidentally, while fixing something else;
+// this test is what stops it reopening for compact specifically.
+//
+// The premise — a live compact hold on a session that is NOT working — is not
+// hypothetical, and that is the whole reason this test is worth its lines.
+// HandleCompactHook plants the hold and then calls dispatchHookActivity to flip
+// the session to working out of band, because the compaction window writes
+// nothing to the transcript. That dispatch is a non-blocking send with a
+// default branch: when debouncedEvents is full it logs "PreCompact hook event
+// dropped" and returns. The hold is placed, the reclassify that would have
+// moved the session to working is lost, and the session sits at waiting or
+// ready holding it. If the /compact is then interrupted no compact_boundary
+// ever lands, so the hold's stale predicate never fires either — the exact
+// orphaned-hold case compactHoldTimeout exists for, in the exact state its
+// ceiling could not be evaluated from. Absorbing a dropped dispatch is what
+// refreshStaleSessions is for; see its doc comment.
+//
+// Observable and clock follow the sibling above: the recorded hold_expired
+// event, because this harness's mock metrics collector leaves state.Metrics
+// nil so any state assertion would be measuring the mock; and a hold backdated
+// far past any defensible ceiling rather than just past the current five
+// minutes, so retuning compactHoldTimeout cannot break a test that is about
+// the ticker reaching the session at all.
+func TestSessionDetector_StaleRefreshExpiresAnOrphanedCompactHoldOnAnIdleSession(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+	det := newDetector(tw, pw, repo)
+
+	rec := &mockRecorder{}
+	det.SetRecorder(rec)
+
+	newHeldWaitingSession(t, repo, "compact1")
+
+	// The PreCompact hook landed three days ago and its working-flip dispatch
+	// was dropped; the compact was then interrupted, so no compact_boundary
+	// ever came to clear the hold the normal way.
+	det.HoldSignalForTest("compact1", session.SignalCompactInProgress, time.Now().Add(-72*time.Hour))
+
+	det.RunStaleSessionRefreshForTest()
+
+	var expired *lifecycle.Event
+	for _, ev := range rec.snapshot() {
+		if ev.Kind == lifecycle.KindHoldExpired {
+			e := ev
+			expired = &e
+		}
+	}
+	if expired == nil {
+		t.Fatalf("no %q event — the ticker never ran a classify pass for the idle session holding "+
+			"compact_in_progress, so compactHoldTimeout could not fire and the orphaned hold is unbounded",
+			lifecycle.KindHoldExpired)
+	}
+	if expired.SessionID != "compact1" {
+		t.Errorf("expiry attributed to %q, want %q", expired.SessionID, "compact1")
+	}
+	if expired.SignalKind != string(session.SignalCompactInProgress) {
+		t.Errorf("SignalKind = %q, want %q", expired.SignalKind, session.SignalCompactInProgress)
+	}
+}
+
 // TestSessionDetector_StaleRefreshLeavesAnUnheldIdleSessionAlone is the
 // counterweight, and a LOCK on behaviour that predates #1360.
 //


### PR DESCRIPTION
Closes #1387.

## Verdict: (a) — the defect was real, is already fixed on `main`, and needed a test, not a change

#1387 was filed by the #1360 agent and describes a real defect: a ceiling is only
evaluated inside `SignalHolds.Overlay`, `Overlay` is only reached from the classify
pipeline, and `refreshStaleSessions` — the only thing that revisits a session no
transcript event is arriving for — ran that pipeline for `StateWorking` alone.

**Verified against the tree, not taken from the issue text.** At `3abc9ceb^` (pre-#1376)
`refreshStaleSessions`' idle arm is exactly `d.retryIdleProjectResolution(state, now)`
and nothing else. On current `main` it is followed by the `shouldRevisitIdleSession`
branch #1376 added, which selects on `SignalHolds.HasAny` (#1360) or `dwell.Pending`
(#1404). So the scheduling gap is closed, for every policy row at once, as an
incidental effect of a PR about something else.

This PR therefore adds **no production behaviour**. The only non-test edit is a comment
cross-reference. That is the deliverable #1387 itself scopes: *"worth keeping open only
long enough to decide whether it deserves its own regression test naming
`compact_in_progress` specifically"*. It does — see below.

## Why a compact-specific test, when #1376 already has one

#1376's `TestSessionDetector_StaleRefreshExpiresAHookHoldOnAWaitingSession` covers the
mechanism via `permission_prompt`. Both it and every other application-layer ceiling
test use that row; nothing anywhere drove a `compact_in_progress` ceiling through the
detector, and no test asserted `KindHoldExpired` for it.

`compact_in_progress` is the row most likely to regress unnoticed, because it is the one
that *looks* covered: `compactHoldTimeout` has bounded it since #657 and was the only
ceiling in the table until #1360, so it reads as proof the mechanism worked. It was not —
it fired only because the hold it bounds pins the session at `working`, the one state the
old ticker already re-read. That is an accident of which state this row applies, not a
property of the mechanism.

## The premise is reachable in production, not hypothetical

A live compact hold on a non-`working` session is a real state, and this is the evidence
that the test is not fiction:

`HandleCompactHook` (`session_detector_lifecycle.go:383`) plants the hold and then calls
`dispatchHookActivity` to flip the session to `working` out of band, because the
compaction window writes nothing to the transcript. That dispatch is a **non-blocking
send with a `default:` branch** (`session_detector_lifecycle.go:310-320`) which logs
`"debouncedEvents channel full, PreCompact hook event dropped"` and returns. The hold is
placed; the reclassify that would have moved the session to `working` is lost; the
session sits at `waiting`/`ready` holding it. If the `/compact` is then interrupted, no
`compact_boundary` ever lands, so the row's `stale` predicate never fires either — the
exact orphaned-hold case `compactHoldTimeout` exists for, in the exact state its ceiling
could not be evaluated from. Absorbing a dropped dispatch is what `refreshStaleSessions`
is for; its own doc comment says so.

## Red-first evidence

The test **cannot be compiled against the literal pre-#1376 tree**: its observable,
`lifecycle.KindHoldExpired`, was introduced by #1360/#1376 and is absent at `3abc9ceb^`
(`git grep KindHoldExpired 3abc9ceb^ -- core/domain/lifecycle/` → no match). The faithful
substitute is the deliberate mutation: pre-#1376's idle arm restored verbatim onto
current `main` (drop the `shouldRevisitIdleSession` branch).

Under that mutation:

```
=== RUN   TestSessionDetector_StaleRefreshExpiresAHookHoldOnAWaitingSession
    session_detector_hold_ceiling_test.go:94: no "hold_expired" event — the ticker never ran a classify pass for the held waiting session, so its ceiling could not fire
--- FAIL: TestSessionDetector_StaleRefreshExpiresAHookHoldOnAWaitingSession (0.00s)
=== RUN   TestSessionDetector_StaleRefreshExpiresAnOrphanedCompactHoldOnAnIdleSession
    session_detector_hold_ceiling_test.go:165: no "hold_expired" event — the ticker never ran a classify pass for the idle session holding compact_in_progress, so compactHoldTimeout could not fire and the orphaned hold is unbounded
--- FAIL: TestSessionDetector_StaleRefreshExpiresAnOrphanedCompactHoldOnAnIdleSession (0.00s)
=== RUN   TestSessionDetector_StaleRefreshLeavesAnUnheldIdleSessionAlone
--- PASS: TestSessionDetector_StaleRefreshLeavesAnUnheldIdleSessionAlone (0.00s)
FAIL
```

The new test goes red with its crafted message, alongside #1376's own sibling — which is
the cross-check that the mutation restored the right thing. The mutation was then
reverted; the production diff here is comment-only.

Unmutated, on this branch: `--- PASS` (0.00s).

**Locks** (pass by construction, not red-first proof):
`TestSessionDetector_StaleRefreshLeavesAnUnheldIdleSessionAlone` stays green under the
mutation, as it must — it pins the *scoping* of the idle revisit, which the mutation
removes rather than widens.

## Is `SignalCompactInProgress` inside the structural ceiling test?

**Yes — inside it, verified by running it, not assumed.**
`TestSignalPolicies_HookPersistentHoldsDeclareACeiling` skips a row iff
`p.tier != TierHook || p.consumeOnce`. The compact row is `TierHook` and does not set
`consumeOnce`, so neither disjunct fires:

```
--- PASS: TestSignalPolicies_HookPersistentHoldsDeclareACeiling/permission_prompt
--- PASS: TestSignalPolicies_HookPersistentHoldsDeclareACeiling/idle_prompt
--- PASS: TestSignalPolicies_HookPersistentHoldsDeclareACeiling/compact_in_progress
```

Worth stating because its ceiling *predates* the `ceiling` field — it was a clock term
inside `stale` until #1360 split it out — so being covered was not a given. The gap was
never the domain-level invariant; it was that nothing proved the ceiling was **reachable
through the ticker** for this row. That is what this PR adds.

## Files changed

| File | Why |
|---|---|
| `core/application/services/session_detector_hold_ceiling_test.go` | +1 test: `TestSessionDetector_StaleRefreshExpiresAnOrphanedCompactHoldOnAnIdleSession`. Sibling of #1376's `permission_prompt` case, same harness, same observable and clock rationale. |
| `core/application/services/session_detector_activity.go` | **Comment only.** `shouldRevisitIdleSession`'s parenthetical about compact's asymmetry now names #1387 and the test that pins it, so the ticket is findable from the code. |

## Verification

Full core suite `go test ./core/... -race -count=1`: exit 0, 55 packages ok, no FAIL.

`tools/preflight.sh` run chunked in the foreground — every chunk PASS:

| Chunk | Result |
|---|---|
| `--only go` | gofmt, core module tests, onboarding-factory tests, replaydata validate, recording-rig smoke, **replay fixtures**, starhistory — all PASS |
| `--only arch` | ARS gate PASS (composite 7.950658 → 7.950525, not regressed) |
| `--only tools` | PASS |
| `--only skills` | PASS (23 files, 0 errors, 0 warnings) |
| `--only security` | PASS (govulncheck + gosec + npm audit) |
| `--only posix` | PASS |
| `--only web` | PASS (both suites) |

**No replay golden moved**, and none should have: the diff adds a test and a comment,
touching no parser, tailer, recording or replay output. The `replay fixtures` gate above
is the evidence rather than an assumption.

Deletion tripwire against **live** `origin/main`:
`git diff --diff-filter=D --name-only origin/main...HEAD` → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review (Phase 5, `medium` effort, one subagent)

Tier split, stated because the columns differ: **review = Medium** (the deliverable is a
correctness argument about a scheduling invariant — a wrong verdict is the real risk),
**simplify = Trivial** (comments and tests only; a fan-out returns nothing on this
material, so an inline reuse/simplification/altitude glance was done instead).

The reviewer independently confirmed all three load-bearing claims — verdict (a), that
the test reaches the defect, and that the dropped-dispatch premise is real — and ran a
**sharper mutation than mine**: deleting only `ceiling: compactHoldTimeout` from the
compact policy row, under which the new test is *the only test in the repo that fails*.
That is stronger evidence than the idle-arm revert alone, because it pins **this row's
ceiling** rather than merely "some classify pass ran". It also verified the mutations via
`go test -overlay=` rather than editing the worktree.

Four findings came back, all documentation-grade, none blocking. **All four applied** in
`4c45a63d`:

1. **A false, self-refuting comment** — the claim that the harness "leaves `state.Metrics`
   nil" is wrong: `mockMetrics.ComputeMetrics` returns `(nil, nil)` and
   `RefreshOnActivity` skips a nil result, so `Metrics` stays at the seeded fixture value.
   It is self-refuting because `Overlay` returns early on nil metrics — if it were true
   the test could never pass. I had inherited the sentence by copying the #1376 sibling,
   so it was corrected **in both places**, with the correction noted inline.
2. **Overstated harm** — "the orphaned hold is unbounded" implied a user-visible strand.
   `Overlay` checks `stale` and the ceiling *before* `apply`, so this row's orphaned hold
   was **inert**: it pinned nothing, and the first pass to arrive would expire rather than
   apply it. Unlike #1360's `permission_prompt` row, which really did hold a session at
   `waiting` for the life of the process. Reworded — and the distinction is the strongest
   argument *for* verdict (a), since it explains why the defect stayed invisible.
3. **A missing condition** — the cross-reference now says the dropped dispatch strands a
   session only "while the session is not already working", and "both hook holds" is
   disambiguated to "both of the hook holds #1360 bounds", since the insert cites a third
   ceiling-bearing row.
4. **Labelling** — the new test is now explicitly called **a LOCK on current `main`**, with
   both mutations it was seen red under recorded in the comment. Its name reads like a
   defect test, and without the label the next reader applying the red-first rule would
   go looking for a fix this PR deliberately does not contain.
