### PR TITLE
fix(permissions): route every PermissionService construction through an allocator

### DIFF
--- a/core/application/services/permission_construction_test.go
+++ b/core/application/services/permission_construction_test.go
@@ -5,11 +5,12 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+
+	"irrlicht/core/domain/permission"
 )
 
 // This file covers issue #1400: a PermissionService built by a bare composite
@@ -34,14 +35,77 @@ import (
 // issue floated an unexported zero-width field to make the literal
 // uncompilable, but it would be inert here: every field of PermissionService is
 // already unexported, so Go already forbids another package from setting one in
-// a literal (only `&services.PermissionService{}` with no fields at all
-// compiles, which populates nothing and is useless). The literal this issue was
-// actually filed about lives in THIS package, where unexported fields are
-// freely settable and no unexported marker field can reach it.
+// a literal. The one spelling that still compiles from outside is
+// `&services.PermissionService{}` with no fields at all — which is not harmless
+// just because it populates nothing: it is a fully-nil service that panics on
+// first use, and it is what an external test in this same directory
+// (`package services_test`) would naturally reach for. The scan below matches
+// it. And the literal this issue was actually filed about lives in THIS
+// package, where unexported fields are freely settable and no unexported marker
+// field could ever have reached it.
 
 // permissionServiceAllocator is the one function allowed to write a
 // PermissionService composite literal.
 const permissionServiceAllocator = "newPermissionService"
+
+// permissionServiceTypeName is matched textually because the scan is a source
+// scan: it deliberately has no type information, so that it stays cheap and
+// keeps working on a file that does not compile.
+const permissionServiceTypeName = "PermissionService"
+
+// namesPermissionServiceDirectly reports whether the type expression IS the
+// struct type. The *ast.SelectorExpr arm is what makes the scan see
+// `services.PermissionService{}` — the spelling the `package services_test`
+// files in this same directory would use, and the only literal an external
+// package can still write now that every field is unexported.
+func namesPermissionServiceDirectly(t ast.Expr) bool {
+	switch v := t.(type) {
+	case *ast.Ident:
+		return v.Name == permissionServiceTypeName
+	case *ast.StarExpr:
+		return namesPermissionServiceDirectly(v.X)
+	case *ast.SelectorExpr:
+		return v.Sel.Name == permissionServiceTypeName
+	}
+	return false
+}
+
+// containerElementNamesPermissionService reports whether the type expression is
+// a slice, array or map whose ELEMENT is the service — the case where the
+// constructions are the container's elements rather than the container itself,
+// and where each element may elide its type (`[]*PermissionService{{...}}`) and
+// so carry nothing of its own for the scan to match.
+//
+// Deliberately narrower than "the type expression mentions PermissionService
+// anywhere": a table-driven test's `[]struct{ svc *PermissionService }{...}`
+// mentions it too, while its elements hold values that came FROM a constructor.
+// Matching that would be a false positive on ordinary, correct test code — and
+// a guard that cries wolf on the right thing gets deleted.
+func containerElementNamesPermissionService(t ast.Expr) bool {
+	switch v := t.(type) {
+	case *ast.ArrayType:
+		return namesPermissionServiceDirectly(v.Elt)
+	case *ast.MapType:
+		return namesPermissionServiceDirectly(v.Value)
+	}
+	return false
+}
+
+// unwrapElement strips the `&` and the `key:` a container element may carry, so
+// that both `[]*PermissionService{{...}}` and
+// `map[string]*PermissionService{"a": {...}}` reach the inner literal. An
+// element written with an elided type has CompositeLit.Type == nil, which is
+// precisely why elements are found through their container rather than on their
+// own.
+func unwrapElement(e ast.Expr) ast.Expr {
+	if kv, ok := e.(*ast.KeyValueExpr); ok {
+		e = kv.Value
+	}
+	if u, ok := e.(*ast.UnaryExpr); ok && u.Op == token.AND {
+		e = u.X
+	}
+	return e
+}
 
 // TestPermissionServiceIsNeverBuiltByBareLiteral fails on any PermissionService
 // composite literal in this package outside the allocator.
@@ -66,30 +130,50 @@ func TestPermissionServiceIsNeverBuiltByBareLiteral(t *testing.T) {
 
 	for _, pkg := range pkgs {
 		for path, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				fn, ok := decl.(*ast.FuncDecl)
-				if !ok || fn.Body == nil {
-					continue
+			// Find the allowed allocator's extent first, then walk the WHOLE
+			// file and decide by position containment. Walking only FuncDecl
+			// bodies would skip every package-scope declaration, and
+			// `var x = &PermissionService{}` at package scope is a perfectly
+			// ordinary shape for a shared test fixture — which is exactly where
+			// the original offender lived.
+			var alloc *ast.FuncDecl
+			for _, d := range file.Decls {
+				if fn, ok := d.(*ast.FuncDecl); ok && fn.Recv == nil && fn.Name.Name == permissionServiceAllocator {
+					alloc = fn
 				}
-				allowed := fn.Recv == nil && fn.Name.Name == permissionServiceAllocator
-				ast.Inspect(fn.Body, func(n ast.Node) bool {
-					lit, ok := n.(*ast.CompositeLit)
-					if !ok {
-						return true
-					}
-					id, ok := lit.Type.(*ast.Ident)
-					if !ok || id.Name != "PermissionService" {
-						return true
-					}
-					if allowed {
-						seenAllocator = true
-						return true
-					}
-					offenders = append(offenders, fmt.Sprintf("%s:%d (in %s)",
-						filepath.Base(path), fset.Position(lit.Pos()).Line, fn.Name.Name))
-					return true
-				})
 			}
+
+			report := func(n ast.Node) {
+				if alloc != nil && n.Pos() >= alloc.Pos() && n.End() <= alloc.End() {
+					seenAllocator = true
+					return
+				}
+				offenders = append(offenders, fmt.Sprintf("%s:%d",
+					filepath.Base(path), fset.Position(n.Pos()).Line))
+			}
+
+			ast.Inspect(file, func(n ast.Node) bool {
+				lit, ok := n.(*ast.CompositeLit)
+				if !ok || lit.Type == nil {
+					return true
+				}
+				if namesPermissionServiceDirectly(lit.Type) {
+					report(lit)
+					return true
+				}
+				if !containerElementNamesPermissionService(lit.Type) {
+					return true
+				}
+				// A container of services: each element literal constructs one,
+				// and an element written with an elided type carries no type of
+				// its own to match, so it is only reachable from here.
+				for _, el := range lit.Elts {
+					if inner, ok := unwrapElement(el).(*ast.CompositeLit); ok {
+						report(inner)
+					}
+				}
+				return true
+			})
 		}
 	}
 
@@ -127,64 +211,81 @@ var nilTolerantFields = map[string]string{
 // or channel-typed field is added to PermissionService and forgotten in the
 // allocator. That is the half of #1400 the source scan cannot reach.
 func TestNewPermissionServiceInitialisesEveryOwnedMap(t *testing.T) {
-	s := newPermissionService()
-	v := reflect.ValueOf(s).Elem()
-	typ := v.Type()
+	// BOTH construction paths, because they can disagree. The allocator makes
+	// every map, and NewPermissionService then overwrites eight fields from
+	// deps — so a future dep-supplied map (the shape `s.factories =
+	// deps.Factories` already has) would re-nil a field the allocator had
+	// allocated, and a walk that only ever saw the allocator would stay green
+	// while production panicked.
+	for _, tc := range []struct {
+		name string
+		svc  *PermissionService
+	}{
+		{permissionServiceAllocator, newPermissionService()},
+		{"NewPermissionService", NewPermissionService(PermissionServiceDeps{
+			Store: emptyPermStore{}, Log: &gateLog{},
+		})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			checked := assertNoNilOwnedMaps(t, tc.name, reflect.ValueOf(tc.svc).Elem(), "")
+			if checked == 0 {
+				t.Fatal("no map- or channel-typed fields were checked — the reflection " +
+					"walk is not seeing the struct, so its silence proves nothing")
+			}
 
+			// detectInterval is not a map, but it is the same shape of bug:
+			// Start's time.NewTicker panics outright on a non-positive
+			// interval, so a service that skipped the allocator is unstartable
+			// as well as nil-unsafe. This is why the issue's "a nil-guard makes
+			// the zero value usable" is not quite true for this type.
+			if tc.svc.detectInterval <= 0 {
+				t.Errorf("%s left detectInterval at %v; time.NewTicker panics on a "+
+					"non-positive interval", tc.name, tc.svc.detectInterval)
+			}
+		})
+	}
+}
+
+// emptyPermStore is the smallest thing NewPermissionService will accept: it
+// loads an empty set and reports no error, so the walk sees the constructor's
+// normal path rather than its error path.
+type emptyPermStore struct{}
+
+func (emptyPermStore) Load() (permission.Set, error) { return permission.Set{}, nil }
+func (emptyPermStore) Save(permission.Set) error     { return nil }
+
+// assertNoNilOwnedMaps walks v's map- and channel-typed fields, descending into
+// embedded structs (whose own fields are promoted, so a nil map inside one is
+// indistinguishable at the use site from a nil map on the outer struct). It
+// returns how many fields it actually checked, so the caller can refuse to
+// treat an empty walk as a pass.
+func assertNoNilOwnedMaps(t *testing.T, ctor string, v reflect.Value, prefix string) int {
+	t.Helper()
+	typ := v.Type()
 	checked := 0
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
+		name := prefix + f.Name
+		if f.Anonymous && f.Type.Kind() == reflect.Struct {
+			checked += assertNoNilOwnedMaps(t, ctor, v.Field(i), name+".")
+			continue
+		}
 		switch f.Type.Kind() {
 		case reflect.Map, reflect.Chan:
 		default:
 			continue
 		}
-		if reason, exempt := nilTolerantFields[f.Name]; exempt {
-			t.Logf("%s: nil tolerated — %s", f.Name, reason)
+		if reason, exempt := nilTolerantFields[name]; exempt {
+			t.Logf("%s: nil tolerated — %s", name, reason)
 			continue
 		}
 		checked++
 		if v.Field(i).IsNil() {
-			t.Errorf("%s() leaves %s (%s) nil. Every write to it panics with "+
+			t.Errorf("%s leaves %s (%s) nil. Every write to it panics with "+
 				"\"assignment to entry in nil map\", far from here. Either allocate it "+
 				"in the allocator, or add it to nilTolerantFields with the reason it is "+
-				"safe to leave nil (#1400).",
-				permissionServiceAllocator, f.Name, f.Type)
+				"safe to leave nil (#1400).", ctor, name, f.Type)
 		}
 	}
-
-	if checked == 0 {
-		t.Fatal("no map- or channel-typed fields were checked — the reflection walk " +
-			"is not seeing the struct, so its silence proves nothing")
-	}
-
-	// detectInterval is not a map, but it is the same shape of bug: Start's
-	// time.NewTicker panics outright on a non-positive interval, so a service
-	// that skipped the allocator is unstartable as well as nil-unsafe. This is
-	// why the issue's "a nil-guard makes the zero value usable" is not quite
-	// true for this type.
-	if s.detectInterval <= 0 {
-		t.Errorf("%s() left detectInterval at %v; time.NewTicker panics on a "+
-			"non-positive interval", permissionServiceAllocator, s.detectInterval)
-	}
-}
-
-// TestPermissionServiceSourceScanReadsRealFiles pins the assumption the source
-// scan rests on: that the test binary's working directory is the package
-// directory, so ParseDir(".") reads this package rather than nothing.
-func TestPermissionServiceSourceScanReadsRealFiles(t *testing.T) {
-	entries, err := os.ReadDir(".")
-	if err != nil {
-		t.Fatalf("reading the package directory: %v", err)
-	}
-	found := false
-	for _, e := range entries {
-		if e.Name() == "permission_service.go" {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatal("permission_service.go is not in the test's working directory; " +
-			"the source scan above is reading the wrong place")
-	}
+	return checked
 }

--- a/core/application/services/permission_construction_test.go
+++ b/core/application/services/permission_construction_test.go
@@ -1,0 +1,190 @@
+package services
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// This file covers issue #1400: a PermissionService built by a bare composite
+// literal instead of by newPermissionService skips every map allocation, and
+// panics on the first effect that writes one.
+//
+// The two tests here are deliberately different in kind, because the hazard has
+// two halves and neither test sees the other's:
+//
+//   - TestPermissionServiceIsNeverBuiltByBareLiteral guards the CONSTRUCTION
+//     SITES — it scans this package's own source, so it fires on a literal that
+//     no test ever executes. That matters because the quiet case is a suite
+//     which only drives Remove paths, or permissions with no effect closures:
+//     it constructs the trap and never springs it, leaving the panic for whoever
+//     adds an unrelated test months later.
+//   - TestNewPermissionServiceInitialisesEveryOwnedMap guards the ALLOCATOR
+//     ITSELF — a new map- or channel-typed field added to the struct and
+//     forgotten in newPermissionService is a hole the source scan cannot see,
+//     because every construction site is still perfectly legal.
+//
+// Neither is a compile-time guard, and that is not a shortfall of effort. The
+// issue floated an unexported zero-width field to make the literal
+// uncompilable, but it would be inert here: every field of PermissionService is
+// already unexported, so Go already forbids another package from setting one in
+// a literal (only `&services.PermissionService{}` with no fields at all
+// compiles, which populates nothing and is useless). The literal this issue was
+// actually filed about lives in THIS package, where unexported fields are
+// freely settable and no unexported marker field can reach it.
+
+// permissionServiceAllocator is the one function allowed to write a
+// PermissionService composite literal.
+const permissionServiceAllocator = "newPermissionService"
+
+// TestPermissionServiceIsNeverBuiltByBareLiteral fails on any PermissionService
+// composite literal in this package outside the allocator.
+//
+// It reports the file and line of the literal. That is the entire point: the
+// runtime failure a bypass produces reports neither. It surfaces as
+// "assignment to entry in nil map" with a stack whose deepest frame is
+// recordEffectResult, several calls away from the construction that caused it,
+// and only if some test happens to drive an effect that writes a map.
+func TestPermissionServiceIsNeverBuiltByBareLiteral(t *testing.T) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing this package's source: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatal("parsed no packages — the scan would pass vacuously")
+	}
+
+	seenAllocator := false
+	var offenders []string
+
+	for _, pkg := range pkgs {
+		for path, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				allowed := fn.Recv == nil && fn.Name.Name == permissionServiceAllocator
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					lit, ok := n.(*ast.CompositeLit)
+					if !ok {
+						return true
+					}
+					id, ok := lit.Type.(*ast.Ident)
+					if !ok || id.Name != "PermissionService" {
+						return true
+					}
+					if allowed {
+						seenAllocator = true
+						return true
+					}
+					offenders = append(offenders, fmt.Sprintf("%s:%d (in %s)",
+						filepath.Base(path), fset.Position(lit.Pos()).Line, fn.Name.Name))
+					return true
+				})
+			}
+		}
+	}
+
+	// Vacuity guard. A scan that matches nothing at all — a renamed type, a
+	// parser that silently read the wrong directory — would otherwise report a
+	// clean package while checking nothing, which is the failure mode this
+	// whole file exists to remove.
+	if !seenAllocator {
+		t.Fatalf("found no PermissionService literal inside %s(); the scan is not "+
+			"looking where it thinks it is, so its silence proves nothing",
+			permissionServiceAllocator)
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("PermissionService built by a bare composite literal at %s.\n"+
+			"Call %s() and assign what you need instead: the literal skips every map "+
+			"allocation, so the service panics on the first effect that writes one — "+
+			"and it panics in recordEffectResult, not here (#1400).",
+			strings.Join(offenders, ", "), permissionServiceAllocator)
+	}
+}
+
+// nilTolerantFields names each field newPermissionService deliberately leaves
+// nil, with the reason. A field is exempt only by being written down here —
+// the default is that it must be initialised, so a new map- or channel-typed
+// field is covered by a test that already exists rather than by whoever adds it
+// remembering to write one.
+var nilTolerantFields = map[string]string{
+	"factories": "dependency-supplied (nil means demo mode: no watcher ever starts) " +
+		"and only ever read — startWatching does one lookup, and a nil-map read is legal",
+}
+
+// TestNewPermissionServiceInitialisesEveryOwnedMap walks the struct by
+// reflection rather than naming today's fields, so it fails when a FUTURE map-
+// or channel-typed field is added to PermissionService and forgotten in the
+// allocator. That is the half of #1400 the source scan cannot reach.
+func TestNewPermissionServiceInitialisesEveryOwnedMap(t *testing.T) {
+	s := newPermissionService()
+	v := reflect.ValueOf(s).Elem()
+	typ := v.Type()
+
+	checked := 0
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		switch f.Type.Kind() {
+		case reflect.Map, reflect.Chan:
+		default:
+			continue
+		}
+		if reason, exempt := nilTolerantFields[f.Name]; exempt {
+			t.Logf("%s: nil tolerated — %s", f.Name, reason)
+			continue
+		}
+		checked++
+		if v.Field(i).IsNil() {
+			t.Errorf("%s() leaves %s (%s) nil. Every write to it panics with "+
+				"\"assignment to entry in nil map\", far from here. Either allocate it "+
+				"in the allocator, or add it to nilTolerantFields with the reason it is "+
+				"safe to leave nil (#1400).",
+				permissionServiceAllocator, f.Name, f.Type)
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no map- or channel-typed fields were checked — the reflection walk " +
+			"is not seeing the struct, so its silence proves nothing")
+	}
+
+	// detectInterval is not a map, but it is the same shape of bug: Start's
+	// time.NewTicker panics outright on a non-positive interval, so a service
+	// that skipped the allocator is unstartable as well as nil-unsafe. This is
+	// why the issue's "a nil-guard makes the zero value usable" is not quite
+	// true for this type.
+	if s.detectInterval <= 0 {
+		t.Errorf("%s() left detectInterval at %v; time.NewTicker panics on a "+
+			"non-positive interval", permissionServiceAllocator, s.detectInterval)
+	}
+}
+
+// TestPermissionServiceSourceScanReadsRealFiles pins the assumption the source
+// scan rests on: that the test binary's working directory is the package
+// directory, so ParseDir(".") reads this package rather than nothing.
+func TestPermissionServiceSourceScanReadsRealFiles(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package directory: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if e.Name() == "permission_service.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("permission_service.go is not in the test's working directory; " +
+			"the source scan above is reading the wrong place")
+	}
+}

--- a/core/application/services/permission_construction_test.go
+++ b/core/application/services/permission_construction_test.go
@@ -107,6 +107,60 @@ func unwrapElement(e ast.Expr) ast.Expr {
 	return e
 }
 
+// allocatorDecl returns the allowed allocator's declaration in this file, or
+// nil. Its extent is what tells a legitimate literal from a bypass: the check
+// is positional rather than "which function body am I walking", because walking
+// only function bodies would skip every package-scope declaration, and
+// `var x = &PermissionService{}` at package scope is a perfectly ordinary shape
+// for a shared test fixture — which is exactly where the original offender
+// lived.
+func allocatorDecl(file *ast.File) *ast.FuncDecl {
+	for _, d := range file.Decls {
+		if fn, ok := d.(*ast.FuncDecl); ok && fn.Recv == nil && fn.Name.Name == permissionServiceAllocator {
+			return fn
+		}
+	}
+	return nil
+}
+
+// scanFileForServiceLiterals reports every PermissionService composite literal
+// in one file that is not inside the allocator, and whether the allocator's own
+// literal was seen (the caller's vacuity guard).
+func scanFileForServiceLiterals(fset *token.FileSet, path string, file *ast.File) (offenders []string, sawAllocator bool) {
+	alloc := allocatorDecl(file)
+
+	report := func(n ast.Node) {
+		if alloc != nil && n.Pos() >= alloc.Pos() && n.End() <= alloc.End() {
+			sawAllocator = true
+			return
+		}
+		offenders = append(offenders, fmt.Sprintf("%s:%d",
+			filepath.Base(path), fset.Position(n.Pos()).Line))
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok || lit.Type == nil {
+			return true
+		}
+		switch {
+		case namesPermissionServiceDirectly(lit.Type):
+			report(lit)
+		case containerElementNamesPermissionService(lit.Type):
+			// Each element literal constructs one service, and an element
+			// written with an elided type carries no type of its own to match,
+			// so it is only reachable from its container.
+			for _, el := range lit.Elts {
+				if inner, ok := unwrapElement(el).(*ast.CompositeLit); ok {
+					report(inner)
+				}
+			}
+		}
+		return true
+	})
+	return offenders, sawAllocator
+}
+
 // TestPermissionServiceIsNeverBuiltByBareLiteral fails on any PermissionService
 // composite literal in this package outside the allocator.
 //
@@ -130,50 +184,9 @@ func TestPermissionServiceIsNeverBuiltByBareLiteral(t *testing.T) {
 
 	for _, pkg := range pkgs {
 		for path, file := range pkg.Files {
-			// Find the allowed allocator's extent first, then walk the WHOLE
-			// file and decide by position containment. Walking only FuncDecl
-			// bodies would skip every package-scope declaration, and
-			// `var x = &PermissionService{}` at package scope is a perfectly
-			// ordinary shape for a shared test fixture — which is exactly where
-			// the original offender lived.
-			var alloc *ast.FuncDecl
-			for _, d := range file.Decls {
-				if fn, ok := d.(*ast.FuncDecl); ok && fn.Recv == nil && fn.Name.Name == permissionServiceAllocator {
-					alloc = fn
-				}
-			}
-
-			report := func(n ast.Node) {
-				if alloc != nil && n.Pos() >= alloc.Pos() && n.End() <= alloc.End() {
-					seenAllocator = true
-					return
-				}
-				offenders = append(offenders, fmt.Sprintf("%s:%d",
-					filepath.Base(path), fset.Position(n.Pos()).Line))
-			}
-
-			ast.Inspect(file, func(n ast.Node) bool {
-				lit, ok := n.(*ast.CompositeLit)
-				if !ok || lit.Type == nil {
-					return true
-				}
-				if namesPermissionServiceDirectly(lit.Type) {
-					report(lit)
-					return true
-				}
-				if !containerElementNamesPermissionService(lit.Type) {
-					return true
-				}
-				// A container of services: each element literal constructs one,
-				// and an element written with an elided type carries no type of
-				// its own to match, so it is only reachable from here.
-				for _, el := range lit.Elts {
-					if inner, ok := unwrapElement(el).(*ast.CompositeLit); ok {
-						report(inner)
-					}
-				}
-				return true
-			})
+			found, sawAllocator := scanFileForServiceLiterals(fset, path, file)
+			offenders = append(offenders, found...)
+			seenAllocator = seenAllocator || sawAllocator
 		}
 	}
 

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -195,30 +195,55 @@ type PermissionServiceDeps struct {
 	HasLive   HasLiveProcessFunc
 }
 
+// newPermissionService allocates a PermissionService with every field the
+// service OWNS already usable: the five maps it writes to, and the detection
+// cadence (time.NewTicker panics on a zero interval, so the zero value is not
+// merely nil-unsafe, it is unstartable). Dependencies are left to the caller.
+//
+// This is the ONLY place a PermissionService composite literal may appear, and
+// that is enforced mechanically rather than by memory —
+// TestPermissionServiceIsNeverBuiltByBareLiteral scans this package's source
+// for any other one. A bypass is worth catching at the literal because it does
+// not fail there: it fails later, in whichever effect first writes a map, with
+// a stack pointing at recordEffectResult and nothing at all pointing at the
+// construction that actually caused it (#1400). Every field added here of map,
+// slice-of-map or channel type re-arms that, which is why the rule is about the
+// construction site rather than about any one field.
+func newPermissionService() *PermissionService {
+	return &PermissionService{
+		detectInterval: detectionPollInterval,
+		probes:         make(map[string]func() bool),
+		set:            permission.Set{},
+		detected:       make(map[string]bool),
+		watching:       make(map[string]context.CancelFunc),
+		effectErrs:     make(map[string]string),
+	}
+}
+
 // NewPermissionService loads the persisted consent state and returns the
 // service.
 func NewPermissionService(deps PermissionServiceDeps) *PermissionService {
 	set, err := deps.Store.Load()
 	if err != nil {
 		deps.Log.LogError("permissions", "", fmt.Sprintf("failed to load permission state (treating all as pending): %v", err))
-		set = permission.Set{}
+		set = nil
 	}
-	return &PermissionService{
-		agents:         deps.Agents,
-		store:          deps.Store,
-		push:           deps.Push,
-		log:            deps.Log,
-		mode:           deps.Mode,
-		registrar:      deps.Registrar,
-		factories:      deps.Factories,
-		hasLive:        deps.HasLive,
-		detectInterval: detectionPollInterval,
-		probes:         make(map[string]func() bool),
-		set:            set,
-		detected:       make(map[string]bool),
-		watching:       make(map[string]context.CancelFunc),
-		effectErrs:     make(map[string]string),
+	s := newPermissionService()
+	s.agents = deps.Agents
+	s.store = deps.Store
+	s.push = deps.Push
+	s.log = deps.Log
+	s.mode = deps.Mode
+	s.registrar = deps.Registrar
+	s.factories = deps.Factories
+	s.hasLive = deps.HasLive
+	// permission.Set is itself map-backed and Put writes to it, so a nil Set —
+	// which a store may return alongside a nil error — is the same nil-map trap
+	// one level down. Keep the allocator's empty one rather than adopting it.
+	if set != nil {
+		s.set = set
 	}
+	return s
 }
 
 // effectKey is the composite key for the effectErrs map.

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -207,7 +207,7 @@ type PermissionServiceDeps struct {
 // not fail there: it fails later, in whichever effect first writes a map, with
 // a stack pointing at recordEffectResult and nothing at all pointing at the
 // construction that actually caused it (#1400). Every field added here of map,
-// slice-of-map or channel type re-arms that, which is why the rule is about the
+// or channel type re-arms that, which is why the rule is about the
 // construction site rather than about any one field.
 func newPermissionService() *PermissionService {
 	return &PermissionService{

--- a/core/application/services/permission_version_gate_test.go
+++ b/core/application/services/permission_version_gate_test.go
@@ -90,9 +90,12 @@ func gatedHooksPermission(min, observed string, applied *bool) agent.Permission 
 
 func newGateService() (*PermissionService, *gateLog) {
 	log := &gateLog{}
-	// effectErrs must exist: runClosureEffect records every outcome there
-	// (#1362), so a bare struct panics on the first effect.
-	return &PermissionService{log: log, effectErrs: map[string]string{}}, log
+	// newPermissionService rather than a struct literal: it owns every map
+	// allocation, so this helper does not have to keep a hand-written list of
+	// which ones the service happens to write to today (#1400).
+	svc := newPermissionService()
+	svc.log = log
+	return svc, log
 }
 
 func grant(svc *PermissionService, p agent.Permission) {


### PR DESCRIPTION
Closes #1400.

## The defect

`runClosureEffect` calls `recordEffectResult` unconditionally, which writes into
`effectErrs`. That map is allocated in the constructor, so any code building a
bare `&PermissionService{...}` literal panics on the first effect that runs.

Reproduced on `1a47e79a` (the branch point) with a bare literal driving one
`Apply`:

```
--- FAIL: TestRepro1400_BareLiteralPanicsOnApply (0.00s)
panic: assignment to entry in nil map [recovered, repanicked]
...
irrlicht/core/application/services.(*PermissionService).recordEffectResult(...)
	core/application/services/permission_service.go:754 +0xe4
irrlicht/core/application/services.(*PermissionService).runClosureEffect(...)
	core/application/services/permission_service.go:743 +0x354
irrlicht/core/application/services.TestRepro1400_BareLiteralPanicsOnApply(...)
	core/application/services/zz_repro_1400_test.go:23 +0x19c
```

Note what the stack names: `recordEffectResult:754`. Nothing in it points at the
literal. That is the diagnostic complaint the issue is actually about, and it is
what the fix targets.

## Which option, and why

The issue offered three. **Option 2 — an unexported zero-width field making the
literal uncompilable from outside the package — is inert for this type**, and
that was checked rather than assumed:

- Every field of `PermissionService` is already unexported, so Go already
  forbids another package from setting one in a composite literal. Only
  `&services.PermissionService{}` with no fields compiles, which populates
  nothing. A repo-wide grep for `services.PermissionService{` /
  `&services.PermissionService{` returns **zero** hits.
- The one real literal is **in-package** (`permission_version_gate_test.go:95`,
  `package services`), where unexported fields are freely settable. No
  unexported marker field can reach it.

**Option 1 — a nil-guard in `recordEffectResult`** — is cheap but does not do
what the issue's parenthetical claims ("makes the zero value usable"). It fixes
one of five nil-map hazards on this struct (`probes`, `set`, `detected`,
`watching` are the others, all written), and `Start` still panics outright on a
bare literal because `detectInterval` is 0 and `time.NewTicker` panics on a
non-positive interval. A guard that removes the loud symptom while four quieter
ones remain is the failure mode the issue is complaining about, one layer along.

**What this PR does instead:** a single unexported allocator,
`newPermissionService()`, is the only place a `PermissionService` literal may
appear. `NewPermissionService` calls it and assigns deps; the one test helper
calls it too. The rule is then enforced mechanically rather than by memory, by
two tests of deliberately different kinds:

- `TestPermissionServiceIsNeverBuiltByBareLiteral` — an AST scan of this
  package's source. It fires on a literal **no test ever executes**, which is
  the quiet case the issue names (a suite driving only `Remove` paths, or
  permissions with no effects, constructs the trap and never springs it). It
  reports **file and line of the literal**, which the runtime panic never does.
- `TestNewPermissionServiceInitialisesEveryOwnedMap` — a reflection walk over
  the struct, not a hand-written field list. It fails when a **future** map- or
  channel-typed field is added and forgotten in the allocator — the half the
  source scan cannot see, because every construction site stays legal. Exempt
  fields must be named in `nilTolerantFields` **with a reason**, so the default
  is "must be initialised" (the same shape as `applyWritesNoUserFile`).

### What this does NOT cover

- It is a **test-time** gate, not compile-time. Nothing here fails a build; CI
  and `preflight --only go` are what catch it.
- The AST scan is scoped to `core/application/services/`. A literal in another
  package would go unseen — but, per the check above, such a literal cannot
  populate any field, so it is inert.
- It does not make the zero value usable, and deliberately so: `&PermissionService{}`
  still panics. The guarantee is "there is one construction path", not "every
  path works".
- **Out of scope, and untouched:** `SessionDetector` in the same package has the
  same class of hazard with **14** bare-literal construction sites and 6
  map/chan fields (`state_dwell_test.go`, `session_detector_stalled_arm_test.go`,
  and others). Worth its own ticket; not fixed here.

## Bare literals found and converted

Repo-wide, `PermissionService{` matches **2** sites: the constructor's own (now
moved into `newPermissionService`) and **1** bare literal —
`core/application/services/permission_version_gate_test.go:95`, in the
`newGateService()` helper used by 11 call sites. That one is converted. Its
existing comment already documented the hazard by hand ("effectErrs must
exist … so a bare struct panics on the first effect"), which is exactly the
memory-based discipline this replaces.

## Red-first evidence

Both new tests were seen fail before the change that makes them pass.

1. **AST scan**, run with the literal still unconverted — this is `main`'s state,
   so it is a genuine red, not a lock:

```
--- FAIL: TestPermissionServiceIsNeverBuiltByBareLiteral (0.03s)
    permission_construction_test.go:107: PermissionService built by a bare composite
    literal at permission_version_gate_test.go:95 (in newGateService), ...
```

2. **Reflection walk**, via a deliberate mutation (dropping `effectErrs` from
   the allocator), since it passes by construction against a correct allocator:

```
--- FAIL: TestNewPermissionServiceInitialisesEveryOwnedMap (0.00s)
    permission_construction_test.go:148: newPermissionService() leaves effectErrs
    (map[string]string) nil. Every write to it panics with "assignment to entry
    in nil map", far from here.
```

The mutation was reverted; `grep` confirms the `make` is back.

3. **The same construction now working** — the repro rewritten to call
   `newPermissionService()` survives the identical `Apply`:
   `survived; applied=true`.

Each of the three has a vacuity guard, because a scan that matches nothing
otherwise reports a clean package while checking nothing: the AST scan fails if
it never finds the allocator's own literal, the reflection walk fails if it
checks zero map/chan fields, and `TestPermissionServiceSourceScanReadsRealFiles`
pins that `ParseDir(".")` is reading this package.

## Also fixed, same class, one line

`NewPermissionService` adopted `Store.Load()`'s result unconditionally.
`permission.Set` is `map[string]map[string]State` and `Put` writes to it, so a
store returning `(nil, nil)` produced the identical nil-map panic one level
down. The allocator's empty `Set` is now kept when `Load` returns nil.

## Verification

`tools/preflight.sh` run chunked in the foreground, all PASS: `go` (gofmt, core
module tests, onboarding-factory, replaydata validate, recording-rig smoke,
replay fixtures, starhistory), `arch` (ARS 7.954239 → 7.954394, no regression),
`tools`, `skills`, `posix`, `security`, `web` (both trees).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round (subagent, `medium` effort, `origin/main...HEAD`)

The reviewer confirmed the production change clean field-by-field against
`origin/main`, and found **three bypasses in the new guard itself** — each
demonstrated with a planted probe, not asserted. All three are fixed in
`80016e3d`, and each fix was re-verified by replanting the probe:

1. **Package-scope literals were invisible.** The scan walked only `FuncDecl`
   bodies, so `var x = &PermissionService{}` at package scope passed — an
   ordinary shape for a shared test fixture, which is where the original
   offender lived. Now walks the whole file and decides by position containment.
2. **Two legal spellings were missed.** The matcher accepted only a bare
   `*ast.Ident`, so `services.PermissionService{}` (an `*ast.SelectorExpr` — the
   spelling the `package services_test` files in this same directory use, and
   the only literal an external package can still write) and elided container
   elements (`[]*PermissionService{{...}}`, `map[string]*PermissionService{...}`)
   both passed. Matching is now on the **element** type rather than "mentions
   the name anywhere", which also avoids the false positive that the broader
   version produced on a table-driven `[]struct{ svc *PermissionService }`.
3. **The reflection walk never exercised the public constructor.** It called
   `newPermissionService()` only, while `NewPermissionService` overwrites eight
   fields from deps afterwards — so a future dep-supplied map (the shape
   `s.factories = deps.Factories` already has) would re-nil an allocated field
   with both tests staying green. It now walks both constructions and descends
   into embedded structs.

Verification that the fixes are live, all five shapes planted at once:

```
--- FAIL: TestPermissionServiceIsNeverBuiltByBareLiteral
  ... at zzprobe_a_test.go:3, zzprobe_a_test.go:4, zzprobe_a_test.go:5,
      zzprobe_a_test.go:7, zzprobe_b_test.go:5.
```

(package-scope, elided slice element, map value, in-function, external-package
selector). Clean tree passes. The `NewPermissionService` arm was separately
mutation-tested by re-nilling `probes` after the allocator runs — it goes red
while the `newPermissionService` arm stays green, so the two arms are
independent rather than one covering for the other.

Also removed `TestPermissionServiceSourceScanReadsRealFiles` on a simplify
glance: the `seenAllocator` vacuity guard subsumes it entirely, since it can
only be satisfied by having parsed the real `permission_service.go`.

Reviewer's one remaining judgement call and the `go/parser.ParseDir`
deprecation were both assessed and are recorded above / left as-is: ignoring
build tags makes a source *scanner* read **more** files, which is the safe
direction, and no `staticcheck`/`golangci-lint` gate exists in this repo.
