### PR TITLE
feat(copilot): hook-based state detection via native http hooks

### DIFF
--- a/core/adapters/inbound/agents/beaconroute_test.go
+++ b/core/adapters/inbound/agents/beaconroute_test.go
@@ -5,6 +5,7 @@ import (
 
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/adapters/inbound/agents/codex"
+	"irrlicht/core/adapters/inbound/agents/copilot"
 	"irrlicht/core/pkg/hookbeacon"
 )
 
@@ -33,6 +34,7 @@ func TestBeaconEndpointPathMatchesTheInstalledReceivers(t *testing.T) {
 	for segment, want := range map[string]string{
 		"claudecode": claudecode.HookEndpointPath,
 		"codex":      codex.HookEndpointPath,
+		"copilot":    copilot.HookEndpointPath,
 	} {
 		if got := hookbeacon.EndpointPath(segment); got != want {
 			t.Errorf("hookbeacon.EndpointPath(%q) = %q, but the receiver is registered at %q — the beacon would post into a route nothing serves", segment, got, want)

--- a/core/adapters/inbound/agents/copilot/adapter_test.go
+++ b/core/adapters/inbound/agents/copilot/adapter_test.go
@@ -175,8 +175,8 @@ func TestAgent_Permissions(t *testing.T) {
 	if transcripts.Apply != nil || transcripts.Remove != nil {
 		t.Error("observe-kind permission must not carry Apply/Remove effects")
 	}
-	if transcripts.Hooks != nil {
-		t.Error("the transcripts permission must not carry a HookInstall")
+	if transcripts.Writes != nil {
+		t.Error("the transcripts permission must not carry a ManagedUserFile")
 	}
 
 	hooks, ok := byKey[PermissionKeyHooks]
@@ -189,14 +189,14 @@ func TestAgent_Permissions(t *testing.T) {
 	if hooks.Apply == nil || hooks.Remove == nil {
 		t.Error("the hooks permission must carry both Apply and Remove effects")
 	}
-	if hooks.Hooks == nil {
-		t.Fatal("the hooks permission must carry a HookInstall")
+	if hooks.Writes == nil {
+		t.Fatal("the hooks permission must carry a ManagedUserFile")
 	}
-	if hooks.Hooks.ConfigPath == nil || hooks.Hooks.Uninstall == nil || hooks.Hooks.Verify == nil {
-		t.Error("HookInstall must declare ConfigPath, Uninstall and Verify")
+	if hooks.Writes.Path == nil || hooks.Writes.Uninstall == nil || hooks.Writes.Verify == nil {
+		t.Error("ManagedUserFile must declare Path, Uninstall and Verify")
 	}
-	if hooks.Hooks.Version == nil {
-		t.Error("HookInstall must declare a version floor")
+	if hooks.Writes.Version == nil {
+		t.Error("ManagedUserFile must declare a version floor")
 	}
 
 	for _, p := range perms {

--- a/core/adapters/inbound/agents/copilot/adapter_test.go
+++ b/core/adapters/inbound/agents/copilot/adapter_test.go
@@ -131,36 +131,82 @@ func TestAgent_Process_ExactName(t *testing.T) {
 	}
 }
 
-// TestAgent_Permissions pins the consent surface. Copilot is observe-only: it
-// installs nothing, so it declares exactly one observe permission and no
-// modify permission — which is also why no contracttesting.AssertPermissionGated
-// call is owed here (that contract covers modify-kind permissions, and the
-// observe gate is enforced daemon-side by startWatching/stopWatching).
+// TestAgent_Permissions pins the consent surface: one observe permission for
+// reading transcripts, and — since #1378 — one modify permission for the hook
+// install.
 //
-// The count matters beyond tidiness: PermissionService resolves an adapter to
-// its FIRST observe-kind entry and stops, so a second one would be silently
-// unreachable.
+// The ONE-observe count matters beyond tidiness: PermissionService resolves an
+// adapter to its FIRST observe-kind entry and stops, so a second observe entry
+// would be silently unreachable. The hooks entry must therefore be
+// modify-kind, which is asserted rather than assumed.
+//
+// Both entries are checked for the four prose fields because the consent
+// wizard renders all of them; the hooks entry's copy is additionally bound to
+// what the installer actually writes by AssertHookDisclosureMatchesInstalled
+// (hookdisclosure_test.go), which is the check that would catch a stale event
+// list here.
 func TestAgent_Permissions(t *testing.T) {
 	perms := Agent().Permissions
-	if len(perms) != 1 {
-		t.Fatalf("got %d permissions, want exactly 1 (observe-only adapter)", len(perms))
+	if len(perms) != 2 {
+		t.Fatalf("got %d permissions, want exactly 2 (transcripts + hooks)", len(perms))
 	}
-	p := perms[0]
-	if p.Key != PermissionKeyTranscripts {
-		t.Errorf("Key = %q, want %q", p.Key, PermissionKeyTranscripts)
+
+	byKey := map[string]agent.Permission{}
+	observes := 0
+	for _, p := range perms {
+		byKey[p.Key] = p
+		if p.Kind == permission.KindObserve {
+			observes++
+		}
 	}
-	if p.Kind != permission.KindObserve {
-		t.Errorf("Kind = %v, want %v", p.Kind, permission.KindObserve)
+	if observes != 1 {
+		t.Errorf("got %d observe-kind permissions, want exactly 1 — "+
+			"PermissionService resolves an adapter to its first observe entry and stops, "+
+			"so any second one is unreachable", observes)
 	}
-	if p.Apply != nil || p.Remove != nil {
+
+	transcripts, ok := byKey[PermissionKeyTranscripts]
+	if !ok {
+		t.Fatalf("no %q permission declared", PermissionKeyTranscripts)
+	}
+	if transcripts.Kind != permission.KindObserve {
+		t.Errorf("transcripts Kind = %v, want %v", transcripts.Kind, permission.KindObserve)
+	}
+	if transcripts.Apply != nil || transcripts.Remove != nil {
 		t.Error("observe-kind permission must not carry Apply/Remove effects")
 	}
-	for name, field := range map[string]string{
-		"Title": p.Title, "FeatureUnlocked": p.FeatureUnlocked,
-		"Touches": p.Touches, "Detail": p.Detail,
-	} {
-		if strings.TrimSpace(field) == "" {
-			t.Errorf("%s is empty — the consent wizard renders this to the user", name)
+	if transcripts.Hooks != nil {
+		t.Error("the transcripts permission must not carry a HookInstall")
+	}
+
+	hooks, ok := byKey[PermissionKeyHooks]
+	if !ok {
+		t.Fatalf("no %q permission declared", PermissionKeyHooks)
+	}
+	if hooks.Kind != permission.KindModify {
+		t.Errorf("hooks Kind = %v, want %v — an install writes a file", hooks.Kind, permission.KindModify)
+	}
+	if hooks.Apply == nil || hooks.Remove == nil {
+		t.Error("the hooks permission must carry both Apply and Remove effects")
+	}
+	if hooks.Hooks == nil {
+		t.Fatal("the hooks permission must carry a HookInstall")
+	}
+	if hooks.Hooks.ConfigPath == nil || hooks.Hooks.Uninstall == nil || hooks.Hooks.Verify == nil {
+		t.Error("HookInstall must declare ConfigPath, Uninstall and Verify")
+	}
+	if hooks.Hooks.Version == nil {
+		t.Error("HookInstall must declare a version floor")
+	}
+
+	for _, p := range perms {
+		for name, field := range map[string]string{
+			"Title": p.Title, "FeatureUnlocked": p.FeatureUnlocked,
+			"Touches": p.Touches, "Detail": p.Detail,
+		} {
+			if strings.TrimSpace(field) == "" {
+				t.Errorf("%s/%s is empty — the consent wizard renders this to the user", p.Key, name)
+			}
 		}
 	}
 }

--- a/core/adapters/inbound/agents/copilot/adapter_test.go
+++ b/core/adapters/inbound/agents/copilot/adapter_test.go
@@ -159,72 +159,72 @@ func permissionsByKey(t *testing.T) map[string]agent.Permission {
 	return byKey
 }
 
-func TestAgent_Permissions(t *testing.T) {
-	byKey := permissionsByKey(t)
+// Split into four top-level tests rather than subtests: a t.Run closure's body
+// counts toward its ENCLOSING function's cognitive complexity, so grouping
+// them made one function measurably harder to read, not easier.
 
-	t.Run("exactly one observe-kind entry", func(t *testing.T) {
-		observes := 0
-		for _, p := range byKey {
-			if p.Kind == permission.KindObserve {
-				observes++
+func TestAgent_Permissions_ExactlyOneObserveEntry(t *testing.T) {
+	observes := 0
+	for _, p := range permissionsByKey(t) {
+		if p.Kind == permission.KindObserve {
+			observes++
+		}
+	}
+	if observes != 1 {
+		t.Errorf("got %d observe-kind permissions, want exactly 1 — PermissionService "+
+			"resolves an adapter to its first observe entry and stops, so any second "+
+			"one is unreachable", observes)
+	}
+}
+
+func TestAgent_Permissions_TranscriptsIsObserveOnly(t *testing.T) {
+	p, ok := permissionsByKey(t)[PermissionKeyTranscripts]
+	if !ok {
+		t.Fatalf("no %q permission declared", PermissionKeyTranscripts)
+	}
+	if p.Kind != permission.KindObserve {
+		t.Errorf("Kind = %v, want %v", p.Kind, permission.KindObserve)
+	}
+	if p.Apply != nil || p.Remove != nil {
+		t.Error("observe-kind permission must not carry Apply/Remove effects")
+	}
+	if p.Writes != nil {
+		t.Error("an observe-kind permission must not declare a ManagedUserFile")
+	}
+}
+
+// TestAgent_Permissions_HooksIsModifyKind checks only what is adapter-specific.
+// Writes' sub-fields (absolute Path, Uninstall, Verify, Version) are asserted
+// registry-wide for every adapter by cmd/irrlichd/managedfiles_test.go,
+// agents/hookverify_test.go and agents/hookversion_test.go; copilot is in
+// All() and inherits all three.
+func TestAgent_Permissions_HooksIsModifyKind(t *testing.T) {
+	p, ok := permissionsByKey(t)[PermissionKeyHooks]
+	if !ok {
+		t.Fatalf("no %q permission declared", PermissionKeyHooks)
+	}
+	if p.Kind != permission.KindModify {
+		t.Errorf("Kind = %v, want %v — an install writes a file", p.Kind, permission.KindModify)
+	}
+	if p.Apply == nil || p.Remove == nil {
+		t.Error("the hooks permission must carry both Apply and Remove effects")
+	}
+	if p.Writes == nil {
+		t.Error("the hooks permission must declare the file it writes")
+	}
+}
+
+func TestAgent_Permissions_ConsentProseIsComplete(t *testing.T) {
+	for _, p := range permissionsByKey(t) {
+		for name, field := range map[string]string{
+			"Title": p.Title, "FeatureUnlocked": p.FeatureUnlocked,
+			"Touches": p.Touches, "Detail": p.Detail,
+		} {
+			if strings.TrimSpace(field) == "" {
+				t.Errorf("%s/%s is empty — the consent wizard renders this to the user", p.Key, name)
 			}
 		}
-		if observes != 1 {
-			t.Errorf("got %d observe-kind permissions, want exactly 1 — PermissionService "+
-				"resolves an adapter to its first observe entry and stops, so any second "+
-				"one is unreachable", observes)
-		}
-	})
-
-	t.Run("transcripts is observe-only", func(t *testing.T) {
-		p, ok := byKey[PermissionKeyTranscripts]
-		if !ok {
-			t.Fatalf("no %q permission declared", PermissionKeyTranscripts)
-		}
-		if p.Kind != permission.KindObserve {
-			t.Errorf("Kind = %v, want %v", p.Kind, permission.KindObserve)
-		}
-		if p.Apply != nil || p.Remove != nil {
-			t.Error("observe-kind permission must not carry Apply/Remove effects")
-		}
-		if p.Writes != nil {
-			t.Error("an observe-kind permission must not declare a ManagedUserFile")
-		}
-	})
-
-	t.Run("hooks is modify-kind with both effects", func(t *testing.T) {
-		p, ok := byKey[PermissionKeyHooks]
-		if !ok {
-			t.Fatalf("no %q permission declared", PermissionKeyHooks)
-		}
-		if p.Kind != permission.KindModify {
-			t.Errorf("Kind = %v, want %v — an install writes a file", p.Kind, permission.KindModify)
-		}
-		if p.Apply == nil || p.Remove == nil {
-			t.Error("the hooks permission must carry both Apply and Remove effects")
-		}
-		// Writes' own sub-fields (Path absolute, Uninstall, Verify, Version)
-		// are asserted registry-wide for every adapter by
-		// cmd/irrlichd/managedfiles_test.go, agents/hookverify_test.go and
-		// agents/hookversion_test.go, so they are deliberately not restated
-		// here — copilot is in All() and inherits all three.
-		if p.Writes == nil {
-			t.Error("the hooks permission must declare the file it writes")
-		}
-	})
-
-	t.Run("consent prose is complete", func(t *testing.T) {
-		for _, p := range byKey {
-			for name, field := range map[string]string{
-				"Title": p.Title, "FeatureUnlocked": p.FeatureUnlocked,
-				"Touches": p.Touches, "Detail": p.Detail,
-			} {
-				if strings.TrimSpace(field) == "" {
-					t.Errorf("%s/%s is empty — the consent wizard renders this to the user", p.Key, name)
-				}
-			}
-		}
-	})
+	}
 }
 
 // TestAgent_NoControlDeclared pins the deliberate omission: backchannel input

--- a/core/adapters/inbound/agents/copilot/adapter_test.go
+++ b/core/adapters/inbound/agents/copilot/adapter_test.go
@@ -145,70 +145,86 @@ func TestAgent_Process_ExactName(t *testing.T) {
 // what the installer actually writes by AssertHookDisclosureMatchesInstalled
 // (hookdisclosure_test.go), which is the check that would catch a stale event
 // list here.
-func TestAgent_Permissions(t *testing.T) {
+// permissionsByKey indexes the real registration once for the subtests below.
+func permissionsByKey(t *testing.T) map[string]agent.Permission {
+	t.Helper()
 	perms := Agent().Permissions
 	if len(perms) != 2 {
 		t.Fatalf("got %d permissions, want exactly 2 (transcripts + hooks)", len(perms))
 	}
-
-	byKey := map[string]agent.Permission{}
-	observes := 0
+	byKey := make(map[string]agent.Permission, len(perms))
 	for _, p := range perms {
 		byKey[p.Key] = p
-		if p.Kind == permission.KindObserve {
-			observes++
-		}
 	}
-	if observes != 1 {
-		t.Errorf("got %d observe-kind permissions, want exactly 1 — "+
-			"PermissionService resolves an adapter to its first observe entry and stops, "+
-			"so any second one is unreachable", observes)
-	}
+	return byKey
+}
 
-	transcripts, ok := byKey[PermissionKeyTranscripts]
-	if !ok {
-		t.Fatalf("no %q permission declared", PermissionKeyTranscripts)
-	}
-	if transcripts.Kind != permission.KindObserve {
-		t.Errorf("transcripts Kind = %v, want %v", transcripts.Kind, permission.KindObserve)
-	}
-	if transcripts.Apply != nil || transcripts.Remove != nil {
-		t.Error("observe-kind permission must not carry Apply/Remove effects")
-	}
-	if transcripts.Writes != nil {
-		t.Error("the transcripts permission must not carry a ManagedUserFile")
-	}
+func TestAgent_Permissions(t *testing.T) {
+	byKey := permissionsByKey(t)
 
-	hooks, ok := byKey[PermissionKeyHooks]
-	if !ok {
-		t.Fatalf("no %q permission declared", PermissionKeyHooks)
-	}
-	if hooks.Kind != permission.KindModify {
-		t.Errorf("hooks Kind = %v, want %v — an install writes a file", hooks.Kind, permission.KindModify)
-	}
-	if hooks.Apply == nil || hooks.Remove == nil {
-		t.Error("the hooks permission must carry both Apply and Remove effects")
-	}
-	if hooks.Writes == nil {
-		t.Fatal("the hooks permission must carry a ManagedUserFile")
-	}
-	if hooks.Writes.Path == nil || hooks.Writes.Uninstall == nil || hooks.Writes.Verify == nil {
-		t.Error("ManagedUserFile must declare Path, Uninstall and Verify")
-	}
-	if hooks.Writes.Version == nil {
-		t.Error("ManagedUserFile must declare a version floor")
-	}
-
-	for _, p := range perms {
-		for name, field := range map[string]string{
-			"Title": p.Title, "FeatureUnlocked": p.FeatureUnlocked,
-			"Touches": p.Touches, "Detail": p.Detail,
-		} {
-			if strings.TrimSpace(field) == "" {
-				t.Errorf("%s/%s is empty — the consent wizard renders this to the user", p.Key, name)
+	t.Run("exactly one observe-kind entry", func(t *testing.T) {
+		observes := 0
+		for _, p := range byKey {
+			if p.Kind == permission.KindObserve {
+				observes++
 			}
 		}
-	}
+		if observes != 1 {
+			t.Errorf("got %d observe-kind permissions, want exactly 1 — PermissionService "+
+				"resolves an adapter to its first observe entry and stops, so any second "+
+				"one is unreachable", observes)
+		}
+	})
+
+	t.Run("transcripts is observe-only", func(t *testing.T) {
+		p, ok := byKey[PermissionKeyTranscripts]
+		if !ok {
+			t.Fatalf("no %q permission declared", PermissionKeyTranscripts)
+		}
+		if p.Kind != permission.KindObserve {
+			t.Errorf("Kind = %v, want %v", p.Kind, permission.KindObserve)
+		}
+		if p.Apply != nil || p.Remove != nil {
+			t.Error("observe-kind permission must not carry Apply/Remove effects")
+		}
+		if p.Writes != nil {
+			t.Error("an observe-kind permission must not declare a ManagedUserFile")
+		}
+	})
+
+	t.Run("hooks is modify-kind with both effects", func(t *testing.T) {
+		p, ok := byKey[PermissionKeyHooks]
+		if !ok {
+			t.Fatalf("no %q permission declared", PermissionKeyHooks)
+		}
+		if p.Kind != permission.KindModify {
+			t.Errorf("Kind = %v, want %v — an install writes a file", p.Kind, permission.KindModify)
+		}
+		if p.Apply == nil || p.Remove == nil {
+			t.Error("the hooks permission must carry both Apply and Remove effects")
+		}
+		// Writes' own sub-fields (Path absolute, Uninstall, Verify, Version)
+		// are asserted registry-wide for every adapter by
+		// cmd/irrlichd/managedfiles_test.go, agents/hookverify_test.go and
+		// agents/hookversion_test.go, so they are deliberately not restated
+		// here — copilot is in All() and inherits all three.
+		if p.Writes == nil {
+			t.Error("the hooks permission must declare the file it writes")
+		}
+	})
+
+	t.Run("consent prose is complete", func(t *testing.T) {
+		for _, p := range byKey {
+			for name, field := range map[string]string{
+				"Title": p.Title, "FeatureUnlocked": p.FeatureUnlocked,
+				"Touches": p.Touches, "Detail": p.Detail,
+			} {
+				if strings.TrimSpace(field) == "" {
+					t.Errorf("%s/%s is empty — the consent wizard renders this to the user", p.Key, name)
+				}
+			}
+		}
+	})
 }
 
 // TestAgent_NoControlDeclared pins the deliberate omission: backchannel input

--- a/core/adapters/inbound/agents/copilot/agent.go
+++ b/core/adapters/inbound/agents/copilot/agent.go
@@ -95,10 +95,13 @@ func Agent() agent.Agent {
 					"`irrlichd --uninstall-hooks`).",
 				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
 				Remove: func() error { _, err := UninstallHooks(); return err },
-				Hooks: &agent.HookInstall{
-					ConfigPath: copilotHooksPath,
-					Uninstall:  UninstallHooks,
-					Verify:     VerifyHooksInstalled,
+				Writes: &agent.ManagedUserFile{
+					Path:      copilotHooksPath,
+					Uninstall: UninstallHooks,
+					// Read-only; the repair it feeds runs through
+					// PermissionService, which re-checks consent under its own
+					// lock before writing (#1372).
+					Verify: VerifyHooksInstalled,
 					Version: &agent.VersionGate{
 						Min:      minCLIVersion,
 						Probe:    []string{"copilot", "--version"},

--- a/core/adapters/inbound/agents/copilot/agent.go
+++ b/core/adapters/inbound/agents/copilot/agent.go
@@ -1,12 +1,31 @@
 package copilot
 
 import (
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/permission"
 )
 
 // PermissionKeyTranscripts gates all GitHub Copilot monitoring (issue #570).
 const PermissionKeyTranscripts = "transcripts"
+
+// displayName is the user-facing CLI name used in consent copy.
+const displayName = "GitHub Copilot CLI"
+
+// Source is the adapter's transcript-tree declaration.
+//
+// The hook receiver's path confiner reads it per request (issue #1361), and
+// Agent() below is its only other caller — one declaration, so the tree the
+// daemon watches and the tree the receiver confines to cannot drift apart.
+func Source() agent.Source {
+	return agent.FilesUnderRoot{
+		Dir:               sessionsDir(),
+		SessionIDFromPath: sessionIDFromPath,
+		Parser: agent.JSONLineParser{
+			NewParser: func() agent.LineParser { return &Parser{} },
+		},
+	}
+}
 
 // Agent returns the GitHub Copilot adapter registration. The Source watches
 // ~/.copilot/session-state and derives each session's ID from the <session-id>
@@ -35,13 +54,7 @@ func Agent() agent.Agent {
 			Match:         agent.ExactName{Name: ProcessName},
 			PIDForSession: DiscoverPID,
 		},
-		Source: agent.FilesUnderRoot{
-			Dir:               sessionsDir(),
-			SessionIDFromPath: sessionIDFromPath,
-			Parser: agent.JSONLineParser{
-				NewParser: func() agent.LineParser { return &Parser{} },
-			},
-		},
+		Source: Source(),
 		Permissions: []agent.Permission{
 			{
 				Key:             PermissionKeyTranscripts,
@@ -57,6 +70,41 @@ func Agent() agent.Agent {
 					"read. Also scans for running copilot processes and reads their working " +
 					"directory to bind a session to its process. Read-only — no file is ever " +
 					"modified. Toggling off stops all reading immediately.",
+			},
+			{
+				Key:             PermissionKeyHooks,
+				Kind:            permission.KindModify,
+				Title:           "Install status hooks",
+				FeatureUnlocked: "Authoritative turn-end detection, and an instant permission-prompt refresh",
+				// Count and event list are derived from installedHookEvents,
+				// never restated: this copy is the consent contract, and
+				// hand-maintaining it is how claudecode's came to promise six
+				// entries against a seven-event install (#1356).
+				Touches: hookjson.EntriesTouched("~/.copilot/hooks/irrlicht.json", installedHookEvents),
+				Detail: "Adds " + hookjson.EventList(installedHookEvents) +
+					" hook entries that POST the hook payload to the local daemon at " +
+					hookEndpointURL() + " via GitHub Copilot's native http hook " +
+					"(no shell, no curl). The file is irrlicht's own — Copilot unions every " +
+					"*.json in that directory, so nothing you wrote there is read or rewritten. " +
+					hookjson.RequiresVersion(displayName, minCLIVersion) +
+					" IMPORTANT: Copilot refuses to deliver http hooks to a loopback address " +
+					"unless " + RequiresLocalhostOptIn + "=1 is set in the environment Copilot " +
+					"itself runs in. irrlicht cannot set that for you, and until you export it " +
+					"these entries are written but never fire. " +
+					"Toggling off removes exactly these entries (also available via " +
+					"`irrlichd --uninstall-hooks`).",
+				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
+				Remove: func() error { _, err := UninstallHooks(); return err },
+				Hooks: &agent.HookInstall{
+					ConfigPath: copilotHooksPath,
+					Uninstall:  UninstallHooks,
+					Verify:     VerifyHooksInstalled,
+					Version: &agent.VersionGate{
+						Min:      minCLIVersion,
+						Probe:    []string{"copilot", "--version"},
+						Observed: newestObservedCLIVersion,
+					},
+				},
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/copilot/hookdefaulthome_test.go
+++ b/core/adapters/inbound/agents/copilot/hookdefaulthome_test.go
@@ -1,0 +1,83 @@
+// hookdefaulthome_test.go covers the configuration every ordinary user is in:
+// COPILOT_HOME unset.
+//
+// Every other hook test in this package relocates COPILOT_HOME to an absolute
+// t.TempDir(), which is the one spelling that hides this defect. With the
+// variable unset, sessionsDir() returns the $HOME-RELATIVE literal
+// ".copilot/session-state", and PathConfiner.Confine refuses a non-absolute
+// path outright (RejectRelativePath) before it ever looks at the roots — so a
+// reconstructed transcript path is thrown away and the Notification branch
+// dispatches nothing at all.
+package copilot
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestNotification_DispatchesWithDefaultHome is the regression test for that
+// defect: the permission-prompt acceleration must work for a user who has
+// never heard of COPILOT_HOME.
+func TestNotification_DispatchesWithDefaultHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(copilotHomeEnvVar, "") // the default configuration
+
+	root := filepath.Join(home, ".copilot", "session-state")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	want := writeSessionTranscript(t, root, "sess-default")
+
+	target := &mockTarget{}
+	confiner := TranscriptConfiner()
+	h := NewHookHandlerWithConfiner(target,
+		keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, mockLogger{}, confiner)
+
+	rec := post(t, h, notificationBody("sess-default", "permission_prompt"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	perms := target.perms()
+	if len(perms) != 1 {
+		t.Fatalf("got %d permission dispatches with COPILOT_HOME unset, want 1 "+
+			"(confiner rejections: %v) — the reconstructed path must be absolute, or the "+
+			"permission-prompt half of the channel is dead for every default install",
+			len(perms), confiner.Rejections())
+	}
+	if perms[0].transcriptPath != want {
+		t.Errorf("transcriptPath = %q, want %q", perms[0].transcriptPath, want)
+	}
+	if n := confiner.RejectionCount(); n != 0 {
+		t.Errorf("confiner counted %d rejection(s) for a legitimate prompt (%v) — this "+
+			"pollutes the counter whose purpose is to signal local probing",
+			n, confiner.Rejections())
+	}
+}
+
+// TestStop_DispatchesWithDefaultHome pins that the turn-end half, which
+// receives an absolute transcript_path from Copilot, is unaffected — so the
+// fix above is not masking a broader breakage.
+func TestStop_DispatchesWithDefaultHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(copilotHomeEnvVar, "")
+
+	root := filepath.Join(home, ".copilot", "session-state")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tp := writeSessionTranscript(t, root, "sess-default")
+
+	target := &mockTarget{}
+	h := NewHookHandlerWithConfiner(target,
+		keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, mockLogger{}, TranscriptConfiner())
+
+	post(t, h, contractPayload(tp, HookStop))
+	if n := len(target.stops()); n != 1 {
+		t.Fatalf("got %d Stop dispatches with COPILOT_HOME unset, want 1", n)
+	}
+}

--- a/core/adapters/inbound/agents/copilot/hookdisclosure_test.go
+++ b/core/adapters/inbound/agents/copilot/hookdisclosure_test.go
@@ -1,0 +1,26 @@
+// hookdisclosure_test.go wires the Copilot hooks permission into the shared
+// issue #1356 contract: the consent copy names every event the installer
+// writes, states the right entry count, and names no event it does not
+// install. This is a LOCK — the copy is derived from installedHookEvents via
+// hookjson.EntriesTouched/EventList rather than hand-written, so it passes by
+// construction; the contract is what keeps it that way when the event set
+// changes.
+package copilot
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DisclosureMatchesInstalled(t *testing.T) {
+	contracttesting.AssertHookDisclosureMatchesInstalled(t, contracttesting.HookDisclosure{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		// "GitHub" is CamelCase by the contract's token rule but is a vendor
+		// name, not a hook event — it reaches the copy through displayName in
+		// hookjson.RequiresVersion.
+		NonEventTerms: []string{"GitHub"},
+	})
+}

--- a/core/adapters/inbound/agents/copilot/hookinstaller.go
+++ b/core/adapters/inbound/agents/copilot/hookinstaller.go
@@ -1,0 +1,295 @@
+// hookinstaller.go manages GitHub Copilot CLI hook entries in
+// $COPILOT_HOME/hooks/irrlicht.json for the irrlicht daemon (issue #1378,
+// epic #1355 Phase D).
+//
+// Copilot reads every *.json file in its user-level hooks directory and unions
+// them — there is no precedence and no shadowing — so irrlicht owns one
+// dedicated file rather than merging into a shared config. A malformed write
+// can therefore never break a hook the user authored themselves, and uninstall
+// is a removal from a file nothing else writes.
+//
+// Delivery is Copilot's native `type: "http"` hook: no shell spawn, no curl on
+// PATH, no beacon. The one cost is an environment variable — see
+// RequiresLocalhostOptIn below, which is the finding this phase turned up.
+package copilot
+
+import (
+	"os"
+	"path/filepath"
+
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/pkg/daemonaddr"
+)
+
+// HookEndpointPath is the daemon's Copilot hook path. Host and port are
+// resolved at install time from the daemon's own bind address, so a daemon on
+// an alternate port installs hooks that reach it rather than whatever owns
+// :7837 (issue #1178). Exported so the daemon's route comes from the same
+// constant the installer writes and matches on.
+const HookEndpointPath = "/api/v1/hooks/copilot"
+
+// hookSentinel identifies irrlicht-managed entries. Deliberately the bare
+// endpoint path and therefore port-independent: a sentinel carrying a port
+// would stop recognizing our own entries the moment the daemon moves,
+// orphaning them and appending a duplicate group instead of upgrading in
+// place (issue #1178).
+const hookSentinel = HookEndpointPath
+
+// RequiresLocalhostOptIn names the environment variable Copilot requires
+// before it will deliver an http hook to a loopback address.
+//
+// This is NOT one of the two https-enforcement rules the Phase C audit
+// reasoned from. Those are narrow: the allowedEnvVars rule only bites when
+// allowedEnvVars is set, and the authorization-affecting rule names only
+// preToolUse / preMcpToolCall / permissionRequest — none of which we install.
+// A third, broader rule sits underneath both: an SSRF guard that refuses every
+// http hook whose URL resolves to a loopback, private or link-local address,
+// regardless of event or configuration. Verified live against CLI 1.0.78 by
+// installing this exact hook file and running a session both ways:
+//
+//	without the variable, every delivery is refused and logged as
+//	  HTTP hook URL "http://127.0.0.1:<port>/api/v1/hooks/copilot" resolves to
+//	  blocked address 127.0.0.1. URLs must not target loopback, private, or
+//	  link-local addresses.
+//	with COPILOT_HOOK_ALLOW_LOCALHOST=1, the same file delivers normally.
+//
+// The daemon cannot set this for the user: Copilot reads it from its own
+// process environment, and irrlicht does not launch Copilot. It therefore has
+// to be stated in the consent copy so the user knows the channel is inert
+// until they export it.
+const RequiresLocalhostOptIn = "COPILOT_HOOK_ALLOW_LOCALHOST"
+
+// minCLIVersion is the lowest Copilot version whose hook event set includes
+// every event we install, with the semantics we depend on.
+//
+// 1.0.26 is the notification event's guarantee boundary: below 1.0.18 there is
+// no notification event at all, and 1.0.18–1.0.25 fires it even when no prompt
+// was actually shown, which would manufacture false waiting states. From
+// 1.0.26 the event fires only when a prompt is really displayed.
+const minCLIVersion = "1.0.26"
+
+// hookEventSince records the Copilot version each installed event is proven to
+// exist at. minCLIVersion must be >= every value here, which
+// AssertHookVersionGate enforces.
+//
+// Both are pinned to the notification guarantee boundary rather than to a
+// separately-established date. Stop (Copilot's Claude-compat alias for its
+// native agentStop) was verified live only on 1.0.78, the version installed on
+// the machine this was developed against; that it also exists at 1.0.26 is
+// ASSUMED, not measured. The assumption is safe in the direction that matters:
+// if Stop turned out to be newer than 1.0.26, the gate would let an
+// in-between CLI receive an entry it ignores, which costs a missing turn-end
+// push and nothing else — the transcript already covers turn end.
+var hookEventSince = map[string]string{
+	HookNotification: "1.0.26",
+	HookStop:         "1.0.26",
+}
+
+// installedHookEvents are the Copilot hook events we install handlers for.
+//
+// Deliberately only two, and deliberately NOT these:
+//
+//   - preToolUse / permissionRequest are excluded on safety grounds. Both fire
+//     on every tool call, the matcher grammar filters on tool name only, and
+//     since 1.0.57 a preToolUse hook that merely errors DENIES the tool call
+//     (exit 2 denies it explicitly since 1.0.70). Hooking either would break
+//     the user's tool calls whenever the daemon is down — a fail-closed hazard
+//     irrlicht must never introduce into someone else's agent.
+//   - userPromptSubmitted is excluded on evidence. Its envelope carries no
+//     transcript path at all, so the receiver would have to reconstruct one to
+//     satisfy path confinement, and the domain has no turn-start signal to map
+//     it to; the transcript's own user.message already opens the turn.
+//   - postToolUse is excluded because we install no hold for it to release —
+//     see hooks.go on why the permission prompt is dispatch-only.
+var installedHookEvents = []string{
+	HookNotification,
+	HookStop,
+}
+
+// matcherForEvent returns the matcher we install for the given event. Neither
+// installed event is tool-scoped, so both take no matcher and hookjson omits
+// the key entirely.
+func matcherForEvent(string) string { return "" }
+
+// ourHookEntry builds the inner hook object we install: Copilot's native http
+// delivery, pointed at the daemon's resolved endpoint.
+//
+// No timeout key is written. Copilot accepts the entry without one (verified
+// live on 1.0.78), and both installed events are structurally non-blocking on
+// Copilot's side — they are dispatched fire-and-forget and can never stall a
+// turn — so a timeout would bound nothing that needs bounding.
+func ourHookEntry() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "http",
+		"url":  hookEndpointURL(),
+	}
+}
+
+// hookEndpointURL is the daemon endpoint the installed hook posts to.
+func hookEndpointURL() string {
+	return daemonaddr.LocalURL(HookEndpointPath)
+}
+
+// hookConfig describes this adapter's install to the shared hookjson
+// machinery: which file to merge into, which sentinel marks our entries, which
+// events get installed, and what the canonical inner entry looks like.
+//
+// Copilot's own documented hook file shape is flat — an event maps straight to
+// an array of entries — whereas hookjson writes Claude Code's nested
+// matcher-group shape. Copilot accepts both: verified live on 1.0.78 by
+// installing exactly what hookjson emits (nested group, and no "version" key,
+// which hookjson never writes) and observing the Stop hook deliver. That is
+// what lets this adapter reuse hookjson unmodified.
+func hookConfig(path string) hookjson.Config {
+	return hookjson.Config{
+		Path:        path,
+		Sentinel:    hookSentinel,
+		Events:      installedHookEvents,
+		MatcherFor:  matcherForEvent,
+		Entry:       ourHookEntry,
+		IsCanonical: hookEntryIsCanonical,
+		WriteFile:   atomicWriteFile,
+	}
+}
+
+// EnsureHooksInstalled adds irrlicht hook entries to
+// $COPILOT_HOME/hooks/irrlicht.json if they are not already present. Creates
+// the file (and the hooks directory) if absent. Returns true if the file was
+// modified.
+func EnsureHooksInstalled() (bool, error) {
+	path, err := copilotHooksPath()
+	if err != nil {
+		return false, err
+	}
+	return hookjson.EnsureInstalled(hookConfig(path))
+}
+
+// VerifyHooksInstalled reports which of our entries are missing from, or stale
+// in, the hooks file — without writing anything (issue #1372). Same hookConfig
+// as the installer, so "stale" means exactly what EnsureHooksInstalled would
+// rewrite.
+func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
+	path, err := copilotHooksPath()
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	return hookjson.Verify(hookConfig(path))
+}
+
+// UninstallHooks removes irrlicht hook entries from the hooks file. Returns
+// true if the file was modified.
+func UninstallHooks() (bool, error) {
+	path, err := copilotHooksPath()
+	if err != nil {
+		return false, err
+	}
+	return hookjson.Uninstall(hookConfig(path))
+}
+
+// newestObservedCLIVersion returns the copilotVersion recorded in the most
+// recently modified Copilot transcript, or "" if none is found. It is the
+// install-time proxy for "the running Copilot version": the adapter captures
+// copilotVersion from each session's session.start header (parser.go), so the
+// newest transcript reflects the CLI the user is running now.
+//
+// It resolves the ABSOLUTE sessions dir rather than the possibly
+// $HOME-relative sessionsDir(), which would make this walk run against the
+// daemon's CWD and always find nothing.
+func newestObservedCLIVersion() string {
+	dir, err := copilotSessionsDir()
+	if err != nil {
+		return ""
+	}
+	newestPath := agentpaths.NewestFileWithSuffix(dir, transcriptFilename)
+	if newestPath == "" {
+		return ""
+	}
+	return sessionStartVersion(newestPath)
+}
+
+// --- helpers ---
+
+// copilotHome resolves the absolute Copilot config directory, honoring an
+// absolute COPILOT_HOME override (mirroring sessionsDir's resolution), else
+// $HOME/.copilot.
+func copilotHome() (string, error) {
+	if h := os.Getenv(copilotHomeEnvVar); filepath.IsAbs(h) {
+		return h, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".copilot"), nil
+}
+
+// copilotSessionsDir resolves the absolute session-state tree with symlinks
+// resolved, so containment checks against it compare like with like (on macOS
+// both /tmp and a home directory routinely reach the real path through a
+// symlink).
+//
+// Derived from the adapter's own declared root rather than re-assembled from
+// constants: that second derivation is exactly what issue #1361 removed from
+// the hook receiver, and leaving a copy here would let the tree the installer
+// walks drift from the one the daemon watches.
+func copilotSessionsDir() (string, error) {
+	root, err := agentpaths.AbsRoot(sessionsDir())
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(root)
+}
+
+// copilotHooksPath is the dedicated file irrlicht owns inside Copilot's
+// user-level hooks directory. Copilot unions every *.json in that directory,
+// so owning one file keeps our writes off anything the user authored.
+//
+// The directory is the same on all three OSes — Copilot does not use a
+// platform config dir here — so no per-GOOS branch is needed.
+func copilotHooksPath() (string, error) {
+	home, err := copilotHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "hooks", "irrlicht.json"), nil
+}
+
+// atomicWriteFile writes data to path via a temp file + rename so a reader (or
+// Copilot) never observes a half-written hook file. Creates the parent dir.
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".irrlicht-hooks-*.json.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// hookEntryIsCanonical reports whether an inner hook object already matches the
+// current canonical form: an http entry pointing at our currently resolved
+// endpoint. An entry left behind by a daemon on a different port reads as
+// stale and is rewritten in place rather than duplicated (#1178).
+func hookEntryIsCanonical(hook map[string]interface{}) bool {
+	t, _ := hook["type"].(string)
+	url, _ := hook["url"].(string)
+	return t == "http" && url == hookEndpointURL()
+}

--- a/core/adapters/inbound/agents/copilot/hookinstaller.go
+++ b/core/adapters/inbound/agents/copilot/hookinstaller.go
@@ -50,10 +50,17 @@ const hookSentinel = HookEndpointPath
 // installing this exact hook file and running a session both ways:
 //
 //	without the variable, every delivery is refused and logged as
-//	  HTTP hook URL "http://127.0.0.1:<port>/api/v1/hooks/copilot" resolves to
+//	  HTTP hook URL "http://localhost:<port>/api/v1/hooks/copilot" resolves to
 //	  blocked address 127.0.0.1. URLs must not target loopback, private, or
 //	  link-local addresses.
 //	with COPILOT_HOOK_ALLOW_LOCALHOST=1, the same file delivers normally.
+//
+// The quoted refusal uses the "localhost" spelling this installer actually
+// writes (daemonaddr.LocalURL), not a 127.0.0.1 literal — the guard resolves
+// the host before judging it, so both spellings are refused identically. That
+// distinction is deliberate evidence, because the consent copy makes an
+// absolute claim about the channel being inert without the variable, and a
+// literal-IP-only guard would have made that claim wrong.
 //
 // The daemon cannot set this for the user: Copilot reads it from its own
 // process environment, and irrlicht does not launch Copilot. It therefore has
@@ -66,8 +73,16 @@ const RequiresLocalhostOptIn = "COPILOT_HOOK_ALLOW_LOCALHOST"
 //
 // 1.0.26 is the notification event's guarantee boundary: below 1.0.18 there is
 // no notification event at all, and 1.0.18–1.0.25 fires it even when no prompt
-// was actually shown, which would manufacture false waiting states. From
-// 1.0.26 the event fires only when a prompt is really displayed.
+// was actually shown. From 1.0.26 the event fires only when a prompt is really
+// displayed.
+//
+// Note what a spurious notification would and would not cost HERE. It could not
+// manufacture a false waiting state — this adapter's notification branch takes
+// no hold at all (see hooks.go) — but it would inject a synthetic activity
+// event, and forceReadyToWorkingIfActive can bounce a ready session to WORKING
+// on one. That is the concrete harm the floor prevents; stating it accurately
+// matters because a floor defended by a reason someone can disprove is a floor
+// that gets lowered.
 const minCLIVersion = "1.0.26"
 
 // hookEventSince records the Copilot version each installed event is proven to
@@ -180,12 +195,40 @@ func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
 
 // UninstallHooks removes irrlicht hook entries from the hooks file. Returns
 // true if the file was modified.
+//
+// Unlike claudecode's settings.json and codex's hooks.json, this file is one
+// irrlicht CREATED and nothing else writes — so removing our entries and
+// leaving an empty document behind is the same failure #1371 fixed one level
+// up: revoking consent has to give the user their directory back, not leave a
+// stray file they never made. hookjson.Uninstall drops the "hooks" key; if
+// that empties the document entirely, the file itself goes too.
+//
+// Gated on the document being empty, so a hook the user hand-added to our file
+// keeps it alive (Copilot unions every *.json in the directory, so that is a
+// legitimate thing for them to have done) — TestUninstallLeavesForeignEntriesAlone
+// covers that side.
 func UninstallHooks() (bool, error) {
 	path, err := copilotHooksPath()
 	if err != nil {
 		return false, err
 	}
-	return hookjson.Uninstall(hookConfig(path))
+	modified, err := hookjson.Uninstall(hookConfig(path))
+	if err != nil || !modified {
+		return modified, err
+	}
+	removeIfEmpty(path)
+	return true, nil
+}
+
+// removeIfEmpty deletes path when it holds no keys at all. Best-effort: a
+// failure to remove leaves an inert empty file, which is strictly better than
+// failing an uninstall that already succeeded.
+func removeIfEmpty(path string) {
+	settings, err := hookjson.ReadSettings(path)
+	if err != nil || len(settings) > 0 {
+		return
+	}
+	_ = os.Remove(path)
 }
 
 // newestObservedCLIVersion returns the copilotVersion recorded in the most
@@ -226,9 +269,14 @@ func copilotHome() (string, error) {
 }
 
 // copilotSessionsDir resolves the absolute session-state tree with symlinks
-// resolved, so containment checks against it compare like with like (on macOS
-// both /tmp and a home directory routinely reach the real path through a
-// symlink).
+// resolved, so the WalkDir below is handed a real directory and a
+// "no sessions yet" tree fails cleanly to "" rather than to an error.
+//
+// It is NOT the receiver's confinement root: hookjson.PathConfiner resolves its
+// own roots (see confine.go), and the receiver deliberately confines against
+// the DECLARED, un-resolved root so its path key matches the fswatcher's. Said
+// explicitly because assuming otherwise is what makes the $HOME-relative
+// hazard in resolveTranscriptPath easy to miss.
 //
 // Derived from the adapter's own declared root rather than re-assembled from
 // constants: that second derivation is exactly what issue #1361 removed from

--- a/core/adapters/inbound/agents/copilot/hookinstaller.go
+++ b/core/adapters/inbound/agents/copilot/hookinstaller.go
@@ -90,7 +90,15 @@ const RequiresLocalhostOptIn = "COPILOT_HOOK_ALLOW_LOCALHOST"
 // on one. That is the concrete harm the floor prevents; stating it accurately
 // matters because a floor defended by a reason someone can disprove is a floor
 // that gets lowered.
-const minCLIVersion = "1.0.26"
+const minCLIVersion = notificationGuaranteeSince
+
+// notificationGuaranteeSince is the Copilot version from which the
+// notification event is guaranteed to fire ONLY when a prompt was really
+// shown. Named once and referenced by both the floor above and every
+// hookEventSince entry below, which is honest rather than merely DRY: the two
+// installed events are pinned to this one boundary, and a future event with
+// its own arrival version gets its own constant rather than reusing this.
+const notificationGuaranteeSince = "1.0.26"
 
 // hookEventSince records the Copilot version each installed event is proven to
 // exist at. minCLIVersion must be >= every value here, which
@@ -105,8 +113,8 @@ const minCLIVersion = "1.0.26"
 // in-between CLI receive an entry it ignores, which costs a missing turn-end
 // push and nothing else — the transcript already covers turn end.
 var hookEventSince = map[string]string{
-	HookNotification: "1.0.26",
-	HookStop:         "1.0.26",
+	HookNotification: notificationGuaranteeSince,
+	HookStop:         notificationGuaranteeSince,
 }
 
 // installedHookEvents are the Copilot hook events we install handlers for.

--- a/core/adapters/inbound/agents/copilot/hookinstaller.go
+++ b/core/adapters/inbound/agents/copilot/hookinstaller.go
@@ -14,14 +14,21 @@
 package copilot
 
 import (
+	"bufio"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"irrlicht/core/adapters/inbound/agents/agentpaths"
 	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/pkg/daemonaddr"
 )
+
+// copilotHomeDirName is the $HOME-relative Copilot config directory, the
+// parent of both session-state/ (adapter.go's defaultRootDir) and hooks/.
+const copilotHomeDirName = ".copilot"
 
 // HookEndpointPath is the daemon's Copilot hook path. Host and port are
 // resolved at install time from the daemon's own bind address, so a daemon on
@@ -254,18 +261,17 @@ func newestObservedCLIVersion() string {
 
 // --- helpers ---
 
-// copilotHome resolves the absolute Copilot config directory, honoring an
-// absolute COPILOT_HOME override (mirroring sessionsDir's resolution), else
-// $HOME/.copilot.
+// copilotHome resolves the absolute Copilot config directory: $COPILOT_HOME
+// when that override is set and absolute, else $HOME/.copilot.
+//
+// Composed from agentpaths rather than re-deciding the rule with a bare
+// filepath.IsAbs. agentpaths owns "how an agent home override is read" for the
+// whole repo precisely so it is not reimplemented per adapter; the hand-rolled
+// version silently dropped a RELATIVE COPILOT_HOME, so the watcher warned the
+// user their value was ignored while the installer said nothing and wrote to a
+// different directory than the one being watched.
 func copilotHome() (string, error) {
-	if h := os.Getenv(copilotHomeEnvVar); filepath.IsAbs(h) {
-		return h, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".copilot"), nil
+	return agentpaths.AbsRoot(agentpaths.FromEnv("copilot", copilotHomeEnvVar, copilotHomeDirName))
 }
 
 // copilotSessionsDir resolves the absolute session-state tree with symlinks
@@ -341,3 +347,54 @@ func hookEntryIsCanonical(hook map[string]interface{}) bool {
 	url, _ := hook["url"].(string)
 	return t == "http" && url == hookEndpointURL()
 }
+
+// sessionStartVersion reads copilotVersion from a transcript's session.start
+// header. Returns "" if the header is missing or unreadable.
+//
+// Bounded to the first few lines: session.start is the first event Copilot
+// writes, and an unbounded scan of a large transcript at install time would be
+// paid for nothing.
+func sessionStartVersion(path string) string {
+	// Sink-local traversal guard. The only caller hands over a path produced by
+	// WalkDir over a self-resolved root, so this is not reachable in practice —
+	// but the plain ".." check is the form CodeQL's go/path-injection query
+	// recognizes as a sanitizer (the root derives from COPILOT_HOME, a taint
+	// source), and both sibling adapters carry it for exactly that reason: see
+	// codex/session_meta.go and claudecode/hookinstaller.go. A rejected path
+	// falls through to the same "unknown version" result an unreadable file
+	// already produces, which fails OPEN to the version gate's Probe.
+	if strings.Contains(path, "..") {
+		return ""
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxVersionScanLineBytes)
+	for i := 0; i < maxVersionScanLines && scanner.Scan(); i++ {
+		var line struct {
+			Type string         `json:"type"`
+			Data map[string]any `json:"data"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			continue
+		}
+		if line.Type != evSessionStart {
+			continue
+		}
+		return str(line.Data, "copilotVersion")
+	}
+	return ""
+}
+
+const (
+	// maxVersionScanLines bounds how far into a transcript the version probe
+	// reads before giving up.
+	maxVersionScanLines = 20
+	// maxVersionScanLineBytes bounds a single line, so an oversized transcript
+	// line cannot make the probe allocate without limit (cell 2-16).
+	maxVersionScanLineBytes = 1 << 20
+)

--- a/core/adapters/inbound/agents/copilot/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/copilot/hookinstaller_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/permission"
 	"irrlicht/core/internal/contracttesting"
 )
@@ -28,18 +29,22 @@ func hooksPermission(t *testing.T) (apply, remove func() error) {
 
 // hooksFileHasOurEntries reports whether the hooks file currently holds an
 // irrlicht entry for every installed event.
+//
+// Uses hookjson's OWN predicates rather than a hand-rolled walk, so the test
+// agrees with the installer by construction. A local copy was both a second
+// encoding of the nested group shape and strictly WEAKER: matching on the
+// url's last path segment alone accepts a foreign entry at
+// https://example.invalid/copilot, and accepts a stale-port entry the
+// installer would rewrite — which would have made the permission-gate and
+// uninstall assertions below pass against entries production considers wrong.
 func hooksFileHasOurEntries(t *testing.T) bool {
 	t.Helper()
 	path, err := copilotHooksPath()
 	if err != nil {
 		t.Fatalf("copilotHooksPath: %v", err)
 	}
-	data, err := os.ReadFile(path)
+	settings, err := hookjson.ReadSettings(path)
 	if err != nil {
-		return false
-	}
-	var settings map[string]interface{}
-	if err := json.Unmarshal(data, &settings); err != nil {
 		return false
 	}
 	hooks, ok := settings["hooks"].(map[string]interface{})
@@ -47,39 +52,11 @@ func hooksFileHasOurEntries(t *testing.T) bool {
 		return false
 	}
 	for _, ev := range installedHookEvents {
-		if !hooksJSONHasEvent(hooks, ev) {
+		if !hookjson.HasOurHook(hooks, ev, hookSentinel) {
 			return false
 		}
 	}
 	return true
-}
-
-func hooksJSONHasEvent(hooks map[string]interface{}, event string) bool {
-	groups, ok := hooks[event].([]interface{})
-	if !ok {
-		return false
-	}
-	for _, g := range groups {
-		group, ok := g.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		inner, ok := group["hooks"].([]interface{})
-		if !ok {
-			continue
-		}
-		for _, h := range inner {
-			entry, ok := h.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			if url, _ := entry["url"].(string); url != "" &&
-				filepath.Base(url) == filepath.Base(HookEndpointPath) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // TestHooksPermission_IsGated wires the install-type flavour of the #797

--- a/core/adapters/inbound/agents/copilot/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/copilot/hookinstaller_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"irrlicht/core/domain/permission"
@@ -200,18 +201,37 @@ func TestUninstallLeavesForeignEntriesAlone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("file gone after uninstall, user entry lost: %v", err)
 	}
-	if !contains(string(data), "example.invalid/mine") {
+	if !strings.Contains(string(data), "example.invalid/mine") {
 		t.Error("uninstall removed a hook entry irrlicht did not install")
 	}
 }
 
-func contains(haystack, needle string) bool {
-	return len(haystack) >= len(needle) && (func() bool {
-		for i := 0; i+len(needle) <= len(haystack); i++ {
-			if haystack[i:i+len(needle)] == needle {
-				return true
-			}
-		}
-		return false
-	})()
+// TestUninstallGivesTheDirectoryBack pins the consent-hygiene half of
+// uninstall. This hook file is one irrlicht created and nothing else writes,
+// so leaving an empty `{}` behind after a revoke is the same failure #1371
+// fixed one level up: the user does not get their directory back.
+func TestUninstallGivesTheDirectoryBack(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(copilotHomeEnvVar, home)
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	path, err := copilotHooksPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("install did not create %s: %v", path, err)
+	}
+
+	if _, err := UninstallHooks(); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		data, _ := os.ReadFile(path)
+		t.Errorf("uninstall left %s behind (content %q) — irrlicht created this file "+
+			"and nothing else writes it, so revoking consent must remove it", path, string(data))
+	}
 }

--- a/core/adapters/inbound/agents/copilot/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/copilot/hookinstaller_test.go
@@ -1,0 +1,217 @@
+// hookinstaller_test.go covers the writing half: the install-type permission
+// gate (#797), and the install/verify/uninstall round trip against Copilot's
+// own hooks directory.
+package copilot
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/internal/contracttesting"
+)
+
+// hooksPermission returns the real declared hooks permission.
+func hooksPermission(t *testing.T) (apply, remove func() error) {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			return p.Apply, p.Remove
+		}
+	}
+	t.Fatal("no hooks permission declared")
+	return nil, nil
+}
+
+// hooksFileHasOurEntries reports whether the hooks file currently holds an
+// irrlicht entry for every installed event.
+func hooksFileHasOurEntries(t *testing.T) bool {
+	t.Helper()
+	path, err := copilotHooksPath()
+	if err != nil {
+		t.Fatalf("copilotHooksPath: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return false
+	}
+	hooks, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	for _, ev := range installedHookEvents {
+		if !hooksJSONHasEvent(hooks, ev) {
+			return false
+		}
+	}
+	return true
+}
+
+func hooksJSONHasEvent(hooks map[string]interface{}, event string) bool {
+	groups, ok := hooks[event].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, g := range groups {
+		group, ok := g.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		inner, ok := group["hooks"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, h := range inner {
+			entry, ok := h.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if url, _ := entry["url"].(string); url != "" &&
+				filepath.Base(url) == filepath.Base(HookEndpointPath) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestHooksPermission_IsGated wires the install-type flavour of the #797
+// contract: nothing is written while the permission is pending, granting
+// writes the entries, and denying removes them again.
+func TestHooksPermission_IsGated(t *testing.T) {
+	t.Setenv(copilotHomeEnvVar, t.TempDir())
+	apply, remove := hooksPermission(t)
+
+	state := permission.StatePending
+	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+		SetState: func(s permission.State) { state = s },
+		Exercise: func() {
+			switch state {
+			case permission.StateGranted:
+				if err := apply(); err != nil {
+					t.Fatalf("apply: %v", err)
+				}
+			case permission.StateDenied:
+				if err := remove(); err != nil {
+					t.Fatalf("remove: %v", err)
+				}
+			}
+		},
+		Observe: func() bool { return hooksFileHasOurEntries(t) },
+	})
+}
+
+// TestInstallVerifyUninstall_RoundTrip pins the three-way agreement between
+// what the installer writes, what Verify reports, and what Uninstall removes.
+func TestInstallVerifyUninstall_RoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(copilotHomeEnvVar, home)
+
+	status, err := VerifyHooksInstalled()
+	if err != nil {
+		t.Fatalf("verify before install: %v", err)
+	}
+	if status.Intact() {
+		t.Error("Verify reports intact before anything was installed")
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !modified {
+		t.Error("first install reported no modification")
+	}
+
+	if status, err = VerifyHooksInstalled(); err != nil || !status.Intact() {
+		t.Errorf("Verify after install: intact=%v err=%v damage=%s", status.Intact(), err, status.Damage())
+	}
+
+	// Idempotent: a second install changes nothing.
+	if modified, err = EnsureHooksInstalled(); err != nil || modified {
+		t.Errorf("second install modified=%v err=%v, want false/nil", modified, err)
+	}
+
+	if modified, err = UninstallHooks(); err != nil || !modified {
+		t.Errorf("uninstall modified=%v err=%v, want true/nil", modified, err)
+	}
+	if hooksFileHasOurEntries(t) {
+		t.Error("entries survive uninstall")
+	}
+}
+
+// TestVerifyDoesNotCreateTheConfigFile is the read-only half of #1372, checked
+// here as well as by the registry tripwire because this adapter's config path
+// is a file inside a directory that may not exist either.
+func TestVerifyDoesNotCreateTheConfigFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(copilotHomeEnvVar, home)
+
+	if _, err := VerifyHooksInstalled(); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "hooks")); !os.IsNotExist(err) {
+		t.Errorf("Verify created the hooks directory; it must be read-only")
+	}
+}
+
+// TestUninstallLeavesForeignEntriesAlone pins that a hook the user wrote in
+// our own file is preserved. Copilot unions every *.json in the directory, so
+// a user could legitimately add one to irrlicht.json by hand.
+func TestUninstallLeavesForeignEntriesAlone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(copilotHomeEnvVar, home)
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	path, err := copilotHooksPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatal(err)
+	}
+	hooks := settings["hooks"].(map[string]interface{})
+	hooks["Stop"] = append(hooks["Stop"].([]interface{}), map[string]interface{}{
+		"hooks": []interface{}{map[string]interface{}{"type": "http", "url": "https://example.invalid/mine"}},
+	})
+	out, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := UninstallHooks(); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	data, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("file gone after uninstall, user entry lost: %v", err)
+	}
+	if !contains(string(data), "example.invalid/mine") {
+		t.Error("uninstall removed a hook entry irrlicht did not install")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (func() bool {
+		for i := 0; i+len(needle) <= len(haystack); i++ {
+			if haystack[i:i+len(needle)] == needle {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/core/adapters/inbound/agents/copilot/hookpath_test.go
+++ b/core/adapters/inbound/agents/copilot/hookpath_test.go
@@ -1,0 +1,41 @@
+// hookpath_test.go wires this adapter's hook receiver into the shared issue
+// #1361 contract: a caller-supplied transcript path is confined to the
+// adapter's declared roots, symlinks resolved first, and anything outside is
+// refused, logged, counted — and still answered 2xx.
+package copilot
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHookPathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, contracttesting.HookReceiver{
+		Root: copilotSessionRoot,
+		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			confiner := TranscriptConfiner()
+			return contracttesting.HookReceiverUnderTest{
+				Handler:    NewHookHandlerWithConfiner(target, nil, mockLogger{}, confiner),
+				Observed:   func() bool { return target.totalCalls() > 0 },
+				Rejections: confiner.RejectionCount,
+			}
+		},
+		NewProduction: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.HookReceiverUnderTest{
+				Handler:  NewHookHandler(target, nil, mockLogger{}),
+				Observed: func() bool { return target.totalCalls() > 0 },
+			}
+		},
+		WriteTranscript: writeContractTranscript,
+		TranscriptExt:   transcriptExt,
+		PayloadFor: func(transcriptPath string) string {
+			return contractPayload(transcriptPath, HookStop)
+		},
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/copilot/hookport_test.go
+++ b/core/adapters/inbound/agents/copilot/hookport_test.go
@@ -1,0 +1,60 @@
+// hookport_test.go wires the Copilot hook installer into the shared issue
+// #1178 contract: the endpoint it writes follows the daemon's bind address, an
+// entry left by a daemon on a different port is rewritten in place rather than
+// duplicated, and uninstall is not port-scoped.
+package copilot
+
+import (
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/pkg/daemonaddr"
+)
+
+// TestHookEntry_DefaultPortForm pins the exact object Copilot reads, which the
+// shared contract deliberately does not look at — it only cares that the
+// endpoint inside follows the bind address.
+//
+// Two things here are load-bearing and were both verified live against CLI
+// 1.0.78. The type is "http", Copilot's native delivery, so nothing spawns a
+// shell and curl need not be on PATH. And there is no timeout key: Copilot
+// accepts the entry without one, and both installed events are dispatched
+// fire-and-forget on its side, so there is nothing for a timeout to bound.
+func TestHookEntry_DefaultPortForm(t *testing.T) {
+	t.Setenv(daemonaddr.EnvBindAddr, "")
+	entry := ourHookEntry()
+	if got, want := entry["type"], "http"; got != want {
+		t.Errorf("type = %v, want %v", got, want)
+	}
+	if got, want := entry["url"], "http://localhost:7837/api/v1/hooks/copilot"; got != want {
+		t.Errorf("url = %v, want %v", got, want)
+	}
+	if _, ok := entry["timeout"]; ok {
+		t.Error("entry carries a timeout key; Copilot dispatches these events fire-and-forget")
+	}
+	if _, ok := entry["timeoutSec"]; ok {
+		t.Error("entry carries a timeoutSec key; Copilot dispatches these events fire-and-forget")
+	}
+}
+
+func TestHookEndpointFollowsBindAddr(t *testing.T) {
+	contracttesting.AssertHookEndpointFollowsBindAddr(t, contracttesting.HookInstaller{
+		SettingsPath: func(t *testing.T) string {
+			home := t.TempDir()
+			t.Setenv(copilotHomeEnvVar, home)
+			return filepath.Join(home, "hooks", "irrlicht.json")
+		},
+		Sentinel: hookSentinel,
+		Events:   installedHookEvents,
+		Entry:    ourHookEntry,
+		// Copilot delivers natively over http, so the endpoint is the url
+		// field rather than a substring of a shell command.
+		EndpointOf: func(hook map[string]interface{}) string {
+			url, _ := hook["url"].(string)
+			return url
+		},
+		EnsureInstalled: EnsureHooksInstalled,
+		Uninstall:       UninstallHooks,
+	})
+}

--- a/core/adapters/inbound/agents/copilot/hookreceipt_test.go
+++ b/core/adapters/inbound/agents/copilot/hookreceipt_test.go
@@ -1,0 +1,38 @@
+// hookreceipt_test.go wires this adapter's hook receiver into the shared issue
+// #1368 contract: a consent-passed request counts as a receipt whatever the
+// receiver then does with it, and a consent-denied one does not.
+//
+// Copilot's receiver has two gates and the receipt is counted against the
+// first, deliberately: "transcripts" authorizes READING the transcript, while
+// noting that a POST arrived needs only the "hooks" consent — and a
+// hooks-granted / transcripts-denied install has a channel that plainly works
+// and must not be convicted of silence by the liveness watchdog.
+package copilot
+
+import (
+	"net/http"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestHookReceiptObserved(t *testing.T) {
+	contracttesting.AssertHookReceiptObserved(t, contracttesting.HookReceiptReceiver{
+		Adapter:         AdapterName,
+		Root:            copilotSessionRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandlerWithConfiner(&mockTarget{},
+				keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, log, TranscriptConfiner())
+		},
+		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandlerWithConfiner(&mockTarget{}, keyedGate{}, log, TranscriptConfiner())
+		},
+		PayloadFor:   contractPayload,
+		KnownEvent:   HookStop,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/copilot/hooks.go
+++ b/core/adapters/inbound/agents/copilot/hooks.go
@@ -50,12 +50,18 @@ import (
 	"runtime"
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/outbound"
 )
 
 // PermissionKeyHooks gates installing and receiving Copilot hooks (issue #570).
-const PermissionKeyHooks = "hooks"
+//
+// Aliased to the shared domain constant rather than restated: since #1383 two
+// projections narrow on it — agents.HookConfigs (what --uninstall-hooks
+// revokes) and the managed-user-file catalog — so a literal that drifted would
+// silently drop this install out of both.
+const PermissionKeyHooks = agent.HooksPermissionKey
 
 // Hook event names, as they appear in the delivered envelope's
 // hook_event_name field.

--- a/core/adapters/inbound/agents/copilot/hooks.go
+++ b/core/adapters/inbound/agents/copilot/hooks.go
@@ -1,0 +1,340 @@
+// hooks.go provides the HTTP handler for receiving GitHub Copilot CLI hook
+// events (issue #1378, epic #1355 Phase D).
+//
+// Two events are installed, and they are treated very differently. The
+// asymmetry is the substance of this file, so it is stated up front:
+//
+//   - Stop fires once at true turn end and carries transcript_path. It holds
+//     SignalTurnDone, a TierHook signal, giving an authoritative ready at turn
+//     end instead of one inferred from the transcript tail. The hold is
+//     consume-once (see session.signalPolicies), so it cannot bleed into the
+//     next turn and cannot pin a session by construction.
+//
+//   - Notification/permission_prompt fires at prompt entry, and is DISPATCH
+//     ONLY: it injects a synthetic activity event so the session is
+//     re-classified immediately, but installs no hold. The waiting verdict
+//     still comes from the transcript's own permission.requested →
+//     TranscriptPermissionPending → transcript_permission_prompt rule (#1256),
+//     at TierTranscript.
+//
+// Why the permission prompt does not hold a TierHook signal, which is the
+// obvious thing to want and is what claudecode and codex both do:
+//
+// Copilot emits NOTHING when the user denies a prompt. Verified live on 1.0.78
+// by driving an interactive session and refusing the prompt: no Stop, no
+// postToolUse, no postToolUseFailure, no errorOccurred arrived in 42 seconds,
+// while the UI had already returned to ready. The shared SignalPermissionPrompt
+// row is released either by a PostToolUse-style Release (which only fires on
+// approval) or by its stale predicate, Metrics.LastWasToolDenial — and this
+// adapter's parser deliberately declines to set that flag, because it is Claude
+// Code's turn-ENDING cancellation marker whereas Copilot carries on after a
+// denial (see parsePermissionCompleted). With neither release available, a hold
+// taken on a prompt the user then denies would stay held until the 12-hour
+// ceiling (#1360) — the session would read waiting for the rest of the day.
+//
+// A dispatch-only notification keeps the whole benefit that is actually
+// available here and none of that risk. Copilot writes permission.requested to
+// its transcript roughly a millisecond before it fires the hook (measured:
+// 22:58:27.940 vs 22:58:27.941), so the hook was never going to beat the
+// transcript to the fact — it can only beat the daemon's own observation lag,
+// which is exactly what the synthetic activity event removes.
+package copilot
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// PermissionKeyHooks gates installing and receiving Copilot hooks (issue #570).
+const PermissionKeyHooks = "hooks"
+
+// Hook event names, as they appear in the delivered envelope's
+// hook_event_name field.
+//
+// Re-exports of the domain constants rather than independent literals, so a
+// rename on this side cannot silently stop matching the shared table — the
+// drift #1320 removed, one adapter over.
+//
+// Copilot's own event roster is camelCase (notification, agentStop). Both are
+// registered here under their PascalCase Claude-compat aliases, which is not
+// cosmetic: registered as Stop, the turn-end envelope arrives in Claude Code's
+// exact shape (hook_event_name, session_id, transcript_path — all snake_case),
+// whereas the native agentStop registration delivers camelCase keys and no
+// hook_event_name at all. One field name to switch on, for both events.
+const (
+	HookNotification = session.HookNotification
+	HookStop         = session.HookStop
+)
+
+// Notification types that mean "Copilot is blocked on the user". Copilot fires
+// notification for other reasons too (idle turns, background task completion),
+// and only these two open a state.
+const (
+	notificationPermissionPrompt  = "permission_prompt"
+	notificationElicitationDialog = "elicitation_dialog"
+)
+
+// logComponentHookReceiver is the Logger component tag for every log line
+// emitted by the hook HTTP handler below.
+const logComponentHookReceiver = "copilot-hook-receiver"
+
+// transcriptExt is the file extension the hook receiver confines
+// caller-supplied paths to. It must be an EXTENSION, not the full basename:
+// the confiner compares it with filepath.Ext, so the constant transcript
+// filename would match nothing and refuse every legitimate path.
+//
+// Confining by extension is not the weaker check it looks like. The exact
+// basename is still required immediately afterwards by sessionIDFromPath,
+// which returns "" for anything that is not events.jsonl and makes the
+// receiver drop the request — so a confined-but-wrong file in the tree
+// (workspace.yaml, session.db) never reaches a dispatch.
+const transcriptExt = ".jsonl"
+
+// copilotHookPayload is the JSON body Copilot POSTs on a hook event.
+//
+// It decodes BOTH envelope shapes on purpose, because Copilot does not use one.
+// Registered under a PascalCase alias, Stop arrives Claude-shaped
+// (session_id / transcript_path). Notification ignores the compat mapping
+// entirely — verified live by registering it under both spellings and
+// receiving byte-identical bodies — and arrives with a camelCase sessionId,
+// no transcript path of any spelling, plus hook_event_name and
+// notification_type. Hence the paired fields and resolveTranscriptPath below.
+type copilotHookPayload struct {
+	HookEventName string `json:"hook_event_name"`
+
+	// TranscriptPath is carried by Stop and absent from Notification.
+	TranscriptPath string `json:"transcript_path"`
+
+	// SessionID / SessionIDCamel are the two spellings of the same value.
+	// Copilot's session id is the session-state directory name, which is what
+	// sessionIDFromPath derives from a transcript path, so either one can
+	// reconstruct the path the other omits.
+	SessionID      string `json:"session_id"`
+	SessionIDCamel string `json:"sessionId"`
+
+	// NotificationType distinguishes a blocked-on-user notification from the
+	// idle and background-task ones. Empty on Stop.
+	NotificationType string `json:"notification_type"`
+}
+
+// sessionID returns whichever spelling the envelope used.
+func (p copilotHookPayload) sessionID() string {
+	if p.SessionID != "" {
+		return p.SessionID
+	}
+	return p.SessionIDCamel
+}
+
+// HookTarget is the interface the handler calls into. Satisfied by
+// *services.SessionDetector without importing the services package — the same
+// agent-agnostic surface claudecode's and codex's hooks use.
+type HookTarget interface {
+	HandlePermissionHook(sessionID, transcriptPath, hookEventName string)
+	HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool)
+}
+
+// ConsentGranter is the shared consent check every JSON-hook receiver gates on
+// (issue #570) — an alias, not a copy, so the three receivers cannot drift.
+type ConsentGranter = hookjson.ConsentGranter
+
+// NewHookHandler returns an http.HandlerFunc that receives Copilot hook events
+// and dispatches them to the target.
+//
+// gate is the consent check; while the "hooks" permission is not granted the
+// payload is dropped with 200, so the installed hook stays quiet. A nil gate
+// means no gating — used by tests.
+func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) http.HandlerFunc {
+	return NewHookHandlerWithConfiner(target, gate, log, TranscriptConfiner())
+}
+
+// TranscriptConfiner returns the confiner this adapter's hook receiver guards
+// caller-supplied transcript paths with, rooted in the adapter's own
+// agent.Source declaration (issue #1361) rather than re-derived from the
+// adapter's constants — so the tree the receiver confines to cannot drift from
+// the one the daemon watches.
+func TranscriptConfiner() *hookjson.PathConfiner {
+	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
+}
+
+// NewHookHandlerWithConfiner is NewHookHandler with an explicit confiner, for
+// tests that need to drive a receiver rooted somewhere other than the real
+// session-state tree and to read back what it refused.
+func NewHookHandlerWithConfiner(target HookTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		serveHookRequest(target, gate, log, confiner, w, r)
+	}
+}
+
+// serveHookRequest is NewHookHandler's request logic, pulled out of the
+// returned closure so its branching isn't counted at the closure's extra
+// nesting depth. The step order matches codex's receiver exactly and each step
+// is load-bearing — see the contract assertions in hook*_test.go.
+func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if gate != nil && !gate.Granted(AdapterName, PermissionKeyHooks) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// The channel delivered (issue #1368). Counted against the "hooks" consent
+	// only — the transcripts gate below authorizes READING the transcript, not
+	// observing that a POST arrived, and a hooks-granted / transcripts-denied
+	// install has a working channel this counter must not call dead.
+	hookjson.ObserveHookReceipt(AdapterName)
+
+	var payload copilotHookPayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// Dispatching makes the detector read the transcript, so it is gated
+	// behind the "transcripts" consent, not merely the "hooks" write consent.
+	// The check comes BEFORE confinement so a denied session still yields a
+	// quiet 200 and the path is never resolved on that branch.
+	if gate != nil && !gate.Granted(AdapterName, PermissionKeyTranscripts) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	raw := resolveTranscriptPath(payload)
+
+	// The path arrives in an HTTP body on a local, unauthenticated endpoint, so
+	// it is untrusted even when we assembled it ourselves from a caller-supplied
+	// session id: any local process could otherwise steer the daemon into
+	// opening a file of its choosing by sending "../../..". Confine before any
+	// read and carry the confined path downstream (issue #1361).
+	transcriptPath, reason := confiner.Confine(raw)
+	if reason != hookjson.RejectNone {
+		hookjson.RejectPath(w, log, logComponentHookReceiver, raw, reason)
+		return
+	}
+
+	sessionID := sessionIDFromPath(transcriptPath)
+	if sessionID == "" {
+		// Not a path this adapter owns — drop rather than guess an id. The
+		// transcript tailer covers the state regardless.
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	dispatchHookEvent(target, log, sessionID, transcriptPath, payload)
+	w.WriteHeader(http.StatusOK)
+}
+
+// resolveTranscriptPath returns the transcript path to confine.
+//
+// Stop supplies one directly. Notification supplies none at all, so it is
+// reconstructed from the session id against the adapter's OWN declared root —
+// never from anything the caller sent. The result is still confined by the
+// caller, which is what makes a hostile session id ("../../etc") harmless: it
+// is the confiner, not this function, that decides the path is in-tree.
+func resolveTranscriptPath(payload copilotHookPayload) string {
+	if payload.TranscriptPath != "" {
+		return payload.TranscriptPath
+	}
+	id := payload.sessionID()
+	if id == "" {
+		return ""
+	}
+	return filepath.Join(sessionsDir(), id, transcriptFilename)
+}
+
+// dispatchHookEvent routes a decoded, consent-passed, confined, session-
+// resolved payload to the right target method.
+func dispatchHookEvent(target HookTarget, log outbound.Logger, sessionID, transcriptPath string, payload copilotHookPayload) {
+	switch payload.HookEventName {
+	case HookStop:
+		// Turn end. Copilot's Stop envelope carries no last-assistant text
+		// (verified live on 1.0.78: the body is hook_event_name, session_id,
+		// timestamp, cwd, transcript_path, stop_reason, stop_hook_active), so
+		// the empty text below is the honest value rather than a placeholder —
+		// the transcript remains the source for what the turn actually said,
+		// and the hook contributes only the authoritative turn boundary.
+		log.LogInfo(logComponentHookReceiver, sessionID, "received Stop")
+		target.HandleStopHook(sessionID, transcriptPath, "", false)
+	case HookNotification:
+		handleNotificationHook(target, log, sessionID, transcriptPath, payload)
+	default:
+		// Unrecognized hook event — accept but ignore, counted per name and
+		// reported once, in the one place that behaviour is decided for every
+		// receiver (issue #1364). serveHookRequest's 200 is unaffected.
+		hookjson.IgnoreUnknownEvent(log, logComponentHookReceiver, AdapterName, sessionID, payload.HookEventName)
+	}
+}
+
+// handleNotificationHook processes a Copilot notification.
+//
+// Only the two blocked-on-user types do anything, and what they do is dispatch,
+// not hold — see this file's package comment for why a TierHook hold would pin
+// a denied session for twelve hours. Passing HookNotification through to
+// HandlePermissionHook is deliberate and is what makes this dispatch-only for
+// free: session.HookSignal has no row for Notification, so the shared handler
+// applies no signal and only injects the synthetic activity event.
+//
+// Any other notification type is ignored outright — it is a known event, not an
+// unknown one, so it must not be counted as unrecognized.
+func handleNotificationHook(target HookTarget, log outbound.Logger, sessionID, transcriptPath string, payload copilotHookPayload) {
+	switch payload.NotificationType {
+	case notificationPermissionPrompt, notificationElicitationDialog:
+	default:
+		return
+	}
+
+	log.LogInfo(logComponentHookReceiver, sessionID,
+		fmt.Sprintf("received Notification (%s)", payload.NotificationType))
+	target.HandlePermissionHook(sessionID, transcriptPath, HookNotification)
+}
+
+// sessionStartVersion reads copilotVersion from a transcript's session.start
+// header. Returns "" if the header is missing or unreadable.
+//
+// Bounded to the first few lines: session.start is the first event Copilot
+// writes, and an unbounded scan of a large transcript at install time would be
+// paid for nothing.
+func sessionStartVersion(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxVersionScanLineBytes)
+	for i := 0; i < maxVersionScanLines && scanner.Scan(); i++ {
+		var line struct {
+			Type string         `json:"type"`
+			Data map[string]any `json:"data"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			continue
+		}
+		if line.Type != evSessionStart {
+			continue
+		}
+		return str(line.Data, "copilotVersion")
+	}
+	return ""
+}
+
+const (
+	// maxVersionScanLines bounds how far into a transcript the version probe
+	// reads before giving up.
+	maxVersionScanLines = 20
+	// maxVersionScanLineBytes bounds a single line, so an oversized transcript
+	// line cannot make the probe allocate without limit (cell 2-16).
+	maxVersionScanLineBytes = 1 << 20
+)

--- a/core/adapters/inbound/agents/copilot/hooks.go
+++ b/core/adapters/inbound/agents/copilot/hooks.go
@@ -41,14 +41,11 @@
 package copilot
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"irrlicht/core/adapters/inbound/agents/agentpaths"
 	"irrlicht/core/adapters/inbound/agents/hookjson"
@@ -276,7 +273,17 @@ func resolveTranscriptPath(payload copilotHookPayload) string {
 	if id == "" {
 		return ""
 	}
-	root, err := agentpaths.AbsRoot(sessionsDir())
+	// Derived from the SAME declaration the confiner guards, not from
+	// sessionsDir() directly. Those agree today because Source() sets only Dir
+	// — but the moment it grows DirByOS (the declared Windows seam) or DirFunc,
+	// a second derivation would reconstruct against one root while the confiner
+	// guarded another, and every Notification would come back RejectEscapesRoot
+	// silently. That is exactly the drift #1361 removed from the receivers.
+	src, ok := Source().(agent.FilesUnderRoot)
+	if !ok {
+		return ""
+	}
+	root, err := agentpaths.AbsRoot(src.RootDirFor(runtime.GOOS))
 	if err != nil {
 		// No resolvable root — fail closed. An empty path is refused as
 		// RejectEmptyPath, which is the honest reason.
@@ -330,54 +337,3 @@ func handleNotificationHook(target HookTarget, log outbound.Logger, sessionID, t
 		fmt.Sprintf("received Notification (%s)", payload.NotificationType))
 	target.HandlePermissionHook(sessionID, transcriptPath, HookNotification)
 }
-
-// sessionStartVersion reads copilotVersion from a transcript's session.start
-// header. Returns "" if the header is missing or unreadable.
-//
-// Bounded to the first few lines: session.start is the first event Copilot
-// writes, and an unbounded scan of a large transcript at install time would be
-// paid for nothing.
-func sessionStartVersion(path string) string {
-	// Sink-local traversal guard. The only caller hands over a path produced by
-	// WalkDir over a self-resolved root, so this is not reachable in practice —
-	// but the plain ".." check is the form CodeQL's go/path-injection query
-	// recognizes as a sanitizer (the root derives from COPILOT_HOME, a taint
-	// source), and both sibling adapters carry it for exactly that reason: see
-	// codex/session_meta.go and claudecode/hookinstaller.go. A rejected path
-	// falls through to the same "unknown version" result an unreadable file
-	// already produces, which fails OPEN to the version gate's Probe.
-	if strings.Contains(path, "..") {
-		return ""
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		return ""
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), maxVersionScanLineBytes)
-	for i := 0; i < maxVersionScanLines && scanner.Scan(); i++ {
-		var line struct {
-			Type string         `json:"type"`
-			Data map[string]any `json:"data"`
-		}
-		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
-			continue
-		}
-		if line.Type != evSessionStart {
-			continue
-		}
-		return str(line.Data, "copilotVersion")
-	}
-	return ""
-}
-
-const (
-	// maxVersionScanLines bounds how far into a transcript the version probe
-	// reads before giving up.
-	maxVersionScanLines = 20
-	// maxVersionScanLineBytes bounds a single line, so an oversized transcript
-	// line cannot make the probe allocate without limit (cell 2-16).
-	maxVersionScanLineBytes = 1 << 20
-)

--- a/core/adapters/inbound/agents/copilot/hooks.go
+++ b/core/adapters/inbound/agents/copilot/hooks.go
@@ -48,7 +48,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
 	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
@@ -248,6 +250,24 @@ func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logge
 // never from anything the caller sent. The result is still confined by the
 // caller, which is what makes a hostile session id ("../../etc") harmless: it
 // is the confiner, not this function, that decides the path is in-tree.
+//
+// The root MUST be absolutised. sessionsDir() returns the $HOME-relative
+// literal ".copilot/session-state" whenever COPILOT_HOME is unset — the
+// configuration every ordinary user is in — and PathConfiner.Confine refuses a
+// non-absolute path outright (RejectRelativePath) before it ever consults the
+// roots. Without AbsRoot the whole Notification branch is therefore dead in the
+// default install: nothing dispatches, an error-level line is logged per
+// prompt, and the confiner's rejection counter — whose job is to signal a local
+// process probing the endpoint — accrues one false positive per legitimate
+// permission prompt. Every hook test in this package relocates COPILOT_HOME to
+// an absolute temp dir, which is exactly the spelling that hides it;
+// hookdefaulthome_test.go is the one that does not.
+//
+// AbsRoot rather than copilotSessionsDir(): the confiner rebuilds the accepted
+// path on the DECLARED root, deliberately un-symlink-resolved, so that the hook's
+// key and the fswatcher's key are the same string (see confine.go). Handing it a
+// pre-resolved root would reintroduce the two-spellings-one-session problem that
+// comment exists to prevent.
 func resolveTranscriptPath(payload copilotHookPayload) string {
 	if payload.TranscriptPath != "" {
 		return payload.TranscriptPath
@@ -256,7 +276,13 @@ func resolveTranscriptPath(payload copilotHookPayload) string {
 	if id == "" {
 		return ""
 	}
-	return filepath.Join(sessionsDir(), id, transcriptFilename)
+	root, err := agentpaths.AbsRoot(sessionsDir())
+	if err != nil {
+		// No resolvable root — fail closed. An empty path is refused as
+		// RejectEmptyPath, which is the honest reason.
+		return ""
+	}
+	return filepath.Join(root, id, transcriptFilename)
 }
 
 // dispatchHookEvent routes a decoded, consent-passed, confined, session-
@@ -312,6 +338,17 @@ func handleNotificationHook(target HookTarget, log outbound.Logger, sessionID, t
 // writes, and an unbounded scan of a large transcript at install time would be
 // paid for nothing.
 func sessionStartVersion(path string) string {
+	// Sink-local traversal guard. The only caller hands over a path produced by
+	// WalkDir over a self-resolved root, so this is not reachable in practice —
+	// but the plain ".." check is the form CodeQL's go/path-injection query
+	// recognizes as a sanitizer (the root derives from COPILOT_HOME, a taint
+	// source), and both sibling adapters carry it for exactly that reason: see
+	// codex/session_meta.go and claudecode/hookinstaller.go. A rejected path
+	// falls through to the same "unknown version" result an unreadable file
+	// already produces, which fails OPEN to the version gate's Probe.
+	if strings.Contains(path, "..") {
+		return ""
+	}
 	f, err := os.Open(path)
 	if err != nil {
 		return ""

--- a/core/adapters/inbound/agents/copilot/hooks_test.go
+++ b/core/adapters/inbound/agents/copilot/hooks_test.go
@@ -1,0 +1,374 @@
+package copilot
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// --- test doubles, shared by this file and the contract wirings ---
+
+type permCall struct {
+	sessionID, transcriptPath, hookEventName string
+}
+
+type stopCall struct {
+	sessionID, transcriptPath, lastAssistantText string
+	waitingCue                                   bool
+}
+
+type mockTarget struct {
+	mu        sync.Mutex
+	permCalls []permCall
+	stopCalls []stopCall
+}
+
+func (m *mockTarget) HandlePermissionHook(sessionID, transcriptPath, hookEventName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.permCalls = append(m.permCalls, permCall{sessionID, transcriptPath, hookEventName})
+}
+
+func (m *mockTarget) HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopCalls = append(m.stopCalls, stopCall{sessionID, transcriptPath, lastAssistantText, waitingCue})
+}
+
+func (m *mockTarget) totalCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.permCalls) + len(m.stopCalls)
+}
+
+func (m *mockTarget) perms() []permCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]permCall(nil), m.permCalls...)
+}
+
+func (m *mockTarget) stops() []stopCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]stopCall(nil), m.stopCalls...)
+}
+
+type keyedGate map[string]bool
+
+func (g keyedGate) Granted(_, key string) bool { return g[key] }
+
+type mockLogger struct{}
+
+func (mockLogger) LogInfo(string, string, string)                       {}
+func (mockLogger) LogError(string, string, string)                      {}
+func (mockLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (mockLogger) Close() error                                         { return nil }
+
+// --- helpers ---
+
+// copilotSessionRoot relocates COPILOT_HOME to a temp dir and returns the
+// declared transcript root inside it. COPILOT_HOME moves the whole config
+// directory, and transcripts live in its session-state/ subdirectory.
+func copilotSessionRoot(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv(copilotHomeEnvVar, home)
+	root := filepath.Join(home, "session-state")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("create session-state dir: %v", err)
+	}
+	return root
+}
+
+// writeSessionTranscript lays down <dir>/<id>/events.jsonl and returns its path.
+func writeSessionTranscript(t *testing.T, dir, id string) string {
+	t.Helper()
+	sessionDir := filepath.Join(dir, id)
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		t.Fatalf("mkdir session: %v", err)
+	}
+	path := filepath.Join(sessionDir, transcriptFilename)
+	line := `{"type":"session.start","data":{"copilotVersion":"1.0.78"}}` + "\n"
+	if err := os.WriteFile(path, []byte(line), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// writeContractTranscript is the shape the receiving-side contracts want: a
+// transcript inside dir whose session id the receiver can resolve. The decoy
+// the contract plants outside the tree goes through the same writer, so the
+// only thing keeping it from dispatching is confinement, not an unreadable
+// file.
+func writeContractTranscript(t *testing.T, dir string) string {
+	t.Helper()
+	return writeSessionTranscript(t, dir, "sess-contract")
+}
+
+// contractPayload renders a Stop-shaped body (the envelope that carries
+// transcript_path) for one event name.
+func contractPayload(transcriptPath, event string) string {
+	body, err := json.Marshal(copilotHookPayload{
+		TranscriptPath: transcriptPath,
+		HookEventName:  event,
+		SessionID:      filepath.Base(filepath.Dir(transcriptPath)),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
+// post drives the handler with a raw JSON body and returns the response.
+func post(t *testing.T, h http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, HookEndpointPath, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// newReceiver builds a fully-granted receiver over the real production
+// confiner, plus the target it dispatches into.
+func newReceiver(t *testing.T) (http.Handler, *mockTarget) {
+	t.Helper()
+	target := &mockTarget{}
+	gate := keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}
+	return NewHookHandlerWithConfiner(target, gate, mockLogger{}, TranscriptConfiner()), target
+}
+
+// --- behaviour ---
+
+// TestStopHook_DispatchesTurnDone pins the turn-end half of the channel: the
+// Stop envelope carries transcript_path directly, and the receiver forwards a
+// turn-done signal for the session that path names.
+//
+// The empty last-assistant text is asserted rather than ignored because it is a
+// deliberate choice, not an oversight: Copilot's Stop body carries no such
+// field (verified live on 1.0.78), so inventing one would be fabrication.
+func TestStopHook_DispatchesTurnDone(t *testing.T) {
+	root := copilotSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-stop")
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(tp, HookStop))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	stops := target.stops()
+	if len(stops) != 1 {
+		t.Fatalf("got %d Stop dispatches, want 1 (perm=%d)", len(stops), len(target.perms()))
+	}
+	if stops[0].sessionID != "sess-stop" {
+		t.Errorf("sessionID = %q, want %q", stops[0].sessionID, "sess-stop")
+	}
+	if stops[0].transcriptPath != tp {
+		t.Errorf("transcriptPath = %q, want the confined path %q", stops[0].transcriptPath, tp)
+	}
+	if stops[0].lastAssistantText != "" || stops[0].waitingCue {
+		t.Errorf("Stop forwarded text=%q cue=%v; Copilot's Stop body carries neither, so both must be zero",
+			stops[0].lastAssistantText, stops[0].waitingCue)
+	}
+}
+
+// notificationBody renders the Notification envelope exactly as Copilot 1.0.78
+// delivers it: camelCase sessionId, hook_event_name, notification_type, and
+// NO transcript path of any spelling.
+func notificationBody(sessionID, notificationType string) string {
+	return `{"sessionId":"` + sessionID + `",` +
+		`"timestamp":1786316307940,` +
+		`"cwd":"/tmp/wd",` +
+		`"message":"Fetch URL: https://example.com",` +
+		`"title":"Permission needed",` +
+		`"hook_event_name":"Notification",` +
+		`"notification_type":"` + notificationType + `"}`
+}
+
+// TestNotification_ReconstructsTranscriptPathFromSessionID is the load-bearing
+// one for this adapter. Copilot's Notification envelope carries no transcript
+// path at all — only a camelCase sessionId — so the receiver has to rebuild the
+// path against its own declared root before anything downstream can use it.
+//
+// A receiver that only read transcript_path would dispatch nothing here, and
+// the permission prompt would get no acceleration whatsoever.
+func TestNotification_ReconstructsTranscriptPathFromSessionID(t *testing.T) {
+	root := copilotSessionRoot(t)
+	want := writeSessionTranscript(t, root, "sess-notif")
+	h, target := newReceiver(t)
+
+	rec := post(t, h, notificationBody("sess-notif", "permission_prompt"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	perms := target.perms()
+	if len(perms) != 1 {
+		t.Fatalf("got %d permission dispatches, want 1 — the envelope has no transcript_path, "+
+			"so the receiver must rebuild it from sessionId", len(perms))
+	}
+	if perms[0].sessionID != "sess-notif" {
+		t.Errorf("sessionID = %q, want %q", perms[0].sessionID, "sess-notif")
+	}
+	if perms[0].transcriptPath != want {
+		t.Errorf("transcriptPath = %q, want %q", perms[0].transcriptPath, want)
+	}
+}
+
+// TestNotification_DispatchesUnderAHookNameThatHoldsNoSignal is the guard on
+// the whole design decision in hooks.go's package comment.
+//
+// The name forwarded to HandlePermissionHook decides whether a persistent
+// TierHook hold is taken, because the shared handler looks it up in
+// session.HookSignal. Notification has no row there, so forwarding it means
+// dispatch-only. Forwarding PermissionRequest instead — a one-word change that
+// looks like a harmless normalization — would take a hold that Copilot can
+// never release on a denied prompt, pinning the session waiting until the
+// 12-hour ceiling.
+func TestNotification_DispatchesUnderAHookNameThatHoldsNoSignal(t *testing.T) {
+	root := copilotSessionRoot(t)
+	writeSessionTranscript(t, root, "sess-notif")
+	h, target := newReceiver(t)
+
+	post(t, h, notificationBody("sess-notif", "permission_prompt"))
+
+	perms := target.perms()
+	if len(perms) != 1 {
+		t.Fatalf("got %d permission dispatches, want 1", len(perms))
+	}
+	if perms[0].hookEventName != HookNotification {
+		t.Fatalf("forwarded hook name = %q, want %q — any name with a session.HookSignal row "+
+			"takes a persistent hold, and Copilot emits nothing on a denied prompt to release it",
+			perms[0].hookEventName, HookNotification)
+	}
+	if _, holds := session.HookSignal(perms[0].hookEventName); holds {
+		t.Errorf("hook name %q maps to a signal hold; Copilot must dispatch without holding "+
+			"because a denied prompt produces no release event", perms[0].hookEventName)
+	}
+}
+
+// TestNotification_NonBlockingTypesAreIgnored pins that Copilot's other
+// notification types do nothing. They are KNOWN events, so they must also not
+// be counted as unrecognized — that counter exists to surface an upstream
+// rename, and burying it under routine idle notifications would defeat it.
+func TestNotification_NonBlockingTypesAreIgnored(t *testing.T) {
+	root := copilotSessionRoot(t)
+	writeSessionTranscript(t, root, "sess-notif")
+
+	for _, nt := range []string{"idle_prompt", "background_task", ""} {
+		h, target := newReceiver(t)
+		rec := post(t, h, notificationBody("sess-notif", nt))
+		if rec.Code != http.StatusOK {
+			t.Errorf("notification_type=%q: status = %d, want 200", nt, rec.Code)
+		}
+		if n := target.totalCalls(); n != 0 {
+			t.Errorf("notification_type=%q dispatched %d times, want 0", nt, n)
+		}
+	}
+}
+
+// TestNotification_ElicitationDialogAlsoOpens pins the second blocked-on-user
+// type alongside permission_prompt.
+func TestNotification_ElicitationDialogAlsoOpens(t *testing.T) {
+	root := copilotSessionRoot(t)
+	writeSessionTranscript(t, root, "sess-notif")
+	h, target := newReceiver(t)
+
+	post(t, h, notificationBody("sess-notif", "elicitation_dialog"))
+
+	if n := len(target.perms()); n != 1 {
+		t.Fatalf("got %d dispatches for elicitation_dialog, want 1", n)
+	}
+}
+
+// TestNotification_HostileSessionIDIsConfined is the security consequence of
+// rebuilding a path from a caller-supplied id: the id is untrusted, so the
+// reconstructed path must still go through the confiner. A traversal id must
+// dispatch nothing and still answer 2xx (the shared rule — a refusal is
+// reported by the log and counter, never by a status on the user's path).
+func TestNotification_HostileSessionIDIsConfined(t *testing.T) {
+	root := copilotSessionRoot(t)
+	writeSessionTranscript(t, root, "sess-notif")
+	h, target := newReceiver(t)
+
+	rec := post(t, h, notificationBody("../../../../etc", "permission_prompt"))
+
+	if rec.Code < 200 || rec.Code > 299 {
+		t.Errorf("status = %d, want 2xx: a confinement refusal is reported by the log and "+
+			"counter, not by a status code", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Fatalf("a traversal sessionId dispatched %d times, want 0", n)
+	}
+}
+
+// TestHookReceiver_DeniedHooksConsentDropsQuietly is the #570 gate at the
+// receiving end: while the hooks permission is not granted, an installed hook
+// that is still firing must be dropped without dispatching.
+func TestHookReceiver_DeniedHooksConsentDropsQuietly(t *testing.T) {
+	root := copilotSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-stop")
+	target := &mockTarget{}
+	h := NewHookHandlerWithConfiner(target, keyedGate{}, mockLogger{}, TranscriptConfiner())
+
+	rec := post(t, h, contractPayload(tp, HookStop))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Fatalf("dispatched %d times while hooks consent was denied, want 0", n)
+	}
+}
+
+// TestHookReceiver_DeniedTranscriptsConsentDropsQuietly pins the second gate:
+// dispatching makes the detector read the transcript, so a transcripts-denied
+// session must not dispatch even though the hooks consent is granted.
+func TestHookReceiver_DeniedTranscriptsConsentDropsQuietly(t *testing.T) {
+	root := copilotSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-stop")
+	target := &mockTarget{}
+	h := NewHookHandlerWithConfiner(target, keyedGate{PermissionKeyHooks: true}, mockLogger{}, TranscriptConfiner())
+
+	rec := post(t, h, contractPayload(tp, HookStop))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Fatalf("dispatched %d times while transcripts consent was denied, want 0", n)
+	}
+}
+
+// TestHookReceiver_NonPostRejected is a LOCK on the shared receiver shape.
+func TestHookReceiver_NonPostRejected(t *testing.T) {
+	copilotSessionRoot(t)
+	h, _ := newReceiver(t)
+	req := httptest.NewRequest(http.MethodGet, HookEndpointPath, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET status = %d, want 405", rec.Code)
+	}
+}
+
+// TestHookReceiver_MalformedJSONIs400 is a LOCK: a body that will not decode is
+// the one case that answers non-2xx, because nothing about it is a path.
+func TestHookReceiver_MalformedJSONIs400(t *testing.T) {
+	copilotSessionRoot(t)
+	h, target := newReceiver(t)
+	rec := post(t, h, "{not json")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Errorf("dispatched %d times on malformed JSON, want 0", n)
+	}
+}

--- a/core/adapters/inbound/agents/copilot/hooks_test.go
+++ b/core/adapters/inbound/agents/copilot/hooks_test.go
@@ -232,6 +232,17 @@ func TestNotification_ReconstructsTranscriptPathFromSessionID(t *testing.T) {
 // looks like a harmless normalization — would take a hold that Copilot can
 // never release on a denied prompt, pinning the session waiting until the
 // 12-hour ceiling.
+//
+// READ THIS IF YOU ARE EDITING core/domain/session/hook_signal.go, NOT THIS
+// FILE. The second half of the assertion below fails on a change made in that
+// package rather than in this one. hookSignalEffects has no HookNotification
+// row today, and its own doc comment invites adding one ("a row here is the
+// right fix, not a bespoke branch") — which is sound for claudecode, whose
+// Notification means idle_prompt. For copilot the same row would silently
+// convert this deliberate no-hold into the 12-hour pin described above,
+// because copilot is the one adapter whose CLI emits nothing at all when the
+// user denies. If this went red from that side: copilot needs a dispatch that
+// takes no hold, so give it one explicitly rather than deleting this check.
 func TestNotification_DispatchesUnderAHookNameThatHoldsNoSignal(t *testing.T) {
 	root := copilotSessionRoot(t)
 	writeSessionTranscript(t, root, "sess-notif")

--- a/core/adapters/inbound/agents/copilot/hooktranscript_test.go
+++ b/core/adapters/inbound/agents/copilot/hooktranscript_test.go
@@ -1,0 +1,54 @@
+// hooktranscript_test.go pins the one way installing hooks changes what the
+// adapter READS, as opposed to what it receives.
+//
+// Copilot logs its own hook execution into the session transcript: every
+// delivery appends a hook.start / hook.end pair. So the moment a user grants
+// the hooks permission, the file the tailer is reading grows a class of line
+// that no existing recording contains. That is exactly the shape of change
+// that silently moves state detection, and it is invisible to the replay
+// goldens — every frozen copilot recording predates hook installation, so a
+// byte-identical replay proves the parser is unchanged, NOT that it handles
+// these lines.
+//
+// The lines below are verbatim from a real 1.0.78 session driven with this
+// adapter's own hook file installed.
+package copilot
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+const (
+	realHookStartLine = `{"id":"h1","parentId":null,"timestamp":"2026-08-09T22:57:36.167Z","type":"hook.start","data":{"hookInvocationId":"ae08178b-e3be-426f-b007-61a8763b651c","hookType":"agentStop","input":{"transcriptPath":"/tmp/x/events.jsonl","stopReason":"end_turn","stop_hook_active":false,"sessionId":"309e2571-49c6-4344-bb26-2f1d019e72e3"}}}`
+	realHookEndLine   = `{"id":"h2","parentId":"h1","timestamp":"2026-08-09T22:57:36.192Z","type":"hook.end","data":{"hookInvocationId":"ae08178b-e3be-426f-b007-61a8763b651c","hookType":"agentStop","success":true}}`
+)
+
+// TestHookLifecycleLinesAreInert pins that Copilot's own hook.start/hook.end
+// bookkeeping is skipped rather than mistaken for agent activity. A hook.start
+// treated as activity would flip a finished session back to working on every
+// turn end — and it would do so ONLY for users who granted the permission,
+// which is the hardest kind of bug to reproduce.
+func TestHookLifecycleLinesAreInert(t *testing.T) {
+	for _, tc := range []struct{ name, line string }{
+		{"hook.start", realHookStartLine},
+		{"hook.end", realHookEndLine},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var raw map[string]any
+			if err := json.Unmarshal([]byte(tc.line), &raw); err != nil {
+				t.Fatalf("fixture does not parse: %v", err)
+			}
+			p := &Parser{}
+			ev := p.ParseLine(raw)
+			if ev == nil {
+				t.Fatal("ParseLine returned nil")
+			}
+			if !ev.Skip {
+				t.Errorf("%s was not skipped (EventType=%q) — Copilot writes this line for "+
+					"every hook delivery, so treating it as activity would keep a session "+
+					"working forever once hooks are granted", tc.name, ev.EventType)
+			}
+		})
+	}
+}

--- a/core/adapters/inbound/agents/copilot/hookunknown_test.go
+++ b/core/adapters/inbound/agents/copilot/hookunknown_test.go
@@ -1,0 +1,30 @@
+// hookunknown_test.go wires this adapter's hook receiver into the shared issue
+// #1364 contract: an event name the receiver does not recognize is counted per
+// (adapter, name), reported once per distinct name, and still answered 2xx.
+package copilot
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestUnknownHookEventObserved(t *testing.T) {
+	contracttesting.AssertUnknownHookEventObserved(t, contracttesting.UnknownEventReceiver{
+		Adapter:         AdapterName,
+		Root:            copilotSessionRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) contracttesting.UnknownEventReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.UnknownEventReceiverUnderTest{
+				Handler:  NewHookHandlerWithConfiner(target, nil, log, TranscriptConfiner()),
+				Observed: func() bool { return target.totalCalls() > 0 },
+			}
+		},
+		PayloadFor:   contractPayload,
+		KnownEvent:   HookStop,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/copilot/hookversion_test.go
+++ b/core/adapters/inbound/agents/copilot/hookversion_test.go
@@ -44,10 +44,10 @@ func hooksVersionGate(t *testing.T) *agent.VersionGate {
 	t.Helper()
 	for _, p := range Agent().Permissions {
 		if p.Key == PermissionKeyHooks {
-			if p.Hooks == nil || p.Hooks.Version == nil {
+			if p.Writes == nil || p.Writes.Version == nil {
 				t.Fatal("hooks permission declares no version gate")
 			}
-			return p.Hooks.Version
+			return p.Writes.Version
 		}
 	}
 	t.Fatal("no hooks permission")

--- a/core/adapters/inbound/agents/copilot/hookversion_test.go
+++ b/core/adapters/inbound/agents/copilot/hookversion_test.go
@@ -1,0 +1,110 @@
+// hookversion_test.go wires the Copilot hooks permission into the shared issue
+// #1365 contract, and pins the adapter's own passive version source.
+package copilot
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DeclaresVersionGate(t *testing.T) {
+	contracttesting.AssertHookVersionGate(t, contracttesting.HookVersionGate{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		Since:         hookEventSince,
+	})
+}
+
+// writeCopilotSessionWithVersion lays down a $COPILOT_HOME/session-state tree
+// holding one transcript whose session.start header declares copilotVersion —
+// the adapter's install-time proxy for "the Copilot the user is running now".
+func writeCopilotSessionWithVersion(t *testing.T, cliVersion string) {
+	t.Helper()
+	home := t.TempDir()
+	dir := filepath.Join(home, "session-state", "s1")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session: %v", err)
+	}
+	line := `{"type":"session.start","data":{"copilotVersion":"` + cliVersion + `"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, transcriptFilename), []byte(line), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	t.Setenv(copilotHomeEnvVar, home)
+}
+
+// hooksVersionGate returns the declared gate, read off the real registration
+// the daemon consumes rather than a copy.
+func hooksVersionGate(t *testing.T) *agent.VersionGate {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			if p.Hooks == nil || p.Hooks.Version == nil {
+				t.Fatal("hooks permission declares no version gate")
+			}
+			return p.Hooks.Version
+		}
+	}
+	t.Fatal("no hooks permission")
+	return nil
+}
+
+// TestHooksGate_BelowFloorSaysWhy pins that a Copilot older than the
+// notification guarantee is refused WITH a reason naming both versions. Below
+// 1.0.26 the notification event either does not exist (pre-1.0.18) or fires
+// when no prompt was shown (1.0.18–1.0.25), which would manufacture false
+// waiting states — so this floor is about correctness, not just presence.
+func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
+	writeCopilotSessionWithVersion(t, "1.0.20")
+	gate := hooksVersionGate(t)
+
+	if gate.Observed == nil {
+		t.Fatal("copilot declares no Observed version source; it reads copilotVersion from " +
+			"the session.start header it already tails")
+	}
+	if got := gate.Observed(); got != "1.0.20" {
+		t.Fatalf("Observed() = %q, want the copilotVersion from the newest transcript", got)
+	}
+
+	allowed, why := gate.Permits(gate.Observed())
+	if allowed {
+		t.Fatal("gate permits installing into Copilot 1.0.20, below the declared floor")
+	}
+	if !strings.Contains(why, "1.0.20") || !strings.Contains(why, minCLIVersion) {
+		t.Errorf("refusal %q names neither the installed version nor the required one; "+
+			"the reason has to tell the user what to upgrade", why)
+	}
+}
+
+// TestHooksGate_AtOrAboveFloorInstalls is a LOCK: it pins that the gate has not
+// become a blanket refusal, which from a log looks identical to one that works.
+func TestHooksGate_AtOrAboveFloorInstalls(t *testing.T) {
+	for _, v := range []string{minCLIVersion, "1.0.78", "1.1.0", "2.0.0"} {
+		writeCopilotSessionWithVersion(t, v)
+		gate := hooksVersionGate(t)
+		if allowed, why := gate.Permits(gate.Observed()); !allowed {
+			t.Errorf("gate refuses Copilot %s, at or above the %s floor: %s", v, minCLIVersion, why)
+		}
+	}
+}
+
+// TestHooksGate_NoTranscriptFallsThroughToProbe pins that a machine with no
+// Copilot sessions yet resolves to "unknown", not to "version 0" — an unread
+// version is not an old one, and refusing here would disable hooks on a fresh
+// install.
+func TestHooksGate_NoTranscriptFallsThroughToProbe(t *testing.T) {
+	t.Setenv(copilotHomeEnvVar, t.TempDir())
+	gate := hooksVersionGate(t)
+
+	if got := gate.Observed(); got != "" {
+		t.Fatalf("Observed() = %q with no transcripts on disk, want empty", got)
+	}
+	if allowed, why := gate.Permits(""); !allowed {
+		t.Errorf("gate refuses on an unknown version: %s", why)
+	}
+}

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -18,6 +18,7 @@ import (
 	"irrlicht/core/adapters/inbound/agents"
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/adapters/inbound/agents/codex"
+	"irrlicht/core/adapters/inbound/agents/copilot"
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	backchannelhandler "irrlicht/core/adapters/inbound/backchannel"
 	gastownadapter "irrlicht/core/adapters/inbound/orchestrators/gastown"
@@ -925,6 +926,8 @@ func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, 
 		claudecode.NewStatuslineHandler(metricsCollector, permService, logger))
 	mux.HandleFunc("POST "+codex.HookEndpointPath,
 		codex.NewHookHandler(detector, permService, logger))
+	mux.HandleFunc("POST "+copilot.HookEndpointPath,
+		copilot.NewHookHandler(detector, permService, logger))
 }
 
 // publishAddrFile writes the addr file and thereby signals "the daemon is

--- a/tools/onboarding-factory/internal/hookcov/hookcov_test.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov_test.go
@@ -17,13 +17,19 @@ import (
 func TestDeclaredMatchesRegistry(t *testing.T) {
 	got := Declared()
 
-	// Exhaustive as of this commit: claudecode and codex are the only two
-	// adapters declaring a hooks permission. If a third gains one, this fails
+	// Exhaustive as of this commit: claudecode, codex and copilot are the
+	// adapters declaring a hooks permission. If a fourth gains one, this fails
 	// and the new adapter joins the list — that is the intended workflow, not
 	// an obstacle.
+	//
+	// copilot joined in #1378 and is expected to report StatusGap for a while:
+	// it declares hooks, but no copilot recording carries a hook_received
+	// event yet, because that phase deliberately re-recorded nothing (the
+	// frozen sidecars are hook-free and the replay goldens had to stay
+	// byte-identical). A GAP here is the honest reading of that, not a defect.
 	want := map[string]bool{
 		"aider": false, "antigravity": false, "claudecode": true, "codex": true,
-		"copilot": false, "gemini-cli": false, "hermes": false, "kiro-cli": false,
+		"copilot": true, "gemini-cli": false, "hermes": false, "kiro-cli": false,
 		"mistral-vibe": false, "opencode": false, "pi": false,
 	}
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
Closes #1378 — Phase D of epic #1355, the minimum viable slice.

## The blocking question, answered: **an env var IS required**

`COPILOT_HOOK_ALLOW_LOCALHOST=1` is **mandatory** for a plain `http://127.0.0.1:<port>` hook. Established empirically on CLI 1.0.78 under an isolated `COPILOT_HOME`, both directions:

- **Without it** — hooks load and fire, every delivery is refused, 0 received:
  ```
  HTTP hook URL "http://127.0.0.1:7901/api/v1/hooks/copilot" resolves to blocked
  address 127.0.0.1. URLs must not target loopback, private, or link-local addresses.
  ```
- **With it** — the same file delivers normally.

This is a **third** rule, not either https string the Phase C audit reasoned from. Those are narrow (`allowedEnvVars` only when set; authorization-affecting only for `preToolUse`/`preMcpToolCall`/`permissionRequest`). Underneath both sits an SSRF guard refusing *every* http hook to a loopback address, regardless of event or config. The audit's inference that a bare localhost hook "appears unconstrained" was wrong for a reason those strings could not show.

**Consequence for the user:** the daemon cannot set this — Copilot reads it from its own process environment and irrlicht does not launch Copilot. The consent copy therefore says so explicitly: entries are written but never fire until the user exports it.

## Design: the two events, and why they are treated differently

| Event | Registered as | Carries | Effect |
|---|---|---|---|
| turn end | `Stop` (Claude-compat alias of `agentStop`) | `transcript_path`, `session_id` | `SignalTurnDone` — **TierHook**, consume-once |
| permission prompt | `Notification` + `notification_type ∈ {permission_prompt, elicitation_dialog}` | camelCase `sessionId`, **no transcript path** | **dispatch only, no hold** |

### Why the permission prompt takes no TierHook hold — the `agentStop` fallback question

**Copilot emits nothing when the user denies a prompt.** Verified live twice: after refusing, no `Stop`, `postToolUse`, `postToolUseFailure` or `errorOccurred` arrived in 42 s and 35 s, while the UI had already returned to ready.

The shared `SignalPermissionPrompt` row releases either by a `PostToolUse` Release (approval only) or by its stale predicate `Metrics.LastWasToolDenial` — and copilot's parser **deliberately declines** to set that flag (`parsePermissionCompleted`: it is Claude Code's turn-*ending* marker, whereas Copilot carries on after a denial). With neither release available, a hold taken on a denied prompt would sit until the **12-hour ceiling (#1360)**.

So the fallback is **the transcript**, and it cannot pin the session because it is not a hold at all: `Notification` is forwarded under a name that has no `session.HookSignal` row, so `HandlePermissionHook` applies no signal and only injects the synthetic activity event. The waiting verdict comes from the pre-existing `transcript_permission_prompt` rule (#1256) at **TierTranscript**, which self-releases on `permission.completed`. Nothing new can hold, so nothing new can pin. `TestNotification_DispatchesUnderAHookNameThatHoldsNoSignal` guards the one-word change that would reintroduce the hazard.

`preToolUse` / `permissionRequest` are **not** hooked (fail-closed since 1.0.57). `userPromptSubmitted` is not hooked: its envelope carries no transcript path and the domain has no turn-start signal.

## The four success tests, measured

| # | Test | Result |
|---|---|---|
| 1 | Adapter diff ≤ 250 LOC excl. tests | **FAIL — 338 code lines** (808 raw incl. 409 comment / 61 blank) |
| 2 | Live `waiting` + `ready`, `TierHook` | **PARTIAL** — both states verified live; `ready` is TierHook, `waiting` is TierTranscript *by design* |
| 3 | Goldens frozen, byte-identical | **PASS** — no replaydata file touched |
| 4 | Copilot cells re-recorded | **PASS — 0** (threshold was >5) |

### Test 1 — over budget, stated plainly

**338 > 250. The "declaration not implementation" thesis is not proven at this threshold, and Phase F is not justified on this evidence.** Not arguing it down. (It grew from 318 during review: the default-`$HOME` fix, the uninstall cleanup and the CodeQL guard are all real code the first pass was missing.)

The useful detail: **83 of those code lines are verbatim boilerplate from codex** — `atomicWriteFile` (24), `copilotHome`/`copilotSessionsDir`/`copilotHooksPath` (24), the `EnsureHooksInstalled`/`VerifyHooksInstalled`/`UninstallHooks` trio (21), `hookConfig` (11), `hookEndpointURL` (3). That is data *for* a Phase F extraction, but it is a measurement taken after the fact, not a promise: even removing all 83 leaves 255, which still does not clear 250.

### Test 2 — live, with the latency delta

Real session, isolated `COPILOT_HOME`, dev daemon on :7899. Hook channel armed, `receipts: 2`, `silent: false`, reverification `intact`, `unknown_events_total: 0`.

```
01:38:51.987  copilot-hook-receiver   received Notification (permission_prompt)
01:38:52.102  session-detector        transcript permission prompt open → waiting
01:40:43.953  copilot-hook-receiver   received Stop
01:40:43.955  session-detector        agent finished turn → ready
```

Hook-vs-heuristic delta, measured as *transcript marker → daemon verdict*, same scenario with the hook file present and removed (n=1 each):

| path | hooks ON | hooks OFF | delta |
|---|---|---|---|
| `assistant.turn_end` → `ready` | **21 ms** | **118 ms** | **−97 ms (5.6× faster)** |
| `permission.requested` → `waiting` | **117 ms** | **104 ms** | **none (within noise)** |

**The turn-end win is real; the permission-prompt win is zero.** That is the honest headline, and it has a cause: Copilot writes `permission.requested` to its transcript ~1 ms *before* it fires the hook (22:58:27.940 vs .941), so there was never source-side latency to recover — only the daemon's own observation lag, which the fswatcher already covers in ~100 ms.

### Test 4 — 0 cells re-recorded

Nothing was re-recorded, so the re-record bill is not the cancellation trigger for Phase H on this adapter. One caveat found live and now pinned: Copilot writes `hook.start`/`hook.end` **into the transcript** on every delivery, so any *future* copilot recording made with hooks installed will contain lines no frozen recording has. `TestHookLifecycleLinesAreInert` locks them as skipped.

`of status --hooks` will report copilot as a **GAP** (declares hooks, no hook-bearing recording) — the honest reading of "re-recorded nothing", not a defect.

## Inherited, not rebuilt

`hookjson` **unmodified**, shared receiver **unmodified**, parser **untouched** (verified: the non-test diff touches only `copilot/agent.go`, `copilot/hooks.go`, `copilot/hookinstaller.go`, `startup.go`). Copilot accepts hookjson's nested matcher-group shape with no `version` key — verified live, which is what makes the reuse possible.

All **7** contract families wired: disclosure, endpoint/bind-addr, path confinement, unknown events, receipts, version gate, permission gate.

## Red-first / mutation evidence

There is **no defect test here** — this is new capability, not a bug fix, so nothing could be red on `main`. Per AGENTS.md the equivalent bar is a deliberate mutation seen red per obligation. Nine were run, each reverted:

| mutation | result |
|---|---|
| M1 disclosure understates entry count | RED — `consent copy declares 1 hook entries, installer writes 2` |
| M2 endpoint hardcodes :7837 | RED — `the endpoint does not follow IRRLICHT_BIND_ADDR` |
| M3 confinement forwards raw path | RED — `dispatched downstream` + `counted 0 rejection(s), want 1` |
| M4 drop `ObserveHookReceipt` | RED — `added 0 receipts … want exactly 1` |
| M5 drop `IgnoreUnknownEvent` | RED — `arrived 3 times, counted 0` |
| M6 event newer than floor | RED — `declared floor 1.0.26 is below 1.0.99` |
| M7 `Remove` becomes a no-op | RED — `effect still observed after revoking` |
| M8 forward `PermissionRequest` (design guard) | RED — `forwarded hook name = "PermissionRequest"` |
| M9 parser treats `hook.start` as activity | RED — `hook.start was not skipped` |

**Locks** (pass by construction, labelled as such): `TestHooksPermission_DisclosureMatchesInstalled`, `TestHooksGate_AtOrAboveFloorInstalls`, `TestHookLifecycleLinesAreInert`, `TestHookReceiver_NonPostRejected`, `TestHookReceiver_MalformedJSONIs400`, and the updated `TestAgent_Permissions`.

## Review + simplify

The review subagent (effort `high`) found a **real defect I shipped**, now fixed with a red-first regression test:

> With `COPILOT_HOME` unset — the default for every ordinary user — `sessionsDir()` returns the `$HOME`-relative `.copilot/session-state`, and `PathConfiner` refuses a non-absolute path as `RejectRelativePath` **before** consulting the roots. The Notification branch therefore dispatched nothing, logged an error per prompt, and added a false positive to the confiner's probe-detection counter. Every existing hook test set `COPILOT_HOME` to an absolute temp dir — the one spelling that hides it.

`hookdefaulthome_test.go` was **seen red first** (`got 0 permission dispatches … confiner rejections: map[relative_path:1]`) and is green after the fix. Six further review findings applied: CodeQL sink-local guard on the version probe; uninstall now removes the empty file it created (`TestUninstallGivesTheDirectoryBack`, mutation-verified); and three comments corrected that described behaviour the code did not have.

`/simplify` (4 agents) converged on four more, all applied: `resolveTranscriptPath` now derives its root from the same `Source()` declaration the confiner guards rather than a second derivation; `copilotHome` composes `agentpaths` instead of re-deciding the override rule; the install-time version probe moved out of the request-path file; and the installer test uses `hookjson.HasOurHook` instead of a hand-rolled walk that was **weaker than production** (it matched on the URL's last segment, so a stale-port or foreign entry read as ours).

Deliberately **not** done, recorded as Phase F evidence rather than fixed: `atomicWriteFile` is now a third verbatim copy, and the whole `serveHookRequest` skeleton is near-identical across three adapters — collapsing either means editing `hookjson`, which is a measured criterion of this ticket.

## Rebase note

Rebased twice: across #1411/#1383, which renamed `HookInstall`→`ManagedUserFile` and `Permission.Hooks`→`Permission.Writes`. The rebase auto-merged **textually clean but semantically broken** (build failed on the renamed fields) — adapted in `7d472653`. `--print-managed-files` now lists copilot's hook file and honours `COPILOT_HOME`, so it is covered by both #1383 projections.

Then across #1429, which touched `startup.go`; the merged `registerHookRoutes` was re-read and still registers all four routes coherently.

AGENTS.md's "All seven contract families" count re-verified after each rebase: `grep -c "^func Assert"` = **7**. Consistent.

SonarCloud now reports **0 open issues** on this PR (both findings fixed: a thrice-duplicated version literal, and cognitive complexity in the permissions test — note that flattening `t.Run` subtests into top-level tests was the fix, because a closure body counts toward its *enclosing* function).

Its quality gate is nonetheless red, on exactly one condition:

```
new_duplicated_lines_density   7.3%   threshold 3%
```

That is an **independent, objective measurement of the duplication this ticket deliberately did not remove** — `atomicWriteFile`, the home/path resolvers, the Ensure/Verify/Uninstall trio and the `serveHookRequest` skeleton, all now in their third copy. Collapsing any of it means editing `hookjson`, which is a measured success criterion here. Recording the number rather than suppressing it: it is the strongest quantitative input this phase produces for the Phase F decision, and it says the duplication is real and above the project's own tolerance.

CodeScene is also red and is advisory per AGENTS.md — not chased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
