### PR TITLE
fix(tailer): read ~/.claude/settings.json as JSONC, like hookjson does

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,16 @@ Before marking a ticket done, run the full suite — every layer must pass:
 - Architecture: `core/architecture_test.go` (runs automatically as part of
   `go test ./core/...`) statically enforces the hexagonal import direction
   from Key Conventions — `domain/` and `ports/` packages may not import
-  outward into `adapters/` or `application/`, and `application/services/`
-  may only reach `adapters/inbound/` through `ports/`.
+  outward into `adapters/` or `application/`, `application/services/`
+  may only reach `adapters/inbound/` through `ports/`, and `pkg/` — the
+  shared leaf layer that every other layer depends on, `domain/agent`
+  included — may not import `adapters/` or `application/` at all. It checks
+  **direct** imports only, so a rule constrains the edges a package declares,
+  not what those edges drag in transitively. `pkg/` was unbound until #1391,
+  where the natural fix for a decode shared between `pkg/tailer` and the
+  `hookjson` adapter was an import that no rule in the table forbade; the
+  shared code went to a new leaf (`core/pkg/jsonc`) and the missing rule was
+  added with it.
 - Architecture score: `tools/ars-gate.sh` flags it when the Agent Readiness
   Score (composite or any category) regresses vs `origin/main` — advisory,
   not a merge gate: it runs as a PR check (`.github/workflows/ars-gate.yml`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,8 +75,8 @@ Before marking a ticket done, run the full suite — every layer must pass:
   from Key Conventions — `domain/` and `ports/` packages may not import
   outward into `adapters/` or `application/`, `application/services/`
   may only reach `adapters/inbound/` through `ports/`, and `pkg/` — the
-  shared leaf layer that every other layer depends on, `domain/agent`
-  included — may not import `adapters/` or `application/` at all. It checks
+  shared leaf layer depended on from domain, adapters, application and
+  cmd alike — may not import `adapters/` or `application/` at all. It checks
   **direct** imports only, so a rule constrains the edges a package declares,
   not what those edges drag in transitively. `pkg/` was unbound until #1391,
   where the natural fix for a decode shared between `pkg/tailer` and the

--- a/core/adapters/inbound/agents/hookjson/jsonc.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc.go
@@ -86,9 +86,9 @@ var errNoSafeSplice = errors.New("hookjson: cannot splice safely")
 // a valid document is (#1391). Only the blanker moved; every span-parsing and
 // splicing symbol below stays here, where its only caller is.
 //
-// These two remain as package-local aliases so the ~40 call sites and tests
-// below read unchanged, and so this package keeps naming the operation in its
-// own vocabulary.
+// These two remain as package-local aliases so the nine call sites in this
+// package and its tests read unchanged, and so this package keeps naming the
+// operation in its own vocabulary.
 
 // blankComments returns a copy of src with every JSONC comment overwritten by
 // spaces.

--- a/core/adapters/inbound/agents/hookjson/jsonc.go
+++ b/core/adapters/inbound/agents/hookjson/jsonc.go
@@ -69,6 +69,8 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+
+	"irrlicht/core/pkg/jsonc"
 )
 
 // errNoSafeSplice means this document cannot be edited in place with confidence
@@ -78,76 +80,23 @@ import (
 var errNoSafeSplice = errors.New("hookjson: cannot splice safely")
 
 // --- comment blanking ---
+//
+// The blanker itself now lives in core/pkg/jsonc, because core/pkg/tailer
+// reads ~/.claude/settings.json too and the two readers have to agree on what
+// a valid document is (#1391). Only the blanker moved; every span-parsing and
+// splicing symbol below stays here, where its only caller is.
+//
+// These two remain as package-local aliases so the ~40 call sites and tests
+// below read unchanged, and so this package keeps naming the operation in its
+// own vocabulary.
 
 // blankComments returns a copy of src with every JSONC comment overwritten by
 // spaces.
-func blankComments(src []byte) []byte {
-	blanked, _ := blankCommentsMask(src)
-	return blanked
-}
+func blankComments(src []byte) []byte { return jsonc.Blank(src) }
 
-// blankCommentsMask also reports which bytes belonged to a comment. Newlines
-// inside a block comment are left as newlines in the blanked text — so line
-// structure and byte offsets are identical to src — but they are still marked,
-// which is how the separator arithmetic knows a comment spans lines.
-func blankCommentsMask(src []byte) ([]byte, []bool) {
-	out := make([]byte, len(src))
-	copy(out, src)
-	mask := make([]bool, len(src))
-
-	inString := false
-	for i := 0; i < len(src); i++ {
-		c := src[i]
-		if inString {
-			switch c {
-			case '\\':
-				i++ // an escaped byte can never close the string
-			case '"':
-				inString = false
-			}
-			continue
-		}
-		switch {
-		case c == '"':
-			inString = true
-		case c == '/' && i+1 < len(src) && src[i+1] == '/':
-			i = blankLineComment(src, out, mask, i) - 1
-		case c == '/' && i+1 < len(src) && src[i+1] == '*':
-			i = blankBlockComment(src, out, mask, i) - 1
-		}
-	}
-	return out, mask
-}
-
-// blankLineComment blanks from i up to (not including) the next newline and
-// returns the index it stopped at.
-func blankLineComment(src, out []byte, mask []bool, i int) int {
-	for i < len(src) && src[i] != '\n' {
-		out[i] = ' '
-		mask[i] = true
-		i++
-	}
-	return i
-}
-
-// blankBlockComment blanks from i through the closing `*/` (or to end of input
-// when unterminated, which then fails the parse) and returns the index just
-// past it.
-func blankBlockComment(src, out []byte, mask []bool, i int) int {
-	for i < len(src) {
-		mask[i] = true
-		if src[i] == '*' && i+1 < len(src) && src[i+1] == '/' {
-			out[i], out[i+1] = ' ', ' '
-			mask[i+1] = true
-			return i + 2
-		}
-		if src[i] != '\n' {
-			out[i] = ' '
-		}
-		i++
-	}
-	return i
-}
+// blankCommentsMask also reports which bytes belonged to a comment. See
+// jsonc.BlankMask for why length is preserved.
+func blankCommentsMask(src []byte) ([]byte, []bool) { return jsonc.BlankMask(src) }
 
 // --- span-recording parse ---
 

--- a/core/architecture_test.go
+++ b/core/architecture_test.go
@@ -47,6 +47,31 @@ func TestArchitectureLayerImportDirection(t *testing.T) {
 			sourcePrefix:      "irrlicht/core/application/services/",
 			forbiddenPrefixes: []string{"irrlicht/core/adapters/inbound/"},
 		},
+		// pkg/ is the shared leaf layer: stdlib, other pkg/ packages, and
+		// domain types. It is depended ON by every other layer — including
+		// domain/agent, which imports pkg/tailer — so an edge out of pkg/ into
+		// adapters/ or application/ inverts the direction for everything above
+		// it at once.
+		//
+		// Added by #1391, where the obvious fix for a shared JSONC decode was
+		// to have pkg/tailer import the hookjson adapter. Nothing in this table
+		// bound pkg/ at the time, so that import would have passed this test
+		// and quietly established the repo's first pkg -> adapters edge. It
+		// happens to be caught today by the compiler — domain/agent imports
+		// pkg/tailer and hookjson imports domain/agent, so the edge closes an
+		// import cycle — but that is an accident of which adapter it was, not a
+		// rule. An adapter that imports no domain package would have compiled
+		// fine.
+		//
+		// ports/ is deliberately absent from the forbidden list: no pkg/
+		// package imports it today, but a leaf implementing a port interface
+		// would be legitimate, and this rule is meant to pin the direction that
+		// is actually wrong rather than the widest one available.
+		{
+			name:              "pkg must not import adapters or application",
+			sourcePrefix:      "irrlicht/core/pkg/",
+			forbiddenPrefixes: []string{"irrlicht/core/adapters/", "irrlicht/core/application/"},
+		},
 	}
 
 	for _, pkg := range pkgs {

--- a/core/architecture_test.go
+++ b/core/architecture_test.go
@@ -48,10 +48,13 @@ func TestArchitectureLayerImportDirection(t *testing.T) {
 			forbiddenPrefixes: []string{"irrlicht/core/adapters/inbound/"},
 		},
 		// pkg/ is the shared leaf layer: stdlib, other pkg/ packages, and
-		// domain types. It is depended ON by every other layer — including
-		// domain/agent, which imports pkg/tailer — so an edge out of pkg/ into
-		// adapters/ or application/ inverts the direction for everything above
-		// it at once.
+		// domain types. It is depended on from every layer that imports
+		// anything at all — domain (2 packages), adapters (62), application
+		// (6), cmd (4) — so an edge out of pkg/ into adapters/ or
+		// application/ inverts the direction for all of them at once. The
+		// domain edge is the sharpest: domain/agent imports pkg/tailer, so
+		// pkg/ reaching outward would put adapters transitively underneath
+		// domain.
 		//
 		// Added by #1391, where the obvious fix for a shared JSONC decode was
 		// to have pkg/tailer import the hookjson adapter. Nothing in this table
@@ -63,10 +66,17 @@ func TestArchitectureLayerImportDirection(t *testing.T) {
 		// rule. An adapter that imports no domain package would have compiled
 		// fine.
 		//
-		// ports/ is deliberately absent from the forbidden list: no pkg/
-		// package imports it today, but a leaf implementing a port interface
-		// would be legitimate, and this rule is meant to pin the direction that
-		// is actually wrong rather than the widest one available.
+		// ports/ is deliberately absent from the forbidden list. Today the two
+		// do not touch in either direction — no pkg/ package imports ports/,
+		// and no ports/ package imports pkg/ — but a leaf implementing a port
+		// interface would be legitimate, and this rule is meant to pin the
+		// direction that is actually wrong rather than the widest one
+		// available.
+		//
+		// Like every rule here it sees only non-test imports: packages.Load
+		// runs without Tests, so a pkg/**/*_test.go importing an adapter would
+		// pass. None does today. That gap is pre-existing and shared by all
+		// four rules, not introduced with this one.
 		{
 			name:              "pkg must not import adapters or application",
 			sourcePrefix:      "irrlicht/core/pkg/",

--- a/core/pkg/jsonc/jsonc.go
+++ b/core/pkg/jsonc/jsonc.go
@@ -1,0 +1,96 @@
+// Package jsonc blanks comments out of JSONC so that encoding/json can read
+// it, without changing anything else about the bytes.
+//
+// It exists because two unrelated readers of the same file have to agree on
+// what a valid document is. `hookjson` (an adapter) writes hooks into
+// ~/.claude/settings.json and, since #1371, tolerates comments there;
+// `core/pkg/tailer` reads the same file to recover the operator's default
+// model. When only one of them tolerated comments, a user with a commented
+// settings.json got hooks installed successfully and an empty model with no
+// error anywhere (#1391).
+//
+// The obvious way to share the code — have `tailer` import `hookjson` — does
+// not merely bend the hexagonal layering, it does not compile:
+// `core/domain/agent` imports `core/pkg/tailer`, and `hookjson` imports
+// `core/domain/agent`, so the edge closes an import cycle. Hence a leaf
+// package under core/pkg/ that both sides can depend on.
+//
+// Scope is deliberately narrow: comments, and nothing else. This is NOT a
+// permissive JSON dialect. Trailing commas, single-quoted strings and bare
+// keys stay hard errors in whatever decoder runs next, exactly as they were —
+// a shared blanker is only safe to adopt if it cannot quietly widen what its
+// callers accept. See TestBlank_DoesNotWidenJSON.
+package jsonc
+
+// Blank returns a copy of src with every JSONC comment overwritten by spaces.
+func Blank(src []byte) []byte {
+	blanked, _ := BlankMask(src)
+	return blanked
+}
+
+// BlankMask also reports which bytes belonged to a comment. Newlines inside a
+// block comment are left as newlines in the blanked text — so line structure
+// and byte offsets are identical to src — but they are still marked, which is
+// how hookjson's separator arithmetic knows a comment spans lines.
+//
+// Length is preserved on purpose: every byte offset into the blanked text
+// still indexes the original, which is what lets a parser that has never heard
+// of comments hand back offsets usable against a file full of them.
+func BlankMask(src []byte) ([]byte, []bool) {
+	out := make([]byte, len(src))
+	copy(out, src)
+	mask := make([]bool, len(src))
+
+	inString := false
+	for i := 0; i < len(src); i++ {
+		c := src[i]
+		if inString {
+			switch c {
+			case '\\':
+				i++ // an escaped byte can never close the string
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch {
+		case c == '"':
+			inString = true
+		case c == '/' && i+1 < len(src) && src[i+1] == '/':
+			i = blankLineComment(src, out, mask, i) - 1
+		case c == '/' && i+1 < len(src) && src[i+1] == '*':
+			i = blankBlockComment(src, out, mask, i) - 1
+		}
+	}
+	return out, mask
+}
+
+// blankLineComment blanks from i up to (not including) the next newline and
+// returns the index it stopped at.
+func blankLineComment(src, out []byte, mask []bool, i int) int {
+	for i < len(src) && src[i] != '\n' {
+		out[i] = ' '
+		mask[i] = true
+		i++
+	}
+	return i
+}
+
+// blankBlockComment blanks from i through the closing `*/` (or to end of input
+// when unterminated, which then fails the parse) and returns the index just
+// past it.
+func blankBlockComment(src, out []byte, mask []bool, i int) int {
+	for i < len(src) {
+		mask[i] = true
+		if src[i] == '*' && i+1 < len(src) && src[i+1] == '/' {
+			out[i], out[i+1] = ' ', ' '
+			mask[i+1] = true
+			return i + 2
+		}
+		if src[i] != '\n' {
+			out[i] = ' '
+		}
+		i++
+	}
+	return i
+}

--- a/core/pkg/jsonc/jsonc_test.go
+++ b/core/pkg/jsonc/jsonc_test.go
@@ -1,0 +1,134 @@
+package jsonc
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestBlank_ProducesParseableJSONAtIdenticalOffsets pins the two properties
+// every caller depends on: the result decodes, and it is the same length with
+// the same line structure — which is what lets hookjson's splicer use offsets
+// from a comment-blind parser against a file full of comments.
+func TestBlank_ProducesParseableJSONAtIdenticalOffsets(t *testing.T) {
+	cases := map[string]string{
+		"line comment":              "{\n  // note\n  \"a\": 1\n}\n",
+		"block comment":             "{\n  /* note */\n  \"a\": 1\n}\n",
+		"multiline block":           "{\n  /* one\n     two */\n  \"a\": 1\n}\n",
+		"trailing line comment":     "{\n  \"a\": 1 // note\n}\n",
+		"comment-looking string":    "{\n  \"a\": \"// not a comment\"\n}\n",
+		"block-looking string":      "{\n  \"a\": \"/* not a comment */\"\n}\n",
+		"escaped quote in string":   "{\n  \"a\": \"he said \\\" // no\"\n}\n",
+		"url in string":             "{\n  \"a\": \"http://example.com\"\n}\n",
+		"no comments at all":        "{\n  \"a\": 1\n}\n",
+		"comment at eof no newline": "{\n  \"a\": 1\n}\n// trailing",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			blanked := Blank([]byte(src))
+			if len(blanked) != len(src) {
+				t.Fatalf("length changed: got %d, want %d", len(blanked), len(src))
+			}
+			if strings.Count(string(blanked), "\n") != strings.Count(src, "\n") {
+				t.Errorf("newline count changed\nsrc:     %q\nblanked: %q", src, blanked)
+			}
+			var v interface{}
+			if err := json.Unmarshal(blanked, &v); err != nil {
+				t.Errorf("blanked text is not valid JSON: %v\nblanked: %q", err, blanked)
+			}
+		})
+	}
+}
+
+// TestBlank_LeavesStringContentAlone guards the one way a comment blanker can
+// destroy data: mistaking a `//` inside a string for a comment. A document
+// with no comments must come back byte-identical.
+func TestBlank_LeavesStringContentAlone(t *testing.T) {
+	src := `{"url": "http://example.com/a", "glob": "/*.go", "cmd": "a && b"}`
+	if got := string(Blank([]byte(src))); got != src {
+		t.Errorf("a document with no comments was modified\nsrc:     %q\nblanked: %q", src, got)
+	}
+}
+
+// TestBlank_DoesNotWidenJSON is a LOCK, and it is the reason this package is
+// safe to share.
+//
+// hookjson.ReadSettings errors on genuinely malformed input on purpose —
+// overwriting such a file would destroy content the user meant to keep
+// (hookjson's TestReadSettings_MalformedJSONErrors and
+// TestMalformedInput_StillErrors pin that). core/pkg/tailer now runs the same
+// blanker, so if blanking ever started accepting a wider dialect, both readers
+// would silently widen with it and irrlicht would begin rewriting files it
+// only half understands.
+//
+// Comments are the entire scope. Everything below must still fail to decode
+// after blanking.
+func TestBlank_DoesNotWidenJSON(t *testing.T) {
+	cases := map[string]string{
+		"trailing comma":   "{\n  \"a\": 1,\n}\n",
+		"single quotes":    `{'a': 1}`,
+		"unterminated str": `{"a": "oops}`,
+		"unclosed comment": "{\n  /* never closed\n  \"a\": 1\n}\n",
+		"bare word":        `{a: 1}`,
+		"truncated":        `{"a":`,
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			var v interface{}
+			if err := json.Unmarshal(Blank([]byte(src)), &v); err == nil {
+				t.Errorf("Blank(%q) then Unmarshal: got nil error, want a decode error — the blanker must not widen the dialect", src)
+			}
+		})
+	}
+}
+
+// TestBlankMask_MarksExactlyTheCommentBytes pins the mask contract hookjson's
+// separator arithmetic relies on, including the detail that a newline inside a
+// block comment stays a newline in the output but is still marked.
+func TestBlankMask_MarksExactlyTheCommentBytes(t *testing.T) {
+	src := "{\"a\":1} // tail"
+	blanked, mask := BlankMask([]byte(src))
+
+	if len(mask) != len(src) {
+		t.Fatalf("mask length %d, want %d", len(mask), len(src))
+	}
+	const commentStart = 8 // index of the first '/'
+	for i := range src {
+		want := i >= commentStart
+		if mask[i] != want {
+			t.Errorf("mask[%d] = %v, want %v (byte %q)", i, mask[i], want, src[i])
+		}
+	}
+	if got := string(blanked); got != "{\"a\":1}        " {
+		t.Errorf("blanked = %q, want the comment replaced by spaces", got)
+	}
+}
+
+func TestBlankMask_BlockCommentKeepsNewlinesButMarksThem(t *testing.T) {
+	src := "{\n  /* one\n     two */\n  \"a\": 1\n}\n"
+	blanked, mask := BlankMask([]byte(src))
+
+	if strings.Count(string(blanked), "\n") != strings.Count(src, "\n") {
+		t.Errorf("newlines not preserved\nblanked: %q", blanked)
+	}
+	// The newline that sits inside the block comment must be marked even
+	// though it survives into the blanked text.
+	inner := strings.Index(src, "one\n") + len("one")
+	if src[inner] != '\n' {
+		t.Fatalf("test setup: expected a newline at %d, got %q", inner, src[inner])
+	}
+	if !mask[inner] {
+		t.Error("newline inside a block comment is not marked as comment")
+	}
+	if blanked[inner] != '\n' {
+		t.Errorf("newline inside a block comment was blanked to %q, want it preserved", blanked[inner])
+	}
+}
+
+// TestBlank_EmptyInput is the boundary the byte loops are easiest to get wrong.
+func TestBlank_EmptyInput(t *testing.T) {
+	blanked, mask := BlankMask(nil)
+	if len(blanked) != 0 || len(mask) != 0 {
+		t.Errorf("BlankMask(nil) = %q, %v; want empty, empty", blanked, mask)
+	}
+}

--- a/core/pkg/jsonc/jsonc_test.go
+++ b/core/pkg/jsonc/jsonc_test.go
@@ -125,10 +125,18 @@ func TestBlankMask_BlockCommentKeepsNewlinesButMarksThem(t *testing.T) {
 	}
 }
 
-// TestBlank_EmptyInput is the boundary the byte loops are easiest to get wrong.
+// TestBlank_EmptyInput is the boundary the byte loops are easiest to get
+// wrong. Both entry points are exercised: Blank delegates to BlankMask today,
+// but it is the one core/pkg/tailer calls, so a refactor that gives it its own
+// loop must not find this boundary uncovered.
 func TestBlank_EmptyInput(t *testing.T) {
-	blanked, mask := BlankMask(nil)
-	if len(blanked) != 0 || len(mask) != 0 {
-		t.Errorf("BlankMask(nil) = %q, %v; want empty, empty", blanked, mask)
+	for _, src := range [][]byte{nil, {}} {
+		if got := Blank(src); len(got) != 0 {
+			t.Errorf("Blank(%q) = %q; want empty", src, got)
+		}
+		blanked, mask := BlankMask(src)
+		if len(blanked) != 0 || len(mask) != 0 {
+			t.Errorf("BlankMask(%q) = %q, %v; want empty, empty", src, blanked, mask)
+		}
 	}
 }

--- a/core/pkg/tailer/model_fallback_test.go
+++ b/core/pkg/tailer/model_fallback_test.go
@@ -1,8 +1,6 @@
 package tailer
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -12,17 +10,7 @@ import (
 // expected value (e.g. via getClaudeModel) can do so.
 func writeClaudeSettingsFixture(t *testing.T, model string) string {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"),
-		[]byte(`{"model":"`+model+`"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	return home
+	return writeClaudeSettingsRaw(t, `{"model":"`+model+`"}`)
 }
 
 // noInBandModelLines is a minimal user/assistant transcript that carries no

--- a/core/pkg/tailer/settings_jsonc_test.go
+++ b/core/pkg/tailer/settings_jsonc_test.go
@@ -90,9 +90,16 @@ func TestGetClaudeModel_CommentDelimitersInsideStringsAreNotComments(t *testing.
 // TestMalformedInput_StillErrors). Blanking comments must not make this reader
 // any more permissive than that one: the shapes below are exactly the JSONC-
 // adjacent ones hookjson still rejects, and getClaudeModel must keep yielding
-// "" for each. If the two readers ever disagree about whether a file is valid,
-// irrlicht will install hooks into a config it cannot read, or refuse one it
-// can — which is the class of bug #1391 itself is.
+// "" for each. If the two readers disagree about whether a NON-EMPTY document
+// is valid, irrlicht will install hooks into a config it cannot read, or
+// refuse one it can — which is the class of bug #1391 itself is.
+//
+// They do already differ on the trivial cases, harmlessly and by design:
+// hookjson short-circuits a missing or whitespace-only file to an empty map
+// with no error (it is about to write one), while getClaudeModel just fails
+// its decode. Both converge on "no model", so nothing observable diverges.
+// The direction that would matter is tailer accepting what hookjson rejects,
+// and that is what the table below pins.
 func TestGetClaudeModel_MalformedStaysEmpty(t *testing.T) {
 	cases := map[string]string{
 		"trailing comma":   "{\n  \"model\": \"claude-sonnet-4-20250514\",\n}\n",

--- a/core/pkg/tailer/settings_jsonc_test.go
+++ b/core/pkg/tailer/settings_jsonc_test.go
@@ -1,0 +1,113 @@
+package tailer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeClaudeSettingsRaw seeds a hermetic HOME with the exact bytes given as
+// ~/.claude/settings.json. Unlike writeClaudeSettingsFixture it does not build
+// the document, so a case can hand it JSONC — or deliberate garbage — and
+// still be sure it never touches the developer's real settings file.
+func writeClaudeSettingsRaw(t *testing.T, body string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+// TestGetClaudeModel_ReadsCommentedSettings pins issue #1391.
+//
+// PR #1381 (issue #1371) taught hookjson.ReadSettings to blank JSONC comments
+// before decoding, so irrlicht installs hooks into a commented
+// ~/.claude/settings.json without complaint. getClaudeModel kept its plain
+// json.Unmarshal, so the very same file that accepted our hooks yields no
+// model at all — and no cost estimate derived from it. The failure is silent:
+// the error path of that Unmarshal returns "".
+//
+// The two readers must agree on what a valid settings.json is.
+func TestGetClaudeModel_ReadsCommentedSettings(t *testing.T) {
+	cases := map[string]string{
+		"line comment above the key": "{\n" +
+			"  // pinned so cost estimates stay stable\n" +
+			"  \"model\": \"claude-sonnet-4-20250514\"\n" +
+			"}\n",
+		"trailing line comment": "{\n" +
+			"  \"model\": \"claude-sonnet-4-20250514\" // pinned\n" +
+			"}\n",
+		"block comment": "{\n" +
+			"  /* team default, see docs/models.md */\n" +
+			"  \"model\": \"claude-sonnet-4-20250514\"\n" +
+			"}\n",
+		"block comment spanning lines": "{\n" +
+			"  /* why this model:\n" +
+			"     it is the cheapest that passes our evals */\n" +
+			"  \"model\": \"claude-sonnet-4-20250514\"\n" +
+			"}\n",
+	}
+
+	want := NormalizeModelName("claude-sonnet-4-20250514")
+
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			home := writeClaudeSettingsRaw(t, body)
+			if got := getClaudeModel(home); got != want {
+				t.Errorf("getClaudeModel on a commented settings.json = %q, want %q\nsettings.json was:\n%s", got, want, body)
+			}
+		})
+	}
+}
+
+// TestGetClaudeModel_CommentDelimitersInsideStringsAreNotComments guards the
+// obvious wrong fix — a naive strings.Index("//") strip would eat the value.
+// A URL in a settings value is the everyday shape that breaks it.
+func TestGetClaudeModel_CommentDelimitersInsideStringsAreNotComments(t *testing.T) {
+	body := "{\n" +
+		"  \"apiBaseUrl\": \"https://example.invalid/v1\", // not a comment above\n" +
+		"  \"model\": \"claude-sonnet-4-20250514\"\n" +
+		"}\n"
+	home := writeClaudeSettingsRaw(t, body)
+	want := NormalizeModelName("claude-sonnet-4-20250514")
+	if got := getClaudeModel(home); got != want {
+		t.Errorf("getClaudeModel = %q, want %q (a // inside a string value is data, not a comment)", got, want)
+	}
+}
+
+// TestGetClaudeModel_MalformedStaysEmpty is a LOCK, not a defect test: it
+// passes on main by construction and must keep passing.
+//
+// hookjson.ReadSettings deliberately errors on genuinely malformed input —
+// overwriting such a file would destroy content the user meant to keep
+// (hookjson_test.go TestReadSettings_MalformedJSONErrors, jsonc_test.go
+// TestMalformedInput_StillErrors). Blanking comments must not make this reader
+// any more permissive than that one: the shapes below are exactly the JSONC-
+// adjacent ones hookjson still rejects, and getClaudeModel must keep yielding
+// "" for each. If the two readers ever disagree about whether a file is valid,
+// irrlicht will install hooks into a config it cannot read, or refuse one it
+// can — which is the class of bug #1391 itself is.
+func TestGetClaudeModel_MalformedStaysEmpty(t *testing.T) {
+	cases := map[string]string{
+		"trailing comma":   "{\n  \"model\": \"claude-sonnet-4-20250514\",\n}\n",
+		"single quotes":    `{'model': 'claude-sonnet-4-20250514'}`,
+		"unterminated str": `{"model": "claude-sonnet-4-20250514}`,
+		"unclosed comment": "{\n  /* never closed\n  \"model\": \"claude-sonnet-4-20250514\"\n}\n",
+		"bare word":        `{model: 1}`,
+		"truncated":        `{"model":`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			home := writeClaudeSettingsRaw(t, body)
+			if got := getClaudeModel(home); got != "" {
+				t.Errorf("getClaudeModel on malformed settings.json = %q, want \"\" (must stay as strict as hookjson.ReadSettings)\nsettings.json was:\n%s", got, body)
+			}
+		})
+	}
+}

--- a/core/pkg/tailer/tailer_config.go
+++ b/core/pkg/tailer/tailer_config.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"irrlicht/core/pkg/jsonc"
 )
 
 // surviveTurnDone returns true for tools whose tool_result arrives after the
@@ -77,13 +79,24 @@ func getDefaultModelFromConfig(adapter string) string {
 	}
 }
 
+// getClaudeModel recovers the operator's configured default model from
+// ~/.claude/settings.json.
+//
+// Comments are blanked before decoding because that same file is the one
+// hookjson installs hooks into, and since #1371 hookjson reads it as JSONC. A
+// reader that is stricter than the writer is silently wrong: the user gets a
+// successful hook install and an empty model, with no error on either side
+// (#1391). Both now go through core/pkg/jsonc so they cannot drift again.
+//
+// Blanking widens nothing beyond comments — a trailing comma or a bare key is
+// still a decode failure here, exactly as it is in hookjson.ReadSettings.
 func getClaudeModel(homeDir string) string {
 	data, err := os.ReadFile(filepath.Join(homeDir, ".claude", "settings.json"))
 	if err != nil {
 		return ""
 	}
 	var settings map[string]interface{}
-	if err := json.Unmarshal(data, &settings); err != nil {
+	if err := json.Unmarshal(jsonc.Blank(data), &settings); err != nil {
 		return ""
 	}
 	if model, ok := settings["model"].(string); ok {


### PR DESCRIPTION
Closes #1391.

## The divergence, verified on `main`

PR #1381 (commit `c93a2bdd`, closed #1371, merged 2026-08-09) taught
`hookjson.ReadSettings` to blank JSONC comments before decoding. It did not
touch `core/pkg/tailer`, which reads the same file — so the two readers stopped
agreeing about what a valid `~/.claude/settings.json` is.

Both sides, quoted from `main`:

```go
// core/adapters/inbound/agents/hookjson/hookjson.go:189  — tolerant since #1381
if err := json.Unmarshal(blankComments(data), &settings); err != nil {
```
```go
// core/pkg/tailer/tailer_config.go:86  — still strict
if err := json.Unmarshal(data, &settings); err != nil {
    return ""
}
```

Measured on unfixed `main`, handing **the same commented file** to each:

| Reader | Result |
|---|---|
| `hookjson.ReadSettings` | `model="claude-sonnet-4-20250514"`, `err=<nil>` |
| `tailer.getClaudeModel`  | `""` |

So a user with a commented settings.json gets a successful hook install and no
model name — and therefore no cost estimate derived from it — with no error on
either side.

## Extract, not import — the import does not compile

The issue flags that `core/pkg/tailer` importing `hookjson` would be the repo's
first `pkg -> adapters` edge, and that `architecture_test.go` would not catch it.
Both true. But the import is worse than a layering smell — it is an import cycle,
because `core/domain/agent` imports `core/pkg/tailer`:

```
package irrlicht/core/pkg/tailer
	imports irrlicht/core/adapters/inbound/agents/hookjson from tailer_config.go
	imports irrlicht/core/domain/agent from confine.go
	imports irrlicht/core/pkg/tailer from file_parser.go: import cycle not allowed
```

So the extraction is taken.

**What moves:** `blankComments`, `blankCommentsMask` and their two byte-loop
helpers `blankLineComment` / `blankBlockComment` — ~40 lines that reference no
other symbol in `hookjson` and import nothing at all, not even stdlib. They
become `jsonc.Blank` / `jsonc.BlankMask` in the new leaf package `core/pkg/jsonc`.

**What stays:** everything else in `hookjson/jsonc.go` — `parseSpans`, the
`splicer` and its ~25 methods, `applyEdits`, `alignArray`, layout detection. That
machinery has exactly one caller and belongs where it is. `hookjson` keeps
`blankComments`/`blankCommentsMask` as two one-line package-local aliases, so its
call sites and its existing test suite read unchanged.

**Nothing else in `hookjson` becomes reachable from `pkg/`.** The new package
imports nothing; the dependency runs `hookjson -> jsonc`, not the reverse.
Verified: `go list -deps ./pkg/...` shows no `core/adapters` or `core/application`
edge, direct or transitive.

## `architecture_test.go` — fixed here, deliberately

`core/pkg/` was bound by no rule, so the wrong fix would have passed the
architecture test. It is caught today only by the compiler, and that is an
accident of *which* adapter it was: an adapter importing no domain package would
have compiled fine and landed the edge silently.

This PR adds the rule rather than deferring it, because this is the PR that
discovered the hole and the PR whose reasoning is the rule's justification —
split across two, the explanation and the guard each land without the other.
It is ~6 lines in an existing table plus its rationale, and it passes today.

`ports/` is deliberately **not** in the forbidden list: no `pkg/` package imports
it, but a leaf implementing a port interface would be legitimate, so the rule
pins the direction that is actually wrong rather than the widest one available.

Out of scope and left alone: the architecture test checks **direct** imports
only. That is a real and larger gap — a transitive `domain -> ... -> adapters`
path would still pass — but it is a separate change with a much wider blast
radius, and is not needed for the edge this issue is about.

## Red-first evidence

`TestGetClaudeModel_ReadsCommentedSettings` + the string-delimiter guard, run on
`main` before the fix existed — 5 failing cases:

```
--- FAIL: TestGetClaudeModel_ReadsCommentedSettings (0.00s)
    --- FAIL: TestGetClaudeModel_ReadsCommentedSettings/line_comment_above_the_key (0.00s)
        settings_jsonc_test.go:63: getClaudeModel on a commented settings.json = "", want "claude-4-sonnet"
            settings.json was:
            {
              // pinned so cost estimates stay stable
              "model": "claude-sonnet-4-20250514"
            }
    --- FAIL: .../trailing_line_comment
    --- FAIL: .../block_comment
    --- FAIL: .../block_comment_spanning_lines
--- FAIL: TestGetClaudeModel_CommentDelimitersInsideStringsAreNotComments (0.00s)
    settings_jsonc_test.go:80: getClaudeModel = "", want "claude-4-sonnet" (a // inside a string value is data, not a comment)
FAIL	irrlicht/core/pkg/tailer	0.367s
```

All green after the fix.

**The new architecture rule** passes by construction, so it was seen red on a
deliberate mutation (a `pkg/jsonc -> adapters/outbound/httputil` import, chosen
because that adapter has no `core/pkg` dependency and so does not cycle):

```
--- FAIL: TestArchitectureLayerImportDirection (0.14s)
    architecture_test.go:92: layering violation (pkg must not import adapters or application): "irrlicht/core/pkg/jsonc" imports "irrlicht/core/adapters/outbound/httputil"
```

Mutation reverted; the rule passes on the real tree.

### Locks (pass on `main` by construction — not red-first proofs)

- `TestGetClaudeModel_MalformedStaysEmpty` — `hookjson.ReadSettings` errors on
  genuinely malformed input on purpose, and that is correct behaviour, not a
  defect. This pins that `tailer` does not become *more permissive* than
  `hookjson`: trailing comma, single quotes, unterminated string, unclosed
  comment, bare word and truncated input all still yield `""`. The case list
  mirrors `hookjson`'s own `TestMalformedInput_StillErrors`.
- `TestBlank_DoesNotWidenJSON` — the same property asserted at the shared
  blanker, which is what makes it safe for two callers to adopt.

## Files changed

| File | Why |
|---|---|
| `core/pkg/jsonc/jsonc.go` (new) | The extracted blanker, `Blank`/`BlankMask`; package doc records why the import alternative was not available. |
| `core/pkg/jsonc/jsonc_test.go` (new) | Owns the blanker's properties: parseable output at identical offsets, string content untouched, mask contract, empty input — plus the "does not widen JSON" lock. |
| `core/pkg/tailer/tailer_config.go` | `getClaudeModel` blanks comments before decoding; doc comment records why it must track `hookjson`. |
| `core/pkg/tailer/settings_jsonc_test.go` (new) | The red-first defect test, the string-delimiter guard, and the permissiveness-parity lock. |
| `core/adapters/inbound/agents/hookjson/jsonc.go` | The four moved functions become two one-line delegations to `core/pkg/jsonc`; everything else untouched. |
| `core/architecture_test.go` | New `pkg must not import adapters or application` rule + rationale. |
| `AGENTS.md` | Its description of the architecture gate listed only three bound prefixes and did not say the check is direct-imports-only; both now stated. |

## Verification

- `go test ./core/... -race -count=1` — 56 packages ok, no failures.
- `tools/preflight.sh` run chunked in the foreground; every gate PASS:
  `go` (gofmt, core, onboarding-factory, replaydata validate, recording-rig
  smoke, replay fixtures, starhistory), `arch` (ARS composite 7.9507 -> 7.9536,
  no regression), `tools`, `skills` (23 files, 0 errors/warnings), `posix`,
  `web` (both trees), `security` (govulncheck + gosec + npm audit).
- Deletion tripwire against live `origin/main`
  (`git diff --diff-filter=D --name-only origin/main...HEAD`): empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review outcome (Phase 5)

Reviewed at **medium** effort by a dedicated review subagent against
`origin/main...HEAD`. **No correctness defects.** It independently reproduced
both the red-first failure and the architecture-rule mutation, and mechanically
confirmed the move is byte-for-byte identical (extract both versions of the
function cluster, rename, `diff` — sole difference is one trailing blank line).

Four low-severity documentation findings, all applied in `df18bca4`:

1. The `hookjson` alias comment claimed "~40 call sites"; there are nine.
2. "the shared leaf layer that every other layer depends on" was untrue of
   `ports/`, which touches `pkg/` in neither direction — and it contradicted
   the very next paragraph. Now names the layers that actually do.
3. The `tailer` parity lock's rationale overstated strict agreement:
   `hookjson.ReadSettings` short-circuits a missing or whitespace-only file to
   an empty map while `getClaudeModel` fails its decode. Harmless — both yield
   no model — but now stated rather than contradicted.
4. `TestBlank_EmptyInput` was named for `Blank` and only called `BlankMask`.

Also folded in: `writeClaudeSettingsFixture` now delegates to
`writeClaudeSettingsRaw`, and the rule comment records that the architecture
rules see non-test imports only (`packages.Load` runs without `Tests`) — a
pre-existing gap shared by all four rules, verified to have no live violation
under `core/pkg/`.

**Simplify:** taken at the **Small** row (inline glance, no four-agent fan-out)
while review was taken at **Medium** — the split is deliberate. The diff is
large by line count but the material is ~96 lines of verbatim-relocated Go,
~250 lines of tests and comments, and only a handful of genuinely new
statements; a code-simplification fan-out has nothing to chew on there, whereas
the review found four real findings and earned its tier.

## CodeScene (advisory, not a merge gate)

Red, and it is a relocation artifact — evidence rather than a shrug. It flags
`BlankMask` in the **new** `core/pkg/jsonc/jsonc.go` for Complex Method /
Complex Conditional, while simultaneously reporting `hookjson/jsonc.go`
improving **7.38 → 8.27** and "1 file improves in Code Health". That function
is unchanged code that already existed at exactly this complexity inside
`hookjson`; CodeScene scores it as new because the file is new.

Deliberately not refactored: rewriting it would forfeit the byte-for-byte
identity of the move, which is this PR's main safety argument and what the
review verified mechanically. A behaviour-preserving simplification of the
blanker is a reasonable follow-up on its own merits, decoupled from this fix.
